### PR TITLE
Create *tls.Config in lib/web.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
@@ -40,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
+	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
@@ -1292,6 +1294,24 @@ func closeAgent(teleAgent *teleagent.AgentServer, socketDirPath string) error {
 	}
 
 	return nil
+}
+
+// createWebClient builds a *client.WebClient that is used to simulate
+// browser requests.
+func createWebClient(cluster *TeleInstance, opts ...roundtrip.ClientParam) (*client.WebClient, error) {
+	// Craft URL to Web UI.
+	u := &url.URL{
+		Scheme: "https",
+		Host:   cluster.Config.Proxy.WebAddr.Addr,
+	}
+
+	opts = append(opts, roundtrip.HTTPClient(client.NewInsecureWebClient()))
+	wc, err := client.NewWebClient(u.String(), opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return wc, nil
 }
 
 func fatalIf(err error) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3056,6 +3056,66 @@ func (s *IntSuite) TestList(c *check.C) {
 	}
 }
 
+// TestMultipleSignup makes sure that multiple users can create Teleport accounts.
+func (s *IntSuite) TestMultipleSignup(c *check.C) {
+	type createNewUserReq struct {
+		InviteToken string `json:"invite_token"`
+		Pass        string `json:"pass"`
+	}
+
+	// Create and start a Teleport cluster.
+	makeConfig := func() (*check.C, []string, []*InstanceSecrets, *service.Config) {
+		clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
+			SessionRecording: services.RecordAtNode,
+		})
+		c.Assert(err, check.IsNil)
+
+		tconf := service.MakeDefaultConfig()
+		tconf.Auth.Preference.SetSecondFactor("off")
+		tconf.Auth.Enabled = true
+		tconf.Auth.ClusterConfig = clusterConfig
+		tconf.Proxy.Enabled = true
+		tconf.Proxy.DisableWebService = false
+		tconf.Proxy.DisableWebInterface = true
+		tconf.SSH.Enabled = true
+		return c, nil, nil, tconf
+	}
+	main := s.newTeleportWithConfig(makeConfig())
+	defer main.Stop(true)
+
+	mainAuth := main.Process.GetAuthServer()
+
+	// Create a few users to make sure the proxy uses the correct identity
+	// when connecting to the auth server.
+	for i := 0; i < 5; i++ {
+		// Create a random username.
+		username, err := utils.CryptoRandomHex(16)
+		c.Assert(err, check.IsNil)
+
+		// Create signup token, this is like doing "tctl users add foo foo".
+		token, err := mainAuth.CreateSignupToken(services.UserV1{
+			Name:          username,
+			AllowedLogins: []string{username},
+		}, backend.Forever)
+		c.Assert(err, check.IsNil)
+
+		// Create client that will simulate web browser.
+		clt, err := createWebClient(main)
+		c.Assert(err, check.IsNil)
+
+		// Render the signup page.
+		_, err = clt.Get(clt.Endpoint("webapi", "users", "invites", token), url.Values{})
+		c.Assert(err, check.IsNil)
+
+		// Make sure signup is successful.
+		_, err = clt.PostJSON(clt.Endpoint("webapi", "users"), createNewUserReq{
+			InviteToken: token,
+			Pass:        "fake-password-123",
+		})
+		c.Assert(err, check.IsNil)
+	}
+}
+
 // runCommand is a shortcut for running SSH command, it creates a client
 // connected to proxy of the passed in instance, runs the command, and returns
 // the result. If multiple attempts are requested, a 250 millisecond delay is

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1762,15 +1762,15 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 		webHandler, err = web.NewHandler(
 			web.Config{
-				Proxy:           tsrv,
-				AuthServers:     cfg.AuthServers[0],
-				DomainName:      cfg.Hostname,
-				ProxyClient:     conn.Client,
-				DisableUI:       process.Config.Proxy.DisableWebInterface,
-				ProxySSHAddr:    cfg.Proxy.SSHAddr,
-				ProxyWebAddr:    cfg.Proxy.WebAddr,
-				ClientTLSConfig: clientTLSConfig,
-				ProxySettings:   proxySettings,
+				Proxy:         tsrv,
+				AuthServers:   cfg.AuthServers[0],
+				DomainName:    cfg.Hostname,
+				ProxyClient:   conn.Client,
+				DisableUI:     process.Config.Proxy.DisableWebInterface,
+				ProxySSHAddr:  cfg.Proxy.SSHAddr,
+				ProxyWebAddr:  cfg.Proxy.WebAddr,
+				ProxySettings: proxySettings,
+				CipherSuites:  cfg.CipherSuites,
 			})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -964,7 +964,7 @@ func (s *RoleSuite) TestCheckRuleAccess(c *C) {
 		}
 		for j, check := range tc.checks {
 			comment := Commentf("test case %v '%v', check %v", i, tc.name, j)
-			result := set.CheckAccessToRule(&check.context, check.namespace, check.rule, check.verb)
+			result := set.CheckAccessToRule(&check.context, check.namespace, check.rule, check.verb, false)
 			if check.hasAccess {
 				c.Assert(result, IsNil, comment)
 			} else {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -20,7 +20,6 @@ package web
 
 import (
 	"compress/gzip"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -103,8 +102,8 @@ type Config struct {
 	// ProxyWebAddr points to the web (HTTPS) address of the proxy
 	ProxyWebAddr utils.NetAddr
 
-	// ClientTLSConfig is the TLS configuration the client uses.
-	ClientTLSConfig *tls.Config
+	// CipherSuites is the list of cipher suites Teleport suppports.
+	CipherSuites []uint16
 
 	// ProxySettings is a settings communicated to proxy
 	ProxySettings client.ProxySettings
@@ -126,7 +125,7 @@ func (r *RewritingHandler) Close() error {
 // NewHandler returns a new instance of web proxy handler
 func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	const apiPrefix = "/" + teleport.WebAPIVersion
-	lauth, err := newSessionCache(cfg.ProxyClient, []utils.NetAddr{cfg.AuthServers}, cfg.ClientTLSConfig)
+	lauth, err := newSessionCache(cfg.ProxyClient, []utils.NetAddr{cfg.AuthServers}, cfg.CipherSuites)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -214,16 +214,12 @@ func (s *WebSuite) SetUpTest(c *C) {
 	)
 	c.Assert(err, IsNil)
 
-	tlsConfig := &tls.Config{
-		CipherSuites: utils.DefaultCipherSuites(),
-	}
-
 	handler, err := NewHandler(Config{
-		Proxy:           revTunServer,
-		AuthServers:     utils.FromAddr(s.server.Addr()),
-		DomainName:      s.server.ClusterName(),
-		ProxyClient:     s.proxyClient,
-		ClientTLSConfig: tlsConfig,
+		Proxy:        revTunServer,
+		AuthServers:  utils.FromAddr(s.server.Addr()),
+		DomainName:   s.server.ClusterName(),
+		ProxyClient:  s.proxyClient,
+		CipherSuites: utils.DefaultCipherSuites(),
 	}, SetSessionStreamPollPeriod(200*time.Millisecond))
 	c.Assert(err, IsNil)
 
@@ -1623,7 +1619,7 @@ func removeSpace(in string) string {
 
 func newTerminalHandler() TerminalHandler {
 	return TerminalHandler{
-		log: logrus.WithFields(logrus.Fields{}),
+		log:     logrus.WithFields(logrus.Fields{}),
 		encoder: unicode.UTF8.NewEncoder(),
 		decoder: unicode.UTF8.NewDecoder(),
 	}

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -85,7 +85,9 @@ func getLogins(roleSet services.RoleSet) []string {
 
 func hasAccess(roleSet services.RoleSet, ctx *services.Context, kind string, verbs ...string) bool {
 	for _, verb := range verbs {
-		err := roleSet.CheckAccessToRule(ctx, defaults.Namespace, kind, verb)
+		// Since this check occurs often and it does not imply the caller is trying
+		// to access any resource, silence any logging done on the proxy.
+		err := roleSet.CheckAccessToRule(ctx, defaults.Namespace, kind, verb, true)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
**Purpose**

Pass cipher suites to `lib/web` and create a fresh `*tls.Config`. Also cleaned up logging to reduce logging for false positives.

**Implementation**

* Pass cipher suites to `lib/web` and create a fresh `*tls.Config`.
* Cleaned up logging.
* Added test coverage.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2132