### PR TITLE
Updated reverse tunnel to allow use to forwarding server.

### DIFF
--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/crypto/ssh/agent"
+
 	"github.com/gravitational/teleport/lib/auth"
 )
 
@@ -29,7 +31,7 @@ import (
 // There are two implementations of this interface: local and remote sites.
 type RemoteSite interface {
 	// Dial dials any address within the site network
-	Dial(fromAddr, toAddr net.Addr) (net.Conn, error)
+	Dial(fromAddr, toAddr net.Addr, userAgent agent.Agent) (net.Conn, error)
 	// GetLastConnected returns last time the remote site was seen connected
 	GetLastConnected() time.Time
 	// GetName returns site name (identified by authority domain's name)

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reversetunnel
+
+import (
+	"net"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/native"
+
+	"github.com/gravitational/trace"
+)
+
+// certificateCache holds host certificates used by the recording proxy. It's
+// created at the package level because both local site and remote site use it.
+var certificateCache map[string]ssh.Signer = make(map[string]ssh.Signer)
+
+// cacheMutex is for go routine safety.
+var cacheMutex sync.Mutex
+
+// getCertificate will fetch a certificate from the cache. If the certificate
+// is not in the cache, it will be generated, put in the cache, and returned.
+func getCertificate(addr string, authService auth.ClientI) (ssh.Signer, error) {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+
+	var certificate ssh.Signer
+	var err error
+	var ok bool
+
+	// extract the principal from the address
+	principal, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	certificate, ok = certificateCache[principal]
+	if !ok {
+		certificate, err = generateHostCert(principal, authService)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		certificateCache[principal] = certificate
+	}
+
+	return certificate, nil
+}
+
+// generateHostCert will generate a SSH host certificate for a given principal.
+func generateHostCert(principal string, authService auth.ClientI) (ssh.Signer, error) {
+	keygen := native.New()
+	defer keygen.Close()
+
+	// generate public/private keypair
+	privBytes, pubBytes, err := keygen.GenerateKeyPair("")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// have auth server sign and return a host certificate to us
+	clusterName, err := authService.GetDomainName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	certBytes, err := authService.GenerateHostCert(pubBytes, principal, principal, clusterName, teleport.Roles{teleport.RoleNode}, 0)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// create a *ssh.Certificate
+	privateKey, err := ssh.ParsePrivateKey(privBytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	publicKey, _, _, _, err := ssh.ParseAuthorizedKey(certBytes)
+	if err != nil {
+		return nil, err
+	}
+	cert, ok := publicKey.(*ssh.Certificate)
+	if !ok {
+		return nil, trace.BadParameter("not a certificate")
+	}
+
+	// return a ssh.Signer
+	s, err := ssh.NewCertSigner(cert, privateKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return s, nil
+}

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -12,7 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package reversetunnel
@@ -21,6 +20,8 @@ import (
 	"fmt"
 	"net"
 	"time"
+
+	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
@@ -117,7 +118,7 @@ func (p *clusterPeers) GetLastConnected() time.Time {
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
-func (p *clusterPeers) Dial(from, to net.Addr) (conn net.Conn, err error) {
+func (p *clusterPeers) Dial(from, to net.Addr, a agent.Agent) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy has not been discovered yet, try again later")
 }
 

--- a/lib/srv/regular/proxy_test.go
+++ b/lib/srv/regular/proxy_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package regular
 
 import (
+	"github.com/gravitational/teleport/lib/srv"
+
 	"gopkg.in/check.v1"
 )
 
@@ -33,8 +35,10 @@ func (s *ProxyTestSuite) SetUpSuite(c *check.C) {
 }
 
 func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
+	ctx := &srv.ServerContext{}
+
 	// proxy request for a host:port
-	subsys, err := parseProxySubsys("proxy:host:22", s.srv)
+	subsys, err := parseProxySubsys("proxy:host:22", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys, check.NotNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
@@ -43,7 +47,7 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 	c.Assert(subsys.clusterName, check.Equals, "")
 
 	// similar request, just with '@' at the end (missing site)
-	subsys, err = parseProxySubsys("proxy:host:22@", s.srv)
+	subsys, err = parseProxySubsys("proxy:host:22@", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
 	c.Assert(subsys.host, check.Equals, "host")
@@ -51,7 +55,7 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 	c.Assert(subsys.clusterName, check.Equals, "")
 
 	// proxy request for just the sitename
-	subsys, err = parseProxySubsys("proxy:@moon", s.srv)
+	subsys, err = parseProxySubsys("proxy:@moon", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys, check.NotNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
@@ -60,7 +64,7 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 	c.Assert(subsys.clusterName, check.Equals, "moon")
 
 	// proxy request for the host:port@sitename
-	subsys, err = parseProxySubsys("proxy:station:100@moon", s.srv)
+	subsys, err = parseProxySubsys("proxy:station:100@moon", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys, check.NotNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
@@ -69,7 +73,7 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 	c.Assert(subsys.clusterName, check.Equals, "moon")
 
 	// proxy request for the host:port@namespace@cluster
-	subsys, err = parseProxySubsys("proxy:station:100@system@moon", s.srv)
+	subsys, err = parseProxySubsys("proxy:station:100@system@moon", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys, check.NotNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
@@ -80,6 +84,8 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 }
 
 func (s *ProxyTestSuite) TestParseBadRequests(c *check.C) {
+	ctx := &srv.ServerContext{}
+
 	testCases := []string{
 		// empty request
 		"proxy:",
@@ -92,7 +98,7 @@ func (s *ProxyTestSuite) TestParseBadRequests(c *check.C) {
 	}
 	for _, input := range testCases {
 		comment := check.Commentf("test case: %q", input)
-		_, err := parseProxySubsys(input, s.srv)
+		_, err := parseProxySubsys(input, s.srv, ctx)
 		c.Assert(err, check.NotNil, comment)
 	}
 }

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -963,7 +963,7 @@ func (s *Server) parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext)
 		return nil, fmt.Errorf("failed to parse subsystem request, error: %v", err)
 	}
 	if s.proxyMode && strings.HasPrefix(r.Name, "proxy:") {
-		return parseProxySubsys(r.Name, s)
+		return parseProxySubsys(r.Name, s, ctx)
 	}
 	if s.proxyMode && strings.HasPrefix(r.Name, "proxysites") {
 		return parseProxySitesSubsys(r.Name, s)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -200,7 +200,7 @@ func (c *SessionContext) newRemoteClient(site reversetunnel.RemoteSite) (auth.Cl
 
 		// first get a net.Conn (tcp connection) to the remote auth server. no
 		// authentication has occurred.
-		netConn, err = site.Dial(&srcAddr, &dstAddr)
+		netConn, err = site.Dial(&srcAddr, &dstAddr, nil)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
**Purpose**

As covered in #1494, even though Teleport now contains a forwarding server, it's never used. This PR updates the reversetunnel code to use the forwarding server when in recording mode.

**Implementation**

* When creating a proxy subsystem, pass along the agent used to connect to the target host.
* Pass the agent to the localsite or remotesite.
* For remotesites, first the SSSH agent needs to be forwarded to the reversetunnel agent on the other side, then a connection can be built using it.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1494