### PR TITLE
Fixed browser hang on self-signed https cert

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -579,7 +579,7 @@ func initSelfSignedHTTPSCert(cfg *Config) (keyPath string, certPath string, err 
 	}
 	log.Warningf("[CONFIG] Generating self signed key and cert to %v %v", keyPath, certPath)
 
-	creds, err := utils.GenerateSelfSignedCert([]string{cfg.Hostname}, []string{"127.0.0.1"})
+	creds, err := utils.GenerateSelfSignedCert([]string{cfg.Hostname, "localhost"})
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}


### PR DESCRIPTION
The problem was:
- Self-signed cert was also used as CA cert.
- This means a browser would add it to its list of CA certs.
- Then I'd delete /var/lib/teleport/*
- And a new CA would be created for the same name, confusing the browser

To fix:
- Certificate isn't marked as CA
- Org name is set to "Acme Co" instead of "Teleport"

Fixes #206
