### PR TITLE
Marshal as bool.

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -284,8 +284,9 @@ const MetadataSchema = `{
     "expires": {"type": "string"},
     "labels": {
       "type": "object",
+      "additionalProperties": false,
       "patternProperties": {
-         "^[a-zA-Z/.0-9_]$":  { "type": "string" }
+         "^[a-zA-Z/.0-9_*]+$":  { "type": "string" }
       }
     }
   }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1750,9 +1750,9 @@ func (b Bool) Value() bool {
 	return b.bool
 }
 
-// MarshalJSON marshals Duration to string
+// MarshalJSON marshals boolean value.
 func (b Bool) MarshalJSON() ([]byte, error) {
-	return json.Marshal(fmt.Sprintf("%t", b.bool))
+	return json.Marshal(b.bool)
 }
 
 // UnmarshalJSON unmarshals JSON from string or bool,
@@ -1868,8 +1868,14 @@ const RoleSpecV3SchemaTemplate = `{
     "max_session_ttl": { "type": "string" },
     "options": {
       "type": "object",
-      "patternProperties": {
-        "^[a-zA-Z/.0-9_]$": { "type": "string" }
+      "additionalProperties": false,
+      "properties": {
+        "forward_agent": { "type": ["boolean", "string"] },
+        "max_session_ttl": { "type": "string" },
+        "port_forwarding": { "type": ["boolean", "string"] },
+        "cert_format": { "type": "string" },
+        "client_idle_timeout": { "type": "string" },
+        "disconnect_expired_cert": { "type": ["boolean", "string"] }
       }
     },
     "allow": { "$ref": "#/definitions/role_condition" },
@@ -1887,8 +1893,9 @@ const RoleSpecV3SchemaDefinitions = `
       },
       "node_labels": {
         "type": "object",
+        "additionalProperties": false,
         "patternProperties": {
-          "^[a-zA-Z/.0-9_]$": { "type": "string" }
+          "^[a-zA-Z/.0-9_*]+$": { "type": "string" }
         }
       },
       "logins": {

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -278,12 +278,14 @@ const ServerSpecV2Schema = `{
     "hostname": {"type": "string"},
     "labels": {
       "type": "object",
+      "additionalProperties": false,
       "patternProperties": {
         "^.*$":  { "type": "string" }
       }
     },
     "cmd_labels": {
       "type": "object",
+      "additionalProperties": false,
       "patternProperties": {
         "^.*$": {
           "type": "object",

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -315,8 +315,14 @@ const UserSpecV2SchemaTemplate = `{
     },
     "traits": {
       "type": "object",
+      "additionalProperties": false,
       "patternProperties": {
-        "^[a-zA-Z/.0-9_]$":  { "type": "array", "items": {"type": "string"} }
+        "^[a-zA-Z/.0-9_]+$": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "oidc_identities": {


### PR DESCRIPTION
**Purpose**

Marshal as bool not as string. This allows 2.6 proxies to work with 2.7 auth servers.

**Implementation**

Marshal as bool not as string