### PR TITLE
Batch get for tunnel connection, remote cluster

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -77,8 +77,8 @@ type AccessPoint interface {
 	DeleteTunnelConnection(clusterName, connName string) error
 
 	// GetTunnelConnections returns tunnel connections for a given cluster
-	GetTunnelConnections(clusterName string) ([]services.TunnelConnection, error)
+	GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error)
 
 	// GetAllTunnelConnections returns all tunnel connections
-	GetAllTunnelConnections() ([]services.TunnelConnection, error)
+	GetAllTunnelConnections(opts ...services.MarshalOption) ([]services.TunnelConnection, error)
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1213,18 +1213,18 @@ func (a *AuthWithRoles) UpsertTunnelConnection(conn services.TunnelConnection) e
 	return a.authServer.UpsertTunnelConnection(conn)
 }
 
-func (a *AuthWithRoles) GetTunnelConnections(clusterName string) ([]services.TunnelConnection, error) {
+func (a *AuthWithRoles) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetTunnelConnections(clusterName)
+	return a.authServer.GetTunnelConnections(clusterName, opts...)
 }
 
-func (a *AuthWithRoles) GetAllTunnelConnections() ([]services.TunnelConnection, error) {
+func (a *AuthWithRoles) GetAllTunnelConnections(opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetAllTunnelConnections()
+	return a.authServer.GetAllTunnelConnections(opts...)
 }
 
 func (a *AuthWithRoles) DeleteTunnelConnection(clusterName string, connName string) error {
@@ -1268,11 +1268,11 @@ func (a *AuthWithRoles) GetRemoteCluster(clusterName string) (services.RemoteClu
 	return a.authServer.GetRemoteCluster(clusterName)
 }
 
-func (a *AuthWithRoles) GetRemoteClusters() ([]services.RemoteCluster, error) {
+func (a *AuthWithRoles) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
 	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetRemoteClusters()
+	return a.authServer.GetRemoteClusters(opts...)
 }
 
 func (a *AuthWithRoles) DeleteRemoteCluster(clusterName string) error {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -713,7 +713,7 @@ func (c *Client) UpsertTunnelConnection(conn services.TunnelConnection) error {
 }
 
 // GetTunnelConnections returns tunnel connections for a given cluster
-func (c *Client) GetTunnelConnections(clusterName string) ([]services.TunnelConnection, error) {
+func (c *Client) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing cluster name parameter")
 	}
@@ -737,7 +737,7 @@ func (c *Client) GetTunnelConnections(clusterName string) ([]services.TunnelConn
 }
 
 // GetAllTunnelConnections returns all tunnel connections
-func (c *Client) GetAllTunnelConnections() ([]services.TunnelConnection, error) {
+func (c *Client) GetAllTunnelConnections(opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	out, err := c.Get(c.Endpoint("tunnelconnections"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -795,7 +795,7 @@ func (c *Client) GetUserLoginAttempts(user string) ([]services.LoginAttempt, err
 }
 
 // GetRemoteClusters returns a list of remote clusters
-func (c *Client) GetRemoteClusters() ([]services.RemoteCluster, error) {
+func (c *Client) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
 	out, err := c.Get(c.Endpoint("remoteclusters"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -354,10 +354,10 @@ func (a *AuthServer) updateRemoteClusterStatus(remoteCluster services.RemoteClus
 }
 
 // GetRemoteClusters returns remote clusters with udpated statuses
-func (a *AuthServer) GetRemoteClusters() ([]services.RemoteCluster, error) {
+func (a *AuthServer) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	remoteClusters, err := a.Presence.GetRemoteClusters()
+	remoteClusters, err := a.Presence.GetRemoteClusters(opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/backend/dir/impl.go
+++ b/lib/backend/dir/impl.go
@@ -133,7 +133,7 @@ func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
 }
 
 // GetItems returns all items (key/value pairs) in a given bucket.
-func (bk *Backend) GetItems(bucket []string) ([]backend.Item, error) {
+func (bk *Backend) GetItems(bucket []string, opts ...backend.OpOption) ([]backend.Item, error) {
 	var out []backend.Item
 
 	// Get a list of all buckets in the backend.
@@ -186,10 +186,13 @@ func (bk *Backend) GetItems(bucket []string) ([]backend.Item, error) {
 				continue
 			}
 
+			fullPath := filepath.Join(filepath.Base(pathToBucket), k)
 			out = append(out, backend.Item{
-				Key:   key,
-				Value: v.Value,
+				FullPath: fullPath,
+				Key:      key,
+				Value:    v.Value,
 			})
+
 		}
 	}
 
@@ -639,10 +642,10 @@ func removeDuplicates(items []backend.Item) []backend.Item {
 
 	// Loop over all items, if it has not been seen before, append to result.
 	for _, e := range items {
-		_, ok := encountered[e.Key]
+		_, ok := encountered[e.FullPath]
 		if !ok {
 			// Record this element as an encountered element.
-			encountered[e.Key] = true
+			encountered[e.FullPath] = true
 
 			// Append to result slice.
 			result = append(result, e)

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -22,6 +22,7 @@ package dynamo
 import (
 	"testing"
 
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -47,7 +48,8 @@ func (s *DynamoDBSuite) SetUpSuite(c *C) {
 		"table_name": s.tableName,
 	})
 	c.Assert(err, IsNil)
-	s.bk = bk.(*DynamoDBBackend)
+	sanitizer := bk.(*backend.Sanitizer)
+	s.bk = sanitizer.Backend().(*DynamoDBBackend)
 	c.Assert(err, IsNil)
 	s.suite.B = s.bk
 }

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -70,12 +70,12 @@ func (s *Sanitizer) GetKeys(bucket []string) ([]string, error) {
 }
 
 // GetItems returns a list of items (key value pairs) for a bucket.
-func (s *Sanitizer) GetItems(bucket []string) ([]Item, error) {
+func (s *Sanitizer) GetItems(bucket []string, opts ...OpOption) ([]Item, error) {
 	if !isSliceSafe(bucket) {
 		return nil, trace.BadParameter(errorMessage)
 	}
 
-	return s.backend.GetItems(bucket)
+	return s.backend.GetItems(bucket, opts...)
 }
 
 // CreateVal creates value with a given TTL and key in the bucket. If the

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -103,7 +103,7 @@ func (n *nopBackend) GetKeys(bucket []string) ([]string, error) {
 	return []string{"foo"}, nil
 }
 
-func (n *nopBackend) GetItems(bucket []string) ([]Item, error) {
+func (n *nopBackend) GetItems(bucket []string, opts ...OpOption) ([]Item, error) {
 	return []Item{Item{Key: "foo", Value: []byte("bar")}}, nil
 }
 

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -162,6 +162,26 @@ func (s *BackendSuite) BatchCRUD(c *C) {
 	c.Assert(items[0].Key, Equals, "akey")
 	c.Assert(string(items[1].Value), Equals, "val1")
 	c.Assert(items[1].Key, Equals, "bkey")
+
+	c.Assert(s.B.UpsertVal([]string{"a", "b", "sub1"}, "subkey11", []byte("val11"), 0), IsNil)
+	c.Assert(s.B.UpsertVal([]string{"a", "b", "sub1"}, "subkey12", []byte("val12"), 0), IsNil)
+	c.Assert(s.B.UpsertVal([]string{"a", "b", "sub2", "sub3"}, "subkey31", []byte("val31"), 0), IsNil)
+
+	items, err = s.B.GetItems([]string{"a", "b"}, backend.WithRecursive())
+	c.Assert(err, IsNil)
+	c.Assert(len(items), Equals, 5)
+
+	c.Assert(string(items[0].Value), Equals, "val2")
+	c.Assert(items[0].Key, Equals, "akey")
+	c.Assert(string(items[1].Value), Equals, "val1")
+	c.Assert(items[1].Key, Equals, "bkey")
+	c.Assert(string(items[2].Value), Equals, "val11")
+	c.Assert(items[2].Key, Equals, "sub1")
+	c.Assert(string(items[3].Value), Equals, "val12")
+	c.Assert(items[3].Key, Equals, "sub1")
+	c.Assert(string(items[4].Value), Equals, "val31")
+	c.Assert(items[4].Key, Equals, "sub2")
+
 }
 
 // Directories checks directories access

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -251,10 +251,10 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 
 	// apply connection throttling:
-	limiters := []limiter.LimiterConfig{
-		cfg.SSH.Limiter,
-		cfg.Auth.Limiter,
-		cfg.Proxy.Limiter,
+	limiters := []*limiter.LimiterConfig{
+		&cfg.SSH.Limiter,
+		&cfg.Auth.Limiter,
+		&cfg.Proxy.Limiter,
 	}
 	for _, l := range limiters {
 		if fc.Limits.MaxConnections > 0 {
@@ -271,7 +271,6 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 			})
 		}
 	}
-
 	// add static signed keypairs supplied from configs
 	for i := range fc.Global.Keys {
 		identity, err := fc.Global.Keys[i].Identity()

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -560,7 +560,7 @@ func (s *server) isUserAuthority(auth ssh.PublicKey) bool {
 }
 
 func (s *server) getTrustedCAKeys(CertType services.CertAuthType) ([]ssh.PublicKey, error) {
-	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false)
+	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false, services.SkipValidation())
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +576,7 @@ func (s *server) getTrustedCAKeys(CertType services.CertAuthType) ([]ssh.PublicK
 }
 
 func (s *server) checkTrustedKey(CertType services.CertAuthType, domainName string, key ssh.PublicKey) error {
-	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false)
+	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false, services.SkipValidation())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -83,7 +82,6 @@ type server struct {
 	// Server API.
 	localAccessPoint auth.AccessPoint
 
-	hostCertChecker ssh.CertChecker
 	userCertChecker ssh.CertChecker
 
 	// srv is the "base class" i.e. the underlying SSH server
@@ -264,7 +262,6 @@ func NewServer(cfg Config) (Server, error) {
 		return nil, err
 	}
 	srv.userCertChecker = ssh.CertChecker{IsUserAuthority: srv.isUserAuthority}
-	srv.hostCertChecker = ssh.CertChecker{IsHostAuthority: srv.isHostAuthority}
 	srv.srv = s
 	go srv.periodicFunctions()
 	return srv, nil
@@ -559,8 +556,16 @@ func (s *server) isUserAuthority(auth ssh.PublicKey) bool {
 	return false
 }
 
-func (s *server) getTrustedCAKeys(CertType services.CertAuthType) ([]ssh.PublicKey, error) {
-	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false, services.SkipValidation())
+func (s *server) getTrustedCAKeysByID(id services.CertAuthID) ([]ssh.PublicKey, error) {
+	ca, err := s.localAccessPoint.GetCertAuthority(id, false, services.SkipValidation())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return ca.Checkers()
+}
+
+func (s *server) getTrustedCAKeys(certType services.CertAuthType) ([]ssh.PublicKey, error) {
+	cas, err := s.localAccessPoint.GetCertAuthorities(certType, false, services.SkipValidation())
 	if err != nil {
 		return nil, err
 	}
@@ -573,28 +578,6 @@ func (s *server) getTrustedCAKeys(CertType services.CertAuthType) ([]ssh.PublicK
 		out = append(out, checkers...)
 	}
 	return out, nil
-}
-
-func (s *server) checkTrustedKey(CertType services.CertAuthType, domainName string, key ssh.PublicKey) error {
-	cas, err := s.localAccessPoint.GetCertAuthorities(CertType, false, services.SkipValidation())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	for _, ca := range cas {
-		if ca.GetClusterName() != domainName {
-			continue
-		}
-		checkers, err := ca.Checkers()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		for _, checker := range checkers {
-			if sshutils.KeysEqual(key, checker) {
-				return nil
-			}
-		}
-	}
-	return trace.NotFound("authority domain %v not found or has no mathching keys", domainName)
 }
 
 func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
@@ -617,31 +600,9 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permiss
 			logger.Warningf("Failed to authenticate host, err: %v.", err)
 			return nil, err
 		}
-		// CheckHostKey expects the addr that is passed in to be in the format
-		// host:port. This is because this function is usually used by a client to
-		// check if the host it attempted to connect to presented a certificate for
-		// the host requested (this prevents man-in-the-middle attacks).
-		//
-		// In this situation however, it's a server essentially performing user
-		// authentication, but since it's machine-to-machine communication, the
-		// "user" is presenting a host certificate. To make CheckHostKey behave
-		// like Authenticate we pass in a addr in the host:port format it expects.
-		addr := formatAddr(conn.User())
-		err := s.hostCertChecker.CheckHostKey(addr, conn.RemoteAddr(), key)
+		err := s.checkHostCert(logger, conn.User(), authDomain, cert)
 		if err != nil {
 			logger.Warningf("Failed to authenticate host, err: %v.", err)
-			return nil, trace.Wrap(err)
-		}
-		if err := s.hostCertChecker.CheckCert(conn.User(), cert); err != nil {
-			logger.Warningf("Failed to authenticate host err: %v.", err)
-			return nil, trace.Wrap(err)
-		}
-		// this fixes possible injection attack
-		// when we have 2 trusted remote sites, and one can simply
-		// pose as another. so we have to check that authority
-		// matches by some other way (in absence of x509 chains)
-		if err := s.checkTrustedKey(services.HostCA, authDomain, cert.SignatureKey); err != nil {
-			logger.Warningf("This client claims to be signed as cluster %q, but no matching signing keys found", authDomain)
 			return nil, trace.Wrap(err)
 		}
 		return &ssh.Permissions{
@@ -672,6 +633,43 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permiss
 	default:
 		return nil, trace.BadParameter("unsupported cert type: %v", cert.CertType)
 	}
+}
+
+// checkHostCert verifies that host certificate is signed
+// by the recognized certificate authority
+func (s *server) checkHostCert(logger *log.Entry, user string, clusterName string, cert *ssh.Certificate) error {
+	if cert.CertType != ssh.HostCert {
+		return trace.BadParameter("expected host cert, got wrong cert type: %d", cert.CertType)
+	}
+
+	// fetch keys of the certificate authority to check
+	// if there is a match
+	keys, err := s.getTrustedCAKeysByID(services.CertAuthID{
+		Type:       services.HostCA,
+		DomainName: clusterName,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// match key of the certificate authority with the signature key
+	var match bool
+	for _, k := range keys {
+		if sshutils.KeysEqual(k, cert.SignatureKey) {
+			match = true
+			break
+		}
+	}
+	if !match {
+		return trace.NotFound("cluster %v has no matching CA keys", clusterName)
+	}
+
+	checker := ssh.CertChecker{}
+	if err := checker.CheckCert(user, cert); err != nil {
+		return trace.BadParameter(err.Error())
+	}
+
+	return nil
 }
 
 func (s *server) upsertSite(conn net.Conn, sshConn *ssh.ServerConn) (*remoteSite, *remoteConn, error) {
@@ -910,29 +908,6 @@ func newRemoteSite(srv *server, domainName string) (*remoteSite, error) {
 	go remoteSite.periodicUpdateCertAuthorities()
 
 	return remoteSite, nil
-}
-
-// formatAddr adds :port to the passed in string if it's not in
-// host:port format.
-func formatAddr(s string) string {
-	i := strings.Index(s, ":")
-	if i == -1 {
-		return s + ":0"
-	}
-	if i == len(s)-1 {
-		return s[:len(s)-1] + ":0"
-	}
-
-	port, err := strconv.Atoi(s[i+1:])
-	if err != nil {
-		return s[:i] + ":0"
-	}
-
-	if port < 0 || port > 65535 {
-		return s[:i] + ":0"
-	}
-
-	return s
 }
 
 const (

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -106,10 +106,10 @@ type Presence interface {
 	UpsertTunnelConnection(TunnelConnection) error
 
 	// GetTunnelConnections returns tunnel connections for a given cluster
-	GetTunnelConnections(clusterName string) ([]TunnelConnection, error)
+	GetTunnelConnections(clusterName string, opts ...MarshalOption) ([]TunnelConnection, error)
 
 	// GetAllTunnelConnections returns all tunnel connections
-	GetAllTunnelConnections() ([]TunnelConnection, error)
+	GetAllTunnelConnections(opts ...MarshalOption) ([]TunnelConnection, error)
 
 	// DeleteTunnelConnection deletes tunnel connection by name
 	DeleteTunnelConnection(clusterName string, connName string) error
@@ -124,7 +124,7 @@ type Presence interface {
 	CreateRemoteCluster(RemoteCluster) error
 
 	// GetRemoteClusters returns a list of remote clusters
-	GetRemoteClusters() ([]RemoteCluster, error)
+	GetRemoteClusters(opts ...MarshalOption) ([]RemoteCluster, error)
 
 	// GetRemoteCluster returns a remote cluster by name
 	GetRemoteCluster(clusterName string) (RemoteCluster, error)

--- a/lib/state/cachingaccesspoint.go
+++ b/lib/state/cachingaccesspoint.go
@@ -640,9 +640,9 @@ func (cs *CachingAuthClient) GetUsers() (users []services.User, err error) {
 // GetTunnelConnections is a part of auth.AccessPoint implementation
 // GetTunnelConnections are not using recent cache as they are designed
 // to be called periodically and always return fresh data
-func (cs *CachingAuthClient) GetTunnelConnections(clusterName string) (conns []services.TunnelConnection, err error) {
+func (cs *CachingAuthClient) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) (conns []services.TunnelConnection, err error) {
 	err = cs.try(func() error {
-		conns, err = cs.ap.GetTunnelConnections(clusterName)
+		conns, err = cs.ap.GetTunnelConnections(clusterName, opts...)
 		return err
 	})
 	if err != nil {
@@ -668,9 +668,9 @@ func (cs *CachingAuthClient) GetTunnelConnections(clusterName string) (conns []s
 // GetAllTunnelConnections is a part of auth.AccessPoint implementation
 // GetAllTunnelConnections are not using recent cache, as they are designed
 // to be called periodically and always return fresh data
-func (cs *CachingAuthClient) GetAllTunnelConnections() (conns []services.TunnelConnection, err error) {
+func (cs *CachingAuthClient) GetAllTunnelConnections(opts ...services.MarshalOption) (conns []services.TunnelConnection, err error) {
 	err = cs.try(func() error {
-		conns, err = cs.ap.GetAllTunnelConnections()
+		conns, err = cs.ap.GetAllTunnelConnections(opts...)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
Use batch fetch for tunnel connections
and remote cluster objects to speed up
teleport in scenarios with many trusted clusters.