### PR TITLE
Continue to emit session specific audit events when session recording is disabled.

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1434,7 +1434,8 @@ func (s *IntSuite) TestAuditOff(c *check.C) {
 	}
 
 	// audit log should have the fact that the session occured recorded in it
-	sessions, _ = site.GetSessions(defaults.Namespace)
+	sessions, err = site.GetSessions(defaults.Namespace)
+	c.Assert(err, check.IsNil)
 	c.Assert(len(sessions), check.Equals, 1)
 
 	// however, attempts to read the actual sessions should fail because it was

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -545,12 +545,6 @@ func (l *AuditLog) LoggerFor(namespace string, sid session.ID) (SessionLogger, e
 		return nil, trace.BadParameter("missing parameter namespace")
 	}
 
-	// if we are not recording sessions, create a logger that discards all
-	// session data sent to it.
-	if l.RecordSessions == false {
-		return &discardSessionLogger{}, nil
-	}
-
 	logger, ok := l.loggers.Get(string(sid))
 	if ok {
 		sessionLogger, converted := logger.(SessionLogger)
@@ -578,6 +572,7 @@ func (l *AuditLog) LoggerFor(namespace string, sid session.ID) (SessionLogger, e
 		EventsFileName: l.sessionLogFn(namespace, sid),
 		StreamFileName: l.sessionStreamFn(namespace, sid),
 		Clock:          l.Clock,
+		RecordSessions: l.RecordSessions,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -158,17 +158,21 @@ func (a *AuditTestSuite) TestSessionRecordingOff(c *check.C) {
 	err = alog.EmitAuditEvent(SessionEndEvent, EventFields{SessionEventID: "200", EventLogin: "doggy", EventNamespace: defaults.Namespace})
 	c.Assert(err, check.IsNil)
 
-	// get all events from the audit log, we should have two
+	// get all events from the audit log, should have two events
 	found, err := alog.SearchEvents(now.Add(-time.Hour), now.Add(time.Hour), "")
 	c.Assert(err, check.IsNil)
 	c.Assert(found, check.HasLen, 2)
 	c.Assert(found[0].GetString(EventLogin), check.Equals, "doggy")
 	c.Assert(found[1].GetString(EventLogin), check.Equals, "doggy")
 
-	// inspect the session log for "200". it should be empty.
+	// inspect the session log for "200", should have two events
 	history, err := alog.GetSessionEvents(defaults.Namespace, "200", 0)
 	c.Assert(err, check.IsNil)
-	c.Assert(history, check.HasLen, 0)
+	c.Assert(history, check.HasLen, 2)
+
+	// try getting the session stream, should get an error
+	_, err = alog.GetSessionChunk(defaults.Namespace, "200", 0, 5000)
+	c.Assert(err, check.NotNil)
 }
 
 func (a *AuditTestSuite) TestBasicLogging(c *check.C) {

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -46,24 +46,3 @@ func (d *DiscardAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) (
 func (d *DiscardAuditLog) SearchSessionEvents(fromUTC time.Time, toUTC time.Time) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }
-
-// discardSessionLogger implements a session logger that does nothing. It
-// discards all events and chunks written to it. It is used when session
-// recording has been disabled.
-type discardSessionLogger struct{}
-
-func (d *discardSessionLogger) LogEvent(fields EventFields) {
-	return
-}
-
-func (d *discardSessionLogger) Close() error {
-	return nil
-}
-
-func (d *discardSessionLogger) Finalize() error {
-	return nil
-}
-
-func (d *discardSessionLogger) WriteChunk(chunk *SessionChunk) (written int, err error) {
-	return 0, nil
-}


### PR DESCRIPTION
**Purpose**

In #1430 the ability to not record sessions was introduced. Starting with #1430 events continued to go to the Audit Log, but session specific events and stream bytes were discarded. Unfortunately as covered in #1519 the stream specific events are required by the Web UI to do things like close terminal windows when a session is complete.

This PR reintroduces stream specific events when session recording is disabled.

**Implementation**

* Removed the `discardSessionLogger`.
* Only create the stream bytes file when session recording is enabled.
* In `WriteChunk`, chunks are only written if recording is enabled.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1519