### PR TITLE
map OIDC scopes to roles, implements #620

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -54,4 +54,7 @@ const (
 	// SafeTerminalType is the fall-back TTY type to fall back to (when $TERM
 	// is not defined)
 	SafeTerminalType = "xterm"
+
+	// ConnectorOIDC means connector type OIDC
+	ConnectorOIDC = "oidc"
 )

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -157,6 +157,14 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 	err = s.clt.UpsertUser(user)
 	c.Assert(err, IsNil)
 
+	user2 := &services.TeleportUser{Name: "user2", AllowedLogins: []string{"user2"}}
+	role2 := services.RoleForUser(user2)
+	err = s.clt.UpsertRole(role)
+	c.Assert(err, IsNil)
+	user.Roles = []string{role2.GetName()}
+	err = s.clt.UpsertUser(user2)
+	c.Assert(err, IsNil)
+
 	newChecker, err := NewAccessChecker(s.AccessS, s.WebS)
 	c.Assert(err, IsNil)
 

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -152,6 +152,13 @@ func GetCheckerForSystemUsers(username string) (services.AccessChecker, error) {
 					services.Wildcard: services.RW(),
 				},
 			})
+	case teleport.RoleNop.User():
+		return services.FromSpec(
+			username,
+			services.RoleSpec{
+				Namespaces: []string{},
+				Resources:  map[string][]string{},
+			})
 	}
 
 	return nil, trace.NotFound("%v is not reconginzed", username)

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -389,7 +389,7 @@ func (s *TunSuite) TestPermissions(c *C) {
 	_, err = cltw.GetNodes(defaults.Namespace)
 	c.Assert(err, NotNil)
 
-	// Requesting forbidden for Web action
+	// Requesting sign in forbidden for Web action
 	_, err = cltw.SignIn(user.Name, pass)
 	c.Assert(err, NotNil)
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -59,6 +59,7 @@ func RoleForUser(u User) *RoleResource {
 				KindNode:          RO(),
 				KindAuthServer:    RO(),
 				KindReverseTunnel: RO(),
+				KindCertAuthority: RO(),
 			},
 		},
 	}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -115,8 +115,7 @@ func (s *ServicesTestSuite) UsersCRUD(c *C) {
 		&services.TeleportUser{Name: "user1"}, &services.TeleportUser{Name: "user2"}})
 
 	out, err := s.WebS.GetUser("user1")
-	c.Assert(err, IsNil)
-	usersEqual(c, out, &services.TeleportUser{Name: "user1"})
+	usersEqual(c, out, u[0])
 
 	user := &services.TeleportUser{Name: "user1", AllowedLogins: []string{"admin", "root"}}
 	c.Assert(s.WebS.UpsertUser(user), IsNil)

--- a/lib/services/users_test.go
+++ b/lib/services/users_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/coreos/go-oidc/jose"
+	. "gopkg.in/check.v1"
+)
+
+type UserSuite struct {
+}
+
+var _ = Suite(&UserSuite{})
+
+func (s *UserSuite) SetUpSuite(c *C) {
+	utils.InitLoggerForTests()
+}
+
+func (s *RoleSuite) TestOIDCMapping(c *C) {
+	conn := OIDCConnector{}
+	c.Assert(conn.MapClaims(jose.Claims{"a": "b"}), DeepEquals, []string(nil))
+
+	conn = OIDCConnector{
+		ClaimsToRoles: []ClaimMapping{
+			{Claim: "role", Value: "admin", Roles: []string{"admin", "bob"}},
+			{Claim: "role", Value: "user", Roles: []string{"user"}},
+		},
+	}
+	c.Assert(conn.MapClaims(jose.Claims{"a": "b"}), DeepEquals, []string(nil))
+	c.Assert(conn.MapClaims(jose.Claims{"role": "b"}), DeepEquals, []string(nil))
+	c.Assert(conn.MapClaims(jose.Claims{"role": "admin"}), DeepEquals, []string{"admin", "bob"})
+	c.Assert(conn.MapClaims(jose.Claims{"role": "user"}), DeepEquals, []string{"user"})
+	c.Assert(conn.MapClaims(jose.Claims{"role": []string{"user"}}), DeepEquals, []string{"user"})
+}

