### PR TITLE
Update TLS and SSH Cryptographic Primitives

### DIFF
--- a/lib/client/https_client.go
+++ b/lib/client/https_client.go
@@ -18,30 +18,36 @@ limitations under the License.
 package client
 
 import (
-	"crypto/tls"
 	"crypto/x509"
 	"net/http"
 	"net/url"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 )
 
 func NewInsecureWebClient() *http.Client {
+	tlsConfig := utils.TLSConfig()
+	tlsConfig.InsecureSkipVerify = true
+
 	return &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: tlsConfig,
 		},
 	}
 }
 
 func newClientWithPool(pool *x509.CertPool) *http.Client {
+	tlsConfig := utils.TLSConfig()
+	tlsConfig.RootCAs = pool
+
 	return &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{RootCAs: pool},
+			TLSClientConfig: tlsConfig,
 		},
 	}
 }

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -43,23 +43,29 @@ func ListenTLS(address string, certFile, keyFile string) (net.Listener, error) {
 	return tls.Listen("tcp", address, tlsConfig)
 }
 
-// TLSConfig returns default TLS configuration with
-// strict TLS settings configured (e.g. min TLS1.2)
+// TLSConfig returns default TLS configuration strong defaults.
 func TLSConfig() *tls.Config {
 	config := &tls.Config{}
+
+	// Only support modern ciphers (Chacha20 and AES GCM). Key exchanges which
+	// support perfect forward secrecy (ECDHE) have priority over those that do
+	// not (RSA).
 	config.CipherSuites = []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-
-		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 	}
+
+	// Pick the servers preferred ciphersuite, not the clients.
+	config.PreferServerCipherSuites = true
 
 	config.MinVersion = tls.VersionTLS12
 	config.SessionTicketsDisabled = false


### PR DESCRIPTION
**Purpose**

TLS configuration was updated to remove ciphersuites vulnerably to [Lucky 13 style attacks](https://www.imperialviolet.org/2013/02/04/luckythirteen.html). Teleport now only supports the following ciphersuites:

```
TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305

TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

TLS_RSA_WITH_AES_128_GCM_SHA256
TLS_RSA_WITH_AES_256_GCM_SHA384
```

The first 6 also support perfect forward secrecy (PFS). The last two were added even though they don't support PFS for backward compatibility. For example without adding the last two, OpenSSL would only support two of the ciphersuites.

In addition, `PreferServerCipherSuites` was turned on so the server picks the ciphersuites from its own preference list. This is to ensure that Teleport always picks PFS whenever it can and only downgrades to non-PFS when no other ciphersuite is offered.

On the SSH front, ciphers, KEX, and MAC algorithms now have better enforcement in the forwarding server. Before the in-memory forwarding server always presented the default list during the KEX and only enforced Teleport preferences on the client connection to the server. With these changes, Teleport now serves the cipher, KEX, and MAC preferences in both directions during the `SSH_MSG_KEXINIT`.

**Related Issues**

https://github.com/gravitational/teleport/issues/1856
https://github.com/gravitational/teleport/pull/1948