### PR TITLE
Fix several issues with audit events.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   one:
     image: teleport:latest
     container_name: one
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one.yaml --gops --gops-addr=127.0.0.1:4321
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one.yaml --gops
     mem_limit: 300m
     memswap_limit: 0
     ports:
@@ -29,7 +29,7 @@ services:
   one-node:
     image: teleport:latest
     container_name: one-node
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one-node.yaml --gops --gops-addr=127.0.0.1:4321
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one-node.yaml --gops
     env_file: env.file
     mem_limit: 300m
     volumes:
@@ -45,7 +45,7 @@ services:
   one-proxy:
     image: teleport:latest
     container_name: one-proxy
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one-proxy.yaml --gops --gops-addr=127.0.0.1:4321
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one-proxy.yaml --gops
     mem_limit: 300m
     ports:
       - "4080:3080"
@@ -67,7 +67,7 @@ services:
     mem_limit: 300m
     image: teleport:latest
     container_name: two-auth
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-auth.yaml --insecure --gops --gops-addr=127.0.0.1:4321
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-auth.yaml --insecure --gops
     env_file: env.file
     volumes:
       - ./data/two/auth:/var/lib/teleport
@@ -83,7 +83,7 @@ services:
     mem_limit: 300m
     image: teleport:latest
     container_name: two-proxy
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-proxy.yaml --gops --gops-addr=127.0.0.1:4321
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-proxy.yaml --gops
     env_file: env.file
     ports:
       - "5080:5080"
@@ -102,7 +102,7 @@ services:
     mem_limit: 300m
     image: teleport:latest
     container_name: two-node
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-node.yaml --gops --gops-addr=127.0.0.1:4321
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-node.yaml --gops
     env_file: env.file
     volumes:
       - ./data/two/node:/var/lib/teleport

--- a/examples/aws/terraform/ansible/upgrade.yaml
+++ b/examples/aws/terraform/ansible/upgrade.yaml
@@ -20,24 +20,46 @@
 
     - include: vars.yaml
 
-    - name: Download and unpack new version of teleport
-      get_url:
-        url: https://get.gravitational.com/teleport/{{teleport_version}}/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
-        dest: /tmp/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
-    - name: Unpack teleport binaries
-      unarchive:
-        extra_opts: ['--strip-components=1', '--show-stored-names']
-        exclude:
-          - "examples/*"
-          - "README.md"
-          - "VERSION"
-          - "INSTALL"
-          - "CHANGELOG"
-        src: /tmp/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
-        dest: /usr/local/bin
-        remote_src: yes
-        owner: "{{ 'root' if 'node' in group_names else 'teleport' }}"
-        group: "{{ 'root' if 'node' in group_names else 'teleport' }}"
+    - name: Copy gops to target box (for debugging)
+      when: gops_path is defined
+      block:
+      - copy:
+          src: "{{gops_path}}"
+          dest: /usr/local/bin
+          mode: 0755
+
+    - name: Copy binaries from local directory
+      when: teleport_path is defined
+      block:
+      - copy:
+          src: "{{teleport_path}}/teleport"
+          dest: /usr/local/bin
+
+      - copy:
+          src: "{{teleport_path}}/tctl"
+          dest: /usr/local/bin
+
+    - name: Copy binaries from official repository
+      when: teleport_version is defined
+      block:
+      - name: Download and unpack new version of teleport
+        get_url:
+          url: https://get.gravitational.com/teleport/{{teleport_version}}/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
+          dest: /tmp/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
+      - name: Unpack teleport binaries
+        unarchive:
+          extra_opts: ['--strip-components=1', '--show-stored-names']
+          exclude:
+            - "examples/*"
+            - "README.md"
+            - "VERSION"
+            - "INSTALL"
+            - "CHANGELOG"
+          src: /tmp/teleport-ent-v{{teleport_version}}-linux-amd64-bin.tar.gz
+          dest: /usr/local/bin
+          remote_src: yes
+          owner: "{{ 'root' if 'node' in group_names else 'teleport' }}"
+          group: "{{ 'root' if 'node' in group_names else 'teleport' }}"
 
 
 # Scale down all auth servers but the first one

--- a/examples/aws/terraform/ansible/vars.yaml
+++ b/examples/aws/terraform/ansible/vars.yaml
@@ -2,6 +2,6 @@
 
 - name: Check if teleport_version is specified
   fail:
