### PR TITLE
Add context support to ProxyClient.ConnectToNode

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"bufio"
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -367,14 +368,14 @@ func (tc *TeleportClient) LocalAgent() *LocalKeyAgent {
 
 // getTargetNodes returns a list of node addresses this SSH command needs to
 // operate on.
-func (tc *TeleportClient) getTargetNodes(proxy *ProxyClient) ([]string, error) {
+func (tc *TeleportClient) getTargetNodes(ctx context.Context, proxy *ProxyClient) ([]string, error) {
 	var (
 		err    error
 		nodes  []services.Server
 		retval = make([]string, 0)
 	)
 	if tc.Labels != nil && len(tc.Labels) > 0 {
-		nodes, err = proxy.FindServersByLabels(tc.Labels)
+		nodes, err = proxy.FindServersByLabels(ctx, tc.Labels)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -392,7 +393,7 @@ func (tc *TeleportClient) getTargetNodes(proxy *ProxyClient) ([]string, error) {
 // otherwise runs interactive shell
 //
 // Returns nil if successful, or (possibly) *exec.ExitError
-func (tc *TeleportClient) SSH(command []string, runLocally bool) error {
+func (tc *TeleportClient) SSH(ctx context.Context, command []string, runLocally bool) error {
 	// connect to proxy first:
 	if !tc.Config.ProxySpecified() {
 		return trace.BadParameter("proxy server is not specified")
@@ -407,7 +408,7 @@ func (tc *TeleportClient) SSH(command []string, runLocally bool) error {
 		return trace.Wrap(err)
 	}
 	// which nodes are we executing this commands on?
-	nodeAddrs, err := tc.getTargetNodes(proxyClient)
+	nodeAddrs, err := tc.getTargetNodes(ctx, proxyClient)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -421,7 +422,7 @@ func (tc *TeleportClient) SSH(command []string, runLocally bool) error {
 			"\x1b[1mWARNING\x1b[0m: multiple nodes match the label selector. Picking %v (first)\n",
 			nodeAddrs[0])
 	}
-	nodeClient, err := proxyClient.ConnectToNode(nodeAddrs[0]+"@"+siteInfo.Name, tc.Config.HostLogin)
+	nodeClient, err := proxyClient.ConnectToNode(ctx, nodeAddrs[0]+"@"+siteInfo.Name, tc.Config.HostLogin)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -437,7 +438,7 @@ func (tc *TeleportClient) SSH(command []string, runLocally bool) error {
 	}
 	// execute command(s) or a shell on remote node(s)
 	if len(command) > 0 {
-		return tc.runCommand(siteInfo.Name, nodeAddrs, proxyClient, command)
+		return tc.runCommand(ctx, siteInfo.Name, nodeAddrs, proxyClient, command)
 	}
 	return tc.runShell(nodeClient, nil)
 }
@@ -456,7 +457,7 @@ func (tc *TeleportClient) startPortForwarding(nodeClient *NodeClient) error {
 }
 
 // Join connects to the existing/active SSH session
-func (tc *TeleportClient) Join(sessionID session.ID, input io.Reader) (err error) {
+func (tc *TeleportClient) Join(ctx context.Context, sessionID session.ID, input io.Reader) (err error) {
 	tc.Stdin = input
 	if sessionID.Check() != nil {
 		return trace.Errorf("Invalid session ID format: %s", string(sessionID))
@@ -472,7 +473,7 @@ func (tc *TeleportClient) Join(sessionID session.ID, input io.Reader) (err error
 		return trace.Wrap(err)
 	}
 	defer proxyClient.Close()
-	site, err := proxyClient.ConnectToSite()
+	site, err := proxyClient.ConnectToSite(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -519,7 +520,7 @@ func (tc *TeleportClient) Join(sessionID session.ID, input io.Reader) (err error
 	if tc.SiteName != "" {
 		fullNodeAddr = fmt.Sprintf("%s@%s", node.Addr, tc.SiteName)
 	}
-	nc, err := proxyClient.ConnectToNode(fullNodeAddr, tc.Config.HostLogin)
+	nc, err := proxyClient.ConnectToNode(ctx, fullNodeAddr, tc.Config.HostLogin)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -533,7 +534,7 @@ func (tc *TeleportClient) Join(sessionID session.ID, input io.Reader) (err error
 }
 
 // Play replays the recorded session
-func (tc *TeleportClient) Play(sessionId string) (err error) {
+func (tc *TeleportClient) Play(ctx context.Context, sessionId string) (err error) {
 	sid, err := session.ParseID(sessionId)
 	if err != nil {
 		return fmt.Errorf("'%v' is not a valid session ID (must be GUID)", sid)
@@ -543,7 +544,7 @@ func (tc *TeleportClient) Play(sessionId string) (err error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	site, err := proxyClient.ConnectToSite()
+	site, err := proxyClient.ConnectToSite(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -622,7 +623,7 @@ func (tc *TeleportClient) Play(sessionId string) (err error) {
 }
 
 // SCP securely copies file(s) from one SSH server to another
-func (tc *TeleportClient) SCP(args []string, port int, recursive bool) (err error) {
+func (tc *TeleportClient) SCP(ctx context.Context, args []string, port int, recursive bool) (err error) {
 	if len(args) < 2 {
 		return trace.Errorf("Need at least two arguments for scp")
 	}
@@ -660,7 +661,7 @@ func (tc *TeleportClient) SCP(args []string, port int, recursive bool) (err erro
 		}
 		addr := net.JoinHostPort(host, strconv.Itoa(port))
 
-		client, err := proxyClient.ConnectToNode(addr, tc.HostLogin)
+		client, err := proxyClient.ConnectToNode(ctx, addr, tc.HostLogin)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -679,7 +680,7 @@ func (tc *TeleportClient) SCP(args []string, port int, recursive bool) (err erro
 		if login != "" {
 			tc.HostLogin = login
 		}
-		client, err := proxyClient.ConnectToNode(addr, tc.HostLogin)
+		client, err := proxyClient.ConnectToNode(ctx, addr, tc.HostLogin)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -713,7 +714,7 @@ func isRemoteDest(name string) bool {
 }
 
 // ListNodes returns a list of nodes connected to a proxy
-func (tc *TeleportClient) ListNodes() ([]services.Server, error) {
+func (tc *TeleportClient) ListNodes(ctx context.Context) ([]services.Server, error) {
 	var err error
 	// userhost is specified? that must be labels
 	if tc.Host != "" {
@@ -730,11 +731,11 @@ func (tc *TeleportClient) ListNodes() ([]services.Server, error) {
 	}
 
 	defer proxyClient.Close()
-	return proxyClient.FindServersByLabels(tc.Labels)
+	return proxyClient.FindServersByLabels(ctx, tc.Labels)
 }
 
 // runCommand executes a given bash command on a bunch of remote nodes
-func (tc *TeleportClient) runCommand(siteName string, nodeAddresses []string, proxyClient *ProxyClient, command []string) error {
+func (tc *TeleportClient) runCommand(ctx context.Context, siteName string, nodeAddresses []string, proxyClient *ProxyClient, command []string) error {
 	resultsC := make(chan error, len(nodeAddresses))
 	for _, address := range nodeAddresses {
 		go func(address string) {
@@ -746,7 +747,7 @@ func (tc *TeleportClient) runCommand(siteName string, nodeAddresses []string, pr
 				resultsC <- err
 			}()
 			var nodeClient *NodeClient
-			nodeClient, err = proxyClient.ConnectToNode(address+"@"+siteName, tc.Config.HostLogin)
+			nodeClient, err = proxyClient.ConnectToNode(ctx, address+"@"+siteName, tc.Config.HostLogin)
 			if err != nil {
 				fmt.Fprintln(tc.Stderr, err)
 				return

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -242,7 +243,7 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 	currentSize, _ := term.GetWinsize(0)
 
 	// start the timer which asks for server-side window size changes:
-	siteClient, err := ns.nodeClient.Proxy.ConnectToSite()
+	siteClient, err := ns.nodeClient.Proxy.ConnectToSite(context.TODO())
 	if err != nil {
 		log.Error(err)
 		return

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -175,7 +176,7 @@ func onPlay(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	if err := tc.Play(cf.SessionID); err != nil {
+	if err := tc.Play(context.TODO(), cf.SessionID); err != nil {
 		utils.FatalError(err)
 	}
 }
@@ -218,7 +219,7 @@ func onListNodes(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	servers, err := tc.ListNodes()
+	servers, err := tc.ListNodes(context.TODO())
 	if err != nil {
 		utils.FatalError(err)
 	}
@@ -274,7 +275,7 @@ func onSSH(cf *CLIConf) {
 	}
 
 	tc.Stdin = os.Stdin
-	if err = tc.SSH(cf.RemoteCommand, cf.LocalExec); err != nil {
+	if err = tc.SSH(context.TODO(), cf.RemoteCommand, cf.LocalExec); err != nil {
 		// exit with the same exit status as the failed command:
 		if tc.ExitStatus != 0 {
 			os.Exit(tc.ExitStatus)
@@ -297,7 +298,7 @@ func onJoin(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(fmt.Errorf("'%v' is not a valid session ID (must be GUID)", cf.SessionID))
 	}
-	if err = tc.Join(*sid, nil); err != nil {
+	if err = tc.Join(context.TODO(), *sid, nil); err != nil {
 		utils.FatalError(err)
 	} else {
 		// successful session? update the profile then:
@@ -311,7 +312,7 @@ func onSCP(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	if err := tc.SCP(cf.CopySpec, int(cf.NodePort), cf.RecursiveCopy); err != nil {
+	if err := tc.SCP(context.TODO(), cf.CopySpec, int(cf.NodePort), cf.RecursiveCopy); err != nil {
 		// exit with the same exit status as the failed command:
 		if tc.ExitStatus != 0 {
 			os.Exit(tc.ExitStatus)


### PR DESCRIPTION
Add context support to `ProxyClient.ConnectToNode` to be able to timeout the connection.
The method is otherwise blocking and might hang upon establishing a connection if the other side closes the connection.

Let me know when/if I should port this to master/other branch.