### PR TITLE
tsh logout + tctl create

### DIFF
--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"bytes"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -29,6 +30,10 @@ type Key struct {
 	Priv []byte `json:"Priv,omitempty"`
 	Pub  []byte `json:"Pub,omitempty"`
 	Cert []byte `json:"Cert,omitempty"`
+
+	// ProxyHost (optionally) contains the hostname of the proxy server
+	// which issued this key
+	ProxyHost string
 }
 
 // LocalKeyStore interface allows for different storage back-ends for TSH to load/save its keys
@@ -62,6 +67,17 @@ func (k *Key) AsAgentKey() (*agent.AddedKey, error) {
 		LifetimeSecs:     0,
 		ConfirmBeforeUse: false,
 	}, nil
+}
+
+// EqualsTo returns true if this key is the same as the other.
+// Primarily used in tests
+func (k *Key) EqualsTo(other *Key) bool {
+	if k == other {
+		return true
+	}
+	return bytes.Equal(k.Cert, other.Cert) &&
+		bytes.Equal(k.Priv, other.Priv) &&
+		bytes.Equal(k.Pub, other.Pub)
 }
 
 // CertValidBefore returns the time of the cert expiration

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -59,7 +59,11 @@ func NewLocalAgent(keyDir, username string) (a *LocalKeyAgent, err error) {
 		return nil, trace.Wrap(err)
 	}
 	for i := range keys {
-		if err := a.Agent.Add(keys[i]); err != nil {
+		k, err := keys[i].AsAgentKey()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if err := a.Agent.Add(*k); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -68,20 +72,8 @@ func NewLocalAgent(keyDir, username string) (a *LocalKeyAgent, err error) {
 
 // loadKeys return the list of keys for the given user
 // from the local keystore (files in ~/.tsh)
-func (a *LocalKeyAgent) LoadKeys(username string) ([]agent.AddedKey, error) {
-	keys, err := a.keyStore.GetKeys(username)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	retval := make([]agent.AddedKey, len(keys))
-	for i, key := range keys {
-		ak, err := key.AsAgentKey()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		retval[i] = *ak
-	}
-	return retval, nil
+func (a *LocalKeyAgent) LoadKeys(username string) ([]Key, error) {
+	return a.keyStore.GetKeys(username)
 }
 
 // AddHostSignersToCache takes a list of CAs whom we trust. This list is added to a database

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -176,7 +176,7 @@ func (fs *FSLocalKeyStore) GetKey(host, username string) (*Key, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	key := &Key{Pub: pub, Priv: priv, Cert: cert}
+	key := &Key{Pub: pub, Priv: priv, Cert: cert, ProxyHost: host}
 
 	// expired certificate? this key won't be accepted anymore, lets delete it:
 	certExpiration, err := key.CertValidBefore()

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -62,7 +62,9 @@ func (s *KeyStoreTestSuite) TestListKeys(c *check.C) {
 	keys := make([]Key, keyNum)
 	for i := 0; i < keyNum; i++ {
 		key := s.makeSignedKey(c, false)
-		s.store.AddKey(fmt.Sprintf("host-%v", i), "bob", key)
+		host := fmt.Sprintf("host-%v", i)
+		s.store.AddKey(host, "bob", key)
+		key.ProxyHost = host
 		keys[i] = *key
 	}
 	// add 1 key for "sam"
@@ -93,7 +95,7 @@ func (s *KeyStoreTestSuite) TestKeyCRUD(c *check.C) {
 	// load back and compare:
 	keyCopy, err := s.store.GetKey("host.a", "bob")
 	c.Assert(err, check.IsNil)
-	c.Assert(key, check.DeepEquals, keyCopy)
+	c.Assert(key.EqualsTo(keyCopy), check.Equals, true)
 
 	// Delete & verify that its' gone
 	err = s.store.DeleteKey("host.a", "bob")
@@ -119,7 +121,7 @@ func (s *KeyStoreTestSuite) TestKeyExpiration(c *check.C) {
 	// get all keys back. only "good" key should be returned:
 	keys, _ := s.store.GetKeys("sam")
 	c.Assert(keys, check.HasLen, 1)
-	c.Assert(keys[0], check.DeepEquals, *good)
+	c.Assert(keys[0].EqualsTo(good), check.Equals, true)
 }
 
 func (s *KeyStoreTestSuite) TestKnownHosts(c *check.C) {

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -113,4 +114,41 @@ func (cp *ClientProfile) SaveTo(filePath string, opts ProfileOptions) error {
 		err = os.Symlink(path.Base(filePath), symlink)
 	}
 	return trace.Wrap(err)
+}
+
+// LogoutFromEverywhere looks at the list of proxy servers tsh is currently logged into
+// by examining ~/.tsh and logs him out of them all
+func LogoutFromEverywhere(username string) error {
+	// if no --user flag was passed, get the current OS user:
+	if username == "" {
+		me, err := user.Current()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		username = me.Username
+	}
+	// load all current keys:
+	agent, err := NewLocalAgent("", username)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	keys, err := agent.LoadKeys(username)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if len(keys) == 0 {
+		fmt.Printf("%s is not logged in\n", username)
+		return nil
+	}
+	// ... and delete them:
+	for _, key := range keys {
+		err = agent.DeleteKey(key.ProxyHost, username)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error logging %s out of %s: %s\n",
+				username, key.ProxyHost, err)
+		} else {
+			fmt.Printf("logged %s out of %s\n", username, key.ProxyHost)
+		}
+	}
+	return nil
 }

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -115,7 +115,7 @@ type GetCommand struct {
 	withSecrets bool
 }
 
-type UpsertCommand struct {
+type CreateCommand struct {
 	config   *service.Config
 	filename string
 }
@@ -137,7 +137,7 @@ func main() {
 	cmdReverseTunnel := ReverseTunnelCommand{config: cfg}
 	cmdTokens := TokenCommand{config: cfg}
 	cmdGet := GetCommand{config: cfg}
-	cmdUpsert := UpsertCommand{config: cfg}
+	cmdCreate := CreateCommand{config: cfg}
 	cmdDelete := DeleteCommand{config: cfg}
 
 	// define global flags:
@@ -181,8 +181,8 @@ func main() {
 	get.Flag("with-secrets", "Include secrets in resources like certificate authorities or OIDC connectors").Default("false").BoolVar(&cmdGet.withSecrets)
 
 	// upsert one or many resources
-	upsert := app.Command("upsert", "Update or insert one or many resources").Hidden()
-	upsert.Flag("filename", "Filename with resources").Short('f').StringVar(&cmdUpsert.filename)
+	create := app.Command("create", "Create or update a resource").Hidden()
+	create.Flag("filename", "resource definition file").Short('f').StringVar(&cmdCreate.filename)
 
 	// list users command
 	userList := users.Command("ls", "List all user accounts")
@@ -274,8 +274,8 @@ func main() {
 	switch command {
 	case get.FullCommand():
 		err = cmdGet.Get(client)
-	case upsert.FullCommand():
-		err = cmdUpsert.Upsert(client)
+	case create.FullCommand():
+		err = cmdCreate.Create(client)
 	case delete.FullCommand():
 		err = cmdDelete.Delete(client)
 	case userAdd.FullCommand():
@@ -877,8 +877,8 @@ func (g *GetCommand) Get(client *auth.TunClient) error {
 	return trace.BadParameter("unsupported format")
 }
 
-// Upsert updates or insterts one or many resources
-func (u *UpsertCommand) Upsert(client *auth.TunClient) error {
+// Create updates or insterts one or many resources
+func (u *CreateCommand) Create(client *auth.TunClient) error {
 	var reader io.ReadCloser
 	var err error
 	if u.filename != "" {


### PR DESCRIPTION
## Description

This commit closes #667 

- `tsh logout` will now log you out of everything
- `tctl upsert` has been renamed to `tctl create`

## TODO

`tctl create` does not have `--force` flag because implementing it for every resource type right now is not a high priority.
