### PR TITLE
Introduce additional phase to CA rotation.

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -115,6 +115,10 @@ const (
 	// in a graceful way.
 	TeleportReloadEvent = "TeleportReload"
 
+	// TeleportPhaseChangeEvent is generated to indidate that teleport
+	// CA rotation phase has been updated, used in tests
+	TeleportPhaseChangeEvent = "TeleportPhaseChange"
+
 	// TeleportReadyEvent is generated to signal that all teleport
 	// internal components have started successfully.
 	TeleportReadyEvent = "TeleportReady"

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -572,6 +572,12 @@ const (
 	// RotationPhaseStandby is the initial phase of the rotation
 	// it means no operations have started.
 	RotationPhaseStandby = "standby"
+	// RotationPhaseInit = is a phase of the rotation
+	// when new certificate authoirty is issued, but not used
+	// It is necessary for remote trusted clusters to fetch the
+	// new certificate authority, otherwise the new clients
+	// will reject it
+	RotationPhaseInit = "init"
 	// RotationPhaseUpdateClients is a phase of the rotation
 	// when client credentials will have to be updated and reloaded
 	// but servers will use and respond with old credentials
@@ -593,6 +599,7 @@ const (
 
 // RotatePhases lists all supported rotation phases
 var RotatePhases = []string{
+	RotationPhaseInit,
 	RotationPhaseStandby,
 	RotationPhaseUpdateClients,
 	RotationPhaseUpdateServers,
@@ -710,10 +717,11 @@ func (r *Rotation) CheckAndSetDefaults(clock clockwork.Clock) error {
 // even time periods between rotation phases.
 func GenerateSchedule(clock clockwork.Clock, gracePeriod time.Duration) (*RotationSchedule, error) {
 	if gracePeriod <= 0 {
-		return nil, trace.BadParameter("bad grace period %q, provide value >= 0", gracePeriod)
+		return nil, trace.BadParameter("invalid grace period %q, provide value > 0", gracePeriod)
 	}
 	return &RotationSchedule{
-		UpdateServers: clock.Now().UTC().Add(gracePeriod / 2).UTC(),
+		UpdateClients: clock.Now().UTC().Add(gracePeriod / 3).UTC(),
+		UpdateServers: clock.Now().UTC().Add((gracePeriod * 2) / 3).UTC(),
 		Standby:       clock.Now().UTC().Add(gracePeriod).UTC(),
 	}, nil
 }
@@ -721,6 +729,8 @@ func GenerateSchedule(clock clockwork.Clock, gracePeriod time.Duration) (*Rotati
 // RotationSchedule is a rotation schedule setting time switches
 // for different phases.
 type RotationSchedule struct {
+	// UpdateClients specifies time to switch to the "Update clients" phase
+	UpdateClients time.Time `json:"update_clients,omitempty"`
 	// UpdateServers specifies time to switch to the "Update servers" phase.
 	UpdateServers time.Time `json:"update_servers,omitempty"`
 	// Standby specifies time to switch to the "Standby" phase.
@@ -831,6 +841,7 @@ const RotationSchema = `{
     "schedule": {
       "type": "object",
       "properties": {
+        "update_clients": {"type": "string"},
         "update_servers": {"type": "string"},
         "standby": {"type": "string"}
       }


### PR DESCRIPTION
Flaky tests in teleport integration suite uncovered a problem.
It is possible that main cluster rotates certificate authority,
and will try to dial to the remote cluster with new credentials
before the remote cluster could fetch the new CA to trust.

To fix this, phase "update_clients" was split in two phases:

* Init and Update clients

Init phase does nothing on the main cluster except generating
new certificate authorities, that are trusted but not used in the
cluster.

This phase exists to give remote clusters opporunity
to update the list of trusted certificate authorities
of the main cluster, before main cluster reconnects with new clients
in "Update clients" phase.