### PR TITLE
FIX 1693: SOCKS5 dynamic port forwarding

### DIFF
--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -157,3 +157,46 @@ func (s *APITestSuite) TestPortsParsing(c *check.C) {
 	c.Assert(ports, check.IsNil)
 	c.Assert(err, check.ErrorMatches, "^Invalid port forwarding spec: .foo.*")
 }
+
+func (s *APITestSuite) TestDynamicPortsParsing(c *check.C) {
+	// empty:
+	ports, err := ParseDynamicPortForwardSpec(nil)
+	c.Assert(ports, check.IsNil)
+	c.Assert(err, check.IsNil)
+	ports, err = ParseDynamicPortForwardSpec([]string{})
+	c.Assert(ports, check.IsNil)
+	c.Assert(err, check.IsNil)
+	// not empty (but valid)
+	spec := []string{
+		"8080",
+		":8080",
+		"10.0.10.1:8080",
+	}
+	ports, err = ParseDynamicPortForwardSpec(spec)
+	c.Assert(err, check.IsNil)
+	c.Assert(ports, check.HasLen, len(spec))
+	c.Assert(ports, check.DeepEquals, DynamicForwardedPorts{
+		{
+			SrcIP:   "127.0.0.1",
+			SrcPort: 8080,
+		},
+		{
+			SrcIP:   "",
+			SrcPort: 8080,
+		},
+		{
+			SrcIP:   "10.0.10.1",
+			SrcPort: 8080,
+		},
+	})
+	// back to strings:
+	clone := ports.ToStringSpec()
+	c.Assert(spec[0], check.Equals, clone[0])
+	c.Assert(spec[1], check.Equals, clone[1])
+
+	// parse invalid spec:
+	spec = []string{"foo", "bar"}
+	ports, err = ParseDynamicPortForwardSpec(spec)
+	c.Assert(ports, check.IsNil)
+	c.Assert(err, check.ErrorMatches, "^Invalid dynamic port forwarding spec: .foo.*")
+}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -20,7 +20,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net"
@@ -548,49 +550,50 @@ func (client *NodeClient) scp(scpCommand scp.Command, shellCmd string, errWriter
 	return trace.Wrap(err)
 }
 
