### PR TITLE
Use gzip for session recordings, fixes #1579

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -289,16 +289,16 @@ func (s *IntSuite) TestAuditOn(c *check.C) {
 		// read back the entire session (we have to try several times until we get back
 		// everything because the session is closing)
 		var sessionStream []byte
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 6; i++ {
 			sessionStream, err = site.GetSessionChunk(defaults.Namespace, session.ID, 0, events.MaxChunkBytes)
 			c.Assert(err, check.IsNil)
 			if strings.Contains(string(sessionStream), "exit") {
 				break
 			}
 			time.Sleep(time.Millisecond * 250)
-			if i > 10 {
+			if i >= 5 {
 				// session stream keeps coming back short
-				c.Fatal("stream is not getting data")
+				c.Fatal("stream is not getting data: %q", string(sessionStream))
 			}
 		}
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -165,6 +165,9 @@ const (
 	// amount of simultaneously processes concurrent sessions by the
 	// Audit log server, and 16K is OK for now
 	AuditLogSessions = 16384
+
+	// PlaybackRecycleTTL is the TTL for unpacked session playback files
+	PlaybackRecycleTTL = 3 * time.Hour
 )
 
 var (

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -19,6 +19,7 @@ package events
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -52,13 +53,6 @@ const (
 
 	// LogfileExt defines the ending of the daily event log file
 	LogfileExt = ".log"
-
-	// SessionLogPrefix defines the endof of session log files
-	SessionLogPrefix = ".session.log"
-
-	// SessionStreamPrefix defines the ending of session stream files,
-	// that's where interactive PTY I/O is saved.
-	SessionStreamPrefix = ".session.bytes"
 )
 
 var (
@@ -81,6 +75,9 @@ type AuditLog struct {
 	sync.Mutex
 	*log.Entry
 	AuditLogConfig
+
+	// playbackDir is a directory used for unpacked session recordings
+	playbackDir string
 
 	loggers *ttlmap.TTLMap
 
@@ -125,6 +122,10 @@ type AuditLogConfig struct {
 	// DirMask if provided will be used to set directory mask access
 	// otherwise set to default value
 	DirMask *os.FileMode
+
+	// PlaybackRecycleTTL is a time after uncompressed playback files will be
+	// deleted
+	PlaybackRecycleTTL time.Duration
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -151,6 +152,9 @@ func (a *AuditLogConfig) CheckAndSetDefaults() error {
 	if (a.GID != nil && a.UID == nil) || (a.UID != nil && a.GID == nil) {
 		return trace.BadParameter("if UID or GID is set, both should be specified")
 	}
+	if a.PlaybackRecycleTTL == 0 {
+		a.PlaybackRecycleTTL = defaults.PlaybackRecycleTTL
+	}
 	return nil
 }
 
@@ -161,15 +165,15 @@ func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	al := &AuditLog{
+		playbackDir:    filepath.Join(cfg.DataDir, "playbacks"),
 		AuditLogConfig: cfg,
 		Entry: log.WithFields(log.Fields{
 			trace.Component: teleport.ComponentAuditLog,
 		}),
 	}
 	loggers, err := ttlmap.New(defaults.AuditLogSessions,
-		ttlmap.CallOnExpire(al.asyncCloseSessionLogger), ttlmap.Clock(cfg.Clock))
+		ttlmap.CallOnExpire(al.closeSessionLogger), ttlmap.Clock(cfg.Clock))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -189,6 +193,10 @@ func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 	if err := os.MkdirAll(sessionDir, *cfg.DirMask); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
+	// create a directory for uncompressed playbacks
+	if err := os.MkdirAll(al.playbackDir, *cfg.DirMask); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
 	if cfg.UID != nil && cfg.GID != nil {
 		err := os.Chown(cfg.DataDir, *cfg.UID, *cfg.GID)
 		if err != nil {
@@ -198,9 +206,13 @@ func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 		if err != nil {
 			return nil, trace.ConvertSystemError(err)
 		}
+		err = os.Chown(al.playbackDir, *cfg.UID, *cfg.GID)
+		if err != nil {
+			return nil, trace.ConvertSystemError(err)
+		}
 	}
-
 	go al.periodicCloseInactiveLoggers()
+	go al.periodicCleanupPlaybacks()
 	return al, nil
 }
 
@@ -221,13 +233,7 @@ func (l *AuditLog) PostSessionSlice(slice SessionSlice) error {
 		l.Errorf("failed to get logger: %v", trace.DebugReport(err))
 		return trace.BadParameter("audit.log: no session writer for %s", slice.SessionID)
 	}
-	for i := range slice.Chunks {
-		_, err := sl.WriteChunk(slice.Chunks[i])
-		if err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	return nil
+	return sl.PostSessionSlice(slice)
 }
 
 // DELETE IN: 2.6.0
@@ -389,6 +395,98 @@ func (l *AuditLog) GetSessionChunk(namespace string, sid session.ID, offsetBytes
 	}
 }
 
+func (l *AuditLog) cleanupOldPlaybacks() error {
+	// scan the log directory and clean files last
+	// accessed after an hour
+	df, err := os.Open(l.playbackDir)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	defer df.Close()
+	entries, err := df.Readdir(-1)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	for i := range entries {
+		fi := entries[i]
+		if fi.IsDir() {
+			continue
+		}
+		fd := fi.ModTime().UTC()
+		diff := l.Clock.Now().UTC().Sub(fd)
+		if diff <= l.PlaybackRecycleTTL {
+			continue
+		}
+		fileToRemove := filepath.Join(l.playbackDir, fi.Name())
+		err := os.Remove(fileToRemove)
+		if err != nil {
+			l.Warningf("Failed to remove file %v: %v.", fileToRemove, err)
+		}
+		l.Debugf("Removed unpacked session playback file %v after %v.", fileToRemove, diff)
+	}
+	return nil
+}
+
+type readSeekCloser interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+}
+
+func (l *AuditLog) unpackFile(fileName string) (readSeekCloser, error) {
+	unpackedFile := filepath.Join(l.playbackDir, filepath.Base(fileName))
+
+	// If client has called GetSessionChunk before session is over
+	// this could lead to cases when not all data will be returned,
+	// because unpackFile will be called concurrently with the unfinished write
+	unpackedInfo, err := os.Stat(unpackedFile)
+	err = trace.ConvertSystemError(err)
+	switch {
+	case err != nil && !trace.IsNotFound(err):
+		return nil, trace.Wrap(err)
+	case err == nil:
+		packedInfo, err := os.Stat(fileName)
+		if err != nil {
+			return nil, trace.ConvertSystemError(err)
+		}
+		// no new data has been added
+		if unpackedInfo.ModTime().After(packedInfo.ModTime()) {
+			return os.OpenFile(unpackedFile, os.O_RDONLY, 0640)
+		}
+	}
+
+	start := l.Clock.Now()
+	dest, err := os.OpenFile(unpackedFile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	source, err := os.OpenFile(fileName, os.O_RDONLY, 0640)
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	defer source.Close()
+	reader, err := gzip.NewReader(source)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer reader.Close()
+	if _, err := io.Copy(dest, reader); err != nil {
+		// Unexpected EOF is returned by gzip reader
+		// when the file has not been closed yet,
+		// ignore this error
+		if err != io.ErrUnexpectedEOF {
+			dest.Close()
+			return nil, trace.Wrap(err)
+		}
+	}
+	if _, err := dest.Seek(0, 0); err != nil {
+		dest.Close()
+		return nil, trace.Wrap(err)
+	}
+	l.Debugf("Uncompressed %v into %v in %v", fileName, unpackedFile, l.Clock.Now().Sub(start))
+	return dest, nil
+}
+
 func (l *AuditLog) getSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
 	if namespace == "" {
 		return nil, trace.BadParameter("missing parameter namespace")
@@ -401,20 +499,19 @@ func (l *AuditLog) getSessionChunk(namespace string, sid session.ID, offsetBytes
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	fstream, err := os.OpenFile(fileName, os.O_RDONLY, 0640)
+	reader, err := l.unpackFile(fileName)
 	if err != nil {
-		log.Warning(err)
 		return nil, trace.Wrap(err)
 	}
-	defer fstream.Close()
+	defer reader.Close()
 
 	// seek to 'offset' from the beginning
-	fstream.Seek(int64(offsetBytes)-fileOffset, 0)
+	reader.Seek(int64(offsetBytes)-fileOffset, 0)
 
 	// copy up to maxBytes from the offset position:
 	var buff bytes.Buffer
-	io.Copy(&buff, io.LimitReader(fstream, int64(maxBytes)))
-	return buff.Bytes(), nil
+	_, err = io.Copy(&buff, io.LimitReader(reader, int64(maxBytes)))
+	return buff.Bytes(), err
 }
 
 // Returns all events that happen during a session sorted by time
@@ -461,11 +558,15 @@ func (l *AuditLog) fetchSessionEvents(fileName string, afterN int) ([]EventField
 		return nil, trace.Wrap(err)
 	}
 	defer logFile.Close()
+	reader, err := gzip.NewReader(logFile)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer reader.Close()
 
 	retval := make([]EventFields, 0, 256)
-
 	// read line by line:
-	scanner := bufio.NewScanner(logFile)
+	scanner := bufio.NewScanner(reader)
 	for lineNo := 0; scanner.Scan(); lineNo++ {
 		if lineNo < afterN {
 			continue
@@ -633,16 +734,16 @@ func (l *AuditLog) migrateSessionsDir() error {
 		}
 		sessionID := parts[0]
 		sourceEventsFile := filepath.Join(recordingsDir, fmt.Sprintf("%v.session.log", sessionID))
-		targetEventsFile := filepath.Join(recordingsDir, fmt.Sprintf("%v-0.events", sessionID))
-		l.Debugf("Migrating, session ID %v. Renamed %v to %v", sessionID, sourceEventsFile, targetEventsFile)
-		err := os.Rename(sourceEventsFile, targetEventsFile)
+		targetEventsFile := filepath.Join(recordingsDir, fmt.Sprintf("%v-0.events.gz", sessionID))
+		l.Debugf("Migrating, session ID %v. Compressed %v to %v", sessionID, sourceEventsFile, targetEventsFile)
+		err := moveAndGzipFile(sourceEventsFile, targetEventsFile)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		sourceChunksFile := filepath.Join(recordingsDir, fmt.Sprintf("%v.session.bytes", sessionID))
-		targetChunksFile := filepath.Join(recordingsDir, fmt.Sprintf("%v-0.chunks", sessionID))
-		l.Debugf("Migrating session ID %v. Renamed %v to %v", sessionID, sourceChunksFile, targetChunksFile)
-		err = os.Rename(sourceChunksFile, targetChunksFile)
+		targetChunksFile := filepath.Join(recordingsDir, fmt.Sprintf("%v-0.chunks.gz", sessionID))
+		l.Debugf("Migrating session ID %v. Compressed %v to %v", sessionID, sourceChunksFile, targetChunksFile)
+		err = moveAndGzipFile(sourceChunksFile, targetChunksFile)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -677,11 +778,33 @@ func (l *AuditLog) migrateSessionsDir() error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		l.Debugf("Migrating session ID %v. Wrote index file %v.", indexFileName)
+		l.Debugf("Migrating session ID %v. Wrote index file %v.", sessionID, indexFileName)
 	}
 	l.Infof("Moving sessions folder from %v to %v", sessionDir, targetDir)
 	if err := os.Rename(sessionDir, targetDir); err != nil {
 		return trace.ConvertSystemError(err)
+	}
+	return nil
+}
+
+func moveAndGzipFile(source string, target string) error {
+	sourceFile, err := os.Open(source)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	defer sourceFile.Close()
+	destFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	destWriter := newGzipWriter(destFile)
+	defer destWriter.Close()
+	_, err = io.Copy(destWriter, sourceFile)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := os.Remove(source); err != nil {
+		return trace.Wrap(err)
 	}
 	return nil
 }
@@ -868,6 +991,7 @@ func (l *AuditLog) rotateLog() (err error) {
 func (l *AuditLog) Close() error {
 	l.Lock()
 	defer l.Unlock()
+
 	if l.file != nil {
 		l.file.Close()
 		l.file = nil
@@ -950,10 +1074,6 @@ func (l *AuditLog) LoggerFor(namespace string, sid session.ID, compatibilityMode
 
 }
 
-func (l *AuditLog) asyncCloseSessionLogger(key string, val interface{}) {
-	go l.closeSessionLogger(key, val)
-}
-
 func (l *AuditLog) closeSessionLogger(key string, val interface{}) {
 	l.Debugf("Closing session logger %v.", key)
 	logger, ok := val.(SessionLogger)
@@ -974,6 +1094,20 @@ func (l *AuditLog) periodicCloseInactiveLoggers() {
 		select {
 		case <-ticker.C:
 			l.closeInactiveLoggers()
+		}
+	}
+}
+
+func (l *AuditLog) periodicCleanupPlaybacks() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := l.cleanupOldPlaybacks(); err != nil {
+				l.Warningf("Error while cleaning up playback files: %v.", err)
+			}
 		}
 	}
 }

--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -17,8 +17,10 @@ limitations under the License.
 package events
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -31,7 +33,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// SessionLogger is an interface that all session loggers must implement.
+// sessionLogger is an interface that all session loggers must implement.
 type SessionLogger interface {
 	// LogEvent logs events associated with this session.
 	LogEvent(fields EventFields) error
@@ -45,10 +47,8 @@ type SessionLogger interface {
 	// releasing audit resources associated with the session
 	Finalize() error
 
-	// WriteChunk takes a stream of bytes (usually the output from a session
-	// terminal) and writes it into a "stream file", for future replay of
-	// interactive sessions.
-	WriteChunk(chunk *SessionChunk) (written int, err error)
+	// PostSessionSlice posts session slice
+	PostSessionSlice(slice SessionSlice) error
 }
 
 // DiskSessionLoggerConfig sets up parameters for disk session logger
@@ -103,26 +103,22 @@ type DiskSessionLogger struct {
 	sid session.ID
 
 	indexFile  *os.File
-	eventsFile *os.File
-	chunksFile *os.File
+	eventsFile *gzipWriter
+	chunksFile *gzipWriter
 
 	lastEventIndex int64
 	lastChunkIndex int64
-
-	// recordSessions controls if sessions are recorded along with audit events.
-	recordSessions bool
 }
 
 // LogEvent logs an event associated with this session
 func (sl *DiskSessionLogger) LogEvent(fields EventFields) error {
-	panic("does  not work")
+	panic("should not be used")
 }
 
 // Close is called when clients close on the requested "session writer".
 // We ignore their requests because this writer (file) should be closed only
 // when the session logger is closed
 func (sl *DiskSessionLogger) Close() error {
-	sl.Debugf("Close")
 	return nil
 }
 
@@ -135,7 +131,22 @@ func (sl *DiskSessionLogger) Finalize() error {
 	return sl.finalize()
 }
 
+// flush is used to flush gzip frames to file, otherwise
+// some attempts to read the file could fail
+func (sl *DiskSessionLogger) flush() error {
+	var err, err2 error
+
+	if sl.RecordSessions && sl.chunksFile != nil {
+		err = sl.chunksFile.Flush()
+	}
+	if sl.eventsFile != nil {
+		err2 = sl.eventsFile.Flush()
+	}
+	return trace.NewAggregate(err, err2)
+}
+
 func (sl *DiskSessionLogger) finalize() error {
+
 	auditOpenFiles.Dec()
 
 	if sl.indexFile != nil {
@@ -155,12 +166,12 @@ func (sl *DiskSessionLogger) finalize() error {
 
 // eventsFileName consists of session id and the first global event index recorded there
 func eventsFileName(dataDir string, sessionID session.ID, eventIndex int64) string {
-	return filepath.Join(dataDir, fmt.Sprintf("%v-%v.events", sessionID.String(), eventIndex))
+	return filepath.Join(dataDir, fmt.Sprintf("%v-%v.events.gz", sessionID.String(), eventIndex))
 }
 
 // chunksFileName consists of session id and the first global offset recorded
 func chunksFileName(dataDir string, sessionID session.ID, offset int64) string {
-	return filepath.Join(dataDir, fmt.Sprintf("%v-%v.chunks", sessionID.String(), offset))
+	return filepath.Join(dataDir, fmt.Sprintf("%v-%v.chunks.gz", sessionID.String(), offset))
 }
 
 func (sl *DiskSessionLogger) openEventsFile(eventIndex int64) error {
@@ -172,7 +183,7 @@ func (sl *DiskSessionLogger) openEventsFile(eventIndex int64) error {
 	}
 	eventsFileName := eventsFileName(sl.DataDir, sl.SessionID, eventIndex)
 
-	// udpate the index file to write down that new events file has been created
+	// update the index file to write down that new events file has been created
 	data, err := json.Marshal(indexEntry{
 		FileName: filepath.Base(eventsFileName),
 		Type:     fileTypeEvents,
@@ -188,10 +199,11 @@ func (sl *DiskSessionLogger) openEventsFile(eventIndex int64) error {
 	}
 
 	// open new events file for writing
-	sl.eventsFile, err = os.OpenFile(eventsFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+	file, err := os.OpenFile(eventsFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	sl.eventsFile = newGzipWriter(file)
 	return nil
 }
 
@@ -220,18 +232,33 @@ func (sl *DiskSessionLogger) openChunksFile(offset int64) error {
 	}
 
 	// open new chunks file for writing
-	sl.chunksFile, err = os.OpenFile(chunksFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+	file, err := os.OpenFile(chunksFileName, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	sl.chunksFile = newGzipWriter(file)
 	return nil
 }
 
-// WriteChunk takes a stream of bytes (usually the output from a session terminal)
-// and writes it into a "stream file", for future replay of interactive sessions.
-func (sl *DiskSessionLogger) WriteChunk(chunk *SessionChunk) (written int, err error) {
+// PostSessionSlice takes series of events associated with the session
+// and writes them to events files and data file for future replays
+func (sl *DiskSessionLogger) PostSessionSlice(slice SessionSlice) error {
 	sl.Lock()
 	defer sl.Unlock()
+
+	for i := range slice.Chunks {
+		if slice.Chunks[i].EventType == SessionEndEvent {
+			defer sl.closeLogger()
+		}
+		_, err := sl.writeChunk(slice.Chunks[i])
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return sl.flush()
+}
+
+func (sl *DiskSessionLogger) writeChunk(chunk *SessionChunk) (written int, err error) {
 
 	// this section enforces the following invariant:
 	// a single events file only contains successive events
@@ -243,9 +270,6 @@ func (sl *DiskSessionLogger) WriteChunk(chunk *SessionChunk) (written int, err e
 	sl.lastEventIndex = chunk.EventIndex
 
 	if chunk.EventType != SessionPrintEvent {
-		if chunk.EventType == SessionEndEvent {
-			defer sl.closeLogger()
-		}
 		var fields EventFields
 		err := json.Unmarshal(chunk.Data, &fields)
 		if err != nil {
@@ -338,4 +362,51 @@ type printEvent struct {
 	EventIndex int64 `json:"ei"`
 	// ChunkIndex is the global chunk index
 	ChunkIndex int64 `json:"ci"`
+}
+
+// gzipWriter wraps file, on close close both gzip writer and file
+type gzipWriter struct {
+	*gzip.Writer
+	file *os.File
+}
+
+// Close closes gzip writer and file
+func (f *gzipWriter) Close() error {
+	var errors []error
+	errors = append(errors, f.Writer.Close())
+	errors = append(errors, f.file.Close())
+	return trace.NewAggregate(errors...)
+}
+
+func newGzipWriter(file *os.File) *gzipWriter {
+	w := gzip.NewWriter(file)
+	return &gzipWriter{
+		Writer: w,
+		file:   file,
+	}
+}
+
+// gzipReader wraps file, on close close both gzip writer and file
+type gzipReader struct {
+	io.ReadCloser
+	file io.Closer
+}
+
+// Close closes file and gzip writer
+func (f *gzipReader) Close() error {
+	var errors []error
+	errors = append(errors, f.ReadCloser.Close())
+	errors = append(errors, f.file.Close())
+	return trace.NewAggregate(errors...)
+}
+
+func newGzipReader(file *os.File) (*gzipReader, error) {
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &gzipReader{
+		ReadCloser: reader,
+		file:       file,
+	}, nil
 }

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -418,9 +418,13 @@ func (a *Agent) proxyTransport(ch ssh.Channel, reqC <-chan *ssh.Request) {
 		return
 	}
 
+	if conn == nil {
+		a.Warningf("No error, but conn is nil: %v", conn)
+	}
+
 	// successfully dialed
 	req.Reply(true, []byte("connected"))
-	a.Debugf("successfully dialed to %v, start proxying", server)
+	a.Debugf("Successfully dialed to %v, start proxying.", server)
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)


### PR DESCRIPTION
* Session recordings are created with gzip compression.
* Migration compresses old recordings and converts to new format.