### PR TITLE
Fix issue where users would get locked out when using OTP tokens.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -251,6 +251,12 @@ func (s *AuthServer) WithUserLock(username string, authenticateFn func() error) 
 	}
 	fnErr := authenticateFn()
 	if fnErr == nil {
+		// upon successful login, reset the failed attempt counter
+		err = s.DeleteUserLoginAttempts(username)
+		if !trace.IsNotFound(err) {
+			return trace.Wrap(err)
+		}
+
 		return nil
 	}
 	// do not lock user in case if DB is flaky or down

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -761,7 +761,10 @@ func TunClientStorage(storage utils.AddrStorage) TunClientOption {
 }
 
 // TunDisableRefresh will disable refreshing the list of auth servers. This is
-// required when requesting user certificates.
+// required when requesting user certificates because we only allow a single
+// HTTP request to be made over the tunnel. This is because each request does
+// keyAuth, and for situations like password+otp where the OTP token is invalid
+// after the first use, that means all other requests would fail.
 func TunDisableRefresh() TunClientOption {
 	return func(t *TunClient) {
 		t.disableRefresh = true

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -85,9 +85,12 @@ type TunClient struct {
 	discoveredAuthServers []utils.NetAddr
 	authMethods           []ssh.AuthMethod
 	refreshTicker         *time.Ticker
-	closeC                chan struct{}
-	closeOnce             sync.Once
-	addrStorage           utils.AddrStorage
+	// disableRefresh will disable the refresh ticker. Used when we only call a
+	// single function with a TunClient (initial fetch of certs).
+	disableRefresh bool
+	closeC         chan struct{}
+	closeOnce      sync.Once
+	addrStorage    utils.AddrStorage
 	// purpose is used for more informative logging. it explains _why_ this
 	// client was created
 	purpose string
@@ -757,6 +760,14 @@ func TunClientStorage(storage utils.AddrStorage) TunClientOption {
 	}
 }
 
+// TunDisableRefresh will disable refreshing the list of auth servers. This is
+// required when requesting user certificates.
+func TunDisableRefresh() TunClientOption {
+	return func(t *TunClient) {
+		t.disableRefresh = true
+	}
+}
+
 // NewTunClient returns an instance of new HTTP client to Auth server API
 // exposed over SSH tunnel, so client  uses SSH credentials to dial and authenticate
 //  - purpose is mostly for debuggin, like "web client" or "reverse tunnel client"
@@ -889,9 +900,11 @@ func (c *TunClient) Dial(network, address string) (net.Conn, error) {
 	}
 	// dialed & authenticated? lets start synchronizing the
 	// list of auth servers:
-	if c.refreshTicker == nil {
-		c.refreshTicker = time.NewTicker(defaults.AuthServersRefreshPeriod)
-		go c.authServersSyncLoop()
+	if c.disableRefresh == false {
+		if c.refreshTicker == nil {
+			c.refreshTicker = time.NewTicker(defaults.AuthServersRefreshPeriod)
+			go c.authServersSyncLoop()
+		}
 	}
 	return &tunConn{client: client, Conn: conn}, nil
 }

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -144,7 +144,7 @@ const (
 	Namespace = "default"
 
 	// AttemptTTL is TTL for login attempt
-	AttemptTTL = time.Hour * 24 * 7
+	AttemptTTL = time.Minute * 30
 )
 
 var (

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -46,6 +46,10 @@ type Identity interface {
 	// GetUserLoginAttempts returns user login attempts
 	GetUserLoginAttempts(user string) ([]LoginAttempt, error)
 
+	// DeleteUserLoginAttempts removes all login attempts of a user. Should be
+	// called after successful login.
+	DeleteUserLoginAttempts(user string) error
+
 	// CreateUser creates user if it does not exist
 	CreateUser(user User) error
 

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -351,6 +351,18 @@ func (s *IdentityService) GetUserLoginAttempts(user string) ([]services.LoginAtt
 	return out, nil
 }
 
+// DeleteUserLoginAttempts removes all login attempts of a user. Should be
+// called after successful login.
+func (s *IdentityService) DeleteUserLoginAttempts(user string) error {
+	err := s.DeleteBucket([]string{"web", "users", user}, "attempts")
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return trace.NotFound(fmt.Sprintf("user '%v' is not found", user))
+		}
+	}
+	return trace.Wrap(err)
+}
+
 // GetWebSession returns a web session state for a given user and session id
 func (s *IdentityService) GetWebSession(user, sid string) (services.WebSession, error) {
 	val, err := s.GetVal([]string{"web", "users", user, "sessions"}, sid)


### PR DESCRIPTION
**Purpose**

For local accounts to obtain SSH certificates, connect to an `AuthTunnel` with the `AuthMethod` being password, password+otp, or password+u2f. When we added `WithUserLock` in  https://github.com/gravitational/teleport/pull/1306 we didn't take into account that the Go HTTP client would use a connection pool to make requests. Since the OTP token can only be used once and the HTTP client would open multiple connections, this causes the fail count to go up by 2 for every successful login. In addition, successful logins would not decrease the fail count.

This means after two successful login with password+otp, you would be locked out of Teleport.

**Implementation**

The long term fix for this is to separate out obtain a SSH certificate from operations on the Auth Server. The short term fix is as follows.

1. Limit the `TunClient` to a single request. Added the `/ca/user/certs/bundle` endpoint and added `TunDisableRefresh` to enable this.
1. Upon successful login wipe out failed counter.
1. Shorten the TTL for failed attempts to expire.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1347