### PR TITLE
Added "seed_config" configuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,16 @@ You need to have Golang v1.5 or newer.
 
 Clone this repository into `$GOPATH/gravitational/teleport` and run `make`. 
 
+You'll have to create `/var/lib/teleport` directory and then you can start 
+Teleport as a single-node cluster in development mode: `build/teleport start -d`
+
 If you want to release your own Teleport version, edit this [Makefile](Makefile), update 
 `VERSION` and `SUFFIX` constants, then run `make setver` to update [version.go](version.go)
 
 If you want to cut another binary release tarball, run `make release`.
+
+NOTE: The Go compiler is somewhat sensitive to amount of memory: you will need at least 1GB of 
+virtual memory to compile Teleport. 512MB instance without swap will not work.
 
 ## Why did We Build Teleport?
 
@@ -71,14 +77,6 @@ within multiple organizations.
 
 The best way to contribute is to create issues or pull requests right here on Github. You can also reach the Gravitational team through their [website](http://gravitational.com/)
 
-### Building
-
-Teleport is written in Go. If you have Golang 1.5 and newer, simply clone this repository
-and run `make`. You'll have to create `/var/lib/teleport` directory and then you can start 
-Teleport as a single-node cluster in development mode: `build/teleport start -d`
-
-NOTE: The Go compiler is somewhat sensitive to amount of memory: you will need at least 1GB of 
-virtual memory to compile Teleport. 512MB instance without swap will not work.
 
 ## Status
 

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -197,6 +197,7 @@ func (i *TeleInstance) Create(trustedSecrets []*InstanceSecrets, enableSSH bool,
 		return err
 	}
 	tconf := service.MakeDefaultConfig()
+	tconf.SeedConfig = true
 	tconf.DataDir = dataDir
 	tconf.Console = console
 	tconf.Auth.DomainName = i.Secrets.SiteName

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -63,6 +63,9 @@ func (s *IntSuite) TearDownSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
+func (s *IntSuite) SetUpTest(c *check.C) {
+}
+
 func (s *IntSuite) SetUpSuite(c *check.C) {
 	var err error
 	utils.InitLoggerForTests()

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -90,11 +90,10 @@ type InitConfig struct {
 }
 
 // Init instantiates and configures an instance of AuthServer
-func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
+func Init(cfg InitConfig, seedConfig bool) (*AuthServer, *Identity, error) {
 	if cfg.DataDir == "" {
 		return nil, nil, trace.BadParameter("DataDir: data dir can not be empty")
 	}
-
 	if cfg.HostUUID == "" {
 		return nil, nil, trace.BadParameter("HostUUID: host UUID can not be empty")
 	}
@@ -110,22 +109,46 @@ func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
 	asrv := NewAuthServer(&cfg)
 
 	// we determine if it's the first start by checking if the CA's are set
-	var firstStart bool
-
-	firstStart, err = isFirstStart(asrv, cfg)
+	firstStart, err := isFirstStart(asrv, cfg)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	// populate authorities on first start
-	if len(cfg.Authorities) != 0 {
+	// we skip certain configuration if 'seed_config' is set to true
+	// and this is NOT the first time teleport starts on this machine
+	skipConfig := seedConfig && !firstStart
+
+	// add trusted authorities from the configuration into the trust backend:
+	keepMap := make(map[string]int, 0)
+	if !skipConfig {
 		for _, ca := range cfg.Authorities {
 			if err := asrv.Trust.UpsertCertAuthority(ca, backend.Forever); err != nil {
 				return nil, nil, trace.Wrap(err)
 			}
+			keepMap[ca.DomainName] = 1
 		}
 	}
-
+	// delete trusted authorities from the trust back-end if they're not
+	// in the configuration:
+	if !seedConfig {
+		hostCAs, err := asrv.Trust.GetCertAuthorities(services.HostCA, false)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		userCAs, err := asrv.Trust.GetCertAuthorities(services.UserCA, false)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		for _, ca := range append(hostCAs, userCAs...) {
+			_, configured := keepMap[ca.DomainName]
+			if ca.DomainName != cfg.DomainName && !configured {
+				if err = asrv.Trust.DeleteCertAuthority(*ca.ID()); err != nil {
+					return nil, nil, trace.Wrap(err)
+				}
+				log.Infof("removed old trusted CA: '%s'", ca.DomainName)
+			}
+		}
+	}
 	// this block will generate user CA authority on first start if it's
 	// not currently present, it will also use optional passed user ca keypair
 	// that can be supplied in configuration
@@ -133,7 +156,6 @@ func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
 		if !trace.IsNotFound(err) {
 			return nil, nil, trace.Wrap(err)
 		}
-
 		log.Infof("FIRST START: Generating host CA on first start")
 		priv, pub, err := asrv.GenerateKeyPair("")
 		if err != nil {
@@ -149,7 +171,6 @@ func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
 			return nil, nil, trace.Wrap(err)
 		}
 	}
-
 	// this block will generate user CA authority on first start if it's
 	// not currently present, it will also use optional passed user ca keypair
 	// that can be supplied in configuration
@@ -173,38 +194,83 @@ func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
 			return nil, nil, trace.Wrap(err)
 		}
 	}
-	if len(cfg.ReverseTunnels) != 0 {
+	// add reverse runnels from the configuration into the backend
+	keepMap = make(map[string]int, 0)
+	if !skipConfig {
 		log.Infof("Initializing reverse tunnels")
 		for _, tunnel := range cfg.ReverseTunnels {
 			if err := asrv.UpsertReverseTunnel(tunnel, 0); err != nil {
 				return nil, nil, trace.Wrap(err)
 			}
+			keepMap[tunnel.DomainName] = 1
 		}
 	}
-	if firstStart {
-		if len(cfg.OIDCConnectors) != 0 {
-			log.Infof("FIRST START: Initializing oidc connectors")
-			for _, connector := range cfg.OIDCConnectors {
-				if err := asrv.UpsertOIDCConnector(connector, 0); err != nil {
+	// remove the reverse tunnels from the backend if they're not
+	// present in the configuration
+	if !seedConfig {
+		tunnels, err := asrv.GetReverseTunnels()
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		for _, tunnel := range tunnels {
+			_, configured := keepMap[tunnel.DomainName]
+			if !configured {
+				if err = asrv.DeleteReverseTunnel(tunnel.DomainName); err != nil {
 					return nil, nil, trace.Wrap(err)
 				}
+				log.Infof("removed reverse tunnel: '%s'", tunnel.DomainName)
 			}
 		}
 	}
-	identity, err := initKeys(asrv, cfg.DataDir, IdentityID{HostUUID: cfg.HostUUID, Role: teleport.RoleAdmin})
-	if err != nil {
-		return nil, nil, err
+	// add OIDC connectors to the back-end:
+	keepMap = make(map[string]int, 0)
+	if !skipConfig {
+		log.Infof("Initializing OIDC connectors")
+		for _, connector := range cfg.OIDCConnectors {
+			if err := asrv.UpsertOIDCConnector(connector, 0); err != nil {
+				return nil, nil, trace.Wrap(err)
+			}
+			log.Infof("created ODIC connector '%s'", connector.ID)
+			keepMap[connector.ID] = 1
+		}
+	}
+	// remove OIDC connectors from the backend if they're not
+	// present in the configuration
+	if !seedConfig {
+		connectors, _ := asrv.GetOIDCConnectors(false)
+		for _, connector := range connectors {
+			_, configured := keepMap[connector.ID]
+			if !configured {
+				if err = asrv.DeleteOIDCConnector(connector.ID); err != nil {
+					return nil, nil, trace.Wrap(err)
+				}
+				log.Infof("removed OIDC connector '%s'", connector.ID)
+			}
+		}
 	}
 
+	identity, err := initKeys(asrv, cfg.DataDir,
+		IdentityID{HostUUID: cfg.HostUUID, Role: teleport.RoleAdmin})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 	return asrv, identity, nil
 }
 
+// isFirstStart returns 'true' if the auth server is starting for the 1st time
+// on this server.
 func isFirstStart(authServer *AuthServer, cfg InitConfig) (bool, error) {
-	_, err := authServer.GetCertAuthority(services.CertAuthID{DomainName: cfg.DomainName, Type: services.HostCA}, false)
+	// check if the CA exists?
+	_, err := authServer.GetCertAuthority(
+		services.CertAuthID{
+			DomainName: cfg.DomainName,
+			Type:       services.HostCA,
+		}, false)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return false, trace.Wrap(err)
 		}
+		// CA not found? --> first start!
 		return true, nil
 	}
 	return false, nil

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -273,6 +273,22 @@ func (s *ConfigTestSuite) TestTrustedClusters(c *check.C) {
 	c.Assert(len(conf.ReverseTunnels), check.Equals, 0)
 }
 
+func (s *ConfigTestSuite) TestSeedConfig(c *check.C) {
+	config := `teleport:
+  nodename: cat.example.com
+  seed_config: true
+`
+	fc, err := ReadConfig(bytes.NewBufferString(config))
+	c.Assert(err, check.IsNil)
+	c.Assert(fc.SeedConfig, check.Equals, true)
+
+	conf := service.MakeDefaultConfig()
+	c.Assert(conf.SeedConfig, check.Equals, false)
+
+	ApplyFileConfig(fc, conf)
+	c.Assert(conf.SeedConfig, check.Equals, true)
+}
+
 func (s *ConfigTestSuite) TestApplyConfig(c *check.C) {
 	conf, err := ReadConfig(bytes.NewBufferString(SmallConfigString))
 	c.Assert(err, check.IsNil)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -100,6 +100,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	if fc == nil {
 		return nil
 	}
+	cfg.SeedConfig = fc.SeedConfig
 	// merge file-based config with defaults in 'cfg'
 	if fc.Auth.Disabled() {
 		cfg.Auth.Enabled = false

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -43,6 +43,7 @@ import (
 var (
 	// all possible valid YAML config keys
 	validKeys = map[string]bool{
+		"seed_config":        true,
 		"cluster_name":       true,
 		"trusted_clusters":   true,
 		"pid_file":           true,
@@ -349,6 +350,11 @@ type Global struct {
 	// Each service (like proxy, auth, node) can find the key it needs
 	// by looking into certificate
 	Keys []KeyPair `yaml:"keys,omitempty"`
+
+	// SeedConfig [GRAVITATIONAL USE] when set to true, Teleport treats
+	// its configuration file simply as a seed data on initial start-up.
+	// For OSS Teleport it should always be 'false' by default.
+	SeedConfig bool `yaml:"seed_config,omitempty"`
 }
 
 // Service is a common configuration of a teleport service

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -107,6 +107,10 @@ type Config struct {
 
 	// Trust is a service that manages users and credentials
 	Identity services.Identity
+
+	// SeedConfig tells teleport to treat its start-up configuration as initial
+	// "seed" configuration on 1st start.
+	SeedConfig bool
 }
 
 // ApplyToken assigns a given token to all internal services but only if token
@@ -284,6 +288,7 @@ func ApplyDefaults(cfg *Config) {
 		hostname = "localhost"
 		log.Errorf("Failed to determine hostname: %v", err)
 	}
+	cfg.SeedConfig = false
 
 	// defaults for the auth service:
 	cfg.Auth.Enabled = true

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -295,7 +295,7 @@ func (process *TeleportProcess) initAuthService(authority auth.Authority) error 
 		Provisioner:     cfg.Provisioner,
 		Identity:        cfg.Identity,
 		StaticTokens:    cfg.Auth.StaticTokens,
-	})
+	}, cfg.SeedConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -399,6 +399,7 @@ func (process *TeleportProcess) initAuthService(authority auth.Authority) error 
 		log.Infof("[AUTH] heartbeat to other auth servers exited")
 		return nil
 	})
+
 	// execute this when process is asked to exit:
 	process.onExit(func(payload interface{}) {
 		askedToExit = true


### PR DESCRIPTION
Teleport YAML config now has a new configuration variable for internal
use by Gravitational:

``` yaml
teleport:
   seed_config: true
```

If set to 'true', Teleport treats YAML configuration simply as a seed
configuration on first start.

If set to 'false' (default for OSS version), Teleport will throw away
its back-end config, treating YAML config as the only source of truth.

Specifically, for now, the following settings are thrown away if not
found in YAML:
- trusted authorities
- reverse tunnels
## Note to Gravity

Gravity must set `seed_config` to true.
