### PR TITLE
Change cluster validation method from using CA cert to CA pin hash

### DIFF
--- a/assets/marketplace/Jenkinsfile-build-ent
+++ b/assets/marketplace/Jenkinsfile-build-ent
@@ -20,7 +20,7 @@ pipeline {
         stage('Run Packer to build specified version') {
             steps {
                 dir('assets/marketplace') {
-                    sh "BUILD_AMI_NAME=gravitational-teleport-ami-ent-${params.version} TELEPORT_VERSION=${params.version} make ent-jenkins-build"
+                    sh "PUBLIC_AMI_NAME=gravitational-teleport-ami-ent-${params.version} MARKETPLACE_AMI_NAME=gravitational-teleport-marketplace-ami-ent-${params.version} TELEPORT_VERSION=${params.version} make ent-jenkins-build"
                 }
             }
         }

--- a/assets/marketplace/Jenkinsfile-build-oss
+++ b/assets/marketplace/Jenkinsfile-build-oss
@@ -20,7 +20,7 @@ pipeline {
         stage('Run Packer to build specified version') {
             steps {
                 dir('assets/marketplace') {
-                    sh "BUILD_AMI_NAME=gravitational-teleport-ami-oss-${params.version} TELEPORT_VERSION=${params.version} make oss-jenkins-build"
+                    sh "PUBLIC_AMI_NAME=gravitational-teleport-ami-oss-${params.version} MARKETPLACE_AMI_NAME=gravitational-teleport-marketplace-ami-oss-${params.version} TELEPORT_VERSION=${params.version} make oss-jenkins-build"
                 }
             }
         }

--- a/assets/marketplace/Makefile
+++ b/assets/marketplace/Makefile
@@ -4,8 +4,11 @@ BUILD_VPC_ID ?=
 # VPC subnet used for builds
 BUILD_SUBNET_ID ?=
 
-# Override for AMI name if needed
-BUILD_AMI_NAME ?=
+# Public AMI name
+PUBLIC_AMI_NAME ?=
+
+# Marketplace AMI name ?=
+MARKETPLACE_AMI_NAME ?=
 
 # Default build region
 AWS_REGION ?= us-west-2
@@ -41,22 +44,28 @@ GRAFANA_VERSION ?= 5.4.3
 export
 
 
+# Build local 'debug' AMI
 .PHONY: oss
 oss: TELEPORT_TYPE=oss
 oss: check-vars
 oss:
 	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE)"
 	@echo "BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
-	packer build -force -var build_timestamp=$(BUILD_TIMESTAMP) single-ami.json
+	mkdir -p files/build
+	packer build -force -var build_timestamp=$(BUILD_TIMESTAMP) -except teleport-aws-linux-marketplace single-ami.json
 	@echo "$(BUILD_TIMESTAMP)" > files/build/oss_build_timestamp.txt
 
+# Build named 'production' AMI and marketplace version
 .PHONY: oss-jenkins-build
 oss-jenkins-build: TELEPORT_TYPE=oss
 oss-jenkins-build: check-vars
 oss-jenkins-build:
-	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) with name $(BUILD_AMI_NAME)"
+	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) via Jenkins"
+	@echo "Public AMI name: $(PUBLIC_AMI_NAME)"
+	@echo "Marketplace AMI name: $(MARKETPLACE_AMI_NAME)"
 	@echo "BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
-	packer build -force -var ami_name=$(BUILD_AMI_NAME) -var build_timestamp=$(BUILD_TIMESTAMP) single-ami.json
+	mkdir -p files/build
+	packer build -force -var ami_name=$(PUBLIC_AMI_NAME) -var marketplace_ami_name=$(MARKETPLACE_AMI_NAME) -var build_type=production -var build_timestamp=$(BUILD_TIMESTAMP) single-ami.json
 	@echo "$(BUILD_TIMESTAMP)" > files/build/oss_build_timestamp.txt
 
 .PHONY: change-amis-to-public-oss
@@ -64,21 +73,27 @@ change-amis-to-public-oss:
 	@echo "Making OSS AMIs public"
 	bash files/make-amis-public.sh oss
 
+# Build local 'debug' AMI
 .PHONY: ent
 ent: TELEPORT_TYPE=ent
 ent: check-vars
 	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE)"
 	@echo "BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
