### PR TITLE
Fixed scp regressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all: $(VERSRC) $(BINARIES)
 $(BUILDDIR)/tctl: $(LIBS) $(TOOLS) tool/tctl/*.go
 	go build -o $(BUILDDIR)/tctl -i $(BUILDFLAGS) ./tool/tctl
 
-$(BUILDDIR)/teleport: $(LIBS) tool/teleport/*.go
+$(BUILDDIR)/teleport: $(LIBS) tool/teleport/*.go tool/teleport/common/*.go
 	go build -o $(BUILDDIR)/teleport -i $(BUILDFLAGS) ./tool/teleport
 
 $(BUILDDIR)/tsh: $(LIBS) tool/tsh/*.go


### PR DESCRIPTION
This PR fixes #877. 

## Summary

1. Minor addition to Makefile to pull new .go files from  tool/teleport/common
2. os.Glob() returns an empty list (instead of an error) if the file/pattern is not found, so added check for that.
3. sendFile was prematurely sending 'C' command before trying to open a file. This used to lead to creation of empty files for invalid   sources.

Also, removed some confusing comments.

## Issues

`make test` on OSX does not work for me and it's not related to this PR. This is what I see:

```bash
$ make test
?   	github.com/gravitational/teleport/tool/tsh	[no test files]
signal: killed
FAIL	github.com/gravitational/teleport/tool/tsh/common	0.007s
signal: killed
FAIL	github.com/gravitational/teleport/lib/auth	0.007s
?   	github.com/gravitational/teleport/lib/auth/mocku2f	[no test files]
signal: killed
FAIL	github.com/gravitational/teleport/lib/auth/native	0.006s
...
```
not sure what "signal:killed" means.
