### PR TITLE
`tctl create` improvements

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -611,6 +611,7 @@ func (s *APIServer) upsertUser(auth ClientI, w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	err = auth.UpsertUser(user)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR closes  #1137 (finally). Last bits:

* `tctl create` works on different resources for e vs OSS
* `tctl rm` works on different resources for e vs OSS
* `tctl create` now supports `--force, -f` flag for doing updates

Also this PR fixes the build of `e` which is currently broken due to failed merges in the past.

Related: [teleport.e/pull/12](https://github.com/gravitational/teleport.e/pull/12)