### PR TITLE
Ev/tsh identity

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 */
 
 package client
@@ -1022,7 +1023,7 @@ func (tc *TeleportClient) Login(activateKey bool) (*Key, error) {
 
 	// generate a new keypair. the public key will be signed via proxy if our
 	// password+OTP are legit
-	key, err := MakeNewKey()
+	key, err := NewKey()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/identity.go
+++ b/lib/client/identity.go
@@ -1,0 +1,106 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+)
+
+// MakeNewKey generates a new unsigned key. Such key must be signed by a
+// Teleport CA (auth server) before it becomes useful.
+func MakeNewKey() (key *Key, err error) {
+	key = &Key{}
+	keygen := native.New()
+	defer keygen.Close()
+	key.Priv, key.Pub, err = keygen.GenerateKeyPair("")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return key, nil
+}
+
+// IdentityFileFormat describes possible file formats how a user identity can be sotred
+type IdentityFileFormat string
+
+const (
+	// IdentityFormatFile is when a key + cert are stored concatenated into a single file
+	IdentityFormatFile IdentityFileFormat = "file"
+
+	// IdentityFormatDir is OpenSSH-compatible format, when a key and a cert are stored in
+	// two different files (in the same directory)
+	IdentityFormatDir IdentityFileFormat = "dir"
+
+	// DefaultIdentityFormat is what Teleport uses by default
+	DefaultIdentityFormat = IdentityFormatFile
+)
+
+// MakeIdentityFile takes a username + his credentials and saves them to disk
+// in a specified format
+func MakeIdentityFile(username, fp string, key *Key, format IdentityFileFormat) (err error) {
+	const (
+		// the files and the dir will be created with these permissions:
+		fileMode = 0600
+		dirMode  = 0770
+	)
+	switch format {
+	// dump user identity into a single file:
+	case IdentityFormatFile:
+		var (
+			output  io.Writer = os.Stdout
+			beQuiet bool      = true
+		)
+		if fp != "" {
+			beQuiet = false
+			f, err := os.OpenFile(fp, os.O_CREATE|os.O_WRONLY, fileMode)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			output = f
+			defer f.Close()
+		}
+		// write key:
+		if _, err = output.Write(key.Priv); err != nil {
+			return trace.Wrap(err)
+		}
+		// append cert:
+		if _, err = output.Write(key.Cert); err != nil {
+			return trace.Wrap(err)
+		}
+		if !beQuiet {
+			fmt.Printf("Identity file: %s\n", fp)
+		}
+	// dump user identity into separate files:
+	case IdentityFormatDir:
+		certPath := username + "-cert.pub"
+		keyPath := username
+
+		// --out flag
+		if fp != "" {
+			if !utils.IsDir(fp) {
+				if err = os.MkdirAll(fp, dirMode); err != nil {
+					return trace.Wrap(err)
+				}
+			}
+			certPath = filepath.Join(fp, certPath)
+			keyPath = filepath.Join(fp, keyPath)
+		}
+
+		err = ioutil.WriteFile(certPath, key.Cert, fileMode)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		err = ioutil.WriteFile(keyPath, key.Priv, fileMode)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("Private key: %v\nCertificate: %v\n", keyPath, certPath)
+	}
+	return nil
+}

