### PR TITLE
Large Trusted Clusters

### DIFF
--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -350,13 +350,15 @@ func (a *AuthServer) validateSAMLResponse(samlResponse string) (*SAMLAuthRespons
 		response.Cert = certs.ssh
 		response.TLSCert = certs.tls
 
-		authorities, err := a.GetCertAuthorities(services.HostCA, false)
+		// Return the host CA for this cluster only.
+		authority, err := a.GetCertAuthority(services.CertAuthID{
+			Type:       services.HostCA,
+			DomainName: a.clusterName.GetClusterName(),
+		}, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		for _, authority := range authorities {
-			response.HostSigners = append(response.HostSigners, authority)
-		}
+		response.HostSigners = append(response.HostSigners, authority)
 	}
 	return response, nil
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -457,6 +457,7 @@ func (c *Config) SaveProfile(profileDir string, profileOptions ...ProfileOptions
 	if c.ProxyHostPort == "" {
 		return nil
 	}
+
 	profileDir = FullProfilePath(profileDir)
 	profilePath := path.Join(profileDir, c.ProxyHost()) + ".yaml"
 
@@ -1502,7 +1503,6 @@ func (tc *TeleportClient) Login(ctx context.Context, activateKey bool) (*Key, er
 			return nil, trace.Wrap(err)
 		}
 	}
-
 	return key, nil
 }
 
@@ -1567,6 +1567,12 @@ func (tc *TeleportClient) applyProxySettings(proxySettings ProxySettings) error 
 		if !exists {
 			tc.ProxyHostPort = fmt.Sprintf("%s:%d,%d", tc.ProxyHost(), tc.ProxyWebPort(), addr.Port(defaults.SSHProxyListenPort))
 		}
+	}
+	// If the proxy settings contain a SSH public address, overwrite the value
+	// passed in by the user with the value the proxy advertises.
+	if proxySettings.SSH.PublicAddr != "" {
+		tc.SetProxy(ProxyHost(proxySettings.SSH.PublicAddr), tc.ProxyWebPort(), tc.ProxySSHPort())
+		tc.localAgent.SetProxyHost(ProxyHost(proxySettings.SSH.PublicAddr))
 	}
 	return nil
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -57,11 +57,15 @@ import (
 	"github.com/docker/docker/pkg/term"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/terminal"
 )
+
+var log = logrus.WithFields(logrus.Fields{
+	trace.Component: teleport.ComponentClient,
+})
 
 const (
 	// Directory location where tsh profiles (and session keys) are stored
@@ -1319,10 +1323,10 @@ func (tc *TeleportClient) connectToProxy(ctx context.Context) (*ProxyClient, err
 			clientAddr:      tc.ClientAddr,
 		}
 	}
-	successMsg := fmt.Sprintf("[CLIENT] successful auth with proxy %v", proxyAddr)
+	successMsg := fmt.Sprintf("Successful auth with proxy %v.", proxyAddr)
 	// try to authenticate using every non interactive auth method we have:
 	for i, m := range tc.authMethods() {
-		log.Infof("[CLIENT] connecting proxy=%v login='%v' method=%d", proxyAddr, sshConfig.User, i)
+		log.Infof("Connecting to proxy %v with login %v and method %d.", proxyAddr, sshConfig.User, i)
 		var sshClient *ssh.Client
 
 		sshConfig.Auth = []ssh.AuthMethod{m}
@@ -1764,11 +1768,11 @@ func connectToSSHAgent() agent.Agent {
 	socketPath := os.Getenv(teleport.SSHAuthSock)
 	conn, err := agentconn.Dial(socketPath)
 	if err != nil {
-		log.Errorf("[KEY AGENT] Unable to connect to SSH agent on socket: %q.", socketPath)
+		log.Errorf("Unable to connect to SSH agent on socket: %q.", socketPath)
 		return nil
 	}
 
-	log.Infof("[KEY AGENT] Conneced to System Agent: %q", socketPath)
+	log.Infof("Conneced to System Agent: %q.", socketPath)
 	return agent.NewClient(conn)
 }
 

--- a/lib/client/bench.go
+++ b/lib/client/bench.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/codahale/hdrhistogram"
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 )
 
 // Benchmark specifies benchmark requests to run

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 )
 
 // ProxyClient implements ssh client to a teleport proxy
