### PR TITLE
Removed some unnecessary warnigns/errors from the logs

### DIFF
--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -283,7 +283,9 @@ func (s *AuthTunnel) handleWebAgentRequest(sconn *ssh.ServerConn, ch ssh.Channel
 		return
 	}
 	if err := agent.ServeAgent(newKeyAgent, ch); err != nil {
-		log.Errorf("Serve agent err: %v", err)
+		if err != io.EOF {
+			log.Errorf("Serve agent err: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
In both cases there was no reason to log a warning/error, these are
normal return values (empty cookie or io.EOF at the end of agent serve)
