### PR TITLE
Validate host certificates in both tsh as well as the recording proxy.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package integration
 
 import (
@@ -460,11 +476,33 @@ func (i *TeleInstance) GenerateConfig(trustedSecrets []*InstanceSecrets, tconf *
 	tconf.Proxy.ReverseTunnelListenAddr.Addr = i.Secrets.ListenAddr
 	tconf.HostUUID = i.Secrets.GetIdentity().ID.HostUUID
 	tconf.SSH.Addr.Addr = net.JoinHostPort(i.Hostname, i.GetPortSSH())
+	tconf.SSH.PublicAddrs = []utils.NetAddr{
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Loopback,
+		},
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Host,
+		},
+	}
 	tconf.Auth.SSHAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortAuth())
 	tconf.Proxy.SSHAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortProxy())
 	tconf.Proxy.WebAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortWeb())
-	tconf.Proxy.PublicAddrs = []utils.NetAddr{{Addr: i.Hostname}}
-
+	tconf.Proxy.PublicAddrs = []utils.NetAddr{
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        i.Hostname,
+		},
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Loopback,
+		},
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Host,
+		},
+	}
 	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.SSHAddr)
 	tconf.Auth.StorageConfig = backend.Config{
 		Type:   lite.GetName(),
@@ -572,6 +610,16 @@ func (i *TeleInstance) StartNode(tconf *service.Config) (*service.TeleportProces
 		Enabled:   true,
 		RecentTTL: &ttl,
 	}
+	tconf.SSH.PublicAddrs = []utils.NetAddr{
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Loopback,
+		},
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Host,
+		},
+	}
 	tconf.Auth.Enabled = false
 	tconf.Proxy.Enabled = false
 
@@ -633,6 +681,16 @@ func (i *TeleInstance) StartNodeAndProxy(name string, sshPort, proxyWebPort, pro
 
 	tconf.SSH.Enabled = true
 	tconf.SSH.Addr.Addr = net.JoinHostPort(i.Hostname, fmt.Sprintf("%v", sshPort))
+	tconf.SSH.PublicAddrs = []utils.NetAddr{
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Loopback,
+		},
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Host,
+		},
+	}
 
 	// Create a new Teleport process and add it to the list of nodes that
 	// compose this "cluster".
@@ -696,6 +754,16 @@ func (i *TeleInstance) StartProxy(cfg ProxyConfig) error {
 
 	tconf.Proxy.Enabled = true
 	tconf.Proxy.SSHAddr.Addr = net.JoinHostPort(i.Hostname, fmt.Sprintf("%v", cfg.SSHPort))
+	tconf.Proxy.PublicAddrs = []utils.NetAddr{
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Loopback,
+		},
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        Host,
+		},
+	}
 	tconf.Proxy.ReverseTunnelListenAddr.Addr = net.JoinHostPort(i.Hostname, fmt.Sprintf("%v", cfg.ReverseTunnelPort))
 	tconf.Proxy.WebAddr.Addr = net.JoinHostPort(i.Hostname, fmt.Sprintf("%v", cfg.WebPort))
 	tconf.Proxy.DisableReverseTunnel = false

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -59,9 +59,10 @@ import (
 )
 
 const (
-	Host   = "localhost"
-	HostID = "00000000-0000-0000-0000-000000000000"
-	Site   = "local-site"
+	Loopback = "127.0.0.1"
+	Host     = "localhost"
+	HostID   = "00000000-0000-0000-0000-000000000000"
+	Site     = "local-site"
 
 	AllocatePortsNum = 300
 )
@@ -1173,7 +1174,7 @@ func (s *IntSuite) TestHA(c *check.C) {
 	}
 
 	cmd := []string{"echo", "hello world"}
