### PR TITLE
fix build error on 32bit environment

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/gravitational/teleport",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v62",
+	"GodepVersion": "v74",
 	"Packages": [
 		"./lib/...",
 		"./tool/..."
@@ -36,7 +36,7 @@
 		},
 		{
 			"ImportPath": "github.com/buger/goterm",
-			"Rev": "af3f07dadc88b80c7b5a15f26033c6dd979f012f"
+			"Rev": "d281585cd7365cff9edfed1a5115fc624a012bdc"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/Godeps/_workspace/src/github.com/ugorji/go/codec",

--- a/vendor/github.com/buger/goterm/README.md
+++ b/vendor/github.com/buger/goterm/README.md
@@ -8,7 +8,7 @@ Full API documentation: http://godoc.org/github.com/buger/goterm
 
 ## Basic usage
 
-Full screen console app, priting current time:
+Full screen console app, printing current time:
 
 ```go
 import (
@@ -33,6 +33,10 @@ func main() {
 }
 ```
 
+This can be seen in [examples/time_example.go](examples/time_example.go).  To
+run it yourself, go into your `$GOPATH/src/github.com/buger/goterm` directory
+and run `go run ./examples/time_example.go`
+
 
 Print red bold message on white background:
 
@@ -44,8 +48,10 @@ tm.Println(tm.Backgound(tm.Color(tm.Bold("Important header"), tm.RED), tm.WHITE)
 Create box and move it to center of the screen:
 
 ```go
+tm.Clear()
+
 // Create Box with 30% width of current screen, and height of 20 lines
-box := tm.NewBox(30|tm.PCT, 20)
+box := tm.NewBox(30|tm.PCT, 20, 0)
 
 // Add some content to the box
 // Note that you can add ANY content, even tables
@@ -53,8 +59,11 @@ fmt.Fprint(box, "Some box content")
 
 // Move Box to approx center of the screen
 tm.Print(tm.MoveTo(box.String(), 40|tm.PCT, 40|tm.PCT))
+
+tm.Flush()
 ```
 
+This can be found in [examples/box_example.go](examples/box_example.go).
 
 Draw table:
 
@@ -64,7 +73,10 @@ totals := tm.NewTable(0, 10, 5, ' ', 0)
 fmt.Fprintf(totals, "Time\tStarted\tActive\tFinished\n")
 fmt.Fprintf(totals, "%s\t%d\t%d\t%d\n", "All", started, started-finished, finished)
 tm.Println(totals)
+tm.Flush()
 ```
+
+This can be found in [examples/table_example.go](examples/table_example.go).
 
 ## Line charts
 
@@ -92,6 +104,7 @@ Chart example:
     tm.Println(chart.Draw(data))
 ```
 
+This can be found in [examples/chart_example.go](examples/chart_example.go).
 
 Drawing 2 separate graphs in different scales. Each graph have its own Y axe.
 

--- a/vendor/github.com/buger/goterm/terminal_nosysioctl.go
+++ b/vendor/github.com/buger/goterm/terminal_nosysioctl.go
@@ -1,0 +1,12 @@
+// +build windows plan9 solaris
+
+package goterm
+
+func getWinsize() (*winsize, error) {
+	ws := new(winsize)
+
+	ws.Col = 80
+	ws.Row = 24
+
+	return ws, nil
+}

--- a/vendor/github.com/buger/goterm/terminal_sysioctl.go
+++ b/vendor/github.com/buger/goterm/terminal_sysioctl.go
@@ -1,0 +1,36 @@
+// +build !windows,!plan9,!solaris
+
+package goterm
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+func getWinsize() (*winsize, error) {
+	ws := new(winsize)
+
+	var _TIOCGWINSZ int64
+
+	switch runtime.GOOS {
+	case "linux":
+		_TIOCGWINSZ = 0x5413
+	case "darwin":
+		_TIOCGWINSZ = 1074295912
+	}
+
+	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(syscall.Stdin),
+		uintptr(_TIOCGWINSZ),
+		uintptr(unsafe.Pointer(ws)),
+	)
+
+	if int(r1) == -1 {
+		fmt.Println("Error:", os.NewSyscallError("GetWinsize", errno))
+		return nil, os.NewSyscallError("GetWinsize", errno)
+	}
+	return ws, nil
+}


### PR DESCRIPTION
fix the following compile error:

```
make -f version.mk setver
make[1]: Entering directory '/home/yifan/go_user/src/github.com/gravitational/teleport'
make[1]: Leaving directory '/home/yifan/go_user/src/github.com/gravitational/teleport'
go build -o build/teleport -i -ldflags -w ./tool/teleport
go build -o build/tctl -i -ldflags -w ./tool/tctl
# github.com/gravitational/teleport/vendor/github.com/buger/goterm
vendor/github.com/buger/goterm/terminal.go:106: constant 2147483648 overflows int
vendor/github.com/buger/goterm/terminal.go:110: constant 2147483648 overflows int
Makefile:34: recipe for target 'tctl' failed
make: *** [tctl] Error 2
```
