### PR TITLE
Introduce new upload API.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -130,6 +130,9 @@ const (
 	// Component pluggable authentication module (PAM)
 	ComponentPAM = "pam"
 
+	// ComponentUpload is a session recording upload server
+	ComponentUpload = "upload"
+
 	// DebugEnvVar tells tests to use verbose debug output
 	DebugEnvVar = "DEBUG"
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -306,20 +306,18 @@ func (s *IntSuite) TestAuditOn(c *check.C) {
 		}
 
 		// wait for the upload of the right session to complete
-		if tt.auditSessionsURI != "" {
-			timeoutC := time.After(10 * time.Second)
-		loop:
-			for {
-				select {
-				case event := <-t.UploadEventsC:
-					if event.SessionID != string(session.ID) {
-						log.Debugf("Skipping mismatching session %v, expecting upload of %v.", event.SessionID, session.ID)
-						continue
-					}
-					break loop
-				case <-timeoutC:
-					c.Fatalf("Timeout waiting for upload of session %v to complete to %v", session.ID, tt.auditSessionsURI)
+		timeoutC := time.After(10 * time.Second)
+	loop:
+		for {
+			select {
+			case event := <-t.UploadEventsC:
+				if event.SessionID != string(session.ID) {
+					log.Debugf("Skipping mismatching session %v, expecting upload of %v.", event.SessionID, session.ID)
+					continue
 				}
+				break loop
+			case <-timeoutC:
+				c.Fatalf("Timeout waiting for upload of session %v to complete to %v", session.ID, tt.auditSessionsURI)
 			}
 		}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -800,6 +800,19 @@ func (a *AuthWithRoles) PostSessionChunk(namespace string, sid session.ID, reade
 	return a.alog.PostSessionChunk(namespace, sid, reader)
 }
 
+func (a *AuthWithRoles) UploadSessionRecording(r events.SessionRecording) error {
+	if err := r.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := a.action(r.Namespace, services.KindEvent, services.VerbCreate); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := a.action(r.Namespace, services.KindEvent, services.VerbUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+	return a.alog.UploadSessionRecording(r)
+}
+
 func (a *AuthWithRoles) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
 	if err := a.action(namespace, services.KindSession, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1678,6 +1678,24 @@ func (c *Client) GetSessionChunk(namespace string, sid session.ID, offsetBytes, 
 	return response.Bytes(), nil
 }
 
+// UploadSessionRecording uploads session recording to the audit server
+func (c *Client) UploadSessionRecording(r events.SessionRecording) error {
+	file := roundtrip.File{
+		Name:     "recording",
+		Filename: "recording",
+		Reader:   r.Recording,
+	}
+	values := url.Values{
+		"sid":       []string{string(r.SessionID)},
+		"namespace": []string{r.Namespace},
+	}
+	_, err := c.PostForm(c.Endpoint("namespaces", r.Namespace, "sessions", string(r.SessionID), "recording"), values, file)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
 // Returns events that happen during a session sorted by time
 // (oldest first).
 //

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -20,12 +20,15 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gravitational/teleport"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/boltbk"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/services"
@@ -55,6 +58,12 @@ func (cfg *TestAuthServerConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing parameter Dir")
 	}
 	return nil
+}
+
+// CreateUploaderDir creates directory for file uploader service
+func CreateUploaderDir(dir string) error {
+	return os.MkdirAll(filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload,
+		events.SessionLogsDir, defaults.Namespace), teleport.SharedDirMode)
 }
 
 // TestAuthServer is auth server using local filesystem backend

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -137,6 +137,11 @@ const (
 	V1 = 0
 	// V2 is the V2 version of slice chunks  API
 	V2 = 2
+	// V3 is almost like V2, but it assumes
+	// that session recordings are being uploaded
+	// at the end of the session, so it skips writing session event index
+	// on the fly
+	V3 = 3
 )
 
 // IAuditLog is the primary (and the only external-facing) interface for AuditLogger.
@@ -155,6 +160,9 @@ type IAuditLog interface {
 	// PostSessionChunk returns a writer which SSH nodes use to submit
 	// their live sessions into the session log
 	PostSessionChunk(namespace string, sid session.ID, reader io.Reader) error
+
+	// UploadSessionRecording uploads session recording to the audit server
+	UploadSessionRecording(r SessionRecording) error
 
 	// GetSessionChunk returns a reader which can be used to read a byte stream
 	// of a recorded session starting from 'offsetBytes' (pass 0 to start from the

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -1215,7 +1215,6 @@ func (a *AuditTestSuite) TestForwardAndUpload(c *check.C) {
 		Namespace:  defaults.Namespace,
 		Context:    context.TODO(),
 		ScanPeriod: 100 * time.Millisecond,
-		Handler:    fileHandler,
 		AuditLog:   alog,
 		EventsC:    eventsC,
 	})

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -46,3 +46,7 @@ func (d *DiscardAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string, l
 func (d *DiscardAuditLog) SearchSessionEvents(fromUTC time.Time, toUTC time.Time, limit int) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
 }
+
+func (d *DiscardAuditLog) UploadSessionRecording(SessionRecording) error {
+	return nil
+}

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -306,6 +306,10 @@ func (l *Log) PostSessionSlice(slice events.SessionSlice) error {
 	return nil
 }
 
+func (l *Log) UploadSessionRecording(events.SessionRecording) error {
+	return trace.BadParameter("not supported")
+}
+
 // PostSessionChunk returns a writer which SSH nodes use to submit
 // their live sessions into the session log
 func (l *Log) PostSessionChunk(namespace string, sid session.ID, reader io.Reader) error {

--- a/lib/events/forward.go
+++ b/lib/events/forward.go
@@ -100,8 +100,14 @@ func (l *Forwarder) PostSessionSlice(slice SessionSlice) error {
 		return nil
 	}
 	slice.Chunks = chunks
+	slice.Version = V3
 	err = l.ForwardTo.PostSessionSlice(slice)
 	return err
+}
+
+// UploadSessionRecording uploads session recording to the audit server
+func (l *Forwarder) UploadSessionRecording(r SessionRecording) error {
+	return l.ForwardTo.UploadSessionRecording(r)
 }
 
 // PostSessionChunk returns a writer which SSH nodes use to submit

--- a/lib/events/mock.go
+++ b/lib/events/mock.go
@@ -70,6 +70,10 @@ func (d *MockAuditLog) PostSessionChunk(namespace string, sid session.ID, reader
 	return nil
 }
 
+func (d *MockAuditLog) UploadSessionRecording(SessionRecording) error {
+	return nil
+}
+
 func (d *MockAuditLog) PostSessionSlice(slice SessionSlice) error {
 	if err := d.GetError(); err != nil {
 		d.FailedAttemptsC <- &slice

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -130,12 +130,13 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.srvHostPort = fmt.Sprintf("%v:%v", s.server.ClusterName(), s.srvPort)
+	nodeDir := c.MkDir()
 	srv, err := New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: s.srvAddress},
 		s.server.ClusterName(),
 		[]ssh.Signer{s.signer},
 		s.nodeClient,
-		c.MkDir(),
+		nodeDir,
 		nil,
 		utils.NetAddr{},
 		SetNamespace(defaults.Namespace),
@@ -147,6 +148,7 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.srv = srv
 	s.srv.isTestStub = true
+	c.Assert(auth.CreateUploaderDir(nodeDir), IsNil)
 
 	c.Assert(s.srv.Start(), IsNil)
 	c.Assert(s.srv.registerServer(), IsNil)
@@ -854,12 +856,13 @@ func (s *SrvSuite) TestLimiter(c *C) {
 	c.Assert(err, IsNil)
 
 	srvAddress := "127.0.0.1:" + s.freePorts.Pop()
+	nodeStateDir := c.MkDir()
 	srv, err := New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: srvAddress},
 		s.server.ClusterName(),
 		[]ssh.Signer{s.signer},
 		s.nodeClient,
-		c.MkDir(),
+		nodeStateDir,
 		nil,
 		utils.NetAddr{},
 		SetLimiter(limiter),
@@ -871,6 +874,8 @@ func (s *SrvSuite) TestLimiter(c *C) {
 	)
 	c.Assert(err, IsNil)
 	c.Assert(srv.Start(), IsNil)
+
+	c.Assert(auth.CreateUploaderDir(nodeStateDir), IsNil)
 	defer srv.Close()
 
 	// maxConnection = 3

--- a/lib/state/log.go
+++ b/lib/state/log.go
@@ -478,3 +478,8 @@ func (ll *CachingAuditLog) SearchEvents(time.Time, time.Time, string, int) ([]ev
 func (ll *CachingAuditLog) SearchSessionEvents(time.Time, time.Time, int) ([]events.EventFields, error) {
 	return nil, errNotSupported
 }
+
+// UploadSessionRecording uploads session recording to the audit server
+func (ll *CachingAuditLog) UploadSessionRecording(events.SessionRecording) error {
+	return errNotSupported
+}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -167,12 +167,13 @@ func (s *WebSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// create SSH service:
+	nodeDataDir := c.MkDir()
 	node, err := regular.New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: fmt.Sprintf("127.0.0.1:%v", nodePort)},
 		s.server.ClusterName(),
 		[]ssh.Signer{signer},
 		nodeClient,
-		c.MkDir(),
+		nodeDataDir,
 		nil,
 		utils.NetAddr{},
 		regular.SetNamespace(defaults.Namespace),
@@ -185,6 +186,8 @@ func (s *WebSuite) SetUpTest(c *C) {
 	s.node = node
 	s.srvID = node.ID()
 	c.Assert(s.node.Start(), IsNil)
+
+	c.Assert(auth.CreateUploaderDir(nodeDataDir), IsNil)
 
 	// create reverse tunnel service:
 	s.proxyClient, err = s.server.NewClient(auth.TestBuiltin(teleport.RoleProxy))


### PR DESCRIPTION
This PR improves session recording:

* Nodes and proxies always buffer recorded sessions
to disk during the session what improves performance
and makes the recording more resilient to network failures.

* Async uploader running on proxy or node always uploads the
session tarball to the audit log server.

* Audit log server is the only component uploading
to the S3 or any other API.