### PR TITLE
Kubernetes proxy to use impersonation API

### DIFF
--- a/examples/chart/teleport/templates/clusterrole.yaml
+++ b/examples/chart/teleport/templates/clusterrole.yaml
@@ -10,20 +10,11 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
 - apiGroups:
-  - certificates.k8s.io
+  - ""
   resources:
-  - certificatesigningrequests
+  - users
+  - groups
+  - serviceaccounts
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - watch
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests/approval
-  - certificatesigningrequests/status
-  verbs:
-   - update
+  - impersonate
 {{- end -}}

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016-2018 Gravitational, Inc.
+Copyright 2016-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/transport"
 	"k8s.io/client-go/transport/spdy"
 )
 
@@ -166,8 +167,18 @@ func (s *KubeSuite) TestKubeExec(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer t.Stop(true)
 
+	// impersonating client requests will be denied
+	impersonatingProxyClient, impersonatingProxyClientConfig, err := kubeProxyClient(t, username, &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system: masters"}})
+	c.Assert(err, check.IsNil)
+
+	// try get request to fetch available pods
+	_, err = impersonatingProxyClient.Core().Pods(kubeSystemNamespace).List(metav1.ListOptions{
+		LabelSelector: kubeDNSLabels.AsSelector().String(),
+	})
+	c.Assert(err, check.NotNil)
+
 	// set up kube configuration using proxy
-	proxyClient, proxyClientConfig, err := kubeProxyClient(t, username)
+	proxyClient, proxyClientConfig, err := kubeProxyClient(t, username, nil)
 	c.Assert(err, check.IsNil)
 
 	// try get request to fetch available pods
@@ -175,6 +186,7 @@ func (s *KubeSuite) TestKubeExec(c *check.C) {
 		LabelSelector: kubeDNSLabels.AsSelector().String(),
 	})
 	c.Assert(len(pods.Items), check.Not(check.Equals), int(0))
+	c.Assert(err, check.IsNil)
 
 	// Exec through proxy and collect output
 	pod := pods.Items[0]
@@ -235,6 +247,22 @@ loop:
 
 	c.Assert(string(capturedStream), check.Equals, sessionStream)
 
+	// impersonating kube exec should be denied
+	// interactive command, allocate pty
+	term = NewTerminal(250)
+	term.Type("\aecho hi\n\r\aexit\n\r\a")
+	out = &bytes.Buffer{}
+	err = kubeExec(impersonatingProxyClientConfig, kubeExecArgs{
+		podName:      pod.Name,
+		podNamespace: pod.Namespace,
+		container:    kubeDNSContainer,
+		command:      []string{"/bin/sh"},
+		stdout:       out,
+		tty:          true,
+		stdin:        &term,
+	})
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Matches, ".*impersonation request has been denied.*")
 }
 
 // TestKubePortForward tests kubernetes port forwarding
