### PR TITLE
Spelling fix: retreive -> retrieve in all docs

### DIFF
--- a/docs/2.3/admin-guide.md
+++ b/docs/2.3/admin-guide.md
@@ -798,7 +798,7 @@ Command         | Description | Examples
     attention to spaces vs tabs!
 
 Here's an example how the YAML resource definition for a user Joe might look like.
-It can be retreived by executing `tctl get user/joe`
+It can be retrieved by executing `tctl get user/joe`
 
 ```bash
 kind: user

--- a/docs/2.3/enterprise.md
+++ b/docs/2.3/enterprise.md
@@ -195,7 +195,7 @@ $ tsh --proxy=proxy.example.com login --auth=corporate
 ```
 
 The command above will print a URL which the user will have to visit to
-retreive an SSH certificate to be used to access SSH nodes.
+retrieve an SSH certificate to be used to access SSH nodes.
 
 Refer to the following pages for detailed guides of how to configure authentication
 connectors of both SAML and OIDC types:

--- a/docs/2.3/oidc.md
+++ b/docs/2.3/oidc.md
@@ -69,10 +69,10 @@ spec:
   client_id: "xxxxxxxx.example.com"
   client_secret: "zzzzzzzzzzzzzzzzzzzzzzzz"
   redirect_url: "https://teleport-proxy.example.com:3080/v1/webapi/oidc/callback"
-  # scope instructs Teleport to query for 'group' scope to retreive
+  # scope instructs Teleport to query for 'group' scope to retrieve
   # user's group membership
   scope: ["group"]
-  # once Teleport retreives the user's groups, this section configures
+  # once Teleport retrieves the user's groups, this section configures
   # the mapping from groups to Teleport roles
   claims_to_roles:
      - claim: "group"

--- a/docs/2.4/admin-guide.md
+++ b/docs/2.4/admin-guide.md
@@ -938,7 +938,7 @@ Command         | Description | Examples
     attention to spaces vs tabs!
 
 Here's an example how the YAML resource definition for a user Joe might look like.
-It can be retreived by executing `tctl get user/joe`
+It can be retrieved by executing `tctl get user/joe`
 
 ```bash
 kind: user

--- a/docs/2.4/enterprise.md
+++ b/docs/2.4/enterprise.md
@@ -195,7 +195,7 @@ $ tsh --proxy=proxy.example.com login --auth=corporate
 ```
 
 The command above will print a URL which the user will have to visit to
-retreive an SSH certificate to be used to access SSH nodes.
+retrieve an SSH certificate to be used to access SSH nodes.
 
 Refer to the following pages for detailed guides of how to configure authentication
 connectors of both SAML and OIDC types:

--- a/docs/2.4/oidc.md
+++ b/docs/2.4/oidc.md
@@ -69,10 +69,10 @@ spec:
   client_id: "xxxxxxxx.example.com"
   client_secret: "zzzzzzzzzzzzzzzzzzzzzzzz"
   redirect_url: "https://teleport-proxy.example.com:3080/v1/webapi/oidc/callback"
-  # scope instructs Teleport to query for 'group' scope to retreive
+  # scope instructs Teleport to query for 'group' scope to retrieve
   # user's group membership
   scope: ["group"]
-  # once Teleport retreives the user's groups, this section configures
+  # once Teleport retrieves the user's groups, this section configures
   # the mapping from groups to Teleport roles
   claims_to_roles:
      - claim: "group"

--- a/docs/2.5/admin-guide.md
+++ b/docs/2.5/admin-guide.md
@@ -1007,7 +1007,7 @@ Command         | Description | Examples
     attention to spaces vs tabs!
 
 Here's an example how the YAML resource definition for a user Joe might look like.
