### PR TITLE
Teleport signal handling and live reload.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,6 +1,7 @@
 package teleport
 
 import (
+	"strings"
 	"time"
 )
 
@@ -78,6 +79,9 @@ const (
 
 	// ComponentProxy is SSH proxy (SSH server forwarding connections)
 	ComponentProxy = "proxy"
+
+	// ComponentDiagnostic is a diagnostic service
+	ComponentDiagnostic = "diagnostic"
 
 	// ComponentTunClient is a tunnel client
 	ComponentTunClient = "client:tunnel"
@@ -200,6 +204,12 @@ const (
 	// Off means mode is off
 	Off = "off"
 )
+
+// Component generates "component:subcomponent1:subcomponent2" strings used
+// in debugging
+func Component(components ...string) string {
+	return strings.Join(components, ":")
+}
 
 const (
 	// AuthorizedKeys are public keys that check against User CAs.

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/boltbk"
+	"github.com/gravitational/teleport/lib/backend/dir"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -363,7 +363,7 @@ func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *servic
 	tconf.Proxy.WebAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortWeb())
 	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.SSHAddr)
 	tconf.Auth.StorageConfig = backend.Config{
-		Type:   boltbk.GetName(),
+		Type:   dir.GetName(),
 		Params: backend.Params{"path": dataDir},
 	}
 

--- a/lib/auth/tun.go
+++ b/lib/auth/tun.go
@@ -181,6 +181,14 @@ func (s *AuthTunnel) Close() error {
 	return nil
 }
 
