### PR TITLE
Fixed the bug in the Web GUI (send too much size data)

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -161,6 +161,9 @@ type TerminalHandler struct {
 
 	// decoder is used to decode UTF-8 strings.
 	decoder *encoding.Decoder
+
+	// read buffer
+	buffer []byte
 }
 
 // Serve builds a connect to the remote node and then pumps back two types of
@@ -459,6 +462,15 @@ func (t *TerminalHandler) write(data []byte, ws *websocket.Conn) (n int, err err
 // Read unwraps the envelope and either fills out the passed in bytes or
 // performs an action on the connection (sending window-change request).
 func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error) {
+	if len(t.buffer) > 0 {
+		n := copy(out, t.buffer)
+		if n == len(t.buffer) {
+			t.buffer = []byte{}
+		} else {
+			t.buffer = t.buffer[n:]
+		}
+		return n, nil
+	}
 	var bytes []byte
 	err = websocket.Message.Receive(ws, &bytes)
 	if err != nil {
@@ -486,10 +498,8 @@ func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error
 
 	switch string(envelope.GetType()) {
 	case defaults.WebsocketRaw:
-		if len(out) < len(data) {
-			t.log.Warnf("websocket failed to receive everything: %d vs %d", len(out), len(data))
-		}
-		return copy(out, data), nil
+		t.buffer = data
+		return 0, nil
 	case defaults.WebsocketResize:
 		var e events.EventFields
 		err := json.Unmarshal(data, &e)

--- a/web/src/app/lib/term/tty.js
+++ b/web/src/app/lib/term/tty.js
@@ -64,21 +64,9 @@ class Tty extends EventEmitter {
   }
 
   send(data) {
-    // split string to char array for multibyte
-    const arr = data.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\uD800-\uDFFF]/g) || [];
-    for (let i=0; i < arr.length; ){
-      let sendData = ""
-      // utf-8 char is max 4byte
-      // 128/4=32, size of arr is max 2
-      // 30 + 2 = 32
-      while(sendData.length <= 30 && i < arr.length){
-        sendData += arr[i]
-        i++
-      }
-      var msg = this._proto.encodeRawMessage(sendData);
-      var bytearray = new Uint8Array(msg);
-      this.socket.send(bytearray.buffer);
-    }
+    var msg = this._proto.encodeRawMessage(data);
+    var bytearray = new Uint8Array(msg);
+    this.socket.send(bytearray.buffer);
   }
 
   requestResize(w, h){

--- a/web/src/app/lib/term/tty.js
+++ b/web/src/app/lib/term/tty.js
@@ -64,9 +64,21 @@ class Tty extends EventEmitter {
   }
 
   send(data) {
-    var msg = this._proto.encodeRawMessage(data);
-    var bytearray = new Uint8Array(msg);
-    this.socket.send(bytearray.buffer);
+    // split string to char array for multibyte
+    const arr = data.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\uD800-\uDFFF]/g) || [];
+    for (let i=0; i < arr.length; ){
+      let sendData = ""
+      // utf-8 char is max 4byte
+      // 128/4=32, size of arr is max 2
+      // 30 + 2 = 32
+      while(sendData.length <= 30 && i < arr.length){
+        sendData += arr[i]
+        i++
+      }
+      var msg = this._proto.encodeRawMessage(sendData);
+      var bytearray = new Uint8Array(msg);
+      this.socket.send(bytearray.buffer);
+    }
   }
 
   requestResize(w, h){


### PR DESCRIPTION
Fix #2313

If GUI sends more than 128byte,  the message `websocket failed to receive everything:` is displayed in the log.

Another fix:
https://github.com/paihu/teleport/commit/2247f51f69ab25907f86c3f1df37b2b02090526d