### PR TITLE
Paginate on capacity throttling, fixes #2576

### DIFF
--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -76,7 +76,7 @@ func (s *DynamoDBSuite) TestBatchCRUD(c *C) {
 	s.suite.BatchCRUD(c)
 }
 
-func (s *Suite) TestDeduplicate(c *check.C) {
+func (s *DynamoDBSuite) TestDeduplicate(c *C) {
 	s.suite.Deduplicate(c)
 }
 


### PR DESCRIPTION
This commit adds pagination for cases when DynamoDB turns on capacity throttling on large result sets.

I'm adding this backport per customer's request experiencing this issue on production.