### PR TITLE
Remote clusters should only send their own CAs.

### DIFF
--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -153,6 +153,8 @@ type CertAuthority interface {
 	V1() *CertAuthorityV1
 	// V2 returns V2 version of the resource
 	V2() *CertAuthorityV2
+	// String returns human readable version of the CertAuthority
+	String() string
 }
 
 // NewCertAuthority returns new cert authority
@@ -228,6 +230,11 @@ func (c *CertAuthorityV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
 // V2 returns V2 version of the resouirce - itself
 func (c *CertAuthorityV2) V2() *CertAuthorityV2 {
 	return c
+}
+
+// String returns human readable version of the CertAuthorityV2.
+func (c *CertAuthorityV2) String() string {
+	return fmt.Sprintf("CA(name=%v, type=%v)", c.GetClusterName(), c.GetType())
 }
 
 // V1 returns V1 version of the object
@@ -497,6 +504,11 @@ func (c *CertAuthorityV1) V2() *CertAuthorityV2 {
 		},
 		rawObject: *c,
 	}
+}
+
+// String returns human readable version of the CertAuthorityV1.
+func (c *CertAuthorityV1) String() string {
+	return fmt.Sprintf("CA(name=%v, type=%v)", c.DomainName, c.Type)
 }
 
 var certAuthorityMarshaler CertAuthorityMarshaler = &TeleportCertAuthorityMarshaler{}


### PR DESCRIPTION
**Purpose**

At the moment, when doing a Trusted Cluster exchange, the remote cluster sends all the CAs that it has to the main cluster which then adds these CAs to it's own backend. Then the main CA sends it's CAs to the Trusted Cluster which adds them to it's own backend.

This exchange works correctly the first time it occurs. However if you try and add an existing Trusted Cluster twice, since the Trusted Cluster sends all of the CAs it has, it sends back the CA for the main cluster as well, but it sends it back without signing keys. The main cluster adds it to it's backend which then causes an error similar to the following to occur when trying to add a node (because the CA legitimately no longer has it's signing keys).

```
failed to join the cluster: main has no signing keys
```

To fix this problem, the Trusted Cluster should only send it's own CAs to the main cluster.

**Implementation**

* When the remote cluster gets a list of CAs, filter out all non-local CAs.
* Improved logging so we log the certificate authorities we send and receive. 
* Added test coverage in the integration package to upsert a Trusted Cluster multiple time and check that the right certificates were exchanged.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1050