### PR TITLE
Update default cryptographic primitives.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -413,3 +413,12 @@ const (
 	// ResizeRequestEnvelopeType is receiving a resize request.
 	ResizeRequestEnvelopeType = "r.r"
 )
+
+// The following are cryptographic primitives Teleport does not support in
+// it's default configuration.
+const (
+	DiffieHellmanGroup14SHA1 = "diffie-hellman-group14-sha1"
+	DiffieHellmanGroup1SHA1  = "diffie-hellman-group1-sha1"
+	HMACSHA1                 = "hmac-sha1"
+	HMACSHA196               = "hmac-sha1-96"
+)

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -269,6 +269,26 @@ func SliceContainsStr(slice []string, value string) bool {
 	return false
 }
 
+// RemoveFromSlice makes a copy of the slice and removes the passed in values from the copy.
+func RemoveFromSlice(slice []string, values ...string) []string {
+	output := make([]string, 0, len(slice))
+
+	remove := make(map[string]bool)
+	for _, value := range values {
+		remove[value] = true
+	}
+
+	for _, s := range slice {
+		_, ok := remove[s]
+		if ok {
+			continue
+		}
+		output = append(output, s)
+	}
+
+	return output
+}
+
 // CheckCertificateFormatFlag checks if the certificate format is valid.
 func CheckCertificateFormatFlag(s string) (string, error) {
 	switch s {

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -89,6 +89,13 @@ func (s *UtilsSuite) TestMiscFunctions(c *check.C) {
 	c.Assert(Deduplicate([]string{}), check.DeepEquals, []string{})
 	c.Assert(Deduplicate([]string{"a", "b"}), check.DeepEquals, []string{"a", "b"})
 	c.Assert(Deduplicate([]string{"a", "b", "b", "a", "c"}), check.DeepEquals, []string{"a", "b", "c"})
+
+	// RemoveFromSlice
+	c.Assert(RemoveFromSlice([]string{}, "a"), check.DeepEquals, []string{})
+	c.Assert(RemoveFromSlice([]string{"a"}, "a"), check.DeepEquals, []string{})
+	c.Assert(RemoveFromSlice([]string{"a", "b"}, "a"), check.DeepEquals, []string{"b"})
+	c.Assert(RemoveFromSlice([]string{"a", "b"}, "b"), check.DeepEquals, []string{"a"})
+	c.Assert(RemoveFromSlice([]string{"a", "a", "b"}, "a"), check.DeepEquals, []string{"b"})
 }
 
 // TestVersions tests versions compatibility checking


### PR DESCRIPTION
**Purpose**

Update default cryptographic primitives for Teleport.

**Implementation**

Remove default support for:

* `diffie-hellman-group14-sha1`
* `diffie-hellman-group1-sha1`
* `hmac-sha1`
* `hmac-sha1-96`

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1856