### PR TITLE
Forwarding Server

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -67,6 +67,9 @@ const (
 	// ComponentNode is SSH node (SSH server serving requests)
 	ComponentNode = "node"
 
+	// ComponentNode is SSH node (SSH server serving requests)
+	ComponentForwardingNode = "node:forward"
+
 	// ComponentProxy is SSH proxy (SSH server forwarding connections)
 	ComponentProxy = "proxy"
 
@@ -78,6 +81,15 @@ const (
 
 	// ComponentSubsystemProxy is the proxy subsystem.
 	ComponentSubsystemProxy = "subsystem:proxy"
+
+	// ComponentLocalTerm is a terminal on a regular SSH node.
+	ComponentLocalTerm = "term:local"
+
+	// ComponentRemoteTerm is a terminal on a forwarding SSH node.
+	ComponentRemoteTerm = "term:remote"
+
+	// ComponentRemoteSubsystem is subsystem on a forwarding SSH node.
+	ComponentRemoteSubsystem = "subsystem:remote"
 
 	// ComponentAuditLog is audit log component
 	ComponentAuditLog = "auditlog"
@@ -215,6 +227,9 @@ const (
 	// logins for local accounts.
 	TraitInternalRoleVariable = "{{internal.logins}}"
 )
+
+// SCP is Secure Copy.
+const SCP = "scp"
 
 // Root is *nix system administrator account name.
 const Root = "root"

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -253,12 +253,7 @@ func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *servic
 		tconf = service.MakeDefaultConfig()
 	}
 	tconf.DataDir = dataDir
-	tconf.Auth.ClusterConfig, err = services.NewClusterConfig(services.ClusterConfigSpecV3{
-		SessionRecording: services.RecordAtNode,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	tconf.Auth.ClusterConfig = services.DefaultClusterConfig()
 	tconf.Auth.ClusterName, err = services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: i.Secrets.SiteName,
 	})
@@ -353,7 +348,7 @@ func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *servic
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		user.Key.Cert, err = auth.GenerateUserCert(user.Key.Pub, teleUser, logins, ttl, true, teleport.CompatibilityNone)
+		user.Key.Cert, err = auth.GenerateUserCert(user.Key.Pub, teleUser, logins, ttl, true, true, teleport.CompatibilityNone)
 		if err != nil {
 			return err
 		}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -231,7 +231,7 @@ func (s *AuthServer) GenerateHostCert(hostPublicKey []byte, hostID, nodeName, cl
 
 // GenerateUserCert generates user certificate, it takes pkey as a signing
 // private key (user certificate authority)
-func (s *AuthServer) GenerateUserCert(key []byte, user services.User, allowedLogins []string, ttl time.Duration, canForwardAgents bool, compatibility string) ([]byte, error) {
+func (s *AuthServer) GenerateUserCert(key []byte, user services.User, allowedLogins []string, ttl time.Duration, canForwardAgents bool, canPortForward bool, compatibility string) ([]byte, error) {
 	domainName, err := s.GetDomainName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -256,6 +256,7 @@ func (s *AuthServer) GenerateUserCert(key []byte, user services.User, allowedLog
 		Roles:                 user.GetRoles(),
 		Compatibility:         compatibility,
 		PermitAgentForwarding: canForwardAgents,
+		PermitPortForwarding:  canPortForward,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -742,7 +743,8 @@ func (s *AuthServer) NewWebSession(userName string) (services.WebSession, error)
 		AllowedLogins:       allowedLogins,
 		TTL:                 bearerTokenTTL,
 		PermitAgentForwarding: roles.CanForwardAgents(),
-		Roles: user.GetRoles(),
+		PermitPortForwarding:  roles.CanPortForward(),
+		Roles:                 user.GetRoles(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -468,7 +468,7 @@ func (a *AuthWithRoles) GenerateUserCert(key []byte, username string, ttl time.D
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GenerateUserCert(
-		key, user, allowedLogins, sessionTTL, checker.CanForwardAgents(), compatibility)
+		key, user, allowedLogins, sessionTTL, checker.CanForwardAgents(), checker.CanPortForward(), compatibility)
 }
 
 func (a *AuthWithRoles) CreateSignupToken(user services.UserV1, ttl time.Duration) (token string, e error) {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -105,11 +105,11 @@ type InitConfig struct {
 	// factor (off, otp, u2f) passed in from a configuration file.
 	AuthPreference services.AuthPreference
 
-	// ClusterConfig holds cluster level configuration.
-	ClusterConfig services.ClusterConfig
-
 	// AuditLog is used for emitting events to audit log
 	AuditLog events.IAuditLog
+
+	// ClusterConfig holds cluster level configuration.
+	ClusterConfig services.ClusterConfig
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -178,10 +178,6 @@ func (s *AuthInitSuite) TestAuthPreference(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
-		SessionRecording: services.RecordAtNode,
-	})
-	c.Assert(err, IsNil)
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "me.localhost",
 	})
@@ -197,7 +193,7 @@ func (s *AuthInitSuite) TestAuthPreference(c *C) {
 		NodeName:       "foo",
 		Backend:        bk,
 		Authority:      testauthority.New(),
-		ClusterConfig:  clusterConfig,
+		ClusterConfig:  services.DefaultClusterConfig(),
 		ClusterName:    clusterName,
 		StaticTokens:   staticTokens,
 		AuthPreference: ap,
@@ -230,8 +226,8 @@ func (s *AuthInitSuite) TestClusterID(c *C) {
 		NodeName:      "foo",
 		Backend:       bk,
 		Authority:     testauthority.New(),
-		ClusterName:   clusterName,
 		ClusterConfig: services.DefaultClusterConfig(),
+		ClusterName:   clusterName,
 	})
 	c.Assert(err, IsNil)
 
@@ -247,8 +243,8 @@ func (s *AuthInitSuite) TestClusterID(c *C) {
 		NodeName:      "foo",
 		Backend:       bk,
 		Authority:     testauthority.New(),
-		ClusterName:   clusterName,
 		ClusterConfig: services.DefaultClusterConfig(),
+		ClusterName:   clusterName,
 	})
 	c.Assert(err, IsNil)
 

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -208,6 +208,9 @@ func (n *nauth) GenerateUserCert(c services.UserCertParams) ([]byte, error) {
 	if c.PermitAgentForwarding {
 		cert.Permissions.Extensions[teleport.CertExtensionPermitAgentForwarding] = ""
 	}
+	if !c.PermitPortForwarding {
+		delete(cert.Permissions.Extensions, teleport.CertExtensionPermitPortForwarding)
+	}
 	if len(c.Roles) != 0 {
 		// if we are requesting a certificate with support for older versions of OpenSSH
 		// don't add roles to certificate extensions, due to a bug in <= OpenSSH 7.1

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -182,6 +182,7 @@ func (s *NativeSuite) TestUserCertCompatibility(c *C) {
 			Roles:                 []string{"foo"},
 			Compatibility:         tt.inCompatibility,
 			PermitAgentForwarding: true,
+			PermitPortForwarding:  true,
 		})
 		c.Assert(err, IsNil, comment)
 

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -218,7 +218,14 @@ func (a *AuthServer) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthResponse, 
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		cert, err := a.GenerateUserCert(req.PublicKey, user, allowedLogins, certTTL, roles.CanForwardAgents(), req.Compatibility)
+		cert, err := a.GenerateUserCert(
+			req.PublicKey,
+			user,
+			allowedLogins,
+			certTTL,
+			roles.CanForwardAgents(),
+			roles.CanPortForward(),
+			req.Compatibility)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -177,6 +177,7 @@ func GetCheckerForBuiltinRole(clusterConfig services.ClusterConfig, role telepor
 						services.NewRule(services.KindAuthServer, services.RO()),
 						services.NewRule(services.KindReverseTunnel, services.RO()),
 						services.NewRule(services.KindTunnelConnection, services.RO()),
+						services.NewRule(services.KindClusterConfig, services.RO()),
 					},
 				},
 			})

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -340,7 +340,7 @@ func (a *AuthServer) ValidateSAMLResponse(samlResponse string) (*SAMLAuthRespons
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		cert, err := a.GenerateUserCert(request.PublicKey, user, allowedLogins, certTTL, roles.CanForwardAgents(), request.Compatibility)
+		cert, err := a.GenerateUserCert(request.PublicKey, user, allowedLogins, certTTL, roles.CanForwardAgents(), roles.CanPortForward(), request.Compatibility)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/test/suite.go
+++ b/lib/auth/test/suite.go
@@ -87,6 +87,7 @@ func (s *AuthSuite) GenerateUserCert(c *C) {
 		AllowedLogins:       []string{"centos", "root"},
 		TTL:                 time.Hour,
 		PermitAgentForwarding: true,
+		PermitPortForwarding:  true,
 	})
 	c.Assert(err, IsNil)
 
@@ -100,6 +101,7 @@ func (s *AuthSuite) GenerateUserCert(c *C) {
 		AllowedLogins:       []string{"root"},
 		TTL:                 -20,
 		PermitAgentForwarding: true,
+		PermitPortForwarding:  true,
 	})
 	c.Assert(err, NotNil)
 
