### PR TITLE
Update profile on OIDC/SAML login

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -960,6 +960,12 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	// update current profile
+	err = tc.SaveProfile("")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// After successfull login we have local agent updated with latest
 	// and greatest auth information, try it now
 	sshConfig.Auth = []ssh.AuthMethod{authMethod}


### PR DESCRIPTION
**Purpose**

When logging in using OIDC or SAML save your profile upon successful login.

**Implementation**

* Upon successful login, call `tc.SaveProfile`.

**Related Issue**

Fixes https://github.com/gravitational/teleport/issues/1013