### PR TITLE
Removed namespaces and expires from user interface.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -156,7 +156,7 @@ func (s *InstanceSecrets) GetCAs() []services.CertAuthority {
 }
 
 func (s *InstanceSecrets) AllowedLogins() []string {
-	logins := make([]string, len(s.Users))
+	var logins []string
 	for i := range s.Users {
 		logins = append(logins, s.Users[i].AllowedLogins...)
 	}

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -33,8 +33,8 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 
+	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 // Config structure is used to initialize _all_ services Teleporot can run.

--- a/lib/services/clustername.go
+++ b/lib/services/clustername.go
@@ -204,7 +204,12 @@ func (t *TeleportClusterNameMarshaler) Unmarshal(bytes []byte) (ClusterName, err
 	if err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
-	utils.UTC(&clusterName.Metadata.Expires)
+
+	err = clusterName.CheckAndSetDefaults()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &clusterName, nil
 }
 

--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -70,7 +70,7 @@ func (s *AccessService) UpsertRole(role services.Role, ttl time.Duration) error 
 	}
 
 	// TODO(klizhentas): Picking smaller of the two ttls
-	backendTTL := backend.TTL(s.Clock(), role.GetMetadata().Expires)
+	backendTTL := backend.TTL(s.Clock(), role.Expiry())
 	if backendTTL < ttl {
 		ttl = backendTTL
 	}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -80,7 +80,7 @@ func (s *PresenceService) UpsertNamespace(n services.Namespace) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ttl := backend.TTL(s.Clock(), n.Metadata.Expires)
