### PR TITLE
Dynamic Port Forwarding

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -795,7 +795,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:47a2761ead778ee220541a87da1cff9a09023664d4c2ecb3dd4eb8a30583e542"
+  digest = "1:0fcfb2bfaeb68353db0d1611bec6a7f5488214d522988e7ad7d4b5e91fbd2d0e"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -803,7 +803,9 @@
     "http2",
     "http2/hpack",
     "idna",
+    "internal/socks",
     "internal/timeseries",
+    "proxy",
     "trace",
     "websocket",
   ]
@@ -1132,6 +1134,7 @@
     "golang.org/x/crypto/ssh/agent",
     "golang.org/x/crypto/ssh/terminal",
     "golang.org/x/net/context",
+    "golang.org/x/net/proxy",
     "golang.org/x/net/websocket",
     "golang.org/x/text/encoding",
     "golang.org/x/text/encoding/unicode",

--- a/constants.go
+++ b/constants.go
@@ -125,6 +125,9 @@ const (
 	// ComponentConnectProxy is the HTTP CONNECT proxy used to tunnel connection.
 	ComponentConnectProxy = "http:proxy"
 
+	// ComponentSOCKS is a SOCKS5 proxy.
+	ComponentSOCKS = "socks"
+
 	// ComponentKeyGen is the public/private keypair generator.
 	ComponentKeyGen = "keygen"
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -91,6 +91,27 @@ func (p *ForwardedPort) ToString() string {
 	return net.JoinHostPort(p.SrcIP, sport) + ":" + net.JoinHostPort(p.DestHost, dport)
 }
 
+// DynamicForwardedPort local port for dynamic application-level port forwarding.
+// Whenever a connection is made to this port, SOCKS5 protocol is used
+// to determine where to connect to from the remote machine.
+// More or less equivalent to OpenSSH's -D flag
+type DynamicForwardedPort struct {
+	SrcIP   string
+	SrcPort int
+}
+
+type DynamicForwardedPorts []DynamicForwardedPort
+
+// ToString() returns a string representation of a dynamic port spec, compatible
+// with OpenSSH's -D  flag, i.e. "src_host:src_port"
+func (p *DynamicForwardedPort) ToString() string {
+	sport := strconv.Itoa(p.SrcPort)
+	if utils.IsLocalhost(p.SrcIP) {
+		return sport
+	}
+	return net.JoinHostPort(p.SrcIP, sport)
+}
+
 // HostKeyCallback is called by SSH client when it needs to check
 // remote host key or certificate validity
 type HostKeyCallback func(host string, ip net.Addr, key ssh.PublicKey) error
@@ -169,6 +190,9 @@ type Config struct {
 
 	// Locally forwarded ports (parameters to -L ssh flag)
 	LocalForwardPorts ForwardedPorts
+
+	// Locally forwarded dynamic ports (parameters to -D ssh flag)
+	DynamicForwardedPorts DynamicForwardedPorts
 
 	// HostKeyCallback will be called to check host keys of the remote
 	// node, if not specified will be using CheckHostSignature function
@@ -472,6 +496,11 @@ func (c *Config) LoadProfile(profileDir string, proxyName string) error {
 	}
 
 	c.LocalForwardPorts, err = ParsePortForwardSpec(cp.ForwardedPorts)
+	if err != nil {
+		log.Warnf("Error parsing user profile: %v", err)
+	}
+
+	c.DynamicForwardedPorts, err = ParseDynamicPortForwardSpec(cp.DynamicForwardedPorts)
 	if err != nil {
 		log.Warnf("Error parsing user profile: %v", err)
 	}
@@ -832,6 +861,15 @@ func (tc *TeleportClient) startPortForwarding(nodeClient *NodeClient) error {
 				return trace.Wrap(err)
 			}
 			go nodeClient.listenAndForward(socket, net.JoinHostPort(fp.DestHost, strconv.Itoa(fp.DestPort)))
+		}
+	}
+	if len(tc.Config.DynamicForwardedPorts) > 0 {
+		for _, fp := range tc.Config.DynamicForwardedPorts {
+			socket, err := net.Listen("tcp", net.JoinHostPort(fp.SrcIP, strconv.Itoa(fp.SrcPort)))
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			go nodeClient.listenForDynamicForward(socket)
 		}
 	}
 	return nil
@@ -1984,7 +2022,7 @@ func runLocalCommand(command []string) error {
 	return cmd.Run()
 }
 
