### PR TITLE
Authentication Configuration

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -72,18 +72,24 @@ const (
 	// pining each other with it:
 	KeepAliveReqType = "keepalive@openssh.com"
 
-	// OTP means One-time Password Algorithm.
+	// OTP means One-time Password Algorithm for Two-Factor Authentication.
 	OTP = "otp"
 
-	// TOTP means Time-based One-time Password Algorithm.
+	// TOTP means Time-based One-time Password Algorithm. for Two-Factor Authentication.
 	TOTP = "totp"
 
-	// HOTP means HMAC-based One-time Password Algorithm.
+	// HOTP means HMAC-based One-time Password Algorithm.for Two-Factor Authentication.
 	HOTP = "hotp"
 
-	// U2F means Universal 2nd Factor.
+	// U2F means Universal 2nd Factor.for Two-Factor Authentication.
 	U2F = "u2f"
 
-	// OIDC means OpenID Connect.
+	// OFF means no second factor.for Two-Factor Authentication.
+	OFF = "off"
+
+	// Local means authentication will happen locally within the Teleport cluster.
+	Local = "local"
+
+	// OIDC means authentication will happen remotly using an OIDC connector.
 	OIDC = "oidc"
 )

--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -197,6 +197,13 @@ auth_service:
     # Turns 'auth' role on. Default is 'yes'
     enabled: yes
 
+    # defines the types and second factors the auth server supports
+    authentication:
+        # type can be local or oidc
+        type: local
+        # second_factor can be off, otp, or u2f
+        second_factor: otp
+
     # IP and the port to bind to. Other Teleport nodes will be connecting to
     # this port (AKA "Auth API" or "Cluster API") to validate client 
     # certificates 
@@ -747,14 +754,20 @@ OIDC integration with applications like Teleport.
 
 ```
 auth_service:
-  enabled: true
-  cluster_name: magadan
-  oidc_connectors:    
-    - id: google
-      redirect_url: https://localhost:3080/v1/webapi/oidc/callback
-      client_id: id-from-google.apps.googleusercontent.com
-      client_secret: secret-key-from-google
-      issuer_url: https://accounts.google.com
+    authentication:
+        type: oidc
+        oidc:
+            id: google
+            redirect_url: https://localhost:3080/v1/webapi/oidc/callback
+            client_id: id-from-google.apps.googleusercontent.com
+            client_secret: secret-key-from-google
+            issuer_url: https://accounts.google.com
+            display: "whaterver"
+            scope: ["ssh_permissions", "roles"]
+            claims_to_roles: 
+                - claim: role
+                  value: admin
+                  roles: ["dba", "backup", "root"]
 ```
 
 Now you should be able to create Teleport users whose identity is managed by Google.
@@ -817,17 +830,17 @@ service configuration in `teleport.yaml`:
 
 ```bash
 auth_service:
-  u2f:
-    # Must be set to 'yes' to enable and 'no' to disable:
-    enabled: yes
+    authentication:
+        type: local
+        second_factor: u2f 
+        u2f:
+            # Only matters when multiple proxy servers are used:
+            app_id: https://mycorp.com/appid.js
 
-    # Only matters when multiple proxy servers are used:
-    app_id: https://mycorp.com/appid.js
-
-    # U2F facets must be set to Teleport proxy servers:
-    facets:
-    - https://proxy1.mycorp.com:3080
-    - https://proxy2.mycorp.com:3080
+            # U2F facets must be set to Teleport proxy servers:
+            facets:
+            - https://proxy1.mycorp.com:3080
+            - https://proxy2.mycorp.com:3080
 ```
 
 If your Teleport is deployed with the same `teleport` process running as a proxy

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -122,11 +122,6 @@ func (a *AuthWithRoles) GetDomainName() (string, error) {
 	return a.authServer.GetDomainName()
 }
 
