### PR TITLE
Better signal handling and pools for gzip.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   one:
     image: teleport:latest
     container_name: one
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one.yaml --gops
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one.yaml
     mem_limit: 300m
     memswap_limit: 0
     ports:
@@ -29,7 +29,7 @@ services:
   one-node:
     image: teleport:latest
     container_name: one-node
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one-node.yaml --gops
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one-node.yaml
     env_file: env.file
     mem_limit: 300m
     volumes:
@@ -45,7 +45,7 @@ services:
   one-proxy:
     image: teleport:latest
     container_name: one-proxy
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one-proxy.yaml --gops
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/one-proxy.yaml
     mem_limit: 300m
     ports:
       - "4080:3080"
@@ -67,7 +67,7 @@ services:
     mem_limit: 300m
     image: teleport:latest
     container_name: two-auth
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-auth.yaml --insecure --gops
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-auth.yaml --insecure
     env_file: env.file
     volumes:
       - ./data/two/auth:/var/lib/teleport
@@ -83,7 +83,7 @@ services:
     mem_limit: 300m
     image: teleport:latest
     container_name: two-proxy
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-proxy.yaml --gops
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-proxy.yaml
     env_file: env.file
     ports:
       - "5080:5080"
@@ -102,7 +102,7 @@ services:
     mem_limit: 300m
     image: teleport:latest
     container_name: two-node
