### PR TITLE
Propagate context to HTTP client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -417,11 +417,12 @@
   version = "0.0.6"
 
 [[projects]]
-  digest = "1:4c786beee51db5f821486d5afec0b6b325baf536662ed75b39ba4a7559253363"
+  digest = "1:1920655c8439bf875819f7d8db882b089f3ca6cb9b3c9ca6413bc2ec2217ea82"
   name = "github.com/gravitational/roundtrip"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "6a87d116a90b9c4e73bedc19ebc9c17f1b43d826"
+  revision = "e1e0cd6b05a6bb1791b262e63160038828fd7b3a"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:d92cabdc7cfe96302f98b2fac7b0f1107ef9ab066708d45d6feaca39aeb4f6f3"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -86,7 +86,7 @@ ignored = ["github.com/Sirupsen/logrus"]
 
 [[constraint]]
   name = "github.com/gravitational/roundtrip"
-  revision = "6a87d116a90b9c4e73bedc19ebc9c17f1b43d826"
+  version = "1.0.0"
 
 [[constraint]]
   version = "0.0.1"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3131,11 +3131,11 @@ func (s *IntSuite) TestMultipleSignup(c *check.C) {
 		c.Assert(err, check.IsNil)
 
 		// Render the signup page.
-		_, err = clt.Get(clt.Endpoint("webapi", "users", "invites", token), url.Values{})
+		_, err = clt.Get(context.Background(), clt.Endpoint("webapi", "users", "invites", token), url.Values{})
 		c.Assert(err, check.IsNil)
 
 		// Make sure signup is successful.
-		_, err = clt.PostJSON(clt.Endpoint("webapi", "users"), createNewUserReq{
+		_, err = clt.PostJSON(context.Background(), clt.Endpoint("webapi", "users"), createNewUserReq{
 			InviteToken: token,
 			Pass:        "fake-password-123",
 		})

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -238,13 +238,13 @@ func (c *Client) GetTransport() *http.Transport {
 // PostJSON is a generic method that issues http POST request to the server
 func (c *Client) PostJSON(
 	endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.PostJSON(endpoint, val))
+	return httplib.ConvertResponse(c.Client.PostJSON(context.TODO(), endpoint, val))
 }
 
 // PutJSON is a generic method that issues http PUT request to the server
 func (c *Client) PutJSON(
 	endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.PutJSON(endpoint, val))
+	return httplib.ConvertResponse(c.Client.PutJSON(context.TODO(), endpoint, val))
 }
 
 // PostForm is a generic method that issues http POST request to the server
@@ -253,17 +253,17 @@ func (c *Client) PostForm(
 	vals url.Values,
 	files ...roundtrip.File) (*roundtrip.Response, error) {
 
-	return httplib.ConvertResponse(c.Client.PostForm(endpoint, vals, files...))
+	return httplib.ConvertResponse(c.Client.PostForm(context.TODO(), endpoint, vals, files...))
 }
 
 // Get issues http GET request to the server
 func (c *Client) Get(u string, params url.Values) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.Get(u, params))
+	return httplib.ConvertResponse(c.Client.Get(context.TODO(), u, params))
 }
 
 // Delete issues http Delete Request to the server
 func (c *Client) Delete(u string) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(c.Client.Delete(u))
+	return httplib.ConvertResponse(c.Client.Delete(context.TODO(), u))
 }
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -12,12 +12,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -487,7 +487,7 @@ func (s *AuthServer) sendValidateRequestToProxy(host string, validateRequest *Va
 		return nil, trace.Wrap(err)
 	}
 
