### PR TITLE
Convert "permission denied" errors into trace errors.

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -71,8 +71,13 @@ func (cfg *TestAuthServerConfig) CheckAndSetDefaults() error {
 
 // CreateUploaderDir creates directory for file uploader service
 func CreateUploaderDir(dir string) error {
-	return os.MkdirAll(filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload,
+	err := os.MkdirAll(filepath.Join(dir, teleport.LogsDir, teleport.ComponentUpload,
 		events.SessionLogsDir, defaults.Namespace), teleport.SharedDirMode)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+
+	return nil
 }
 
 // TestAuthServer is auth server using local filesystem backend

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -413,7 +413,7 @@ func (fs *FSLocalKeyStore) dirFor(proxyHost string, create bool) (string, error)
 	if create {
 		if err := os.MkdirAll(dirPath, profileDirPerms); err != nil {
 			fs.log.Error(err)
-			return "", trace.Wrap(err)
+			return "", trace.ConvertSystemError(err)
 		}
 	}
 
@@ -439,7 +439,7 @@ func initKeysDir(dirPath string) (string, error) {
 		if os.IsNotExist(err) {
 			err = os.MkdirAll(dirPath, os.ModeDir|profileDirPerms)
 			if err != nil {
-				return "", trace.Wrap(err)
+				return "", trace.ConvertSystemError(err)
 			}
 		} else {
 			return "", trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -486,7 +486,7 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 	if os.IsNotExist(err) {
 		err := os.MkdirAll(cfg.DataDir, os.ModeDir|0700)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.ConvertSystemError(err)
 		}
 	}
 

--- a/lib/sshutils/scp/local.go
+++ b/lib/sshutils/scp/local.go
@@ -45,7 +45,7 @@ func (l *localFileSystem) MkDir(path string, mode int) error {
 	fileMode := os.FileMode(mode & int(os.ModePerm))
 	err := os.MkdirAll(path, fileMode)
 	if err != nil && !os.IsExist(err) {
-		return trace.Wrap(err)
+		return trace.ConvertSystemError(err)
 	}
 
 	return nil


### PR DESCRIPTION
**Purpose**

Convert "permission denied" errors into trace errors.

**Implementation**

For the error to be printed correctly, the OS "permission denied" error needs to be converted into a trace error.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2525