### PR TITLE
TTL Cert

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -369,12 +369,17 @@ func (a *AuthWithRoles) GenerateUserCert(key []byte, username string, ttl time.D
 			return nil, trace.Wrap(err)
 		}
 	}
+
+	// adjust session ttl to the smaller of two values: the session
+	// ttl requested in tsh or the session ttl for the role.
+	sessionTTL := checker.AdjustSessionTTL(ttl)
+
 	// check signing TTL and return a list of allowed logins
-	allowedLogins, err := checker.CheckLogins(ttl)
+	allowedLogins, err := checker.CheckLogins(sessionTTL)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GenerateUserCert(key, username, allowedLogins, ttl)
+	return a.authServer.GenerateUserCert(key, username, allowedLogins, sessionTTL)
 }
 
 func (a *AuthWithRoles) CreateSignupToken(user services.UserV1) (token string, e error) {

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -296,8 +296,8 @@ type AccessChecker interface {
 	// CheckLogins checks if role set can login up to given duration
 	// and returns a combined list of allowed logins
 	CheckLogins(ttl time.Duration) ([]string, error)
-	// AdjustSessionTTL will reduce the requested ttl to lowes max allowed TTL
-	// for this role set, otherwise it returns ttl unchanges
+	// AdjustSessionTTL will reduce the requested ttl to lowest max allowed TTL
+	// for this role set, otherwise it returns ttl unchanged
 	AdjustSessionTTL(ttl time.Duration) time.Duration
 	// CheckAgentForward checks if the role can request agent forward for this user
 	CheckAgentForward(login string) error

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "2.0.0-alpha.7"
+	Version = "2.0.0-beta.1"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
## Description

Problem:

Set up a user role with max session ttl < 12 hours, e.g. 8 hours
Assign only this role to user
tsh login will not work with error `can not request certificate for 12h`

Expected outcome:

certificate should be issued for 8 hours