+	ttl := backend.TTL(s.Clock(), n.Metadata.Expiry())
 	err = s.UpsertVal([]string{namespacesPrefix, n.Metadata.Name}, "params", []byte(data), ttl)
 	if err != nil {
 		return trace.Wrap(err)
@@ -140,7 +140,7 @@ func (s *PresenceService) getServers(kind, prefix string) ([]services.Server, er
 }
 
 func (s *PresenceService) upsertServer(prefix string, server services.Server) error {
-	ttl := backend.TTL(s.Clock(), server.GetMetadata().Expires)
+	ttl := backend.TTL(s.Clock(), server.Expiry())
 	data, err := services.GetServerMarshaler().MarshalServer(server)
 	if err != nil {
 		return trace.Wrap(err)
@@ -193,7 +193,7 @@ func (s *PresenceService) UpsertNode(server services.Server) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ttl := backend.TTL(s.Clock(), server.GetMetadata().Expires)
+	ttl := backend.TTL(s.Clock(), server.Expiry())
 	err = s.UpsertVal([]string{namespacesPrefix, server.GetNamespace(), nodesPrefix}, server.GetName(), data, ttl)
 	return trace.Wrap(err)
 }
@@ -239,7 +239,7 @@ func (s *PresenceService) UpsertReverseTunnel(tunnel services.ReverseTunnel) err
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ttl := backend.TTL(s.Clock(), tunnel.GetMetadata().Expires)
+	ttl := backend.TTL(s.Clock(), tunnel.Expiry())
 	err = s.UpsertVal([]string{reverseTunnelsPrefix}, tunnel.GetName(), data, ttl)
 	return trace.Wrap(err)
 }
@@ -282,7 +282,7 @@ func (s *PresenceService) UpsertTrustedCluster(trustedCluster services.TrustedCl
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ttl := backend.TTL(s.Clock(), trustedCluster.GetMetadata().Expires)
+	ttl := backend.TTL(s.Clock(), trustedCluster.Expiry())
 	err = s.UpsertVal([]string{"trustedclusters"}, trustedCluster.GetName(), []byte(data), ttl)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -34,7 +34,7 @@ func (s *CA) UpsertCertAuthority(ca services.CertAuthority) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ttl := backend.TTL(s.Clock(), ca.GetMetadata().Expires)
+	ttl := backend.TTL(s.Clock(), ca.Expiry())
 	err = s.UpsertVal([]string{"authorities", string(ca.GetType())}, ca.GetName(), data, ttl)
 	if err != nil {
 		return trace.Wrap(err)
@@ -101,7 +101,7 @@ func (s *CA) DeactivateCertAuthority(id services.CertAuthID) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ttl := backend.TTL(s.Clock(), certAuthority.GetMetadata().Expires)
+	ttl := backend.TTL(s.Clock(), certAuthority.Expiry())
 
 	err = s.UpsertVal([]string{"authorities", "deactivated", string(id.Type)}, id.DomainName, data, ttl)
 	if err != nil {

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -299,7 +299,8 @@ func (s *IdentityService) UpsertWebSession(user, sid string, session services.We
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ttl := backend.AnyTTL(clockwork.NewRealClock(), session.GetBearerTokenExpiryTime(), session.GetMetadata().Expires)
+	sessionMetadata := session.GetMetadata()
+	ttl := backend.AnyTTL(clockwork.NewRealClock(), session.GetBearerTokenExpiryTime(), sessionMetadata.Expiry())
 	err = s.UpsertVal([]string{"web", "users", user, "sessions"},
 		sid, bytes, ttl)
 	if trace.IsNotFound(err) {

--- a/lib/services/migrations_test.go
+++ b/lib/services/migrations_test.go
@@ -259,7 +259,7 @@ func (s *MigrationsSuite) TestMigrateRoles(c *C) {
 			MaxSessionTTL: NewDuration(20 * time.Hour),
 			Logins:        []string{"foo"},
 			NodeLabels:    map[string]string{"a": "b"},
-			Namespaces:    []string{"system", "default"},
+			Namespaces:    []string{"default"},
 			Resources:     map[string][]string{"role": []string{"read", "write"}},
 		},
 	}
@@ -279,7 +279,7 @@ func (s *MigrationsSuite) TestMigrateRoles(c *C) {
 			Allow: RoleConditions{
 				Logins:     []string{"foo"},
 				NodeLabels: map[string]string{"a": "b"},
-				Namespaces: []string{"system", "default"},
+				Namespaces: []string{"default"},
 				Rules: []Rule{
 					NewRule(KindRole, RW()),
 				},

--- a/lib/services/namespace.go
+++ b/lib/services/namespace.go
@@ -88,7 +88,11 @@ func UnmarshalNamespace(data []byte) (*Namespace, error) {
 	if err := utils.UnmarshalWithSchema(GetNamespaceSchema(), &namespace, data); err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
-	utils.UTC(&namespace.Metadata.Expires)
+
+	if err := namespace.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &namespace, nil
 }
 

--- a/lib/services/oidc_test.go
+++ b/lib/services/oidc_test.go
@@ -121,8 +121,6 @@ func (s *OIDCSuite) TestUnmarshalInvalid(c *check.C) {
       }
 	`
 
-	oc, err := GetOIDCConnectorMarshaler().UnmarshalOIDCConnector([]byte(input))
-	c.Assert(err, check.IsNil)
-	err = oc.Check()
+	_, err := GetOIDCConnectorMarshaler().UnmarshalOIDCConnector([]byte(input))
 	c.Assert(err, check.NotNil)
 }

--- a/lib/services/statictokens.go
+++ b/lib/services/statictokens.go
@@ -219,7 +219,12 @@ func (t *TeleportStaticTokensMarshaler) Unmarshal(bytes []byte) (StaticTokens, e
 	if err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
-	utils.UTC(&staticTokens.Metadata.Expires)
+
+	err = staticTokens.CheckAndSetDefaults()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &staticTokens, nil
 }
 

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -392,7 +392,7 @@ func (s *ServicesTestSuite) RolesCRUD(c *C) {
 			Allow: services.RoleConditions{
 				Logins:     []string{"root", "bob"},
 				NodeLabels: map[string]string{services.Wildcard: services.Wildcard},
-				Namespaces: []string{"default", "system"},
+				Namespaces: []string{"default"},
 				Rules: []services.Rule{
 					services.NewRule(services.KindRole, services.RO()),
 				},

--- a/lib/services/trustedcluster.go
+++ b/lib/services/trustedcluster.go
@@ -420,7 +420,12 @@ func (t *TeleportTrustedClusterMarshaler) Unmarshal(bytes []byte) (TrustedCluste
 	if err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
-	utils.UTC(&trustedCluster.Metadata.Expires)
+
+	err = trustedCluster.CheckAndSetDefaults()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &trustedCluster, nil
 }
 

--- a/lib/utils/time.go
+++ b/lib/utils/time.go
@@ -33,6 +33,10 @@ func ToTTL(c clockwork.Clock, tm time.Time) time.Duration {
 
 // UTC converts time to UTC timezone
 func UTC(t *time.Time) {
+	if t == nil {
+		return
+	}
+
 	if t.IsZero() {
 		// to fix issue with timezones for tests
 		*t = time.Time{}


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1225, we need to remove `namespaces` and `expires` from the Teleport UI.

In addition, YAML tags have been removed because they were incorrectly added in https://github.com/gravitational/teleport/pull/1115.

The other issues in https://github.com/gravitational/teleport/issues/1225 will be addressed in a future Teleport release.

**Implementation**

* Removed YAML tags as they are not used in the library we use to work with YAML.
* The fields `namespace` and `namespaces` are now always omitted during marshaling. These fields are always set to `default` during unmarshaling.
* The `expires` is omitted during marshaling if it is not set. If it has been set, it is emitted.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1225