### PR TITLE
Add Prometheus monitoring to the Audit Log.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -296,6 +296,12 @@ var (
 	// without receiving a response from the client before the client is
 	// disconnected. The max count mirrors ClientAliveCountMax of sshd.
 	KeepAliveCountMax = 3
+
+	// DiskAlertThreshold is the disk space alerting threshold.
+	DiskAlertThreshold = 90
+
+	// DiskAlertInterval is disk space check interval.
+	DiskAlertInterval = 5 * time.Minute
 )
 
 // Default connection limits, they can be applied separately on any of the Teleport


### PR DESCRIPTION
**Description**

Add a Prometheus gauge which can be used to monitor how much disk space
is used and a Prometheus counter which can be used to count the number
of events that failed to emit to the Audit Log.

**Related Issues**

Fixes https://github.com/gravitational/teleport.e/issues/103