### PR TITLE
Enterprise-as-submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,6 @@ tmp
 *.[568vq]
 [568vq].out
 
-# enterprise submodule
-e
-
 *.cgo1.go
 *.cgo2.c
 _cgo_defun.c

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ tmp
 *.[568vq]
 [568vq].out
 
+# enterprise submodule
+e
+
 *.cgo1.go
 *.cgo2.c
 _cgo_defun.c

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "e"]
+	path = e
+	url = git@github.com:gravitational/teleport.e.git

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LIBS = $(shell find lib -type f -name '*.go') *.go
 # Default target: builds all 3 executables and plaaces them in a current directory
 #
 .PHONY: all
-all: $(VERSRC) $(BINARIES) 
+all: $(VERSRC) $(BINARIES)
 
 $(BUILDDIR)/tctl: $(LIBS) $(TOOLS) tool/tctl/common/*.go tool/tctl/*go
 	go build -o $(BUILDDIR)/tctl -i $(BUILDFLAGS) ./tool/tctl
@@ -51,7 +51,6 @@ install: build
 	cp -f $(BUILDDIR)/tsh       $(BINDIR)/
 	cp -f $(BUILDDIR)/teleport  $(BINDIR)/
 	mkdir -p $(DATADIR)
-	cp -fr web/dist/* $(DATADIR)
 
 
 .PHONY: clean
@@ -60,6 +59,7 @@ clean:
 	rm -rf teleport
 	rm -rf *.gz
 	rm -rf `go env GOPATH`/pkg/`go env GOHOSTOS`_`go env GOARCH`/github.com/gravitational/teleport*
+	@if [ -f e/Makefile ]; then $(MAKE) -C e clean; fi
 
 
 #
@@ -202,3 +202,7 @@ buildbox-grpc:
       --gofast_out=plugins=grpc:.\
     *.proto
 
+# Enterprise build
+.PHONY:enterprise
+enterprise:
+	@if [ -f e/Makefile ]; then $(MAKE) -C e; fi

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Teleport enables teams to easily adopt the best SSH practices like:
 - Record and replay SSH sessions for knowledge sharing and auditing purposes.
 - Collaboratively troubleshoot issues through session sharing.
 - Connect to clusters located behind firewalls without direct Internet access via SSH bastions.
-- Ability to integrate SSH credentials with your organization identities via OAuth (Google Apps, Github).
+- Ability to integrate SSH credentials with your organization identities via OpenID Connect or SAML with endpoints like Okta or Active Directory.
 - Keep the full audit log of all SSH sessions within a cluster.
 
 Teleport is built on top of the high-quality [Golang SSH](https://godoc.org/golang.org/x/crypto/ssh) 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -36,7 +36,7 @@ bbox:
 # Runs tests inside a build container 
 #
 .PHONY:test
-test: integration
+test: bbox
 	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
 		/bin/bash -c \
 		"examples/etcd/start-etcd.sh & sleep 1; \

--- a/examples/local-cluster/tctl.sh
+++ b/examples/local-cluster/tctl.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cd auth && tctl -c teleport.yaml $1 $2 $3
+cd auth && tctl -c teleport.yaml "$@"

--- a/lib/state/cachingaccesspoint.go
+++ b/lib/state/cachingaccesspoint.go
@@ -119,7 +119,10 @@ func NewCachingAuthClient(config Config) (*CachingAuthClient, error) {
 	if !cs.SkipPreload {
 		err := cs.fetchAll()
 		if err != nil {
-			log.Warningf("failed to fetch results for cache %v", err)
+			// we almost always get some "access denied" errors here because
+			// not all cacheable resources are available (for example nodes do
+			// not have access to tunnels)
+			log.Debugf("Auth cache: %v", err)
 		}
 	}
 	return cs, nil

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -163,9 +163,13 @@ func ReadOrMakeHostUUID(dataDir string) (string, error) {
 	return id, nil
 }
 
-// PrintVersion prints human readable version
-func PrintVersion() {
-	ver := fmt.Sprintf("Teleport v%s", teleport.Version)
+// PrintVersion prints human readable version.
+//   - distro: name of the distribution. Empty string for OSS or "enterprise"
+func PrintVersion(distro string) {
+	if distro != "" {
+		distro = " " + distro
+	}
+	ver := fmt.Sprintf("Teleport%s v%s", distro, teleport.Version)
 	if teleport.Gitref != "" {
 		ver = fmt.Sprintf("%s git:%s", ver, teleport.Gitref)
 	}

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -45,7 +45,6 @@ import (
 	"github.com/buger/goterm"
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"golang.org/x/crypto/ssh"
 	kyaml "k8s.io/client-go/1.4/pkg/util/yaml"
 )
@@ -110,13 +109,6 @@ type AuthServerCommand struct {
 	config *service.Config
 }
 
-type ReverseTunnelCommand struct {
-	config      *service.Config
-	domainNames string
-	dialAddrs   utils.NetAddrList
-	ttl         time.Duration
-}
-
 type TokenCommand struct {
 	config *service.Config
 	// token argument to 'tokens del' command
@@ -141,7 +133,11 @@ type DeleteCommand struct {
 	ref    services.Ref
 }
 
-func Run() {
+// Run() is the same as 'make'. It helps to share the code between different
+// "distributions" like OSS or Enterprise
+//
+// distribution: name of the Teleport distribution
+func Run(distribution string) {
 	utils.InitLogger(utils.LoggingForCLI, logrus.WarnLevel)
 	app := utils.InitCLIParser("tctl", GlobalHelpString)
 
@@ -150,7 +146,6 @@ func Run() {
 	cmdUsers := UserCommand{config: cfg}
 	cmdNodes := NodeCommand{config: cfg}
 	cmdAuth := AuthCommand{config: cfg}
-	cmdReverseTunnel := ReverseTunnelCommand{config: cfg}
 	cmdTokens := TokenCommand{config: cfg}
 	cmdGet := GetCommand{config: cfg}
 	cmdCreate := CreateCommand{config: cfg}
@@ -227,8 +222,6 @@ func Run() {
 
 	// operations with authorities
 	auth := app.Command("auth", "Operations with user and host certificate authorities (CAs)").Hidden()
-	authList := auth.Command("ls", "List trusted certificate authorities (CAs)")
-	authList.Flag("type", "certificate type: 'user' or 'host'").StringVar(&cmdAuth.authType)
 	authExport := auth.Command("export", "Export public cluster (CA) keys to stdout")
 	authExport.Flag("keys", "if set, will print private keys").BoolVar(&cmdAuth.exportPrivateKeys)
 	authExport.Flag("fingerprint", "filter authority by fingerprint").StringVar(&cmdAuth.exportAuthorityFingerprint)
@@ -246,19 +239,6 @@ func Run() {
 	authSign.Flag("ttl", "TTL (time to live) for the generated certificate").Default(fmt.Sprintf("%v", defaults.CertDuration)).DurationVar(&cmdAuth.genTTL)
 	authSign.Flag("compat", "OpenSSH compatibility flag").StringVar(&cmdAuth.compatibility)
 
-	// operations with reverse tunnels
-	reverseTunnels := app.Command("tunnels", "Operations on reverse tunnels clusters").Hidden()
-	reverseTunnelsList := reverseTunnels.Command("ls", "List tunnels").Hidden()
-	reverseTunnelsDelete := reverseTunnels.Command("del", "Delete a tunnel").Hidden()
-	reverseTunnelsDelete.Arg("name", "Tunnels to delete").
-		Required().StringVar(&cmdReverseTunnel.domainNames)
-	reverseTunnelsUpsert := reverseTunnels.Command("add", "Create a new reverse tunnel").Hidden()
-	reverseTunnelsUpsert.Arg("name", "Name of the tunnel").
-		Required().StringVar(&cmdReverseTunnel.domainNames)
-	reverseTunnelsUpsert.Arg("addrs", "Comma-separated list of tunnels").
-		Required().SetValue(&cmdReverseTunnel.dialAddrs)
-	reverseTunnelsUpsert.Flag("ttl", "Optional TTL (time to live) for the tunnel").DurationVar(&cmdReverseTunnel.ttl)
-
 	// parse CLI commands+flags:
 	command, err := app.Parse(os.Args[1:])
 	if err != nil {
@@ -267,7 +247,7 @@ func Run() {
 
 	// "version" command?
 	if command == ver.FullCommand() {
-		onVersion()
+		utils.PrintVersion(distribution)
 		return
 	}
 
@@ -309,16 +289,8 @@ func Run() {
 		err = cmdNodes.Invite(client)
 	case nodeList.FullCommand():
 		err = cmdNodes.ListActive(client)
-	case authList.FullCommand():
-		err = cmdAuth.ListAuthorities(client)
 	case authExport.FullCommand():
 		err = cmdAuth.ExportAuthorities(client)
-	case reverseTunnelsList.FullCommand():
-		err = cmdReverseTunnel.ListActive(client)
-	case reverseTunnelsDelete.FullCommand():
-		err = cmdReverseTunnel.Delete(client)
-	case reverseTunnelsUpsert.FullCommand():
-		err = cmdReverseTunnel.Upsert(client)
 	case tokenList.FullCommand():
 		err = cmdTokens.List(client)
 	case tokenDel.FullCommand():
@@ -336,10 +308,6 @@ func Ref(s kingpin.Settings) *services.Ref {
 	r := new(services.Ref)
 	s.SetValue(r)
 	return r
-}
-
-func onVersion() {
-	utils.PrintVersion()
 }
 
 func printHeader(t *goterm.Table, cols []string) {
@@ -487,83 +455,6 @@ func (u *NodeCommand) ListActive(client *auth.TunClient) error {
 	}
 	coll := &serverCollection{servers: nodes}
 	coll.writeText(os.Stdout)
-	return nil
-}
-
-// ListAuthorities shows list of user authorities we trust
-func (a *AuthCommand) ListAuthorities(client *auth.TunClient) error {
-	// by default show authorities of both types:
-	authTypes := []services.CertAuthType{
-		services.UserCA,
-		services.HostCA,
-	}
-	// but if there was a --type switch, only select those:
-	if a.authType != "" {
-		authTypes = []services.CertAuthType{services.CertAuthType(a.authType)}
-		if err := authTypes[0].Check(); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	localAuthName, err := client.GetDomainName()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	var (
-		localCAs   []services.CertAuthority
-		trustedCAs []services.CertAuthority
-	)
-	for _, t := range authTypes {
-		cas, err := client.GetCertAuthorities(t, false)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		for i := range cas {
-			if cas[i].GetClusterName() == localAuthName {
-				localCAs = append(localCAs, cas[i])
-			} else {
-				trustedCAs = append(trustedCAs, cas[i])
-			}
-		}
-	}
-	localCAsView := func() string {
-		t := goterm.NewTable(0, 10, 5, ' ', 0)
-		printHeader(t, []string{"CA Type", "Fingerprint"})
-		for _, a := range localCAs {
-			for _, keyBytes := range a.GetCheckingKeys() {
-				fingerprint, err := sshutils.AuthorizedKeyFingerprint(keyBytes)
-				if err != nil {
-					fingerprint = fmt.Sprintf("<bad key: %v", err)
-				}
-				fmt.Fprintf(t, "%v\t%v\n", a.GetType(), fingerprint)
-			}
-		}
-		return fmt.Sprintf("CA keys for the local cluster %v:\n\n", localAuthName) +
-			t.String()
-	}
-	trustedCAsView := func() string {
-		t := goterm.NewTable(0, 10, 5, ' ', 0)
-		printHeader(t, []string{"Cluster Name", "CA Type", "Fingerprint", "Roles"})
-		for _, a := range trustedCAs {
-			for _, keyBytes := range a.GetCheckingKeys() {
-				fingerprint, err := sshutils.AuthorizedKeyFingerprint(keyBytes)
-				if err != nil {
-					fingerprint = fmt.Sprintf("<bad key: %v", err)
-				}
-				var logins string
-				if a.GetType() == services.HostCA {
-					logins = "N/A"
-				} else {
-					logins = strings.Join(a.GetRoles(), ",")
-				}
-				fmt.Fprintf(t, "%v\t%v\t%v\t%v\n", a.GetClusterName(), a.GetType(), fingerprint, logins)
-			}
-		}
-		return "\nCA Keys for Trusted Clusters:\n\n" + t.String()
-	}
-	fmt.Printf(localCAsView())
-	if len(trustedCAs) > 0 {
-		fmt.Printf(trustedCAsView())
-	}
 	return nil
 }
 
@@ -816,45 +707,6 @@ func (a *AuthCommand) GenerateAndSignKeys(client *auth.TunClient) error {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("Private key: %v\nCertificate: %v\n", keyPath, certPath)
-	}
-	return nil
-}
-
-// ListActive retreives the list of nodes who recently sent heartbeats to
-// to a cluster and prints it to stdout
-func (r *ReverseTunnelCommand) ListActive(client *auth.TunClient) error {
-	tunnels, err := client.GetReverseTunnels()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	coll := &reverseTunnelCollection{tunnels: tunnels}
-	coll.writeText(os.Stdout)
-	return nil
-}
-
-// Upsert updates or inserts new reverse tunnel
-func (r *ReverseTunnelCommand) Upsert(client *auth.TunClient) error {
-	tunnel := services.NewReverseTunnel(r.domainNames, r.dialAddrs.Addresses())
-	tunnel.SetTTL(clockwork.NewRealClock(), r.ttl)
-	err := client.UpsertReverseTunnel(tunnel)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	fmt.Printf("Reverse tunnel updated\n")
-	return nil
-}
-
-// Delete deletes teleport user(s). User IDs are passed as a comma-separated
-// list in UserCommand.login
-func (r *ReverseTunnelCommand) Delete(client *auth.TunClient) error {
-	for _, domainName := range strings.Split(r.domainNames, ",") {
-		if err := client.DeleteReverseTunnel(domainName); err != nil {
-			if trace.IsNotFound(err) {
-				return trace.Errorf("'%v' is not found", domainName)
-			}
-			return trace.Wrap(err)
-		}
-		fmt.Printf("Cluster '%v' has been disconnected\n", domainName)
 	}
 	return nil
 }

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -21,5 +21,8 @@ import (
 )
 
 func main() {
-	common.Run()
+	const (
+		ossDistribution = ""
+	)
+	common.Run(ossDistribution)
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -40,7 +40,10 @@ import (
 )
 
 // same as main() but has a testing switch
-func Run(cmdlineArgs []string, testRun bool) (executedCommand string, conf *service.Config) {
+//   - cmdlineArgs are passed from main()
+//   - distro can be "" (OSS version) or "enterprise"
+//   - testRun is 'true' when running under an integration test
+func Run(cmdlineArgs []string, distro string, testRun bool) (executedCommand string, conf *service.Config) {
 	var err error
 	// configure trace's errors to produce full stack traces
 	isDebug, _ := strconv.ParseBool(os.Getenv(teleport.VerboseLogsEnvVar))
@@ -175,7 +178,7 @@ func Run(cmdlineArgs []string, testRun bool) (executedCommand string, conf *serv
 	case dump.FullCommand():
 		onConfigDump()
 	case ver.FullCommand():
-		onVersion()
+		utils.PrintVersion(distro)
 	}
 	if err != nil {
 		utils.FatalError(err)
@@ -281,9 +284,4 @@ func (rw *StdReadWriter) Read(b []byte) (int, error) {
 
 func (rw *StdReadWriter) Write(b []byte) (int, error) {
 	return os.Stdout.Write(b)
-}
-
-// onVersion is the handler for "version"
-func onVersion() {
-	utils.PrintVersion()
 }

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -30,6 +30,10 @@ import (
 	"gopkg.in/check.v1"
 )
 
+const (
+	ossDistro = ""
+)
+
 // bootstrap check
 func TestTeleportMain(t *testing.T) { check.TestingT(t) }
 
@@ -66,7 +70,7 @@ func (s *MainTestSuite) SetUpSuite(c *check.C) {
 }
 
 func (s *MainTestSuite) TestDefault(c *check.C) {
-	cmd, conf := Run([]string{"start"}, true)
+	cmd, conf := Run([]string{"start"}, ossDistro, true)
 	c.Assert(cmd, check.Equals, "start")
 	c.Assert(conf.Hostname, check.Equals, s.hostname)
 	c.Assert(conf.DataDir, check.Equals, "/tmp/teleport/var/lib/teleport")
@@ -78,17 +82,17 @@ func (s *MainTestSuite) TestDefault(c *check.C) {
 }
 
 func (s *MainTestSuite) TestRolesFlag(c *check.C) {
-	cmd, conf := Run([]string{"start", "--roles=node"}, true)
+	cmd, conf := Run([]string{"start", "--roles=node"}, ossDistro, true)
 	c.Assert(conf.SSH.Enabled, check.Equals, true)
 	c.Assert(conf.Auth.Enabled, check.Equals, false)
 	c.Assert(conf.Proxy.Enabled, check.Equals, false)
 
-	cmd, conf = Run([]string{"start", "--roles=proxy"}, true)
+	cmd, conf = Run([]string{"start", "--roles=proxy"}, ossDistro, true)
 	c.Assert(conf.SSH.Enabled, check.Equals, false)
 	c.Assert(conf.Auth.Enabled, check.Equals, false)
 	c.Assert(conf.Proxy.Enabled, check.Equals, true)
 
-	cmd, conf = Run([]string{"start", "--roles=auth"}, true)
+	cmd, conf = Run([]string{"start", "--roles=auth"}, ossDistro, true)
 	c.Assert(conf.SSH.Enabled, check.Equals, false)
 	c.Assert(conf.Auth.Enabled, check.Equals, true)
 	c.Assert(conf.Proxy.Enabled, check.Equals, false)
@@ -96,7 +100,7 @@ func (s *MainTestSuite) TestRolesFlag(c *check.C) {
 }
 
 func (s *MainTestSuite) TestConfigFile(c *check.C) {
-	cmd, conf := Run([]string{"start", "--roles=node", "--labels=a=a1,b=b1", "--config=" + s.configFile}, true)
+	cmd, conf := Run([]string{"start", "--roles=node", "--labels=a=a1,b=b1", "--config=" + s.configFile}, ossDistro, true)
 	c.Assert(cmd, check.Equals, "start")
 	c.Assert(conf.SSH.Enabled, check.Equals, true)
 	c.Assert(conf.Auth.Enabled, check.Equals, false)

--- a/tool/teleport/main.go
+++ b/tool/teleport/main.go
@@ -23,6 +23,9 @@ import (
 )
 
 func main() {
-	const testRun = false
-	common.Run(os.Args[1:], testRun)
+	const (
+		testRun         = false
+		ossDistribution = ""
+	)
+	common.Run(os.Args[1:], ossDistribution, testRun)
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -220,7 +220,7 @@ func Run(args []string, underTest bool) {
 
 	switch command {
 	case ver.FullCommand():
-		onVersion()
+		utils.PrintVersion("")
 	case ssh.FullCommand():
 		onSSH(&cf)
 	case bench.FullCommand():
@@ -601,10 +601,6 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 	c.Compatibility = compatibility
 
 	return client.NewClient(c)
-}
-
-func onVersion() {
-	utils.PrintVersion()
 }
 
 func printHeader(t *goterm.Table, cols []string) {


### PR DESCRIPTION
## Overview

This PR has two changes:

* New approach to building Enterprise 
* Removes undocumented features from `tctl`

### Building Enterprise 

Instead of keeping Enterprise teleport in a separate repo which re-vendors OSS, this PR moves to a different model: enterprise is still its own repo, but it's a submodule of OSS repo (kept in `e` directory).

Do `git submodule update` and then see more in `e/README.md`.

Also fixed a few cosmetic things that do not affect any functionality.

### Udocumented tctl features

This PR removes undocumented tctl commands for managing CAs and remote tunnels. This is in preparation for cleaning up the overall CLI UX, i.e. removing undocumented things or moving (and documenting them) to enterprise builds.

## TODO

This PR only fixes the OSS side of things. The new procedure for producing Enterprise builds is not done yet.
