### PR TITLE
Dockerfiles redesign

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile makes the "build box": the container used to build
 # official releases of Teleport and its documentation
-FROM quay.io/gravitational/buildbox-base
+FROM quay.io/gravitational/buildbox-base:1.0
 
 ARG UID
 ARG GID

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,51 +1,16 @@
 # This Dockerfile makes the "build box": the container used to build
 # official releases of Teleport and its documentation
-FROM debian:jessie
+FROM quay.io/gravitational/buildbox-base
 
 ARG UID
 ARG GID
-
-ENV DEBIAN_FRONTEND noninteractive
-
-ADD locale.gen /etc/locale.gen
-ADD profile /etc/profile
 
 COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
 COPY pam/teleport-acct-failure /etc/pam.d
 COPY pam/teleport-session-failure /etc/pam.d
 COPY pam/teleport-success /etc/pam.d
 
-RUN (apt-get clean; \
-	 apt-get -q -y update --fix-missing; \
-     apt-get -q -y update; \
-     apt-get -q -y upgrade; \
-	 apt-get install -q -y apt-utils less locales)
-
-# Set locale to en_US.UTF-8
-RUN locale-gen; \
-	locale-gen en_US.UTF-8 ;\
-	dpkg-reconfigure locales
-
-RUN apt-get install -q -y \
-         libsqlite3-0 \
-         curl \
-         make \
-         git \
-         libc6-dev \
-         libpam-dev \
-         gcc \
-         tar \
-         gzip \
-         python \
-         python-pip \
-         libyaml-dev \
-         python-dev \
-         nginx \
-         zip; \
-      apt-get -y autoclean; apt-get -y clean
-
-# Install mkDocs
-RUN pip install click==6.1 recommonmark==0.4.0 markdown-include==0.5.1 mkdocs==0.16.1 Markdown==2.6.7
+RUN apt-get install -q -y libpam-dev
 
 RUN (groupadd jenkins --gid=$GID -o && useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
      mkdir -p /var/lib/teleport && chown -R jenkins /var/lib/teleport)
@@ -62,14 +27,7 @@ RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/go1.9
     chmod a+w /var/lib;\
     chmod a-w /
 
-# Install SASS
-RUN  apt-get install -q -y ruby-sass
-
-ENV LANGUAGE="en_US.UTF-8" \
-    LANG="en_US.UTF-8" \
-    LC_ALL="en_US.UTF-8" \
-    LC_CTYPE="en_US.UTF-8" \
-    GOPATH="/gopath" \
+ENV GOPATH="/gopath" \
     GOROOT="/opt/go" \
     PATH="$PATH:/opt/go/bin:/gopath/bin:/gopath/src/github.com/gravitational/teleport/build"
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -2,6 +2,11 @@
 # This Makefile is used for producing official Teleport releases
 #
 BBOX=teleport-buildbox:latest
+
+DOCSBOX=teleport-docsbox:latest
+DOCSHOST=teleport-docs
+DOCSDIR=/teleport
+
 HOSTNAME=buildbox
 SRCDIR=/gopath/src/github.com/gravitational/teleport
 DOCKERFLAGS=--rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME)
@@ -33,6 +38,25 @@ bbox:
 	docker build --build-arg UID=$$(id -u) --build-arg GID=$$(id -g) --tag $(BBOX) .
 
 #
+# Builds a Docker container for building mkdocs documentation
+#
+.PHONY:
+docsbox:
+	docker build --build-arg UID=$$(id -u) \
+		         --build-arg GID=$$(id -g) \
+		         --build-arg USER=jenkins \
+	             --build-arg WORKDIR=$(DOCSDIR) \
+		         --tag $(DOCSBOX) -f docs.dockerfile .
+
+#
+# Removes the docker image
+#
+.PHONY:clean
+clean:
+	docker image rm --force $(BBOX)
+	docker image rm --force $(DOCSBOX)
+
+#
 # Runs tests inside a build container
 #
 .PHONY:test
@@ -52,23 +76,40 @@ integration: bbox
 # Builds docs
 #
 .PHONY:docs
-docs: bbox
-	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
-		-e HOME=$(SRCDIR)/build.assets $(BBOX) \
+docs: docsbox
+	docker run --rm=true -ti $(NOROOT) \
+		-v $$(pwd)/..:$(DOCSDIR) \
+		-v /tmp:/tmp \
+		-w $(DOCSDIR) \
+		-h $(DOCSHOST) $(DOCSBOX) \
 		./docs/build.sh
 	@echo "\nSUCCESS: Teleport docs ----> build/docs\n"
+
+#
+# allows to enter into bash shell of docs container
+#
+.PHONY:
+enter-docs: docsbox
+	docker run --rm=true $(NOROOT) \
+		-v $$(pwd)/..:$(DOCSDIR) \
+		-v /tmp:/tmp \
+		-w $(DOCSDIR) \
+		-h $(DOCSHOST) \
+		-ti $(DOCSBOX) /bin/bash
 
 #
 # Runs docs website on localhost
 #
 .PHONY:run-docs
-run-docs: bbox
+run-docs: docsbox
 	@echo -e "\n\n----> LIVE EDIT HERE: http://localhost:6600/admin-guide/\n"
-	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
+	docker run -ti $(NOROOT) \
+		-v $$(pwd)/..:$(DOCSDIR) \
+		-v /tmp:/tmp \
 		-e HOME=$(SRCDIR)/build.assets \
 		-p 6600:6600 \
-		-w $(SRCDIR) \
-		$(BBOX) docs/run.sh
+		-w $(DOCSDIR) \
+		$(DOCSBOX) docs/run.sh
 
 #
 # Starts shell inside the build container

--- a/build.assets/docs.dockerfile
+++ b/build.assets/docs.dockerfile
@@ -1,0 +1,14 @@
+FROM quay.io/gravitational/mkdocs-base
+
+ARG UID
+ARG GID
+ARG USER
+ARG WORKDIR
+
+RUN apt-get install -q -y ruby-sass
+
+RUN groupadd $USER --gid=$GID -o && useradd $USER --uid=$UID --gid=$GID --create-home --shell=/bin/bash
+RUN echo "source /etc/profile" > /home/$USER/.bashrc
+
+VOLUME ["$WORKDIR"]
+EXPOSE 6600

--- a/build.assets/docs.dockerfile
+++ b/build.assets/docs.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/mkdocs-base
+FROM quay.io/gravitational/mkdocs-base:0.16.1
 
 ARG UID
 ARG GID


### PR DESCRIPTION
## Changes

This commit optimizes the usage of Docker images.
There are 2 major changes:

* Docs and code are built using different Docker images:
        * `teleport-buildbox` is for building the code
        * `teleport-docsbox`  is for building the documentation
* Both docker images above are constructed using Gravitational-hosted
  _base_ images hosted on quay.io. Basically this means that majority of
  images are pre-built and hosted on quay. This makes the build process
  much faster.

## Quay.io

https://quay.io/repository/gravitational/mkdocs-base
https://quay.io/repository/gravitational/buildbox-base

@klizhentas it would be really nice if all our quay images were annotated properly, i.e.

- easy to see the purpose of the image
- easy to see the Dockerfile used to create it
- instructions for updating
