### PR TITLE
Web UI passes the true client IP into SSH sessions for correct audit

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -166,6 +166,11 @@ type Config struct {
 	// Interactive, when set to true, tells tsh to launch a remote command
 	// in interactive mode, i.e. attaching the temrinal to it
 	Interactive bool
+
+	// ClientAddr (if set) specifies the true client IP. Usually it's not needed (since the server
+	// can look at the connecting address to determine client's IP) but for cases when the
+	// client is web-based, this must be set to HTTP's remote addr
+	ClientAddr string
 }
 
 func MakeDefaultConfig() *Config {
@@ -885,6 +890,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 			authMethod:      m,
 			hostLogin:       tc.Config.HostLogin,
 			siteName:        tc.Config.SiteName,
+			clientAddr:      tc.ClientAddr,
 		}
 	}
 	successMsg := fmt.Sprintf("[CLIENT] successful auth with proxy %v", proxyAddr)

--- a/lib/srv/proxy.go
+++ b/lib/srv/proxy.go
@@ -122,6 +122,17 @@ func (t *proxySubsys) start(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Requ
 		tunnel     = t.srv.proxyTun
 		clientAddr = sconn.RemoteAddr()
 	)
+	// did the client pass us a true client IP ahead of time via an environment variable?
+	// (usually the web client would do that)
+	ctx.Lock()
+	trueClientIP, ok := ctx.env["TELEPORT_TRUE_CLIENT_IP"]
+	ctx.Unlock()
+	if ok {
+		a, err := utils.ParseAddr(trueClientIP)
+		if err == nil {
+			clientAddr = a
+		}
+	}
 	// get the site by name:
 	if t.siteName != "" {
 		site, err = tunnel.GetSite(t.siteName)

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -78,6 +78,10 @@ const (
 	// SSH version string
 	// https://tools.ietf.org/html/rfc4253
 	MaxVersionStringBytes = 255
+
+	// TrueClientAddrVar environment variable is used by the web UI to pass
+	// the remote IP (user's IP) from the browser/HTTP session into an SSH session
+	TrueClientAddrVar = "TELEPORT_CLIENT_ADDR"
 )
 
 // ServerOption is a functional argument for server

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -181,6 +181,7 @@ func (t *terminalHandler) Run(w http.ResponseWriter, r *http.Request) {
 			Host:             t.server.GetHostname(),
 			Env:              map[string]string{sshutils.SessionEnvVar: string(t.params.SessionID)},
 			HostKeyCallback:  func(string, net.Addr, ssh.PublicKey) error { return nil },
+			ClientAddr:       r.RemoteAddr,
 		})
 		if err != nil {
 			errToTerm(err, ws)


### PR DESCRIPTION
This PR closes #735 

## Description
This is how the web client passes the client IP taken from the HTTP session into SSH:
   
- When a web-based client creates a Teleport Client object, it now passes the
  true client IP (as taken from HTTP requests) into the created SSH-to-proxy
  session via an environment variable.
    
- The Teleport proxy interprets that variable when it dials the destination
  server and passes it on using the same handshake protocol as a regular
  teleport CLI client.

## Warning

This PR should be reviewed only after #751 is merged because it depends on the CLI client-to-web integration. (also it would make it smaller and MUCH easier to review this PR, because 95% of the changes you see are actually from #751)
