### PR TITLE
allow admin users generate certs for other users

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -470,7 +470,10 @@ func (s *APIServer) generateUserCert(w http.ResponseWriter, r *http.Request, _ h
 	// This allows us to make sure that users can only request new certificates
 	// only for themselves, except admin users
 	caller, _, ok := r.BasicAuth()
-	if !ok || (req.User != caller && s.a.role != teleport.RoleAdmin) {
+	if !ok {
+		return nil, trace.AccessDenied("Missing username or password")
+	}
+	if req.User != caller && s.a.role != teleport.RoleAdmin {
 		return nil, trace.AccessDenied("User %s cannot request a certificate for %s",
 			caller, req.User)
 	}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -469,8 +469,8 @@ func (s *APIServer) generateUserCert(w http.ResponseWriter, r *http.Request, _ h
 	// SSH-to-HTTP gateway (tun server) sets HTTP basic auth to SSH cert principal
 	// This allows us to make sure that users can only request new certificates
 	// only for themselves, except admin users
-	caller, _, _ := r.BasicAuth()
-	if req.User != caller && s.a.role != teleport.RoleAdmin {
+	caller, _, ok := r.BasicAuth()
+	if !ok || (req.User != caller && s.a.role != teleport.RoleAdmin) {
 		return nil, trace.AccessDenied("User %s cannot request a certificate for %s",
 			caller, req.User)
 	}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -471,10 +471,10 @@ func (s *APIServer) generateUserCert(w http.ResponseWriter, r *http.Request, _ h
 	// only for themselves, except admin users
 	caller, _, ok := r.BasicAuth()
 	if !ok {
-		return nil, trace.AccessDenied("Missing username or password")
+		return nil, trace.AccessDenied("missing username or password")
 	}
 	if req.User != caller && s.a.role != teleport.RoleAdmin {
-		return nil, trace.AccessDenied("User %s cannot request a certificate for %s",
+		return nil, trace.AccessDenied("user %s cannot request a certificate for %s",
 			caller, req.User)
 	}
 	cert, err := s.a.GenerateUserCert(req.Key, req.User, req.TTL)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -468,9 +468,9 @@ func (s *APIServer) generateUserCert(w http.ResponseWriter, r *http.Request, _ h
 	}
 	// SSH-to-HTTP gateway (tun server) sets HTTP basic auth to SSH cert principal
 	// This allows us to make sure that users can only request new certificates
-	// only for themselves
+	// only for themselves, except admin users
 	caller, _, _ := r.BasicAuth()
-	if req.User != caller {
+	if req.User != caller && s.a.role != teleport.RoleAdmin {
 		return nil, trace.AccessDenied("User %s cannot request a certificate for %s",
 			caller, req.User)
 	}

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -154,7 +154,7 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 	// should NOT be able to generate a user cert without basic HTTP auth
 	cert, err = userClient.GenerateUserCert(pub, "user1", time.Hour)
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, ".*cannot request a certificate for user1")
+	c.Assert(err, ErrorMatches, ".*username or password")
 
 	// Users don't match
 	roundtrip.BasicAuth("user2", "two")(&userClient.Client)


### PR DESCRIPTION
This PR allows admin users generate certs for other users. Regular users are still restricted
