### PR TITLE
Enforce trusted cluster resource name, fixes #1543

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -942,7 +942,7 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 	var upsertSuccess bool
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v", trustedCluster, i)
-		err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
+		_, err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
 		if err != nil {
 			if trace.IsConnectionProblem(err) {
 				log.Debugf("retrying on connection problem: %v", err)
@@ -1147,7 +1147,7 @@ func (s *IntSuite) trustedClusters(c *check.C, multiplex bool) {
 	var upsertSuccess bool
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v", trustedCluster, i)
-		err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
+		_, err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
 		if err != nil {
 			if trace.IsConnectionProblem(err) {
 				log.Debugf("retrying on connection problem: %v", err)
@@ -1215,7 +1215,7 @@ func (s *IntSuite) trustedClusters(c *check.C, multiplex bool) {
 	// this should re-establish connection
 	err = aux.Process.GetAuthServer().DeleteTrustedCluster(trustedCluster.GetName())
 	c.Assert(err, check.IsNil)
-	err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
+	_, err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
 	c.Assert(err, check.IsNil)
 
 	// check that remote cluster has been re-provisioned

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -440,12 +440,12 @@ func (s *APIServer) upsertTrustedCluster(auth ClientI, w http.ResponseWriter, r 
 		return nil, trace.Wrap(err)
 	}
 
-	err = auth.UpsertTrustedCluster(trustedCluster)
+	out, err := auth.UpsertTrustedCluster(trustedCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return message("ok"), nil
+	return rawMessage(services.GetTrustedClusterMarshaler().Marshal(out, services.WithVersion(version)))
 }
 
 func (s *APIServer) validateTrustedCluster(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -172,6 +172,13 @@ func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool) 
 	return a.authServer.GetCertAuthority(id, loadKeys)
 }
 
+func (a *AuthWithRoles) GetAnyCertAuthority(id services.CertAuthID) (services.CertAuthority, error) {
+	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbReadNoSecrets); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.authServer.GetAnyCertAuthority(id)
+}
+
 func (a *AuthWithRoles) GetDomainName() (string, error) {
 	// anyone can read it, no harm in that
 	return a.authServer.GetDomainName()
@@ -311,6 +318,13 @@ func (a *AuthWithRoles) UpsertReverseTunnel(r services.ReverseTunnel) error {
 		return trace.Wrap(err)
 	}
 	return a.authServer.UpsertReverseTunnel(r)
+}
+
+func (a *AuthWithRoles) GetReverseTunnel(name string) (services.ReverseTunnel, error) {
+	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.authServer.GetReverseTunnel(name)
 }
 
 func (a *AuthWithRoles) GetReverseTunnels() ([]services.ReverseTunnel, error) {
@@ -1033,12 +1047,12 @@ func (a *AuthWithRoles) GetTrustedCluster(name string) (services.TrustedCluster,
 	return a.authServer.GetTrustedCluster(name)
 }
 
-func (a *AuthWithRoles) UpsertTrustedCluster(tc services.TrustedCluster) error {
+func (a *AuthWithRoles) UpsertTrustedCluster(tc services.TrustedCluster) (services.TrustedCluster, error) {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbCreate); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbUpdate); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	return a.authServer.UpsertTrustedCluster(tc)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -379,6 +379,11 @@ func (c *Client) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool) 
 	return services.GetCertAuthorityMarshaler().UnmarshalCertAuthority(out.Bytes())
 }
 
+// GetAnyCertAuthority returns certificate authority by given id whether it's activated or not
+func (c *Client) GetAnyCertAuthority(id services.CertAuthID) (services.CertAuthority, error) {
+	return nil, trace.BadParameter("not implemented")
+}
+
 // DeleteCertAuthority deletes cert authority by ID
 func (c *Client) DeleteCertAuthority(id services.CertAuthID) error {
 	if err := id.Check(); err != nil {
@@ -550,6 +555,11 @@ func (c *Client) UpsertReverseTunnel(tunnel services.ReverseTunnel) error {
 	}
 	_, err = c.PostJSON(c.Endpoint("reversetunnels"), args)
 	return trace.Wrap(err)
+}
+
+// GetReverseTunnel returns reverse tunnel by name
+func (c *Client) GetReverseTunnel(name string) (services.ReverseTunnel, error) {
+	return nil, trace.BadParameter("not implemented")
 }
 
 // GetReverseTunnels returns the list of created reverse tunnels
@@ -2028,20 +2038,18 @@ func (c *Client) GetTrustedClusters() ([]services.TrustedCluster, error) {
 	return trustedClusters, nil
 }
 
-func (c *Client) UpsertTrustedCluster(trustedCluster services.TrustedCluster) error {
+func (c *Client) UpsertTrustedCluster(trustedCluster services.TrustedCluster) (services.TrustedCluster, error) {
 	trustedClusterBytes, err := services.GetTrustedClusterMarshaler().Marshal(trustedCluster)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-
-	_, err = c.PostJSON(c.Endpoint("trustedclusters"), &upsertTrustedClusterReq{
+	out, err := c.PostJSON(c.Endpoint("trustedclusters"), &upsertTrustedClusterReq{
 		TrustedCluster: trustedClusterBytes,
 	})
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-
-	return nil
+	return services.GetTrustedClusterMarshaler().Unmarshal(out.Bytes())
 }
 
 func (c *Client) ValidateTrustedCluster(validateRequest *ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error) {
@@ -2255,7 +2263,11 @@ type ClientI interface {
 	session.Service
 	services.ClusterConfiguration
 
+	// ValidateTrustedCluster validates trusted cluster token with
+	// main cluster, in case if validation is successfull, main cluster
+	// adds remote cluster
 	ValidateTrustedCluster(*ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error)
+
 	GetDomainName() (string, error)
 	// GenerateServerKeys generates new host private keys and certificates (signed
 	// by the host certificate authority) for a node

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -35,20 +35,28 @@ import (
 )
 
 // UpsertTrustedCluster creates or toggles a Trusted Cluster relationship.
-func (a *AuthServer) UpsertTrustedCluster(trustedCluster services.TrustedCluster) error {
+func (a *AuthServer) UpsertTrustedCluster(trustedCluster services.TrustedCluster) (services.TrustedCluster, error) {
 	var exists bool
-	existingCluster, err := a.Presence.GetTrustedCluster(trustedCluster.GetName())
-	if err == nil {
-		exists = true
+
+	// it is recommended to omit trusted cluster name, because
+	// it will be always set to the cluster name as set by the cluster
+	var existingCluster services.TrustedCluster
+	var err error
+	if trustedCluster.GetName() != "" {
+		existingCluster, err = a.Presence.GetTrustedCluster(trustedCluster.GetName())
+		if err == nil {
+			exists = true
+		}
 	}
+
 	enable := trustedCluster.GetEnabled()
 
 	// if the trusted cluster already exists in the backend, make sure it's a
-	// valid state change we are trying to make
+	// valid state change client is trying to make
 	if exists == true {
 		err := existingCluster.CanChangeStateTo(trustedCluster)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 
@@ -60,14 +68,14 @@ func (a *AuthServer) UpsertTrustedCluster(trustedCluster services.TrustedCluster
 		err := a.activateCertAuthority(trustedCluster)
 		if err != nil {
 			if trace.IsNotFound(err) {
-				return trace.BadParameter("enable only supported for Trusted Clusters created with Teleport 2.3 and above")
+				return nil, trace.BadParameter("enable only supported for Trusted Clusters created with Teleport 2.3 and above")
 			}
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 
 		err = a.createReverseTunnel(trustedCluster)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	case exists == true && enable == false:
 		log.Debugf("Disabling existing Trusted Cluster relationship.")
@@ -75,58 +83,82 @@ func (a *AuthServer) UpsertTrustedCluster(trustedCluster services.TrustedCluster
 		err := a.deactivateCertAuthority(trustedCluster)
 		if err != nil {
 			if trace.IsNotFound(err) {
-				return trace.BadParameter("enable only supported for Trusted Clusters created with Teleport 2.3 and above")
+				return nil, trace.BadParameter("enable only supported for Trusted Clusters created with Teleport 2.3 and above")
 			}
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 
 		err = a.DeleteReverseTunnel(trustedCluster.GetName())
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	case exists == false && enable == true:
 		log.Debugf("Creating enabled Trusted Cluster relationship.")
 
+		if err := a.checkLocalRoles(trustedCluster.GetRoleMap()); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
 		remoteCAs, err := a.establishTrust(trustedCluster)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
+
+		// force name of the trusted cluster resource
+		// to be equal to the name of the remote cluster it is connecting to
+		trustedCluster.SetName(remoteCAs[0].GetClusterName())
 
 		err = a.addCertAuthorities(trustedCluster, remoteCAs)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 
 		err = a.createReverseTunnel(trustedCluster)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
+
 	case exists == false && enable == false:
 		log.Debugf("Creating disabled Trusted Cluster relationship.")
 
+		if err := a.checkLocalRoles(trustedCluster.GetRoleMap()); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
 		remoteCAs, err := a.establishTrust(trustedCluster)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
+
+		// force name to the name of the trusted cluster
+		trustedCluster.SetName(remoteCAs[0].GetClusterName())
 
 		err = a.addCertAuthorities(trustedCluster, remoteCAs)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 
 		err = a.deactivateCertAuthority(trustedCluster)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
+	return a.Presence.UpsertTrustedCluster(trustedCluster)
+}
 
-	err = a.Presence.UpsertTrustedCluster(trustedCluster)
-	if err != nil {
-		return trace.Wrap(err)
+func (a *AuthServer) checkLocalRoles(roleMap services.RoleMap) error {
+	for _, mapping := range roleMap {
+		for _, localRole := range mapping.Local {
+			_, err := a.GetRole(localRole)
+			if err != nil {
+				if trace.IsNotFound(err) {
+					return trace.NotFound("a role %q referenced in a mapping %v:%v is not defined", localRole, mapping.Remote, mapping.Local)
+				}
+				return trace.Wrap(err)
+			}
+		}
 	}
-
 	return nil
-
 }
 
 // DeleteTrustedCluster removes services.CertAuthority, services.ReverseTunnel,

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -88,9 +88,9 @@ func (s *PresenceSuite) TestTrustedClusterCRUD(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// create trusted clusters
-	err = presenceBackend.UpsertTrustedCluster(tc)
+	_, err = presenceBackend.UpsertTrustedCluster(tc)
 	c.Assert(err, check.IsNil)
-	err = presenceBackend.UpsertTrustedCluster(stc)
+	_, err = presenceBackend.UpsertTrustedCluster(stc)
 	c.Assert(err, check.IsNil)
 
 	// get trusted cluster make sure it's correct

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -60,6 +60,9 @@ type Presence interface {
 	// UpsertReverseTunnel upserts reverse tunnel entry temporarily or permanently
 	UpsertReverseTunnel(tunnel ReverseTunnel) error
 
+	// GetReverseTunnel returns reverse tunnel by name
+	GetReverseTunnel(name string) (ReverseTunnel, error)
+
 	// GetReverseTunnels returns a list of registered servers
 	GetReverseTunnels() ([]ReverseTunnel, error)
 
@@ -85,7 +88,7 @@ type Presence interface {
 	DeleteNamespace(name string) error
 
 	// UpsertTrustedCluster creates or updates a TrustedCluster in the backend.
-	UpsertTrustedCluster(TrustedCluster) error
+	UpsertTrustedCluster(TrustedCluster) (TrustedCluster, error)
 
 	// GetTrustedCluster returns a single TrustedCluster by name.
 	GetTrustedCluster(string) (TrustedCluster, error)

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -49,6 +49,12 @@ type Trust interface {
 	// controls if signing keys are loaded
 	GetCertAuthority(id CertAuthID, loadSigningKeys bool) (CertAuthority, error)
 
+	// DELETE IN: 2.6.0
+	// GetAnyCertAuthority returns activated or deactivated certificate authority
+	// by given id whether it is activated or not. Signing keys are never loaded.
+	// This method is used in migrations.
+	GetAnyCertAuthority(id CertAuthID) (ca CertAuthority, error error)
+
 	// GetCertAuthorities returns a list of authorities of a given type
 	// loadSigningKeys controls whether signing keys should be loaded or not
 	GetCertAuthorities(caType CertAuthType, loadSigningKeys bool) ([]CertAuthority, error)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -189,10 +189,15 @@ func (u *ResourceCommand) createTrustedCluster(client auth.ClientI, raw services
 	if u.force == false && exists {
 		return trace.AlreadyExists("trusted cluster '%s' already exists", name)
 	}
-	if err := client.UpsertTrustedCluster(tc); err != nil {
+
+	out, err := client.UpsertTrustedCluster(tc)
+	if err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Printf("trusted cluster '%s' has been %s\n", name, UpsertVerb(exists))
+	if out.GetName() != tc.GetName() {
+		fmt.Printf("WARNING: trusted cluster %q resource has been renamed to match remote cluster name %q\n", name, out.GetName())
+	}
+	fmt.Printf("trusted cluster %q has been %v\n", out.GetName(), UpsertVerb(exists))
 	return nil
 }
 


### PR DESCRIPTION
This commit makes sure that trusted cluster resource
name is the same name as the cluster name it conects to.

If user supplies name of the trusted cluster resource
that is different from the cluster name, the warning
will be issued and trusted cluster will be renamed.

Upgrade procedure renames existing trusted clusters
in place.

If user supplies trusted cluster without role
mappings, or with role mappings referring to
non-existent roles that do not exist, the
error will be returned.