### PR TITLE
Add support for configurable keep-alives

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package teleport
 
 import (
@@ -151,6 +167,10 @@ const (
 
 	// ComponentRBAC is role-based access control.
 	ComponentRBAC = "rbac"
+
+	// ComponentKeepAlive is keep-alive messages sent from clients to servers
+	// and vice versa.
+	ComponentKeepAlive = "keepalive"
 
 	// DebugEnvVar tells tests to use verbose debug output
 	DebugEnvVar = "DEBUG"

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -475,8 +475,12 @@ func (c *NodeClient) handleGlobalRequests(ctx context.Context, requestCh <-chan 
 					continue
 				}
 			default:
-				// This handles keepalive messages and matches the behaviour of OpenSSH.
-				r.Reply(false, nil)
+				// This handles keep-alive messages and matches the behaviour of OpenSSH.
+				err := r.Reply(false, nil)
+				if err != nil {
+					log.Warnf("Unable to reply to %v request.", r.Type)
+					continue
+				}
 			}
 		case <-ctx.Done():
 			return

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -414,13 +414,15 @@ func applyAuthConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 	auditConfig.Type = fc.Storage.Type
 
-	// build cluster config from session recording and host key checking preferences
+	// Set cluster-wide configuration from file configuration.
 	cfg.Auth.ClusterConfig, err = services.NewClusterConfig(services.ClusterConfigSpecV3{
 		SessionRecording:      fc.Auth.SessionRecording,
 		ProxyChecksHostKeys:   fc.Auth.ProxyChecksHostKeys,
 		Audit:                 *auditConfig,
 		ClientIdleTimeout:     fc.Auth.ClientIdleTimeout,
 		DisconnectExpiredCert: fc.Auth.DisconnectExpiredCert,
+		KeepAliveInterval:     fc.Auth.KeepAliveInterval,
+		KeepAliveCountMax:     fc.Auth.KeepAliveCountMax,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -147,6 +147,8 @@ var (
 		"disconnect_expired_cert": false,
 		"ciphersuites":            false,
 		"ca_pin":                  false,
+		"keep_alive_interval":     false,
+		"keep_alive_count_max":    false,
 	}
 )
 
@@ -548,6 +550,14 @@ type Auth struct {
 	// if specified, teleport will use API server address and
 	// trusted certificate authority information from it
 	KubeconfigFile string `yaml:"kubeconfig_file,omitempty"`
+
+	// KeepAliveInterval set the keep-alive interval for server to client
+	// connections.
+	KeepAliveInterval services.Duration `yaml:"keep_alive_interval,omitempty"`
+
+	// KeepAliveCountMax set the number of keep-alive messages that can be
+	// missed before the server disconnects the client.
+	KeepAliveCountMax int `yaml:"keep_alive_count_max"`
 }
 
 // TrustedCluster struct holds configuration values under "trusted_clusters" key

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -271,6 +271,16 @@ var (
 
 	// LowResPollingPeriod is a default low resolution polling period
 	LowResPollingPeriod = 90 * time.Second
+
+	// KeepAliveInterval is interval at which Teleport will send keep-alive
+	// messages to the client. The interval of 15 minutes mirrors
+	// ClientAliveInterval of sshd.
+	KeepAliveInterval = 15 * time.Minute
+
+	// KeepAliveCountMax is the number of keep-alive messages that can be sent
+	// without receiving a response from the client before the client is
+	// disconnected. The max count mirrors ClientAliveCountMax of sshd.
+	KeepAliveCountMax = 3
 )
 
 // Default connection limits, they can be applied separately on any of the Teleport

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -308,9 +308,9 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 	// update ctx with a session ID
 	c.session, _ = findSession()
 	if c.session == nil {
-		log.Debugf("[SSH] will create new session for SSH connection %v", c.Conn.RemoteAddr())
+		log.Debugf("Will create new session for SSH connection %v.", c.Conn.RemoteAddr())
 	} else {
-		log.Debugf("[SSH] will join session %v for SSH connection %v", c.session, c.Conn.RemoteAddr())
+		log.Debugf("Will join session %v for SSH connection %v.", c.session, c.Conn.RemoteAddr())
 	}
 
 	return nil

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net"
 	"sync"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
@@ -367,6 +366,12 @@ func (s *Server) Serve() {
 	config.KeyExchanges = s.kexAlgorithms
 	config.MACs = s.macAlgorithms
 
+	clusterConfig, err := s.GetAccessPoint().GetClusterConfig()
+	if err != nil {
+		s.log.Errorf("Unable to fetch cluster config: %v.", err)
+		return
+	}
+
 	s.log.Debugf("Supported ciphers: %q.", s.ciphers)
 	s.log.Debugf("Supported KEX algorithms: %q.", s.kexAlgorithms)
 	s.log.Debugf("Supported MAC algorithms: %q.", s.macAlgorithms)
@@ -411,9 +416,19 @@ func (s *Server) Serve() {
 	}
 
 	// The keep-alive loop will keep pinging the remote server and after it has
-	// missed a certain number of keep alive requests it will cancel the
+	// missed a certain number of keep-alive requests it will cancel the
 	// closeContext which signals the server to shutdown.
-	go s.keepAliveLoop()
+	go srv.StartKeepAliveLoop(srv.KeepAliveParams{
+		Conns: []srv.RequestSender{
+			s.sconn,
+			s.remoteClient,
+		},
+		Interval:     clusterConfig.GetKeepAliveInterval(),
+		MaxCount:     clusterConfig.GetKeepAliveCountMax(),
+		CloseContext: s.closeContext,
+		CloseCancel:  s.closeCancel,
+	})
+
 	go s.handleConnection(chans, reqs)
 }
 
@@ -501,39 +516,6 @@ func (s *Server) handleConnection(chans <-chan ssh.NewChannel, reqs <-chan *ssh.
 			go s.handleChannel(newChannel)
 		// If the server is closing (either the heartbeat failed or Close() was
 		// called, exit out of the connection handler loop.
-		case <-s.closeContext.Done():
-			return
-		}
-	}
-}
-
-func (s *Server) keepAliveLoop() {
-	var missed int
-
-	// Tick at 1/3 of the idle timeout duration.
-	tickerCh := time.NewTicker(defaults.DefaultIdleConnectionDuration / 3)
-	defer tickerCh.Stop()
-
-	for {
-		select {
-		case <-tickerCh.C:
-			// Send a keep alive to the target node and the client to ensure both are alive.
-			proxyToNodeOk := s.sendKeepAliveWithTimeout(s.remoteClient, defaults.ReadHeadersTimeout)
-			proxyToClientOk := s.sendKeepAliveWithTimeout(s.sconn, defaults.ReadHeadersTimeout)
-			if proxyToNodeOk && proxyToClientOk {
-				missed = 0
-				continue
-			}
-
-			// If 3 keep alives are missed, the connection is dead, call cancel and cleanup.
-			missed += 1
-			if missed == 3 {
-				s.log.Infof("Missed %v keep alive messages, closing connection.", missed)
-				s.closeCancel()
-				return
-			}
-		// If Close() was called on the server (connection is done) then no more
-		// need to wait for keep alives.
 		case <-s.closeContext.Done():
 			return
 		}
@@ -833,35 +815,6 @@ func (s *Server) handleEnv(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerCont
 	}
 
 	return nil
-}
-
-// RequestSender is an interface that impliments SendRequest. It is used so
-// server and client connections can be passed to functions to send requests.
-type RequestSender interface {
-	// SendRequest is used to send a out-of-band request.
-	SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error)
-}
-
-// sendKeepAliveWithTimeout sends a keepalive@openssh.com message to the remote
-// client. A manual timeout is needed here because SendRequest will wait for a
-// response forever.
-func (s *Server) sendKeepAliveWithTimeout(conn RequestSender, timeout time.Duration) bool {
-	errorCh := make(chan error, 1)
-
-	go func() {
-		_, _, err := conn.SendRequest(teleport.KeepAliveReqType, true, nil)
-		errorCh <- err
-	}()
-
-	select {
-	case err := <-errorCh:
-		if err != nil {
-			return false
-		}
-		return true
-	case <-time.After(timeout):
-		return false
-	}
 }
 
 func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {

--- a/lib/srv/keepalive.go
+++ b/lib/srv/keepalive.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srv
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/defaults"
+
+	"github.com/gravitational/trace"
+
+	"github.com/sirupsen/logrus"
+)
+
+// RequestSender is an interface that impliments SendRequest. It is used so
+// server and client connections can be passed to functions to send requests.
+type RequestSender interface {
+	// SendRequest is used to send a out-of-band request.
+	SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error)
+}
+
+// KeepAliveParams configures the keep-alive loop.
+type KeepAliveParams struct {
+	// Conns is the list of connections to send keep-alive connections to. All
+	// connections must respond to the keep-alive to not be considered missed.
+	Conns []RequestSender
+
+	// Interval is the interval to send keep-alive messsages at.
+	Interval time.Duration
+
+	// MaxCount is the number of keep-alive messages that can be missed before
+	// the connection is disconnected.
+	MaxCount int
+
+	// CloseContext is used by the server to notify the keep-alive loop to stop.
+	CloseContext context.Context
+
+	// CloseCancel is used by the keep-alive loop to notify the server to stop.
+	CloseCancel context.CancelFunc
+}
+
+// StartKeepAliveLoop starts the keep-alive loop.
+func StartKeepAliveLoop(p KeepAliveParams) {
+	var missedCount int
+
+	log := logrus.WithFields(logrus.Fields{
+		trace.Component: teleport.ComponentKeepAlive,
+	})
+	log.Debugf("Starting keep-alive loop with with interval %v and max count %v.", p.Interval, p.MaxCount)
+
+	tickerCh := time.NewTicker(p.Interval)
+	defer tickerCh.Stop()
+
+	for {
+		select {
+		case <-tickerCh.C:
+			var sentCount int
+
+			// Send a keep alive message on all connections and make sure a response
+			// was received on all.
+			for _, conn := range p.Conns {
+				ok := sendKeepAliveWithTimeout(conn, defaults.ReadHeadersTimeout, p.CloseContext)
+				if ok {
+					sentCount += 1
+				}
+			}
+			if sentCount == len(p.Conns) {
+				missedCount = 0
+				continue
+			}
+
+			// If enough keep-alives are missed, the connection is dead, call cancel
+			// and notify the server to disconnect and cleanup.
+			missedCount = missedCount + 1
+			if missedCount > p.MaxCount {
+				log.Infof("Missed %v keep-alive messages, closing connection.", missedCount)
+				p.CloseCancel()
+				return
+			}
+		// If an external caller closed the context (connection is done) then no
+		// more need to wait around for keep-alives.
+		case <-p.CloseContext.Done():
+			return
+		}
+	}
+}
+
+// sendKeepAliveWithTimeout sends a keepalive@openssh.com message to the remote
+// client. A manual timeout is needed here because SendRequest will wait for a
+// response forever.
+func sendKeepAliveWithTimeout(conn RequestSender, timeout time.Duration, closeContext context.Context) bool {
+	errorCh := make(chan error, 1)
+
+	go func() {
+		// SendRequest will unblock when connection or channel is closed.
+		_, _, err := conn.SendRequest(teleport.KeepAliveReqType, true, nil)
+		errorCh <- err
+	}()
+
+	select {
+	case err := <-errorCh:
+		if err != nil {
+			return false
+		}
+		return true
+	case <-time.After(timeout):
+		return false
+	case <-closeContext.Done():
+		return false
+	}
+}

