### PR TITLE
Fixed incorrect certificates TTL for SAML users.

### DIFF
--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -334,7 +334,7 @@ func (a *AuthServer) ValidateSAMLResponse(samlResponse string) (*SAMLAuthRespons
 	}
 
 	if len(request.PublicKey) != 0 {
-		certTTL := utils.MinTTL(utils.ToTTL(a.clock, expiresAt), request.CertTTL)
+		certTTL := utils.MinTTL(sessionTTL, request.CertTTL)
 		allowedLogins, err := roles.CheckLoginDuration(certTTL)
 		if err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1169, if `MaxSessionTTL` is set to a value lower than 12 hours, Teleport will not issue a certificate. This was caused by not adjusting the TTL according to the max session defined in the role.

```

error while processing callback: this user cannot request a certificate for 11h59m59.996443235s
```

**Implementation**

* Adjust the TTL based of the value in the role then pick the minimum of that and the TTL that comes in the request (via command line flag to `tsh`) before requesting a certificate like we do for the web session.

**Related Issue**

Fixes https://github.com/gravitational/teleport/issues/1169