### PR TITLE
KindAuthConnector

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -128,6 +128,9 @@ const (
 	// KindTrustedCluster is a resource that contains trusted cluster configuration.
 	KindTrustedCluster = "trusted_cluster"
 
+	// KindAuthConnector allows access to OIDC and SAML connectors.
+	KindAuthConnector = "auth_connector"
+
 	// V3 is the third version of resources.
 	V3 = "v3"
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -39,8 +39,7 @@ import (
 // all users.
 var DefaultUserRules = []Rule{
 	NewRule(KindRole, RO()),
-	NewRule(KindOIDC, RO()),
-	NewRule(KindSAML, RO()),
+	NewRule(KindAuthConnector, RO()),
 	NewRule(KindSession, RO()),
 	NewRule(KindTrustedCluster, RW()),
 }

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -105,8 +105,7 @@ func (s *RoleSuite) TestRoleParse(c *C) {
 						Namespaces: []string{defaults.Namespace},
 						Rules: []Rule{
 							NewRule(KindRole, RO()),
-							NewRule(KindOIDC, RO()),
-							NewRule(KindSAML, RO()),
+							NewRule(KindAuthConnector, RO()),
 							NewRule(KindSession, RO()),
 							NewRule(KindTrustedCluster, RW()),
 						},


### PR DESCRIPTION
**Purpose**

This PR introduced the `auth_connector` that grants access to CRUD operations to both OIDC and SAML resources.

**Implementation**

* Introduced a new `KindAuthConnector` resource name.
* Introduced `authConnectorAction` function that checks for access to the resource directly and then for the meta `auth_connector` resource.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1200