-It can be retreived by executing `tctl get user/joe`
+It can be retrieved by executing `tctl get user/joe`
 
 ```bash
 kind: user

--- a/docs/2.5/enterprise.md
+++ b/docs/2.5/enterprise.md
@@ -60,7 +60,7 @@ Teleport.
 
 ## SSO
 
-The commercial edition of Teleport allows users to retreive their SSH
+The commercial edition of Teleport allows users to retrieve their SSH
 credentials via a [single sign-on](https://en.wikipedia.org/wiki/Single_sign-on) 
 (SSO) system used by the rest of the organization. 
 
@@ -75,7 +75,7 @@ or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
 ### How does SSO work with SSH?
 
-From the user's perspective they need to execute the following command to retreive their SSH certificate.
+From the user's perspective they need to execute the following command to retrieve their SSH certificate.
 
 ```bash
 $ tsh login

--- a/docs/2.5/oidc.md
+++ b/docs/2.5/oidc.md
@@ -72,10 +72,10 @@ spec:
   client_id: "xxxxxxxx.example.com"
   client_secret: "zzzzzzzzzzzzzzzzzzzzzzzz"
   redirect_url: "https://teleport-proxy.example.com:3080/v1/webapi/oidc/callback"
-  # scope instructs Teleport to query for 'group' scope to retreive
+  # scope instructs Teleport to query for 'group' scope to retrieve
   # user's group membership
   scope: ["group"]
-  # once Teleport retreives the user's groups, this section configures
+  # once Teleport retrieves the user's groups, this section configures
   # the mapping from groups to Teleport roles
   claims_to_roles:
      - claim: "group"

