### PR TITLE
Handle "exec" commands correctly

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -76,6 +76,15 @@ type Exec interface {
 
 // NewExecRequest creates a new local or remote Exec.
 func NewExecRequest(ctx *ServerContext, command string) (Exec, error) {
+	// doesn't matter what mode the cluster is in, if this is a teleport node
+	// return a local *localExec
+	if ctx.srv.Component() == teleport.ComponentNode {
+		return &localExec{
+			Ctx:     ctx,
+			Command: command,
+		}, nil
+	}
+
 	clusterConfig, err := ctx.srv.GetAccessPoint().GetClusterConfig()
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
**Purpose**

Teleport clients create multiple sessions when running a "exec" request. This makes sure that each session gets an agent forwarded on it so the recording proxy and forward the agent to the target node.

**Implementation**

1. Always forward agent to each SSH session request.
1. When creating a new SSH exec request, if the caller is a Teleport node, create a local request regardless of which mode the proxy is in.

**Related Issues**

n/a