### PR TITLE
Do not override syslog target, fixes #2550

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -297,6 +297,9 @@ const (
 
 	// HumanDateFormatMilli is a human readable date formatting with milliseconds
 	HumanDateFormatMilli = "Jan _2 15:04:05.000 UTC"
+
+	// DebugLevel is a debug logging level name
+	DebugLevel = "debug"
 )
 
 // Component generates "component:subcomponent1:subcomponent2" strings used

--- a/lib/utils/syslog.go
+++ b/lib/utils/syslog.go
@@ -23,21 +23,23 @@ import (
 	"log/syslog"
 	"os"
 
+	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	logrusSyslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 // SwitchLoggingtoSyslog tells the logger to send the output to syslog. This
 // code is behind a build flag because Windows does not support syslog.
-func SwitchLoggingtoSyslog() {
+func SwitchLoggingtoSyslog() error {
 	log.StandardLogger().SetHooks(make(log.LevelHooks))
 	hook, err := logrusSyslog.NewSyslogHook("", "", syslog.LOG_WARNING, "")
 	if err != nil {
-		// syslog not available
+		// syslog is not available
 		log.SetOutput(os.Stderr)
-	} else {
-		// ... and disable stderr:
-		log.AddHook(hook)
-		log.SetOutput(ioutil.Discard)
+		return trace.Wrap(err)
 	}
+	log.AddHook(hook)
+	// ... and disable stderr:
+	log.SetOutput(ioutil.Discard)
+	return nil
 }


### PR DESCRIPTION
Whenever teleport was started with -d flag,
output target was always overwritten to stderr.

This commit makes sure that target supplied
in the configuration is not overwritten
even in case when -d flag is set.