### PR TITLE
LocalKeyAgent changes for OpenSSH interoperability

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -40,6 +40,7 @@ test: integration
 	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
 		/bin/bash -c \
 		"examples/etcd/start-etcd.sh & sleep 1; \
+		ssh-agent > external.agent && source external.agent; \
 		cd $(SRCDIR) && make TELEPORT_DEBUG=0 FLAGS='-cover -race' clean test"
 
 .PHONY:integration

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"gopkg.in/check.v1"
+)
+
+type KeyAgentTestSuite struct {
+	keyDir   string
+	key      *Key
+	username string
+	hostname string
+}
+
+var _ = check.Suite(&KeyAgentTestSuite{})
+var _ = fmt.Printf
+
+func (s *KeyAgentTestSuite) SetUpSuite(c *check.C) {
+	var err error
+	utils.InitLoggerForTests()
+
+	// path to temporary  ~/.tsh directory to use during tests
+	s.keyDir, err = ioutil.TempDir("", "keyagent-test-")
+	c.Assert(err, check.IsNil)
+
+	// temporary username and hostname to use during tests
+	s.username = "foo"
+	s.hostname = "bar"
+
+	// temporary key to use during tests
+	s.key, err = makeKey(s.username, []string{s.username}, 1*time.Minute)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *KeyAgentTestSuite) TearDownSuite(c *check.C) {
+	var err error
+	err = os.RemoveAll(s.keyDir)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *KeyAgentTestSuite) SetUpTest(c *check.C) {
+}
+
+// TestAddKey ensures correct adding of ssh keys. This test checks the following:
+//   * When adding a key it's written to disk.
+//   * When we add a key, it's added to both the teleport ssh agent as well
+//     as the system ssh agent.
+//   * When we add a key, both the certificate and private key are added into
+//     the both the teleport ssh agent and the system ssh agent.
+//   * When we add a key, it's tagged with a comment that indicates that it's
+//     a teleport key with the teleport username.
+func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
+	// make a new local agent
+	lka, err := NewLocalAgent(s.keyDir, s.username)
+	c.Assert(err, check.IsNil)
+
+	// add the key to the local agent, this should write the key
+	// to disk as well as load it in the agent
+	_, err = lka.AddKey(s.hostname, s.username, s.key)
+	c.Assert(err, check.IsNil)
+
+	// check that the key has been written to disk
+	for _, ext := range []string{fileExtCert, fileExtKey, fileExtPub} {
+		_, err := os.Stat(fmt.Sprintf("%v/keys/%v/%v%v", s.keyDir, s.hostname, s.username, ext))
+		c.Assert(err, check.IsNil)
+	}
+
+	// get all agent keys from teleport agent and system agent
+	teleportAgentKeys, err := lka.Agent.List()
+	c.Assert(err, check.IsNil)
+	systemAgentKeys, err := lka.sshAgent.List()
+	c.Assert(err, check.IsNil)
+
+	// check that we've loaded a cert as well as a private key into the teleport agent
+	// and it's for the user we expected to add a certificate for
+	c.Assert(teleportAgentKeys, check.HasLen, 2)
+	c.Assert(teleportAgentKeys[0].Type(), check.Equals, "ssh-rsa-cert-v01@openssh.com")
+	c.Assert(teleportAgentKeys[0].Comment, check.Equals, "teleport:"+s.username)
+	c.Assert(teleportAgentKeys[1].Type(), check.Equals, "ssh-rsa")
+	c.Assert(teleportAgentKeys[1].Comment, check.Equals, "teleport:"+s.username)
+
+	// check that we've loaded a cert as well as a private key into the system again
+	found := false
+	for _, sak := range systemAgentKeys {
+		if sak.Comment == "teleport:"+s.username && sak.Type() == "ssh-rsa" {
+			found = true
+		}
+	}
+	c.Assert(true, check.Equals, found)
+	found = false
+	for _, sak := range systemAgentKeys {
+		if sak.Comment == "teleport:"+s.username && sak.Type() == "ssh-rsa-cert-v01@openssh.com" {
+			found = true
+		}
+	}
+	c.Assert(true, check.Equals, found)
+
+	// unload all keys for this user from the teleport agent and system agent
+	err = lka.UnloadKey(s.username)
+	c.Assert(err, check.IsNil)
+}
+
+// TestLoadKey ensures correct loading of a key into an agent. This test
+// checks the following:
+//   * Loading a key multiple times overwrites the same key.
+//   * The key is correctly loaded into the agent. This is tested by having
+//     the agent sign data that is then verified using the public key
+//     directly.
+func (s *KeyAgentTestSuite) TestLoadKey(c *check.C) {
+	userdata := []byte("hello, world")
+
+	// make a new local agent
+	lka, err := NewLocalAgent(s.keyDir, s.username)
+	c.Assert(err, check.IsNil)
+
+	// unload any keys that might be in the agent for this user
+	err = lka.UnloadKey(s.username)
+	c.Assert(err, check.IsNil)
+
+	// get all the keys in the teleport and system agent
+	teleportAgentKeys, err := lka.Agent.List()
+	c.Assert(err, check.IsNil)
+	teleportAgentInitialKeyCount := len(teleportAgentKeys)
+	systemAgentKeys, err := lka.sshAgent.List()
+	c.Assert(err, check.IsNil)
+	systemAgentInitialKeyCount := len(systemAgentKeys)
+
+	// load the key to the twice, this should only
+	// result in one key for this user in the agent
+	_, err = lka.LoadKey(s.username, *s.key)
+	c.Assert(err, check.IsNil)
+	_, err = lka.LoadKey(s.username, *s.key)
+	c.Assert(err, check.IsNil)
+
+	// get all the keys in the teleport and system agent
+	teleportAgentKeys, err = lka.Agent.List()
+	c.Assert(err, check.IsNil)
+	systemAgentKeys, err = lka.sshAgent.List()
+	c.Assert(err, check.IsNil)
+
+	// check if we have the correct counts
+	c.Assert(teleportAgentKeys, check.HasLen, teleportAgentInitialKeyCount+2)
+	c.Assert(systemAgentKeys, check.HasLen, systemAgentInitialKeyCount+2)
+
+	// now sign data using the teleport agent and system agent
+	teleportAgentSignature, err := lka.Agent.Sign(teleportAgentKeys[0], userdata)
+	c.Assert(err, check.IsNil)
+	systemAgentSignature, err := lka.sshAgent.Sign(systemAgentKeys[0], userdata)
+	c.Assert(err, check.IsNil)
+
+	// parse the pem bytes for the private key, create a signer, and extract the public key
+	sshPrivateKey, err := ssh.ParseRawPrivateKey(s.key.Priv)
+	c.Assert(err, check.IsNil)
+	sshSigner, err := ssh.NewSignerFromKey(sshPrivateKey)
+	c.Assert(err, check.IsNil)
+	sshPublicKey := sshSigner.PublicKey()
+
+	// verify data signed by both the teleport agent and system agent was signed correctly
+	sshPublicKey.Verify(userdata, teleportAgentSignature)
+	c.Assert(err, check.IsNil)
+	sshPublicKey.Verify(userdata, systemAgentSignature)
+	c.Assert(err, check.IsNil)
+
+	// unload all keys from the teleport agent and system agent
+	err = lka.UnloadKey(s.username)
+	c.Assert(err, check.IsNil)
+}
+
+func makeKey(username string, allowedLogins []string, ttl time.Duration) (*Key, error) {
+	keygen := native.New()
+
+	privateKey, publicKey, err := keygen.GenerateKeyPair("")
+	if err != nil {
+		return nil, err
+	}
+
+	certificate, err := keygen.GenerateUserCert(caPrivateKey, publicKey, username, allowedLogins, ttl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Key{
+		Priv: privateKey,
+		Pub:  publicKey,
+		Cert: certificate,
+	}, nil
+}

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -131,7 +131,7 @@ func LogoutFromEverywhere(username string) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	keys, err := agent.LoadKeys(username)
+	keys, err := agent.GetKeys(username)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/client/testdata_test.go
+++ b/lib/client/testdata_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+var caPrivateKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIJKQIBAAKCAgEA2Kfs+ns9YWVVgDz+/buBc7L8i04slNhnBNR8RLr7gJFulqsp
+dZa7cdZV+l2D1UgPUdLk64ScrOZ531yHXeGKkw2VX5z9W3c4PY8oDW38Yn+YRoNL
+A2xPhOEfJ+owwO/ci9o+nyBaVFXJLemVLfsHYeZlQXK1iM+0dxLfQ+jDbxh9JeaQ
+POurjfhn0nurXI2tXniX/JQ4E2ZVm5m8OsJAxDbFNjiX+BjkPsgcX/+Izqn9BA4O
+BiO/d5I7eFzmsmxV2H/aITxVEYjRr+cUDtTskUD/71Y7J0gRhxVyUrURx9DkSRR0
+TPMxVcYKZZeUTC7k2OAJOFHh3Q43Of5tcnl2lpiQ+b0gheIQTKG3N5qYlMOoYJ45
+CxQ/mEo1E+R45vrAnF/pb6eTwtPk4imTqoNOzBnvB2uBuIph5+FBK1RuKVh6hotH
+HDpcYsrPO22Yupo8CHpKZUZT97hF6OunUhQwtKWlaesze7lFSa11PId+2pAWpRlo
+a+ttWh7WVV7Mt8ZxpBtdUOEEkZn4PHvabGG+xx4AEMevyvoGSzFpiAaFdgh+DOrX
++nDN+d31afziVHcEtiGTONyE//del+s59N0ph74NTm1P5/9I7TqtomkxcD1xrVCe
+csjf++CmCX8eMn6hFj/NSXcPBXz45TohXPaPSrHbsEPynkJrEA1HW9y9ZgkCAwEA
+AQKCAgBa8bKCOnU7iwPm/rOy4qCmZn2oJDqGiIhF+MPpPewQvfuD93lByPIKCQSy
+QcrzHnp/yF0bl+EEmwKRhg+0ktZOgCcxqX6YhGTxQkR3zrFgz1qmTrqQR0jh6HXh
+lWa9tnIHqqcauMPyHsiCI0jhsjwZFlNus64MLdP9H8jkgrJ20frGjBAD4pFy2NEM
+A6mdAkPCIjD6b2VSj2RkGpZuu9fgBXWnGv5/wEMfL3TpvyQ4TBbPOu8cGKlokdOw
+5J5aSyuF47U2ulKjN6F9iyxaRXrARl6oorPV+2SQJaqFmUhLbh5FpvZizrro3GbE
+2mn/yLd7ah+0qnp7BlqcV3at1Nq3+qjqDRbYyAiq4kP+vdfgYr8awj+bcMhFa5KK
+Ca0XOsR3BUzg7A7inYdD60FB/G7I9QMhYe7zcpingGTF79dQGmrrG2hjoatLJe7p
+fzi9essji+OqjceOUBL5qEQgFejVVasfRpbBeI4G77Cg/cCkXL+3CVDKaPYqJfY/
+pSmPMo8FgxEYRiNYWYfOIeB02sfHVDWmVNXp8hmYP6YrUVtjuFJSPSFMWdS+fMhd
+0mw4nOs+ULK4UgBoj0wQQK70mhHDe2bZp0f3ygKXHg94vFeK4T3t7S+E3mGqfqvq
+eESYjNAotKUZPqwejAKhkTXgHvD1CIYg2NgOPre4JjdLzdeD2QKCAQEA8pg0dbAf
+76FzrdUvt3NmvNXhnFLgi01VUiFBzaZFeflaTF2uT1gYEWRCitWZ+jdy2IDgCVbU
+7zqSXx+uVBUe/9ZBa54qoXrHgj0PAYT+nKqXit892UyQ8VYpA2wYVls7RmPI3F/X
+uNAn44KDV/GHTCRuD1s5k1m4NY2pIH7PpFHYXGG9SeqXUM7Ig9DN8k+xmLLbTHT1
+8V3NeAsX6YBIAOW507GMiPgKBwYp8hfUZSnfj6BdoEsb9c7dvVuxtpW//IQniSq0
+Cx7xZBtNoiQrjzDrmQupoMp+I/+clVxhb84kRDFV1cbkHLUZDww0znYz+YF3U4NL
+SHQ6JPFpIE0o0wKCAQEA5KDJsJ9WYTHUqdHnaXB/gGpVKAfMxFtNcuA7w0QA0Du6
+9azv9SEL446y6k/8MjS5H/dVvA68W9rzrU6GW3Bl9ELE7Nr/r3xMCxQMnTC+Nag8
+qjECAOVEbIKiJ5FpZ7ETxIkRzv1BVJq7Ve26q84l0m82FJsXtqLMvCXC76jujZpj
+e+uO6ET3K2ac/c030a18s9bya4A6EzcR5YenOeYIay8u+IUhB6ts6aZTNF5W9xMI
+fIkwniJOBPrqIkMWRN+NMZLIZlqzZ6m0EQZKnhEgymLJPoxrj4ox93oZ3gWhBwAo
+Jzexaah9KpQcFlFHJ9iU8pOk/O7utaRcPs89E/4sMwKCAQEA8mIwyAWZYwulUOHY
+MysSU0o/iLklsQkrXkvsO1UNxbjmB7byGkSih33tHloc5mvQS5E4RxyC1CNpa7Fz
+tH8F4ghohOYbIgxSmkX3YEVJP68SiqZSXXKqvvafM9Qk3ON6bfH1FnqMRxNzR1V3
+db7Ut7cOYDl9ZUQXUSqg+N67CCreSi89uUSyuwJgRZOysY/+mdraUaHquaZHTNGI
+qryJNJxS9rhG+fMZ0brO3hwBErKrtA0+fpGM9iQiWLfs78jfcaV4+wu3qATamnLN
+Nlt9SixOuTN14DlxnvYdtP4APH1yrs+8O0PlVul6iBZiDIb9lyVL3B0qctHt5ktu
+BeASEQKCAQEAzj7iU6wZ74pVb3EFEpBC5SSHd5o5tfUrk/MG1qsVFMSdbx04Rukt
+4XWMn2XSe7QmQNkOBZ1BfJezdWc+O2TVBJnrLkSNndBChUfr7S3YmW0QdPPK++XX
+aRAbmhhKfxk2XPjOEO1ULy96yhSwbmaEpiZfIg2bQc3xZdWm2i6KLUHWdybT/2Kf
+mw5xl1+2+DdKJK5GeIXvXgAy694JFGkYtSCWfekTF+kkUk8SBk8IotEPudDFBBKs
+UT/NUWU1xKHqrIrer78o0t47q5QCYj/PVePx6bQhIBcp5jfG+AwZ7MfOcTqDmG4/
+o9aC0/s0dpSiIYbhsq8UttXzxVGMpumHEwKCAQB/AfSGXTrgJI9ib6sIMt1tr2/p
+H42FuGZ4Uz3VOgJZGJbGZBn0UNBAOB2TOvsWjzX0Bt0nFd7Jv/f6gclXE78/Xd9U
+w0Gmuk4pgsV0Jn5U9AJvA8tqV6VftVprgJEnIS4pKGQfY9T2VKavlaHIusn1ajNc
+kbaGvVk9A39yoGUfaf9nSpT9znSsMDYcY3Atk69LbUlg6kMo3WzItdX/622Laddt
+lBcFrAyjLXT86WW3w9HxDkLn+7HrgS7B8RD1HRmAVqoGCibqWU63Wt38rEaos2Jc
+osEoTuWjO+9HrrfbtolzFBYcFwlJBQDZoskpQBST3Ezr9spAOydcm/U+u4tC
+-----END RSA PRIVATE KEY-----`)

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -368,16 +368,18 @@ export SSH_AGENT_PID=%v
 # you can redirect this output into a file and call 'source' on it
 `, socketAddr.Addr, pid)
 
