### PR TITLE
Dynamic Roles

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -260,7 +260,7 @@ func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *servic
 		}
 		role := services.RoleForUser(teleUser)
 		role.SetLogins(user.AllowedLogins)
-		err = auth.UpsertRole(role)
+		err = auth.UpsertRole(role, backend.Forever)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/services"
@@ -1308,7 +1309,7 @@ func (s *APIServer) upsertRole(auth ClientI, w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = auth.UpsertRole(role)
+	err = auth.UpsertRole(role, backend.Forever)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -119,7 +119,7 @@ func (s *APISuite) TearDownTest(c *C) {
 }
 
 type clt interface {
-	UpsertRole(services.Role) error
+	UpsertRole(services.Role, time.Duration) error
 	UpsertUser(services.User) error
 }
 
@@ -130,7 +130,7 @@ func createUserAndRole(clt clt, username string, allowedLogins []string) (servic
 	}
 	role := services.RoleForUser(user)
 	role.SetLogins([]string{user.GetName()})
-	err = clt.UpsertRole(role)
+	err = clt.UpsertRole(role, backend.Forever)
 	if err != nil {
 		panic(err)
 	}
@@ -221,7 +221,7 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 
 	// now update role to permit agent forwarding
 	userRole.SetForwardAgent(true)
-	err = s.clt.UpsertRole(userRole)
+	err = s.clt.UpsertRole(userRole, backend.Forever)
 	c.Assert(err, IsNil)
 
 	authorizer, err = NewUserAuthorizer("user1", s.WebS, s.AccessS)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -779,13 +778,38 @@ type OIDCAuthResponse struct {
 	HostSigners []services.CertAuthority `json:"host_signers"`
 }
 
-func (a *AuthServer) createOIDCUser(connector services.OIDCConnector, ident *oidc.Identity, claims jose.Claims) error {
+// buildRoles takes a connector and claims and returns a slice of roles. If the claims
+// match a concrete roles in the connector, those roles are returned directly. If the
+// claims match a template role in the connector, then that role is first created from
+// the template, then returned.
+func (a *AuthServer) buildRoles(connector services.OIDCConnector, claims jose.Claims) ([]string, error) {
 	roles := connector.MapClaims(claims)
 	if len(roles) == 0 {
-		log.Warningf("[OIDC] could not find any of expected claims: %v in the set returned by provider %v: %v",
-			strings.Join(connector.GetClaims(), ","), connector.GetName(), strings.Join(services.GetClaimNames(claims), ","))
-		return trace.AccessDenied("access denied to %v", ident.Email)
+		role, err := connector.RoleFromTemplate(claims)
+		if err != nil {
+			log.Warningf("[OIDC] Unable to map claims to roles or role templates for %q", connector.GetName())
+			return nil, trace.AccessDenied("unable to map claims to roles or role templates for %q", connector.GetName())
+		}
+
+		// upsert templated role
+		err = a.Access.UpsertRole(role)
+		if err != nil {
+			log.Warningf("[OIDC] Unable to upsert templated role for connector: %q", connector.GetName())
+			return nil, trace.AccessDenied("unable to upsert templated role: %q", connector.GetName())
+		}
+
+		roles = []string{role.GetName()}
 	}
+
+	return roles, nil
+}
+
+func (a *AuthServer) createOIDCUser(connector services.OIDCConnector, ident *oidc.Identity, claims jose.Claims) error {
+	roles, err := a.buildRoles(connector, claims)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	log.Debugf("[IDENTITY] %v/%v is a dynamic identity, generating user with roles: %v", connector.GetName(), ident.Email, roles)
 	user, err := services.GetUserMarshaler().GenerateUser(&services.UserV2{
 		Kind:    services.KindUser,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -792,7 +792,7 @@ func (a *AuthServer) buildRoles(connector services.OIDCConnector, ident *oidc.Id
 		}
 
 		// figure out ttl for role. expires = now + ttl  =>  ttl = expires - now
-		ttl := ident.ExpiresAt.Sub(time.Now())
+		ttl := ident.ExpiresAt.Sub(a.clock.Now())
 
 		// upsert templated role
 		err = a.Access.UpsertRole(role, ttl)
@@ -848,7 +848,7 @@ func (a *AuthServer) createOIDCUser(connector services.OIDCConnector, ident *oid
 		}
 	}
 
-	// check if any exisiting user is a non-oidc user, dont override their
+	// check if exisiting user is a non-oidc user, if so, return an error
 	if existingUser != nil {
 		connectorRef := existingUser.GetCreatedBy().Connector
 		if connectorRef == nil || connectorRef.Type != teleport.ConnectorOIDC || connectorRef.ID != connector.GetName() {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/coreos/go-oidc/jose"
+	"github.com/coreos/go-oidc/oidc"
 	"github.com/jonboulle/clockwork"
 	. "gopkg.in/check.v1"
 )
@@ -235,8 +236,13 @@ func (s *AuthSuite) TestBuildRolesInvalid(c *C) {
 	claims.Add("nickname", "foo")
 	claims.Add("full_name", "foo bar")
 
+	// create an identity for the ttl
+	ident := &oidc.Identity{
+		ExpiresAt: time.Now().Add(1 * time.Minute),
+	}
+
 	// try and build roles should be invalid since we have no mappings
-	_, err := s.a.buildRoles(oidcConnector, claims)
+	_, err := s.a.buildRoles(oidcConnector, ident, claims)
 	c.Assert(err, NotNil)
 }
 
@@ -265,8 +271,13 @@ func (s *AuthSuite) TestBuildRolesStatic(c *C) {
 	claims.Add("nickname", "foo")
 	claims.Add("full_name", "foo bar")
 
+	// create an identity for the ttl
+	ident := &oidc.Identity{
+		ExpiresAt: time.Now().Add(1 * time.Minute),
+	}
+
 	// build roles and check that we mapped to "user" role
-	roles, err := s.a.buildRoles(oidcConnector, claims)
+	roles, err := s.a.buildRoles(oidcConnector, ident, claims)
 	c.Assert(err, IsNil)
 	c.Assert(roles, HasLen, 1)
 	c.Assert(roles[0], Equals, "user")
@@ -310,8 +321,13 @@ func (s *AuthSuite) TestBuildRolesTemplate(c *C) {
 	claims.Add("nickname", "foo")
 	claims.Add("full_name", "foo bar")
 
+	// create an identity for the ttl
+	ident := &oidc.Identity{
+		ExpiresAt: time.Now().Add(1 * time.Minute),
+	}
+
 	// build roles
-	roles, err := s.a.buildRoles(oidcConnector, claims)
+	roles, err := s.a.buildRoles(oidcConnector, ident, claims)
 	c.Assert(err, IsNil)
 
 	// check that the newly created role was both returned and upserted into the backend

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -560,11 +560,11 @@ func (a *AuthWithRoles) GetRoles() ([]services.Role, error) {
 }
 
 // UpsertRole creates or updates role
-func (a *AuthWithRoles) UpsertRole(role services.Role) error {
+func (a *AuthWithRoles) UpsertRole(role services.Role, ttl time.Duration) error {
 	if err := a.action(defaults.Namespace, services.KindRole, services.ActionWrite); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.UpsertRole(role)
+	return a.authServer.UpsertRole(role, ttl)
 }
 
 // GetRole returns role by name

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1113,7 +1113,7 @@ func (c *Client) GetRoles() ([]services.Role, error) {
 }
 
 // UpsertRole creates or updates role
-func (c *Client) UpsertRole(role services.Role) error {
+func (c *Client) UpsertRole(role services.Role, ttl time.Duration) error {
 	data, err := services.GetRoleMarshaler().MarshalRole(role)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -172,7 +172,7 @@ func Init(cfg InitConfig, dynamicConfig bool) (*AuthServer, *Identity, error) {
 		}
 
 		for _, role := range cfg.Roles {
-			if err := asrv.UpsertRole(role); err != nil {
+			if err := asrv.UpsertRole(role, backend.Forever); err != nil {
 				return nil, nil, trace.Wrap(err)
 			}
 			log.Infof("[INIT] Created Role: %v", role)
@@ -330,7 +330,7 @@ func migrateUsers(asrv *AuthServer) error {
 		// create role for user and upsert to backend
 		role := services.RoleForUser(user)
 		role.SetLogins(raw.AllowedLogins)
-		err = asrv.UpsertRole(role)
+		err = asrv.UpsertRole(role, backend.Forever)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -370,7 +370,7 @@ func migrateCertAuthority(asrv *AuthServer) error {
 
 		// create role for certificate authority and upsert to backend
 		newCA, role := services.ConvertV1CertAuthority(&raw)
-		err = asrv.UpsertRole(role)
+		err = asrv.UpsertRole(role, backend.Forever)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/auth/new_web_user.go
+++ b/lib/auth/new_web_user.go
@@ -27,6 +27,7 @@ import (
 	"bytes"
 	"image/png"
 
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -188,7 +189,7 @@ func (s *AuthServer) CreateUserWithOTP(token string, password string, otpToken s
 	// apply user allowed logins
 	role := services.RoleForUser(tokenData.User.V2())
 	role.SetLogins(tokenData.User.AllowedLogins)
-	if err := s.UpsertRole(role); err != nil {
+	if err := s.UpsertRole(role, backend.Forever); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -234,7 +235,7 @@ func (s *AuthServer) CreateUserWithoutOTP(token string, password string) (servic
 	// apply user allowed logins
 	role := services.RoleForUser(tokenData.User.V2())
 	role.SetLogins(tokenData.User.AllowedLogins)
-	if err := s.UpsertRole(role); err != nil {
+	if err := s.UpsertRole(role, backend.Forever); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -304,7 +305,7 @@ func (s *AuthServer) CreateUserWithU2FToken(token string, password string, respo
 
 	role := services.RoleForUser(tokenData.User.V2())
 	role.SetLogins(tokenData.User.AllowedLogins)
-	if err := s.UpsertRole(role); err != nil {
+	if err := s.UpsertRole(role, backend.Forever); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -139,7 +139,7 @@ func (s *TunSuite) TestUnixServerClient(c *C) {
 
 	user, role := createUserAndRole(s.a, userName, []string{userName})
 	role.SetResource(services.KindNode, services.RW())
-	err = s.a.UpsertRole(role)
+	err = s.a.UpsertRole(role, backend.Forever)
 	c.Assert(err, IsNil)
 
 	err = s.a.UpsertPassword(user.GetName(), pass)

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -18,6 +18,10 @@ package config
 import (
 	"encoding/base64"
 	"fmt"
+	"time"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
 
 	"gopkg.in/check.v1"
 )
@@ -45,8 +49,8 @@ func (s *FileTestSuite) TestAuthenticationSection(c *check.C) {
 		// 0 - local with otp
 		{
 			`
-auth_service: 
-  authentication: 
+auth_service:
+  authentication:
     type: local
     second_factor: otp
 `,
@@ -58,8 +62,8 @@ auth_service:
 		// 1 - local auth without otp
 		{
 			`
-auth_service: 
-  authentication: 
+auth_service:
+  authentication:
     type: local
     second_factor: off
 `,
@@ -131,6 +135,77 @@ auth_service:
 								"dba",
 								"backup",
 								"root",
+							},
+						},
+					},
+				},
+			},
+		},
+		// 4 - oidc role templates
+		{
+			`
+auth_service:
+  authentication:
+    type: oidc
+    oidc:
+      id: google
+      redirect_url: "https://localhost:3080/v1/webapi/oidc/callback"
+      client_id: id-from-google.apps.googleusercontent.com
+      client_secret: secret-key-from-google
+      issuer_url: "https://accounts.google.com"
+      display: whaterver
+      scope: [ "roles" ]
+      claims_to_roles:
+        - claim: roles
+          value: teleport-admin
+          role_template:
+            kind: role
+            version: v2
+            metadata:
+              name: "{{index . \"email\"}}"
+              namespace: "default"
+            spec:
+              namespaces: [ "*" ]
+              max_session_ttl: 90h0m0s
+              logins: [ "{{index . \"nickname\"}}", root ]
+              node_labels:
+                 "*": "*"
+              resources:
+                "*": [ "read", "write" ]
+              forward_agent: true
+`,
+
+			&AuthenticationConfig{
+				Type: "oidc",
+				OIDC: &OIDCConnector{
+					ID:           "google",
+					RedirectURL:  "https://localhost:3080/v1/webapi/oidc/callback",
+					ClientID:     "id-from-google.apps.googleusercontent.com",
+					ClientSecret: "secret-key-from-google",
+					IssuerURL:    "https://accounts.google.com",
+					Display:      "whaterver",
+					Scope: []string{
+						"roles",
+					},
+					ClaimsToRoles: []ClaimMapping{
+						ClaimMapping{
+							Claim: "roles",
+							Value: "teleport-admin",
+							RoleTemplate: &services.RoleV2{
+								Kind:    services.KindRole,
+								Version: services.V2,
+								Metadata: services.Metadata{
+									Name:      `{{index . "email"}}`,
+									Namespace: defaults.Namespace,
+								},
+								Spec: services.RoleSpecV2{
+									MaxSessionTTL: services.NewDuration(90 * 60 * time.Minute),
+									Logins:        []string{`{{index . "nickname"}}`, `root`},
+									NodeLabels:    map[string]string{"*": "*"},
+									Namespaces:    []string{"*"},
+									Resources:     map[string][]string{"*": []string{"read", "write"}},
+									ForwardAgent:  true,
+								},
 							},
 						},
 					},

--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"sort"
+	"time"
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
@@ -54,12 +55,12 @@ func (s *AccessService) GetRoles() ([]services.Role, error) {
 }
 
 // UpsertRole updates parameters about role
-func (s *AccessService) UpsertRole(role services.Role) error {
+func (s *AccessService) UpsertRole(role services.Role, ttl time.Duration) error {
 	data, err := services.GetRoleMarshaler().MarshalRole(role)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = s.UpsertVal([]string{"roles", role.GetName()}, "params", []byte(data), backend.Forever)
+	err = s.UpsertVal([]string{"roles", role.GetName()}, "params", []byte(data), ttl)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/oidc_test.go
+++ b/lib/services/oidc_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package services
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/coreos/go-oidc/jose"
+	"gopkg.in/check.v1"
+)
+
+type OIDCSuite struct{}
+
+var _ = check.Suite(&OIDCSuite{})
+var _ = fmt.Printf
+
+func (s *OIDCSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
+}
+
+func (s *OIDCSuite) TestUnmarshal(c *check.C) {
+	input := `
+      {
+        "kind": "oidc",
+        "version": "v2",
+        "metadata": {
+          "name": "google"
+        },
+        "spec": {
+          "issuer_url": "https://accounts.google.com",
+          "client_id": "id-from-google.apps.googleusercontent.com",
+          "client_secret": "secret-key-from-google",
+          "redirect_url": "https://localhost:3080/v1/webapi/oidc/callback",
+          "display": "whatever",
+          "scope": ["roles"],
+          "claims_to_roles": [{
+            "claim": "roles",
+            "value": "teleport-user",
+            "role_template": {
+              "kind": "role",
+              "version": "v2",
+              "metadata": {
+                "name": "{{index . \"email\"}}",
+                "namespace": "default"
+              },
+              "spec": {
+                "namespaces": ["default"],
+                "max_session_ttl": "90h0m0s",
+                "logins": ["{{index . \"nickname\"}}", "root"],
+                "node_labels": {
+                  "*": "*"
+                }
+              }
+            }
+          }]
+        }
+      }
+	`
+
+	output := OIDCConnectorV2{
+		Kind:    KindOIDCConnector,
+		Version: V2,
+		Metadata: Metadata{
+			Name:      "google",
+			Namespace: defaults.Namespace,
+		},
+		Spec: OIDCConnectorSpecV2{
+			IssuerURL:    "https://accounts.google.com",
+			ClientID:     "id-from-google.apps.googleusercontent.com",
+			ClientSecret: "secret-key-from-google",
+			RedirectURL:  "https://localhost:3080/v1/webapi/oidc/callback",
+			Display:      "whatever",
+			Scope:        []string{"roles"},
+			ClaimsToRoles: []ClaimMapping{
+				ClaimMapping{
+					Claim: "roles",
+					Value: "teleport-user",
+					RoleTemplate: &RoleV2{
+						Kind:    KindRole,
+						Version: V2,
+						Metadata: Metadata{
+							Name:      `{{index . "email"}}`,
+							Namespace: defaults.Namespace,
+						},
+						Spec: RoleSpecV2{
+							Namespaces:    []string{"default"},
+							MaxSessionTTL: NewDuration(90 * 60 * time.Minute),
+							Logins:        []string{`{{index . "nickname"}}`, `root`},
+							NodeLabels:    map[string]string{"*": "*"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	oc, err := GetOIDCConnectorMarshaler().UnmarshalOIDCConnector([]byte(input))
+	c.Assert(err, check.IsNil)
+	c.Assert(oc, check.DeepEquals, &output)
+}
+
+func (s *OIDCSuite) TestUnmarshalInvalid(c *check.C) {
+	input := `
+      {
+        "kind": "oidc",
+        "version": "v2",
+        "metadata": {
+          "name": "google"
+        },
+        "spec": {
+          "issuer_url": "https://accounts.google.com",
+          "client_id": "id-from-google.apps.googleusercontent.com",
+          "client_secret": "secret-key-from-google",
+          "redirect_url": "https://localhost:3080/v1/webapi/oidc/callback",
+          "display": "whatever",
+          "scope": ["roles"],
+          "claims_to_roles": [{
+            "claim": "roles",
+            "value": "teleport-user",
+            "roles": [ "foo", "bar", "baz" ],
+            "role_template": {
+              "kind": "role",
+              "version": "v2",
+              "metadata": {
+                "name": "{{index . \"email\"}}",
+                "namespace": "default"
+              },
+              "spec": {
+                "namespaces": ["default"],
+                "max_session_ttl": "90h0m0s",
+                "logins": ["{{index . \"nickname\"}}", "root"],
+                "node_labels": {
+                  "*": "*"
+                }
+              }
+            }
+          }]
+        }
+      }
+	`
+
+	oc, err := GetOIDCConnectorMarshaler().UnmarshalOIDCConnector([]byte(input))
+	c.Assert(err, check.IsNil)
+	err = oc.Check()
+	c.Assert(err, check.NotNil)
+}
+
+func (s *OIDCSuite) TestRoleFromTemplate(c *check.C) {
+	oidcConnector := OIDCConnectorV2{
+		Kind:    KindOIDCConnector,
+		Version: V2,
+		Metadata: Metadata{
+			Name:      "google",
+			Namespace: defaults.Namespace,
+		},
+		Spec: OIDCConnectorSpecV2{
+			IssuerURL:    "https://accounts.google.com",
+			ClientID:     "id-from-google.apps.googleusercontent.com",
+			ClientSecret: "secret-key-from-google",
+			RedirectURL:  "https://localhost:3080/v1/webapi/oidc/callback",
+			Display:      "whatever",
+			Scope:        []string{"roles"},
+			ClaimsToRoles: []ClaimMapping{
+				ClaimMapping{
+					Claim: "roles",
+					Value: "teleport-user",
+					RoleTemplate: &RoleV2{
+						Kind:    KindRole,
+						Version: V2,
+						Metadata: Metadata{
+							Name:      `{{index . "email"}}`,
+							Namespace: defaults.Namespace,
+						},
+						Spec: RoleSpecV2{
+							Namespaces:    []string{"default"},
+							MaxSessionTTL: NewDuration(30 * 60 * time.Minute),
+							Logins:        []string{`{{index . "nickname"}}`, `root`},
+							NodeLabels:    map[string]string{"*": "*"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// create some claims
+	var claims = make(jose.Claims)
+	claims.Add("roles", "teleport-user")
+	claims.Add("email", "foo@example.com")
+	claims.Add("nickname", "foo")
+	claims.Add("full_name", "foo bar")
+
+	role, err := oidcConnector.RoleFromTemplate(claims)
+	c.Assert(err, check.IsNil)
+
+	outRole, err := NewRole("foo@example.com", RoleSpecV2{
+		Logins:        []string{"foo", "root"},
+		MaxSessionTTL: NewDuration(30 * time.Hour),
+		NodeLabels:    map[string]string{"*": "*"},
+		Namespaces:    []string{"default"},
+		Resources:     nil,
+		ForwardAgent:  false,
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(role, check.DeepEquals, outRole)
+}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -103,7 +103,7 @@ type Access interface {
 	GetRoles() ([]Role, error)
 
 	// UpsertRole creates or updates role
-	UpsertRole(role Role) error
+	UpsertRole(role Role, ttl time.Duration) error
 
 	// GetRole returns role by name
 	GetRole(name string) (Role, error)

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -389,14 +389,14 @@ func (s *ServicesTestSuite) RolesCRUD(c *C) {
 			Resources:     map[string][]string{services.KindRole: []string{services.ActionRead}},
 		},
 	}
-	err = s.Access.UpsertRole(&role)
+	err = s.Access.UpsertRole(&role, backend.Forever)
 	c.Assert(err, IsNil)
 	rout, err := s.Access.GetRole(role.Metadata.Name)
 	c.Assert(err, IsNil)
 	c.Assert(rout, DeepEquals, &role)
 
 	role.Spec.Logins = []string{"bob"}
-	err = s.Access.UpsertRole(&role)
+	err = s.Access.UpsertRole(&role, backend.Forever)
 	c.Assert(err, IsNil)
 	rout, err = s.Access.GetRole(role.Metadata.Name)
 	c.Assert(err, IsNil)

--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -223,7 +223,7 @@ func (s *SrvSuite) TestAgentForward(c *C) {
 	role, err := s.a.GetRole(roleName)
 	c.Assert(err, IsNil)
 	role.SetForwardAgent(true)
-	err = s.a.UpsertRole(role)
+	err = s.a.UpsertRole(role, backend.Forever)
 	c.Assert(err, IsNil)
 
 	err = agent.RequestAgentForwarding(se)
@@ -868,7 +868,7 @@ func newUpack(username string, allowedLogins []string, a *auth.AuthServer) (*upa
 	role := services.RoleForUser(user)
 	role.SetResource(services.Wildcard, services.RW())
 	role.SetLogins(allowedLogins)
-	err = a.UpsertRole(role)
+	err = a.UpsertRole(role, backend.Forever)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -173,7 +173,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	role := services.RoleForUser(teleUser)
 	role.SetLogins([]string{s.user})
 	role.SetResource(services.Wildcard, services.RW())
-	err = s.authServer.UpsertRole(role)
+	err = s.authServer.UpsertRole(role, backend.Forever)
 	c.Assert(err, IsNil)
 
 	teleUser.AddRole(role.GetName())
@@ -445,7 +445,7 @@ func (s *WebSuite) authPack(c *C) *authPack {
 	c.Assert(err, IsNil)
 	role := services.RoleForUser(teleUser)
 	role.SetLogins([]string{s.user})
-	err = s.roleAuth.UpsertRole(role)
+	err = s.roleAuth.UpsertRole(role, backend.Forever)
 	c.Assert(err, IsNil)
 	teleUser.AddRole(role.GetName())
 

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
@@ -970,7 +971,7 @@ func (u *CreateCommand) Create(client *auth.TunClient) error {
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			if err := client.UpsertRole(role); err != nil {
+			if err := client.UpsertRole(role, backend.Forever); err != nil {
 				return trace.Wrap(err)
 			}
 			fmt.Printf("role %v upserted\n", role.GetName())


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/891, at the moment using OIDC with individual system logins means you have to either create a role for every user or keep updating a shared role with logins whenever someone new joins the team.

To improve the user experience of OIDC and Teleport, this PR allows you to define a role template that can be used to dynamically create roles based off the claims received from an identity provider.

**Implementation**

* The `claims_to_roles` for an OIDC connector can now contain `roles` or a `role_template` that contains an embedded role that is filled out by data from claims.

    ```yaml
    claims_to_roles:
      - claim: roles
        value: teleport-admin
        role_template:
          kind: role
          version: v2
          metadata:
            name: '{{index . "email"}}'
            namespace: "default"
          spec:
            namespaces: [ "*" ]
            max_session_ttl: 90h0m0s
            logins: [ '{{index . "nickname"}}', root ]
            node_labels:
               "*": "*"
            resources:
              "*": [ "read", "write" ]
            forward_agent: true
    ```

* `UpsertRole` has been updated with a TTL so that dynamic roles are removed along with the dynamic user.
* User creation logic has been updated so if you re-login via OIDC you don't have to wait for your existing `User` to expire.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/891