### PR TITLE
SIGINT handling

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -425,7 +425,7 @@ func onListSites(cf *CLIConf) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	proxyClient, err := tc.ConnectToProxy()
+	proxyClient, err := tc.ConnectToProxy(cf.Context)
 	if err != nil {
 		utils.FatalError(err)
 	}
@@ -458,7 +458,7 @@ func onSSH(cf *CLIConf) {
 	}
 
 	tc.Stdin = os.Stdin
-	if err = tc.SSH(context.TODO(), cf.RemoteCommand, cf.LocalExec); err != nil {
+	if err = tc.SSH(cf.Context, cf.RemoteCommand, cf.LocalExec); err != nil {
 		// exit with the same exit status as the failed command:
 		if tc.ExitStatus != 0 {
 			fmt.Fprintln(os.Stderr, utils.UserMessageFromError(err))


### PR DESCRIPTION
**Problem**

https://github.com/gravitational/teleport/issues/1650 raised two issues with SIGINT handling of `tsh`. The first is that Ctrl-C does not work when network connectivity is down. The second is that Ctrl-C does not work when running a command against multiple nodes (like tailing log files).

**Implementation**

* Propagate the cancelation context to `ConnectToProxy` where it should try to connect to the proxy in another goroutine and exit early if the context has been canceled.
* When running a command on multiple servers, close the connection and kill the client if SIGINT if the context has been canceled.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1650