### PR TITLE
Add GetUser to state.CachingAuthClient.

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -58,6 +58,9 @@ type AccessPoint interface {
 	// GetCertAuthorities returns a list of cert authorities
 	GetCertAuthorities(caType services.CertAuthType, loadKeys bool) ([]services.CertAuthority, error)
 
+	// GetUser returns a services.User for this cluster.
+	GetUser(string) (services.User, error)
+
 	// GetUsers returns a list of local users registered with this domain
 	GetUsers() ([]services.User, error)
 

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -335,18 +335,14 @@ func (h *AuthHandlers) fetchRoleSet(cert *ssh.Certificate, ca services.CertAutho
 	// for local users, go and check their individual permissions
 	var roles services.RoleSet
 	if clusterName == ca.GetClusterName() {
-		users, err := h.AccessPoint.GetUsers()
+		u, err := h.AccessPoint.GetUser(teleportUser)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		for _, u := range users {
-			if u.GetName() == teleportUser {
-				// pass along the traits so we get the substituted roles for this user
-				roles, err = services.FetchRoles(u.GetRoles(), h.AccessPoint, u.GetTraits())
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-			}
+		// Pass along the traits so we get the substituted roles for this user.
+		roles, err = services.FetchRoles(u.GetRoles(), h.AccessPoint, u.GetTraits())
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 	} else {
 		certRoles, err := extractRolesFromCert(cert)


### PR DESCRIPTION
**Purpose**

During login `GetUsers` is called and iterated over to find the `services.User` the user is trying to login as. This makes the login flow sensitive the number of users in the backend. Instead use `GetUser` get the exact `services.User` the user is trying to login as.

**Implementation**

* Add `GetUser` to `state.CachingAuthClient`.
* Use `GetUser` in the auth handler.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2021