### PR TITLE
Switch to default dir backend.

### DIFF
--- a/lib/backend/boltbk/boltbk.go
+++ b/lib/backend/boltbk/boltbk.go
@@ -19,6 +19,7 @@ package boltbk
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -58,6 +59,24 @@ type BoltBackend struct {
 // as shown in 'storage/type' section of Teleport YAML config
 func GetName() string {
 	return "bolt"
+}
+
+// Exists returns true if backend has been used before
+func Exists(path string) (bool, error) {
+	path, err := filepath.Abs(filepath.Join(path, keysBoltFile))
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	f, err := os.Open(path)
+	err = trace.ConvertSystemError(err)
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return false, nil
+		}
+		return false, trace.Wrap(err)
+	}
+	defer f.Close()
+	return true, nil
 }
 
 // New initializes and returns a fully created BoltDB backend. It's

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -52,6 +52,12 @@ const (
 	// Default DB to use for persisting state. Another options is "etcd"
 	BackendType = "bolt"
 
+	// BackendDir is a default backend subdirectory
+	BackendDir = "backend"
+
+	// BackendPath is a default backend path parameter
+	BackendPath = "path"
+
 	// Name of events bolt database file stored in DataDir
 	EventsBoltFile = "events.db"
 

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/boltbk"
+	"github.com/gravitational/teleport/lib/backend/dir"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
@@ -378,8 +378,8 @@ func ApplyDefaults(cfg *Config) {
 	// defaults for the auth service:
 	cfg.Auth.Enabled = true
 	cfg.Auth.SSHAddr = *defaults.AuthListenAddr()
-	cfg.Auth.StorageConfig.Type = boltbk.GetName()
-	cfg.Auth.StorageConfig.Params = backend.Params{"path": cfg.DataDir}
+	cfg.Auth.StorageConfig.Type = dir.GetName()
+	cfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(cfg.DataDir, defaults.BackendDir)}
 	cfg.Auth.StaticTokens = services.DefaultStaticTokens()
 	cfg.Auth.ClusterConfig = services.DefaultClusterConfig()
 	defaults.ConfigureLimiter(&cfg.Auth.Limiter)

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package service
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/gravitational/teleport/lib/backend/dir"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -60,8 +62,8 @@ func (s *ConfigSuite) TestDefaultConfig(c *check.C) {
 	c.Assert(auth.SSHAddr, check.DeepEquals, localAuthAddr)
 	c.Assert(auth.Limiter.MaxConnections, check.Equals, int64(defaults.LimiterMaxConnections))
 	c.Assert(auth.Limiter.MaxNumberOfUsers, check.Equals, defaults.LimiterMaxConcurrentUsers)
-	c.Assert(auth.StorageConfig.Type, check.Equals, "bolt")
-	c.Assert(auth.StorageConfig.Params["path"], check.Equals, config.DataDir)
+	c.Assert(config.Auth.StorageConfig.Type, check.Equals, dir.GetName())
+	c.Assert(auth.StorageConfig.Params[defaults.BackendPath], check.Equals, filepath.Join(config.DataDir, defaults.BackendDir))
 
 	// SSH section
 	ssh := config.SSH

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1757,7 +1757,7 @@ func warnOnErr(err error) {
 // initAuthStorage initializes the storage backend for the auth service.
 func (process *TeleportProcess) initAuthStorage() (bk backend.Backend, err error) {
 	bc := &process.Config.Auth.StorageConfig
-
+	process.Debugf("Using %v backend.", bc.Type)
 	switch bc.Type {
 	// legacy bolt backend:
 	case boltbk.GetName():


### PR DESCRIPTION
This commit fixes #1741

* If bolt backend was used as a default,
new teleport continues using it as a default to prevent
regressions on start.

* Otherwise, dir backend is used as a default.