### PR TITLE
Fix TOTP test that would occasionally fail due to timing issues.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -8,6 +8,11 @@ import (
 const ForeverTTL time.Duration = 0
 
 const (
+	TOTPValidityPeriod uint = 30 // TOTPValidityPeriod is the number of seconds a TOTP token is valid.
+	TOTPSkew           uint = 1  // TOTPSkew adds that many periods before and after to the validity window.
+)
+
+const (
 	// Component indicates a component of teleport, used for logging
 	Component = "component"
 

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/jonboulle/clockwork"
 	"github.com/kylelemons/godebug/diff"
 	"github.com/pquerna/otp/totp"
 	"golang.org/x/crypto/ssh"
@@ -81,6 +82,9 @@ func (s *APISuite) SetUpTest(c *C) {
 	})
 	s.sessions, err = session.New(s.bk)
 	c.Assert(err, IsNil)
+
+	// use a fake clock during tests for stability
+	s.a.clock = clockwork.NewFakeClock()
 
 	s.AccessS = local.NewAccessService(s.bk)
 	s.WebS = local.NewIdentityService(s.bk)
@@ -256,7 +260,8 @@ func (s *APISuite) TestPasswordCRUD(c *C) {
 
 	err = s.a.UpsertTOTP("user1", otpSecret)
 	c.Assert(err, IsNil)
-	validToken, err := totp.GenerateCode(otpSecret, time.Now())
+
+	validToken, err := totp.GenerateCode(otpSecret, s.a.clock.Now())
 	c.Assert(err, IsNil)
 
 	err = s.clt.CheckPassword("user1", pass, validToken)
@@ -293,13 +298,13 @@ func (s *APISuite) TestOTPCRUD(c *C) {
 	// valid for 30 seconds + 30 second skew before and after for a usability
 	// reasons. so a token made between seconds 31 and 60 is still valid, and
 	// invalidity starts at 61 seconds in the future.
-	invalidToken, err := totp.GenerateCode(otpSecret, time.Now().Add(61*time.Second))
+	invalidToken, err := totp.GenerateCode(otpSecret, s.a.clock.Now().Add(61*time.Second))
 	c.Assert(err, IsNil)
 	err = s.clt.CheckPassword("user1", pass, invalidToken)
 	c.Assert(err, NotNil)
 
 	// a valid token (created right now and from a valid key) should return success
-	validToken, err := totp.GenerateCode(otpSecret, time.Now())
+	validToken, err := totp.GenerateCode(otpSecret, s.a.clock.Now())
 	c.Assert(err, IsNil)
 
 	err = s.clt.CheckPassword("user1", pass, validToken)

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -286,9 +286,14 @@ func (s *APISuite) TestOTPCRUD(c *C) {
 	err = s.clt.CheckPassword("user1", pass, "123456")
 	c.Assert(err, NotNil)
 
-	// a invalid token (made 1 minute in the future but from a valid key)
-	// should also return access denied
-	invalidToken, err := totp.GenerateCode(otpSecret, time.Now().Add(1*time.Minute))
+	// an invalid token should return access denied
+	//
+	// this tests makes the token 61 seconds in the future (but from a valid key)
+	// even though the validity period is 30 seconds. this is because a token is
+	// valid for 30 seconds + 30 second skew before and after for a usability
+	// reasons. so a token made between seconds 31 and 60 is still valid, and
+	// invalidity starts at 61 seconds in the future.
+	invalidToken, err := totp.GenerateCode(otpSecret, time.Now().Add(61*time.Second))
 	c.Assert(err, IsNil)
 	err = s.clt.CheckPassword("user1", pass, invalidToken)
 	c.Assert(err, NotNil)


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/755, tests in `apiserver_test.go` would occasionally fail on the following line: 
```
FAIL: apiserver_test.go:265: APISuite.TestOTPCRUD

apiserver_test.go:293:
    c.Assert(err, NotNil)
... value = nil
```

The functionality being tested was:

1. Create an invalid token `otpToken`. Token validity is 30 seconds and therefore a token created 1 minute in the future should be invalid.
2. Try and validate `otpToken`, validation should return an error because it's too far in the future.

This test would pass the majority of the time but would occasionally fail and the token would be considered valid. This is because while the validity period is 30 seconds an additional 30 seconds is added to the validity window before and after for usability reasons (imagine entering a token at second 29) so the actual validity is 60 seconds.

This test would still pass most of the time because token creation and validation do not happen at exactly the same time, but I imagine occasionally it would fall within the validity window and cause the test to fail.

For this test to consistently "succeed" the invalid token needs to be created 61 seconds in the future so it's always past the validity window and the validation always fails.

In addition, instead of relying on the system clock, a fake clock should be used so we can get stable and reliable results.

**Implementation**

* When creating an invalid token, create it 61 seconds in the future.
* Use `clock` in the AuthServer and set it to a fake clock during tests.