### PR TITLE
Authentication Selection Regressions

### DIFF
--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -168,7 +168,7 @@ func (*TeleportSAMLConnectorMarshaler) UnmarshalSAMLConnector(bytes []byte) (SAM
 			return nil, trace.BadParameter(err.Error())
 		}
 
-		if err := c.CheckAndSetDefaults(); err != nil {
+		if err := c.Metadata.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
 


### PR DESCRIPTION
**Purpose**

This PR fixes two authentication selection regressions. The first issue is that the second factor type was not being returned at the `/webapi/ping` endpoint which broke local fallback logins. The second issue was a regressions introduced by the changes in https://github.com/gravitational/teleport/pull/1237 which cause `CheckAndSetDefaults` to be called every time a resource is unmarshaled.

**Implementation**

The first issue was fixed by always returning the second factor type when returning the `AuthenticationSettings` when calling the `/webapi/ping` endpoint.

The second issue was resolved by reducing the scope of what `CheckAndSetDefaults` did. In https://github.com/gravitational/teleport/pull/1237 we updated the `UnmarshalSAMLConnector` method to always call `CheckAndSetDefaults` so we can re-add missing fields that were stripped (like namespaces and expires). This is an issue when you are requesting a connector without secrets because `CheckAndSetDefaults` was looking for signing keys. To fix this the scope of `CheckAndSetDefaults` has been reduced so it checks that the connector has all the required fields but does not validate their values.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1272