### PR TITLE
Configurable Cipher, KEX, and MAC

### DIFF
--- a/docs/2.0/admin-guide.md
+++ b/docs/2.0/admin-guide.md
@@ -190,6 +190,34 @@ teleport:
     storage:
         type: bolt
 
+    # Cipher algorithms that the server supports. This section only needs to be
+    # set if you want to override the defaults.
+    ciphers:
+      - aes128-ctr
+      - aes192-ctr
+      - aes256-ctr
+      - aes128-gcm@openssh.com
+      - arcfour256
+      - arcfour128
+
+    # Key exchange algorithms that the server supports. This section only needs
+    # to be set if you want to override the defaults.
+    kex_algos:
+      - kexAlgoCurve25519SHA256
+      - kexAlgoECDH256
+      - kexAlgoECDH384
+      - kexAlgoECDH521
+      - kexAlgoDH14SHA1
+      - kexAlgoDH1SHA1
+
+    # Message authentication code (MAC) algorithms that the server supports.
+    # This section only needs to be set if you want to override the defaults.
+    mac_algos:
+      - hmac-sha2-256-etm@openssh.com
+      - hmac-sha2-256
+      - hmac-sha1
+      - hmac-sha1-96
+
 # This section configures the 'auth service':
 auth_service:
     # Turns 'auth' role on. Default is 'yes'

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -221,6 +221,17 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		cfg.Auth.DynamicConfig = *fc.SeedConfig
 	}
 
+	// apply ciphers, kex algorithms, and mac algorithms
+	if fc.Ciphers != nil {
+		cfg.Ciphers = fc.Ciphers
+	}
+	if fc.KEXAlgorithms != nil {
+		cfg.KEXAlgorithms = fc.KEXAlgorithms
+	}
+	if fc.MACAlgorithms != nil {
+		cfg.MACAlgorithms = fc.MACAlgorithms
+	}
+
 	// apply connection throttling:
 	limiters := []limiter.LimiterConfig{
 		cfg.SSH.Limiter,

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -335,6 +335,48 @@ teleport:
 	}
 }
 
