### PR TITLE
(web) fixing fixture tests

### DIFF
--- a/lib/web/static_test.go
+++ b/lib/web/static_test.go
@@ -60,6 +60,7 @@ func (s *StaticSuite) TestZipFS(c *check.C) {
 	fs, err := readZipArchive("../../fixtures/assets.zip")
 	c.Assert(err, check.IsNil)
 	c.Assert(fs, check.NotNil)
+	checkFS(fs, c)
 }
 
 func checkFS(fs http.FileSystem, c *check.C) {


### PR DESCRIPTION
* adds CSRF protection to OIDC callbacks
* adds additional HTTP header flags for static resources.
* closes #1337 
* closes #1364 