### PR TITLE
Cache services.ClusterConfig in AuthServer

### DIFF
--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -82,6 +82,12 @@ func (s *APISuite) SetUpTest(c *C) {
 	s.sessions, err = session.New(s.bk)
 	c.Assert(err, IsNil)
 
+	// set cluster config
+	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
+		SessionRecording: services.RecordAtNode,
+	})
+	c.Assert(err, IsNil)
+
 	// set cluster name
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "localhost",
@@ -104,7 +110,7 @@ func (s *APISuite) SetUpTest(c *C) {
 	s.AccessS = local.NewAccessService(s.bk)
 	s.WebS = local.NewIdentityService(s.bk)
 
-	authorizer, err := NewRoleAuthorizer(teleport.RoleAdmin)
+	authorizer, err := NewRoleAuthorizer(clusterConfig, teleport.RoleAdmin)
 	c.Assert(err, IsNil)
 
 	apiServer := NewAPIServer(&APIConfig{
@@ -630,4 +636,30 @@ func (s *APISuite) TestSharedSessions(c *C) {
 	c.Assert(len(history), Equals, 1)
 	c.Assert(history[0].GetString(events.SessionEventID), Equals, string(anotherSessionID))
 	c.Assert(history[0].GetString("val"), Equals, "three")
+}
+
+func (s *APISuite) TestSyncCachedClusterConfig(c *C) {
+	// set cluster config to record at nodes
+	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
+		SessionRecording: services.RecordAtNode,
+	})
+	err = s.a.SetClusterConfig(clusterConfig)
+	c.Assert(err, IsNil)
+
+	// check to make sure the cached value is the same
+	clusterConfig = s.a.getCachedClusterConfig()
+	c.Assert(clusterConfig.GetSessionRecording(), Equals, services.RecordAtNode)
+
+	// update cluster config to record at proxy
+	clusterConfig.SetSessionRecording(services.RecordAtProxy)
+	err = s.a.SetClusterConfig(clusterConfig)
+	c.Assert(err, IsNil)
+
+	// manually force synching cluster config
+	err = s.a.syncCachedClusterConfig()
+	c.Assert(err, IsNil)
+
+	// check to make sure the cached value was updated
+	clusterConfig = s.a.getCachedClusterConfig()
+	c.Assert(clusterConfig.GetSessionRecording(), Equals, services.RecordAtProxy)
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -89,6 +89,9 @@ func NewAuthServer(cfg *InitConfig, opts ...AuthServerOption) *AuthServer {
 	}
 	closeCtx, cancelFunc := context.WithCancel(context.TODO())
 	as := AuthServer{
+		Entry: log.WithFields(log.Fields{
+			trace.Component: teleport.ComponentAuth,
+		}),
 		bk:                   cfg.Backend,
 		Authority:            cfg.Authority,
 		Trust:                cfg.Trust,
@@ -109,6 +112,12 @@ func NewAuthServer(cfg *InitConfig, opts ...AuthServerOption) *AuthServer {
 	if as.clock == nil {
 		as.clock = clockwork.NewRealClock()
 	}
+
+	// start sync loop that keeps cluster config synced with what's in backend.
+	// this is used by the context passed in requests to always have a fresh copy
+	// of the cluster config without hammering the backend.
+	go as.syncCachedClusterConfigLoop()
+
 	return &as
 }
 
@@ -120,6 +129,8 @@ func NewAuthServer(cfg *InitConfig, opts ...AuthServerOption) *AuthServer {
 //   - same for users and their sessions
 //   - checks public keys to see if they're signed by it (can be trusted or not)
 type AuthServer struct {
+	*log.Entry
+
 	lock          sync.Mutex
 	oidcClients   map[string]*oidcClient
 	samlProviders map[string]*samlProvider
@@ -127,6 +138,11 @@ type AuthServer struct {
 	bk            backend.Backend
 	closeCtx      context.Context
 	cancelFunc    context.CancelFunc
+
+	// cachedClusterConfig stores a cached copy of the cluster config to avoid
+	// hamming the backend with too many requests.
+	cachedClusterConfig   services.ClusterConfig
+	cachedClusterConfigMu sync.RWMutex
 
 	Authority
 
@@ -780,6 +796,56 @@ func (a *AuthServer) DeleteRole(name string) error {
 		}
 	}
 	return a.Access.DeleteRole(name)
+}
+
+// syncCachedClusterConfigLoop keeps updating the cached cluster config.
+func (a *AuthServer) syncCachedClusterConfigLoop() {
+	// update the cache at the same rate nodes heartbeat
+	ticker := time.NewTicker(defaults.ServerHeartbeatTTL)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-a.closeCtx.Done():
+			return
+		case <-ticker.C:
+			err := a.syncCachedClusterConfig()
+			if err != nil {
+				a.Warnf("failed to sync cluster config: %v", err)
+				continue
+			}
+		}
+	}
+}
+
+// getCachedClusterConfig returns a copy of cached services.ClusterConfig. If
+// nothing is cached yet, a safe default is returned.
+func (a *AuthServer) getCachedClusterConfig() services.ClusterConfig {
+	a.cachedClusterConfigMu.RLock()
+	defer a.cachedClusterConfigMu.RUnlock()
+
+	// if cache is empty, return a safe default
+	clusterConfig := a.cachedClusterConfig
+	if clusterConfig == nil {
+		return services.DefaultClusterConfig()
+	}
+
+	return a.cachedClusterConfig.Copy()
+}
+
+// syncCachedClusterConfig gets cluster config from the backend and updated
+// the cached value.
+func (a *AuthServer) syncCachedClusterConfig() error {
+	clusterConfig, err := a.GetClusterConfig()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	a.cachedClusterConfigMu.Lock()
+	defer a.cachedClusterConfigMu.Unlock()
+
+	a.cachedClusterConfig = clusterConfig
+	return nil
 }
 
 const (

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -154,7 +154,12 @@ func Init(cfg InitConfig) (*AuthServer, *Identity, error) {
 		log.Infof("[INIT] Created Reverse Tunnel: %v", tunnel)
 	}
 
+	// set cluster level config on the backend and then force a sync of the cache.
 	err = asrv.SetClusterConfig(cfg.ClusterConfig)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	err = asrv.syncCachedClusterConfig()
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -178,6 +178,10 @@ func (s *AuthInitSuite) TestAuthPreference(c *C) {
 	})
 	c.Assert(err, IsNil)
 
+	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
+		SessionRecording: services.RecordAtNode,
+	})
+	c.Assert(err, IsNil)
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "me.localhost",
 	})
