### PR TITLE
Added the ability to stop teleport without restarting the process

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -130,6 +130,13 @@ type AuthServer struct {
 	*services.BkKeysService
 }
 
+func (a *AuthServer) Close() error {
+	if a.bk != nil {
+		return trace.Wrap(a.bk.Close())
+	}
+	return nil
+}
+
 // GetLocalDomain returns domain name that identifies this authority server
 func (a *AuthServer) GetLocalDomain() (string, error) {
 	return a.DomainName, nil

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -161,6 +161,10 @@ func (c *Client) GetLocalDomain() (string, error) {
 	return domain, nil
 }
 
+func (c *Client) Close() error {
+	return nil
+}
+
 // UpsertCertAuthority updates or inserts new cert authority
 func (c *Client) UpsertCertAuthority(ca services.CertAuthority, ttl time.Duration) error {
 	if err := ca.Check(); err != nil {

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -20,6 +20,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
+	"runtime/debug"
 	"sync/atomic"
 	"time"
 
@@ -55,6 +57,9 @@ func New() *nauth {
 }
 
 func (n *nauth) GetNewKeyPairFromPool() ([]byte, []byte, error) {
+	fmt.Println("[KEYS] getting a key...")
+	debug.PrintStack()
+
 	select {
 	case key := <-n.generatedKeysC:
 		return key.privPem, key.pubBytes, nil
@@ -64,7 +69,6 @@ func (n *nauth) GetNewKeyPairFromPool() ([]byte, []byte, error) {
 }
 
 func (n *nauth) precalculateKeys() {
-
 	for {
 		privPem, pubBytes, err := n.GenerateKeyPair("")
 		if err != nil {

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -55,4 +55,6 @@ type Backend interface {
 	ReleaseLock(token string) error
 	// CompareAndSwap implements compare ans swap operation for a key
 	CompareAndSwap(bucket []string, key string, val []byte, ttl time.Duration, prevVal []byte) ([]byte, error)
+	// Close releases the resources taken up by this backend
+	Close() error
 }

--- a/lib/events/boltlog/bl.go
+++ b/lib/events/boltlog/bl.go
@@ -34,7 +34,8 @@ import (
 )
 
 type BoltLog struct {
-	db *bolt.DB
+	db   *bolt.DB
+	path string
 }
 
 func New(path string) (*BoltLog, error) {
@@ -43,7 +44,8 @@ func New(path string) (*BoltLog, error) {
 		return nil, err
 	}
 	return &BoltLog{
-		db: db,
+		db:   db,
+		path: path,
 	}, nil
 }
 

--- a/lib/events/log.go
+++ b/lib/events/log.go
@@ -79,6 +79,7 @@ type Log interface {
 	LogSession(session.Session) error
 	GetEvents(filter Filter) ([]lunk.Entry, error)
 	GetSessionEvents(filter Filter) ([]session.Session, error)
+	Close() error
 }
 
 // FilterToURL encodes filter to URL query parameters
@@ -139,6 +140,10 @@ func FilterFromURL(vals url.Values) (*Filter, error) {
 var NullEventLogger = &NOPEventLogger{}
 
 type NOPEventLogger struct {
+}
+
+func (*NOPEventLogger) Close() error {
+	return nil
 }
 
 func (*NOPEventLogger) Log(lunk.EventID, lunk.Event) {

--- a/lib/recorder/boltrec/brec.go
+++ b/lib/recorder/boltrec/brec.go
@@ -72,6 +72,19 @@ type boltRecorder struct {
 	dbs  map[string]*boltRW
 }
 
+func (r *boltRecorder) Close() error {
+	r.Lock()
+	defer r.Unlock()
+
+	for _, db := range r.dbs {
+		if err := db.Close(); err != nil {
+			log.Error(err)
+		}
+	}
+	r.dbs = nil
+	return nil
+}
+
 func (r *boltRecorder) decRef(b *boltRW) error {
 	r.Lock()
 	defer r.Unlock()

--- a/lib/recorder/recorder.go
+++ b/lib/recorder/recorder.go
@@ -33,6 +33,8 @@ type Recorder interface {
 	GetChunkWriter(id string) (ChunkWriteCloser, error)
 	// GetChunkReader returns a reader of recorded chunks
 	GetChunkReader(id string) (ChunkReadCloser, error)
+	// Close releases the resources taken by the recorder
+	Close() error
 }
 
 // Chunk is a piece of recorded session on some node

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -71,6 +71,8 @@ type Server interface {
 	FindSimilarSite(name string) (RemoteSite, error)
 	// Start starts server
 	Start() error
+	// CLose closes server's socket
+	Close() error
 	// Wait waits for server to close all outstanding operations
 	Wait()
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -68,6 +69,9 @@ const (
 	SSHIdentityEvent = "SSHIdentity"
 	// AuthIdentityEvent is generated when auth's identity has been initialized
 	AuthIdentityEvent = "AuthIdentity"
+	// TeleportExitEvent is generated when someone is askign Teleport Process to close
+	// all listening sockets and exit
+	TeleportExitEvent = "TeleportExit"
 )
 
 // RoleConfig is a configuration for a server role (either proxy or node)
@@ -164,7 +168,7 @@ func (process *TeleportProcess) connectToAuthService(role teleport.Role) (*Conne
 
 // NewTeleport takes the daemon configuration, instantiates all required services
 // and starts them under a supervisor, returning the supervisor object
-func NewTeleport(cfg *Config) (Supervisor, error) {
+func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 	if err := validateConfig(cfg); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -260,6 +264,10 @@ func (process *TeleportProcess) getLocalAuth() *auth.AuthServer {
 
 // initAuthService can be called to initialize auth server service
 func (process *TeleportProcess) initAuthService() error {
+	var (
+		askedToExit bool = false
+		err         error
+	)
 	cfg := process.Config
 	// Initialize the storage back-ends for keys, events and records
 	b, err := process.initAuthStorage()
@@ -310,6 +318,9 @@ func (process *TeleportProcess) initAuthService() error {
 
 	process.RegisterFunc(func() error {
 		apiServer.Serve()
+		if askedToExit {
+			log.Infof("[AUTH] API server exited")
+		}
 		return nil
 	})
 
@@ -320,9 +331,10 @@ func (process *TeleportProcess) initAuthService() error {
 
 	// Register an SSH endpoint which is used to create an SSH tunnel to send HTTP
 	// requests to the Auth API
+	var authTunnel *auth.AuthTunnel
 	process.RegisterFunc(func() error {
 		utils.Consolef(cfg.Console, "[AUTH]  Auth service is starting on %v", cfg.Auth.SSHAddr.Addr)
-		tsrv, err := auth.NewTunnel(
+		authTunnel, err = auth.NewTunnel(
 			cfg.Auth.SSHAddr, []ssh.Signer{identity.KeySigner},
 			apiServer,
 			authServer,
@@ -332,7 +344,11 @@ func (process *TeleportProcess) initAuthService() error {
 			utils.Consolef(cfg.Console, "[PROXY] Error: %v", err)
 			return trace.Wrap(err)
 		}
-		if err := tsrv.Start(); err != nil {
+		if err := authTunnel.Start(); err != nil {
+			if askedToExit {
+				log.Infof("[PROXY] Auth Tunnel exited")
+				return nil
+			}
 			utils.Consolef(cfg.Console, "[PROXY] Error: %v", err)
 			return trace.Wrap(err)
 		}
@@ -341,8 +357,9 @@ func (process *TeleportProcess) initAuthService() error {
 
 	// Heart beat auth server presence, this is not the best place for this
 	// logic, consolidate it into auth package later
+	var authClient *auth.TunClient
 	process.RegisterFunc(func() error {
-		authClient, err := auth.NewTunClient(
+		authClient, err = auth.NewTunClient(
 			[]utils.NetAddr{cfg.Auth.SSHAddr},
 			identity.Cert.ValidPrincipals[0],
 			[]ssh.AuthMethod{ssh.PublicKeys(identity.KeySigner)})
@@ -366,17 +383,40 @@ func (process *TeleportProcess) initAuthService() error {
 			}
 			srv.Addr = fmt.Sprintf("%v:%v", process.Config.AdvertiseIP.String(), port)
 		}
-		for {
+		for !askedToExit {
 			err := authClient.UpsertAuthServer(srv, defaults.ServerHeartbeatTTL)
 			if err != nil {
 				log.Warningf("failed to announce presence: %v", err)
 			}
 			sleepTime := defaults.ServerHeartbeatTTL/2 + utils.RandomDuration(defaults.ServerHeartbeatTTL/10)
-			//log.Infof("[AUTH] will ping auth service in %v", sleepTime)
 			time.Sleep(sleepTime)
 		}
+		log.Infof("[AUTH] heartbeat to other auth servers exited")
+		return nil
+	})
+	// execute this when process is asked to exit:
+	process.onExit(func(payload interface{}) {
+		askedToExit = true
+		authTunnel.Close()
+		authClient.Close()
+		apiServer.Close()
+		log.Infof("[AUTH] auth service exited")
 	})
 	return nil
+}
+
+// onExit allows individual services to register a callback function which will be
+// called when Teleport Process is asked to exit. Usually services terminate themselves
+// when the callback is called
+func (process *TeleportProcess) onExit(callback func(interface{})) {
+	go func() {
+		eventC := make(chan Event)
+		process.WaitForEvent(TeleportExitEvent, eventC, make(chan struct{}))
+		select {
+		case event := <-eventC:
+			callback(event.Payload)
+		}
+	}()
 }
 
 func (process *TeleportProcess) initSSH() error {
@@ -438,11 +478,13 @@ func (process *TeleportProcess) RegisterWithAuthServer(token string, role telepo
 	// this means the server has not been initialized yet, we are starting
 	// the registering client that attempts to connect to the auth server
 	// and provision the keys
+	var authClient *auth.TunClient
 	process.RegisterFunc(func() error {
 		for {
-			conn, err := process.connectToAuthService(role)
+			connector, err := process.connectToAuthService(role)
 			if err == nil {
-				process.BroadcastEvent(Event{Name: eventName, Payload: conn})
+				process.BroadcastEvent(Event{Name: eventName, Payload: connector})
+				authClient = connector.Client
 				return nil
 			}
 			if teleport.IsConnectionProblem(err) {
@@ -474,6 +516,12 @@ func (process *TeleportProcess) RegisterWithAuthServer(token string, role telepo
 				utils.Consolef(cfg.Console, "[%v] Successfully registered with the cluster", role)
 				continue
 			}
+		}
+	})
+
+	process.onExit(func(interface{}) {
+		if authClient != nil {
+			authClient.Close()
 		}
 	})
 }
@@ -508,11 +556,14 @@ func (process *TeleportProcess) initProxy() error {
 		}
 		return trace.Wrap(process.initProxyEndpoint(conn))
 	})
-
 	return nil
 }
 
 func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
+	var (
+		askedToExit = true
+		err         error
+	)
 	cfg := process.Config
 	proxyLimiter, err := limiter.NewLimiter(cfg.Proxy.Limiter)
 	if err != nil {
@@ -568,10 +619,14 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		// notify parties that we've started reverse tunnel server
 		process.BroadcastEvent(Event{Name: ProxyReverseTunnelServerEvent, Payload: tsrv})
 		tsrv.Wait()
+		if askedToExit {
+			log.Infof("[PROXY] Reverse tunnel exited")
+		}
 		return nil
 	})
 
 	// Register web proxy server
+	var webListener net.Listener
 	process.RegisterFunc(func() error {
 		utils.Consolef(cfg.Console, "[PROXY] Web proxy service is starting on %v", cfg.Proxy.WebAddr.Addr)
 		webHandler, err := web.NewHandler(
@@ -586,19 +641,23 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 
 		proxyLimiter.WrapHandle(webHandler)
-
 		process.BroadcastEvent(Event{Name: ProxyWebServerEvent, Payload: webHandler})
 
 		log.Infof("[PROXY] init TLS listeners")
-		err = utils.ListenAndServeTLS(
+		webListener, err = utils.ListenTLS(
 			cfg.Proxy.WebAddr.Addr,
-			proxyLimiter,
 			cfg.Proxy.TLSCert,
 			cfg.Proxy.TLSKey)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-
+		if err = http.Serve(webListener, proxyLimiter); err != nil {
+			if askedToExit {
+				log.Infof("[PROXY] web server exited")
+				return nil
+			}
+			log.Error(err)
+		}
 		return nil
 	})
 
@@ -606,6 +665,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	process.RegisterFunc(func() error {
 		utils.Consolef(cfg.Console, "[PROXY] SSH proxy service is starting on %v", cfg.Proxy.SSHAddr.Addr)
 		if err := SSHProxy.Start(); err != nil {
+			if askedToExit {
+				log.Infof("[PROXY] SSH proxy exited")
+				return nil
+			}
 			utils.Consolef(cfg.Console, "[PROXY] Error: %v", err)
 			return trace.Wrap(err)
 		}
@@ -620,6 +683,15 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 		agentPool.Wait()
 		return nil
+	})
+
+	// execute this when process is asked to exit:
+	process.onExit(func(payload interface{}) {
+		tsrv.Close()
+		SSHProxy.Close()
+		agentPool.Stop()
+		webListener.Close()
+		log.Infof("[PROXY] proxy service exited")
 	})
 	return nil
 }
@@ -643,6 +715,10 @@ func (process *TeleportProcess) initAuthStorage() (backend.Backend, error) {
 	}
 
 	return bk, nil
+}
+
+func (process *TeleportProcess) Close() error {
+	return trace.Wrap(process.localAuth.Close())
 }
 
 func initEventStorage(btype string, params string) (events.Log, error) {

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -82,6 +82,9 @@ type Server struct {
 
 	// this gets set to true for unit testing
 	isTestStub bool
+
+	// sets to true when the server needs to be stopped
+	stopped bool
 }
 
 // ServerOption is a functional option passed to the server
@@ -272,7 +275,7 @@ func (s *Server) registerServer() error {
 // heartbeatPresence periodically calls into the auth server to let everyone
 // know we're up & alive
 func (s *Server) heartbeatPresence() {
-	for {
+	for !s.stopped {
 		if err := s.registerServer(); err != nil {
 			log.Warningf("failed to announce %#v presence: %v", s, err)
 		}
@@ -476,11 +479,13 @@ func (s *Server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permiss
 
 // Close closes listening socket and stops accepting connections
 func (s *Server) Close() error {
+	s.stopped = true
 	return s.srv.Close()
 }
 
 // Start starts server
 func (s *Server) Start() error {
+	s.stopped = false
 	if len(s.cmdLabels) > 0 {
 		s.updateLabels()
 	}

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"math/big"
 	"net"
-	"net/http"
 	"os"
 	"time"
 
@@ -36,22 +35,15 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// ListenAndServeTLS sets up TLS listener for the http handler
-// and blocks in listening and serving requests
-func ListenAndServeTLS(address string, handler http.Handler,
-	certFile, keyFile string) error {
-
+// ListenTLS sets up TLS listener for the http handler, starts listening
+// on a TCP socket and returns the socket which is ready to be used
+// for http.Serve
+func ListenTLS(address string, certFile, keyFile string) (net.Listener, error) {
 	tlsConfig, err := CreateTLSConfiguration(certFile, keyFile)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-
-	listener, err := tls.Listen("tcp", address, tlsConfig)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return http.Serve(listener, handler)
+	return tls.Listen("tcp", address, tlsConfig)
 }
 
 // CreateTLSConfiguration sets up default TLS configuration


### PR DESCRIPTION
This is now possible:

``` go
// start teleport and stop it in 5 seconds
srv, err := service.NewTeleport(service.MakeDefaultConfig())
go func() {
  time.Sleep(time.Second * 5)
  // this causes all services started by Teleport to stop listening and return
  srv.BroadcastEvent(service.Event{Name: service.TeleportExitEvent, Payload: "Telescope!"})
}()
// Run() will return after 5 seconds (after all child services will have stopped running)
srv.Run()
// Close() will close BoltDB file handles
srv.Close()
```

Despite hefty size, it's actually a very safe change (because existing Teleport daemon itself never calls `Close()` on itself). We should probably go over this in hangout
