### PR TITLE
Add context support to ProxyClient.ConnectToNode

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -136,7 +137,7 @@ func (s *IntSuite) TestAudit(c *check.C) {
 		c.Assert(err, check.IsNil)
 		cl.Stdout = &myTerm
 		cl.Stdin = &myTerm
-		err = cl.SSH([]string{}, false)
+		err = cl.SSH(context.TODO(), []string{}, false)
 		endC <- err
 	}()
 
@@ -290,7 +291,7 @@ func (s *IntSuite) TestInteractive(c *check.C) {
 		cl.Stdin = &personA
 		// Person A types something into the terminal (including "exit")
 		personA.Type("\aecho hi\n\r\aexit\n\r\a")
-		err = cl.SSH([]string{}, false)
+		err = cl.SSH(context.TODO(), []string{}, false)
 		c.Assert(err, check.IsNil)
 		sessionEndC <- true
 	}
@@ -311,7 +312,7 @@ func (s *IntSuite) TestInteractive(c *check.C) {
 		c.Assert(err, check.IsNil)
 		cl.Stdout = &personB
 		for i := 0; i < 10; i++ {
-			err = cl.Join(defaults.Namespace, session.ID(sessionID), &personB)
+			err = cl.Join(context.TODO(), defaults.Namespace, session.ID(sessionID), &personB)
 			if err == nil {
 				break
 			}
@@ -348,7 +349,7 @@ func (s *IntSuite) TestEnvironmentVariables(c *check.C) {
 	out := &bytes.Buffer{}
 	tc.Stdout = out
 	tc.Stdin = nil
-	err = tc.SSH(cmd, false)
+	err = tc.SSH(context.TODO(), cmd, false)
 
 	c.Assert(err, check.IsNil)
 	c.Assert(strings.TrimSpace(out.String()), check.Equals, testVal)
@@ -365,7 +366,7 @@ func (s *IntSuite) TestInvalidLogins(c *check.C) {
 	// try the wrong site:
 	tc, err := t.NewClient(s.me.Username, "wrong-site", Host, t.GetPortSSHInt())
 	c.Assert(err, check.IsNil)
-	err = tc.SSH(cmd, false)
+	err = tc.SSH(context.TODO(), cmd, false)
 	c.Assert(err, check.ErrorMatches, "cluster wrong-site not found")
 }
 
@@ -411,7 +412,7 @@ func (s *IntSuite) TestTwoSites(c *check.C) {
 	tc, err := a.NewClient(username, "site-A", Host, sshPort)
 	tc.Stdout = &outputA
 	c.Assert(err, check.IsNil)
-	err = tc.SSH(cmd, false)
+	err = tc.SSH(context.TODO(), cmd, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(outputA.String(), check.Equals, "hello world\n")
 
@@ -419,13 +420,13 @@ func (s *IntSuite) TestTwoSites(c *check.C) {
 	tc, err = b.NewClient(username, "site-A", Host, sshPort)
 	tc.Stdout = &outputB
 	c.Assert(err, check.IsNil)
-	err = tc.SSH(cmd, false)
+	err = tc.SSH(context.TODO(), cmd, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(outputA, check.DeepEquals, outputB)
 
 	// Stop "site-A" and try to connect to it again via "site-A" (expect a connection error)
 	a.Stop(false)
-	err = tc.SSH(cmd, false)
+	err = tc.SSH(context.TODO(), cmd, false)
 	c.Assert(err, check.ErrorMatches, "Failed connecting to cluster site-A: ssh: subsystem request failed")
 
 	// Reset and start "Site-A" again
@@ -438,7 +439,7 @@ func (s *IntSuite) TestTwoSites(c *check.C) {
 	// and 'tc' (client) is also supposed to reconnect
 	for i := 0; i < 10; i++ {
 		time.Sleep(time.Millisecond * 5)
-		err = tc.SSH(cmd, false)
+		err = tc.SSH(context.TODO(), cmd, false)
 		if err == nil {
 			break
 		}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -119,12 +120,12 @@ func (proxy *ProxyClient) GetSites() ([]services.Site, error) {
 //
 // A server is matched when ALL labels match.
 // If no labels are passed, ALL nodes are returned.
-func (proxy *ProxyClient) FindServersByLabels(namespace string, labels map[string]string) ([]services.Server, error) {
+func (proxy *ProxyClient) FindServersByLabels(ctx context.Context, namespace string, labels map[string]string) ([]services.Server, error) {
 	if namespace == "" {
 		return nil, trace.BadParameter("missing parameter namespace")
 	}
 	nodes := make([]services.Server, 0)
-	site, err := proxy.ConnectToSite(false)
+	site, err := proxy.ConnectToSite(ctx, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -146,7 +147,7 @@ func (proxy *ProxyClient) FindServersByLabels(namespace string, labels map[strin
 //
 // if 'quiet' is set to true, no errors will be printed to stdout, otherwise
 // any connection errors are visible to a user.
-func (proxy *ProxyClient) ConnectToSite(quiet bool) (auth.ClientI, error) {
+func (proxy *ProxyClient) ConnectToSite(ctx context.Context, quiet bool) (auth.ClientI, error) {
 	site, err := proxy.getSite()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -156,7 +157,7 @@ func (proxy *ProxyClient) ConnectToSite(quiet bool) (auth.ClientI, error) {
 	// note the addres we're using: "@sitename", which in practice looks like "@{site-global-id}"
 	// the Teleport proxy interprets such address as a request to connec to the active auth server
 	// of the named site
-	nodeClient, err := proxy.ConnectToNode("@"+site.Name, proxy.hostLogin, quiet)
+	nodeClient, err := proxy.ConnectToNode(ctx, "@"+site.Name, proxy.hostLogin, quiet)
 	if err != nil {
 		log.Error(err)
 		return nil, trace.Wrap(err)
@@ -174,7 +175,7 @@ func (proxy *ProxyClient) ConnectToSite(quiet bool) (auth.ClientI, error) {
 
 // ConnectToNode connects to the ssh server via Proxy.
 // It returns connected and authenticated NodeClient
-func (proxy *ProxyClient) ConnectToNode(nodeAddress string, user string, quiet bool) (*NodeClient, error) {
+func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress string, user string, quiet bool) (*NodeClient, error) {
 	log.Infof("[CLIENT] connecting to node: %s", nodeAddress)
 	e := trace.Errorf("unknown Error")
 
@@ -238,8 +239,7 @@ func (proxy *ProxyClient) ConnectToNode(nodeAddress string, user string, quiet b
 			Auth:            []ssh.AuthMethod{authMethod},
 			HostKeyCallback: proxy.hostKeyCallback,
 		}
-		conn, chans, reqs, err := ssh.NewClientConn(pipeNetConn,
-			nodeAddress, sshConfig)
+		conn, chans, reqs, err := newClientConn(ctx, pipeNetConn, nodeAddress, sshConfig)
 		if err != nil {
 			if utils.IsHandshakeFailedError(err) {
 				e = trace.Wrap(err)
@@ -260,6 +260,38 @@ func (proxy *ProxyClient) ConnectToNode(nodeAddress string, user string, quiet b
 		return nil, trace.Errorf(`access denied to login "%v" when connecting to %v: %v`, user, parts[0], e)
 	}
 	return nil, e
+}
+
+func newClientConn(ctx context.Context, conn net.Conn, nodeAddress string, config *ssh.ClientConfig) (ssh.Conn, <-chan ssh.NewChannel, <-chan *ssh.Request, error) {
+	type response struct {
+		conn   ssh.Conn
+		chanCh <-chan ssh.NewChannel
+		reqCh  <-chan *ssh.Request
+		err    error
+	}
+
+	respCh := make(chan response, 1)
+	go func() {
+		conn, chans, reqs, err := ssh.NewClientConn(conn, nodeAddress, config)
+		respCh <- response{conn, chans, reqs, err}
+	}()
+
+	select {
+	case resp := <-respCh:
+		if resp.err != nil {
+			return nil, nil, nil, trace.Wrap(resp.err, "failed to connect to %q", nodeAddress)
+		}
+		return resp.conn, resp.chanCh, resp.reqCh, nil
+	case <-ctx.Done():
+		errClose := conn.Close()
+		if errClose != nil {
+			log.Errorf("failed to close connection: %v", errClose)
+		}
+		// drain the channel
+		resp := <-respCh
+		log.Debugf("context closing")
+		return nil, nil, nil, trace.ConnectionProblem(resp.err, "failed to connect to %q", nodeAddress)
+	}
 }
 
 func (proxy *ProxyClient) Close() error {

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -246,7 +247,7 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 	currentSize, _ := term.GetWinsize(0)
 
 	// start the timer which asks for server-side window size changes:
-	siteClient, err := ns.nodeClient.Proxy.ConnectToSite(true)
+	siteClient, err := ns.nodeClient.Proxy.ConnectToSite(context.TODO(), true)
 	if err != nil {
 		log.Error(err)
 		return

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -74,7 +74,7 @@ func MultiCloser(closers ...io.Closer) *multiCloser {
 // IsHandshakeFailedError specifies whether this error indicates
 // failed handshake
 func IsHandshakeFailedError(err error) bool {
-	return strings.Contains(err.Error(), "ssh: handshake failed")
+	return strings.Contains(trace.Unwrap(err).Error(), "ssh: handshake failed")
 }
 
 // IsShellFailedError specifies whether this error indicates

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -185,7 +186,7 @@ func onPlay(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	if err := tc.Play(cf.Namespace, cf.SessionID); err != nil {
+	if err := tc.Play(context.TODO(), cf.Namespace, cf.SessionID); err != nil {
 		utils.FatalError(err)
 	}
 }
@@ -231,7 +232,7 @@ func onListNodes(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	servers, err := tc.ListNodes()
+	servers, err := tc.ListNodes(context.TODO())
 	if err != nil {
 		utils.FatalError(err)
 	}
@@ -297,7 +298,7 @@ func onSSH(cf *CLIConf) {
 	}
 
 	tc.Stdin = os.Stdin
-	if err = tc.SSH(cf.RemoteCommand, cf.LocalExec); err != nil {
+	if err = tc.SSH(context.TODO(), cf.RemoteCommand, cf.LocalExec); err != nil {
 		// exit with the same exit status as the failed command:
 		if tc.ExitStatus != 0 {
 			fmt.Fprintln(os.Stderr, utils.UserMessageFromError(err))
@@ -318,7 +319,7 @@ func onJoin(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(fmt.Errorf("'%v' is not a valid session ID (must be GUID)", cf.SessionID))
 	}
-	if err = tc.Join(cf.Namespace, *sid, nil); err != nil {
+	if err = tc.Join(context.TODO(), cf.Namespace, *sid, nil); err != nil {
 		utils.FatalError(err)
 	}
 }
@@ -329,7 +330,7 @@ func onSCP(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	if err := tc.SCP(cf.CopySpec, int(cf.NodePort), cf.RecursiveCopy, cf.Quiet); err != nil {
+	if err := tc.SCP(context.TODO(), cf.CopySpec, int(cf.NodePort), cf.RecursiveCopy, cf.Quiet); err != nil {
 		// exit with the same exit status as the failed command:
 		if tc.ExitStatus != 0 {
 			os.Exit(tc.ExitStatus)


### PR DESCRIPTION
Add context support to ProxyClient.ConnectToNode to be able to timeout the connection.
The method is otherwise blocking and might hang upon establishing a connection if the other side closes the connection.
