### PR TITLE
Teleport was constantly asking for username+HOTP+password

### DIFF
--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -143,7 +143,7 @@ func (n *nauth) GenerateHostCert(privateSigningKey, publicKey []byte, hostname, 
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if ttl != 0 {
-		b := time.Now().UTC().Add(ttl)
+		b := time.Now().In(time.UTC).Add(ttl)
 		validBefore = uint64(b.UnixNano())
 	}
 	cert := &ssh.Certificate{
@@ -155,7 +155,6 @@ func (n *nauth) GenerateHostCert(privateSigningKey, publicKey []byte, hostname, 
 	cert.Permissions.Extensions = make(map[string]string)
 	cert.Permissions.Extensions[utils.CertExtensionRole] = string(role)
 	cert.Permissions.Extensions[utils.CertExtensionAuthority] = string(authDomain)
-
 	signer, err := ssh.ParsePrivateKey(privateSigningKey)
 	if err != nil {
 		return nil, err
@@ -179,8 +178,9 @@ func (n *nauth) GenerateUserCert(pkey, key []byte, teleportUsername string, allo
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if ttl != 0 {
-		b := time.Now().UTC().Add(ttl)
-		validBefore = uint64(b.Unix())
+		b := time.Now().In(time.UTC).Add(ttl)
+		validBefore = uint64(b.UnixNano())
+		log.Infof("generated user key for %v with expiry on (%v) %v", allowedLogins, validBefore, b)
 	}
 	// we do not use any extensions in users certs because of this:
 	// https://bugzilla.mindrot.org/show_bug.cgi?id=2387

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -78,7 +78,7 @@ func (n *Keygen) GenerateHostCert(pkey, key []byte, hostname, authDomain string,
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if ttl != 0 {
-		b := time.Now().UTC().Add(ttl)
+		b := time.Now().In(time.UTC).Add(ttl)
 		validBefore = uint64(b.UnixNano())
 	}
 	cert := &ssh.Certificate{
@@ -107,7 +107,7 @@ func (n *Keygen) GenerateUserCert(pkey, key []byte, teleportUsername string, all
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if ttl != 0 {
-		b := time.Now().UTC().Add(ttl)
+		b := time.Now().In(time.UTC).Add(ttl)
 		validBefore = uint64(b.UnixNano())
 	}
 	cert := &ssh.Certificate{

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -94,9 +94,6 @@ type Config struct {
 	// or use any local certs, and not use interactive logins
 	SkipLocalAuth bool
 
-	// AuthMethods if passed will be used to login into cluster
-	AuthMethods []ssh.AuthMethod
-
 	// Output is a writer, if not passed, stdout will be used
 	Output io.Writer
 
@@ -198,11 +195,6 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 
 	if tc.HostKeyCallback == nil {
 		tc.HostKeyCallback = tc.localAgent.CheckHostSignature
-	}
-
-	// add auth methods supplied by user if any
-	for _, method := range c.AuthMethods {
-		tc.authMethods = append(tc.authMethods, method)
 	}
 
 	// sometimes we need to use external auth without using local auth

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -94,6 +94,10 @@ type Config struct {
 	// or use any local certs, and not use interactive logins
 	SkipLocalAuth bool
 
+	// AuthMethods to use to login into cluster. If left empty, teleport will
+	// use its own session store,
+	AuthMethods []ssh.AuthMethod
+
 	// Output is a writer, if not passed, stdout will be used
 	Output io.Writer
 
@@ -154,8 +158,11 @@ func (c *Config) ProxySpecified() bool {
 // workflow built in
 type TeleportClient struct {
 	Config
-	localAgent  *LocalKeyAgent
-	authMethods []ssh.AuthMethod
+	localAgent *LocalKeyAgent
+}
+
+func (tc *TeleportClient) authMethods() []ssh.AuthMethod {
+	return tc.Config.AuthMethods
 }
 
 // NewClient creates a TeleportClient object and fully configures it
@@ -178,10 +185,7 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 		return nil, trace.Errorf("invalid requested cert TTL")
 	}
 
-	tc = &TeleportClient{
-		Config:      *c,
-		authMethods: make([]ssh.AuthMethod, 0),
-	}
+	tc = &TeleportClient{Config: *c}
 
 	// initialize the local agent (auth agent which uses local SSH keys signed by the CA):
 	tc.localAgent, err = NewLocalAgent("")
@@ -200,19 +204,19 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 	// sometimes we need to use external auth without using local auth
 	// methods, e.g. in automation daemons
 	if c.SkipLocalAuth {
-		if len(tc.authMethods) == 0 {
-			return nil, trace.BadParameter(
-				"SkipLocalAuth is true but no AuthMethods provided")
+		if len(c.AuthMethods) == 0 {
+			return nil, trace.BadParameter("SkipLocalAuth is true but no AuthMethods provided")
 		}
 		return tc, nil
 	}
+
 	// first, see if we can authenticate with credentials stored in
 	// a local SSH agent:
 	if sshAgent := connectToSSHAgent(); sshAgent != nil {
-		tc.authMethods = append(tc.authMethods, authMethodFromAgent(sshAgent))
+		tc.Config.AuthMethods = append(tc.Config.AuthMethods, authMethodFromAgent(sshAgent))
 	}
 	// then, we'll auth with the local agent keys:
-	tc.authMethods = append(tc.authMethods, authMethodFromAgent(tc.localAgent))
+	tc.Config.AuthMethods = append(tc.Config.AuthMethods, authMethodFromAgent(tc.localAgent))
 
 	return tc, nil
 }
@@ -671,7 +675,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 	log.Debugf("connecting to proxy: %v with host login %v", proxyAddr, sshConfig.User)
 
 	// try to authenticate using every non interactive auth method we have:
-	for _, m := range tc.authMethods {
+	for _, m := range tc.authMethods() {
 		sshConfig.Auth = []ssh.AuthMethod{m}
 		proxyClient, err := ssh.Dial("tcp", proxyAddr, sshConfig)
 		log.Infof("ssh.Dial error: %v", err)
@@ -686,7 +690,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 			Client:          proxyClient,
 			proxyAddress:    proxyAddr,
 			hostKeyCallback: sshConfig.HostKeyCallback,
-			authMethods:     tc.authMethods,
+			authMethods:     tc.authMethods(),
 			hostLogin:       tc.Config.HostLogin,
 			siteName:        tc.Config.SiteName,
 		}, nil
@@ -722,7 +726,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 		Client:          proxyClient,
 		proxyAddress:    proxyAddr,
 		hostKeyCallback: sshConfig.HostKeyCallback,
-		authMethods:     tc.authMethods,
+		authMethods:     tc.authMethods(),
 		hostLogin:       tc.Config.HostLogin,
 		siteName:        tc.Config.SiteName,
 	}, nil

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -85,7 +85,6 @@ func (proxy *ProxyClient) getSite() (*services.Site, error) {
 // GetSites returns list of the "sites" (AKA teleport clusters) connected to the proxy
 // Each site is returned as an instance of its auth server
 //
-// NOTE: this version of teleport supports only one site per proxy
 func (proxy *ProxyClient) GetSites() ([]services.Site, error) {
 	proxySession, err := proxy.Client.NewSession()
 	if err != nil {

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -51,8 +51,12 @@ func (k *Key) AsAgentKey() (*agent.AddedKey, error) {
 func (k *Key) CertValidBefore() (time.Time, error) {
 	pcert, _, _, _, err := ssh.ParseAuthorizedKey(k.Cert)
 	if err != nil {
-		return time.Now().UTC(), trace.Wrap(err)
+		return time.Now().In(time.UTC), trace.Wrap(err)
 	}
 	cert := pcert.(*ssh.Certificate)
-	return time.Unix(0, int64(cert.ValidBefore)).UTC(), nil
+
+	utime := int64(cert.ValidBefore)
+	etime := time.Unix(0, utime)
+
+	return etime.In(time.UTC), nil
 }

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -128,7 +128,6 @@ func (fs *FSLocalKeyStore) AddKey(host string, key *Key) error {
 	if err = writeBytes(fileNameKey, key.Priv); err != nil {
 		return trace.Wrap(err)
 	}
-	log.Infof("keystore.AddKey(%s)", host)
 	return nil
 }
 
@@ -165,8 +164,8 @@ func (fs *FSLocalKeyStore) GetKey(host string) (*Key, error) {
 	}
 	log.Infof("returning cert %v valid until %v", certFile, certExpiration)
 	if certExpiration.Before(time.Now().UTC()) {
+		log.Infof("TTL expired (%v) for session key %v", certExpiration, dirPath)
 		os.RemoveAll(dirPath)
-		log.Infof("TTL expired for session key %v", dirPath)
 		return nil, trace.NotFound("session keys for %s are not found", host)
 	}
 	return key, nil


### PR DESCRIPTION
The problem was in `time.Unix()` instead of `time.Unixnano()`
I'm not even sure how Unix() got in there...
