### PR TITLE
Filter out active sessions from GetSessions when using recording proxy.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1025,9 +1025,9 @@ func (a *AuthServer) syncCachedClusterConfigLoop() {
 	}
 }
 
-// getCachedClusterConfig returns a copy of cached services.ClusterConfig. If
+// GetCachedClusterConfig returns a copy of cached services.ClusterConfig. If
 // nothing is cached yet, a safe default is returned.
-func (a *AuthServer) getCachedClusterConfig() services.ClusterConfig {
+func (a *AuthServer) GetCachedClusterConfig() services.ClusterConfig {
 	a.cachedClusterConfigMu.RLock()
 	defer a.cachedClusterConfigMu.RUnlock()
 

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -98,7 +98,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	srv.SessionServer, err = session.New(srv.Backend)
+	srv.SessionServer, err = session.New(srv.Backend, services.DefaultClusterConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -151,7 +151,7 @@ func (a *AuthMiddleware) GetUser(r *http.Request) (interface{}, error) {
 	// therefore it is not allowed to reduce scope
 	if len(peers) == 0 {
 		return BuiltinRole{
-			GetClusterConfig: a.AuthServer.getCachedClusterConfig,
+			GetClusterConfig: a.AuthServer.GetCachedClusterConfig,
 			Role:             teleport.RoleNop,
 			Username:         string(teleport.RoleNop),
 		}, nil
@@ -204,7 +204,7 @@ func (a *AuthMiddleware) GetUser(r *http.Request) (interface{}, error) {
 	// agent, e.g. Proxy, connecting to the cluster
 	if systemRole != nil {
 		return BuiltinRole{
-			GetClusterConfig: a.AuthServer.getCachedClusterConfig,
+			GetClusterConfig: a.AuthServer.GetCachedClusterConfig,
 			Role:             *systemRole,
 			Username:         identity.Username,
 		}, nil

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -425,7 +425,7 @@ func (s *TLSSuite) TestSyncCachedClusterConfig(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// check to make sure the cached value is the same
-	clusterConfig = authServer.getCachedClusterConfig()
+	clusterConfig = authServer.GetCachedClusterConfig()
 	c.Assert(clusterConfig.GetSessionRecording(), check.Equals, services.RecordAtNode)
 
 	// update cluster config to record at proxy
@@ -438,7 +438,7 @@ func (s *TLSSuite) TestSyncCachedClusterConfig(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// check to make sure the cached value was updated
-	clusterConfig = authServer.getCachedClusterConfig()
+	clusterConfig = authServer.GetCachedClusterConfig()
 	c.Assert(clusterConfig.GetSessionRecording(), check.Equals, services.RecordAtProxy)
 }
 

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -371,7 +371,7 @@ func (s *AuthTunnel) onAPIConnection(sconn *ssh.ServerConn, sshChan ssh.Channel,
 			return
 		}
 		builtin := BuiltinRole{
-			GetClusterConfig: s.authServer.getCachedClusterConfig,
+			GetClusterConfig: s.authServer.GetCachedClusterConfig,
 			Role:             systemRole,
 			Username:         sconn.Permissions.Extensions[ExtHost],
 		}

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -79,7 +79,7 @@ func (s *TunSuite) SetUpTest(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	s.sessionServer, err = session.New(s.bk)
+	s.sessionServer, err = session.New(s.bk, services.DefaultClusterConfig)
 	c.Assert(err, IsNil)
 
 	access := local.NewAccessService(s.bk)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -456,7 +456,7 @@ func (process *TeleportProcess) initAuthService(authority sshca.Authority) error
 	// second, create the API Server: it's actually a collection of API servers,
 	// each serving requests for a "role" which is assigned to every connected
 	// client based on their certificate (user, server, admin, etc)
-	sessionService, err := session.New(b)
+	sessionService, err := session.New(b, authServer.GetCachedClusterConfig)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
**Purpose**

Even though the recording proxy does not support joining sessions, the `GetSessions` call on the Auth Server returns a list of active sessions. The Web UI then displays these as sessions the user can join. These sessions should not be displayed because they can not actually be joined.

**Implementation**

* `getCachedClusterConfig -> GetCachedClusterConfig` so it can be used outside the Auth Server.
* `GetSessions` on the Auth Server has been updated to check the value of the cached cluster configuration to see what mode the cluster is in. If it is the recording proxy, an empty list of sessions is returned because no sessions can be joined.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1421