### PR TITLE
scp 'destination' parameter did not allow for username spec

### DIFF
--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -65,3 +65,15 @@ func (s *APITestSuite) TestParseLabels(c *check.C) {
 	c.Assert(m, check.IsNil)
 	c.Assert(err, check.NotNil)
 }
+
+func (s *APITestSuite) TestSCPParsing(c *check.C) {
+	user, host, dest := parseSCPDestination("root@remote.host:/etc/nginx.conf")
+	c.Assert(user, check.Equals, "root")
+	c.Assert(host, check.Equals, "remote.host")
+	c.Assert(dest, check.Equals, "/etc/nginx.conf")
+
+	user, host, dest = parseSCPDestination("remote.host:/etc/nginx.conf")
+	c.Assert(user, check.Equals, "")
+	c.Assert(host, check.Equals, "remote.host")
+	c.Assert(dest, check.Equals, "/etc/nginx.conf")
+}


### PR DESCRIPTION
Fixes #318
