### PR TITLE
Frozen tunnels (instead of closed connection) due to an expired session

### DIFF
--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -332,7 +332,8 @@ func (slice Sessions) Len() int {
 	return len(slice)
 }
 
-// GetSession returns the session by it's id
+// GetSession returns the session by it's id. Returns nil if a session
+// is not found
 func (s *server) GetSession(id ID) (*Session, error) {
 	var sess *Session
 	err := s.bk.GetJSONVal(activeBucket(), string(id), &sess)

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -547,7 +547,7 @@ func (s *session) removeParty(p *party) error {
 			log.Error(err)
 			return
 		}
-		if dbSession.RemoveParty(p.id) {
+		if dbSession != nil && dbSession.RemoveParty(p.id) {
 			db.UpdateSession(rsession.UpdateRequest{
 				ID:      dbSession.ID,
 				Parties: &dbSession.Parties,


### PR DESCRIPTION
My stress test for reproducing "frozen tunnels" bug #444 managed to reproduce something similar: a tunnel would "freeze" when a session expires due to all parties leaving.

Truns out, `GetSession()` method returns `nil` when a session is not found (as opposed to NotFoundError, per our coding conventions).

I tried returning NotFoundError first, but this causes a chain of deeper changes and breaking a bunch of unrelated tests, risking introducing other bugs which I have no time for. 

So I'm committing a tiny point fix + better comments for future users of GetSession().
