### PR TITLE
Use CheckAndSetDefaults in tctl and add KindNode to default list of

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -147,6 +147,8 @@ type Role interface {
 	CanForwardAgent() bool
 	// SetForwardAgent sets forward agent property
 	SetForwardAgent(forwardAgent bool)
+	// CheckAndSetDefaults checks and set default values for missing fields.
+	CheckAndSetDefaults() error
 }
 
 // RoleV2 represents role resource specification

--- a/lib/web/ui/roleaccess.go
+++ b/lib/web/ui/roleaccess.go
@@ -21,6 +21,7 @@ var adminResources = []string{
 	teleservices.KindCertAuthority,
 	teleservices.KindReverseTunnel,
 	teleservices.KindTrustedCluster,
+	teleservices.KindNode,
 }
 
 // AdminAccess describes admin access

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -998,6 +998,10 @@ func (u *CreateCommand) Create(client *auth.TunClient) error {
 			if err != nil {
 				return trace.Wrap(err)
 			}
+			err = role.CheckAndSetDefaults()
+			if err != nil {
+				return trace.Wrap(err)
+			}
 			if err := client.UpsertRole(role, backend.Forever); err != nil {
 				return trace.Wrap(err)
 			}


### PR DESCRIPTION
**Purpose**

At the moment when creating a resource with `tctl` we don't set defaults for missing fields. This PR changes this to set defaults. In addition, `KindNode` is added to the list of resources granted access to when creating a role in the Web UI.

**Implementation**

* Call `CheckAndSetDefaults` from `tctl`.
* Add `KindNode` to the list of resources granted access to.

**Related Issues**

Fixes https://github.com/gravitational/enterprise/issues/32
Fixes https://github.com/gravitational/enterprise/issues/33