### PR TITLE
Window size and login improvements

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -336,3 +336,10 @@ const (
 	// SharedDirMode is a mode for a directory shared with group
 	SharedDirMode = 0750
 )
+
+const (
+	// WindowChangeRequest is sent by servers to clients when the server
+	// side PTY has changed size. It is to inform clients to update their own PTY
+	// size.
+	WindowChangeRequest = "x-teleport-window-change"
+)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2004,6 +2004,120 @@ func (s *IntSuite) TestPAM(c *check.C) {
 	}
 }
 
+// TestWindowChange checks if custom Teleport window change requests are sent
+// when the server side PTY changes its size.
+func (s *IntSuite) TestWindowChange(c *check.C) {
+	t := s.newTeleport(c, nil, true)
+	defer t.Stop(true)
+
+	site := t.GetSiteAPI(Site)
+	c.Assert(site, check.NotNil)
+
+	personA := NewTerminal(250)
+	personB := NewTerminal(250)
+
+	// openSession will open a new session on a server.
+	openSession := func() {
+		cl, err := t.NewClient(ClientConfig{
+			Login:   s.me.Username,
+			Cluster: Site,
+			Host:    Host,
+			Port:    t.GetPortSSHInt(),
+		})
+		c.Assert(err, check.IsNil)
+
+		cl.Stdout = &personA
+		cl.Stdin = &personA
+
+		err = cl.SSH(context.TODO(), []string{}, false)
+		c.Assert(err, check.IsNil)
+	}
+
+	// joinSession will join the existing session on a server.
+	joinSession := func() {
+		// Find the existing session in the backend.
+		var sessionID string
+		for {
+			time.Sleep(time.Millisecond)
+			sessions, _ := site.GetSessions(defaults.Namespace)
+			if len(sessions) == 0 {
+				continue
+			}
+			sessionID = string(sessions[0].ID)
+			break
+		}
+
+		cl, err := t.NewClient(ClientConfig{
+			Login:   s.me.Username,
+			Cluster: Site,
+			Host:    Host,
+			Port:    t.GetPortSSHInt(),
+		})
+		c.Assert(err, check.IsNil)
+
+		cl.Stdout = &personB
+		cl.Stdin = &personB
+
+		// Change the size of the window immediately after it is created.
+		cl.OnShellCreated = func(s *ssh.Session, c *ssh.Client, terminal io.ReadWriteCloser) (exit bool, err error) {
+			err = s.WindowChange(48, 160)
+			if err != nil {
+				return true, trace.Wrap(err)
+			}
+			return false, nil
+		}
+
+		for i := 0; i < 10; i++ {
+			err = cl.Join(context.TODO(), defaults.Namespace, session.ID(sessionID), &personB)
+			if err == nil {
+				break
+			}
+		}
+		c.Assert(err, check.IsNil)
+	}
+
+	// waitForOutput checks the output of the passed in terminal of a string until
+	// some timeout has occured.
+	waitForOutput := func(t Terminal, s string) error {
+		tickerCh := time.Tick(500 * time.Millisecond)
+		timeoutCh := time.After(30 * time.Second)
+		for {
+			select {
+			case <-tickerCh:
+				if strings.Contains(t.Output(500), s) {
+					return nil
+				}
+			case <-timeoutCh:
+				return trace.BadParameter("timed out waiting for output")
+			}
+		}
+
+	}
+
+	// Open session, the initial size will be 80x24.
+	go openSession()
+
+	// Use the "printf" command to print the terminal size on the screen and
+	// make sure it is 80x25.
+	personA.Type("\aprintf '%s %s\n' $(tput cols) $(tput lines)\n\r\a")
+	err := waitForOutput(personA, "80 25")
+	c.Assert(err, check.IsNil)
+
+	// As soon as person B joins the session, the terminal is resized to 160x48.
+	// Have another user join the session. As soon as the second shell is
+	// created, the window is resized to 160x48 (see joinSession implementation).
+	go joinSession()
+
+	// Use the "printf" command to print the window size again and make sure it's
+	// 160x48.
+	personA.Type("\aprintf '%s %s\n' $(tput cols) $(tput lines)\n\r\a")
+	err = waitForOutput(personA, "160 48")
+	c.Assert(err, check.IsNil)
+
+	// Close the session.
+	personA.Type("\aexit\r\n\a")
+}
+
 // runCommand is a shortcut for running SSH command, it creates a client
 // connected to proxy of the passed in instance, runs the command, and returns
 // the result. If multiple attempts are requested, a 250 millisecond delay is

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/scp"
 	"github.com/gravitational/teleport/lib/utils"
@@ -63,6 +64,7 @@ type NodeClient struct {
 	Namespace string
 	Client    *ssh.Client
 	Proxy     *ProxyClient
+	TC        *TeleportClient
 }
 
 // GetSites returns list of the "sites" (AKA teleport clusters) connected to the proxy
@@ -420,9 +422,54 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress string,
 		return nil, trace.Wrap(err)
 	}
 
-	client := ssh.NewClient(conn, chans, reqs)
+	// We pass an empty channel which we close right away to ssh.NewClient
+	// because the client need to handle requests itself.
+	emptyCh := make(chan *ssh.Request)
+	close(emptyCh)
 
-	return &NodeClient{Client: client, Proxy: proxy, Namespace: defaults.Namespace}, nil
+	client := ssh.NewClient(conn, chans, emptyCh)
+
+	nc := &NodeClient{
+		Client:    client,
+		Proxy:     proxy,
+		Namespace: defaults.Namespace,
+		TC:        proxy.teleportClient,
+	}
+
+	// Start a goroutine that will run for the duration of the client to process
+	// global requests from the client. Teleport clients will use this to update
+	// terminal sizes when the remote PTY size has changed.
+	go nc.handleGlobalRequests(ctx, reqs)
+
+	return nc, nil
+}
+
+func (c *NodeClient) handleGlobalRequests(ctx context.Context, requestCh <-chan *ssh.Request) {
+	for {
+		select {
+		case r := <-requestCh:
+			// When the channel is closing, nil is returned.
+			if r == nil {
+				break
+			}
+
+			switch r.Type {
+			case teleport.WindowChangeRequest:
+				// Parse window change request and write to the channel.
+				wc, err := session.NewWindowChangeRequest(r.Payload)
+				if err != nil {
+					log.Warnf("Unable to parse window change request: %v: %v.", string(r.Payload), err)
+					continue
+				}
+				c.TC.SendWindowChangeRequest(wc)
+			default:
+				// This handles keepalive messages and matches the behaviour of OpenSSH.
+				r.Reply(false, nil)
+			}
+		case <-ctx.Done():
+			break
+		}
+	}
 }
 
 // newClientConn is a wrapper around ssh.NewClientConn
