### PR TITLE
Refactored Trusted Cluster creation/update.

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -99,6 +99,10 @@ func (a *AuthWithRoles) UpdateSession(req session.UpdateRequest) error {
 	return a.sessions.UpdateSession(req)
 }
 
+func (a *AuthWithRoles) CreateCertAuthority(ca services.CertAuthority) error {
+	return trace.BadParameter("not implemented")
+}
+
 func (a *AuthWithRoles) UpsertCertAuthority(ca services.CertAuthority) error {
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
@@ -913,24 +917,6 @@ func (a *AuthWithRoles) DeleteTrustedCluster(name string) error {
 	}
 
 	return a.authServer.DeleteTrustedCluster(name)
-}
-
-// EnableTrustedCluster will enable a TrustedCluster that is already in the backend.
-func (a *AuthWithRoles) EnableTrustedCluster(t services.TrustedCluster) error {
-	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return a.authServer.EnableTrustedCluster(t)
-}
-
-// DisableTrustedCluster will disable a TrustedCluster that is already in the backend.
-func (a *AuthWithRoles) DisableTrustedCluster(t services.TrustedCluster) error {
-	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return a.authServer.DisableTrustedCluster(t)
 }
 
 func (a *AuthWithRoles) Close() error {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -218,6 +218,11 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// CreateCertAuthority inserts new cert authority
+func (c *Client) CreateCertAuthority(ca services.CertAuthority) error {
+	return trace.BadParameter("not implemented")
+}
+
 // UpsertCertAuthority updates or inserts new cert authority
 func (c *Client) UpsertCertAuthority(ca services.CertAuthority) error {
 	if err := ca.Check(); err != nil {
@@ -1560,16 +1565,6 @@ func (c *Client) ValidateTrustedCluster(validateRequest *ValidateTrustedClusterR
 func (c *Client) DeleteTrustedCluster(name string) error {
 	_, err := c.Delete(c.Endpoint("trustedclusters", name))
 	return trace.Wrap(err)
-}
-
-// EnableTrustedCluster will enable a TrustedCluster that is already in the backend.
-func (c *Client) EnableTrustedCluster(trustedCluster services.TrustedCluster) error {
-	return c.EnableTrustedCluster(trustedCluster)
-}
-
-// DisableTrustedCluster will disable a TrustedCluster that is already in the backend.
-func (c *Client) DisableTrustedCluster(trustedCluster services.TrustedCluster) error {
-	return c.DisableTrustedCluster(trustedCluster)
 }
 
 // WebService implements features used by Web UI clients

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -336,16 +336,6 @@ func (s *PresenceService) DeleteTrustedCluster(name string) error {
 	return trace.Wrap(err)
 }
 
-// EnableTrustedCluster updates the resource on the backend with new state.
-func (s *PresenceService) EnableTrustedCluster(t services.TrustedCluster) error {
-	return s.UpsertTrustedCluster(t)
-}
-
-// DisableTrustedCluster updates the resource on the backend with the new state.
-func (s *PresenceService) DisableTrustedCluster(t services.TrustedCluster) error {
-	return s.UpsertTrustedCluster(t)
-}
-
 const (
 	localClusterPrefix   = "localCluster"
 	reverseTunnelsPrefix = "reverseTunnels"

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -95,12 +95,6 @@ type Presence interface {
 
 	// DeleteTrustedCluster removes a TrustedCluster from the backend by name.
 	DeleteTrustedCluster(string) error
-
-	// EnableTrustedCluster will enable a TrustedCluster that is already in the backend.
-	EnableTrustedCluster(TrustedCluster) error
-
-	// DisableTrustedCluster will disable a TrustedCluster that is already in the backend.
-	DisableTrustedCluster(TrustedCluster) error
 }
 
 // NewNamespace returns new namespace

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -33,6 +33,9 @@ import (
 // Remote authorities have only public keys available, so they can
 // be only used to validate
 type Trust interface {
+	// CreateCertAuthority inserts a new certificate authority
+	CreateCertAuthority(ca CertAuthority) error
+
 	// UpsertCertAuthority updates or inserts a new certificate authority
 	UpsertCertAuthority(ca CertAuthority) error
 


### PR DESCRIPTION
**Purpose**

Simply the Trusted Cluster creation and update process.

**Implementation**

Always create a disabled Trusted Cluster, then enable it if needed.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1288