### PR TITLE
[3.1] Sort out principals into DNS names and IP addresses.

### DIFF
--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"net"
 	"time"
 
 	"github.com/gravitational/teleport"
@@ -178,8 +179,16 @@ func (ca *CertAuthority) GenerateCertificate(req CertificateRequest) ([]byte, er
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		// BasicConstraintsValid is true to not allow any intermediate certs.
 		BasicConstraintsValid: true,
-		IsCA:     false,
-		DNSNames: req.DNSNames,
+		IsCA: false,
+	}
+
+	// sort out principals into DNS names and IP addresses
+	for i := range req.DNSNames {
+		if ip := net.ParseIP(req.DNSNames[i]); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, req.DNSNames[i])
+		}
 	}
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, ca.Cert, req.PublicKey, ca.Signer)

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tlsca
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509/pkix"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/lib/fixtures"
+
+	"github.com/jonboulle/clockwork"
+	check "gopkg.in/check.v1"
+)
+
+func TestTLSCA(t *testing.T) { check.TestingT(t) }
+
+type TLSCASuite struct {
+	clock clockwork.Clock
+}
+
+var _ = check.Suite(&TLSCASuite{
+	clock: clockwork.NewFakeClock(),
+})
+
+// TestPrincipals makes sure that SAN extension of generated x509 cert gets
+// correctly set with DNS names and IP addresses based on the provided
+// principals.
+func (s *TLSCASuite) TestPrincipals(c *check.C) {
+	ca, err := New([]byte(fixtures.SigningCertPEM), []byte(fixtures.SigningKeyPEM))
+	c.Assert(err, check.IsNil)
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	c.Assert(err, check.IsNil)
+
+	hostnames := []string{"localhost", "example.com"}
+	ips := []string{"127.0.0.1", "192.168.1.1"}
+
+	certBytes, err := ca.GenerateCertificate(CertificateRequest{
+		Clock:     s.clock,
+		PublicKey: privateKey.Public(),
+		Subject:   pkix.Name{CommonName: "test"},
+		NotAfter:  s.clock.Now().Add(time.Hour),
+		DNSNames:  append(hostnames, ips...),
+	})
+	c.Assert(err, check.IsNil)
+
+	cert, err := ParseCertificatePEM(certBytes)
+	c.Assert(err, check.IsNil)
+	c.Assert(cert.DNSNames, check.DeepEquals, hostnames)
+	var certIPs []string
+	for _, ip := range cert.IPAddresses {
+		certIPs = append(certIPs, ip.String())
+	}
+	c.Assert(certIPs, check.DeepEquals, ips)
+}


### PR DESCRIPTION
Forward-port of https://github.com/gravitational/teleport/pull/2519 to 3.1.