### PR TITLE
Files needed for automatic RPM and SRPM

### DIFF
--- a/build.assets/pkg/buildTeleportRPM.sh
+++ b/build.assets/pkg/buildTeleportRPM.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+##
+## Author: guanana
+## Version: 1.0
+##
+
+#Usage information
+usage(){
+cat <<EOF 2>&1 
+
+Usage: $0 -f tarfile -r build-release -v build-version [-c changelog] [-s spec_dir] [-n program_name]
+
+It generates the spec file
+
+	-n, --program-name		Program name. Default: teleport
+	-f, --tar-file			Tar file where find the binaries
+	-r, --build-release		Release number of the package
+	-v, --build-version		Version number of the package
+	-c, --changelog			Message to display in the changelog
+					field of the RPM
+	-s, --spec-location		Specify the output location of the
+					spec file. Default: ~/rpmbuild/SPECS
+	-h, --help			Display this message
+
+
+EOF
+exit 1
+}
+
+#Build various variables needed for the spec creation
+build_deps(){
+	ROOT_FOLDER="opt"
+	BASE_INSTALL="\/$ROOT_FOLDER\/$P_NAME\/"
+	TAR_FILE=$(echo $TAR_PKG | sed 's/.*\///')
+	if [ ! -d "$HOME/rpmbuild" ]; then	
+		rpmdev-setuptree
+	fi
+	SPEC_FILE="$SPEC_LOCATION$P_NAME$BUILD_VERSION-$BUILD_RELEASE.spec"
+	# Remaking the TAR FILE
+	tar xfz $TAR_PKG
+	mkdir $ROOT_FOLDER
+	cp -R $HOME/init-scripts $P_NAME
+	mv $P_NAME $ROOT_FOLDER
+	mkdir $P_NAME-$BUILD_VERSION-$BUILD_RELEASE
+	mv $ROOT_FOLDER $P_NAME-$BUILD_VERSION-$BUILD_RELEASE
+	cp -R $HOME/etc $P_NAME-$BUILD_VERSION-$BUILD_RELEASE/
+	tar cfz $TAR_PKG $ROOT_FOLDER $P_NAME-$BUILD_VERSION-$BUILD_RELEASE 2&>/dev/null
+	# Copy the source into the expected folder
+	cp $TAR_PKG $HOME/rpmbuild/SOURCES/
+	# Creating file list
+	FILE_LIST=$(tar tf $TAR_PKG | cut -d '/' -f2,3,4,5,6,7,8,9,10 | grep -v $P_NAME.yaml | grep -v README.md | sed 's/^/\//' | grep -v "/$")
+}
+
+build_spec(){
+SPEC_FILE="$SPEC_LOCATION$P_NAME$BUILD_VERSION-$BUILD_RELEASE.spec"
+build_deps
+cat<<EOXF >$SPEC_FILE
+Name:           $P_NAME
+Version:        $BUILD_VERSION
+Release:        $BUILD_RELEASE
+Summary:        SSH server with built-in bastion and a web UI
+
+License:        Apache 2.0
+URL:            http://gravitational.com/$P_NAME
+Source0:        $TAR_FILE
+Group:		Gravitational Inc <info@gravitational.com>
+
+BuildArch:	x86_64
+BuildRoot:	%{_tmppath}/\${name}%{version}
+Requires: libc.so.6()(64bit) libc.so.6(GLIBC_2.2.5)(64bit) libpthread.so.0()(64bit) libpthread.so.0(GLIBC_2.2.5)(64bit) libpthread.so.0(GLIBC_2.3.2)(64bit) rtld(GNU_HASH)
+
+%description
+The SSH server with 2nd factor authentication, session recording and replay, Google Accounts integration and cluster membership introspection. It has a built-in SSH bastion and a beautiful Web UI.
+
+%prep
+if [ -f /etc/$P_NAME.yaml ]; then
+	cp /etc/$P_NAME.yaml /tmp/$P_NAME.yaml.user
+fi
+
+%setup -q -n $P_NAME-$BUILD_VERSION-$BUILD_RELEASE
+
+%install
+mkdir -p "\$RPM_BUILD_ROOT"
+cp -R * "\$RPM_BUILD_ROOT/"
+
+%files
+%config /etc/$P_NAME.yaml
+%doc /opt/$P_NAME/README.md
+$FILE_LIST
+
+%post
+ln -s /opt/$P_NAME/$P_NAME /usr/bin/
+ln -s /opt/$P_NAME/tsh /usr/bin/
+ln -s /opt/$P_NAME/tctl /usr/bin/
+if [ ! -d /etc/$P_NAME ]; then 
+	mkdir /etc/$P_NAME
+fi
+if [ -d /etc/systemd ]; then
+	cp /opt/$P_NAME/init-scripts/systemd/system/$P_NAME.service /etc/systemd/system/$P_NAME.service
+	systemctl daemon-reload
+	systemctl start $P_NAME
+	systemctl enable $P_NAME
+elif [ -d /etc/init.d ]; then
+	cp /opt/$P_NAME/init-scripts/init.d/$P_NAME /etc/init.d/$P_NAME
+	service $P_NAME start
+	chkconfig $P_NAME on
+fi
+if [ -f /tmp/$P_NAME.yaml ]; then
+	mv /etc/$P_NAME.yaml /etc/$P_NAME.yaml.new
+	mv /tmp/$P_NAME.yaml /etc/$P_NAME.yaml
+fi
+cat <<EOF 2>&1
+
+########################
+#Enjoy $P_NAME!
+#
+#If you need to generate the certificates for the proxy, you can execute
+# openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout /etc/$P_NAME/$P_NAME.key -out /etc/$P_NAME/$P_NAME.crt
+#*For more information read README.md
+########################
+
+EOF
+
+%postun
+rm -f /usr/bin/$P_NAME
+rm -f /usr/bin/tsh
+rm -f /usr/bin/tctl
+
+%clean
+rm -rf $RPM_BUILD_ROOD
+%changelog
+$CHANGE_LOG
+
+EOXF
+}
+
+# Read the input options
+TEMP=`getopt -o f:v:r:c:s:n: --long tar-file:,build-version:,build-release:,help,changelog:,spec-location:,program-name: -n 'parse-options' -- "$@"`
+if [[ $? -ne 0 ]]; then
+        usage
+fi
+eval set -- "$TEMP"
+while [ $# -gt 0 ]; do
+   case "$1" in
+        -f | --tar-file ) TAR_PKG=$2 ; shift;shift ;;
+        -v | --build-version ) BUILD_VERSION=$2; shift;shift ;;
+        -r | --build-release ) BUILD_RELEASE=$2; shift;shift ;;
+        -c | --changelog ) CHANGE_LOG=$2;  shift; shift;;
+        -s | --spec-location ) SPEC_LOCATION=$2; shift; shift;;
+	-n | --program-name ) P_NAME=$2; shift; shift;;
+        -h | --help ) usage; shift; exit 1;;
+        -- ) shift; break;;
+        *) echo "Internal error!" ; usage| tee ~/error.log ; shift; exit 1 ;;
+    esac
+done
+
+# Check vars
+if [ -z "$TAR_PKG" ] || [ -z "$BUILD_VERSION" ] || [ -z "$BUILD_RELEASE" ]; then
+        usage
+fi
+if [ -z "$SPEC_LOCATION" ]; then
+        SPEC_LOCATION="$HOME/rpmbuild/SPECS/"
+fi
+if [ -z "$P_NAME" ]; then
+	P_NAME="teleport"
+fi
+
+build_spec
+rpmbuild --clean -ba $SPEC_FILE 

