### PR TITLE
fix panic on concurrent bucket delete, fixes #976

### DIFF
--- a/lib/backend/dir/impl.go
+++ b/lib/backend/dir/impl.go
@@ -206,12 +206,20 @@ func (bk *Backend) DeleteBucket(parent []string, bucket string) error {
 func removeFiles(dir string) error {
 	d, err := os.Open(dir)
 	if err != nil {
-		return trace.ConvertSystemError(err)
+		err = trace.ConvertSystemError(err)
+		if !trace.IsNotFound(err) {
+			return err
+		}
+		return nil
 	}
 	defer d.Close()
 	names, err := d.Readdirnames(-1)
 	if err != nil {
-		return trace.ConvertSystemError(err)
+		err = trace.ConvertSystemError(err)
+		if !trace.IsNotFound(err) {
+			return err
+		}
+		return nil
 	}
 	for _, name := range names {
 		path := filepath.Join(dir, name)
@@ -221,8 +229,7 @@ func removeFiles(dir string) error {
 			if !trace.IsNotFound(err) {
 				return err
 			}
-		}
-		if !fi.IsDir() {
+		} else if !fi.IsDir() {
 			err = os.Remove(path)
 			if err != nil {
 				err = trace.ConvertSystemError(err)


### PR DESCRIPTION
**Purpose**

The following panic would occur sometimes when handling a subsystem request.

```
goroutine 20824 [running]:
panic(0xd9d2e0, 0xc420012050)
    /opt/go/src/runtime/panic.go:500 +0x1a1
github.com/gravitational/teleport/lib/backend/dir.removeFiles(0xc421d82ec0, 0x36, 0x0, 0x0)
    /gopath/src/github.com/gravitational/teleport/lib/backend/dir/impl.go:225 +0x1de
github.com/gravitational/teleport/lib/backend/dir.(*Backend).DeleteBucket(0xc420230080, 0xc4227e9360, 0x2, 0x2, 0xeccca9, 0x5, 0xa, 0x0)
    /gopath/src/github.com/gravitational/teleport/lib/backend/dir/impl.go:199 +0x144
github.com/gravitational/teleport/lib/services/local.(*PresenceService).DeleteAllNodes(0xc4204ec470, 0xeced13, 0x7, 0x0, 0x0)
    /gopath/src/github.com/gravitational/teleport/lib/services/local/presence.go:154 +0xbe
github.com/gravitational/teleport/lib/state.(*CachingAuthClient).GetNodes(0xc4202986e0, 0xeced13, 0x7, 0xc4204b3400, 0x39, 0x39, 0x0, 0x0)
    /gopath/src/github.com/gravitational/teleport/lib/state/cachingaccesspoint.go:281 +0x17a
github.com/gravitational/teleport/lib/srv.(*proxySubsys).proxyToHost(0xc420078b60, 0x15e70e0, 0xc420a90a20, 0x15e06e0, 0xc4203c55c0, 0x15e73e0, 0xc420ff0480, 0xc422582b66, 0x0)
    /gopath/src/github.com/gravitational/teleport/lib/srv/proxy.go:230 +0xc0a
github.com/gravitational/teleport/lib/srv.(*proxySubsys).start(0xc420078b60, 0xc4224f8a00, 0x15e73e0, 0xc420ff0480, 0xc420559640, 0xc421dac1c0, 0xc421e95800, 0xc421e95800)
    /gopath/src/github.com/gravitational/teleport/lib/srv/proxy.go:156 +0x2e9
github.com/gravitational/teleport/lib/srv.(*Server).handleSubsystem(0xc42014a000, 0x15e73e0, 0xc420ff0480, 0xc420559640, 0xc421dac1c0, 0x2, 0xc4221eb6c0)
    /gopath/src/github.com/gravitational/teleport/lib/srv/sshserver.go:968 +0x260
github.com/gravitational/teleport/lib/srv.(*Server).dispatch(0xc42014a000, 0x15e73e0, 0xc420ff0480, 0xc420559640, 0xc421dac1c0, 0xc42198baa0, 0x0)
    /gopath/src/github.com/gravitational/teleport/lib/srv/sshserver.go:834 +0x2ca
github.com/gravitational/teleport/lib/srv.(*Server).handleSessionRequests(0xc42014a000, 0xc4224f8a00, 0x15e73e0, 0xc420ff0480, 0xc421e956e0)
    /gopath/src/github.com/gravitational/teleport/lib/srv/sshserver.go:801 +0x308
created by github.com/gravitational/teleport/lib/srv.(*Server).HandleNewChan
    /gopath/src/github.com/gravitational/teleport/lib/srv/sshserver.go:637 +0x268
```

The root cause of this panic was that `os.Stat` could return a non-NotFound error, and we would still try and access fields within `*os.FileInfo`.

**Implementation**

* Check the result of `os.Stat` and don't process `*os.FileInfo` if it returns an error.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/976