### PR TITLE
This PR exists to debug a PR issue with Github support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Debugging Github Issue
+
 # Gravitational Teleport
 
 |Project Links|


### PR DESCRIPTION
Communication history for Github support engineers:

Stacey,

I created the new PR to illustrate the issue:
https://github.com/gravitational/teleport/pull/345

See? It has two checks:
- **default** - the correct one. see? it passed.
- **TeleportPR** - weird orphan we can't get rid of. It never passes.

Whenever we turn on Github PR merger plugin for Jenkins, it creates 
"default" check (correct) and this weird "TeleportPR" re-surfaces from
somewhere.

We want:
- Get rid of "TeleportPR" check (it prevents us from merging).
- Keep "default" check

```
Begin forwarded message:

From: "Stacey Burns (GitHub Staff)" <support@github.com>
Subject: Re: Bug report: our repository has a "stuck" status we can't get rid of
Date: April 6, 2016 at 12:10:43 AM PDT
To: Ev Kontsevoy <biz@kontsevoy.com>

Hi Ev,

We have the record below which created the Status check called 'TeleportPR'

{
 "action": "required_status_check.create",
 "actor": "klizhentas",
 "created_at": "2016-03-31 01:57:54 +0200",
 "name": "required_status_check.create",
 "org": "gravitational",
 "repo": "gravitational/teleport"
}

As far as I can see there is only one Status Check on this branch though.
The PR you linked is now closed, my apologies for not getting back to your sooner. 

Would you be able to send us a screenshot or details of another PR where you see this?

Thanks
Stacey 
```

Ev Kontsevoy wrote to Github support:

```
Hi,

Whenever we create a pull request for our repository, it always gets a 
required "status check" called "TeleportPR" we can't get rid of.

Take a look a this PR.

Why are there two checks? One is "default" (the correct one) and another one 
is "TeleportPR" - what is that? I've added a comment to the PR where I used 
Github status API (via curl) to list the current status and there is no "TeleportPR".
```
