### PR TITLE
Return errors from GetSession

### DIFF
--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -271,15 +271,19 @@ func (s *server) GetSessions(namespace string) ([]Session, error) {
 	keys, err := s.bk.GetKeys(bucket)
 	if err != nil {
 		log.Error(err)
-		return nil, err
+		return nil, trace.Wrap(err)
 	}
 	for i, sid := range keys {
 		if i > MaxSessionSliceLength {
 			break
 		}
 		se, err := s.GetSession(namespace, ID(sid))
-		if trace.IsNotFound(err) {
-			continue
+		if err != nil {
+			if trace.IsNotFound(err) {
+				continue
+			}
+			log.Errorf("Unable to retrieve session: %v", err)
+			return nil, trace.Wrap(err)
 		}
 		out = append(out, *se)
 	}
@@ -317,6 +321,7 @@ func (s *server) GetSession(namespace string, id ID) (*Session, error) {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("session(%v, %v) is not found", namespace, id)
 		}
+		return nil, trace.Wrap(err)
 	}
 	return sess, nil
 }

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -683,7 +683,7 @@ func (s *session) pollAndSync() {
 	errCount := 0
 	sync := func() error {
 		sess, err := sessionServer.GetSession(ns, s.id)
-		if sess == nil {
+		if err != nil || sess == nil {
 			return trace.Wrap(err)
 		}
 		var active = true


### PR DESCRIPTION
**Purpose**

`GetSession()` was hiding errors, this PR changes this behavior by returning errors other than `trace.NotFound` errors.

**Implementation**

* Update `GetSession` to return non `trace.NotFound` errors.
* Update `GetSessions` to propagate errors (this way we don't try and append a `nil` session to a slice).
* In `pollAndSync` propagate the error if either we have an error or if the session is `nil`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1002