### PR TITLE
Expose the user invite API.

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -97,6 +97,9 @@ func NewAPIServer(config *APIConfig) http.Handler {
 	srv.POST("/:version/users/:user/ssh/authenticate", srv.withAuth(srv.authenticateSSHUser))
 	srv.GET("/:version/users/:user/web/sessions/:sid", srv.withAuth(srv.getWebSession))
 	srv.DELETE("/:version/users/:user/web/sessions/:sid", srv.withAuth(srv.deleteWebSession))
+
+	// User signup tokens.
+	srv.GET("/:version/signuptokens", srv.withAuth(srv.getSignupTokens))
 	srv.GET("/:version/signuptokens/:token", srv.withAuth(srv.getSignupTokenData))
 	srv.POST("/:version/signuptokens/users", srv.withAuth(srv.createUserWithToken))
 	srv.POST("/:version/signuptokens", srv.withAuth(srv.createSignupToken))
@@ -1110,6 +1113,15 @@ func (s *APIServer) getSession(auth ClientI, w http.ResponseWriter, r *http.Requ
 		return nil, trace.Wrap(err)
 	}
 	return se, nil
+}
+
+func (s *APIServer) getSignupTokens(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+	tokens, err := auth.GetSignupTokens()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return tokens, nil
 }
 
 type getSignupTokenDataResponse struct {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -730,6 +730,17 @@ func (a *AuthWithRoles) CreateSignupToken(user services.UserV1, ttl time.Duratio
 	return a.authServer.CreateSignupToken(user, ttl)
 }
 
+// GetSignupTokens returns all the user signup tokens in the cluster.
+func (a *AuthWithRoles) GetSignupTokens() ([]services.SignupToken, error) {
+	if err := a.action(defaults.Namespace, services.KindToken, services.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := a.action(defaults.Namespace, services.KindToken, services.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.authServer.GetSignupTokens()
+}
+
 func (a *AuthWithRoles) GetSignupTokenData(token string) (user string, otpQRCode []byte, err error) {
 	// signup token are their own authz resource
 	return a.authServer.GetSignupTokenData(token)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1405,6 +1405,20 @@ func (c *Client) CreateSignupToken(user services.UserV1, ttl time.Duration) (str
 	return token, nil
 }
 
+// GetSignupTokens returns all the user signup tokens in the cluster.
+func (c *Client) GetSignupTokens() ([]services.SignupToken, error) {
+	out, err := c.Get(c.Endpoint("signuptokens"), url.Values{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var tokens []services.SignupToken
+	if err := json.Unmarshal(out.Bytes(), &tokens); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return tokens, nil
+}
+
 // GetSignupTokenData returns token data for a valid token
 func (c *Client) GetSignupTokenData(token string) (user string, otpQRCode []byte, e error) {
 	out, err := c.Get(c.Endpoint("signuptokens", token), url.Values{})
@@ -2476,6 +2490,9 @@ type IdentityService interface {
 
 	// GetSignupTokenData returns token data for a valid token
 	GetSignupTokenData(token string) (user string, otpQRCode []byte, e error)
+
+	// GetSignupTokens returns all the user signup tokens in the cluster.
+	GetSignupTokens() ([]services.SignupToken, error)
 
 	// CreateSignupToken creates one time token for creating account for the user
 	// For each token it creates username and OTP key

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -237,6 +237,12 @@ type SignupToken struct {
 	Expires   time.Time `json:"expires"`
 }
 
+// String returns a human readable version of the user signup token.
+func (s SignupToken) String() string {
+	return fmt.Sprintf("SignupToken(User=%v, expires=%v)",
+		s.User.V2().GetName(), s.Expires)
+}
+
 // OIDCIdentity is OpenID Connect identity that is linked
 // to particular user and connector and lets user to log in using external
 // credentials, e.g. google

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -162,6 +162,11 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	h.POST("/webapi/users", httplib.MakeHandler(h.createNewUser))
 	h.PUT("/webapi/users/password", h.WithAuth(h.changePassword))
 
+	// User signup tokens.
+	h.POST("/webapi/sites/:site/namespaces/:namespace/signuptokens", h.WithClusterAuth(h.createSignupToken))
+	h.GET("/webapi/sites/:site/namespaces/:namespace/signuptokens", h.WithClusterAuth(h.getSignupTokens))
+	h.DELETE("/webapi/sites/:site/namespaces/:namespace/signuptokens/:token", h.WithClusterAuth(h.deleteSignupToken))
+
 	// Issues SSH temp certificates based on 2FA access creds
 	h.POST("/webapi/ssh/certs", httplib.MakeHandler(h.createSSHCert))
 

--- a/lib/web/signuptokens.go
+++ b/lib/web/signuptokens.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package web
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/services"
+
+	"github.com/gravitational/trace"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+type createSignupTokenRequest struct {
+	Username      string        `json:"username"`
+	AllowedLogins []string      `json:"allowed_logins"`
+	KubeGroups    []string      `json:"kube_groups"`
+	TTL           time.Duration `json:"ttl"`
+}
+
+type createSignupTokenResponse struct {
+	Token string `json:"token"`
+}
+
+func (h *Handler) createSignupToken(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	var req *createSignupTokenRequest
+	err := httplib.ReadJSON(r, &req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Get a site specific auth client.
+	clt, err := ctx.GetUserClient(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Create user signup token.
+	user := services.UserV1{
+		Name:          req.Username,
+		AllowedLogins: req.AllowedLogins,
+		KubeGroups:    req.KubeGroups,
+	}
+	token, err := clt.CreateSignupToken(user, req.TTL)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return createSignupTokenResponse{
+		Token: token,
+	}, nil
+}
+
+type getSignupTokensResponse struct {
+	Tokens []services.SignupToken `json:"tokens"`
+}
+
+func (h *Handler) getSignupTokens(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	// Get a site specific auth client.
+	clt, err := ctx.GetUserClient(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Get all user signup tokens.
+	tokens, err := clt.GetSignupTokens()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &getSignupTokensResponse{
+		Tokens: tokens,
+	}, nil
+}
+
+func (h *Handler) deleteSignupToken(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	// Get a site specific auth client.
+	clt, err := ctx.GetUserClient(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Remove specific user signup token.
+	err = clt.DeleteToken(p.ByName("token"))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ok(), nil
+}


### PR DESCRIPTION
**Purpose**

Expose the user invite API to allow creating, listing, and deleting user signup tokens from the Web UI.

**Implementation**

* Added `GetSignupTokens` to the Auth Server API which returns all user signup tokens.
* Exposed creating, listing, and deleting of user signup tokens for a cluster in the web proxy.
* Allow listing of user signup tokens only in the CLI.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2392