### PR TITLE
LocalKeyAgent only loads keys for a user logged into a proxy.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -100,6 +100,14 @@ const (
 	// ComponentAuditLog is audit log component
 	ComponentAuditLog = "auditlog"
 
+	// ComponentKeyAgent is an agent that has loaded the sessions keys and
+	// certificates for a user connected to a proxy.
+	ComponentKeyAgent = "keyagent"
+
+	// ComponentKeyStore is all sessions keys and certificates a user has on disk
+	// for all proxies.
+	ComponentKeyStore = "keystore"
+
 	// DebugEnvVar tells tests to use verbose debug output
 	DebugEnvVar = "DEBUG"
 

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -95,12 +95,12 @@ func (s *KeyAgentTestSuite) SetUpTest(c *check.C) {
 //     a teleport key with the teleport username.
 func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
 	// make a new local agent
-	lka, err := NewLocalAgent(s.keyDir, s.username)
+	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
 	c.Assert(err, check.IsNil)
 
 	// add the key to the local agent, this should write the key
 	// to disk as well as load it in the agent
-	_, err = lka.AddKey(s.hostname, s.username, s.key)
+	_, err = lka.AddKey(s.key)
 	c.Assert(err, check.IsNil)
 
 	// check that the key has been written to disk
@@ -140,7 +140,7 @@ func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
 	c.Assert(true, check.Equals, found)
 
 	// unload all keys for this user from the teleport agent and system agent
-	err = lka.UnloadKey(s.username)
+	err = lka.UnloadKey()
 	c.Assert(err, check.IsNil)
 }
 
@@ -154,11 +154,11 @@ func (s *KeyAgentTestSuite) TestLoadKey(c *check.C) {
 	userdata := []byte("hello, world")
 
 	// make a new local agent
-	lka, err := NewLocalAgent(s.keyDir, s.username)
+	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
 	c.Assert(err, check.IsNil)
 
 	// unload any keys that might be in the agent for this user
-	err = lka.UnloadKey(s.username)
+	err = lka.UnloadKey()
 	c.Assert(err, check.IsNil)
 
 	// get all the keys in the teleport and system agent
@@ -171,9 +171,9 @@ func (s *KeyAgentTestSuite) TestLoadKey(c *check.C) {
 
 	// load the key to the twice, this should only
 	// result in one key for this user in the agent
-	_, err = lka.LoadKey(s.username, *s.key)
+	_, err = lka.LoadKey(*s.key)
 	c.Assert(err, check.IsNil)
-	_, err = lka.LoadKey(s.username, *s.key)
+	_, err = lka.LoadKey(*s.key)
 	c.Assert(err, check.IsNil)
 
 	// get all the keys in the teleport and system agent
@@ -206,13 +206,13 @@ func (s *KeyAgentTestSuite) TestLoadKey(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// unload all keys from the teleport agent and system agent
-	err = lka.UnloadKey(s.username)
+	err = lka.UnloadKey()
 	c.Assert(err, check.IsNil)
 }
 
 func (s *KeyAgentTestSuite) TestHostVerification(c *check.C) {
 	// make a new local agent
-	lka, err := NewLocalAgent(s.keyDir, s.username)
+	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
 	c.Assert(err, check.IsNil)
 
 	// by default user has not refused any hosts:

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -29,14 +29,14 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/sshutils"
-	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
-
-	"golang.org/x/crypto/ssh"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -57,87 +57,81 @@ const (
 	keyFilePerms os.FileMode = 0600
 )
 
-// LocalKeyStore interface allows for different storage back-ends for TSH to
-// load/save its keys
+// LocalKeyStore interface allows for different storage backends for tsh to
+// load/save its keys.
 //
 // The _only_ filesystem-based implementation of LocalKeyStore is declared
 // below (FSLocalKeyStore)
 type LocalKeyStore interface {
-	// client key management
-	GetKeys(username string) ([]Key, error)
-	AddKey(host string, username string, key *Key) error
-	GetKey(host string, username string) (*Key, error)
-	DeleteKey(host string, username string) error
+	// AddKey adds the given session key for the proxy and username to the
+	// storage backend.
+	AddKey(proxy string, username string, key *Key) error
 
-	// interface to known_hosts file:
+	// GetKey returns the session key for the given username and proxy.
+	GetKey(proxy string, username string) (*Key, error)
+
+	// DeleteKey removes a specific session key from a proxy.
+	DeleteKey(proxyHost string, username string) error
+
+	// DeleteKeys removes all session keys from disk.
+	DeleteKeys() error
+
+	// AddKnownHostKeys adds the public key to the list of known hosts for
+	// a hostname.
 	AddKnownHostKeys(hostname string, keys []ssh.PublicKey) error
+
+	// GetKnownHostKeys returns all public keys for a hostname.
 	GetKnownHostKeys(hostname string) ([]ssh.PublicKey, error)
 
-	// SaveCerts saves trusted TLS certificates of certificate authorities
+	// SaveCerts saves trusted TLS certificates of certificate authorities.
 	SaveCerts(proxy string, cas []auth.TrustedCerts) error
-	// GetCerts gets trusted TLS certificates of certificate authorities
+
+	// GetCerts gets trusted TLS certificates of certificate authorities.
 	GetCerts(proxy string) (*x509.CertPool, error)
 }
 
-// FSLocalKeyStore implements LocalKeyStore interface using the filesystem
+// FSLocalKeyStore implements LocalKeyStore interface using the filesystem.
 // Here's the file layout for the FS store:
+//
 // ~/.tsh/
-// ├── known_hosts   --> trusted certificate authorities (their keys) in a format similar to known_hosts
-// └── sessions      --> server-signed session keys
-//     └── host-a
-//     |   ├── cert
-//     |   ├── key
-//     |   └── pub
-//     └── host-b
-//         ├── cert
-//         ├── key
-//         └── pub
+// ├── known_hosts             --> trusted certificate authorities (their keys) in a format similar to known_hosts
+// └── keys
+//    ├── one.example.com
+//    │   ├── certs.pem
+//    │   ├── foo              --> RSA Private Key
+//    │   ├── foo-cert.pub     --> SSH certificate for proxies and nodes
+//    │   ├── foo.pub          --> Public Key
+//    │   └── foo-x509.pem     --> TLS client certificate for Auth Server
+//    └── two.example.com
+//        ├── certs.pem
+//        ├── bar
+//        ├── bar-cert.pub
+//        ├── bar.pub
+//        └── bar-x509.pem
 type FSLocalKeyStore struct {
-	LocalKeyStore
+	// log holds the structured logger.
+	log *logrus.Entry
 
-	// KeyDir is the directory where all keys are stored
+	// KeyDir is the directory where all keys are stored.
 	KeyDir string
 }
 
 // NewFSLocalKeyStore creates a new filesystem-based local keystore object
 // and initializes it.
 //
-// if dirPath is empty, sets it to ~/.tsh
+// If dirPath is empty, sets it to ~/.tsh.
 func NewFSLocalKeyStore(dirPath string) (s *FSLocalKeyStore, err error) {
 	dirPath, err = initKeysDir(dirPath)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	return &FSLocalKeyStore{
+		log: logrus.WithFields(logrus.Fields{
+			trace.Component: teleport.ComponentKeyStore,
+		}),
 		KeyDir: dirPath,
 	}, nil
-}
-
-// GetKeys returns all user session keys stored in the store
-func (fs *FSLocalKeyStore) GetKeys(username string) (keys []Key, err error) {
-	dirPath := filepath.Join(fs.KeyDir, sessionKeyDir)
-	if !utils.IsDir(dirPath) {
-		return make([]Key, 0), nil
-	}
-	dirEntries, err := ioutil.ReadDir(dirPath)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	for _, fi := range dirEntries {
-		if !fi.IsDir() {
-			continue
-		}
-		k, err := fs.GetKey(fi.Name(), username)
-		if err != nil {
-			// if a key is reported as 'not found' it's probably because it expired
-			if !trace.IsNotFound(err) {
-				return nil, trace.Wrap(err)
-			}
-			continue
-		}
-		keys = append(keys, *k)
-	}
-	return keys, nil
 }
 
 // AddKey adds a new key to the session store. If a key for the host is already
@@ -151,7 +145,7 @@ func (fs *FSLocalKeyStore) AddKey(host, username string, key *Key) error {
 		fp := filepath.Join(dirPath, fname)
 		err := ioutil.WriteFile(fp, data, keyFilePerms)
 		if err != nil {
-			log.Error(err)
+			fs.log.Error(err)
 		}
 		return err
 	}
@@ -190,37 +184,54 @@ func (fs *FSLocalKeyStore) DeleteKey(host string, username string) error {
 	return nil
 }
 
+// DeleteKeys removes all session keys from disk.
+func (fs *FSLocalKeyStore) DeleteKeys() error {
+	dirPath := filepath.Join(fs.KeyDir, sessionKeyDir)
+
+	err := os.RemoveAll(dirPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
 // GetKey returns a key for a given host. If the key is not found,
 // returns trace.NotFound error.
-func (fs *FSLocalKeyStore) GetKey(host, username string) (*Key, error) {
-	dirPath, err := fs.dirFor(host)
+func (fs *FSLocalKeyStore) GetKey(proxyHost string, username string) (*Key, error) {
+	dirPath, err := fs.dirFor(proxyHost)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	_, err = ioutil.ReadDir(dirPath)
+	if err != nil {
+		return nil, trace.NotFound("no session keys for %v in %v", username, proxyHost)
+	}
+
 	certFile := filepath.Join(dirPath, username+fileExtCert)
 	cert, err := ioutil.ReadFile(certFile)
 	if err != nil {
-		log.Error(err)
+		fs.log.Error(err)
 		return nil, trace.Wrap(err)
 	}
 	tlsCertFile := filepath.Join(dirPath, username+fileExtTLSCert)
 	tlsCert, err := ioutil.ReadFile(tlsCertFile)
 	if err != nil {
-		log.Error(err)
+		fs.log.Error(err)
 		return nil, trace.Wrap(err)
 	}
 	pub, err := ioutil.ReadFile(filepath.Join(dirPath, username+fileExtPub))
 	if err != nil {
-		log.Error(err)
+		fs.log.Error(err)
 		return nil, trace.Wrap(err)
 	}
 	priv, err := ioutil.ReadFile(filepath.Join(dirPath, username))
 	if err != nil {
-		log.Error(err)
+		fs.log.Error(err)
 		return nil, trace.Wrap(err)
 	}
 
-	key := &Key{Pub: pub, Priv: priv, Cert: cert, ProxyHost: host, TLSCert: tlsCert}
+	key := &Key{Pub: pub, Priv: priv, Cert: cert, ProxyHost: proxyHost, TLSCert: tlsCert}
 
 	// expired certificate? this key won't be accepted anymore, lets delete it:
 	certExpiration, err := key.CertValidBefore()
@@ -231,11 +242,11 @@ func (fs *FSLocalKeyStore) GetKey(host, username string) (*Key, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.Debugf("[KEYSTORE] Returning certificate %q valid until %q,  TLS certificate %q valid until %q", certFile, certExpiration, tlsCertFile, tlsCertExpiration)
+	fs.log.Debugf("Returning certificate %q valid until %q,  TLS certificate %q valid until %q", certFile, certExpiration, tlsCertFile, tlsCertExpiration)
 	if certExpiration.Before(time.Now()) || tlsCertExpiration.Before(time.Now()) {
-		log.Infof("[KEYSTORE] TTL expired (%v) or (%v)  for session key %v", certExpiration, tlsCertExpiration, dirPath)
+		fs.log.Infof("TTL expired (%v) or (%v)  for session key %v", certExpiration, tlsCertExpiration, dirPath)
 		os.RemoveAll(dirPath)
-		return nil, trace.NotFound("session keys for %s are not found", host)
+		return nil, trace.NotFound("session keys for %s are not found", proxyHost)
 	}
 	return key, nil
 }
@@ -285,7 +296,7 @@ func (fs *FSLocalKeyStore) GetCerts(proxy string) (*x509.CertPool, error) {
 			break
 		}
 		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
-			log.Debugf("Skipping PEM block type=%v headers=%v.", block.Type, block.Headers)
+			fs.log.Debugf("Skipping PEM block type=%v headers=%v.", block.Type, block.Headers)
 			continue
 		}
 
@@ -293,7 +304,7 @@ func (fs *FSLocalKeyStore) GetCerts(proxy string) (*x509.CertPool, error) {
 		if err != nil {
 			return nil, trace.BadParameter("failed to parse certificate: %v", err)
 		}
-		log.Debugf("Adding trusted cluster certificate authority %q to trusted pool.", cert.Issuer)
+		fs.log.Debugf("Adding trusted cluster certificate authority %q to trusted pool.", cert.Issuer)
 		pool.AddCert(cert)
 	}
 	return pool, nil
@@ -320,7 +331,7 @@ func (fs *FSLocalKeyStore) AddKnownHostKeys(hostname string, hostKeys []ssh.Publ
 	}
 	// add every host key to the list of entries
 	for i := range hostKeys {
-		log.Debugf("adding known host %s with key: %v", hostname, sshutils.Fingerprint(hostKeys[i]))
+		fs.log.Debugf("Adding known host %s with key: %v", hostname, sshutils.Fingerprint(hostKeys[i]))
 		bytes := ssh.MarshalAuthorizedKey(hostKeys[i])
 		line := strings.TrimSpace(fmt.Sprintf("%s %s", hostname, bytes))
 		if _, exists := entries[line]; !exists {
@@ -380,11 +391,13 @@ func (fs *FSLocalKeyStore) GetKnownHostKeys(hostname string) ([]ssh.PublicKey, e
 }
 
 // dirFor is a helper function. It returns a directory where session keys
-// for a given host are stored
-func (fs *FSLocalKeyStore) dirFor(hostname string) (string, error) {
-	dirPath := filepath.Join(fs.KeyDir, sessionKeyDir, hostname)
+// for a given host are stored. fs.KeyDir is typically "~/.tsh", sessionKeyDir
+// is typically "keys", and proxyHost is typically something like
+// "proxy.example.com".
+func (fs *FSLocalKeyStore) dirFor(proxyHost string) (string, error) {
+	dirPath := filepath.Join(fs.KeyDir, sessionKeyDir, proxyHost)
 	if err := os.MkdirAll(dirPath, profileDirPerms); err != nil {
-		log.Error(err)
+		fs.log.Error(err)
 		return "", trace.Wrap(err)
 	}
 	return dirPath, nil

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -120,41 +119,4 @@ func (cp *ClientProfile) SaveTo(filePath string, opts ProfileOptions) error {
 		err = os.Symlink(filepath.Base(filePath), symlink)
 	}
 	return trace.Wrap(err)
-}
-
-// LogoutFromEverywhere looks at the list of proxy servers tsh is currently logged into
-// by examining ~/.tsh and logs him out of them all
-func LogoutFromEverywhere(username string) error {
-	// if no --user flag was passed, get the current OS user:
-	if username == "" {
-		me, err := user.Current()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		username = me.Username
-	}
-	// load all current keys:
-	agent, err := NewLocalAgent("", username)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	keys, err := agent.GetKeys(username)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if len(keys) == 0 {
-		fmt.Printf("%s is not logged in\n", username)
-		return nil
-	}
-	// ... and delete them:
-	for _, key := range keys {
-		err = agent.DeleteKey(key.ProxyHost, username)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error logging %s out of %s: %s\n",
-				username, key.ProxyHost, err)
-		} else {
-			fmt.Printf("logged %s out of %s\n", username, key.ProxyHost)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
**Purpose**

https://github.com/gravitational/teleport/issues/1541 and https://github.com/gravitational/teleport/issues/1611 cover two problems `tsh` has. The first is that Teleport will use the incorrect key when trying to connect to a cluster if you use the same username across different proxies. The second issue is that Teleport does not log a user out correctly.

**Implementation**

* `GetKeys` has been removed from `LocalKeyAgent` as it now only operates on a single user and proxy at a time. This was done to simplify the logic for `LocalKeyAgent` otherwise to fix https://github.com/gravitational/teleport/issues/1541 `LocalKeyAgent` would have to be updated to know about multiple proxies. 
* Added `DeleteKeys` to remove all keys to `FSLocalKeyStore` to remove all keys for all users connected to all proxies.
* `tsh logout` without any parameters will call `DeleteKeys` and remove all keys for all users connected to all proxies.
* `tsh --proxy=one.example.com --user=rjones` will log out `rjones` from `one.example.com`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1541
Fixes https://github.com/gravitational/teleport/issues/1611