@@ -109,7 +111,9 @@ func (s *AuthSuite) GenerateUserCert(c *C) {
 		Username:            "user",
 		AllowedLogins:       []string{"root"},
 		TTL:                 0,
-		PermitAgentForwarding: true})
+		PermitAgentForwarding: true,
+		PermitPortForwarding:  true,
+	})
 	c.Assert(err, NotNil)
 
 	_, err = s.A.GenerateUserCert(services.UserCertParams{
@@ -119,6 +123,7 @@ func (s *AuthSuite) GenerateUserCert(c *C) {
 		AllowedLogins:       []string{"root"},
 		TTL:                 time.Hour,
 		PermitAgentForwarding: true,
+		PermitPortForwarding:  true,
 	})
 	c.Assert(err, IsNil)
 
@@ -130,7 +135,8 @@ func (s *AuthSuite) GenerateUserCert(c *C) {
 		AllowedLogins:       []string{"root"},
 		TTL:                 time.Hour,
 		PermitAgentForwarding: true,
-		Roles: inRoles,
+		PermitPortForwarding:  true,
+		Roles:                 inRoles,
 	})
 	c.Assert(err, IsNil)
 	parsedKey, _, _, _, err := ssh.ParseAuthorizedKey(cert)

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -103,6 +103,9 @@ func (n *Keygen) GenerateUserCert(c services.UserCertParams) ([]byte, error) {
 	if c.PermitAgentForwarding {
 		cert.Permissions.Extensions[teleport.CertExtensionPermitAgentForwarding] = ""
 	}
+	if !c.PermitPortForwarding {
+		delete(cert.Permissions.Extensions, teleport.CertExtensionPermitPortForwarding)
+	}
 	if len(c.Roles) != 0 {
 		roles, err := services.MarshalCertRoles(c.Roles)
 		if err != nil {

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -271,6 +271,7 @@ func makeKey(username string, allowedLogins []string, ttl time.Duration) (*Key, 
 		AllowedLogins:       allowedLogins,
 		TTL:                 ttl,
 		PermitAgentForwarding: true,
+		PermitPortForwarding:  true,
 	})
 	if err != nil {
 		return nil, err

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -181,6 +181,7 @@ func (s *KeyStoreTestSuite) makeSignedKey(c *check.C, makeExpired bool) *Key {
 		AllowedLogins:       allowedLogins,
 		TTL:                 ttl,
 		PermitAgentForwarding: false,
+		PermitPortForwarding:  true,
 	})
 	c.Assert(err, check.IsNil)
 	return &Key{

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -316,7 +316,7 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 			}
 			// send the new window size to the server
 			_, err = s.SendRequest(
-				sshutils.WindowChangeReq, false,
+				sshutils.WindowChangeRequest, false,
 				ssh.Marshal(sshutils.WinChangeReqParams{
 					W: uint32(winSize.Width),
 					H: uint32(winSize.Height),

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -406,12 +406,14 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		}
 	}
 
-	// read in and set session recording
-	clusterConfig, err := fc.Auth.SessionRecording.Parse()
+	// build cluster config from session recording and host key checking preferences
+	cfg.Auth.ClusterConfig, err = services.NewClusterConfig(services.ClusterConfigSpecV3{
+		SessionRecording:    fc.Auth.SessionRecording,
+		ProxyChecksHostKeys: fc.Auth.ProxyChecksHostKeys,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	cfg.Auth.ClusterConfig = clusterConfig
 
 	// read in and set the license file path (not used in open-source version)
 	licenseFile := fc.Auth.LicenseFile

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -47,91 +47,92 @@ var (
 	// true  = has sub-keys
 	// false = does not have sub-keys (a leaf)
 	validKeys = map[string]bool{
-		"namespace":            true,
-		"cluster_name":         true,
-		"trusted_clusters":     true,
-		"pid_file":             true,
-		"cert_file":            true,
-		"private_key_file":     true,
-		"cert":                 true,
-		"private_key":          true,
-		"checking_keys":        true,
-		"checking_key_files":   true,
-		"signing_keys":         true,
-		"signing_key_files":    true,
-		"allowed_logins":       true,
-		"teleport":             true,
-		"enabled":              true,
-		"ssh_service":          true,
-		"proxy_service":        true,
-		"auth_service":         true,
-		"auth_token":           true,
-		"auth_servers":         true,
-		"domain_name":          true,
-		"storage":              false,
-		"nodename":             true,
-		"log":                  true,
-		"period":               true,
-		"connection_limits":    true,
-		"max_connections":      true,
-		"max_users":            true,
-		"rates":                true,
-		"commands":             true,
-		"labels":               false,
-		"output":               true,
-		"severity":             true,
-		"role":                 true,
-		"name":                 true,
-		"type":                 true,
-		"data_dir":             true,
-		"web_listen_addr":      true,
-		"tunnel_listen_addr":   true,
-		"ssh_listen_addr":      true,
-		"listen_addr":          true,
-		"https_key_file":       true,
-		"https_cert_file":      true,
-		"advertise_ip":         true,
-		"authorities":          true,
-		"keys":                 true,
-		"reverse_tunnels":      true,
-		"addresses":            true,
-		"oidc_connectors":      true,
-		"id":                   true,
-		"issuer_url":           true,
-		"client_id":            true,
-		"client_secret":        true,
-		"redirect_url":         true,
-		"acr_values":           true,
-		"provider":             true,
-		"tokens":               true,
-		"region":               true,
-		"table_name":           true,
-		"access_key":           true,
-		"secret_key":           true,
-		"u2f":                  true,
-		"app_id":               true,
-		"facets":               true,
-		"authentication":       true,
-		"second_factor":        false,
-		"oidc":                 true,
-		"display":              false,
-		"scope":                false,
-		"claims_to_roles":      true,
-		"dynamic_config":       false,
-		"seed_config":          false,
-		"public_addr":          false,
-		"cache":                true,
-		"ttl":                  false,
-		"issuer":               false,
-		"permit_user_env":      false,
-		"ciphers":              false,
-		"kex_algos":            false,
-		"mac_algos":            false,
-		"connector_name":       false,
-		"session_recording":    false,
-		"read_capacity_units":  false,
-		"write_capacity_units": false,
-		"license_file":         false,
+		"namespace":              true,
+		"cluster_name":           true,
+		"trusted_clusters":       true,
+		"pid_file":               true,
+		"cert_file":              true,
+		"private_key_file":       true,
+		"cert":                   true,
+		"private_key":            true,
+		"checking_keys":          true,
+		"checking_key_files":     true,
+		"signing_keys":           true,
+		"signing_key_files":      true,
+		"allowed_logins":         true,
+		"teleport":               true,
+		"enabled":                true,
+		"ssh_service":            true,
+		"proxy_service":          true,
+		"auth_service":           true,
+		"auth_token":             true,
+		"auth_servers":           true,
+		"domain_name":            true,
+		"storage":                false,
+		"nodename":               true,
+		"log":                    true,
+		"period":                 true,
+		"connection_limits":      true,
+		"max_connections":        true,
+		"max_users":              true,
+		"rates":                  true,
+		"commands":               true,
+		"labels":                 false,
+		"output":                 true,
+		"severity":               true,
+		"role":                   true,
+		"name":                   true,
+		"type":                   true,
+		"data_dir":               true,
+		"web_listen_addr":        true,
+		"tunnel_listen_addr":     true,
+		"ssh_listen_addr":        true,
+		"listen_addr":            true,
+		"https_key_file":         true,
+		"https_cert_file":        true,
+		"advertise_ip":           true,
+		"authorities":            true,
+		"keys":                   true,
+		"reverse_tunnels":        true,
+		"addresses":              true,
+		"oidc_connectors":        true,
+		"id":                     true,
+		"issuer_url":             true,
+		"client_id":              true,
+		"client_secret":          true,
+		"redirect_url":           true,
+		"acr_values":             true,
+		"provider":               true,
+		"tokens":                 true,
+		"region":                 true,
+		"table_name":             true,
+		"access_key":             true,
+		"secret_key":             true,
+		"u2f":                    true,
+		"app_id":                 true,
+		"facets":                 true,
+		"authentication":         true,
+		"second_factor":          false,
+		"oidc":                   true,
+		"display":                false,
+		"scope":                  false,
+		"claims_to_roles":        true,
+		"dynamic_config":         false,
+		"seed_config":            false,
+		"public_addr":            false,
+		"cache":                  true,
+		"ttl":                    false,
+		"issuer":                 false,
+		"permit_user_env":        false,
+		"ciphers":                false,
+		"kex_algos":              false,
+		"mac_algos":              false,
+		"connector_name":         false,
+		"session_recording":      false,
+		"read_capacity_units":    false,
+		"write_capacity_units":   false,
+		"license_file":           false,
+		"proxy_checks_host_keys": false,
 	}
 )
 
@@ -469,7 +470,15 @@ type Auth struct {
 	Authentication *AuthenticationConfig `yaml:"authentication,omitempty"`
 
 	// SessionRecording determines where the session is recorded: node, proxy, or off.
-	SessionRecording SessionRecording `yaml:"session_recording"`
+	SessionRecording string `yaml:"session_recording"`
+
+	// ProxyChecksHostKeys is used when the proxy is in recording mode and
+	// determines if the proxy will check the host key of the client or not.
+	ProxyChecksHostKeys string `yaml:"proxy_checks_host_keys,omitempty"`
+
+	// LicenseFile is a path to the license file. The path can be either absolute or
+	// relative to the global data dir
+	LicenseFile string `yaml:"license_file,omitempty"`
 
 	// FOR INTERNAL USE:
 	// Authorities : 3rd party certificate authorities (CAs) this auth service trusts.
@@ -497,10 +506,6 @@ type Auth struct {
 	// it here overrides defaults.
 	// Deprecated: Remove in Teleport 2.4.1.
 	DynamicConfig *bool `yaml:"dynamic_config,omitempty"`
-
-	// LicenseFile is a path to the license file. The path can be either absolute or
-	// relative to the global data dir
-	LicenseFile string `yaml:"license_file,omitempty"`
 }
 
 // TrustedCluster struct holds configuration values under "trusted_clusters" key
@@ -624,16 +629,6 @@ func (u *UniversalSecondFactor) Parse() services.U2F {
 		AppID:  u.AppID,
 		Facets: u.Facets,
 	}
-}
-
-// SessionRecording determines where the session is recorded: node, proxy, or off.
-type SessionRecording string
-
-// Parse reads session_recording and creates a services.ClusterConfig.
-func (s SessionRecording) Parse() (services.ClusterConfig, error) {
-	return services.NewClusterConfig(services.ClusterConfigSpecV3{
-		SessionRecording: services.RecordingType(s),
-	})
 }
 
 // SSH is 'ssh_service' section of the config file

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -86,9 +86,16 @@ const (
 	ExecEventCode    = "exitCode"
 	ExecEventError   = "exitError"
 
+	// SubsystemEvent is the result of the execution of a subsystem.
+	SubsystemEvent = "subsystem"
+	SubsystemName  = "name"
+	SubsystemError = "exitError"
+
 	// Port forwarding event
-	PortForwardEvent = "port"
-	PortForwardAddr  = "addr"
+	PortForwardEvent   = "port"
+	PortForwardAddr    = "addr"
+	PortForwardSuccess = "success"
+	PortForwardErr     = "error"
 
 	// AuthAttemptEvent is authentication attempt that either
 	// succeeded or failed based on event status

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -243,9 +243,6 @@ type AuthConfig struct {
 	// Roles is a set of roles to pre-provision for this cluster
 	Roles []services.Role
 
-	// ClusterConfig stores cluster level configuration.
-	ClusterConfig services.ClusterConfig
-
 	// ClusterName is a name that identifies this authority and all
 	// host nodes in the cluster that will share this authority domain name
 	// as a base name, e.g. if authority domain name is example.com,
@@ -267,6 +264,9 @@ type AuthConfig struct {
 	// Preference defines the authentication preference (type and second factor) for
 	// the auth server.
 	Preference services.AuthPreference
+
+	// ClusterConfig stores cluster level configuration.
+	ClusterConfig services.ClusterConfig
 
 	// LicenseFile is a full path to the license file
 	LicenseFile string

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -74,6 +74,8 @@ type UserCertParams struct {
 	AllowedLogins []string
 	// PermitAgentForwarding permits agent forwarding for this cert
 	PermitAgentForwarding bool
+	// PermitPortForwarding permits port forwarding.
+	PermitPortForwarding bool
 	// Roles is a list of roles assigned to this user
 	Roles []string
 	// Compatibility specifies OpenSSH compatibility flags.

--- a/lib/services/migrations_test.go
+++ b/lib/services/migrations_test.go
@@ -274,7 +274,8 @@ func (s *MigrationsSuite) TestMigrateRoles(c *C) {
 		},
 		Spec: RoleSpecV3{
 			Options: RoleOptions{
-				MaxSessionTTL: NewDuration(20 * time.Hour),
+				MaxSessionTTL:  NewDuration(20 * time.Hour),
+				PortForwarding: true,
 			},
 			Allow: RoleConditions{
 				Logins:     []string{"foo"},

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -192,7 +192,8 @@ func (s *RoleSuite) TestRoleParse(c *C) {
 				},
 				Spec: RoleSpecV3{
 					Options: RoleOptions{
-						MaxSessionTTL: NewDuration(defaults.MaxCertDuration),
+						MaxSessionTTL:  NewDuration(defaults.MaxCertDuration),
+						PortForwarding: true,
 					},
 					Allow: RoleConditions{
 						NodeLabels: map[string]string{Wildcard: Wildcard},
@@ -213,7 +214,8 @@ func (s *RoleSuite) TestRoleParse(c *C) {
 		      "metadata": {"name": "name1"},
 		      "spec": {
                  "options": {
-                   "max_session_ttl": "20h"
+                   "max_session_ttl": "20h",
+                   "port_forwarding": true
                  },
                  "allow": {
                    "node_labels": {"a": "b"},
@@ -243,7 +245,8 @@ func (s *RoleSuite) TestRoleParse(c *C) {
 				},
 				Spec: RoleSpecV3{
 					Options: RoleOptions{
-						MaxSessionTTL: NewDuration(20 * time.Hour),
+						MaxSessionTTL:  NewDuration(20 * time.Hour),
+						PortForwarding: true,
 					},
 					Allow: RoleConditions{
 						NodeLabels: map[string]string{"a": "b"},

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -76,11 +76,11 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests()
 	s.usr, _ = user.Current()
 	s.ctx = &ServerContext{IsTestStub: true}
-	s.ctx.Login = s.usr.Username
+	s.ctx.Identity.Login = s.usr.Username
 	s.ctx.session = &session{id: "xxx"}
-	s.ctx.TeleportUser = "galt"
+	s.ctx.Identity.TeleportUser = "galt"
 	s.ctx.Conn = &ssh.ServerConn{Conn: s}
-	s.ctx.ExecRequest = &LocalExecRequest{Ctx: s.ctx}
+	s.ctx.ExecRequest = &localExec{Ctx: s.ctx}
 	s.localAddr, _ = utils.ParseAddr("127.0.0.1:3022")
 	s.remoteAddr, _ = utils.ParseAddr("10.0.0.5:4817")
 }

--- a/lib/srv/forward/remote.go
+++ b/lib/srv/forward/remote.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forward
+
+import (
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/utils/proxy"
+	"github.com/gravitational/trace"
+)
+
+// newRemoteSession will create and return a *ssh.Client and *ssh.Session
+// with a remote host.
+func newRemoteSession(dstAddr string, systemLogin string, userAgent agent.Agent, authHandlers *srv.AuthHandlers) (*ssh.Client, *ssh.Session, error) {
+	// the proxy will use the agent that has been forwarded to it as the auth
+	// method when connecting to the remote host
+	if userAgent == nil {
+		return nil, nil, trace.AccessDenied("agent must be forwarded to proxy")
+	}
+	authMethod := ssh.PublicKeysCallback(userAgent.Signers)
+
+	clientConfig := &ssh.ClientConfig{
+		User: systemLogin,
+		Auth: []ssh.AuthMethod{
+			authMethod,
+		},
+		HostKeyCallback: authHandlers.HostKeyAuth,
+		Timeout:         defaults.DefaultDialTimeout,
+	}
+
+	client, err := proxy.DialWithDeadline("tcp", dstAddr, clientConfig)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	session, err := client.NewSession()
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return client, session, nil
+}

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1,0 +1,707 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forward
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Server is a forwarding server. Server is used to create a single in-memory
+// SSH server that will forward connections to a remote server. It's used along
+// with the recording proxy to allow Teleport to record sessions with OpenSSH
+// nodes at the proxy level.
+//
+// To create a forwarding server and serve a single SSH connection on it:
+//
+//   serverConfig := forward.ServerConfig{
+//      ...
+//   }
+//   remoteServer, err := forward.New(serverConfig)
+//   if err != nil {
+//   	return nil, trace.Wrap(err)
+//   }
+//   go remoteServer.Serve()
+//
+//   conn, err := remoteServer.Dial()
+//   if err != nil {
+//   	return nil, trace.Wrap(err)
+//   }
+type Server struct {
+	log *log.Entry
+
+	clientConn net.Conn
+	serverConn net.Conn
+
+	// agent is the SSH user agent that was forwarded to the proxy.
+	agent agent.Agent
+	// agentChannel is the channel over which communication with the agent occurs.
+	agentChannel ssh.Channel
+
+	// hostCertificate is the SSH host certificate this in-memory server presents
+	// to the client.
+	hostCertificate ssh.Signer
+
+	// remoteClient represents a *ssh.Client connected to the target node.
+	remoteClient *ssh.Client
+	// remoteSession represents a *ssh.Session on the target node.
+	remoteSession *ssh.Session
+
+	// authHandlers are common authorization and authentication handlers shared
+	// by the regular and forwarding server.
+	authHandlers *srv.AuthHandlers
+	// termHandlers are common terminal handlers shared by the regular and
+	// forwarding server.
+	termHandlers *srv.TermHandlers
+
+	authClient      auth.ClientI
+	auditLog        events.IAuditLog
+	authService     auth.AccessPoint
+	sessionRegistry *srv.SessionRegistry
+	sessionServer   session.Service
+}
+
+// ServerConfig is the configuration needed to create an instance of a Server.
+type ServerConfig struct {
+	AuthClient      auth.ClientI
+	UserAgent       agent.Agent
+	Source          string
+	Destination     string
+	HostCertificate ssh.Signer
+}
+
+// CheckDefaults makes sure all required parameters are passed in.
+func (s *ServerConfig) CheckDefaults() error {
+	if s.AuthClient == nil {
+		return trace.BadParameter("auth client required")
+	}
+	if s.UserAgent == nil {
+		return trace.BadParameter("user agent required to connect to remote host")
+	}
+	if s.Source == "" {
+		return trace.BadParameter("source address required to identify client")
+	}
+	if s.Destination == "" {
+		return trace.BadParameter("destination address required to connect to remote host")
+	}
+	if s.HostCertificate == nil {
+		return trace.BadParameter("host certificate required to act on behalf of remote host")
+	}
+
+	return nil
+}
+
+// New creates a new unstarted Server.
+func New(c ServerConfig) (*Server, error) {
+	// check and make sure we everything we need to build a forwarding node
+	err := c.CheckDefaults()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// build a pipe connection to hook up the client and the server. we save both
+	// here and will pass them along to the context when we create it so they
+	// can be closed by the context.
+	srcAddr, err := utils.ParseAddr(c.Source)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	dstAddr, err := utils.ParseAddr(c.Destination)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	serverConn, clientConn := utils.DualPipeNetConn(srcAddr, dstAddr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	s := &Server{
+		log: log.WithFields(log.Fields{
+			trace.Component: teleport.ComponentForwardingNode,
+			trace.ComponentFields: map[string]string{
+				"src-addr": c.Source,
+				"dst-addr": c.Destination,
+			},
+		}),
+		agent:           c.UserAgent,
+		hostCertificate: c.HostCertificate,
+		authClient:      c.AuthClient,
+		auditLog:        c.AuthClient,
+		authService:     c.AuthClient,
+		sessionServer:   c.AuthClient,
+		serverConn:      serverConn,
+		clientConn:      clientConn,
+	}
+
+	s.sessionRegistry = srv.NewSessionRegistry(s)
+
+	// common auth handlers
+	s.authHandlers = &srv.AuthHandlers{
+		Entry: log.WithFields(log.Fields{
+			trace.Component:       teleport.ComponentForwardingNode,
+			trace.ComponentFields: log.Fields{},
+		}),
+		Server:      nil,
+		Component:   teleport.ComponentForwardingNode,
+		AuditLog:    c.AuthClient,
+		AccessPoint: c.AuthClient,
+	}
+
+	// common term handlers
+	s.termHandlers = &srv.TermHandlers{
+		SessionRegistry: s.sessionRegistry,
+	}
+
+	return s, nil
+}
+
+// ID returns 0 for forwarding servers for now.
+func (s *Server) ID() string {
+	// TODO(russjones): I can't set this until we merge in the lib/reversetunnel
+	// changes because localsite and remotesite are the onces that create this
+	// server.
+	return "0"
+}
+
+// GetNamespace returns the namespace the forwarding server resides in.
+func (s *Server) GetNamespace() string {
+	return defaults.Namespace
+}
+
+// AdvertiseAddr is the address of the remote host this forwarding server is
+// connected to.
+func (s *Server) AdvertiseAddr() string {
+	return s.clientConn.RemoteAddr().String()
+}
+
+// Component is the type of node this server is.
+func (s *Server) Component() string {
+	return teleport.ComponentForwardingNode
+}
+
+// EmitAuditEvent sends an event to the Audit Log.
+func (s *Server) EmitAuditEvent(eventType string, fields events.EventFields) {
+	auditLog := s.GetAuditLog()
+	if auditLog != nil {
+		if err := auditLog.EmitAuditEvent(eventType, fields); err != nil {
+			s.log.Error(err)
+		}
+	} else {
+		s.log.Warn("SSH server has no audit log")
+	}
+}
+
+// PermitUserEnvironment is always false because it's up the the remote host
+// to decide if the user environment will be read or not.
+func (s *Server) PermitUserEnvironment() bool {
+	return false
+}
+
+// GetAuditLog returns the Audit Log for this cluster.
+func (s *Server) GetAuditLog() events.IAuditLog {
+	return s.auditLog
+}
+
+// GetAccessPoint returns an auth.AccessPoint for this cluster.
+func (s *Server) GetAccessPoint() auth.AccessPoint {
+	return s.authService
+}
+
+// GetSessionServer returns a session server.
+func (s *Server) GetSessionServer() session.Service {
+	return s.sessionServer
+}
+
+// Dial returns the client connection created by pipeAddrConn.
+func (s *Server) Dial() (net.Conn, error) {
+	return s.clientConn, nil
+}
+
+func (s *Server) Serve() {
+	config := &ssh.ServerConfig{
+		PublicKeyCallback: s.authHandlers.UserKeyAuth,
+	}
+	config.AddHostKey(s.hostCertificate)
+
+	sconn, chans, reqs, err := ssh.NewServerConn(s.serverConn, config)
+	if err != nil {
+		s.clientConn.Close()
+		s.serverConn.Close()
+
+		s.log.Errorf("Unable to create server connection: %v.", err)
+		return
+	}
+
+	// take connection and build identity for the user from it to be passed
+	// along with context
+	identityContext, err := s.authHandlers.CreateIdentityContext(sconn)
+	if err != nil {
+		s.clientConn.Close()
+		s.serverConn.Close()
+
+		s.log.Errorf("Unable to create server connection: %v.", err)
+		return
+	}
+
+	// build a remote session to the remote node
+	s.log.Debugf("Creating remote connection to %v@%v", sconn.User(), s.clientConn.RemoteAddr().String())
+	s.remoteClient, s.remoteSession, err = newRemoteSession(s.clientConn.RemoteAddr().String(), sconn.User(), s.agent, s.authHandlers)
+	if err != nil {
+		// reject the connection with an error so the client doesn't hang then
+		// close the connection
+		s.rejectChannel(chans, err)
+		sconn.Close()
+
+		s.clientConn.Close()
+		s.serverConn.Close()
+
+		s.log.Errorf("Unable to create remote connection: %v", err)
+		return
+	}
+
+	// create a cancelable context and pass it to a keep alive loop. the keep
+	// alive loop will keep pinging the remote server and after it has missed a
+	// certain number of keep alive requests it will cancel the context which
+	// will close any listening goroutines.
+	ctx, cancel := context.WithCancel(context.Background())
+	go s.keepAliveLoop(cancel, sconn)
+	go s.handleConnection(ctx, sconn, identityContext, chans, reqs)
+}
+
+func (s *Server) handleConnection(ctx context.Context, sconn *ssh.ServerConn, identityContext srv.IdentityContext, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request) {
+	for {
+		select {
+		// global out-of-band requests
+		case newRequest := <-reqs:
+			if newRequest == nil {
+				s.log.Debugf("Closing connection to %v", sconn.RemoteAddr())
+				return
+			}
+			go s.handleGlobalRequest(newRequest)
+		// channel requests
+		case newChannel := <-chans:
+			if newChannel == nil {
+				s.log.Debugf("Closing connection to %v", sconn.RemoteAddr())
+				return
+			}
+			go s.handleChannel(sconn, identityContext, newChannel)
+		// if the heartbeats failed, we close everything and cleanup
+		case <-ctx.Done():
+			sconn.Close()
+
+			s.clientConn.Close()
+			s.serverConn.Close()
+
+			s.log.Debugf("Context closed, cleaning up and closing forwarding server")
+			return
+		}
+	}
+}
+
+func (s *Server) keepAliveLoop(cancel context.CancelFunc, sconn *ssh.ServerConn) {
+	var missed int
+
+	// tick at 1/3 of the idle timeout duration
+	keepAliveTick := time.NewTicker(defaults.DefaultIdleConnectionDuration / 3)
+	defer keepAliveTick.Stop()
+
+	for {
+		select {
+		case <-keepAliveTick.C:
+			// send a keep alive to the target node and the client to ensure both are alive.
+			proxyToNodeOk := s.sendKeepAliveWithTimeout(s.remoteClient, defaults.ReadHeadersTimeout)
+			proxyToClientOk := s.sendKeepAliveWithTimeout(sconn, defaults.ReadHeadersTimeout)
+			if proxyToNodeOk && proxyToClientOk {
+				missed = 0
+				continue
+			}
+
+			// if we miss 3 in a row the connections dead, call cancel and cleanup
+			missed += 1
+			if missed == 3 {
+				s.log.Infof("Missed %v keep alive messages, closing connection", missed)
+				cancel()
+				return
+			}
+		}
+	}
+}
+
+func (s *Server) rejectChannel(chans <-chan ssh.NewChannel, err error) {
+	for newChannel := range chans {
+		err := newChannel.Reject(ssh.ConnectionFailed, err.Error())
+		if err != nil {
+			s.log.Errorf("Unable to reject and close connection.")
+		}
+		return
+	}
+}
+
+func (s *Server) handleGlobalRequest(req *ssh.Request) {
+	ok, err := s.remoteSession.SendRequest(req.Type, req.WantReply, req.Payload)
+	if err != nil {
+		s.log.Warnf("Failed to forward global request %v: %v", req.Type, err)
+		return
+	}
+	if req.WantReply {
+		err = req.Reply(ok, nil)
+		if err != nil {
+			s.log.Warnf("Failed to reply to global request: %v: %v", req.Type, err)
+		}
+	}
+}
+
+func (s *Server) handleChannel(sconn *ssh.ServerConn, identityContext srv.IdentityContext, nch ssh.NewChannel) {
+	channelType := nch.ChannelType()
+
+	switch channelType {
+	// a client requested the terminal size to be sent along with every
+	// session message (Teleport-specific SSH channel for web-based terminals)
+	case "x-teleport-request-resize-events":
+		ch, _, _ := nch.Accept()
+		go s.handleTerminalResize(sconn, ch)
+	// interactive sessions
+	case "session":
+		ch, requests, err := nch.Accept()
+		if err != nil {
+			s.log.Infof("Unable to accept channel: %v", err)
+		}
+		go s.handleSessionRequests(sconn, identityContext, ch, requests)
+	// port forwarding
+	case "direct-tcpip":
+		req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
+		if err != nil {
+			s.log.Errorf("Failed to parse request data: %v, err: %v", string(nch.ExtraData()), err)
+			nch.Reject(ssh.UnknownChannelType, "failed to parse direct-tcpip request")
+		}
+		ch, _, err := nch.Accept()
+		if err != nil {
+			s.log.Infof("Unable to accept channel: %v", err)
+		}
+		go s.handleDirectTCPIPRequest(sconn, identityContext, ch, req)
+	default:
+		nch.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
+	}
+}
+
+// handleDirectTCPIPRequest handles port forwarding requests.
+func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, req *sshutils.DirectTCPIPReq) {
+	ctx := srv.NewServerContext(s, sconn, identityContext)
+
+	ctx.RemoteClient = s.remoteClient
+	ctx.RemoteSession = s.remoteSession
+	ctx.SetAgent(s.agent, s.agentChannel)
+
+	ctx.AddCloser(ch)
+	ctx.AddCloser(sconn)
+	ctx.AddCloser(s.serverConn)
+	ctx.AddCloser(s.clientConn)
+	ctx.AddCloser(s.remoteSession)
+	ctx.AddCloser(s.remoteClient)
+
+	defer ctx.Debugf("Closed direct-tcp context")
+	defer ctx.Close()
+
+	srcAddr := fmt.Sprintf("%v:%d", req.Orig, req.OrigPort)
+	dstAddr := fmt.Sprintf("%v:%d", req.Host, req.Port)
+
+	// check if the role allows port forwarding for this user
+	err := s.authHandlers.CheckPortForward(dstAddr, ctx)
+	if err != nil {
+		ch.Stderr().Write([]byte(err.Error()))
+		return
+	}
+
+	ctx.Debugf("Opening direct-tcpip channel from %v to %v", srcAddr, dstAddr)
+
+	conn, err := s.remoteClient.Dial("tcp", dstAddr)
+	if err != nil {
+		ctx.Infof("Failed to connect to: %v: %v", dstAddr, err)
+		return
+	}
+	defer conn.Close()
+
+	// emit a port forwarding audit event
+	s.EmitAuditEvent(events.PortForwardEvent, events.EventFields{
+		events.PortForwardAddr:    dstAddr,
+		events.PortForwardSuccess: true,
+		events.EventLogin:         ctx.Identity.Login,
+		events.LocalAddr:          sconn.LocalAddr().String(),
+		events.RemoteAddr:         sconn.RemoteAddr().String(),
+	})
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		io.Copy(ch, conn)
+		ch.Close()
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		io.Copy(conn, ch)
+		conn.Close()
+	}()
+
+	wg.Wait()
+}
+
+// handleTerminalResize is called by the web proxy via its SSH connection.
+// when a web browser connects to the web API, the web proxy asks us,
+// by creating this new SSH channel, to start injecting the terminal size
+// into every SSH write back to it.
+//
+// this is the only way to make web-based terminal UI not break apart
+// when window changes its size
+func (s *Server) handleTerminalResize(sconn *ssh.ServerConn, ch ssh.Channel) {
+	err := s.sessionRegistry.PushTermSizeToParty(sconn, ch)
+	if err != nil {
+		s.log.Warnf("Unable to push terminal size to party: %v", err)
+	}
+}
+
+// handleSessionRequests handles out of band session requests once the session channel has been created
+// this function's loop handles all the "exec", "subsystem" and "shell" requests.
+func (s *Server) handleSessionRequests(sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, in <-chan *ssh.Request) {
+	ctx := srv.NewServerContext(s, sconn, identityContext)
+
+	ctx.RemoteClient = s.remoteClient
+	ctx.RemoteSession = s.remoteSession
+	ctx.SetAgent(s.agent, s.agentChannel)
+
+	ctx.AddCloser(ch)
+	ctx.AddCloser(sconn)
+	ctx.AddCloser(s.serverConn)
+	ctx.AddCloser(s.clientConn)
+	ctx.AddCloser(s.remoteSession)
+	ctx.AddCloser(s.remoteClient)
+
+	defer s.log.Debugf("Closed session context")
+	defer ctx.Close()
+
+	for {
+		// update ctx with the session ID:
+		err := ctx.CreateOrJoinSession(s.sessionRegistry)
+		if err != nil {
+			errorMessage := fmt.Sprintf("unable to update context: %v", err)
+			ctx.Errorf("%v", errorMessage)
+
+			// write the error to channel and close it
+			ch.Stderr().Write([]byte(errorMessage))
+			_, err := ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: teleport.RemoteCommandFailure}))
+			if err != nil {
+				ctx.Errorf("Failed to send exit status %v", errorMessage)
+			}
+			return
+		}
+
+		select {
+		case result := <-ctx.SubsystemResultCh:
+			// this means that subsystem has finished executing and
+			// want us to close session and the channel
+			ctx.Debugf("Subsystem execution result: %v", result.Err)
+			return
+		case req := <-in:
+			if req == nil {
+				// this will happen when the client closes/drops the connection
+				ctx.Debugf("Client %v disconnected", sconn.RemoteAddr())
+				return
+			}
+			if err := s.dispatch(ch, req, ctx); err != nil {
+				s.replyError(ch, req, err)
+				return
+			}
+			if req.WantReply {
+				req.Reply(true, nil)
+			}
+		case result := <-ctx.ExecResultCh:
+			ctx.Debugf("Exec request (%q) complete: %v", result.Command, result.Code)
+
+			// this means that exec process has finished and delivered the execution result,
+			// we send it back and close the session
+			_, err := ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: uint32(result.Code)}))
+			if err != nil {
+				ctx.Infof("Failed to send exit status for %v: %v", result.Command, err)
+			}
+			return
+		}
+	}
+}
+
+func (s *Server) dispatch(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
+	ctx.Debugf("Handling request %v (WantReply=%v)", req.Type, req.WantReply)
+
+	switch req.Type {
+	case sshutils.ExecRequest:
+		return s.termHandlers.HandleExec(ch, req, ctx)
+	case sshutils.PTYRequest:
+		return s.termHandlers.HandlePTYReq(ch, req, ctx)
+	case sshutils.ShellRequest:
+		return s.termHandlers.HandleShell(ch, req, ctx)
+	case sshutils.WindowChangeRequest:
+		return s.termHandlers.HandleWinChange(ch, req, ctx)
+	case sshutils.EnvRequest:
+		return s.handleEnv(ch, req, ctx)
+	case sshutils.SubsystemRequest:
+		return s.handleSubsystem(ch, req, ctx)
+	case sshutils.AgentForwardRequest:
+		// to maintain interoperability with OpenSSH, agent forwarding requests
+		// should never fail, all errors should be logged and we should continue
+		// processing requests.
+		err := s.handleAgentForward(ch, req, ctx)
+		if err != nil {
+			s.log.Debug(err)
+		}
+		return nil
+	default:
+		return trace.BadParameter(
+			"%v doesn't support request type '%v'", s.Component(), req.Type)
+	}
+}
+
+func (s *Server) handleAgentForward(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
+	// check if the user's RBAC role allows agent forwarding
+	err := s.authHandlers.CheckAgentForward(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// route authentication requests to the agent that was forwarded to the proxy
+	err = agent.ForwardToAgent(s.remoteClient, ctx.GetAgent())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// make an "auth-agent-req@openssh.com" request on the target node
+	err = agent.RequestAgentForwarding(s.remoteSession)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func (s *Server) handleSubsystem(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
+	subsystem, err := parseSubsystemRequest(req, ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// start the requested subsystem, if it fails to start return result right away
+	err = subsystem.Start(ch)
+	if err != nil {
+		ctx.SendSubsystemResult(srv.SubsystemResult{
+			Name: subsystem.subsytemName,
+			Err:  trace.Wrap(err),
+		})
+		return trace.Wrap(err)
+	}
+
+	// wait for the subsystem to finish and return that result
+	go func() {
+		err := subsystem.Wait()
+		ctx.SendSubsystemResult(srv.SubsystemResult{
+			Name: subsystem.subsytemName,
+			Err:  trace.Wrap(err),
+		})
+	}()
+
+	return nil
+}
+
+func (s *Server) handleEnv(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
+	var e sshutils.EnvReqParams
+	if err := ssh.Unmarshal(req.Payload, &e); err != nil {
+		ctx.Error(err)
+		return trace.Wrap(err, "failed to parse env request")
+	}
+
+	err := s.remoteSession.Setenv(e.Name, e.Value)
+	if err != nil {
+		s.log.Debugf("Unable to set environment variable: %v: %v", e.Name, e.Value)
+	}
+
+	return nil
+}
+
+// RequestSender is an interface that impliments SendRequest. It is used so
+// server and client connections can be passed to functions to send requests.
+type RequestSender interface {
+	// SendRequest is used to send a out-of-band request.
+	SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error)
+}
+
+// sendKeepAliveWithTimeout sends a keepalive@openssh.com message to the remote
+// client. A manual timeout is needed here because SendRequest will wait for a
+// response forever.
+func (s *Server) sendKeepAliveWithTimeout(conn RequestSender, timeout time.Duration) bool {
+	errorCh := make(chan error, 1)
+
+	go func() {
+		_, _, err := conn.SendRequest(teleport.KeepAliveReqType, true, nil)
+		errorCh <- err
+	}()
+
+	select {
+	case err := <-errorCh:
+		if err != nil {
+			return false
+		}
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
+	s.log.Error(err)
+	message := []byte(utils.UserMessageFromError(err))
+	ch.Stderr().Write(message)
+	if req.WantReply {
+		req.Reply(false, message)
+	}
+}
+
+func parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext) (*remoteSubsystem, error) {
+	var r sshutils.SubsystemReq
+	err := ssh.Unmarshal(req.Payload, &r)
+	if err != nil {
+		return nil, trace.BadParameter("failed to parse subsystem request: %v", err)
+	}
+
+	return parseRemoteSubsystem(context.Background(), r.Name, ctx), nil
+}

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forward
+
+import (
+	"context"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/trace"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// remoteSubsystem is a subsystem that executes on a remote node.
+type remoteSubsystem struct {
+	log *log.Entry
+
+	serverContext *srv.ServerContext
+	subsytemName  string
+
+	ctx     context.Context
+	errorCh chan error
+}
+
+// parseRemoteSubsystem returns *remoteSubsystem which can be used to run a subsystem on a remote node.
+func parseRemoteSubsystem(ctx context.Context, subsytemName string, serverContext *srv.ServerContext) *remoteSubsystem {
+	return &remoteSubsystem{
+		log: log.WithFields(log.Fields{
+			trace.Component: teleport.ComponentRemoteSubsystem,
+			trace.ComponentFields: map[string]string{
+				"name": subsytemName,
+			},
+		}),
+		serverContext: serverContext,
+		subsytemName:  subsytemName,
+		ctx:           ctx,
+		errorCh:       make(chan error, 3),
+	}
+}
+
+// Start will begin execution of the remote subsytem on the passed in channel.
+func (r *remoteSubsystem) Start(channel ssh.Channel) error {
+	session := r.serverContext.RemoteSession
+
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	stderr, err := session.StderrPipe()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// request the subsystem from the remote node. if successful, the user can
+	// interact with the remote subsystem with stdin, stdout, and stderr.
+	err = session.RequestSubsystem(r.subsytemName)
+	if err != nil {
+		// emit an event to the audit log with the reason remote execution failed
+		r.emitAuditEvent(err)
+
+		return trace.Wrap(err)
+	}
+
+	// copy back and forth between stdin, stdout, and stderr and the SSH channel.
+	go func() {
+		defer session.Close()
+
+		_, err := io.Copy(channel, stdout)
+		r.errorCh <- err
+	}()
+	go func() {
+		defer session.Close()
+
+		_, err := io.Copy(channel.Stderr(), stderr)
+		r.errorCh <- err
+	}()
+	go func() {
+		defer session.Close()
+
+		_, err := io.Copy(stdin, channel)
+		r.errorCh <- err
+	}()
+
+	return nil
+}
+
+// Wait until the remote subsystem has finished execution and then return the last error.
+func (r *remoteSubsystem) Wait() error {
+	var lastErr error
+
+	for i := 0; i < 3; i++ {
+		select {
+		case err := <-r.errorCh:
+			if err != nil && err != io.EOF {
+				r.log.Warnf("Connection problem: %v %T", trace.DebugReport(err), err)
+				lastErr = err
+			}
+		case <-r.ctx.Done():
+			lastErr = trace.ConnectionProblem(nil, "context is closing")
+		}
+	}
+
+	// emit an event to the audit log with the result of execution
+	r.emitAuditEvent(lastErr)
+
+	return lastErr
+}
+
+func (r *remoteSubsystem) emitAuditEvent(err error) {
+	srv := r.serverContext.GetServer()
+
+	srv.EmitAuditEvent(events.SubsystemEvent, events.EventFields{
+		events.SubsystemName:  r.subsytemName,
+		events.SubsystemError: err,
+		events.EventUser:      r.serverContext.Identity.TeleportUser,
+		events.EventLogin:     r.serverContext.Identity.Login,
+		events.LocalAddr:      r.serverContext.RemoteClient.LocalAddr().String(),
+		events.RemoteAddr:     r.serverContext.RemoteClient.RemoteAddr().String(),
+	})
+}

--- a/lib/srv/subsystem.go
+++ b/lib/srv/subsystem.go
@@ -22,6 +22,10 @@ import (
 
 // SubsystemResult is a result of execution of the subsystem.
 type SubsystemResult struct {
+	// Name holds the name of the subsystem that was executed.
+	Name string
+
+	// Err holds the result of execution of the subsystem.
 	Err error
 }
 

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srv
+
+import (
+	"golang.org/x/crypto/ssh"
+
+	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/trace"
+)
+
+// TermHandlers are common terminal handling functions used by both the
+// regular and forwarding server.
+type TermHandlers struct {
+	SessionRegistry *SessionRegistry
+}
+
+// HandleExec handles requests of type "exec" which can execute with or
+// without a TTY. Result of execution is propagated back on the ExecResult
+// channel of the context.
+func (t *TermHandlers) HandleExec(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
+	execRequest, err := parseExecRequest(req, ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// a terminal has been previously allocate for this command.
+	// run this inside an interactive session
+	if ctx.GetTerm() != nil {
+		return t.SessionRegistry.OpenSession(ch, req, ctx)
+	}
+
+	// otherwise, regular execution
+	result, err := execRequest.Start(ch)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// if the program failed to start, we should send that result back
+	if result != nil {
+		ctx.Debugf("Exec request (%v) result: %v", execRequest, result)
+		ctx.SendExecResult(*result)
+	}
+
+	// in case if result is nil and no error, this means that program is
+	// running in the background
+	go func() {
+		result, err = execRequest.Wait()
+		if err != nil {
+			ctx.Errorf("Exec request (%v) wait failed: %v", execRequest, err)
+		}
+		if result != nil {
+			ctx.SendExecResult(*result)
+		}
+	}()
+
+	return nil
+}
+
+// HandlePTYReq handles requests of type "pty-req" which allocate a TTY for
+// "exec" or "shell" requests. The "pty-req" includes the size of the TTY as
+// well as the terminal type requested.
+func (t *TermHandlers) HandlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
+	// parse and extract the requested window size of the pty
+	ptyRequest, err := parsePTYReq(req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	termModes, err := ptyRequest.TerminalModes()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	params, err := rsession.NewTerminalParamsFromUint32(ptyRequest.W, ptyRequest.H)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	ctx.Debugf("Requested terminal of size %v", *params)
+
+	// get an existing terminal or create a new one
+	term := ctx.GetTerm()
+	if term == nil {
+		// a regular or forwarding terminal will be allocated
+		term, err = NewTerminal(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		ctx.SetTerm(term)
+	}
+	term.SetWinSize(*params)
+	term.SetTermType(ptyRequest.Env)
+	term.SetTerminalModes(termModes)
+
+	// update the session
+	if err := t.SessionRegistry.NotifyWinChange(*params, ctx); err != nil {
+		ctx.Error("Unable to update session: %v", err)
+	}
+
+	return nil
+}
+
+// HandleShell handles requests of type "shell" which request a interactive
+// shell be created within a TTY.
+func (t *TermHandlers) HandleShell(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
+	var err error
+
+	// creating an empty exec request implies a interactive shell was requested
+	ctx.ExecRequest, err = NewExecRequest(ctx, "")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := t.SessionRegistry.OpenSession(ch, req, ctx); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// HandleWinChange handles requests of type "window-change" which update the
+// size of the TTY running on the server.
+func (t *TermHandlers) HandleWinChange(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
+	params, err := parseWinChange(req)
+	if err != nil {
+		ctx.Error(err)
+		return trace.Wrap(err)
+	}
+
+	term := ctx.GetTerm()
+	if term != nil {
+		err = term.SetWinSize(*params)
+		if err != nil {
+			ctx.Errorf("Unable to set window size: %v", err)
+		}
+	}
+
+	err = t.SessionRegistry.NotifyWinChange(*params, ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func parseExecRequest(req *ssh.Request, ctx *ServerContext) (Exec, error) {
+	var err error
+
+	var r sshutils.ExecReq
+	if err = ssh.Unmarshal(req.Payload, &r); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ctx.ExecRequest, err = NewExecRequest(ctx, r.Command)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ctx.ExecRequest, nil
+}
+
+func parsePTYReq(req *ssh.Request) (*sshutils.PTYReqParams, error) {
+	var r sshutils.PTYReqParams
+	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// if the caller asked for an invalid sized pty (like ansible
+	// which asks for a 0x0 size) update the request with defaults
+	if err := r.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &r, nil
+}
+
+func parseWinChange(req *ssh.Request) (*rsession.TerminalParams, error) {
+	var r sshutils.WinChangeReqParams
+	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return params, nil
+}

--- a/lib/sshutils/req.go
+++ b/lib/sshutils/req.go
@@ -17,6 +17,10 @@ limitations under the License.
 package sshutils
 
 import (
+	"encoding/binary"
+
+	"golang.org/x/crypto/ssh"
+
 	"github.com/gravitational/teleport"
 
 	"github.com/gravitational/trace"
@@ -44,6 +48,54 @@ type PTYReqParams struct {
 	Wpx   uint32
 	Hpx   uint32
 	Modes string
+}
+
+// TerminalModes converts encoded terminal modes into a ssh.TerminalModes map.
+// The encoding is described in: https://tools.ietf.org/html/rfc4254#section-8
+//
+//   All 'encoded terminal modes' (as passed in a pty request) are encoded
+//   into a byte stream.  It is intended that the coding be portable
+//   across different environments.  The stream consists of opcode-
+//   argument pairs wherein the opcode is a byte value.  Opcodes 1 to 159
+//   have a single uint32 argument.  Opcodes 160 to 255 are not yet
+//   defined, and cause parsing to stop (they should only be used after
+//   any other data).  The stream is terminated by opcode TTY_OP_END
+//   (0x00).
+//
+// In practice, this means encoded terminal modes get translated like below:
+//
+//  0x80 0x00 0x00 0x38 0x40  0x81 0x00 0x00 0x38 0x40  0x35 0x00 0x00 0x00 0x00  0x00
+//  |___|__________________|  |___|__________________|  |___|__________________|  |__|
+//         0x80: 0x3840              0x81: 0x3840              0x35: 0x00         0x00
+//  ssh.TTY_OP_ISPEED: 14400  ssh.TTY_OP_OSPEED: 14400         ssh.ECHO:0
+//
+func (p *PTYReqParams) TerminalModes() (ssh.TerminalModes, error) {
+	terminalModes := ssh.TerminalModes{}
+
+	if len(p.Modes) == 1 && p.Modes[0] == 0 {
+		return terminalModes, nil
+	}
+
+	chunkSize := 5
+	for i := 0; i < len(p.Modes); i = i + chunkSize {
+		// the first byte of the chunk is the key
+		key := uint8(p.Modes[i])
+
+		// a key with value 0 means is the termination of the stream
+		if key == 0 {
+			break
+		}
+
+		// the remaining 4 bytes of the chunk are the value
+		if i+chunkSize > len(p.Modes) {
+			return nil, trace.BadParameter("invalid terminal modes encoding")
+		}
+		value := binary.BigEndian.Uint32([]byte(p.Modes[i+1 : i+chunkSize]))
+
+		terminalModes[key] = value
+	}
+
+	return terminalModes, nil
 }
 
 // Check validates PTY parameters.
@@ -81,17 +133,33 @@ type SubsystemReq struct {
 	Name string
 }
 
+// SessionEnvVar is environment variable for SSH session
+const SessionEnvVar = "TELEPORT_SESSION"
+
 const (
-	// SessionEnvVar is environment variable for SSH session
-	SessionEnvVar = "TELEPORT_SESSION"
-	// SetEnvReq sets environment requests
-	SetEnvReq = "env"
-	// WindowChangeReq is a request to change window
-	WindowChangeReq = "window-change"
-	// PTYReq is a request for PTY
-	PTYReq = "pty-req"
-	// AgentReq is ssh agent requesst
-	AgentReq = "auth-agent-req@openssh.com"
+	// ExecRequest is a request to run a command.
+	ExecRequest = "exec"
+
+	// ShellRequest is a request for a shell.
+	ShellRequest = "shell"
+
+	// EnvRequest is a request to set an environment variable.
+	EnvRequest = "env"
+
+	// SubsystemRequest is a request to run a subsystem.
+	SubsystemRequest = "subsystem"
+
+	// WindowChangeRequest is a request to change window.
+	WindowChangeRequest = "window-change"
+
+	// PTYRequest is a request for PTY.
+	PTYRequest = "pty-req"
+
+	// AgentForwardRequest is SSH agent request.
+	AgentForwardRequest = "auth-agent-req@openssh.com"
+
+	// AuthAgentRequest is a request to a SSH client to open an agent channel.
+	AuthAgentRequest = "auth-agent@openssh.com"
 )
 
 const (

--- a/lib/utils/fakeconn.go
+++ b/lib/utils/fakeconn.go
@@ -83,6 +83,18 @@ func (nc *PipeNetConn) SetWriteDeadline(t time.Time) error {
 	return nil
 }
 
+// DualPipeAddrConn creates a net.Pipe to connect a client and a server. The
+// two net.Conn instances are wrapped in an addrConn which holds the source and
+// destination addresses.
+func DualPipeNetConn(srcAddr net.Addr, dstAddr net.Addr) (*PipeNetConn, *PipeNetConn) {
+	server, client := net.Pipe()
+
+	serverConn := NewPipeNetConn(server, server, server, dstAddr, srcAddr)
+	clientConn := NewPipeNetConn(client, client, client, srcAddr, dstAddr)
+
+	return serverConn, clientConn
+}
+
 func SplitReaders(r1 io.Reader, r2 io.Reader) io.Reader {
 	reader, writer := io.Pipe()
 	go io.Copy(writer, r1)

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -138,7 +138,7 @@ func (t *TerminalHandler) resizePTYWindow(params session.TerminalParams) error {
 	}
 	_, err := t.sshSession.SendRequest(
 		// send SSH "window resized" SSH request:
-		sshutils.WindowChangeReq,
+		sshutils.WindowChangeRequest,
 		// no response needed
 		false,
 		ssh.Marshal(sshutils.WinChangeReqParams{


### PR DESCRIPTION
**Purpose**

To support recording sessions with OpenSSH nodes Teleport needs to create a in-memory SSH server in the proxy that forwards connections to a remote host. This PR creates this server but does not use it yet.

**Implementation**

* Consolidate handlers between the regular and forwarding server further in `lib/srv/authhandlers.go`.
* Created new forwarding server in `lib/srv/forward/sshserver.go`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1481
Fixes https://github.com/gravitational/teleport/issues/1486
Fixes https://github.com/gravitational/teleport/issues/1487