### PR TITLE
Sensible default environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,4 +183,3 @@ start-test-etcd:
 .PHONY: remove-temp-files
 remove-temp-files:
 	find . -name flymake_* -delete
-

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -60,6 +60,7 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 		"SHELL=/bin/sh",
 		"SSH_TELEPORT_USER=galt",
 		"SSH_SESSION_WEBPROXY_ADDR=<proxyhost>:3080",
+		"TERM=xterm",
 		"SSH_CLIENT=10.0.0.5 4817 3022",
 		"SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022",
 		"SSH_SESSION_ID=xxx",
@@ -95,7 +96,7 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 
 func (s *ExecSuite) TestLoginDefsParser(c *check.C) {
 	c.Assert(getDefaultEnvPath("../../fixtures/login.defs"), check.Equals, "PATH=/usr/local/bin:/usr/bin:/bin:/foo")
-	c.Assert(getDefaultEnvPath("bad/file"), check.Equals, "PATH=")
+	c.Assert(getDefaultEnvPath("bad/file"), check.Equals, "PATH="+defaultPath)
 }
 
 // implementation of ssh.Conn interface

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -72,5 +72,8 @@ func (s *UtilsSuite) TestGetShell(c *check.C) {
 
 	shell, err = GetLoginShell("daemon")
 	c.Assert(err, check.IsNil)
-	c.Assert(shell == "/usr/sbin/nologin" || shell == "/usr/bin/nologin" || shell == "/usr/bin/false", check.Equals, true)
+	c.Assert(shell == "/usr/sbin/nologin" ||
+		shell == "/sbin/nologin" ||
+		shell == "/usr/bin/nologin" ||
+		shell == "/usr/bin/false", check.Equals, true)
 }


### PR DESCRIPTION
## Description

Added some logic to set `$PATH` to reasonable defaults if they can't be extracted from login.defs. Also noticed that we don't set `$TERM` for web-based clients.  
## Other

Noticed that our tests fail on RHEL/CentOS, fixed that also.
## Misc

Fixes #542 
