### PR TITLE
Multiple Principals

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -357,7 +357,10 @@ Gravitational Teleport is a "clustered" SSH manager, meaning it only allows SSH
 access to nodes that had been previously granted cluster membership. 
 
 A cluster membership means that every node in a cluster has its own host
-certificate signed by the cluster's auth server. 
+certificate signed by the cluster's auth server. Note: if interoperability with
+OpenSSH is a concern, make sure the node name and DNS name match because OpenSSH
+clients validate the DNS name against the node name presented on the certificate
+when connecting to a Teleport node.
 
 A new Teleport node needs an "invite token" to join a cluster. An invitation token 
 also defines which role a new node can assume within a cluster: `auth`, `proxy` or 
@@ -665,6 +668,13 @@ behind `work.example.com`:
 ```bash
 > ssh root@database.work.example.com
 ```
+
+!!! tip "NOTE":
+    Teleport uses OpenSSH certificates instead of keys which means you can not connect
+    to a Teleport node by IP address you have to connect by DNS name. This is because
+    OpenSSH ensures the DNS name of the node you are connecting is listed listed under
+    the `Principals` section of the OpenSSH certificate to verify you are connecting
+    to the correct node.
 
 ### Integrating with OpenSSH Servers
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -39,8 +39,9 @@ import (
 )
 
 const (
-	Host = "127.0.0.1"
-	Site = "local-site"
+	Host   = "localhost"
+	HostID = "00000000-0000-0000-0000-000000000000"
+	Site   = "local-site"
 
 	AllocatePortsNum = 100
 )
