### PR TITLE
Implemented 'teleport status' command

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -173,6 +173,8 @@ func prepareOSCommand(ctx *ctx, args ...string) (*exec.Cmd, error) {
 		"HOME=" + osUser.HomeDir,
 		"USER=" + osUserName,
 		"SHELL=" + c.Path,
+		"SSH_TELEPORT_USER=" + ctx.teleportUser,
+		"SSH_SESSION_WEBPROXY_ADDR=<proxyhost>:3080",
 	}
 	// this configures shell to run in 'login' mode
 	c.Args[0] = "-" + filepath.Base(shellCommand)

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -43,6 +43,7 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 	s.ctx.login = s.usr.Username
 	s.ctx.info = s
 	s.ctx.session = &session{id: "xxx"}
+	s.ctx.teleportUser = "galt"
 
 	s.localAddr, _ = utils.ParseAddr("127.0.0.1:3022")
 	s.remoteAddr, _ = utils.ParseAddr("10.0.0.5:4817")
@@ -65,6 +66,8 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 		fmt.Sprintf("HOME=%s", s.usr.HomeDir),
 		fmt.Sprintf("USER=%s", s.usr.Username),
 		"SHELL=/bin/sh",
+		"SSH_TELEPORT_USER=galt",
+		"SSH_SESSION_WEBPROXY_ADDR=<proxyhost>:3080",
 		"SSH_CLIENT=10.0.0.5 4817 3022",
 		"SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022",
 		"SSH_SESSION_ID=xxx",

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -134,7 +134,15 @@ func onStart(config *service.Config) error {
 
 // onStatus is the handler for "status" CLI command
 func onStatus(config *service.Config) error {
-	fmt.Println("status command is not implemented")
+	sid := os.Getenv("SSH_SESSION_ID")
+	proxyHost := os.Getenv("SSH_SESSION_WEBPROXY_ADDR")
+	tuser := os.Getenv("SSH_TELEPORT_USER")
+	if sid == "" || proxyHost == "" {
+		fmt.Println("You are not inside of a Teleport SSH session")
+		return nil
+	}
+	fmt.Printf("User ID    : %s, logged in as %s from %s\n", tuser, os.Getenv("USER"), os.Getenv("SSH_CLIENT"))
+	fmt.Printf("Session ID : %s\nSession URL: https://%s/web/sessions/%s\n", sid, proxyHost, sid)
 	return nil
 }
 


### PR DESCRIPTION
TODO:

When `auth_access_point.GetProcies()` gets implemented, I will remove
hardcoded <proxyhost> with an actual host+port of the proxy

Fixes #232
Closes #232
