### PR TITLE
Update docs and logging for sending party initiated flows.

### DIFF
--- a/docs/2.0/saml.md
+++ b/docs/2.0/saml.md
@@ -158,7 +158,7 @@ tctl create -f dev.yaml
 ### Login
 
 For the Web UI, if the above configuration were real, you would see a button
-that says `Login with adfs`. Simply click on that and you will be
+that says `Login with Okta`. Simply click on that and you will be
 re-directed to a login page for your identity provider and if successful,
 redirected back to Teleport.
 
@@ -167,6 +167,10 @@ and a browser window should automatically open taking you to the login page for
 your identity provider. `tsh` will also output a link the login page of the
 identity provider if you are not automatically redirected.
 
+!!! note "IMPORTANT":
+    Teleport only supports sending party initiated flows for SAML 2.0. This
+    means you can not initiate login from your identity provider, you have to
+    initiate login from either the Teleport Web UI or CLI.
 
 ## ADFS
 

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -189,9 +189,14 @@ func parseSAMLInResponseTo(response string) (string, error) {
 		return "", trace.BadParameter("unable to parse response")
 	}
 
+	// teleport only supports sending party initiated flows (Teleport sends an
+	// AuthnRequest to the IdP and gets a SAMLResponse from the IdP). identity
+	// provider initiated flows (where Teleport gets an unsolicited SAMLResponse
+	// from the IdP) are not supported.
 	el := doc.Root()
 	responseTo := el.SelectAttr("InResponseTo")
 	if responseTo == nil {
+		log.Errorf("[SAML] Teleport does not support initiating login from an identity provider, login must be initiated from either the Teleport Web UI or CLI.")
 		return "", trace.BadParameter("identity provider initiated flows are not supported")
 	}
 	if responseTo.Value == "" {


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1145, when using SAML 2.0 if you try and initiate login from your identity provider you are unable to login and Teleport logs the below message.

```
error while processing callback: identity provider initiated flows are not supported
```

While this message is accurate, it could be simpler and explain what needs to be done to correct this error.

**Implementation**

* In the error log, log that you need to initiate login from Teleport and not from your identity provider.
* Added a comment that explains the flows that we support in developer terms.
* Update documentation to explain that login needs to be initiated from Teleport not from your identity provider.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1145