### PR TITLE
U2F defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,3 +190,8 @@ remove-temp-files:
 .PHONY:docker
 docker:
 	make -C build.assets
+
+# Interactively enters a Docker container (which you can build and run Teleport inside of)
+.PHONY:enter
+enter:
+	make -C build.assets enter

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -140,6 +140,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	cfg.ApplyToken(fc.AuthToken)
 	cfg.Auth.DomainName = fc.Auth.DomainName
 
+	// U2F (universal 2nd factor auth) configuration:
 	u2f, err := fc.Auth.U2F.Parse()
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -411,6 +411,7 @@ type Auth struct {
 	// for exmple: "auth,proxy,node:MTIzNGlvemRmOWE4MjNoaQo"
 	StaticTokens []StaticToken `yaml:"tokens,omitempty"`
 
+	// Configuration for "universal 2nd factor"
 	U2F U2F `yaml:"u2f,omitempty"`
 }
 
@@ -627,6 +628,8 @@ type U2F struct {
 	Facets      []string `yaml:"facets,omitempty"`
 }
 
+// Parse parses the values in 'u2f' configuration section of 'auth' and
+// validates its content:
 func (u *U2F) Parse() (*services.U2F, error) {
 	enabled := false
 	switch strings.ToLower(u.EnabledFlag) {

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -301,7 +301,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Auth.KeysBackend.Params = boltParams(defaults.DataDir, defaults.KeysBoltFile)
 	cfg.Auth.RecordsBackend.Type = defaults.BackendType
 	cfg.Auth.RecordsBackend.Params = boltParams(defaults.DataDir, defaults.RecordsBoltFile)
-	cfg.Auth.U2F.Enabled = true
+	cfg.Auth.U2F.Enabled = false
 	cfg.Auth.U2F.AppID = fmt.Sprintf("https://%s:%d", strings.ToLower(hostname), defaults.HTTPListenPort)
 	cfg.Auth.U2F.Facets = []string{cfg.Auth.U2F.AppID}
 	defaults.ConfigureLimiter(&cfg.Auth.Limiter)


### PR DESCRIPTION
This PR makes sure that U2F is turned **off** by default when `teleport.yaml` is missing.