### PR TITLE
Deduplicate principals for host certificates.

### DIFF
--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -239,5 +239,6 @@ func buildPrincipals(hostID string, nodeName string, clusterName string, roles t
 		principals = append(principals, fmt.Sprintf("%s.%s", nodeName, clusterName))
 	}
 
-	return principals
+	// deduplicate (in-case hostID and nodeName are the same) and return
+	return utils.Deduplicate(principals)
 }

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -59,6 +59,15 @@ func (s *NativeSuite) TestGenerateUserCert(c *C) {
 	s.suite.GenerateUserCert(c)
 }
 
+// TestBuildPrincipals makes sure that the list of principals for a host
+// certificate is correctly built.
+//   * If the node has role admin, then only the host ID should be listed
+//     in the principals field.
+//   * If only a host ID is provided, don't include a empty node name
+//     this is for backward compatibility.
+//   * If both host ID and node name are given, then both should be included
+//     on the certificate.
+//   * If the host ID and node name are the same, only list one.
 func (s *NativeSuite) TestBuildPrincipals(c *C) {
 	caPrivateKey, _, err := s.suite.A.GenerateKeyPair("")
 	c.Assert(err, IsNil)
@@ -96,6 +105,14 @@ func (s *NativeSuite) TestBuildPrincipals(c *C) {
 			"example.com",
 			teleport.Roles{teleport.RoleProxy},
 			[]string{"22222222-2222-2222-2222-222222222222.example.com", "proxy.example.com"},
+		},
+		// 3 - deduplicate principals
+		{
+			"33333333-3333-3333-3333-333333333333",
+			"33333333-3333-3333-3333-333333333333",
+			"example.com",
+			teleport.Roles{teleport.RoleProxy},
+			[]string{"33333333-3333-3333-3333-333333333333.example.com"},
 		},
 	}
 


### PR DESCRIPTION
**Purpose**

As reported in https://github.com/gravitational/teleport/issues/770, if the host ID and node name are the same, the host certificate contains duplicate entries in the principals fields. This PR deduplicates the principals field to ensure it doesn't contain duplicate entries.

**Implementation**

In `lib/auth/native/native.go` when building the list of principals, deduplicate before returning.
