### PR TITLE
add principal

### DIFF
--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -239,6 +239,7 @@ func buildPrincipals(hostID string, nodeName string, clusterName string, roles t
 	// nodeName is the DNS name, this is for OpenSSH interoperability
 	if nodeName != "" {
 		principals = append(principals, fmt.Sprintf("%s.%s", nodeName, clusterName))
+		principals = append(principals, nodeName)
 	}
 
 	// deduplicate (in-case hostID and nodeName are the same) and return

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -104,7 +104,7 @@ func (s *NativeSuite) TestBuildPrincipals(c *C) {
 			"proxy",
 			"example.com",
 			teleport.Roles{teleport.RoleProxy},
-			[]string{"22222222-2222-2222-2222-222222222222.example.com", "proxy.example.com"},
+			[]string{"22222222-2222-2222-2222-222222222222.example.com", "proxy.example.com", "proxy"},
 		},
 		// 3 - deduplicate principals
 		{
@@ -112,7 +112,7 @@ func (s *NativeSuite) TestBuildPrincipals(c *C) {
 			"33333333-3333-3333-3333-333333333333",
 			"example.com",
 			teleport.Roles{teleport.RoleProxy},
-			[]string{"33333333-3333-3333-3333-333333333333.example.com"},
+			[]string{"33333333-3333-3333-3333-333333333333.example.com", "33333333-3333-3333-3333-333333333333"},
 		},
 	}
 
@@ -136,7 +136,6 @@ func (s *NativeSuite) TestBuildPrincipals(c *C) {
 		hostCertificate, ok := publicKey.(*ssh.Certificate)
 		c.Assert(ok, Equals, true)
 
-		c.Assert(hostCertificate.ValidPrincipals, HasLen, len(tt.outValidPrincipals))
 		c.Assert(hostCertificate.ValidPrincipals, DeepEquals, tt.outValidPrincipals)
 	}
 }


### PR DESCRIPTION
When proxy is behind a load balancer, the list of principals does not have proxy name, so SSH fails to validate the host.

This PR makes it possible, so users can set `nodename` to the proxy name and get properly issued principal. 