### PR TITLE
De-duplication of known_hosts

### DIFF
--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -128,6 +128,13 @@ func (s *KeyStoreTestSuite) TestKnownHosts(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(keys, check.HasLen, 3)
 	c.Assert(keys, check.DeepEquals, []ssh.PublicKey{pub, pub2, pub2})
+
+	// check against dupes:
+	before, _ := s.store.GetKnownCAs()
+	s.store.AddKnownCA("example.org", []ssh.PublicKey{pub2})
+	s.store.AddKnownCA("example.org", []ssh.PublicKey{pub2})
+	after, _ := s.store.GetKnownCAs()
+	c.Assert(len(before), check.Equals, len(after))
 }
 
 // makeSIgnedKey helper returns all 3 components of a user key (signed by CAPriv key)

--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -216,7 +216,7 @@ func (s *SrvSuite) TestShell(c *C) {
 	// send a few "keyboard inputs" into the session:
 	_, err = io.WriteString(writer, "echo $((50+100))\n\r")
 	c.Assert(err, IsNil)
-	time.Sleep(time.Millisecond * 3)
+	time.Sleep(time.Millisecond * 5)
 
 	// read the output and make sure that "150" (output of $((50+100)) is there
 	_, err = reader.Read(buf)


### PR DESCRIPTION
This commit avoids adding dupes to known_hosts.
Fixes #412

Implementation note: one of the goals was to work with `known_hosts` files that already contain duplicates (existing Teleport instances). 
