### PR TITLE
Remove allowed logins and labels from implicit role.

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -117,8 +117,6 @@ func NewImplicitRole() Role {
 			},
 			Allow: RoleConditions{
 				Namespaces: []string{defaults.Namespace},
-				Logins:     []string{teleport.TraitInternalRoleVariable},
-				NodeLabels: map[string]string{Wildcard: Wildcard},
 				Rules:      CopyRulesSlice(DefaultImplicitRules),
 			},
 		},


### PR DESCRIPTION
**Purpose**

The implicit role should be a minimal role that is only used to grant access to resources not exposed to the user. Therefore we should remove logins and labels from it.

**Implementation**

When creating the default implicit role, only set the namespace and rules in it.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1259