### PR TITLE
Dynamic Configuration

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -197,6 +197,12 @@ auth_service:
     # Turns 'auth' role on. Default is 'yes'
     enabled: yes
 
+    # Turns on dynamic configuration. Dynamic configuration defines the source
+    # for configuration information, configuration files on disk or what's
+    # stored in the backend. Default is false if no backend is specified,
+    # otherwise if backend is specified, it is assumed to be true.
+    dynamic_config: false
+
     # defines the types and second factors the auth server supports
     authentication:
         # type can be local or oidc

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -218,7 +218,6 @@ func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *servic
 	if tconf == nil {
 		tconf = service.MakeDefaultConfig()
 	}
-	tconf.SeedConfig = true
 	tconf.DataDir = dataDir
 	tconf.Auth.DomainName = i.Secrets.SiteName
 	tconf.Auth.Authorities = append(tconf.Auth.Authorities, i.Secrets.GetCAs()...)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -109,7 +109,7 @@ type InitConfig struct {
 }
 
 // Init instantiates and configures an instance of AuthServer
-func Init(cfg InitConfig, seedConfig bool) (*AuthServer, *Identity, error) {
+func Init(cfg InitConfig, dynamicConfig bool) (*AuthServer, *Identity, error) {
 	if cfg.DataDir == "" {
 		return nil, nil, trace.BadParameter("DataDir: data dir can not be empty")
 	}
@@ -119,7 +119,7 @@ func Init(cfg InitConfig, seedConfig bool) (*AuthServer, *Identity, error) {
 
 	err := cfg.Backend.AcquireLock(cfg.DomainName, 30*time.Second)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, trace.Wrap(err)
 	}
 	defer cfg.Backend.ReleaseLock(cfg.DomainName)
 
@@ -132,115 +132,86 @@ func Init(cfg InitConfig, seedConfig bool) (*AuthServer, *Identity, error) {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	// we skip certain configuration if 'seed_config' is set to true
-	// and this is NOT the first time teleport starts on this machine
-	skipConfig := seedConfig && !firstStart
+	// the logic for when to upload resources to the backend is as follows:
+	//
+	// if dynamicConfig is false:                   upload resources
+	// if dynamicConfig is true AND firstStart:     upload resources
+	// if dynamicConfig is true AND NOT firstStart: don't upload resources
+	uploadResources := true
+	if dynamicConfig == true && firstStart == false {
+		uploadResources = false
+	}
 
-	// upon first start, set the cluster auth prerference from the configuration file
-	// and create a resource on the backend, after that always read from the backend
-	if firstStart {
-		log.Infof("Initializing Cluster Authentication Preference: %v", cfg.AuthPreference)
+	if uploadResources {
 		err = asrv.SetClusterAuthPreference(cfg.AuthPreference)
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
+		log.Infof("[INIT] Set Cluster Authentication Preference: %v", cfg.AuthPreference)
 
 		if cfg.U2F != nil {
-			log.Infof("Initializing Universal Second Factor Settings: %v", cfg.U2F)
 			err = asrv.SetUniversalSecondFactor(cfg.U2F)
 			if err != nil {
 				return nil, nil, trace.Wrap(err)
 			}
+			log.Infof("[INIT] Set Universal Second Factor Settings: %v", cfg.U2F)
 		}
-	}
 
-	// add trusted authorities from the configuration into the trust backend:
-	keepMap := make(map[string]int, 0)
-	if !skipConfig {
-		log.Infof("Initializing roles")
+		if cfg.OIDCConnectors != nil && len(cfg.OIDCConnectors) > 0 {
+			for _, connector := range cfg.OIDCConnectors {
+				if err := asrv.UpsertOIDCConnector(connector, 0); err != nil {
+					return nil, nil, trace.Wrap(err)
+				}
+				log.Infof("[INIT] Created ODIC Connector: %q", connector.GetName())
+			}
+		}
+
 		for _, role := range cfg.Roles {
 			if err := asrv.UpsertRole(role); err != nil {
 				return nil, nil, trace.Wrap(err)
 			}
+			log.Infof("[INIT] Created Role: %v", role)
 		}
 
-		log.Infof("Initializing cert authorities")
 		for i := range cfg.Authorities {
 			ca := cfg.Authorities[i]
 			ca, err = services.GetCertAuthorityMarshaler().GenerateCertAuthority(ca)
 			if err != nil {
 				return nil, nil, trace.Wrap(err)
 			}
+
 			if err := asrv.Trust.UpsertCertAuthority(ca, backend.Forever); err != nil {
 				return nil, nil, trace.Wrap(err)
 			}
-			keepMap[ca.GetClusterName()] = 1
+			log.Infof("[INIT] Created Trusted Certificate Authority: %v", ca)
 		}
-	}
-	// delete trusted authorities from the trust back-end if they're not
-	// in the configuration:
-	if !seedConfig {
-		hostCAs, err := asrv.Trust.GetCertAuthorities(services.HostCA, false)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-		userCAs, err := asrv.Trust.GetCertAuthorities(services.UserCA, false)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-		for _, ca := range append(hostCAs, userCAs...) {
-			_, configured := keepMap[ca.GetClusterName()]
-			if ca.GetClusterName() != cfg.DomainName && !configured {
-				if err = asrv.Trust.DeleteCertAuthority(ca.GetID()); err != nil {
-					return nil, nil, trace.Wrap(err)
-				}
-				log.Infof("removed old trusted CA: '%s'", ca.GetClusterName())
+
+		for _, tunnel := range cfg.ReverseTunnels {
+			if err := asrv.UpsertReverseTunnel(tunnel, 0); err != nil {
+				return nil, nil, trace.Wrap(err)
 			}
+			log.Infof("[INIT] Created Reverse Tunnel: %v", tunnel)
 		}
-	}
-	// this block will generate user CA authority on first start if it's
-	// not currently present, it will also use optional passed user ca keypair
-	// that can be supplied in configuration
-	if _, err := asrv.GetCertAuthority(services.CertAuthID{DomainName: cfg.DomainName, Type: services.HostCA}, false); err != nil {
-		if !trace.IsNotFound(err) {
-			return nil, nil, trace.Wrap(err)
-		}
-		log.Infof("FIRST START: Generating host CA on first start")
-		priv, pub, err := asrv.GenerateKeyPair("")
+
+		err = asrv.UpsertNamespace(services.NewNamespace(defaults.Namespace))
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-		hostCA := &services.CertAuthorityV2{
-			Kind:    services.KindCertAuthority,
-			Version: services.V2,
-			Metadata: services.Metadata{
-				Name:      cfg.DomainName,
-				Namespace: defaults.Namespace,
-			},
-			Spec: services.CertAuthoritySpecV2{
-				ClusterName:  cfg.DomainName,
-				Type:         services.HostCA,
-				SigningKeys:  [][]byte{priv},
-				CheckingKeys: [][]byte{pub},
-			},
-		}
-		if err := asrv.Trust.UpsertCertAuthority(hostCA, backend.Forever); err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
+		log.Infof("[INIT] Created Namespace: %q", defaults.Namespace)
 	}
-	// this block will generate user CA authority on first start if it's
-	// not currently present, it will also use optional passed user ca keypair
-	// that can be supplied in configuration
+
+	// generate a user certificate authority if it doesn't exist
 	if _, err := asrv.GetCertAuthority(services.CertAuthID{DomainName: cfg.DomainName, Type: services.UserCA}, false); err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, nil, trace.Wrap(err)
 		}
 
-		log.Infof("FIRST START: Generating user CA on first start")
+		log.Infof("[FIRST START]: Generating user certificate authority (CA)")
 		priv, pub, err := asrv.GenerateKeyPair("")
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
+
 		userCA := &services.CertAuthorityV2{
 			Kind:    services.KindCertAuthority,
 			Version: services.V2,
@@ -255,143 +226,146 @@ func Init(cfg InitConfig, seedConfig bool) (*AuthServer, *Identity, error) {
 				CheckingKeys: [][]byte{pub},
 			},
 		}
+
 		if err := asrv.Trust.UpsertCertAuthority(userCA, backend.Forever); err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
 	}
-	// add reverse runnels from the configuration into the backend
-	keepMap = make(map[string]int, 0)
-	if !skipConfig {
-		log.Infof("Initializing reverse tunnels")
-		for _, tunnel := range cfg.ReverseTunnels {
-			if err := asrv.UpsertReverseTunnel(tunnel, 0); err != nil {
-				return nil, nil, trace.Wrap(err)
-			}
-			keepMap[tunnel.GetClusterName()] = 1
-		}
-	}
 
-	// remove the reverse tunnels from the backend if they're not
-	// present in the configuration
-	if !seedConfig {
-		tunnels, err := asrv.GetReverseTunnels()
+	// generate a host certificate authority if it doesn't exist
+	if _, err := asrv.GetCertAuthority(services.CertAuthID{DomainName: cfg.DomainName, Type: services.HostCA}, false); err != nil {
+		if !trace.IsNotFound(err) {
+			return nil, nil, trace.Wrap(err)
+		}
+
+		log.Infof("[FIRST START]: Generating host certificate authority (CA)")
+		priv, pub, err := asrv.GenerateKeyPair("")
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-		for _, tunnel := range tunnels {
-			_, configured := keepMap[tunnel.GetClusterName()]
-			if !configured {
-				if err = asrv.DeleteReverseTunnel(tunnel.GetClusterName()); err != nil {
-					return nil, nil, trace.Wrap(err)
-				}
-				log.Infof("removed reverse tunnel: '%s'", tunnel.GetClusterName())
-			}
-		}
-	}
 
-	// add OIDC connectors to the back-end. we always add connectors to the backend
-	// because settings can come from legacy configuration so we keep doing this
-	// until we remove support for legacy formats.
-	keepMap = make(map[string]int, 0)
-	if !skipConfig {
-		log.Infof("Initializing OIDC connectors")
-		for _, connector := range cfg.OIDCConnectors {
-			if err := asrv.UpsertOIDCConnector(connector, 0); err != nil {
-				return nil, nil, trace.Wrap(err)
-			}
-			log.Infof("created ODIC connector '%s'", connector.GetName())
-			keepMap[connector.GetName()] = 1
+		hostCA := &services.CertAuthorityV2{
+			Kind:    services.KindCertAuthority,
+			Version: services.V2,
+			Metadata: services.Metadata{
+				Name:      cfg.DomainName,
+				Namespace: defaults.Namespace,
+			},
+			Spec: services.CertAuthoritySpecV2{
+				ClusterName:  cfg.DomainName,
+				Type:         services.HostCA,
+				SigningKeys:  [][]byte{priv},
+				CheckingKeys: [][]byte{pub},
+			},
 		}
-	}
-	// remove OIDC connectors from the backend if they're not
-	// present in the configuration
-	if !seedConfig {
-		connectors, _ := asrv.GetOIDCConnectors(false)
-		for _, connector := range connectors {
-			_, configured := keepMap[connector.GetName()]
-			if !configured {
-				if err = asrv.DeleteOIDCConnector(connector.GetName()); err != nil {
-					return nil, nil, trace.Wrap(err)
-				}
-				log.Infof("removed OIDC connector '%s'", connector.GetName())
-			}
-		}
-	}
 
-	// migrate u2f settings to the backend. we do this because settings can come from legacy
-	// configuration so always push to the backend until we remove support for the legacy format.
-	if cfg.U2F != nil {
-		err = asrv.SetUniversalSecondFactor(cfg.U2F)
-		if err != nil {
+		if err := asrv.Trust.UpsertCertAuthority(hostCA, backend.Forever); err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
 	}
 
-	// create default namespace
-	err = asrv.UpsertNamespace(services.NewNamespace(defaults.Namespace))
+	// read host keys from disk or create them if they don't exist
+	iid := IdentityID{
+		HostUUID: cfg.HostUUID,
+		NodeName: cfg.NodeName,
+		Role:     teleport.RoleAdmin,
+	}
+	identity, err := initKeys(asrv, cfg.DataDir, iid)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	// migrate old users to new format
+	// migrate any legacy resources to new format
+	err = migrateLegacyResources(asrv)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return asrv, identity, nil
+}
+
+func migrateLegacyResources(asrv *AuthServer) error {
+	err := migrateUsers(asrv)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = migrateCertAuthority(asrv)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func migrateUsers(asrv *AuthServer) error {
 	users, err := asrv.GetUsers()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	for i := range users {
 		user := users[i]
 		raw, ok := (user.GetRawObject()).(services.UserV1)
 		if !ok {
 			continue
 		}
-		log.Infof("migrating legacy user %v", user.GetName())
+		log.Infof("[MIGRATION] Legacy User: %v", user.GetName())
+
+		// create role for user and upsert to backend
 		role := services.RoleForUser(user)
 		role.SetLogins(raw.AllowedLogins)
 		err = asrv.UpsertRole(role)
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
+
+		// upsert new user to backend
 		user.AddRole(role.GetName())
 		if err := asrv.UpsertUser(user); err != nil {
-			return nil, nil, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 	}
 
-	// migrate old cert authorities
-	cas, err := asrv.GetCertAuthorities(services.UserCA, true)
-	for i := range cas {
-		ca := cas[i]
-		if err := migrateCertAuthority(asrv, ca); err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-	}
-
-	identity, err := initKeys(asrv, cfg.DataDir,
-		IdentityID{HostUUID: cfg.HostUUID, NodeName: cfg.NodeName, Role: teleport.RoleAdmin})
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	return asrv, identity, nil
+	return nil
 }
 
-func migrateCertAuthority(asrv *AuthServer, in services.CertAuthority) error {
-	raw, ok := (in.GetRawObject()).(services.CertAuthorityV1)
-	if !ok {
-		return nil
-	}
-	_, err := asrv.GetRole(services.RoleNameForCertAuthority(in.GetClusterName()))
-	if err == nil {
-		return nil
-	}
-	if !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-	ca, role := services.ConvertV1CertAuthority(&raw)
-	log.Infof("migrating legacy cert authority %v", in.GetName())
-	err = asrv.UpsertRole(role)
+func migrateCertAuthority(asrv *AuthServer) error {
+	cas, err := asrv.GetCertAuthorities(services.UserCA, true)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := asrv.UpsertCertAuthority(ca, 0); err != nil {
-		return trace.Wrap(err)
+
+	for i := range cas {
+		ca := cas[i]
+		raw, ok := (ca.GetRawObject()).(services.CertAuthorityV1)
+		if !ok {
+			continue
+		}
+
+		_, err := asrv.GetRole(services.RoleNameForCertAuthority(ca.GetClusterName()))
+		if err == nil {
+			continue
+		}
+		if !trace.IsNotFound(err) {
+			return trace.Wrap(err)
+		}
+
+		log.Infof("[MIGRATION] Legacy Certificate Authority: %v", ca.GetName())
+
+		// create role for certificate authority and upsert to backend
+		newCA, role := services.ConvertV1CertAuthority(&raw)
+		err = asrv.UpsertRole(role)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// upsert new certificate authority to backend
+		if err := asrv.UpsertCertAuthority(newCA, 0); err != nil {
+			return trace.Wrap(err)
+		}
 	}
+
 	return nil
 }
 
@@ -452,7 +426,7 @@ func initKeys(a *AuthServer, dataDir string, id IdentityID) (*Identity, error) {
 // domain trusts us (signed our public key)
 func writeKeys(dataDir string, id IdentityID, key []byte, cert []byte) error {
 	kp, cp := keysPath(dataDir, id)
-	log.Debugf("write key to %v, cert from %v", kp, cp)
+	log.Debugf("[INIT] Writing keys to disk: Key: %q, Cert: %q", kp, cp)
 
 	if err := ioutil.WriteFile(kp, key, 0600); err != nil {
 		return err
@@ -568,7 +542,7 @@ func ReadIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
 // key storage (dataDir).
 func ReadIdentity(dataDir string, id IdentityID) (i *Identity, err error) {
 	kp, cp := keysPath(dataDir, id)
-	log.Debugf("host identity: [key: %v, cert: %v]", kp, cp)
+	log.Debugf("[INIT] Reading keys from disk: Key: %q, Cert: %q", kp, cp)
 
 	keyBytes, err := utils.ReadPath(kp)
 	if err != nil {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -103,7 +103,6 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	if fc == nil {
 		return nil
 	}
-	cfg.SeedConfig = fc.SeedConfig
 	// merge file-based config with defaults in 'cfg'
 	if fc.Auth.Disabled() {
 		cfg.Auth.Enabled = false
@@ -149,9 +148,15 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		cfg.Auth.StorageConfig.Params["path"] = cfg.DataDir
 	}
 
-	// apply storage configuration, if present:
+	// if a backend is specified, override the defaults
 	if fc.Storage.Type != "" {
+		cfg.Auth.DynamicConfig = true
 		cfg.Auth.StorageConfig = fc.Storage
+	}
+
+	// if dynamic_config is specified, override the default
+	if fc.Auth.DynamicConfig != nil {
+		cfg.Auth.DynamicConfig = *fc.Auth.DynamicConfig
 	}
 
 	// apply logger settings

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -43,9 +43,10 @@ import (
 
 var (
 	// all possible valid YAML config keys
+	// true  = non-scalar
+	// false = scalar
 	validKeys = map[string]bool{
 		"namespace":          true,
-		"seed_config":        true,
 		"cluster_name":       true,
 		"trusted_clusters":   true,
 		"pid_file":           true,
@@ -113,6 +114,7 @@ var (
 		"display":            false,
 		"scope":              false,
 		"claims_to_roles":    true,
+		"dynamic_config":     false,
 	}
 )
 
@@ -308,11 +310,6 @@ type Global struct {
 	// Each service (like proxy, auth, node) can find the key it needs
 	// by looking into certificate
 	Keys []KeyPair `yaml:"keys,omitempty"`
-
-	// SeedConfig [GRAVITATIONAL USE] when set to true, Teleport treats
-	// its configuration file simply as a seed data on initial start-up.
-	// For OSS Teleport it should always be 'false' by default.
-	SeedConfig bool `yaml:"seed_config,omitempty"`
 }
 
 // Service is a common configuration of a teleport service
@@ -378,6 +375,10 @@ type Auth struct {
 	// Configuration for "universal 2nd factor"
 	// Deprecated: Use U2F section in Authentication section instead.
 	U2F U2F `yaml:"u2f,omitempty"`
+
+	// DynamicConfig determines when file configuration is pushed to the backend. Setting
+	// it here overrides defaults.
+	DynamicConfig *bool `yaml:"dynamic_config,omitempty"`
 }
 
 // TrustedCluster struct holds configuration values under "trusted_clusters" key

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -103,10 +103,6 @@ type Config struct {
 
 	// Access is a service that controls access
 	Access services.Access
-
-	// SeedConfig tells teleport to treat its start-up configuration as initial
-	// "seed" configuration on 1st start.
-	SeedConfig bool
 }
 
 // ApplyToken assigns a given token to all internal services but only if token
@@ -198,8 +194,11 @@ type AuthConfig struct {
 	// environments where paranoid security is not needed
 	StaticTokens []services.ProvisionToken
 
-	// StorageConfig contains configuration settings for
-	// the secrets storage backend
+	// DynamicConfig determines the source of configuration truth for Teleport. File
+	// configuration or configuration that is in the backend.
+	DynamicConfig bool
+
+	// StorageConfig contains configuration settings for the storage backend.
 	StorageConfig backend.Config
 
 	Limiter limiter.LimiterConfig
@@ -240,7 +239,6 @@ func ApplyDefaults(cfg *Config) {
 		hostname = "localhost"
 		log.Errorf("Failed to determine hostname: %v", err)
 	}
-	cfg.SeedConfig = false
 
 	// global defaults
 	cfg.Hostname = hostname
@@ -250,6 +248,7 @@ func ApplyDefaults(cfg *Config) {
 	// defaults for the auth service:
 	cfg.Auth.Enabled = true
 	cfg.Auth.SSHAddr = *defaults.AuthListenAddr()
+	cfg.Auth.DynamicConfig = false
 	cfg.Auth.StorageConfig.Type = boltbk.GetName()
 	cfg.Auth.StorageConfig.Params = backend.Params{"path": cfg.DataDir}
 	defaults.ConfigureLimiter(&cfg.Auth.Limiter)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -212,10 +212,10 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 		}
 		if len(cfg.Identities) != 0 {
 			cfg.HostUUID = cfg.Identities[0].ID.HostUUID
-			log.Infof("[INIT] taking host uuid from first identity: %v", cfg.HostUUID)
+			log.Infof("[INIT] Taking host UUID from first identity: %v", cfg.HostUUID)
 		} else {
 			cfg.HostUUID = uuid.New()
-			log.Infof("[INIT] generating new host UUID: %v", cfg.HostUUID)
+			log.Infof("[INIT] Generating new host UUID: %v", cfg.HostUUID)
 		}
 		if err := utils.WriteHostUUID(cfg.DataDir, cfg.HostUUID); err != nil {
 			return nil, trace.Wrap(err)
@@ -294,6 +294,7 @@ func (process *TeleportProcess) initAuthService(authority auth.Authority) error 
 		err         error
 	)
 	cfg := process.Config
+
 	// Initialize the storage back-ends for keys, events and records
 	b, err := process.initAuthStorage()
 	if err != nil {
@@ -334,7 +335,7 @@ func (process *TeleportProcess) initAuthService(authority auth.Authority) error 
 		AuthPreference:  cfg.Auth.Preference,
 		OIDCConnectors:  cfg.OIDCConnectors,
 		U2F:             cfg.Auth.U2F,
-	}, cfg.SeedConfig)
+	}, cfg.Auth.DynamicConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -798,7 +799,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	return nil
 }
 
-// initAuthStorage initializes the storage backend for the auth. service
+// initAuthStorage initializes the storage backend for the auth service.
 func (process *TeleportProcess) initAuthStorage() (bk backend.Backend, err error) {
 	bc := &process.Config.Auth.StorageConfig
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -241,6 +241,11 @@ func (r *RoleV2) CheckAndSetDefaults() error {
 	return nil
 }
 
+func (r *RoleV2) String() string {
+	return fmt.Sprintf("Role(Name=%v,MaxSessionTTL=%v,Logins=%v,NodeLabels=%v,Namespaces=%v,Resources=%v)",
+		r.GetName(), r.GetMaxSessionTTL(), r.GetLogins(), r.GetNodeLabels(), r.GetNamespaces(), r.GetResources())
+}
+
 // RoleSpecV2 is role specification for RoleV2
 type RoleSpecV2 struct {
 	// MaxSessionTTL is a maximum SSH or Web session TTL


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/795, Teleport uses static and dynamic configuration with the static configuration sometimes overriding the dynamic configuration. This PR adds support for `dynamic_config` which controls what the source of truth for an auth server is: configuration files on disk or what's stored in the backend.

**Implementation**

_Code Updates_

* The value of `default_config` is determined as so:
  * If explicitly set in `config.FileConfig`, take that value.
  * If not explicitly set in `config.FileConfig` then when creating a default `service.Config` set it to `false`.
  * If a backend is defined in `config.FileConfig` then update the value in `service.Config` to `true.`
* In `lib/auth/init.go` the `Init` function has been updated. Now resources always uploaded except if `dynamicConfig` is `true` and it is not the first start.
* In `lib/auth/init.go` the `Init` function has been updated to never delete resources.
* Resource migration has been consolidated to the `migrateLegacyResources` function.
* All references to seed config have been removed.

_Documentation Updates_

* The `dynamic_config` has been added to the Admin Guide with an explanation of what it does.

**Focus Areas For Review**

* Logic changes: Changed when resources and uploaded to the backend. Removed all code for deleting resources.
* Logic changes: Refactored migration logic in `migrateCertAuthority` and `migrateUsers`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/795