### PR TITLE
Corrected static token handling.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -621,10 +621,12 @@ func (s *AuthServer) GetTokens() (tokens []services.ProvisionToken, err error) {
 	}
 	// get static tokens:
 	tkns, err := s.GetStaticTokens()
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
-	tokens = append(tokens, tkns.GetStaticTokens()...)
+	if err == nil {
+		tokens = append(tokens, tkns.GetStaticTokens()...)
+	}
 	// get user tokens:
 	userTokens, err := s.Identity.GetSignupTokens()
 	if err != nil {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -154,6 +154,11 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 	c.Assert(s.a.UpsertCertAuthority(
 		suite.NewTestCA(services.HostCA, "me.localhost")), IsNil)
 
+	// before we do anything, we should have 0 tokens
+	btokens, err := s.a.GetTokens()
+	c.Assert(err, IsNil)
+	c.Assert(len(btokens), Equals, 0)
+
 	// generate single-use token (TTL is 0)
 	tok, err := s.a.GenerateToken(teleport.Roles{teleport.RoleNode}, 0)
 	c.Assert(err, IsNil)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -359,9 +359,11 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		return trace.Wrap(err)
 	}
 	// read in static tokens from file configuration and create services.StaticTokens
-	cfg.Auth.StaticTokens, err = fc.Auth.StaticTokens.Parse()
-	if err != nil {
-		return trace.Wrap(err)
+	if fc.Auth.StaticTokens != nil {
+		cfg.Auth.StaticTokens, err = fc.Auth.StaticTokens.Parse()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
 	// read in and set authentication preferences
 	if fc.Auth.Authentication != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -518,7 +518,7 @@ func (c ClusterName) Parse() (services.ClusterName, error) {
 type StaticTokens []StaticToken
 
 func (t StaticTokens) Parse() (services.StaticTokens, error) {
-	var staticTokens []services.ProvisionToken
+	staticTokens := []services.ProvisionToken{}
 
 	for _, token := range t {
 		st, err := token.Parse()

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -307,6 +307,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Auth.SSHAddr = *defaults.AuthListenAddr()
 	cfg.Auth.StorageConfig.Type = boltbk.GetName()
 	cfg.Auth.StorageConfig.Params = backend.Params{"path": cfg.DataDir}
+	cfg.Auth.StaticTokens = services.DefaultStaticTokens()
 	defaults.ConfigureLimiter(&cfg.Auth.Limiter)
 	// set new style default auth preferences
 	ap := &services.AuthPreferenceV2{}

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -68,7 +68,7 @@ func (s *ClusterConfigurationService) GetStaticTokens() (services.StaticTokens, 
 	data, err := s.GetVal([]string{"cluster_configuration"}, "static_tokens")
 	if err != nil {
 		if trace.IsNotFound(err) {
-			return nil, trace.NotFound("cluster name not found")
+			return nil, trace.NotFound("static tokens not found")
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/statictokens.go
+++ b/lib/services/statictokens.go
@@ -62,6 +62,22 @@ func NewStaticTokens(spec StaticTokensSpecV2) (StaticTokens, error) {
 	return &st, nil
 }
 
+// DefaultStaticTokens is used to get the default static tokens (empty list)
+// when nothing is specified in file configuration.
+func DefaultStaticTokens() StaticTokens {
+	return &StaticTokensV2{
+		Kind:    KindStaticTokens,
+		Version: V2,
+		Metadata: Metadata{
+			Name:      MetaNameStaticTokens,
+			Namespace: defaults.Namespace,
+		},
+		Spec: StaticTokensSpecV2{
+			StaticTokens: []ProvisionToken{},
+		},
+	}
+}
+
 // StaticTokensV2 implements the StaticTokens interface.
 type StaticTokensV2 struct {
 	// Kind is a resource kind - always resource.


### PR DESCRIPTION
**Purpose**

Change the behavior of how static tokens are handled to match what users expect.

1. Starting Teleport with no configuration file will set static tokens to an empty list on the backend.
1. Starting Teleport with a configuration file but nothing defined for the `tokens` field will set static tokens to an empty list on the backend.
1. Starting Teleport with a configuration file with `tokens: []` will set static tokens to an empty list on the backend.
1. Starting Teleport with a configuration file with `tokens: ["node,auth,proxy:foo"]` will set static tokens to an `node,auth,proxy:foo` backend.

**Implementation**

* When Teleport starts it creates default configuration with static tokens set to an empty list.
* If the file configuration contains values for the `tokens` field, then `service.Config` is updated with the tokens in file configuration.
* Upon every start, static tokens are pushed to the backend overwriting whatever existed in the backend.
* When listing tokens, only list tokens if they exist otherwise don't append anything to the list of tokens.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1348