### PR TITLE
SSH keepalive implementation + refactoring

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -56,6 +56,10 @@ const (
 	// to all backends during initialization
 	DataDirParameterName = "data_dir"
 
+	// SSH request type to keep the connection alive. A client and a server keep
+	// pining each other with it:
+	KeepAliveReqType = "keepalive@openssh.com"
+
 	// OTP means One-time Password Algorithm.
 	OTP = "otp"
 

--- a/lib/backend/dir/impl_test.go
+++ b/lib/backend/dir/impl_test.go
@@ -179,6 +179,6 @@ func (s *Suite) TestLocking(c *check.C) {
 
 	// release the lock, and the gorouting should unlock and advance i
 	s.bk.ReleaseLock(lock)
-	time.Sleep(time.Millisecond * 5)
+	time.Sleep(time.Millisecond * 7)
 	c.Assert(atomic.LoadInt32(&i), check.Equals, int32(1))
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -822,7 +822,7 @@ func (tc *TeleportClient) runShell(nodeClient *NodeClient, sessToJoin *session.S
 		return trace.Wrap(err)
 	}
 	if nodeSession.ExitMsg == "" {
-		fmt.Printf("Connection to %s closed from the remote side\n", tc.NodeHostPort())
+		fmt.Println("the connection was closed on the remote side", time.Now())
 	} else {
 		fmt.Println(nodeSession.ExitMsg)
 	}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -250,6 +250,7 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress string,
 		}
 		return nil, trace.Wrap(err)
 	}
+
 	client := ssh.NewClient(conn, chans, reqs)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -71,7 +71,7 @@ const (
 
 	// DefaultIdleConnectionDuration indicates for how long Teleport will hold
 	// the SSH connection open if there are no reads/writes happening over it.
-	DefaultIdleConnectionDuration = 10 * time.Minute
+	DefaultIdleConnectionDuration = 20 * time.Minute
 
 	// DefaultReadHeadersTimeout is a default TCP timeout when we wait
 	// for the response headers to arrive

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/gravitational/teleport"
@@ -248,39 +247,41 @@ func (s *Server) handleConnection(conn net.Conn) {
 	log.Infof("[SSH:%v] new connection %v -> %v vesion: %v",
 		s.component, sconn.RemoteAddr(), sconn.LocalAddr(), string(sconn.ClientVersion()))
 
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-
-	go func() {
-		// Handle incoming out-of-band Requests
-		s.handleRequests(reqs)
-		wg.Done()
-	}()
-	go func() {
-		// Handle channel requests on this connections
-		s.handleChannels(conn, sconn, chans)
-		wg.Done()
-	}()
-
-	wg.Wait()
-}
-
-func (s *Server) handleRequests(reqs <-chan *ssh.Request) {
-	for req := range reqs {
-		log.Infof("[SSH:%v] recieved out-of-band request: %+v", s.component, req)
-		if s.reqHandler != nil {
-			s.reqHandler.HandleRequest(req)
-		}
+	// will be called when the connection is closed
+	connClosed := func() {
+		log.Infof("[SSH:%v] closed connection", s.component)
 	}
-}
 
-func (s *Server) handleChannels(conn net.Conn, sconn *ssh.ServerConn, chans <-chan ssh.NewChannel) {
-	for nch := range chans {
-		if nch == nil {
-			log.Warningf("nil channel: %v", nch)
-			continue
+	// The keepalive ticket will ensure that SSH keepalive requests are being sent
+	// to the client at an interval much shorter than idle connection kill switch
+	keepAliveTick := time.NewTicker(defaults.DefaultIdleConnectionDuration / 3)
+	defer keepAliveTick.Stop()
+	keepAlivePayload := [8]byte{0}
+
+	for {
+		select {
+		// handle out of band ssh requests
+		case req := <-reqs:
+			if req == nil {
+				connClosed()
+				return
+			}
+			log.Infof("[SSH:%v] recieved out-of-band request: %+v", s.component, req)
+			if s.reqHandler != nil {
+				go s.reqHandler.HandleRequest(req)
+			}
+			// handle channels:
+		case nch := <-chans:
+			if nch == nil {
+				connClosed()
+				return
+			}
+			go s.newChanHandler.HandleNewChan(conn, sconn, nch)
+			// send keepalive pings to the clients
+		case <-keepAliveTick.C:
+			const wantReply = true
+			sconn.SendRequest(teleport.KeepAliveReqType, wantReply, keepAlivePayload[:])
 		}
-		s.newChanHandler.HandleNewChan(conn, sconn, nch)
 	}
 }
 


### PR DESCRIPTION
### SSH KeepAlive

The base SSH server implementation now sends SSH keepalive at ta rate of 1/4 of "idle timeout" constant. The client properly responds to keepalive pings. This closes #736 

### SSH Server refactoring

The SSH server, instead of creating 3 goroutines per SSH connection for handling SSH requests and SSH channels separately, now uses the same (existing) goroutine with for-loop + select statement. @klizhentas lets review this carefully.