### PR TITLE
Teleport improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ test: FLAGS ?= -cover
 test: 
 	go test -v $(PKGPATH)/tool/tsh/... \
 			   $(PKGPATH)/lib/... \
+			   $(PKGPATH)/integration/... \
 			   $(PKGPATH)/tool/teleport... $(FLAGS) -tags test
 	go vet ./tool/... ./lib/...
 

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,9 @@ docs:
 .PHONY: test
 test: FLAGS ?= -cover
 test: 
+	go test -v $(PKGPATH)/integration
 	go test -v $(PKGPATH)/tool/tsh/... \
 			   $(PKGPATH)/lib/... \
-			   $(PKGPATH)/integration/... \
 			   $(PKGPATH)/tool/teleport... $(FLAGS) -tags test
 	go vet ./tool/... ./lib/...
 

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -67,6 +67,7 @@ type InstanceSecrets struct {
 	// other sites to connect to this instance. Set to empty
 	// string if this instance is not allowing incoming tunnels
 	ListenAddr string `json:"tunnel_addr"`
+	// UserKey is the key a user can use to login
 }
 
 // NewInstance creates a new Teleport process instance

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -152,8 +152,12 @@ func (this *InstanceSecrets) GetIdentity() *auth.Identity {
 	return i
 }
 
