### PR TITLE
Add Windows-specific code to enable building on Windows

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -22,17 +22,12 @@ import (
 	"io"
 	"net"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
@@ -282,109 +277,6 @@ func (ns *NodeSession) allocateTerminal(termType string, s *ssh.Session) (io.Rea
 	), nil
 }
 
-func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
-	// SIGWINCH is sent to the process when the window size of the terminal has
-	// changed.
-	sigwinchCh := make(chan os.Signal, 1)
-	signal.Notify(sigwinchCh, syscall.SIGWINCH)
-
-	lastSize, err := term.GetWinsize(0)
-	if err != nil {
-		log.Errorf("Unable to get window size: %v", err)
-		return
-	}
-
-	// Sync the local terminal with size received from the remote server every
-	// two seconds. If we try and do it live, synchronization jitters occur.
-	tickerCh := time.NewTicker(defaults.TerminalResizePeriod)
-	defer tickerCh.Stop()
-
-	for {
-		select {
-		// The client updated the size of the local PTY. This change needs to occur
-		// on the server side PTY as well.
-		case sigwinch := <-sigwinchCh:
-			if sigwinch == nil {
-				return
-			}
-
-			currSize, err := term.GetWinsize(0)
-			if err != nil {
-				log.Warnf("Unable to get window size: %v.", err)
-				continue
-			}
-
-			// Terminal size has not changed, don't do anything.
-			if currSize.Height == lastSize.Height && currSize.Width == lastSize.Width {
-				continue
-			}
-
-			// Send the "window-change" request over the channel.
-			_, err = s.SendRequest(
-				sshutils.WindowChangeRequest,
-				false,
-				ssh.Marshal(sshutils.WinChangeReqParams{
-					W: uint32(currSize.Width),
-					H: uint32(currSize.Height),
-				}))
-			if err != nil {
-				log.Warnf("Unable to send %v reqest: %v.", sshutils.WindowChangeRequest, err)
-				continue
-			}
-
-			log.Debugf("Updated window size from %v to %v due to SIGWINCH.", lastSize, currSize)
-
-			lastSize = currSize
-
-		// Extract "resize" events in the stream and store the last window size.
-		case event := <-ns.nodeClient.TC.EventsChannel():
-			// Only "resize" events are important to tsh, all others can be ignored.
-			if event.GetType() != events.ResizeEvent {
-				continue
-			}
-
-			terminalParams, err := session.UnmarshalTerminalParams(event.GetString(events.TerminalSize))
-			if err != nil {
-				log.Warnf("Unable to unmarshal terminal parameters: %v.", err)
-				continue
-			}
-
-			lastSize = terminalParams.Winsize()
-			log.Debugf("Recevied window size %v from node in session.\n", lastSize, event.GetString(events.SessionEventID))
-
-		// Update size of local terminal with the last size received from remote server.
-		case <-tickerCh.C:
-			// Get the current size of the terminal and the last size report that was
-			// received.
-			currSize, err := term.GetWinsize(0)
-			if err != nil {
-				log.Warnf("Unable to get current terminal size: %v.", err)
-				continue
-			}
-
-			// Terminal size has not changed, don't do anything.
-			if currSize.Width == lastSize.Width && currSize.Height == lastSize.Height {
-				continue
-			}
-
-			// This changes the size of the local PTY. This will re-draw what's within
-			// the window.
-			err = term.SetWinsize(0, lastSize)
-			if err != nil {
-				log.Warnf("Unable to update terminal size: %v.\n", err)
-				continue
-			}
-
-			// This is what we use to resize the physical terminal window itself.
-			os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", lastSize.Height, lastSize.Width)))
-
-			log.Debugf("Updated window size from to %v due to remote window change.", currSize, lastSize)
-		case <-ns.closer.C:
-			return
-		}
-	}
-}
-
 // isTerminalAttached returns true when this session is be controlled by
 // a real terminal.
 // It will return False for sessions initiated by the Web client or
@@ -481,42 +373,6 @@ func (ns *NodeSession) runCommand(ctx context.Context, cmd []string, callback Sh
 			return trace.ConnectionProblem(ctx.Err(), "connection canceled")
 		}
 	})
