### PR TITLE
OpenSSH user certificate compatibility 

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -166,3 +166,13 @@ const (
 
 // MaxEnvironmentFileLines is the maximum number of lines in a environment file.
 const MaxEnvironmentFileLines = 1000
+
+const (
+	// CompatibilityOldSSH is used to make Teleport interoperate with older
+	// versions of OpenSSH.
+	CompatibilityOldSSH = "oldssh"
+
+	// CompatibilityNone is used for normal Teleport operation without any
+	// compatibility modes.
+	CompatibilityNone = ""
+)

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -337,7 +337,7 @@ func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *servic
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		user.Key.Cert, err = auth.GenerateUserCert(user.Key.Pub, teleUser, logins, ttl, true)
+		user.Key.Cert, err = auth.GenerateUserCert(user.Key.Pub, teleUser, logins, ttl, true, teleport.CompatibilityNone)
 		if err != nil {
 			return err
 		}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -715,9 +715,10 @@ func (s *APIServer) generateHostCert(auth ClientI, w http.ResponseWriter, r *htt
 }
 
 type generateUserCertReq struct {
-	Key  []byte        `json:"key"`
-	User string        `json:"user"`
-	TTL  time.Duration `json:"ttl"`
+	Key           []byte        `json:"key"`
+	User          string        `json:"user"`
+	TTL           time.Duration `json:"ttl"`
+	Compatibility string        `json:"compatibility,omitempty"`
 }
 
 func (s *APIServer) generateUserCert(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
@@ -725,7 +726,11 @@ func (s *APIServer) generateUserCert(auth ClientI, w http.ResponseWriter, r *htt
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	cert, err := auth.GenerateUserCert(req.Key, req.User, req.TTL)
+	compatibility, err := utils.CheckCompatibilityFlag(req.Compatibility)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cert, err := auth.GenerateUserCert(req.Key, req.User, req.TTL, compatibility)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -235,7 +235,7 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 	authServer, userClient := s.newServerWithAuthorizer(c, authorizer)
 	defer authServer.Close()
 
-	cert, err = userClient.GenerateUserCert(pub, "user1", time.Hour)
+	cert, err = userClient.GenerateUserCert(pub, "user1", time.Hour, teleport.CompatibilityNone)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "auth API: access denied [00]")
 
@@ -245,7 +245,7 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 	authServer2, userClient2 := s.newServerWithAuthorizer(c, authorizer)
 	defer authServer2.Close()
 
-	cert, err = userClient2.GenerateUserCert(pub, "user1", time.Hour)
+	cert, err = userClient2.GenerateUserCert(pub, "user1", time.Hour, teleport.CompatibilityNone)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, ".*cannot request a certificate for user1")
 
@@ -255,7 +255,7 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 	authServer3, userClient3 := s.newServerWithAuthorizer(c, authorizer)
 	defer authServer3.Close()
 
-	cert, err = userClient3.GenerateUserCert(pub, "user1", 40*time.Hour)
+	cert, err = userClient3.GenerateUserCert(pub, "user1", 40*time.Hour, teleport.CompatibilityNone)
 	c.Assert(err, IsNil)
 	parsedKey, _, _, _, err := ssh.ParseAuthorizedKey(cert)
 	c.Assert(err, IsNil)
@@ -278,7 +278,7 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 	authServer4, userClient4 := s.newServerWithAuthorizer(c, authorizer)
 	defer authServer4.Close()
 
-	cert, err = userClient4.GenerateUserCert(pub, "user1", 1*time.Hour)
+	cert, err = userClient4.GenerateUserCert(pub, "user1", 1*time.Hour, teleport.CompatibilityNone)
 	c.Assert(err, IsNil)
 	parsedKey, _, _, _, err = ssh.ParseAuthorizedKey(cert)
 	c.Assert(err, IsNil)
@@ -289,7 +289,7 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 	c.Assert(exists, Equals, true)
 
 	// apply HTTP Auth to generate user cert:
-	cert, err = userClient3.GenerateUserCert(pub, "user1", time.Hour)
+	cert, err = userClient3.GenerateUserCert(pub, "user1", time.Hour, teleport.CompatibilityNone)
 	c.Assert(err, IsNil)
 
 	_, _, _, _, err = ssh.ParseAuthorizedKey(cert)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -215,7 +215,7 @@ func (s *AuthServer) GenerateHostCert(hostPublicKey []byte, hostID, nodeName, cl
 
 // GenerateUserCert generates user certificate, it takes pkey as a signing
 // private key (user certificate authority)
-func (s *AuthServer) GenerateUserCert(key []byte, user services.User, allowedLogins []string, ttl time.Duration, canForwardAgents bool) ([]byte, error) {
+func (s *AuthServer) GenerateUserCert(key []byte, user services.User, allowedLogins []string, ttl time.Duration, canForwardAgents bool, compatibility string) ([]byte, error) {
 	ca, err := s.Trust.GetCertAuthority(services.CertAuthID{
 		Type:       services.UserCA,
 		DomainName: s.DomainName,
@@ -228,13 +228,14 @@ func (s *AuthServer) GenerateUserCert(key []byte, user services.User, allowedLog
 		return nil, trace.Wrap(err)
 	}
 	return s.Authority.GenerateUserCert(services.UserCertParams{
-		PrivateCASigningKey: privateKey,
-		PublicUserKey:       key,
-		Username:            user.GetName(),
-		AllowedLogins:       allowedLogins,
-		TTL:                 ttl,
+		PrivateCASigningKey:   privateKey,
+		PublicUserKey:         key,
+		Username:              user.GetName(),
+		AllowedLogins:         allowedLogins,
+		TTL:                   ttl,
+		Roles:                 user.GetRoles(),
+		Compatibility:         compatibility,
 		PermitAgentForwarding: canForwardAgents,
-		Roles: user.GetRoles(),
 	})
 }
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -365,7 +365,7 @@ func (a *AuthWithRoles) GenerateHostCert(
 	return a.authServer.GenerateHostCert(key, hostID, nodeName, clusterName, roles, ttl)
 }
 
-func (a *AuthWithRoles) GenerateUserCert(key []byte, username string, ttl time.Duration) ([]byte, error) {
+func (a *AuthWithRoles) GenerateUserCert(key []byte, username string, ttl time.Duration, compatibility string) ([]byte, error) {
 	if err := a.currentUserAction(username); err != nil {
 		return nil, trace.AccessDenied("%v cannot request a certificate for %v", a.user.GetName(), username)
 	}
@@ -398,7 +398,7 @@ func (a *AuthWithRoles) GenerateUserCert(key []byte, username string, ttl time.D
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GenerateUserCert(
-		key, user, allowedLogins, sessionTTL, checker.CanForwardAgents())
+		key, user, allowedLogins, sessionTTL, checker.CanForwardAgents(), compatibility)
 }
 
 func (a *AuthWithRoles) CreateSignupToken(user services.UserV1) (token string, e error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -742,17 +742,16 @@ func (c *Client) GenerateHostCert(
 	return []byte(cert), nil
 }
 
-// GenerateUserCert takes the public key in the Open SSH ``authorized_keys``
-// plain text format, signs it using User Certificate Authority signing key and returns the
-// resulting certificate.
-func (c *Client) GenerateUserCert(
-	key []byte, user string, ttl time.Duration) ([]byte, error) {
-
+// GenerateUserCert takes the public key in the OpenSSH `authorized_keys` plain
+// text format, signs it using User Certificate Authority signing key and
+// returns the resulting certificate.
+func (c *Client) GenerateUserCert(key []byte, user string, ttl time.Duration, compatibility string) ([]byte, error) {
 	out, err := c.PostJSON(c.Endpoint("ca", "user", "certs"),
 		generateUserCertReq{
-			Key:  key,
-			User: user,
-			TTL:  ttl,
+			Key:           key,
+			User:          user,
+			TTL:           ttl,
+			Compatibility: compatibility,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1610,10 +1609,10 @@ type IdentityService interface {
 	// resulting certificate.
 	GenerateHostCert(key []byte, hostID, nodeName, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error)
 
-	// GenerateUserCert takes the public key in the Open SSH ``authorized_keys``
+	// GenerateUserCert takes the public key in the OpenSSH `authorized_keys`
 	// plain text format, signs it using User Certificate Authority signing key and returns the
 	// resulting certificate.
-	GenerateUserCert(key []byte, user string, ttl time.Duration) ([]byte, error)
+	GenerateUserCert(key []byte, user string, ttl time.Duration, compatibility string) ([]byte, error)
 
 	// GetSignupTokenData returns token data for a valid token
 	GetSignupTokenData(token string) (user string, otpQRCode []byte, e error)

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -218,7 +218,7 @@ func (a *AuthServer) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthResponse, 
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		cert, err := a.GenerateUserCert(req.PublicKey, user, allowedLogins, certTTL, roles.CanForwardAgents())
+		cert, err := a.GenerateUserCert(req.PublicKey, user, allowedLogins, certTTL, roles.CanForwardAgents(), req.Compatibility)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -315,7 +315,7 @@ func (a *AuthServer) ValidateSAMLResponse(samlResponse string) (*SAMLAuthRespons
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		cert, err := a.GenerateUserCert(request.PublicKey, user, allowedLogins, certTTL, roles.CanForwardAgents())
+		cert, err := a.GenerateUserCert(request.PublicKey, user, allowedLogins, certTTL, roles.CanForwardAgents(), request.Compatibility)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -61,6 +61,8 @@ type UserCertParams struct {
 	PermitAgentForwarding bool
 	// Roles is a list of roles assigned to this user
 	Roles []string
+	// Compatibility specifies OpenSSH compatibility flags.
+	Compatibility string
 }
 
 // CertRoles defines certificate roles

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -285,6 +285,9 @@ type OIDCAuthRequest struct {
 	// ClientRedirectURL is a URL client wants to be redirected
 	// after successfull authentication
 	ClientRedirectURL string `json:"client_redirect_url"`
+
+	// Compatibility specifies OpenSSH compatibility flags.
+	Compatibility string `json:"compatibility,omitempty"`
 }
 
 // Check returns nil if all parameters are great, err otherwise
@@ -341,6 +344,9 @@ type SAMLAuthRequest struct {
 	// ClientRedirectURL is a URL client wants to be redirected
 	// after successfull authentication
 	ClientRedirectURL string `json:"client_redirect_url"`
+
+	// Compatibility specifies OpenSSH compatibility flags.
+	Compatibility string `json:"compatibility,omitempty"`
 }
 
 // Check returns nil if all parameters are great, err otherwise

--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -929,7 +929,7 @@ func newUpack(username string, allowedLogins []string, a *auth.AuthServer) (*upa
 		return nil, trace.Wrap(err)
 	}
 
-	ucert, err := a.GenerateUserCert(upub, user, allowedLogins, 0, true)
+	ucert, err := a.GenerateUserCert(upub, user, allowedLogins, 0, true, teleport.CompatibilityNone)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -203,6 +203,16 @@ func SliceContainsStr(slice []string, value string) bool {
 	return false
 }
 
+// CheckCompatibilityFlag check that the compatibility flag is valid.
+func CheckCompatibilityFlag(s string) (string, error) {
+	switch s {
+	case teleport.CompatibilityNone, teleport.CompatibilityOldSSH:
+		return s, nil
+	default:
+		return teleport.CompatibilityNone, trace.BadParameter("invalid compatibility parameter: %q", s)
+	}
+}
+
 const (
 	// HumanTimeFormatString is a human readable date formatting
 	HumanTimeFormatString = "Mon Jan _2 15:04 UTC"

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -526,6 +526,7 @@ func (m *Handler) oidcLoginConsole(w http.ResponseWriter, r *http.Request, p htt
 			PublicKey:         req.PublicKey,
 			CertTTL:           req.CertTTL,
 			CheckUser:         true,
+			Compatibility:     req.Compatibility,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -61,6 +61,7 @@ func (m *Handler) samlSSOConsole(w http.ResponseWriter, r *http.Request, p httpr
 			ClientRedirectURL: req.RedirectURL,
 			PublicKey:         req.PublicKey,
 			CertTTL:           req.CertTTL,
+			Compatibility:     req.Compatibility,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -325,7 +325,7 @@ func (s *sessionCache) GetCertificateWithoutOTP(c client.CreateSSHCertReq) (*cli
 	}
 	defer clt.Close()
 
-	return createCertificate(c.User, c.PubKey, c.TTL, clt)
+	return createCertificate(c.User, c.PubKey, c.TTL, c.Compatibility, clt)
 }
 
 func (s *sessionCache) GetCertificateWithOTP(c client.CreateSSHCertReq) (*client.SSHLoginResponse, error) {
@@ -340,11 +340,11 @@ func (s *sessionCache) GetCertificateWithOTP(c client.CreateSSHCertReq) (*client
 	}
 	defer clt.Close()
 
-	return createCertificate(c.User, c.PubKey, c.TTL, clt)
+	return createCertificate(c.User, c.PubKey, c.TTL, c.Compatibility, clt)
 }
 
-func createCertificate(user string, pubkey []byte, ttl time.Duration, clt *auth.TunClient) (*client.SSHLoginResponse, error) {
-	cert, err := clt.GenerateUserCert(pubkey, user, ttl)
+func createCertificate(user string, pubkey []byte, ttl time.Duration, compatibility string, clt *auth.TunClient) (*client.SSHLoginResponse, error) {
+	cert, err := clt.GenerateUserCert(pubkey, user, ttl, compatibility)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -368,12 +368,14 @@ func (s *sessionCache) GetCertificateWithU2F(c client.CreateSSHCertWithU2FReq) (
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	clt, err := auth.NewTunClient("web.session-u2f", s.authServers, c.User, method)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer clt.Close()
-	return createCertificate(c.User, c.PubKey, c.TTL, clt)
+
+	return createCertificate(c.User, c.PubKey, c.TTL, c.Compatibility, clt)
 }
 
 func (s *sessionCache) GetUserInviteInfo(token string) (user string, otpQRCode []byte, err error) {


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1083, starting in Teleport 2.2.0 we have started including roles in the certificate extensions when issuing user certificates. This causes problems in versions of OpenSSH older than 7.1: https://bugzilla.mindrot.org/show_bug.cgi?id=2387

To work around this issue, we are introducing a optional command line flag `--compat=oldssh` to both `tsh` and `tctl` that can be used to request certificates in the legacy format.

**Implementation**

* In `lib/auth/native/native.go` when generating a certificate, if the passed in compatibility parameter is `oldssh` we omit setting the roles in the user certificate extensions.
* `tsh` has been updated to support a command line flag `--compat=oldssh`. `tsh` validates the value of the parameter then passes it along to the certificate generation code.
* `tctl` has been updated to support a command line flag `--compat=oldssh` to be used with `tctl auth sign`. `tctl` also validates the value of the parameter then passes it along to the certificate generation code.
* The Auth Server also validates values for the compatibility parameter.

**Related Issue**

Fixes https://github.com/gravitational/teleport/issues/1083