### PR TITLE
fix(systemd.kill): fix all child processes are killed when the teleport is restarted

### DIFF
--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
+KillMode=process
 ExecStart=/usr/local/bin/teleport start --pid-file=/var/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/var/run/teleport.pid


### PR DESCRIPTION
fix all child processes are killed when the teleport is restarted

refs gravitational/teleport#2355

Signed-off-by: mritd <mritd1234@gmail.com>