### PR TITLE
Fix a runtime error caused by usage of debug CLI flag

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -813,7 +813,7 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 	}
 
 	// apply command line --debug flag to override logger severity
-	if clf.Debug {
+	if fileConf != nil && clf.Debug {
 		fileConf.Logger.Severity = teleport.DebugLevel
 	}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -725,6 +725,18 @@ ssh_service:
 	}
 }
 
+// TestDebugFlag ensures that the debug command-line flag is correctly set in the config.
+func (s *ConfigTestSuite) TestDebugFlag(c *check.C) {
+	clf := CommandLineFlags{
+		Debug: true,
+	}
+	cfg := service.MakeDefaultConfig()
+	c.Assert(cfg.Debug, check.Equals, false)
+	err := Configure(&clf, cfg)
+	c.Assert(err, check.IsNil)
+	c.Assert(cfg.Debug, check.Equals, true)
+}
+
 func (s *ConfigTestSuite) TestLicenseFile(c *check.C) {
 	testCases := []struct {
 		path   string


### PR DESCRIPTION
A change introduced in 6bae91466f00a25f00b2199390d979a91c1a7a29
causes Teleport to crash when running with the debug command-line
(`-d`) without any configuration file:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0x1608bd9]

goroutine 1 [running]:
github.com/gravitational/teleport/lib/config.Configure(0xc00014a9a0, 0xc0002e9100, 0x5, 0x1)
    /gopath/src/github.com/gravitational/teleport/lib/config/configuration.go:816 +0xa9
github.com/gravitational/teleport/tool/teleport/common.Run(0xc0000b0050, 0x3, 0x3, 0x0, 0x0, 0xc00002ff88, 0xc00008e058)
    /gopath/src/github.com/gravitational/teleport/tool/teleport/common/teleport.go:147 +0x2912
main.main()
    /gopath/src/github.com/gravitational/teleport/tool/teleport/main.go:26 +0x67
```

`fileConf` is nil when we run Teleport without any configuration file.
When we try to turn on debugging from the command-line, it will try to
override the debug configuration in `fileConf`, but it will fail to
do so as it is not initialised.

This commit fixes the problem by ensuring `fileConf` is not nil
before trying to configure it. The behaviour mimics that of `ApplyFileConfig`
which simply short-circuits, and returns early when `fileConf` is nil.

A test was also added to ensure the debug configuration works.
The test would have caught the exception.