@@ -193,6 +197,7 @@ func (s *AuthInitSuite) TestAuthPreference(c *C) {
 		NodeName:       "foo",
 		Backend:        bk,
 		Authority:      testauthority.New(),
+		ClusterConfig:  clusterConfig,
 		ClusterName:    clusterName,
 		StaticTokens:   staticTokens,
 		AuthPreference: ap,

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -49,6 +49,7 @@ type TunSuite struct {
 	tsrv          *AuthTunnel
 	a             *AuthServer
 	signer        ssh.Signer
+	hostuuid      string
 	dir           string
 	alog          events.IAuditLog
 	conf          *APIConfig
@@ -84,6 +85,14 @@ func (s *TunSuite) SetUpTest(c *C) {
 		Identity:  identity,
 	})
 
+	// set cluster config
+	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
+		SessionRecording: services.RecordAtNode,
+	})
+	c.Assert(err, IsNil)
+	err = s.a.SetClusterConfig(clusterConfig)
+	c.Assert(err, IsNil)
+
 	// set cluster name
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "localhost",
@@ -109,7 +118,8 @@ func (s *TunSuite) SetUpTest(c *C) {
 
 	hpriv, hpub, err := s.a.GenerateKeyPair("")
 	c.Assert(err, IsNil)
-	hcert, err := s.a.GenerateHostCert(hpub, "00000000-0000-0000-0000-000000000000", "localhost", "localhost", teleport.Roles{teleport.RoleNode}, 0)
+	s.hostuuid = "00000000-0000-0000-0000-000000000000"
+	hcert, err := s.a.GenerateHostCert(hpub, s.hostuuid, "localhost", "localhost", teleport.Roles{teleport.RoleProxy}, 0)
 	c.Assert(err, IsNil)
 
 	authorizer, err := NewAuthorizer(s.a.Access, s.a.Identity, s.a.Trust)
@@ -190,6 +200,42 @@ func (s *TunSuite) TestUnixServerClient(c *C) {
 
 	// call some endpoint
 	_, err = clt.GetUser(userName)
+	c.Assert(err, IsNil)
+}
+
+// TestClusterConfigContext checks that the cluster configuration gets passed
+// along in the context and permissions get updated accordingly.
+func (s *TunSuite) TestClusterConfigContext(c *C) {
+	_, hpub, err := s.a.GenerateKeyPair("")
+	c.Assert(err, IsNil)
+
+	// connect to the auth server with role proxy
+	authMethod := []ssh.AuthMethod{ssh.PublicKeys(s.signer)}
+	clt, err := NewTunClient("test",
+		[]utils.NetAddr{{AddrNetwork: "tcp", Addr: s.tsrv.Addr()}}, s.hostuuid+".localhost", authMethod)
+	c.Assert(err, IsNil)
+	defer clt.Close()
+
+	// try and generate a host cert, this should fail because we are recording
+	// at the nodes not at the proxy
+	_, err = clt.GenerateHostCert(hpub, "a", "b", "localhost", teleport.Roles{teleport.RoleProxy}, 0)
+	c.Assert(err, NotNil)
+
+	// update cluster config to record at the proxy
+	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
+		SessionRecording: services.RecordAtProxy,
+	})
+	c.Assert(err, IsNil)
+	err = s.a.SetClusterConfig(clusterConfig)
+	c.Assert(err, IsNil)
+
+	// force a sync so the cached value gets updated
+	err = s.a.syncCachedClusterConfig()
+	c.Assert(err, IsNil)
+
+	// try and generate a host cert, now the proxy should be able to generate a
+	// host cert because it's in recording mode.
+	_, err = clt.GenerateHostCert(hpub, "a", "b", "localhost", teleport.Roles{teleport.RoleProxy}, 0)
 	c.Assert(err, IsNil)
 }
 

