### PR TITLE
2.4.x: avoid resetting the SIGINT handler unconditionally

### DIFF
--- a/lib/utils/signal.go
+++ b/lib/utils/signal.go
@@ -2,16 +2,22 @@ package utils
 
 /*
 #include <signal.h>
-void resetInterruptSignalHandler() {
+int resetInterruptSignalHandler() {
 	struct sigaction act;
-	if (!sigaction(SIGINT, 0, &act) && act.sa_handler == SIG_IGN) {
+	int result;
+	if ((result = sigaction(SIGINT, 0, &act)) != 0) {
+		return result;
+	}
+	if (act.sa_handler == SIG_IGN) {
 		// Reset the handler for SIGINT to system default.
 		// FIXME: Note, this will also overwrite runtime's signal handler
 		signal(SIGINT, SIG_DFL);
 	}
+	return 0;
 }
 */
 import "C"
+import log "github.com/sirupsen/logrus"
 
 // ResetInterruptSignal will reset the handler for SIGINT back to the default
 // handler. We need to do this because when sysvinit launches Teleport on some
@@ -21,5 +27,8 @@ import "C"
 // http://garethrees.org/2015/08/07/ping/
 // https://github.com/openssh/openssh-portable/commit/4e0f5e1ec9b6318ef251180dbca50eaa01f74536
 func ResetInterruptSignalHandler() {
-	C.resetInterruptSignalHandler()
+	result := C.resetInterruptSignalHandler()
+	if result != 0 {
+		log.Warnf("Failed to reset interrupt signal handler: %v.", result)
+	}
 }

--- a/lib/utils/signal.go
+++ b/lib/utils/signal.go
@@ -3,7 +3,12 @@ package utils
 /*
 #include <signal.h>
 void resetInterruptSignalHandler() {
-signal(SIGINT, SIG_DFL);
+	struct sigaction act;
+	if (!sigaction(SIGINT, 0, &act) && act.sa_handler == SIG_IGN) {
+		// Reset the handler for SIGINT to system default.
+		// FIXME: Note, this will also overwrite runtime's signal handler
+		signal(SIGINT, SIG_DFL);
+	}
 }
 */
 import "C"


### PR DESCRIPTION
This happens unconditionally inside `NewTeleport` which makes any Go code using this to start an instance of teleport unable to trap SIGINT signal from a Go function.

Avoid resetting the SIGINT handler if it has not actually been set to ignore (Go's runtime respects `SIG_IGN`, btw, by not setting a handler).
