### PR TITLE
Propagate closing context to login handler.

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -333,7 +333,7 @@ func onLogin(cf *CLIConf) {
 	makeIdentityFile := (cf.IdentityFileOut != "")
 	activateKey := !makeIdentityFile
 
-	if key, err = tc.Login(activateKey); err != nil {
+	if key, err = tc.Login(cf.Context, activateKey); err != nil {
 		utils.FatalError(err)
 	}
 	if makeIdentityFile {


### PR DESCRIPTION
**Purpose**

To allow cancelation of SSO based login, propagate Ctrl-C to the SSO handler.

**Implementation**

Propagate context (upon which `Done()` is called when Ctrl-C is issued) to the SSO handler.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1882