### PR TITLE
Bugfix

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -245,6 +245,7 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 	siteClient, err := ns.nodeClient.Proxy.ConnectToSite()
 	if err != nil {
 		log.Error(err)
+		return
 	}
 	tick := time.NewTicker(defaults.SessionRefreshPeriod)
 	defer tick.Stop()


### PR DESCRIPTION
Fixes #553

Teleport client (`tsh`) fails to connect to proxy, yet runs "window resize" goroutine. where it happly segfaults by calling `nodeClient` which is null.
