### PR TITLE
Logout from everywhere

### DIFF
--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -324,6 +324,16 @@ func (a *LocalKeyAgent) DeleteKey(proxyHost string, username string) error {
 	return nil
 }
 
+// ClearAllKeys Simply clears the keydir loggingout the user from all the sessions.
+func (a *LocalKeyAgent) ClearAllKeys() error {
+	// remove key from key store
+	err := a.keyStore.Cleanup()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 // AuthMethods returns the list of different authentication methods this agent supports
 // It returns two:
 //	  1. First to try is the external SSH agent

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -393,17 +393,16 @@ func (fs *FSLocalKeyStore) dirFor(hostname string) (string, error) {
 	return dirPath, nil
 }
 
-// CleanupAll
+// Cleanup cleans KeyDir
 func (fs *FSLocalKeyStore) Cleanup() error {
 
 	var err error
 
-	//Empty the content of keyDir and recreate it
 	if err = os.RemoveAll(fs.KeyDir); err != nil {
 		log.Error(err)
 		return err
 	}
-	//Now recreate initalize it
+
 	fs.KeyDir, err = initKeysDir(fs.KeyDir)
 
 	return err

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -77,6 +77,9 @@ type LocalKeyStore interface {
 	SaveCerts(proxy string, cas []auth.TrustedCerts) error
 	// GetCerts gets trusted TLS certificates of certificate authorities
 	GetCerts(proxy string) (*x509.CertPool, error)
+
+	//Cleanup the local store completely
+	Cleanup() error
 }
 
 // FSLocalKeyStore implements LocalKeyStore interface using the filesystem
@@ -388,6 +391,22 @@ func (fs *FSLocalKeyStore) dirFor(hostname string) (string, error) {
 		return "", trace.Wrap(err)
 	}
 	return dirPath, nil
+}
+
+// CleanupAll
+func (fs *FSLocalKeyStore) Cleanup() error {
+
+	var err error
+
+	//Empty the content of keyDir and recreate it
+	if err = os.RemoveAll(fs.KeyDir); err != nil {
+		log.Error(err)
+		return err
+	}
+	//Now recreate initalize it
+	fs.KeyDir, err = initKeysDir(fs.KeyDir)
+
+	return err
 }
 
 // initKeysDir initializes the keystore root directory. Usually it is ~/.tsh

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -126,6 +126,7 @@ func (cp *ClientProfile) SaveTo(filePath string, opts ProfileOptions) error {
 // by examining ~/.tsh and logs him out of them all
 func LogoutFromEverywhere(username string) error {
 	// if no --user flag was passed, get the current OS user:
+
 	if username == "" {
 		me, err := user.Current()
 		if err != nil {
@@ -143,11 +144,12 @@ func LogoutFromEverywhere(username string) error {
 		return trace.Wrap(err)
 	}
 	if len(keys) == 0 {
-		fmt.Printf("%s is not logged in\n", username)
-		return nil
+		fmt.Printf("%s is not logged in, but logging out of everywhere\n", username)
+		return agent.ClearAllKeys()
 	}
 	// ... and delete them:
 	for _, key := range keys {
+
 		err = agent.DeleteKey(key.ProxyHost, username)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error logging %s out of %s: %s\n",

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -144,7 +144,7 @@ func LogoutFromEverywhere(username string) error {
 		return trace.Wrap(err)
 	}
 	if len(keys) == 0 {
-		fmt.Printf("%s is not logged in, but logging out of everywhere\n", username)
+		fmt.Printf("%s is not logged in, logging out of everywhere\n", username)
 		return agent.ClearAllKeys()
 	}
 	// ... and delete them:


### PR DESCRIPTION
Are you looking for something like this?

The user is 
``
echo $USER
d
``
Login
```
$./build/tsh login --proxy=localhost --insecure --user=d@example.com
WARNING: You are using insecure connection to SSH proxy https://localhost:3080
Enter password for Teleport user d@example.com:
Enter your OTP token:
*******
WARNING: You are using insecure connection to SSH proxy https://localhost:3080

You are now logged in
```
and when you logout
```
./build/tsh logout
d is not logged in, but logging out of everywhere
```

and the keydir is 
```
ls -lrt ~/.tsh/
total 0
```

#1541 