### PR TITLE
Skip userinfo if provider doesn't support it.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -909,6 +909,10 @@ func claimsFromUserInfo(oidcClient *oidc.Client, issuerURL string, accessToken s
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// If the provider doesn't offer a UserInfo endpoint don't err.
+	if pc.UserInfoEndpoint == nil {
+		return nil, nil
+	}
 	endpoint := pc.UserInfoEndpoint.String()
 	err = isHTTPS(endpoint)
 	if err != nil {
@@ -979,6 +983,11 @@ func (a *AuthServer) getClaims(oidcClient *oidc.Client, issuerURL string, code s
 		log.Debugf("[OIDC] Unable to fetch UserInfo claims: %v", err)
 		return nil, trace.Wrap(err)
 	}
+	if userInfoClaims == nil {
+		log.Warn("[OIDC] Provider doesn't offer UserInfo endpoint. Only token claims will be used.")
+		return idTokenClaims, nil
+	}
+
 	log.Debugf("[OIDC] UserInfo claims: %v", userInfoClaims)
 
 	// make sure that the subject in the userinfo claim matches the subject in


### PR DESCRIPTION
While integrating the CoreOS Dex  oidc (https://github.com/coreos/dex) with teleport we found a problem during the claim validation process:

Dex doesn't implement the UserInfo endpoint, which seems to be optional anyway according to the standard  (see coreos/dex#376).

Teleport auth service crashes when requesting this endpoint as in:

```go 
func claimsFromUserInfo(oidcClient *oidc.Client, issuerURL string, accessToken string) (jose.Claims, error) {
        err := isHTTPS(issuerURL)
        if err != nil {
                return nil, trace.Wrap(err)
        }

        oac, err := oidcClient.OAuthClient()
        if err != nil {
                return nil, trace.Wrap(err)
        }
        hc := oac.HttpClient()

        // go get the provider config so we can find out where the UserInfo endpoint is
        pc, err := oidc.FetchProviderConfig(oac.HttpClient(), issuerURL)
        if err != nil {
                return nil, trace.Wrap(err)
        }
        endpoint := pc.UserInfoEndpoint.String()
````
`pc.UserInfoEndpoint` is casted to String.

This PR tries to avoid this crash by checking for the UserInfoEndpoint presence in the provider configuration, using just the token claims in this case. 

Do you think this would be a good approach?

