### PR TITLE
Trim whitespace in SAML metadata decoding.

### DIFF
--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -550,7 +550,7 @@ func (o *SAMLConnectorV2) GetServiceProvider(clock clockwork.Clock) (*saml2.SAML
 		}
 
 		for _, kd := range metadata.IDPSSODescriptor.KeyDescriptors {
-			certData, err := base64.StdEncoding.DecodeString(kd.KeyInfo.X509Data.X509Certificate.Data)
+			certData, err := base64.StdEncoding.DecodeString(strings.TrimSpace(kd.KeyInfo.X509Data.X509Certificate.Data))
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}


### PR DESCRIPTION
**Description**

Some identity providers add additional whitespace in the `ds:X509Certificate` entity. For example:

```
<ds:X509Certificate>
    [...]
</ds:X509Certificate>
```

Instead of the following:

```
<ds:X509Certificate>[...]</ds:X509Certificate>
```

This PR fixes this issue by removing whitespace before attempting to base64 decode the certificate.