### PR TITLE
Title anchors for documentation

### DIFF
--- a/docs/theme/base.html
+++ b/docs/theme/base.html
@@ -26,6 +26,12 @@
   <link href="{{ path }}" rel="stylesheet">
   {%- endfor %}
 
+  <!-- external JS -->
+  <script src="{{ base_url }}/js/jquery-2.1.1.min.js"></script>
+  <script src="{{ base_url }}/js/modernizr-2.8.3.min.js"></script>
+  <script type="text/javascript" src="{{ base_url }}/js/highlight.pack.js"></script>
+  <script src="{{ base_url }}/js/theme.js"></script>
+
   {% if page %}
   <script>
     // Current page data
@@ -34,12 +40,24 @@
     var mkdocs_page_url = "{{ page.abs_url }}";        
     // Teleport documentation version
     var docVersions = ["1.3", "2.0", "2.3"]
+
+
+    // append sub-anchors to the H2 and H3 elements for one-click linking:
+    $(document).ready(function(){
+        $("h2,h3").each(function(){
+            var e = $(this)
+            e.append("<a href='#" + e.attr("id") + "'></a>");
+        });
+    });
   </script>
+
+  <style type="text/css">
+      // styles for sub-anchors for H1 and H2 headers:
+      h2[id] a, h3[id] a { border-bottom: none; text-decoration: none; color: #2980b9; }
+      h2[id]:hover a:before, h3[id]:hover a:before { content: " \00B6"; }
+  </style>
+
   {% endif %}
-  <script src="{{ base_url }}/js/jquery-2.1.1.min.js"></script>
-  <script src="{{ base_url }}/js/modernizr-2.8.3.min.js"></script>
-  <script type="text/javascript" src="{{ base_url }}/js/highlight.pack.js"></script>
-  <script src="{{ base_url }}/js/theme.js"></script>
 
   {%- block extrahead %} {% endblock %}
 


### PR DESCRIPTION
These bits of JS/CSS add dynamic "sub-anchors" to all H2 and H3 tags.
This allows users to easily link to a section of a documentation page.