### PR TITLE
Added support for directory mode to scp.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1163,6 +1163,15 @@ func (tc *TeleportClient) SCP(ctx context.Context, args []string, port int, recu
 	}
 	// upload:
 	if isRemoteDest(last) {
+		filesToUpload := args[:len(args)-1]
+
+		// If more than a single file were provided, scp must be in directory mode
+		// and the target on the remote host needs to be a directory.
+		var directoryMode bool
+		if len(filesToUpload) > 1 {
+			directoryMode = true
+		}
+
 		login, host, dest := scp.ParseSCPDestination(last)
 		if login != "" {
 			tc.HostLogin = login
@@ -1175,14 +1184,15 @@ func (tc *TeleportClient) SCP(ctx context.Context, args []string, port int, recu
 		}
 
 		// copy everything except the last arg (that's destination)
-		for _, src := range args[:len(args)-1] {
+		for _, src := range filesToUpload {
 			scpConfig := scp.Config{
 				User:           tc.Username,
 				ProgressWriter: progressWriter,
 				RemoteLocation: dest,
 				Flags: scp.Flags{
-					Target:    []string{src},
-					Recursive: recursive,
+					Target:        []string{src},
+					Recursive:     recursive,
+					DirectoryMode: directoryMode,
 				},
 			}
 

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -126,7 +126,7 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 	scpc.Flag("f", "source mode (data producer)").Short('f').Default("false").BoolVar(&scpFlags.Source)
 	scpc.Flag("v", "verbose mode").Default("false").Short('v').BoolVar(&scpFlags.Verbose)
 	scpc.Flag("r", "recursive mode").Default("false").Short('r').BoolVar(&scpFlags.Recursive)
-	scpc.Flag("d", "directory mode").Short('d').Hidden().Bool()
+	scpc.Flag("d", "directory mode").Short('d').Hidden().BoolVar(&scpFlags.DirectoryMode)
 	scpc.Flag("remote-addr", "address of the remote client").StringVar(&scpFlags.RemoteAddr)
 	scpc.Flag("local-addr", "local address which accepted the request").StringVar(&scpFlags.LocalAddr)
 	scpc.Arg("target", "").StringsVar(&scpFlags.Target)


### PR DESCRIPTION
**Purpose**

Added support for directory mode `-d` flag similar to OpenSSH. This is to prevent a bug where the remote target file was clobbered when multiple source files were specified.

**Implementation**

* On the client side, make sure directory mode is requested when sending multiple files.
* On the server side, when in directory mode, validate that the target is a directory.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2094