### PR TITLE
Session access controls

### DIFF
--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1227,6 +1227,26 @@ func (c *Client) SearchEvents(from, to time.Time, query string) ([]events.EventF
 	return retval, nil
 }
 
+// SearchSessionEvents returns session related events to find completed sessions.
+func (c *Client) SearchSessionEvents(from, to time.Time) ([]events.EventFields, error) {
+	query := url.Values{
+		"to":   []string{to.Format(time.RFC3339)},
+		"from": []string{from.Format(time.RFC3339)},
+	}
+
+	response, err := c.Get(c.Endpoint("events", "session"), query)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	retval := make([]events.EventFields, 0)
+	if err := json.Unmarshal(response.Bytes(), &retval); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return retval, nil
+}
+
 // GetNamespaces returns a list of namespaces
 func (c *Client) GetNamespaces() ([]services.Namespace, error) {
 	out, err := c.Get(c.Endpoint("namespaces"), url.Values{})

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -167,7 +167,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 					Namespaces: []string{services.Wildcard},
 					Rules: []services.Rule{
 						services.NewRule(services.KindNode, services.RW()),
-						services.NewRule(services.KindSession, services.RW()),
+						services.NewRule(services.KindSSHSession, services.RW()),
 						services.NewRule(services.KindEvent, services.RW()),
 						services.NewRule(services.KindProxy, services.RO()),
 						services.NewRule(services.KindCertAuthority, services.RO()),
@@ -188,7 +188,8 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 					Rules: []services.Rule{
 						services.NewRule(services.KindProxy, services.RW()),
 						services.NewRule(services.KindOIDCRequest, services.RW()),
-						services.NewRule(services.KindSession, services.RW()),
+						services.NewRule(services.KindSSHSession, services.RW()),
+						services.NewRule(services.KindSession, services.RO()),
 						services.NewRule(services.KindEvent, services.RW()),
 						services.NewRule(services.KindSAMLRequest, services.RW()),
 						services.NewRule(services.KindOIDC, services.RO()),
@@ -214,7 +215,7 @@ func GetCheckerForBuiltinRole(role teleport.Role) (services.AccessChecker, error
 					Namespaces: []string{services.Wildcard},
 					Rules: []services.Rule{
 						services.NewRule(services.KindWebSession, services.RW()),
-						services.NewRule(services.KindSession, services.RW()),
+						services.NewRule(services.KindSSHSession, services.RW()),
 						services.NewRule(services.KindAuthServer, services.RO()),
 						services.NewRule(services.KindUser, services.RO()),
 						services.NewRule(services.KindRole, services.RO()),

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -141,6 +141,10 @@ type IAuditLog interface {
 	// The only mandatory requirement is a date range (UTC). Results must always
 	// show up sorted by date (newest first)
 	SearchEvents(fromUTC, toUTC time.Time, query string) ([]EventFields, error)
+
+	// SearchSessionEvents returns session related events only. This is used to
+	// find completed session.
+	SearchSessionEvents(fromUTC time.Time, toUTC time.Time) ([]EventFields, error)
 }
 
 // EventFields instance is attached to every logged event

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -428,7 +428,7 @@ func (l *AuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
 	return nil
 }
 
-// Search finds events. Results show up sorted by date (newest first)
+// SearchEvents finds events. Results show up sorted by date (newest first)
 func (l *AuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]EventFields, error) {
 	log.Infof("auditLog.SearchEvents(%v, %v, query=%v)", fromUTC, toUTC, query)
 	queryVals, err := url.ParseQuery(query)
@@ -475,6 +475,20 @@ func (l *AuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]Event
 		events = append(events, found...)
 	}
 	return events, nil
+}
+
+// SearchSessionEvents searches for session related events. Used to find completed sessions.
+func (l *AuditLog) SearchSessionEvents(fromUTC, toUTC time.Time) ([]EventFields, error) {
+	log.Infof("auditLog.SearchSessionEvents(%v, %v)", fromUTC, toUTC)
+
+	// only search for specific event types
+	query := url.Values{}
+	query[EventType] = []string{
+		SessionStartEvent,
+		SessionEndEvent,
+	}
+
+	return l.SearchEvents(fromUTC, toUTC, query.Encode())
 }
 
 // byDate implements sort.Interface.

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -34,3 +34,6 @@ func (d *DiscardAuditLog) GetSessionEvents(namespace string, sid session.ID, aft
 func (d *DiscardAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }
+func (d *DiscardAuditLog) SearchSessionEvents(fromUTC time.Time, toUTC time.Time) ([]EventFields, error) {
+	return make([]EventFields, 0), nil
+}

--- a/lib/events/mock.go
+++ b/lib/events/mock.go
@@ -85,3 +85,7 @@ func (d *MockAuditLog) GetSessionEvents(namespace string, sid session.ID, after 
 func (d *MockAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }
+
+func (d *MockAuditLog) SearchSessionEvents(fromUTC, toUTC time.Time) ([]EventFields, error) {
+	return make([]EventFields, 0), nil
+}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -70,8 +70,11 @@ const (
 	// KindOIDCReques is saml auth request resource
 	KindSAMLRequest = "saml_request"
 
-	// KindSession is a recorded session resource
+	// KindSession is a recorded SSH session.
 	KindSession = "session"
+
+	// KindSSHSession is an active SSH session.
+	KindSSHSession = "ssh_session"
 
 	// KindWebSession is a web session resource
 	KindWebSession = "web_session"

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -51,6 +51,9 @@ var DefaultImplicitRules = []Rule{
 	NewRule(KindAuthServer, RO()),
 	NewRule(KindReverseTunnel, RO()),
 	NewRule(KindCertAuthority, RO()),
+	NewRule(KindClusterAuthPreference, RO()),
+	NewRule(KindClusterName, RO()),
+	NewRule(KindSSHSession, RO()),
 }
 
 // DefaultCertAuthorityRules provides access the minimal set of resources
@@ -931,7 +934,7 @@ func (r *RoleV2) CheckAndSetDefaults() error {
 	}
 	if r.Spec.Resources == nil {
 		r.Spec.Resources = map[string][]string{
-			KindSession:       RO(),
+			KindSSHSession:    RO(),
 			KindRole:          RO(),
 			KindNode:          RO(),
 			KindAuthServer:    RO(),

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -343,15 +343,15 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 						Allow: RoleConditions{
 							Namespaces: []string{defaults.Namespace},
 							Rules: []Rule{
-								NewRule(KindSession, []string{VerbRead}),
+								NewRule(KindSSHSession, []string{VerbRead}),
 							},
 						},
 					},
 				},
 			},
 			checks: []check{
-				{rule: KindSession, verb: VerbRead, namespace: defaults.Namespace, hasAccess: true},
-				{rule: KindSession, verb: VerbList, namespace: defaults.Namespace, hasAccess: false},
+				{rule: KindSSHSession, verb: VerbRead, namespace: defaults.Namespace, hasAccess: true},
+				{rule: KindSSHSession, verb: VerbList, namespace: defaults.Namespace, hasAccess: false},
 			},
 		},
 		{
@@ -366,7 +366,7 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 						Allow: RoleConditions{
 							Namespaces: []string{"system"},
 							Rules: []Rule{
-								NewRule(KindSession, []string{VerbRead}),
+								NewRule(KindSSHSession, []string{VerbRead}),
 							},
 						},
 					},
@@ -380,16 +380,16 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 						Allow: RoleConditions{
 							Namespaces: []string{defaults.Namespace},
 							Rules: []Rule{
-								NewRule(KindSession, []string{VerbCreate, VerbRead}),
+								NewRule(KindSSHSession, []string{VerbCreate, VerbRead}),
 							},
 						},
 					},
 				},
 			},
 			checks: []check{
-				{rule: KindSession, verb: VerbRead, namespace: defaults.Namespace, hasAccess: true},
-				{rule: KindSession, verb: VerbCreate, namespace: defaults.Namespace, hasAccess: true},
-				{rule: KindSession, verb: VerbCreate, namespace: "system", hasAccess: false},
+				{rule: KindSSHSession, verb: VerbRead, namespace: defaults.Namespace, hasAccess: true},
+				{rule: KindSSHSession, verb: VerbCreate, namespace: defaults.Namespace, hasAccess: true},
+				{rule: KindSSHSession, verb: VerbCreate, namespace: "system", hasAccess: false},
 				{rule: KindRole, verb: VerbRead, namespace: defaults.Namespace, hasAccess: false},
 			},
 		},