-}
-
-// watchSignals register UNIX signal handlers and properly terminates a remote shell session
-// must be called as a goroutine right after a remote shell is created
-func (ns *NodeSession) watchSignals(shell io.Writer) {
-	exitSignals := make(chan os.Signal, 1)
-	// catch SIGTERM
-	signal.Notify(exitSignals, syscall.SIGTERM)
-	go func() {
-		defer ns.closer.Close()
-		<-exitSignals
-	}()
-	// Catch Ctrl-C signal
-	ctrlCSignal := make(chan os.Signal, 1)
-	signal.Notify(ctrlCSignal, syscall.SIGINT)
-	go func() {
-		for {
-			<-ctrlCSignal
-			_, err := shell.Write([]byte{3})
-			if err != nil {
-				log.Errorf(err.Error())
-			}
-		}
-	}()
-	// Catch Ctrl-Z signal
-	ctrlZSignal := make(chan os.Signal, 1)
-	signal.Notify(ctrlZSignal, syscall.SIGTSTP)
-	go func() {
-		for {
-			<-ctrlZSignal
-			_, err := shell.Write([]byte{26})
-			if err != nil {
-				log.Errorf(err.Error())
-			}
-		}
-	}()
 }
 
 // pipeInOut launches two goroutines: one to pipe the local input into the remote shell,

--- a/lib/client/session_unix.go
+++ b/lib/client/session_unix.go
@@ -1,0 +1,161 @@
+// +build !windows
+
+package client
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/moby/moby/pkg/term"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
+	// SIGWINCH is sent to the process when the window size of the terminal has
+	// changed.
+	sigwinchCh := make(chan os.Signal, 1)
+	signal.Notify(sigwinchCh, syscall.SIGWINCH)
+
+	lastSize, err := term.GetWinsize(0)
+	if err != nil {
+		log.Errorf("Unable to get window size: %v", err)
+		return
+	}
+
+	// Sync the local terminal with size received from the remote server every
+	// two seconds. If we try and do it live, synchronization jitters occur.
+	tickerCh := time.NewTicker(defaults.TerminalResizePeriod)
+	defer tickerCh.Stop()
+
+	for {
+		select {
+		// The client updated the size of the local PTY. This change needs to occur
+		// on the server side PTY as well.
+		case sigwinch := <-sigwinchCh:
+			if sigwinch == nil {
+				return
+			}
+
+			currSize, err := term.GetWinsize(0)
+			if err != nil {
+				log.Warnf("Unable to get window size: %v.", err)
+				continue
+			}
+
+			// Terminal size has not changed, don't do anything.
+			if currSize.Height == lastSize.Height && currSize.Width == lastSize.Width {
+				continue
+			}
+
+			// Send the "window-change" request over the channel.
+			_, err = s.SendRequest(
+				sshutils.WindowChangeRequest,
+				false,
+				ssh.Marshal(sshutils.WinChangeReqParams{
+					W: uint32(currSize.Width),
+					H: uint32(currSize.Height),
+				}))
+			if err != nil {
+				log.Warnf("Unable to send %v reqest: %v.", sshutils.WindowChangeRequest, err)
+				continue
+			}
+
+			log.Debugf("Updated window size from %v to %v due to SIGWINCH.", lastSize, currSize)
+
+			lastSize = currSize
+
+		// Extract "resize" events in the stream and store the last window size.
+		case event := <-ns.nodeClient.TC.EventsChannel():
+			// Only "resize" events are important to tsh, all others can be ignored.
+			if event.GetType() != events.ResizeEvent {
+				continue
+			}
+
+			terminalParams, err := session.UnmarshalTerminalParams(event.GetString(events.TerminalSize))
+			if err != nil {
+				log.Warnf("Unable to unmarshal terminal parameters: %v.", err)
+				continue
+			}
+
+			lastSize = terminalParams.Winsize()
+			log.Debugf("Recevied window size %v from node in session.\n", lastSize, event.GetString(events.SessionEventID))
+
+		// Update size of local terminal with the last size received from remote server.
+		case <-tickerCh.C:
+			// Get the current size of the terminal and the last size report that was
+			// received.
+			currSize, err := term.GetWinsize(0)
+			if err != nil {
+				log.Warnf("Unable to get current terminal size: %v.", err)
+				continue
+			}
+
+			// Terminal size has not changed, don't do anything.
+			if currSize.Width == lastSize.Width && currSize.Height == lastSize.Height {
+				continue
+			}
+
+			// This changes the size of the local PTY. This will re-draw what's within
+			// the window.
+			err = term.SetWinsize(0, lastSize)
+			if err != nil {
+				log.Warnf("Unable to update terminal size: %v.\n", err)
+				continue
+			}
+
+			// This is what we use to resize the physical terminal window itself.
+			os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", lastSize.Height, lastSize.Width)))
+
+			log.Debugf("Updated window size from to %v due to remote window change.", currSize, lastSize)
+		case <-ns.closer.C:
+			return
+		}
+	}
+}
+
+// watchSignals register UNIX signal handlers and properly terminates a remote shell session
+// must be called as a goroutine right after a remote shell is created
+func (ns *NodeSession) watchSignals(shell io.Writer) {
+	exitSignals := make(chan os.Signal, 1)
+	// catch SIGTERM
+	signal.Notify(exitSignals, syscall.SIGTERM)
+	go func() {
+		defer ns.closer.Close()
+		<-exitSignals
+	}()
+	// Catch Ctrl-C signal
+	ctrlCSignal := make(chan os.Signal, 1)
+	signal.Notify(ctrlCSignal, syscall.SIGINT)
+	go func() {
+		for {
+			<-ctrlCSignal
+			_, err := shell.Write([]byte{3})
+			if err != nil {
+				log.Errorf(err.Error())
+			}
+		}
+	}()
+	// Catch Ctrl-Z signal
+	ctrlZSignal := make(chan os.Signal, 1)
+	signal.Notify(ctrlZSignal, syscall.SIGTSTP)
+	go func() {
+		for {
+			<-ctrlZSignal
+			_, err := shell.Write([]byte{26})
+			if err != nil {
+				log.Errorf(err.Error())
+			}
+		}
+	}()
+}

