### PR TITLE
Remove ReadSecrets and replace with ReadUpdate.

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -117,7 +117,7 @@ func (a *AuthWithRoles) GetCertAuthorities(caType services.CertAuthType, loadKey
 		return nil, trace.Wrap(err)
 	}
 	if loadKeys {
-		if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbReadSecrets); err != nil {
+		if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -129,7 +129,7 @@ func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool) 
 		return nil, trace.Wrap(err)
 	}
 	if loadKeys {
-		if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbReadSecrets); err != nil {
+		if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -528,7 +528,7 @@ func (a *AuthWithRoles) GetOIDCConnector(id string, withSecrets bool) (services.
 		return nil, trace.Wrap(err)
 	}
 	if withSecrets {
-		if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbReadSecrets); err != nil {
+		if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -543,7 +543,7 @@ func (a *AuthWithRoles) GetOIDCConnectors(withSecrets bool) ([]services.OIDCConn
 		return nil, trace.Wrap(err)
 	}
 	if withSecrets {
-		if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbReadSecrets); err != nil {
+		if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -591,7 +591,7 @@ func (a *AuthWithRoles) GetSAMLConnector(id string, withSecrets bool) (services.
 		return nil, trace.Wrap(err)
 	}
 	if withSecrets {
-		if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbReadSecrets); err != nil {
+		if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -606,7 +606,7 @@ func (a *AuthWithRoles) GetSAMLConnectors(withSecrets bool) ([]services.SAMLConn
 		return nil, trace.Wrap(err)
 	}
 	if withSecrets {
-		if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbReadSecrets); err != nil {
+		if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbUpdate); err != nil {
 			return nil, trace.Wrap(err)
 
 		}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -146,9 +146,6 @@ const (
 	// VerbConnect is used to allow you to connect to a remote object.
 	VerbConnect = "connect"
 
-	// VerbReadSecrets is used to allow reading secret information from an object.
-	VerbReadSecrets = "readsecrets"
-
 	// VerbList is used to list all objects. Does not imply the ability to read a single object.
 	VerbList = "list"
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1059,7 +1059,7 @@ func (r *RoleV2) V3() *RoleV3 {
 			verbs = RO()
 		} else if containsWrite {
 			// in RoleV2 ActionWrite implied the ability to read secrets.
-			verbs = []string{VerbReadSecrets, VerbCreate, VerbUpdate, VerbDelete}
+			verbs = []string{VerbCreate, VerbUpdate, VerbDelete}
 		}
 
 		rules = append(rules, NewRule(resource, verbs))
@@ -1126,7 +1126,7 @@ func FromSpec(name string, spec RoleSpecV3) (RoleSet, error) {
 
 // RW is a shortcut that returns all verbs.
 func RW() []string {
-	return []string{VerbReadSecrets, VerbConnect, VerbList, VerbCreate, VerbRead, VerbUpdate, VerbDelete}
+	return []string{VerbConnect, VerbList, VerbCreate, VerbRead, VerbUpdate, VerbDelete}
 }
 
 // RO is a shortcut that returns read only verbs.


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1246, we want to remove the `ReadSecrets` verb and replace it with the `Update` verb.

**Implementation**

* Replace `VerbReadSecrets` with `VerbUpdate` everywhere.
* Remove `VerbReadSecrets` everywhere.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1246