### PR TITLE
Updated error logging.

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -133,7 +133,16 @@ func UserMessageFromError(err error) string {
 		return trace.DebugReport(err)
 	}
 	if err != nil {
-		return err.Error()
+		// If the error is a trace error, check if it has a user message embedded in
+		// it. If a user message is embedded in it, print the user message and the
+		// original error. Otherwise return the original with a generic "A fatal
+		// error occured" message.
+		if er, ok := err.(*trace.TraceErr); ok {
+			if er.Message != "" {
+				return fmt.Sprintf("%v: %v", er.Message, er.Err.Error())
+			}
+		}
+		return fmt.Sprintf("A fatal error occurred: %v", err.Error())
 	}
 	return ""
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -145,9 +145,6 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 			utils.FatalError(err)
 		}
 		if !options.InitOnly {
-			log.Debug(conf.DebugDumpToYAML())
-		}
-		if !options.InitOnly {
 			err = OnStart(conf)
 		}
 	case scpc.FullCommand():
@@ -170,11 +167,11 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 func OnStart(config *service.Config) error {
 	srv, err := service.NewTeleport(config)
 	if err != nil {
-		return trace.Wrap(err, "initializing teleport")
+		return trace.Wrap(err, "Initialization failed")
 	}
 
 	if err := srv.Start(); err != nil {
-		return trace.Wrap(err, "starting teleport")
+		return trace.Wrap(err, "Startup Failed")
 	}
 
 	return srv.WaitForSignals(context.TODO())


### PR DESCRIPTION
**Purpose**

Cleanup error logging.

**Implementation**

When `utils.FatalError` is called, check if a user message has been embedded in the error. If it does, prefix the user message to the wrapped error. If not, it prefixes a generic user message: "A fatal error occurred".

Here are a few examples of what these errors will look like:

```
$ teleport start
Initialization failed: mkdir /var/lib/teleport: permission denied
```
```
$ teleport start
A fatal error occurred: mkdir /var/lib/teleport: permission denied
```
```
$ teleport start -d

ERROR REPORT:
Original Error: *os.PathError mkdir /var/lib/teleport: permission denied
Stack Trace:
	/home/rjones/Development/go/src/github.com/gravitational/teleport/lib/service/service.go:335 github.com/gravitational/teleport/lib/service.NewTeleport
	/home/rjones/Development/go/src/github.com/gravitational/teleport/tool/teleport/common/teleport.go:168 github.com/gravitational/teleport/tool/teleport/common.OnStart
	/home/rjones/Development/go/src/github.com/gravitational/teleport/tool/teleport/common/teleport.go:148 github.com/gravitational/teleport/tool/teleport/common.Run
	/home/rjones/Development/go/src/github.com/gravitational/teleport/tool/teleport/main.go:29 main.main
	/usr/local/go/src/runtime/proc.go:204 runtime.main
	/usr/local/go/src/runtime/asm_amd64.s:2338 runtime.goexit
User Message: Initialization failed
```

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1798