### PR TITLE
Update admin-guide.md

### DIFF
--- a/docs/3.0/admin-guide.md
+++ b/docs/3.0/admin-guide.md
@@ -1638,9 +1638,7 @@ $ tctl auth rotate --type=host --grace-period=8h
 
 The rotation takes time, especially for hosts, because each node in a cluster
 needs to be notified that a rotation is taking place and request a new
-certificate for itself before the grace period ends. If the grace period is 
-set to "0h" (zero hours) it means that all previously issued certificates
-become invalid immediately.
+certificate for itself before the grace period ends.
 
 !!! warning "Warning":
     Be careful when choosing a grace period when rotating host certificates.


### PR DESCRIPTION
Remove deprecated "0h" grace period option as per https://github.com/gravitational/teleport/issues/2218#issuecomment-421094514