+func (this *TeleInstance) GetPortSSHInt() int {
+	return this.Ports[0]
+}
+
 func (this *TeleInstance) GetPortSSH() string {
-	return strconv.Itoa(this.Ports[0])
+	return strconv.Itoa(this.GetPortSSHInt())
 }
 
 func (this *TeleInstance) GetPortAuth() string {

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -201,6 +202,7 @@ func (this *TeleInstance) Create(trustedSecrets []*InstanceSecrets, enableSSH bo
 	tconf.AuthServers[0].Addr = tconf.Auth.SSHAddr.Addr
 	tconf.ConfigureBolt(dataDir)
 	tconf.DataDir = dataDir
+	tconf.Keygen = testauthority.New()
 	this.Config = tconf
 	this.Process, err = service.NewTeleport(tconf)
 	if err != nil {
@@ -216,7 +218,8 @@ func (this *TeleInstance) Create(trustedSecrets []*InstanceSecrets, enableSSH bo
 		if err != nil {
 			return err
 		}
-		priv, pub := makeKey()
+		priv, pub, _ := tconf.Keygen.GenerateKeyPair("")
+		//priv, pub := makeKey()
 		ttl := time.Duration(time.Hour * 24)
 		cert, err := auth.GenerateUserCert(pub, user.Username, ttl)
 		if err != nil {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -211,7 +211,6 @@ func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
 			}
 		}
 	}
-
 	identity, err := initKeys(asrv, cfg.DataDir, IdentityID{HostUUID: cfg.HostUUID, Role: teleport.RoleAdmin})
 	if err != nil {
 		return nil, nil, err

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -113,6 +113,8 @@ func (n *nauth) precalculateKeys() {
 
 // GenerateKeyPair returns fresh priv/pub keypair, takes about 300ms to execute
 func (n *nauth) GenerateKeyPair(passphrase string) ([]byte, []byte, error) {
+	//fmt.Println("-----> generating new keypair")
+	//debug.PrintStack()
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -113,8 +113,6 @@ func (n *nauth) precalculateKeys() {
 
 // GenerateKeyPair returns fresh priv/pub keypair, takes about 300ms to execute
 func (n *nauth) GenerateKeyPair(passphrase string) ([]byte, []byte, error) {
-	//fmt.Println("-----> generating new keypair")
-	//debug.PrintStack()
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -33,7 +33,7 @@ func New() *nauth {
 }
 
 const (
-	privPem = `-----BEGIN RSA PRIVATE KEY-----
+	Priv = `-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAvJGHcmQNWUjY2eKasmw171qZR0B5FOnzy/nAGB1JAE+QokFe
 Bjo8Gkk3L2TSuVNn0NI5uo5Jwp7GYtbfSbowo11E922Bwp0sFoVzeeUMyLud9EPz
 Hl8+VvE8WEa1lC4D4aqravAfTeeePrONIYoBttX5oYXQ7aZkM8N7yS7KWNOZpy9f
@@ -61,14 +61,14 @@ fE2RAoGBALWvlHVH/29KOVmM52sOk49tcyc3czjs/YANvbokiItxOB8VPY6QQQnS
 uy6c6X17xkP5q2Lq4i90ikyWm3Oc25aUEw48pRyK/6rABRUzpDLB
 -----END RSA PRIVATE KEY-----`
 
-	pubBytes = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8kYdyZA1ZSNjZ4pqybDXvWplHQHkU6fPL+cAYHUkAT5CiQV4GOjwaSTcvZNK5U2fQ0jm6jknCnsZi1t9JujCjXUT3bYHCnSwWhXN55QzIu530Q/MeXz5W8TxYRrWULgPhqqtq8B9N554+s40higG21fmhhdDtpmQzw3vJLspY05mnL1+fW+RIKkM4rb150sdZXKINxfNQvERteE8WX0vL2yG4RuqJzYtGCDEGeHd+HLne7xfmqPxun7bUYaxAlplhm1z2J41hqaj8pBwDSEV9SBOZXvh6FjS9nvJCT7Z1bbZwWrAO/7E2ac0eV+5iEc0J+TyufO3F9uod+J+AICtB`
+	Pub = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8kYdyZA1ZSNjZ4pqybDXvWplHQHkU6fPL+cAYHUkAT5CiQV4GOjwaSTcvZNK5U2fQ0jm6jknCnsZi1t9JujCjXUT3bYHCnSwWhXN55QzIu530Q/MeXz5W8TxYRrWULgPhqqtq8B9N554+s40higG21fmhhdDtpmQzw3vJLspY05mnL1+fW+RIKkM4rb150sdZXKINxfNQvERteE8WX0vL2yG4RuqJzYtGCDEGeHd+HLne7xfmqPxun7bUYaxAlplhm1z2J41hqaj8pBwDSEV9SBOZXvh6FjS9nvJCT7Z1bbZwWrAO/7E2ac0eV+5iEc0J+TyufO3F9uod+J+AICtB`
 )
 
 func (n *nauth) GetNewKeyPairFromPool() ([]byte, []byte, error) {
 	return n.GenerateKeyPair("")
 }
 func (n *nauth) GenerateKeyPair(passphrase string) ([]byte, []byte, error) {
-	return []byte(privPem), []byte(pubBytes), nil
+	return []byte(Priv), []byte(Pub), nil
 }
 
 func (n *nauth) GenerateHostCert(pkey, key []byte, hostname, authDomain string, role teleport.Role, ttl time.Duration) ([]byte, error) {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -328,6 +328,9 @@ func (tc *TeleportClient) SSH(command []string, runLocally bool) error {
 // Join connects to the existing/active SSH session
 func (tc *TeleportClient) Join(sid string) (err error) {
 	sessionID := session.ID(sid)
+	if sessionID.Check() != nil {
+		return trace.Errorf("Invalid session ID format: %s", sid)
+	}
 
 	var notFoundError = &teleport.NotFoundError{Message: "Session not found or it has ended"}
 	// connect to proxy:

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -345,7 +345,6 @@ func (tc *TeleportClient) Join(sid string) (err error) {
 		return trace.Wrap(err)
 	}
 	if len(sites) == 0 {
-		fmt.Println("no sites!")
 		return trace.Wrap(notFoundError)
 	}
 	site, err := proxyClient.ConnectToSite(sites[0].Name, tc.Config.HostLogin)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -326,7 +326,9 @@ func (tc *TeleportClient) SSH(command []string, runLocally bool) error {
 }
 
 // Join connects to the existing/active SSH session
-func (tc *TeleportClient) Join(sessionID session.ID) (err error) {
+func (tc *TeleportClient) Join(sid string) (err error) {
+	sessionID := session.ID(sid)
+
 	var notFoundError = &teleport.NotFoundError{Message: "Session not found or it has ended"}
 	// connect to proxy:
 	if !tc.Config.ProxySpecified() {
@@ -343,6 +345,7 @@ func (tc *TeleportClient) Join(sessionID session.ID) (err error) {
 		return trace.Wrap(err)
 	}
 	if len(sites) == 0 {
+		fmt.Println("no sites!")
 		return trace.Wrap(notFoundError)
 	}
 	site, err := proxyClient.ConnectToSite(sites[0].Name, tc.Config.HostLogin)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -362,7 +362,6 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID) (io.Rea
 			case <-tick.C:
 				sess, err := siteClient.GetSession(sessionID)
 				if err != nil {
-					log.Infof("failed to get session: %v", err)
 					continue
 				}
 				// no previous session

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -317,22 +317,22 @@ func applyString(src string, target *string) bool {
 
 // Configure merges command line arguments with what's in a configuration file
 // with CLI commands taking precedence
-func Configure(clf *CommandLineFlags) (cfg *service.Config, err error) {
+func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 	// load /etc/teleport.yaml and apply it's values:
 	fileConf, err := readConfigFile(clf.ConfigFile)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 	// if configuration is passed as an environment variable,
 	// try to decode it and override the config file
 	if clf.ConfigString != "" {
 		fileConf, err = ReadFromString(clf.ConfigString)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 	}
 	if err = ApplyFileConfig(fileConf, cfg); err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	// apply --debug flag:
@@ -344,7 +344,7 @@ func Configure(clf *CommandLineFlags) (cfg *service.Config, err error) {
 	// apply --roles flag:
 	if clf.Roles != "" {
 		if err := validateRoles(clf.Roles); err != nil {
-			return cfg, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 		cfg.SSH.Enabled = strings.Index(clf.Roles, defaults.RoleNode) != -1
 		cfg.Auth.Enabled = strings.Index(clf.Roles, defaults.RoleAuthService) != -1
@@ -359,7 +359,7 @@ func Configure(clf *CommandLineFlags) (cfg *service.Config, err error) {
 		}
 		addr, err := utils.ParseHostPortAddr(clf.AuthServerAddr, int(defaults.AuthListenPort))
 		if err != nil {
-			return cfg, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 		log.Infof("Using auth server: %v", addr.FullAddress())
 		cfg.AuthServers = []utils.NetAddr{*addr}
@@ -381,21 +381,21 @@ func Configure(clf *CommandLineFlags) (cfg *service.Config, err error) {
 	// --advertise-ip flag
 	if clf.AdvertiseIP != nil {
 		if err := validateAdvertiseIP(clf.AdvertiseIP); err != nil {
-			return nil, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 		cfg.AdvertiseIP = clf.AdvertiseIP
 	}
 
 	// apply --labels flag
 	if err = parseLabels(clf.Labels, &cfg.SSH); err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	// locate web assets if web proxy is enabled
 	if cfg.Proxy.Enabled {
 		cfg.Proxy.AssetsDir, err = LocateWebAssets()
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 	}
 
@@ -403,7 +403,7 @@ func Configure(clf *CommandLineFlags) (cfg *service.Config, err error) {
 	if clf.PIDFile != "" {
 		cfg.PIDFile = clf.PIDFile
 	}
-	return cfg, nil
+	return nil
 }
 
 // parseLabels takes the value of --labels flag and tries to correctly populate

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -318,9 +318,6 @@ func applyString(src string, target *string) bool {
 // Configure merges command line arguments with what's in a configuration file
 // with CLI commands taking precedence
 func Configure(clf *CommandLineFlags) (cfg *service.Config, err error) {
-	// create the default configuration:
-	cfg = service.MakeDefaultConfig()
-
 	// load /etc/teleport.yaml and apply it's values:
 	fileConf, err := readConfigFile(clf.ConfigFile)
 	if err != nil {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -552,7 +552,6 @@ func LocateWebAssets() (string, error) {
 	}
 	// checker function to determine if dirPath contains the web assets
 	locateAssets := func(dirPath string) bool {
-		fmt.Println("checking ", dirPath)
 		for _, af := range assetsToCheck {
 			if !fileExists(filepath.Join(dirPath, af)) {
 				return false

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -357,7 +357,6 @@ func (a *Agent) startHeartbeat(conn ssh.Conn) {
 			errC <- err
 			return
 		}
-		hb.SendRequest("ping", false, nil)
 		for {
 			select {
 			case <-a.broadcastClose.C:

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -210,7 +210,6 @@ func (a *Agent) connect() error {
 	go a.handleAccessPoint(c.HandleChannelOpen(chanAccessPoint))
 	go a.handleTransport(c.HandleChannelOpen(chanTransport))
 
-	a.log.Infof("connection established")
 	return nil
 }
 

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -137,7 +137,6 @@ func (a *Agent) reconnect() error {
 			return nil
 		case <-ticker.C:
 			if err = a.connect(); err != nil {
-				a.log.Infof("connect attempt %v: %v", i, err)
 				i++
 				continue
 			}
@@ -166,7 +165,6 @@ func (a *Agent) checkHostSignature(hostport string, remote net.Addr, key ssh.Pub
 		return trace.Wrap(err, "failed to fetch remote certs")
 	}
 	for _, ca := range cas {
-		a.log.Infof("checking against %v", ca.ID())
 		checkers, err := ca.Checkers()
 		if err != nil {
 			return trace.Wrap(teleport.BadParameter("key", fmt.Sprintf("error parsing key: %v", err)))
@@ -190,7 +188,6 @@ func (a *Agent) connect() error {
 		a.log.Error(err)
 		return err
 	}
-	a.log.Infof("agent connect")
 
 	var c *ssh.Client
 	var err error

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -357,6 +357,7 @@ func (a *Agent) startHeartbeat(conn ssh.Conn) {
 			errC <- err
 			return
 		}
+		hb.SendRequest("ping", false, nil)
 		for {
 			select {
 			case <-a.broadcastClose.C:

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -107,10 +107,16 @@ func (m *AgentPool) FetchAndSyncAgents() error {
 func (m *AgentPool) pollAndSyncAgents() {
 	ticker := time.NewTicker(defaults.ReverseTunnelsRefreshPeriod)
 	defer ticker.Stop()
+	m.FetchAndSyncAgents()
 	for {
 		select {
 		case <-m.closeBroadcast.C:
 			m.Infof("closing")
+			m.Lock()
+			defer m.Unlock()
+			for _, a := range m.agents {
+				a.Close()
+			}
 			return
 		case <-ticker.C:
 			err := m.FetchAndSyncAgents()

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -283,8 +283,6 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permiss
 		"user":   conn.User(),
 	})
 
-	logger.Infof("auth attempt with key %v", key.Type())
-
 	cert, ok := key.(*ssh.Certificate)
 	if !ok {
 		logger.Warningf("server doesn't support provided key type")

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -66,6 +66,9 @@ type Config struct {
 	// Auth server authentication and authorizatin server config
 	Auth AuthConfig
 
+	// Keygen points to a key generator implementation
+	Keygen auth.Authority
+
 	// Proxy is SSH proxy that manages incoming and outbound connections
 	// via multiple reverse tunnels
 	Proxy ProxyConfig

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -182,7 +182,6 @@ func (s *Server) handleConnection(conn net.Conn) {
 	}
 	sconn, chans, reqs, err := ssh.NewServerConn(conn, &s.cfg)
 	if err != nil {
-		log.Infof("failed to initiate connection, err: %v", err)
 		conn.SetDeadline(time.Time{})
 		return
 	}

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -101,6 +101,9 @@ func run(cmdlineArgs []string, testRun bool) (executedCommand string, appliedCon
 		utils.FatalError(err)
 	}
 
+	// create the default configuration:
+	appliedConfig = service.MakeDefaultConfig()
+
 	// execute the selected command unless we're running tests
 	if !testRun {
 		switch command {

--- a/tool/teleport/main_test.go
+++ b/tool/teleport/main_test.go
@@ -26,6 +26,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"gopkg.in/check.v1"
 )
@@ -42,6 +43,7 @@ type MainTestSuite struct {
 var _ = check.Suite(&MainTestSuite{})
 
 func (s *MainTestSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
 	var err error
 	// get the hostname
 	s.hostname, err = os.Hostname()

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -274,7 +274,7 @@ func onJoin(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	if err = tc.Join(cf.SessionID); err != nil {
+	if err = tc.Join(string(cf.SessionID)); err != nil {
 		utils.FatalError(err)
 	}
 }


### PR DESCRIPTION
You can look into each commit separately, but here is the overview:
- Added support for arbitrary users for integration tests. You can create users separately from "teleport instances".
- Small Teleport commands like "status" or "version" do not look for web assets anymore.
- Integrated "testauthority" into integration testing
- Improved polling logic in a few places