--- a/build.assets/pkg/etc/teleport.yaml
+++ b/build.assets/pkg/etc/teleport.yaml
@@ -1,0 +1,116 @@
+# By default, this file should be stored in /etc/teleport.yaml
+
+## IMPORTANT ##
+#When editing YAML configuration, please pay attention to how your editor handles white space. YAML requires consistent handling of tab characters
+# This section of the configuration file applies to all teleport
+# services.
+teleport:
+    # nodename allows to assign an alternative name this node can be reached by.
+    # by default it's equal to hostname
+    nodename: graviton
+
+    # Data directory where Teleport keeps its data, like keys/users for 
+    # authentication (if using the default BoltDB back-end)
+    data_dir: /var/lib/teleport
+
+    # one-time invitation token used to join a cluster. it is not used on 
+    # subsequent starts
+    auth_token: xxxx-token-xxxx
+
+    # when running in multi-homed or NATed environments Teleport nodes need 
+    # to know which IP it will be reachable at by other nodes
+    #advertise_ip: 0.0.0.0
+
+    # list of auth servers in a cluster. you will have more than one auth server
+    # if you configure teleport auth to run in HA configuration
+    auth_servers: 
+        - localhost:3025
+
+    # Teleport throttles all connections to avoid abuse. These settings allow
+    # you to adjust the default limits
+    connection_limits:
+        max_connections: 1000
+        max_users: 250
+
+    # Logging configuration. Possible output values are 'stdout', 'stderr' and 
+    # 'syslog'. Possible severity values are INFO, WARN and ERROR (default).
+    log:
+        output: stderr
+        severity: ERROR
+
+    # Type of storage used for keys. You need to configure this to use etcd
+    # backend if you want to run Teleport in HA configuration.
+    storage:
+        type: bolt
+
+# This section configures the 'auth service':
+auth_service:
+    enabled: yes
+    # IP and the port to bind to. Other Teleport nodes will be connecting to
+    # this port (AKA "Auth API" or "Cluster API") to validate client 
+    # certificates 
+    listen_addr: 0.0.0.0:3025
+
+    # Pre-defined tokens for adding new nodes to a cluster. Each token specifies
+    # the role a new node will be allowed to assume. The more secure way to 
+    # add nodes is to use `ttl node add --ttl` command to generate auto-expiring 
+    # tokens. 
+    #
+    # We recommend to use tools like `pwgen` to generate sufficiently random
+    # tokens of 32+ byte length.
+    tokens:
+        - "proxy,node:xxxxx"
+        - "auth:yyyy"
+
+# This section configures the 'node service':
+ssh_service:
+    enabled: yes
+    # IP and the port for SSH service to bind to. 
+    listen_addr: 0.0.0.0:3022
+    # See explanation of labels in "Labeling Nodes" section below
+    labels:
+        role: master
+        type: postgres
+    # List (YAML array) of commands to periodically execute and use
+    # their output as labels. 
+    # See explanation of how this works in "Labeling Nodes" section below
+    commands:
+    - name: hostname
+      command: [/usr/bin/hostname]
+      period: 1m0s
+    - name: arch
+      command: [/usr/bin/uname, -p]
+      period: 1h0m0s
+
+# This section configures the 'proxy servie'
+proxy_service:
+    enabled: yes
+    # SSH forwarding/proxy address. Command line (CLI) clients always begin their
+    # SSH sessions by connecting to this port
+    listen_addr: 0.0.0.0:3023
+
+    # Reverse tunnel listening address. An auth server (CA) can establish an 
+    # outbound (from behind the firewall) connection to this address. 
+    # This will allow users of the outside CA to connect to behind-the-firewall 
+    # nodes.
+    tunnel_listen_addr: 0.0.0.0:3024
+
+    # List (array) of other clusters this CA trusts.
+    trusted_clusters:
+      - key_file: /path/to/main-cluster.ca
+        # Comma-separated list of OS logins allowed to users of this 
+        # trusted cluster
+        allow_logins: john,root
+        # Establishes a reverse SSH tunnel from this cluster to the trusted
+        # cluster, allowing the trusted cluster users to access nodes of this 
+        # cluster
+        #tunnel_addr: 80.10.0.12:3024
+
+    # The HTTPS listen address to serve the Web UI and also to authenticate the 
+    # command line (CLI) users via password+HOTP
+    web_listen_addr: 0.0.0.0:3080
+
+    # TLS certificate for the HTTPS connection. Configuring these properly is 
+    # critical for Teleport security.
+    https_key_file: /etc/teleport/teleport.key
+    https_cert_file: /etc/teleport/teleport.crt

--- a/build.assets/pkg/init-scripts/systemd/system/teleport.service
+++ b/build.assets/pkg/init-scripts/systemd/system/teleport.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Teleport SSH Service
+After=network.target 
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/teleport start
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
To create the RPM package you just need to create a RPM base machine (tested with Centos & Fedora) and run the script with the parameters.

In the new machine, on the home of the user will run the script you need to add the folders upload

├── buildTeleportRPM.sh
├── etc
│   └── teleport.yaml
├── init-scripts
│   ├── init.d
│   │   └── teleport
│   └── systemd
│       └── system
│           └── teleport.service

Example of use:

```
./buildTeleportRPM.sh -f teleport-v1.1.0-linux-amd64-bin.tar.gz -r 1.0 -v 1 -c "* Sat Oct 1 2016 build
-User experience improvements: nicer error messages
-Better compatibility with ssh command: -t flag can be used to force allocation of TTY
-https://github.com/gravitational/teleport/milestone/7?closed=1"
```

You can get more help running: 
./buildTeleportRPM.sh --help
