### PR TITLE
adding `where` and `actions` section scripts in rules

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -322,6 +322,12 @@
   revision = "5725fecc9a4f3aa6fdc3ffd29cef771241809add"
 
 [[projects]]
+  name = "github.com/vulcand/predicate"
+  packages = ["."]
+  revision = "939c094524d124c55fa8afe0e077701db4a865e2"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
   revision = "e0fe6f68307607d540ed8eac07a342c33fa1b54a"
@@ -388,6 +394,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b95b2baa7e996bc32da399192180a50cf289a0b9718f85b57e14a86f46e25048"
+  inputs-digest = "451ff02b1741edaebc95ff6dde7beabbe4d721e179cba379452fa312df4a9f7a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,6 +21,10 @@
 #  version = "2.4.0"
 
 [[constraint]]
+  name = "github.com/vulcand/predicate"
+  version = "v1.0.0"
+
+[[constraint]]
   name = "github.com/docker/docker"
   revision = "1009e6a40b295187e038b67e184e9c0384d95538"
 

--- a/constants.go
+++ b/constants.go
@@ -129,6 +129,9 @@ const (
 
 	// SAML means authentication will happen remotly using an SAML connector.
 	SAML = "saml"
+
+	// JSON means JSON serialization format
+	JSON = "json"
 )
 
 const (

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -42,7 +42,7 @@ type AuthWithRoles struct {
 }
 
 func (a *AuthWithRoles) action(namespace string, resource string, action string) error {
-	return a.checker.CheckAccessToRule(namespace, resource, action)
+	return a.checker.CheckAccessToRule(&services.Context{User: a.user}, namespace, resource, action)
 }
 
 // currentUserAction is a special checker that allows certain actions for users
@@ -52,7 +52,7 @@ func (a *AuthWithRoles) currentUserAction(username string) error {
 	if username == a.user.GetName() {
 		return nil
 	}
-	return a.checker.CheckAccessToRule(
+	return a.checker.CheckAccessToRule(&services.Context{User: a.user},
 		defaults.Namespace, services.KindUser, services.VerbCreate)
 }
 

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -86,7 +86,7 @@ func (l *LogAction) Log(level, format string, args ...interface{}) predicate.Boo
 			ilevel = log.DebugLevel
 		}
 		writer := log.StandardLogger().WriterLevel(ilevel)
-		writer.Write([]byte(fmt.Sprintf("%v %v", l.ctx, fmt.Sprintf(format, args...))))
+		writer.Write([]byte(fmt.Sprintf(format, args...)))
 		return true
 	}
 }

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -47,7 +47,8 @@ func NewWhereParser(ctx RuleContext) (predicate.Parser, error) {
 			OR:  predicate.Or,
 		},
 		Functions: map[string]interface{}{
-			"equals": predicate.Equals,
+			"equals":   predicate.Equals,
+			"contains": predicate.Contains,
 		},
 		GetIdentifier: ctx.GetIdentifier,
 		GetProperty:   predicate.GetStringMapValue,
