### PR TITLE
User CA Export

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -721,15 +721,20 @@ have to configure `sshd` to trust Teleport CA.
 Export the Teleport CA certificate into a file:
 
 ```bash
-> tctl auth --type=user export > cluster-ca.pub
+> tctl auth --type=user export > teleport-user-ca.pub
 ```
 
-Copy this file to every node running `sshd`, for example into `/etc/ssh/teleport-ca.pub`
-Then update the `sshd` configuration, usually `/etc/ssh/sshd_config`:
+* To allow access per-user, append the contents of `teleport-user-ca.pub` to
+  `~/.ssh/authorized_keys`.
+* To allow access for all users:
+  * Edit `teleport-user-ca.pub` and remove `cert-authority` from the start of line.
+  * Copy `teleport-user-ca.pub` to `/etc/ssh/teleport-user-ca.pub`
+  * Update `sshd` configuration (usually `/etc/ssh/sshd_config`) to point to this
+  file:
 
-```
-TrustedUserCAKeys /etc/ssh/user-ca.pub
-```
+    ```
+    TrustedUserCAKeys /etc/ssh/teleport-user-ca.pub
+    ```
 
 ### Integrating with Ansible
 

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "2.0.0-beta.1"
+	Version = "2.0.0-beta.2"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
**Purpose**

SSH supports two different formats for storing a user certificate authority, Teleport was not exporting user certificates in either format. This made integrating `sshd` nodes impossible because user certificates could not be verified.

**Implementation**

OpenSSH supports two different formats for user certificates:

* For global settings, set `TrustedUserCAKeys` in `/etc/ssh/sshd_config` and point to a file with the key bytes only.
* For per-user settings, add a line to `~/.ssh/authorized_keys` that has the key bytes prefixed with `cert-authority`.

`tctl auth --type=user export` has been updated to now export user certificate authorities using the per-user style. The Admin Guide has been updated to reflect this as well as containing instructions on to change it to the global style.

