### PR TITLE
Load Keys into System Agent and Exit

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1142,14 +1142,17 @@ func loopbackPool(proxyAddr string) *x509.CertPool {
 func connectToSSHAgent() agent.Agent {
 	socketPath := os.Getenv(teleport.SSHAuthSock)
 	if socketPath == "" {
-		log.Infof("%v is not set. Is local SSH agent running?", teleport.SSHAuthSock)
+		log.Infof("[KEY AGENT] %v is not set. Try running eval `ssh-agent` and trying again.", teleport.SSHAuthSock)
 		return nil
 	}
+
 	conn, err := net.Dial("unix", socketPath)
 	if err != nil {
-		log.Errorf("cant connect to SSH agent on %s", socketPath)
+		log.Errorf("[KEY AGENT] Unable to connect to SSH agent on socket: %q.", socketPath)
 		return nil
 	}
+
+	log.Infof("[KEY AGENT] Conneced to System Agent: %q", socketPath)
 	return agent.NewClient(conn)
 }
 

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -58,6 +58,8 @@ func NewLocalAgent(keyDir, username string) (a *LocalKeyAgent, err error) {
 		return nil, trace.Wrap(err)
 	}
 
+	log.Infof("[KEY AGENT] Loading %v keys for %q", len(keys), username)
+
 	// load all keys into the agent
 	for _, key := range keys {
 		_, err = a.LoadKey(username, key)
@@ -93,7 +95,7 @@ func (a *LocalKeyAgent) LoadKey(username string, key Key) (*agent.AddedKey, erro
 		for _, agentKey := range agentKeys {
 			err = agents[i].Add(*agentKey)
 			if err != nil {
-				log.Warnf("Unable to communicate with agent and add key: %v", err)
+				log.Warnf("[KEY AGENT] Unable to communicate with agent and add key: %v", err)
 			}
 		}
 	}

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -183,9 +183,9 @@ func (fs *FSLocalKeyStore) GetKey(host, username string) (*Key, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.Debugf("returning cert %v valid until %v", certFile, certExpiration)
+	log.Debugf("[KEYSTORE] Returning certificate %q valid until %q", certFile, certExpiration)
 	if certExpiration.Before(time.Now()) {
-		log.Infof("TTL expired (%v) for session key %v", certExpiration, dirPath)
+		log.Infof("[KEYSTORE] TTL expired (%v) for session key %v", certExpiration, dirPath)
 		os.RemoveAll(dirPath)
 		return nil, trace.NotFound("session keys for %s are not found", host)
 	}


### PR DESCRIPTION
**Purpose**

At the moment `tsh agent` creates a new agent (and loads keys into the system agent already running) but never returns control back to the user. This works most of the time, but this is not ideal when calling `tsh agent` from a script like `~/.bash_profile` where you want to load keys into the system agent then quit so you can gain control again.

This PR changes this behavior by adding a `--load` flag to `tsh`. When set `tsh agent` will load Teleport keys into the existing system agent then exit.

**Implementation**

* Added a `--load` flag to `tsh`.
* Moved code around in `onAgentStart` so keys are loaded first then if in "system agent only" mode, exit.

**Example Usage**
 
```bash
# verify we don't have an ssh agent running already
$ echo $SSH_AUTH_SOCK

# start a new agent and verify that we have no keys loaded
$ eval `ssh-agent`
Agent pid 36
$ ssh-add -l
The agent has no identities.

# use tsh agent to load keys and exit
$ tsh --proxy=localhost --user rjones agent --load
# check our keys were loaded
$: ssh-add -l
2048 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00 teleport:rjones (RSA-CERT)
2048 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00 teleport:rjones (RSA)

# verify calling tsh agent multiple times with --load doesn't cause
# double (multiple) loading of keys
$ tsh --proxy=localhost --user rjones agent --load
$ ssh-add -l
2048 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00 teleport:rjones (RSA-CERT)
2048 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00 teleport:rjones (RSA)
```