### PR TITLE
[3.0] Moved expires to resource metadata for services.Users.

### DIFF
--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -337,11 +337,11 @@ func (a *AuthServer) createOIDCUser(connector services.OIDCConnector, ident *oid
 		Metadata: services.Metadata{
 			Name:      ident.Email,
 			Namespace: defaults.Namespace,
+			Expires:   &ident.ExpiresAt,
 		},
 		Spec: services.UserSpecV2{
-			Roles:   roles,
-			Traits:  traits,
-			Expires: ident.ExpiresAt,
+			Roles:  roles,
+			Traits: traits,
 			OIDCIdentities: []services.ExternalIdentity{
 				{
 					ConnectorID: connector.GetName(),

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package auth
 
 import (
@@ -120,11 +136,11 @@ func (a *AuthServer) createSAMLUser(connector services.SAMLConnector, assertionI
 		Metadata: services.Metadata{
 			Name:      assertionInfo.NameID,
 			Namespace: defaults.Namespace,
+			Expires:   &expiresAt,
 		},
 		Spec: services.UserSpecV2{
 			Roles:          roles,
 			Traits:         traits,
-			Expires:        expiresAt,
 			SAMLIdentities: []services.ExternalIdentity{{ConnectorID: connector.GetName(), Username: assertionInfo.NameID}},
 			CreatedBy: services.CreatedBy{
 				User: services.UserRef{Name: "system"},

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package services
 
 import (
@@ -392,12 +408,10 @@ func (u *UserV2) Equals(other User) bool {
 	return true
 }
 
-// Expiry returns expiry time for temporary users
+// Expiry returns expiry time for temporary users. Prefer expires from
+// metadata, if it does not exist, fall back to expires in spec.
 func (u *UserV2) Expiry() time.Time {
-	if u.Metadata.Expires == nil {
-		return time.Time{}
-	}
-	if !u.Metadata.Expires.IsZero() {
+	if u.Metadata.Expires != nil && !u.Metadata.Expires.IsZero() {
 		return *u.Metadata.Expires
 	}
 	return u.Spec.Expires


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/commit/85557b380d38390ac8bca233c27d2d05dfd208d5 to 3.0.

Moved expiry field from spec to metadata for services.Users and updated
expiry check to prefer metadata and fallback to spec if not found.