### PR TITLE
Release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.1
+
+### Improvements
+
+* Added `--compat=oldssh` to both `tsh` and `tctl` that can be used to request certificates in the legacy format (no roles in extensions). [#1083](https://github.com/gravitational/teleport/issues/1083)
+
+### Bugfixes
+
+* Fixed multiple regressions when using SAML with dynamic roles. [#1080](https://github.com/gravitational/teleport/issues/1080)
+
 ## 2.2.0
 
 ### Features

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=2.2.0
+VERSION=2.2.1
 
 # These are standard autotools variables, don't change them please
 BUILDDIR ?= build

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "2.2.0"
+	Version = "2.2.1"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
**Purpose**

Teleport 2.2.1 is a maintenance release which contains a improvement and bug fix.

* Added `--compat=oldssh` to both `tsh` and `tctl` that can be used to request certificates in the legacy format (no roles in extensions). [#1083](https://github.com/gravitational/teleport/issues/1083)
* Fixed multiple regressions when using SAML with dynamic roles. [#1080](https://github.com/gravitational/teleport/issues/1080)

**Implementation**

n/a

**Related Issues**

Closes https://github.com/gravitational/teleport/milestone/17