--- a/lib/client/session_windows.go
+++ b/lib/client/session_windows.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+  "io"
+  "os"
+  "os/signal"
+  "syscall"
+
+  "golang.org/x/crypto/ssh"
+
+  log "github.com/sirupsen/logrus"
+)
+
+func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
+  return
+}
+
+// watchSignals register UNIX signal handlers and properly terminates a remote shell session
+// must be called as a goroutine right after a remote shell is created
+func (ns *NodeSession) watchSignals(shell io.Writer) {
+	exitSignals := make(chan os.Signal, 1)
+	// catch SIGTERM
+	signal.Notify(exitSignals, syscall.SIGTERM)
+	go func() {
+		defer ns.closer.Close()
+		<-exitSignals
+	}()
+	// Catch Ctrl-C signal
+	ctrlCSignal := make(chan os.Signal, 1)
+	signal.Notify(ctrlCSignal, syscall.SIGINT)
+	go func() {
+		for {
+			<-ctrlCSignal
+			_, err := shell.Write([]byte{3})
+			if err != nil {
+				log.Errorf(err.Error())
+			}
+		}
+	}()
+}

--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -17,7 +17,6 @@ limitations under the License.
 package events
 
 import (
-	"archive/tar"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
@@ -26,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/gravitational/teleport"
@@ -136,29 +134,6 @@ func (sl *DiskSessionLogger) LogEvent(fields EventFields) error {
 // when the session logger is closed
 func (sl *DiskSessionLogger) Close() error {
 	return nil
-}
-
-func openFileForTar(filename string) (*tar.Header, io.ReadCloser, error) {
-	fi, err := os.Stat(filename)
-	if err != nil {
-		return nil, nil, trace.ConvertSystemError(err)
-	}
-	header := tar.Header{
-		Name:    filepath.Base(filename),
-		Size:    fi.Size(),
-		Mode:    int64(fi.Mode()),
-		ModTime: fi.ModTime(),
-	}
-	sys, ok := fi.Sys().(*syscall.Stat_t)
-	if ok {
-		header.Uid = int(sys.Uid)
-		header.Gid = int(sys.Gid)
-	}
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, nil, trace.ConvertSystemError(err)
-	}
-	return &header, f, nil
 }
 
 // Finalize is called by the session when it's closing. This is where we're

--- a/lib/events/sessionlog_unix.go
+++ b/lib/events/sessionlog_unix.go
@@ -1,0 +1,36 @@
+// +build !windows
+
+package events
+
+import (
+  "archive/tar"
+  "io"
+  "os"
+  "path/filepath"
+  "syscall"
+
+  "github.com/gravitational/trace"
+)
+
+func openFileForTar(filename string) (*tar.Header, io.ReadCloser, error) {
+	fi, err := os.Stat(filename)
+	if err != nil {
+		return nil, nil, trace.ConvertSystemError(err)
+	}
+	header := tar.Header{
+		Name:    filepath.Base(filename),
+		Size:    fi.Size(),
+		Mode:    int64(fi.Mode()),
+		ModTime: fi.ModTime(),
+	}
+	sys, ok := fi.Sys().(*syscall.Stat_t)
+	if ok {
+		header.Uid = int(sys.Uid)
+		header.Gid = int(sys.Gid)
+	}
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, nil, trace.ConvertSystemError(err)
+	}
+	return &header, f, nil
+}