--- a/lib/utils/roles_test.go
+++ b/lib/utils/roles_test.go
@@ -44,12 +44,12 @@ func (s *RolesTestSuite) TestParsing(c *check.C) {
 
 func (s *RolesTestSuite) TestBadRoles(c *check.C) {
 	bad := teleport.Role("bad-role")
-	c.Assert(bad.Check(), check.ErrorMatches, "role bad-role is not supported")
+	c.Assert(bad.Check(), check.ErrorMatches, "role bad-role is not registered")
 	badRoles := teleport.Roles{
 		bad,
 		teleport.RoleAdmin,
 	}
-	c.Assert(badRoles.Check(), check.ErrorMatches, "role bad-role is not supported")
+	c.Assert(badRoles.Check(), check.ErrorMatches, "role bad-role is not registered")
 }
 
 func (s *RolesTestSuite) TestEquivalence(c *check.C) {

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -168,6 +168,22 @@ func HumanTimeFormat(d time.Time) string {
 	return d.Format(HumanTimeFormatString)
 }
 
+// Deduplicate deduplicates list of strings
+func Deduplicate(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]string, 0, len(in))
+	seen := make(map[string]bool, len(in))
+	for _, val := range in {
+		if _, ok := seen[val]; !ok {
+			out = append(out, val)
+			seen[val] = true
+		}
+	}
+	return out
+}
+
 const (
 	// HumanTimeFormatString is a human readable date formatting
 	HumanTimeFormatString = "Mon Jan _2 15:04 UTC"

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -26,6 +26,12 @@ type UtilsSuite struct {
 
 var _ = check.Suite(&UtilsSuite{})
 
+func (s *UtilsSuite) TestDeduplicate(c *check.C) {
+	c.Assert(Deduplicate([]string{}), check.DeepEquals, []string{})
+	c.Assert(Deduplicate([]string{"a", "b"}), check.DeepEquals, []string{"a", "b"})
+	c.Assert(Deduplicate([]string{"a", "b", "b", "a", "c"}), check.DeepEquals, []string{"a", "b", "c"})
+}
+
 func (s *UtilsSuite) TestHostUUID(c *check.C) {
 	// call twice, get same result
 	dir := c.MkDir()

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -263,7 +263,6 @@ func (s *sessionCache) AuthWithU2FSignResponse(user string, response *u2f.SignRe
 	defer clt.Close()
 	session, err := clt.PreAuthenticatedSignIn(user)
 	if err != nil {
-		defer clt.Close()
 		return nil, trace.Wrap(err)
 	}
 	return session, nil

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -664,7 +664,6 @@ func (m *Handler) u2fSignRequest(w http.ResponseWriter, r *http.Request, p httpr
 	}
 	u2fSignReq, err := m.auth.GetU2FSignRequest(req.User, req.Pass)
 	if err != nil {
-		log.Infof("bad access credentials: %v", err)
 		return nil, trace.AccessDenied("bad auth credentials")
 	}
 
@@ -695,7 +694,6 @@ func (m *Handler) createSessionWithU2FSignResponse(w http.ResponseWriter, r *htt
 
 	sess, err := m.auth.AuthWithU2FSignResponse(req.User, &req.U2FSignResponse)
 	if err != nil {
-		log.Infof("bad access credentials: %v", err)
 		return nil, trace.AccessDenied("bad auth credentials")
 	}
 	if err := SetSession(w, req.User, sess.ID); err != nil {

--- a/roles.go
+++ b/roles.go
@@ -84,10 +84,10 @@ func (r *Role) String() string {
 // if it's ok, false otherwise
 func (r *Role) Check() error {
 	switch *r {
-	case RoleAuth, RoleUser, RoleWeb, RoleNode, RoleAdmin, RoleProvisionToken, RoleSignup, RoleProxy:
+	case RoleAuth, RoleUser, RoleWeb, RoleNode, RoleAdmin, RoleProvisionToken, RoleSignup, RoleProxy, RoleNop:
 		return nil
 	}
-	return trace.BadParameter("role %v is not supported", *r)
+	return trace.BadParameter("role %v is not registered", *r)
 }
 
 // Role returns system username associated with it
@@ -120,4 +120,7 @@ const (
 	RoleProvisionToken Role = "ProvisionToken"
 	// RoleSignup is for first time signing up users
 	RoleSignup Role = "Signup"
+	// RoleNop is used for actions that already using external authz mechanisms
+	// e.g. tokens or passwords
+	RoleNop Role = "Nop"
 )

--- a/tool/tctl/collection.go
+++ b/tool/tctl/collection.go
@@ -114,7 +114,7 @@ func printActions(resources map[string][]string) string {
 	pairs := []string{}
 	for key, actions := range resources {
 		if key == services.Wildcard {
-			return "<all resources>"
+			return fmt.Sprintf("<all resources>: %v", strings.Join(actions, ","))
 		}
 		pairs = append(pairs, fmt.Sprintf("%v:%v", key, strings.Join(actions, ",")))
 	}

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -386,12 +386,12 @@ func (u *UserCommand) List(client *auth.TunClient) error {
 	}
 	usersView := func(users []services.User) string {
 		t := goterm.NewTable(0, 10, 5, ' ', 0)
-		printHeader(t, []string{"User", "Roles"})
+		printHeader(t, []string{"User", "Roles", "Created By"})
 		if len(users) == 0 {
 			return t.String()
 		}
 		for _, u := range users {
-			fmt.Fprintf(t, "%v\t%v\n", u.GetName(), strings.Join(u.GetRoles(), ","))
+			fmt.Fprintf(t, "%v\t%v\t%v\n", u.GetName(), strings.Join(u.GetRoles(), ","), u.GetCreatedBy().String())
 		}
 		return t.String()
 	}


### PR DESCRIPTION
## Description

Map OIDC scopes in connectors to roles and generate users as defined in #620.

* System creates new user with the name that is defined by OIDC identity. 
* User entry is created with TTL of the OIDC session
* If the user exists and is created by some other OIDC identity or by system, the system fails

Misc:

* Fix inconsistent behavior when `GetUser` returns entry even if user does not exist.
* Fix security vulnerability when user name was assumed based on SSH login, not on KeyId as designed in some cases.

