### PR TITLE
If we can't connect to an Auth Server log it at level ERROR.

### DIFF
--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -992,7 +992,7 @@ func (c *TunClient) getClient() (client *ssh.Client, err error) {
 		if trace.IsAccessDenied(err) {
 			return nil, trace.Wrap(err)
 		}
-		log.Debugf("%v.getClient() throttle auth server %v: %v", c, authServer, err)
+		log.Errorf("%v.getClient() error while connecting to auth server %v: %v: throttling", c, authServer, err)
 		c.throttleAuthServer(authServer.String())
 	}
 	return nil, trace.ConnectionProblem(nil, "all auth servers are offline")


### PR DESCRIPTION
**Purpose**

We loop over all Auth Servers trying to connect to each one in turn. If we are unable to connect to a server we log the reason at the DEBUG level, and if we are unable to connect to any of them we finally log `all auth servers are offline` at the ERROR level.

This PR changes this behavior to log the intermediate failures at the ERROR level as well so it is easier to discover why we were not able to connect to an Auth Server.

**Implementation**

* Change log line from DEBUG to ERROR.

**Related Issue**

Fixes https://github.com/gravitational/teleport/issues/1021