### PR TITLE
Configure web session duration, fixes #691

### DIFF
--- a/lib/auth/new_web_user.go
+++ b/lib/auth/new_web_user.go
@@ -211,7 +211,7 @@ func (s *AuthServer) CreateUserWithToken(token string, password string, otpToken
 		return nil, trace.Wrap(err)
 	}
 
-	err = s.UpsertWebSession(user.GetName(), sess, WebSessionTTL)
+	err = s.UpsertWebSession(user.GetName(), sess)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -280,7 +280,7 @@ func (s *AuthServer) CreateUserWithU2FToken(token string, password string, respo
 		return nil, trace.Wrap(err)
 	}
 
-	err = s.UpsertWebSession(user.GetName(), sess, WebSessionTTL)
+	err = s.UpsertWebSession(user.GetName(), sess)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 )
 
 // Forever means that object TTL will not expire unless deleted
@@ -99,4 +100,17 @@ func (p Params) GetString(key string) string {
 	}
 	s, _ := v.(string)
 	return s
+}
+
+// TTL converts time to TTL from current time supplied
+// by provider, if t is zero, returns forever
+func TTL(clock clockwork.Clock, t time.Time) time.Duration {
+	if t.IsZero() {
+		return Forever
+	}
+	diff := t.UTC().Sub(clock.Now().UTC())
+	if diff < 0 {
+		return Forever
+	}
+	return diff
 }

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -91,8 +91,8 @@ type Identity interface {
 	// be used during tests.
 	DeleteUsedTOTPToken(user string) error
 
-	// UpsertWebSession updates or inserts a web session for a user and session id
-	UpsertWebSession(user, sid string, session WebSession, ttl time.Duration) error
+	// UpsertWebSession updates or inserts a web session for a user and session
+	UpsertWebSession(user, sid string, session WebSession) error
 
 	// GetWebSession returns a web session state for a given user and session id
 	GetWebSession(user, sid string) (WebSession, error)

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -72,17 +72,6 @@ func (s *IdentityService) GetUsers() ([]services.User, error) {
 	return out, nil
 }
 
-func ttl(clock clockwork.Clock, t time.Time) time.Duration {
-	if t.IsZero() {
-		return backend.Forever
-	}
-	diff := t.UTC().Sub(clock.Now().UTC())
-	if diff < 0 {
-		return backend.Forever
-	}
-	return diff
-}
-
 // CreateUser creates user if it does not exist
 func (s *IdentityService) CreateUser(user services.User) error {
 	if err := user.Check(); err != nil {
@@ -92,7 +81,7 @@ func (s *IdentityService) CreateUser(user services.User) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = s.backend.CreateVal([]string{"web", "users", user.GetName()}, "params", []byte(data), ttl(clockwork.NewRealClock(), user.GetExpiry()))
+	err = s.backend.CreateVal([]string{"web", "users", user.GetName()}, "params", []byte(data), backend.TTL(clockwork.NewRealClock(), user.GetExpiry()))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -108,7 +97,7 @@ func (s *IdentityService) UpsertUser(user services.User) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = s.backend.UpsertVal([]string{"web", "users", user.GetName()}, "params", []byte(data), ttl(clockwork.NewRealClock(), user.GetExpiry()))
+	err = s.backend.UpsertVal([]string{"web", "users", user.GetName()}, "params", []byte(data), backend.TTL(clockwork.NewRealClock(), user.GetExpiry()))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -278,13 +267,16 @@ func (s *IdentityService) DeleteUsedTOTPToken(user string) error {
 }
 
 // UpsertWebSession updates or inserts a web session for a user and session id
-func (s *IdentityService) UpsertWebSession(user, sid string, session services.WebSession, ttl time.Duration) error {
+// the session will be created with bearer token expiry time TTL, because
+// it is expected to be extended by the client before then
+func (s *IdentityService) UpsertWebSession(user, sid string, session services.WebSession) error {
 	session.SetUser(user)
 	session.SetName(sid)
 	bytes, err := services.GetWebSessionMarshaler().MarshalWebSession(session)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	ttl := backend.TTL(clockwork.NewRealClock(), session.GetBearerTokenExpiryTime())
 	err = s.backend.UpsertVal([]string{"web", "users", user, "sessions"},
 		sid, bytes, ttl)
 	if trace.IsNotFound(err) {

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -328,7 +328,7 @@ func (s *ServicesTestSuite) WebSessionCRUD(c *C) {
 		Priv:    []byte("priv123"),
 		Expires: dt,
 	})
-	err = s.WebS.UpsertWebSession("user1", "sid1", ws, 0)
+	err = s.WebS.UpsertWebSession("user1", "sid1", ws)
 	c.Assert(err, IsNil)
 
 	out, err := s.WebS.GetWebSession("user1", "sid1")
@@ -337,7 +337,7 @@ func (s *ServicesTestSuite) WebSessionCRUD(c *C) {
 
 	ws1 := services.NewWebSession(
 		"sid1", services.WebSessionSpecV2{Pub: []byte("pub321"), Priv: []byte("priv321"), Expires: dt})
-	err = s.WebS.UpsertWebSession("user1", "sid1", ws1, 0)
+	err = s.WebS.UpsertWebSession("user1", "sid1", ws1)
 	c.Assert(err, IsNil)
 
 	out2, err := s.WebS.GetWebSession("user1", "sid1")

--- a/lib/utils/time.go
+++ b/lib/utils/time.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+// MinTTL finds min non 0 TTL duration,
+// if both durations are 0, fails
+func MinTTL(a, b time.Duration) time.Duration {
+	if a == 0 {
+		return b
+	}
+	if b == 0 {
+		return a
+	}
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// ToTTL converts expiration time to TTL duration
+// relative to current time as provided by clock
+func ToTTL(c clockwork.Clock, tm time.Time) time.Duration {
+	now := c.Now().UTC()
+	if tm.IsZero() || tm.Before(now) {
+		return 0
+	}
+	return tm.Sub(now)
+}
+
+// UTC converts time to UTC timezone
+func UTC(t *time.Time) {
+	if t.IsZero() {
+		// to fix issue with timezones for tests
+		*t = time.Time{}
+		return
+	}
+	*t = t.UTC()
+}

--- a/lib/web/api.go
+++ b/lib/web/api.go
@@ -521,7 +521,7 @@ func NewSessionResponse(ctx *SessionContext) (*CreateSessionResponse, error) {
 		Type:      roundtrip.AuthBearer,
 		Token:     webSession.GetBearerToken(),
 		User:      user.WebSessionInfo(allowedLogins),
-		ExpiresIn: int(webSession.GetExpiryTime().Sub(time.Now()) / time.Second),
+		ExpiresIn: int(webSession.GetBearerTokenExpiryTime().Sub(time.Now()) / time.Second),
 	}, nil
 }
 


### PR DESCRIPTION
* Fix bug with OIDC powered sessions logged out after 10 minutes
* Adjust web sessions durations by taking roles into account
* Provide explicit TTL enforced on the server side for bearer tokens

Before this PR the web session TTL was measured using defaults,
10 minutes for local sessions and 1 hour for OIDC sessions and
the system relied on client to renew the bearer token.

With this change bearer token TTL is set to 10 minutes
and the entire web session will expire if not renewed before

The maximum session duration is set to 12 hours, if not
limited to a smaller value by roles in RBAC modules.