### PR TITLE
Refactored lib/srv to support multiple servers.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -76,6 +76,9 @@ const (
 	// ComponentCachingClient is a caching auth client
 	ComponentCachingClient = "client:cache"
 
+	// ComponentSubsystemProxy is the proxy subsystem.
+	ComponentSubsystemProxy = "subsystem:proxy"
+
 	// DebugEnvVar tells tests to use verbose debug output
 	DebugEnvVar = "DEBUG"
 

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -24,8 +24,6 @@ import (
 	"path"
 	"path/filepath"
 
-	"gopkg.in/check.v1"
-
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/lib/auth"
@@ -34,12 +32,14 @@ import (
 	"github.com/gravitational/teleport/lib/backend/boltbk"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+
+	"gopkg.in/check.v1"
 )
 
 // ExecSuite also implements ssh.ConnMetadata
 type ExecSuite struct {
 	usr        *user.User
-	ctx        *ctx
+	ctx        *ServerContext
 	localAddr  net.Addr
 	remoteAddr net.Addr
 }
@@ -75,13 +75,12 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 
 	utils.InitLoggerForTests()
 	s.usr, _ = user.Current()
-	s.ctx = &ctx{isTestStub: true}
-	s.ctx.login = s.usr.Username
+	s.ctx = &ServerContext{IsTestStub: true}
+	s.ctx.Login = s.usr.Username
 	s.ctx.session = &session{id: "xxx"}
-	s.ctx.teleportUser = "galt"
-	s.ctx.conn = &ssh.ServerConn{Conn: s}
-	s.ctx.exec = &execResponse{ctx: s.ctx}
-	s.ctx.srv = &Server{authService: a, uuid: "00000000-0000-0000-0000-000000000000"}
+	s.ctx.TeleportUser = "galt"
+	s.ctx.Conn = &ssh.ServerConn{Conn: s}
+	s.ctx.ExecRequest = &LocalExecRequest{Ctx: s.ctx}
 	s.localAddr, _ = utils.ParseAddr("127.0.0.1:3022")
 	s.remoteAddr, _ = utils.ParseAddr("10.0.0.5:4817")
 }
@@ -104,7 +103,7 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 	}
 
 	// empty command (simple shell)
