### PR TITLE
Role Rules

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -191,6 +191,10 @@ const (
 	TraitInternalRoleVariable = "{{internal.logins}}"
 )
 
-// NewDefaultRole is the name of the default role for all local users if
+// DefaultRole is the name of the default role for all local users if
 // another role is not explicitly assigned (Enterprise only).
 const DefaultRoleName = "default"
+
+// DefaultImplicitRole is implicit role that gets added to all service.RoleSet
+// objects.
+const DefaultImplicitRole = "default-implicit-role"

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -164,9 +164,9 @@ func createUserAndRoleWithoutRoles(clt clt, username string, allowedLogins []str
 	}
 
 	role := services.RoleForUser(user)
-	resources := role.GetSystemResources(services.Allow)
-	delete(resources, services.KindRole)
-	role.SetSystemResources(services.Allow, resources)
+	rules := role.GetRules(services.Allow)
+	delete(rules, services.KindRole)
+	role.SetRules(services.Allow, rules)
 	role.SetLogins(services.Allow, []string{user.GetName()})
 	err = clt.UpsertRole(role, backend.Forever)
 	if err != nil {

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -152,7 +152,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					SystemResources: map[string][]string{
+					Rules: map[string][]string{
 						services.KindAuthServer: services.RW(),
 					},
 				},
@@ -165,7 +165,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					SystemResources: map[string][]string{
+					Rules: map[string][]string{
 						services.KindNode:          services.RW(),
 						services.KindSession:       services.RW(),
 						services.KindEvent:         services.RW(),
@@ -185,7 +185,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					SystemResources: map[string][]string{
+					Rules: map[string][]string{
 						services.KindProxy:                 services.RW(),
 						services.KindOIDCRequest:           services.RW(),
 						services.KindSession:               services.RW(),
@@ -201,7 +201,8 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 						services.KindUser:                  services.RO(),
 						services.KindRole:                  services.RO(),
 						services.KindClusterAuthPreference: services.RO(),
-						services.KindUniversalSecondFactor: services.RO(),
+						services.KindClusterName:           services.RO(),
+						services.KindStaticTokens:          services.RO(),
 					},
 				},
 			})
@@ -211,7 +212,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					SystemResources: map[string][]string{
+					Rules: map[string][]string{
 						services.KindWebSession:     services.RW(),
 						services.KindSession:        services.RW(),
 						services.KindAuthServer:     services.RO(),
@@ -228,7 +229,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					SystemResources: map[string][]string{
+					Rules: map[string][]string{
 						services.KindAuthServer:            services.RO(),
 						services.KindClusterAuthPreference: services.RO(),
 					},
@@ -245,7 +246,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 					Namespaces: []string{services.Wildcard},
 					Logins:     []string{},
 					NodeLabels: map[string]string{services.Wildcard: services.Wildcard},
-					SystemResources: map[string][]string{
+					Rules: map[string][]string{
 						services.Wildcard: services.RW(),
 					},
 				},
@@ -255,8 +256,8 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			role.String(),
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
-					Namespaces:      []string{},
-					SystemResources: map[string][]string{},
+					Namespaces: []string{},
+					Rules:      map[string][]string{},
 				},
 			})
 	}

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -156,9 +156,9 @@ func (s *TunSuite) TestUnixServerClient(c *C) {
 	otpSecret := base32.StdEncoding.EncodeToString([]byte(rawSecret))
 
 	user, role := createUserAndRole(s.a, userName, []string{userName})
-	resources := role.GetSystemResources(services.Allow)
-	resources[services.KindNode] = services.RW()
-	role.SetSystemResources(services.Allow, resources)
+	rules := role.GetRules(services.Allow)
+	rules[services.KindNode] = services.RW()
+	role.SetRules(services.Allow, rules)
 	err = s.a.UpsertRole(role, backend.Forever)
 	c.Assert(err, IsNil)
 
@@ -188,7 +188,8 @@ func (s *TunSuite) TestUnixServerClient(c *C) {
 		"test", authMethod)
 	c.Assert(err, IsNil)
 
-	err = clt.UpsertNode(newServer(services.KindNode, "a.example.com", "hello", "hello", defaults.Namespace))
+	// call some endpoint
+	_, err = clt.GetUser(userName)
 	c.Assert(err, IsNil)
 }
 

--- a/lib/services/migrations_test.go
+++ b/lib/services/migrations_test.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/gravitational/teleport/lib/defaults"
@@ -27,6 +28,8 @@ import (
 	"github.com/kylelemons/godebug/diff"
 	. "gopkg.in/check.v1"
 )
+
+var _ = fmt.Printf
 
 type MigrationsSuite struct {
 }
