### PR TITLE
tctl: do not create datadir/host_uuid if none has been found

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -82,7 +82,7 @@ func InitLoggerForTests() {
 	log.SetOutput(ioutil.Discard)
 }
 
-// FatalError is for CLI front-ends: it detects gravitational.Trace debugging
+// FatalError is for CLI front-ends: it detects gravitational/trace debugging
 // information, sends it to the logger, strips it off and prints a clean message to stderr
 func FatalError(err error) {
 	fmt.Fprintln(os.Stderr, UserMessageFromError(err))

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -716,11 +716,11 @@ func connectToAuthService(cfg *service.Config) (client *auth.TunClient, err erro
 	return client, nil
 }
 
-// validateConfig updtes&validates tctl configuration
+// validateConfig validates and updates tctl configuration
 func validateConfig(cfg *service.Config) {
 	var err error
-	// read or generate a host UUID for this node
-	cfg.HostUUID, err = utils.ReadOrMakeHostUUID(cfg.DataDir)
+	// read a host UUID for this node
+	cfg.HostUUID, err = utils.ReadHostUUID(cfg.DataDir)
 	if err != nil {
 		utils.FatalError(err)
 	}


### PR DESCRIPTION
If the client runs with elevated permissions and the command fails (for instance, when the auth server state has not yet been generated), it will leave the file behind making further attempts to properly generate content in data directory by a under-privileged process impossible.
