### PR TITLE
Better Access Denied Error

### DIFF
--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -987,6 +987,11 @@ func (c *TunClient) getClient() (client *ssh.Client, err error) {
 		if err == nil {
 			return client, nil
 		}
+		// if it's an auth failure, fail right away because all auth servers are backed
+		// by the same data store and result does not depend on which auth server you hit.
+		if trace.IsAccessDenied(err) {
+			return nil, trace.Wrap(err)
+		}
 		log.Debugf("%v.getClient() throttle auth server %v: %v", c, authServer, err)
 		c.throttleAuthServer(authServer.String())
 	}


### PR DESCRIPTION
**Purpose**

When connecting to an Auth Server, if the failure is a `trace.AccessDenied` error, return it right away instead of trying all Auth Servers before failing with a generic `all auth servers are offline` message.

**Implementation**

* If the error is `trace.AccessDenied` return it immediately.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1052