-	// making a client leads to the creation of a client.LocalAgent which
-	// has a side effect of loading all keys into said agent. so we don't
-	// actually need to manually load keys into memory here.
-	_, err := makeClient(cf, true)
+	// create a client, a side effect of this is that it creates a
+	// client.LocalAgent that is an ssh agent with all keys from disk
+	// loaded in it
+	tc, err := makeClient(cf, true)
 	if err != nil {
 		utils.FatalError(err)
 	}
 
 	// create a new teleport agent and start listening
-	agentServer := teleagent.NewServer()
+	agentServer := teleagent.AgentServer{
+		tc.LocalAgent(),
+	}
 	if err := agentServer.ListenAndServe(socketAddr); err != nil {
 		utils.FatalError(err)
 	}

--- a/tool/tsh/main.go
+++ b/tool/tsh/main.go
@@ -356,6 +356,7 @@ func onAgentStart(cf *CLIConf) {
 			Addr:        filepath.Join(os.TempDir(), fmt.Sprintf("teleport-%d.socket", pid)),
 		}
 	}
+
 	// This makes teleport agent behave exactly like ssh-agent command,
 	// the output and behavior matches the openssh behavior,
 	// so users can do 'eval $(tsh agent --proxy=<addr>&)
@@ -367,26 +368,16 @@ export SSH_AGENT_PID=%v
 # you can redirect this output into a file and call 'source' on it
 `, socketAddr.Addr, pid)
 
-	agentServer := teleagent.NewServer()
-	tc, err := makeClient(cf, true)
+	// making a client leads to the creation of a client.LocalAgent which
+	// has a side effect of loading all keys into said agent. so we don't
+	// actually need to manually load keys into memory here.
+	_, err := makeClient(cf, true)
 	if err != nil {
 		utils.FatalError(err)
 	}
 
-	agentKeys, err := tc.LocalAgent().LoadKeys(tc.Username)
-	if err != nil {
-		utils.FatalError(err)
-	}
-	// add existing keys to the running agent for ux purposes
-	for i := range agentKeys {
-		key, err := agentKeys[i].AsAgentKey()
-		if err != nil {
-			utils.FatalError(err)
-		}
-		if err = agentServer.Add(*key); err != nil {
-			utils.FatalError(err)
-		}
-	}
+	// create a new teleport agent and start listening
+	agentServer := teleagent.NewServer()
 	if err := agentServer.ListenAndServe(socketAddr); err != nil {
 		utils.FatalError(err)
 	}


### PR DESCRIPTION
**Purpose**

As covered in #579, connecting to a Teleport node from an OpenSSH client using the Teleport agent is broken due to a bug in OpenSSH: https://bugzilla.mindrot.org/show_bug.cgi?id=2550

This PR works around this behavior in older OpenSSH clients by loaded both a certificate with an embedded private key as well as the private into the Teleport agent so OpenSSH clients can connect to Teleport nodes.

**Implementation**

*Code Updates*

* `AsAgentKey` has been renamed `AsAgentKeys` in `lib/client/interfaces.go` to reflect that it returns a certificate (with embedded private key) as well as a private key.
* `onAgentStart` in `tools/tsh/main.go` has been refactored to not explicitly load keys because it's already done as a side-effect of creating a Teleport client (which creates a `LocalKeyAgent`).
* Refactored `LocalKeyAgent` to consolidate key loading and unloading code in the `LoadKey` and `UnloadKey` functions.

*Test Updates*

* Added test coverage for `LocalKeyAgent`.
* Added `lib/client/testdata_test.go` to store test data (like keys and certificates) for tests.

*Build Configuration Updates*

* `build.assets/Makefile` has been updated to create an external `ssh-agent` within the test container for `LocalKeyAgent ` to communicate with.