-	cmd, err := prepInteractiveCommand(s.ctx)
+	cmd, err := prepareInteractiveCommand(s.ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(cmd, check.NotNil)
 	c.Assert(cmd.Path, check.Equals, "/bin/sh")
@@ -113,8 +112,8 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 	c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
 
 	// non-empty command (exec a prog)
-	s.ctx.isTestStub = true
-	s.ctx.exec.cmdName = "ls -lh /etc"
+	s.ctx.IsTestStub = true
+	s.ctx.ExecRequest.SetCommand("ls -lh /etc")
 	cmd, err = prepareCommand(s.ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(cmd, check.NotNil)
@@ -124,7 +123,7 @@ func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 	c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
 
 	// command without args
-	s.ctx.exec.cmdName = "top"
+	s.ctx.ExecRequest.SetCommand("top")
 	cmd, err = prepareCommand(s.ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(cmd.Path, check.Equals, "/bin/sh")

--- a/lib/srv/regular/proxy_test.go
+++ b/lib/srv/regular/proxy_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package srv
+package regular
 
 import (
 	"gopkg.in/check.v1"

--- a/lib/srv/regular/sites.go
+++ b/lib/srv/regular/sites.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package srv
+package regular
 
 import (
 	"encoding/json"
 
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv"
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
@@ -43,13 +44,13 @@ func (t *proxySitesSubsys) String() string {
 	return "proxySites()"
 }
 
-func (t *proxySitesSubsys) wait() error {
+func (t *proxySitesSubsys) Wait() error {
 	return nil
 }
 
-// start serves a request for "proxysites" custom SSH subsystem. It builds an array of
+// Start serves a request for "proxysites" custom SSH subsystem. It builds an array of
 // service.Site structures, and writes it serialized as JSON back to the SSH client
-func (t *proxySitesSubsys) start(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
+func (t *proxySitesSubsys) Start(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
 	log.Debugf("proxysites.start(%v)", ctx)
 	remoteSites := t.srv.proxyTun.GetSites()
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package srv implements SSH server that supports multiplexing
+// Package regular implements SSH server that supports multiplexing
 // tunneling, SSH connections proxying and only supports Key based auth
-package srv
+package regular
 
 import (
 	"fmt"
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
@@ -65,7 +66,7 @@ type Server struct {
 	hostSigner    ssh.Signer
 	shell         string
 	authService   auth.AccessPoint
-	reg           *sessionRegistry
+	reg           *srv.SessionRegistry
 	sessionServer rsession.Service
 	limiter       *limiter.Limiter
 
@@ -113,6 +114,22 @@ type Server struct {
 	macAlgorithms []string
 }
 
+func (s *Server) GetNamespace() string {
+	return s.namespace
+}
+
+func (s *Server) GetAuditLog() events.IAuditLog {
+	return s.alog
+}
+
+func (s *Server) GetAuthService() auth.AccessPoint {
+	return s.authService
+}
+
+func (s *Server) GetSessionServer() rsession.Service {
+	return s.sessionServer
+}
+
 // ServerOption is a functional option passed to the server
 type ServerOption func(s *Server) error
 
@@ -147,9 +164,9 @@ func SetShell(shell string) ServerOption {
 }
 
 // SetSessionServer represents realtime session registry server
-func SetSessionServer(srv rsession.Service) ServerOption {
+func SetSessionServer(sessionServer rsession.Service) ServerOption {
 	return func(s *Server) error {
-		s.sessionServer = srv
+		s.sessionServer = sessionServer
 		return nil
 	}
 }
@@ -266,7 +283,6 @@ func New(addr utils.NetAddr,
 		return nil, trace.Wrap(err)
 	}
 	s.certChecker = ssh.CertChecker{IsAuthority: s.isAuthority}
-
 	for _, o := range options {
 		if err := o(s); err != nil {
 			return nil, trace.Wrap(err)
@@ -280,8 +296,8 @@ func New(addr utils.NetAddr,
 		component = teleport.ComponentNode
 	}
 
-	s.reg = newSessionRegistry(s)
-	srv, err := sshutils.NewServer(
+	s.reg = srv.NewSessionRegistry(s)
+	server, err := sshutils.NewServer(
 		component,
 		addr, s, signers,
 		sshutils.AuthMethods{PublicKey: s.keyAuth},
@@ -293,7 +309,7 @@ func New(addr utils.NetAddr,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	s.srv = srv
+	s.srv = server
 	return s, nil
 }
 
@@ -301,17 +317,11 @@ func (s *Server) getNamespace() string {
 	return services.ProcessNamespace(s.namespace)
 }
 
-func (s *Server) logFields(fields log.Fields) log.Fields {
-	var component string
+func (s *Server) Component() string {
 	if s.proxyMode {
-		component = teleport.ComponentProxy
-	} else {
-		component = teleport.ComponentNode
+		return teleport.ComponentProxy
 	}
-	return log.Fields{
-		trace.Component:       component,
-		trace.ComponentFields: fields,
-	}
+	return teleport.ComponentNode
 }
 
 // Addr returns server address
@@ -372,13 +382,13 @@ func (s *Server) getInfo() services.Server {
 
 // registerServer attempts to register server in the cluster
 func (s *Server) registerServer() error {
-	srv := s.getInfo()
-	srv.SetTTL(s.clock, defaults.ServerHeartbeatTTL)
+	server := s.getInfo()
+	server.SetTTL(s.clock, defaults.ServerHeartbeatTTL)
 	if !s.proxyMode {
-		return trace.Wrap(s.authService.UpsertNode(srv))
+		return trace.Wrap(s.authService.UpsertNode(server))
 	}
-	srv.SetPublicAddr(s.proxyPublicAddr.String())
-	return trace.Wrap(s.authService.UpsertProxy(srv))
+	server.SetPublicAddr(s.proxyPublicAddr.String())
+	return trace.Wrap(s.authService.UpsertProxy(server))
 }
 
 // heartbeatPresence periodically calls into the auth server to let everyone
@@ -765,9 +775,9 @@ func (s *Server) HandleNewChan(nc net.Conn, sconn *ssh.ServerConn, nch ssh.NewCh
 // handleDirectTCPIPRequest does the port forwarding
 func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, ch ssh.Channel, req *sshutils.DirectTCPIPReq) {
 	// ctx holds the connection context and keeps track of the associated resources
-	ctx := newCtx(s, sconn)
-	ctx.isTestStub = s.isTestStub
-	ctx.addCloser(ch)
+	ctx := srv.NewServerContext(s, sconn)
+	ctx.IsTestStub = s.isTestStub
+	ctx.AddCloser(ch)
 	defer ctx.Debugf("direct-tcp closed")
 	defer ctx.Close()
 
@@ -782,7 +792,7 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, ch ssh.Channel,
 	// audit event:
 	s.EmitAuditEvent(events.PortForwardEvent, events.EventFields{
 		events.PortForwardAddr: addr,
-		events.EventLogin:      ctx.login,
+		events.EventLogin:      ctx.Login,
 		events.LocalAddr:       sconn.LocalAddr().String(),
 		events.RemoteAddr:      sconn.RemoteAddr().String(),
 	})
@@ -810,18 +820,9 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, ch ssh.Channel,
 // this is the only way to make web-based terminal UI not break apart
 // when window changes its size
 func (s *Server) handleTerminalResize(sconn *ssh.ServerConn, ch ssh.Channel) {
-	// the party may not be immediately available for this connection,
-	// keep asking for a full second:
-	for i := 0; i < 10; i++ {
-		party := s.reg.PartyForConnection(sconn)
-		if party == nil {
-			time.Sleep(time.Millisecond * 100)
-			continue
-		}
-		// this starts a loop which will keep updating the terminal
-		// size for every SSH write back to this connection
-		party.termSizePusher(ch)
-		return
+	err := s.reg.PushTermSizeToParty(sconn, ch)
+	if err != nil {
+		log.Warnf("Unable to push terminal size to party: %v", err)
 	}
 }
 
@@ -829,43 +830,15 @@ func (s *Server) handleTerminalResize(sconn *ssh.ServerConn, ch ssh.Channel) {
 // this function's loop handles all the "exec", "subsystem" and "shell" requests.
 func (s *Server) handleSessionRequests(sconn *ssh.ServerConn, ch ssh.Channel, in <-chan *ssh.Request) {
 	// ctx holds the connection context and keeps track of the associated resources
-	ctx := newCtx(s, sconn)
-	ctx.isTestStub = s.isTestStub
-	ctx.addCloser(ch)
+	ctx := srv.NewServerContext(s, sconn)
+	ctx.IsTestStub = s.isTestStub
+	ctx.AddCloser(ch)
 	defer ctx.Close()
-
-	// As SSH conversation progresses, at some point a session will be created and
-	// its ID will be added to the environment
-	updateContext := func() error {
-		ssid, found := ctx.getEnv(sshutils.SessionEnvVar)
-		if !found {
-			return nil
-		}
-		// make sure whatever session is requested is a valid session
-		_, err := rsession.ParseID(ssid)
-		if err != nil {
-			return trace.BadParameter("invalid session id")
-		}
-		findSession := func() (*session, bool) {
-			s.reg.Lock()
-			defer s.reg.Unlock()
-			return s.reg.findSession(rsession.ID(ssid))
-		}
-		// update ctx with a session ID
-		ctx.session, _ = findSession()
-		if ctx.session == nil {
-			log.Debugf("[SSH] will create new session for SSH connection %v", sconn.RemoteAddr())
-		} else {
-			log.Debugf("[SSH] will join session %v for SSH connection %v", ctx.session, sconn.RemoteAddr())
-		}
-
-		return nil
-	}
 
 	for {
 		// update ctx with the session ID:
 		if !s.proxyMode {
-			err := updateContext()
+			err := ctx.CreateOrJoinSession(s.reg)
 			if err != nil {
 				errorMessage := fmt.Sprintf("unable to update context: %v", err)
 				ctx.Errorf("[SSH] %v", errorMessage)
@@ -880,10 +853,10 @@ func (s *Server) handleSessionRequests(sconn *ssh.ServerConn, ch ssh.Channel, in
 			}
 		}
 		select {
-		case creq := <-ctx.subsystemResultC:
+		case creq := <-ctx.SubsystemResultCh:
 			// this means that subsystem has finished executing and
 			// want us to close session and the channel
-			ctx.Debugf("[SSH] close session request: %v", creq.err)
+			ctx.Debugf("[SSH] close session request: %v", creq.Err)
 			return
 		case req := <-in:
 			if req == nil {
@@ -898,13 +871,13 @@ func (s *Server) handleSessionRequests(sconn *ssh.ServerConn, ch ssh.Channel, in
 			if req.WantReply {
 				req.Reply(true, nil)
 			}
-		case result := <-ctx.result:
+		case result := <-ctx.ExecResultCh:
 			ctx.Debugf("[SSH] ctx.result = %v", result)
 			// this means that exec process has finished and delivered the execution result,
 			// we send it back and close the session
-			_, err := ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: uint32(result.code)}))
+			_, err := ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: uint32(result.Code)}))
 			if err != nil {
-				ctx.Infof("[SSH] %v failed to send exit status: %v", result.command, err)
+				ctx.Infof("[SSH] %v failed to send exit status: %v", result.Command, err)
 			}
 			return
 		}
@@ -913,7 +886,7 @@ func (s *Server) handleSessionRequests(sconn *ssh.ServerConn, ch ssh.Channel, in
 
 // dispatch receives an SSH request for a subsystem and disptaches the request to the
 // appropriate subsystem implementation
-func (s *Server) dispatch(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
+func (s *Server) dispatch(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
 	ctx.Debugf("[SSH] ssh.dispatch(req=%v, wantReply=%v)", req.Type, req.WantReply)
 	// if this SSH server is configured to only proxy, we do not support anything other
 	// than our own custom "subsystems" and environment manipulation
@@ -939,8 +912,8 @@ func (s *Server) dispatch(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 		return s.handlePTYReq(ch, req, ctx)
 	case "shell":
 		// SSH client asked to launch shell, we allocate PTY and start shell session
-		ctx.exec = &execResponse{ctx: ctx}
-		if err := s.reg.openSession(ch, req, ctx); err != nil {
+		ctx.ExecRequest = srv.NewExecRequest(ctx, "")
+		if err := s.reg.OpenSession(ch, req, ctx); err != nil {
 			log.Error(err)
 			return trace.Wrap(err)
 		}
@@ -967,16 +940,16 @@ func (s *Server) dispatch(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 	}
 }
 
-func (s *Server) handleAgentForward(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
-	roles, err := s.fetchRoleSet(ctx.teleportUser, ctx.clusterName)
+func (s *Server) handleAgentForward(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
+	roles, err := s.fetchRoleSet(ctx.TeleportUser, ctx.ClusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := roles.CheckAgentForward(ctx.login); err != nil {
+	if err := roles.CheckAgentForward(ctx.Login); err != nil {
 		log.Warningf("[SSH:node] denied forward agent %v", err)
 		return trace.Wrap(err)
 	}
-	systemUser, err := user.Lookup(ctx.login)
+	systemUser, err := user.Lookup(ctx.Login)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
@@ -989,12 +962,12 @@ func (s *Server) handleAgentForward(ch ssh.Channel, req *ssh.Request, ctx *ctx) 
 		return trace.Wrap(err)
 	}
 
-	authChan, _, err := ctx.conn.OpenChannel("auth-agent@openssh.com", nil)
+	authChan, _, err := ctx.Conn.OpenChannel("auth-agent@openssh.com", nil)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	clientAgent := agent.NewClient(authChan)
-	ctx.setAgent(clientAgent, authChan)
+	ctx.SetAgent(clientAgent, authChan)
 
 	pid := os.Getpid()
 	socketDir, err := ioutil.TempDir(os.TempDir(), "teleport-")
@@ -1018,34 +991,39 @@ func (s *Server) handleAgentForward(ch ssh.Channel, req *ssh.Request, ctx *ctx) 
 	if req.WantReply {
 		req.Reply(true, nil)
 	}
-	ctx.setEnv(teleport.SSHAuthSock, socketPath)
-	ctx.setEnv(teleport.SSHAgentPID, fmt.Sprintf("%v", pid))
-	ctx.addCloser(agentServer)
-	ctx.addCloser(dirCloser)
-	ctx.Debugf("[SSH:node] opened agent channel for teleport user %v and socket %v", ctx.teleportUser, socketPath)
+	ctx.SetEnv(teleport.SSHAuthSock, socketPath)
+	ctx.SetEnv(teleport.SSHAgentPID, fmt.Sprintf("%v", pid))
+	ctx.AddCloser(agentServer)
+	ctx.AddCloser(dirCloser)
+	ctx.Debugf("[SSH:node] opened agent channel for teleport user %v and socket %v", ctx.TeleportUser, socketPath)
 	go agentServer.Serve()
 
 	return nil
 }
 
 // handleWinChange gets called when 'window chnged' SSH request comes in
-func (s *Server) handleWinChange(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
+func (s *Server) handleWinChange(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
 	params, err := parseWinChange(req)
 	if err != nil {
 		ctx.Error(err)
 		return trace.Wrap(err)
 	}
-	term := ctx.getTerm()
+	term := ctx.GetTerm()
 	if term != nil {
-		err = term.setWinsize(*params)
+		err = term.SetWinSize(*params)
 		if err != nil {
 			ctx.Error(err)
 		}
 	}
-	return trace.Wrap(s.reg.notifyWinChange(*params, ctx))
+	err = s.reg.NotifyWinChange(*params, ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
 }
 
-func (s *Server) handleSubsystem(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
+func (s *Server) handleSubsystem(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
 	sb, err := parseSubsystemRequest(s, req)
 	if err != nil {
 		ctx.Warnf("[SSH] %v failed to parse subsystem request: %v", err)
@@ -1054,68 +1032,57 @@ func (s *Server) handleSubsystem(ch ssh.Channel, req *ssh.Request, ctx *ctx) err
 	ctx.Debugf("[SSH] subsystem request: %v", sb)
 	// starting subsystem is blocking to the client,
 	// while collecting its result and waiting is not blocking
-	if err := sb.start(ctx.conn, ch, req, ctx); err != nil {
+	if err := sb.Start(ctx.Conn, ch, req, ctx); err != nil {
 		ctx.Warnf("[SSH] failed executing request: %v", err)
-		ctx.sendSubsystemResult(trace.Wrap(err))
+		ctx.SendSubsystemResult(srv.SubsystemResult{trace.Wrap(err)})
 		return trace.Wrap(err)
 	}
 	go func() {
-		err := sb.wait()
+		err := sb.Wait()
 		log.Debugf("[SSH] %v finished with result: %v", sb, err)
-		ctx.sendSubsystemResult(trace.Wrap(err))
+		ctx.SendSubsystemResult(srv.SubsystemResult{trace.Wrap(err)})
 	}()
 	return nil
 }
 
 // handleEnv accepts environment variables sent by the client and stores them
 // in connection context
-func (s *Server) handleEnv(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
+func (s *Server) handleEnv(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
 	var e sshutils.EnvReqParams
 	if err := ssh.Unmarshal(req.Payload, &e); err != nil {
 		ctx.Error(err)
 		return trace.Wrap(err, "failed to parse env request")
 	}
-	ctx.setEnv(e.Name, e.Value)
+	ctx.SetEnv(e.Name, e.Value)
 	return nil
 }
 
 // handlePTYReq allocates PTY for this SSH connection per client's request
-func (s *Server) handlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
-	var (
-		params *rsession.TerminalParams
-		err    error
-		term   *terminal
-	)
-	r, err := parsePTYReq(req)
+func (s *Server) handlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
+	// parse and get the window size requested
+	r, err := srv.ParsePTYReq(req)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// if the caller asked for an invalid sized pty (like ansible
-	// which asks for a 0x0 size) update the request with defaults
-	err = r.CheckAndSetDefaults()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	params, err = rsession.NewTerminalParamsFromUint32(r.W, r.H)
+	params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	ctx.Debugf("[SSH] terminal requested of size %v", *params)
 
-	// already have terminal?
-	if term = ctx.getTerm(); term == nil {
-		term, params, err = requestPTY(req)
+	// get an existing terminal or create a new one
+	term := ctx.GetTerm()
+	if term == nil {
+		term, err = srv.NewTerminal(ctx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		ctx.setTerm(term)
+		ctx.SetTerm(term)
 	}
-	term.setWinsize(*params)
+	term.SetWinSize(*params)
 
 	// update the session:
-	if err := s.reg.notifyWinChange(*params, ctx); err != nil {
+	if err := s.reg.NotifyWinChange(*params, ctx); err != nil {
 		log.Error(err)
 	}
 	return nil
@@ -1125,8 +1092,8 @@ func (s *Server) handlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *ctx) error 
 // a command after making an SSH connection)
 //
 // Note: this also handles 'scp' requests because 'scp' is a subset of "exec"
-func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
-	execResponse, err := parseExecRequest(req, ctx)
+func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
+	execRequest, err := parseExecRequest(ctx, ch, req)
 	if err != nil {
 		ctx.Infof("failed to parse exec request: %v", err)
 		replyError(ch, req, err)
@@ -1137,18 +1104,18 @@ func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 	}
 	// a terminal has been previously allocate for this command.
 	// run this inside an interactive session
-	if ctx.term != nil {
-		return s.reg.openSession(ch, req, ctx)
+	if ctx.GetTerm() != nil {
+		return s.reg.OpenSession(ch, req, ctx)
 	}
 	// ... otherwise, regular execution:
-	result, err := execResponse.start(ch)
+	result, err := execRequest.Start(ch)
 	if err != nil {
 		ctx.Error(err)
 		replyError(ch, req, err)
 	}
 	if result != nil {
-		ctx.Debugf("%v result collected: %v", execResponse, result)
-		ctx.sendResult(*result)
+		ctx.Debugf("%v result collected: %v", execRequest, result)
+		ctx.SendExecResult(*result)
 	}
 	if err != nil {
 		return trace.Wrap(err)
@@ -1157,12 +1124,12 @@ func (s *Server) handleExec(ch ssh.Channel, req *ssh.Request, ctx *ctx) error {
 	// in case if result is nil and no error, this means that program is
 	// running in the background
 	go func() {
-		result, err = execResponse.wait()
+		result, err = execRequest.Wait()
 		if err != nil {
-			ctx.Errorf("%v wait failed: %v", execResponse, err)
+			ctx.Errorf("%v wait failed: %v", execRequest, err)
 		}
 		if result != nil {
-			ctx.sendResult(*result)
+			ctx.SendExecResult(*result)
 		}
 	}()
 	return nil
@@ -1192,21 +1159,39 @@ func replyError(ch ssh.Channel, req *ssh.Request, err error) {
 	}
 }
 
-func closeAll(closers ...io.Closer) error {
-	var err error
-	for _, cl := range closers {
-		if cl == nil {
-			continue
-		}
-		if e := cl.Close(); e != nil {
-			err = e
-		}
+func parseWinChange(req *ssh.Request) (*rsession.TerminalParams, error) {
+	var r sshutils.WinChangeReqParams
+	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return err
+	params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return params, nil
 }
 
-type closerFunc func() error
+func parseExecRequest(ctx *srv.ServerContext, channel ssh.Channel, req *ssh.Request) (srv.Exec, error) {
+	var r sshutils.ExecReq
+	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
-func (f closerFunc) Close() error {
-	return f()
+	ctx.ExecRequest = srv.NewExecRequest(ctx, r.Command)
+
+	return ctx.ExecRequest, nil
+}
+
+func parseSubsystemRequest(srv *Server, req *ssh.Request) (srv.Subsystem, error) {
+	var r sshutils.SubsystemReq
+	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
+		return nil, fmt.Errorf("failed to parse subsystem request, error: %v", err)
+	}
+	if srv.proxyMode && strings.HasPrefix(r.Name, "proxy:") {
+		return parseProxySubsys(r.Name, srv)
+	}
+	if srv.proxyMode && strings.HasPrefix(r.Name, "proxysites") {
+		return parseProxySitesSubsys(r.Name, srv)
+	}
+	return nil, trace.BadParameter("unrecognized subsystem: %v", r.Name)
 }

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package srv
+package regular
 
 import (
 	"bytes"

--- a/lib/srv/subsystem.go
+++ b/lib/srv/subsystem.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2017 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,36 +17,20 @@ limitations under the License.
 package srv
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 )
 
-type subsys struct {
-	Name string
+// SubsystemResult is a result of execution of the subsystem.
+type SubsystemResult struct {
+	Err error
 }
 
-// subsystem represents SSH subsytem - special command executed
-// in the context of the session
-type subsystem interface {
-	// start starts subsystem
-	start(*ssh.ServerConn, ssh.Channel, *ssh.Request, *ctx) error
-	// wait is returned by subystem when it's completed
-	wait() error
-}
+// Subsystem represents SSH subsytem - special command executed
+// in the context of the session.
+type Subsystem interface {
+	// Start starts subsystem
+	Start(*ssh.ServerConn, ssh.Channel, *ssh.Request, *ServerContext) error
 
-func parseSubsystemRequest(srv *Server, req *ssh.Request) (subsystem, error) {
-	var s subsys
-	if err := ssh.Unmarshal(req.Payload, &s); err != nil {
-		return nil, fmt.Errorf("failed to parse subsystem request, error: %v", err)
-	}
-	if srv.proxyMode && strings.HasPrefix(s.Name, "proxy:") {
-		return parseProxySubsys(s.Name, srv)
-	}
-	if srv.proxyMode && strings.HasPrefix(s.Name, "proxysites") {
-		return parseProxySitesSubsys(s.Name, srv)
-	}
-	return nil, trace.BadParameter("unrecognized subsystem: %v", s.Name)
+	// Wait is returned by subystem when it's completed
+	Wait() error
 }

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -17,9 +17,13 @@ limitations under the License.
 package srv
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"sync"
+	"syscall"
+
+	"golang.org/x/crypto/ssh"
 
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
@@ -28,116 +32,158 @@ import (
 	"github.com/kr/pty"
 	"github.com/moby/moby/pkg/term"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 )
 
-// terminal provides handy functions for managing PTY, usch as resizing windows
-// execing processes with PTY and cleaning up
+// Terminal defines an interface of handy functions for managing a (local or
+// remote) PTY, such as resizing windows, executing commands with a PTY, and
+// cleaning up.
+type Terminal interface {
+	// AddParty adds another participant to this terminal. We will keep the
+	// Terminal open until all participants have left.
+	AddParty(delta int)
+
+	// Run will run the terminal.
+	Run() error
+
+	// Wait will block until the terminal is complete.
+	Wait() (*ExecResult, error)
+
+	// Kill will force kill the terminal.
+	Kill() error
+
+	// PTY returns the PTY backing the terminal.
+	PTY() io.ReadWriter
+
+	// TTY returns the TTY backing the terminal.
+	TTY() *os.File
+
+	// Close will free resources associated with the terminal.
+	Close() error
+
+	// GetWinSize returns the window size of the terminal.
+	GetWinSize() (*term.Winsize, error)
+
+	// SetWinSize sets the window size of the terminal.
+	SetWinSize(params rsession.TerminalParams) error
+
+	// GetTerminalParams is a fast call to get cached terminal parameters
+	// and avoid extra system call.
+	GetTerminalParams() rsession.TerminalParams
+
+	// SetTermType sets the terminal type from "req-pty"
+	SetTermType(string)
+}
+
+// NewTerminal returns a new terminal. Terminal can be local or remote
+// depending on cluster configuration.
+func NewTerminal(ctx *ServerContext) (Terminal, error) {
+	return NewLocalTerminal(ctx)
+}
+
+// terminal is a local PTY created by Teleport nodes.
 type terminal struct {
-	sync.WaitGroup
-	sync.Mutex
-	pty    *os.File
-	tty    *os.File
-	err    error
-	done   bool
+	wg sync.WaitGroup
+	mu sync.Mutex
+
+	cmd *exec.Cmd
+	ctx *ServerContext
+
+	pty *os.File
+	tty *os.File
+
 	params rsession.TerminalParams
 }
 
-func parsePTYReq(req *ssh.Request) (*sshutils.PTYReqParams, error) {
-	var r sshutils.PTYReqParams
-	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
-		log.Warnf("failed to parse PTY request: %v", err)
-		return nil, err
-	}
-	return &r, nil
-}
-
-func newTerminal() (*terminal, error) {
-	// Create new PTY
+// NewLocalTerminal creates and returns a local PTY.
+func NewLocalTerminal(ctx *ServerContext) (*terminal, error) {
 	pty, tty, err := pty.Open()
 	if err != nil {
 		log.Warnf("could not start pty (%s)", err)
 		return nil, err
 	}
-	return &terminal{pty: pty, tty: tty, err: err}, nil
+	return &terminal{
+		ctx: ctx,
+		pty: pty,
+		tty: tty,
+	}, nil
 }
 
-func requestPTY(req *ssh.Request) (*terminal, *rsession.TerminalParams, error) {
-	var r sshutils.PTYReqParams
-	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
-		log.Warnf("failed to parse PTY request: %v", err)
-		return nil, nil, trace.Wrap(err)
-	}
-	err := r.CheckAndSetDefaults()
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	log.Debugf("Parsed pty request pty(env=%v, w=%v, h=%v)", r.Env, r.W, r.H)
-
-	t, err := newTerminal()
-	if err != nil {
-		log.Warnf("failed to create term: %v", err)
-		return nil, nil, trace.Wrap(err)
-	}
-	params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	t.setWinsize(*params)
-	return t, params, nil
+// AddParty adds another participant to this terminal. We will keep the
+// Terminal open until all participants have left.
+func (t *terminal) AddParty(delta int) {
+	t.wg.Add(delta)
 }
 
-func (t *terminal) getWinsize() (*term.Winsize, error) {
-	t.Lock()
-	defer t.Unlock()
-	if t.pty == nil {
-		return nil, trace.NotFound("no pty")
-	}
-	ws, err := term.GetWinsize(t.pty.Fd())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return ws, nil
-}
+// Run will run the terminal.
+func (t *terminal) Run() error {
+	defer t.closeTTY()
 
-func (t *terminal) setWinsize(params rsession.TerminalParams) error {
-	t.Lock()
-	defer t.Unlock()
-	if t.pty == nil {
-		return trace.NotFound("no pty")
-	}
-	if err := term.SetWinsize(t.pty.Fd(), params.Winsize()); err != nil {
+	cmd, err := prepareInteractiveCommand(t.ctx)
+	if err != nil {
 		return trace.Wrap(err)
 	}
-	t.params = params
+	t.cmd = cmd
+
+	cmd.Stdout = t.tty
+	cmd.Stdin = t.tty
+	cmd.Stderr = t.tty
+	cmd.SysProcAttr.Setctty = true
+	cmd.SysProcAttr.Setsid = true
+
+	err = cmd.Start()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 
-// getTerminalParams is a fast call to get cached terminal parameters
-// and avoid extra system call
-func (t *terminal) getTerminalParams() rsession.TerminalParams {
-	t.Lock()
-	defer t.Unlock()
-	return t.params
-}
-
-func (t *terminal) closeTTY() {
-	if err := t.tty.Close(); err != nil {
-		log.Warnf("failed to close TTY: %v", err)
+// Wait will block until the terminal is complete.
+func (t *terminal) Wait() (*ExecResult, error) {
+	err := t.cmd.Wait()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			status := exitErr.Sys().(syscall.WaitStatus)
+			return &ExecResult{Code: status.ExitStatus(), Command: t.cmd.Path}, nil
+		}
+		return nil, err
 	}
-	t.tty = nil
+
+	status, ok := t.cmd.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok {
+		return nil, trace.Errorf("unknown exit status: %T(%v)", t.cmd.ProcessState.Sys(), t.cmd.ProcessState.Sys())
+	}
+
+	return &ExecResult{
+		Code:    status.ExitStatus(),
+		Command: t.cmd.Path,
+	}, nil
 }
 
-func (t *terminal) run(c *exec.Cmd) error {
-	defer t.closeTTY()
-	c.Stdout = t.tty
-	c.Stdin = t.tty
-	c.Stderr = t.tty
-	c.SysProcAttr.Setctty = true
-	c.SysProcAttr.Setsid = true
-	return trace.Wrap(c.Start())
+// Kill will force kill the terminal.
+func (t *terminal) Kill() error {
+	if t.cmd.Process != nil {
+		if err := t.cmd.Process.Kill(); err != nil {
+			if err.Error() != "os: process already finished" {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	return nil
 }
 
+// PTY returns the PTY backing the terminal.
+func (t *terminal) PTY() io.ReadWriter {
+	return t.pty
+}
+
+// TTY returns the TTY backing the terminal.
+func (t *terminal) TTY() *os.File {
+	return t.tty
+}
+
+// Close will free resources associated with the terminal.
 func (t *terminal) Close() error {
 	var err error
 	// note, pty is closed in the copying goroutine,
@@ -151,26 +197,81 @@ func (t *terminal) Close() error {
 	return trace.Wrap(err)
 }
 
+func (t *terminal) closeTTY() {
+	if err := t.tty.Close(); err != nil {
+		log.Warnf("failed to close TTY: %v", err)
+	}
+	t.tty = nil
+}
+
 func (t *terminal) closePTY() {
-	t.Lock()
-	defer t.Unlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	defer log.Debugf("PTY is closed")
 
-	// wait until all copying is over
-	t.Wait()
+	// wait until all copying is over (all participants have left)
+	t.wg.Wait()
 
 	t.pty.Close()
 	t.pty = nil
 }
 
-func parseWinChange(req *ssh.Request) (*rsession.TerminalParams, error) {
-	var r sshutils.WinChangeReqParams
-	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
-		return nil, trace.Wrap(err)
+// GetWinSize returns the window size of the terminal.
+func (t *terminal) GetWinSize() (*term.Winsize, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.pty == nil {
+		return nil, trace.NotFound("no pty")
 	}
-	params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
+	ws, err := term.GetWinsize(t.pty.Fd())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return params, nil
+	return ws, nil
+}
+
+// SetWinSize sets the window size of the terminal.
+func (t *terminal) SetWinSize(params rsession.TerminalParams) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.pty == nil {
+		return trace.NotFound("no pty")
+	}
+	if err := term.SetWinsize(t.pty.Fd(), params.Winsize()); err != nil {
+		return trace.Wrap(err)
+	}
+	t.params = params
+	return nil
+}
+
+// GetTerminalParams is a fast call to get cached terminal parameters
+// and avoid extra system call.
+func (t *terminal) GetTerminalParams() rsession.TerminalParams {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.params
+}
+
+// SetTermType sets the terminal type from "req-pty" request.
+func (t *terminal) SetTermType(term string) {
+	if term == "" {
+		term = defaultTerm
+	}
+	t.cmd.Env = append(t.cmd.Env, "TERM="+term)
+}
+
+func ParsePTYReq(req *ssh.Request) (*sshutils.PTYReqParams, error) {
+	var r sshutils.PTYReqParams
+	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
+		log.Warnf("failed to parse PTY request: %v", err)
+		return nil, err
+	}
+
+	// if the caller asked for an invalid sized pty (like ansible
+	// which asks for a 0x0 size) update the request with defaults
+	if err := r.CheckAndSetDefaults(); err != nil {
+		return nil, err
+	}
+
+	return &r, nil
 }

--- a/lib/sshutils/req.go
+++ b/lib/sshutils/req.go
@@ -71,6 +71,16 @@ func (p *PTYReqParams) CheckAndSetDefaults() error {
 	return nil
 }
 
+// ExecReq specifies parameters for a "exec" request.
+type ExecReq struct {
+	Command string
+}
+
+// SubsystemReq specifies the parameters for a "subsystem" request.
+type SubsystemReq struct {
+	Name string
+}
+
 const (
 	// SessionEnvVar is environment variable for SSH session
 	SessionEnvVar = "TELEPORT_SESSION"

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -57,7 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/session"
 	sess "github.com/gravitational/teleport/lib/session"
-	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/srv/regular"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/state"
 	"github.com/gravitational/teleport/lib/utils"
@@ -82,8 +82,8 @@ func TestWeb(t *testing.T) {
 }
 
 type WebSuite struct {
-	node        *srv.Server
-	proxy       *srv.Server
+	node        *regular.Server
+	proxy       *regular.Server
 	srvAddress  string
 	srvID       string
 	srvHostPort string
@@ -259,7 +259,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	s.srvAddress = fmt.Sprintf("127.0.0.1:%v", nodePort)
 
 	// create SSH service:
-	node, err := srv.New(
+	node, err := regular.New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: s.srvAddress},
 		s.domainName,
 		[]ssh.Signer{s.signer},
@@ -267,9 +267,10 @@ func (s *WebSuite) SetUpTest(c *C) {
 		s.dir,
 		nil,
 		utils.NetAddr{},
-		srv.SetShell("/bin/sh"),
-		srv.SetSessionServer(sessionServer),
-		srv.SetAuditLog(s.roleAuth),
+		regular.SetNamespace(defaults.Namespace),
+		regular.SetShell("/bin/sh"),
+		regular.SetSessionServer(sessionServer),
+		regular.SetAuditLog(s.roleAuth),
 	)
 	c.Assert(err, IsNil)
 	s.node = node
@@ -321,16 +322,16 @@ func (s *WebSuite) SetUpTest(c *C) {
 	proxyAddr := utils.NetAddr{
 		AddrNetwork: "tcp", Addr: fmt.Sprintf("127.0.0.1:%v", proxyPort),
 	}
-	s.proxy, err = srv.New(proxyAddr,
+	s.proxy, err = regular.New(proxyAddr,
 		s.domainName,
 		[]ssh.Signer{s.signer},
 		s.roleAuth,
 		s.dir,
 		nil,
 		utils.NetAddr{},
-		srv.SetProxyMode(revTunServer),
-		srv.SetSessionServer(s.roleAuth),
-		srv.SetAuditLog(s.roleAuth),
+		regular.SetProxyMode(revTunServer),
+		regular.SetSessionServer(s.roleAuth),
+		regular.SetAuditLog(s.roleAuth),
 	)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
**Purpose**

To share common functionality (like session recording) we need to create interfaces so the context and session sharing code can interact with Servers without knowing if they are interacting with the regular server or forwarding server.

_Note, this PR does not include any logic changes, it's a purely interfaces + refactoring._

**Implementation**

* Created `srv.Server` interface that all SSH servers are required to implement.
* Exported fields in `srv.ServerContext`.
* Exported fields in `srv.SessionRegistry`.
* Created `Exec`, `Terminal`, and `Subsystem` interfaces.
* Moved `lib/srv/sshserver.go` to `lib/srv/regular/sshserver.go`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1446