### PR TITLE
Added the ability to stop teleport without restarting the process

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -130,6 +130,13 @@ type AuthServer struct {
 	*services.BkKeysService
 }
 
+func (a *AuthServer) Close() error {
+	if a.bk != nil {
+		return trace.Wrap(a.bk.Close())
+	}
+	return nil
+}
+
 // GetLocalDomain returns domain name that identifies this authority server
 func (a *AuthServer) GetLocalDomain() (string, error) {
 	return a.DomainName, nil

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -161,6 +161,10 @@ func (c *Client) GetLocalDomain() (string, error) {
 	return domain, nil
 }
 
+func (c *Client) Close() error {
+	return nil
+}
+
 // UpsertCertAuthority updates or inserts new cert authority
 func (c *Client) UpsertCertAuthority(ca services.CertAuthority, ttl time.Duration) error {
 	if err := ca.Check(); err != nil {

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -121,9 +121,8 @@ func (s *AuthTunnel) Start() error {
 func (s *AuthTunnel) Close() error {
 	if s != nil && s.sshServer != nil {
 		return s.sshServer.Close()
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // HandleNewChan implements NewChanHandler interface: it gets called every time a new SSH

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -55,4 +55,6 @@ type Backend interface {
 	ReleaseLock(token string) error
 	// CompareAndSwap implements compare ans swap operation for a key
 	CompareAndSwap(bucket []string, key string, val []byte, ttl time.Duration, prevVal []byte) ([]byte, error)
+	// Close releases the resources taken up by this backend
+	Close() error
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -703,7 +703,9 @@ func (tc *TeleportClient) Login() error {
 
 	// generate a new keypair. the public key will be signed via proxy if our password+HOTP
 	// are legit
-	priv, pub, err := native.New().GenerateKeyPair("")
+	keygen := native.New()
+	defer keygen.Close()
+	priv, pub, err := keygen.GenerateKeyPair("")
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/events/boltlog/bl.go
+++ b/lib/events/boltlog/bl.go
@@ -34,7 +34,8 @@ import (
 )
 
 type BoltLog struct {
-	db *bolt.DB
+	db   *bolt.DB
+	path string
 }
 
 func New(path string) (*BoltLog, error) {
@@ -43,7 +44,8 @@ func New(path string) (*BoltLog, error) {
 		return nil, err
 	}
 	return &BoltLog{
-		db: db,
+		db:   db,
+		path: path,
 	}, nil
 }
 

--- a/lib/events/log.go
+++ b/lib/events/log.go
@@ -79,6 +79,7 @@ type Log interface {
 	LogSession(session.Session) error
 	GetEvents(filter Filter) ([]lunk.Entry, error)
 	GetSessionEvents(filter Filter) ([]session.Session, error)
+	Close() error
 }
 
 // FilterToURL encodes filter to URL query parameters
@@ -139,6 +140,10 @@ func FilterFromURL(vals url.Values) (*Filter, error) {
 var NullEventLogger = &NOPEventLogger{}
 
 type NOPEventLogger struct {
+}
+
+func (*NOPEventLogger) Close() error {
+	return nil
 }
 
 func (*NOPEventLogger) Log(lunk.EventID, lunk.Event) {

--- a/lib/recorder/boltrec/brec.go
+++ b/lib/recorder/boltrec/brec.go
@@ -72,6 +72,19 @@ type boltRecorder struct {
 	dbs  map[string]*boltRW
 }
 
+func (r *boltRecorder) Close() error {
+	r.Lock()
+	defer r.Unlock()
+
+	for _, db := range r.dbs {
+		if err := db.Close(); err != nil {
+			log.Error(err)
+		}
+	}
+	r.dbs = nil
+	return nil
+}
+
 func (r *boltRecorder) decRef(b *boltRW) error {
 	r.Lock()
 	defer r.Unlock()

--- a/lib/recorder/recorder.go
+++ b/lib/recorder/recorder.go
@@ -33,6 +33,8 @@ type Recorder interface {
 	GetChunkWriter(id string) (ChunkWriteCloser, error)
 	// GetChunkReader returns a reader of recorded chunks
 	GetChunkReader(id string) (ChunkReadCloser, error)
+	// Close releases the resources taken by the recorder
+	Close() error
 }
 
 // Chunk is a piece of recorded session on some node

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -71,6 +71,8 @@ type Server interface {
 	FindSimilarSite(name string) (RemoteSite, error)
 	// Start starts server
 	Start() error
+	// CLose closes server's socket
+	Close() error
 	// Wait waits for server to close all outstanding operations
 	Wait()
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -284,10 +284,10 @@ func (process *TeleportProcess) initAuthService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	keygenerator := native.New()
+	keygen := native.New()
 	acfg := auth.InitConfig{
 		Backend:         b,
-		Authority:       keygenerator,
+		Authority:       keygen,
 		DomainName:      cfg.Auth.DomainName,
 		AuthServiceName: cfg.Hostname,
 		DataDir:         cfg.DataDir,
@@ -400,7 +400,7 @@ func (process *TeleportProcess) initAuthService() error {
 		authTunnel.Close()
 		authClient.Close()
 		apiServer.Close()
-		keygenerator.Close()
+		keygen.Close()
 		log.Infof("[AUTH] auth service exited")
 	})
 	return nil

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -31,7 +32,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
-	authority "github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/boltbk"
 	"github.com/gravitational/teleport/lib/backend/etcdbk"
@@ -68,6 +69,9 @@ const (
 	SSHIdentityEvent = "SSHIdentity"
 	// AuthIdentityEvent is generated when auth's identity has been initialized
 	AuthIdentityEvent = "AuthIdentity"
+	// TeleportExitEvent is generated when someone is askign Teleport Process to close
+	// all listening sockets and exit
+	TeleportExitEvent = "TeleportExit"
 )
 
 // RoleConfig is a configuration for a server role (either proxy or node)
@@ -164,7 +168,7 @@ func (process *TeleportProcess) connectToAuthService(role teleport.Role) (*Conne
 
 // NewTeleport takes the daemon configuration, instantiates all required services
 // and starts them under a supervisor, returning the supervisor object
-func NewTeleport(cfg *Config) (Supervisor, error) {
+func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 	if err := validateConfig(cfg); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -260,6 +264,10 @@ func (process *TeleportProcess) getLocalAuth() *auth.AuthServer {
 
 // initAuthService can be called to initialize auth server service
 func (process *TeleportProcess) initAuthService() error {
+	var (
+		askedToExit bool = false
+		err         error
+	)
 	cfg := process.Config
 	// Initialize the storage back-ends for keys, events and records
 	b, err := process.initAuthStorage()
@@ -276,10 +284,10 @@ func (process *TeleportProcess) initAuthService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
+	keygenerator := native.New()
 	acfg := auth.InitConfig{
 		Backend:         b,
-		Authority:       authority.New(),
+		Authority:       keygenerator,
 		DomainName:      cfg.Auth.DomainName,
 		AuthServiceName: cfg.Hostname,
 		DataDir:         cfg.DataDir,
@@ -310,6 +318,9 @@ func (process *TeleportProcess) initAuthService() error {
 
 	process.RegisterFunc(func() error {
 		apiServer.Serve()
+		if askedToExit {
+			log.Infof("[AUTH] API server exited")
+		}
 		return nil
 	})
 
@@ -320,9 +331,10 @@ func (process *TeleportProcess) initAuthService() error {
 
 	// Register an SSH endpoint which is used to create an SSH tunnel to send HTTP
 	// requests to the Auth API
+	var authTunnel *auth.AuthTunnel
 	process.RegisterFunc(func() error {
 		utils.Consolef(cfg.Console, "[AUTH]  Auth service is starting on %v", cfg.Auth.SSHAddr.Addr)
-		tsrv, err := auth.NewTunnel(
+		authTunnel, err = auth.NewTunnel(
 			cfg.Auth.SSHAddr, []ssh.Signer{identity.KeySigner},
 			apiServer,
 			authServer,
@@ -332,7 +344,11 @@ func (process *TeleportProcess) initAuthService() error {
 			utils.Consolef(cfg.Console, "[PROXY] Error: %v", err)
 			return trace.Wrap(err)
 		}
-		if err := tsrv.Start(); err != nil {
+		if err := authTunnel.Start(); err != nil {
+			if askedToExit {
+				log.Infof("[PROXY] Auth Tunnel exited")
+				return nil
+			}
 			utils.Consolef(cfg.Console, "[PROXY] Error: %v", err)
 			return trace.Wrap(err)
 		}
@@ -341,8 +357,9 @@ func (process *TeleportProcess) initAuthService() error {
 
 	// Heart beat auth server presence, this is not the best place for this
 	// logic, consolidate it into auth package later
+	var authClient *auth.TunClient
 	process.RegisterFunc(func() error {
-		authClient, err := auth.NewTunClient(
+		authClient, err = auth.NewTunClient(
 			[]utils.NetAddr{cfg.Auth.SSHAddr},
 			identity.Cert.ValidPrincipals[0],
 			[]ssh.AuthMethod{ssh.PublicKeys(identity.KeySigner)})
@@ -366,17 +383,41 @@ func (process *TeleportProcess) initAuthService() error {
 			}
 			srv.Addr = fmt.Sprintf("%v:%v", process.Config.AdvertiseIP.String(), port)
 		}
-		for {
+		for !askedToExit {
 			err := authClient.UpsertAuthServer(srv, defaults.ServerHeartbeatTTL)
 			if err != nil {
 				log.Warningf("failed to announce presence: %v", err)
 			}
 			sleepTime := defaults.ServerHeartbeatTTL/2 + utils.RandomDuration(defaults.ServerHeartbeatTTL/10)
-			//log.Infof("[AUTH] will ping auth service in %v", sleepTime)
 			time.Sleep(sleepTime)
 		}
+		log.Infof("[AUTH] heartbeat to other auth servers exited")
+		return nil
+	})
+	// execute this when process is asked to exit:
+	process.onExit(func(payload interface{}) {
+		askedToExit = true
+		authTunnel.Close()
+		authClient.Close()
+		apiServer.Close()
+		keygenerator.Close()
+		log.Infof("[AUTH] auth service exited")
 	})
 	return nil
+}
+
+// onExit allows individual services to register a callback function which will be
+// called when Teleport Process is asked to exit. Usually services terminate themselves
+// when the callback is called
+func (process *TeleportProcess) onExit(callback func(interface{})) {
+	go func() {
+		eventC := make(chan Event)
+		process.WaitForEvent(TeleportExitEvent, eventC, make(chan struct{}))
+		select {
+		case event := <-eventC:
+			callback(event.Payload)
+		}
+	}()
 }
 
 func (process *TeleportProcess) initSSH() error {
@@ -438,11 +479,13 @@ func (process *TeleportProcess) RegisterWithAuthServer(token string, role telepo
 	// this means the server has not been initialized yet, we are starting
 	// the registering client that attempts to connect to the auth server
 	// and provision the keys
+	var authClient *auth.TunClient
 	process.RegisterFunc(func() error {
 		for {
-			conn, err := process.connectToAuthService(role)
+			connector, err := process.connectToAuthService(role)
 			if err == nil {
-				process.BroadcastEvent(Event{Name: eventName, Payload: conn})
+				process.BroadcastEvent(Event{Name: eventName, Payload: connector})
+				authClient = connector.Client
 				return nil
 			}
 			if teleport.IsConnectionProblem(err) {
@@ -474,6 +517,12 @@ func (process *TeleportProcess) RegisterWithAuthServer(token string, role telepo
 				utils.Consolef(cfg.Console, "[%v] Successfully registered with the cluster", role)
 				continue
 			}
+		}
+	})
+
+	process.onExit(func(interface{}) {
+		if authClient != nil {
+			authClient.Close()
 		}
 	})
 }
@@ -508,11 +557,14 @@ func (process *TeleportProcess) initProxy() error {
 		}
 		return trace.Wrap(process.initProxyEndpoint(conn))
 	})
-
 	return nil
 }
 
 func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
+	var (
+		askedToExit = true
+		err         error
+	)
 	cfg := process.Config
 	proxyLimiter, err := limiter.NewLimiter(cfg.Proxy.Limiter)
 	if err != nil {
@@ -568,10 +620,14 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		// notify parties that we've started reverse tunnel server
 		process.BroadcastEvent(Event{Name: ProxyReverseTunnelServerEvent, Payload: tsrv})
 		tsrv.Wait()
+		if askedToExit {
+			log.Infof("[PROXY] Reverse tunnel exited")
+		}
 		return nil
 	})
 
 	// Register web proxy server
+	var webListener net.Listener
 	process.RegisterFunc(func() error {
 		utils.Consolef(cfg.Console, "[PROXY] Web proxy service is starting on %v", cfg.Proxy.WebAddr.Addr)
 		webHandler, err := web.NewHandler(
@@ -586,19 +642,23 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 
 		proxyLimiter.WrapHandle(webHandler)
-
 		process.BroadcastEvent(Event{Name: ProxyWebServerEvent, Payload: webHandler})
 
 		log.Infof("[PROXY] init TLS listeners")
-		err = utils.ListenAndServeTLS(
+		webListener, err = utils.ListenTLS(
 			cfg.Proxy.WebAddr.Addr,
-			proxyLimiter,
 			cfg.Proxy.TLSCert,
 			cfg.Proxy.TLSKey)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-
+		if err = http.Serve(webListener, proxyLimiter); err != nil {
+			if askedToExit {
+				log.Infof("[PROXY] web server exited")
+				return nil
+			}
+			log.Error(err)
+		}
 		return nil
 	})
 
@@ -606,6 +666,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	process.RegisterFunc(func() error {
 		utils.Consolef(cfg.Console, "[PROXY] SSH proxy service is starting on %v", cfg.Proxy.SSHAddr.Addr)
 		if err := SSHProxy.Start(); err != nil {
+			if askedToExit {
+				log.Infof("[PROXY] SSH proxy exited")
+				return nil
+			}
 			utils.Consolef(cfg.Console, "[PROXY] Error: %v", err)
 			return trace.Wrap(err)
 		}
@@ -620,6 +684,15 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 		agentPool.Wait()
 		return nil
+	})
+
+	// execute this when process is asked to exit:
+	process.onExit(func(payload interface{}) {
+		tsrv.Close()
+		SSHProxy.Close()
+		agentPool.Stop()
+		webListener.Close()
+		log.Infof("[PROXY] proxy service exited")
 	})
 	return nil
 }
@@ -643,6 +716,11 @@ func (process *TeleportProcess) initAuthStorage() (backend.Backend, error) {
 	}
 
 	return bk, nil
+}
+
+func (process *TeleportProcess) Close() error {
+	process.BroadcastEvent(Event{Name: TeleportExitEvent})
+	return trace.Wrap(process.localAuth.Close())
 }
 
 func initEventStorage(btype string, params string) (events.Log, error) {

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -37,6 +37,10 @@ type Supervisor interface {
 	// it within the system
 	RegisterFunc(fn ServiceFunc)
 
+	// ServiceCount returns the number of registered and actively running
+	// services
+	ServiceCount() int
+
 	// Start starts all unstarted services
 	Start() error
 
@@ -51,9 +55,9 @@ type Supervisor interface {
 	// interested parties
 	BroadcastEvent(Event)
 
-	// WaitForEvent waits for event to be broadcastet, if the event
+	// WaitForEvent waits for event to be broadcasted, if the event
 	// was already broadcasted, payloadC will receive current event immediately
-	// close cancelC channel to skip notification and release resources
+	// CLose 'cancelC' channel to force WaitForEvent to return prematurely
 	WaitForEvent(name string, eventC chan Event, cancelC chan struct{})
 }
 
@@ -61,11 +65,26 @@ type LocalSupervisor struct {
 	state int
 	sync.Mutex
 	wg           *sync.WaitGroup
-	services     []Service
+	services     []*Service
 	errors       []error
 	events       map[string]Event
 	eventsC      chan Event
 	eventWaiters map[string][]*waiter
+	closer       *utils.CloseBroadcaster
+}
+
+// NewSupervisor returns new instance of initialized supervisor
+func NewSupervisor() Supervisor {
+	srv := &LocalSupervisor{
+		services:     []*Service{},
+		wg:           &sync.WaitGroup{},
+		events:       map[string]Event{},
+		eventsC:      make(chan Event, 100),
+		eventWaiters: make(map[string][]*waiter),
+		closer:       utils.NewCloseBroadcaster(),
+	}
+	go srv.fanOut()
+	return srv
 }
 
 // Event is a special service event that can be generated
@@ -82,22 +101,47 @@ func (e *Event) String() string {
 func (s *LocalSupervisor) Register(srv Service) {
 	s.Lock()
 	defer s.Unlock()
+	s.services = append(s.services, &srv)
 
-	s.services = append(s.services, srv)
+	log.Infof("[SUPERVISOR] Service %v added (%v)", srv, len(s.services))
+
 	if s.state == stateStarted {
-		s.serve(srv)
+		s.serve(&srv)
 	}
+}
+
+// ServiceCount returns the number of registered and actively running services
+func (s *LocalSupervisor) ServiceCount() int {
+	s.Lock()
+	defer s.Unlock()
+	return len(s.services)
 }
 
 func (s *LocalSupervisor) RegisterFunc(fn ServiceFunc) {
 	s.Register(fn)
 }
 
-func (s *LocalSupervisor) serve(srv Service) {
+func (s *LocalSupervisor) serve(srv *Service) {
+	// this func will be called _after_ a service stops running:
+	removeService := func() {
+		s.Lock()
+		defer s.Unlock()
+		for i, el := range s.services {
+			if el == srv {
+				s.services = append(s.services[:i], s.services[i+1:]...)
+				break
+			}
+		}
+		log.Infof("[SUPERVISOR] Service %v is done (%v)", *srv, len(s.services))
+	}
+
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
-		err := srv.Serve()
+		defer removeService()
+
+		log.Infof("[SUPERVISOR] Service %v started (%v)", *srv, s.ServiceCount())
+		err := (*srv).Serve()
 		if err != nil {
 			utils.FatalError(err)
 		}
@@ -122,6 +166,7 @@ func (s *LocalSupervisor) Start() error {
 }
 
 func (s *LocalSupervisor) Wait() error {
+	defer s.closer.Close()
 	s.wg.Wait()
 	return nil
 }
@@ -184,21 +229,10 @@ func (s *LocalSupervisor) fanOut() {
 			for _, waiter := range waiters {
 				go s.notifyWaiter(waiter, event)
 			}
+		case <-s.closer.C:
+			return
 		}
 	}
-}
-
-// NewSupervisor returns new instance of initialized supervisor
-func NewSupervisor() Supervisor {
-	srv := &LocalSupervisor{
-		services:     []Service{},
-		wg:           &sync.WaitGroup{},
-		events:       map[string]Event{},
-		eventsC:      make(chan Event, 100),
-		eventWaiters: make(map[string][]*waiter),
-	}
-	go srv.fanOut()
-	return srv
 }
 
 type waiter struct {

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -146,7 +146,7 @@ func SetRecorder(rec recorder.Recorder) ServerOption {
 // SetProxyMode starts this server in SSH proxying mode
 func SetProxyMode(tsrv reversetunnel.Server) ServerOption {
 	return func(s *Server) error {
-		s.proxyMode = true
+		s.proxyMode = (tsrv != nil)
 		s.proxyTun = tsrv
 		return nil
 	}

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"math/big"
 	"net"
-	"net/http"
 	"os"
 	"time"
 
@@ -36,22 +35,15 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// ListenAndServeTLS sets up TLS listener for the http handler
-// and blocks in listening and serving requests
-func ListenAndServeTLS(address string, handler http.Handler,
-	certFile, keyFile string) error {
-
+// ListenTLS sets up TLS listener for the http handler, starts listening
+// on a TCP socket and returns the socket which is ready to be used
+// for http.Serve
+func ListenTLS(address string, certFile, keyFile string) (net.Listener, error) {
 	tlsConfig, err := CreateTLSConfiguration(certFile, keyFile)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-
-	listener, err := tls.Listen("tcp", address, tlsConfig)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return http.Serve(listener, handler)
+	return tls.Listen("tcp", address, tlsConfig)
 }
 
 // CreateTLSConfiguration sets up default TLS configuration

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -468,7 +468,9 @@ func (u *AuthServerCommand) Invite(client *auth.TunClient) error {
 
 // GenerateKeys generates a new keypair
 func (a *AuthCommand) GenerateKeys() error {
-	privBytes, pubBytes, err := native.New().GenerateKeyPair("")
+	keygen := native.New()
+	defer keygen.Close()
+	privBytes, pubBytes, err := keygen.GenerateKeyPair("")
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -493,6 +495,7 @@ func (a *AuthCommand) GenerateAndSignKeys() error {
 		return trace.Wrap(err)
 	}
 	ca := native.New()
+	defer ca.Close()
 	privBytes, pubBytes, err := ca.GenerateKeyPair("")
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This is now possible:

``` go
cfg := service.MakeDefaultConfig()
srv, _ := service.NewTeleport(cfg)
go func() {
    time.Sleep(time.Second)
    srv.Close()
}()
srv.Run()
```

It will start Teleport, wait 1 second and stop Teleport.
### Limitations

Obviously, Teleport originally has not been written to be stopped gracefully, the design is inherently "start-and-run-forever". Because of this, some problems remain: the biggest one is that Teleport does not really know when it _finished_ initializing. Therefore calling `.Stop()` too quickly will result in undefined behaviour.

This PR is a bit "hackish" about adding this, but it's very safe because the existing Teleport daemon does not actually call `.Close()` on itself.
