### PR TITLE
Set login in Teleport client when creating an non-interactive client

### DIFF
--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -78,7 +78,7 @@ func (k *Key) ClientTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-// CertUsername returns the name of the teleport user encoded in the certificate
+// CertUsername returns the name of the Teleport user encoded in the SSH certificate.
 func (k *Key) CertUsername() (string, error) {
 	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(k.Cert)
 	if err != nil {
@@ -89,6 +89,19 @@ func (k *Key) CertUsername() (string, error) {
 		return "", trace.BadParameter("expected SSH certificate, got public key")
 	}
 	return cert.KeyId, nil
+}
+
+// CertPrincipals returns the principals listed on the SSH certificate.
+func (k *Key) CertPrincipals() ([]string, error) {
+	publicKey, _, _, _, err := ssh.ParseAuthorizedKey(k.Cert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cert, ok := publicKey.(*ssh.Certificate)
+	if !ok {
+		return nil, trace.BadParameter("no certificate found")
+	}
+	return cert.ValidPrincipals, nil
 }
 
 // AsAgentKeys converts client.Key struct to a []*agent.AddedKey. All elements

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -380,13 +380,13 @@ func onLogin(cf *CLIConf) {
 		case cf.Proxy == "" && cf.SiteName == "":
 			printProfiles(profile, profiles)
 			return
-			// in case if parameters match, print current status
+		// in case if parameters match, print current status
 		case host(cf.Proxy) == host(profile.ProxyURL.Host) && cf.SiteName == profile.Cluster:
 			printProfiles(profile, profiles)
 			return
-			// proxy is unspecified or the same as the currently provided proxy,
-			// but cluster is specified, treat this as selecting a new cluster
-			// for the same proxy
+		// proxy is unspecified or the same as the currently provided proxy,
+		// but cluster is specified, treat this as selecting a new cluster
+		// for the same proxy
 		case (cf.Proxy == "" || host(cf.Proxy) == host(profile.ProxyURL.Host)) && cf.SiteName != "":
 			tc.SaveProfile("")
 			if err := kubeclient.UpdateKubeconfig(tc); err != nil {
@@ -394,7 +394,7 @@ func onLogin(cf *CLIConf) {
 			}
 			onStatus(cf)
 			return
-			// otherwise just passthrough to standard login
+		// otherwise just passthrough to standard login
 		default:
 		}
 	}
@@ -454,6 +454,19 @@ func setupNoninteractiveClient(tc *client.TeleportClient, key *client.Key) error
 		return trace.Wrap(err)
 	}
 	tc.Username = certUsername
+
+	// Extract and set the HostLogin to be the first principal. It doesn't
+	// matter what the value is, but some valid principal has to be set
+	// otherwise the certificate won't be validated.
+	certPrincipals, err := key.CertPrincipals()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if len(certPrincipals) == 0 {
+		return trace.BadParameter("no principals found")
+	}
+	tc.HostLogin = certPrincipals[0]
+
 	identityAuth, err := authFromIdentity(key)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
**Purpose**

During login, Teleport connects back to the proxy and fetches the list of Trusted Clusters. During this process the SSH certificate is validated. If the requested login is not in the list of valid principals of the certificate, the request is requested with the following message.

```
$ tsh --proxy=localhost --user=rjones --insecure login --out=rjones-cert --format=openssh
error: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
```

**Implementation**

To fix this, extract the principal from the certificate and set the login when making the request.