### PR TITLE
Don't use cache when building Docker image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ install: build
 .PHONY: image
 image:
 	cp ./build.assets/charts/Dockerfile $(BUILDDIR)/
-	cd $(BUILDDIR) && docker build . -t quay.io/gravitational/teleport:$(VERSION)
+	cd $(BUILDDIR) && docker build --no-cache . -t quay.io/gravitational/teleport:$(VERSION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e image; fi
 
 .PHONY: publish


### PR DESCRIPTION
Add the --no-cache flag to docker build so that "apt-get update &&
apt-get upgrade" are run on every image build.