### PR TITLE
Backport SSH dial deadline to 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.2.6
+
+#### Bug fixes
+
+* Fixed issue with SSH dial potentially hanging indefinitely. [#1153](https://github.com/gravitational/teleport/issues/1153)
+
 ## 2.2.5
 
 #### Bug fixes
@@ -74,7 +80,7 @@
 
 Teleport 2.0.5 contains a variety of security fixes. We strongly encourage anyone running Teleport 2.0.0 and above to upgrade to 2.0.5.
 
-The most pressing issues (a phishing attack which can potentially be used to extract plaintext credentials and an attack where an already authenticated user can escalate privileges) can be resolved by upgrading the web proxy. However, however all nodes need to be upgraded to mitigate all vulnerabilities. 
+The most pressing issues (a phishing attack which can potentially be used to extract plaintext credentials and an attack where an already authenticated user can escalate privileges) can be resolved by upgrading the web proxy. However, however all nodes need to be upgraded to mitigate all vulnerabilities.
 
 ### Bugfixes
 
@@ -218,8 +224,8 @@ certificates did not work correctly in this release due to #529
 ### Bugfixes
 
 * Wrong url to register new users. #497
-* Logged in users inherit Teleport supplemental groups bug security. #507 
-* Joining a session running on a trusted cluster does not work. #504 
+* Logged in users inherit Teleport supplemental groups bug security. #507
+* Joining a session running on a trusted cluster does not work. #504
 
 ## 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
 
 Teleport 2.0.5 contains a variety of security fixes. We strongly encourage anyone running Teleport 2.0.0 and above to upgrade to 2.0.5.
 
-The most pressing issues (a phishing attack which can potentially be used to extract plaintext credentials and an attack where an already authenticated user can escalate privileges) can be resolved by upgrading the web proxy. However, however all nodes need to be upgraded to mitigate all vulnerabilities.
+The most pressing issues (a phishing attack which can be used to extract plaintext credentials and an attack where an already authenticated user can escalate privileges) can be resolved by upgrading the web proxy. However, all nodes need to be upgraded to mitigate all vulnerabilities.
 
 ### Bugfixes
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=2.2.5
+VERSION=2.2.6
 
 # These are standard autotools variables, don't change them please
 BUILDDIR ?= build
@@ -24,7 +24,7 @@ LIBS = $(shell find lib -type f -name '*.go') *.go
 # Default target: builds all 3 executables and plaaces them in a current directory
 #
 .PHONY: all
-all: $(VERSRC) $(BINARIES) 
+all: $(VERSRC) $(BINARIES)
 
 $(BUILDDIR)/tctl: $(LIBS) $(TOOLS) tool/tctl/common/*.go tool/tctl/*go
 	go build -o $(BUILDDIR)/tctl -i $(BUILDFLAGS) ./tool/tctl
@@ -42,8 +42,8 @@ goinstall:
 	go install github.com/gravitational/teleport/tool/tctl
 
 #
-# make install will installs system-wide teleport 
-# 
+# make install will installs system-wide teleport
+#
 .PHONY: install
 install: build
 	@echo "\n** Make sure to run 'make install' as root! **\n"
@@ -82,7 +82,7 @@ run-docs:
 #
 .PHONY: test
 test: FLAGS ?=
-test: 
+test:
 	go test -v ./tool/tsh/... \
 			   ./lib/... \
 			   ./tool/teleport... $(FLAGS) $(ADDFLAGS)
@@ -92,7 +92,7 @@ test:
 # integration tests. need a TTY to work and not compatible with a race detector
 #
 .PHONY: integration
-integration: 
+integration:
 	go test -v ./integration/...
 
 # This rule triggers re-generation of version.go and gitref.go if Makefile changes
@@ -111,9 +111,9 @@ tag:
 	@echo "Run this:\n> git tag $(GITTAG)\n> git push --tags"
 
 #
-# make release - produces a binary release tarball 
-#	
-.PHONY: 
+# make release - produces a binary release tarball
+#
+.PHONY:
 release: clean all $(BUILDDIR)/webassets.zip
 	cp -f build.assets/release.mk $(BUILDDIR)/Makefile
 	cat $(BUILDDIR)/webassets.zip >> $(BUILDDIR)/teleport
@@ -201,4 +201,3 @@ buildbox-grpc:
 	cd $(GRPC_API) && protoc -I=.:$$PROTO_INCLUDE \
       --gofast_out=plugins=grpc:.\
     *.proto
-

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "2.2.5"
+	Version = "2.2.6"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/1152 to 2.2.