### PR TITLE
make audit accessible by admin group members

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -144,6 +144,16 @@ const (
 
 	// JSON means JSON serialization format
 	JSON = "json"
+
+	// LinuxAdminGID is the ID of the standard adm group on linux
+	LinuxAdminGID = 4
+
+	// LinuxOS is the name of the linux OS
+	LinuxOS = "linux"
+
+	// DirMaskSharedGroup is the mask for a directory accessible
+	// by the owner and group
+	DirMaskSharedGroup = 0770
 )
 
 const (

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -33,6 +33,20 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// IsGroupMember returns whether currently logged user is a member of a group
+func IsGroupMember(gid int) (bool, error) {
+	groups, err := os.Getgroups()
+	if err != nil {
+		return false, trace.ConvertSystemError(err)
+	}
+	for _, group := range groups {
+		if group == gid {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // SplitHostPort splits host and port and checks that host is not empty
 func SplitHostPort(hostname string) (string, string, error) {
 	host, port, err := net.SplitHostPort(hostname)


### PR DESCRIPTION
If user running teleport is a member of adm group
create the directory and all subdirectories
accessible to admins.

Remove obsolete migrations required for pre 2.3 releases.