@@ -267,7 +295,7 @@ func (s *KubeSuite) TestKubePortForward(c *check.C) {
 	defer t.Stop(true)
 
 	// set up kube configuration using proxy
-	_, proxyClientConfig, err := kubeProxyClient(t, username)
+	_, proxyClientConfig, err := kubeProxyClient(t, username, nil)
 	c.Assert(err, check.IsNil)
 
 	// pick the first kube-dns pod and run port forwarding on it
@@ -310,6 +338,23 @@ func (s *KubeSuite) TestKubePortForward(c *check.C) {
 	addr, err := resolver.LookupHost(context.TODO(), "kubernetes.default.svc.cluster.local")
 	c.Assert(err, check.IsNil)
 	c.Assert(len(addr), check.Not(check.Equals), 0)
+
+	// impersonating client requests will be denied
+	_, impersonatingProxyClientConfig, err := kubeProxyClient(t, username, &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system: masters"}})
+	c.Assert(err, check.IsNil)
+
+	localPort = s.ports.Pop()
+	impersonatingForwarder, err := newPortForwarder(impersonatingProxyClientConfig, kubePortForwardArgs{
+		ports:        []string{fmt.Sprintf("%v:53", localPort)},
+		podName:      pod.Name,
+		podNamespace: pod.Namespace,
+	})
+	c.Assert(err, check.IsNil)
+
+	// This request should be denied
+	err = impersonatingForwarder.ForwardPorts()
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Matches, ".*impersonation request has been denied.*")
 }
 
 // TestKubeTrustedClusters tests scenario with trusted clsuters
@@ -352,6 +397,8 @@ func (s *KubeSuite) TestKubeTrustedClusters(c *check.C) {
 
 	// route all the traffic to the aux cluster
 	mainConf.Proxy.Kube.Enabled = true
+	// ClusterOverride forces connection to be routed
+	// to cluster aux
 	mainConf.Proxy.Kube.ClusterOverride = clusterAux
 	err = main.CreateEx(nil, mainConf)
 	c.Assert(err, check.IsNil)
@@ -419,8 +466,18 @@ func (s *KubeSuite) TestKubeTrustedClusters(c *check.C) {
 		}
 	}
 
+	// impersonating client requests will be denied
+	impersonatingProxyClient, impersonatingProxyClientConfig, err := kubeProxyClient(main, username, &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system: masters"}})
+	c.Assert(err, check.IsNil)
+
+	// try get request to fetch available pods
+	_, err = impersonatingProxyClient.Core().Pods(kubeSystemNamespace).List(metav1.ListOptions{
+		LabelSelector: kubeDNSLabels.AsSelector().String(),
+	})
+	c.Assert(err, check.NotNil)
+
 	// set up kube configuration using main proxy
-	proxyClient, proxyClientConfig, err := kubeProxyClient(main, username)
+	proxyClient, proxyClientConfig, err := kubeProxyClient(main, username, nil)
 	c.Assert(err, check.IsNil)
 
 	// try get request to fetch available pods
@@ -488,6 +545,23 @@ loop:
 
 	c.Assert(string(capturedStream), check.Equals, sessionStream)
 
+	// impersonating kube exec should be denied
+	// interactive command, allocate pty
+	term = NewTerminal(250)
+	term.Type("\aecho hi\n\r\aexit\n\r\a")
+	out = &bytes.Buffer{}
+	err = kubeExec(impersonatingProxyClientConfig, kubeExecArgs{
+		podName:      pod.Name,
+		podNamespace: pod.Namespace,
+		container:    kubeDNSContainer,
+		command:      []string{"/bin/sh"},
+		stdout:       out,
+		tty:          true,
+		stdin:        &term,
+	})
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Matches, ".*impersonation request has been denied.*")
+
 	// forward local port to target port 53 of the dnsmasq container
 	localPort := s.ports.Pop()
 
@@ -521,6 +595,20 @@ loop:
 	c.Assert(err, check.IsNil)
 	c.Assert(len(addr), check.Not(check.Equals), 0)
 
+	// impersonating client requests will be denied
+	localPort = s.ports.Pop()
+	impersonatingForwarder, err := newPortForwarder(impersonatingProxyClientConfig, kubePortForwardArgs{
+		ports:        []string{fmt.Sprintf("%v:53", localPort)},
+		podName:      pod.Name,
+		podNamespace: pod.Namespace,
+	})
+	c.Assert(err, check.IsNil)
+
+	// This request should be denied
+	err = impersonatingForwarder.ForwardPorts()
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Matches, ".*impersonation request has been denied.*")
+
 }
 
 // teleKubeConfig sets up teleport with kubernetes turned on
@@ -535,7 +623,7 @@ func (s *KubeSuite) teleKubeConfig(hostname string) *service.Config {
 	// set kubernetes specific parameters
 	tconf.Proxy.Kube.Enabled = true
 	tconf.Proxy.Kube.ListenAddr.Addr = net.JoinHostPort(hostname, s.ports.Pop())
-	tconf.Auth.KubeconfigPath = s.kubeConfigPath
+	tconf.Proxy.Kube.KubeconfigPath = s.kubeConfigPath
 
 	return tconf
 }
@@ -563,7 +651,7 @@ func tlsClientConfig(cfg *rest.Config) (*tls.Config, error) {
 }
 
 // kubeProxyClient returns kubernetes client using local teleport proxy
