### PR TITLE
Added support for "tctl get connectors".

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -119,6 +119,9 @@ const (
 	// KindGithubConnector is Github OAuth2 connector resource
 	KindGithubConnector = "github"
 
+	// KindConnectors is a shortcut for all authentication connector types.
+	KindConnectors = "connectors"
+
 	// KindAuthPreference is the type of authentication for this cluster.
 	KindClusterAuthPreference = "cluster_auth_preference"
 
@@ -431,6 +434,8 @@ func ParseShortcut(in string) (string, error) {
 		return KindSAMLConnector, nil
 	case "github":
 		return KindGithubConnector, nil
+	case "connectors":
+		return KindConnectors, nil
 	case "user", "users":
 		return KindUser, nil
 	case "cert_authorities", "cas":

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -393,6 +393,83 @@ func (c *samlCollection) writeYAML(w io.Writer) error {
 	return trace.Wrap(err)
 }
 
+type connectorsCollection struct {
+	oidc   []services.OIDCConnector
+	saml   []services.SAMLConnector
+	github []services.GithubConnector
+}
+
+func (c *connectorsCollection) writeText(w io.Writer) error {
+	if len(c.oidc) > 0 {
+		_, err := io.WriteString(w, "\nOIDC:\n")
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		oc := &oidcCollection{connectors: c.oidc}
+		err = oc.writeText(w)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	if len(c.saml) > 0 {
+		_, err := io.WriteString(w, "\nSAML:\n")
+		sc := &samlCollection{connectors: c.saml}
+		err = sc.writeText(w)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	if len(c.github) > 0 {
+		_, err := io.WriteString(w, "\nGitHub:\n")
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		gc := &githubCollection{connectors: c.github}
+		err = gc.writeText(w)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+func (c *connectorsCollection) writeJSON(w io.Writer) error {
+	data, err := json.MarshalIndent(c.toMarshal(), "", "    ")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = w.Write(data)
+	return trace.Wrap(err)
+}
+
+func (c *connectorsCollection) toMarshal() interface{} {
+	var connectors []interface{}
+
+	for _, o := range c.oidc {
+		connectors = append(connectors, o)
+	}
+	for _, s := range c.saml {
+		connectors = append(connectors, s)
+	}
+	for _, g := range c.github {
+		connectors = append(connectors, g)
+	}
+
+	return connectors
+}
+
+func (c *connectorsCollection) writeYAML(w io.Writer) error {
+	data, err := yaml.Marshal(c.toMarshal())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = w.Write(data)
+	return trace.Wrap(err)
+}
+
 type trustedClusterCollection struct {
 	trustedClusters []services.TrustedCluster
 }


### PR DESCRIPTION
**Purpose**

Added support for `tctl get connectors`.

**Implementation**

Add support for a meta resource called `connectors` that fetches and returns all known connectors.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2246