### PR TITLE
introduce teleport version, fixes #241

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _testmain.go
 flymake*
 
 QR.png
+/vendor/github.com/gravitational/version/LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ _testmain.go
 flymake*
 
 QR.png
-/vendor/github.com/gravitational/version/LICENSE

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -98,6 +98,10 @@
 			"Rev": "0fd0db9ea941edb81e90278f4eb8f29f5615637e"
 		},
 		{
+			"ImportPath": "github.com/gravitational/version",
+			"Rev": "cfc6250a884a833eed6ac0417a6f245f5ac49d7a"
+		},
+		{
 			"ImportPath": "github.com/jonboulle/clockwork",
 			"Rev": "ed104f61ea4877bea08af6f759805674861e968d"
 		},

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ teleport:
 tsh: 
 	go build -o $(OUT)/tsh -i github.com/gravitational/teleport/tool/tsh
 
-install: remove-temp-files
-	go install github.com/gravitational/teleport/tool/teleport \
+install: remove-temp-files flags
+	go install -ldflags $(TELEPORT_LINKFLAGS) github.com/gravitational/teleport/tool/teleport \
 	           github.com/gravitational/teleport/tool/tctl \
 	           github.com/gravitational/teleport/tool/tsh \
 
@@ -49,6 +49,10 @@ test:
 			   github.com/gravitational/teleport/lib/... \
 			   github.com/gravitational/teleport/tool/teleport... $(FLAGS)
 	go vet ./tool/... ./lib/...
+
+flags:
+	go install github.com/gravitational/teleport/vendor/github.com/gravitational/version/cmd/linkflags
+	$(eval TELEPORT_LINKFLAGS := "$(shell linkflags -pkg=$(PWD) -verpkg=github.com/gravitational/teleport/vendor/github.com/gravitational/version)")
 
 
 test-with-etcd: install

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -29,6 +30,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
+	"github.com/gravitational/version"
 	"github.com/pborman/uuid"
 	"golang.org/x/crypto/ssh"
 )
@@ -141,6 +143,16 @@ func ReadOrMakeHostUUID(dataDir string) (string, error) {
 		return "", trace.Wrap(err)
 	}
 	return string(bytes), nil
