### PR TITLE
CA Export Format

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -103,6 +103,13 @@ const (
 )
 
 const (
+	// AuthorizedKeys are public keys that check against User CAs.
+	AuthorizedKeys = "authorized_keys"
+	// KnownHosts are public keys that check against Host CAs.
+	KnownHosts = "known_hosts"
+)
+
+const (
 	// CertExtensionPermitAgentForwarding allows agent forwarding for certificate
 	CertExtensionPermitAgentForwarding = "permit-agent-forwarding"
 	// CertExtensionPermitPTY allows user to request PTY

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -188,7 +188,7 @@ func Init(cfg InitConfig, dynamicConfig bool) (*AuthServer, *Identity, error) {
 			if err := asrv.Trust.UpsertCertAuthority(ca, backend.Forever); err != nil {
 				return nil, nil, trace.Wrap(err)
 			}
-			log.Infof("[INIT] Created Trusted Certificate Authority: %v", ca)
+			log.Infof("[INIT] Created Trusted Certificate Authority: %q, type: %q", ca.GetName(), ca.GetType())
 		}
 
 		for _, tunnel := range cfg.ReverseTunnels {


### PR DESCRIPTION
**Purpose**

In https://github.com/gravitational/teleport/pull/839 we corrected the User CA export format for OpenSSH comparability. However, as documented in https://github.com/gravitational/teleport/issues/869 we did not update our own code that parses certificates, specifically for Trusted Clusters, to understand User CA in the correct `authorized_keys` format. In addition, we were not exporting the cluster name in the new format.

**Implementation**

* When exporting a user certificate, include the cluster name and type in the comment field.
* When parsing a certificate first determine the format, is it in `authorized_keys` format or `known_hosts` format. Based off that parse the certificates appropriately.
* Added `--compat=1.0` flag to `tctl` to export in the old format for legacy situations.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/869