### PR TITLE
Only update kubeconfig if the proxy supports Kubernetes.

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -424,9 +424,11 @@ func onLogin(cf *CLIConf) {
 		return
 	}
 
-	// Update kubernetes config file.
-	if err := kubeclient.UpdateKubeconfig(tc); err != nil {
-		utils.FatalError(err)
+	// If the proxy is advertising that it supports Kubernetes, update kubeconfig.
+	if tc.KubeProxyAddr != "" {
+		if err := kubeclient.UpdateKubeconfig(tc); err != nil {
+			utils.FatalError(err)
+		}
 	}
 
 	// Regular login without -i flag.


### PR DESCRIPTION
**Purpose**

Don't update `kubeconfig` if Teleport is not running as a Kubernetes proxy.

**Implementation**

* Upon login, the Teleport client is updated with the address the Kubernetes proxy can be reached at. If this value is not set, don't update `kubeconfig`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2304