-func kubeProxyClient(t *TeleInstance, username string) (*kubernetes.Clientset, *rest.Config, error) {
+func kubeProxyClient(t *TeleInstance, username string, impersonation *rest.ImpersonationConfig) (*kubernetes.Clientset, *rest.Config, error) {
 	authServer := t.Process.GetAuthServer()
 	clusterName, err := authServer.GetClusterName()
 	if err != nil {
@@ -592,6 +680,9 @@ func kubeProxyClient(t *TeleInstance, username string) (*kubernetes.Clientset, *
 	config := &rest.Config{
 		Host:            "https://" + t.Config.Proxy.Kube.ListenAddr.Addr,
 		TLSClientConfig: tlsClientConfig,
+	}
+	if impersonation != nil {
+		config.Impersonate = *impersonation
 	}
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -655,11 +746,20 @@ func newPortForwarder(kubeConfig *rest.Config, args kubePortForwardArgs) (*kubeP
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	upgradeRoundTripper := streamspdy.NewSpdyRoundTripper(tlsConfig, true)
 	client := &http.Client{
 		Transport: upgradeRoundTripper,
 	}
 	dialer := spdy.NewDialer(upgradeRoundTripper, client, "POST", u)
+	if kubeConfig.Impersonate.UserName != "" {
+		client.Transport = transport.NewImpersonatingRoundTripper(
+			transport.ImpersonationConfig{
+				UserName: kubeConfig.Impersonate.UserName,
+				Groups:   kubeConfig.Impersonate.Groups,
+			},
+			upgradeRoundTripper)
+	}
 
 	out, errOut := &bytes.Buffer{}, &bytes.Buffer{}
 	stopC, readyC := make(chan struct{}), make(chan struct{})

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -101,7 +101,6 @@ func NewAuthServer(cfg *InitConfig, opts ...AuthServerOption) (*AuthServer, erro
 		githubClients:        make(map[string]*githubClient),
 		cancelFunc:           cancelFunc,
 		closeCtx:             closeCtx,
-		kubeconfigPath:       cfg.KubeconfigPath,
 	}
 	for _, o := range opts {
 		o(&as)
@@ -153,9 +152,6 @@ type AuthServer struct {
 
 	// cipherSuites is a list of ciphersuites that the auth server supports.
 	cipherSuites []uint16
-
-	// kubeconfigPath is a path to PEM encoded kubernetes CA certificate
-	kubeconfigPath string
 }
 
 // runPeriodicOperations runs some periodic bookkeeping operations

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -126,9 +126,6 @@ type InitConfig struct {
 
 	// CipherSuites is a list of ciphersuites that the auth server supports.
 	CipherSuites []uint16
-
-	// KubeconfigPath is an optional path to kubernetes config file
-	KubeconfigPath string
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,22 +17,13 @@ limitations under the License.
 package auth
 
 import (
-	"fmt"
-	"io/ioutil"
-	"net"
-	"net/url"
-	"os"
-
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/kube/authority"
-	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 
 	"github.com/gravitational/trace"
-	"k8s.io/client-go/kubernetes"
 )
 
 // KubeCSR is a kubernetes CSR request
@@ -53,7 +44,7 @@ func (a *KubeCSR) CheckAndSetDefaults() error {
 	return nil
 }
 
-// KubeCSRREsponse is a response to kubernetes CSR request
+// KubeCSRResponse is a response to kubernetes CSR request
 type KubeCSRResponse struct {
 	// Cert is a signed certificate PEM block
 	Cert []byte `json:"cert"`
@@ -63,17 +54,6 @@ type KubeCSRResponse struct {
 	// of the kubernetes API server that can be set
 	// in the kubeconfig
 	TargetAddr string `json:"target_addr"`
-}
-
-type kubeCreds struct {
-	// clt is a working kubernetes client
-	clt *kubernetes.Clientset
-	// caPEM is a PEM encoded certificate authority
-	// of the kubernetes API server
-	caPEM []byte
-	// targetAddr is a target address of the
-	// kubernetes cluster read from config
-	targetAddr string
 }
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
@@ -87,28 +67,9 @@ func (s *AuthServer) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if req.ClusterName == s.clusterName.GetClusterName() {
-		log.Debugf("Generating certificate for local Kubernetes cluster.")
-
-		kubeCreds, err := s.getKubeClient()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		cert, err := authority.ProcessCSR(kubeCreds.clt, req.CSR)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return &KubeCSRResponse{
-			Cert:            cert,
-			CertAuthorities: [][]byte{kubeCreds.caPEM},
-			TargetAddr:      kubeCreds.targetAddr,
-		}, nil
-	}
-
-	// Certificate for remote cluster is a user certificate
+	// Certificate for remote clusters is a user certificate
 	// with special provisions.
-	log.Debugf("Generating certificate for remote Kubernetes cluster.")
+	log.Debugf("Generating certificate to access remote Kubernetes clusters.")
 
 	hostCA, err := s.GetCertAuthority(services.CertAuthID{
 		Type:       services.HostCA,
@@ -179,79 +140,4 @@ func (s *AuthServer) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 		re.CertAuthorities = append(re.CertAuthorities, keyPair.Cert)
 	}
 	return re, nil
-}
-
-func (s *AuthServer) getKubeClient() (*kubeCreds, error) {
-	// no kubeconfig is set, assume auth server is running in the cluster
-	if s.kubeconfigPath == "" {
-		caPEM, err := ioutil.ReadFile(teleport.KubeCAPath)
-		if err != nil {
-			return nil, trace.BadParameter(`auth server assumed that it is 
-running in a kubernetes cluster, but %v mounted in pods could not be read: %v, 
-set kubeconfig_path if auth server is running outside of the cluster`, teleport.KubeCAPath, err)
-		}
-
-		clt, cfg, err := kubeutils.GetKubeClient(os.Getenv(teleport.EnvKubeConfig))
-		if err != nil {
-			return nil, trace.BadParameter(`auth server assumed that it is 
-running in a kubernetes cluster, but could not init in-cluster kubernetes client: %v`, err)
-		}
-
-		targetAddr, err := parseKubeHost(cfg.Host)
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to parse kubernetes host")
-		}
-
-		return &kubeCreds{
-			clt:        clt,
-			caPEM:      caPEM,
-			targetAddr: targetAddr,
-		}, nil
-	}
-
-	log.Debugf("Reading configuration from kubeconfig file %v.", s.kubeconfigPath)
-
-	clt, cfg, err := kubeutils.GetKubeClient(s.kubeconfigPath)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	targetAddr, err := parseKubeHost(cfg.Host)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to parse kubernetes host")
-	}
-
-	var caPEM []byte
-	if len(cfg.CAData) == 0 {
-		if cfg.CAFile == "" {
-			return nil, trace.BadParameter("can't find trusted certificates in %v", s.kubeconfigPath)
-		}
-		caPEM, err = ioutil.ReadFile(cfg.CAFile)
-		if err != nil {
-			return nil, trace.BadParameter("failed to read trusted certificates from %v: %v", cfg.CAFile, err)
-		}
-	} else {
-		caPEM = cfg.CAData
-	}
-
-	return &kubeCreds{
-		clt:        clt,
-		caPEM:      caPEM,
-		targetAddr: targetAddr,
-	}, nil
-}
-
-// parseKubeHost parses and formats kubernetes hostname
-// to host:port format, if no port it set,
-// it assumes default HTTPS port
-func parseKubeHost(host string) (string, error) {
-	u, err := url.Parse(host)
-	if err != nil {
-		return "", trace.Wrap(err, "failed to parse kubernetes host")
-	}
-	if _, _, err := net.SplitHostPort(u.Host); err != nil {
-		// add default HTTPS port
-		return fmt.Sprintf("%v:443", u.Host), nil
-	}
-	return u.Host, nil
 }

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -319,9 +319,10 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 func applyAuthConfig(fc *FileConfig, cfg *service.Config) error {
 	var err error
 
-	// passhtrough custom certificate authority file
 	if fc.Auth.KubeconfigFile != "" {
-		cfg.Auth.KubeconfigPath = fc.Auth.KubeconfigFile
+		warningMessage := "The auth_service no longer needs kubeconfig_file. It has " +
+			"been moved to proxy_service section. This setting is ignored."
+		log.Warning(warningMessage)
 	}
 	cfg.Auth.EnableProxyProtocol, err = utils.ParseOnOff("proxy_protocol", fc.Auth.ProxyProtocol, true)
 	if err != nil {
@@ -518,6 +519,9 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 	// apply kubernetes proxy config, by default kube proxy is disabled
 	if fc.Proxy.Kube.Configured() {
 		cfg.Proxy.Kube.Enabled = fc.Proxy.Kube.Enabled()
+	}
+	if fc.Proxy.Kube.KubeconfigFile != "" {
+		cfg.Proxy.Kube.KubeconfigPath = fc.Proxy.Kube.KubeconfigFile
 	}
 	if fc.Proxy.Kube.ListenAddress != "" {
 		addr, err := utils.ParseHostPortAddr(fc.Proxy.Kube.ListenAddress, int(defaults.KubeProxyListenPort))

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -761,6 +761,10 @@ type Kube struct {
 	Service `yaml:",inline"`
 	// PublicAddr is a publicly advertised address of the kubernetes proxy
 	PublicAddr utils.Strings `yaml:"public_addr,omitempty"`
+	// KubeconfigFile is an optional path to kubeconfig file,
+	// if specified, teleport will use API server address and
+	// trusted certificate authority information from it
+	KubeconfigFile string `yaml:"kubeconfig_file,omitempty"`
 }
 
 // ReverseTunnel is a SSH reverse tunnel maintained by one cluster's

--- a/lib/kube/doc.go
+++ b/lib/kube/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// package kube contains subpackages with utility functions
+// Package kube contains subpackages with utility functions
 // and proxies to intercept and authenticate Kubernetes API traffic
 package kube

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Gravitational, Inc.
+Copyright 2018-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -32,3 +32,13 @@ func GetKubeClient(configPath string) (client *kubernetes.Clientset, config *res
 	}
 	return client, config, nil
 }
+
+// GetKubeConfig returns kubernetes configuration
+// from configPath file or, by default reads in-cluster configuration
+func GetKubeConfig(configPath string) (*rest.Config, error) {
+	// if path to kubeconfig was provided, init config from it
+	if configPath != "" {
+		return clientcmd.BuildConfigFromFlags("", configPath)
+	}
+	return rest.InClusterConfig()
+}

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -320,6 +320,9 @@ type KubeProxyConfig struct {
 	// PublicAddrs is a list of the public addresses the Teleport Kube proxy can be accessed by,
 	// it also affects the host principals and routing logic
 	PublicAddrs []utils.NetAddr
+
+	// KubeconfigPath is a path to kubeconfig
+	KubeconfigPath string
 }
 
 // AuthConfig is a configuration of the auth server
@@ -370,9 +373,6 @@ type AuthConfig struct {
 
 	// PublicAddrs affects the SSH host principals and DNS names added to the SSH and TLS certs.
 	PublicAddrs []utils.NetAddr
-
-	// KubeconfigPath is a path to kubeconfig
-	KubeconfigPath string
 }
 
 // SSHConfig configures SSH server node role

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -920,7 +920,6 @@ func (process *TeleportProcess) initAuthService() error {
 		OIDCConnectors:       cfg.OIDCConnectors,
 		AuditLog:             process.auditLog,
 		CipherSuites:         cfg.CipherSuites,
-		KubeconfigPath:       cfg.Auth.KubeconfigPath,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -1906,6 +1905,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				AuditLog:        conn.Client,
 				ServerID:        cfg.HostUUID,
 				ClusterOverride: cfg.Proxy.Kube.ClusterOverride,
+				KubeconfigPath:  cfg.Proxy.Kube.KubeconfigPath,
 			},
 			TLS:           tlsConfig,
 			LimiterConfig: cfg.Proxy.Limiter,


### PR DESCRIPTION
This commit switches Teleport proxy to use impersonation
API instead of the CSR API.

This allows Teleport to work on EKS clusters, GKE and all
other CNCF compabitble clusters.

This commit updates helm chart RBAC as well.

It introduces extra configuration flag to proxy_service
configuration parameter:

```yaml
proxy_service:
   # kubeconfig_file is used for scenarios
   # when Teleport Proxy is deployed outside
   # of the kubernetes cluster
   kubeconfig_file: /path/to/kube/config
```

It deprecates similar flag in auth_service:

```yaml
auth_service:
   # DEPRECATED. THIS FLAG IS IGNORED
   kubeconfig_file: /path/to/kube/config
```