### PR TITLE
Better error reporting for tsh

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -91,13 +91,15 @@ func FatalError(err error) {
 
 // UserMessageFromError returns user friendly error message from error
 func UserMessageFromError(err error) string {
-	err = trace.Unwrap(err)
 
 	// untrusted cert?
-	switch err.(interface{}).(type) {
+	switch trace.Unwrap(err).(interface{}).(type) {
 	case x509.UnknownAuthorityError, x509.CertificateInvalidError:
 		return "WARNING:\n The proxy you are connecting to uses the self-signed HTTPS certificate.\n" +
 			" Try --insecure flag if you know what you're doing.\n"
+	}
+	if log.GetLevel() == log.DebugLevel {
+		return trace.DebugReport(err)
 	}
 	return err.Error()
 }

--- a/vendor/github.com/gravitational/trace/httplib.go
+++ b/vendor/github.com/gravitational/trace/httplib.go
@@ -65,7 +65,9 @@ func ReadError(statusCode int, re []byte) error {
 	var e error
 	switch statusCode {
 	case http.StatusNotFound:
-		e = &NotFoundError{}
+		e = &NotFoundError{
+			Message: string(re),
+		}
 	case http.StatusBadRequest:
 		e = &BadParameterError{}
 	case http.StatusPreconditionFailed:


### PR DESCRIPTION
This PR is about two things:

1. Forwards the original HTTP error to the user without replacing it with generic "object not found". The related PR for trace package is here: https://github.com/gravitational/trace/pull/27

2. Adds proper handling for `-d` (debug) CLI flag. When passed, `tsh` will print the call stack along with the error message.

The original intent was to fix #719 but looks like the server had broken the backwards compatibility with old `tsh` clients on the server side. Shall we change the URL and make `namespace` an argument, as opposed to injecting it into query path?