### PR TITLE
Split kubeconfig path after extracting from environment.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -175,6 +175,9 @@ const (
 	// ComponentTSH is the "tsh" binary.
 	ComponentTSH = "tsh"
 
+	// ComponentKubeClient is the Kubernetes client.
+	ComponentKubeClient = "client:kube"
+
 	// DebugEnvVar tells tests to use verbose debug output
 	DebugEnvVar = "DEBUG"
 


### PR DESCRIPTION
**Purpose**

When saving and loading `kubeconfig`, if an environment variable is provided, pick `kubeconfig` from the first file in the list.

**Implementation**

When saving and loading `kubeconfig`, if an environment variable is provided, pick `kubeconfig` from the first file in the list.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2291