### PR TITLE
Additional Security Headers

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -278,6 +278,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 					}
 				}
 			}
+			httplib.SetIndexHTMLHeaders(w.Header())
 			indexPage.Execute(w, session)
 		} else {
 			http.NotFound(w, r)


### PR DESCRIPTION
**Purpose**

Sets addition HTTP response headers that instruct web agents not to cache HTTP traffic and apply additional security policies supported by modern browsers.

**Implementation**

* Disabled caching with the following headers.
  * `Cache-Control:  no-cache, no-store, must-revalidate`
  * `Pragma: no-cache`
  * `Expires: 0`
* Only allow same origin iframes.
  * `X-Frame-Options: SAMEORIGIN`
* Detect and prevent reflected cross-site scripting (XSS) attacks in modern browsers.
  * `X-XSS-Protection: 1; mode=block`
* Require all future requests to be HTTPS.
  * `Strict-Transport-Security: max-age=31536000; includeSubDomains`
* Prevent web browsers from using content sniffing to discover a file’s MIME type.
  * `X-Content-Type-Options: nosniff`
* Set Content Security Policy.
  * `Content-Security-Policy: script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; img-src 'self' data: blob:`

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1148