### PR TITLE
Preset auth servers in file storage if configuration has auth servers

### DIFF
--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -591,7 +591,7 @@ func NewTunClient(purpose string,
 	if tc.addrStorage != nil {
 		cachedAuthServers, err := tc.addrStorage.GetAddresses()
 		if err != nil {
-			log.Warningf("unable to load the auth server cache: %v", err)
+			log.Infof("unable to load the auth server cache: %v", err)
 		} else {
 			tc.setAuthServers(cachedAuthServers)
 		}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -135,12 +135,6 @@ func (process *TeleportProcess) connectToAuthService(role teleport.Role) (*Conne
 	storage := utils.NewFileAddrStorage(
 		filepath.Join(process.Config.DataDir, "authservers.json"))
 
-	if len(process.Config.AuthServers) > 0 {
-		if err := storage.SetAddresses(process.Config.AuthServers); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
 	authUser := identity.Cert.ValidPrincipals[0]
 	authClient, err := auth.NewTunClient(
 		string(role),

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -135,6 +135,12 @@ func (process *TeleportProcess) connectToAuthService(role teleport.Role) (*Conne
 	storage := utils.NewFileAddrStorage(
 		filepath.Join(process.Config.DataDir, "authservers.json"))
 
+	if len(process.Config.AuthServers) > 0 {
+		if err := storage.SetAddresses(process.Config.AuthServers); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	authUser := identity.Cert.ValidPrincipals[0]
 	authClient, err := auth.NewTunClient(
 		string(role),


### PR DESCRIPTION
Without this, if auth servers are specified in the configuration, this leads to errors like:

```
Original Error: *trace.NotFoundError open /tmp/teleport/authservers.json: no such file or directory
Stack Trace:
    /home/foo/bar/vendor/github.com/gravitational/teleport/lib/utils/storage.go:44 bar/vendor/github.com/gravitational/teleport/lib/utils.(*FileAddrStorage).GetAddresses
    /home/foo/bar/vendor/github.com/gravitational/teleport/lib/auth/tun.go:592 bar/vendor/github.com/gravitational/teleport/lib/auth.NewTunClient
    /home/foo/bar/vendor/github.com/gravitational/teleport/lib/service/service.go:139 bar/vendor/github.com/gravitational/teleport/lib/service.(*TeleportProcess).connectToAuthService
    /home/foo/bar/vendor/github.com/gravitational/teleport/lib/service/service.go:501 bar/vendor/github.com/gravitational/teleport/lib/service.(*TeleportProcess).RegisterWithAuthServer.func1
    /home/foo/bar/vendor/github.com/gravitational/teleport/lib/service/supervisor.go:250 bar/vendor/github.com/gravitational/teleport/lib/service.ServiceFunc.Serve
    /home/foo/bar/vendor/github.com/gravitational/teleport/lib/service/supervisor.go:144 bar/vendor/github.com/gravitational/teleport/lib/service.(*LocalSupervisor).serve.func2
    /home/foo/dev/go/go/src/runtime/asm_amd64.s:2087 runtime.goexit
User Message: open /tmp/teleport/authservers.json: no such file or directory
  file=auth/tun.go:577 func=auth.NewTunClient
```
