### PR TITLE
Issue 2188 - Allow order of users displayed when using web UI

### DIFF
--- a/web/src/app/flux/userAcl/store.js
+++ b/web/src/app/flux/userAcl/store.js
@@ -19,17 +19,6 @@ import { Store, toImmutable } from 'nuclear-js';
 import { Record, List } from 'immutable';
 import { RECEIVE_USERACL } from './actionTypes';
 
-// sort logins by making 'root' as the first in the list
-const sortLogins = loginList => {
-  let index = loginList.indexOf('root');
-  if (index !== -1) {
-    loginList = loginList.remove(index);
-    return loginList.sort().unshift('root')
-  }
-
-  return loginList;
-}
-
 const Access = new Record({
   list: false,
   read: false,
@@ -49,7 +38,7 @@ class AccessListRec extends Record({
     const map = toImmutable(json);    
     const sshLogins = new List(map.get('sshLogins'));            
     const params = {
-      sshLogins: sortLogins(sshLogins),
+      sshLogins: sshLogins,
       authConnectors: new Access(map.get('authConnectors')),
       trustedClusters: new Access(map.get('trustedClusters')),
       roles: new Access(map.get('roles')),


### PR DESCRIPTION
The behavior of always having root first is somewhat bizarre.  I looked through git logs and opened an issue but haven't gotten any response yet about why this exists.

The behavior I expect is user ordering to be preserved based on when a user is created with tctl, so I opened https://github.com/gravitational/teleport/issues/2188 and this PR to determine if that's possible.