### PR TITLE
Disable verbose logging in tests.

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -56,7 +56,7 @@ var _ = Suite(&AuthSuite{})
 var _ = fmt.Printf
 
 func (s *AuthSuite) SetUpSuite(c *C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *AuthSuite) SetUpTest(c *C) {

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/gravitational/trace"
 	. "gopkg.in/check.v1"
-	"testing"
 )
 
 type AuthInitSuite struct {
@@ -45,7 +44,7 @@ var _ = Suite(&AuthInitSuite{})
 var _ = fmt.Printf
 
 func (s *AuthInitSuite) SetUpSuite(c *C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *AuthInitSuite) TearDownSuite(c *C) {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"testing"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -55,7 +54,7 @@ type TLSSuite struct {
 var _ = check.Suite(&TLSSuite{})
 
 func (s *TLSSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *TLSSuite) SetUpTest(c *check.C) {

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -42,7 +42,7 @@ type DynamoDBSuite struct {
 var _ = check.Suite(&DynamoDBSuite{})
 
 func (s *DynamoDBSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 	var err error
 
 	s.tableName = "teleport.dynamo.test"

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -45,7 +45,7 @@ type EtcdSuite struct {
 var _ = check.Suite(&EtcdSuite{})
 
 func (s *EtcdSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 
 	// this config must match examples/etcd/teleport.yaml
 	s.config = backend.Params{

--- a/lib/backend/legacy/boltbk/boltbk_test.go
+++ b/lib/backend/legacy/boltbk/boltbk_test.go
@@ -38,7 +38,7 @@ type BoltSuite struct {
 var _ = check.Suite(&BoltSuite{})
 
 func (s *BoltSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *BoltSuite) SetUpTest(c *check.C) {

--- a/lib/backend/lite/lite_test.go
+++ b/lib/backend/lite/lite_test.go
@@ -39,7 +39,7 @@ type LiteSuite struct {
 var _ = check.Suite(&LiteSuite{})
 
 func (s *LiteSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 	newBackend := func() (backend.Backend, error) {
 		return New(context.Background(), map[string]interface{}{
 			"path":               c.MkDir(),

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"testing"
 	"time"
 
 	"strconv"
@@ -40,7 +39,7 @@ var _ = fmt.Printf
 var _ = check.Suite(&ServiceTestSuite{})
 
 func (s *ServiceTestSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *ServiceTestSuite) TestSelfSignedHTTPS(c *check.C) {

--- a/lib/services/legacy/legacy_test.go
+++ b/lib/services/legacy/legacy_test.go
@@ -44,7 +44,7 @@ type LegacySuite struct {
 var _ = check.Suite(&LegacySuite{})
 
 func (s *LegacySuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 // TestProtoServer tests that protobuf server is compatible with

--- a/lib/services/license_test.go
+++ b/lib/services/license_test.go
@@ -34,7 +34,7 @@ type LicenseSuite struct {
 var _ = check.Suite(&LicenseSuite{})
 
 func (s *LicenseSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *LicenseSuite) TestUnmarshal(c *check.C) {

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -19,7 +19,6 @@ package local
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/gravitational/teleport/lib/backend"
@@ -41,7 +40,7 @@ var _ = check.Suite(&ClusterConfigurationSuite{})
 var _ = fmt.Printf
 
 func (s *ClusterConfigurationSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *ClusterConfigurationSuite) TearDownSuite(c *check.C) {

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"gopkg.in/check.v1"
-	"testing"
 )
 
 type PresenceSuite struct {
@@ -39,7 +38,7 @@ var _ = check.Suite(&PresenceSuite{})
 var _ = fmt.Printf
 
 func (s *PresenceSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *PresenceSuite) TearDownSuite(c *check.C) {

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -42,7 +42,7 @@ var _ = fmt.Printf
 var _ = check.Suite(&ServicesSuite{})
 
 func (s *ServicesSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *ServicesSuite) SetUpTest(c *check.C) {

--- a/lib/services/servers_test.go
+++ b/lib/services/servers_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package services
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gravitational/teleport/lib/defaults"
@@ -32,7 +31,7 @@ type ServerSuite struct {
 var _ = check.Suite(&ServerSuite{})
 
 func (s *ServerSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 // TestServersCompare tests comparing two servers

--- a/lib/session/session_test.go
+++ b/lib/session/session_test.go
@@ -43,7 +43,7 @@ type SessionSuite struct {
 var _ = Suite(&SessionSuite{})
 
 func (s *SessionSuite) SetUpSuite(c *C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 func (s *SessionSuite) SetUpTest(c *C) {

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -57,7 +57,7 @@ var _ = check.Suite(&ExecSuite{})
 var _ = fmt.Printf
 
 func (s *ExecSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 
 	bk, err := lite.NewWithConfig(context.TODO(), lite.Config{Path: c.MkDir()})
 	c.Assert(err, check.IsNil)

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -19,7 +19,6 @@ package srv
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/gravitational/teleport/lib/defaults"
@@ -40,7 +39,7 @@ var _ = check.Suite(&HeartbeatSuite{})
 var _ = fmt.Printf
 
 func (s *HeartbeatSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 
 // TestHeartbeatAnnounce tests announce cycles used for proxies and auth servers

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -84,7 +84,7 @@ var _ = Suite(&SrvSuite{})
 func (s *SrvSuite) SetUpSuite(c *C) {
 	var err error
 
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 
 	s.freePorts, err = utils.GetFreeTCPPorts(100)
 	c.Assert(err, IsNil)

--- a/lib/srv/term_test.go
+++ b/lib/srv/term_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"testing"
 
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -36,7 +35,7 @@ var _ = check.Suite(&TermSuite{})
 var _ = fmt.Printf
 
 func (s *TermSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 }
 func (s *TermSuite) TearDownSuite(c *check.C) {}
 func (s *TermSuite) SetUpTest(c *check.C)     {}

--- a/lib/state/cachingaccesspoint_test.go
+++ b/lib/state/cachingaccesspoint_test.go
@@ -115,7 +115,7 @@ var _ = check.Suite(&ClusterSnapshotSuite{})
 func TestState(t *testing.T) { check.TestingT(t) }
 
 func (s *ClusterSnapshotSuite) SetUpSuite(c *check.C) {
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 	s.clock = clockwork.NewRealClock()
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -101,7 +101,7 @@ var _ = Suite(&WebSuite{})
 func (s *WebSuite) SetUpSuite(c *C) {
 	var err error
 	os.Unsetenv(teleport.DebugEnvVar)
-	utils.InitLoggerForTests(testing.Verbose())
+	utils.InitLoggerForTests()
 
 	// configure tests to use static assets from web/dist:
 	debugAssetsPath = "../../web/dist"


### PR DESCRIPTION
**Description**

Disable verbose logging in tests everywhere to help narrow down what test failed.