### PR TITLE
Fix Docker image.

### DIFF
--- a/build.assets/charts/Dockerfile
+++ b/build.assets/charts/Dockerfile
@@ -1,12 +1,23 @@
-FROM ubuntu:18.10
+FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y \
+# Install dumb-init and ca-certificate. The dumb-init package is to ensure
+# signals and orphaned processes are are handled correctly. The ca-certificate
+# package is installed because the base Ubuntu image does not come with any
+# certificate authorities.
+#
+# Note that /var/lib/apt/lists/* is cleaned up in the same RUN command as
+# "apt-get update" to reduce the size of the image.
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install --no-install-recommends -y \
     dumb-init \
- && rm -rf /var/lib/apt/lists/*
+    ca-certificates \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
-# Bundle teleport and control binary
+# Bundle "teleport", "tctl", and "tsh" binaries into image.
 ADD teleport /usr/local/bin/teleport
 ADD tctl /usr/local/bin/tctl
+ADD tsh /usr/local/bin/tsh
 
-# By setting this entry point, we expose make target as command
+# By setting this entry point, we expose make target as command.
 ENTRYPOINT ["/usr/bin/dumb-init", "teleport", "start", "-c", "/etc/teleport/teleport.yaml"]

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1149,7 +1149,7 @@ func (s *TLSSuite) TestGetCertAuthority(c *check.C) {
 	role := services.NewImplicitRole()
 	role.SetName(user.GetName())
 	role.SetLogins(services.Allow, []string{user.GetName()})
-	err = s.server.Auth().UpsertRole(role, backend.Forever)
+	err = s.server.Auth().UpsertRole(role)
 	c.Assert(err, check.IsNil)
 
 	user.AddRole(role.GetName())


### PR DESCRIPTION
**Purpose**

Trying to start Teleport using DynamoDB as the backend would result in the following error:

```
ERROR REPORT:
Original Error: *awserr.baseError RequestError: send request failed
caused by: Post https://dynamodb.us-west-2.amazonaws.com/: x509: certificate signed by unknown authority
```

This was caused by missing CA certificates in the Docker image.

**Implementation**

* Install `ca-certificates` in Docker image.
* Re-factor Dockerfile to add comments for each layer.
* Downgrade to LTS Ubuntu release.
