### PR TITLE
Streamlined login in TSH

### DIFF
--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package client contains SSH and HTTPS clients to connect
-// to the Teleport proxy
 package client
 
 import (
@@ -379,6 +377,7 @@ func (client *NodeClient) Upload(localSourcePath, remoteDestinationPath string) 
 		Target:      localSourcePath,
 	}
 
+	// "impersonate" scp to a server
 	shellCmd := "/usr/bin/scp -t"
 	if fileInfo.IsDir() {
 		shellCmd += " -r"
@@ -397,6 +396,7 @@ func (client *NodeClient) Download(remoteSourcePath, localDestinationPath string
 		Target:      localDestinationPath,
 	}
 
+	// "impersonate" scp to a server
 	shellCmd := "/usr/bin/scp -f"
 	if isDir {
 		shellCmd += " -r"

--- a/lib/client/hotp_mock.go
+++ b/lib/client/hotp_mock.go
@@ -13,13 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-// package auth implements certificate signing authority and access control server
-// Authority server is composed of several parts:
-//
-// * Authority server itself that implements signing and acl logic
-// * HTTP server wrapper for authority server
-// * HTTP client wrapper
-//
 
 package client
 

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -57,7 +57,7 @@ func AddHostSignersToCache(hostSigners []services.CertAuthority) error {
 	return nil
 }
 
-func CheckHostSignerFromCache(hostId string, remote net.Addr, key ssh.PublicKey) error {
+func CheckHostSignature(hostId string, remote net.Addr, key ssh.PublicKey) error {
 	cert, ok := key.(*ssh.Certificate)
 	if !ok {
 		return trace.Errorf("expected certificate")
@@ -238,5 +238,5 @@ func getKeysDir() string {
 var (
 	KeyFilePrefix       = "teleport_"
 	KeyFileSuffix       = ".tkey"
-	HostSignersFilename = "HostSigners.db"
+	HostSignersFilename = "hostsigners.db"
 )

--- a/lib/client/utils.go
+++ b/lib/client/utils.go
@@ -26,7 +26,6 @@ package client
 import (
 	"fmt"
 	"math/rand"
-	"net"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -64,21 +63,7 @@ func NewWebAuth(ag agent.Agent,
 
 		return ag.Signers()
 	}
-
-	hostKeyCallback = func(hostID string, remote net.Addr, key ssh.PublicKey) error {
-		err := CheckHostSignerFromCache(hostID, remote, key)
-		if err != nil {
-			err = Login(ag, webProxyAddress, user, certificateTTL, passwordCallback, insecure)
-			if err != nil {
-				fmt.Printf("Can't login to %v\n", err)
-				return trace.Wrap(err)
-			}
-			return CheckHostSignerFromCache(hostID, remote, key)
-		}
-		return nil
-	}
-
-	return ssh.PublicKeysCallback(callbackFunc), hostKeyCallback
+	return ssh.PublicKeysCallback(callbackFunc), CheckHostSignature
 }
 
 type PasswordCallback func() (password, hotpToken string, e error)


### PR DESCRIPTION
This diff is really hard to read... Here's what I do here:

Instead of asking to login inside of the callback, there is one clear
place where password is asked, it's inside of `TeleportClient.ConnectToProxy()`
