### PR TITLE
refactor internal rule representation

### DIFF
--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -164,9 +164,9 @@ func createUserAndRoleWithoutRoles(clt clt, username string, allowedLogins []str
 	}
 
 	role := services.RoleForUser(user)
-	rules := role.GetRules(services.Allow)
-	delete(rules, services.KindRole)
-	role.SetRules(services.Allow, rules)
+	set := services.MakeRuleSet(role.GetRules(services.Allow))
+	delete(set, services.KindRole)
+	role.SetRules(services.Allow, set.Slice())
 	role.SetLogins(services.Allow, []string{user.GetName()})
 	err = clt.UpsertRole(role, backend.Forever)
 	if err != nil {

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -152,8 +152,8 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					Rules: map[string][]string{
-						services.KindAuthServer: services.RW(),
+					Rules: []services.Rule{
+						services.NewRule(services.KindAuthServer, services.RW()),
 					},
 				},
 			})
@@ -165,17 +165,17 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					Rules: map[string][]string{
-						services.KindNode:          services.RW(),
-						services.KindSession:       services.RW(),
-						services.KindEvent:         services.RW(),
-						services.KindProxy:         services.RO(),
-						services.KindCertAuthority: services.RO(),
-						services.KindUser:          services.RO(),
-						services.KindNamespace:     services.RO(),
-						services.KindRole:          services.RO(),
-						services.KindAuthServer:    services.RO(),
-						services.KindReverseTunnel: services.RO(),
+					Rules: []services.Rule{
+						services.NewRule(services.KindNode, services.RW()),
+						services.NewRule(services.KindSession, services.RW()),
+						services.NewRule(services.KindEvent, services.RW()),
+						services.NewRule(services.KindProxy, services.RO()),
+						services.NewRule(services.KindCertAuthority, services.RO()),
+						services.NewRule(services.KindUser, services.RO()),
+						services.NewRule(services.KindNamespace, services.RO()),
+						services.NewRule(services.KindRole, services.RO()),
+						services.NewRule(services.KindAuthServer, services.RO()),
+						services.NewRule(services.KindReverseTunnel, services.RO()),
 					},
 				},
 			})
@@ -185,24 +185,24 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					Rules: map[string][]string{
-						services.KindProxy:                 services.RW(),
-						services.KindOIDCRequest:           services.RW(),
-						services.KindSession:               services.RW(),
-						services.KindEvent:                 services.RW(),
-						services.KindSAMLRequest:           services.RW(),
-						services.KindOIDC:                  services.RO(),
-						services.KindSAML:                  services.RO(),
-						services.KindNamespace:             services.RO(),
-						services.KindNode:                  services.RO(),
-						services.KindAuthServer:            services.RO(),
-						services.KindReverseTunnel:         services.RO(),
-						services.KindCertAuthority:         services.RO(),
-						services.KindUser:                  services.RO(),
-						services.KindRole:                  services.RO(),
-						services.KindClusterAuthPreference: services.RO(),
-						services.KindClusterName:           services.RO(),
-						services.KindStaticTokens:          services.RO(),
+					Rules: []services.Rule{
+						services.NewRule(services.KindProxy, services.RW()),
+						services.NewRule(services.KindOIDCRequest, services.RW()),
+						services.NewRule(services.KindSession, services.RW()),
+						services.NewRule(services.KindEvent, services.RW()),
+						services.NewRule(services.KindSAMLRequest, services.RW()),
+						services.NewRule(services.KindOIDC, services.RO()),
+						services.NewRule(services.KindSAML, services.RO()),
+						services.NewRule(services.KindNamespace, services.RO()),
+						services.NewRule(services.KindNode, services.RO()),
+						services.NewRule(services.KindAuthServer, services.RO()),
+						services.NewRule(services.KindReverseTunnel, services.RO()),
+						services.NewRule(services.KindCertAuthority, services.RO()),
+						services.NewRule(services.KindUser, services.RO()),
+						services.NewRule(services.KindRole, services.RO()),
+						services.NewRule(services.KindClusterAuthPreference, services.RO()),
+						services.NewRule(services.KindClusterName, services.RO()),
+						services.NewRule(services.KindStaticTokens, services.RO()),
 					},
 				},
 			})
