### PR TITLE
Trusted Cluster Toggle 

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -727,8 +727,8 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 	err = trustedCluster.CheckAndSetDefaults()
 	c.Assert(err, check.IsNil)
 
-	// try and upsert a trusted cluster multiple times
-	var upsertSuccessCount int
+	// try and upsert a trusted cluster
+	var upsertSuccess bool
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v", trustedCluster, i)
 		err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
@@ -739,10 +739,11 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 			}
 			c.Fatalf("got non connection problem %v", err)
 		}
-		upsertSuccessCount++
+		upsertSuccess = true
+		break
 	}
-	// make sure we upsert a trusted cluster multiple times.
-	c.Assert(upsertSuccessCount > 1, check.Equals, true)
+	// make sure we upsert a trusted cluster
+	c.Assert(upsertSuccess, check.Equals, true)
 
 	nodePorts := s.getPorts(3)
 	sshPort, proxyWebPort, proxySSHPort := nodePorts[0], nodePorts[1], nodePorts[2]

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -143,6 +143,14 @@ func (a *AuthWithRoles) DeleteCertAuthority(id services.CertAuthID) error {
 	return a.authServer.DeleteCertAuthority(id)
 }
 
+func (a *AuthWithRoles) ActivateCertAuthority(id services.CertAuthID) error {
+	return trace.BadParameter("not implemented")
+}
+
+func (a *AuthWithRoles) DeactivateCertAuthority(id services.CertAuthID) error {
+	return trace.BadParameter("not implemented")
+}
+
 func (a *AuthWithRoles) GenerateToken(roles teleport.Roles, ttl time.Duration) (string, error) {
 	if err := a.action(defaults.Namespace, services.KindToken, services.ActionWrite); err != nil {
 		return "", trace.Wrap(err)
@@ -766,7 +774,7 @@ func (a *AuthWithRoles) GetTrustedCluster(name string) (services.TrustedCluster,
 		return nil, trace.Wrap(err)
 	}
 
-	return a.authServer.getTrustedCluster(name)
+	return a.authServer.GetTrustedCluster(name)
 }
 
 func (a *AuthWithRoles) GetTrustedClusters() ([]services.TrustedCluster, error) {
@@ -775,7 +783,7 @@ func (a *AuthWithRoles) GetTrustedClusters() ([]services.TrustedCluster, error) 
 		return nil, trace.Wrap(err)
 	}
 
-	return a.authServer.getTrustedClusters()
+	return a.authServer.GetTrustedClusters()
 }
 
 func (a *AuthWithRoles) UpsertTrustedCluster(tc services.TrustedCluster) error {
@@ -815,7 +823,47 @@ func (a *AuthWithRoles) DeleteTrustedCluster(name string) error {
 		return trace.Wrap(err)
 	}
 
-	return a.authServer.deleteTrustedCluster(name)
+	return a.authServer.DeleteTrustedCluster(name)
+}
+
+// EnableTrustedCluster will enable a TrustedCluster that is already in the backend.
+func (a *AuthWithRoles) EnableTrustedCluster(t services.TrustedCluster) error {
+	log.Debugf("EnableTrustedCluster %v", t)
+
+	err := a.action(defaults.Namespace, services.KindTrustedCluster, services.ActionWrite)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.action(defaults.Namespace, services.KindCertAuthority, services.ActionWrite)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.action(defaults.Namespace, services.KindReverseTunnel, services.ActionWrite)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return a.authServer.EnableTrustedCluster(t)
+}
+
+// DisableTrustedCluster will disable a TrustedCluster that is already in the backend.
+func (a *AuthWithRoles) DisableTrustedCluster(t services.TrustedCluster) error {
+	log.Debugf("DisableTrustedCluster %v", t)
+
+	err := a.action(defaults.Namespace, services.KindTrustedCluster, services.ActionWrite)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.action(defaults.Namespace, services.KindCertAuthority, services.ActionWrite)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = a.action(defaults.Namespace, services.KindReverseTunnel, services.ActionWrite)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return a.authServer.DisableTrustedCluster(t)
 }
 
 func (a *AuthWithRoles) Close() error {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -277,6 +277,18 @@ func (c *Client) DeleteCertAuthority(id services.CertAuthID) error {
 	return trace.Wrap(err)
 }
 
+// ActivateCertAuthority moves a CertAuthority from the deactivated list to
+// the normal list.
+func (c *Client) ActivateCertAuthority(id services.CertAuthID) error {
+	return trace.BadParameter("not implemented")
+}
+
+// DeactivateCertAuthority moves a CertAuthority from the normal list to
+// the deactivated list.
+func (c *Client) DeactivateCertAuthority(id services.CertAuthID) error {
+	return trace.BadParameter("not implemented")
+}
+
 // GenerateToken creates a special provisioning token for a new SSH server
 // that is valid for ttl period seconds.
 //
@@ -1518,6 +1530,16 @@ func (c *Client) ValidateTrustedCluster(validateRequest *ValidateTrustedClusterR
 func (c *Client) DeleteTrustedCluster(name string) error {
 	_, err := c.Delete(c.Endpoint("trustedclusters", name))
 	return trace.Wrap(err)
+}
+
+// EnableTrustedCluster will enable a TrustedCluster that is already in the backend.
+func (c *Client) EnableTrustedCluster(trustedCluster services.TrustedCluster) error {
+	return c.EnableTrustedCluster(trustedCluster)
+}
+
+// DisableTrustedCluster will disable a TrustedCluster that is already in the backend.
+func (c *Client) DisableTrustedCluster(trustedCluster services.TrustedCluster) error {
+	return c.DisableTrustedCluster(trustedCluster)
 }
 
 // WebService implements features used by Web UI clients

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -336,6 +336,16 @@ func (s *PresenceService) DeleteTrustedCluster(name string) error {
 	return trace.Wrap(err)
 }
 
+// EnableTrustedCluster updates the resource on the backend with new state.
+func (s *PresenceService) EnableTrustedCluster(t services.TrustedCluster) error {
+	return s.UpsertTrustedCluster(t)
+}
+
+// DisableTrustedCluster updates the resource on the backend with the new state.
+func (s *PresenceService) DisableTrustedCluster(t services.TrustedCluster) error {
+	return s.UpsertTrustedCluster(t)
+}
+
 const (
 	localClusterPrefix   = "localCluster"
 	reverseTunnelsPrefix = "reverseTunnels"

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -95,6 +95,12 @@ type Presence interface {
 
 	// DeleteTrustedCluster removes a TrustedCluster from the backend by name.
 	DeleteTrustedCluster(string) error
+
+	// EnableTrustedCluster will enable a TrustedCluster that is already in the backend.
+	EnableTrustedCluster(TrustedCluster) error
+
+	// DisableTrustedCluster will disable a TrustedCluster that is already in the backend.
+	DisableTrustedCluster(TrustedCluster) error
 }
 
 // NewNamespace returns new namespace

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -49,6 +49,14 @@ type Trust interface {
 	// GetCertAuthorities returns a list of authorities of a given type
 	// loadSigningKeys controls whether signing keys should be loaded or not
 	GetCertAuthorities(caType CertAuthType, loadSigningKeys bool) ([]CertAuthority, error)
+
+	// ActivateCertAuthority moves a CertAuthority from the deactivated list to
+	// the normal list.
+	ActivateCertAuthority(id CertAuthID) error
+
+	// DeactivateCertAuthority moves a CertAuthority from the normal list to
+	// the deactivated list.
+	DeactivateCertAuthority(id CertAuthID) error
 }
 
 const (


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1199, to enable/disable a Trusted Cluster we have to re-establish trust. This PR changes this behavior by allowing the Trusted Cluster to temporarily remove the trust relationship and let it be re-established later.

**Implementation**

* Allow `services.CertAuthorty` to be enabled/disabled by copying them to `/authorities/deactivated/*/{cluster name}`.
* Change the behavior of the `UpsertTrustedCluster` from always trying to establish trust, to only trying to establish trust if a `services.TrustedCluster` meta-resource does not exist. If a `services.TrustedCluster` meta-resource exists, we use this endpoint to enable/disable the relationship.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1199