### PR TITLE
add support for TELEPORT_DEBUG_TESTS environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 ETCD_NODE1 := http://127.0.0.1:4001
 ETCD_NODES := ${ETCD_NODE1}
 ETCD_FLAGS := TELEPORT_TEST_ETCD_NODES=${ETCD_NODES}
+TELEPORT_DEBUG_TESTS ?= no
 OUT := out
-export GO15VENDOREXPERIMENT=1
+GO15VENDOREXPERIMENT := 1
+export
 
 .PHONY: install test test-with-etcd remove-temp files test-package update test-grep-package cover-package cover-package-with-etcd run profile sloccount set-etcd install-assets docs-serve
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -13,7 +13,7 @@ build: bbox
 		   -v "$$(pwd)/../":/gopath/src/github.com/gravitational/teleport \
 		   -u $$(id -u):$$(id -g) \
 		   $(BBOX) \
-		   /bin/bash -c "make -C /gopath/src/github.com/gravitational/teleport FLAGS='-cover -race' clean test all"
+		   /bin/bash -c "make -C /gopath/src/github.com/gravitational/teleport TELEPORT_DEBUG_TESTS=true FLAGS='-cover -race' clean test all"
 
 #
 # builds buildbox:1.0.0 Docker container which is Debian8 with Golang 1.4.2

--- a/constants.go
+++ b/constants.go
@@ -14,3 +14,8 @@ const (
 	// ETCDBackendType is etcd backend
 	ETCDBackendType = "etcd"
 )
