### PR TITLE
Safe redirect for oidc/saml

### DIFF
--- a/lib/httplib/httplib.go
+++ b/lib/httplib/httplib.go
@@ -175,3 +175,13 @@ func RewritePaths(next http.Handler, rewrites ...RewritePair) http.Handler {
 		next.ServeHTTP(w, req)
 	})
 }
+
+// SafeRedirect performs a relative redirect to the URI part of the provided redirect URL
+func SafeRedirect(w http.ResponseWriter, r *http.Request, redirectURL string) error {
+	parsedURL, err := url.Parse(redirectURL)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	http.Redirect(w, r, parsedURL.RequestURI(), http.StatusFound)
+	return nil
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -612,7 +612,7 @@ func (h *Handler) oidcCallback(w http.ResponseWriter, r *http.Request, p httprou
 		if err := SetSession(w, response.Username, response.Session.GetName()); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		http.Redirect(w, r, response.Req.ClientRedirectURL, http.StatusFound)
+		httplib.SafeRedirect(w, r, response.Req.ClientRedirectURL)
 		return nil, nil
 	}
 	log.Infof("oidcCallback redirecting to console login")

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -525,7 +525,7 @@ func (s *WebSuite) TestSAMLSuccess(c *C) {
 	// we have got valid session
 	c.Assert(authRe.Headers().Get("Set-Cookie"), Not(Equals), "")
 	// we are being redirected to orignal URL
-	c.Assert(authRe.Headers().Get("Location"), Equals, "http://localhost/after")
+	c.Assert(authRe.Headers().Get("Location"), Equals, "/after")
 }
 
 type authPack struct {

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -96,7 +96,7 @@ func (m *Handler) samlACS(w http.ResponseWriter, r *http.Request, p httprouter.P
 		if err := SetSession(w, response.Username, response.Session.GetName()); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		http.Redirect(w, r, response.Req.ClientRedirectURL, http.StatusFound)
+		httplib.SafeRedirect(w, r, response.Req.ClientRedirectURL)
 		return nil, nil
 	}
 	l.Debugf("samlCallback redirecting to console login")


### PR DESCRIPTION
Strip host from the client redirect URL during OIDC callback and perform relative redirect 
