### PR TITLE
Log events to multiple destinations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -338,8 +338,8 @@
 [[projects]]
   name = "github.com/gravitational/trace"
   packages = ["."]
-  revision = "0bd13642feb8f57acc0d8e3a568edc34e05a74b9"
-  version = "1.1.3"
+  revision = "3318e711adee0b3f48d3399ebf5aaddf329a2b4f"
+  version = "1.1.5"
 
 [[projects]]
   name = "github.com/gravitational/ttlmap"
@@ -879,6 +879,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dc5a18582036cab4d73a614a940bcb5138ca769a5e1427e7aec4dd85d68228ad"
+  inputs-digest = "7fb0202a49ed7fb0c258b7738e4d2a8c96c8a76c2d1151295102df98385ba8cf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,12 +20,12 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
-ignored = ["github.com/Sirupsen/logrus"]
-
 [prune]
   go-tests = true
   unused-packages = true
   non-go = true
+
+ignored = ["github.com/Sirupsen/logrus"]
 
 [[constraint]]
   name = "github.com/alecthomas/template"
@@ -130,7 +130,7 @@ ignored = ["github.com/Sirupsen/logrus"]
 
 [[constraint]]
   name = "github.com/gravitational/trace"
-  version = "1.1.3"
+  version = "1.1.5"
 
 [[constraint]]
   name = "github.com/coreos/go-oidc"

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -842,9 +845,22 @@ func (s *TLSSuite) TestSharedSessions(c *check.C) {
 		return data
 	}
 
+	uploadDir := c.MkDir()
+
 	// emit two events: "one" and "two" for this session, and event "three"
 	// for some other session
