### PR TITLE
Add support for no_proxy environment variable

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -41,6 +41,10 @@ const (
 
 	// HTTPProxy is an environment variable pointing to a HTTP proxy.
 	HTTPProxy = "HTTP_PROXY"
+
+	// NoProxy is an environment variable matching the cases
+	// when HTTPS_PROXY or HTTP_PROXY is ignored
+	NoProxy = "NO_PROXY"
 )
 
 const (

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -295,7 +295,7 @@ func (a *Agent) checkHostSignature(hostport string, remote net.Addr, key ssh.Pub
 func (a *Agent) connect() (conn *ssh.Client, err error) {
 	for _, authMethod := range a.authMethods {
 		// if http_proxy is set, dial through the proxy
-		dialer := proxy.DialerFromEnvironment()
+		dialer := proxy.DialerFromEnvironment(a.Addr.Addr)
 		conn, err = dialer.Dial(a.Addr.AddrNetwork, a.Addr.Addr, &ssh.ClientConfig{
 			User:            a.Username,
 			Auth:            []ssh.AuthMethod{authMethod},

--- a/lib/utils/proxy/noproxy.go
+++ b/lib/utils/proxy/noproxy.go
@@ -1,0 +1,74 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// HTTP client implementation. See RFC 2616.
+//
+// This is the low-level Transport implementation of RoundTripper.
+// The high-level interface is in client.go.
+
+package proxy
+
+import (
+	"os"
+	"strings"
+
+	"github.com/gravitational/teleport"
+)
+
+// useProxy reports whether requests to addr should use a proxy,
+// according to the NO_PROXY or no_proxy environment variable.
+// addr is always a canonicalAddr with a host and port.
+func useProxy(addr string) bool {
+	if len(addr) == 0 {
+		return true
+	}
+	var noProxy string
+	for _, env := range []string{teleport.NoProxy, strings.ToLower(teleport.NoProxy)} {
+		noProxy = os.Getenv(env)
+		if noProxy != "" {
+			break
+		}
+	}
+
+	if noProxy == "" {
+		return true
+	}
+	if noProxy == "*" {
+		return false
+	}
+
+	addr = strings.ToLower(strings.TrimSpace(addr))
+	if hasPort(addr) {
+		addr = addr[:strings.LastIndex(addr, ":")]
+	}
+	for _, p := range strings.Split(noProxy, ",") {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if len(p) == 0 {
+			continue
+		}
+		if hasPort(p) {
+			p = p[:strings.LastIndex(p, ":")]
+		}
+		if addr == p {
+			return false
+		}
+		if len(p) == 0 {
+			// There is no host part, likely the entry is malformed; ignore.
+			continue
+		}
+		if p[0] == '.' && (strings.HasSuffix(addr, p) || addr == p[1:]) {
+			// no_proxy ".foo.com" matches "bar.foo.com" or "foo.com"
+			return false
+		}
+		if p[0] != '.' && strings.HasSuffix(addr, p) && addr[len(addr)-len(p)-1] == '.' {
+			// no_proxy "foo.com" matches "bar.foo.com"
+			return false
+		}
+	}
+	return true
+}
+
+// Given a string of the form "host", "host:port", or "[ipv6::address]:port",
+// return true if the string includes a port.
+func hasPort(s string) bool { return strings.LastIndex(s, ":") > strings.LastIndex(s, "]") }


### PR DESCRIPTION
NO_PROXY or no_proxy environment variables
can be set to override variable HTTP_PROXY
or HTTPS_PROXY. Current implementation
is taken from Go standard library.