### PR TITLE
Added support for ACR values for OIDC connectors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=2.0.0-rc.4
+VERSION=2.1.0-alpha.2
 
 # These are standard autotools variables, don't change them please
 BUILDDIR ?= build

--- a/constants.go
+++ b/constants.go
@@ -132,3 +132,8 @@ const (
 	// CertExtensionPermitPortForwarding allows user to request port forwarding
 	CertExtensionPermitPortForwarding = "permit-port-forwarding"
 )
+
+const (
+	// NetIQ is an identity provider.
+	NetIQ = "netiq"
+)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1130,7 +1130,7 @@ func (a *AuthServer) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthResponse, 
 	// if we are sending acr values, make sure we also validate them
 	acrValue := connector.GetACR()
 	if acrValue != "" {
-		err := a.validateACRValues(acrValue, connector.GetIdentityProvider(), claims)
+		err := a.validateACRValues(acrValue, connector.GetProvider(), claims)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -920,15 +920,16 @@ func claimsFromUserInfo(oidcClient *oidc.Client, issuerURL string, accessToken s
 	}
 	hc := oac.HttpClient()
 
-	// go get the provider config so we can find out where the UserInfo endpoint is
+	// go get the provider config so we can find out where the UserInfo endpoint
+	// is. if the provider doesn't offer a UserInfo endpoint return not found.
 	pc, err := oidc.FetchProviderConfig(oac.HttpClient(), issuerURL)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// If the provider doesn't offer a UserInfo endpoint don't err.
 	if pc.UserInfoEndpoint == nil {
-		return nil, nil
+		return nil, trace.NotFound("UserInfo endpoint not found")
 	}
+
 	endpoint := pc.UserInfoEndpoint.String()
 	err = isHTTPS(endpoint)
 	if err != nil {
@@ -996,14 +997,13 @@ func (a *AuthServer) getClaims(oidcClient *oidc.Client, issuerURL string, code s
 
 	userInfoClaims, err := claimsFromUserInfo(oidcClient, issuerURL, t.AccessToken)
 	if err != nil {
+		if trace.IsNotFound(err) {
+			log.Debugf("[OIDC] Provider doesn't offer UserInfo endpoint. Returning token claims: %v", idTokenClaims)
+			return idTokenClaims, nil
+		}
 		log.Debugf("[OIDC] Unable to fetch UserInfo claims: %v", err)
 		return nil, trace.Wrap(err)
 	}
-	if userInfoClaims == nil {
-		log.Warn("[OIDC] Provider doesn't offer UserInfo endpoint. Only token claims will be used.")
-		return idTokenClaims, nil
-	}
-
 	log.Debugf("[OIDC] UserInfo claims: %v", userInfoClaims)
 
 	// make sure that the subject in the userinfo claim matches the subject in

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1134,6 +1134,7 @@ func (a *AuthServer) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthResponse, 
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+		log.Debugf("[OIDC] ACR values %q successfully validated", acrValue)
 	}
 
 	ident, err := oidc.IdentityFromClaims(claims)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -749,9 +749,25 @@ func (s *AuthServer) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*servi
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	// online is OIDC online scope, "select_account" forces user to always select account
-	redirectURL := oauthClient.AuthCodeURL(req.StateToken, "online", "select_account")
-	req.RedirectURL = redirectURL
+	req.RedirectURL = oauthClient.AuthCodeURL(req.StateToken, "online", "select_account")
+
+	// if the connector has an Authentication Context Class Reference (ACR) value set,
+	// update redirect url and add it as a query value.
+	acrValue := connector.GetACR()
+	if acrValue != "" {
+		u, err := url.Parse(req.RedirectURL)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		q := u.Query()
+		q.Set("acr_values", acrValue)
+		u.RawQuery = q.Encode()
+		req.RedirectURL = u.String()
+	}
+
+	log.Debugf("[OIDC] Redirect URL: %v", req.RedirectURL)
 
 	err = s.Identity.CreateOIDCAuthRequest(req, defaults.OIDCAuthRequestTTL)
 	if err != nil {
@@ -1018,6 +1034,56 @@ func (a *AuthServer) getClaims(oidcClient *oidc.Client, issuerURL string, code s
 	return claims, nil
 }
 
+// validateACRValues validates that we get an appropriate response for acr values. By default
+// we expect the same value we send, but this function also handles Identity Provider specific
+// forms of validation.
+func (a *AuthServer) validateACRValues(acrValue string, identityProvider string, claims jose.Claims) error {
+	switch identityProvider {
+	case teleport.NetIQ:
+		log.Debugf("[OIDC] Validating ACR values with %q rules", identityProvider)
+
+		tokenAcr, ok := claims["acr"]
+		if !ok {
+			return trace.BadParameter("acr claim does not exist")
+		}
+		tokenAcrMap, ok := tokenAcr.(map[string][]string)
+		if !ok {
+			return trace.BadParameter("acr unknown type: %T", tokenAcr)
+		}
+		tokenAcrValues, ok := tokenAcrMap["values"]
+		if !ok {
+			return trace.BadParameter("acr.values not found in claims")
+		}
+		acrValueMatched := false
+		for _, v := range tokenAcrValues {
+			if acrValue == v {
+				acrValueMatched = true
+				break
+			}
+		}
+		if !acrValueMatched {
+			log.Debugf("[OIDC] No ACR match found for %q in %q", acrValue, tokenAcrValues)
+			return trace.BadParameter("acr claim does not match")
+		}
+	default:
+		log.Debugf("[OIDC] Validating ACR values with default rules")
+
+		claimValue, exists, err := claims.StringClaim("acr")
+		if !exists {
+			return trace.BadParameter("acr claim does not exist")
+		}
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if claimValue != acrValue {
+			log.Debugf("[OIDC] No ACR match found %q != %q", acrValue, claimValue)
+			return trace.BadParameter("acr claim does not match")
+		}
+	}
+
+	return nil
+}
+
 // ValidateOIDCAuthCallback is called by the proxy to check OIDC query parameters
 // returned by OIDC Provider, if everything checks out, auth server
 // will respond with OIDCAuthResponse, otherwise it will return error
@@ -1060,6 +1126,15 @@ func (a *AuthServer) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthResponse, 
 			oauth2.ErrorUnsupportedResponseType, "unable to construct claims", q)
 	}
 	log.Debugf("[OIDC] Claims: %v", claims)
+
+	// if we are sending acr values, make sure we also validate them
+	acrValue := connector.GetACR()
+	if acrValue != "" {
+		err := a.validateACRValues(acrValue, connector.GetIdentityProvider(), claims)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
 
 	ident, err := oidc.IdentityFromClaims(claims)
 	if err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -101,7 +101,7 @@ var (
 		"client_secret":      true,
 		"redirect_url":       true,
 		"acr_values":         true,
-		"identity_provider":  true,
+		"provider":           true,
 		"tokens":             true,
 		"region":             true,
 		"table_name":         true,
@@ -699,9 +699,9 @@ type OIDCConnector struct {
 	RedirectURL string `yaml:"redirect_url"`
 	// ACR is the acr_values parameter to be sent with an authorization request.
 	ACR string `yaml:"acr_values,omitempty"`
-	// IdentityProvider is the Identity Provider we connect to. This field is
+	// Provider is the identity provider we connect to. This field is
 	// only required if using acr_values.
-	IdentityProvider string `yaml:"identity_provider,omitempty"`
+	Provider string `yaml:"provider,omitempty"`
 	// Display controls how this connector is displayed
 	Display string `yaml:"display"`
 	// Scope is a list of additional scopes to request from OIDC
@@ -744,7 +744,7 @@ func (o *OIDCConnector) Parse() (services.OIDCConnector, error) {
 	}
 	v2 := other.V2()
 	v2.SetACR(o.ACR)
-	v2.SetIdentityProvider(o.IdentityProvider)
+	v2.SetProvider(o.Provider)
 	if err := v2.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -100,6 +100,8 @@ var (
 		"client_id":          true,
 		"client_secret":      true,
 		"redirect_url":       true,
+		"acr_values":         true,
+		"identity_provider":  true,
 		"tokens":             true,
 		"region":             true,
 		"table_name":         true,
@@ -695,6 +697,11 @@ type OIDCConnector struct {
 	// client's browser back to it after successfull authentication
 	// Should match the URL on Provider's side
 	RedirectURL string `yaml:"redirect_url"`
+	// ACR is the acr_values parameter to be sent with an authorization request.
+	ACR string `yaml:"acr_values,omitempty"`
+	// IdentityProvider is the Identity Provider we connect to. This field is
+	// only required if using acr_values.
+	IdentityProvider string `yaml:"identity_provider,omitempty"`
 	// Display controls how this connector is displayed
 	Display string `yaml:"display"`
 	// Scope is a list of additional scopes to request from OIDC
@@ -736,6 +743,8 @@ func (o *OIDCConnector) Parse() (services.OIDCConnector, error) {
 		ClaimsToRoles: mappings,
 	}
 	v2 := other.V2()
+	v2.SetACR(o.ACR)
+	v2.SetIdentityProvider(o.IdentityProvider)
 	if err := v2.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -48,6 +48,10 @@ type OIDCConnector interface {
 	// client's browser back to it after successfull authentication
 	// Should match the URL on Provider's side
 	GetRedirectURL() string
+	// GetACR returns the Authentication Context Class Reference (ACR) value.
+	GetACR() string
+	// GetIdentityProvider returns the Identity Provider.
+	GetIdentityProvider() string
 	// Display - Friendly name for this provider.
 	GetDisplay() string
 	// Scope is additional scopes set by provder
@@ -70,6 +74,10 @@ type OIDCConnector interface {
 	SetIssuerURL(string)
 	// SetRedirectURL sets RedirectURL
 	SetRedirectURL(string)
+	// SetACR sets the Authentication Context Class Reference (ACR) value.
+	SetACR(string)
+	// SetIdentityProvider sets the Identity Provider.
+	SetIdentityProvider(string)
 	// SetScope sets additional scopes set by provider
 	SetScope([]string)
 	// SetClaimsToRoles sets dynamic mapping from claims to roles
@@ -257,6 +265,16 @@ func (o *OIDCConnectorV2) SetRedirectURL(redirectURL string) {
 	o.Spec.RedirectURL = redirectURL
 }
 
+// SetACR sets the Authentication Context Class Reference (ACR) value.
+func (o *OIDCConnectorV2) SetACR(acrValue string) {
+	o.Spec.ACR = acrValue
+}
+
+// SetIdentityProvider sets the Identity Provider.
+func (o *OIDCConnectorV2) SetIdentityProvider(identityProvider string) {
+	o.Spec.IdentityProvider = identityProvider
+}
+
 // SetScope sets additional scopes set by provider
 func (o *OIDCConnectorV2) SetScope(scope []string) {
 	o.Spec.Scope = scope
@@ -298,6 +316,16 @@ func (o *OIDCConnectorV2) GetClientSecret() string {
 // Should match the URL on Provider's side
 func (o *OIDCConnectorV2) GetRedirectURL() string {
 	return o.Spec.RedirectURL
+}
+
+// GetACR returns the Authentication Context Class Reference (ACR) value.
+func (o *OIDCConnectorV2) GetACR() string {
+	return o.Spec.ACR
+}
+
+// GetIdentityProvider returns the Identity Provider.
+func (o *OIDCConnectorV2) GetIdentityProvider() string {
+	return o.Spec.IdentityProvider
 }
 
 // Display - Friendly name for this provider.
@@ -497,6 +525,11 @@ type OIDCConnectorSpecV2 struct {
 	// client's browser back to it after successfull authentication
 	// Should match the URL on Provider's side
 	RedirectURL string `json:"redirect_url"`
+	// ACR is an Authentication Context Class Reference value. The meaning of the ACR
+	// value is context-specific and varies for identity providers.
+	ACR string `json:"acr_values,omitempty"`
+	// IdentityProvider is the external identity provider.
+	IdentityProvider string `json:"identity_provider,omitempty"`
 	// Display - Friendly name for this provider.
 	Display string `json:"display,omitempty"`
 	// Scope is additional scopes set by provder
@@ -515,6 +548,8 @@ var OIDCConnectorSpecV2Schema = fmt.Sprintf(`{
     "client_id": {"type": "string"},
     "client_secret": {"type": "string"},
     "redirect_url": {"type": "string"},
+    "acr_values": {"type": "string"},
+    "identity_provider": {"type": "string"},
     "display": {"type": "string"},
     "scope": {
       "type": "array",

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -50,8 +50,8 @@ type OIDCConnector interface {
 	GetRedirectURL() string
 	// GetACR returns the Authentication Context Class Reference (ACR) value.
 	GetACR() string
-	// GetIdentityProvider returns the Identity Provider.
-	GetIdentityProvider() string
+	// GetProvider returns the identity provider.
+	GetProvider() string
 	// Display - Friendly name for this provider.
 	GetDisplay() string
 	// Scope is additional scopes set by provder
@@ -76,8 +76,8 @@ type OIDCConnector interface {
 	SetRedirectURL(string)
 	// SetACR sets the Authentication Context Class Reference (ACR) value.
 	SetACR(string)
-	// SetIdentityProvider sets the Identity Provider.
-	SetIdentityProvider(string)
+	// SetProvider sets the identity provider.
+	SetProvider(string)
 	// SetScope sets additional scopes set by provider
 	SetScope([]string)
 	// SetClaimsToRoles sets dynamic mapping from claims to roles
@@ -270,9 +270,9 @@ func (o *OIDCConnectorV2) SetACR(acrValue string) {
 	o.Spec.ACR = acrValue
 }
 
-// SetIdentityProvider sets the Identity Provider.
-func (o *OIDCConnectorV2) SetIdentityProvider(identityProvider string) {
-	o.Spec.IdentityProvider = identityProvider
+// SetProvider sets the identity provider.
+func (o *OIDCConnectorV2) SetProvider(identityProvider string) {
+	o.Spec.Provider = identityProvider
 }
 
 // SetScope sets additional scopes set by provider
@@ -323,9 +323,9 @@ func (o *OIDCConnectorV2) GetACR() string {
 	return o.Spec.ACR
 }
 
-// GetIdentityProvider returns the Identity Provider.
-func (o *OIDCConnectorV2) GetIdentityProvider() string {
-	return o.Spec.IdentityProvider
+// GetProvider returns the identity provider.
+func (o *OIDCConnectorV2) GetProvider() string {
+	return o.Spec.Provider
 }
 
 // Display - Friendly name for this provider.
@@ -528,8 +528,8 @@ type OIDCConnectorSpecV2 struct {
 	// ACR is an Authentication Context Class Reference value. The meaning of the ACR
 	// value is context-specific and varies for identity providers.
 	ACR string `json:"acr_values,omitempty"`
-	// IdentityProvider is the external identity provider.
-	IdentityProvider string `json:"identity_provider,omitempty"`
+	// Provider is the external identity provider.
+	Provider string `json:"provider,omitempty"`
 	// Display - Friendly name for this provider.
 	Display string `json:"display,omitempty"`
 	// Scope is additional scopes set by provder
@@ -549,7 +549,7 @@ var OIDCConnectorSpecV2Schema = fmt.Sprintf(`{
     "client_secret": {"type": "string"},
     "redirect_url": {"type": "string"},
     "acr_values": {"type": "string"},
-    "identity_provider": {"type": "string"},
+    "provider": {"type": "string"},
     "display": {"type": "string"},
     "scope": {
       "type": "array",

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "2.0.0-rc.4"
+	Version = "2.1.0-alpha.2"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
**Purpose**

This PR adds support for sending `acr_values` when requesting a authorization code. If `acr_values` are sent with a request, we extract the `acr` claim from the ID token and make sure it matches what we went. If `provider` is set, we process the `acr` claim in a provider specific manner.

A sample configuration file:

```yaml
authentication:
   type: oidc
   oidc:
      id: local idp
      redirect_url: https://localhost:3080/v1/webapi/oidc/callback
      acr_values: "foo"
      provider: netiq
      client_id: 000000000000-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.example.com
      client_secret: AAAAAAAAAAAAAAAAAAAAAAAA
      issuer_url: https://oidc.example.com
      display: "Login with IDP"
      scope: [ "group", "username", "email" ]
      claims_to_roles:
         ...
```

**Implementation**

* When building the request to obtain an authorization code, we add set `acr_values` if it exists within the  OIDC connector. If identity provider specific processing is requested, `provider` needs to be set as well.
* At the moment the only supported values for `provider` are `"netiq"` and `""`.
* After exchanging the authorization code for a ID token, we extract the claims from the ID token, if `acr_values` is set in the connector, we validate using either using custom rules or default rules.
* Minor code cleanup, use `trace.NotFound`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/901