### PR TITLE
UX and performance changes

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -287,3 +287,8 @@ const (
 	// at expected interval
 	RemoteClusterStatusOnline = "online"
 )
+
+const (
+	// SharedDirMode is a mode for a directory shared with group
+	SharedDirMode = 0750
+)

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -148,7 +148,8 @@ func readToken(token string) (string, error) {
 	if err != nil {
 		return "", nil
 	}
-	return string(out), nil
+	// trim newlines as tokens in files tend to have newlines
+	return strings.TrimSpace(string(out)), nil
 }
 
 // PackedKeys is a collection of private key, SSH host certificate

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -639,9 +639,11 @@ func (process *TeleportProcess) newLocalCache(clt auth.ClientI, cacheName []stri
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
 	}
-
 	path := filepath.Join(append([]string{process.Config.DataDir, "cache"}, cacheName...)...)
-	cacheBackend, err := dir.New(backend.Params{"path": path})
+	if err := os.MkdirAll(path, teleport.SharedDirMode); err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	cacheBackend, err := boltbk.New(backend.Params{"path": path})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -467,7 +467,10 @@ func (c *connectionWrapper) Read(b []byte) (int, error) {
 	buff := make([]byte, MaxVersionStringBytes)
 	n, err := c.Conn.Read(buff)
 	if err != nil {
-		log.Error(err)
+		// EOF happens quite often, don't pollute the logs with EOF
+		if err != io.EOF {
+			log.Error(err)
+		}
 		return n, err
 	}
 	// chop off extra unused bytes at the end of the buffer:


### PR DESCRIPTION
* Do not log EOF errors, avoid polluting logs
* Trim space from tokens when reading from file
* Do not use dir based caching

The caching problem deserves a separate explanation.

Directory backend is not concurrent friendly - it has a
fundamental design flaw - multiple gorotuines writing to the
same file corrupt cache data.

This requires either redesign of the backend or switching
to boltdb backend for caching.

Boltdb backend uses transactions and is safe for concurrent
access. This PR changes local cache to use boltdb instead
of the dir backend that is now used only in tests.