### PR TITLE
fix docker dev env docs and image build problem

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ FROM teleport-buildbox:latest
 ENV DEBUG=1 GOPATH=/root/go PATH=$PATH:/root/go/src/github.com/gravitational/teleport/build:/root/go/bin
 
 # htop is useful for testing terminal resizing
-RUN apt-get install -y htop vim screen; \
+RUN apt-get update; apt-get install -y htop vim screen; \
     mkdir -p /root/go/src/github.com/gravitational/teleport 
 
 # allows ansible and ssh testing

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,9 +6,9 @@ for testing & development purposes.
 ### Building 
 
 First, you need to build `teleport:latest` Docker image. This image is built
-automatically when you type `make` BUT...
+when you type `make build` BUT...
 
-But you have to build the base image first, by running `make -C build.assets`
+But you have to build the base image first, by running `make docker`
 from `$GOPATH/github.com/gravitational/teleport` (repository base dir).
 
 ### Starting 


### PR DESCRIPTION
- docs were out of sync with makefile, mainly the teleport:latest wasn't automatically built with `make all`
- fixed package not found issue mentioned in #2275 and #2274