@@ -405,20 +405,20 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 						Deny: RoleConditions{
 							Namespaces: []string{defaults.Namespace},
 							Rules: []Rule{
-								NewRule(KindSession, []string{VerbCreate}),
+								NewRule(KindSSHSession, []string{VerbCreate}),
 							},
 						},
 						Allow: RoleConditions{
 							Namespaces: []string{defaults.Namespace},
 							Rules: []Rule{
-								NewRule(KindSession, []string{VerbCreate}),
+								NewRule(KindSSHSession, []string{VerbCreate}),
 							},
 						},
 					},
 				},
 			},
 			checks: []check{
-				{rule: KindSession, verb: VerbCreate, namespace: defaults.Namespace, hasAccess: false},
+				{rule: KindSSHSession, verb: VerbCreate, namespace: defaults.Namespace, hasAccess: false},
 			},
 		},
 	}

--- a/lib/state/log.go
+++ b/lib/state/log.go
@@ -413,3 +413,6 @@ func (ll *CachingAuditLog) GetSessionEvents(string, session.ID, int) ([]events.E
 func (ll *CachingAuditLog) SearchEvents(time.Time, time.Time, string) ([]events.EventFields, error) {
 	return nil, errNotSupported
 }
+func (ll *CachingAuditLog) SearchSessionEvents(time.Time, time.Time) ([]events.EventFields, error) {
+	return nil, errNotSupported
+}

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -186,7 +186,7 @@ func (t *terminalHandler) Run(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		defer agent.Close()
-		principal, auth, err := t.getUserCredentials(agent)
+		principal, auth, err := getUserCredentials(agent)
 		if err != nil {
 			errToTerm(err, ws)
 			return
@@ -242,8 +242,7 @@ func (t *terminalHandler) Run(w http.ResponseWriter, r *http.Request) {
 
 // getUserCredentials retreives the SSH credentials (certificate) for the currently logged in user
 // from the auth server API.
-//
-func (t *terminalHandler) getUserCredentials(agent auth.AgentCloser) (string, ssh.AuthMethod, error) {
+func getUserCredentials(agent auth.AgentCloser) (string, ssh.AuthMethod, error) {
 	var (
 		cert *ssh.Certificate
 		pub  ssh.PublicKey


### PR DESCRIPTION
**Purpose**

As covered in, https://github.com/gravitational/teleport/issues/1223, this PR addresses two issues. The first is the rule names that gate access to various resources. The second is getting a client to a remote auth server with the logged in users role.

**Implementation**

For the first issue, the following three rules gate access to sessions.

* services.KindSSHSession this controls active sessions. This should be hidden from user roles because this is only used by proxies and nodes.
* services.KindSession this controls recorded sessions. This should be exposed to users and used to gate access to endpoints from the audit log where we fetch session playback related events.
* services.KindEvent which is used to access the full audit log and emit events to the audit log.

In addition a new endpoint `/events/sesssion` and function `SearchSessionEvents` has been created that can only return events related to session start and end which is used to reconstruct the list of completed sessions.

For the second issue, the `Dial` function for a `reversetunnel.RemoteSite` has been updated to accept a special string `@remote-auth-server` which returns a TCP connection to the remote auth server. We then build the `authMethods` for the logged in user and establish a SSH connection and from there an client to the auth server. This way we get a client with the users role instead of the role of the proxy.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1223