### PR TITLE
Update username in local agent if response comes from proxy.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1060,6 +1060,9 @@ func (tc *TeleportClient) Login(activateKey bool) (*Key, error) {
 
 		// in this case identity is returned by the proxy
 		tc.Username = response.Username
+		if tc.localAgent != nil {
+			tc.localAgent.username = response.Username
+		}
 	case teleport.SAML:
 		response, err = tc.ssoLogin(pr.Auth.SAML.Name, key.Pub, teleport.SAML)
 		if err != nil {
@@ -1067,6 +1070,9 @@ func (tc *TeleportClient) Login(activateKey bool) (*Key, error) {
 		}
 		// in this case identity is returned by the proxy
 		tc.Username = response.Username
+		if tc.localAgent != nil {
+			tc.localAgent.username = response.Username
+		}
 	case teleport.Github:
 		response, err = tc.ssoLogin(pr.Auth.Github.Name, key.Pub, teleport.Github)
 		if err != nil {
@@ -1074,6 +1080,9 @@ func (tc *TeleportClient) Login(activateKey bool) (*Key, error) {
 		}
 		// in this case identity is returned by the proxy
 		tc.Username = response.Username
+		if tc.localAgent != nil {
+			tc.localAgent.username = response.Username
+		}
 	default:
 		return nil, trace.BadParameter("unsupported authentication type: %q", pr.Auth.Type)
 	}

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -14,6 +14,9 @@ import (
 type ProfileOptions int
 
 const (
+	// ProfileCreateNew creates new profile, but does not update current profile
+	ProfileCreateNew = 0
+	// ProfileMakeCurrent creates a new profile and makes it current
 	ProfileMakeCurrent = 1 << iota
 )
 


### PR DESCRIPTION
**Purpose**

Backport part of https://github.com/gravitational/teleport/pull/1642 and https://github.com/gravitational/teleport/pull/1705 from 2.5.0 to `branch/2.4`.

**Implementation**

* If using an external identity provider, set the username on the local agent which will be used to name the certificate and key files to disk.
* Upon first ad-hoc login, update the profile so login does not have to occur again.

**Proposed Solution**

Fixes https://github.com/gravitational/teleport/issues/1749