### PR TITLE
Fix logging, collect status of forked processes

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -83,6 +83,9 @@ const (
 	// ComponentDiagnostic is a diagnostic service
 	ComponentDiagnostic = "diagnostic"
 
+	// ComponentClient is a client
+	ComponentClient = "client"
+
 	// ComponentTunClient is a tunnel client
 	ComponentTunClient = "client:tunnel"
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -152,6 +152,11 @@ type TeleportProcess struct {
 	// importedDescriptors is a list of imported file descriptors
 	// passed by the parent process
 	importedDescriptors []FileDescriptor
+
+	// forkedPIDs is a collection of a teleport processes forked
+	// during restart used to collect their status in case if the
+	// child process crashed.
+	forkedPIDs []int
 }
 
 // GetAuthServer returns the process' auth server
@@ -618,7 +623,7 @@ func (process *TeleportProcess) initAuthService() error {
 	// requests to the Auth API
 	var authTunnel *auth.AuthTunnel
 	process.RegisterFunc("auth.ssh", func() error {
-		log.Infof("Auth SSH service is starting on %v", cfg.Auth.SSHAddr.Addr)
+		log.Infof("Auth SSH service is starting on %v.", cfg.Auth.SSHAddr.Addr)
 		authTunnel, err = auth.NewTunnel(
 			cfg.Auth.SSHAddr,
 			identity.KeySigner,
@@ -646,6 +651,8 @@ func (process *TeleportProcess) initAuthService() error {
 	})
 
 	process.RegisterFunc("auth.tls", func() error {
+		utils.Consolef(cfg.Console, teleport.ComponentAuth, "Auth service is starting on %v.", cfg.Auth.SSHAddr.Addr)
+
 		// since tlsServer.Serve is a blocking call, we emit this even right before
 		// the service has started
 		process.BroadcastEvent(Event{Name: AuthTLSReady, Payload: nil})
@@ -873,6 +880,7 @@ func (process *TeleportProcess) initSSH() error {
 		}
 
 		log.Infof("Service is starting on %v %v.", cfg.SSH.Addr.Addr, process.Config.CachePolicy)
+		utils.Consolef(cfg.Console, teleport.ComponentNode, "Service is starting on %v.", cfg.SSH.Addr.Addr)
 		go s.Serve(listener)
 
 		// broadcast that the node has started
@@ -1233,6 +1241,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 		process.RegisterFunc("proxy.reveresetunnel.server", func() error {
+			utils.Consolef(cfg.Console, teleport.ComponentProxy, "Reverse tunnel service is starting on %v.", cfg.Proxy.ReverseTunnelListenAddr.Addr)
 			log.Infof("Starting on %v using %v", cfg.Proxy.ReverseTunnelListenAddr.Addr, process.Config.CachePolicy)
 			if err := tsrv.Start(); err != nil {
 				log.Error(err)
@@ -1275,6 +1284,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Handler: proxyLimiter,
 		}
 		process.RegisterFunc("proxy.web", func() error {
+			utils.Consolef(cfg.Console, teleport.ComponentProxy, "Web proxy service is starting on %v.", cfg.Proxy.WebAddr.Addr)
 			log.Infof("Web proxy service is starting on %v.", cfg.Proxy.WebAddr.Addr)
 			defer webHandler.Close()
 			process.BroadcastEvent(Event{Name: ProxyWebServerReady, Payload: webHandler})
@@ -1314,6 +1324,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	}
 
 	process.RegisterFunc("proxy.ssh", func() error {
+		utils.Consolef(cfg.Console, teleport.ComponentProxy, "SSH proxy service is starting on %v.", cfg.Proxy.SSHAddr.Addr)
 		log.Infof("SSH proxy service is starting on %v", cfg.Proxy.SSHAddr.Addr)
 		go sshProxy.Serve(listener)
 		// broadcast that the proxy ssh server has started

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -24,6 +24,7 @@ import (
 	"log/syslog"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/gravitational/teleport"
 
@@ -139,12 +140,16 @@ func UserMessageFromError(err error) string {
 
 // Consolef prints the same message to a 'ui console' (if defined) and also to
 // the logger with INFO priority
-func Consolef(w io.Writer, msg string, params ...interface{}) {
+func Consolef(w io.Writer, component string, msg string, params ...interface{}) {
+	entry := log.WithFields(log.Fields{
+		trace.Component: component,
+	})
 	msg = fmt.Sprintf(msg, params...)
+	entry.Info(msg)
 	if w != nil {
-		fmt.Fprintln(w, msg)
+		component := strings.ToUpper(component)
+		fmt.Fprintf(w, "[%v]%v%v\n", strings.ToUpper(component), strings.Repeat(" ", 8-len(component)), msg)
 	}
-	log.Info(msg)
 }
 
 // InitCLIParser configures kingpin command line args parser with

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -154,8 +154,9 @@ func connectToAuthService(cfg *service.Config) (client auth.ClientI, err error) 
 	// check connectivity by calling something on a clinet:
 	conn, err := client.GetDialer()(context.TODO())
 	if err != nil {
-		utils.Consolef(os.Stderr,
-			"Cannot connect to the auth server: %v.\nIs the auth server running on %v?", err, cfg.AuthServers[0].Addr)
+		utils.Consolef(os.Stderr, teleport.ComponentClient,
+			"Cannot connect to the auth server: %v.\nIs the auth server running on %v?",
+			err, cfg.AuthServers[0].Addr)
 		os.Exit(1)
 	}
 	conn.Close()

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -57,7 +57,7 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 	}
 	// configure logger for a typical CLI scenario until configuration file is
 	// parsed
-	utils.InitLogger(utils.LoggingForDaemon, log.WarnLevel)
+	utils.InitLogger(utils.LoggingForDaemon, log.ErrorLevel)
 	app := utils.InitCLIParser("teleport", "Clustered SSH service. Learn more at https://gravitational.com/teleport")
 
 	// define global flags:

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -77,7 +77,7 @@ func (s *MainTestSuite) TestDefault(c *check.C) {
 	c.Assert(conf.SSH.Enabled, check.Equals, true)
 	c.Assert(conf.Proxy.Enabled, check.Equals, true)
 	c.Assert(conf.Console, check.Equals, os.Stdout)
-	c.Assert(log.GetLevel(), check.Equals, log.WarnLevel)
+	c.Assert(log.GetLevel(), check.Equals, log.ErrorLevel)
 }
 
 func (s *MainTestSuite) TestRolesFlag(c *check.C) {


### PR DESCRIPTION
fixes #1785, fixes #1776

This commit fixes several issues with output:

First teleport start now prints output
matching quickstart guide and sets default
console logging to ERROR.

SIGCHLD handler now only collects
processes PID forked during live restart
to avoid confusing other wait calls that
have no process status to collect any more.