### PR TITLE
Use signal pipe to make live reload better.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -231,6 +231,9 @@ const (
 
 	// LogsDir is a log subdirectory for events and logs
 	LogsDir = "log"
+
+	// Syslog is a mode for syslog logging
+	Syslog = "syslog"
 )
 
 // Component generates "component:subcomponent1:subcomponent2" strings used

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -176,6 +176,8 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		log.SetOutput(os.Stderr)
 	case "stdout", "out", "1":
 		log.SetOutput(os.Stdout)
+	case teleport.Syslog:
+		utils.SwitchLoggingtoSyslog()
 	default:
 		// assume it's a file path:
 		logFile, err := os.Create(fc.Logger.Output)
@@ -205,12 +207,6 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		return trace.Wrap(err)
 	}
 	cfg.CachePolicy = *cachePolicy
-
-	// TODO(klizhentas): Removed on sasha/ha?
-	// TODO(ekontsevoy): I would advise against it. syslog is the only logger which works with scp
-	if strings.ToLower(fc.Logger.Output) == "syslog" {
-		utils.SwitchLoggingtoSyslog()
-	}
 
 	// apply ciphers, kex algorithms, and mac algorithms
 	if fc.Ciphers != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -336,16 +336,6 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 		}
 	}
 
-	// create the pid file
-	if cfg.PIDFile != "" {
-		f, err := os.OpenFile(cfg.PIDFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
-		if err != nil {
-			return nil, trace.ConvertSystemError(err)
-		}
-		fmt.Fprintf(f, "%v", os.Getpid())
-		defer f.Close()
-	}
-
 	importedDescriptors, err := importFileDescriptors()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -439,6 +429,23 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 
 	if !serviceStarted {
 		return nil, trace.BadParameter("all services failed to start")
+	}
+
+	if err := process.writeToSignalPipe(fmt.Sprintf("Process %v has started.", os.Getpid())); err != nil {
+		log.Warningf("Failed to write to signal pipe: %v", err)
+		// despite the failure, it's ok to proceed,
+		// it could mean that the parent process has crashed and the pipe
+		// is no longer valid.
+	}
+
+	// create the new pid file only after started successfully
+	if cfg.PIDFile != "" {
+		f, err := os.OpenFile(cfg.PIDFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+		if err != nil {
+			return nil, trace.ConvertSystemError(err)
+		}
+		fmt.Fprintf(f, "%v", os.Getpid())
+		defer f.Close()
 	}
 
 	return process, nil


### PR DESCRIPTION
This commit allows teleport parent process to track
the status of the forked child process using os.Pipe.

Child process signals success to parent process by writing
to Pipe.

This allows HUP and USR2 to be more intelligent as they
can now detect the failure or success of the process.

fixes #1844 