+
+const (
+	// DebugOutputEnvVar tells tests to use verbose debug output
+	DebugOutputEnvVar = "TELEPORT_DEBUG_TESTS"
+)

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -61,7 +61,7 @@ type APISuite struct {
 var _ = Suite(&APISuite{})
 
 func (s *APISuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 	authority.PrecalculatedKeysNum = 1
 }
 

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -40,7 +40,7 @@ type AuthSuite struct {
 var _ = Suite(&AuthSuite{})
 
 func (s *AuthSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *AuthSuite) SetUpTest(c *C) {

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -33,7 +33,7 @@ type NativeSuite struct {
 var _ = Suite(&NativeSuite{})
 
 func (s *NativeSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 	PrecalculatedKeysNum = 1
 	s.suite = &test.AuthSuite{A: New()}
 }

--- a/lib/auth/permission_test.go
+++ b/lib/auth/permission_test.go
@@ -29,7 +29,7 @@ type PermCheckerSuite struct {
 var _ = Suite(&PermCheckerSuite{})
 
 func (s *PermCheckerSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *PermCheckerSuite) TestSessions(c *C) {

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -51,7 +51,7 @@ type TunSuite struct {
 var _ = Suite(&TunSuite{})
 
 func (s *TunSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *TunSuite) TearDownTest(c *C) {

--- a/lib/backend/boltbk/boltbk_test.go
+++ b/lib/backend/boltbk/boltbk_test.go
@@ -36,7 +36,7 @@ type BoltSuite struct {
 var _ = Suite(&BoltSuite{})
 
 func (s *BoltSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *BoltSuite) SetUpTest(c *C) {

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -48,7 +48,7 @@ var _ = Suite(&EtcdSuite{
 })
 
 func (s *EtcdSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 	nodesVal := os.Getenv("TELEPORT_TEST_ETCD_NODES")
 	if nodesVal == "" {
 		// Skips the entire suite

--- a/lib/events/boltlog/bl_test.go
+++ b/lib/events/boltlog/bl_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package boltlog
 
 import (
@@ -36,7 +37,7 @@ type BoltLogSuite struct {
 var _ = Suite(&BoltLogSuite{})
 
 func (s *BoltLogSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *BoltLogSuite) SetUpTest(c *C) {

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -33,7 +33,7 @@ type LimiterSuite struct {
 var _ = Suite(&LimiterSuite{})
 
 func (s *LimiterSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *LimiterSuite) SetUpTest(c *C) {

--- a/lib/recorder/boltrec/brec_test.go
+++ b/lib/recorder/boltrec/brec_test.go
@@ -35,7 +35,7 @@ type BoltRecSuite struct {
 var _ = Suite(&BoltRecSuite{})
 
 func (s *BoltRecSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *BoltRecSuite) SetUpTest(c *C) {

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -32,7 +32,7 @@ type ConfigSuite struct {
 var _ = Suite(&ConfigSuite{})
 
 func (s *ConfigSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *ConfigSuite) TestDefaultConfig(c *C) {

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -36,7 +36,7 @@ type BoltSuite struct {
 var _ = Suite(&BoltSuite{})
 
 func (s *BoltSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *BoltSuite) SetUpTest(c *C) {

--- a/lib/session/session_test.go
+++ b/lib/session/session_test.go
@@ -40,7 +40,7 @@ type BoltSuite struct {
 var _ = Suite(&BoltSuite{})
 
 func (s *BoltSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *BoltSuite) SetUpTest(c *C) {

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -37,7 +37,7 @@ type ExecSuite struct {
 var _ = check.Suite(&ExecSuite{})
 
 func (s *ExecSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 	s.usr, _ = user.Current()
 	s.ctx = &ctx{isTestStub: true}
 	s.ctx.login = s.usr.Username

--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -71,7 +71,7 @@ type SrvSuite struct {
 var _ = Suite(&SrvSuite{})
 
 func (s *SrvSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *SrvSuite) SetUpTest(c *C) {

--- a/lib/sshutils/scp/scp_test.go
+++ b/lib/sshutils/scp/scp_test.go
@@ -38,7 +38,7 @@ type SCPSuite struct {
 var _ = Suite(&SCPSuite{})
 
 func (s *SCPSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *SCPSuite) TestSendFile(c *C) {

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -37,7 +37,7 @@ type ServerSuite struct {
 var _ = Suite(&ServerSuite{})
 
 func (s *ServerSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 
 	pk, err := ssh.ParsePrivateKey(suite.PEMBytes["ecdsa"])
 	c.Assert(err, IsNil)

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package utils
 
 import (
@@ -21,12 +22,14 @@ import (
 	"io/ioutil"
 	"log/syslog"
 	"os"
+	"strconv"
 
-	"github.com/gravitational/kingpin"
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport"
 
 	log "github.com/Sirupsen/logrus"
 	logrusSyslog "github.com/Sirupsen/logrus/hooks/syslog"
+	"github.com/gravitational/kingpin"
+	"github.com/gravitational/trace"
 )
 
 // InitLoggerCLI tools by default log into syslog, not stderr
@@ -54,6 +57,19 @@ func InitLoggerDebug() {
 	log.SetFormatter(&trace.TextFormatter{})
 	log.SetOutput(os.Stderr)
 	log.SetLevel(log.DebugLevel)
+}
+
+// InitLoggerForTests inits logger to discard ouput in tests unless
+// TELEPORT_DEBUG is set to "true"
+func InitLoggerForTests() {
+	val, _ := strconv.ParseBool(os.Getenv(teleport.DebugOutputEnvVar))
+	if val {
+		InitLoggerDebug()
+		return
+	}
+	log.SetLevel(log.ErrorLevel)
+	log.StandardLogger().Hooks = make(log.LevelHooks)
+	log.SetOutput(ioutil.Discard)
 }
 
 // FatalError is for CLI front-ends: it detects gravitational.Trace debugging

--- a/lib/web/web_test.go
+++ b/lib/web/web_test.go
@@ -78,7 +78,7 @@ type WebSuite struct {
 var _ = Suite(&WebSuite{})
 
 func (s *WebSuite) SetUpSuite(c *C) {
-	utils.InitLoggerCLI()
+	utils.InitLoggerForTests()
 }
 
 func (s *WebSuite) SetUpTest(c *C) {


### PR DESCRIPTION
By default tests are not verbose, but if variable is set, they are using debugging setting. In addition to that, Jenkins uses verbose output as well