+}
+
+// PrintVersion prints human readable version
+func PrintVersion() {
+	ver := version.Get()
+	if ver.GitCommit != "" {
+		fmt.Printf("%v git:%v\n", ver.Version, ver.GitCommit)
+	} else {
+		fmt.Printf("%v\n", ver.Version)
+	}
 }
 
 const (

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -162,7 +162,7 @@ func main() {
 }
 
 func onVersion() {
-	fmt.Println("TODO: Version command has not been implemented yet")
+	utils.PrintVersion()
 }
 
 func printHeader(t *goterm.Table, cols []string) {

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -154,5 +154,5 @@ func onConfigDump() {
 
 // onVersion is the handler for "version"
 func onVersion() {
-	fmt.Println("'version' command is not implemented")
+	utils.PrintVersion()
 }

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -284,7 +284,7 @@ func makeClient(cf *CLIConf) (tc *client.TeleportClient, err error) {
 }
 
 func onVersion() {
-	fmt.Println("Version!")
+	utils.PrintVersion()
 }
 
 func printHeader(t *goterm.Table, cols []string) {

--- a/vendor/github.com/gravitational/version/LICENSE
+++ b/vendor/github.com/gravitational/version/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/gravitational/version/README.md
+++ b/vendor/github.com/gravitational/version/README.md
@@ -1,0 +1,72 @@
+# version
+
+`version` is a Go library for automatic build versioning. It attempts to simplify the mundane task of adding build version information to any Go package.
+
+### Usage
+
+Install the command line utility to generate the linker flags necessary for versioning from the cmd/linkflags:
+
+```shell
+go install github.com/gravitational/version/cmd/linkflags
+```
+
+Add the following configuration to your build script / Makefile
+(assuming a bash script):
+
+```bash
+GO_LDFLAGS=$(linkflags -pkg=path/to/your/package)
+
+# build with the linker flags:
+go build -ldflags="${GO_LDFLAGS}"
+```
+
+To use, simply import the package and either obtain the version with `Get` or print the JSON-formatted version with `Print`:
+
+```go
+package main
+
+import "github.com/gravitational/version"
+
+func main() {
+	version.Print()
+}
+```
+
+If you have a custom vendoring solution, you might have this package stored under a different path than the default (`go get`).
+In this case, you can override the default with a command line option (using [godep] as a vendoring solution):
+
+```shell
+MY_PACKAGE=github.com/my/package
+MY_PACKAGE_PATH=$(pwd)
+GO_LDFLAGS=$(linkflags -pkg=${MY_PACKAGE_PATH} -verpkg=${MY_PACKAGE}/Godeps/_workspace/src/github.com/gravitational/version)
+```
+
+The version part of the version information requires that you properly [tag] your packages:
+
+```shell
+$ git tag
+v1.0.0-alpha.1
+v1.0.0-beta.1
+```
+
+The build versioning scheme is a slight modification of the scheme from the [Kubernetes] project.
+It consists of three parts:
+  - a version string in [semver] format
+  - git commit ID
+  - git tree state (`clean` or `dirty`)
+
+```go
+type Info struct {
+	Version      string `json:"version"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+}
+```
+
+
+[//]: # (Footnots and references)
+
+[Kubernetes]: <https://github.com/kubernetes/kubernetes>
+[semver]: <http://semver.org>
+[godep]: <https://github.com/tools/godep>
+[tag]: <https://git-scm.com/book/en/v2/Git-Basics-Tagging>

--- a/vendor/github.com/gravitational/version/base.go
+++ b/vendor/github.com/gravitational/version/base.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package version
+
+// Version value defaults
+var (
+	// Version string, a slightly modified version of `git describe` to be semver-complaint
+	version      string = "v0.0.0-master+$Format:%h$"
+	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
+)
+
+// Init sets an alternative default for the version string.
+func Init(baseVersion string) {
+	version = baseVersion
+}

--- a/vendor/github.com/gravitational/version/cmd/linkflags/main.go
+++ b/vendor/github.com/gravitational/version/cmd/linkflags/main.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/gravitational/version"
+	"github.com/gravitational/version/pkg/tool"
+)
+
+// pkg is the path to the package the tool will create linker flags for.
+var pkg = flag.String("pkg", "", "root package path")
+
+// versionPackage is the path to this version package.
+// It is used to access version information attributes during link time.
+// This flag is useful when the version package is custom-vendored and has a different package path.
+var versionPackage = flag.String("verpkg", "github.com/gravitational/version", "path to the version package")
+
+var compatMode = flag.Bool("compat", false, "generate linker flags using go1.4 syntax")
+
+// semverPattern defines a regexp pattern to modify the results of `git describe` to be semver-complaint.
+var semverPattern = regexp.MustCompile(`(.+)-([0-9]{1,})-g([0-9a-f]{14})$`)
+
+// goVersionPattern defines a regexp pattern to parse versions of the `go tool`.
+var goVersionPattern = regexp.MustCompile(`go([1-9])\.(\d+)(?:.\d+)*`)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func run() error {
+	log.SetFlags(0)
+	flag.Parse()
+	if *pkg == "" {
+		return fmt.Errorf("-pkg required")
+	}
+
+	goVersion, err := goToolVersion()
+	if err != nil {
+		return fmt.Errorf("failed to determine go tool version: %v\n", err)
+	}
+
+	info, err := getVersionInfo(*pkg)
+	if err != nil {
+		return fmt.Errorf("failed to determine version information: %v\n", err)
+	}
+
+	var linkFlags []string
+	linkFlag := func(key, value string) string {
+		if goVersion <= 14 || *compatMode {
+			return fmt.Sprintf("-X %s.%s %s", *versionPackage, key, value)
+		} else {
+			return fmt.Sprintf("-X %s.%s=%s", *versionPackage, key, value)
+		}
+	}
+
+	// Determine the values of version-related variables as commands to the go linker.
+	if info.GitCommit != "" {
+		linkFlags = append(linkFlags, linkFlag("gitCommit", info.GitCommit))
+		linkFlags = append(linkFlags, linkFlag("gitTreeState", info.GitTreeState))
+	}
+	if info.Version != "" {
+		linkFlags = append(linkFlags, linkFlag("version", info.Version))
+	}
+
+	fmt.Printf("%s", strings.Join(linkFlags, " "))
+	return nil
+}
+
+// getVersionInfo collects the build version information for package pkg.
+func getVersionInfo(pkg string) (*version.Info, error) {
+	git := newGit(pkg)
+	commitID, err := git.commitID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain git commit ID: %v\n", err)
+	}
+	treeState, err := git.treeState()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine git tree state: %v\n", err)
+	}
+	tag, err := git.tag(commitID)
+	if err != nil {
+		tag = ""
+	}
+	if tag != "" {
+		tag = semverify(tag)
+		if treeState == dirty {
+			tag = tag + "-" + string(treeState)
+		}
+	}
+	return &version.Info{
+		Version:      tag,
+		GitCommit:    commitID,
+		GitTreeState: string(treeState),
+	}, nil
+}
+
+// goToolVersion determines the version of the `go tool`.
+func goToolVersion() (toolVersion, error) {
+	goTool := &tool.T{Cmd: "go"}
+	out, err := goTool.Exec("version")
+	if err != nil {
+		return toolVersionUnknown, err
+	}
+	build := strings.Split(out, " ")
+	if len(build) > 2 {
+		return parseToolVersion(build[2]), nil
+	}
+	return toolVersionUnknown, nil
+}
+
+// parseToolVersion translates a string version of the form 'go1.4.3' to a numeric value 14.
+func parseToolVersion(version string) toolVersion {
+	match := goVersionPattern.FindStringSubmatch(version)
+	if len(match) > 2 {
+		// After a successful match, match[1] and match[2] are integers
+		major := mustAtoi(match[1])
+		minor := mustAtoi(match[2])
+		return toolVersion(major*10 + minor)
+	}
+	return toolVersionUnknown
+}
+
+func newGit(pkg string) *git {
+	args := []string{"--work-tree", pkg, "--git-dir", filepath.Join(pkg, ".git")}
+	return &git{&tool.T{
+		Cmd:  "git",
+		Args: args,
+	}}
+}
+
+// git represents an instance of the git tool.
+type git struct {
+	*tool.T
+}
+
+// treeState describes the state of the git tree.
+// `git describe --dirty` only considers changes to existing files.
+// We track tree state and consider untracked files as they also affect the build.
+type treeState string
+
+const (
+	clean treeState = "clean"
+	dirty           = "dirty"
+)
+
+// toolVersion represents a tool version as an integer.
+// toolVersion only considers the first two significant version parts and is computed as follows:
+// 	majorVersion*10+minorVersion
+type toolVersion int
+
+const toolVersionUnknown toolVersion = 0
+
+func (r *git) commitID() (string, error) {
+	return r.Exec("rev-parse", "HEAD^{commit}")
+}
+
+func (r *git) treeState() (treeState, error) {
+	out, err := r.Exec("status", "--porcelain")
+	if err != nil {
+		return "", err
+	}
+	if len(out) == 0 {
+		return clean, nil
+	}
+	return dirty, nil
+}
+
+func (r *git) tag(commitID string) (string, error) {
+	return r.Exec("describe", "--tags", "--abbrev=14", commitID+"^{commit}")
+}
+
+// semverify transforms the output of `git describe` to be semver-complaint.
+func semverify(version string) string {
+	var result []byte
+	match := semverPattern.FindStringSubmatchIndex(version)
+	if match != nil {
+		return string(semverPattern.ExpandString(result, "$1.$2+$3", string(version), match))
+	}
+	return version
+}
+
+// mustAtoi converts value to an integer.
+// It panics if the value does not represent a valid integer.
+func mustAtoi(value string) int {
+	result, err := strconv.Atoi(value)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}

--- a/vendor/github.com/gravitational/version/doc.go
+++ b/vendor/github.com/gravitational/version/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// Package version supplies version information collected at build time.
+package version

--- a/vendor/github.com/gravitational/version/pkg/tool/tool.go
+++ b/vendor/github.com/gravitational/version/pkg/tool/tool.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// Package tool provides a currying wrapper around os/exec.Command that fixes a set of arguments.
+package tool
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+)
+
+// T represents an instance of a running tool specified with cmd and
+// an optional list of fixed initial arguments args.
+type T struct {
+	Cmd  string
+	Args []string
+}
+
+// Error is a tool execution error.
+type Error struct {
+	Tool   string
+	Output []byte
+	Err    error
+}
+
+func (r *Error) Error() string {
+	return fmt.Sprintf("error executing `%s`: %v (%s)", r.Tool, r.Err, r.Output)
+}
+
+// exec executes a given command specified with args prepending a set of fixed arguments.
+// Otherwise behaves exactly as rawExec
+func (r *T) Exec(args ...string) (string, error) {
+	args = append(r.Args[:], args...)
+	return r.RawExec(args...)
+}
+
+// RawExec executes a given command specified with args and returns the output
+// with whitespace trimmed.
+func (r *T) RawExec(args ...string) (string, error) {
+	out, err := exec.Command(r.Cmd, args...).CombinedOutput()
+	if err == nil {
+		out = bytes.TrimSpace(out)
+	}
+	if err != nil {
+		err = &Error{
+			Tool:   r.Cmd,
+			Output: out,
+			Err:    err,
+		}
+	}
+	return string(out), err
+}

--- a/vendor/github.com/gravitational/version/test/main.go
+++ b/vendor/github.com/gravitational/version/test/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/gravitational/version"
+
+func init() {
+	// Reset base version to a custom one in case no tag has been created.
+	// It will be reset with a git tag if there's one.
+	version.Init("v0.0.1")
+}
+
+func main() {
+	version.Print()
+}

--- a/vendor/github.com/gravitational/version/version.go
+++ b/vendor/github.com/gravitational/version/version.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Info describes build version with a semver-complaint version string and
+// git-related commit/tree state details.
+type Info struct {
+	Version      string `json:"version"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+}
+
+// Get returns current build version.
+func Get() Info {
+	return Info{
+		Version:      version,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+	}
+}
+
+func (r Info) String() string {
+	return r.Version
+}
+
+// Print prints build version in default format.
+func Print() {
+	payload, err := json.Marshal(Get())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%s", payload)
+}


### PR DESCRIPTION
Here's how it works:
- It takes the closest tag that is present in the build
- Automatically applies this tag
- Adds git commit as well
- Is 100% go gettable
- No external deps, all vendored
