### PR TITLE
Add support for remote_cluster, implements #1526

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -266,3 +266,12 @@ const DefaultImplicitRole = "default-implicit-role"
 
 // APIDomain is a default domain name for Auth server API
 const APIDomain = "teleport.cluster.local"
+
+const (
+	// RemoteClusterStatusOffline indicates that cluster is considered as
+	// offline, since it has missed a series of heartbeats
+	RemoteClusterStatusOffline = "offline"
+	// RemoteClusterStatusOnline indicates that cluster is sending heartbeats
+	// at expected interval
+	RemoteClusterStatusOnline = "online"
+)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1108,6 +1108,44 @@ func (a *AuthWithRoles) DeleteAllTunnelConnections() error {
 	return a.authServer.DeleteAllTunnelConnections()
 }
 
+func (a *AuthWithRoles) CreateRemoteCluster(conn services.RemoteCluster) error {
+	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbCreate); err != nil {
+		return trace.Wrap(err)
+	}
+	return a.authServer.CreateRemoteCluster(conn)
+}
+
+func (a *AuthWithRoles) GetRemoteCluster(clusterName string) (services.RemoteCluster, error) {
+	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.authServer.GetRemoteCluster(clusterName)
+}
+
+func (a *AuthWithRoles) GetRemoteClusters() ([]services.RemoteCluster, error) {
+	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.authServer.GetRemoteClusters()
+}
+
+func (a *AuthWithRoles) DeleteRemoteCluster(clusterName string) error {
+	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbDelete); err != nil {
+		return trace.Wrap(err)
+	}
+	return a.authServer.DeleteRemoteCluster(clusterName)
+}
+
+func (a *AuthWithRoles) DeleteAllRemoteClusters() error {
+	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbList); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbDelete); err != nil {
+		return trace.Wrap(err)
+	}
+	return a.authServer.DeleteAllRemoteClusters()
+}
+
 func (a *AuthWithRoles) Close() error {
 	return a.authServer.Close()
 }

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -258,6 +258,7 @@ func GetCheckerForBuiltinRole(clusterConfig services.ClusterConfig, role telepor
 							services.NewRule(services.KindStaticTokens, services.RO()),
 							services.NewRule(services.KindTunnelConnection, services.RW()),
 							services.NewRule(services.KindHostCert, services.RW()),
+							services.NewRule(services.KindRemoteCluster, services.RO()),
 						},
 					},
 				})
@@ -290,6 +291,7 @@ func GetCheckerForBuiltinRole(clusterConfig services.ClusterConfig, role telepor
 						services.NewRule(services.KindClusterName, services.RO()),
 						services.NewRule(services.KindStaticTokens, services.RO()),
 						services.NewRule(services.KindTunnelConnection, services.RW()),
+						services.NewRule(services.KindRemoteCluster, services.RO()),
 					},
 				},
 			})

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -197,6 +197,16 @@ func (s *TLSSuite) TestTunnelConnectionsCRUD(c *check.C) {
 	suite.TunnelConnectionsCRUD(c)
 }
 