--- a/docs/2.5/ssh_sso.md
+++ b/docs/2.5/ssh_sso.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The commercial edition of Teleport allows users to retreive their SSH
+The commercial edition of Teleport allows users to retrieve their SSH
 credentials through a [Single Sign-On](https://en.wikipedia.org/wiki/Single_sign-on) 
 (SSO) system used by the rest of the organization. 
 
@@ -17,7 +17,7 @@ or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
 ## How does SSO work with SSH?
 
-From the user's perspective they need to execute the following command to retreive their SSH certificate.
+From the user's perspective they need to execute the following command to retrieve their SSH certificate.
 
 ```bash
 $ tsh login

--- a/docs/2.5/trustedclusters.md
+++ b/docs/2.5/trustedclusters.md
@@ -319,8 +319,8 @@ how your network security groups are configured on AWS.
 Troubleshooting access denied messages can be challenging. A Teleport administrator
 should check to see the following:
 
-* Which roles a user is assigned on "main" when they retreive their SSH
-  certificate via `tsh login`. You can inspect the retreived certificate with
+* Which roles a user is assigned on "main" when they retrieve their SSH
+  certificate via `tsh login`. You can inspect the retrieved certificate with
   `tsh status` command on the client side.
 * Which roles a user is assigned on "east" when the role mapping takes place.
   The role mapping result is reflected in the Teleport audit log. By default,

--- a/docs/2.5/user-manual.md
+++ b/docs/2.5/user-manual.md
@@ -58,7 +58,7 @@ $ tsh ssh --proxy=work.example.com node
 
 ## Logging In
 
-To retreive a user's certificate, execute:
+To retrieve a user's certificate, execute:
 
 ```bash
 # Full form:
@@ -80,7 +80,7 @@ https_proxy_port   | the HTTPS port the proxy host is listening to. defaults to 
 ssh_proxy_port     | the SSH port the proxy is listening to. defaults to 3023.
 
 
-The login command retreives a user's certificate and stores it 
+The login command retrieves a user's certificate and stores it 
 in `~/.tsh` directory as well as in the [ssh agent](https://en.wikipedia.org/wiki/Ssh-agent), 
 if there is one running.
 

--- a/docs/2.7/admin-guide.md
+++ b/docs/2.7/admin-guide.md
@@ -1035,7 +1035,7 @@ Command         | Description | Examples
     attention to spaces vs tabs!
 
 Here's an example how the YAML resource definition for a user Joe might look like.
-It can be retreived by executing `tctl get user/joe`
+It can be retrieved by executing `tctl get user/joe`
 
 ```bash
 kind: user

--- a/docs/2.7/enterprise.md
+++ b/docs/2.7/enterprise.md
@@ -60,7 +60,7 @@ Teleport.
 
 ## SSO
 
-The commercial edition of Teleport allows users to retreive their SSH
+The commercial edition of Teleport allows users to retrieve their SSH
 credentials via a [single sign-on](https://en.wikipedia.org/wiki/Single_sign-on) 
 (SSO) system used by the rest of the organization. 
 
@@ -75,7 +75,7 @@ or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
 ### How does SSO work with SSH?
 
-From the user's perspective they need to execute the following command to retreive their SSH certificate.
+From the user's perspective they need to execute the following command to retrieve their SSH certificate.
 
 ```bash
 $ tsh login

--- a/docs/2.7/oidc.md
+++ b/docs/2.7/oidc.md
@@ -72,10 +72,10 @@ spec:
   client_id: "xxxxxxxx.example.com"
   client_secret: "zzzzzzzzzzzzzzzzzzzzzzzz"
   redirect_url: "https://teleport-proxy.example.com:3080/v1/webapi/oidc/callback"
-  # scope instructs Teleport to query for 'group' scope to retreive
+  # scope instructs Teleport to query for 'group' scope to retrieve
   # user's group membership
   scope: ["group"]
-  # once Teleport retreives the user's groups, this section configures
+  # once Teleport retrieves the user's groups, this section configures
   # the mapping from groups to Teleport roles
   claims_to_roles:
      - claim: "group"

--- a/docs/2.7/ssh_sso.md
+++ b/docs/2.7/ssh_sso.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The commercial edition of Teleport allows users to retreive their SSH
+The commercial edition of Teleport allows users to retrieve their SSH
 credentials through a [Single Sign-On](https://en.wikipedia.org/wiki/Single_sign-on) 
 (SSO) system used by the rest of the organization. 
 
@@ -17,7 +17,7 @@ or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
 ## How does SSO work with SSH?
 
-From the user's perspective they need to execute the following command to retreive their SSH certificate.
+From the user's perspective they need to execute the following command to retrieve their SSH certificate.
 
 ```bash
 $ tsh login

--- a/docs/2.7/trustedclusters.md
+++ b/docs/2.7/trustedclusters.md
@@ -319,8 +319,8 @@ how your network security groups are configured on AWS.
 Troubleshooting access denied messages can be challenging. A Teleport administrator
 should check to see the following:
 
-* Which roles a user is assigned on "main" when they retreive their SSH
-  certificate via `tsh login`. You can inspect the retreived certificate with
+* Which roles a user is assigned on "main" when they retrieve their SSH
+  certificate via `tsh login`. You can inspect the retrieved certificate with
   `tsh status` command on the client side.
 * Which roles a user is assigned on "east" when the role mapping takes place.
   The role mapping result is reflected in the Teleport audit log. By default,

--- a/docs/2.7/user-manual.md
+++ b/docs/2.7/user-manual.md
@@ -58,7 +58,7 @@ $ tsh ssh --proxy=work.example.com node
 
 ## Logging In
 
-To retreive a user's certificate, execute:
+To retrieve a user's certificate, execute:
 
 ```bash
 # Full form:
@@ -80,7 +80,7 @@ https_proxy_port   | the HTTPS port the proxy host is listening to. defaults to 
 ssh_proxy_port     | the SSH port the proxy is listening to. defaults to 3023.
 
 
-The login command retreives a user's certificate and stores it 
+The login command retrieves a user's certificate and stores it 
 in `~/.tsh` directory as well as in the [ssh agent](https://en.wikipedia.org/wiki/Ssh-agent), 
 if there is one running.
 

--- a/docs/3.0/admin-guide.md
+++ b/docs/3.0/admin-guide.md
@@ -1110,7 +1110,7 @@ Command         | Description | Examples
     attention to spaces vs tabs!
 
 Here's an example how the YAML resource definition for a user Joe might look like.
-It can be retreived by executing `tctl get user/joe`
+It can be retrieved by executing `tctl get user/joe`
 
 ```yaml
 kind: user
@@ -1676,7 +1676,7 @@ scp_if_ssh = True
 
 Teleport 3.0+ can be configured as a compliance gateway for Kubernetes
 clusters.  This allows users to authenticate against a Teleport proxy using
-`tsh login` command to retreive credentials for both SSH and Kubernetes API.
+`tsh login` command to retrieve credentials for both SSH and Kubernetes API.
 
 Below is a high-level diagram of how Teleport can be deployed in front of
 a Kubernetes cluster:
@@ -1689,7 +1689,7 @@ section in the Architecture chapter.
 In the scenario illustrated above a user would execute the following commands:
 
 ```bsh
-# Authentication step to retreive the certificates. tsh login places the SSH
+# Authentication step to retrieve the certificates. tsh login places the SSH
 # certificate into `~/.tsh` as usual and updates kubeconfig with Kubernetes
 # credentials:
 $ tsh --proxy=teleport.example.com login

--- a/docs/3.0/architecture.md
+++ b/docs/3.0/architecture.md
@@ -471,7 +471,7 @@ clusters. This enables the following capabilities:
 * A Teleport Proxy becomes a single authentication endpoint for both SSH and
   Kubernetes.
 * Users authenticate against a Teleport proxy using `tsh login` command and
-  retreive credentials for both SSH and Kubernetes API.
+  retrieve credentials for both SSH and Kubernetes API.
 * Users' RBAC roles are always synchronized between SSH and Kubernetes, making
   it easier to implement policies like _developers must not access production
   data_.
@@ -488,7 +488,7 @@ clusters. This enables the following capabilities:
 As shown in the diagram above:
 
 * A user executes `tsh login` against a Teleport proxy as usual.
-* `tsh login` retreives the short lived x509 and SSH certificates issued by the Telepoort CA (auth server).
+* `tsh login` retrieves the short lived x509 and SSH certificates issued by the Telepoort CA (auth server).
    The user's kubernetes configuration (kubeconfig) is updated with x509 certs and
    credentials and now points to the Teleport proxy as the Kubernetes API endpoint.
 * All Kubernetes API requests now go through the Teleport proxy.

--- a/docs/3.0/enterprise.md
+++ b/docs/3.0/enterprise.md
@@ -49,7 +49,7 @@ Teleport.
 
 ## SSO
 
-The commercial edition of Teleport allows users to retreive their SSH
+The commercial edition of Teleport allows users to retrieve their SSH
 credentials via a [single sign-on](https://en.wikipedia.org/wiki/Single_sign-on) 
 (SSO) system used by the rest of the organization. 
 
@@ -64,7 +64,7 @@ or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
 ### How does SSO work with SSH?
 
-From the user's perspective they need to execute the following command to retreive their SSH certificate.
+From the user's perspective they need to execute the following command to retrieve their SSH certificate.
 
 ```bash
 $ tsh login

--- a/docs/3.0/oidc.md
+++ b/docs/3.0/oidc.md
@@ -73,11 +73,11 @@ spec:
   client_secret: "zzzzzzzzzzzzzzzzzzzzzzzz"
   redirect_url: "https://teleport-proxy.example.com:3080/v1/webapi/oidc/callback"
 
-  # scope instructs Teleport to query for 'group' scope to retreive
+  # scope instructs Teleport to query for 'group' scope to retrieve
   # user's group membership
   scope: ["group"]
 
-  # once Teleport retreives the user's groups, this section configures
+  # once Teleport retrieves the user's groups, this section configures
   # the mapping from groups to Teleport roles
   claims_to_roles:
      - { claim: "group", value: "admin", roles: ["admin"] }

--- a/docs/3.0/ssh_sso.md
+++ b/docs/3.0/ssh_sso.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The commercial edition of Teleport allows users to retreive their SSH
+The commercial edition of Teleport allows users to retrieve their SSH
 credentials through a [Single Sign-On](https://en.wikipedia.org/wiki/Single_sign-on)
 (SSO) system used by the rest of the organization.
 
@@ -17,7 +17,7 @@ or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
 ## How does SSO work with SSH?
 
-From the user's perspective they need to execute the following command to retreive their SSH certificate.
+From the user's perspective they need to execute the following command to retrieve their SSH certificate.
 
 ```bsh
 $ tsh login

--- a/docs/3.0/trustedclusters.md
+++ b/docs/3.0/trustedclusters.md
@@ -342,8 +342,8 @@ how your network security groups are configured on AWS.
 Troubleshooting access denied messages can be challenging. A Teleport administrator
 should check to see the following:
 
-* Which roles a user is assigned on "main" when they retreive their SSH
-  certificate via `tsh login`. You can inspect the retreived certificate with
+* Which roles a user is assigned on "main" when they retrieve their SSH
+  certificate via `tsh login`. You can inspect the retrieved certificate with
   `tsh status` command on the client side.
 * Which roles a user is assigned on "east" when the role mapping takes place.
   The role mapping result is reflected in the Teleport audit log. By default,

--- a/docs/3.0/user-manual.md
+++ b/docs/3.0/user-manual.md
@@ -58,7 +58,7 @@ $ tsh ssh --proxy=work.example.com node
 
 ## Logging In
 
-To retreive a user's certificate, execute:
+To retrieve a user's certificate, execute:
 
 ```bash
 # Full form:
@@ -80,7 +80,7 @@ https_proxy_port   | the HTTPS port the proxy host is listening to (defaults to 
 ssh_proxy_port     | the SSH port the proxy is listening to (defaults to 3023).
 
 
-The login command retreives a user's certificate and stores it 
+The login command retrieves a user's certificate and stores it 
 in `~/.tsh` directory as well as in the [ssh agent](https://en.wikipedia.org/wiki/Ssh-agent), 
 if there is one running.
 

--- a/docs/3.1/admin-guide.md
+++ b/docs/3.1/admin-guide.md
@@ -1229,7 +1229,7 @@ Command         | Description | Examples
     attention to spaces vs tabs!
 
 Here's an example how the YAML resource definition for a user Joe might look like.
-It can be retreived by executing `tctl get user/joe`
+It can be retrieved by executing `tctl get user/joe`
 
 ```yaml
 kind: user
@@ -1797,7 +1797,7 @@ scp_if_ssh = True
 
 Teleport 3.0+ can be configured as a compliance gateway for Kubernetes
 clusters.  This allows users to authenticate against a Teleport proxy using
-`tsh login` command to retreive credentials for both SSH and Kubernetes API.
+`tsh login` command to retrieve credentials for both SSH and Kubernetes API.
 
 Below is a high-level diagram of how Teleport can be deployed in front of
 a Kubernetes cluster:
@@ -1810,7 +1810,7 @@ section in the Architecture chapter.
 In the scenario illustrated above a user would execute the following commands:
 
 ```bsh
-# Authentication step to retreive the certificates. tsh login places the SSH
+# Authentication step to retrieve the certificates. tsh login places the SSH
 # certificate into `~/.tsh` as usual and updates kubeconfig with Kubernetes
 # credentials:
 $ tsh --proxy=teleport.example.com login

--- a/docs/3.1/architecture.md
+++ b/docs/3.1/architecture.md
@@ -471,7 +471,7 @@ clusters. This enables the following capabilities:
 * A Teleport Proxy becomes a single authentication endpoint for both SSH and
   Kubernetes.
 * Users authenticate against a Teleport proxy using `tsh login` command and
-  retreive credentials for both SSH and Kubernetes API.
+  retrieve credentials for both SSH and Kubernetes API.
 * Users' RBAC roles are always synchronized between SSH and Kubernetes, making
   it easier to implement policies like _developers must not access production
   data_.
@@ -488,7 +488,7 @@ clusters. This enables the following capabilities:
 As shown in the diagram above:
 
 * A user executes `tsh login` against a Teleport proxy as usual.
-* `tsh login` retreives the short lived x509 and SSH certificates issued by the Telepoort CA (auth server).
+* `tsh login` retrieves the short lived x509 and SSH certificates issued by the Telepoort CA (auth server).
    The user's kubernetes configuration (kubeconfig) is updated with x509 certs and
    credentials and now points to the Teleport proxy as the Kubernetes API endpoint.
 * All Kubernetes API requests now go through the Teleport proxy.

--- a/docs/3.1/enterprise.md
+++ b/docs/3.1/enterprise.md
@@ -49,7 +49,7 @@ Teleport.
 
 ## SSO
 
-The commercial edition of Teleport allows users to retreive their SSH
+The commercial edition of Teleport allows users to retrieve their SSH
 credentials via a [single sign-on](https://en.wikipedia.org/wiki/Single_sign-on) 
 (SSO) system used by the rest of the organization. 
 
@@ -64,7 +64,7 @@ or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
 ### How does SSO work with SSH?
 
-From the user's perspective they need to execute the following command to retreive their SSH certificate.
+From the user's perspective they need to execute the following command to retrieve their SSH certificate.
 
 ```bash
 $ tsh login

--- a/docs/3.1/oidc.md
+++ b/docs/3.1/oidc.md
@@ -73,11 +73,11 @@ spec:
   client_secret: "zzzzzzzzzzzzzzzzzzzzzzzz"
   redirect_url: "https://teleport-proxy.example.com:3080/v1/webapi/oidc/callback"
 
-  # scope instructs Teleport to query for 'group' scope to retreive
+  # scope instructs Teleport to query for 'group' scope to retrieve
   # user's group membership
   scope: ["group"]
 
-  # once Teleport retreives the user's groups, this section configures
+  # once Teleport retrieves the user's groups, this section configures
   # the mapping from groups to Teleport roles
   claims_to_roles:
      - { claim: "group", value: "admin", roles: ["admin"] }

--- a/docs/3.1/trustedclusters.md
+++ b/docs/3.1/trustedclusters.md
@@ -342,8 +342,8 @@ how your network security groups are configured on AWS.
 Troubleshooting access denied messages can be challenging. A Teleport administrator
 should check to see the following:
 
-* Which roles a user is assigned on "main" when they retreive their SSH
-  certificate via `tsh login`. You can inspect the retreived certificate with
+* Which roles a user is assigned on "main" when they retrieve their SSH
+  certificate via `tsh login`. You can inspect the retrieved certificate with
   `tsh status` command on the client side.
 * Which roles a user is assigned on "east" when the role mapping takes place.
   The role mapping result is reflected in the Teleport audit log. By default,

--- a/docs/3.1/user-manual.md
+++ b/docs/3.1/user-manual.md
@@ -92,7 +92,7 @@ $ tsh ssh --proxy=work.example.com --user=joe root@node
 
 ## Logging In
 
-To retreive a user's certificate, execute:
+To retrieve a user's certificate, execute:
 
 ```bash
 # Full form:
@@ -114,7 +114,7 @@ https_proxy_port   | the HTTPS port the proxy host is listening to (defaults to 
 ssh_proxy_port     | the SSH port the proxy is listening to (defaults to 3023).
 
 
-The login command retreives a user's certificate and stores it 
+The login command retrieves a user's certificate and stores it 
 in `~/.tsh` directory as well as in the [ssh agent](https://en.wikipedia.org/wiki/Ssh-agent), 
 if there is one running.
 
@@ -283,7 +283,7 @@ using familiar SSH syntax:
 # Have this alias configured, perhaps via ~/.bashrc
 $ alias ssh=/usr/local/bin/tsh
 
-# Login into a cluster and retreive your SSH certificate:
+# Login into a cluster and retrieve your SSH certificate:
 $ tsh --proxy=proxy.example.com login
 
 # These commands execute `tsh ssh` under the hood:


### PR DESCRIPTION
Noticed a repeated typo and fixed it. Not sure if there's another step needed to edit/regenerate the live docs on the website?