### PR TITLE
Lock rotateLog function as it's called from multiple goroutines.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -166,6 +166,9 @@ const (
 	// Audit log server, and 16K is OK for now
 	AuditLogSessions = 16384
 
+	// AuditLogTimeFormat is the format for the timestamp on audit log files.
+	AuditLogTimeFormat = "2006-01-02.15:04:05"
+
 	// PlaybackRecycleTTL is the TTL for unpacked session playback files
 	PlaybackRecycleTTL = 3 * time.Hour
 )

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -954,21 +954,23 @@ func (l *AuditLog) findInFile(fn string, query url.Values) ([]EventFields, error
 	return retval, nil
 }
 
-// rotateLog() checks if the current log file is older than a given duration,
-// and if it is, closes it and opens a new one
+// rotateLog checks if the current log file is older than a given duration,
+// and if it is, closes it and opens a new one.
 func (l *AuditLog) rotateLog() (err error) {
+	l.Lock()
+	defer l.Unlock()
+
 	// determine the timestamp for the current log file
 	fileTime := l.Clock.Now().In(time.UTC).Round(l.RotationPeriod)
 
 	openLogFile := func() error {
-		l.Lock()
-		defer l.Unlock()
 		logfname := filepath.Join(l.DataDir, l.ServerID,
-			fileTime.Format("2006-01-02.15:04:05")+LogfileExt)
+			fileTime.Format(defaults.AuditLogTimeFormat)+LogfileExt)
 		l.file, err = os.OpenFile(logfname, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
 		if err != nil {
 			log.Error(err)
 		}
+
 		l.fileTime = fileTime
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
**Purpose**

Fixes race found by Go race detector in https://github.com/gravitational/teleport/issues/1606. 

**Implementation**

* Locking the entire function as `l.file` and `l.fileTime` are both updated in `rotateLog` which is called from multiple goroutines.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1606