### PR TITLE
Flat keyspace directory backend.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -464,7 +464,7 @@ func (i *TeleInstance) GenerateConfig(trustedSecrets []*InstanceSecrets, tconf *
 	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.SSHAddr)
 	tconf.Auth.StorageConfig = backend.Config{
 		Type:   dir.GetName(),
-		Params: backend.Params{"path": dataDir},
+		Params: backend.Params{"path": dataDir + string(os.PathListSeparator) + defaults.BackendDir},
 	}
 
 	tconf.Keygen = testauthority.New()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -232,7 +232,7 @@ func (s *IntSuite) TestAuditOn(c *check.C) {
 			for {
 				select {
 				case <-tickCh:
-					nodesInSite, err := site.GetNodes(defaults.Namespace)
+					nodesInSite, err := site.GetNodes(defaults.Namespace, services.SkipValidation())
 					if err != nil && !trace.IsNotFound(err) {
 						return trace.Wrap(err)
 					}

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -39,7 +39,7 @@ type AccessPoint interface {
 	GetNamespace(name string) (*services.Namespace, error)
 
 	// GetServers returns a list of registered servers
-	GetNodes(namespace string) ([]services.Server, error)
+	GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error)
 
 	// UpsertServer registers server presence, permanently if ttl is 0 or
 	// for the specified duration with second resolution if it's >= 1 second

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1053,7 +1053,7 @@ func (s *AuthServer) DeleteNamespace(namespace string) error {
 	if namespace == defaults.Namespace {
 		return trace.AccessDenied("can't delete default namespace")
 	}
-	nodes, err := s.Presence.GetNodes(namespace)
+	nodes, err := s.Presence.GetNodes(namespace, services.SkipValidation())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -296,6 +296,17 @@ func (a *AuthWithRoles) GenerateServerKeys(req GenerateServerKeysRequest) (*Pack
 	return a.authServer.GenerateServerKeys(req)
 }
 
+// UpsertNodes bulk upserts nodes into the backend.
+func (a *AuthWithRoles) UpsertNodes(namespace string, servers []services.Server) error {
+	if err := a.action(namespace, services.KindNode, services.VerbCreate); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := a.action(namespace, services.KindNode, services.VerbUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+	return a.authServer.UpsertNodes(namespace, servers)
+}
+
 func (a *AuthWithRoles) UpsertNode(s services.Server) error {
 	if err := a.action(s.GetNamespace(), services.KindNode, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
@@ -306,11 +317,11 @@ func (a *AuthWithRoles) UpsertNode(s services.Server) error {
 	return a.authServer.UpsertNode(s)
 }
 
-func (a *AuthWithRoles) GetNodes(namespace string) ([]services.Server, error) {
+func (a *AuthWithRoles) GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error) {
 	if err := a.action(namespace, services.KindNode, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetNodes(namespace)
+	return a.authServer.GetNodes(namespace, opts...)
 }
 
 func (a *AuthWithRoles) UpsertAuthServer(s services.Server) error {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -85,13 +85,13 @@ func (s *TLSSuite) TestRemoteBuiltinRole(c *check.C) {
 
 	// certificate authority is not recognized, because
 	// the trust has not been established yet
-	_, err = remoteProxy.GetNodes(defaults.Namespace)
+	_, err = remoteProxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.ErrorMatches, ".*bad certificate.*")
 
 	// after trust is established, things are good
 	err = s.server.AuthServer.Trust(remoteServer, nil)
 
-	_, err = remoteProxy.GetNodes(defaults.Namespace)
+	_, err = remoteProxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// remote auth server will get rejected even with established trust
@@ -127,7 +127,7 @@ func (s *TLSSuite) TestAcceptedUsage(c *check.C) {
 
 	// certificate authority is not recognized, because
 	// the trust has not been established yet
-	_, err = client.GetNodes(defaults.Namespace)
+	_, err = client.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// restricted clients can use restricted servers if restrictions
@@ -137,7 +137,7 @@ func (s *TLSSuite) TestAcceptedUsage(c *check.C) {
 	client, err = tlsServer.NewClient(identity)
 	c.Assert(err, check.IsNil)
 
-	_, err = client.GetNodes(defaults.Namespace)
+	_, err = client.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// restricted clients can will be rejected if usage does not match
@@ -146,7 +146,7 @@ func (s *TLSSuite) TestAcceptedUsage(c *check.C) {
 	client, err = tlsServer.NewClient(identity)
 	c.Assert(err, check.IsNil)
 
-	_, err = client.GetNodes(defaults.Namespace)
+	_, err = client.GetNodes(defaults.Namespace, services.SkipValidation())
 	fixtures.ExpectAccessDenied(c, err)
 
 	// restricted clients can will be rejected, for now if there is any mismatch,
@@ -156,7 +156,7 @@ func (s *TLSSuite) TestAcceptedUsage(c *check.C) {
 	client, err = tlsServer.NewClient(identity)
 	c.Assert(err, check.IsNil)
 
-	_, err = client.GetNodes(defaults.Namespace)
+	_, err = client.GetNodes(defaults.Namespace, services.SkipValidation())
 	fixtures.ExpectAccessDenied(c, err)
 
 }
@@ -236,11 +236,11 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 		TestBuiltin(teleport.RoleProxy), s.server.Addr(), certPool)
 	c.Assert(err, check.IsNil)
 
-	_, err = newRemoteProxy.GetNodes(defaults.Namespace)
+	_, err = newRemoteProxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// old proxy client is still trusted
-	_, err = s.server.CloneClient(remoteProxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(remoteProxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 }
 
@@ -291,7 +291,7 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// client works before rotation is initiated
-	_, err = proxy.GetNodes(defaults.Namespace)
+	_, err = proxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// starts rotation
@@ -317,7 +317,7 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 	c.Assert(ca.GetRotation().Phase, check.Equals, services.RotationPhaseUpdateClients)
 
 	// old clients should work
-	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// new clients work as well
@@ -337,14 +337,14 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 	c.Assert(ca.GetRotation().Phase, check.Equals, services.RotationPhaseUpdateServers)
 
 	// old clients should work
-	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// new clients work as well
 	newProxy, err = s.server.NewClient(TestBuiltin(teleport.RoleProxy))
 	c.Assert(err, check.IsNil)
 
-	_, err = newProxy.GetNodes(defaults.Namespace)
+	_, err = newProxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// complete rotation - advance rotation by clock
@@ -363,11 +363,11 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 	// connection instead of re-using the one from pool
 	// this is not going to be a problem in real teleport
 	// as it reloads the full server after reload
-	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.ErrorMatches, ".*bad certificate.*")
 
 	// new clients work
-	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 }
 
@@ -383,7 +383,7 @@ func (s *TLSSuite) TestAutoFallback(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// client works before rotation is initiated
-	_, err = proxy.GetNodes(defaults.Namespace)
+	_, err = proxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// starts rotation
@@ -435,7 +435,7 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// client works before rotation is initiated
-	_, err = proxy.GetNodes(defaults.Namespace)
+	_, err = proxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// can't jump to mid-phase
@@ -459,7 +459,7 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// old clients should work
-	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// clients reconnect
@@ -472,14 +472,14 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// old clients should work
-	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// new clients work as well
 	newProxy, err := s.server.NewClient(TestBuiltin(teleport.RoleProxy))
 	c.Assert(err, check.IsNil)
 
-	_, err = newProxy.GetNodes(defaults.Namespace)
+	_, err = newProxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// can't jump to standy
@@ -501,11 +501,11 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// old clients should work
-	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// new clients work as well
-	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// complete rotation
@@ -522,11 +522,11 @@ func (s *TLSSuite) TestManualRotation(c *check.C) {
 	// connection instead of re-using the one from pool
 	// this is not going to be a problem in real teleport
 	// as it reloads the full server after reload
-	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.ErrorMatches, ".*bad certificate.*")
 
 	// new clients work
-	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 }
 
@@ -537,7 +537,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// client works before rotation is initiated
-	_, err = proxy.GetNodes(defaults.Namespace)
+	_, err = proxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// starts rotation
@@ -565,7 +565,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 	newProxy, err := s.server.NewClient(TestBuiltin(teleport.RoleProxy))
 	c.Assert(err, check.IsNil)
 
-	_, err = newProxy.GetNodes(defaults.Namespace)
+	_, err = newProxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// advance rotation:
@@ -588,7 +588,7 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 
 	// new clients work, server still accepts the creds
 	// because new clients should re-register and receive new certs
-	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 
 	// can't jump to other phases
@@ -610,11 +610,11 @@ func (s *TLSSuite) TestRollback(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// clients with new creds will no longer work
-	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(newProxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.ErrorMatches, ".*bad certificate.*")
 
 	// clients with old creds will still work
-	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace)
+	_, err = s.server.CloneClient(proxy).GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 }
 
@@ -674,7 +674,7 @@ func (s *TLSSuite) TestNopUser(c *check.C) {
 	_, err = client.GetUsers()
 	fixtures.ExpectAccessDenied(c, err)
 
-	_, err = client.GetNodes(defaults.Namespace)
+	_, err = client.GetNodes(defaults.Namespace, services.SkipValidation())
 	fixtures.ExpectAccessDenied(c, err)
 }
 

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -47,6 +47,9 @@ type Backend interface {
 	// UpsertVal updates or inserts value with a given TTL into a bucket
 	// ForeverTTL for no TTL
 	UpsertVal(bucket []string, key string, val []byte, ttl time.Duration) error
+	// UpsertItems updates or inserts all passed in backend.Items (with a TTL)
+	// into the given bucket.
+	UpsertItems(bucket []string, items []Item) error
 	// GetVal return a value for a given key in the bucket
 	GetVal(path []string, key string) ([]byte, error)
 	// CompareAndSwapVal compares and swaps values in atomic operation,
@@ -74,6 +77,8 @@ type Item struct {
 	Key string
 	// Value is an item value.
 	Value []byte
+	// TTL is the expire time for the item.
+	TTL time.Duration
 }
 
 // backend.Params type defines a flexible unified back-end configuration API.

--- a/lib/backend/boltbk/boltbk.go
+++ b/lib/backend/boltbk/boltbk.go
@@ -171,6 +171,10 @@ func (b *BoltBackend) GetKeys(path []string) ([]string, error) {
 	return keys, nil
 }
 
+func (bk *BoltBackend) UpsertItems(bucket []string, items []backend.Item) error {
+	return trace.BadParameter("not implemented")
+}
+
 func (b *BoltBackend) UpsertVal(path []string, key string, val []byte, ttl time.Duration) error {
 	return b.upsertVal(path, key, val, ttl)
 }

--- a/lib/backend/dir/doc.go
+++ b/lib/backend/dir/doc.go
@@ -12,16 +12,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-fs package implements backend.Backend interface using a regular
-filesystem-based directory. The filesystem needs to be POSIX
-compliant and support 'date modified' attribute on files.
-
 */
 
-// Package 'dir' implements the "directory backend". It uses a regular
-// filesystem directories/files to store Teleport auth server state.
-//
-// Limitations:
-// 	- key names cannot start with '.' (dot)
+// dir package implements backend.Backend interface using the filesystem. The
+// filesystem needs to be POSIX compliant and support BSD locks (flock).
 package dir

--- a/lib/backend/dir/impl.go
+++ b/lib/backend/dir/impl.go
@@ -18,11 +18,15 @@ package dir
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/gravitational/teleport/lib/backend"
@@ -30,49 +34,45 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
 	defaultDirMode  os.FileMode = 0770
 	defaultFileMode os.FileMode = 0600
 
-	// name of this backend type (as seen in 'storage/type' in YAML)
+	// backendName of this backend type as seen in "storage/type" in YAML.
 	backendName = "dir"
 
-	// selfLock is the lock used internally for compare-and-swap
-	selfLock = ".backend"
-
-	// subdirectory where locks are stored
+	// locksBucket is where backend locks are stored.
 	locksBucket = ".locks"
-
-	// reservedPrefix is a character which bucket/key names cannot begin with
-	reservedPrefix = '.'
 )
 
-// fs.Backend implements backend.Backend interface using a regular
+// Backend implements backend.Backend interface using a regular
 // POSIX-style filesystem
 type Backend struct {
-	// RootDir is the root (home) directory where the backend
-	// stores all the data.
-	RootDir string
-
 	// InternalClock is a test-friendly source of current time
 	InternalClock clockwork.Clock
 
-	*log.Entry
+	// rootDir is the directory where the backend stores all the data.
+	rootDir string
+
+	// log is a structured component logger.
+	log *logrus.Entry
 }
 
+// Clock returns the clock used by this backend.
 func (b *Backend) Clock() clockwork.Clock {
 	return b.InternalClock
 }
 
-// GetName
+// GetName returns the name of this backend.
 func GetName() string {
 	return backendName
 }
 
-// New creates a new instance of Filesystem backend, it conforms to backend.NewFunc API
+// New creates a new instance of a directory based backend that implements
+// backend.Backend.
 func New(params backend.Params) (backend.Backend, error) {
 	rootDir := params.GetString("path")
 	if rootDir == "" {
@@ -82,318 +82,299 @@ func New(params backend.Params) (backend.Backend, error) {
 		return nil, trace.BadParameter("filesystem backend: 'path' is not set")
 	}
 
+	// Ensure that the path to the root directory exists.
+	err := os.MkdirAll(rootDir, defaultDirMode)
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
 	bk := &Backend{
-		RootDir:       rootDir,
 		InternalClock: clockwork.NewRealClock(),
-		Entry: log.WithFields(log.Fields{
+		rootDir:       rootDir,
+		log: logrus.WithFields(logrus.Fields{
 			trace.Component: "backend:dir",
-			trace.ComponentFields: log.Fields{
+			trace.ComponentFields: logrus.Fields{
 				"dir": rootDir,
 			},
 		}),
 	}
 
-	locksDir := path.Join(bk.RootDir, locksBucket)
-	if err := os.MkdirAll(locksDir, defaultDirMode); err != nil {
-		return nil, trace.ConvertSystemError(err)
+	// DELETE IN: 2.8.0
+	// Migrate data to new flat keyspace backend.
+	err = migrate(rootDir, bk)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// Wrap the backend in a input sanitizer and return it.
 	return backend.NewSanitizer(bk), nil
 }
 
-// GetItems is a function that returns keys in batch
-func (bk *Backend) GetItems(bucket []string) ([]backend.Item, error) {
-	keys, err := bk.GetKeys(bucket)
+// Close releases the resources taken up the backend.
+func (bk *Backend) Close() error {
+	return nil
+}
+
+// GetKeys returns a list of keys for a given bucket.
+func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
+	// Get all the key/value pairs for this bucket.
+	items, err := bk.GetItems(bucket)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var items []backend.Item
-	for _, key := range keys {
-		v, err := bk.GetVal(bucket, key)
+
+	// Return only the keys, the keys are already sorted by GetItems.
+	keys := make([]string, len(items))
+	for i, e := range items {
+		keys[i] = e.Key
+	}
+
+	return keys, nil
+}
+
+// GetItems returns all items (key/value pairs) in a given bucket.
+func (bk *Backend) GetItems(bucket []string) ([]backend.Item, error) {
+	var out []backend.Item
+
+	// Get a list of all buckets in the backend.
+	files, err := ioutil.ReadDir(path.Join(bk.rootDir))
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
+	// Loop over all buckets in the backend.
+	for _, fi := range files {
+		pathToBucket := bk.pathToBucket(fi.Name())
+		bucketPrefix := bk.flatten(bucket)
+
+		// Skip over any buckets without a matching prefix.
+		if !strings.HasPrefix(pathToBucket, bucketPrefix) {
+			continue
+		}
+
+		// Open the bucket to work on the items.
+		b, err := bk.openBucket(pathToBucket, os.O_RDWR)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		items = append(items, backend.Item{Key: key, Value: v})
+		defer b.Close()
+
+		// Loop over all keys, flatten them, and return key and value to caller.
+		for k, v := range b.items {
+			var key string
+
+			// If bucket path on disk and the requested bucket were an exact match,
+			// return the key as-is.
+			//
+			// However, if this was a partial match, for example pathToBucket is
+			// "/roles/admin/params" but the bucketPrefix is "/roles" then extract
+			// the first suffix (in this case "admin") and use this as the key. This
+			// is consistent with our DynamoDB implementation.
+			if pathToBucket == bucketPrefix {
+				key = k
+			} else {
+				key, err = suffix(pathToBucket, bucketPrefix)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+			}
+
+			// If the bucket item is expired, update the bucket, and don't include
+			// it in the output.
+			if bk.isExpired(v) {
+				b.deleteItem(k)
+				continue
+			}
+
+			out = append(out, backend.Item{
+				Key:   key,
+				Value: v.Value,
+			})
+		}
 	}
-	return items, nil
+
+	// Sort and return results.
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Key < out[j].Key
+	})
+
+	return out, nil
 }
 
-// GetKeys returns a list of keys for a given path
-func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
-	files, err := ioutil.ReadDir(path.Join(bk.RootDir, path.Join(bucket...)))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return []string{}, nil
-		}
-		return nil, trace.ConvertSystemError(err)
-	}
-	// enumerate all directory entries and select only non-hidden files
-	retval := make([]string, 0)
-	for _, fi := range files {
-		name := fi.Name()
-		// legal keys cannot start with '.' (resrved prefix)
-		if name[0] != reservedPrefix {
-			retval = append(retval, name)
-		}
-	}
-	return retval, nil
-}
-
-// CreateVal creates value with a given TTL and key in the bucket
-// if the value already exists, returns AlreadyExistsError
+// CreateVal creates a key/value pair with the given TTL in the bucket. If
+// the key already exists in the bucket, trace.AlreadyExists is returned.
 func (bk *Backend) CreateVal(bucket []string, key string, val []byte, ttl time.Duration) error {
-	// do not allow keys that start with a dot
-	if key[0] == reservedPrefix {
-		return trace.BadParameter("invalid key: '%s'. Key names cannot start with '.'", key)
-	}
-	// create the directory:
-	dirPath := path.Join(bk.RootDir, path.Join(bucket...))
-	err := os.MkdirAll(dirPath, defaultDirMode)
+	// Open the bucket to work on the items.
+	b, err := bk.openBucket(bk.flatten(bucket), os.O_CREATE|os.O_RDWR)
 	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	// create the file (AKA "key"):
-	filename := path.Join(dirPath, key)
-	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, defaultFileMode)
-	if err != nil {
-		if os.IsExist(err) {
-			return trace.AlreadyExists("%s/%s already exists", dirPath, key)
-		}
-		return trace.ConvertSystemError(err)
-	}
-	defer f.Close()
-	if err := utils.FSWriteLock(f); err != nil {
 		return trace.Wrap(err)
 	}
-	defer utils.FSUnlock(f)
-	if err := f.Truncate(0); err != nil {
-		return trace.ConvertSystemError(err)
+	defer b.Close()
+
+	// If the key exists and is not expired, return trace.AlreadyExists.
+	item, ok := b.getItem(key)
+	if ok && !bk.isExpired(item) {
+		return trace.AlreadyExists("key already exists")
 	}
-	n, err := f.Write(val)
-	if err == nil && n < len(val) {
-		return trace.Wrap(io.ErrShortWrite)
-	}
-	return trace.Wrap(bk.applyTTL(dirPath, key, ttl))
+
+	// Otherwise, update the item in the bucket.
+	b.updateItem(key, val, ttl)
+
+	return nil
 }
 
-// CompareAndSwapVal compares and swap values in atomic operation
-func (bk *Backend) CompareAndSwapVal(bucket []string, key string, val []byte, prevVal []byte, ttl time.Duration) error {
-	if len(prevVal) == 0 {
-		return trace.BadParameter("missing prevVal parameter, to atomically create item, use CreateVal method")
-	}
-	// do not allow keys that start with a dot
-	if key[0] == reservedPrefix {
-		return trace.BadParameter("invalid key: '%s'. Key names cannot start with '.'", key)
-	}
-	// create the directory:
-	dirPath := path.Join(bk.RootDir, path.Join(bucket...))
-	err := os.MkdirAll(dirPath, defaultDirMode)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	// create the file (AKA "key"):
-	filename := path.Join(dirPath, key)
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_EXCL, defaultFileMode)
-	if err != nil {
-		err = trace.ConvertSystemError(err)
-		if trace.IsNotFound(err) {
-			return trace.CompareFailed("%v/%v did not match expected value", dirPath, key)
-		}
-		return trace.Wrap(err)
-	}
-	defer f.Close()
-	if err := utils.FSWriteLock(f); err != nil {
-		return trace.Wrap(err)
-	}
-	defer utils.FSUnlock(f)
-	// before writing, make sure the values are equal
-	oldVal, err := ioutil.ReadAll(f)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	if bytes.Compare(oldVal, prevVal) != 0 {
-		return trace.CompareFailed("%v/%v did not match expected value", dirPath, key)
-	}
-	if _, err := f.Seek(0, 0); err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	if err := f.Truncate(0); err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	n, err := f.Write(val)
-	if err == nil && n < len(val) {
-		return trace.Wrap(io.ErrShortWrite)
-	}
-	return trace.Wrap(bk.applyTTL(dirPath, key, ttl))
-}
-
-// UpsertVal updates or inserts value with a given TTL into a bucket
-// ForeverTTL for no TTL
+// UpsertVal inserts (or updates if it already exists) the value for a key
+// with the given TTL.
 func (bk *Backend) UpsertVal(bucket []string, key string, val []byte, ttl time.Duration) error {
-	// create the directory:
-	dirPath := path.Join(bk.RootDir, path.Join(bucket...))
-	err := os.MkdirAll(dirPath, defaultDirMode)
+	// Open the bucket to work on the items.
+	b, err := bk.openBucket(bk.flatten(bucket), os.O_CREATE|os.O_RDWR)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	filename := path.Join(dirPath, key)
-	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, defaultFileMode)
+	defer b.Close()
+
+	// Update the item in the bucket.
+	b.updateItem(key, val, ttl)
+
+	return nil
+}
+
+// UpsertItems inserts (or updates if it already exists) all passed in
+// backend.Items with the given TTL.
+func (bk *Backend) UpsertItems(bucket []string, newItems []backend.Item) error {
+	// Open the bucket to work on the items.
+	b, err := bk.openBucket(bk.flatten(bucket), os.O_CREATE|os.O_RDWR)
 	if err != nil {
-		if os.IsExist(err) {
-			return trace.AlreadyExists("%s/%s already exists", dirPath, key)
-		}
-		return trace.ConvertSystemError(err)
-	}
-	defer f.Close()
-	if err := utils.FSWriteLock(f); err != nil {
 		return trace.Wrap(err)
 	}
-	defer utils.FSUnlock(f)
-	if err := f.Truncate(0); err != nil {
-		return trace.ConvertSystemError(err)
+	defer b.Close()
+
+	// Update items in bucket.
+	for _, e := range newItems {
+		b.updateItem(e.Key, e.Value, e.TTL)
 	}
-	n, err := f.Write(val)
-	if err == nil && n < len(val) {
-		return trace.Wrap(io.ErrShortWrite)
-	}
-	return trace.Wrap(bk.applyTTL(dirPath, key, ttl))
+
+	return nil
 }
 
 // GetVal return a value for a given key in the bucket
 func (bk *Backend) GetVal(bucket []string, key string) ([]byte, error) {
-	dirPath := path.Join(path.Join(bk.RootDir, path.Join(bucket...)))
-	filename := path.Join(dirPath, key)
-	expired, err := bk.checkTTL(dirPath, key)
+	// Open the bucket to work on the items.
+	b, err := bk.openBucket(bk.flatten(bucket), os.O_RDWR)
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if expired {
-		bk.DeleteKey(bucket, key)
-		return nil, trace.NotFound("key %q is not found", key)
-	}
-	f, err := os.OpenFile(filename, os.O_RDONLY, defaultFileMode)
-	if err != nil {
-		// GetVal() on a bucket must return 'BadParameter' error:
-		if fi, _ := os.Stat(filename); fi != nil && fi.IsDir() {
-			return nil, trace.BadParameter("%q is not a valid key", key)
+		// GetVal on a bucket needs to return trace.BadParameter. If opening the
+		// bucket failed a partial match up to a bucket may still exist. To support
+		// returning trace.BadParameter in this situation, loop over all keys in the
+		// backend and see if any match the prefix. If any match the prefix return
+		// trace.BadParameter, otherwise return the original error. This is
+		// consistent with our DynamoDB implementation.
+		files, er := ioutil.ReadDir(path.Join(bk.rootDir))
+		if er != nil {
+			return nil, trace.ConvertSystemError(er)
+		}
+		var matched int
+		for _, fi := range files {
+			pathToBucket := bk.pathToBucket(fi.Name())
+			fullBucket := append(bucket, key)
+			bucketPrefix := bk.flatten(fullBucket)
+
+			// Prefix matched, for example if pathToBucket is "/foo/bar/baz" and
+			// bucketPrefix is "/foo/bar".
+			if strings.HasPrefix(pathToBucket, bucketPrefix) {
+				matched = matched + 1
+			}
+		}
+		if matched > 0 {
+			return nil, trace.BadParameter("%v is not a valid key", key)
 		}
 		return nil, trace.ConvertSystemError(err)
 	}
-	defer f.Close()
-	if err := utils.FSReadLock(f); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer utils.FSUnlock(f)
-	bytes, err := ioutil.ReadAll(f)
-	if err != nil {
-		return nil, trace.ConvertSystemError(err)
-	}
-	// this could happen when CreateKey or UpsertKey created a file
-	// but, GetVal managed to get readLock right after it,
-	// so there are no contents there
-	if len(bytes) == 0 {
+	defer b.Close()
+
+	// If the key does not exist, return trace.NotFound right away.
+	item, ok := b.getItem(key)
+	if !ok {
 		return nil, trace.NotFound("key %q is not found", key)
 	}
-	return bytes, nil
+
+	// If the key is expired, remove it from the bucket and write it out and exit.
+	if bk.isExpired(item) {
+		b.deleteItem(key)
+
+		return nil, trace.NotFound("key %q is not found", key)
+	}
+
+	return item.Value, nil
 }
 
-// DeleteKey deletes a key in a bucket
+// CompareAndSwapVal compares and swap values in atomic operation
+func (bk *Backend) CompareAndSwapVal(bucket []string, key string, val []byte, prevVal []byte, ttl time.Duration) error {
+	// Open the bucket to work on the items.
+	b, err := bk.openBucket(bk.flatten(bucket), os.O_CREATE|os.O_RDWR)
+	if err != nil {
+		er := trace.ConvertSystemError(err)
+		if trace.IsNotFound(er) {
+			return trace.CompareFailed("%v/%v did not match expected value", bucket, key)
+		}
+		return trace.Wrap(er)
+	}
+	defer b.Close()
+
+	// Read in existing key. If it does not exist, is expired, or does not
+	// match, return trace.CompareFailed.
+	oldItem, ok := b.getItem(key)
+	if !ok {
+		return trace.CompareFailed("%v/%v did not match expected value", bucket, key)
+	}
+	if bk.isExpired(oldItem) {
+		return trace.CompareFailed("%v/%v did not match expected value", bucket, key)
+	}
+	if bytes.Compare(oldItem.Value, prevVal) != 0 {
+		return trace.CompareFailed("%v/%v did not match expected value", bucket, key)
+	}
+
+	// The compare was successful, update the item.
+	b.updateItem(key, val, ttl)
+
+	return nil
+}
+
+// DeleteKey deletes a key in a bucket.
 func (bk *Backend) DeleteKey(bucket []string, key string) error {
-	dirPath := path.Join(bk.RootDir, path.Join(bucket...))
-	filename := path.Join(dirPath, key)
-	f, err := os.OpenFile(filename, os.O_RDONLY, defaultFileMode)
+	// Open the bucket to work on the items.
+	b, err := bk.openBucket(bk.flatten(bucket), os.O_RDWR)
 	if err != nil {
-		if fi, _ := os.Stat(filename); fi != nil && fi.IsDir() {
-			return trace.BadParameter("%q is not a valid key", key)
-		}
-		return trace.ConvertSystemError(err)
-	}
-	defer f.Close()
-	if err := utils.FSWriteLock(f); err != nil {
 		return trace.Wrap(err)
 	}
-	defer utils.FSUnlock(f)
-	if err := os.Remove(bk.ttlFile(dirPath, key)); err != nil {
-		if !os.IsNotExist(err) {
-			log.Warn(err)
-		}
+	defer b.Close()
+
+	// If the key doesn't exist, return trace.NotFound.
+	_, ok := b.getItem(key)
+	if !ok {
+		return trace.NotFound("key %v not found", key)
 	}
-	return trace.ConvertSystemError(os.Remove(filename))
+
+	// Otherwise, delete key.
+	b.deleteItem(key)
+
+	return nil
 }
 
-// DeleteBucket deletes the bucket by a given path
+// DeleteBucket deletes the bucket by a given path.
 func (bk *Backend) DeleteBucket(parent []string, bucket string) error {
-	return removeFiles(path.Join(path.Join(bk.RootDir, path.Join(parent...)), bucket))
-}
+	fullBucket := append(parent, bucket)
 
-// removeFiles removes files from the directory non-recursively
-// we need this function because os.RemoveAll does not work
-// on concurrent requests - can produce directory not empty
-// error, because someone could create a new file in the directory
-func removeFiles(dir string) error {
-	d, err := os.Open(dir)
+	err := os.Remove(bk.flatten(fullBucket))
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
-	defer d.Close()
-	names, err := d.Readdirnames(-1)
-	if err != nil {
-		err = trace.ConvertSystemError(err)
-		if !trace.IsNotFound(err) {
-			return err
-		}
-		return nil
-	}
-	for _, name := range names {
-		path := filepath.Join(dir, name)
-		fi, err := os.Stat(path)
-		if err != nil {
-			err = trace.ConvertSystemError(err)
-			if !trace.IsNotFound(err) {
-				return err
-			}
-		} else if !fi.IsDir() {
-			err = removeFile(path)
-			if err != nil {
-				return err
-			}
-		} else if fi.IsDir() {
-			if err := removeFiles(path); err != nil {
-				return err
-			}
-		}
-	}
+
 	return nil
 }
 
-func removeFile(path string) error {
-	f, err := os.OpenFile(path, os.O_RDONLY, defaultFileMode)
-	err = trace.ConvertSystemError(err)
-	if err != nil {
-		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-		return nil
-	}
-	defer f.Close()
-	if err := utils.FSWriteLock(f); err != nil {
-		return trace.Wrap(err)
-	}
-	defer utils.FSUnlock(f)
-	err = os.Remove(path)
-	if err != nil {
-		err = trace.ConvertSystemError(err)
-		if !trace.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-// AcquireLock grabs a lock that will be released automatically in TTL
+// AcquireLock grabs a lock that will be released automatically in TTL.
 func (bk *Backend) AcquireLock(token string, ttl time.Duration) (err error) {
-	bk.Debugf("AcquireLock(%s)", token)
+	bk.log.Debugf("AcquireLock(%s)", token)
 
 	if err = backend.ValidateLockTTL(ttl); err != nil {
 		return trace.Wrap(err)
@@ -410,17 +391,18 @@ func (bk *Backend) AcquireLock(token string, ttl time.Duration) (err error) {
 			break // success
 		}
 		if trace.IsAlreadyExists(err) { // locked? wait and repeat:
-			bk.Clock().Sleep(time.Millisecond * 250)
+			bk.Clock().Sleep(250 * time.Millisecond)
 			continue
 		}
 		return trace.ConvertSystemError(err)
 	}
+
 	return nil
 }
 
-// ReleaseLock forces lock release before TTL
+// ReleaseLock forces lock release before TTL.
 func (bk *Backend) ReleaseLock(token string) (err error) {
-	bk.Debugf("ReleaseLock(%s)", token)
+	bk.log.Debugf("ReleaseLock(%s)", token)
 
 	if err = bk.DeleteKey([]string{locksBucket}, token); err != nil {
 		if !os.IsNotExist(err) {
@@ -430,44 +412,218 @@ func (bk *Backend) ReleaseLock(token string) (err error) {
 	return nil
 }
 
-// Close releases the resources taken up by a backend
-func (bk *Backend) Close() error {
+// pathToBucket prepends the root directory to the bucket returning the full
+// path to the bucket on the filesystem.
+func (bk *Backend) pathToBucket(bucket string) string {
+	return filepath.Join(bk.rootDir, bucket)
+}
+
+// flatten takes a bucket and flattens it (URL encodes) and prepends the root
+// directory returning the full path to the bucket on the filesystem.
+func (bk *Backend) flatten(bucket []string) string {
+	// Convert ["foo", "bar"] to "foo/bar"
+	raw := filepath.Join(bucket...)
+
+	// URL encode bucket from "foo/bar" to "foo%2Fbar".
+	flat := url.QueryEscape(raw)
+
+	return filepath.Join(bk.rootDir, flat)
+}
+
+// isExpired checks if the bucket item is expired or not.
+func (bk *Backend) isExpired(bv bucketItem) bool {
+	if bv.ExpiryTime.IsZero() {
+		return false
+	}
+	return bk.Clock().Now().After(bv.ExpiryTime)
+}
+
+// bucket contains a set of keys that map to values and a TTL.
+type bucket struct {
+	// backend is the underlying data store.
+	backend *Backend
+
+	// file is the underlying file that the bucket represents.
+	file *os.File
+
+	// items is a set of key/value pairs that this bucket holds.
+	items map[string]bucketItem
+
+	// itemsUpdated is used to control if the items have been updated and should
+	// be written out to disk again.
+	itemsUpdated bool
+}
+
+// bucketItem is the "Value" part of a key/value pair.
+type bucketItem struct {
+	// Value is content of the key.
+	Value []byte `json:"value"`
+
+	// ExpiryTime is when this value will expire.
+	ExpiryTime time.Time `json:"expiry,omitempty"`
+}
+
+// openBucket will open a file, lock it, and then read in all the items in
+// the bucket.
+func (bk *Backend) openBucket(prefix string, openFlag int) (*bucket, error) {
+	// Open bucket with requested flags.
+	file, err := os.OpenFile(prefix, openFlag, defaultFileMode)
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
+	// Lock the bucket so no one else can access it.
+	if err := utils.FSWriteLock(file); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Read in all items from the bucket.
+	items, err := readBucket(file)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &bucket{
+		backend: bk,
+		items:   items,
+		file:    file,
+	}, nil
+}
+
+func (b *bucket) getItem(key string) (bucketItem, bool) {
+	item, ok := b.items[key]
+	return item, ok
+}
+
+func (b *bucket) deleteItem(key string) {
+	delete(b.items, key)
+	b.itemsUpdated = true
+}
+
+func (b *bucket) updateItem(key string, value []byte, ttl time.Duration) {
+	item := bucketItem{
+		Value: value,
+	}
+	if ttl != backend.Forever {
+		item.ExpiryTime = b.backend.Clock().Now().Add(ttl)
+	}
+
+	b.items[key] = item
+	b.itemsUpdated = true
+}
+
+// Close will write out items (if requested), unlock file, and close it.
+func (b *bucket) Close() error {
+	var err error
+
+	// If the items were updated, write them out to disk.
+	if b.itemsUpdated {
+		err = writeBucket(b.file, b.items)
+		if err != nil {
+			b.backend.log.Warnf("Unable to update keys in %v: %v.", b.file.Name(), err)
+		}
+	}
+
+	err = utils.FSUnlock(b.file)
+	if err != nil {
+		b.backend.log.Warnf("Unable to unlock file: %v.", err)
+	}
+
+	err = b.file.Close()
+	if err != nil {
+		b.backend.log.Warnf("Unable to close file: %v.", err)
+	}
+
 	return nil
 }
 
-// applyTTL assigns a given TTL to a file with sub-second granularity
-func (bk *Backend) applyTTL(dirPath string, key string, ttl time.Duration) error {
-	if ttl == backend.Forever {
-		return nil
+// readBucket will read in the bucket and return a map of keys. The second return
+// value returns true to false to indicate if the file was empty or not.
+func readBucket(f *os.File) (map[string]bucketItem, error) {
+	// If the file is empty, return an empty bucket.
+	ok, err := isEmpty(f)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	expiryTime := bk.Clock().Now().Add(ttl)
-	bytes, _ := expiryTime.MarshalText()
-	return trace.ConvertSystemError(
-		ioutil.WriteFile(bk.ttlFile(dirPath, key), bytes, defaultFileMode))
+	if ok {
+		return map[string]bucketItem{}, nil
+	}
+
+	// The file is not empty, read it into a map.
+	var items map[string]bucketItem
+	bytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+	err = json.Unmarshal(bytes, &items)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return items, nil
 }
 
-// checkTTL checks if a given file has TTL and returns 'true' if it's expired
-func (bk *Backend) checkTTL(dirPath string, key string) (expired bool, err error) {
-	bytes, err := ioutil.ReadFile(bk.ttlFile(dirPath, key))
+// writeBucket will truncate the file and write out the items to the file f.
+func writeBucket(f *os.File, items map[string]bucketItem) error {
+	// Marshal items to disk format.
+	bytes, err := json.Marshal(items)
 	if err != nil {
-		if os.IsNotExist(err) { // no TTL
-			return false, nil
-		}
+		return trace.Wrap(err)
+	}
+
+	// Truncate the file.
+	if _, err := f.Seek(0, 0); err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	if err := f.Truncate(0); err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	// Write out the contents to disk.
+	n, err := f.Write(bytes)
+	if err == nil && n < len(bytes) {
+		return trace.Wrap(io.ErrShortWrite)
+	}
+
+	return nil
+}
+
+// isEmpty checks if the file is empty or not.
+func isEmpty(f *os.File) (bool, error) {
+	fi, err := f.Stat()
+	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	// this could happen if file was deleted, we can sometimes read empty contents
-	if len(bytes) == 0 {
+
+	if fi.Size() > 0 {
 		return false, nil
 	}
-	var expiryTime time.Time
-	if err = expiryTime.UnmarshalText(bytes); err != nil {
-		return false, trace.Wrap(err)
-	}
-	return bk.Clock().Now().After(expiryTime), nil
+
+	return true, nil
 }
 
-// ttlFile returns the full path of the "TTL file" where the TTL is
-// stored for a given key, example: /root/bucket/.keyname.ttl
-func (bk *Backend) ttlFile(dirPath, key string) string {
-	return path.Join(dirPath, "."+key+".ttl")
+// suffix returns the first bucket after where pathToBucket and bucketPrefix
+// differ.  For example, if pathToBucket is "/roles/admin/params" and
+// bucketPrefix is "/roles", then "admin" is returned.
+func suffix(pathToBucket string, bucketPrefix string) (string, error) {
+	full, err := url.QueryUnescape(pathToBucket)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	prefix, err := url.QueryUnescape(bucketPrefix)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	remain := full[len(prefix)+1:]
+	if remain == "" {
+		return "", trace.BadParameter("unable to split %v", remain)
+	}
+
+	vals := strings.Split(remain, string(filepath.Separator))
+	if len(vals) == 0 {
+		return "", trace.BadParameter("unable to split %v", remain)
+	}
+
+	return vals[0], nil
 }

--- a/lib/backend/dir/migrate.go
+++ b/lib/backend/dir/migrate.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dir
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gravitational/teleport/lib/backend"
+
+	"github.com/gravitational/trace"
+)
+
+// DELETE IN: 2.8.0
+// migrate old directory backend to the new flat keyspace.
+func migrate(rootDir string, b *Backend) error {
+	// Check if the directory structure is the old bucket format.
+	ok, err := isOld(rootDir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Found the new flat keyspace directory backend, nothing to do.
+	if !ok {
+		b.log.Debugf("Found new flat keyspace, skipping migration.")
+		return nil
+	}
+
+	// The old directory backend was found, make a backup in-case is needs to
+	// be restored.
+	backupDir := rootDir + ".backup-" + time.Now().Format(time.RFC3339)
+	err = os.Rename(rootDir, backupDir)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = os.MkdirAll(rootDir, defaultDirMode)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	b.log.Infof("Migrating directory backend to new flat keyspace. Backup in %v.", backupDir)
+
+	// Go over every file in the backend. If the key is not expired upsert
+	// into the new backend.
+	err = filepath.Walk(backupDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return trace.ConvertSystemError(err)
+		}
+
+		// Skip the locks directory completely.
+		if info.IsDir() && info.Name() == ".locks" {
+			return filepath.SkipDir
+		}
+		// Skip over directories themselves, but not their content.
+		if info.IsDir() {
+			return nil
+		}
+		// Skip over TTL files (they are handled by readTTL function).
+		if strings.HasPrefix(info.Name(), ".") {
+			return nil
+		}
+
+		// Construct key and flat bucket.
+		key := info.Name()
+		flatbucket := strings.TrimPrefix(path, backupDir)
+		flatbucket = strings.TrimSuffix(flatbucket, string(filepath.Separator)+key)
+
+		// Read in TTL for key. If the key is expired, skip over it.
+		ttl, expired, err := readTTL(backupDir, flatbucket, key)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if expired {
+			b.log.Infof("Skipping migration of expired bucket %q and key %q.", flatbucket, info.Name())
+			return nil
+		}
+
+		// Read in the value of the key.
+		value, err := ioutil.ReadFile(path)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// Upsert key and value (with TTL) into new flat keyspace backend.
+		bucket := strings.Split(flatbucket, string(filepath.Separator))
+		err = b.UpsertVal(bucket, key, value, ttl)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		b.log.Infof("Migrated bucket %q and key %q with TTL %v.", flatbucket, key, ttl)
+
+		return nil
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	b.log.Infof("Migration successful.")
+	return nil
+}
+
+// DELETE IN: 2.8.0
+// readTTL reads in TTL for the given key. If no TTL key is found,
+// backend.Forever is returned.
+func readTTL(rootDir string, bucket string, key string) (time.Duration, bool, error) {
+	filename := filepath.Join(rootDir, bucket, "."+key+".ttl")
+
+	bytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return backend.Forever, false, nil
+		}
+		return backend.Forever, false, trace.Wrap(err)
+	}
+	if len(bytes) == 0 {
+		return backend.Forever, false, nil
+	}
+
+	var expiryTime time.Time
+	if err = expiryTime.UnmarshalText(bytes); err != nil {
+		return backend.Forever, false, trace.Wrap(err)
+	}
+
+	ttl := expiryTime.Sub(time.Now())
+	if ttl < 0 {
+		return backend.Forever, true, nil
+	}
+	return ttl, false, nil
+}
+
+// DELETE IN: 2.8.0
+// isOld checks if the directory backend is in the old format or not.
+func isOld(rootDir string) (bool, error) {
+	d, err := os.Open(rootDir)
+	if err != nil {
+		return false, trace.ConvertSystemError(err)
+	}
+	defer d.Close()
+
+	files, err := d.Readdir(0)
+	if err != nil {
+		return false, trace.ConvertSystemError(err)
+	}
+
+	for _, fi := range files {
+		if fi.IsDir() {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -480,6 +480,10 @@ func (b *DynamoDBBackend) CreateVal(path []string, key string, val []byte, ttl t
 	return b.createKey(fullPath, val, ttl, false)
 }
 
+func (b *DynamoDBBackend) UpsertItems(bucket []string, items []backend.Item) error {
+	return trace.BadParameter("not implemented")
+}
+
 // UpsertVal update or create a key with defined value (refresh TTL if already exist)
 func (b *DynamoDBBackend) UpsertVal(path []string, key string, val []byte, ttl time.Duration) error {
 	fullPath := b.fullPath(append(path, key)...)

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -208,6 +208,10 @@ func (b *bk) CompareAndSwapVal(path []string, key string, val []byte, prevVal []
 // maxOptimisticAttempts is the number of attempts optimistic locking
 const maxOptimisticAttempts = 5
 
+func (bk *bk) UpsertItems(bucket []string, items []backend.Item) error {
+	return trace.BadParameter("not implemented")
+}
+
 func (b *bk) UpsertVal(path []string, key string, val []byte, ttl time.Duration) error {
 	_, err := b.api.Set(
 		context.Background(),

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -104,6 +104,21 @@ func (s *Sanitizer) UpsertVal(bucket []string, key string, val []byte, ttl time.
 	return s.backend.UpsertVal(bucket, key, val, ttl)
 }
 
+// UpsertItems updates or inserts all passed in backend.Items (with a TTL)
+// into the given bucket.
+func (s *Sanitizer) UpsertItems(bucket []string, items []Item) error {
+	if !isSliceSafe(bucket) {
+		return trace.BadParameter(errorMessage)
+	}
+	for _, e := range items {
+		if !isStringSafe(e.Key) {
+			return trace.BadParameter(errorMessage)
+		}
+	}
+
+	return s.backend.UpsertItems(bucket, items)
+}
+
 // GetVal returns a value for a given key in the bucket.
 func (s *Sanitizer) GetVal(bucket []string, key string) ([]byte, error) {
 	if !isSliceSafe(bucket) {

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -115,6 +115,10 @@ func (n *nopBackend) UpsertVal(bucket []string, key string, val []byte, ttl time
 	return nil
 }
 
+func (n *nopBackend) UpsertItems(bucket []string, items []Item) error {
+	return nil
+}
+
 func (n *nopBackend) GetVal(path []string, key string) ([]byte, error) {
 	return []byte("foo"), nil
 }

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -29,6 +30,8 @@ import (
 	"github.com/gravitational/trace"
 	. "gopkg.in/check.v1"
 )
+
+var _ = fmt.Printf
 
 func TestBackend(t *testing.T) { TestingT(t) }
 
@@ -110,6 +113,8 @@ func (s *BackendSuite) BasicCRUD(c *C) {
 	c.Assert(s.B.UpsertVal([]string{"a", "c"}, "xkey", []byte("val3"), 0), IsNil)
 	c.Assert(s.B.UpsertVal([]string{"a", "c"}, "ykey", []byte("val4"), 0), IsNil)
 	c.Assert(s.B.DeleteBucket([]string{"a"}, "c"), IsNil)
+	c.Assert(s.B.DeleteBucket([]string{"a"}, "c"), NotNil)
+
 	_, err = s.B.GetVal([]string{"a", "c"}, "xkey")
 	c.Assert(trace.IsNotFound(err), Equals, true, Commentf("%#v", err))
 	_, err = s.B.GetVal([]string{"a", "c"}, "ykey")

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -832,7 +832,7 @@ func (tc *TeleportClient) Join(ctx context.Context, namespace string, sessionID 
 	serverID := session.Parties[0].ServerID
 
 	// find a server address by its ID
-	nodes, err := site.GetNodes(namespace)
+	nodes, err := site.GetNodes(namespace, services.SkipValidation())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -120,10 +120,12 @@ func (proxy *ProxyClient) FindServersByLabels(ctx context.Context, namespace str
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	siteNodes, err := site.GetNodes(namespace)
+
+	siteNodes, err := site.GetNodes(namespace, services.SkipValidation())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	// look at every node on this site and see which ones match:
 	for _, node := range siteNodes {
 		if node.MatchAgainst(labels) {

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -137,7 +137,7 @@ func (s *PresenceService) getServers(kind, prefix string) ([]services.Server, er
 			}
 			return nil, trace.Wrap(err)
 		}
-		server, err := services.GetServerMarshaler().UnmarshalServer(data, kind)
+		server, err := services.GetServerMarshaler().UnmarshalServer(data, kind, services.SkipValidation())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -164,7 +164,7 @@ func (s *PresenceService) DeleteAllNodes(namespace string) error {
 }
 
 // GetNodes returns a list of registered servers
-func (s *PresenceService) GetNodes(namespace string) ([]services.Server, error) {
+func (s *PresenceService) GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error) {
 	if namespace == "" {
 		return nil, trace.BadParameter("missing namespace value")
 	}
@@ -181,20 +181,23 @@ func (s *PresenceService) GetNodes(namespace string) ([]services.Server, error) 
 	// Marshal values into a []services.Server slice.
 	servers := make([]services.Server, len(items))
 	for i, item := range items {
-		server, err := services.GetServerMarshaler().UnmarshalServer(item.Value, services.KindNode)
+		server, err := services.GetServerMarshaler().UnmarshalServer(
+			item.Value,
+			services.KindNode,
+			opts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		servers[i] = server
 	}
 
-	s.log.Debugf("GetServers(%v) in %v", len(servers), time.Now().Sub(start))
+	s.log.Debugf("GetServers(%v) in %v.", len(servers), time.Now().Sub(start))
 
 	return servers, nil
 }
 
-// UpsertNode registers node presence, permanently if ttl is 0 or
-// for the specified duration with second resolution if it's >= 1 second
+// UpsertNode registers node presence, permanently if TTL is 0 or for the
+// specified duration with second resolution if it's >= 1 second.
 func (s *PresenceService) UpsertNode(server services.Server) error {
 	if server.GetNamespace() == "" {
 		return trace.BadParameter("missing node namespace")
@@ -206,6 +209,39 @@ func (s *PresenceService) UpsertNode(server services.Server) error {
 	ttl := backend.TTL(s.Clock(), server.Expiry())
 	err = s.UpsertVal([]string{namespacesPrefix, server.GetNamespace(), nodesPrefix}, server.GetName(), data, ttl)
 	return trace.Wrap(err)
+}
+
+// UpsertNodes is used for bulk insertion of nodes. Schema validation is
+// always skipped during bulk insertion.
+func (s *PresenceService) UpsertNodes(namespace string, servers []services.Server) error {
+	if namespace == "" {
+		return trace.BadParameter("missing node namespace")
+	}
+
+	start := time.Now()
+
+	var items []backend.Item
+	for _, server := range servers {
+		bytes, err := services.GetServerMarshaler().MarshalServer(server)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		items = append(items, backend.Item{
+			Key:   server.GetName(),
+			Value: bytes,
+			TTL:   backend.TTL(s.Clock(), server.Expiry()),
+		})
+	}
+
+	err := s.UpsertItems([]string{namespacesPrefix, namespace, nodesPrefix}, items)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.log.Debugf("UpsertNodes(%v) in %v", len(servers), time.Now().Sub(start))
+
+	return nil
 }
 
 // GetAuthServers returns a list of registered servers

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -23,22 +23,25 @@ import (
 // Presence records and reports the presence of all components
 // of the cluster - Nodes, Proxies and SSH nodes
 type Presence interface {
-
 	// UpsertLocalClusterName upserts local domain
 	UpsertLocalClusterName(name string) error
 
 	// GetLocalClusterName upserts local domain
 	GetLocalClusterName() (string, error)
 
-	// GetNodes returns a list of registered servers
-	GetNodes(namespace string) ([]Server, error)
+	// GetNodes returns a list of registered servers. Schema validation can be
+	// skipped to improve performance.
+	GetNodes(namespace string, opts ...MarshalOption) ([]Server, error)
 
-	// DeleteAllNodes deletes all nodes in a namespace
+	// DeleteAllNodes deletes all nodes in a namespace.
 	DeleteAllNodes(namespace string) error
 
-	// UpsertNode registers node presence, permanently if ttl is 0 or
-	// for the specified duration with second resolution if it's >= 1 second
+	// UpsertNode registers node presence, permanently if TTL is 0 or for the
+	// specified duration with second resolution if it's >= 1 second.
 	UpsertNode(server Server) error
+
+	// UpsertNodes bulk inserts nodes.
+	UpsertNodes(namespace string, servers []Server) error
 
 	// GetAuthServers returns a list of registered servers
 	GetAuthServers() ([]Server, error)

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -194,6 +194,16 @@ const (
 	VerbRotate = "rotate"
 )
 
+func CollectOptions(opts []MarshalOption) (*MarshalConfig, error) {
+	var cfg MarshalConfig
+	for _, o := range opts {
+		if err := o(&cfg); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	return &cfg, nil
+}
+
 func collectOptions(opts []MarshalOption) (*MarshalConfig, error) {
 	var cfg MarshalConfig
 	for _, o := range opts {
@@ -208,6 +218,9 @@ func collectOptions(opts []MarshalOption) (*MarshalConfig, error) {
 type MarshalConfig struct {
 	// Version specifies particular version we should marshal resources with
 	Version string
+
+	// SkipValidation is used to skip schema validation.
+	SkipValidation bool
 }
 
 // GetVersion returns explicitly provided version or sets latest as default
@@ -231,6 +244,14 @@ func WithVersion(v string) MarshalOption {
 		default:
 			return trace.BadParameter("version '%v' is not supported", v)
 		}
+	}
+}
+
+// SkipValidation is used to disable schema validation.
+func SkipValidation() MarshalOption {
+	return func(c *MarshalConfig) error {
+		c.SkipValidation = true
+		return nil
 	}
 }
 

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -244,7 +244,7 @@ func (t *proxySubsys) proxyToHost(
 	// going to "local" CA? lets use the caching 'auth service' directly and avoid
 	// hitting the reverse tunnel link (it can be offline if the CA is down)
 	if site.GetName() == localDomain {
-		servers, err = t.srv.authService.GetNodes(t.namespace)
+		servers, err = t.srv.authService.GetNodes(t.namespace, services.SkipValidation())
 		if err != nil {
 			t.log.Warn(err)
 		}
@@ -254,7 +254,7 @@ func (t *proxySubsys) proxyToHost(
 		if err != nil {
 			t.log.Warn(err)
 		} else {
-			servers, err = siteClient.GetNodes(t.namespace)
+			servers, err = siteClient.GetNodes(t.namespace, services.SkipValidation())
 			if err != nil {
 				t.log.Warn(err)
 			}

--- a/lib/state/api.go
+++ b/lib/state/api.go
@@ -12,7 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package state

--- a/lib/state/cachingaccesspoint_test.go
+++ b/lib/state/cachingaccesspoint_test.go
@@ -12,12 +12,13 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package state
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/boltbk"
+	"github.com/gravitational/teleport/lib/backend/dir"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/services"
@@ -36,6 +38,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/check.v1"
 )
+
+var _ = fmt.Printf
 
 // fake cluster we're testing on:
 var (
@@ -174,7 +178,12 @@ func (s *ClusterSnapshotSuite) TearDownTest(c *check.C) {
 }
 
 func (s *ClusterSnapshotSuite) TestEverything(c *check.C) {
-	cacheBackend, err := boltbk.New(backend.Params{"path": c.MkDir()})
+	tempDir, err := ioutil.TempDir("", "everything-test-")
+	c.Assert(err, check.IsNil)
+	cacheBackend, err := dir.New(backend.Params{"path": tempDir})
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(tempDir)
+
 	c.Assert(err, check.IsNil)
 	snap, err := NewCachingAuthClient(Config{
 		AccessPoint: s.authServer,
@@ -191,7 +200,7 @@ func (s *ClusterSnapshotSuite) TestEverything(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(users, check.HasLen, len(Users))
 
-	nodes, err := snap.GetNodes(defaults.Namespace)
+	nodes, err := snap.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
 	c.Assert(nodes, check.HasLen, len(Nodes))
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1340,7 +1340,7 @@ func (h *Handler) siteNodesGet(w http.ResponseWriter, r *http.Request, p httprou
 	if !services.IsValidNamespace(namespace) {
 		return nil, trace.BadParameter("invalid namespace %q", namespace)
 	}
-	servers, err := clt.GetNodes(namespace)
+	servers, err := clt.GetNodes(namespace, services.SkipValidation())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1382,7 +1382,7 @@ type authProviderMock struct {
 	server services.ServerV2
 }
 
-func (mock authProviderMock) GetNodes(n string) ([]services.Server, error) {
+func (mock authProviderMock) GetNodes(n string, opts ...services.MarshalOption) ([]services.Server, error) {
 	return []services.Server{&mock.server}, nil
 }
 

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -76,7 +76,7 @@ type TerminalRequest struct {
 
 // AuthProvider is a subset of the full Auth API.
 type AuthProvider interface {
-	GetNodes(namespace string) ([]services.Server, error)
+	GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error)
 	GetSessionEvents(namespace string, sid session.ID, after int, includePrintEvents bool) ([]events.EventFields, error)
 }
 
@@ -100,7 +100,7 @@ func NewTerminal(req TerminalRequest, authProvider AuthProvider, ctx *SessionCon
 		return nil, trace.BadParameter("term: bad term dimensions")
 	}
 
-	servers, err := authProvider.GetNodes(req.Namespace)
+	servers, err := authProvider.GetNodes(req.Namespace, services.SkipValidation())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/trace"
 )
 
@@ -172,7 +173,7 @@ func (c *NodeCommand) Invite(client auth.ClientI) error {
 // ListActive retreives the list of nodes who recently sent heartbeats to
 // to a cluster and prints it to stdout
 func (c *NodeCommand) ListActive(client auth.ClientI) error {
-	nodes, err := client.GetNodes(c.namespace)
+	nodes, err := client.GetNodes(c.namespace, services.SkipValidation())
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
**Purpose**

`tsh ssh` (and other commands like `tsh ls`) take a long time on large clusters. For example, on a 4k node cluster with a local etcd instance as the backend and auth, proxy, node all running in the same process, `tsh ssh` can take over 6 seconds. These numbers are larger for real world deployments where auth, proxy, and node run on different machines as well as etcd.

This is due to two reasons:

1. During login, `tsh` calls `GetNodes` several times. Each time `GetNodes` is called, it's validates the schema of the `services.Server` it returns. In the example 4k cluster, this in of itself takes up to 4 seconds. The solution to this is make schema validation optional in calls to `GetNodes`.

2. The remaining second is spent by the state cache re-upserting 4k items back into the dir backend. For example, writing 600 bytes to a new file takes about 200 us but writing 600 bytes to an open file takes about 10 us. To reduce the time spent re-upserting 4k items into the dir backend, the dir backend needs to support bulk insertion.

Fixes to these two problems should reduce login time to 500 ms to 1 second for 4k clusters.

**Implementation**

For the first problem, the API for `GetNodes(namespace string)` was updated to `GetNodes(namespace string, skipValidation bool)` allowing the caller to control if schema validation is run or not. In addition, `json-iterator` was used to speed up marshalling and unmarshalling.

For the second problem, the directory backend was re-written to support a flat keyspace. Once support for a flat keyspace was added, then the directory backend could store buckets with content being a list of keys. Then backend operations would simply be reading in all the keys in a bucket, operating on the map of items in the bucket, and then re-writing it back out. This reduces the time a upsert takes from 200 us to 10 us for each item, which for 4k nodes reduces total time from 800 ms to 40 ms.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2061