### PR TITLE
If no keys are left in agent pool, remove entry.

### DIFF
--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -240,10 +240,16 @@ type matchAgentFn func(a *Agent) bool
 func (m *AgentPool) closeAgentsIf(matchKey *agentKey, matchAgent matchAgentFn) {
 	if matchKey != nil {
 		m.agents[*matchKey] = filterAndClose(m.agents[*matchKey], matchAgent)
+		if len(m.agents[*matchKey]) == 0 {
+			delete(m.agents, *matchKey)
+		}
 		return
 	}
 	for key, agents := range m.agents {
 		m.agents[key] = filterAndClose(agents, matchAgent)
+		if len(m.agents[key]) == 0 {
+			delete(m.agents, key)
+		}
 	}
 }
 


### PR DESCRIPTION
**Purpose**

Backported part of https://github.com/gravitational/teleport/pull/1533 from 2.5.0 to `branch/2.4`.

**Implementation**

* If no keys are left in agent pool, remove entry. This allows the re-sync work work because it checks for existence in a map.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1751