### PR TITLE
Docs / Build process improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 2.3 
+
+This release focus was to increase Teleport user experience, including:
+
+* Easier configuration
+* Better documentation
+* Improved CLI interface
+* Make the Web UI better
+
+#### Improvements
+
+* Web UI: users can connect to OpenSSH servers using the Web UI.
+* Web UI: arbitrary logins are supported, in addition to role-defined ones.
+* CLI: trusted clusters can now be managed on the fly without having to edit Teleport configuration. [#1137](https://github.com/gravitational/teleport/issues/1137)
+* CLI: `tsh login` supports exporting a user identity into a file to be used later with OpenSSH.
+* `tsh agent` command has been deprecated: users are expected to use native SSH Agents on their platforms.
+
+#### Teleport Enterprise 
+
+* More granular RBAC rules [#1092](https://github.com/gravitational/teleport/issues/1092)
+* Role definitions now support templates. [#1120](https://github.com/gravitational/teleport/issues/1120)
+* Authentication: Teleport now supports multilpe OIDC/SAML endpoints.
+* Configuration: local authentication is always enabled as a fallback if a SAML/OIDC endpoints go offline.
+* Configuration: SAML/OIDC endpoints can be created on the fly using `tctl` and without having to edit configuration file or restart Teleport.
+* Web UI: it is now easier to turn a trusted cluster on/off [#1199](https://github.com/gravitational/teleport/issues/1199).
+
+#### Bug Fixes
+
+* Proper handling of `ENV_SUPATH` from login.defs [#1004](https://github.com/gravitational/teleport/pull/1004)
+* Reverse tunnels would periodically lose connectivity. [#1156](https://github.com/gravitational/teleport/issues/1156)
+* tsh now stores user identities in a format compatible with OpenSSH. [1171](https://github.com/gravitational/teleport/issues/1171).
+
 ## 2.2.6
 
 #### Bug fixes

--- a/Makefile
+++ b/Makefile
@@ -121,18 +121,26 @@ tag:
 # make release - produces a binary release tarball 
 #	
 .PHONY: 
-release: clean all $(BUILDDIR)/webassets.zip
+release: clean full
+	cp -rf $(BUILDDIR) teleport
+	cp -rf examples teleport/
+	tar -czf $(RELEASE).tar.gz teleport
+	rm -rf teleport
+	@echo "\nCREATED: $(RELEASE).tar.gz"
+
+
+#
+# make full - builds the binary with built-in web assets and places it into $(BUILDDIR)
+#
+.PHONY:full
+full: all $(BUILDDIR)/webassets.zip
 	cp -f build.assets/release.mk $(BUILDDIR)/Makefile
 	cat $(BUILDDIR)/webassets.zip >> $(BUILDDIR)/teleport
 	rm -fr $(BUILDDIR)/webassets.zip
 	cp README.md $(BUILDDIR)
 	cp CHANGELOG.md $(BUILDDIR)
 	zip -q -A $(BUILDDIR)/teleport
-	cp -rf $(BUILDDIR) teleport
-	@echo $(GITTAG) > teleport/VERSION
-	tar -czf $(RELEASE).tar.gz teleport
-	rm -rf teleport
-	@echo "\nCREATED: $(RELEASE).tar.gz"
+	echo $(GITTAG) > $(BUILDDIR)/VERSION
 
 # build/webassets.zip archive contains the web assets (UI) which gets
 # appended to teleport binary

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -53,7 +53,8 @@ integration: bbox
 #
 .PHONY:docs
 docs: bbox
-	docker run $(DOCKERFLAGS) -ti $(NOROOT) -e HOME=$(SRCDIR)/build.assets $(BBOX) \
+	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
+		-e HOME=$(SRCDIR)/build.assets $(BBOX) \
 		./docs/build.sh
 	@echo "\nSUCCESS: Teleport docs ----> build/docs\n"
 
@@ -74,11 +75,14 @@ run-docs: bbox
 #
 .PHONY:enter
 enter: bbox
-	docker run $(DOCKERFLAGS) -ti $(NOROOT) -e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BBOX) /bin/bash
+	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
+		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BBOX) /bin/bash
 
 #
 # Create a teleport package using the build container
 #
 .PHONY:release
 release: 
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOX) /usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)"
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOX) \
+		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)"
+


### PR DESCRIPTION
A few minor things:

- Updated Teleport changelog to reflect 2.3 changes
- Added `make full` target (same as `make release` but without the tarball). This is useful for quick build&deploy actions for rapid usability testing.
- Minor formatting in our makefiles.