### PR TITLE
Use xdg-open to open a default browser

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -492,7 +492,7 @@ const (
 
 const (
 	// OpenBrowserLinux is the command used to open a web browser on Linux.
-	OpenBrowserLinux = "sensible-browser"
+	OpenBrowserLinux = "xdg-open"
 
 	// OpenBrowserDarwin is the command used to open a web browser on macOS/Darwin.
 	OpenBrowserDarwin = "open"


### PR DESCRIPTION
As `sensible-browser` would not always open a default browser, the `xdg-open` command is going to be used instead. The `sensible-browser` will be used as a fallback.

Addresses #2454 