### PR TITLE
Populate tsh profile after ad-hoc login.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -218,7 +218,7 @@ func MakeDefaultConfig() *Config {
 func (c *Config) LoadProfile(profileDir string, proxyName string) error {
 	profileDir = FullProfilePath(profileDir)
 	// read the profile:
-	cp, err := ProfileFromDir(profileDir, proxyName)
+	cp, err := ProfileFromDir(profileDir, ProxyHost(proxyName))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil
@@ -238,7 +238,7 @@ func (c *Config) LoadProfile(profileDir string, proxyName string) error {
 
 // SaveProfile updates the given profiles directory with the current configuration
 // If profileDir is an empty string, the default ~/.tsh is used
-func (c *Config) SaveProfile(profileDir string) error {
+func (c *Config) SaveProfile(profileDir string, profileOptions ...ProfileOptions) error {
 	if c.ProxyHostPort == "" {
 		return nil
 	}
@@ -253,8 +253,17 @@ func (c *Config) SaveProfile(profileDir string) error {
 	cp.ForwardedPorts = c.LocalForwardPorts.ToStringSpec()
 	cp.SiteName = c.SiteName
 
-	// create a profile file:
-	if err := cp.SaveTo(profilePath, ProfileMakeCurrent); err != nil {
+	// create a profile file and set it current base on the option
+	var opts ProfileOptions
+	if len(profileOptions) == 0 {
+		// default behavior is to override the profile
+		opts = ProfileMakeCurrent
+	} else {
+		for _, flag := range profileOptions {
+			opts |= flag
+		}
+	}
+	if err := cp.SaveTo(profilePath, opts); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
@@ -266,9 +275,14 @@ func (c *Config) SetProxy(host string, webPort, sshPort int) {
 
 // ProxyHost returns the hostname of the proxy server (without any port numbers)
 func (c *Config) ProxyHost() string {
-	host, _, err := net.SplitHostPort(c.ProxyHostPort)
+	return ProxyHost(c.ProxyHostPort)
+}
+
+// ProxyHost returns the hostname of the proxy server (without any port numbers)
+func ProxyHost(proxyHost string) string {
+	host, _, err := net.SplitHostPort(proxyHost)
 	if err != nil {
-		return c.ProxyHostPort
+		return proxyHost
 	}
 	return host
 }
@@ -346,7 +360,7 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		log.Infof("no teleport login given. defaulting to %s", c.Username)
+		log.Infof("No teleport login given. defaulting to %s", c.Username)
 	}
 	if c.ProxyHostPort == "" {
 		return nil, trace.BadParameter("No proxy address specified, missed --proxy flag?")
@@ -1004,6 +1018,10 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 			fmt.Printf("Refusing to connect to untrusted proxy %v without --insecure flag\n", proxyAddr)
 		}
 		return nil, trace.Wrap(err)
+	}
+	// Save profile to record proxy credentials
+	if err := tc.SaveProfile("", ProfileCreateNew); err != nil {
+		log.Warningf("Failed to save profile: %v", err)
 	}
 	authMethod, err := key.AsAuthMethod()
 	if err != nil {

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -275,7 +275,7 @@ func (proxy *ProxyClient) isRecordingProxy() (bool, error) {
 
 // dialAuthServer returns auth server connection forwarded via proxy
 func (proxy *ProxyClient) dialAuthServer(ctx context.Context, clusterName string) (net.Conn, error) {
-	log.Debugf("client=%v connecting to auth server on cluster ", proxy.clientAddr, clusterName)
+	log.Debugf("Client %v is connecting to auth server on cluster %q.", proxy.clientAddr, clusterName)
 
 	address := "@" + clusterName
 

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -14,6 +14,9 @@ import (
 type ProfileOptions int
 
 const (
+	// ProfileCreateNew creates new profile, but does not update current profile
+	ProfileCreateNew = 0
+	// ProfileMakeCurrent creates a new profile and makes it current
 	ProfileMakeCurrent = 1 << iota
 )
 


### PR DESCRIPTION
If user has not logged in yet, and runs

tsh --proxy=example.com ls

Teleport launches ad-hoc login screen, however
because tsh did not write profile, username
and proxy were lost, so any next execution

tsh --proxy=example.com ls

Will launch the same login screen and will
ask for proxy, what is not user-friendly.

This PR fixes it by saving profile after
ad-hoc login attempts.