### PR TITLE
Introduce version checking and fix YAML lists

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -190,6 +190,10 @@ type Config struct {
 
 	// AuthConnector is the name of the authentication connector to use.
 	AuthConnector string
+
+	// CheckVersions will check that client version is compatible
+	// with auth server version when connecting.
+	CheckVersions bool
 }
 
 // CachePolicy defines cache policy for local clients
@@ -1043,6 +1047,12 @@ func (tc *TeleportClient) Login(activateKey bool) (*Key, error) {
 	pr, err := Ping(httpsProxyHostPort, tc.InsecureSkipVerify, certPool, tc.AuthConnector)
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	if tc.CheckVersions {
+		if err := utils.CheckVersions(teleport.Version, pr.ServerVersion); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// generate a new keypair. the public key will be signed via proxy if client's

--- a/lib/utils/ver.go
+++ b/lib/utils/ver.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"github.com/coreos/go-semver/semver"
+
+	"github.com/gravitational/trace"
+)
+
+// CheckVersions compares client and server versions
+// and makes sure they are compatible using Teleport convention
+func CheckVersions(clientVersion, serverVersion string) error {
+	clientSemver, err := semver.NewVersion(clientVersion)
+	if err != nil {
+		return trace.Wrap(err,
+			"unsupported version format, need semver format: %q, e.g 1.0.0", clientVersion)
+	}
+
+	serverSemver, err := semver.NewVersion(serverVersion)
+	if err != nil {
+		return trace.Wrap(err,
+			"unsupported version format, need semver format: %q, e.g 1.0.0", clientVersion)
+	}
+
+	// for now only do simple check that client is not newer version
+	// than server
+	switch {
+	case serverSemver.Major != clientSemver.Major:
+		return trace.BadParameter("client version %q is not compatible server version %q, please make client and server versions use the same major versions", clientVersion, serverVersion)
+	case serverSemver.LessThan(*clientSemver):
+		return trace.BadParameter("client version %q is newer than server version %q, please downgrade client or upgrade server", clientVersion, serverVersion)
+		// for now let's not enforce minor versions diff as it's too harsh
+	}
+
+	return nil
+}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -168,7 +168,11 @@ func (u *ResourceCommand) Create(client auth.ClientI) error {
 		if !found {
 			return trace.BadParameter("creating resources of type %q is not supported", raw.Kind)
 		}
-		return creator(client, raw)
+		// only return in case of error, to create multiple resources
+		// in case if yaml spec is a list
+		if err := creator(client, raw); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 }
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -123,6 +123,9 @@ type CLIConf struct {
 
 	// AuthConnector is the name of the connector to use.
 	AuthConnector string
+
+	// SkipVersionCheck skips version checking for client and server
+	SkipVersionCheck bool
 }
 
 func main() {
@@ -165,6 +168,7 @@ func Run(args []string, underTest bool) {
 	app.Flag("namespace", "Namespace of the cluster").Default(defaults.Namespace).Hidden().StringVar(&cf.Namespace)
 	app.Flag("gops", "Start gops endpoint on a given address").Hidden().BoolVar(&cf.Gops)
 	app.Flag("gops-addr", "Specify gops addr to listen on").Hidden().StringVar(&cf.GopsAddr)
+	app.Flag("skip-version-check", "Skip version checking between server and client.").Hidden().BoolVar(&cf.SkipVersionCheck)
 	debugMode := app.Flag("debug", "Verbose logging to stdout").Short('d').Bool()
 	app.HelpFlag.Short('h')
 	ver := app.Command("version", "Print the version")
@@ -618,6 +622,9 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 	if !cf.NoCache {
 		c.CachePolicy = &client.CachePolicy{}
 	}
+
+	// check version compatibility of the server and client
+	c.CheckVersions = !cf.SkipVersionCheck
 
 	// parse compatibility parameter
 	certificateFormat, err := parseCertificateCompatibilityFlag(cf.Compatibility, cf.CertificateFormat)


### PR DESCRIPTION
Fixes #1663, #1665

This commit fixes a couple of issues with tsh and tctl:

* tsh now check the version of the server and prints error
if tsh is newer version than the server.

* tctl did not work properly when yaml file contained
multiple resources in a list