--- a/lib/events/sessionlog_windows.go
+++ b/lib/events/sessionlog_windows.go
@@ -1,0 +1,28 @@
+package events
+
+import (
+  "archive/tar"
+  "io"
+  "os"
+  "path/filepath"
+
+  "github.com/gravitational/trace"
+)
+
+func openFileForTar(filename string) (*tar.Header, io.ReadCloser, error) {
+	fi, err := os.Stat(filename)
+	if err != nil {
+		return nil, nil, trace.ConvertSystemError(err)
+	}
+	header := tar.Header{
+		Name:    filepath.Base(filename),
+		Size:    fi.Size(),
+		Mode:    int64(fi.Mode()),
+		ModTime: fi.ModTime(),
+	}
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, nil, trace.ConvertSystemError(err)
+	}
+	return &header, f, nil
+}

--- a/lib/shell/shell_native.go
+++ b/lib/shell/shell_native.go
@@ -1,0 +1,11 @@
+// +build !cgo
+
+package shell
+
+const (
+	DefaultShell = "/bin/sh"
+)
+
+func GetLoginShell(username string) (string, error) {
+  return DefaultShell, nil
+}

--- a/lib/utils/agentconn/agentconn.go
+++ b/lib/utils/agentconn/agentconn.go
@@ -1,0 +1,23 @@
+package agentconn
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+const SocketEnvironmentVariableName = "SSH_AUTH_SOCK"
+
+func DialDefaultAgent() (net.Conn, error) {
+	socket := os.Getenv(SocketEnvironmentVariableName)
+
+	if socket == "" {
+		return nil, fmt.Errorf("%s is not set")
+	}
+
+	return dialAgent(socket)
+}
+
+func DialAgent(socket string) (net.Conn, error) {
+	return dialAgent(socket)
+}

--- a/lib/utils/agentconn/agentconn_unix.go
+++ b/lib/utils/agentconn/agentconn_unix.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package agentconn
+
+import "net"
+
+func dialAgent(socket string) (net.Conn, error) {
+	return net.Dial("unix", socket)
+}

