### PR TITLE
fix use case when username contains @ character

### DIFF
--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -637,4 +637,8 @@ func (s *ClientSuite) TestSplitUserAndAddress(c *C) {
 	user, addr = SplitUserAndAddress("abcd:1234")
 	c.Assert(user, Equals, "")
 	c.Assert(addr, Equals, "abcd:1234")
+
+	user, addr = SplitUserAndAddress("user@gmail.com@address")
+	c.Assert(user, Equals, "user@gmail.com")
+	c.Assert(addr, Equals, "address")
 }

--- a/lib/client/simple_client.go
+++ b/lib/client/simple_client.go
@@ -334,13 +334,11 @@ func ParseTargetServers(target string, user, proxyAddress string, authMethods []
 // SplitUserAndAddress splits target into user and address using "@"
 // as delimiter. If target doesn't contain "@", it returns empty user
 // and target as address
-func SplitUserAndAddress(target string) (user, address string) {
-	if !strings.Contains(target, "@") {
+func SplitUserAndAddress(target string) (string, string) {
+	idx := strings.LastIndex(target, "@")
+	if idx == -1 {
 		return "", target
 	}
-
-	parts := strings.Split(target, "@")
-	user = parts[0]
-	address = strings.Join(parts[1:len(parts)], "@")
+	user, address := target[0:idx], target[idx+1:len(target)]
 	return user, address
 }


### PR DESCRIPTION
I've encountered a problem: when user has @ token, the split function grabs the wrong token. This PR fixes the problem.  @alexlyulkov can you please review?
