### PR TITLE
Marshal YAML as list of documents, fixes #2479

### DIFF
--- a/lib/utils/jsontools.go
+++ b/lib/utils/jsontools.go
@@ -18,12 +18,15 @@ package utils
 
 import (
 	"bytes"
+	"io"
+	"reflect"
 	"unicode"
 
 	"github.com/gravitational/trace"
 
 	"github.com/ghodss/yaml"
 	"github.com/json-iterator/go"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // ToJSON converts a single YAML document into a JSON document
@@ -76,4 +79,88 @@ func FastMarshal(v interface{}) ([]byte, error) {
 	}
 
 	return data, nil
+}
+
+const yamlDocDelimiter = "---"
+
+// WriteYAML detects whether value is a list
+// and marshals multiple documents delimited by `---`, otherwise, marshals
+// a single value
+func WriteYAML(w io.Writer, values interface{}) error {
+	if reflect.TypeOf(values).Kind() != reflect.Slice {
+		return trace.Wrap(writeYAML(w, values))
+	}
+	// first pass makes sure that all values are documents (objects or maps)
+	slice := reflect.ValueOf(values)
+	allDocs := func() bool {
+		for i := 0; i < slice.Len(); i++ {
+			if !isDoc(slice.Index(i)) {
+				return false
+			}
+		}
+		return true
+	}
+	if !allDocs() {
+		return trace.Wrap(writeYAML(w, values))
+	}
+	// second pass can marshal documents
+	for i := 0; i < slice.Len(); i++ {
+		err := writeYAML(w, slice.Index(i).Interface())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if i != slice.Len()-1 {
+			if _, err := w.Write([]byte(yamlDocDelimiter + "\n")); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+	return nil
+}
+
+// isDoc detects whether value constitues a document
+func isDoc(val reflect.Value) bool {
+	iterations := 0
+	for val.Kind() == reflect.Interface || val.Kind() == reflect.Ptr {
+		val = val.Elem()
+		// preventing cycles
+		iterations++
+		if iterations > 10 {
+			return false
+		}
+	}
+	return val.Kind() == reflect.Struct || val.Kind() == reflect.Map
+}
+
+// writeYAML writes marshaled YAML to writer
+func writeYAML(w io.Writer, values interface{}) error {
+	data, err := yaml.Marshal(values)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = w.Write(data)
+	return trace.Wrap(err)
+}
+
+// ReadYAML can unmarshal a stream of documents, used in tests.
+func ReadYAML(reader io.Reader) (interface{}, error) {
+	decoder := kyaml.NewYAMLOrJSONDecoder(reader, 32*1024)
+	var values []interface{}
+	for {
+		var val interface{}
+		err := decoder.Decode(&val)
+		if err != nil {
+			if err == io.EOF {
+				if len(values) == 0 {
+					return nil, trace.BadParameter("no resources found, empty input?")
+				}
+				if len(values) == 1 {
+					return values[0], nil
+				}
+				return values, nil
+			}
+			return nil, trace.Wrap(err)
+		}
+		values = append(values, val)
+	}
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 
-	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 )
 
@@ -77,12 +76,7 @@ func (r *roleCollection) toMarshal() interface{} {
 }
 
 func (r *roleCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(r.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, r.toMarshal())
 }
 
 type namespaceCollection struct {
@@ -115,12 +109,7 @@ func (n *namespaceCollection) toMarshal() interface{} {
 }
 
 func (n *namespaceCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(n.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, n.toMarshal())
 }
 
 func printActions(rules []services.Rule) string {
@@ -174,12 +163,7 @@ func (s *serverCollection) toMarshal() interface{} {
 }
 
 func (r *serverCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(r.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, r.toMarshal())
 }
 
 type userCollection struct {
@@ -212,12 +196,7 @@ func (s *userCollection) toMarshal() interface{} {
 }
 
 func (r *userCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(r.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, r.toMarshal())
 }
 
 type authorityCollection struct {
@@ -267,12 +246,7 @@ func (a *authorityCollection) toMarshal() interface{} {
 }
 
 func (a *authorityCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(a.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, a.toMarshal())
 }
 
 type reverseTunnelCollection struct {
@@ -307,12 +281,7 @@ func (r *reverseTunnelCollection) toMarshal() interface{} {
 }
 
 func (r *reverseTunnelCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(r.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, r.toMarshal())
 }
 
 type oidcCollection struct {
@@ -347,12 +316,7 @@ func (c *oidcCollection) toMarshal() interface{} {
 }
 
 func (c *oidcCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(c.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, c.toMarshal())
 }
 
 type samlCollection struct {
@@ -385,12 +349,7 @@ func (c *samlCollection) toMarshal() interface{} {
 }
 
 func (c *samlCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(c.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, c.toMarshal())
 }
 
 type connectorsCollection struct {
@@ -462,12 +421,7 @@ func (c *connectorsCollection) toMarshal() interface{} {
 }
 
 func (c *connectorsCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(c.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, c.toMarshal())
 }
 
 type trustedClusterCollection struct {
@@ -508,12 +462,7 @@ func (c *trustedClusterCollection) toMarshal() interface{} {
 }
 
 func (c *trustedClusterCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(c.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, c.toMarshal())
 }
 
 type githubCollection struct {
@@ -547,12 +496,7 @@ func (c *githubCollection) toMarshal() interface{} {
 }
 
 func (c *githubCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(c.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, c.toMarshal())
 }
 
 func formatTeamsToLogins(mappings []services.TeamMapping) string {
@@ -602,10 +546,5 @@ func (c *remoteClusterCollection) toMarshal() interface{} {
 }
 
 func (c *remoteClusterCollection) writeYAML(w io.Writer) error {
-	data, err := yaml.Marshal(c.toMarshal())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	_, err = w.Write(data)
-	return trace.Wrap(err)
+	return utils.WriteYAML(w, c.toMarshal())
 }


### PR DESCRIPTION
This commit fixes an issue when tctl
output in YAML was not compatible with tctl create.

Before:

```
$ tctl get users

- User: value
- User: value
```

After:

```
$ tctl get users

User: value
---
User: value
```