### PR TITLE
Use ConvertResponse to detect trace.AccessDenied

### DIFF
--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/services"
 
 	"github.com/gravitational/roundtrip"
@@ -231,7 +232,7 @@ func (s *AuthServer) sendValidateRequestToProxy(host string, validateRequest *Va
 		return nil, trace.Wrap(err)
 	}
 
-	out, err := clt.PostJSON(clt.Endpoint("webapi", "trustedclusters", "validate"), validateRequestRaw)
+	out, err := httplib.ConvertResponse(clt.PostJSON(clt.Endpoint("webapi", "trustedclusters", "validate"), validateRequestRaw))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1466,7 +1466,7 @@ func (h *Handler) validateTrustedCluster(w http.ResponseWriter, r *http.Request,
 
 	validateResponse, err := h.auth.ValidateTrustedCluster(validateRequest)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.AccessDenied("invalid token")
 	}
 
 	validateResponseRaw, err := validateResponse.ToRaw()


### PR DESCRIPTION
**Purpose**

When requesting token validation, we were not checking the response code or error, any response back was treated as success. This PR changes that behavior and calls `httplib.ConvertResponse` so a unsuccessful request is detected in `error`.

**Implementation**

* Wrap `clt.PostJSON` in `httplib.ConvertResponse`.
* Return `trace.AccessDenied` in the proxy.