### PR TITLE
Exit when no remote Auth Servers found

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -383,7 +383,11 @@ func (a *Agent) proxyTransport(ch ssh.Channel, reqC <-chan *ssh.Request) {
 	if server == RemoteAuthServer {
 		authServers, err := a.Client.GetAuthServers()
 		if err != nil {
-			a.Warningf("unable to find auth servers: %v", err)
+			a.Warningf("Unable retrieve list of remote Auth Servers: %v.", err)
+			return
+		}
+		if len(authServers) == 0 {
+			a.Warningf("No remote Auth Servers returned by client.")
 			return
 		}
 		for _, as := range authServers {
@@ -393,7 +397,7 @@ func (a *Agent) proxyTransport(ch ssh.Channel, reqC <-chan *ssh.Request) {
 		servers = append(servers, server)
 	}
 
-	a.Debugf("got out of band request %v", servers)
+	a.Debugf("Received out-of-band proxy transport request: %v", servers)
 
 	var conn net.Conn
 	var err error


### PR DESCRIPTION
**Purpose**

Looking into the panic found in https://github.com/gravitational/teleport/issues/1577, it appears that it occurs when `conn` is `nil`. That can potentially occur when the client returns an empty list of remote Auth Servers.

**Implementation**

* If an empty list of remote Auth Servers is returned, exit right away with an error.

**Related Issues**

https://github.com/gravitational/teleport/issues/1577