### PR TITLE
Process ENV_PATH and ENV_SUPATH from login.defs.

### DIFF
--- a/fixtures/login.defs
+++ b/fixtures/login.defs
@@ -99,7 +99,7 @@ HUSHLOGIN_FILE	.hushlogin
 # *REQUIRED*  The default PATH settings, for superuser and normal users.
 #
 # (they are minimal, add the rest in the shell startup files)
-ENV_SUPATH	PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV_SUPATH	PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/bar
 ENV_PATH	PATH=/usr/local/bin:/usr/bin:/bin:/foo
 
 #

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -72,7 +72,7 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 	expectedEnv := []string{
 		"LANG=en_US.UTF-8",
-		getDefaultEnvPath(""),
+		getDefaultEnvPath("1000", defaultLoginDefsPath),
 		fmt.Sprintf("HOME=%s", s.usr.HomeDir),
 		fmt.Sprintf("USER=%s", s.usr.Username),
 		"SHELL=/bin/sh",
@@ -115,8 +115,12 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 }
 
 func (s *ExecSuite) TestLoginDefsParser(c *check.C) {
-	c.Assert(getDefaultEnvPath("../../fixtures/login.defs"), check.Equals, "PATH=/usr/local/bin:/usr/bin:/bin:/foo")
-	c.Assert(getDefaultEnvPath("bad/file"), check.Equals, "PATH="+defaultPath)
+	expectedEnvSuPath := "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/bar"
+	expectedSuPath := "PATH=/usr/local/bin:/usr/bin:/bin:/foo"
+
+	c.Assert(getDefaultEnvPath("0", "../../fixtures/login.defs"), check.Equals, expectedEnvSuPath)
+	c.Assert(getDefaultEnvPath("1000", "../../fixtures/login.defs"), check.Equals, expectedSuPath)
+	c.Assert(getDefaultEnvPath("1000", "bad/file"), check.Equals, defaultEnvPath)
 }
 
 // implementation of ssh.Conn interface


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1046, Teleport does not process `ENV_SUPATH` for root. This PR adds support for processing `ENV_SUPATH` as well as fallback values.

**Implementation**

* When looking for the default path in `login.defs` look for `ENV_PATH` for normal users and `ENV_SUPATH` for users with UID of `0`.
* If `ENV_SUPATH` is not available for a user with UID `0`, then first fallback to `ENV_PATH` the fallback to the Teleport default. 

**Related Issue**

Fixes https://github.com/gravitational/teleport/issues/1046