### PR TITLE
Skip over expired Roles

### DIFF
--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -42,13 +42,16 @@ func (s *AccessService) GetRoles() ([]services.Role, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out := make([]services.Role, len(keys))
-	for i, name := range keys {
+	var out []services.Role
+	for _, name := range keys {
 		u, err := s.GetRole(name)
 		if err != nil {
+			if trace.IsNotFound(err) {
+				continue
+			}
 			return nil, trace.Wrap(err)
 		}
-		out[i] = u
+		out = append(out, u)
 	}
 	sort.Sort(services.SortedRoles(out))
 	return out, nil


### PR DESCRIPTION
**Purpose**

At the moment, `GetRoles` potentially returns something like the following in the Web UI sometimes:

```
role foo@example.com is not found
If you believe this is an issue with Teleport, please create a GitHub issue.
```

This is because `GetRoles` does not skip over expired roles. This PR changes this behavior and skips over expired roles.

**Implementation**

* When calling `GetRole`, check if the error is a `trace.IsNotFound` and if it is, skip over it.