### PR TITLE
Add anonymizer

### DIFF
--- a/lib/utils/anonymizer.go
+++ b/lib/utils/anonymizer.go
@@ -40,7 +40,7 @@ type hmacAnonymizer struct {
 // NewHMACAnonymizer returns a new HMAC-based anonymizer
 func NewHMACAnonymizer(key string) (*hmacAnonymizer, error) {
 	if strings.TrimSpace(key) == "" {
-		return nil, trace.BadParameter("hmac key must not be empty")
+		return nil, trace.BadParameter("HMAC key must not be empty")
 	}
 	return &hmacAnonymizer{
 		key: key,

--- a/lib/utils/anonymizer.go
+++ b/lib/utils/anonymizer.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// Anonymizer defines an interface for anonymizing data
+type Anonymizer interface {
+	// Anonymize returns anonymized string from the provided data
+	Anonymize(data []byte) string
+}
+
+// hmacAnonymizer implements anonymization using HMAC
+type hmacAnonymizer struct {
+	// key is the HMAC key
+	key string
+}
+
+// NewHMACAnonymizer returns a new HMAC-based anonymizer
+func NewHMACAnonymizer(key string) (*hmacAnonymizer, error) {
+	if strings.TrimSpace(key) == "" {
+		return nil, trace.BadParameter("hmac key must not be empty")
+	}
+	return &hmacAnonymizer{
+		key: key,
+	}, nil
+}
+
+// Anonymize anonymizes the provided data using HMAC
+func (a *hmacAnonymizer) Anonymize(data []byte) string {
+	h := hmac.New(sha256.New, []byte(a.key))
+	h.Write(data)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}

--- a/lib/utils/anonymizer_test.go
+++ b/lib/utils/anonymizer_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"github.com/gravitational/trace"
+	"gopkg.in/check.v1"
+)
+
+type AnonymizerSuite struct{}
+
+var _ = check.Suite(&AnonymizerSuite{})
+
+func (s *AnonymizerSuite) TestHMACAnonymizer(c *check.C) {
+	a, err := NewHMACAnonymizer(" ")
+	c.Assert(err, check.FitsTypeOf, trace.BadParameter(""))
+	c.Assert(a, check.IsNil)
+
+	a, err = NewHMACAnonymizer("key")
+	c.Assert(err, check.IsNil)
+	c.Assert(a, check.NotNil)
+
+	data := "secret"
+	result := a.Anonymize([]byte(data))
+	c.Assert(result, check.Not(check.Equals), "")
+	c.Assert(result, check.Not(check.Equals), data)
+}


### PR DESCRIPTION
This PR adds HMAC anonymizer helper, moved from Pro version. Right now it is not used in open-source version and exists only for transparency purposes for people who wish to see how Teleport Pro anonymizes metrics.
