### PR TITLE
Add readyz endpoint and clusters metrics.

### DIFF
--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -46,6 +46,9 @@ type RemoteSite interface {
 	// CachingAccessPoint returns access point that is lightweight
 	// but is resilient to auth server crashes
 	CachingAccessPoint() (auth.AccessPoint, error)
+	// GetTunnelsCount returns the amount of active inbound tunnels
+	// from the remote cluster
+	GetTunnelsCount() int
 }
 
 // Server is a TCP/IP SSH server which listens on an SSH endpoint and remote/local

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -89,6 +89,11 @@ type localSite struct {
 	certificateCache *certificateCache
 }
 
+// GetTunnelsCount always returns 1 for local cluster
+func (s *localSite) GetTunnelsCount() int {
+	return 1
+}
+
 func (s *localSite) CachingAccessPoint() (auth.AccessPoint, error) {
 	return s.accessPoint, nil
 }

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -45,6 +45,10 @@ type clusterPeers struct {
 	peers       map[string]*clusterPeer
 }
 
+func (p *clusterPeers) GetTunnelsCount() int {
+	return len(p.peers)
+}
+
 func (p *clusterPeers) pickPeer() (*clusterPeer, error) {
 	var currentPeer *clusterPeer
 	for _, peer := range p.peers {

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -120,6 +120,11 @@ func (s *remoteSite) authServerContextDialer(ctx context.Context, network, addre
 	return s.DialAuthServer()
 }
 
+// GetTunnelsCount always returns 0 for local cluster
+func (s *remoteSite) GetTunnelsCount() int {
+	return s.connectionCount()
+}
+
 func (s *remoteSite) CachingAccessPoint() (auth.AccessPoint, error) {
 	return s.remoteAccessPoint, nil
 }


### PR DESCRIPTION
This commit fixes #1610.

New readyz endpoint is added to existing
/metrics and /healthz endpoints activated by
diag addr-flag:

`teleport start --diag-addr=127.0.0.1:1234`

Readyz endpoint will report 503 if node or
proxy failed to connect to the cluster and 200 OK
otherwise.

Additional prometheus gagues report connection
count for trusted and remote clusters:

```
remote_clusters{cluster="one"} 1
remote_clusters{cluster="two"} 1

trusted_clusters{cluster="one",state="connected"} 0
trusted_clusters{cluster="one",state="connecting"} 0
trusted_clusters{cluster="one",state="disconnected"} 0
trusted_clusters{cluster="one",state="discovered"} 1
trusted_clusters{cluster="one",state="discovering"} 0
```