### PR TITLE
Add web assets to OSS binary

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -132,12 +132,12 @@ enter: bbox
 .PHONY:release
 release: bbox
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOX) \
-		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)"
+		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=linux
 
 #
 # Create a Windows Teleport package using the build container.
 #
 .PHONY:release-windows
-release-windows:
+release-windows: bbox
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOX) \
 		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=windows


### PR DESCRIPTION
**Problem**

Teleport OSS binary was being build without web assets.

**Implementation**

Pass the OS when calling the Makefile. This allows building of Teleport within a container when the host OS does not have Go installed.