### PR TITLE
Allow user certificates with TTL larger than 30 hours

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -72,13 +72,26 @@ func (a *AuthWithRoles) authConnectorAction(namespace string, resource string, v
 	return nil
 }
 
+// hasBuiltinRole checks the type of the role set returned and the name.
+// Returns true if role set is builtin and the name matches.
+func (a *AuthWithRoles) hasBuiltinRole(name string) bool {
+	if _, ok := a.checker.(BuiltinRoleSet); !ok {
+		return false
+	}
+	if !a.checker.HasRole(name) {
+		return false
+	}
+
+	return true
+}
+
 // AuthenticateWebUser authenticates web user, creates and  returns web session
 // in case if authentication is successfull
 func (a *AuthWithRoles) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
 	// authentication request has it's own authentication, however this limits the requests
 	// types to proxies to make it harder to break
-	if !a.checker.HasRole(string(teleport.RoleProxy)) {
-		return nil, trace.AccessDenied("this request can be only executed by proxy")
+	if !a.hasBuiltinRole(string(teleport.RoleProxy)) {
+		return nil, trace.AccessDenied("this request can be only executed by a proxy")
 	}
 	return a.authServer.AuthenticateWebUser(req)
 }
@@ -88,8 +101,8 @@ func (a *AuthWithRoles) AuthenticateWebUser(req AuthenticateUserRequest) (servic
 func (a *AuthWithRoles) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	// authentication request has it's own authentication, however this limits the requests
 	// types to proxies to make it harder to break
-	if !a.checker.HasRole(string(teleport.RoleProxy)) {
-		return nil, trace.AccessDenied("this request can be only executed by proxy")
+	if !a.hasBuiltinRole(string(teleport.RoleProxy)) {
+		return nil, trace.AccessDenied("this request can be only executed by a proxy")
 	}
 	return a.authServer.AuthenticateSSHUser(req)
 }
@@ -530,37 +543,35 @@ func (a *AuthWithRoles) GenerateHostCert(
 }
 
 func (a *AuthWithRoles) GenerateUserCert(key []byte, username string, ttl time.Duration, compatibility string) ([]byte, error) {
-	if err := a.currentUserAction(username); err != nil {
-		return nil, trace.AccessDenied("%v cannot request a certificate for %v", a.user.GetName(), username)
+	// This endpoint is only accessible to tctl.
+	if !a.hasBuiltinRole(string(teleport.RoleAdmin)) {
+		return nil, trace.AccessDenied("this request can be only executed by an admin")
 	}
-	// notice that user requesting the certificate and the user currently
-	// authenticated may differ (e.g. admin generates certificate for the user scenario)
-	// so we fetch user's permissions
-	checker := a.checker
-	var user services.User
-	var err error
-	if a.user.GetName() != username {
-		user, err = a.GetUser(username)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		checker, err = services.FetchRoles(user.GetRoles(), a.authServer, user.GetTraits())
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	} else {
-		user = a.user
+
+	// Extract the user and role set for whom the certificate will be generated.
+	user, err := a.GetUser(username)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
+	checker, err := services.FetchRoles(user.GetRoles(), a.authServer, user.GetTraits())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Generate certificate, note that the roles TTL will be ignored because
+	// the request is coming from "tctl auth sign" itself.
 	certs, err := a.authServer.generateUserCert(certRequest{
-		user:          user,
-		roles:         checker,
-		ttl:           ttl,
-		compatibility: compatibility,
-		publicKey:     key,
+		user:            user,
+		roles:           checker,
+		ttl:             ttl,
+		compatibility:   compatibility,
+		publicKey:       key,
+		overrideRoleTTL: true,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	return certs.ssh, nil
 }
 
@@ -1193,8 +1204,8 @@ func (a *AuthWithRoles) DeleteAllRemoteClusters() error {
 // signed certificate if sucessfull.
 func (a *AuthWithRoles) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	// limits the requests types to proxies to make it harder to break
-	if !a.checker.HasRole(string(teleport.RoleProxy)) {
-		return nil, trace.AccessDenied("this request can be only executed by proxy")
+	if !a.hasBuiltinRole(string(teleport.RoleProxy)) {
+		return nil, trace.AccessDenied("this request can be only executed by a proxy")
 	}
 	return a.authServer.ProcessKubeCSR(req)
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -555,8 +555,6 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 	}
 	if c.KeyTTL == 0 {
 		c.KeyTTL = defaults.CertDuration
-	} else if c.KeyTTL > defaults.MaxCertDuration || c.KeyTTL < defaults.MinCertDuration {
-		return nil, trace.BadParameter("invalid requested cert TTL")
 	}
 	c.Namespace = services.ProcessNamespace(c.Namespace)
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -119,7 +119,7 @@ func NewImplicitRole() Role {
 		},
 		Spec: RoleSpecV3{
 			Options: RoleOptions{
-				MaxSessionTTL: NewDuration(defaults.MaxCertDuration),
+				MaxSessionTTL: MaxDuration(),
 			},
 			Allow: RoleConditions{
 				Namespaces: []string{defaults.Namespace},


### PR DESCRIPTION
**Purpose**

Allow administrators the ability to either directly (through `tctl`) or indirectly (creating a role with large TTL value) create user certificates with TTL longer than the default maximum TTL duration.

**Implementation**

Increase the max session TTL for `default-implicit-role` to the maximum allowable value. This allows creation of roles with values larger than the default. Users can then then use `tsh` to generate certificates with TTL values larger than the maximum value currently allowed.

Also update the `GenerateUserCert` endpoint to only accept request from `tctl` and allow `tctl`
 to bypass any TTL restrictions.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1745