### PR TITLE
TSH key management has been rewritten from scratch

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -29,7 +29,7 @@ bbox:
 .PHONY:test
 test: integration
 	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
-		/bin/bash -c "$(MAKE) -C $(SRCDIR) TELEPORT_DEBUG_TESTS=0 FLAGS='-cover -race' clean test"
+		/bin/bash -c "$(MAKE) -C $(SRCDIR) TELEPORT_DEBUG_TESTS=1 FLAGS='-cover -race' clean test"
 
 
 .PHONY:integration

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -35,7 +35,7 @@ test: integration
 .PHONY:integration
 integration: bbox
 	docker run $(DOCKERFLAGS) $(NOROOT) -i $(BBOX) \
-		/bin/bash -c "$(MAKE) -C $(SRCDIR) TELEPORT_DEBUG_TESTS=false FLAGS='-cover' integration"
+		/bin/bash -c "$(MAKE) -C $(SRCDIR) FLAGS='-cover' integration"
 
 #
 # Builds docs

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -29,7 +29,7 @@ bbox:
 .PHONY:test
 test: integration
 	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
-		/bin/bash -c "$(MAKE) -C $(SRCDIR) TELEPORT_DEBUG_TESTS=true FLAGS='-cover -race' clean test"
+		/bin/bash -c "$(MAKE) -C $(SRCDIR) TELEPORT_DEBUG_TESTS=0 FLAGS='-cover -race' clean test"
 
 
 .PHONY:integration

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -307,7 +309,7 @@ func (this *TeleInstance) NewClient(login string, site string, host string, port
 		HostPort:           port,
 		HostLogin:          login,
 		InsecureSkipVerify: true,
-		KeysDir:            this.Config.DataDir,
+		KeysDir:            filepath.Join(this.Config.DataDir, fmt.Sprintf("%v", rand.Intn(1024*1024*1024))),
 		SiteName:           site,
 	})
 	if err != nil {
@@ -318,7 +320,7 @@ func (this *TeleInstance) NewClient(login string, site string, host string, port
 	if !ok {
 		return nil, fmt.Errorf("unknown login '%v'", login)
 	}
-	err = tc.SaveKey(user.Key)
+	err = tc.AddKey(host, user.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net"
 	"os"
-	"path/filepath"
 	"strconv"
 	"time"
 
@@ -302,6 +300,10 @@ func (this *TeleInstance) Start() (err error) {
 
 // NewClient returns a fully configured client (with server CAs and user keys)
 func (this *TeleInstance) NewClient(login string, site string, host string, port int) (tc *client.TeleportClient, err error) {
+	keyDir, err := ioutil.TempDir(this.Config.DataDir, "tsh")
+	if err != nil {
+		return nil, err
+	}
 	tc, err = client.NewClient(&client.Config{
 		Login:              login,
 		ProxyHost:          this.Config.Proxy.SSHAddr.Addr,
@@ -309,7 +311,7 @@ func (this *TeleInstance) NewClient(login string, site string, host string, port
 		HostPort:           port,
 		HostLogin:          login,
 		InsecureSkipVerify: true,
-		KeysDir:            filepath.Join(this.Config.DataDir, fmt.Sprintf("%v", rand.Intn(1024*1024*1024))),
+		KeysDir:            keyDir,
 		SiteName:           site,
 	})
 	if err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -157,7 +157,7 @@ func (s *IntSuite) TestInteractive(c *check.C) {
 	waitFor(sessionEndC, time.Second*10)
 
 	// make sure both parites saw the same output:
-	c.Assert(personA.Output(30), check.DeepEquals, personB.Output(30))
+	c.Assert(string(personA.Output(30)), check.Equals, string(personB.Output(30)))
 }
 
 // TestInvalidLogins validates that you can't login with invalid login or

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -25,11 +25,11 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-type nauth struct {
+type Keygen struct {
 }
 
-func New() *nauth {
-	return &nauth{}
+func New() *Keygen {
+	return &Keygen{}
 }
 
 const (
@@ -64,14 +64,14 @@ uy6c6X17xkP5q2Lq4i90ikyWm3Oc25aUEw48pRyK/6rABRUzpDLB
 	Pub = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8kYdyZA1ZSNjZ4pqybDXvWplHQHkU6fPL+cAYHUkAT5CiQV4GOjwaSTcvZNK5U2fQ0jm6jknCnsZi1t9JujCjXUT3bYHCnSwWhXN55QzIu530Q/MeXz5W8TxYRrWULgPhqqtq8B9N554+s40higG21fmhhdDtpmQzw3vJLspY05mnL1+fW+RIKkM4rb150sdZXKINxfNQvERteE8WX0vL2yG4RuqJzYtGCDEGeHd+HLne7xfmqPxun7bUYaxAlplhm1z2J41hqaj8pBwDSEV9SBOZXvh6FjS9nvJCT7Z1bbZwWrAO/7E2ac0eV+5iEc0J+TyufO3F9uod+J+AICtB`
 )
 
-func (n *nauth) GetNewKeyPairFromPool() ([]byte, []byte, error) {
+func (n *Keygen) GetNewKeyPairFromPool() ([]byte, []byte, error) {
 	return n.GenerateKeyPair("")
 }
-func (n *nauth) GenerateKeyPair(passphrase string) ([]byte, []byte, error) {
+func (n *Keygen) GenerateKeyPair(passphrase string) ([]byte, []byte, error) {
 	return []byte(Priv), []byte(Pub), nil
 }
 
-func (n *nauth) GenerateHostCert(pkey, key []byte, hostname, authDomain string, role teleport.Role, ttl time.Duration) ([]byte, error) {
+func (n *Keygen) GenerateHostCert(pkey, key []byte, hostname, authDomain string, role teleport.Role, ttl time.Duration) ([]byte, error) {
 	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(key)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (n *nauth) GenerateHostCert(pkey, key []byte, hostname, authDomain string, 
 	return ssh.MarshalAuthorizedKey(cert), nil
 }
 
-func (n *nauth) GenerateUserCert(pkey, key []byte, teleportUsername string, allowedLogins []string, ttl time.Duration) ([]byte, error) {
+func (n *Keygen) GenerateUserCert(pkey, key []byte, teleportUsername string, allowedLogins []string, ttl time.Duration) ([]byte, error) {
 	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(key)
 	if err != nil {
 		return nil, err

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -806,6 +806,10 @@ func (tc *TeleportClient) MakeKey() (key *Key, err error) {
 	return key, nil
 }
 
+func (tc *TeleportClient) AddKey(host string, key *Key) error {
+	return tc.localAgent.AddKey(host, key)
+}
+
 // directLogin asks for a password + HOTP token, makes a request to CA via proxy
 func (tc *TeleportClient) directLogin(pub []byte) (*web.SSHLoginResponse, error) {
 	password, hotpToken, err := tc.AskPasswordAndHOTP()

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -192,12 +192,12 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if c.Output == nil {
-		c.Output = os.Stdout
+	if tc.Output == nil {
+		tc.Output = os.Stdout
 	}
 
-	if c.HostKeyCallback == nil {
-		c.HostKeyCallback = tc.localAgent.CheckHostSignature
+	if tc.HostKeyCallback == nil {
+		tc.HostKeyCallback = tc.localAgent.CheckHostSignature
 	}
 
 	// add auth methods supplied by user if any
@@ -681,7 +681,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 	proxyAddr := tc.Config.ProxyHostPort(defaults.SSHProxyListenPort)
 	sshConfig := &ssh.ClientConfig{
 		User:            tc.getProxyLogin(),
-		HostKeyCallback: tc.Config.HostKeyCallback,
+		HostKeyCallback: tc.HostKeyCallback,
 	}
 	authMethods := tc.getAuthMethods(true)
 	if len(authMethods) == 0 {
@@ -701,7 +701,6 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 				}
 				return nil, trace.Wrap(err)
 			}
-			log.Infof("Got %v auth methods!", tc.getAuthMethods(false))
 			return &ProxyClient{
 				Client:          proxyClient,
 				proxyAddress:    proxyAddr,

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -58,8 +58,8 @@ func (s *APITestSuite) TestNew(c *check.C) {
 		SiteName:  "site",
 	}
 	tc, err := NewClient(&conf)
-	c.Assert(tc, check.NotNil)
 	c.Assert(err, check.IsNil)
+	c.Assert(tc, check.NotNil)
 
 	la := tc.LocalAgent()
 	c.Assert(la, check.NotNil)

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -28,7 +28,7 @@ type LocalKeyStore interface {
 
 	// trusted hosts key management:
 	AddKnownHost(hostname string, publicKeys []ssh.PublicKey) error
-	GetKnownHost(hostname string) ([]ssh.PublicKey, error)
+	GetKnownHosts() ([]ssh.PublicKey, error)
 }
 
 // AsAgentKey converts our Key structure to ssh.Agent.Key

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -26,9 +26,9 @@ type LocalKeyStore interface {
 	AddKey(host string, key *Key) error
 	GetKey(host string) (*Key, error)
 
-	// trusted hosts key management:
-	AddKnownHost(hostname string, publicKeys []ssh.PublicKey) error
-	GetKnownHosts() ([]ssh.PublicKey, error)
+	// trusted CAs management:
+	AddKnownCA(domainName string, publicKeys []ssh.PublicKey) error
+	GetKnownCAs() ([]ssh.PublicKey, error)
 }
 
 // AsAgentKey converts our Key structure to ssh.Agent.Key

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"time"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// Key describes a stored client key
+type Key struct {
+	Priv []byte `json:"Priv,omitempty"`
+	Pub  []byte `json:"Pub,omitempty"`
+	Cert []byte `json:"Cert,omitempty"`
+
+	// Deadline AKA TTL is the time when this key is safe to be discarded
+	// for garbage collection purposes
+	Deadline time.Time `json:"Deadline,omitempty"`
+}
+
+// LocalKeyStore interface allows for different storage back-ends for TSH to load/save its keys
+type LocalKeyStore interface {
+	// client key management
+	GetKeys() ([]Key, error)
+	AddKey(host string, key *Key) error
+	GetKey(host string) (*Key, error)
+
+	// trusted hosts key management:
+	AddKnownHost(hostname string, publicKeys []ssh.PublicKey) error
+}
+
+// AsAgentKey converts our Key structure to ssh.Agent.Key
+func (k *Key) AsAgentKey() (*agent.AddedKey, error) {
+	// parse the returned&signed key:
+	pcert, _, _, _, err := ssh.ParseAuthorizedKey(k.Cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	pk, err := ssh.ParseRawPrivateKey(k.Priv)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &agent.AddedKey{
+		PrivateKey:       pk,
+		Certificate:      pcert.(*ssh.Certificate),
+		Comment:          "",
+		LifetimeSecs:     0,
+		ConfirmBeforeUse: false,
+	}, nil
+}

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -28,6 +28,7 @@ type LocalKeyStore interface {
 
 	// trusted hosts key management:
 	AddKnownHost(hostname string, publicKeys []ssh.PublicKey) error
+	GetKnownHost(hostname string) ([]ssh.PublicKey, error)
 }
 
 // AsAgentKey converts our Key structure to ssh.Agent.Key

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+Keystore implements functions for saving and loading from hard disc
+temporary teleport certificates
+*/
+
+package client
+
+import (
+	"net"
+	"path/filepath"
+
+	"github.com/gravitational/teleport/lib/backend/boltbk"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/sshutils"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+type LocalKeyAgent struct {
+	// implements ssh agent.Agent interface
+	agent.Agent
+
+	keyStore LocalKeyStore
+
+	// KeyDir is the directory path where local keys are stored
+	KeyDir string
+}
+
+// NewLocalAgent loads all the saved teleport certificates and
+// creates ssh agent with them
+func NewLocalAgent(keyDir string) (a *LocalKeyAgent, err error) {
+	keystore, err := NewFSLocalKeyStore(keyDir)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	a = &LocalKeyAgent{
+		Agent:    agent.NewKeyring(),
+		KeyDir:   keystore.KeyDir,
+		keyStore: keystore,
+	}
+	// add all stored keys into the agent:
+	keys, err := a.GetKeys()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for i := range keys {
+		if err := a.Agent.Add(keys[i]); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	return a, nil
+}
+
+func (a *LocalKeyAgent) GetKeys() ([]agent.AddedKey, error) {
+	keys, err := a.keyStore.GetKeys()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	retval := make([]agent.AddedKey, len(keys))
+	for i, key := range keys {
+		ak, err := key.AsAgentKey()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		retval[i] = *ak
+	}
+	return retval, nil
+}
+
+// AddHostSignersToCache takes a list of CAs whom we trust. This list is added to a database
+// of "seen" CAs.
+//
+// Every time we connect to a new host, we'll request its certificaate to be signed by one
+// of these trusted CAs.
+//
+// Why do we trust these CAs? Because we received them from a trusted Teleport Proxy.
+// Why do we trust the proxy? Because we've connected to it via HTTPS + username + Password + HOTP.
+func (a *LocalKeyAgent) AddHostSignersToCache(hostSigners []services.CertAuthority) error {
+	bk, err := boltbk.New(filepath.Join(a.KeyDir, HostSignersFilename))
+	if err != nil {
+		return trace.Wrap(nil)
+	}
+	defer bk.Close()
+	ca := local.NewCAService(bk)
+
+	for _, hostSigner := range hostSigners {
+		err := ca.UpsertCertAuthority(hostSigner, 0)
+		if err != nil {
+			return trace.Wrap(nil)
+		}
+
+	}
+
+	// TODO (ev): keep only this:
+	for _, hostSigner := range hostSigners {
+		publicKeys, err := hostSigner.Checkers()
+		if err != nil {
+			log.Error(err)
+			return trace.Wrap(err)
+		}
+		a.keyStore.AddKnownHost(hostSigner.DomainName, publicKeys)
+	}
+	return nil
+}
+
+// CheckHostSignature checks if the given host key was signed by one of the trusted
+// certificaate authorities (CAs)
+func (a *LocalKeyAgent) CheckHostSignature(hostId string, remote net.Addr, key ssh.PublicKey) error {
+	cert, ok := key.(*ssh.Certificate)
+	if !ok {
+		return trace.Errorf("expected certificate")
+	}
+
+	bk, err := boltbk.New(filepath.Join(a.KeyDir, HostSignersFilename))
+	if err != nil {
+		return trace.Wrap(nil)
+	}
+	defer bk.Close()
+	ca := local.NewCAService(bk)
+
+	cas, err := ca.GetCertAuthorities(services.HostCA, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for i := range cas {
+		checkers, err := cas[i].Checkers()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for _, checker := range checkers {
+			if sshutils.KeysEqual(cert.SignatureKey, checker) {
+				return nil
+			}
+		}
+	}
+	return trace.Errorf("no matching authority found")
+}
+
+func (a *LocalKeyAgent) AddKey(host string, key *Key) error {
+	err := a.keyStore.AddKey(host, key)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	agentKey, err := key.AsAgentKey()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return a.Agent.Add(*agentKey)
+}
+
+var (
+	HostSignersFilename = "hostsigners.db"
+)

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -105,16 +105,20 @@ func (a *LocalKeyAgent) CheckHostSignature(hostId string, remote net.Addr, key s
 	if !ok {
 		return trace.Errorf("expected certificate")
 	}
-	keys, err := a.keyStore.GetKnownHost(hostId)
+	keys, err := a.keyStore.GetKnownHosts()
 	if err != nil {
+		log.Error(err)
 		return trace.Wrap(err)
 	}
 	for i := range keys {
 		if sshutils.KeysEqual(cert.SignatureKey, keys[i]) {
+			log.Info("we can trust host %v", hostId)
 			return nil
 		}
 	}
-	return trace.Errorf("no matching authority found")
+	err = trace.AccessDenied("remote host %v at %v cannot be trusted", hostId, remote)
+	log.Error(err)
+	return trace.Wrap(err)
 }
 
 func (a *LocalKeyAgent) AddKey(host string, key *Key) error {

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -93,7 +93,7 @@ func (a *LocalKeyAgent) AddHostSignersToCache(hostSigners []services.CertAuthori
 			log.Error(err)
 			return trace.Wrap(err)
 		}
-		a.keyStore.AddKnownHost(hostSigner.DomainName, publicKeys)
+		a.keyStore.AddKnownCA(hostSigner.DomainName, publicKeys)
 	}
 	return nil
 }
@@ -105,7 +105,7 @@ func (a *LocalKeyAgent) CheckHostSignature(hostId string, remote net.Addr, key s
 	if !ok {
 		return trace.Errorf("expected certificate")
 	}
-	keys, err := a.keyStore.GetKnownHosts()
+	keys, err := a.keyStore.GetKnownCAs()
 	if err != nil {
 		log.Error(err)
 		return trace.Wrap(err)

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -12,10 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-
-Keystore implements functions for saving and loading from hard disc
-temporary teleport certificates
 */
 
 package client
@@ -103,7 +99,7 @@ func (a *LocalKeyAgent) AddHostSignersToCache(hostSigners []services.CertAuthori
 func (a *LocalKeyAgent) CheckHostSignature(hostId string, remote net.Addr, key ssh.PublicKey) error {
 	cert, ok := key.(*ssh.Certificate)
 	if !ok {
-		return trace.Errorf("expected certificate")
+		return trace.BadParameter("expected certificate")
 	}
 	keys, err := a.keyStore.GetKnownHosts()
 	if err != nil {

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -95,9 +95,8 @@ func (fs *FSLocalKeyStore) GetKeys() (keys []Key, err error) {
 			// if a key is reported as 'not found' it's probably because it expired
 			if !trace.IsNotFound(err) {
 				return nil, trace.Wrap(err)
-			} else {
-				continue
 			}
+			continue
 		}
 		keys = append(keys, *k)
 	}

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -1,265 +1,193 @@
-/*
-Copyright 2015 Gravitational, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-
-Keystore implements functions for saving and loading from hard disc
-temporary teleport certificates
-*/
-
 package client
 
 import (
-	"encoding/json"
 	"io/ioutil"
-	"math/rand"
-	"net"
 	"os"
 	"os/user"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
-
-	"github.com/gravitational/teleport/lib/backend/boltbk"
-	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/services/local"
-	"github.com/gravitational/teleport/lib/sshutils"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
+
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
 )
 
-type LocalKeyAgent struct {
-	agent.Agent
-	// KeyDir is the directory path where local keys are stored
+const (
+	defaultKeyDir = ".tsh"
+	sessionKeyDir = "sessions"
+	fileNameCert  = "cert"
+	fileNameKey   = "key"
+	fileNamePub   = "pub"
+	fileNameTTL   = ".ttl"
+)
+
+// FSLocalKeyStore implements LocalKeyStore interface using the filesystem
+type FSLocalKeyStore struct {
+	LocalKeyStore
+
+	// KeyDir is the directory where all keys are stored
 	KeyDir string
 }
 
-// AddHostSignersToCache takes a list of CAs whom we trust. This list is added to a database
-// of "seen" CAs.
+// NewFSLocalKeyStore creates a new filesystem-based local keystore object
+// and initializes it.
 //
-// Every time we connect to a new host, we'll request its certificaate to be signed by one
-// of these trusted CAs.
-//
-// Why do we trust these CAs? Because we received them from a trusted Teleport Proxy.
-// Why do we trust the proxy? Because we've connected to it via HTTPS + username + Password + HOTP.
-func (a *LocalKeyAgent) AddHostSignersToCache(hostSigners []services.CertAuthority) error {
-	bk, err := boltbk.New(filepath.Join(a.KeyDir, HostSignersFilename))
+// if dirPath is empty, sets it to ~/.tsh
+func NewFSLocalKeyStore(dirPath string) (s *FSLocalKeyStore, err error) {
+	log.Infof("using FSLocalKeyStore")
+	dirPath, err = initKeysDir(dirPath)
 	if err != nil {
-		return trace.Wrap(nil)
+		return nil, trace.Wrap(err)
 	}
-	defer bk.Close()
-	ca := local.NewCAService(bk)
-
-	for _, hostSigner := range hostSigners {
-		err := ca.UpsertCertAuthority(hostSigner, 0)
-		if err != nil {
-			return trace.Wrap(nil)
-		}
-	}
-	return nil
+	return &FSLocalKeyStore{
+		KeyDir: dirPath,
+	}, nil
 }
 
-// CheckHostSignature checks if the given host key was signed by one of the trusted
-// certificaate authorities (CAs)
-func (a *LocalKeyAgent) CheckHostSignature(hostId string, remote net.Addr, key ssh.PublicKey) error {
-	cert, ok := key.(*ssh.Certificate)
-	if !ok {
-		return trace.Errorf("expected certificate")
+func (fs *FSLocalKeyStore) GetKeys() (keys []Key, err error) {
+	dirPath := filepath.Join(fs.KeyDir, sessionKeyDir)
+	if !isDir(dirPath) {
+		return make([]Key, 0), nil
 	}
-
-	bk, err := boltbk.New(filepath.Join(a.KeyDir, HostSignersFilename))
+	dirEntries, err := ioutil.ReadDir(dirPath)
 	if err != nil {
-		return trace.Wrap(nil)
+		return nil, trace.Wrap(err)
 	}
-	defer bk.Close()
-	ca := local.NewCAService(bk)
+	for _, fi := range dirEntries {
+		if !fi.IsDir() {
+			continue
+		}
+		k, err := fs.GetKey(fi.Name())
+		if err != nil {
+			// if a key is reported as 'not found' it's probably because it expired
+			if !trace.IsNotFound(err) {
+				return nil, trace.Wrap(err)
+			} else {
+				continue
+			}
+		}
+		keys = append(keys, *k)
+	}
+	return keys, nil
+}
 
-	cas, err := ca.GetCertAuthorities(services.HostCA, false)
+func (fs *FSLocalKeyStore) AddKey(host string, key *Key) error {
+	dirPath, err := fs.dirFor(host)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	for i := range cas {
-		checkers, err := cas[i].Checkers()
+	writeBytes := func(fname string, data []byte) error {
+		fp := filepath.Join(dirPath, fname)
+		err := ioutil.WriteFile(fp, data, 0640)
 		if err != nil {
-			return trace.Wrap(err)
+			log.Error(err)
 		}
-		for _, checker := range checkers {
-			if sshutils.KeysEqual(cert.SignatureKey, checker) {
-				return nil
-			}
-		}
+		return err
 	}
-	return trace.Errorf("no matching authority found")
+	if err = writeBytes(fileNameCert, key.Cert); err != nil {
+		return trace.Wrap(err)
+	}
+	if err = writeBytes(fileNamePub, key.Pub); err != nil {
+		return trace.Wrap(err)
+	}
+	if err = writeBytes(fileNameKey, key.Priv); err != nil {
+		return trace.Wrap(err)
+	}
+	ttl, _ := key.Deadline.MarshalJSON()
+	if err = writeBytes(fileNameTTL, ttl); err != nil {
+		return trace.Wrap(err)
+	}
+	log.Infof("keystore.AddKey(%s)", host)
+	return nil
 }
 
-// getKeyes returns a list of local keys agents can use to authenticate
-func (a *LocalKeyAgent) GetKeys() ([]agent.AddedKey, error) {
-	existingKeys, err := a.loadAllKeys()
+func (fs *FSLocalKeyStore) GetKey(host string) (*Key, error) {
+	dirPath, err := fs.dirFor(host)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	addedKeys := make([]agent.AddedKey, len(existingKeys))
-	for i, key := range existingKeys {
-		pcert, _, _, _, err := ssh.ParseAuthorizedKey(key.Cert)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		pk, err := ssh.ParseRawPrivateKey(key.Priv)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		addedKey := agent.AddedKey{
-			PrivateKey:       pk,
-			Certificate:      pcert.(*ssh.Certificate),
-			Comment:          "",
-			LifetimeSecs:     0,
-			ConfirmBeforeUse: false,
-		}
-		addedKeys[i] = addedKey
-	}
-	return addedKeys, nil
-}
-
-// GetLocalAgent loads all the saved teleport certificates and
-// creates ssh agent with them
-func GetLocalAgent(keyDir string) (a *LocalKeyAgent, err error) {
-	if keyDir == "" {
-		keyDir, err = initDefaultKeysDir()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		if !isDir(keyDir) {
-			return nil, trace.Errorf("Cannot store keys. %s is not a directory", keyDir)
-		}
-	}
-	a = &LocalKeyAgent{
-		Agent:  agent.NewKeyring(),
-		KeyDir: keyDir,
-	}
-	keys, err := a.GetKeys()
+	ttl, err := ioutil.ReadFile(filepath.Join(dirPath, fileNameTTL))
 	if err != nil {
+		log.Error(err)
 		return nil, trace.Wrap(err)
 	}
-	for _, key := range keys {
-		if err := a.Add(key); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	var deadline time.Time
+	if err = deadline.UnmarshalJSON(ttl); err != nil {
+		log.Error(err)
+		return nil, trace.Wrap(err)
 	}
-	return a, nil
+	// this session key is expired
+	if deadline.Before(time.Now()) {
+		os.RemoveAll(dirPath)
+		return nil, trace.NotFound("session keys for %s are not found", host)
+	}
+	cert, err := ioutil.ReadFile(filepath.Join(dirPath, fileNameCert))
+	if err != nil {
+		log.Error(err)
+		return nil, trace.Wrap(err)
+	}
+	pub, err := ioutil.ReadFile(filepath.Join(dirPath, fileNamePub))
+	if err != nil {
+		log.Error(err)
+		return nil, trace.Wrap(err)
+	}
+	priv, err := ioutil.ReadFile(filepath.Join(dirPath, fileNameKey))
+	if err != nil {
+		log.Error(err)
+		return nil, trace.Wrap(err)
+	}
+	log.Infof("keystore.Get(%v)", host)
+	return &Key{
+		Pub:      pub,
+		Priv:     priv,
+		Cert:     cert,
+		Deadline: deadline,
+	}, nil
 }
 
-// initDefaultKeysDir initializes `~/.tsh` directory
-func initDefaultKeysDir() (dirPath string, err error) {
-	// construct `~/.tsh` path name:
-	u, err := user.Current()
-	if err != nil {
-		dirPath = os.TempDir()
-	} else {
-		dirPath = u.HomeDir
-	}
-	dirPath = filepath.Join(dirPath, ".tsh")
+func (fs *FSLocalKeyStore) AddKnownHost(hostname string, publicKeys []ssh.PublicKey) error {
+	return nil
+}
 
-	// need to create it?
-	_, err = os.Stat(dirPath)
-	if os.IsNotExist(err) {
-		err = os.MkdirAll(dirPath, os.ModeDir|0777)
-		if err != nil {
-			return "", trace.Wrap(err)
-		}
-	} else {
-		if err != nil {
+func (fs *FSLocalKeyStore) dirFor(hostname string) (string, error) {
+	dirPath := filepath.Join(fs.KeyDir, sessionKeyDir, hostname)
+	if !isDir(dirPath) {
+		if err := os.MkdirAll(dirPath, 0777); err != nil {
+			log.Error(err)
 			return "", trace.Wrap(err)
 		}
 	}
 	return dirPath, nil
 }
 
-// Key describes a key on disk
-type Key struct {
-	Priv     []byte    `json:"Priv,omitempty"`
-	Pub      []byte    `json:"Pub,omitempty"`
-	Cert     []byte    `json:"Cert,omitempty"`
-	Deadline time.Time `json:"Deadline,omitempty"`
-}
-
-func (a *LocalKeyAgent) saveKey(key *Key) error {
-	filename := filepath.Join(a.KeyDir, KeyFilePrefix+strconv.FormatInt(rand.Int63n(100), 16)+KeyFileSuffix)
-	bytes, err := json.Marshal(key)
-	if err != nil {
-		return trace.Wrap(err)
+func initKeysDir(dirPath string) (string, error) {
+	var err error
+	// not specified? use `~/.tsh`
+	if dirPath == "" {
+		u, err := user.Current()
+		if err != nil {
+			dirPath = os.TempDir()
+		} else {
+			dirPath = u.HomeDir
+		}
+		dirPath = filepath.Join(dirPath, defaultKeyDir)
 	}
-	return ioutil.WriteFile(filename, bytes, 0666)
-}
-
-func loadKey(filename string) (Key, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	// create if doesn't exist:
+	_, err = os.Stat(dirPath)
 	if err != nil {
-		return Key{}, trace.Wrap(err)
-	}
-
-	var key Key
-
-	err = json.Unmarshal(bytes, &key)
-	if err != nil {
-		return Key{}, trace.Wrap(err)
-	}
-
-	return key, nil
-
-}
-
-func (a *LocalKeyAgent) loadAllKeys() ([]Key, error) {
-	keys := make([]Key, 0)
-	files, err := ioutil.ReadDir(a.KeyDir)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	for _, file := range files {
-		fn := file.Name()
-		if !file.IsDir() && strings.HasPrefix(fn, KeyFilePrefix) && strings.HasSuffix(fn, KeyFileSuffix) {
-			fp := filepath.Join(a.KeyDir, file.Name())
-			key, err := loadKey(fp)
+		if os.IsNotExist(err) {
+			err = os.MkdirAll(dirPath, os.ModeDir|0777)
 			if err != nil {
-				log.Errorf(err.Error())
-				continue
+				return "", trace.Wrap(err)
 			}
-
-			if time.Now().Before(key.Deadline) {
-				keys = append(keys, key)
-			} else {
-				// remove old keys
-				err = os.Remove(fp)
-				if err != nil {
-					log.Errorf(err.Error())
-				}
-			}
+		} else {
+			return "", trace.Wrap(err)
 		}
 	}
-	return keys, nil
-}
 
-var (
-	KeyFilePrefix       = "teleport_"
-	KeyFileSuffix       = ".tkey"
-	HostSignersFilename = "hostsigners.db"
-)
+	return dirPath, nil
+}
 
 func isDir(dirPath string) bool {
 	fi, err := os.Stat(dirPath)

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -32,19 +32,19 @@ import (
 )
 
 const (
-	defaultKeyDir    = ".tsh"
-	sessionKeyDir    = "sessions"
-	fileNameCert     = "cert"
-	fileNameKey      = "key"
-	fileNamePub      = "pub"
-	fileNameTTL      = ".ttl"
-	fileNameKnownCAs = "known_cas"
+	defaultKeyDir      = ".tsh"
+	sessionKeyDir      = "sessions"
+	fileNameCert       = "cert"
+	fileNameKey        = "key"
+	fileNamePub        = "pub"
+	fileNameTTL        = ".ttl"
+	fileNameKnownHosts = "known_hosts"
 )
 
 // FSLocalKeyStore implements LocalKeyStore interface using the filesystem
 // Here's the file layout for the FS store:
 // ~/.tsh/
-// ├── known_cas     --> trusted certificate authorities (their keys) in a format similar to known_hosts
+// ├── known_hosts   --> trusted certificate authorities (their keys) in a format similar to known_hosts
 // └── sessions      --> server-signed session keys
 //     └── host-a
 //     |   ├── cert
@@ -184,7 +184,7 @@ func (fs *FSLocalKeyStore) GetKey(host string) (*Key, error) {
 
 // AddKnownHost adds a new entry to 'known_CAs' file
 func (fs *FSLocalKeyStore) AddKnownCA(domainName string, hostKeys []ssh.PublicKey) error {
-	fp, err := os.OpenFile(filepath.Join(fs.KeyDir, fileNameKnownCAs), os.O_CREATE|os.O_APPEND|os.O_RDWR, 0640)
+	fp, err := os.OpenFile(filepath.Join(fs.KeyDir, fileNameKnownHosts), os.O_CREATE|os.O_APPEND|os.O_RDWR, 0640)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -199,7 +199,7 @@ func (fs *FSLocalKeyStore) AddKnownCA(domainName string, hostKeys []ssh.PublicKe
 
 // GetKnownHost returns public keys of all trusted CAs
 func (fs *FSLocalKeyStore) GetKnownCAs() ([]ssh.PublicKey, error) {
-	bytes, err := ioutil.ReadFile(filepath.Join(fs.KeyDir, fileNameKnownCAs))
+	bytes, err := ioutil.ReadFile(filepath.Join(fs.KeyDir, fileNameKnownHosts))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2016 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	//log "github.com/Sirupsen/logrus"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/utils"
+	"gopkg.in/check.v1"
+)
+
+type KeyStoreTestSuite struct {
+	storeDir string
+	store    *FSLocalKeyStore
+	keygen   *testauthority.Keygen
+}
+
+var _ = check.Suite(&KeyStoreTestSuite{})
+
+func (s *KeyStoreTestSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
+	var err error
+	s.keygen = testauthority.New()
+	s.storeDir = c.MkDir()
+	s.store, err = NewFSLocalKeyStore(s.storeDir)
+	c.Assert(err, check.IsNil)
+	c.Assert(s.store, check.NotNil)
+	c.Assert(isDir(s.store.KeyDir), check.Equals, true)
+}
+
+func (s *KeyStoreTestSuite) TearDownSuite(c *check.C) {
+	os.RemoveAll(s.storeDir)
+}
+
+func (s *KeyStoreTestSuite) SetUpTest(c *check.C) {
+	os.RemoveAll(s.store.KeyDir)
+}
+
+func (s *KeyStoreTestSuite) TestListKeys(c *check.C) {
+	const keyNum = 5
+	// add 5 keys:
+	keys := make([]Key, keyNum)
+	for i := 0; i < keyNum; i++ {
+		key := s.makeSignedKey(c)
+		s.store.AddKey(fmt.Sprintf("host-%v", i), key)
+		keys[i] = *key
+	}
+	// read them all:
+	keys2, err := s.store.GetKeys()
+	c.Assert(err, check.IsNil)
+	c.Assert(keys, check.HasLen, keyNum)
+	c.Assert(keys, check.DeepEquals, keys2)
+}
+
+func (s *KeyStoreTestSuite) TestKeySaveLoad(c *check.C) {
+	key := s.makeSignedKey(c)
+	// add key:
+	err := s.store.AddKey("host.a", key)
+	c.Assert(err, check.IsNil)
+	// load back and compare:
+	keyCopy, err := s.store.GetKey("host.a")
+	c.Assert(err, check.IsNil)
+	c.Assert(key, check.DeepEquals, keyCopy)
+}
+
+func (s *KeyStoreTestSuite) TestKeyExpiration(c *check.C) {
+	// make two keys: one is current, and the expire one
+	good := s.makeSignedKey(c)
+	expired := s.makeSignedKey(c)
+	expired.Deadline = time.Now().Add(-time.Hour)
+
+	s.store.AddKey("good.host", good)
+	s.store.AddKey("expired.host", expired)
+
+	// get all keys back. only "good" key should be returned:
+	keys, _ := s.store.GetKeys()
+	c.Assert(keys, check.HasLen, 1)
+	c.Assert(keys[0], check.DeepEquals, *good)
+}
+
+// makeSIgnedKey helper returns all 3 components of a user key (signed by CAPriv key)
+func (s *KeyStoreTestSuite) makeSignedKey(c *check.C) *Key {
+	var (
+		err             error
+		priv, pub, cert []byte
+	)
+	priv, pub, _ = s.keygen.GenerateKeyPair("")
+	username := "vincento"
+	allowedLogins := []string{username, "root"}
+	ttl := time.Duration(time.Minute * 20)
+	cert, err = s.keygen.GenerateUserCert(CAPriv, pub, username, allowedLogins, ttl)
+	c.Assert(err, check.IsNil)
+	return &Key{
+		Priv:     priv,
+		Pub:      pub,
+		Cert:     cert,
+		Deadline: time.Now().Add(ttl),
+	}
+}
+
+var (
+	CAPriv = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwBgwn+vkjCcKEr2fbX1mLN555B9amVYfD/fUZBNbXKpHaqYn
+lM2WlyRR+xCrU9H/X6xT+wKJs1tsxFbxdBc1RWJtaqz/VpQCjomOulBzwumzB5hT
+pJfGblGjkPvpt1zwfmKdpBg0jxXUHHR4u4N6OX0dxd0ImRQ4W9QUtEqzgqToS5u4
+iwpeg6i1SoAdHBaSeqYhK9+nGrrJBAl/HVSgvL9tGn/+cQqlOiQz0t61V20+oMBA
+P+rOTIiwRXn98iMKFjzVW1HTL5Lwit3oJQX0Lrd/I6tN2De6TJxbbOOkF45V/P/k
+nBzbxV0fpnhcvZMnQqg1qdUmNVi6VC1O5qIPiwIDAQABAoIBAEg0T4KtLnkn63dj
+41tKeW+AKJ0A1BMy9fYQl7sOM5c/QhzqW5JpPKOPOWl/uIaHNtCFfAOrzoqmYNnk
+PFoApztvZeVlJY0rkVJ2jjmmJ/0pzuuZ7Ea/7gxlj2/d4NnVi2hWNR8LIiZudA5G
+EWOaZgTZ7KkFDkhL+2s46pdiRNtj7l5FXn2tCh7jmFgKS4m1/QqV9KdE5EjwB2mj
+BoP/j4V8O0RM05QpiYX/D5/Rr06tBavwTGW3vz/7OPIbf1el1mjfbLlt3z2tH0A5
+BSGB4JEwIZ3+2xlZokHy95OSDzE46TsSzgNx3SDzGRc8UnSZN9yunxnL4ej11WYt
+59YmD+ECgYEA3zxrDAtscpoxJSwcSkwqcMdElMK4D/BZw/tE9HhpHx3Pdd5XtMio
+CHUkkqxwGJeVIixDjwnl4VfA1s0wy3CtHq6mmwfUviYrH2eqxe5RxNyZOZguk6is
+GurZzD+ZfacsEIHyz2fZdnEAIFubu/S6x4TQPGg23oxnQpXXq1vzZFkCgYEA3Emz
+W4MXvYWvRdbn+W3onHz/vty9owj/BKSP6giPGrpQFdLs8yoBUw1yTOGqAIfuWMLS
+xvjULSlhei5PYD1xM2+B4luxM8K25DlqUpgRVtdmjQ/wxnzlmhDAPIMh7LUtw/6o
+JJ+diAKTI86T8tokIL7WFaSvzdrz7/WrZQWkpoMCgYAPVAK1rQMhS10chE7c+yXe
+4I/g9w3Ualh/kH1HnAz7yfw4x6+WBkEjc4ezWovH5ICk/A0XgUJ7mp7vIN+82FvK
+w4tFEeCVveEwItojBR4wOkV7Iuvvz6EhqAaUc7mCWzw3VfTqMONJsrCjiCbFXSSG
+FqSFwVIjLdjZRZitd37a4QKBgQDWfjjTIVlLY9EfWrszZu54+Ul4Sa2pAwh1N9sd
+kUnuR33VUjUALGVvvgcOjyieLb1J1iGwNfc7JjDQ7CjD1+/Smn/IrWlksfKtVK6P
+T5yKh2BGeEAEtPZHxom4IiM1PdEbJ2oHhxe3qHInCm2KqRdGfysrldjMw6aEfxxt
+WEpTCwKBgHLZYgNf/dGgWgw7bVu/k61jxw3yZuU/0marFOPINME/AnTcSAGnkC0S
+oDZhaPxjz3+2AHWAjUgW1ltTY8FsJYTOYsvzkYPfya4CgHCLg3D9ss1m4Rc7w5qo
+Fa6bvW5jo543NztjlKts7XYVqroMCu0sIMS7R4JGsmw3VJcnnMP2
+-----END RSA PRIVATE KEY-----`)
+
+	CAPub = []byte(`ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAGDCf6+SMJwoSvZ9tfWYs3nnkH1qZVh8P99RkE1tcqkdqpieUzZaXJFH7EKtT0f9frFP7AomzW2zEVvF0FzVFYm1qrP9WlAKOiY66UHPC6bMHmFOkl8ZuUaOQ++m3XPB+Yp2kGDSPFdQcdHi7g3o5fR3F3QiZFDhb1BS0SrOCpOhLm7iLCl6DqLVKgB0cFpJ6piEr36causkECX8dVKC8v20af/5xCqU6JDPS3rVXbT6gwEA/6s5MiLBFef3yIwoWPNVbUdMvkvCK3eglBfQut38jq03YN7pMnFts46QXjlX8/+ScHNvFXR+meFy9kydCqDWp1SY1WLpULU7mog+L ekontsevoy@turing`)
+)

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -106,14 +106,14 @@ func (s *KeyStoreTestSuite) TestKnownHosts(c *check.C) {
 	_, p2, _ := s.keygen.GenerateKeyPair("")
 	pub2, _, _, _, _ := ssh.ParseAuthorizedKey(p2)
 
-	err = s.store.AddKnownHost("example.com", []ssh.PublicKey{pub})
+	err = s.store.AddKnownCA("example.com", []ssh.PublicKey{pub})
 	c.Assert(err, check.IsNil)
-	err = s.store.AddKnownHost("example.com", []ssh.PublicKey{pub2})
+	err = s.store.AddKnownCA("example.com", []ssh.PublicKey{pub2})
 	c.Assert(err, check.IsNil)
-	err = s.store.AddKnownHost("example.org", []ssh.PublicKey{pub2})
+	err = s.store.AddKnownCA("example.org", []ssh.PublicKey{pub2})
 	c.Assert(err, check.IsNil)
 
-	keys, err := s.store.GetKnownHosts()
+	keys, err := s.store.GetKnownCAs()
 	c.Assert(err, check.IsNil)
 	c.Assert(keys, check.HasLen, 3)
 	c.Assert(keys, check.DeepEquals, []ssh.PublicKey{pub, pub2, pub2})

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -75,7 +75,7 @@ func InitLoggerForTests() {
 // FatalError is for CLI front-ends: it detects gravitational.Trace debugging
 // information, sends it to the logger, strips it off and prints a clean message to stderr
 func FatalError(err error) {
-	log.Errorf(err.Error())
+	log.Error(err)
 	fmt.Fprintln(os.Stderr, "ERROR: "+UserMessageFromError(err))
 	os.Exit(1)
 }


### PR DESCRIPTION
There are two parts to TSH key management: 
- trusted CA keys 
- session keys

Both have been stored in unmanageable format (BoltDB for CA keys and JSON for session keys). 
Also, there was no test coverage.

This commit replaces both with a simple file-based storage which looks like this:

```
~/.tsh
├── known_cas
└── sessions
    ├── example.com
    │   ├── cert
    │   ├── key
    │   └── pub
    └── test.org
        ├── cert
        ├── key
        └── pub
```

The format of these files is compatible with OpenSSH. 
100% test coverage.
Also when doing a code review I found a serious security issue #368

Fixes #368
Fixes #367
