### PR TITLE
Fix proxying long polling requests.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -321,8 +321,8 @@
     "ratelimit",
     "utils"
   ]
-  revision = "5ee2776d4b3845fcc956508a171bbf1cbdb4fe1a"
-  version = "1.0.1"
+  revision = "e4a7e35311e6c4da4cf9e73c6a3d8cf523937211"
+  version = "1.0.2"
 
 [[projects]]
   name = "github.com/gravitational/reporting"
@@ -916,6 +916,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4d680ed328cd1c599ebb3fd0e75e13b10482761fb3775badafbccd2a0ce3e2ab"
+  inputs-digest = "27cc87b56a789ad4cd6b07e910c2159416d60dc89e45b1a5f834cbc256957b21"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -104,7 +104,7 @@ ignored = ["github.com/Sirupsen/logrus"]
   version = ">=0.0.2, <=1.0.0-gc98f59f"
 
 [[constraint]]
-  version = "1.0.1"
+  version = "1.0.2"
   name = "github.com/gravitational/oxy"
 
 [[constraint]]

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -649,6 +649,7 @@ func (f *Forwarder) newClusterSession(ctx authContext) (*clusterSession, error) 
 	tlsConfig.BuildNameToCertificate()
 
 	fwd, err := forward.New(
+		forward.FlushInterval(100*time.Millisecond),
 		forward.RoundTripper(f.newTransport(ctx.cluster.Dial, tlsConfig)),
 		forward.WebsocketDial(ctx.cluster.Dial),
 		forward.Logger(logrus.StandardLogger()),

--- a/vendor/github.com/gravitational/oxy/forward/flushcopy.go
+++ b/vendor/github.com/gravitational/oxy/forward/flushcopy.go
@@ -1,0 +1,95 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// HTTP reverse proxy handler
+
+package forward
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+func copyResponse(ctx *handlerContext, flushInterval time.Duration, dst io.Writer, src io.Reader) (int64, error) {
+	if flushInterval != 0 {
+		if wf, ok := dst.(writeFlusher); ok {
+			mlw := &maxLatencyWriter{
+				dst:     wf,
+				latency: flushInterval,
+				done:    make(chan bool),
+			}
+			go mlw.flushLoop()
+			defer mlw.stop()
+			dst = mlw
+		}
+	}
+	return copyBuffer(ctx, dst, src, nil)
+}
+
+func copyBuffer(ctx *handlerContext, dst io.Writer, src io.Reader, buf []byte) (int64, error) {
+	if len(buf) == 0 {
+		buf = make([]byte, 32*1024)
+	}
+	var written int64
+	for {
+		nr, rerr := src.Read(buf)
+		if rerr != nil && rerr != io.EOF && rerr != context.Canceled {
+			ctx.log.Infof("ReverseProxy read error during body copy: %v", rerr)
+		}
+		if nr > 0 {
+			nw, werr := dst.Write(buf[:nr])
+			if nw > 0 {
+				written += int64(nw)
+			}
+			if werr != nil {
+				return written, werr
+			}
+			if nr != nw {
+				return written, io.ErrShortWrite
+			}
+		}
+		if rerr != nil {
+			return written, rerr
+		}
+	}
+}
+
+type writeFlusher interface {
+	io.Writer
+	http.Flusher
+}
+
+type maxLatencyWriter struct {
+	dst     writeFlusher
+	latency time.Duration
+
+	mu   sync.Mutex // protects Write + Flush
+	done chan bool
+}
+
+func (m *maxLatencyWriter) Write(p []byte) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.dst.Write(p)
+}
+
+func (m *maxLatencyWriter) flushLoop() {
+	t := time.NewTicker(m.latency)
+	defer t.Stop()
+	for {
+		select {
+		case <-m.done:
+			return
+		case <-t.C:
+			m.mu.Lock()
+			m.dst.Flush()
+			m.mu.Unlock()
+		}
+	}
+}
+
+func (m *maxLatencyWriter) stop() { m.done <- true }


### PR DESCRIPTION
Fixes #2039

This commit fixes long polling cases with teleport
for K8s that did not work because flush was not
called during io.Copy commands.