### PR TITLE
Fetch fresh server representation when checking access to server

### DIFF
--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -32,6 +32,10 @@ type Server interface {
 	GetCmdLabels() map[string]CommandLabel
 	// GetPublicAddr is an optional field that returns the public address this cluster can be reached at.
 	GetPublicAddr() string
+	// GetRotation gets the state of certificate authority rotation.
+	GetRotation() Rotation
+	// SetRotation sets the state of certificate authority rotation.
+	SetRotation(Rotation)
 	// String returns string representation of the server
 	String() string
 	// SetAddr sets server address
@@ -154,6 +158,16 @@ func (s *ServerV2) GetAddr() string {
 // GetPublicAddr is an optional field that returns the public address this cluster can be reached at.
 func (s *ServerV2) GetPublicAddr() string {
 	return s.Spec.PublicAddr
+}
+
+// GetRotation gets the state of certificate authority rotation.
+func (s *ServerV2) GetRotation() Rotation {
+	return s.Spec.Rotation
+}
+
+// SetRotation sets the state of certificate authority rotation.
+func (s *ServerV2) SetRotation(r Rotation) {
+	s.Spec.Rotation = r
 }
 
 // GetHostname returns server hostname

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -42,7 +42,7 @@ type AuthHandlers struct {
 	*log.Entry
 
 	// Server is the services.Server in the backend.
-	Server services.Server
+	Server Server
 
 	// Component is the type of SSH server (node, proxy, or recording proxy).
 	Component string
@@ -326,7 +326,7 @@ func (h *AuthHandlers) canLoginWithRBAC(cert *ssh.Certificate, clusterName strin
 	}
 
 	// check if roles allow access to server
-	if err := roles.CheckAccessToServer(osUser, h.Server); err != nil {
+	if err := roles.CheckAccessToServer(osUser, h.Server.GetInfo()); err != nil {
 		return trace.AccessDenied("user %s@%s is not authorized to login as %v@%s: %v",
 			teleportUser, ca.GetClusterName(), osUser, clusterName, err)
 	}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -81,6 +81,9 @@ type Server interface {
 
 	// GetClock returns a clock setup for the server
 	GetClock() clockwork.Clock
+
+	// GetInfo returns a services.Server that represents this server.
+	GetInfo() services.Server
 }
 
 // IdentityContext holds all identity information associated with the user

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -409,7 +409,7 @@ func New(addr utils.NetAddr,
 			trace.Component:       component,
 			trace.ComponentFields: log.Fields{},
 		}),
-		Server:      s.getInfo(),
+		Server:      s,
 		Component:   component,
 		AuditLog:    s.alog,
 		AccessPoint: s.authService,
@@ -502,7 +502,8 @@ func (s *Server) getRole() teleport.Role {
 	return teleport.RoleNode
 }
 
-func (s *Server) getInfo() *services.ServerV2 {
+// GetInfo returns a services.Server that represents this server.
+func (s *Server) GetInfo() services.Server {
 	return &services.ServerV2{
 		Kind:    services.KindNode,
 		Version: services.V2,
@@ -521,7 +522,7 @@ func (s *Server) getInfo() *services.ServerV2 {
 
 // registerServer attempts to register server in the cluster
 func (s *Server) registerServer() error {
-	server := s.getInfo()
+	server := s.GetInfo()
 	if s.getRotation != nil {
 		rotation, err := s.getRotation(s.getRole())
 		if err != nil {
@@ -529,7 +530,7 @@ func (s *Server) registerServer() error {
 				log.Warningf("Failed to get rotation state: %v", err)
 			}
 		} else {
-			server.Spec.Rotation = *rotation
+			server.SetRotation(*rotation)
 		}
 	}
 	server.SetTTL(s.clock, defaults.ServerHeartbeatTTL)


### PR DESCRIPTION
**Problem**

Upon startup, a regular Teleport SSH server creates common auth handlers `srv.AuthHandlers`. A copy of `services.Server` that holds the dynamic labels is copied to this structure and then it's used to check access. Because dynamic labels are not set immediately upon startup (and update periodically), this structure does not contain the dynamic labels (or they are incorrect).

To solve this problem, the common auth handlers need the ability to fetch a fresh `services.Server` and use that to check when checking access to a server.

**Implementation**

* Add a `GetInfo()` method to the regular and forwarding server that returns a fresh `services.Server`.
* Call `GetInfo()` and pass the `services.Server` is the role check.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2056