### PR TITLE
ValidateCertificateChain: account for possible invalid PEM data block.

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -302,7 +302,8 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		}
 		err = utils.VerifyCertificateChain(certificateBytes)
 		if err != nil {
-			return trace.BadParameter("unable to verify HTTPS certificate chain in %v: %v", fc.Proxy.CertFile, err)
+			return trace.BadParameter("unable to verify HTTPS certificate chain in %v: %s",
+				fc.Proxy.CertFile, utils.UserMessageFromError(err))
 		}
 
 		cfg.Proxy.TLSCert = fc.Proxy.CertFile

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -168,6 +168,9 @@ func VerifyCertificateChain(certificateBytes []byte) error {
 
 	for {
 		certificateBlock, remainingBytes = pem.Decode(remainingBytes)
+		if certificateBlock == nil {
+			return trace.NotFound("no PEM data found")
+		}
 		certificateChain = append(certificateChain, certificateBlock.Bytes)
 
 		if len(remainingBytes) == 0 {

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -163,12 +163,12 @@ func ParsePrivateKeyDER(der []byte) (crypto.Signer, error) {
 func VerifyCertificateChain(certificateBytes []byte) error {
 	// build the certificate chain next
 	var certificateBlock *pem.Block
-	var remainingBytes []byte = certificateBytes
+	var remainingBytes []byte = bytes.TrimSpace(certificateBytes)
 	var certificateChain [][]byte
 
 	for {
 		certificateBlock, remainingBytes = pem.Decode(remainingBytes)
-		if certificateBlock == nil {
+		if certificateBlock == nil || certificateBlock.Type != pemBlockCertificate {
 			return trace.NotFound("no PEM data found")
 		}
 		certificateChain = append(certificateChain, certificateBlock.Bytes)
@@ -216,3 +216,5 @@ func VerifyCertificateChain(certificateBytes []byte) error {
 
 	return nil
 }
+
+const pemBlockCertificate = "CERTIFICATE"

--- a/lib/utils/certs_test.go
+++ b/lib/utils/certs_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2015 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"io/ioutil"
+
+	"github.com/gravitational/trace"
+	. "gopkg.in/check.v1"
+)
+
+type CertsSuite struct {
+}
+
+var _ = Suite(&CertsSuite{})
+
+func (_ *CertsSuite) TestRejectsInvalidPEMData(c *C) {
+	err := VerifyCertificateChain([]byte("no data"))
+	c.Assert(trace.Unwrap(err), FitsTypeOf, &trace.NotFoundError{})
+}
+
+func (_ *CertsSuite) TestRejectsSelfSignedCertificate(c *C) {
+	cert, err := ioutil.ReadFile("../../fixtures/certs/ca.pem")
+	c.Assert(err, IsNil)
+
+	err = VerifyCertificateChain(cert)
+	c.Assert(err, ErrorMatches, "x509: certificate signed by unknown authority")
+}

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -94,7 +94,7 @@ func FatalError(err error) {
 // UserMessageFromError returns user friendly error message from error
 func UserMessageFromError(err error) string {
 	// untrusted cert?
-	switch innerError := trace.Unwrap(err).(interface{}).(type) {
+	switch innerError := trace.Unwrap(err).(type) {
 	case x509.HostnameError:
 		return fmt.Sprintf("Cannot establish https connection to %s:\n%s\n%s\n",
 			innerError.Host,
@@ -129,7 +129,10 @@ func UserMessageFromError(err error) string {
 	if log.GetLevel() == log.DebugLevel {
 		return trace.DebugReport(err)
 	}
-	return err.Error()
+	if err != nil {
+		return err.Error()
+	}
+	return ""
 }
 
 // Consolef prints the same message to a 'ui console' (if defined) and also to


### PR DESCRIPTION
**Purpose**

Improve `ValidateCertificateChain` to make handling of PEM data more robust.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1349