### PR TITLE
modify naming scheme to be compatible with ssh-add

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -754,8 +754,8 @@ func (a *AuthCommand) GenerateAndSignKeys(client *auth.TunClient) error {
 		return trace.Wrap(err)
 	}
 
-	certPath := a.genUser + ".cert"
-	keyPath := a.genUser + ".key"
+	certPath := a.genUser + "-cert.pub"
+	keyPath := a.genUser
 	pubPath := a.genUser + ".pub"
 
 	// --out flag


### PR DESCRIPTION
**Purpose**

Change key and certificate file names to match what OpenSSH generates for interoperability.

**Implementation**

```
<identity>.cert -> <identity>-cert.pub
<identity>.key  -> <identity>
<identity>.pub  -> <identity>.pub
```