-	out, err := httplib.ConvertResponse(clt.PostJSON(clt.Endpoint("webapi", "trustedclusters", "validate"), validateRequestRaw))
+	out, err := httplib.ConvertResponse(clt.PostJSON(context.TODO(), clt.Endpoint("webapi", "trustedclusters", "validate"), validateRequestRaw))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/https_client.go
+++ b/lib/client/https_client.go
@@ -18,6 +18,7 @@ limitations under the License.
 package client
 
 import (
+	"context"
 	"crypto/x509"
 	"net/http"
 	"net/url"
@@ -71,20 +72,18 @@ type WebClient struct {
 	*roundtrip.Client
 }
 
-func (w *WebClient) PostJSON(
-	endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(w.Client.PostJSON(endpoint, val))
+func (w *WebClient) PostJSON(ctx context.Context, endpoint string, val interface{}) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(w.Client.PostJSON(ctx, endpoint, val))
 }
 
-func (w *WebClient) PutJSON(
-	endpoint string, val interface{}) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(w.Client.PutJSON(endpoint, val))
+func (w *WebClient) PutJSON(ctx context.Context, endpoint string, val interface{}) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(w.Client.PutJSON(ctx, endpoint, val))
 }
 
-func (w *WebClient) Get(endpoint string, val url.Values) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(w.Client.Get(endpoint, val))
+func (w *WebClient) Get(ctx context.Context, endpoint string, val url.Values) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(w.Client.Get(ctx, endpoint, val))
 }
 
