### PR TITLE
fix migrations from V1

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -537,7 +537,7 @@ type Authority struct {
 }
 
 // Parse reads values and returns parsed CertAuthority
-func (a *Authority) Parse() (services.CertAuthority, error) {
+func (a *Authority) Parse() (services.CertAuthority, services.Role, error) {
 	ca := &services.CertAuthorityV1{
 		AllowedLogins: a.AllowedLogins,
 		DomainName:    a.DomainName,
@@ -547,7 +547,7 @@ func (a *Authority) Parse() (services.CertAuthority, error) {
 	for _, path := range a.CheckingKeyFiles {
 		keyBytes, err := utils.ReadPath(path)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, nil, trace.Wrap(err)
 		}
 		ca.CheckingKeys = append(ca.CheckingKeys, keyBytes)
 	}
@@ -559,7 +559,7 @@ func (a *Authority) Parse() (services.CertAuthority, error) {
 	for _, path := range a.SigningKeyFiles {
 		keyBytes, err := utils.ReadPath(path)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, nil, trace.Wrap(err)
 		}
 		ca.SigningKeys = append(ca.SigningKeys, keyBytes)
 	}
@@ -568,7 +568,8 @@ func (a *Authority) Parse() (services.CertAuthority, error) {
 		ca.SigningKeys = append(ca.SigningKeys, []byte(val))
 	}
 
-	return ca.V2(), nil
+	new, role := services.ConvertV1CertAuthority(ca)
+	return new, role, nil
 }
 
 // ClaimMapping is OIDC claim mapping that maps

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -87,6 +87,15 @@ func RoleForCertAuthority(ca CertAuthority) Role {
 	}
 }
 
+// ConvertV1CertAuthority converts V1 cert authority for new CA and Role
+func ConvertV1CertAuthority(v1 *CertAuthorityV1) (CertAuthority, Role) {
+	ca := v1.V2()
+	role := RoleForCertAuthority(ca)
+	role.SetLogins(v1.AllowedLogins)
+	ca.AddRole(role.GetName())
+	return ca, role
+}
+
 // Access service manages roles and permissions
 type Access interface {
 	// GetRoles returns a list of roles

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -33,6 +33,15 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+func CopyStrings(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
 type HostKeyCallback func(hostID string, remote net.Addr, key ssh.PublicKey) error
 
 func ReadPath(path string) ([]byte, error) {


### PR DESCRIPTION
Trusted clusters and cert authorities static configuration
sections were not properly processed and we've been creating
incomplete V2 objects in the database. This commit fixes the problem by properly converting v1 objects to V2 objects when parsing static configs.