### PR TITLE
SSH/TLS multiplexer with Proxy protocol support

### DIFF
--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -138,7 +138,7 @@ func (b *bk) reconnect() error {
 	clt, err := client.New(client.Config{
 		Endpoints:               b.nodes,
 		Transport:               tr,
-		HeaderTimeoutPerRequest: defaults.DefaultReadHeadersTimeout,
+		HeaderTimeoutPerRequest: defaults.ReadHeadersTimeout,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -85,9 +85,9 @@ const (
 	// the SSH connection open if there are no reads/writes happening over it.
 	DefaultIdleConnectionDuration = 20 * time.Minute
 
-	// DefaultReadHeadersTimeout is a default TCP timeout when we wait
+	// ReadHeadersTimeout is a default TCP timeout when we wait
 	// for the response headers to arrive
-	DefaultReadHeadersTimeout = time.Second
+	ReadHeadersTimeout = time.Second
 
 	// MaxSignupTokenTTL is a maximum TTL for a web signup one time token
 	// clients can reduce this time, not increase it

--- a/lib/fixtures/keys.go
+++ b/lib/fixtures/keys.go
@@ -1,4 +1,4 @@
-package suite
+package fixtures
 
 var PEMBytes = map[string][]byte{
 	"dsa": []byte(`-----BEGIN DSA PRIVATE KEY-----

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package multiplexer implements SSH and TLS multiplexing
+// on the same listener
+//
+// mux, _ := multiplexer.New(Config{Listener: listener})
+// mux.SSH() // returns listener getting SSH connections
+// mux.TLS() // returns listener getting TLS connections
+//
+package multiplexer
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/gravitational/teleport/lib/defaults"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	log "github.com/sirupsen/logrus"
+)
+
+// Config is a multiplexer config
+type Config struct {
+	// Listener is listener to multiplex connection on
+	Listener net.Listener
+	// Context is a context to signal stops, cancellations
+	Context context.Context
+	// ReadDeadline is a connection read deadline,
+	// set to defaults.ReadHeadersTimeout if unspecified
+	ReadDeadline time.Duration
+	// Clock is a clock to override in tests, set to real time clock
+	// by default
+	Clock clockwork.Clock
+}
+
+// CheckAndSetDefaults verifies configuration and sets defaults
+func (c *Config) CheckAndSetDefaults() error {
+	if c.Listener == nil {
+		return trace.BadParameter("missing parameter Listener")
+	}
+	if c.Context == nil {
+		c.Context = context.TODO()
+	}
+	if c.ReadDeadline == 0 {
+		c.ReadDeadline = defaults.ReadHeadersTimeout
+	}
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+	return nil
+}
+
+// New returns a new instance of multiplexer
+func New(cfg Config) (*Mux, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ctx, cancel := context.WithCancel(cfg.Context)
+	waitContext, waitCancel := context.WithCancel(context.TODO())
+	return &Mux{
+		Entry: log.WithFields(log.Fields{
+			trace.Component: "mux",
+		}),
+		Config:      cfg,
+		context:     ctx,
+		cancel:      cancel,
+		sshListener: newListener(ctx, cfg.Listener.Addr()),
+		tlsListener: newListener(ctx, cfg.Listener.Addr()),
+		waitContext: waitContext,
+		waitCancel:  waitCancel,
+	}, nil
+}
+
+// Mux supports having both SSH and TLS on the same listener socket
+type Mux struct {
+	sync.RWMutex
+	*log.Entry
+	Config
+	listenerClosed bool
+	sshListener    *Listener
+	tlsListener    *Listener
+	context        context.Context
+	cancel         context.CancelFunc
+	waitContext    context.Context
+	waitCancel     context.CancelFunc
+}
+
+// SSH returns listener that receives SSH connections
+func (m *Mux) SSH() net.Listener {
+	return m.sshListener
+}
+
+// TLS returns listener that receives TLS connections
+func (m *Mux) TLS() net.Listener {
+	return m.tlsListener
+}
+
+func (m *Mux) isClosed() bool {
+	m.RLock()
+	defer m.RUnlock()
+	return m.listenerClosed
+}
+
+func (m *Mux) closeListener() {
+	m.Lock()
+	defer m.Unlock()
+	// propagate close signal to other listeners
+	m.cancel()
+	if m.Listener == nil {
+		return
+	}
+	if m.listenerClosed {
+		return
+	}
+	m.listenerClosed = true
+	m.Listener.Close()
+}
+
+// Close closes listener
+func (m *Mux) Close() error {
+	m.closeListener()
+	return nil
+}
+
+// Wait waits until listener shuts down and stops accepting new connections
+// this is to workaround issue https://github.com/golang/go/issues/10527
+// in tests
+func (m *Mux) Wait() {
+	<-m.waitContext.Done()
+}
+
+// Serve is a blocking function that serves on the listening socket
+// and accepts requests. Every request is served in a separate goroutine
+func (m *Mux) Serve() error {
+	defer m.waitCancel()
+	backoffTimer := time.NewTicker(5 * time.Second)
+	defer backoffTimer.Stop()
+	for {
+		conn, err := m.Listener.Accept()
+		if err == nil {
+			go m.detectAndForward(conn)
+			continue
+		}
+		if m.isClosed() {
+			return nil
+		}
+		select {
+		case <-backoffTimer.C:
+			m.Debugf("backoff on accept error: %v", trace.DebugReport(err))
+		case <-m.context.Done():
+			return nil
+		}
+	}
+}
+
+func (m *Mux) detectAndForward(conn net.Conn) {
+	err := conn.SetReadDeadline(m.Clock.Now().Add(m.ReadDeadline))
+	if err != nil {
+		m.Warning(err.Error())
+		conn.Close()
+		return
+	}
+	connWrapper, err := detect(conn)
+	if err != nil {
+		m.Warning(err.Error())
+		conn.Close()
+		return
+	}
+
+	err = conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		m.Warning(err.Error())
+		conn.Close()
+		return
+	}
+
+	switch connWrapper.protocol {
+	case ProtoTLS:
+		select {
+		case m.tlsListener.connC <- connWrapper:
+		case <-m.context.Done():
+			connWrapper.Close()
+			return
+		}
+	case ProtoSSH:
+		select {
+		case m.sshListener.connC <- connWrapper:
+		case <-m.context.Done():
+			connWrapper.Close()
+			return
+		}
+	default:
+		// should not get here, handle this just in case
+		connWrapper.Close()
+		m.Errorf("detected but unsupported protocol: %v", connWrapper.protocol)
+	}
+}
+
+func detect(conn net.Conn) (*Conn, error) {
+	reader := bufio.NewReader(conn)
+
+	var proxyLine *ProxyLine
+	for i := 0; i < 2; i++ {
+		bytes, err := reader.Peek(3)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to peek connection")
+		}
+
+		proto, err := detectProto(bytes)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		switch proto {
+		case ProtoProxy:
+			if proxyLine != nil {
+				return nil, trace.BadParameter("duplicate proxy line")
+			}
+			proxyLine, err = ReadProxyLine(reader)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			// repeat the cycle to detect the protocol
+		case ProtoTLS, ProtoSSH:
+			return &Conn{
+				protocol:  proto,
+				Conn:      conn,
+				reader:    reader,
+				proxyLine: proxyLine,
+			}, nil
+		}
+	}
+	// if code ended here after two attempts, something is wrong
+	return nil, trace.BadParameter("unknown protocol")
+}
+
+const (
+	// ProtoUnknown is for unknown protocol
+	ProtoUnknown = iota
+	// ProtoTLS is TLS protocol
+	ProtoTLS
+	// ProtoSSH is SSH protocol
+	ProtoSSH
+	// ProtoProxy is a HAProxy proxy line protocol
+	ProtoProxy
+)
+
+var (
+	proxyPrefix = []byte{'P', 'R', 'O', 'X', 'Y'}
+	sshPrefix   = []byte{'S', 'S', 'H'}
+	tlsPrefix   = []byte{0x16}
+)
+
+func detectProto(in []byte) (int, error) {
+	switch {
+	// reader peeks only 3 bytes, slice the longer proxy prefix
+	case bytes.HasPrefix(in, proxyPrefix[:3]):
+		return ProtoProxy, nil
+	case bytes.HasPrefix(in, sshPrefix):
+		return ProtoSSH, nil
+	case bytes.HasPrefix(in, tlsPrefix):
+		return ProtoTLS, nil
+	default:
+		return ProtoUnknown, trace.BadParameter("failed to detect protocol")
+	}
+}

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -218,6 +218,11 @@ func (m *Mux) detectAndForward(conn net.Conn) {
 func detect(conn net.Conn) (*Conn, error) {
 	reader := bufio.NewReader(conn)
 
+	// the first attempt is to parse optional proxy
+	// protocol line that is injected by load balancers
+	// before actual protocol traffic flows.
+	// if the first attempt encounters proxy it
+	// goes to the second pass to do protocol detection
 	var proxyLine *ProxyLine
 	for i := 0; i < 2; i++ {
 		bytes, err := reader.Peek(3)

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplexer
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type MuxSuite struct {
+	signers []ssh.Signer
+}
+
+var _ = check.Suite(&MuxSuite{})
+
+func (s *MuxSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
+
+	pk, err := ssh.ParsePrivateKey(fixtures.PEMBytes["ecdsa"])
+	c.Assert(err, check.IsNil)
+	s.signers = []ssh.Signer{pk}
+}
+
+// TestMultiplexing tests basic use case of multiplexing TLS
+// and SSH on the same listener socket
+func (s *MuxSuite) TestMultiplexing(c *check.C) {
+	ports, err := utils.GetFreeTCPPorts(1)
+	c.Assert(err, check.IsNil)
+
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", ports[0]))
+	c.Assert(err, check.IsNil)
+
+	mux, err := New(Config{
+		Listener: listener,
+	})
+	c.Assert(err, check.IsNil)
+	go mux.Serve()
+	defer mux.Close()
+
+	backend1 := &httptest.Server{
+		Listener: mux.TLS(),
+		Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "backend 1")
+		}),
+		},
+	}
+	backend1.StartTLS()
+	defer backend1.Close()
+
+	called := false
+	sshHandler := sshutils.NewChanHandlerFunc(func(_ net.Conn, conn *ssh.ServerConn, nch ssh.NewChannel) {
+		called = true
+		nch.Reject(ssh.Prohibited, "nothing to see here")
+	})
+
+	srv, err := sshutils.NewServer(
+		"test",
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
+		sshHandler,
+		s.signers,
+		sshutils.AuthMethods{Password: pass("abc123")},
+	)
+	c.Assert(err, check.IsNil)
+	go srv.Serve(mux.SSH())
+	defer srv.Close()
+	clt, err := ssh.Dial("tcp", listener.Addr().String(), &ssh.ClientConfig{
+		Auth:    []ssh.AuthMethod{ssh.Password("abc123")},
+		Timeout: time.Second,
+	})
+	c.Assert(err, check.IsNil)
+	defer clt.Close()
+
+	// call new session to initiate opening new channel
+	clt.NewSession()
+	// make sure the channel handler was called OK
+	c.Assert(called, check.Equals, true)
+
+	client := testClient(backend1)
+	re, err := client.Get(backend1.URL)
+	c.Assert(err, check.IsNil)
+	bytes, err := ioutil.ReadAll(re.Body)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(bytes), check.Equals, "backend 1")
+
+	// Close mux, new requests should fail
+	mux.Close()
+	mux.Wait()
+
+	// use new client to use new connection pool
+	client = testClient(backend1)
+	_, err = client.Get(backend1.URL)
+	c.Assert(err, check.NotNil)
+}
+
+// TestProxy tests Proxy line support protocol
+func (s *MuxSuite) TestProxy(c *check.C) {
+	ports, err := utils.GetFreeTCPPorts(1)
+	c.Assert(err, check.IsNil)
+
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", ports[0]))
+	c.Assert(err, check.IsNil)
+
+	mux, err := New(Config{
+		Listener: listener,
+	})
+	c.Assert(err, check.IsNil)
+	go mux.Serve()
+	defer mux.Close()
+
+	backend1 := &httptest.Server{
+		Listener: mux.TLS(),
+		Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, r.RemoteAddr)
+		}),
+		},
+	}
+	backend1.StartTLS()
+	defer backend1.Close()
+
+	remoteAddr := net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8000}
+	proxyLine := ProxyLine{
+		Protocol:    TCP4,
+		Source:      remoteAddr,
+		Destination: net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9000},
+	}
+
+	parsedURL, err := url.Parse(backend1.URL)
+	c.Assert(err, check.IsNil)
+
+	conn, err := net.Dial("tcp", parsedURL.Host)
+	c.Assert(err, check.IsNil)
+	defer conn.Close()
+	// send proxy line first before establishing TLS connection
+	_, err = fmt.Fprintf(conn, proxyLine.String())
+	c.Assert(err, check.IsNil)
+
+	// upgrade connection to TLS
+	tlsConn := tls.Client(conn, clientConfig(backend1))
+	defer tlsConn.Close()
+
+	// make sure the TLS call succeeded and we got remote address
+	// correctly
+	out, err := utils.RoundtripWithConn(tlsConn)
+	c.Assert(err, check.IsNil)
+	c.Assert(out, check.Equals, remoteAddr.String())
+}
+
+// TestTimeout tests client timeout - client dials, but writes nothing
+// make sure server hangs up
+func (s *MuxSuite) TestTimeout(c *check.C) {
+	ports, err := utils.GetFreeTCPPorts(1)
+	c.Assert(err, check.IsNil)
+
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", ports[0]))
+	c.Assert(err, check.IsNil)
+
+	config := Config{
+		Listener:     listener,
+		ReadDeadline: time.Millisecond,
+	}
+	mux, err := New(config)
+	c.Assert(err, check.IsNil)
+	go mux.Serve()
+	defer mux.Close()
+
+	backend1 := &httptest.Server{
+		Listener: mux.TLS(),
+		Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, r.RemoteAddr)
+		}),
+		},
+	}
+	backend1.StartTLS()
+	defer backend1.Close()
+
+	parsedURL, err := url.Parse(backend1.URL)
+	c.Assert(err, check.IsNil)
+
+	conn, err := net.Dial("tcp", parsedURL.Host)
+	c.Assert(err, check.IsNil)
+	defer conn.Close()
+
+	time.Sleep(config.ReadDeadline + 5*time.Millisecond)
+	// upgrade connection to TLS
+	tlsConn := tls.Client(conn, clientConfig(backend1))
+	defer tlsConn.Close()
+
+	// roundtrip should fail on the timeout
+	_, err = utils.RoundtripWithConn(tlsConn)
+	c.Assert(err, check.NotNil)
+}
+
+// TestUnknownProtocol make sure that multiplexer closes connection
+// with unknown protocol
+func (s *MuxSuite) TestUnknownProtocol(c *check.C) {
+	ports, err := utils.GetFreeTCPPorts(1)
+	c.Assert(err, check.IsNil)
+
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", ports[0]))
+	c.Assert(err, check.IsNil)
+
+	mux, err := New(Config{
+		Listener: listener,
+	})
+	c.Assert(err, check.IsNil)
+	go mux.Serve()
+	defer mux.Close()
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	c.Assert(err, check.IsNil)
+	defer conn.Close()
+
+	// try plain HTTP
+	_, err = fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+	c.Assert(err, check.IsNil)
+
+	// connection should be closed
+	_, err = conn.Read(make([]byte, 1))
+	c.Assert(err, check.Equals, io.EOF)
+}
+
+// clientConfig returns tls client config from test http server
+// set up to listen on TLS
+func clientConfig(srv *httptest.Server) *tls.Config {
+	cert, err := x509.ParseCertificate(srv.TLS.Certificates[0].Certificate[0])
+	if err != nil {
+		panic(err)
+	}
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(cert)
+	return &tls.Config{
+		RootCAs:    certpool,
+		ServerName: fmt.Sprintf("%v", cert.IPAddresses[0].String()),
+	}
+}
+
+func testClient(srv *httptest.Server) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: clientConfig(srv),
+		},
+	}
+}
+
+func pass(need string) sshutils.PasswordFunc {
+	return func(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
+		if string(password) == need {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("passwords don't match")
+	}
+}

--- a/lib/multiplexer/proxyline.go
+++ b/lib/multiplexer/proxyline.go
@@ -1,0 +1,124 @@
+/**
+ *  Copyright 2013 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Note: original copyright is preserved on purpose
+ */
+
+package multiplexer
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+const (
+	// TCP4 is TCP over IPv4
+	TCP4 = "TCP4"
+	// TCP6 is tCP over IPv6
+	TCP6 = "TCP6"
+	// Unknown is unsupported or unknown protocol
+	UNKNOWN = "UNKNOWN"
+)
+
+var (
+	proxyCRLF = "\r\n"
+	proxySep  = " "
+)
+
+// ProxyLine is HA Proxy protocol version 1
+// https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+// Original implementation here: https://github.com/racker/go-proxy-protocol
+type ProxyLine struct {
+	Protocol    string
+	Source      net.TCPAddr
+	Destination net.TCPAddr
+}
+
+// String returns on-the wire string representation of the proxy line
+func (p *ProxyLine) String() string {
+	return fmt.Sprintf("PROXY %s %s %s %d %d\r\n", p.Protocol, p.Source.IP.String(), p.Destination.IP.String(), p.Source.Port, p.Destination.Port)
+}
+
+// ReadProxyLine reads proxy line protocol from the reader
+func ReadProxyLine(reader *bufio.Reader) (*ProxyLine, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if !strings.HasSuffix(line, proxyCRLF) {
+		return nil, trace.BadParameter("expected CRLF in proxy protocol, got something else")
+	}
+	tokens := strings.Split(line[:len(line)-2], proxySep)
+	ret := ProxyLine{}
+	if len(tokens) < 6 {
+		return nil, trace.BadParameter("malformed PROXY line protocol string")
+	}
+	switch tokens[1] {
+	case TCP4:
+		ret.Protocol = TCP4
+	case TCP6:
+		ret.Protocol = TCP6
+	default:
+		ret.Protocol = UNKNOWN
+	}
+	sourceIP, err := parseIP(ret.Protocol, tokens[2])
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	destIP, err := parseIP(ret.Protocol, tokens[3])
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	sourcePort, err := parsePortNumber(tokens[4])
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	destPort, err := parsePortNumber(tokens[5])
+	if err != nil {
+		return nil, err
+	}
+	ret.Source = net.TCPAddr{IP: sourceIP, Port: sourcePort}
+	ret.Destination = net.TCPAddr{IP: destIP, Port: destPort}
+	return &ret, nil
+}
+
+func parsePortNumber(portString string) (int, error) {
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		return -1, trace.BadParameter("bad port %q: %v", port, err)
+	}
+	if port < 0 || port > 65535 {
+		return -1, trace.BadParameter("port %q not in supported range [0...65535]", portString)
+	}
+	return port, nil
+}
+
+func parseIP(protocol string, addrString string) (net.IP, error) {
+	addr := net.ParseIP(addrString)
+	switch {
+	case len(addr) == 0:
+		return nil, trace.BadParameter("failed to parse address")
+	case addr.To4() != nil && protocol != TCP4:
+		return nil, trace.BadParameter("got IPV4 address %q for IPV6 proto %q", addr.String(), protocol)
+	case addr.To4() == nil && protocol == TCP6:
+		return nil, trace.BadParameter("got IPV6 address %v %q for IPV4 proto %q", len(addr), addr.String(), protocol)
+	}
+	return addr, nil
+}

--- a/lib/multiplexer/wrappers.go
+++ b/lib/multiplexer/wrappers.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplexer
+
+import (
+	"bufio"
+	"context"
+	"net"
+
+	"github.com/gravitational/trace"
+)
+
+// Conn is a connection wrapper that supports
+// communicating remote address from proxy protocol
+// and replays first several bytes read during
+// protocol detection
+type Conn struct {
+	net.Conn
+	protocol  int
+	proxyLine *ProxyLine
+	reader    *bufio.Reader
+}
+
+// Read reads from connection
+func (c *Conn) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+// LocalAddr returns local address of the connection
+func (c *Conn) LocalAddr() net.Addr {
+	if c.proxyLine != nil {
+		return &c.proxyLine.Destination
+	}
+	return c.Conn.LocalAddr()
+}
+
+// RemoteAddr returns remote address of the connection
+func (c *Conn) RemoteAddr() net.Addr {
+	if c.proxyLine != nil {
+		return &c.proxyLine.Source
+	}
+	return c.Conn.RemoteAddr()
+}
+
+func newListener(parent context.Context, addr net.Addr) *Listener {
+	context, cancel := context.WithCancel(parent)
+	return &Listener{
+		addr:    addr,
+		connC:   make(chan *Conn),
+		cancel:  cancel,
+		context: context,
+	}
+}
+
+// Listener is a listener that receives
+// connections from multiplexer based on the connection type
+type Listener struct {
+	addr    net.Addr
+	connC   chan *Conn
+	cancel  context.CancelFunc
+	context context.Context
+}
+
+// Addr returns listener addr, the address of multiplexer listener
+func (l *Listener) Addr() net.Addr {
+	return l.addr
+}
+
+// Accept accepts connections from parent multiplexer listener
+func (l *Listener) Accept() (net.Conn, error) {
+	select {
+	case <-l.context.Done():
+		return nil, trace.ConnectionProblem(nil, "listener is closed")
+	case conn := <-l.connC:
+		if conn == nil {
+			return nil, trace.ConnectionProblem(nil, "listener is closed")
+		}
+		return conn, nil
+	}
+}
+
+// Close closes the listener, connections to multiplexer will hang
+func (l *Listener) Close() error {
+	l.cancel()
+	return nil
+}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -40,7 +40,7 @@ import (
 // NewTestCA returns new test authority with a test key as a public and
 // signing key
 func NewTestCA(caType services.CertAuthType, domainName string) *services.CertAuthorityV2 {
-	keyBytes := PEMBytes["rsa"]
+	keyBytes := fixtures.PEMBytes["rsa"]
 	key, err := ssh.ParsePrivateKey(keyBytes)
 	if err != nil {
 		panic(err)

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -543,7 +543,7 @@ func (r *sessionRecorder) Close() error {
 	// to release resources associated with this session.
 	// not doing so will not result in memory leak, but could result
 	// in missing playback events
-	context, cancel := context.WithTimeout(context.TODO(), defaults.DefaultReadHeadersTimeout)
+	context, cancel := context.WithTimeout(context.TODO(), defaults.ReadHeadersTimeout)
 	defer cancel() // releases resources if slowOperation completes before timeout elapses
 	err = r.alog.WaitForDelivery(context)
 	if err != nil {

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/teleport/lib/services/suite"
+	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"golang.org/x/crypto/ssh"
@@ -39,7 +39,7 @@ var _ = Suite(&ServerSuite{})
 func (s *ServerSuite) SetUpSuite(c *C) {
 	utils.InitLoggerForTests()
 
-	pk, err := ssh.ParsePrivateKey(suite.PEMBytes["ecdsa"])
+	pk, err := ssh.ParsePrivateKey(fixtures.PEMBytes["ecdsa"])
 	c.Assert(err, IsNil)
 	s.signers = []ssh.Signer{pk}
 }

--- a/lib/utils/conn.go
+++ b/lib/utils/conn.go
@@ -17,8 +17,12 @@ limitations under the License.
 package utils
 
 import (
+	"bufio"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
+	"net/http"
 
 	"github.com/gravitational/trace"
 )
@@ -51,4 +55,36 @@ func (c *CloserConn) Close() error {
 	}
 	errors = append(errors, c.Conn.Close())
 	return trace.NewAggregate(errors...)
+}
+
+// Roundtrip is a single connection simplistic HTTP client
+// that allows us to bypass a connection pool to test load balancing
+// used in tests, as it only supports GET request on /
+func Roundtrip(addr string) (string, error) {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	return RoundtripWithConn(conn)
+}
+
+// RoundtripWithConn uses HTTP GET on the existing connection,
+// used in tests as it only performs GET request on /
+func RoundtripWithConn(conn net.Conn) (string, error) {
+	_, err := fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+	if err != nil {
+		return "", err
+	}
+
+	re, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		return "", err
+	}
+	defer re.Body.Close()
+	out, err := ioutil.ReadAll(re.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }


### PR DESCRIPTION
This commit adds multiplexer library of SSH/TLS on the same
listener socket. The multiplexer detects the protocol by the first
3 bytes of the incoming connection and forwards wrapped
connection either to the SSH or TLS listeners.

The library also supports PROXY line protocol
and wraps connection information with connection details
from the proxy line received by the server