### PR TITLE
Added "tsh status" command.

### DIFF
--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -162,26 +162,6 @@ func (s *KeyStoreTestSuite) TestDeleteAll(c *check.C) {
 	c.Assert(err, check.NotNil)
 }
 
-func (s *KeyStoreTestSuite) TestKeyExpiration(c *check.C) {
-	// make two keys: one is current, and the expire one
-	good := s.makeSignedKey(c, false)
-	good.ProxyHost = "good.host"
-	expired := s.makeSignedKey(c, true)
-	expired.ProxyHost = "expired.host"
-
-	s.store.AddKey("good.host", "sam", good)
-	s.store.AddKey("expired.host", "sam", expired)
-
-	// only "good" key should be returned
-	goodKey, err := s.store.GetKey("good.host", "sam")
-	c.Assert(err, check.IsNil)
-	c.Assert(goodKey, check.DeepEquals, good)
-
-	// expired key should not be returned
-	_, err = s.store.GetKey("expired.host", "sam")
-	c.Assert(err, check.NotNil)
-}
-
 func (s *KeyStoreTestSuite) TestKnownHosts(c *check.C) {
 	os.MkdirAll(s.store.KeyDir, 0777)
 	pub, _, _, _, err := ssh.ParseAuthorizedKey(CAPub)


### PR DESCRIPTION
**Purpose**

Show the proxy the user is logged into and metadata from the certificate.

**Implementation**

The output of `tsh status` after logging in looks like this:

```
$ tsh status
> Profile URL:  https://proxy.example.com:3080
  Logged in as: rjones
  Roles:        admin*
  Logins:       rjones
  Valid until:  2018-04-11 04:10:32 -0700 PDT [valid for 12h0m0s]
  Extensions:   permit-agent-forwarding, permit-port-forwarding, permit-pty

  Profile URL:  https://localhost:3080
  Logged in as: rjones
  Roles:        admin*
  Logins:       rjones
  Valid until:  2018-04-11 04:10:23 -0700 PDT [valid for 12h0m0s]
  Extensions:   permit-agent-forwarding, permit-port-forwarding, permit-pty


* RBAC is only available in Teleport Enterprise
  https://gravitaitonal.com/teleport/docs/enteprise
```

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1628