### PR TITLE
Set defaults for templated roles.

### DIFF
--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -417,6 +417,12 @@ func (o *OIDCConnectorV2) RoleFromTemplate(claims jose.Claims) (Role, error) {
 				roleTemplate.SetName(executedName)
 				roleTemplate.SetLogins(executedLogins)
 
+				// check all fields and make sure we have have a valid role
+				err = roleTemplate.CheckAndSetDefaults()
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
 				return roleTemplate, nil
 			}
 		}

--- a/lib/services/oidc_test.go
+++ b/lib/services/oidc_test.go
@@ -162,6 +162,8 @@ func (s *OIDCSuite) TestUnmarshalInvalid(c *check.C) {
 	c.Assert(err, check.NotNil)
 }
 
+// TestRoleFromTemplate checks that we can create a valid role from a template. Also
+// makes sure missing fields are filled in.
 func (s *OIDCSuite) TestRoleFromTemplate(c *check.C) {
 	oidcConnector := OIDCConnectorV2{
 		Kind:    KindOIDCConnector,
@@ -189,7 +191,6 @@ func (s *OIDCSuite) TestRoleFromTemplate(c *check.C) {
 							Namespace: defaults.Namespace,
 						},
 						Spec: RoleSpecV2{
-							Namespaces:    []string{"default"},
 							MaxSessionTTL: NewDuration(30 * 60 * time.Minute),
 							Logins:        []string{`{{index . "nickname"}}`, `root`},
 							NodeLabels:    map[string]string{"*": "*"},


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/912, at the moment if you create a role from a template, you have to explicitly define the values for all fields. This PR changes this behavior by filling in the default value for missing or empty fields.

**Implementation**

* When building a role, call `CheckAndSetDefaults` to make sure the role is filled out.
* In `CheckAndSetDefaults` require that all fields have default values if unset or empty.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/912