### PR TITLE
Fetch groups for GSuite SSO.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -377,6 +377,15 @@ const (
 	TraitInternalKubeGroupsVariable = "{{internal.kubernetes_groups}}"
 )
 
+const (
+	// GSuiteIssuerURL is issuer URL used for GSuite provider
+	GSuiteIssuerURL = "https://accounts.google.com"
+	// GSuiteGroupsEndpoint is gsuite API endpoint
+	GSuiteGroupsEndpoint = "https://www.googleapis.com/admin/directory/v1/groups"
+	// GSuiteGroupsScope is a scope to get access to admin groups API
+	GSuiteGroupsScope = "https://www.googleapis.com/auth/admin.directory.group.readonly"
+)
+
 // SCP is Secure Copy.
 const SCP = "scp"
 


### PR DESCRIPTION
Fixes #2455

This commit adds support for fetching
groups for GSuite SSO logins via
OIDC connector interface.

If OIDC connector has a special scope:

`https://www.googleapis.com/auth/admin.directory.group.readonly`

teleport will fetch user's group membership and populate
groups claim.