### PR TITLE
Ev/groups

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -40,7 +40,7 @@ RUN (apt-get update && apt-get install -q -y \
     apt-get -y autoclean; apt-get -y clean
 
 # Install Golang:
-RUN (mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/go1.6.1.linux-amd64.tar.gz | tar xz;\
+RUN (mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz | tar xz;\
      mkdir -p /gopath/src/github.com/gravitational/teleport;\
      chmod a+w /gopath;\
      chmod a+w /var/lib)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -382,13 +382,10 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID, env map
 				}
 				// nothing changed
 				if prevSess.TerminalParams.W == sess.TerminalParams.W && prevSess.TerminalParams.H == sess.TerminalParams.H {
-					log.Infof("TERMINAL SIZE HAS NOT CHANGED")
 					continue
 				}
 
 				newSize := sess.TerminalParams.Winsize()
-
-				log.Infof("NEW TERMINAL SIZE: %v", newSize)
 
 				currentSize, err := term.GetWinsize(0)
 				if err != nil {

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -382,10 +382,13 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID, env map
 				}
 				// nothing changed
 				if prevSess.TerminalParams.W == sess.TerminalParams.W && prevSess.TerminalParams.H == sess.TerminalParams.H {
+					log.Infof("TERMINAL SIZE HAS NOT CHANGED")
 					continue
 				}
 
 				newSize := sess.TerminalParams.Winsize()
+
+				log.Infof("NEW TERMINAL SIZE: %v", newSize)
 
 				currentSize, err := term.GetWinsize(0)
 				if err != nil {


### PR DESCRIPTION
### Problem

When launching a shell session, Teleport usually sets UID:GID pair for the new process. That does not include the list of "supplemental groups" most users have. When this happens, a new session inherits the group ID of the caller's process. If you run `teleport start` as `root`, that means giving it a supplemental GID of `0` (root). 

Reported in #507
### Code/Solution

Go 1.6 does not have the cross-platform facility for getting a list of supplemental groups for a given UID (user). Golang 1.7 does. This code fetches that list and applies it to the new process credentials.

If the list is empty, it uses user's GID as a supplemental group, therefore it never inherits parent's process (teleport) groups.

There is no way make this work without Golang 1.7.
