### PR TITLE
Simply Trusted Cluster permission check

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -893,18 +893,6 @@ func (a *AuthWithRoles) UpsertTrustedCluster(tc services.TrustedCluster) error {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbCreate); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbCreate); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
 
 	return a.authServer.UpsertTrustedCluster(tc)
 }
@@ -918,12 +906,6 @@ func (a *AuthWithRoles) DeleteTrustedCluster(name string) error {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbDelete); err != nil {
-		return trace.Wrap(err)
-	}
 
 	return a.authServer.DeleteTrustedCluster(name)
 }
@@ -933,12 +915,6 @@ func (a *AuthWithRoles) EnableTrustedCluster(t services.TrustedCluster) error {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
 
 	return a.authServer.EnableTrustedCluster(t)
 }
@@ -946,12 +922,6 @@ func (a *AuthWithRoles) EnableTrustedCluster(t services.TrustedCluster) error {
 // DisableTrustedCluster will disable a TrustedCluster that is already in the backend.
 func (a *AuthWithRoles) DisableTrustedCluster(t services.TrustedCluster) error {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -171,7 +171,9 @@ func (c *SessionContext) GetUserClient(site reversetunnel.RemoteSite) (auth.Clie
 		}
 
 		// add a closer for the underlying connection
-		c.AddClosers(rConn)
+		if rConn != nil {
+			c.AddClosers(rConn)
+		}
 
 		// we'll save the remote client in our session context so we don't have to
 		// build a new connection next time. all remote clients will be closed when


### PR DESCRIPTION
**Purpose**

This PR simplifies Trusted Cluster permissions check. If you have access to a Trusted Cluster, it implies access to Cert Authorities and Reverse Tunnels to manipulate that Trusted Cluster.

**Implementation**

* Removed check on `services.KindCertAuthority` and `services.KindReverseTunnel`.
* Minor bug fix, don't add a `nil` closer.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1250