### PR TITLE
Allow agent forwarding from Web UI and tsh

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -111,6 +111,10 @@ const (
 	// pining each other with it:
 	KeepAliveReqType = "keepalive@openssh.com"
 
+	// RecordingProxyReqType is the name of a global request which returns if
+	// the proxy is recording sessions or not.
+	RecordingProxyReqType = "recording-proxy@teleport.com"
+
 	// OTP means One-time Password Algorithm for Two-Factor Authentication.
 	OTP = "otp"
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -125,6 +125,12 @@ type Config struct {
 	// against Teleport client and obtaining credentials from elsewhere.
 	SkipLocalAuth bool
 
+	// Agent is used when SkipLocalAuth is true
+	Agent agent.Agent
+
+	// ForwardAgent is used by the client to request agent forwarding from the server.
+	ForwardAgent bool
+
 	// AuthMethods are used to login into the cluster. If specified, the client will
 	// use them in addition to certs stored in its local agent (from disk)
 	AuthMethods []ssh.AuthMethod
@@ -367,6 +373,11 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 	if c.SkipLocalAuth {
 		if len(c.AuthMethods) == 0 {
 			return nil, trace.BadParameter("SkipLocalAuth is true but no AuthMethods provided")
+		}
+		// if the client was passed an agent in the configuration and skip local auth, use
+		// the passed in agent.
+		if c.Agent != nil {
+			tc.localAgent = &LocalKeyAgent{Agent: c.Agent}
 		}
 	} else {
 		// initialize the local agent (auth agent which uses local SSH keys signed by the CA):

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -179,6 +179,8 @@ func (t *TerminalHandler) Run(w http.ResponseWriter, r *http.Request) {
 		output := utils.NewWebSockWrapper(ws, utils.WebSocketTextMode)
 		clientConfig := &client.Config{
 			SkipLocalAuth:    true,
+			Agent:            agent,
+			ForwardAgent:     true,
 			AuthMethods:      []ssh.AuthMethod{auth},
 			DefaultPrincipal: principal,
 			HostLogin:        t.params.Login,

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -74,6 +74,8 @@ type CLIConf struct {
 	RecursiveCopy bool
 	// -L flag for ssh. Local port forwarding like 'ssh -L 80:remote.host:80 -L 443:remote.host:443'
 	LocalForwardPorts []string
+	// ForwardAgent agent to target node. Equivalent of -A for OpenSSH.
+	ForwardAgent bool
 	// --local flag for ssh
 	LocalExec bool
 	// SiteName specifies remote site go login to
@@ -167,6 +169,7 @@ func Run(args []string, underTest bool) {
 	ssh.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cf.UserHost)
 	ssh.Arg("command", "Command to execute on a remote host").StringsVar(&cf.RemoteCommand)
 	ssh.Flag("port", "SSH port on a remote host").Short('p').Int16Var(&cf.NodePort)
+	ssh.Flag("forward-agent", "Forward agent to target node").Short('A').BoolVar(&cf.ForwardAgent)
 	ssh.Flag("forward", "Forward localhost connections to remote server").Short('L').StringsVar(&cf.LocalForwardPorts)
 	ssh.Flag("local", "Execute command on localhost after connecting to SSH node").Default("false").BoolVar(&cf.LocalExec)
 	ssh.Flag("tty", "Allocate TTY").Short('t').BoolVar(&cf.Interactive)
@@ -598,6 +601,9 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 
 	// copy the authentication connector over
 	c.AuthConnector = cf.AuthConnector
+
+	// copy over if we want agent forwarding or not
+	c.ForwardAgent = cf.ForwardAgent
 
 	return client.NewClient(c)
 }


### PR DESCRIPTION
**Purpose**

This PR adds the ability to forward your Teleport agent both using `tsh` and the Web UI. Note, the system agent is not forwarded in either case, we forward the Teleport agent only.

`tsh` supports for the `-A` flag which allows you the option to forward or not forward your agent. The Web UI will always attempt to forward our agent. If agent forwarding either not allowed by RBAC rules or policy on the node, the user will still be able to login, but their agent will not be forwarded.

**Implementation**

* Config for Teleport Client supports `ForwardAgent` boolean.
* Added support for `-A` in `tsh` to toggle `ForwardAgent`.
* Web UI always sets `ForwardAgent` to true.
* We always try and forward agent to proxy. We do this to lay the groundwork for the recording proxy where this will be required. This does not cause problems and is not a security risk because it's a NOP in the regular server.
* When we create a session if `ForwardAgent` is true, we request agent forwarding.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1000