### PR TITLE
In-memory forwarding servers now have a random server_id.

### DIFF
--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -175,7 +175,6 @@ func (s *localSite) dialWithAgent(from net.Addr, to net.Addr, userAgent agent.Ag
 	// don't need to close this server it will close and release all resources
 	// once conn is closed.
 	serverConfig := forward.ServerConfig{
-		ID:              s.srv.Config.ID,
 		AuthClient:      s.client,
 		UserAgent:       userAgent,
 		TargetConn:      targetConn,

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -556,7 +556,6 @@ func (s *remoteSite) dialWithAgent(from, to net.Addr, userAgent agent.Agent) (ne
 	// sure that the session gets recorded in the local cluster instead of the
 	// remote cluster.
 	serverConfig := forward.ServerConfig{
-		ID:              s.srv.Config.ID,
 		AuthClient:      s.localClient,
 		UserAgent:       userAgent,
 		TargetConn:      targetConn,

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils/proxy"
 	"github.com/gravitational/trace"
 
+	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -105,7 +106,6 @@ type Server struct {
 
 // ServerConfig is the configuration needed to create an instance of a Server.
 type ServerConfig struct {
-	ID              string
 	AuthClient      auth.ClientI
 	UserAgent       agent.Agent
 	TargetConn      net.Conn
@@ -128,9 +128,6 @@ type ServerConfig struct {
 
 // CheckDefaults makes sure all required parameters are passed in.
 func (s *ServerConfig) CheckDefaults() error {
-	if s.ID == "" {
-		return trace.BadParameter("server ID is required")
-	}
 	if s.AuthClient == nil {
 		return trace.BadParameter("auth client required")
 	}
@@ -177,7 +174,7 @@ func New(c ServerConfig) (*Server, error) {
 				"dst-addr": c.DstAddr.String(),
 			},
 		}),
-		id:              c.ID,
+		id:              uuid.New(),
 		targetConn:      c.TargetConn,
 		serverConn:      serverConn,
 		clientConn:      clientConn,


### PR DESCRIPTION
**Purpose**

Currently when a forwarding server is created, it creates itself with the ID of the proxy. Due to this, when attempting to join a session using the forwarding proxy, users would be dropped into the proxy itself. Teleport would look where to connect to, would find the server ID of the proxy, and connect to it.

To fix this, we generate random server IDs for in-memory forwarding servers. The random ID can't be found in the Teleport list of nodes and doesn't resolve to anything, so Teleport does not connect to it successfully.

**Implementation**

* Instead of setting the server ID to be the ID of the proxy, create a random server ID. This way when attempting to join, this node will not be found in the Teleport list of nodes and DNS lookups will fail leading to not being able to connect to a session.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1421

