### PR TITLE
Update profile on OIDC/SAML login

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -356,6 +356,17 @@ func onSSH(cf *CLIConf) {
 		utils.FatalError(err)
 	}
 
+	// set the OnAuthentication callback which gets called with the authentication
+	// result. if the user has successfully authenticated, save their profile.
+	tc.OnAuthentication = func(ok bool) {
+		if ok {
+			err := tc.SaveProfile("")
+			if err != nil {
+				utils.FatalError(err)
+			}
+		}
+	}
+
 	tc.Stdin = os.Stdin
 	if err = tc.SSH(context.TODO(), cf.RemoteCommand, cf.LocalExec); err != nil {
 		// exit with the same exit status as the failed command:


### PR DESCRIPTION
**Purpose**

Create a authentication callback in `TeleportClient` that can be used to save your profile upon successful login.

**Implementation**

* Upon success or failure call `OnAuthentication` with the result.
* In `tsh`, if authentication was successful, save the users profile.

**Related Issue**

Fixes https://github.com/gravitational/teleport/issues/1013