### PR TITLE
Improved CLI UX + a bunch of regressions fixed

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -427,7 +427,7 @@ func (s *IntSuite) TestTwoSites(c *check.C) {
 	// Stop "site-A" and try to connect to it again via "site-A" (expect a connection error)
 	a.Stop(false)
 	err = tc.SSH(context.TODO(), cmd, false)
-	c.Assert(err, check.ErrorMatches, "Failed connecting to cluster site-A: ssh: subsystem request failed")
+	c.Assert(err, check.ErrorMatches, `failed connecting to node 127.0.0.1:\d+. site-A is offline`)
 
 	// Reset and start "Site-A" again
 	a.Reset()

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -702,12 +702,17 @@ func (c *TunClient) GetDialer() AccessPointDialer {
 	}
 }
 
-// GetAgent returns SSH agent that uses ReqWebSessionAgent Auth server extension
+// GetAgent creates an SSH key agent (similar object to what CLI uses), this
+// key agent fetches user keys directly from the auth server using a custom channel
+// created via "ReqWebSessionAgent" reguest
 func (c *TunClient) GetAgent() (AgentCloser, error) {
 	client, err := c.getClient() // we need an established connection first
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// create a special SSH channel into the auth server, which will be used to
+	// serve user keys to a web-based terminal client (which will be using the
+	// returned SSH agent)
 	ch, _, err := client.OpenChannel(ReqWebSessionAgent, nil)
 	if err != nil {
 		return nil, trace.ConnectionProblem(err, "failed to connect to remote API")

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -70,7 +70,6 @@ type FSLocalKeyStore struct {
 //
 // if dirPath is empty, sets it to ~/.tsh
 func NewFSLocalKeyStore(dirPath string) (s *FSLocalKeyStore, err error) {
-	log.Debugf("using FSLocalKeyStore")
 	dirPath, err = initKeysDir(dirPath)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -296,11 +296,11 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 				prevSess = sess
 				continue
 			}
-			log.Infof("[CLIENT] updating the session %v with %d parties", sess.ID, len(sess.Parties))
 			// nothing changed
 			if prevSess.TerminalParams.W == sess.TerminalParams.W && prevSess.TerminalParams.H == sess.TerminalParams.H {
 				continue
 			}
+			log.Infof("[CLIENT] updating the session %v with %d parties", sess.ID, len(sess.Parties))
 
 			newSize := sess.TerminalParams.Winsize()
 			currentSize, err = term.GetWinsize(0)

--- a/lib/srv/proxy.go
+++ b/lib/srv/proxy.go
@@ -257,7 +257,7 @@ func (t *proxySubsys) proxyToHost(
 		remoteAddr,
 		&utils.NetAddr{Addr: serverAddr, AddrNetwork: "tcp"})
 	if err != nil {
-		return trace.ConvertSystemError(err)
+		return trace.Wrap(err)
 	}
 
 	// this custom SSH handshake allows SSH proxy to relay the client's IP

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -126,11 +126,7 @@ func (c *SessionContext) ExtendWebSession() (*auth.Session, error) {
 // GetAgent returns agent that can we used to answer challenges
 // for the web to ssh connection
 func (c *SessionContext) GetAgent() (auth.AgentCloser, error) {
-	a, err := c.clt.GetAgent()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return a, nil
+	return c.clt.GetAgent()
 }
 
 // Close cleans up connections associated with requests

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -46,7 +46,7 @@ func main() {
 func run(cmdlineArgs []string, testRun bool) (executedCommand string, conf *service.Config) {
 	var err error
 	// configure trace's errors to produce full stack traces
-	isDebug, _ := strconv.ParseBool(os.Getenv(teleport.DebugEnvVar))
+	isDebug, _ := strconv.ParseBool(os.Getenv(teleport.VerboseLogsEnvVar))
 	if isDebug {
 		trace.SetDebug(true)
 	}

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/teleagent"
-	//"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 

--- a/vendor/github.com/gravitational/trace/errors.go
+++ b/vendor/github.com/gravitational/trace/errors.go
@@ -236,10 +236,9 @@ func ConvertSystemError(err error) error {
 	}
 	switch realErr := innerError.(type) {
 	case *net.OpError:
-		message := fmt.Sprintf("failed to connect to server %v", realErr.Addr)
 		return WrapWithMessage(&ConnectionProblemError{
-			Message: message,
-			Err:     realErr}, message)
+			Message: realErr.Error(),
+			Err:     realErr}, realErr.Error())
 	case *os.PathError:
 		message := fmt.Sprintf("failed to execute command %v error:  %v", realErr.Path, realErr.Err)
 		return WrapWithMessage(&AccessDeniedError{


### PR DESCRIPTION
This commit adds several improvements to how CLI SSH login works.
This PR closes #717 (fixes #717)

- slightly improved Makefile (but BSD compatibility is lost again)
- Validated keys are added to the SSH agent [1]
- tsh will not verify host keys _twice_ anymore
- tsh will not login into proxy _twice_ on every session anymore
- error messages for "access denied" look clean now

[1] This is huge. This means that tsh login can "feed" the keys to the built-in SSH agents of the OS and OpenSSH can fetch them from there.

QUESTION: why do we even need `tsh agent` option then? ssh-agent is installed on every Linux/OSX machine and it's _much_ nicer than ours (it forks and has CLI CRUD)