### PR TITLE
Add support for ClusterAuthPreference and UniversalSecondFactor Get/Set from tctl

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -263,6 +263,10 @@ func ParseShortcut(in string) (string, error) {
 		return KindReverseTunnel, nil
 	case "trusted_cluster", "tc":
 		return KindTrustedCluster, nil
+	case "cluster_authentication_preferences", "cap":
+		return KindClusterAuthPreference, nil
+	case "universal_second_factor", "u2f":
+		return KindUniversalSecondFactor, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %v", in)
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -402,3 +402,71 @@ func (c *trustedClusterCollection) writeYAML(w io.Writer) error {
 	_, err = w.Write(data)
 	return trace.Wrap(err)
 }
+
+type authPreferenceCollection struct {
+	services.AuthPreference
+}
+
+func (c *authPreferenceCollection) writeText(w io.Writer) error {
+	t := goterm.NewTable(0, 10, 5, ' ', 0)
+	printHeader(t, []string{"Type", "Second Factor"})
+	fmt.Fprintf(t, "%v\t%v\n", c.GetType(), c.GetSecondFactor())
+	_, err := io.WriteString(w, t.String())
+	return trace.Wrap(err)
+}
+
+func (c *authPreferenceCollection) writeJSON(w io.Writer) error {
+	data, err := json.MarshalIndent(c.toMarshal(), "", "    ")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = w.Write(data)
+	return trace.Wrap(err)
+}
+
+func (c *authPreferenceCollection) toMarshal() interface{} {
+	return c
+}
+
+func (c *authPreferenceCollection) writeYAML(w io.Writer) error {
+	data, err := yaml.Marshal(c.toMarshal())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = w.Write(data)
+	return trace.Wrap(err)
+}
+
+type universalSecondFactorCollection struct {
+	services.UniversalSecondFactor
+}
+
+func (c *universalSecondFactorCollection) writeText(w io.Writer) error {
+	t := goterm.NewTable(0, 10, 5, ' ', 0)
+	printHeader(t, []string{"App ID", "Facets"})
+	fmt.Fprintf(t, "%v\t%q\n", c.GetAppID(), c.GetFacets())
+	_, err := io.WriteString(w, t.String())
+	return trace.Wrap(err)
+}
+
+func (c *universalSecondFactorCollection) writeJSON(w io.Writer) error {
+	data, err := json.MarshalIndent(c.toMarshal(), "", "    ")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = w.Write(data)
+	return trace.Wrap(err)
+}
+
+func (c *universalSecondFactorCollection) toMarshal() interface{} {
+	return c
+}
+
+func (c *universalSecondFactorCollection) writeYAML(w io.Writer) error {
+	data, err := yaml.Marshal(c.toMarshal())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = w.Write(data)
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -992,6 +992,24 @@ func (u *CreateCommand) Create(client *auth.TunClient) error {
 				return trace.Wrap(err)
 			}
 			fmt.Printf("trusted cluster %q upserted\n", tc.GetName())
+		case services.KindClusterAuthPreference:
+			cap, err := services.GetAuthPreferenceMarshaler().Unmarshal(raw.Raw)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := client.SetClusterAuthPreference(cap); err != nil {
+				return trace.Wrap(err)
+			}
+			fmt.Printf("cluster auth preference upserted\n")
+		case services.KindUniversalSecondFactor:
+			universalSecondFactor, err := services.GetUniversalSecondFactorMarshaler().Unmarshal(raw.Raw)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if err := client.SetUniversalSecondFactor(universalSecondFactor); err != nil {
+				return trace.Wrap(err)
+			}
+			fmt.Printf("universal second factor upserted\n")
 		case "":
 			return trace.BadParameter("missing resource kind")
 		default:
@@ -1140,6 +1158,18 @@ func (g *GetCommand) getCollection(client auth.ClientI) (collection, error) {
 			return nil, trace.Wrap(err)
 		}
 		return &trustedClusterCollection{trustedClusters: []services.TrustedCluster{trustedCluster}}, nil
+	case services.KindClusterAuthPreference:
+		cap, err := client.GetClusterAuthPreference()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &authPreferenceCollection{AuthPreference: cap}, nil
+	case services.KindUniversalSecondFactor:
+		universalSecondFactor, err := client.GetUniversalSecondFactor()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &universalSecondFactorCollection{UniversalSecondFactor: universalSecondFactor}, nil
 	}
 
 	return nil, trace.BadParameter("'%v' is not supported", g.ref.Kind)


### PR DESCRIPTION
**Purpose**

Support getting and setting `ClusterAuthPreference` and `UniversalSecondFactor` resources from `tctl` so they can be viewed and changed at runtime.

**Examples**

To list current settings:

```
tctl get cap
tctl get u2f
```

To update `ClusterAuthPreference` create the below file then run `tctl create -f cap.yaml`.

```
kind: cluster_auth_preference
version: v2
metadata:
  description: ""
  name: "cluster-auth-preference"
  namespace: "default"
spec:
  type: local
  second_factor: u2f
```

To update `UniversalSecondFactor` create the below file then run `tctl create -f u2f.yaml`.

```
kind: universal_second_factor
version: v2
metadata:
  description: ""
  name: "universal-second-factor"
  namespace: "default"
spec:
  app_id: "https://localhost:3080"
  facets:
  - "https://localhost"
  - "https://localhost:3080"
```