-	packer build -force -var build_timestamp=$(BUILD_TIMESTAMP) single-ami.json
+	mkdir -p files/build
+	packer build -force -var build_timestamp=$(BUILD_TIMESTAMP) -except teleport-aws-linux-marketplace single-ami.json
 	@echo "$(BUILD_TIMESTAMP)" > files/build/ent_build_timestamp.txt
 
+# Build named 'production' AMI and marketplace version
 .PHONY: ent-jenkins-build
 ent-jenkins-build: TELEPORT_TYPE=ent
 ent-jenkins-build: check-vars
 ent-jenkins-build:
-	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) with name $(BUILD_AMI_NAME)"
+	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) via Jenkins"
+	@echo "Public AMI name: $(PUBLIC_AMI_NAME)"
+	@echo "Marketplace AMI name: $(MARKETPLACE_AMI_NAME)"
 	@echo "BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
-	packer build -force -var ami_name=$(BUILD_AMI_NAME) -var build_timestamp=$(BUILD_TIMESTAMP) single-ami.json
+	mkdir -p files/build
+	packer build -force -var ami_name=$(PUBLIC_AMI_NAME) -var marketplace_ami_name=$(MARKETPLACE_AMI_NAME) -var build_type=production -var build_timestamp=$(BUILD_TIMESTAMP) single-ami.json
 	@echo "$(BUILD_TIMESTAMP)" > files/build/ent_build_timestamp.txt
 
 .PHONY: change-amis-to-public-ent

--- a/assets/marketplace/files/bin/teleport-generate-config
+++ b/assets/marketplace/files/bin/teleport-generate-config
@@ -24,6 +24,8 @@ source /etc/teleport.d/conf
 # things will happen.
 echo ${LOCAL_HOSTNAME} > /var/lib/teleport/host_uuid
 chown -R teleport:adm /var/lib/teleport
+touch /etc/teleport.yaml
+chown 664 /etc/teleport.yaml
 
 # Use letsencrypt by default unless we are explicitly using ACM here
 if [[ "${USE_ACM}" != "true" ]]; then
@@ -101,6 +103,7 @@ elif [[ "${TELEPORT_ROLE}" == "proxy" ]]; then
     cat >/etc/teleport.yaml <<EOF
 teleport:
   auth_token: /var/lib/teleport/token
+  ca_pin: CA_PIN_HASH_PLACEHOLDER
   nodename: ${LOCAL_HOSTNAME}
   advertise_ip: ${LOCAL_IP}
   log:
@@ -159,6 +162,7 @@ elif [[ "${TELEPORT_ROLE}" == "node" ]]; then
     cat >/etc/teleport.yaml <<EOF
 teleport:
   auth_token: /var/lib/teleport/token
+  ca_pin: CA_PIN_HASH_PLACEHOLDER
   nodename: ${LOCAL_HOSTNAME}
   advertise_ip: ${LOCAL_IP}
   log:

--- a/assets/marketplace/files/bin/teleport-ssm-get-token
+++ b/assets/marketplace/files/bin/teleport-ssm-get-token
@@ -14,5 +14,18 @@ set -o pipefail
 # Fetch token published by Auth server to SSM parameter store to join the cluster
 aws ssm get-parameter --with-decryption --name /teleport/${TELEPORT_CLUSTER_NAME}/tokens/${TELEPORT_ROLE} --region ${EC2_REGION} --query Parameter.Value --output text > /var/lib/teleport/token
 
-# Fetch Auth server CA certificate to validate the identity of the auth server
-aws ssm get-parameter --name /teleport/${TELEPORT_CLUSTER_NAME}/ca --region=${EC2_REGION} --query=Parameter.Value --output text > /var/lib/teleport/ca.cert
+# Fetch Auth server CA pin hash to validate the identity of the auth server
+# Store any old value for the CA pin hash, then compare the new one to see if we need to update the Teleport config file
+OLD_CA_PIN_HASH=$(grep 'ca_pin' /etc/teleport.yaml | cut -d: -f2- | tr -d ' ')
+CA_PIN_HASH=$(aws ssm get-parameter --name /teleport/${TELEPORT_CLUSTER_NAME}/ca-pin-hash --region=${EC2_REGION} --query=Parameter.Value --output text)
+echo ${CA_PIN_HASH} > /var/lib/teleport/ca-pin-hash
+
+# update Teleport config file if the CA pin hash has changed
+if [[ "${CA_PIN_HASH}" != "${OLD_CA_PIN_HASH}" ]]; then
+    echo "CA pin hash has changed from '${OLD_CA_PIN_HASH}' to '${CA_PIN_HASH}' - updating config"
+    # Workaround for sed not being able to create temporary files in systemd runtime directories
+    cp /etc/teleport.yaml /tmp/teleport.yaml
+    sed -i "s/${OLD_CA_PIN_HASH}/${CA_PIN_HASH}/g" /tmp/teleport.yaml
+    cp /tmp/teleport.yaml /etc/teleport.yaml
+    rm -f /tmp/teleport.yaml
+fi

