### PR TITLE
Fix HTTP CONNECT response handling

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -108,6 +108,9 @@ const (
 	// for all proxies.
 	ComponentKeyStore = "keystore"
 
+	// ComponentConnectProxy is the HTTP CONNECT proxy used to tunnel connection.
+	ComponentConnectProxy = "http:proxy"
+
 	// DebugEnvVar tells tests to use verbose debug output
 	DebugEnvVar = "DEBUG"
 

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -796,7 +796,7 @@ type proxyServer struct {
 // the specified host. Also tracks the number of connections that it proxies for
 // debugging purposes.
 func (p *proxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// validate http connect parameters
+	// Validate http connect parameters.
 	if r.Method != http.MethodConnect {
 		trace.WriteError(w, trace.BadParameter("%v not supported", r.Method))
 		return
@@ -806,7 +806,20 @@ func (p *proxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// hijack request so we can get underlying connection
+	// Dial to the target host, this is done before hijacking the connection to
+	// ensure the target host is accessible.
+	dconn, err := net.Dial("tcp", r.Host)
+	if err != nil {
+		trace.WriteError(w, err)
+		return
+	}
+	defer dconn.Close()
+
+	// Once the client receives 200 OK, the rest of the data will no longer be
+	// http, but whatever protocol is being tunneled.
+	w.WriteHeader(http.StatusOK)
+
+	// Hijack request so we can get underlying connection.
 	hj, ok := w.(http.Hijacker)
 	if !ok {
 		trace.WriteError(w, trace.AccessDenied("unable to hijack connection"))
@@ -819,34 +832,12 @@ func (p *proxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer sconn.Close()
 
-	// dial to host we want to proxy connection to
-	dconn, err := net.Dial("tcp", r.Host)
-	if err != nil {
-		trace.WriteError(w, err)
-		return
-	}
-	defer dconn.Close()
-
-	// write 200 OK to the source, but don't close the connection
-	resp := &http.Response{
-		Status:     "OK",
-		StatusCode: 200,
-		Proto:      "HTTP/1.1",
-		ProtoMajor: 1,
-		ProtoMinor: 0,
-	}
-	err = resp.Write(sconn)
-	if err != nil {
-		trace.WriteError(w, err)
-		return
-	}
-
-	// success, we're proxying data now
+	// Success, we're proxying data now.
 	p.Lock()
 	p.count = p.count + 1
 	p.Unlock()
 
-	// copy from src to dst and dst to src
+	// Copy from src to dst and dst to src.
 	errc := make(chan error, 2)
 	replicate := func(dst io.Writer, src io.Reader) {
 		_, err := io.Copy(dst, src)
@@ -855,7 +846,7 @@ func (p *proxyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	go replicate(sconn, dconn)
 	go replicate(dconn, sconn)
 
-	// wait until done, error, or 10 second
+	// Wait until done, error, or 10 second.
 	select {
 	case <-time.After(10 * time.Second):
 	case <-errc:


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1659, the `TestTwoClustersProxy` test would intermittently fail with `two sites do not see each other: tunnels are not working`. Investigating further it appeared that the connection could not be established due to a failure in the SSH handshake: `ssh: handshake failed: ssh: overflow reading version string`.

Investigating the above revealed the true cause of the failure. Upon receipt of the response to the HTTP CONNECT request, `http.ReadResponse` is used to parse the status line. This function takes a buffered reader and as a side effect occasionally part of the body is read (and buffered) as well. This would mainly happen when the traffic being tunneled is copied over the connection before the response has been read from the connection.

Due to the above, part of the SSH handshake would be lost, leading to the handshake failing, leading the the inability of the connection to be established.

To resolve this issue, a internal `*bufferedConn` is used which first reads any buffered data, then reads from the underlying connection.

**Implementation**

* After parsing the HTTP CONNECT response, return a `*bufferedConn` which will first return any buffered data and then data from the connection.
* Changed the order of writing the response and hijacking the connection so the following logs are not written to stdout during integration tests:
    ```
    2018/02/08 16:51:13 http: response.WriteHeader on hijacked connection
    2018/02/08 16:51:13 http: response.Write on hijacked connection
    ```

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1659