### PR TITLE
Fix issue with pip 10 being unable to remove requests library

### DIFF
--- a/assets/marketplace/files/install.sh
+++ b/assets/marketplace/files/install.sh
@@ -16,7 +16,7 @@ CURL_OPTS="-L --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300"
 # remove it if you don't need letsencrypt.
 curl ${CURL_OPTS} -O https://bootstrap.pypa.io/get-pip.py
 python2.7 get-pip.py
-pip install awscli requests[security]==2.18.4
+pip install -I awscli requests[security]==2.18.4
 pip install certbot==0.21.0 certbot-dns-route53==0.21.0
 
 # Create teleport user. It is helpful to share the same UID


### PR DESCRIPTION
## Description

As per https://pip.pypa.io/en/stable/news/#b1-2018-03-31:
- Removed support for uninstalling projects which have been installed using distutils. distutils installed projects do not include metadata indicating what files belong to that install and thus it is impossible to actually uninstall them rather than just remove the metadata saying they've been installed while leaving all of the actual files behind. (#2386)

pip 10 has now been released and is installed when running get-pip.py as part of ```files/install.sh```. This script also attempts to install a specific version of the requests library, which normally entails removing the old version first. pip 10 now refuses to do this because a version of requests has already been installed using distutils and it cannot guarantee to remove it properly. This causes it to exit with a non-zero error code and therefore the packer build fails.

## Implementation

Adding ```-I``` to the ```pip install``` command means that the requests library is changed in-place rather than attempting to uninstall it first. This gets around the new pip 10 error and causes the packer build to complete.