### PR TITLE
tsh logout implementation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -148,7 +148,7 @@ db            xxxxx-xxxx-xxxx-xxxxxxx     10.0.10.2:3022     location=virginia,a
 Let's use the newly created labels to filter the output of `tsh ls` and ask to show only
 nodes located in Virginia:
 
-```
+```bash
 > tsh --proxy=localhost ls location=virginia
 
 Node Name     Node ID                     Address            Labels

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -841,6 +841,11 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 	}, nil
 }
 
+// Logout locates a certificate stored for a given proxy and deletes it
+func (tc *TeleportClient) Logout() error {
+	return trace.Wrap(tc.localAgent.DeleteKey(tc.ProxyHost, tc.Config.Username))
+}
+
 // Login logs user in using proxy's local 2FA auth access
 // or used OIDC external authentication, it later
 // saves the generated credentials into local keystore for future use
@@ -875,6 +880,17 @@ func (tc *TeleportClient) Login() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	// get site info:
+	proxy, err := tc.ConnectToProxy()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	site, err := proxy.getSite()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	tc.SiteName = site.Name
 	return nil
 }
 

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -21,6 +21,7 @@ type LocalKeyStore interface {
 	GetKeys(username string) ([]Key, error)
 	AddKey(host string, username string, key *Key) error
 	GetKey(host string, username string) (*Key, error)
+	DeleteKey(host string, username string) error
 
 	// trusted CAs management:
 	AddKnownCA(domainName string, publicKeys []ssh.PublicKey) error

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -129,3 +129,7 @@ func (a *LocalKeyAgent) AddKey(host string, username string, key *Key) error {
 	}
 	return a.Agent.Add(*agentKey)
 }
+
+func (a *LocalKeyAgent) DeleteKey(host string, username string) error {
+	return trace.Wrap(a.keyStore.DeleteKey(host, username))
+}

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -136,6 +136,25 @@ func (fs *FSLocalKeyStore) AddKey(host, username string, key *Key) error {
 	return nil
 }
 
+// DeleteKey deletes a key from the local store
+func (fs *FSLocalKeyStore) DeleteKey(host string, username string) error {
+	dirPath, err := fs.dirFor(host)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	files := []string{
+		filepath.Join(dirPath, username+fileExtCert),
+		filepath.Join(dirPath, username+fileExtPub),
+		filepath.Join(dirPath, username+fileExtKey),
+	}
+	for _, fn := range files {
+		if err = os.Remove(fn); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
 // GetKey returns a key for a given host. If the key is not found,
 // returns trace.NotFound error.
 func (fs *FSLocalKeyStore) GetKey(host, username string) (*Key, error) {


### PR DESCRIPTION
Fixes #420

Also, `login` command now clearly states which cluster (AKA "site") you've logged in to.
