### PR TITLE
Ev/leak

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -194,7 +194,7 @@ func (i *TeleInstance) GetSiteAPI(siteName string) auth.ClientI {
 func (i *TeleInstance) Create(trustedSecrets []*InstanceSecrets, enableSSH bool, console io.Writer) error {
 	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName)
 	if err != nil {
-		return err
+		return trace.Wrap(err)
 	}
 	tconf := service.MakeDefaultConfig()
 	tconf.SeedConfig = true
@@ -229,7 +229,7 @@ func (i *TeleInstance) Create(trustedSecrets []*InstanceSecrets, enableSSH bool,
 	i.Config = tconf
 	i.Process, err = service.NewTeleport(tconf)
 	if err != nil {
-		return err
+		return trace.Wrap(err)
 	}
 	// create users:
 	auth := i.Process.GetAuthServer()
@@ -239,7 +239,7 @@ func (i *TeleInstance) Create(trustedSecrets []*InstanceSecrets, enableSSH bool,
 			AllowedLogins: user.AllowedLogins,
 		})
 		if err != nil {
-			return err
+			return trace.Wrap(err)
 		}
 		priv, pub, _ := tconf.Keygen.GenerateKeyPair("")
 		//priv, pub := makeKey()
@@ -262,7 +262,7 @@ func (i *TeleInstance) Create(trustedSecrets []*InstanceSecrets, enableSSH bool,
 func (i *TeleInstance) Reset() (err error) {
 	i.Process, err = service.NewTeleport(i.Config)
 	if err != nil {
-		return err
+		return trace.Wrap(err)
 	}
 	return nil
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -188,14 +188,17 @@ type TeleportClient struct {
 	Config
 	localAgent *LocalKeyAgent
 
+	// OnShellCreated gets called when the shell is created. It's
+	// safe to keep it nil
 	OnShellCreated ShellCreatedCallback
 
 	// ExitMsg (if set) will be printed at the end of the SSH session
 	ExitMsg string
 }
 
-// This callback can be supplied for every teleport client. It will be called
-// right after the remote shell is created, but the session hasn't begun yet.
+// ShellCreatedCallback can be supplied for every teleport client. It will
+// be called right after the remote shell is created, but the session
+// hasn't begun yet.
 //
 // It allows clients to cancel SSH action
 type ShellCreatedCallback func(shell io.ReadWriteCloser) (exit bool, err error)
@@ -722,7 +725,7 @@ func (tc *TeleportClient) runShell(nodeClient *NodeClient, sessionID session.ID,
 	if tc.OnShellCreated != nil {
 		exit, err := tc.OnShellCreated(shell)
 		if exit {
-			return err
+			return trace.Wrap(err)
 		}
 	}
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -346,7 +346,7 @@ func (client *NodeClient) Shell(
 	// this goroutine sleeps until a terminal size changes (it receives an OS signal)
 	sigC := make(chan os.Signal, 1)
 	signal.Notify(sigC, syscall.SIGWINCH)
-	broadcastOurTerminalSize := func() {
+	broadcastTerminalSize := func() {
 		for {
 			select {
 			case sig := <-sigC:
@@ -376,7 +376,7 @@ func (client *NodeClient) Shell(
 	}
 
 	// detect changes of the session's terminal
-	updateOurTerminalSize := func() {
+	updateTerminalSize := func() {
 		tick := time.NewTicker(defaults.SessionRefreshPeriod)
 		defer tick.Stop()
 		var prevSess *session.Session
@@ -419,8 +419,8 @@ func (client *NodeClient) Shell(
 	}
 
 	if attachedTerm {
-		go broadcastOurTerminalSize()
-		go updateOurTerminalSize()
+		go broadcastTerminalSize()
+		go updateTerminalSize()
 	}
 
 	go func() {

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -262,8 +262,21 @@ func (proxy *ProxyClient) Close() error {
 	return proxy.Client.Close()
 }
 
-// Shell returns remote shell as io.ReadWriterCloser object
-func (client *NodeClient) Shell(width, height int, sessionID session.ID, env map[string]string) (io.ReadWriteCloser, error) {
+// Shell returns a configured remote shell (for a window of a requested size)
+// as io.ReadWriterCloser object
+//
+// Parameters:
+//	- width & height : size of the window
+//  - session id     : ID of a session (if joining existing) or empty to create
+//                     a new session
+//  - env            : list of environment variables to set for a new session
+//  - attachedTerm   : boolean indicating if this client is attached to a real terminal
+func (client *NodeClient) Shell(
+	width, height int,
+	sessionID session.ID,
+	env map[string]string,
+	attachedTerm bool) (io.ReadWriteCloser, error) {
+
 	if sessionID == "" {
 		// initiate a new session if not passed
 		sessionID = session.NewID()
@@ -333,7 +346,7 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID, env map
 	// this goroutine sleeps until a terminal size changes (it receives an OS signal)
 	sigC := make(chan os.Signal, 1)
 	signal.Notify(sigC, syscall.SIGWINCH)
-	go func() {
+	broadcastOurTerminalSize := func() {
 		for {
 			select {
 			case sig := <-sigC:
@@ -343,8 +356,8 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID, env map
 				// get the size:
 				winSize, err := term.GetWinsize(0)
 				if err != nil {
-					log.Infof("error getting size: %s", err)
-					continue
+					log.Errorf("Error getting size: %s", err)
+					break
 				}
 				// send the new window size to the server
 				_, err = clientSession.SendRequest(
@@ -357,15 +370,14 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID, env map
 					log.Infof("failed to send window change reqest: %v", err)
 				}
 			case <-broadcastClose.C:
-				log.Infof("detected close")
 				return
 			}
 		}
-	}()
+	}
 
-	tick := time.NewTicker(defaults.SessionRefreshPeriod)
 	// detect changes of the session's terminal
-	go func() error {
+	updateOurTerminalSize := func() {
+		tick := time.NewTicker(defaults.SessionRefreshPeriod)
 		defer tick.Stop()
 		var prevSess *session.Session
 		for {
@@ -373,6 +385,7 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID, env map
 			case <-tick.C:
 				sess, err := siteClient.GetSession(sessionID)
 				if err != nil {
+					log.Error(err)
 					continue
 				}
 				// no previous session
@@ -386,7 +399,6 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID, env map
 				}
 
 				newSize := sess.TerminalParams.Winsize()
-
 				currentSize, err := term.GetWinsize(0)
 				if err != nil {
 					log.Error(err)
@@ -401,10 +413,15 @@ func (client *NodeClient) Shell(width, height int, sessionID session.ID, env map
 				}
 				prevSess = sess
 			case <-broadcastClose.C:
-				return nil
+				return
 			}
 		}
-	}()
+	}
+
+	if attachedTerm {
+		go broadcastOurTerminalSize()
+		go updateOurTerminalSize()
+	}
 
 	go func() {
 		io.Copy(os.Stderr, stderr)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -656,6 +656,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			utils.Consolef(cfg.Console, "[PROXY] starting the web server: %v", err)
 			return trace.Wrap(err)
 		}
+		defer webHandler.Close()
 
 		proxyLimiter.WrapHandle(webHandler)
 		process.BroadcastEvent(Event{Name: ProxyWebServerEvent, Payload: webHandler})

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -164,6 +164,7 @@ type sessionCache struct {
 
 // Close closes all allocated resources and stops goroutines
 func (s *sessionCache) Close() error {
+	log.Infof("[WEB] closing session cache")
 	return s.closer.Close()
 }
 

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -1249,17 +1249,6 @@ type Server struct {
 	http.Server
 }
 
-func New(addr utils.NetAddr, cfg Config) (*Server, error) {
-	h, err := NewHandler(cfg)
-	if err != nil {
-		return nil, err
-	}
-	srv := &Server{}
-	srv.Server.Addr = addr.Addr
-	srv.Server.Handler = h
-	return srv, nil
-}
-
 // CreateSignupLink generates and returns a URL which is given to a new
 // user to complete registration with Teleport via Web UI
 func CreateSignupLink(hostPort string, token string) string {


### PR DESCRIPTION
### Refactorings
- Found and deleted the unused function in `web` package
- Added `trace.Wrap()` calls where they were missing
### Fixed a few goroutine leaks in teleport.

This fixes #508 Details:
1. Teleport creates a goroutine for querying the size of the terminal. It calls `term.GetWindowSize(0)` with hard-coded `0`. But if there's no terminal attached, this never succeeds and that goroutine is stuck in an endless loop forever.
2. Web session cache creates a goroutine to kill unused/stale sessions. Well... nobody was calling `sessionCache.Close()`, so that goroutine was leaking (one per client). 
### Improvements to Shell Creation

While debugging, I noticed that the sequence of steps of how we initialize shell was wrong. Now there's a callback (from the client to the caller) which can be used to validate that SSH connection has been established, before trying to launch shell.