@@ -183,7 +184,12 @@ var emptyUser = &UserV2{}
 // EmptyResource is used to represent a use case when no resource
 // is specified in the rules matcher
 type EmptyResource struct {
-	ResourceHeader
+	// Kind is a resource kind
+	Kind string `json:"kind"`
+	// Version is a resource version
+	Version string `json:"version"`
+	// Metadata is Role metadata
+	Metadata Metadata `json:"metadata"`
 }
 
 // SetExpiry sets expiry time for the object.

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/teleport"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/predicate"
+)
+
+// RuleContext specifies context passed to the
+// rule processing matcher, and contains information
+// about current session, e.g. current user
+type RuleContext interface {
+	// GetIdentifier returns identifier defined in a context
+	GetIdentifier(fields []string) (interface{}, error)
+	// String returns human friendly representation of a context
+	String() string
+}
+
+// NewWhereParser returns standard parser for `where` section in access rules
+func NewWhereParser(ctx RuleContext) (predicate.Parser, error) {
+	return predicate.NewParser(predicate.Def{
+		Operators: predicate.Operators{
+			AND: predicate.And,
+			OR:  predicate.Or,
+		},
+		Functions: map[string]interface{}{
+			"equals": predicate.Equals,
+		},
+		GetIdentifier: ctx.GetIdentifier,
+		GetProperty:   predicate.GetStringMapValue,
+	})
+}
+
+// NewActionsParser returns standard parser for 'actions' section in access rules
+func NewActionsParser(ctx RuleContext) (predicate.Parser, error) {
+	return predicate.NewParser(predicate.Def{
+		Operators: predicate.Operators{},
+		Functions: map[string]interface{}{
+			"log": NewLogActionFn(ctx),
+		},
+		GetIdentifier: ctx.GetIdentifier,
+		GetProperty:   predicate.GetStringMapValue,
+	})
+}
+
+// NewLogActionFn creates logger functions
+func NewLogActionFn(ctx RuleContext) interface{} {
+	return (&LogAction{ctx: ctx}).Log
+}
+
+// LogAction represents action that will emit log entry
+// when specified in the actions of a matched rule
+type LogAction struct {
+	ctx RuleContext
+}
+
+// Log logs with specified level and formatting string with arguments
+func (l *LogAction) Log(level, format string, args ...interface{}) predicate.BoolPredicate {
+	return func() bool {
+		ilevel, err := log.ParseLevel(level)
+		if err != nil {
+			ilevel = log.DebugLevel
+		}
+		writer := log.StandardLogger().WriterLevel(ilevel)
+		writer.Write([]byte(fmt.Sprintf("%v %v", l.ctx, fmt.Sprintf(format, args...))))
+		return true
+	}
+}
+
+// Context is a default rule context used in teleport
+type Context struct {
+	// User is currently authenticated user
+	User User
+	// Resource is an optional resource, in case if the rule
+	// checks access to the resource
+	Resource Resource
+}
+
+// String returns user friendly representation of this context
+func (ctx *Context) String() string {
+	return fmt.Sprintf("user %v, resource: %v", ctx.User, ctx.Resource)
+}
+
+const (
+	// UserIdentifier represents user registered identifier in the rules
+	UserIdentifier = "user"
+	// ResourceIdentifier represents resource registered identifer in the rules
+	ResourceIdentifier = "resource"
+)
+
+// GetIdentifier returns identifier defined in a context
+func (ctx *Context) GetIdentifier(fields []string) (interface{}, error) {
+	switch fields[0] {
+	case UserIdentifier:
+		var user User
+		if ctx.User == nil {
+			user = emptyUser
+		} else {
+			user = ctx.User
+		}
+		return predicate.GetFieldByTag(user, teleport.JSON, fields[1:])
+	case ResourceIdentifier:
+		var resource Resource
+		if ctx.Resource == nil {
+			resource = emptyResource
+		} else {
+			resource = ctx.Resource
+		}
+		return predicate.GetFieldByTag(resource, "json", fields[1:])
+	default:
+		return nil, trace.NotFound("%v is not defined", strings.Join(fields, "."))
+	}
+}
+
+// NewParserFn returns function that creates parser of 'where' section
+// in access rules
+type NewParserFn func(ctx RuleContext) (predicate.Parser, error)
+
+var whereParser = NewWhereParser
+var actionsParser = NewActionsParser
+
+// GetWhereParserFn returns global function that creates where parsers
+// this function is used in external tools to override and extend 'where' in rules
+func GetWhereParserFn() NewParserFn {
+	marshalerMutex.RLock()
+	defer marshalerMutex.RUnlock()
+	return whereParser
+}
+
+// SetWhereParserFn sets global function that creates where parsers
+// this function is used in external tools to override and extend 'where' in rules
+func SetWhereParserFn(fn NewParserFn) {
+	marshalerMutex.Lock()
+	defer marshalerMutex.Unlock()
+	whereParser = fn
+}
+
+// GetActionsParserFn returns global function that creates where parsers
+// this function is used in external tools to override and extend actions in rules
+func GetActionsParserFn() NewParserFn {
+	marshalerMutex.RLock()
+	defer marshalerMutex.RUnlock()
+	return actionsParser
+}
+
+// SetActionsParserFn sets global function that creates actions  parsers
+// this function is used in external tools to override and extend actions in rules
+func SetActionsParserFn(fn NewParserFn) {
+	marshalerMutex.Lock()
+	defer marshalerMutex.Unlock()
+	actionsParser = fn
+}
+
+// emptyResource is used when no resource is specified
+var emptyResource = &EmptyResource{}
+
+// emptyUser is used when no user is specified
+var emptyUser = &UserV2{}
+
+// EmptyResource is used to represent a use case when no resource
+// is specified in the rules matcher
+type EmptyResource struct {
+	ResourceHeader
+}
+
+// SetExpiry sets expiry time for the object.
+func (r *EmptyResource) SetExpiry(expires time.Time) {
+	r.Metadata.SetExpiry(expires)
+}
+
+// Expiry returns the expiry time for the object.
+func (r *EmptyResource) Expiry() time.Time {
+	return r.Metadata.Expiry()
+}
+
+// SetTTL sets TTL header using realtime clock.
+func (r *EmptyResource) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+	r.Metadata.SetTTL(clock, ttl)
+}
+
+// SetName sets the role name and is a shortcut for SetMetadata().Name.
+func (r *EmptyResource) SetName(s string) {
+	r.Metadata.Name = s
+}
+
+// GetName gets the role name and is a shortcut for GetMetadata().Name.
+func (r *EmptyResource) GetName() string {
+	return r.Metadata.Name
+}
+
+// GetMetadata returns role metadata.
+func (r *EmptyResource) GetMetadata() Metadata {
+	return r.Metadata
+}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1084,7 +1084,7 @@ type AccessChecker interface {
 	CheckAccessToServer(login string, server Server) error
 
 	// CheckAccessToRule checks access to a rule within a namespace.
-	CheckAccessToRule(namespace string, rule string, verb string) error
+	CheckAccessToRule(context RuleContext, namespace string, rule string, verb string) error
 
 	// CheckLoginDuration checks if role set can login up to given duration and
 	// returns a combined list of allowed logins.

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -764,7 +764,6 @@ func (set RuleSet) Match(whereParser predicate.Parser, actionsParser predicate.P
 	if len(set) == 0 {
 		return false, nil
 	}
-
 	// check for wildcard resource matcher
 	for _, rule := range set[Wildcard] {
 		match, err := rule.MatchesWhere(whereParser)
@@ -1358,7 +1357,7 @@ func (set RoleSet) CheckAccessToRule(ctx RuleContext, namespace string, resource
 				return trace.Wrap(err)
 			}
 			if matched {
-				return trace.AccessDenied("%v access to %v in namespace %v is denied for %v: deny rule matched", verb, resource, namespace, role)
+				return trace.AccessDenied("%v access to %v in namespace %q is denied for role %q: deny rule matched", verb, resource, namespace, role.GetName())
 			}
 		}
 	}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/predicate"
 )
 
 // DefaultUserRules provides access to the default set of rules assigned to
