### PR TITLE
lazy load templates

### DIFF
--- a/lib/web/site.go
+++ b/lib/web/site.go
@@ -46,9 +46,8 @@ import (
 // SiteHandler implements methods for single site
 type SiteHandler struct {
 	httprouter.Router
-	cfg          SiteHandlerConfig
-	templates    map[string]*template.Template
-	hasTemplates uint32
+	cfg       SiteHandlerConfig
+	templates map[string]*template.Template
 	sync.Mutex
 }
 


### PR DESCRIPTION
Make sure that web proxy does not need templates to exists if the handler methods are not actually called (this is needed for gravity integration to work)
