### PR TITLE
Provisioning and clear role separation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 ETCD_NODE1 := http://127.0.0.1:4001
-ETCD_NODE2 := http://127.0.0.1:4002
-ETCD_NODE3 := http://127.0.0.1:4003
-ETCD_NODES := ${ETCD_NODE1},${ETCD_NODE2},${ETCD_NODE3}
+ETCD_NODES := ${ETCD_NODE1}
 ETCD_FLAGS := TELEPORT_TEST_ETCD_NODES=${ETCD_NODES}
 
-.PHONY: install test test-with-etcd remove-temp files test-package update test-grep-package cover-package cover-package-with-etcd run profile sloccount set-etcd
+.PHONY: install test test-with-etcd remove-temp files test-package update test-grep-package cover-package cover-package-with-etcd run profile sloccount set-etcd install-assets
 
-install: remove-temp-files
+install: remove-temp-files install-assets
 	go get github.com/jteeuwen/go-bindata/go-bindata
 	go install github.com/gravitational/teleport/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs
 	go-bindata-assetfs -pkg="cp" ./assets/...
@@ -14,6 +12,14 @@ install: remove-temp-files
 	sed -i 's|github.com/elazarl/go-bindata-assetfs|github.com/gravitational/teleport/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs|' ./cp/bindata_assetfs.go
 	go install github.com/gravitational/teleport/teleport
 	go install github.com/gravitational/teleport/tctl
+
+
+install-assets:
+	go get github.com/jteeuwen/go-bindata/go-bindata
+	go install github.com/gravitational/teleport/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs
+	go-bindata-assetfs -pkg="cp" ./assets/...
+	mv bindata_assetfs.go ./cp
+	sed -i 's|github.com/elazarl/go-bindata-assetfs|github.com/gravitational/teleport/Godeps/_workspace/src/github.com/elazarl/go-bindata-assetfs|' ./cp/bindata_assetfs.go
 
 test: remove-temp-files
 	go test -v ./... -cover
@@ -46,28 +52,38 @@ cover-package-with-etcd: remove-temp-files
 	${ETCD_FLAGS} go test -v ./$(p)  -coverprofile=/tmp/coverage.out
 	go tool cover -html=/tmp/coverage.out
 
-run: install
-	teleport -addr=localhost:2022\
+run-auth:
+	go install github.com/gravitational/teleport/teleport
+	teleport -auth\
+             -authBackend=etcd\
+             -authBackendConfig='{"nodes": ["${ETCD_NODE1}"], "key": "/teleport"}'\
+             -authDomain=gravitational.io\
              -log=console\
              -logSeverity=INFO\
-	         -shell=/bin/bash\
-             -hostCert=./fixtures/keys/hosts/node.gravitational.io-cert.pub\
-             -hostPrivateKey=./fixtures/keys/hosts/node.gravitational.io\
-             -authSrv\
-	         -authKey=vnzHIFxaXHtbnzeOCZWcPGimQkr3CH6Ir1XXFLcewxM=\
-             -cpSrv\
-	         -cpAuth="localhost:2023"\
-	         -cpHost="gravitational.io"\
-             -backend=etcd\
-             -backendConfig='{"nodes": ["${ETCD_NODE1}","${ETCD_NODE2}","${ETCD_NODE3}"], "key": "/teleport"}'
+             -dataDir=/tmp\
+             -fqdn=auth.gravitational.io
+run-ssh:
+	go install github.com/gravitational/teleport/teleport
+	teleport -ssh\
+             -log=console\
+             -logSeverity=INFO\
+             -dataDir=/tmp\
+             -fqdn=node1.gravitational.io\
+             -authServer=tcp://auth.gravitational.io:33001\
+             -sshToken=token
+
+run-cp: install-assets
+	go install github.com/gravitational/teleport/teleport
+	teleport -cp\
+             -cpDomain=gravitational.io\
+             -log=console\
+             -logSeverity=INFO\
+             -dataDir=/tmp\
+             -fqdn=node2.gravitational.io\
+             -authServer=tcp://auth.gravitational.io:33001
 
 profile:
 	go tool pprof http://localhost:6060/debug/pprof/profile
 
 sloccount:
 	find . -path ./Godeps -prune -o -name "*.go" -print0 | xargs -0 wc -l
-
-# sets development etcd keys
-set-etcd:
-	bash ./scripts/etcd.sh
-

