### PR TITLE
Refactored Trusted Cluster state change.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ clean:
 	rm -rf $(BUILDDIR)
 	rm -rf teleport
 	rm -rf *.gz
-	rm -rf $(VERSRC)
 	rm -rf `go env GOPATH`/pkg/`go env GOHOSTOS`_`go env GOARCH`/github.com/gravitational/teleport*
 	@if [ -f e/Makefile ]; then $(MAKE) -C e clean; fi
 
@@ -91,7 +90,7 @@ run-docs:
 #
 .PHONY: test
 test: FLAGS ?=
-test: 
+test: $(VERSRC)
 	go test -v ./tool/tsh/... \
 			   ./lib/... \
 			   ./tool/teleport... $(FLAGS) $(ADDFLAGS)


### PR DESCRIPTION
**Purpose**

Simplify the Trusted Cluster state change code to be easier to reason about.

**Implementation**

* Explicit state machine.
* We return an error if an state change is not supported.
* We now return an error when trying to delete a Trusted Cluster that does not exist.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1288