@@ -504,18 +551,18 @@ func (client *NodeClient) Download(remoteSourcePath, localDestinationPath string
 // scp runs remote scp command(shellCmd) on the remote server and
 // runs local scp handler using scpConf
 func (client *NodeClient) scp(scpCommand scp.Command, shellCmd string, errWriter io.Writer) error {
-	session, err := client.Client.NewSession()
+	s, err := client.Client.NewSession()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer session.Close()
+	defer s.Close()
 
-	stdin, err := session.StdinPipe()
+	stdin, err := s.StdinPipe()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	stdout, err := session.StdoutPipe()
+	stdout, err := s.StdoutPipe()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -537,7 +584,7 @@ func (client *NodeClient) scp(scpCommand scp.Command, shellCmd string, errWriter
 		close(closeC)
 	}()
 
-	runErr := session.Run(shellCmd)
+	runErr := s.Run(shellCmd)
 	if runErr != nil && err == nil {
 		err = runErr
 	}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -444,13 +444,14 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress string,
 	return nc, nil
 }
 
+// handleGlobalRequests processes global requests for the connection.
 func (c *NodeClient) handleGlobalRequests(ctx context.Context, requestCh <-chan *ssh.Request) {
 	for {
 		select {
 		case r := <-requestCh:
 			// When the channel is closing, nil is returned.
 			if r == nil {
-				break
+				return
 			}
 
 			switch r.Type {
@@ -467,7 +468,7 @@ func (c *NodeClient) handleGlobalRequests(ctx context.Context, requestCh <-chan 
 				r.Reply(false, nil)
 			}
 		case <-ctx.Done():
-			break
+			return
 		}
 	}
 }

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -281,81 +281,91 @@ func (ns *NodeSession) allocateTerminal(termType string, s *ssh.Session) (io.Rea
 }
 
 func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
-	// sibscribe for "terminal resized" signal:
-	sigC := make(chan os.Signal, 1)
-	signal.Notify(sigC, syscall.SIGWINCH)
-	currentSize, _ := term.GetWinsize(0)
+	// SIGWINCH is sent to the process when the window size of the terminal has
+	// changed.
+	sigwinchCh := make(chan os.Signal, 1)
+	signal.Notify(sigwinchCh, syscall.SIGWINCH)
 
-	// start the timer which asks for server-side window size changes:
-	siteClient, err := ns.nodeClient.Proxy.ConnectToSite(context.TODO(), true)
+	lastSize, err := term.GetWinsize(0)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("Unable to get window size: %v", err)
 		return
 	}
-	tick := time.NewTicker(defaults.SessionRefreshPeriod)
-	defer tick.Stop()
 
-	var prevSess *session.Session
+	// Sync the local terminal with size received from the remote server every
+	// two seconds. If we try and do it live, synchronization jitters occur.
+	tickerCh := time.NewTicker(defaults.SessionRefreshPeriod)
+	defer tickerCh.Stop()
+
 	for {
 		select {
-		// our own terminal window got resized:
-		case sig := <-sigC:
-			if sig == nil {
+		// The client updated the size of the local PTY. This change needs to occur
+		// on the server side PTY as well.
+		case sigwinch := <-sigwinchCh:
+			if sigwinch == nil {
 				return
 			}
-			// get the size:
-			winSize, err := term.GetWinsize(0)
+
+			currSize, err := term.GetWinsize(0)
 			if err != nil {
-				log.Warnf("[CLIENT] Error getting size: %s", err)
+				log.Warnf("Unable to get window size: %v.", err)
 				break
 			}
-			// it's the result of our own size change (see below)
-			if winSize.Height == currentSize.Height && winSize.Width == currentSize.Width {
+
+			// Terminal size has not changed, don't do anything.
+			if currSize.Height == lastSize.Height && currSize.Width == lastSize.Width {
 				continue
 			}
-			// send the new window size to the server
+
+			// Send the "window-change" request over the channel.
 			_, err = s.SendRequest(
-				sshutils.WindowChangeRequest, false,
+				sshutils.WindowChangeRequest,
+				false,
 				ssh.Marshal(sshutils.WinChangeReqParams{
-					W: uint32(winSize.Width),
-					H: uint32(winSize.Height),
+					W: uint32(currSize.Width),
+					H: uint32(currSize.Height),
 				}))
 			if err != nil {
-				log.Warnf("[CLIENT] failed to send window change reqest: %v", err)
-			}
-		case <-tick.C:
-			sess, err := siteClient.GetSession(ns.namespace, ns.id)
-			if err != nil {
-				if !trace.IsNotFound(err) {
-					log.Error(trace.DebugReport(err))
-				}
+				log.Warnf("Unable to send %v reqest: %v.", sshutils.WindowChangeRequest, err)
 				continue
 			}
-			// no previous session
-			if prevSess == nil || sess == nil {
-				prevSess = sess
-				continue
-			}
-			// nothing changed
-			if prevSess.TerminalParams.W == sess.TerminalParams.W && prevSess.TerminalParams.H == sess.TerminalParams.H {
-				continue
-			}
-			log.Infof("[CLIENT] updating the session %v with %d parties", sess.ID, len(sess.Parties))
 
-			newSize := sess.TerminalParams.Winsize()
-			currentSize, err = term.GetWinsize(0)
+			log.Debugf("Updated window size from %v to %v due to SIGWINCH.", lastSize, currSize)
+
+			lastSize = currSize
+
+		// Extract and store size as it comes from the remote server.
+		case wc := <-ns.nodeClient.TC.WindowChangeRequests():
+			lastSize = wc.TerminalParams.Winsize()
+			log.Debugf("Recevied window size %v from node in session.\n", lastSize, wc.SessionID)
+
+		// Update size of local terminal with the last size received from remote server.
+		case <-tickerCh.C:
+			// Get the current size of the terminal and the last size report that was
+			// received.
+			currSize, err := term.GetWinsize(0)
 			if err != nil {
-				log.Error(err)
+				log.Warnf("Unable to get current terminal size: %v.", err)
+				continue
 			}
-			if currentSize.Width != newSize.Width || currentSize.Height != newSize.Height {
-				// ok, something have changed, let's resize to the new parameters
-				err = term.SetWinsize(0, newSize)
-				if err != nil {
-					log.Error(err)
-				}
-				os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", newSize.Height, newSize.Width)))
+
+			// Terminal size has not changed, don't do anything.
+			if currSize.Width == lastSize.Width && currSize.Height == lastSize.Height {
+				continue
 			}
-			prevSess = sess
+
+			// This changes the size of the local PTY. This will re-draw what's within
+			// the window.
+			err = term.SetWinsize(0, lastSize)
+			if err != nil {
+				log.Warnf("Unable to update terminal size: %v.\n", err)
+				continue
+			}
+
+			// This is what we use to resize the physical terminal window itself.
+			os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", lastSize.Height, lastSize.Width)))
+
+			log.Debugf("Updated window size from to %v due to remote window change.", currSize, lastSize)
 		case <-ns.closer.C:
 			return
 		}

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -309,7 +309,7 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 			currSize, err := term.GetWinsize(0)
 			if err != nil {
 				log.Warnf("Unable to get window size: %v.", err)
-				break
+				continue
 			}
 
 			// Terminal size has not changed, don't do anything.
@@ -366,6 +366,8 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 			os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", lastSize.Height, lastSize.Width)))
 
 			log.Debugf("Updated window size from to %v due to remote window change.", currSize, lastSize)
+
+		// The session was closed.
 		case <-ns.closer.C:
 			return
 		}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -224,10 +224,6 @@ var (
 	// session will be considered idle
 	SessionIdlePeriod = SessionRefreshPeriod * 10
 
-	// TerminalSizeRefreshPeriod is how frequently clients who share sessions sync up
-	// their terminal sizes
-	TerminalSizeRefreshPeriod = 2 * time.Second
-
 	// NewtworkBackoffDuration is a standard backoff on network requests
 	// usually is slow, e.g. once in 30 seconds
 	NetworkBackoffDuration = time.Second * 30

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -87,7 +87,8 @@ func NewExecRequest(ctx *ServerContext, command string) (Exec, error) {
 
 	// When in recording mode, return an *remoteExec which will execute the
 	// command on a remote host. This is used by in-memory forwarding nodes.
-	if ctx.ClusterConfig.GetSessionRecording() == services.RecordAtProxy {
+	clusterConfig := ctx.GetServer().GetClusterConfig()
+	if clusterConfig.GetSessionRecording() == services.RecordAtProxy {
 		return &remoteExec{
 			ctx:     ctx,
 			command: command,

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -76,8 +76,8 @@ type Exec interface {
 
 // NewExecRequest creates a new local or remote Exec.
 func NewExecRequest(ctx *ServerContext, command string) (Exec, error) {
-	// doesn't matter what mode the cluster is in, if this is a teleport node
-	// return a local *localExec
+	// It doesn't matter what mode the cluster is in, if this is a Teleport node
+	// return a local *localExec.
 	if ctx.srv.Component() == teleport.ComponentNode {
 		return &localExec{
 			Ctx:     ctx,
@@ -85,14 +85,9 @@ func NewExecRequest(ctx *ServerContext, command string) (Exec, error) {
 		}, nil
 	}
 
-	clusterConfig, err := ctx.srv.GetAccessPoint().GetClusterConfig()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// when in recording mode, return an *remoteExec which will execute the
-	// command on a remote host. used by forwarding nodes.
-	if clusterConfig.GetSessionRecording() == services.RecordAtProxy {
+	// When in recording mode, return an *remoteExec which will execute the
+	// command on a remote host. This is used by in-memory forwarding nodes.
+	if ctx.ClusterConfig.GetSessionRecording() == services.RecordAtProxy {
 		return &remoteExec{
 			ctx:     ctx,
 			command: command,
@@ -100,8 +95,8 @@ func NewExecRequest(ctx *ServerContext, command string) (Exec, error) {
 		}, nil
 	}
 
-	// otherwise return a *localExec which will execute locally on the server.
-	// used by the regular teleport nodes.
+	// Otherwise return a *localExec which will execute locally on the server.
+	// used by the regular Teleport nodes.
 	return &localExec{
 		Ctx:     ctx,
 		Command: command,

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -125,6 +125,11 @@ type Server struct {
 
 	// dataDir is a server local data directory
 	dataDir string
+
+	// cachedClusterConfig stores a cached copy of the cluster config to avoid
+	// hamming the backend with too many requests.
+	cachedClusterConfig   services.ClusterConfig
+	cachedClusterConfigMu sync.RWMutex
 }
 
 // GetDataDir returns server data dir
@@ -159,22 +164,71 @@ func (s *Server) GetPAM() (*pam.Config, error) {
 	return s.pamConfig, nil
 }
 
+// GetClusterConfig returns a cached services.ClusterConfig for this cluster.
+func (s *Server) GetClusterConfig() services.ClusterConfig {
+	return s.getCachedClusterConfig()
+}
+
 // isAuditedAtProxy returns true if sessions are being recorded at the proxy
 // and this is a Teleport node.
 func (s *Server) isAuditedAtProxy() bool {
-	// always be safe, better to double record than not record at all
-	clusterConfig, err := s.GetAccessPoint().GetClusterConfig()
-	if err != nil {
-		return false
-	}
-
-	isRecordAtProxy := clusterConfig.GetSessionRecording() == services.RecordAtProxy
+	isRecordAtProxy := s.GetClusterConfig().GetSessionRecording() == services.RecordAtProxy
 	isTeleportNode := s.Component() == teleport.ComponentNode
 
 	if isRecordAtProxy && isTeleportNode {
 		return true
 	}
 	return false
+}
+
+// syncCachedClusterConfigLoop keeps updating the cached cluster config.
+func (s *Server) syncCachedClusterConfigLoop() {
+	// Update the cache at the same rate nodes heartbeat.
+	tickerCh := time.NewTicker(defaults.ServerHeartbeatTTL)
+	defer tickerCh.Stop()
+
+	for {
+		select {
+		case <-s.closer.C:
+			return
+		case <-tickerCh.C:
+			err := s.syncCachedClusterConfig()
+			if err != nil {
+				log.Warnf("Failed to sync cluster config: %v.", err)
+				continue
+			}
+		}
+	}
+}
+
+// getCachedClusterConfig returns a copy of cached services.ClusterConfig. If
+// nothing is cached yet, a safe default is returned.
+func (s *Server) getCachedClusterConfig() services.ClusterConfig {
+	s.cachedClusterConfigMu.RLock()
+	defer s.cachedClusterConfigMu.RUnlock()
+
+	// If the cache is empty, return a safe default.
+	clusterConfig := s.cachedClusterConfig
+	if clusterConfig == nil {
+		return services.DefaultClusterConfig()
+	}
+
+	return s.cachedClusterConfig.Copy()
+}
+
+// syncCachedClusterConfig gets cluster config from the backend and updated
+// the cached value.
+func (s *Server) syncCachedClusterConfig() error {
+	clusterConfig, err := s.authService.GetClusterConfig()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.cachedClusterConfigMu.Lock()
+	defer s.cachedClusterConfigMu.Unlock()
+
+	s.cachedClusterConfig = clusterConfig
+	return nil
 }
 
 // ServerOption is a functional option passed to the server
@@ -196,21 +250,46 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return err
 }
 
-// Start starts server
-func (s *Server) Start() error {
+func (s *Server) startLoops() error {
 	if len(s.getCommandLabels()) > 0 {
 		s.updateLabels()
 	}
+
+	// Keep heartbeating back that this node is up to the auth server.
 	go s.heartbeatPresence()
+
+	// Do a blocking sync of the cluster configuration so it starts with the
+	// correct configuration.
+	err := s.syncCachedClusterConfig()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Loop forever in the background syncing the cluster configuration in the
+	// backend with a local copy. This is for performance because the cluster
+	// configuration is frequently fetched during login.
+	go s.syncCachedClusterConfigLoop()
+
+	return nil
+}
+
+// Start starts server.
+func (s *Server) Start() error {
+	err := s.startLoops()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	return s.srv.Start()
 }
 
-// Serve servers service on started listener
+// Serve servers service on started listener.
 func (s *Server) Serve(l net.Listener) error {
-	if len(s.getCommandLabels()) > 0 {
-		s.updateLabels()
+	err := s.startLoops()
+	if err != nil {
+		return trace.Wrap(err)
 	}
-	go s.heartbeatPresence()
+
 	return s.srv.Serve(l)
 }
 
@@ -383,19 +462,20 @@ func New(addr utils.NetAddr,
 		return nil, trace.Wrap(err)
 	}
 
-	// add in common auth handlers
+	// Add in common auth handlers.
 	s.authHandlers = &srv.AuthHandlers{
 		Entry: log.WithFields(log.Fields{
 			trace.Component:       component,
 			trace.ComponentFields: log.Fields{},
 		}),
-		Server:      s.getInfo(),
+		Server:      s,
+		ServerInfo:  s.getInfo(),
 		Component:   component,
 		AuditLog:    s.alog,
 		AccessPoint: s.authService,
 	}
 
-	// common term handlers
+	// Common term handlers.
 	s.termHandlers = &srv.TermHandlers{
 		SessionRegistry: s.reg,
 	}
@@ -710,13 +790,7 @@ func (s *Server) HandleNewChan(nc net.Conn, sconn *ssh.ServerConn, nch ssh.NewCh
 func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, req *sshutils.DirectTCPIPReq) {
 	// Create context for this channel. This context will be closed when
 	// forwarding is complete.
-	ctx, err := srv.NewServerContext(s, sconn, identityContext)
-	if err != nil {
-		ctx.Errorf("Unable to create connection context: %v.", err)
-		ch.Stderr().Write([]byte("Unable to create connection context."))
-		return
-	}
-
+	ctx := srv.NewServerContext(s, sconn, identityContext)
 	ctx.IsTestStub = s.isTestStub
 	ctx.AddCloser(ch)
 	defer ctx.Debugf("direct-tcp closed")
@@ -726,7 +800,7 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 	dstAddr := fmt.Sprintf("%v:%d", req.Host, req.Port)
 
 	// check if the role allows port forwarding for this user
-	err = s.authHandlers.CheckPortForward(dstAddr, ctx)
+	err := s.authHandlers.CheckPortForward(dstAddr, ctx)
 	if err != nil {
 		ch.Stderr().Write([]byte(err.Error()))
 		return
@@ -802,12 +876,7 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 func (s *Server) handleSessionRequests(sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, in <-chan *ssh.Request) {
 	// Create context for this channel. This context will be closed when the
 	// session request is complete.
-	ctx, err := srv.NewServerContext(s, sconn, identityContext)
-	if err != nil {
-		ctx.Errorf("Unable to create connection context: %v.", err)
-		ch.Stderr().Write([]byte("Unable to create connection context."))
-		return
-	}
+	ctx := srv.NewServerContext(s, sconn, identityContext)
 	ctx.IsTestStub = s.isTestStub
 	ctx.AddCloser(ch)
 	defer ctx.Close()
@@ -960,7 +1029,7 @@ func (s *Server) handleAgentForwardNode(req *ssh.Request, ctx *srv.ServerContext
 func (s *Server) handleAgentForwardProxy(req *ssh.Request, ctx *srv.ServerContext) error {
 	// Forwarding an agent to the proxy is only supported when the proxy is in
 	// recording mode.
-	if ctx.ClusterConfig.GetSessionRecording() != services.RecordAtProxy {
+	if s.GetClusterConfig().GetSessionRecording() != services.RecordAtProxy {
 		return trace.BadParameter("agent forwarding to proxy only supported in recording mode")
 	}
 
@@ -1042,20 +1111,10 @@ func (s *Server) handleRecordingProxy(req *ssh.Request) {
 	log.Debugf("Global request (%v, %v) received", req.Type, req.WantReply)
 
 	if req.WantReply {
-		// get the cluster config, if we can't get it, reply false
-		clusterConfig, err := s.authService.GetClusterConfig()
-		if err != nil {
-			err := req.Reply(false, nil)
-			if err != nil {
-				log.Warnf("Unable to respond to global request (%v, %v): %v", req.Type, req.WantReply, err)
-			}
-			return
-		}
-
-		// reply true that we were able to process the message and reply with a
-		// bool if we are in recording mode or not
-		recordingProxy = clusterConfig.GetSessionRecording() == services.RecordAtProxy
-		err = req.Reply(true, []byte(strconv.FormatBool(recordingProxy)))
+		// Reply true that we were able to process the message and reply with a
+		// bool if we are in recording mode or not.
+		recordingProxy = s.GetClusterConfig().GetSessionRecording() == services.RecordAtProxy
+		err := req.Reply(true, []byte(strconv.FormatBool(recordingProxy)))
 		if err != nil {
 			log.Warnf("Unable to respond to global request (%v, %v): %v: %v", req.Type, req.WantReply, recordingProxy, err)
 			return

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -961,15 +961,17 @@ func (s *SrvSuite) TestServerAliveInterval(c *C) {
 // TestGlobalRequestRecordingProxy simulates sending a global out-of-band
 // recording-proxy@teleport.com request.
 func (s *SrvSuite) TestGlobalRequestRecordingProxy(c *C) {
-	// set cluster config to record at the node
+	// Set cluster config to record at the node.
 	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
 		SessionRecording: services.RecordAtNode,
 	})
 	c.Assert(err, IsNil)
 	err = s.server.Auth().SetClusterConfig(clusterConfig)
 	c.Assert(err, IsNil)
+	err = s.srv.syncCachedClusterConfig()
+	c.Assert(err, IsNil)
 
-	// send the request again, we have cluster config and when we parse the
+	// Send the request again, we have cluster config and when we parse the
 	// response, it should be false because recording is occuring at the node.
 	ok, responseBytes, err := s.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
 	c.Assert(err, IsNil)
@@ -978,15 +980,17 @@ func (s *SrvSuite) TestGlobalRequestRecordingProxy(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(response, Equals, false)
 
-	// set cluster config to record at the proxy
+	// Set cluster config to record at the proxy.
 	clusterConfig, err = services.NewClusterConfig(services.ClusterConfigSpecV3{
 		SessionRecording: services.RecordAtProxy,
 	})
 	c.Assert(err, IsNil)
 	err = s.server.Auth().SetClusterConfig(clusterConfig)
 	c.Assert(err, IsNil)
+	err = s.srv.syncCachedClusterConfig()
+	c.Assert(err, IsNil)
 
-	// send request again, now that we have cluster config and it's set to record
+	// Send request again, now that we have cluster config and it's set to record
 	// at the proxy, we should return true and when we parse the payload it should
 	// also be true
 	ok, responseBytes, err = s.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -264,7 +264,8 @@ func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *S
 	// If sessions are being recorded at the proxy, sessions can not be shared.
 	// In that situation, PTY size information does not need to be propagated
 	// back to all clients and we can return right away.
-	if ctx.ClusterConfig.GetSessionRecording() == services.RecordAtProxy {
+	clusterConfig := ctx.GetServer().GetClusterConfig()
+	if clusterConfig.GetSessionRecording() == services.RecordAtProxy {
 		return nil
 	}
 
@@ -345,7 +346,7 @@ func newSessionRecorder(alog events.IAuditLog, ctx *ServerContext, sid rsession.
 			SessionID:      sid,
 			ServerID:       "upload",
 			DataDir:        filepath.Join(ctx.srv.GetDataDir(), teleport.LogsDir),
-			RecordSessions: ctx.ClusterConfig.GetSessionRecording() != services.RecordOff,
+			RecordSessions: ctx.GetServer().GetClusterConfig().GetSessionRecording() != services.RecordOff,
 			Namespace:      ctx.srv.GetNamespace(),
 			ForwardTo:      alog,
 		})
@@ -780,7 +781,8 @@ func (s *session) getNamespace() string {
 func (s *session) activeHeartbeat(ctx *ServerContext) {
 	// If sessions are being recorded at the proxy, an identical version of this
 	// goroutine is running in the proxy, which means it does not need to run here.
-	if ctx.ClusterConfig.GetSessionRecording() == services.RecordAtProxy &&
+	clusterConfig := ctx.GetServer().GetClusterConfig()
+	if clusterConfig.GetSessionRecording() == services.RecordAtProxy &&
 		s.registry.srv.Component() == teleport.ComponentNode {
 		return
 	}

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -235,15 +235,18 @@ func (s *SessionRegistry) getParties(ctx *ServerContext) (parties []*party) {
 	return parties
 }
 
-// notifyWinChange is called when an SSH server receives a command notifying
-// us that the terminal size has changed
+// NotifyWinChange is called to notify all members in the party that the PTY
+// size has changed. The notification is sent as a global SSH request and it
+// is the responsibility of the client to update it's window size upon receipt.
 func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *ServerContext) error {
 	if ctx.session == nil {
 		s.log.Debugf("Unable to update window size, no session found in context.")
 		return nil
 	}
 	sid := ctx.session.id
-	// report this to the event/audit log:
+
+	// Report the updated window size to the event log (this is so the sessions
+	// can be replayed correctly).
 	ctx.session.recorder.alog.EmitAuditEvent(events.ResizeEvent, events.EventFields{
 		events.EventNamespace: s.srv.GetNamespace(),
 		events.SessionEventID: sid,
@@ -251,24 +254,49 @@ func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *S
 		events.EventUser:      ctx.Identity.TeleportUser,
 		events.TerminalSize:   params.Serialize(),
 	})
+
+	// Update the size of the server side PTY.
 	err := ctx.session.term.SetWinSize(params)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	// notify all connected parties about the change in real time
-	// (if they're capable)
-	for _, p := range s.getParties(ctx) {
-		p.onWindowChanged(&params)
+	// If sessions are being recorded at the proxy, sessions can not be shared.
+	// In that situation, PTY size information does not need to be propagated
+	// back to all clients and we can return right away.
+	if ctx.ClusterConfig.GetSessionRecording() == services.RecordAtProxy {
+		return nil
 	}
 
-	go func() {
-		err := s.srv.GetSessionServer().UpdateSession(
-			rsession.UpdateRequest{ID: sid, TerminalParams: &params, Namespace: s.srv.GetNamespace()})
-		if err != nil {
-			s.log.Errorf("Unable to update session %v: %v", sid, err)
+	// Notify all members of the party (except originator) that the size of the
+	// window has changed so the client can update it's own local PTY. Note that
+	// OpenSSH clients will ignore this and not update their own local PTY.
+	for _, p := range s.getParties(ctx) {
+		// Don't send the window change notification back to the originator.
+		if p.ctx.ID() == ctx.ID() {
+			continue
 		}
-	}()
+
+		// Create and serialize message to be sent to client.
+		wc := rsession.WindowChangeRequest{
+			SessionID:      sid.String(),
+			Time:           time.Now(),
+			TerminalParams: params,
+		}
+		wcMessage, err := wc.Serialize()
+		if err != nil {
+			s.log.Warnf("Unable to serialize window change parameters for %v: %v.", p.sconn.RemoteAddr(), err)
+			continue
+		}
+
+		// Send the message as a global request.
+		_, _, err = p.sconn.SendRequest(teleport.WindowChangeRequest, false, wcMessage)
+		if err != nil {
+			s.log.Warnf("Unable to send window change notification to %v: %v.", p.sconn.RemoteAddr(), err)
+		}
+		s.log.Debugf("Sent %v window change notification to %v.", params, p.sconn.RemoteAddr())
+	}
+
 	return nil
 }
 
@@ -289,43 +317,6 @@ func (s *SessionRegistry) findSession(id rsession.ID) (*session, bool) {
 	return sess, found
 }
 
-func (r *SessionRegistry) PushTermSizeToParty(sconn *ssh.ServerConn, ch ssh.Channel) error {
-	// the party may not be immediately available for this connection,
-	// keep asking for a full second:
-	for i := 0; i < 10; i++ {
-		party := r.partyForConnection(sconn)
-		if party == nil {
-			time.Sleep(time.Millisecond * 100)
-			continue
-		}
-
-		// this starts a loop which will keep updating the terminal
-		// size for every SSH write back to this connection
-		party.termSizePusher(ch)
-		return nil
-	}
-
-	return trace.Errorf("unable to push term size to party")
-}
-
-// partyForConnection finds an existing party which owns the given connection
-func (r *SessionRegistry) partyForConnection(sconn *ssh.ServerConn) *party {
-	r.Lock()
-	defer r.Unlock()
-
-	for _, session := range r.sessions {
-		session.Lock()
-		defer session.Unlock()
-		parties := session.parties
-		for _, party := range parties {
-			if party.sconn == sconn {
-				return party
-			}
-		}
-	}
-	return nil
-}
-
 // sessionRecorder implements io.Writer to be plugged into the multi-writer
 // associated with every session. It forwards session stream to the audit log
 type sessionRecorder struct {
@@ -343,21 +334,18 @@ type sessionRecorder struct {
 }
 
 func newSessionRecorder(alog events.IAuditLog, ctx *ServerContext, sid rsession.ID) (*sessionRecorder, error) {
+	var err error
 	var auditLog events.IAuditLog
 	if alog == nil {
 		auditLog = &events.DiscardAuditLog{}
 	} else {
-		clusterConfig, err := ctx.srv.GetAccessPoint().GetClusterConfig()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		// always write sessions to local disk first
-		// forward them to auth server later
+		// Always write sessions to local disk first, then forward them to the Auth
+		// Server later.
 		auditLog, err = events.NewForwarder(events.ForwarderConfig{
 			SessionID:      sid,
 			ServerID:       "upload",
 			DataDir:        filepath.Join(ctx.srv.GetDataDir(), teleport.LogsDir),
-			RecordSessions: clusterConfig.GetSessionRecording() != services.RecordOff,
+			RecordSessions: ctx.ClusterConfig.GetSessionRecording() != services.RecordOff,
 			Namespace:      ctx.srv.GetNamespace(),
 			ForwardTo:      alog,
 		})
@@ -644,9 +632,8 @@ func (s *session) start(ch ssh.Channel, ctx *ServerContext) error {
 		events.TerminalSize:    params.Serialize(),
 	})
 
-	// start asynchronous loop of synchronizing session state with
-	// the session server (terminal size and activity)
-	go s.pollAndSync()
+	// Start a heartbeat that marks this session as active in the backend.
+	go s.activeHeartbeat(ctx)
 
 	doneCh := make(chan bool, 1)
 
@@ -786,77 +773,47 @@ func (s *session) getNamespace() string {
 	return s.registry.srv.GetNamespace()
 }
 
-// pollAndSync is a loops forever trying to sync terminal size to what's in
-// the session (so all connected parties have the same terminal size) and
-// update the "active" field of the session. If the session are recorded at
-// the proxy, then this function does nothing as it's counterpart in the proxy
-// will do this work.
-func (s *session) pollAndSync() {
+// activeHeartbeat continued to update the session and mark it as active in
+// the backend as long as the session is not closed. If the session are
+// recorded at the proxy, then this function does nothing as it's counterpart
+// in the proxy will do this work.
+func (s *session) activeHeartbeat(ctx *ServerContext) {
 	// If sessions are being recorded at the proxy, an identical version of this
 	// goroutine is running in the proxy, which means it does not need to run here.
-	clusterConfig, err := s.registry.srv.GetAccessPoint().GetClusterConfig()
-	if err != nil {
-		s.log.Errorf("Unable to sync terminal size: %v.", err)
+	if ctx.ClusterConfig.GetSessionRecording() == services.RecordAtProxy &&
+		s.registry.srv.Component() == teleport.ComponentNode {
 		return
 	}
-	if clusterConfig.GetSessionRecording() == services.RecordAtProxy &&
-		s.registry.srv.Component() == teleport.ComponentNode {
+
+	// If no session server (endpoint interface for active sessions) is passed in
+	// (for example Teleconsole does this) then nothing to sync.
+	sessionServer := s.registry.srv.GetSessionServer()
+	if sessionServer == nil {
 		return
 	}
 
 	s.log.Debugf("Starting poll and sync of terminal size to all parties.")
 	defer s.log.Debugf("Stopping poll and sync of terminal size to all parties.")
 
-	ns := s.getNamespace()
+	tickerCh := time.NewTicker(defaults.SessionRefreshPeriod)
+	defer tickerCh.Stop()
 
-	sessionServer := s.registry.srv.GetSessionServer()
-	if sessionServer == nil {
-		return
-	}
-	errCount := 0
-	sync := func() error {
-		sess, err := sessionServer.GetSession(ns, s.id)
-		if err != nil || sess == nil {
-			return trace.Wrap(err)
-		}
-		var active = true
-		sessionServer.UpdateSession(rsession.UpdateRequest{
-			Namespace: ns,
-			ID:        sess.ID,
-			Active:    &active,
-			Parties:   nil,
-		})
-		winSize, err := s.term.GetWinSize()
-		if err != nil {
-			return err
-		}
-		termSizeChanged := (int(winSize.Width) != sess.TerminalParams.W ||
-			int(winSize.Height) != sess.TerminalParams.H)
-		if termSizeChanged {
-			s.log.Debugf("Terminal changed from: %v to %v", sess.TerminalParams, winSize)
-			err = s.term.SetWinSize(sess.TerminalParams)
-		}
-		return err
-	}
-
-	tick := time.NewTicker(defaults.TerminalSizeRefreshPeriod)
-	defer tick.Stop()
+	// Loop as long as the session is active, updating the session in the backend.
 	for {
-		if err := sync(); err != nil {
-			s.log.Infof("Unable to sync terminal: %v", err)
-			errCount++
-			// if the error count keeps going up, this means we're stuck in
-			// a bad state: end this goroutine to avoid leaks
-			if errCount > maxTermSyncErrorCount {
-				return
-			}
-		} else {
-			errCount = 0
-		}
 		select {
+		case <-tickerCh.C:
+			var active = true
+			err := sessionServer.UpdateSession(rsession.UpdateRequest{
+				Namespace: s.getNamespace(),
+				ID:        s.id,
+				Active:    &active,
+				Parties:   nil,
+			})
+			if err != nil {
+				s.log.Warnf("Unable to update session %v as active: %v", s.id, err)
+			}
 		case <-s.closeC:
 			return
-		case <-tick.C:
 		}
 	}
 }
@@ -1043,48 +1000,6 @@ func newParty(s *session, ch ssh.Channel, ctx *ServerContext) *party {
 		sconn:     ctx.Conn,
 		termSizeC: make(chan []byte, 5),
 		closeC:    make(chan bool),
-	}
-}
-
-func (p *party) onWindowChanged(params *rsession.TerminalParams) {
-	p.log.Debugf("Window size changed to %v in party: %v", params.Serialize(), p.id)
-
-	p.Lock()
-	defer p.Unlock()
-
-	// this prefix will be appended to the end of every socker write going
-	// to this party:
-	prefix := []byte("\x00" + params.Serialize())
-	if p.termSizeC != nil && len(p.termSizeC) == 0 {
-		p.termSizeC <- prefix
-	}
-}
-
-// This goroutine pushes terminal resize events directly into a connected web client
-func (p *party) termSizePusher(ch ssh.Channel) {
-	var (
-		err error
-		n   int
-	)
-	defer func() {
-		if err != nil {
-			p.log.Error(err)
-		}
-	}()
-
-	for err == nil {
-		select {
-		case newSize := <-p.termSizeC:
-			n, err = ch.Write(newSize)
-			if err == io.EOF {
-				continue
-			}
-			if err != nil || n == 0 {
-				return
-			}
-		case <-p.closeC:
-			return
-		}
 	}
 }
 

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -93,7 +93,8 @@ func NewTerminal(ctx *ServerContext) (Terminal, error) {
 
 	// If this is not a Teleport node, find out what mode the cluster is in and
 	// return the correct terminal.
-	if ctx.ClusterConfig.GetSessionRecording() == services.RecordAtProxy {
+	clusterConfig := ctx.GetServer().GetClusterConfig()
+	if clusterConfig.GetSessionRecording() == services.RecordAtProxy {
 		return newRemoteTerminal(ctx)
 	}
 	return newLocalTerminal(ctx)

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -85,19 +85,15 @@ type Terminal interface {
 // NewTerminal returns a new terminal. Terminal can be local or remote
 // depending on cluster configuration.
 func NewTerminal(ctx *ServerContext) (Terminal, error) {
-	// doesn't matter what mode the cluster is in, if this is a teleport node
-	// return a local terminal
+	// It doesn't matter what mode the cluster is in, if this is a Teleport node
+	// return a local terminal.
 	if ctx.srv.Component() == teleport.ComponentNode {
 		return newLocalTerminal(ctx)
 	}
 
-	// otherwise find out what mode the cluster is in and return the
-	// correct terminal
-	clusterConfig, err := ctx.srv.GetAccessPoint().GetClusterConfig()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if clusterConfig.GetSessionRecording() == services.RecordAtProxy {
+	// If this is not a Teleport node, find out what mode the cluster is in and
+	// return the correct terminal.
+	if ctx.ClusterConfig.GetSessionRecording() == services.RecordAtProxy {
 		return newRemoteTerminal(ctx)
 	}
 	return newLocalTerminal(ctx)

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -180,22 +180,16 @@ func (t *TermHandlers) HandleShell(ch ssh.Channel, req *ssh.Request, ctx *Server
 }
 
 // HandleWinChange handles requests of type "window-change" which update the
-// size of the TTY running on the server.
+// size of the PTY running on the server and update any other members in the
+// party.
 func (t *TermHandlers) HandleWinChange(ch ssh.Channel, req *ssh.Request, ctx *ServerContext) error {
 	params, err := parseWinChange(req)
 	if err != nil {
-		ctx.Error(err)
 		return trace.Wrap(err)
 	}
 
-	term := ctx.GetTerm()
-	if term != nil {
-		err = term.SetWinSize(*params)
-		if err != nil {
-			ctx.Errorf("Unable to set window size: %v", err)
-		}
-	}
-
+	// Update any other members in the party that the window size has changed
+	// and to update their terminal windows accordingly.
 	err = t.SessionRegistry.NotifyWinChange(*params, ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/web/stream.go
+++ b/lib/web/stream.go
@@ -144,6 +144,7 @@ func (w *sessionStreamHandler) stream(ws *websocket.Conn) error {
 				log.Errorf("Unable to send server list event to web client: %v.", err)
 				continue
 			}
+		// Stream is closing.
 		case <-w.closeC:
 			log.Infof("Exiting event stream to web client.")
 			return nil

--- a/lib/web/stream.go
+++ b/lib/web/stream.go
@@ -17,6 +17,7 @@ limitations under the License.
 package web
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -67,9 +68,9 @@ func (w *sessionStreamHandler) Close() error {
 	return nil
 }
 
-// sessionStreamPollPeriod defines how frequently web sessions are
-// sent new events
-var sessionStreamPollPeriod = time.Second
+// sessionStreamPollPeriod defines how frequently web sessions are sent new
+// events.
+var sessionStreamPollPeriod = 5 * time.Second
 
 // stream runs in a loop generating "something changed" events for a
 // given active WebSession
@@ -88,71 +89,66 @@ func (w *sessionStreamHandler) stream(ws *websocket.Conn) error {
 		io.Copy(ioutil.Discard, ws)
 	}()
 
-	eventsCursor := -1
-	emptyEventList := make([]events.EventFields, 0)
+	// Ticker used to send list of servers to web client periodically.
+	tickerCh := time.NewTicker(w.pollPeriod)
+	defer tickerCh.Stop()
 
-	pollEvents := func() []events.EventFields {
-		// ask for any events than happened since the last call:
-		re, err := clt.GetSessionEvents(w.namespace, w.sessionID, eventsCursor+1, false)
-		if err != nil {
-			if !trace.IsNotFound(err) {
-				log.Error(err)
-			}
-			return emptyEventList
-		}
-		batchLen := len(re)
-		if batchLen == 0 {
-			return emptyEventList
-		}
-		// advance the cursor, so next time we'll ask for the latest:
-		eventsCursor = re[batchLen-1].GetInt(events.EventCursor)
-		return re
-	}
-
-	ticker := time.NewTicker(w.pollPeriod)
-	defer ticker.Stop()
 	defer w.Close()
 
-	// keep polling in a loop:
+	c, err := w.ctx.getTerminal(w.sessionID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	for {
-		// wait for next timer tick or a signal to abort:
 		select {
-		case <-ticker.C:
+		// Push the new window size to the web client.
+		case wc := <-c.teleportClient.WindowChangeRequests():
+			win := wc.TerminalParams.Winsize()
+
+			// Convert the window change request into something that looks like an
+			// Audit Event for compatibility and send over the websocket.
+			streamEvents := &sessionStreamEvent{
+				Events: []events.EventFields{
+					events.EventFields{
+						events.EventType:      events.ResizeEvent,
+						events.SessionEventID: wc.SessionID,
+						events.EventTime:      wc.Time.String(),
+						events.TerminalSize:   fmt.Sprintf("%d:%d", win.Width, win.Height),
+					},
+				},
+			}
+			log.Debugf("Sending window change %v for %v to web client.", win, wc.SessionID)
+
+			err = websocket.JSON.Send(ws, streamEvents)
+			if err != nil {
+				log.Errorf("Unable to send window change event over websocket: %v", err)
+				continue
+			}
+		// Periodically send list of servers to the web client.
+		case <-tickerCh.C:
+			servers, err := clt.GetNodes(w.namespace)
+			if err != nil {
+				log.Errorf("Unable to fetch list of nodes: %v.", err)
+				continue
+			}
+
+			// Send list of server to the web client.
+			streamEvents := &sessionStreamEvent{
+				Servers: services.ServersToV1(servers),
+			}
+			log.Debugf("Sending server list (%v) to web client.", len(servers))
+
+			err = websocket.JSON.Send(ws, streamEvents)
+			if err != nil {
+				log.Errorf("Unable to send server list event to web client: %v.", err)
+				continue
+			}
 		case <-w.closeC:
-			log.Infof("[web] session.stream() exited")
+			log.Infof("Exiting event stream to web client.")
 			return nil
 		}
 
-		newEvents := pollEvents()
-		sess, err := clt.GetSession(w.namespace, w.sessionID)
-		if err != nil {
-			if trace.IsNotFound(err) {
-				continue
-			}
-			log.Error(err)
-		}
-		if sess == nil {
-			log.Warningf("invalid session ID: %v", w.sessionID)
-			continue
-		}
-		servers, err := clt.GetNodes(w.namespace)
-		if err != nil {
-			log.Error(err)
-		}
-		if len(newEvents) > 0 {
-			log.Infof("[WEB] streaming for %v. Events: %v, Nodes: %v, Parties: %v",
-				w.sessionID, len(newEvents), len(servers), len(sess.Parties))
-		}
-
-		// push events to the web client
-		event := &sessionStreamEvent{
-			Events:  newEvents,
-			Session: sess,
-			Servers: services.ServersToV1(servers),
-		}
-		if err := websocket.JSON.Send(ws, event); err != nil {
-			log.Error(err)
-		}
 	}
 }
 

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -112,6 +112,8 @@ type TerminalHandler struct {
 	hostPort int
 	// sshClient is initialized after an SSH connection to a node is established
 	sshSession *ssh.Session
+
+	teleportClient *client.TeleportClient
 }
 
 func (t *TerminalHandler) Close() error {
@@ -207,6 +209,8 @@ func (t *TerminalHandler) Run(w http.ResponseWriter, r *http.Request) {
 			errToTerm(err, ws)
 			return
 		}
+		t.teleportClient = tc
+
 		// this callback will execute when a shell is created, it will give
 		// us a reference to ssh.Client object
 		tc.OnShellCreated = func(s *ssh.Session, c *ssh.Client, _ io.ReadWriteCloser) (bool, error) {


### PR DESCRIPTION
**Purpose**

As described in #1874 and #1910, Teleport has performance issues with window size changes and initial login when using DynamoDB as the backend.

**Implementation**

* For window sizes changes, for regular sessions Teleport should propagate back the remote PTY size via a global SSH request from the server to the client. For sessions recorded at the proxy, nothing should be sent back because only the client can change the remote PTY size.
* Both servers in `lib/srv` have been refactored to use a cached copy of cluster configuration to reduce the number of requests to DynamoDB upon login.
* Improvements in `lib/web` so it runs consistently.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1874
Fixes https://github.com/gravitational/teleport/issues/1910