### PR TITLE
Update configuration.go to use all auth_servers

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -135,7 +135,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 			if err != nil {
 				return trace.Errorf("cannot parse auth server address: '%v'", as)
 			}
-			cfg.AuthServers = []utils.NetAddr{*addr}
+			cfg.AuthServers = append(cfg.AuthServers, *addr)
 		}
 	}
 	cfg.ApplyToken(fc.AuthToken)


### PR DESCRIPTION
Only the last provided auth_server was being used.
#593
