### PR TITLE
fix audit log file leak, fixes #1433

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -156,10 +156,10 @@
   version = "1.1.1"
 
 [[projects]]
-  branch = "master"
   name = "github.com/gravitational/ttlmap"
   packages = ["."]
-  revision = "348cf76cace4d93fdacc38dfdaa2306f4f0e9c16"
+  revision = "91fd36b9004c1ee5a778739752ea1aba5638c03a"
+  version = "0.0.1"
 
 [[projects]]
   name = "github.com/grpc-ecosystem/grpc-gateway"
@@ -392,6 +392,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "735b82dec018f4584f873438cf8cf57ba19f1a65643656fd2f9ad659be7403b9"
+  inputs-digest = "0d5ba19796a8723d2194ffa3917e3374eed4638672d291c10bf7013e159e4bdb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -83,7 +83,7 @@ ignored = ["github.com/Sirupsen/logrus"]
   name = "github.com/gravitational/roundtrip"
 
 [[constraint]]
-  branch = "master"
+  version = "0.0.1"
   name = "github.com/gravitational/ttlmap"
 
 [[constraint]]

--- a/constants.go
+++ b/constants.go
@@ -79,6 +79,9 @@ const (
 	// ComponentSubsystemProxy is the proxy subsystem.
 	ComponentSubsystemProxy = "subsystem:proxy"
 
+	// ComponentAuditLog is audit log component
+	ComponentAuditLog = "auditlog"
+
 	// DebugEnvVar tells tests to use verbose debug output
 	DebugEnvVar = "DEBUG"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,20 @@ services:
           - one-lb
 
   #
+  # one-node is a single-node Teleport cluster called "one" (runs all 3 roles: proxy, auth and node)
+  #
+  one-node:
+    image: teleport:latest
+    container_name: one-node
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one-node.yaml
+    env_file: env.file
+    volumes:
+      - ../:/root/go/src/github.com/gravitational/teleport
+    networks:
+      teleport:
+        ipv4_address: 172.10.1.20
+
+  #
   # one-proxy is a second xproxy of the first cluster
   #
   one-proxy:

--- a/docker/one-node.yaml
+++ b/docker/one-node.yaml
@@ -1,7 +1,6 @@
-# Single-node Teleport cluster called "one" (runs all 3 roles: proxy, auth and node)
 teleport:
-  nodename: one
-  advertise_ip: 172.10.1.1
+  auth_servers: ["one"]
+  auth_token: foo
   log:
     output: /var/lib/teleport/teleport.log
     severity: INFO
@@ -12,15 +11,7 @@ teleport:
       type: dir
 
 auth_service:
-  enabled: yes
-
-  authentication:
-    type: oidc
-
-  cluster_name: one
-  tokens: 
-       - "node,auth,proxy:foo"
-       - "trustedcluster:bar"
+  enabled: no
 
 ssh_service:
   enabled: yes
@@ -32,5 +23,5 @@ ssh_service:
         period: 5m
 
 proxy_service:
-  enabled: yes
+  enabled: no
 

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -72,7 +72,8 @@ func (s *APISuite) SetUpTest(c *C) {
 	s.bk, err = boltbk.New(backend.Params{"path": dir})
 	c.Assert(err, IsNil)
 
-	s.alog, err = events.NewAuditLog(dir, true)
+	s.alog, err = events.NewAuditLog(events.AuditLogConfig{
+		DataDir: dir, RecordSessions: true})
 	c.Assert(err, IsNil)
 
 	s.a = NewAuthServer(&InitConfig{

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"io"
 	"net/url"
 	"time"
@@ -997,6 +998,10 @@ func (a *AuthWithRoles) DeleteAllTunnelConnections() error {
 
 func (a *AuthWithRoles) Close() error {
 	return a.authServer.Close()
+}
+
+func (a *AuthWithRoles) Wait(context.Context) error {
+	return nil
 }
 
 // NewAuthWithRoles creates new auth server with access control

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1000,7 +1000,7 @@ func (a *AuthWithRoles) Close() error {
 	return a.authServer.Close()
 }
 
-func (a *AuthWithRoles) Wait(context.Context) error {
+func (a *AuthWithRoles) WaitForDelivery(context.Context) error {
 	return nil
 }
 

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -18,6 +18,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -215,6 +216,10 @@ func (c *Client) GetDomainName() (string, error) {
 }
 
 func (c *Client) Close() error {
+	return nil
+}
+
+func (c *Client) Wait(context.Context) error {
 	return nil
 }
 

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -219,7 +219,7 @@ func (c *Client) Close() error {
 	return nil
 }
 
-func (c *Client) Wait(context.Context) error {
+func (c *Client) WaitForDelivery(context.Context) error {
 	return nil
 }
 

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -69,7 +69,8 @@ func (s *TunSuite) SetUpTest(c *C) {
 	s.bk, err = dir.New(backend.Params{"path": s.dir})
 	c.Assert(err, IsNil)
 
-	s.alog, err = events.NewAuditLog(s.dir, true)
+	s.alog, err = events.NewAuditLog(events.AuditLogConfig{
+		DataDir: s.dir, RecordSessions: true})
 	c.Assert(err, IsNil)
 
 	s.sessionServer, err = session.New(s.bk)

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -145,6 +145,10 @@ const (
 
 	// AttemptTTL is TTL for login attempt
 	AttemptTTL = time.Minute * 30
+
+	// AuditLogSessions is the default expected amount of concurrent sessions
+	// supported by Audit logger
+	AuditLogSessions = 16384
 )
 
 var (
@@ -169,6 +173,10 @@ var (
 	// TODO(klizhentas) all polling periods should go away once backend
 	// releases events
 	SessionRefreshPeriod = 2 * time.Second
+
+	// SessionIdlePeriod is the period of inactivity after which the
+	// session will be considered idle
+	SessionIdlePeriod = SessionRefreshPeriod * 10
 
 	// TerminalSizeRefreshPeriod is how frequently clients who share sessions sync up
 	// their terminal sizes

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -147,7 +147,9 @@ const (
 	AttemptTTL = time.Minute * 30
 
 	// AuditLogSessions is the default expected amount of concurrent sessions
-	// supported by Audit logger
+	// supported by Audit logger, this number limits the possible
+	// amount of simultaneously processes concurrent sessions by the
+	// Audit log server, and 16K is OK for now
 	AuditLogSessions = 16384
 )
 

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package events
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
@@ -107,6 +108,7 @@ type IAuditLog interface {
 	// Closer releases connection and resources associated with log if any
 	io.Closer
 
+	// EmitAuditEvent emits audit event
 	EmitAuditEvent(eventType string, fields EventFields) error
 
 	// PostSessionSlice sends chunks of recorded session to the event log
@@ -145,6 +147,10 @@ type IAuditLog interface {
 	// SearchSessionEvents returns session related events only. This is used to
 	// find completed session.
 	SearchSessionEvents(fromUTC time.Time, toUTC time.Time) ([]EventFields, error)
+
+	// Wait waits for resources to be released and outstanding requests to
+	// complete after calling Close method
+	Wait(context.Context) error
 }
 
 // EventFields instance is attached to every logged event

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -148,9 +148,9 @@ type IAuditLog interface {
 	// find completed session.
 	SearchSessionEvents(fromUTC time.Time, toUTC time.Time) ([]EventFields, error)
 
-	// Wait waits for resources to be released and outstanding requests to
+	// WaitForDelivery waits for resources to be released and outstanding requests to
 	// complete after calling Close method
-	Wait(context.Context) error
+	WaitForDelivery(context.Context) error
 }
 
 // EventFields instance is attached to every logged event

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -160,7 +160,7 @@ func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 	return al, nil
 }
 
-func (l *AuditLog) Wait(context.Context) error {
+func (l *AuditLog) WaitForDelivery(context.Context) error {
 	return nil
 }
 
@@ -192,7 +192,6 @@ func (l *AuditLog) migrateSessions() error {
 
 // PostSessionSlice submits slice of session chunks to the audit log server.
 func (l *AuditLog) PostSessionSlice(slice SessionSlice) error {
-	l.Debugf("PostSessionSlice(%s)", slice.SessionID)
 	if slice.Namespace == "" {
 		return trace.BadParameter("missing parameter Namespace")
 	}

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -92,7 +92,7 @@ type AuditLog struct {
 	fileTime time.Time
 }
 
-// AuditLogConfig specifies configuration
+// AuditLogConfig specifies configuration for AuditLog server
 type AuditLogConfig struct {
 	// DataDir is the directory where audit log stores the data
 	DataDir string
@@ -131,7 +131,7 @@ func (a *AuditLogConfig) CheckAndSetDefaults() error {
 // Creates and returns a new Audit Log oboject whish will store its logfiles in
 // a given directory. Session recording can be disabled by setting
 // recordSessions to false.
-func NewAuditLog(cfg AuditLogConfig) (IAuditLog, error) {
+func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -150,7 +150,7 @@ func NewAuditLog(cfg AuditLogConfig) (IAuditLog, error) {
 	loggers, err := ttlmap.New(defaults.AuditLogSessions,
 		ttlmap.CallOnExpire(al.asyncCloseSessionLogger), ttlmap.Clock(cfg.Clock))
 	if err != nil {
-		return nil, err
+		return nil, trace.Wrap(err)
 	}
 	al.loggers = loggers
 	if err := al.migrateSessions(); err != nil {
@@ -614,7 +614,7 @@ func (l *AuditLog) closeInactiveLoggers() {
 
 	expired := l.loggers.RemoveExpired(10)
 	if expired != 0 {
-		l.Infof("closed %v inactive session loggers", expired)
+		l.Debugf("closed %v inactive session loggers", expired)
 	}
 }
 

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -19,6 +19,7 @@ package events
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,11 +31,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
+	"github.com/gravitational/ttlmap"
+	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
@@ -70,14 +74,14 @@ func init() {
 	prometheus.MustRegister(auditOpenFiles)
 }
 
-type TimeSourceFunc func() time.Time
-
 // AuditLog is a new combined facility to record Teleport events and
 // sessions. It implements IAuditLog
 type AuditLog struct {
 	sync.Mutex
-	loggers map[session.ID]SessionLogger
-	dataDir string
+	*log.Entry
+	AuditLogConfig
+
+	loggers *ttlmap.TTLMap
 
 	// file is the current global event log file. As the time goes
 	// on, it will be replaced by a new file every day
@@ -86,43 +90,83 @@ type AuditLog struct {
 	// fileTime is a rounded (to a day, by default) timestamp of the
 	// currently opened file
 	fileTime time.Time
+}
+
+// AuditLogConfig specifies configuration
+type AuditLogConfig struct {
+	// DataDir is the directory where audit log stores the data
+	DataDir string
+
+	// RecordSessions controls if sessions are recorded along with audit events.
+	RecordSessions bool
 
 	// RotationPeriod defines how frequently to rotate the log file
 	RotationPeriod time.Duration
 
-	// same as time.Now(), but helps with testing
-	TimeSource TimeSourceFunc
+	// SessionIdlePeriod defines the period after which sessions will be considered
+	// idle (and audit log will free up some resources)
+	SessionIdlePeriod time.Duration
 
-	// recordSessions controls if sessions are recorded along with audit events.
-	recordSessions bool
+	// Clock is a clock either real one or used in tests
+	Clock clockwork.Clock
+}
+
+// CheckAndSetDefaults checks and sets defaults
+func (a *AuditLogConfig) CheckAndSetDefaults() error {
+	if a.DataDir == "" {
+		return trace.BadParameter("missing parameter DataDir")
+	}
+	if a.Clock == nil {
+		a.Clock = clockwork.NewRealClock()
+	}
+	if a.RotationPeriod == 0 {
+		a.RotationPeriod = defaults.LogRotationPeriod
+	}
+	if a.SessionIdlePeriod == 0 {
+		a.SessionIdlePeriod = defaults.SessionIdlePeriod
+	}
+	return nil
 }
 
 // Creates and returns a new Audit Log oboject whish will store its logfiles in
 // a given directory. Session recording can be disabled by setting
 // recordSessions to false.
-func NewAuditLog(dataDir string, recordSessions bool) (IAuditLog, error) {
+func NewAuditLog(cfg AuditLogConfig) (IAuditLog, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	// create a directory for session logs:
-	sessionDir := filepath.Join(dataDir, SessionLogsDir)
+	sessionDir := filepath.Join(cfg.DataDir, SessionLogsDir)
 	if err := os.MkdirAll(sessionDir, 0770); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	al := &AuditLog{
-		loggers:        make(map[session.ID]SessionLogger, 0),
-		dataDir:        dataDir,
-		RotationPeriod: defaults.LogRotationPeriod,
-		TimeSource:     time.Now,
-		recordSessions: recordSessions,
+		AuditLogConfig: cfg,
+		Entry: log.WithFields(log.Fields{
+			trace.Component: teleport.ComponentAuditLog,
+		}),
 	}
+	loggers, err := ttlmap.New(defaults.AuditLogSessions,
+		ttlmap.CallOnExpire(al.asyncCloseSessionLogger), ttlmap.Clock(cfg.Clock))
+	if err != nil {
+		return nil, err
+	}
+	al.loggers = loggers
 	if err := al.migrateSessions(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	go al.periodicCloseInactiveLoggers()
 	return al, nil
+}
+
+func (l *AuditLog) Wait(context.Context) error {
+	return nil
 }
 
 func (l *AuditLog) migrateSessions() error {
 	// if 'default' namespace does not exist, migrate old logs to the new location
-	sessionDir := filepath.Join(l.dataDir, SessionLogsDir)
+	sessionDir := filepath.Join(l.DataDir, SessionLogsDir)
 	targetDir := filepath.Join(sessionDir, defaults.Namespace)
 	_, err := utils.StatDir(targetDir)
 	if err == nil {
@@ -131,9 +175,9 @@ func (l *AuditLog) migrateSessions() error {
 	if !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
-	log.Infof("[MIGRATION] migrating sessions from %v to %v", sessionDir, filepath.Join(sessionDir, defaults.Namespace))
+	l.Infof("[MIGRATION] migrating sessions from %v to %v", sessionDir, filepath.Join(sessionDir, defaults.Namespace))
 	// can't directly rename dir to its own subdir, so using temp dir
-	tempDir := filepath.Join(l.dataDir, "___migrate")
+	tempDir := filepath.Join(l.DataDir, "___migrate")
 	if err := os.Rename(sessionDir, tempDir); err != nil {
 		return trace.ConvertSystemError(err)
 	}
@@ -148,6 +192,7 @@ func (l *AuditLog) migrateSessions() error {
 
 // PostSessionSlice submits slice of session chunks to the audit log server.
 func (l *AuditLog) PostSessionSlice(slice SessionSlice) error {
+	l.Debugf("PostSessionSlice(%s)", slice.SessionID)
 	if slice.Namespace == "" {
 		return trace.BadParameter("missing parameter Namespace")
 	}
@@ -156,6 +201,7 @@ func (l *AuditLog) PostSessionSlice(slice SessionSlice) error {
 	}
 	sl, err := l.LoggerFor(slice.Namespace, session.ID(slice.SessionID))
 	if err != nil {
+		l.Errorf("failed to get logger: %v", trace.DebugReport(err))
 		return trace.BadParameter("audit.log: no session writer for %s", slice.SessionID)
 	}
 	for i := range slice.Chunks {
@@ -174,7 +220,7 @@ func (l *AuditLog) PostSessionChunk(namespace string, sid session.ID, reader io.
 		return trace.Wrap(err)
 	}
 	chunk := &SessionChunk{
-		Time: l.TimeSource().In(time.UTC).UnixNano(),
+		Time: l.Clock.Now().In(time.UTC).UnixNano(),
 		Data: tmp,
 	}
 	return l.PostSessionSlice(SessionSlice{
@@ -189,7 +235,7 @@ func (l *AuditLog) PostSessionChunk(namespace string, sid session.ID, reader io.
 // session stream range from offsetBytes to offsetBytes+maxBytes
 //
 func (l *AuditLog) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
-	log.Debugf("audit.log: getSessionReader(%v, %v)", namespace, sid)
+	l.Debugf("getSessionReader(%v, %v)", namespace, sid)
 	if namespace == "" {
 		return nil, trace.BadParameter("missing parameter namespace")
 	}
@@ -252,7 +298,7 @@ func (l *AuditLog) GetSessionEvents(namespace string, sid session.ID, afterN int
 
 // EmitAuditEvent adds a new event to the log. Part of auth.IAuditLog interface.
 func (l *AuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
-	log.Debugf("auditLog.EmitAuditEvent(%s)", eventType)
+	l.Debugf("EmitAuditEvent(%v: %v)", eventType, fields)
 
 	// see if the log needs to be rotated
 	if err := l.rotateLog(); err != nil {
@@ -261,7 +307,7 @@ func (l *AuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
 
 	// set event type and time:
 	fields[EventType] = eventType
-	fields[EventTime] = l.TimeSource().In(time.UTC).Round(time.Second)
+	fields[EventTime] = l.Clock.Now().In(time.UTC).Round(time.Second)
 
 	// line is the text to be logged
 	line := eventToLine(fields)
@@ -275,16 +321,16 @@ func (l *AuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
 
 			// Session ended? Get rid of the session logger then:
 			if eventType == SessionEndEvent {
-				log.Debugf("audit log: removing session logger for SID=%v", sessionID)
+				l.Debugf("removing session logger for SID=%v", sessionID)
 				l.Lock()
-				delete(l.loggers, session.ID(sessionID))
+				l.loggers.Remove(sessionID)
 				l.Unlock()
 				if err := sl.Finalize(); err != nil {
 					log.Error(err)
 				}
 			}
 		} else {
-			log.Warning(err.Error())
+			l.Errorf("failed to get logger: %v", trace.DebugReport(err))
 		}
 	}
 	// log it to the main log file:
@@ -296,7 +342,7 @@ func (l *AuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
 
 // SearchEvents finds events. Results show up sorted by date (newest first)
 func (l *AuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]EventFields, error) {
-	log.Infof("auditLog.SearchEvents(%v, %v, query=%v)", fromUTC, toUTC, query)
+	l.Debugf("SearchEvents(%v, %v, query=%v)", fromUTC, toUTC, query)
 	queryVals, err := url.ParseQuery(query)
 	if err != nil {
 		return nil, trace.BadParameter("missing parameter query", query)
@@ -308,7 +354,7 @@ func (l *AuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]Event
 	}
 
 	// scan the log directory:
-	df, err := os.Open(l.dataDir)
+	df, err := os.Open(l.DataDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -334,7 +380,7 @@ func (l *AuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]Event
 	// search within each file:
 	events := make([]EventFields, 0)
 	for i := range filtered {
-		found, err := l.findInFile(filepath.Join(l.dataDir, filtered[i].Name()), queryVals)
+		found, err := l.findInFile(filepath.Join(l.DataDir, filtered[i].Name()), queryVals)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -345,7 +391,7 @@ func (l *AuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]Event
 
 // SearchSessionEvents searches for session related events. Used to find completed sessions.
 func (l *AuditLog) SearchSessionEvents(fromUTC, toUTC time.Time) ([]EventFields, error) {
-	log.Infof("auditLog.SearchSessionEvents(%v, %v)", fromUTC, toUTC)
+	l.Infof("SearchSessionEvents(%v, %v)", fromUTC, toUTC)
 
 	// only search for specific event types
 	query := url.Values{}
@@ -369,7 +415,7 @@ func (f byDate) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }
 //
 // You can pass multiple types like "event=session.start&event=session.end"
 func (l *AuditLog) findInFile(fn string, query url.Values) ([]EventFields, error) {
-	log.Infof("auditLog.findInFile(%s, %v)", fn, query)
+	l.Infof("findInFile(%s, %v)", fn, query)
 	retval := make([]EventFields, 0)
 
 	eventFilter := query[EventType]
@@ -401,7 +447,7 @@ func (l *AuditLog) findInFile(fn string, query url.Values) ([]EventFields, error
 		// in the query:
 		var ef EventFields
 		if err = json.Unmarshal(scanner.Bytes(), &ef); err != nil {
-			log.Warnf("invalid JSON in %s line %d", fn, lineNo)
+			l.Warnf("invalid JSON in %s line %d", fn, lineNo)
 		}
 		for i := range eventFilter {
 			if ef.GetString(EventType) == eventFilter[i] {
@@ -420,12 +466,12 @@ func (l *AuditLog) findInFile(fn string, query url.Values) ([]EventFields, error
 // and if it is, closes it and opens a new one
 func (l *AuditLog) rotateLog() (err error) {
 	// determine the timestamp for the current log file
-	fileTime := l.TimeSource().In(time.UTC).Round(l.RotationPeriod)
+	fileTime := l.Clock.Now().In(time.UTC).Round(l.RotationPeriod)
 
 	openLogFile := func() error {
 		l.Lock()
 		defer l.Unlock()
-		logfname := filepath.Join(l.dataDir,
+		logfname := filepath.Join(l.DataDir,
 			fileTime.Format("2006-01-02.15:04:05")+LogfileExt)
 		l.file, err = os.OpenFile(logfname, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
 		if err != nil {
@@ -457,9 +503,14 @@ func (l *AuditLog) Close() error {
 		l.file.Close()
 		l.file = nil
 	}
-	for sid, logger := range l.loggers {
-		logger.Close()
-		delete(l.loggers, sid)
+
+	// close any open sessions that haven't expired yet and are open
+	for {
+		key, value, found := l.loggers.Pop()
+		if !found {
+			break
+		}
+		l.closeSessionLogger(key, value)
 	}
 	return nil
 }
@@ -468,7 +519,7 @@ func (l *AuditLog) Close() error {
 // session by its ID
 func (l *AuditLog) sessionStreamFn(namespace string, sid session.ID) string {
 	return filepath.Join(
-		l.dataDir,
+		l.DataDir,
 		SessionLogsDir,
 		namespace,
 		fmt.Sprintf("%s%s", sid, SessionStreamPrefix))
@@ -478,7 +529,7 @@ func (l *AuditLog) sessionStreamFn(namespace string, sid session.ID) string {
 // session by its ID
 func (l *AuditLog) sessionLogFn(namespace string, sid session.ID) string {
 	return filepath.Join(
-		l.dataDir,
+		l.DataDir,
 		SessionLogsDir,
 		namespace,
 		fmt.Sprintf("%s%s", sid, SessionLogPrefix))
@@ -486,7 +537,7 @@ func (l *AuditLog) sessionLogFn(namespace string, sid session.ID) string {
 
 // LoggerFor creates a logger for a specified session. Session loggers allow
 // to group all events into special "session log files" for easier audit
-func (l *AuditLog) LoggerFor(namespace string, sid session.ID) (sl SessionLogger, err error) {
+func (l *AuditLog) LoggerFor(namespace string, sid session.ID) (SessionLogger, error) {
 	l.Lock()
 	defer l.Unlock()
 
@@ -496,42 +547,75 @@ func (l *AuditLog) LoggerFor(namespace string, sid session.ID) (sl SessionLogger
 
 	// if we are not recording sessions, create a logger that discards all
 	// session data sent to it.
-	if l.recordSessions == false {
+	if l.RecordSessions == false {
 		return &discardSessionLogger{}, nil
 	}
 
-	sl, ok := l.loggers[sid]
+	logger, ok := l.loggers.Get(string(sid))
 	if ok {
-		return sl, nil
+		sessionLogger, converted := logger.(SessionLogger)
+		if !converted {
+			return nil, trace.BadParameter("unsupported type: %T", logger)
+		}
+		// refresh the last active time of the logger
+		l.loggers.Set(string(sid), logger, l.SessionIdlePeriod)
+		return sessionLogger, nil
 	}
 	// make sure session logs dir is present
-	sdir := filepath.Join(l.dataDir, SessionLogsDir, namespace)
+	sdir := filepath.Join(l.DataDir, SessionLogsDir, namespace)
 	if err := os.MkdirAll(sdir, 0770); err != nil {
-		log.Error(err)
 		return nil, trace.Wrap(err)
 	}
-	// create a new session stream file:
-	fstream, err := os.OpenFile(l.sessionStreamFn(namespace, sid), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+	sessionLogger, err := NewDiskSessionLogger(DiskSessionLoggerConfig{
+		SessionID:      sid,
+		EventsFileName: l.sessionLogFn(namespace, sid),
+		StreamFileName: l.sessionStreamFn(namespace, sid),
+		Clock:          l.Clock,
+	})
 	if err != nil {
-		log.Error(err)
 		return nil, trace.Wrap(err)
 	}
-	// create a new session file:
-	fevents, err := os.OpenFile(l.sessionLogFn(namespace, sid), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
-	if err != nil {
-		log.Error(err)
-		return nil, trace.Wrap(err)
-	}
-	sl = &diskSessionLogger{
-		sid:         sid,
-		streamFile:  fstream,
-		eventsFile:  fevents,
-		timeSource:  l.TimeSource,
-		createdTime: l.TimeSource().In(time.UTC).Round(time.Second),
-	}
-	l.loggers[sid] = sl
+	l.loggers.Set(string(sid), sessionLogger, l.SessionIdlePeriod)
 	auditOpenFiles.Inc()
-	return sl, nil
+	return sessionLogger, nil
+}
+
+func (l *AuditLog) asyncCloseSessionLogger(key string, val interface{}) {
+	go l.closeSessionLogger(key, val)
+}
+
+func (l *AuditLog) closeSessionLogger(key string, val interface{}) {
+	l.Debugf("closing session logger %v", key)
+	logger, ok := val.(SessionLogger)
+	if !ok {
+		l.Warningf("warning, not valid value type %T for %v", val, key)
+		return
+	}
+	if err := logger.Finalize(); err != nil {
+		log.Warningf("failed to finalize: %v", trace.DebugReport(err))
+	}
+}
+
+func (l *AuditLog) periodicCloseInactiveLoggers() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			l.closeInactiveLoggers()
+		}
+	}
+}
+
+func (l *AuditLog) closeInactiveLoggers() {
+	l.Lock()
+	defer l.Unlock()
+
+	expired := l.loggers.RemoveExpired(10)
+	if expired != 0 {
+		l.Infof("closed %v inactive session loggers", expired)
+	}
 }
 
 // eventToLine helper creates a loggable line/string for a given event

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -11,8 +11,10 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 )
 
 type AuditTestSuite struct {
@@ -31,7 +33,10 @@ func (a *AuditTestSuite) TearDownSuite(c *check.C) {
 // creates a file-based audit log and returns a proper *AuditLog pointer
 // instead of the usual IAuditLog interface
 func (a *AuditTestSuite) makeLog(c *check.C, dataDir string, recordSessions bool) (*AuditLog, error) {
-	alog, err := NewAuditLog(dataDir, recordSessions)
+	alog, err := NewAuditLog(AuditLogConfig{
+		DataDir:        dataDir,
+		RecordSessions: recordSessions,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -44,6 +49,9 @@ func (a *AuditTestSuite) makeLog(c *check.C, dataDir string, recordSessions bool
 
 func (a *AuditTestSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests()
+}
+
+func (a *AuditTestSuite) SetUpTest(c *check.C) {
 	a.dataDir = c.MkDir()
 }
 
@@ -57,22 +65,21 @@ func (a *AuditTestSuite) TestNew(c *check.C) {
 
 func (a *AuditTestSuite) TestComplexLogging(c *check.C) {
 	now := time.Now().In(time.UTC).Round(time.Second)
-	os.RemoveAll(a.dataDir)
 
 	// create audit log, write a couple of events into it, close it
 	alog, err := a.makeLog(c, a.dataDir, true)
 	c.Assert(err, check.IsNil)
-	alog.TimeSource = func() time.Time { return now }
+	alog.Clock = clockwork.NewFakeClockAt(now)
 
 	// emit two session-attached events (same session)
 	err = alog.EmitAuditEvent(SessionStartEvent, EventFields{SessionEventID: "100", EventLogin: "vincent", EventNamespace: defaults.Namespace})
 	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers, check.HasLen, 1)
+	c.Assert(alog.loggers.Len(), check.Equals, 1)
 	err = alog.EmitAuditEvent(SessionLeaveEvent, EventFields{SessionEventID: "100", EventLogin: "vincent", EventNamespace: defaults.Namespace})
-	c.Assert(alog.loggers, check.HasLen, 1)
+	c.Assert(alog.loggers.Len(), check.Equals, 1)
 	err = alog.EmitAuditEvent(SessionJoinEvent, EventFields{SessionEventID: "200", EventLogin: "doggy", EventNamespace: defaults.Namespace})
 	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers, check.HasLen, 2)
+	c.Assert(alog.loggers.Len(), check.Equals, 2)
 
 	// type "hello" into session "200":
 	err = alog.PostSessionChunk(defaults.Namespace, "200", bytes.NewBufferString("hello"))
@@ -81,13 +88,13 @@ func (a *AuditTestSuite) TestComplexLogging(c *check.C) {
 	// emit "sesion-end" event. one of the loggers must disappear
 	err = alog.EmitAuditEvent(SessionEndEvent, EventFields{SessionEventID: "200", EventLogin: "doggy", EventNamespace: defaults.Namespace})
 	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers, check.HasLen, 1)
+	c.Assert(alog.loggers.Len(), check.Equals, 1)
 
 	// add a few more loggers and close:
 	alog.EmitAuditEvent(SessionJoinEvent, EventFields{SessionEventID: "300", EventLogin: "frankie", EventNamespace: defaults.Namespace})
 	alog.EmitAuditEvent(SessionJoinEvent, EventFields{SessionEventID: "400", EventLogin: "rosie", EventNamespace: defaults.Namespace})
 	alog.Close()
-	c.Assert(alog.loggers, check.HasLen, 0)
+	c.Assert(alog.loggers.Len(), check.Equals, 0)
 
 	// inspect session "200". it could have three events: join, print and leave:
 	history, err := alog.GetSessionEvents(defaults.Namespace, "200", 0)
@@ -137,12 +144,11 @@ func (a *AuditTestSuite) TestComplexLogging(c *check.C) {
 
 func (a *AuditTestSuite) TestSessionRecordingOff(c *check.C) {
 	now := time.Now().In(time.UTC).Round(time.Second)
-	os.RemoveAll(a.dataDir)
 
 	// create audit log with session recording disabled
 	alog, err := a.makeLog(c, a.dataDir, false)
 	c.Assert(err, check.IsNil)
-	alog.TimeSource = func() time.Time { return now }
+	alog.Clock = clockwork.NewFakeClockAt(now)
 
 	// emit "session.start" event into the audit log for session "200"
 	err = alog.EmitAuditEvent(SessionStartEvent, EventFields{SessionEventID: "200", EventLogin: "doggy", EventNamespace: defaults.Namespace})
@@ -174,10 +180,10 @@ func (a *AuditTestSuite) TestBasicLogging(c *check.C) {
 	// create audit log, write a couple of events into it, close it
 	alog, err := a.makeLog(c, a.dataDir, true)
 	c.Assert(err, check.IsNil)
-	alog.TimeSource = func() time.Time { return now }
+	alog.Clock = clockwork.NewFakeClockAt(now)
 
 	// emit regular event:
-	err = alog.EmitAuditEvent("user.farted", EventFields{"apples?": "yes"})
+	err = alog.EmitAuditEvent("user.joined", EventFields{"apples?": "yes"})
 	c.Assert(err, check.IsNil)
 	logfile := alog.file.Name()
 	c.Assert(alog.Close(), check.IsNil)
@@ -186,5 +192,75 @@ func (a *AuditTestSuite) TestBasicLogging(c *check.C) {
 	bytes, err := ioutil.ReadFile(logfile)
 	c.Assert(err, check.IsNil)
 	c.Assert(string(bytes), check.Equals,
-		fmt.Sprintf("{\"apples?\":\"yes\",\"event\":\"user.farted\",\"time\":\"%s\"}\n", now.Format(time.RFC3339)))
+		fmt.Sprintf("{\"apples?\":\"yes\",\"event\":\"user.joined\",\"time\":\"%s\"}\n", now.Format(time.RFC3339)))
+}
+
+// TestAutoClose tests scenario with auto closing of inactive sessions
+func (a *AuditTestSuite) TestAutoClose(c *check.C) {
+	// create audit log, write a couple of events into it, close it
+	fakeClock := clockwork.NewFakeClock()
+	alogI, err := NewAuditLog(AuditLogConfig{
+		DataDir:        a.dataDir,
+		RecordSessions: true,
+		Clock:          fakeClock,
+	})
+	c.Assert(err, check.IsNil)
+	alog := alogI.(*AuditLog)
+
+	// start the session and emit data stream to it
+	err = alog.EmitAuditEvent(SessionStartEvent, EventFields{SessionEventID: "100", EventLogin: "bob", EventNamespace: defaults.Namespace})
+	c.Assert(err, check.IsNil)
+	c.Assert(alog.loggers.Len(), check.Equals, 1)
+
+	sessionID := "100"
+	// type "hello" into session "100":
+	err = alog.PostSessionChunk(defaults.Namespace, session.ID(sessionID), bytes.NewBufferString("hello"))
+	c.Assert(err, check.IsNil)
+
+	// now fake sleep past expiration
+	fakeClock.Advance(defaults.SessionIdlePeriod * 2)
+
+	// logger for idle session should be closed
+	alog.closeInactiveLoggers()
+	c.Assert(alog.loggers.Len(), check.Equals, 0)
+
+	// send another event to the session
+	err = alog.PostSessionChunk(defaults.Namespace, session.ID(sessionID), bytes.NewBufferString("howdy"))
+	c.Assert(err, check.IsNil)
+	// the logger has been reopened
+	c.Assert(alog.loggers.Len(), check.Equals, 1)
+
+	// emitting session end event should close the session
+	err = alog.EmitAuditEvent(SessionEndEvent, EventFields{SessionEventID: sessionID, EventLogin: "bob", EventNamespace: defaults.Namespace})
+	c.Assert(alog.loggers.Len(), check.Equals, 0)
+
+	// read the session bytes
+	history, err := alog.GetSessionEvents(defaults.Namespace, "100", 2)
+	c.Assert(err, check.IsNil)
+	c.Assert(history, check.HasLen, 2)
+
+	// make sure offsets were properly set (0 for the first event and 5 bytes for hello):
+	c.Assert(history[0][SessionByteOffset], check.Equals, float64(0))
+	c.Assert(history[1][SessionByteOffset], check.Equals, float64(len("hello")))
+}
+
+// TestCloseOutstanding makes sure the logger closed outstanding sessions
+func (a *AuditTestSuite) TestCloseOutstanding(c *check.C) {
+	// create audit log, write a couple of events into it, close it
+	fakeClock := clockwork.NewFakeClock()
+	alogI, err := NewAuditLog(AuditLogConfig{
+		DataDir:        a.dataDir,
+		RecordSessions: true,
+		Clock:          fakeClock,
+	})
+	c.Assert(err, check.IsNil)
+	alog := alogI.(*AuditLog)
+
+	// start the session and emit data stream to it
+	err = alog.EmitAuditEvent(SessionStartEvent, EventFields{SessionEventID: "100", EventLogin: "bob", EventNamespace: defaults.Namespace})
+	c.Assert(err, check.IsNil)
+	c.Assert(alog.loggers.Len(), check.Equals, 1)
+
+	alog.Close()
+	c.Assert(alog.loggers.Len(), check.Equals, 0)
 }

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -40,11 +40,7 @@ func (a *AuditTestSuite) makeLog(c *check.C, dataDir string, recordSessions bool
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	retval, ok := alog.(*AuditLog)
-	if !ok {
-		c.FailNow()
-	}
-	return retval, nil
+	return alog, nil
 }
 
 func (a *AuditTestSuite) SetUpSuite(c *check.C) {
@@ -199,13 +195,12 @@ func (a *AuditTestSuite) TestBasicLogging(c *check.C) {
 func (a *AuditTestSuite) TestAutoClose(c *check.C) {
 	// create audit log, write a couple of events into it, close it
 	fakeClock := clockwork.NewFakeClock()
-	alogI, err := NewAuditLog(AuditLogConfig{
+	alog, err := NewAuditLog(AuditLogConfig{
 		DataDir:        a.dataDir,
 		RecordSessions: true,
 		Clock:          fakeClock,
 	})
 	c.Assert(err, check.IsNil)
-	alog := alogI.(*AuditLog)
 
 	// start the session and emit data stream to it
 	err = alog.EmitAuditEvent(SessionStartEvent, EventFields{SessionEventID: "100", EventLogin: "bob", EventNamespace: defaults.Namespace})
@@ -248,13 +243,12 @@ func (a *AuditTestSuite) TestAutoClose(c *check.C) {
 func (a *AuditTestSuite) TestCloseOutstanding(c *check.C) {
 	// create audit log, write a couple of events into it, close it
 	fakeClock := clockwork.NewFakeClock()
-	alogI, err := NewAuditLog(AuditLogConfig{
+	alog, err := NewAuditLog(AuditLogConfig{
 		DataDir:        a.dataDir,
 		RecordSessions: true,
 		Clock:          fakeClock,
 	})
 	c.Assert(err, check.IsNil)
-	alog := alogI.(*AuditLog)
 
 	// start the session and emit data stream to it
 	err = alog.EmitAuditEvent(SessionStartEvent, EventFields{SessionEventID: "100", EventLogin: "bob", EventNamespace: defaults.Namespace})

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -13,7 +13,7 @@ import (
 type DiscardAuditLog struct {
 }
 
-func (d *DiscardAuditLog) Wait(context.Context) error {
+func (d *DiscardAuditLog) WaitForDelivery(context.Context) error {
 	return nil
 }
 

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -10,6 +11,10 @@ import (
 // DiscardAuditLog is do-nothing, discard-everything implementation
 // of IAuditLog interface used for cases when audit is turned off
 type DiscardAuditLog struct {
+}
+
+func (d *DiscardAuditLog) Wait(context.Context) error {
+	return nil
 }
 
 func (d *DiscardAuditLog) Close() error {

--- a/lib/events/mock.go
+++ b/lib/events/mock.go
@@ -17,6 +17,7 @@ limitations under the License.
 package events
 
 import (
+	"context"
 	"io"
 	"sync"
 	"time"
@@ -51,6 +52,10 @@ func (d *MockAuditLog) GetError() error {
 	d.Lock()
 	defer d.Unlock()
 	return d.returnError
+}
+
+func (d *MockAuditLog) Wait(context.Context) error {
+	return nil
 }
 
 func (d *MockAuditLog) Close() error {

--- a/lib/events/mock.go
+++ b/lib/events/mock.go
@@ -54,7 +54,7 @@ func (d *MockAuditLog) GetError() error {
 	return d.returnError
 }
 
-func (d *MockAuditLog) Wait(context.Context) error {
+func (d *MockAuditLog) WaitForDelivery(context.Context) error {
 	return nil
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -326,7 +326,10 @@ func (process *TeleportProcess) initAuthService(authority auth.Authority) error 
 			log.Warn(warningMessage)
 		}
 
-		auditLog, err = events.NewAuditLog(filepath.Join(cfg.DataDir, "log"), recordSessions)
+		auditLog, err = events.NewAuditLog(events.AuditLogConfig{
+			DataDir:        filepath.Join(cfg.DataDir, "log"),
+			RecordSessions: recordSessions,
+		})
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -528,8 +528,10 @@ func (s *Server) EmitAuditEvent(eventType string, fields events.EventFields) {
 	log.Debugf("server.EmitAuditEvent(%v)", eventType)
 	alog := s.alog
 	if alog != nil {
+		// record the event time with ms precision
+		fields[events.EventTime] = s.clock.Now().In(time.UTC).Round(time.Millisecond)
 		if err := alog.EmitAuditEvent(eventType, fields); err != nil {
-			log.Error(err)
+			log.Error(trace.DebugReport(err))
 		}
 	} else {
 		log.Warn("SSH server has no audit log")

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -841,13 +841,13 @@ func (s *Server) handleSubsystem(ch ssh.Channel, req *ssh.Request, ctx *srv.Serv
 	// while collecting its result and waiting is not blocking
 	if err := sb.Start(ctx.Conn, ch, req, ctx); err != nil {
 		ctx.Warnf("[SSH] failed executing request: %v", err)
-		ctx.SendSubsystemResult(srv.SubsystemResult{trace.Wrap(err)})
+		ctx.SendSubsystemResult(srv.SubsystemResult{Err: trace.Wrap(err)})
 		return trace.Wrap(err)
 	}
 	go func() {
 		err := sb.Wait()
 		log.Debugf("[SSH] %v finished with result: %v", sb, err)
-		ctx.SendSubsystemResult(srv.SubsystemResult{trace.Wrap(err)})
+		ctx.SendSubsystemResult(srv.SubsystemResult{Err: trace.Wrap(err)})
 	}()
 	return nil
 }

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -95,7 +95,8 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	var err error
 	s.dir = c.MkDir()
 
-	s.alog, err = events.NewAuditLog(s.dir, true)
+	s.alog, err = events.NewAuditLog(events.AuditLogConfig{
+		DataDir: s.dir, RecordSessions: true})
 	c.Assert(err, IsNil)
 
 	u, err := user.Current()

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -545,7 +545,7 @@ func (r *sessionRecorder) Close() error {
 	// in missing playback events
 	context, cancel := context.WithTimeout(context.TODO(), defaults.DefaultReadHeadersTimeout)
 	defer cancel() // releases resources if slowOperation completes before timeout elapses
-	err = r.alog.Wait(context)
+	err = r.alog.WaitForDelivery(context)
 	if err != nil {
 		errors = append(errors, err)
 		log.Warningf("timeout waiting for session to flush events: %v", trace.DebugReport(err))

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -548,7 +548,7 @@ func (r *sessionRecorder) Close() error {
 	err = r.alog.Wait(context)
 	if err != nil {
 		errors = append(errors, err)
-		log.Warningf("timeout waiting for session to flush events: %v", err)
+		log.Warningf("timeout waiting for session to flush events: %v", trace.DebugReport(err))
 	}
 
 	return trace.NewAggregate(errors...)

--- a/lib/state/log.go
+++ b/lib/state/log.go
@@ -386,9 +386,9 @@ func (ll *CachingAuditLog) post(chunks []*events.SessionChunk) error {
 	return nil
 }
 
-// Wait waits until all operations of the caching audit log complete
+// WaitForDelivery waits until all operations of the caching audit log complete
 // after Close has been called, e.g. flushing remaining items
-func (ll *CachingAuditLog) Wait(ctx context.Context) error {
+func (ll *CachingAuditLog) WaitForDelivery(ctx context.Context) error {
 	select {
 	case <-ll.waitCtx.Done():
 		return nil

--- a/lib/state/log_test.go
+++ b/lib/state/log_test.go
@@ -126,7 +126,7 @@ func (s *CacheLogSuite) TestFlushWait(c *check.C) {
 	c.Assert(err, check.IsNil)
 	wait, cancel := context.WithTimeout(context.TODO(), time.Second)
 	defer cancel()
-	err = log.Wait(wait)
+	err = log.WaitForDelivery(wait)
 	c.Assert(err, check.IsNil)
 
 	var out *events.SessionSlice

--- a/lib/state/log_test.go
+++ b/lib/state/log_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package state
 
 import (
+	"context"
 	"time"
 
 	"github.com/gravitational/teleport/lib/events"
@@ -99,6 +100,35 @@ func (s *CacheLogSuite) TestFlushOnClose(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = log.Close()
 	c.Assert(err, check.IsNil)
+	var out *events.SessionSlice
+	select {
+	case out = <-mock.SlicesC:
+	case <-time.After(time.Second):
+		c.Fatalf("timeout")
+	}
+	fixtures.DeepCompare(c, out, slice)
+}
+
+// TestFlushWait makes sure wait returns correctly
+// after audit log closes and the event is received
+func (s *CacheLogSuite) TestFlushWait(c *check.C) {
+	mock := events.NewMockAuditLog(1)
+	log := newLog(CachingAuditLogConfig{
+		FlushTimeout: 10 * time.Second,
+		FlushChunks:  100,
+		QueueLen:     200,
+		Server:       mock,
+	})
+	slice := s.newSlice("hello")
+	err := log.PostSessionSlice(*slice)
+	c.Assert(err, check.IsNil)
+	err = log.Close()
+	c.Assert(err, check.IsNil)
+	wait, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+	err = log.Wait(wait)
+	c.Assert(err, check.IsNil)
+
 	var out *events.SessionSlice
 	select {
 	case out = <-mock.SlicesC:

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -117,7 +117,8 @@ func (s *WebSuite) SetUpSuite(c *C) {
 
 	sessionStreamPollPeriod = time.Millisecond
 	s.logDir = c.MkDir()
-	s.auditLog, err = events.NewAuditLog(s.logDir, true)
+	s.auditLog, err = events.NewAuditLog(events.AuditLogConfig{
+		DataDir: s.logDir, RecordSessions: true})
 	c.Assert(err, IsNil)
 	c.Assert(s.auditLog, NotNil)
 	s.mockU2F, err = mocku2f.Create()

--- a/vendor/github.com/gravitational/ttlmap/ttlmap_test.go
+++ b/vendor/github.com/gravitational/ttlmap/ttlmap_test.go
@@ -400,3 +400,29 @@ func (s *TestSuite) TestRemove(c *C) {
 	_, ok = m.Get("c")
 	c.Assert(ok, Equals, false)
 }
+
+func (s *TestSuite) TestPop(c *C) {
+	m := s.newMap(100)
+
+	_, _, exists := m.Pop()
+	c.Assert(exists, Equals, false)
+
+	err := m.Set("a", "aval", 2*time.Second)
+	c.Assert(err, Equals, nil)
+
+	err = m.Set("b", "bval", time.Second)
+	c.Assert(err, Equals, nil)
+
+	key, val, exists := m.Pop()
+	c.Assert(exists, Equals, true)
+	c.Assert(key, Equals, "b")
+	c.Assert(val, Equals, "bval")
+
+	key, val, exists = m.Pop()
+	c.Assert(exists, Equals, true)
+	c.Assert(key, Equals, "a")
+	c.Assert(val, Equals, "aval")
+
+	_, _, exists = m.Pop()
+	c.Assert(exists, Equals, false)
+}


### PR DESCRIPTION
This is a fix for file leak in audit log server caused
by design issue:

Session file descriptors in audit log were opened on demand
when the session event or byte stream chunk  was reported.

AuditLog server relied on SessionEnd event to close the
file descriptors associated with the session.

However, when SessionEnd event does not arrive (e.g.
there is a timeout or disconnect), the file descriptors
were not closed. This commit adds periodic clean up
of inactive sessions.

SessionEnd is now used as an optimization measure
to close the files, but is not used as the only
trigger to close files.

Now, inactive idle sessions, will close file descriptors
after periods of inactivity and will reopen the file
descriptors when the session activity resumes.

SessionLogger was not designed to open/close files
multiple times as it was reseting offsets
every time the session files were opened. This
change fixes this condition as well.