### PR TITLE
Removed  backend.CompareAndSwap() method from all backends

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -39,7 +39,7 @@ type Backend interface {
 	// GetKeys returns a list of keys for a given path
 	GetKeys(bucket []string) ([]string, error)
 	// CreateVal creates value with a given TTL and key in the bucket
-	// if the value already exists, returns AlreadyExistsError
+	// if the value already exists, it must return trace.AlreadyExistsError
 	CreateVal(bucket []string, key string, val []byte, ttl time.Duration) error
 	// UpsertVal updates or inserts value with a given TTL into a bucket
 	// ForeverTTL for no TTL
@@ -54,8 +54,6 @@ type Backend interface {
 	AcquireLock(token string, ttl time.Duration) error
 	// ReleaseLock forces lock release before TTL
 	ReleaseLock(token string) error
-	// CompareAndSwap implements compare ans swap operation for a key
-	CompareAndSwap(bucket []string, key string, val []byte, ttl time.Duration, prevVal []byte) ([]byte, error)
 	// Close releases the resources taken up by this backend
 	Close() error
 }

--- a/lib/backend/boltbk/boltbk.go
+++ b/lib/backend/boltbk/boltbk.go
@@ -143,29 +143,6 @@ func (b *BoltBackend) upsertVal(path []string, key string, val []byte, ttl time.
 	return b.upsertKey(path, key, bytes)
 }
 
-func (b *BoltBackend) CompareAndSwap(path []string, key string, val []byte, ttl time.Duration, prevVal []byte) ([]byte, error) {
-	b.Lock()
-	defer b.Unlock()
-
-	storedVal, err := b.GetVal(path, key)
-	if err != nil {
-		if trace.IsNotFound(err) && len(prevVal) != 0 {
-			return nil, err
-		}
-	}
-	if len(prevVal) == 0 && err == nil {
-		return nil, trace.AlreadyExists("key '%v' already exists", key)
-	}
-	if string(prevVal) == string(storedVal) {
-		err = b.upsertVal(path, key, val, ttl)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return storedVal, nil
-	}
-	return storedVal, trace.CompareFailed("expected: %v, got: %v", string(prevVal), string(storedVal))
-}
-
 func (b *BoltBackend) GetVal(path []string, key string) ([]byte, error) {
 	var val []byte
 	if err := b.getKey(path, key, &val); err != nil {

--- a/lib/backend/boltbk/boltbk_test.go
+++ b/lib/backend/boltbk/boltbk_test.go
@@ -58,10 +58,6 @@ func (s *BoltSuite) TestBasicCRUD(c *C) {
 	s.suite.BasicCRUD(c)
 }
 
-func (s *BoltSuite) TestCompareAndSwap(c *C) {
-	s.suite.CompareAndSwap(c)
-}
-
 func (s *BoltSuite) TestExpiration(c *C) {
 	s.suite.Expiration(c)
 }

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -328,29 +328,6 @@ func (b *DynamoDBBackend) ReleaseLock(token string) error {
 	return b.deleteKey(fp)
 }
 
-// CompareAndSwap key
-func (b *DynamoDBBackend) CompareAndSwap(
-	path []string, key string, val []byte, ttl time.Duration, prevVal []byte) ([]byte, error) {
-
-	storedVal, err := b.GetVal(path, key)
-	if err != nil {
-		if trace.IsNotFound(err) && len(prevVal) != 0 {
-			return nil, err
-		}
-	}
-	if len(prevVal) == 0 && err == nil {
-		return nil, trace.AlreadyExists("key '%v' already exists", key)
-	}
-	if string(prevVal) == string(storedVal) {
-		err = b.UpsertVal(path, key, val, ttl)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return storedVal, nil
-	}
-	return storedVal, trace.CompareFailed("expected: %v, got: %v", string(prevVal), string(storedVal))
-}
-
 // DeleteBucket remove all prefixed keys
 // WARNING: there is no bucket feature, deleting "bucket" mean a deletion one by one
 func (b *DynamoDBBackend) DeleteBucket(path []string, key string) error {

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -68,10 +68,6 @@ func (s *DynamoDBSuite) TestBasicCRUD(c *C) {
 	s.suite.BasicCRUD(c)
 }
 
-func (s *DynamoDBSuite) TestCompareAndSwap(c *C) {
-	s.suite.CompareAndSwap(c)
-}
-
 func (s *DynamoDBSuite) TestExpiration(c *C) {
 	s.suite.Expiration(c)
 }

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -120,35 +120,6 @@ func (b *bk) UpsertVal(path []string, key string, val []byte, ttl time.Duration)
 	return convertErr(err)
 }
 
-func (b *bk) CompareAndSwap(path []string, key string, val []byte, ttl time.Duration, prevVal []byte) ([]byte, error) {
-	var err error
-	var re *client.Response
-	if len(prevVal) != 0 {
-		re, err = b.api.Set(
-			context.Background(),
-			b.key(append(path, key)...), base64.StdEncoding.EncodeToString(val),
-			&client.SetOptions{TTL: ttl, PrevValue: base64.StdEncoding.EncodeToString(prevVal), PrevExist: client.PrevExist})
-	} else {
-		re, err = b.api.Set(
-			context.Background(),
-			b.key(append(path, key)...), base64.StdEncoding.EncodeToString(val),
-			&client.SetOptions{TTL: ttl, PrevExist: client.PrevNoExist})
-	}
-	err = convertErr(err)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if re.PrevNode != nil {
-		value, err := base64.StdEncoding.DecodeString(re.PrevNode.Value)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return value, nil
-	}
-	return nil, nil
-}
-
 func (b *bk) GetVal(path []string, key string) ([]byte, error) {
 	re, err := b.api.Get(context.Background(), b.key(append(path, key)...), nil)
 	if err != nil {

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -85,10 +85,6 @@ func (s *EtcdSuite) TestBasicCRUD(c *C) {
 	s.suite.BasicCRUD(c)
 }
 
-func (s *EtcdSuite) TestCompareAndSwap(c *C) {
-	s.suite.CompareAndSwap(c)
-}
-
 func (s *EtcdSuite) TestExpiration(c *C) {
 	s.suite.Expiration(c)
 }

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -115,36 +115,6 @@ func (s *BackendSuite) BasicCRUD(c *C) {
 	c.Assert(trace.IsNotFound(err), Equals, true, Commentf("%#v", err))
 }
 
-func (s *BackendSuite) CompareAndSwap(c *C) {
-	prev, err := s.B.CompareAndSwap([]string{"a", "b"}, "bkey", []byte("val10"), 0, []byte("1231"))
-	c.Assert(trace.IsNotFound(err), Equals, true, Commentf("%#v", err))
-	c.Assert(len(prev), Equals, 0)
-
-	prev, err = s.B.CompareAndSwap([]string{"a", "b"}, "bkey", []byte("val1"), 0, []byte{})
-	c.Assert(err, IsNil)
-	c.Assert(len(prev), Equals, 0)
-
-	_, err = s.B.CompareAndSwap([]string{"a", "b"}, "bkey", []byte("val2"), 0, []byte{})
-	c.Assert(trace.IsAlreadyExists(err), Equals, true, Commentf("%#v", err))
-
-	_, err = s.B.CompareAndSwap([]string{"a", "b"}, "bkey", []byte("val2"), 0, []byte("abcd"))
-	c.Assert(trace.IsCompareFailed(err), Equals, true, Commentf("%#v", err))
-
-	out, err := s.B.GetVal([]string{"a", "b"}, "bkey")
-	c.Assert(err, IsNil)
-	c.Assert(string(out), Equals, "val1")
-
-	c.Assert(s.B.UpsertVal([]string{"a", "b"}, "anotherkey", []byte("val3"), 0), IsNil)
-
-	prev, err = s.B.CompareAndSwap([]string{"a", "b"}, "bkey", []byte("val4"), 0, []byte("val1"))
-	c.Assert(err, IsNil)
-	c.Assert(string(prev), DeepEquals, "val1")
-
-	out, err = s.B.GetVal([]string{"a", "b"}, "bkey")
-	c.Assert(err, IsNil)
-	c.Assert(string(out), Equals, "val4")
-}
-
 func (s *BackendSuite) Expiration(c *C) {
 	bucket := []string{"one", "two"}
 	c.Assert(s.B.UpsertVal(bucket, "bkey", []byte("val1"), time.Second), IsNil)


### PR DESCRIPTION
Teleport does not use `backend.CompareAndSwap()` method anymore. And it's a good thing because in most backends this method was implemented using the same global lock (and DynamoDB backend did not implement it properly - it was not atomic).