### PR TITLE
Precompute keys only for auth and proxies.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -143,7 +143,8 @@ func NewInstance(cfg InstanceConfig) *TeleInstance {
 		fatalIf(err)
 	}
 	// generate instance secrets (keys):
-	keygen := native.New()
+	keygen, err := native.New(native.PrecomputeKeys(0))
+	fatalIf(err)
 	if cfg.Priv == nil || cfg.Pub == nil {
 		cfg.Priv, cfg.Pub, _ = keygen.GenerateKeyPair("")
 	}
@@ -1276,6 +1277,10 @@ func fatalIf(err error) {
 }
 
 func makeKey() (priv, pub []byte) {
-	priv, pub, _ = native.New().GenerateKeyPair("")
+	k, err := native.New(native.PrecomputeKeys(0))
+	if err != nil {
+		panic(err)
+	}
+	priv, pub, _ = k.GenerateKeyPair("")
 	return priv, pub
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2377,7 +2377,7 @@ func (s *IntSuite) TestRotateTrustedClusters(c *check.C) {
 			if ca.GetRotation().Phase == phase {
 				return nil
 			}
-			lastPhase = phase
+			lastPhase = ca.GetRotation().Phase
 			time.Sleep(tconf.PollingPeriod / 2)
 		}
 		return trace.CompareFailed("failed to converge to phase %q, last phase %q", phase, lastPhase)

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -41,8 +41,9 @@ var _ = fmt.Printf
 
 func (s *NativeSuite) SetUpSuite(c *C) {
 	utils.InitLoggerForTests()
-	PrecomputedNum = 1
-	s.suite = &test.AuthSuite{A: New()}
+	a, err := New(PrecomputeKeys(1))
+	c.Assert(err, IsNil)
+	s.suite = &test.AuthSuite{A: a}
 }
 
 func (s *NativeSuite) TestGenerateKeypairEmptyPass(c *C) {
@@ -59,6 +60,17 @@ func (s *NativeSuite) TestGenerateHostCert(c *C) {
 
 func (s *NativeSuite) TestGenerateUserCert(c *C) {
 	s.suite.GenerateUserCert(c)
+}
+
+// TestDisablePrecompute makes sure that keygen works
+// when no keys are precomputed
+func (s *NativeSuite) TestDisablePrecompute(c *C) {
+	a, err := New(PrecomputeKeys(0))
+	c.Assert(err, IsNil)
+
+	caPrivateKey, _, err := a.GenerateKeyPair("")
+	c.Assert(err, IsNil)
+	c.Assert(caPrivateKey, NotNil)
 }
 
 // TestBuildPrincipals makes sure that the list of principals for a host

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -555,7 +555,17 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 	// Create a process wide key generator that will be shared. This is so the
 	// key generator can pre-generate keys and share these across services.
 	if cfg.Keygen == nil {
-		cfg.Keygen = native.New()
+		precomputeCount := native.PrecomputedNum
+		// in case if not auth or proxy services are enabled,
+		// there is no need to precompute any SSH keys in the pool
+		if !cfg.Auth.Enabled && !cfg.Proxy.Enabled {
+			precomputeCount = 0
+		}
+		var err error
+		cfg.Keygen, err = native.New(native.PrecomputeKeys(precomputeCount))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// Produce global TeleportReadyEvent

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -217,7 +217,10 @@ func (a *AuthCommand) ExportAuthorities(client auth.ClientI) error {
 
 // GenerateKeys generates a new keypair
 func (a *AuthCommand) GenerateKeys() error {
-	keygen := native.New()
+	keygen, err := native.New(native.PrecomputeKeys(0))
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	defer keygen.Close()
 	privBytes, pubBytes, err := keygen.GenerateKeyPair("")
 	if err != nil {


### PR DESCRIPTION
This commit fixes #1886

Previously the code was precomputing keys
even for SSH nodes, that do not need precomputed
private keys pool.