### PR TITLE
Support configurable cipher suites.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -159,6 +159,9 @@ type AuthServer struct {
 
 	// kubeCACertPath is a path to kubernetes certificate authority
 	kubeCACertPath string
+
+	// cipherSuites is a list of ciphersuites that the auth server supports.
+	cipherSuites []uint16
 }
 
 // runPeriodicOperations runs some periodic bookkeeping operations

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -49,12 +49,12 @@ func LocalRegister(id IdentityID, authServer *AuthServer, additionalPrincipals [
 // Register is used to generate host keys when a node or proxy are running on different hosts
 // than the auth server. This method requires provisioning tokens to prove a valid auth server
 // was used to issue the joining request.
-func Register(dataDir, token string, id IdentityID, servers []utils.NetAddr, additionalPrincipals []string) (*Identity, error) {
+func Register(dataDir, token string, id IdentityID, servers []utils.NetAddr, additionalPrincipals []string, cipherSuites []uint16) (*Identity, error) {
 	tok, err := readToken(token)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tlsConfig := utils.TLSConfig()
+	tlsConfig := utils.TLSConfig(cipherSuites)
 	certPath := filepath.Join(dataDir, defaults.CACertFile)
 	certBytes, err := utils.ReadPath(certPath)
 	if err != nil {

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -470,7 +470,7 @@ func (s *AuthServer) sendValidateRequestToProxy(host string, validateRequest *Va
 		}
 
 		// Disable certificate checking while in debug mode.
-		tlsConfig := utils.TLSConfig()
+		tlsConfig := utils.TLSConfig(s.cipherSuites)
 		tlsConfig.InsecureSkipVerify = true
 		tr.TLSClientConfig = tlsConfig
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -170,7 +170,9 @@ func (proxy *ProxyClient) ConnectToSite(ctx context.Context, quiet bool) (auth.C
 		return auth.NewTLSClientWithDialer(dialer, proxy.teleportClient.TLS)
 	}
 
-	tlsConfig := utils.TLSConfig()
+	// Because Teleport clients can't be configured (yet), they take the default
+	// list of cipher suites from Go.
+	tlsConfig := utils.TLSConfig(nil)
 	localAgent := proxy.teleportClient.LocalAgent()
 	pool, err := localAgent.GetCerts()
 	if err != nil {

--- a/lib/client/https_client.go
+++ b/lib/client/https_client.go
@@ -31,7 +31,9 @@ import (
 )
 
 func NewInsecureWebClient() *http.Client {
-	tlsConfig := utils.TLSConfig()
+	// Because Teleport clients can't be configured (yet), they take the default
+	// list of cipher suites from Go.
+	tlsConfig := utils.TLSConfig(nil)
 	tlsConfig.InsecureSkipVerify = true
 
 	return &http.Client{
@@ -42,7 +44,9 @@ func NewInsecureWebClient() *http.Client {
 }
 
 func newClientWithPool(pool *x509.CertPool) *http.Client {
-	tlsConfig := utils.TLSConfig()
+	// Because Teleport clients can't be configured (yet), they take the default
+	// list of cipher suites from Go.
+	tlsConfig := utils.TLSConfig(nil)
 	tlsConfig.RootCAs = pool
 
 	return &http.Client{

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -231,7 +231,15 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 	cfg.CachePolicy = *cachePolicy
 
-	// apply ciphers, kex algorithms, and mac algorithms
+	// Apply (TLS) cipher suites and (SSH) ciphers, KEX algorithms, and MAC
+	// algorithms.
+	if len(fc.CipherSuites) > 0 {
+		cipherSuites, err := utils.CipherSuiteMapping(fc.CipherSuites)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		cfg.CipherSuites = cipherSuites
+	}
 	if fc.Ciphers != nil {
 		cfg.Ciphers = fc.Ciphers
 	}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -144,6 +144,7 @@ var (
 		"service_name":            false,
 		"client_idle_timeout":     false,
 		"disconnect_expired_cert": false,
+		"ciphersuites":            false,
 	}
 )
 
@@ -368,15 +369,19 @@ type Global struct {
 	// by looking into certificate
 	Keys []KeyPair `yaml:"keys,omitempty"`
 
-	// Ciphers is a list of ciphers that the server supports. If omitted,
+	// CipherSuites is a list of TLS ciphersuites that Teleport supports. If
+	// omitted, a Teleport selected list of defaults will be used.
+	CipherSuites []string `yaml:"ciphersuites,omitempty"`
+
+	// Ciphers is a list of SSH ciphers that the server supports. If omitted,
 	// the defaults will be used.
 	Ciphers []string `yaml:"ciphers,omitempty"`
 
-	// KEXAlgorithms is a list of key exchange (KEX) algorithms that the
+	// KEXAlgorithms is a list of SSH key exchange (KEX) algorithms that the
 	// server supports. If omitted, the defaults will be used.
 	KEXAlgorithms []string `yaml:"kex_algos,omitempty"`
 
-	// MACAlgorithms is a list of message authentication codes (MAC) that
+	// MACAlgorithms is a list of SSH message authentication codes (MAC) that
 	// the server supports. If omitted the defaults will be used.
 	MACAlgorithms []string `yaml:"mac_algos,omitempty"`
 }

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -117,15 +117,19 @@ type Config struct {
 	// ClusterConfiguration is a service that provides cluster configuration
 	ClusterConfiguration services.ClusterConfiguration
 
-	// Ciphers is a list of ciphers that the server supports. If omitted,
+	// CipherSuites is a list of TLS ciphersuites that Teleport supports. If
+	// omitted, a Teleport selected list of defaults will be used.
+	CipherSuites []uint16
+
+	// Ciphers is a list of SSH ciphers that the server supports. If omitted,
 	// the defaults will be used.
 	Ciphers []string
 
-	// KEXAlgorithms is a list of key exchange (KEX) algorithms that the
+	// KEXAlgorithms is a list of SSH key exchange (KEX) algorithms that the
 	// server supports. If omitted, the defaults will be used.
 	KEXAlgorithms []string
 
-	// MACAlgorithms is a list of message authentication codes (MAC) that
+	// MACAlgorithms is a list of SSH message authentication codes (MAC) that
 	// the server supports. If omitted the defaults will be used.
 	MACAlgorithms []string
 
@@ -395,6 +399,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Hostname = hostname
 	cfg.DataDir = defaults.DataDir
 	cfg.Console = os.Stdout
+	cfg.CipherSuites = utils.DefaultCipherSuites()
 	cfg.Ciphers = sc.Ciphers
 	cfg.KEXAlgorithms = kex
 	cfg.MACAlgorithms = macs

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -35,8 +35,8 @@ import (
 // ListenTLS sets up TLS listener for the http handler, starts listening
 // on a TCP socket and returns the socket which is ready to be used
 // for http.Serve
-func ListenTLS(address string, certFile, keyFile string) (net.Listener, error) {
-	tlsConfig, err := CreateTLSConfiguration(certFile, keyFile)
+func ListenTLS(address string, certFile, keyFile string, cipherSuites []uint16) (net.Listener, error) {
+	tlsConfig, err := CreateTLSConfiguration(certFile, keyFile, cipherSuites)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -44,24 +44,13 @@ func ListenTLS(address string, certFile, keyFile string) (net.Listener, error) {
 }
 
 // TLSConfig returns default TLS configuration strong defaults.
-func TLSConfig() *tls.Config {
+func TLSConfig(cipherSuites []uint16) *tls.Config {
 	config := &tls.Config{}
 
-	// Only support modern ciphers (Chacha20 and AES GCM). Key exchanges which
-	// support perfect forward secrecy (ECDHE) have priority over those that do
-	// not (RSA).
-	config.CipherSuites = []uint16{
-		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	// If ciphers suites were passed in, use them. Otherwise use the the
+	// Go defaults.
+	if len(cipherSuites) > 0 {
+		config.CipherSuites = cipherSuites
 	}
 
 	// Pick the servers preferred ciphersuite, not the clients.
@@ -75,8 +64,8 @@ func TLSConfig() *tls.Config {
 }
 
 // CreateTLSConfiguration sets up default TLS configuration
-func CreateTLSConfiguration(certFile, keyFile string) (*tls.Config, error) {
-	config := TLSConfig()
+func CreateTLSConfiguration(certFile, keyFile string, cipherSuites []uint16) (*tls.Config, error) {
+	config := TLSConfig(cipherSuites)
 
 	if _, err := os.Stat(certFile); err != nil {
 		return nil, trace.BadParameter("certificate is not accessible by '%v'", certFile)
@@ -160,9 +149,68 @@ func GenerateSelfSignedCert(hostNames []string) (*TLSCredentials, error) {
 	}, nil
 }
 
+// CipherSuiteMapping transforms Teleport formatted cipher suites strings
+// into uint16 IDs.
+func CipherSuiteMapping(cipherSuites []string) ([]uint16, error) {
+	out := make([]uint16, 0, len(cipherSuites))
+
+	for _, cs := range cipherSuites {
+		c, ok := cipherSuiteMapping[cs]
+		if !ok {
+			return nil, trace.BadParameter("cipher suite not supported: %v", cs)
+		}
+
+		out = append(out, c)
+	}
+
+	return out, nil
+}
+
+// cipherSuiteMapping is the mapping between Teleport formatted cipher
+// suites strings and uint16 IDs.
+var cipherSuiteMapping map[string]uint16 = map[string]uint16{
+	"tls-rsa-with-aes-128-cbc-sha":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"tls-rsa-with-aes-256-cbc-sha":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"tls-rsa-with-aes-128-cbc-sha256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	"tls-rsa-with-aes-128-gcm-sha256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"tls-rsa-with-aes-256-gcm-sha384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"tls-ecdhe-ecdsa-with-aes-128-cbc-sha":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"tls-ecdhe-ecdsa-with-aes-256-cbc-sha":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"tls-ecdhe-rsa-with-aes-128-cbc-sha":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"tls-ecdhe-rsa-with-aes-256-cbc-sha":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"tls-ecdhe-ecdsa-with-aes-128-cbc-sha256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"tls-ecdhe-rsa-with-aes-128-cbc-sha256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"tls-ecdhe-rsa-with-aes-128-gcm-sha256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"tls-ecdhe-ecdsa-with-aes-128-gcm-sha256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"tls-ecdhe-rsa-with-aes-256-gcm-sha384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"tls-ecdhe-ecdsa-with-aes-256-gcm-sha384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"tls-ecdhe-rsa-with-chacha20-poly1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	"tls-ecdhe-ecdsa-with-chacha20-poly1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+}
+
 const (
 	// DefaultLRUCapacity is a capacity for LRU session cache
 	DefaultLRUCapacity = 1024
 	// DefaultCertTTL sets the TTL of the self-signed certificate (1 year)
 	DefaultCertTTL = (24 * time.Hour) * 365
 )
+
+// DefaultCipherSuites returns the default list of cipher suites that
+// Teleport supports. By default Teleport only support modern ciphers
+// (Chacha20 and AES GCM). Key exchanges which support perfect forward
+// secrecy (ECDHE) have priority over those that do not (RSA).
+func DefaultCipherSuites() []uint16 {
+	return []uint16{
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	}
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -20,6 +20,7 @@ package web
 
 import (
 	"compress/gzip"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -101,6 +102,9 @@ type Config struct {
 	ProxySSHAddr utils.NetAddr
 	// ProxyWebAddr points to the web (HTTPS) address of the proxy
 	ProxyWebAddr utils.NetAddr
+
+	// ClientTLSConfig is the TLS configuration the client uses.
+	ClientTLSConfig *tls.Config
 }
 
 type RewritingHandler struct {
@@ -119,7 +123,7 @@ func (r *RewritingHandler) Close() error {
 // NewHandler returns a new instance of web proxy handler
 func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	const apiPrefix = "/" + teleport.WebAPIVersion
-	lauth, err := newSessionCache(cfg.ProxyClient, []utils.NetAddr{cfg.AuthServers})
+	lauth, err := newSessionCache(cfg.ProxyClient, []utils.NetAddr{cfg.AuthServers}, cfg.ClientTLSConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -212,11 +212,16 @@ func (s *WebSuite) SetUpTest(c *C) {
 	)
 	c.Assert(err, IsNil)
 
+	tlsConfig := &tls.Config{
+		CipherSuites: utils.DefaultCipherSuites(),
+	}
+
 	handler, err := NewHandler(Config{
-		Proxy:       revTunServer,
-		AuthServers: utils.FromAddr(s.server.Addr()),
-		DomainName:  s.server.ClusterName(),
-		ProxyClient: s.proxyClient,
+		Proxy:           revTunServer,
+		AuthServers:     utils.FromAddr(s.server.Addr()),
+		DomainName:      s.server.ClusterName(),
+		ProxyClient:     s.proxyClient,
+		ClientTLSConfig: tlsConfig,
 	}, SetSessionStreamPollPeriod(200*time.Millisecond))
 	c.Assert(err, IsNil)
 

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -142,7 +142,7 @@ func connectToAuthService(cfg *service.Config) (client auth.ClientI, err error) 
 		}
 		return nil, trace.Wrap(err)
 	}
-	tlsConfig, err := i.TLSConfig()
+	tlsConfig, err := i.TLSConfig(cfg.CipherSuites)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
**Purpose**

Adde support for configuring ciphersuites in `teleport.yaml`.

**Implementation**

Allow creating a `TLSConfig` with specific ciphers. If no ciphers are provided use the default set. In this way servers and clients used within Teleport will use the same set of ciphersuites. External clients like `tsh` will use the default ciphersuites.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1999