### PR TITLE
Filesystem-based Teleport storage backend

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -40,8 +40,11 @@ const (
 	// DefaultTimeout sets read and wrie timeouts for SSH server ops
 	DefaultTimeout time.Duration = 30 * time.Second
 
-	// DebugOutputEnvVar tells tests to use verbose debug output
-	DebugOutputEnvVar = "TELEPORT_DEBUG"
+	// DebugEnvVar tells tests to use verbose debug output
+	DebugEnvVar = "DEBUG"
+
+	// VerboseLogEnvVar forces all logs to be verbose (down to DEBUG level)
+	VerboseLogsEnvVar = "TELEPORT_DEBUG"
 
 	// DefaultTerminalWidth defines the default width of a server-side allocated
 	// pseudo TTY

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -36,8 +36,6 @@ type Backend interface {
 	// CreateVal creates value with a given TTL and key in the bucket
 	// if the value already exists, returns AlreadyExistsError
 	CreateVal(bucket []string, key string, val []byte, ttl time.Duration) error
-	// TouchVal updates the TTL of the key without changing the value
-	TouchVal(bucket []string, key string, ttl time.Duration) error
 	// UpsertVal updates or inserts value with a given TTL into a bucket
 	// ForeverTTL for no TTL
 	UpsertVal(bucket []string, key string, val []byte, ttl time.Duration) error

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -43,8 +43,6 @@ type Backend interface {
 	UpsertVal(bucket []string, key string, val []byte, ttl time.Duration) error
 	// GetVal return a value for a given key in the bucket
 	GetVal(path []string, key string) ([]byte, error)
-	// GetValAndTTL returns value and TTL for a key in bucket
-	GetValAndTTL(bucket []string, key string) ([]byte, time.Duration, error)
 	// DeleteKey deletes a key in a bucket
 	DeleteKey(bucket []string, key string) error
 	// DeleteBucket deletes the bucket by a given path

--- a/lib/backend/boltbk/boltbk.go
+++ b/lib/backend/boltbk/boltbk.go
@@ -130,31 +130,6 @@ func (b *BoltBackend) CreateVal(bucket []string, key string, val []byte, ttl tim
 	return trace.Wrap(err)
 }
 
-func (b *BoltBackend) TouchVal(bucket []string, key string, ttl time.Duration) error {
-	err := b.db.Update(func(tx *bolt.Tx) error {
-		bkt, err := UpsertBucket(tx, bucket)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		val := bkt.Get([]byte(key))
-		if val == nil {
-			return trace.NotFound("'%v' already exists", key)
-		}
-		var k *kv
-		if err := json.Unmarshal(val, &k); err != nil {
-			return trace.Wrap(err)
-		}
-		k.TTL = ttl
-		k.Created = b.clock.UtcNow()
-		bytes, err := json.Marshal(k)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		return bkt.Put([]byte(key), bytes)
-	})
-	return trace.Wrap(err)
-}
-
 func (b *BoltBackend) upsertVal(path []string, key string, val []byte, ttl time.Duration) error {
 	v := &kv{
 		Created: b.clock.UtcNow(),

--- a/lib/backend/boltbk/boltbk_test.go
+++ b/lib/backend/boltbk/boltbk_test.go
@@ -66,10 +66,6 @@ func (s *BoltSuite) TestExpiration(c *C) {
 	s.suite.Expiration(c)
 }
 
-func (s *BoltSuite) TestRenewal(c *C) {
-	s.suite.Renewal(c)
-}
-
 func (s *BoltSuite) TestCreate(c *C) {
 	s.suite.Create(c)
 }

--- a/lib/backend/boltbk/boltcfg.go
+++ b/lib/backend/boltbk/boltcfg.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 )
 
@@ -28,19 +27,7 @@ type cfg struct {
 	Path string `json:"path"`
 }
 
-// FromString initialized the backend from backend-specific string
-func FromObject(in interface{}) (backend.Backend, error) {
-	if in == nil {
-		return nil, trace.Errorf(
-			`please supply a valid dictionary, e.g. {"path": "/opt/bolt.db"}`)
-	}
-	var c *cfg
-	if err := utils.ObjectToStruct(in, &c); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return New(c.Path)
-}
-
+// FromJSON creates a new bolt backend from a JSON string
 func FromJSON(paramsJSON string) (backend.Backend, error) {
 	c := cfg{}
 	err := json.Unmarshal([]byte(paramsJSON), &c)

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -358,19 +358,6 @@ func (b *DynamoDBBackend) GetVal(path []string, key string) ([]byte, error) {
 	return r.Value, nil
 }
 
-// GetValAndTTL retrieve a value and a TTL from a key
-func (b *DynamoDBBackend) GetValAndTTL(path []string, key string) ([]byte, time.Duration, error) {
-	fullPath := b.key(append(path, key)...)
-	r, err := b.getKey(fullPath)
-	if err != nil {
-		return nil, 0, err
-	}
-	if r.TTL != 0 {
-		r.TTL = time.Unix(r.Timestamp, 0).Add(r.TTL).Sub(time.Now().UTC())
-	}
-	return r.Value, r.TTL, nil
-}
-
 func suffix(key string) string {
 	vals := strings.Split(key, "/")
 	return vals[0]

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -207,16 +207,6 @@ func (b *DynamoDBBackend) UpsertVal(path []string, key string, val []byte, ttl t
 	return b.CreateVal(path, key, val, ttl)
 }
 
-// TouchVal refresh a key
-func (b *DynamoDBBackend) TouchVal(path []string, key string, ttl time.Duration) error {
-	fullPath := b.key(append(path, key)...)
-	r, err := b.getKey(fullPath)
-	if err != nil {
-		return trace.NotFound("%v not found", fullPath)
-	}
-	return b.CreateVal(path, key, r.Value, ttl)
-}
-
 const delayBetweenLockAttempts = 100 * time.Millisecond
 
 // AcquireLock for a token

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -184,21 +184,6 @@ func (b *bk) GetVal(path []string, key string) ([]byte, error) {
 	return value, nil
 }
 
-func (b *bk) GetValAndTTL(path []string, key string) ([]byte, time.Duration, error) {
-	re, err := b.api.Get(context.Background(), b.key(append(path, key)...), nil)
-	if err != nil {
-		return nil, 0, convertErr(err)
-	}
-	if re.Node.Dir {
-		return nil, 0, trace.BadParameter("'%v': trying to get value of bucket", key)
-	}
-	value, err := base64.StdEncoding.DecodeString(re.Node.Value)
-	if err != nil {
-		return nil, 0, trace.Wrap(err)
-	}
-	return value, time.Duration(re.Node.TTL) * time.Second, nil
-}
-
 func (b *bk) DeleteKey(path []string, key string) error {
 	_, err := b.api.Delete(context.Background(), b.key(append(path, key)...), nil)
 	return convertErr(err)

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -113,26 +113,6 @@ func (b *bk) CreateVal(path []string, key string, val []byte, ttl time.Duration)
 // maxOptimisticAttempts is the number of attempts optimistic locking
 const maxOptimisticAttempts = 5
 
-func (b *bk) TouchVal(path []string, key string, ttl time.Duration) error {
-	var err error
-	var re *client.Response
-	for i := 0; i < maxOptimisticAttempts; i++ {
-		re, err = b.api.Get(context.Background(), key, nil)
-		if err != nil {
-			return trace.Wrap(convertErr(err))
-		}
-		_, err = b.api.Set(
-			context.Background(),
-			b.key(append(path, key)...), re.Node.Value,
-			&client.SetOptions{TTL: ttl, PrevValue: re.Node.Value, PrevExist: client.PrevExist})
-		err = convertErr(err)
-		if err == nil {
-			return nil
-		}
-	}
-	return trace.Wrap(err)
-}
-
 func (b *bk) UpsertVal(path []string, key string, val []byte, ttl time.Duration) error {
 	_, err := b.api.Set(
 		context.Background(),

--- a/lib/backend/fs/doc.go
+++ b/lib/backend/fs/doc.go
@@ -19,11 +19,9 @@ compliant and support 'date modified' attribute on files.
 */
 
 //
-// filesystem backend is supposed to be used for single-host,
-// multip-process teleport deployments (it allows for multi-process locking).
+// Package 'fs' implements the "filesystem backend". It uses a regular
+// filesystem (directories with files) to store Teleport auth server state.
 //
 // Limitations:
 // 	- key names cannot start with '.' (dot)
-//
-
 package fs

--- a/lib/backend/fs/doc.go
+++ b/lib/backend/fs/doc.go
@@ -16,13 +16,14 @@ limitations under the License.
 fs package implements backend.Backend interface using a regular
 filesystem-based directory. The filesystem needs to be POSIX
 compliant and support 'date modified' attribute on files.
-
-filesystem backend is supposed to be used for single-host,
-multip-process teleport deployments (it allows for multi-process locking).
-
-Limitations:
-	- key names cannot start with '.' (dot)
-
 */
+
+//
+// filesystem backend is supposed to be used for single-host,
+// multip-process teleport deployments (it allows for multi-process locking).
+//
+// Limitations:
+// 	- key names cannot start with '.' (dot)
+//
 
 package fs

--- a/lib/backend/fs/doc.go
+++ b/lib/backend/fs/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2016 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+fs package implements backend.Backend interface using a regular
+filesystem-based directory. The filesystem needs to be POSIX
+compliant and support 'date modified' attribute on files.
+*/
+
+package fs

--- a/lib/backend/fs/doc.go
+++ b/lib/backend/fs/doc.go
@@ -16,6 +16,13 @@ limitations under the License.
 fs package implements backend.Backend interface using a regular
 filesystem-based directory. The filesystem needs to be POSIX
 compliant and support 'date modified' attribute on files.
+
+filesystem backend is supposed to be used for single-host,
+multip-process teleport deployments (it allows for multi-process locking).
+
+Limitations:
+	- key names cannot start with '.' (dot)
+
 */
 
 package fs

--- a/lib/backend/fs/impl.go
+++ b/lib/backend/fs/impl.go
@@ -12,8 +12,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
+
 package fs
 
 import (

--- a/lib/backend/fs/impl.go
+++ b/lib/backend/fs/impl.go
@@ -131,12 +131,6 @@ func (bk *Backend) DeleteBucket(parent []string, bucket string) error {
 		path.Join(path.Join(bk.Path, path.Join(parent...)), bucket)))
 }
 
-// TouchVal updates the TTL of the key without changing the value
-func (bk *Backend) TouchVal(bucket []string, key string, ttl time.Duration) error {
-	// NOT USED
-	return nil
-}
-
 // AcquireLock grabs a lock that will be released automatically in TTL
 func (bk *Backend) AcquireLock(token string, ttl time.Duration) error {
 	return nil

--- a/lib/backend/fs/impl.go
+++ b/lib/backend/fs/impl.go
@@ -109,7 +109,7 @@ func (bk *Backend) UpsertVal(bucket []string, key string, val []byte, ttl time.D
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	// create the file (AKA "key"):
+	// create the (or overwrite existing) file (AKA "key"):
 	return ioutil.WriteFile(path.Join(dirPath, key), val, defaultFileMode)
 }
 
@@ -129,11 +129,6 @@ func (bk *Backend) DeleteKey(bucket []string, key string) error {
 func (bk *Backend) DeleteBucket(parent []string, bucket string) error {
 	return trace.ConvertSystemError(os.RemoveAll(
 		path.Join(path.Join(bk.Path, path.Join(parent...)), bucket)))
-}
-
-// GetValAndTTL returns value and TTL for a key in bucket
-func (bk *Backend) GetValAndTTL(bucket []string, key string) ([]byte, time.Duration, error) {
-	return nil, 0, nil
 }
 
 // TouchVal updates the TTL of the key without changing the value

--- a/lib/backend/fs/impl.go
+++ b/lib/backend/fs/impl.go
@@ -22,28 +22,53 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/trace"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/mailgun/timetools"
 )
 
 const (
 	defaultDirMode  os.FileMode = 0770
 	defaultFileMode os.FileMode = 0600
+
+	// subdirectory where locks are stored
+	locksDir = ".locks"
+
+	// selfLock is the lock used internally for compare-and-swap
+	selfLock = ".backend"
 )
 
+// fs.Backend implements backend.Backend interface using a regular
+// POSIX-style filesystem
 type Backend struct {
-	Path string
+	sync.Mutex
+
+	// RootDir is the root (home) directory where the backend
+	// stores all the data.
+	RootDir string
+
+	// LocksDir is where lock files are kept
+	LocksDir string
+
+	// Clock is a test-friendly source of current time
+	Clock timetools.TimeProvider
+
+	// locks keeps the map of active file locks
+	locks map[string]string
 }
 
 // FromJSON creates a new filesystem-based storage backend using a JSON
 // configuration string which must look like this:
 //   { "path": "/var/lib/whatever" }
-func FromJSON(jsonStr string) (*Backend, error) {
+func FromJSON(jsonStr string) (bk *Backend, err error) {
 	const key = "path"
 	var m map[string]string
-	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+	if err = json.Unmarshal([]byte(jsonStr), &m); err != nil {
 		log.Error(trace.DebugReport(err))
 		return nil, trace.Errorf("Invalid file backend configuration: %v", err)
 	}
@@ -51,15 +76,23 @@ func FromJSON(jsonStr string) (*Backend, error) {
 	if !ok {
 		return nil, trace.Errorf("'%s' field is missing for the file backend", key)
 	}
-	if err := os.MkdirAll(path, defaultDirMode); err != nil {
+	return New(path)
+}
+
+// New creates a fully initialized filesystem backend
+func New(rootDir string) (*Backend, error) {
+	bk := &Backend{RootDir: rootDir, Clock: &timetools.RealTime{}}
+	bk.LocksDir = path.Join(bk.RootDir, locksDir)
+	bk.locks = make(map[string]string)
+	if err := os.MkdirAll(bk.LocksDir, defaultDirMode); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-	return &Backend{Path: path}, nil
+	return bk, nil
 }
 
 // GetKeys returns a list of keys for a given path
 func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
-	files, err := ioutil.ReadDir(path.Join(bk.Path, path.Join(bucket...)))
+	files, err := ioutil.ReadDir(path.Join(bk.RootDir, path.Join(bucket...)))
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
@@ -77,8 +110,12 @@ func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
 // CreateVal creates value with a given TTL and key in the bucket
 // if the value already exists, returns AlreadyExistsError
 func (bk *Backend) CreateVal(bucket []string, key string, val []byte, ttl time.Duration) error {
+	// do not allow keys that start with a dot
+	if key[0] == '.' {
+		return trace.BadParameter("Invalid key: '%s'. Key names cannot start with '.'", key)
+	}
 	// create the directory:
-	dirPath := path.Join(bk.Path, path.Join(bucket...))
+	dirPath := path.Join(bk.RootDir, path.Join(bucket...))
 	err := os.MkdirAll(dirPath, defaultDirMode)
 	if err != nil {
 		return trace.ConvertSystemError(err)
@@ -97,6 +134,7 @@ func (bk *Backend) CreateVal(bucket []string, key string, val []byte, ttl time.D
 	if err == nil && n < len(val) {
 		return trace.Wrap(io.ErrShortWrite)
 	}
+	bk.applyTTL(dirPath, key, ttl)
 	return nil
 }
 
@@ -104,7 +142,7 @@ func (bk *Backend) CreateVal(bucket []string, key string, val []byte, ttl time.D
 // ForeverTTL for no TTL
 func (bk *Backend) UpsertVal(bucket []string, key string, val []byte, ttl time.Duration) error {
 	// create the directory:
-	dirPath := path.Join(bk.Path, path.Join(bucket...))
+	dirPath := path.Join(bk.RootDir, path.Join(bucket...))
 	err := os.MkdirAll(dirPath, defaultDirMode)
 	if err != nil {
 		return trace.Wrap(err)
@@ -115,39 +153,149 @@ func (bk *Backend) UpsertVal(bucket []string, key string, val []byte, ttl time.D
 
 // GetVal return a value for a given key in the bucket
 func (bk *Backend) GetVal(bucket []string, key string) ([]byte, error) {
-	return ioutil.ReadFile(
-		path.Join(path.Join(bk.Path, path.Join(bucket...)), key))
+	dirPath := path.Join(path.Join(bk.RootDir, path.Join(bucket...)))
+	expired, err := bk.checkTTL(dirPath, key)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if expired {
+		bk.DeleteKey(bucket, key)
+		return nil, trace.NotFound("key '%s' is not found", key)
+	}
+	return ioutil.ReadFile(path.Join(dirPath, key))
 }
 
 // DeleteKey deletes a key in a bucket
 func (bk *Backend) DeleteKey(bucket []string, key string) error {
+	dirPath := path.Join(bk.RootDir, path.Join(bucket...))
+	if err := os.Remove(bk.ttlFile(dirPath, key)); err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn(err)
+		}
+	}
 	return trace.ConvertSystemError(os.Remove(
-		path.Join(path.Join(bk.Path, path.Join(bucket...)), key)))
+		path.Join(dirPath, key)))
 }
 
 // DeleteBucket deletes the bucket by a given path
 func (bk *Backend) DeleteBucket(parent []string, bucket string) error {
 	return trace.ConvertSystemError(os.RemoveAll(
-		path.Join(path.Join(bk.Path, path.Join(parent...)), bucket)))
+		path.Join(path.Join(bk.RootDir, path.Join(parent...)), bucket)))
 }
 
 // AcquireLock grabs a lock that will be released automatically in TTL
-func (bk *Backend) AcquireLock(token string, ttl time.Duration) error {
+func (bk *Backend) AcquireLock(token string, ttl time.Duration) (err error) {
+	lockPath := path.Join(bk.LocksDir, token)
+	var f *os.File
+	for {
+		f, err = os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+		if err == nil { // success
+			defer f.Close()
+			break
+		}
+		if os.IsExist(err) { // locked? wait and repeat:
+			bk.Clock.Sleep(time.Millisecond * 100)
+			continue
+		}
+		return trace.ConvertSystemError(err)
+	}
+
+	// protect the locks map:
+	bk.Lock()
+	defer bk.Unlock()
+	bk.locks[token] = f.Name()
+
+	// start the goroutine which will release lock after the given TTL
+	if ttl != backend.Forever {
+		go func() {
+			bk.Clock.Sleep(ttl)
+			bk.ReleaseLock(token)
+		}()
+	}
 	return nil
 }
 
 // ReleaseLock forces lock release before TTL
-func (bk *Backend) ReleaseLock(token string) error {
-	return nil
+func (bk *Backend) ReleaseLock(token string) (err error) {
+	// protect the locks map:
+	bk.Lock()
+	defer bk.Unlock()
+	// find the lock:
+	fn, found := bk.locks[token]
+	if !found {
+		return trace.NotFound("lock '%s' is not found", token)
+	}
+	// remove it:
+	if err = os.Remove(fn); err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn(err)
+		}
+	}
+	return trace.ConvertSystemError(err)
 }
 
 // CompareAndSwap implements compare ans swap operation for a key
 func (bk *Backend) CompareAndSwap(
 	bucket []string, key string, val []byte, ttl time.Duration, prevVal []byte) ([]byte, error) {
-	return nil, nil
+	// lock the entire backend:
+	bk.AcquireLock(selfLock, time.Second)
+	defer bk.ReleaseLock(selfLock)
+
+	storedVal, err := bk.GetVal(bucket, key)
+	if err != nil {
+		if trace.IsNotFound(err) && len(prevVal) != 0 {
+			return nil, err
+		}
+	}
+	if len(prevVal) == 0 && err == nil {
+		return nil, trace.AlreadyExists("key '%v' already exists", key)
+	}
+	if string(prevVal) == string(storedVal) {
+		if err = bk.UpsertVal(bucket, key, val, ttl); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return storedVal, nil
+	}
+	return storedVal, trace.CompareFailed("expected: %v, got: %v", string(prevVal), string(storedVal))
 }
 
-// Close releases the resources taken up by this backend
+// Close releases the resources taken up by this backend: locks
 func (bk *Backend) Close() error {
+	for lockName, _ := range bk.locks {
+		bk.ReleaseLock(lockName)
+	}
 	return nil
+}
+
+// applyTTL assigns a given TTL to a file with sub-second granularity
+func (bk *Backend) applyTTL(dirPath string, key string, ttl time.Duration) error {
+	if ttl == backend.Forever {
+		return nil
+	}
+	expiryTime := bk.Clock.UtcNow().Add(ttl)
+	bytes, _ := expiryTime.MarshalText()
+	return trace.ConvertSystemError(
+		ioutil.WriteFile(bk.ttlFile(dirPath, key), bytes, defaultFileMode))
+}
+
+// checkTTL checks if a given file has TTL and returns 'true' if it's expired
+func (bk *Backend) checkTTL(dirPath string, key string) (expired bool, err error) {
+	bytes, err := ioutil.ReadFile(bk.ttlFile(dirPath, key))
+	if err != nil {
+		if os.IsNotExist(err) { // no TTL
+			return false, nil
+		}
+		return false, trace.Wrap(err)
+	}
+	var expiryTime time.Time
+	if err = expiryTime.UnmarshalText(bytes); err != nil {
+		return false, trace.Wrap(err)
+	}
+	return bk.Clock.UtcNow().After(expiryTime), nil
+}
+
+// ttlFile returns the full path of the "TTL file" where the TTL is
+// stored for a given key, example: /root/bucket/.keyname.ttl
+func (bk *Backend) ttlFile(dirPath, key string) string {
+	return path.Join(dirPath, "."+key+".ttl")
 }

--- a/lib/backend/fs/impl.go
+++ b/lib/backend/fs/impl.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2016 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package fs
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gravitational/trace"
+)
+
+const (
+	defaultDirMode  os.FileMode = 0770
+	defaultFileMode os.FileMode = 0600
+)
+
+type Backend struct {
+	Path string
+}
+
+// FromJSON creates a new filesystem-based storage backend using a JSON
+// configuration string which must look like this:
+//   { "path": "/var/lib/whatever" }
+func FromJSON(jsonStr string) (*Backend, error) {
+	const key = "path"
+	var m map[string]string
+	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+		log.Error(trace.DebugReport(err))
+		return nil, trace.Errorf("Invalid file backend configuration: %v", err)
+	}
+	path, ok := m[key]
+	if !ok {
+		return nil, trace.Errorf("'%s' field is missing for the file backend", key)
+	}
+	if err := os.MkdirAll(path, defaultDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	return &Backend{Path: path}, nil
+}
+
+// GetKeys returns a list of keys for a given path
+func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
+	files, err := ioutil.ReadDir(path.Join(bk.Path, path.Join(bucket...)))
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	// enumerate all directory entries and select only non-hidden files
+	retval := make([]string, 0)
+	for _, fi := range files {
+		name := fi.Name()
+		if !fi.IsDir() && name[0] != '.' {
+			retval = append(retval, name)
+		}
+	}
+	return retval, nil
+}
+
+// CreateVal creates value with a given TTL and key in the bucket
+// if the value already exists, returns AlreadyExistsError
+func (bk *Backend) CreateVal(bucket []string, key string, val []byte, ttl time.Duration) error {
+	// create the directory:
+	dirPath := path.Join(bk.Path, path.Join(bucket...))
+	err := os.MkdirAll(dirPath, defaultDirMode)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	// create the file (AKA "key"):
+	filename := path.Join(dirPath, key)
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, defaultFileMode)
+	if err != nil {
+		if os.IsExist(err) {
+			return trace.AlreadyExists("%s/%s already exists", dirPath, key)
+		}
+		return trace.ConvertSystemError(err)
+	}
+	defer f.Close()
+	n, err := f.Write(val)
+	if err == nil && n < len(val) {
+		return trace.Wrap(io.ErrShortWrite)
+	}
+	return nil
+}
+
+// UpsertVal updates or inserts value with a given TTL into a bucket
+// ForeverTTL for no TTL
+func (bk *Backend) UpsertVal(bucket []string, key string, val []byte, ttl time.Duration) error {
+	// create the directory:
+	dirPath := path.Join(bk.Path, path.Join(bucket...))
+	err := os.MkdirAll(dirPath, defaultDirMode)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// create the file (AKA "key"):
+	return ioutil.WriteFile(path.Join(dirPath, key), val, defaultFileMode)
+}
+
+// GetVal return a value for a given key in the bucket
+func (bk *Backend) GetVal(bucket []string, key string) ([]byte, error) {
+	return ioutil.ReadFile(
+		path.Join(path.Join(bk.Path, path.Join(bucket...)), key))
+}
+
+// DeleteKey deletes a key in a bucket
+func (bk *Backend) DeleteKey(bucket []string, key string) error {
+	return trace.ConvertSystemError(os.Remove(
+		path.Join(path.Join(bk.Path, path.Join(bucket...)), key)))
+}
+
+// DeleteBucket deletes the bucket by a given path
+func (bk *Backend) DeleteBucket(parent []string, bucket string) error {
+	return trace.ConvertSystemError(os.RemoveAll(
+		path.Join(path.Join(bk.Path, path.Join(parent...)), bucket)))
+}
+
+// GetValAndTTL returns value and TTL for a key in bucket
+func (bk *Backend) GetValAndTTL(bucket []string, key string) ([]byte, time.Duration, error) {
+	return nil, 0, nil
+}
+
+// TouchVal updates the TTL of the key without changing the value
+func (bk *Backend) TouchVal(bucket []string, key string, ttl time.Duration) error {
+	// NOT USED
+	return nil
+}
+
+// AcquireLock grabs a lock that will be released automatically in TTL
+func (bk *Backend) AcquireLock(token string, ttl time.Duration) error {
+	return nil
+}
+
+// ReleaseLock forces lock release before TTL
+func (bk *Backend) ReleaseLock(token string) error {
+	return nil
+}
+
+// CompareAndSwap implements compare ans swap operation for a key
+func (bk *Backend) CompareAndSwap(
+	bucket []string, key string, val []byte, ttl time.Duration, prevVal []byte) ([]byte, error) {
+	return nil, nil
+}
+
+// Close releases the resources taken up by this backend
+func (bk *Backend) Close() error {
+	return nil
+}

--- a/lib/backend/fs/impl_test.go
+++ b/lib/backend/fs/impl_test.go
@@ -18,8 +18,6 @@ package fs
 
 import (
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,40 +25,18 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 
+	"github.com/jonboulle/clockwork"
+
 	"gopkg.in/check.v1"
 )
-
-type FrozenTime struct {
-	sync.Mutex
-	CurrentTime time.Time
-}
-
-func (t *FrozenTime) UtcNow() time.Time {
-	t.Lock()
-	defer t.Unlock()
-	return t.CurrentTime
-}
-
-func (t *FrozenTime) Sleep(d time.Duration) {
-	t.Lock()
-	defer t.Unlock()
-	t.CurrentTime = t.CurrentTime.Add(d)
-}
-
-func (t *FrozenTime) After(d time.Duration) <-chan time.Time {
-	t.Sleep(d)
-	c := make(chan time.Time, 1)
-	c <- t.CurrentTime
-	return c
-}
 
 type Suite struct {
 	dirName string
 	bk      backend.Backend
-	clock   FrozenTime
+	clock   clockwork.FakeClock
 }
 
-var _ = check.Suite(&Suite{})
+var _ = check.Suite(&Suite{clock: clockwork.NewFakeClock()})
 
 // bootstrap check.v1:
 func TestFSBackend(t *testing.T) { check.TestingT(t) }
@@ -73,7 +49,7 @@ func (s *Suite) SetUpSuite(c *check.C) {
 	c.Assert(bk.RootDir, check.Equals, dirName)
 	c.Assert(utils.IsDir(bk.RootDir), check.Equals, true)
 
-	bk.Clock = &s.clock
+	bk.Clock = s.clock
 	s.bk = bk
 }
 
@@ -169,48 +145,10 @@ func (s *Suite) TestTTL(c *check.C) {
 	c.Assert(string(v), check.Equals, string(value))
 
 	// after sleeping for 2 seconds the value must be gone:
-	s.clock.Sleep(time.Second * 2)
+	s.clock.Advance(time.Second * 2)
+
 	v, err = s.bk.GetVal(bucket, "key")
 	c.Assert(trace.IsNotFound(err), check.Equals, true)
 	c.Assert(err.Error(), check.Equals, `key 'key' is not found`)
 	c.Assert(v, check.IsNil)
-}
-
-func (s *Suite) TestLock(c *check.C) {
-	var protectedFlag int64 = 1
-	defer s.bk.ReleaseLock("lock")
-
-	err := s.bk.AcquireLock("lock", time.Second)
-	c.Assert(err, check.IsNil)
-
-	go func() {
-		defer s.bk.ReleaseLock("lock")
-		s.bk.AcquireLock("lock", time.Second)
-		atomic.AddInt64(&protectedFlag, 1)
-	}()
-
-	s.clock.Sleep(time.Millisecond)
-	c.Assert(atomic.LoadInt64(&protectedFlag), check.Equals, int64(1))
-}
-
-func (s *Suite) TestLockTTL(c *check.C) {
-	var protectedFlag int64 = 1
-	ln := "ttl-test"
-
-	err := s.bk.AcquireLock(ln, time.Second)
-	c.Assert(err, check.IsNil)
-	defer s.bk.ReleaseLock(ln)
-
-	go func() {
-		s.bk.AcquireLock(ln, time.Minute)
-		defer s.bk.ReleaseLock(ln)
-		atomic.AddInt64(&protectedFlag, 1)
-	}()
-
-	time.Sleep(time.Millisecond * 3) // give the goroutine some time to start
-
-	// wait for 5 seconds. this should be enough for the 1st lock
-	// to expire and the goroutine should be able to flip the flag
-	s.clock.Sleep(time.Second * 5)
-	c.Assert(atomic.LoadInt64(&protectedFlag), check.Equals, int64(2))
 }

--- a/lib/backend/fs/impl_test.go
+++ b/lib/backend/fs/impl_test.go
@@ -3,17 +3,20 @@ package fs
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 
+	"github.com/mailgun/timetools"
 	"gopkg.in/check.v1"
 )
 
 type Suite struct {
 	dirName string
 	bk      backend.Backend
+	clock   timetools.FreezedTime
 }
 
 var _ = check.Suite(&Suite{})
@@ -26,14 +29,11 @@ func (s *Suite) SetUpSuite(c *check.C) {
 	bk, err := FromJSON(fmt.Sprintf(`{ "path": "%s" }`, dirName))
 
 	c.Assert(err, check.IsNil)
-	c.Assert(bk.Path, check.Equals, dirName)
-	c.Assert(utils.IsDir(bk.Path), check.Equals, true)
+	c.Assert(bk.RootDir, check.Equals, dirName)
+	c.Assert(utils.IsDir(bk.RootDir), check.Equals, true)
 
+	bk.Clock = &s.clock
 	s.bk = bk
-}
-
-func (s *Suite) TestLocking(c *check.C) {
-	fmt.Println("Check locking", s.dirName)
 }
 
 func (s *Suite) TestCreateAndRead(c *check.C) {
@@ -68,7 +68,7 @@ func (s *Suite) TestListDelete(c *check.C) {
 
 	// create two entries in root:
 	s.bk.CreateVal(root, "one", []byte("1"), backend.Forever)
-	s.bk.CreateVal(root, "two", []byte("2"), backend.Forever)
+	s.bk.CreateVal(root, "two", []byte("2"), time.Second)
 
 	// create one entry in the kid:
 	s.bk.CreateVal(kid, "three", []byte("3"), backend.Forever)
@@ -103,4 +103,60 @@ func (s *Suite) TestListDelete(c *check.C) {
 	// try to list non-existing:
 	_, err = s.bk.GetKeys(kid)
 	c.Assert(trace.IsNotFound(err), check.Equals, true)
+}
+
+func (s *Suite) TestTTL(c *check.C) {
+	bucket := []string{"root"}
+	value := []byte("value")
+
+	s.bk.CreateVal(bucket, "key", value, time.Second)
+	v, err := s.bk.GetVal(bucket, "key")
+	c.Assert(err, check.IsNil)
+	c.Assert(string(v), check.Equals, string(value))
+
+	// after sleeping for 2 seconds the value must be gone:
+	s.clock.Sleep(time.Second * 2)
+	v, err = s.bk.GetVal(bucket, "key")
+	c.Assert(trace.IsNotFound(err), check.Equals, true)
+	c.Assert(err.Error(), check.Equals, `key 'key' is not found`)
+	c.Assert(v, check.IsNil)
+}
+
+func (s *Suite) TestLock(c *check.C) {
+	protectedFlag := true
+	defer s.bk.ReleaseLock("lock")
+
+	err := s.bk.AcquireLock("lock", time.Second)
+	c.Assert(err, check.IsNil)
+
+	go func() {
+		defer s.bk.ReleaseLock("lock")
+		s.bk.AcquireLock("lock", time.Second)
+		protectedFlag = false
+	}()
+
+	s.clock.Sleep(time.Millisecond)
+	c.Assert(protectedFlag, check.Equals, true)
+}
+
+func (s *Suite) TestLockTTL(c *check.C) {
+	protectedFlag := true
+	ln := "ttl-test"
+
+	err := s.bk.AcquireLock(ln, time.Second)
+	c.Assert(err, check.IsNil)
+	defer s.bk.ReleaseLock(ln)
+
+	go func() {
+		s.bk.AcquireLock(ln, time.Minute)
+		protectedFlag = false
+		s.bk.ReleaseLock(ln)
+	}()
+
+	time.Sleep(time.Millisecond) // give the goroutine some time to start
+
+	// wait for 5 seconds. this should be enough for the 1st lock
+	// to expire and the goroutine should be able to flip the flag
+	s.clock.Sleep(time.Second * 5)
+	c.Assert(protectedFlag, check.Equals, false)
 }

--- a/lib/backend/fs/impl_test.go
+++ b/lib/backend/fs/impl_test.go
@@ -1,0 +1,106 @@
+package fs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+
+	"gopkg.in/check.v1"
+)
+
+type Suite struct {
+	dirName string
+	bk      backend.Backend
+}
+
+var _ = check.Suite(&Suite{})
+
+// bootstrap check.v1:
+func TestFSBackend(t *testing.T) { check.TestingT(t) }
+
+func (s *Suite) SetUpSuite(c *check.C) {
+	dirName := c.MkDir()
+	bk, err := FromJSON(fmt.Sprintf(`{ "path": "%s" }`, dirName))
+
+	c.Assert(err, check.IsNil)
+	c.Assert(bk.Path, check.Equals, dirName)
+	c.Assert(utils.IsDir(bk.Path), check.Equals, true)
+
+	s.bk = bk
+}
+
+func (s *Suite) TestLocking(c *check.C) {
+	fmt.Println("Check locking", s.dirName)
+}
+
+func (s *Suite) TestCreateAndRead(c *check.C) {
+	path := []string{"one", "two"}
+
+	// must succeed:
+	err := s.bk.CreateVal(path, "key", []byte("original"), backend.Forever)
+	c.Assert(err, check.IsNil)
+
+	// must get 'already exists' error
+	err = s.bk.CreateVal(path, "key", []byte("failed-write"), backend.Forever)
+	c.Assert(trace.IsAlreadyExists(err), check.Equals, true)
+
+	// read back the original:
+	val, err := s.bk.GetVal(path, "key")
+	c.Assert(err, check.IsNil)
+	c.Assert(string(val), check.Equals, "original")
+
+	// upsert:
+	err = s.bk.UpsertVal(path, "key", []byte("new-value"), backend.Forever)
+	c.Assert(err, check.IsNil)
+
+	// read back the new value:
+	val, err = s.bk.GetVal(path, "key")
+	c.Assert(err, check.IsNil)
+	c.Assert(string(val), check.Equals, "new-value")
+}
+
+func (s *Suite) TestListDelete(c *check.C) {
+	root := []string{"root"}
+	kid := []string{"root", "kid"}
+
+	// create two entries in root:
+	s.bk.CreateVal(root, "one", []byte("1"), backend.Forever)
+	s.bk.CreateVal(root, "two", []byte("2"), backend.Forever)
+
+	// create one entry in the kid:
+	s.bk.CreateVal(kid, "three", []byte("3"), backend.Forever)
+
+	// list the root (should get 2 back):
+	kids, err := s.bk.GetKeys(root)
+	c.Assert(err, check.IsNil)
+	c.Assert(kids, check.HasLen, 2)
+	c.Assert(kids[0], check.Equals, "one")
+	c.Assert(kids[1], check.Equals, "two")
+
+	// list the kid (should get 1)
+	kids, err = s.bk.GetKeys(kid)
+	c.Assert(err, check.IsNil)
+	c.Assert(kids, check.HasLen, 1)
+	c.Assert(kids[0], check.Equals, "three")
+
+	// delete one of the kids:
+	err = s.bk.DeleteKey(kid, "three")
+	c.Assert(err, check.IsNil)
+	kids, err = s.bk.GetKeys(kid)
+	c.Assert(kids, check.HasLen, 0)
+
+	// try to delete non-existing key:
+	err = s.bk.DeleteKey(kid, "three")
+	c.Assert(trace.IsNotFound(err), check.Equals, true)
+
+	// try to delete the root bucket:
+	err = s.bk.DeleteBucket(root, "kid")
+	c.Assert(err, check.IsNil)
+
+	// try to list non-existing:
+	_, err = s.bk.GetKeys(kid)
+	c.Assert(trace.IsNotFound(err), check.Equals, true)
+}

--- a/lib/backend/fs/impl_test.go
+++ b/lib/backend/fs/impl_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fs
 
 import (

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -147,21 +147,6 @@ func (s *BackendSuite) Expiration(c *C) {
 	c.Assert(keys, DeepEquals, []string{"akey"})
 }
 
-func (s *BackendSuite) Renewal(c *C) {
-	c.Assert(s.B.UpsertVal([]string{"a", "b"}, "bkey", []byte("val1"), time.Second), IsNil)
-
-	time.Sleep(time.Second)
-
-	c.Assert(s.B.TouchVal([]string{"a", "b"}, "bkey", 100*time.Second), IsNil)
-
-	val, err := s.B.GetVal([]string{"a", "b"}, "bkey")
-	c.Assert(err, IsNil)
-	c.Assert(string(val), Equals, "val1")
-
-	err = s.B.TouchVal([]string{"a", "b"}, "non-key", 100*time.Second)
-	c.Assert(trace.IsNotFound(err), Equals, true)
-}
-
 func (s *BackendSuite) Create(c *C) {
 	c.Assert(s.B.CreateVal([]string{"a", "b"}, "bkey", []byte("val1"), time.Second), IsNil)
 	err := s.B.CreateVal([]string{"a", "b"}, "bkey", []byte("val2"), 0)

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -175,7 +175,7 @@ func (s *BackendSuite) Locking(c *C) {
 	err := s.B.ReleaseLock(tok1)
 	c.Assert(trace.IsNotFound(err), Equals, true, Commentf("%#v", err))
 
-	c.Assert(s.B.AcquireLock(tok1, time.Second), IsNil)
+	c.Assert(s.B.AcquireLock(tok1, time.Second*100), IsNil)
 	x := int32(7)
 
 	go func() {

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -66,11 +66,11 @@ func (s *BackendSuite) BasicCRUD(c *C) {
 
 	_, err = s.B.GetVal([]string{"a"}, "b")
 	c.Assert(trace.IsBadParameter(err), Equals, true, Commentf("%#v", err))
-	_, _, err = s.B.GetValAndTTL([]string{"a"}, "b")
+	_, err = s.B.GetVal([]string{"a"}, "b")
 	c.Assert(trace.IsBadParameter(err), Equals, true, Commentf("%#v", err))
 	_, err = s.B.GetVal([]string{"a", "b"}, "x")
 	c.Assert(trace.IsNotFound(err), Equals, true, Commentf("%#v", err))
-	_, _, err = s.B.GetValAndTTL([]string{"a", "b"}, "x")
+	_, err = s.B.GetVal([]string{"a", "b"}, "x")
 	c.Assert(trace.IsNotFound(err), Equals, true, Commentf("%#v", err))
 
 	keys, _ = s.B.GetKeys([]string{"a", "b", "bkey"})
@@ -83,10 +83,9 @@ func (s *BackendSuite) BasicCRUD(c *C) {
 	out, err := s.B.GetVal([]string{"a", "b"}, "bkey")
 	c.Assert(err, IsNil)
 	c.Assert(string(out), Equals, "val1")
-	out, ttl, err := s.B.GetValAndTTL([]string{"a", "b"}, "bkey")
+	out, err = s.B.GetVal([]string{"a", "b"}, "bkey")
 	c.Assert(err, IsNil)
 	c.Assert(string(out), Equals, "val1")
-	c.Assert(ttl, Equals, time.Duration(0))
 
 	c.Assert(s.B.UpsertVal([]string{"a", "b"}, "bkey", []byte("val-updated"), 0), IsNil)
 	out, err = s.B.GetVal([]string{"a", "b"}, "bkey")
@@ -155,10 +154,9 @@ func (s *BackendSuite) Renewal(c *C) {
 
 	c.Assert(s.B.TouchVal([]string{"a", "b"}, "bkey", 100*time.Second), IsNil)
 
-	val, ttl, err := s.B.GetValAndTTL([]string{"a", "b"}, "bkey")
+	val, err := s.B.GetVal([]string{"a", "b"}, "bkey")
 	c.Assert(err, IsNil)
 	c.Assert(string(val), Equals, "val1")
-	c.Assert(ttl > time.Second, Equals, true)
 
 	err = s.B.TouchVal([]string{"a", "b"}, "non-key", 100*time.Second)
 	c.Assert(trace.IsNotFound(err), Equals, true)
@@ -180,11 +178,9 @@ func (s *BackendSuite) ValueAndTTl(c *C) {
 
 	time.Sleep(1000 * time.Millisecond)
 
-	value, ttl, err := s.B.GetValAndTTL([]string{"a", "b"}, "bkey")
+	value, err := s.B.GetVal([]string{"a", "b"}, "bkey")
 	c.Assert(err, IsNil)
 	c.Assert(string(value), DeepEquals, "val1")
-	ttlIsRight := (ttl < 1400*time.Millisecond) && (ttl > 600*time.Millisecond)
-	c.Assert(ttlIsRight, Equals, true)
 }
 
 func (s *BackendSuite) Locking(c *C) {

--- a/lib/services/local/prov.go
+++ b/lib/services/local/prov.go
@@ -63,7 +63,7 @@ func (s *ProvisioningService) UpsertToken(token string, roles teleport.Roles, tt
 
 // GetToken finds and returns token by id
 func (s *ProvisioningService) GetToken(token string) (*services.ProvisionToken, error) {
-	out, _, err := s.backend.GetValAndTTL([]string{"tokens"}, token)
+	out, err := s.backend.GetVal([]string{"tokens"}, token)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -81,6 +81,9 @@ func (s *CA) GetCertAuthorities(caType services.CertAuthType, loadSigningKeys bo
 	}
 	domains, err := s.backend.GetKeys([]string{"authorities", string(caType)})
 	if err != nil {
+		if trace.IsNotFound(err) {
+			return cas, nil
+		}
 		return nil, trace.Wrap(err)
 	}
 	for _, domain := range domains {

--- a/lib/state/cachingaccesspoint_test.go
+++ b/lib/state/cachingaccesspoint_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/boltbk"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"gopkg.in/check.v1"
 )
@@ -97,6 +98,10 @@ var _ = check.Suite(&ClusterSnapshotSuite{})
 
 // bootstrap check
 func TestState(t *testing.T) { check.TestingT(t) }
+
+func (s *ClusterSnapshotSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
+}
 
 func (s *ClusterSnapshotSuite) SetUpTest(c *check.C) {
 	// create a new auth server:

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -70,9 +70,9 @@ func InitDebugLogger(level log.Level) {
 }
 
 // InitLoggerForTests inits logger to discard ouput in tests unless
-// TELEPORT_DEBUG is set to "true"
+// DEBUG is set to "1"
 func InitLoggerForTests() {
-	val, _ := strconv.ParseBool(os.Getenv(teleport.DebugOutputEnvVar))
+	val, _ := strconv.ParseBool(os.Getenv(teleport.VerboseLogsEnvVar))
 	if val {
 		InitLoggerDebug()
 		return

--- a/lib/utils/timeout_test.go
+++ b/lib/utils/timeout_test.go
@@ -61,8 +61,8 @@ func (s *TimeoutSuite) TearDownSuite(c *check.C) {
 }
 
 func (s *TimeoutSuite) TestSlowOperation(c *check.C) {
-	client := newClient(time.Millisecond * 3)
-	_, err := client.Get(s.server.URL + "/slow?delay=5ms")
+	client := newClient(time.Millisecond * 5)
+	_, err := client.Get(s.server.URL + "/slow?delay=10ms")
 	// must fail with I/O timeout
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Matches, "^.*i/o timeout$")

--- a/lib/web/static.go
+++ b/lib/web/static.go
@@ -28,7 +28,10 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
+
 	"github.com/kardianos/osext"
 )
 
@@ -71,8 +74,8 @@ func NewStaticFileSystem(debugMode bool) (http.FileSystem, error) {
 // isDebugMode determines if teleport is running in a "debug" mode.
 // It looks at DEBUG environment variable
 func isDebugMode() bool {
-	v, err := strconv.ParseBool(os.Getenv("DEBUG"))
-	return v && err == nil
+	v, _ := strconv.ParseBool(os.Getenv(teleport.DebugEnvVar))
+	return v
 }
 
 // LoadWebResources returns a filesystem implementation compatible

--- a/lib/web/static_test.go
+++ b/lib/web/static_test.go
@@ -20,6 +20,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/gravitational/teleport"
+
 	"gopkg.in/check.v1"
 )
 
@@ -34,13 +36,13 @@ func (s *StaticSuite) SetUpSuite(c *check.C) {
 
 func (s *StaticSuite) TestDebugModeEnv(c *check.C) {
 	c.Assert(isDebugMode(), check.Equals, false)
-	os.Setenv("DEBUG", "no")
+	os.Setenv(teleport.DebugEnvVar, "no")
 	c.Assert(isDebugMode(), check.Equals, false)
-	os.Setenv("DEBUG", "0")
+	os.Setenv(teleport.DebugEnvVar, "0")
 	c.Assert(isDebugMode(), check.Equals, false)
-	os.Setenv("DEBUG", "1")
+	os.Setenv(teleport.DebugEnvVar, "1")
 	c.Assert(isDebugMode(), check.Equals, true)
-	os.Setenv("DEBUG", "true")
+	os.Setenv(teleport.DebugEnvVar, "true")
 	c.Assert(isDebugMode(), check.Equals, true)
 }
 

--- a/lib/web/web_test.go
+++ b/lib/web/web_test.go
@@ -88,12 +88,13 @@ var _ = Suite(&WebSuite{})
 
 func (s *WebSuite) SetUpSuite(c *C) {
 	var err error
+	os.Unsetenv(teleport.DebugEnvVar)
+	utils.InitLoggerForTests()
 
 	// configure tests to use static assets from web/dist:
 	debugAssetsPath = "../../web/dist"
-	os.Setenv("DEBUG", "true")
+	os.Setenv(teleport.DebugEnvVar, "true")
 
-	utils.InitLoggerForTests()
 	sessionStreamPollPeriod = time.Millisecond
 	s.logDir = c.MkDir()
 	s.auditLog, err = events.NewAuditLog(s.logDir)
@@ -106,6 +107,7 @@ func (s *WebSuite) SetUpSuite(c *C) {
 
 func (s *WebSuite) TearDownSuite(c *C) {
 	os.RemoveAll(s.logDir)
+	os.Unsetenv(teleport.DebugEnvVar)
 }
 
 func (s *WebSuite) SetUpTest(c *C) {

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -23,8 +23,10 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
@@ -43,7 +45,9 @@ func main() {
 // same as main() but has a testing switch
 func run(cmdlineArgs []string, testRun bool) (executedCommand string, conf *service.Config) {
 	var err error
-	if os.Getenv("DEBUG") != "" {
+	// configure trace's errors to produce full stack traces
+	isDebug, _ := strconv.ParseBool(os.Getenv(teleport.DebugEnvVar))
+	if isDebug {
 		trace.SetDebug(true)
 	}
 	// configure logger for a typical CLI scenario until configuration file is

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -43,7 +43,9 @@ func main() {
 // same as main() but has a testing switch
 func run(cmdlineArgs []string, testRun bool) (executedCommand string, conf *service.Config) {
 	var err error
-
+	if os.Getenv("DEBUG") != "" {
+		trace.SetDebug(true)
+	}
 	// configure logger for a typical CLI scenario until configuration file is
 	// parsed
 	utils.InitLoggerCLI()

--- a/tool/teleport/main_test.go
+++ b/tool/teleport/main_test.go
@@ -75,9 +75,6 @@ func (s *MainTestSuite) TestDefault(c *check.C) {
 	c.Assert(conf.Proxy.Enabled, check.Equals, true)
 	c.Assert(conf.Console, check.Equals, os.Stdout)
 	c.Assert(log.GetLevel(), check.Equals, log.WarnLevel)
-
-	cmd, conf = run([]string{"start", "-d"}, true)
-	c.Assert(log.GetLevel(), check.Equals, log.DebugLevel)
 }
 
 func (s *MainTestSuite) TestRolesFlag(c *check.C) {
@@ -99,7 +96,7 @@ func (s *MainTestSuite) TestRolesFlag(c *check.C) {
 }
 
 func (s *MainTestSuite) TestConfigFile(c *check.C) {
-	cmd, conf := run([]string{"start", "--roles=node", "-d", "--labels=a=a1,b=b1", "--config=" + s.configFile}, true)
+	cmd, conf := run([]string{"start", "--roles=node", "--labels=a=a1,b=b1", "--config=" + s.configFile}, true)
 	c.Assert(cmd, check.Equals, "start")
 	c.Assert(conf.SSH.Enabled, check.Equals, true)
 	c.Assert(conf.Auth.Enabled, check.Equals, false)


### PR DESCRIPTION
### Changes

There are 2 parts to this PR:

1. Removed unused code and methods from the `backend.Backend` interface, namely `GetValAndTTL()` and `TouchVal()`.
2. Implemented filesystem-based storage back-end with identical behavior to Bolt.

NOTE: the new back end is not plugged in into production code. It is there to be merged later as part of 1.5 milestone.

### The Benefit

From the product perspective, the value proposition of this back-end is:

* Provides HA for people without operational expertise with etcd or Dynamo. They can use network-backed FS (either Gluster/NFS kind or enterprise storage) in combination with multiple auth servers or (even better) with a single auto-migrating auth server.

* Reduced system requirements (Bolt did not work properly on some filesystems).