+// Shutdown gracefully shuts down auth server
+func (s *AuthTunnel) Shutdown(ctx context.Context) error {
+	if s != nil && s.sshServer != nil {
+		return s.sshServer.Shutdown(ctx)
+	}
+	return nil
+}
+
 // HandleNewChan implements NewChanHandler interface: it gets called every time a new SSH
 // connection is established
 func (s *AuthTunnel) HandleNewChan(_ net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -75,15 +75,10 @@ type CommandLineFlags struct {
 
 	// --labels flag
 	Labels string
-	// --httpprofile hidden flag
-	HTTPProfileEndpoint bool
 	// --pid-file flag
 	PIDFile string
-	// Gops starts gops agent on a specified address
-	// if not specified, gops won't start
+	// Gops starts gops agent on a first available address
 	Gops bool
-	// GopsAddr specifies to gops addr to listen on
-	GopsAddr string
 	// DiagnosticAddr is listen address for diagnostic endpoint
 	DiagnosticAddr string
 	// PermitUserEnvironment enables reading of ~/.tsh/environment
@@ -664,6 +659,15 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 	}
 	if err = ApplyFileConfig(fileConf, cfg); err != nil {
 		return trace.Wrap(err)
+	}
+
+	// apply diangostic address flag
+	if clf.DiagnosticAddr != "" {
+		addr, err := utils.ParseAddr(clf.DiagnosticAddr)
+		if err != nil {
+			return trace.Wrap(err, "failed to parse diag-addr")
+		}
+		cfg.DiagnosticAddr = *addr
 	}
 
 	// apply --insecure-no-tls flag:

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -92,6 +92,9 @@ const (
 	// the SSH connection open if there are no reads/writes happening over it.
 	DefaultIdleConnectionDuration = 20 * time.Minute
 
+	// ShutdownPollPeriod is a polling period for graceful shutdowns of SSH servers
+	ShutdownPollPeriod = 500 * time.Millisecond
+
 	// ReadHeadersTimeout is a default TCP timeout when we wait
 	// for the response headers to arrive
 	ReadHeadersTimeout = time.Second

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reversetunnel
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -58,8 +59,10 @@ type Server interface {
 	RemoveSite(domainName string) error
 	// Start starts server
 	Start() error
-	// CLose closes server's socket
+	// Close closes server's operations immediately
 	Close() error
+	// Shutdown performs graceful server shutdown
+	Shutdown(context.Context) error
 	// Wait waits for server to close all outstanding operations
 	Wait()
 }

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -402,7 +402,7 @@ func (s *server) diffConns(newConns, existingConns map[string]services.TunnelCon
 }
 
 func (s *server) Wait() {
-	s.srv.Wait()
+	s.srv.Wait(context.TODO())
 }
 
 func (s *server) Start() error {
@@ -413,6 +413,11 @@ func (s *server) Start() error {
 func (s *server) Close() error {
 	s.cancel()
 	return s.srv.Close()
+}
+
+func (s *server) Shutdown(ctx context.Context) error {
+	s.cancel()
+	return s.srv.Shutdown(ctx)
 }
 
 func (s *server) HandleNewChan(conn net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -127,6 +127,9 @@ type Config struct {
 	// MACAlgorithms is a list of message authentication codes (MAC) that
 	// the server supports. If omitted the defaults will be used.
 	MACAlgorithms []string
+
+	// DiagnosticAddr is an address for diagnostic and healthz endpoint service
+	DiagnosticAddr utils.NetAddr
 }
 
 // ApplyToken assigns a given token to all internal services but only if token
@@ -202,12 +205,12 @@ func (c CachePolicy) String() string {
 		recentCachePolicy = fmt.Sprintf("will cache frequently accessed items for %v", c.GetRecentTTL())
 	}
 	if c.NeverExpires {
-		return fmt.Sprintf("cache will not expire in case if connection to database is lost, %v", recentCachePolicy)
+		return fmt.Sprintf("cache that will not expire in case if connection to database is lost, %v", recentCachePolicy)
 	}
 	if c.TTL == 0 {
-		return fmt.Sprintf("cache will expire after connection to database is lost after %v, %v", defaults.CacheTTL, recentCachePolicy)
+		return fmt.Sprintf("cache that will expire after connection to database is lost after %v, %v", defaults.CacheTTL, recentCachePolicy)
 	}
-	return fmt.Sprintf("cache will expire after connection to database is lost after %v, %v", c.TTL, recentCachePolicy)
+	return fmt.Sprintf("cache that will expire after connection to database is lost after %v, %v", c.TTL, recentCachePolicy)
 }
 
 // ProxyConfig configures proy service

--- a/lib/service/signals.go
+++ b/lib/service/signals.go
@@ -1,0 +1,348 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// printShutdownStatus prints running services until shut down
+func (process *TeleportProcess) printShutdownStatus(ctx context.Context) {
+	t := time.NewTicker(5 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			log.Infof("Waiting for services: %v to finish.", process.Supervisor.Services())
+		}
+	}
+}
+
+// WaitForSignals waits for system signals and processes them.
+// Should not be called twice by the process.
+func (process *TeleportProcess) WaitForSignals(ctx context.Context) error {
+	sigC := make(chan os.Signal, 1024)
+	signal.Notify(sigC, os.Interrupt, os.Kill, syscall.SIGTERM, syscall.SIGUSR2, syscall.SIGCHLD, syscall.SIGHUP)
+
+	doneContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Block until a signal is received or handler got an error.
+	// Notice how this handler is serialized - it will only receive
+	// signals in sequence and will not run in parallel.
+	for {
+		select {
+		case signal := <-sigC:
+			switch signal {
+			case syscall.SIGTERM, syscall.SIGINT:
+				go process.printShutdownStatus(doneContext)
+				process.Shutdown(ctx)
+				log.Infof("All services stopped, exiting.")
+				return nil
+			case syscall.SIGKILL, syscall.SIGQUIT:
+				log.Infof("Got signal %q, exiting immediately.", signal)
+				process.Close()
+				return nil
+			case syscall.SIGUSR2:
+				log.Infof("Got signal %q, forking a new process.", signal)
+				if err := process.forkChild(); err != nil {
+					log.Infof("Failed to fork: %s", trace.DebugReport(err))
+				} else {
+					log.Infof("Successfully started new process.")
+				}
+			case syscall.SIGHUP:
+				log.Infof("Got signal %q, performing graceful restart.", signal)
+				if err := process.forkChild(); err != nil {
+					log.Infof("Failed to fork: %s", trace.DebugReport(err))
+				} else {
+					log.Infof("Successfully started new process.")
+				}
+				log.Infof("Shutting down gracefully.")
+				go process.printShutdownStatus(doneContext)
+				process.Shutdown(ctx)
+				log.Infof("All services stopped, exiting.")
+				return nil
+			case syscall.SIGCHLD:
+				log.Debugf("Child exited, got %q, collecting status.", signal)
+				var wait syscall.WaitStatus
+				syscall.Wait4(-1, &wait, syscall.WNOHANG, nil)
+			default:
+				log.Infof("Ignoring %q.", signal)
+			}
+		case <-ctx.Done():
+			process.Close()
+			process.Wait()
+			log.Info("Got request to shutdown, context is closing")
+			return nil
+		}
+	}
+}
+
+// closeImportedDescriptors closes imported but unused file descriptors,
+// what could happen if service has updated configuration
+func (process *TeleportProcess) closeImportedDescriptors(prefix string) error {
+	process.Lock()
+	defer process.Unlock()
+
+	var errors []error
+	for i := range process.importedDescriptors {
+		d := process.importedDescriptors[i]
+		if strings.HasPrefix(d.Type, prefix) {
+			log.Infof("Closing imported but unused descriptor %v %v.", d.Type, d.Address)
+			errors = append(errors, d.File.Close())
+		}
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// importOrCreateListener imports listener passed by the parent process (happens during live reload)
+// or creates a new listener if there was no listener registered
+func (process *TeleportProcess) importOrCreateListener(listenerType, address string) (net.Listener, error) {
+	l, err := process.importListener(listenerType, address)
+	if err == nil {
+		log.Infof("Using file descriptor %v %v passed by the parent process.", listenerType, address)
+		return l, nil
+	}
+	if !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	log.Infof("Service %v is creating new listener on %v.", listenerType, address)
+	return process.createListener(listenerType, address)
+}
+
+// importListener imports listener passed by the parent process, if no listener is found
+// returns NotFound, otherwise removes the file from the list
+func (process *TeleportProcess) importListener(listenerType, address string) (net.Listener, error) {
+	process.Lock()
+	defer process.Unlock()
+
+	for i := range process.importedDescriptors {
+		d := process.importedDescriptors[i]
+		if d.Type == listenerType && d.Address == address {
+			l, err := d.ToListener()
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			process.importedDescriptors = append(process.importedDescriptors[:i], process.importedDescriptors[i+1:]...)
+			process.registeredListeners = append(process.registeredListeners, RegisteredListener{Type: listenerType, Address: address, Listener: l})
+			return l, nil
+		}
+	}
+
+	return nil, trace.NotFound("no file descriptor for type %v and address %v has been imported", listenerType, address)
+}
+
+// createListener creates listener and adds to a list of tracked listeners
+func (process *TeleportProcess) createListener(listenerType, address string) (net.Listener, error) {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	process.Lock()
+	defer process.Unlock()
+	r := RegisteredListener{Type: listenerType, Address: address, Listener: listener}
+	process.registeredListeners = append(process.registeredListeners, r)
+	return listener, nil
+}
+
+// exportFileDescriptors exports file descriptors to be passed to child process
+func (process *TeleportProcess) exportFileDescriptors() ([]FileDescriptor, error) {
+	var out []FileDescriptor
+	process.Lock()
+	defer process.Unlock()
+	for _, r := range process.registeredListeners {
+		file, err := utils.GetListenerFile(r.Listener)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		out = append(out, FileDescriptor{File: file, Type: r.Type, Address: r.Address})
+	}
+	return out, nil
+}
+
+// importFileDescriptors imports file descriptors from environment if there are any
+func importFileDescriptors() ([]FileDescriptor, error) {
+	// These files may be passed in by the parent process
+	filesString := os.Getenv(teleportFilesEnvVar)
+	if filesString == "" {
+		return nil, nil
+	}
+
+	files, err := filesFromString(filesString)
+	if err != nil {
+		return nil, trace.BadParameter("child process has failed to read files, error %q", err)
+	}
+
+	if len(files) != 0 {
+		log.Infof("Child has been passed files: %v", files)
+	}
+
+	return files, nil
+}
+
+// RegisteredListener is a listener registered
+// within teleport process, can be passed to child process
+type RegisteredListener struct {
+	// Type is a listener type, e.g. auth:ssh
+	Type string
+	// Address is an address listener is serving on, e.g. 127.0.0.1:3025
+	Address string
+	// Listener is a file listener object
+	Listener net.Listener
+}
+
+// FileDescriptor is a file descriptor associated
+// with a listener
+type FileDescriptor struct {
+	// Type is a listener type, e.g. auth:ssh
+	Type string
+	// Address is an addresss of the listener, e.g. 127.0.0.1:3025
+	Address string
+	// File is a file descriptor associated with the listener
+	File *os.File
+}
+
+func (fd *FileDescriptor) ToListener() (net.Listener, error) {
+	listener, err := net.FileListener(fd.File)
+	if err != nil {
+		return nil, err
+	}
+	fd.File.Close()
+	return listener, nil
+}
+
+type fileDescriptor struct {
+	Address  string `json:"addr"`
+	Type     string `json:"type"`
+	FileFD   int    `json:"fd"`
+	FileName string `json:"fileName"`
+}
+
+// filesToString serializes file descriptors as well as accompanying information (like socket host and port)
+func filesToString(files []FileDescriptor) (string, error) {
+	out := make([]fileDescriptor, len(files))
+	for i, f := range files {
+		out[i] = fileDescriptor{
+			// Once files will be passed to the child process and their FDs will change.
+			// The first three passed files are stdin, stdout and stderr, every next file will have the index + 3
+			// That's why we rearrange the FDs for child processes to get the correct file descriptors.
+			FileFD:   i + 3,
+			FileName: f.File.Name(),
+			Address:  f.Address,
+			Type:     f.Type,
+		}
+	}
+	bytes, err := json.Marshal(out)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+const teleportFilesEnvVar = "TELEPORT_OS_FILES"
+
+func execPath() (string, error) {
+	name, err := exec.LookPath(os.Args[0])
+	if err != nil {
+		return "", err
+	}
+	if _, err = os.Stat(name); nil != err {
+		return "", err
+	}
+	return name, err
+}
+
+// filesFromString de-serializes the file descriptors and turns them in the os.Files
+func filesFromString(in string) ([]FileDescriptor, error) {
+	var out []fileDescriptor
+	if err := json.Unmarshal([]byte(in), &out); err != nil {
+		return nil, err
+	}
+	files := make([]FileDescriptor, len(out))
+	for i, o := range out {
+		files[i] = FileDescriptor{
+			File:    os.NewFile(uintptr(o.FileFD), o.FileName),
+			Address: o.Address,
+			Type:    o.Type,
+		}
+	}
+	return files, nil
+}
+
+func (process *TeleportProcess) forkChild() error {
+	path, err := execPath()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	workingDir, err := os.Getwd()
+	if nil != err {
+		return err
+	}
+
+	log := log.WithFields(logrus.Fields{"path": path, "workingDir": workingDir})
+
+	log.Info("Forking child.")
+
+	listenerFiles, err := process.exportFileDescriptors()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// These files will be passed to the child process
+	files := []*os.File{os.Stdin, os.Stdout, os.Stderr}
+	for _, f := range listenerFiles {
+		files = append(files, f.File)
+	}
+
+	// Serialize files to JSON string representation
+	vals, err := filesToString(listenerFiles)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Passing %s to child", vals)
+	os.Setenv(teleportFilesEnvVar, vals)
+
+	p, err := os.StartProcess(path, os.Args, &os.ProcAttr{
+		Dir:   workingDir,
+		Env:   os.Environ(),
+		Files: files,
+		Sys:   &syscall.SysProcAttr{},
+	})
+
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	log.WithFields(logrus.Fields{"pid": p.Pid}).Infof("Started new child process.")
+	return nil
+}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -195,7 +195,7 @@ func (s *PresenceService) GetNodes(namespace string) ([]services.Server, error) 
 		}
 		servers = append(servers, server)
 	}
-	s.Infof("GetServers(%v) in %v", len(servers), time.Now().Sub(start))
+	s.Debugf("GetServers(%v) in %v", len(servers), time.Now().Sub(start))
 	// sorting helps with tests and makes it all deterministic
 	sort.Sort(services.SortedServers(servers))
 	return servers, nil
@@ -218,7 +218,7 @@ func (s *PresenceService) batchGetNodes(namespace string) ([]services.Server, er
 		servers[i] = server
 	}
 
-	s.Infof("GetServers(%v) in %v", len(servers), time.Now().Sub(start))
+	s.Debugf("GetServers(%v) in %v", len(servers), time.Now().Sub(start))
 	// sorting helps with tests and makes it all deterministic
 	sort.Sort(services.SortedServers(servers))
 	return servers, nil

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gravitational/teleport"
@@ -67,6 +68,11 @@ type Server struct {
 
 	closeContext context.Context
 	closeFunc    context.CancelFunc
+
+	// conns tracks amount of current active connections
+	conns int32
+	// shutdownPollPeriod sets polling period for shutdown
+	shutdownPollPeriod time.Duration
 }
 
 const (
@@ -96,6 +102,14 @@ type ServerOption func(cfg *Server) error
 func SetLimiter(limiter *limiter.Limiter) ServerOption {
 	return func(s *Server) error {
 		s.limiter = limiter
+		return nil
+	}
+}
+
+// SetShutdownPollPeriod sets a polling period for graceful shutdowns of SSH servers
+func SetShutdownPollPeriod(period time.Duration) ServerOption {
+	return func(s *Server) error {
+		s.shutdownPollPeriod = period
 		return nil
 	}
 }
@@ -134,6 +148,10 @@ func NewServer(
 			return nil, err
 		}
 	}
+	if s.shutdownPollPeriod == 0 {
+		s.shutdownPollPeriod = defaults.ShutdownPollPeriod
+	}
+
 	for _, signer := range hostSigners {
 		(&s.cfg).AddHostKey(signer)
 	}
@@ -234,8 +252,43 @@ func (s *Server) setListener(l net.Listener) error {
 
 // Wait waits until server stops serving new connections
 // on the listener socket
-func (s *Server) Wait() {
-	<-s.closeContext.Done()
+func (s *Server) Wait(ctx context.Context) {
+	select {
+	case <-s.closeContext.Done():
+	case <-ctx.Done():
+	}
+}
+
+// Shutdown initiates graceful shutdown - waiting until all active
+// connections will get closed
+func (s *Server) Shutdown(ctx context.Context) error {
+	// close listener to stop receiving new connections
+	err := s.Close()
+	s.Wait(ctx)
+	activeConnections := s.trackConnections(0)
+	if activeConnections == 0 {
+		return err
+	}
+	s.Infof("Shutdown: waiting for %v connections to finish.", activeConnections)
+	lastReport := time.Time{}
+	ticker := time.NewTicker(s.shutdownPollPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			activeConnections = s.trackConnections(0)
+			if activeConnections == 0 {
+				return err
+			}
+			if time.Now().Sub(lastReport) > 10*s.shutdownPollPeriod {
+				s.Infof("Shutdown: waiting for %v connections to finish.", activeConnections)
+				lastReport = time.Now()
+			}
+		case <-ctx.Done():
+			s.Infof("Context cancelled wait, returning")
+			return trace.ConnectionProblem(err, "context cancelled")
+		}
+	}
 }
 
 // Close closes listening socket and stops accepting connections
@@ -282,6 +335,10 @@ func (s *Server) acceptConnections() {
 	}
 }
 
+func (s *Server) trackConnections(delta int32) int32 {
+	return atomic.AddInt32(&s.conns, delta)
+}
+
 // handleConnection is called every time an SSH server accepts a new
 // connection from a client.
 //
@@ -289,6 +346,8 @@ func (s *Server) acceptConnections() {
 // and proxies, proxies and servers, servers and auth, etc).
 //
 func (s *Server) handleConnection(conn net.Conn) {
+	s.trackConnections(1)
+	defer s.trackConnections(-1)
 	// initiate an SSH connection, note that we don't need to close the conn here
 	// in case of error as ssh server takes care of this
 	remoteAddr, _, err := net.SplitHostPort(conn.RemoteAddr().String())

--- a/lib/system/signal.go
+++ b/lib/system/signal.go
@@ -1,4 +1,4 @@
-package utils
+package system
 
 /*
 #include <signal.h>

--- a/lib/utils/addr.go
+++ b/lib/utils/addr.go
@@ -129,6 +129,8 @@ func ParseAddr(a string) (*NetAddr, error) {
 		return &NetAddr{Addr: u.Host, AddrNetwork: u.Scheme, Path: u.Path}, nil
 	case "unix":
 		return &NetAddr{Addr: u.Path, AddrNetwork: u.Scheme}, nil
+	case "http", "https":
+		return &NetAddr{Addr: u.Host, AddrNetwork: u.Scheme, Path: u.Path}, nil
 	default:
 		return nil, trace.BadParameter("'%v': unsupported scheme: '%v'", a, u.Scheme)
 	}

--- a/lib/utils/addr_test.go
+++ b/lib/utils/addr_test.go
@@ -66,6 +66,16 @@ func (s *AddrTestSuite) TestParse(c *C) {
 	c.Assert(addr.IsEmpty(), Equals, false)
 }
 
+func (s *AddrTestSuite) TestParseHTTP(c *C) {
+	addr, err := ParseAddr("http://one:25/path")
+	c.Assert(err, IsNil)
+	c.Assert(addr, NotNil)
+	c.Assert(addr.Addr, Equals, "one:25")
+	c.Assert(addr.Path, Equals, "/path")
+	c.Assert(addr.FullAddress(), Equals, "http://one:25")
+	c.Assert(addr.IsEmpty(), Equals, false)
+}
+
 func (s *AddrTestSuite) TestParseDefaults(c *C) {
 	addr, err := ParseAddr("host:25")
 	c.Assert(err, IsNil)

--- a/lib/utils/listener.go
+++ b/lib/utils/listener.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"net"
+	"os"
+
+	"github.com/gravitational/trace"
+)
+
+// GetListenerFile returns file associated with listener
+func GetListenerFile(listener net.Listener) (*os.File, error) {
+	switch t := listener.(type) {
+	case *net.TCPListener:
+		return t.File()
+	case *net.UnixListener:
+		return t.File()
+	}
+	return nil, trace.BadParameter("unsupported listener: %T", listener)
+}

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -79,7 +79,6 @@ func CreateTLSConfiguration(certFile, keyFile string) (*tls.Config, error) {
 		return nil, trace.BadParameter("certificate is not accessible by '%v'", certFile)
 	}
 
-	log.Infof("[PROXY] TLS cert=%v key=%v", certFile, keyFile)
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -681,7 +681,6 @@ func (s *sessionCache) ValidateSession(user, sid string) (*SessionContext, error
 		// this means that someone has just inserted the context, so
 		// close our extra context and return
 		if trace.IsAlreadyExists(err) {
-			log.Infof("just created, returning the existing one")
 			defer c.Close()
 			return out, nil
 		}

--- a/lib/web/stream.go
+++ b/lib/web/stream.go
@@ -95,7 +95,9 @@ func (w *sessionStreamHandler) stream(ws *websocket.Conn) error {
 		// ask for any events than happened since the last call:
 		re, err := clt.GetSessionEvents(w.namespace, w.sessionID, eventsCursor+1)
 		if err != nil {
-			log.Error(err)
+			if !trace.IsNotFound(err) {
+				log.Error(err)
+			}
 			return emptyEventList
 		}
 		batchLen := len(re)


### PR DESCRIPTION
This commit introduces signal handling.
Parent teleport process is now capable of forking
the child process and passing listeners file descriptors
to the child.

Parent process then can gracefully shutdown
by tracking the amount of current connections and
closing listeners once the amount goes to 0.

Here are the signals handled:

* USR2 signal will cause the parent to fork
a child process and pass listener file descriptors to it.
Child process will close unused file descriptors
and will bind to the used ones.

At this moment two processes - the parent
and the forked child process will be serving requests.
After looking at the traffic and the log files,
administrator can either shut down the parent process
or the child process if the child process is not functioning
as expected.

* TERM, INT signals will trigger graceful process shutdown.
Auth, node and proxy processes will wait until the amount
of active connections goes down to 0 and will exit after that.

* KILL, QUIT signals will cause immediate non-graceful
shutdown.

* HUP signal combines USR2 and TERM signals in a convenient
way: parent process will fork a child process and
self-initate graceful shutdown. This is a more convenient
than USR2/TERM sequence, but less agile and robust
as if the connection to the parent process drops, but
the new process exits with error, administrators
can lock themselves out of the environment.

Additionally, boltdb backend has to be phased out,
as it does not support read/writes by two concurrent
processes. This had required refactoring of the dir
backend to use file locking to allow inter-process
collaboration on read/write operations.