### PR TITLE
Add Go version to output of version subcommand.

### DIFF
--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -19,7 +19,9 @@ limitations under the License.
 package modules
 
 import (
+	"bytes"
 	"fmt"
+	"runtime"
 	"sync"
 
 	"github.com/gravitational/teleport"
@@ -79,13 +81,15 @@ func (p *defaultModules) DefaultAllowedLogins() []string {
 	return []string{teleport.TraitInternalLoginsVariable}
 }
 
-// PrintVersion prints teleport version
+// PrintVersion prints the Teleport version.
 func (p *defaultModules) PrintVersion() {
-	ver := fmt.Sprintf("Teleport v%s", teleport.Version)
-	if teleport.Gitref != "" {
-		ver = fmt.Sprintf("%s git:%s", ver, teleport.Gitref)
-	}
-	fmt.Println(ver)
+	var buf bytes.Buffer
+
+	buf.WriteString(fmt.Sprintf("Teleport v%s ", teleport.Version))
+	buf.WriteString(fmt.Sprintf("git:%s ", teleport.Gitref))
+	buf.WriteString(runtime.Version())
+
+	fmt.Println(buf.String())
 }
 
 // RolesFromLogins returns roles for external user based on the logins


### PR DESCRIPTION
**Purpose**

With https://github.com/gravitational/teleport/issues/2277, Teleport binaries will now be built with different versions of Go. To assist in debugging, the version of Go the binary was built with is now included in the `version` sub command.

**Implementation**

* Print the Teleport version in the output of `PrintVersion`.

**Related Issues**

https://github.com/gravitational/teleport.e/pull/96
https://github.com/gravitational/teleport/issues/2277