### PR TITLE
Fix TestTwoClusters

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -717,7 +717,7 @@ func (s *IntSuite) TestTwoClusters(c *check.C) {
 		// "site-A" and "site-B" reverse tunnels are supposed to reconnect,
 		// and 'tc' (client) is also supposed to reconnect
 		for i := 0; i < 10; i++ {
-			time.Sleep(time.Millisecond * 5)
+			time.Sleep(250 * time.Millisecond)
 			err = tc.SSH(context.TODO(), cmd, false)
 			if err == nil {
 				break


### PR DESCRIPTION
**Purpose**

Increase timeout while waiting for clusters to see each other. Also consolidated and improved the `startAndWait` function.

**Implementation**

* Increased delay in waiting for the two clusters too see each other.
* Consolidated `startAndWait` and improved logging.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1678