--- a/assets/marketplace/files/bin/teleport-ssm-publish-tokens
+++ b/assets/marketplace/files/bin/teleport-ssm-publish-tokens
@@ -21,7 +21,7 @@ NODE_TOKEN=$(uuid)
 ${TCTL} nodes add --roles=node --ttl=4h --token=${NODE_TOKEN}
 aws ssm put-parameter --name /teleport/${TELEPORT_CLUSTER_NAME}/tokens/node --region ${EC2_REGION} --type="SecureString" --value="${NODE_TOKEN}" --overwrite
 
-# Export CA certificate to SSM parameter store
-# so nodes and proxies can check the identity of the auth server they are connecting to
-CERT=$(${TCTL} auth export --type=tls)
-aws ssm put-parameter --name /teleport/${TELEPORT_CLUSTER_NAME}/ca --region ${EC2_REGION} --type="String" --value="${CERT}" --overwrite
+# Export CA pin hash to SSM parameter store
+CA_PIN_HASH=$(tctl status | grep "CA pin" | awk '{print $3}')
+echo ${CA_PIN_HASH}
+aws ssm put-parameter --name /teleport/${TELEPORT_CLUSTER_NAME}/ca-pin-hash --region ${EC2_REGION} --type="String" --value="${CA_PIN_HASH}" --overwrite

--- a/assets/marketplace/files/bin/teleport-ssm-publish-tokens
+++ b/assets/marketplace/files/bin/teleport-ssm-publish-tokens
@@ -23,5 +23,4 @@ aws ssm put-parameter --name /teleport/${TELEPORT_CLUSTER_NAME}/tokens/node --re
 
 # Export CA pin hash to SSM parameter store
 CA_PIN_HASH=$(tctl status | grep "CA pin" | awk '{print $3}')
-echo ${CA_PIN_HASH}
 aws ssm put-parameter --name /teleport/${TELEPORT_CLUSTER_NAME}/ca-pin-hash --region ${EC2_REGION} --type="String" --value="${CA_PIN_HASH}" --overwrite

--- a/assets/marketplace/files/make-amis-public.sh
+++ b/assets/marketplace/files/make-amis-public.sh
@@ -31,7 +31,7 @@ BUILD_TIMESTAMP=$(<"${TIMESTAMP_FILE}")
 
 # Write AMI ID for each region to AMI ID file
 for REGION in ${REGION_LIST}; do
-    aws ec2 describe-images --region ${REGION} --filters Name=tag:BuildTimestamp,Values=${BUILD_TIMESTAMP} > "${BUILD_DIR}/${REGION}.json"
+    aws ec2 describe-images --region ${REGION} --filters Name=tag:BuildTimestamp,Values=${BUILD_TIMESTAMP},Name=tag:BuildType,Values=production > "${BUILD_DIR}/${REGION}.json"
     AMI_ID=$(jq --raw-output '.Images[0].ImageId' "${BUILD_DIR}/${REGION}.json")
     if [[ "${AMI_ID}" == "" || "${AMI_ID}" == "null" ]]; then
         echo "Error: cannot get AMI ID for ${REGION}"

--- a/assets/marketplace/single-ami.json
+++ b/assets/marketplace/single-ami.json
@@ -11,10 +11,11 @@
     "telegraf_version": "{{env `TELEGRAF_VERSION`}}",
     "influxdb_version": "{{env `INFLUXDB_VERSION`}}",
     "grafana_version": "{{env `GRAFANA_VERSION`}}",
