### PR TITLE
Replaced echo with printf in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=1.0.0
+VERSION=1.0.1-beta.1
 
 # These are standard autotools variables, don't change them please
 BUILDDIR ?= build

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@
 package teleport
 
 const (
-	Version = "1.0.0"
+	Version = "1.0.1-beta.1"
 )
 
 var Gitref string

--- a/version.mk
+++ b/version.mk
@@ -16,5 +16,5 @@ func init() { Gitref = \"$(GITREF)\"}  "
 #
 .PHONY:setver
 setver:
-	@echo $(VERSION_GO) | gofmt > version.go
-	@echo $(GITREF_GO) | gofmt > gitref.go
+	@printf $(VERSION_GO) | gofmt > version.go
+	@printf $(GITREF_GO) | gofmt > gitref.go


### PR DESCRIPTION
Fixes #467

`echo -e` is not a POSIX compliant command to use in a Makefile.
Replaced it with `printf`