@@ -96,7 +97,7 @@ func (s *IntSuite) SetUpSuite(c *check.C) {
 // newTeleport helper returns a running Teleport instance pre-configured
 // with the current user os.user.Current()
 func (s *IntSuite) newTeleport(c *check.C, logins []string, enableSSH bool) *TeleInstance {
-	t := NewInstance(Site, Host, s.getPorts(5), s.priv, s.pub)
+	t := NewInstance(Site, HostID, Host, s.getPorts(5), s.priv, s.pub)
 	// use passed logins, but use suite's default login if nothing was passed
 	if logins == nil || len(logins) == 0 {
 		logins = []string{s.me.Username}
@@ -377,8 +378,8 @@ func (s *IntSuite) TestInvalidLogins(c *check.C) {
 func (s *IntSuite) TestTwoSites(c *check.C) {
 	username := s.me.Username
 
-	a := NewInstance("site-A", Host, s.getPorts(5), s.priv, s.pub)
-	b := NewInstance("site-B", Host, s.getPorts(5), s.priv, s.pub)
+	a := NewInstance("site-A", HostID, Host, s.getPorts(5), s.priv, s.pub)
+	b := NewInstance("site-B", HostID, Host, s.getPorts(5), s.priv, s.pub)
 
 	a.AddUser(username, []string{username})
 	b.AddUser(username, []string{username})
@@ -426,7 +427,7 @@ func (s *IntSuite) TestTwoSites(c *check.C) {
 	// Stop "site-A" and try to connect to it again via "site-A" (expect a connection error)
 	a.Stop(false)
 	err = tc.SSH(context.TODO(), cmd, false)
-	c.Assert(err, check.ErrorMatches, `failed connecting to node 127.0.0.1. site-A is offline`)
+	c.Assert(err, check.ErrorMatches, `failed connecting to node localhost. site-A is offline`)
 
 	// Reset and start "Site-A" again
 	a.Reset()

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -567,11 +567,12 @@ func (s *APIServer) generateKeyPair(auth ClientI, w http.ResponseWriter, r *http
 }
 
 type generateHostCertReq struct {
-	Key        []byte         `json:"key"`
-	Hostname   string         `json:"hostname"`
-	AuthDomain string         `json:"auth_domain"`
-	Roles      teleport.Roles `json:"roles"`
-	TTL        time.Duration  `json:"ttl"`
+	Key         []byte         `json:"key"`
+	HostID      string         `json:"hostname"`
+	NodeName    string         `json:"node_name"`
+	ClusterName string         `json:"auth_domain"`
+	Roles       teleport.Roles `json:"roles"`
+	TTL         time.Duration  `json:"ttl"`
 }
 
 func (s *APIServer) generateHostCert(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
@@ -579,10 +580,12 @@ func (s *APIServer) generateHostCert(auth ClientI, w http.ResponseWriter, r *htt
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	cert, err := auth.GenerateHostCert(req.Key, req.Hostname, req.AuthDomain, req.Roles, req.TTL)
+
+	cert, err := auth.GenerateHostCert(req.Key, req.HostID, req.NodeName, req.ClusterName, req.Roles, req.TTL)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	return string(cert), nil
 }
 
@@ -622,9 +625,10 @@ func (s *APIServer) generateToken(auth ClientI, w http.ResponseWriter, r *http.R
 }
 
 type registerUsingTokenReq struct {
-	HostID string        `json:"hostID"`
-	Role   teleport.Role `json:"role"`
-	Token  string        `json:"token"`
+	HostID   string        `json:"hostID"`
+	NodeName string        `json:"node_name"`
+	Role     teleport.Role `json:"role"`
+	Token    string        `json:"token"`
 }
 
 func (s *APIServer) registerUsingToken(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
@@ -632,10 +636,12 @@ func (s *APIServer) registerUsingToken(auth ClientI, w http.ResponseWriter, r *h
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	keys, err := auth.RegisterUsingToken(req.Token, req.HostID, req.Role)
+
+	keys, err := auth.RegisterUsingToken(req.Token, req.HostID, req.NodeName, req.Role)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	return keys, nil
 }
 

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -155,8 +155,9 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 	c.Assert(err, IsNil)
 
 	// make sure we can parse the private and public key
-	cert, err := s.clt.GenerateHostCert(
-		pub, "localhost", "localhost", teleport.Roles{teleport.RoleNode}, time.Hour)
+	cert, err := s.clt.GenerateHostCert(pub,
+		"00000000-0000-0000-0000-000000000000", "localhost", "localhost",
+		teleport.Roles{teleport.RoleNode}, time.Hour)
 	c.Assert(err, IsNil)
 
 	_, _, _, _, err = ssh.ParseAuthorizedKey(cert)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -149,10 +149,10 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 	c.Assert(roles.Include(teleport.RoleProxy), Equals, false)
 
 	// unsuccessful registration (wrong role)
-	keys, err := s.a.RegisterUsingToken(tok, "bad-host", teleport.RoleProxy)
+	keys, err := s.a.RegisterUsingToken(tok, "bad-host-id", "bad-node-name", teleport.RoleProxy)
 	c.Assert(keys, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err, ErrorMatches, "'bad-host' cannot join the cluster, the token does not allow 'Proxy' role")
+	c.Assert(err, ErrorMatches, `"bad-node-name" \[bad-host-id\] can not join the cluster, the token does not allow "Proxy" role`)
 
 	roles, err = s.a.ValidateToken(tok)
 	c.Assert(err, IsNil)
@@ -164,15 +164,15 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 	c.Assert(err, IsNil)
 
 	// use it twice:
-	_, err = s.a.RegisterUsingToken(multiUseToken, "once", teleport.RoleProxy)
+	_, err = s.a.RegisterUsingToken(multiUseToken, "once", "node-name", teleport.RoleProxy)
 	c.Assert(err, IsNil)
-	_, err = s.a.RegisterUsingToken(multiUseToken, "twice", teleport.RoleProxy)
+	_, err = s.a.RegisterUsingToken(multiUseToken, "twice", "node-name", teleport.RoleProxy)
 	c.Assert(err, IsNil)
 
 	// try to use after TTL:
 	s.a.clock = clockwork.NewFakeClockAt(time.Now().UTC().Add(time.Hour + 1))
-	_, err = s.a.RegisterUsingToken(multiUseToken, "late.bird", teleport.RoleProxy)
-	c.Assert(err, ErrorMatches, "'late.bird' cannot join the cluster. The token has expired")
+	_, err = s.a.RegisterUsingToken(multiUseToken, "late.bird", "node-name", teleport.RoleProxy)
+	c.Assert(err, ErrorMatches, `"node-name" \[late.bird\] can not join the cluster. Token has expired`)
 
 	// expired token should be gone now
 	err = s.a.DeleteToken(multiUseToken)
@@ -181,9 +181,9 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 	// lets use static tokens now
 	roles = teleport.Roles{teleport.RoleProxy}
 	s.a.StaticTokens = append(s.a.StaticTokens, services.ProvisionToken{Token: "static-token-value", Roles: roles, Expires: time.Unix(0, 0)})
-	_, err = s.a.RegisterUsingToken("static-token-value", "static.host", teleport.RoleProxy)
+	_, err = s.a.RegisterUsingToken("static-token-value", "static.host", "node-name", teleport.RoleProxy)
 	c.Assert(err, IsNil)
-	_, err = s.a.RegisterUsingToken("static-token-value", "wrong.role", teleport.RoleAuth)
+	_, err = s.a.RegisterUsingToken("static-token-value", "wrong.role", "node-name", teleport.RoleAuth)
 	c.Assert(err, NotNil)
 	r, err := s.a.ValidateToken("static-token-value")
 	c.Assert(err, IsNil)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -141,9 +141,9 @@ func (a *AuthWithRoles) GenerateToken(roles teleport.Roles, ttl time.Duration) (
 	return a.authServer.GenerateToken(roles, ttl)
 }
 
-func (a *AuthWithRoles) RegisterUsingToken(token, hostID string, role teleport.Role) (*PackedKeys, error) {
+func (a *AuthWithRoles) RegisterUsingToken(token, hostID string, nodeName string, role teleport.Role) (*PackedKeys, error) {
 	// tokens have authz mechanism  on their own, no need to check
-	return a.authServer.RegisterUsingToken(token, hostID, role)
+	return a.authServer.RegisterUsingToken(token, hostID, nodeName, role)
 }
 
 func (a *AuthWithRoles) RegisterNewAuthServer(token string) error {
@@ -347,13 +347,13 @@ func (a *AuthWithRoles) GenerateKeyPair(pass string) ([]byte, []byte, error) {
 }
 
 func (a *AuthWithRoles) GenerateHostCert(
-	key []byte, hostname, authDomain string, roles teleport.Roles,
+	key []byte, hostID, nodeName, clusterName string, roles teleport.Roles,
 	ttl time.Duration) ([]byte, error) {
 
 	if err := a.action(defaults.Namespace, services.KindHostCert, services.ActionWrite); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GenerateHostCert(key, hostname, authDomain, roles, ttl)
+	return a.authServer.GenerateHostCert(key, hostID, nodeName, clusterName, roles, ttl)
 }
 
 func (a *AuthWithRoles) GenerateUserCert(key []byte, username string, ttl time.Duration) ([]byte, error) {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -511,7 +511,7 @@ func ReadIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
 	}
 
 	return &Identity{
-		ID:              IdentityID{HostUUID: cert.ValidPrincipals[0], NodeName: cert.ValidPrincipals[1], Role: role},
+		ID:              IdentityID{HostUUID: cert.ValidPrincipals[0], Role: role},
 		AuthorityDomain: authorityDomain,
 		KeyBytes:        keyBytes,
 		CertBytes:       certBytes,

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -59,7 +59,7 @@ func (s *AuthInitSuite) TestReadIdentity(c *C) {
 	id, err := ReadIdentityFromKeyPair(priv, cert)
 	c.Assert(err, IsNil)
 	c.Assert(id.AuthorityDomain, Equals, "example.com")
-	c.Assert(id.ID, DeepEquals, IdentityID{HostUUID: "id1", NodeName: "node-name", Role: teleport.RoleNode})
+	c.Assert(id.ID, DeepEquals, IdentityID{HostUUID: "id1", Role: teleport.RoleNode})
 	c.Assert(id.CertBytes, DeepEquals, cert)
 	c.Assert(id.KeyBytes, DeepEquals, priv)
 

--- a/lib/auth/test/suite.go
+++ b/lib/auth/test/suite.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/services"
 
 	"golang.org/x/crypto/ssh"
 	. "gopkg.in/check.v1"
@@ -59,8 +60,16 @@ func (s *AuthSuite) GenerateHostCert(c *C) {
 	priv, pub, err := s.A.GenerateKeyPair("")
 	c.Assert(err, IsNil)
 
-	cert, err := s.A.GenerateHostCert(priv, pub, "auth.example.com",
-		"example.com", teleport.Roles{teleport.RoleAdmin}, time.Hour)
+	cert, err := s.A.GenerateHostCert(
+		services.CertParams{
+			PrivateCASigningKey: priv,
+			PublicHostKey:       pub,
+			HostID:              "00000000-0000-0000-0000-000000000000",
+			NodeName:            "auth.example.com",
+			ClusterName:         "example.com",
+			Roles:               teleport.Roles{teleport.RoleAdmin},
+			TTL:                 time.Hour,
+		})
 	c.Assert(err, IsNil)
 
 	_, _, _, _, err = ssh.ParseAuthorizedKey(cert)

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -91,7 +91,7 @@ func (s *TunSuite) SetUpTest(c *C) {
 
 	hpriv, hpub, err := s.a.GenerateKeyPair("")
 	c.Assert(err, IsNil)
-	hcert, err := s.a.GenerateHostCert(hpub, "localhost", "localhost", teleport.Roles{teleport.RoleNode}, 0)
+	hcert, err := s.a.GenerateHostCert(hpub, "00000000-0000-0000-0000-000000000000", "localhost", "localhost", teleport.Roles{teleport.RoleNode}, 0)
 	c.Assert(err, IsNil)
 
 	authorizer, err := NewAuthorizer(s.a.Access, s.a.Identity, s.a.Trust)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -321,6 +321,7 @@ func (process *TeleportProcess) initAuthService(authority auth.Authority) error 
 		AuthServiceName: cfg.Hostname,
 		DataDir:         cfg.DataDir,
 		HostUUID:        cfg.HostUUID,
+		NodeName:        cfg.Hostname,
 		Authorities:     cfg.Auth.Authorities,
 		ReverseTunnels:  cfg.ReverseTunnels,
 		OIDCConnectors:  cfg.OIDCConnectors,
@@ -552,7 +553,7 @@ func (process *TeleportProcess) initSSH() error {
 // certificate authority
 func (process *TeleportProcess) RegisterWithAuthServer(token string, role teleport.Role, eventName string) {
 	cfg := process.Config
-	identityID := auth.IdentityID{Role: role, HostUUID: cfg.HostUUID}
+	identityID := auth.IdentityID{Role: role, HostUUID: cfg.HostUUID, NodeName: cfg.Hostname}
 
 	// this means the server has not been initialized yet, we are starting
 	// the registering client that attempts to connect to the auth server

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -25,9 +25,9 @@ type CertParams struct {
 }
 
 func (c *CertParams) Check() error {
-	if c.HostID == "" || c.NodeName == "" || c.ClusterName == "" {
-		return trace.BadParameter("HostID [%q], NodeName [%q], and ClusterName [%q] are all required",
-			c.HostID, c.NodeName, c.ClusterName)
+	if c.HostID == "" || c.ClusterName == "" {
+		return trace.BadParameter("HostID [%q] and ClusterName [%q] are required",
+			c.HostID, c.ClusterName)
 	}
 
 	if err := c.Roles.Check(); err != nil {

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -3,13 +3,39 @@ package services
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 )
+
+// CertParams defines all parameters needed to generate a host certificate.
+type CertParams struct {
+	PrivateCASigningKey []byte         // PrivateCASigningKey is the private key of the CA that will sign the public key of the host.
+	PublicHostKey       []byte         // PublicHostKey is the public key of the host.
+	HostID              string         // HostID is used by Teleport to uniquely identify a node within a cluster.
+	NodeName            string         // NodeName is the DNS name of the node.
+	ClusterName         string         // ClusterName is the name of the cluster within which a node lives.
+	Roles               teleport.Roles // Roles identifies the roles of a Teleport instance.
+	TTL                 time.Duration  // TTL defines how long a certificate is valid for.
+}
+
+func (c *CertParams) Check() error {
+	if c.HostID == "" || c.NodeName == "" || c.ClusterName == "" {
+		return trace.BadParameter("HostID [%q], NodeName [%q], and ClusterName [%q] are all required",
+			c.HostID, c.NodeName, c.ClusterName)
+	}
+
+	if err := c.Roles.Check(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
 
 // CertAuthority is a host or user certificate authority that
 // can check and if it has private key stored as well, sign it too
@@ -31,6 +57,7 @@ type CertAuthority interface {
 	// GetRoles returns a list of roles assumed by users signed by this CA
 	GetRoles() []string
 	// FirstSigningKey returns first signing key or returns error if it's not here
+	// The first key is returned because multiple keys can exist during key rotation.
 	FirstSigningKey() ([]byte, error)
 	// GetRawObject returns raw object data, used for migrations
 	GetRawObject() interface{}

--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -134,7 +134,7 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	// set up host private key and certificate
 	hpriv, hpub, err := s.a.GenerateKeyPair("")
 	c.Assert(err, IsNil)
-	hcert, err := s.a.GenerateHostCert(hpub, s.domainName, s.domainName, teleport.Roles{teleport.RoleAdmin}, 0)
+	hcert, err := s.a.GenerateHostCert(hpub, "00000000-0000-0000-0000-000000000000", s.domainName, s.domainName, teleport.Roles{teleport.RoleAdmin}, 0)
 	c.Assert(err, IsNil)
 
 	// set up user CA and set up a user that has access to the server

--- a/lib/web/web_test.go
+++ b/lib/web/web_test.go
@@ -188,7 +188,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	hpriv, hpub, err := authServer.GenerateKeyPair("")
 	c.Assert(err, IsNil)
 	hcert, err := authServer.GenerateHostCert(
-		hpub, s.domainName, s.domainName, teleport.Roles{teleport.RoleAdmin}, 0)
+		hpub, "00000000-0000-0000-0000-000000000000", s.domainName, s.domainName, teleport.Roles{teleport.RoleAdmin}, 0)
 	c.Assert(err, IsNil)
 
 	// set up user CA and set up a user that has access to the server

--- a/roles.go
+++ b/roles.go
@@ -86,7 +86,7 @@ func (roles Roles) Equals(other Roles) bool {
 	return true
 }
 
-// Check returns an erorr if the role set is incorrect (contains unknown roles)
+// Check returns an error if the role set is incorrect (contains unknown roles)
 func (roles Roles) Check() (err error) {
 	for _, role := range roles {
 		if err = role.Check(); err != nil {


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/579, connecting to a Teleport node from an OpenSSH client presents a UX problem: you need to connect via the host UUID + cluster name for certificate verification to pass.

To improve the UX for users with Teleport nodes and OpenSSH clients, this PR adds the node name into the list of Principals on the certificate. This means as long the DNS name for the host matches the node name, OpenSSH clients should be able to connect to Teleport nodes without problems.

**Implementation** 

_Code Updates_

* The signature for `GenerateHostCert` method on the `Authority` interface (as well as the implementation in `lib/auth/native`) has been updated with `nodeName`.
* All functions up to `GenerateHostCert` have been updated to pass along the node name along with the host ID.
* `authDomain` has been renamed `clusterName`.

_Documentation Updates_

The Teleport Admin Manual has been updated to reflect two things:

* For Teleport and OpenSSH interoperability it is recommended node names and DNS names should match.
* You can not connect to Teleport nodes by IP address in older versions of OpenSSH.