### PR TITLE
Removed `oidc_connectors` from sample configuration

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -481,7 +481,7 @@ type Auth struct {
 
 	// OIDCConnectors is a list of trusted OpenID Connect Identity providers
 	// Deprecated: Use OIDC section in Authentication section instead.
-	OIDCConnectors []OIDCConnector `yaml:"oidc_connectors"`
+	OIDCConnectors []OIDCConnector `yaml:"oidc_connectors,omitempty"`
 
 	// Configuration for "universal 2nd factor"
 	// Deprecated: Use U2F section in Authentication section instead.


### PR DESCRIPTION
Problem:

`teleport configure` prints `oidc_connectors: []` for sample configuration
file (even for OSS version).

This property has been deprecated long time ago. I added 'omitempty' to
JSON serialization.