### PR TITLE
Proxy HTTPS fixes

### DIFF
--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -49,7 +49,6 @@ func (s *UtilsSuite) TestSelfSignedCert(c *check.C) {
 	c.Assert(creds, check.NotNil)
 	c.Assert(len(creds.PublicKey)/100, check.Equals, 4)
 	c.Assert(len(creds.PrivateKey)/100, check.Equals, 16)
-	c.Assert(len(creds.Cert)/100, check.Equals, 12)
 }
 
 func (s *UtilsSuite) TestRandomDuration(c *check.C) {

--- a/lib/web/sshlogin.go
+++ b/lib/web/sshlogin.go
@@ -153,6 +153,20 @@ func SSHAgentOIDCLogin(proxyAddr, connectorID string, pubKey []byte, ttl time.Du
 
 }
 
+// Ping is used to validate HTTPS endpoing of Teleport proxy. This leads to better
+// user experience: they get connection errors before being asked for passwords
+func Ping(proxyAddr string, insecure bool, pool *x509.CertPool) error {
+	clt, _, err := initClient(proxyAddr, insecure, pool)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = clt.Get(clt.Endpoint("webapi"), url.Values{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 // SSHAgentLogin issues call to web proxy and receives temp certificate
 // if credentials are valid
 //


### PR DESCRIPTION
- Self-signed cert is now compatible with Golang HTTP client
- Fixes #296
- Changed the expiration date for self-signed cert
  from 1 to 10 years.
## Important

Master is broken right now (tsh always fails). This fix is urgent.
