### PR TITLE
Consolidate token validation code.

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -289,7 +289,7 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 		NodeName: "node-name",
 		Role:     teleport.RoleProxy,
 	})
-	c.Assert(err, ErrorMatches, `node "node-name" \[late.bird\] can not join the cluster, token has expired`)
+	c.Assert(err, ErrorMatches, `"node-name" \[late.bird\] can not join the cluster with role Proxy, token error: token expired`)
 
 	// expired token should be gone now
 	err = s.a.DeleteToken(multiUseToken)

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -441,10 +441,6 @@ func (a *AuthServer) validateTrustedClusterToken(token string) error {
 		return trace.AccessDenied("role does not match")
 	}
 
-	if !a.checkTokenTTL(token) {
-		return trace.AccessDenied("expired token")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
**Purpose**

Consolidate token validation code so we don't try and check expiry (and delete) a static token.

**Implementation**

Consolidate token validation code so we don't try and check expiry (and delete) a static token.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1939