### PR TITLE
Node has read access to reverse tunnel.

### DIFF
--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -175,6 +175,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 						services.KindNamespace:     services.RO(),
 						services.KindRole:          services.RO(),
 						services.KindAuthServer:    services.RO(),
+						services.KindReverseTunnel: services.RO(),
 					},
 				},
 			})


### PR DESCRIPTION
**Purpose**

When Teleport starts, the following warning is printed to the logs:

```
failed to fetch results for cache read access to tunnel in namespace default is denied
for roles NODE
```

Node needs read access to system resource `tunnel`.

**Implementation**

Added read access to `tunnel` to node.