### PR TITLE
Ev/scp

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -640,7 +640,7 @@ func (tc *TeleportClient) SCP(args []string, port int, recursive bool) (err erro
 	if !tc.Config.ProxySpecified() {
 		return trace.BadParameter("proxy server is not specified")
 	}
-	log.Infof("Connecting to proxy...")
+	log.Infof("Connecting to proxy to copy (recursively=%v)...", recursive)
 	proxyClient, err := tc.ConnectToProxy()
 	if err != nil {
 		return trace.Wrap(err)
@@ -679,7 +679,7 @@ func (tc *TeleportClient) SCP(args []string, port int, recursive bool) (err erro
 		}
 		// copy everything except the last arg (that's destination)
 		for _, src := range args[:len(args)-1] {
-			err = client.Upload(src, dest, tc.Stderr)
+			err = client.Upload(src, dest, recursive, tc.Stderr)
 			if err != nil {
 				return onError(err)
 			}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -625,7 +625,7 @@ func (tc *TeleportClient) Play(sessionId string) (err error) {
 }
 
 // SCP securely copies file(s) from one SSH server to another
-func (tc *TeleportClient) SCP(args []string, port int, recursive bool) (err error) {
+func (tc *TeleportClient) SCP(args []string, port int, recursive bool, quiet bool) (err error) {
 	if len(args) < 2 {
 		return trace.Errorf("Need at least two arguments for scp")
 	}
@@ -657,6 +657,11 @@ func (tc *TeleportClient) SCP(args []string, port int, recursive bool) (err erro
 		return proxyClient.ConnectToNode(addr+"@"+siteInfo.Name, tc.HostLogin, false)
 	}
 
+	var progressWriter io.Writer
+	if !quiet {
+		progressWriter = tc.Stdout
+	}
+
 	// gets called to convert SSH error code to tc.ExitStatus
 	onError := func(err error) error {
 		exitError, _ := trace.Unwrap(err).(*ssh.ExitError)
@@ -679,11 +684,10 @@ func (tc *TeleportClient) SCP(args []string, port int, recursive bool) (err erro
 		}
 		// copy everything except the last arg (that's destination)
 		for _, src := range args[:len(args)-1] {
-			err = client.Upload(src, dest, recursive, tc.Stderr)
+			err = client.Upload(src, dest, recursive, tc.Stderr, progressWriter)
 			if err != nil {
 				return onError(err)
 			}
-			fmt.Printf("Uploaded %s\n", src)
 		}
 		// download:
 	} else {
@@ -698,11 +702,10 @@ func (tc *TeleportClient) SCP(args []string, port int, recursive bool) (err erro
 		}
 		// copy everything except the last arg (that's destination)
 		for _, dest := range args[1:] {
-			err = client.Download(src, dest, recursive, tc.Stderr)
+			err = client.Download(src, dest, recursive, tc.Stderr, progressWriter)
 			if err != nil {
 				return onError(err)
 			}
-			fmt.Printf("Downloaded %s\n", src)
 		}
 	}
 	return nil

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -262,12 +262,12 @@ func (proxy *ProxyClient) Close() error {
 }
 
 // Upload uploads local file(s) or to the remote server's destination path
-func (client *NodeClient) Upload(srcPath, rDestPath string, recursive bool, stderr io.Writer) error {
+func (client *NodeClient) Upload(srcPath, rDestPath string, recursive bool, stderr, progressWriter io.Writer) error {
 	scpConf := scp.Command{
-		Source:      true,
-		TargetIsDir: utils.IsDir(rDestPath),
-		Recursive:   recursive,
-		Target:      srcPath,
+		Source:    true,
+		Recursive: recursive,
+		Target:    srcPath,
+		Terminal:  progressWriter,
 	}
 
 	// "impersonate" scp to a server
@@ -280,12 +280,12 @@ func (client *NodeClient) Upload(srcPath, rDestPath string, recursive bool, stde
 }
 
 // Download downloads file or dir from the remote server
-func (client *NodeClient) Download(remoteSourcePath, localDestinationPath string, recursive bool, stderr io.Writer) error {
+func (client *NodeClient) Download(remoteSourcePath, localDestinationPath string, recursive bool, stderr, progressWriter io.Writer) error {
 	scpConf := scp.Command{
-		Sink:        true,
-		TargetIsDir: recursive,
-		Recursive:   recursive,
-		Target:      localDestinationPath,
+		Sink:      true,
+		Recursive: recursive,
+		Target:    localDestinationPath,
+		Terminal:  progressWriter,
 	}
 
 	// "impersonate" scp to a server

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -261,52 +261,39 @@ func (proxy *ProxyClient) Close() error {
 	return proxy.Client.Close()
 }
 
-// Upload uploads file or dir to the remote server
-func (client *NodeClient) Upload(localSourcePath, remoteDestinationPath string, stderr io.Writer) error {
-	file, err := os.Open(localSourcePath)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	fileInfo, err := file.Stat()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	file.Close()
-
+// Upload uploads local file(s) or to the remote server's destination path
+func (client *NodeClient) Upload(srcPath, rDestPath string, recursive bool, stderr io.Writer) error {
 	scpConf := scp.Command{
 		Source:      true,
-		TargetIsDir: fileInfo.IsDir(),
-		Recursive:   fileInfo.IsDir(),
-		Target:      localSourcePath,
+		TargetIsDir: utils.IsDir(rDestPath),
+		Recursive:   recursive,
+		Target:      srcPath,
 	}
 
 	// "impersonate" scp to a server
 	shellCmd := "/usr/bin/scp -t"
-	if fileInfo.IsDir() {
+	if recursive {
 		shellCmd += " -r"
 	}
-	shellCmd += " " + remoteDestinationPath
-
+	shellCmd += " " + rDestPath
 	return client.scp(scpConf, shellCmd, stderr)
 }
 
 // Download downloads file or dir from the remote server
-func (client *NodeClient) Download(remoteSourcePath, localDestinationPath string, isDir bool, stderr io.Writer) error {
+func (client *NodeClient) Download(remoteSourcePath, localDestinationPath string, recursive bool, stderr io.Writer) error {
 	scpConf := scp.Command{
 		Sink:        true,
-		TargetIsDir: isDir,
-		Recursive:   isDir,
+		TargetIsDir: recursive,
+		Recursive:   recursive,
 		Target:      localDestinationPath,
 	}
 
 	// "impersonate" scp to a server
 	shellCmd := "/usr/bin/scp -f"
-	if isDir {
+	if recursive {
 		shellCmd += " -r"
 	}
 	shellCmd += " " + remoteSourcePath
-
 	return client.scp(scpConf, shellCmd, stderr)
 }
 

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -83,7 +83,7 @@ func parseExecRequest(req *ssh.Request, ctx *ctx) (*execResponse, error) {
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			e.Command = fmt.Sprintf("%s scp --remote-addr=%s --local-addr=%s %v",
+			e.Command = fmt.Sprintf("%s scp %s --remote-addr=%s --local-addr=%s %v",
 				teleportBin,
 				ctx.conn.RemoteAddr().String(),
 				ctx.conn.LocalAddr().String(),

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -83,7 +83,7 @@ func parseExecRequest(req *ssh.Request, ctx *ctx) (*execResponse, error) {
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			e.Command = fmt.Sprintf("%s scp %s --remote-addr=%s --local-addr=%s %v",
+			e.Command = fmt.Sprintf("%s scp --remote-addr=%s --local-addr=%s %v",
 				teleportBin,
 				ctx.conn.RemoteAddr().String(),
 				ctx.conn.LocalAddr().String(),

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -19,7 +19,6 @@ limitations under the License.
 package srv
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net"
@@ -914,7 +913,7 @@ func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 
 func replyError(ch ssh.Channel, req *ssh.Request, err error) {
 	message := []byte(utils.UserMessageFromError(err))
-	io.Copy(ch.Stderr(), bytes.NewBuffer(message))
+	ch.Stderr().Write(message)
 	if req.WantReply {
 		req.Reply(false, message)
 	}

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -105,7 +105,6 @@ func run(cmdlineArgs []string, testRun bool) (executedCommand string, conf *serv
 	scpc.Flag("t", "sink mode (data consumer)").Short('t').Default("false").BoolVar(&scpCommand.Sink)
 	scpc.Flag("f", "source mode (data producer)").Short('f').Default("false").BoolVar(&scpCommand.Source)
 	scpc.Flag("v", "verbose mode").Default("false").Short('v').BoolVar(&scpCommand.Verbose)
-	scpc.Flag("d", "target is dir and must exist").Short('d').Default("false").BoolVar(&scpCommand.TargetIsDir)
 	scpc.Flag("r", "recursive mode").Default("false").Short('r').BoolVar(&scpCommand.Recursive)
 	scpc.Flag("remote-addr", "address of the remote client").StringVar(&scpCommand.RemoteAddr)
 	scpc.Flag("local-addr", "local address which accepted the request").StringVar(&scpCommand.LocalAddr)

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -77,6 +77,8 @@ type CLIConf struct {
 	SiteName string
 	// Interactive, when set to true, launches remote command with the terminal attached
 	Interactive bool
+	// Quiet mode, -q command (disables progress printing)
+	Quiet bool
 }
 
 // run executes TSH client. same as main() but easier to test
@@ -118,6 +120,7 @@ func run(args []string, underTest bool) {
 	scp.Arg("from, to", "Source and destination to copy").Required().StringsVar(&cf.CopySpec)
 	scp.Flag("recursive", "Recursive copy of subdirectories").Short('r').BoolVar(&cf.RecursiveCopy)
 	scp.Flag("port", "Port to connect to on the remote host").Short('P').Int16Var(&cf.NodePort)
+	scp.Flag("quiet", "Quiet mode").Short('q').BoolVar(&cf.Quiet)
 	// ls
 	ls := app.Command("ls", "List remote SSH nodes")
 	ls.Arg("labels", "List of labels to filter node list").StringVar(&cf.UserHost)
@@ -311,7 +314,7 @@ func onSCP(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	if err := tc.SCP(cf.CopySpec, int(cf.NodePort), cf.RecursiveCopy); err != nil {
+	if err := tc.SCP(cf.CopySpec, int(cf.NodePort), cf.RecursiveCopy, cf.Quiet); err != nil {
 		// exit with the same exit status as the failed command:
 		if tc.ExitStatus != 0 {
 			os.Exit(tc.ExitStatus)


### PR DESCRIPTION
## Attention

Before merging this, please merge #605 first.

## Fixes

- Removed strange handling of the ending / symbol, causing directories
  not being created. Fixes #606

- Added `-q` (quiet) flag for compatibility with OpenSSH.

- Removed strange (and completely ignored) `-d` option which did not do anything but the description said "target is a directory". Appears to be some kind of legacy switch. OpenSSH doesn't have it.

- Removed odd code here and there.    

## Misc

- Added per-file progress indicator (reports "XXX uploaded").
