### PR TITLE
WIP: Minor changes

### DIFF
--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -82,7 +82,7 @@ func (s *EtcdSuite) SetUpTest(c *C) {
 		})
 	err = convertErr(err)
 	if err != nil && !trace.IsNotFound(err) {
-		if strings.Contains(err.Error(), "cluster is unavailable") {
+		if strings.Contains(err.Error(), "connection refused") {
 			fmt.Println("WARNING: etcd cluster is not available. Start examples/etcd/start-etcd.sh")
 			s.skip = true
 			c.Skip(err.Error())

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -508,8 +508,13 @@ type TrustedCluster struct {
 	TunnelAddr string `yaml:"tunnel_addr,omitempty"`
 }
 
-type ClusterName string
+type (
+	ClusterName  string
+	StaticToken  string
+	StaticTokens []StaticToken
+)
 
+// Parse
 func (c ClusterName) Parse() (services.ClusterName, error) {
 	if string(c) == "" {
 		return nil, nil
@@ -518,8 +523,6 @@ func (c ClusterName) Parse() (services.ClusterName, error) {
 		ClusterName: string(c),
 	})
 }
-
-type StaticTokens []StaticToken
 
 func (t StaticTokens) Parse() (services.StaticTokens, error) {
 	var staticTokens []services.ProvisionToken
@@ -536,8 +539,6 @@ func (t StaticTokens) Parse() (services.StaticTokens, error) {
 		StaticTokens: staticTokens,
 	})
 }
-
-type StaticToken string
 
 // Parse is applied to a string in "role,role,role:token" format. It breaks it
 // apart and constructs a services.ProvisionToken which contains the token,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -226,10 +226,12 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 		cfg.AuthServers = []utils.NetAddr{cfg.Auth.SSHAddr}
 	}
 
-	// if user did not provide auth domain name, use this host UUID
+	// if user did not provide auth domain name, use the hostname of the auth server
 	if cfg.Auth.Enabled && cfg.Auth.ClusterName == nil {
+		// TODO (ekontsevoy) the logic here seems to be wrong.
+		//
 		cfg.Auth.ClusterName, err = services.NewClusterName(services.ClusterNameSpecV2{
-			ClusterName: cfg.HostUUID,
+			ClusterName: cfg.Hostname,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
[PLEASE IGNORE FOR NOW]

- Fixed the tests: they used to fail on machines wthout etcd running (I
  assume the new version of etcd client got vendored in?)

- The cluster name now defaults to the _hostname of the auth server_ if
  a user does not set it explicitly. It used to be a GUID.

- Code formatting