### PR TITLE
remove the GO15VENDOREXPERIMENT environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ BINDIR ?= /usr/local/bin
 DATADIR ?= /usr/local/share/teleport
 ADDFLAGS ?=
 
-GO15VENDOREXPERIMENT := 1
 PWD ?= $(shell pwd)
 ETCD_CERTS := $(realpath fixtures/certs)
 ETCD_FLAGS := TELEPORT_TEST_ETCD_CONFIG='{"nodes": ["https://localhost:4001"], "key":"/teleport/test", "tls_key_file": "$(ETCD_CERTS)/proxy1-key.pem", "tls_cert_file": "$(ETCD_CERTS)/proxy1.pem", "tls_ca_file": "$(ETCD_CERTS)/ca.pem"}'

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -55,8 +55,7 @@ ENV LANGUAGE="en_US.UTF-8" \
     LC_CTYPE="en_US.UTF-8" \
     GOPATH="/gopath" \
     GOROOT="/opt/go" \
-    PATH="$PATH:/opt/go/bin:/gopath/bin" \
-    GO15VENDOREXPERIMENT="1"
+    PATH="$PATH:/opt/go/bin:/gopath/bin"
 
 VOLUME ["/gopath/src/github.com/gravitational/teleport"]
 EXPOSE 6600

--- a/build.assets/release/Makefile
+++ b/build.assets/release/Makefile
@@ -4,7 +4,6 @@ BUILDFLAGS ?= %BUILDFLAGS%
 BINDIR ?= /usr/local/bin
 DATADIR ?= /usr/local/share/teleport
 PKGPATH := github.com/gravitational/teleport
-GO15VENDOREXPERIMENT := 1
 export
 
 #


### PR DESCRIPTION
Go 1.7 removed support for the variable: https://golang.org/doc/go1.7
Since teleport requires 1.7 or higher, the variable is redundant.
