### PR TITLE
Fix ^C ignored issue on CentOS 6.8.

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -185,6 +185,9 @@ func (process *TeleportProcess) connectToAuthService(role teleport.Role) (*Conne
 // NewTeleport takes the daemon configuration, instantiates all required services
 // and starts them under a supervisor, returning the supervisor object
 func NewTeleport(cfg *Config) (*TeleportProcess, error) {
+	// before we do anything reset the SIGINT handler back to the default
+	utils.ResetInterruptSignalHandler()
+
 	if err := validateConfig(cfg); err != nil {
 		return nil, trace.Wrap(err, "Configuration error")
 	}

--- a/lib/utils/signal.go
+++ b/lib/utils/signal.go
@@ -1,0 +1,20 @@
+package utils
+
+/*
+#include <signal.h>
+void resetInterruptSignalHandler() {
+signal(SIGINT, SIG_DFL);
+}
+*/
+import "C"
+
+// ResetInterruptSignal will reset the handler for SIGINT back to the default
+// handler. We need to do this because when sysvinit launches Teleport on some
+// operating systems (like CentOS 6.8) it configures Teleport to ignore SIGINT
+// signals. See the following for more details:
+//
+// http://garethrees.org/2015/08/07/ping/
+// https://github.com/openssh/openssh-portable/commit/4e0f5e1ec9b6318ef251180dbca50eaa01f74536
+func ResetInterruptSignalHandler() {
+	C.resetInterruptSignalHandler()
+}


### PR DESCRIPTION
**Purpose**

On certain operating systems (like CentOS 6.8) when sysvinit launches Teleport it configures it to ignore `SIGINT`. You can see this behavior by connecting to a Teleport node started by sysvinit typing the following:

```
$ nc -l localhost 12345
^C^C^C^C
```

If you `strace` the process and manually send `SIGINT` you'll see it receives `SIGINT` but does nothing:

```
$ strace -p 32867
Process 32867 attached
accept(3, 0x7ffc24beb650, [128])        = ? ERESTARTSYS (To be restarted if SA_RESTART is set)
--- SIGINT {si_signo=SIGINT, si_code=SI_USER, si_pid=33049, si_uid=0} ---
accept(3,
```

To resolve this issue, we need to reset the signal handler to the default signal handler so `SIGINT` can be processed.

**Implementation**

Since Go does not allow us to directly reset the signal handler, we have to use cgo to call the following code when a Teleport process starts:

```
#include <signal.h>
signal(SIGINT, SIG_DFL)
```

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/981

**References**

* http://garethrees.org/2015/08/07/ping/
* https://github.com/openssh/openssh-portable/commit/4e0f5e1ec9b6318ef251180dbca50eaa01f74536
