### PR TITLE
Fix typo in admin guide for dynamo configuration

### DIFF
--- a/docs/3.0/admin-guide.md
+++ b/docs/3.0/admin-guide.md
@@ -248,7 +248,7 @@ teleport:
 
         # Array of locations where the audit log events will be stored. by
         # default they are stored in `/var/lib/teleport/log`
-        audit_events_uri: [file:///var/lib/teleport/log, dynamo://events_table_name]
+        audit_events_uri: [file:///var/lib/teleport/log, dynamodb://events_table_name]
 
         # Use this setting to configure teleport to store the recorded sessions in
         # an AWS S3 bucket. see "Using Amazon S3" chapter for more information.
@@ -1939,7 +1939,7 @@ teleport:
 
     # This setting configures Teleport to send the audit events in two places: in a DynamoDB table
     # and also keep a copy on a local filesystem.
-    audit_events_uri:  [file:///var/lib/teleport/audit/events, dynamo://table_name]
+    audit_events_uri:  [file:///var/lib/teleport/audit/events, dynamodb://table_name]
     # This setting configures Teleport to save the recorded sessions in an S3 bucket:
     audit_sessions_uri: s3://example.com/teleport.events
 ```


### PR DESCRIPTION
## what

Fix typo in admin guide on how to configure the `audit_events_uri` to use dynamodb

## why

The documentation incorrectly states the scheme for dynamodb should be `dynamo://`. This leads to an error when the auth service starts up. The correct value is `dynamodb://`

> error: unsupported scheme for audit_events_uri: \"dynamo\", currently supported schemes are \"dynamodb\" and \"file\", initialization failed