### PR TITLE
Support for "allocate TTY" option when launching commands via SSH

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -35,7 +35,7 @@ test: integration
 
 .PHONY:integration
 integration: bbox
-	docker run $(DOCKERFLAGS) $(NOROOT) -i $(BBOX) \
+	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
  		/bin/bash -c "$(MAKE) -C $(SRCDIR) FLAGS='-cover' integration"
 
 #

--- a/constants.go
+++ b/constants.go
@@ -42,4 +42,16 @@ const (
 
 	// DebugOutputEnvVar tells tests to use verbose debug output
 	DebugOutputEnvVar = "TELEPORT_DEBUG"
+
+	// DefaultTerminalWidth defines the default width of a server-side allocated
+	// pseudo TTY
+	DefaultTerminalWidth = 80
+
+	// DefaultTerminalHeight defines the default height of a server-side allocated
+	// pseudo TTY
+	DefaultTerminalHeight = 25
+
+	// SafeTerminalType is the fall-back TTY type to fall back to (when $TERM
+	// is not defined)
+	SafeTerminalType = "xterm"
 )

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -129,6 +129,10 @@ type Config struct {
 
 	// Env is a map of environmnent variables to send when opening session
 	Env map[string]string
+
+	// Interactive, when set to true, tells tsh to launch a remote command
+	// in interactive mode, i.e. attaching the temrinal to it
+	Interactive bool
 }
 
 // ProxyHostPort returns a full host:port address of the SSH proxy
@@ -675,7 +679,7 @@ func (tc *TeleportClient) runCommand(siteName string, nodeAddresses []string, pr
 				return
 			}
 			// TODO: instead of "always false" (always non-interactive) implement a proper flag!!!
