### PR TITLE
Improved shell detection

### DIFF
--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -5,6 +5,15 @@ import (
 	"os"
 )
 
+// IsFile returns true if a given file path points to an existing file
+func IsFile(fp string) bool {
+	fi, err := os.Stat(fp)
+	if err == nil {
+		return !fi.IsDir()
+	}
+	return false
+}
+
 // IsDir is a helper function to quickly check if a given path is a valid directory
 func IsDir(dirPath string) bool {
 	fi, err := os.Stat(dirPath)

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -69,5 +69,9 @@ func (s *UtilsSuite) TestGetShell(c *check.C) {
 
 	shell, err = GetLoginShell("non-existent-user")
 	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Matches, ".*cannot determine shell for.*")
+	c.Assert(err.Error(), check.Matches, "user: unknown user non-existent-user")
+
+	shell, err = GetLoginShell("daemon")
+	c.Assert(err, check.IsNil)
+	c.Assert(shell == "/usr/sbin/nologin" || shell == "/usr/bin/false", check.Equals, true)
 }


### PR DESCRIPTION
Fixes #376 
I looked at the suggested patch: https://github.com/gravitational/teleport/files/234960/patch.txt 
It woks but it would be nice to avoid unsafe code. Instead, I've improved our existing detection.

It looks at `/etc/passwd` and walks backwards, looking at colon-separated values. When it finds the first existing file, it assumes it's shell (as opposed to grabbing the 6th position as before). 
