### PR TITLE
Added new YAML configuration parameter: `tunnel_listen_addr`

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -85,7 +85,8 @@ Teleport services listen on several ports. This table shows the default port num
 |----------|------------|-------------------------------------------
 |3022      | Node       | SSH port. This is Teleport's equivalent of port `#22` for SSH.
 |3023      | Proxy      | SSH port clients connect to. A proxy will forward this connection to port `#3022` on the destination node.
-|3024      | Auth       | SSH port used by the Auth Service to serve its API to other nodes in a cluster.
+|3025      | Auth       | SSH port used by the Auth Service to serve its API to other nodes in a cluster.
+|3024      | Tunnel     | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server.
 |3080      | Proxy      | HTTPS connection to authenticate `tsh` users and web users into the cluster. The same connection is used to serve a Web UI.
 
 
@@ -236,11 +237,21 @@ ssh_service:
 # This section configures the 'proxy servie'
 proxy_service:
     enabled: yes
-    listen_addr: 127.0.0.1:3023
-    web_listen_addr: 127.0.0.1:3080
+    # SSH forwrading/proxy address. Command line (CLI) clients always begin their
+    # SSH sessions by connecting to this port
+    listen_addr: 0.0.0.0:3023
 
-    # TLS certificate for the server-side HTTPS connection.
-    # Configuring these properly is critical for Teleport security.
+    # Reverse tunnel listening address. An auth server (CA) can establish an outbound 
+    # (from behind the firwall) connection to this address. This will allow users of
+    # the outside CA to connect to behind-the-firewall nodes.
+    tunnel_listen_addr: 0.0.0.0:3024
+
+    # The HTTPS listen address to serve the Web UI and also to authenticate the 
+    # command line (CLI) users via password+HOTP
+    web_listen_addr: 0.0.0.0:3080
+
+    # TLS certificate for the HTTPS connection. Configuring these properly is 
+    # critical for Teleport security.
     https_key_file: /etc/teleport/teleport.key
     https_cert_file: /etc/teleport/teleport.crt
 ```

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -253,6 +253,13 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		}
 		cfg.Proxy.WebAddr = *addr
 	}
+	if fc.Proxy.TunAddr != "" {
+		addr, err := utils.ParseHostPortAddr(fc.Proxy.TunAddr, int(defaults.SSHProxyTunnelListenPort))
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		cfg.Proxy.ReverseTunnelListenAddr = *addr
+	}
 	if fc.Proxy.KeyFile != "" {
 		if !fileExists(fc.Proxy.KeyFile) {
 			return trace.Errorf("https key does not exist: %s", fc.Proxy.KeyFile)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -80,6 +80,7 @@ var (
 		"peers":              true,
 		"prefix":             true,
 		"web_listen_addr":    true,
+		"tunnel_listen_addr": true,
 		"ssh_listen_addr":    true,
 		"listen_addr":        true,
 		"https_key_file":     true,
@@ -233,6 +234,7 @@ func MakeSampleFileConfig() (fc *FileConfig) {
 	p.EnabledFlag = "yes"
 	p.ListenAddress = conf.Proxy.SSHAddr.Addr
 	p.WebAddr = conf.Proxy.WebAddr.Addr
+	p.TunAddr = conf.Proxy.ReverseTunnelListenAddr.Addr
 	p.CertFile = "/etc/teleport/teleport.crt"
 	p.KeyFile = "/etc/teleport/teleport.key"
 
@@ -416,6 +418,7 @@ type CommandLabel struct {
 type Proxy struct {
 	Service  `yaml:",inline"`
 	WebAddr  string `yaml:"web_listen_addr,omitempty"`
+	TunAddr  string `yaml:"tunnel_listen_addr,omitempty"`
 	KeyFile  string `yaml:"https_key_file,omitempty"`
 	CertFile string `yaml:"https_cert_file,omitempty"`
 }


### PR DESCRIPTION
Prior to this change every listen address in Teleport was configurable
with the exception of "reverse tunnels"
1. Added the parameter to YAML parser
2. Added a test
3. Updated the admin guide (documentation)
