### PR TITLE
Ansible Regressions

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -367,6 +367,11 @@
 			"Rev": "16b258d86efc53ac5cf3e550604f566c32624fab"
 		},
 		{
+			"ImportPath": "github.com/mattn/go-shellwords",
+			"Comment": "v1.0.2",
+			"Rev": "005a0944d84452842197c2108bd9168ced206f78"
+		},
+		{
 			"ImportPath": "github.com/mdp/rsc/gf256",
 			"Rev": "90f07065088deccf50b28eb37c93dad3078c0f3c"
 		},
@@ -433,6 +438,14 @@
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/curve25519",
+			"Rev": "453249f01cfeb54c3d549ddb75ff152ca243f9d8"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/ed25519",
+			"Rev": "453249f01cfeb54c3d549ddb75ff152ca243f9d8"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/ed25519/internal/edwards25519",
 			"Rev": "453249f01cfeb54c3d549ddb75ff152ca243f9d8"
 		},
 		{
@@ -511,14 +524,6 @@
 			"ImportPath": "k8s.io/client-go/1.4/pkg/util/yaml",
 			"Comment": "v1.4.0",
 			"Rev": "3a5b96cfd3d3ff1d53d979b4297c4f3b869aab09"
-		},
-		{
-			"ImportPath": "golang.org/x/crypto/ed25519",
-			"Rev": "453249f01cfeb54c3d549ddb75ff152ca243f9d8"
-		},
-		{
-			"ImportPath": "golang.org/x/crypto/ed25519/internal/edwards25519",
-			"Rev": "453249f01cfeb54c3d549ddb75ff152ca243f9d8"
 		}
 	]
 }

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -959,6 +959,14 @@ func (s *Server) handlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *ctx) error 
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	// if the caller asked for an invalid sized pty (like ansible
+	// which asks for a 0x0 size) update the request with defaults
+	err = r.CheckAndSetDefaults()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	params, err = rsession.NewTerminalParamsFromUint32(r.W, r.H)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/sshutils/req.go
+++ b/lib/sshutils/req.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package sshutils
 
