### PR TITLE
Add method to customize web session output

### DIFF
--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -49,6 +49,8 @@ type User interface {
 	Check() error
 	// Equals checks if user equals to another
 	Equals(other User) bool
+	// WebSessionInfo returns web session information
+	WebSessionInfo() interface{}
 }
 
 // TeleportUser is an optional user entry in the database
@@ -89,6 +91,11 @@ func (u *TeleportUser) Equals(other User) bool {
 		}
 	}
 	return true
+}
+
+// WebSessionInfo returns web session information
+func (u *TeleportUser) WebSessionInfo() interface{} {
+	return u
 }
 
 // GetAllowedLogins returns user's allowed linux logins

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -50,7 +50,7 @@ type User interface {
 	// Equals checks if user equals to another
 	Equals(other User) bool
 	// WebSessionInfo returns web session information
-	WebSessionInfo() interface{}
+	WebSessionInfo() User
 }
 
 // TeleportUser is an optional user entry in the database

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -94,7 +94,7 @@ func (u *TeleportUser) Equals(other User) bool {
 }
 
 // WebSessionInfo returns web session information
-func (u *TeleportUser) WebSessionInfo() interface{} {
+func (u *TeleportUser) WebSessionInfo() User {
 	return u
 }
 

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -412,7 +412,7 @@ type CreateSessionResponse struct {
 	// Token value
 	Token string `json:"token"`
 	// User represents the user
-	User interface{} `json:"user"`
+	User services.User `json:"user"`
 	// ExpiresIn sets seconds before this token is not valid
 	ExpiresIn int `json:"expires_in"`
 }


### PR DESCRIPTION
This method is necessary to allow us to customize the way user is presented to the web session API in the browser.
