### PR TITLE
Don't read configuration section if it's not enabled.

### DIFF
--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -397,6 +397,25 @@ func (s *ConfigTestSuite) TestApplyConfig(c *check.C) {
 	c.Assert(cfg.Proxy.ReverseTunnelListenAddr.FullAddress(), check.Equals, "tcp://tunnelhost:1001")
 }
 
+// TestApplyConfigNoneEnabled makes sure that if a section is not enabled,
+// it's fields are not read in.
+func (s *ConfigTestSuite) TestApplyConfigNoneEnabled(c *check.C) {
+	conf, err := ReadConfig(bytes.NewBufferString(NoServicesConfigString))
+	c.Assert(err, check.IsNil)
+	c.Assert(conf, check.NotNil)
+
+	cfg := service.MakeDefaultConfig()
+	err = ApplyFileConfig(conf, cfg)
+	c.Assert(err, check.IsNil)
+
+	c.Assert(cfg.Auth.Enabled, check.Equals, false)
+	c.Assert(cfg.Auth.PublicAddrs, check.HasLen, 0)
+	c.Assert(cfg.Proxy.Enabled, check.Equals, false)
+	c.Assert(cfg.Proxy.PublicAddrs, check.HasLen, 0)
+	c.Assert(cfg.SSH.Enabled, check.Equals, false)
+	c.Assert(cfg.SSH.PublicAddrs, check.HasLen, 0)
+}
+
 func (s *ConfigTestSuite) TestBackendDefaults(c *check.C) {
 	read := func(val string) *service.Config {
 		// default value is dir backend

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 import (

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package config
 
 const StaticConfigString = `
@@ -134,6 +135,26 @@ proxy_service:
   web_listen_addr: webhost
   tunnel_listen_addr: tunnelhost:1001
   public_addr: web3:443
+`
+
+// NoServicesConfigString is a configuration file with no services enabled
+// but with values for all services set.
+const NoServicesConfigString = `
+teleport:
+  nodename: node.example.com
+
+auth_service:
+  enabled: no
+  cluster_name: "example.com"
+  public_addr: "auth.example.com"
+
+ssh_service:
+  enabled: no
+  public_addr: "ssh.example.com"
+
+proxy_service:
+  enabled: no
+  public_addr: "proxy.example.com"
 `
 
 // LegacyAuthenticationSection is the deprecated format for authentication method. We still


### PR DESCRIPTION
**Purpose**

Don't read configuration section if it's not enabled.

**Implementation**

Check each configuration block for `auth_service`, `proxy_service`, and `ssh_service` to see if it's enabled before trying to apply file configuration.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1820