### PR TITLE
Fix name of role, has to start with uppercase.

### DIFF
--- a/roles.go
+++ b/roles.go
@@ -44,7 +44,7 @@ const (
 	// RoleProvisionToken is a role for nodes authenticated using provisioning tokens
 	RoleProvisionToken Role = "ProvisionToken"
 	// RoleTrustedCluster is a role needed for tokens used to add trusted clusters.
-	RoleTrustedCluster Role = "trusted_cluster"
+	RoleTrustedCluster Role = "Trusted_cluster"
 	// RoleSignup is for first time signing up users
 	RoleSignup Role = "Signup"
 	// RoleNop is used for actions that already using external authz mechanisms


### PR DESCRIPTION
**Purpose**

If you followed the documentation with a Trusted Cluster static token, Teleport would refuse to start with the following error:

```
role Trusted_cluster is not registered
```

This PR fixes this behavior by correctly checking the type of static token.

**Implementation**

When we check the type of the static token, we always uppercase the first letter. This means the stored Role name should also start with a uppercase letter. This will allow `trusted_cluster` to be validated.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1381