### PR TITLE
Support different ready states.

### DIFF
--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/ghodss/yaml"
+	"github.com/jonboulle/clockwork"
 )
 
 // Config structure is used to initialize _all_ services Teleporot can run.
@@ -161,6 +162,9 @@ type Config struct {
 
 	// CAPin is the SKPI hash of the CA used to verify the Auth Server.
 	CAPin string
+
+	// Clock is used to control time in tests.
+	Clock clockwork.Clock
 }
 
 // ApplyToken assigns a given token to all internal services but only if token

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package service
 
 import (
@@ -369,12 +385,16 @@ func (process *TeleportProcess) periodicSyncRotationState() error {
 		case <-t.C:
 			status, err := process.syncRotationState()
 			if err != nil {
+				process.BroadcastEvent(Event{Name: TeleportDegradedEvent, Payload: nil})
+
 				if trace.IsConnectionProblem(err) {
 					process.Warningf("Connection problem: sync rotation state: %v.", err)
 				} else {
 					process.Warningf("Failed to sync rotation state: %v.", err)
 				}
 			} else {
+				process.BroadcastEvent(Event{Name: TeleportOKEvent, Payload: nil})
+
 				if status.phaseChanged || status.needsReload {
 					process.Debugf("Sync rotation state detected cert authority reload phase update.")
 				}

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -16,14 +16,26 @@ limitations under the License.
 package service
 
 import (
+	"fmt"
+	"net/http"
 	"os"
+	"time"
 
+	"strconv"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+
+	"github.com/jonboulle/clockwork"
 	"gopkg.in/check.v1"
 )
 
 type ServiceTestSuite struct {
 }
 
+var _ = fmt.Printf
 var _ = check.Suite(&ServiceTestSuite{})
 
 func (s *ServiceTestSuite) SetUpSuite(c *check.C) {
@@ -45,4 +57,82 @@ func (s *ServiceTestSuite) TestSelfSignedHTTPS(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(fileExists(cfg.Proxy.TLSCert), check.Equals, true)
 	c.Assert(fileExists(cfg.Proxy.TLSKey), check.Equals, true)
+}
+
+func (s *ServiceTestSuite) TestMonitor(c *check.C) {
+	fakeClock := clockwork.NewFakeClock()
+
+	ports, err := utils.GetFreeTCPPorts(2)
+	c.Assert(err, check.IsNil)
+	authPort, err := strconv.Atoi(ports.Pop())
+	c.Assert(err, check.IsNil)
+	authAddr, err := utils.ParseHostPortAddr("127.0.0.1", authPort)
+	c.Assert(err, check.IsNil)
+	diagPort, err := strconv.Atoi(ports.Pop())
+	c.Assert(err, check.IsNil)
+	diagAddr, err := utils.ParseHostPortAddr("127.0.0.1", diagPort)
+	c.Assert(err, check.IsNil)
+
+	endpoint := fmt.Sprintf("http://%v/readyz", diagAddr.String())
+
+	cfg := MakeDefaultConfig()
+	cfg.Clock = fakeClock
+	cfg.DataDir = c.MkDir()
+	cfg.DiagnosticAddr = *diagAddr
+	cfg.AuthServers = []utils.NetAddr{*authAddr}
+	cfg.Auth.Enabled = true
+	cfg.Auth.StorageConfig.Params["path"] = c.MkDir()
+	cfg.Proxy.Enabled = false
+	cfg.SSH.Enabled = false
+
+	process, err := NewTeleport(cfg)
+	c.Assert(err, check.IsNil)
+
+	// Start Teleport and make sure the status is OK.
+	go process.Run()
+	err = waitForStatus(endpoint, http.StatusOK)
+	c.Assert(err, check.IsNil)
+
+	// Broadcast a degraded event and make sure Teleport reports it's in a
+	// degraded state.
+	process.BroadcastEvent(Event{Name: TeleportDegradedEvent, Payload: nil})
+	err = waitForStatus(endpoint, http.StatusServiceUnavailable)
+	c.Assert(err, check.IsNil)
+
+	// Broadcast a OK event, this should put Teleport into a recovering state.
+	process.BroadcastEvent(Event{Name: TeleportOKEvent, Payload: nil})
+	err = waitForStatus(endpoint, http.StatusBadRequest)
+	c.Assert(err, check.IsNil)
+
+	// Broadcast another OK event, Teleport should still be in recovering state
+	// because not enough time has passed.
+	process.BroadcastEvent(Event{Name: TeleportOKEvent, Payload: nil})
+	err = waitForStatus(endpoint, http.StatusBadRequest)
+	c.Assert(err, check.IsNil)
+
+	// Advance time past the recovery time and then send another OK event, this
+	// should put Teleport into a OK state.
+	fakeClock.Advance(defaults.ServerHeartbeatTTL*2 + 1)
+	process.BroadcastEvent(Event{Name: TeleportOKEvent, Payload: nil})
+	err = waitForStatus(endpoint, http.StatusOK)
+	c.Assert(err, check.IsNil)
+}
+
+func waitForStatus(diagAddr string, statusCode int) error {
+	tickCh := time.Tick(250 * time.Millisecond)
+	timeoutCh := time.After(5 * time.Second)
+	for {
+		select {
+		case <-tickCh:
+			resp, err := http.Get(diagAddr)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if resp.StatusCode == statusCode {
+				return nil
+			}
+		case <-timeoutCh:
+			return trace.BadParameter("timeout waiting for status %v", statusCode)
+		}
+	}
 }

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/gravitational/teleport/lib/defaults"
+)
+
+const (
+	// stateOK means Teleport is operating normally.
+	stateOK = 0
+
+	// stateRecovering means Teleport has begun recovering from a degraded state.
+	stateRecovering = 1
+
+	// stateDegraded means some kind of connection error has occured to put
+	// Teleport into a degraded state.
+	stateDegraded = 2
+)
+
+// processState tracks the state of the Teleport process.
+type processState struct {
+	process      *TeleportProcess
+	recoveryTime time.Time
+	currentState int64
+}
+
+// newProcessState returns a new FSM that tracks the state of the Teleport process.
+func newProcessState(process *TeleportProcess) *processState {
+	return &processState{
+		process:      process,
+		recoveryTime: process.Clock.Now(),
+		currentState: stateOK,
+	}
+}
+
+// Process updates the state of Teleport.
+func (f *processState) Process(event Event) {
+	switch event.Name {
+	// Ready event means Teleport has started successfully.
+	case TeleportReadyEvent:
+		atomic.StoreInt64(&f.currentState, stateOK)
+		f.process.Infof("Detected that service started and joined the cluster successfully.")
+	// If a degraded event was received, always change the state to degraded.
+	case TeleportDegradedEvent:
+		atomic.StoreInt64(&f.currentState, stateDegraded)
+		f.process.Infof("Detected Teleport is running in a degraded state.")
+	// If the current state is degraded, and a OK event has been
+	// received, change the state to recovering. If the current state is
+	// recovering and a OK events is received, if it's been longer
+	// than the recovery time (2 time the server heartbeat ttl), change
+	// state to OK.
+	case TeleportOKEvent:
+		switch atomic.LoadInt64(&f.currentState) {
+		case stateDegraded:
+			atomic.StoreInt64(&f.currentState, stateRecovering)
+			f.recoveryTime = f.process.Clock.Now()
+			f.process.Infof("Teleport is recovering from a degraded state.")
+		case stateRecovering:
+			if f.process.Clock.Now().Sub(f.recoveryTime) > defaults.ServerHeartbeatTTL*2 {
+				atomic.StoreInt64(&f.currentState, stateOK)
+				f.process.Infof("Teleport has recovered from a degraded state.")
+			}
+		}
+	}
+}
+
+// GetState returns the current state of the system.
+func (f *processState) GetState() int64 {
+	return atomic.LoadInt64(&f.currentState)
+}

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -322,7 +322,12 @@ func (s *LocalSupervisor) BroadcastEvent(event Event) {
 	}
 
 	s.events[event.Name] = event
-	log.WithFields(logrus.Fields{"event": event.String(), trace.Component: teleport.Component(teleport.ComponentProcess, s.id)}).Debugf("Broadcasting event.")
+
+	// Log all events other than recovered events to prevent the logs from
+	// being flooded.
+	if event.String() != TeleportOKEvent {
+		log.WithFields(logrus.Fields{"event": event.String(), trace.Component: teleport.Component(teleport.ComponentProcess, s.id)}).Debugf("Broadcasting event.")
+	}
 
 	go func() {
 		select {


### PR DESCRIPTION
**Purpose**

Provide a more accurate and rich response from the `/readyz` endpoint.

**Implementation**

Add support for `TeleportDegradedEvent` and `TeleportOKEvent`. A degraded event immediately puts Teleport into `stateDegraded`. When a `TeleportOKEvent` is received, Teleport goes into `stateRecovering`. If enough time has passed between `stateRecovering` events, Teleport goes into `stateOK`.

Teleport returns `503` in `stateDegraded`, `400` in `stateRecovering`, and `200` in `stateOK`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2276