-	tc, err := b.NewClient(ClientConfig{Login: username, Cluster: "cluster-a", Host: "127.0.0.1", Port: sshPort})
+	tc, err := b.NewClient(ClientConfig{Login: username, Cluster: "cluster-a", Host: Loopback, Port: sshPort})
 	c.Assert(err, check.IsNil)
 	output := &bytes.Buffer{}
 	tc.Stdout = output
@@ -1321,7 +1322,7 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 	c.Assert(nodes, check.HasLen, 2)
 
 	cmd := []string{"echo", "hello world"}
-	tc, err := main.NewClient(ClientConfig{Login: username, Cluster: clusterAux, Host: "127.0.0.1", Port: sshPort})
+	tc, err := main.NewClient(ClientConfig{Login: username, Cluster: clusterAux, Host: Loopback, Port: sshPort})
 	c.Assert(err, check.IsNil)
 	output := &bytes.Buffer{}
 	tc.Stdout = output
@@ -1526,7 +1527,7 @@ func (s *IntSuite) trustedClusters(c *check.C, multiplex bool) {
 	}
 
 	cmd := []string{"echo", "hello world"}
-	tc, err := main.NewClient(ClientConfig{Login: username, Cluster: clusterAux, Host: "127.0.0.1", Port: sshPort})
+	tc, err := main.NewClient(ClientConfig{Login: username, Cluster: clusterAux, Host: Loopback, Port: sshPort})
 	c.Assert(err, check.IsNil)
 	output := &bytes.Buffer{}
 	tc.Stdout = output
