### PR TITLE
Kubernetes SNI proxy improvements, implements #2614

### DIFF
--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -30,12 +30,13 @@ import (
 
 // LocalRegister is used to generate host keys when a node or proxy is running within the same process
 // as the auth server. This method does not need to use provisioning tokens.
-func LocalRegister(id IdentityID, authServer *AuthServer, additionalPrincipals []string) (*Identity, error) {
+func LocalRegister(id IdentityID, authServer *AuthServer, additionalPrincipals, dnsNames []string) (*Identity, error) {
 	keys, err := authServer.GenerateServerKeys(GenerateServerKeysRequest{
 		HostID:               id.HostUUID,
 		NodeName:             id.NodeName,
 		Roles:                teleport.Roles{id.Role},
 		AdditionalPrincipals: additionalPrincipals,
+		DNSNames:             dnsNames,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -57,6 +58,8 @@ type RegisterParams struct {
 	Servers []utils.NetAddr
 	// AdditionalPrincipals is a list of additional principals to dial
 	AdditionalPrincipals []string
+	// DNSNames is a list of DNS names to add to x509 certificate
+	DNSNames []string
 	// PrivateKey is a PEM encoded private key (not passed to auth servers)
 	PrivateKey []byte
 	// PublicTLSKey is a server's public key to sign
@@ -105,6 +108,7 @@ func Register(params RegisterParams) (*Identity, error) {
 		NodeName:             params.ID.NodeName,
 		Role:                 params.ID.Role,
 		AdditionalPrincipals: params.AdditionalPrincipals,
+		DNSNames:             params.DNSNames,
 		PublicTLSKey:         params.PublicTLSKey,
 		PublicSSHKey:         params.PublicSSHKey,
 	})
@@ -228,6 +232,8 @@ type ReRegisterParams struct {
 	ID IdentityID
 	// AdditionalPrincipals is a list of additional principals to dial
 	AdditionalPrincipals []string
+	// DNSNames is a list of DNS Names to add to the x509 client certificate
+	DNSNames []string
 	// PrivateKey is a PEM encoded private key (not passed to auth servers)
 	PrivateKey []byte
 	// PublicTLSKey is a server's public key to sign
@@ -247,6 +253,7 @@ func ReRegister(params ReRegisterParams) (*Identity, error) {
 		NodeName:             params.ID.NodeName,
 		Roles:                teleport.Roles{params.ID.Role},
 		AdditionalPrincipals: params.AdditionalPrincipals,
+		DNSNames:             params.DNSNames,
 		PublicTLSKey:         params.PublicTLSKey,
 		PublicSSHKey:         params.PublicSSHKey,
 	})

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -334,7 +334,8 @@ func (f *Forwarder) setupContext(ctx auth.AuthContext, req *http.Request, isRemo
 		return nil, trace.Wrap(err)
 	}
 	for _, remoteCluster := range f.Tunnel.GetSites() {
-		if strings.HasPrefix(req.Host, remoteCluster.GetName()+".") {
+		encodedName := kubeutils.EncodeClusterName(remoteCluster.GetName())
+		if strings.HasPrefix(req.Host, remoteCluster.GetName()+".") || strings.HasPrefix(req.Host, encodedName+".") {
 			f.Debugf("Going to proxy to cluster: %v based on matching host prefix %v.", remoteCluster.GetName(), req.Host)
 			targetCluster = remoteCluster
 			isRemoteCluster = remoteCluster.GetName() != f.ClusterName
@@ -771,6 +772,7 @@ func (f *Forwarder) newClusterSession(ctx authContext) (*clusterSession, error) 
 	return sess, nil
 }
 
+// DialFunc is a network dialer function that returns a network connection
 type DialFunc func(string, string) (net.Conn, error)
 
 func (f *Forwarder) newTransport(dial DialFunc, tlsConfig *tls.Config) *http.Transport {

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"encoding/hex"
+
 	"github.com/gravitational/trace"
 
 	"k8s.io/client-go/kubernetes"
@@ -41,4 +43,29 @@ func GetKubeConfig(configPath string) (*rest.Config, error) {
 		return clientcmd.BuildConfigFromFlags("", configPath)
 	}
 	return rest.InClusterConfig()
+}
+
+// EncodeClusterName encodes cluster name for SNI matching
+//
+// For example:
+//
+// * Main cluster is main.example.com
+// * Remote cluster is remote.example.com
+//
+// After 'tsh login' the URL of the Kubernetes endpoint of 'remote.example.com'
+// when accessed 'via main.example.com' looks like this:
+//
+// 'k72656d6f74652e6578616d706c652e636f6d0a.main.example.com'
+//
+// For this to work, users have to add this address in public_addr section of kubernetes service
+// to include 'main.example.com' in X509 '*.main.example.com' domain name
+//
+// where part '72656d6f74652e6578616d706c652e636f6d0a' is a hex encoded remote.example.com
+//
+// It is hex encoded to allow wildcard matching to work. In DNS wildcard match
+// include only one '.'
+//
+func EncodeClusterName(clusterName string) string {
+	// k is to avoid first letter to be a number
+	return "k" + hex.EncodeToString([]byte(clusterName))
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015-2017 Gravitational, Inc.
+Copyright 2015-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -311,11 +311,11 @@ func (process *TeleportProcess) GetIdentity(role teleport.Role) (i *auth.Identit
 			// for admin identity use local auth server
 			// because admin identity is requested by auth server
 			// itself
-			principals, err := process.getAdditionalPrincipals(role)
+			principals, dnsNames, err := process.getAdditionalPrincipals(role)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			i, err = auth.GenerateIdentity(process.localAuth, id, principals)
+			i, err = auth.GenerateIdentity(process.localAuth, id, principals, dnsNames)
 		} else {
 			// try to locate static identity provided in the file
 			i, err = process.findStaticIdentity(id)
@@ -1497,8 +1497,9 @@ func (process *TeleportProcess) initDiagnosticService() error {
 
 // getAdditionalPrincipals returns a list of additional principals to add
 // to role's service certificates.
-func (process *TeleportProcess) getAdditionalPrincipals(role teleport.Role) ([]string, error) {
+func (process *TeleportProcess) getAdditionalPrincipals(role teleport.Role) ([]string, []string, error) {
 	var principals []string
+	var dnsNames []string
 	if process.Config.Hostname != "" {
 		principals = append(principals, process.Config.Hostname)
 	}
@@ -1508,6 +1509,18 @@ func (process *TeleportProcess) getAdditionalPrincipals(role teleport.Role) ([]s
 		addrs = append(process.Config.Proxy.PublicAddrs, utils.NetAddr{Addr: reversetunnel.RemoteKubeProxy})
 		addrs = append(addrs, process.Config.Proxy.SSHPublicAddrs...)
 		addrs = append(addrs, process.Config.Proxy.Kube.PublicAddrs...)
+		// Automatically add wildcards for every proxy public address for k8s SNI routing
+		if process.Config.Proxy.Kube.Enabled {
+			for _, publicAddr := range utils.JoinAddrSlices(process.Config.Proxy.PublicAddrs, process.Config.Proxy.Kube.PublicAddrs) {
+				host, err := utils.Host(publicAddr.Addr)
+				if err != nil {
+					return nil, nil, trace.Wrap(err)
+				}
+				if ip := net.ParseIP(host); ip == nil {
+					dnsNames = append(dnsNames, "*."+host)
+				}
+			}
+		}
 	case teleport.RoleAuth, teleport.RoleAdmin:
 		addrs = process.Config.Auth.PublicAddrs
 	case teleport.RoleNode:
@@ -1516,11 +1529,11 @@ func (process *TeleportProcess) getAdditionalPrincipals(role teleport.Role) ([]s
 	for _, addr := range addrs {
 		host, err := utils.Host(addr.Addr)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, nil, trace.Wrap(err)
 		}
 		principals = append(principals, host)
 	}
-	return principals, nil
+	return principals, dnsNames, nil
 }
 
 // initProxy gets called if teleport runs with 'proxy' role enabled.

--- a/lib/utils/addr.go
+++ b/lib/utils/addr.go
@@ -172,6 +172,17 @@ func FromAddr(a net.Addr) NetAddr {
 	return NetAddr{AddrNetwork: a.Network(), Addr: a.String()}
 }
 
+// JoinAddrSlices joins two addr slices and returns a resulting slice
+func JoinAddrSlices(a []NetAddr, b []NetAddr) []NetAddr {
+	if len(a)+len(b) == 0 {
+		return nil
+	}
+	out := make([]NetAddr, 0, len(a)+len(b))
+	out = append(out, a...)
+	out = append(out, b...)
+	return out
+}
+
 // ParseHostPortAddr takes strings like "host:port" and returns
 // *NetAddr or an error
 //

--- a/lib/utils/copy.go
+++ b/lib/utils/copy.go
@@ -38,6 +38,17 @@ func CopyByteSlices(in [][]byte) [][]byte {
 	return out
 }
 
+// JoinStringSlices joins two string slices and returns a resulting slice
+func JoinStringSlices(a []string, b []string) []string {
+	if len(a)+len(b) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(a)+len(b))
+	out = append(out, a...)
+	out = append(out, b...)
+	return out
+}
+
 // CopyStrings makes a deep copy of the passed in string slice and returns
 // the copy.
 func CopyStrings(in []string) []string {


### PR DESCRIPTION
This commit hex encodes trusted cluster names
in target addresses for kubernetes SNI proxy.

For example, assuming public address of Teleport
Kubernetes proxy is main.example.com, and trusted
cluster is remote.example.com, resulting target
address added to kubeconfig will look like

k72656d6f74652e6578616d706c652e636f6d0a.main.example.com

And Teleport Proxy's DNS Name will include wildcard:

'*.main.example.com' in addition to 'main.example.com'

Note that no dots are in the SNI address thanks to hex encoding.

This will allow administrators to avoid manually updating
list of public_addr sections every time the trusted cluster and use
the wildcard DNS name.

The following addr:

remote.example.com.main.example.com would not have matched
*.main.example.com per DNS wildcard spec.