### PR TITLE
Remove parallel builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,15 +52,8 @@ endif
 .PHONY: all
 all: $(VERSRC)
 	@echo $(PAM_MESSAGE)
-	$(MAKE) -s -j 3 $(BINARIES)
-
-$(BUILDDIR)/tctl: $(LIBS) $(TELEPORTSRC) $(TELEPORTVENDOR)
-	go build $(PAMFLAGS) -o $(BUILDDIR)/tctl -i $(BUILDFLAGS) ./tool/tctl
-
-$(BUILDDIR)/teleport: $(LIBS) $(TELEPORTSRC) $(TELEPORTVENDOR)
 	go build $(PAMFLAGS) -o $(BUILDDIR)/teleport -i $(BUILDFLAGS) ./tool/teleport
-
-$(BUILDDIR)/tsh: $(LIBS) $(TELEPORTSRC) $(TELEPORTVENDOR)
+	go build $(PAMFLAGS) -o $(BUILDDIR)/tctl -i $(BUILDFLAGS) ./tool/tctl
 	go build $(PAMFLAGS) -o $(BUILDDIR)/tsh -i $(BUILDFLAGS) ./tool/tsh
 
 #


### PR DESCRIPTION
**Purpose**

Now that `go install` does not run before `go build` and `go build` was run in parallel, we're seeing errors like the following:

```
go install github.com/gravitational/teleport/vendor/github.com/coreos/etcd/pkg/pathutil: build output "/gopath/pkg/linux_amd64/github.com/gravitational/teleport/vendor/github.com/coreos/etcd/pkg/pathutil.a" already exists and is not an object file
```

Removing parallel makes fixes this problem. Builds will be temporarily slower until we move to Go 1.10.