### PR TITLE
Fix trusted cluster migrations.

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -560,6 +560,7 @@ func migrateTrustedClusters(asrv *AuthServer) error {
 
 		if reverseTunnel != nil {
 			reverseTunnel.SetName(hostCA.GetClusterName())
+			reverseTunnel.SetClusterName(hostCA.GetClusterName())
 			if err := asrv.UpsertReverseTunnel(reverseTunnel); err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/services/tunnel.go
+++ b/lib/services/tunnel.go
@@ -21,6 +21,8 @@ type ReverseTunnel interface {
 	Resource
 	// GetClusterName returns name of the cluster
 	GetClusterName() string
+	// SetClusterName sets cluster name
+	SetClusterName(name string)
 	// GetDialAddrs returns list of dial addresses for this cluster
 	GetDialAddrs() []string
 	// Check checks tunnel for errors
@@ -112,6 +114,11 @@ func (r *ReverseTunnelV2) CheckAndSetDefaults() error {
 	}
 
 	return nil
+}
+
+// SetClusterName sets name of a cluster
+func (r *ReverseTunnelV2) SetClusterName(name string) {
+	r.Spec.ClusterName = name
 }
 
 // GetClusterName returns name of the cluster


### PR DESCRIPTION
Rename cluster name in reverse tunnel,
incorrect name was causing clusters to disconnect
as the name did not match.