### PR TITLE
Refactored Trusted Cluster state change code.

### DIFF
--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -97,6 +97,11 @@ func (s *CA) DeactivateCertAuthority(id services.CertAuthID) error {
 		return trace.BadParameter("can not deactivate CertAuthority which does not exist: %v: %v", id, err)
 	}
 
+	err = s.DeleteCertAuthority(id)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	data, err := services.GetCertAuthorityMarshaler().MarshalCertAuthority(certAuthority)
 	if err != nil {
 		return trace.Wrap(err)
@@ -104,11 +109,6 @@ func (s *CA) DeactivateCertAuthority(id services.CertAuthID) error {
 	ttl := backend.TTL(s.Clock(), certAuthority.Expiry())
 
 	err = s.UpsertVal([]string{"authorities", "deactivated", string(id.Type)}, id.DomainName, data, ttl)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	err = s.DeleteCertAuthority(id)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
**Purpose**

Simplify the Trusted Cluster state change code to be easier to reason about and fix the regressions found in https://github.com/gravitational/teleport/issues/1288.

**Implementation**

* Trusted Cluster can be created in a disabled state.
* Trusted Clusters can be toggled enabled/disabled.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1288