@@ -212,14 +212,14 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					Rules: map[string][]string{
-						services.KindWebSession:     services.RW(),
-						services.KindSession:        services.RW(),
-						services.KindAuthServer:     services.RO(),
-						services.KindUser:           services.RO(),
-						services.KindRole:           services.RO(),
-						services.KindNamespace:      services.RO(),
-						services.KindTrustedCluster: services.RO(),
+					Rules: []services.Rule{
+						services.NewRule(services.KindWebSession, services.RW()),
+						services.NewRule(services.KindSession, services.RW()),
+						services.NewRule(services.KindAuthServer, services.RO()),
+						services.NewRule(services.KindUser, services.RO()),
+						services.NewRule(services.KindRole, services.RO()),
+						services.NewRule(services.KindNamespace, services.RO()),
+						services.NewRule(services.KindTrustedCluster, services.RO()),
 					},
 				},
 			})
@@ -229,9 +229,9 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{services.Wildcard},
-					Rules: map[string][]string{
-						services.KindAuthServer:            services.RO(),
-						services.KindClusterAuthPreference: services.RO(),
+					Rules: []services.Rule{
+						services.NewRule(services.KindAuthServer, services.RO()),
+						services.NewRule(services.KindClusterAuthPreference, services.RO()),
 					},
 				},
 			})
@@ -246,8 +246,8 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 					Namespaces: []string{services.Wildcard},
 					Logins:     []string{},
 					NodeLabels: map[string]string{services.Wildcard: services.Wildcard},
-					Rules: map[string][]string{
-						services.Wildcard: services.RW(),
+					Rules: []services.Rule{
+						services.NewRule(services.Wildcard, services.RW()),
 					},
 				},
 			})