-    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-node.yaml --gops
+    command: ${CONTAINERHOME}/build/teleport start -d -c ${CONTAINERHOME}/docker/two-node.yaml
     env_file: env.file
     volumes:
       - ./data/two/node:/var/lib/teleport

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -77,8 +77,6 @@ type CommandLineFlags struct {
 	Labels string
 	// --pid-file flag
 	PIDFile string
-	// Gops starts gops agent on a first available address
-	Gops bool
 	// DiagnosticAddr is listen address for diagnostic endpoint
 	DiagnosticAddr string
 	// PermitUserEnvironment enables reading of ~/.tsh/environment
@@ -679,6 +677,7 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 	if clf.Debug {
 		cfg.Console = ioutil.Discard
 		utils.InitLogger(utils.LoggingForDaemon, log.DebugLevel)
+		cfg.Debug = clf.Debug
 	}
 
 	// apply --roles flag:

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -130,6 +130,10 @@ type Config struct {
 
 	// DiagnosticAddr is an address for diagnostic and healthz endpoint service
 	DiagnosticAddr utils.NetAddr
+
+	// Debug sets debugging mode, results in diagnostic address
+	// endpoint extended with additional /debug handlers
+	Debug bool
 }
 
 // ApplyToken assigns a given token to all internal services but only if token

--- a/lib/service/info.go
+++ b/lib/service/info.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2017 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package service
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"runtime/pprof"
+	"time"
+)
+
+// writeDebugInfo writes debugging information
+// about this process
+func writeDebugInfo(w io.Writer) {
+	fmt.Fprintf(w, "Runtime stats\n")
+	runtimeStats(w)
+
+	fmt.Fprintf(w, "Memory stats\n")
+	memStats(w)
+
+	fmt.Fprintf(w, "Goroutines\n")
+	goroutineDump(w)
+}
+
+func goroutineDump(w io.Writer) {
+	pprof.Lookup("goroutine").WriteTo(w, 2)
+}
+
+func runtimeStats(w io.Writer) {
+	fmt.Fprintf(w, "goroutines: %v\n", runtime.NumGoroutine())
+	fmt.Fprintf(w, "OS threads: %v\n", pprof.Lookup("threadcreate").Count())
+	fmt.Fprintf(w, "GOMAXPROCS: %v\n", runtime.GOMAXPROCS(0))
+	fmt.Fprintf(w, "num CPU: %v\n", runtime.NumCPU())
+}
+
+func memStats(w io.Writer) {
+	var s runtime.MemStats
+	runtime.ReadMemStats(&s)
+	fmt.Fprintf(w, "alloc: %v\n", s.Alloc)
+	fmt.Fprintf(w, "total-alloc: %v\n", s.TotalAlloc)
+	fmt.Fprintf(w, "sys: %v\n", s.Sys)
+	fmt.Fprintf(w, "lookups: %v\n", s.Lookups)
+	fmt.Fprintf(w, "mallocs: %v\n", s.Mallocs)
+	fmt.Fprintf(w, "frees: %v\n", s.Frees)
+	fmt.Fprintf(w, "heap-alloc: %v\n", s.HeapAlloc)
+	fmt.Fprintf(w, "heap-sys: %v\n", s.HeapSys)
+	fmt.Fprintf(w, "heap-idle: %v\n", s.HeapIdle)
+	fmt.Fprintf(w, "heap-in-use: %v\n", s.HeapInuse)
+	fmt.Fprintf(w, "heap-released: %v\n", s.HeapReleased)
+	fmt.Fprintf(w, "heap-objects: %v\n", s.HeapObjects)
+	fmt.Fprintf(w, "stack-in-use: %v\n", s.StackInuse)
+	fmt.Fprintf(w, "stack-sys: %v\n", s.StackSys)
+	fmt.Fprintf(w, "stack-mspan-inuse: %v\n", s.MSpanInuse)
+	fmt.Fprintf(w, "stack-mspan-sys: %v\n", s.MSpanSys)
+	fmt.Fprintf(w, "stack-mcache-inuse: %v\n", s.MCacheInuse)
+	fmt.Fprintf(w, "stack-mcache-sys: %v\n", s.MCacheSys)
+	fmt.Fprintf(w, "other-sys: %v\n", s.OtherSys)
+	fmt.Fprintf(w, "gc-sys: %v\n", s.GCSys)
+	fmt.Fprintf(w, "next-gc: when heap-alloc >= %v\n", s.NextGC)
+	lastGC := "-"
+	if s.LastGC != 0 {
+		lastGC = fmt.Sprint(time.Unix(0, int64(s.LastGC)))
+	}
+	fmt.Fprintf(w, "last-gc: %v\n", lastGC)
+	fmt.Fprintf(w, "gc-pause-total: %v\n", time.Duration(s.PauseTotalNs))
+	fmt.Fprintf(w, "gc-pause: %v\n", s.PauseNs[(s.NumGC+255)%256])
+	fmt.Fprintf(w, "num-gc: %v\n", s.NumGC)
+	fmt.Fprintf(w, "enable-gc: %v\n", s.EnableGC)
+	fmt.Fprintf(w, "debug-gc: %v\n", s.DebugGC)
+}

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -181,7 +181,7 @@ func SetRequestHandler(req RequestHandler) ServerOption {
 
 func SetCiphers(ciphers []string) ServerOption {
 	return func(s *Server) error {
-		s.Debugf("supported ciphers: %q", ciphers)
+		s.Debugf("Supported ciphers: %q.", ciphers)
 		if ciphers != nil {
 			s.cfg.Ciphers = ciphers
 		}
@@ -191,7 +191,7 @@ func SetCiphers(ciphers []string) ServerOption {
 
 func SetKEXAlgorithms(kexAlgorithms []string) ServerOption {
 	return func(s *Server) error {
-		s.Debugf("supported KEX algorithms: %q", kexAlgorithms)
+		s.Debugf("Supported KEX algorithms: %q.", kexAlgorithms)
 		if kexAlgorithms != nil {
 			s.cfg.KeyExchanges = kexAlgorithms
 		}
@@ -201,7 +201,7 @@ func SetKEXAlgorithms(kexAlgorithms []string) ServerOption {
 
 func SetMACAlgorithms(macAlgorithms []string) ServerOption {
 	return func(s *Server) error {
-		s.Debugf("supported MAC algorithms: %q", macAlgorithms)
+		s.Debugf("Supported MAC algorithms: %q.", macAlgorithms)
 		if macAlgorithms != nil {
 			s.cfg.MACs = macAlgorithms
 		}
@@ -314,20 +314,20 @@ func (s *Server) acceptConnections() {
 	backoffTimer := time.NewTicker(5 * time.Second)
 	defer backoffTimer.Stop()
 	addr := s.Addr()
-	s.Debugf("listening on %v", addr)
+	s.Debugf("Listening on %v.", addr)
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
 			if s.isClosed() {
-				s.Debugf("server %v has closed", addr)
+				s.Debugf("Server %v has closed.", addr)
 				return
 			}
 			select {
 			case <-s.closeContext.Done():
-				s.Debugf("server %v has closed", addr)
+				s.Debugf("Server %v has closed.", addr)
 				return
 			case <-backoffTimer.C:
-				s.Debugf("backoff on network error: %v", err)
+				s.Debugf("Backoff on network error: %v.", err)
 			}
 		} else {
 			go s.handleConnection(conn)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -32,8 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils/scp"
 	"github.com/gravitational/teleport/lib/utils"
 
-	"github.com/google/gops/agent"
-
 	"github.com/gravitational/trace"
 
 	log "github.com/sirupsen/logrus"
@@ -109,10 +107,8 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 		"Base64 encoded configuration string").Hidden().Envar(defaults.ConfigEnvar).
 		StringVar(&ccf.ConfigString)
 	start.Flag("labels", "List of labels for this node").StringVar(&ccf.Labels)
-	start.Flag("gops",
-		"Start gops troubleshooting endpoint on a first available adress.").BoolVar(&ccf.Gops)
 	start.Flag("diag-addr",
-		"Start diangonstic prometheus and healthz endpoint.").StringVar(&ccf.DiagnosticAddr)
+		"Start diangonstic prometheus and healthz endpoint.").Hidden().StringVar(&ccf.DiagnosticAddr)
 	start.Flag("permit-user-env",
 		"Enables reading of ~/.tsh/environment when creating a session").Hidden().BoolVar(&ccf.PermitUserEnvironment)
 	start.Flag("insecure",
@@ -150,13 +146,6 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 		}
 		if !options.InitOnly {
 			log.Debug(conf.DebugDumpToYAML())
-		}
-		if ccf.Gops {
-			log.Debug("Starting gops agent.")
-			err := agent.Listen(&agent.Options{})
-			if err != nil {
-				log.Warningf("failed to start gops agent %v", err)
-			}
 		}
 		if !options.InitOnly {
 			err = OnStart(conf)


### PR DESCRIPTION
Fixes #1698.

* Added sync.Pool to take care of many gzip.Writer
allocating a lot of large objects on the heap.

* Reshuffled signal handling, SIGQUIT is now
graceful shutdown, just like in Nginx.

* Signal USR1 prints hepful diagnostic info to stderr.

* Removed gops endpoint and flags.

* Fixed logs in some places.

* Debug flag now adds extra pprof handlers to diagnostic
endpoint.