### PR TITLE
Regression fixes

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -63,7 +63,7 @@ const (
 	TOTP = "totp"
 
 	// HOTP means HMAC-based One-time Password Algorithm.
-	HOTP = "htop"
+	HOTP = "hotp"
 
 	// U2F means Universal 2nd Factor.
 	U2F = "u2f"

--- a/lib/auth/new_web_user.go
+++ b/lib/auth/new_web_user.go
@@ -124,7 +124,7 @@ func (s *AuthServer) GetSignupTokenData(token string) (user string, qrCode []byt
 	// It's a TOCTOU bug in the making: https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use
 	_, err = s.GetPasswordHash(tokenData.User.Name)
 	if err == nil {
-		return "", nil, trace.Errorf("can't add user %q: user already exists", tokenData.User)
+		return "", nil, trace.Errorf("can't add user %v: user already exists", tokenData.User)
 	}
 
 	return tokenData.User.Name, tokenData.OTPQRCode, nil

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -944,8 +944,10 @@ func (tc *TeleportClient) Login() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	log.Debugf("using 2nd factor type: '%v'", tc.SecondFactorType)
 
 	var response *web.SSHLoginResponse
+
 	switch tc.SecondFactorType {
 	case teleport.OTP:
 	case teleport.HOTP: // htop is deprecated
@@ -965,6 +967,8 @@ func (tc *TeleportClient) Login() error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+	default:
+		return trace.BadParameter("unsupported 2nd factor authentication type: '%s'", tc.SecondFactorType)
 	}
 	key.Cert = response.Cert
 	// save the key:

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -165,7 +165,6 @@ func (s *remoteSite) ConnectToServer(server, user string, auth []ssh.AuthMethod)
 	// ask remote channel to dial
 	dialed, err := ch.SendRequest(chanTransportDialReq, true, []byte(server))
 	if err != nil {
-		remoteConn.markInvalid(err)
 		return nil, trace.Wrap(err)
 	}
 	if !dialed {

--- a/lib/srv/proxy.go
+++ b/lib/srv/proxy.go
@@ -61,10 +61,10 @@ type proxySubsys struct {
 func parseProxySubsys(name string, srv *Server) (*proxySubsys, error) {
 	log.Debugf("parse_proxy_subsys(%s)", name)
 	var (
-		siteName   string
-		host       string
-		port       string
-		paramError = trace.BadParameter("invalid format for proxy request: '%v', expected 'proxy:host:port@site'", name)
+		clusterName string
+		host        string
+		port        string
+		paramError  = trace.BadParameter("invalid format for proxy request: '%v', expected 'proxy:host:port@site'", name)
 	)
 	const prefix = "proxy:"
 	// get rid of 'proxy:' prefix:
@@ -77,23 +77,23 @@ func parseProxySubsys(name string, srv *Server) (*proxySubsys, error) {
 	parts := strings.Split(name, "@")
 	switch len(parts) {
 	case 2:
-		siteName = strings.Join(parts[1:], "@")
+		clusterName = strings.Join(parts[1:], "@")
 		name = parts[0]
 	case 3:
-		siteName = strings.Join(parts[2:], "@")
+		clusterName = strings.Join(parts[2:], "@")
 		namespace = parts[1]
 		name = parts[0]
 	}
 	// find host & port in the arguments:
 	host, port, err := net.SplitHostPort(name)
-	if siteName == "" && err != nil {
+	if clusterName == "" && err != nil {
 		return nil, trace.Wrap(paramError)
 	}
-	// validate siteName
-	if siteName != "" && srv.proxyTun != nil {
-		_, err := srv.proxyTun.GetSite(siteName)
+	if clusterName != "" && srv.proxyTun != nil {
+		_, err := srv.proxyTun.GetSite(clusterName)
 		if err != nil {
-			return nil, trace.BadParameter("unknown site '%s'", siteName)
+			fmt.Printf("parts: %v\n", parts)
+			return nil, trace.BadParameter("unknown cluster '%s'", clusterName)
 		}
 	}
 
@@ -102,7 +102,7 @@ func parseProxySubsys(name string, srv *Server) (*proxySubsys, error) {
 		srv:       srv,
 		host:      host,
 		port:      port,
-		siteName:  siteName,
+		siteName:  clusterName,
 		closeC:    make(chan struct{}),
 	}, nil
 }


### PR DESCRIPTION
This PR applies two fixes:

## Fix one:

Fixed typo in defining `teleport.HOTP` constant. This fixes bug #721

## Fix two:

Removes 'drop tunnel connection' logic on any tunnel-related error. This fixes 2nd problem "Handling Unreachable nodes" for issue #717 (see @klizhentas comment there)