-			if err = nodeSession.runCommand(command, false); err != nil {
+			if err = nodeSession.runCommand(command, tc.Config.Interactive); err != nil {
 				exitErr, ok := err.(*ssh.ExitError)
 				if ok {
 					tc.ExitStatus = exitErr.ExitStatus()

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -255,24 +255,6 @@ func (proxy *ProxyClient) Close() error {
 	return proxy.Client.Close()
 }
 
-// Shell returns a configured remote shell (for a window of a requested size)
-// as io.ReadWriterCloser object
-//
-// Parameters:
-//	- width & height : size of the window
-//  - session id     : ID of a session (if joining existing) or empty to create
-//                     a new session
-//  - env            : list of environment variables to set for a new session
-//  - attachedTerm   : boolean indicating if this client is attached to a real terminal
-func (client *NodeClient) Shell(nc *NodeSession) (io.ReadWriteCloser, error) {
-	pipe, err := nc.allocateTerminal()
-	// start the shell on the server:
-	if err := nc.serverSession.Shell(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return pipe, err
-}
-
 // Run executes command on the remote server and writes its stdout to
 // the 'output' argument
 func (client *NodeClient) Run(cmd []string, stdin io.Reader, stdout, stderr io.Writer, env map[string]string) error {

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -255,26 +255,6 @@ func (proxy *ProxyClient) Close() error {
 	return proxy.Client.Close()
 }
 
-// Run executes command on the remote server and writes its stdout to
-// the 'output' argument
-func (client *NodeClient) Run(cmd []string, stdin io.Reader, stdout, stderr io.Writer, env map[string]string) error {
-	session, err := client.Client.NewSession()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	// pass environment variables set by client
-	for key, val := range env {
-		err = session.Setenv(key, val)
-		if err != nil {
-			log.Warn(err)
-		}
-	}
-	session.Stdout = stdout
-	session.Stderr = stderr
-	session.Stdin = stdin
-	return session.Run(strings.Join(cmd, " "))
-}
-
 // Upload uploads file or dir to the remote server
 func (client *NodeClient) Upload(localSourcePath, remoteDestinationPath string, stderr io.Writer) error {
 	file, err := os.Open(localSourcePath)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -19,26 +19,19 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/session"
-	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/scp"
 	"github.com/gravitational/teleport/lib/utils"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/docker/pkg/term"
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 )
@@ -262,104 +255,6 @@ func (proxy *ProxyClient) Close() error {
 	return proxy.Client.Close()
 }
 
-type NodeSession struct {
-	// id is the Teleport session ID
-	id session.ID
-
-	// env is the environment variables that need to be created
-	// on the server for this session
-	env map[string]string
-
-	// attachedTerm is set to true when this session is be controlled by
-	// a real terminal.
-	// This will be set to False for sessions initiated by the Web client or
-	// for non-interactive sessions (commands)
-	attachedTerm bool
-
-	// terminalSize is the inital size of the terminal. It only has meaning
-	// when the session is interactive
-	terminalSize *term.Winsize
-
-	// serverSession is the server-side SSH session
-	serverSession *ssh.Session
-
-	// nodeClient is the parent of this session: the client connected to an
-	// SSH node
-	nodeClient *NodeClient
-}
-
-func newSession(client *NodeClient,
-	joinSession *session.Session,
-	env map[string]string,
-	attachedTerm bool) (*NodeSession, error) {
-
-	var err error
-	ns := &NodeSession{
-		attachedTerm: attachedTerm,
-		env:          env,
-		nodeClient:   client,
-		terminalSize: &term.Winsize{Width: 80, Height: 25},
-	}
-
-	// read the size of the terminal window:
-	if attachedTerm {
-		ns.terminalSize, err = term.GetWinsize(0)
-		if err != nil {
-			log.Error(err)
-		}
-		state, err := term.SetRawTerminal(0)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		defer term.RestoreTerminal(0, state)
-	}
-
-	// if we're joining an existing session, we need to assume that session's
-	// existing/current terminal size:
-	if joinSession != nil {
-		ns.id = joinSession.ID
-		ns.terminalSize = joinSession.TerminalParams.Winsize()
-		if attachedTerm {
-			err = term.SetWinsize(0, ns.terminalSize)
-			if err != nil {
-				log.Error(err)
-			}
-			os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", ns.terminalSize.Height, ns.terminalSize.Width)))
-		}
-		// new session!
-	} else {
-		ns.id = session.NewID()
-	}
-	if ns.env == nil {
-		ns.env = make(map[string]string)
-	}
-	ns.env[sshutils.SessionEnvVar] = string(ns.id)
-
-	// create the server-side session:
-	ns.serverSession, err = client.Client.NewSession()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	// pass language info into the remote session.
-	evarsToPass := []string{"LANG", "LANGUAGE"}
-	for _, evar := range evarsToPass {
-		if value := os.Getenv(evar); value != "" {
-			err = ns.serverSession.Setenv(evar, value)
-			if err != nil {
-				log.Warn(err)
-			}
-		}
-	}
-	// pass environment variables set by client
-	for key, val := range env {
-		err = ns.serverSession.Setenv(key, val)
-		if err != nil {
-			log.Warn(err)
-		}
-	}
-	return ns, nil
-}
-
 // Shell returns a configured remote shell (for a window of a requested size)
 // as io.ReadWriterCloser object
 //
@@ -376,122 +271,6 @@ func (client *NodeClient) Shell(nc *NodeSession) (io.ReadWriteCloser, error) {
 		return nil, trace.Wrap(err)
 	}
 	return pipe, err
-}
-
-// allocateTerminal creates (allocates) a server-side terminal for a given session.
-func (ns *NodeSession) allocateTerminal() (io.ReadWriteCloser, error) {
-	err := ns.serverSession.RequestPty("xterm",
-		int(ns.terminalSize.Height),
-		int(ns.terminalSize.Width),
-		ssh.TerminalModes{})
-
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	writer, err := ns.serverSession.StdinPipe()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	reader, err := ns.serverSession.StdoutPipe()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	stderr, err := ns.serverSession.StderrPipe()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	closer := utils.NewCloseBroadcaster()
-	if ns.attachedTerm {
-		go ns.updateTerminalSize(closer)
-	}
-	go func() {
-		io.Copy(os.Stderr, stderr)
-	}()
-	return utils.NewPipeNetConn(
-		reader,
-		writer,
-		utils.MultiCloser(writer, ns.serverSession, closer),
-		&net.IPAddr{},
-		&net.IPAddr{},
-	), nil
-}
-
-func (ns *NodeSession) updateTerminalSize(closer *utils.CloseBroadcaster) {
-	// sibscribe for "terminal resized" signal:
-	sigC := make(chan os.Signal, 1)
-	signal.Notify(sigC, syscall.SIGWINCH)
-	currentSize, _ := term.GetWinsize(0)
-
-	// start the timer which asks for server-side window size changes:
-	siteClient, err := ns.nodeClient.Proxy.ConnectToSite()
-	if err != nil {
-		log.Error(err)
-	}
-	tick := time.NewTicker(defaults.SessionRefreshPeriod)
-	defer tick.Stop()
-
-	var prevSess *session.Session
-	for {
-		select {
-		case sig := <-sigC:
-			if sig == nil {
-				return
-			}
-			// get the size:
-			winSize, err := term.GetWinsize(0)
-			if err != nil {
-				log.Warnf("[CLIENT] Error getting size: %s", err)
-				break
-			}
-			// it's the result of our own size change (see below)
-			if winSize.Height == currentSize.Height && winSize.Width == currentSize.Width {
-				continue
-			}
-			// send the new window size to the server
-			_, err = ns.serverSession.SendRequest(
-				sshutils.WindowChangeReq, false,
-				ssh.Marshal(sshutils.WinChangeReqParams{
-					W: uint32(winSize.Width),
-					H: uint32(winSize.Height),
-				}))
-			if err != nil {
-				log.Warnf("[CLIENT] failed to send window change reqest: %v", err)
-			}
-		case <-tick.C:
-			sess, err := siteClient.GetSession(ns.id)
-			if err != nil {
-				log.Error(err)
-				continue
-			}
-			// no previous session
-			if prevSess == nil || sess == nil {
-				prevSess = sess
-				continue
-			}
-			log.Infof("[CLIENT] updating the session %v with %d parties", sess.ID, len(sess.Parties))
-			// nothing changed
-			if prevSess.TerminalParams.W == sess.TerminalParams.W && prevSess.TerminalParams.H == sess.TerminalParams.H {
-				continue
-			}
-
-			newSize := sess.TerminalParams.Winsize()
-			currentSize, err = term.GetWinsize(0)
-			if err != nil {
-				log.Error(err)
-			}
-			if currentSize.Width != newSize.Width || currentSize.Height != newSize.Height {
-				// ok, something have changed, let's resize to the new parameters
-				err = term.SetWinsize(0, newSize)
-				if err != nil {
-					log.Error(err)
-				}
-				os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", newSize.Height, newSize.Width)))
-			}
-			prevSess = sess
-		case <-closer.C:
-			return
-		}
-	}
 }
 
 // Run executes command on the remote server and writes its stdout to

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -1,0 +1,235 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/docker/docker/pkg/term"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+type NodeSession struct {
+	// id is the Teleport session ID
+	id session.ID
+
+	// env is the environment variables that need to be created
+	// on the server for this session
+	env map[string]string
+
+	// attachedTerm is set to true when this session is be controlled by
+	// a real terminal.
+	// This will be set to False for sessions initiated by the Web client or
+	// for non-interactive sessions (commands)
+	attachedTerm bool
+
+	// terminalSize is the inital size of the terminal. It only has meaning
+	// when the session is interactive
+	terminalSize *term.Winsize
+
+	// serverSession is the server-side SSH session
+	serverSession *ssh.Session
+
+	// nodeClient is the parent of this session: the client connected to an
+	// SSH node
+	nodeClient *NodeClient
+}
+
+func newSession(client *NodeClient,
+	joinSession *session.Session,
+	env map[string]string,
+	attachedTerm bool) (*NodeSession, error) {
+
+	var err error
+	ns := &NodeSession{
+		attachedTerm: attachedTerm,
+		env:          env,
+		nodeClient:   client,
+		terminalSize: &term.Winsize{Width: 80, Height: 25},
+	}
+
+	// read the size of the terminal window:
+	if attachedTerm {
+		ns.terminalSize, err = term.GetWinsize(0)
+		if err != nil {
+			log.Error(err)
+		}
+		state, err := term.SetRawTerminal(0)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		defer term.RestoreTerminal(0, state)
+	}
+
+	// if we're joining an existing session, we need to assume that session's
+	// existing/current terminal size:
+	if joinSession != nil {
+		ns.id = joinSession.ID
+		ns.terminalSize = joinSession.TerminalParams.Winsize()
+		if attachedTerm {
+			err = term.SetWinsize(0, ns.terminalSize)
+			if err != nil {
+				log.Error(err)
+			}
+			os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", ns.terminalSize.Height, ns.terminalSize.Width)))
+		}
+		// new session!
+	} else {
+		ns.id = session.NewID()
+	}
+	if ns.env == nil {
+		ns.env = make(map[string]string)
+	}
+	ns.env[sshutils.SessionEnvVar] = string(ns.id)
+
+	// create the server-side session:
+	ns.serverSession, err = client.Client.NewSession()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// pass language info into the remote session.
+	evarsToPass := []string{"LANG", "LANGUAGE"}
+	for _, evar := range evarsToPass {
+		if value := os.Getenv(evar); value != "" {
+			err = ns.serverSession.Setenv(evar, value)
+			if err != nil {
+				log.Warn(err)
+			}
+		}
+	}
+	// pass environment variables set by client
+	for key, val := range env {
+		err = ns.serverSession.Setenv(key, val)
+		if err != nil {
+			log.Warn(err)
+		}
+	}
+	return ns, nil
+}
+
+// allocateTerminal creates (allocates) a server-side terminal for a given session.
+func (ns *NodeSession) allocateTerminal() (io.ReadWriteCloser, error) {
+	err := ns.serverSession.RequestPty("xterm",
+		int(ns.terminalSize.Height),
+		int(ns.terminalSize.Width),
+		ssh.TerminalModes{})
+
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	writer, err := ns.serverSession.StdinPipe()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	reader, err := ns.serverSession.StdoutPipe()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	stderr, err := ns.serverSession.StderrPipe()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	closer := utils.NewCloseBroadcaster()
+	if ns.attachedTerm {
+		go ns.updateTerminalSize(closer)
+	}
+	go func() {
+		io.Copy(os.Stderr, stderr)
+	}()
+	return utils.NewPipeNetConn(
+		reader,
+		writer,
+		utils.MultiCloser(writer, ns.serverSession, closer),
+		&net.IPAddr{},
+		&net.IPAddr{},
+	), nil
+}
+
+func (ns *NodeSession) updateTerminalSize(closer *utils.CloseBroadcaster) {
+	// sibscribe for "terminal resized" signal:
+	sigC := make(chan os.Signal, 1)
+	signal.Notify(sigC, syscall.SIGWINCH)
+	currentSize, _ := term.GetWinsize(0)
+
+	// start the timer which asks for server-side window size changes:
+	siteClient, err := ns.nodeClient.Proxy.ConnectToSite()
+	if err != nil {
+		log.Error(err)
+	}
+	tick := time.NewTicker(defaults.SessionRefreshPeriod)
+	defer tick.Stop()
+
+	var prevSess *session.Session
+	for {
+		select {
+		case sig := <-sigC:
+			if sig == nil {
+				return
+			}
+			// get the size:
+			winSize, err := term.GetWinsize(0)
+			if err != nil {
+				log.Warnf("[CLIENT] Error getting size: %s", err)
+				break
+			}
+			// it's the result of our own size change (see below)
+			if winSize.Height == currentSize.Height && winSize.Width == currentSize.Width {
+				continue
+			}
+			// send the new window size to the server
+			_, err = ns.serverSession.SendRequest(
+				sshutils.WindowChangeReq, false,
+				ssh.Marshal(sshutils.WinChangeReqParams{
+					W: uint32(winSize.Width),
+					H: uint32(winSize.Height),
+				}))
+			if err != nil {
+				log.Warnf("[CLIENT] failed to send window change reqest: %v", err)
+			}
+		case <-tick.C:
+			sess, err := siteClient.GetSession(ns.id)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+			// no previous session
+			if prevSess == nil || sess == nil {
+				prevSess = sess
+				continue
+			}
+			log.Infof("[CLIENT] updating the session %v with %d parties", sess.ID, len(sess.Parties))
+			// nothing changed
+			if prevSess.TerminalParams.W == sess.TerminalParams.W && prevSess.TerminalParams.H == sess.TerminalParams.H {
+				continue
+			}
+
+			newSize := sess.TerminalParams.Winsize()
+			currentSize, err = term.GetWinsize(0)
+			if err != nil {
+				log.Error(err)
+			}
+			if currentSize.Width != newSize.Width || currentSize.Height != newSize.Height {
+				// ok, something have changed, let's resize to the new parameters
+				err = term.SetWinsize(0, newSize)
+				if err != nil {
+					log.Error(err)
+				}
+				os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", newSize.Height, newSize.Width)))
+			}
+			prevSess = sess
+		case <-closer.C:
+			return
+		}
+	}
+}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -88,6 +88,9 @@ type ctx struct {
 
 	// session, if there's an active one
 	session *session
+
+	// full command asked to be executed in this context
+	exec *execResponse
 }
 
 // addCloser adds any closer in ctx that will be called

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -166,7 +166,6 @@ func prepareCommand(ctx *ctx, cmd string) (*exec.Cmd, error) {
 		c = exec.Command(shell, append([]string{"-c", cmd})...)
 	}
 	c.Env = []string{
-		"TERM=xterm",
 		"LANG=en_US.UTF-8",
 		"HOME=" + osUser.HomeDir,
 		"USER=" + osUserName,

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -65,7 +65,7 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 	}
 
 	// empty command (simple shell)
-	cmd, err := prepareShell(s.ctx)
+	cmd, err := prepInteractiveCommand(s.ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(cmd, check.NotNil)
 	c.Assert(cmd.Path, check.Equals, "/bin/sh")

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	rsession "github.com/gravitational/teleport/lib/session"
@@ -278,12 +279,15 @@ type session struct {
 // newSession creates a new session with a given ID within a given context.
 func newSession(id rsession.ID, r *sessionRegistry, context *ctx) (*session, error) {
 	rsess := rsession.Session{
-		ID:             id,
-		TerminalParams: rsession.TerminalParams{W: 80, H: 25},
-		Login:          context.login,
-		Created:        time.Now().UTC(),
-		LastActive:     time.Now().UTC(),
-		ServerID:       context.srv.ID(),
+		ID: id,
+		TerminalParams: rsession.TerminalParams{
+			W: teleport.DefaultTerminalWidth,
+			H: teleport.DefaultTerminalHeight,
+		},
+		Login:      context.login,
+		Created:    time.Now().UTC(),
+		LastActive: time.Now().UTC(),
+		ServerID:   context.srv.ID(),
 	}
 	term := context.getTerm()
 	if term != nil {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -57,7 +57,7 @@ func (r *sessionRegistry) Close() {
 }
 
 // joinShell either joins an existing session or starts a new shell
-func (s *sessionRegistry) joinShell(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
+func (s *sessionRegistry) openSession(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 	if ctx.session != nil {
 		// emit "joined session" event:
 		s.srv.EmitAuditEvent(events.SessionJoinEvent, events.EventFields{
@@ -88,15 +88,15 @@ func (s *sessionRegistry) joinShell(ch ssh.Channel, req *ssh.Request, ctx *ctx) 
 	s.addSession(sess)
 	ctx.Infof("[SESSION] new session %v", sid)
 
-	if err := sess.startShell(ch, ctx); err != nil {
+	if err := sess.start(ch, ctx); err != nil {
 		sess.Close()
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-// leaveShell remvoes a given party from this session
-func (s *sessionRegistry) leaveShell(party *party) error {
+// leaveSession removes the given party from this session
+func (s *sessionRegistry) leaveSession(party *party) error {
 	sess := party.s
 	s.Lock()
 	defer s.Unlock()
@@ -426,8 +426,8 @@ func (r *sessionRecorder) Close() error {
 	return nil
 }
 
-// startShell starts a new shell process in the current session
-func (s *session) startShell(ch ssh.Channel, ctx *ctx) error {
+// start starts a new interactive process (or a shell) in the current session
+func (s *session) start(ch ssh.Channel, ctx *ctx) error {
 	// create a new "party" (connected client)
 	p := newParty(s, ch, ctx)
 
@@ -444,7 +444,7 @@ func (s *session) startShell(ch ssh.Channel, ctx *ctx) error {
 		}
 	}
 	// prepare environment & Launch shell:
-	cmd, err := prepareShell(ctx)
+	cmd, err := prepInteractiveCommand(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -826,7 +826,7 @@ func (p *party) String() string {
 func (p *party) Close() (err error) {
 	p.closeOnce.Do(func() {
 		p.ctx.Infof("party[%v].Close()", p.id)
-		if err = p.s.registry.leaveShell(p); err != nil {
+		if err = p.s.registry.leaveSession(p); err != nil {
 			p.ctx.Error(err)
 		}
 		close(p.closeC)

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -75,6 +75,8 @@ type CLIConf struct {
 	ExternalAuth string
 	// SiteName specifies remote site go login to
 	SiteName string
+	// Interactive, when set to true, launches remote command with the terminal attached
+	Interactive bool
 }
 
 // run executes TSH client. same as main() but easier to test
@@ -104,6 +106,7 @@ func run(args []string, underTest bool) {
 	ssh.Flag("port", "SSH port on a remote host").Short('p').Int16Var(&cf.NodePort)
 	ssh.Flag("forward", "Forward localhost connections to remote server").Short('L').StringsVar(&cf.LocalForwardPorts)
 	ssh.Flag("local", "Execute command on localhost after connecting to SSH node").Default("false").BoolVar(&cf.LocalExec)
+	ssh.Flag("", "Allocate TTY").Short('t').BoolVar(&cf.Interactive)
 	// join
 	join := app.Command("join", "Join the active SSH session")
 	join.Arg("session-id", "ID of the session to join").Required().StringVar(&cf.SessionID)
@@ -395,6 +398,7 @@ func makeClient(cf *CLIConf) (tc *client.TeleportClient, err error) {
 		LocalForwardPorts:  fPorts,
 		ConnectorID:        cf.ExternalAuth,
 		SiteName:           cf.SiteName,
+		Interactive:        cf.Interactive,
 	}
 	return client.NewClient(c)
 }

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -272,7 +272,8 @@ func onSSH(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	if err = tc.SSH(cf.RemoteCommand, cf.LocalExec, nil); err != nil {
+	tc.Stdin = os.Stdin
+	if err = tc.SSH(cf.RemoteCommand, cf.LocalExec); err != nil {
 		// exit with the same exit status as the failed command:
 		if tc.ExitStatus != 0 {
 			os.Exit(tc.ExitStatus)


### PR DESCRIPTION
### Description

`tsh` now supports `-t` flag to allocate TTY before executing a command. The flag will remain undocumented until more testing is done and documentation is updated. 
This PR is just for the "guts".
### Changes

`tsh` has gone through some major refactoring/changes, most importantly a "client session" object has been added which is somewhat similar to server-side `ctx`. This structure keeps the details of the ongoing session, including the terminal.

On the server side, the changes (surprisingly) have been light: primarily I have unified the code responsible for launching shells and launching interactive commands (so it's the same thing now).

Also, `tsh` now tries to request the same terminal type, as your `$TERM` variable says.
