### PR TITLE
By default, no rules.

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -502,9 +502,6 @@ func (r *RoleV3) CheckAndSetDefaults() error {
 	if r.Spec.Allow.NodeLabels == nil {
 		r.Spec.Allow.NodeLabels = map[string]string{Wildcard: Wildcard}
 	}
-	if r.Spec.Allow.Rules == nil {
-		r.Spec.Allow.Rules = CopyRulesSlice(AdminUserRules)
-	}
 	if r.Spec.Deny.Namespaces == nil {
 		r.Spec.Deny.Namespaces = []string{defaults.Namespace}
 	}

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -103,12 +103,6 @@ func (s *RoleSuite) TestRoleParse(c *C) {
 					Allow: RoleConditions{
 						NodeLabels: map[string]string{Wildcard: Wildcard},
 						Namespaces: []string{defaults.Namespace},
-						Rules: []Rule{
-							NewRule(KindRole, RW()),
-							NewRule(KindAuthConnector, RW()),
-							NewRule(KindSession, RO()),
-							NewRule(KindTrustedCluster, RW()),
-						},
 					},
 					Deny: RoleConditions{
 						Namespaces: []string{defaults.Namespace},


### PR DESCRIPTION
**Purpose**

By default, you should have access to no rules.

**Implementation**

Remove granting access in CheckAndSetDefaults.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1321
