### PR TITLE
Updated Session URL

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -17,6 +17,21 @@ const (
 	// SSHAgentPID is the environment variable pointing to the agent
 	// process ID
 	SSHAgentPID = "SSH_AGENT_PID"
+
+	// SSHTeleportUser is the current Teleport user that is logged in.
+	SSHTeleportUser = "SSH_TELEPORT_USER"
+
+	// SSHSessionWebproxyAddr is the address the web proxy.
+	SSHSessionWebproxyAddr = "SSH_SESSION_WEBPROXY_ADDR"
+
+	// SSHTeleportClusterName is the name of the cluster this node belongs to.
+	SSHTeleportClusterName = "SSH_TELEPORT_CLUSTER_NAME"
+
+	// SSHTeleportHostUUID is the UUID of the host.
+	SSHTeleportHostUUID = "SSH_TELEPORT_HOST_UUID"
+
+	// SSHSessionID is the UUID of the current session.
+	SSHSessionID = "SSH_SESSION_ID"
 )
 
 const (

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -180,15 +180,25 @@ func onStart(config *service.Config) error {
 
 // onStatus is the handler for "status" CLI command
 func onStatus() error {
-	sid := os.Getenv("SSH_SESSION_ID")
-	proxyHost := os.Getenv("SSH_SESSION_WEBPROXY_ADDR")
-	tuser := os.Getenv("SSH_TELEPORT_USER")
+	sshClient := os.Getenv("SSH_CLIENT")
+	systemUser := os.Getenv("USER")
+	teleportUser := os.Getenv(teleport.SSHTeleportUser)
+	proxyHost := os.Getenv(teleport.SSHSessionWebproxyAddr)
+	clusterName := os.Getenv(teleport.SSHTeleportClusterName)
+	hostUUID := os.Getenv(teleport.SSHTeleportHostUUID)
+	sid := os.Getenv(teleport.SSHSessionID)
+
 	if sid == "" || proxyHost == "" {
 		fmt.Println("You are not inside of a Teleport SSH session")
 		return nil
 	}
-	fmt.Printf("User ID    : %s, logged in as %s from %s\n", tuser, os.Getenv("USER"), os.Getenv("SSH_CLIENT"))
-	fmt.Printf("Session ID : %s\nSession URL: https://%s/web/sessions/%s\n", sid, proxyHost, sid)
+
+	fmt.Printf("User ID     : %s, logged in as %s from %s\n", teleportUser, systemUser, sshClient)
+	fmt.Printf("Cluster Name: %s\n", clusterName)
+	fmt.Printf("Host UUID   : %s\n", hostUUID)
+	fmt.Printf("Session ID  : %s\n", sid)
+	fmt.Printf("Session URL : https://%s/web/cluster/%v/node/%v/%v/%v\n", proxyHost, clusterName, hostUUID, systemUser, sid)
+
 	return nil
 }
 


### PR DESCRIPTION
**Purpose**

As reported in https://github.com/gravitational/teleport/issues/900, the output of `teleport status` is currently incorrect. The path to a session has changed and the output of `teleport status` has not beed updated.

**Implementation**

* In `lib/srv/exec.go` we now export `SSH_TELEPORT_HOST_UUID` and `SSH_TELEPORT_CLUSTER_NAME` as these are ended to construct the path to a session now.
* In `tool/teleport/common/teleport.go` we now list the Host UUID and Cluster Name in addition to the corrected Session URL.

**Related Issues** 

Fixes https://github.com/gravitational/teleport/issues/900