### PR TITLE
Set default cluster configuration when not specified.

### DIFF
--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -311,6 +311,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Auth.StorageConfig.Type = boltbk.GetName()
 	cfg.Auth.StorageConfig.Params = backend.Params{"path": cfg.DataDir}
 	cfg.Auth.StaticTokens = services.DefaultStaticTokens()
+	cfg.Auth.ClusterConfig = services.DefaultClusterConfig()
 	defaults.ConfigureLimiter(&cfg.Auth.Limiter)
 	// set new style default auth preferences
 	ap := &services.AuthPreferenceV2{}

--- a/lib/services/clusterconfig.go
+++ b/lib/services/clusterconfig.go
@@ -63,6 +63,22 @@ func NewClusterConfig(spec ClusterConfigSpecV3) (ClusterConfig, error) {
 	return &cc, nil
 }
 
+// DefaultClusterConfig is used as the default cluster configuration when
+// one is not specified (record at node).
+func DefaultClusterConfig() ClusterConfig {
+	return &ClusterConfigV3{
+		Kind:    KindClusterConfig,
+		Version: V3,
+		Metadata: Metadata{
+			Name:      MetaNameClusterConfig,
+			Namespace: defaults.Namespace,
+		},
+		Spec: ClusterConfigSpecV3{
+			SessionRecording: RecordAtNode,
+		},
+	}
+}
+
 // ClusterConfigV3 implements the ClusterConfig interface.
 type ClusterConfigV3 struct {
 	// Kind is a resource kind - always resource.


### PR DESCRIPTION
**Purpose**

When Teleport starts, no cluster configuration exists, which causes it to panic.

**Implementation**

Set the default cluster configuration when none is specified.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1436