### PR TITLE
Fix 401 Unauthorized errors for proxied K8S API requests

### DIFF
--- a/lib/kube/authority/authority.go
+++ b/lib/kube/authority/authority.go
@@ -49,7 +49,7 @@ func ProcessCSR(csrPEM []byte, caCertPath string) (*Cert, error) {
 			Usages: []certificates.KeyUsage{
 				certificates.UsageDigitalSignature,
 				certificates.UsageKeyEncipherment,
-				certificates.UsageServerAuth,
+				certificates.UsageClientAuth,
 			},
 		},
 	})


### PR DESCRIPTION
In theory this is due to a misconfiguration in CSR that is submitted to Kubernetes Certificates API. The KeyUsage should include `UsageClientAuth` rather than `UsageServerAuth`, because the issued cert is actually used for Client Auth, which is that Kubernetes API server does to authenticate you as a client according to the provided cert

Ref https://github.com/gravitational/teleport/pull/2014#issuecomment-398061175