### PR TITLE
Remove -cover flag from test target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ run-docs:
 # tests everything: called by Jenkins
 #
 .PHONY: test
-test: FLAGS ?= -cover
+test: FLAGS ?=
 test: 
 	go test -v ./tool/tsh/... \
 			   ./lib/... \


### PR DESCRIPTION
**Purpose**

We've recently had an issue where we've found data races using the `-race` flag on our Jenkins box but we've been unable to reproduce these running tests on `metal` or a MacBook Pro. Because we run tests with the `-cover` flag as well, this makes hunting down the problem difficult because `-cover` injects code into source which can lead to incorrect line numbers: https://go-review.googlesource.com/c/38640/

This PR removed the `-cover` flag so it's easier to discover/resolve issues the race detector finds that can not be reproduced on `metal` or our MacBooks.

**Implementation**

* Removed `-cover` flag from `Makefile`.

**Related Issues**

https://github.com/gravitational/teleport/issues/1040

