### PR TITLE
A bunch of configuration fixes.

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -162,6 +162,10 @@ teleport:
     # by default it's equal to hostname
     nodename: graviton
 
+    # Data directory where Teleport keeps its data, like keys/users for 
+    # authentication (if using the default BoltDB back-end)
+    data_dir: /var/lib/teleport
+
     # one-time invitation token used to join a cluster. it is not used on 
     # subsequent starts
     auth_token: xxxx-token-xxxx
@@ -192,7 +196,6 @@ teleport:
     # backend if you want to run Teleport in HA configuration.
     storage:
         type: bolt
-        data_dir: /var/lib/teleport
 
 # This section configures the 'auth service':
 auth_service:

--- a/fixtures/local-cluster.yaml
+++ b/fixtures/local-cluster.yaml
@@ -1,0 +1,16 @@
+# Simple config file with just a few customizations (with comments)
+teleport:
+  nodename: localhost
+  # auth token allows easy adding of other nodes. pass this value
+  # as --token when starting nodes.
+  auth_token: OhwiZ2ainushemith1oquiex
+  log:
+    output: stderr
+    severity: INFO
+auth_service:
+  enabled: yes
+  cluster_name: teleport.local
+ssh_service:
+  enabled: yes
+proxy_service:
+  enabled: yes

--- a/fixtures/tmp-cluster.yaml
+++ b/fixtures/tmp-cluster.yaml
@@ -1,0 +1,22 @@
+# This config file creates a single node teleport cluster with all
+# its data in /tmp 
+#
+# All listening ports are changed as well
+#
+teleport:
+  nodename: tmp.localhost
+  auth_token: Tex7siequoo9eew4Eitoo1ni
+  data_dir: /tmp/teleport
+  log:
+    output: stderr
+    severity: INFO
+auth_service:
+  enabled: yes
+  cluster_name: teleport.tmp
+  listen_addr: 0.0.0.0:5010
+ssh_service:
+  enabled: yes
+  listen_addr: 0.0.0.0:5011
+proxy_service:
+  listen_addr: 0.0.0.0:5012
+  enabled: yes

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -197,6 +197,7 @@ func (i *TeleInstance) Create(trustedSecrets []*InstanceSecrets, enableSSH bool,
 		return err
 	}
 	tconf := service.MakeDefaultConfig()
+	tconf.DataDir = dataDir
 	tconf.Console = console
 	tconf.Auth.DomainName = i.Secrets.SiteName
 	tconf.Auth.Authorities = append(tconf.Auth.Authorities, i.Secrets.GetCAs()...)
@@ -221,9 +222,8 @@ func (i *TeleInstance) Create(trustedSecrets []*InstanceSecrets, enableSSH bool,
 	tconf.Proxy.SSHAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortProxy())
 	tconf.Proxy.WebAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortWeb())
 	tconf.Proxy.DisableWebUI = true
