### PR TITLE
Improve RBAC logging when checking access to a server.

### DIFF
--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -527,8 +527,8 @@ func (s *Server) checkPermissionToLogin(cert *ssh.Certificate, teleportUser, osU
 	}
 
 	if err := roles.CheckAccessToServer(osUser, s.getInfo()); err != nil {
-		return "", trace.AccessDenied("user %s@%s is not authorized to login as %v@%s",
-			teleportUser, ca.GetClusterName(), osUser, domainName)
+		return "", trace.AccessDenied("user %s@%s is not authorized to login as %v@%s: %v",
+			teleportUser, ca.GetClusterName(), osUser, domainName, err)
 	}
 
 	return domainName, nil
@@ -692,7 +692,7 @@ func (s *Server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permiss
 	}
 	clusterName, err := s.checkPermissionToLogin(cert, teleportUser, conn.User())
 	if err != nil {
-		logger.Error(err)
+		logger.Errorf("Permission denied: %v", err)
 		logAuditEvent(err)
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1055, right now our debug logging doesn't tell us why access was denied which makes RBAC issues difficult to debug. This PR adds additional logging and updates the existing logging to make it easier to understand why access was denied.

**Implementation**

Upon failure to login, a log line like the following will be emitted:

```
ERRO[0011] Permission denied: user rjones@one is not authorized to login as rjones@two: access to node two-node is denied to role(s): [Role developer denied access; match(namespace=true, label=false, login=true)]  file=srv/sshserver.go:696 fingerprint=ssh-rsa-cert-v01@openssh.com 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00 func=srv.(*Server).keyAuth local=127.0.0.1:5022 remote=127.0.0.1:62643 user=rjones
```

The following audit log will be emitted:

```json
{
	"error": "user rjones@one is not authorized to login as rjones@two: access to node two-node is denied to role(s): [Role developer denied access; match(namespace=true, label=false, login=true)]",
	"event": "auth",
	"success": false,
	"time": "2017-06-13T22:15:23Z",
	"user": "rjones"
}
```

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1055