### PR TITLE
--token and --name are not mandatory anymore...

### DIFF
--- a/lib/auth/api_with_roles.go
+++ b/lib/auth/api_with_roles.go
@@ -69,7 +69,6 @@ func (api *APIWithRoles) Serve() {
 	for role, _ := range api.listeners {
 		wg.Add(1)
 		go func(listener net.Listener, handler http.Handler) {
-			log.Debugf("[api_with_roles] about to call http.Serve() on a listener")
 			if err := http.Serve(listener, handler); (err != nil) && (err != io.EOF) {
 				log.Errorf(err.Error())
 			}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -227,6 +227,8 @@ func (c *Client) GenerateToken(nodename string, role teleport.Role, ttl time.Dur
 	return token, nil
 }
 
+// RegisterUserToken calls the auth service API to register a new node via registration token
+// which has been previously issued via GenerateToken
 func (c *Client) RegisterUsingToken(token, nodename string, role teleport.Role) (PackedKeys, error) {
 	out, err := c.PostJSON(c.Endpoint("tokens", "register"),
 		registerUsingTokenReq{

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -191,19 +191,18 @@ func InitKeys(a *AuthServer, domainName, dataDir string) (ssh.Signer, error) {
 	return i.KeySigner, nil
 }
 
+// writeKeys saves the key/cert pair for a given domain onto disk. This usually means the
+// domain trusts us (signed our public key)
 func writeKeys(domainName, dataDir string, key []byte, cert []byte) error {
 	kp, cp := keysPath(domainName, dataDir)
-
 	log.Debugf("write key to %v, cert from %v", kp, cp)
 
 	if err := ioutil.WriteFile(kp, key, 0600); err != nil {
 		return err
 	}
-
 	if err := ioutil.WriteFile(cp, cert, 0600); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -26,6 +26,8 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// Register is used by auth service clients (other services, like proxy or SSH) when a new node
+// joins the cluster
 func Register(domainName, dataDir, token string, role teleport.Role, servers []utils.NetAddr) error {
 	tok, err := readToken(token)
 	if err != nil {
@@ -46,6 +48,7 @@ func Register(domainName, dataDir, token string, role teleport.Role, servers []u
 
 	defer client.Close()
 
+	// TODO: replace domain name with host UUID
 	keys, err := client.RegisterUsingToken(tok, domainName, role)
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/teleport/configuration.go
+++ b/tool/teleport/configuration.go
@@ -284,12 +284,6 @@ func configure(clf *CommandLineFlags) (cfg *service.Config, err error) {
 
 	// apply --auth-server flag:
 	if clf.AuthServerAddr != "" {
-		if clf.NodeName == "" {
-			return cfg, trace.Errorf("Need --name flag")
-		}
-		if clf.AuthToken == "" {
-			return cfg, trace.Errorf("Need --token flag")
-		}
 		if cfg.Auth.Enabled {
 			log.Warnf("not starting the local auth service. --auth-server flag tells to connect to another auth server")
 			cfg.Auth.Enabled = false
@@ -304,9 +298,6 @@ func configure(clf *CommandLineFlags) (cfg *service.Config, err error) {
 
 	// apply --name flag:
 	if clf.NodeName != "" {
-		if clf.NodeName == "" {
-			return cfg, trace.Errorf("Need --name flag")
-		}
 		cfg.Hostname = clf.NodeName
 	}
 

--- a/web/dist/app/app
+++ b/web/dist/app/app
@@ -1,1 +1,1 @@
-/home/akontsevoy/go/src/github.com/gravitational/teleport/web/dist/app
+/Users/ekontsevoy/go/src/github.com/gravitational/teleport/web/dist/app


### PR DESCRIPTION
... when a teleport node re-joins the cluster who already trusts it
refs #187
closes #187 
fixes #187
