### PR TITLE
Read user environment when creating child session

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -163,3 +163,6 @@ const (
 	// we don't have another status code for it.
 	RemoteCommandFailure = 255
 )
+
+// MaxEnvironmentFileLines is the maximum number of lines in a environment file.
+const MaxEnvironmentFileLines = 1000

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -81,6 +81,9 @@ type CommandLineFlags struct {
 	GopsAddr string
 	// DiagnosticAddr is listen address for diagnostic endpoint
 	DiagnosticAddr string
+	// PermitUserEnvironment enables reading of ~/.tsh/environment
+	// when creating a new session.
+	PermitUserEnvironment bool
 }
 
 // readConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)
@@ -419,6 +422,10 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	if fc.SSH.Namespace != "" {
 		cfg.SSH.Namespace = fc.SSH.Namespace
 	}
+	if fc.SSH.PermitUserEnvironment {
+		cfg.SSH.PermitUserEnvironment = true
+	}
+
 	// read 'trusted_clusters' section:
 	if fc.Auth.Enabled() && len(fc.Auth.TrustedClusters) > 0 {
 		if err := readTrustedClusters(fc.Auth.TrustedClusters, cfg); err != nil {
@@ -702,6 +709,11 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 		cfg.Auth.StorageConfig.Params = backend.Params{}
 	}
 	cfg.Auth.StorageConfig.Params["data_dir"] = cfg.DataDir
+
+	// command line flag takes precedence over file config
+	if clf.PermitUserEnvironment {
+		cfg.SSH.PermitUserEnvironment = true
+	}
 
 	return nil
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -122,6 +122,7 @@ var (
 		"cache":              true,
 		"ttl":                false,
 		"issuer":             false,
+		"permit_user_env":    false,
 	}
 )
 
@@ -526,10 +527,11 @@ func (u *UniversalSecondFactor) Parse() (services.UniversalSecondFactor, error) 
 
 // SSH is 'ssh_service' section of the config file
 type SSH struct {
-	Service   `yaml:",inline"`
-	Namespace string            `yaml:"namespace,omitempty"`
-	Labels    map[string]string `yaml:"labels,omitempty"`
-	Commands  []CommandLabel    `yaml:"commands,omitempty"`
+	Service               `yaml:",inline"`
+	Namespace             string            `yaml:"namespace,omitempty"`
+	Labels                map[string]string `yaml:"labels,omitempty"`
+	Commands              []CommandLabel    `yaml:"commands,omitempty"`
+	PermitUserEnvironment bool              `yaml:"permit_user_env,omitempty"`
 }
 
 // CommandLabel is `command` section of `ssh_service` in the config file

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -262,13 +262,14 @@ type AuthConfig struct {
 
 // SSHConfig configures SSH server node role
 type SSHConfig struct {
-	Enabled   bool
-	Addr      utils.NetAddr
-	Namespace string
-	Shell     string
-	Limiter   limiter.LimiterConfig
-	Labels    map[string]string
-	CmdLabels services.CommandLabels
+	Enabled               bool
+	Addr                  utils.NetAddr
+	Namespace             string
+	Shell                 string
+	Limiter               limiter.LimiterConfig
+	Labels                map[string]string
+	CmdLabels             services.CommandLabels
+	PermitUserEnvironment bool
 }
 
 // MakeDefaultConfig creates a new Config structure and populates it with defaults

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -548,6 +548,7 @@ func (process *TeleportProcess) initSSH() error {
 			srv.SetSessionServer(conn.Client),
 			srv.SetLabels(cfg.SSH.Labels, cfg.SSH.CmdLabels),
 			srv.SetNamespace(namespace),
+			srv.SetPermitUserEnvironment(cfg.SSH.PermitUserEnvironment),
 		)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -276,6 +276,17 @@ func prepareCommand(ctx *ctx) (*exec.Cmd, error) {
 			c.Env = append(c.Env, fmt.Sprintf("%s=%s", teleport.SSHSessionID, ctx.session.id))
 		}
 	}
+
+	// if the server allows reading in of ~/.tsh/environment read it in
+	// and pass environment variables along to new session
+	if ctx.srv.PermitUserEnvironment() {
+		filename := filepath.Join(osUser.HomeDir, ".tsh", "environment")
+		userEnvs, err := utils.ReadEnvironmentFile(filename)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		c.Env = append(c.Env, userEnvs...)
+	}
 	return c, nil
 }
 

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -94,6 +94,10 @@ type Server struct {
 
 	// clock is a system clock
 	clock clockwork.Clock
+
+	// permitUserEnvironment controls if this server will read ~/.tsh/environment
+	// before creating a new session.
+	permitUserEnvironment bool
 }
 
 // ServerOption is a functional option passed to the server
@@ -188,6 +192,14 @@ func SetNamespace(namespace string) ServerOption {
 	}
 }
 
