### PR TITLE
Updated "tctl tokens ..." command.

### DIFF
--- a/lib/asciitable/example_test.go
+++ b/lib/asciitable/example_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package asciitable
+
+import (
+	"fmt"
+)
+
+func ExampleMakeTable() {
+	// Create a table with three column headers.
+	t := MakeTable([]string{"Token", "Type", "Expiry Time (UTC)"})
+
+	// Add in multiple rows.
+	t.AddRow([]string{"b53bd9d3e04add33ac53edae1a2b3d4f", "auth", "30 Aug 18 23:31 UTC"})
+	t.AddRow([]string{"5ecde0ca17824454b21937109df2c2b5", "node", "30 Aug 18 23:31 UTC"})
+	t.AddRow([]string{"9333929146c08928a36466aea12df963", "trusted_cluster", "30 Aug 18 23:33 UTC"})
+
+	// Write the table to stdout.
+	fmt.Println(t.AsBuffer().String())
+}

--- a/lib/asciitable/table.go
+++ b/lib/asciitable/table.go
@@ -12,45 +12,33 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-This module implements a simple ASCII table formatter for printing
-tabular values into a text terminal.
-
-Example usage:
-
-func main() {
-	// building a table
-	t := MakeTable([]string{"Name", "Motto", "Age"})
-	t.AddRow([]string{"Joe Forrester", "Trains are much better than cars", "40"})
-	t.AddRow([]string{"Jesus", "Read the bible", "2018"})
-
-	// using the table:
-	t.WriteTo(os.Stdout)
-}
-
 */
 
+// Package asciitable implements a simple ASCII table formatter for printing
+// tabular values into a text terminal.
 package asciitable
 
 import (
 	"bytes"
 	"fmt"
 	"strings"
+	"text/tabwriter"
 )
 
+// column represents a column in the table. Contains the maximum width of the
+// column as well as the title.
 type column struct {
 	width int
 	title string
 }
 
-type PrintOptions int
-
+// Table holds tabular values in a rows and columns format.
 type Table struct {
 	columns []column
 	rows    [][]string
 }
 
