### PR TITLE
Verify that there is a bug in addr parsing

### DIFF
--- a/lib/utils/addr_test.go
+++ b/lib/utils/addr_test.go
@@ -49,6 +49,11 @@ func (s *AddrTestSuite) TestParseHostPort(c *C) {
 	addr, err = ParseHostPortAddr("localhost", -1)
 	c.Assert(err, NotNil)
 	c.Assert(addr, IsNil)
+
+	// redundant scheme + missing port
+	addr, err = ParseHostPortAddr("https://localhost", -1)
+	c.Assert(err, NotNil)
+	c.Assert(addr, IsNil)
 }
 
 func (s *AddrTestSuite) TestEmpty(c *C) {


### PR DESCRIPTION
`https://localhost/` results in a "valid" netaddr that results in confusion like https://github.com/gravitational/teleport/pull/2014#issuecomment-399322820:

```
addr_test.go:56:
    //c.Assert(err, NotNil)
    c.Assert(addr, IsNil)
... value *utils.NetAddr = &utils.NetAddr{Addr:"https:", AddrNetwork:"tcp", Path:"//localhost"} ("https:")
```