-// ToString() returns the same string spec which can be parsed by ParsePortForwardSpec
+// ToStringSpec() returns the same string spec which can be parsed by ParsePortForwardSpec
 func (fp ForwardedPorts) ToStringSpec() (retval []string) {
 	for _, p := range fp {
 		retval = append(retval, p.ToString())
@@ -1993,7 +2031,7 @@ func (fp ForwardedPorts) ToStringSpec() (retval []string) {
 }
 
 // ParsePortForwardSpec parses parameter to -L flag, i.e. strings like "[ip]:80:remote.host:3000"
-// The opposite of this function (spec generation) is ForwardedPorts.ToString()
+// The opposite of this function (spec generation) is ForwardedPorts.ToStringSpec()
 func ParsePortForwardSpec(spec []string) (ports ForwardedPorts, err error) {
 	if len(spec) == 0 {
 		return ports, nil
@@ -2017,6 +2055,41 @@ func ParsePortForwardSpec(spec []string) (ports ForwardedPorts, err error) {
 		}
 		p.DestHost = parts[2]
 		p.DestPort, err = strconv.Atoi(parts[3])
+		if err != nil {
+			return nil, fmt.Errorf(errTemplate, str)
+		}
+	}
+	return ports, nil
+}
+
+// ToStringSpec() returns the same string spec which can be parsed by ParseDynamicPortForwardSpec
+func (fp DynamicForwardedPorts) ToStringSpec() (retval []string) {
+	for _, p := range fp {
+		retval = append(retval, p.ToString())
+	}
+	return retval
+}
+
+// ParseDynamicPortForwardSpec parses parameter to -L flag, i.e. strings like "[ip]:80:remote.host:3000"
+// The opposite of this function (spec generation) is DynamicForwardPorts.ToStringSpec()
+func ParseDynamicPortForwardSpec(spec []string) (ports DynamicForwardedPorts, err error) {
+	if len(spec) == 0 {
+		return ports, nil
+	}
+	const errTemplate = "Invalid dynamic port forwarding spec: '%s'. Could be like `local.host:8080`"
+	ports = make(DynamicForwardedPorts, len(spec), len(spec))
+
+	for i, str := range spec {
+		parts := strings.Split(str, ":")
+		if len(parts) > 2 {
+			return nil, fmt.Errorf(errTemplate, str)
+		}
+		if len(parts) == 1 {
+			parts = append([]string{"127.0.0.1"}, parts...)
+		}
+		p := &ports[i]
+		p.SrcIP = parts[0]
+		p.SrcPort, err = strconv.Atoi(parts[1])
 		if err != nil {
 			return nil, fmt.Errorf(errTemplate, str)
 		}

--- a/lib/client/bench.go
+++ b/lib/client/bench.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/codahale/hdrhistogram"
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 )
 
 // Benchmark specifies benchmark requests to run

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -20,7 +20,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net"
@@ -577,49 +579,50 @@ func (client *NodeClient) ExecuteSCP(cmd scp.Command) error {
 	return trace.Wrap(err)
 }
 
+func proxyConnection(client *NodeClient, incoming net.Conn, remoteAddr string) {
+	defer incoming.Close()
+	var (
+		conn net.Conn
+		err  error
+	)
+	log.Debugf("nodeClient.proxyConnection(%v -> %v) started", incoming.RemoteAddr(), remoteAddr)
+	for attempt := 1; attempt <= 5; attempt++ {
+		conn, err = client.Client.Dial("tcp", remoteAddr)
+		if err != nil {
+			log.Errorf("Connection attempt %v: %v", attempt, err)
+			// failed to establish an outbound connection? try again:
+			time.Sleep(time.Millisecond * time.Duration(100*attempt))
+			continue
+		}
+		// connection established: continue:
+		break
+	}
+	// permanent failure establishing connection
+	if err != nil {
+		log.Errorf("Failed to connect to node %v", remoteAddr)
+		return
+	}
+	defer conn.Close()
+	// start proxying:
+	doneC := make(chan interface{}, 2)
+	go func() {
+		io.Copy(incoming, conn)
+		doneC <- true
+	}()
+	go func() {
+		io.Copy(conn, incoming)
+		doneC <- true
+	}()
+	<-doneC
+	<-doneC
+	log.Debugf("nodeClient.proxyConnection(%v -> %v) exited", incoming.RemoteAddr(), remoteAddr)
+}
+
 // listenAndForward listens on a given socket and forwards all incoming connections
 // to the given remote address via
 func (client *NodeClient) listenAndForward(socket net.Listener, remoteAddr string) {
 	defer socket.Close()
 	defer client.Close()
-	proxyConnection := func(incoming net.Conn) {
-		defer incoming.Close()
-		var (
-			conn net.Conn
-			err  error
-		)
-		log.Debugf("nodeClient.listenAndForward(%v -> %v) started", incoming.RemoteAddr(), remoteAddr)
-		for attempt := 1; attempt <= 5; attempt++ {
-			conn, err = client.Client.Dial("tcp", remoteAddr)
-			if err != nil {
-				log.Errorf("Connection attempt %v: %v", attempt, err)
-				// failed to establish an outbound connection? try again:
-				time.Sleep(time.Millisecond * time.Duration(100*attempt))
-				continue
-			}
-			// connection established: continue:
-			break
-		}
-		// permanent failure establishing connection
-		if err != nil {
-			log.Errorf("Failed to connect to node %v", remoteAddr)
-			return
-		}
-		defer conn.Close()
-		// start proxying:
-		doneC := make(chan interface{}, 2)
-		go func() {
-			io.Copy(incoming, conn)
-			doneC <- true
-		}()
-		go func() {
-			io.Copy(conn, incoming)
-			doneC <- true
-		}()
-		<-doneC
-		<-doneC
-		log.Debugf("nodeClient.listenAndForward(%v -> %v) exited", incoming.RemoteAddr(), remoteAddr)
-	}
 	// request processing loop: accept incoming requests to be connected to nodes
 	// and proxy them to 'remoteAddr'
 	for {
@@ -628,7 +631,169 @@ func (client *NodeClient) listenAndForward(socket net.Listener, remoteAddr strin
 			log.Error(err)
 			break
 		}
-		go proxyConnection(incoming)
+		go proxyConnection(client, incoming, remoteAddr)
+	}
+}
+
+func readByte(reader io.Reader) (byte, error) {
+	buf := []byte{0}
+	_, err := io.ReadFull(reader, buf)
+	return buf[0], err
+}
+
+const (
+	socks4Version                 byte = 0x04
+	socks5Version                 byte = 0x05
+	socks5Reserved                byte = 0x00
+	socks5AuthNotRequired         byte = 0x00
+	socks5AuthNoAcceptableMethods byte = 0xFF
+	socks5CommandConnect          byte = 0x01
+	socks5AddressTypeIPv4         byte = 0x01
+	socks5AddressTypeDomainName   byte = 0x03
+	socks5AddressTypeIPv6         byte = 0x04
+	socks5Succeeded               byte = 0x00
+)
+
+func socks5ProxyAuthenticate(incoming net.Conn) error {
+	nmethods, err := readByte(incoming)
+	if err != nil {
+		return err
+	}
+
+	chosenMethod := socks5AuthNoAcceptableMethods
+	for i := byte(0); i < nmethods; i++ {
+		method, err := readByte(incoming)
+		if err != nil {
+			return err
+		}
+		if method == socks5AuthNotRequired {
+			chosenMethod = socks5AuthNotRequired
+		}
+	}
+
+	_, err = incoming.Write([]byte{socks5Version, chosenMethod})
+	if err != nil {
+		return err
+	}
+
+	if chosenMethod == socks5AuthNoAcceptableMethods {
+		return errors.New("Unable to find suitable authentication method")
+	}
+
+	return nil
+}
+
+func socks5ProxyConnectRequest(incoming net.Conn) (remoteAddr string, err error) {
+	header := make([]byte, 4)
+	_, err = io.ReadFull(incoming, header)
+	if err != nil {
+		return
+	}
+	if !bytes.Equal(header[0:3], []byte{socks5Version, socks5CommandConnect, socks5Reserved}) {
+		err = errors.New("only connect command is supported for SOCKS5")
+		return
+	}
+
+	var ip net.IP
+	var remoteHost string
+	switch header[3] {
+	case socks5AddressTypeIPv4:
+		ip = make([]byte, net.IPv4len)
+	case socks5AddressTypeIPv6:
+		ip = make([]byte, net.IPv6len)
+	case socks5AddressTypeDomainName:
+		var domainNameLen byte
+		domainNameLen, err = readByte(incoming)
+		if err != nil {
+			return
+		}
+		remoteAddrBuf := make([]byte, domainNameLen)
+		_, err = io.ReadFull(incoming, remoteAddrBuf)
+		if err != nil {
+			return
+		}
+		remoteHost = string(remoteAddrBuf)
+	default:
+		err = errors.New("Unsupported address type for SOCKS5 connect request")
+		return
+	}
+
+	if ip != nil {
+		// Still need to read the ip address
+		_, err = io.ReadFull(incoming, ip)
+		if err != nil {
+			return
+		}
+		remoteHost = ip.String()
+	}
+
+	var remotePort uint16
+	err = binary.Read(incoming, binary.BigEndian, &remotePort)
+	if err != nil {
+		return
+	}
+
+	// Send the same minimal response as openSSH does
+	response := make([]byte, 4+net.IPv4len+2)
+	copy(response, []byte{socks5Version, socks5Succeeded, socks5Reserved, socks5AddressTypeIPv4})
+	_, err = incoming.Write(response)
+	if err != nil {
+		return
+	}
+
+	return net.JoinHostPort(remoteHost, strconv.Itoa(int(remotePort))), nil
+}
+
+func socks5ProxyConnection(client *NodeClient, incoming net.Conn) {
+	err := socks5ProxyAuthenticate(incoming)
+	if nil != err {
+		log.Errorf("socks5ProxyConnection unable to authenticate (%v) [%v]", incoming, err)
+		return
+	}
+
+	remoteAddr, err := socks5ProxyConnectRequest(incoming)
+	if nil != err {
+		log.Errorf("socks5ProxyConnection did not receive connect (%v) [%v]", incoming, err)
+		return
+	}
+
+	proxyConnection(client, incoming, remoteAddr)
+}
+
+func dynamicProxyConnection(client *NodeClient, incoming net.Conn) {
+	defer incoming.Close()
+	log.Debugf("nodeClient.dynamicProxyConnection(%v) started", incoming.RemoteAddr())
+
+	version := []byte{0}
+	_, err := incoming.Read(version)
+	if err != nil {
+		log.Errorf("Failed to read first byte of %v", incoming)
+		return
+	}
+	switch version[0] {
+	case socks5Version:
+		socks5ProxyConnection(client, incoming)
+	case socks4Version:
+		log.Errorf("SOCKS4 dynamic port forwarding is no yet supported (%v)", incoming)
+	default:
+		log.Errorf("Unknown dynamic port forwarding protocol requested by (%v)", incoming)
+	}
+}
+
+// listenForDynamicForward listens on a given socket and forwards all incoming connections
+// to the remote address they specify
+func (client *NodeClient) listenForDynamicForward(socket net.Listener) {
+	defer socket.Close()
+	defer client.Close()
+	// request processing loop: accept incoming requests to be connected to nodes
+	// and proxy them
+	for {
+		incoming, err := socket.Accept()
+		if err != nil {
+			log.Error(err)
+			break
+		}
+		go dynamicProxyConnection(client, incoming)
 	}
 }
 

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
+
 	"github.com/jonboulle/clockwork"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/check.v1"
 )
 

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -56,6 +56,8 @@ type ClientProfile struct {
 	// ForwardedPorts is the list of ports to forward to the target node.
 	ForwardedPorts []string `yaml:"forward_ports,omitempty"`
 
+	// DynamicForwardedPorts is a list of ports to use for dynamic port
+	// forwarding (SOCKS5).
 	DynamicForwardedPorts []string `yaml:"dynamic_forward_ports,omitempty"`
 
 	// DELETE IN: 3.1.0

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -56,6 +56,8 @@ type ClientProfile struct {
 	// ForwardedPorts is the list of ports to forward to the target node.
 	ForwardedPorts []string `yaml:"forward_ports,omitempty"`
 
+	DynamicForwardedPorts []string `yaml:"dynamic_forward_ports,omitempty"`
+
 	// DELETE IN: 3.1.0
 	// The following fields have been deprecated and replaced with
 	// "proxy_web_addr" and "proxy_ssh_addr".

--- a/lib/client/profile_test.go
+++ b/lib/client/profile_test.go
@@ -31,10 +31,11 @@ var _ = check.Suite(&ProfileTestSuite{})
 
 func (s *ProfileTestSuite) TestEverything(c *check.C) {
 	p := &ClientProfile{
-		WebProxyAddr:   "proxy:3088",
-		SSHProxyAddr:   "proxy:3023",
-		Username:       "testuser",
-		ForwardedPorts: []string{"8000:example.com:8000"},
+		WebProxyAddr:          "proxy:3088",
+		SSHProxyAddr:          "proxy:3023",
+		Username:              "testuser",
+		ForwardedPorts:        []string{"8000:example.com:8000"},
+		DynamicForwardedPorts: []string{"localhost:8080"},
 	}
 
 	home := c.MkDir()

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -40,8 +40,6 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
-
-	log "github.com/sirupsen/logrus"
 )
 
 type NodeSession struct {

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -39,7 +39,6 @@ import (
 
 	"github.com/mailgun/lemma/secret"
 	"github.com/pborman/uuid"
-	log "github.com/sirupsen/logrus"
 	"github.com/tstranex/u2f"
 )
 

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -212,6 +212,10 @@ const (
 
 	// CSRSignTimeout is a default timeout for CSR request to be processed by K8s
 	CSRSignTimeout = 30 * time.Second
+
+	// Localhost is the address of localhost. Used for the default binding
+	// address for port forwarding.
+	Localhost = "127.0.0.1"
 )
 
 var (

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -794,12 +794,12 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 			Stdout:      ioutil.Discard,
 		})
 		if err != nil {
-			ctx.Errorf("Unable to open PAM context for session: %v: %v", ctx.SessionID(), err)
+			ctx.Errorf("Unable to open PAM context for direct-tcpip request: %v.", err)
 			ch.Stderr().Write([]byte(err.Error()))
 			return
 		}
 
-		ctx.Debugf("Opening PAM context for session %v", ctx.SessionID())
+		ctx.Debugf("Opening PAM context for direct-tcpip request.")
 	}
 
 	conn, err := net.Dial("tcp", dstAddr)
@@ -837,10 +837,10 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 	if s.pamConfig.Enabled {
 		err = pamContext.Close()
 		if err != nil {
-			ctx.Errorf("Unable to close PAM context for session %v: %v.", ctx.SessionID(), err)
+			ctx.Errorf("Unable to close PAM context for direct-tcpip request: %v.", err)
 			return
 		}
-		ctx.Debugf("Closing PAM context for session %v.", ctx.SessionID())
+		ctx.Debugf("Closing PAM context for direct-tcpip request.")
 	}
 }
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -769,8 +769,8 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 	defer ctx.Debugf("direct-tcp closed")
 	defer ctx.Close()
 
-	srcAddr := fmt.Sprintf("%v:%d", req.Orig, req.OrigPort)
-	dstAddr := fmt.Sprintf("%v:%d", req.Host, req.Port)
+	srcAddr := net.JoinHostPort(req.Orig, strconv.Itoa(int(req.OrigPort)))
+	dstAddr := net.JoinHostPort(req.Host, strconv.Itoa(int(req.Port)))
 
 	// check if the role allows port forwarding for this user
 	err = s.authHandlers.CheckPortForward(dstAddr, ctx)

--- a/lib/utils/socks/socks.go
+++ b/lib/utils/socks/socks.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package socks implements a SOCKS5 handshake.
+package socks
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"strconv"
+
+	"github.com/gravitational/teleport"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.WithFields(logrus.Fields{
+	trace.Component: teleport.ComponentSOCKS,
+})
+
+const (
+	socks5Version               byte = 0x05
+	socks5Reserved              byte = 0x00
+	socks5AuthNotRequired       byte = 0x00
+	socks5CommandConnect        byte = 0x01
+	socks5AddressTypeIPv4       byte = 0x01
+	socks5AddressTypeDomainName byte = 0x03
+	socks5AddressTypeIPv6       byte = 0x04
+	socks5Succeeded             byte = 0x00
+)
+
+// Handshake performs a SOCKS5 handshake with the client and returns
+// the remote address to proxy the connection to.
+func Handshake(conn net.Conn) (string, error) {
+	// Read in the version and reject anything other than SOCKS5.
+	version, err := readByte(conn)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	if version != socks5Version {
+		return "", trace.BadParameter("only SOCKS5 is supported")
+	}
+
+	// Read in the authentication method requested by the client and write back
+	// the method that was selected. At the moment only "no authentication
+	// required" is supported.
+	authMethods, err := readAuthenticationMethod(conn)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	if !byteSliceContains(authMethods, socks5AuthNotRequired) {
+		return "", trace.BadParameter("only 'no authentication required' is supported")
+	}
+	err = writeMethodSelection(conn)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Read in the request from the client and make sure the requested command
+	// is supported and extract the remote address. If everything is good, write
+	// out a success response.
+	remoteAddr, err := readRequest(conn)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	err = writeReply(conn)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return remoteAddr, nil
+}
+
+// readAuthenticationMethod reads in the authentication methods the client
+// supports.
+func readAuthenticationMethod(conn net.Conn) ([]byte, error) {
+	// Read in the number of authentication methods supported.
+	nmethods, err := readByte(conn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Read nmethods number of bytes from the connection return the list of
+	// supported authentication methods to the caller.
+	authMethods := make([]byte, nmethods)
+	for i := byte(0); i < nmethods; i++ {
+		method, err := readByte(conn)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		authMethods = append(authMethods, method)
+	}
+
+	return authMethods, nil
+}
+
+// writeMethodSelection writes out the response to the authentication methods.
+// Right now, only SOCKS5 and "no authentication methods" is supported.
+func writeMethodSelection(conn net.Conn) error {
+	message := []byte{socks5Version, socks5AuthNotRequired}
+
+	n, err := conn.Write(message)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if n != len(message) {
+		return trace.BadParameter("wrote: %v wanted to write: %v", n, len(message))
+	}
+
+	return nil
+}
+
+// readRequest reads in the SOCKS5 request from the client and returns the
+// host:port the client wants to connect to.
+func readRequest(conn net.Conn) (string, error) {
+	// Read in the version and reject anything other than SOCKS5.
+	version, err := readByte(conn)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	if version != socks5Version {
+		return "", trace.BadParameter("only SOCKS5 is supported")
+	}
+
+	// Read in the command the client is requesting. Only CONNECT is supported.
+	command, err := readByte(conn)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	if command != socks5CommandConnect {
+		return "", trace.BadParameter("only CONNECT command is supported")
+	}
+
+	// Read in and throw away the reserved byte.
+	_, err = readByte(conn)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Read in the address type and determine how many more bytes need to be
+	// read in to read in the remote host address.
+	addrLen, err := readAddrType(conn)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Read in the destination address.
+	destAddr := make([]byte, addrLen)
+	_, err = io.ReadFull(conn, destAddr)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Read in the destination port.
+	var destPort uint16
+	err = binary.Read(conn, binary.BigEndian, &destPort)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return net.JoinHostPort(string(destAddr), strconv.Itoa(int(destPort))), nil
+}
+
+// readAddrType reads in the address type and returns the length of the dest
+// addr field.
+func readAddrType(conn net.Conn) (int, error) {
+	// Read in the type of the remote host.
+	addrType, err := readByte(conn)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	// Based off the type, determine how many more bytes to read in for the
+	// remote address. For IPv4 it's 4 bytes, for IPv6 it's 16, and for domain
+	// names read in another byte to determine the length of the field.
+	switch addrType {
+	case socks5AddressTypeIPv4:
+		return net.IPv4len, nil
+	case socks5AddressTypeIPv6:
+		return net.IPv6len, nil
+	case socks5AddressTypeDomainName:
+		len, err := readByte(conn)
+		if err != nil {
+			return 0, trace.Wrap(err)
+		}
+		return int(len), nil
+	default:
+		return 0, trace.BadParameter("unsupported address type: %v", addrType)
+	}
+}
+
+// Write the response to the client.
+func writeReply(conn net.Conn) error {
+	// Write success reply, similar to OpenSSH only success is written.
+	// https://github.com/openssh/openssh-portable/blob/5d14019/channels.c#L1442-L1452
+	message := []byte{
+		socks5Version,
+		socks5Succeeded,
+		socks5Reserved,
+		socks5AddressTypeIPv4,
+	}
+	n, err := conn.Write(message)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if n != len(message) {
+		return trace.BadParameter("wrote: %v wanted to write: %v", n, len(message))
+	}
+
+	// Reply also requires BND.ADDR and BDN.PORT even though they are ignored
+	// because Teleport only supports CONNECT.
+	message = []byte{0, 0, 0, 0, 0, 0}
+	n, err = conn.Write(message)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if n != len(message) {
+		return trace.BadParameter("wrote: %v wanted to write: %v", n, len(message))
+	}
+
+	return nil
+}
+
+// readByte a single byte from the passed in net.Conn.
+func readByte(conn net.Conn) (byte, error) {
+	b := make([]byte, 1)
+	_, err := io.ReadFull(conn, b)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	return b[0], nil
+}
+
+// byteSliceContains checks if the slice a contains the byte b.
+func byteSliceContains(a []byte, b byte) bool {
+	for _, v := range a {
+		if v == b {
+			return true
+		}
+	}
+
+	return false
+}

--- a/lib/utils/socks/socks_test.go
+++ b/lib/utils/socks/socks_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package socks
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"golang.org/x/net/proxy"
+
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type SOCKSSuite struct{}
+
+var _ = check.Suite(&SOCKSSuite{})
+var _ = fmt.Printf
+
+func (s *SOCKSSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
+}
+func (s *SOCKSSuite) TearDownSuite(c *check.C) {}
+func (s *SOCKSSuite) SetUpTest(c *check.C)     {}
+func (s *SOCKSSuite) TearDownTest(c *check.C)  {}
+
+func (s *SOCKSSuite) TestHandshake(c *check.C) {
+	remoteAddr := "example.com:443"
+
+	// Create and start a debug SOCKS5 server that calls socks.Handshake().
+	socksServer, err := newDebugServer()
+	c.Assert(err, check.IsNil)
+	go socksServer.Serve()
+
+	// Create a proxy dialer that can perform a SOCKS5 handshake.
+	proxy, err := proxy.SOCKS5("tcp", socksServer.Addr().String(), nil, nil)
+	c.Assert(err, check.IsNil)
+
+	// Connect to the SOCKS5 server, this is where the handshake function is called.
+	conn, err := proxy.Dial("tcp", remoteAddr)
+	c.Assert(err, check.IsNil)
+
+	// Read in what was written on the connection. With the debug server it's
+	// always the addres requested.
+	buf := make([]byte, len(remoteAddr))
+	_, err = io.ReadFull(conn, buf)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(buf), check.Equals, remoteAddr)
+
+	// Close and cleanup.
+	err = conn.Close()
+	c.Assert(err, check.IsNil)
+}
+
+// debugServer is a debug SOCKS5 server that performs a SOCKS5 handshake
+// then writes the remote address and closes the connection.
+type debugServer struct {
+	ln net.Listener
+}
+
+// newDebugServer creates a new debug server on a random port.
+func newDebugServer() (*debugServer, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &debugServer{
+		ln: ln,
+	}, nil
+}
+
+// Addr returns the address the debug server is running on.
+func (d *debugServer) Addr() net.Addr {
+	return d.ln.Addr()
+}
+
+// Serve accepts and handles the connection.
+func (d *debugServer) Serve() {
+	for {
+		conn, err := d.ln.Accept()
+		if err != nil {
+			log.Debugf("Failed to accept connection: %v.", err)
+			break
+		}
+
+		go d.handle(conn)
+	}
+}
+
+// handle performs the SOCKS5 handshake then writes the remote address to
+// the net.Conn and closes it.
+func (d *debugServer) handle(conn net.Conn) {
+	defer conn.Close()
+
+	remoteAddr, err := Handshake(conn)
+	if err != nil {
+		log.Debugf("Handshake failed: %v.", err)
+		return
+	}
+
+	n, err := conn.Write([]byte(remoteAddr))
+	if err != nil {
+		log.Debugf("Failed to write to connection: %v.", err)
+		return
+	}
+	if n != len(remoteAddr) {
+		log.Debugf("Short write, wrote %v wanted %v.", n, len(remoteAddr))
+		return
+	}
+}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -79,7 +79,8 @@ type CLIConf struct {
 	RecursiveCopy bool
 	// -L flag for ssh. Local port forwarding like 'ssh -L 80:remote.host:80 -L 443:remote.host:443'
 	LocalForwardPorts []string
-	// -D flag for ssh. Dynamic port forwarding like 'ssh -D 8080'
+	// DynamicForwardedPorts is port forwarding using SOCKS5. It is similar to
+	// "ssh -D 8080 example.com".
 	DynamicForwardedPorts []string
 	// ForwardAgent agent to target node. Equivalent of -A for OpenSSH.
 	ForwardAgent bool
@@ -189,7 +190,7 @@ func Run(args []string, underTest bool) {
 	ssh.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
 	ssh.Flag("forward-agent", "Forward agent to target node").Short('A').BoolVar(&cf.ForwardAgent)
 	ssh.Flag("forward", "Forward localhost connections to remote server").Short('L').StringsVar(&cf.LocalForwardPorts)
-	ssh.Flag("dynamic-forward", "Forward localhost connections to remote server").Short('D').StringsVar(&cf.DynamicForwardedPorts)
+	ssh.Flag("dynamic-forward", "Forward localhost connections to remote server using SOCKS5").Short('D').StringsVar(&cf.DynamicForwardedPorts)
 	ssh.Flag("local", "Execute command on localhost after connecting to SSH node").Default("false").BoolVar(&cf.LocalExec)
 	ssh.Flag("tty", "Allocate TTY").Short('t').BoolVar(&cf.Interactive)
 	ssh.Flag("cluster", clusterHelp).Envar(clusterEnvVar).StringVar(&cf.SiteName)

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -76,7 +76,7 @@ func (s *MainTestSuite) TestMakeClient(c *check.C) {
 	conf.UserHost = "root@localhost"
 	conf.NodePort = 46528
 	conf.LocalForwardPorts = []string{"80:remote:180"}
-	conf.DynamicForwardedPorts = []string{"8080"}
+	conf.DynamicForwardedPorts = []string{":8080"}
 	tc, err = makeClient(&conf, true)
 	c.Assert(tc.Config.KeyTTL, check.Equals, time.Minute*time.Duration(conf.MinsToLive))
 	c.Assert(tc.Config.HostLogin, check.Equals, "root")

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -76,6 +76,7 @@ func (s *MainTestSuite) TestMakeClient(c *check.C) {
 	conf.UserHost = "root@localhost"
 	conf.NodePort = 46528
 	conf.LocalForwardPorts = []string{"80:remote:180"}
+	conf.DynamicForwardedPorts = []string{"8080"}
 	tc, err = makeClient(&conf, true)
 	c.Assert(tc.Config.KeyTTL, check.Equals, time.Minute*time.Duration(conf.MinsToLive))
 	c.Assert(tc.Config.HostLogin, check.Equals, "root")
@@ -85,6 +86,12 @@ func (s *MainTestSuite) TestMakeClient(c *check.C) {
 			SrcPort:  80,
 			DestHost: "remote",
 			DestPort: 180,
+		},
+	})
+	c.Assert(tc.Config.DynamicForwardedPorts, check.DeepEquals, client.DynamicForwardedPorts{
+		{
+			SrcIP:   "127.0.0.1",
+			SrcPort: 8080,
 		},
 	})
 }

--- a/vendor/golang.org/x/net/internal/socks/client.go
+++ b/vendor/golang.org/x/net/internal/socks/client.go
@@ -1,0 +1,168 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package socks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"time"
+)
+
+var (
+	noDeadline   = time.Time{}
+	aLongTimeAgo = time.Unix(1, 0)
+)
+
+func (d *Dialer) connect(ctx context.Context, c net.Conn, address string) (_ net.Addr, ctxErr error) {
+	host, port, err := splitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	if deadline, ok := ctx.Deadline(); ok && !deadline.IsZero() {
+		c.SetDeadline(deadline)
+		defer c.SetDeadline(noDeadline)
+	}
+	if ctx != context.Background() {
+		errCh := make(chan error, 1)
+		done := make(chan struct{})
+		defer func() {
+			close(done)
+			if ctxErr == nil {
+				ctxErr = <-errCh
+			}
+		}()
+		go func() {
+			select {
+			case <-ctx.Done():
+				c.SetDeadline(aLongTimeAgo)
+				errCh <- ctx.Err()
+			case <-done:
+				errCh <- nil
+			}
+		}()
+	}
+
+	b := make([]byte, 0, 6+len(host)) // the size here is just an estimate
+	b = append(b, Version5)
+	if len(d.AuthMethods) == 0 || d.Authenticate == nil {
+		b = append(b, 1, byte(AuthMethodNotRequired))
+	} else {
+		ams := d.AuthMethods
+		if len(ams) > 255 {
+			return nil, errors.New("too many authentication methods")
+		}
+		b = append(b, byte(len(ams)))
+		for _, am := range ams {
+			b = append(b, byte(am))
+		}
+	}
+	if _, ctxErr = c.Write(b); ctxErr != nil {
+		return
+	}
+
+	if _, ctxErr = io.ReadFull(c, b[:2]); ctxErr != nil {
+		return
+	}
+	if b[0] != Version5 {
+		return nil, errors.New("unexpected protocol version " + strconv.Itoa(int(b[0])))
+	}
+	am := AuthMethod(b[1])
+	if am == AuthMethodNoAcceptableMethods {
+		return nil, errors.New("no acceptable authentication methods")
+	}
+	if d.Authenticate != nil {
+		if ctxErr = d.Authenticate(ctx, c, am); ctxErr != nil {
+			return
+		}
+	}
+
+	b = b[:0]
+	b = append(b, Version5, byte(d.cmd), 0)
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			b = append(b, AddrTypeIPv4)
+			b = append(b, ip4...)
+		} else if ip6 := ip.To16(); ip6 != nil {
+			b = append(b, AddrTypeIPv6)
+			b = append(b, ip6...)
+		} else {
+			return nil, errors.New("unknown address type")
+		}
+	} else {
+		if len(host) > 255 {
+			return nil, errors.New("FQDN too long")
+		}
+		b = append(b, AddrTypeFQDN)
+		b = append(b, byte(len(host)))
+		b = append(b, host...)
+	}
+	b = append(b, byte(port>>8), byte(port))
+	if _, ctxErr = c.Write(b); ctxErr != nil {
+		return
+	}
+
+	if _, ctxErr = io.ReadFull(c, b[:4]); ctxErr != nil {
+		return
+	}
+	if b[0] != Version5 {
+		return nil, errors.New("unexpected protocol version " + strconv.Itoa(int(b[0])))
+	}
+	if cmdErr := Reply(b[1]); cmdErr != StatusSucceeded {
+		return nil, errors.New("unknown error " + cmdErr.String())
+	}
+	if b[2] != 0 {
+		return nil, errors.New("non-zero reserved field")
+	}
+	l := 2
+	var a Addr
+	switch b[3] {
+	case AddrTypeIPv4:
+		l += net.IPv4len
+		a.IP = make(net.IP, net.IPv4len)
+	case AddrTypeIPv6:
+		l += net.IPv6len
+		a.IP = make(net.IP, net.IPv6len)
+	case AddrTypeFQDN:
+		if _, err := io.ReadFull(c, b[:1]); err != nil {
+			return nil, err
+		}
+		l += int(b[0])
+	default:
+		return nil, errors.New("unknown address type " + strconv.Itoa(int(b[3])))
+	}
+	if cap(b) < l {
+		b = make([]byte, l)
+	} else {
+		b = b[:l]
+	}
+	if _, ctxErr = io.ReadFull(c, b); ctxErr != nil {
+		return
+	}
+	if a.IP != nil {
+		copy(a.IP, b)
+	} else {
+		a.Name = string(b[:len(b)-2])
+	}
+	a.Port = int(b[len(b)-2])<<8 | int(b[len(b)-1])
+	return &a, nil
+}
+
+func splitHostPort(address string) (string, int, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", 0, err
+	}
+	portnum, err := strconv.Atoi(port)
+	if err != nil {
+		return "", 0, err
+	}
+	if 1 > portnum || portnum > 0xffff {
+		return "", 0, errors.New("port number out of range " + port)
+	}
+	return host, portnum, nil
+}