--- a/lib/utils/agentconn/agentconn_windows.go
+++ b/lib/utils/agentconn/agentconn_windows.go
@@ -1,0 +1,85 @@
+package agentconn
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"regexp"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// The Cygwin support below was originally based on this implementation:
+// https://github.com/abourget/secrets-bridge/blob/master/pkg/agentfwd/agentconn_windows.go
+
+const microsoftOpenSSHAgentPipe = "\\\\.\\pipe\\openssh-ssh-agent"
+
+var windowsFakeSocket = regexp.MustCompile(`!<socket >(\d+) ([A-Fa-f0-9-]+)`)
+
+func dialAgent(socket string) (net.Conn, error) {
+	// If the socket path isn't set, or is set to the named pipe associated with
+	// Microsoft's native OpenSSH implementation, try connecting with a native
+	// Windows named pipe.
+	if socket == "" || socket == microsoftOpenSSHAgentPipe {
+		return winio.DialPipe(microsoftOpenSSHAgentPipe, nil)
+	}
+
+	// If a socket path was specified, fall back to Cygwin's Unix socket emulation
+	socketFileData, err := ioutil.ReadFile(socket)
+	if err != nil {
+		return nil, err
+	}
+
+	matches := windowsFakeSocket.FindStringSubmatch(string(socketFileData))
+	if matches == nil {
+		return nil, fmt.Errorf("couldn't parse SSH_AUTH_SOCK file %s", socket)
+	}
+
+	tcpPort := matches[1]
+	key := matches[2]
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%s", tcpPort))
+	if err != nil {
+		return conn, err
+	}
+
+	b := make([]byte, 16)
+	fmt.Sscanf(key,
+		"%02x%02x%02x%02x-%02x%02x%02x%02x-%02x%02x%02x%02x-%02x%02x%02x%02x",
+		&b[3], &b[2], &b[1], &b[0],
+		&b[7], &b[6], &b[5], &b[4],
+		&b[11], &b[10], &b[9], &b[8],
+		&b[15], &b[14], &b[13], &b[12],
+	)
+
+	if _, err = conn.Write(b); err != nil {
+		return nil, fmt.Errorf("write b: %v", err)
+	}
+
+	b2 := make([]byte, 16)
+	if _, err = conn.Read(b2); err != nil {
+		return nil, fmt.Errorf("read b2: %v", err)
+	}
+
+	pidsUids := make([]byte, 12)
+	pid := os.Getpid()
+	uid := 0
+	gid := pid // for cygwin's AF_UNIX -> AF_INET, pid = gid
+
+	binary.LittleEndian.PutUint32(pidsUids, uint32(pid))
+	binary.LittleEndian.PutUint32(pidsUids[4:], uint32(uid))
+	binary.LittleEndian.PutUint32(pidsUids[8:], uint32(gid))
+
+	if _, err = conn.Write(pidsUids); err != nil {
+		return nil, fmt.Errorf("write pid,uid,gid: %v", err)
+	}
+
+	b3 := make([]byte, 12)
+	if _, err = conn.Read(b3); err != nil {
+		return nil, fmt.Errorf("read pid,uid,gid: %v", err)
+	}
+
+	return conn, nil
+}

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log/syslog"
 	"os"
 	"strconv"
 	"strings"
