### PR TITLE
Update tctl to support generating a host certificate

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -731,6 +731,7 @@ type generateHostCertReq struct {
 	Key         []byte         `json:"key"`
 	HostID      string         `json:"hostname"`
 	NodeName    string         `json:"node_name"`
+	Principals  []string       `json:"principals"`
 	ClusterName string         `json:"auth_domain"`
 	Roles       teleport.Roles `json:"roles"`
 	TTL         time.Duration  `json:"ttl"`
@@ -742,7 +743,7 @@ func (s *APIServer) generateHostCert(auth ClientI, w http.ResponseWriter, r *htt
 		return nil, trace.Wrap(err)
 	}
 
-	cert, err := auth.GenerateHostCert(req.Key, req.HostID, req.NodeName, req.ClusterName, req.Roles, req.TTL)
+	cert, err := auth.GenerateHostCert(req.Key, req.HostID, req.NodeName, req.Principals, req.ClusterName, req.Roles, req.TTL)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -243,8 +243,8 @@ func (s *APISuite) TestGenerateKeysAndCerts(c *C) {
 
 	// make sure we can parse the private and public key
 	cert, err := s.clt.GenerateHostCert(pub,
-		"00000000-0000-0000-0000-000000000000", "localhost", "localhost",
-		teleport.Roles{teleport.RoleNode}, time.Hour)
+		"00000000-0000-0000-0000-000000000000", "localhost", nil,
+		"localhost", teleport.Roles{teleport.RoleNode}, time.Hour)
 	c.Assert(err, IsNil)
 
 	_, _, _, _, err = ssh.ParseAuthorizedKey(cert)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -196,7 +196,7 @@ func (a *AuthServer) GetDomainName() (string, error) {
 
 // GenerateHostCert uses the private key of the CA to sign the public key of the host
 // (along with meta data like host ID, node name, roles, and ttl) to generate a host certificate.
-func (s *AuthServer) GenerateHostCert(hostPublicKey []byte, hostID, nodeName, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error) {
+func (s *AuthServer) GenerateHostCert(hostPublicKey []byte, hostID, nodeName string, principals []string, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error) {
 	domainName, err := s.GetDomainName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -223,6 +223,7 @@ func (s *AuthServer) GenerateHostCert(hostPublicKey []byte, hostID, nodeName, cl
 		PublicHostKey:       hostPublicKey,
 		HostID:              hostID,
 		NodeName:            nodeName,
+		Principals:          principals,
 		ClusterName:         clusterName,
 		Roles:               roles,
 		TTL:                 ttl,
@@ -512,7 +513,7 @@ func (s *AuthServer) GenerateServerKeys(hostID string, nodeName string, roles te
 	}
 
 	// generate host certificate with an infinite ttl
-	c, err := s.GenerateHostCert(pub, hostID, nodeName, domainName, roles, 0)
+	c, err := s.GenerateHostCert(pub, hostID, nodeName, nil, domainName, roles, 0)
 	if err != nil {
 		log.Warningf("[AUTH] Node %q [%v] can not join: certificate generation error: %v", nodeName, hostID, err)
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -427,12 +427,12 @@ func (a *AuthWithRoles) GenerateKeyPair(pass string) ([]byte, []byte, error) {
 }
 
 func (a *AuthWithRoles) GenerateHostCert(
-	key []byte, hostID, nodeName, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error) {
+	key []byte, hostID, nodeName string, principals []string, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error) {
 
 	if err := a.action(defaults.Namespace, services.KindHostCert, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GenerateHostCert(key, hostID, nodeName, clusterName, roles, ttl)
+	return a.authServer.GenerateHostCert(key, hostID, nodeName, principals, clusterName, roles, ttl)
 }
 
 func (a *AuthWithRoles) GenerateUserCert(key []byte, username string, ttl time.Duration, compatibility string) ([]byte, error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -837,13 +837,14 @@ func (c *Client) GenerateKeyPair(pass string) ([]byte, []byte, error) {
 // plain text format, signs it using Host Certificate Authority private key and returns the
 // resulting certificate.
 func (c *Client) GenerateHostCert(
-	key []byte, hostID, nodeName, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error) {
+	key []byte, hostID, nodeName string, principals []string, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error) {
 
 	out, err := c.PostJSON(c.Endpoint("ca", "host", "certs"),
 		generateHostCertReq{
 			Key:         key,
 			HostID:      hostID,
 			NodeName:    nodeName,
+			Principals:  principals,
 			ClusterName: clusterName,
 			Roles:       roles,
 			TTL:         ttl,
@@ -1836,7 +1837,7 @@ type IdentityService interface {
 	// GenerateHostCert takes the public key in the Open SSH ``authorized_keys``
 	// plain text format, signs it using Host Certificate Authority private key and returns the
 	// resulting certificate.
-	GenerateHostCert(key []byte, hostID, nodeName, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error)
+	GenerateHostCert(key []byte, hostID, nodeName string, principals []string, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error)
 
 	// GenerateUserCert takes the public key in the OpenSSH `authorized_keys`
 	// plain text format, signs it using User Certificate Authority signing key and returns the

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -150,7 +150,14 @@ func (n *nauth) GenerateHostCert(c services.HostCertParams) ([]byte, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	// build a valid list of principals from the HostID and NodeName and then
+	// add in any additional principals passed in.
 	principals := BuildPrincipals(c.HostID, c.NodeName, c.ClusterName, c.Roles)
+	principals = append(principals, c.Principals...)
+	if len(principals) == 0 {
+		return nil, trace.BadParameter("no principals provided: %v, %v, %v",
+			c.HostID, c.NodeName, c.Principals)
+	}
 
 	// create certificate
 	validBefore := uint64(ssh.CertTimeInfinity)
@@ -243,6 +250,11 @@ func BuildPrincipals(hostID string, nodeName string, clusterName string, roles t
 	// verify changing this won't break older clients.
 	if roles.Include(teleport.RoleAdmin) {
 		return []string{hostID}
+	}
+
+	// if no hostID was passed it, the user might be specifying an exact list of principals
+	if hostID == "" {
+		return []string{}
 	}
 
 	// always include the hostID, this is what teleport uses internally to find nodes

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -120,7 +120,9 @@ func (s *TunSuite) SetUpTest(c *C) {
 	hpriv, hpub, err := s.a.GenerateKeyPair("")
 	c.Assert(err, IsNil)
 	s.hostuuid = "00000000-0000-0000-0000-000000000000"
-	hcert, err := s.a.GenerateHostCert(hpub, s.hostuuid, "localhost", "localhost", teleport.Roles{teleport.RoleProxy}, 0)
+	hcert, err := s.a.GenerateHostCert(hpub,
+		s.hostuuid, "localhost", nil,
+		"localhost", teleport.Roles{teleport.RoleProxy}, 0)
 	c.Assert(err, IsNil)
 
 	authorizer, err := NewAuthorizer(s.a.Access, s.a.Identity, s.a.Trust)
@@ -219,7 +221,9 @@ func (s *TunSuite) TestClusterConfigContext(c *C) {
 
 	// try and generate a host cert, this should fail because we are recording
 	// at the nodes not at the proxy
-	_, err = clt.GenerateHostCert(hpub, "a", "b", "localhost", teleport.Roles{teleport.RoleProxy}, 0)
+	_, err = clt.GenerateHostCert(hpub,
+		"a", "b", nil,
+		"localhost", teleport.Roles{teleport.RoleProxy}, 0)
 	c.Assert(err, NotNil)
 
 	// update cluster config to record at the proxy
@@ -236,7 +240,9 @@ func (s *TunSuite) TestClusterConfigContext(c *C) {
 
 	// try and generate a host cert, now the proxy should be able to generate a
 	// host cert because it's in recording mode.
-	_, err = clt.GenerateHostCert(hpub, "a", "b", "localhost", teleport.Roles{teleport.RoleProxy}, 0)
+	_, err = clt.GenerateHostCert(hpub,
+		"a", "b", nil,
+		"localhost", teleport.Roles{teleport.RoleProxy}, 0)
 	c.Assert(err, IsNil)
 }
 

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -78,7 +78,6 @@ func (s *ClientTestSuite) TestNewSession(c *check.C) {
 
 func (s *ClientTestSuite) TestIdentityFileMaking(c *check.C) {
 	keyFilePath := c.MkDir() + "openssh"
-	username := "joeuser"
 
 	var key Key
 	key.Cert = []byte("cert")
@@ -86,7 +85,7 @@ func (s *ClientTestSuite) TestIdentityFileMaking(c *check.C) {
 	key.Pub = []byte("pub")
 
 	// test OpenSSH-compatible identity file creation:
-	err := MakeIdentityFile(username, keyFilePath, &key, IdentityFormatOpenSSH)
+	err := MakeIdentityFile(keyFilePath, &key, IdentityFormatOpenSSH)
 	c.Assert(err, check.IsNil)
 
 	// key is OK:
@@ -101,7 +100,7 @@ func (s *ClientTestSuite) TestIdentityFileMaking(c *check.C) {
 
 	// test standard Teleport identity file creation:
 	keyFilePath = c.MkDir() + "file"
-	err = MakeIdentityFile(username, keyFilePath, &key, IdentityFormatFile)
+	err = MakeIdentityFile(keyFilePath, &key, IdentityFormatFile)
 	c.Assert(err, check.IsNil)
 
 	// key+cert are OK:

--- a/lib/client/identity.go
+++ b/lib/client/identity.go
@@ -56,7 +56,7 @@ const (
 
 // MakeIdentityFile takes a username + his credentials and saves them to disk
 // in a specified format
-func MakeIdentityFile(username, filePath string, key *Key, format IdentityFileFormat) (err error) {
+func MakeIdentityFile(filePath string, key *Key, format IdentityFileFormat) (err error) {
 	const (
 		// the files and the dir will be created with these permissions:
 		fileMode = 0600
@@ -65,9 +65,6 @@ func MakeIdentityFile(username, filePath string, key *Key, format IdentityFileFo
 
 	if filePath == "" {
 		return trace.BadParameter("identity location is not specified")
-	}
-	if username == "" {
-		return trace.BadParameter("identity name is not specified")
 	}
 
 	var output io.Writer = os.Stdout

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -135,8 +135,8 @@ func (c *certificateCache) generateHostCert(principal string) (ssh.Signer, error
 		return nil, trace.Wrap(err)
 	}
 	certBytes, err := c.authClient.GenerateHostCert(pubBytes,
-		principal, principal, clusterName,
-		teleport.Roles{teleport.RoleNode}, 0)
+		principal, principal, nil,
+		clusterName, teleport.Roles{teleport.RoleNode}, 0)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -23,6 +23,8 @@ type HostCertParams struct {
 	PublicHostKey []byte
 	// HostID is used by Teleport to uniquely identify a node within a cluster
 	HostID string
+	// Principals is a list of additional principals to add to the certificate.
+	Principals []string
 	// NodeName is the DNS name of the node
 	NodeName string
 	// ClusterName is the name of the cluster within which a node lives
@@ -34,9 +36,12 @@ type HostCertParams struct {
 }
 
 func (c *HostCertParams) Check() error {
-	if c.HostID == "" || c.ClusterName == "" {
-		return trace.BadParameter("HostID [%q] and ClusterName [%q] are required",
-			c.HostID, c.ClusterName)
+	if c.HostID == "" && len(c.Principals) == 0 {
+		return trace.BadParameter("HostID [%q] or Principals [%q] are required",
+			c.HostID, c.Principals)
+	}
+	if c.ClusterName == "" {
+		return trace.BadParameter("ClusterName [%q] is required", c.ClusterName)
 	}
 
 	if err := c.Roles.Check(); err != nil {

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -167,7 +167,7 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	// set up host private key and certificate
 	hpriv, hpub, err := s.a.GenerateKeyPair("")
 	c.Assert(err, IsNil)
-	hcert, err := s.a.GenerateHostCert(hpub, hostID, s.domainName, s.domainName, teleport.Roles{teleport.RoleAdmin}, 0)
+	hcert, err := s.a.GenerateHostCert(hpub, hostID, s.domainName, nil, s.domainName, teleport.Roles{teleport.RoleAdmin}, 0)
 	c.Assert(err, IsNil)
 
 	// set up user CA and set up a user that has access to the server

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -253,8 +253,9 @@ func (s *WebSuite) SetUpTest(c *C) {
 	// set up host private key and certificate
 	hpriv, hpub, err := s.authServer.GenerateKeyPair("")
 	c.Assert(err, IsNil)
-	hcert, err := s.authServer.GenerateHostCert(
-		hpub, hostID, s.domainName, s.domainName, teleport.Roles{teleport.RoleAdmin}, 0)
+	hcert, err := s.authServer.GenerateHostCert(hpub,
+		hostID, s.domainName, nil,
+		s.domainName, teleport.Roles{teleport.RoleAdmin}, 0)
 	c.Assert(err, IsNil)
 
 	// set up user CA and set up a user that has access to the server

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/kingpin"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/client"
@@ -18,6 +18,8 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/kingpin"
 )
 
 // AuthCommand implements `tctl auth` group of commands
@@ -27,6 +29,7 @@ type AuthCommand struct {
 	genPubPath                 string
 	genPrivPath                string
 	genUser                    string
+	genHost                    string
 	genTTL                     time.Duration
 	exportAuthorityFingerprint string
 	exportPrivateKeys          bool
@@ -57,7 +60,8 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *service.Confi
 	a.authGenerate.Flag("priv-key", "path to the private key").Required().StringVar(&a.genPrivPath)
 
 	a.authSign = auth.Command("sign", "Create an identity file(s) for a given user")
-	a.authSign.Flag("user", "Teleport user name").Required().StringVar(&a.genUser)
+	a.authSign.Flag("user", "Teleport user name").StringVar(&a.genUser)
+	a.authSign.Flag("host", "Teleport host name").StringVar(&a.genHost)
 	a.authSign.Flag("out", "identity output").Short('o').StringVar(&a.output)
 	a.authSign.Flag("format", "identity format: 'file' (default) or 'dir'").Default(string(client.DefaultIdentityFormat)).StringVar((*string)(&a.outputFormat))
 	a.authSign.Flag("ttl", "TTL (time to live) for the generated certificate").Default(fmt.Sprintf("%v", defaults.CertDuration)).DurationVar(&a.genTTL)
@@ -199,6 +203,61 @@ func (a *AuthCommand) GenerateKeys() error {
 
 // GenerateAndSignKeys generates a new keypair and signs it for role
 func (a *AuthCommand) GenerateAndSignKeys(clusterApi *auth.TunClient) error {
+	switch {
+	case a.genUser != "" && a.genHost == "":
+		return a.generateUserKeys(clusterApi)
+	case a.genUser == "" && a.genHost != "":
+		return a.generateHostKeys(clusterApi)
+	default:
+		return trace.BadParameter("--user or --host must be specified")
+	}
+}
+
+func (a *AuthCommand) generateHostKeys(clusterApi *auth.TunClient) error {
+	// only format=openssh is supported
+	if a.outputFormat != client.IdentityFormatOpenSSH {
+		return trace.BadParameter("invalid --format flag %q, only %q is supported", a.outputFormat, client.IdentityFormatOpenSSH)
+	}
+
+	// split up comma separated list
+	principals := strings.Split(a.genHost, ",")
+
+	// generate a keypair
+	key, err := client.NewKey()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	cn, err := clusterApi.GetClusterName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	clusterName := cn.GetClusterName()
+
+	key.Cert, err = clusterApi.GenerateHostCert(key.Pub,
+		"", "", principals,
+		clusterName, teleport.Roles{teleport.RoleNode}, 0)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// if no name was given, take the first name on the list of principals
+	filePath := a.output
+	if filePath == "" {
+		filePath = principals[0]
+	}
+
+	err = client.MakeIdentityFile(filePath, key, a.outputFormat)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if a.output != "" {
+		fmt.Printf("\nThe certificate has been written to %s\n", a.output)
+	}
+	return nil
+}
+
+func (a *AuthCommand) generateUserKeys(clusterApi *auth.TunClient) error {
 	// parse compatibility parameter
 	compatibility, err := utils.CheckCompatibilityFlag(a.compatibility)
 	if err != nil {
@@ -218,7 +277,7 @@ func (a *AuthCommand) GenerateAndSignKeys(clusterApi *auth.TunClient) error {
 	}
 
 	// write the cert+private key to the output:
-	err = client.MakeIdentityFile(a.genUser, a.output, key, a.outputFormat)
+	err = client.MakeIdentityFile(a.output, key, a.outputFormat)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -322,7 +322,7 @@ func onLogin(cf *CLIConf) {
 		utils.FatalError(err)
 	}
 	if makeIdentityFile {
-		client.MakeIdentityFile(cf.Username, cf.IdentityFileOut, key, cf.IdentityFormat)
+		client.MakeIdentityFile(cf.IdentityFileOut, key, cf.IdentityFormat)
 		fmt.Printf("\nThe certificate has been written to %s\n", cf.IdentityFileOut)
 		return
 	}


### PR DESCRIPTION
**Purpose**

As covered in #1458, to support the Teleport recording proxy, Teleport administrators need to have the ability to place host certificates issues by the Teleport CA on OpenSSH nodes. This PR adds the ability to generate arbitrary host certificates to `tctl`.

**Implementation**

```bash
$ tctl auth sign --host=host1.example.com,host2.example.com --format=openssh
```
**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1458