### PR TITLE
Fix IPv6 issues.

### DIFF
--- a/docs/3.0/admin-guide.md
+++ b/docs/3.0/admin-guide.md
@@ -219,7 +219,8 @@ teleport:
     # When running in multi-homed or NATed environments Teleport nodes need
     # to know which IP it will be reachable at by other nodes
     #
-    # This value can be specified as FQDN e.g. host.example.com
+    # This value can be specified as FQDN e.g. host.example.com. IPv6 addresses
+    # should be specified without brackets.
     advertise_ip: 10.1.0.5
 
     # list of auth servers in a cluster. you will have more than one auth server

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -781,7 +781,7 @@ func (tc *TeleportClient) LocalAgent() *LocalKeyAgent {
 }
 
 // getTargetNodes returns a list of node addresses this SSH command needs to
-// operate on.
+// operate on. If no nodes match, the host:port is returned precent encoded.
 func (tc *TeleportClient) getTargetNodes(ctx context.Context, proxy *ProxyClient) ([]string, error) {
 	var (
 		err    error
@@ -798,7 +798,12 @@ func (tc *TeleportClient) getTargetNodes(ctx context.Context, proxy *ProxyClient
 		}
 	}
 	if len(nodes) == 0 {
-		retval = append(retval, net.JoinHostPort(tc.Host, strconv.Itoa(tc.HostPort)))
+		// Precent code the host:port. This is done so the returned address can be
+		// passed to url.Parse where the host:port is placed within the userinfo
+		// part of the URL which only allows alpha numberic plus some punctuation.
+		// See the following for details: https://github.com/golang/go/issues/23392.
+		escaped := url.QueryEscape(net.JoinHostPort(tc.Host, strconv.Itoa(tc.HostPort)))
+		retval = append(retval, escaped)
 	}
 	return retval, nil
 }


### PR DESCRIPTION
**Purpose**

Allow Teleport to set a IPv6 advertise address and allow `tsh` to connect to IPv6 nodes.

**Implementation**

* Encode `host:port` to allow it to pass userinfo validation.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2124