--- a/vendor/golang.org/x/net/internal/socks/socks.go
+++ b/vendor/golang.org/x/net/internal/socks/socks.go
@@ -1,0 +1,316 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package socks provides a SOCKS version 5 client implementation.
+//
+// SOCKS protocol version 5 is defined in RFC 1928.
+// Username/Password authentication for SOCKS version 5 is defined in
+// RFC 1929.
+package socks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+)
+
+// A Command represents a SOCKS command.
+type Command int
+
+func (cmd Command) String() string {
+	switch cmd {
+	case CmdConnect:
+		return "socks connect"
+	case cmdBind:
+		return "socks bind"
+	default:
+		return "socks " + strconv.Itoa(int(cmd))
+	}
+}
+
+// An AuthMethod represents a SOCKS authentication method.
+type AuthMethod int
+
+// A Reply represents a SOCKS command reply code.
+type Reply int
+
+func (code Reply) String() string {
+	switch code {
+	case StatusSucceeded:
+		return "succeeded"
+	case 0x01:
+		return "general SOCKS server failure"
+	case 0x02:
+		return "connection not allowed by ruleset"
+	case 0x03:
+		return "network unreachable"
+	case 0x04:
+		return "host unreachable"
+	case 0x05:
+		return "connection refused"
+	case 0x06:
+		return "TTL expired"
+	case 0x07:
+		return "command not supported"
+	case 0x08:
+		return "address type not supported"
+	default:
+		return "unknown code: " + strconv.Itoa(int(code))
+	}
+}
+
+// Wire protocol constants.
+const (
+	Version5 = 0x05
+
+	AddrTypeIPv4 = 0x01
+	AddrTypeFQDN = 0x03
+	AddrTypeIPv6 = 0x04
+
+	CmdConnect Command = 0x01 // establishes an active-open forward proxy connection
+	cmdBind    Command = 0x02 // establishes a passive-open forward proxy connection
+
+	AuthMethodNotRequired         AuthMethod = 0x00 // no authentication required
+	AuthMethodUsernamePassword    AuthMethod = 0x02 // use username/password
+	AuthMethodNoAcceptableMethods AuthMethod = 0xff // no acceptable authentication methods
+
+	StatusSucceeded Reply = 0x00
+)
+
+// An Addr represents a SOCKS-specific address.
+// Either Name or IP is used exclusively.
+type Addr struct {
+	Name string // fully-qualified domain name
+	IP   net.IP
+	Port int
+}
+
+func (a *Addr) Network() string { return "socks" }
+
+func (a *Addr) String() string {
+	if a == nil {
+		return "<nil>"
+	}
+	port := strconv.Itoa(a.Port)
+	if a.IP == nil {
+		return net.JoinHostPort(a.Name, port)
+	}
+	return net.JoinHostPort(a.IP.String(), port)
+}
+
+// A Conn represents a forward proxy connection.
+type Conn struct {
+	net.Conn
+
+	boundAddr net.Addr
+}
+
+// BoundAddr returns the address assigned by the proxy server for
+// connecting to the command target address from the proxy server.
+func (c *Conn) BoundAddr() net.Addr {
+	if c == nil {
+		return nil
+	}
+	return c.boundAddr
+}
+
+// A Dialer holds SOCKS-specific options.
+type Dialer struct {
+	cmd          Command // either CmdConnect or cmdBind
+	proxyNetwork string  // network between a proxy server and a client
+	proxyAddress string  // proxy server address
+
+	// ProxyDial specifies the optional dial function for
+	// establishing the transport connection.
+	ProxyDial func(context.Context, string, string) (net.Conn, error)
+
+	// AuthMethods specifies the list of request authention
+	// methods.
+	// If empty, SOCKS client requests only AuthMethodNotRequired.
+	AuthMethods []AuthMethod
+
+	// Authenticate specifies the optional authentication
+	// function. It must be non-nil when AuthMethods is not empty.
+	// It must return an error when the authentication is failed.
+	Authenticate func(context.Context, io.ReadWriter, AuthMethod) error
+}
+
+// DialContext connects to the provided address on the provided
+// network.
+//
+// The returned error value may be a net.OpError. When the Op field of
+// net.OpError contains "socks", the Source field contains a proxy
+// server address and the Addr field contains a command target
+// address.
+//
+// See func Dial of the net package of standard library for a
+// description of the network and address parameters.
+func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if err := d.validateTarget(network, address); err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	if ctx == nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: errors.New("nil context")}
+	}
+	var err error
+	var c net.Conn
+	if d.ProxyDial != nil {
+		c, err = d.ProxyDial(ctx, d.proxyNetwork, d.proxyAddress)
+	} else {
+		var dd net.Dialer
+		c, err = dd.DialContext(ctx, d.proxyNetwork, d.proxyAddress)
+	}
+	if err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	a, err := d.connect(ctx, c, address)
+	if err != nil {
+		c.Close()
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	return &Conn{Conn: c, boundAddr: a}, nil
+}
+
+// DialWithConn initiates a connection from SOCKS server to the target
+// network and address using the connection c that is already
+// connected to the SOCKS server.
+//
+// It returns the connection's local address assigned by the SOCKS
+// server.
+func (d *Dialer) DialWithConn(ctx context.Context, c net.Conn, network, address string) (net.Addr, error) {
+	if err := d.validateTarget(network, address); err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	if ctx == nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: errors.New("nil context")}
+	}
+	a, err := d.connect(ctx, c, address)
+	if err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	return a, nil
+}
+
+// Dial connects to the provided address on the provided network.
+//
+// Unlike DialContext, it returns a raw transport connection instead
+// of a forward proxy connection.
+//
+// Deprecated: Use DialContext or DialWithConn instead.
+func (d *Dialer) Dial(network, address string) (net.Conn, error) {
+	if err := d.validateTarget(network, address); err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	var err error
+	var c net.Conn
+	if d.ProxyDial != nil {
+		c, err = d.ProxyDial(context.Background(), d.proxyNetwork, d.proxyAddress)
+	} else {
+		c, err = net.Dial(d.proxyNetwork, d.proxyAddress)
+	}
+	if err != nil {
+		proxy, dst, _ := d.pathAddrs(address)
+		return nil, &net.OpError{Op: d.cmd.String(), Net: network, Source: proxy, Addr: dst, Err: err}
+	}
+	if _, err := d.DialWithConn(context.Background(), c, network, address); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (d *Dialer) validateTarget(network, address string) error {
+	switch network {
+	case "tcp", "tcp6", "tcp4":
+	default:
+		return errors.New("network not implemented")
+	}
+	switch d.cmd {
+	case CmdConnect, cmdBind:
+	default:
+		return errors.New("command not implemented")
+	}
+	return nil
+}
+
+func (d *Dialer) pathAddrs(address string) (proxy, dst net.Addr, err error) {
+	for i, s := range []string{d.proxyAddress, address} {
+		host, port, err := splitHostPort(s)
+		if err != nil {
+			return nil, nil, err
+		}
+		a := &Addr{Port: port}
+		a.IP = net.ParseIP(host)
+		if a.IP == nil {
+			a.Name = host
+		}
+		if i == 0 {
+			proxy = a
+		} else {
+			dst = a
+		}
+	}
+	return
+}
+
+// NewDialer returns a new Dialer that dials through the provided
+// proxy server's network and address.
+func NewDialer(network, address string) *Dialer {
+	return &Dialer{proxyNetwork: network, proxyAddress: address, cmd: CmdConnect}
+}
+
+const (
+	authUsernamePasswordVersion = 0x01
+	authStatusSucceeded         = 0x00
+)
+
+// UsernamePassword are the credentials for the username/password
+// authentication method.
+type UsernamePassword struct {
+	Username string
+	Password string
+}
+
+// Authenticate authenticates a pair of username and password with the
+// proxy server.
+func (up *UsernamePassword) Authenticate(ctx context.Context, rw io.ReadWriter, auth AuthMethod) error {
+	switch auth {
+	case AuthMethodNotRequired:
+		return nil
+	case AuthMethodUsernamePassword:
+		if len(up.Username) == 0 || len(up.Username) > 255 || len(up.Password) == 0 || len(up.Password) > 255 {
+			return errors.New("invalid username/password")
+		}
+		b := []byte{authUsernamePasswordVersion}
+		b = append(b, byte(len(up.Username)))
+		b = append(b, up.Username...)
+		b = append(b, byte(len(up.Password)))
+		b = append(b, up.Password...)
+		// TODO(mikio): handle IO deadlines and cancelation if
+		// necessary
+		if _, err := rw.Write(b); err != nil {
+			return err
+		}
+		if _, err := io.ReadFull(rw, b[:2]); err != nil {
+			return err
+		}
+		if b[0] != authUsernamePasswordVersion {
+			return errors.New("invalid username/password version")
+		}
+		if b[1] != authStatusSucceeded {
+			return errors.New("username/password authentication failed")
+		}
+		return nil
+	}
+	return errors.New("unsupported authentication method " + strconv.Itoa(int(auth)))
+}

--- a/vendor/golang.org/x/net/proxy/direct.go
+++ b/vendor/golang.org/x/net/proxy/direct.go
@@ -1,0 +1,18 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package proxy
+
+import (
+	"net"
+)
+
+type direct struct{}
+
+// Direct is a direct proxy: one that makes network connections directly.
+var Direct = direct{}
+
+func (direct) Dial(network, addr string) (net.Conn, error) {
+	return net.Dial(network, addr)
+}

--- a/vendor/golang.org/x/net/proxy/per_host.go
+++ b/vendor/golang.org/x/net/proxy/per_host.go
@@ -1,0 +1,140 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package proxy
+
+import (
+	"net"
+	"strings"
+)
+
+// A PerHost directs connections to a default Dialer unless the host name
+// requested matches one of a number of exceptions.
+type PerHost struct {
+	def, bypass Dialer
+
+	bypassNetworks []*net.IPNet
+	bypassIPs      []net.IP
+	bypassZones    []string
+	bypassHosts    []string
+}
+
+// NewPerHost returns a PerHost Dialer that directs connections to either
+// defaultDialer or bypass, depending on whether the connection matches one of
+// the configured rules.
+func NewPerHost(defaultDialer, bypass Dialer) *PerHost {
+	return &PerHost{
+		def:    defaultDialer,
+		bypass: bypass,
+	}
+}
+
+// Dial connects to the address addr on the given network through either
+// defaultDialer or bypass.
+func (p *PerHost) Dial(network, addr string) (c net.Conn, err error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.dialerForRequest(host).Dial(network, addr)
+}
+
+func (p *PerHost) dialerForRequest(host string) Dialer {
+	if ip := net.ParseIP(host); ip != nil {
+		for _, net := range p.bypassNetworks {
+			if net.Contains(ip) {
+				return p.bypass
+			}
+		}
+		for _, bypassIP := range p.bypassIPs {
+			if bypassIP.Equal(ip) {
+				return p.bypass
+			}
+		}
+		return p.def
+	}
+
+	for _, zone := range p.bypassZones {
+		if strings.HasSuffix(host, zone) {
+			return p.bypass
+		}
+		if host == zone[1:] {
+			// For a zone ".example.com", we match "example.com"
+			// too.
+			return p.bypass
+		}
+	}
+	for _, bypassHost := range p.bypassHosts {
+		if bypassHost == host {
+			return p.bypass
+		}
+	}
+	return p.def
+}
+
+// AddFromString parses a string that contains comma-separated values
+// specifying hosts that should use the bypass proxy. Each value is either an
+// IP address, a CIDR range, a zone (*.example.com) or a host name
+// (localhost). A best effort is made to parse the string and errors are
+// ignored.
+func (p *PerHost) AddFromString(s string) {
+	hosts := strings.Split(s, ",")
+	for _, host := range hosts {
+		host = strings.TrimSpace(host)
+		if len(host) == 0 {
+			continue
+		}
+		if strings.Contains(host, "/") {
+			// We assume that it's a CIDR address like 127.0.0.0/8
+			if _, net, err := net.ParseCIDR(host); err == nil {
+				p.AddNetwork(net)
+			}
+			continue
+		}
+		if ip := net.ParseIP(host); ip != nil {
+			p.AddIP(ip)
+			continue
+		}
+		if strings.HasPrefix(host, "*.") {
+			p.AddZone(host[1:])
+			continue
+		}
+		p.AddHost(host)
+	}
+}
+
+// AddIP specifies an IP address that will use the bypass proxy. Note that
+// this will only take effect if a literal IP address is dialed. A connection
+// to a named host will never match an IP.
+func (p *PerHost) AddIP(ip net.IP) {
+	p.bypassIPs = append(p.bypassIPs, ip)
+}
+
+// AddNetwork specifies an IP range that will use the bypass proxy. Note that
+// this will only take effect if a literal IP address is dialed. A connection
+// to a named host will never match.
+func (p *PerHost) AddNetwork(net *net.IPNet) {
+	p.bypassNetworks = append(p.bypassNetworks, net)
+}
+
+// AddZone specifies a DNS suffix that will use the bypass proxy. A zone of
+// "example.com" matches "example.com" and all of its subdomains.
+func (p *PerHost) AddZone(zone string) {
+	if strings.HasSuffix(zone, ".") {
+		zone = zone[:len(zone)-1]
+	}
+	if !strings.HasPrefix(zone, ".") {
+		zone = "." + zone
+	}
+	p.bypassZones = append(p.bypassZones, zone)
+}
+
+// AddHost specifies a host name that will use the bypass proxy.
+func (p *PerHost) AddHost(host string) {
+	if strings.HasSuffix(host, ".") {
+		host = host[:len(host)-1]
+	}
+	p.bypassHosts = append(p.bypassHosts, host)
+}

--- a/vendor/golang.org/x/net/proxy/proxy.go
+++ b/vendor/golang.org/x/net/proxy/proxy.go
@@ -1,0 +1,134 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package proxy provides support for a variety of protocols to proxy network
+// data.
+package proxy // import "golang.org/x/net/proxy"
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"os"
+	"sync"
+)
+
+// A Dialer is a means to establish a connection.
+type Dialer interface {
+	// Dial connects to the given address via the proxy.
+	Dial(network, addr string) (c net.Conn, err error)
+}
+
+// Auth contains authentication parameters that specific Dialers may require.
+type Auth struct {
+	User, Password string
+}
+
+// FromEnvironment returns the dialer specified by the proxy related variables in
+// the environment.
+func FromEnvironment() Dialer {
+	allProxy := allProxyEnv.Get()
+	if len(allProxy) == 0 {
+		return Direct
+	}
+
+	proxyURL, err := url.Parse(allProxy)
+	if err != nil {
+		return Direct
+	}
+	proxy, err := FromURL(proxyURL, Direct)
+	if err != nil {
+		return Direct
+	}
+
+	noProxy := noProxyEnv.Get()
+	if len(noProxy) == 0 {
+		return proxy
+	}
+
+	perHost := NewPerHost(proxy, Direct)
+	perHost.AddFromString(noProxy)
+	return perHost
+}
+
+// proxySchemes is a map from URL schemes to a function that creates a Dialer
+// from a URL with such a scheme.
+var proxySchemes map[string]func(*url.URL, Dialer) (Dialer, error)
+
+// RegisterDialerType takes a URL scheme and a function to generate Dialers from
+// a URL with that scheme and a forwarding Dialer. Registered schemes are used
+// by FromURL.
+func RegisterDialerType(scheme string, f func(*url.URL, Dialer) (Dialer, error)) {
+	if proxySchemes == nil {
+		proxySchemes = make(map[string]func(*url.URL, Dialer) (Dialer, error))
+	}
+	proxySchemes[scheme] = f
+}
+
+// FromURL returns a Dialer given a URL specification and an underlying
+// Dialer for it to make network requests.
+func FromURL(u *url.URL, forward Dialer) (Dialer, error) {
+	var auth *Auth
+	if u.User != nil {
+		auth = new(Auth)
+		auth.User = u.User.Username()
+		if p, ok := u.User.Password(); ok {
+			auth.Password = p
+		}
+	}
+
+	switch u.Scheme {
+	case "socks5":
+		return SOCKS5("tcp", u.Host, auth, forward)
+	}
+
+	// If the scheme doesn't match any of the built-in schemes, see if it
+	// was registered by another package.
+	if proxySchemes != nil {
+		if f, ok := proxySchemes[u.Scheme]; ok {
+			return f(u, forward)
+		}
+	}
+
+	return nil, errors.New("proxy: unknown scheme: " + u.Scheme)
+}
+
+var (
+	allProxyEnv = &envOnce{
+		names: []string{"ALL_PROXY", "all_proxy"},
+	}
+	noProxyEnv = &envOnce{
+		names: []string{"NO_PROXY", "no_proxy"},
+	}
+)
+
+// envOnce looks up an environment variable (optionally by multiple
+// names) once. It mitigates expensive lookups on some platforms
+// (e.g. Windows).
+// (Borrowed from net/http/transport.go)
+type envOnce struct {
+	names []string
+	once  sync.Once
+	val   string
+}
+
+func (e *envOnce) Get() string {
+	e.once.Do(e.init)
+	return e.val
+}
+
+func (e *envOnce) init() {
+	for _, n := range e.names {
+		e.val = os.Getenv(n)
+		if e.val != "" {
+			return
+		}
+	}
+}
+
+// reset is used by tests
+func (e *envOnce) reset() {
+	e.once = sync.Once{}
+	e.val = ""
+}

