### PR TITLE
Pass the certificate format when creating a Web session as well.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -767,6 +767,7 @@ func (s *AuthServer) NewWebSession(userName string) (services.WebSession, error)
 		PermitAgentForwarding: roles.CanForwardAgents(),
 		PermitPortForwarding:  roles.CanPortForward(),
 		Roles:                 user.GetRoles(),
+		CertificateFormat:     roles.CertificateFormat(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
**Purpose**

When https://github.com/gravitational/teleport/pull/1559 was written it was written against 2.5.0 where this block of code did not exist because refactoring of the Auth Server had consolidated a lot of the code. This adds this fix to `branch/2.4` only. 

**Implementation**

* Pass the certificate format when creating a Web session as well.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1733