### PR TITLE
Always specify NameID Format

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -88,7 +88,12 @@ const (
 	ConnectorOIDC = "oidc"
 
 	// ConnectorSAML means connector type SAML
-	ConnectorSAML = "oidc"
+	ConnectorSAML = "saml"
+
+	// SAMLPostBinding specifies the POST SAML binding to use
+	SAMLPOSTBinding = "post"
+	// SAMLRedirectBinding specifies SAML redirect binding to use
+	SAMLRedirectBinding = "redirect"
 
 	// DataDirParameterName is the name of the data dir configuration parameter passed
 	// to all backends during initialization

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -326,6 +326,14 @@ type SAMLAuthRequest struct {
 	// RedirectURL will be used by browser
 	RedirectURL string `json:"redirect_url"`
 
+	// AuthnRequestForm is HTML form response that
+	// can be used in HTTP POST binding that uses
+	// self-submitting HTTP POST Form button
+	AuthnRequestForm []byte `json:"authn_request_form"`
+
+	// Binding specifies POST/REDIRECT
+	Binding string `json:"binding"`
+
 	// PublicKey is an optional public key, users want these
 	// keys to be signed by auth servers user CA in case
 	// of successfull auth

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -640,6 +640,7 @@ func (o *SAMLConnectorV2) GetServiceProvider(clock clockwork.Clock) (*saml2.SAML
 		IDPCertificateStore:            &certStore,
 		SPKeyStore:                     keyStore,
 		Clock:                          dsig.NewFakeClock(clock),
+		NameIdFormat:                   "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
 	}
 
 	// adfs specific settings

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/services"
@@ -34,6 +35,17 @@ func (m *Handler) samlSSO(w http.ResponseWriter, r *http.Request, p httprouter.P
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	if response.Binding == teleport.SAMLPOSTBinding && false {
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Cache-Control", "no-cache, no-store")
+		w.Header().Set("Pragma", "no-cache")
+		_, err := w.Write(response.AuthnRequestForm)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return nil, nil
 	}
 
 	http.Redirect(w, r, response.RedirectURL, http.StatusFound)


### PR DESCRIPTION
**Purpose**

As-per the SAML 2.0 spec, the format of the NameID always needs to be specified, even if the format you are specifying is "unspecified".

**Implementation**

Always explicitly set the format of the NameID to `urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified`.