### PR TITLE
Removed a bunch of dead/unused code

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -212,7 +212,7 @@ func MakeSampleFileConfig() (fc *FileConfig) {
 	g.Limits.MaxConnections = defaults.LimiterMaxConnections
 	g.Limits.MaxUsers = defaults.LimiterMaxConcurrentUsers
 	g.DataDir = defaults.DataDir
-	g.Storage.Type = conf.Auth.RecordsBackend.Type
+	g.Storage.Type = conf.Auth.KeysBackend.Type
 	g.PIDFile = "/var/run/teleport.pid"
 
 	// sample SSH config:
@@ -338,6 +338,7 @@ type Log struct {
 // Global is 'teleport' (global) section of the config file
 type Global struct {
 	NodeName    string           `yaml:"nodename,omitempty"`
+	DataDir     string           `yaml:"data_dir,omitempty"`
 	PIDFile     string           `yaml:"pid_file,omitempty"`
 	AuthToken   string           `yaml:"auth_token,omitempty"`
 	AuthServers []string         `yaml:"auth_servers,omitempty"`
@@ -345,7 +346,6 @@ type Global struct {
 	Logger      Log              `yaml:"log,omitempty"`
 	Storage     backend.Config   `yaml:"storage,omitempty"`
 	AdvertiseIP net.IP           `yaml:"advertise_ip,omitempty"`
-	DataDir     string           `yaml:"data_dir,omitempty"`
 
 	// Keys holds the list of SSH key/cert pairs used by all services
 	// Each service (like proxy, auth, node) can find the key it needs

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -130,14 +130,8 @@ func (cfg *Config) ApplyToken(token string) bool {
 // ConfigureBolt configures Bolt back-ends with a data dir.
 func (cfg *Config) ConfigureBolt() {
 	a := &cfg.Auth
-	if a.EventsBackend.Type == teleport.BoltBackendType {
-		a.EventsBackend.Params = boltParams(cfg.DataDir, defaults.EventsBoltFile)
-	}
 	if a.KeysBackend.Type == teleport.BoltBackendType {
 		a.KeysBackend.Params = boltParams(cfg.DataDir, defaults.KeysBoltFile)
-	}
-	if a.RecordsBackend.Type == teleport.BoltBackendType {
-		a.RecordsBackend.Params = boltParams(cfg.DataDir, defaults.RecordsBoltFile)
 	}
 }
 
@@ -151,13 +145,6 @@ func (cfg *Config) ConfigureETCD(etcdCfg etcdbk.Config) error {
 	}
 	a.KeysBackend.Type = teleport.ETCDBackendType
 	a.KeysBackend.Params = params
-
-	// We can't store records and events in ETCD
-	a.EventsBackend.Type = teleport.BoltBackendType
-	a.EventsBackend.Params = boltParams(cfg.DataDir, defaults.EventsBoltFile)
-
-	a.RecordsBackend.Type = teleport.BoltBackendType
-	a.RecordsBackend.Params = boltParams(cfg.DataDir, defaults.RecordsBoltFile)
 	return nil
 }
 
@@ -245,22 +232,6 @@ type AuthConfig struct {
 		BackendConf *backend.Config
 	}
 
-	// EventsBackend configures backend that stores cluster events (login attempts, etc)
-	EventsBackend struct {
-		// Type is a backend type, etcd or bolt
-		Type string
-		// Params is map with backend specific parameters
-		Params string
-	}
-
-	// RecordsBackend configures backend that stores live SSH sessions recordings
-	RecordsBackend struct {
-		// Type is a backend type, currently only bolt
-		Type string
-		// Params is map with backend specific parameters
-		Params string
-	}
-
 	Limiter limiter.LimiterConfig
 
 	// NoAudit, when set to true, disables session recording and event audit
@@ -299,12 +270,8 @@ func ApplyDefaults(cfg *Config) {
 	// defaults for the auth service:
 	cfg.Auth.Enabled = true
 	cfg.Auth.SSHAddr = *defaults.AuthListenAddr()
-	cfg.Auth.EventsBackend.Type = defaults.BackendType
-	cfg.Auth.EventsBackend.Params = boltParams(defaults.DataDir, defaults.EventsBoltFile)
 	cfg.Auth.KeysBackend.Type = defaults.BackendType
 	cfg.Auth.KeysBackend.Params = boltParams(defaults.DataDir, defaults.KeysBoltFile)
-	cfg.Auth.RecordsBackend.Type = defaults.BackendType
-	cfg.Auth.RecordsBackend.Params = boltParams(defaults.DataDir, defaults.RecordsBoltFile)
 	cfg.Auth.U2F.Enabled = false
 	cfg.Auth.U2F.AppID = fmt.Sprintf("https://%s:%d", strings.ToLower(hostname), defaults.HTTPListenPort)
 	cfg.Auth.U2F.Facets = []string{cfg.Auth.U2F.AppID}

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -62,10 +62,6 @@ func (s *ConfigSuite) TestDefaultConfig(c *C) {
 	c.Assert(auth.Limiter.MaxNumberOfUsers, Equals, defaults.LimiterMaxConcurrentUsers)
 	c.Assert(auth.KeysBackend.Type, Equals, "bolt")
 	c.Assert(auth.KeysBackend.Params, Equals, `{"path": "/var/lib/teleport/keys.db"}`)
-	c.Assert(auth.EventsBackend.Type, Equals, "bolt")
-	c.Assert(auth.EventsBackend.Params, Equals, `{"path": "/var/lib/teleport/events.db"}`)
-	c.Assert(auth.RecordsBackend.Type, Equals, "bolt")
-	c.Assert(auth.RecordsBackend.Params, Equals, `{"path": "/var/lib/teleport/records.db"}`)
 
 	// SSH section
 	ssh := config.SSH


### PR DESCRIPTION
Originally Teleport had facilities to configure events/recordings via two
separate backends.

In reality those two objects (session events and session recordings)
need each other and currently there is only one implementaiton of it.

The old structures were unused. This commit is 100% dead code removeal.