### PR TITLE
Trim whitespace during auth export.

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -664,7 +664,7 @@ func userCAFormat(ca services.CertAuthority, keyBytes []byte) (string, error) {
 		"clustername": []string{ca.GetClusterName()},
 	}
 
-	return fmt.Sprintf("cert-authority %s %s", keyBytes, comment.Encode()), nil
+	return fmt.Sprintf("cert-authority %s %s", strings.TrimSpace(string(keyBytes)), comment.Encode()), nil
 }
 
 // hostCAFormat returns the certificate authority public key exported as a single line


### PR DESCRIPTION
**Purpose**

Trim whitespace from key bytes so comment (`clustername` and `type`) are on the same line.

**Implementation**

* Wrap `keyBytes` with `strings.TrimSpace`.