### PR TITLE
Initial Terminal Size

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -336,7 +336,7 @@ func newSession(id rsession.ID, r *SessionRegistry, ctx *ServerContext) (*sessio
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		rsess.TerminalParams.W = int(winsize.Width - 1)
+		rsess.TerminalParams.W = int(winsize.Width)
 		rsess.TerminalParams.H = int(winsize.Height)
 	}
 	err := r.srv.GetSessionServer().CreateSession(rsess)

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -373,7 +373,7 @@ func (t *remoteTerminal) Run() error {
 		t.termType = defaultTerm
 	}
 
-	if err := t.session.RequestPty(t.termType, t.params.W, t.params.H, t.termModes); err != nil {
+	if err := t.session.RequestPty(t.termType, t.params.H, t.params.W, t.termModes); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1087, Teleport was not wrapping long lines correctly upon login. This PR changes the size of the TTY on the server so lines are wrapped correctly.

**Implementation**

Two different problems were causing the same incorrect behavior.

* For regular Teleport it was due to the width of the terminal being reduced by one.
* For the recording proxy it was due to the width and height being transposed.

**Related Issue**

Fixes https://github.com/gravitational/teleport/issues/1087