### PR TITLE
Set some defaults from identity file.

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1002,8 +1002,8 @@ func (s *IntSuite) TestTwoClusters(c *check.C) {
 		c.Assert(err, check.IsNil)
 		c.Assert(outputA.String(), check.Equals, "hello world\n")
 
-		// Update known CAs.
-		err = tc.UpdateKnownCA(context.TODO())
+		// Update trusted CAs.
+		err = tc.UpdateTrustedCA(context.TODO())
 		c.Assert(err, check.IsNil)
 
 		// The known_hosts file should have two certificates, the way bytes.Split

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -87,7 +87,7 @@ func (s *ClientTestSuite) TestIdentityFileMaking(c *check.C) {
 	key.Pub = []byte("pub")
 
 	// test OpenSSH-compatible identity file creation:
-	err := MakeIdentityFile(keyFilePath, &key, IdentityFormatOpenSSH)
+	err := MakeIdentityFile(keyFilePath, &key, IdentityFormatOpenSSH, nil)
 	c.Assert(err, check.IsNil)
 
 	// key is OK:
@@ -102,7 +102,7 @@ func (s *ClientTestSuite) TestIdentityFileMaking(c *check.C) {
 
 	// test standard Teleport identity file creation:
 	keyFilePath = c.MkDir() + "file"
-	err = MakeIdentityFile(keyFilePath, &key, IdentityFormatFile)
+	err = MakeIdentityFile(keyFilePath, &key, IdentityFormatFile, nil)
 	c.Assert(err, check.IsNil)
 
 	// key+cert are OK:

--- a/lib/sshutils/close.go
+++ b/lib/sshutils/close.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2018 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sshutils
 
 import (

--- a/lib/sshutils/marshal.go
+++ b/lib/sshutils/marshal.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sshutils
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// MarshalAuthorizedKeysFormat returns the certificate authority public key exported as a single
+// line that can be placed in ~/.ssh/authorized_keys file. The format adheres to the
+// man sshd (8) authorized_keys format, a space-separated list of: options, keytype,
+// base64-encoded key, comment.
+// For example:
+//
+//    cert-authority AAA... type=user&clustername=cluster-a
+//
+// URL encoding is used to pass the CA type and cluster name into the comment field.
+func MarshalAuthorizedKeysFormat(clusterName string, keyBytes []byte) (string, error) {
+	comment := url.Values{
+		"type":        []string{"user"},
+		"clustername": []string{clusterName},
+	}
+
+	return fmt.Sprintf("cert-authority %s %s", strings.TrimSpace(string(keyBytes)), comment.Encode()), nil
+}
+
+// MarshalAuthorizedHostsFormat returns the certificate authority public key exported as a single line
+// that can be placed in ~/.ssh/authorized_hosts. The format adheres to the man sshd (8)
+// authorized_hosts format, a space-separated list of: marker, hosts, key, and comment.
+// For example:
+//
+//    @cert-authority *.cluster-a ssh-rsa AAA... type=host
+//
+// URL encoding is used to pass the CA type and allowed logins into the comment field.
+func MarshalAuthorizedHostsFormat(clusterName string, keyBytes []byte, logins []string) (string, error) {
+	comment := url.Values{
+		"type":   []string{"host"},
+		"logins": logins,
+	}
+
+	return fmt.Sprintf("@cert-authority *.%s %s %s",
+		clusterName, strings.TrimSpace(string(keyBytes)), comment.Encode()), nil
+}


### PR DESCRIPTION
This reduces the amount of typing some users have
to do when using identity file:

* Teleport user is set from the certificate
* Auth preference is set to local