### PR TITLE
Added support for --version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ETCD_NODE1 := http://127.0.0.1:4001
 ETCD_NODES := ${ETCD_NODE1}
 ETCD_FLAGS := TELEPORT_TEST_ETCD_NODES=${ETCD_NODES}
+LDFLAGS    := "$(shell linkflags -pkg=.)"
 OUT=out
 export GO15VENDOREXPERIMENT=1
 
@@ -14,17 +15,17 @@ all: teleport tctl tsh
 
 .PHONY: tctl
 tctl: 
-	go build -o $(OUT)/tctl -i github.com/gravitational/teleport/tool/tctl
+	go build -ldflags=$(LDFLAGS) -o $(OUT)/tctl -i github.com/gravitational/teleport/tool/tctl
 
 .PHONY: teleport
 teleport: 
 	ln -f -s $$(pwd)/web/dist/app /var/lib/teleport/app
 	ln -f -s $$(pwd)/web/dist/index.html /var/lib/teleport/index.html
-	go build -o $(OUT)/teleport -i github.com/gravitational/teleport/tool/teleport
+	go build -ldflags=$(LDFLAGS) -o $(OUT)/teleport -i github.com/gravitational/teleport/tool/teleport
 
 .PHONY: tsh
 tsh: 
-	go build -o $(OUT)/tsh -i github.com/gravitational/teleport/tool/tsh
+	go build -ldflags=$(LDFLAGS) -o $(OUT)/tsh -i github.com/gravitational/teleport/tool/tsh
 
 install: remove-temp-files
 	go install github.com/gravitational/teleport/tool/teleport \

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web"
+	"github.com/gravitational/version"
 
 	"github.com/buger/goterm"
 	"github.com/gravitational/trace"
@@ -150,7 +151,7 @@ func main() {
 }
 
 func onVersion() {
-	fmt.Println("TODO: Version command has not been implemented yet")
+	fmt.Println(version.Get().Version)
 }
 
 func printHeader(t *goterm.Table, cols []string) {

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/version"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
@@ -154,5 +155,5 @@ func onConfigDump() {
 
 // onVersion is the handler for "version"
 func onVersion() {
-	fmt.Println("'version' command is not implemented")
+	fmt.Println(version.Get().Version)
 }

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/version"
 
 	"github.com/buger/goterm"
 	"github.com/pborman/uuid"
@@ -245,7 +246,7 @@ func makeClient(cf *CLIConf) (tc *client.TeleportClient, err error) {
 }
 
 func onVersion() {
-	fmt.Println("Version!")
+	fmt.Println(version.Get().Version)
 }
 
 func printHeader(t *goterm.Table, cols []string) {


### PR DESCRIPTION
Note: I'm **very unhappy** with how gravitational/version works. Here is why:
1. If there's no git tag applied to the current ref, it loses its version and only dumps git ref.
2. It will be _painful_ to always keep track of git tags.
3. It creates a binary dependency on build process (linkflags), making it impossible to "go get teleport"
4. It feels incrediblly over-engineered for such trivial thing. I could have actually saved myslef a ton of time by 
   adding 'git show-ref' into Makefile directly. linkflag program doesn't automate anything, only gets in the way.

A MUCH SIMPLER design would be to have VERSION variable in the Makefile, followed by `$(shell git show-ref)`
