### PR TITLE
Fix regression in tctl nodes add output

### DIFF
--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -157,7 +157,10 @@ func (c *NodeCommand) Invite(client auth.ClientI) error {
 				token, strings.ToLower(roles.String()), token, authServers[0].GetAddr(), int(c.ttl.Minutes()), authServers[0].GetAddr())
 		}
 	} else {
-		out, err := json.Marshal(token)
+		// Always return a list, otherwise we'll break users tooling. See #1846 for
+		// more details.
+		tokens := []string{token}
+		out, err := json.Marshal(tokens)
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal token")
 		}


### PR DESCRIPTION
**Purpose**

As covered in https://github.com/gravitational/teleport/issues/1846, the output of `tctl nodes add --format=json` changed which broke tooling build around it. This PR reverts the output to the original format.

**Implementation**

* Instead of returning a single token, always return a list of tokens.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1846