### PR TITLE
Check for the advertised minimum version for clients.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -365,6 +365,9 @@ const DefaultImplicitRole = "default-implicit-role"
 // APIDomain is a default domain name for Auth server API
 const APIDomain = "teleport.cluster.local"
 
+// MinClientVersion is the minimum client version required by the server.
+const MinClientVersion = "3.0.0"
+
 const (
 	// RemoteClusterStatusOffline indicates that cluster is considered as
 	// offline, since it has missed a series of heartbeats

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1461,8 +1461,9 @@ func (tc *TeleportClient) Login(ctx context.Context, activateKey bool) (*Key, er
 		return nil, trace.Wrap(err)
 	}
 
-	if tc.CheckVersions {
-		if err := utils.CheckVersions(teleport.Version, pr.ServerVersion); err != nil {
+	// If version checking was requested and the server advertises a minimum version.
+	if tc.CheckVersions && pr.MinClientVersion != "" {
+		if err := utils.CheckVersions(teleport.Version, pr.MinClientVersion); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -286,8 +286,8 @@ func SSHAgentSSOLogin(ctx context.Context, proxyAddr, connectorID string, pubKey
 	}
 }
 
-// PingResponse contains data about the Teleport server like supported authentication
-// types, server version, etc.
+// PingResponse contains data about the Teleport server like supported
+// authentication types, server version, etc.
 type PingResponse struct {
 	// Auth contains the forms of authentication the auth server supports.
 	Auth AuthenticationSettings `json:"auth"`
@@ -295,6 +295,8 @@ type PingResponse struct {
 	Proxy ProxySettings `json:"proxy"`
 	// ServerVersion is the version of Teleport that is running.
 	ServerVersion string `json:"server_version"`
+	// MinClientVersion is the minimum client version required by the server.
+	MinClientVersion string `json:"min_client_version"`
 }
 
 // ProxySettings contains basic information about proxy settings

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -101,23 +101,20 @@ func (s *UtilsSuite) TestMiscFunctions(c *check.C) {
 // TestVersions tests versions compatibility checking
 func (s *UtilsSuite) TestVersions(c *check.C) {
 	testCases := []struct {
-		info   string
-		client string
-		server string
-		err    error
+		info      string
+		client    string
+		minClient string
+		err       error
 	}{
-		{info: "same versions are ok", client: "1.0.0", server: "1.0.0"},
-		{info: "minor diff is ok if server is newer", client: "1.0.0", server: "1.1.0"},
-		{info: "minor diff is ok if server is newer even after one version", client: "1.0.0", server: "1.3.0"},
-		{info: "minor diff is not ok if server is older", client: "1.1.0", server: "1.0.0", err: trace.BadParameter("")},
-		{info: "major diff is not ok", client: "5.1.0", server: "1.0.0", err: trace.BadParameter("")},
-		{info: "major diff is not ok", client: "1.1.0", server: "5.0.0", err: trace.BadParameter("")},
-		{info: "minor diff is ok if server is newer", client: "1.0.0-beta.1", server: "1.1.0-alpha.1"},
-		{info: "older pre-release client is ok", client: "1.0.0-beta.1", server: "1.0.0-beta.12"},
+		{info: "client older than min version", client: "1.0.0", minClient: "1.1.0", err: trace.BadParameter("")},
+		{info: "client same as min version", client: "1.0.0", minClient: "1.0.0"},
+		{info: "client newer than min version", client: "1.1.0", minClient: "1.0.0"},
+		{info: "pre-releases clients are ok", client: "1.1.0-alpha.1", minClient: "1.0.0"},
+		{info: "older pre-releases are no ok", client: "1.1.0-alpha.1", minClient: "1.1.0", err: trace.BadParameter("")},
 	}
 	for i, testCase := range testCases {
 		comment := check.Commentf("test case %v %q", i, testCase.info)
-		err := CheckVersions(testCase.client, testCase.server)
+		err := CheckVersions(testCase.client, testCase.minClient)
 		if testCase.err == nil {
 			c.Assert(err, check.IsNil, comment)
 		} else {

--- a/lib/utils/ver.go
+++ b/lib/utils/ver.go
@@ -17,35 +17,34 @@ limitations under the License.
 package utils
 
 import (
-	"github.com/coreos/go-semver/semver"
+	"fmt"
 
 	"github.com/gravitational/trace"
+
+	"github.com/coreos/go-semver/semver"
 )
 
-// CheckVersions compares client and server versions
-// and makes sure they are compatible using Teleport convention
-func CheckVersions(clientVersion, serverVersion string) error {
+// CheckVersions compares client and server versions and makes sure that the
+// client version is greater than or equal to the minimum version supported
+// by the server.
+func CheckVersions(clientVersion string, minClientVersion string) error {
 	clientSemver, err := semver.NewVersion(clientVersion)
 	if err != nil {
 		return trace.Wrap(err,
 			"unsupported version format, need semver format: %q, e.g 1.0.0", clientVersion)
 	}
 
-	serverSemver, err := semver.NewVersion(serverVersion)
+	minClientSemver, err := semver.NewVersion(minClientVersion)
 	if err != nil {
 		return trace.Wrap(err,
-			"unsupported version format, need semver format: %q, e.g 1.0.0", clientVersion)
+			"unsupported version format, need semver format: %q, e.g 1.0.0", minClientVersion)
 	}
 
-	// for now only do simple check that client is not newer version
-	// than server, ignore patch versions
-
-	switch {
-	case serverSemver.Major != clientSemver.Major:
-		return trace.BadParameter("client version %q is not compatible server version %q, please make client and server versions use the same major versions", clientVersion, serverVersion)
-	case serverSemver.Minor < clientSemver.Minor:
-		return trace.BadParameter("client version %q is newer than server version %q, please downgrade client or upgrade server", clientVersion, serverVersion)
-		// for now let's not enforce minor versions diff as it's too harsh
+	if clientSemver.Compare(*minClientSemver) < 0 {
+		errorMessage := fmt.Sprintf("minimum client version supported by the server "+
+			"is %v. Please upgrade the client, downgrade the server, or use the "+
+			"--skip-version-check flag to by-pass this check.", minClientVersion)
+		return trace.BadParameter(errorMessage)
 	}
 
 	return nil

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -176,7 +176,7 @@ func Run(args []string, underTest bool) {
 	app.Flag("namespace", "Namespace of the cluster").Default(defaults.Namespace).Hidden().StringVar(&cf.Namespace)
 	app.Flag("gops", "Start gops endpoint on a given address").Hidden().BoolVar(&cf.Gops)
 	app.Flag("gops-addr", "Specify gops addr to listen on").Hidden().StringVar(&cf.GopsAddr)
-	app.Flag("skip-version-check", "Skip version checking between server and client.").Hidden().BoolVar(&cf.SkipVersionCheck)
+	app.Flag("skip-version-check", "Skip version checking between server and client.").BoolVar(&cf.SkipVersionCheck)
 	debugMode := app.Flag("debug", "Verbose logging to stdout").Short('d').Bool()
 	app.HelpFlag.Short('h')
 	ver := app.Command("version", "Print the version")


### PR DESCRIPTION
Backport counterpart for https://github.com/gravitational/teleport/pull/2352.