### PR TITLE
Check logins when applying traits

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -290,31 +290,43 @@ func ApplyTraits(r Role, traits map[string][]string) Role {
 
 		var outLogins []string
 		for _, login := range inLogins {
-			// extract the variablePrefix and variableName from the role variable
+			// Extract the variablePrefix and variableName from the role variable.
 			variablePrefix, variableName, err := parse.IsRoleVariable(login)
 
-			// if we didn't find a variable (found a normal login) then append it and
-			// go on to the next login
+			// If a variable was not found check if it's a valid Unix login. If it is
+			// a valid Unix login add it to the list of logins, otherwise skip.
 			if trace.IsNotFound(err) {
+				if !cstrings.IsValidUnixUser(login) {
+					log.Debugf("Skipping login %v, not a valid Unix login.", login)
+					continue
+				}
 				outLogins = append(outLogins, login)
 				continue
 			}
 
-			// for internal traits, we only support internal.logins at the moment
+			// For internal traits, only internal.logins is supported at the moment.
 			if variablePrefix == teleport.TraitInternalPrefix {
 				if variableName != teleport.TraitLogins {
 					continue
 				}
 			}
 
-			// if we can't find the variable in the traits, skip it
-			variableValue, ok := traits[variableName]
+			// If the variable is not found in the traits, skip it.
+			variableValues, ok := traits[variableName]
 			if !ok {
 				continue
 			}
 
-			// we found the variable in the traits, append it to the list of logins
-			outLogins = append(outLogins, variableValue...)
+			// Filter out logins that come from variables that are not valid Unix logins.
+			for _, variableValue := range variableValues {
+				if !cstrings.IsValidUnixUser(variableValue) {
+					log.Debugf("Skipping login %v, not a valid Unix login.", variableValue)
+					continue
+				}
+
+				// A valid variable was found in the traits, append it to the list of logins.
+				outLogins = append(outLogins, variableValue)
+			}
 		}
 
 		r.SetLogins(condition, utils.Deduplicate(outLogins))
@@ -569,9 +581,6 @@ func (r *RoleV3) CheckAndSetDefaults() error {
 	for _, login := range r.Spec.Allow.Logins {
 		if login == Wildcard {
 			return trace.BadParameter("wildcard matcher is not allowed in logins")
-		}
-		if !cstrings.IsValidUnixUser(login) {
-			return trace.BadParameter("%q is not a valid user name", login)
 		}
 	}
 	for key, val := range r.Spec.Allow.NodeLabels {
@@ -1172,9 +1181,6 @@ func (r *RoleV2) CheckAndSetDefaults() error {
 	for _, login := range r.Spec.Logins {
 		if login == Wildcard {
 			return trace.BadParameter("wildcard matcher is not allowed in logins")
-		}
-		if !cstrings.IsValidUnixUser(login) {
-			return trace.BadParameter("'%v' is not a valid user name", login)
 		}
 	}
 	for key, val := range r.Spec.NodeLabels {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -910,6 +910,14 @@ func (s *RoleSuite) TestApplyTraits(c *C) {
 			[]string{`{{external.foo}}`, "bar"},
 			[]string{"bar"},
 		},
+		// 7 - invalid unix login
+		{
+			map[string][]string{
+				"foo": []string{"-foo"},
+			},
+			[]string{`{{external.foo}}`, "bar"},
+			[]string{"bar"},
+		},
 	}
 
 	for i, tt := range tests {
@@ -951,6 +959,11 @@ func (s *RoleSuite) TestCheckAndSetDefaults(c *C) {
 		// 2 - valid syntax
 		{
 			[]string{"{{foo.bar}}"},
+			false,
+		},
+		// 3 - valid syntax
+		{
+			[]string{`{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}`},
 			false,
 		},
 	}


### PR DESCRIPTION
**Purpose**

Check logins when applying traits and not when creating a role. This allows creating roles with variables. An example where this causes problems was:

```
{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}
```

**Implementation**

* Don't check logins when creating a role.
* Remove logins that are not valid Unix logins when applying traits.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2022