### PR TITLE
Validate self-signed certificates upon startup correctly.

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -295,15 +295,31 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 			return trace.Errorf("https cert does not exist: %s", fc.Proxy.CertFile)
 		}
 
-		// verify we have a valid certificate chain before starting teleport
-		certificateBytes, err := utils.ReadPath(fc.Proxy.CertFile)
+		// read in certificate chain from disk
+		certificateChainBytes, err := utils.ReadPath(fc.Proxy.CertFile)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		err = utils.VerifyCertificateChain(certificateBytes)
+
+		// parse certificate chain into []*x509.Certificate
+		certificateChain, err := utils.ReadCertificateChain(certificateChainBytes)
 		if err != nil {
-			return trace.BadParameter("unable to verify HTTPS certificate chain in %v: %s",
-				fc.Proxy.CertFile, utils.UserMessageFromError(err))
+			return trace.Wrap(err)
+		}
+
+		// if starting teleport with a self signed certificate, print a warning, and
+		// then take whatever was passed to us. otherwise verify the certificate
+		// chain from leaf to root so browsers don't complain.
+		if utils.IsSelfSigned(certificateChain) {
+			warningMessage := "Starting Teleport with a self-signed TLS certificate, this is " +
+				"not safe for production clusters. Using a self-signed certificate opens " +
+				"Teleport users to Man-in-the-Middle attacks."
+			log.Warnf(warningMessage)
+		} else {
+			if err := utils.VerifyCertificateChain(certificateChain); err != nil {
+				return trace.BadParameter("unable to verify HTTPS certificate chain in %v: %s",
+					fc.Proxy.CertFile, utils.UserMessageFromError(err))
+			}
 		}
 
 		cfg.Proxy.TLSCert = fc.Proxy.CertFile

--- a/lib/utils/certs_test.go
+++ b/lib/utils/certs_test.go
@@ -29,14 +29,17 @@ type CertsSuite struct {
 var _ = Suite(&CertsSuite{})
 
 func (_ *CertsSuite) TestRejectsInvalidPEMData(c *C) {
-	err := VerifyCertificateChain([]byte("no data"))
+	_, err := ReadCertificateChain([]byte("no data"))
 	c.Assert(trace.Unwrap(err), FitsTypeOf, &trace.NotFoundError{})
 }
 
 func (_ *CertsSuite) TestRejectsSelfSignedCertificate(c *C) {
-	cert, err := ioutil.ReadFile("../../fixtures/certs/ca.pem")
+	certificateChainBytes, err := ioutil.ReadFile("../../fixtures/certs/ca.pem")
 	c.Assert(err, IsNil)
 
-	err = VerifyCertificateChain(cert)
+	certificateChain, err := ReadCertificateChain(certificateChainBytes)
+	c.Assert(err, IsNil)
+
+	err = VerifyCertificateChain(certificateChain)
 	c.Assert(err, ErrorMatches, "x509: certificate signed by unknown authority")
 }


### PR DESCRIPTION
**Purpose**

In https://github.com/gravitational/teleport/pull/1189 we introduced certificate chain validation. This is so that Teleport does not start with a certificate chain that web browsers will reject. However, in doing we only validated certificates from CAs that the users operating system trusts. This is a problem for self signed certificates because they are signed by a unknown CA (to the operating system).

To fix this, we are changing the behavior of Teleport. Now when reading in certificates it checks if the certificate is self-signed or not. If it is self-signed, it sets itself as root when validating the chain. If not, we validate against the CAs that the operating system trusts.

**Implementation**

* Added `IsSelfSigned` function which checks if the `SubjectKeyId` and `AuthorityKeyId` are the same and returns `true` if they are. RFC5280 seems to indicate this is sufficient.
* If the certificate is self-signed, we add itself as the root because it signed itself.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1392