### PR TITLE
Update tsh login to select clusters.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -889,7 +889,7 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 		SiteName:           cfg.Cluster,
 		ForwardAgent:       cfg.ForwardAgent,
 	}
-	cconf.SetProxy(proxyHost, proxyWebPort, proxySSHPort)
+	cconf.SetProxy(proxyHost, proxyWebPort, proxySSHPort, 0)
 
 	return client.NewClient(cconf)
 }

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -43,7 +43,7 @@ func (s *APITestSuite) TestConfig(c *check.C) {
 	c.Assert(conf.ProxySSHHostPort(), check.Equals, "example.org:3023")
 	c.Assert(conf.ProxyWebHostPort(), check.Equals, "example.org:3080")
 
-	conf.SetProxy("example.org", 100, 200)
+	conf.SetProxy("example.org", 100, 200, 0)
 	c.Assert(conf.ProxyWebHostPort(), check.Equals, "example.org:100")
 	c.Assert(conf.ProxySSHHostPort(), check.Equals, "example.org:200")
 
@@ -54,6 +54,12 @@ func (s *APITestSuite) TestConfig(c *check.C) {
 	conf.ProxyHostPort = "example.org:,200"
 	c.Assert(conf.ProxySSHHostPort(), check.Equals, "example.org:200")
 	c.Assert(conf.ProxyWebHostPort(), check.Equals, "example.org:3080")
+
+	conf.SetProxy("example.org", 100, 200, 300)
+	c.Assert(conf.ProxyWebHostPort(), check.Equals, "example.org:100")
+	c.Assert(conf.ProxySSHHostPort(), check.Equals, "example.org:200")
+	c.Assert(conf.ProxyKubeHostPort(), check.Equals, "example.org:300")
+
 }
 
 func (s *APITestSuite) TestNew(c *check.C) {

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -37,9 +37,10 @@ type ClientProfile struct {
 	//
 	// proxy configuration
 	//
-	ProxyHost    string `yaml:"proxy_host,omitempty"`
-	ProxySSHPort int    `yaml:"proxy_port,omitempty"`
-	ProxyWebPort int    `yaml:"proxy_web_port,omitempty"`
+	ProxyHost     string `yaml:"proxy_host,omitempty"`
+	ProxySSHPort  int    `yaml:"proxy_port,omitempty"`
+	ProxyWebPort  int    `yaml:"proxy_web_port,omitempty"`
+	ProxyKubePort int    `yaml:"proxy_kube_port,omitempty"`
 
 	//
 	// auth/identity

--- a/lib/kube/client/kubeclient.go
+++ b/lib/kube/client/kubeclient.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -22,8 +21,10 @@ func UpdateKubeconfig(tc *client.TeleportClient) error {
 		return trace.Wrap(err)
 	}
 	clusterName := tc.ProxyHost()
-	// TODO: unhardcode the port
-	clusterAddr := fmt.Sprintf("https://%v:%v", tc.ProxyHost(), defaults.KubeProxyListenPort)
+	if tc.SiteName != "" && tc.SiteName != clusterName {
+		clusterName = fmt.Sprintf("%v.%v", tc.SiteName, tc.ProxyHost())
+	}
+	clusterAddr := fmt.Sprintf("https://%v:%v", clusterName, tc.ProxyKubePort())
 
 	creds, err := tc.LocalAgent().GetKey()
 	if err != nil {

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -280,7 +280,7 @@ func (f *Forwarder) setupContext(ctx auth.AuthContext, req *http.Request, isRemo
 		return nil, trace.Wrap(err)
 	}
 	for _, remoteCluster := range f.Tunnel.GetSites() {
-		if strings.HasSuffix(req.Host, remoteCluster.GetName()+".") {
+		if strings.HasPrefix(req.Host, remoteCluster.GetName()+".") {
 			f.Debugf("Going to proxy to cluster: %v based on matching host suffix %v.", remoteCluster.GetName(), req.Host)
 			targetCluster = remoteCluster
 			isRemoteCluster = remoteCluster.GetName() != f.ClusterName
@@ -561,9 +561,9 @@ type clusterSession struct {
 func (f *Forwarder) getOrCreateClusterSession(ctx authContext) (*clusterSession, error) {
 	client := f.getClusterSession(ctx)
 	if client != nil {
-		f.Debugf("Returning existing creds for %v.", ctx)
 		return client, nil
 	}
+	f.Debugf("Requesting new creds for %v.", ctx)
 	return f.newClusterSession(ctx)
 }
 

--- a/tool/tsh/help.go
+++ b/tool/tsh/help.go
@@ -10,5 +10,11 @@ EXAMPLES:
   $ tsh --proxy=host.example.com:8080,8023 login    
   
   Use port 8080 and 3023 (default) for SSH proxy:
-  $ tsh --proxy=host.example.com:8080 login`
+  $ tsh --proxy=host.example.com:8080 login
+
+  Login and select cluster "two":
+  $ tsh --proxy=host.example.com login two
+
+  Select cluster "two" using existing credentials and proxy:
+  $ tsh login two`
 )


### PR DESCRIPTION
The following changes have been introduced
to tsh login behavior:

1. tsh login now accepts cluster name
as an optional positional argument:

$ tsh login clustername

2. If tsh login is called without arguments
and the current credentials are valid,
tsh login now prints status, previous behavior
always forced login:

$ tsh login
... print status if logged in...

2. If tsh login is called with the proxy
equal to current, tsh login selects cluster,
otherwise it will re-login to another proxy:

$ tsh login one
... selected cluster one

$ tsh login two
... selected cluster two

$ tsh login --proxy=example.com three
... selected cluster three because
proxy is the same

$ tsh login --proxy=acme.example.com four
...will switch to proxy acme.example.com
and cluster four