### PR TITLE
Hostname handling changes:

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -54,7 +54,12 @@ func (s *AuthSuite) SetUpTest(c *C) {
 		encryptor.GetTestKey)
 	c.Assert(err, IsNil)
 
-	s.a = NewAuthServer(s.bk, authority.New(), "localhost")
+	authConfig := &InitConfig{
+		Backend:    s.bk,
+		Authority:  authority.New(),
+		DomainName: "localhost",
+	}
+	s.a = NewAuthServer(authConfig)
 }
 
 // TODO(klizhentas) introduce more thorough tests, test more edge cases

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -34,10 +34,21 @@ import (
 )
 
 type InitConfig struct {
-	Backend       *encryptedbk.ReplicatedBackend
-	Authority     Authority
-	DomainName    string
-	DataDir       string
+	Backend   *encryptedbk.ReplicatedBackend
+	Authority Authority
+
+	// DomainName stores the FQDN of the signing CA (its certificate will have this
+	// name embedded). It is usually set to the GUID of the host the Auth service runs on
+	DomainName string
+
+	// AuthServiceName is a human-readable name of this CA. If several Auth services are running
+	// (managing multiple teleport clusters) this field is used to tell them apart in UIs
+	// It usually defaults to the hostname of the machine the Auth service runs on.
+	AuthServiceName string
+
+	// DataDir is the full path to the directory where keys, events and logs are kept
+	DataDir string
+
 	SecretKey     string
 	AllowedTokens map[string]string
 
@@ -47,6 +58,7 @@ type InitConfig struct {
 	UserCA *services.CertAuthority
 }
 
+// Init instantiates and configures an instance of AuthServer
 func Init(cfg InitConfig) (*AuthServer, ssh.Signer, error) {
 	if cfg.DataDir == "" {
 		return nil, nil, fmt.Errorf("path can not be empty")
@@ -66,7 +78,7 @@ func Init(cfg InitConfig) (*AuthServer, ssh.Signer, error) {
 	defer lockService.ReleaseLock(cfg.DomainName)
 
 	// check that user CA and host CA are present and set the certs if needed
-	asrv := NewAuthServer(cfg.Backend, cfg.Authority, cfg.DomainName)
+	asrv := NewAuthServer(&cfg)
 
 	// we determine if it's the first start by checking if the CA's are set
 	var firstStart bool

--- a/lib/auth/new_web_user.go
+++ b/lib/auth/new_web_user.go
@@ -74,7 +74,7 @@ func (s *AuthServer) CreateSignupToken(user string, allowedLogins []string) (str
 		log.Errorf("[AUTH API] failed to generate HOTP: %v", err)
 		return "", trace.Wrap(err)
 	}
-	otpQR, err := otp.QR("teleport: " + user + "@" + s.DomainName)
+	otpQR, err := otp.QR("Teleport: " + user + "@" + s.AuthServiceName)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/auth/srv.go
+++ b/lib/auth/srv.go
@@ -200,7 +200,7 @@ func (s *APIServer) upsertServer(w http.ResponseWriter, r *http.Request, p httpr
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.Debugf("[AUTH API] ping from %v", r.RemoteAddr)
+	log.Debugf("[AUTH API] ping from %v (%v) at %v", req.Server.ID, req.Server.Hostname, r.RemoteAddr)
 
 	// if server sent "local" IP address to us, replace the ip/host part with the remote address we see
 	// on the socket, but keep the original port:
@@ -700,6 +700,7 @@ type getSignupTokenDataResponse struct {
 	HotpFirstValues []string `json:"hotp_first_values"`
 }
 
+// getSignupTokenData auth API method creates a new sign-up token for adding a new user
 func (s *APIServer) getSignupTokenData(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
 	token := p[0].Value
 

--- a/lib/auth/srv_test.go
+++ b/lib/auth/srv_test.go
@@ -82,7 +82,11 @@ func (s *APISuite) SetUpTest(c *C) {
 	s.rec, err = boltrec.New(s.dir)
 	c.Assert(err, IsNil)
 
-	s.a = NewAuthServer(s.bk, authority.New(), "localhost")
+	s.a = NewAuthServer(&InitConfig{
+		Backend:    s.bk,
+		Authority:  authority.New(),
+		DomainName: "localhost",
+	})
 	sessionServer, err := session.New(s.bk)
 	c.Assert(err, IsNil)
 	s.srv = httptest.NewServer(NewAPIServer(

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -77,7 +77,12 @@ func (s *TunSuite) SetUpTest(c *C) {
 
 	sessionServer, err := session.New(s.bk)
 	c.Assert(err, IsNil)
-	s.a = NewAuthServer(s.bk, authority.New(), "localhost")
+
+	s.a = NewAuthServer(&InitConfig{
+		Backend:    s.bk,
+		Authority:  authority.New(),
+		DomainName: "localhost",
+	})
 	s.srv = NewAPIWithRoles(s.a, s.bl, sessionServer, s.rec,
 		NewStandardPermissions(),
 		StandardRoles,

--- a/lib/hangout/hangout.go
+++ b/lib/hangout/hangout.go
@@ -276,12 +276,13 @@ func (h *Hangout) initAuth(cfg service.Config, readOnlyHangout bool) error {
 		return trace.Wrap(err)
 	}
 	acfg := auth.InitConfig{
-		Backend:       b,
-		Authority:     authority.New(),
-		DomainName:    cfg.Hostname,
-		DataDir:       cfg.DataDir,
-		SecretKey:     cfg.Auth.SecretKey,
-		AllowedTokens: cfg.Auth.AllowedTokens,
+		Backend:         b,
+		Authority:       authority.New(),
+		DomainName:      cfg.HostUUID,
+		AuthServiceName: cfg.Hostname,
+		DataDir:         cfg.DataDir,
+		SecretKey:       cfg.Auth.SecretKey,
+		AllowedTokens:   cfg.Auth.AllowedTokens,
 	}
 	asrv, signer, err := auth.Init(acfg)
 	if err != nil {

--- a/lib/hangout/hangout_test.go
+++ b/lib/hangout/hangout_test.go
@@ -83,7 +83,10 @@ func (s *HangoutsSuite) SetUpSuite(c *C) {
 		encryptor.GetTestKey)
 	c.Assert(err, IsNil)
 
-	s.a = auth.NewAuthServer(s.bk, authority.New(), "localhost")
+	s.a = auth.NewAuthServer(&auth.InitConfig{
+		Backend:    s.bk,
+		Authority:  authority.New(),
+		DomainName: "localhost"})
 
 	// set up host private key and certificate
 	c.Assert(s.a.UpsertCertAuthority(

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -99,6 +99,7 @@ func (cfg *Config) RoleConfig() RoleConfig {
 	return RoleConfig{
 		DataDir:     cfg.DataDir,
 		HostUUID:    cfg.HostUUID,
+		HostName:    cfg.Hostname,
 		AuthServers: cfg.AuthServers,
 		Auth:        cfg.Auth,
 		Console:     cfg.Console,

--- a/lib/srv/srv_test.go
+++ b/lib/srv/srv_test.go
@@ -94,7 +94,10 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.domainName = "localhost"
-	s.a = auth.NewAuthServer(s.bk, authority.New(), s.domainName)
+	s.a = auth.NewAuthServer(&auth.InitConfig{
+		Backend:    s.bk,
+		Authority:  authority.New(),
+		DomainName: s.domainName})
 
 	eventsLog, err := boltlog.New(filepath.Join(s.dir, "boltlog"))
 	c.Assert(err, IsNil)

--- a/lib/web/web_test.go
+++ b/lib/web/web_test.go
@@ -101,7 +101,10 @@ func (s *WebSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.domainName = "localhost"
-	authServer := auth.NewAuthServer(s.bk, authority.New(), s.domainName)
+	authServer := auth.NewAuthServer(&auth.InitConfig{
+		Backend:    s.bk,
+		Authority:  authority.New(),
+		DomainName: s.domainName})
 
 	eventsLog, err := boltlog.New(filepath.Join(s.dir, "boltlog"))
 	c.Assert(err, IsNil)

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -222,7 +222,7 @@ func (u *NodeCommand) ListActive(client *auth.TunClient) error {
 	}
 	nodesView := func(nodes []services.Server) string {
 		t := goterm.NewTable(0, 10, 5, ' ', 0)
-		printHeader(t, []string{"Node Name", "Address", "Labels"})
+		printHeader(t, []string{"Node Hostname", "Node ID", "Address", "Labels"})
 		if len(nodes) == 0 {
 			return t.String()
 		}
@@ -234,7 +234,7 @@ func (u *NodeCommand) ListActive(client *auth.TunClient) error {
 			for key, val := range n.CmdLabels {
 				labels = append(labels, fmt.Sprintf("%s:%s", key, val.Result))
 			}
-			fmt.Fprintf(t, "%v\t%v\t%v\n", n.Hostname, n.Addr, strings.Join(labels, ","))
+			fmt.Fprintf(t, "%v\t%v\t%v\t%v\n", n.Hostname, n.ID, n.Addr, strings.Join(labels, ","))
 		}
 		return t.String()
 	}

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -74,8 +74,8 @@ func run(cmdlineArgs []string, testRun bool) (executedCommand string, appliedCon
 	start.Flag("token",
 		"One-time token to register with an auth server [none]").
 		StringVar(&ccf.AuthToken)
-	start.Flag("name",
-		"Node name to register with an auth server with [none]").
+	start.Flag("nodename",
+		"Name of this node, defaults to hostname").
 		StringVar(&ccf.NodeName)
 	start.Flag("config",
 		fmt.Sprintf("Path to a configuration file [%v]", defaults.ConfigFilePath)).

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -103,7 +103,8 @@ func (s *TshSuite) SetUpSuite(c *C) {
 		encryptor.GetTestKey)
 	c.Assert(err, IsNil)
 
-	s.a = auth.NewAuthServer(s.bk, authority.New(), "localhost")
+	s.a = auth.NewAuthServer(&auth.InitConfig{
+		Backend: s.bk, Authority: authority.New(), DomainName: "localhost"})
 
 	eventsLog, err := boltlog.New(filepath.Join(s.dir, "boltlog"))
 	c.Assert(err, IsNil)


### PR DESCRIPTION
### Original Ticket

See #194 I have scaled down the implementation somewhat.
### Scaled down implementation

To move faster and break fewer things, I have decided to keep the 'name' as-is in the storage back-end, instead of making it a label. Using a label is probably better, I'm simply saving time. Otherwise it's done.
### List of changes:
1. `--name` has been renamed to `nodename`
2. A name is not necessary to join a cluster. Only tokens are used.
3. HostUUID is used for key signing. This means that a node can be successfully re-started 
   with a    different `--nodename` setting.
4. `--nodename` setting is passed through into AuthServer as "AuthServiceName".
   This will be used in UIs when there are multiple clusters, and also
   in places like Google Authenticator
5. `tctl nodes ls` now lists both host name and host UUID

Closes #194
Fixes #194
