### PR TITLE
Increase time allowed for tests to run.

### DIFF
--- a/lib/backend/dir/impl_test.go
+++ b/lib/backend/dir/impl_test.go
@@ -208,9 +208,10 @@ func (s *Suite) TestLocking(c *check.C) {
 	// release the lock, and the gorouting should unlock and advance i
 	s.bk.ReleaseLock(lock)
 	resumed := false
-	for attempt := 0; attempt < 50 && !resumed; attempt++ {
-		time.Sleep(time.Millisecond * 2)
+	for attempt := 0; attempt < 100 && !resumed; attempt++ {
+		time.Sleep(time.Millisecond * 10)
 		resumed = atomic.LoadInt32(&i) > 0
 	}
 	c.Assert(resumed, check.Equals, true)
+
 }

--- a/lib/utils/timeout_test.go
+++ b/lib/utils/timeout_test.go
@@ -69,7 +69,7 @@ func (s *TimeoutSuite) TestSlowOperation(c *check.C) {
 }
 
 func (s *TimeoutSuite) TestNormalOperation(c *check.C) {
-	client := newClient(time.Millisecond * 5)
+	client := newClient(time.Millisecond * 100)
 	resp, err := client.Get(s.server.URL + "/ping")
 	c.Assert(err, check.IsNil)
 	c.Assert(bodyText(resp), check.Equals, "pong")


### PR DESCRIPTION
**Purpose**

The two below tests intermittently fail both when run on Jenkins and locally.

```
FAIL: timeout_test.go:71: TimeoutSuite.TestNormalOperation

timeout_test.go:74:
    c.Assert(err, check.IsNil)
... value *url.Error = &url.Error{Op:"Get", URL:"http://127.0.0.1:42922/ping", Err:(*net.OpError)(0xc42056e050)} ("Get http://127.0.0.1:42922/ping: read tcp 127.0.0.1:49496->127.0.0.1:42922: i/o timeout")

OOPS: 21 passed, 1 FAILED
```

```
FAIL: impl_test.go:186: Suite.TestLocking

impl_test.go:215:
    c.Assert(resumed, check.Equals, true)
... obtained bool = false
... expected bool = true

OOPS: 4 passed, 1 FAILED
```

I was able to get them to fail more frequently by lowering the timeout and increasing the load of the CPU using a [Javascript benchmark tool](https://webkit.org/perf/sunspider/sunspider.html) as well as the `stress` CLI tool.

**Implementation**

Provide more time for tests to run.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1386