### PR TITLE
Add 'type' field to github auth request.

### DIFF
--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -276,6 +276,8 @@ func (i *ExternalIdentity) Check() error {
 type GithubAuthRequest struct {
 	// ConnectorID is the name of the connector to use
 	ConnectorID string `json:"connector_id"`
+	// Type is opaque string that helps callbacks identify the request type
+	Type string `json:"type"`
 	// StateToken is used to validate the request
 	StateToken string `json:"state_token"`
 	// CSRFToken is used to protect against CSRF attacks


### PR DESCRIPTION
Add `Type` field to `GithubAuthRequest` so callbacks can determine the request type. The `OIDCAuthRequest` and `SAMLAuthRequest` types already have this field defined. It is used, for instance, to distinguish between web vs console login in Telekube.
