### PR TITLE
Specify timeout when establishing reverse tunnel

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -160,6 +160,7 @@ func (a *Agent) connect() (conn *ssh.Client, err error) {
 			User:            a.clientName,
 			Auth:            []ssh.AuthMethod{authMethod},
 			HostKeyCallback: a.hostKeyCallback,
+			Timeout:         defaults.DefaultDialTimeout,
 		})
 		if conn != nil {
 			break


### PR DESCRIPTION
**Purpose**

Teleport does not specify a timeout when dialing to remote servers which causes problems for applications built on-top of Teleport. For example in certain situations Telekube clusters can become permanently stuck in an offline state in certain cases after Ops Center redeployment due to this issue.

**Implementation**

* Set a timeout when dialing to the main cluster.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1140