@@ -97,7 +96,7 @@ func (proxy *ProxyClient) GetSites() ([]services.Site, error) {
 		return nil, trace.ConnectionProblem(nil, "timeout")
 	}
 
-	log.Debugf("[CLIENT] found clusters: %v", stdout.String())
+	log.Debugf("Found clusters: %v.", stdout.String())
 
 	var sites []services.Site
 	if err := json.Unmarshal(stdout.Bytes(), &sites); err != nil {
@@ -332,7 +331,7 @@ func (proxy *ProxyClient) dialAuthServer(ctx context.Context, clusterName string
 // ConnectToNode connects to the ssh server via Proxy.
 // It returns connected and authenticated NodeClient
 func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress string, user string, quiet bool) (*NodeClient, error) {
-	log.Infof("[CLIENT] client=%v connecting to node=%s", proxy.clientAddr, nodeAddress)
+	log.Infof("Client %v connecting to node %s.", proxy.clientAddr, nodeAddress)
 
 	// parse destination first:
 	localAddr, err := utils.ParseAddr("tcp://" + proxy.proxyAddress)

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -110,6 +110,11 @@ func NewLocalAgent(keyDir string, proxyHost string, username string) (a *LocalKe
 	return a, nil
 }
 
+// SetProxyHost updates the proxy host for this agent.
+func (a *LocalKeyAgent) SetProxyHost(proxyHost string) {
+	a.proxyHost = proxyHost
+}
+
 // LoadKey adds a key into the Teleport ssh agent as well as the system ssh
 // agent.
 func (a *LocalKeyAgent) LoadKey(key Key) (*agent.AddedKey, error) {

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/check.v1"
 )
 

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -40,8 +40,6 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
-
-	log "github.com/sirupsen/logrus"
 )
 
 type NodeSession struct {

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -38,7 +38,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/mailgun/lemma/secret"
-	log "github.com/sirupsen/logrus"
 	"github.com/tstranex/u2f"
 )
 

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -308,10 +308,14 @@ type KubeProxySettings struct {
 	PublicAddr string `json:"public_addr,omitempty"`
 }
 
-// SSHProxySettings is SSH specific proxy settings
+// SSHProxySettings is SSH specific proxy settings.
 type SSHProxySettings struct {
-	// ListenAddr is SSH listen address
+	// ListenAddr is the address that the SSH proxy is listening for
+	// connections on.
 	ListenAddr string `json:"listen_addr,omitempty"`
+
+	// PublicAddr is the public address the SSH proxy is accessible at.
+	PublicAddr string `json:"public_addr,omitempty"`
 }
 
 // PingResponse contains the form of authentication the auth server supports.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1757,6 +1757,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				ListenAddr: cfg.Proxy.SSHAddr.String(),
 			},
 		}
+		if len(cfg.Proxy.PublicAddrs) > 0 {
+			proxySettings.SSH.PublicAddr = cfg.Proxy.PublicAddrs[0].String()
+		}
 		if len(cfg.Proxy.Kube.PublicAddrs) > 0 {
 			proxySettings.Kube.PublicAddr = cfg.Proxy.Kube.PublicAddrs[0].String()
 		}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -410,6 +410,17 @@ func onLogin(cf *CLIConf) {
 	// regular login (without -i flag)
 	tc.SaveProfile("")
 
+	// Make the client again (this way it will pick up the updated profile) and
+	// then update the known hosts file.
+	tc, err = makeClient(cf, true)
+	if err != nil {
+		utils.FatalError(err)
+	}
+	err = tc.UpdateKnownHosts(cf.Context)
+	if err != nil {
+		utils.FatalError(err)
+	}
+
 	onStatus(cf)
 }
 


### PR DESCRIPTION
**Purpose**

Fixes an issues where users can not SSO login using `tsh` on clusters that have 8 or more trusted clusters attached to it.

**Implementation**

* When validating a SAML response on a Auth Server, only send back the servers own host CA.
* Upon successful login, connect to the Auth Server and pull down all host CAs and update known hosts file.