### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/2.0/saml.md
+++ b/docs/2.0/saml.md
@@ -28,7 +28,7 @@ ssh_service:
   enabled: yes
 ```
 
-### Confiugre Okta
+### Configure Okta
 
 #### Create App
 

--- a/docs/2.3/saml.md
+++ b/docs/2.3/saml.md
@@ -29,7 +29,7 @@ auth_service:
 ...
 ```
 
-### Confiugre Okta
+### Configure Okta
 
 First, create a SAML 2.0 Web App in Okta configuration section
 
@@ -321,7 +321,7 @@ auth_service:
 ...
 ```
 
-### Confiugre One Login Application
+### Configure One Login Application
 
 Create a SAML 2.0 Web App in SAML configuration section:
 

--- a/docs/2.4/saml.md
+++ b/docs/2.4/saml.md
@@ -29,7 +29,7 @@ auth_service:
 ...
 ```
 
-### Confiugre Okta
+### Configure Okta
 
 First, create a SAML 2.0 Web App in Okta configuration section
 
@@ -321,7 +321,7 @@ auth_service:
 ...
 ```
 
-### Confiugre One Login Application
+### Configure One Login Application
 
 Create a SAML 2.0 Web App in SAML configuration section:
 

--- a/docs/2.5/ssh_okta.md
+++ b/docs/2.5/ssh_okta.md
@@ -25,7 +25,7 @@ auth_service:
         type: saml
 ```
 
-## Confiugre Okta
+## Configure Okta
 
 First, create a SAML 2.0 Web App in Okta configuration section
 


### PR DESCRIPTION
Configure was misspelled in a few places. Fixed it.