### PR TITLE
Allow adm group to read logs

### DIFF
--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -109,7 +109,7 @@ type AuditLog struct {
 func NewAuditLog(dataDir string, recordSessions bool) (IAuditLog, error) {
 	// create the log directory first, with slightly broader permissions
 	if err := os.MkdirAll(dataDir, 0770); err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
 	if err := os.Chown(dataDir, RootUID, AdmGID); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -87,6 +87,12 @@ const (
 	// SessionStreamPrefix defines the ending of session stream files,
 	// that's where interactive PTY I/O is saved.
 	SessionStreamPrefix = ".session.bytes"
+
+	// UID of the root user (always 0)
+	RootUID = 0
+
+	// GID of the adm group (always 4)
+	AdmGID = 4
 )
 
 var (
@@ -562,6 +568,10 @@ func (l *AuditLog) rotateLog() (err error) {
 		logfname := filepath.Join(l.dataDir,
 			fileTime.Format("2006-01-02.15:04:05")+LogfileExt)
 		l.file, err = os.OpenFile(logfname, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+		if err != nil {
+			log.Error(err)
+		}
+		err := os.Chown(logfname, RootUID, AdmGID)
 		if err != nil {
 			log.Error(err)
 		}

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -103,10 +103,17 @@ type AuditLog struct {
 	recordSessions bool
 }
 
-// Creates and returns a new Audit Log oboject whish will store its logfiles in
+// Creates and returns a new Audit Log object which will store its logfiles in
 // a given directory. Session recording can be disabled by setting
 // recordSessions to false.
 func NewAuditLog(dataDir string, recordSessions bool) (IAuditLog, error) {
+	// create the log directory first, with slightly broader permissions
+	if err := os.MkdirAll(dataDir, 0770); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := os.Chown(dataDir, RootUID, AdmGID); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	// create a directory for session logs:
 	sessionDir := filepath.Join(dataDir, SessionLogsDir)
 	if err := os.MkdirAll(sessionDir, 0770); err != nil {


### PR DESCRIPTION
Traditionally the `adm` group is allowed to read system logs, but not write to them.

This enables log agents that run as a non-root user to read the logs. We want the audit logs to be readable by log agents but probably not the session logs.