### PR TITLE
Unload stale keys

### DIFF
--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -52,6 +52,13 @@ func NewLocalAgent(keyDir, username string) (a *LocalKeyAgent, err error) {
 		sshAgent: connectToSSHAgent(),
 	}
 
+	// unload all teleport keys from the agent first to ensure
+	// we don't leave stale keys in the agent
+	err = a.UnloadKeys()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// read all keys from disk (~/.tsh usually)
 	keys, err := a.GetKeys(username)
 	if err != nil {
@@ -123,6 +130,35 @@ func (a *LocalKeyAgent) UnloadKey(username string) error {
 		// remove any teleport keys we currently have loaded in the agent for this user
 		for _, key := range keyList {
 			if key.Comment == fmt.Sprintf("teleport:%v", username) {
+				err = agents[i].Remove(key)
+				if err != nil {
+					log.Warnf("Unable to communicate with agent and remove key: %v", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// UnloadKeys will unload all Teleport keys from the teleport agent as well as the system agent.
+func (a *LocalKeyAgent) UnloadKeys() error {
+	agents := []agent.Agent{a.Agent}
+	if a.sshAgent != nil {
+		agents = append(agents, a.sshAgent)
+	}
+
+	// iterate over all agents we have
+	for i, _ := range agents {
+		// get a list of all keys in the agent
+		keyList, err := agents[i].List()
+		if err != nil {
+			log.Warnf("Unable to communicate with agent and list keys: %v", err)
+		}
+
+		// remove any teleport keys we currently have loaded in the agent
+		for _, key := range keyList {
+			if strings.HasPrefix(key.Comment, "teleport:") {
 				err = agents[i].Remove(key)
 				if err != nil {
 					log.Warnf("Unable to communicate with agent and remove key: %v", err)


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/843 at the moment we update keys in the system agent if we have a newer key but we never unload stale keys. This PR changes this behavior by unloading all Teleport keys before loading new keys in the agent.

This will allow users to call `tsh agent --load` in their `~/.bash_profile` and it will always keep the system agent updated with active certificates.

**Implementation**

When creating a new local agent, call `UnloadKeys` to remove all Teleport keys in the system agent. We find Teleport specific keys by looking at the comment field of each key for the prefix `teleport:` and remove it.

**Related Issues**

Fixed in https://github.com/gravitational/teleport/issues/843