### PR TITLE
Unload keys from agent upon logout.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1047,9 +1047,25 @@ func (tc *TeleportClient) ConnectToProxy() (*ProxyClient, error) {
 	return proxyClient, nil
 }
 
-// Logout locates a certificate stored for a given proxy and deletes it
+// Logout removes certificate and key for the currently logged in user from
+// the filesystem and agent.
 func (tc *TeleportClient) Logout() error {
-	return trace.Wrap(tc.localAgent.DeleteKey())
+	err := tc.localAgent.DeleteKey()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// LogoutAll removes all certificates for all users from the filesystem
+// and agent.
+func (tc *TeleportClient) LogoutAll() error {
+	err := tc.localAgent.DeleteKeys()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 // Login logs the user into a Teleport cluster by talking to a Teleport proxy.

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -335,7 +335,8 @@ func (a *LocalKeyAgent) AddKey(key *Key) (*agent.AddedKey, error) {
 	return a.LoadKey(*key)
 }
 
-// DeleteKey removes the key from the key store as well as unloading the key from the agent.
+// DeleteKey removes the key from the key store as well as unloading the key
+// from the agent.
 func (a *LocalKeyAgent) DeleteKey() error {
 	// remove key from key store
 	err := a.keyStore.DeleteKey(a.proxyHost, a.username)
@@ -343,11 +344,31 @@ func (a *LocalKeyAgent) DeleteKey() error {
 		return trace.Wrap(err)
 	}
 
-	// remove any keys that are loaded for this user from the teleport and system agents
+	// remove any keys that are loaded for this user from the teleport and
+	// system agents
 	err = a.UnloadKey()
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	return nil
+}
+
+// DeleteKeys removes all keys from the keystore as well as unloads keys
+// from the agent.
+func (a *LocalKeyAgent) DeleteKeys() error {
+	// Remove keys from the filesystem.
+	err := a.keyStore.DeleteKeys()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Remove all keys from the Teleport and system agents.
+	err = a.UnloadKeys()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -348,13 +348,6 @@ func onLogin(cf *CLIConf) {
 func onLogout(cf *CLIConf) {
 	client.UnlinkCurrentProfile()
 
-	// get access to the file system key store in ~/.tsh
-	flka, err := client.NewFSLocalKeyStore(client.FullProfilePath(""))
-	if err != nil {
-		fmt.Printf("Unable to logout user: %v\n", err)
-		return
-	}
-
 	// extract the proxy name
 	proxyHost, _, err := net.SplitHostPort(cf.Proxy)
 	if err != nil {
@@ -364,26 +357,45 @@ func onLogout(cf *CLIConf) {
 	switch {
 	// proxy and username for key to remove
 	case proxyHost != "" && cf.Username != "":
-		err = flka.DeleteKey(proxyHost, cf.Username)
+		tc, err := makeClient(cf, true)
+		if err != nil {
+			utils.FatalError(err)
+			return
+		}
+
+		// Remove keys for this user from disk and running agent.
+		err = tc.Logout()
 		if err != nil {
 			if trace.IsNotFound(err) {
 				fmt.Printf("User %v already logged out from %v.\n", cf.Username, proxyHost)
-				return
+				os.Exit(1)
 			}
-			fmt.Printf("Unable to logout %v from %v: %v\n", cf.Username, proxyHost, err)
+			utils.FatalError(err)
 			return
 		}
 		fmt.Printf("Logged out %v from %v.\n", cf.Username, proxyHost)
 	// remove all keys
 	case proxyHost == "" && cf.Username == "":
-		err = flka.DeleteKeys()
+		// The makeClient function requires a proxy. However this value is not used
+		// because the user will be logged out from all proxies. Pass a dummy value
+		// to allow creation of the TeleportClient.
+		cf.Proxy = "dummy:1234"
+		tc, err := makeClient(cf, true)
 		if err != nil {
-			fmt.Printf("Unable to remove all keys: %v\n", err)
+			utils.FatalError(err)
 			return
 		}
+
+		// Remove all keys from disk and the running agent.
+		err = tc.LogoutAll()
+		if err != nil {
+			utils.FatalError(err)
+			return
+		}
+
 		fmt.Printf("Logged out all users from all proxies.\n")
 	default:
-		fmt.Printf("Specify --proxy and --username to remove keys for specific user ")
+		fmt.Printf("Specify --proxy and --user to remove keys for specific user ")
 		fmt.Printf("from a proxy or neither to log out all users from all proxies.\n")
 	}
 }


### PR DESCRIPTION
**Purpose**

Unload keys from agent upon logout.

**Implementation**

* Instead of operating on the filesystem keystore directly, operate on the key agent so keys can be unloaded from the agent upon logout.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1541