### PR TITLE
Write PID file before signal the parent process.

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -431,13 +431,6 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 		return nil, trace.BadParameter("all services failed to start")
 	}
 
-	if err := process.writeToSignalPipe(fmt.Sprintf("Process %v has started.", os.Getpid())); err != nil {
-		log.Warningf("Failed to write to signal pipe: %v", err)
-		// despite the failure, it's ok to proceed,
-		// it could mean that the parent process has crashed and the pipe
-		// is no longer valid.
-	}
-
 	// create the new pid file only after started successfully
 	if cfg.PIDFile != "" {
 		f, err := os.OpenFile(cfg.PIDFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
@@ -446,6 +439,13 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 		}
 		fmt.Fprintf(f, "%v", os.Getpid())
 		defer f.Close()
+	}
+
+	if err := process.writeToSignalPipe(fmt.Sprintf("Process %v has started.", os.Getpid())); err != nil {
+		log.Warningf("Failed to write to signal pipe: %v", err)
+		// despite the failure, it's ok to proceed,
+		// it could mean that the parent process has crashed and the pipe
+		// is no longer valid.
 	}
 
 	return process, nil


### PR DESCRIPTION
This fixes the race with systemd reload.

P - parent, C - child

During live reload scenario,
the following happens:

P -> forks C
P -> blocks  on pipe read
C -> writes to  pipe
C -> writes pid file
P < - reads message from pipe
P <- shuts down

However, there is a race:

P -> forks C
P -> blocks  on pipe read
C -> writes to pipe
P < - reads message from pipe
P <- shuts down
C -> writes pid file

In this case parent process exited
before child process writes new pid file
what makes systemd think that main process
is down and stop both processes.

This fix changes the sequence to:

P -> forks C
P -> blocks on pipe read
C -> writes pid file
C -> writes to pipe
P < - reads message from pipe
P <- shuts down

to make sure the race can't happen any more.