### PR TITLE
Audit log contains login failures.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -339,10 +339,6 @@ func (s *AuthServer) generateUserCert(req certRequest) (*certs, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	s.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
-		events.EventUser:   req.user.GetName(),
-		events.LoginMethod: events.LoginMethodLocal,
-	})
 	return &certs{ssh: sshCert, tls: tlsCert}, nil
 }
 

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -85,6 +86,25 @@ type SessionCreds struct {
 
 // AuthenticateUser authenticates user based on the request type
 func (s *AuthServer) AuthenticateUser(req AuthenticateUserRequest) error {
+	err := s.authenticateUser(req)
+	if err != nil {
+		s.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+			events.EventUser:          req.Username,
+			events.LoginMethod:        events.LoginMethodLocal,
+			events.AuthAttemptSuccess: false,
+			events.AuthAttemptErr:     err.Error(),
+		})
+	} else {
+		s.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+			events.EventUser:          req.Username,
+			events.LoginMethod:        events.LoginMethodLocal,
+			events.AuthAttemptSuccess: true,
+		})
+	}
+	return err
+}
+
+func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -464,7 +464,7 @@ func (o *OIDCConnectorV2) RoleFromTemplate(claims jose.Claims) (Role, error) {
 		}
 	}
 
-	return nil, trace.BadParameter("no matching claim name/value, claims: %q", claims)
+	return nil, trace.BadParameter("no matching claim name/value, claims: %v", claims)
 }
 
 // Check returns nil if all parameters are great, err otherwise

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -525,7 +525,7 @@ func (o *SAMLConnectorV2) RoleFromTemplate(assertionInfo saml2.AssertionInfo) (R
 		}
 	}
 
-	return nil, trace.BadParameter("no matching assertion name/value, assertions: %q", assertionMap)
+	return nil, trace.BadParameter("no matching assertion name/value, assertions: %v", assertionMap)
 }
 
 // GetServiceProvider initialises service provider spec from settings

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -813,10 +813,11 @@ func (h *Handler) oidcCallback(w http.ResponseWriter, r *http.Request, p httprou
 	if err != nil {
 		log.Warningf("[OIDC] Error while processing callback: %v", err)
 
+		message := "Unable to process callback from OIDC provider. Ask your system administrator to check audit logs for details."
 		// redirect to an error page
 		pathToError := url.URL{
 			Path:     "/web/msg/error/login_failed",
-			RawQuery: url.Values{"details": []string{"Unable to process callback from OIDC provider."}}.Encode(),
+			RawQuery: url.Values{"details": []string{message}}.Encode(),
 		}
 		http.Redirect(w, r, pathToError.String(), http.StatusFound)
 		return nil, nil

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -101,10 +101,12 @@ func (m *Handler) samlACS(w http.ResponseWriter, r *http.Request, p httprouter.P
 	if err != nil {
 		log.Warningf("error while processing callback: %v", err)
 
+		message := "Unable to process callback from SAML provider. Ask your system administrator to check audit logs for details."
+
 		// redirect to an error page
 		pathToError := url.URL{
 			Path:     "/web/msg/error/login_failed",
-			RawQuery: url.Values{"details": []string{"Unable to process callback from SAML provider."}}.Encode(),
+			RawQuery: url.Values{"details": []string{message}}.Encode(),
 		}
 		http.Redirect(w, r, pathToError.String(), http.StatusFound)
 		return nil, nil


### PR DESCRIPTION
This commit fixes #1553, fixes #1554 and makes sure
that audit log contains login success and failure entries
for OIDC, SAML, Github and local logins.