### PR TITLE
Moved Check* methods into auth package.

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -454,11 +454,6 @@ type upsertPasswordReq struct {
 	Password string `json:"password"`
 }
 
-type upsertPasswordResponse struct {
-	OTPURL    string `json:"otp_url"`
-	OTPQRCode []byte `json:"otp_qr"`
-}
-
 func (s *APIServer) upsertPassword(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *upsertPasswordReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
@@ -466,12 +461,12 @@ func (s *APIServer) upsertPassword(auth ClientI, w http.ResponseWriter, r *http.
 	}
 
 	user := p.ByName("user")
-	otpURL, otpQRCode, err := auth.UpsertPassword(user, []byte(req.Password))
+	err := auth.UpsertPassword(user, []byte(req.Password))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return &upsertPasswordResponse{OTPURL: otpURL, OTPQRCode: otpQRCode}, nil
+	return message(fmt.Sprintf("password for for user %q upserted", user)), nil
 }
 
 type upsertUserRawReq struct {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package auth
 
 import (
-	"net/url"
 	"testing"
 	"time"
 
@@ -73,13 +72,8 @@ func (s *AuthSuite) TestSessions(c *C) {
 
 	createUserAndRole(s.a, user, []string{user})
 
-	otpURL, _, err := s.a.UpsertPassword(user, pass)
+	err = s.a.UpsertPassword(user, pass)
 	c.Assert(err, IsNil)
-
-	// make sure label in url is correct
-	u, err := url.Parse(otpURL)
-	c.Assert(err, IsNil)
-	c.Assert(u.Path, Equals, "/user1")
 
 	ws, err = s.a.SignIn(user, pass)
 	c.Assert(err, IsNil)
@@ -108,13 +102,8 @@ func (s *AuthSuite) TestUserLock(c *C) {
 
 	createUserAndRole(s.a, user, []string{user})
 
-	otpURL, _, err := s.a.UpsertPassword(user, pass)
+	err = s.a.UpsertPassword(user, pass)
 	c.Assert(err, IsNil)
-
-	// make sure label in url is correct
-	u, err := url.Parse(otpURL)
-	c.Assert(err, IsNil)
-	c.Assert(u.Path, Equals, "/user1")
 
 	// successfull log in
 	ws, err = s.a.SignIn(user, pass)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -242,18 +242,32 @@ func (a *AuthWithRoles) UpsertToken(token string, roles teleport.Roles, ttl time
 	return a.authServer.UpsertToken(token, roles, ttl)
 }
 
-func (a *AuthWithRoles) UpsertPassword(user string, password []byte) (hotpURL string, hotpQR []byte, err error) {
+func (a *AuthWithRoles) UpsertPassword(user string, password []byte) error {
 	if err := a.currentUserAction(user); err != nil {
-		return "", nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 	return a.authServer.UpsertPassword(user, password)
 }
 
-func (a *AuthWithRoles) CheckPassword(user string, password []byte, hotpToken string) error {
+func (a *AuthWithRoles) CheckPassword(user string, password []byte, otpToken string) error {
 	if err := a.currentUserAction(user); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.CheckPassword(user, password, hotpToken)
+	return a.authServer.CheckPassword(user, password, otpToken)
+}
+
+func (a *AuthWithRoles) UpsertTOTP(user string, otpSecret string) error {
+	if err := a.currentUserAction(user); err != nil {
+		return trace.Wrap(err)
+	}
+	return a.authServer.UpsertTOTP(user, otpSecret)
+}
+
+func (a *AuthWithRoles) GetOTPData(user string) (string, []byte, error) {
+	if err := a.currentUserAction(user); err != nil {
+		return "", nil, trace.Wrap(err)
+	}
+	return a.authServer.GetOTPData(user)
 }
 
 func (a *AuthWithRoles) SignIn(user string, password []byte) (*Session, error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -515,22 +515,17 @@ func (c *Client) GetU2FAppID() (string, error) {
 }
 
 // UpsertPassword updates web access password for the user
-func (c *Client) UpsertPassword(user string, password []byte) (otpURL string, otpQRCode []byte, err error) {
-	out, err := c.PostJSON(
+func (c *Client) UpsertPassword(user string, password []byte) error {
+	_, err := c.PostJSON(
 		c.Endpoint("users", user, "web", "password"),
 		upsertPasswordReq{
 			Password: string(password),
 		})
 	if err != nil {
-		return "", nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
-	var re *upsertPasswordResponse
-	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
-		return "", nil, trace.Wrap(err)
-	}
-
-	return re.OTPURL, re.OTPQRCode, err
+	return nil
 }
 
 // UpsertUser user updates or inserts user entry
@@ -1172,7 +1167,7 @@ type WebService interface {
 // IdentityService manages identities and userse
 type IdentityService interface {
 	// UpsertPassword updates web access password for the user
-	UpsertPassword(user string, password []byte) (otpURL string, otpQRCode []byte, err error)
+	UpsertPassword(user string, password []byte) error
 
 	// UpsertOIDCConnector updates or creates OIDC connector
 	UpsertOIDCConnector(connector services.OIDCConnector, ttl time.Duration) error

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -1,0 +1,142 @@
+package auth
+
+import (
+	"crypto/subtle"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+
+	"github.com/pquerna/otp/totp"
+)
+
+// CheckPasswordWOToken checks just password without checking OTP tokens
+// used in case of SSH authentication, when token has been validated.
+func (s *AuthServer) CheckPasswordWOToken(user string, password []byte) error {
+	err := services.VerifyPassword(password)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	hash, err := s.GetPasswordHash(user)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err = bcrypt.CompareHashAndPassword(hash, password); err != nil {
+		return trace.BadParameter("passwords do not match")
+	}
+
+	return nil
+}
+
+// CheckPassword checks the password and OTP token. Called by tsh or lib/web/*.
+func (s *AuthServer) CheckPassword(user string, password []byte, otpToken string) error {
+	err := s.CheckPasswordWOToken(user, password)
+	if err != nil {
+		return trace.AccessDenied("invalid password")
+	}
+
+	err = s.CheckOTP(user, otpToken)
+	if err != nil {
+		return trace.AccessDenied("invalid otp token")
+	}
+
+	return nil
+}
+
+// CheckOTP determines the type of OTP token used (for legacy HOTP support), fetches the
+// appropriate type from the backend, and checks if the token is valid.
+func (s *AuthServer) CheckOTP(user string, otpToken string) error {
+	var err error
+
+	otpType, err := s.getOTPType(user)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	switch otpType {
+	case "hotp":
+		otp, err := s.GetHOTP(user)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// look ahead n tokens to see if we can find a matching token
+		if !otp.Scan(otpToken, defaults.HOTPFirstTokensRange) {
+			return trace.AccessDenied("bad htop token")
+		}
+
+		// we need to upsert the hotp state again because the
+		// counter was incremented
+		if err := s.UpsertHOTP(user, otp); err != nil {
+			return trace.Wrap(err)
+		}
+	case "totp":
+		otpSecret, err := s.GetTOTP(user)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// get the previously used token to mitigate token replay attacks
+		usedToken, err := s.GetUsedTOTPToken(user)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// we use a constant time compare function to mitigate timing attacks
+		if subtle.ConstantTimeCompare([]byte(otpToken), []byte(usedToken)) == 1 {
+			return trace.AccessDenied("previously used totp token")
+		}
+
+		valid := totp.Validate(otpToken, otpSecret)
+		if !valid {
+			return trace.AccessDenied("invalid totp token")
+		}
+
+		// if we have a valid token, update the previously used token
+		err = s.UpsertUsedTOTPToken(user, otpToken)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+// getOTPType returns the type of OTP token used, HOTP or TOTP.
+// Deprecated: Remove this method once HOTP support has been removed.
+func (s *AuthServer) getOTPType(user string) (string, error) {
+	_, err := s.GetHOTP(user)
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return "totp", nil
+		}
+		return "", trace.Wrap(err)
+	}
+	return "hotp", nil
+}
+
+// GetOTPData returns the OTP Key, Key URL, and the QR code.
+func (s *AuthServer) GetOTPData(user string) (string, []byte, error) {
+	// get otp key from backend
+	otpSecret, err := s.GetTOTP(user)
+	if err != nil {
+		return "", nil, trace.Wrap(err)
+	}
+
+	// create otp url
+	params := map[string][]byte{"secret": []byte(otpSecret)}
+	otpURL := utils.GenerateOTPURL("totp", user, params)
+
+	// create the qr code
+	otpQR, err := utils.GenerateQRCode(otpURL)
+	if err != nil {
+		return "", nil, trace.Wrap(err)
+	}
+
+	return otpURL, otpQR, nil
+}

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package services implements API services exposed by Teleport:
-// * presence service that takes care of heratbeats
+// * presence service that takes care of heartbeats
 // * web service that takes care of web logins
 // * ca service - certificate authorities
 package services
@@ -101,14 +101,7 @@ type Identity interface {
 	DeleteWebSession(user, sid string) error
 
 	// UpsertPassword upserts new password and OTP token
-	UpsertPassword(user string, password []byte) (otpURL string, otpQRCode []byte, err error)
-
-	// CheckPassword is called on web user or tsh user login using the password and otp token
-	CheckPassword(user string, password []byte, otpToken string) error
-
-	// CheckPasswordWOToken checks just password without checking HOTP tokens
-	// used in case of SSH authentication, when token has been validated
-	CheckPasswordWOToken(user string, password []byte) error
+	UpsertPassword(user string, password []byte) error
 
 	// UpsertSignupToken upserts signup token - one time token that lets user to create a user account
 	UpsertSignupToken(token string, tokenData SignupToken, ttl time.Duration) error

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -86,14 +86,6 @@ func (s *ServicesSuite) TestPasswordHashCRUD(c *C) {
 	s.suite.PasswordHashCRUD(c)
 }
 
-func (s *ServicesSuite) TestPasswordAndHotpCRUD(c *C) {
-	s.suite.PasswordCRUD(c)
-}
-
-func (s *ServicesSuite) TestPasswordGarbage(c *C) {
-	s.suite.PasswordGarbage(c)
-}
-
 func (s *ServicesSuite) TestWebSessionCRUD(c *C) {
 	s.suite.WebSessionCRUD(c)
 }

--- a/lib/utils/otp.go
+++ b/lib/utils/otp.go
@@ -1,9 +1,36 @@
 package utils
 
 import (
+	"bytes"
 	"encoding/base32"
+	"image/png"
 	"net/url"
+
+	"github.com/gravitational/trace"
+
+	"github.com/pquerna/otp"
 )
+
+// GenerateQRCode takes in a OTP Key URL and returns a PNG-encoded QR code.
+func GenerateQRCode(u string) ([]byte, error) {
+	otpKey, err := otp.NewKeyFromURL(u)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	otpImage, err := otpKey.Image(450, 450)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var otpQR bytes.Buffer
+	err = png.Encode(&otpQR, otpImage)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return otpQR.Bytes(), nil
+}
 
 // GenerateOTPURL returns a OTP Key URL that can be used to construct a HOTP or TOTP key. For more
 // details see: https://github.com/google/google-authenticator/wiki/Key-Uri-Format


### PR DESCRIPTION
**Purpose**

Currently the `Identity` interface required the implementation of several `Check*` methods, like `CheckPassword`, `CheckPasswordWOToken`, and `CheckOTP`. This required identity implementations to reimplement this logic even though they only performed CRUD operations. 

This PR moves this logic out of the services (or models) and moves it into the `AuthService` for two reasons:

* Reimplementing this logic is dangerous, if a bug is found in one location the fix may not be propagated to other implementations.
* Implementing a new backend is now significantly easier.

**Implementation**

* The `Check*` methods mentioned above were removed from the `Identity` interface as well as it's implementation in `lib/services/local/users.go`.
* The `Check*` methods were added to `AuthService` in `lib/auth/password.go`.
* The `UpsertPassword` method definition in the `Identity` service has been updated to no longer return OTP metadata. The method implementation in `lib/services/local/users.go` has also removed the logic that updates the OTP generator.

**Related PR**
https://github.com/gravitational/teleport/pull/709