### PR TITLE
Adds the ability to specify non-standard HTTPS proxy port

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -134,7 +134,7 @@ Run shell or execute a command on a remote SSH node.
 
 Flags:
       --user      SSH proxy user [ekontsevoy]
-      --proxy     SSH proxy host or IP address
+      --proxy     SSH proxy host or IP address, for example --proxy=host:ssh_port,https_port
       --ttl       Minutes to live for a SSH session 
       --insecure  Do not verify server certificate and host name. Use only in test environments
   -d, --debug     Verbose logging to stdout
@@ -157,6 +157,20 @@ using familiar SSH syntax:
 > ssh root@host
 > ssh -p 6122 root@host ls
 ```
+
+### Note about Proxies
+
+A Teleport proxy uses two ports: `3080` for HTTPS and `3023` for proxying SSH connections.
+The HTTPS port is used to serve Web UI and also to implement 2nd factor auth for `tsh` client.
+
+If your Teleport proxy is configured to listen on other ports, you should specify
+them via `--proxy` flag as shown:
+
+```
+tsh --proxy=host:5000,5001
+```
+
+This means "connect to the port `5000` for SSH and to `5001` for HTTPS".
 
 ### Port Forwarding
 

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -40,11 +40,20 @@ func (s *APITestSuite) TestConfig(c *check.C) {
 	c.Assert(conf.ProxySpecified(), check.Equals, false)
 	conf.ProxyHost = "example.org"
 	c.Assert(conf.ProxySpecified(), check.Equals, true)
-	c.Assert(conf.ProxyHostPort(12), check.Equals, "example.org:12")
+	c.Assert(conf.ProxyHostPort(false), check.Equals, "example.org:3023")
+	c.Assert(conf.ProxyHostPort(true), check.Equals, "example.org:3080")
 
 	conf.ProxyHost = "example.org:100"
 	c.Assert(conf.ProxySpecified(), check.Equals, true)
-	c.Assert(conf.ProxyHostPort(12), check.Equals, "example.org:100")
+	c.Assert(conf.ProxyHostPort(false), check.Equals, "example.org:100")
+	c.Assert(conf.ProxyHostPort(true), check.Equals, "example.org:3080")
+
+	conf.ProxyHost = "example.org:100,200"
+	c.Assert(conf.ProxyHostPort(false), check.Equals, "example.org:100")
+	c.Assert(conf.ProxyHostPort(true), check.Equals, "example.org:200")
+
+	conf.ProxyHost = "example.org:,200"
+	c.Assert(conf.ProxyHostPort(true), check.Equals, "example.org:200")
 }
 
 func (s *APITestSuite) TestNew(c *check.C) {
@@ -63,10 +72,7 @@ func (s *APITestSuite) TestNew(c *check.C) {
 
 	la := tc.LocalAgent()
 	c.Assert(la, check.NotNil)
-
 	c.Assert(tc.NodeHostPort(), check.Equals, "localhost:22")
-	c.Assert(tc.ProxySpecified(), check.Equals, true)
-	c.Assert(tc.ProxyHostPort(12), check.Equals, "proxy:12")
 }
 
 func (s *APITestSuite) TestParseLabels(c *check.C) {

--- a/tool/tsh/main_test.go
+++ b/tool/tsh/main_test.go
@@ -56,7 +56,8 @@ func (s *MainTestSuite) TestMakeClient(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(tc, check.NotNil)
 	c.Assert(tc.Config.NodeHostPort(), check.Equals, "localhost:3022")
-	c.Assert(tc.Config.ProxyHostPort(666), check.Equals, "proxy:666")
+	c.Assert(tc.Config.ProxyHostPort(false), check.Equals, "proxy:3023")
+	c.Assert(tc.Config.ProxyHostPort(true), check.Equals, "proxy:3080")
 	c.Assert(tc.Config.HostLogin, check.Equals, client.Username())
 	c.Assert(tc.Config.KeyTTL, check.Equals, defaults.CertDuration)
 


### PR DESCRIPTION
This commit fixes #491

Now `tsh` accepts `--proxy=host:port,port` allowing to specify two
ports, one for SSH and another for HTTPS.