+func proxyConnection(client *NodeClient, incoming net.Conn, remoteAddr string) {
+	defer incoming.Close()
+	var (
+		conn net.Conn
+		err  error
+	)
+	log.Debugf("nodeClient.proxyConnection(%v -> %v) started", incoming.RemoteAddr(), remoteAddr)
+	for attempt := 1; attempt <= 5; attempt++ {
+		conn, err = client.Client.Dial("tcp", remoteAddr)
+		if err != nil {
+			log.Errorf("Connection attempt %v: %v", attempt, err)
+			// failed to establish an outbound connection? try again:
+			time.Sleep(time.Millisecond * time.Duration(100*attempt))
+			continue
+		}
+		// connection established: continue:
+		break
+	}
+	// permanent failure establishing connection
+	if err != nil {
+		log.Errorf("Failed to connect to node %v", remoteAddr)
+		return
+	}
+	defer conn.Close()
+	// start proxying:
+	doneC := make(chan interface{}, 2)
+	go func() {
+		io.Copy(incoming, conn)
+		doneC <- true
+	}()
+	go func() {
+		io.Copy(conn, incoming)
+		doneC <- true
+	}()
+	<-doneC
+	<-doneC
+	log.Debugf("nodeClient.proxyConnection(%v -> %v) exited", incoming.RemoteAddr(), remoteAddr)
+}
+
 // listenAndForward listens on a given socket and forwards all incoming connections
 // to the given remote address via
 func (client *NodeClient) listenAndForward(socket net.Listener, remoteAddr string) {
 	defer socket.Close()
 	defer client.Close()
-	proxyConnection := func(incoming net.Conn) {
-		defer incoming.Close()
-		var (
-			conn net.Conn
-			err  error
-		)
-		log.Debugf("nodeClient.listenAndForward(%v -> %v) started", incoming.RemoteAddr(), remoteAddr)
-		for attempt := 1; attempt <= 5; attempt++ {
-			conn, err = client.Client.Dial("tcp", remoteAddr)
-			if err != nil {
-				log.Errorf("Connection attempt %v: %v", attempt, err)
-				// failed to establish an outbound connection? try again:
-				time.Sleep(time.Millisecond * time.Duration(100*attempt))
-				continue
-			}
-			// connection established: continue:
-			break
-		}
-		// permanent failure establishing connection
-		if err != nil {
-			log.Errorf("Failed to connect to node %v", remoteAddr)
-			return
-		}
-		defer conn.Close()
-		// start proxying:
-		doneC := make(chan interface{}, 2)
-		go func() {
-			io.Copy(incoming, conn)
-			doneC <- true
-		}()
-		go func() {
-			io.Copy(conn, incoming)
-			doneC <- true
-		}()
-		<-doneC
-		<-doneC
-		log.Debugf("nodeClient.listenAndForward(%v -> %v) exited", incoming.RemoteAddr(), remoteAddr)
-	}
 	// request processing loop: accept incoming requests to be connected to nodes
 	// and proxy them to 'remoteAddr'
 	for {
@@ -599,7 +602,169 @@ func (client *NodeClient) listenAndForward(socket net.Listener, remoteAddr strin
 			log.Error(err)
 			break
 		}
-		go proxyConnection(incoming)
+		go proxyConnection(client, incoming, remoteAddr)
+	}
+}
+
+func readByte(reader io.Reader) (byte, error) {
+	buf := []byte{0}
+	_, err := io.ReadFull(reader, buf)
+	return buf[0], err
+}
+
+const (
+	socks4Version                 byte = 0x04
+	socks5Version                 byte = 0x05
+	socks5Reserved                byte = 0x00
+	socks5AuthNotRequired         byte = 0x00
+	socks5AuthNoAcceptableMethods byte = 0xFF
+	socks5CommandConnect          byte = 0x01
+	socks5AddressTypeIPv4         byte = 0x01
+	socks5AddressTypeDomainName   byte = 0x03
+	socks5AddressTypeIPv6         byte = 0x04
+	socks5Succeeded               byte = 0x00
+)
+
+func socks5ProxyAuthenticate(incoming net.Conn) error {
+	nmethods, err := readByte(incoming)
+	if err != nil {
+		return err
+	}
+
+	chosenMethod := socks5AuthNoAcceptableMethods
+	for i := byte(0); i < nmethods; i++ {
+		method, err := readByte(incoming)
+		if err != nil {
+			return err
+		}
+		if method == socks5AuthNotRequired {
+			chosenMethod = socks5AuthNotRequired
+		}
+	}
+
+	_, err = incoming.Write([]byte{socks5Version, chosenMethod})
+	if err != nil {
+		return err
+	}
+
+	if chosenMethod == socks5AuthNoAcceptableMethods {
+		return errors.New("Unable to find suitable authentication method")
+	}
+
+	return nil
+}
+
+func socks5ProxyConnectRequest(incoming net.Conn) (remoteAddr string, err error) {
+	header := make([]byte, 4)
+	_, err = io.ReadFull(incoming, header)
+	if err != nil {
+		return
+	}
+	if !bytes.Equal(header[0:3], []byte{socks5Version, socks5CommandConnect, socks5Reserved}) {
+		err = errors.New("only connect command is supported for SOCKS5")
+		return
+	}
+
+	var ip net.IP
+	var remoteHost string
+	switch header[3] {
+	case socks5AddressTypeIPv4:
+		ip = make([]byte, net.IPv4len)
+	case socks5AddressTypeIPv6:
+		ip = make([]byte, net.IPv6len)
+	case socks5AddressTypeDomainName:
+		var domainNameLen byte
+		domainNameLen, err = readByte(incoming)
+		if err != nil {
+			return
+		}
+		remoteAddrBuf := make([]byte, domainNameLen)
+		_, err = io.ReadFull(incoming, remoteAddrBuf)
+		if err != nil {
+			return
+		}
+		remoteHost = string(remoteAddrBuf)
+	default:
+		err = errors.New("Unsupported address type for SOCKS5 connect request")
+		return
+	}
+
+	if ip != nil {
+		// Still need to read the ip address
+		_, err = io.ReadFull(incoming, ip)
+		if err != nil {
+			return
+		}
+		remoteHost = ip.String()
+	}
+
+	var remotePort uint16
+	err = binary.Read(incoming, binary.BigEndian, &remotePort)
+	if err != nil {
+		return
+	}
+
+	// Send the same minimal response as openSSH does
+	response := make([]byte, 4+net.IPv4len+2)
+	copy(response, []byte{socks5Version, socks5Succeeded, socks5Reserved, socks5AddressTypeIPv4})
+	_, err = incoming.Write(response)
+	if err != nil {
+		return
+	}
+
+	return net.JoinHostPort(remoteHost, strconv.Itoa(int(remotePort))), nil
+}
+
+func socks5ProxyConnection(client *NodeClient, incoming net.Conn) {
+	err := socks5ProxyAuthenticate(incoming)
+	if nil != err {
+		log.Errorf("socks5ProxyConnection unable to authenticate (%v) [%v]", incoming, err)
+		return
+	}
+
+	remoteAddr, err := socks5ProxyConnectRequest(incoming)
+	if nil != err {
+		log.Errorf("socks5ProxyConnection did not receive connect (%v) [%v]", incoming, err)
+		return
+	}
+
+	proxyConnection(client, incoming, remoteAddr)
+}
+
+func dynamicProxyConnection(client *NodeClient, incoming net.Conn) {
+	defer incoming.Close()
+	log.Debugf("nodeClient.dynamicProxyConnection(%v) started", incoming.RemoteAddr())
+
+	version := []byte{0}
+	_, err := incoming.Read(version)
+	if err != nil {
+		log.Errorf("Failed to read first byte of %v", incoming)
+		return
+	}
+	switch version[0] {
+	case socks5Version:
+		socks5ProxyConnection(client, incoming)
+	case socks4Version:
+		log.Errorf("SOCKS4 dynamic port forwarding is no yet supported (%v)", incoming)
+	default:
+		log.Errorf("Unknown dynamic port forwarding protocol requested by (%v)", incoming)
+	}
+}
+
+// listenForDynamicForward listens on a given socket and forwards all incoming connections
+// to the remote address they specify
+func (client *NodeClient) listenForDynamicForward(socket net.Listener) {
+	defer socket.Close()
+	defer client.Close()
+	// request processing loop: accept incoming requests to be connected to nodes
+	// and proxy them
+	for {
+		incoming, err := socket.Accept()
+		if err != nil {
+			log.Error(err)
+			break
+		}
+		go dynamicProxyConnection(client, incoming)
 	}
 }
 

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -52,7 +52,8 @@ type ClientProfile struct {
 	//
 	// other stuff
 	//
-	ForwardedPorts []string `yaml:"forward_ports,omitempty"`
+	ForwardedPorts        []string `yaml:"forward_ports,omitempty"`
+	DynamicForwardedPorts []string `yaml:"dynamic_forward_ports,omitempty"`
 }
 
 // FullProfilePath returns the full path to the user profile directory.

