### PR TITLE
Increase size of connection pool.

### DIFF
--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -123,10 +123,16 @@ func NewTLSClientWithDialer(dialContext DialContext, cfg *tls.Config, params ...
 		DialContext:           dialContext,
 		ResponseHeaderTimeout: defaults.DefaultDialTimeout,
 		TLSClientConfig:       cfg,
-		MaxIdleConnsPerHost:   defaults.HTTPIdleConnsPerHost,
+
+		// Increase the size of the connection pool. This substantially improves the
+		// performance of Teleport under load as it reduces the number of TLS
+		// handshakes performed.
+		MaxIdleConns:        defaults.HTTPMaxIdleConns,
+		MaxIdleConnsPerHost: defaults.HTTPMaxIdleConnsPerHost,
+
 		// IdleConnTimeout defines the maximum amount of time before idle connections
 		// are closed. Leaving this unset will lead to connections open forever and
-		// will cause memory leaks in a long running process
+		// will cause memory leaks in a long running process.
 		IdleConnTimeout: defaults.HTTPIdleTimeout,
 	}
 	// this logic is necessary to force client to always send certificate

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -81,9 +81,11 @@ const (
 	// connection attempts
 	DefaultDialTimeout = 30 * time.Second
 
-	// HTTPIdleConnsPerHost specifies maximum idle connections per host
-	// in HTTP connection pool
-	HTTPIdleConnsPerHost = 5
+	// HTTPMaxIdleConns is the max idle connections across all hosts.
+	HTTPMaxIdleConns = 2000
+
+	// HTTPMaxIdleConnsPerHost is the max idle connections per-host.
+	HTTPMaxIdleConnsPerHost = 1000
 
 	// HTTPIdleTimeout is a default timeout for idle HTTP connections
 	HTTPIdleTimeout = 30 * time.Second


### PR DESCRIPTION
**Purpose**

Increase the size of the HTTP connection pool. This improves the performance of Teleport under heavy load as it reduces the number of TLS handshakes that occur.

**Implementation**

* Increase the maximum number of idle connections to 2,000.
* Increase the maximum number of idle connections per-host to 1,000.
* Apply these changes to both the `auth.Client` and DynamoDB backend.