### PR TITLE
agent regression fix

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -338,7 +338,9 @@ func (a *Agent) runHeartbeat(conn *ssh.Client) {
 	// when this happens, this is #1 issue we have right now with Teleport. So I'm making
 	// it EASY to see in the logs. This condition should never be permanent (like repeates
 	// every XX seconds)
-	log.Warn(err)
+	if err != nil {
+		log.Warn(err)
+	}
 
 	if err != nil || conn == nil {
 		select {

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -24,6 +24,17 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// RemoveDirCloser removes directory and all it's contents
+// when Close is called
+type RemoveDirCloser struct {
+	Path string
+}
+
+// Close removes directory and all it's contents
+func (r *RemoveDirCloser) Close() error {
+	return trace.ConvertSystemError(os.RemoveAll(r.Path))
+}
+
 // IsFile returns true if a given file path points to an existing file
 func IsFile(fp string) bool {
 	fi, err := os.Stat(fp)


### PR DESCRIPTION
**Description**

Agent socket is always owned by root instead of the user which causes permission denied errors when using non-root accounts.

**Implementation**

Change the owner of the socket to the system user it belongs to.