### PR TITLE
Use shellescape library

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,10 +1,11 @@
 {
 	"ImportPath": "github.com/gravitational/teleport",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v74",
+	"GodepVersion": "v76",
 	"Packages": [
 		"./lib/...",
 		"./tool/...",
+		"./lib/web/...",
 		"./integration/..."
 	],
 	"Deps": [
@@ -29,6 +30,11 @@
 		{
 			"ImportPath": "github.com/alecthomas/units",
 			"Rev": "6b4e7dc5e3143b85ea77909c72caf89416fc2915"
+		},
+		{
+			"ImportPath": "github.com/alessio/shellescape",
+			"Comment": "v1.2",
+			"Rev": "52074bc9df61e0d2af85c160b3a325403955d7fb"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws",

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/alessio/shellescape"
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 )
@@ -345,8 +346,8 @@ func (client *NodeClient) Upload(srcPath, rDestPath string, recursive bool, stde
 	if recursive {
 		shellCmd += " -r"
 	}
-	// quote path to mitigate shell injection
-	shellCmd += fmt.Sprintf(" %q", rDestPath)
+	// mitigate shell injection
+	shellCmd += fmt.Sprintf(" %v", shellescape.Quote(rDestPath))
 	return client.scp(scpConf, shellCmd, stderr)
 }
 
@@ -364,8 +365,8 @@ func (client *NodeClient) Download(remoteSourcePath, localDestinationPath string
 	if recursive {
 		shellCmd += " -r"
 	}
-	// quote path to mitigate shell injection
-	shellCmd += fmt.Sprintf(" %q", remoteSourcePath)
+	// mitigate shell injection
+	shellCmd += fmt.Sprintf(" %v", shellescape.Quote(remoteSourcePath))
 	return client.scp(scpConf, shellCmd, stderr)
 }
 

--- a/vendor/github.com/alessio/shellescape/.gitignore
+++ b/vendor/github.com/alessio/shellescape/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/alessio/shellescape/.travis.yml
+++ b/vendor/github.com/alessio/shellescape/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+
+go:
+  - 1.5

--- a/vendor/github.com/alessio/shellescape/AUTHORS
+++ b/vendor/github.com/alessio/shellescape/AUTHORS
@@ -1,0 +1,1 @@
+Alessio Treglia <alessio@debian.org>

--- a/vendor/github.com/alessio/shellescape/LICENSE
+++ b/vendor/github.com/alessio/shellescape/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Alessio Treglia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/alessio/shellescape/README.md
+++ b/vendor/github.com/alessio/shellescape/README.md
@@ -1,0 +1,57 @@
+[![GoDoc](https://godoc.org/github.com/alessio/shellescape?status.svg)](https://godoc.org/github.com/alessio/shellescape) 
+[![Travis-CI Status](https://api.travis-ci.org/alessio/shellescape.png?branch=master)](http://travis-ci.org/#!/alessio/shellescape)
+[![Coverage](http://gocover.io/_badge/github.com/alessio/shellescape)](http://gocover.io/github.com/alessio/shellescape)
+# shellescape
+Escape arbitrary strings for safe use as command line arguments.
+## Contents of the package
+
+This package provides the `shellescape.Quote()` function that returns a
+shell-escaped copy of a string. This functionality could be helpful
+in those cases where it is known that the output of a Go program will
+be appended to/used in the context of shell programs' command line arguments.
+
+This work was inspired by the Python original package [shellescape] 
+(https://pypi.python.org/pypi/shellescape).
+
+## Usage
+
+The following snippet shows a typical unsafe idiom:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Printf("ls -l %s\n", os.Args[1])
+}
+```
+_[See in Go Playground](https://play.golang.org/p/Wj2WoUfH_d)_
+
+Especially when creating pipeline of commands which might end up being
+executed by a shell interpreter, tt is particularly unsafe to not
+escape arguments.
+
+`shellescape.Quote()` comes in handy and to safely escape strings:
+
+```go
+package main
+
+import (
+        "fmt"
+        "os"
+
+        "gopkg.in/alessio/shellescape.v1"
+)
+
+func main() {
+        fmt.Printf("ls -l %s\n", shellescape.Quote(os.Args[1]))
+}
+```
+_[See in Go Playground](https://play.golang.org/p/HJ_CXgSrmp)_
+
+## The escargs utility
+__escargs__ reads lines from the standard input and prints shell-escaped versions. Unlinke __xargs__, blank lines on the standard input are not discarded.

--- a/vendor/github.com/alessio/shellescape/shellescape.go
+++ b/vendor/github.com/alessio/shellescape/shellescape.go
@@ -1,0 +1,39 @@
+/*
+Package shellescape provides the shellescape.Quote to escape arbitrary
+strings for a safe use as command line arguments in the most common
+POSIX shells.
+
+The original Python package which this work was inspired by can be found
+at https://pypi.python.org/pypi/shellescape.
+*/
+package shellescape
+
+/*
+The functionality provided by shellescape.Quote could be helpful
+in those cases where it is known that the output of a Go program will
+be appended to/used in the context of shell programs' command line arguments.
+*/
+
+import (
+	"regexp"
+	"strings"
+)
+
+var pattern *regexp.Regexp
+
+func init() {
+	pattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
+}
+
+// Quote returns a shell-escaped version of the string s. The returned value
+// is a string that can safely be used as one token in a shell command line.
+func Quote(s string) string {
+	if len(s) == 0 {
+		return "''"
+	}
+	if pattern.MatchString(s) {
+		return "'" + strings.Replace(s, "'", "'\"'\"'", -1) + "'"
+	}
+
+	return s
+}


### PR DESCRIPTION
**Purpose**

Double quotes still allow environment variable evaluation, use the shellescape library which uses single quotes.

**Implementation**

* Use `shellescape.Quote` instead of `%q`.