-    "ami_name": "gravitational-teleport-ami-{{env `TELEPORT_TYPE`}}-{{env `TELEPORT_VERSION`}}"
+    "ami_name": "teleport-debug-ami-{{env `TELEPORT_TYPE`}}-{{env `TELEPORT_VERSION`}}",
+    "build_type": "debug"
   },
   "builders": [{
-    "name": "Teleport AWS Linux",
+    "name": "teleport-aws-linux",
     "ami_description": "Gravitational Teleport using AWS Linux AMI",
     "type": "amazon-ebs",
     "region": "{{user `aws_region`}}",
@@ -40,7 +41,8 @@
     "force_delete_snapshot": "true",
     "tags": {
       "Name": "{{user `ami_name`}}",
-      "BuildTimestamp": "{{user `build_timestamp`}}"
+      "BuildTimestamp": "{{user `build_timestamp`}}",
+      "BuildType": "{{user `build_type`}}"
     },
     "run_tags": {
       "Name": "{{user `ami_name`}}"
@@ -50,6 +52,45 @@
     },
     "snapshot_tags": {
       "Name": "{{user `ami_name`}}"
+    }
+  },{
+    "name": "teleport-aws-linux-marketplace",
+    "ami_description": "Gravitational Teleport using AWS Linux AMI for AWS Marketplace",
+    "type": "amazon-ebs",
+    "region": "{{user `aws_region`}}",
+    "source_ami_filter": {
+        "filters": {
+            "virtualization-type": "hvm",
+            "name": "amzn2-ami-hvm*-ebs",
+            "root-device-type": "ebs"
+        },
+        "owners": ["137112412989", "591542846629", "801119661308",
+                   "102837901569", "013907871322", "206029621532",
+                   "286198878708", "443319210888"],
+        "most_recent": true
+    },
+    "instance_type": "{{user `instance_type`}}",
+    "ssh_username": "ec2-user",
+    "ami_name": "{{user `marketplace_ami_name` | clean_ami_name}}",
+    "ssh_pty" : true,
+    "associate_public_ip_address": true,
+    "vpc_id": "{{user `vpc`}}",
+    "subnet_id": "{{user `subnet`}}",
+    "ami_regions": "{{user `destination_regions`}}",
+    "force_delete_snapshot": "true",
+    "tags": {
+      "Name": "{{user `marketplace_ami_name`}}",
+      "BuildTimestamp": "{{user `build_timestamp`}}",
+      "BuildType": "marketplace"
+    },
+    "run_tags": {
+      "Name": "{{user `marketplace_ami_name`}}"
+    },
+    "run_volume_tags": {
+      "Name": "{{user `marketplace_ami_name`}}"
+    },
+    "snapshot_tags": {
+      "Name": "{{user `marketplace_ami_name`}}"
     }
   }],
   "provisioners": [{

--- a/examples/aws/terraform/Makefile
+++ b/examples/aws/terraform/Makefile
@@ -56,8 +56,8 @@ apply:
 	terraform init
 	terraform apply
 
-# Destroy destroys the infrastructure
-.PHONY: destroy
-destroy:
+# Destroy destroys the infrastructure, it doesn't ask for confirmation so be sure you actually want to
+.PHONY: destroy-yes-i-want-to-do-this
+destroy-yes-i-want-to-do-this:
 	terraform init
-	terraform destroy
+	terraform destroy -auto-approve

--- a/examples/aws/terraform/node_iam.tf
+++ b/examples/aws/terraform/node_iam.tf
@@ -49,7 +49,7 @@ resource "aws_iam_role_policy" "node_ssm" {
                 "ssm:GetParametersByPath",
                 "ssm:GetParameter"
             ],
-            "Resource": "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/teleport/${var.cluster_name}/ca"
+            "Resource": "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/teleport/${var.cluster_name}/ca-pin-hash"
         },
         {
          "Effect":"Allow",

--- a/examples/aws/terraform/proxy_iam.tf
+++ b/examples/aws/terraform/proxy_iam.tf
@@ -77,7 +77,7 @@ resource "aws_iam_role_policy" "proxy_ssm" {
                 "ssm:GetParametersByPath",
                 "ssm:GetParameter"
             ],
-            "Resource": "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/teleport/${var.cluster_name}/ca"
+            "Resource": "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/teleport/${var.cluster_name}/ca-pin-hash"
         },
         {
          "Effect":"Allow",


### PR DESCRIPTION
This also fixes outstanding issues with proxy/node failing to join the cluster if the cluster name has been reused - the join will now fail and systemd will restart the proxy/node process on a loop until the CA pin hash has been updated correctly.
AMI builds have also been split into local 'debug' versions and separate production/marketplace versions with different names which are built in parallel to avoid issues with AWS Marketplace changing AMI visibility when submitted.