### PR TITLE
proxy subsystem improvements

### DIFF
--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -44,6 +44,7 @@ type RemoteSite interface {
 	GetName() string
 	GetStatus() string
 	GetClient() *auth.Client
+	GetServers() ([]services.Server, error)
 }
 
 type Server interface {
@@ -280,7 +281,7 @@ func (s *server) FindSimilarSite(domainName string) (RemoteSite, error) {
 }
 
 type remoteSite struct {
-	domainName       string
+	domainName string
 	conn       ssh.Conn
 	lastActive time.Time
 	srv        *server
@@ -394,7 +395,7 @@ func (s *remoteSite) DialServer(server string) (net.Conn, error) {
 			log.Errorf("server %v(%v) has incorrect address format (%v)",
 				srv.Addr, srv.Hostname, err.Error())
 		} else {
-			if (len(srv.Hostname) != 0) && (len(port) != 0) && (server == srv.Hostname+":"+port) {
+			if (len(srv.Hostname) != 0) && (len(port) != 0) && (server == srv.Hostname+":"+port || server == srv.Addr) {
 				serverIsKnown = true
 			}
 		}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -120,6 +120,10 @@ func InitAuthService(supervisor Supervisor, cfg RoleConfig, hostname string) err
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	trustedAuthorities, err := cfg.Auth.TrustedAuthorities.Authorities()
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	acfg := auth.InitConfig{
 		Backend:            b,
 		Authority:          authority.New(),
@@ -128,15 +132,21 @@ func InitAuthService(supervisor Supervisor, cfg RoleConfig, hostname string) err
 		DataDir:            cfg.DataDir,
 		SecretKey:          cfg.Auth.SecretKey,
 		AllowedTokens:      cfg.Auth.AllowedTokens,
-		TrustedAuthorities: cfg.Auth.TrustedAuthorities.Authorities(),
+		TrustedAuthorities: trustedAuthorities,
 	}
 	if len(cfg.Auth.UserCA.PublicKey) != 0 && len(cfg.Auth.UserCA.PrivateKey) != 0 {
-		acfg.UserCA = cfg.Auth.UserCA.CA()
+		acfg.UserCA, err = cfg.Auth.UserCA.CA()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		acfg.UserCA.DomainName = hostname
 		acfg.UserCA.Type = services.UserCert
 	}
 	if len(cfg.Auth.HostCA.PublicKey) != 0 && len(cfg.Auth.HostCA.PrivateKey) != 0 {
-		acfg.HostCA = cfg.Auth.HostCA.CA()
+		acfg.HostCA, err = cfg.Auth.HostCA.CA()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		acfg.HostCA.DomainName = hostname
 		acfg.HostCA.Type = services.HostCert
 	}

--- a/lib/services/ca.go
+++ b/lib/services/ca.go
@@ -258,6 +258,6 @@ type LocalCertificateAuthority struct {
 type CertificateAuthority struct {
 	Type       string `json:"type" yaml:"type"`
 	ID         string `json:"id" yaml:"id"`
-	DomainName string `json:"domain_name" yaml:"domain_name"`
-	PublicKey  []byte `json:"public_key" yaml:"public_key"`
+	DomainName string `json:"domain_name" yaml:"domain_name" env:"domain_name"`
+	PublicKey  []byte `json:"public_key" yaml:"public_key" env:"public_key"`
 }

--- a/lib/srv/sites.go
+++ b/lib/srv/sites.go
@@ -1,0 +1,48 @@
+package srv
+
+import (
+	"encoding/json"
+
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/gravitational/log"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/github.com/gravitational/trace"
+	"github.com/gravitational/teleport/Godeps/_workspace/src/golang.org/x/crypto/ssh"
+)
+
+// proxySubsys is an SSH subsystem for easy proxyneling through proxy server
+// This subsystem creates a new TCP connection and connects ssh channel
+// with this connection
+type proxySitesSubsys struct {
+	srv *Server
+}
+
+func parseProxySitesSubsys(name string, srv *Server) (*proxySitesSubsys, error) {
+	return &proxySitesSubsys{
+		srv: srv,
+	}, nil
+}
+
+func (t *proxySitesSubsys) String() string {
+	return "proxySites()"
+}
+
+func (t *proxySitesSubsys) execute(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
+	log.Infof("%v execute()", ctx)
+	sites := map[string]interface{}{}
+	for _, s := range t.srv.proxyTun.GetSites() {
+		servers, err := s.GetServers()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		sites[s.GetName()] = servers
+	}
+
+	data, err := json.Marshal(sites)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := ch.Write(data); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/lib/srv/subsystem.go
+++ b/lib/srv/subsystem.go
@@ -47,8 +47,11 @@ func parseSubsystemRequest(srv *Server, req *ssh.Request) (subsystem, error) {
 	if strings.HasPrefix(s.Name, "ls:") {
 		return parseLSSubsys(s.Name)
 	}
-	if strings.HasPrefix(s.Name, "proxy:") && (srv.proxyMode) {
+	if srv.proxyMode && strings.HasPrefix(s.Name, "proxy:") {
 		return parseProxySubsys(s.Name, srv)
+	}
+	if srv.proxyMode && strings.HasPrefix(s.Name, "proxysites") {
+		return parseProxySitesSubsys(s.Name, srv)
 	}
 	return nil, fmt.Errorf("unrecognized subsystem: %v", s.Name)
 }


### PR DESCRIPTION
this PR introduces two improvements for proxy subsystem:
- `proxysites` subsystem outputs the list of sites and servers registered in the proxy, this allows SSH clients to discover possible sites and servers
- `proxy` subsystem allows connection via `hostname:port` without trying to resolve hostname. This solves the problem where server is visible as `a.example.com` but there's no real DNS entry that leads to this address in the cluster. With this change server will find the hostname in the list of the servers and will dial it's IP address instead of the server hostname
