### PR TITLE
User experience enhancements for OpenSSH options.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -375,12 +375,11 @@
   revision = "c4048f792f70d207e6d8b9c1bf52319247f202b8"
 
 [[projects]]
-  branch = "master"
-  digest = "1:6104a01c77e5dbf8fa0385ad2e9a6b5338710fd640754b6afe18241f07ce3044"
+  digest = "1:f60d0b16dff12cd86152c8004638fca13231f51a45ccbafcb9f487a64a73db05"
   name = "github.com/gravitational/kingpin"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "52bc17adf63c0807b5e5b5d91350703630f621c7"
+  revision = "742f2714c145075a68df26ccc25bc05545310f3a"
 
 [[projects]]
   digest = "1:637144c8995935a3a02d03ade2d1374abeac2a47fdafb798a05642d3e19ff86c"
@@ -1099,6 +1098,7 @@
     "github.com/coreos/etcd/clientv3",
     "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",
     "github.com/coreos/etcd/mvcc/mvccpb",
+    "github.com/coreos/go-oidc/http",
     "github.com/coreos/go-oidc/jose",
     "github.com/coreos/go-oidc/oauth2",
     "github.com/coreos/go-oidc/oidc",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,7 +94,7 @@ ignored = ["github.com/Sirupsen/logrus"]
 
 [[constraint]]
   name = "github.com/gravitational/kingpin"
-  branch = "master"
+  revision = "742f2714c145075a68df26ccc25bc05545310f3a"
 
 [[constraint]]
   name = "github.com/gravitational/roundtrip"

