### PR TITLE
Read kubernetes config from kubeconfig

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -82,9 +82,6 @@ func NewAuthServer(cfg *InitConfig, opts ...AuthServerOption) (*AuthServer, erro
 	if cfg.AuditLog == nil {
 		cfg.AuditLog = events.NewDiscardAuditLog()
 	}
-	if cfg.KubeCACertPath == "" {
-		cfg.KubeCACertPath = teleport.KubeCAPath
-	}
 
 	closeCtx, cancelFunc := context.WithCancel(context.TODO())
 	as := AuthServer{
@@ -104,7 +101,7 @@ func NewAuthServer(cfg *InitConfig, opts ...AuthServerOption) (*AuthServer, erro
 		githubClients:        make(map[string]*githubClient),
 		cancelFunc:           cancelFunc,
 		closeCtx:             closeCtx,
-		kubeCACertPath:       cfg.KubeCACertPath,
+		kubeconfigPath:       cfg.KubeconfigPath,
 	}
 	for _, o := range opts {
 		o(&as)
@@ -157,8 +154,8 @@ type AuthServer struct {
 	// cipherSuites is a list of ciphersuites that the auth server supports.
 	cipherSuites []uint16
 
-	// kubeCACertPath is a path to PEM encoded kubernetes CA certificate
-	kubeCACertPath string
+	// kubeconfigPath is a path to PEM encoded kubernetes CA certificate
+	kubeconfigPath string
 }
 
 // runPeriodicOperations runs some periodic bookkeeping operations

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -127,8 +127,8 @@ type InitConfig struct {
 	// CipherSuites is a list of ciphersuites that the auth server supports.
 	CipherSuites []uint16
 
-	// KubeCACertPath is an optional path to kubernetes CA certificate authority
-	KubeCACertPath string
+	// KubeconfigPath is an optional path to kubernetes config file
+	KubeconfigPath string
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -17,16 +17,22 @@ limitations under the License.
 package auth
 
 import (
+	"fmt"
 	"io/ioutil"
+	"net"
+	"net/url"
+	"os"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/kube/authority"
+	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 
 	"github.com/gravitational/trace"
+	"k8s.io/client-go/kubernetes"
 )
 
 // KubeCSR is a kubernetes CSR request
@@ -53,6 +59,21 @@ type KubeCSRResponse struct {
 	Cert []byte `json:"cert"`
 	// CertAuthorities is a list of PEM block with trusted cert authorities
 	CertAuthorities [][]byte `json:"cert_authorities"`
+	// TargetAddr is an optional target address
+	// of the kubernetes API server that can be set
+	// in the kubeconfig
+	TargetAddr string `json:"target_addr"`
+}
+
+type kubeCreds struct {
+	// clt is a working kubernetes client
+	clt *kubernetes.Clientset
+	// caPEM is a PEM encoded certificate authority
+	// of the kubernetes API server
+	caPEM []byte
+	// targetAddr is a target address of the
+	// kubernetes cluster read from config
+	targetAddr string
 }
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
@@ -66,19 +87,25 @@ func (s *AuthServer) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// generate cluster with local kubernetes cluster
 	if req.ClusterName == s.clusterName.GetClusterName() {
-		caPEM, err := ioutil.ReadFile(s.kubeCACertPath)
+		log.Debugf("Generating certificate for local Kubernetes cluster.")
+
+		kubeCreds, err := s.getKubeClient()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		log.Debugf("Generating certificate with local Kubernetes cluster.")
-		cert, err := authority.ProcessCSR(req.CSR, caPEM)
+
+		cert, err := authority.ProcessCSR(kubeCreds.clt, req.CSR)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &KubeCSRResponse{Cert: cert.Cert, CertAuthorities: [][]byte{cert.CA}}, nil
+		return &KubeCSRResponse{
+			Cert:            cert,
+			CertAuthorities: [][]byte{kubeCreds.caPEM},
+			TargetAddr:      kubeCreds.targetAddr,
+		}, nil
 	}
+
 	// Certificate for remote cluster is a user certificate
 	// with special provisions.
 	log.Debugf("Generating certificate for remote Kubernetes cluster.")
@@ -143,4 +170,79 @@ func (s *AuthServer) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 		re.CertAuthorities = append(re.CertAuthorities, keyPair.Cert)
 	}
 	return re, nil
+}
+
+func (s *AuthServer) getKubeClient() (*kubeCreds, error) {
+	// no kubeconfig is set, assume auth server is running in the cluster
+	if s.kubeconfigPath == "" {
+		caPEM, err := ioutil.ReadFile(teleport.KubeCAPath)
+		if err != nil {
+			return nil, trace.BadParameter(`auth server assumed that it is 
+running in a kubernetes cluster, but %v mounted in pods could not be read: %v, 
+set kubeconfig_path if auth server is running outside of the cluster`, teleport.KubeCAPath, err)
+		}
+
+		clt, cfg, err := kubeutils.GetKubeClient(os.Getenv(teleport.EnvKubeConfig))
+		if err != nil {
+			return nil, trace.BadParameter(`auth server assumed that it is 
+running in a kubernetes cluster, but could not init in-cluster kubernetes client`, err)
+		}
+
+		targetAddr, err := parseKubeHost(cfg.Host)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to parse kubernetes host")
+		}
+
+		return &kubeCreds{
+			clt:        clt,
+			caPEM:      caPEM,
+			targetAddr: targetAddr,
+		}, nil
+	}
+
+	log.Debugf("Reading configuration from kubeconfig file %v.", s.kubeconfigPath)
+
+	clt, cfg, err := kubeutils.GetKubeClient(s.kubeconfigPath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	targetAddr, err := parseKubeHost(cfg.Host)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse kubernetes host")
+	}
+
+	var caPEM []byte
+	if len(cfg.CAData) == 0 {
+		if cfg.CAFile == "" {
+			return nil, trace.BadParameter("can't find trusted certificates in %v", s.kubeconfigPath)
+		}
+		caPEM, err = ioutil.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, trace.BadParameter("failed to read trusted certificates from %v: %v", cfg.CAFile, err)
+		}
+	} else {
+		caPEM = cfg.CAData
+	}
+
+	return &kubeCreds{
+		clt:        clt,
+		caPEM:      caPEM,
+		targetAddr: targetAddr,
+	}, nil
+}
+
+// parseKubeHost parses and formats kubernetes hostname
+// to host:port format, if no port it set,
+// it assumes default HTTPS port
+func parseKubeHost(host string) (string, error) {
+	u, err := url.Parse(host)
+	if err != nil {
+		return "", trace.Wrap(err, "failed to parse kubernetes host")
+	}
+	if _, _, err := net.SplitHostPort(u.Host); err != nil {
+		// add default HTTPS port
+		return fmt.Sprintf("%v:443", u.Host), nil
+	}
+	return u.Host, nil
 }

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -310,8 +310,8 @@ func applyAuthConfig(fc *FileConfig, cfg *service.Config) error {
 	var err error
 
 	// passhtrough custom certificate authority file
-	if fc.Auth.KubeCACertFile != "" {
-		cfg.Auth.KubeCACertPath = fc.Auth.KubeCACertFile
+	if fc.Auth.KubeconfigFile != "" {
+		cfg.Auth.KubeconfigPath = fc.Auth.KubeconfigFile
 	}
 	cfg.Auth.EnableProxyProtocol, err = utils.ParseOnOff("proxy_protocol", fc.Auth.ProxyProtocol, true)
 	if err != nil {
@@ -513,13 +513,6 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 			return trace.Wrap(err)
 		}
 		cfg.Proxy.Kube.ListenAddr = *addr
-	}
-	if fc.Proxy.Kube.APIAddr != "" {
-		addr, err := utils.ParseHostPortAddr(fc.Proxy.Kube.APIAddr, 443)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		cfg.Proxy.Kube.APIAddr = *addr
 	}
 	if len(fc.Proxy.Kube.PublicAddr) != 0 {
 		addrs, err := fc.Proxy.Kube.PublicAddr.Addrs(defaults.KubeProxyListenPort)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -67,7 +67,7 @@ var (
 		"proxy_service":           true,
 		"auth_service":            true,
 		"kubernetes":              true,
-		"kubernetes_ca_cert_file": true,
+		"kubeconfig_file":         true,
 		"auth_token":              true,
 		"auth_servers":            true,
 		"domain_name":             true,
@@ -91,7 +91,6 @@ var (
 		"tunnel_listen_addr":      true,
 		"ssh_listen_addr":         true,
 		"listen_addr":             true,
-		"api_addr":                false,
 		"ca_cert_file":            false,
 		"https_key_file":          true,
 		"https_cert_file":         true,
@@ -541,10 +540,10 @@ type Auth struct {
 	// if true, connections with expired client certificates will get disconnected
 	DisconnectExpiredCert services.Bool `yaml:"disconnect_expired_cert"`
 
-	// KubeCACertFile is a path to kubernetes certificate authority certificate file,
-	// used in cases when auth server is deployed outside of the kubernetes
-	// cluster.
-	KubeCACertFile string `yaml:"kubernetes_ca_cert_file,omitempty"`
+	// KubeconfigFile is an optional path to kubeconfig file,
+	// if specified, teleport will use API server address and
+	// trusted certificate authority information from it
+	KubeconfigFile string `yaml:"kubeconfig_file,omitempty"`
 }
 
 // TrustedCluster struct holds configuration values under "trusted_clusters" key
@@ -746,8 +745,6 @@ type Proxy struct {
 type Kube struct {
 	// Service is a generic service configuration section
 	Service `yaml:",inline"`
-	// KubeAPIAddr is an address of a target kubernetes API server
-	APIAddr string `yaml:"api_addr,omitempty"`
 	// PublicAddr is a publicly advertised address of the kubernetes proxy
 	PublicAddr utils.Strings `yaml:"public_addr,omitempty"`
 }

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -12,9 +12,15 @@ import (
 // using in-cluster configuration if available and falling back to
 // configuration file under configPath otherwise
 func GetKubeClient(configPath string) (client *kubernetes.Clientset, config *rest.Config, err error) {
-	config, err = rest.InClusterConfig()
-	if err != nil {
+	// if path to kubeconfig was provided, init config from it
+	if configPath != "" {
 		config, err = clientcmd.BuildConfigFromFlags("", configPath)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+	} else {
+		// otherwise attempt to init as if connecting from cluster
+		config, err = rest.InClusterConfig()
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -364,8 +364,8 @@ type AuthConfig struct {
 	// PublicAddrs affects the SSH host principals and DNS names added to the SSH and TLS certs.
 	PublicAddrs []utils.NetAddr
 
-	// KubeCACertPath is a path to kubernetes CA certificate
-	KubeCACertPath string
+	// KubeconfigPath is a path to kubeconfig
+	KubeconfigPath string
 }
 
 // SSHConfig configures SSH server node role

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -905,7 +905,7 @@ func (process *TeleportProcess) initAuthService() error {
 		OIDCConnectors:       cfg.OIDCConnectors,
 		AuditLog:             process.auditLog,
 		CipherSuites:         cfg.CipherSuites,
-		KubeCACertPath:       cfg.Auth.KubeCACertPath,
+		KubeconfigPath:       cfg.Auth.KubeconfigPath,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -1871,7 +1871,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				AccessPoint:     accessPoint,
 				AuditLog:        conn.Client,
 				ServerID:        cfg.HostUUID,
-				TargetAddr:      cfg.Proxy.Kube.APIAddr.Addr,
 				ClusterOverride: cfg.Proxy.Kube.ClusterOverride,
 			},
 			TLS:           tlsConfig,


### PR DESCRIPTION
Fixes #1986

When deployed outside of the kubernetes cluster,
teleport now reads all configuration from kubernetes
config file, supplied via parameter.

Auth server then passes information about
target api server back to the proxy.