### PR TITLE
External traits in node labels and regexp role map

### DIFF
--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -149,6 +149,11 @@ func (a *AuthServer) UpsertTrustedCluster(trustedCluster services.TrustedCluster
 func (a *AuthServer) checkLocalRoles(roleMap services.RoleMap) error {
 	for _, mapping := range roleMap {
 		for _, localRole := range mapping.Local {
+			// expansion means dynamic mapping is in place,
+			// so local role is undefined
+			if utils.ContainsExpansion(localRole) {
+				continue
+			}
 			_, err := a.GetRole(localRole)
 			if err != nil {
 				if trace.IsNotFound(err) {

--- a/lib/services/map_test.go
+++ b/lib/services/map_test.go
@@ -128,6 +128,55 @@ func (s *RoleMapSuite) TestRoleMap(c *check.C) {
 				{Remote: Wildcard, Local: []string{"local-logs"}},
 			},
 		},
+		{
+			name:   "glob capture match",
+			remote: []string{"remote-devs"},
+			local:  []string{"local-devs"},
+			roleMap: RoleMap{
+				{Remote: "remote-*", Local: []string{"local-$1"}},
+			},
+		},
+		{
+			name:   "passthrough match",
+			remote: []string{"remote-devs"},
+			local:  []string{"remote-devs"},
+			roleMap: RoleMap{
+				{Remote: "^(.*)$", Local: []string{"$1"}},
+			},
+		},
+		{
+			name:   "partial match",
+			remote: []string{"remote-devs", "something-else"},
+			local:  []string{"remote-devs"},
+			roleMap: RoleMap{
+				{Remote: "^(remote-.*)$", Local: []string{"$1"}},
+			},
+		},
+		{
+			name:   "partial empty expand section is removed",
+			remote: []string{"remote-devs"},
+			local:  []string{"remote-devs", "remote-"},
+			roleMap: RoleMap{
+				{Remote: "^(remote-.*)$", Local: []string{"$1", "remote-$2", "$2"}},
+			},
+		},
+		{
+			name:   "multiple matches yuield different results",
+			remote: []string{"remote-devs"},
+			local:  []string{"remote-devs", "test"},
+			roleMap: RoleMap{
+				{Remote: "^(remote-.*)$", Local: []string{"$1"}},
+				{Remote: `^\Aremote-.*$`, Local: []string{"test"}},
+			},
+		},
+		{
+			name:   "different expand groups can be referred",
+			remote: []string{"remote-devs"},
+			local:  []string{"remote-devs", "devs"},
+			roleMap: RoleMap{
+				{Remote: "^(remote-(.*))$", Local: []string{"$1", "$2"}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -137,8 +186,8 @@ func (s *RoleMapSuite) TestRoleMap(c *check.C) {
 			c.Assert(err, check.NotNil, comment)
 			c.Assert(err, check.FitsTypeOf, tc.err)
 		} else {
-			c.Assert(err, check.IsNil)
-			c.Assert(local, check.DeepEquals, tc.local)
+			c.Assert(err, check.IsNil, comment)
+			c.Assert(local, check.DeepEquals, tc.local, comment)
 		}
 	}
 }

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -849,79 +849,167 @@ func (s *RoleSuite) TestCheckRuleSorting(c *C) {
 }
 
 func (s *RoleSuite) TestApplyTraits(c *C) {
+	type rule struct {
+		inLogins      []string
+		outLogins     []string
+		inLabels      map[string]string
+		outLabels     map[string]string
+		inKubeGroups  []string
+		outKubeGroups []string
+	}
 	var tests = []struct {
-		inTraits  map[string][]string
-		inLogins  []string
-		outLogins []string
+		comment  string
+		inTraits map[string][]string
+		allow    rule
+		deny     rule
 	}{
-		// 0 - substitute in allow rule
+
 		{
-			map[string][]string{
+			comment: "logins substitute in allow rule",
+			inTraits: map[string][]string{
 				"foo": []string{"bar"},
 			},
-			[]string{`{{external.foo}}`, "root"},
-			[]string{"bar", "root"},
+			allow: rule{
+				inLogins:  []string{`{{external.foo}}`, "root"},
+				outLogins: []string{"bar", "root"},
+			},
 		},
-		// 1 - substitute in deny rule
 		{
-			map[string][]string{
+			comment: "logins substitute in deny rule",
+			inTraits: map[string][]string{
 				"foo": []string{"bar"},
 			},
-			[]string{`{{external.foo}}`},
-			[]string{"bar"},
+			deny: rule{
+				inLogins:  []string{`{{external.foo}}`},
+				outLogins: []string{"bar"},
+			},
 		},
-		// 2 - no variable in logins
 		{
-			map[string][]string{
+			comment: "kube group substitute in allow rule",
+			inTraits: map[string][]string{
 				"foo": []string{"bar"},
 			},
-			[]string{"root"},
-			[]string{"root"},
+			allow: rule{
+				inKubeGroups:  []string{`{{external.foo}}`, "root"},
+				outKubeGroups: []string{"bar", "root"},
+			},
 		},
-		// 3 - invalid variable in logins gets passed along
 		{
-			map[string][]string{
+			comment: "kube group substitute in deny rule",
+			inTraits: map[string][]string{
 				"foo": []string{"bar"},
 			},
-			[]string{`external.foo}}`},
-			[]string{`external.foo}}`},
+			deny: rule{
+				inKubeGroups:  []string{`{{external.foo}}`, "root"},
+				outKubeGroups: []string{"bar", "root"},
+			},
 		},
-		// 4 - variable in logins, none in traits
 		{
-			map[string][]string{
+			comment: "no variable in logins",
+			inTraits: map[string][]string{
 				"foo": []string{"bar"},
 			},
-			[]string{`{{internal.bar}}`, "root"},
-			[]string{"root"},
+			allow: rule{
+				inLogins:  []string{"root"},
+				outLogins: []string{"root"},
+			},
 		},
-		// 5 - multiple variables in traits
+
 		{
-			map[string][]string{
+			comment: "invalid variable in logins gets passed along",
+			inTraits: map[string][]string{
+				"foo": []string{"bar"},
+			},
+			allow: rule{
+				inLogins:  []string{`external.foo}}`},
+				outLogins: []string{`external.foo}}`},
+			},
+		},
+		{
+			comment: "variable in logins, none in traits",
+			inTraits: map[string][]string{
+				"foo": []string{"bar"},
+			},
+			allow: rule{
+				inLogins:  []string{`{{internal.bar}}`, "root"},
+				outLogins: []string{"root"},
+			},
+		},
+		{
+			comment: "multiple variables in traits",
+			inTraits: map[string][]string{
 				"logins": []string{"bar", "baz"},
 			},
-			[]string{`{{internal.logins}}`, "root"},
-			[]string{"bar", "baz", "root"},
+			allow: rule{
+				inLogins:  []string{`{{internal.logins}}`, "root"},
+				outLogins: []string{"bar", "baz", "root"},
+			},
 		},
-		// 6 - deduplicate
 		{
-			map[string][]string{
+			comment: "deduplicate",
+			inTraits: map[string][]string{
 				"foo": []string{"bar"},
 			},
-			[]string{`{{external.foo}}`, "bar"},
-			[]string{"bar"},
+			allow: rule{
+				inLogins:  []string{`{{external.foo}}`, "bar"},
+				outLogins: []string{"bar"},
+			},
 		},
-		// 7 - invalid unix login
 		{
-			map[string][]string{
+			comment: "invalid unix login",
+			inTraits: map[string][]string{
 				"foo": []string{"-foo"},
 			},
-			[]string{`{{external.foo}}`, "bar"},
-			[]string{"bar"},
+			allow: rule{
+				inLogins:  []string{`{{external.foo}}`, "bar"},
+				outLogins: []string{"bar"},
+			},
+		},
+		{
+			comment: "label substitute in allow and deny rule",
+			inTraits: map[string][]string{
+				"foo":   []string{"bar"},
+				"hello": []string{"there"},
+			},
+			allow: rule{
+				inLabels:  map[string]string{`{{external.foo}}`: "{{external.hello}}"},
+				outLabels: map[string]string{`bar`: "there"},
+			},
+			deny: rule{
+				inLabels:  map[string]string{`{{external.hello}}`: "{{external.foo}}"},
+				outLabels: map[string]string{`there`: "bar"},
+			},
+		},
+
+		{
+			comment: "missing node variables are set to empty during substitution",
+			inTraits: map[string][]string{
+				"foo": []string{"bar"},
+			},
+			allow: rule{
+				inLabels: map[string]string{
+					`{{external.foo}}`:     "value",
+					`{{external.missing}}`: "missing",
+					`missing`:              "{{external.missing}}",
+				},
+				outLabels: map[string]string{`bar`: "value", "missing": "", "": "missing"},
+			},
+		},
+
+		{
+			comment: "the first variable value is picked for labels",
+			inTraits: map[string][]string{
+				"foo": []string{"bar", "baz"},
+			},
+			allow: rule{
+				inLabels:  map[string]string{`{{external.foo}}`: "value"},
+				outLabels: map[string]string{`bar`: "value"},
+			},
 		},
 	}
 
 	for i, tt := range tests {
-		comment := Commentf("Test %v", i)
+		comment := Commentf("Test %v %v", i, tt.comment)
 
 		role := &RoleV3{
 			Kind:    KindRole,
@@ -932,12 +1020,26 @@ func (s *RoleSuite) TestApplyTraits(c *C) {
 			},
 			Spec: RoleSpecV3{
 				Allow: RoleConditions{
-					Logins: tt.inLogins,
+					Logins:     tt.allow.inLogins,
+					NodeLabels: tt.allow.inLabels,
+					KubeGroups: tt.allow.inKubeGroups,
+				},
+				Deny: RoleConditions{
+					Logins:     tt.deny.inLogins,
+					NodeLabels: tt.deny.inLabels,
+					KubeGroups: tt.deny.inKubeGroups,
 				},
 			},
 		}
+
 		outRole := role.ApplyTraits(tt.inTraits)
-		c.Assert(outRole.GetLogins(Allow), DeepEquals, tt.outLogins, comment)
+		c.Assert(outRole.GetLogins(Allow), DeepEquals, tt.allow.outLogins, comment)
+		c.Assert(outRole.GetNodeLabels(Allow), DeepEquals, tt.allow.outLabels, comment)
+		c.Assert(outRole.GetKubeGroups(Allow), DeepEquals, tt.allow.outKubeGroups, comment)
+
+		c.Assert(outRole.GetLogins(Deny), DeepEquals, tt.deny.outLogins, comment)
+		c.Assert(outRole.GetNodeLabels(Deny), DeepEquals, tt.deny.outLabels, comment)
+		c.Assert(outRole.GetKubeGroups(Deny), DeepEquals, tt.deny.outKubeGroups, comment)
 	}
 }
 

--- a/lib/services/trustedcluster.go
+++ b/lib/services/trustedcluster.go
@@ -140,72 +140,77 @@ func (r RoleMap) Equals(o RoleMap) bool {
 
 // String prints user friendly representation of role mapping
 func (r RoleMap) String() string {
-	directMatch, wildcardMatch, err := r.parse()
+	values, err := r.parse()
 	if err != nil {
 		return fmt.Sprintf("<failed to parse: %v", err)
 	}
-	if len(wildcardMatch) != 0 {
-		directMatch[Wildcard] = wildcardMatch
-	}
-	if len(directMatch) != 0 {
-		return fmt.Sprintf("%v", directMatch)
+	if len(values) != 0 {
+		return fmt.Sprintf("%v", values)
 	}
 	return "<empty>"
 }
 
-func (r RoleMap) parse() (map[string][]string, []string, error) {
-	var wildcardMatch []string
+func (r RoleMap) parse() (map[string][]string, error) {
 	directMatch := make(map[string][]string)
 	for i := range r {
 		roleMap := r[i]
 		if roleMap.Remote == "" {
-			return nil, nil, trace.BadParameter("missing 'remote' parameter for role_map")
+			return nil, trace.BadParameter("missing 'remote' parameter for role_map")
+		}
+		_, err := utils.ReplaceRegexp(roleMap.Remote, "", "")
+		if trace.IsBadParameter(err) {
+			return nil, trace.BadParameter("failed to parse 'remote' parameter for role_map: %v", err.Error())
 		}
 		if len(roleMap.Local) == 0 {
-			return nil, nil, trace.BadParameter("missing 'local' parameter for 'role_map'")
+			return nil, trace.BadParameter("missing 'local' parameter for 'role_map'")
 		}
 		for _, local := range roleMap.Local {
 			if local == "" {
-				return nil, nil, trace.BadParameter("missing 'local' property of 'role_map' entry")
+				return nil, trace.BadParameter("missing 'local' property of 'role_map' entry")
 			}
 			if local == Wildcard {
-				return nil, nil, trace.BadParameter("wilcard value is not supported for 'local' property of 'role_map' entry")
+				return nil, trace.BadParameter("wilcard value is not supported for 'local' property of 'role_map' entry")
 			}
 		}
-		if roleMap.Remote == Wildcard {
-			if wildcardMatch != nil {
-				return nil, nil, trace.BadParameter("only one wildcard local role matcher is allowed")
-			}
-			wildcardMatch = roleMap.Local
-		} else {
-			_, ok := directMatch[roleMap.Remote]
-			if ok {
-				return nil, nil, trace.BadParameter("remote role '%v' match is already specified", roleMap.Remote)
-			}
-			directMatch[roleMap.Remote] = roleMap.Local
+		_, ok := directMatch[roleMap.Remote]
+		if ok {
+			return nil, trace.BadParameter("remote role '%v' match is already specified", roleMap.Remote)
 		}
+		directMatch[roleMap.Remote] = roleMap.Local
 	}
-	return directMatch, wildcardMatch, nil
+	return directMatch, nil
 }
 
 // Map maps local roles to remote roles
 func (r RoleMap) Map(remoteRoles []string) ([]string, error) {
-	directMatch, wildcardMatch, err := r.parse()
+	_, err := r.parse()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	var outRoles []string
-	if len(remoteRoles) == 0 && len(wildcardMatch) != 0 {
-		outRoles = append(outRoles, wildcardMatch...)
-		return outRoles, nil
+	// when no remote roles is specified, assume that
+	// there is a single empty remote role (that should match wildcards)
+	if len(remoteRoles) == 0 {
+		remoteRoles = []string{""}
 	}
-	for _, remoteRole := range remoteRoles {
-		match, ok := directMatch[remoteRole]
-		if ok {
-			outRoles = append(outRoles, match...)
-		}
-		if wildcardMatch != nil {
-			outRoles = append(outRoles, wildcardMatch...)
+	for _, mapping := range r {
+		expression := mapping.Remote
+		for _, remoteRole := range remoteRoles {
+			for _, replacementRole := range mapping.Local {
+				replacement, err := utils.ReplaceRegexp(expression, replacementRole, remoteRole)
+				switch {
+				case err == nil:
+					// empty replacement can occur when $2 expand refers
+					// to non-existing capture group in match expression
+					if replacement != "" {
+						outRoles = append(outRoles, replacement)
+					}
+				case trace.IsNotFound(err):
+					continue
+				default:
+					return nil, trace.Wrap(err)
+				}
+			}
 		}
 	}
 	return outRoles, nil
@@ -213,7 +218,7 @@ func (r RoleMap) Map(remoteRoles []string) ([]string, error) {
 
 // Check checks RoleMap for errors
 func (r RoleMap) Check() error {
-	_, _, err := r.parse()
+	_, err := r.parse()
 	return trace.Wrap(err)
 }
 

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// ContainsExpansion returns true if value contains
+// expansion syntax, e.g. $1 or ${10}
+func ContainsExpansion(val string) bool {
+	return reExpansion.FindAllStringIndex(val, -1) != nil
+}
+
+// GlobToRegexp replaces glob-style standalone wildcard values
+// with real .* regexp-friendly values, does not modify regexp-compatible values,
+// quotes non-wildcard values
+func GlobToRegexp(in string) string {
+	return replaceWildcard.ReplaceAllString(regexp.QuoteMeta(in), "(.*)")
+}
+
+// ReplaceRegexp replaces value in string, accepts regular expression and simplified
+// wildcard syntax, it has several important differeneces with standard lib
+// regexp replacer:
+// * Wildcard globs '*' are treated as regular expression .* expression
+// * Expression is treated as regular expression if it starts with ^ and ends with $
+// * Full match is expected, partial replacements ignored
+// * If there is no match, returns not found error
+func ReplaceRegexp(expression string, replaceWith string, input string) (string, error) {
+	if !strings.HasPrefix(expression, "^") || !strings.HasSuffix(expression, "$") {
+		// replace glob-style wildcards with regexp wildcards
+		// for plain strings, and quote all characters that could
+		// be interpreted in regular expression
+		expression = "^" + GlobToRegexp(expression) + "$"
+	}
+	expr, err := regexp.Compile(expression)
+	if err != nil {
+		return "", trace.BadParameter(err.Error())
+	}
+	// if there is no match, return NotFound error
+	index := expr.FindAllStringIndex(input, -1)
+	if len(index) == 0 {
+		return "", trace.NotFound("no match found")
+	}
+	return expr.ReplaceAllString(input, replaceWith), nil
+}
+
+var replaceWildcard = regexp.MustCompile(`(\\\*)`)
+var reExpansion = regexp.MustCompile(`\$[^\$]+`)

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -184,3 +184,185 @@ func (s *UtilsSuite) TestParseAdvertiseAddr(c *check.C) {
 		}
 	}
 }
+
+// TestGlobToRegexp tests replacement of glob-style wildcard values
+// with regular expression compatible value
+func (s *UtilsSuite) TestGlobToRegexp(c *check.C) {
+	testCases := []struct {
+		comment string
+		in      string
+		out     string
+	}{
+		{
+			comment: "simple values are not replaced",
+			in:      "value-value",
+			out:     "value-value",
+		},
+		{
+			comment: "wildcard and start of string is replaced with regexp wildcard expression",
+			in:      "*",
+			out:     "(.*)",
+		},
+		{
+			comment: "wildcard is replaced with regexp wildcard expression",
+			in:      "a-*-b-*",
+			out:     "a-(.*)-b-(.*)",
+		},
+		{
+			comment: "special chars are quoted",
+			in:      "a-.*-b-*$",
+			out:     `a-\.(.*)-b-(.*)\$`,
+		},
+	}
+	for i, testCase := range testCases {
+		comment := check.Commentf("test case %v %v", i, testCase.comment)
+		out := GlobToRegexp(testCase.in)
+		c.Assert(out, check.Equals, testCase.out, comment)
+	}
+}
+
+// TestReplaceRegexp tests regexp-style replacement of values
+func (s *UtilsSuite) TestReplaceRegexp(c *check.C) {
+	testCases := []struct {
+		comment string
+		expr    string
+		replace string
+		in      string
+		out     string
+		err     error
+	}{
+		{
+			comment: "simple values are replaced directly",
+			expr:    "value",
+			replace: "value",
+			in:      "value",
+			out:     "value",
+		},
+		{
+			comment: "no match returns explicit not found error",
+			expr:    "value",
+			replace: "value",
+			in:      "val",
+			err:     trace.NotFound(""),
+		},
+		{
+			comment: "empty value is no match",
+			expr:    "",
+			replace: "value",
+			in:      "value",
+			err:     trace.NotFound(""),
+		},
+		{
+			comment: "bad regexp results in bad parameter error",
+			expr:    "^(($",
+			replace: "value",
+			in:      "val",
+			err:     trace.BadParameter(""),
+		},
+		{
+			comment: "full match is supported",
+			expr:    "^value$",
+			replace: "value",
+			in:      "value",
+			out:     "value",
+		},
+		{
+			comment: "wildcard replaces to itself",
+			expr:    "^(.*)$",
+			replace: "$1",
+			in:      "value",
+			out:     "value",
+		},
+		{
+			comment: "wildcard replaces to predefined value",
+			expr:    "*",
+			replace: "boo",
+			in:      "different",
+			out:     "boo",
+		},
+		{
+			comment: "wildcard replaces empty string to predefined value",
+			expr:    "*",
+			replace: "boo",
+			in:      "",
+			out:     "boo",
+		},
+		{
+			comment: "regexp wildcard replaces to itself",
+			expr:    "^(.*)$",
+			replace: "$1",
+			in:      "value",
+			out:     "value",
+		},
+		{
+			comment: "partial conversions are supported",
+			expr:    "^test-(.*)$",
+			replace: "replace-$1",
+			in:      "test-hello",
+			out:     "replace-hello",
+		},
+		{
+			comment: "partial conversions are supported",
+			expr:    "^test-(.*)$",
+			replace: "replace-$1",
+			in:      "test-hello",
+			out:     "replace-hello",
+		},
+	}
+	for i, testCase := range testCases {
+		comment := check.Commentf("test case %v %v", i, testCase.comment)
+		out, err := ReplaceRegexp(testCase.expr, testCase.replace, testCase.in)
+		if testCase.err == nil {
+			c.Assert(err, check.IsNil, comment)
+			c.Assert(out, check.Equals, testCase.out, comment)
+		} else {
+			comment := check.Commentf("test case %v %v, expected type %T, got type %T", i, testCase.comment, testCase.err, err)
+			c.Assert(err, check.FitsTypeOf, testCase.err, comment)
+		}
+	}
+}
+
+// TestContainsExpansion tests whether string contains expansion value
+func (s *UtilsSuite) TestContainsExpansion(c *check.C) {
+	testCases := []struct {
+		comment  string
+		val      string
+		contains bool
+	}{
+		{
+			comment:  "detect simple expansion",
+			val:      "$1",
+			contains: true,
+		},
+		{
+			comment:  "escaping is honored",
+			val:      "$$",
+			contains: false,
+		},
+		{
+			comment:  "escaping is honored",
+			val:      "$$$$",
+			contains: false,
+		},
+		{
+			comment:  "escaping is honored",
+			val:      "$$$$$",
+			contains: false,
+		},
+		{
+			comment:  "escaping and expansion",
+			val:      "$$$$$1",
+			contains: true,
+		},
+		{
+			comment:  "expansion with brackets",
+			val:      "${100}",
+			contains: true,
+		},
+	}
+	for i, testCase := range testCases {
+		comment := check.Commentf("test case %v %v", i, testCase.comment)
+		contains := ContainsExpansion(testCase.val)
+		c.Assert(contains, check.Equals, testCase.contains, comment)
+	}
+}


### PR DESCRIPTION
This commit adds two extensions to template variables
in roles and adds support for regular expressions
and group captures in role mapping of trusted clusters.

1. Roles node_labels can expand variables from traits:

allow:
  node_labels:
    '{{external.key}}': '{{external.val}}'
deny:
  node_labels:
    '{{external.key}}': '{{external.val}}'

If traits variable is not found, label key pair in allow or
deny rule will be set to empty key or value, so if 'external.val'
trait is missing, the resulting role will not match
allow or deny rule:

allow:
  node_labels:
    '': 'val'
deny:
  node_labels:
    '': 'val'

Same thing will happen for missing value:

allow:
  node_labels:
    'key': ''
deny:
  node_labels:
    'key': ''

2. Trusted cluster role mapping can now
support advanced expressions:

a. Glob values will math any string, including
empty one

   role_map:
   - remote: 'cluster-*'
     local: [clusteradmin]

a. Regular expression syntax is supported:

Syntax: https://github.com/google/re2/wiki/Syntax

Brackets can be used as a capture group and referred
to with expand variable:

   role_map:
   - remote: '^clusteradmin-(.*)$'
     local: [unprivileged-$1]

Will map incoming role 'clusteradmin-account-1' to 'guest-account-1'.

3. Same regular expression syntax is supported for SAML and OIDC
mappings:

a. Glob matches of values instead of static matches:

  claims_to_roles:
      - {claim: "roles", value: "gravitational/*", roles: ["clusteradmin"]}

b. Regexp matches with subgroup expands:

  attributes_to_roles:
      - {name: "roles", value: "^gravitational/(.*)$", roles: ["cluster-$1"]}