### PR TITLE
Build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ darwin
 
 # usually release tarballs get in the way
 *.gz
+*.zip
 
 # built web assets
 web/dist/app/app
@@ -51,7 +52,7 @@ docs/latest.yaml
 .terraform
 terraform.tfstate
 
-# OSX 
+# macOS
 **/.DS_Store
 
 # ansible stuff

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,11 @@ DATADIR ?= /usr/local/share/teleport
 ADDFLAGS ?=
 PWD ?= `pwd`
 GOCACHEDIR ?= `go env GOCACHE`
+GOPKGDIR ?= `go env GOPATH`/pkg/`go env GOHOSTOS`_`go env GOARCH`/github.com/gravitational/teleport*
 TELEPORT_DEBUG ?= no
 GITTAG=v$(VERSION)
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
+CGOFLAG ?= CGO_ENABLED=1
 
 OS ?= `go env GOOS`
 ARCH ?= `go env GOARCH`
@@ -67,15 +69,15 @@ all: $(VERSRC)
 # If you are considering changing this behavior, please consult with dev team first
 .PHONY: $(BUILDDIR)/tctl
 $(BUILDDIR)/tctl:
-	go build $(PAMFLAGS) -o $(BUILDDIR)/tctl $(BUILDFLAGS) ./tool/tctl
+	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build $(PAMFLAGS) -o $(BUILDDIR)/tctl $(BUILDFLAGS) ./tool/tctl
 
 .PHONY: $(BUILDDIR)/teleport
 $(BUILDDIR)/teleport:
-	go build $(PAMFLAGS) -o $(BUILDDIR)/teleport $(BUILDFLAGS) ./tool/teleport
+	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build $(PAMFLAGS) -o $(BUILDDIR)/teleport $(BUILDFLAGS) ./tool/teleport
 
 .PHONY: $(BUILDDIR)/tsh
 $(BUILDDIR)/tsh:
-	GOOS=$(OS) go build $(PAMFLAGS) -o $(BUILDDIR)/tsh $(BUILDFLAGS) ./tool/tsh
+	GOOS=$(OS) GOARCH=$(ARCH) $(CGOFLAG) go build $(PAMFLAGS) -o $(BUILDDIR)/tsh $(BUILDFLAGS) ./tool/tsh
 
 #
 # make full - Builds Teleport binaries with the built-in web assets and
@@ -99,11 +101,11 @@ clean:
 	@echo "---> Cleaning up OSS build artifacts."
 	rm -rf $(BUILDDIR)
 	rm -rf $(GOCACHEDIR)
+	rm -rf $(GOPKGDIR)
 	rm -rf teleport
 	rm -rf *.gz
 	rm -rf *.zip
 	rm -f gitref.go
-	rm -rf `go env GOPATH`/pkg/`go env GOHOSTOS`_`go env GOARCH`/github.com/gravitational/teleport*
 
 #
 # make release - Produces a binary release tarball.

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,5 +1,5 @@
-# This Dockerfile makes the "build box": the container used to build
-# official releases of Teleport and its documentation
+# This Dockerfile makes the "build box": the container used to build official
+# releases of Teleport and its documentation.
 FROM quay.io/gravitational/buildbox-base:1.0
 
 ARG UID
@@ -11,17 +11,20 @@ COPY pam/teleport-session-failure /etc/pam.d
 COPY pam/teleport-success /etc/pam.d
 
 RUN apt-get install -q -y libpam-dev
+RUN apt-get install -q -y libc6-dev-i386
+RUN apt-get install -q -y net-tools
+RUN apt-get install -q -y tree
 
 RUN (groupadd jenkins --gid=$GID -o && useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
      mkdir -p /var/lib/teleport && chown -R jenkins /var/lib/teleport)
 
-# get etcd
+# Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
-     cp etcd-v3.3.9-linux-amd64/etcd* /bin/ ;\
-     apt-get install -y net-tools tree)
+     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
-# Install Golang:
-RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/go1.9.7.linux-amd64.tar.gz | tar xz;\
+# Install Go.
+ARG RUNTIME
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz;\
     mkdir -p /gopath/src/github.com/gravitational/teleport;\
     chmod a+w /gopath;\
     chmod a+w /var/lib;\

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -15,6 +15,10 @@ NOROOT=-u $$(id -u):$$(id -g)
 KUBECONFIG ?=
 TEST_KUBE ?=
 
+OS ?= linux
+ARCH ?= amd64
+RUNTIME ?= go1.11.1
+
 ifneq ("$(KUBECONFIG)","")
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(KUBECONFIG):/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=$(TEST_KUBE)
 endif
@@ -43,7 +47,11 @@ build-binaries: bbox
 #
 .PHONY:bbox
 bbox:
-	docker build --build-arg UID=$$(id -u) --build-arg GID=$$(id -g) --tag $(BBOX) .
+	docker build \
+		--build-arg UID=$$(id -u) \
+		--build-arg GID=$$(id -g) \
+		--build-arg RUNTIME=$(RUNTIME) \
+		--tag $(BBOX) .
 
 #
 # Builds a Docker container for building mkdocs documentation
@@ -127,12 +135,12 @@ enter: bbox
 		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BBOX) /bin/bash
 
 #
-# Create a teleport package using the build container
+# Create a Teleport package using the build container.
 #
 .PHONY:release
 release: bbox
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOX) \
-		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=linux
+		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME)
 
 #
 # Create a Windows Teleport package using the build container.


### PR DESCRIPTION
**Purpose**

Allow passing in the processor architecture as well as the Go runtime used to build Teleport releases.

**Implementation**

* Updated `Dockerfile` and `Makefile` to support passing in of the processor architecture as well as Go runtime and use theses values to setup the environment correctly (pull down the correct runtime) as well as pass these flags to Go to build for the appropriate architecture.

**Related Issues**

https://github.com/gravitational/teleport.e/pull/97