### PR TITLE
Support Windows claim formats.

### DIFF
--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -317,7 +317,7 @@ const UserSpecV2SchemaTemplate = `{
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-zA-Z/.0-9_]+$": {
+        "^[a-zA-Z/.0-9_:]+$": {
           "type": ["array", "null"],
           "items": {
             "type": "string"


### PR DESCRIPTION
**Purpose**

Starting in #2152, Teleport started actually validating traits in `services.User`. In doing so, traits for Windows users, which are URLs, started failing because they contain a `:`. 

**Implementation**

Added `:` to the list of allowed patterns for traits to support Windows traits that have the following format:

```
http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname
```