### PR TITLE
Agent Forwarding Refactoring

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -129,8 +129,9 @@ type ServerContext struct {
 	// ClusterName is the name of the cluster current user is authenticated with.
 	ClusterName string
 
-	// Certificate is the SSH certificate used in this session.
-	Certificate string
+	// Certificate is the SSH user certificate bytes marshalled in the OpenSSH
+	// authorized_keys format.
+	Certificate []byte
 }
 
 // NewServerContext creates a new *ServerContext which is used to pass and
@@ -145,7 +146,7 @@ func NewServerContext(srv Server, conn *ssh.ServerConn) *ServerContext {
 		SubsystemResultCh: make(chan SubsystemResult, 10),
 		TeleportUser:      conn.Permissions.Extensions[utils.CertTeleportUser],
 		ClusterName:       conn.Permissions.Extensions[utils.CertTeleportClusterName],
-		Certificate:       conn.Permissions.Extensions[utils.CertTeleportUserCertificate],
+		Certificate:       []byte(conn.Permissions.Extensions[utils.CertTeleportUserCertificate]),
 		Login:             conn.User(),
 	}
 
@@ -164,14 +165,14 @@ func NewServerContext(srv Server, conn *ssh.ServerConn) *ServerContext {
 
 // GetCertificate parses the SSH certificate bytes and returns a *ssh.Certificate.
 func (c *ServerContext) GetCertificate() (*ssh.Certificate, error) {
-	k, _, _, _, err := ssh.ParseAuthorizedKey([]byte(c.Certificate))
+	k, _, _, _, err := ssh.ParseAuthorizedKey(c.Certificate)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	cert, ok := k.(*ssh.Certificate)
 	if !ok {
-		return nil, trace.BadParameter("not a certificate: %v")
+		return nil, trace.BadParameter("not a certificate")
 	}
 
 	return cert, nil

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -128,6 +128,9 @@ type ServerContext struct {
 
 	// ClusterName is the name of the cluster current user is authenticated with.
 	ClusterName string
+
+	// Certificate is the SSH certificate used in this session.
+	Certificate string
 }
 
 // NewServerContext creates a new *ServerContext which is used to pass and
@@ -142,6 +145,7 @@ func NewServerContext(srv Server, conn *ssh.ServerConn) *ServerContext {
 		SubsystemResultCh: make(chan SubsystemResult, 10),
 		TeleportUser:      conn.Permissions.Extensions[utils.CertTeleportUser],
 		ClusterName:       conn.Permissions.Extensions[utils.CertTeleportClusterName],
+		Certificate:       conn.Permissions.Extensions[utils.CertTeleportUserCertificate],
 		Login:             conn.User(),
 	}
 
@@ -156,6 +160,21 @@ func NewServerContext(srv Server, conn *ssh.ServerConn) *ServerContext {
 		},
 	})
 	return ctx
+}
+
+// GetCertificate parses the SSH certificate bytes and returns a *ssh.Certificate.
+func (c *ServerContext) GetCertificate() (*ssh.Certificate, error) {
+	k, _, _, _, err := ssh.ParseAuthorizedKey([]byte(c.Certificate))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cert, ok := k.(*ssh.Certificate)
+	if !ok {
+		return nil, trace.BadParameter("not a certificate: %v")
+	}
+
+	return cert, nil
 }
 
 // CreateOrJoinSession will look in the SessionRegistry for the session ID. If

