### PR TITLE
Use random URL path

### DIFF
--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/mailgun/lemma/secret"
+	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/tstranex/u2f"
 )
@@ -228,10 +229,14 @@ func SSHAgentSSOLogin(ctx context.Context, proxyAddr, connectorID string, pubKey
 	// Start a HTTP server on the client that re-directs to the SAML provider.
 	// This creates nice short URLs and also works around some platforms (like
 	// Windows) that truncate long URLs before passing them to the default browser.
-	redir := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	redirPath := "/" + uuid.New()
+	redirMux := http.NewServeMux()
+	redirMux.HandleFunc(redirPath, func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, re.RedirectURL, http.StatusFound)
-	}))
+	})
+	redir := httptest.NewServer(redirMux)
 	defer redir.Close()
+	redirURL := redir.URL + redirPath
 
 	// If a command was found to launch the browser, create and start it.
 	var execCmd *exec.Cmd
@@ -240,19 +245,19 @@ func SSHAgentSSOLogin(ctx context.Context, proxyAddr, connectorID string, pubKey
 	case teleport.DarwinOS:
 		path, err := exec.LookPath(teleport.OpenBrowserDarwin)
 		if err == nil {
-			execCmd = exec.Command(path, redir.URL)
+			execCmd = exec.Command(path, redirURL)
 		}
 	// Windows.
 	case teleport.WindowsOS:
 		path, err := exec.LookPath(teleport.OpenBrowserWindows)
 		if err == nil {
-			execCmd = exec.Command(path, "url.dll,FileProtocolHandler", redir.URL)
+			execCmd = exec.Command(path, "url.dll,FileProtocolHandler", redirURL)
 		}
 	// Linux or any other operating sytem.
 	default:
 		path, err := exec.LookPath(teleport.OpenBrowserLinux)
 		if err == nil {
-			execCmd = exec.Command(path, redir.URL)
+			execCmd = exec.Command(path, redirURL)
 		}
 	}
 	if execCmd != nil {
@@ -261,7 +266,7 @@ func SSHAgentSSOLogin(ctx context.Context, proxyAddr, connectorID string, pubKey
 
 	// Print to screen in-case the command that launches the browser did not run.
 	fmt.Printf("If browser window does not open automatically, open it by ")
-	fmt.Printf("clicking on the link:\n %v\n", redir.URL)
+	fmt.Printf("clicking on the link:\n %v\n", redirURL)
 
 	log.Infof("Waiting for response at: %v.", server.URL)
 


### PR DESCRIPTION
This commit fixes #2214

This commit makes it a bit harder to get the redirect
URL created by local tsh by using random UUID
as a path.

This is done to make it hard to guess a redirect URL
generated by tsh.