### PR TITLE
Fixed scp, added single node config, added certificate ttl checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,15 @@ pack-teleport: pkg teleport
 pkg:
 	@if [ "$$PKG" = "" ] ; then echo "ERROR: enter PKG parameter:\n\nmake publish PKG=<name>:<sem-ver>, e.g. teleport:0.0.1\n\n" && exit 255; fi
 
-# run-embedded-proxy starts a auth server, ssh node and proxy that allows web access 
+# run-embedded starts a auth server, ssh node and proxy that allows web access 
 # to all the nodes
 run-embedded: install
 	rm -f /tmp/teleport.auth.sock
 	teleport --config=examples/embedded.yaml
+
+# run-node starts a ssh node
+run-node: install
+	teleport --config=examples/node.yaml
 
 # run-site-to-proxy starts a ssh node, auth server and reverse tunnel that connect outside of
 # the organization server

--- a/examples/node.yaml
+++ b/examples/node.yaml
@@ -1,0 +1,16 @@
+log:
+  output: console
+  severity: INFO
+
+data_dir: /var/lib/teleport # directory where teleport stores it's state (SSH keys and database data)
+
+hostname: localhost # SSH hostname of this node
+
+ssh:
+  # enable simple ssh endpoint
+  enabled: true
+  addr: tcp://localhost:33021
+
+auth_servers: 
+  - tcp://localhost:33000
+

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -92,7 +92,7 @@ func (n *nauth) GenerateUserCert(pkey, key []byte, id, username string, ttl time
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if ttl != 0 {
 		b := time.Now().Add(ttl)
-		validBefore = uint64(b.UnixNano())
+		validBefore = uint64(b.Unix())
 	}
 	cert := &ssh.Certificate{
 		ValidPrincipals: []string{username},

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -388,6 +388,12 @@ func (s *TunServer) keyAuth(
 		return nil, err
 	}
 
+	if err := s.certChecker.CheckCert(conn.User(), key.(*ssh.Certificate)); err != nil {
+		log.Warningf("conn(%v->%v, user=%v) ERROR: Failed to authorize user %v, err: %v",
+			conn.RemoteAddr(), conn.LocalAddr(), conn.User(), conn.User(), err)
+		return nil, trace.Wrap(err)
+	}
+
 	perms := &ssh.Permissions{
 		Extensions: map[string]string{
 			ExtHost: conn.User(),

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -182,6 +182,12 @@ func (s *server) keyAuth(
 		return nil, err
 	}
 
+	if err := s.certChecker.CheckCert(conn.User(), key.(*ssh.Certificate)); err != nil {
+		log.Warningf("conn(%v->%v, user=%v) ERROR: Failed to authorize user %v, err: %v",
+			conn.RemoteAddr(), conn.LocalAddr(), conn.User(), conn.User(), err)
+		return nil, trace.Wrap(err)
+	}
+
 	perms := &ssh.Permissions{
 		Extensions: map[string]string{
 			ExtHost: conn.User(),

--- a/lib/srv/srv.go
+++ b/lib/srv/srv.go
@@ -247,6 +247,11 @@ func (s *Server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permiss
 			conn.RemoteAddr(), conn.LocalAddr(), conn.User(), conn.User(), err)
 		return nil, err
 	}
+	if err := s.certChecker.CheckCert(conn.User(), key.(*ssh.Certificate)); err != nil {
+		log.Warningf("conn(%v->%v, user=%v) ERROR: Failed to authorize user %v, err: %v",
+			conn.RemoteAddr(), conn.LocalAddr(), conn.User(), conn.User(), err)
+		return nil, trace.Wrap(err)
+	}
 	return p, nil
 }
 

--- a/lib/sshutils/scp/scp_test.go
+++ b/lib/sshutils/scp/scp_test.go
@@ -95,7 +95,7 @@ func (s *SCPSuite) TestReceiveFile(c *C) {
 	err := ioutil.WriteFile(source, contents, 0666)
 	c.Assert(err, IsNil)
 
-	outDir := c.MkDir()
+	outDir := c.MkDir() + "/"
 
 	srv, err := New(Command{Sink: true, Target: outDir})
 	c.Assert(err, IsNil)
@@ -206,7 +206,7 @@ func (s *SCPSuite) TestReceiveDir(c *C) {
 		filepath.Join(dir, "target2"), []byte("file 2"), 0666)
 	c.Assert(err, IsNil)
 
-	outDir := c.MkDir()
+	outDir := c.MkDir() + "/"
 
 	srv, err := New(Command{Sink: true, Target: outDir, Recursive: true})
 	c.Assert(err, IsNil)

--- a/tool/tctl/command/cmd.go
+++ b/tool/tctl/command/cmd.go
@@ -161,7 +161,7 @@ func (cmd *Command) Run(args []string) error {
 	agentStartAPIAddr := agentStart.Flag("api-addr", "api listening address").Default(teleagent.DefaultAgentAPIAddress).String()
 
 	agentLogin := agent.Command("login", "Generate remote server certificate for teleagent ssh agent using your credentials")
-	agentLoginAgentAddr := agentLogin.Flag("agent-addr", "ssh agent address").Default(teleagent.DefaultAgentAPIAddress).String()
+	agentLoginAgentAddr := agentLogin.Flag("agent-api-addr", "ssh agent api address").Default(teleagent.DefaultAgentAPIAddress).String()
 	agentLoginProxyAddr := agentLogin.Flag("proxy-addr", "FQDN of the remote proxy").Required().String()
 	agentLoginTTL := agentLogin.Flag("ttl", "Certificate duration").Default("10h").Duration()
 


### PR DESCRIPTION
Teleport scp implementation had a bug, it didn't handle "/" at the end of the remote destination path(For example: "scp file1  dir1/dir2/file2" and "scp file1  dir1/dir2/dir3/"). Fixed it.
