### PR TITLE
Fixed incorrect method use, log.Warn -> log.Infof.

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -376,7 +376,7 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	// open file, if it doesn't exist return a default path and move on
 	f, err := os.Open(loginDefsPath)
 	if err != nil {
-		log.Warn("Unable to open %q: %v: returning default path: %q", loginDefsPath, err, defaultEnvPath)
+		log.Infof("Unable to open %q: %v: returning default path: %q", loginDefsPath, err, defaultEnvPath)
 		return defaultEnvPath
 	}
 	defer f.Close()


### PR DESCRIPTION
**Purpose**

At the moment we are logging a warning if `/etc/login.defs` doesn't exist. This probably shouldn't be a warning but should logged at the info level because it's perfectly valid for someone to not have `/etc/login.defs` but it's worth knowing that the default path was used nonetheless.

In addition, we were using `log.Warn` instead of `log.Warnf` which caused the error message to be difficult to read.

```
WARN[0033] Unable to open %q: %v: returning default path: %q/etc/login.defsopen /etc/login.defs: no such file or directoryPATH=/bin:/usr/bin:/usr/local/bin:/sbin  file=srv/exec.go:380 func=srv.getDefaultEnvPath
```

**Implementation**

* Change `log.Warn` to `log.Infof`.