### PR TITLE
Sort out principals into DNS names and IP addresses.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ endif
 
 .PHONY: test-package
 test-package: remove-temp-files
-	go test -v -test.parallel=0 ./$(p)
+	go test -v ./$(p)
 
 .PHONY: test-grep-package
 test-grep-package: remove-temp-files

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -354,7 +354,7 @@ func (s *IntSuite) TestAuditOn(c *check.C) {
 			time.Sleep(time.Millisecond * 250)
 			if i >= 5 {
 				// session stream keeps coming back short
-				c.Fatal("stream is not getting data: %q", string(sessionStream))
+				c.Fatalf("Stream is not getting data: %q.", string(sessionStream))
 			}
 		}
 

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -185,7 +185,7 @@ set kubeconfig_path if auth server is running outside of the cluster`, teleport.
 		clt, cfg, err := kubeutils.GetKubeClient(os.Getenv(teleport.EnvKubeConfig))
 		if err != nil {
 			return nil, trace.BadParameter(`auth server assumed that it is 
-running in a kubernetes cluster, but could not init in-cluster kubernetes client`, err)
+running in a kubernetes cluster, but could not init in-cluster kubernetes client: %v`, err)
 		}
 
 		targetAddr, err := parseKubeHost(cfg.Host)

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -185,7 +185,7 @@ func (a *AuthMiddleware) GetUser(r *http.Request) (interface{}, error) {
 	clientCert := peers[0]
 	certClusterName, err := tlsca.ClusterName(clientCert.Issuer)
 	if err != nil {
-		log.Warning("Failed to parse client certificate %v.", err)
+		log.Warnf("Failed to parse client certificate %v.", err)
 		return nil, trace.AccessDenied("access denied: invalid client certificate")
 	}
 

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -133,7 +133,7 @@ func New(params backend.Params) (backend.Backend, error) {
 	err := utils.ObjectToStruct(params, &cfg)
 	if err != nil {
 		log.Error(err)
-		return nil, trace.BadParameter("DynamoDB configuration is invalid", err)
+		return nil, trace.BadParameter("invalid DynamoDB configuration: %v", err)
 	}
 
 	defer l.Debug("AWS session is created.")

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -153,7 +153,7 @@ func New(params backend.Params) (backend.Backend, error) {
 	// convert generic backend parameters structure to etcd config:
 	var cfg *Config
 	if err = utils.ObjectToStruct(params, &cfg); err != nil {
-		return nil, trace.BadParameter("invalid etcd configuration", err)
+		return nil, trace.BadParameter("invalid etcd configuration: %v", err)
 	}
 	if err = cfg.Validate(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -352,7 +352,7 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 			}
 
 			lastSize = terminalParams.Winsize()
-			log.Debugf("Recevied window size %v from node in session.\n", lastSize, event.GetString(events.SessionEventID))
+			log.Debugf("Recevied window size %v from node in session %v.", lastSize, event.GetString(events.SessionEventID))
 
 		// Update size of local terminal with the last size received from remote server.
 		case <-tickerCh.C:
@@ -373,14 +373,14 @@ func (ns *NodeSession) updateTerminalSize(s *ssh.Session) {
 			// the window.
 			err = term.SetWinsize(0, lastSize)
 			if err != nil {
-				log.Warnf("Unable to update terminal size: %v.\n", err)
+				log.Warnf("Unable to update terminal size: %v.", err)
 				continue
 			}
 
 			// This is what we use to resize the physical terminal window itself.
 			os.Stdout.Write([]byte(fmt.Sprintf("\x1b[8;%d;%dt", lastSize.Height, lastSize.Width)))
 
-			log.Debugf("Updated window size from to %v due to remote window change.", currSize, lastSize)
+			log.Debugf("Updated window size from %v to %v due to remote window change.", currSize, lastSize)
 		case <-ns.closer.C:
 			return
 		}

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -134,11 +134,11 @@ func (l *FileLog) SearchEvents(fromUTC, toUTC time.Time, query string, limit int
 	// how many days of logs to search?
 	days := int(toUTC.Sub(fromUTC).Hours() / 24)
 	if days < 0 {
-		return nil, trace.BadParameter("query", query)
+		return nil, trace.BadParameter("invalid days")
 	}
 	queryVals, err := url.ParseQuery(query)
 	if err != nil {
-		return nil, trace.BadParameter("missing parameter query", query)
+		return nil, trace.BadParameter("invalid query")
 	}
 	filtered, err := l.matchingFiles(fromUTC, toUTC)
 	if err != nil {

--- a/lib/kube/proxy/portforward.go
+++ b/lib/kube/proxy/portforward.go
@@ -188,7 +188,7 @@ func (h *portForwardProxy) forwardStreamPair(p *httpStreamPair, remotePort int64
 	headers.Set(StreamType, StreamTypeData)
 	dataStream, err := h.targetConn.CreateStream(headers)
 	if err != nil {
-		return trace.ConnectionProblem(err, "error creating forwarding stream for port -> %d: %v", remotePort)
+		return trace.ConnectionProblem(err, "error creating forwarding stream for port -> %d: %v", remotePort, err)
 	}
 	defer dataStream.Close()
 

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -57,7 +57,7 @@ func (p *clusterPeers) pickPeer() (*clusterPeer, error) {
 		}
 	}
 	if currentPeer == nil {
-		return nil, trace.NotFound("no active peers found for %v")
+		return nil, trace.NotFound("no active peers found for %v", p.clusterName)
 	}
 	return currentPeer, nil
 }
@@ -159,7 +159,7 @@ type clusterPeer struct {
 }
 
 func (s *clusterPeer) CachingAccessPoint() (auth.AccessPoint, error) {
-	return nil, trace.ConnectionProblem(nil, "unable to fetch access point, this proxy %v has not been discovered yet, try again later")
+	return nil, trace.ConnectionProblem(nil, "unable to fetch access point, this proxy %v has not been discovered yet, try again later", s)
 }
 
 func (s *clusterPeer) GetClient() (auth.ClientI, error) {

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -637,7 +637,7 @@ func (s *Server) serveAgent(ctx *srv.ServerContext) error {
 	socketPath := filepath.Join(socketDir, fmt.Sprintf("teleport-%v.socket", pid))
 	if err := os.Chown(socketDir, uid, gid); err != nil {
 		if err := dirCloser.Close(); err != nil {
-			log.Warn("failed to remove directory: %v", err)
+			log.Warnf("failed to remove directory: %v", err)
 		}
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"net"
 	"time"
 
 	"github.com/gravitational/teleport"
@@ -174,8 +175,16 @@ func (ca *CertAuthority) GenerateCertificate(req CertificateRequest) ([]byte, er
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		// BasicConstraintsValid is true to not allow any intermediate certs.
 		BasicConstraintsValid: true,
-		IsCA:     false,
-		DNSNames: req.DNSNames,
+		IsCA: false,
+	}
+
+	// sort out principals into DNS names and IP addresses
+	for i := range req.DNSNames {
+		if ip := net.ParseIP(req.DNSNames[i]); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, req.DNSNames[i])
+		}
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, ca.Cert, req.PublicKey, ca.Signer)

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tlsca
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509/pkix"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/lib/fixtures"
+
+	"github.com/jonboulle/clockwork"
+	check "gopkg.in/check.v1"
+)
+
+func TestTLSCA(t *testing.T) { check.TestingT(t) }
+
+type TLSCASuite struct {
+	clock clockwork.Clock
+}
+
+var _ = check.Suite(&TLSCASuite{
+	clock: clockwork.NewFakeClock(),
+})
+
+// TestPrincipals makes sure that SAN extension of generated x509 cert gets
+// correctly set with DNS names and IP addresses based on the provided
+// principals.
+func (s *TLSCASuite) TestPrincipals(c *check.C) {
+	ca, err := New([]byte(fixtures.SigningCertPEM), []byte(fixtures.SigningKeyPEM))
+	c.Assert(err, check.IsNil)
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	c.Assert(err, check.IsNil)
+
+	hostnames := []string{"localhost", "example.com"}
+	ips := []string{"127.0.0.1", "192.168.1.1"}
+
+	certBytes, err := ca.GenerateCertificate(CertificateRequest{
+		Clock:     s.clock,
+		PublicKey: privateKey.Public(),
+		Subject:   pkix.Name{CommonName: "test"},
+		NotAfter:  s.clock.Now().Add(time.Hour),
+		DNSNames:  append(hostnames, ips...),
+	})
+	c.Assert(err, check.IsNil)
+
+	cert, err := ParseCertificatePEM(certBytes)
+	c.Assert(err, check.IsNil)
+	c.Assert(cert.DNSNames, check.DeepEquals, hostnames)
+	var certIPs []string
+	for _, ip := range cert.IPAddresses {
+		certIPs = append(certIPs, ip.String())
+	}
+	c.Assert(certIPs, check.DeepEquals, ips)
+}

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -41,7 +41,7 @@ func ParseSigningKeyStorePEM(keyPEM, certPEM string) (*SigningKeyStore, error) {
 	}
 	rsaKey, ok := key.(*rsa.PrivateKey)
 	if !ok {
-		return nil, trace.BadParameter("key of type %T is not supported, only RSA keys are supported for signatures")
+		return nil, trace.BadParameter("key of type %T is not supported, only RSA keys are supported for signatures", key)
 	}
 	certASN, _ := pem.Decode([]byte(certPEM))
 	if certASN == nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -655,7 +655,7 @@ func (h *Handler) oidcLoginWeb(w http.ResponseWriter, r *http.Request, p httprou
 
 	csrfToken, err := csrf.ExtractTokenFromCookie(r)
 	if err != nil {
-		log.Warningf("unable to extract CSRF token from cookie", err)
+		log.Warningf("unable to extract CSRF token from cookie: %v", err)
 		return nil, trace.AccessDenied("access denied")
 	}
 
@@ -827,7 +827,7 @@ func (h *Handler) oidcCallback(w http.ResponseWriter, r *http.Request, p httprou
 	if response.Req.CreateWebSession {
 		err = csrf.VerifyToken(response.Req.CSRFToken, r)
 		if err != nil {
-			log.Warningf("[OIDC] unable to verify CSRF token", err)
+			log.Warningf("[OIDC] unable to verify CSRF token: %v", err)
 			return nil, trace.AccessDenied("access denied")
 		}
 

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -117,7 +117,7 @@ func (m *Handler) samlACS(w http.ResponseWriter, r *http.Request, p httprouter.P
 		log.Debugf("redirecting to web browser")
 		err = csrf.VerifyToken(response.Req.CSRFToken, r)
 		if err != nil {
-			l.Warningf("unable to verify CSRF token", err)
+			l.Warningf("unable to verify CSRF token: %v", err)
 			return nil, trace.AccessDenied("access denied")
 		}
 


### PR DESCRIPTION
Otherwise certificates get generated with IP address set as a DNS name in SAN extension, e.g.

```
X509v3 Subject Alternative Name: 
     DNS:192.168.121.167
```

which is incorrect and certificate does not validate when accessing service via IP, should be:

```
X509v3 Subject Alternative Name: 
     IP Address:192.168.121.167
```

I will forward-port this to `branch/3.1` and `master` as well.