--- a/lib/services/clusterconfig.go
+++ b/lib/services/clusterconfig.go
@@ -43,6 +43,9 @@ type ClusterConfig interface {
 
 	// CheckAndSetDefaults checks and set default values for missing fields.
 	CheckAndSetDefaults() error
+
+	// Copy creates a copy of the resource and returns it.
+	Copy() ClusterConfig
 }
 
 // NewClusterConfig is a convenience wrapper to create a ClusterConfig resource.
@@ -174,6 +177,12 @@ func (c *ClusterConfigV3) CheckAndSetDefaults() error {
 	}
 
 	return nil
+}
+
+// Copy creates a copy of the resource and returns it.
+func (c *ClusterConfigV3) Copy() ClusterConfig {
+	out := *c
+	return &out
 }
 
 // String represents a human readable version of the cluster name.

--- a/lib/srv/sshserver_test.go
+++ b/lib/srv/sshserver_test.go
@@ -148,7 +148,7 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	up, err := newUpack(s.user, []string{s.user}, s.a)
 	c.Assert(err, IsNil)
 
-	ctx := context.WithValue(context.TODO(), teleport.ContextUser, teleport.LocalUser{Username: s.user})
+	ctx := context.WithValue(context.TODO(), auth.ContextUser, auth.LocalUser{Username: s.user})
 	authContext, err := authorizer.Authorize(ctx)
 	c.Assert(err, IsNil)
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -234,7 +234,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	sessionServer, err := sess.New(s.bk)
 	c.Assert(err, IsNil)
 
-	ctx := context.WithValue(context.TODO(), teleport.ContextUser, teleport.LocalUser{Username: s.user})
+	ctx := context.WithValue(context.TODO(), auth.ContextUser, auth.LocalUser{Username: s.user})
 	authContext, err := authorizer.Authorize(ctx)
 
 	c.Assert(err, IsNil)

--- a/roles.go
+++ b/roles.go
@@ -136,29 +136,3 @@ func (r *Role) Check() error {
 	}
 	return trace.BadParameter("role %v is not registered", *r)
 }
-
-// ContextUser is a user set in the context of the request
-const ContextUser = "teleport-user"
-
-// LocalUsername is a local username
-type LocalUser struct {
-	// Username is local username
-	Username string
-}
-
-// BuiltinRole is monitoring
-type BuiltinRole struct {
-	// Role is the builtin role this username is associated with
-	Role Role
-}
-
-// RemoteUser defines encoded remote user
-type RemoteUser struct {
-	// Username is a name of the remote user
-	Username string `json:"username"`
-	// ClusterName is a name of the remote cluster
-	// of the user
-	ClusterName string `json:"cluster_name"`
-	// RemoteRoles is optional list of remote roles
-	RemoteRoles []string `json:"remote_roles"`
-}


### PR DESCRIPTION
**Purpose**

As part of #1327, the proxy has the requirement that it should be configurable at runtime to either record at the proxy or record at the node. To enable this, we we cache `services.ClusterConfig` in the Auth Server and then use this cached value when authorizing requests. This allows us to change which permissions are returned for the proxy at runtime.

**Implementation**

* Cache `services.ClusterConfig` in the Auth Server.
* Pass a getter for `services.ClusterConfig` along in the context for every request to the Auth Server.
* Check where sessions are being recorded in `permissions.go` and return a `services.RoleSet` with `RW` access to `services.HostCert` if the sessions are being recorded at the proxy.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1441