-func (a *AuthWithRoles) GetU2FAppID() (string, error) {
-	// authenticated users can all read this
-	return a.authServer.GetU2FAppID()
-}
-
 func (a *AuthWithRoles) DeleteCertAuthority(id services.CertAuthID) error {
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.ActionWrite); err != nil {
 		return trace.Wrap(err)
@@ -576,6 +571,42 @@ func (a *AuthWithRoles) DeleteRole(name string) error {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteRole(name)
+}
+
+func (a *AuthWithRoles) GetClusterAuthPreference() (services.AuthPreference, error) {
+	err := a.action(defaults.Namespace, services.KindClusterAuthPreference, services.ActionRead)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return a.authServer.GetClusterAuthPreference()
+}
+
+func (a *AuthWithRoles) SetClusterAuthPreference(cap services.AuthPreference) error {
+	err := a.action(defaults.Namespace, services.KindClusterAuthPreference, services.ActionWrite)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return a.authServer.SetClusterAuthPreference(cap)
+}
+
+func (a *AuthWithRoles) GetUniversalSecondFactor() (services.UniversalSecondFactor, error) {
+	err := a.action(defaults.Namespace, services.KindUniversalSecondFactor, services.ActionRead)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return a.authServer.GetUniversalSecondFactor()
+}
+
+func (a *AuthWithRoles) SetUniversalSecondFactor(u2f services.UniversalSecondFactor) error {
+	err := a.action(defaults.Namespace, services.KindUniversalSecondFactor, services.ActionWrite)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return a.authServer.SetUniversalSecondFactor(u2f)
 }
 
 // NewAuthWithRoles creates new auth server with access control

--- a/lib/auth/new_web_user.go
+++ b/lib/auth/new_web_user.go
@@ -131,7 +131,7 @@ func (s *AuthServer) GetSignupTokenData(token string) (user string, qrCode []byt
 }
 
 func (s *AuthServer) CreateSignupU2FRegisterRequest(token string) (u2fRegisterRequest *u2f.RegisterRequest, e error) {
-	err := s.CheckU2FEnabled()
+	universalSecondFactor, err := s.GetUniversalSecondFactor()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -143,10 +143,10 @@ func (s *AuthServer) CreateSignupU2FRegisterRequest(token string) (u2fRegisterRe
 
 	_, err = s.GetPasswordHash(tokenData.User.Name)
 	if err == nil {
-		return nil, trace.AlreadyExists("can't add user %v, user already exists", tokenData.User)
+		return nil, trace.AlreadyExists("can't add user %q, user already exists", tokenData.User)
 	}
 
-	c, err := u2f.NewChallenge(s.U2F.AppID, s.U2F.Facets)
+	c, err := u2f.NewChallenge(universalSecondFactor.GetAppID(), universalSecondFactor.GetFacets())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -220,9 +220,10 @@ func (s *AuthServer) CreateUserWithToken(token string, password string, otpToken
 }
 
 func (s *AuthServer) CreateUserWithU2FToken(token string, password string, response u2f.RegisterResponse) (services.WebSession, error) {
-	err := s.CheckU2FEnabled()
+	// before trying to create a user, see U2F is actually setup on the backend
+	_, err := s.GetUniversalSecondFactor()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, err
 	}
 
 	tokenData, err := s.GetSignupToken(token)

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package config
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"gopkg.in/check.v1"
+)
+
+type FileTestSuite struct {
+}
+
+var _ = check.Suite(&FileTestSuite{})
+var _ = fmt.Printf
+
+func (s *FileTestSuite) SetUpSuite(c *check.C) {
+}
+
+func (s *FileTestSuite) TearDownSuite(c *check.C) {
+}
+
+func (s *FileTestSuite) SetUpTest(c *check.C) {
+}
+
+func (s *FileTestSuite) TestAuthenticationSection(c *check.C) {
+	tests := []struct {
+		inConfigString          string
+		outAuthenticationConfig *AuthenticationConfig
+	}{
+		// 0 - local with otp
+		{
+			`
+auth_service: 
+  authentication: 
+    type: local
+    second_factor: otp
+`,
+			&AuthenticationConfig{
+				Type:         "local",
+				SecondFactor: "otp",
+			},
+		},
+		// 1 - local auth without otp
+		{
+			`
+auth_service: 
+  authentication: 
+    type: local
+    second_factor: off
+`,
+			&AuthenticationConfig{
+				Type:         "local",
+				SecondFactor: "off",
+			},
+		},
+		// 2 - local auth with u2f
+		{
+			`
+auth_service:
+   authentication:
+       type: local
+       second_factor: u2f
+       u2f:
+           app_id: https://graviton:3080
+           facets:
+           - https://graviton:3080
+`,
+			&AuthenticationConfig{
+				Type:         "local",
+				SecondFactor: "u2f",
+				U2F: &UniversalSecondFactor{
+					AppID: "https://graviton:3080",
+					Facets: []string{
+						"https://graviton:3080",
+					},
+				},
+			},
+		},
+		// 3 - oidc without second factor
+		{
+			`
+auth_service:
+  authentication:
+    type: oidc
+    oidc:
+      id: google
+      redirect_url: "https://localhost:3080/v1/webapi/oidc/callback"
+      client_id: id-from-google.apps.googleusercontent.com
+      client_secret: secret-key-from-google
+      issuer_url: "https://accounts.google.com"
+      display: whaterver
+      scope: [ "ssh_permissions", "roles"]
+      claims_to_roles:
+        - claim: role
+          value: admin
+          roles: ["dba", "backup", "root"]
+`,
+			&AuthenticationConfig{
+				Type: "oidc",
+				OIDC: &OIDCConnector{
+					ID:           "google",
+					RedirectURL:  "https://localhost:3080/v1/webapi/oidc/callback",
+					ClientID:     "id-from-google.apps.googleusercontent.com",
+					ClientSecret: "secret-key-from-google",
+					IssuerURL:    "https://accounts.google.com",
+					Display:      "whaterver",
+					Scope: []string{
+						"ssh_permissions",
+						"roles",
+					},
+					ClaimsToRoles: []ClaimMapping{
+						ClaimMapping{
+							Claim: "role",
+							Value: "admin",
+							Roles: []string{
+								"dba",
+								"backup",
+								"root",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// run tests
+	for i, tt := range tests {
+		comment := check.Commentf("Test %v", i)
+
+		encodedConfigString := base64.StdEncoding.EncodeToString([]byte(tt.inConfigString))
+
+		fc, err := ReadFromString(encodedConfigString)
+		c.Assert(err, check.IsNil, comment)
+
+		c.Assert(fc.Auth.Authentication, check.DeepEquals, tt.outAuthenticationConfig, comment)
+	}
+}
+
+// TestLegacySection ensures we continue to parse and correctly load deprecated
+// OIDC connector and U2F authentication configuration.
+func (s *FileTestSuite) TestLegacyAuthenticationSection(c *check.C) {
+	encodedLegacyAuthenticationSection := base64.StdEncoding.EncodeToString([]byte(LegacyAuthenticationSection))
+
+	// read config into struct
+	fc, err := ReadFromString(encodedLegacyAuthenticationSection)
+	c.Assert(err, check.IsNil)
+
+	// validate oidc connector
+	c.Assert(fc.Auth.OIDCConnectors, check.HasLen, 1)
+	c.Assert(fc.Auth.OIDCConnectors[0].ID, check.Equals, "google")
+	c.Assert(fc.Auth.OIDCConnectors[0].RedirectURL, check.Equals, "https://localhost:3080/v1/webapi/oidc/callback")
+	c.Assert(fc.Auth.OIDCConnectors[0].ClientID, check.Equals, "id-from-google.apps.googleusercontent.com")
+	c.Assert(fc.Auth.OIDCConnectors[0].ClientSecret, check.Equals, "secret-key-from-google")
+	c.Assert(fc.Auth.OIDCConnectors[0].IssuerURL, check.Equals, "https://accounts.google.com")
+
+	// validate u2f
+	c.Assert(fc.Auth.U2F.EnabledFlag, check.Equals, "yes")
+	c.Assert(fc.Auth.U2F.AppID, check.Equals, "https://graviton:3080")
+	c.Assert(fc.Auth.U2F.Facets, check.HasLen, 1)
+	c.Assert(fc.Auth.U2F.Facets[0], check.Equals, "https://graviton:3080")
+}

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package config
+
+const StaticConfigString = `
+#
+# Some comments
+#
+teleport:
+  nodename: edsger.example.com
+  advertise_ip: 10.10.10.1
+  pid_file: /var/run/teleport.pid
+  auth_servers:
+    - auth0.server.example.org:3024
+    - auth1.server.example.org:3024
+  auth_token: xxxyyy
+  log:
+    output: stderr
+    severity: INFO
+  storage:
+    type: etcd
+    peers: ['one', 'two']
+    tls_key_file: /tls.key
+    tls_cert_file: /tls.cert
+    tls_ca_file: /tls.ca
+  connection_limits:
+    max_connections: 90
+    max_users: 91
+    rates:
+    - period: 1m1s
+      average: 70
+      burst: 71
+    - period: 10m10s
+      average: 170
+      burst: 171
+  keys: 
+  - cert: node.cert
+    private_key: !!binary cHJpdmF0ZSBrZXk=
+  - cert_file: /proxy.cert.file
+    private_key_file: /proxy.key.file
+
+auth_service:
+  enabled: yes
+  listen_addr: auth:3025
+  tokens:
+  - "proxy,node:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  - "auth:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  authorities: 
+  - type: host
+    domain_name: example.com
+    checking_keys: 
+      - checking key 1
+    checking_key_files:
+      - /ca.checking.key
+    signing_keys: 
+      - !!binary c2lnbmluZyBrZXkgMQ==
+    signing_key_files:
+      - /ca.signing.key
+  reverse_tunnels:
+      - domain_name: tunnel.example.com  	  
+        addresses: ["com-1", "com-2"]
+      - domain_name: tunnel.example.org  	  
+        addresses: ["org-1"]
+
+ssh_service:
+  enabled: no
+  listen_addr: ssh:3025
+  labels:
+    name: mongoserver
+    role: slave
+  commands:
+  - name: hostname
+    command: [/bin/hostname]
+    period: 10ms
+  - name: date
+    command: [/bin/date]
+    period: 20ms
+`
+
+const SmallConfigString = `
+teleport:
+  nodename: cat.example.com
+  advertise_ip: 10.10.10.1
+  pid_file: /var/run/teleport.pid
+  auth_servers:
+    - auth0.server.example.org:3024
+    - auth1.server.example.org:3024
+  auth_token: xxxyyy
+  log:
+    output: stderr
+    severity: INFO
+  connection_limits:
+    max_connections: 90
+    max_users: 91
+    rates:
+    - period: 1m1s
+      average: 70
+      burst: 71
+    - period: 10m10s
+      average: 170
+      burst: 171
+auth_service:
+  enabled: yes
+  listen_addr: 10.5.5.1:3025
+  cluster_name: magadan
+  tokens:
+  - "proxy,node:xxx"
+  - "auth:yyy"
+ssh_service:
+  enabled: no
+
+proxy_service:
+  enabled: yes
+  web_listen_addr: webhost
+  tunnel_listen_addr: tunnelhost:1001
+`
+
+// LegacyAuthenticationSection is the deprecated format for authentication method. We still
+// need to support it until it's fully removed.
+const LegacyAuthenticationSection = `
+auth_service:
+  oidc_connectors:    
+    - id: google
+      redirect_url: https://localhost:3080/v1/webapi/oidc/callback
+      client_id: id-from-google.apps.googleusercontent.com
+      client_secret: secret-key-from-google
+      issuer_url: https://accounts.google.com
+  u2f:
+    enabled: "yes"
+    app_id: https://graviton:3080
+    facets:
+    - https://graviton:3080
+`

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -17,11 +17,9 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"os"
-	"strings"
 
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/backend"
@@ -209,7 +207,12 @@ type AuthConfig struct {
 	// NoAudit, when set to true, disables session recording and event audit
 	NoAudit bool
 
-	U2F services.U2F
+	// Preference defines the authentication preference (type and second factor) for
+	// the auth server.
+	Preference services.AuthPreference
+
+	// U2F defines is settings for Universal Second Factor (appID and facets).
+	U2F services.UniversalSecondFactor
 }
 
 // SSHConfig configures SSH server node role
@@ -247,9 +250,6 @@ func ApplyDefaults(cfg *Config) {
 	// defaults for the auth service:
 	cfg.Auth.Enabled = true
 	cfg.Auth.SSHAddr = *defaults.AuthListenAddr()
-	cfg.Auth.U2F.Enabled = false
-	cfg.Auth.U2F.AppID = fmt.Sprintf("https://%s:%d", strings.ToLower(hostname), defaults.HTTPListenPort)
-	cfg.Auth.U2F.Facets = []string{cfg.Auth.U2F.AppID}
 	cfg.Auth.StorageConfig.Type = boltbk.GetName()
 	cfg.Auth.StorageConfig.Params = backend.Params{"path": cfg.DataDir}
 	defaults.ConfigureLimiter(&cfg.Auth.Limiter)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -324,15 +324,16 @@ func (process *TeleportProcess) initAuthService(authority auth.Authority) error 
 		NodeName:        cfg.Hostname,
 		Authorities:     cfg.Auth.Authorities,
 		ReverseTunnels:  cfg.ReverseTunnels,
-		OIDCConnectors:  cfg.OIDCConnectors,
 		Trust:           cfg.Trust,
 		Presence:        cfg.Presence,
 		Provisioner:     cfg.Provisioner,
 		Identity:        cfg.Identity,
 		Access:          cfg.Access,
 		StaticTokens:    cfg.Auth.StaticTokens,
-		U2F:             cfg.Auth.U2F,
 		Roles:           cfg.Auth.Roles,
+		AuthPreference:  cfg.Auth.Preference,
+		OIDCConnectors:  cfg.OIDCConnectors,
+		U2F:             cfg.Auth.U2F,
 	}, cfg.SeedConfig)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/authentication.go
+++ b/lib/services/authentication.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+)
+
+// ClusterAuthPreference defines an interface to get and set
+// authentication preferences for a cluster.
+type ClusterAuthPreference interface {
+	// GetClusterAuthPreference returns the authentication preferences for a cluster.
+	GetClusterAuthPreference() (AuthPreference, error)
+
+	// SetClusterAuthPreference sets the authentication preferences for a cluster.
+	SetClusterAuthPreference(AuthPreference) error
+}
+
+// AuthPreference defines the authentication preferences for a specific
+// cluster. It defines the type (local, oidc) and second factor (off, otp, oidc).
+type AuthPreference interface {
+	// GetType returns the type of authentication.
+	GetType() string
+
+	// SetType sets the type of authentication.
+	SetType(string)
+
+	// GetSecondFactor returns the type of second factor.
+	GetSecondFactor() string
+
+	// SetSecondFactor sets the type of second factor.
+	SetSecondFactor(string)
+
+	// Check verifies the constraints for AuthPreference.
+	Check() error
+}
+
+// NewAuthPreference is a convenience method to to create AuthPreferenceV2.
+func NewAuthPreference(spec AuthPreferenceSpecV2) (AuthPreference, error) {
+	return &AuthPreferenceV2{
+		Kind:    KindClusterAuthPreference,
+		Version: V2,
+		Metadata: Metadata{
+			Name:      MetaNameClusterAuthPreference,
+			Namespace: defaults.Namespace,
+		},
+		Spec: spec,
+	}, nil
+}
+
+// AuthPreferenceV2 implements AuthPreference.
+type AuthPreferenceV2 struct {
+	// Kind is a resource kind - always resource.
+	Kind string `json:"kind"`
+
+	// Version is a resource version.
+	Version string `json:"version"`
+
+	// Metadata is metadata about the resource.
+	Metadata Metadata `json:"metadata"`
+
+	// Spec is the specification of the resource.
+	Spec AuthPreferenceSpecV2 `json:"spec"`
+}
+
+// AuthPreferenceSpecV2 is the actual data we care about for AuthPreferenceV2.
+type AuthPreferenceSpecV2 struct {
+	// Type is the type of authentication.
+	Type string `json:"type"`
+
+	// SecondFactor is the type of second factor.
+	SecondFactor string `json:"second_factor"`
+}
+
+// GetType returns the type of authentication.
+func (c *AuthPreferenceV2) GetType() string {
+	return c.Spec.Type
+}
+
+// SetType sets the type of authentication.
+func (c *AuthPreferenceV2) SetType(s string) {
+	c.Spec.Type = s
+}
+
+// GetSecondFactor returns the type of second factor.
+func (c *AuthPreferenceV2) GetSecondFactor() string {
+	return c.Spec.SecondFactor
+}
+
+// SetSecondFactor sets the type of second factor.
+func (c *AuthPreferenceV2) SetSecondFactor(s string) {
+	c.Spec.SecondFactor = s
+}
+
+// Check verifies the constraints for AuthPreference.
+func (c *AuthPreferenceV2) Check() error {
+	switch c.Spec.Type {
+	case teleport.Local:
+		if c.Spec.SecondFactor != teleport.OFF && c.Spec.SecondFactor != teleport.OTP && c.Spec.SecondFactor != teleport.U2F {
+			return trace.BadParameter("second factor type %q not supported", c.Spec.SecondFactor)
+		}
+	case teleport.OIDC:
+		if c.Spec.SecondFactor != "" {
+			return trace.BadParameter("second factor not supported with oidc connector")
+		}
+	default:
+		return trace.BadParameter("unsupported type %q", c.Spec.Type)
+	}
+
+	return nil
+}
+
+const AuthPreferenceSpecSchemaTemplate = `{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {"type": "string"},
+    "second_factor": {"type": "string"}%v
+  }
+}`
+
+// GetAuthPreferenceSchema returns the schema with optionally injected
+// schema for extensions.
+func GetAuthPreferenceSchema(extensionSchema string) string {
+	var authPreferenceSchema string
+	if authPreferenceSchema == "" {
+		authPreferenceSchema = fmt.Sprintf(AuthPreferenceSpecSchemaTemplate, "")
+	} else {
+		authPreferenceSchema = fmt.Sprintf(AuthPreferenceSpecSchemaTemplate, ","+extensionSchema)
+	}
+	return fmt.Sprintf(V2SchemaTemplate, MetadataSchema, authPreferenceSchema)
+}
+
+// AuthPreferenceMarshaler implements marshal/unmarshal of AuthPreference implementations
+// mostly adds support for extended versions.
+type AuthPreferenceMarshaler interface {
+	Marshal(c AuthPreference, opts ...MarshalOption) ([]byte, error)
+	Unmarshal(bytes []byte) (AuthPreference, error)
+}
+
+var authPreferenceMarshaler AuthPreferenceMarshaler = &TeleportAuthPreferenceMarshaler{}
+
+func SetAuthPreferenceMarshaler(m AuthPreferenceMarshaler) {
+	marshalerMutex.Lock()
+	defer marshalerMutex.Unlock()
+	authPreferenceMarshaler = m
+}
+
+func GetAuthPreferenceMarshaler() AuthPreferenceMarshaler {
+	marshalerMutex.Lock()
+	defer marshalerMutex.Unlock()
+	return authPreferenceMarshaler
+}
+
+type TeleportAuthPreferenceMarshaler struct{}
+
+// Unmarshal unmarshals role from JSON or YAML.
+func (t *TeleportAuthPreferenceMarshaler) Unmarshal(bytes []byte) (AuthPreference, error) {
+	var authPreference AuthPreferenceV2
+
+	if len(bytes) == 0 {
+		return nil, trace.BadParameter("missing resource data")
+	}
+
+	err := utils.UnmarshalWithSchema(GetAuthPreferenceSchema(""), &authPreference, bytes)
+	if err != nil {
+		return nil, trace.BadParameter(err.Error())
+	}
+
+	return &authPreference, nil
+}
+
+// Marshal marshals role to JSON or YAML.
+func (t *TeleportAuthPreferenceMarshaler) Marshal(c AuthPreference, opts ...MarshalOption) ([]byte, error) {
+	return json.Marshal(c)
+}

--- a/lib/services/authentication_test.go
+++ b/lib/services/authentication_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"fmt"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"gopkg.in/check.v1"
+)
+
+type ClusterAuthPreferenceSuite struct{}
+
+var _ = check.Suite(&ClusterAuthPreferenceSuite{})
+var _ = fmt.Printf
+
+func (s *ClusterAuthPreferenceSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
+}
+
+func (s *ClusterAuthPreferenceSuite) TestUnmarshal(c *check.C) {
+	input := `
+      {
+        "kind": "cluster_auth_preference",
+        "metadata": {
+          "name": "cluster-auth-preference"
+        },
+        "spec": {
+          "type": "local",
+          "second_factor": "otp"
+        }
+      }
+	`
+
+	output := AuthPreferenceV2{
+		Kind:    KindClusterAuthPreference,
+		Version: V2,
+		Metadata: Metadata{
+			Name:      MetaNameClusterAuthPreference,
+			Namespace: defaults.Namespace,
+		},
+		Spec: AuthPreferenceSpecV2{
+			Type:         "local",
+			SecondFactor: "otp",
+		},
+	}
+
+	ap, err := GetAuthPreferenceMarshaler().Unmarshal([]byte(input))
+	c.Assert(err, check.IsNil)
+	c.Assert(ap, check.DeepEquals, &output)
+}

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -282,6 +282,7 @@ func (i *OIDCAuthRequest) Check() error {
 }
 
 // U2F is a configuration of the U2F two factor authentication
+// Deprecated: Use services.UniversalSecondFactor instead.
 type U2F struct {
 	Enabled bool
 	// AppID identifies the website to the U2F keys. It should not be changed once a U2F

--- a/lib/services/local/authentication.go
+++ b/lib/services/local/authentication.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+)
+
+// ClusterAuthPreferenceService is responsible for managing cluster authentication preferences.
+type ClusterAuthPreferenceService struct {
+	backend.Backend
+}
+
+// NewClusterAuthPreferenceService returns a new ClusterAuthPreferenceService.
+func NewClusterAuthPreferenceService(backend backend.Backend) *ClusterAuthPreferenceService {
+	return &ClusterAuthPreferenceService{
+		Backend: backend,
+	}
+}
+
+// GetClusterAuthPreference fetches the cluster authentication preferences
+// from the backend and return them.
+func (s *ClusterAuthPreferenceService) GetClusterAuthPreference() (services.AuthPreference, error) {
+	data, err := s.GetVal([]string{"authentication"}, "preference")
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return nil, trace.NotFound("authentication preference not found")
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return services.GetAuthPreferenceMarshaler().Unmarshal(data)
+}
+
+// SetClusterAuthPreference sets the cluster authentication preferences
+// on the backend.
+func (s *ClusterAuthPreferenceService) SetClusterAuthPreference(preferences services.AuthPreference) error {
+	data, err := services.GetAuthPreferenceMarshaler().Marshal(preferences)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = s.UpsertVal([]string{"authentication"}, "preference", []byte(data), backend.Forever)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}

--- a/lib/services/local/authentication_test.go
+++ b/lib/services/local/authentication_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/boltbk"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"gopkg.in/check.v1"
+)
+
+type ClusterAuthPreferenceSuite struct {
+	bk      backend.Backend
+	tempDir string
+}
+
+var _ = check.Suite(&ClusterAuthPreferenceSuite{})
+var _ = fmt.Printf
+
+func (s *ClusterAuthPreferenceSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
+}
+
+func (s *ClusterAuthPreferenceSuite) TearDownSuite(c *check.C) {
+}
+
+func (s *ClusterAuthPreferenceSuite) SetUpTest(c *check.C) {
+	var err error
+
+	s.tempDir, err = ioutil.TempDir("", "preference-test-")
+	c.Assert(err, check.IsNil)
+
+	s.bk, err = boltbk.New(backend.Params{"path": s.tempDir})
+	c.Assert(err, check.IsNil)
+}
+
+func (s *ClusterAuthPreferenceSuite) TearDownTest(c *check.C) {
+	var err error
+
+	c.Assert(s.bk.Close(), check.IsNil)
+
+	err = os.RemoveAll(s.tempDir)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *ClusterAuthPreferenceSuite) TestCycle(c *check.C) {
+	caps := NewClusterAuthPreferenceService(s.bk)
+
+	ap, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
+		Type:         "local",
+		SecondFactor: "otp",
+	})
+	c.Assert(err, check.IsNil)
+
+	err = caps.SetClusterAuthPreference(ap)
+	c.Assert(err, check.IsNil)
+
+	gotAP, err := caps.GetClusterAuthPreference()
+	c.Assert(err, check.IsNil)
+
+	c.Assert(gotAP.GetType(), check.Equals, "local")
+	c.Assert(gotAP.GetSecondFactor(), check.Equals, "otp")
+}

--- a/lib/services/local/u2f.go
+++ b/lib/services/local/u2f.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+)
+
+// UniversalSecondFactorService is responsible for managing universal second factor settings.
+type UniversalSecondFactorService struct {
+	backend.Backend
+}
+
+// NewUniversalSecondFactorService returns a new UniversalSecondFactorService.
+func NewUniversalSecondFactorService(backend backend.Backend) *UniversalSecondFactorService {
+	return &UniversalSecondFactorService{
+		Backend: backend,
+	}
+}
+
+// GetUniversalSecondFactor fetches the universal second factor settings
+// from the backend and returns them.
+func (s *UniversalSecondFactorService) GetUniversalSecondFactor() (services.UniversalSecondFactor, error) {
+	data, err := s.GetVal([]string{"authentication", "preference"}, "u2f")
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return nil, trace.NotFound("no universal second factor settings")
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	return services.GetUniversalSecondFactorMarshaler().Unmarshal(data)
+}
+
+// GetUniversalSecondFactor sets the universal second factor settings
+// on the backend.
+func (s *UniversalSecondFactorService) SetUniversalSecondFactor(settings services.UniversalSecondFactor) error {
+	data, err := services.GetUniversalSecondFactorMarshaler().Marshal(settings)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = s.UpsertVal([]string{"authentication", "preference"}, "u2f", []byte(data), backend.Forever)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package services
 
 import (

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package services
 
 import (
@@ -73,6 +89,18 @@ const (
 
 	// KindOIDCConnector is a OIDC connector resource
 	KindOIDCConnector = "oidc"
+
+	// KindAuthPreference is the type of authentication for this cluster.
+	KindClusterAuthPreference = "cluster_auth_preference"
+
+	// KindAuthPreference is the type of authentication for this cluster.
+	MetaNameClusterAuthPreference = "cluster-auth-preference"
+
+	// KindUniversalSecondFactor is a type of second factor authentication.
+	KindUniversalSecondFactor = "universal_second_factor"
+
+	// MetaNameUniversalSecondFactor is a type of second factor authentication.
+	MetaNameUniversalSecondFactor = "universal-second-factor"
 
 	// V2 is our current version
 	V2 = "v2"

--- a/lib/services/u2f.go
+++ b/lib/services/u2f.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+)
+
+// UniversalSecondFactorSettings defines the interface to get and set
+// Universal Second Factor settings.
+type UniversalSecondFactorSettings interface {
+	// GetUniversalSecondFactor returns universal second factor settings.
+	GetUniversalSecondFactor() (UniversalSecondFactor, error)
+
+	// SetUniversalSecondFactor sets universal second factor settings.
+	SetUniversalSecondFactor(UniversalSecondFactor) error
+}
+
+// UniversalSecondFactor defines settings for Universal Second Factor
+// like the AppID and Facets.
+type UniversalSecondFactor interface {
+	// GetAppID returns the application ID for universal second factor.
+	GetAppID() string
+
+	// SetAppID sets the application ID for universal second factor.
+	SetAppID(string)
+
+	// GetFacets returns the facets for universal second factor.
+	GetFacets() []string
+
+	// SetFacets sets the facets for universal second factor.
+	SetFacets([]string)
+}
+
+// NewUniversalSecondFactor is a convenience method to to create UniversalSecondFactorV2.
+func NewUniversalSecondFactor(spec UniversalSecondFactorSpecV2) (UniversalSecondFactor, error) {
+	return &UniversalSecondFactorV2{
+		Kind:    KindUniversalSecondFactor,
+		Version: V2,
+		Metadata: Metadata{
+			Name:      MetaNameUniversalSecondFactor,
+			Namespace: defaults.Namespace,
+		},
+		Spec: spec,
+	}, nil
+}
+
+// UniversalSecondFactorV2 implements UniversalSecondFactor.
+type UniversalSecondFactorV2 struct {
+	// Kind is a resource kind - always resource.
+	Kind string `json:"kind"`
+
+	// Version is a resource version.
+	Version string `json:"version"`
+
+	// Metadata is metadata about the resource.
+	Metadata Metadata `json:"metadata"`
+
+	// Spec is the specification of the resource.
+	Spec UniversalSecondFactorSpecV2 `json:"spec"`
+}
+
+// UniversalSecondFactorSpecV2 is the actual data we care about for UniversalSecondFactorV2.
+type UniversalSecondFactorSpecV2 struct {
+	// AppID is the application ID for universal second factor.
+	AppID string `json:"app_id"`
+
+	// Facets are the facets for universal second factor.
+	Facets []string `json:"facets"`
+}
+
+// GetAppID returns the application ID for universal second factor.
+func (c *UniversalSecondFactorV2) GetAppID() string {
+	return c.Spec.AppID
+}
+
+// SetAppID sets the application ID for universal second factor.
+func (c *UniversalSecondFactorV2) SetAppID(s string) {
+	c.Spec.AppID = s
+}
+
+// GetFacets returns the facets for universal second factor.
+func (c *UniversalSecondFactorV2) GetFacets() []string {
+	return c.Spec.Facets
+}
+
+// SetFacets sets the facets for universal second factor.
+func (c *UniversalSecondFactorV2) SetFacets(s []string) {
+	c.Spec.Facets = s
+}
+
+const UniversalSecondFactorSpecSchemaTemplate = `{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "app_id": {"type": "string"},
+	"facets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }%v
+  }
+}`
+
+// GetUniversalSecondFactorSchema returns the schema with optionally injected
+// schema for extensions.
+func GetUniversalSecondFactorSchema(extensionSchema string) string {
+	var authPreferenceSchema string
+	if authPreferenceSchema == "" {
+		authPreferenceSchema = fmt.Sprintf(UniversalSecondFactorSpecSchemaTemplate, "")
+	} else {
+		authPreferenceSchema = fmt.Sprintf(UniversalSecondFactorSpecSchemaTemplate, ","+extensionSchema)
+	}
+	return fmt.Sprintf(V2SchemaTemplate, MetadataSchema, authPreferenceSchema)
+}
+
+// UniversalSecondFactorMarshaler implements marshal/unmarshal of UniversalSecondFactor implementations
+// mostly adds support for extended versions.
+type UniversalSecondFactorMarshaler interface {
+	Marshal(c UniversalSecondFactor, opts ...MarshalOption) ([]byte, error)
+	Unmarshal(bytes []byte) (UniversalSecondFactor, error)
+}
+
+var universalSecondFactorMarshaler UniversalSecondFactorMarshaler = &TeleportUniversalSecondFactorMarshaler{}
+
+func SetUniversalSecondFactorMarshaler(m UniversalSecondFactorMarshaler) {
+	marshalerMutex.Lock()
+	defer marshalerMutex.Unlock()
+	universalSecondFactorMarshaler = m
+}
+
+func GetUniversalSecondFactorMarshaler() UniversalSecondFactorMarshaler {
+	marshalerMutex.Lock()
+	defer marshalerMutex.Unlock()
+	return universalSecondFactorMarshaler
+}
+
+type TeleportUniversalSecondFactorMarshaler struct{}
+
+// Unmarshal unmarshals role from JSON or YAML.
+func (t *TeleportUniversalSecondFactorMarshaler) Unmarshal(bytes []byte) (UniversalSecondFactor, error) {
+	var authPreference UniversalSecondFactorV2
+
+	if len(bytes) == 0 {
+		return nil, trace.BadParameter("missing resource data")
+	}
+
+	err := utils.UnmarshalWithSchema(GetUniversalSecondFactorSchema(""), &authPreference, bytes)
+	if err != nil {
+		return nil, trace.BadParameter(err.Error())
+	}
+
+	return &authPreference, nil
+}
+
+// Marshal marshals role to JSON or YAML.
+func (t *TeleportUniversalSecondFactorMarshaler) Marshal(c UniversalSecondFactor, opts ...MarshalOption) ([]byte, error) {
+	return json.Marshal(c)
+}

--- a/lib/web/api.go
+++ b/lib/web/api.go
@@ -312,11 +312,15 @@ func (m *Handler) getSettings(w http.ResponseWriter, r *http.Request) (interface
 	if len(settings.Auth.OIDCConnectors) == 0 {
 		settings.Auth.OIDCConnectors = make([]oidcConnector, 0)
 	}
-	u2fAppID, err := m.cfg.ProxyClient.GetU2FAppID()
+
+	universalSecondFactor, err := m.cfg.ProxyClient.GetUniversalSecondFactor()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if err != nil {
 		settings.Auth.U2FAppID = ""
 	} else {
-		settings.Auth.U2FAppID = u2fAppID
+		settings.Auth.U2FAppID = universalSecondFactor.GetAppID()
 	}
 	out, err := json.Marshal(settings)
 	if err != nil {

--- a/lib/web/web_test.go
+++ b/lib/web/web_test.go
@@ -145,14 +145,18 @@ func (s *WebSuite) SetUpTest(c *C) {
 		Backend:    s.bk,
 		Authority:  authority.New(),
 		DomainName: s.domainName,
-		U2F: services.U2F{
-			Enabled: true,
-			AppID:   "https://" + s.domainName,
-			Facets:  []string{"https://" + s.domainName},
-		},
-		Identity: identity,
-		Access:   access,
+		Identity:   identity,
+		Access:     access,
 	})
+
+	// configure u2f
+	universalSecondFactor, err := services.NewUniversalSecondFactor(services.UniversalSecondFactorSpecV2{
+		AppID:  "https://" + s.domainName,
+		Facets: []string{"https://" + s.domainName},
+	})
+	c.Assert(err, IsNil)
+	err = authServer.SetUniversalSecondFactor(universalSecondFactor)
+	c.Assert(err, IsNil)
 
 	teleUser, err := services.NewUser(s.user)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/757, we need to do some refactoring around authentication configuration so Teleport can support more authentication methods. In addition, we want to start pushing authentication configuration change to the backend so Teleport can both be configured dynamically and for consistency (configuration files can drift).

**Implementation**

*Code Updates*

* The Teleport configuration format was changed in `lib/config` to add support for a `authentication` section. Backward compatibility with the old format was retained so older configuration file will still work.

* If `seed_config` is `true` and this is the first time the Teleport process is started, configuration information is pushed to the backend. After that configuration information is always read from the backend, changes to the configuration files will not have any effect.

* The resources `AuthPreference` and `UniversalSecondFactor` were added in `lib/services` and implementations in `lib/services/local`. 

* The `OIDCConnector` resource was left untouched.

* Four new endpoints (GET/POST for both) were added to the Auth Server to allow you to get and set the above two resources.

* Since U2F has gone from purely defined in the configuration file to a resource, if we detect U2F is set but no configuration information is in the backend, a migration is kicked off.

*Test Updates*

* Tests have been added that cover new functionality as well as backward compatibility with the old configuration format.

*Documentation Updates*

* Admin Guide was updated to show how to use the new configuration file format.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/757