### PR TITLE
Add root to the list of logins for an Enterprise role.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -194,6 +194,9 @@ const (
 	TraitInternalRoleVariable = "{{internal.logins}}"
 )
 
+// Root is *nix system administrator account name.
+const Root = "root"
+
 // DefaultRole is the name of the default admin role for all local users if
 // another role is not explicitly assigned (Enterprise only).
 const AdminRoleName = "admin"

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -744,6 +744,11 @@ func (a *AuthWithRoles) GetRoles() ([]services.Role, error) {
 	return a.authServer.GetRoles()
 }
 
+// CreateRole creates a role.
+func (a *AuthWithRoles) CreateRole(role services.Role, ttl time.Duration) error {
+	return trace.BadParameter("not implemented")
+}
+
 // UpsertRole creates or updates role
 func (a *AuthWithRoles) UpsertRole(role services.Role, ttl time.Duration) error {
 	if err := a.action(defaults.Namespace, services.KindRole, services.VerbCreate); err != nil {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1309,6 +1309,11 @@ func (c *Client) GetRoles() ([]services.Role, error) {
 	return roles, nil
 }
 
+// CreateRole creates a role.
+func (c *Client) CreateRole(role services.Role, ttl time.Duration) error {
+	return trace.BadParameter("not implemented")
+}
+
 // UpsertRole creates or updates role
 func (c *Client) UpsertRole(role services.Role, ttl time.Duration) error {
 	data, err := services.GetRoleMarshaler().MarshalRole(role)

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -101,7 +101,7 @@ func (s *TunSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// create the default role
-	c.Assert(s.a.UpsertRole(services.NewAdminRole(), backend.Forever), IsNil)
+	c.Assert(s.a.UpsertRole(services.NewAdminRole(false), backend.Forever), IsNil)
 
 	// set up host private key and certificate
 	c.Assert(s.a.UpsertCertAuthority(

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -189,7 +189,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// create the default role
-	c.Assert(s.authServer.UpsertRole(services.NewAdminRole(), backend.Forever), IsNil)
+	c.Assert(s.authServer.UpsertRole(services.NewAdminRole(false), backend.Forever), IsNil)
 
 	// configure cluster authentication preferences
 	cap, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{


### PR DESCRIPTION
**Purpose**

Add `root` to the list of allowed logins for Enterprise.

**Implementation**

* When creating the default admin account, check if the binary is Teleport or Enterprise. If Enterprise, add `root` to the list of allowed logins to the default admin account.
* Added `CreateRole` so we don't override an existing Teleport admin role when a user upgrades to Enterprise. Did not implement `CreateRole` in the Auth Server API because `POST` was already taken by `UpsertRole`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1267