--- a/lib/client/identity.go
+++ b/lib/client/identity.go
@@ -1,3 +1,20 @@
+/*
+Copyright 2016 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 package client
 
 import (
@@ -11,9 +28,9 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// MakeNewKey generates a new unsigned key. Such key must be signed by a
+// NewKey generates a new unsigned key. Such key must be signed by a
 // Teleport CA (auth server) before it becomes useful.
-func MakeNewKey() (key *Key, err error) {
+func NewKey() (key *Key, err error) {
 	key = &Key{}
 	keygen := native.New()
 	defer keygen.Close()
@@ -41,18 +58,18 @@ const (
 
 // MakeIdentityFile takes a username + his credentials and saves them to disk
 // in a specified format
-func MakeIdentityFile(username, fp string, key *Key, format IdentityFileFormat) (err error) {
+func MakeIdentityFile(username, filePath string, key *Key, format IdentityFileFormat) (err error) {
 	const (
 		// the files and the dir will be created with these permissions:
-		fileMode = 0600
+		fileMode = 0666
 		dirMode  = 0770
 	)
 	var output io.Writer = os.Stdout
 	switch format {
 	// dump user identity into a single file:
 	case IdentityFormatFile:
-		if fp != "" {
-			f, err := os.OpenFile(fp, os.O_CREATE|os.O_WRONLY, fileMode)
+		if filePath != "" {
+			f, err := os.Create(filePath)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -73,14 +90,14 @@ func MakeIdentityFile(username, fp string, key *Key, format IdentityFileFormat) 
 		keyPath := username
 
 		// --out flag
-		if fp != "" {
-			if !utils.IsDir(fp) {
-				if err = os.MkdirAll(fp, dirMode); err != nil {
+		if filePath != "" {
+			if !utils.IsDir(filePath) {
+				if err = os.MkdirAll(filePath, dirMode); err != nil {
 					return trace.Wrap(err)
 				}
 			}
-			certPath = filepath.Join(fp, certPath)
-			keyPath = filepath.Join(fp, keyPath)
+			certPath = filepath.Join(filePath, certPath)
+			keyPath = filepath.Join(filePath, keyPath)
 		}
 
 		err = ioutil.WriteFile(certPath, key.Cert, fileMode)

--- a/lib/client/identity.go
+++ b/lib/client/identity.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -48,15 +47,11 @@ func MakeIdentityFile(username, fp string, key *Key, format IdentityFileFormat) 
 		fileMode = 0600
 		dirMode  = 0770
 	)
+	var output io.Writer = os.Stdout
 	switch format {
 	// dump user identity into a single file:
 	case IdentityFormatFile:
-		var (
-			output  io.Writer = os.Stdout
-			beQuiet bool      = true
-		)
 		if fp != "" {
-			beQuiet = false
 			f, err := os.OpenFile(fp, os.O_CREATE|os.O_WRONLY, fileMode)
 			if err != nil {
 				return trace.Wrap(err)
@@ -71,9 +66,6 @@ func MakeIdentityFile(username, fp string, key *Key, format IdentityFileFormat) 
 		// append cert:
 		if _, err = output.Write(key.Cert); err != nil {
 			return trace.Wrap(err)
-		}
-		if !beQuiet {
-			fmt.Printf("Identity file: %s\n", fp)
 		}
 	// dump user identity into separate files:
 	case IdentityFormatDir:
@@ -100,7 +92,6 @@ func MakeIdentityFile(username, fp string, key *Key, format IdentityFileFormat) 
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Printf("Private key: %v\nCertificate: %v\n", keyPath, certPath)
 	}
 	return nil
 }

--- a/lib/client/identity.go
+++ b/lib/client/identity.go
@@ -61,15 +61,15 @@ const (
 func MakeIdentityFile(username, filePath string, key *Key, format IdentityFileFormat) (err error) {
 	const (
 		// the files and the dir will be created with these permissions:
-		fileMode = 0666
-		dirMode  = 0770
+		fileMode = 0600
+		dirMode  = 0700
 	)
 	var output io.Writer = os.Stdout
 	switch format {
 	// dump user identity into a single file:
 	case IdentityFormatFile:
 		if filePath != "" {
-			f, err := os.Create(filePath)
+			f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, fileMode)
 			if err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -45,6 +45,23 @@ const (
 	fileNameKnownHosts = "known_hosts"
 )
 
+// LocalKeyStore interface allows for different storage back-ends for TSH to
+// load/save its keys
+//
+// The _only_ filesystem-based implementation of LocalKeyStore is declared
+// below (FSLocalKeyStore)
+type LocalKeyStore interface {
+	// client key management
+	GetKeys(username string) ([]Key, error)
+	AddKey(host string, username string, key *Key) error
+	GetKey(host string, username string) (*Key, error)
+	DeleteKey(host string, username string) error
+
+	// interface to known_hosts file:
+	AddKnownHostKeys(hostname string, keys []ssh.PublicKey) error
+	GetKnownHostKeys(hostname string) ([]ssh.PublicKey, error)
+}
+
 // FSLocalKeyStore implements LocalKeyStore interface using the filesystem
 // Here's the file layout for the FS store:
 // ~/.tsh/

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -754,7 +754,14 @@ func (a *AuthCommand) GenerateAndSignKeys(clusterApi *auth.TunClient) error {
 	}
 
 	// write the cert+private key to the output:
-	return trace.Wrap(client.MakeIdentityFile(a.genUser, a.output, key, a.outputFormat))
+	err = client.MakeIdentityFile(a.genUser, a.output, key, a.outputFormat)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if a.output != "" {
+		fmt.Printf("\nThe certificate has been written to %s\n", a.output)
+	}
+	return nil
 }
 
 // ListActive retreives the list of nodes who recently sent heartbeats to

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -742,7 +742,7 @@ func (a *AuthCommand) GenerateAndSignKeys(clusterApi *auth.TunClient) error {
 	}
 
 	// generate a keypair:
-	key, err := client.MakeNewKey()
+	key, err := client.NewKey()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
@@ -90,16 +90,10 @@ type AuthCommand struct {
 	exportAuthorityFingerprint string
 	exportPrivateKeys          bool
 	output                     string
-	outputFormat               string
+	outputFormat               client.IdentityFileFormat
 	compatVersion              string
 	compatibility              string
 }
-
-const (
-	IdentityFormatFile    = "file"
-	IdentityFormatDir     = "dir"
-	DefaultIdentityFormat = IdentityFormatFile
-)
 
 type SAMLCommand struct {
 	config *service.Config
@@ -242,7 +236,7 @@ func Run() {
 	authSign := auth.Command("sign", "Create an identity file(s) for a given user")
 	authSign.Flag("user", "Teleport user name").Required().StringVar(&cmdAuth.genUser)
 	authSign.Flag("out", "identity output").Short('o').StringVar(&cmdAuth.output)
-	authSign.Flag("format", "identity format: 'file' (default) or 'dir'").Default(DefaultIdentityFormat).StringVar(&cmdAuth.outputFormat)
+	authSign.Flag("format", "identity format: 'file' (default) or 'dir'").Default(string(client.DefaultIdentityFormat)).StringVar((*string)(&cmdAuth.outputFormat))
 	authSign.Flag("ttl", "TTL (time to live) for the generated certificate").Default(fmt.Sprintf("%v", defaults.CertDuration)).DurationVar(&cmdAuth.genTTL)
 	authSign.Flag("compat", "OpenSSH compatibility flag").StringVar(&cmdAuth.compatibility)
 
@@ -740,84 +734,27 @@ func (a *AuthCommand) GenerateKeys() error {
 }
 
 // GenerateAndSignKeys generates a new keypair and signs it for role
-func (a *AuthCommand) GenerateAndSignKeys(client *auth.TunClient) error {
-	ca := native.New()
-	defer ca.Close()
-	privateKey, publicKey, err := ca.GenerateKeyPair("")
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
+func (a *AuthCommand) GenerateAndSignKeys(clusterApi *auth.TunClient) error {
 	// parse compatibility parameter
 	compatibility, err := utils.CheckCompatibilityFlag(a.compatibility)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	cert, err := client.GenerateUserCert(publicKey, a.genUser, a.genTTL, compatibility)
+	// generate a keypair:
+	key, err := client.MakeNewKey()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	switch a.outputFormat {
-	//
-	// dump user identity into a single file:
-	//
-	case IdentityFormatFile:
-		var (
-			output  io.Writer = os.Stdout
-			beQuiet bool      = true
-		)
-		if a.output != "" {
-			beQuiet = false
-			f, err := os.OpenFile(a.output, os.O_CREATE|os.O_WRONLY, 0600)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			output = f
-			defer f.Close()
-		}
-		// write key:
-		if _, err = output.Write(privateKey); err != nil {
-			return trace.Wrap(err)
-		}
-		// append cert:
-		if _, err = output.Write(cert); err != nil {
-			return trace.Wrap(err)
-		}
-		if !beQuiet {
-			fmt.Printf("Identity file: %s\n", a.output)
-		}
-	//
-	// dump user identity into separate files:
-	//
-	case IdentityFormatDir:
-		certPath := a.genUser + "-cert.pub"
-		keyPath := a.genUser
-
-		// --out flag
-		if a.output != "" {
-			if !utils.IsDir(a.output) {
-				if err = os.MkdirAll(a.output, 0770); err != nil {
-					return trace.Wrap(err)
-				}
-			}
-			certPath = filepath.Join(a.output, certPath)
-			keyPath = filepath.Join(a.output, keyPath)
-		}
-
-		err = ioutil.WriteFile(certPath, cert, 0600)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		err = ioutil.WriteFile(keyPath, privateKey, 0600)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("Private key: %v\nCertificate: %v\n", keyPath, certPath)
+	// sign it and produce a cert:
+	key.Cert, err = clusterApi.GenerateUserCert(key.Pub, a.genUser, a.genTTL, compatibility)
+	if err != nil {
+		return trace.Wrap(err)
 	}
-	return nil
+
+	// write the cert+private key to the output:
+	return trace.Wrap(client.MakeIdentityFile(a.genUser, a.output, key, a.outputFormat))
 }
 
 // ListActive retreives the list of nodes who recently sent heartbeats to

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -107,10 +107,16 @@ type CLIConf struct {
 	Gops bool
 	// GopsAddr specifies to gops addr to listen on
 	GopsAddr string
-	// IdentityFile is an argument to -i flag (path to the private key+cert file)
-	IdentityFile string
+	// IdentityFileIn is an argument to -i flag (path to the private key+cert file)
+	IdentityFileIn string
 	// Compatibility flags, --compat, specifies OpenSSH compatibility flags.
 	Compatibility string
+
+	// IdentityFileOut is an argument to -out flag
+	IdentityFileOut string
+	// IdentityFormat (used for --format flag for 'tsh login') defines which
+	// format to use with --out to store a fershly retreived certificate
+	IdentityFormat client.IdentityFileFormat
 }
 
 // Run executes TSH client. same as main() but easier to test
@@ -128,7 +134,7 @@ func Run(args []string, underTest bool) {
 	app.Flag("user", fmt.Sprintf("SSH proxy user [%s]", localUser)).Envar("TELEPORT_USER").StringVar(&cf.Username)
 	app.Flag("cluster", "Specify the cluster to connect").Envar("TELEPORT_SITE").StringVar(&cf.SiteName)
 	app.Flag("ttl", "Minutes to live for a SSH session").Int32Var(&cf.MinsToLive)
-	app.Flag("identity", "Identity file").Short('i').StringVar(&cf.IdentityFile)
+	app.Flag("identity", "Identity file").Short('i').StringVar(&cf.IdentityFileIn)
 	app.Flag("compat", "OpenSSH compatibility flag").StringVar(&cf.Compatibility)
 
 	app.Flag("insecure", "Do not verify server's certificate and host name. Use only in test environments").Default("false").BoolVar(&cf.InsecureSkipVerify)
@@ -145,7 +151,7 @@ func Run(args []string, underTest bool) {
 	ssh.Flag("port", "SSH port on a remote host").Short('p').Int16Var(&cf.NodePort)
 	ssh.Flag("forward", "Forward localhost connections to remote server").Short('L').StringsVar(&cf.LocalForwardPorts)
 	ssh.Flag("local", "Execute command on localhost after connecting to SSH node").Default("false").BoolVar(&cf.LocalExec)
-	ssh.Flag("", "Allocate TTY").Short('t').BoolVar(&cf.Interactive)
+	ssh.Flag("tty", "Allocate TTY").Short('t').BoolVar(&cf.Interactive)
 	// join
 	join := app.Command("join", "Join the active SSH session")
 	join.Arg("session-id", "ID of the session to join").Required().StringVar(&cf.SessionID)
@@ -172,6 +178,8 @@ func Run(args []string, underTest bool) {
 	// login logs in with remote proxy and obtains a "session certificate" which gets
 	// stored in ~/.tsh directory
 	login := app.Command("login", "Log in to a cluster and retreive the session certificate")
+	login.Flag("out", "Identity output").Short('o').StringVar(&cf.IdentityFileOut)
+	login.Flag("format", "Identity format").Default(string(client.DefaultIdentityFormat)).StringVar((*string)(&cf.IdentityFormat))
 
 	// logout deletes obtained session certificates in ~/.tsh
 	logout := app.Command("logout", "Delete a cluster certificate")
@@ -259,16 +267,37 @@ func onPlay(cf *CLIConf) {
 
 // onLogin logs in with remote proxy and gets signed certificates
 func onLogin(cf *CLIConf) {
-	tc, err := makeClient(cf, true)
+	var (
+		err error
+		tc  *client.TeleportClient
+		key *client.Key
+	)
+
+	if cf.IdentityFileIn != "" {
+		utils.FatalError(trace.BadParameter("-i flag cannot be used with login"))
+	}
+
+	// make the teleport client and retreive the certificate from the proxy:
+	tc, err = makeClient(cf, true)
 	if err != nil {
 		utils.FatalError(err)
 	}
 
-	if _, err := tc.Login(); err != nil {
+	// -i flag specified? save the retreived cert into an identity file
+	makeIdentityFile := (cf.IdentityFileOut != "")
+	activateKey := !makeIdentityFile
+
+	if key, err = tc.Login(activateKey); err != nil {
 		utils.FatalError(err)
 	}
-	tc.SaveProfile("")
+	if makeIdentityFile {
+		client.MakeIdentityFile(cf.Username, cf.IdentityFileOut, key, cf.IdentityFormat)
+		fmt.Printf("\nThe certificate has been written to %s\n", cf.IdentityFileOut)
+		return
+	}
 
+	// regular login (without -i flag)
+	tc.SaveProfile("")
 	if tc.SiteName != "" {
 		fmt.Printf("\nYou are now logged into %s as %s\n", tc.SiteName, tc.Username)
 	} else {
@@ -525,7 +554,7 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 	c := client.MakeDefaultConfig()
 
 	// Look if a user identity was given via -i flag
-	if cf.IdentityFile != "" {
+	if cf.IdentityFileIn != "" {
 		var (
 			key          *client.Key
 			identityAuth ssh.AuthMethod
@@ -533,7 +562,7 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 			hostAuthFunc client.HostKeyCallback
 		)
 		// read the ID file and create an "auth method" from it:
-		key, hostAuthFunc, err = loadIdentity(cf.IdentityFile)
+		key, hostAuthFunc, err = loadIdentity(cf.IdentityFileIn)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -171,7 +171,7 @@ func Run(args []string, underTest bool) {
 
 	// login logs in with remote proxy and obtains a "session certificate" which gets
 	// stored in ~/.tsh directory
-	login := app.Command("login", "Log in to the cluster and store the session certificate to avoid login prompts")
+	login := app.Command("login", "Log in to a cluster and retreive the session certificate")
 
 	// logout deletes obtained session certificates in ~/.tsh
 	logout := app.Command("logout", "Delete a cluster certificate")
@@ -619,12 +619,13 @@ func printHeader(t *goterm.Table, cols []string) {
 // refuseArgs helper makes sure that 'args' (list of CLI arguments)
 // does not contain anything other than command
 func refuseArgs(command string, args []string) {
-	if len(args) == 0 {
-		return
-	}
-	lastArg := args[len(args)-1]
-	if lastArg != command {
-		utils.FatalError(trace.BadParameter("%s does not expect arguments", command))
+	for _, arg := range args {
+		if arg == command || strings.HasPrefix(arg, "-") {
+			continue
+		} else {
+			utils.FatalError(trace.BadParameter("unexpected argument: %s", arg))
+		}
+
 	}
 }
 


### PR DESCRIPTION
## Implementation Notes

First of all, this functionality has already been implemented for `tctl auth sign`. All I had to do was:

* Move it out of `tctl` into `lib/client`
* Hook it up into `client.Login()`
* Make sure `client.Login()` does not "activate" the key (i.e. push it into an active `ssh-agent` or store it into `~/.tsh` if `--out` flag is used).

## Details

Moved the identity generation code code from `tctl` into `lib/client/identity.go`.
Updated teleport client:

`TeleportClient.Login()` used to do too much:

* it retreived the cert and stored it in `client.Key`
* it also generated `ssh.AuthMethod` for that key

Now it simply returns `client.Key` but `client.Key` is now perfectly capable of generating the auth method itself via `ssh.AuthMethod()` method.

When --out is used for `tsh login`, we DO NOT save the keys anywhere but the identity file. This means _nothing_ goes into `~/.tsh`

## Result

This PR closes #1127