### PR TITLE
Hard fail when trying to update ClusterName.

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -783,7 +783,7 @@ func (a *AuthWithRoles) GetClusterName() (services.ClusterName, error) {
 	return a.authServer.GetClusterName()
 }
 
-// SetClusterName sets the name of the cluster.
+// SetClusterName sets the name of the cluster. SetClusterName can only be called once.
 func (a *AuthWithRoles) SetClusterName(c services.ClusterName) error {
 	if err := a.action(defaults.Namespace, services.KindClusterName, services.VerbCreate); err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -226,10 +226,10 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 		cfg.AuthServers = []utils.NetAddr{cfg.Auth.SSHAddr}
 	}
 
-	// if user did not provide auth domain name, use this host UUID
+	// if user did not provide auth domain name, use this host's name
 	if cfg.Auth.Enabled && cfg.Auth.ClusterName == nil {
 		cfg.Auth.ClusterName, err = services.NewClusterName(services.ClusterNameSpecV2{
-			ClusterName: cfg.HostUUID,
+			ClusterName: cfg.Hostname,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -47,14 +47,15 @@ func (s *ClusterConfigurationService) GetClusterName() (services.ClusterName, er
 	return services.GetClusterNameMarshaler().Unmarshal(data)
 }
 
-// SetClusterName sets the name of the cluster in the backend.
+// SetClusterName sets the name of the cluster in the backend. SetClusterName
+// can only be called once on a cluster after which it will return trace.AlreadyExists.
 func (s *ClusterConfigurationService) SetClusterName(c services.ClusterName) error {
 	data, err := services.GetClusterNameMarshaler().Marshal(c)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	err = s.UpsertVal([]string{"cluster_configuration"}, "name", []byte(data), backend.Forever)
+	err = s.CreateVal([]string{"cluster_configuration"}, "name", []byte(data), backend.Forever)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
**Purpose**

This PR prevents the cluster name from being accidentally being overridden. Once the cluster name is set, if a different cluster name comes from the configuration file, Teleport will fail to start.

**Implementation**

Upon startup, Teleport checks if cluster name has been set.

If cluster name has not been set on the backend, Teleport will set the cluster name on the backend with what is in the configuration file.

If the cluster name has been set on the backend and what is in the configuration file differs from what is in the backend, Teleport will hard fail.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1098