### PR TITLE
Use `nodename` in 

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -147,7 +147,7 @@ type serverCollection struct {
 }
 
 func (s *serverCollection) writeText(w io.Writer) error {
-	t := asciitable.MakeTable([]string{"Hostname", "UUID", "Address", "Labels"})
+	t := asciitable.MakeTable([]string{"Nodename", "UUID", "Address", "Labels"})
 	for _, s := range s.servers {
 		t.AddRow([]string{
 			s.GetHostname(), s.GetName(), s.GetAddr(), s.LabelsString(),


### PR DESCRIPTION
Not a big thing, but this cause some confusion for me before I understood what was wrong.

Thought I'd let you know. Great tool btw! 🏅 

Current output:

```sh
$ tctl nodes ls

Hostname   UUID                                 Address        Labels                                     
---------- ------------------------------------ -------------- -------------------
my-node-name-1 554af099-14b9-4054-9225-ddf7a38e3d7a 127.0.0.1:3022 dc=loc,role=web 
```

Suggested output:
```sh
$ tctl nodes ls

Nodename   UUID                                 Address        Labels                                     
---------- ------------------------------------ -------------- -------------------
my-node-name-1 554af099-14b9-4054-9225-ddf7a38e3d7a 127.0.0.1:3022 dc=loc,role=web 
```