--- a/tool/tsh/options.go
+++ b/tool/tsh/options.go
@@ -180,11 +180,23 @@ func parseOptions(opts []string) (Options, error) {
 }
 
 func splitOption(option string) (string, string, error) {
-	parts := strings.Fields(option)
+	parts := strings.FieldsFunc(option, fieldsFunc)
 
 	if len(parts) != 2 {
 		return "", "", trace.BadParameter("invalid format for option")
 	}
 
 	return parts[0], parts[1], nil
+}
+
+// fieldsFunc splits key-value pairs off ' ' and '='.
+func fieldsFunc(c rune) bool {
+	switch {
+	case c == ' ':
+		return true
+	case c == '=':
+		return true
+	default:
+		return false
+	}
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -43,6 +43,8 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
 	gops "github.com/google/gops/agent"
@@ -181,6 +183,9 @@ func Run(args []string, underTest bool) {
 	app.Flag("proxy", "SSH proxy address").Envar("TELEPORT_PROXY").StringVar(&cf.Proxy)
 	app.Flag("nocache", "do not cache cluster discovery locally").Hidden().BoolVar(&cf.NoCache)
 	app.Flag("user", fmt.Sprintf("SSH proxy user [%s]", localUser)).Envar("TELEPORT_USER").StringVar(&cf.Username)
+	app.Flag("option", "").Short('o').Hidden().AllowDuplicate().PreAction(func(ctx *kingpin.ParseContext) error {
+		return trace.BadParameter("invalid flag, perhaps you want to use this flag as tsh ssh -o?")
+	}).String()
 
 	app.Flag("ttl", "Minutes to live for a SSH session").Int32Var(&cf.MinsToLive)
 	app.Flag("identity", "Identity file").Short('i').StringVar(&cf.IdentityFileIn)
@@ -206,7 +211,7 @@ func Run(args []string, underTest bool) {
 	ssh.Flag("local", "Execute command on localhost after connecting to SSH node").Default("false").BoolVar(&cf.LocalExec)
 	ssh.Flag("tty", "Allocate TTY").Short('t').BoolVar(&cf.Interactive)
 	ssh.Flag("cluster", clusterHelp).Envar(clusterEnvVar).StringVar(&cf.SiteName)
-	ssh.Flag("option", "OpenSSH options in the format used in the configuration file").Short('o').StringsVar(&cf.Options)
+	ssh.Flag("option", "OpenSSH options in the format used in the configuration file").Short('o').AllowDuplicate().StringsVar(&cf.Options)
 
 	// join
 	join := app.Command("join", "Join the active SSH session")
@@ -235,7 +240,7 @@ func Run(args []string, underTest bool) {
 	// login logs in with remote proxy and obtains a "session certificate" which gets
 	// stored in ~/.tsh directory
 	login := app.Command("login", "Log in to a cluster and retrieve the session certificate")
-	login.Flag("out", "Identity output").Short('o').StringVar(&cf.IdentityFileOut)
+	login.Flag("out", "Identity output").Short('o').AllowDuplicate().StringVar(&cf.IdentityFileOut)
 	login.Flag("format", fmt.Sprintf("Identity format [%s] or %s (for OpenSSH compatibility)",
 		client.DefaultIdentityFormat,
 		client.IdentityFormatOpenSSH)).Default(string(client.DefaultIdentityFormat)).StringVar((*string)(&cf.IdentityFormat))

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -153,6 +153,19 @@ func (s *MainTestSuite) TestOptions(c *check.C) {
 				StrictHostKeyChecking: true,
 			},
 		},
+		// Valid
+		{
+			inOptions: []string{
+				"AddKeysToAgent=yes",
+			},
+			outError: false,
+			outOptions: Options{
+				AddKeysToAgent:        true,
+				ForwardAgent:          false,
+				RequestTTY:            false,
+				StrictHostKeyChecking: true,
+			},
+		},
 		// Invalid value.
 		{
 			inOptions: []string{

--- a/vendor/github.com/gravitational/kingpin/app.go
+++ b/vendor/github.com/gravitational/kingpin/app.go
@@ -305,6 +305,9 @@ func checkDuplicateFlags(current *CmdClause, flagGroups []*flagGroup) error {
 	// Check for duplicates.
 	for _, flags := range flagGroups {
 		for _, flag := range current.flagOrder {
+			if flag.allowDuplicate {
+				continue
+			}
 			if flag.shorthand != 0 {
 				if _, ok := flags.short[string(flag.shorthand)]; ok {
 					return fmt.Errorf("duplicate short flag -%c", flag.shorthand)

--- a/vendor/github.com/gravitational/kingpin/flags.go
+++ b/vendor/github.com/gravitational/kingpin/flags.go
@@ -64,6 +64,9 @@ func (f *flagGroup) checkDuplicates() error {
 	seenShort := map[byte]bool{}
 	seenLong := map[string]bool{}
 	for _, flag := range f.flagOrder {
+		if flag.allowDuplicate {
+			continue
+		}
 		if flag.shorthand != 0 {
 			if _, ok := seenShort[flag.shorthand]; ok {
 				return fmt.Errorf("duplicate short flag -%c", flag.shorthand)
@@ -167,6 +170,9 @@ type FlagClause struct {
 	defaultValues []string
 	placeholder   string
 	hidden        bool
+
+	// allowDuplicate allows this flag to be repeated.
+	allowDuplicate bool
 }
 
 func newFlag(name, help string) *FlagClause {
@@ -225,6 +231,12 @@ func (f *FlagClause) init() error {
 		return fmt.Errorf("invalid default for '--%s', expecting single value", f.name)
 	}
 	return nil
+}
+
+// AllowDuplicate allows this flag to be repeated.
+func (f *FlagClause) AllowDuplicate() *FlagClause {
+	f.allowDuplicate = true
+	return f
 }
 
 // Dispatch to the given function after the flag is parsed and validated.


### PR DESCRIPTION
**Purpose**

User experience enhancements for OpenSSH options.

**Implementation**

* Added support for key=value syntax for OpenSSH options.
* Show helpful error message when the `-o` flag is in the wrong position.

Note, this PR depends on https://github.com/gravitational/kingpin/pull/4.

**Related Issues**

https://github.com/gravitational/teleport/issues/2330
https://github.com/gravitational/kingpin/pull/4