### PR TITLE
Don't set logins directly from allowed logins for CertAuthority V2.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -76,7 +76,7 @@ the YAML file to `tctl` via `-c` flag.
 
 ### Trusted Clusters
 
-To setup Trusted Clusters:
+#### Trusted Clusters with Resources
 
 1. Update `two-role.yaml` and replace `username_goes_here` with your username.
 1. Create a `Role` and `TrustedCluster` resource on Cluster Two.
@@ -86,6 +86,41 @@ To setup Trusted Clusters:
     tctl -c /root/go/src/github.com/gravitational/teleport/docker/two-auth.yaml create -f docker/two-role-admin.yaml
     tctl -c /root/go/src/github.com/gravitational/teleport/docker/two-auth.yaml create -f docker/two-tc.yaml
     ```
+
+#### Trusted Clusters with File Configuration
+
+##### Export CAs
+
+Run the following commands to export your CAs.
+
+```bash
+# enter cluster two and export ca
+make enter-two
+tctl -c /root/go/src/github.com/gravitational/teleport/docker/two-auth.yaml auth export > docker/data/two/two.ca
+exit
+
+# enter cluster one and export ca
+make enter-one
+tctl auth export > docker/data/one/one.ca
+exit
+```
+
+##### Upate Configuration
+
+Stop both clusters with `make stop`, update the file configuration for both clusters, and start again with `make`.
+
+```bash
+# update docker/one.yaml with the following under "auth_service"
+trusted_clusters:
+  - key_file: /root/go/src/github.com/gravitational/teleport/docker/data/two/two.ca
+```
+```bash
+# update docker/two-auth.yaml with the following under "auth_service"
+trusted_clusters:
+  - key_file: /root/go/src/github.com/gravitational/teleport/docker/data/one/one.ca
+    allow_logins: root
+    tunnel_addr: one
+```
 
 ### Ansible
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -444,7 +444,7 @@ func parseAuthorizedKeys(bytes []byte, allowedLogins []string) (services.CertAut
 		clusterName,
 		nil,
 		[][]byte{ssh.MarshalAuthorizedKey(pubkey)},
-		allowedLogins)
+		nil)
 
 	// transform old allowed logins into roles
 	role := services.RoleForCertAuthority(ca)


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/918, when you export CAs using the new style format, you will see the following in the Web UI:

```
access denied to root connecting to node-on-second-cluster                                                                                
disconnected  
```

The reason is because we were settings logins directly from allowed logins. This PR changes this behavior to match the behavior for how we parse CAs in the `known_hosts` format, we don't set logins directly but rather create a role first and add the role to the CertAuthority.

**Implementation**

* Don't directly set `allowedLogins`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/918