### PR TITLE
Tests fail on OSX without brew binutils

### DIFF
--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -310,7 +310,7 @@ func (s *SrvSuite) testClient(c *C, proxyAddr, targetAddr, remoteAddr string, ss
 	c.Assert(err, IsNil)
 	defer se2.Close()
 
-	out, err := se2.Output("expr 2 + 3")
+	out, err := se2.Output("echo $((2+3))")
 	c.Assert(err, IsNil)
 
 	c.Assert(strings.Trim(string(out), " \n"), Equals, "5")


### PR DESCRIPTION
Replaced 'expr' with simple bash math