--- a/assets/static/js/grv/servers.js
+++ b/assets/static/js/grv/servers.js
@@ -92,7 +92,8 @@ var ServerRow = React.createClass({
 var ServerForm = React.createClass({
   connect: function(srv) {
       var self = this;
-      var socket = new WebSocket("ws://cp.gravitational.io:2025/api/ssh/connect/"+srv.addr, "proto");
+      var hostport = location.hostname+(location.port ? ':'+location.port: '');
+      var socket = new WebSocket("ws://"+hostport+"/api/ssh/connect/"+srv.addr, "proto");
       socket.onopen = function() {
           self.term = new Terminal({
               cols: 120,

--- a/assets/static/js/grv/webtuns.js
+++ b/assets/static/js/grv/webtuns.js
@@ -147,13 +147,13 @@ var WebTunForm = React.createClass({
       
       <div className="form-group">
          <label>SSH Proxy</label> 
-         <input placeholder="node.gravitational.io:2022" className="form-control" ref="proxy"/>
+         <input placeholder="host:port" className="form-control" ref="proxy"/>
          <p>SSH proxy in form of host:port will be used to access the target address</p>
       </div>
 
       <div className="form-group">
          <label>SSH Proxy</label> 
-         <input placeholder="http://localhost:8080" className="form-control" ref="target"/>
+         <input placeholder="http://host:port" className="form-control" ref="target"/>
          <p>Target web server address</p>
       </div>
 </BootstrapModal>
@@ -193,12 +193,14 @@ var WebTunRow = React.createClass({
       this.props.onTunDelete(this.props.tun.prefix);
   },
   render: function() {
+      var base = location.hostname.split(".").slice(1).join(".");
+        var hostport = base+(location.port ? ':'+location.port: '');
     return (
 <tr className="tun">
    <td>{this.props.tun.prefix}</td>
    <td>{this.props.tun.proxy}</td>
    <td>{this.props.tun.target}</td>
-   <td><a href={"http://"+this.props.tun.prefix+".gravitational.io:2025"} target="_blank">{"http://"+this.props.tun.prefix+".gravitational.io:2025"}</a></td>
+   <td><a href={"http://"+this.props.tun.prefix+"."+hostport} target="_blank">{"http://"+this.props.tun.prefix+"."+hostport}</a></td>
    <td><a href="#" onClick={this.handleDelete}><i className="fa fa-times text-navy"></i></a></td>
 </tr>
     );

--- a/auth/ap.go
+++ b/auth/ap.go
@@ -1,0 +1,29 @@
+package auth
+
+import (
+	"time"
+
+	"github.com/gravitational/teleport/backend"
+)
+
+// AccessPoint is a interface needed by nodes to control the access
+// to the node, and provide heartbeats
+type AccessPoint interface {
+	// GetServers returns a list of registered servers
+	GetServers() ([]backend.Server, error)
+
+	// UpsertServer registers server presence, permanently if ttl is 0 or
+	// for the specified duration with second resolution if it's >= 1 second
+	UpsertServer(s backend.Server, ttl time.Duration) error
+
+	// GetUserCAPub returns the user certificate authority public key
+	GetUserCAPub() ([]byte, error)
+
+	// GetUserKeys returns a list of authorized keys for a given user
+	// in a OpenSSH key authorized_keys format
+	GetUserKeys(user string) ([]backend.AuthorizedKey, error)
+
+	// GetWebSessionsKeys returns a list of generated public keys
+	// associated with user web session
+	GetWebSessionsKeys(user string) ([]backend.AuthorizedKey, error)
+}

--- a/auth/api.go
+++ b/auth/api.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/log"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/oxy/trace"
+	"github.com/gravitational/teleport/utils"
+)
+
+func StartHTTPServer(a string, srv *AuthServer) error {
+	addr, err := utils.ParseAddr(a)
+	if err != nil {
+		return err
+	}
+	t, err := trace.New(
+		NewAPIServer(srv), log.GetLogger().Writer(log.SeverityInfo))
+	if err != nil {
+		return err
+	}
+	if addr.Network == "tcp" {
+		hsrv := &http.Server{
+			Addr:    addr.Addr,
+			Handler: t,
+		}
+		return hsrv.ListenAndServe()
+	}
+	l, err := net.Listen(addr.Network, addr.Addr)
+	if err != nil {
+		return err
+	}
+	hsrv := &http.Server{
+		Handler: t,
+	}
+	return hsrv.Serve(l)
+}

--- a/auth/clt.go
+++ b/auth/clt.go
@@ -3,32 +3,83 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"time"
-
-	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
-	"strings"
+	"time"
 
 	"github.com/gravitational/teleport/backend"
+	"github.com/gravitational/teleport/utils"
+
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/gravitational/roundtrip"
 )
 
 const CurrentVersion = "v1"
 
 type Client struct {
-	addr   string
-	client *http.Client
+	roundtrip.Client
 }
 
-func NewClient(addr string) *Client {
-	return &Client{
-		addr:   addr,
-		client: http.DefaultClient,
+func NewClientFromNetAddr(a utils.NetAddr, params ...roundtrip.ClientParam) (*Client, error) {
+	client := &http.Client{
+		Transport: &http.Transport{
+			Dial: func(network, address string) (net.Conn, error) {
+				return net.Dial(a.Network, a.Addr)
+			}}}
+	params = append(params, roundtrip.HTTPClient(client))
+	return NewClient("http://placeholder:0", params...)
+}
+
+func NewClient(addr string, params ...roundtrip.ClientParam) (*Client, error) {
+	c, err := roundtrip.NewClient(addr, CurrentVersion, params...)
+	if err != nil {
+		return nil, err
 	}
+	return &Client{*c}, nil
+}
+
+func (c *Client) convertResponse(re *roundtrip.Response, err error) (*roundtrip.Response, error) {
+	if err != nil {
+		return nil, err
+	}
+	if re.Code() == http.StatusNotFound {
+		return nil, &backend.NotFoundError{Message: string(re.Bytes())}
+	}
+	if re.Code() < 200 || re.Code() > 299 {
+		return nil, fmt.Errorf("error: %v", string(re.Bytes()))
+	}
+	return re, nil
+}
+
+func (c *Client) PostForm(endpoint string, vals url.Values) (*roundtrip.Response, error) {
+	return c.convertResponse(c.Client.PostForm(endpoint, vals))
+}
+
+func (c *Client) Get(u string, params url.Values) (*roundtrip.Response, error) {
+	return c.convertResponse(c.Client.Get(u, params))
+}
+
+func (c *Client) Delete(u string) (*roundtrip.Response, error) {
+	return c.convertResponse(c.Client.Delete(u))
+}
+
+func (c *Client) GenerateToken(fqdn string, ttl time.Duration) (string, error) {
+	out, err := c.PostForm(c.Endpoint("tokens"), url.Values{
+		"fqdn": []string{fqdn},
+		"ttl":  []string{ttl.String()},
+	})
+	if err != nil {
+		return "", err
+	}
+	var re *tokenResponse
+	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
+		return "", err
+	}
+	return re.Token, nil
 }
 
 func (c *Client) UpsertServer(s backend.Server, ttl time.Duration) error {
-	_, err := c.PostForm(c.endpoint("servers"), url.Values{
+	_, err := c.PostForm(c.Endpoint("servers"), url.Values{
 		"id":   []string{string(s.ID)},
 		"addr": []string{string(s.Addr)},
 		"ttl":  []string{ttl.String()},
@@ -37,19 +88,19 @@ func (c *Client) UpsertServer(s backend.Server, ttl time.Duration) error {
 }
 
 func (c *Client) GetServers() ([]backend.Server, error) {
-	out, err := c.Get(c.endpoint("servers"), url.Values{})
+	out, err := c.Get(c.Endpoint("servers"), url.Values{})
 	if err != nil {
 		return nil, err
 	}
 	var re *serversResponse
-	if err := json.Unmarshal(out, &re); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
 		return nil, err
 	}
 	return re.Servers, nil
 }
 
 func (c *Client) UpsertWebTun(wt backend.WebTun, ttl time.Duration) error {
-	_, err := c.PostForm(c.endpoint("tunnels", "web"), url.Values{
+	_, err := c.PostForm(c.Endpoint("tunnels", "web"), url.Values{
 		"target": []string{string(wt.TargetAddr)},
 		"proxy":  []string{string(wt.ProxyAddr)},
 		"prefix": []string{string(wt.Prefix)},
@@ -59,104 +110,112 @@ func (c *Client) UpsertWebTun(wt backend.WebTun, ttl time.Duration) error {
 }
 
 func (c *Client) GetWebTuns() ([]backend.WebTun, error) {
-	out, err := c.Get(c.endpoint("tunnels", "web"), url.Values{})
+	out, err := c.Get(c.Endpoint("tunnels", "web"), url.Values{})
 	if err != nil {
 		return nil, err
 	}
 	var re *webTunsResponse
-	if err := json.Unmarshal(out, &re); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
 		return nil, err
 	}
 	return re.Tunnels, nil
 }
 
 func (c *Client) GetWebTun(prefix string) (*backend.WebTun, error) {
-	out, err := c.Get(c.endpoint("tunnels", "web", prefix), url.Values{})
+	out, err := c.Get(c.Endpoint("tunnels", "web", prefix), url.Values{})
 	if err != nil {
 		return nil, err
 	}
 	var re *webTunResponse
-	if err := json.Unmarshal(out, &re); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
 		return nil, err
 	}
 	return &re.Tunnel, nil
 }
 
 func (c *Client) DeleteWebTun(prefix string) error {
-	return c.Delete(c.endpoint("tunnels", "web", prefix))
+	_, err := c.Delete(c.Endpoint("tunnels", "web", prefix))
+	return err
 }
 
 func (c *Client) UpsertPassword(user string, password []byte) error {
 	_, err := c.PostForm(
-		c.endpoint("users", user, "web", "password"),
+		c.Endpoint("users", user, "web", "password"),
 		url.Values{"password": []string{string(password)}},
 	)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (c *Client) CheckPassword(user string, password []byte) error {
 	_, err := c.PostForm(
-		c.endpoint("users", user, "web", "password", "check"),
-		url.Values{"password": []string{string(password)}},
-	)
-	if err != nil {
-		return err
-	}
-	return nil
+		c.Endpoint("users", user, "web", "password", "check"),
+		url.Values{"password": []string{string(password)}})
+	return err
 }
 
 func (c *Client) SignIn(user string, password []byte) (string, error) {
 	out, err := c.PostForm(
-		c.endpoint("users", user, "web", "signin"),
+		c.Endpoint("users", user, "web", "signin"),
 		url.Values{"password": []string{string(password)}},
 	)
 	if err != nil {
 		return "", err
 	}
 	var re *sessionResponse
-	if err := json.Unmarshal(out, &re); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
 		return "", err
 	}
 	return re.SID, nil
 }
 
 func (c *Client) GetWebSession(user string, sid string) (string, error) {
-	out, err := c.Get(c.endpoint("users", user, "web", "sessions", sid), url.Values{})
+	out, err := c.Get(c.Endpoint("users", user, "web", "sessions", sid), url.Values{})
 	if err != nil {
 		return "", err
 	}
 	var re *sessionResponse
-	if err := json.Unmarshal(out, &re); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
 		return "", err
 	}
 	return re.SID, nil
 }
 
+func (c *Client) GetWebSessionsKeys(user string) ([]backend.AuthorizedKey, error) {
+	out, err := c.Get(c.Endpoint("users", user, "web", "sessions"), url.Values{})
+	if err != nil {
+		return nil, err
+	}
+	var re *sessionsResponse
+	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
+		return nil, err
+	}
+	return re.Keys, nil
+}
+
 func (c *Client) DeleteWebSession(user string, sid string) error {
-	return c.Delete(c.endpoint("users", user, "web", "sessions", sid))
+	_, err := c.Delete(c.Endpoint("users", user, "web", "sessions", sid))
+	return err
 }
 
 func (c *Client) GetUsers() ([]string, error) {
-	out, err := c.Get(c.endpoint("users"), url.Values{})
+	out, err := c.Get(c.Endpoint("users"), url.Values{})
 	if err != nil {
 		return nil, err
 	}
 	var users *usersResponse
-	if err := json.Unmarshal(out, &users); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &users); err != nil {
 		return nil, err
 	}
 	return users.Users, nil
 }
 
 func (c *Client) DeleteUser(user string) error {
-	return c.Delete(c.endpoint("users", user))
+	_, err := c.Delete(c.Endpoint("users", user))
+	return err
 }
 
 func (c *Client) UpsertUserKey(username string, key backend.AuthorizedKey, ttl time.Duration) ([]byte, error) {
-	out, err := c.PostForm(c.endpoint("users", username, "keys"), url.Values{
+	out, err := c.PostForm(c.Endpoint("users", username, "keys"), url.Values{
 		"key": []string{string(key.Value)},
 		"id":  []string{key.ID},
 		"ttl": []string{ttl.String()},
@@ -165,66 +224,67 @@ func (c *Client) UpsertUserKey(username string, key backend.AuthorizedKey, ttl t
 		return nil, err
 	}
 	var cert *certResponse
-	if err := json.Unmarshal(out, &cert); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &cert); err != nil {
 		return nil, err
 	}
 	return []byte(cert.Cert), err
 }
 
 func (c *Client) GetUserKeys(user string) ([]backend.AuthorizedKey, error) {
-	out, err := c.Get(c.endpoint("users", user, "keys"), url.Values{})
+	out, err := c.Get(c.Endpoint("users", user, "keys"), url.Values{})
 	if err != nil {
 		return nil, err
 	}
 	var keys *pubKeysResponse
-	if err := json.Unmarshal(out, &keys); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &keys); err != nil {
 		return nil, err
 	}
 	return keys.PubKeys, nil
 }
 
 func (c *Client) DeleteUserKey(username string, id string) error {
-	return c.Delete(c.endpoint("users", username, "keys", id))
+	_, err := c.Delete(c.Endpoint("users", username, "keys", id))
+	return err
 }
 
 func (c *Client) GetHostCAPub() ([]byte, error) {
-	out, err := c.Get(c.endpoint("ca", "host", "keys", "pub"), url.Values{})
+	out, err := c.Get(c.Endpoint("ca", "host", "keys", "pub"), url.Values{})
 	if err != nil {
 		return nil, err
 	}
 	var pubkey *pubKeyResponse
-	if err := json.Unmarshal(out, &pubkey); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &pubkey); err != nil {
 		return nil, err
 	}
 	return []byte(pubkey.PubKey), err
 }
 
 func (c *Client) GetUserCAPub() ([]byte, error) {
-	out, err := c.Get(c.endpoint("ca", "user", "keys", "pub"), url.Values{})
+	out, err := c.Get(c.Endpoint("ca", "user", "keys", "pub"), url.Values{})
 	if err != nil {
 		return nil, err
 	}
 	var pubkey *pubKeyResponse
-	if err := json.Unmarshal(out, &pubkey); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &pubkey); err != nil {
 		return nil, err
 	}
 	return []byte(pubkey.PubKey), err
 }
 
 func (c *Client) GenerateKeyPair(pass string) ([]byte, []byte, error) {
-	out, err := c.PostForm(c.endpoint("keypair"), url.Values{})
+	out, err := c.PostForm(c.Endpoint("keypair"), url.Values{})
 	if err != nil {
 		return nil, nil, err
 	}
 	var kp *keyPairResponse
-	if err := json.Unmarshal(out, &kp); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &kp); err != nil {
 		return nil, nil, err
 	}
 	return kp.PrivKey, []byte(kp.PubKey), err
 }
 
 func (c *Client) GenerateHostCert(key []byte, id, hostname string, ttl time.Duration) ([]byte, error) {
-	out, err := c.PostForm(c.endpoint("ca", "host", "certs"), url.Values{
+	out, err := c.PostForm(c.Endpoint("ca", "host", "certs"), url.Values{
 		"key":      []string{string(key)},
 		"id":       []string{id},
 		"hostname": []string{hostname},
@@ -234,14 +294,14 @@ func (c *Client) GenerateHostCert(key []byte, id, hostname string, ttl time.Dura
 		return nil, err
 	}
 	var cert *certResponse
-	if err := json.Unmarshal(out, &cert); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &cert); err != nil {
 		return nil, err
 	}
 	return []byte(cert.Cert), err
 }
 
 func (c *Client) GenerateUserCert(key []byte, id, user string, ttl time.Duration) ([]byte, error) {
-	out, err := c.PostForm(c.endpoint("ca", "user", "certs"), url.Values{
+	out, err := c.PostForm(c.Endpoint("ca", "user", "certs"), url.Values{
 		"key":  []string{string(key)},
 		"id":   []string{id},
 		"user": []string{user},
@@ -251,90 +311,18 @@ func (c *Client) GenerateUserCert(key []byte, id, user string, ttl time.Duration
 		return nil, err
 	}
 	var cert *certResponse
-	if err := json.Unmarshal(out, &cert); err != nil {
+	if err := json.Unmarshal(out.Bytes(), &cert); err != nil {
 		return nil, err
 	}
 	return []byte(cert.Cert), err
 }
 
 func (c *Client) ResetHostCA() error {
-	_, err := c.PostForm(c.endpoint("ca", "host", "keys"), url.Values{})
+	_, err := c.PostForm(c.Endpoint("ca", "host", "keys"), url.Values{})
 	return err
 }
 
 func (c *Client) ResetUserCA() error {
-	_, err := c.PostForm(c.endpoint("ca", "user", "keys"), url.Values{})
+	_, err := c.PostForm(c.Endpoint("ca", "user", "keys"), url.Values{})
 	return err
-}
-
-func (c *Client) PostForm(endpoint string, vals url.Values) ([]byte, error) {
-	return c.RoundTrip(func() (*http.Response, error) {
-		return c.client.Post(
-			endpoint, "application/x-www-form-urlencoded",
-			strings.NewReader(vals.Encode()))
-	})
-}
-
-func (c *Client) Delete(endpoint string) error {
-	data, err := c.RoundTrip(func() (*http.Response, error) {
-		req, err := http.NewRequest("DELETE", endpoint, nil)
-		if err != nil {
-			return nil, err
-		}
-		return c.client.Do(req)
-	})
-	if err != nil {
-		return err
-	}
-	var re *StatusResponse
-	err = json.Unmarshal(data, &re)
-	return err
-}
-
-func (c *Client) Get(u string, params url.Values) ([]byte, error) {
-	baseUrl, err := url.Parse(u)
-	if err != nil {
-		return nil, err
-	}
-	baseUrl.RawQuery = params.Encode()
-	return c.RoundTrip(func() (*http.Response, error) {
-		return c.client.Get(baseUrl.String())
-	})
-}
-
-type RoundTripFn func() (*http.Response, error)
-
-func (c *Client) RoundTrip(fn RoundTripFn) ([]byte, error) {
-	re, err := fn()
-	if err != nil {
-		return nil, err
-	}
-	defer re.Body.Close()
-	body, err := ioutil.ReadAll(re.Body)
-	if err != nil {
-		return nil, err
-	}
-	if re.StatusCode != http.StatusOK && re.StatusCode != http.StatusCreated {
-		var s *StatusResponse
-		if err := json.Unmarshal(body, &s); err != nil {
-			return nil, fmt.Errorf(
-				"failed to decode response '%s', error: %v", string(body), err)
-		}
-		s.StatusCode = re.StatusCode
-		return nil, s
-	}
-	return body, nil
-}
-
-func (c *Client) endpoint(params ...string) string {
-	return fmt.Sprintf("%s/%s/%s", c.addr, CurrentVersion, strings.Join(params, "/"))
-}
-
-type StatusResponse struct {
-	StatusCode int
-	Message    string `json:"message"`
-}
-
-func (e *StatusResponse) Error() string {
-	return e.Message
 }

--- a/auth/init.go
+++ b/auth/init.go
@@ -1,0 +1,204 @@
+package auth
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gravitational/teleport/backend"
+	"github.com/gravitational/teleport/sshutils"
+	"github.com/gravitational/teleport/utils"
+
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/lemma/secret"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/log"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/crypto/ssh"
+)
+
+func Init(b backend.Backend, a Authority,
+	fqdn, authDomain, dataDir string) (*AuthServer, ssh.Signer, error) {
+
+	if authDomain == "" {
+		return nil, nil, fmt.Errorf("node name can not be empty")
+	}
+	if dataDir == "" {
+		return nil, nil, fmt.Errorf("path can not be empty")
+	}
+
+	if err := b.AcquireLock(authDomain, 60*time.Second); err != nil {
+		return nil, nil, err
+	}
+	defer b.ReleaseLock(authDomain)
+
+	scrt, err := InitSecret(dataDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// check that user CA and host CA are present and set the certs if needed
+	asrv := NewAuthServer(b, a, scrt)
+
+	if _, e := asrv.GetHostCAPub(); e != nil {
+		if _, ok := e.(*backend.NotFoundError); ok {
+			if err := asrv.ResetHostCA(""); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	if _, e := asrv.GetUserCAPub(); e != nil {
+		if _, ok := e.(*backend.NotFoundError); ok {
+			if err := asrv.ResetUserCA(""); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	signer, err := InitKeys(asrv, fqdn, dataDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return asrv, signer, nil
+}
+
+// initialize this node's host certificate signed by host authority
+func InitKeys(a *AuthServer, fqdn, dataDir string) (ssh.Signer, error) {
+	if fqdn == "" {
+		return nil, fmt.Errorf("fqdn can not be empty")
+	}
+
+	kp, cp := keysPath(fqdn, dataDir)
+
+	keyExists, err := pathExists(kp)
+	if err != nil {
+		return nil, err
+	}
+
+	certExists, err := pathExists(cp)
+	if err != nil {
+		return nil, err
+	}
+
+	if !keyExists || !certExists {
+		k, pub, err := a.GenerateKeyPair("")
+		if err != nil {
+			return nil, err
+		}
+		c, err := a.GenerateHostCert(pub, fqdn, fqdn, 0)
+		if err != nil {
+			return nil, err
+		}
+		if err := writeKeys(fqdn, dataDir, k, c); err != nil {
+			return nil, err
+		}
+	}
+	return ReadKeys(fqdn, dataDir)
+}
+
+func writeKeys(fqdn, dataDir string, key []byte, cert []byte) error {
+	kp, cp := keysPath(fqdn, dataDir)
+
+	log.Infof("write key to %v, cert from %v", kp, cp)
+
+	if err := ioutil.WriteFile(kp, key, 0600); err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(cp, cert, 0600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ReadKeys(fqdn, dataDir string) (ssh.Signer, error) {
+	kp, cp := keysPath(fqdn, dataDir)
+
+	log.Infof("read key from %v, cert from %v", kp, cp)
+
+	key, err := utils.ReadPath(kp)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := utils.ReadPath(cp)
+	if err != nil {
+		return nil, err
+	}
+
+	return sshutils.NewHostSigner(key, cert)
+}
+
+func HaveKeys(fqdn, dataDir string) (bool, error) {
+	kp, cp := keysPath(fqdn, dataDir)
+
+	exists, err := pathExists(kp)
+	if !exists || err != nil {
+		return exists, err
+	}
+
+	exists, err = pathExists(cp)
+	if !exists || err != nil {
+		return exists, err
+	}
+
+	return true, nil
+}
+
+func InitSecret(dataDir string) (*secret.Service, error) {
+	keyPath := secretKeyPath(dataDir)
+	exists, err := pathExists(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		log.Infof("Secret not found. Writing to %v", keyPath)
+		k, err := secret.NewKey()
+		if err != nil {
+			return nil, err
+		}
+		err = ioutil.WriteFile(
+			keyPath, []byte(secret.KeyToEncodedString(k)), 0600)
+		if err != nil {
+			return nil, err
+		}
+	}
+	log.Infof("Reading secret from %v", keyPath)
+	return ReadSecret(dataDir)
+}
+
+func ReadSecret(dataDir string) (*secret.Service, error) {
+	keyPath := secretKeyPath(dataDir)
+	bytes, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	key, err := secret.EncodedStringToKey(string(bytes))
+	if err != nil {
+		return nil, err
+	}
+	return secret.New(&secret.Config{KeyBytes: key})
+}
+
+func secretKeyPath(dataDir string) string {
+	return filepath.Join(dataDir, "teleport.secret")
+}
+
+func keysPath(fqdn, dataDir string) (key string, cert string) {
+	key = filepath.Join(dataDir, fmt.Sprintf("%v.key", fqdn))
+	cert = filepath.Join(dataDir, fmt.Sprintf("%v.cert", fqdn))
+	return
+}
+
+func pathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/auth/register.go
+++ b/auth/register.go
@@ -1,0 +1,49 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/teleport/utils"
+
+	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/crypto/ssh"
+)
+
+func Register(fqdn, dataDir, token string, servers []utils.NetAddr) error {
+	method, err := NewTokenAuth(fqdn, token)
+	if err != nil {
+		return err
+	}
+	config := &ssh.ClientConfig{
+		User: fqdn,
+		Auth: method,
+	}
+	client, err := ssh.Dial(servers[0].Network, servers[0].Addr, config)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	ch, _, err := client.OpenChannel(ReqProvision, nil)
+	if err != nil {
+		return err
+	}
+	defer ch.Close()
+
+	buf := &bytes.Buffer{}
+	if _, err = io.Copy(buf, ch.Stderr()); err != nil {
+		return fmt.Errorf("failed to read key pair from channel: %v", err)
+	}
+	var keys *PackedKeys
+	if err := json.NewDecoder(buf).Decode(&keys); err != nil {
+		return err
+	}
+	return writeKeys(fqdn, dataDir, keys.Key, keys.Cert)
+}
+
+type PackedKeys struct {
+	Key  []byte `json:"key"`
+	Cert []byte `json:"cert"`
+}

--- a/auth/tun_test.go
+++ b/auth/tun_test.go
@@ -1,11 +1,18 @@
 package auth
 
 import (
+	"io/ioutil"
+	"net"
+	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"path/filepath"
 
 	"github.com/gravitational/teleport/auth/openssh"
+	"github.com/gravitational/teleport/backend"
 	"github.com/gravitational/teleport/backend/membk"
 	"github.com/gravitational/teleport/sshutils"
+	"github.com/gravitational/teleport/utils"
 
 	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/lemma/secret"
 	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/log"
@@ -14,14 +21,13 @@ import (
 )
 
 type TunSuite struct {
-	clt  *TunClient
 	bk   *membk.MemBackend
 	scrt *secret.Service
 
-	srv   *httptest.Server
-	tsrv  *TunServer
-	a     *AuthServer
-	creds AuthMethod
+	srv    *httptest.Server
+	tsrv   *TunServer
+	a      *AuthServer
+	signer ssh.Signer
 }
 
 var _ = Suite(&TunSuite{})
@@ -33,6 +39,10 @@ func (s *TunSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	s.scrt = srv
 	log.Init([]*log.LogConfig{&log.LogConfig{Name: "console"}})
+}
+
+func (s *TunSuite) TearDownTest(c *C) {
+	s.srv.Close()
 }
 
 func (s *TunSuite) SetUpTest(c *C) {
@@ -49,59 +59,131 @@ func (s *TunSuite) SetUpTest(c *C) {
 
 	signer, err := sshutils.NewHostSigner(hpriv, hcert)
 	c.Assert(err, IsNil)
+	s.signer = signer
+	u, err := url.Parse(s.srv.URL)
+	c.Assert(err, IsNil)
 
 	tsrv, err := NewTunServer(
-		sshutils.Addr{Net: "tcp", Addr: "127.0.0.1:0"},
+		utils.NetAddr{Network: "tcp", Addr: "127.0.0.1:0"},
 		[]ssh.Signer{signer},
-		s.srv.URL, s.a)
+		utils.NetAddr{Network: "tcp", Addr: u.Host}, s.a)
+
+	c.Assert(err, IsNil)
+	c.Assert(tsrv.Start(), IsNil)
+	s.tsrv = tsrv
+}
+
+func (s *TunSuite) TestUnixServerClient(c *C) {
+	d, err := ioutil.TempDir("", "teleport-test")
+	c.Assert(err, IsNil)
+	socketPath := filepath.Join(d, "unix.sock")
+
+	l, err := net.Listen("unix", socketPath)
+	c.Assert(err, IsNil)
+
+	h := NewAPIServer(s.a)
+	srv := &httptest.Server{
+		Listener: l,
+		Config: &http.Server{
+			Handler: h,
+		},
+	}
+	srv.Start()
+	defer srv.Close()
+
+	u, err := url.Parse(s.srv.URL)
+	c.Assert(err, IsNil)
+
+	tsrv, err := NewTunServer(
+		utils.NetAddr{Network: "tcp", Addr: "127.0.0.1:0"},
+		[]ssh.Signer{s.signer},
+		utils.NetAddr{Network: "tcp", Addr: u.Host}, s.a)
 
 	c.Assert(err, IsNil)
 	c.Assert(tsrv.Start(), IsNil)
 	s.tsrv = tsrv
 
-	s.creds = AuthMethod{
-		User: "test",
-		Type: "password",
-		Pass: []byte("pwd123"),
-	}
-	s.a.UpsertPassword(s.creds.User, s.creds.Pass)
+	user := "test"
+	pass := []byte("pwd123")
 
-	clt, err := NewTunClient(tsrv.Addr(), s.creds)
+	s.a.UpsertPassword(user, pass)
+
+	authMethod, err := NewWebPasswordAuth(user, pass)
 	c.Assert(err, IsNil)
-	s.clt = clt
-}
 
-func (s *TunSuite) TearDownTest(c *C) {
-	s.srv.Close()
+	clt, err := NewTunClient(
+		utils.NetAddr{Network: "tcp", Addr: tsrv.Addr()},
+		"test", authMethod)
+	c.Assert(err, IsNil)
+
+	err = clt.UpsertServer(
+		backend.Server{ID: "a.example.com", Addr: "hello"}, 0)
+	c.Assert(err, IsNil)
 }
 
 func (s *TunSuite) TestSessions(c *C) {
 	c.Assert(s.a.ResetUserCA(""), IsNil)
 
-	user := s.creds.User
-	pass := []byte("abc123")
+	user := "ws-test"
+	pass := []byte("ws-abc123")
 
-	ws, err := s.clt.SignIn(user, pass)
-	c.Assert(err, NotNil)
-	c.Assert(ws, Equals, "")
+	c.Assert(s.a.UpsertPassword(user, pass), IsNil)
 
-	c.Assert(s.clt.UpsertPassword(user, pass), IsNil)
+	authMethod, err := NewWebPasswordAuth(user, pass)
+	c.Assert(err, IsNil)
 
-	ws, err = s.clt.SignIn(user, pass)
+	clt, err := NewTunClient(
+		utils.NetAddr{Network: "tcp", Addr: s.tsrv.Addr()}, user, authMethod)
+	c.Assert(err, IsNil)
+	defer clt.Close()
+
+	c.Assert(clt.UpsertPassword(user, pass), IsNil)
+
+	ws, err := clt.SignIn(user, pass)
 	c.Assert(err, IsNil)
 	c.Assert(ws, Not(Equals), "")
 
-	out, err := s.clt.GetWebSession(user, ws)
+	out, err := clt.GetWebSession(user, ws)
 	c.Assert(err, IsNil)
 	c.Assert(out, DeepEquals, ws)
 
 	// Resume session via sesison id
-	clt, err := NewTunClient(s.tsrv.Addr(), AuthMethod{User: user, Type: "session", Pass: []byte(ws)})
+	authMethod, err = NewWebSessionAuth(user, []byte(ws))
 	c.Assert(err, IsNil)
 
-	err = clt.DeleteWebSession(user, ws)
+	cltw, err := NewTunClient(
+		utils.NetAddr{Network: "tcp", Addr: s.tsrv.Addr()}, user, authMethod)
 	c.Assert(err, IsNil)
-	return
+	defer cltw.Close()
+
+	err = cltw.DeleteWebSession(user, ws)
+	c.Assert(err, IsNil)
+
 	_, err = clt.GetWebSession(user, ws)
 	c.Assert(err, NotNil)
+}
+
+func (s *TunSuite) TestSessionsBadPassword(c *C) {
+	c.Assert(s.a.ResetUserCA(""), IsNil)
+
+	user := "system-test"
+	pass := []byte("system-abc123")
+
+	c.Assert(s.a.UpsertPassword(user, pass), IsNil)
+
+	authMethod, err := NewWebPasswordAuth(user, pass)
+	c.Assert(err, IsNil)
+
+	clt, err := NewTunClient(
+		utils.NetAddr{Network: "tcp", Addr: s.tsrv.Addr()}, user, authMethod)
+	c.Assert(err, IsNil)
+	defer clt.Close()
+
+	ws, err := clt.SignIn(user, []byte("different-pass"))
+	c.Assert(err, NotNil)
+	c.Assert(ws, Equals, "")
+
+	ws, err = clt.SignIn("not-exitsts", pass)
+	c.Assert(err, NotNil)
+	c.Assert(ws, Equals, "")
 }

--- a/backend/etcdbk/etcd_test.go
+++ b/backend/etcdbk/etcd_test.go
@@ -109,3 +109,11 @@ func (s *EtcdSuite) TestWebSessionCRUD(c *C) {
 func (s *EtcdSuite) TestWebTunCRUD(c *C) {
 	s.suite.WebTunCRUD(c)
 }
+
+func (s *EtcdSuite) TestLocking(c *C) {
+	s.suite.Locking(c)
+}
+
+func (s *EtcdSuite) TestToken(c *C) {
+	s.suite.TokenCRUD(c)
+}

--- a/backend/membk/mem_test.go
+++ b/backend/membk/mem_test.go
@@ -60,3 +60,11 @@ func (s *MemSuite) TestWebSessionCRUD(c *C) {
 func (s *MemSuite) TestWebTunCRUD(c *C) {
 	s.suite.WebTunCRUD(c)
 }
+
+func (s *MemSuite) TestLocking(c *C) {
+	s.suite.Locking(c)
+}
+
+func (s *MemSuite) TestToken(c *C) {
+	s.suite.TokenCRUD(c)
+}

--- a/cp/srv.go
+++ b/cp/srv.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/gravitational/memlog"
+	"github.com/gravitational/teleport/utils"
 )
 
 // CPSrv implements Control Panel server
@@ -14,7 +15,7 @@ type CPServer struct {
 }
 
 type Config struct {
-	AuthSrv []string
+	AuthSrv []utils.NetAddr
 	LogSrv  memlog.Logger
 	Host    string
 }

--- a/cp/ws.go
+++ b/cp/ws.go
@@ -2,16 +2,19 @@ package cp
 
 import (
 	"fmt"
-	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/net/websocket"
+
 	"net/http"
 
-	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/log"
 	"github.com/gravitational/teleport/sshutils"
+	"github.com/gravitational/teleport/utils"
+
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/log"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/net/websocket"
 )
 
 // wsHandler
 type wsHandler struct {
-	authServers []string
+	authServers []utils.NetAddr
 	ctx         *ctx
 	addr        string
 	up          *sshutils.Upstream

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,274 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/gravitational/teleport/auth"
+	"github.com/gravitational/teleport/auth/openssh"
+	"github.com/gravitational/teleport/backend"
+	"github.com/gravitational/teleport/backend/etcdbk"
+	"github.com/gravitational/teleport/cp"
+	"github.com/gravitational/teleport/srv"
+	"github.com/gravitational/teleport/utils"
+
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/codahale/lunk"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/gravitational/memlog"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/log"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/oxy/trace"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/crypto/ssh"
+)
+
+type TeleportService struct {
+	Supervisor
+	log memlog.Logger
+}
+
+func NewTeleport(cfg Config) (*TeleportService, error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	if err := initLogging(cfg.Log, cfg.LogSeverity); err != nil {
+		return nil, err
+	}
+
+	t := &TeleportService{}
+	t.Supervisor = *New()
+	t.log = memlog.New()
+
+	if cfg.Auth.Enabled {
+		if err := initAuth(t, cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	if cfg.CP.Enabled {
+		if err := initCP(t, cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	if cfg.SSH.Enabled {
+		if err := initSSH(t, cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return t, nil
+}
+
+func initAuth(t *TeleportService, cfg Config) error {
+	a := cfg.Auth
+	if a.Domain == "" {
+		return fmt.Errorf("please provide auth domain, e.g. example.com")
+	}
+
+	b, err := initBackend(cfg.Auth.Backend, cfg.Auth.BackendConfig)
+	if err != nil {
+		return err
+	}
+
+	asrv, signer, err := auth.Init(
+		b, openssh.New(), cfg.FQDN, cfg.Auth.Domain, cfg.DataDir)
+	if err != nil {
+		log.Errorf("failed to init auth server: %v", err)
+		return err
+	}
+
+	// register HTTP API endpoint
+	t.RegisterFunc(func() error {
+		apisrv := auth.NewAPIServer(asrv)
+		t, err := trace.New(apisrv, log.GetLogger().Writer(log.SeverityInfo))
+		if err != nil {
+			log.Fatalf("failed to start: %v", err)
+		}
+
+		log.Infof("teleport http authority starting on %v", a.HTTPAddr)
+		return utils.StartHTTPServer(a.HTTPAddr, t)
+	})
+
+	// register SSH endpoint
+	t.RegisterFunc(func() error {
+		tsrv, err := auth.NewTunServer(
+			a.SSHAddr, []ssh.Signer{signer},
+			a.HTTPAddr,
+			asrv)
+		if err != nil {
+			log.Errorf("failed to start teleport ssh tunnel")
+			return err
+		}
+		if err := tsrv.Start(); err != nil {
+			log.Errorf("failed to start teleport ssh endpoint: %v", err)
+			return err
+		}
+		return nil
+	})
+	return nil
+}
+
+func initCP(t *TeleportService, cfg Config) error {
+	if len(cfg.AuthServers) == 0 {
+		return fmt.Errorf("supply at least one auth server")
+	}
+	if len(cfg.CP.Domain) == 0 {
+		return fmt.Errorf("cp hostname is required")
+	}
+	csrv, err := cp.NewServer(cp.Config{
+		AuthSrv: cfg.AuthServers,
+		LogSrv:  t.log,
+		Host:    cfg.CP.Domain,
+	})
+	if err != nil {
+		log.Errorf("failed to start CP server: %v", err)
+		return err
+	}
+	log.Infof("teleport control panel starting on %v", cfg.CP.Addr)
+
+	t.RegisterFunc(func() error {
+		return utils.StartHTTPServer(cfg.CP.Addr, csrv)
+	})
+	return nil
+}
+
+func initSSH(t *TeleportService, cfg Config) error {
+	if len(cfg.AuthServers) == 0 {
+		return fmt.Errorf("supply at least one auth server")
+	}
+	haveKeys, err := auth.HaveKeys(cfg.FQDN, cfg.DataDir)
+	if err != nil {
+		return err
+	}
+	if !haveKeys {
+		// this means the server has not been initialized yet we are starting
+		// the registering client that attempts to connect ot the auth server
+		// and provision the keys
+		return initSSHRegister(t, cfg)
+	}
+	return initSSHEndpoint(t, cfg)
+}
+
+func initSSHEndpoint(t *TeleportService, cfg Config) error {
+	signer, err := auth.ReadKeys(cfg.FQDN, cfg.DataDir)
+
+	elog := &FanOutEventLogger{
+		Loggers: []lunk.EventLogger{
+			lunk.NewTextEventLogger(log.GetLogger().Writer(log.SeverityInfo)),
+			lunk.NewJSONEventLogger(t.log),
+		}}
+
+	client, err := auth.NewTunClient(
+		cfg.AuthServers[0],
+		cfg.FQDN,
+		[]ssh.AuthMethod{ssh.PublicKeys(signer)})
+
+	s, err := srv.New(cfg.SSH.Addr,
+		[]ssh.Signer{signer},
+		client,
+		srv.SetShell(cfg.SSH.Shell),
+		srv.SetEventLogger(elog))
+	if err != nil {
+		return err
+	}
+
+	t.RegisterFunc(func() error {
+		log.Infof("teleport ssh starting on %v", cfg.SSH.Addr)
+		if err := s.Start(); err != nil {
+			log.Fatalf("failed to start: %v", err)
+			return err
+		}
+		s.Wait()
+		return nil
+	})
+	return nil
+}
+
+func initSSHRegister(t *TeleportService, cfg Config) error {
+	t.RegisterFunc(func() error {
+		log.Infof("teleport:ssh connecting to auth servers")
+		if err := auth.Register(
+			cfg.FQDN, cfg.DataDir, cfg.SSH.Token, cfg.AuthServers); err != nil {
+			log.Errorf("teleport:ssh register failed: %v", err)
+			return err
+		}
+		log.Infof("teleport:ssh registered successfully, starting SSH endpoint")
+		return initSSHEndpoint(t, cfg)
+	})
+	return nil
+}
+
+func initBackend(btype, bcfg string) (backend.Backend, error) {
+	switch btype {
+	case "etcd":
+		return etcdbk.FromString(bcfg)
+	}
+	return nil, fmt.Errorf("unsupported backend type: %v", btype)
+}
+
+func initLogging(ltype, severity string) error {
+	s, err := log.SeverityFromString(severity)
+	if err != nil {
+		return err
+	}
+	log.Init([]*log.LogConfig{&log.LogConfig{Name: ltype}})
+	log.SetSeverity(s)
+	return nil
+}
+
+func validateConfig(cfg Config) error {
+	if cfg.DataDir == "" {
+		return fmt.Errorf("please supply data directory")
+	}
+	if !cfg.Auth.Enabled && !cfg.SSH.Enabled && !cfg.CP.Enabled {
+		return fmt.Errorf("supply at least one of Auth, SSH or CP roles")
+	}
+	return nil
+}
+
+type FanOutEventLogger struct {
+	Loggers []lunk.EventLogger
+}
+
+func (f *FanOutEventLogger) Log(id lunk.EventID, e lunk.Event) {
+	for _, l := range f.Loggers {
+		l.Log(id, e)
+	}
+}
+
+type Config struct {
+	HostCertPath string
+	HostKeyPath  string
+
+	Log         string
+	LogSeverity string
+
+	DataDir string
+	FQDN    string
+
+	AuthServers []utils.NetAddr
+
+	SSH  SSHConfig
+	Auth AuthConfig
+	CP   CPConfig
+}
+
+type AuthConfig struct {
+	Enabled       bool
+	HTTPAddr      utils.NetAddr
+	SSHAddr       utils.NetAddr
+	Domain        string
+	Backend       string
+	BackendConfig string
+}
+
+type SSHConfig struct {
+	Token   string
+	Enabled bool
+	Addr    utils.NetAddr
+	Shell   string
+}
+
+type CPConfig struct {
+	Enabled bool
+	Addr    utils.NetAddr
+	Domain  string
+}

--- a/service/supervisor.go
+++ b/service/supervisor.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"sync"
+
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/log"
+)
+
+// Supervisor implements the simple service logick
+type Supervisor struct {
+	state int
+	sync.Mutex
+	wg       *sync.WaitGroup
+	services []Service
+	errors   []error
+}
+
+// Register adds the service to the pool, if supervisor is in
+// the started state, the service will be started immediatelly
+// otherwise, it will be started after Start() has been called
+func (s *Supervisor) Register(srv Service) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.services = append(s.services, srv)
+	if s.state == stateStarted {
+		s.serve(srv)
+	}
+}
+
+func (s *Supervisor) RegisterFunc(fn ServiceFunc) {
+	s.Register(fn)
+}
+
+func (s *Supervisor) serve(srv Service) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		err := srv.Serve()
+		log.Infof("%v completed with %v", s, err)
+	}()
+}
+
+func (s *Supervisor) Start() error {
+	s.Lock()
+	defer s.Unlock()
+	s.state = stateStarted
+
+	if len(s.services) == 0 {
+		log.Infof("no services registered, returning")
+		return nil
+	}
+
+	for _, srv := range s.services {
+		s.serve(srv)
+	}
+
+	return nil
+}
+
+func (s *Supervisor) Wait() {
+	s.wg.Wait()
+}
+
+func New() *Supervisor {
+	return &Supervisor{
+		services: []Service{},
+		wg:       &sync.WaitGroup{},
+	}
+}
+
+type Service interface {
+	Serve() error
+}
+
+type ServiceFunc func() error
+
+func (s ServiceFunc) Serve() error {
+	return s()
+}
+
+const (
+	stateCreated = iota
+	stateStarted = iota
+)

--- a/srv/resolver.go
+++ b/srv/resolver.go
@@ -3,7 +3,7 @@ package srv
 import (
 	"strings"
 
-	"github.com/gravitational/teleport/backend"
+	"github.com/gravitational/teleport/auth"
 )
 
 // resolver is an interface implementing a query resolver,
@@ -15,7 +15,7 @@ type resolver interface {
 // backend resolver is a simple implementation of the resolver
 // that uses servers presence information to find the servers
 type backendResolver struct {
-	b backend.Backend
+	ap auth.AccessPoint
 }
 
 // resolve provides a simple demo resolve functionality,such as globbing, expanding to all hosts
@@ -24,7 +24,7 @@ func (b *backendResolver) resolve(query string) ([]string, error) {
 	// simply expand the query to all known hosts
 	if query == "*" {
 		out := []string{}
-		srvs, err := b.b.GetServers()
+		srvs, err := b.ap.GetServers()
 		if err != nil {
 			return nil, err
 		}

--- a/srv/srv_test.go
+++ b/srv/srv_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gravitational/teleport/backend"
 	"github.com/gravitational/teleport/backend/membk"
 	"github.com/gravitational/teleport/sshutils"
+	"github.com/gravitational/teleport/utils"
 
 	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/lemma/secret"
 	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/crypto/ssh"
@@ -58,7 +59,7 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	srv, err := New(
-		sshutils.Addr{Net: "tcp", Addr: "localhost:0"},
+		utils.NetAddr{Network: "tcp", Addr: "localhost:0"},
 		[]ssh.Signer{signer},
 		s.bk,
 		SetShell("/bin/sh"),

--- a/sshutils/server_test.go
+++ b/sshutils/server_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/teleport/utils"
+
 	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/log"
 	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/crypto/ssh"
 	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/crypto/ssh/testdata"
@@ -34,7 +36,7 @@ func (s *ServerSuite) TestStartStop(c *C) {
 		nch.Reject(ssh.Prohibited, "nothing to see here")
 	})
 	srv, err := NewServer(
-		Addr{"tcp", "localhost:0"},
+		utils.NetAddr{Network: "tcp", Addr: "localhost:0"},
 		fn,
 		s.signers,
 		AuthMethods{Password: pass("abc123")})

--- a/tctl/command/token.go
+++ b/tctl/command/token.go
@@ -1,0 +1,36 @@
+package command
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/codegangsta/cli"
+)
+
+func newTokenCommand(c *Command) cli.Command {
+	return cli.Command{
+		Name:  "token",
+		Usage: "Generates provisioning tokens",
+		Subcommands: []cli.Command{
+			{
+				Name:  "generate",
+				Usage: "Generate provisioning token for server with fqdn",
+				Flags: []cli.Flag{
+					cli.StringFlag{Name: "fqdn", Usage: "FQDN of the server"},
+					cli.DurationFlag{Name: "ttl", Value: 120 * time.Second, Usage: "TTL"},
+				},
+				Action: c.generateToken,
+			},
+		},
+	}
+}
+
+func (cmd *Command) generateToken(c *cli.Context) {
+	token, err := cmd.client.GenerateToken(
+		c.String("fqdn"), c.Duration("ttl"))
+	if err != nil {
+		cmd.printError(err)
+		return
+	}
+	fmt.Fprintf(cmd.out, token)
+}

--- a/teleport/main.go
+++ b/teleport/main.go
@@ -1,217 +1,122 @@
 package main
 
 import (
+	"flag"
 	"fmt"
-
-	"net/http"
 	"os"
 
-	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/codahale/lunk"
-	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/codegangsta/cli"
-	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/gravitational/memlog"
-	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/lemma/secret"
 	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/log"
-	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/mailgun/oxy/trace"
-	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/crypto/ssh"
-	"github.com/gravitational/teleport/auth"
-	"github.com/gravitational/teleport/auth/openssh"
-	"github.com/gravitational/teleport/backend"
-	"github.com/gravitational/teleport/backend/etcdbk"
-	"github.com/gravitational/teleport/cp"
-	"github.com/gravitational/teleport/srv"
-	"github.com/gravitational/teleport/sshutils"
+	"github.com/gravitational/teleport/service"
 	"github.com/gravitational/teleport/utils"
-	"sync"
 )
 
 func main() {
-	app := cli.NewApp()
-	app.Name = "teleport"
-	app.Usage = "Clustering SSH and key management server"
-	app.Flags = []cli.Flag{
-		cli.StringFlag{Name: "addr", Value: "localhost:2022", Usage: "SSH host:port pair to listen on"},
-		cli.StringFlag{Name: "shell", Value: "/bin/sh", Usage: "path to shell to launch for interactive sessions"},
-		cli.StringFlag{Name: "hostPrivateKey", Usage: "path to host SSH private key"},
-		cli.StringFlag{Name: "hostCert", Usage: "path to host SSH signed certificate"},
-		cli.StringFlag{Name: "backend", Value: "etcd", Usage: "backend type, currently only 'etcd'"},
-		cli.StringFlag{Name: "backendConfig", Value: "", Usage: "backend-specific configuration string"},
+	cfg := service.Config{}
 
-		cli.BoolFlag{Name: "authSrv", Usage: "start CA authority server"},
-		cli.StringFlag{Name: "authAddr", Value: "localhost:2023", Usage: "CA Auth controller server host:port pair to listen on"},
-		cli.StringFlag{Name: "authTunAddr", Value: "localhost:2024", Usage: "CA Auth controller server SSH host:port pair to listen on"},
-		cli.StringFlag{Name: "authKey", Usage: "CA auth encryption key"},
+	flag.StringVar(
+		&cfg.Log, "log", "console",
+		"log output, currently 'console' or 'syslog'")
 
-		cli.BoolFlag{Name: "cpSrv", Usage: "start Control Plane web server"},
-		cli.StringFlag{Name: "cpAddr", Value: "localhost:2025", Usage: "Control Plane webserver"},
-		cli.StringSliceFlag{Name: "cpAuth", Usage: "list of auth servers for CP to connect to", Value: &cli.StringSlice{"localhost:2024"}},
-		cli.StringFlag{Name: "cpHost", Value: "localhost", Usage: "Control Plane webserver base host"},
+	flag.StringVar(
+		&cfg.LogSeverity, "logSeverity", "WARN",
+		"log severity, INFO or WARN or ERROR")
 
-		cli.StringFlag{Name: "log", Value: "console", Usage: "Log output, currently 'console' or 'syslog'"},
-		cli.StringFlag{Name: "logSeverity", Value: "WARN", Usage: "Log severity, logs warning by default"},
+	flag.StringVar(
+		&cfg.DataDir, "dataDir", "",
+		"path to directory where teleport stores it's state")
+
+	flag.StringVar(
+		&cfg.FQDN, "fqdn", "",
+		"fqdn of this server, e.g. node1.example.com, should be unique")
+
+	flag.Var(utils.NewNetAddrList(&cfg.AuthServers),
+		"authServer", "list of SSH auth server endpoints")
+
+	// SSH specific role options
+	flag.BoolVar(&cfg.SSH.Enabled, "ssh", false,
+		"enable SSH server endpoint")
+
+	flag.Var(
+		utils.NewNetAddrVal(
+			utils.NetAddr{
+				Network: "tcp",
+				Addr:    "localhost:33000",
+			}, &cfg.SSH.Addr),
+		"sshAddr", "SSH endpoint listening address")
+
+	flag.StringVar(
+		&cfg.SSH.Shell, "sshShell", "/bin/bash",
+		"path to shell to launch for interactive sessions")
+
+	// Auth server role options
+	flag.BoolVar(&cfg.Auth.Enabled, "auth", false,
+		"enable Authentication server endpoint")
+
+	flag.StringVar(
+		&cfg.Auth.Backend, "authBackend", "etcd",
+		"auth backend type, currently only 'etcd'")
+
+	flag.StringVar(
+		&cfg.Auth.BackendConfig, "authBackendConfig", "",
+		"auth backend-specific configuration string")
+
+	flag.Var(
+		utils.NewNetAddrVal(
+			utils.NetAddr{
+				Network: "unix",
+				Addr:    "/tmp/teleport.auth.sock",
+			}, &cfg.Auth.HTTPAddr),
+		"authHTTPAddr", "Auth Server HTTP API listening address")
+
+	flag.Var(
+		utils.NewNetAddrVal(
+			utils.NetAddr{
+				Network: "tcp",
+				Addr:    "localhost:33001",
+			}, &cfg.Auth.SSHAddr),
+		"authSSHAddr", "Auth Server SSH tunnel API listening address")
+
+	flag.StringVar(
+		&cfg.Auth.Domain, "authDomain", "",
+		"authentication server domain name, e.g. example.com")
+
+	flag.StringVar(
+		&cfg.SSH.Token, "sshToken", "",
+		"one time provisioning token for SSH node to register with authority")
+
+	// CP role options
+	flag.BoolVar(&cfg.CP.Enabled, "cp", false,
+		"enable Control Panel endpoint")
+
+	flag.Var(
+		utils.NewNetAddrVal(
+			utils.NetAddr{
+				Network: "tcp",
+				Addr:    "localhost:33003",
+			}, &cfg.CP.Addr),
+		"cpAddr", "CP server web listening address")
+
+	flag.StringVar(
+		&cfg.CP.Domain, "cpDomain", "",
+		"control panel domain to serve, e.g. example.com")
+
+	flag.Parse()
+
+	// some variables can be set via environment variables
+	// TODO(klizhentas) - implement
+	if os.Getenv("TELEPORT_SSH_TOKEN") != "" {
+		cfg.SSH.Token = os.Getenv("TELEPORT_SSH_TOKEN")
 	}
-	app.Action = run
-	app.Run(os.Args)
-}
 
-func run(c *cli.Context) {
-	if err := parseArgs(c); err != nil {
-		log.Errorf("failed to parse arguments, err %v", err)
-	}
-}
-
-func setupLogging(c *cli.Context) error {
-	s, err := log.SeverityFromString(c.String("logSeverity"))
+	srv, err := service.NewTeleport(cfg)
 	if err != nil {
-		return err
-	}
-	log.Init([]*log.LogConfig{&log.LogConfig{Name: c.String("log")}})
-	log.SetSeverity(s)
-	return nil
-}
-
-func parseArgs(c *cli.Context) error {
-	if err := setupLogging(c); err != nil {
-		return err
-	}
-	hostKey, err := utils.ReadPath(c.String("hostPrivateKey"))
-	if err != nil {
-		return err
-	}
-	hostCert, err := utils.ReadPath(c.String("hostCert"))
-	if err != nil {
-		return err
-	}
-	b, err := initBackend(c.String("backend"), c.String("backendConfig"))
-	if err != nil {
-		return err
+		fmt.Printf("error starting teleport: %v\n", err)
+		return
 	}
 
-	ml := memlog.New()
-
-	hostSigner, err := sshutils.NewHostSigner(hostKey, hostCert)
-	if err != nil {
-		return err
+	if err := srv.Start(); err != nil {
+		log.Errorf("teleport failed to start with error: %v", err)
+		return
 	}
-
-	elog := &FanOutEventLogger{
-		Loggers: []lunk.EventLogger{
-			lunk.NewTextEventLogger(log.GetLogger().Writer(log.SeverityInfo)),
-			lunk.NewJSONEventLogger(ml),
-		}}
-
-	s, err := srv.New(
-		sshutils.Addr{Net: "tcp", Addr: c.String("addr")},
-		[]ssh.Signer{hostSigner},
-		b,
-		srv.SetShell(c.String("shell")),
-		srv.SetEventLogger(elog),
-	)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("teleport ssh starting on %v", c.String("addr"))
-	if err := s.Start(); err != nil {
-		log.Fatalf("failed to start: %v", err)
-	}
-	// TODO(klizhentas): cleanup this code and remove this logic to supervisor
-	wg := &sync.WaitGroup{}
-
-	if c.Bool("authSrv") {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			authAddr := c.String("authAddr")
-
-			key, err := secret.EncodedStringToKey(c.String("authKey"))
-			if err != nil {
-				log.Errorf("invalid key %v", err)
-				return
-			}
-			scrt, err := secret.New(&secret.Config{KeyBytes: key})
-			if err != nil {
-				log.Errorf("failed to start secret service: %v", err)
-				return
-			}
-
-			asrv := auth.NewAuthServer(b, openssh.New(), scrt)
-			tsrv, err := auth.NewTunServer(
-				sshutils.Addr{Net: "tcp", Addr: c.String("authTunAddr")},
-				[]ssh.Signer{hostSigner},
-				"http://"+c.String("authAddr"),
-				asrv)
-			if err != nil {
-				log.Errorf("failed to start teleport ssh tunnel")
-				return
-			}
-			if err := tsrv.Start(); err != nil {
-				log.Errorf("failed to start teleport ssh tunnel: %v", err)
-				return
-			}
-			a := auth.NewAPIServer(asrv)
-			t, err := trace.New(a, log.GetLogger().Writer(log.SeverityInfo))
-			if err != nil {
-				log.Fatalf("failed to start: %v", err)
-			}
-
-			log.Infof("teleport http authority starting on %v", authAddr)
-			srv := &http.Server{
-				Addr:    authAddr,
-				Handler: t,
-			}
-			if err := srv.ListenAndServe(); err != nil {
-				log.Fatalf("failed to start: %v", err)
-			}
-			log.Infof("teleport auth server exited gracefully")
-		}()
-	}
-
-	if c.Bool("cpSrv") {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			csrv, err := cp.NewServer(cp.Config{
-				AuthSrv: c.StringSlice("cpAuth"),
-				LogSrv:  ml,
-				Host:    c.String("cpHost"),
-			})
-			if err != nil {
-				log.Errorf("failed to start CP server: %v", err)
-				return
-			}
-			cpAddr := c.String("cpAddr")
-			log.Infof("teleport control panel starting on %v", cpAddr)
-			srv := &http.Server{
-				Addr:    cpAddr,
-				Handler: csrv,
-			}
-			if err := srv.ListenAndServe(); err != nil {
-				log.Fatalf("failed to start: %v", err)
-			}
-			log.Infof("teleport cp server exited gracefully")
-		}()
-	}
-
-	wg.Wait()
-	s.Wait()
-
-	return nil
-}
-
-func initBackend(btype, bcfg string) (backend.Backend, error) {
-	switch btype {
-	case "etcd":
-		return etcdbk.FromString(bcfg)
-	}
-	return nil, fmt.Errorf("unsupported backend type: %v", btype)
-}
-
-type FanOutEventLogger struct {
-	Loggers []lunk.EventLogger
-}
-
-func (f *FanOutEventLogger) Log(id lunk.EventID, e lunk.Event) {
-	for _, l := range f.Loggers {
-		l.Log(id, e)
-	}
+	srv.Wait()
 }

--- a/utils/addr.go
+++ b/utils/addr.go
@@ -1,0 +1,82 @@
+package utils
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type NetAddr struct {
+	Addr    string
+	Network string
+}
+
+func (a *NetAddr) String() string {
+	return fmt.Sprintf("%v://%v", a.Network, a.Addr)
+}
+
+func ParseAddr(a string) (*NetAddr, error) {
+	u, err := url.Parse(a)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse '%v':%v", a, err)
+	}
+	switch u.Scheme {
+	case "tcp":
+		return &NetAddr{Addr: u.Host, Network: u.Scheme}, nil
+	case "unix":
+		return &NetAddr{Addr: u.Path, Network: u.Scheme}, nil
+	default:
+		return nil, fmt.Errorf("unsupported scheme '%v': '%v'", a, u.Scheme)
+	}
+}
+
+func NewNetAddrVal(defaultVal NetAddr, val *NetAddr) *NetAddrVal {
+	*val = defaultVal
+	return (*NetAddrVal)(val)
+}
+
+// NetAddrVal can be used with flag package
+type NetAddrVal NetAddr
+
+func (a *NetAddrVal) Set(s string) error {
+	v, err := ParseAddr(s)
+	if err != nil {
+		return err
+	}
+	a.Addr = v.Addr
+	a.Network = v.Network
+	return nil
+}
+
+func (a *NetAddrVal) String() string {
+	return ((*NetAddr)(a)).String()
+}
+
+func (a *NetAddrVal) Get() interface{} {
+	return NetAddr(*a)
+}
+
+func NewNetAddrList(addrs *[]NetAddr) *NetAddrList {
+	return &NetAddrList{addrs: addrs}
+}
+
+type NetAddrList struct {
+	addrs *[]NetAddr
+}
+
+func (nl *NetAddrList) Set(s string) error {
+	v, err := ParseAddr(s)
+	if err != nil {
+		return err
+	}
+	*nl.addrs = append(*nl.addrs, *v)
+	return nil
+}
+
+func (nl *NetAddrList) String() string {
+	var ns []string
+	for _, n := range *nl.addrs {
+		ns = append(ns, n.String())
+	}
+	return strings.Join(ns, " ")
+}

--- a/utils/srv.go
+++ b/utils/srv.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"net"
+	"net/http"
+)
+
+func StartHTTPServer(addr NetAddr, h http.Handler) error {
+	if addr.Network == "tcp" {
+		hsrv := &http.Server{
+			Addr:    addr.Addr,
+			Handler: h,
+		}
+		return hsrv.ListenAndServe()
+	}
+	l, err := net.Listen(addr.Network, addr.Addr)
+	if err != nil {
+		return err
+	}
+	hsrv := &http.Server{
+		Handler: h,
+	}
+	return hsrv.Serve(l)
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,7 +17,7 @@ func ReadPath(path string) ([]byte, error) {
 	}
 	bytes, err := ioutil.ReadFile(abs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read private host key by path '%v', error: %v", abs, err)
+		return nil, err
 	}
 	return bytes, nil
 }


### PR DESCRIPTION
Distinct roles separation:
- Stateful auth server, it is stateful and exposes SSH
  authentication endpoint to the cluster
- Stateless ssh node, it connects to the auth server
  to authenticate access requests
- Stateless cp node, it provides web portal to access
  the cluster and update users keys

Provisioning:
- Auth server automatically sets itself up on the first start,
  no need to explicitly set encryption keys and authority certs
- SSH node connects to the Auth server to provision host private keys
  and sertificates using special SSH provisioning key issued by
  the auth server
