### PR TITLE
Cleaned up Teleport logging

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -25,6 +25,9 @@ const (
 	// to bypass firewall restrictions
 	ComponentReverseTunnel = "reversetunnel"
 
+	// ComponentAuth is the cluster CA node (auth server API)
+	ComponentAuth = "auth"
+
 	// ComponentNode is SSH node (SSH server serving requests)
 	ComponentNode = "node"
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -757,9 +757,9 @@ func (tc *TeleportClient) runShell(nodeClient *NodeClient, sessToJoin *session.S
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		log.Infof("connecting to remote shell using stdin")
+		log.Infof("[CLIENT] connecting to remote shell using stdin")
 	} else {
-		log.Infof("connecting to remote shell NOT using stdin")
+		log.Infof("[CLIENT] connecting to remote shell NOT using stdin")
 	}
 	defer func() {
 		if state != nil {
@@ -879,7 +879,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 		HostKeyCallback: tc.HostKeyCallback,
 	}
 
-	log.Infof("connecting to proxy: %v with host login %v", proxyAddr, sshConfig.User)
+	log.Infof("[CLIENT] connecting to proxy %v with host login '%v'", proxyAddr, sshConfig.User)
 
 	// try to authenticate using every non interactive auth method we have:
 	for _, m := range tc.authMethods() {
@@ -891,7 +891,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 			}
 			return nil, trace.Wrap(err)
 		}
-		log.Infof("Successfully authenticated with %v", proxyAddr)
+		log.Infof("[CLIENT] successfully authenticated with %v", proxyAddr)
 		return &ProxyClient{
 			Client:          proxyClient,
 			proxyAddress:    proxyAddr,

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -70,7 +70,7 @@ type FSLocalKeyStore struct {
 //
 // if dirPath is empty, sets it to ~/.tsh
 func NewFSLocalKeyStore(dirPath string) (s *FSLocalKeyStore, err error) {
-	log.Infof("using FSLocalKeyStore")
+	log.Debugf("using FSLocalKeyStore")
 	dirPath, err = initKeysDir(dirPath)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -184,7 +184,7 @@ func (fs *FSLocalKeyStore) GetKey(host, username string) (*Key, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.Infof("returning cert %v valid until %v", certFile, certExpiration)
+	log.Debugf("returning cert %v valid until %v", certFile, certExpiration)
 	if certExpiration.Before(time.Now().UTC()) {
 		log.Infof("TTL expired (%v) for session key %v", certExpiration, dirPath)
 		os.RemoveAll(dirPath)
@@ -214,7 +214,7 @@ func (fs *FSLocalKeyStore) AddKnownHostKeys(hostname string, hostKeys []ssh.Publ
 	}
 	// add every host key to the list of entries
 	for i := range hostKeys {
-		log.Infof("adding known host %s with key: %v", hostname, sshutils.Fingerprint(hostKeys[i]))
+		log.Debugf("adding known host %s with key: %v", hostname, sshutils.Fingerprint(hostKeys[i]))
 		bytes := ssh.MarshalAuthorizedKey(hostKeys[i])
 		line := strings.TrimSpace(fmt.Sprintf("%s %s", hostname, bytes))
 		if _, exists := entries[line]; !exists {

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -119,10 +119,6 @@ const (
 	// LogRotationPeriod defines how frequently to rotate the audit log file
 	LogRotationPeriod = (time.Hour * 24)
 
-	// SessionLingerTTL defines for how long abandoned sessions remain active,
-	// waiting for their parties to restore connection (before being garbage-collected)
-	SessionLingerTTL = time.Duration(time.Second * 5)
-
 	// MaxLoginAttempts sets the max. number of allowed failed login attempts
 	// before a user account is locked for AccountLockInterval
 	MaxLoginAttempts byte = 5

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -136,7 +136,7 @@ func (a *Agent) checkHostSignature(hostport string, remote net.Addr, key ssh.Pub
 		}
 		for _, checker := range checkers {
 			if sshutils.KeysEqual(checker, cert.SignatureKey) {
-				a.log.Infof("matched key %v for %v", ca.ID(), hostport)
+				a.log.Debugf("matched key %v for %v", ca.ID(), hostport)
 				return nil
 			}
 		}
@@ -250,7 +250,7 @@ func (a *Agent) runHeartbeat(conn *ssh.Client) {
 		if conn == nil {
 			return trace.Errorf("heartbeat cannot ping: need to reconnect")
 		}
-		log.Infof("reverse tunnel agent connected to %s", conn.RemoteAddr())
+		log.Infof("[TUNNEL CLIENT] connected to %s", conn.RemoteAddr())
 		defer conn.Close()
 		hb, reqC, err := conn.OpenChannel(chanHeartbeat, nil)
 		if err != nil {
@@ -269,7 +269,7 @@ func (a *Agent) runHeartbeat(conn *ssh.Client) {
 				return nil
 			// time to ping:
 			case <-ticker.C:
-				log.Infof("reverse tunnel agent pings \"%s\" at %s", a.remoteDomainName, conn.RemoteAddr())
+				log.Debugf("[TUNNEL CLIENT] pings \"%s\" at %s", a.remoteDomainName, conn.RemoteAddr())
 				_, err := hb.SendRequest("ping", false, nil)
 				if err != nil {
 					log.Error(err)
@@ -285,7 +285,7 @@ func (a *Agent) runHeartbeat(conn *ssh.Client) {
 				if nch == nil {
 					continue
 				}
-				a.log.Infof("reverseTunnel.Agent: access point request: %v", nch.ChannelType())
+				a.log.Infof("[TUNNEL CLIENT] access point request: %v", nch.ChannelType())
 				ch, req, err := nch.Accept()
 				if err != nil {
 					a.log.Errorf("failed to accept request: %v", err)
@@ -297,7 +297,7 @@ func (a *Agent) runHeartbeat(conn *ssh.Client) {
 				if nch == nil {
 					continue
 				}
-				a.log.Infof("reverseTunnel.Agent: transport request: %v", nch.ChannelType())
+				a.log.Infof("[TUNNEL CLIENT] transport request: %v", nch.ChannelType())
 				ch, req, err := nch.Accept()
 				if err != nil {
 					a.log.Errorf("failed to accept request: %v", err)

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -105,7 +105,7 @@ func (m *AgentPool) pollAndSyncAgents() {
 	for {
 		select {
 		case <-m.closeBroadcast.C:
-			m.Infof("closing")
+			m.Debugf("closing")
 			m.Lock()
 			defer m.Unlock()
 			for _, a := range m.agents {
@@ -132,14 +132,14 @@ func (m *AgentPool) syncAgents(tunnels []services.ReverseTunnel) error {
 	}
 	agentsToAdd, agentsToRemove := diffTunnels(m.agents, keys)
 	for _, key := range agentsToRemove {
-		m.Infof("removing %v", &key)
+		m.Debugf("removing %v", &key)
 		agent := m.agents[key]
 		delete(m.agents, key)
 		agent.Close()
 	}
 
 	for _, key := range agentsToAdd {
-		m.Infof("adding %v", &key)
+		m.Debugf("adding %v", &key)
 		agent, err := NewAgent(key.addr, key.domainName, m.cfg.HostUUID, m.cfg.HostSigners, m.cfg.Client)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/reversetunnel/direct.go
+++ b/lib/reversetunnel/direct.go
@@ -82,12 +82,12 @@ func (s *directSite) ConnectToServer(server, user string, auth []ssh.AuthMethod)
 }
 
 func (s *directSite) Dial(network string, addr string) (net.Conn, error) {
-	s.log.Infof("Dial(net=%v, addr=%v)", network, addr)
+	s.log.Debugf("Dial(addr=%v)", addr)
 	return net.Dial(network, addr)
 }
 
 func (s *directSite) DialServer(addr string) (net.Conn, error) {
-	s.log.Infof("DialServer(addr=%v)", addr)
+	s.log.Debugf("DialServer(addr=%v)", addr)
 	return s.Dial("tcp", addr)
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -150,12 +150,12 @@ func (process *TeleportProcess) connectToAuthService(role teleport.Role) (*Conne
 	// try calling a test method via auth api:
 	//
 	// ??? in case of failure it never gets back here!!!
-	_, err = authClient.GetLocalDomain()
+	dn, err := authClient.GetLocalDomain()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	// success ? we're logged in!
-	log.Infof("%s connected to the cluster", authUser)
+	log.Infof("[Node] %s connected to the cluster '%s'", authUser, dn)
 	return &Connector{Client: authClient, Identity: identity}, nil
 }
 
@@ -510,14 +510,14 @@ func (process *TeleportProcess) RegisterWithAuthServer(token string, role telepo
 			if process.getLocalAuth() != nil {
 				// Auth service is on the same host, no need to go though the invitation
 				// procedure
-				log.Infof("this server has local Auth server started, using it to add role to the cluster")
+				log.Debugf("[Node] this server has local Auth server started, using it to add role to the cluster")
 				err = auth.LocalRegister(cfg.DataDir, identityID, process.getLocalAuth())
 			} else {
 				// Auth server is remote, so we need a provisioning token
 				if token == "" {
 					return trace.BadParameter("%v must join a cluster and needs a provisioning token", role)
 				}
-				log.Infof("%v joining the cluster with a token %v", role, token)
+				log.Infof("[Node] %v joining the cluster with a token %v", role, token)
 				err = auth.Register(cfg.DataDir, token, identityID, cfg.AuthServers)
 			}
 			if err != nil {

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -103,7 +103,7 @@ func (s *LocalSupervisor) Register(srv Service) {
 	defer s.Unlock()
 	s.services = append(s.services, &srv)
 
-	log.Infof("[SUPERVISOR] Service %v added (%v)", srv, len(s.services))
+	log.Debugf("[SUPERVISOR] Service %v added (%v)", srv, len(s.services))
 
 	if s.state == stateStarted {
 		s.serve(&srv)
@@ -132,7 +132,7 @@ func (s *LocalSupervisor) serve(srv *Service) {
 				break
 			}
 		}
-		log.Infof("[SUPERVISOR] Service %v is done (%v)", *srv, len(s.services))
+		log.Debugf("[SUPERVISOR] Service %v is done (%v)", *srv, len(s.services))
 	}
 
 	s.wg.Add(1)
@@ -140,7 +140,7 @@ func (s *LocalSupervisor) serve(srv *Service) {
 		defer s.wg.Done()
 		defer removeService()
 
-		log.Infof("[SUPERVISOR] Service %v started (%v)", *srv, s.ServiceCount())
+		log.Debugf("[SUPERVISOR] Service %v started (%v)", *srv, s.ServiceCount())
 		err := (*srv).Serve()
 		if err != nil {
 			utils.FatalError(err)
@@ -182,7 +182,7 @@ func (s *LocalSupervisor) BroadcastEvent(event Event) {
 	s.Lock()
 	defer s.Unlock()
 	s.events[event.Name] = event
-	log.Infof("BroadcastEvent: %v", &event)
+	log.Debugf("BroadcastEvent: %v", &event)
 
 	go func() {
 		s.eventsC <- event

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -176,7 +176,7 @@ func (c *ctx) String() string {
 }
 
 func (c *ctx) setEnv(key, val string) {
-	c.Infof("setEnv(%v=%v)", key, val)
+	c.Debugf("setEnv(%v=%v)", key, val)
 	c.env[key] = val
 }
 

--- a/lib/srv/proxy.go
+++ b/lib/srv/proxy.go
@@ -51,7 +51,7 @@ type proxySubsys struct {
 //  "proxy:@sitename"        - Teleport request to connect to an auth server for site with name 'sitename'
 //  "proxy:host:22@sitename" - Teleport request to connect to host:22 on site 'sitename'
 func parseProxySubsys(name string, srv *Server) (*proxySubsys, error) {
-	log.Infof("parse_proxy_subsys(%s)", name)
+	log.Debugf("parse_proxy_subsys(%s)", name)
 	var (
 		siteName   string
 		host       string
@@ -122,7 +122,7 @@ func (t *proxySubsys) start(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Requ
 				return trace.Errorf("no connected sites")
 			}
 			site = sites[0]
-			log.Infof("proxy_subsystem: no site specified. connecting to default: '%s'", site.GetName())
+			log.Debugf("proxy_subsystem: no site specified. connecting to default: '%s'", site.GetName())
 		}
 		return t.proxyToHost(site, ch)
 	}
@@ -151,7 +151,7 @@ func (t *proxySubsys) proxyToSite(site reversetunnel.RemoteSite, ch ssh.Channel)
 			log.Error(err)
 			continue
 		}
-		log.Infof("proxy_subsystem: connected to auth server: %v", authServer.Addr)
+		log.Infof("[PROXY] connected to auth server: %v", authServer.Addr)
 		go func() {
 			var err error
 			defer func() {

--- a/lib/srv/sites.go
+++ b/lib/srv/sites.go
@@ -50,7 +50,7 @@ func (t *proxySitesSubsys) wait() error {
 // start serves a request for "proxysites" custom SSH subsystem. It builds an array of
 // service.Site structures, and writes it serialized as JSON back to the SSH client
 func (t *proxySitesSubsys) start(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
-	log.Infof("proxysites.start(%v)", ctx)
+	log.Debugf("proxysites.start(%v)", ctx)
 	remoteSites := t.srv.proxyTun.GetSites()
 
 	// build an arary of services.Site structures:

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -46,7 +46,7 @@ type terminal struct {
 func parsePTYReq(req *ssh.Request) (*sshutils.PTYReqParams, error) {
 	var r sshutils.PTYReqParams
 	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
-		log.Infof("failed to parse PTY request: %v", err)
+		log.Warnf("failed to parse PTY request: %v", err)
 		return nil, err
 	}
 	return &r, nil
@@ -56,7 +56,7 @@ func newTerminal() (*terminal, error) {
 	// Create new PTY
 	pty, tty, err := pty.Open()
 	if err != nil {
-		log.Infof("could not start pty (%s)", err)
+		log.Warnf("could not start pty (%s)", err)
 		return nil, err
 	}
 	return &terminal{pty: pty, tty: tty, err: err}, nil
@@ -65,13 +65,13 @@ func newTerminal() (*terminal, error) {
 func requestPTY(req *ssh.Request) (*terminal, *rsession.TerminalParams, error) {
 	var r sshutils.PTYReqParams
 	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
-		log.Infof("failed to parse PTY request: %v", err)
+		log.Warnf("failed to parse PTY request: %v", err)
 		return nil, nil, trace.Wrap(err)
 	}
-	log.Infof("Parsed pty request pty(enn=%v, w=%v, h=%v)", r.Env, r.W, r.H)
+	log.Debugf("Parsed pty request pty(enn=%v, w=%v, h=%v)", r.Env, r.W, r.H)
 	t, err := newTerminal()
 	if err != nil {
-		log.Infof("failed to create term: %v", err)
+		log.Warnf("failed to create term: %v", err)
 		return nil, nil, trace.Wrap(err)
 	}
 	params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
@@ -118,7 +118,7 @@ func (t *terminal) getTerminalParams() rsession.TerminalParams {
 
 func (t *terminal) closeTTY() {
 	if err := t.tty.Close(); err != nil {
-		log.Infof("failed to close TTY: %v", err)
+		log.Warnf("failed to close TTY: %v", err)
 	}
 	t.tty = nil
 }

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -52,6 +52,7 @@ func (s *ServerSuite) TestStartStop(c *C) {
 	})
 
 	srv, err := NewServer(
+		"test",
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
 		fn,
 		s.signers,

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -52,11 +52,20 @@ func InitLoggerCLI() {
 
 // InitLoggerDebug configures the logger to dump everything to stderr
 func InitLoggerDebug() {
+	InitDebugLogger(log.DebugLevel)
+}
+
+// InitLoggerVerbose is a less chatty version of debug logger above
+func InitLoggerVerbose() {
+	InitDebugLogger(log.InfoLevel)
+}
+
+func InitDebugLogger(level log.Level) {
 	// clear existing hooks:
 	log.StandardLogger().Hooks = make(log.LevelHooks)
 	log.SetFormatter(&trace.TextFormatter{})
 	log.SetOutput(os.Stderr)
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(level)
 }
 
 // InitLoggerForTests inits logger to discard ouput in tests unless


### PR DESCRIPTION
- Downgraded many messages from `Debug` to `Info`
- Edited messages so they're not verbose and not too short
- Added "context" to some
- Added logical teleport component as [COMPONENT] at the beginning of
  many, making logs **vastly** easier to read. **NOTE** I am only doing this for debug/info, because they're only used for development/debugging and not in production.
- Added one more logging level option when creating Teleport (only
  Teleconsole uses it for now)

The output with 'info' severity now look extremely clean.
This is startup, for example:

```
INFO[0000] [AUTH]  Auth service is starting on turing:32829  file=utils/cli.go:107
INFO[0000] [SSH:auth] listening socket: 127.0.0.1:32829  file=sshutils/server.go:119
INFO[0000] [SSH:auth] is listening on 127.0.0.1:32829    file=sshutils/server.go:144
INFO[0000] [Proxy] Successfully registered with the cluster  file=utils/cli.go:107
INFO[0000] [Node] Successfully registered with the cluster  file=utils/cli.go:107
INFO[0000] [AUTH] keyAuth: 127.0.0.1:56886->127.0.0.1:32829, user=turing  file=auth/tun.go:370
WARN[0000] unable to load the auth server cache: open /tmp/cluster-teleconsole-client781495771/authservers.json: no such file or directory  file=auth/tun.go:594
INFO[0000] [SSH:auth] new connection 127.0.0.1:56886 -> 127.0.0.1:32829 vesion: SSH-2.0-Go  file=sshutils/server.go:205
INFO[0000] [AUTH] keyAuth: 127.0.0.1:56888->127.0.0.1:32829, user=turing.teleconsole-client  file=auth/tun.go:370
INFO[0000] [AUTH] keyAuth: 127.0.0.1:56890->127.0.0.1:32829, user=turing.teleconsole-client  file=auth/tun.go:370
INFO[0000] [Node] turing connected to the cluster 'teleconsole-client'  file=service/service.go:158
INFO[0000] [AUTH] keyAuth: 127.0.0.1:56892->127.0.0.1:32829, user=turing  file=auth/tun.go:370
INFO[0000] [SSH:auth] new connection 127.0.0.1:56890 -> 127.0.0.1:32829 vesion: SSH-2.0-Go  file=sshutils/server.go:205
INFO[0000] [SSH:auth] new connection 127.0.0.1:56888 -> 127.0.0.1:32829 vesion: SSH-2.0-Go  file=sshutils/server.go:205
INFO[0000] [Node] turing.teleconsole-client connected to the cluster 'teleconsole-client'  file=service/service.go:158
INFO[0000] [Node] turing.teleconsole-client connected to the cluster 'teleconsole-client'  file=service/service.go:158
INFO[0000] [SSH] received event(SSHIdentity)             file=service/service.go:436
INFO[0000] [SSH] received event(ProxyIdentity)           file=service/service.go:563
```

You can easily tell that auth, ssh node and proxy have successfully started.
