### PR TITLE
Don't allow Teleport to be started with a different cluster name.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -112,12 +112,6 @@ func NewAuthServer(cfg *InitConfig, opts ...AuthServerOption) (*AuthServer, erro
 	if as.clock == nil {
 		as.clock = clockwork.NewRealClock()
 	}
-	if !cfg.SkipPeriodicOperations {
-		log.Infof("Auth server is running periodic operations.")
-		go as.runPeriodicOperations()
-	} else {
-		log.Infof("Auth server is skipping periodic operations.")
-	}
 
 	return &as, nil
 }


### PR DESCRIPTION
**Purpose**

Don't allow clusters to be renamed.

**Implementation**

Upon startup if setting of cluster name returns `trace.AlreadyExists`, fetch the cluster name from the backend and compare it to the existing name. If the names don't match, log a warning and continue with the cluster name set in the backend.

The following warning is logged:

```
WARN [AUTH]      Cannot rename cluster to "other.example.com": continuing with
"main.example.com". Teleport clusters can not be renamed once they are created. You
are seeing this warning for one of two reasons. Either you have not set "cluster_name" in
Teleport configuration and changed the hostname of the auth server or you are trying to
change the value of "cluster_name". auth/init.go:222
```

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2198