### PR TITLE
WIP: add flags support

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -186,6 +186,9 @@ const (
 	// DirMaskSharedGroup is the mask for a directory accessible
 	// by the owner and group
 	DirMaskSharedGroup = 0770
+
+	// CSV stands for comma separated values
+	CSV = "csv"
 )
 
 const (

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -378,14 +378,6 @@ type CachePolicy struct {
 	TTL string `yaml:"ttl,omitempty"`
 }
 
-func isTrue(v string) bool {
-	switch v {
-	case "yes", "yeah", "y", "true", "1":
-		return true
-	}
-	return false
-}
-
 func isNever(v string) bool {
 	switch v {
 	case "never", "no", "0":
@@ -396,7 +388,7 @@ func isNever(v string) bool {
 
 // Enabled determines if a given "_service" section has been set to 'true'
 func (c *CachePolicy) Enabled() bool {
-	return c.EnabledFlag == "" || isTrue(c.EnabledFlag)
+	return c.EnabledFlag == "" || utils.IsTrue(c.EnabledFlag)
 }
 
 // NeverExpires returns if cache never expires by itself

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -33,6 +33,16 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// IsTrue returns true if v matches teleport's convention
+// of string values "yes" and similar
+func IsTrue(v string) bool {
+	switch v {
+	case "yes", "yeah", "y", "true", "1":
+		return true
+	}
+	return false
+}
+
 // IsGroupMember returns whether currently logged user is a member of a group
 func IsGroupMember(gid int) (bool, error) {
 	groups, err := os.Getgroups()


### PR DESCRIPTION
Adds support for parse flags property to split CSV attribute statement values.
Currently works only for SAML.

```yaml
kind: saml
version: v2
metadata:
  name: OktaSAML
  namespace: default
spec:
  parse_flags: [csv]
...
```