### PR TITLE
Added support for FedRAMP/FIPS 140-2

### DIFF
--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -770,3 +770,54 @@ func (s *ConfigTestSuite) TestLicenseFile(c *check.C) {
 		c.Assert(cfg.Auth.LicenseFile, check.Equals, tc.result)
 	}
 }
+
+// TestFIPS makes sure configuration is correctly updated/enforced when in
+// FedRAMP/FIPS 140-2 mode.
+func (s *ConfigTestSuite) TestFIPS(c *check.C) {
+	tests := []struct {
+		inConfigString string
+		inFIPSMode     bool
+		outError       bool
+	}{
+		{
+			inConfigString: configWithoutFIPSKex,
+			inFIPSMode:     true,
+			outError:       true,
+		},
+		{
+			inConfigString: configWithoutFIPSKex,
+			inFIPSMode:     false,
+			outError:       false,
+		},
+		{
+			inConfigString: configWithFIPSKex,
+			inFIPSMode:     true,
+			outError:       false,
+		},
+		{
+			inConfigString: configWithFIPSKex,
+			inFIPSMode:     false,
+			outError:       false,
+		},
+	}
+
+	for i, tt := range tests {
+		comment := check.Commentf("Test %v", i)
+
+		clf := CommandLineFlags{
+			ConfigString: base64.StdEncoding.EncodeToString([]byte(tt.inConfigString)),
+			FIPS:         tt.inFIPSMode,
+		}
+
+		cfg := service.MakeDefaultConfig()
+		service.ApplyDefaults(cfg)
+		service.ApplyFIPSDefaults(cfg)
+
+		err := Configure(&clf, cfg)
+		if tt.outError {
+			c.Assert(err, check.NotNil, comment)
+		} else {
+			c.Assert(err, check.IsNil, comment)
+		}
+	}
+}

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -168,3 +168,29 @@ auth_service:
     facets:
     - https://graviton:3080
 `
+
+// configWithFIPSKex is a configuration file with a FIPS compliant KEX
+// algorithm.
+const configWithFIPSKex = `
+teleport:
+  kex_algos:
+    - ecdh-sha2-nistp256
+auth_service:
+  enabled: yes
+  authentication:
+    type: saml
+    local_auth: false
+`
+
+// configWithoutFIPSKex is a configuration file without a FIPS compliant KEX
+// algorithm.
+const configWithoutFIPSKex = `
+teleport:
+  kex_algos:
+    - curve25519-sha256@libssh.org
+auth_service:
+  enabled: yes
+  authentication:
+    type: saml
+    local_auth: false
+`

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -19,6 +19,7 @@ limitations under the License.
 package defaults
 
 import (
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -512,3 +513,36 @@ const (
 // WindowsOpenSSHNamedPipe is the address of the named pipe that the
 // OpenSSH agent is on.
 const WindowsOpenSSHNamedPipe = `\\.\pipe\openssh-ssh-agent`
+
+var (
+	// FIPSCipherSuites is a list of supported FIPS compliant TLS cipher suites.
+	FIPSCipherSuites = []uint16{
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	}
+
+	// FIPSCiphers is a list of supported FIPS compliant SSH ciphers.
+	FIPSCiphers = []string{
+		"aes128-ctr",
+		"aes192-ctr",
+		"aes256-ctr",
+		"aes128-gcm@openssh.com",
+	}
+
+	// FIPSCiphers is a list of supported FIPS compliant SSH kex algorithms.
+	FIPSKEXAlgorithms = []string{
+		"ecdh-sha2-nistp256",
+		"ecdh-sha2-nistp384",
+		"echd-sha2-nistp521",
+	}
+
+	// FIPSCiphers is a list of supported FIPS compliant SSH mac algorithms.
+	FIPSMACAlgorithms = []string{
+		"hmac-sha2-256-etm@openssh.com",
+		"hmac-sha2-256",
+	}
+)

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -202,7 +202,8 @@ func (h *Handler) ensureBucket() error {
 		// if this client has not created the bucket, don't reconfigure it
 		return nil
 	}
-	// turn on versioning
+
+	// Turn on versioning.
 	ver := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(h.Bucket),
 		VersioningConfiguration: &s3.VersioningConfiguration{
@@ -215,6 +216,7 @@ func (h *Handler) ensureBucket() error {
 		return trace.Wrap(err)
 	}
 
+	// Turn on server-side encryption for the bucket.
 	_, err = h.client.PutBucketEncryption(&s3.PutBucketEncryptionInput{
 		Bucket: aws.String(h.Bucket),
 		ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -47,6 +47,8 @@ type Modules interface {
 	TraitsFromLogins([]string, []string) map[string][]string
 	// SupportsKubernetes returns true if this cluster supports kubernetes
 	SupportsKubernetes() bool
+	// IsBoringBinary checks if the binary was compiled with BoringCrypto.
+	IsBoringBinary() bool
 }
 
 // SetModules sets the modules interface
@@ -115,6 +117,11 @@ func (p *defaultModules) TraitsFromLogins(logins []string, kubeGroups []string) 
 // SupportsKubernetes returns true if this cluster supports kubernetes
 func (p *defaultModules) SupportsKubernetes() bool {
 	return true
+}
+
+// IsBoringBinary checks if the binary was compiled with BoringCrypto.
+func (p *defaultModules) IsBoringBinary() bool {
+	return false
 }
 
 var (

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -49,6 +49,9 @@ func (s *ModulesSuite) TestDefaultModules(c *check.C) {
 		teleport.TraitLogins:     []string{"root"},
 		teleport.TraitKubeGroups: []string{"system:masters"},
 	})
+
+	isBoring := GetModules().IsBoringBinary()
+	c.Assert(isBoring, check.Equals, false)
 }
 
 func (s *ModulesSuite) TestTestModules(c *check.C) {
@@ -65,6 +68,9 @@ func (s *ModulesSuite) TestTestModules(c *check.C) {
 
 	traits := GetModules().TraitsFromLogins([]string{"root"}, []string{"system:masters"})
 	c.Assert(traits, check.IsNil)
+
+	isBoring := GetModules().IsBoringBinary()
+	c.Assert(isBoring, check.Equals, true)
 }
 
 type testModules struct{}
@@ -93,4 +99,8 @@ func (p *testModules) RolesFromLogins(logins []string) []string {
 
 func (p *testModules) TraitsFromLogins(logins []string, kubeGroups []string) map[string][]string {
 	return nil
+}
+
+func (p *testModules) IsBoringBinary() bool {
+	return true
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/s3sessions"
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
@@ -501,6 +502,15 @@ func waitAndReload(ctx context.Context, cfg Config, srv Process, newTeleport New
 func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 	// before we do anything reset the SIGINT handler back to the default
 	system.ResetInterruptSignalHandler()
+
+	// If FIPS mode was requested make sure binary is build against BoringCrypto.
+	if cfg.FIPS {
+		if !modules.GetModules().IsBoringBinary() {
+			return nil, trace.BadParameter("binary not compiled against BoringCrypto, check " +
+				"that Enterprise release was downloaded from " +
+				"https://dashboard.gravitational.com")
+		}
+	}
 
 	if err := validateConfig(cfg); err != nil {
 		return nil, trace.Wrap(err, "configuration error")
@@ -1998,6 +2008,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				ProxyWebAddr:  cfg.Proxy.WebAddr,
 				ProxySettings: proxySettings,
 				CipherSuites:  cfg.CipherSuites,
+				FIPS:          cfg.FIPS,
 			})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -416,6 +416,40 @@ func SliceContainsStr(slice []string, value string) bool {
 	return false
 }
 
+// StringSliceSubset returns true if b is a subset of a.
+func StringSliceSubset(a []string, b []string) error {
+	aset := make(map[string]bool)
+	for _, v := range a {
+		aset[v] = true
+	}
+
+	for _, v := range b {
+		_, ok := aset[v]
+		if !ok {
+			return trace.BadParameter("%v not in set", v)
+		}
+
+	}
+	return nil
+}
+
+// UintSliceSubset returns true if b is a subset of a.
+func UintSliceSubset(a []uint16, b []uint16) error {
+	aset := make(map[uint16]bool)
+	for _, v := range a {
+		aset[v] = true
+	}
+
+	for _, v := range b {
+		_, ok := aset[v]
+		if !ok {
+			return trace.BadParameter("%v not in set", v)
+		}
+
+	}
+	return nil
+}
+
 // RemoveFromSlice makes a copy of the slice and removes the passed in values from the copy.
 func RemoveFromSlice(slice []string, values ...string) []string {
 	output := make([]string, 0, len(slice))

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -116,6 +116,10 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 		"Enables reading of ~/.tsh/environment when creating a session").Hidden().BoolVar(&ccf.PermitUserEnvironment)
 	start.Flag("insecure",
 		"Insecure mode disables certificate validation").BoolVar(&ccf.InsecureMode)
+	start.Flag("fips",
+		"Start Teleport in FedRAMP/FIPS 140-2 mode.").
+		Default("false").
+		BoolVar(&ccf.FIPS)
 
 	// define start's usage info (we use kingpin's "alias" field for this)
 	start.Alias(usageNotes + usageExamples)
@@ -137,8 +141,13 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 		utils.FatalError(err)
 	}
 
-	// create the default configuration:
+	// Create default configuration.
 	conf = service.MakeDefaultConfig()
+
+	// If FIPS mode is specified update defaults to be FIPS appropriate.
+	if ccf.FIPS {
+		service.ApplyFIPSDefaults(conf)
+	}
 
 	// execute the selected command unless we're running tests
 	switch command {


### PR DESCRIPTION
**Description**

Added `--fips` flag to `teleport start` command which can start Enterprise in FedRAMP/FIPS 140-2 mode.

In FIPS mode, Teleport configures the TLS and SSH servers with FIPS compliant cryptographic algorithms. In FIPS mode, if non-compliant algorithms are chosen, Teleport will fail to start. In addition, Teleport checks if the binary was compiled against an approved cryptographic module (BoringCrypto) and fails to start if it was not.

**Related Issues**

https://github.com/gravitational/teleport.e/pull/107
https://github.com/gravitational/teleport.e/issues/106