### PR TITLE
Added make task to create a Teleport release using docker

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -60,3 +60,10 @@ run-docs: bbox
 .PHONY:enter
 enter: bbox
 	docker run $(DOCKERFLAGS) -ti $(NOROOT) $(BBOX) /bin/bash
+
+#
+# Create a teleport package using the build container
+#
+.PHONY:release
+release: 
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOX) /usr/bin/make release -e VERSION="$(VERSION)" -e ADDFLAGS="$(ADDFLAGS)"


### PR DESCRIPTION
By adding this task, we can create a teleport release for linux-amd64 using Docker (so you don't need to install a Go environment in the host)

## Usage examples
`$ make -C build.assets release`

`$ make -C build.assets release ADDFLAGS='-tags dynamodb' VERSION=1.2.9`