### PR TITLE
More reliable make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ clean:
 	rm -rf $(BUILDDIR)
 	rm -rf teleport
 	rm -rf *.gz
+	rm -rf `go env GOPATH`/pkg/`go env GOHOSTOS`_`go env GOARCH`/github.com/gravitational/teleport*
 
 
 #


### PR DESCRIPTION
`make clean` now removes not only output binaries, but also object files for Teleport in the packages dir under $GOHOME.

So, running `make` after `make clean` will guarantee that every file will be rebuilt.