-	err = clt.PostSessionSlice(events.SessionSlice{
+	err = os.MkdirAll(filepath.Join(uploadDir, "upload", "sessions", defaults.Namespace), 0755)
+	forwarder, err := events.NewForwarder(events.ForwarderConfig{
+		Namespace:      defaults.Namespace,
+		SessionID:      sess.ID,
+		ServerID:       teleport.ComponentUpload,
+		DataDir:        uploadDir,
+		RecordSessions: true,
+		ForwardTo:      clt,
+	})
+	c.Assert(err, check.IsNil)
+
+	err = forwarder.PostSessionSlice(events.SessionSlice{
 		Namespace: defaults.Namespace,
 		SessionID: string(sess.ID),
 		Chunks: []*events.SessionChunk{
@@ -861,11 +877,21 @@ func (s *TLSSuite) TestSharedSessions(c *check.C) {
 				Data:       marshal(events.EventFields{events.EventLogin: "bob", "val": "two"}),
 			},
 		},
-		Version: events.V2,
+		Version: events.V3,
 	})
 	c.Assert(err, check.IsNil)
+	c.Assert(forwarder.Close(), check.IsNil)
 
 	anotherSessionID := session.NewID()
+	forwarder, err = events.NewForwarder(events.ForwarderConfig{
+		Namespace:      defaults.Namespace,
+		SessionID:      sess.ID,
+		ServerID:       teleport.ComponentUpload,
+		DataDir:        uploadDir,
+		RecordSessions: true,
+		ForwardTo:      clt,
+	})
+	c.Assert(err, check.IsNil)
 	err = clt.PostSessionSlice(events.SessionSlice{
 		Namespace: defaults.Namespace,
 		SessionID: string(anotherSessionID),
@@ -883,9 +909,34 @@ func (s *TLSSuite) TestSharedSessions(c *check.C) {
 				Data:       marshal(events.EventFields{events.EventLogin: "alice", "val": "three"}),
 			},
 		},
-		Version: events.V2,
+		Version: events.V3,
 	})
 	c.Assert(err, check.IsNil)
+	c.Assert(forwarder.Close(), check.IsNil)
+
+	// start uploader process
+	eventsC := make(chan *events.UploadEvent, 100)
+	uploader, err := events.NewUploader(events.UploaderConfig{
+		ServerID:   "upload",
+		DataDir:    uploadDir,
+		Namespace:  defaults.Namespace,
+		Context:    context.TODO(),
+		ScanPeriod: 100 * time.Millisecond,
+		AuditLog:   clt,
+		EventsC:    eventsC,
+	})
+	c.Assert(err, check.IsNil)
+	err = uploader.Scan()
+	c.Assert(err, check.IsNil)
+
+	// scanner should upload the events
+	select {
+	case event := <-eventsC:
+		c.Assert(event, check.NotNil)
+		c.Assert(event.Error, check.IsNil)
+	case <-time.After(time.Second):
+		c.Fatalf("Timeout wating for the upload event")
+	}
 
 	// ask for strictly session events:
 	e, err := clt.GetSessionEvents(defaults.Namespace, sess.ID, 0, true)

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -372,7 +372,7 @@ func (s *ConfigTestSuite) TestApplyConfig(c *check.C) {
 	conf, err := ReadConfig(bytes.NewBufferString(SmallConfigString))
 	c.Assert(err, check.IsNil)
 	c.Assert(conf, check.NotNil)
-	c.Assert(conf.Proxy.PublicAddr, check.DeepEquals, Strings{"web3:443"})
+	c.Assert(conf.Proxy.PublicAddr, check.DeepEquals, utils.Strings{"web3:443"})
 
 	cfg := service.MakeDefaultConfig()
 	err = ApplyFileConfig(conf, cfg)
@@ -542,7 +542,7 @@ func checkStaticConfig(c *check.C, conf *FileConfig) {
 	c.Assert(conf.SSH.Commands[1].Name, check.Equals, "date")
 	c.Assert(conf.SSH.Commands[1].Command, check.DeepEquals, []string{"/bin/date"})
 	c.Assert(conf.SSH.Commands[1].Period.Nanoseconds(), check.Equals, int64(20000000))
-	c.Assert(conf.SSH.PublicAddr, check.DeepEquals, Strings{
+	c.Assert(conf.SSH.PublicAddr, check.DeepEquals, utils.Strings{
 		"luna3:22",
 	})
 
@@ -569,7 +569,7 @@ func checkStaticConfig(c *check.C, conf *FileConfig) {
 	c.Assert(conf.Auth.StaticTokens, check.DeepEquals,
 		StaticTokens{"proxy,node:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "auth:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 
-	c.Assert(conf.Auth.PublicAddr, check.DeepEquals, Strings{
+	c.Assert(conf.Auth.PublicAddr, check.DeepEquals, utils.Strings{
 		"auth.default.svc.cluster.local:3080",
 	})
 

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2018 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,9 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -40,7 +38,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/gravitational/ttlmap"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -86,12 +83,6 @@ type AuditLog struct {
 	// playbackDir is a directory used for unpacked session recordings
 	playbackDir string
 
-	loggers *ttlmap.TTLMap
-
-	// file is the current global event log file. As the time goes
-	// on, it will be replaced by a new file every day
-	file *os.File
-
 	// fileTime is a rounded (to a day, by default) timestamp of the
 	// currently opened file
 	fileTime time.Time
@@ -105,6 +96,10 @@ type AuditLog struct {
 
 	// cancel triggers closing of the signal context
 	cancel context.CancelFunc
+
+	// localLog is a local events log used
+	// to emit audit events if no external log has been specified
+	localLog *FileLog
 }
 
 // AuditLogConfig specifies configuration for AuditLog server
@@ -211,12 +206,6 @@ func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 		ctx:             ctx,
 		cancel:          cancel,
 	}
-	loggers, err := ttlmap.New(defaults.AuditLogSessions,
-		ttlmap.CallOnExpire(al.closeSessionLogger), ttlmap.Clock(cfg.Clock))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	al.loggers = loggers
 	// create a directory for audit logs, audit log does not create
 	// session logs before migrations are run in case if the directory
 	// has to be moved
@@ -247,7 +236,20 @@ func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 			return nil, trace.ConvertSystemError(err)
 		}
 	}
-	go al.periodicCloseInactiveLoggers()
+
+	if al.ExternalLog == nil {
+		var err error
+		al.localLog, err = NewFileLog(FileLogConfig{
+			RotationPeriod: al.RotationPeriod,
+			Dir:            auditDir,
+			Clock:          al.Clock,
+			SearchDirs:     al.auditDirs,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	go al.periodicCleanupPlaybacks()
 	return al, nil
 }
@@ -317,28 +319,12 @@ func (l *AuditLog) PostSessionSlice(slice SessionSlice) error {
 	if l.ExternalLog != nil {
 		return l.ExternalLog.PostSessionSlice(slice)
 	}
-	if slice.Version < V2 {
-		return trace.BadParameter("audit log rejected V1 log entry, upgrade your components.")
-	}
-	// API prior to V3 was writing to audit log in real time
-	// V3 API has changed that, as session events and recording itself
-	// is shipped in one transaction. This solves many problems, as events
-	// are no longer fragmented across multiple auth servers behind the load balancer
-	// and there is no need to live-write the the session chunks and events
-	// for V3 API.
 	if slice.Version < V3 {
-		sl, err := l.LoggerFor(slice.Namespace, session.ID(slice.SessionID))
-		if err != nil {
-			l.Errorf("failed to get logger: %v", trace.DebugReport(err))
-			return trace.BadParameter("audit.log: no session writer for %s", slice.SessionID)
-		}
-		var errors []error
-		errors = append(errors, sl.PostSessionSlice(slice))
-		errors = append(errors, l.processSlice(sl, &slice))
-		return trace.NewAggregate(errors...)
+		return trace.BadParameter("audit log rejected %v log entry, upgrade your components.", slice.Version)
 	}
 	// V3 API does not write session log to local session directory,
-	// instead it writes locally
+	// instead it writes locally, this internal method captures
+	// non-print events to the global audit log
 	return l.processSlice(nil, &slice)
 }
 
@@ -347,21 +333,11 @@ func (l *AuditLog) processSlice(sl SessionLogger, slice *SessionSlice) error {
 		if chunk.EventType == SessionPrintEvent || chunk.EventType == "" {
 			continue
 		}
-		// session logger is optional for processSlice function
-		// only close it if necessary
-		if sl != nil && chunk.EventType == SessionEndEvent {
-			defer func() {
-				l.removeLogger(slice.SessionID)
-				if err := sl.Finalize(); err != nil {
-					log.Warningf("Failed to finalize logger: %v.", trace.DebugReport(err))
-				}
-			}()
-		}
 		fields, err := EventFromChunk(slice.SessionID, chunk)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := l.emitAuditEvent(chunk.EventType, fields); err != nil {
+		if err := l.EmitAuditEvent(chunk.EventType, fields); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -781,7 +757,13 @@ func (l *AuditLog) GetSessionEvents(namespace string, sid session.ID, afterN int
 	// Print events are stored in the context of the downloaded session
 	// so pull them
 	if !includePrintEvents && l.ExternalLog != nil {
-		return l.ExternalLog.GetSessionEvents(namespace, sid, afterN, includePrintEvents)
+		events, err := l.ExternalLog.GetSessionEvents(namespace, sid, afterN, includePrintEvents)
+		// some loggers (e.g. FileLog) do not support retrieving session only print events,
+		// in this case rely on local fallback to download the session,
+		// unpack it and use local search
+		if !trace.IsNotImplemented(err) {
+			return events, err
+		}
 	}
 	// If code has to fetch print events (for playback) it has to download
 	// the playback from external storage first
@@ -852,104 +834,7 @@ func (l *AuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
 	if l.ExternalLog != nil {
 		return l.ExternalLog.EmitAuditEvent(eventType, fields)
 	}
-
-	if err := l.emitAuditEvent(eventType, fields); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
-}
-
-func (l *AuditLog) removeLogger(sessionID string) {
-	l.Debugf("Removing session logger for SID=%v.", sessionID)
-	l.Lock()
-	defer l.Unlock()
-	l.loggers.Remove(sessionID)
-}
-
-// emitAuditEvent adds a new event to the log. Part of auth.IAuditLog interface.
-func (l *AuditLog) emitAuditEvent(eventType string, fields EventFields) error {
-	// see if the log needs to be rotated
-	if err := l.rotateLog(); err != nil {
-		log.Error(err)
-	}
-
-	// set event type and time:
-	fields[EventType] = eventType
-	if _, ok := fields[EventTime]; !ok {
-		fields[EventTime] = l.Clock.Now().In(time.UTC).Round(time.Second)
-	}
-	// line is the text to be logged
-	line, err := json.Marshal(fields)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	// log it to the main log file:
-	if l.file != nil {
-		fmt.Fprintln(l.file, string(line))
-	}
-	return nil
-}
-
-// matchingFiles returns files matching the time restrictions of the query
-// across multiple auth servers, returns a list of file names
-func (l *AuditLog) matchingFiles(fromUTC, toUTC time.Time) ([]eventFile, error) {
-	authServers, err := l.getAuthServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	var filtered []eventFile
-	for _, serverID := range authServers {
-		// scan the log directory:
-		df, err := os.Open(filepath.Join(l.DataDir, serverID))
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		defer df.Close()
-		entries, err := df.Readdir(-1)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		for i := range entries {
-			fi := entries[i]
-			if fi.IsDir() || filepath.Ext(fi.Name()) != LogfileExt {
-				continue
-			}
-			base := strings.TrimSuffix(fi.Name(), filepath.Ext(fi.Name()))
-			fd, err := time.Parse(defaults.AuditLogTimeFormat, base)
-			if err != nil {
-				l.Warningf("Failed to parse audit log file %q format: %v", base, err)
-				continue
-			}
-			// File rounding in current logs is non-deterministic,
-			// as Round function used in rotateLog can round up to the lowest
-			// or the highest period. That's why this has to check both
-			// periods.
-			// Previous logic used modification time what was flaky
-			// as it could be changed by migrations or simply moving files
-			if fd.After(fromUTC.Add(-1*l.RotationPeriod)) && fd.Before(toUTC.Add(l.RotationPeriod)) {
-				eventFile := eventFile{
-					FileInfo: fi,
-					path:     filepath.Join(l.DataDir, serverID, fi.Name()),
-				}
-				filtered = append(filtered, eventFile)
-			}
-		}
-	}
-	// sort all accepted files by date
-	sort.Sort(byDate(filtered))
-	return filtered, nil
-}
-
-func (l *AuditLog) moveAuditLogFile(fileName string) error {
-	sourceFile := filepath.Join(l.DataDir, fileName)
-	targetFile := filepath.Join(l.DataDir, l.ServerID, fileName)
-	l.Infof("Migrating log file from %v to %v", sourceFile, targetFile)
-	if err := os.Rename(sourceFile, targetFile); err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	return nil
+	return l.localLog.EmitAuditEvent(eventType, fields)
 }
 
 // emitEvent emits event for test purposes
@@ -965,134 +850,18 @@ func (l *AuditLog) emitEvent(e AuditLogEvent) {
 	}
 }
 
-// migrateSessionsDir migrates session directory session by session
-func (l *AuditLog) migrateSessionsDir() error {
-	sessionDir := filepath.Join(l.DataDir, SessionLogsDir)
-	_, err := utils.StatDir(sessionDir)
+// auditDirs returns directories used for audit log storage
+func (l *AuditLog) auditDirs() ([]string, error) {
+	authServers, err := l.getAuthServers()
 	if err != nil {
-		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-		l.Debugf("No V1 sessions directory, nothing to migrate.")
+		return nil, trace.Wrap(err)
 	}
 
-	targetDir := filepath.Join(l.DataDir, l.ServerID, SessionLogsDir)
-	// transform the recorded files to the new index format
-	recordingsDir := filepath.Join(l.DataDir, SessionLogsDir, defaults.Namespace)
-	targetRecordingsDir := filepath.Join(targetDir, defaults.Namespace)
-	fileInfos, err := listDir(recordingsDir)
-	if err != nil {
-		// source directory does not exist, means nothing to migrate
-		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-		return nil
+	var out []string
+	for _, serverID := range authServers {
+		out = append(out, filepath.Join(l.DataDir, serverID))
 	}
-	for _, fi := range fileInfos {
-		if fi.IsDir() {
-			l.Debugf("Migrating, skipping directory %v", fi.Name())
-			continue
-		}
-
-		// only trigger migrations on .log
-		// to avoid double migrations attempts or migrating recordings
-		// that were already migrated
-		if !strings.HasSuffix(fi.Name(), "session.log") {
-			continue
-		}
-
-		parts := strings.Split(fi.Name(), ".")
-		if len(parts) < 2 {
-			l.Debugf("Migrating, skipping unknown file: %v", fi.Name())
-		}
-		sessionID := parts[0]
-		sourceEventsFile := filepath.Join(recordingsDir, fmt.Sprintf("%v.session.log", sessionID))
-		targetEventsFile := filepath.Join(targetRecordingsDir, fmt.Sprintf("%v-0.events.gz", sessionID))
-		l.Debugf("Migrating, session ID %v. Compressed %v to %v", sessionID, sourceEventsFile, targetEventsFile)
-		err := moveAndGzipFile(sourceEventsFile, targetEventsFile)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		sourceChunksFile := filepath.Join(recordingsDir, fmt.Sprintf("%v.session.bytes", sessionID))
-		targetChunksFile := filepath.Join(targetRecordingsDir, fmt.Sprintf("%v-0.chunks.gz", sessionID))
-		l.Debugf("Migrating session ID %v. Compressed %v to %v", sessionID, sourceChunksFile, targetChunksFile)
-		err = moveAndGzipFile(sourceChunksFile, targetChunksFile)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		indexFileName := filepath.Join(targetRecordingsDir, fmt.Sprintf("%v.index", sessionID))
-
-		eventsData, err := json.Marshal(indexEntry{
-			FileName: filepath.Base(targetEventsFile),
-			Type:     fileTypeEvents,
-			Index:    0,
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		chunksData, err := json.Marshal(indexEntry{
-			FileName: filepath.Base(targetChunksFile),
-			Type:     fileTypeChunks,
-			Offset:   0,
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		err = ioutil.WriteFile(indexFileName,
-			[]byte(
-				fmt.Sprintf("%v\n%v\n",
-					string(eventsData),
-					string(chunksData),
-				)),
-			0640,
-		)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		l.Debugf("Migrating session ID %v. Wrote index file %v.", sessionID, indexFileName)
-	}
-	l.Info("Sessions migrations completed.")
-	l.emitEvent(AuditLogEvent{
-		Type: sessionsMigratedEvent,
-	})
-	return nil
-}
-
-func moveAndGzipFile(source string, target string) error {
-	sourceFile, err := os.Open(source)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	defer sourceFile.Close()
-	destFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	destWriter := newGzipWriter(destFile)
-	defer destWriter.Close()
-	_, err = io.Copy(destWriter, sourceFile)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if err := os.Remove(source); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
-func listDir(dir string) ([]os.FileInfo, error) {
-	df, err := os.Open(dir)
-	if err != nil {
-		return nil, trace.ConvertSystemError(err)
-	}
-	defer df.Close()
-	entries, err := df.Readdir(-1)
-	if err != nil {
-		return nil, trace.ConvertSystemError(err)
-	}
-	return entries, nil
+	return out, nil
 }
 
 // SearchEvents finds events. Results show up sorted by date (newest first),
@@ -1108,38 +877,7 @@ func (l *AuditLog) SearchEvents(fromUTC, toUTC time.Time, query string, limit in
 	if l.ExternalLog != nil {
 		return l.ExternalLog.SearchEvents(fromUTC, toUTC, query, limit)
 	}
-	// how many days of logs to search?
-	days := int(toUTC.Sub(fromUTC).Hours() / 24)
-	if days < 0 {
-		return nil, trace.BadParameter("query", query)
-	}
-	queryVals, err := url.ParseQuery(query)
-	if err != nil {
-		return nil, trace.BadParameter("missing parameter query", query)
-	}
-	filtered, err := l.matchingFiles(fromUTC, toUTC)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var total int
-	// search within each file:
-	events := make([]EventFields, 0)
-	for i := range filtered {
-		found, err := l.findInFile(filtered[i].path, queryVals, &total, limit)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		events = append(events, found...)
-		if limit > 0 && total >= limit {
-			break
-		}
-	}
-	// sort all accepted files by timestamp or by event index
-	// in case if events are associated with the same session, to make
-	// sure that events are not displayed out of order in case of multiple
-	// auth servers.
-	sort.Sort(ByTimeAndIndex(events))
-	return events, nil
+	return l.localLog.SearchEvents(fromUTC, toUTC, query, limit)
 }
 
 // SearchSessionEvents searches for session related events. Used to find completed sessions.
@@ -1149,195 +887,7 @@ func (l *AuditLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int) ([]E
 	if l.ExternalLog != nil {
 		return l.ExternalLog.SearchSessionEvents(fromUTC, toUTC, limit)
 	}
-
-	// only search for specific event types
-	query := url.Values{}
-	query[EventType] = []string{
-		SessionStartEvent,
-		SessionEndEvent,
-	}
-
-	// because of the limit and distributed nature of auth server event
-	// logs, some events can be fetched with session end event and without
-	// session start event. to fix this, the code below filters out the events without
-	// start event to guarantee that all events in the range will get fetched
-	events, err := l.SearchEvents(fromUTC, toUTC, query.Encode(), limit)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// filter out 'session end' events that do not
-	// have a corresponding 'session start' event
-	started := make(map[string]struct{}, len(events)/2)
-	filtered := make([]EventFields, 0, len(events))
-	for i := range events {
-		event := events[i]
-		eventType := event[EventType]
-		sessionID := event.GetString(SessionEventID)
-		if sessionID == "" {
-			continue
-		}
-		if eventType == SessionStartEvent {
-			started[sessionID] = struct{}{}
-			filtered = append(filtered, event)
-		}
-		if eventType == SessionEndEvent {
-			if _, ok := started[sessionID]; ok {
-				filtered = append(filtered, event)
-			}
-		}
-	}
-
-	return filtered, nil
-}
-
-type eventFile struct {
-	os.FileInfo
-	path string
-}
-
-// byDate implements sort.Interface.
-type byDate []eventFile
-
-func (f byDate) Len() int           { return len(f) }
-func (f byDate) Less(i, j int) bool { return f[i].ModTime().Before(f[j].ModTime()) }
-func (f byDate) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }
-
-// ByTimeAndIndex sorts events by time extracting timestamp from JSON field
-// and if there are several session events with the same session
-// by event index, regardless of the time
-type ByTimeAndIndex []EventFields
-
-func (f ByTimeAndIndex) Len() int {
-	return len(f)
-}
-
-func (f ByTimeAndIndex) Less(i, j int) bool {
-	itime := getTime(f[i][EventTime])
-	jtime := getTime(f[j][EventTime])
-	if itime.Equal(jtime) && f[i][SessionEventID] == f[j][SessionEventID] {
-		return getEventIndex(f[i][EventIndex]) < getEventIndex(f[j][EventIndex])
-	}
-	return itime.Before(jtime)
-}
-
-func (f ByTimeAndIndex) Swap(i, j int) {
-	f[i], f[j] = f[j], f[i]
-}
-
-// getTime converts json time to string
-func getTime(v interface{}) time.Time {
-	sval, ok := v.(string)
-	if !ok {
-		return time.Time{}
-	}
-	t, err := time.Parse(time.RFC3339, sval)
-	if err != nil {
-		return time.Time{}
-	}
-	return t
-}
-
-func getEventIndex(v interface{}) float64 {
-	switch val := v.(type) {
-	case float64:
-		return val
-	}
-	return 0
-}
-
-// findInFile scans a given log file and returns events that fit the criteria
-// This simplistic implementation ONLY SEARCHES FOR EVENT TYPE(s)
-//
-// You can pass multiple types like "event=session.start&event=session.end"
-func (l *AuditLog) findInFile(fn string, query url.Values, total *int, limit int) ([]EventFields, error) {
-	l.Debugf("Called findInFile(%s, %v).", fn, query)
-	retval := make([]EventFields, 0)
-
-	eventFilter, ok := query[EventType]
-	if !ok && len(query) > 0 {
-		return nil, nil
-	}
-	doFilter := len(eventFilter) > 0
-
-	// open the log file:
-	lf, err := os.OpenFile(fn, os.O_RDONLY, 0)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer lf.Close()
-
-	// for each line...
-	scanner := bufio.NewScanner(lf)
-	for lineNo := 0; scanner.Scan(); lineNo++ {
-		accepted := false
-		// optimization: to avoid parsing JSON unnecessarily, lets see if we
-		// can filter out lines that don't even have the requested event type on the line
-		for i := range eventFilter {
-			if strings.Contains(scanner.Text(), eventFilter[i]) {
-				accepted = true
-				break
-			}
-		}
-		if doFilter && !accepted {
-			continue
-		}
-		// parse JSON on the line and compare event type field to what's
-		// in the query:
-		var ef EventFields
-		if err = json.Unmarshal(scanner.Bytes(), &ef); err != nil {
-			l.Warnf("invalid JSON in %s line %d", fn, lineNo)
-			continue
-		}
-		for i := range eventFilter {
-			if ef.GetString(EventType) == eventFilter[i] {
-				accepted = true
-				break
-			}
-		}
-		if accepted || !doFilter {
-			retval = append(retval, ef)
-			*total += 1
-			if limit > 0 && *total >= limit {
-				break
-			}
-		}
-	}
-	return retval, nil
-}
-
-// rotateLog checks if the current log file is older than a given duration,
-// and if it is, closes it and opens a new one.
-func (l *AuditLog) rotateLog() (err error) {
-	l.Lock()
-	defer l.Unlock()
-
-	// determine the timestamp for the current log file
-	fileTime := l.Clock.Now().In(time.UTC).Round(l.RotationPeriod)
-
-	openLogFile := func() error {
-		logfname := filepath.Join(l.DataDir, l.ServerID,
-			fileTime.Format(defaults.AuditLogTimeFormat)+LogfileExt)
-		l.file, err = os.OpenFile(logfname, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
-		if err != nil {
-			log.Error(err)
-		}
-
-		l.fileTime = fileTime
-		return trace.Wrap(err)
-	}
-
-	// need to create a log file?
-	if l.file == nil {
-		return openLogFile()
-	}
-
-	// time to advance the logfile?
-	if l.fileTime.Before(fileTime) {
-		l.file.Close()
-		return openLogFile()
-	}
-	return nil
+	return l.localLog.SearchSessionEvents(fromUTC, toUTC, limit)
 }
 
 // Closes the audit log, which inluces closing all file handles and releasing
@@ -1352,92 +902,13 @@ func (l *AuditLog) Close() error {
 	l.Lock()
 	defer l.Unlock()
 
-	if l.file != nil {
-		l.file.Close()
-		l.file = nil
-	}
-
-	// close any open sessions that haven't expired yet and are open
-	for {
-		key, value, found := l.loggers.Pop()
-		if !found {
-			break
+	if l.localLog != nil {
+		if err := l.localLog.Close(); err != nil {
+			log.Warningf("Close failure: %v", err)
 		}
-		l.closeSessionLogger(key, value)
+		l.localLog = nil
 	}
 	return nil
-}
-
-// LoggerFor creates a logger for a specified session. Session loggers allow
-// to group all events into special "session log files" for easier audit
-func (l *AuditLog) LoggerFor(namespace string, sid session.ID) (SessionLogger, error) {
-	l.Lock()
-	defer l.Unlock()
-
-	if namespace == "" {
-		return nil, trace.BadParameter("missing parameter namespace")
-	}
-
-	logger, ok := l.loggers.Get(string(sid))
-	if ok {
-		sessionLogger, converted := logger.(SessionLogger)
-		if !converted {
-			return nil, trace.BadParameter("unsupported type: %T", logger)
-		}
-		// refresh the last active time of the logger
-		l.loggers.Set(string(sid), logger, l.SessionIdlePeriod)
-		return sessionLogger, nil
-	}
-	// make sure session logs dir is present
-	sdir := filepath.Join(l.DataDir, l.ServerID, SessionLogsDir, namespace)
-	if err := os.Mkdir(sdir, *l.DirMask); err != nil {
-		if !os.IsExist(err) {
-			return nil, trace.Wrap(err)
-		}
-	} else if l.UID != nil && l.GID != nil {
-		err := os.Chown(sdir, *l.UID, *l.GID)
-		if err != nil {
-			return nil, trace.ConvertSystemError(err)
-		}
-	}
-	sessionLogger, err := NewDiskSessionLogger(DiskSessionLoggerConfig{
-		SessionID:      sid,
-		Namespace:      namespace,
-		ServerID:       l.ServerID,
-		DataDir:        l.DataDir,
-		Clock:          l.Clock,
-		RecordSessions: l.RecordSessions,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	l.loggers.Set(string(sid), sessionLogger, l.SessionIdlePeriod)
-	auditOpenFiles.Inc()
-	return sessionLogger, nil
-}
-
-func (l *AuditLog) closeSessionLogger(key string, val interface{}) {
-	l.Debugf("Closing session logger %v.", key)
-	logger, ok := val.(SessionLogger)
-	if !ok {
-		l.Warningf("Warning, not valid value type %T for %v.", val, key)
-		return
-	}
-	if err := logger.Finalize(); err != nil {
-		log.Warningf("Failed to finalize: %v.", trace.DebugReport(err))
-	}
-}
-
-func (l *AuditLog) periodicCloseInactiveLoggers() {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			l.closeInactiveLoggers()
-		}
-	}
 }
 
 func (l *AuditLog) periodicCleanupPlaybacks() {
@@ -1451,15 +922,5 @@ func (l *AuditLog) periodicCleanupPlaybacks() {
 				l.Warningf("Error while cleaning up playback files: %v.", err)
 			}
 		}
-	}
-}
-
-func (l *AuditLog) closeInactiveLoggers() {
-	l.Lock()
-	defer l.Unlock()
-
-	expired := l.loggers.RemoveExpired(10)
-	if expired != 0 {
-		l.Debugf("Closed %v inactive session loggers.", expired)
 	}
 }

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -28,6 +28,7 @@ import (
 
 	"gopkg.in/check.v1"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/session"
@@ -80,15 +81,21 @@ func (a *AuditTestSuite) TestNew(c *check.C) {
 }
 
 // TestSessionsOnOneAuthServer tests scenario when there are two auth servers
-// but session is recorded only on the one
+// and session is recorded on the first one
 func (a *AuditTestSuite) TestSessionsOnOneAuthServer(c *check.C) {
 	fakeClock := clockwork.NewFakeClock()
+
+	storageDir := c.MkDir()
+	fileHandler, err := filesessions.NewHandler(filesessions.Config{
+		Directory: storageDir,
+	})
 
 	alog, err := NewAuditLog(AuditLogConfig{
 		Clock:          fakeClock,
 		DataDir:        a.dataDir,
 		RecordSessions: true,
 		ServerID:       "server1",
+		UploadHandler:  fileHandler,
 	})
 	c.Assert(err, check.IsNil)
 
@@ -97,13 +104,27 @@ func (a *AuditTestSuite) TestSessionsOnOneAuthServer(c *check.C) {
 		DataDir:        a.dataDir,
 		RecordSessions: true,
 		ServerID:       "server2",
+		UploadHandler:  fileHandler,
 	})
 	c.Assert(err, check.IsNil)
 
+	uploadDir := c.MkDir()
+	err = os.MkdirAll(filepath.Join(uploadDir, "upload", "sessions", defaults.Namespace), 0755)
 	sessionID := "100"
+	forwarder, err := NewForwarder(ForwarderConfig{
+		Namespace:      defaults.Namespace,
+		SessionID:      session.ID(sessionID),
+		ServerID:       teleport.ComponentUpload,
+		DataDir:        uploadDir,
+		RecordSessions: true,
+		ForwardTo:      alog,
+		Clock:          fakeClock,
+	})
+	c.Assert(err, check.IsNil)
+
 	// start the session and emit data stream to it
 	firstMessage := []byte("hello")
-	err = alog.PostSessionSlice(SessionSlice{
+	err = forwarder.PostSessionSlice(SessionSlice{
 		Namespace: defaults.Namespace,
 		SessionID: sessionID,
 		Chunks: []*SessionChunk{
@@ -131,9 +152,12 @@ func (a *AuditTestSuite) TestSessionsOnOneAuthServer(c *check.C) {
 				Data:       marshal(EventFields{EventLogin: "bob"}),
 			},
 		},
-		Version: V2,
+		Version: V3,
 	})
 	c.Assert(err, check.IsNil)
+	c.Assert(forwarder.Close(), check.IsNil)
+
+	upload(c, uploadDir, fakeClock, alog)
 
 	// does not matter which audit server is accessed the results should be the same
 	for _, a := range []*AuditLog{alog, alog2} {
@@ -158,455 +182,73 @@ func (a *AuditTestSuite) TestSessionsOnOneAuthServer(c *check.C) {
 	}
 }
 
-// TestSessionsTwoAuthServers tests two auth servers behind the load balancer handling the event stream
-// for the same session
-func (a *AuditTestSuite) TestSessionsTwoAuthServers(c *check.C) {
-	fakeClock := clockwork.NewFakeClock()
-
-	alog, err := NewAuditLog(AuditLogConfig{
-		Clock:          fakeClock,
-		DataDir:        a.dataDir,
-		RecordSessions: true,
-		ServerID:       "server1",
+func upload(c *check.C, uploadDir string, clock clockwork.Clock, auditLog IAuditLog) {
+	// start uploader process
+	eventsC := make(chan *UploadEvent, 100)
+	uploader, err := NewUploader(UploaderConfig{
+		ServerID:   "upload",
+		DataDir:    uploadDir,
+		Clock:      clock,
+		Namespace:  defaults.Namespace,
+		Context:    context.TODO(),
+		ScanPeriod: 100 * time.Millisecond,
+		AuditLog:   auditLog,
+		EventsC:    eventsC,
 	})
 	c.Assert(err, check.IsNil)
 
-	alog2, err := NewAuditLog(AuditLogConfig{
-		Clock:          fakeClock,
-		DataDir:        a.dataDir,
-		RecordSessions: true,
-		ServerID:       "server2",
-	})
+	// scanner should upload the events
+	err = uploader.Scan()
 	c.Assert(err, check.IsNil)
 
-	sessionID := "100"
-	// start the session and emit data stream to it
-	firstMessage := []byte("hello")
-	err = alog.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// start the seession
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				EventIndex: 0,
-				EventType:  SessionStartEvent,
-				Data:       marshal(EventFields{EventLogin: "bob"}),
-			},
-			// type "hello" into session "100"
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				EventIndex: 1,
-				ChunkIndex: 0,
-				Offset:     0,
-				EventType:  SessionPrintEvent,
-				Data:       firstMessage,
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers.Len(), check.Equals, 1)
-
-	// now fake sleep past expiration
-	firstDelay := defaults.SessionIdlePeriod * 2
-	fakeClock.Advance(firstDelay)
-
-	// logger for idle session should be closed
-	alog.closeInactiveLoggers()
-	c.Assert(alog.loggers.Len(), check.Equals, 0)
-
-	// send another event to the session via second auth server
-	secondMessage := []byte("good day")
-	err = alog2.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// notice how offsets are sent by the client
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				Delay:      int64(firstDelay / time.Millisecond),
-				EventIndex: 2,
-				ChunkIndex: 1,
-				Offset:     int64(len(firstMessage)),
-				EventType:  SessionPrintEvent,
-				Data:       secondMessage,
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(alog2.loggers.Len(), check.Equals, 1)
-
-	// emit next event 17 milliseconds later to the first auth server
-	thirdMessage := []byte("test")
-	secondDelay := 17 * time.Millisecond
-	fakeClock.Advance(secondDelay)
-	err = alog.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// notice how offsets are sent by the client
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				EventIndex: 3,
-				ChunkIndex: 2,
-				Delay:      int64((firstDelay + secondDelay) / time.Millisecond),
-				Offset:     int64(len(firstMessage) + len(secondMessage)),
-				EventType:  SessionPrintEvent,
-				Data:       thirdMessage,
-			},
-			// emitting session end event should close the session
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				EventIndex: 4,
-				EventType:  SessionEndEvent,
-				Data:       marshal(EventFields{EventLogin: "bob"}),
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-
-	// emitting session end event should close the session
-	c.Assert(alog.loggers.Len(), check.Equals, 0)
-
-	// does not matter which audit server is accessed the results should be the same
-	for _, a := range []*AuditLog{alog, alog2} {
-		// read the session bytes
-		history, err := a.GetSessionEvents(defaults.Namespace, session.ID(sessionID), 1, true)
-		c.Assert(err, check.IsNil)
-		c.Assert(history, check.HasLen, 4)
-
-		// make sure offsets were properly set (0 for the first event and 5 bytes for hello):
-		c.Assert(history[0][SessionByteOffset], check.Equals, float64(0))
-		c.Assert(history[1][SessionByteOffset], check.Equals, float64(len(firstMessage)))
-		c.Assert(history[2][SessionByteOffset], check.Equals, float64(len(firstMessage)+len(secondMessage)))
-
-		// make sure delays are right
-		c.Assert(history[0][SessionEventTimestamp], check.Equals, float64(0))
-		c.Assert(history[1][SessionEventTimestamp], check.Equals, float64(firstDelay/time.Millisecond))
-		c.Assert(history[2][SessionEventTimestamp], check.Equals, float64((firstDelay+secondDelay)/time.Millisecond))
-
-		// fetch all bytes
-		buff, err := a.GetSessionChunk(defaults.Namespace, session.ID(sessionID), 0, 5000)
-		c.Assert(err, check.IsNil)
-		c.Assert(string(buff), check.Equals, "hellogood daytest")
-
-		// with offset
-		buff, err = a.GetSessionChunk(defaults.Namespace, session.ID(sessionID), 2, 5000)
-		c.Assert(err, check.IsNil)
-		c.Assert(string(buff), check.Equals, "llogood daytest")
-
-		// with another offset at the boundary of the first message
-		buff, err = a.GetSessionChunk(defaults.Namespace, session.ID(sessionID), len(firstMessage), 5000)
-		c.Assert(err, check.IsNil)
-		c.Assert(string(buff), check.Equals, "good daytest")
-
-		// with another offset after the boundary of the first message
-		buff, err = a.GetSessionChunk(defaults.Namespace, session.ID(sessionID), len(firstMessage)+1, 5000)
-		c.Assert(err, check.IsNil)
-		c.Assert(string(buff), check.Equals, "ood daytest")
-
-		// with another offset after the boundary of the third message
-		buff, err = a.GetSessionChunk(defaults.Namespace, session.ID(sessionID), len(firstMessage)+len(secondMessage), 5000)
-		c.Assert(err, check.IsNil)
-		c.Assert(string(buff), check.Equals, "test")
-
-		// with another offset outside the boundaries
-		buff, err = a.GetSessionChunk(defaults.Namespace, session.ID(sessionID), len(firstMessage)+len(secondMessage)+len(thirdMessage), 5000)
-		c.Assert(err, check.IsNil)
-		c.Assert(string(buff), check.Equals, "")
+	select {
+	case event := <-eventsC:
+		c.Assert(event, check.NotNil)
+		c.Assert(event.Error, check.IsNil)
+	case <-time.After(time.Second):
+		c.Fatalf("Timeout wating for the upload event")
 	}
-}
-
-// TestSearchTwoAuthServers tests search on two auth servers behind the load balancer handling the event stream
-// for the same session
-func (a *AuditTestSuite) TestSearchTwoAuthServers(c *check.C) {
-	startTime := time.Now().UTC()
-
-	alog, err := NewAuditLog(AuditLogConfig{
-		DataDir:        a.dataDir,
-		RecordSessions: true,
-		ServerID:       "server1",
-	})
-	c.Assert(err, check.IsNil)
-
-	alog2, err := NewAuditLog(AuditLogConfig{
-		DataDir:        a.dataDir,
-		RecordSessions: true,
-		ServerID:       "server2",
-	})
-	c.Assert(err, check.IsNil)
-
-	sessionID := "100"
-	// start the session and emit data stream to it
-	firstMessage := []byte("hello")
-	err = alog.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// start the seession
-			&SessionChunk{
-				Time:       time.Now().UTC().UnixNano(),
-				EventIndex: 0,
-				EventType:  SessionStartEvent,
-				Data:       marshal(EventFields{EventLogin: "bob"}),
-			},
-			// type "hello" into session "100"
-			&SessionChunk{
-				Time:       time.Now().UTC().UnixNano(),
-				EventIndex: 1,
-				ChunkIndex: 0,
-				Offset:     0,
-				EventType:  SessionPrintEvent,
-				Data:       firstMessage,
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers.Len(), check.Equals, 1)
-
-	// send another event to the session via second auth server
-	secondMessage := []byte("good day")
-	err = alog2.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// notice how offsets are sent by the client
-			&SessionChunk{
-				Time:       time.Now().UTC().UnixNano(),
-				EventIndex: 2,
-				ChunkIndex: 1,
-				Offset:     int64(len(firstMessage)),
-				EventType:  SessionPrintEvent,
-				Data:       secondMessage,
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(alog2.loggers.Len(), check.Equals, 1)
-
-	// emit next event 17 milliseconds later to the second auth server
-	thirdMessage := []byte("test")
-	err = alog2.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// notice how offsets are sent by the client
-			&SessionChunk{
-				Time:       time.Now().Add(time.Hour).UTC().UnixNano(),
-				EventIndex: 3,
-				ChunkIndex: 2,
-				Offset:     int64(len(firstMessage) + len(secondMessage)),
-				EventType:  SessionPrintEvent,
-				Data:       thirdMessage,
-			},
-			// emitting session end event should close the session
-			&SessionChunk{
-				Time:       time.Now().Add(time.Hour).UTC().UnixNano(),
-				EventIndex: 4,
-				EventType:  SessionEndEvent,
-				Data:       marshal(EventFields{EventLogin: "bob"}),
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-
-	// emitting session end event should close the session on the second logger
-	c.Assert(alog2.loggers.Len(), check.Equals, 0)
-
-	// does not matter which audit server is accessed the results should be the same
-	for _, a := range []*AuditLog{alog, alog2} {
-		comment := check.Commentf("auth server %v", a.ServerID)
-
-		// search events, start time is in the future
-		query := fmt.Sprintf("%s=%s", EventType, SessionStartEvent)
-		found, err := a.SearchEvents(startTime.Add(48*time.Hour), startTime.Add(72*time.Hour), query, 0)
-		c.Assert(err, check.IsNil)
-		c.Assert(len(found), check.Equals, 0, comment)
-
-		// try searching (wrong query)
-		found, err = a.SearchEvents(startTime, startTime.Add(time.Hour), "foo=bar", 0)
-		c.Assert(err, check.IsNil)
-		c.Assert(len(found), check.Equals, 0, comment)
-
-		// try searching (good query: for "session start")
-		found, err = a.SearchEvents(startTime.Add(-time.Hour), startTime.Add(time.Hour), query, 0)
-		c.Assert(err, check.IsNil)
-		c.Assert(len(found), check.Equals, 1, comment)
-		c.Assert(found[0].GetString(EventLogin), check.Equals, "bob", comment)
-
-		// try searching (empty query means "anything")
-		found, err = alog.SearchEvents(startTime.Add(-time.Hour), startTime.Add(time.Hour), "", 0)
-		c.Assert(err, check.IsNil)
-		c.Assert(len(found), check.Equals, 2) // total number of events logged in this test
-		c.Assert(found[0].GetString(EventType), check.Equals, SessionStartEvent, comment)
-		c.Assert(found[1].GetString(EventType), check.Equals, SessionEndEvent, comment)
-
-		// limit to 1
-		found, err = alog.SearchEvents(startTime.Add(-time.Hour), startTime.Add(time.Hour), "", 1)
-		c.Assert(err, check.IsNil)
-		c.Assert(len(found), check.Equals, 1) // total number of events logged in this test
-	}
-}
-
-// TestSearchTwoAuthServersSameTime tests search on two auth servers behind the load balancer handling the event stream
-// for the same session emitted around the same time
-func (a *AuditTestSuite) TestSearchTwoAuthServersSameTime(c *check.C) {
-	startTime := time.Now().UTC()
-
-	alog, err := NewAuditLog(AuditLogConfig{
-		DataDir:        a.dataDir,
-		RecordSessions: true,
-		ServerID:       "server1",
-	})
-	c.Assert(err, check.IsNil)
-
-	alog2, err := NewAuditLog(AuditLogConfig{
-		DataDir:        a.dataDir,
-		RecordSessions: true,
-		ServerID:       "server2",
-	})
-	c.Assert(err, check.IsNil)
-
-	sessionID := "100"
-	// start the session and emit data stream to it
-	firstMessage := []byte("hello")
-	now := time.Now().UTC().UnixNano()
-	err = alog.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// start the seession
-			&SessionChunk{
-				Time:       now,
-				EventIndex: 0,
-				EventType:  SessionStartEvent,
-				Data:       marshal(EventFields{EventLogin: "bob"}),
-			},
-			// type "hello" into session "100"
-			&SessionChunk{
-				Time:       now,
-				EventIndex: 1,
-				ChunkIndex: 0,
-				Offset:     0,
-				EventType:  SessionPrintEvent,
-				Data:       firstMessage,
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers.Len(), check.Equals, 1)
-
-	// send another event to the session via second auth server
-	secondMessage := []byte("good day")
-	err = alog2.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// notice how offsets are sent by the client
-			&SessionChunk{
-				Time:       now,
-				EventIndex: 2,
-				ChunkIndex: 1,
-				Offset:     int64(len(firstMessage)),
-				EventType:  SessionPrintEvent,
-				Data:       secondMessage,
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(alog2.loggers.Len(), check.Equals, 1)
-
-	// emit next event 17 milliseconds later to the second auth server
-	thirdMessage := []byte("test")
-	err = alog2.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// notice how offsets are sent by the client
-			&SessionChunk{
-				Time:       now,
-				EventIndex: 3,
-				ChunkIndex: 2,
-				Offset:     int64(len(firstMessage) + len(secondMessage)),
-				EventType:  SessionPrintEvent,
-				Data:       thirdMessage,
-			},
-			// emitting session end event should close the session
-			&SessionChunk{
-				Time:       now,
-				EventIndex: 4,
-				EventType:  SessionEndEvent,
-				Data:       marshal(EventFields{EventLogin: "bob"}),
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-
-	// emitting session end event should close the session on the second logger
-	c.Assert(alog2.loggers.Len(), check.Equals, 0)
-
-	// does not matter which audit server is accessed the results should be the same
-	for _, a := range []*AuditLog{alog, alog2} {
-		comment := check.Commentf("auth server %v", a.ServerID)
-
-		// try searching (empty query means "anything")
-		found, err := alog.SearchEvents(startTime.Add(-time.Hour), startTime.Add(time.Hour), "", 0)
-		c.Assert(err, check.IsNil)
-		c.Assert(len(found), check.Equals, 2) // total number of events logged in this test
-		c.Assert(found[0].GetString(EventType), check.Equals, SessionStartEvent, comment)
-		c.Assert(found[1].GetString(EventType), check.Equals, SessionEndEvent, comment)
-	}
-}
-
-type file struct {
-	path     string
-	contents []byte
-}
-
-var v1Files = []file{
-	{
-		path: "2017-12-14.00:00:00.log",
-		contents: []byte(`{"event":"user.login","method":"oidc","time":"2017-12-13T17:38:34Z","user":"alice@example.com"}
-{"addr.local":"172.10.1.20:3022","addr.remote":"172.10.1.254:52406","event":"session.start","login":"root","namespace":"default","server_id":"3e79a2d7-c9e3-4d3f-96ce-1e1346b4900c","sid":"74a5fc73-e02c-11e7-aee2-0242ac0a0101","size":"80:25","time":"2017-12-13T17:38:40Z","user":"alice@example.com"}
-{"event":"session.leave","namespace":"default","server_id":"020130c8-b41f-4da5-a061-74c2b0e2b40b","sid":"75aef036-e02c-11e7-aee2-0242ac0a0101","time":"2017-12-13T17:38:42Z","user":"alice@example.com"}
-`),
-	},
-	{
-		path: "sessions/default/74a5fc73-e02c-11e7-aee2-0242ac0a0101.session.log",
-		contents: []byte(`{"addr.local":"172.10.1.20:3022","addr.remote":"172.10.1.254:52406","event":"session.start","login":"root","namespace":"default","server_id":"3e79a2d7-c9e3-4d3f-96ce-1e1346b4900c","sid":"74a5fc73-e02c-11e7-aee2-0242ac0a0101","size":"80:25","time":"2017-12-13T17:38:40Z","user":"alice@example.com"}
-{"event":"session.leave","namespace":"default","server_id":"3e79a2d7-c9e3-4d3f-96ce-1e1346b4900c","sid":"74a5fc73-e02c-11e7-aee2-0242ac0a0101","time":"2017-12-13T17:38:41Z","user":"alice@example.com"}
-{"time":"2017-12-13T17:38:40.038Z","event":"print","bytes":31,"ms":0,"offset":0}
-`),
-	},
-	{
-		path:     "sessions/default/74a5fc73-e02c-11e7-aee2-0242ac0a0101.session.bytes",
-		contents: []byte(`"this string is exactly 31 bytes"`),
-	},
 }
 
 func (a *AuditTestSuite) TestSessionRecordingOff(c *check.C) {
+	storageDir := c.MkDir()
+	fileHandler, err := filesessions.NewHandler(filesessions.Config{
+		Directory: storageDir,
+	})
+
 	now := time.Now().In(time.UTC).Round(time.Second)
 
 	// create audit log with session recording disabled
-	alog, err := a.makeLog(c, a.dataDir, false)
+	fakeClock := clockwork.NewFakeClockAt(now)
+
+	alog, err := NewAuditLog(AuditLogConfig{
+		Clock:          fakeClock,
+		DataDir:        a.dataDir,
+		RecordSessions: true,
+		ServerID:       "server1",
+		UploadHandler:  fileHandler,
+	})
 	c.Assert(err, check.IsNil)
-	alog.Clock = clockwork.NewFakeClockAt(now)
 
 	username := "alice"
 	sessionID := "200"
 
+	uploadDir := c.MkDir()
+	err = os.MkdirAll(filepath.Join(uploadDir, "upload", "sessions", defaults.Namespace), 0755)
+	forwarder, err := NewForwarder(ForwarderConfig{
+		Namespace:      defaults.Namespace,
+		SessionID:      session.ID(sessionID),
+		ServerID:       teleport.ComponentUpload,
+		DataDir:        uploadDir,
+		RecordSessions: false,
+		ForwardTo:      alog,
+		Clock:          fakeClock,
+	})
+	c.Assert(err, check.IsNil)
+
 	// start the session and emit data stream to it
 	firstMessage := []byte("hello")
-	err = alog.PostSessionSlice(SessionSlice{
+	err = forwarder.PostSessionSlice(SessionSlice{
 		Namespace: defaults.Namespace,
 		SessionID: sessionID,
 		Chunks: []*SessionChunk{
@@ -634,15 +276,17 @@ func (a *AuditTestSuite) TestSessionRecordingOff(c *check.C) {
 				Data:       marshal(EventFields{EventLogin: username}),
 			},
 		},
-		Version: V2,
+		Version: V3,
 	})
 	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers.Len(), check.Equals, 0)
+	c.Assert(forwarder.Close(), check.IsNil)
 
-	// get all events from the audit log, should have two events
+	upload(c, uploadDir, fakeClock, alog)
+
+	// get all events from the audit log, should have two session event and one upload event
 	found, err := alog.SearchEvents(now.Add(-time.Hour), now.Add(time.Hour), "", 0)
 	c.Assert(err, check.IsNil)
-	c.Assert(found, check.HasLen, 2)
+	c.Assert(found, check.HasLen, 3)
 	c.Assert(found[0].GetString(EventLogin), check.Equals, username)
 	c.Assert(found[1].GetString(EventLogin), check.Equals, username)
 
@@ -666,7 +310,7 @@ func (a *AuditTestSuite) TestBasicLogging(c *check.C) {
 	// emit regular event:
 	err = alog.EmitAuditEvent("user.joined", EventFields{"apples?": "yes"})
 	c.Assert(err, check.IsNil)
-	logfile := alog.file.Name()
+	logfile := alog.localLog.file.Name()
 	c.Assert(alog.Close(), check.IsNil)
 
 	// read back what's been written:
@@ -674,196 +318,6 @@ func (a *AuditTestSuite) TestBasicLogging(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(string(bytes), check.Equals,
 		fmt.Sprintf("{\"apples?\":\"yes\",\"event\":\"user.joined\",\"time\":\"%s\"}\n", now.Format(time.RFC3339)))
-}
-
-// TestAutoClose tests scenario with auto closing of inactive sessions
-func (a *AuditTestSuite) TestAutoClose(c *check.C) {
-	// create audit log, write a couple of events into it, close it
-	fakeClock := clockwork.NewFakeClock()
-	alog, err := NewAuditLog(AuditLogConfig{
-		DataDir:        a.dataDir,
-		RecordSessions: true,
-		Clock:          fakeClock,
-		ServerID:       "autoclose1",
-	})
-	c.Assert(err, check.IsNil)
-
-	sessionID := "100"
-	// start the session and emit data stream to it
-	firstMessage := []byte("hello")
-	err = alog.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// start the seession
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				EventIndex: 0,
-				EventType:  SessionStartEvent,
-				Data:       marshal(EventFields{EventLogin: "bob"}),
-			},
-			// type "hello" into session "100"
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				EventIndex: 1,
-				ChunkIndex: 0,
-				Offset:     0,
-				EventType:  SessionPrintEvent,
-				Data:       firstMessage,
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers.Len(), check.Equals, 1)
-
-	// now fake sleep past expiration
-	firstDelay := defaults.SessionIdlePeriod * 2
-	fakeClock.Advance(firstDelay)
-
-	// logger for idle session should be closed
-	alog.closeInactiveLoggers()
-	c.Assert(alog.loggers.Len(), check.Equals, 0)
-
-	// send another event to the session
-	secondMessage := []byte("good day")
-	err = alog.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// notice how offsets are sent by the client
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				Delay:      int64(firstDelay / time.Millisecond),
-				EventIndex: 2,
-				ChunkIndex: 1,
-				Offset:     int64(len(firstMessage)),
-				EventType:  SessionPrintEvent,
-				Data:       secondMessage,
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers.Len(), check.Equals, 1)
-
-	// emit next event 17 milliseconds later
-	thirdMessage := []byte("test")
-	secondDelay := 17 * time.Millisecond
-	fakeClock.Advance(secondDelay)
-	err = alog.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: sessionID,
-		Chunks: []*SessionChunk{
-			// notice how offsets are sent by the client
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				EventIndex: 3,
-				ChunkIndex: 2,
-				Delay:      int64((firstDelay + secondDelay) / time.Millisecond),
-				Offset:     int64(len(firstMessage) + len(secondMessage)),
-				EventType:  SessionPrintEvent,
-				Data:       thirdMessage,
-			},
-			// emitting session end event should close the session
-			&SessionChunk{
-				Time:       fakeClock.Now().UTC().UnixNano(),
-				EventIndex: 4,
-				EventType:  SessionEndEvent,
-				Data:       marshal(EventFields{EventLogin: "bob"}),
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-
-	// emitting session end event should close the session
-	c.Assert(alog.loggers.Len(), check.Equals, 0)
-
-	// read the session bytes
-	history, err := alog.GetSessionEvents(defaults.Namespace, session.ID(sessionID), 1, true)
-	c.Assert(err, check.IsNil)
-	c.Assert(history, check.HasLen, 4)
-
-	// make sure offsets were properly set (0 for the first event and 5 bytes for hello):
-	c.Assert(history[0][SessionByteOffset], check.Equals, float64(0))
-	c.Assert(history[1][SessionByteOffset], check.Equals, float64(len(firstMessage)))
-	c.Assert(history[2][SessionByteOffset], check.Equals, float64(len(firstMessage)+len(secondMessage)))
-
-	// make sure delays are right
-	c.Assert(history[0][SessionEventTimestamp], check.Equals, float64(0))
-	c.Assert(history[1][SessionEventTimestamp], check.Equals, float64(firstDelay/time.Millisecond))
-	c.Assert(history[2][SessionEventTimestamp], check.Equals, float64((firstDelay+secondDelay)/time.Millisecond))
-
-	// Cleanup old playbacks
-	// Fetch chunks so playback directory will be populated
-	data, err := alog.GetSessionChunk(defaults.Namespace, session.ID(sessionID), 0, 5000)
-	c.Assert(err, check.IsNil)
-	c.Assert(string(data), check.Equals, "hellogood daytest")
-
-	// two files were unpacked in playback dir
-	c.Assert(listFiles(alog.playbackDir), check.HasLen, 2)
-
-	// first cleanup did not delete files
-	alog.Clock = clockwork.NewFakeClockAt(time.Now().UTC())
-	c.Assert(alog.cleanupOldPlaybacks(), check.IsNil)
-	c.Assert(listFiles(alog.playbackDir), check.HasLen, 2)
-
-	// Advance clock past cleanup TTL, files were cleaned up
-	alog.Clock = clockwork.NewFakeClockAt(time.Now().UTC().Add(alog.PlaybackRecycleTTL + time.Minute))
-	c.Assert(alog.cleanupOldPlaybacks(), check.IsNil)
-	c.Assert(listFiles(alog.playbackDir), check.HasLen, 0)
-}
-
-func listFiles(name string) []string {
-	df, err := os.Open(name)
-	if err != nil {
-		panic(err)
-	}
-	defer df.Close()
-	entries, err := df.Readdir(-1)
-	if err != nil {
-		panic(err)
-	}
-	var out []string
-	for i := range entries {
-		fi := entries[i]
-		if !fi.IsDir() {
-			out = append(out, fi.Name())
-		}
-	}
-	return out
-}
-
-// TestCloseOutstanding makes sure the logger closed outstanding sessions
-func (a *AuditTestSuite) TestCloseOutstanding(c *check.C) {
-	// create audit log, write a couple of events into it, close it
-	fakeClock := clockwork.NewFakeClock()
-	alog, err := NewAuditLog(AuditLogConfig{
-		DataDir:        a.dataDir,
-		RecordSessions: true,
-		Clock:          fakeClock,
-		ServerID:       "outstanding",
-	})
-	c.Assert(err, check.IsNil)
-	// start the session and emit data stream to it
-	err = alog.PostSessionSlice(SessionSlice{
-		Namespace: defaults.Namespace,
-		SessionID: "100",
-		Chunks: []*SessionChunk{
-			&SessionChunk{
-				EventIndex: 0,
-				EventType:  SessionStartEvent,
-				Data:       marshal(EventFields{EventLogin: "bob"}),
-			},
-		},
-		Version: V2,
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(alog.loggers.Len(), check.Equals, 1)
-
-	alog.Close()
-	c.Assert(alog.loggers.Len(), check.Equals, 0)
 }
 
 // TestForwardAndUpload tests forwarding server and upload
@@ -874,14 +328,7 @@ func (a *AuditTestSuite) TestForwardAndUpload(c *check.C) {
 		Directory: storageDir,
 	})
 
-	// start uploader and make sure it uploads event to the event
-	// storage
-
-	uploadDir := c.MkDir()
-	err = os.MkdirAll(filepath.Join(uploadDir, "upload", "sessions", defaults.Namespace), 0755)
-
 	fakeClock := clockwork.NewFakeClock()
-
 	alog, err := NewAuditLog(AuditLogConfig{
 		DataDir:        a.dataDir,
 		RecordSessions: true,
@@ -890,6 +337,44 @@ func (a *AuditTestSuite) TestForwardAndUpload(c *check.C) {
 		UploadHandler:  fileHandler,
 	})
 	c.Assert(err, check.IsNil)
+	defer alog.Close()
+
+	a.forwardAndUpload(c, fakeClock, alog)
+}
+
+// TestExternalLog tests forwarding server and upload
+// server case
+func (a *AuditTestSuite) TestExternalLog(c *check.C) {
+	storageDir := c.MkDir()
+	fileHandler, err := filesessions.NewHandler(filesessions.Config{
+		Directory: storageDir,
+	})
+
+	fileLog, err := NewFileLog(FileLogConfig{
+		Dir: c.MkDir(),
+	})
+	c.Assert(err, check.IsNil)
+
+	fakeClock := clockwork.NewFakeClock()
+	alog, err := NewAuditLog(AuditLogConfig{
+		DataDir:        a.dataDir,
+		RecordSessions: true,
+		Clock:          fakeClock,
+		ServerID:       "remote",
+		UploadHandler:  fileHandler,
+		ExternalLog:    fileLog,
+	})
+	c.Assert(err, check.IsNil)
+	defer alog.Close()
+
+	a.forwardAndUpload(c, fakeClock, alog)
+}
+
+// forwardAndUpload tests forwarding server and upload
+// server case
+func (a *AuditTestSuite) forwardAndUpload(c *check.C, fakeClock clockwork.Clock, alog IAuditLog) {
+	uploadDir := c.MkDir()
+	err := os.MkdirAll(filepath.Join(uploadDir, "upload", "sessions", defaults.Namespace), 0755)
 
 	sessionID := session.ID("100")
 	forwarder, err := NewForwarder(ForwarderConfig{
@@ -937,31 +422,7 @@ func (a *AuditTestSuite) TestForwardAndUpload(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(forwarder.Close(), check.IsNil)
 
-	// start uploader process
-	eventsC := make(chan *UploadEvent, 100)
-	uploader, err := NewUploader(UploaderConfig{
-		ServerID:   "upload",
-		DataDir:    uploadDir,
-		Clock:      fakeClock,
-		Namespace:  defaults.Namespace,
-		Context:    context.TODO(),
-		ScanPeriod: 100 * time.Millisecond,
-		AuditLog:   alog,
-		EventsC:    eventsC,
-	})
-	c.Assert(err, check.IsNil)
-
-	// scanner should upload the events
-	err = uploader.scan()
-	c.Assert(err, check.IsNil)
-
-	select {
-	case event := <-eventsC:
-		c.Assert(event, check.NotNil)
-		c.Assert(event.Error, check.IsNil)
-	case <-time.After(time.Second):
-		c.Fatalf("Timeout wating for the upload event")
-	}
+	upload(c, uploadDir, fakeClock, alog)
 
 	compare := func() error {
 		history, err := alog.GetSessionEvents(defaults.Namespace, session.ID(sessionID), 0, true)

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -1,0 +1,479 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	log "github.com/sirupsen/logrus"
+)
+
+// FileLogConfig is a configuration for file log
+type FileLogConfig struct {
+	// RotationPeriod defines how frequently to rotate the log file
+	RotationPeriod time.Duration
+	// Dir is a directory where logger puts the files
+	Dir string
+	// Clock is a clock interface, used in tests
+	Clock clockwork.Clock
+	// SearchDirs is a function that returns
+	// search directories, if not set, only Dir is used
+	SearchDirs func() ([]string, error)
+}
+
+// CheckAndSetDefaults checks and sets config defaults
+func (cfg *FileLogConfig) CheckAndSetDefaults() error {
+	if cfg.Dir == "" {
+		return trace.BadParameter("missing parameter Dir")
+	}
+	if !utils.IsDir(cfg.Dir) {
+		return trace.BadParameter("path %q does not exist or is not a directory", cfg.Dir)
+	}
+	if cfg.RotationPeriod == 0 {
+		cfg.RotationPeriod = defaults.LogRotationPeriod
+	}
+	if cfg.Clock == nil {
+		cfg.Clock = clockwork.NewRealClock()
+	}
+	return nil
+}
+
+// NewFileLog returns a new instance of a file log
+func NewFileLog(cfg FileLogConfig) (*FileLog, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	f := &FileLog{
+		FileLogConfig: cfg,
+		Entry: log.WithFields(log.Fields{
+			trace.Component: teleport.ComponentAuditLog,
+		}),
+	}
+	return f, nil
+}
+
+// FileLog is a file local audit events log,
+// logs all events to the local file in json encoded form
+type FileLog struct {
+	*log.Entry
+	FileLogConfig
+	sync.Mutex
+	// file is the current global event log file. As the time goes
+	// on, it will be replaced by a new file every day
+	file *os.File
+	// fileTime is a rounded (to a day, by default) timestamp of the
+	// currently opened file
+	fileTime time.Time
+}
+
+// EmitAuditEvent adds a new event to the log. Part of auth.IFileLog interface.
+func (l *FileLog) EmitAuditEvent(eventType string, fields EventFields) error {
+	// see if the log needs to be rotated
+	if err := l.rotateLog(); err != nil {
+		log.Error(err)
+	}
+
+	// set event type and time:
+	fields[EventType] = eventType
+	if _, ok := fields[EventTime]; !ok {
+		fields[EventTime] = l.Clock.Now().In(time.UTC).Round(time.Second)
+	}
+	// line is the text to be logged
+	line, err := json.Marshal(fields)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// log it to the main log file:
+	if l.file != nil {
+		fmt.Fprintln(l.file, string(line))
+	}
+	return nil
+}
+
+// SearchEvents finds events. Results show up sorted by date (newest first),
+// limit is used when set to value > 0
+func (l *FileLog) SearchEvents(fromUTC, toUTC time.Time, query string, limit int) ([]EventFields, error) {
+	l.Debugf("SearchEvents(%v, %v, query=%v, limit=%v)", fromUTC, toUTC, query, limit)
+	if limit <= 0 {
+		limit = defaults.EventsIterationLimit
+	}
+	if limit > defaults.EventsMaxIterationLimit {
+		return nil, trace.BadParameter("limit %v exceeds max iteration limit %v", limit, defaults.MaxIterationLimit)
+	}
+	// how many days of logs to search?
+	days := int(toUTC.Sub(fromUTC).Hours() / 24)
+	if days < 0 {
+		return nil, trace.BadParameter("query", query)
+	}
+	queryVals, err := url.ParseQuery(query)
+	if err != nil {
+		return nil, trace.BadParameter("missing parameter query", query)
+	}
+	filtered, err := l.matchingFiles(fromUTC, toUTC)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var total int
+	// search within each file:
+	events := make([]EventFields, 0)
+	for i := range filtered {
+		found, err := l.findInFile(filtered[i].path, queryVals, &total, limit)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		events = append(events, found...)
+		if limit > 0 && total >= limit {
+			break
+		}
+	}
+	// sort all accepted files by timestamp or by event index
+	// in case if events are associated with the same session, to make
+	// sure that events are not displayed out of order in case of multiple
+	// auth servers.
+	sort.Sort(ByTimeAndIndex(events))
+	return events, nil
+}
+
+// SearchSessionEvents searches for session related events. Used to find completed sessions.
+func (l *FileLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int) ([]EventFields, error) {
+	l.Debugf("SearchSessionEvents(%v, %v, %v)", fromUTC, toUTC, limit)
+
+	// only search for specific event types
+	query := url.Values{}
+	query[EventType] = []string{
+		SessionStartEvent,
+		SessionEndEvent,
+	}
+
+	// because of the limit and distributed nature of auth server event
+	// logs, some events can be fetched with session end event and without
+	// session start event. to fix this, the code below filters out the events without
+	// start event to guarantee that all events in the range will get fetched
+	events, err := l.SearchEvents(fromUTC, toUTC, query.Encode(), limit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// filter out 'session end' events that do not
+	// have a corresponding 'session start' event
+	started := make(map[string]struct{}, len(events)/2)
+	filtered := make([]EventFields, 0, len(events))
+	for i := range events {
+		event := events[i]
+		eventType := event[EventType]
+		sessionID := event.GetString(SessionEventID)
+		if sessionID == "" {
+			continue
+		}
+		if eventType == SessionStartEvent {
+			started[sessionID] = struct{}{}
+			filtered = append(filtered, event)
+		}
+		if eventType == SessionEndEvent {
+			if _, ok := started[sessionID]; ok {
+				filtered = append(filtered, event)
+			}
+		}
+	}
+
+	return filtered, nil
+}
+
+// Close closes the audit log, which inluces closing all file handles and releasing
+// all session loggers
+func (l *FileLog) Close() error {
+	l.Lock()
+	defer l.Unlock()
+
+	var err error
+	if l.file != nil {
+		err = l.file.Close()
+		l.file = nil
+	}
+	return err
+}
+
+func (l *FileLog) WaitForDelivery(context.Context) error {
+	return nil
+}
+
+func (l *FileLog) UploadSessionRecording(SessionRecording) error {
+	return trace.NotImplemented("not implemented")
+}
+
+func (l *FileLog) PostSessionSlice(slice SessionSlice) error {
+	if slice.Namespace == "" {
+		return trace.BadParameter("missing parameter Namespace")
+	}
+	if len(slice.Chunks) == 0 {
+		return trace.BadParameter("missing session chunks")
+	}
+	if slice.Version < V3 {
+		return trace.BadParameter("audit log rejected V%v log entry, upgrade your components.", slice.Version)
+	}
+	// V3 API does not write session log to local session directory,
+	// instead it writes locally, this internal method captures
+	// non-print events to the global audit log
+	return l.processSlice(nil, &slice)
+}
+
+func (l *FileLog) processSlice(sl SessionLogger, slice *SessionSlice) error {
+	for _, chunk := range slice.Chunks {
+		if chunk.EventType == SessionPrintEvent || chunk.EventType == "" {
+			continue
+		}
+		fields, err := EventFromChunk(slice.SessionID, chunk)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if err := l.EmitAuditEvent(chunk.EventType, fields); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+func (l *FileLog) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
+	return nil, trace.NotImplemented("not implemented")
+}
+
+func (l *FileLog) GetSessionEvents(namespace string, sid session.ID, after int, fetchPrintEvents bool) ([]EventFields, error) {
+	return nil, trace.NotImplemented("not implemented")
+}
+
+// rotateLog checks if the current log file is older than a given duration,
+// and if it is, closes it and opens a new one.
+func (l *FileLog) rotateLog() (err error) {
+	l.Lock()
+	defer l.Unlock()
+
+	// determine the timestamp for the current log file
+	fileTime := l.Clock.Now().In(time.UTC).Round(l.RotationPeriod)
+
+	openLogFile := func() error {
+		logfname := filepath.Join(l.Dir,
+			fileTime.Format(defaults.AuditLogTimeFormat)+LogfileExt)
+		l.file, err = os.OpenFile(logfname, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+		if err != nil {
+			log.Error(err)
+		}
+
+		l.fileTime = fileTime
+		return trace.Wrap(err)
+	}
+
+	// need to create a log file?
+	if l.file == nil {
+		return openLogFile()
+	}
+
+	// time to advance the logfile?
+	if l.fileTime.Before(fileTime) {
+		l.file.Close()
+		return openLogFile()
+	}
+	return nil
+}
+
+// matchingFiles returns files matching the time restrictions of the query
+// across multiple auth servers, returns a list of file names
+func (l *FileLog) matchingFiles(fromUTC, toUTC time.Time) ([]eventFile, error) {
+	var dirs []string
+	var err error
+	if l.SearchDirs != nil {
+		dirs, err = l.SearchDirs()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		dirs = []string{l.Dir}
+	}
+
+	var filtered []eventFile
+	for _, dir := range dirs {
+		// scan the log directory:
+		df, err := os.Open(dir)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		defer df.Close()
+		entries, err := df.Readdir(-1)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		for i := range entries {
+			fi := entries[i]
+			if fi.IsDir() || filepath.Ext(fi.Name()) != LogfileExt {
+				continue
+			}
+			base := strings.TrimSuffix(fi.Name(), filepath.Ext(fi.Name()))
+			fd, err := time.Parse(defaults.AuditLogTimeFormat, base)
+			if err != nil {
+				l.Warningf("Failed to parse audit log file %q format: %v", base, err)
+				continue
+			}
+			// File rounding in current logs is non-deterministic,
+			// as Round function used in rotateLog can round up to the lowest
+			// or the highest period. That's why this has to check both
+			// periods.
+			// Previous logic used modification time what was flaky
+			// as it could be changed by migrations or simply moving files
+			if fd.After(fromUTC.Add(-1*l.RotationPeriod)) && fd.Before(toUTC.Add(l.RotationPeriod)) {
+				eventFile := eventFile{
+					FileInfo: fi,
+					path:     filepath.Join(dir, fi.Name()),
+				}
+				filtered = append(filtered, eventFile)
+			}
+		}
+	}
+	// sort all accepted files by date
+	sort.Sort(byDate(filtered))
+	return filtered, nil
+}
+
+// findInFile scans a given log file and returns events that fit the criteria
+// This simplistic implementation ONLY SEARCHES FOR EVENT TYPE(s)
+//
+// You can pass multiple types like "event=session.start&event=session.end"
+func (l *FileLog) findInFile(fn string, query url.Values, total *int, limit int) ([]EventFields, error) {
+	l.Debugf("Called findInFile(%s, %v).", fn, query)
+	retval := make([]EventFields, 0)
+
+	eventFilter, ok := query[EventType]
+	if !ok && len(query) > 0 {
+		return nil, nil
+	}
+	doFilter := len(eventFilter) > 0
+
+	// open the log file:
+	lf, err := os.OpenFile(fn, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer lf.Close()
+
+	// for each line...
+	scanner := bufio.NewScanner(lf)
+	for lineNo := 0; scanner.Scan(); lineNo++ {
+		accepted := false
+		// optimization: to avoid parsing JSON unnecessarily, lets see if we
+		// can filter out lines that don't even have the requested event type on the line
+		for i := range eventFilter {
+			if strings.Contains(scanner.Text(), eventFilter[i]) {
+				accepted = true
+				break
+			}
+		}
+		if doFilter && !accepted {
+			continue
+		}
+		// parse JSON on the line and compare event type field to what's
+		// in the query:
+		var ef EventFields
+		if err = json.Unmarshal(scanner.Bytes(), &ef); err != nil {
+			l.Warnf("invalid JSON in %s line %d", fn, lineNo)
+			continue
+		}
+		for i := range eventFilter {
+			if ef.GetString(EventType) == eventFilter[i] {
+				accepted = true
+				break
+			}
+		}
+		if accepted || !doFilter {
+			retval = append(retval, ef)
+			*total += 1
+			if limit > 0 && *total >= limit {
+				break
+			}
+		}
+	}
+	return retval, nil
+}
+
+type eventFile struct {
+	os.FileInfo
+	path string
+}
+
+// byDate implements sort.Interface.
+type byDate []eventFile
+
+func (f byDate) Len() int           { return len(f) }
+func (f byDate) Less(i, j int) bool { return f[i].ModTime().Before(f[j].ModTime()) }
+func (f byDate) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }
+
+// ByTimeAndIndex sorts events by time extracting timestamp from JSON field
+// and if there are several session events with the same session
+// by event index, regardless of the time
+type ByTimeAndIndex []EventFields
+
+func (f ByTimeAndIndex) Len() int {
+	return len(f)
+}
+
+func (f ByTimeAndIndex) Less(i, j int) bool {
+	itime := getTime(f[i][EventTime])
+	jtime := getTime(f[j][EventTime])
+	if itime.Equal(jtime) && f[i][SessionEventID] == f[j][SessionEventID] {
+		return getEventIndex(f[i][EventIndex]) < getEventIndex(f[j][EventIndex])
+	}
+	return itime.Before(jtime)
+}
+
+func (f ByTimeAndIndex) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+// getTime converts json time to string
+func getTime(v interface{}) time.Time {
+	sval, ok := v.(string)
+	if !ok {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, sval)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+func getEventIndex(v interface{}) float64 {
+	switch val := v.(type) {
+	case float64:
+		return val
+	}
+	return 0
+}

--- a/lib/events/forward.go
+++ b/lib/events/forward.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 )
 
 // ForwarderConfig forwards session log events
@@ -26,6 +27,8 @@ type ForwarderConfig struct {
 	Namespace string
 	// ForwardTo is the audit log to forward non-print events to
 	ForwardTo IAuditLog
+	// Clock is a clock to set for tests
+	Clock clockwork.Clock
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -35,6 +38,9 @@ func (s *ForwarderConfig) CheckAndSetDefaults() error {
 	}
 	if s.DataDir == "" {
 		return trace.BadParameter("missing data dir")
+	}
+	if s.Clock == nil {
+		s.Clock = clockwork.NewRealClock()
 	}
 	return nil
 }
@@ -50,6 +56,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 		RecordSessions: cfg.RecordSessions,
 		Namespace:      cfg.Namespace,
 		ServerID:       cfg.ServerID,
+		Clock:          cfg.Clock,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/events/multilog.go
+++ b/lib/events/multilog.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/teleport/lib/session"
+
+	"github.com/gravitational/trace"
+)
+
+// NewMultiLog returns a new instance of a multi logger
+func NewMultiLog(loggers ...IAuditLog) *MultiLog {
+	return &MultiLog{
+		loggers: loggers,
+	}
+}
+
+// MultiLog is a logger that fan outs write operations
+// to all loggers, and performs all read and search operations
+// on the first logger that implements the operation
+type MultiLog struct {
+	loggers []IAuditLog
+}
+
+// WaitForDelivery waits for resources to be released and outstanding requests to
+// complete after calling Close method
+func (m *MultiLog) WaitForDelivery(ctx context.Context) error {
+	return nil
+}
+
+// Closer releases connections and resources associated with logs if any
+func (m *MultiLog) Close() error {
+	var errors []error
+	for _, log := range m.loggers {
+		errors = append(errors, log.Close())
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// EmitAuditEvent emits audit event
+func (m *MultiLog) EmitAuditEvent(eventType string, fields EventFields) error {
+	var errors []error
+	for _, log := range m.loggers {
+		errors = append(errors, log.EmitAuditEvent(eventType, fields))
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// UploadSessionRecording uploads session recording to the audit server
+func (m *MultiLog) UploadSessionRecording(rec SessionRecording) error {
+	var errors []error
+	for _, log := range m.loggers {
+		errors = append(errors, log.UploadSessionRecording(rec))
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// DELETE IN: 2.7.0
+// This method is no longer necessary as nodes and proxies >= 2.7.0
+// use UploadSessionRecording method.
+// PostSessionSlice sends chunks of recorded session to the event log
+func (m *MultiLog) PostSessionSlice(slice SessionSlice) error {
+	var errors []error
+	for _, log := range m.loggers {
+		errors = append(errors, log.PostSessionSlice(slice))
+	}
+	return trace.NewAggregate(errors...)
+}
+
+// GetSessionChunk returns a reader which can be used to read a byte stream
+// of a recorded session starting from 'offsetBytes' (pass 0 to start from the
+// beginning) up to maxBytes bytes.
+//
+// If maxBytes > MaxChunkBytes, it gets rounded down to MaxChunkBytes
+func (m *MultiLog) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) (data []byte, err error) {
+	for _, log := range m.loggers {
+		data, err = log.GetSessionChunk(namespace, sid, offsetBytes, maxBytes)
+		if !trace.IsNotImplemented(err) {
+			return data, err
+		}
+	}
+	return data, err
+}
+
+// Returns all events that happen during a session sorted by time
+// (oldest first).
+//
+// after tells to use only return events after a specified cursor Id
+//
+// This function is usually used in conjunction with GetSessionReader to
+// replay recorded session streams.
+func (m *MultiLog) GetSessionEvents(namespace string, sid session.ID, after int, fetchPrintEvents bool) (events []EventFields, err error) {
+	for _, log := range m.loggers {
+		events, err = log.GetSessionEvents(namespace, sid, after, fetchPrintEvents)
+		if !trace.IsNotImplemented(err) {
+			return events, err
+		}
+	}
+	return events, err
+}
+
+// SearchEvents is a flexible way to find events. The format of a query string
+// depends on the implementing backend. A recommended format is urlencoded
+// (good enough for Lucene/Solr)
+//
+// Pagination is also defined via backend-specific query format.
+//
+// The only mandatory requirement is a date range (UTC). Results must always
+// show up sorted by date (newest first)
+func (m *MultiLog) SearchEvents(fromUTC, toUTC time.Time, query string, limit int) (events []EventFields, err error) {
+	for _, log := range m.loggers {
+		events, err = log.SearchEvents(fromUTC, toUTC, query, limit)
+		if !trace.IsNotImplemented(err) {
+			return events, err
+		}
+	}
+	return events, err
+}
+
+// SearchSessionEvents returns session related events only. This is used to
+// find completed session.
+func (m *MultiLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int) (events []EventFields, err error) {
+	for _, log := range m.loggers {
+		events, err = log.SearchSessionEvents(fromUTC, toUTC, limit)
+		if !trace.IsNotImplemented(err) {
+			return events, err
+		}
+	}
+	return events, err
+}

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -148,7 +148,7 @@ func (u *Uploader) Serve() error {
 			u.Debugf("Uploader is exiting.")
 			return nil
 		case <-t.C:
-			if err := u.scan(); err != nil {
+			if err := u.Scan(); err != nil {
 				if trace.Unwrap(err) != errContext {
 					u.Warningf("Uploader scan failed: %v", trace.DebugReport(err))
 				}
@@ -268,7 +268,8 @@ func (u *Uploader) uploadFile(lockFilePath string, sessionID session.ID) error {
 	return nil
 }
 
-func (u *Uploader) scan() error {
+// Scan scans the directory and uploads recordings
+func (u *Uploader) Scan() error {
 	df, err := os.Open(u.scanDir)
 	err = trace.ConvertSystemError(err)
 	if err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -725,32 +725,69 @@ func initUploadHandler(auditConfig services.AuditConfig) (events.UploadHandler, 
 	default:
 		return nil, trace.BadParameter(
 			"unsupported scheme for audit_sesions_uri: %q, currently supported schemes are %q and %q",
-			uri.Scheme, teleport.SchemeS3)
+			uri.Scheme, teleport.SchemeS3, teleport.SchemeFile)
 	}
 }
 
 // initExternalLog initializes external storage, if the storage is not
 // setup, returns nil
 func initExternalLog(auditConfig services.AuditConfig) (events.IAuditLog, error) {
-	if auditConfig.Type == "" {
-		if auditConfig.AuditTableName != "" {
-			return nil, trace.BadParameter("no storage type defined for table name %q in config %#v", auditConfig.AuditTableName, auditConfig)
-		}
-		return nil, trace.NotFound("no external log is defined")
+	if auditConfig.AuditTableName != "" {
+		auditConfig.AuditEventsURI = append(auditConfig.AuditEventsURI, fmt.Sprintf("%v://%v", dynamo.GetName(), auditConfig.AuditTableName))
 	}
-	if auditConfig.AuditTableName == "" {
-		return nil, trace.NotFound("no external log is defined")
-	}
-	if auditConfig.Type != dynamo.GetName() {
-		return nil, trace.BadParameter("unsupported events backend %q, the only supported backend is %q", auditConfig.Type, dynamo.GetName())
-	}
-	if !auditConfig.ShouldUploadSessions() {
+	if len(auditConfig.AuditEventsURI) > 0 && !auditConfig.ShouldUploadSessions() {
 		return nil, trace.BadParameter("please specify audit_sessions_uri when using external audit backends")
 	}
-	return dynamoevents.New(dynamoevents.Config{
-		Tablename: auditConfig.AuditTableName,
-		Region:    auditConfig.Region,
-	})
+	var hasNonFileLog bool
+	var loggers []events.IAuditLog
+	for _, eventsURI := range auditConfig.AuditEventsURI {
+		uri, err := utils.ParseSessionsURI(eventsURI)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		switch uri.Scheme {
+		case dynamo.GetName():
+			hasNonFileLog = true
+			logger, err := dynamoevents.New(dynamoevents.Config{
+				Tablename: uri.Host,
+				Region:    auditConfig.Region,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			loggers = append(loggers, logger)
+		case teleport.SchemeFile:
+			logger, err := events.NewFileLog(events.FileLogConfig{
+				Dir: uri.Path,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			loggers = append(loggers, logger)
+		default:
+			return nil, trace.BadParameter(
+				"unsupported scheme for audit_events_uri: %q, currently supported schemes are %q and %q",
+				uri.Scheme, dynamo.GetName(), teleport.SchemeFile)
+		}
+	}
+	// only file external loggers are prohibited (they are not supposed
+	// to be used on their own, only in combo with external loggers)
+	// they also don't implement certain features, so they are going
+	// to be inefficient
+	switch len(loggers) {
+	case 0:
+		return nil, trace.NotFound("no external log is defined")
+	case 1:
+		if !hasNonFileLog {
+			return nil, trace.BadParameter("file:// log can not be used on it's own, can be only used in combination with external session logs, e.g. dynamodb://")
+		}
+		return loggers[0], nil
+	default:
+		if !hasNonFileLog {
+			return nil, trace.BadParameter("file:// log can not be used on it's own, can be only used in combination with external session logs, e.g. dynamodb://")
+		}
+		return events.NewMultiLog(loggers...), nil
+	}
 }
 
 // initAuthService can be called to initialize auth server service

--- a/lib/services/clusterconfig.go
+++ b/lib/services/clusterconfig.go
@@ -121,7 +121,12 @@ type AuditConfig struct {
 	Region string `json:"region,omitempty"`
 	// AuditSessionsURI is a parameter where to upload sessions
 	AuditSessionsURI string `json:"audit_sessions_uri,omitempty"`
+	// AuditEventsURI is a parameter with all supported outputs
+	// for audit events
+	AuditEventsURI utils.Strings `json:"audit_events_uri,omitempty"`
 	// AuditTableName is a DB table name used for audits
+	// Deprecated in favor of AuditEventsURI
+	// DELETE IN (3.1.0)
 	AuditTableName string `json:"audit_table_name,omitempty"`
 }
 

--- a/lib/utils/conv.go
+++ b/lib/utils/conv.go
@@ -53,10 +53,10 @@ import (
 func ObjectToStruct(in interface{}, out interface{}) error {
 	bytes, err := json.Marshal(in)
 	if err != nil {
-		return trace.Wrap(err, fmt.Sprintf("failed to marshal: %v", in))
+		return trace.Wrap(err, fmt.Sprintf("failed to marshal %v, %v", in, err))
 	}
 	if err := json.Unmarshal([]byte(bytes), out); err != nil {
-		return trace.Wrap(err, fmt.Sprintf("failed to unmarshal %v into %T", in, out))
+		return trace.Wrap(err, fmt.Sprintf("failed to unmarshal %v into %T, %v", in, out, err))
 	}
 	return nil
 }

--- a/vendor/github.com/gravitational/trace/errors.go
+++ b/vendor/github.com/gravitational/trace/errors.go
@@ -146,6 +146,43 @@ func IsBadParameter(e error) bool {
 	return ok
 }
 
+// NotImplemented returns a new instance of NotImplementedError
+func NotImplemented(message string, args ...interface{}) error {
+	return WrapWithMessage(&NotImplementedError{
+		Message: fmt.Sprintf(message, args...),
+	}, message, args...)
+}
+
+// NotImplementedError defines an error condition to describe the result
+// of a call to an unimplemented API
+type NotImplementedError struct {
+	Message string `json:"message"`
+}
+
+// Error returns log friendly description of an error
+func (e *NotImplementedError) Error() string {
+	return e.Message
+}
+
+// OrigError returns original error
+func (e *NotImplementedError) OrigError() error {
+	return e
+}
+
+// IsNotImplementedError indicates that this error is of NotImplementedError type
+func (e *NotImplementedError) IsNotImplementedError() bool {
+	return true
+}
+
+// IsNotImplemented returns whether this error is of NotImplementedError type
+func IsNotImplemented(e error) bool {
+	type ni interface {
+		IsNotImplementedError() bool
+	}
+	err, ok := Unwrap(e).(ni)
+	return ok && err.IsNotImplementedError()
+}
+
 // CompareFailed returns new instance of CompareFailedError
 func CompareFailed(message string, args ...interface{}) error {
 	return WrapWithMessage(&CompareFailedError{Message: fmt.Sprintf(message, args...)}, message, args...)
@@ -338,8 +375,8 @@ func IsLimitExceeded(e error) bool {
 // TrustError indicates trust-related validation error (e.g. untrusted cert)
 type TrustError struct {
 	// Err is original error
-	Err     error `json:"error"`
-	Message string
+	Err     error  `json:"-"`
+	Message string `json:"message"`
 }
 
 // Error returns log-friendly error description

--- a/vendor/github.com/gravitational/trace/trace.go
+++ b/vendor/github.com/gravitational/trace/trace.go
@@ -249,7 +249,7 @@ func (e *TraceErr) UserMessage() string {
 	if e.Message != "" {
 		return e.Message
 	}
-	return e.Err.Error()
+	return UserMessage(e.Err)
 }
 
 // DebugReport returns develeoper-friendly error report
@@ -259,9 +259,6 @@ func (e *TraceErr) DebugReport() string {
 
 // Error returns user-friendly error message when not in debug mode
 func (e *TraceErr) Error() string {
-	if IsDebug() {
-		return e.DebugReport()
-	}
 	return e.UserMessage()
 }
 


### PR DESCRIPTION
This commit implements #2070

```yaml
teleport:
  storage:
    type: dir
    audit_events_uri:  [file:///var/lib/teleport/events, dynamodb://test_grv8_events]
    audit_sessions_uri: s3://testgrv8records
```