+import (
+	"github.com/gravitational/teleport"
+
+	"github.com/gravitational/trace"
+)
+
 // EnvReqParams are parameters for env request
 type EnvReqParams struct {
 	Name  string
@@ -40,6 +46,31 @@ type PTYReqParams struct {
 	Modes string
 }
 
+// Check validates PTY parameters.
+func (p *PTYReqParams) Check() error {
+	if p.W > maxSize || p.W < minSize {
+		return trace.BadParameter("bad width: %v", p.W)
+	}
+	if p.H > maxSize || p.H < minSize {
+		return trace.BadParameter("bad height: %v", p.H)
+	}
+
+	return nil
+}
+
+// CheckAndSetDefaults validates PTY parameters and ensures parameters
+// are within default values.
+func (p *PTYReqParams) CheckAndSetDefaults() error {
+	if p.W > maxSize || p.W < minSize {
+		p.W = teleport.DefaultTerminalWidth
+	}
+	if p.H > maxSize || p.H < minSize {
+		p.H = teleport.DefaultTerminalHeight
+	}
+
+	return nil
+}
+
 const (
 	// SessionEnvVar is environment variable for SSH session
 	SessionEnvVar = "TELEPORT_SESSION"
@@ -51,4 +82,9 @@ const (
 	PTYReq = "pty-req"
 	// AgentReq is ssh agent requesst
 	AgentReq = "auth-agent-req@openssh.com"
+)
+
+const (
+	minSize = 1
+	maxSize = 4096
 )

--- a/vendor/github.com/mattn/go-shellwords/.travis.yml
+++ b/vendor/github.com/mattn/go-shellwords/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+  - tip
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+script:
+    - $HOME/gopath/bin/goveralls -repotoken 2FMhp57u8LcstKL9B190fLTcEnBtAAiEL

--- a/vendor/github.com/mattn/go-shellwords/README.md
+++ b/vendor/github.com/mattn/go-shellwords/README.md
@@ -1,0 +1,47 @@
+# go-shellwords
+
+[![Coverage Status](https://coveralls.io/repos/mattn/go-shellwords/badge.png?branch=master)](https://coveralls.io/r/mattn/go-shellwords?branch=master)
+[![Build Status](https://travis-ci.org/mattn/go-shellwords.svg?branch=master)](https://travis-ci.org/mattn/go-shellwords)
+
+Parse line as shell words.
+
+## Usage
+
+```go
+args, err := shellwords.Parse("./foo --bar=baz")
+// args should be ["./foo", "--bar=baz"]
+```
+
+```go
+os.Setenv("FOO", "bar")
+p := shellwords.NewParser()
+p.ParseEnv = true
+args, err := p.Parse("./foo $FOO")
+// args should be ["./foo", "bar"]
+```
+
+```go
+p := shellwords.NewParser()
+p.ParseBacktick = true
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+```go
+shellwords.ParseBacktick = true
+p := shellwords.NewParser()
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+# Thanks
+
+This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse::CommandLine).
+
+# License
+
+under the MIT License: http://mattn.mit-license.org/2014
+
+# Author
+
+Yasuhiro Matsumoto (a.k.a mattn)

--- a/vendor/github.com/mattn/go-shellwords/shellwords.go
+++ b/vendor/github.com/mattn/go-shellwords/shellwords.go
@@ -1,0 +1,145 @@
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"regexp"
+)
+
+var (
+	ParseEnv      bool = false
+	ParseBacktick bool = false
+)
+
+var envRe = regexp.MustCompile(`\$({[a-zA-Z0-9_]+}|[a-zA-Z0-9_]+)`)
+
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\r', '\n':
+		return true
+	}
+	return false
+}
+
+func replaceEnv(s string) string {
+	return envRe.ReplaceAllStringFunc(s, func(s string) string {
+		s = s[1:]
+		if s[0] == '{' {
+			s = s[1 : len(s)-1]
+		}
+		return os.Getenv(s)
+	})
+}
+
+type Parser struct {
+	ParseEnv      bool
+	ParseBacktick bool
+	Position      int
+}
+
+func NewParser() *Parser {
+	return &Parser{ParseEnv, ParseBacktick, 0}
+}
+
+func (p *Parser) Parse(line string) ([]string, error) {
+	args := []string{}
+	buf := ""
+	var escaped, doubleQuoted, singleQuoted, backQuote bool
+	backtick := ""
+
+	pos := -1
+	got := false
+
+loop:
+	for i, r := range line {
+		if escaped {
+			buf += string(r)
+			escaped = false
+			continue
+		}
+
+		if r == '\\' {
+			if singleQuoted {
+				buf += string(r)
+			} else {
+				escaped = true
+			}
+			continue
+		}
+
+		if isSpace(r) {
+			if singleQuoted || doubleQuoted || backQuote {
+				buf += string(r)
+				backtick += string(r)
+			} else if got {
+				if p.ParseEnv {
+					buf = replaceEnv(buf)
+				}
+				args = append(args, buf)
+				buf = ""
+				got = false
+			}
+			continue
+		}
+
+		switch r {
+		case '`':
+			if !singleQuoted && !doubleQuoted {
+				if p.ParseBacktick {
+					if backQuote {
+						out, err := shellRun(backtick)
+						if err != nil {
+							return nil, err
+						}
+						buf = out
+					}
+					backtick = ""
+					backQuote = !backQuote
+					continue
+				}
+				backtick = ""
+				backQuote = !backQuote
+			}
+		case '"':
+			if !singleQuoted {
+				doubleQuoted = !doubleQuoted
+				continue
+			}
+		case '\'':
+			if !doubleQuoted {
+				singleQuoted = !singleQuoted
+				continue
+			}
+		case ';', '&', '|', '<', '>':
+			if !(escaped || singleQuoted || doubleQuoted || backQuote) {
+				pos = i
+				break loop
+			}
+		}
+
+		got = true
+		buf += string(r)
+		if backQuote {
+			backtick += string(r)
+		}
+	}
+
+	if got {
+		if p.ParseEnv {
+			buf = replaceEnv(buf)
+		}
+		args = append(args, buf)
+	}
+
+	if escaped || singleQuoted || doubleQuoted || backQuote {
+		return nil, errors.New("invalid command line string")
+	}
+
+	p.Position = pos
+
+	return args, nil
+}
+
+func Parse(line string) ([]string, error) {
+	return NewParser().Parse(line)
+}

--- a/vendor/github.com/mattn/go-shellwords/util_posix.go
+++ b/vendor/github.com/mattn/go-shellwords/util_posix.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line string) (string, error) {
+	shell := os.Getenv("SHELL")
+	b, err := exec.Command(shell, "-c", line).Output()
+	if err != nil {
+		return "", errors.New(err.Error() + ":" + string(b))
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/vendor/github.com/mattn/go-shellwords/util_windows.go
+++ b/vendor/github.com/mattn/go-shellwords/util_windows.go
@@ -1,0 +1,17 @@
+package shellwords
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line string) (string, error) {
+	shell := os.Getenv("COMSPEC")
+	b, err := exec.Command(shell, "/c", line).Output()
+	if err != nil {
+		return "", errors.New(err.Error() + ":" + string(b))
+	}
+	return strings.TrimSpace(string(b)), nil
+}


### PR DESCRIPTION
**Purpose**

Two Ansible regressions exist:

1. When running a playbook, Ansible returns `bad widthPTY allocation request failed`. This is because Ansible requests a `0x0` terminal which Teleport considers invalid.
2. As covered in https://github.com/gravitational/teleport/issues/849, when running a playbook, Ansible returns an error that looks like:  `-p: 1: -p: Syntax error: Unterminated quoted string`. This is because Ansible runs a command that looks something like this `'/bin/sh -c "mkdir -p /tmp"'` and Teleport uses `strings.Split(" ")` instead of shell aware splitting.

**Implementation**

* The first issue, requesting a terminal of size `0x0`, is solved by returning a default sized terminal if an invalid size is requested.
* The second is fixed by using a shell aware splitting function. This way `'/bin/sh -c "mkdir -p /tmp"'` is split into `["/bin/sh", "-c", "mkdir -p /tmp"]` instead of `["/bin/sh", "-c", "mkdir", "-p", "/tmp"]`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/849