### PR TITLE
Fix configuration file regressions.

### DIFF
--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -254,7 +254,7 @@ type AuthenticationSettings struct {
 	Type string `json:"type"`
 	// SecondFactor is the type of second factor to use in authentication.
 	// Supported options are: off, otp, and u2f.
-	SecondFactor string `json:"second_factor"`
+	SecondFactor string `json:"second_factor,omitempty"`
 	// U2F contains the Universal Second Factor settings needed for authentication.
 	U2F *U2FSettings `json:"u2f,omitempty"`
 	// OIDC contains the OIDC Connector settings needed for authentication.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -283,6 +283,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 			cfg.OIDCConnectors = []services.OIDCConnector{oidcConnector}
 
 			cfg.Auth.Preference.SetType(teleport.OIDC)
+			cfg.Auth.Preference.SetSecondFactor("")
 		}
 
 		// parse the configuration to see if we have defined u2f

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -253,6 +253,10 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Auth.StorageConfig.Type = boltbk.GetName()
 	cfg.Auth.StorageConfig.Params = backend.Params{"path": cfg.DataDir}
 	defaults.ConfigureLimiter(&cfg.Auth.Limiter)
+	// set new style default auth preferences
+	ap := &services.AuthPreferenceV2{}
+	ap.CheckAndSetDefaults()
+	cfg.Auth.Preference = ap
 
 	// defaults for the SSH proxy service:
 	cfg.Proxy.Enabled = true

--- a/lib/services/authentication.go
+++ b/lib/services/authentication.go
@@ -135,7 +135,7 @@ func (c *AuthPreferenceV2) CheckAndSetDefaults() error {
 		}
 	case teleport.OIDC:
 		if c.Spec.SecondFactor != "" {
-			return trace.BadParameter("second factor not supported with oidc connector")
+			return trace.BadParameter("second factor [%q] not supported with oidc connector")
 		}
 	default:
 		return trace.BadParameter("unsupported type %q", c.Spec.Type)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -327,8 +327,8 @@ func buildOIDCConnectorSettings(authClient auth.ClientI) *client.OIDCSettings {
 	}
 }
 
-func buildAuthenticationSettings(authClient auth.ClientI) (*client.PingResponse, error) {
-	as := client.AuthenticationSettings{}
+func buildAuthenticationSettings(authClient auth.ClientI) (*client.AuthenticationSettings, error) {
+	as := &client.AuthenticationSettings{}
 
 	cap, err := authClient.GetClusterAuthPreference()
 	if err != nil {
@@ -346,50 +346,39 @@ func buildAuthenticationSettings(authClient auth.ClientI) (*client.PingResponse,
 		as.OIDC = buildOIDCConnectorSettings(authClient)
 	}
 
-	return &client.PingResponse{
-		Auth:          as,
-		ServerVersion: teleport.Version,
-	}, nil
+	return as, nil
 }
 
 func (m *Handler) getAuthenticationSettings(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
-	pr, err := buildAuthenticationSettings(m.cfg.ProxyClient)
+	as, err := buildAuthenticationSettings(m.cfg.ProxyClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return pr, nil
+	return &client.PingResponse{
+		Auth:          *as,
+		ServerVersion: teleport.Version,
+	}, nil
 }
 
 type webConfig struct {
-	Auth interface{} `json:"auth"`
+	// Auth contains the forms of authentication the auth server supports.
+	Auth *client.AuthenticationSettings `json:"auth,omitempty"`
+
 	// ServerVersion is the version of Teleport that is running.
 	ServerVersion string `json:"serverVersion"`
 }
 
 // getConfigurationSettings returns configuration for the web application.
 func (m *Handler) getConfigurationSettings(w http.ResponseWriter, r *http.Request) (interface{}, error) {
-	webCfg := webConfig{ServerVersion: teleport.Version}
-	as := client.AuthenticationSettings{}
-	cap, err := m.cfg.ProxyClient.GetClusterAuthPreference()
-
-	if err == nil {
-		as.Type = cap.GetType()
-		as.SecondFactor = cap.GetSecondFactor()
-
-		// if we have u2f or oidc settings, build those as well
-		if cap.GetSecondFactor() == teleport.U2F {
-			as.U2F = buildUniversalSecondFactorSettings(m.cfg.ProxyClient)
-		}
-
-		if cap.GetType() == teleport.OIDC {
-			as.OIDC = buildOIDCConnectorSettings(m.cfg.ProxyClient)
-		}
-
-		webCfg.Auth = as
-
-	} else {
+	var as, err = buildAuthenticationSettings(m.cfg.ProxyClient)
+	if err != nil {
 		log.Infof("Cannot retrieve cluster auth preferences: %v", err)
+	}
+
+	webCfg := webConfig{
+		Auth:          as,
+		ServerVersion: teleport.Version,
 	}
 
 	out, err := json.Marshal(webCfg)


### PR DESCRIPTION
**Purpose**

https://github.com/gravitational/teleport/issues/789 points out a variety of scenarios that needed to be tested to resolve a few regressions that occurred. This PR makes minor fixes to resolve those regressions.

**Implementation**

* Made `second_factor` in `PingResponse` optional (it is not set when you use a OIDC connector).
* Made Second Factor an empty string when a OIDC connector is found this way it's omitted (see above).
* Teleport can once again be started without a configuration file because `service.Config` is now populated with Authentication Preference defaults.
* Refactoring discussed with @alex-kovoy in https://github.com/gravitational/teleport/pull/791 for `lib/web/apiserver.go`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/789