### PR TITLE
Use ubuntu as the base image for teleport docker

### DIFF
--- a/build.assets/charts/Dockerfile
+++ b/build.assets/charts/Dockerfile
@@ -1,4 +1,8 @@
-FROM quay.io/gravitational/debian-grande:0.0.1
+FROM ubuntu:18.10
+
+RUN apt-get update && apt-get install -y \
+    dumb-init \
+ && rm -rf /var/lib/apt/lists/*
 
 # Bundle teleport and control binary
 ADD teleport /usr/local/bin/teleport


### PR DESCRIPTION
I'm not sure how this is tested, but on my machine it produces a clean scan result with clair. The resulting image is also about 25% smaller than using debian-grande.