### PR TITLE
fix linguist stats for project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+web/dist/app/vendor.js linguist-vendored
+web/dist/app/assets/* linguist-vendored
+web/src/assets/* linguist-vendored
+web/src/styles/bootstrap/bootstrap.scss linguist-vendored
+docs/theme/js/* linguist-vendored
+docs/theme/js/theme.js linguist-vendored=false


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/866677/15755128/216ecf86-2904-11e6-9322-3626bcf29458.png)
After:
![after](https://cloud.githubusercontent.com/assets/866677/15755123/171a0d16-2904-11e6-8ca7-97a4b03d3087.png)

I added some obvious paths. To go further, edit `.gitattributes`:

```
docs/theme/js/* linguist-vendored
```

To ignore path 

```
docs/theme/js/theme.js linguist-vendored=false
```

To re-enable stats for path.

Links:
[github/linguist#overrides](https://github.com/github/linguist#overrides)