--- a/vendor/golang.org/x/net/proxy/socks5.go
+++ b/vendor/golang.org/x/net/proxy/socks5.go
@@ -1,0 +1,36 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package proxy
+
+import (
+	"context"
+	"net"
+
+	"golang.org/x/net/internal/socks"
+)
+
+// SOCKS5 returns a Dialer that makes SOCKSv5 connections to the given
+// address with an optional username and password.
+// See RFC 1928 and RFC 1929.
+func SOCKS5(network, address string, auth *Auth, forward Dialer) (Dialer, error) {
+	d := socks.NewDialer(network, address)
+	if forward != nil {
+		d.ProxyDial = func(_ context.Context, network string, address string) (net.Conn, error) {
+			return forward.Dial(network, address)
+		}
+	}
+	if auth != nil {
+		up := socks.UsernamePassword{
+			Username: auth.User,
+			Password: auth.Password,
+		}
+		d.AuthMethods = []socks.AuthMethod{
+			socks.AuthMethodNotRequired,
+			socks.AuthMethodUsernamePassword,
+		}
+		d.Authenticate = up.Authenticate
+	}
+	return d, nil
+}


### PR DESCRIPTION
**Purpose**

Build off the work of @steven-aerts in https://github.com/gravitational/teleport/pull/1694 and add support for dynamic port forwarding (SOCKS5).

**Implementation**

* Add the `-D` flag to tsh.
* Add support for a SOCKS5 handshake to discover the remote address to proxy.
* Proxy connections using a `direct-tcpip` channel.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/1693
Fixes https://github.com/gravitational/teleport/pull/1694