### PR TITLE
Pass principals as traits to remote cluster.

### DIFF
--- a/lib/srv/sshserver.go
+++ b/lib/srv/sshserver.go
@@ -521,9 +521,12 @@ func (s *Server) checkPermissionToLogin(cert *ssh.Certificate, teleportUser, osU
 			log.Errorf("failed to map roles %v", err)
 			return "", trace.AccessDenied("failed to map roles")
 		}
-		// pass nil for the traits as we don't want to allow substitution into
-		// someone elses cluster
-		roles, err = services.FetchRoles(roleNames, s.authService, nil)
+		// pass the principals on the certificate along as the login traits
+		// to the remote cluster.
+		traits := map[string][]string{
+			teleport.TraitLogins: cert.ValidPrincipals,
+		}
+		roles, err = services.FetchRoles(roleNames, s.authService, traits)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}


### PR DESCRIPTION
**Purpose**

If the certificate to login to a remote cluster is valid, then use the list of principals on the certificate as the allowed logins to the remote cluster.

**Implementation**

* Extract the `ValidPrincipals` from the `ssh.Certificate` and create a trait map for them with the key name being `teleport.TraitLogins`.
* When fetching roles, the `ValidPrincipals` will be substituted in to the list of allowed logins.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1290