@@ -683,11 +684,47 @@ func NewRule(resource string, verbs []string) Rule {
 // Rule represents allow or deny rule that is executed to check
 // if user or service have access to resource
 type Rule struct {
-	// Resources is a list of
+	// Resources is a list of resources
 	Resources []string `json:"resources"`
-	Verbs     []string `json:"verbs"`
-	Where     string   `json:"where,omitempty"`
-	Actions   []string `json:"actions,omitempty"`
+	// Verbs is a list of verbs
+	Verbs []string `json:"verbs"`
+	// Where specifies optional advanced matcher
+	Where string `json:"where,omitempty"`
+	// Actions specifies optional actions taken when this rule matches
+	Actions []string `json:"actions,omitempty"`
+}
+
+// MatchesWhere returns true if Where rule matches
+// Empty Where block always matches
+func (r *Rule) MatchesWhere(parser predicate.Parser) (bool, error) {
+	if r.Where == "" {
+		return true, nil
+	}
+	ifn, err := parser.Parse(r.Where)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	fn, ok := ifn.(predicate.BoolPredicate)
+	if !ok {
+		return false, trace.BadParameter("unsupported type: %T", ifn)
+	}
+	return fn(), nil
+}
+
+// ProcessActions processes actions specified for this rule
+func (r *Rule) ProcessActions(parser predicate.Parser) error {
+	for _, action := range r.Actions {
+		ifn, err := parser.Parse(action)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fn, ok := ifn.(predicate.BoolPredicate)
+		if !ok {
+			return trace.BadParameter("unsupported type: %T", ifn)
+		}
+		fn()
+	}
+	return nil
 }
 
 // HasVerb returns true if the rule has verb,
@@ -722,27 +759,41 @@ func (r *Rule) Equals(other Rule) bool {
 type RuleSet map[string][]Rule
 
 // MatchRule tests if the resource name and verb are in a given list of rules.
-func (set RuleSet) Match(resource string, verb string) bool {
+func (set RuleSet) Match(whereParser predicate.Parser, actionsParser predicate.Parser, resource string, verb string) (bool, error) {
 	// empty set matches nothing
 	if len(set) == 0 {
-		return false
+		return false, nil
 	}
 
 	// check for wildcard resource matcher
 	for _, rule := range set[Wildcard] {
-		if rule.HasVerb(Wildcard) || rule.HasVerb(verb) {
-			return true
+		match, err := rule.MatchesWhere(whereParser)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		if match && (rule.HasVerb(Wildcard) || rule.HasVerb(verb)) {
+			if err := rule.ProcessActions(actionsParser); err != nil {
+				return true, trace.Wrap(err)
+			}
+			return true, nil
 		}
 	}
 
 	// check for matching resource by name
 	for _, rule := range set[resource] {
-		if rule.HasVerb(Wildcard) || rule.HasVerb(verb) {
-			return true
+		match, err := rule.MatchesWhere(whereParser)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		if match && (rule.HasVerb(Wildcard) || rule.HasVerb(verb)) {
+			if err := rule.ProcessActions(actionsParser); err != nil {
+				return true, trace.Wrap(err)
+			}
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // Slice returns slice from a set
@@ -1289,20 +1340,40 @@ func (set RoleSet) String() string {
 	return fmt.Sprintf("roles %v", strings.Join(roleNames, ","))
 }
 
-func (set RoleSet) CheckAccessToRule(namespace string, resource string, verb string) error {
+func (set RoleSet) CheckAccessToRule(ctx RuleContext, namespace string, resource string, verb string) error {
+	whereParser, err := GetWhereParserFn()(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	actionsParser, err := GetActionsParserFn()(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	// check deny: a single match on a deny rule prohibits access
 	for _, role := range set {
 		matchNamespace := MatchNamespace(role.GetNamespaces(Deny), ProcessNamespace(namespace))
-		if matchNamespace && MakeRuleSet(role.GetRules(Deny)).Match(resource, verb) {
-			return trace.AccessDenied("%v access to %v in namespace %v is denied for %v: deny rule matched", verb, resource, namespace, role)
+		if matchNamespace {
+			matched, err := MakeRuleSet(role.GetRules(Deny)).Match(whereParser, actionsParser, resource, verb)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if matched {
+				return trace.AccessDenied("%v access to %v in namespace %v is denied for %v: deny rule matched", verb, resource, namespace, role)
+			}
 		}
 	}
 
 	// check allow: if rule matches, grant access to resource
 	for _, role := range set {
 		matchNamespace := MatchNamespace(role.GetNamespaces(Allow), ProcessNamespace(namespace))
-		if matchNamespace && MakeRuleSet(role.GetRules(Allow)).Match(resource, verb) {
-			return nil
+		if matchNamespace {
+			match, err := MakeRuleSet(role.GetRules(Allow)).Match(whereParser, actionsParser, resource, verb)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if match {
+				return nil
+			}
 		}
 	}
 
@@ -1412,6 +1483,13 @@ const RoleSpecV3SchemaDefinitions = `
               "items": { "type": "string" }
             },
             "verbs": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "where": {
+               "type": "string"
+            },
+            "actions": {
               "type": "array",
               "items": { "type": "string" }
             }

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -429,7 +429,7 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 		}
 		for j, check := range tc.checks {
 			comment := Commentf("test case %v '%v', check %v", i, tc.name, j)
-			result := set.CheckAccessToRule(check.namespace, check.rule, check.verb)
+			result := set.CheckAccessToRule(&Context{}, check.namespace, check.rule, check.verb)
 			if check.hasAccess {
 				c.Assert(result, IsNil, comment)
 			} else {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -451,7 +451,7 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 									Verbs:     []string{VerbRead},
 									Where:     `contains(user.spec.traits["group"], "prod")`,
 									Actions: []string{
-										`log("info", "4 - tc match")`,
+										`log("info", "4 - tc match for user %v", user.metadata.name)`,
 									},
 								},
 							},
@@ -465,6 +465,9 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 				{
 					context: Context{
 						User: &UserV2{
+							Metadata: Metadata{
+								Name: "bob",
+							},
 							Spec: UserSpecV2{
 								Traits: map[string][]string{
 									"group": []string{"dev", "prod"},

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -111,7 +112,11 @@ func (s *RoleSuite) TestRoleParse(c *C) {
                    "rules": [
                      {
                        "resources": ["role"],
-                       "verbs": ["read", "list"]
+                       "verbs": ["read", "list"],
+                       "where": "contains(user.spec.traits[\"groups\"], \"prod\")",
+                       "actions": [
+                          "log(\"info\", \"log entry\")"
+                       ]
                      }
                    ]
                  },
@@ -135,7 +140,14 @@ func (s *RoleSuite) TestRoleParse(c *C) {
 						NodeLabels: map[string]string{"a": "b"},
 						Namespaces: []string{"system", "default"},
 						Rules: []Rule{
-							NewRule(KindRole, []string{VerbRead, VerbList}),
+							Rule{
+								Resources: []string{KindRole},
+								Verbs:     []string{VerbRead, VerbList},
+								Where:     "contains(user.spec.traits[\"groups\"], \"prod\")",
+								Actions: []string{
+									"log(\"info\", \"log entry\")",
+								},
+							},
 						},
 					},
 					Deny: RoleConditions{
@@ -153,7 +165,7 @@ func (s *RoleSuite) TestRoleParse(c *C) {
 			c.Assert(err, NotNil, comment)
 		} else {
 			c.Assert(err, IsNil, comment)
-			c.Assert(*role, DeepEquals, tc.role, comment)
+			fixtures.DeepCompare(c, *role, tc.role)
 
 			out, err := json.Marshal(role)
 			c.Assert(err, IsNil, comment)
@@ -318,6 +330,7 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 		verb      string
 		namespace string
 		rule      string
+		context   Context
 	}
 	testCases := []struct {
 		name   string
@@ -421,6 +434,109 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 				{rule: KindSession, verb: VerbCreate, namespace: defaults.Namespace, hasAccess: false},
 			},
 		},
+		{
+			name: "4 - user can read sessions if trait matches",
+			roles: []RoleV3{
+				RoleV3{
+					Metadata: Metadata{
+						Name:      "name1",
+						Namespace: defaults.Namespace,
+					},
+					Spec: RoleSpecV3{
+						Allow: RoleConditions{
+							Namespaces: []string{defaults.Namespace},
+							Rules: []Rule{
+								Rule{
+									Resources: []string{KindSession},
+									Verbs:     []string{VerbRead},
+									Where:     `contains(user.spec.traits["group"], "prod")`,
+									Actions: []string{
+										`log("info", "4 - tc match")`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			checks: []check{
+				{rule: KindSession, verb: VerbRead, namespace: defaults.Namespace, hasAccess: false},
+				{rule: KindSession, verb: VerbList, namespace: defaults.Namespace, hasAccess: false},
+				{
+					context: Context{
+						User: &UserV2{
+							Spec: UserSpecV2{
+								Traits: map[string][]string{
+									"group": []string{"dev", "prod"},
+								},
+							},
+						},
+					},
+					rule:      KindSession,
+					verb:      VerbRead,
+					namespace: defaults.Namespace,
+					hasAccess: true,
+				},
+				{
+					context: Context{
+						User: &UserV2{
+							Spec: UserSpecV2{
+								Traits: map[string][]string{
+									"group": []string{"dev"},
+								},
+							},
+						},
+					},
+					rule:      KindSession,
+					verb:      VerbRead,
+					namespace: defaults.Namespace,
+					hasAccess: false,
+				},
+			},
+		},
+		{
+			name: "5 - user can read role if role has label",
+			roles: []RoleV3{
+				RoleV3{
+					Metadata: Metadata{
+						Name:      "name1",
+						Namespace: defaults.Namespace,
+					},
+					Spec: RoleSpecV3{
+						Allow: RoleConditions{
+							Namespaces: []string{defaults.Namespace},
+							Rules: []Rule{
+								Rule{
+									Resources: []string{KindRole},
+									Verbs:     []string{VerbRead},
+									Where:     `equals(resource.metadata.labels["team"], "dev")`,
+									Actions: []string{
+										`log("error", "4 - tc match")`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			checks: []check{
+				{rule: KindRole, verb: VerbRead, namespace: defaults.Namespace, hasAccess: false},
+				{rule: KindRole, verb: VerbList, namespace: defaults.Namespace, hasAccess: false},
+				{
+					context: Context{
+						Resource: &RoleV2{
+							Metadata: Metadata{
+								Labels: map[string]string{"team": "dev"},
+							},
+						},
+					},
+					rule:      KindRole,
+					verb:      VerbRead,
+					namespace: defaults.Namespace,
+					hasAccess: true,
+				},
+			},
+		},
 	}
 	for i, tc := range testCases {
 		var set RoleSet
@@ -429,13 +545,12 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 		}
 		for j, check := range tc.checks {
 			comment := Commentf("test case %v '%v', check %v", i, tc.name, j)
-			result := set.CheckAccessToRule(&Context{}, check.namespace, check.rule, check.verb)
+			result := set.CheckAccessToRule(&check.context, check.namespace, check.rule, check.verb)
 			if check.hasAccess {
 				c.Assert(result, IsNil, comment)
 			} else {
 				c.Assert(trace.IsAccessDenied(result), Equals, true, comment)
 			}
-
 		}
 	}
 }

--- a/lib/web/ui/roleaccess.go
+++ b/lib/web/ui/roleaccess.go
@@ -100,12 +100,8 @@ func (a *RoleAccess) initSSH(teleRole services.Role) error {
 }
 
 func (a *RoleAccess) initAdmin(teleRole services.Role) {
-	hasAllNamespaces := services.MatchNamespace(
-		teleRole.GetNamespaces(services.Allow),
-		services.Wildcard)
-
-	rules := teleRole.GetRules(services.Allow)
-	a.Admin.Enabled = hasFullAccess(rules, adminRules) && hasAllNamespaces
+	// FIXME: this logic is obsolete
+	a.Admin.Enabled = false
 }
 
 func (a *RoleAccess) applyAdmin(role services.Role) {
@@ -136,18 +132,4 @@ func allowAllNamespaces(teleRole services.Role) {
 
 func none() []string {
 	return nil
-}
-
-func hasFullAccess(rules []services.Rule, resources []string) bool {
-	set := services.MakeRuleSet(rules)
-	for _, resource := range resources {
-		hasRead := set.Match(resource, services.ActionRead)
-		hasWrite := set.Match(resource, services.ActionWrite)
-
-		if !(hasRead && hasWrite) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/vendor/github.com/vulcand/predicate/.gitignore
+++ b/vendor/github.com/vulcand/predicate/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/vulcand/predicate/LICENSE
+++ b/vendor/github.com/vulcand/predicate/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/vulcand/predicate/Makefile
+++ b/vendor/github.com/vulcand/predicate/Makefile
@@ -1,0 +1,13 @@
+
+test: clean
+	go test -v ./... -cover
+
+clean:
+	find . -name flymake_* -delete
+
+cover: clean
+	go test -v .  -coverprofile=/tmp/coverage.out
+	go tool cover -html=/tmp/coverage.out
+
+sloccount:
+	 find . -name "*.go" -print0 | xargs -0 wc -l

--- a/vendor/github.com/vulcand/predicate/README.md
+++ b/vendor/github.com/vulcand/predicate/README.md
@@ -1,0 +1,53 @@
+Predicate
+=========
+
+Predicate package used to create interpreted mini languages with Go syntax - mostly to define
+various predicates for configuration, e.g. 
+
+```
+Latency() > 40 || ErrorRate() > 0.5.
+```
+
+Here's an example of fully functional predicate language to deal with division remainders:
+
+```go
+// takes number and returns true or false
+type numberPredicate func(v int) bool
+
+// Converts one number to another
+type numberMapper func(v int) int
+
+// Function that creates predicate to test if the remainder is 0
+func divisibleBy(divisor int) numberPredicate {
+     return func(v int) bool {
+         return v%divisor == 0
+     }
+}
+
+// Function - logical operator AND that combines predicates
+func numberAND(a, b numberPredicate) numberPredicate {
+    return func(v int) bool {
+        return a(v) && b(v)
+    }
+}
+
+func main(){
+    // Create a new parser and define the supported operators and methods
+    p, err := NewParser(Def{
+        Operators: Operators{
+            AND: numberAND,
+        },
+        Functions: map[string]interface{}{
+            "DivisibleBy": divisibleBy,
+        },
+    })
+
+    pr, err := p.Parse("DivisibleBy(2) && DivisibleBy(3)")
+    if err == nil {
+        fmt.Fatalf("Error: %v", err)
+    }
+    pr.(numberPredicate)(2) // false
+    pr.(numberPredicate)(3) // false
+    pr.(numberPredicate)(6) // true
+}
+```

--- a/vendor/github.com/vulcand/predicate/lib.go
+++ b/vendor/github.com/vulcand/predicate/lib.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2016 Vulcand Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicate
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// GetStringMapValue is a helper function that returns property
+// from map[string]string or map[string][]string
+// the function returns empty value in case if key not found
+// In case if map is nil, returns empty value as well
+func GetStringMapValue(mapVal, keyVal interface{}) (interface{}, error) {
+	key, ok := keyVal.(string)
+	if !ok {
+		return nil, trace.BadParameter("only string keys are supported")
+	}
+	switch m := mapVal.(type) {
+	case map[string][]string:
+		if len(m) == 0 {
+			// to return nil with a proper type
+			var n []string
+			return n, nil
+		}
+		return m[key], nil
+	case map[string]string:
+		if len(m) == 0 {
+			return "", nil
+		}
+		return m[key], nil
+	default:
+		return nil, trace.BadParameter("type %T is not supported", m)
+	}
+}
+
+// BoolPredicate is a function without arguments that returns
+// boolean value when called
+type BoolPredicate func() bool
+
+// Equals can compare complex objects, e.g. arrays of strings
+// and strings together
+func Equals(a interface{}, b interface{}) BoolPredicate {
+	return func() bool {
+		switch aval := a.(type) {
+		case string:
+			bval, ok := b.(string)
+			return ok && aval == bval
+		case []string:
+			bval, ok := b.([]string)
+			if !ok {
+				return false
+			}
+			if len(aval) != len(bval) {
+				return false
+			}
+			for i := range aval {
+				if aval[i] != bval[i] {
+					return false
+				}
+			}
+			return true
+		default:
+			return false
+		}
+	}
+}
+
+// Contains checks if string slice contains a string
+// Contains([]string{"a", "b"}, "b") -> true
+func Contains(a interface{}, b interface{}) BoolPredicate {
+	return func() bool {
+		aval, ok := a.([]string)
+		if !ok {
+			return false
+		}
+		bval, ok := b.(string)
+		if !ok {
+			return false
+		}
+		for _, v := range aval {
+			if v == bval {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// And is a boolean predicate that calls two boolean predicates
+// and returns result of && operation on their return values
+func And(a, b BoolPredicate) BoolPredicate {
+	return func() bool {
+		return a() && b()
+	}
+}
+
+// Or is a boolean predicate that calls two boolean predicates
+// and returns result of || operation on their return values
+func Or(a, b BoolPredicate) BoolPredicate {
+	return func() bool {
+		return a() || b()
+	}
+}
+
+// GetFieldByTag returns a field from the object based on the tag
+func GetFieldByTag(ival interface{}, tagName string, fieldNames []string) (interface{}, error) {
+	if len(fieldNames) == 0 {
+		return nil, trace.BadParameter("missing field names")
+	}
+	val := reflect.ValueOf(ival)
+	if val.Kind() == reflect.Interface || val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	if val.Kind() != reflect.Struct {
+		return nil, trace.NotFound("field name %v is not found", strings.Join(fieldNames, "."))
+	}
+	fieldName := fieldNames[0]
+	rest := fieldNames[1:]
+
+	valType := val.Type()
+	for i := 0; i < valType.NumField(); i++ {
+		tagValue := valType.Field(i).Tag.Get(tagName)
+		parts := strings.Split(tagValue, ",")
+		if parts[0] == fieldName {
+			value := val.Field(i).Interface()
+			if len(rest) == 0 {
+				return value, nil
+			}
+			return GetFieldByTag(value, tagName, rest)
+		}
+	}
+	return nil, trace.NotFound("field name %v is not found", strings.Join(fieldNames, "."))
+}

--- a/vendor/github.com/vulcand/predicate/parse.go
+++ b/vendor/github.com/vulcand/predicate/parse.go
@@ -1,0 +1,256 @@
+package predicate
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+func NewParser(d Def) (Parser, error) {
+	return &predicateParser{d: d}, nil
+}
+
+type predicateParser struct {
+	d Def
+}
+
+func (p *predicateParser) Parse(in string) (interface{}, error) {
+	expr, err := parser.ParseExpr(in)
+	if err != nil {
+		return nil, err
+	}
+	return p.parseNode(expr)
+}
+
+func (p *predicateParser) parseNode(node ast.Node) (interface{}, error) {
+	switch n := node.(type) {
+	case *ast.BasicLit:
+		return literalToValue(n)
+	case *ast.BinaryExpr:
+		x, err := p.parseNode(n.X)
+		if err != nil {
+			return nil, err
+		}
+		y, err := p.parseNode(n.Y)
+		if err != nil {
+			return nil, err
+		}
+		return p.joinPredicates(n.Op, x, y)
+	case *ast.CallExpr:
+		// We expect function that will return predicate
+		name, err := getIdentifier(n.Fun)
+		if err != nil {
+			return nil, err
+		}
+		fn, err := p.getFunction(name)
+		if err != nil {
+			return nil, err
+		}
+		arguments, err := p.evaluateArguments(n.Args)
+		if err != nil {
+			return nil, err
+		}
+		return callFunction(fn, arguments)
+	case *ast.ParenExpr:
+		return p.parseNode(n.X)
+	}
+	return nil, trace.BadParameter("unsupported %T", node)
+}
+
+func (p *predicateParser) evaluateArguments(nodes []ast.Expr) ([]interface{}, error) {
+	out := make([]interface{}, len(nodes))
+	for i, n := range nodes {
+		val, err := p.evaluateExpr(n)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		out[i] = val
+	}
+	return out, nil
+}
+
+func (p *predicateParser) evaluateExpr(n ast.Expr) (interface{}, error) {
+	switch l := n.(type) {
+	case *ast.BasicLit:
+		val, err := literalToValue(l)
+		if err != nil {
+			return nil, err
+		}
+		return val, nil
+	case *ast.IndexExpr:
+		if p.d.GetProperty == nil {
+			return nil, trace.NotFound("properties are not supported")
+		}
+		mapVal, err := p.evaluateExpr(l.X)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		keyVal, err := p.evaluateExpr(l.Index)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		val, err := p.d.GetProperty(mapVal, keyVal)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return val, nil
+	case *ast.SelectorExpr:
+		fields, err := evaluateSelector(l, []string{})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if p.d.GetIdentifier == nil {
+			return nil, trace.NotFound("%v is not defined", strings.Join(fields, "."))
+		}
+		val, err := p.d.GetIdentifier(fields)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return val, nil
+	case *ast.Ident:
+		if p.d.GetIdentifier == nil {
+			return nil, trace.NotFound("%v is not defined", l.Name)
+		}
+		val, err := p.d.GetIdentifier([]string{l.Name})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return val, nil
+	default:
+		return nil, trace.BadParameter("%T is not supported", n)
+	}
+}
+
+// evaluateSelector recursively evaluates the selector field and returns a list
+// of properties at the end
+func evaluateSelector(sel *ast.SelectorExpr, fields []string) ([]string, error) {
+	fields = append([]string{sel.Sel.Name}, fields...)
+	switch l := sel.X.(type) {
+	case *ast.SelectorExpr:
+		return evaluateSelector(l, fields)
+	case *ast.Ident:
+		fields = append([]string{l.Name}, fields...)
+		return fields, nil
+	default:
+		return nil, trace.BadParameter("unsupported selector type: %T", l)
+	}
+}
+
+func (p *predicateParser) getFunction(name string) (interface{}, error) {
+	v, ok := p.d.Functions[name]
+	if !ok {
+		return nil, trace.BadParameter("unsupported function: %s", name)
+	}
+	return v, nil
+}
+
+func (p *predicateParser) joinPredicates(op token.Token, a, b interface{}) (interface{}, error) {
+	joinFn, err := p.getJoinFunction(op)
+	if err != nil {
+		return nil, err
+	}
+	return callFunction(joinFn, []interface{}{a, b})
+}
+
+func (p *predicateParser) getJoinFunction(op token.Token) (interface{}, error) {
+	var fn interface{}
+	switch op {
+	case token.LAND:
+		fn = p.d.Operators.AND
+	case token.LOR:
+		fn = p.d.Operators.OR
+	case token.GTR:
+		fn = p.d.Operators.GT
+	case token.GEQ:
+		fn = p.d.Operators.GE
+	case token.LSS:
+		fn = p.d.Operators.LT
+	case token.LEQ:
+		fn = p.d.Operators.LE
+	case token.EQL:
+		fn = p.d.Operators.EQ
+	case token.NEQ:
+		fn = p.d.Operators.NEQ
+	}
+	if fn == nil {
+		return nil, trace.BadParameter("%v is not supported", op)
+	}
+	return fn, nil
+}
+
+func getIdentifier(node ast.Node) (string, error) {
+	sexpr, ok := node.(*ast.SelectorExpr)
+	if ok {
+		id, ok := sexpr.X.(*ast.Ident)
+		if !ok {
+			return "", trace.BadParameter("expected selector identifier, got: %T", sexpr.X)
+		}
+		return fmt.Sprintf("%s.%s", id.Name, sexpr.Sel.Name), nil
+	}
+
+	id, ok := node.(*ast.Ident)
+	if !ok {
+		return "", trace.BadParameter("expected identifier, got: %T", node)
+	}
+	return id.Name, nil
+}
+
+func literalToValue(a *ast.BasicLit) (interface{}, error) {
+	switch a.Kind {
+	case token.FLOAT:
+		value, err := strconv.ParseFloat(a.Value, 64)
+		if err != nil {
+			return nil, trace.BadParameter("failed to parse argument: %s, error: %s", a.Value, err)
+		}
+		return value, nil
+	case token.INT:
+		value, err := strconv.Atoi(a.Value)
+		if err != nil {
+			return nil, trace.BadParameter("failed to parse argument: %s, error: %s", a.Value, err)
+		}
+		return value, nil
+	case token.STRING:
+		value, err := strconv.Unquote(a.Value)
+		if err != nil {
+			return nil, trace.BadParameter("failed to parse argument: %s, error: %s", a.Value, err)
+		}
+		return value, nil
+	}
+	return nil, trace.BadParameter("unsupported function argument type: '%v'", a.Kind)
+}
+
+func callFunction(f interface{}, args []interface{}) (v interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = trace.BadParameter("%s", r)
+		}
+	}()
+	arguments := make([]reflect.Value, len(args))
+	for i, a := range args {
+		arguments[i] = reflect.ValueOf(a)
+	}
+	fn := reflect.ValueOf(f)
+
+	ret := fn.Call(arguments)
+	switch len(ret) {
+	case 1:
+		return ret[0].Interface(), nil
+	case 2:
+		v, e := ret[0].Interface(), ret[1].Interface()
+		if e == nil {
+			return v, nil
+		}
+		err, ok := e.(error)
+		if !ok {
+			return nil, trace.BadParameter("expected error as a second return value, got %T", e)
+		}
+		return v, err
+	}
+	return nil, trace.BadParameter("expected at least one return argument for '%v'", fn)
+}

--- a/vendor/github.com/vulcand/predicate/parse_test.go
+++ b/vendor/github.com/vulcand/predicate/parse_test.go
@@ -1,0 +1,477 @@
+package predicate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type PredicateSuite struct {
+}
+
+var _ = check.Suite(&PredicateSuite{})
+
+func (s *PredicateSuite) getParser(c *check.C) Parser {
+	return s.getParserWithOpts(c, nil, nil)
+}
+
+func (s *PredicateSuite) getParserWithOpts(c *check.C, getID GetIdentifierFn, getProperty GetPropertyFn) Parser {
+	p, err := NewParser(Def{
+		Operators: Operators{
+			AND: numberAND,
+			OR:  numberOR,
+			GT:  numberGT,
+			LT:  numberLT,
+			EQ:  numberEQ,
+			NEQ: numberNEQ,
+			LE:  numberLE,
+			GE:  numberGE,
+		},
+		Functions: map[string]interface{}{
+			"DivisibleBy":        divisibleBy,
+			"Remainder":          numberRemainder,
+			"Len":                stringLength,
+			"number.DivisibleBy": divisibleBy,
+			"Equals":             Equals,
+			"Contains":           Contains,
+		},
+		GetIdentifier: getID,
+		GetProperty:   getProperty,
+	})
+	c.Assert(err, check.IsNil)
+	c.Assert(p, check.NotNil)
+	return p
+}
+
+func (s *PredicateSuite) TestSinglePredicate(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("DivisibleBy(2)")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(2))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, false)
+}
+
+func (s *PredicateSuite) TestModulePredicate(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("number.DivisibleBy(2)")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(2))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, false)
+}
+
+func (s *PredicateSuite) TestJoinAND(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("DivisibleBy(2) && DivisibleBy(3)")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(2), check.Equals, false)
+	c.Assert(fn(3), check.Equals, false)
+	c.Assert(fn(6), check.Equals, true)
+}
+
+func (s *PredicateSuite) TestJoinOR(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("DivisibleBy(2) || DivisibleBy(3)")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, true)
+	c.Assert(fn(5), check.Equals, false)
+}
+
+func (s *PredicateSuite) TestGT(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("Remainder(3) > 1")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(1), check.Equals, false)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, false)
+	c.Assert(fn(4), check.Equals, false)
+	c.Assert(fn(5), check.Equals, true)
+}
+
+func (s *PredicateSuite) TestGTE(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("Remainder(3) >= 1")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(1), check.Equals, true)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, false)
+	c.Assert(fn(4), check.Equals, true)
+	c.Assert(fn(5), check.Equals, true)
+}
+
+func (s *PredicateSuite) TestLT(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("Remainder(3) < 2")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(1), check.Equals, true)
+	c.Assert(fn(2), check.Equals, false)
+	c.Assert(fn(3), check.Equals, true)
+	c.Assert(fn(4), check.Equals, true)
+	c.Assert(fn(5), check.Equals, false)
+}
+
+func (s *PredicateSuite) TestLE(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("Remainder(3) <= 2")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(1), check.Equals, true)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, true)
+	c.Assert(fn(4), check.Equals, true)
+	c.Assert(fn(5), check.Equals, true)
+}
+
+func (s *PredicateSuite) TestEQ(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("Remainder(3) == 2")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(1), check.Equals, false)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, false)
+	c.Assert(fn(4), check.Equals, false)
+	c.Assert(fn(5), check.Equals, true)
+}
+
+func (s *PredicateSuite) TestNEQ(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("Remainder(3) != 2")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(1), check.Equals, true)
+	c.Assert(fn(2), check.Equals, false)
+	c.Assert(fn(3), check.Equals, true)
+	c.Assert(fn(4), check.Equals, true)
+	c.Assert(fn(5), check.Equals, false)
+}
+
+func (s *PredicateSuite) TestParen(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("(Remainder(3) != 1) && (Remainder(3) != 0)")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(0), check.Equals, false)
+	c.Assert(fn(1), check.Equals, false)
+	c.Assert(fn(2), check.Equals, true)
+}
+
+func (s *PredicateSuite) TestStrings(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse(`Remainder(3) == Len("hi")`)
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(0), check.Equals, false)
+	c.Assert(fn(1), check.Equals, false)
+	c.Assert(fn(2), check.Equals, true)
+}
+
+func (s *PredicateSuite) TestGTFloat64(c *check.C) {
+	p := s.getParser(c)
+
+	pr, err := p.Parse("Remainder(3) > 1.2")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(1))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(1), check.Equals, false)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, false)
+	c.Assert(fn(4), check.Equals, false)
+	c.Assert(fn(5), check.Equals, true)
+}
+
+func (s *PredicateSuite) TestIdentifier(c *check.C) {
+	getID := func(fields []string) (interface{}, error) {
+		c.Assert(fields, check.DeepEquals, []string{"first", "second", "third"})
+		return 2, nil
+	}
+	p := s.getParserWithOpts(c, getID, nil)
+
+	pr, err := p.Parse("DivisibleBy(first.second.third)")
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(2))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, false)
+}
+
+func (s *PredicateSuite) TestMap(c *check.C) {
+	getID := func(fields []string) (interface{}, error) {
+		c.Assert(fields, check.DeepEquals, []string{"first", "second"})
+		return map[string]int{"key": 2}, nil
+	}
+	getProperty := func(mapVal, keyVal interface{}) (interface{}, error) {
+		m := mapVal.(map[string]int)
+		k := keyVal.(string)
+		return m[k], nil
+	}
+
+	p := s.getParserWithOpts(c, getID, getProperty)
+
+	pr, err := p.Parse(`DivisibleBy(first.second["key"])`)
+	c.Assert(err, check.IsNil)
+	c.Assert(pr, check.FitsTypeOf, divisibleBy(2))
+	fn := pr.(numberPredicate)
+	c.Assert(fn(2), check.Equals, true)
+	c.Assert(fn(3), check.Equals, false)
+}
+
+func (s *PredicateSuite) TestIdentifierAndFunction(c *check.C) {
+	getID := func(fields []string) (interface{}, error) {
+		switch fields[0] {
+		case "firstSlice":
+			return []string{"a"}, nil
+		case "secondSlice":
+			return []string{"b"}, nil
+		case "a":
+			return "a", nil
+		case "b":
+			return "b", nil
+		}
+		return nil, nil
+	}
+	p := s.getParserWithOpts(c, getID, nil)
+
+	pr, err := p.Parse("Equals(firstSlice, firstSlice)")
+	c.Assert(err, check.IsNil)
+	fn := pr.(BoolPredicate)
+	c.Assert(fn(), check.Equals, true)
+
+	pr, err = p.Parse("Equals(a, a)")
+	c.Assert(err, check.IsNil)
+	fn = pr.(BoolPredicate)
+	c.Assert(fn(), check.Equals, true)
+
+	pr, err = p.Parse("Equals(firstSlice, secondSlice)")
+	c.Assert(err, check.IsNil)
+	fn = pr.(BoolPredicate)
+	c.Assert(fn(), check.Equals, false)
+}
+
+func (s *PredicateSuite) TestContains(c *check.C) {
+	val := TestStruct{}
+	val.Param.Key1 = map[string][]string{"key": []string{"a", "b", "c"}}
+
+	getID := func(fields []string) (interface{}, error) {
+		return GetFieldByTag(val, "json", fields[1:])
+	}
+	p := s.getParserWithOpts(c, getID, GetStringMapValue)
+
+	pr, err := p.Parse(`Contains(val.param.key1["key"], "a")`)
+	c.Assert(err, check.IsNil)
+	c.Assert(pr.(BoolPredicate)(), check.Equals, true)
+
+	pr, err = p.Parse(`Contains(val.param.key1["key"], "z")`)
+	c.Assert(err, check.IsNil)
+	c.Assert(pr.(BoolPredicate)(), check.Equals, false)
+
+	pr, err = p.Parse(`Contains(val.param.key1["missing"], "a")`)
+	c.Assert(err, check.IsNil)
+	c.Assert(pr.(BoolPredicate)(), check.Equals, false)
+}
+
+func (s *PredicateSuite) TestEquals(c *check.C) {
+	val := TestStruct{}
+	val.Param.Key2 = map[string]string{"key": "a"}
+
+	getID := func(fields []string) (interface{}, error) {
+		return GetFieldByTag(val, "json", fields[1:])
+	}
+	p := s.getParserWithOpts(c, getID, GetStringMapValue)
+
+	pr, err := p.Parse(`Equals(val.param.key2["key"], "a")`)
+	c.Assert(err, check.IsNil)
+	c.Assert(pr.(BoolPredicate)(), check.Equals, true)
+
+	pr, err = p.Parse(`Equals(val.param.key2["key"], "b")`)
+	c.Assert(err, check.IsNil)
+	c.Assert(pr.(BoolPredicate)(), check.Equals, false)
+
+	pr, err = p.Parse(`Contains(val.param.key2["missing"], "z")`)
+	c.Assert(err, check.IsNil)
+	c.Assert(pr.(BoolPredicate)(), check.Equals, false)
+
+	pr, err = p.Parse(`Contains(val.param.key1["missing"], "z")`)
+	c.Assert(err, check.IsNil)
+	c.Assert(pr.(BoolPredicate)(), check.Equals, false)
+}
+
+// TestStruct is a test sturcture with json tags
+type TestStruct struct {
+	Param struct {
+		Key1 map[string][]string `json:"key1,omitempty"`
+		Key2 map[string]string   `json:"key2,omitempty"`
+	} `json:"param,omitempty"`
+}
+
+func (s *PredicateSuite) TestGetTagField(c *check.C) {
+	val := TestStruct{}
+	val.Param.Key1 = map[string][]string{"key": []string{"val"}}
+
+	type testCase struct {
+		tag    string
+		fields []string
+		val    interface{}
+		expect interface{}
+		err    error
+	}
+	testCases := []testCase{
+		// nested field
+		{tag: "json", val: val, fields: []string{"param", "key1"}, expect: val.Param.Key1},
+		// pointer to struct
+		{tag: "json", val: &val, fields: []string{"param", "key1"}, expect: val.Param.Key1},
+		// not found field
+		{tag: "json", val: &val, fields: []string{"param", "key3"}, err: trace.NotFound("not found")},
+		// nil pointer
+		{tag: "json", val: nil, fields: []string{"param", "key1"}, err: trace.BadParameter("bad param")},
+	}
+
+	for i, tc := range testCases {
+		comment := check.Commentf("test case %v", i)
+		out, err := GetFieldByTag(tc.val, tc.tag, tc.fields)
+		if tc.err != nil {
+			c.Assert(err, check.FitsTypeOf, tc.err, comment)
+		} else {
+			c.Assert(err, check.IsNil, comment)
+			c.Assert(out, check.DeepEquals, tc.expect, comment)
+		}
+	}
+}
+
+func (s *PredicateSuite) TestUnhappyCases(c *check.C) {
+	cases := []string{
+		")(",                      // invalid expression
+		"SomeFunc",                // unsupported id
+		"Remainder(banana)",       // unsupported argument
+		"Remainder(1, 2)",         // unsupported arguments count
+		"Remainder(Len)",          // unsupported argument
+		`Remainder(Len("Ho"))`,    // unsupported argument
+		"Bla(1)",                  // unknown method call
+		"0.2 && Remainder(1)",     // unsupported value
+		`Len("Ho") && 0.2`,        // unsupported value
+		"func(){}()",              // function call
+		"Remainder(3) >> 3",       // unsupported operator
+		`Remainder(3) > "banana"`, // unsupported comparison type
+	}
+	p := s.getParser(c)
+	for _, expr := range cases {
+		pr, err := p.Parse(expr)
+		c.Assert(err, check.NotNil)
+		c.Assert(pr, check.IsNil)
+	}
+}
+
+type numberPredicate func(v int) bool
+type numberMapper func(v int) int
+
+func divisibleBy(divisor int) numberPredicate {
+	return func(v int) bool {
+		return v%divisor == 0
+	}
+}
+
+func numberAND(a, b numberPredicate) numberPredicate {
+	return func(v int) bool {
+		return a(v) && b(v)
+	}
+}
+
+func numberOR(a, b numberPredicate) numberPredicate {
+	return func(v int) bool {
+		return a(v) || b(v)
+	}
+}
+
+func numberRemainder(divideBy int) numberMapper {
+	return func(v int) int {
+		return v % divideBy
+	}
+}
+
+func numberGT(m numberMapper, value interface{}) (numberPredicate, error) {
+	switch value.(type) {
+	case int:
+	case float64:
+	default:
+		return nil, fmt.Errorf("GT: unsupported argument type: %T", value)
+	}
+	return func(v int) bool {
+		switch val := value.(type) {
+		case int:
+			return m(v) > val
+		case float64:
+			return m(v) > int(val)
+		default:
+			return true
+		}
+	}, nil
+}
+
+func numberGE(m numberMapper, value int) (numberPredicate, error) {
+	return func(v int) bool {
+		return m(v) >= value
+	}, nil
+}
+
+func numberLE(m numberMapper, value int) (numberPredicate, error) {
+	return func(v int) bool {
+		return m(v) <= value
+	}, nil
+}
+
+func numberLT(m numberMapper, value int) numberPredicate {
+	return func(v int) bool {
+		return m(v) < value
+	}
+}
+
+func numberEQ(m numberMapper, value int) numberPredicate {
+	return func(v int) bool {
+		return m(v) == value
+	}
+}
+
+func numberNEQ(m numberMapper, value int) numberPredicate {
+	return func(v int) bool {
+		return m(v) != value
+	}
+}
+
+func stringLength(v string) int {
+	return len(v)
+}

--- a/vendor/github.com/vulcand/predicate/predicate.go
+++ b/vendor/github.com/vulcand/predicate/predicate.go
@@ -1,0 +1,84 @@
+/*
+Predicate package used to create interpreted mini languages with Go syntax - mostly to define
+various predicates for configuration, e.g. Latency() > 40 || ErrorRate() > 0.5.
+
+Here's an example of fully functional predicate language to deal with division remainders:
+
+    // takes number and returns true or false
+    type numberPredicate func(v int) bool
+
+    // Converts one number to another
+    type numberMapper func(v int) int
+
+    // Function that creates predicate to test if the remainder is 0
+    func divisibleBy(divisor int) numberPredicate {
+	    return func(v int) bool {
+		    return v%divisor == 0
+        }
+    }
+
+    // Function - logical operator AND that combines predicates
+    func numberAND(a, b numberPredicate) numberPredicate {
+        return func(v int) bool {
+            return a(v) && b(v)
+        }
+    }
+
+    p, err := NewParser(Def{
+		Operators: Operators{
+			AND: numberAND,
+		},
+		Functions: map[string]interface{}{
+			"DivisibleBy": divisibleBy,
+		},
+	})
+
+	pr, err := p.Parse("DivisibleBy(2) && DivisibleBy(3)")
+    if err == nil {
+        fmt.Fatalf("Error: %v", err)
+    }
+    pr.(numberPredicate)(2) // false
+    pr.(numberPredicate)(3) // false
+    pr.(numberPredicate)(6) // true
+*/
+package predicate
+
+// Def contains supported operators (e.g. LT, GT) and functions passed in as a map.
+type Def struct {
+	Operators Operators
+	// Function matching is case sensitive, e.g. Len is different from len
+	Functions map[string]interface{}
+	// GetIdentifier returns value of any identifier passed in
+	// in the form []string{"id", "field", "subfield"}
+	GetIdentifier GetIdentifierFn
+	// GetProperty returns property from a map
+	GetProperty GetPropertyFn
+}
+
+// GetIdentifierFn function returns identifier based on selector
+// e.g. id.field.subfield will be passed as.
+// GetIdentifierFn([]string{"id", "field", "subfield"})
+type GetIdentifierFn func(selector []string) (interface{}, error)
+
+// GetPropertyFn reuturns property from a mapVal by key keyVal
+type GetPropertyFn func(mapVal, keyVal interface{}) (interface{}, error)
+
+// Operators contain functions for equality and logical comparison.
+type Operators struct {
+	EQ  interface{}
+	NEQ interface{}
+
+	LT interface{}
+	GT interface{}
+
+	LE interface{}
+	GE interface{}
+
+	OR  interface{}
+	AND interface{}
+}
+
+// Parser takes the string with expression and calls the operators and functions.
+type Parser interface {
+	Parse(string) (interface{}, error)
+}


### PR DESCRIPTION
The following logic has been added to the roles:

```yaml
kind: role
version: v3
metadata:
  name: example
spec:
  rules:
    allow:
      # only users with 'groups' trait received from identity server can modify roles
      - resources: ['roles']
        verbs: ['create', 'read', 'update', 'delete']
        where: contains(user.spec.traits["groups"], "prod")
        actions:
          # this will output user information 
          - log("info", "user %v has accessed roles", user.metadata.name)
```

Behavior:

* actions will be only triggered for the rule that has matched first, so order is important.
* where and action blocks are optional
* if no resource is supplied for the action, resource reference is ignored.

The following is supported/not supported now:

* `contains` function is supported and has following signature: 

```go
// finds a string in a slice of strings
contains([]string{"a", "b"}, "value")
```

* `euqals` function is supported and has following signature:

```go
// compares two string values
equals("a", "b")
```

* property access is supported for `user` and provides access to the current user to all fields defined in the manifest as validated by schema:

```go
user.spec.traits
user.metadata.labels
```

* map key access is supported:

```go
user.spec.traits["key"] -> []string
user.metadata.labels["label"] -> string
```

* action `log` is supported with the following signature

```go
log("info|debug|error", "user %v tried to access resource %v", user.metadata.name)
```

* `resource` property is supported but not currently initialized, as we have to pass the resource for every action, we may do it later when the need arises in certain scenarios. 

* Note for @alex-kovoy : the web/roleaccess.go is completely broken now, I rely on you refactoring it.