@@ -277,8 +280,8 @@ func (s *MigrationsSuite) TestMigrateRoles(c *C) {
 				Logins:     []string{"foo"},
 				NodeLabels: map[string]string{"a": "b"},
 				Namespaces: []string{"system", "default"},
-				SystemResources: map[string][]string{
-					"role": []string{ActionRead, ActionWrite},
+				Rules: map[string][]string{
+					KindRole: RW(),
 				},
 			},
 		},

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -109,12 +109,6 @@ const (
 	// KindAuthPreference is the type of authentication for this cluster.
 	MetaNameClusterAuthPreference = "cluster-auth-preference"
 
-	// KindUniversalSecondFactor is a type of second factor authentication.
-	KindUniversalSecondFactor = "universal_second_factor"
-
-	// MetaNameUniversalSecondFactor is a type of second factor authentication.
-	MetaNameUniversalSecondFactor = "universal-second-factor"
-
 	// KindClusterName is a type of configuration resource that contains the cluster name.
 	KindClusterName = "cluster_name"
 
@@ -139,6 +133,29 @@ const (
 	// V1 is the first version of resources. Note: The first version was
 	// not explicitly versioned.
 	V1 = "v1"
+)
+
+const (
+	// VerbConnect is used to allow you to connect to a remote object.
+	VerbConnect = "connect"
+
+	// VerbReadSecrets is used to allow reading secret information from an object.
+	VerbReadSecrets = "readsecrets"
+
+	// VerbList is used to list all objects. Does not imply the ability to read a single object.
+	VerbList = "list"
+
+	// VerbCreate is used to create an object.
+	VerbCreate = "create"
+
+	// VerbRead is used to read a single object.
+	VerbRead = "read"
+
+	// VerbUpdate is used to update an object.
+	VerbUpdate = "update"
+
+	// VerbDelete is used to remove an object.
+	VerbDelete = "delete"
 )
 
 func collectOptions(opts []MarshalOption) (*MarshalConfig, error) {
@@ -351,8 +368,6 @@ func ParseShortcut(in string) (string, error) {
 		return KindTrustedCluster, nil
 	case "cluster_authentication_preferences", "cap":
 		return KindClusterAuthPreference, nil
-	case "universal_second_factor", "u2f":
-		return KindUniversalSecondFactor, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %v", in)
 }

--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -934,9 +934,9 @@ func newUpack(username string, allowedLogins []string, a *auth.AuthServer) (*upa
 		return nil, trace.Wrap(err)
 	}
 	role := services.RoleForUser(user)
-	resources := role.GetSystemResources(services.Allow)
-	resources[services.Wildcard] = services.RW()
-	role.SetSystemResources(services.Allow, resources)
+	rules := role.GetRules(services.Allow)
+	rules[services.Wildcard] = services.RW()
+	role.SetRules(services.Allow, rules)
 	role.SetLogins(services.Allow, allowedLogins)
 	err = a.UpsertRole(role, backend.Forever)
 	if err != nil {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -208,9 +208,9 @@ func (s *WebSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	role := services.RoleForUser(teleUser)
 	role.SetLogins(services.Allow, []string{s.user})
-	resources := role.GetSystemResources(services.Allow)
-	resources[services.Wildcard] = services.RW()
-	role.SetSystemResources(services.Allow, resources)
+	rules := role.GetRules(services.Allow)
+	rules[services.Wildcard] = services.RW()
+	role.SetRules(services.Allow, rules)
 	err = s.authServer.UpsertRole(role, backend.Forever)
 	c.Assert(err, IsNil)
 

--- a/lib/web/ui/roleaccess.go
+++ b/lib/web/ui/roleaccess.go
@@ -16,7 +16,7 @@ const (
 	roleDefaultAllowedLogin = "!invalid!"
 )
 
-var adminResources = []string{
+var adminRules = []string{
 	services.KindRole,
 	services.KindUser,
 	services.KindOIDC,
@@ -104,19 +104,19 @@ func (a *RoleAccess) initAdmin(teleRole services.Role) {
 		teleRole.GetNamespaces(services.Allow),
 		services.Wildcard)
 
-	resources := teleRole.GetSystemResources(services.Allow)
-	a.Admin.Enabled = hasFullAccess(resources, adminResources) && hasAllNamespaces
+	rules := teleRole.GetRules(services.Allow)
+	a.Admin.Enabled = hasFullAccess(rules, adminRules) && hasAllNamespaces
 }
 
 func (a *RoleAccess) applyAdmin(role services.Role) {
 	if a.Admin.Enabled {
 		allowAllNamespaces(role)
-		applyResourceAccess(role, adminResources, services.RW())
+		applyResourceAccess(role, adminRules, services.RW())
 	} else {
-		resources := role.GetSystemResources(services.Allow)
-		delete(resources, services.Wildcard)
-		role.SetSystemResources(services.Allow, resources)
-		applyResourceAccess(role, adminResources, services.RO())
+		rules := role.GetRules(services.Allow)
+		delete(rules, services.Wildcard)
+		role.SetRules(services.Allow, rules)
+		applyResourceAccess(role, adminRules, services.RO())
 	}
 }
 
@@ -160,10 +160,10 @@ func hasFullAccess(rules map[string][]string, resources []string) bool {
 	return true
 }
 
-func applyResourceAccess(role services.Role, resources []string, verbs []string) {
-	rs := role.GetSystemResources(services.Allow)
-	for _, resource := range resources {
-		rs[resource] = verbs
+func applyResourceAccess(role services.Role, rules []string, verbs []string) {
+	rs := role.GetRules(services.Allow)
+	for _, rule := range rules {
+		rs[rule] = verbs
 	}
-	role.SetSystemResources(services.Allow, rs)
+	role.SetRules(services.Allow, rs)
 }


### PR DESCRIPTION
**Purpose**

In https://github.com/gravitational/teleport/issues/1200, we describe a list of rules users can operate on and the list of allowable verbs. In this PR we implement those rules and verbs.

**Implementation**

* All old resources were made into rules. `RW` was converted to `connect, list, create, read, readsecrets, update, delete` while `RO` was converted to `list, read`.
* `lib/auth/auth_with_roles.go` was updated to support the new verbs.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1200