### PR TITLE
Set max session TTL for default-implicit-role to maximum allowed value.

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -119,7 +119,7 @@ func NewImplicitRole() Role {
 		},
 		Spec: RoleSpecV3{
 			Options: RoleOptions{
-				MaxSessionTTL: NewDuration(defaults.MaxCertDuration),
+				MaxSessionTTL: MaxDuration(),
 			},
 			Allow: RoleConditions{
 				Namespaces: []string{defaults.Namespace},


### PR DESCRIPTION
**Purpose**

Allow `tctl` to create user certificates with TTL longer than the default maximum TTL duration.

**Implementation**

Increase the max session TTL for `default-implicit-role` to the maximum allowable value. This allows creation of roles with values larger than the default which then allow `tctl` to create user certificates with values larger than the default maximum TTL duration.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1745