### PR TITLE
Renamed default role to admin role.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -194,9 +194,9 @@ const (
 	TraitInternalRoleVariable = "{{internal.logins}}"
 )
 
-// DefaultRole is the name of the default role for all local users if
+// DefaultRole is the name of the default admin role for all local users if
 // another role is not explicitly assigned (Enterprise only).
-const DefaultRoleName = "default"
+const AdminRoleName = "admin"
 
 // DefaultImplicitRole is implicit role that gets added to all service.RoleSet
 // objects.

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -191,8 +191,8 @@ func Init(cfg InitConfig, dynamicConfig bool) (*AuthServer, *Identity, error) {
 	}
 	log.Infof("[INIT] Created Namespace: %q", defaults.Namespace)
 
-	// always create a default role
-	defaultRole := services.NewDefaultRole()
+	// always create a default admin role
+	defaultRole := services.NewAdminRole()
 	err = asrv.UpsertRole(defaultRole, backend.Forever)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/auth/new_web_user.go
+++ b/lib/auth/new_web_user.go
@@ -289,7 +289,7 @@ func (a *AuthServer) createUserAndSession(stoken *services.SignupToken) (service
 	// to services.UserV2 we convert allowed logins to traits.
 	user := stoken.User.V2()
 	if len(user.GetRoles()) == 0 {
-		user.SetRoles([]string{teleport.DefaultRoleName})
+		user.SetRoles([]string{teleport.AdminRoleName})
 	}
 
 	// upsert user into the backend

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -101,7 +101,7 @@ func (s *TunSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// create the default role
-	c.Assert(s.a.UpsertRole(services.NewDefaultRole(), backend.Forever), IsNil)
+	c.Assert(s.a.UpsertRole(services.NewAdminRole(), backend.Forever), IsNil)
 
 	// set up host private key and certificate
 	c.Assert(s.a.UpsertCertAuthority(

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -35,11 +35,11 @@ import (
 	"github.com/vulcand/predicate"
 )
 
-// DefaultUserRules provides access to the default set of rules assigned to
+// AdminUserRules provides access to the default set of rules assigned to
 // all users.
-var DefaultUserRules = []Rule{
-	NewRule(KindRole, RO()),
-	NewRule(KindAuthConnector, RO()),
+var AdminUserRules = []Rule{
+	NewRule(KindRole, RW()),
+	NewRule(KindAuthConnector, RW()),
 	NewRule(KindSession, RO()),
 	NewRule(KindTrustedCluster, RW()),
 }
@@ -77,14 +77,14 @@ func RoleNameForCertAuthority(name string) string {
 	return "ca:" + name
 }
 
-// NewDefaultRole is the default role for all local users if another role
+// NewAdminRole is the default admin role for all local users if another role
 // is not explicitly assigned (Enterprise only).
-func NewDefaultRole() Role {
+func NewAdminRole() Role {
 	return &RoleV3{
 		Kind:    KindRole,
 		Version: V3,
 		Metadata: Metadata{
-			Name:      teleport.DefaultRoleName,
+			Name:      teleport.AdminRoleName,
 			Namespace: defaults.Namespace,
 		},
 		Spec: RoleSpecV3{
@@ -95,7 +95,7 @@ func NewDefaultRole() Role {
 				Namespaces: []string{defaults.Namespace},
 				Logins:     []string{teleport.TraitInternalRoleVariable},
 				NodeLabels: map[string]string{Wildcard: Wildcard},
-				Rules:      CopyRulesSlice(DefaultUserRules),
+				Rules:      CopyRulesSlice(AdminUserRules),
 			},
 		},
 	}
@@ -125,7 +125,7 @@ func NewImplicitRole() Role {
 	}
 }
 
-// RoleForUser creates role for a services.User.
+// RoleForUser creates an admin role for a services.User.
 func RoleForUser(u User) Role {
 	return &RoleV3{
 		Kind:    KindRole,
@@ -141,7 +141,7 @@ func RoleForUser(u User) Role {
 			Allow: RoleConditions{
 				Namespaces: []string{defaults.Namespace},
 				NodeLabels: map[string]string{Wildcard: Wildcard},
-				Rules:      CopyRulesSlice(DefaultUserRules),
+				Rules:      CopyRulesSlice(AdminUserRules),
 			},
 		},
 	}
@@ -491,7 +491,7 @@ func (r *RoleV3) CheckAndSetDefaults() error {
 		r.Spec.Allow.NodeLabels = map[string]string{Wildcard: Wildcard}
 	}
 	if r.Spec.Allow.Rules == nil {
-		r.Spec.Allow.Rules = CopyRulesSlice(DefaultUserRules)
+		r.Spec.Allow.Rules = CopyRulesSlice(AdminUserRules)
 	}
 
 	// if we find {{ or }} but the syntax is invalid, the role is invalid

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -104,8 +104,8 @@ func (s *RoleSuite) TestRoleParse(c *C) {
 						NodeLabels: map[string]string{Wildcard: Wildcard},
 						Namespaces: []string{defaults.Namespace},
 						Rules: []Rule{
-							NewRule(KindRole, RO()),
-							NewRule(KindAuthConnector, RO()),
+							NewRule(KindRole, RW()),
+							NewRule(KindAuthConnector, RW()),
 							NewRule(KindSession, RO()),
 							NewRule(KindTrustedCluster, RW()),
 						},

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -189,7 +189,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// create the default role
-	c.Assert(s.authServer.UpsertRole(services.NewDefaultRole(), backend.Forever), IsNil)
+	c.Assert(s.authServer.UpsertRole(services.NewAdminRole(), backend.Forever), IsNil)
 
 	// configure cluster authentication preferences
 	cap, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{


### PR DESCRIPTION
**Purpose**

Renamed the default role to `admin` and gave the `admin` role write access to roles and auth connectors.

**Implementation**

* Default role has been renamed to admin to make it more clear what permissions this role has.
* The admin role has been given full access to roles and auth connectors in addition to trusted clusters.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1251