### PR TITLE
Create single server context for forwarding server.

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -749,7 +749,7 @@ func (s *IntSuite) TestTwoClusters(c *check.C) {
 						return nil
 					}
 				case <-stopCh:
-					return trace.BadParameter("unable to find %v events after 5s: %v", count)
+					return trace.BadParameter("unable to find %v events after 5s", count)
 				}
 			}
 		}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -201,6 +201,10 @@ func NewServerContext(srv Server, conn *ssh.ServerConn, identityContext Identity
 	return ctx
 }
 
+func (c *ServerContext) ID() int {
+	return c.id
+}
+
 func (c *ServerContext) GetServer() Server {
 	return c.srv
 }


### PR DESCRIPTION
**Purpose**

Initially the forwarding server would be created when the connection was requested and torn down after the completion of either a `direct-tcpip` or `session` channel request. This PR changes this behavior to wait until the connection is complete (or timed out due to missed heartbeats) and then tear down the forwarding server.

**Implementation**

* Create a single server context that lasts for the entire life of the forwarding server.
* Close the `direct-tcpip` or `session` channel to signal to the client that the request is complete.