### PR TITLE
Pass site name along in fileTransferRequest.

### DIFF
--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -49,6 +49,7 @@ type fileTransferRequest struct {
 func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	query := r.URL.Query()
 	req := fileTransferRequest{
+		cluster:        p.ByName("site"),
 		login:          p.ByName("login"),
 		namespace:      p.ByName("namespace"),
 		server:         p.ByName("server"),


### PR DESCRIPTION
**Purpose**

Fix issue that didn't allow SCP to work with Trusted Clusters.

**Implementation**

* Pass the cluster name along in the `fileTransferRequest` so the Teleport Client can be constructed correctly.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2300