### PR TITLE
Corrected signup URL note.

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2023,7 +2023,7 @@ func ok() interface{} {
 
 // CreateSignupLink generates and returns a URL which is given to a new
 // user to complete registration with Teleport via Web UI
-func CreateSignupLink(client auth.ClientI, token string) string {
+func CreateSignupLink(client auth.ClientI, token string) (string, string) {
 	proxyHost := "<proxyhost>:3080"
 
 	proxies, err := client.GetProxies()
@@ -2044,7 +2044,7 @@ func CreateSignupLink(client auth.ClientI, token string) string {
 		Host:   proxyHost,
 		Path:   "web/newuser/" + token,
 	}
-	return u.String()
+	return u.String(), proxyHost
 }
 
 type responseData struct {

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -113,11 +113,11 @@ func (u *UserCommand) Add(client auth.ClientI) error {
 }
 
 func (u *UserCommand) PrintSignupURL(client auth.ClientI, token string, ttl time.Duration) {
-	url := web.CreateSignupLink(client, token)
+	signupURL, proxyHost := web.CreateSignupLink(client, token)
 
 	fmt.Printf("Signup token has been created and is valid for %v hours. Share this URL with the user:\n%v\n\n",
-		int(ttl/time.Hour), url)
-	fmt.Printf("NOTE: Make sure <proxyhost> points at a Teleport proxy which users can access.\n")
+		int(ttl/time.Hour), signupURL)
+	fmt.Printf("NOTE: Make sure %v points at a Teleport proxy which users can access.\n", proxyHost)
 }
 
 // Update updates existing user


### PR DESCRIPTION
**Purpose**

When printing the signup URL, print the real proxy host:port in the note.

**Implementation**

* Return both the signup URL and proxy host.
* Print the host:port in the note.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1777