### PR TITLE
Regexp support for node lables

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1401,7 +1401,6 @@ func MatchLabels(selector Labels, target map[string]string) (bool, string, error
 		return false, "no match, empty selector", nil
 	}
 
-	// matchLabels, labelsMessage := MatchLabels(role.GetNodeLabels(Deny), s.GetAllLabels())
 	// *: * matches everything even empty target set.
 	selectorValues := selector[Wildcard]
 	if len(selectorValues) == 1 && selectorValues[0] == Wildcard {
@@ -1417,9 +1416,9 @@ func MatchLabels(selector Labels, target map[string]string) (bool, string, error
 		}
 
 		if !utils.SliceContainsStr(selectorValues, Wildcard) {
-			result, err := utils.SliceContainsRegexStr(targetVal, selectorValues)
+			result, err := utils.SliceMatchesRegex(targetVal, selectorValues)
 			if err != nil {
-				return false, "", trace.BadParameter(err.Error())
+				return false, "", trace.Wrap(err)
 			} else if !result {
 				return false, fmt.Sprintf("no value match: got '%v' want: '%v'", targetVal, selectorValues), nil
 			}
@@ -1568,7 +1567,7 @@ func (set RoleSet) CheckAccessToServer(login string, s Server) error {
 		matchNamespace, namespaceMessage := MatchNamespace(role.GetNamespaces(Deny), s.GetNamespace())
 		matchLabels, labelsMessage, err := MatchLabels(role.GetNodeLabels(Deny), s.GetAllLabels())
 		if err != nil {
-			return trace.CompareFailed(err.Error())
+			return trace.Wrap(err)
 		}
 		matchLogin, loginMessage := MatchLogin(role.GetLogins(Deny), login)
 		if matchNamespace && (matchLabels || matchLogin) {
@@ -1588,7 +1587,7 @@ func (set RoleSet) CheckAccessToServer(login string, s Server) error {
 		matchNamespace, namespaceMessage := MatchNamespace(role.GetNamespaces(Allow), s.GetNamespace())
 		matchLabels, labelsMessage, err := MatchLabels(role.GetNodeLabels(Allow), s.GetAllLabels())
 		if err != nil {
-			return trace.CompareFailed(err.Error())
+			return trace.Wrap(err)
 		}
 		matchLogin, loginMessage := MatchLogin(role.GetLogins(Allow), login)
 		if matchNamespace && matchLabels && matchLogin {

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -46,5 +46,26 @@ func ReplaceRegexp(expression string, replaceWith string, input string) (string,
 	return expr.ReplaceAllString(input, replaceWith), nil
 }
 
+func SliceContainsRegexStr(input string, expressions []string) (bool, error) {
+	for _, expression := range expressions {
+		if !strings.HasPrefix(expression, "^") || !strings.HasSuffix(expression, "$") {
+			// replace glob-style wildcards with regexp wildcards
+			// for plain strings, and quote all characters that could
+			// be interpreted in regular expression
+			expression = "^" + GlobToRegexp(expression) + "$"
+		}
+
+		expr, err := regexp.Compile(expression)
+		if err != nil {
+			return false, trace.BadParameter(err.Error())
+		}
+		if expr.MatchString(input) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 var replaceWildcard = regexp.MustCompile(`(\\\*)`)
 var reExpansion = regexp.MustCompile(`\$[^\$]+`)

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -46,7 +46,9 @@ func ReplaceRegexp(expression string, replaceWith string, input string) (string,
 	return expr.ReplaceAllString(input, replaceWith), nil
 }
 
-func SliceContainsRegexStr(input string, expressions []string) (bool, error) {
+// SliceMatchesRegex checks if input matches any of the expressions. The
+// match is always evaluated as a regex either an exact match or regexp.
+func SliceMatchesRegex(input string, expressions []string) (bool, error) {
 	for _, expression := range expressions {
 		if !strings.HasPrefix(expression, "^") || !strings.HasSuffix(expression, "$") {
 			// replace glob-style wildcards with regexp wildcards
@@ -59,6 +61,10 @@ func SliceContainsRegexStr(input string, expressions []string) (bool, error) {
 		if err != nil {
 			return false, trace.BadParameter(err.Error())
 		}
+
+		// Since the expression is always surrounded by ^ and $ this is an exact
+		// match for either a a plain string (for example ^hello$) or for a regexp
+		// (for example ^hel*o$).
 		if expr.MatchString(input) {
 			return true, nil
 		}


### PR DESCRIPTION
**Purpose**

Building off the work of @ken5scal in https://github.com/gravitational/teleport/pull/2206, add regexp support for node labels.

**Implementation**

* Add support for regexp in MatchLabels.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2205
Fixes https://github.com/gravitational/teleport/pull/2206