### PR TITLE
Fix scp issues

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -132,10 +132,10 @@ func UserMessageFromError(err error) string {
 		// error occurred" message.
 		if er, ok := err.(*trace.TraceErr); ok {
 			if er.Message != "" {
-				return fmt.Sprintf("error: %v", er.Message)
+				return fmt.Sprintf("error: %v", EscapeControl(er.Message))
 			}
 		}
-		return fmt.Sprintf("error: %v", err.Error())
+		return fmt.Sprintf("error: %v", EscapeControl(err.Error()))
 	}
 	return ""
 }
@@ -165,6 +165,27 @@ func InitCLIParser(appName, appHelp string) (app *kingpin.Application) {
 
 	// set our own help template
 	return app.UsageTemplate(defaultUsageTemplate)
+}
+
+// EscapeControl escapes all ANSI escape sequences from string and returns a
+// string that is safe to print on the CLI. This is to ensure that malicious
+// servers can not hide output. For more details, see:
+//   * https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
+func EscapeControl(s string) string {
+	if needsQuoting(s) {
+		return fmt.Sprintf("%q", s)
+	}
+	return s
+}
+
+// needsQuoting returns true if any non-printable characters are found.
+func needsQuoting(text string) bool {
+	for _, r := range text {
+		if !strconv.IsPrint(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // Usage template with compactly formatted commands.

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+
+	"gopkg.in/check.v1"
+
+	"github.com/gravitational/trace"
+)
+
+type CLISuite struct {
+}
+
+var _ = check.Suite(&CLISuite{})
+var _ = fmt.Printf
+
+func (s *CLISuite) SetUpSuite(c *check.C) {
+	InitLoggerForTests()
+}
+func (s *CLISuite) TearDownSuite(c *check.C) {}
+func (s *CLISuite) SetUpTest(c *check.C)     {}
+func (s *CLISuite) TearDownTest(c *check.C)  {}
+
+func (s *CLISuite) TestUserMessageFromError(c *check.C) {
+	tests := []struct {
+		inError   error
+		outString string
+	}{
+		{
+			inError:   trace.Wrap(x509.UnknownAuthorityError{}),
+			outString: "WARNING:\n\n  The proxy you are connecting to has presented a",
+		},
+		{
+			inError:   trace.Wrap(x509.CertificateInvalidError{}),
+			outString: "WARNING:\n\n  The certificate presented by the proxy is invalid",
+		},
+		{
+			inError:   trace.Errorf("\x1b[1mWARNING\x1b[0m"),
+			outString: `error: "\x1b[1mWARNING\x1b[0m"`,
+		},
+	}
+
+	for i, tt := range tests {
+		comment := check.Commentf("Test %v", i)
+		message := UserMessageFromError(tt.inError)
+		c.Assert(strings.HasPrefix(message, tt.outString), check.Equals, true, comment)
+	}
+}


### PR DESCRIPTION
**Purpose**

Fixed scp [client vulnerabilities to a malicious server](https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt) found by Harry Sintonen.

**Implementation**

* Reject invalid directory names like `.` and `..` to disallow setting attributes on the target directory.
* Strip control characters from file progress.
* Strip control characters from stderr output.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2539