### PR TITLE
fix error message and refactor terminal size types

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -377,8 +377,8 @@ func (f *Forwarder) exec(ctx *authContext, w http.ResponseWriter, req *http.Requ
 		defer recorder.Close()
 		request.onResize = func(resize remotecommand.TerminalSize) {
 			params := session.TerminalParams{
-				W: int(resize.Width),
-				H: int(resize.Height),
+				W: uint32(resize.Width),
+				H: uint32(resize.Height),
 			}
 			// Build the resize event.
 			resizeEvent := events.EventFields{

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -445,8 +445,10 @@ func newSession(id rsession.ID, r *SessionRegistry, ctx *ServerContext) (*sessio
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		rsess.TerminalParams.W = int(winsize.Width)
-		rsess.TerminalParams.H = int(winsize.Height)
+
+		// ssh.Unmarshal does not support uint16
+		rsess.TerminalParams.W = uint32(winsize.Width)
+		rsess.TerminalParams.H = uint32(winsize.Height)
 	}
 
 	// get the session server where session information lives. if the recording

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -369,7 +369,7 @@ func (t *remoteTerminal) Run() error {
 		t.termType = defaultTerm
 	}
 
-	if err := t.session.RequestPty(t.termType, t.params.H, t.params.W, t.termModes); err != nil {
+	if err := t.session.RequestPty(t.termType, int(t.params.H), int(t.params.W), t.termModes); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -487,7 +487,7 @@ func (t *remoteTerminal) SetTerminalModes(termModes ssh.TerminalModes) {
 	t.termModes = termModes
 }
 
-func (t *remoteTerminal) windowChange(w int, h int) error {
+func (t *remoteTerminal) windowChange(w uint32, h uint32) error {
 	type windowChangeRequest struct {
 		W   uint32
 		H   uint32
@@ -495,10 +495,10 @@ func (t *remoteTerminal) windowChange(w int, h int) error {
 		Hpx uint32
 	}
 	req := windowChangeRequest{
-		W:   uint32(w),
-		H:   uint32(h),
-		Wpx: uint32(w * 8),
-		Hpx: uint32(h * 8),
+		W:   w,
+		H:   h,
+		Wpx: w * 8,
+		Hpx: h * 8,
 	}
 	_, err := t.session.SendRequest(sshutils.WindowChangeRequest, false, ssh.Marshal(&req))
 	return err

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -17,8 +17,9 @@ limitations under the License.
 package srv
 
 import (
-	"golang.org/x/crypto/ssh"
 	"io/ioutil"
+
+	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/pam"
@@ -133,7 +134,7 @@ func (t *TermHandlers) HandlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *Serve
 		return trace.Wrap(err)
 	}
 
-	params, err := rsession.NewTerminalParamsFromUint32(ptyRequest.W, ptyRequest.H)
+	params, err := rsession.NewTerminalParams(ptyRequest.W, ptyRequest.H)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -235,7 +236,7 @@ func parseWinChange(req *ssh.Request) (*rsession.TerminalParams, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	params, err := rsession.NewTerminalParamsFromUint32(r.W, r.H)
+	params, err := rsession.NewTerminalParams(r.W, r.H)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -890,7 +890,7 @@ func (s *WebSuite) TestNewTerminalHandler(c *C) {
 				Login:     validLogin,
 				Server:    validServer,
 				Term: session.TerminalParams{
-					H: -1,
+					H: 0,
 					W: 0,
 				},
 			},
@@ -958,7 +958,7 @@ func (s *WebSuite) TestResizeTerminal(c *C) {
 
 	// Resize the second terminal. This should be reflected on the first terminal
 	// because resize events are not sent back to the originator.
-	params, err := session.NewTerminalParamsFromInt(300, 120)
+	params, err := session.NewTerminalParams(300, 120)
 	c.Assert(err, IsNil)
 	data, err := json.Marshal(events.EventFields{
 		events.EventType:      events.ResizeEvent,

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -376,8 +376,8 @@ func (t *TerminalHandler) windowChange(params *session.TerminalParams) error {
 		sshutils.WindowChangeRequest,
 		false,
 		ssh.Marshal(sshutils.WinChangeReqParams{
-			W: uint32(params.W),
-			H: uint32(params.H),
+			W: params.W,
+			H: params.H,
 		}))
 	if err != nil {
 		t.log.Error(err)


### PR DESCRIPTION
1. fixes the typo in error message (terminal resize) 
2. refactors terminal size types (use uint32) in all places.