### PR TITLE
Fetch trusted CA from the main cluster.

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1004,7 +1004,7 @@ func (s *IntSuite) TestTwoClusters(c *check.C) {
 		c.Assert(outputA.String(), check.Equals, "hello world\n")
 
 		// Update trusted CAs.
-		err = tc.UpdateTrustedCA(context.TODO())
+		err = tc.UpdateTrustedCA(context.TODO(), a.Secrets.SiteName)
 		c.Assert(err, check.IsNil)
 
 		// The known_hosts file should have two certificates, the way bytes.Split

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -373,7 +373,7 @@ func (a *AuthWithRoles) NewWatcher(ctx context.Context, watch services.Watch) (s
 	for _, kind := range watch.Kinds {
 		switch kind {
 		case services.KindCertAuthority:
-			if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbRead); err != nil {
+			if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbReadNoSecrets); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		default:

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -52,6 +52,9 @@ type Key struct {
 
 	// TrustedCA is a list of trusted certificate authorities
 	TrustedCA []auth.TrustedCerts
+
+	// ClusterName is a cluster name this key is associated with
+	ClusterName string
 }
 
 // TLSConfig returns client TLS configuration used

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -419,7 +419,7 @@ func onLogin(cf *CLIConf) {
 		if err := setupNoninteractiveClient(tc, key); err != nil {
 			utils.FatalError(err)
 		}
-		authorities, err := tc.GetTrustedCA(cf.Context)
+		authorities, err := tc.GetTrustedCA(cf.Context, key.ClusterName)
 		if err != nil {
 			utils.FatalError(err)
 		}
@@ -439,7 +439,7 @@ func onLogin(cf *CLIConf) {
 	tc.SaveProfile("")
 
 	// Connect to the Auth Server and fetch the known hosts for this cluster.
-	err = tc.UpdateTrustedCA(cf.Context)
+	err = tc.UpdateTrustedCA(cf.Context, key.ClusterName)
 	if err != nil {
 		utils.FatalError(err)
 	}


### PR DESCRIPTION
This PR fixes an issue with tsh login.

Here is a flaw in logic described using the following
scenario:

Assume there are two clusters, 'main' and 'east'.

1. User logs into the first cluster 'main'
2. Selects the cluster 'east' in the profile
3. Next day, logs in again
4. Client pulls the trusted CA from the cluster 'main'
as a part of SSH login procedure and adds to the keystore
5. Client connects to cluster 'east' because it is
set as a current cluster in the profile
6. Client attempts to connect to the auth server of the cluster
'east' and fails because it does not trust the certificate
of the 'east' yet, only 'main.

This PR fixes the issue by making sure the client
always connects to the cluster 'main' in the step 5 instead.