--- a/lib/client/profile_test.go
+++ b/lib/client/profile_test.go
@@ -31,11 +31,12 @@ var _ = check.Suite(&ProfileTestSuite{})
 
 func (s *ProfileTestSuite) TestEverything(c *check.C) {
 	p := &ClientProfile{
-		ProxyHost:      "proxy",
-		ProxySSHPort:   3023,
-		ProxyWebPort:   3088,
-		Username:       "testuser",
-		ForwardedPorts: []string{"8000:example.com:8000"},
+		ProxyHost:             "proxy",
+		ProxySSHPort:          3023,
+		ProxyWebPort:          3088,
+		Username:              "testuser",
+		ForwardedPorts:        []string{"8000:example.com:8000"},
+		DynamicForwardedPorts: []string{"localhost:8080"},
 	}
 
 	home := c.MkDir()

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -679,8 +679,8 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 	defer ctx.Debugf("direct-tcp closed")
 	defer ctx.Close()
 
-	srcAddr := fmt.Sprintf("%v:%d", req.Orig, req.OrigPort)
-	dstAddr := fmt.Sprintf("%v:%d", req.Host, req.Port)
+	srcAddr := net.JoinHostPort(req.Orig, strconv.Itoa(int(req.OrigPort)))
+	dstAddr := net.JoinHostPort(req.Host, strconv.Itoa(int(req.Port)))
 
 	// check if the role allows port forwarding for this user
 	err := s.authHandlers.CheckPortForward(dstAddr, ctx)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -76,6 +76,8 @@ type CLIConf struct {
 	RecursiveCopy bool
 	// -L flag for ssh. Local port forwarding like 'ssh -L 80:remote.host:80 -L 443:remote.host:443'
 	LocalForwardPorts []string
+	// -D flag for ssh. Dynamic port forwarding like 'ssh -D 8080'
+	DynamicForwardedPorts []string
 	// ForwardAgent agent to target node. Equivalent of -A for OpenSSH.
 	ForwardAgent bool
 	// --local flag for ssh
@@ -179,6 +181,7 @@ func Run(args []string, underTest bool) {
 	ssh.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
 	ssh.Flag("forward-agent", "Forward agent to target node").Short('A').BoolVar(&cf.ForwardAgent)
 	ssh.Flag("forward", "Forward localhost connections to remote server").Short('L').StringsVar(&cf.LocalForwardPorts)
+	ssh.Flag("dynamic-forward", "Forward localhost connections to remote server").Short('D').StringsVar(&cf.DynamicForwardedPorts)
 	ssh.Flag("local", "Execute command on localhost after connecting to SSH node").Default("false").BoolVar(&cf.LocalExec)
 	ssh.Flag("tty", "Allocate TTY").Short('t').BoolVar(&cf.Interactive)
 	// join
@@ -551,6 +554,11 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 		return nil, err
 	}
 
+	dPorts, err := client.ParseDynamicPortForwardSpec(cf.DynamicForwardedPorts)
+	if err != nil {
+		return nil, err
+	}
+
 	// 1: start with the defaults
 	c := client.MakeDefaultConfig()
 
@@ -602,6 +610,9 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 	}
 	if len(fPorts) > 0 {
 		c.LocalForwardPorts = fPorts
+	}
+	if len(dPorts) > 0 {
+		c.DynamicForwardedPorts = dPorts
 	}
 	if cf.SiteName != "" {
 		c.SiteName = cf.SiteName

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -76,6 +76,7 @@ func (s *MainTestSuite) TestMakeClient(c *check.C) {
 	conf.UserHost = "root@localhost"
 	conf.NodePort = 46528
 	conf.LocalForwardPorts = []string{"80:remote:180"}
+	conf.DynamicForwardedPorts = []string{"8080"}
 	tc, err = makeClient(&conf, true)
 	c.Assert(tc.Config.KeyTTL, check.Equals, time.Minute*time.Duration(conf.MinsToLive))
 	c.Assert(tc.Config.HostLogin, check.Equals, "root")
@@ -85,6 +86,12 @@ func (s *MainTestSuite) TestMakeClient(c *check.C) {
 			SrcPort:  80,
 			DestHost: "remote",
 			DestPort: 180,
+		},
+	})
+	c.Assert(tc.Config.DynamicForwardedPorts, check.DeepEquals, client.DynamicForwardedPorts{
+		{
+			SrcIP:   "127.0.0.1",
+			SrcPort: 8080,
 		},
 	})
 }


### PR DESCRIPTION
Implements the -D flag of ssh, but only with a SOCKS5 proxy.
OpenSSH also supports a SOCKS4 proxy.

This commit also fixes a bug in the server which prevented it from
forwarding raw IPv6 sockets, as the addresses were incorrectly
escaped.