### PR TITLE
Add support for extra principals, fixes #1174

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -892,24 +892,15 @@ func (s *APIServer) generateToken(auth ClientI, w http.ResponseWriter, r *http.R
 	return string(token), nil
 }
 
-type registerUsingTokenReq struct {
-	HostID   string        `json:"hostID"`
-	NodeName string        `json:"node_name"`
-	Role     teleport.Role `json:"role"`
-	Token    string        `json:"token"`
-}
-
 func (s *APIServer) registerUsingToken(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
-	var req *registerUsingTokenReq
+	var req RegisterUsingTokenRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	keys, err := auth.RegisterUsingToken(req.Token, req.HostID, req.NodeName, req.Role)
+	keys, err := auth.RegisterUsingToken(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	return keys, nil
 }
 
@@ -929,22 +920,13 @@ func (s *APIServer) registerNewAuthServer(auth ClientI, w http.ResponseWriter, r
 	return message("ok"), nil
 }
 
-type generateServerKeysReq struct {
-	// HostID is unique ID of the host
-	HostID string `json:"host_id"`
-	// NodeName is user friendly host name
-	NodeName string `json:"node_name"`
-	// Roles is a list of roles assigned to node
-	Roles teleport.Roles `json:"roles"`
-}
-
 func (s *APIServer) generateServerKeys(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
-	var req *generateServerKeysReq
+	var req GenerateServerKeysRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	keys, err := auth.GenerateServerKeys(req.HostID, req.NodeName, req.Roles)
+	keys, err := auth.GenerateServerKeys(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -597,9 +597,36 @@ func HostFQDN(hostUUID, clusterName string) string {
 	return fmt.Sprintf("%v.%v", hostUUID, clusterName)
 }
 
+// GenerateServerKeysRequest is a request to generate server keys
+type GenerateServerKeysRequest struct {
+	// HostID is a unique ID of the host
+	HostID string `json:"host_id"`
+	// NodeName is a user friendly host name
+	NodeName string `json:"node_name"`
+	// Roles is a list of roles assigned to node
+	Roles teleport.Roles `json:"roles"`
+	// AdditionalPrincipals is a list of additional principals
+	// to include in OpenSSH and X509 certificates
+	AdditionalPrincipals []string `json:"additional_principals"`
+}
+
+// CheckAndSetDefaults checks and sets default values
+func (req *GenerateServerKeysRequest) CheckAndSetDefaults() error {
+	if req.HostID == "" {
+		return trace.BadParameter("missing parameter HostID")
+	}
+	if len(req.Roles) != 1 {
+		return trace.BadParameter("expected only one system role, got %v", len(req.Roles))
+	}
+	return nil
+}
+
 // GenerateServerKeys generates new host private keys and certificates (signed
 // by the host certificate authority) for a node.
-func (s *AuthServer) GenerateServerKeys(hostID string, nodeName string, roles teleport.Roles) (*PackedKeys, error) {
+func (s *AuthServer) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedKeys, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	clusterName, err := s.GetDomainName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -636,33 +663,36 @@ func (s *AuthServer) GenerateServerKeys(hostID string, nodeName string, roles te
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	// generate hostSSH certificate
 	hostSSHCert, err := s.Authority.GenerateHostCert(services.HostCertParams{
 		PrivateCASigningKey: caPrivateKey,
 		PublicHostKey:       pubSSHKey,
-		HostID:              hostID,
-		NodeName:            nodeName,
+		HostID:              req.HostID,
+		NodeName:            req.NodeName,
 		ClusterName:         clusterName,
-		Roles:               roles,
+		Roles:               req.Roles,
+		Principals:          append([]string{}, req.AdditionalPrincipals...),
 	})
-
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	// generate host TLS certificate
 	identity := tlsca.Identity{
-		Username: HostFQDN(hostID, clusterName),
-		Groups:   roles.StringSlice(),
+		Username: HostFQDN(req.HostID, clusterName),
+		Groups:   req.Roles.StringSlice(),
 	}
 	certRequest := tlsca.CertificateRequest{
 		Clock:     s.clock,
 		PublicKey: cryptoPubKey,
 		Subject:   identity.Subject(),
 		NotAfter:  s.clock.Now().UTC().Add(defaults.CATTL),
+		DNSNames:  append([]string{}, req.AdditionalPrincipals...),
 	}
 	// HTTPS requests need to specify DNS name that should be present in the
 	// certificate as one of the DNS Names. It is not known in advance,
 	// that is why there is a default one for all certificates
-	if roles.Include(teleport.RoleAuth) || roles.Include(teleport.RoleAdmin) {
-		certRequest.DNSNames = []string{teleport.APIDomain}
+	if req.Roles.Include(teleport.RoleAuth) || req.Roles.Include(teleport.RoleAdmin) {
+		certRequest.DNSNames = append(certRequest.DNSNames, teleport.APIDomain)
 	}
 	hostTLSCert, err := tlsAuthority.GenerateCertificate(certRequest)
 	if err != nil {
@@ -720,6 +750,35 @@ func (s *AuthServer) checkTokenTTL(token string) bool {
 	return true
 }
 
+// RegisterUsingTokenRequest is a request to register with
+// auth server using authentication token
+type RegisterUsingTokenRequest struct {
+	// HostID is a unique host ID, usually a UUID
+	HostID string `json:"hostID"`
+	// NodeName is a node name
+	NodeName string `json:"node_name"`
+	// Role is a system role, e.g. Proxy
+	Role teleport.Role `json:"role"`
+	// Token is an authentication token
+	Token string `json:"token"`
+	// AdditionalPrincipals is a list of additional principals
+	AdditionalPrincipals []string `json:"additional_principals"`
+}
+
+// CheckAndSetDefaults checks for errors and sets defaults
+func (r *RegisterUsingTokenRequest) CheckAndSetDefaults() error {
+	if r.HostID == "" {
+		return trace.BadParameter("missing parameter HostID")
+	}
+	if r.Token == "" {
+		return trace.BadParameter("missing parameter Token")
+	}
+	if err := r.Role.Check(); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 // RegisterUsingToken adds a new node to the Teleport cluster using previously issued token.
 // A node must also request a specific role (and the role must match one of the roles
 // the token was generated for).
@@ -727,40 +786,41 @@ func (s *AuthServer) checkTokenTTL(token string) bool {
 // If a token was generated with a TTL, it gets enforced (can't register new nodes after TTL expires)
 // If a token was generated with a TTL=0, it means it's a single-use token and it gets destroyed
 // after a successful registration.
-func (s *AuthServer) RegisterUsingToken(token, hostID string, nodeName string, role teleport.Role) (*PackedKeys, error) {
-	log.Infof("Node %q [%v] is trying to join with role: %v.", nodeName, hostID, role)
-	if hostID == "" {
-		return nil, trace.BadParameter("HostID cannot be empty")
-	}
-
-	if err := role.Check(); err != nil {
+func (s *AuthServer) RegisterUsingToken(req RegisterUsingTokenRequest) (*PackedKeys, error) {
+	log.Infof("Node %q [%v] is trying to join with role: %v.", req.NodeName, req.HostID, req.Role)
+	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// make sure the token is valid
-	roles, err := s.ValidateToken(token)
+	roles, err := s.ValidateToken(req.Token)
 	if err != nil {
-		msg := fmt.Sprintf("%q [%v] can not join the cluster with role %s, token error: %v", nodeName, hostID, role, err)
+		msg := fmt.Sprintf("%q [%v] can not join the cluster with role %s, token error: %v", req.NodeName, req.HostID, req.Role, err)
 		log.Warn(msg)
 		return nil, trace.AccessDenied(msg)
 	}
 
-	// make sure the caller is requested wthe role allowed by the token
-	if !roles.Include(role) {
-		msg := fmt.Sprintf("node %q [%v] can not join the cluster, the token does not allow %q role", nodeName, hostID, role)
+	// make sure the caller is requested the role allowed by the token
+	if !roles.Include(req.Role) {
+		msg := fmt.Sprintf("node %q [%v] can not join the cluster, the token does not allow %q role", req.NodeName, req.HostID, req.Role)
 		log.Warn(msg)
 		return nil, trace.BadParameter(msg)
 	}
-	if !s.checkTokenTTL(token) {
-		return nil, trace.AccessDenied("node %q [%v] can not join the cluster, token has expired", nodeName, hostID)
+	if !s.checkTokenTTL(req.Token) {
+		return nil, trace.AccessDenied("node %q [%v] can not join the cluster, token has expired", req.NodeName, req.HostID)
 	}
 
 	// generate and return host certificate and keys
-	keys, err := s.GenerateServerKeys(hostID, nodeName, teleport.Roles{role})
+	keys, err := s.GenerateServerKeys(GenerateServerKeysRequest{
+		HostID:               req.HostID,
+		NodeName:             req.NodeName,
+		Roles:                teleport.Roles{req.Role},
+		AdditionalPrincipals: req.AdditionalPrincipals,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.Infof("Node %q [%v] has joined the cluster.", nodeName, hostID)
+	log.Infof("Node %q [%v] has joined the cluster.", req.NodeName, req.HostID)
 	return keys, nil
 }
 

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -216,7 +216,11 @@ func (a *TestAuthServer) NewCertificate(identity TestIdentity) (*tls.Certificate
 		}
 		return &cert, nil
 	case BuiltinRole:
-		keys, err := a.AuthServer.GenerateServerKeys(id.Username, id.Username, teleport.Roles{id.Role})
+		keys, err := a.AuthServer.GenerateServerKeys(GenerateServerKeysRequest{
+			HostID:   id.Username,
+			NodeName: id.Username,
+			Roles:    teleport.Roles{id.Role},
+		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -518,7 +522,11 @@ func (t *TestTLSServer) Stop() error {
 
 // NewServerIdentity generates new server identity, used in tests
 func NewServerIdentity(clt *AuthServer, hostID string, role teleport.Role) (*Identity, error) {
-	keys, err := clt.GenerateServerKeys(hostID, hostID, teleport.Roles{teleport.RoleAuth})
+	keys, err := clt.GenerateServerKeys(GenerateServerKeysRequest{
+		HostID:   hostID,
+		NodeName: hostID,
+		Roles:    teleport.Roles{teleport.RoleAuth},
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -56,6 +56,7 @@ func (n *Keygen) GenerateHostCert(c services.HostCertParams) ([]byte, error) {
 		validBefore = uint64(b.Unix())
 	}
 	principals := native.BuildPrincipals(c.HostID, c.NodeName, c.ClusterName, c.Roles)
+	principals = append(principals, c.Principals...)
 	cert := &ssh.Certificate{
 		ValidPrincipals: principals,
 		Key:             pubKey,

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -111,7 +111,11 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// set up host private key and certificate
-	certs, err := s.server.Auth().GenerateServerKeys(hostID, s.server.ClusterName(), teleport.Roles{teleport.RoleNode})
+	certs, err := s.server.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
+		HostID:   hostID,
+		NodeName: s.server.ClusterName(),
+		Roles:    teleport.Roles{teleport.RoleNode},
+	})
 	c.Assert(err, IsNil)
 
 	// set up user CA and set up a user that has access to the server

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -33,6 +33,19 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// StringsSet creates set of string (map[string]struct{})
+// from a list of strings
+func StringsSet(in []string) map[string]struct{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for _, v := range in {
+		out[v] = struct{}{}
+	}
+	return out
+}
+
 // ParseOnOff parses whether value is "on" or "off", parameterName is passed for error
 // reporting purposes, defaultValue is returned when no value is set
 func ParseOnOff(parameterName, val string, defaultValue bool) (bool, error) {
@@ -60,6 +73,18 @@ func IsGroupMember(gid int) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// Host extracts host from host:port string
+func Host(hostname string) (string, error) {
+	if hostname == "" {
+		return "", trace.BadParameter("missing parameter hostname")
+	}
+	if !strings.Contains(hostname, ":") {
+		return hostname, nil
+	}
+	host, _, err := SplitHostPort(hostname)
+	return host, err
 }
 
 // SplitHostPort splits host and port and checks that host is not empty

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -152,7 +152,11 @@ func (s *WebSuite) SetUpTest(c *C) {
 	nodePort := s.freePorts[len(s.freePorts)-1]
 	s.freePorts = s.freePorts[:len(s.freePorts)-1]
 
-	certs, err := s.server.Auth().GenerateServerKeys(hostID, s.server.ClusterName(), teleport.Roles{teleport.RoleNode})
+	certs, err := s.server.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
+		HostID:   hostID,
+		NodeName: s.server.ClusterName(),
+		Roles:    teleport.Roles{teleport.RoleNode},
+	})
 	c.Assert(err, IsNil)
 
 	signer, err := sshutils.NewSigner(certs.Key, certs.Cert)


### PR DESCRIPTION
Add support for extra principals for proxy.
Proxy section already supports public_addr
property that is used during tctl users add
output.

Use the value from this property to update
host SSH certificate for proxy service.

```yaml
proxy_service:
  public_addr: example.com:3024
```

With the configuration above, proxy host
certificate will contain example.com principal
in the SSH principals list.
  