### PR TITLE
Unwrap the error before running it through the matcher

### DIFF
--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -73,7 +73,7 @@ func MultiCloser(closers ...io.Closer) *multiCloser {
 // IsHandshakeFailedError specifies whether this error indicates
 // failed handshake
 func IsHandshakeFailedError(err error) bool {
-	return strings.Contains(err.Error(), "ssh: handshake failed")
+	return strings.Contains(trace.Unwrap(err).Error(), "ssh: handshake failed")
 }
 
 // IsShellFailedError specifies whether this error indicates


### PR DESCRIPTION
 to avoid mismatches.

Discovered with integration tests in master - so backporting the change too.