### PR TITLE
PAM regression

### DIFF
--- a/lib/pam/pam.c
+++ b/lib/pam/pam.c
@@ -29,7 +29,7 @@ char *library_name()
 #ifdef __APPLE__
     return "libpam.dylib";
 #else
-    return "libpam.so";
+    return "libpam.so.0";
 #endif
 }
 


### PR DESCRIPTION
On systems where the `libpam-dev` package (or equivalent) has not been installed no symlink exists pointing `libpam.so` to `libpam.so.0`. The library that is installed is `libpam.so.0`:

```
$ ldconfig -p | grep libpam
	libpamc.so.0 (libc6,x86-64) => /lib/x86_64-linux-gnu/libpamc.so.0
	libpam_misc.so.0 (libc6,x86-64) => /lib/x86_64-linux-gnu/libpam_misc.so.0
	libpam.so.0 (libc6,x86-64) => /lib/x86_64-linux-gnu/libpam.so.0
```

This PR updates the SONAME that `dlopen` uses.