### PR TITLE
Added ClusterName to discovery request

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -884,7 +884,7 @@ func (s *IntSuite) TestDiscovery(c *check.C) {
 
 	// wait for both sites to see each other via their reverse tunnels (for up to 10 seconds)
 	abortTime := time.Now().Add(time.Second * 10)
-	for len(main.Tunnel.GetSites()) < 2 && len(main.Tunnel.GetSites()) < 2 {
+	for len(main.Tunnel.GetSites()) < 2 {
 		time.Sleep(time.Millisecond * 2000)
 		if time.Now().After(abortTime) {
 			c.Fatalf("two clusters do not see each other: tunnels are not working")

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -12,25 +12,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-reversetunnel package allows teleport clusters to connect to each
-other and to allow users of one cluster to get access to machines
-inside of another cluster.
-
-This capability is called "Trusted Clusters": see Teleport documentation.
-The words "site" and "clusters" are used in the code interchangeably.
-
-Every cluster, in order to be accessible by other trusted clusters,
-must register itself with the reverse tunnel server.
-
-Reverse tunnel server: the TCP/IP server which accepts remote connections
-(tunnels) and keeps track of them. There are two types of tunnels:
-	- Direct (local)
-	- Remote
-
-Direct sites/tunnels are tunnels to itself, i.e. within the same cluster.
-Remote sites/tunnels are, well, remote.
 */
+
 package reversetunnel
 
 import (

--- a/lib/reversetunnel/discovery.go
+++ b/lib/reversetunnel/discovery.go
@@ -12,7 +12,7 @@ import (
 )
 
 type discoveryRequest struct {
-	ClusterName string            `json:"-"`
+	ClusterName string            `json:"cluster_name"`
 	ClusterAddr utils.NetAddr     `json:"-"`
 	Proxies     []services.Server `json:"proxies"`
 }
@@ -56,7 +56,8 @@ func (r discoveryRequest) String() string {
 }
 
 type discoveryRequestRaw struct {
-	Proxies []json.RawMessage `json:"proxies"`
+	ClusterName string            `json:"cluster_name"`
+	Proxies     []json.RawMessage `json:"proxies"`
 }
 
 func marshalDiscoveryRequest(req discoveryRequest) ([]byte, error) {
@@ -69,7 +70,7 @@ func marshalDiscoveryRequest(req discoveryRequest) ([]byte, error) {
 		}
 		out.Proxies = append(out.Proxies, data)
 	}
-
+	out.ClusterName = req.ClusterName
 	return json.Marshal(out)
 }
 
@@ -91,5 +92,6 @@ func unmarshalDiscoveryRequest(data []byte) (*discoveryRequest, error) {
 		}
 		out.Proxies = append(out.Proxies, proxy)
 	}
+	out.ClusterName = raw.ClusterName
 	return &out, nil
 }

--- a/lib/reversetunnel/doc.go
+++ b/lib/reversetunnel/doc.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/* package reversetunnel provides interfaces for accessing remote clusters
+/*
+package reversetunnel provides interfaces for accessing remote clusters
    via reverse tunnels and directly.
 
 Reverse Tunnels

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -118,7 +118,7 @@ func (p *clusterPeers) GetLastConnected() time.Time {
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
 func (p *clusterPeers) Dial(from, to net.Addr) (conn net.Conn, err error) {
-	return nil, trace.ConnectionProblem(nil, "lost connection to reverse tunnel")
+	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy has not been discovered yet, try again later")
 }
 
 // newClusterPeer returns new cluster peer
@@ -146,11 +146,11 @@ type clusterPeer struct {
 }
 
 func (s *clusterPeer) CachingAccessPoint() (auth.AccessPoint, error) {
-	return nil, trace.ConnectionProblem(nil, "lost connection to reverse tunnel")
+	return nil, trace.ConnectionProblem(nil, "unable to fetch access point, this proxy %v has not been discovered yet, try again later")
 }
 
 func (s *clusterPeer) GetClient() (auth.ClientI, error) {
-	return nil, trace.ConnectionProblem(nil, "lost connection to reverse tunnel")
+	return nil, trace.ConnectionProblem(nil, "unable to fetch client, this proxy %v has not been discovered yet, try again later", s)
 }
 
 func (s *clusterPeer) String() string {
@@ -177,5 +177,5 @@ func (s *clusterPeer) GetLastConnected() time.Time {
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
 func (s *clusterPeer) Dial(from, to net.Addr) (conn net.Conn, err error) {
-	return nil, trace.ConnectionProblem(nil, "lost connection to remote proxy")
+	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy %v has not been discovered yet, try again later", s)
 }


### PR DESCRIPTION
**Purpose**

Discovery request was not using cluster name and was using tunnel name for the cluster name. Now proxy sends the cluster name with the discovery request.

**Implementation**

* Send `ClusterName` in discovery request.
* Added comments to code.
* Minor refactoring.

**Related Issues**

n/a