### PR TITLE
Update certs.pem file along with known hosts when fetching known CA.

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -412,7 +412,7 @@ func onLogin(cf *CLIConf) {
 	tc.SaveProfile("")
 
 	// Connect to the Auth Server and fetch the known hosts for this cluster.
-	err = tc.UpdateKnownHosts(cf.Context)
+	err = tc.UpdateKnownCA(cf.Context)
 	if err != nil {
 		utils.FatalError(err)
 	}


### PR DESCRIPTION
**Purpose**

In https://github.com/gravitational/teleport/pull/2193, the behavior of the Auth Server was changed to only send a single CA upon login and fetch all other CAs from the Auth Server. In that PR only the `~/.tsh/known_hosts` file was updated and not `~/.tsh/keys/proxy/certs.pem` which prevented successful connections to a remote auth server.

**Implementation**

Upon successful login, update both the known hosts file and certs file.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2204