### PR TITLE
Join address for web, reverse tunnel, fixes #1544

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -114,7 +114,7 @@ func (s *IntSuite) SetUpSuite(c *check.C) {
 // newTeleport helper returns a running Teleport instance pre-configured
 // with the current user os.user.Current().
 func (s *IntSuite) newTeleport(c *check.C, logins []string, enableSSH bool) *TeleInstance {
-	t := NewInstance(Site, HostID, Host, s.getPorts(5), s.priv, s.pub)
+	t := NewInstance(InstanceConfig{ClusterName: Site, HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
 	// use passed logins, but use suite's default login if nothing was passed
 	if logins == nil || len(logins) == 0 {
 		logins = []string{s.me.Username}
@@ -135,7 +135,7 @@ func (s *IntSuite) newTeleport(c *check.C, logins []string, enableSSH bool) *Tel
 // Teleport instance with the passed in user, instance secrets, and Teleport
 // configuration.
 func (s *IntSuite) newTeleportWithConfig(c *check.C, logins []string, instanceSecrets []*InstanceSecrets, teleportConfig *service.Config) *TeleInstance {
-	t := NewInstance(Site, HostID, Host, s.getPorts(5), s.priv, s.pub)
+	t := NewInstance(InstanceConfig{ClusterName: Site, HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
 
 	// use passed logins, but use suite's default login if nothing was passed
 	if logins == nil || len(logins) == 0 {
@@ -617,8 +617,8 @@ func (s *IntSuite) TestTwoClusters(c *check.C) {
 
 		username := s.me.Username
 
-		a := NewInstance("site-A", HostID, Host, s.getPorts(5), s.priv, s.pub)
-		b := NewInstance("site-B", HostID, Host, s.getPorts(5), s.priv, s.pub)
+		a := NewInstance(InstanceConfig{ClusterName: "site-A", HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
+		b := NewInstance(InstanceConfig{ClusterName: "site-B", HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
 
 		a.AddUser(username, []string{username})
 		b.AddUser(username, []string{username})
@@ -776,8 +776,8 @@ func (s *IntSuite) TestTwoClustersProxy(c *check.C) {
 
 	username := s.me.Username
 
-	a := NewInstance("site-A", HostID, Host, s.getPorts(5), s.priv, s.pub)
-	b := NewInstance("site-B", HostID, Host, s.getPorts(5), s.priv, s.pub)
+	a := NewInstance(InstanceConfig{ClusterName: "site-A", HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
+	b := NewInstance(InstanceConfig{ClusterName: "site-B", HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
 
 	a.AddUser(username, []string{username})
 	b.AddUser(username, []string{username})
@@ -810,8 +810,8 @@ func (s *IntSuite) TestTwoClustersProxy(c *check.C) {
 func (s *IntSuite) TestHA(c *check.C) {
 	username := s.me.Username
 
-	a := NewInstance("cluster-a", HostID, Host, s.getPorts(5), s.priv, s.pub)
-	b := NewInstance("cluster-b", HostID, Host, s.getPorts(5), s.priv, s.pub)
+	a := NewInstance(InstanceConfig{ClusterName: "cluster-a", HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
+	b := NewInstance(InstanceConfig{ClusterName: "cluster-b", HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
 
 	a.AddUser(username, []string{username})
 	b.AddUser(username, []string{username})
@@ -879,8 +879,8 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 
 	clusterMain := "cluster-main"
 	clusterAux := "cluster-aux"
-	main := NewInstance(clusterMain, HostID, Host, s.getPorts(5), s.priv, s.pub)
-	aux := NewInstance(clusterAux, HostID, Host, s.getPorts(5), s.priv, s.pub)
+	main := NewInstance(InstanceConfig{ClusterName: clusterMain, HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
+	aux := NewInstance(InstanceConfig{ClusterName: clusterAux, HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
 
 	// main cluster has a local user and belongs to role "main-devs"
 	mainDevs := "main-devs"
@@ -1067,15 +1067,25 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 	c.Assert(aux.Stop(true), check.IsNil)
 }
 
-// TestRemoteClusters tests disconnecting remote clusters
-// using remote cluster feature
-func (s *IntSuite) TestRemoteClusters(c *check.C) {
+// TestTrustedClusters tests remote clusters scenarios
+// using trusted clusters feature
+func (s *IntSuite) TestTrustedClusters(c *check.C) {
+	s.trustedClusters(c, false)
+}
+
+// TestMultiplexingTrustedClusters tests remote clusters scenarios
+// using trusted clusters feature
+func (s *IntSuite) TestMultiplexingTrustedClusters(c *check.C) {
+	s.trustedClusters(c, true)
+}
+
+func (s *IntSuite) trustedClusters(c *check.C, multiplex bool) {
 	username := s.me.Username
 
 	clusterMain := "cluster-main"
 	clusterAux := "cluster-aux"
-	main := NewInstance(clusterMain, HostID, Host, s.getPorts(5), s.priv, s.pub)
-	aux := NewInstance(clusterAux, HostID, Host, s.getPorts(5), s.priv, s.pub)
+	main := NewInstance(InstanceConfig{ClusterName: clusterMain, HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub, MultiplexProxy: multiplex})
+	aux := NewInstance(InstanceConfig{ClusterName: clusterAux, HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
 
 	// main cluster has a local user and belongs to role "main-devs"
 	mainDevs := "main-devs"
@@ -1254,8 +1264,8 @@ func (s *IntSuite) TestDiscovery(c *check.C) {
 	go lb.Serve()
 	defer lb.Close()
 
-	remote := NewInstance("cluster-remote", HostID, Host, s.getPorts(5), s.priv, s.pub)
-	main := NewInstance("cluster-main", HostID, Host, s.getPorts(5), s.priv, s.pub)
+	remote := NewInstance(InstanceConfig{ClusterName: "cluster-remote", HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
+	main := NewInstance(InstanceConfig{ClusterName: "cluster-main", HostID: HostID, NodeName: Host, Ports: s.getPorts(5), Priv: s.priv, Pub: s.pub})
 
 	remote.AddUser(username, []string{username})
 	main.AddUser(username, []string{username})

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -261,6 +261,10 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 
 	// apply "proxy_service" section
+	cfg.Proxy.EnableProxyProtocol, err = utils.ParseOnOff("proxy_protocol", fc.Proxy.ProxyProtocol, true)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	if fc.Proxy.ListenAddress != "" {
 		addr, err := utils.ParseHostPortAddr(fc.Proxy.ListenAddress, int(defaults.SSHProxyListenPort))
 		if err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -654,14 +654,25 @@ type CommandLabel struct {
 	Period  time.Duration `yaml:"period"`
 }
 
-// Proxy is `proxy_service` section of the config file:
+// Proxy is a `proxy_service` section of the config file:
 type Proxy struct {
-	Service    `yaml:",inline"`
-	WebAddr    string `yaml:"web_listen_addr,omitempty"`
-	TunAddr    string `yaml:"tunnel_listen_addr,omitempty"`
-	KeyFile    string `yaml:"https_key_file,omitempty"`
-	CertFile   string `yaml:"https_cert_file,omitempty"`
+	// Service is a generic service configuration section
+	Service `yaml:",inline"`
+	// WebAddr is a web UI listen address
+	WebAddr string `yaml:"web_listen_addr,omitempty"`
+	// TunAddr is a reverse tunnel address
+	TunAddr string `yaml:"tunnel_listen_addr,omitempty"`
+	// KeyFile is a TLS key file
+	KeyFile string `yaml:"https_key_file,omitempty"`
+	// CertFile is a TLS Certificate file
+	CertFile string `yaml:"https_cert_file,omitempty"`
+	// PublicAddr is a publicly advertised address of the proxy
 	PublicAddr string `yaml:"public_addr,omitempty"`
+	// ProxyProtocol turns on support for HAProxy proxy protocol
+	// this is the option that has be turned on only by administrator,
+	// as only admin knows whether service is in front of trusted load balancer
+	// or not.
+	ProxyProtocol string `yaml:"proxy_protocol,omitempty"`
 }
 
 // ReverseTunnel is a SSH reverse tunnel maintained by one cluster's

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -210,6 +210,9 @@ type ProxyConfig struct {
 	// ReverseTunnelListenAddr is address where reverse tunnel dialers connect to
 	ReverseTunnelListenAddr utils.NetAddr
 
+	// EnableProxyProtocol enables proxy protocol support
+	EnableProxyProtocol bool
+
 	// WebAddr is address for web portal of the proxy
 	WebAddr utils.NetAddr
 

--- a/lib/services/trustedcluster.go
+++ b/lib/services/trustedcluster.go
@@ -260,6 +260,11 @@ func (c *TrustedClusterV2) CheckAndSetDefaults() error {
 			},
 		}
 	}
+	// Imply that by default proxy listens on the same port for
+	// web and reverse tunnel connections
+	if c.Spec.ReverseTunnelAddress == "" {
+		c.Spec.ReverseTunnelAddress = c.Spec.ProxyAddress
+	}
 	if err := c.Spec.RoleMap.Check(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -444,6 +444,14 @@ func (s *SrvSuite) testClient(c *C, proxyAddr, targetAddr, remoteAddr string, ss
 	c.Assert(string(out), Equals, "hello\n")
 }
 
+func mustListen(a utils.NetAddr) net.Listener {
+	l, err := net.Listen("tcp", a.Addr)
+	if err != nil {
+		panic(err)
+	}
+	return l
+}
+
 func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 	log.Infof("[TEST START] TestProxyReverseTunnel")
 
@@ -453,7 +461,7 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 		ClientTLS:             s.proxyClient.TLSConfig(),
 		ID:                    hostID,
 		ClusterName:           s.server.ClusterName(),
-		ListenAddr:            reverseTunnelAddress,
+		Listener:              mustListen(reverseTunnelAddress),
 		HostSigners:           []ssh.Signer{s.signer},
 		LocalAuthClient:       s.proxyClient,
 		LocalAccessPoint:      s.proxyClient,
@@ -622,7 +630,7 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 		ClusterName:           s.server.ClusterName(),
 		ClientTLS:             s.proxyClient.TLSConfig(),
 		ID:                    hostID,
-		ListenAddr:            reverseTunnelAddress,
+		Listener:              mustListen(reverseTunnelAddress),
 		HostSigners:           []ssh.Signer{s.signer},
 		LocalAuthClient:       s.proxyClient,
 		LocalAccessPoint:      s.proxyClient,
@@ -722,7 +730,7 @@ func (s *SrvSuite) TestProxyDirectAccess(c *C) {
 		ClientTLS:             s.proxyClient.TLSConfig(),
 		ID:                    hostID,
 		ClusterName:           s.server.ClusterName(),
-		ListenAddr:            reverseTunnelAddress,
+		Listener:              mustListen(reverseTunnelAddress),
 		HostSigners:           []ssh.Signer{s.signer},
 		LocalAuthClient:       s.proxyClient,
 		LocalAccessPoint:      s.proxyClient,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -184,12 +184,12 @@ func (s *WebSuite) SetUpTest(c *C) {
 	s.proxyClient, err = s.server.NewClient(auth.TestBuiltin(teleport.RoleProxy))
 	c.Assert(err, IsNil)
 
+	revTunListener, err := net.Listen("tcp", fmt.Sprintf("%v:0", s.server.ClusterName()))
+	c.Assert(err, IsNil)
+
 	revTunServer, err := reversetunnel.NewServer(reversetunnel.Config{
-		ID: node.ID(),
-		ListenAddr: utils.NetAddr{
-			AddrNetwork: "tcp",
-			Addr:        fmt.Sprintf("%v:0", s.server.ClusterName()),
-		},
+		ID:                    node.ID(),
+		Listener:              revTunListener,
 		ClientTLS:             s.proxyClient.TLSConfig(),
 		ClusterName:           s.server.ClusterName(),
 		HostSigners:           []ssh.Signer{signer},


### PR DESCRIPTION
Support configuration for web and reverse tunnel
proxies to listen on the same port.

* Default config are not changed for backwards compatibility.
* If administrator configures web and reverse tunnel
addresses to be on the same port, multiplexing is turned on
* In trusted clusters configuration reverse_tunnel_addr
defaults to web_addr.