### PR TITLE
Emit data transfer events.

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -88,6 +88,11 @@ const (
 	// SessionLeaveEvent indicates that someone left a session
 	SessionLeaveEvent = "session.leave"
 
+	// Data transfer events.
+	SessionDataEvent = "session.data"
+	DataTransmitted  = "tx"
+	DataReceived     = "rx"
+
 	// ClientDisconnectEvent is emitted when client is disconnected
 	// by the server due to inactivity or any other reason
 	ClientDisconnectEvent = "client.disconnect"

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -12,7 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package reversetunnel
@@ -484,7 +483,7 @@ func (s *server) Shutdown(ctx context.Context) error {
 }
 
 func (s *server) HandleNewChan(conn net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {
-	// apply read/write timeouts to the server connection
+	// Apply read/write timeouts to the server connection.
 	conn = utils.ObeyIdleTimeout(conn,
 		defaults.ReverseTunnelAgentHeartbeatPeriod*10,
 		"reverse tunnel server")

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -214,7 +214,7 @@ func New(c ServerConfig) (*Server, error) {
 		}),
 		id:              uuid.New(),
 		targetConn:      c.TargetConn,
-		serverConn:      serverConn,
+		serverConn:      utils.NewTrackingConn(serverConn),
 		clientConn:      clientConn,
 		userAgent:       c.UserAgent,
 		hostCertificate: c.HostCertificate,
@@ -594,6 +594,7 @@ func (s *Server) handleDirectTCPIPRequest(ch ssh.Channel, req *sshutils.DirectTC
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}
+	ctx.Connection = s.serverConn
 	ctx.RemoteClient = s.remoteClient
 	defer ctx.Close()
 
@@ -657,6 +658,7 @@ func (s *Server) handleSessionRequests(ch ssh.Channel, in <-chan *ssh.Request) {
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}
+	ctx.Connection = s.serverConn
 	ctx.RemoteClient = s.remoteClient
 	ctx.AddCloser(ch)
 	defer ctx.Close()

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -741,7 +741,7 @@ func (s *Server) HandleRequest(r *ssh.Request) {
 }
 
 // HandleNewChan is called when new channel is opened
-func (s *Server) HandleNewChan(nc net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {
+func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {
 	identityContext, err := s.authHandlers.CreateIdentityContext(sconn)
 	if err != nil {
 		nch.Reject(ssh.Prohibited, fmt.Sprintf("Unable to create identity from connection: %v", err))
@@ -760,7 +760,7 @@ func (s *Server) HandleNewChan(nc net.Conn, sconn *ssh.ServerConn, nch ssh.NewCh
 				nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 				return
 			}
-			go s.handleSessionRequests(sconn, identityContext, ch, requests)
+			go s.handleSessionRequests(wconn, sconn, identityContext, ch, requests)
 		} else {
 			nch.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
 		}
@@ -777,7 +777,7 @@ func (s *Server) HandleNewChan(nc net.Conn, sconn *ssh.ServerConn, nch ssh.NewCh
 			nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 			return
 		}
-		go s.handleSessionRequests(sconn, identityContext, ch, requests)
+		go s.handleSessionRequests(wconn, sconn, identityContext, ch, requests)
 	// Channels of type "direct-tcpip" handles request for port forwarding.
 	case "direct-tcpip":
 		req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
@@ -792,14 +792,14 @@ func (s *Server) HandleNewChan(nc net.Conn, sconn *ssh.ServerConn, nch ssh.NewCh
 			nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 			return
 		}
-		go s.handleDirectTCPIPRequest(sconn, identityContext, ch, req)
+		go s.handleDirectTCPIPRequest(wconn, sconn, identityContext, ch, req)
 	default:
 		nch.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
 	}
 }
 
 // handleDirectTCPIPRequest handles port forwarding requests.
-func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, req *sshutils.DirectTCPIPReq) {
+func (s *Server) handleDirectTCPIPRequest(wconn net.Conn, sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, req *sshutils.DirectTCPIPReq) {
 	// Create context for this channel. This context will be closed when
 	// forwarding is complete.
 	ctx, err := srv.NewServerContext(s, sconn, identityContext)
@@ -808,7 +808,7 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}
-
+	ctx.Connection = wconn
 	ctx.IsTestStub = s.isTestStub
 	ctx.AddCloser(ch)
 	defer ctx.Debugf("direct-tcp closed")
@@ -892,7 +892,7 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 // handleSessionRequests handles out of band session requests once the session
 // channel has been created this function's loop handles all the "exec",
 // "subsystem" and "shell" requests.
-func (s *Server) handleSessionRequests(sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, in <-chan *ssh.Request) {
+func (s *Server) handleSessionRequests(conn net.Conn, sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, in <-chan *ssh.Request) {
 	// Create context for this channel. This context will be closed when the
 	// session request is complete.
 	ctx, err := srv.NewServerContext(s, sconn, identityContext)
@@ -901,12 +901,13 @@ func (s *Server) handleSessionRequests(sconn *ssh.ServerConn, identityContext sr
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}
+	ctx.Connection = conn
 	ctx.IsTestStub = s.isTestStub
 	ctx.AddCloser(ch)
 	defer ctx.Close()
 
 	// Create a close context used to signal between the server and the
-	// keep-alive loop when to close th connection (from either side).
+	// keep-alive loop when to close the connection (from either side).
 	closeContext, closeCancel := context.WithCancel(context.Background())
 	defer closeCancel()
 


### PR DESCRIPTION
**Description**

Created `*utils.TrackingConn` that wraps the server side `net.Conn` and is used to track how much data is transmitted and received over the `net.Conn`. At the close of a connection (close of a `*srv.ServerContext`) the total data transmitted and received is emitted to the Audit Log.

**Related Issues**

Fixes https://github.com/gravitational/teleport.e/issues/101