### PR TITLE
Reintroduced --auth flag to tsh.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -175,6 +175,9 @@ type Config struct {
 
 	// Compatibility specifies OpenSSH compatibility flags.
 	Compatibility string
+
+	// AuthConnector is the name of the authentication connector to use.
+	AuthConnector string
 }
 
 // CachePolicy defines cache policy for local clients
@@ -1016,7 +1019,7 @@ func (tc *TeleportClient) Login(activateKey bool) (*Key, error) {
 	certPool := loopbackPool(httpsProxyHostPort)
 
 	// ping the endpoint to see if it's up and find the type of authentication supported
-	pr, err := Ping(httpsProxyHostPort, tc.InsecureSkipVerify, certPool)
+	pr, err := Ping(httpsProxyHostPort, tc.InsecureSkipVerify, certPool, tc.AuthConnector)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -297,13 +297,18 @@ type OIDCSettings struct {
 // to better user experience: users get connection errors before being asked for passwords. The second
 // is to return the form of authentication that the server supports. This also leads to better user
 // experience: users only get prompted for the type of authentication the server supports.
-func Ping(proxyAddr string, insecure bool, pool *x509.CertPool) (*PingResponse, error) {
+func Ping(proxyAddr string, insecure bool, pool *x509.CertPool, connectorName string) (*PingResponse, error) {
 	clt, _, err := initClient(proxyAddr, insecure, pool)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	response, err := clt.Get(clt.Endpoint("webapi", "ping"), url.Values{})
+	endpoint := clt.Endpoint("webapi", "ping")
+	if connectorName != "" {
+		endpoint = clt.Endpoint("webapi", "ping", connectorName)
+	}
+
+	response, err := clt.Get(endpoint, url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/authentication.go
+++ b/lib/services/authentication.go
@@ -141,26 +141,17 @@ func (c *AuthPreferenceV2) CheckAndSetDefaults() error {
 	if c.Spec.Type == "" {
 		c.Spec.Type = teleport.Local
 	}
-	if c.Spec.SecondFactor == "" && c.Spec.Type == teleport.Local {
+	if c.Spec.SecondFactor == "" {
 		c.Spec.SecondFactor = teleport.OTP
 	}
 
-	// make sure whatever was passed in was sane
-	switch c.Spec.Type {
-	case teleport.Local:
-		if c.Spec.SecondFactor != teleport.OFF && c.Spec.SecondFactor != teleport.OTP && c.Spec.SecondFactor != teleport.U2F {
-			return trace.BadParameter("second factor type %q not supported", c.Spec.SecondFactor)
-		}
-	case teleport.OIDC:
-		if c.Spec.SecondFactor != "" {
-			return trace.BadParameter("second factor [%q] not supported with OIDC connector")
-		}
-	case teleport.SAML:
-		if c.Spec.SecondFactor != "" {
-			return trace.BadParameter("second factor [%q] not supported with SAML connector")
-		}
-	default:
-		return trace.BadParameter("unsupported type %q", c.Spec.Type)
+	// make sure type makes sense
+	if c.Spec.Type != teleport.Local && c.Spec.Type != teleport.OIDC && c.Spec.Type != teleport.SAML {
+		return trace.BadParameter("authentication type %q not supported", c.Spec.Type)
+	}
+	// make sure second factor makes sense
+	if c.Spec.SecondFactor != teleport.OFF && c.Spec.SecondFactor != teleport.OTP && c.Spec.SecondFactor != teleport.U2F {
+		return trace.BadParameter("second factor type %q not supported", c.Spec.SecondFactor)
 	}
 
 	return nil

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -24,6 +24,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -463,6 +464,9 @@ func (o *OIDCConnectorV2) RoleFromTemplate(claims jose.Claims) (Role, error) {
 func (o *OIDCConnectorV2) Check() error {
 	if o.Metadata.Name == "" {
 		return trace.BadParameter("ID: missing connector name")
+	}
+	if o.Metadata.Name == teleport.Local {
+		return trace.BadParameter("ID: invalid connector name %v is a reserved name", teleport.Local)
 	}
 	if _, err := url.Parse(o.Spec.IssuerURL); err != nil {
 		return trace.BadParameter("IssuerURL: bad url: '%v'", o.Spec.IssuerURL)

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -529,6 +529,9 @@ func (o *SAMLConnectorV2) GetServiceProvider(clock clockwork.Clock) (*saml2.SAML
 	if o.Metadata.Name == "" {
 		return nil, trace.BadParameter("ID: missing connector name, name your connector to refer to internally e.g. okta1")
 	}
+	if o.Metadata.Name == teleport.Local {
+		return nil, trace.BadParameter("ID: invalid connector name %v is a reserved name", teleport.Local)
+	}
 	if o.Spec.AssertionConsumerService == "" {
 		return nil, trace.BadParameter("missing acs - assertion consumer service parameter, set service URL that will receive POST requests from SAML")
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -118,6 +118,9 @@ type CLIConf struct {
 	// IdentityFormat (used for --format flag for 'tsh login') defines which
 	// format to use with --out to store a fershly retreived certificate
 	IdentityFormat client.IdentityFileFormat
+
+	// AuthConnector is the name of the connector to use.
+	AuthConnector string
 }
 
 func main() {
@@ -154,8 +157,8 @@ func Run(args []string, underTest bool) {
 	app.Flag("ttl", "Minutes to live for a SSH session").Int32Var(&cf.MinsToLive)
 	app.Flag("identity", "Identity file").Short('i').StringVar(&cf.IdentityFileIn)
 	app.Flag("compat", "OpenSSH compatibility flag").StringVar(&cf.Compatibility)
-
 	app.Flag("insecure", "Do not verify server's certificate and host name. Use only in test environments").Default("false").BoolVar(&cf.InsecureSkipVerify)
+	app.Flag("auth", "Specify the type of authentication connector to use.").StringVar(&cf.AuthConnector)
 	app.Flag("namespace", "Namespace of the cluster").Default(defaults.Namespace).Hidden().StringVar(&cf.Namespace)
 	app.Flag("gops", "Start gops endpoint on a given address").Hidden().BoolVar(&cf.Gops)
 	app.Flag("gops-addr", "Specify gops addr to listen on").Hidden().StringVar(&cf.GopsAddr)
@@ -652,6 +655,9 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 		return nil, trace.Wrap(err)
 	}
 	c.Compatibility = compatibility
+
+	// copy the authentication connector over
+	c.AuthConnector = cf.AuthConnector
 
 	return client.NewClient(c)
 }


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1090, we need a way to fallback to a different authentication method if our primary method becomes unavailable. This PR re-introduced the `--auth` flag so we can pick a temporary pick a different authentication method that is supported by the cluster.

**Implementation**

* A new endpoint `/webapi/ping/:connector_name` was introduced. This endpoint behaves exactly like ping except that it returns information for the specific connector specified. It first tries to retrieve the `local` connector if that is the connector requested, then tried OIDC, and then SAML.
* If the `--auth` flag is passed in we hit the `/webapi/ping/connector_name` endpoint instead of `/webapi/ping` to retrieve the information need to make the appropriate request to login.

**Note**: Due to the above, a potential security vulnerability that could arise is an attacker can probe this endpoint to generate a list of supported connectors. If an attacker finds a misconfigured non-default connector, they could use it to exploit the cluster. It's recommended that all connectors that are configured for a Teleport cluster be fully and correctly configured.**

**Related Issues**

https://github.com/gravitational/teleport/issues/1090