### PR TITLE
Cover the missing edge cases to replicate the old behavior

### DIFF
--- a/lib/utils/addr.go
+++ b/lib/utils/addr.go
@@ -326,8 +326,11 @@ func guessHostIP(ifaces []netInterface) (ip net.IP) {
 			}
 		}
 	}
-	// did not find anything? return loopback
 	if ip == nil {
+		if len(ips) > 0 {
+			return ips[0]
+		}
+		// fallback to loopback
 		ip = net.IPv4(127, 0, 0, 1)
 	}
 	return ip

--- a/lib/utils/addr_test.go
+++ b/lib/utils/addr_test.go
@@ -185,13 +185,24 @@ func (s *AddrTestSuite) TestGuessesIPAddress(c *C) {
 			ifaces: []netInterface{
 				iface{
 					addrs: []net.Addr{
-						&net.IPAddr{IP: net.ParseIP("172.192.12.1")},
+						&net.IPAddr{IP: net.ParseIP("52.35.21.180")},
 						&net.IPAddr{IP: net.ParseIP("fe80::af:6dff:fefd:150f")},
 					},
 				},
 			},
-			expected: net.ParseIP("172.192.12.1"),
+			expected: net.ParseIP("52.35.21.180"),
 			comment:  "ignores IPv6",
+		},
+		{
+			ifaces: []netInterface{
+				iface{
+					addrs: []net.Addr{
+						&net.IPAddr{IP: net.ParseIP("fe80::af:6dff:fefd:150f")},
+					},
+				},
+			},
+			expected: net.ParseIP("127.0.0.1"),
+			comment:  "falls back to loopback",
 		},
 	}
 


### PR DESCRIPTION
Just realized I slightly altered the behavior of `GuessHostIP`, so revisit the implementation to make a better fit:
- use arbitrary IP address if none from the preference list matched. Previous implementation would've used the last IP in the list, but both choices are arbitrary enough, so using first seems like an equally good option
- fallback to loopback if no suitable address has been found
