### PR TITLE
Update ExecPath to support android systems

### DIFF
--- a/vendor/github.com/kardianos/osext/osext_procfs.go
+++ b/vendor/github.com/kardianos/osext/osext_procfs.go
@@ -16,7 +16,8 @@ import (
 
 func executable() (string, error) {
 	switch runtime.GOOS {
-	case "linux":
+	//android uses the same /proc filesystem as linux, and is equivalent here.
+	case "linux","android":
 		const deletedTag = " (deleted)"
 		execpath, err := os.Readlink("/proc/self/exe")
 		if err != nil {


### PR DESCRIPTION
ExecPath relies on the /proc filesystem on Linux to determine the executable path. Android uses that same /proc filesystem and should use the same call to determine its executable path.