### PR TITLE
Changed how self-signed HTTPS cert is generated

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -766,7 +766,6 @@ func initSelfSignedHTTPSCert(cfg *Config) (err error) {
 
 	keyPath := filepath.Join(cfg.DataDir, defaults.SelfSignedKeyPath)
 	certPath := filepath.Join(cfg.DataDir, defaults.SelfSignedCertPath)
-	pubPath := filepath.Join(cfg.DataDir, defaults.SelfSignedPubPath)
 
 	cfg.Proxy.TLSKey = keyPath
 	cfg.Proxy.TLSCert = certPath
@@ -791,9 +790,6 @@ func initSelfSignedHTTPSCert(cfg *Config) (err error) {
 	}
 	if err := ioutil.WriteFile(certPath, creds.Cert, 0600); err != nil {
 		return trace.Wrap(err, "error writing key PEM")
-	}
-	if err := ioutil.WriteFile(pubPath, creds.PublicKey, 0600); err != nil {
-		return trace.Wrap(err, "error writing pub key PEM")
 	}
 	return nil
 }

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -111,25 +111,28 @@ func GenerateSelfSignedCert(hostNames []string) (*TLSCredentials, error) {
 
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
+		Issuer: pkix.Name{
+			CommonName:   "*",
+			Organization: []string{"Self-signed certificate. Make sure to replace!"},
+		},
 		Subject: pkix.Name{
-			Organization: []string{"Acme Co"},
+			CommonName:   "*",
+			Organization: []string{"Self-signed certificate. Make sure to replace!"},
 		},
 		NotBefore: notBefore,
 		NotAfter:  notAfter,
 
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		IsCA: true,
 	}
 
 	// collect IP addresses localhost resolves to and add them to the cert. template:
-	template.DNSNames = hostNames
+	template.DNSNames = append(hostNames, "*")
 	ips, _ := net.LookupIP("localhost")
 	if ips != nil {
 		template.IPAddresses = ips
 	}
-
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -49,7 +49,7 @@ func (s *UtilsSuite) TestSelfSignedCert(c *check.C) {
 	c.Assert(creds, check.NotNil)
 	c.Assert(len(creds.PublicKey)/100, check.Equals, 4)
 	c.Assert(len(creds.PrivateKey)/100, check.Equals, 16)
-	c.Assert(len(creds.Cert)/100, check.Equals, 11)
+	c.Assert(len(creds.Cert)/100, check.Equals, 12)
 }
 
 func (s *UtilsSuite) TestRandomDuration(c *check.C) {

--- a/vagrant/libvirt/data/b-auth/teleport.yaml
+++ b/vagrant/libvirt/data/b-auth/teleport.yaml
@@ -11,7 +11,7 @@ auth_service:
   listen_addr: 0.0.0.0:3025
 
 ssh_service:
-  enabled: no
+  enabled: yes
 
 proxy_service:
-  enabled: no
+  enabled: yes


### PR DESCRIPTION
Fixes #434

Changes:
- Certificate is not "CA" anymore
- Added `*` for CN field

Also, removed saving of the public key, that file is not needed.
