### PR TITLE
fixes issue with race on closed listener

### DIFF
--- a/lib/utils/loadbalancer_test.go
+++ b/lib/utils/loadbalancer_test.go
@@ -167,9 +167,11 @@ func (s *LBSuite) TestClose(c *check.C) {
 	// second close works
 	lb.Close()
 
+	lb.Wait()
+
 	// requests are failing
 	out, err = roundtrip(frontend.String())
-	c.Assert(err, check.NotNil)
+	c.Assert(err, check.NotNil, check.Commentf("output: %v, err: %v", string(out), err))
 }
 
 func (s *LBSuite) TestDropConnections(c *check.C) {


### PR DESCRIPTION
We were getting this issue in tests:

```
----------------------------------------------------------------------
FAIL: loadbalancer_test.go:144: LBSuite.TestClose

loadbalancer_test.go:172:
    c.Assert(err, check.NotNil, check.Commentf("output: %v, err: %v", string(out), err))
... value = nil
... output: backend 1, err: <nil>
```

This PR fixes it