### PR TITLE
BUILDFLAGS can be custom-set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ADDFLAGS ?=
 PWD ?= `pwd`
 TELEPORT_DEBUG ?= no
 GITTAG=v$(VERSION)
-BUILDFLAGS := $(ADDFLAGS) -ldflags '-w -s'
+BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
 
 RELEASE=teleport-$(GITTAG)-`go env GOOS`-`go env GOARCH`-bin
 BINARIES=$(BUILDDIR)/tsh $(BUILDDIR)/teleport $(BUILDDIR)/tctl


### PR DESCRIPTION
Allow users who build Teleport from source to set their own build flags.
Minor change, a request from an enterprise customer.