### PR TITLE
Ev/ver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ETCD_NODE1 := http://127.0.0.1:4001
 ETCD_NODES := ${ETCD_NODE1}
 ETCD_FLAGS := TELEPORT_TEST_ETCD_NODES=${ETCD_NODES}
+LDFLAGS    := "$(shell linkflags -pkg=.)"
 OUT=out
 export GO15VENDOREXPERIMENT=1
 
@@ -14,17 +15,17 @@ all: teleport tctl tsh
 
 .PHONY: tctl
 tctl: 
-	go build -o $(OUT)/tctl -i github.com/gravitational/teleport/tool/tctl
+	go build -ldflags=$(LDFLAGS) -o $(OUT)/tctl -i github.com/gravitational/teleport/tool/tctl
 
 .PHONY: teleport
 teleport: 
 	ln -f -s $$(pwd)/web/dist/app /var/lib/teleport/app
 	ln -f -s $$(pwd)/web/dist/index.html /var/lib/teleport/index.html
-	go build -o $(OUT)/teleport -i github.com/gravitational/teleport/tool/teleport
+	go build -ldflags=$(LDFLAGS) -o $(OUT)/teleport -i github.com/gravitational/teleport/tool/teleport
 
 .PHONY: tsh
 tsh: 
-	go build -o $(OUT)/tsh -i github.com/gravitational/teleport/tool/tsh
+	go build -ldflags=$(LDFLAGS) -o $(OUT)/tsh -i github.com/gravitational/teleport/tool/tsh
 
 install: remove-temp-files
 	go install github.com/gravitational/teleport/tool/teleport \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+VERSION    := v0.9.0
 ETCD_NODE1 := http://127.0.0.1:4001
 ETCD_NODES := ${ETCD_NODE1}
 ETCD_FLAGS := TELEPORT_TEST_ETCD_NODES=${ETCD_NODES}
-LDFLAGS    := "$(shell linkflags -pkg=.)"
+LDFLAGS    := "-X github.com/gravitational/version.version=$(VERSION) -X github.com/gravitational/version.gitCommit=$(shell git show-ref HEAD --hash=16)"
 OUT=out
 export GO15VENDOREXPERIMENT=1
 

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -117,6 +117,11 @@ func main() {
 		utils.InitLoggerDebug()
 	}
 
+	if command == ver.FullCommand() {
+		onVersion()
+		return
+	}
+
 	validateConfig(cfg)
 
 	// connect to the teleport auth service:
@@ -127,8 +132,6 @@ func main() {
 
 	// execute the selected command:
 	switch command {
-	case ver.FullCommand():
-		onVersion()
 	case userAdd.FullCommand():
 		err = cmdUsers.Add(cfg.Hostname, client)
 	case userList.FullCommand():
@@ -151,7 +154,7 @@ func main() {
 }
 
 func onVersion() {
-	fmt.Println(version.Get().Version)
+	fmt.Printf("%s, git:%s\n", version.Get().Version, version.Get().GitCommit)
 }
 
 func printHeader(t *goterm.Table, cols []string) {

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web"
+	"github.com/gravitational/version"
 
 	"github.com/buger/goterm"
 	"github.com/gravitational/trace"
@@ -150,7 +151,7 @@ func main() {
 }
 
 func onVersion() {
-	fmt.Println("TODO: Version command has not been implemented yet")
+	fmt.Println(version.Get().Version)
 }
 
 func printHeader(t *goterm.Table, cols []string) {

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -155,5 +155,5 @@ func onConfigDump() {
 
 // onVersion is the handler for "version"
 func onVersion() {
-	fmt.Println(version.Get().Version)
+	fmt.Printf("%s, git:%s\n", version.Get().Version, version.Get().GitCommit)
 }

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/version"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
@@ -154,5 +155,5 @@ func onConfigDump() {
 
 // onVersion is the handler for "version"
 func onVersion() {
-	fmt.Println("'version' command is not implemented")
+	fmt.Println(version.Get().Version)
 }

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -246,7 +246,7 @@ func makeClient(cf *CLIConf) (tc *client.TeleportClient, err error) {
 }
 
 func onVersion() {
-	fmt.Println(version.Get().Version)
+	fmt.Printf("%s, git:%s\n", version.Get().Version, version.Get().GitCommit)
 }
 
 func printHeader(t *goterm.Table, cols []string) {

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/version"
 
 	"github.com/buger/goterm"
 	"github.com/pborman/uuid"
@@ -245,7 +246,7 @@ func makeClient(cf *CLIConf) (tc *client.TeleportClient, err error) {
 }
 
 func onVersion() {
-	fmt.Println("Version!")
+	fmt.Println(version.Get().Version)
 }
 
 func printHeader(t *goterm.Table, cols []string) {


### PR DESCRIPTION
Better implementation of version
I got rid of linkflags binary and passing values into `version` library directly.

Now:
- The version is set in Makefile, not as a git tag
- Build process does not depend on `linkflags`
- The CLI output is good looking and does not depend on git labels:

``` bash
~/: out/tsh version
v0.9.0, git:2a24c329d72b0236
~/: out/teleport version
v0.9.0, git:2a24c329d72b0236
~/: out/tctl version
v0.9.0, git:2a24c329d72b0236
```

Also I updated tctl to be able to show version without having to connect to teleport daemon first.
