### PR TITLE
teleport and tctl use real proxy an auth addresses/hostnames

### DIFF
--- a/lib/auth/ap.go
+++ b/lib/auth/ap.go
@@ -42,6 +42,9 @@ type AccessPoint interface {
 	// for the specified duration with second resolution if it's >= 1 second
 	UpsertProxy(s services.Server, ttl time.Duration) error
 
+	// GetProxies returns a list of proxy servers registered in the cluster
+	GetProxies() ([]services.Server, error)
+
 	// GetCertAuthorities returns a list of cert authorities
 	GetCertAuthorities(caType services.CertAuthType, loadKeys bool) ([]*services.CertAuthority, error)
 


### PR DESCRIPTION
(where possible).
this is better than placeholders

Fixes #329
