### PR TITLE
Correct various typos

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -703,7 +703,7 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 	c.Assert(main.CreateEx(makeConfig(false)), check.IsNil)
 	c.Assert(aux.CreateEx(makeConfig(true)), check.IsNil)
 
-	// auxillary cluster has a role aux-devs
+	// auxiliary cluster has a role aux-devs
 	// connect aux cluster to main cluster
 	// using trusted clusters, so remote user will be allowed to assume
 	// role specified by mapping remote role "devs" to local role "local-devs"

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -1793,7 +1793,7 @@ func (s *APIServer) setClusterAuthPreference(auth ClientI, w http.ResponseWriter
 		return nil, trace.Wrap(err)
 	}
 
-	return message(fmt.Sprintf("cluster authenticaton preference set: %+v", cap)), nil
+	return message(fmt.Sprintf("cluster authentication preference set: %+v", cap)), nil
 }
 
 type upsertTunnelConnectionRawReq struct {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -233,7 +233,7 @@ func (s *AuthServer) GenerateUserCert(key []byte, user services.User, allowedLog
 	})
 }
 
-// WithUserLock executes function authenticateFn that perorms user authenticaton
+// WithUserLock executes function authenticateFn that performs user authentication
 // if authenticateFn returns non nil error, the login attempt will be logged in as failed.
 // The only exception to this rule is ConnectionProblemError, in case if it occurs
 // access will be denied, but login attempt will not be recorded
@@ -303,7 +303,7 @@ func (s *AuthServer) SignIn(user string, password []byte) (services.WebSession, 
 }
 
 // PreAuthenticatedSignIn is for 2-way authentication methods like U2F where the password is
