### PR TITLE
Introduce multi-role tokens

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -447,8 +447,8 @@ func (s *APIServer) generateUserCert(w http.ResponseWriter, r *http.Request, _ h
 }
 
 type generateTokenReq struct {
-	Role teleport.Role `json:"role"`
-	TTL  time.Duration `json:"ttl"`
+	Roles teleport.Roles `json:"roles"`
+	TTL   time.Duration  `json:"ttl"`
 }
 
 func (s *APIServer) generateToken(w http.ResponseWriter, r *http.Request, _ httprouter.Params) (interface{}, error) {
@@ -456,7 +456,7 @@ func (s *APIServer) generateToken(w http.ResponseWriter, r *http.Request, _ http
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	token, err := s.a.GenerateToken(req.Role, req.TTL)
+	token, err := s.a.GenerateToken(req.Roles, req.TTL)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -327,7 +327,7 @@ func (s *APISuite) TestReverseTunnels(c *C) {
 }
 
 func (s *APISuite) TestTokens(c *C) {
-	out, err := s.clt.GenerateToken("Node", 0)
+	out, err := s.clt.GenerateToken(teleport.Roles{teleport.RoleNode}, 0)
 	c.Assert(err, IsNil)
 	c.Assert(len(out), Not(Equals), 0)
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -97,11 +97,11 @@ func (a *AuthWithRoles) DeleteCertAuthority(id services.CertAuthID) error {
 	}
 	return a.authServer.DeleteCertAuthority(id)
 }
-func (a *AuthWithRoles) GenerateToken(role teleport.Role, ttl time.Duration) (string, error) {
+func (a *AuthWithRoles) GenerateToken(roles teleport.Roles, ttl time.Duration) (string, error) {
 	if err := a.permChecker.HasPermission(a.role, ActionGenerateToken); err != nil {
 		return "", trace.Wrap(err)
 	}
-	return a.authServer.GenerateToken(role, ttl)
+	return a.authServer.GenerateToken(roles, ttl)
 }
 func (a *AuthWithRoles) RegisterUsingToken(token, hostID string, role teleport.Role) (*PackedKeys, error) {
 	if err := a.permChecker.HasPermission(a.role, ActionRegisterUsingToken); err != nil {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -224,9 +224,9 @@ func (c *Client) DeleteCertAuthority(id services.CertAuthID) error {
 // and get signed certificate and private key from the auth server.
 //
 // The token can be used only once.
-func (c *Client) GenerateToken(role teleport.Role, ttl time.Duration) (string, error) {
+func (c *Client) GenerateToken(roles teleport.Roles, ttl time.Duration) (string, error) {
 	out, err := c.PostJSON(c.Endpoint("tokens"), generateTokenReq{
-		Role: role,
+		Roles: roles,
 	})
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -821,7 +821,7 @@ type ClientI interface {
 	UpsertCertAuthority(cert services.CertAuthority, ttl time.Duration) error
 	GetCertAuthorities(caType services.CertAuthType, loadKeys bool) ([]*services.CertAuthority, error)
 	DeleteCertAuthority(caType services.CertAuthID) error
-	GenerateToken(role teleport.Role, ttl time.Duration) (string, error)
+	GenerateToken(roles teleport.Roles, ttl time.Duration) (string, error)
 	RegisterUsingToken(token, hostID string, role teleport.Role) (*PackedKeys, error)
 	RegisterNewAuthServer(token string) error
 	UpsertNode(s services.Server, ttl time.Duration) error

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -61,10 +61,6 @@ type InitConfig struct {
 	// DataDir is the full path to the directory where keys, events and logs are kept
 	DataDir string
 
-	// AllowedTokens is a static set of allowed provisioning tokens
-	// auth server will recognize on the first start
-	AllowedTokens map[string]string
-
 	// ReverseTunnels is a list of reverse tunnels statically supplied
 	// in configuration, so auth server will init the tunnels on the first start
 	ReverseTunnels []services.ReverseTunnel
@@ -177,22 +173,6 @@ func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
 		}
 	}
 	if firstStart {
-		if len(cfg.AllowedTokens) != 0 {
-			log.Infof("FIRST START: Setting allowed provisioning tokens")
-			for token, domainName := range cfg.AllowedTokens {
-				log.Infof("FIRST START: upsert provisioning token: domainName: %v", domainName)
-				var role string
-				token, role, err = services.SplitTokenRole(token)
-				if err != nil {
-					return nil, nil, trace.Wrap(err)
-				}
-
-				if err := asrv.UpsertToken(token, role, 600*time.Second); err != nil {
-					return nil, nil, trace.Wrap(err)
-				}
-			}
-		}
-
 		if len(cfg.ReverseTunnels) != 0 {
 			log.Infof("FIRST START: Initializing reverse tunnels")
 			for _, tunnel := range cfg.ReverseTunnels {
@@ -201,7 +181,6 @@ func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
 				}
 			}
 		}
-
 		if len(cfg.OIDCConnectors) != 0 {
 			log.Infof("FIRST START: Initializing oidc connectors")
 			for _, connector := range cfg.OIDCConnectors {

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -147,7 +147,7 @@ func (aap *allowAllPermissions) HasPermission(role teleport.Role, action string)
 	return nil
 }
 
-var StandardRoles = []teleport.Role{
+var StandardRoles = teleport.Roles{
 	teleport.RoleAuth,
 	teleport.RoleUser,
 	teleport.RoleWeb,

--- a/lib/services/local/prov.go
+++ b/lib/services/local/prov.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
@@ -38,13 +39,12 @@ func NewProvisioningService(backend backend.Backend) *ProvisioningService {
 }
 
 // UpsertToken adds provisioning tokens for the auth server
-func (s *ProvisioningService) UpsertToken(token, role string, ttl time.Duration) error {
+func (s *ProvisioningService) UpsertToken(token string, roles teleport.Roles, ttl time.Duration) error {
 	if ttl < time.Second || ttl > defaults.MaxProvisioningTokenTTL {
 		ttl = defaults.MaxProvisioningTokenTTL
 	}
-
 	t := services.ProvisionToken{
-		Role: role,
+		Roles: roles,
 	}
 	out, err := json.Marshal(t)
 	if err != nil {

--- a/lib/services/provisioning.go
+++ b/lib/services/provisioning.go
@@ -19,13 +19,13 @@ package services
 import (
 	"time"
 
-	"github.com/gravitational/trace"
+	"github.com/gravitational/teleport"
 )
 
 // Provisioner governs adding new nodes to the cluster
 type Provisioner interface {
 	// UpsertToken adds provisioning tokens for the auth server
-	UpsertToken(token, role string, ttl time.Duration) error
+	UpsertToken(token string, roles teleport.Roles, ttl time.Duration) error
 
 	// GetToken finds and returns token by id
 	GetToken(token string) (*ProvisionToken, error)
@@ -34,33 +34,10 @@ type Provisioner interface {
 	DeleteToken(token string) error
 }
 
-func JoinTokenRole(token, role string) (ouputToken string, e error) {
-	switch role {
-	case TokenRoleAuth:
-		return "a" + token, nil
-	case TokenRoleNode:
-		return "n" + token, nil
-	}
-	return "", trace.BadParameter("unknown role: %v", role)
-}
-
-func SplitTokenRole(outputToken string) (token, role string, e error) {
-	if len(outputToken) <= 1 {
-		return outputToken, "", trace.BadParameter("unknown role: '%v'", role)
-	}
-	if outputToken[0] == 'n' {
-		return outputToken[1:], TokenRoleNode, nil
-	}
-	if outputToken[0] == 'a' {
-		return outputToken[1:], TokenRoleAuth, nil
-	}
-	return outputToken, "", trace.BadParameter("unknown role: '%v'")
-}
-
 // ProvisionToken stores metadata about some provisioning token
 type ProvisionToken struct {
-	Role string        `json:"role"`
-	TTL  time.Duration `json:"-"`
+	Roles teleport.Roles `json:"roles"`
+	TTL   time.Duration  `json:"-"`
 }
 
 const (

--- a/roles.go
+++ b/roles.go
@@ -9,6 +9,17 @@ import (
 
 // Role identifies the role of SSH server connection
 type Role string
+type Roles []Role
+
+// Includes returns 'true' if a given list of roles includes a given role
+func (roles Roles) Include(role Role) bool {
+	for _, r := range roles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}
 
 // Set sets the value of the role from string, used to integrate with CLI tools
 func (r *Role) Set(v string) error {


### PR DESCRIPTION
This commit:
- Makes all Teleport tokens multi-role (a token is associated with a list of roles its owner can assume)
- Removes some unused/obsolete features
   a) "AllowedTokens" config setting which we don't use
   b) "authorities" TCTL command
- Removes role-in-token encoding feature: it is redundant since roles are checked during token validation (they are stored in the database) anyway.

**Important**

It does not affect how Teleport works (it merely replaces `teleport.Role` with `[]teleport.Role` everywhere, a slice of 1 element), just preparing the plumbing for `--roles` flag for `tctl nodes add`
