### PR TITLE
Updated reverse tunnel to allow use to forwarding server.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -296,6 +296,8 @@ func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *servic
 	}
 	tconf.Keygen = testauthority.New()
 
+	tconf.Auth.ClusterConfig = services.DefaultClusterConfig()
+
 	i.Config = tconf
 	i.Process, err = service.NewTeleport(tconf)
 	if err != nil {

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -214,6 +214,14 @@ const (
 )
 
 const (
+	// HostCertCacheSize is the number of host certificates to cache at any moment.
+	HostCertCacheSize = 4000
+
+	// HostCertCacheTime is how long a certificate stays in the cache.
+	HostCertCacheTime = 24 * time.Hour
+)
+
+const (
 	// MinCertDuration specifies minimum duration of validity of issued cert
 	MinCertDuration = time.Minute
 	// MaxCertDuration limits maximum duration of validity of issued cert

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -372,6 +372,11 @@ func (a *Agent) proxyTransport(ch ssh.Channel, reqC <-chan *ssh.Request) {
 	server := string(req.Payload)
 	var servers []string
 
+	// Deprecated: Remove in Teleport 2.5.
+	//   Starting with Teleport 2.4 the client now discovers the list of Auth
+	//   Servers and sends them via the transport request. So this block can be
+	//   be replaced just net.Dial.
+	//
 	// if the request is for the special string @remote-auth-server, then get the
 	// list of auth servers and return that. otherwise try and connect to the
 	// passed in server.

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/crypto/ssh/agent"
+
 	"github.com/gravitational/teleport/lib/auth"
 )
 
@@ -28,8 +30,10 @@ import (
 //
 // There are two implementations of this interface: local and remote sites.
 type RemoteSite interface {
-	// Dial dials any address within the site network
-	Dial(fromAddr, toAddr net.Addr) (net.Conn, error)
+	// DialAuthServer returns a net.Conn to the Auth Server of a site.
+	DialAuthServer() (net.Conn, error)
+	// Dial dials any address within the site network.
+	Dial(fromAddr, toAddr net.Addr, userAgent agent.Agent) (net.Conn, error)
 	// GetLastConnected returns last time the remote site was seen connected
 	GetLastConnected() time.Time
 	// GetName returns site name (identified by authority domain's name)

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reversetunnel
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/defaults"
+
+	"github.com/gravitational/trace"
+	"github.com/gravitational/ttlmap"
+)
+
+type certificateCache struct {
+	mu         sync.Mutex
+	cache      *ttlmap.TTLMap
+	authClient auth.ClientI
+}
+
+// NewHostCertificateCache creates a shared host certificate cache that is
+// used by the forwarding server.
+func NewHostCertificateCache(authClient auth.ClientI) (*certificateCache, error) {
+	cache, err := ttlmap.New(defaults.HostCertCacheSize)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &certificateCache{
+		cache:      cache,
+		authClient: authClient,
+	}, nil
+}
+
+// GetHostCertificate will fetch a certificate from the cache. If the certificate
+// is not in the cache, it will be generated, put in the cache, and returned. Mul
+// Multiple callers can arrive and generate a host certificate at the same time.
+// This is a tradeoff to prevent long delays here due to the expensive
+// certificate generation call.
+func (c *certificateCache) GetHostCertificate(addr string) (ssh.Signer, error) {
+	var certificate ssh.Signer
+	var err error
+	var ok bool
+
+	// extract the principal from the address
+	principal, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	certificate, ok = c.get(principal)
+	if !ok {
+		certificate, err = c.generateHostCert(principal)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		err = c.set(principal, certificate, defaults.HostCertCacheTime)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return certificate, nil
+}
+
+// get is goroutine safe and will return a ssh.Signer for a principal from
+// the cache.
+func (c *certificateCache) get(principal string) (ssh.Signer, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	certificate, ok := c.cache.Get(principal)
+	if !ok {
+		return nil, false
+	}
+
+	certificateSigner, ok := certificate.(ssh.Signer)
+	if !ok {
+		return nil, false
+	}
+
+	return certificateSigner, true
+}
+
+// set is goroutine safe and will set a ssh.Signer for a principal in
+// the cache.
+func (c *certificateCache) set(principal string, certificate ssh.Signer, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	err := c.cache.Set(principal, certificate, ttl)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// generateHostCert will generate a SSH host certificate for a given
+// principal.
+func (c *certificateCache) generateHostCert(principal string) (ssh.Signer, error) {
+	keygen := native.New()
+	defer keygen.Close()
+
+	// generate public/private keypair
+	privBytes, pubBytes, err := keygen.GenerateKeyPair("")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// have auth server sign and return a host certificate to us
+	clusterName, err := c.authClient.GetDomainName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	certBytes, err := c.authClient.GenerateHostCert(pubBytes,
+		principal, principal, clusterName,
+		teleport.Roles{teleport.RoleNode}, 0)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// create a *ssh.Certificate
+	privateKey, err := ssh.ParsePrivateKey(privBytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	publicKey, _, _, _, err := ssh.ParseAuthorizedKey(certBytes)
+	if err != nil {
+		return nil, err
+	}
+	cert, ok := publicKey.(*ssh.Certificate)
+	if !ok {
+		return nil, trace.BadParameter("not a certificate")
+	}
+
+	// return a ssh.Signer
+	s, err := ssh.NewCertSigner(cert, privateKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return s, nil
+}

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -12,7 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package reversetunnel
@@ -21,6 +20,8 @@ import (
 	"fmt"
 	"net"
 	"time"
+
+	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
@@ -114,10 +115,14 @@ func (p *clusterPeers) GetLastConnected() time.Time {
 	return peer.GetLastConnected()
 }
 
+func (p *clusterPeers) DialAuthServer() (net.Conn, error) {
+	return nil, trace.ConnectionProblem(nil, "unable to dial to auth server, this proxy has not been discovered yet, try again later")
+}
+
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
-func (p *clusterPeers) Dial(from, to net.Addr) (conn net.Conn, err error) {
+func (p *clusterPeers) Dial(from, to net.Addr, userAgent agent.Agent) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy has not been discovered yet, try again later")
 }
 

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -12,7 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package reversetunnel
@@ -27,17 +26,20 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/forward"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/mailgun/oxy/forward"
+	oxyforward "github.com/mailgun/oxy/forward"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 )
 
 // remoteSite is a remote site that established the inbound connecton to
@@ -53,19 +55,33 @@ type remoteSite struct {
 	lastActive  time.Time
 	srv         *server
 	transport   *http.Transport
-	clt         *auth.Client
-	accessPoint auth.AccessPoint
 	connInfo    services.TunnelConnection
 	ctx         context.Context
 	clock       clockwork.Clock
+
+	// certificateCache caches host certificates for the forwarding server.
+	certificateCache *certificateCache
+
+	// localClient provides access to the Auth Server API of the cluster
+	// within which reversetunnel.Server is running.
+	localClient auth.ClientI
+	// remoteClient provides access to the Auth Server API of the remote cluster that
+	// this site belongs to.
+	remoteClient *auth.Client
+	// localAccessPoint provides access to a cached subset of the Auth Server API of
+	// the local cluster.
+	localAccessPoint auth.AccessPoint
+	// remoteAccessPoint provides access to a cached subset of the Auth Server API of
+	// the remote cluster this site belongs to.
+	remoteAccessPoint auth.AccessPoint
 }
 
 func (s *remoteSite) CachingAccessPoint() (auth.AccessPoint, error) {
-	return s.accessPoint, nil
+	return s.remoteAccessPoint, nil
 }
 
 func (s *remoteSite) GetClient() (auth.ClientI, error) {
-	return s.clt, nil
+	return s.remoteClient, nil
 }
 
 func (s *remoteSite) String() string {
@@ -127,7 +143,7 @@ func (s *remoteSite) addConn(conn net.Conn, sshConn ssh.Conn) (*remoteConn, erro
 }
 
 func (s *remoteSite) getLatestTunnelConnection() (services.TunnelConnection, error) {
-	conns, err := s.srv.AccessPoint.GetTunnelConnections(s.domainName)
+	conns, err := s.localAccessPoint.GetTunnelConnections(s.domainName)
 	if err != nil {
 		s.Warningf("failed to fetch tunnel statuses: %v", err)
 		return nil, trace.Wrap(err)
@@ -166,7 +182,7 @@ func (s *remoteSite) registerHeartbeat(t time.Time) {
 	connInfo := s.copyConnInfo()
 	connInfo.SetLastHeartbeat(t)
 	connInfo.SetExpiry(s.clock.Now().Add(defaults.ReverseTunnelOfflineThreshold))
-	err := s.srv.AccessPoint.UpsertTunnelConnection(connInfo)
+	err := s.localAccessPoint.UpsertTunnelConnection(connInfo)
 	if err != nil {
 		s.Warningf("failed to register heartbeat: %v", err)
 	}
@@ -175,7 +191,7 @@ func (s *remoteSite) registerHeartbeat(t time.Time) {
 // deleteConnectionRecord deletes connection record to let know peer proxies
 // that this node lost the connection and needs to be discovered
 func (s *remoteSite) deleteConnectionRecord() {
-	s.srv.AccessPoint.DeleteTunnelConnection(s.connInfo.GetClusterName(), s.connInfo.GetName())
+	s.localAccessPoint.DeleteTunnelConnection(s.connInfo.GetClusterName(), s.connInfo.GetName())
 }
 
 // handleHearbeat receives heartbeat messages from the connected agent
@@ -262,7 +278,7 @@ func (s *remoteSite) isOnline(conn services.TunnelConnection) bool {
 // connections
 func (s *remoteSite) findDisconnectedProxies() ([]services.Server, error) {
 	connInfo := s.copyConnInfo()
-	conns, err := s.srv.AccessPoint.GetTunnelConnections(s.domainName)
+	conns, err := s.localAccessPoint.GetTunnelConnections(s.domainName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -272,7 +288,7 @@ func (s *remoteSite) findDisconnectedProxies() ([]services.Server, error) {
 			connected[conn.GetProxyName()] = true
 		}
 	}
-	proxies, err := s.srv.AccessPoint.GetProxies()
+	proxies, err := s.localAccessPoint.GetProxies()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -302,7 +318,7 @@ func (s *remoteSite) sendDiscoveryRequest() error {
 	if len(disconnectedProxies) == 0 {
 		return nil
 	}
-	clusterName, err := s.srv.AccessPoint.GetDomainName()
+	clusterName, err := s.localAccessPoint.GetDomainName()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -379,57 +395,113 @@ func (s *remoteSite) dialAccessPoint(network, addr string) (net.Conn, error) {
 	}
 }
 
+func (s *remoteSite) DialAuthServer() (conn net.Conn, err error) {
+	// get list of remote auth servers
+	authServers, err := s.remoteClient.GetAuthServers()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	for _, authServer := range authServers {
+		conn, err = s.connThroughTunnel(chanTransportDialReq, authServer.GetAddr())
+		if err == nil {
+			return conn, nil
+		}
+	}
+
+	return nil, trace.ConnectionProblem(err, "unable to connect to auth server")
+}
+
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
-func (s *remoteSite) Dial(from, to net.Addr) (conn net.Conn, err error) {
-	s.Debugf("dialing %v through the tunnel", to)
-	stop := false
-
-	_, addr := to.Network(), to.String()
-
-	try := func() (net.Conn, error) {
-		remoteConn, err := s.nextConn()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		var ch ssh.Channel
-		ch, _, err = remoteConn.sshConn.OpenChannel(chanTransport, nil)
-		if err != nil {
-			remoteConn.markInvalid(err)
-			return nil, trace.Wrap(err)
-		}
-		stop = true
-		// send a special SSH out-of-band request called "teleport-transport"
-		// the agent on the other side will create a new TCP/IP connection to
-		// 'addr' on its network and will start proxying that connection over
-		// this SSH channel:
-		var dialed bool
-		dialed, err = ch.SendRequest(chanTransportDialReq, true, []byte(addr))
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		if !dialed {
-			defer ch.Close()
-			// pull the error message from the tunnel client (remote cluster)
-			// passed to us via stderr:
-			errMessage, _ := ioutil.ReadAll(ch.Stderr())
-			if errMessage == nil {
-				errMessage = []byte("failed connecting to " + addr)
-			}
-			return nil, trace.Errorf(strings.TrimSpace(string(errMessage)))
-		}
-		return utils.NewChConn(remoteConn.sshConn, ch), nil
+func (s *remoteSite) Dial(from net.Addr, to net.Addr, userAgent agent.Agent) (net.Conn, error) {
+	clusterConfig, err := s.localAccessPoint.GetClusterConfig()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
+
+	// if the proxy is in recording mode use the agent to dial and build a
+	// in-memory forwarding server
+	if clusterConfig.GetSessionRecording() == services.RecordAtProxy {
+		if userAgent == nil {
+			return nil, trace.BadParameter("user agent missing")
+		}
+		return s.dialWithAgent(from, to, userAgent)
+	}
+	return s.dial(from, to)
+}
+
+func (s *remoteSite) dial(from, to net.Addr) (net.Conn, error) {
+	s.Debugf("Dialing from %v to %v", from, to)
+
+	conn, err := s.connThroughTunnel(chanTransportDialReq, to.String())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return conn, nil
+}
+
+func (s *remoteSite) dialWithAgent(from, to net.Addr, userAgent agent.Agent) (net.Conn, error) {
+	s.Debugf("Dialing with an agent from %v to %v", from, to)
+
+	// get a host certificate for the forwarding node from the cache
+	hostCertificate, err := s.certificateCache.GetHostCertificate(to.String())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	targetConn, err := s.connThroughTunnel(chanTransportDialReq, to.String())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// create a forwarding server that serves a single ssh connection on it. we
+	// don't need to close this server it will close and release all resources
+	// once conn is closed.
+	//
+	// note, a localClient is passed to the forwarding server, that's to make
+	// sure that the session gets recorded in the local cluster instead of the
+	// remote cluster.
+	serverConfig := forward.ServerConfig{
+		ID:              s.srv.Config.ID,
+		AuthClient:      s.localClient,
+		UserAgent:       userAgent,
+		TargetConn:      targetConn,
+		SrcAddr:         from,
+		DstAddr:         to,
+		HostCertificate: hostCertificate,
+	}
+	remoteServer, err := forward.New(serverConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	go remoteServer.Serve()
+
+	// return a connection to the forwarding server
+	conn, err := remoteServer.Dial()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return conn, nil
+}
+
+func (s *remoteSite) connThroughTunnel(transportType string, data string) (conn net.Conn, err error) {
+	var stop bool
+
+	s.Debugf("Requesting %v connection to remote site with payload: %v", transportType, data)
+
 	// loop through existing TCP/IP connections (reverse tunnels) and try
 	// to establish an inbound connection-over-ssh-channel to the remote
 	// cluster (AKA "remotetunnel agent"):
 	for i := 0; i < s.connectionCount() && !stop; i++ {
-		conn, err = try()
+		conn, stop, err = s.chanTransportConn(transportType, data)
 		if err == nil {
 			return conn, nil
 		}
-		s.Warningf("Dial(addr=%v) failed: %v", addr, err)
+		s.Warnf("Request for %v connection to remote site failed: %v", transportType, err)
 	}
 	// didn't connect and no error? this means we didn't have any connected
 	// tunnels to try
@@ -439,10 +511,46 @@ func (s *remoteSite) Dial(from, to net.Addr) (conn net.Conn, err error) {
 	return nil, err
 }
 
+func (s *remoteSite) chanTransportConn(transportType string, addr string) (net.Conn, bool, error) {
+	var stop bool
+
+	remoteConn, err := s.nextConn()
+	if err != nil {
+		return nil, stop, trace.Wrap(err)
+	}
+	var ch ssh.Channel
+	ch, _, err = remoteConn.sshConn.OpenChannel(chanTransport, nil)
+	if err != nil {
+		remoteConn.markInvalid(err)
+		return nil, stop, trace.Wrap(err)
+	}
+	// send a special SSH out-of-band request called "teleport-transport"
+	// the agent on the other side will create a new TCP/IP connection to
+	// 'addr' on its network and will start proxying that connection over
+	// this SSH channel:
+	var dialed bool
+	dialed, err = ch.SendRequest(transportType, true, []byte(addr))
+	if err != nil {
+		return nil, stop, trace.Wrap(err)
+	}
+	stop = true
+	if !dialed {
+		defer ch.Close()
+		// pull the error message from the tunnel client (remote cluster)
+		// passed to us via stderr:
+		errMessage, _ := ioutil.ReadAll(ch.Stderr())
+		if errMessage == nil {
+			errMessage = []byte("failed connecting to " + addr)
+		}
+		return nil, stop, trace.Errorf(strings.TrimSpace(string(errMessage)))
+	}
+	return utils.NewChConn(remoteConn.sshConn, ch), stop, nil
+}
+
 func (s *remoteSite) handleAuthProxy(w http.ResponseWriter, r *http.Request) {
 	s.Debugf("handleAuthProxy()")
 
-	fwd, err := forward.New(forward.RoundTripper(s.transport), forward.Logger(s.Entry))
+	fwd, err := oxyforward.New(oxyforward.RoundTripper(s.transport), oxyforward.Logger(s.Entry))
 	if err != nil {
 		roundtrip.ReplyJSON(w, http.StatusInternalServerError, err.Error())
 		return

--- a/lib/srv/forward/remote.go
+++ b/lib/srv/forward/remote.go
@@ -17,6 +17,8 @@ limitations under the License.
 package forward
 
 import (
+	"net"
+
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
@@ -28,7 +30,7 @@ import (
 
 // newRemoteSession will create and return a *ssh.Client and *ssh.Session
 // with a remote host.
-func newRemoteSession(dstAddr string, systemLogin string, userAgent agent.Agent, authHandlers *srv.AuthHandlers) (*ssh.Client, *ssh.Session, error) {
+func newRemoteSession(conn net.Conn, dstAddr string, systemLogin string, userAgent agent.Agent, authHandlers *srv.AuthHandlers) (*ssh.Client, *ssh.Session, error) {
 	// the proxy will use the agent that has been forwarded to it as the auth
 	// method when connecting to the remote host
 	if userAgent == nil {
@@ -45,7 +47,7 @@ func newRemoteSession(dstAddr string, systemLogin string, userAgent agent.Agent,
 		Timeout:         defaults.DefaultDialTimeout,
 	}
 
-	client, err := proxy.DialWithDeadline("tcp", dstAddr, clientConfig)
+	client, err := proxy.NewClientConnWithDeadline(conn, dstAddr, clientConfig)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -26,6 +26,9 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -36,21 +39,22 @@ import (
 
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 )
 
 // proxySubsys implements an SSH subsystem for proxying listening sockets from
 // remote hosts to a proxy client (AKA port mapping)
 type proxySubsys struct {
-	log         *log.Entry
-	srv         *Server
-	host        string
-	port        string
-	namespace   string
-	clusterName string
-	closeC      chan struct{}
-	error       error
-	closeOnce   sync.Once
+	log          *log.Entry
+	srv          *Server
+	host         string
+	port         string
+	namespace    string
+	clusterName  string
+	closeC       chan struct{}
+	error        error
+	closeOnce    sync.Once
+	agent        agent.Agent
+	agentChannel ssh.Channel
 }
 
 // parseProxySubsys looks at the requested subsystem name and returns a fully configured
@@ -61,7 +65,7 @@ type proxySubsys struct {
 //  "proxy:@clustername"        - Teleport request to connect to an auth server for cluster with name 'clustername'
 //  "proxy:host:22@clustername" - Teleport request to connect to host:22 on cluster 'clustername'
 //  "proxy:host:22@namespace@clustername"
-func parseProxySubsys(request string, srv *Server) (*proxySubsys, error) {
+func parseProxySubsys(request string, srv *Server, ctx *srv.ServerContext) (*proxySubsys, error) {
 	log.Debugf("parse_proxy_subsys(%q)", request)
 	var (
 		clusterName  string
@@ -117,12 +121,14 @@ func parseProxySubsys(request string, srv *Server) (*proxySubsys, error) {
 			trace.Component:       teleport.ComponentSubsystemProxy,
 			trace.ComponentFields: map[string]string{},
 		}),
-		namespace:   namespace,
-		srv:         srv,
-		host:        targetHost,
-		port:        targetPort,
-		clusterName: clusterName,
-		closeC:      make(chan struct{}),
+		namespace:    namespace,
+		srv:          srv,
+		host:         targetHost,
+		port:         targetPort,
+		clusterName:  clusterName,
+		closeC:       make(chan struct{}),
+		agent:        ctx.GetAgent(),
+		agentChannel: ctx.GetAgentChannel(),
 	}, nil
 }
 
@@ -192,48 +198,31 @@ func (t *proxySubsys) Start(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Requ
 func (t *proxySubsys) proxyToSite(
 	site reversetunnel.RemoteSite, remoteAddr net.Addr, ch ssh.Channel) error {
 
-	var (
-		err  error
-		conn net.Conn
-	)
-	siteClient, err := site.GetClient()
+	conn, err := site.DialAuthServer()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	authServers, err := siteClient.GetAuthServers()
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	t.log.Infof("Connected to auth server: %v", conn.RemoteAddr())
 
-	for _, authServer := range authServers {
-
-		conn, err = site.Dial(remoteAddr,
-			&utils.NetAddr{Addr: authServer.GetAddr(), AddrNetwork: "tcp"})
-		if err != nil {
-			t.log.Error(err)
-			continue
-		}
-		t.log.Infof("Connected to auth server: %v", authServer.GetAddr())
-		go func() {
-			var err error
-			defer func() {
-				t.close(err)
-			}()
-			defer ch.Close()
-			_, err = io.Copy(ch, conn)
+	go func() {
+		var err error
+		defer func() {
+			t.close(err)
 		}()
-		go func() {
-			var err error
-			defer func() {
-				t.close(err)
-			}()
-			defer conn.Close()
-			_, err = io.Copy(conn, ch)
-
+		defer ch.Close()
+		_, err = io.Copy(ch, conn)
+	}()
+	go func() {
+		var err error
+		defer func() {
+			t.close(err)
 		}()
-		return nil
-	}
-	return err
+		defer conn.Close()
+		_, err = io.Copy(conn, ch)
+
+	}()
+
+	return nil
 }
 
 // proxyToHost establishes a proxy connection from the connected SSH client to the
@@ -306,14 +295,17 @@ func (t *proxySubsys) proxyToHost(
 		t.log.Warnf("server lookup failed: using default=%v", serverAddr)
 	}
 
-	// we must dial by server IP address because hostname
-	// may not be actually DNS resolvable
+	// dial by IP address because the hostname may not be DNS resolvable
+	// pass the agent along to the site (if the proxy is in recording mode, this
+	// agent will be used for user auth)
 	conn, err := site.Dial(
 		remoteAddr,
-		&utils.NetAddr{Addr: serverAddr, AddrNetwork: "tcp"})
+		&utils.NetAddr{Addr: serverAddr, AddrNetwork: "tcp"},
+		t.agent)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	// this custom SSH handshake allows SSH proxy to relay the client's IP
 	// address to the SSH server
 	t.doHandshake(remoteAddr, ch, conn)
@@ -333,8 +325,8 @@ func (t *proxySubsys) proxyToHost(
 		}()
 		defer conn.Close()
 		_, err = io.Copy(conn, ch)
-
 	}()
+
 	return nil
 }
 

--- a/lib/srv/regular/proxy_test.go
+++ b/lib/srv/regular/proxy_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package regular
 
 import (
+	"github.com/gravitational/teleport/lib/srv"
+
 	"gopkg.in/check.v1"
 )
 
@@ -33,8 +35,10 @@ func (s *ProxyTestSuite) SetUpSuite(c *check.C) {
 }
 
 func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
+	ctx := &srv.ServerContext{}
+
 	// proxy request for a host:port
-	subsys, err := parseProxySubsys("proxy:host:22", s.srv)
+	subsys, err := parseProxySubsys("proxy:host:22", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys, check.NotNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
@@ -43,7 +47,7 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 	c.Assert(subsys.clusterName, check.Equals, "")
 
 	// similar request, just with '@' at the end (missing site)
-	subsys, err = parseProxySubsys("proxy:host:22@", s.srv)
+	subsys, err = parseProxySubsys("proxy:host:22@", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
 	c.Assert(subsys.host, check.Equals, "host")
@@ -51,7 +55,7 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 	c.Assert(subsys.clusterName, check.Equals, "")
 
 	// proxy request for just the sitename
-	subsys, err = parseProxySubsys("proxy:@moon", s.srv)
+	subsys, err = parseProxySubsys("proxy:@moon", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys, check.NotNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
@@ -60,7 +64,7 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 	c.Assert(subsys.clusterName, check.Equals, "moon")
 
 	// proxy request for the host:port@sitename
-	subsys, err = parseProxySubsys("proxy:station:100@moon", s.srv)
+	subsys, err = parseProxySubsys("proxy:station:100@moon", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys, check.NotNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
@@ -69,7 +73,7 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 	c.Assert(subsys.clusterName, check.Equals, "moon")
 
 	// proxy request for the host:port@namespace@cluster
-	subsys, err = parseProxySubsys("proxy:station:100@system@moon", s.srv)
+	subsys, err = parseProxySubsys("proxy:station:100@system@moon", s.srv, ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(subsys, check.NotNil)
 	c.Assert(subsys.srv, check.Equals, s.srv)
@@ -80,6 +84,8 @@ func (s *ProxyTestSuite) TestParseProxyRequest(c *check.C) {
 }
 
 func (s *ProxyTestSuite) TestParseBadRequests(c *check.C) {
+	ctx := &srv.ServerContext{}
+
 	testCases := []string{
 		// empty request
 		"proxy:",
@@ -92,7 +98,7 @@ func (s *ProxyTestSuite) TestParseBadRequests(c *check.C) {
 	}
 	for _, input := range testCases {
 		comment := check.Commentf("test case: %q", input)
-		_, err := parseProxySubsys(input, s.srv)
+		_, err := parseProxySubsys(input, s.srv, ctx)
 		c.Assert(err, check.NotNil, comment)
 	}
 }

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -963,7 +963,7 @@ func (s *Server) parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext)
 		return nil, fmt.Errorf("failed to parse subsystem request, error: %v", err)
 	}
 	if s.proxyMode && strings.HasPrefix(r.Name, "proxy:") {
-		return parseProxySubsys(r.Name, s)
+		return parseProxySubsys(r.Name, s, ctx)
 	}
 	if s.proxyMode && strings.HasPrefix(r.Name, "proxysites") {
 		return parseProxySitesSubsys(r.Name, s)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -504,8 +504,10 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 		ID:                    s.domainName,
 		ListenAddr:            reverseTunnelAddress,
 		HostSigners:           []ssh.Signer{s.signer},
-		AccessPoint:           s.roleAuth,
+		LocalAuthClient:       s.roleAuth,
+		LocalAccessPoint:      s.roleAuth,
 		NewCachingAccessPoint: state.NoCache,
+		DirectClusters:        []reversetunnel.DirectCluster{{Name: s.domainName, Client: s.roleAuth}},
 	})
 	c.Assert(err, IsNil)
 	c.Assert(reverseTunnelServer.Start(), IsNil)
@@ -645,10 +647,14 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 	var sites []services.Site
 	c.Assert(json.Unmarshal(stdout.Bytes(), &sites), IsNil)
 	c.Assert(sites, NotNil)
-	c.Assert(sites, HasLen, 1)
+	c.Assert(sites, HasLen, 2)
 	c.Assert(sites[0].Name, Equals, "localhost")
 	c.Assert(sites[0].Status, Equals, "online")
+	c.Assert(sites[1].Name, Equals, "localhost")
+	c.Assert(sites[1].Status, Equals, "online")
+
 	c.Assert(time.Since(sites[0].LastConnected).Seconds() < 5, Equals, true)
+	c.Assert(time.Since(sites[1].LastConnected).Seconds() < 5, Equals, true)
 
 	err = tunClt.DeleteReverseTunnel(s.domainName)
 	c.Assert(err, IsNil)
@@ -670,8 +676,10 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 		ID:                    s.domainName,
 		ListenAddr:            reverseTunnelAddress,
 		HostSigners:           []ssh.Signer{s.signer},
-		AccessPoint:           s.roleAuth,
+		LocalAuthClient:       s.roleAuth,
+		LocalAccessPoint:      s.roleAuth,
 		NewCachingAccessPoint: state.NoCache,
+		DirectClusters:        []reversetunnel.DirectCluster{{Name: s.domainName, Client: s.roleAuth}},
 	})
 	c.Assert(err, IsNil)
 
@@ -772,7 +780,8 @@ func (s *SrvSuite) TestProxyDirectAccess(c *C) {
 		ID:                    s.domainName,
 		ListenAddr:            reverseTunnelAddress,
 		HostSigners:           []ssh.Signer{s.signer},
-		AccessPoint:           s.roleAuth,
+		LocalAuthClient:       s.roleAuth,
+		LocalAccessPoint:      s.roleAuth,
 		NewCachingAccessPoint: state.NoCache,
 		DirectClusters:        []reversetunnel.DirectCluster{{Name: s.domainName, Client: s.roleAuth}},
 	})

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -295,7 +295,8 @@ func (s *WebSuite) SetUpTest(c *C) {
 			Addr:        fmt.Sprintf("%v:0", s.domainName),
 		},
 		HostSigners:           []ssh.Signer{s.signer},
-		AccessPoint:           s.roleAuth,
+		LocalAuthClient:       s.roleAuth,
+		LocalAccessPoint:      s.roleAuth,
 		NewCachingAccessPoint: state.NoCache,
 		DirectClusters:        []reversetunnel.DirectCluster{{Name: s.domainName, Client: s.roleAuth}},
 	})

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -193,14 +193,9 @@ func (c *SessionContext) newRemoteClient(site reversetunnel.RemoteSite) (auth.Cl
 	var netConn net.Conn
 
 	sshDialer := func(network, addr string) (net.Conn, error) {
-		// we tell the remote site we want a connection to the auth server by using
-		// a non-resolvable string @remote-auth-server as the destination.
-		srcAddr := utils.NetAddr{Addr: "web.get-remote-client-with-user-role", AddrNetwork: "tcp"}
-		dstAddr := utils.NetAddr{Addr: reversetunnel.RemoteAuthServer, AddrNetwork: "tcp"}
-
 		// first get a net.Conn (tcp connection) to the remote auth server. no
 		// authentication has occurred.
-		netConn, err = site.Dial(&srcAddr, &dstAddr)
+		netConn, err = site.DialAuthServer()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
**Purpose**

As covered in #1494, even though Teleport now contains a forwarding server, it's never used. This PR updates the reversetunnel code to use the forwarding server when in recording mode.

**Implementation**

* When creating a proxy subsystem, pass along the agent used to connect to the target host.
* Pass the agent to the localsite or remotesite.
* For remotesites, first the SSSH agent needs to be forwarded to the reversetunnel agent on the other side, then a connection can be built using it.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1494