### PR TITLE
SAML logging and regression fixes

### DIFF
--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -263,8 +263,8 @@ func (a *AuthServer) buildRoles(connector services.OIDCConnector, ident *oidc.Id
 	if len(roles) == 0 {
 		role, err := connector.RoleFromTemplate(claims)
 		if err != nil {
-			log.Warningf("[OIDC] Unable to map claims to roles or role templates for %q", connector.GetName())
-			return nil, trace.AccessDenied("unable to map claims to roles or role templates for %q", connector.GetName())
+			log.Warningf("[OIDC] Unable to map claims to roles or role templates for %q: %v", connector.GetName(), err)
+			return nil, trace.AccessDenied("unable to map claims to roles or role templates for %q: %v", connector.GetName(), err)
 		}
 
 		// figure out ttl for role. expires = now + ttl  =>  ttl = expires - now
@@ -273,8 +273,8 @@ func (a *AuthServer) buildRoles(connector services.OIDCConnector, ident *oidc.Id
 		// upsert templated role
 		err = a.Access.UpsertRole(role, ttl)
 		if err != nil {
-			log.Warningf("[OIDC] Unable to upsert templated role for connector: %q", connector.GetName())
-			return nil, trace.AccessDenied("unable to upsert templated role: %q", connector.GetName())
+			log.Warningf("[OIDC] Unable to upsert templated role for connector: %q: %v", connector.GetName(), err)
+			return nil, trace.AccessDenied("unable to upsert templated role: %q: %v", connector.GetName(), err)
 		}
 
 		roles = []string{role.GetName()}

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -88,8 +88,8 @@ func (a *AuthServer) buildSAMLRoles(connector services.SAMLConnector, assertionI
 	if len(roles) == 0 {
 		role, err := connector.RoleFromTemplate(assertionInfo)
 		if err != nil {
-			log.Warningf("[SAML] Unable to map claims to roles or role templates for %q", connector.GetName())
-			return nil, trace.AccessDenied("unable to map claims to roles or role templates for %q", connector.GetName())
+			log.Warningf("[SAML] Unable to map claims to roles or role templates for %q: %v", connector.GetName(), err)
+			return nil, trace.AccessDenied("unable to map claims to roles or role templates for %q: %v", connector.GetName(), err)
 		}
 
 		// figure out ttl for role. expires = now + ttl  =>  ttl = expires - now
@@ -98,8 +98,8 @@ func (a *AuthServer) buildSAMLRoles(connector services.SAMLConnector, assertionI
 		// upsert templated role
 		err = a.Access.UpsertRole(role, ttl)
 		if err != nil {
-			log.Warningf("[SAML] Unable to upsert templated role for connector: %q", connector.GetName())
-			return nil, trace.AccessDenied("unable to upsert templated role: %q", connector.GetName())
+			log.Warningf("[SAML] Unable to upsert templated role for connector: %q: %v", connector.GetName(), err)
+			return nil, trace.AccessDenied("unable to upsert templated role: %q: %v", connector.GetName(), err)
 		}
 
 		roles = []string{role.GetName()}

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -456,7 +456,7 @@ func (o *OIDCConnectorV2) RoleFromTemplate(claims jose.Claims) (Role, error) {
 		}
 	}
 
-	return nil, trace.Errorf("unable to create role from template")
+	return nil, trace.BadParameter("no matching claim name/value, claims: %q", claims)
 }
 
 // Check returns nil if all parameters are great, err otherwise

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -435,6 +435,11 @@ func (o *SAMLConnectorV2) MapAttributes(assertionInfo saml2.AssertionInfo) []str
 	return utils.Deduplicate(roles)
 }
 
+// executeSAMLStringTemplate takes a raw template string and a map of
+// assertions to execute a template and generate output. Because the data
+// structure used to execute the template is a map, the format of the raw
+// string is expected to be {{index . "key"}}. See
+// https://golang.org/pkg/text/template/ for more details.
 func executeSAMLStringTemplate(raw string, assertion map[string]string) (string, error) {
 	tmpl, err := template.New("dynamic-roles").Parse(raw)
 	if err != nil {
@@ -449,6 +454,11 @@ func executeSAMLStringTemplate(raw string, assertion map[string]string) (string,
 	return buf.String(), nil
 }
 
+// executeSAMLStringTemplate takes raw template strings and a map of
+// assertions to execute templates and generate a slice of output. Because the
+// data structure used to execute the template is a map, the format of each raw
+// string is expected to be {{index . "key"}}. See
+// https://golang.org/pkg/text/template/ for more details.
 func executeSAMLSliceTemplate(raw []string, assertion map[string]string) ([]string, error) {
 	var sl []string
 


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1080, at the moment SAML and role templates do not work. This PR makes the appropriate changes so we can build dynamic roles once again.

**Implementation**

* Improved logging so it's more clear why we were unable to create a dynamic role for both SAML and OIDC.
* Added `buildAssertionMap` function that is used to transform `saml2.AssertionInfo` into `map[string]string` which is easier to work with and can be passed directly to `tmpl.Execute`.
* Fixed the logic in `RoleFromTemplate` to check assertion names against mapping names and assertion values against mapping values.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1080