### PR TITLE
Fixed the regression with GuessAdvertiseIP()

### DIFF
--- a/lib/utils/addr_test.go
+++ b/lib/utils/addr_test.go
@@ -127,96 +127,65 @@ func (s *AddrTestSuite) TestLoopbackAddrs(c *C) {
 
 func (s *AddrTestSuite) TestGuessesIPAddress(c *C) {
 	var testCases = []struct {
-		ifaces   []netInterface
+		addrs    []net.Addr
 		expected net.IP
 		comment  string
 	}{
 		{
-			ifaces: []netInterface{
-				iface{
-					addrs: []net.Addr{
-						&net.IPAddr{IP: net.ParseIP("10.0.100.80")},
-						&net.IPAddr{IP: net.ParseIP("192.13.1.80")},
-						&net.IPAddr{IP: net.ParseIP("172.192.12.1")},
-					},
-				},
+			addrs: []net.Addr{
+				&net.IPAddr{IP: net.ParseIP("10.0.100.80")},
+				&net.IPAddr{IP: net.ParseIP("192.13.1.80")},
+				&net.IPAddr{IP: net.ParseIP("172.192.12.1")},
 			},
 			expected: net.ParseIP("10.0.100.80"),
 			comment:  "prefers 10.x.y.z",
 		},
 		{
-			ifaces: []netInterface{
-				iface{
-					addrs: []net.Addr{
-						&net.IPAddr{IP: net.ParseIP("192.13.1.80")},
-						&net.IPAddr{IP: net.ParseIP("172.192.12.1")},
-					},
-				},
+			addrs: []net.Addr{
+				&net.IPAddr{IP: net.ParseIP("192.13.1.80")},
+				&net.IPAddr{IP: net.ParseIP("172.192.12.1")},
 			},
 			expected: net.ParseIP("192.13.1.80"),
 			comment:  "prefers 192.x.y.z",
 		},
 		{
-			ifaces: []netInterface{
-				iface{
-					addrs: []net.Addr{
-						&net.IPAddr{IP: net.ParseIP("172.192.12.1")},
-						&net.IPAddr{IP: net.ParseIP("52.35.21.180")},
-					},
-				},
+			addrs: []net.Addr{
+				&net.IPAddr{IP: net.ParseIP("172.192.12.1")},
+				&net.IPAddr{IP: net.ParseIP("52.35.21.180")},
 			},
 			expected: net.ParseIP("172.192.12.1"),
 			comment:  "prefers 172.x.y.z",
 		},
 		{
-			ifaces: []netInterface{
-				iface{
-					addrs: []net.Addr{
-						&net.IPAddr{IP: net.ParseIP("192.192.12.1")},
-						&net.IPAddr{IP: net.ParseIP("192.192.12.2")},
-						&net.IPAddr{IP: net.ParseIP("52.35.21.180")},
-					},
-				},
+			addrs: []net.Addr{
+				&net.IPAddr{IP: net.ParseIP("192.192.12.1")},
+				&net.IPAddr{IP: net.ParseIP("192.192.12.2")},
+				&net.IPAddr{IP: net.ParseIP("52.35.21.180")},
 			},
 			expected: net.ParseIP("192.192.12.2"),
 			comment:  "prefers last",
 		},
 		{
-			ifaces: []netInterface{
-				iface{
-					addrs: []net.Addr{
-						&net.IPAddr{IP: net.ParseIP("52.35.21.180")},
-						&net.IPAddr{IP: net.ParseIP("fe80::af:6dff:fefd:150f")},
-					},
-				},
+			addrs: []net.Addr{
+				&net.IPAddr{IP: net.ParseIP("52.35.21.180")},
+				&net.IPAddr{IP: net.ParseIP("fe80::af:6dff:fefd:150f")},
 			},
 			expected: net.ParseIP("52.35.21.180"),
 			comment:  "ignores IPv6",
 		},
 		{
-			ifaces: []netInterface{
-				iface{
-					addrs: []net.Addr{
-						&net.IPAddr{IP: net.ParseIP("fe80::af:6dff:fefd:150f")},
-					},
-				},
+			addrs: []net.Addr{
+				&net.IPAddr{IP: net.ParseIP("fe80::af:6dff:fefd:150f")},
 			},
 			expected: net.ParseIP("127.0.0.1"),
 			comment:  "falls back to loopback",
 		},
 	}
-
 	for _, testCase := range testCases {
-		ip := guessHostIP(testCase.ifaces)
+		ip := guessHostIP(testCase.addrs)
 		c.Assert(ip, DeepEquals, testCase.expected, Commentf(testCase.comment))
 	}
 }
-
-type iface struct {
-	addrs []net.Addr
-}
-
-func (r iface) Addrs() ([]net.Addr, error) { return r.addrs, nil }
 
 func (s *AddrTestSuite) TestMarshal(c *C) {
 	testCases := []struct {


### PR DESCRIPTION
Fixes #486 

Simplified GuessHostIP() function. Instead of interating on interfaces, it now iterates on a slice of IP addresses, which makes testing easier and less error prone (no need to mock complicated `net.Interface` type)
