### PR TITLE
Removed confusing section fromt the docs

### DIFF
--- a/docs/2.0/admin-guide.md
+++ b/docs/2.0/admin-guide.md
@@ -707,11 +707,6 @@ exec            | Remote command has been executed via SSH, like `tsh ssh root@n
 scp             | Remote file copy has been executed. The following fields will be logged: `{"path": "/path/to/file.txt", "len": 32344, "action": "read" }`
 resize          | Terminal has been resized.
 
-!!! tip "Note":
-    The commercial Teleport edition called "Teleport Enterprise" supports native
-    audit log exporting into external systems like Splunk, AlertLogic and others.
-    Take a look at [Teleport Enterprise](enterprise.md) section to learn more.
-
 ### Recorded Sessions
 
 In addition to logging `session.start` and `session.end` events, Teleport also records the entire

--- a/docs/2.3/admin-guide.md
+++ b/docs/2.3/admin-guide.md
@@ -734,11 +734,6 @@ scp             | Remote file copy has been executed. The following fields will 
 resize          | Terminal has been resized.
 user.login      | A user logged into web UI or via tsh. The following fields will be logged: `{"user": "alice@example.com", "method": "local"}`.
 
-!!! tip "Note":
-    The commercial Teleport edition called "Teleport Enterprise" supports native
-    audit log exporting into external systems like Splunk, AlertLogic and others.
-    Take a look at [Teleport Enterprise](enterprise.md) section to learn more.
-
 ### Recorded Sessions
 
 In addition to logging `session.start` and `session.end` events, Teleport also records the entire

--- a/docs/2.4/admin-guide.md
+++ b/docs/2.4/admin-guide.md
@@ -772,11 +772,6 @@ scp             | Remote file copy has been executed. The following fields will 
 resize          | Terminal has been resized.
 user.login      | A user logged into web UI or via tsh. The following fields will be logged: `{"user": "alice@example.com", "method": "local"}`.
 
-!!! tip "Note":
-    The commercial Teleport edition called "Teleport Enterprise" supports native
-    audit log exporting into external systems like Splunk, AlertLogic and others.
-    Take a look at [Teleport Enterprise](enterprise.md) section to learn more.
-
 ### Recorded Sessions
 
 In addition to logging `session.start` and `session.end` events, Teleport also records the entire

--- a/docs/2.5/admin-guide.md
+++ b/docs/2.5/admin-guide.md
@@ -822,11 +822,6 @@ scp             | Remote file copy has been executed. The following fields will 
 resize          | Terminal has been resized.
 user.login      | A user logged into web UI or via tsh. The following fields will be logged: `{"user": "alice@example.com", "method": "local"}`.
 
-!!! tip "Note":
-    The commercial Teleport edition called "Teleport Enterprise" supports native
-    audit log exporting into external systems like Splunk, AlertLogic and others.
-    Take a look at [Teleport Enterprise](enterprise.md) section to learn more.
-
 ### Recorded Sessions
 
 In addition to logging `session.start` and `session.end` events, Teleport also records the entire

--- a/docs/2.7/admin-guide.md
+++ b/docs/2.7/admin-guide.md
@@ -847,11 +847,6 @@ scp             | Remote file copy has been executed. The following fields will 
 resize          | Terminal has been resized.
 user.login      | A user logged into web UI or via tsh. The following fields will be logged: `{"user": "alice@example.com", "method": "local"}`.
 
-!!! tip "Note":
-    The commercial Teleport edition called "Teleport Enterprise" supports native
-    audit log exporting into external systems like Splunk, AlertLogic and others.
-    Take a look at [Teleport Enterprise](enterprise.md) section to learn more.
-
 ### Recorded Sessions
 
 In addition to logging `session.start` and `session.end` events, Teleport also records the entire


### PR DESCRIPTION
This part is gone:

>The commercial Teleport edition called "Teleport Enterprise" supports
>native audit log exporting into external systems like Splunk, AlertLogic
>and others. Take a look at Teleport Enterprise section to learn more.’