### PR TITLE
Wait for copy to complete before propagating exit-status.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -171,6 +171,10 @@ const (
 
 	// PlaybackRecycleTTL is the TTL for unpacked session playback files
 	PlaybackRecycleTTL = 3 * time.Hour
+
+	// WaitCopyTimeout is how long Teleport will wait for a session to finish
+	// copying data from the PTY after "exit-status" has been received.
+	WaitCopyTimeout = 5 * time.Second
 )
 
 var (


### PR DESCRIPTION
**Purpose**

Occasionally Teleport session recordings don't contain the end of a session. This happens because of a race condition between when everything has been copied from the PTY and when `exit-status` has been received by the server. To fix this problem, the PTY is not closed until everything has been copied from the PTY.

**Implementation**

* New sessions create two goroutines, one that performs a `io.Copy` from the PTY to the writer (which is the session recorder and a direct connection to the remote client) and another goroutine that waits until either `exit-status` has been received (for the forwarding node) or `exec.Cmd` is complete (regular Teleport).
* Use a `doneCh` to notify the goroutine that is waiting for the execution of the shell to complete to also wait for the `io.Copy` to finish before broadcasting the `exit-status` to the client. This has to be done because broadcasting of the `exit-status` causes the PTY to be closed.
* Timeout after 5 seconds if everything has not been copied and log an error that end of the session may be missing.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1646