### PR TITLE
Include nodename in the host certificate.

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -924,7 +924,15 @@ func ReadIdentity(dataDir string, id IdentityID) (i *Identity, err error) {
 		}
 	}
 
-	return ReadIdentityFromKeyPair(keyBytes, sshCertBytes, tlsCertBytes, tlsCACertBytes)
+	identity, err := ReadIdentityFromKeyPair(keyBytes, sshCertBytes, tlsCertBytes, tlsCACertBytes)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Inject nodename back into identity read from disk.
+	identity.ID.NodeName = id.NodeName
+
+	return identity, nil
 }
 
 // WriteIdentity writes identity keypair to disk

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -196,7 +196,11 @@ func (process *TeleportProcess) readIdentity(role teleport.Role) (*auth.Identity
 	process.Lock()
 	defer process.Unlock()
 
-	id := auth.IdentityID{HostUUID: process.Config.HostUUID, Role: role}
+	id := auth.IdentityID{
+		Role:     role,
+		HostUUID: process.Config.HostUUID,
+		NodeName: process.Config.Hostname,
+	}
 	identity, err := auth.ReadIdentity(process.Config.DataDir, id)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -219,7 +223,11 @@ func (process *TeleportProcess) GetIdentity(role teleport.Role) (i *auth.Identit
 		return i, nil
 	}
 
-	id := auth.IdentityID{HostUUID: process.Config.HostUUID, Role: role}
+	id := auth.IdentityID{
+		Role:     role,
+		HostUUID: process.Config.HostUUID,
+		NodeName: process.Config.Hostname,
+	}
 	i, err = auth.ReadIdentity(process.Config.DataDir, id)
 	if err != nil {
 		if trace.IsNotFound(err) {


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1786, migrating from 2.4.x to 2.5.x causes host certificates to lose all principals other than the host UUID. The nodename (as well as nodename.clustername) needs to be included in the host certificate otherwise OpenSSH clients will not be able to connect to a host.

**Implementation**

* When re-generating host certificates, include the nodename from process configuration in the identity read from disk.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1786