### PR TITLE
Allow Password Only Users

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -404,9 +404,14 @@ func (a *AuthWithRoles) GetSignupU2FRegisterRequest(token string) (u2fRegisterRe
 	return a.authServer.CreateSignupU2FRegisterRequest(token)
 }
 
-func (a *AuthWithRoles) CreateUserWithToken(token, password, hotpToken string) (services.WebSession, error) {
+func (a *AuthWithRoles) CreateUserWithOTP(token, password, otpToken string) (services.WebSession, error) {
 	// tokens are their own authz mechanism, no need to double check
-	return a.authServer.CreateUserWithToken(token, password, hotpToken)
+	return a.authServer.CreateUserWithOTP(token, password, otpToken)
+}
+
+func (a *AuthWithRoles) CreateUserWithoutOTP(token string, password string) (services.WebSession, error) {
+	// tokens are their own authz mechanism, no need to double check
+	return a.authServer.CreateUserWithoutOTP(token, password)
 }
 
 func (a *AuthWithRoles) CreateUserWithU2FToken(token string, password string, u2fRegisterResponse u2f.RegisterResponse) (services.WebSession, error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -796,14 +796,27 @@ func (c *Client) GetSignupU2FRegisterRequest(token string) (u2fRegisterRequest *
 	return &u2fRegReq, nil
 }
 
-// CreateUserWithToken creates account with provided token and password.
+// CreateUserWithOTP creates account with provided token and password.
 // Account username and OTP key are taken from token data.
 // Deletes token after account creation.
-func (c *Client) CreateUserWithToken(token, password, otpToken string) (services.WebSession, error) {
+func (c *Client) CreateUserWithOTP(token, password, otpToken string) (services.WebSession, error) {
 	out, err := c.PostJSON(c.Endpoint("signuptokens", "users"), createUserWithTokenReq{
 		Token:    token,
 		Password: password,
 		OTPToken: otpToken,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return services.GetWebSessionMarshaler().UnmarshalWebSession(out.Bytes())
+}
+
+// CreateUserWithoutOTP validates a given token creates a user
+// with the given password and deletes the token afterwards.
+func (c *Client) CreateUserWithoutOTP(token string, password string) (services.WebSession, error) {
+	out, err := c.PostJSON(c.Endpoint("signuptokens", "users"), createUserWithTokenReq{
+		Token:    token,
+		Password: password,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1337,10 +1350,14 @@ type IdentityService interface {
 	// returns a secure web session id.
 	SignIn(user string, password []byte) (services.WebSession, error)
 
-	// CreateUserWithToken creates account with provided token and password.
+	// CreateUserWithOTP creates account with provided token and password.
 	// Account username and OTP key are taken from token data.
 	// Deletes token after account creation.
-	CreateUserWithToken(token, password, otpToken string) (services.WebSession, error)
+	CreateUserWithOTP(token, password, otpToken string) (services.WebSession, error)
+
+	// CreateUserWithoutOTP validates a given token creates a user
+	// with the given password and deletes the token afterwards.
+	CreateUserWithoutOTP(token string, password string) (services.WebSession, error)
 
 	// GenerateToken creates a special provisioning token for a new SSH server
 	// that is valid for ttl period seconds.

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -208,7 +208,8 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV2{
 				Namespaces: []string{services.Wildcard},
 				Resources: map[string][]string{
-					services.KindAuthServer: services.RO(),
+					services.KindAuthServer:            services.RO(),
+					services.KindClusterAuthPreference: services.RO(),
 				},
 			})
 	case teleport.RoleAdmin:

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -290,6 +290,14 @@ func (s *TunSuite) TestWebCreatingNewUserValidClientInvalidToken(c *C) {
 // valid signup token and then tries to get a valid token back. Then try and login
 // as the new user. This should all succeed.
 func (s *TunSuite) TestWebCreatingNewUserValidClientValidToken(c *C) {
+	ap, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
+		Type:         "local",
+		SecondFactor: "otp",
+	})
+	c.Assert(err, IsNil)
+	err = s.a.SetClusterAuthPreference(ap)
+	c.Assert(err, IsNil)
+
 	c.Assert(s.a.UpsertCertAuthority(
 		suite.NewTestCA(services.UserCA, "localhost"), backend.Forever), IsNil)
 
@@ -319,7 +327,7 @@ func (s *TunSuite) TestWebCreatingNewUserValidClientValidToken(c *C) {
 	c.Assert(err, IsNil)
 
 	// create a user
-	_, err = clt.CreateUserWithToken(token, password, validToken)
+	_, err = clt.CreateUserWithOTP(token, password, validToken)
 	c.Assert(err, IsNil)
 
 	// delete token so we can re-use it without messing with clocks
@@ -344,6 +352,14 @@ func (s *TunSuite) TestWebCreatingNewUserValidClientValidToken(c *C) {
 // using a valid signup token and then uses a valid token to create a user. Then
 // try to create another user. This should fail.
 func (s *TunSuite) TestWebCreatingNewUserValidClientValidTokenReuseToken(c *C) {
+	ap, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
+		Type:         "local",
+		SecondFactor: "otp",
+	})
+	c.Assert(err, IsNil)
+	err = s.a.SetClusterAuthPreference(ap)
+	c.Assert(err, IsNil)
+
 	c.Assert(s.a.UpsertCertAuthority(
 		suite.NewTestCA(services.UserCA, "localhost"), backend.Forever), IsNil)
 
@@ -367,11 +383,11 @@ func (s *TunSuite) TestWebCreatingNewUserValidClientValidTokenReuseToken(c *C) {
 	c.Assert(err, IsNil)
 
 	// first time we should be able to create a user
-	_, err = clt.CreateUserWithToken(token, validPassword, validToken)
+	_, err = clt.CreateUserWithOTP(token, validPassword, validToken)
 	c.Assert(err, IsNil)
 
 	// second time it should fail
-	_, err = clt.CreateUserWithToken(token, validPassword, validToken)
+	_, err = clt.CreateUserWithOTP(token, validPassword, validToken)
 	c.Assert(err, NotNil)
 
 	// signup token should be gone now

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1005,8 +1005,8 @@ func (tc *TeleportClient) localLogin(secondFactor string, pub []byte) (*SSHLogin
 	var response *SSHLoginResponse
 
 	switch secondFactor {
-	case teleport.OTP, teleport.TOTP, teleport.HOTP:
-		response, err = tc.directLogin(pub)
+	case teleport.OFF, teleport.OTP, teleport.TOTP, teleport.HOTP:
+		response, err = tc.directLogin(secondFactor, pub)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1045,13 +1045,26 @@ func (tc *TeleportClient) AddKey(host string, key *Key) (*CertAuthMethod, error)
 }
 
 // directLogin asks for a password + HOTP token, makes a request to CA via proxy
-func (tc *TeleportClient) directLogin(pub []byte) (*SSHLoginResponse, error) {
+func (tc *TeleportClient) directLogin(secondFactorType string, pub []byte) (*SSHLoginResponse, error) {
+	var err error
+
 	httpsProxyHostPort := tc.Config.ProxyWebHostPort()
 	certPool := loopbackPool(httpsProxyHostPort)
 
-	password, otpToken, err := tc.AskPasswordAndOTP()
+	var password string
+	var otpToken string
+
+	password, err = tc.AskPassword()
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	// only ask for a second factor if it's enabled
+	if secondFactorType != teleport.OFF {
+		otpToken, err = tc.AskOTP()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// ask the CA (via proxy) to sign our public key:
@@ -1165,22 +1178,15 @@ func Username() (string, error) {
 	return u.Username, nil
 }
 
-// AskPasswordAndOTP prompts the user to enter the password + OTP 2nd factor
-func (tc *TeleportClient) AskPasswordAndOTP() (pwd string, token string, err error) {
-	fmt.Printf("Enter password for Teleport user %v:\n", tc.Config.Username)
-	pwd, err = passwordFromConsole()
-	if err != nil {
-		fmt.Fprintln(tc.Stderr, err)
-		return "", "", trace.Wrap(err)
-	}
-
+// AskOTP prompts the user to enter the OTP token.
+func (tc *TeleportClient) AskOTP() (token string, err error) {
 	fmt.Printf("Enter your OTP token:\n")
 	token, err = lineFromConsole()
 	if err != nil {
 		fmt.Fprintln(tc.Stderr, err)
-		return "", "", trace.Wrap(err)
+		return "", trace.Wrap(err)
 	}
-	return pwd, token, nil
+	return token, nil
 }
 
 // AskPassword prompts the user to enter the password

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -73,6 +73,7 @@ type WebSuite struct {
 	srvID       string
 	srvHostPort string
 	bk          backend.Backend
+	authServer  *auth.AuthServer
 	roleAuth    *auth.AuthWithRoles
 	dir         string
 	user        string
@@ -141,7 +142,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	trust := local.NewCAService(s.bk)
 
 	s.domainName = "localhost"
-	authServer := auth.NewAuthServer(&auth.InitConfig{
+	s.authServer = auth.NewAuthServer(&auth.InitConfig{
 		Backend:    s.bk,
 		Authority:  authority.New(),
 		DomainName: s.domainName,
@@ -155,7 +156,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		SecondFactor: teleport.U2F,
 	})
 	c.Assert(err, IsNil)
-	err = authServer.SetClusterAuthPreference(cap)
+	err = s.authServer.SetClusterAuthPreference(cap)
 	c.Assert(err, IsNil)
 
 	// configure u2f
@@ -164,7 +165,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		Facets: []string{"https://" + s.domainName},
 	})
 	c.Assert(err, IsNil)
-	err = authServer.SetUniversalSecondFactor(universalSecondFactor)
+	err = s.authServer.SetUniversalSecondFactor(universalSecondFactor)
 	c.Assert(err, IsNil)
 
 	teleUser, err := services.NewUser(s.user)
@@ -172,19 +173,19 @@ func (s *WebSuite) SetUpTest(c *C) {
 	role := services.RoleForUser(teleUser)
 	role.SetLogins([]string{s.user})
 	role.SetResource(services.Wildcard, services.RW())
-	err = authServer.UpsertRole(role)
+	err = s.authServer.UpsertRole(role)
 	c.Assert(err, IsNil)
 
 	teleUser.AddRole(role.GetName())
-	err = authServer.UpsertUser(teleUser)
+	err = s.authServer.UpsertUser(teleUser)
 	c.Assert(err, IsNil)
 
 	authorizer, err := auth.NewAuthorizer(access, identity, trust)
 	c.Assert(err, IsNil)
 
-	c.Assert(authServer.UpsertCertAuthority(
+	c.Assert(s.authServer.UpsertCertAuthority(
 		suite.NewTestCA(services.UserCA, s.domainName), backend.Forever), IsNil)
-	c.Assert(authServer.UpsertCertAuthority(
+	c.Assert(s.authServer.UpsertCertAuthority(
 		suite.NewTestCA(services.HostCA, s.domainName), backend.Forever), IsNil)
 
 	sessionServer, err := sess.New(s.bk)
@@ -195,12 +196,12 @@ func (s *WebSuite) SetUpTest(c *C) {
 
 	c.Assert(err, IsNil)
 
-	s.roleAuth = auth.NewAuthWithRoles(authServer, authContext.Checker, s.user, sessionServer, s.auditLog)
+	s.roleAuth = auth.NewAuthWithRoles(s.authServer, authContext.Checker, s.user, sessionServer, s.auditLog)
 
 	// set up host private key and certificate
-	hpriv, hpub, err := authServer.GenerateKeyPair("")
+	hpriv, hpub, err := s.authServer.GenerateKeyPair("")
 	c.Assert(err, IsNil)
-	hcert, err := authServer.GenerateHostCert(
+	hcert, err := s.authServer.GenerateHostCert(
 		hpub, "00000000-0000-0000-0000-000000000000", s.domainName, s.domainName, teleport.Roles{teleport.RoleAdmin}, 0)
 	c.Assert(err, IsNil)
 
@@ -256,7 +257,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		tunAddr,
 		s.signer,
 		&auth.APIConfig{
-			AuthServer:     authServer,
+			AuthServer:     s.authServer,
 			SessionService: sessionServer,
 			Authorizer:     authorizer,
 			AuditLog:       s.auditLog,
@@ -304,6 +305,15 @@ func (s *WebSuite) SetUpTest(c *C) {
 	addr, _ := utils.ParseAddr(s.webServer.Listener.Addr().String())
 	handler.handler.cfg.ProxyWebAddr = *addr
 	handler.handler.cfg.ProxySSHAddr = proxyAddr
+
+	// reset back to otp
+	cap, err = services.NewAuthPreference(services.AuthPreferenceSpecV2{
+		Type:         teleport.Local,
+		SecondFactor: teleport.OTP,
+	})
+	c.Assert(err, IsNil)
+	err = s.authServer.SetClusterAuthPreference(cap)
+	c.Assert(err, IsNil)
 }
 
 func (s *WebSuite) url() *url.URL {
@@ -1037,6 +1047,5 @@ func (s *WebSuite) TestPing(c *C) {
 	c.Assert(json.Unmarshal(re.Bytes(), &out), IsNil)
 
 	c.Assert(out.Auth.Type, Equals, teleport.Local)
-	c.Assert(out.Auth.SecondFactor, Equals, teleport.U2F)
-	c.Assert(out.Auth.U2F.AppID, Equals, "https://"+s.domainName)
+	c.Assert(out.Auth.SecondFactor, Equals, teleport.OTP)
 }


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/848, at the moment we require a second factor for all local users. This PR changes this behavior and allows you to create users where the only authentication method is passwords.

**Implementation**

* Two new `AuthMethods` have been created to `AuthWebPassword` and `AuthWebPasswordAndOTP` to support password only login and password+otp login.
* `lib/web` has been updated to first check cluster authentication preferences before trying to create or renew a session. Based off the cluster authentication preferences either `AuthWebPassword` or `AuthWebPasswordAndOTP` is used.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/848