### PR TITLE
Update Cloudformation build scripts

### DIFF
--- a/assets/marketplace/Makefile
+++ b/assets/marketplace/Makefile
@@ -13,7 +13,7 @@ BUILD_AMI_NAME ?=
 AWS_REGION ?= us-west-2
 
 # Teleport version
-TELEPORT_VERSION ?= 2.6.1
+TELEPORT_VERSION ?= 3.0.1
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007

--- a/assets/marketplace/template.json
+++ b/assets/marketplace/template.json
@@ -18,7 +18,7 @@
     "source_ami_filter": {
         "filters": {
             "virtualization-type": "hvm",
-            "name": "amzn2-ami*-ebs",
+            "name": "amzn2-ami-hvm*-ebs",
             "root-device-type": "ebs"
         },
         "owners": ["137112412989", "591542846629", "801119661308",


### PR DESCRIPTION
Update source_ami_filter in Packer template to prevent use of the minimal image. Also update Teleport version in Makefile to 3.0.1