@@ -31,7 +30,6 @@ import (
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	logrusSyslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 type LoggingPurpose int
@@ -71,20 +69,6 @@ func InitLogger(purpose LoggingPurpose, level log.Level) {
 
 func InitLoggerForTests() {
 	InitLogger(LoggingForTests, log.DebugLevel)
-}
-
-// SwitchLoggingtoSyslog tells the logger to send the output to syslog
-func SwitchLoggingtoSyslog() {
-	log.StandardLogger().SetHooks(make(log.LevelHooks))
-	hook, err := logrusSyslog.NewSyslogHook("", "", syslog.LOG_WARNING, "")
-	if err != nil {
-		// syslog not available
-		log.SetOutput(os.Stderr)
-	} else {
-		// ... and disable stderr:
-		log.AddHook(hook)
-		log.SetOutput(ioutil.Discard)
-	}
 }
 
 // FatalError is for CLI front-ends: it detects gravitational/trace debugging

--- a/lib/utils/cli_nosyslog.go
+++ b/lib/utils/cli_nosyslog.go
@@ -1,0 +1,14 @@
+// +build windows
+
+package utils
+
+import (
+  "os"
+
+  log "github.com/sirupsen/logrus"
+)
+
+func SwitchLoggingtoSyslog() {
+  // syslog is not available on windows
+  log.SetOutput(os.Stderr)
+}

--- a/lib/utils/cli_syslog.go
+++ b/lib/utils/cli_syslog.go
@@ -1,0 +1,25 @@
+// +build !windows,!nacl,!plan9
+
+package utils
+
+import (
+  "log/syslog"
+  "os"
+
+  log "github.com/sirupsen/logrus"
+  logrusSyslog "github.com/sirupsen/logrus/hooks/syslog"
+)
+
+// SwitchLoggingtoSyslog tells the logger to send the output to syslog
+func SwitchLoggingtoSyslog() {
+	log.StandardLogger().SetHooks(make(log.LevelHooks))
+	hook, err := logrusSyslog.NewSyslogHook("", "", syslog.LOG_WARNING, "")
+	if err != nil {
+		// syslog not available
+		log.SetOutput(os.Stderr)
+	} else {
+		// ... and disable stderr:
+		log.AddHook(hook)
+		log.SetOutput(ioutil.Discard)
+	}
+}

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
@@ -156,43 +155,4 @@ func StatDir(path string) (os.FileInfo, error) {
 		return nil, trace.BadParameter("%v is not a directory", path)
 	}
 	return fi, nil
-}
-
-// FSWriteLock grabs Flock-style filesystem lock on an open file
-// in exclusive mode.
-func FSWriteLock(f *os.File) error {
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	return nil
-}
-
-// FSTryWriteLock tries to grab write lock, returns CompareFailed
-// if lock is already grabbed
-func FSTryWriteLock(f *os.File) error {
-	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-	if err != nil {
-		if err == syscall.EWOULDBLOCK {
-			return trace.CompareFailed("lock %v is acquired by another process", f.Name())
-		}
-		return trace.ConvertSystemError(err)
-	}
-	return nil
-}
-
-// FSReadLock grabs Flock-style filesystem lock on an open file
-// in read (shared) mode
-func FSReadLock(f *os.File) error {
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_SH); err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	return nil
-}
-
-// FSUnlock unlcocks Flock-style filesystem lock
-func FSUnlock(f *os.File) error {
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_UN); err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	return nil
 }

--- a/lib/utils/fs_unix.go
+++ b/lib/utils/fs_unix.go
@@ -1,0 +1,49 @@
+// +build !windows
+
+package utils
+
+import (
+  "os"
+  "syscall"
+
+  "github.com/gravitational/trace"
+)
+
+// FSWriteLock grabs Flock-style filesystem lock on an open file
+// in exclusive mode.
+func FSWriteLock(f *os.File) error {
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	return nil
+}
+
+// FSTryWriteLock tries to grab write lock, returns CompareFailed
+// if lock is already grabbed
+func FSTryWriteLock(f *os.File) error {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		if err == syscall.EWOULDBLOCK {
+			return trace.CompareFailed("lock %v is acquired by another process", f.Name())
+		}
+		return trace.ConvertSystemError(err)
+	}
+	return nil
+}
+
+// FSReadLock grabs Flock-style filesystem lock on an open file
+// in read (shared) mode
+func FSReadLock(f *os.File) error {
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_SH); err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	return nil
+}
+
+// FSUnlock unlcocks Flock-style filesystem lock
+func FSUnlock(f *os.File) error {
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_UN); err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	return nil
+}

--- a/lib/utils/fs_windows.go
+++ b/lib/utils/fs_windows.go
@@ -1,0 +1,21 @@
+package utils
+
+import "os"
+
+// For the moment, these functions are no-ops that should be replaced with a
+// native implementation in the future.
+func FSWriteLock(f *os.File) error {
+  return nil
+}
+
+func FSTryWriteLock(f *os.File) error {
+	return nil
+}
+
+func FSReadLock(f *os.File) error {
+	return nil
+}
+
+func FSUnlock(f *os.File) error {
+	return nil
+}


### PR DESCRIPTION
These changes are largely factoring out Unix-specific code and substituting code that will work with Windows, enabled by Go's build flag when compiling for Windows. The primary use case is to use `tsh` natively on Windows.

Also included is a mechanism to interact with `ssh-agent` when running on Windows, including using named pipes to interact with Microsoft's new native OpenSSH as well as Cygwin's pseudo Unix domain sockets when running Git for Windows.

There are some changes to the vendoring that will have to be incorporated before this will build properly. Specifically, `moby/moby/pkg/term` is broken for Windows at the moment, and also does not include the required function `SetWinsize`. This one may need to be forked and corrected. Additionally, `Microsoft/go-winio` will need to be vendored.