--- a/lib/srv/keepalive_test.go
+++ b/lib/srv/keepalive_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srv
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+
+	"gopkg.in/check.v1"
+)
+
+type KeepAliveSuite struct{}
+
+var _ = fmt.Printf
+var _ = check.Suite(&KeepAliveSuite{})
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+func (s *KeepAliveSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
+}
+func (s *KeepAliveSuite) TearDownSuite(c *check.C) {}
+func (s *KeepAliveSuite) SetUpTest(c *check.C)     {}
+func (s *KeepAliveSuite) TearDownTest(c *check.C)  {}
+
+func (s *KeepAliveSuite) TestServerClose(c *check.C) {
+	doneCh := make(chan bool, 1)
+	closeContext, closeCancel := context.WithCancel(context.Background())
+
+	// Create a request sender that always replies to keep-alive requests.
+	requestSender := &testRequestSender{
+		reply: true,
+	}
+
+	go func() {
+		StartKeepAliveLoop(KeepAliveParams{
+			Conns: []RequestSender{
+				requestSender,
+			},
+			Interval:     10 * time.Millisecond,
+			MaxCount:     2,
+			CloseContext: closeContext,
+			CloseCancel:  closeCancel,
+		})
+		doneCh <- true
+	}()
+
+	// Wait for a keep-alive to be sent.
+	err := waitForRequests(requestSender, 1)
+	c.Assert(err, check.IsNil)
+
+	// Close the context (server), should cause the loop to stop as well.
+	closeCancel()
+
+	// Wait 1 second for the keep-alive loop to stop, or return an error.
+	select {
+	case <-time.After(1 * time.Second):
+		c.Fatalf("Timeout waiting for keep-alive loop to stop.")
+	case <-doneCh:
+	}
+}
+
+func (s *KeepAliveSuite) TestLoopClose(c *check.C) {
+	doneCh := make(chan bool, 1)
+	closeContext, closeCancel := context.WithCancel(context.Background())
+
+	// Create a request sender that never replies to keep-alive requests.
+	requestSender := &testRequestSender{
+		reply: false,
+	}
+
+	go func() {
+		StartKeepAliveLoop(KeepAliveParams{
+			Conns: []RequestSender{
+				requestSender,
+			},
+			Interval:     10 * time.Millisecond,
+			MaxCount:     2,
+			CloseContext: closeContext,
+			CloseCancel:  closeCancel,
+		})
+		doneCh <- true
+	}()
+
+	// Wait for a keep-alive to be sent.
+	err := waitForRequests(requestSender, 1)
+	c.Assert(err, check.IsNil)
+
+	// Wait 1 second for the keep-alive loop to stop, or return an error.
+	select {
+	case <-time.After(1 * time.Second):
+		c.Fatalf("Timeout waiting for keep-alive loop to stop.")
+	case <-doneCh:
+	}
+}
+
+func waitForRequests(requestSender *testRequestSender, count int) error {
+	tickerCh := time.NewTicker(50 * time.Millisecond)
+	defer tickerCh.Stop()
+	timeoutCh := time.NewTimer(1 * time.Second)
+	defer timeoutCh.Stop()
+
+	for {
+		select {
+		case <-tickerCh.C:
+			if requestSender.Count() > count {
+				return nil
+			}
+		case <-timeoutCh.C:
+			return trace.BadParameter("timeout waiting for requests")
+		}
+	}
+}
+
+type testRequestSender struct {
+	reply bool
+	count int64
+}
+
+func (n *testRequestSender) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	atomic.AddInt64(&n.count, 1)
+	if n.reply == false {
+		return false, nil, trace.BadParameter("no reply")
+	}
+	return false, nil, nil
+}
+
+func (n *testRequestSender) Count() int {
+	return int(atomic.LoadInt64(&n.count))
+
+}

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -38,13 +38,13 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // proxySubsys implements an SSH subsystem for proxying listening sockets from
 // remote hosts to a proxy client (AKA port mapping)
 type proxySubsys struct {
-	log          *log.Entry
+	log          *logrus.Entry
 	srv          *Server
 	host         string
 	port         string
@@ -117,7 +117,7 @@ func parseProxySubsys(request string, srv *Server, ctx *srv.ServerContext) (*pro
 	}
 
 	return &proxySubsys{
-		log: log.WithFields(log.Fields{
+		log: logrus.WithFields(logrus.Fields{
 			trace.Component:       teleport.ComponentSubsystemProxy,
 			trace.ComponentFields: map[string]string{},
 		}),
@@ -141,7 +141,7 @@ func (t *proxySubsys) String() string {
 // a mapping connection between a client & remote node we're proxying to)
 func (t *proxySubsys) Start(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
 	// once we start the connection, update logger to include component fields
-	t.log = log.WithFields(log.Fields{
+	t.log = logrus.WithFields(logrus.Fields{
 		trace.Component: teleport.ComponentSubsystemProxy,
 		trace.ComponentFields: map[string]string{
 			"src": sconn.RemoteAddr().String(),

--- a/lib/srv/regular/sites.go
+++ b/lib/srv/regular/sites.go
@@ -19,12 +19,12 @@ package regular
 import (
 	"encoding/json"
 
+	"golang.org/x/crypto/ssh"
+
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
 )
 
 // proxySubsys is an SSH subsystem for easy proxyneling through proxy server

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -31,6 +31,9 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/backend"
@@ -45,9 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
+
 	. "gopkg.in/check.v1"
 )
 

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -12,12 +12,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-This file contains the implementations of sshutils.Server class.
-It is the underlying "base SSH server" for everything in Teleport.
-
 */
 
+// Package sshutils contains contains the implementations of the base SSH
+// server used throughout Teleport.
 package sshutils
 
 import (


### PR DESCRIPTION
**Purpose**

Allow configurable keep-alives to be sent from Teleport servers to clients. This is to prevent firewalls, load balancers, and VPNs from tearing down idle SSH session.

**Implementation**

* Added `keep_alive_interval` to Teleport configuration. This sets the interval at which Teleport will send keep-alive messages. The default value mirrors `sshd` at 15 minutes.
* Added  `keep_alive_count_max`, the number of messed keep-alive messages before the server tears down the connection to the client. The default value mirrors `sshd` at 3.
* Both the regular and forwarding server now both use the same keep-alive code.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2334