### PR TITLE
Kubernetes configuration, fetch proxy settings.

### DIFF
--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -142,9 +142,16 @@ config:
     public_addr: teleport.example.com
     web_listen_addr: 0.0.0.0:3080
     listen_addr: 0.0.0.0:3023
-    kube_listen_addr: 0.0.0.0:3026
     https_key_file: /var/lib/certs/tls.key
     https_cert_file: /var/lib/certs/tls.crt
+    # kubernetes section configures
+    # kubernetes proxy protocol support
+    kubernetes:
+      enabled: yes
+      listen_addr: 0.0.0.0:3026
+      # public_addr is used to set values
+      # setup in kubeconfig after tsh login
+      # public_addr: [kubeproxy.example.com:443]
 
 ## Additional container arguments
 extraArgs: []

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -889,7 +889,7 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 		SiteName:           cfg.Cluster,
 		ForwardAgent:       cfg.ForwardAgent,
 	}
-	cconf.SetProxy(proxyHost, proxyWebPort, proxySSHPort, 0)
+	cconf.SetProxy(proxyHost, proxyWebPort, proxySSHPort)
 
 	return client.NewClient(cconf)
 }

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -383,8 +383,9 @@ func (s *KubeSuite) TestKubeTrustedClusters(c *check.C) {
 	lib.SetInsecureDevMode(true)
 	defer lib.SetInsecureDevMode(false)
 
-	// route allt he traffic to the aux cluster
-	mainConf.Proxy.KubeClusterOverride = clusterAux
+	// route all the traffic to the aux cluster
+	mainConf.Proxy.Kube.Enabled = true
+	mainConf.Proxy.Kube.ClusterOverride = clusterAux
 	err = main.CreateEx(nil, mainConf)
 	c.Assert(err, check.IsNil)
 
@@ -563,8 +564,9 @@ func (s *KubeSuite) teleKubeConfig(hostname string) *service.Config {
 	tconf.ShutdownTimeout = 2 * tconf.ClientTimeout
 
 	// set kubernetes specific parameters
-	tconf.Proxy.KubeListenAddr.Addr = net.JoinHostPort(hostname, s.ports.Pop())
-	tconf.Proxy.KubeAPIAddr.Addr = s.kubeAPIHost
+	tconf.Proxy.Kube.Enabled = true
+	tconf.Proxy.Kube.ListenAddr.Addr = net.JoinHostPort(hostname, s.ports.Pop())
+	tconf.Proxy.Kube.APIAddr.Addr = s.kubeAPIHost
 	tconf.Auth.KubeCACertPath = s.kubeCACertPath
 
 	return tconf
@@ -620,7 +622,7 @@ func kubeProxyClient(t *TeleInstance, username string) (*kubernetes.Clientset, *
 		KeyData:  key,
 	}
 	config := &rest.Config{
-		Host:            "https://" + t.Config.Proxy.KubeListenAddr.Addr,
+		Host:            "https://" + t.Config.Proxy.Kube.ListenAddr.Addr,
 		TLSClientConfig: tlsClientConfig,
 	}
 	client, err := kubernetes.NewForConfig(config)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -2032,7 +2032,7 @@ func (s *APIServer) setClusterConfig(auth ClientI, w http.ResponseWriter, r *htt
 		return nil, trace.Wrap(err)
 	}
 
-	return message(fmt.Sprintf("cluster config set: %+v", cc)), nil
+	return message("cluster config set"), nil
 }
 
 func (s *APIServer) getClusterName(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -83,6 +83,7 @@ func NewAuthServer(cfg *InitConfig, opts ...AuthServerOption) (*AuthServer, erro
 	if cfg.KubeCACertPath == "" {
 		cfg.KubeCACertPath = teleport.KubeCAPath
 	}
+
 	closeCtx, cancelFunc := context.WithCancel(context.TODO())
 	as := AuthServer{
 		clusterName:          cfg.ClusterName,
@@ -157,11 +158,11 @@ type AuthServer struct {
 	// privateKey is used in tests to use pre-generated private keys
 	privateKey []byte
 
-	// kubeCACertPath is a path to kubernetes certificate authority
-	kubeCACertPath string
-
 	// cipherSuites is a list of ciphersuites that the auth server supports.
 	cipherSuites []uint16
+
+	// kubeCACertPath is a path to PEM encoded kubernetes CA certificate
+	kubeCACertPath string
 }
 
 // runPeriodicOperations runs some periodic bookkeeping operations

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -124,11 +124,11 @@ type InitConfig struct {
 	// used in tests that don't need periodc operations.
 	SkipPeriodicOperations bool
 
-	// KubeCACertPath is an optional path to kubernetes CA certificate authority
-	KubeCACertPath string
-
 	// CipherSuites is a list of ciphersuites that the auth server supports.
 	CipherSuites []uint16
+
+	// KubeCACertPath is an optional path to kubernetes CA certificate authority
+	KubeCACertPath string
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -17,6 +17,8 @@ limitations under the License.
 package auth
 
 import (
+	"io/ioutil"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/kube/authority"
@@ -61,8 +63,12 @@ func (s *AuthServer) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 
 	// generate cluster with local kubernetes cluster
 	if req.ClusterName == s.clusterName.GetClusterName() {
+		caPEM, err := ioutil.ReadFile(s.kubeCACertPath)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		log.Debugf("Generating certificate with local Kubernetes cluster.")
-		cert, err := authority.ProcessCSR(req.CSR, s.kubeCACertPath)
+		cert, err := authority.ProcessCSR(req.CSR, caPEM)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2018 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -708,6 +708,16 @@ func (s *TLSSuite) TestReadOwnRole(c *check.C) {
 	fixtures.ExpectAccessDenied(c, err)
 }
 
+func (s *TLSSuite) TestAuthPreference(c *check.C) {
+	clt, err := s.server.NewClient(TestAdmin())
+	c.Assert(err, check.IsNil)
+
+	suite := &suite.ServicesTestSuite{
+		ConfigS: clt,
+	}
+	suite.AuthPreference(c)
+}
+
 func (s *TLSSuite) TestTunnelConnectionsCRUD(c *check.C) {
 	clt, err := s.server.NewClient(TestAdmin())
 	c.Assert(err, check.IsNil)

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -45,7 +45,7 @@ func (s *APITestSuite) TestConfig(c *check.C) {
 	c.Assert(conf.ProxySSHHostPort(), check.Equals, "example.org:3023")
 	c.Assert(conf.ProxyWebHostPort(), check.Equals, "example.org:3080")
 
-	conf.SetProxy("example.org", 100, 200, 0)
+	conf.SetProxy("example.org", 100, 200)
 	c.Assert(conf.ProxyWebHostPort(), check.Equals, "example.org:100")
 	c.Assert(conf.ProxySSHHostPort(), check.Equals, "example.org:200")
 
@@ -57,10 +57,9 @@ func (s *APITestSuite) TestConfig(c *check.C) {
 	c.Assert(conf.ProxySSHHostPort(), check.Equals, "example.org:200")
 	c.Assert(conf.ProxyWebHostPort(), check.Equals, "example.org:3080")
 
-	conf.SetProxy("example.org", 100, 200, 300)
+	conf.SetProxy("example.org", 100, 200)
 	c.Assert(conf.ProxyWebHostPort(), check.Equals, "example.org:100")
 	c.Assert(conf.ProxySSHHostPort(), check.Equals, "example.org:200")
-	c.Assert(conf.ProxyKubeHostPort(), check.Equals, "example.org:300")
 
 }
 

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -37,10 +37,12 @@ type ClientProfile struct {
 	//
 	// proxy configuration
 	//
-	ProxyHost     string `yaml:"proxy_host,omitempty"`
-	ProxySSHPort  int    `yaml:"proxy_port,omitempty"`
-	ProxyWebPort  int    `yaml:"proxy_web_port,omitempty"`
-	ProxyKubePort int    `yaml:"proxy_kube_port,omitempty"`
+	ProxyHost    string `yaml:"proxy_host,omitempty"`
+	ProxySSHPort int    `yaml:"proxy_port,omitempty"`
+	ProxyWebPort int    `yaml:"proxy_web_port,omitempty"`
+
+	// KubeProxyAddr is a kubernetes address in host:port format
+	KubeProxyAddr string `yaml:"kube_proxy_addr,omitempty"`
 
 	//
 	// auth/identity

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -278,8 +278,32 @@ func SSHAgentSSOLogin(ctx context.Context, proxyAddr, connectorID string, pubKey
 type PingResponse struct {
 	// Auth contains the forms of authentication the auth server supports.
 	Auth AuthenticationSettings `json:"auth"`
+	// Proxy contains the proxy settings.
+	Proxy ProxySettings `json:"proxy"`
 	// ServerVersion is the version of Teleport that is running.
 	ServerVersion string `json:"server_version"`
+}
+
+// ProxySettings contains basic information about proxy settings
+type ProxySettings struct {
+	// Kube is a kubernetes specific proxy section
+	Kube KubeProxySettings `json:"kube"`
+	// SSH is SSH specific proxy settings
+	SSH SSHProxySettings `json:"ssh"`
+}
+
+// KubeProxySettings is kubernetes proxy settings
+type KubeProxySettings struct {
+	// Enabled is true when kubernetes proxy is enabled
+	Enabled bool `json:"enabled,omitempty"`
+	// PublicAddr is a kubernetes proxy public address if set
+	PublicAddr string `json:"public_addr,omitempty"`
+}
+
+// SSHProxySettings is SSH specific proxy settings
+type SSHProxySettings struct {
+	// ListenAddr is SSH listen address
+	ListenAddr string `json:"listen_addr,omitempty"`
 }
 
 // PingResponse contains the form of authentication the auth server supports.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -66,6 +66,8 @@ var (
 		"ssh_service":             true,
 		"proxy_service":           true,
 		"auth_service":            true,
+		"kubernetes":              true,
+		"kubernetes_ca_cert_file": true,
 		"auth_token":              true,
 		"auth_servers":            true,
 		"domain_name":             true,
@@ -88,10 +90,9 @@ var (
 		"web_listen_addr":         true,
 		"tunnel_listen_addr":      true,
 		"ssh_listen_addr":         true,
-		"kube_listen_addr":        true,
-		"kube_api_addr":           true,
-		"kube_ca_cert_file":       true,
 		"listen_addr":             true,
+		"api_addr":                false,
+		"ca_cert_file":            false,
 		"https_key_file":          true,
 		"https_cert_file":         true,
 		"advertise_ip":            true,
@@ -532,15 +533,17 @@ type Auth struct {
 	// server certificates
 	PublicAddr utils.Strings `yaml:"public_addr,omitempty"`
 
-	// KubeCACertFile is a path to kubernetes certificate authority certificate file
-	KubeCACertFile string `yaml:"kube_ca_cert_file,omitempty"`
-
 	// ClientIdleTimeout sets global cluster default setting for client idle timeouts
 	ClientIdleTimeout services.Duration `yaml:"client_idle_timeout"`
 
 	// DisconnectExpiredCert provides disconnect expired certificate setting -
 	// if true, connections with expired client certificates will get disconnected
 	DisconnectExpiredCert services.Bool `yaml:"disconnect_expired_cert"`
+
+	// KubeCACertFile is a path to kubernetes certificate authority certificate file,
+	// used in cases when auth server is deployed outside of the kubernetes
+	// cluster.
+	KubeCACertFile string `yaml:"kubernetes_ca_cert_file,omitempty"`
 }
 
 // TrustedCluster struct holds configuration values under "trusted_clusters" key
@@ -715,10 +718,6 @@ type Proxy struct {
 	WebAddr string `yaml:"web_listen_addr,omitempty"`
 	// TunAddr is a reverse tunnel address
 	TunAddr string `yaml:"tunnel_listen_addr,omitempty"`
-	// KubeAddr is a proxy address for kubernetes
-	KubeAddr string `yaml:"kube_listen_addr,omitempty"`
-	// KubeAPIAddr is an address of a kubernetes API server
-	KubeAPIAddr string `yaml:"kube_api_addr,omitempty"`
 	// KeyFile is a TLS key file
 	KeyFile string `yaml:"https_key_file,omitempty"`
 	// CertFile is a TLS Certificate file
@@ -730,6 +729,18 @@ type Proxy struct {
 	// as only admin knows whether service is in front of trusted load balancer
 	// or not.
 	ProxyProtocol string `yaml:"proxy_protocol,omitempty"`
+	// Kube configures kubernetes protocol support of the proxy
+	Kube Kube `yaml:"kubernetes,omitempty"`
+}
+
+// Kube is a `kubernetes_service`
+type Kube struct {
+	// Service is a generic service configuration section
+	Service `yaml:",inline"`
+	// KubeAPIAddr is an address of a target kubernetes API server
+	APIAddr string `yaml:"api_addr,omitempty"`
+	// PublicAddr is a publicly advertised address of the kubernetes proxy
+	PublicAddr utils.Strings `yaml:"public_addr,omitempty"`
 }
 
 // ReverseTunnel is a SSH reverse tunnel maintained by one cluster's

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -379,6 +379,11 @@ func ProxyListenAddr() *utils.NetAddr {
 	return makeAddr(BindIP, SSHProxyListenPort)
 }
 
+// KubeProxyListenAddr returns the default listening address for the Kubernetes Proxy service
+func KubeProxyListenAddr() *utils.NetAddr {
+	return makeAddr(BindIP, KubeProxyListenPort)
+}
+
 // ProxyWebListenAddr returns the default listening address for the Web-based SSH Proxy service
 func ProxyWebListenAddr() *utils.NetAddr {
 	return makeAddr(BindIP, HTTPListenPort)

--- a/lib/kube/authority/authority.go
+++ b/lib/kube/authority/authority.go
@@ -2,7 +2,6 @@ package authority
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -29,11 +28,7 @@ type Cert struct {
 
 // ProcessCSR processes CSR request with local k8s certificate authority
 // and returns certificate PEM signed by CA
-func ProcessCSR(csrPEM []byte, caCertPath string) (*Cert, error) {
-	caPEM, err := ioutil.ReadFile(caCertPath)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+func ProcessCSR(csrPEM []byte, caPEM []byte) (*Cert, error) {
 	clt, _, err := kubeutils.GetKubeClient(os.Getenv(teleport.EnvKubeConfig))
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/kube/client/kubeclient.go
+++ b/lib/kube/client/kubeclient.go
@@ -20,11 +20,12 @@ func UpdateKubeconfig(tc *client.TeleportClient) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	clusterName := tc.ProxyHost()
-	if tc.SiteName != "" && tc.SiteName != clusterName {
-		clusterName = fmt.Sprintf("%v.%v", tc.SiteName, tc.ProxyHost())
+
+	clusterName, proxyPort := tc.KubeProxyHostPort()
+	if tc.SiteName != "" {
+		clusterName = fmt.Sprintf("%v.%v", tc.SiteName, clusterName)
 	}
-	clusterAddr := fmt.Sprintf("https://%v:%v", clusterName, tc.ProxyKubePort())
+	clusterAddr := fmt.Sprintf("https://%v:%v", clusterName, proxyPort)
 
 	creds, err := tc.LocalAgent().GetKey()
 	if err != nil {

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -205,17 +205,15 @@ type cluster struct {
 }
 
 func (c *cluster) Dial(_, _ string) (net.Conn, error) {
-	return c.RemoteSite.Dial(
+	return c.RemoteSite.DialTCP(
 		&c.remoteAddr,
-		&utils.NetAddr{AddrNetwork: "tcp", Addr: c.targetAddr},
-		nil)
+		&utils.NetAddr{AddrNetwork: "tcp", Addr: c.targetAddr})
 }
 
 func (c *cluster) DialWithContext(ctx context.Context, _, _ string) (net.Conn, error) {
-	return c.RemoteSite.Dial(
+	return c.RemoteSite.DialTCP(
 		&c.remoteAddr,
-		&utils.NetAddr{AddrNetwork: "tcp", Addr: c.targetAddr},
-		nil)
+		&utils.NetAddr{AddrNetwork: "tcp", Addr: c.targetAddr})
 }
 
 // handlerWithAuthFunc is http handler with passed auth context
@@ -304,7 +302,7 @@ func (f *Forwarder) setupContext(ctx auth.AuthContext, req *http.Request, isRemo
 	}
 	for _, remoteCluster := range f.Tunnel.GetSites() {
 		if strings.HasPrefix(req.Host, remoteCluster.GetName()+".") {
-			f.Debugf("Going to proxy to cluster: %v based on matching host suffix %v.", remoteCluster.GetName(), req.Host)
+			f.Debugf("Going to proxy to cluster: %v based on matching host prefix %v.", remoteCluster.GetName(), req.Host)
 			targetCluster = remoteCluster
 			isRemoteCluster = remoteCluster.GetName() != f.ClusterName
 			break

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -33,8 +33,14 @@ import (
 type RemoteSite interface {
 	// DialAuthServer returns a net.Conn to the Auth Server of a site.
 	DialAuthServer() (net.Conn, error)
-	// Dial dials any address within the site network.
+	// Dial dials any address within the site network, in terminating
+	// mode it uses local instance of forwarding server to terminate
+	// and record the connection
 	Dial(fromAddr, toAddr net.Addr, userAgent agent.Agent) (net.Conn, error)
+	// DialTCP dials any address within the site network,
+	// ignores recording mode and always uses TCP dial, used
+	// in components that need direct dialer.
+	DialTCP(fromAddr, toAddr net.Addr) (net.Conn, error)
 	// GetLastConnected returns last time the remote site was seen connected
 	GetLastConnected() time.Time
 	// GetName returns site name (identified by authority domain's name)

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -152,10 +152,10 @@ func (s *localSite) Dial(from net.Addr, to net.Addr, userAgent agent.Agent) (net
 		return s.dialWithAgent(from, to, userAgent)
 	}
 
-	return s.dial(from, to)
+	return s.DialTCP(from, to)
 }
 
-func (s *localSite) dial(from net.Addr, to net.Addr) (net.Conn, error) {
+func (s *localSite) DialTCP(from net.Addr, to net.Addr) (net.Conn, error) {
 	s.log.Debugf("Dialing from %v to %v", from, to)
 
 	return net.DialTimeout(to.Network(), to.String(), defaults.DefaultDialTimeout)

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -127,6 +127,10 @@ func (p *clusterPeers) DialAuthServer() (net.Conn, error) {
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
 func (p *clusterPeers) Dial(from, to net.Addr, userAgent agent.Agent) (conn net.Conn, err error) {
+	return p.DialTCP(from, to)
+}
+
+func (p *clusterPeers) DialTCP(from, to net.Addr) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy has not been discovered yet, try again later")
 }
 

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -567,10 +567,10 @@ func (s *remoteSite) Dial(from net.Addr, to net.Addr, userAgent agent.Agent) (ne
 		}
 		return s.dialWithAgent(from, to, userAgent)
 	}
-	return s.dial(from, to)
+	return s.DialTCP(from, to)
 }
 
-func (s *remoteSite) dial(from, to net.Addr) (net.Conn, error) {
+func (s *remoteSite) DialTCP(from, to net.Addr) (net.Conn, error) {
 	s.Debugf("Dialing from %v to %v", from, to)
 
 	conn, err := s.connThroughTunnel(chanTransportDialReq, to.String())

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -241,7 +241,7 @@ func (c CachePolicy) String() string {
 	return fmt.Sprintf("cache that will expire after connection to database is lost after %v, %v", c.TTL, recentCachePolicy)
 }
 
-// ProxyConfig configures proy service
+// ProxyConfig specifies configuration for proxy service
 type ProxyConfig struct {
 	// Enabled turns proxy role on or off for this process
 	Enabled bool
@@ -264,16 +264,6 @@ type ProxyConfig struct {
 	// EnableProxyProtocol enables proxy protocol support
 	EnableProxyProtocol bool
 
-	// KubeListenAddr is address where reverse tunnel dialers connect to
-	KubeListenAddr utils.NetAddr
-
-	// KubeAPIAddr is address of kubernetes API server
-	KubeAPIAddr utils.NetAddr
-
-	// KubeClusterOverride causes all traffic to go to a specific remote
-	// cluster, used only in tests
-	KubeClusterOverride string
-
 	// WebAddr is address for web portal of the proxy
 	WebAddr utils.NetAddr
 
@@ -290,6 +280,32 @@ type ProxyConfig struct {
 
 	// PublicAddrs is a list of the public addresses the Teleport UI can be accessed at,
 	// it also affects the SSH host principals and DNS names added to the SSH and TLS certs.
+	PublicAddrs []utils.NetAddr
+
+	// Kube specifies kubernetes proxy configuration
+	Kube KubeProxyConfig
+}
+
+// KubeProxyConfig specifies configuration for proxy service
+type KubeProxyConfig struct {
+	// Enabled turns kubernetes proxy role on or off for this process
+	Enabled bool
+
+	// ListenAddr is address where reverse tunnel dialers connect to
+	ListenAddr utils.NetAddr
+
+	// KubeAPIAddr is address of kubernetes API server
+	APIAddr utils.NetAddr
+
+	// ClusterOverride causes all traffic to go to a specific remote
+	// cluster, used only in tests
+	ClusterOverride string
+
+	// CACert is a PEM encoded kubernetes CA certificate
+	CACert []byte
+
+	// PublicAddrs is a list of the public addresses the Teleport Kube proxy can be accessed by,
+	// it also affects the host principals and routing logic
 	PublicAddrs []utils.NetAddr
 }
 
@@ -342,7 +358,7 @@ type AuthConfig struct {
 	// PublicAddrs affects the SSH host principals and DNS names added to the SSH and TLS certs.
 	PublicAddrs []utils.NetAddr
 
-	// KubeCACertPath is a path to kubernetes CA certificate file
+	// KubeCACertPath is a path to kubernetes CA certificate
 	KubeCACertPath string
 }
 
@@ -424,6 +440,10 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Proxy.WebAddr = *defaults.ProxyWebListenAddr()
 	cfg.Proxy.ReverseTunnelListenAddr = *defaults.ReverseTunnellListenAddr()
 	defaults.ConfigureLimiter(&cfg.Proxy.Limiter)
+
+	// defaults for the Kubernetes proxy service
+	cfg.Proxy.Kube.Enabled = false
+	cfg.Proxy.Kube.ListenAddr = *defaults.KubeProxyListenAddr()
 
 	// defaults for the SSH service:
 	cfg.SSH.Enabled = true

--- a/lib/services/clusterconfig.go
+++ b/lib/services/clusterconfig.go
@@ -363,16 +363,22 @@ const ClusterConfigSpecSchemaTemplate = `{
       "properties": {
         "type": {
           "type": "string"
-         }, 
+        },
         "region": {
           "type": "string"
-         }, 
+        },
+        "audit_events_uri": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "audit_sessions_uri": {
           "type": "string"
-         }, 
+        },
         "audit_table_name": {
           "type": "string"
-         }
+        }
       }
     }%v
   }

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/dir"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"gopkg.in/check.v1"
@@ -65,23 +66,11 @@ func (s *ClusterConfigurationSuite) TearDownTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *ClusterConfigurationSuite) TestCycle(c *check.C) {
-	caps := NewClusterConfigurationService(s.bk)
-
-	ap, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
-		Type:         "local",
-		SecondFactor: "otp",
-	})
-	c.Assert(err, check.IsNil)
-
-	err = caps.SetAuthPreference(ap)
-	c.Assert(err, check.IsNil)
-
-	gotAP, err := caps.GetAuthPreference()
-	c.Assert(err, check.IsNil)
-
-	c.Assert(gotAP.GetType(), check.Equals, "local")
-	c.Assert(gotAP.GetSecondFactor(), check.Equals, "otp")
+func (s *ClusterConfigurationSuite) TestAuthPreference(c *check.C) {
+	suite := &suite.ServicesTestSuite{
+		ConfigS: NewClusterConfigurationService(s.bk),
+	}
+	suite.AuthPreference(c)
 }
 
 func (s *ClusterConfigurationSuite) TestSessionRecording(c *check.C) {

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -125,7 +125,7 @@ const (
 	// KindClusterConfig is the resource that holds cluster level configuration.
 	KindClusterConfig = "cluster_config"
 
-	// MetaNameClusterName is the exact name of the singleton resource.
+	// MetaNameClusterConfig is the exact name of the cluster config singleton resource.
 	MetaNameClusterConfig = "cluster-config"
 
 	// KindClusterName is a type of configuration resource that contains the cluster name.

--- a/lib/utils/addr_test.go
+++ b/lib/utils/addr_test.go
@@ -39,6 +39,12 @@ func (s *AddrTestSuite) TestParseHostPort(c *C) {
 	c.Assert(addr.AddrNetwork, Equals, "tcp")
 	c.Assert(addr.Addr, Equals, "localhost:22")
 
+	// scheme + existing port
+	addr, err = ParseHostPortAddr("https://localhost", 443)
+	c.Assert(err, IsNil)
+	c.Assert(addr.AddrNetwork, Equals, "https")
+	c.Assert(addr.Addr, Equals, "localhost:443")
+
 	// success
 	addr, err = ParseHostPortAddr("localhost", 1111)
 	c.Assert(err, IsNil)
@@ -49,6 +55,10 @@ func (s *AddrTestSuite) TestParseHostPort(c *C) {
 	addr, err = ParseHostPortAddr("localhost", -1)
 	c.Assert(err, NotNil)
 	c.Assert(addr, IsNil)
+
+	// scheme + missing port
+	_, err = ParseHostPortAddr("https://localhost", -1)
+	c.Assert(err, NotNil)
 }
 
 func (s *AddrTestSuite) TestEmpty(c *C) {
@@ -64,6 +74,32 @@ func (s *AddrTestSuite) TestParse(c *C) {
 	c.Assert(addr.Path, Equals, "/path")
 	c.Assert(addr.FullAddress(), Equals, "tcp://one:25")
 	c.Assert(addr.IsEmpty(), Equals, false)
+	c.Assert(addr.Host(), Equals, "one")
+	c.Assert(addr.Port(0), Equals, 25)
+}
+
+func (s *AddrTestSuite) TestParseIPV6(c *C) {
+	addr, err := ParseAddr("[::1]:49870")
+	c.Assert(err, IsNil)
+	c.Assert(addr, NotNil)
+	c.Assert(addr.Addr, Equals, "[::1]:49870")
+	c.Assert(addr.Path, Equals, "")
+	c.Assert(addr.FullAddress(), Equals, "tcp://[::1]:49870")
+	c.Assert(addr.IsEmpty(), Equals, false)
+	c.Assert(addr.Host(), Equals, "::1")
+	c.Assert(addr.Port(0), Equals, 49870)
+}
+
+func (s *AddrTestSuite) TestParseEmptyPort(c *C) {
+	addr, err := ParseAddr("one")
+	c.Assert(err, IsNil)
+	c.Assert(addr, NotNil)
+	c.Assert(addr.Addr, Equals, "one")
+	c.Assert(addr.Path, Equals, "")
+	c.Assert(addr.FullAddress(), Equals, "tcp://one")
+	c.Assert(addr.IsEmpty(), Equals, false)
+	c.Assert(addr.Host(), Equals, "one")
+	c.Assert(addr.Port(443), Equals, 443)
 }
 
 func (s *AddrTestSuite) TestParseHTTP(c *C) {


### PR DESCRIPTION
This commit moves proxy kubernetes configuration
to a separate nested block to provide more fine
grained settings:

```yaml
auth:
  kubernetes_ca_cert_path: /tmp/custom-ca
proxy:
  enabled: yes
  kubernetes:
    enabled: yes
    public_addr: [custom.example.com:port]
    api_addr: kuberentes.example.com:443
    listen_addr: localhost:3026
```

1. Kubernetes config section is explicitly enabled
and disabled. It is disabled by default.

2. Public address in kubernetes section
is propagated to tsh profile

The other part of the commit updates Ping
endpoint to send proxy configuration back to
the client, including kubernetes public address
and ssh listen address.

Clients updates profile accordingly to configuration
received from the proxy.