### PR TITLE
Update global dial timeout to 30 seconds.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -76,7 +76,7 @@ const (
 
 	// DefaultDialTimeout is a default TCP dial timeout we set for our
 	// connection attempts
-	DefaultDialTimeout = 10 * time.Second
+	DefaultDialTimeout = 30 * time.Second
 
 	// HTTPIdleConnsPerHost specifies maximum idle connections per host
 	// in HTTP connection pool


### PR DESCRIPTION
**Purpose**

Increase global timeout to 30 seconds.

**Implementation**

Increase global timeout to 30 seconds.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1760