### PR TITLE
Always read tsh profile.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -192,11 +192,11 @@ func MakeDefaultConfig() *Config {
 
 // LoadProfile populates Config with the values stored in the given
 // profiles directory. If profileDir is an empty string, the default profile
-// directory ~/.tsh is used
-func (c *Config) LoadProfile(profileDir string) error {
+// directory ~/.tsh is used.
+func (c *Config) LoadProfile(profileDir string, proxyName string) error {
 	profileDir = FullProfilePath(profileDir)
 	// read the profile:
-	cp, err := ProfileFromDir(profileDir)
+	cp, err := ProfileFromDir(profileDir, proxyName)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil

--- a/lib/client/profile_test.go
+++ b/lib/client/profile_test.go
@@ -60,8 +60,13 @@ func (s *ProfileTestSuite) TestEverything(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(stat.Size() > 10, check.Equals, true)
 
-	// load and verify:
-	clone, err := ProfileFromDir(home)
+	// load and verify from symlink
+	clone, err := ProfileFromDir(home, "")
+	c.Assert(err, check.IsNil)
+	c.Assert(*clone, check.DeepEquals, *p)
+
+	// load and verify directly
+	clone, err = ProfileFromDir(home, "test")
 	c.Assert(err, check.IsNil)
 	c.Assert(*clone, check.DeepEquals, *p)
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -511,11 +511,11 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 	// 1: start with the defaults
 	c := client.MakeDefaultConfig()
 
-	// 2: override with `./tsh` profiles (but only if no proxy is given via the CLI)
-	if cf.Proxy == "" {
-		if err = c.LoadProfile(""); err != nil {
-			fmt.Printf("WARNING: Failed loading tsh profile.\n%v\n", err)
-		}
+	// 2: load profile. if no --proxy is given use ~/.tsh/profile symlink otherwise
+	// fetch profile for exact proxy we are trying to connect to.
+	err = c.LoadProfile("", cf.Proxy)
+	if err != nil {
+		fmt.Printf("WARNING: Failed to load tsh profile for %q: %v\n", cf.Proxy, err)
 	}
 
 	// 3: override with the CLI flags


### PR DESCRIPTION
**Purpose**

At the moment, we are only reading `tsh` profiles if you do not set the `--proxy` flag. This PR changes this behavior to always read profiles.

**Implementation**

`tsh` behavior has been changed to always read profiles.

* If no `--proxy` flag is set, then it reads from the default profile symlink `~/<tsh-dir>/profile`.
* If the `--proxy` flag is set, then read profile from `~/<tsh-dir>/<proxy-host>.yaml`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1047