### PR TITLE
Verify Certificate Chain

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -289,6 +289,17 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		if !fileExists(fc.Proxy.CertFile) {
 			return trace.Errorf("https cert does not exist: %s", fc.Proxy.CertFile)
 		}
+
+		// verify we have a valid certificate chain before starting teleport
+		certificateBytes, err := utils.ReadPath(fc.Proxy.CertFile)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		err = utils.VerifyCertificateChain(certificateBytes)
+		if err != nil {
+			return trace.BadParameter("unable to verify HTTPS certificate chain in %v: %v", fc.Proxy.CertFile, err)
+		}
+
 		cfg.Proxy.TLSCert = fc.Proxy.CertFile
 	}
 

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -100,9 +100,31 @@ func UserMessageFromError(err error) string {
 			innerError.Host,
 			innerError.Error(),
 			"try a different hostname for --proxy or specify --insecure flag if you know what you're doing.")
-	case x509.UnknownAuthorityError, x509.CertificateInvalidError:
-		return "WARNING:\n The proxy you are connecting to uses the self-signed HTTPS certificate.\n" +
-			" Try --insecure flag if you know what you're doing.\n"
+	case x509.UnknownAuthorityError:
+		return `WARNING:
+
+  The proxy you are connecting to has presented a certificate signed by a
+  unknown authority. This is most likely due to either being presented
+  with a self-signed certificate or the certificate was truly signed by an
+  authority not known to the client.
+
+  If you know the certificate is self-signed and would like to ignore this
+  error use the --insecure flag.
+
+  If you have your own certificate authority that you would like to use to
+  validate the certificate chain presented by the proxy, set the
+  SSL_CERT_FILE and SSL_CERT_DIR environment variables respectively and try
+  again.
+
+  If you think something malicious may be occurring, contact your Teleport
+  system administrator to resolve this issue.
+`
+	case x509.CertificateInvalidError:
+		return fmt.Sprintf(`WARNING:
+
+  The certificate presented by the proxy is invalid: %v.
+
+  Contact your Teleport system administrator to resolve this issue.`, innerError)
 	}
 	if log.GetLevel() == log.DebugLevel {
 		return trace.DebugReport(err)


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1187, at the moment Teleport will start up with a invalid certificate chain. In addition, the error message presented to clients when the client starts is not clear.

This PR changes this behavior by validating the certificate chain before starting and provides more details when an certificate error occurs.

**Implementation**

* Upon startup, validate the chain of certificates presented in `https_cert_file`.
* Update the human readable error messages returned by `x509.UnknownAuthorityError` and `x509.CertificateInvalidError`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1187