### PR TITLE
Moved HTTP client code from lib/web into lib/client

### DIFF
--- a/lib/client/https_client.go
+++ b/lib/client/https_client.go
@@ -15,7 +15,7 @@ limitations under the License.
 
 */
 
-package web
+package client
 
 import (
 	"crypto/tls"
@@ -29,7 +29,10 @@ import (
 	"github.com/gravitational/trace"
 )
 
-func newInsecureClient() *http.Client {
+// Version is a current webapi version
+const APIVersion = "v1"
+
+func NewInsecureWebClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -45,34 +48,34 @@ func newClientWithPool(pool *x509.CertPool) *http.Client {
 	}
 }
 
-func newWebClient(url string, opts ...roundtrip.ClientParam) (*webClient, error) {
+func NewWebClient(url string, opts ...roundtrip.ClientParam) (*WebClient, error) {
 	clt, err := roundtrip.NewClient(url, APIVersion, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &webClient{clt}, nil
+	return &WebClient{clt}, nil
 }
 
-// webClient is a package local lightweight client used
+// WebClient is a package local lightweight client used
 // in tests and some functions to handle errors properly
-type webClient struct {
+type WebClient struct {
 	*roundtrip.Client
 }
 
-func (w *webClient) PostJSON(
+func (w *WebClient) PostJSON(
 	endpoint string, val interface{}) (*roundtrip.Response, error) {
 	return httplib.ConvertResponse(w.Client.PostJSON(endpoint, val))
 }
 
-func (w *webClient) PutJSON(
+func (w *WebClient) PutJSON(
 	endpoint string, val interface{}) (*roundtrip.Response, error) {
 	return httplib.ConvertResponse(w.Client.PutJSON(endpoint, val))
 }
 
-func (w *webClient) Get(endpoint string, val url.Values) (*roundtrip.Response, error) {
+func (w *WebClient) Get(endpoint string, val url.Values) (*roundtrip.Response, error) {
 	return httplib.ConvertResponse(w.Client.Get(endpoint, val))
 }
 
-func (w *webClient) Delete(endpoint string) (*roundtrip.Response, error) {
+func (w *WebClient) Delete(endpoint string) (*roundtrip.Response, error) {
 	return httplib.ConvertResponse(w.Client.Delete(endpoint))
 }

--- a/lib/teleagent/agent.go
+++ b/lib/teleagent/agent.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/web"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gravitational/trace"
@@ -72,7 +72,7 @@ func (a *Client) Login(proxyAddr string,
 		return trace.Wrap(err)
 	}
 
-	login, err := web.SSHAgentLogin(proxyAddr, user, pass, hotpToken,
+	login, err := client.SSHAgentLogin(proxyAddr, user, pass, hotpToken,
 		pub, ttl, insecure, nil)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
@@ -274,7 +275,7 @@ func (s *sessionCache) AuthWithU2FSignResponse(user string, response *u2f.SignRe
 	return session, nil
 }
 
-func (s *sessionCache) GetCertificate(c createSSHCertReq) (*SSHLoginResponse, error) {
+func (s *sessionCache) GetCertificate(c client.CreateSSHCertReq) (*client.SSHLoginResponse, error) {
 	method, err := auth.NewWebPasswordAuth(c.User, []byte(c.Password), c.OTPToken)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -289,7 +290,7 @@ func (s *sessionCache) GetCertificate(c createSSHCertReq) (*SSHLoginResponse, er
 	return createCertificate(c.User, c.PubKey, c.TTL, clt)
 }
 
-func createCertificate(user string, pubkey []byte, ttl time.Duration, clt *auth.TunClient) (*SSHLoginResponse, error) {
+func createCertificate(user string, pubkey []byte, ttl time.Duration, clt *auth.TunClient) (*client.SSHLoginResponse, error) {
 	cert, err := clt.GenerateUserCert(pubkey, user, ttl)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -303,13 +304,13 @@ func createCertificate(user string, pubkey []byte, ttl time.Duration, clt *auth.
 		return nil, trace.Wrap(err)
 	}
 
-	return &SSHLoginResponse{
+	return &client.SSHLoginResponse{
 		Cert:        cert,
 		HostSigners: signers,
 	}, nil
 }
 
-func (s *sessionCache) GetCertificateWithU2F(c createSSHCertWithU2FReq) (*SSHLoginResponse, error) {
+func (s *sessionCache) GetCertificateWithU2F(c client.CreateSSHCertWithU2FReq) (*client.SSHLoginResponse, error) {
 	method, err := auth.NewWebU2FSignResponseAuth(c.User, &c.U2FSignResponse)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
The purpose of this commit was to remove the `lib/client` dependency of `lib/web`. 

Now `lib/client` is completely dependency-free of the server libs and can be reusable.

**Next step:** make the web UI use the same client code as the CLI. This will remove a ton of duplicate code making Teleport audit surface area much smaller.