### PR TITLE
Detect remote cluster by SNI name

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -53,7 +53,7 @@ type AccessPoint interface {
 	GetProxies() ([]services.Server, error)
 
 	// GetCertAuthority returns cert authority by id
-	GetCertAuthority(id services.CertAuthID, loadKeys bool) (services.CertAuthority, error)
+	GetCertAuthority(id services.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error)
 
 	// GetCertAuthorities returns a list of cert authorities
 	GetCertAuthorities(caType services.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]services.CertAuthority, error)

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -77,8 +77,8 @@ type AccessPoint interface {
 	DeleteTunnelConnection(clusterName, connName string) error
 
 	// GetTunnelConnections returns tunnel connections for a given cluster
-	GetTunnelConnections(clusterName string) ([]services.TunnelConnection, error)
+	GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error)
 
 	// GetAllTunnelConnections returns all tunnel connections
-	GetAllTunnelConnections() ([]services.TunnelConnection, error)
+	GetAllTunnelConnections(opts ...services.MarshalOption) ([]services.TunnelConnection, error)
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -660,19 +660,36 @@ func (s *AuthServer) GenerateToken(req GenerateTokenRequest) (string, error) {
 }
 
 // ClientCertPool returns trusted x509 cerificate authority pool
-func (s *AuthServer) ClientCertPool() (*x509.CertPool, error) {
+func (s *AuthServer) ClientCertPool(clusterName string) (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
 	var authorities []services.CertAuthority
-	hostCAs, err := s.GetCertAuthorities(services.HostCA, false, services.SkipValidation())
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if clusterName == "" {
+		hostCAs, err := s.GetCertAuthorities(services.HostCA, false, services.SkipValidation())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		userCAs, err := s.GetCertAuthorities(services.UserCA, false, services.SkipValidation())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		authorities = append(authorities, hostCAs...)
+		authorities = append(authorities, userCAs...)
+	} else {
+		hostCA, err := s.GetCertAuthority(
+			services.CertAuthID{Type: services.HostCA, DomainName: clusterName},
+			false, services.SkipValidation())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		userCA, err := s.GetCertAuthority(
+			services.CertAuthID{Type: services.UserCA, DomainName: clusterName},
+			false, services.SkipValidation())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		authorities = append(authorities, hostCA)
+		authorities = append(authorities, userCA)
 	}
-	userCAs, err := s.GetCertAuthorities(services.UserCA, false, services.SkipValidation())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	authorities = append(authorities, hostCAs...)
-	authorities = append(authorities, userCAs...)
 
 	for _, auth := range authorities {
 		for _, keyPair := range auth.GetTLSKeyPairs() {
@@ -805,7 +822,7 @@ func (s *AuthServer) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedK
 	// certificate as one of the DNS Names. It is not known in advance,
 	// that is why there is a default one for all certificates
 	if req.Roles.Include(teleport.RoleAuth) || req.Roles.Include(teleport.RoleAdmin) {
-		certRequest.DNSNames = append(certRequest.DNSNames, teleport.APIDomain)
+		certRequest.DNSNames = append(certRequest.DNSNames, "*."+teleport.APIDomain, teleport.APIDomain)
 	}
 	hostTLSCert, err := tlsAuthority.GenerateCertificate(certRequest)
 	if err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1213,18 +1213,18 @@ func (a *AuthWithRoles) UpsertTunnelConnection(conn services.TunnelConnection) e
 	return a.authServer.UpsertTunnelConnection(conn)
 }
 
-func (a *AuthWithRoles) GetTunnelConnections(clusterName string) ([]services.TunnelConnection, error) {
+func (a *AuthWithRoles) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetTunnelConnections(clusterName)
+	return a.authServer.GetTunnelConnections(clusterName, opts...)
 }
 
-func (a *AuthWithRoles) GetAllTunnelConnections() ([]services.TunnelConnection, error) {
+func (a *AuthWithRoles) GetAllTunnelConnections(opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetAllTunnelConnections()
+	return a.authServer.GetAllTunnelConnections(opts...)
 }
 
 func (a *AuthWithRoles) DeleteTunnelConnection(clusterName string, connName string) error {
@@ -1268,11 +1268,11 @@ func (a *AuthWithRoles) GetRemoteCluster(clusterName string) (services.RemoteClu
 	return a.authServer.GetRemoteCluster(clusterName)
 }
 
-func (a *AuthWithRoles) GetRemoteClusters() ([]services.RemoteCluster, error) {
+func (a *AuthWithRoles) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
 	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetRemoteClusters()
+	return a.authServer.GetRemoteClusters(opts...)
 }
 
 func (a *AuthWithRoles) DeleteRemoteCluster(clusterName string) error {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -225,7 +225,7 @@ func (a *AuthWithRoles) GetCertAuthorities(caType services.CertAuthType, loadKey
 	return a.authServer.GetCertAuthorities(caType, loadKeys, opts...)
 }
 
-func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool) (services.CertAuthority, error) {
+func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -234,7 +234,7 @@ func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool) 
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.GetCertAuthority(id, loadKeys)
+	return a.authServer.GetCertAuthority(id, loadKeys, opts...)
 }
 
 func (a *AuthWithRoles) GetDomainName() (string, error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -75,6 +76,33 @@ func (c *Client) TLSConfig() *tls.Config {
 // DialContext is a function that dials to the specified address
 type DialContext func(in context.Context, network, addr string) (net.Conn, error)
 
+// EncodeClusterName encodes cluster name in the SNI hostname
+func EncodeClusterName(clusterName string) string {
+	// hex is used to hide "." that will prevent wildcard *. entry to match
+	return fmt.Sprintf("%v.%v", hex.EncodeToString([]byte(clusterName)), teleport.APIDomain)
+}
+
+// DecodeClusterName decodes cluster name, returns NotFound
+// if no cluster name is encoded (empty subdomain),
+// so servers can detect cases when no server name passed
+// returns BadParameter if encoding does not match
+func DecodeClusterName(serverName string) (string, error) {
+	if serverName == teleport.APIDomain {
+		return "", trace.NotFound("no cluster name is encoded")
+	}
+	const suffix = "." + teleport.APIDomain
+	if !strings.HasSuffix(serverName, suffix) {
+		return "", trace.BadParameter("unrecognized name, expected suffix %v, got %q", teleport.APIDomain, serverName)
+	}
+	clusterName := strings.TrimSuffix(serverName, suffix)
+
+	decoded, err := hex.DecodeString(clusterName)
+	if err != nil {
+		return "", trace.BadParameter("failed to decode cluster name: %v", err)
+	}
+	return string(decoded), nil
+}
+
 // NewAddrDialer returns new dialer from a list of addresses
 func NewAddrDialer(addrs []utils.NetAddr) DialContext {
 	dialer := net.Dialer{
@@ -113,7 +141,9 @@ func ClientTimeout(timeout time.Duration) roundtrip.ClientParam {
 // NewTLSClientWithDialer returns new TLS client that uses mutual TLS authenticate
 // and dials the remote server using dialer
 func NewTLSClientWithDialer(dialContext DialContext, cfg *tls.Config, params ...roundtrip.ClientParam) (*Client, error) {
-	cfg.ServerName = teleport.APIDomain
+	if cfg.ServerName == "" {
+		cfg.ServerName = teleport.APIDomain
+	}
 	transport := &http.Transport{
 		// notice that below roundtrip.Client is passed
 		// teleport.APIEndpoint as an address for the API server, this is
@@ -417,7 +447,7 @@ func (c *Client) GetCertAuthorities(caType services.CertAuthType, loadKeys bool,
 
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
-func (c *Client) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool) (services.CertAuthority, error) {
+func (c *Client) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
 	if err := id.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -713,7 +713,7 @@ func (c *Client) UpsertTunnelConnection(conn services.TunnelConnection) error {
 }
 
 // GetTunnelConnections returns tunnel connections for a given cluster
-func (c *Client) GetTunnelConnections(clusterName string) ([]services.TunnelConnection, error) {
+func (c *Client) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing cluster name parameter")
 	}
@@ -737,7 +737,7 @@ func (c *Client) GetTunnelConnections(clusterName string) ([]services.TunnelConn
 }
 
 // GetAllTunnelConnections returns all tunnel connections
-func (c *Client) GetAllTunnelConnections() ([]services.TunnelConnection, error) {
+func (c *Client) GetAllTunnelConnections(opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	out, err := c.Get(c.Endpoint("tunnelconnections"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -795,7 +795,7 @@ func (c *Client) GetUserLoginAttempts(user string) ([]services.LoginAttempt, err
 }
 
 // GetRemoteClusters returns a list of remote clusters
-func (c *Client) GetRemoteClusters() ([]services.RemoteCluster, error) {
+func (c *Client) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
 	out, err := c.Get(c.Endpoint("remoteclusters"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -617,6 +617,7 @@ func (i *Identity) TLSConfig(cipherSuites []uint16) (*tls.Config, error) {
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	tlsConfig.RootCAs = certPool
 	tlsConfig.ClientCAs = certPool
+	tlsConfig.ServerName = EncodeClusterName(i.ClusterName)
 	return tlsConfig, nil
 }
 

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -120,13 +120,25 @@ func (t *TLSServer) Serve(listener net.Listener) error {
 // and server's GetConfigForClient reloads the list of trusted
 // local and remote certificate authorities
 func (t *TLSServer) GetConfigForClient(info *tls.ClientHelloInfo) (*tls.Config, error) {
+	var clusterName string
+	var err error
+	if info.ServerName != "" {
+		clusterName, err = DecodeClusterName(info.ServerName)
+		if err != nil {
+			if !trace.IsNotFound(err) {
+				log.Warningf("Client sent unsupported cluster name %q, what resulted in error %v.", info.ServerName, err)
+				return nil, trace.AccessDenied("access is denied")
+			}
+		}
+	}
+
 	// update client certificate pool based on currently trusted TLS
 	// certificate authorities.
 	// TODO(klizhentas) drop connections of the TLS cert authorities
 	// that are not trusted
 	// TODO(klizhentas) what are performance implications of returning new config
 	// per connections? E.g. what happens to session tickets. Benchmark this.
-	pool, err := t.AuthServer.ClientCertPool()
+	pool, err := t.AuthServer.ClientCertPool(clusterName)
 	if err != nil {
 		log.Errorf("failed to retrieve client pool: %v", trace.DebugReport(err))
 		// this falls back to the default config

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -354,10 +354,10 @@ func (a *AuthServer) updateRemoteClusterStatus(remoteCluster services.RemoteClus
 }
 
 // GetRemoteClusters returns remote clusters with udpated statuses
-func (a *AuthServer) GetRemoteClusters() ([]services.RemoteCluster, error) {
+func (a *AuthServer) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	remoteClusters, err := a.Presence.GetRemoteClusters()
+	remoteClusters, err := a.Presence.GetRemoteClusters(opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -413,21 +413,18 @@ func (a *AuthServer) validateTrustedCluster(validateRequest *ValidateTrustedClus
 		}
 	}
 
-	// export our certificate authority and return it to the cluster
+	// export local cluster certificate authority and return it to the cluster
 	validateResponse := ValidateTrustedClusterResponse{
 		CAs: []services.CertAuthority{},
 	}
 	for _, caType := range []services.CertAuthType{services.HostCA, services.UserCA} {
-		certAuthorities, err := a.GetCertAuthorities(caType, false, services.SkipValidation())
+		certAuthority, err := a.GetCertAuthority(
+			services.CertAuthID{Type: caType, DomainName: domainName},
+			false, services.SkipValidation())
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		for _, certAuthority := range certAuthorities {
-			if certAuthority.GetClusterName() == domainName {
-				validateResponse.CAs = append(validateResponse.CAs, certAuthority)
-			}
-		}
+		validateResponse.CAs = append(validateResponse.CAs, certAuthority)
 	}
 
 	// log the local certificate authorities we are sending

--- a/lib/backend/dir/impl.go
+++ b/lib/backend/dir/impl.go
@@ -559,7 +559,7 @@ func readBucket(f *os.File) (map[string]bucketItem, error) {
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-	err = json.Unmarshal(bytes, &items)
+	err = utils.FastUnmarshal(bytes, &items)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/backend/dir/impl.go
+++ b/lib/backend/dir/impl.go
@@ -133,7 +133,7 @@ func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
 }
 
 // GetItems returns all items (key/value pairs) in a given bucket.
-func (bk *Backend) GetItems(bucket []string) ([]backend.Item, error) {
+func (bk *Backend) GetItems(bucket []string, opts ...backend.OpOption) ([]backend.Item, error) {
 	var out []backend.Item
 
 	// Get a list of all buckets in the backend.
@@ -186,10 +186,13 @@ func (bk *Backend) GetItems(bucket []string) ([]backend.Item, error) {
 				continue
 			}
 
+			fullPath := filepath.Join(filepath.Base(pathToBucket), k)
 			out = append(out, backend.Item{
-				Key:   key,
-				Value: v.Value,
+				FullPath: fullPath,
+				Key:      key,
+				Value:    v.Value,
 			})
+
 		}
 	}
 
@@ -639,10 +642,10 @@ func removeDuplicates(items []backend.Item) []backend.Item {
 
 	// Loop over all items, if it has not been seen before, append to result.
 	for _, e := range items {
-		_, ok := encountered[e.Key]
+		_, ok := encountered[e.FullPath]
 		if !ok {
 			// Record this element as an encountered element.
-			encountered[e.Key] = true
+			encountered[e.FullPath] = true
 
 			// Append to result slice.
 			result = append(result, e)

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -22,6 +22,7 @@ package dynamo
 import (
 	"testing"
 
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -47,7 +48,8 @@ func (s *DynamoDBSuite) SetUpSuite(c *C) {
 		"table_name": s.tableName,
 	})
 	c.Assert(err, IsNil)
-	s.bk = bk.(*DynamoDBBackend)
+	sanitizer := bk.(*backend.Sanitizer)
+	s.bk = sanitizer.Backend().(*DynamoDBBackend)
 	c.Assert(err, IsNil)
 	s.suite.B = s.bk
 }

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -70,12 +70,12 @@ func (s *Sanitizer) GetKeys(bucket []string) ([]string, error) {
 }
 
 // GetItems returns a list of items (key value pairs) for a bucket.
-func (s *Sanitizer) GetItems(bucket []string) ([]Item, error) {
+func (s *Sanitizer) GetItems(bucket []string, opts ...OpOption) ([]Item, error) {
 	if !isSliceSafe(bucket) {
 		return nil, trace.BadParameter(errorMessage)
 	}
 
-	return s.backend.GetItems(bucket)
+	return s.backend.GetItems(bucket, opts...)
 }
 
 // CreateVal creates value with a given TTL and key in the bucket. If the

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -103,7 +103,7 @@ func (n *nopBackend) GetKeys(bucket []string) ([]string, error) {
 	return []string{"foo"}, nil
 }
 
-func (n *nopBackend) GetItems(bucket []string) ([]Item, error) {
+func (n *nopBackend) GetItems(bucket []string, opts ...OpOption) ([]Item, error) {
 	return []Item{Item{Key: "foo", Value: []byte("bar")}}, nil
 }
 

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -175,10 +175,14 @@ func (s *BackendSuite) BatchCRUD(c *C) {
 	c.Assert(items[0].Key, Equals, "akey")
 	c.Assert(string(items[1].Value), Equals, "val1")
 	c.Assert(items[1].Key, Equals, "bkey")
-	c.Assert(string(items[2].Value), Equals, "val11")
-	c.Assert(items[2].Key, Equals, "sub1")
-	c.Assert(string(items[3].Value), Equals, "val12")
-	c.Assert(items[3].Key, Equals, "sub1")
+
+	// both keys are equal, so order is not strictly defined,
+	// compare it as a map
+	v := map[string]string{}
+	v[string(items[2].Value)] = items[2].Key
+	v[string(items[3].Value)] = items[3].Key
+	c.Assert(v, DeepEquals, map[string]string{"val11": "sub1", "val12": "sub1"})
+
 	c.Assert(string(items[4].Value), Equals, "val31")
 	c.Assert(items[4].Key, Equals, "sub2")
 

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -162,6 +162,26 @@ func (s *BackendSuite) BatchCRUD(c *C) {
 	c.Assert(items[0].Key, Equals, "akey")
 	c.Assert(string(items[1].Value), Equals, "val1")
 	c.Assert(items[1].Key, Equals, "bkey")
+
+	c.Assert(s.B.UpsertVal([]string{"a", "b", "sub1"}, "subkey11", []byte("val11"), 0), IsNil)
+	c.Assert(s.B.UpsertVal([]string{"a", "b", "sub1"}, "subkey12", []byte("val12"), 0), IsNil)
+	c.Assert(s.B.UpsertVal([]string{"a", "b", "sub2", "sub3"}, "subkey31", []byte("val31"), 0), IsNil)
+
+	items, err = s.B.GetItems([]string{"a", "b"}, backend.WithRecursive())
+	c.Assert(err, IsNil)
+	c.Assert(len(items), Equals, 5)
+
+	c.Assert(string(items[0].Value), Equals, "val2")
+	c.Assert(items[0].Key, Equals, "akey")
+	c.Assert(string(items[1].Value), Equals, "val1")
+	c.Assert(items[1].Key, Equals, "bkey")
+	c.Assert(string(items[2].Value), Equals, "val11")
+	c.Assert(items[2].Key, Equals, "sub1")
+	c.Assert(string(items[3].Value), Equals, "val12")
+	c.Assert(items[3].Key, Equals, "sub1")
+	c.Assert(string(items[4].Value), Equals, "val31")
+	c.Assert(items[4].Key, Equals, "sub2")
+
 }
 
 // Directories checks directories access

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -251,10 +251,10 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 
 	// apply connection throttling:
-	limiters := []limiter.LimiterConfig{
-		cfg.SSH.Limiter,
-		cfg.Auth.Limiter,
-		cfg.Proxy.Limiter,
+	limiters := []*limiter.LimiterConfig{
+		&cfg.SSH.Limiter,
+		&cfg.Auth.Limiter,
+		&cfg.Proxy.Limiter,
 	}
 	for _, l := range limiters {
 		if fc.Limits.MaxConnections > 0 {
@@ -271,7 +271,6 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 			})
 		}
 	}
-
 	// add static signed keypairs supplied from configs
 	for i := range fc.Global.Keys {
 		identity, err := fc.Global.Keys[i].Identity()

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -77,7 +77,6 @@ type localSite struct {
 	domainName  string
 	connections []*remoteConn
 	lastUsed    int
-	lastActive  time.Time
 	srv         *server
 
 	// client provides access to the Auth Server API of the local cluster.

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -439,7 +439,7 @@ func (s *remoteSite) isOnline(conn services.TunnelConnection) bool {
 // connections
 func (s *remoteSite) findDisconnectedProxies() ([]services.Server, error) {
 	connInfo := s.copyConnInfo()
-	conns, err := s.localAccessPoint.GetTunnelConnections(s.domainName)
+	conns, err := s.localAccessPoint.GetTunnelConnections(s.domainName, services.SkipValidation())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -53,13 +53,14 @@ type remoteSite struct {
 	domainName  string
 	connections []*remoteConn
 	lastUsed    int
-	lastActive  time.Time
 	srv         *server
 	transport   *http.Transport
 	connInfo    services.TunnelConnection
-	ctx         context.Context
-	cancel      context.CancelFunc
-	clock       clockwork.Clock
+	// lastConnInfo is the last conn
+	lastConnInfo services.TunnelConnection
+	ctx          context.Context
+	cancel       context.CancelFunc
+	clock        clockwork.Clock
 
 	// certificateCache caches host certificates for the forwarding server.
 	certificateCache *certificateCache
@@ -100,6 +101,10 @@ func (s *remoteSite) getRemoteClient() (auth.ClientI, bool, error) {
 		}
 		tlsConfig := s.srv.ClientTLS.Clone()
 		tlsConfig.RootCAs = pool
+		// encode the name of this cluster to identify this cluster,
+		// connecting to the remote one (it is used to find the right certificate
+		// authority to verify)
+		tlsConfig.ServerName = auth.EncodeClusterName(s.srv.ClusterName)
 		clt, err := auth.NewTLSClientWithDialer(s.authServerContextDialer, tlsConfig)
 		if err != nil {
 			return nil, false, trace.Wrap(err)
@@ -204,17 +209,8 @@ func (s *remoteSite) addConn(conn net.Conn, sshConn ssh.Conn) (*remoteConn, erro
 	return rc, nil
 }
 
-func (s *remoteSite) getLatestTunnelConnection() (services.TunnelConnection, error) {
-	conns, err := s.localAccessPoint.GetTunnelConnections(s.domainName)
-	if err != nil {
-		s.Warningf("failed to fetch tunnel statuses: %v", err)
-		return nil, trace.Wrap(err)
-	}
-	return services.LatestTunnelConnection(conns)
-}
-
 func (s *remoteSite) GetStatus() string {
-	connInfo, err := s.getLatestTunnelConnection()
+	connInfo, err := s.getLastConnInfo()
 	if err != nil {
 		return teleport.RemoteClusterStatusOffline
 	}
@@ -227,10 +223,26 @@ func (s *remoteSite) copyConnInfo() services.TunnelConnection {
 	return s.connInfo.Clone()
 }
 
+func (s *remoteSite) setLastConnInfo(connInfo services.TunnelConnection) {
+	s.Lock()
+	defer s.Unlock()
+	s.lastConnInfo = connInfo.Clone()
+}
+
+func (s *remoteSite) getLastConnInfo() (services.TunnelConnection, error) {
+	s.RLock()
+	defer s.RUnlock()
+	if s.lastConnInfo == nil {
+		return nil, trace.NotFound("no last connection found")
+	}
+	return s.lastConnInfo.Clone(), nil
+}
+
 func (s *remoteSite) registerHeartbeat(t time.Time) {
 	connInfo := s.copyConnInfo()
 	connInfo.SetLastHeartbeat(t)
 	connInfo.SetExpiry(s.clock.Now().Add(defaults.ReverseTunnelOfflineThreshold))
+	s.setLastConnInfo(connInfo)
 	err := s.localAccessPoint.UpsertTunnelConnection(connInfo)
 	if err != nil {
 		s.Warningf("failed to register heartbeat: %v", err)
@@ -291,7 +303,7 @@ func (s *remoteSite) GetName() string {
 }
 
 func (s *remoteSite) GetLastConnected() time.Time {
-	connInfo, err := s.getLatestTunnelConnection()
+	connInfo, err := s.getLastConnInfo()
 	if err != nil {
 		return time.Time{}
 	}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -560,7 +560,7 @@ func (s *server) isUserAuthority(auth ssh.PublicKey) bool {
 }
 
 func (s *server) getTrustedCAKeys(CertType services.CertAuthType) ([]ssh.PublicKey, error) {
-	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false)
+	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false, services.SkipValidation())
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +576,7 @@ func (s *server) getTrustedCAKeys(CertType services.CertAuthType) ([]ssh.PublicK
 }
 
 func (s *server) checkTrustedKey(CertType services.CertAuthType, domainName string, key ssh.PublicKey) error {
-	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false)
+	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false, services.SkipValidation())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -83,7 +82,6 @@ type server struct {
 	// Server API.
 	localAccessPoint auth.AccessPoint
 
-	hostCertChecker ssh.CertChecker
 	userCertChecker ssh.CertChecker
 
 	// srv is the "base class" i.e. the underlying SSH server
@@ -264,7 +262,6 @@ func NewServer(cfg Config) (Server, error) {
 		return nil, err
 	}
 	srv.userCertChecker = ssh.CertChecker{IsUserAuthority: srv.isUserAuthority}
-	srv.hostCertChecker = ssh.CertChecker{IsHostAuthority: srv.isHostAuthority}
 	srv.srv = s
 	go srv.periodicFunctions()
 	return srv, nil
@@ -559,8 +556,16 @@ func (s *server) isUserAuthority(auth ssh.PublicKey) bool {
 	return false
 }
 
-func (s *server) getTrustedCAKeys(CertType services.CertAuthType) ([]ssh.PublicKey, error) {
-	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false, services.SkipValidation())
+func (s *server) getTrustedCAKeysByID(id services.CertAuthID) ([]ssh.PublicKey, error) {
+	ca, err := s.localAccessPoint.GetCertAuthority(id, false, services.SkipValidation())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return ca.Checkers()
+}
+
+func (s *server) getTrustedCAKeys(certType services.CertAuthType) ([]ssh.PublicKey, error) {
+	cas, err := s.localAccessPoint.GetCertAuthorities(certType, false, services.SkipValidation())
 	if err != nil {
 		return nil, err
 	}
@@ -573,28 +578,6 @@ func (s *server) getTrustedCAKeys(CertType services.CertAuthType) ([]ssh.PublicK
 		out = append(out, checkers...)
 	}
 	return out, nil
-}
-
-func (s *server) checkTrustedKey(CertType services.CertAuthType, domainName string, key ssh.PublicKey) error {
-	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false, services.SkipValidation())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	for _, ca := range cas {
-		if ca.GetClusterName() != domainName {
-			continue
-		}
-		checkers, err := ca.Checkers()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		for _, checker := range checkers {
-			if sshutils.KeysEqual(key, checker) {
-				return nil
-			}
-		}
-	}
-	return trace.NotFound("authority domain %v not found or has no mathching keys", domainName)
 }
 
 func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
@@ -617,31 +600,9 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permiss
 			logger.Warningf("Failed to authenticate host, err: %v.", err)
 			return nil, err
 		}
-		// CheckHostKey expects the addr that is passed in to be in the format
-		// host:port. This is because this function is usually used by a client to
-		// check if the host it attempted to connect to presented a certificate for
-		// the host requested (this prevents man-in-the-middle attacks).
-		//
-		// In this situation however, it's a server essentially performing user
-		// authentication, but since it's machine-to-machine communication, the
-		// "user" is presenting a host certificate. To make CheckHostKey behave
-		// like Authenticate we pass in a addr in the host:port format it expects.
-		addr := formatAddr(conn.User())
-		err := s.hostCertChecker.CheckHostKey(addr, conn.RemoteAddr(), key)
+		err := s.checkHostCert(logger, conn.User(), authDomain, cert)
 		if err != nil {
 			logger.Warningf("Failed to authenticate host, err: %v.", err)
-			return nil, trace.Wrap(err)
-		}
-		if err := s.hostCertChecker.CheckCert(conn.User(), cert); err != nil {
-			logger.Warningf("Failed to authenticate host err: %v.", err)
-			return nil, trace.Wrap(err)
-		}
-		// this fixes possible injection attack
-		// when we have 2 trusted remote sites, and one can simply
-		// pose as another. so we have to check that authority
-		// matches by some other way (in absence of x509 chains)
-		if err := s.checkTrustedKey(services.HostCA, authDomain, cert.SignatureKey); err != nil {
-			logger.Warningf("This client claims to be signed as cluster %q, but no matching signing keys found", authDomain)
 			return nil, trace.Wrap(err)
 		}
 		return &ssh.Permissions{
@@ -672,6 +633,43 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permiss
 	default:
 		return nil, trace.BadParameter("unsupported cert type: %v", cert.CertType)
 	}
+}
+
+// checkHostCert verifies that host certificate is signed
+// by the recognized certificate authority
+func (s *server) checkHostCert(logger *log.Entry, user string, clusterName string, cert *ssh.Certificate) error {
+	if cert.CertType != ssh.HostCert {
+		return trace.BadParameter("expected host cert, got wrong cert type: %d", cert.CertType)
+	}
+
+	// fetch keys of the certificate authority to check
+	// if there is a match
+	keys, err := s.getTrustedCAKeysByID(services.CertAuthID{
+		Type:       services.HostCA,
+		DomainName: clusterName,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// match key of the certificate authority with the signature key
+	var match bool
+	for _, k := range keys {
+		if sshutils.KeysEqual(k, cert.SignatureKey) {
+			match = true
+			break
+		}
+	}
+	if !match {
+		return trace.NotFound("cluster %v has no matching CA keys", clusterName)
+	}
+
+	checker := ssh.CertChecker{}
+	if err := checker.CheckCert(user, cert); err != nil {
+		return trace.BadParameter(err.Error())
+	}
+
+	return nil
 }
 
 func (s *server) upsertSite(conn net.Conn, sshConn *ssh.ServerConn) (*remoteSite, *remoteConn, error) {
@@ -910,29 +908,6 @@ func newRemoteSite(srv *server, domainName string) (*remoteSite, error) {
 	go remoteSite.periodicUpdateCertAuthorities()
 
 	return remoteSite, nil
-}
-
-// formatAddr adds :port to the passed in string if it's not in
-// host:port format.
-func formatAddr(s string) string {
-	i := strings.Index(s, ":")
-	if i == -1 {
-		return s + ":0"
-	}
-	if i == len(s)-1 {
-		return s[:len(s)-1] + ":0"
-	}
-
-	port, err := strconv.Atoi(s[i+1:])
-	if err != nil {
-		return s[:i] + ":0"
-	}
-
-	if port < 0 || port > 65535 {
-		return s[:i] + ":0"
-	}
-
-	return s
 }
 
 const (

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -42,13 +42,22 @@ func (process *TeleportProcess) connect(role teleport.Role) (conn *Connector, er
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	// TODO(klizhentas): REMOVE IN 3.1
+	// this is a migration clutch, used to re-register
+	// in case if identity of the auth server does not have the wildcard cert
+	if role == teleport.RoleAdmin || role == teleport.RoleAuth {
+		if !identity.HasPrincipals([]string{"*." + teleport.APIDomain}) {
+			process.Debugf("Detected Auth server certificate without wildcard, regenerating.")
+			return process.firstTimeConnect(role)
+		}
+	}
 
 	rotation := state.Spec.Rotation
 
 	switch rotation.State {
 	// rotation is on standby, so just use whatever is current
 	case "", services.RotationStateStandby:
-		// The roles of admin and auth are treaded in a special way, as in this case
+		// The roles of admin and auth are treated in a special way, as in this case
 		// the process does not need TLS clients and can use local auth directly.
 		if role == teleport.RoleAdmin || role == teleport.RoleAuth {
 			return &Connector{

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -163,7 +163,7 @@ func (s *CA) DeactivateCertAuthority(id services.CertAuthID) error {
 
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
-func (s *CA) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool) (services.CertAuthority, error) {
+func (s *CA) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
 	if err := id.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -171,7 +171,7 @@ func (s *CA) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool) (ser
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	ca, err := services.GetCertAuthorityMarshaler().UnmarshalCertAuthority(data)
+	ca, err := services.GetCertAuthorityMarshaler().UnmarshalCertAuthority(data, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -106,10 +106,10 @@ type Presence interface {
 	UpsertTunnelConnection(TunnelConnection) error
 
 	// GetTunnelConnections returns tunnel connections for a given cluster
-	GetTunnelConnections(clusterName string) ([]TunnelConnection, error)
+	GetTunnelConnections(clusterName string, opts ...MarshalOption) ([]TunnelConnection, error)
 
 	// GetAllTunnelConnections returns all tunnel connections
-	GetAllTunnelConnections() ([]TunnelConnection, error)
+	GetAllTunnelConnections(opts ...MarshalOption) ([]TunnelConnection, error)
 
 	// DeleteTunnelConnection deletes tunnel connection by name
 	DeleteTunnelConnection(clusterName string, connName string) error
@@ -124,7 +124,7 @@ type Presence interface {
 	CreateRemoteCluster(RemoteCluster) error
 
 	// GetRemoteClusters returns a list of remote clusters
-	GetRemoteClusters() ([]RemoteCluster, error)
+	GetRemoteClusters(opts ...MarshalOption) ([]RemoteCluster, error)
 
 	// GetRemoteCluster returns a remote cluster by name
 	GetRemoteCluster(clusterName string) (RemoteCluster, error)

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -52,7 +52,7 @@ type Trust interface {
 
 	// GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 	// controls if signing keys are loaded
-	GetCertAuthority(id CertAuthID, loadSigningKeys bool) (CertAuthority, error)
+	GetCertAuthority(id CertAuthID, loadSigningKeys bool, opts ...MarshalOption) (CertAuthority, error)
 
 	// GetCertAuthorities returns a list of authorities of a given type
 	// loadSigningKeys controls whether signing keys should be loaded or not

--- a/lib/state/cachingaccesspoint.go
+++ b/lib/state/cachingaccesspoint.go
@@ -209,7 +209,7 @@ func (cs *CachingAuthClient) fetchAll() error {
 			continue
 		}
 		clusters[clusterName] = true
-		_, err = cs.GetTunnelConnections(clusterName)
+		_, err = cs.GetTunnelConnections(clusterName, services.SkipValidation())
 		errors = append(errors, err)
 	}
 	return trace.NewAggregate(errors...)
@@ -647,7 +647,7 @@ func (cs *CachingAuthClient) GetTunnelConnections(clusterName string, opts ...se
 	})
 	if err != nil {
 		if trace.IsConnectionProblem(err) {
-			return cs.presence.GetTunnelConnections(clusterName)
+			return cs.presence.GetTunnelConnections(clusterName, opts...)
 		}
 		return conns, err
 	}

--- a/lib/state/cachingaccesspoint.go
+++ b/lib/state/cachingaccesspoint.go
@@ -497,15 +497,15 @@ func (cs *CachingAuthClient) GetProxies() (proxies []services.Server, err error)
 }
 
 // GetCertAuthority is a part of auth.AccessPoint implementation
-func (cs *CachingAuthClient) GetCertAuthority(id services.CertAuthID, loadKeys bool) (ca services.CertAuthority, err error) {
+func (cs *CachingAuthClient) GetCertAuthority(id services.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (ca services.CertAuthority, err error) {
 	cs.fetch(params{
 		key: certKey(id, loadKeys),
 		fetch: func() error {
-			ca, err = cs.ap.GetCertAuthority(id, loadKeys)
+			ca, err = cs.ap.GetCertAuthority(id, loadKeys, opts...)
 			return err
 		},
 		useCache: func() error {
-			ca, err = cs.trust.GetCertAuthority(id, loadKeys)
+			ca, err = cs.trust.GetCertAuthority(id, loadKeys, opts...)
 			return err
 		},
 		updateCache: func() (keys []string, cerr error) {

--- a/lib/state/cachingaccesspoint.go
+++ b/lib/state/cachingaccesspoint.go
@@ -640,9 +640,9 @@ func (cs *CachingAuthClient) GetUsers() (users []services.User, err error) {
 // GetTunnelConnections is a part of auth.AccessPoint implementation
 // GetTunnelConnections are not using recent cache as they are designed
 // to be called periodically and always return fresh data
-func (cs *CachingAuthClient) GetTunnelConnections(clusterName string) (conns []services.TunnelConnection, err error) {
+func (cs *CachingAuthClient) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) (conns []services.TunnelConnection, err error) {
 	err = cs.try(func() error {
-		conns, err = cs.ap.GetTunnelConnections(clusterName)
+		conns, err = cs.ap.GetTunnelConnections(clusterName, opts...)
 		return err
 	})
 	if err != nil {
@@ -668,9 +668,9 @@ func (cs *CachingAuthClient) GetTunnelConnections(clusterName string) (conns []s
 // GetAllTunnelConnections is a part of auth.AccessPoint implementation
 // GetAllTunnelConnections are not using recent cache, as they are designed
 // to be called periodically and always return fresh data
-func (cs *CachingAuthClient) GetAllTunnelConnections() (conns []services.TunnelConnection, err error) {
+func (cs *CachingAuthClient) GetAllTunnelConnections(opts ...services.MarshalOption) (conns []services.TunnelConnection, err error) {
 	err = cs.try(func() error {
-		conns, err = cs.ap.GetAllTunnelConnections()
+		conns, err = cs.ap.GetAllTunnelConnections(opts...)
 		return err
 	})
 	if err != nil {

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -220,6 +220,7 @@ func (c *SessionContext) ClientTLSConfig(clusterName ...string) (*tls.Config, er
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	tlsConfig.RootCAs = certPool
+	tlsConfig.ServerName = auth.EncodeClusterName(c.parent.clusterName)
 	return tlsConfig, nil
 }
 
@@ -625,6 +626,7 @@ func (s *sessionCache) ValidateSession(user, sid string) (*SessionContext, error
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	tlsConfig.RootCAs = certPool
+	tlsConfig.ServerName = auth.EncodeClusterName(s.clusterName)
 
 	userClient, err := auth.NewTLSClient(s.authServers, tlsConfig)
 	if err != nil {


### PR DESCRIPTION
This commit improves performance of teleport with
hundreds of connected trusted clusters.

TLS handshake protocol expects server to send a
list of trusted certificate authorities to the client
and client must present certificate signed by those.

With Teleport current implementation, every remote cluster
client is signed by local certificate and is not cross
signed.

Auth server now expects clients to announce the
remote cluster they are connecting from using SNI.

Auth server will send only certificate authorities
of the cluster announced via SNI.

Alternative idea is to cross sign the certificate
of the client of the remote cluster. We will explore
this idea in the next releases.

This commit also removes unnecessary reads
from the database to check the remote server status
that slows down user interface and other clients.

This is done at the expense of proxies showing
servers as offline in case if this individual
proxy does not have the connection, although
it's a small UI price to pay for not reading
the database, as proxy will eventually
get the connection thanks to the discovery
protocol.