### PR TITLE
Detect remote cluster by SNI name

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -53,7 +53,7 @@ type AccessPoint interface {
 	GetProxies() ([]services.Server, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id services.CertAuthID, loadKeys bool) (services.CertAuthority, error)
+	GetCertAuthority(id services.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
 	GetCertAuthorities(caType services.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]services.CertAuthority, error)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -653,19 +653,36 @@ func (s *AuthServer) GenerateToken(req GenerateTokenRequest) (string, error) {
 }
 
 // ClientCertPool returns trusted x509 cerificate authority pool
-func (s *AuthServer) ClientCertPool() (*x509.CertPool, error) {
+func (s *AuthServer) ClientCertPool(clusterName string) (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
 	var authorities []services.CertAuthority
-	hostCAs, err := s.GetCertAuthorities(services.HostCA, false, services.SkipValidation())
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if clusterName == "" {
+		hostCAs, err := s.GetCertAuthorities(services.HostCA, false, services.SkipValidation())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		userCAs, err := s.GetCertAuthorities(services.UserCA, false, services.SkipValidation())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		authorities = append(authorities, hostCAs...)
+		authorities = append(authorities, userCAs...)
+	} else {
+		hostCA, err := s.GetCertAuthority(
+			services.CertAuthID{Type: services.HostCA, DomainName: clusterName},
+			false, services.SkipValidation())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		userCA, err := s.GetCertAuthority(
+			services.CertAuthID{Type: services.UserCA, DomainName: clusterName},
+			false, services.SkipValidation())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		authorities = append(authorities, hostCA)
+		authorities = append(authorities, userCA)
 	}
-	userCAs, err := s.GetCertAuthorities(services.UserCA, false, services.SkipValidation())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	authorities = append(authorities, hostCAs...)
-	authorities = append(authorities, userCAs...)
 
 	for _, auth := range authorities {
 		for _, keyPair := range auth.GetTLSKeyPairs() {
@@ -774,7 +791,7 @@ func (s *AuthServer) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedK
 	// certificate as one of the DNS Names. It is not known in advance,
 	// that is why there is a default one for all certificates
 	if req.Roles.Include(teleport.RoleAuth) || req.Roles.Include(teleport.RoleAdmin) {
-		certRequest.DNSNames = append(certRequest.DNSNames, teleport.APIDomain)
+		certRequest.DNSNames = append(certRequest.DNSNames, "*."+teleport.APIDomain, teleport.APIDomain)
 	}
 	hostTLSCert, err := tlsAuthority.GenerateCertificate(certRequest)
 	if err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -210,7 +210,7 @@ func (a *AuthWithRoles) GetCertAuthorities(caType services.CertAuthType, loadKey
 	return a.authServer.GetCertAuthorities(caType, loadKeys, opts...)
 }
 
-func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool) (services.CertAuthority, error) {
+func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -219,7 +219,7 @@ func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool) 
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.GetCertAuthority(id, loadKeys)
+	return a.authServer.GetCertAuthority(id, loadKeys, opts...)
 }
 
 func (a *AuthWithRoles) GetDomainName() (string, error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -75,6 +76,33 @@ func (c *Client) TLSConfig() *tls.Config {
 // DialContext is a function that dials to the specified address
 type DialContext func(in context.Context, network, addr string) (net.Conn, error)
 
+// EncodeClusterName encodes cluster name in the SNI hostname
+func EncodeClusterName(clusterName string) string {
+	// hex is used to hide "." that will prevent wildcard *. entry to match
+	return fmt.Sprintf("%v.%v", hex.EncodeToString([]byte(clusterName)), teleport.APIDomain)
+}
+
+// DecodeClusterName decodes cluster name, returns NotFound
+// if no cluster name is encoded (empty subdomain),
+// so servers can detect cases when no server name passed
+// returns BadParameter if encoding does not match
+func DecodeClusterName(serverName string) (string, error) {
+	if serverName == teleport.APIDomain {
+		return "", trace.NotFound("no cluster name is encoded")
+	}
+	const suffix = "." + teleport.APIDomain
+	if !strings.HasSuffix(serverName, suffix) {
+		return "", trace.BadParameter("unrecognized name, expected suffix %v, got %q", teleport.APIDomain, serverName)
+	}
+	clusterName := strings.TrimSuffix(serverName, suffix)
+
+	decoded, err := hex.DecodeString(clusterName)
+	if err != nil {
+		return "", trace.BadParameter("failed to decode cluster name: %v", err)
+	}
+	return string(decoded), nil
+}
+
 // NewAddrDialer returns new dialer from a list of addresses
 func NewAddrDialer(addrs []utils.NetAddr) DialContext {
 	dialer := net.Dialer{
@@ -113,7 +141,9 @@ func ClientTimeout(timeout time.Duration) roundtrip.ClientParam {
 // NewTLSClientWithDialer returns new TLS client that uses mutual TLS authenticate
 // and dials the remote server using dialer
 func NewTLSClientWithDialer(dialContext DialContext, cfg *tls.Config, params ...roundtrip.ClientParam) (*Client, error) {
-	cfg.ServerName = teleport.APIDomain
+	if cfg.ServerName == "" {
+		cfg.ServerName = teleport.APIDomain
+	}
 	transport := &http.Transport{
 		// notice that below roundtrip.Client is passed
 		// teleport.APIEndpoint as an address for the API server, this is
@@ -400,7 +430,7 @@ func (c *Client) GetCertAuthorities(caType services.CertAuthType, loadKeys bool,
 
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
-func (c *Client) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool) (services.CertAuthority, error) {
+func (c *Client) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
 	if err := id.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -570,6 +570,7 @@ func (i *Identity) TLSConfig() (*tls.Config, error) {
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	tlsConfig.RootCAs = certPool
 	tlsConfig.ClientCAs = certPool
+	tlsConfig.ServerName = EncodeClusterName(i.ClusterName)
 	return tlsConfig, nil
 }
 

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -413,21 +413,18 @@ func (a *AuthServer) validateTrustedCluster(validateRequest *ValidateTrustedClus
 		}
 	}
 
-	// export our certificate authority and return it to the cluster
+	// export local cluster certificate authority and return it to the cluster
 	validateResponse := ValidateTrustedClusterResponse{
 		CAs: []services.CertAuthority{},
 	}
 	for _, caType := range []services.CertAuthType{services.HostCA, services.UserCA} {
-		certAuthorities, err := a.GetCertAuthorities(caType, false, services.SkipValidation())
+		certAuthority, err := a.GetCertAuthority(
+			services.CertAuthID{Type: caType, DomainName: domainName},
+			false, services.SkipValidation())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		for _, certAuthority := range certAuthorities {
-			if certAuthority.GetClusterName() == domainName {
-				validateResponse.CAs = append(validateResponse.CAs, certAuthority)
-			}
-		}
+		validateResponse.CAs = append(validateResponse.CAs, certAuthority)
 	}
 
 	// log the local certificate authorities we are sending

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -76,7 +76,6 @@ type localSite struct {
 	domainName  string
 	connections []*remoteConn
 	lastUsed    int
-	lastActive  time.Time
 	srv         *server
 
 	// client provides access to the Auth Server API of the local cluster.

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -53,13 +53,14 @@ type remoteSite struct {
 	domainName  string
 	connections []*remoteConn
 	lastUsed    int
-	lastActive  time.Time
 	srv         *server
 	transport   *http.Transport
 	connInfo    services.TunnelConnection
-	ctx         context.Context
-	cancel      context.CancelFunc
-	clock       clockwork.Clock
+	// lastConnInfo is the last conn
+	lastConnInfo services.TunnelConnection
+	ctx          context.Context
+	cancel       context.CancelFunc
+	clock        clockwork.Clock
 
 	// certificateCache caches host certificates for the forwarding server.
 	certificateCache *certificateCache
@@ -100,6 +101,10 @@ func (s *remoteSite) getRemoteClient() (auth.ClientI, bool, error) {
 		}
 		tlsConfig := s.srv.ClientTLS.Clone()
 		tlsConfig.RootCAs = pool
+		// encode the name of this cluster to identify this cluster,
+		// connecting to the remote one (it is used to find the right certificate
+		// authority to verify)
+		tlsConfig.ServerName = auth.EncodeClusterName(s.srv.ClusterName)
 		clt, err := auth.NewTLSClientWithDialer(s.authServerContextDialer, tlsConfig)
 		if err != nil {
 			return nil, false, trace.Wrap(err)
@@ -199,17 +204,8 @@ func (s *remoteSite) addConn(conn net.Conn, sshConn ssh.Conn) (*remoteConn, erro
 	return rc, nil
 }
 
-func (s *remoteSite) getLatestTunnelConnection() (services.TunnelConnection, error) {
-	conns, err := s.localAccessPoint.GetTunnelConnections(s.domainName)
-	if err != nil {
-		s.Warningf("failed to fetch tunnel statuses: %v", err)
-		return nil, trace.Wrap(err)
-	}
-	return services.LatestTunnelConnection(conns)
-}
-
 func (s *remoteSite) GetStatus() string {
-	connInfo, err := s.getLatestTunnelConnection()
+	connInfo, err := s.getLastConnInfo()
 	if err != nil {
 		return teleport.RemoteClusterStatusOffline
 	}
@@ -222,10 +218,26 @@ func (s *remoteSite) copyConnInfo() services.TunnelConnection {
 	return s.connInfo.Clone()
 }
 
+func (s *remoteSite) setLastConnInfo(connInfo services.TunnelConnection) {
+	s.Lock()
+	defer s.Unlock()
+	s.lastConnInfo = connInfo.Clone()
+}
+
+func (s *remoteSite) getLastConnInfo() (services.TunnelConnection, error) {
+	s.RLock()
+	defer s.RUnlock()
+	if s.lastConnInfo == nil {
+		return nil, trace.NotFound("no last connection found")
+	}
+	return s.lastConnInfo.Clone(), nil
+}
+
 func (s *remoteSite) registerHeartbeat(t time.Time) {
 	connInfo := s.copyConnInfo()
 	connInfo.SetLastHeartbeat(t)
 	connInfo.SetExpiry(s.clock.Now().Add(defaults.ReverseTunnelOfflineThreshold))
+	s.setLastConnInfo(connInfo)
 	err := s.localAccessPoint.UpsertTunnelConnection(connInfo)
 	if err != nil {
 		s.Warningf("failed to register heartbeat: %v", err)
@@ -286,7 +298,7 @@ func (s *remoteSite) GetName() string {
 }
 
 func (s *remoteSite) GetLastConnected() time.Time {
-	connInfo, err := s.getLatestTunnelConnection()
+	connInfo, err := s.getLastConnInfo()
 	if err != nil {
 		return time.Time{}
 	}

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -163,7 +163,7 @@ func (s *CA) DeactivateCertAuthority(id services.CertAuthID) error {
 
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
-func (s *CA) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool) (services.CertAuthority, error) {
+func (s *CA) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
 	if err := id.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -171,7 +171,7 @@ func (s *CA) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool) (ser
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	ca, err := services.GetCertAuthorityMarshaler().UnmarshalCertAuthority(data)
+	ca, err := services.GetCertAuthorityMarshaler().UnmarshalCertAuthority(data, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -52,7 +52,7 @@ type Trust interface {
 
 	// GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 	// controls if signing keys are loaded
-	GetCertAuthority(id CertAuthID, loadSigningKeys bool) (CertAuthority, error)
+	GetCertAuthority(id CertAuthID, loadSigningKeys bool, opts ...MarshalOption) (CertAuthority, error)
 
 	// GetCertAuthorities returns a list of authorities of a given type
 	// loadSigningKeys controls whether signing keys should be loaded or not

--- a/lib/state/cachingaccesspoint.go
+++ b/lib/state/cachingaccesspoint.go
@@ -497,15 +497,15 @@ func (cs *CachingAuthClient) GetProxies() (proxies []services.Server, err error)
 }
 
 // GetCertAuthority is a part of auth.AccessPoint implementation
-func (cs *CachingAuthClient) GetCertAuthority(id services.CertAuthID, loadKeys bool) (ca services.CertAuthority, err error) {
+func (cs *CachingAuthClient) GetCertAuthority(id services.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (ca services.CertAuthority, err error) {
 	cs.fetch(params{
 		key: certKey(id, loadKeys),
 		fetch: func() error {
-			ca, err = cs.ap.GetCertAuthority(id, loadKeys)
+			ca, err = cs.ap.GetCertAuthority(id, loadKeys, opts...)
 			return err
 		},
 		useCache: func() error {
-			ca, err = cs.trust.GetCertAuthority(id, loadKeys)
+			ca, err = cs.trust.GetCertAuthority(id, loadKeys, opts...)
 			return err
 		},
 		updateCache: func() (keys []string, cerr error) {

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -220,6 +220,7 @@ func (c *SessionContext) ClientTLSConfig(clusterName ...string) (*tls.Config, er
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	tlsConfig.RootCAs = certPool
+	tlsConfig.ServerName = auth.EncodeClusterName(c.parent.clusterName)
 	return tlsConfig, nil
 }
 
@@ -622,6 +623,7 @@ func (s *sessionCache) ValidateSession(user, sid string) (*SessionContext, error
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	tlsConfig.RootCAs = certPool
+	tlsConfig.ServerName = auth.EncodeClusterName(s.clusterName)
 
 	userClient, err := auth.NewTLSClient(s.authServers, tlsConfig)
 	if err != nil {


### PR DESCRIPTION
This commit improves performance on hundreds/thousands
trusted clsuter scenario by detecting remote cluster
by name and pulling trusted certificate authorities
only for this cluster hint.

Remote cluster sends its name in the TLS hello handshake
when connecting to the main cluster.

Main cluster uses it as a hint to pull relevant
certificate authorities and verify the handshake
credentials.