-func (w *WebClient) Delete(endpoint string) (*roundtrip.Response, error) {
-	return httplib.ConvertResponse(w.Client.Delete(endpoint))
+func (w *WebClient) Delete(ctx context.Context, endpoint string) (*roundtrip.Response, error) {
+	return httplib.ConvertResponse(w.Client.Delete(ctx, endpoint))
 }

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -209,7 +209,7 @@ func SSHAgentSSOLogin(ctx context.Context, proxyAddr, connectorID string, pubKey
 	query.Set("secret", secret.KeyToEncodedString(keyBytes))
 	u.RawQuery = query.Encode()
 
-	out, err := clt.PostJSON(clt.Endpoint("webapi", protocol, "login", "console"), SSOLoginConsoleReq{
+	out, err := clt.PostJSON(ctx, clt.Endpoint("webapi", protocol, "login", "console"), SSOLoginConsoleReq{
 		RedirectURL:   u.String(),
 		PublicKey:     pubKey,
 		CertTTL:       ttl,
@@ -377,7 +377,7 @@ type GithubSettings struct {
 // to better user experience: users get connection errors before being asked for passwords. The second
 // is to return the form of authentication that the server supports. This also leads to better user
 // experience: users only get prompted for the type of authentication the server supports.
-func Ping(proxyAddr string, insecure bool, pool *x509.CertPool, connectorName string) (*PingResponse, error) {
+func Ping(ctx context.Context, proxyAddr string, insecure bool, pool *x509.CertPool, connectorName string) (*PingResponse, error) {
 	clt, _, err := initClient(proxyAddr, insecure, pool)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -388,7 +388,7 @@ func Ping(proxyAddr string, insecure bool, pool *x509.CertPool, connectorName st
 		endpoint = clt.Endpoint("webapi", "ping", connectorName)
 	}
 
-	response, err := clt.Get(endpoint, url.Values{})
+	response, err := clt.Get(ctx, endpoint, url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -406,12 +406,12 @@ func Ping(proxyAddr string, insecure bool, pool *x509.CertPool, connectorName st
 // if credentials are valid
 //
 // proxyAddr must be specified as host:port
-func SSHAgentLogin(proxyAddr, user, password, otpToken string, pubKey []byte, ttl time.Duration, insecure bool, pool *x509.CertPool, compatibility string) (*auth.SSHLoginResponse, error) {
+func SSHAgentLogin(ctx context.Context, proxyAddr, user, password, otpToken string, pubKey []byte, ttl time.Duration, insecure bool, pool *x509.CertPool, compatibility string) (*auth.SSHLoginResponse, error) {
 	clt, _, err := initClient(proxyAddr, insecure, pool)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	re, err := clt.PostJSON(clt.Endpoint("webapi", "ssh", "certs"), CreateSSHCertReq{
+	re, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "ssh", "certs"), CreateSSHCertReq{
 		User:          user,
 		Password:      password,
 		OTPToken:      otpToken,
@@ -436,13 +436,13 @@ func SSHAgentLogin(proxyAddr, user, password, otpToken string, pubKey []byte, tt
 // If the credentials are valid, the proxy wiil return a challenge.
 // We then call the official u2f-host binary to perform the signing and pass the signature to the proxy.
 // If the authentication succeeds, we will get a temporary certificate back
-func SSHAgentU2FLogin(proxyAddr, user, password string, pubKey []byte, ttl time.Duration, insecure bool, pool *x509.CertPool, compatibility string) (*auth.SSHLoginResponse, error) {
+func SSHAgentU2FLogin(ctx context.Context, proxyAddr, user, password string, pubKey []byte, ttl time.Duration, insecure bool, pool *x509.CertPool, compatibility string) (*auth.SSHLoginResponse, error) {
 	clt, _, err := initClient(proxyAddr, insecure, pool)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	u2fSignRequest, err := clt.PostJSON(clt.Endpoint("webapi", "u2f", "signrequest"), U2fSignRequestReq{
+	u2fSignRequest, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "u2f", "signrequest"), U2fSignRequestReq{
 		User: user,
 		Pass: password,
 	})
@@ -501,7 +501,7 @@ func SSHAgentU2FLogin(proxyAddr, user, password string, pubKey []byte, ttl time.
 		return nil, trace.Wrap(err)
 	}
 
-	re, err := clt.PostJSON(clt.Endpoint("webapi", "u2f", "certs"), CreateSSHCertWithU2FReq{
+	re, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "u2f", "certs"), CreateSSHCertWithU2FReq{
 		User:            user,
 		U2FSignResponse: *u2fSignResponse,
 		PubKey:          pubKey,

--- a/vendor/github.com/gravitational/roundtrip/client.go
+++ b/vendor/github.com/gravitational/roundtrip/client.go
@@ -37,6 +37,7 @@ package roundtrip
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -169,7 +170,7 @@ func (c *Client) Endpoint(params ...string) string {
 //
 // c.PostForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
 //
-func (c *Client) PostForm(endpoint string, vals url.Values, files ...File) (*Response, error) {
+func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values, files ...File) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -184,6 +185,7 @@ func (c *Client) PostForm(endpoint string, vals url.Values, files ...File) (*Res
 			if err != nil {
 				return nil, err
 			}
+			req = req.WithContext(ctx)
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			c.addAuth(req)
 			return c.client.Do(req)
@@ -214,9 +216,10 @@ func (c *Client) PostForm(endpoint string, vals url.Values, files ...File) (*Res
 		if err != nil {
 			return nil, err
 		}
-		c.addAuth(req)
+		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type",
 			fmt.Sprintf(`multipart/form-data;boundary="%v"`, writer.Boundary()))
+		c.addAuth(req)
 		return c.client.Do(req)
 	})
 }
@@ -225,7 +228,7 @@ func (c *Client) PostForm(endpoint string, vals url.Values, files ...File) (*Res
 //
 // c.PostJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
-func (c *Client) PostJSON(endpoint string, data interface{}) (*Response, error) {
+func (c *Client) PostJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -241,6 +244,7 @@ func (c *Client) PostJSON(endpoint string, data interface{}) (*Response, error) 
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type", "application/json")
 		c.addAuth(req)
 		tracer.Start(req)
@@ -252,7 +256,7 @@ func (c *Client) PostJSON(endpoint string, data interface{}) (*Response, error) 
 //
 // c.PutJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
-func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
+func (c *Client) PutJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -268,6 +272,7 @@ func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type", "application/json")
 		c.addAuth(req)
 		tracer.Start(req)
@@ -279,7 +284,7 @@ func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
 //
 // c.PatchJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
-func (c *Client) PatchJSON(endpoint string, data interface{}) (*Response, error) {
+func (c *Client) PatchJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -295,6 +300,7 @@ func (c *Client) PatchJSON(endpoint string, data interface{}) (*Response, error)
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type", "application/json")
 		c.addAuth(req)
 		tracer.Start(req)
@@ -306,7 +312,7 @@ func (c *Client) PatchJSON(endpoint string, data interface{}) (*Response, error)
 //
 // re, err := c.Delete(c.Endpoint("users", "id1"))
 //
-func (c *Client) Delete(endpoint string) (*Response, error) {
+func (c *Client) Delete(ctx context.Context, endpoint string) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -321,6 +327,7 @@ func (c *Client) Delete(endpoint string) (*Response, error) {
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		c.addAuth(req)
 		tracer.Start(req)
 		return c.client.Do(req)
@@ -331,20 +338,20 @@ func (c *Client) Delete(endpoint string) (*Response, error) {
 //
 // re, err := c.DeleteWithParams(c.Endpoint("users", "id1"), url.Values{"force": []string{"true"}})
 //
-func (c *Client) DeleteWithParams(endpoint string, params url.Values) (*Response, error) {
+func (c *Client) DeleteWithParams(ctx context.Context, endpoint string, params url.Values) (*Response, error) {
 	baseURL, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
 	baseURL.RawQuery = params.Encode()
-	return c.Delete(baseURL.String())
+	return c.Delete(ctx, baseURL.String())
 }
 
 // Get executes GET request to the server endpoint with optional query arguments passed in params
 //
 // re, err := c.Get(c.Endpoint("users"), url.Values{"name": []string{"John"}})
 //
-func (c *Client) Get(endpoint string, params url.Values) (*Response, error) {
+func (c *Client) Get(ctx context.Context, endpoint string, params url.Values) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -364,6 +371,7 @@ func (c *Client) Get(endpoint string, params url.Values) (*Response, error) {
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		c.addAuth(req)
 		tracer.Start(req)
 		return c.client.Do(req)
@@ -374,7 +382,7 @@ func (c *Client) Get(endpoint string, params url.Values) (*Response, error) {
 //
 // f, err := c.GetFile("files", "report.txt") // returns "/v1/files/report.txt"
 //
-func (c *Client) GetFile(endpoint string, params url.Values) (*FileResponse, error) {
+func (c *Client) GetFile(ctx context.Context, endpoint string, params url.Values) (*FileResponse, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -392,6 +400,7 @@ func (c *Client) GetFile(endpoint string, params url.Values) (*FileResponse, err
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 	c.addAuth(req)
 	tracer := c.newTracer()
 	tracer.Start(req)
@@ -417,7 +426,7 @@ type ReadSeekCloser interface {
 // OpenFile opens file using HTTP protocol and uses `Range` headers
 // to seek to various positions in the file, this means that server
 // has to support the flags `Range` and `Content-Range`
-func (c *Client) OpenFile(endpoint string, params url.Values) (ReadSeekCloser, error) {
+func (c *Client) OpenFile(ctx context.Context, endpoint string, params url.Values) (ReadSeekCloser, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -432,7 +441,7 @@ func (c *Client) OpenFile(endpoint string, params url.Values) (ReadSeekCloser, e
 	}
 	u.RawQuery = params.Encode()
 
-	return newSeeker(c, u.String())
+	return newSeeker(c, ctx, u.String())
 }
 
 // RoundTripFn inidicates any function that can be passed to RoundTrip

--- a/vendor/github.com/gravitational/roundtrip/seeker.go
+++ b/vendor/github.com/gravitational/roundtrip/seeker.go
@@ -1,6 +1,7 @@
 package roundtrip
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -62,12 +63,13 @@ func (s *seeker) canSeek() error {
 	return s.lastError
 }
 
-func newSeeker(c *Client, endpoint string) (ReadSeekCloser, error) {
+func newSeeker(c *Client, ctx context.Context, endpoint string) (ReadSeekCloser, error) {
 	response, err := c.RoundTrip(func() (*http.Response, error) {
 		req, err := http.NewRequest("HEAD", endpoint, nil)
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		c.addAuth(req)
 		return c.client.Do(req)
 	})


### PR DESCRIPTION
**Purpose**

If `tsh` blocks during an HTTP request (like fetching the ping endpoint) users have to wait until `tsh` times out because Ctrl+C is not respected.

**Implementation**

Propagate cancellation context to github.com/gravitational/roundtrip library to allow cancelation of a HTTP request to return control back to the user.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2285