### PR TITLE
Reply to keepalive@openssh.com messages from clients

### DIFF
--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -1125,6 +1125,15 @@ func (s *SrvSuite) TestLimiter(c *C) {
 	clt.Close()
 }
 
+// TestServerAliveInterval simulates ServerAliveInterval and OpenSSH
+// interoperability by sending a keepalive@openssh.com global request to the
+// server and expecting a response in return.
+func (s *SrvSuite) TestServerAliveInterval(c *C) {
+	ok, _, err := s.clt.SendRequest(teleport.KeepAliveReqType, true, nil)
+	c.Assert(err, IsNil)
+	c.Assert(ok, Equals, true)
+}
+
 // upack holds all ssh signing artefacts needed for signing and checking user keys
 type upack struct {
 	// key is a raw private user key


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/963, OpenSSH allows clients to set `ServerAliveInterval` which sends a `keepalive@openssh.com` request at the configured interval. These requests are sent as global out-of-band requests and Teleport was logging and discarding all requests. This PR changes this behavior by adding a handler for keep alive requests.

**Implementation**

* Added a handler for `keepalive@openssh.com` messages that logs and replies (if requested) to the request.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/963
