### PR TITLE
Remove Unix user name check from Teleport user name.

### DIFF
--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 
-	"github.com/gravitational/configure/cstrings"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 )
@@ -379,8 +378,8 @@ func (u *UserV2) Check() error {
 	if u.Version == "" {
 		return trace.BadParameter("user version is not set")
 	}
-	if !cstrings.IsValidUnixUser(u.Metadata.Name) {
-		return trace.BadParameter("'%v' is not a valid user name", u.Metadata.Name)
+	if u.Metadata.Name == "" {
+		return trace.BadParameter("user name cannot be empty")
 	}
 	for _, id := range u.Spec.OIDCIdentities {
 		if err := id.Check(); err != nil {
@@ -418,8 +417,8 @@ type UserV1 struct {
 
 // Check checks validity of all parameters
 func (u *UserV1) Check() error {
-	if !cstrings.IsValidUnixUser(u.Name) {
-		return trace.BadParameter("'%v' is not a valid user name", u.Name)
+	if u.Name == "" {
+		return trace.BadParameter("user name cannot be empty")
 	}
 	for _, id := range u.OIDCIdentities {
 		if err := id.Check(); err != nil {


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1102, a regression was introduced in Teleport 2.2.0 that does not allow you to list nodes in a Trusted Cluster in certain situations.

This regression occurred because we create a in-memory Teleport user named `remote-{username}-{cluster name}` when running `tsh ls` and perform a `Check` on this user to make sure it's valid. The check fails because we incorrectly try and validate a Teleport user with the rules for a Unix system user (user name can not be longer than 32 characters).

**Implementation**

* Remove the `IsValidUnixUser` from `UserV1` and `UserV2` and simply check if the user name is not empty.

**Related Issue**

Fixes https://github.com/gravitational/teleport/issues/1102