### PR TITLE
Permissions adjustment for data dir

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -99,14 +99,8 @@ func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
 		return nil, nil, trace.BadParameter("HostUUID: host UUID can not be empty")
 	}
 
-	err := os.MkdirAll(cfg.DataDir, os.ModeDir|0777)
-	if err != nil {
-		log.Errorf(err.Error())
-		return nil, nil, err
-	}
-
 	lockService := local.NewLockService(cfg.Backend)
-	err = lockService.AcquireLock(cfg.DomainName, 60*time.Second)
+	err := lockService.AcquireLock(cfg.DomainName, 60*time.Second)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -167,7 +167,7 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 	// create the data directory if it's missing
 	_, err := os.Stat(cfg.DataDir)
 	if os.IsNotExist(err) {
-		err := os.MkdirAll(cfg.DataDir, os.ModeDir|0777)
+		err := os.MkdirAll(cfg.DataDir, os.ModeDir|0700)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
### Problem

Teleport's data dir (`/var/lib/teleport` by default) was created using
umask. Now it's created with `0600` (readable only by Teleport user).
### Other Changes

Also there was some redundancy - the data directory was created twice.