@@ -1608,7 +1609,7 @@ func (s *IntSuite) TestDiscovery(c *check.C) {
 	username := s.me.Username
 
 	// create load balancer for main cluster proxies
-	frontend := *utils.MustParseAddr(fmt.Sprintf("127.0.0.1:%v", s.getPorts(1)[0]))
+	frontend := *utils.MustParseAddr(net.JoinHostPort(Loopback, strconv.Itoa(s.getPorts(1)[0])))
 	lb, err := utils.NewLoadBalancer(context.TODO(), frontend)
 	c.Assert(err, check.IsNil)
 	c.Assert(lb.Listen(), check.IsNil)
@@ -1654,7 +1655,7 @@ func (s *IntSuite) TestDiscovery(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// add second proxy as a backend to the load balancer
-	lb.AddBackend(*utils.MustParseAddr(fmt.Sprintf("127.0.0.1:%v", proxyReverseTunnelPort)))
+	lb.AddBackend(*utils.MustParseAddr(net.JoinHostPort(Loopback, strconv.Itoa(proxyReverseTunnelPort))))
 
 	// At this point the remote cluster should be connected to two proxies in
 	// the main cluster.
@@ -1664,7 +1665,7 @@ func (s *IntSuite) TestDiscovery(c *check.C) {
 	cfg := ClientConfig{
 		Login:   username,
 		Cluster: "cluster-remote",
-		Host:    "127.0.0.1",
+		Host:    Loopback,
 		Port:    remote.GetPortSSHInt(),
 	}
 	output, err := runCommand(main, []string{"echo", "hello world"}, cfg, 1)
@@ -1678,7 +1679,7 @@ func (s *IntSuite) TestDiscovery(c *check.C) {
 	cfgProxy := ClientConfig{
 		Login:   username,
 		Cluster: "cluster-remote",
-		Host:    "127.0.0.1",
+		Host:    Loopback,
 		Port:    remote.GetPortSSHInt(),
 		Proxy:   &proxyConfig,
 	}
@@ -2306,7 +2307,7 @@ func (s *IntSuite) rotateSuccess(c *check.C) {
 
 	cfg := ClientConfig{
 		Login: s.me.Username,
-		Host:  "127.0.0.1",
+		Host:  Loopback,
 		Port:  t.GetPortSSHInt(),
 	}
 	clt, err := t.NewClientWithCreds(cfg, *initialCreds)
@@ -2445,7 +2446,7 @@ func (s *IntSuite) rotateRollback(c *check.C) {
 
 	cfg := ClientConfig{
 		Login: s.me.Username,
-		Host:  "127.0.0.1",
+		Host:  Loopback,
 		Port:  t.GetPortSSHInt(),
 	}
 	clt, err := t.NewClientWithCreds(cfg, *initialCreds)
@@ -2621,7 +2622,7 @@ func (s *IntSuite) rotateTrustedClusters(c *check.C) {
 	// credentials should work
 	cfg := ClientConfig{
 		Login:   s.me.Username,
-		Host:    "127.0.0.1",
+		Host:    Loopback,
 		Cluster: clusterAux,
 		Port:    aux.GetPortSSHInt(),
 	}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -872,6 +872,10 @@ func (s *APIServer) registerUsingToken(auth ClientI, w http.ResponseWriter, r *h
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// Pass along the remote address the request came from to the registration function.
+	req.RemoteAddr = r.RemoteAddr
+
 	keys, err := auth.RegisterUsingToken(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -900,6 +904,9 @@ func (s *APIServer) generateServerKeys(auth ClientI, w http.ResponseWriter, r *h
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// Pass along the remote address the request came from to the registration function.
+	req.RemoteAddr = r.RemoteAddr
 
 	keys, err := auth.GenerateServerKeys(req)
 	if err != nil {

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -180,7 +180,7 @@ func (k *Keygen) GenerateHostCert(c services.HostCertParams) ([]byte, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// build a valid list of principals from the HostID and NodeName and then
+	// Build a valid list of principals from the HostID and NodeName and then
 	// add in any additional principals passed in.
 	principals := BuildPrincipals(c.HostID, c.NodeName, c.ClusterName, c.Roles)
 	principals = append(principals, c.Principals...)
@@ -188,6 +188,7 @@ func (k *Keygen) GenerateHostCert(c services.HostCertParams) ([]byte, error) {
 		return nil, trace.BadParameter("no principals provided: %v, %v, %v",
 			c.HostID, c.NodeName, c.Principals)
 	}
+	principals = utils.Deduplicate(principals)
 
 	// create certificate
 	validBefore := uint64(ssh.CertTimeInfinity)
@@ -210,6 +211,8 @@ func (k *Keygen) GenerateHostCert(c services.HostCertParams) ([]byte, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	log.Debugf("Generated SSH host certificate for role %v with principals: %v.",
+		c.Roles, principals)
 	return ssh.MarshalAuthorizedKey(cert), nil
 }
 

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -17,8 +17,10 @@ limitations under the License.
 package client
 
 import (
+	"bufio"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -29,6 +31,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 
 	"github.com/sirupsen/logrus"
@@ -48,8 +51,8 @@ type LocalKeyAgent struct {
 	// sshAgent is the system ssh agent
 	sshAgent agent.Agent
 
-	// map of "no hosts". these are hosts that user manually (via keyboard
-	// input) refused connecting to.
+	// noHosts is a in-memory map used in tests to track which hosts a user has
+	// manually (via keyboard input) refused connecting to.
 	noHosts map[string]bool
 
 	// function which asks a user to trust host/key combination (during host auth)
@@ -258,77 +261,106 @@ func (a *LocalKeyAgent) UserRefusedHosts() bool {
 	return len(a.noHosts) > 0
 }
 
-// CheckHostSignature checks if the given host key was signed by one of the trusted
-// certificaate authorities (CAs)
-func (a *LocalKeyAgent) CheckHostSignature(host string, remote net.Addr, key ssh.PublicKey) error {
-	hostPromptFunc := func(host string, key ssh.PublicKey) error {
-		userAnswer := "no"
-		if !a.noHosts[host] {
-			fmt.Printf("The authenticity of host '%s' can't be established. "+
-				"Its public key is:\n%s\nAre you sure you want to continue (yes/no)? ",
-				host, ssh.MarshalAuthorizedKey(key))
+// CheckHostSignature checks if the given host key was signed by a Teleport
+// certificate authority (CA) or a host certificate the user has seen before.
+func (a *LocalKeyAgent) CheckHostSignature(addr string, remote net.Addr, key ssh.PublicKey) error {
+	certChecker := ssh.CertChecker{
+		IsHostAuthority: a.checkHostCertificate,
+		HostKeyFallback: a.checkHostKey,
+	}
+	err := certChecker.CheckHostKey(addr, remote, key)
+	if err != nil {
+		a.log.Debugf("Host validation failed: %v.", err)
+		return trace.Wrap(err)
+	}
+	a.log.Debugf("Validated host %v.", addr)
+	return nil
+}
 
-			bytes := make([]byte, 12)
-			os.Stdin.Read(bytes)
-			userAnswer = strings.TrimSpace(strings.ToLower(string(bytes)))
-		}
-		if !strings.HasPrefix(userAnswer, "y") {
-			return trace.AccessDenied("untrusted host %v", host)
-		}
-		// success
-		return nil
-	}
-	// overwritten host prompt func? (probably for tests)
-	if a.hostPromptFunc != nil {
-		hostPromptFunc = a.hostPromptFunc
-	}
-	cert, ok := key.(*ssh.Certificate)
-	if !ok {
-		// not a signed cert? perhaps we're given a host public key (happens when the host is running
-		// sshd instead of teleport daemon
-		keys, _ := a.keyStore.GetKnownHostKeys(host)
-		if len(keys) > 0 && sshutils.KeysEqual(key, keys[0]) {
-			a.log.Debugf("Verified host %s", host)
-			return nil
-		}
-		// ask user:
-		if err := hostPromptFunc(host, key); err != nil {
-			a.noHosts[host] = true
-			return trace.Wrap(err)
-		}
-		// remember the host key (put it into 'known_hosts')
-		if err := a.keyStore.AddKnownHostKeys(host, []ssh.PublicKey{key}); err != nil {
-			a.log.Warnf("Error saving the host key: %v", err)
-		}
-		return nil
-	}
-	key = cert.SignatureKey
-	// we are given a certificate. see if it was signed by any of the known_host keys:
+// checkHostCertificate validates a host certificate. First checks the
+// ~/.tsh/known_hosts cache and if not found, prompts the user to accept
+// or reject.
+func (a *LocalKeyAgent) checkHostCertificate(key ssh.PublicKey, addr string) bool {
+	// Check the local cache (where all Teleport CAs are placed upon login) to
+	// see if any of them match.
 	keys, err := a.keyStore.GetKnownHostKeys("")
 	if err != nil {
-		a.log.Error(err)
-		return trace.Wrap(err)
+		a.log.Errorf("Unable to fetch certificate authorities: %v.", err)
+		return false
 	}
-	a.log.Debugf("Got %d known hosts", len(keys))
 	for i := range keys {
-		if sshutils.KeysEqual(cert.SignatureKey, keys[i]) {
-			a.log.Debugf("Verified host %s", host)
-			return nil
+		if sshutils.KeysEqual(key, keys[i]) {
+			return true
 		}
 	}
-	// final step: if we have not seen the host key/cert before, lets ask the user if
-	// he trusts it, and add to the known_hosts if he says "yes"
-	if err = hostPromptFunc(host, key); err != nil {
-		// he said "no"
-		a.noHosts[host] = true
+
+	// If this certificate was not seen before, prompt the user essentially
+	// treating it like a key.
+	err = a.checkHostKey(addr, nil, key)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// checkHostCertificate validates a host key. First checks the
+// ~/.tsh/known_hosts cache and if not found, prompts the user to accept
+// or reject.
+func (a *LocalKeyAgent) checkHostKey(addr string, remote net.Addr, key ssh.PublicKey) error {
+	var err error
+
+	// Check if this exact host is in the local cache.
+	keys, _ := a.keyStore.GetKnownHostKeys(addr)
+	if len(keys) > 0 && sshutils.KeysEqual(key, keys[0]) {
+		a.log.Debugf("Verified host %s.", addr)
+		return nil
+	}
+
+	// If this key was not seen before, prompt the user with a fingerprint.
+	if a.hostPromptFunc != nil {
+		err = a.hostPromptFunc(addr, key)
+	} else {
+		err = a.defaultHostPromptFunc(addr, key, os.Stdout, os.Stdin)
+	}
+	if err != nil {
+		a.noHosts[addr] = true
 		return trace.Wrap(err)
 	}
-	// user said "yes"
-	err = a.keyStore.AddKnownHostKeys(host, []ssh.PublicKey{key})
+
+	// If the user trusts the key, store the key in the local known hosts
+	// cache ~/.tsh/known_hosts.
+	err = a.keyStore.AddKnownHostKeys(addr, []ssh.PublicKey{key})
 	if err != nil {
-		a.log.Warn(err)
+		a.log.Warnf("Failed to save the host key: %v.", err)
+		return trace.Wrap(err)
 	}
-	return err
+	return nil
+}
+
+// defaultHostPromptFunc is the default host key/certificates prompt.
+func (a *LocalKeyAgent) defaultHostPromptFunc(host string, key ssh.PublicKey, writer io.Writer, reader io.Reader) error {
+	var err error
+
+	userAnswer := "no"
+	if !a.noHosts[host] {
+		fmt.Fprintf(writer, "The authenticity of host '%s' can't be established. "+
+			"Its public key is:\n%s\nAre you sure you want to continue (yes/no)? ",
+			host, ssh.MarshalAuthorizedKey(key))
+
+		userAnswer, err = bufio.NewReader(reader).ReadString('\n')
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		userAnswer = strings.TrimSpace(strings.ToLower(userAnswer))
+	}
+	ok, err := utils.ParseBool(userAnswer)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !ok {
+		return trace.BadParameter("not trusted")
+	}
+	return nil
 }
 
 // AddKey activates a new signed session key by adding it into the keystore and also

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -210,7 +211,86 @@ func (s *KeyAgentTestSuite) TestLoadKey(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *KeyAgentTestSuite) TestHostVerification(c *check.C) {
+func (s *KeyAgentTestSuite) TestHostCertVerification(c *check.C) {
+	// Make a new local agent.
+	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
+	c.Assert(err, check.IsNil)
+
+	// By default user has not refused any hosts.
+	c.Assert(lka.UserRefusedHosts(), check.Equals, false)
+
+	// Create a CA, generate a keypair for the CA, and add it to the known
+	// hosts cache (done by "tsh login").
+	keygen := testauthority.New()
+	caPriv, caPub, err := keygen.GenerateKeyPair("")
+	c.Assert(err, check.IsNil)
+	caPublicKey, _, _, _, err := ssh.ParseAuthorizedKey(caPub)
+	c.Assert(err, check.IsNil)
+	err = lka.keyStore.AddKnownHostKeys("example.com", []ssh.PublicKey{caPublicKey})
+	c.Assert(err, check.IsNil)
+
+	// Generate a host certificate for node with role "node".
+	_, hostPub, err := keygen.GenerateKeyPair("")
+	roles, err := teleport.ParseRoles("node")
+	c.Assert(err, check.IsNil)
+	hostCertBytes, err := keygen.GenerateHostCert(services.HostCertParams{
+		PrivateCASigningKey: caPriv,
+		PublicHostKey:       hostPub,
+		HostID:              "5ff40d80-9007-4f28-8f49-7d4fda2f574d",
+		NodeName:            "server01",
+		Principals: []string{
+			"127.0.0.1",
+		},
+		ClusterName: "example.com",
+		Roles:       roles,
+		TTL:         1 * time.Hour,
+	})
+	c.Assert(err, check.IsNil)
+	hostPublicKey, _, _, _, err := ssh.ParseAuthorizedKey(hostCertBytes)
+	c.Assert(err, check.IsNil)
+
+	tests := []struct {
+		inAddr   string
+		outError bool
+	}{
+		// Correct DNS is valid.
+		{
+			inAddr:   "server01.example.com:3022",
+			outError: false,
+		},
+		// Hostname only is valid.
+		{
+			inAddr:   "server01:3022",
+			outError: false,
+		},
+		// IP is valid.
+		{
+			inAddr:   "127.0.0.1:3022",
+			outError: false,
+		},
+		// UUID is valid.
+		{
+			inAddr:   "5ff40d80-9007-4f28-8f49-7d4fda2f574d.example.com:3022",
+			outError: false,
+		},
+		// Wrong DNS name is invalid.
+		{
+			inAddr:   "server02.example.com:3022",
+			outError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		err = lka.CheckHostSignature(tt.inAddr, nil, hostPublicKey)
+		if tt.outError {
+			c.Assert(err, check.NotNil)
+		} else {
+			c.Assert(err, check.IsNil)
+		}
+	}
+}
+
+func (s *KeyAgentTestSuite) TestHostKeyVerification(c *check.C) {
 	// make a new local agent
 	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
 	c.Assert(err, check.IsNil)
@@ -261,6 +341,49 @@ func (s *KeyAgentTestSuite) TestHostVerification(c *check.C) {
 	err = lka.CheckHostSignature("luna", &a, pk)
 	c.Assert(err, check.IsNil)
 	c.Assert(userWasAsked, check.Equals, false)
+}
+
+func (s *KeyAgentTestSuite) TestDefaultHostPromptFunc(c *check.C) {
+	keygen := testauthority.New()
+
+	a, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
+	c.Assert(err, check.IsNil)
+
+	_, keyBytes, err := keygen.GenerateKeyPair("")
+	c.Assert(err, check.IsNil)
+	key, _, _, _, err := ssh.ParseAuthorizedKey(keyBytes)
+	c.Assert(err, check.IsNil)
+
+	tests := []struct {
+		inAnswer []byte
+		outError bool
+	}{
+		{
+			inAnswer: []byte("y\n"),
+			outError: false,
+		},
+		{
+			inAnswer: []byte("n\n"),
+			outError: true,
+		},
+		{
+			inAnswer: []byte("foo\n"),
+			outError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		// Write an answer to the "keyboard".
+		var buf bytes.Buffer
+		buf.Write(tt.inAnswer)
+
+		err = a.defaultHostPromptFunc("example.com", key, ioutil.Discard, &buf)
+		if tt.outError {
+			c.Assert(err, check.NotNil)
+		} else {
+			c.Assert(err, check.IsNil)
+		}
+	}
 }
 
 func (s *KeyAgentTestSuite) makeKey(username string, allowedLogins []string, ttl time.Duration) (*Key, error) {

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -216,6 +216,10 @@ const (
 	// Localhost is the address of localhost. Used for the default binding
 	// address for port forwarding.
 	Localhost = "127.0.0.1"
+
+	// AnyAddress is used to refer to the non-routable meta-address used to
+	// refer to all addresses on the machine.
+	AnyAddress = "0.0.0.0"
 )
 
 var (

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -21,8 +21,6 @@ import (
 	"net"
 	"time"
 
-	"golang.org/x/crypto/ssh/agent"
-
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -126,8 +124,8 @@ func (p *clusterPeers) DialAuthServer() (net.Conn, error) {
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
-func (p *clusterPeers) Dial(from, to net.Addr, userAgent agent.Agent) (conn net.Conn, err error) {
-	return p.DialTCP(from, to)
+func (p *clusterPeers) Dial(params DialParams) (conn net.Conn, err error) {
+	return p.DialTCP(params.From, params.To)
 }
 
 func (p *clusterPeers) DialTCP(from, to net.Addr) (conn net.Conn, err error) {
@@ -189,7 +187,7 @@ func (s *clusterPeer) GetLastConnected() time.Time {
 // Dial is used to connect a requesting client (say, tsh) to an SSH server
 // located in a remote connected site, the connection goes through the
 // reverse proxy tunnel.
-func (s *clusterPeer) Dial(from, to net.Addr) (conn net.Conn, err error) {
+func (s *clusterPeer) Dial(params DialParams) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy %v has not been discovered yet, try again later", s)
 }
 

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -294,7 +294,7 @@ func (process *TeleportProcess) firstTimeConnect(role teleport.Role) (*Connector
 		// Auth service is on the same host, no need to go though the invitation
 		// procedure.
 		process.Debugf("This server has local Auth server started, using it to add role to the cluster.")
-		identity, err = auth.LocalRegister(id, process.getLocalAuth(), additionalPrincipals)
+		identity, err = auth.LocalRegister(id, process.getLocalAuth(), additionalPrincipals, process.Config.AdvertiseIP)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -562,6 +562,12 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	additionalPrincipals = utils.ReplaceInSlice(
+		additionalPrincipals,
+		defaults.AnyAddress,
+		defaults.Localhost,
+	)
+
 	principalsChanged := len(additionalPrincipals) != 0 && !conn.ServerIdentity.HasPrincipals(additionalPrincipals)
 
 	if local.Matches(remote) && !principalsChanged {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1517,6 +1517,18 @@ func (process *TeleportProcess) getAdditionalPrincipals(role teleport.Role) ([]s
 		addrs = process.Config.Auth.PublicAddrs
 	case teleport.RoleNode:
 		addrs = process.Config.SSH.PublicAddrs
+		// If advertise IP is set, add it to the list of principals. Otherwise
+		// add in the default (0.0.0.0) which will be replaced by the Auth Server
+		// when a host certificate is issued.
+		if process.Config.AdvertiseIP != "" {
+			advertiseIP, err := utils.ParseAddr(process.Config.AdvertiseIP)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			addrs = append(addrs, *advertiseIP)
+		} else {
+			addrs = append(addrs, process.Config.SSH.Addr)
+		}
 	}
 	for _, addr := range addrs {
 		host, err := utils.Host(addr.Addr)

--- a/lib/utils/addr.go
+++ b/lib/utils/addr.go
@@ -126,7 +126,7 @@ func (a *NetAddr) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (a *NetAddr) Set(s string) error {
 	v, err := ParseAddr(s)
 	if err != nil {
-		return err
+		return trace.Wrap(err)
 	}
 	a.Addr = v.Addr
 	a.AddrNetwork = v.AddrNetwork

--- a/lib/utils/copy.go
+++ b/lib/utils/copy.go
@@ -96,3 +96,18 @@ func CopyStringMapInterface(a map[string]interface{}) map[string]interface{} {
 
 	return out
 }
+
+// ReplaceInSlice replaces element old with new and returns a new slice.
+func ReplaceInSlice(s []string, old string, new string) []string {
+	out := make([]string, 0, len(s))
+
+	for _, x := range s {
+		if x == old {
+			out = append(out, new)
+		} else {
+			out = append(out, x)
+		}
+	}
+
+	return out
+}


### PR DESCRIPTION
**Purpose**

At the moment tsh and the recording proxy make sure that host certificates are generated by Teleport. This PR also checks that the host certificate timestamp and hostname (or IP).

**Implementation**

* When generating a host certificate add advertise IP into the host certificate.
* If no advertise IP is specified add `0.0.0.0` to the host certificate and let the Auth Server replace it with the remote address when generating a host certificate.
* Upon dailing, pass in the host address so the forwarding proxy can generate the appropriate host certificate.
* Check that the timestamp and hostname (or IP) of on the host certificate is valid.
* If local registration is occurring add localhost to the host certificate.
