### PR TITLE
Pass kubernetes groups to the remote cluster.

### DIFF
--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -365,8 +365,11 @@ func (s *KubeSuite) TestKubeTrustedClusters(c *check.C) {
 	// role specified by mapping remote role "aux-kube" to local role "main-kube"
 	auxRole, err := services.NewRole("aux-kube", services.RoleSpecV3{
 		Allow: services.RoleConditions{
-			Logins:     []string{username},
-			KubeGroups: []string{teleport.KubeSystemMasters},
+			Logins: []string{username},
+			// Note that main cluster can pass it's kubernetes groups
+			// to the remote cluster, and remote cluster
+			// can choose to use them by using special variable
+			KubeGroups: []string{teleport.TraitInternalKubeGroupsVariable},
 		},
 	})
 	c.Assert(err, check.IsNil)

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -237,10 +237,11 @@ func (a *AuthMiddleware) GetUser(r *http.Request) (interface{}, error) {
 			}, nil
 		}
 		return RemoteUser{
-			ClusterName: certClusterName,
-			Username:    identity.Username,
-			Principals:  identity.Principals,
-			RemoteRoles: identity.Groups,
+			ClusterName:      certClusterName,
+			Username:         identity.Username,
+			Principals:       identity.Principals,
+			KubernetesGroups: identity.KubernetesGroups,
+			RemoteRoles:      identity.Groups,
 		}, nil
 	}
 	// code below expects user or service from local cluster, to distinguish between

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -73,6 +73,8 @@ type Identity struct {
 	Usage []string
 	// Principals is a list of Unix logins allowed.
 	Principals []string
+	// KubernetesGroups is a list of Kubernetes groups allowed
+	KubernetesGroups []string
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -94,16 +96,18 @@ func (id *Identity) Subject() pkix.Name {
 	subject.Organization = append([]string{}, id.Groups...)
 	subject.OrganizationalUnit = append([]string{}, id.Usage...)
 	subject.Locality = append([]string{}, id.Principals...)
+	subject.Province = append([]string{}, id.KubernetesGroups...)
 	return subject
 }
 
 // FromSubject returns identity from subject name
 func FromSubject(subject pkix.Name) (*Identity, error) {
 	i := &Identity{
-		Username:   subject.CommonName,
-		Groups:     subject.Organization,
-		Usage:      subject.OrganizationalUnit,
-		Principals: subject.Locality,
+		Username:         subject.CommonName,
+		Groups:           subject.Organization,
+		Usage:            subject.OrganizationalUnit,
+		Principals:       subject.Locality,
+		KubernetesGroups: subject.Province,
 	}
 	if err := i.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This commit allows remote cluster to reference
the kubernetes groups coming from the roles
of the main cluster in the trusted clusters
configuration.

For example, main cluster can have a user
with a role 'main' and kubernetes groups:

```yaml
kube_groups: ['system:masters']
```
and SSH logins:

```yaml
logins: ['root']
```

Remote cluster can choose to map
this 'main' cluster to it's own:
'remote-admin' cluster in the trusted cluster config:

```yaml
role_map:
  - remote: 'main'
    local: 'remote-admin'
```

The role 'remote-admin' of the remote cluster
can now be templated to use the main cluster role main
logins and kubernetes_groups using variables:

```yaml
logins: ['{{internal.logins}}']
kubernetes_groups: ['{{internal.kubernetes_groups}}']
```

This is possible because teleport now encodes
both values in X509 certificate metadata
and remote cluster passes these values as 'internal' traits
to the template engine.