### PR TITLE
use https where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 |Project Links|
 |---|
-| [Teleport Website](http://gravitational.com/teleport)  |
-| [Documentation](http://gravitational.com/teleport/docs/quickstart/)  |
+| [Teleport Website](https://gravitational.com/teleport)  |
+| [Documentation](https://gravitational.com/teleport/docs/quickstart/)  |
 
 
 ## Introduction
@@ -71,7 +71,7 @@ within multiple organizations.
 
 ## Contributing
 
-The best way to contribute is to create issues or pull requests right here on Github. You can also reach the Gravitational team through their [website](http://gravitational.com/)
+The best way to contribute is to create issues or pull requests right here on Github. You can also reach the Gravitational team through their [website](https://gravitational.com/)
 
 
 ## Status
@@ -92,5 +92,5 @@ The latest stable Teleport build can be found in [Releases](https://github.com/g
 ## Who Built Teleport?
 
 Teleport was created by [Gravitational Inc](https://gravitational.com). We have built Teleport 
-by borrowing from our previous experiences at Rackspace. It has been extracted from [Gravity](http://gravitational.com/vendors.html), our system for helping our clients to deploy 
+by borrowing from our previous experiences at Rackspace. It has been extracted from [Gravity](https://gravitational.com/vendors.html), our system for helping our clients to deploy 
 and remotely manage their SaaS applications on many cloud regions or even on-premise.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,11 +31,11 @@ within multiple organizations.
 ## Who Built Teleport?
 
 Teleport was created by [Gravitational Inc](https://gravitational.com). We have built Teleport 
-by borrowing from our previous experiences at Rackspace. It has been extracted from [Gravity](http://gravitational.com/vendors.html), our system for helping our clients to deploy 
+by borrowing from our previous experiences at Rackspace. It has been extracted from [Gravity](https://gravitational.com/vendors.html), our system for helping our clients to deploy 
 and remotely manage their SaaS applications on many cloud regions or even on-premise.
 
 ## Resources
 To get started with Teleport we recommend starting with the [Architecture Document](architecture.md). Then if you want to jump right in and play with Teleport, you can read the [Quick Start](quickstart.md). For a deeper understanding of how everything works and recommended production setup, please review the [Admin Manual](admin-guide.md) to setup Teleport and the [User Manual](user-manual.md) for daily usage. There is also an [FAQ](faq.md) where we'll be collecting common questions. Finally, you can always type `tsh`, `tctl` or `teleport` in terminal after Teleport has been installed to review those reference guides.
 
-The best way to ask questions or file issues regarding Teleport is by creating a Github issue or pull request. Otherwise, you can reach us through the contact form or chat on our [website](http://gravitational.com/).
+The best way to ask questions or file issues regarding Teleport is by creating a Github issue or pull request. Otherwise, you can reach us through the contact form or chat on our [website](https://gravitational.com/).
 

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -821,7 +821,7 @@ by erasing everything under `"data_dir"` directory. Assuming the default locatio
 ## Getting Help
 
 Please open an [issue on Github](https://github.com/gravitational/teleport/issues).
-Alternatively, you can reach through the contact form on our [website](http://gravitational.com/).
+Alternatively, you can reach through the contact form on our [website](https://gravitational.com/).
 
 For commercial support, custom features or to try our multi-cluster edition of Teleport,
 please reach out to us: `sales@gravitational.com`. 

--- a/docs/theme/base.html
+++ b/docs/theme/base.html
@@ -14,7 +14,7 @@
 
 
   {% if favicon %}<link rel="shortcut icon" href="{{ favicon }}">
-  {% else %}<link rel="shortcut icon" href="http://gravitational.com/favicon.ico" type="image/x-icon" />{% endif %}
+  {% else %}<link rel="shortcut icon" href="https://gravitational.com/favicon.ico" type="image/x-icon" />{% endif %}
 
   {# CSS #}
   <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -375,7 +375,7 @@ other data from `~/.tsh`
 ## Getting Help
 
 Please open an [issue on Github](https://github.com/gravitational/teleport/issues).
-Alternatively, you can reach through the contact form on our [website](http://gravitational.com/).
+Alternatively, you can reach through the contact form on our [website](https://gravitational.com/).
 
 For commercial support, custom features or to try our multi-cluster edition of Teleport,
 please reach out to us: `sales@gravitational.com`.  

--- a/web/dist/app/app.js
+++ b/web/dist/app/app.js
@@ -86,7 +86,7 @@ webpackJsonp([1],[
 	
 	  baseUrl: window.location.origin,
 	
-	  helpUrl: 'http://gravitational.com/teleport/docs/quickstart/',
+	  helpUrl: 'https://gravitational.com/teleport/docs/quickstart/',
 	
 	  maxSessionLoadSize: 50,
 	

--- a/web/src/app/config.js
+++ b/web/src/app/config.js
@@ -21,7 +21,7 @@ let cfg = {
 
   baseUrl: window.location.origin,
 
-  helpUrl: 'http://gravitational.com/teleport/docs/quickstart/',
+  helpUrl: 'https://gravitational.com/teleport/docs/quickstart/',
 
   maxSessionLoadSize: 50,
 


### PR DESCRIPTION
especially for https://gravitational.com/ and https://gravitational.com/teleport 

there are no links to blog.gravitational here (which we shouldn't change to https because it is behind cloudflare) but as far as links on the repo go I think it is safe to use https here 
