### PR TITLE
Fetch certificate authorities during every login.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1603,6 +1603,12 @@ func (tc *TeleportClient) Login(ctx context.Context, activateKey bool) (*Key, er
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+
+		// Connect to the Auth Server of the main cluster
+		// and fetch the known hosts for this cluster.
+		if err := tc.UpdateTrustedCA(ctx, key.ClusterName); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return key, nil
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -438,12 +438,6 @@ func onLogin(cf *CLIConf) {
 	// Regular login without -i flag.
 	tc.SaveProfile("")
 
-	// Connect to the Auth Server and fetch the known hosts for this cluster.
-	err = tc.UpdateTrustedCA(cf.Context, key.ClusterName)
-	if err != nil {
-		utils.FatalError(err)
-	}
-
 	// Print status to show information of the logged in user. Update the
 	// command line flag (used to print status) for the proxy to make sure any
 	// advertised settings are picked up.


### PR DESCRIPTION
This commit fixes the problem when login
is initiated during another command, for example
'tsh ls' and misses code path that updated cert
authorities in the main module.

By moving code in the Login the change makes sure
that additional cert authorities are always fetched.