### PR TITLE
Improved error when CA pin does not match.

### DIFF
--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -209,10 +209,10 @@ func pinRegisterClient(params RegisterParams) (*Client, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// Check that the SKPI pin matches the CA we fetched over a insecure
+	// Check that the SPKI pin matches the CA we fetched over a insecure
 	// connection. This makes sure the CA fetched over a insecure connection is
 	// in-fact the expected CA.
-	err = utils.CheckSKPI(params.CAPin, tlsCA)
+	err = utils.CheckSPKI(params.CAPin, tlsCA)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1699,7 +1699,7 @@ func (s *TLSSuite) TestRegisterCAPin(c *check.C) {
 	c.Assert(err, check.IsNil)
 	tlsCA, err := hostCA.TLSCA()
 	c.Assert(err, check.IsNil)
-	caPin := utils.CalculateSKPI(tlsCA.Cert)
+	caPin := utils.CalculateSPKI(tlsCA.Cert)
 
 	// Attempt to register with valid CA pin, should work.
 	_, err = Register(RegisterParams{

--- a/lib/utils/spki.go
+++ b/lib/utils/spki.go
@@ -26,28 +26,33 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// CalculateSKPI the hash value of the SPKI header in a certificate.
-func CalculateSKPI(cert *x509.Certificate) string {
+// CalculateSPKI the hash value of the SPKI header in a certificate.
+func CalculateSPKI(cert *x509.Certificate) string {
 	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
 	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
-// CheckSKPI the passed in pin against the calculated value from a certificate.
-func CheckSKPI(pin string, cert *x509.Certificate) error {
+// CheckSPKI the passed in pin against the calculated value from a certificate.
+func CheckSPKI(pin string, cert *x509.Certificate) error {
 	// Check that the format of the pin is valid.
 	parts := strings.Split(pin, ":")
 	if len(parts) != 2 {
-		return trace.BadParameter("invalid format for SKPI hash")
+		return trace.BadParameter("invalid format for certificate pin, expected algorithm:pin")
 	}
 	if parts[0] != "sha256" {
-		return trace.BadParameter("only sha256 supported by SKPI hash")
+		return trace.BadParameter("sha256 only supported hashing algorithm for certificate pin")
 	}
 
 	// Check that that pin itself matches that value calculated from the passed
 	// in certificate.
-	if subtle.ConstantTimeCompare([]byte(CalculateSKPI(cert)), []byte(pin)) != 1 {
-		return trace.BadParameter("SKPI values do not match")
+	if subtle.ConstantTimeCompare([]byte(CalculateSPKI(cert)), []byte(pin)) != 1 {
+		return trace.BadParameter(errorMessage)
 	}
 
 	return nil
 }
+
+var errorMessage string = "provided certificate pin does not match cluster pin. " +
+	"This could have occurred if the Certificate Authority (CA) for the cluster " +
+	"was rotated, invalidating the old pin. Run \"tctl status\" to compare the pin " +
+	"used to join the cluster to the actual pin for the cluster."

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -193,7 +193,7 @@ func (c *TokenCommand) List(client auth.ClientI) error {
 	return nil
 }
 
-// calculateCAPin returns the SKPI pin for the local cluster.
+// calculateCAPin returns the SPKI pin for the local cluster.
 func calculateCAPin(client auth.ClientI) (string, error) {
 	localCA, err := client.GetClusterCACert()
 	if err != nil {
@@ -204,5 +204,5 @@ func calculateCAPin(client auth.ClientI) (string, error) {
 		return "", trace.Wrap(err)
 	}
 
-	return utils.CalculateSKPI(tlsCA), nil
+	return utils.CalculateSPKI(tlsCA), nil
 }


### PR DESCRIPTION
**Description**

Improved error messaging when Certificate Authority (CA) pin does not match provided pin. Fixed typo in abbreviation of "Subject Public Key Info" from SKPI to SPKI.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2597