### PR TITLE
Better error logging for users with misconfigured shell

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -533,7 +533,7 @@ func (s *session) start(ch ssh.Channel, ctx *ctx) error {
 	}
 	ctx.Debugf("session exec: %#v", cmd)
 	if err := s.term.run(cmd); err != nil {
-		ctx.Errorf("shell command failed: %v", err)
+		ctx.Errorf("shell command (%v %v) failed: %v", cmd.Path, cmd.Args, err)
 		return trace.ConvertSystemError(err)
 	}
 	if err := s.addParty(p); err != nil {


### PR DESCRIPTION
This small change was inspired by #1053 where the OS user did not have shell confnigured. But OpenSSH launches default `/bin/sh` for such users.

Basically, two changes:

* better error logging
* usage of `/bin/sh` if no shell is defined.

Thoughts?