### PR TITLE
Always create default namespace.

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -197,13 +197,14 @@ func Init(cfg InitConfig, dynamicConfig bool) (*AuthServer, *Identity, error) {
 			}
 			log.Infof("[INIT] Created Reverse Tunnel: %v", tunnel)
 		}
-
-		err = asrv.UpsertNamespace(services.NewNamespace(defaults.Namespace))
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-		log.Infof("[INIT] Created Namespace: %q", defaults.Namespace)
 	}
+
+	// always create the default namespace
+	err = asrv.UpsertNamespace(services.NewNamespace(defaults.Namespace))
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	log.Infof("[INIT] Created Namespace: %q", defaults.Namespace)
 
 	// generate a user certificate authority if it doesn't exist
 	if _, err := asrv.GetCertAuthority(services.CertAuthID{DomainName: cfg.DomainName, Type: services.UserCA}, false); err != nil {


### PR DESCRIPTION
**Purpose**

Always create a default namespace. If we don't always create it, migration from 1.0 to 2.0 breaks when using a defined backend (in that situation dynamic config is true which leads to the default namespace not being created).

**Implementation**

* Move creation of the default namespace outside of the `dynamicConfig && firstStart` block.