### PR TITLE
Consolidated terminal type handling.

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -190,7 +190,6 @@ func (ns *NodeSession) interactiveSession(callback interactiveCallback) error {
 	if termType == "" {
 		termType = teleport.SafeTerminalType
 	}
-	ns.env["TERM"] = termType
 	// create the server-side session:
 	sess, err := ns.createServerSession()
 	if err != nil {

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -350,6 +350,11 @@ func prepareCommand(ctx *ServerContext) (*exec.Cmd, error) {
 	for n, v := range ctx.env {
 		c.Env = append(c.Env, fmt.Sprintf("%s=%s", n, v))
 	}
+	// if a terminal was allocated, apply terminal type variable
+	if ctx.session != nil {
+		c.Env = append(c.Env, fmt.Sprintf("TERM=%v", ctx.session.term.GetTermType()))
+	}
+
 	// apply SSH_xx environment variables
 	remoteHost, remotePort, err := net.SplitHostPort(ctx.Conn.RemoteAddr().String())
 	if err != nil {

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -72,11 +72,14 @@ type Terminal interface {
 	// and avoid extra system call.
 	GetTerminalParams() rsession.TerminalParams
 
-	// SetTermType sets the terminal type from "pty-req"
-	SetTermType(string)
-
 	// SetTerminalModes sets the terminal modes from "pty-req"
 	SetTerminalModes(ssh.TerminalModes)
+
+	// GetTermType gets the terminal type set in "pty-req"
+	GetTermType() string
+
+	// SetTermType sets the terminal type from "pty-req"
+	SetTermType(string)
 }
 
 // NewTerminal returns a new terminal. Terminal can be local or remote
@@ -113,7 +116,8 @@ type terminal struct {
 	pty *os.File
 	tty *os.File
 
-	params rsession.TerminalParams
+	termType string
+	params   rsession.TerminalParams
 }
 
 // NewLocalTerminal creates and returns a local PTY.
@@ -277,11 +281,17 @@ func (t *terminal) GetTerminalParams() rsession.TerminalParams {
 	return t.params
 }
 
+// GetTermType gets the terminal type set in "pty-req"
+func (t *terminal) GetTermType() string {
+	return t.termType
+}
+
 // SetTermType sets the terminal type from "req-pty" request.
 func (t *terminal) SetTermType(term string) {
-	if t.cmd != nil {
-		t.cmd.Env = append(t.cmd.Env, "TERM="+term)
+	if term == "" {
+		term = defaultTerm
 	}
+	t.termType = term
 }
 
 func (t *terminal) SetTerminalModes(termModes ssh.TerminalModes) {
@@ -465,7 +475,15 @@ func (t *remoteTerminal) GetTerminalParams() rsession.TerminalParams {
 	return t.params
 }
 
+// GetTermType gets the terminal type set in "pty-req"
+func (t *remoteTerminal) GetTermType() string {
+	return t.termType
+}
+
 func (t *remoteTerminal) SetTermType(term string) {
+	if term == "" {
+		term = defaultTerm
+	}
 	t.termType = term
 }
 

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -90,7 +90,7 @@ func (t *TermHandlers) HandlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *Serve
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ctx.Debugf("Requested terminal of size %v", *params)
+	ctx.Debugf("Requested terminal %q of size %v", ptyRequest.Env, *params)
 
 	// get an existing terminal or create a new one
 	term := ctx.GetTerm()


### PR DESCRIPTION
**Purpose**

Consolidate terminal type handling code.

**Implementation**

In `tsh`, don't include the terminal type in an environment variable, only pass it in the `pty-req`.

In `teleport`, store the terminal type in either a `srv.localTerminal` or `srv.remoteTerminal`. For local terminals, append this value to the list of environment variables for the `*exec.Cmd` and for remote terminals forward this along in the `pty-req`.