+// TestFileConfigCheck makes sure we don't start with invalid settings.
+func (s *ConfigTestSuite) TestFileConfigCheck(c *check.C) {
+	tests := []struct {
+		inConfigString string
+		outError       bool
+	}{
+		// 0 - all defaults, valid
+		{
+			`
+teleport:
+`,
+			false,
+		},
+		// 1 - invalid cipher, not valid
+		{
+			`
+teleport:
+  ciphers:
+    - aes256-ctr
+    - fake-cipher
+  kex_algos:
+    - kexAlgoCurve25519SHA256
+  mac_algos:
+    - hmac-sha2-256-etm@openssh.com
+`,
+			true,
+		},
+	}
+
+	// run tests
+	for i, tt := range tests {
+		comment := check.Commentf("Test %v", i)
+
+		_, err := ReadConfig(bytes.NewBufferString(tt.inConfigString))
+		if tt.outError {
+			c.Assert(err, check.NotNil, comment)
+		} else {
+			c.Assert(err, check.IsNil, comment)
+		}
+	}
+}
+
 func (s *ConfigTestSuite) TestApplyConfig(c *check.C) {
 	conf, err := ReadConfig(bytes.NewBufferString(SmallConfigString))
 	c.Assert(err, check.IsNil)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -546,6 +546,9 @@ func (process *TeleportProcess) initSSH() error {
 			srv.SetLabels(cfg.SSH.Labels, cfg.SSH.CmdLabels),
 			srv.SetNamespace(namespace),
 			srv.SetPermitUserEnvironment(cfg.SSH.PermitUserEnvironment),
+			srv.SetCiphers(cfg.Ciphers),
+			srv.SetKEXAlgorithms(cfg.KEXAlgorithms),
+			srv.SetMACAlgorithms(cfg.MACAlgorithms),
 		)
 		if err != nil {
 			return trace.Wrap(err)
@@ -706,6 +709,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		srv.SetProxyMode(tsrv),
 		srv.SetSessionServer(conn.Client),
 		srv.SetAuditLog(conn.Client),
+		srv.SetCiphers(cfg.Ciphers),
+		srv.SetKEXAlgorithms(cfg.KEXAlgorithms),
+		srv.SetMACAlgorithms(cfg.MACAlgorithms),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -98,6 +98,18 @@ type Server struct {
 	// permitUserEnvironment controls if this server will read ~/.tsh/environment
 	// before creating a new session.
 	permitUserEnvironment bool
+
+	// ciphers is a list of ciphers that the server supports. If omitted,
+	// the defaults will be used.
+	ciphers []string
+
+	// kexAlgorithms is a list of key exchange (KEX) algorithms that the
+	// server supports. If omitted, the defaults will be used.
+	kexAlgorithms []string
+
+	// macAlgorithms is a list of message authentication codes (MAC) that
+	// the server supports. If omitted the defaults will be used.
+	macAlgorithms []string
 }
 
 // ServerOption is a functional option passed to the server
@@ -200,6 +212,27 @@ func SetPermitUserEnvironment(permitUserEnvironment bool) ServerOption {
 	}
 }
 
+func SetCiphers(ciphers []string) ServerOption {
+	return func(s *Server) error {
+		s.ciphers = ciphers
+		return nil
+	}
+}
+
+func SetKEXAlgorithms(kexAlgorithms []string) ServerOption {
+	return func(s *Server) error {
+		s.kexAlgorithms = kexAlgorithms
+		return nil
+	}
+}
+
+func SetMACAlgorithms(macAlgorithms []string) ServerOption {
+	return func(s *Server) error {
+		s.macAlgorithms = macAlgorithms
+		return nil
+	}
+}
+
 // New returns an unstarted server
 func New(addr utils.NetAddr,
 	hostname string,
@@ -252,7 +285,10 @@ func New(addr utils.NetAddr,
 		addr, s, signers,
 		sshutils.AuthMethods{PublicKey: s.keyAuth},
 		sshutils.SetLimiter(s.limiter),
-		sshutils.SetRequestHandler(s))
+		sshutils.SetRequestHandler(s),
+		sshutils.SetCiphers(s.ciphers),
+		sshutils.SetKEXAlgorithms(s.kexAlgorithms),
+		sshutils.SetMACAlgorithms(s.macAlgorithms))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -149,6 +149,36 @@ func SetRequestHandler(req RequestHandler) ServerOption {
 	}
 }
 
+func SetCiphers(ciphers []string) ServerOption {
+	return func(s *Server) error {
+		log.Debugf("[SSH:%v] Supported Ciphers: %q", s.component, ciphers)
+		if ciphers != nil {
+			s.cfg.Ciphers = ciphers
+		}
+		return nil
+	}
+}
+
+func SetKEXAlgorithms(kexAlgorithms []string) ServerOption {
+	return func(s *Server) error {
+		log.Debugf("[SSH:%v] Supported KEX algorithms: %q", s.component, kexAlgorithms)
+		if kexAlgorithms != nil {
+			s.cfg.KeyExchanges = kexAlgorithms
+		}
+		return nil
+	}
+}
+
+func SetMACAlgorithms(macAlgorithms []string) ServerOption {
+	return func(s *Server) error {
+		log.Debugf("[SSH:%v] Supported MAC algorithms: %q", s.component, macAlgorithms)
+		if macAlgorithms != nil {
+			s.cfg.MACs = macAlgorithms
+		}
+		return nil
+	}
+}
+
 func (s *Server) Addr() string {
 	return s.listener.Addr().String()
 }


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1062, at the moment Teleport does not allow you to configure the list of ciphers, KEX algorithms, or MAC algorithms that the server supports. This PR adds this ability.

**Implementation**

* Created `ciphers`, `kex_algos`, and `mac_algos` to the file configuration under the global `teleport` section.
* Created a `Check` function on `FileConfig` to make sure the passed in ciphers are supported.
* `MakeDefaultConfig` has been updated to pick up default ciphers from `golang.org/x/crypto/ssh`.
* Ciphers, KEX algorithms, and MAC algorithms are propagated to the SSH server in `lib/sshutils` in `ServerConfig`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1062