-	tconf.AuthServers[0].Addr = tconf.Auth.SSHAddr.Addr
-	tconf.ConfigureBolt(dataDir)
-	tconf.DataDir = dataDir
+	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.SSHAddr)
+	tconf.ConfigureBolt()
 	tconf.Keygen = testauthority.New()
 	i.Config = tconf
 	i.Process, err = service.NewTeleport(tconf)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -689,6 +689,7 @@ func (s *APIServer) createUserWithToken(w http.ResponseWriter, r *http.Request, 
 	}
 	sess, err := s.a.CreateUserWithToken(req.Token, req.Password, req.HOTPToken)
 	if err != nil {
+		log.Error(err)
 		return nil, trace.Wrap(err)
 	}
 	return sess, nil

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -578,7 +578,7 @@ func NewTunClient(purpose string,
 	for _, o := range opts {
 		o(tc)
 	}
-	log.Infof("newTunClient(%s)", purpose)
+	log.Infof("newTunClient(%s) with auth: %v", purpose, authServers)
 
 	clt, err := NewClient("http://stub:0", tc.Dial)
 	if err != nil {
@@ -645,7 +645,7 @@ func (c *TunClient) GetAgent() (AgentCloser, error) {
 
 // Dial dials to Auth server's HTTP API over SSH tunnel
 func (c *TunClient) Dial(network, address string) (net.Conn, error) {
-	log.Infof("TunClient[%s].Dial(%v, %v)", c.purpose, network, address)
+	log.Infof("TunClient[%s].Dial()", c.purpose)
 	client, err := c.getClient()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -762,6 +762,7 @@ func (c *TunClient) getClient() (client *ssh.Client, err error) {
 	if len(authServers) == 0 {
 		return nil, trace.Errorf("all auth servers are offline")
 	}
+	log.Infof("tunClient(%s).authServers: %v", c.purpose, authServers)
 
 	// try to connect to the 1st one who will pick up:
 	for _, authServer := range authServers {

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -98,7 +98,7 @@ func (s *ConfigTestSuite) TestSampleConfig(c *check.C) {
 
 	// validate a couple of values:
 	c.Assert(fc.Limits.MaxUsers, check.Equals, defaults.LimiterMaxConcurrentUsers)
-	c.Assert(fc.Global.Storage.DirName, check.Equals, defaults.DataDir)
+	c.Assert(fc.Global.DataDir, check.Equals, defaults.DataDir)
 	c.Assert(fc.Logger.Severity, check.Equals, "INFO")
 
 }
@@ -134,7 +134,7 @@ func (s *ConfigTestSuite) TestConfigReading(c *check.C) {
 	c.Assert(conf.Logger.Output, check.Equals, "stderr")
 	c.Assert(conf.Logger.Severity, check.Equals, "INFO")
 	c.Assert(conf.Storage.Type, check.Equals, "bolt")
-	c.Assert(conf.Storage.DirName, check.Equals, "/var/lib/teleport")
+	c.Assert(conf.DataDir, check.Equals, "/path/to/data")
 	c.Assert(conf.Auth.Enabled(), check.Equals, true)
 	c.Assert(conf.Auth.ListenAddress, check.Equals, "tcp://auth")
 	c.Assert(conf.SSH.Configured(), check.Equals, true)
@@ -330,6 +330,7 @@ func makeConfigFixture() string {
 
 	// common config:
 	conf.NodeName = NodeName
+	conf.DataDir = "/path/to/data"
 	conf.AuthServers = AuthServers
 	conf.Limits.MaxConnections = 100
 	conf.Limits.MaxUsers = 5
@@ -337,7 +338,6 @@ func makeConfigFixture() string {
 	conf.Logger.Output = "stderr"
 	conf.Logger.Severity = "INFO"
 	conf.Storage.Type = "bolt"
-	conf.Storage.DirName = "/var/lib/teleport"
 
 	// auth service:
 	conf.Auth.EnabledFlag = "Yeah"

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -198,7 +198,7 @@ func MakeSampleFileConfig() (fc *FileConfig) {
 	g.AuthServers = []string{defaults.AuthListenAddr().Addr}
 	g.Limits.MaxConnections = defaults.LimiterMaxConnections
 	g.Limits.MaxUsers = defaults.LimiterMaxConcurrentUsers
-	g.Storage.DirName = defaults.DataDir
+	g.DataDir = defaults.DataDir
 	g.Storage.Type = conf.Auth.RecordsBackend.Type
 	g.PIDFile = "/var/run/teleport.pid"
 
@@ -259,7 +259,6 @@ func MakeAuthPeerFileConfig(domainName string, token string) (fc *FileConfig) {
 	g.AuthServers = []string{"<insert auth server peer address here>"}
 	g.Limits.MaxConnections = defaults.LimiterMaxConnections
 	g.Limits.MaxUsers = defaults.LimiterMaxConcurrentUsers
-	g.Storage.DirName = defaults.DataDir
 	g.Storage.Type = teleport.ETCDBackendType
 	g.Storage.Prefix = defaults.ETCDPrefix
 	g.Storage.Peers = []string{"insert ETCD peers addresses here"}
@@ -318,8 +317,6 @@ type Log struct {
 type StorageBackend struct {
 	// Type can be "bolt" or "etcd"
 	Type string `yaml:"type,omitempty"`
-	// DirName is valid only for bolt
-	DirName string `yaml:"data_dir,omitempty"`
 	// Peers is a lsit of etcd peers,  valid only for etcd
 	Peers []string `yaml:"peers,omitempty"`
 	// Prefix is etcd key prefix, valid only for etcd
@@ -342,6 +339,7 @@ type Global struct {
 	Logger      Log              `yaml:"log,omitempty"`
 	Storage     StorageBackend   `yaml:"storage,omitempty"`
 	AdvertiseIP net.IP           `yaml:"advertise_ip,omitempty"`
+	DataDir     string           `yaml:"data_dir,omitempty"`
 
 	// Keys holds the list of SSH key/cert pairs used by all services
 	// Each service (like proxy, auth, node) can find the key it needs

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -122,22 +122,22 @@ func (cfg *Config) ApplyToken(token string) bool {
 }
 
 // ConfigureBolt configures Bolt back-ends with a data dir.
-func (cfg *Config) ConfigureBolt(dataDir string) {
+func (cfg *Config) ConfigureBolt() {
 	a := &cfg.Auth
 
 	if a.EventsBackend.Type == teleport.BoltBackendType {
-		a.EventsBackend.Params = boltParams(dataDir, defaults.EventsBoltFile)
+		a.EventsBackend.Params = boltParams(cfg.DataDir, defaults.EventsBoltFile)
 	}
 	if a.KeysBackend.Type == teleport.BoltBackendType {
-		a.KeysBackend.Params = boltParams(dataDir, defaults.KeysBoltFile)
+		a.KeysBackend.Params = boltParams(cfg.DataDir, defaults.KeysBoltFile)
 	}
 	if a.RecordsBackend.Type == teleport.BoltBackendType {
-		a.RecordsBackend.Params = boltParams(dataDir, defaults.RecordsBoltFile)
+		a.RecordsBackend.Params = boltParams(cfg.DataDir, defaults.RecordsBoltFile)
 	}
 }
 
 // ConfigureETCD configures ETCD backend (still uses BoltDB for some cases)
-func (cfg *Config) ConfigureETCD(dataDir string, etcdCfg etcdbk.Config) error {
+func (cfg *Config) ConfigureETCD(etcdCfg etcdbk.Config) error {
 	a := &cfg.Auth
 
 	params, err := etcdParams(etcdCfg)
@@ -149,10 +149,10 @@ func (cfg *Config) ConfigureETCD(dataDir string, etcdCfg etcdbk.Config) error {
 
 	// We can't store records and events in ETCD
 	a.EventsBackend.Type = teleport.BoltBackendType
-	a.EventsBackend.Params = boltParams(dataDir, defaults.EventsBoltFile)
+	a.EventsBackend.Params = boltParams(cfg.DataDir, defaults.EventsBoltFile)
 
 	a.RecordsBackend.Type = teleport.BoltBackendType
-	a.RecordsBackend.Params = boltParams(dataDir, defaults.RecordsBoltFile)
+	a.RecordsBackend.Params = boltParams(cfg.DataDir, defaults.RecordsBoltFile)
 	return nil
 }
 
@@ -313,9 +313,6 @@ func ApplyDefaults(cfg *Config) {
 	// global defaults
 	cfg.Hostname = hostname
 	cfg.DataDir = defaults.DataDir
-	if cfg.Auth.Enabled {
-		cfg.AuthServers = []utils.NetAddr{cfg.Auth.SSHAddr}
-	}
 	cfg.Console = os.Stdout
 }
 

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -54,11 +54,9 @@ func (s *ConfigSuite) TestDefaultConfig(c *C) {
 	if len(config.Hostname) < 2 {
 		c.Error("default hostname wasn't properly set")
 	}
-	c.Assert(config.AuthServers, DeepEquals, []utils.NetAddr{localAuthAddr})
 
 	// auth section
 	auth := config.Auth
-	c.Assert(config.AuthServers, DeepEquals, []utils.NetAddr{auth.SSHAddr})
 	c.Assert(auth.SSHAddr, DeepEquals, localAuthAddr)
 	c.Assert(auth.Limiter.MaxConnections, Equals, int64(defaults.LimiterMaxConnections))
 	c.Assert(auth.Limiter.MaxNumberOfUsers, Equals, defaults.LimiterMaxConcurrentUsers)


### PR DESCRIPTION
## Changes:

```
1. data_dir is now a global setting in teleport.yaml (instead of being
   inside of "storage" sub-section)

2. changing data_dir in one place causes all of teleport to use it,
   not just bolt backends.

3. moving auth server to listen on non-default ports properly adjusts
   the global auth_servers setting

4. `tctl` now accepts -c flag just like Teleport, so you can pass
   `teleprot.yaml` to it.
```

Fixes #432
Fixes #431
Fixes #430
## Other Changes

`tctl rts` command was renamed to `tctl tunnels`
