### PR TITLE
Increase SSO callback timeout to 180 seconds.

### DIFF
--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
 
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
@@ -276,8 +277,8 @@ func SSHAgentSSOLogin(ctx context.Context, proxyAddr, connectorID string, pubKey
 	case response := <-waitC:
 		log.Debugf("Got response from browser.")
 		return response, nil
-	case <-time.After(60 * time.Second):
-		log.Debugf("Timed out waiting for callback.")
+	case <-time.After(defaults.CallbackTimeout):
+		log.Debugf("Timed out waiting for callback after %v.", defaults.CallbackTimeout)
 		return nil, trace.Wrap(trace.Errorf("timed out waiting for callback"))
 	case <-ctx.Done():
 		log.Debugf("Canceled by user.")

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -220,6 +220,10 @@ const (
 	// AnyAddress is used to refer to the non-routable meta-address used to
 	// refer to all addresses on the machine.
 	AnyAddress = "0.0.0.0"
+
+	// CallbackTimeout is how long to wait for a response from SSO provider
+	// before timeout.
+	CallbackTimeout = 180 * time.Second
 )
 
 var (


### PR DESCRIPTION
**Purpose**

Increase SSO callback timeout to 180 seconds.

**Implementation**

Increase SSO callback timeout to 180 seconds.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2483