-// already checked before issueing the second factor challenge
+// already checked before issuing the second factor challenge
 func (s *AuthServer) PreAuthenticatedSignIn(user string) (services.WebSession, error) {
 	sess, err := s.NewWebSession(user)
 	if err != nil {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -126,7 +126,7 @@ func (s *AuthSuite) TestUserLock(c *C) {
 	err = s.a.UpsertPassword(user, pass)
 	c.Assert(err, IsNil)
 
-	// successfull log in
+	// successful log in
 	ws, err = s.a.SignIn(user, pass)
 	c.Assert(err, IsNil)
 	c.Assert(ws, NotNil)
@@ -489,7 +489,7 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 	c.Assert(err, IsNil)
 	err = authServer.SetClusterName(clusterName)
 	c.Assert(err, NotNil)
-	// try and set static tokens, this should be successfull because the last
+	// try and set static tokens, this should be successful because the last
 	// one to upsert tokens wins
 	staticTokens, err := services.NewStaticTokens(services.StaticTokensSpecV2{
 		StaticTokens: []services.ProvisionToken{services.ProvisionToken{

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -383,7 +383,7 @@ func (c *Client) RegisterNewAuthServer(token string) error {
 	return trace.Wrap(err)
 }
 
-// UpsertNode is used by SSH servers to reprt their presense
+// UpsertNode is used by SSH servers to reprt their presence
 // to the auth servers in form of hearbeat expiring after ttl period.
 func (c *Client) UpsertNode(s services.Server) error {
 	if s.GetNamespace() == "" {
@@ -461,7 +461,7 @@ func (c *Client) GetReverseTunnels() ([]services.ReverseTunnel, error) {
 
 // DeleteReverseTunnel deletes reverse tunnel by domain name
 func (c *Client) DeleteReverseTunnel(domainName string) error {
-	// this is to avoid confusing error in case if domain emtpy for example
+	// this is to avoid confusing error in case if domain empty for example
 	// HTTP route will fail producing generic not found error
 	// instead we catch the error here
 	if strings.TrimSpace(domainName) == "" {
@@ -556,7 +556,7 @@ func (c *Client) DeleteAllTunnelConnections() error {
 	return trace.Wrap(err)
 }
 
-// UpsertAuthServer is used by auth servers to report their presense
+// UpsertAuthServer is used by auth servers to report their presence
 // to other auth servers in form of hearbeat expiring after ttl period.
 func (c *Client) UpsertAuthServer(s services.Server) error {
 	data, err := services.GetServerMarshaler().MarshalServer(s)
@@ -591,7 +591,7 @@ func (c *Client) GetAuthServers() ([]services.Server, error) {
 	return re, nil
 }
 
-// UpsertProxy is used by proxies to report their presense
+// UpsertProxy is used by proxies to report their presence
 // to other auth servers in form of hearbeat expiring after ttl period.
 func (c *Client) UpsertProxy(s services.Server) error {
 	data, err := services.GetServerMarshaler().MarshalServer(s)
@@ -696,7 +696,7 @@ func (c *Client) SignIn(user string, password []byte) (services.WebSession, erro
 }
 
 // PreAuthenticatedSignIn is for 2-way authentication methods like U2F where the password is
-// already checked before issueing the second factor challenge
+// already checked before issuing the second factor challenge
 func (c *Client) PreAuthenticatedSignIn(user string) (services.WebSession, error) {
 	out, err := c.Get(
 		c.Endpoint("users", user, "web", "signin", "preauth"),

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	// this global configures how many pre-caluclated keypairs to keep in the
+	// this global configures how many pre-calculated keypairs to keep in the
 	// background (perform key genreation in a separate goroutine, useful for
 	// web sesssion for snappy UI)
 	PrecalculatedKeysNum = 10

--- a/lib/auth/ssh_to_http.go
+++ b/lib/auth/ssh_to_http.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// Implements a fake "socket" (net.Listener interface) on top of exisitng ssh.Channel
+// Implements a fake "socket" (net.Listener interface) on top of existing ssh.Channel
 type fakeSocket struct {
 	closed      chan int
 	connections chan net.Conn

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -352,7 +352,7 @@ func (s *AuthTunnel) onAPIConnection(sconn *ssh.ServerConn, sshChan ssh.Channel,
 
 	var user interface{} = nil
 	if extRole, ok := sconn.Permissions.Extensions[ExtRole]; ok {
-		// retreive the role from thsi connection's permissions (make sure it's a valid role)
+		// retrieve the role from this connection's permissions (make sure it's a valid role)
 		systemRole := teleport.Role(extRole)
 		if err := systemRole.Check(); err != nil {
 			log.Error(err.Error())

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -369,7 +369,7 @@ func (s *TunSuite) TestWebCreatingNewUserValidClientValidToken(c *C) {
 	c.Assert(ws, Not(Equals), "")
 }
 
-// TestWebCreatingNewUserValidClientValidTokenReuseToken connects to teh auth server
+// TestWebCreatingNewUserValidClientValidTokenReuseToken connects to the auth server
 // using a valid signup token and then uses a valid token to create a user. Then
 // try to create another user. This should fail.
 func (s *TunSuite) TestWebCreatingNewUserValidClientValidTokenReuseToken(c *C) {

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package test contains a backend acceptance test suite that is backend implementation independant
+// Package test contains a backend acceptance test suite that is backend implementation independent
 // each backend will use the suite to test itself
 package test
 
@@ -43,7 +43,7 @@ func (s *BackendSuite) collectChanges(c *C, expected int) []interface{} {
 		case changes[i] = <-s.ChangesC:
 			// successfully collected changes
 		case <-time.After(2 * time.Second):
-			c.Fatalf("Timeout occured waiting for events")
+			c.Fatalf("Timeout occurred waiting for events")
 		}
 	}
 	return changes

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -987,7 +987,7 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// After successfull login we have local agent updated with latest
+	// After successful login we have local agent updated with latest
 	// and greatest auth information, try it now
 	sshConfig.Auth = []ssh.AuthMethod{authMethod}
 	sshConfig.User = proxyPrincipal
@@ -1392,7 +1392,7 @@ func ParsePortForwardSpec(spec []string) (ports ForwardedPorts, err error) {
 	if len(spec) == 0 {
 		return ports, nil
 	}
-	const errTemplate = "Invalid port forwarding spec: '%s'. Sould be like `80:remote.host:80`"
+	const errTemplate = "Invalid port forwarding spec: '%s'. Could be like `80:remote.host:80`"
 	ports = make([]ForwardedPort, len(spec), len(spec))
 
 	for i, str := range spec {

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -155,7 +155,7 @@ func (proxy *ProxyClient) ConnectToSite(ctx context.Context, quiet bool) (auth.C
 	// crate HTTP client to Auth API over SSH connection:
 	sshDialer := func(network, addr string) (net.Conn, error) {
 		// this connects us to the node which is an auth server for this site
-		// note the addres we're using: "@sitename", which in practice looks like "@{site-global-id}"
+		// note the address we're using: "@sitename", which in practice looks like "@{site-global-id}"
 		// the Teleport proxy interprets such address as a request to connec to the active auth server
 		// of the named site
 		nodeClient, err := proxy.ConnectToNode(ctx, "@"+site.Name, proxy.proxyPrincipal, quiet)

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -65,7 +65,7 @@ func (k *Key) AsAgentKeys() ([]*agent.AddedKey, error) {
 	// put a teleport identifier along with the teleport user into the comment field
 	comment := fmt.Sprintf("teleport:%v", publicKey.(*ssh.Certificate).KeyId)
 
-	// return a certificate (with embeded private key) as well as a private key
+	// return a certificate (with embedded private key) as well as a private key
 	return []*agent.AddedKey{
 		&agent.AddedKey{
 			PrivateKey:       privateKey,

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -315,7 +315,7 @@ func (a *LocalKeyAgent) DeleteKey(proxyHost string, username string) error {
 	return nil
 }
 
-// AuthMethods returns the list of differnt authentication methods this agent supports
+// AuthMethods returns the list of different authentication methods this agent supports
 // It returns two:
 //	  1. First to try is the external SSH agent
 //    2. Itself (disk-based local agent)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -441,7 +441,7 @@ func (s *Service) Enabled() bool {
 	return false
 }
 
-// Disabled returns 'true' if the service has been deliverately turned off
+// Disabled returns 'true' if the service has been deliberately turned off
 func (s *Service) Disabled() bool {
 	return s.Configured() && !s.Enabled()
 }
@@ -499,7 +499,7 @@ type TrustedCluster struct {
 	KeyFile string `yaml:"key_file,omitempty"`
 	// AllowedLogins is a comma-separated list of user logins allowed from that cluster
 	AllowedLogins string `yaml:"allow_logins,omitempty"`
-	// TunnelAddr is a comma-separated list of reverse tunnel addressess to
+	// TunnelAddr is a comma-separated list of reverse tunnel addresses to
 	// connect to
 	TunnelAddr string `yaml:"tunnel_addr,omitempty"`
 }
@@ -642,7 +642,7 @@ type Proxy struct {
 	PublicAddr string `yaml:"public_addr,omitempty"`
 }
 
-// ReverseTunnel is a SSH reverse tunnel mantained by one cluster's
+// ReverseTunnel is a SSH reverse tunnel maintained by one cluster's
 // proxy to remote Teleport proxy
 type ReverseTunnel struct {
 	DomainName string   `yaml:"domain_name"`
@@ -788,7 +788,7 @@ type OIDCConnector struct {
 	// be visible to end user
 	ClientSecret string `yaml:"client_secret"`
 	// RedirectURL - Identity provider will use this URL to redirect
-	// client's browser back to it after successfull authentication
+	// client's browser back to it after successful authentication
 	// Should match the URL on Provider's side
 	RedirectURL string `yaml:"redirect_url"`
 	// ACR is the acr_values parameter to be sent with an authorization request.

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -182,7 +182,7 @@ var (
 	// to retry quickly, e.g. once in one second
 	NetworkRetryDuration = time.Second
 
-	// FastAttempts is the intial amount of fast retry attempts
+	// FastAttempts is the initial amount of fast retry attempts
 	// before switching to slow mode
 	FastAttempts = 10
 

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -53,7 +53,7 @@ const (
 	// or updated by a joining party on the server
 	SessionStartEvent = "session.start"
 
-	// SessionEndEvent indicates taht a session has ended
+	// SessionEndEvent indicates that a session has ended
 	SessionEndEvent = "session.end"
 	SessionEventID  = "sid"
 	SessionServerID = "server_id"
@@ -83,7 +83,7 @@ const (
 	AuthAttemptSuccess = "success"
 	AuthAttemptErr     = "error"
 
-	// SCPEvent means data transfer that occured on the server
+	// SCPEvent means data transfer that occurred on the server
 	SCPEvent  = "scp"
 	SCPPath   = "path"
 	SCPLengh  = "len"

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -598,7 +598,7 @@ func (l *AuditLog) Close() error {
 	return nil
 }
 
-// sessionStreamFn helper determins the name of the stream file for a given
+// sessionStreamFn helper determines the name of the stream file for a given
 // session by its ID
 func (l *AuditLog) sessionStreamFn(namespace string, sid session.ID) string {
 	return filepath.Join(
@@ -608,7 +608,7 @@ func (l *AuditLog) sessionStreamFn(namespace string, sid session.ID) string {
 		fmt.Sprintf("%s%s", sid, SessionStreamPrefix))
 }
 
-// sessionLogFn helper determins the name of the stream file for a given
+// sessionLogFn helper determines the name of the stream file for a given
 // session by its ID
 func (l *AuditLog) sessionLogFn(namespace string, sid session.ID) string {
 	return filepath.Join(

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -89,7 +89,7 @@ func (a *AuditTestSuite) TestComplexLogging(c *check.C) {
 	alog.Close()
 	c.Assert(alog.loggers, check.HasLen, 0)
 
-	// inspect session "200". it sould have three events: join, print and leave:
+	// inspect session "200". it could have three events: join, print and leave:
 	history, err := alog.GetSessionEvents(defaults.Namespace, "200", 0)
 	c.Assert(err, check.IsNil)
 	c.Assert(history, check.HasLen, 3)

--- a/lib/events/slice.pb.go
+++ b/lib/events/slice.pb.go
@@ -59,7 +59,7 @@ func (m *SessionSlice) GetChunks() []*SessionChunk {
 
 // SessionChunk is a chunk to be posted in the context of the session
 type SessionChunk struct {
-	// Time is the occurence of this event
+	// Time is the occurrence of this event
 	Time int64 `protobuf:"varint,2,opt,name=Time,json=time,proto3" json:"Time,omitempty"`
 	// Data is captured data
 	Data []byte `protobuf:"bytes,3,opt,name=Data,json=data,proto3" json:"Data,omitempty"`

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -510,9 +510,9 @@ func (a *Agent) run() {
 			default:
 			}
 		}
-		// start heartbeat even if error happend, it will reconnect
+		// start heartbeat even if error happened, it will reconnect
 		// when this happens, this is #1 issue we have right now with Teleport. So we are making
-		// it EASY to see in the logs. This condition should never be permanent (repeates
+		// it EASY to see in the logs. This condition should never be permanent (repeats
 		// every XX seconds)
 		if err := a.processRequests(conn); err != nil {
 			log.Warn(err)

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -62,7 +62,7 @@ type AgentPool struct {
 
 // AgentPoolConfig holds configuration parameters for the agent pool
 type AgentPoolConfig struct {
-	// Client is client to the auth server this agent connects to recieve
+	// Client is client to the auth server this agent connects to receive
 	// a list of pools
 	Client *auth.TunClient
 	// AccessPoint is a lightweight access point

--- a/lib/runtimeflags.go
+++ b/lib/runtimeflags.go
@@ -20,7 +20,7 @@ This flag contains various global booleans that are set during
 Teleport initialization.
 
 These are NOT for configuring Teleport: use regular Config facilities for that,
-preferrably tailored to specific services, i.e proxy config, auth config, etc
+preferably tailored to specific services, i.e proxy config, auth config, etc
 
 These are for being set once, at the beginning of the process, and for
 being visible to any code under 'lib'
@@ -43,7 +43,7 @@ var (
 	flagLock sync.Mutex
 )
 
-// SetInsecureDevMode turns the 'insecure' mode on. In this mode Teleport accpets
+// SetInsecureDevMode turns the 'insecure' mode on. In this mode Teleport accepts
 // self-signed HTTPS certificates (for development only!)
 func SetInsecureDevMode(m bool) {
 	flagLock.Lock()

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -922,7 +922,7 @@ func initSelfSignedHTTPSCert(cfg *Config) (err error) {
 	cfg.Proxy.TLSKey = keyPath
 	cfg.Proxy.TLSCert = certPath
 
-	// return the existing pair if they ahve already been generated:
+	// return the existing pair if they have already been generated:
 	_, err = tls.LoadX509KeyPair(certPath, keyPath)
 	if err == nil {
 		return nil

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -29,7 +29,7 @@ import (
 // service functions and de-registering the service goroutines
 type Supervisor interface {
 	// Register adds the service to the pool, if supervisor is in
-	// the started state, the service will be started immediatelly
+	// the started state, the service will be started immediately
 	// otherwise, it will be started after Start() has been called
 	Register(srv Service)
 

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -234,7 +234,7 @@ func (c *CertAuthorityV2) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (c *CertAuthorityV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }

--- a/lib/services/clustername.go
+++ b/lib/services/clustername.go
@@ -93,7 +93,7 @@ func (c *ClusterNameV2) SetName(e string) {
 	c.Metadata.Name = e
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (c *ClusterNameV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -278,7 +278,7 @@ type OIDCAuthRequest struct {
 
 	// PublicKey is an optional public key, users want these
 	// keys to be signed by auth servers user CA in case
-	// of successfull auth
+	// of successful auth
 	PublicKey []byte `json:"public_key"`
 
 	// CertTTL is the TTL of the certificate user wants to get
@@ -289,7 +289,7 @@ type OIDCAuthRequest struct {
 	CreateWebSession bool `json:"create_web_session"`
 
 	// ClientRedirectURL is a URL client wants to be redirected
-	// after successfull authentication
+	// after successful authentication
 	ClientRedirectURL string `json:"client_redirect_url"`
 
 	// Compatibility specifies OpenSSH compatibility flags.
@@ -337,7 +337,7 @@ type SAMLAuthRequest struct {
 
 	// PublicKey is an optional public key, users want these
 	// keys to be signed by auth servers user CA in case
-	// of successfull auth
+	// of successful auth
 	PublicKey []byte `json:"public_key"`
 
 	// CertTTL is the TTL of the certificate user wants to get
@@ -351,7 +351,7 @@ type SAMLAuthRequest struct {
 	CreateWebSession bool `json:"create_web_session"`
 
 	// ClientRedirectURL is a URL client wants to be redirected
-	// after successfull authentication
+	// after successful authentication
 	ClientRedirectURL string `json:"client_redirect_url"`
 
 	// Compatibility specifies OpenSSH compatibility flags.

--- a/lib/services/migrations_test.go
+++ b/lib/services/migrations_test.go
@@ -150,7 +150,7 @@ func (s *MigrationsSuite) TestMigrateUsers(c *C) {
 	obj.rawObject = nil
 	c.Assert(obj, DeepEquals, expected, Commentf("%v", diff.Diff(d.Sdump(obj), d.Sdump(expected))))
 
-	// test backwards compatiblity
+	// test backwards compatibility
 	data, err = GetUserMarshaler().MarshalUser(expected, WithVersion(V1))
 	c.Assert(err, IsNil)
 	var out4 UserV1

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -46,7 +46,7 @@ type OIDCConnector interface {
 	// be visible to end user
 	GetClientSecret() string
 	// RedirectURL - Identity provider will use this URL to redirect
-	// client's browser back to it after successfull authentication
+	// client's browser back to it after successful authentication
 	// Should match the URL on Provider's side
 	GetRedirectURL() string
 	// GetACR returns the Authentication Context Class Reference (ACR) value.
@@ -243,7 +243,7 @@ func (o *OIDCConnectorV2) SetExpiry(expires time.Time) {
 	o.Metadata.SetExpiry(expires)
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (o *OIDCConnectorV2) Expiry() time.Time {
 	return o.Metadata.Expiry()
 }
@@ -320,7 +320,7 @@ func (o *OIDCConnectorV2) GetClientSecret() string {
 }
 
 // RedirectURL - Identity provider will use this URL to redirect
-// client's browser back to it after successfull authentication
+// client's browser back to it after successful authentication
 // Should match the URL on Provider's side
 func (o *OIDCConnectorV2) GetRedirectURL() string {
 	return o.Spec.RedirectURL
@@ -545,7 +545,7 @@ type OIDCConnectorSpecV2 struct {
 	// be visible to end user
 	ClientSecret string `json:"client_secret"`
 	// RedirectURL - Identity provider will use this URL to redirect
-	// client's browser back to it after successfull authentication
+	// client's browser back to it after successful authentication
 	// Should match the URL on Provider's side
 	RedirectURL string `json:"redirect_url"`
 	// ACR is an Authentication Context Class Reference value. The meaning of the ACR
@@ -640,7 +640,7 @@ type OIDCConnectorV1 struct {
 	// be visible to end user
 	ClientSecret string `json:"client_secret"`
 	// RedirectURL - Identity provider will use this URL to redirect
-	// client's browser back to it after successfull authentication
+	// client's browser back to it after successful authentication
 	// Should match the URL on Provider's side
 	RedirectURL string `json:"redirect_url"`
 	// Display - Friendly name for this provider.

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -294,7 +294,7 @@ type Resource interface {
 	GetName() string
 	// SetName sets the name of the resource
 	SetName(string)
-	// Expiry retuns object expiry setting
+	// Expiry returns object expiry setting
 	Expiry() time.Time
 	// SetExpiry sets object expiry
 	SetExpiry(time.Time)
@@ -324,7 +324,7 @@ func (m *Metadata) SetExpiry(expires time.Time) {
 	m.Expires = &expires
 }
 
-// Expires retuns object expiry setting.
+// Expires returns object expiry setting.
 func (m *Metadata) Expiry() time.Time {
 	if m.Expires == nil {
 		return time.Time{}
@@ -421,7 +421,7 @@ func isDelimiter(r rune) bool {
 	return false
 }
 
-// Ref is a resource refernece
+// Ref is a resource reference
 type Ref struct {
 	Kind string
 	Name string

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -920,7 +920,7 @@ func (r *RoleV2) SetExpiry(expires time.Time) {
 	r.Metadata.SetExpiry(expires)
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (r *RoleV2) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }
@@ -1103,7 +1103,7 @@ type RoleSpecV2 struct {
 	// NodeLabels is a set of matching labels that users of this role
 	// will be allowed to access
 	NodeLabels map[string]string `json:"node_labels,omitempty" yaml:"node_labels,omitempty"`
-	// Namespaces is a list of namespaces, guarding accesss to resources
+	// Namespaces is a list of namespaces, guarding access to resources
 	Namespaces []string `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
 	// Resources limits access to resources
 	Resources map[string][]string `json:"resources,omitempty" yaml:"resources,omitempty"`

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -354,7 +354,7 @@ func (o *SAMLConnectorV2) SetExpiry(expires time.Time) {
 	o.Metadata.SetExpiry(expires)
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (o *SAMLConnectorV2) Expiry() time.Time {
 	return o.Metadata.Expiry()
 }
@@ -587,7 +587,7 @@ func (o *SAMLConnectorV2) GetServiceProvider(clock clockwork.Clock) (*saml2.SAML
 		o.Spec.SSO = metadata.IDPSSODescriptor.SingleSignOnService.Location
 	}
 	if o.Spec.Issuer == "" {
-		return nil, trace.BadParameter("no issuer or entityID set, either set issuer as a paramter or via entity_descriptor spec")
+		return nil, trace.BadParameter("no issuer or entityID set, either set issuer as a parameter or via entity_descriptor spec")
 	}
 	if o.Spec.SSO == "" {
 		return nil, trace.BadParameter("no SSO set either explicitly or via entity_descriptor spec")

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -120,7 +120,7 @@ func (s *ServerV2) SetExpiry(expires time.Time) {
 	s.Metadata.SetExpiry(expires)
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (s *ServerV2) Expiry() time.Time {
 	return s.Metadata.Expiry()
 }

--- a/lib/services/statictokens.go
+++ b/lib/services/statictokens.go
@@ -110,7 +110,7 @@ func (c *StaticTokensV2) SetName(e string) {
 	c.Metadata.Name = e
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (c *StaticTokensV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -79,7 +79,7 @@ func (s *ServicesTestSuite) collectChanges(c *C, expected int) []interface{} {
 		case changes[i] = <-s.ChangesC:
 			// successfully collected changes
 		case <-time.After(2 * time.Second):
-			c.Fatalf("Timeout occured waiting for events")
+			c.Fatalf("Timeout occurred waiting for events")
 		}
 	}
 	return changes

--- a/lib/services/trustedcluster.go
+++ b/lib/services/trustedcluster.go
@@ -162,7 +162,7 @@ func (r RoleMap) parse() (map[string][]string, []string, error) {
 			return nil, nil, trace.BadParameter("missing 'remote' parameter for role_map")
 		}
 		if len(roleMap.Local) == 0 {
-			return nil, nil, trace.BadParameter("missing 'local' paramter for 'role_map'")
+			return nil, nil, trace.BadParameter("missing 'local' parameter for 'role_map'")
 		}
 		for _, local := range roleMap.Local {
 			if local == "" {
@@ -295,7 +295,7 @@ func (c *TrustedClusterV2) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (c *TrustedClusterV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }

--- a/lib/services/tunnel.go
+++ b/lib/services/tunnel.go
@@ -67,7 +67,7 @@ func (r *ReverseTunnelV2) SetExpiry(expires time.Time) {
 	r.Metadata.SetExpiry(expires)
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (r *ReverseTunnelV2) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }

--- a/lib/services/tunnelconn.go
+++ b/lib/services/tunnelconn.go
@@ -99,7 +99,7 @@ func (r *TunnelConnectionV2) SetExpiry(expires time.Time) {
 	r.Metadata.SetExpiry(expires)
 }
 
-// Expires retuns object expiry setting
+// Expires returns object expiry setting
 func (r *TunnelConnectionV2) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -80,7 +80,7 @@ type ConnectorRef struct {
 	Identity string `json:"identity"`
 }
 
-// UserRef holds refernce to user
+// UserRef holds references to user
 type UserRef struct {
 	// Name is name of the user
 	Name string `json:"name"`
@@ -158,11 +158,11 @@ const LoginStatusSchema = `{
    }
 }`
 
-// LoginAttempt represents successfull or unsuccessful attempt for user to login
+// LoginAttempt represents successful or unsuccessful attempt for user to login
 type LoginAttempt struct {
 	// Time is time of the attempt
 	Time time.Time `json:"time"`
-	// Sucess indicates whether attempt was successfull
+	// Success indicates whether attempt was successful
 	Success bool `json:"bool"`
 }
 

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -35,7 +35,7 @@ import (
 // ID is a uinique session id that is based on time UUID v1
 type ID string
 
-// IsZero returns true if this ID is emtpy
+// IsZero returns true if this ID is empty
 func (s *ID) IsZero() bool {
 	return len(*s) == 0
 }

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -340,7 +340,7 @@ func (cmd *Command) receiveFile(st *state, fc NewFileCmd, ch io.ReadWriter) erro
 func (cmd *Command) receiveDir(st *state, fc NewFileCmd, ch io.ReadWriter) error {
 	targetDir := cmd.Target[0]
 
-	// copying into an exising directory? append to it:
+	// copying into an existing directory? append to it:
 	if utils.IsDir(targetDir) {
 		targetDir = st.makePath(targetDir, fc.Name)
 		st.push(fc.Name)

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-This file contains the implementatino of sshutils.Server class.
+This file contains the implementations of sshutils.Server class.
 It is the underlying "base SSH server" for everything in Teleport.
 
 */
@@ -305,7 +305,7 @@ func (s *Server) handleConnection(conn net.Conn) {
 				connClosed()
 				return
 			}
-			s.Debugf("recieved out-of-band request: %+v", req)
+			s.Debugf("received out-of-band request: %+v", req)
 			if s.reqHandler != nil {
 				go s.reqHandler.HandleRequest(req)
 			}

--- a/lib/state/log_test.go
+++ b/lib/state/log_test.go
@@ -195,7 +195,7 @@ func (s *CacheLogSuite) TestRetryOnError(c *check.C) {
 	for i := 0; i < 3; i++ {
 		waitSlice(c, mock.FailedAttemptsC, time.Second)
 	}
-	// wait until successfull attempt
+	// wait until successful attempt
 	mock.SetError(nil)
 	out := waitSlice(c, mock.SlicesC, time.Second)
 	fixtures.DeepCompare(c, out, slice)

--- a/lib/utils/timeout_test.go
+++ b/lib/utils/timeout_test.go
@@ -76,7 +76,7 @@ func (s *TimeoutSuite) TestNormalOperation(c *check.C) {
 }
 
 // newClient helper returns HTTP client configured to use a connection
-// wich drops itself after N idle time
+// which drops itself after N idle time
 func newClient(timeout time.Duration) *http.Client {
 	var t http.Transport
 	t.Dial = func(network string, addr string) (net.Conn, error) {

--- a/lib/utils/websocketwriter.go
+++ b/lib/utils/websocketwriter.go
@@ -34,7 +34,7 @@ import (
 //
 // We need this to make sure that the entire buffer in io.Writer.Write(buffer)
 // is delivered as a single chunk to the web browser, instead of being split
-// into multiple frames. This wrapper basically substitues every Write() with
+// into multiple frames. This wrapper basically substitutes every Write() with
 // Send() and every Read() with Receive()
 type WebSockWrapper struct {
 	io.ReadWriteCloser

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1002,7 +1002,7 @@ type createNewUserReq struct {
 //
 // {"invite_token": "unique invite token", "pass": "user password", "second_factor_token": "valid second factor token"}
 //
-// Sucessful response: (session cookie is set)
+// Successful response: (session cookie is set)
 //
 // {"type": "bearer", "token": "bearer token", "user": "alex", "expires_in": 20}
 func (h *Handler) createNewUser(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
@@ -1037,7 +1037,7 @@ type createNewU2FUserReq struct {
 //
 // {"invite_token": "unique invite token", "pass": "user password", "u2f_register_response": {"registrationData":"verylongbase64string","clientData":"longbase64string"}}
 //
-// Sucessful response: (session cookie is set)
+// Successful response: (session cookie is set)
 //
 // {"type": "bearer", "token": "bearer token", "user": "alex", "expires_in": 20}
 func (h *Handler) createNewU2FUser(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
@@ -1085,7 +1085,7 @@ func convertSites(rs []reversetunnel.RemoteSite) []site {
 //
 // GET /v1/webapi/sites
 //
-// Sucessful response:
+// Successful response:
 //
 // {"sites": {"name": "localhost", "last_connected": "RFC3339 time", "status": "active"}}
 //
@@ -1103,7 +1103,7 @@ type getSiteNamespacesResponse struct {
 
 GET /v1/webapi/namespaces/:namespace/sites/:site/nodes
 
-Sucessful response:
+Successful response:
 
 {"namespaces": [{..namespace resource...}]}
 */
@@ -1155,7 +1155,7 @@ func (h *Handler) siteNodesGet(w http.ResponseWriter, r *http.Request, p httprou
 //
 // Session id can be empty
 //
-// Sucessful response is a websocket stream that allows read write to the server
+// Successful response is a websocket stream that allows read write to the server
 //
 func (h *Handler) siteNodeConnect(
 	w http.ResponseWriter,
@@ -1205,7 +1205,7 @@ func (h *Handler) siteNodeConnect(
 }
 
 // sessionStreamEvent is sent over the session stream socket, it contains
-// last events that occured (only new events are sent)
+// last events that occurred (only new events are sent)
 type sessionStreamEvent struct {
 	Events  []events.EventFields `json:"events"`
 	Session *session.Session     `json:"session"`
@@ -1216,7 +1216,7 @@ type sessionStreamEvent struct {
 //
 // GET /v1/webapi/sites/:site/namespaces/:namespace/sessions/:sid/events/stream?access_token=bearer_token
 //
-// Sucessful response is a websocket stream that allows read write to the server and returns
+// Successful response is a websocket stream that allows read write to the server and returns
 // json events
 //
 func (h *Handler) siteSessionStream(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -429,7 +429,7 @@ func (s *WebSuite) TestNewUser(c *C) {
 	var sites *getSitesResponse
 	c.Assert(json.Unmarshal(re.Bytes(), &sites), IsNil)
 
-	// in absense of session cookie or bearer auth the same request fill fail
+	// in absence of session cookie or bearer auth the same request fill fail
 
 	// no session cookie:
 	clt = s.client(roundtrip.BearerAuth(rawSess.Token))
@@ -799,7 +799,7 @@ func (s *WebSuite) TestWebSessionsBadInput(c *C) {
 	clt := s.client()
 
 	reqs := []createSessionReq{
-		// emtpy request
+		// empty request
 		{},
 		// missing user
 		{
@@ -1221,7 +1221,7 @@ func (s *WebSuite) TestNewU2FUser(c *C) {
 	var sites *getSitesResponse
 	c.Assert(json.Unmarshal(re.Bytes(), &sites), IsNil)
 
-	// in absense of session cookie or bearer auth the same request fill fail
+	// in absence of session cookie or bearer auth the same request fill fail
 
 	// no session cookie:
 	clt = s.client(roundtrip.BearerAuth(rawSess.Token))

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -199,7 +199,7 @@ func (c *SessionContext) newRemoteClient(site reversetunnel.RemoteSite) (auth.Cl
 		dstAddr := utils.NetAddr{Addr: reversetunnel.RemoteAuthServer, AddrNetwork: "tcp"}
 
 		// first get a net.Conn (tcp connection) to the remote auth server. no
-		// authentication has occured.
+		// authentication has occurred.
 		netConn, err = site.Dial(&srcAddr, &dstAddr)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -256,7 +256,7 @@ func getUserCredentials(agent auth.AgentCloser) (string, ssh.AuthMethod, error) 
 	}
 	// take the principal (SSH username) out of the returned certificate
 	if cert == nil {
-		return "", nil, trace.Errorf("unable to retreive the user certificate")
+		return "", nil, trace.Errorf("unable to retrieve the user certificate")
 	}
 	signers, err := agent.Signers()
 	if err != nil {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -153,7 +153,7 @@ func (u *ResourceCommand) Create(client *auth.TunClient) error {
 		if err != nil {
 			if err == io.EOF {
 				if count == 0 {
-					return trace.BadParameter("no resources found, emtpy input?")
+					return trace.BadParameter("no resources found, empty input?")
 				}
 				return nil
 			}
@@ -251,7 +251,7 @@ func (d *ResourceCommand) Delete(client *auth.TunClient) (err error) {
 		}
 		fmt.Printf("trusted cluster %q has been deleted\n", d.ref.Name)
 	default:
-		return trace.BadParameter("deleting resoruces of type %q is not supported", d.ref.Kind)
+		return trace.BadParameter("deleting resources of type %q is not supported", d.ref.Kind)
 	}
 	return nil
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -191,7 +191,7 @@ func Run(args []string, underTest bool) {
 
 	// login logs in with remote proxy and obtains a "session certificate" which gets
 	// stored in ~/.tsh directory
-	login := app.Command("login", "Log in to a cluster and retreive the session certificate")
+	login := app.Command("login", "Log in to a cluster and retrieve the session certificate")
 	login.Flag("out", "Identity output").Short('o').StringVar(&cf.IdentityFileOut)
 	login.Flag("format", fmt.Sprintf("Identity format [%s] or %s (for OpenSSH compatibility)",
 		client.DefaultIdentityFormat,
@@ -301,7 +301,7 @@ func onLogin(cf *CLIConf) {
 		utils.FatalError(trace.BadParameter("invalid identity format: %s", cf.IdentityFormat))
 	}
 
-	// make the teleport client and retreive the certificate from the proxy:
+	// make the teleport client and retrieve the certificate from the proxy:
 	tc, err = makeClient(cf, true)
 	if err != nil {
 		utils.FatalError(err)


### PR DESCRIPTION
This was fixed running the `misspell` linter in fix mode using `gometalinter`. The exact command I ran was :
```
gometalinter --vendor --disable-all -E misspell --linter='misspell:misspell -w {path}:^(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*)$' ./...
```
Plus some typo were fixed by hand on top of it.
I reviewed the diff, no code is affected.