### PR TITLE
Add limits to SearchEvents, fixes #1632

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -735,7 +735,7 @@ func (s *IntSuite) TestTwoClusters(c *check.C) {
 			for {
 				select {
 				case <-tickCh:
-					eventsInSite, err := site.SearchEvents(now, now.Add(1*time.Hour), execQuery)
+					eventsInSite, err := site.SearchEvents(now, now.Add(1*time.Hour), execQuery, 0)
 					if err != nil {
 						return trace.Wrap(err)
 					}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -1716,11 +1716,20 @@ func (s *APIServer) searchEvents(auth ClientI, w http.ResponseWriter, r *http.Re
 			return nil, trace.BadParameter("to")
 		}
 	}
-	// remove 'to' & 'from' fields, passing the rest of the query unmodified
+	var limit int
+	limitStr := query.Get("limit")
+	if limitStr != "" {
+		limit, err = strconv.Atoi(limitStr)
+		if err != nil {
+			return nil, trace.BadParameter("failed to parse limit: %q", limit)
+		}
+	}
+	// remove 'to', 'from' and 'limit' fields, passing the rest of the query unmodified
 	// to whatever pluggable search is implemented by the backend
 	query.Del("to")
 	query.Del("from")
-	eventsList, err := auth.SearchEvents(from, to, query.Encode())
+	query.Del("limit")
+	eventsList, err := auth.SearchEvents(from, to, query.Encode(), limit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1751,9 +1760,16 @@ func (s *APIServer) searchSessionEvents(auth ClientI, w http.ResponseWriter, r *
 			return nil, trace.BadParameter("to")
 		}
 	}
-
+	var limit int
+	limitStr := query.Get("limit")
+	if limitStr != "" {
+		limit, err = strconv.Atoi(limitStr)
+		if err != nil {
+			return nil, trace.BadParameter("failed to parse limit: %q", limit)
+		}
+	}
 	// only pull back start and end events to build list of completed sessions
-	eventsList, err := auth.SearchSessionEvents(from, to)
+	eventsList, err := auth.SearchSessionEvents(from, to, limit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -816,20 +816,20 @@ func (a *AuthWithRoles) GetSessionEvents(namespace string, sid session.ID, after
 	return a.alog.GetSessionEvents(namespace, sid, afterN)
 }
 
-func (a *AuthWithRoles) SearchEvents(from, to time.Time, query string) ([]events.EventFields, error) {
+func (a *AuthWithRoles) SearchEvents(from, to time.Time, query string, limit int) ([]events.EventFields, error) {
 	if err := a.action(defaults.Namespace, services.KindEvent, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return a.alog.SearchEvents(from, to, query)
+	return a.alog.SearchEvents(from, to, query, limit)
 }
 
-func (a *AuthWithRoles) SearchSessionEvents(from, to time.Time) ([]events.EventFields, error) {
+func (a *AuthWithRoles) SearchSessionEvents(from, to time.Time, limit int) ([]events.EventFields, error) {
 	if err := a.action(defaults.Namespace, services.KindSession, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return a.alog.SearchSessionEvents(from, to)
+	return a.alog.SearchSessionEvents(from, to, limit)
 }
 
 // GetNamespaces returns a list of namespaces

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1705,13 +1705,14 @@ func (c *Client) GetSessionEvents(namespace string, sid session.ID, afterN int) 
 }
 
 // SearchEvents returns events that fit the criteria
-func (c *Client) SearchEvents(from, to time.Time, query string) ([]events.EventFields, error) {
+func (c *Client) SearchEvents(from, to time.Time, query string, limit int) ([]events.EventFields, error) {
 	q, err := url.ParseQuery(query)
 	if err != nil {
 		return nil, trace.BadParameter("query")
 	}
 	q.Set("from", from.Format(time.RFC3339))
 	q.Set("to", to.Format(time.RFC3339))
+	q.Set("limit", fmt.Sprintf("%v", limit))
 	response, err := c.Get(c.Endpoint("events"), q)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1724,10 +1725,11 @@ func (c *Client) SearchEvents(from, to time.Time, query string) ([]events.EventF
 }
 
 // SearchSessionEvents returns session related events to find completed sessions.
-func (c *Client) SearchSessionEvents(from, to time.Time) ([]events.EventFields, error) {
+func (c *Client) SearchSessionEvents(from, to time.Time, limit int) ([]events.EventFields, error) {
 	query := url.Values{
-		"to":   []string{to.Format(time.RFC3339)},
-		"from": []string{from.Format(time.RFC3339)},
+		"to":    []string{to.Format(time.RFC3339)},
+		"from":  []string{from.Format(time.RFC3339)},
+		"limit": []string{fmt.Sprintf("%v", limit)},
 	}
 
 	response, err := c.Get(c.Endpoint("events", "session"), query)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -349,14 +349,14 @@ func (s *TLSSuite) TestSharedSessions(c *check.C) {
 	// try searching for events with no filter (empty query) - should get all 3 events:
 	to := time.Now().In(time.UTC).Add(time.Hour)
 	from := to.Add(-time.Hour * 2)
-	history, err := clt.SearchEvents(from, to, "")
+	history, err := clt.SearchEvents(from, to, "", 0)
 	c.Assert(err, check.IsNil)
 	c.Assert(history, check.NotNil)
 	c.Assert(len(history), check.Equals, 3)
 
 	// try searching for only "session.end" events (real query)
 	history, err = clt.SearchEvents(from, to,
-		fmt.Sprintf("%s=%s", events.EventType, events.SessionEndEvent))
+		fmt.Sprintf("%s=%s", events.EventType, events.SessionEndEvent), 0)
 	c.Assert(err, check.IsNil)
 	c.Assert(history, check.NotNil)
 	c.Assert(len(history), check.Equals, 1)

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -127,6 +127,12 @@ const (
 	// MaxIterationLimit is max iteration limit
 	MaxIterationLimit = 1000
 
+	// EventsIterationLimit is a default limit if it's not set for events
+	EventsIterationLimit = 500
+
+	// EventsIterationLimit is max iteration limit for events
+	EventsMaxIterationLimit = 10000
+
 	// ActiveSessionTTL is a TTL when session is marked as inactive
 	ActiveSessionTTL = 30 * time.Second
 

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -174,11 +174,11 @@ type IAuditLog interface {
 	//
 	// The only mandatory requirement is a date range (UTC). Results must always
 	// show up sorted by date (newest first)
-	SearchEvents(fromUTC, toUTC time.Time, query string) ([]EventFields, error)
+	SearchEvents(fromUTC, toUTC time.Time, query string, limit int) ([]EventFields, error)
 
 	// SearchSessionEvents returns session related events only. This is used to
 	// find completed session.
-	SearchSessionEvents(fromUTC time.Time, toUTC time.Time) ([]EventFields, error)
+	SearchSessionEvents(fromUTC time.Time, toUTC time.Time, limit int) ([]EventFields, error)
 
 	// WaitForDelivery waits for resources to be released and outstanding requests to
 	// complete after calling Close method

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -40,9 +40,9 @@ func (d *DiscardAuditLog) GetSessionChunk(namespace string, sid session.ID, offs
 func (d *DiscardAuditLog) GetSessionEvents(namespace string, sid session.ID, after int) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }
-func (d *DiscardAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]EventFields, error) {
+func (d *DiscardAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string, limit int) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }
-func (d *DiscardAuditLog) SearchSessionEvents(fromUTC time.Time, toUTC time.Time) ([]EventFields, error) {
+func (d *DiscardAuditLog) SearchSessionEvents(fromUTC time.Time, toUTC time.Time, limit int) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }

--- a/lib/events/mock.go
+++ b/lib/events/mock.go
@@ -87,10 +87,10 @@ func (d *MockAuditLog) GetSessionEvents(namespace string, sid session.ID, after 
 	return make([]EventFields, 0), nil
 }
 
-func (d *MockAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string) ([]EventFields, error) {
+func (d *MockAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string, limit int) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }
 
-func (d *MockAuditLog) SearchSessionEvents(fromUTC, toUTC time.Time) ([]EventFields, error) {
+func (d *MockAuditLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }

--- a/lib/state/log.go
+++ b/lib/state/log.go
@@ -471,9 +471,9 @@ func (ll *CachingAuditLog) GetSessionChunk(string, session.ID, int, int) ([]byte
 func (ll *CachingAuditLog) GetSessionEvents(string, session.ID, int) ([]events.EventFields, error) {
 	return nil, errNotSupported
 }
-func (ll *CachingAuditLog) SearchEvents(time.Time, time.Time, string) ([]events.EventFields, error) {
+func (ll *CachingAuditLog) SearchEvents(time.Time, time.Time, string, int) ([]events.EventFields, error) {
 	return nil, errNotSupported
 }
-func (ll *CachingAuditLog) SearchSessionEvents(time.Time, time.Time) ([]events.EventFields, error) {
+func (ll *CachingAuditLog) SearchSessionEvents(time.Time, time.Time, int) ([]events.EventFields, error) {
 	return nil, errNotSupported
 }

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1643,7 +1643,7 @@ func (h *Handler) siteEventsGet(w http.ResponseWriter, r *http.Request, p httpro
 		}
 	}
 
-	el, err := clt.SearchSessionEvents(from, to)
+	el, err := clt.SearchSessionEvents(from, to, defaults.EventsIterationLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
SearchEvents and SearchSessionEvents set
default limits of fetched events of 500 up to 10K events
per interval.

No UI changes are required, as users will be able
to refine the search interval to fetch more sessions.