### PR TITLE
Update Signup URL

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2024,8 +2024,8 @@ func ok() interface{} {
 
 // CreateSignupLink generates and returns a URL which is given to a new
 // user to complete registration with Teleport via Web UI
-func CreateSignupLink(hostPort string, token string) string {
-	return "https://" + hostPort + "/web/newuser/" + token
+func CreateSignupLink(token string) string {
+	return "https://<proxyhost>/web/newuser/" + token
 }
 
 type responseData struct {

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -18,8 +18,6 @@ package common
 
 import (
 	"fmt"
-	"net"
-	"strconv"
 	"strings"
 	"time"
 
@@ -115,23 +113,11 @@ func (u *UserCommand) Add(client auth.ClientI) error {
 }
 
 func (u *UserCommand) PrintSignupURL(client auth.ClientI, token string, ttl time.Duration) {
-	hostname := "your.teleport.proxy"
+	url := web.CreateSignupLink(token)
 
-	proxies, err := client.GetProxies()
-	if err == nil {
-		if len(proxies) == 0 {
-			fmt.Printf("\x1b[1mWARNING\x1b[0m: this Teleport cluster does not have any proxy servers online.\nYou need to start some to be able to login.\n\n")
-		} else {
-			hostname = proxies[0].GetHostname()
-		}
-	}
-	_, proxyPort, err := net.SplitHostPort(u.config.Proxy.WebAddr.Addr)
-	if err != nil {
-		proxyPort = strconv.Itoa(defaults.HTTPListenPort)
-	}
-	url := web.CreateSignupLink(net.JoinHostPort(hostname, proxyPort), token)
-	fmt.Printf("Signup token has been created and is valid for %v hours. Share this URL with the user:\n%v\n\nNOTE: make sure '%s' is accessible!\n",
-		int(ttl/time.Hour), url, hostname)
+	fmt.Printf("Signup token has been created and is valid for %v hours. Share this URL with the user:\n%v\n\n",
+		int(ttl/time.Hour), url)
+	fmt.Printf("NOTE: Make sure <proxyhost> points at a Teleport proxy which users can access.\n")
 }
 
 // Update updates existing user


### PR DESCRIPTION
**Purpose**

To better support HA configurations instead of trying to find out which proxy the user should connect to, print `<proxyhost>` and tell the user to make sure the proxy is accessible.

**Implementation**

* Changed the signup message.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1643