### PR TITLE
Discard session server and audit log

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -260,9 +260,10 @@ func (s *IntSuite) TestAuditOn(c *check.C) {
 					if err != nil {
 						return nil, trace.Wrap(err)
 					}
-					if len(sessions) > 0 {
-						return &sessions[0], nil
+					if len(sessions) != 1 {
+						continue
 					}
+					return &sessions[0], nil
 				case <-stopCh:
 					return nil, trace.BadParameter("unable to find sessions after 10s (mode=%v)", tt.inRecordLocation)
 				}

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -216,24 +216,26 @@ func (u *UpdateRequest) Check() error {
 	return nil
 }
 
-// Due to limitations of the current back-end, Teleport won't return more than 1000 sessions
-// per time window
+// MaxSessionSliceLength is the maximum number of sessions per time window
+// that the backend will return.
 const MaxSessionSliceLength = 1000
 
-// Service is a realtime SSH session service
-// that has information about sessions that are in-flight in the
-// cluster at the moment
+// Service is a realtime SSH session service that has information about
+// sessions that are in-flight in the cluster at the moment.
 type Service interface {
-	// GetSessions returns a list of currently active sessions
-	// with all parties involved
+	// GetSessions returns a list of currently active sessions with all parties
+	// involved.
 	GetSessions(namespace string) ([]Session, error)
-	// GetSession returns a session with it's parties by ID
+
+	// GetSession returns a session with it's parties by ID.
 	GetSession(namespace string, id ID) (*Session, error)
-	// CreateSession creates a new active session and it's parameters
-	// if term is skipped, terminal size won't be recorded
+
+	// CreateSession creates a new active session and it's parameters if term is
+	// skipped, terminal size won't be recorded.
 	CreateSession(sess Session) error
-	// UpdateSession updates certain session parameters (last_active, terminal parameters)
-	// other parameters will not be updated
+
+	// UpdateSession updates certain session parameters (last_active, terminal
+	// parameters) other parameters will not be updated.
 	UpdateSession(req UpdateRequest) error
 }
 
@@ -383,6 +385,37 @@ func (s *server) UpdateSession(req UpdateRequest) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	return nil
+}
+
+// discardSessionServer discards all information about sessions given to it.
+type discardSessionServer struct {
+}
+
+// NewDiscardSessionServer returns a new discarding session server. It's used
+// with the recording proxy so that nodes don't register active sessions to
+// the backend.
+func NewDiscardSessionServer() *discardSessionServer {
+	return &discardSessionServer{}
+}
+
+// GetSessions returns an empty list of sessions.
+func (d *discardSessionServer) GetSessions(namespace string) ([]Session, error) {
+	return []Session{}, nil
+}
+
+// GetSession always returns a zero session.
+func (d *discardSessionServer) GetSession(namespace string, id ID) (*Session, error) {
+	return &Session{}, nil
+}
+
+// CreateSession always returns nil, does nothing.
+func (d *discardSessionServer) CreateSession(sess Session) error {
+	return nil
+}
+
+// UpdateSession always returns nil, does nothing.
+func (d *discardSessionServer) UpdateSession(req UpdateRequest) error {
 	return nil
 }
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -124,6 +124,9 @@ func (s *Server) GetNamespace() string {
 }
 
 func (s *Server) GetAuditLog() events.IAuditLog {
+	if s.isAuditedAtProxy() {
+		return events.NewDiscardAuditLog()
+	}
 	return s.alog
 }
 
@@ -132,7 +135,28 @@ func (s *Server) GetAccessPoint() auth.AccessPoint {
 }
 
 func (s *Server) GetSessionServer() rsession.Service {
+	if s.isAuditedAtProxy() {
+		return rsession.NewDiscardSessionServer()
+	}
 	return s.sessionServer
+}
+
+// isAuditedAtProxy returns true if sessions are being recorded at the proxy
+// and this is a Teleport node.
+func (s *Server) isAuditedAtProxy() bool {
+	// always be safe, better to double record than not record at all
+	clusterConfig, err := s.GetAccessPoint().GetClusterConfig()
+	if err != nil {
+		return false
+	}
+
+	isRecordAtProxy := clusterConfig.GetSessionRecording() == services.RecordAtProxy
+	isTeleportNode := s.Component() == teleport.ComponentNode
+
+	if isRecordAtProxy && isTeleportNode {
+		return true
+	}
+	return false
 }
 
 // ServerOption is a functional option passed to the server


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1582, we had double session recordings when using the recording proxy and connecting to a Teleport node. However, https://github.com/gravitational/teleport/issues/1582 was incomplete because double sessions still existed in the backend.

This PR removes double sessions.

**Implementation**

The implementation has been simplified. Now Teleport nodes return a discard session server or discard audit log depending on the mode of the cluster.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1582