### PR TITLE
Default User Role

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -176,3 +176,21 @@ const (
 	// compatibility modes.
 	CompatibilityNone = ""
 )
+
+const (
+	// TraitInternalPrefix is the role variable prefix that indicates it's for
+	// local accounts.
+	TraitInternalPrefix = "internal"
+
+	// TraitLogins is the name the role variable used to store
+	// allowed logins.
+	TraitLogins = "logins"
+
+	// TraitInternalRoleVariable is the role variable used to store allowed
+	// logins for local accounts.
+	TraitInternalRoleVariable = "{{internal.logins}}"
+)
+
+// NewDefaultRole is the name of the default role for all local users if
+// another role is not explicitly assigned (Enterprise only).
+const DefaultRoleName = "default"

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -206,6 +206,14 @@ func Init(cfg InitConfig, dynamicConfig bool) (*AuthServer, *Identity, error) {
 	}
 	log.Infof("[INIT] Created Namespace: %q", defaults.Namespace)
 
+	// always create a default role
+	defaultRole := services.NewDefaultRole()
+	err = asrv.UpsertRole(defaultRole, backend.Forever)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	log.Infof("[INIT] Created default Role: %q", defaultRole.GetName())
+
 	// generate a user certificate authority if it doesn't exist
 	if _, err := asrv.GetCertAuthority(services.CertAuthID{DomainName: cfg.DomainName, Type: services.UserCA}, false); err != nil {
 		if !trace.IsNotFound(err) {

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -85,6 +85,9 @@ func (s *TunSuite) SetUpTest(c *C) {
 		Identity:   identity,
 	})
 
+	// create the default role
+	c.Assert(s.a.UpsertRole(services.NewDefaultRole(), backend.Forever), IsNil)
+
 	// set up host private key and certificate
 	c.Assert(s.a.UpsertCertAuthority(
 		suite.NewTestCA(services.HostCA, "localhost")), IsNil)

--- a/lib/services/migrations_test.go
+++ b/lib/services/migrations_test.go
@@ -118,6 +118,9 @@ func (s *MigrationsSuite) TestMigrateUsers(c *C) {
 			Status:         in.Status,
 			Expires:        in.Expires,
 			CreatedBy:      in.CreatedBy,
+			Traits: map[string][]string{
+				"logins": in.AllowedLogins,
+			},
 		},
 		rawObject: *in,
 	}

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -514,9 +514,9 @@ func (s *RoleSuite) TestApplyTraits(c *C) {
 		// 5 - multiple variables in traits
 		{
 			map[string][]string{
-				"foo": []string{"bar", "baz"},
+				"logins": []string{"bar", "baz"},
 			},
-			[]string{`{{internal.foo}}`, "root"},
+			[]string{`{{internal.logins}}`, "root"},
 			[]string{"bar", "baz", "root"},
 		},
 		// 6 - deduplicate

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -173,6 +173,9 @@ func (s *WebSuite) SetUpTest(c *C) {
 		Access:     access,
 	})
 
+	// create the default role
+	c.Assert(s.authServer.UpsertRole(services.NewDefaultRole(), backend.Forever), IsNil)
+
 	// configure cluster authentication preferences
 	cap, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
 		Type:         teleport.Local,

--- a/lib/web/ui/roleaccess.go
+++ b/lib/web/ui/roleaccess.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/parse"
 
 	"github.com/gravitational/trace"
 )
@@ -92,11 +91,7 @@ func (a *RoleAccess) initSSH(teleRole services.Role) error {
 	filteredLogins := []string{}
 	for _, login := range teleRole.GetLogins(services.Allow) {
 		if login != roleDefaultAllowedLogin {
-			// don't pass along role variables
-			_, _, err = parse.IsRoleVariable(login)
-			if trace.IsNotFound(err) {
-				filteredLogins = append(filteredLogins, login)
-			}
+			filteredLogins = append(filteredLogins, login)
 		}
 	}
 	a.SSH.Logins = filteredLogins


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1136, we're adding support for a default role that all local users will be assigned to for Teleport and optionally for Enterprise. This default role contains a single role variable `{{internal.logins}}` that is populated from user traits.

**Implementation**

* Upon initialization of Teleport, we upsert the `default` role into the backend.
* When `tctl users add ...` we do the following:
  * We add the logins to `services.UserV1` list of allowed logins. When we create the signup token we make sure that you can't add role variables to the list of allowed logins.
  * When converting between `services.UserV1` to `services.V2` we convert allowed logins into traits.
  * When creating a user, we assign them the `default` role.
  * When applying traits, we only allow traits to be applied to `logins` if the prefix is `internal`.
* No migration was included, existing users with individual roles will continue to work as-is but new users will be created assigned to the `default` role.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1136