### PR TITLE
Cache recently accessed items.

### DIFF
--- a/examples/aws/terraform/auth-user-data.tpl
+++ b/examples/aws/terraform/auth-user-data.tpl
@@ -70,6 +70,7 @@ auth_service:
   listen_addr: 0.0.0.0:3025
 
   authentication:
+    second_factor: off
     type: oidc
 
   cluster_name: ${cluster_name}

--- a/examples/aws/terraform/auth_asg.tf
+++ b/examples/aws/terraform/auth_asg.tf
@@ -22,6 +22,12 @@ resource "aws_autoscaling_group" "auth" {
     propagate_at_launch = true
   }
 
+  tag {
+    key =  "TeleportRole"
+    value = "auth"
+    propagate_at_launch = true
+  }
+
   // external autoscale algos can modify these values,
   // so ignore changes to them
   lifecycle {

--- a/examples/aws/terraform/bastion.tf
+++ b/examples/aws/terraform/bastion.tf
@@ -4,12 +4,16 @@
 resource "aws_instance" "bastion" {
   count                       = "1"
   ami                         = "${data.aws_ami.base.id}"
-  instance_type               = "t2.micro"
+  instance_type               = "t2.medium"
   key_name                    = "${var.key_name}"
   associate_public_ip_address = true
   source_dest_check           = false
   vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
   subnet_id                   = "${element(aws_subnet.public.*.id, 0)}"
+  tags {
+    TeleportCluster = "${var.cluster_name}"
+    TeleportRole = "bastion"
+  }
 }
 
 // Bastions are open to internet access

--- a/examples/aws/terraform/node_asg.tf
+++ b/examples/aws/terraform/node_asg.tf
@@ -18,6 +18,12 @@ resource "aws_autoscaling_group" "node" {
     propagate_at_launch = true
   }
 
+  tag {
+    key =  "TeleportRole"
+    value = "node"
+    propagate_at_launch = true
+  }
+
   // external autoscale algos can modify these values,
   // so ignore changes to them
   lifecycle {

--- a/examples/aws/terraform/proxy_asg.tf
+++ b/examples/aws/terraform/proxy_asg.tf
@@ -20,6 +20,12 @@ resource "aws_autoscaling_group" "proxy" {
     propagate_at_launch = true
   }
 
+  tag {
+    key =  "TeleportRole"
+    value = "proxy"
+    propagate_at_launch = true
+  }
+
   // external autoscale algos can modify these values,
   // so ignore changes to them
   lifecycle {

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -454,7 +454,11 @@ func (i *TeleInstance) StartNode(name string, sshPort int) (*service.TeleportPro
 	tconf.HostUUID = name
 	tconf.Hostname = name
 	tconf.DataDir = dataDir
-	tconf.CachePolicy = service.CachePolicy{Enabled: true}
+	var ttl time.Duration
+	tconf.CachePolicy = service.CachePolicy{
+		Enabled:   true,
+		RecentTTL: &ttl,
+	}
 
 	tconf.Auth.Enabled = false
 
@@ -493,7 +497,11 @@ func (i *TeleInstance) StartNodeAndProxy(name string, sshPort, proxyWebPort, pro
 	tconf.HostUUID = name
 	tconf.Hostname = name
 	tconf.DataDir = dataDir
-	tconf.CachePolicy = service.CachePolicy{Enabled: true}
+	var ttl time.Duration
+	tconf.CachePolicy = service.CachePolicy{
+		Enabled:   true,
+		RecentTTL: &ttl,
+	}
 
 	tconf.Auth.Enabled = false
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1172,6 +1172,22 @@ func (a *AuthWithRoles) WaitForDelivery(context.Context) error {
 	return nil
 }
 
+// NewAdminAuthServer returns auth server authorized as admin,
+// used for auth server cached access
+func NewAdminAuthServer(authServer *AuthServer, sessions session.Service, alog events.IAuditLog) (ClientI, error) {
+	ctx, err := NewAdminContext()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &AuthWithRoles{
+		authServer: authServer,
+		checker:    ctx.Checker,
+		user:       ctx.User,
+		alog:       alog,
+		sessions:   sessions,
+	}, nil
+}
+
 // NewAuthWithRoles creates new auth server with access control
 func NewAuthWithRoles(authServer *AuthServer,
 	checker services.AccessChecker,

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -139,7 +139,10 @@ func Init(cfg InitConfig, opts ...AuthServerOption) (*AuthServer, *Identity, err
 	defer cfg.Backend.ReleaseLock(domainName)
 
 	// check that user CA and host CA are present and set the certs if needed
-	asrv := NewAuthServer(&cfg, opts...)
+	asrv, err := NewAuthServer(&cfg, opts...)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 
 	// INTERNAL: Authorities (plus Roles) and ReverseTunnels don't follow the
 	// same pattern as the rest of the configuration (they are not configuration
@@ -185,11 +188,6 @@ func Init(cfg InitConfig, opts ...AuthServerOption) (*AuthServer, *Identity, err
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	err = asrv.syncCachedClusterConfig()
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	log.Infof("Updating cluster configuration: %v.", cfg.ClusterConfig)
 
 	// cluster name can only be set once. if it has already been set and we are
 	// trying to update it to something else, hard fail.

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -57,17 +57,19 @@ func (s *PasswordSuite) SetUpTest(c *C) {
 	s.bk, err = boltbk.New(backend.Params{"path": c.MkDir()})
 	c.Assert(err, IsNil)
 
-	authConfig := &InitConfig{
-		Backend:   s.bk,
-		Authority: authority.New(),
-	}
-	s.a = NewAuthServer(authConfig)
-
 	// set cluster name
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "me.localhost",
 	})
 	c.Assert(err, IsNil)
+	authConfig := &InitConfig{
+		ClusterName: clusterName,
+		Backend:     s.bk,
+		Authority:   authority.New(),
+	}
+	s.a, err = NewAuthServer(authConfig)
+	c.Assert(err, IsNil)
+
 	err = s.a.SetClusterName(clusterName)
 	c.Assert(err, IsNil)
 

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -414,34 +414,6 @@ func (s *TLSSuite) TestOTPCRUD(c *check.C) {
 	c.Assert(err, check.NotNil)
 }
 
-// TestSyncCachedClusterConfig tests behavior with cluster configuration
-func (s *TLSSuite) TestSyncCachedClusterConfig(c *check.C) {
-	// set cluster config to record at nodes
-	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
-		SessionRecording: services.RecordAtNode,
-	})
-	authServer := s.server.Auth()
-	err = authServer.SetClusterConfig(clusterConfig)
-	c.Assert(err, check.IsNil)
-
-	// check to make sure the cached value is the same
-	clusterConfig = authServer.getCachedClusterConfig()
-	c.Assert(clusterConfig.GetSessionRecording(), check.Equals, services.RecordAtNode)
-
-	// update cluster config to record at proxy
-	clusterConfig.SetSessionRecording(services.RecordAtProxy)
-	err = authServer.SetClusterConfig(clusterConfig)
-	c.Assert(err, check.IsNil)
-
-	// manually force synching cluster config
-	err = authServer.syncCachedClusterConfig()
-	c.Assert(err, check.IsNil)
-
-	// check to make sure the cached value was updated
-	clusterConfig = authServer.getCachedClusterConfig()
-	c.Assert(clusterConfig.GetSessionRecording(), check.Equals, services.RecordAtProxy)
-}
-
 // TestWebSessions tests web sessions flow for web user,
 // that logs in, extends web session and tries to perform administratvie action
 // but fails
@@ -702,10 +674,6 @@ func (s *TLSSuite) TestClusterConfigContext(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	err = s.server.Auth().SetClusterConfig(clusterConfig)
-	c.Assert(err, check.IsNil)
-
-	// force a sync so the cached value gets updated
-	err = s.server.Auth().syncCachedClusterConfig()
 	c.Assert(err, check.IsNil)
 
 	// try and generate a host cert, now the proxy should be able to generate a

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -371,7 +371,7 @@ func (s *AuthTunnel) onAPIConnection(sconn *ssh.ServerConn, sshChan ssh.Channel,
 			return
 		}
 		builtin := BuiltinRole{
-			GetClusterConfig: s.authServer.getCachedClusterConfig,
+			GetClusterConfig: s.authServer.GetClusterConfig,
 			Role:             systemRole,
 			Username:         sconn.Permissions.Extensions[ExtHost],
 		}

--- a/lib/auth/tun_test.go
+++ b/lib/auth/tun_test.go
@@ -85,12 +85,18 @@ func (s *TunSuite) SetUpTest(c *C) {
 	access := local.NewAccessService(s.bk)
 	identity := local.NewIdentityService(s.bk)
 
-	s.a = NewAuthServer(&InitConfig{
-		Backend:   s.bk,
-		Authority: authority.New(),
-		Access:    access,
-		Identity:  identity,
+	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
+		ClusterName: "localhost",
 	})
+	c.Assert(err, IsNil)
+	s.a, err = NewAuthServer(&InitConfig{
+		Backend:     s.bk,
+		Authority:   authority.New(),
+		Access:      access,
+		Identity:    identity,
+		ClusterName: clusterName,
+	})
+	c.Assert(err, IsNil)
 
 	// set cluster config
 	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
@@ -101,10 +107,6 @@ func (s *TunSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// set cluster name
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "localhost",
-	})
-	c.Assert(err, IsNil)
 	err = s.a.SetClusterName(clusterName)
 	c.Assert(err, IsNil)
 

--- a/lib/backend/boltbk/boltbk.go
+++ b/lib/backend/boltbk/boltbk.go
@@ -157,7 +157,7 @@ func (b *BoltBackend) upsertVal(path []string, key string, val []byte, ttl time.
 func (b *BoltBackend) GetVal(path []string, key string) ([]byte, error) {
 	var val []byte
 	if err := b.getKey(path, key, &val); err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(boltErr(err))
 	}
 	var k *kv
 	if err := json.Unmarshal(val, &k); err != nil {

--- a/lib/backend/dir/impl.go
+++ b/lib/backend/dir/impl.go
@@ -99,6 +99,23 @@ func New(params backend.Params) (backend.Backend, error) {
 	return bk, nil
 }
 
+// GetItems is a function that returns keys in batch
+func (bk *Backend) GetItems(bucket []string) ([]backend.Item, error) {
+	keys, err := bk.GetKeys(bucket)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var items []backend.Item
+	for _, key := range keys {
+		v, err := bk.GetVal(bucket, key)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		items = append(items, backend.Item{Key: key, Value: v})
+	}
+	return items, nil
+}
+
 // GetKeys returns a list of keys for a given path
 func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
 	files, err := ioutil.ReadDir(path.Join(bk.RootDir, path.Join(bucket...)))

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -435,6 +435,7 @@ func (b *DynamoDBBackend) GetKeys(path []string) ([]string, error) {
 // 	   overwrites it if 'overwrite' is true
 //     atomically returns AlreadyExists error if 'overwrite' is false
 func (b *DynamoDBBackend) createKey(fullPath string, val []byte, ttl time.Duration, overwrite bool) error {
+	start := time.Now()
 	r := record{
 		HashKey:   hashKey,
 		FullPath:  fullPath,
@@ -458,6 +459,7 @@ func (b *DynamoDBBackend) createKey(fullPath string, val []byte, ttl time.Durati
 	}
 	_, err = b.svc.PutItem(&input)
 	err = convertError(err)
+	b.Debugf("CreateVal(%v) in %v", fullPath, time.Now().Sub(start))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -609,11 +611,13 @@ func (b *DynamoDBBackend) getKey(fullPath string) (*record, error) {
 
 // GetVal retrieve a value from a key
 func (b *DynamoDBBackend) GetVal(path []string, key string) ([]byte, error) {
+	start := time.Now()
 	fullPath := b.fullPath(append(path, key)...)
 	r, err := b.getKey(fullPath)
 	if err != nil {
 		return nil, err
 	}
+	b.Debugf("GetVal(%v) in %v", fullPath, time.Now().Sub(start))
 	return r.Value, nil
 }
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -423,7 +423,7 @@ func (tc *TeleportClient) accessPoint(clt auth.AccessPoint, proxyHostPort string
 		SkipPreload:  true,
 		AccessPoint:  clt,
 		Backend:      cacheBackend,
-		CacheTTL:     tc.CachePolicy.CacheTTL,
+		CacheMaxTTL:  tc.CachePolicy.CacheTTL,
 		NeverExpires: tc.CachePolicy.NeverExpires,
 	})
 }
@@ -1068,6 +1068,9 @@ func (tc *TeleportClient) Login(activateKey bool) (*Key, error) {
 
 		// in this case identity is returned by the proxy
 		tc.Username = response.Username
+		if tc.localAgent != nil {
+			tc.localAgent.username = response.Username
+		}
 	case teleport.SAML:
 		response, err = tc.ssoLogin(pr.Auth.SAML.Name, key.Pub, teleport.SAML)
 		if err != nil {
@@ -1075,6 +1078,9 @@ func (tc *TeleportClient) Login(activateKey bool) (*Key, error) {
 		}
 		// in this case identity is returned by the proxy
 		tc.Username = response.Username
+		if tc.localAgent != nil {
+			tc.localAgent.username = response.Username
+		}
 	case teleport.Github:
 		response, err = tc.ssoLogin(pr.Auth.Github.Name, key.Pub, teleport.Github)
 		if err != nil {
@@ -1082,6 +1088,9 @@ func (tc *TeleportClient) Login(activateKey bool) (*Key, error) {
 		}
 		// in this case identity is returned by the proxy
 		tc.Username = response.Username
+		if tc.localAgent != nil {
+			tc.localAgent.username = response.Username
+		}
 	default:
 		return nil, trace.BadParameter("unsupported authentication type: %q", pr.Auth.Type)
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -67,6 +67,9 @@ const (
 	// CacheTTL is a default cache TTL for persistent node cache
 	CacheTTL = 20 * time.Hour
 
+	// RecentCacheTTL is a default cache TTL for recently accessed items
+	RecentCacheTTL = 2 * time.Second
+
 	// InviteTokenTTL sets the lifespan of tokens used for adding nodes and users
 	// to a cluster
 	InviteTokenTTL = 15 * time.Minute
@@ -165,6 +168,10 @@ const (
 	// amount of simultaneously processes concurrent sessions by the
 	// Audit log server, and 16K is OK for now
 	AuditLogSessions = 16384
+
+	// AccessPointCachedValues is the default maximum amount of cached values
+	// in access point
+	AccessPointCachedValues = 16384
 
 	// AuditLogTimeFormat is the format for the timestamp on audit log files.
 	AuditLogTimeFormat = "2006-01-02.15:04:05"

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -52,10 +52,11 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Assert(err, check.IsNil)
-	a := auth.NewAuthServer(&auth.InitConfig{
+	a, err := auth.NewAuthServer(&auth.InitConfig{
 		Backend:   bk,
 		Authority: authority.New(),
 	})
+	c.Assert(err, check.IsNil)
 
 	// set cluster name
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{


### PR DESCRIPTION
Introduce cache for items that were accessed
by proxies and nodes within 2 second window to reduce
load on database under high load.

I'm currently testing this feature under load, this PR is for early feedback.