### PR TITLE
Bufix: certificate expiration issue

### DIFF
--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -143,8 +143,8 @@ func (n *nauth) GenerateHostCert(privateSigningKey, publicKey []byte, hostname, 
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if ttl != 0 {
-		b := time.Now().In(time.UTC).Add(ttl)
-		validBefore = uint64(b.UnixNano())
+		b := time.Now().Add(ttl)
+		validBefore = uint64(b.Unix())
 	}
 	cert := &ssh.Certificate{
 		ValidPrincipals: []string{hostname},
@@ -178,8 +178,8 @@ func (n *nauth) GenerateUserCert(pkey, key []byte, teleportUsername string, allo
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if ttl != 0 {
-		b := time.Now().In(time.UTC).Add(ttl)
-		validBefore = uint64(b.UnixNano())
+		b := time.Now().Add(ttl)
+		validBefore = uint64(b.Unix())
 		log.Infof("generated user key for %v with expiry on (%v) %v", allowedLogins, validBefore, b)
 	}
 	// we do not use any extensions in users certs because of this:

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -48,8 +48,8 @@ func (n *Keygen) GenerateHostCert(pkey, key []byte, hostname, authDomain string,
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if ttl != 0 {
-		b := time.Now().In(time.UTC).Add(ttl)
-		validBefore = uint64(b.UnixNano())
+		b := time.Now().Add(ttl)
+		validBefore = uint64(b.Unix())
 	}
 	cert := &ssh.Certificate{
 		ValidPrincipals: []string{hostname},
@@ -77,8 +77,8 @@ func (n *Keygen) GenerateUserCert(pkey, key []byte, teleportUsername string, all
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if ttl != 0 {
-		b := time.Now().In(time.UTC).Add(ttl)
-		validBefore = uint64(b.UnixNano())
+		b := time.Now().Add(ttl)
+		validBefore = uint64(b.Unix())
 	}
 	cert := &ssh.Certificate{
 		KeyId:           teleportUsername,

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -48,16 +48,15 @@ func (k *Key) AsAgentKey() (*agent.AddedKey, error) {
 	}, nil
 }
 
-// CertValidBefore returns UTC time of the cert expiration
-func (k *Key) CertValidBefore() (time.Time, error) {
+// CertValidBefore returns the time of the cert expiration
+func (k *Key) CertValidBefore() (t time.Time, err error) {
 	pcert, _, _, _, err := ssh.ParseAuthorizedKey(k.Cert)
 	if err != nil {
-		return time.Now().In(time.UTC), trace.Wrap(err)
+		return t, trace.Wrap(err)
 	}
-	cert := pcert.(*ssh.Certificate)
-
-	utime := int64(cert.ValidBefore)
-	etime := time.Unix(0, utime)
-
-	return etime.In(time.UTC), nil
+	cert, ok := pcert.(*ssh.Certificate)
+	if !ok {
+		return t, trace.Errorf("not supported certificate type")
+	}
+	return time.Unix(int64(cert.ValidBefore), 0), nil
 }

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -185,7 +185,7 @@ func (fs *FSLocalKeyStore) GetKey(host, username string) (*Key, error) {
 		return nil, trace.Wrap(err)
 	}
 	log.Debugf("returning cert %v valid until %v", certFile, certExpiration)
-	if certExpiration.Before(time.Now().UTC()) {
+	if certExpiration.Before(time.Now()) {
 		log.Infof("TTL expired (%v) for session key %v", certExpiration, dirPath)
 		os.RemoveAll(dirPath)
 		return nil, trace.NotFound("session keys for %s are not found", host)

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	//log "github.com/Sirupsen/logrus"
 	"fmt"
 	"os"
 	"time"

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -143,7 +143,7 @@ func (sl *SessionLogger) LogEvent(fields EventFields) {
 	// add "bytes written" counter:
 	fields[SessionByteOffset] = atomic.LoadInt64(&sl.writtenBytes)
 
-	// add "seconds since" timestamp:
+	// add "milliseconds since" timestamp:
 	now := sl.timeSource().In(time.UTC).Round(time.Millisecond)
 	fields[SessionEventTimestamp] = int(now.Sub(sl.createdTime).Nanoseconds() / 1000000)
 	fields[EventTime] = now


### PR DESCRIPTION
This commit closes #529

Teleport was using nanoseconds to set the certificate expiration,
instead of seconds.
