### PR TITLE
Fixes possible `TestGetShell` failure

### DIFF
--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -72,5 +72,5 @@ func (s *UtilsSuite) TestGetShell(c *check.C) {
 
 	shell, err = GetLoginShell("daemon")
 	c.Assert(err, check.IsNil)
-	c.Assert(shell == "/usr/sbin/nologin" || shell == "/usr/bin/false", check.Equals, true)
+	c.Assert(shell == "/usr/sbin/nologin" || shell == "/usr/bin/nologin" || shell == "/usr/bin/false", check.Equals, true)
 }


### PR DESCRIPTION
Some distros (e.g. arch) use `/usr/bin/nologin` instead of `/usr/sbin/nologin` for the daemon account.
