### PR TITLE
Ev/tctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ goinstall:
 		github.com/gravitational/teleport/tool/teleport \
 		github.com/gravitational/teleport/tool/tctl
 
-
 #
 # make install will installs system-wide teleport 
 # 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ goinstall:
 		github.com/gravitational/teleport/tool/teleport \
 		github.com/gravitational/teleport/tool/tctl
 
+
 #
 # make install will installs system-wide teleport 
 # 

--- a/docs/2.3/admin-guide.md
+++ b/docs/2.3/admin-guide.md
@@ -465,8 +465,8 @@ of 30 hours and a minimum of 1 minute. Once authenticated, the account will beco
 ```bash
 $ tctl users ls
 
-User           Allowed to Login as
-----           -------------------
+User           Allowed Logins
+----           --------------
 admin          admin,root
 ross           ross
 joe            joe,root 

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -361,7 +361,7 @@ func ParseShortcut(in string) (string, error) {
 		return "", trace.BadParameter("missing resource name")
 	}
 	switch strings.ToLower(in) {
-	case "roles":
+	case "role", "roles":
 		return KindRole, nil
 	case "namespaces", "ns":
 		return KindNamespace, nil
@@ -369,19 +369,19 @@ func ParseShortcut(in string) (string, error) {
 		return KindAuthServer, nil
 	case "proxies":
 		return KindProxy, nil
-	case "nodes":
+	case "nodes", "node":
 		return KindNode, nil
 	case "oidc":
 		return KindOIDCConnector, nil
 	case "saml":
 		return KindSAMLConnector, nil
-	case "users":
+	case "user", "users":
 		return KindUser, nil
 	case "cert_authorities", "cas":
 		return KindCertAuthority, nil
 	case "reverse_tunnels", "rts":
 		return KindReverseTunnel, nil
-	case "trusted_cluster", "tc":
+	case "trusted_cluster", "tc", "cluster", "clusters":
 		return KindTrustedCluster, nil
 	case "cluster_authentication_preferences", "cap":
 		return KindClusterAuthPreference, nil
@@ -441,5 +441,5 @@ func (r *Ref) Set(v string) error {
 }
 
 func (r *Ref) String() string {
-	return fmt.Sprintf("%v/%v", r.Kind, r.Name)
+	return fmt.Sprintf("%s/%s", r.Kind, r.Name)
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -43,7 +43,7 @@ type roleCollection struct {
 
 func (r *roleCollection) writeText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"Role", "Allowed to login as", "Node Labels", "Access to resources"})
+	PrintHeader(t, []string{"Role", "Allowed to login as", "Node Labels", "Access to resources"})
 	if len(r.roles) == 0 {
 		_, err := io.WriteString(w, t.String())
 		return trace.Wrap(err)
@@ -93,7 +93,7 @@ type namespaceCollection struct {
 
 func (n *namespaceCollection) writeText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"Name"})
+	PrintHeader(t, []string{"Name"})
 	if len(n.namespaces) == 0 {
 		_, err := io.WriteString(w, t.String())
 		return trace.Wrap(err)
@@ -155,7 +155,7 @@ type serverCollection struct {
 
 func (s *serverCollection) writeText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"Hostname", "UUID", "Address", "Labels"})
+	PrintHeader(t, []string{"Hostname", "UUID", "Address", "Labels"})
 	if len(s.servers) == 0 {
 		_, err := io.WriteString(w, t.String())
 		return trace.Wrap(err)
@@ -197,17 +197,8 @@ type userCollection struct {
 }
 
 func (s *userCollection) writeText(w io.Writer) error {
-	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"User", "Roles", "Created By"})
-	if len(s.users) == 0 {
-		_, err := io.WriteString(w, t.String())
-		return trace.Wrap(err)
-	}
-	for _, u := range s.users {
-		fmt.Fprintf(t, "%v\t%v\t%v\n", u.GetName(), strings.Join(u.GetRoles(), ","), u.GetCreatedBy().String())
-	}
-	_, err := io.WriteString(w, t.String())
-	return trace.Wrap(err)
+	// a user collection does not need this method
+	return nil
 }
 
 func (s *userCollection) writeJSON(w io.Writer) error {
@@ -241,7 +232,7 @@ type authorityCollection struct {
 
 func (a *authorityCollection) writeText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"Cluster Name", "CA Type", "Fingerprint", "Role Map"})
+	PrintHeader(t, []string{"Cluster Name", "CA Type", "Fingerprint", "Role Map"})
 	for _, a := range a.cas {
 		for _, keyBytes := range a.GetCheckingKeys() {
 			fingerprint, err := sshutils.AuthorizedKeyFingerprint(keyBytes)
@@ -292,7 +283,7 @@ type reverseTunnelCollection struct {
 
 func (r *reverseTunnelCollection) writeText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"Cluster Name", "Dial Addresses"})
+	PrintHeader(t, []string{"Cluster Name", "Dial Addresses"})
 	for _, tunnel := range r.tunnels {
 		fmt.Fprintf(t, "%v\t%v\n", tunnel.GetClusterName(), strings.Join(tunnel.GetDialAddrs(), ","))
 	}
@@ -331,7 +322,7 @@ type oidcCollection struct {
 
 func (c *oidcCollection) writeText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"Name", "Issuer URL", "Additional Scope"})
+	PrintHeader(t, []string{"Name", "Issuer URL", "Additional Scope"})
 	for _, conn := range c.connectors {
 		fmt.Fprintf(t, "%v\t%v\t%v\n", conn.GetName(), conn.GetIssuerURL(), strings.Join(conn.GetScope(), ","))
 	}
@@ -370,7 +361,7 @@ type samlCollection struct {
 
 func (c *samlCollection) writeText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"Name", "SSO URL"})
+	PrintHeader(t, []string{"Name", "SSO URL"})
 	for _, conn := range c.connectors {
 		fmt.Fprintf(t, "%v\t%v\n", conn.GetName(), conn.GetSSO())
 	}
@@ -409,7 +400,7 @@ type trustedClusterCollection struct {
 
 func (c *trustedClusterCollection) writeText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"Name", "Enabled", "Token", "Proxy Address", "Reverse Tunnel Address", "Role Map"})
+	PrintHeader(t, []string{"Name", "Enabled", "Token", "Proxy Address", "Reverse Tunnel Address", "Role Map"})
 	for _, tc := range c.trustedClusters {
 		fmt.Fprintf(t, "%v\t%v\t%v\t%v\t%v\t%v\n", tc.GetName(), tc.GetEnabled(), tc.GetToken(), tc.GetProxyAddress(), tc.GetReverseTunnelAddress(), tc.CombinedMapping())
 	}
@@ -448,7 +439,7 @@ type authPreferenceCollection struct {
 
 func (c *authPreferenceCollection) writeText(w io.Writer) error {
 	t := goterm.NewTable(0, 10, 5, ' ', 0)
-	printHeader(t, []string{"Type", "Second Factor"})
+	PrintHeader(t, []string{"Type", "Second Factor"})
 	fmt.Fprintf(t, "%v\t%v\n", c.GetType(), c.GetSecondFactor())
 	_, err := io.WriteString(w, t.String())
 	return trace.Wrap(err)

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-type collection interface {
+type ResourceCollection interface {
 	writeText(w io.Writer) error
 	writeJSON(w io.Writer) error
 	writeYAML(w io.Writer) error

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -126,8 +126,8 @@ func Run(distribution string, commands []CLICommand) {
 	}
 }
 
-// printHeader helper prints an ASCII table header to stdout
-func printHeader(t *goterm.Table, cols []string) {
+// PrintHeader helper prints an ASCII table header to stdout
+func PrintHeader(t *goterm.Table, cols []string) {
 	dots := make([]string, len(cols))
 	for i := range dots {
 		dots[i] = strings.Repeat("-", len(cols[i]))

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -86,7 +86,7 @@ func (c *TokenCommand) List(client *auth.TunClient) error {
 	}
 	tokensView := func() string {
 		table := goterm.NewTable(0, 10, 5, ' ', 0)
-		printHeader(table, []string{"Token", "Role", "Expiry Time (UTC)"})
+		PrintHeader(table, []string{"Token", "Role", "Expiry Time (UTC)"})
 		for _, t := range tokens {
 			expiry := "never"
 			if t.Expires.Unix() > 0 {


### PR DESCRIPTION
tctl changes (polish for 2.3), refs #1137
   
- tctl get user/joe now works (as reported in #1247)
- tctl create/rm roles changes (moved to 'e')
- `tctl users ls` works differently for OSS-vs-Enterprise (and matches the docs again)
- added synonyms for various resources
- made YAML the default output for tctl get
- added better help + examples for tctl get
- edited error messages
- added the system of "command plugins" which allows 'e' sub-repo of `tctl` to modify default behavior.
- minor refactoring

Related [PR](https://github.com/gravitational/teleport.e/pull/8)
