### PR TITLE
Removed hard-coded doc versions from error messages

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -321,7 +321,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	if fc.Auth.DynamicConfig != nil {
 		warningMessage := "Dynamic configuration is no longer supported. Refer to " +
 			"Teleport documentation for more details: " +
-			"http://gravitational.com/teleport/docs/2.0/admin-guide"
+			"http://gravitational.com/teleport/docs/admin-guide"
 		log.Warnf(warningMessage)
 	}
 	// INTERNAL: Authorities (plus Roles) and ReverseTunnels don't follow the
@@ -349,7 +349,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 			"Existing Trusted Cluster relationships will be maintained, but you will " +
 			"not be able to add or remove Trusted Clusters using file configuration " +
 			"anymore. Refer to Teleport documentation for more details: " +
-			"http://gravitational.com/teleport/docs/2.0/admin-guide"
+			"http://gravitational.com/teleport/docs/admin-guide"
 		log.Warnf(warningMessage)
 	}
 	// read in cluster name from file configuration and create services.ClusterName
@@ -377,7 +377,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 				"Existing OIDC connectors will not be removed but you will not be able to " +
 				"add, remove, or update them using file configuration. Refer to Teleport " +
 				"documentation for more details: " +
-				"http://gravitational.com/teleport/docs/2.0/admin-guide"
+				"http://gravitational.com/teleport/docs/admin-guide"
 			log.Warnf(warningMessage)
 		}
 	}


### PR DESCRIPTION
woo! removed hard-coded (obsolete) links to docs