### PR TITLE
Don't send Teleport version in handshake.

### DIFF
--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -159,9 +158,10 @@ func NewServer(
 	s.cfg.PasswordCallback = ah.Password
 	s.cfg.NoClientAuth = ah.NoClient
 
-	// Teleport SSH server will be sending the following "version string" during
-	// SSH handshake (example): "SSH-2.0-T eleport 1.5.1-beta" (space is important!)
-	s.cfg.ServerVersion = fmt.Sprintf("%s %s", SSHVersionPrefix, teleport.Version)
+	// Teleport servers need to identify as such to allow passing of the client
+	// IP from the client to the proxy to the destination node.
+	s.cfg.ServerVersion = SSHVersionPrefix
+
 	return s, nil
 }
 


### PR DESCRIPTION
**Purpose**

Don't send the Teleport version during the SSH handshake.

**Implementation**

During the SSH handshake, Teleport will now report itself as `SSH-2.0-Teleport` instead of `SSH-2.0-Teleport 2.7.0`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/970