+// SetPermitUserEnvironment allows you to set the value of permitUserEnvironment.
+func SetPermitUserEnvironment(permitUserEnvironment bool) ServerOption {
+	return func(s *Server) error {
+		s.permitUserEnvironment = permitUserEnvironment
+		return nil
+	}
+}
+
 // New returns an unstarted server
 func New(addr utils.NetAddr,
 	hostname string,
@@ -273,6 +285,12 @@ func (s *Server) Addr() string {
 // ID returns server ID
 func (s *Server) ID() string {
 	return s.uuid
+}
+
+// PermitUserEnvironment returns if ~/.tsh/environment will be read before a
+// session is created by this server.
+func (s *Server) PermitUserEnvironment() bool {
+	return s.permitUserEnvironment
 }
 
 func (s *Server) setAdvertiseIP(ip net.IP) {

--- a/lib/utils/environment.go
+++ b/lib/utils/environment.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/gravitational/teleport"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gravitational/trace"
+)
+
+// ReadEnvironmentFile will read environment variables from a passed in location.
+// Lines that start with "#" or empty lines are ignored. Assignments are in the
+// form name=value and no variable expansion occurs.
+func ReadEnvironmentFile(filename string) ([]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	defer file.Close()
+
+	var lineno int
+	var envs []string
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// follow the lead of OpenSSH and don't allow more than 1,000 environment variables
+		// https://github.com/openssh/openssh-portable/blob/master/session.c#L873-L874
+		lineno = lineno + 1
+		if lineno > teleport.MaxEnvironmentFileLines {
+			return nil, trace.BadParameter("too many lines in environment file %v", filename)
+		}
+
+		// empty lines or lines that start with # are ignored
+		if line == "" || line[0] == '#' {
+			continue
+		}
+
+		// split on first =, if not found, log it and continue
+		idx := strings.Index(line, "=")
+		if idx == -1 {
+			log.Debugf("Bad line %v while reading %v: no = separator found", lineno, filename)
+			continue
+		}
+
+		// split key and value and make sure that key has a name
+		key := line[:idx]
+		value := line[idx+1:]
+		if strings.TrimSpace(key) == "" {
+			log.Debugf("Bad line %v while reading %v: key without name", lineno, filename)
+			continue
+		}
+
+		envs = append(envs, key+"="+value)
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return envs, nil
+}

--- a/lib/utils/environment_test.go
+++ b/lib/utils/environment_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"gopkg.in/check.v1"
+)
+
+type EnvironmentSuite struct{}
+
+var _ = check.Suite(&EnvironmentSuite{})
+var _ = fmt.Printf
+
+func (s *EnvironmentSuite) SetUpSuite(c *check.C) {
+	InitLoggerForTests()
+}
+func (s *EnvironmentSuite) TearDownSuite(c *check.C) {}
+func (s *EnvironmentSuite) SetUpTest(c *check.C)     {}
+func (s *EnvironmentSuite) TearDownTest(c *check.C)  {}
+
+func (s *EnvironmentSuite) TestReadEnvironmentFile(c *check.C) {
+	// contents of environment file
+	rawenv := []byte(`
+foo=bar
+# comment
+foo=bar=baz
+    # comment 2
+=
+foo=
+
+=bar
+`)
+
+	// create a temp file with an environment in it
+	f, err := ioutil.TempFile("", "teleport-environment-")
+	c.Assert(err, check.IsNil)
+	defer os.Remove(f.Name())
+	_, err = f.Write(rawenv)
+	c.Assert(err, check.IsNil)
+	err = f.Close()
+	c.Assert(err, check.IsNil)
+
+	// read in the temp file
+	env, err := ReadEnvironmentFile(f.Name())
+	c.Assert(err, check.IsNil)
+
+	// check we parsed it correctly
+	c.Assert(env, check.DeepEquals, []string{"foo=bar", "foo=bar=baz", "foo="})
+}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -105,6 +105,8 @@ func Run(cmdlineArgs []string, testRun bool) (executedCommand string, conf *serv
 		"Specify gops addr to listen on").Hidden().StringVar(&ccf.GopsAddr)
 	start.Flag("diag-addr",
 		"Start diangonstic endpoint on this address").Hidden().StringVar(&ccf.DiagnosticAddr)
+	start.Flag("permit-user-env",
+		"Enables reading of ~/.tsh/environment when creating a session").BoolVar(&ccf.PermitUserEnvironment)
 
 	// define start's usage info (we use kingpin's "alias" field for this)
 	start.Alias(usageNotes + usageExamples)


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1014, at the moment a new Teleport session only gives you a limited number of environment variables. This PR adds support for reading in of a `~./tsh/environment` that contains environment variables that will be loaded before the shell is executed.

**Implementation**

* Added a `--permit-user-env` CLI flag for `teleport`.
* Added a `permit_user_env` field under `ssh_service` for Teleport file configuration.
* If either of the above are set, `~/.tsh/environment` is read when creating a new child session. Variables in this file are not expanded and lines that start with `#` or are empty are ignored.

**Related Issue**

Fixes https://github.com/gravitational/teleport/issues/1014