### PR TITLE
Added support to allow deduplicate by key.

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -38,7 +38,7 @@ const (
 //
 type Backend interface {
 	// GetKeys returns a list of keys for a given path
-	GetKeys(bucket []string) ([]string, error)
+	GetKeys(bucket []string, opts ...OpOption) ([]string, error)
 	// GetItems returns a list of items (key value pairs) for a bucket.
 	GetItems(bucket []string, opts ...OpOption) ([]Item, error)
 	// CreateVal creates value with a given TTL and key in the bucket
@@ -73,10 +73,15 @@ type Backend interface {
 
 // OpConfig contains operation config
 type OpConfig struct {
-	// Recursive triggers recursive get
+	// Recursive triggers recursive get.
 	Recursive bool
-	// KeysOnly fetches only keys
+
+	// KeysOnly fetches only keys.
 	KeysOnly bool
+
+	// DeduplicateByKey removes duplicates based off key instead of the full path.
+	// Used for certain resources like users.
+	DeduplicateByKey bool
 }
 
 // OpOption is operation functional argument
@@ -86,6 +91,14 @@ type OpOption func(*OpConfig) error
 func WithRecursive() OpOption {
 	return func(o *OpConfig) error {
 		o.Recursive = true
+		return nil
+	}
+}
+
+// DeduplicateByKey removes duplicates based off key instead of the full path.
+func WithDeduplicateByKey() OpOption {
+	return func(o *OpConfig) error {
+		o.DeduplicateByKey = true
 		return nil
 	}
 }

--- a/lib/backend/boltbk/boltbk.go
+++ b/lib/backend/boltbk/boltbk.go
@@ -243,7 +243,7 @@ func (b *BoltBackend) GetItems(path []string, opts ...backend.OpOption) ([]backe
 	return items, nil
 }
 
-func (b *BoltBackend) GetKeys(path []string) ([]string, error) {
+func (b *BoltBackend) GetKeys(path []string, opts ...backend.OpOption) ([]string, error) {
 	keys, err := b.getKeys(path)
 	if err != nil {
 		if trace.IsNotFound(err) {

--- a/lib/backend/dir/impl.go
+++ b/lib/backend/dir/impl.go
@@ -116,9 +116,9 @@ func (bk *Backend) Close() error {
 }
 
 // GetKeys returns a list of keys for a given bucket.
-func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
+func (bk *Backend) GetKeys(bucket []string, opts ...backend.OpOption) ([]string, error) {
 	// Get all the key/value pairs for this bucket.
-	items, err := bk.GetItems(bucket)
+	items, err := bk.GetItems(bucket, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -134,6 +134,11 @@ func (bk *Backend) GetKeys(bucket []string) ([]string, error) {
 
 // GetItems returns all items (key/value pairs) in a given bucket.
 func (bk *Backend) GetItems(bucket []string, opts ...backend.OpOption) ([]backend.Item, error) {
+	options, err := backend.CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var out []backend.Item
 
 	// Get a list of all buckets in the backend.
@@ -200,7 +205,8 @@ func (bk *Backend) GetItems(bucket []string, opts ...backend.OpOption) ([]backen
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].Key < out[j].Key
 	})
-	out = removeDuplicates(out)
+
+	out = removeDuplicates(out, options.DeduplicateByKey)
 
 	return out, nil
 }
@@ -635,17 +641,26 @@ func suffix(pathToBucket string, bucketPrefix string) (string, error) {
 // removeDuplicates removes any duplicate items from the passed in slice. This
 // is to ensure that partial matches don't result in multiple values returned.
 // This is consistent with our DynamoDB implementation.
-func removeDuplicates(items []backend.Item) []backend.Item {
+func removeDuplicates(items []backend.Item, deduplicateByKey bool) []backend.Item {
 	// Use map to record duplicates as we find them.
 	encountered := map[string]bool{}
 	result := make([]backend.Item, 0, len(items))
 
 	// Loop over all items, if it has not been seen before, append to result.
 	for _, e := range items {
-		_, ok := encountered[e.FullPath]
+		var ok bool
+		if deduplicateByKey {
+			_, ok = encountered[e.Key]
+		} else {
+			_, ok = encountered[e.FullPath]
+		}
 		if !ok {
 			// Record this element as an encountered element.
-			encountered[e.FullPath] = true
+			if deduplicateByKey {
+				encountered[e.Key] = true
+			} else {
+				encountered[e.FullPath] = true
+			}
 
 			// Append to result slice.
 			result = append(result, e)

--- a/lib/backend/dir/impl_test.go
+++ b/lib/backend/dir/impl_test.go
@@ -159,6 +159,10 @@ func (s *Suite) TestDirectories(c *check.C) {
 	s.suite.Directories(c)
 }
 
+func (s *Suite) TestDeduplicate(c *check.C) {
+	s.suite.Deduplicate(c)
+}
+
 // TODO(russjones): Eventually this test should be removed and the one from
 // the suite should be used. For that to happen, some refactoring around the
 // clock needs to occur to expose clock.Advance to the suite across backends.

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -333,7 +333,12 @@ func (b *DynamoDBBackend) fullPath(bucket ...string) string {
 }
 
 // getRecords retrieve all prefixed keys
-func (b *DynamoDBBackend) getRecords(path string) ([]record, error) {
+func (b *DynamoDBBackend) getRecords(path string, opts ...backend.OpOption) ([]record, error) {
+	options, err := backend.CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var vals []record
 	query := "HashKey = :hashKey AND begins_with (FullPath, :fullPath)"
 	attrV := map[string]interface{}{
@@ -369,7 +374,7 @@ func (b *DynamoDBBackend) getRecords(path string) ([]record, error) {
 		}
 	}
 	sort.Sort(records(vals))
-	vals = removeDuplicates(vals)
+	vals = removeDuplicates(vals, options.DeduplicateByKey)
 	return vals, nil
 }
 
@@ -390,29 +395,40 @@ func suffix(key string) string {
 	return vals[0]
 }
 
-func removeDuplicates(elements []record) []record {
+func removeDuplicates(elements []record, deduplicateByKey bool) []record {
 	// Use map to record duplicates as we find them.
 	encountered := map[string]bool{}
-	result := []record{}
+	result := make([]record, 0, len(elements))
 
-	for v := range elements {
-		if encountered[elements[v].FullPath] == true {
-			// Do not add duplicate.
+	// Loop over all items, if it has not been seen before, append to result.
+	for _, e := range elements {
+		var ok bool
+		if deduplicateByKey {
+			_, ok = encountered[e.key]
 		} else {
+			_, ok = encountered[e.FullPath]
+		}
+
+		if !ok {
 			// Record this element as an encountered element.
-			encountered[elements[v].FullPath] = true
+			if deduplicateByKey {
+				encountered[e.key] = true
+			} else {
+				encountered[e.FullPath] = true
+			}
+
 			// Append to result slice.
-			result = append(result, elements[v])
+			result = append(result, e)
 		}
 	}
-	// Return the new slice.
+
 	return result
 }
 
 // GetItems is a function that returns keys in batch
 func (b *DynamoDBBackend) GetItems(path []string, opts ...backend.OpOption) ([]backend.Item, error) {
 	fullPath := b.fullPath(path...)
-	records, err := b.getRecords(fullPath)
+	records, err := b.getRecords(fullPath, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -427,8 +443,8 @@ func (b *DynamoDBBackend) GetItems(path []string, opts ...backend.OpOption) ([]b
 }
 
 // GetKeys retrieve all keys matching specific path
-func (b *DynamoDBBackend) GetKeys(path []string) ([]string, error) {
-	records, err := b.getRecords(b.fullPath(path...))
+func (b *DynamoDBBackend) GetKeys(path []string, opts ...backend.OpOption) ([]string, error) {
+	records, err := b.getRecords(b.fullPath(path...), opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -76,6 +76,10 @@ func (s *DynamoDBSuite) TestBatchCRUD(c *C) {
 	s.suite.BatchCRUD(c)
 }
 
+func (s *Suite) TestDeduplicate(c *check.C) {
+	s.suite.Deduplicate(c)
+}
+
 func (s *DynamoDBSuite) TestDirectories(c *C) {
 	s.suite.Directories(c)
 }

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -269,7 +269,7 @@ func (b *bk) GetItems(path []string, opts ...backend.OpOption) ([]backend.Item, 
 }
 
 // GetKeys fetches keys (and values) but only returns keys to the caller.
-func (b *bk) GetKeys(path []string) ([]string, error) {
+func (b *bk) GetKeys(path []string, opts ...backend.OpOption) ([]string, error) {
 	items, err := b.getItems(b.key(path...), backend.OpConfig{KeysOnly: true}, clientv3.WithSerializable(), clientv3.WithKeysOnly(), clientv3.WithPrefix())
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -61,12 +61,12 @@ func (s *Sanitizer) Backend() Backend {
 }
 
 // GetKeys returns a list of keys for a given path.
-func (s *Sanitizer) GetKeys(bucket []string) ([]string, error) {
+func (s *Sanitizer) GetKeys(bucket []string, opts ...OpOption) ([]string, error) {
 	if !isSliceSafe(bucket) {
 		return nil, trace.BadParameter(errorMessage)
 	}
 
-	return s.backend.GetKeys(bucket)
+	return s.backend.GetKeys(bucket, opts...)
 }
 
 // GetItems returns a list of items (key value pairs) for a bucket.

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -99,7 +99,7 @@ func (s *Suite) TestSanitizeBucket(c *check.C) {
 type nopBackend struct {
 }
 
-func (n *nopBackend) GetKeys(bucket []string) ([]string, error) {
+func (n *nopBackend) GetKeys(bucket []string, opts ...OpOption) ([]string, error) {
 	return []string{"foo"}, nil
 }
 

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -188,6 +188,16 @@ func (s *BackendSuite) BatchCRUD(c *C) {
 
 }
 
+func (s *BackendSuite) Deduplicate(c *C) {
+	c.Assert(s.B.UpsertVal([]string{"z", "y"}, "xkey", []byte("val1"), 0), IsNil)
+	c.Assert(s.B.UpsertVal([]string{"z", "y"}, "wkey", []byte("val2"), 0), IsNil)
+
+	keys, err := s.B.GetKeys([]string{"z"}, backend.WithDeduplicateByKey())
+	c.Assert(err, IsNil)
+	c.Assert(keys, HasLen, 1)
+	c.Assert(keys[0], Equals, "y")
+}
+
 // Directories checks directories access
 func (s *BackendSuite) Directories(c *C) {
 	bucket := []string{"level1", "level2", "level3"}

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -59,7 +59,7 @@ func (s *IdentityService) DeleteAllUsers() error {
 
 // GetUsers returns a list of users registered with the local auth server
 func (s *IdentityService) GetUsers() ([]services.User, error) {
-	keys, err := s.GetKeys([]string{"web", "users"})
+	keys, err := s.GetKeys([]string{"web", "users"}, backend.WithDeduplicateByKey())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/term_test.go
+++ b/lib/srv/term_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"testing"
 
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -36,7 +35,7 @@ var _ = check.Suite(&TermSuite{})
 var _ = fmt.Printf
 
 func (s *TermSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 func (s *TermSuite) TearDownSuite(c *check.C) {}
 func (s *TermSuite) SetUpTest(c *check.C)     {}


### PR DESCRIPTION
**Description**

Some resources, like users, need to be deduplicated by key instead of full path for some backends (like `dir` and `DynamoDB`) because of the structure of the user resource and the limitation of a key value store.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2107
Fixes https://github.com/gravitational/teleport/issues/2569