### PR TITLE
Add support for CA pinning when joining a cluster.

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -67,6 +67,7 @@ func NewAPIServer(config *APIConfig) http.Handler {
 
 	// Operations on certificate authorities
 	srv.GET("/:version/domain", srv.withAuth(srv.getDomainName))
+	srv.GET("/:version/cacert", srv.withAuth(srv.getClusterCACert))
 
 	srv.POST("/:version/authorities/:type", srv.withAuth(srv.upsertCertAuthority))
 	srv.POST("/:version/authorities/:type/rotate", srv.withAuth(srv.rotateCertAuthority))
@@ -990,6 +991,16 @@ func (s *APIServer) getDomainName(auth ClientI, w http.ResponseWriter, r *http.R
 		return nil, trace.Wrap(err)
 	}
 	return domain, nil
+}
+
+// getClusterCACert returns the CAs for the local cluster without signing keys.
+func (s *APIServer) getClusterCACert(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+	localCA, err := auth.GetClusterCACert()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return localCA, nil
 }
 
 // getU2FAppID returns the U2F AppID in the auth configuration

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -247,6 +247,12 @@ func (a *AuthWithRoles) GetLocalClusterName() (string, error) {
 	return a.authServer.GetLocalClusterName()
 }
 
+// GetClusterCACert returns the CAs for the local cluster without signing keys.
+func (a *AuthWithRoles) GetClusterCACert() (*LocalCAResponse, error) {
+	// Allow all roles to get the local CA.
+	return a.authServer.GetClusterCACert()
+}
+
 func (a *AuthWithRoles) UpsertLocalClusterName(clusterName string) error {
 	if err := a.action(defaults.Namespace, services.KindAuthServer, services.VerbCreate); err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -360,6 +360,19 @@ func (c *Client) GetDomainName() (string, error) {
 	return domain, nil
 }
 
+// GetClusterCACert returns the CAs for the local cluster without signing keys.
+func (c *Client) GetClusterCACert() (*LocalCAResponse, error) {
+	out, err := c.Get(c.Endpoint("cacert"), url.Values{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var localCA LocalCAResponse
+	if err := json.Unmarshal(out.Bytes(), &localCA); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &localCA, nil
+}
+
 func (c *Client) Close() error {
 	return nil
 }
@@ -2302,6 +2315,9 @@ type ClientI interface {
 
 	// GetDomainName returns auth server cluster name
 	GetDomainName() (string, error)
+
+	// GetClusterCACert returns the CAs for the local cluster without signing keys.
+	GetClusterCACert() (*LocalCAResponse, error)
 
 	// GenerateServerKeys generates new host private keys and certificates (signed
 	// by the host certificate authority) for a node

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -18,13 +18,10 @@ package auth
 
 import (
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"strings"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -68,45 +65,40 @@ type RegisterParams struct {
 	PublicSSHKey []byte
 	// CipherSuites is a list of cipher suites to use for TLS client connection
 	CipherSuites []uint16
+	// CAPin is the SKPI hash of the CA used to verify the Auth Server.
+	CAPin string
+	// CAPath is the path to the CA file.
+	CAPath string
 }
 
-// Register is used to generate host keys when a node or proxy are running on different hosts
-// than the auth server. This method requires provisioning tokens to prove a valid auth server
-// was used to issue the joining request.
+// Register is used to generate host keys when a node or proxy are running on
+// different hosts than the auth server. This method requires provisioning
+// tokens to prove a valid auth server was used to issue the joining request
+// as well as a method for the node to validate the auth server.
 func Register(params RegisterParams) (*Identity, error) {
+	// Read in the token. The token can either be passed in or come from a file
+	// on disk.
 	tok, err := readToken(params.Token)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tlsConfig := utils.TLSConfig(params.CipherSuites)
-	certPath := filepath.Join(params.DataDir, defaults.CACertFile)
-	certBytes, err := utils.ReadPath(certPath)
-	if err != nil {
-		// Only support secure cluster joins in the next releases
-		if !trace.IsNotFound(err) {
-			return nil, trace.Wrap(err)
-		}
-		message := fmt.Sprintf(`Your configuration is insecure! Registering without TLS certificate authority, to fix this warning add ca.cert to %v, you can get ca.cert using 'tctl auth export --type=tls > ca.cert'`,
-			params.DataDir)
-		log.Warning(message)
-		tlsConfig.InsecureSkipVerify = true
-	} else {
-		cert, err := tlsca.ParseCertificatePEM(certBytes)
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to parse certificate at %v", certPath)
-		}
-		log.Infof("Joining remote cluster %v.", cert.Subject.CommonName)
-		certPool := x509.NewCertPool()
-		certPool.AddCert(cert)
-		tlsConfig.RootCAs = certPool
+
+	// Build a client to the Auth Server. If a CA pin is specified require the
+	// Auth Server is validated. Otherwise attempt to use the CA file on disk
+	// but if it's not available connect without validating the Auth Server CA.
+	var client *Client
+	switch {
+	case params.CAPin != "":
+		client, err = pinRegisterClient(params)
+	default:
+		client, err = insecureRegisterClient(params)
 	}
-	client, err := NewTLSClient(params.Servers, tlsConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer client.Close()
 
-	// Get the SSH and X509 certificates
+	// Get the SSH and X509 certificates for a node.
 	keys, err := client.RegisterUsingToken(RegisterUsingTokenRequest{
 		Token:                tok,
 		HostID:               params.ID.HostUUID,
@@ -122,6 +114,109 @@ func Register(params RegisterParams) (*Identity, error) {
 
 	return ReadIdentityFromKeyPair(
 		params.PrivateKey, keys.Cert, keys.TLSCert, keys.TLSCACerts)
+}
+
+// insecureRegisterClient attempts to connects to the Auth Server using the
+// CA on disk. If no CA is found on disk, Teleport will not verify the Auth
+// Server it is connecting to.
+func insecureRegisterClient(params RegisterParams) (*Client, error) {
+	tlsConfig := utils.TLSConfig(params.CipherSuites)
+
+	cert, err := readCA(params)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+
+	// If no CA was found, then create a insecure connection to the Auth Server,
+	// otherwise use the CA on disk to validate the Auth Server.
+	if trace.IsNotFound(err) {
+		tlsConfig.InsecureSkipVerify = true
+
+		log.Warnf("Joining cluster without validating the identity of the Auth " +
+			"Server. This may open you up to a Man-In-The-Middle (MITM) attack if an " +
+			"attacker can gain privileged network access. To remedy this, use the CA pin " +
+			"value provided when join token was generated to validate the identity of " +
+			"the Auth Server.")
+	} else {
+		certPool := x509.NewCertPool()
+		certPool.AddCert(cert)
+		tlsConfig.RootCAs = certPool
+
+		log.Infof("Joining remote cluster %v, validating connection with certificate on disk.", cert.Subject.CommonName)
+	}
+
+	client, err := NewTLSClient(params.Servers, tlsConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return client, nil
+}
+
+// readCA will read in CA that will be used to validate the certificate that
+// the Auth Server presents.
+func readCA(params RegisterParams) (*x509.Certificate, error) {
+	certBytes, err := utils.ReadPath(params.CAPath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cert, err := tlsca.ParseCertificatePEM(certBytes)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse certificate at %v", params.CAPath)
+	}
+	return cert, nil
+}
+
+// pinRegisterClient first connects to the Auth Server using a insecure
+// connection to fetch the root CA. If the root CA matches the provided CA
+// pin, a connection will be re-established and the root CA will be used to
+// validate the certificate presented. If both conditions hold true, then we
+// know we are connecting to the expected Auth Server.
+func pinRegisterClient(params RegisterParams) (*Client, error) {
+	// Build a insecure client to the Auth Server. This is safe because even if
+	// an attacker were to MITM this connection the CA pin will not match below.
+	tlsConfig := utils.TLSConfig(params.CipherSuites)
+	tlsConfig.InsecureSkipVerify = true
+	client, err := NewTLSClient(params.Servers, tlsConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer client.Close()
+
+	// Fetch the root CA from the Auth Server. The NOP role has access to the
+	// GetClusterCACert endpoint.
+	localCA, err := client.GetClusterCACert()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsCA, err := tlsca.ParseCertificatePEM(localCA.TLSCA)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Check that the SKPI pin matches the CA we fetched over a insecure
+	// connection. This makes sure the CA fetched over a insecure connection is
+	// in-fact the expected CA.
+	err = utils.CheckSKPI(params.CAPin, tlsCA)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	log.Infof("Joining remote cluster %v with CA pin.", tlsCA.Subject.CommonName)
+
+	// Create another client, but this time with the CA provided to validate
+	// that the Auth Server was issued a certificate by the same CA.
+	tlsConfig = utils.TLSConfig(params.CipherSuites)
+	certPool := x509.NewCertPool()
+	certPool.AddCert(tlsCA)
+	tlsConfig.RootCAs = certPool
+
+	client, err = NewTLSClient(params.Servers, tlsConfig)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return client, nil
 }
 
 // ReRegisterParams specifies parameters for re-registering

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -59,6 +59,9 @@ type CommandLineFlags struct {
 	AuthServerAddr string
 	// --token flag
 	AuthToken string
+	// CAPin is the hash of the SKPI of the root CA. Used to verify the cluster
+	// being joined is the one expected.
+	CAPin string
 	// --listen-ip flag
 	ListenIP net.IP
 	// --advertise-ip flag
@@ -248,6 +251,11 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 	if fc.MACAlgorithms != nil {
 		cfg.MACAlgorithms = fc.MACAlgorithms
+	}
+
+	// Read in how nodes will validate the CA.
+	if fc.CAPin != "" {
+		cfg.CAPin = fc.CAPin
 	}
 
 	// apply connection throttling:
@@ -801,7 +809,7 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 		return trace.Wrap(err)
 	}
 
-	// apply diangostic address flag
+	// Apply diagnostic address flag.
 	if clf.DiagnosticAddr != "" {
 		addr, err := utils.ParseAddr(clf.DiagnosticAddr)
 		if err != nil {
@@ -858,6 +866,11 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 
 	// apply --token flag:
 	cfg.ApplyToken(clf.AuthToken)
+
+	// Apply flags used for the node to validate the Auth Server.
+	if clf.CAPin != "" {
+		cfg.CAPin = clf.CAPin
+	}
 
 	// apply --listen-ip flag:
 	if clf.ListenIP != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -146,6 +146,7 @@ var (
 		"client_idle_timeout":     false,
 		"disconnect_expired_cert": false,
 		"ciphersuites":            false,
+		"ca_pin":                  false,
 	}
 )
 
@@ -385,6 +386,9 @@ type Global struct {
 	// MACAlgorithms is a list of SSH message authentication codes (MAC) that
 	// the server supports. If omitted the defaults will be used.
 	MACAlgorithms []string `yaml:"mac_algos,omitempty"`
+
+	// CAPin is the SKPI hash of the CA used to verify the Auth Server.
+	CAPin string `yaml:"ca_pin"`
 }
 
 // CachePolicy is used to control  local cache

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -158,6 +158,9 @@ type Config struct {
 
 	// ShutdownTimeout is set to override default shutdown timeout.
 	ShutdownTimeout time.Duration
+
+	// CAPin is the SKPI hash of the CA used to verify the Auth Server.
+	CAPin string
 }
 
 // ApplyToken assigns a given token to all internal services but only if token

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1,11 +1,14 @@
 package service
 
 import (
-	"golang.org/x/crypto/ssh"
+	"path/filepath"
 	"time"
+
+	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -287,6 +290,8 @@ func (process *TeleportProcess) firstTimeConnect(role teleport.Role) (*Connector
 			PublicTLSKey:         keyPair.PublicTLSKey,
 			PublicSSHKey:         keyPair.PublicSSHKey,
 			CipherSuites:         process.Config.CipherSuites,
+			CAPin:                process.Config.CAPin,
+			CAPath:               filepath.Join(defaults.DataDir, defaults.CACertFile),
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/tlsca/parsegen.go
+++ b/lib/tlsca/parsegen.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tlsca
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -186,4 +187,17 @@ func MarshalPublicKeyFromPrivateKeyPEM(privateKey crypto.PrivateKey) ([]byte, er
 		return nil, trace.Wrap(err)
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: derBytes}), nil
+}
+
+// MarshalCertificatePEM takes a *x509.Certificate and returns the PEM
+// encoded bytes.
+func MarshalCertificatePEM(cert *x509.Certificate) ([]byte, error) {
+	var buf bytes.Buffer
+
+	err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return buf.Bytes(), nil
 }

--- a/lib/utils/skpi.go
+++ b/lib/utils/skpi.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/x509"
+	"encoding/hex"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// CalculateSKPI the hash value of the SPKI header in a certificate.
+func CalculateSKPI(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// CheckSKPI the passed in pin against the calculated value from a certificate.
+func CheckSKPI(pin string, cert *x509.Certificate) error {
+	// Check that the format of the pin is valid.
+	parts := strings.Split(pin, ":")
+	if len(parts) != 2 {
+		return trace.BadParameter("invalid format for SKPI hash")
+	}
+	if parts[0] != "sha256" {
+		return trace.BadParameter("only sha256 supported by SKPI hash")
+	}
+
+	// Check that that pin itself matches that value calculated from the passed
+	// in certificate.
+	if subtle.ConstantTimeCompare([]byte(CalculateSKPI(cert)), []byte(pin)) != 1 {
+		return trace.BadParameter("SKPI values do not match")
+	}
+
+	return nil
+}

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -153,6 +153,9 @@ func SplitHostPort(hostname string) (string, string, error) {
 }
 
 func ReadPath(path string) ([]byte, error) {
+	if path == "" {
+		return nil, trace.NotFound("empty path")
+	}
 	s, err := filepath.Abs(path)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -97,6 +97,9 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 	start.Flag("token",
 		"Invitation token to register with an auth server [none]").
 		StringVar(&ccf.AuthToken)
+	start.Flag("ca-pin",
+		"CA pin to validate the Auth Server").
+		StringVar(&ccf.CAPin)
 	start.Flag("nodename",
 		"Name of this node, defaults to hostname").
 		StringVar(&ccf.NodeName)


### PR DESCRIPTION
**Purpose**

Improve UX around validation of the Auth Server when joining a cluster.

**Implementation**

* Support an insecure method to join a cluster. This can be used with dynamic or static tokens to join a cluster without validating the identity of the Auth Server.
* Support validating the identity of the Auth Server with a CA on disk.
* Support validating the identity of the Auth Server with a CA pin.

See https://github.com/gravitational/teleport/issues/2237 for further design details.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2237