### PR TITLE
Fixed tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test: FLAGS ?= -cover
 test: 
 	go test -v $(PKGPATH)/tool/tsh/... \
 			   $(PKGPATH)/lib/... \
-			   $(PKGPATH)/tool/teleport... $(FLAGS)
+			   $(PKGPATH)/tool/teleport... $(FLAGS) -tags test
 	go vet ./tool/... ./lib/...
 
 

--- a/lib/services/test_suite.go
+++ b/lib/services/test_suite.go
@@ -1,3 +1,5 @@
+// +build test
+
 /*
 Copyright 2015 Gravitational, Inc.
 


### PR DESCRIPTION
Found a place in Teleport where `check.v1` was imported into production
(not test) code.

This has a few problems:
1. `check.v1` has `init()` package function which alters the program
   execution: it registers globals, like its own flags for the standard 'flag' package 
   This affects how scp.go works, which uses `flag`
2. This also brings accidental symbols into production code (and you may
   have developers using functions indended to be used by tests by
   mistake).

**IMPORTANT** `check.v1` wasn't meant to be imported into production code.

The proper fix (IMO) would be to eliminate any test code stored in files
without _test suffix.

In this case, to save time, I've added 'test' build flag, turned on
condnitional compilation and instructed "go test" to always use this
flag.