+func (s *TLSSuite) TestRemoteClustersCRUD(c *check.C) {
+	clt, err := s.server.NewClient(TestAdmin())
+	c.Assert(err, check.IsNil)
+
+	suite := &suite.ServicesTestSuite{
+		PresenceS: clt,
+	}
+	suite.RemoteClustersCRUD(c)
+}
+
 func (s *TLSSuite) TestServersCRUD(c *check.C) {
 	clt, err := s.server.NewClient(TestAdmin())
 	c.Assert(err, check.IsNil)

--- a/lib/fixtures/fixtures.go
+++ b/lib/fixtures/fixtures.go
@@ -29,6 +29,11 @@ func ExpectAccessDenied(c *check.C, err error) {
 	c.Assert(trace.IsAccessDenied(err), check.Equals, true, check.Commentf("expected AccessDenied, got %T %#v at %v", err, err, string(debug.Stack())))
 }
 
+// ExpectAlreadyExists expects already exists error
+func ExpectAlreadyExists(c *check.C, err error) {
+	c.Assert(trace.IsAlreadyExists(err), check.Equals, true, check.Commentf("expected AlreadyExists, got %T %#v at %v", err, err, string(debug.Stack())))
+}
+
 // DeepCompare uses gocheck DeepEquals but provides nice diff if things are not equal
 func DeepCompare(c *check.C, a, b interface{}) {
 	d := &spew.ConfigState{Indent: " ", DisableMethods: true, DisablePointerMethods: true, DisablePointerAddresses: true}

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -27,6 +27,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"net"
 	"sync"
 	"time"
@@ -188,7 +189,9 @@ func (m *Mux) detectAndForward(conn net.Conn) {
 	}
 	connWrapper, err := detect(conn, m.EnableProxyProtocol)
 	if err != nil {
-		m.Warning(trace.DebugReport(err))
+		if trace.Unwrap(err) != io.EOF {
+			m.Warning(trace.DebugReport(err))
+		}
 		conn.Close()
 		return
 	}

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -102,7 +102,7 @@ func (s *localSite) String() string {
 }
 
 func (s *localSite) GetStatus() string {
-	return RemoteSiteStatusOnline
+	return teleport.RemoteClusterStatusOnline
 }
 
 func (s *localSite) GetName() string {

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -98,7 +98,7 @@ func (p *clusterPeers) String() string {
 func (p *clusterPeers) GetStatus() string {
 	peer, err := p.pickPeer()
 	if err != nil {
-		return RemoteSiteStatusOffline
+		return teleport.RemoteClusterStatusOffline
 	}
 	return peer.GetStatus()
 }
@@ -165,9 +165,9 @@ func (s *clusterPeer) String() string {
 func (s *clusterPeer) GetStatus() string {
 	diff := time.Now().Sub(s.connInfo.GetLastHeartbeat())
 	if diff > defaults.ReverseTunnelOfflineThreshold {
-		return RemoteSiteStatusOffline
+		return teleport.RemoteClusterStatusOffline
 	}
-	return RemoteSiteStatusOnline
+	return teleport.RemoteClusterStatusOnline
 }
 
 func (s *clusterPeer) GetName() string {
@@ -183,4 +183,9 @@ func (s *clusterPeer) GetLastConnected() time.Time {
 // reverse proxy tunnel.
 func (s *clusterPeer) Dial(from, to net.Addr) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy %v has not been discovered yet, try again later", s)
+}
+
+// Close closes cluster peer connections
+func (s *clusterPeer) Close() error {
+	return nil
 }

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -113,3 +113,7 @@ func (s *ServicesSuite) TestTunnelConnectionsCRUD(c *C) {
 func (s *ServicesSuite) TestGithubConnectorCRUD(c *C) {
 	s.suite.GithubConnectorCRUD(c)
 }
+
+func (s *ServicesSuite) TestRemoteClustersCRUD(c *C) {
+	s.suite.RemoteClustersCRUD(c)
+}

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -113,6 +113,21 @@ type Presence interface {
 
 	// DeleteAllTunnelConnections deletes all tunnel connections for cluster
 	DeleteAllTunnelConnections() error
+
+	// CreateRemoteCluster creates a remote cluster
+	CreateRemoteCluster(RemoteCluster) error
+
+	// GetRemoteClusters returns a list of remote clusters
+	GetRemoteClusters() ([]RemoteCluster, error)
+
+	// GetRemoteCluster returns a remote cluster by name
+	GetRemoteCluster(clusterName string) (RemoteCluster, error)
+
+	// DeleteRemoteCluster deletes remote cluster by name
+	DeleteRemoteCluster(clusterName string) error
+
+	// DeleteAllRemoteClusters deletes all remote clusters
+	DeleteAllRemoteClusters() error
 }
 
 // NewNamespace returns new namespace

--- a/lib/services/remotecluster.go
+++ b/lib/services/remotecluster.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+// RemoteCluster represents a remote cluster that has connected via reverse tunnel
+// to this lcuster
+type RemoteCluster interface {
+	// Resource provides common resource properties
+	Resource
+	// GetConnectionStatus returns connection status
+	GetConnectionStatus() string
+	// SetConnectionStatus sets connection  status
+	SetConnectionStatus(string)
+
+	// GetLastHeartbeat returns last heartbeat of the cluster
+	GetLastHeartbeat() time.Time
+	// SetLastHeartbeat sets last heartbeat of the cluster
+	SetLastHeartbeat(t time.Time)
+
+	// CheckAndSetDefaults checks and sets default values
+	CheckAndSetDefaults() error
+}
+
+// NewRemoteCluster is a convenience wa to create a RemoteCluster resource.
+func NewRemoteCluster(name string) (RemoteCluster, error) {
+	return &RemoteClusterV3{
+		Kind:    KindRemoteCluster,
+		Version: V3,
+		Metadata: Metadata{
+			Name:      name,
+			Namespace: defaults.Namespace,
+		},
+	}, nil
+}
+
+// RemoteClusterV3 implements RemoteCluster.
+type RemoteClusterV3 struct {
+	// Kind is a resource kind - always resource.
+	Kind string `json:"kind"`
+
+	// Version is a resource version.
+	Version string `json:"version"`
+
+	// Metadata is metadata about the resource.
+	Metadata Metadata `json:"metadata"`
+
+	// Sstatus is read only status of the remote cluster
+	Status RemoteClusterStatusV3 `json:"status"`
+}
+
+// RemoteClusterSpecV3 represents status of the remote cluster
+type RemoteClusterStatusV3 struct {
+	// Connection represents connection status, online or offline
+	Connection string `json:"connection"`
+	// LastHeartbeat records last heartbeat of the cluster
+	LastHeartbeat time.Time `json:"last_heartbeat"`
+}
+
+// CheckAndSetDefaults checks and sets default values
+func (c *RemoteClusterV3) CheckAndSetDefaults() error {
+	return c.Metadata.CheckAndSetDefaults()
+}
+
+// GetLastHeartbeat returns last heartbeat of the cluster
+func (c *RemoteClusterV3) GetLastHeartbeat() time.Time {
+	return c.Status.LastHeartbeat
+}
+
+// SetLastHeartbeat sets last heartbeat of the cluster
+func (c *RemoteClusterV3) SetLastHeartbeat(t time.Time) {
+	c.Status.LastHeartbeat = t
+}
+
+// GetConnectionStatus returns connection status
+func (c *RemoteClusterV3) GetConnectionStatus() string {
+	return c.Status.Connection
+}
+
+// SetConnectionStatus sets connection  status
+func (c *RemoteClusterV3) SetConnectionStatus(status string) {
+	c.Status.Connection = status
+}
+
+// GetMetadata returns object metadata
+func (c *RemoteClusterV3) GetMetadata() Metadata {
+	return c.Metadata
+}
+
+// SetExpiry sets expiry time for the object
+func (c *RemoteClusterV3) SetExpiry(expires time.Time) {
+	c.Metadata.SetExpiry(expires)
+}
+
+// Expires returns object expiry setting
+func (c *RemoteClusterV3) Expiry() time.Time {
+	return c.Metadata.Expiry()
+}
+
+// SetTTL sets Expires header using realtime clock
+func (c *RemoteClusterV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+	c.Metadata.SetTTL(clock, ttl)
+}
+
+// GetName returns the name of the RemoteCluster.
+func (c *RemoteClusterV3) GetName() string {
+	return c.Metadata.Name
+}
+
+// SetName sets the name of the RemoteCluster.
+func (c *RemoteClusterV3) SetName(e string) {
+	c.Metadata.Name = e
+}
+
+// String represents a human readable version of remote cluster settings.
+func (r *RemoteClusterV3) String() string {
+	return fmt.Sprintf("RemoteCluster(%v, %v)", r.Metadata.Name, r.Status.Connection)
+}
+
+// RemoteClusterSchemaTemplate is a template JSON Schema for V3 style objects
+const RemoteClusterV3SchemaTemplate = `{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["kind", "metadata", "version"],
+  "properties": {
+    "kind": {"type": "string"},
+    "version": {"type": "string", "default": "v3"},
+    "metadata": %v,
+    "status": %v
+  }
+}`
+
+// RemoteClusterV3StatusSchema is a template for remote
+const RemoteClusterV3StatusSchema = `{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["connection", "last_heartbeat"],
+  "properties": {
+    "connection": {"type": "string"},
+    "last_heartbeat": {"type": "string"}
+  }
+}`
+
+// GetRemoteClusterSchema returns the schema for remote cluster
+func GetRemoteClusterSchema() string {
+	return fmt.Sprintf(RemoteClusterV3SchemaTemplate, MetadataSchema, RemoteClusterV3StatusSchema)
+}
+
+// UnmarshalRemoteCluster unmarshals remote cluster from JSON or YAML.
+func UnmarshalRemoteCluster(bytes []byte) (RemoteCluster, error) {
+	var cluster RemoteClusterV3
+
+	if len(bytes) == 0 {
+		return nil, trace.BadParameter("missing resource data")
+	}
+
+	err := utils.UnmarshalWithSchema(GetRemoteClusterSchema(), &cluster, bytes)
+	if err != nil {
+		return nil, trace.BadParameter(err.Error())
+	}
+
+	err = cluster.CheckAndSetDefaults()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &cluster, nil
+}
+
+// MarshalRemoteCluster marshals remote cluster to JSON.
+func MarshalRemoteCluster(c RemoteCluster, opts ...MarshalOption) ([]byte, error) {
+	return json.Marshal(c)
+}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -149,6 +149,10 @@ const (
 	// KindTunnelConection specifies connection of a reverse tunnel to proxy
 	KindTunnelConnection = "tunnel_connection"
 
+	// KindRemoteCluster represents remote cluster connected via reverse tunnel
+	// to proxy
+	KindRemoteCluster = "remote_cluster"
+
 	// V3 is the third version of resources.
 	V3 = "v3"
 
@@ -402,6 +406,8 @@ func ParseShortcut(in string) (string, error) {
 		return KindTrustedCluster, nil
 	case "cluster_authentication_preferences", "cap":
 		return KindClusterAuthPreference, nil
+	case "remote_cluster", "remote_clusters", "rc", "rcs":
+		return KindRemoteCluster, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %v", in)
 }

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -280,6 +280,11 @@ func (d *ResourceCommand) Delete(client auth.ClientI) (err error) {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("trusted cluster %q has been deleted\n", d.ref.Name)
+	case services.KindRemoteCluster:
+		if err = client.DeleteRemoteCluster(d.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("remote cluster %q has been deleted\n", d.ref.Name)
 	default:
 		return trace.BadParameter("deleting resources of type %q is not supported", d.ref.Kind)
 	}
@@ -406,6 +411,19 @@ func (g *ResourceCommand) getCollection(client auth.ClientI) (c ResourceCollecti
 			return nil, trace.Wrap(err)
 		}
 		return &trustedClusterCollection{trustedClusters: []services.TrustedCluster{trustedCluster}}, nil
+	case services.KindRemoteCluster:
+		if g.ref.Name == "" {
+			remoteClusters, err := client.GetRemoteClusters()
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &remoteClusterCollection{remoteClusters: remoteClusters}, nil
+		}
+		remoteCluster, err := client.GetRemoteCluster(g.ref.Name)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &remoteClusterCollection{remoteClusters: []services.RemoteCluster{remoteCluster}}, nil
 	}
 	return nil, trace.BadParameter("'%v' is not supported", g.ref.Kind)
 }


### PR DESCRIPTION
This commit adds remote cluster resource that specifies
connection and trust of the remote trusted cluster to the local
cluster. Deleting remote cluster resource deletes trust
established between clusters on the local cluster side
and terminates all reverse tunnel connections.

Migrations make sure that remote cluster resources exist
after upgrade of the auth server.