@@ -257,7 +257,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 			services.RoleSpecV3{
 				Allow: services.RoleConditions{
 					Namespaces: []string{},
-					Rules:      map[string][]string{},
+					Rules:      []services.Rule{},
 				},
 			})
 	}

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -157,7 +157,7 @@ func (s *TunSuite) TestUnixServerClient(c *C) {
 
 	user, role := createUserAndRole(s.a, userName, []string{userName})
 	rules := role.GetRules(services.Allow)
-	rules[services.KindNode] = services.RW()
+	rules = append(rules, services.NewRule(services.KindNode, services.RW()))
 	role.SetRules(services.Allow, rules)
 	err = s.a.UpsertRole(role, backend.Forever)
 	c.Assert(err, IsNil)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/shell"
 	"github.com/gravitational/teleport/lib/state"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -1364,7 +1365,7 @@ func runLocalCommand(command []string) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		shell, err := utils.GetLoginShell(user.Username)
+		shell, err := shell.GetLoginShell(user.Username)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/services/migrations_test.go
+++ b/lib/services/migrations_test.go
@@ -280,8 +280,8 @@ func (s *MigrationsSuite) TestMigrateRoles(c *C) {
 				Logins:     []string{"foo"},
 				NodeLabels: map[string]string{"a": "b"},
 				Namespaces: []string{"system", "default"},
-				Rules: map[string][]string{
-					KindRole: RW(),
+				Rules: []Rule{
+					NewRule(KindRole, RW()),
 				},
 			},
 		},

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -134,8 +134,8 @@ func (s *RoleSuite) TestRoleParse(c *C) {
 					Allow: RoleConditions{
 						NodeLabels: map[string]string{"a": "b"},
 						Namespaces: []string{"system", "default"},
-						Rules: map[string][]string{
-							KindRole: []string{VerbRead, VerbList},
+						Rules: []Rule{
+							NewRule(KindRole, []string{VerbRead, VerbList}),
 						},
 					},
 					Deny: RoleConditions{
@@ -342,8 +342,8 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 					Spec: RoleSpecV3{
 						Allow: RoleConditions{
 							Namespaces: []string{defaults.Namespace},
-							Rules: map[string][]string{
-								KindSession: []string{VerbRead},
+							Rules: []Rule{
+								NewRule(KindSession, []string{VerbRead}),
 							},
 						},
 					},
@@ -365,8 +365,8 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 					Spec: RoleSpecV3{
 						Allow: RoleConditions{
 							Namespaces: []string{"system"},
-							Rules: map[string][]string{
-								KindSession: []string{VerbRead},
+							Rules: []Rule{
+								NewRule(KindSession, []string{VerbRead}),
 							},
 						},
 					},
@@ -379,8 +379,8 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 					Spec: RoleSpecV3{
 						Allow: RoleConditions{
 							Namespaces: []string{defaults.Namespace},
-							Rules: map[string][]string{
-								KindSession: []string{VerbCreate, VerbRead},
+							Rules: []Rule{
+								NewRule(KindSession, []string{VerbCreate, VerbRead}),
 							},
 						},
 					},
@@ -404,14 +404,14 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 					Spec: RoleSpecV3{
 						Deny: RoleConditions{
 							Namespaces: []string{defaults.Namespace},
-							Rules: map[string][]string{
-								KindSession: []string{VerbCreate},
+							Rules: []Rule{
+								NewRule(KindSession, []string{VerbCreate}),
 							},
 						},
 						Allow: RoleConditions{
 							Namespaces: []string{defaults.Namespace},
-							Rules: map[string][]string{
-								KindSession: []string{VerbCreate},
+							Rules: []Rule{
+								NewRule(KindSession, []string{VerbCreate}),
 							},
 						},
 					},

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -393,8 +393,8 @@ func (s *ServicesTestSuite) RolesCRUD(c *C) {
 				Logins:     []string{"root", "bob"},
 				NodeLabels: map[string]string{services.Wildcard: services.Wildcard},
 				Namespaces: []string{"default", "system"},
-				Rules: map[string][]string{
-					services.KindRole: services.RO(),
+				Rules: []services.Rule{
+					services.NewRule(services.KindRole, services.RO()),
 				},
 			},
 		},

--- a/lib/shell/shell.go
+++ b/lib/shell/shell.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package shell
 
 /*
 #cgo solaris CFLAGS: -D_POSIX_PTHREAD_SEMANTICS

--- a/lib/shell/shell_test.go
+++ b/lib/shell/shell_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shell
+
+import (
+	"gopkg.in/check.v1"
+)
+
+type ShellSuite struct {
+}
+
+var _ = check.Suite(&ShellSuite{})
+
+func (s *ShellSuite) TestGetShell(c *check.C) {
+	shell, err := GetLoginShell("root")
+	c.Assert(err, check.IsNil)
+	c.Assert(shell == "/bin/bash" || shell == "/bin/sh", check.Equals, true)
+
+	shell, err = GetLoginShell("non-existent-user")
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Matches, "user: unknown user non-existent-user")
+
+	shell, err = GetLoginShell("daemon")
+	c.Assert(err, check.IsNil)
+	c.Assert(shell == "/usr/sbin/nologin" ||
+		shell == "/sbin/nologin" ||
+		shell == "/usr/bin/nologin" ||
+		shell == "/usr/bin/false", check.Equals, true)
+}

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -34,10 +34,10 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/shell"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-
 	"github.com/kardianos/osext"
 	log "github.com/sirupsen/logrus"
 )
@@ -118,7 +118,7 @@ func prepInteractiveCommand(ctx *ctx) (*exec.Cmd, error) {
 	// determine shell for the given OS user:
 	if ctx.exec.cmdName == "" {
 		runShell = true
-		ctx.exec.cmdName, err = utils.GetLoginShell(ctx.login)
+		ctx.exec.cmdName, err = shell.GetLoginShell(ctx.login)
 		if err != nil {
 			log.Error(err)
 			return nil, trace.Wrap(err)
@@ -167,7 +167,7 @@ func prepareCommand(ctx *ctx) (*exec.Cmd, error) {
 	}
 
 	// get user's shell:
-	shell, err := utils.GetLoginShell(ctx.login)
+	shell, err := shell.GetLoginShell(ctx.login)
 	if err != nil {
 		log.Warn(err)
 	}

--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -935,7 +935,7 @@ func newUpack(username string, allowedLogins []string, a *auth.AuthServer) (*upa
 	}
 	role := services.RoleForUser(user)
 	rules := role.GetRules(services.Allow)
-	rules[services.Wildcard] = services.RW()
+	rules = append(rules, services.NewRule(services.Wildcard, services.RW()))
 	role.SetRules(services.Allow, rules)
 	role.SetLogins(services.Allow, allowedLogins)
 	err = a.UpsertRole(role, backend.Forever)

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -72,20 +72,3 @@ func (s *UtilsSuite) TestMiscFunctions(c *check.C) {
 	c.Assert(Deduplicate([]string{"a", "b"}), check.DeepEquals, []string{"a", "b"})
 	c.Assert(Deduplicate([]string{"a", "b", "b", "a", "c"}), check.DeepEquals, []string{"a", "b", "c"})
 }
-
-func (s *UtilsSuite) TestGetShell(c *check.C) {
-	shell, err := GetLoginShell("root")
-	c.Assert(err, check.IsNil)
-	c.Assert(shell == "/bin/bash" || shell == "/bin/sh", check.Equals, true)
-
-	shell, err = GetLoginShell("non-existent-user")
-	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Matches, "user: unknown user non-existent-user")
-
-	shell, err = GetLoginShell("daemon")
-	c.Assert(err, check.IsNil)
-	c.Assert(shell == "/usr/sbin/nologin" ||
-		shell == "/sbin/nologin" ||
-		shell == "/usr/bin/nologin" ||
-		shell == "/usr/bin/false", check.Equals, true)
-}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -209,7 +209,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	role := services.RoleForUser(teleUser)
 	role.SetLogins(services.Allow, []string{s.user})
 	rules := role.GetRules(services.Allow)
-	rules[services.Wildcard] = services.RW()
+	rules = append(rules, services.NewRule(services.Wildcard, services.RW()))
 	role.SetRules(services.Allow, rules)
 	err = s.authServer.UpsertRole(role, backend.Forever)
 	c.Assert(err, IsNil)
@@ -457,8 +457,8 @@ func (s *WebSuite) TestSAMLSuccess(c *C) {
 		Allow: services.RoleConditions{
 			NodeLabels: map[string]string{services.Wildcard: services.Wildcard},
 			Namespaces: []string{defaults.Namespace},
-			Rules: map[string][]string{
-				services.Wildcard: services.RW(),
+			Rules: []services.Rule{
+				services.NewRule(services.Wildcard, services.RW()),
 			},
 		},
 	})

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -127,13 +127,10 @@ func (n *namespaceCollection) writeYAML(w io.Writer) error {
 	return trace.Wrap(err)
 }
 
-func printActions(resources map[string][]string) string {
+func printActions(rules []services.Rule) string {
 	pairs := []string{}
-	for key, actions := range resources {
-		if key == services.Wildcard {
-			return fmt.Sprintf("<all resources>: %v", strings.Join(actions, ","))
-		}
-		pairs = append(pairs, fmt.Sprintf("%v:%v", key, strings.Join(actions, ",")))
+	for _, rule := range rules {
+		pairs = append(pairs, fmt.Sprintf("%v:%v", strings.Join(rule.Resources, ","), strings.Join(rule.Verbs, ",")))
 	}
 	return strings.Join(pairs, ",")
 }


### PR DESCRIPTION
Purpose of this PR is to refactor internal Rule representation that did not account for the fact that Rules can contain new properties `Where` and `Actions`

More:

This commit presumes that all logic in web/ui/roleaccess will go away, so I did not spend time recovering it (@alex-kovoy)

Extra stuff:

This PR also moves `cgo` code to a separate package, to avoid problems with IDEs that can't process packages using `cgo` and every single import of `utils` did not work properly with godef for example.

