### PR TITLE
Add unique ids to all audit events.

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -28,6 +28,8 @@ import (
 const (
 	// EventType is event type/kind
 	EventType = "event"
+	// EventUID is a unique event identifier
+	EventUID = "uid"
 	// EventTime is event time
 	EventTime = "time"
 	// EventLogin is OS login
@@ -235,6 +237,11 @@ func (f EventFields) AsString() string {
 // GetType returns the type (string) of the event
 func (f EventFields) GetType() string {
 	return f.GetString(EventType)
+}
+
+// GetUID returns the unique event ID
+func (f EventFields) GetUID() string {
+	return f.GetString(EventUID)
 }
 
 // GetString returns a string representation of a logged field

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -28,8 +28,8 @@ import (
 const (
 	// EventType is event type/kind
 	EventType = "event"
-	// EventUID is a unique event identifier
-	EventUID = "uid"
+	// EventID is a unique event identifier
+	EventID = "uid"
 	// EventTime is event time
 	EventTime = "time"
 	// EventLogin is OS login
@@ -239,9 +239,9 @@ func (f EventFields) GetType() string {
 	return f.GetString(EventType)
 }
 
-// GetUID returns the unique event ID
-func (f EventFields) GetUID() string {
-	return f.GetString(EventUID)
+// GetID returns the unique event ID
+func (f EventFields) GetID() string {
+	return f.GetString(EventID)
 }
 
 // GetString returns a string representation of a logged field

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -127,6 +127,9 @@ type AuditLogConfig struct {
 	// Clock is a clock either real one or used in tests
 	Clock clockwork.Clock
 
+	// UIDGenerator is used to generate unique IDs for events
+	UIDGenerator utils.UID
+
 	// GID if provided will be used to set group ownership of the directory
 	// to GID
 	GID *int
@@ -172,6 +175,9 @@ func (a *AuditLogConfig) CheckAndSetDefaults() error {
 	}
 	if a.Clock == nil {
 		a.Clock = clockwork.NewRealClock()
+	}
+	if a.UIDGenerator == nil {
+		a.UIDGenerator = utils.NewRealUID()
 	}
 	if a.RotationPeriod == 0 {
 		a.RotationPeriod = defaults.LogRotationPeriod
@@ -248,6 +254,7 @@ func NewAuditLog(cfg AuditLogConfig) (*AuditLog, error) {
 			Dir:            auditDir,
 			SymlinkDir:     cfg.DataDir,
 			Clock:          al.Clock,
+			UIDGenerator:   al.UIDGenerator,
 			SearchDirs:     al.auditDirs,
 		})
 		if err != nil {

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events/filesessions"
+	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
@@ -64,6 +65,7 @@ func (a *AuditTestSuite) makeLogWithClock(c *check.C, dataDir string, recordSess
 		RecordSessions: recordSessions,
 		ServerID:       "server1",
 		Clock:          clock,
+		UIDGenerator:   utils.NewFakeUID(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -324,7 +326,7 @@ func (a *AuditTestSuite) TestBasicLogging(c *check.C) {
 	bytes, err := ioutil.ReadFile(logfile)
 	c.Assert(err, check.IsNil)
 	c.Assert(string(bytes), check.Equals,
-		fmt.Sprintf("{\"apples?\":\"yes\",\"event\":\"user.joined\",\"time\":\"%s\"}\n", now.Format(time.RFC3339)))
+		fmt.Sprintf("{\"apples?\":\"yes\",\"event\":\"user.joined\",\"time\":\"%s\",\"uid\":\"%s\"}\n", now.Format(time.RFC3339), fixtures.UUID))
 }
 
 // TestLogRotation makes sure that logs are rotated
@@ -358,7 +360,7 @@ func (a *AuditTestSuite) TestLogRotation(c *check.C) {
 		// read back what's been written:
 		bytes, err := ioutil.ReadFile(logfile)
 		c.Assert(err, check.IsNil)
-		contents := fmt.Sprintf("{\"apples?\":\"yes\",\"event\":\"user.joined\",\"time\":\"%s\"}\n", now.Format(time.RFC3339))
+		contents := fmt.Sprintf("{\"apples?\":\"yes\",\"event\":\"user.joined\",\"time\":\"%s\",\"uid\":\"%s\"}\n", now.Format(time.RFC3339), fixtures.UUID)
 		c.Assert(string(bytes), check.Equals, contents)
 
 		// read back the contents using symlink

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -55,6 +56,8 @@ type Config struct {
 	RetentionPeriod time.Duration
 	// Clock is a clock interface, used in tests
 	Clock clockwork.Clock
+	// UIDGenerator is unique ID generator
+	UIDGenerator utils.UID
 }
 
 // CheckAndSetDefaults is a helper returns an error if the supplied configuration
@@ -75,6 +78,9 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()
+	}
+	if cfg.UIDGenerator == nil {
+		cfg.UIDGenerator = utils.NewRealUID()
 	}
 	return nil
 }
@@ -216,6 +222,9 @@ func (l *Log) EmitAuditEvent(eventType string, fields events.EventFields) error 
 	}
 	// set event type in the fields as it's missing there
 	fields[events.EventType] = eventType
+	if fields.GetUID() == "" {
+		fields[events.EventUID] = l.UIDGenerator.New()
+	}
 	data, err := json.Marshal(fields)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -222,8 +222,8 @@ func (l *Log) EmitAuditEvent(eventType string, fields events.EventFields) error 
 	}
 	// set event type in the fields as it's missing there
 	fields[events.EventType] = eventType
-	if fields.GetUID() == "" {
-		fields[events.EventUID] = l.UIDGenerator.New()
+	if fields.GetID() == "" {
+		fields[events.EventID] = l.UIDGenerator.New()
 	}
 	data, err := json.Marshal(fields)
 	if err != nil {

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -49,6 +49,7 @@ func (s *DynamoeventsSuite) SetUpSuite(c *check.C) {
 		Region:    "us-west-1",
 		Tablename: fmt.Sprintf("teleport-test-%v", uuid.New()),
 		Clock:     fakeClock,
+		UID:       utils.NewFakeUID(),
 	})
 	c.Assert(err, check.IsNil)
 	s.log = log

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -49,6 +49,8 @@ type FileLogConfig struct {
 	SymlinkDir string
 	// Clock is a clock interface, used in tests
 	Clock clockwork.Clock
+	// UIDGenerator is used to generate unique IDs for events
+	UIDGenerator utils.UID
 	// SearchDirs is a function that returns
 	// search directories, if not set, only Dir is used
 	SearchDirs func() ([]string, error)
@@ -76,6 +78,9 @@ func (cfg *FileLogConfig) CheckAndSetDefaults() error {
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()
+	}
+	if cfg.UIDGenerator == nil {
+		cfg.UIDGenerator = utils.NewRealUID()
 	}
 	return nil
 }
@@ -115,8 +120,11 @@ func (l *FileLog) EmitAuditEvent(eventType string, fields EventFields) error {
 		log.Error(err)
 	}
 
-	// set event type and time:
+	// set event type, unique ID and time:
 	fields[EventType] = eventType
+	if fields.GetUID() == "" {
+		fields[EventUID] = l.UIDGenerator.New()
+	}
 	if _, ok := fields[EventTime]; !ok {
 		fields[EventTime] = l.Clock.Now().In(time.UTC).Round(time.Second)
 	}

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -122,8 +122,8 @@ func (l *FileLog) EmitAuditEvent(eventType string, fields EventFields) error {
 
 	// set event type, unique ID and time:
 	fields[EventType] = eventType
-	if fields.GetUID() == "" {
-		fields[EventUID] = l.UIDGenerator.New()
+	if fields.GetID() == "" {
+		fields[EventID] = l.UIDGenerator.New()
 	}
 	if _, ok := fields[EventTime]; !ok {
 		fields[EventTime] = l.Clock.Now().In(time.UTC).Round(time.Second)

--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/session"
-	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -65,8 +64,6 @@ type DiskSessionLoggerConfig struct {
 	DataDir string
 	// Clock is the clock replacement
 	Clock clockwork.Clock
-	// UIDGenerator is used to generate unique IDs for events
-	UIDGenerator utils.UID
 	// RecordSessions controls if sessions are recorded along with audit events.
 	RecordSessions bool
 	// Namespace is logger namespace
@@ -76,9 +73,6 @@ type DiskSessionLoggerConfig struct {
 }
 
 func (cfg *DiskSessionLoggerConfig) CheckAndSetDefaults() error {
-	if cfg.UIDGenerator == nil {
-		cfg.UIDGenerator = utils.NewRealUID()
-	}
 	return nil
 }
 
@@ -358,7 +352,6 @@ func (sl *DiskSessionLogger) writeChunk(sessionID string, chunk *SessionChunk) (
 	}
 	sl.lastChunkIndex = chunk.ChunkIndex
 	event := printEvent{
-		UID:               sl.UIDGenerator.New(),
 		Start:             eventStart,
 		Type:              SessionPrintEvent,
 		Bytes:             int64(len(chunk.Data)),
@@ -400,8 +393,6 @@ type indexEntry struct {
 }
 
 type printEvent struct {
-	// UID is a unique event identifier
-	UID string `json:"uid"`
 	// Start is event start
 	Start time.Time `json:"time"`
 	// Type is event type

--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -314,7 +314,7 @@ func EventFromChunk(sessionID string, chunk *SessionChunk) (EventFields, error) 
 	fields[EventIndex] = chunk.EventIndex
 	fields[EventTime] = eventStart
 	fields[EventType] = chunk.EventType
-	fields[EventUID] = uuid.New()
+	fields[EventID] = uuid.New()
 	return fields, nil
 }
 

--- a/lib/fixtures/fixtures.go
+++ b/lib/fixtures/fixtures.go
@@ -173,3 +173,6 @@ k+vHAoGBAJyA+RtBF5m64/TqhZFcesTtnpWaRhQ50xXnNVF3W1eKGPtdTDKOaENA
 LJxgC1GdoEz2ilXW802H9QrdKf9GPqxwi2TVzfO6pzWkdZcmbItu+QCCFz+co+r8
 +ki49FmlfbR5YVPN+8X40aLQB4xDkCHwRwTkrigzWQhIOv8NAhDA
 -----END RSA PRIVATE KEY-----`
+
+// UUID is the unique identifier used in tests
+const UUID = "11111111-1111-1111-1111-111111111111"

--- a/lib/utils/uid.go
+++ b/lib/utils/uid.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"github.com/gravitational/teleport/lib/fixtures"
+
+	"github.com/pborman/uuid"
+)
+
+// UID provides an interface for generating unique identifiers.
+type UID interface {
+	// New returns a new UUID4.
+	New() string
+}
+
+// realUID is a real UID generator.
+type realUID struct{}
+
+// NewRealUID returns a new real UID generator.
+func NewRealUID() UID {
+	return &realUID{}
+}
+
+// New generates a new UUID4.
+func (u *realUID) New() string {
+	return uuid.New()
+}
+
+// fakeUID is a fake UID generator used in tests.
+type fakeUID struct{}
+
+// NewFakeUID returns a new fake UID generator used in tests.
+func NewFakeUID() UID {
+	return &fakeUID{}
+}
+
+// New returns a fake UUID4.
+func (u *fakeUID) New() string {
+	return fixtures.UUID
+}


### PR DESCRIPTION
This PR makes sure that all emitted audit events include a `uid` field with a unique uuid4 identifier. I've run some tests locally to make sure events get uid field (including "print" and session events) but let me know if you think I've missed anything.
