### PR TITLE
Add Jenkins jobs for building OSS/Enterprise AMIs for submitting to Amazon Marketplace

### DIFF
--- a/assets/marketplace/Jenkinsfile-build-ent
+++ b/assets/marketplace/Jenkinsfile-build-ent
@@ -13,7 +13,7 @@ pipeline {
         stage('Run Packer to build specified version') {
             steps {
                 dir('assets/marketplace') {
-                    sh 'BUILD_AMI_NAME=cloudformation-gravitational-teleport-ent-${params.version} TELEPORT_VERSION=${params.version} make ent-name-build'
+                    sh "BUILD_AMI_NAME=cloudformation-gravitational-teleport-ent-${params.version} TELEPORT_VERSION=${params.version} make ent-name-build"
                 }
             }
         }

--- a/assets/marketplace/Jenkinsfile-build-ent
+++ b/assets/marketplace/Jenkinsfile-build-ent
@@ -8,12 +8,18 @@ pipeline {
     }
     parameters {
         string(name: 'version', defaultValue: '2.6.1', description: 'Teleport version to build')
+        string(name: 'teleport_license_uri', defaultValue: 's3://', description: 'Path to load license file from')
     }
     stages {
         stage('Run Packer to build specified version') {
             steps {
                 dir('assets/marketplace') {
-                    sh "BUILD_AMI_NAME=cloudformation-gravitational-teleport-ent-${params.version} TELEPORT_VERSION=${params.version} make ent-name-build"
+                    sh """
+BUILD_AMI_NAME=cloudformation-gravitational-teleport-ent-${params.version} \
+TELEPORT_VERSION=${params.version} \
+TELEPORT_LICENSE_URI=${params.teleport_license_uri} \
+make ent-name-build
+"""
                 }
             }
         }

--- a/assets/marketplace/Jenkinsfile-build-ent
+++ b/assets/marketplace/Jenkinsfile-build-ent
@@ -1,0 +1,21 @@
+#!groovy
+pipeline {
+    agent any
+    options {
+        ansiColor(colorMapName: 'XTerm')
+        disableConcurrentBuilds()
+        timestamps()
+    }
+    parameters {
+        string(name: 'version', defaultValue: '2.6.1', description: 'Teleport version to build')
+    }
+    stages {
+        stage('Run Packer to build specified version') {
+            steps {
+                dir('assets/marketplace') {
+                    sh 'BUILD_AMI_NAME=cloudformation-gravitational-teleport-ent-${params.version} TELEPORT_VERSION=${params.version} make ent-name-build'
+                }
+            }
+        }
+    }
+}

--- a/assets/marketplace/Jenkinsfile-build-oss
+++ b/assets/marketplace/Jenkinsfile-build-oss
@@ -1,0 +1,21 @@
+#!groovy
+pipeline {
+    agent any
+    options {
+        ansiColor(colorMapName: 'XTerm')
+        disableConcurrentBuilds()
+        timestamps()
+    }
+    parameters {
+        string(name: 'version', defaultValue: '2.6.1', description: 'Teleport version to build')
+    }
+    stages {
+        stage('Run Packer to build specified version') {
+            steps {
+                dir('assets/marketplace') {
+                    sh 'BUILD_AMI_NAME=cloudformation-gravitational-teleport-oss-${params.version} TELEPORT_VERSION=${params.version} make oss-name-build'
+                }
+            }
+        }
+    }
+}

--- a/assets/marketplace/Jenkinsfile-build-oss
+++ b/assets/marketplace/Jenkinsfile-build-oss
@@ -13,7 +13,7 @@ pipeline {
         stage('Run Packer to build specified version') {
             steps {
                 dir('assets/marketplace') {
-                    sh 'BUILD_AMI_NAME=cloudformation-gravitational-teleport-oss-${params.version} TELEPORT_VERSION=${params.version} make oss-name-build'
+                    sh "BUILD_AMI_NAME=cloudformation-gravitational-teleport-oss-${params.version} TELEPORT_VERSION=${params.version} make oss-name-build"
                 }
             }
         }

--- a/assets/marketplace/Makefile
+++ b/assets/marketplace/Makefile
@@ -60,9 +60,10 @@ oss:
 	@echo "$(BUILD_TIMESTAMP)" > files/build/oss_build_timestamp.txt
 
 .PHONY: oss-name-build
+oss-name-build: TELEPORT_TYPE=oss
 oss-name-build:
 	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) with name $(BUILD_AMI_NAME)"
-	packer build -force -var name=$(BUILD_AMI_NAME) template.json
+	packer build -force -var ami_name=$(BUILD_AMI_NAME) template.json
 
 .PHONY: ent
 ent: TELEPORT_TYPE=ent
@@ -79,7 +80,7 @@ ent-name-build: check-ent-vars
 ent-name-build:
 	aws s3 cp $(TELEPORT_LICENSE_URI) files/system/license.pem
 	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) with name $(BUILD_AMI_NAME)"
-	packer build -force -var name=$(BUILD_AMI_NAME) template.json
+	packer build -force -var ami_name=$(BUILD_AMI_NAME) template.json
 
 .PHONY: update-ami-ids-oss
 update-ami-ids-oss:

--- a/assets/marketplace/Makefile
+++ b/assets/marketplace/Makefile
@@ -6,6 +6,9 @@ BUILD_VPC_ID ?=
 # VPC subnet used for builds
 BUILD_SUBNET_ID ?=
 
+# Override for AMI name if needed
+BUILD_AMI_NAME ?=
+
 # Default build region
 AWS_REGION ?= us-west-2
 
@@ -56,6 +59,11 @@ oss:
 	packer build -force -var build_timestamp=$(BUILD_TIMESTAMP) template.json
 	@echo "$(BUILD_TIMESTAMP)" > files/build/oss_build_timestamp.txt
 
+.PHONY: oss-name-build
+oss-name-build:
+	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) with name $(BUILD_AMI_NAME)"
+	packer build -force -var name=$(BUILD_AMI_NAME) template.json
+
 .PHONY: ent
 ent: TELEPORT_TYPE=ent
 ent: check-ent-vars
@@ -64,6 +72,14 @@ ent: check-ent-vars
 	@echo "BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
 	packer build -force -var build_timestamp=$(BUILD_TIMESTAMP) template.json
 	@echo "$(BUILD_TIMESTAMP)" > files/build/ent_build_timestamp.txt
+
+.PHONY: ent-name-build
+ent-name-build: TELEPORT_TYPE=ent
+ent-name-build: check-ent-vars
+ent-name-build:
+	aws s3 cp $(TELEPORT_LICENSE_URI) files/system/license.pem
+	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) with name $(BUILD_AMI_NAME)"
+	packer build -force -var name=$(BUILD_AMI_NAME) template.json
 
 .PHONY: update-ami-ids-oss
 update-ami-ids-oss:


### PR DESCRIPTION
These jobs are tested and work fine, they were used to build the AMIs we've already submitted.

The purpose of these files is to build differently-named AMIs to the standard Jenkinsfile job so they don't get deleted/overwritten by the Packer jobs which are run automatically.

OSS job takes a 'version' parameter which is the version of Teleport it should build. This will become part of the output AMI name.

Enterprise job takes the same 'version' parameter along with a 'teleport_license_uri' parameters which is an S3 URI to copy the license file from before building.