### PR TITLE
Teleport session improvements

### DIFF
--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -76,7 +76,6 @@ func NewStandardPermissions() PermissionChecker {
 		ActionGetChunkWriter:     true,
 		ActionGetSession:         true,
 		ActionGetSessions:        true,
-		ActionGetChunkReader:     true,
 	}
 
 	sp.permissions[teleport.RoleProxy] = map[string]bool{

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -76,6 +76,7 @@ func NewStandardPermissions() PermissionChecker {
 		ActionGetChunkWriter:     true,
 		ActionGetSession:         true,
 		ActionGetSessions:        true,
+		ActionGetChunkReader:     true,
 	}
 
 	sp.permissions[teleport.RoleProxy] = map[string]bool{

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -547,7 +547,8 @@ func (tc *TeleportClient) runCommand(nodeAddresses []string, proxyClient *ProxyC
 	return trace.Wrap(lastError)
 }
 
-// runShell starts an interactive SSH session/shell
+// runShell starts an interactive SSH session/shell. If sessionID is empty, it creates
+// a new shell. Otherwise it tries to join the existing session.
 func (tc *TeleportClient) runShell(nodeClient *NodeClient, sessionID session.ID) error {
 	defer nodeClient.Close()
 	address := tc.NodeHostPort()

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -279,6 +279,7 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID) (io.Rea
 		return nil, trace.Wrap(err)
 	}
 
+	// ask the server to drop us into the existing session:
 	if len(sessionID) > 0 {
 		err = clientSession.Setenv(sshutils.SessionEnvVar, string(sessionID))
 		if err != nil {

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -70,6 +70,7 @@ const (
 	// InviteTokenTTL sets the lifespan of tokens used for adding nodes and users
 	// to a cluster
 	InviteTokenTTL = 15 * time.Minute
+
 	// DefaultDialTimeout is a default TCP dial timeout we set for our
 	// connection attempts
 	DefaultDialTimeout = 30 * time.Second
@@ -141,6 +142,10 @@ var (
 	// TODO(klizhentas) all polling periods should go away once backend
 	// releases events
 	SessionRefreshPeriod = 2 * time.Second
+
+	// TerminalSizeRefreshPeriod is how frequently clients who share sessions sync up
+	// their terminal sizes
+	TerminalSizeRefreshPeriod = 2 * time.Second
 )
 
 // Default connection limits, they can be applied separately on any of the Teleport

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -47,6 +47,15 @@ func (s *sessionRegistry) addSession(sess *session) {
 	s.sessions[sess.id] = sess
 }
 
+func (r *sessionRegistry) Close() {
+	r.Lock()
+	defer r.Unlock()
+	for _, s := range r.sessions {
+		s.Close()
+	}
+	r.sessions = nil
+}
+
 // joinShell either joins an existing session or starts a new shell
 func (s *sessionRegistry) joinShell(sid rsession.ID, sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 	ctx.Infof("joinShell(sid=%v)", sid)

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -101,6 +101,7 @@ func SetEventLogger(e events.Log) ServerOption {
 // Close closes listening socket and stops accepting connections
 func (s *Server) Close() error {
 	s.closer.Close()
+	s.reg.Close()
 	return s.srv.Close()
 }
 

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -102,7 +102,7 @@ func (t *terminal) setWinsize(params rsession.TerminalParams) error {
 	if t.pty == nil {
 		return trace.Wrap(teleport.NotFound("no pty"))
 	}
-	log.Infof("window resize %v", &params)
+	log.Infof("resizing terminal to %v", &params)
 	if err := term.SetWinsize(t.pty.Fd(), params.Winsize()); err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Two changes:
- e349dcc - Make sure all active sessions are properly closed when a `server.Close()` is called.
- 8009984 - Replay last chunk to a new party who joins an existing session. 
