### PR TITLE
Implemented a new Teleport option: "no recording"

### DIFF
--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -46,7 +46,7 @@ type APISuite struct {
 	bk       backend.Backend
 	a        *AuthServer
 	dir      string
-	alog     *events.AuditLog
+	alog     events.IAuditLog
 	sessions session.Service
 
 	CAS           services.Trust
@@ -101,8 +101,12 @@ func (s *APISuite) SetUpTest(c *C) {
 }
 
 func (s *APISuite) TearDownTest(c *C) {
+	fileBasedLog, ok := s.alog.(*events.AuditLog)
+	c.Assert(ok, Equals, true)
+	if ok {
+		fileBasedLog.Close()
+	}
 	s.srv.Close()
-	s.alog.Close()
 	os.RemoveAll(s.dir)
 }
 

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -45,7 +45,7 @@ type TunSuite struct {
 	a             *AuthServer
 	signer        ssh.Signer
 	dir           string
-	alog          *events.AuditLog
+	alog          events.IAuditLog
 	conf          *APIConfig
 	sessionServer session.Service
 }

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -90,9 +90,7 @@ const (
 type TimeSourceFunc func() time.Time
 
 // AuditLog is a new combined facility to record Teleport events and
-// sessions. It implements these interfaces:
-//	- events.Log
-//	- recorder.Recorder
+// sessions. It implements IAuditLog
 type AuditLog struct {
 	sync.Mutex
 	loggers map[session.ID]*SessionLogger
@@ -206,7 +204,7 @@ func (sl *SessionLogger) Write(bytes []byte) (written int, err error) {
 
 // Creates and returns a new Audit Log oboject whish will store its logfiles
 // in a given directory>
-func NewAuditLog(dataDir string) (*AuditLog, error) {
+func NewAuditLog(dataDir string) (IAuditLog, error) {
 	// create a directory for session logs:
 	if err := os.MkdirAll(dataDir, 0770); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -1,0 +1,29 @@
+package events
+
+import (
+	"io"
+	"time"
+
+	"github.com/gravitational/teleport/lib/session"
+)
+
+// DiscardAuditLog is do-nothing, discard-everything implementation
+// of IAuditLog interface used for cases when audit is turned off
+type DiscardAuditLog struct {
+}
+
+func (d *DiscardAuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
+	return nil
+}
+func (d *DiscardAuditLog) PostSessionChunk(sid session.ID, reader io.Reader) error {
+	return nil
+}
+func (d *DiscardAuditLog) GetSessionChunk(sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
+	return make([]byte, 0), nil
+}
+func (d *DiscardAuditLog) GetSessionEvents(sid session.ID, after int) ([]EventFields, error) {
+	return make([]EventFields, 0), nil
+}
+func (d *DiscardAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]EventFields, error) {
+	return make([]EventFields, 0), nil
+}

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -262,6 +262,9 @@ type AuthConfig struct {
 	}
 
 	Limiter limiter.LimiterConfig
+
+	// NoAudit, when set to true, disables session recording and event audit
+	NoAudit bool
 }
 
 // SSHConfig configures SSH server node role

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -273,9 +273,15 @@ func (process *TeleportProcess) initAuthService(authority auth.Authority) error 
 
 	// create the audit log, which will be consuming (and recording) all events
 	// and record sessions
-	auditLog, err := events.NewAuditLog(filepath.Join(cfg.DataDir, "log"))
-	if err != nil {
-		return trace.Wrap(err)
+	var auditLog events.IAuditLog
+	if cfg.Auth.NoAudit {
+		auditLog = &events.DiscardAuditLog{}
+		log.Warn("the audit and session recording are turned off")
+	} else {
+		auditLog, err = events.NewAuditLog(filepath.Join(cfg.DataDir, "log"))
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	// first, create the AuthServer

--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -62,7 +62,7 @@ type SrvSuite struct {
 	bk            backend.Backend
 	a             *auth.AuthServer
 	roleAuth      *auth.AuthWithRoles
-	alog          *events.AuditLog
+	alog          events.IAuditLog
 	up            *upack
 	signer        ssh.Signer
 	dir           string

--- a/lib/web/web_test.go
+++ b/lib/web/web_test.go
@@ -76,7 +76,7 @@ type WebSuite struct {
 	freePorts   []string
 
 	// audit log and its dir:
-	auditLog *events.AuditLog
+	auditLog events.IAuditLog
 	logDir   string
 }
 


### PR DESCRIPTION
Teleport configuration now has a new field: NoAudit (false by default,
which means audit is always on).

When this option is set, Teleport will not record events and will not
record sessions.

It's implemented by adding "DiscardLogger" which implements the same
interface as teh real logger, and it's plugged into the system instead.

NOTE: this option is not exposed in teleport in any way: no config file,
no switch, etc. I quickly needed it for Telecast.
