### PR TITLE
Fix expired session cleanup

### DIFF
--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -188,16 +188,14 @@ func (s *sessionCache) expireSessions() {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-	go func() {
-		for {
-			select {
-			case <-ticker.C:
-				s.clearExpiredSessions()
-			case <-s.closer.C:
-				return
-			}
+	for {
+		select {
+		case <-ticker.C:
+			s.clearExpiredSessions()
+		case <-s.closer.C:
+			return
 		}
-	}()
+	}
 }
 
 func (s *sessionCache) clearExpiredSessions() {


### PR DESCRIPTION
Expired sessions were never cleared out because the ticker was effectively stopped immediately.