-    msg: "No teleport_version is specified"
-  when: teleport_version == ""
+    msg: "No teleport_version or teleport_path is specified"
+  when: teleport_version is not defined and teleport_path is not defined
 

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -397,7 +397,6 @@ func removeDuplicates(elements []record) []record {
 
 // GetItems is a function that retuns keys in batch
 func (b *DynamoDBBackend) GetItems(path []string) ([]backend.Item, error) {
-	start := time.Now()
 	fullPath := b.fullPath(path...)
 	records, err := b.getRecords(fullPath)
 	if err != nil {
@@ -410,14 +409,11 @@ func (b *DynamoDBBackend) GetItems(path []string) ([]backend.Item, error) {
 			Value: r.Value,
 		}
 	}
-	b.Debugf("GetItems(%v) in %v", fullPath, time.Now().Sub(start))
 	return values, nil
 }
 
 // GetKeys retrieve all keys matching specific path
 func (b *DynamoDBBackend) GetKeys(path []string) ([]string, error) {
-	start := time.Now()
-	fullPath := b.fullPath(path...)
 	records, err := b.getRecords(b.fullPath(path...))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -426,7 +422,6 @@ func (b *DynamoDBBackend) GetKeys(path []string) ([]string, error) {
 	for i, r := range records {
 		keys[i] = r.key
 	}
-	b.Debugf("GetKeys(%v) in %v", fullPath, time.Now().Sub(start))
 	return keys, nil
 }
 
@@ -435,7 +430,6 @@ func (b *DynamoDBBackend) GetKeys(path []string) ([]string, error) {
 // 	   overwrites it if 'overwrite' is true
 //     atomically returns AlreadyExists error if 'overwrite' is false
 func (b *DynamoDBBackend) createKey(fullPath string, val []byte, ttl time.Duration, overwrite bool) error {
-	start := time.Now()
 	r := record{
 		HashKey:   hashKey,
 		FullPath:  fullPath,
@@ -459,7 +453,6 @@ func (b *DynamoDBBackend) createKey(fullPath string, val []byte, ttl time.Durati
 	}
 	_, err = b.svc.PutItem(&input)
 	err = convertError(err)
-	b.Debugf("CreateVal(%v) in %v", fullPath, time.Now().Sub(start))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -611,13 +604,11 @@ func (b *DynamoDBBackend) getKey(fullPath string) (*record, error) {
 
 // GetVal retrieve a value from a key
 func (b *DynamoDBBackend) GetVal(path []string, key string) ([]byte, error) {
-	start := time.Now()
 	fullPath := b.fullPath(append(path, key)...)
 	r, err := b.getKey(fullPath)
 	if err != nil {
 		return nil, err
 	}
-	b.Debugf("GetVal(%v) in %v", fullPath, time.Now().Sub(start))
 	return r.Value, nil
 }
 

--- a/lib/state/cachingaccesspoint.go
+++ b/lib/state/cachingaccesspoint.go
@@ -773,11 +773,9 @@ func (cs *CachingAuthClient) useCache(p params) error {
 // using auth server
 func (cs *CachingAuthClient) fetch(p params) {
 	if cs.getRecentCache(p.key) {
-		cs.WithFields(log.Fields{"key": p.key}).Debugf("Recent cache hit.")
 		cs.useCache(p)
 		return
 	}
-	cs.WithFields(log.Fields{"key": p.key}).Debugf("Recent cache miss.")
 	// try fetching value from the auth server
 	err := cs.try(p.fetch)
 	if err == nil {

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -177,7 +177,7 @@ func ReadHostUUID(dataDir string) (string, error) {
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	return string(out), nil
+	return strings.TrimSpace(string(out)), nil
 }
 
 // WriteHostUUID writes host UUID into a file

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -17,8 +17,12 @@ limitations under the License.
 package utils
 
 import (
-	"gopkg.in/check.v1"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
 	"time"
+
+	"gopkg.in/check.v1"
 
 	"github.com/gravitational/trace"
 )
@@ -43,6 +47,15 @@ func (s *UtilsSuite) TestHostUUID(c *check.C) {
 	c.Assert(err, check.NotNil)
 	c.Assert(uuid, check.Equals, "")
 	c.Assert(err.Error(), check.Matches, "^.*no such file or directory.*$")
+
+	// newlines are getting ignored
+	dir = c.MkDir()
+	id := "id-with-newline\n"
+	err = ioutil.WriteFile(filepath.Join(dir, HostUUIDFile), []byte(id), 0666)
+	c.Assert(err, check.IsNil)
+	out, err := ReadHostUUID(dir)
+	c.Assert(err, check.IsNil)
+	c.Assert(out, check.Equals, strings.TrimSpace(id))
 }
 
 func (s *UtilsSuite) TestSelfSignedCert(c *check.C) {


### PR DESCRIPTION
1. Fixes several cosmetic issues with logs:

Fixes #1690, fixes #1687

2. Fixes deadlocks that were revealed during stress
testing on slow encrypted EFS system.

The following deadlock scenario was happening:

Goroutine 1:

t1. auditlock.Lock <- success
t3. diskSessionLogger.Lock <- blocked

Gorotuine 2:

t2. diskSessionLogger.Lock <- success
t4. auditLock.Lock  <- blocked

3. Update ansible upgrade scripts
to support custom binary upgrades.

4. Fix docker flow by removing deprecated
--gops-addr flag

5. Remove verbose logging lines.

6. Reduce compression efficiency to
reduce large memory load.