-// MakeTable creates a new instance of the table with a given title
+// MakeTable creates a new instance of the table with given column names.
 func MakeTable(headers []string) Table {
 	t := MakeHeadlessTable(len(headers))
 	for i := range t.columns {
@@ -60,8 +48,8 @@ func MakeTable(headers []string) Table {
 	return t
 }
 
-// MakeTable creates a new instance of the table without a title,
-// but the number of columns must be set
+// MakeTable creates a new instance of the table without any column names.
+// The number of columns is required.
 func MakeHeadlessTable(columnCount int) Table {
 	return Table{
 		columns: make([]column, columnCount),
@@ -69,45 +57,7 @@ func MakeHeadlessTable(columnCount int) Table {
 	}
 }
 
-// Body returns the fully formatted table body as a buffer
-func (t *Table) Body() *bytes.Buffer {
-	var (
-		padding string
-		buf     bytes.Buffer
-	)
-	for _, row := range t.rows {
-		for columnIndex, cell := range row {
-			padding = strings.Repeat(" ", t.columns[columnIndex].width-len(cell)+1)
-			fmt.Fprintf(&buf, "%s%s", cell, padding)
-		}
-		fmt.Fprintln(&buf, "")
-	}
-	return &buf
-}
-
-// Header returns the fully formatted header as a buffer
-func (t *Table) Header() *bytes.Buffer {
-	var (
-		buf     bytes.Buffer
-		padding string
-	)
-	for i := range t.columns {
-		title := t.columns[i].title
-		padding = strings.Repeat(" ", t.columns[i].width-len(title)+1)
-		fmt.Fprintf(&buf, "%s%s", title, padding)
-	}
-	return &buf
-}
-
-// ColumnWidths returns the slice of ints that are the widths of each column
-func (t *Table) ColumnWidths() []int {
-	retval := make([]int, len(t.columns))
-	for i := range t.columns {
-		retval[i] = t.columns[i].width
-	}
-	return retval
-}
-
+// AddRow adds a row of cells to the table.
 func (t *Table) AddRow(row []string) {
 	limit := min(len(row), len(t.columns))
 	for i := 0; i < limit; i++ {
@@ -117,26 +67,40 @@ func (t *Table) AddRow(row []string) {
 	t.rows = append(t.rows, row[:limit])
 }
 
-// WriteTo prints the table to the given writer
+// AsBuffer returns a *bytes.Buffer with the printed output of the table.
 func (t *Table) AsBuffer() *bytes.Buffer {
-	var buf bytes.Buffer
+	var buffer bytes.Buffer
 
-	// the hearder:
+	writer := tabwriter.NewWriter(&buffer, 5, 0, 1, ' ', 0)
+	template := strings.Repeat("%v\t", len(t.columns))
+
+	// Header and separator.
 	if !t.IsHeadless() {
-		fmt.Fprintf(&buf, "%s\n", t.Header().String())
-		// the separator:
-		for _, w := range t.ColumnWidths() {
-			fmt.Fprintf(&buf, "%s ", strings.Repeat("-", w))
+		var colh []interface{}
+		var cols []interface{}
+
+		for _, col := range t.columns {
+			colh = append(colh, col.title)
+			cols = append(cols, strings.Repeat("-", col.width))
 		}
-		buf.WriteString("\n")
+		fmt.Fprintf(writer, template+"\n", colh...)
+		fmt.Fprintf(writer, template+"\n", cols...)
 	}
 
-	// the body:
-	fmt.Fprintf(&buf, "%s", t.Body().String())
-	return &buf
+	// Body.
+	for _, row := range t.rows {
+		var rowi []interface{}
+		for _, cell := range row {
+			rowi = append(rowi, cell)
+		}
+		fmt.Fprintf(writer, template+"\n", rowi...)
+	}
+
+	writer.Flush()
+	return &buffer
 }
 
-// IsHeadless returns 'true' if none of the table title cells contains any text
+// IsHeadless returns true if none of the table title cells contains any text.
 func (t *Table) IsHeadless() bool {
 	total := 0
 	for i := range t.columns {

--- a/lib/asciitable/table_test.go
+++ b/lib/asciitable/table_test.go
@@ -12,23 +12,23 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-package asciitable
-
 */
+
 package asciitable
 
 import (
+	"fmt"
 	"testing"
 
 	"gopkg.in/check.v1"
 )
 
-// bootstrap check
 func TestAsciiTable(t *testing.T) { check.TestingT(t) }
 
 type TableTestSuite struct {
 }
 
+var _ = fmt.Printf
 var _ = check.Suite(&TableTestSuite{})
 
 const fullTable = `Name          Motto                            Age  
@@ -37,8 +37,8 @@ Joe Forrester Trains are much better than cars 40
 Jesus         Read the bible                   2018 
 `
 
-const headlessTable = `one two 
-1   2   
+const headlessTable = `one  two  
+1    2    
 `
 
 func (s *TableTestSuite) TestFullTable(c *check.C) {
@@ -54,6 +54,6 @@ func (s *TableTestSuite) TestHeadlessTable(c *check.C) {
 	t.AddRow([]string{"one", "two", "three"})
 	t.AddRow([]string{"1", "2", "3"})
 
-	// the table shall have no header and also the 3rd column must be chopped off
+	// The table shall have no header and also the 3rd column must be chopped off.
 	c.Assert(t.AsBuffer().String(), check.Equals, headlessTable)
 }

--- a/roles.go
+++ b/roles.go
@@ -97,7 +97,7 @@ func (roles Roles) Include(role Role) bool {
 func (roles Roles) StringSlice() []string {
 	s := make([]string, 0)
 	for _, r := range roles {
-		s = append(s, string(r))
+		s = append(s, r.String())
 	}
 	return s
 }
@@ -140,9 +140,16 @@ func (r *Role) Set(v string) error {
 	return nil
 }
 
-// String returns debug-friendly representation of this role
+// String returns debug-friendly representation of this role.
 func (r *Role) String() string {
-	return fmt.Sprintf("%v", string(*r))
+	switch string(*r) {
+	case string(RoleSignup):
+		return "User signup"
+	case string(RoleTrustedCluster), string(LegacyClusterTokenType):
+		return "trusted_cluster"
+	default:
+		return fmt.Sprintf("%v", string(*r))
+	}
 }
 
 // Check checks if this a a valid role value, returns nil


### PR DESCRIPTION
**Purpose**

A variety of UX improvements around `tctl tokens ...`.

**Implementation**

The following changes have been made.

* Tokens are sorted by expiration date. This means new tokens show up at the bottom.
* Formatting issues have been fixed by switching to [text/tabwriter](https://golang.org/pkg/text/tabwriter/) package.
* The role column has been renamed to "Type".
* The "Signup" token has been renamed to "User signup" in `tctl tokens ls` output.
* The "Trustedcluster" token has been renamed "trusted_cluster" in `tctl tokens ls` output.

The following changes have **not** been made.

* Static tokens are not marked. At the moment `services.ProvisionToken` does not know if a token is static or dynamic. We can add this property if needed.
* `tctl tokens add --type=user` is not supported.

Example output:

```$ tctl tokens ls
Token                            Type            Expiry Time (UTC)   
-------------------------------- --------------- ------------------- 
foo                              Node,Auth,Proxy never               
bar                              trusted_cluster never               
829580dc469b5e3767ced272ff87f202 trusted_cluster 30 Aug 18 23:43 UTC 
```
```
$ tctl tokens add --type=trusted_cluster --ttl=4m
The cluster invite token: 829580dc469b5e3767ced272ff87f202
This token will expire in 4 minutes

Use this token when defining a trusted cluster resource on a remote cluster.
```
```
$ tctl nodes add --token=foo
The invite token: foo
This token will expire in 30 minutes

Run this on the new node to join the cluster:

> teleport start --roles=node --token=foo --auth-server=10.12.0.6:3025

Please note:

  - This invitation token will expire in 30 minutes
  - 10.12.0.6:3025 must be reachable from the new node
```