### PR TITLE
SCP/Exec improvements

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -497,18 +497,18 @@ behind `work.example.com`:
 
 ### Integrating with OpenSSH Servers
 
-Existing `sshd` servers can be added to a Teleport cluster. 
+Existing `sshd` servers can be added to a Teleport cluster. For that to work, you
+have to configure `sshd` to trust Teleport CA.
 
-1. First, you have to export the CA certificate into a file:
+Export the Teleport CA certificate into a file:
 
 ```bash
 > tctl authorities --type=user export > cluster-ca.pub
 ```
 
-2. Then you should copy this file to every node running `sshd`, for example 
-   `into /etc/ssh/teleport-ca.pub`
+Copy this file to every node running `sshd`, for example into `/etc/ssh/teleport-ca.pub`
+Then update the `sshd` configuration, usually `/etc/ssh/sshd_config`:
 
-3. Update `sshd` configuration, usually `/etc/ssh/sshd_config`:
 ```
 TrustedUserCAKeys /etc/ssh/user-ca.pub
 ```

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -128,7 +128,7 @@ func (s *IntSuite) TestAudit(c *check.C) {
 	go func() {
 		cl, err := t.NewClient(s.me.Username, Site, Host, t.GetPortSSHInt())
 		c.Assert(err, check.IsNil)
-		cl.Output = &myTerm
+		cl.Stdout = &myTerm
 
 		err = cl.SSH([]string{}, false, &myTerm)
 		endC <- err
@@ -280,7 +280,7 @@ func (s *IntSuite) TestInteractive(c *check.C) {
 	openSession := func() {
 		cl, err := t.NewClient(s.me.Username, Site, Host, t.GetPortSSHInt())
 		c.Assert(err, check.IsNil)
-		cl.Output = &personA
+		cl.Stdout = &personA
 		// Person A types something into the terminal (including "exit")
 		personA.Type("\aecho hi\n\r\aexit\n\r\a")
 		err = cl.SSH([]string{}, false, &personA)
@@ -302,7 +302,7 @@ func (s *IntSuite) TestInteractive(c *check.C) {
 		}
 		cl, err := t.NewClient(s.me.Username, Site, Host, t.GetPortSSHInt())
 		c.Assert(err, check.IsNil)
-		cl.Output = &personB
+		cl.Stdout = &personB
 		for i := 0; i < 10; i++ {
 			err = cl.Join(session.ID(sessionID), &personB)
 			if err == nil {
@@ -377,7 +377,7 @@ func (s *IntSuite) TestTwoSites(c *check.C) {
 
 	// directly:
 	tc, err := a.NewClient(username, "site-A", Host, sshPort)
-	tc.Output = &outputA
+	tc.Stdout = &outputA
 	c.Assert(err, check.IsNil)
 	err = tc.SSH(cmd, false, nil)
 	c.Assert(err, check.IsNil)
@@ -385,7 +385,7 @@ func (s *IntSuite) TestTwoSites(c *check.C) {
 
 	// via tunnel b->a:
 	tc, err = b.NewClient(username, "site-A", Host, sshPort)
-	tc.Output = &outputB
+	tc.Stdout = &outputB
 	c.Assert(err, check.IsNil)
 	err = tc.SSH(cmd, false, nil)
 	c.Assert(err, check.IsNil)

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -191,6 +191,10 @@ func (n *nauth) GenerateUserCert(pkey, key []byte, teleportUsername string, allo
 		ValidBefore:     validBefore,
 		CertType:        ssh.UserCert,
 	}
+	cert.Permissions.Extensions = map[string]string{
+		"permit-pty": "",
+	}
+
 	signer, err := ssh.ParsePrivateKey(pkey)
 	if err != nil {
 		return nil, err

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -192,7 +192,8 @@ func (n *nauth) GenerateUserCert(pkey, key []byte, teleportUsername string, allo
 		CertType:        ssh.UserCert,
 	}
 	cert.Permissions.Extensions = map[string]string{
-		"permit-pty": "",
+		"permit-pty":             "",
+		"permit-port-forwarding": "",
 	}
 
 	signer, err := ssh.ParsePrivateKey(pkey)

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -342,12 +342,8 @@ func (s *AuthTunnel) handleDirectTCPIPRequest(sconn *ssh.ServerConn, sshChannel 
 
 func (s *AuthTunnel) keyAuth(
 	conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-	cid := fmt.Sprintf(
-		"conn(%v->%v, user=%v)", conn.RemoteAddr(),
-		conn.LocalAddr(), conn.User())
 
-	log.Infof("%v auth attempt with key %v", cid, key.Type())
-
+	log.Infof("keyAuth: %v->%v, user=%v", conn.RemoteAddr(), conn.LocalAddr(), conn.User())
 	cert, ok := key.(*ssh.Certificate)
 	if !ok {
 		return nil, trace.Errorf("ERROR: Server doesn't support provided key type")

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -549,7 +549,6 @@ func NewTunClient(purpose string,
 	if user == "" {
 		return nil, trace.BadParameter("SSH connection requires a valid username")
 	}
-
 	tc := &TunClient{
 		purpose:           purpose,
 		user:              user,
@@ -570,14 +569,11 @@ func NewTunClient(purpose string,
 
 	// use local information about auth servers if it's available
 	if tc.addrStorage != nil {
-		authServers, err := tc.addrStorage.GetAddresses()
+		cachedAuthServers, err := tc.addrStorage.GetAddresses()
 		if err != nil {
-			if !trace.IsNotFound(err) {
-				return nil, trace.Wrap(err)
-			}
-			log.Infof("local storage is provided, not initialized")
+			log.Errorf("unable to load from auth server cache: %v", err)
 		} else {
-			tc.setAuthServers(authServers)
+			tc.setAuthServers(cachedAuthServers)
 		}
 	}
 	return tc, nil

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -101,7 +101,7 @@ func (a *LocalKeyAgent) AddHostSignersToCache(hostSigners []services.CertAuthori
 func (a *LocalKeyAgent) CheckHostSignature(hostId string, remote net.Addr, key ssh.PublicKey) error {
 	// TODO (ev) remove this!
 	// we're temporarily turning off host validation to experiment with OpenSSH servers
-	return nil
+	//return nil
 
 	cert, ok := key.(*ssh.Certificate)
 	if !ok {

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -99,9 +99,13 @@ func (a *LocalKeyAgent) AddHostSignersToCache(hostSigners []services.CertAuthori
 // CheckHostSignature checks if the given host key was signed by one of the trusted
 // certificaate authorities (CAs)
 func (a *LocalKeyAgent) CheckHostSignature(hostId string, remote net.Addr, key ssh.PublicKey) error {
+	// TODO (ev) remove this!
+	// we're temporarily turning off host validation to experiment with OpenSSH servers
+	return nil
+
 	cert, ok := key.(*ssh.Certificate)
 	if !ok {
-		return trace.BadParameter("expected certificate")
+		return trace.BadParameter("Cannot trust %v. Expected a certificate", remote.String())
 	}
 	keys, err := a.keyStore.GetKnownCAs()
 	if err != nil {

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -58,7 +58,6 @@ type execResponse struct {
 	cmdName string
 	cmd     *exec.Cmd
 	ctx     *ctx
-	isSCP   bool
 }
 
 // parseExecRequest parses SSH exec request
@@ -68,12 +67,10 @@ func parseExecRequest(req *ssh.Request, ctx *ctx) (*execResponse, error) {
 		return nil, fmt.Errorf("failed to parse exec request, error: %v", err)
 	}
 	// is this scp request?
-	isSCP := false
 	args := strings.Split(e.Command, " ")
 	if len(args) > 0 {
 		_, f := filepath.Split(args[0])
 		if f == "scp" {
-			isSCP = true
 			// for 'scp' requests, we'll fork ourselves with scp parameters:
 			teleportBin, err := osext.Executable()
 			if err != nil {
@@ -89,7 +86,6 @@ func parseExecRequest(req *ssh.Request, ctx *ctx) (*execResponse, error) {
 	return &execResponse{
 		ctx:     ctx,
 		cmdName: e.Command,
-		isSCP:   isSCP,
 	}, nil
 }
 

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -105,10 +105,6 @@ func (e *execResponse) String() string {
 // If args are empty, it means a simple shell must be launched
 // Otherwise, a shell launches with "-c args" as parameters
 func prepareOSCommand(ctx *ctx, args ...string) (*exec.Cmd, error) {
-
-	args = strings.Split(args[0], " ")
-	log.Infof("-----------------> ARGS: \n%v", strings.Join(args, "="))
-
 	osUserName := ctx.login
 	// configure UID & GID of the requested OS user:
 	osUser, err := user.Lookup(osUserName)
@@ -151,18 +147,14 @@ func prepareOSCommand(ctx *ctx, args ...string) (*exec.Cmd, error) {
 		}
 	}
 
-	/*
-		if len(args) > 0 {
-			orig := args
-			args = []string{"-c"}
-			args = append(args, orig...)
-		}
+	if len(args) > 0 {
+		orig := args
+		args = []string{"-c"}
+		args = append(args, orig...)
+	}
 
-
-		log.Infof("created OS command '%s' with params: '%v'", shellCommand, args)
-		c := exec.Command(shellCommand, args...)
-	*/
-	c := exec.Command(args[0], args[1:]...)
+	log.Infof("created OS command '%s' with params: '%v'", shellCommand, args)
+	c := exec.Command(shellCommand, args...)
 
 	c.Env = []string{
 		"TERM=xterm",
@@ -220,7 +212,6 @@ func (e *execResponse) start(sconn *ssh.ServerConn, shell string, ch ssh.Channel
 	}
 	// scp request? fork oursevles with scp flags and pipe SSH connection via stdin/out:
 	if e.isSCP {
-		log.Debugf("executing SCP commnand: %v", e.cmd.Args)
 		e.cmd.Stdin = ch
 		e.cmd.Stdout = ch
 		e.cmd.Stderr = os.Stderr

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -56,16 +56,16 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 		"LANG=en_US.UTF-8",
 		fmt.Sprintf("HOME=%s", s.usr.HomeDir),
 		fmt.Sprintf("USER=%s", s.usr.Username),
-		"SHELL=/bin/sh",
 		"SSH_TELEPORT_USER=galt",
 		"SSH_SESSION_WEBPROXY_ADDR=<proxyhost>:3080",
+		"SHELL=/bin/sh",
 		"SSH_CLIENT=10.0.0.5 4817 3022",
 		"SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022",
 		"SSH_SESSION_ID=xxx",
 	}
 
 	// empty command (simple shell)
-	cmd, err := prepareOSCommand(s.ctx)
+	cmd, err := prepareShell(s.ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(cmd, check.NotNil)
 	c.Assert(cmd.Path, check.Equals, "/bin/sh")
@@ -74,11 +74,11 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 	c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
 
 	// non-empty command (exec a prog)
-	cmd, err = prepareOSCommand(s.ctx, "ls -lh")
+	cmd, err = prepareCommand(s.ctx, "ls", "-lh", "/etc")
 	c.Assert(err, check.IsNil)
 	c.Assert(cmd, check.NotNil)
-	c.Assert(cmd.Path, check.Equals, "/bin/sh")
-	c.Assert(cmd.Args, check.DeepEquals, []string{"-sh", "-c", "ls -lh"})
+	c.Assert(cmd.Path, check.Equals, "/bin/ls")
+	c.Assert(cmd.Args, check.DeepEquals, []string{"ls", "-lh", "/etc"})
 	c.Assert(cmd.Dir, check.Equals, s.usr.HomeDir)
 	c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
 }

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -56,9 +56,9 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 		"LANG=en_US.UTF-8",
 		fmt.Sprintf("HOME=%s", s.usr.HomeDir),
 		fmt.Sprintf("USER=%s", s.usr.Username),
+		"SHELL=/bin/sh",
 		"SSH_TELEPORT_USER=galt",
 		"SSH_SESSION_WEBPROXY_ADDR=<proxyhost>:3080",
-		"SHELL=/bin/sh",
 		"SSH_CLIENT=10.0.0.5 4817 3022",
 		"SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022",
 		"SSH_SESSION_ID=xxx",
@@ -74,13 +74,20 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 	c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
 
 	// non-empty command (exec a prog)
-	cmd, err = prepareCommand(s.ctx, "ls", "-lh", "/etc")
+	s.ctx.isTestStub = true
+	cmd, err = prepareCommand(s.ctx, "ls -lh /etc")
 	c.Assert(err, check.IsNil)
 	c.Assert(cmd, check.NotNil)
-	c.Assert(cmd.Path, check.Equals, "/bin/ls")
-	c.Assert(cmd.Args, check.DeepEquals, []string{"ls", "-lh", "/etc"})
+	c.Assert(cmd.Path, check.Equals, "/bin/sh")
+	c.Assert(cmd.Args, check.DeepEquals, []string{"/bin/sh", "-c", "ls -lh /etc"})
 	c.Assert(cmd.Dir, check.Equals, s.usr.HomeDir)
 	c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
+
+	// command without args
+	cmd, err = prepareCommand(s.ctx, "top")
+	c.Assert(err, check.IsNil)
+	c.Assert(cmd.Path, check.Equals, "/usr/bin/top")
+	c.Assert(cmd.Args, check.DeepEquals, []string{"top"})
 }
 
 // implementation of ssh.Conn interface

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -446,7 +446,7 @@ func (s *session) startShell(ch ssh.Channel, ctx *ctx) error {
 		}
 	}
 	// prepare environment & Launch shell:
-	cmd, err := prepareOSCommand(ctx)
+	cmd, err := prepareShell(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -858,8 +858,7 @@ func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 		replyError(ch, req, err)
 		return trace.Wrap(err)
 	}
-	// TODO (ev): scp needs this:
-	if execResponse.isSCP {
+	if req.WantReply {
 		req.Reply(true, nil)
 	}
 	result, err := execResponse.start(ctx.conn, s.shell, ch)
@@ -881,14 +880,6 @@ func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 		if result != nil {
 			ctx.Infof("%v result collected: %v", execResponse, result)
 			ctx.sendResult(*result)
-
-			// TODO (ev): scp needs this:
-			if execResponse.isSCP {
-				_, err = ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: uint32(0)}))
-				if err != nil {
-					ctx.Errorf("failed to send scp exit status: %v", err)
-				}
-			}
 		}
 	}()
 	return nil

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -864,7 +864,7 @@ func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 	if req.WantReply {
 		req.Reply(true, nil)
 	}
-	result, err := execResponse.start(s.shell, ch)
+	result, err := execResponse.start(ch)
 	if err != nil {
 		ctx.Infof("error starting command, %v", err)
 		replyError(ch, req, err)

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -20,7 +20,6 @@ package srv
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -40,7 +39,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
-	"github.com/gravitational/teleport/lib/sshutils/scp"
 	"github.com/gravitational/teleport/lib/utils"
 
 	log "github.com/Sirupsen/logrus"
@@ -851,6 +849,8 @@ func (s *Server) handlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *ctx) error 
 
 // handleExec is responsible for executing 'exec' SSH requests (i.e. executing
 // a command after making an SSH connection)
+//
+// Note: this also handles 'scp' requests because 'scp' is a subset of "exec"
 func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 	execResponse, err := parseExecRequest(req, ctx)
 	if err != nil {
@@ -858,16 +858,10 @@ func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 		replyError(ch, req, err)
 		return trace.Wrap(err)
 	}
-
-	if scp.IsSCP(execResponse.cmdName) {
-		ctx.Infof("detected SCP command: %v", execResponse.cmdName)
-		if err := s.handleSCP(ch, req, ctx, execResponse.cmdName); err != nil {
-			ctx.Warningf("handleSCP() err: %v", err)
-			return trace.Wrap(err)
-		}
-		return ch.Close()
+	// TODO (ev): scp needs this:
+	if execResponse.isSCP {
+		req.Reply(true, nil)
 	}
-
 	result, err := execResponse.start(ctx.conn, s.shell, ch)
 	if err != nil {
 		ctx.Infof("error starting command, %v", err)
@@ -880,7 +874,6 @@ func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 	// in case if result is nil and no error, this means that program is
 	// running in the background
 	go func() {
-		ctx.Infof("%v waiting for result", execResponse)
 		result, err := execResponse.wait()
 		if err != nil {
 			ctx.Infof("%v wait failed: %v", execResponse, err)
@@ -888,34 +881,16 @@ func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 		if result != nil {
 			ctx.Infof("%v result collected: %v", execResponse, result)
 			ctx.sendResult(*result)
+
+			// TODO (ev): scp needs this:
+			if execResponse.isSCP {
+				_, err = ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: uint32(0)}))
+				if err != nil {
+					ctx.Errorf("failed to send scp exit status: %v", err)
+				}
+			}
 		}
 	}()
-	return nil
-}
-
-// handleSCP processes SSH requests for uploading or downloading files via `scp` command
-func (s *Server) handleSCP(ch ssh.Channel, req *ssh.Request, ctx *ctx, args string) error {
-	cmd, err := scp.ParseCommand(args, ctx.conn, s.alog)
-	if err != nil {
-		ctx.Warningf("failed to parse command: %v", cmd)
-		return trace.Wrap(err, fmt.Sprintf("failure to parse command '%v'", cmd))
-	}
-	ctx.Infof("handleSCP(cmd=%#v)", cmd)
-
-	cmdBytes, _ := json.MarshalIndent(cmd, "", "\t")
-	ctx.Infof("SCP command:\n%s\n", string(cmdBytes))
-
-	// TODO(klizhentas) current version of handling exec is incorrect.
-	// req.Reply should be sent as long as command start is done,
-	// not at the end. This is my fix for SCP only:
-	req.Reply(true, nil)
-	if err := cmd.Execute(ch); err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: uint32(0)}))
-	if err != nil {
-		ctx.Errorf("failed to send scp exit status: %v", err)
-	}
 	return nil
 }
 

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -78,7 +78,6 @@ func (cmd *Command) serveSource(ch io.ReadWriter) error {
 	log.Infof("SCP: serving source")
 
 	r := newReader(ch)
-
 	if err := r.read(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -219,7 +218,9 @@ func (cmd *Command) serveSink(ch io.ReadWriter) error {
 			continue
 		}
 
+		log.Infof(">> scanner.Scan()")
 		scanner.Scan()
+		log.Infof("<< scanner.Scan()")
 		if err := scanner.Err(); err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -34,7 +34,7 @@ import (
 
 // InitLoggerCLI tools by default log into syslog, not stderr
 func InitLoggerCLI() {
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(log.WarnLevel)
 	// clear existing hooks:
 	log.StandardLogger().Hooks = make(log.LevelHooks)
 	log.SetFormatter(&trace.TextFormatter{})

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -75,7 +75,7 @@ func InitLoggerForTests() {
 // FatalError is for CLI front-ends: it detects gravitational.Trace debugging
 // information, sends it to the logger, strips it off and prints a clean message to stderr
 func FatalError(err error) {
-	fmt.Fprintln(os.Stderr, "ERROR: "+UserMessageFromError(err))
+	fmt.Fprintln(os.Stderr, UserMessageFromError(err))
 	os.Exit(1)
 }
 

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -34,7 +34,7 @@ import (
 
 // InitLoggerCLI tools by default log into syslog, not stderr
 func InitLoggerCLI() {
-	log.SetLevel(log.WarnLevel)
+	log.SetLevel(log.DebugLevel)
 	// clear existing hooks:
 	log.StandardLogger().Hooks = make(log.LevelHooks)
 	log.SetFormatter(&trace.TextFormatter{})

--- a/lib/utils/storage.go
+++ b/lib/utils/storage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
 )
 
@@ -30,6 +31,7 @@ func (fs *FileAddrStorage) SetAddresses(addrs []NetAddr) error {
 	}
 	err = ioutil.WriteFile(fs.filePath, bytes, 0666)
 	if err != nil {
+		log.Error(err)
 		return trace.ConvertSystemError(err)
 	}
 	return nil
@@ -39,12 +41,15 @@ func (fs *FileAddrStorage) SetAddresses(addrs []NetAddr) error {
 func (fs *FileAddrStorage) GetAddresses() ([]NetAddr, error) {
 	bytes, err := ioutil.ReadFile(fs.filePath)
 	if err != nil {
+		log.Error(err)
 		return nil, trace.ConvertSystemError(err)
 	}
 	var addrs []NetAddr
-	err = json.Unmarshal(bytes, &addrs)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if len(bytes) > 0 {
+		err = json.Unmarshal(bytes, &addrs)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return addrs, nil
 }

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -155,12 +155,12 @@ func main() {
 	// operations with authorities
 	auth := app.Command("authorities", "Operations with user and host certificate authorities").Hidden()
 	auth.Flag("type", "authority type, 'user' or 'host'").Default(string(services.UserCA)).StringVar(&cmdAuth.authType)
-	authList := auth.Command("ls", "List trusted user certificate authorities").Hidden()
-	authExport := auth.Command("export", "Export concatenated keys to standard output").Hidden()
+	authList := auth.Command("ls", "List trusted user certificate authorities")
+	authExport := auth.Command("export", "Export concatenated keys to standard output")
 	authExport.Flag("private-keys", "if set, will print private keys").BoolVar(&cmdAuth.exportPrivateKeys)
 	authExport.Flag("fingerprint", "filter authority by fingerprint").StringVar(&cmdAuth.exportAuthorityFingerprint)
 
-	authGenerate := auth.Command("gen", "Generate new OpenSSH keypair").Hidden()
+	authGenerate := auth.Command("gen", "Generate new OpenSSH keypair")
 	authGenerate.Flag("pub-key", "path to the public key to write").Required().StringVar(&cmdAuth.genPubPath)
 	authGenerate.Flag("priv-key", "path to the private key to write").Required().StringVar(&cmdAuth.genPrivPath)
 

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -225,12 +225,9 @@ func onSCP(cmd *scp.Command) (err error) {
 		}
 	}
 	if !cmd.Source && !cmd.Sink {
-		log.Errorf("remote mode is not supported")
 		return trace.Errorf("remote mode is not supported")
 	}
-	log.Errorf("%v", os.Args[1:])
-	cmd.Execute(&StdReadWriter{})
-	return nil
+	return trace.Wrap(cmd.Execute(&StdReadWriter{}))
 }
 
 type StdReadWriter struct {

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -204,6 +204,8 @@ func onConfigDump() {
 //
 // This is the entry point of "teleport scp" call (the parent process is the teleport daemon)
 func onSCP(cmd *scp.Command) (err error) {
+	utils.InitLoggerDebug()
+
 	// get user's home dir (it serves as a default destination)
 	cmd.User, err = user.Current()
 	if err != nil {

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -204,8 +204,6 @@ func onConfigDump() {
 //
 // This is the entry point of "teleport scp" call (the parent process is the teleport daemon)
 func onSCP(cmd *scp.Command) (err error) {
-	utils.InitLoggerDebug()
-
 	// get user's home dir (it serves as a default destination)
 	cmd.User, err = user.Current()
 	if err != nil {

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -356,6 +356,7 @@ func makeClient(cf *CLIConf) (tc *client.TeleportClient, err error) {
 	c := &client.Config{
 		Stdout:             os.Stdout,
 		Stderr:             os.Stderr,
+		Stdin:              os.Stdin,
 		Username:           cf.Username,
 		ProxyHost:          cf.Proxy,
 		Host:               cf.UserHost,

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -242,9 +242,13 @@ func onSSH(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-
 	if err = tc.SSH(cf.RemoteCommand, cf.LocalExec, nil); err != nil {
-		utils.FatalError(err)
+		// exit with the same exit status as the failed command:
+		if tc.ExitStatus != 0 {
+			os.Exit(tc.ExitStatus)
+		} else {
+			utils.FatalError(err)
+		}
 	}
 }
 
@@ -270,7 +274,12 @@ func onSCP(cf *CLIConf) {
 		utils.FatalError(err)
 	}
 	if err := tc.SCP(cf.CopySpec, int(cf.NodePort), cf.RecursiveCopy); err != nil {
-		utils.FatalError(err)
+		// exit with the same exit status as the failed command:
+		if tc.ExitStatus != 0 {
+			os.Exit(tc.ExitStatus)
+		} else {
+			utils.FatalError(err)
+		}
 	}
 }
 
@@ -345,7 +354,8 @@ func makeClient(cf *CLIConf) (tc *client.TeleportClient, err error) {
 
 	// prep client config:
 	c := &client.Config{
-		Output:             os.Stdout,
+		Stdout:             os.Stdout,
+		Stderr:             os.Stderr,
 		Username:           cf.Username,
 		ProxyHost:          cf.Proxy,
 		Host:               cf.UserHost,

--- a/vendor/github.com/gravitational/trace/errors.go
+++ b/vendor/github.com/gravitational/trace/errors.go
@@ -242,7 +242,7 @@ func ConvertSystemError(err error) error {
 	switch realErr := innerError.(type) {
 	case *net.OpError:
 		return wrap(&ConnectionProblemError{
-			Message: fmt.Sprintf("failed to connect to server %v", realErr.Addr),
+			Message: fmt.Sprintf("failed to connecting to %v", realErr.Addr),
 			Err:     realErr}, 2)
 	case *os.PathError:
 		return wrap(&AccessDeniedError{


### PR DESCRIPTION
## List of changes
- `scp` implementation reuses exec infrastructure: it launches teleport via exec under the requested OS login/mapping.
- `exec` implementation separates stdout and stderr
- `exec` implementation correctly passes the process exit code and `tsh` re-uses that code in turn passing it to the caller
- error reporting has been improved: you get proper stderr without duplicates
- logs are more useful (important errors are now logged, and excessive loggign around execution has been trimmed).
## Misc bugfixes
- Invalid JSON in /var/lib/teleport/authservers.json does not prevent teleport from starting 
- That JSON file was parsed twice, I removed the dupe.
## TODO

Audit log does not provide the detailed (per-file) information about `scp` operations. You only get to see higher level scp commands.