--- a/lib/srv/handlers.go
+++ b/lib/srv/handlers.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srv
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+// AuthHandlers are common authorization and authentication related handlers
+// used by the regular and forwarding server.
+type AuthHandlers struct {
+	// Server is the services.Server in the backend.
+	Server services.Server
+
+	// ProxyMode is if the server is running in proxy mode. Only applies to the
+	// regular server.
+	ProxyMode bool
+
+	// AuditLog is the service used to access Audit Log.
+	AuditLog events.IAuditLog
+
+	// AccessPoint is used to access the Auth Server.
+	AccessPoint auth.AccessPoint
+}
+
+// CheckAgentForward checks the certificate was signed by a valid certificate
+// authority, fetches the appropriate roles, and checks if agent forwarding
+// is allowed.
+func (h *AuthHandlers) CheckAgentForward(ctx *ServerContext) error {
+	cert, err := ctx.GetCertificate()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	ca, err := h.authorityForCert(cert.SignatureKey)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	roles, err := h.fetchRoleSet(cert, ca, ctx.TeleportUser, ctx.ClusterName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := roles.CheckAgentForward(ctx.Login); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// KeyAuth implements SSH client authentication using public keys and is called
+// by the server every time the client connects
+func (h *AuthHandlers) KeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+	cid := fmt.Sprintf("conn(%v->%v, user=%v)", conn.RemoteAddr(), conn.LocalAddr(), conn.User())
+	fingerprint := fmt.Sprintf("%v %v", key.Type(), sshutils.Fingerprint(key))
+	log.Debugf("[SSH] %v auth attempt with key %v", cid, fingerprint)
+
+	logger := log.WithFields(log.Fields{
+		"local":       conn.LocalAddr(),
+		"remote":      conn.RemoteAddr(),
+		"user":        conn.User(),
+		"fingerprint": fingerprint,
+	})
+
+	certChecker := ssh.CertChecker{IsAuthority: h.isAuthority}
+
+	cert, ok := key.(*ssh.Certificate)
+	log.Debugf("[SSH] %v auth attempt with key %v, %#v", cid, fingerprint, cert)
+	if !ok {
+		log.Debugf("[SSH] auth attempt, unsupported key type for %v", fingerprint)
+		return nil, trace.BadParameter("unsupported key type: %v", fingerprint)
+	}
+	if len(cert.ValidPrincipals) == 0 {
+		log.Debugf("[SSH] need a valid principal for key %v", fingerprint)
+		return nil, trace.BadParameter("need a valid principal for key %v", fingerprint)
+	}
+
+	if len(cert.KeyId) == 0 {
+		log.Debugf("[SSH] need a valid key ID for key %v", fingerprint)
+		return nil, trace.BadParameter("need a valid key for key %v", fingerprint)
+	}
+	teleportUser := cert.KeyId
+
+	logAuditEvent := func(err error) {
+		// only failed attempts are logged right now
+		if err != nil {
+			fields := events.EventFields{
+				events.EventUser:          teleportUser,
+				events.AuthAttemptSuccess: false,
+				events.AuthAttemptErr:     err.Error(),
+			}
+			log.Warningf("[SSH] failed login attempt %#v", fields)
+			h.AuditLog.EmitAuditEvent(events.AuthAttemptEvent, fields)
+		}
+	}
+	permissions, err := certChecker.Authenticate(conn, key)
+	if err != nil {
+		logAuditEvent(err)
+		return nil, trace.Wrap(err)
+	}
+	if err := certChecker.CheckCert(conn.User(), cert); err != nil {
+		logAuditEvent(err)
+		return nil, trace.Wrap(err)
+	}
+	logger.Debugf("[SSH] successfully authenticated")
+
+	// see if the host user is valid (no need to do this in proxy mode)
+	if !h.ProxyMode {
+		_, err = user.Lookup(conn.User())
+		if err != nil {
+			host, _ := os.Hostname()
+			logger.Warningf("host '%s' does not have OS user '%s'", host, conn.User())
+			logger.Errorf("no such user")
+			return nil, trace.AccessDenied("no such user: '%s'", conn.User())
+		}
+	}
+
+	clusterName, err := h.AccessPoint.GetDomainName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// this is the only way we know of to pass valid additional data about the
+	// connection to the handlers
+	permissions.Extensions[utils.CertTeleportUser] = teleportUser
+	permissions.Extensions[utils.CertTeleportClusterName] = clusterName
+	permissions.Extensions[utils.CertTeleportUserCertificate] = string(ssh.MarshalAuthorizedKey(cert))
+
+	if h.ProxyMode {
+		return permissions, nil
+	}
+
+	// if we are trying to connect to a node, make sure rbac rules allow it
+	err = h.checkPermissionToLogin(cert, clusterName, teleportUser, conn.User())
+	if err != nil {
+		logger.Errorf("Permission denied: %v", err)
+		logAuditEvent(err)
+		return nil, trace.Wrap(err)
+	}
+
+	return permissions, nil
+}
+
+// checkPermissionToLogin checks the given certificate (supplied by a connected
+// client) to see if this certificate can be allowed to login as user:login
+// pair to requested server.
+func (h *AuthHandlers) checkPermissionToLogin(cert *ssh.Certificate, clusterName string, teleportUser, osUser string) error {
+	log.Debugf("CheckPermsissionToLogin(%v, %v)", teleportUser, osUser)
+
+	// get the ca that signd the users certificate
+	ca, err := h.authorityForCert(cert.SignatureKey)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// get roles assigned to this user
+	roles, err := h.fetchRoleSet(cert, ca, teleportUser, clusterName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// check if roles allow access to server
+	if err := roles.CheckAccessToServer(osUser, h.Server); err != nil {
+		return trace.AccessDenied("user %s@%s is not authorized to login as %v@%s: %v",
+			teleportUser, ca.GetClusterName(), osUser, clusterName, err)
+	}
+
+	return nil
+}
+
+// fetchRoleSet fetches the services.RoleSet assigned to a Teleport user.
+func (h *AuthHandlers) fetchRoleSet(cert *ssh.Certificate, ca services.CertAuthority, teleportUser string, clusterName string) (services.RoleSet, error) {
+	// for local users, go and check their individual permissions
+	var roles services.RoleSet
+	if clusterName == ca.GetClusterName() {
+		users, err := h.AccessPoint.GetUsers()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		for _, u := range users {
+			if u.GetName() == teleportUser {
+				// pass along the traits so we get the substituted roles for this user
+				roles, err = services.FetchRoles(u.GetRoles(), h.AccessPoint, u.GetTraits())
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+			}
+		}
+	} else {
+		certRoles, err := extractRolesFromCert(cert)
+		if err != nil {
+			return nil, trace.AccessDenied("failed to parse certificate roles")
+		}
+		roleNames, err := ca.CombinedMapping().Map(certRoles)
+		if err != nil {
+			return nil, trace.AccessDenied("failed to map roles")
+		}
+		// pass the principals on the certificate along as the login traits
+		// to the remote cluster.
+		traits := map[string][]string{
+			teleport.TraitLogins: cert.ValidPrincipals,
+		}
+		roles, err = services.FetchRoles(roleNames, h.AccessPoint, traits)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return roles, nil
+}
+
+// isAuthority is called during checking the client key, to see if the signing
+// key is the real CA authority key.
+func (h *AuthHandlers) isAuthority(cert ssh.PublicKey) bool {
+	if _, err := h.authorityForCert(cert); err != nil {
+		return false
+	}
+	return true
+}
+
+// authorityForCert checks if the certificate was signed by a Teleport
+// Certificate Authority and returns it.
+func (h *AuthHandlers) authorityForCert(cert ssh.PublicKey) (services.CertAuthority, error) {
+	// get all user certificate authorities
+	cas, err := h.AccessPoint.GetCertAuthorities(services.UserCA, false)
+	if err != nil {
+		log.Warningf("%v", trace.DebugReport(err))
+		return nil, trace.Wrap(err)
+	}
+
+	// find the one that signed our certificate
+	var ca services.CertAuthority
+	for i := range cas {
+		checkers, err := cas[i].Checkers()
+		if err != nil {
+			log.Warningf("%v", err)
+			return nil, trace.Wrap(err)
+		}
+		for _, checker := range checkers {
+			if sshutils.KeysEqual(cert, checker) {
+				ca = cas[i]
+				break
+			}
+		}
+	}
+
+	// the certificate was signed by unknown authority
+	if ca == nil {
+		return nil, trace.AccessDenied("the certificate signed by untrusted CA")
+	}
+
+	return ca, nil
+}
+
+// extractRolesFromCert extracts roles from certificate metadata extensions.
+func extractRolesFromCert(cert *ssh.Certificate) ([]string, error) {
+	data, ok := cert.Extensions[teleport.CertExtensionTeleportRoles]
+	if !ok {
+		// it's ok to not have any roles in the metadata
+		return nil, nil
+	}
+	return services.UnmarshalCertRoles(data)
+}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -60,8 +60,7 @@ type Server struct {
 	namespace string
 	addr      utils.NetAddr
 	hostname  string
-	// certChecker checks the CA of the connecting user
-	certChecker   ssh.CertChecker
+
 	srv           *sshutils.Server
 	hostSigner    ssh.Signer
 	shell         string
@@ -112,6 +111,9 @@ type Server struct {
 	// macAlgorithms is a list of message authentication codes (MAC) that
 	// the server supports. If omitted the defaults will be used.
 	macAlgorithms []string
+
+	// authHandlers are common authorization and authentication related handlers.
+	authHandlers srv.AuthHandlers
 }
 
 func (s *Server) GetNamespace() string {
@@ -282,11 +284,19 @@ func New(addr utils.NetAddr,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	s.certChecker = ssh.CertChecker{IsAuthority: s.isAuthority}
+
 	for _, o := range options {
 		if err := o(s); err != nil {
 			return nil, trace.Wrap(err)
 		}
+	}
+
+	// add in common auth handlers
+	s.authHandlers = srv.AuthHandlers{
+		Server:      s.getInfo(),
+		ProxyMode:   s.proxyMode,
+		AuditLog:    s.alog,
+		AccessPoint: s.authService,
 	}
 
 	var component string
@@ -300,7 +310,7 @@ func New(addr utils.NetAddr,
 	server, err := sshutils.NewServer(
 		component,
 		addr, s, signers,
-		sshutils.AuthMethods{PublicKey: s.keyAuth},
+		sshutils.AuthMethods{PublicKey: s.authHandlers.KeyAuth},
 		sshutils.SetLimiter(s.limiter),
 		sshutils.SetRequestHandler(s),
 		sshutils.SetCiphers(s.ciphers),
@@ -460,166 +470,52 @@ func (s *Server) getCommandLabels() map[string]services.CommandLabel {
 	return out
 }
 
-// extractRolesFromCert extracts roles from certificate metadata extensions
-func (s *Server) extractRolesFromCert(cert *ssh.Certificate) ([]string, error) {
-	data, ok := cert.Extensions[teleport.CertExtensionTeleportRoles]
-	if !ok {
-		// it's ok to not have any roles in the metadata
-		return nil, nil
-	}
-	return services.UnmarshalCertRoles(data)
-}
-
-// checkPermissionToLogin checks the given certificate (supplied by a connected client)
-// to see if this certificate can be allowed to login as user:login pair
-func (s *Server) checkPermissionToLogin(cert *ssh.Certificate, teleportUser, osUser string) (string, error) {
-	// enumerate all known CAs and see if any of them signed the
-	// supplied certificate
-	log.Debugf("[HA SSH NODE] checkPermsissionToLogin(%v, %v)", teleportUser, osUser)
-	cas, err := s.authService.GetCertAuthorities(services.UserCA, false)
+// serveAgent will build the a sock path for this user and serve an SSH agent on unix socket.
+func (s *Server) serveAgent(ctx *srv.ServerContext) error {
+	// gather information about user and process. this will be used to set the
+	// socket path and permissions
+	systemUser, err := user.Lookup(ctx.Login)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return trace.ConvertSystemError(err)
 	}
-	var ca services.CertAuthority
-	for i := range cas {
-		checkers, err := cas[i].Checkers()
-		if err != nil {
-			return "", trace.Wrap(err)
-		}
-		for _, checker := range checkers {
-			if sshutils.KeysEqual(cert.SignatureKey, checker) {
-				ca = cas[i]
-				break
-			}
-		}
-	}
-	// the certificate was signed by unknown authority
-	if ca == nil {
-		return "", trace.AccessDenied(
-			"the certificate for user '%v' is signed by untrusted CA",
-			teleportUser)
-	}
-
-	domainName, err := s.authService.GetDomainName()
+	uid, err := strconv.Atoi(systemUser.Uid)
 	if err != nil {
-		return "", trace.Wrap(err)
+		return trace.Wrap(err)
 	}
-
-	// for local users, go and check their individual permissions
-	var roles services.RoleSet
-	if domainName == ca.GetClusterName() {
-		users, err := s.authService.GetUsers()
-		if err != nil {
-			return "", trace.Wrap(err)
-		}
-		for _, u := range users {
-			if u.GetName() == teleportUser {
-				// pass along the traits so we get the substituted roles for this user
-				roles, err = services.FetchRoles(u.GetRoles(), s.authService, u.GetTraits())
-				if err != nil {
-					return "", trace.Wrap(err)
-				}
-			}
-		}
-	} else {
-		certRoles, err := s.extractRolesFromCert(cert)
-		if err != nil {
-			log.Errorf("failed to extract roles from cert: %v", err)
-			return "", trace.AccessDenied("failed to parse certificate roles")
-		}
-		roleNames, err := ca.CombinedMapping().Map(certRoles)
-		if err != nil {
-			log.Errorf("failed to map roles %v", err)
-			return "", trace.AccessDenied("failed to map roles")
-		}
-		// pass the principals on the certificate along as the login traits
-		// to the remote cluster.
-		traits := map[string][]string{
-			teleport.TraitLogins: cert.ValidPrincipals,
-		}
-		roles, err = services.FetchRoles(roleNames, s.authService, traits)
-		if err != nil {
-			return "", trace.Wrap(err)
-		}
-	}
-
-	if err := roles.CheckAccessToServer(osUser, s.getInfo()); err != nil {
-		return "", trace.AccessDenied("user %s@%s is not authorized to login as %v@%s: %v",
-			teleportUser, ca.GetClusterName(), osUser, domainName, err)
-	}
-
-	return domainName, nil
-}
-
-// fetchRoleSet fretches role set for a given user
-func (s *Server) fetchRoleSet(teleportUser string, clusterName string) (services.RoleSet, error) {
-	localClusterName, err := s.authService.GetDomainName()
+	gid, err := strconv.Atoi(systemUser.Gid)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
+	pid := os.Getpid()
 
-	cas, err := s.authService.GetCertAuthorities(services.UserCA, false)
+	// build the socket path and set permissions
+	socketDir, err := ioutil.TempDir(os.TempDir(), "teleport-")
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
+	}
+	dirCloser := &utils.RemoveDirCloser{Path: socketDir}
+	socketPath := filepath.Join(socketDir, fmt.Sprintf("teleport-%v.socket", pid))
+	if err := os.Chown(socketDir, uid, gid); err != nil {
+		if err := dirCloser.Close(); err != nil {
+			log.Warn("failed to remove directory: %v", err)
+		}
+		return trace.ConvertSystemError(err)
 	}
 
-	var ca services.CertAuthority
-	for i := range cas {
-		if cas[i].GetClusterName() == clusterName {
-			ca = cas[i]
-			break
-		}
-	}
-	if ca == nil {
-		return nil, trace.NotFound("could not find certificate authority for cluster %v and user %v", clusterName, teleportUser)
-	}
-
-	var roles services.RoleSet
-	if localClusterName == clusterName {
-		users, err := s.authService.GetUsers()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		for _, u := range users {
-			if u.GetName() == teleportUser {
-				roles, err = services.FetchRoles(u.GetRoles(), s.authService, u.GetTraits())
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-			}
-		}
-	} else {
-		roles, err = services.FetchRoles(ca.GetRoles(), s.authService, nil)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	return roles, err
-}
-
-// isAuthority is called during checking the client key, to see if the signing
-// key is the real CA authority key.
-func (s *Server) isAuthority(cert ssh.PublicKey) bool {
-	// find cert authority by it's key
-	cas, err := s.authService.GetCertAuthorities(services.UserCA, false)
+	// start an agent on a unix socket
+	agentServer := &teleagent.AgentServer{Agent: ctx.GetAgent()}
+	err = agentServer.ListenUnixSocket(socketPath, uid, gid, 0600)
 	if err != nil {
-		log.Warningf("%v", trace.DebugReport(err))
-		return false
+		return trace.Wrap(err)
 	}
+	ctx.SetEnv(teleport.SSHAuthSock, socketPath)
+	ctx.SetEnv(teleport.SSHAgentPID, fmt.Sprintf("%v", pid))
+	ctx.AddCloser(agentServer)
+	ctx.AddCloser(dirCloser)
+	ctx.Debugf("[SSH:node] opened agent channel for teleport user %v and socket %v", ctx.TeleportUser, socketPath)
+	go agentServer.Serve()
 
-	for i := range cas {
-		checkers, err := cas[i].Checkers()
-		if err != nil {
-			log.Warningf("%v", err)
-			return false
-		}
-		for _, checker := range checkers {
-			if sshutils.KeysEqual(cert, checker) {
-				return true
-			}
-		}
-	}
-	return false
+	return nil
 }
 
 // EmitAuditEvent logs a given event to the audit log attached to the
@@ -634,88 +530,6 @@ func (s *Server) EmitAuditEvent(eventType string, fields events.EventFields) {
 	} else {
 		log.Warn("SSH server has no audit log")
 	}
-}
-
-// keyAuth implements SSH client authentication using public keys and is called
-// by the server every time the client connects
-func (s *Server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-	cid := fmt.Sprintf("conn(%v->%v, user=%v)", conn.RemoteAddr(), conn.LocalAddr(), conn.User())
-	fingerprint := fmt.Sprintf("%v %v", key.Type(), sshutils.Fingerprint(key))
-	log.Debugf("[SSH] %v auth attempt with key %v", cid, fingerprint)
-
-	logger := log.WithFields(log.Fields{
-		"local":       conn.LocalAddr(),
-		"remote":      conn.RemoteAddr(),
-		"user":        conn.User(),
-		"fingerprint": fingerprint,
-	})
-
-	cert, ok := key.(*ssh.Certificate)
-	log.Debugf("[SSH] %v auth attempt with key %v, %#v", cid, fingerprint, cert)
-	if !ok {
-		log.Debugf("[SSH] auth attempt, unsupported key type for %v", fingerprint)
-		return nil, trace.BadParameter("unsupported key type: %v", fingerprint)
-	}
-	if len(cert.ValidPrincipals) == 0 {
-		log.Debugf("[SSH] need a valid principal for key %v", fingerprint)
-		return nil, trace.BadParameter("need a valid principal for key %v", fingerprint)
-	}
-
-	if len(cert.KeyId) == 0 {
-		log.Debugf("[SSH] need a valid key ID for key %v", fingerprint)
-		return nil, trace.BadParameter("need a valid key for key %v", fingerprint)
-	}
-	teleportUser := cert.KeyId
-
-	logAuditEvent := func(err error) {
-		// only failed attempts are logged right now
-		if err != nil {
-			fields := events.EventFields{
-				events.EventUser:          teleportUser,
-				events.AuthAttemptSuccess: false,
-				events.AuthAttemptErr:     err.Error(),
-			}
-			log.Warningf("[SSH] failed login attempt %#v", fields)
-			s.EmitAuditEvent(events.AuthAttemptEvent, fields)
-		}
-	}
-	permissions, err := s.certChecker.Authenticate(conn, key)
-	if err != nil {
-		logAuditEvent(err)
-		return nil, trace.Wrap(err)
-	}
-	if err := s.certChecker.CheckCert(conn.User(), cert); err != nil {
-		logAuditEvent(err)
-		return nil, trace.Wrap(err)
-	}
-	logger.Debugf("[SSH] successfully authenticated")
-
-	// see if the host user is valid (no need to do this in proxy mode)
-	if !s.proxyMode {
-		_, err = user.Lookup(conn.User())
-		if err != nil {
-			host, _ := os.Hostname()
-			logger.Warningf("host '%s' does not have OS user '%s'", host, conn.User())
-			logger.Errorf("no such user")
-			return nil, trace.AccessDenied("no such user: '%s'", conn.User())
-		}
-	}
-
-	// this is the only way we know of to pass valid principal with the
-	// connection
-	permissions.Extensions[utils.CertTeleportUser] = teleportUser
-
-	if s.proxyMode {
-		return permissions, nil
-	}
-	clusterName, err := s.checkPermissionToLogin(cert, teleportUser, conn.User())
-	if err != nil {
-		logger.Errorf("Permission denied: %v", err)
-		logAuditEvent(err)
-		return nil, trace.Wrap(err)
-	}
-	permissions.Extensions[utils.CertTeleportClusterName] = clusterName
-	return permissions, nil
 }
 
 // HandleRequest is a callback for handling global out-of-band requests.
@@ -933,70 +747,44 @@ func (s *Server) dispatch(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerConte
 		// https://tools.ietf.org/html/draft-ietf-secsh-agent-02
 		// the open ssh proto spec that we implement is here:
 		// http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.agent
-		return s.handleAgentForward(ch, req, ctx)
+
+		// to maintain interoperability with OpenSSH, agent forwarding requests
+		// should never fail, all errors should be logged and we should continue
+		// processing requests.
+		err := s.handleAgentForwardNode(ch, req, ctx)
+		if err != nil {
+			log.Info(err)
+		}
+		return nil
 	default:
 		return trace.BadParameter(
 			"proxy doesn't support request type '%v'", req.Type)
 	}
 }
 
-func (s *Server) handleAgentForward(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
-	roles, err := s.fetchRoleSet(ctx.TeleportUser, ctx.ClusterName)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if err := roles.CheckAgentForward(ctx.Login); err != nil {
-		log.Warningf("[SSH:node] denied forward agent %v", err)
-		return trace.Wrap(err)
-	}
-	systemUser, err := user.Lookup(ctx.Login)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	uid, err := strconv.Atoi(systemUser.Uid)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	gid, err := strconv.Atoi(systemUser.Gid)
+// handleAgentForwardNode will create a unix socket and serve the agent running
+// on the client on it.
+func (s *Server) handleAgentForwardNode(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
+	// check if the users rbac role allows agent forwarding
+	err := s.authHandlers.CheckAgentForward(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
+	// open a channel to the client where the client will serve an agent
 	authChan, _, err := ctx.Conn.OpenChannel("auth-agent@openssh.com", nil)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	clientAgent := agent.NewClient(authChan)
-	ctx.SetAgent(clientAgent, authChan)
 
-	pid := os.Getpid()
-	socketDir, err := ioutil.TempDir(os.TempDir(), "teleport-")
+	// save the agent in the context so it can be used later
+	ctx.SetAgent(agent.NewClient(authChan), authChan)
+
+	// serve an agent on a unix socket on this node
+	err = s.serveAgent(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	dirCloser := &utils.RemoveDirCloser{Path: socketDir}
-	socketPath := filepath.Join(socketDir, fmt.Sprintf("teleport-%v.socket", pid))
-	if err := os.Chown(socketDir, uid, gid); err != nil {
-		if err := dirCloser.Close(); err != nil {
-			log.Warn("failed to remove directory: %v", err)
-		}
-		return trace.ConvertSystemError(err)
-	}
-
-	agentServer := &teleagent.AgentServer{Agent: clientAgent}
-	err = agentServer.ListenUnixSocket(socketPath, uid, gid, 0600)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if req.WantReply {
-		req.Reply(true, nil)
-	}
-	ctx.SetEnv(teleport.SSHAuthSock, socketPath)
-	ctx.SetEnv(teleport.SSHAgentPID, fmt.Sprintf("%v", pid))
-	ctx.AddCloser(agentServer)
-	ctx.AddCloser(dirCloser)
-	ctx.Debugf("[SSH:node] opened agent channel for teleport user %v and socket %v", ctx.TeleportUser, socketPath)
-	go agentServer.Serve()
 
 	return nil
 }

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -291,19 +291,23 @@ func New(addr utils.NetAddr,
 		}
 	}
 
-	// add in common auth handlers
-	s.authHandlers = srv.AuthHandlers{
-		Server:      s.getInfo(),
-		ProxyMode:   s.proxyMode,
-		AuditLog:    s.alog,
-		AccessPoint: s.authService,
-	}
-
 	var component string
 	if s.proxyMode {
 		component = teleport.ComponentProxy
 	} else {
 		component = teleport.ComponentNode
+	}
+
+	// add in common auth handlers
+	s.authHandlers = srv.AuthHandlers{
+		Entry: log.WithFields(log.Fields{
+			trace.Component:       component,
+			trace.ComponentFields: log.Fields{},
+		}),
+		Server:      s.getInfo(),
+		Component:   component,
+		AuditLog:    s.alog,
+		AccessPoint: s.authService,
 	}
 
 	s.reg = srv.NewSessionRegistry(s)

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -226,6 +226,8 @@ const (
 	CertExtensionAuthority = "x-teleport-authority"
 	// HostUUIDFile is the file name where the host UUID file is stored
 	HostUUIDFile = "host_uuid"
-	// CertTeleportClusterName  is a name of the teleport cluster
+	// CertTeleportClusterName is a name of the teleport cluster
 	CertTeleportClusterName = "x-teleport-cluster-name"
+	// CertTeleportUserCertificate is the certificate of the authenticated in user.
+	CertTeleportUserCertificate = "x-teleport-certificate"
 )


### PR DESCRIPTION
**Purpose**

As covered in #1452, Teleport has a lot of code duplication `srv/regular/sshserver.go`. This PR consolidates to code and moves it it to an `AuthHandlers` structure that can be reused the forwarding server as well as fixes a bug in the regular handler.

**Implementation**

* Save the SSH certificate in the context so it can be passed to handlers.
* Consolidate authorization and authentication code in `AuthHandlers`.
* Fix issue where incorrect cluster permissions were being checked for agent forwarding.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1452