### PR TITLE
Ability to specify which users can login to which nodes

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -181,6 +181,10 @@ func (s *APIServer) getNodes(w http.ResponseWriter, r *http.Request, p httproute
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	username := r.URL.Query().Get("username")
+	if username != "" {
+		servers, err = s.a.GetUserNodes(username)
+	}
 	return servers, nil
 }
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -134,6 +134,13 @@ func (a *AuthWithRoles) GetNodes() ([]services.Server, error) {
 	return a.authServer.GetNodes()
 }
 
+func (a *AuthWithRoles) GetUserNodes(username string) ([]services.Server, error) {
+	if err := a.permChecker.HasPermission(a.role, ActionGetUserServers); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.authServer.GetUserNodes(username)
+}
+
 func (a *AuthWithRoles) UpsertAuthServer(s services.Server, ttl time.Duration) error {
 	if err := a.permChecker.HasPermission(a.role, ActionUpsertAuthServer); err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -307,6 +307,21 @@ func (c *Client) GetNodes() ([]services.Server, error) {
 	return re, nil
 }
 
+// GetUserNodes returns the list of servers available to specified user registered in the cluster.
+func (c *Client) GetUserNodes(username string) ([]services.Server, error) {
+	requestValues := url.Values{}
+	requestValues.Add("username", username)
+	out, err := c.Get(c.Endpoint("nodes"), requestValues)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var re []services.Server
+	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return re, nil
+}
+
 // UpsertReverseTunnel is used by admins to create a new reverse tunnel
 // to the remote proxy to bypass firewall restrictions
 func (c *Client) UpsertReverseTunnel(tunnel services.ReverseTunnel, ttl time.Duration) error {
@@ -845,6 +860,7 @@ type ClientI interface {
 	RegisterNewAuthServer(token string) error
 	UpsertNode(s services.Server, ttl time.Duration) error
 	GetNodes() ([]services.Server, error)
+	GetUserNodes(username string) ([]services.Server, error)
 	GetAuthServers() ([]services.Server, error)
 	UpsertPassword(user string, password []byte) (hotpURL string, hotpQR []byte, err error)
 	CheckPassword(user string, password []byte, hotpToken string) error

--- a/lib/auth/new_web_user.go
+++ b/lib/auth/new_web_user.go
@@ -88,6 +88,7 @@ func (s *AuthServer) CreateSignupToken(user services.User) (string, error) {
 		User: services.TeleportUser{
 			Name:           user.GetName(),
 			AllowedLogins:  user.GetAllowedLogins(),
+			NodeLabels:     user.GetNodeLabels(),
 			OIDCIdentities: user.GetIdentities()},
 		Hotp:            otpMarshalled,
 		HotpFirstValues: otpFirstValues,

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -48,6 +48,7 @@ func NewStandardPermissions() PermissionChecker {
 		ActionGenerateUserCert:   true,
 		ActionGetCertAuthorities: true,
 		ActionGetServers:         true,
+		ActionGetUserServers:     true,
 		ActionGetSession:         true,
 		ActionGetSessions:        true,
 		ActionViewSession:        true,
@@ -80,6 +81,7 @@ func NewStandardPermissions() PermissionChecker {
 		ActionGetOIDCConnectorsWithoutSecrets: true,
 		ActionGetReverseTunnels:               true,
 		ActionGetServers:                      true,
+		ActionGetUserServers:                  true,
 		ActionUpsertProxy:                     true,
 		ActionGetProxies:                      true,
 		ActionGetAuthServers:                  true,
@@ -174,6 +176,7 @@ const (
 	ActionRegisterNewAuthServer             = "RegisterNewAuthServer"
 	ActionUpsertServer                      = "UpsertServer"
 	ActionGetServers                        = "GetServers"
+	ActionGetUserServers                    = "GetUserServers"
 	ActionUpsertAuthServer                  = "UpsertAuthServer"
 	ActionGetAuthServers                    = "GetAuthServers"
 	ActionUpsertProxy                       = "UpsertProxy"

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -864,6 +864,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 			hostKeyCallback: sshConfig.HostKeyCallback,
 			authMethods:     tc.authMethods(),
 			hostLogin:       tc.Config.HostLogin,
+			teleportLogin:   tc.Config.Username,
 			siteName:        tc.Config.SiteName,
 		}, nil
 	}
@@ -898,6 +899,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 		hostKeyCallback: sshConfig.HostKeyCallback,
 		authMethods:     tc.authMethods(),
 		hostLogin:       tc.Config.HostLogin,
+		teleportLogin:   tc.Config.Username,
 		siteName:        tc.Config.SiteName,
 	}, nil
 }

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -41,6 +41,7 @@ import (
 type ProxyClient struct {
 	Client          *ssh.Client
 	hostLogin       string
+	teleportLogin   string
 	proxyAddress    string
 	hostKeyCallback utils.HostKeyCallback
 	authMethods     []ssh.AuthMethod
@@ -123,7 +124,7 @@ func (proxy *ProxyClient) FindServersByLabels(labels map[string]string) ([]servi
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	siteNodes, err := site.GetNodes()
+	siteNodes, err := site.GetUserNodes(proxy.teleportLogin)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -41,6 +41,8 @@ type User interface {
 	GetName() string
 	// GetAllowedLogins returns user's allowed linux logins
 	GetAllowedLogins() []string
+	// GetNodeLabels returns user's allowed node labels
+	GetNodeLabels() []string
 	// GetIdentities returns a list of connected OIDCIdentities
 	GetIdentities() []OIDCIdentity
 	// String returns user
@@ -62,6 +64,10 @@ type TeleportUser struct {
 	// user is allowed to login as
 	AllowedLogins []string `json:"allowed_logins"`
 
+	// NodeLabels represents a list of node labels this teleport
+	// user is allowed to login
+	NodeLabels []string `json:"node_labels"`
+
 	// OIDCIdentities lists associated OpenID Connect identities
 	// that let user log in using externally verified identity
 	OIDCIdentities []OIDCIdentity `json:"oidc_identities"`
@@ -72,12 +78,22 @@ func (u *TeleportUser) Equals(other User) bool {
 	if u.Name != other.GetName() {
 		return false
 	}
+	// MAYBE: move to function
 	otherLogins := other.GetAllowedLogins()
 	if len(u.AllowedLogins) != len(otherLogins) {
 		return false
 	}
 	for i := range u.AllowedLogins {
 		if u.AllowedLogins[i] != otherLogins[i] {
+			return false
+		}
+	}
+	otherLabels := other.GetNodeLabels()
+	if len(u.NodeLabels) != len(otherLabels) {
+		return false
+	}
+	for i := range u.NodeLabels {
+		if u.NodeLabels[i] != otherLabels[i] {
 			return false
 		}
 	}
@@ -103,6 +119,11 @@ func (u *TeleportUser) GetAllowedLogins() []string {
 	return u.AllowedLogins
 }
 
+// GetNodeLabels returns user's allowed node labels
+func (u *TeleportUser) GetNodeLabels() []string {
+	return u.NodeLabels
+}
+
 // GetIdentities returns a list of connected OIDCIdentities
 func (u *TeleportUser) GetIdentities() []OIDCIdentity {
 	return u.OIDCIdentities
@@ -114,7 +135,7 @@ func (u *TeleportUser) GetName() string {
 }
 
 func (u *TeleportUser) String() string {
-	return fmt.Sprintf("User(name=%v, allowed_logins=%v, identities=%v)", u.Name, u.AllowedLogins, u.OIDCIdentities)
+	return fmt.Sprintf("User(name=%v, allowed_logins=%v, node_labels=%v, identities=%v)", u.Name, u.AllowedLogins, u.NodeLabels, u.OIDCIdentities)
 }
 
 // Check checks validity of all parameters

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -121,7 +121,13 @@ func (u *TeleportUser) GetAllowedLogins() []string {
 
 // GetNodeLabels returns user's allowed node labels
 func (u *TeleportUser) GetNodeLabels() []string {
-	return u.NodeLabels
+	labels := make([]string, 0)
+	for _, l := range u.NodeLabels {
+		if l != "" {
+			labels = append(labels, l)
+		}
+	}
+	return labels
 }
 
 // GetIdentities returns a list of connected OIDCIdentities

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -34,6 +34,9 @@ type Presence interface {
 	// GetNodes returns a list of registered servers
 	GetNodes() ([]Server, error)
 
+	// GetUserNodes returns a list of registered servers filtered by user
+	GetUserNodes(username string) ([]Server, error)
+
 	// UpsertNode registers node presence, permanently if ttl is 0 or
 	// for the specified duration with second resolution if it's >= 1 second
 	UpsertNode(server Server, ttl time.Duration) error

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -683,7 +683,7 @@ func (m *Handler) getSiteNodes(w http.ResponseWriter, r *http.Request, _ httprou
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	servers, err := clt.GetNodes()
+	servers, err := clt.GetUserNodes(c.user)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -55,6 +55,7 @@ type UserCommand struct {
 	config        *service.Config
 	login         string
 	allowedLogins string
+	nodeLabels    string
 	identities    []string
 }
 
@@ -134,6 +135,8 @@ func main() {
 	userAdd.Arg("login", "Teleport user login").Required().StringVar(&cmdUsers.login)
 	userAdd.Arg("local-logins", "Local UNIX users this account can log in as [login]").
 		Default("").StringVar(&cmdUsers.allowedLogins)
+	userAdd.Arg("node-labels", "Node labels this account can log in as [login]").
+		Default("").StringVar(&cmdUsers.nodeLabels)
 	userAdd.Flag("identity", "[EXPERIMENTAL] Add OpenID Connect identity, e.g. --identity=google:bob@gmail.com").Hidden().StringsVar(&cmdUsers.identities)
 	userAdd.Alias(AddUserHelp)
 
@@ -286,6 +289,7 @@ func (u *UserCommand) Add(client *auth.TunClient) error {
 	user := services.TeleportUser{
 		Name:          u.login,
 		AllowedLogins: strings.Split(u.allowedLogins, ","),
+		NodeLabels: strings.Split(u.nodeLabels, ","),
 	}
 	if len(u.identities) != 0 {
 		for _, identityVar := range u.identities {
@@ -329,12 +333,12 @@ func (u *UserCommand) List(client *auth.TunClient) error {
 	}
 	usersView := func(users []services.User) string {
 		t := goterm.NewTable(0, 10, 5, ' ', 0)
-		printHeader(t, []string{"User", "Allowed to login as"})
+		printHeader(t, []string{"User", "Allowed to login as", "Can login to"})
 		if len(users) == 0 {
 			return t.String()
 		}
 		for _, u := range users {
-			fmt.Fprintf(t, "%v\t%v\n", u.GetName(), strings.Join(u.GetAllowedLogins(), ","))
+			fmt.Fprintf(t, "%v\t%v\t%v\n", u.GetName(), strings.Join(u.GetAllowedLogins(), ","), strings.Join(u.GetNodeLabels(), ","))
 		}
 		return t.String()
 	}


### PR DESCRIPTION
Try to implement ability to specify which users can login to which nodes.

- tctl new parameter in users add:
`tctl users add test user type=slave,type=master`

- tctl new column when users ls:
`User | Allowed to login as | Can login to`

- filter nodes by user allowed labels when tsh ls or web interface nodes ls (not safe)

- implement node access filter depending on allowed labels
