### PR TITLE
Fix logging, collect status of forked processes

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -83,6 +83,9 @@ const (
 	// ComponentDiagnostic is a diagnostic service
 	ComponentDiagnostic = "diagnostic"
 
+	// ComponentClient is a client
+	ComponentClient = "client"
+
 	// ComponentTunClient is a tunnel client
 	ComponentTunClient = "client:tunnel"
 

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -138,7 +138,7 @@ type Config struct {
 
 	// UploadEventsC is a channel for upload events
 	// used in tests
-	UploadEventsC chan *events.UploadEvent
+	UploadEventsC chan *events.UploadEvent `json:"-"`
 }
 
 // ApplyToken assigns a given token to all internal services but only if token

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -24,6 +24,7 @@ import (
 	"log/syslog"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/gravitational/teleport"
 
@@ -139,12 +140,16 @@ func UserMessageFromError(err error) string {
 
 // Consolef prints the same message to a 'ui console' (if defined) and also to
 // the logger with INFO priority
-func Consolef(w io.Writer, msg string, params ...interface{}) {
+func Consolef(w io.Writer, component string, msg string, params ...interface{}) {
+	entry := log.WithFields(log.Fields{
+		trace.Component: component,
+	})
 	msg = fmt.Sprintf(msg, params...)
+	entry.Info(msg)
 	if w != nil {
-		fmt.Fprintln(w, msg)
+		component := strings.ToUpper(component)
+		fmt.Fprintf(w, "[%v]%v%v\n", strings.ToUpper(component), strings.Repeat(" ", 8-len(component)), msg)
 	}
-	log.Info(msg)
 }
 
 // InitCLIParser configures kingpin command line args parser with

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -154,8 +154,9 @@ func connectToAuthService(cfg *service.Config) (client auth.ClientI, err error) 
 	// check connectivity by calling something on a clinet:
 	conn, err := client.GetDialer()(context.TODO())
 	if err != nil {
-		utils.Consolef(os.Stderr,
-			"Cannot connect to the auth server: %v.\nIs the auth server running on %v?", err, cfg.AuthServers[0].Addr)
+		utils.Consolef(os.Stderr, teleport.ComponentClient,
+			"Cannot connect to the auth server: %v.\nIs the auth server running on %v?",
+			err, cfg.AuthServers[0].Addr)
 		os.Exit(1)
 	}
 	conn.Close()

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -57,7 +57,7 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 	}
 	// configure logger for a typical CLI scenario until configuration file is
 	// parsed
-	utils.InitLogger(utils.LoggingForDaemon, log.WarnLevel)
+	utils.InitLogger(utils.LoggingForDaemon, log.ErrorLevel)
 	app := utils.InitCLIParser("teleport", "Clustered SSH service. Learn more at https://gravitational.com/teleport")
 
 	// define global flags:

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -77,7 +77,7 @@ func (s *MainTestSuite) TestDefault(c *check.C) {
 	c.Assert(conf.SSH.Enabled, check.Equals, true)
 	c.Assert(conf.Proxy.Enabled, check.Equals, true)
 	c.Assert(conf.Console, check.Equals, os.Stdout)
-	c.Assert(log.GetLevel(), check.Equals, log.WarnLevel)
+	c.Assert(log.GetLevel(), check.Equals, log.ErrorLevel)
 }
 
 func (s *MainTestSuite) TestRolesFlag(c *check.C) {


### PR DESCRIPTION
fixes #1785, fixes #1776

This commit fixes several issues with output:

First teleport start now prints output
matching quickstart guide and sets default
console logging to ERROR.

SIGCHLD handler now only collects
processes PID forked during live restart
to avoid confusing other wait calls that
have no process status to collect any more.