### PR TITLE
Remove Teleport related entries from kubeconfig upon "tsh logout".

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -172,6 +172,9 @@ const (
 	// and vice versa.
 	ComponentKeepAlive = "keepalive"
 
+	// ComponentTSH is the "tsh" binary.
+	ComponentTSH = "tsh"
+
 	// DebugEnvVar tells tests to use verbose debug output
 	DebugEnvVar = "DEBUG"
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -354,7 +354,7 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 		ValidUntil: validUntil,
 		Extensions: extensions,
 		Roles:      roles,
-		Cluster:    profile.SiteName,
+		Cluster:    profile.Name(),
 	}, nil
 }
 

--- a/tool/tsh/help.go
+++ b/tool/tsh/help.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 const (
@@ -7,8 +23,8 @@ const (
 
 EXAMPLES:
   Use ports 8080 and 8023 for https and SSH proxy:
-  $ tsh --proxy=host.example.com:8080,8023 login    
-  
+  $ tsh --proxy=host.example.com:8080,8023 login
+
   Use port 8080 and 3023 (default) for SSH proxy:
   $ tsh --proxy=host.example.com:8080 login
 


### PR DESCRIPTION
**Purpose**

Upon `tsh logout` also remove Teleport related entries in `kubeconfig`.

**Implementation**

* If logging out from a particular cluster, remove just the Teleport related entries for that cluster from `kubeconfig`.
* If logging out of all clusters, remove all Teleport related entries from `kubeconfig`.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2258