### PR TITLE
[Forward-port 3.2] Add "search events" web API method.

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -635,6 +635,94 @@ func (s *AuthSuite) TestMigrateAdminRole(c *C) {
 	c.Assert(out.GetKubeGroups(services.Allow), DeepEquals, modules.GetModules().DefaultKubeGroups())
 }
 
+// TestMigrateRoleRules ensures that roles get updated with events access
+// during migration.
+func (s *AuthSuite) TestMigrateRoleRules(c *C) {
+	testCases := []struct {
+		// RoleName is the test role name.
+		RoleName string
+		// AllowRules is the role allow rules before migration.
+		AllowRules []services.Rule
+		// DenyRules is the role deny rules before migration.
+		DenyRules []services.Rule
+		// ExpectedAllowRules is the role allow rules after migration.
+		ExpectedAllowRules []services.Rule
+		// Comment is the test case description.
+		Comment string
+	}{
+		{
+			Comment:  "Role has sessions access",
+			RoleName: "role-1",
+			AllowRules: []services.Rule{
+				services.NewRule(services.KindSession, services.RO()),
+			},
+			ExpectedAllowRules: []services.Rule{
+				services.NewRule(services.KindSession, services.RO()),
+				services.NewRule(services.KindEvent, services.RO()),
+			},
+		},
+		{
+			Comment:  "Role explicitly denies events access",
+			RoleName: "role-2",
+			AllowRules: []services.Rule{
+				services.NewRule(services.KindSession, services.RO()),
+			},
+			DenyRules: []services.Rule{
+				services.NewRule(services.KindEvent, services.RO()),
+			},
+			ExpectedAllowRules: []services.Rule{
+				services.NewRule(services.KindSession, services.RO()),
+			},
+		},
+		{
+			Comment:  "Role does not have sessions access",
+			RoleName: "role-3",
+			AllowRules: []services.Rule{
+				services.NewRule(services.KindNode, services.RO()),
+			},
+			ExpectedAllowRules: []services.Rule{
+				services.NewRule(services.KindNode, services.RO()),
+			},
+		},
+		{
+			Comment:  "Role already has events access",
+			RoleName: "role-4",
+			AllowRules: []services.Rule{
+				services.NewRule(services.KindEvent, services.RO()),
+			},
+			ExpectedAllowRules: []services.Rule{
+				services.NewRule(services.KindEvent, services.RO()),
+			},
+		},
+		{
+			Comment:  "Role has wildcard access",
+			RoleName: "role-5",
+			AllowRules: []services.Rule{
+				services.NewRule(services.Wildcard, services.RO()),
+			},
+			ExpectedAllowRules: []services.Rule{
+				services.NewRule(services.Wildcard, services.RO()),
+			},
+		},
+	}
+	for _, tc := range testCases {
+		// Create the test role.
+		role, err := services.NewRole(tc.RoleName, services.RoleSpecV3{
+			Allow: services.RoleConditions{Rules: tc.AllowRules},
+			Deny:  services.RoleConditions{Rules: tc.DenyRules},
+		})
+		c.Assert(err, IsNil)
+		c.Assert(s.a.UpsertRole(role, backend.Forever), IsNil)
+		// Run migration.
+		c.Assert(migrateRoleRules(s.a), IsNil)
+		// Get the role back and make sure it's been migrated properly.
+		retrievedRole, err := s.a.GetRole(tc.RoleName)
+		c.Assert(err, IsNil)
+		c.Assert(retrievedRole.GetRules(services.Allow), DeepEquals,
+			tc.ExpectedAllowRules, Commentf(tc.Comment))
+	}
+}
+
 // writeKeys saves the key/cert pair for a given domain onto disk. This usually means the
 // domain trusts us (signed our public key)
 func writeKeys(dataDir string, id IdentityID, key []byte, sshCert []byte, tlsCert []byte, tlsCACert []byte) error {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -418,6 +418,10 @@ func migrateLegacyResources(cfg InitConfig, asrv *AuthServer) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	err = migrateRoleRules(asrv)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }
 
@@ -500,6 +504,60 @@ func migrateAdminRole(asrv *AuthServer) error {
 	log.Infof("Migrating default admin role, adding default kubernetes groups.")
 	role.SetKubeGroups(services.Allow, defaultRole.GetKubeGroups(services.Allow))
 	return asrv.UpsertRole(role, backend.Forever)
+}
+
+// migrateRoleRules adds missing permissions to roles.
+//
+// Currently it adds read-only permissions for audit events to all roles that
+// have read-only session permissions to make sure audit log tab will work.
+func migrateRoleRules(asrv *AuthServer) error {
+	roles, err := asrv.GetRoles()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, role := range roles {
+		allowRules := role.GetRules(services.Allow)
+		denyRules := role.GetRules(services.Deny)
+		// First make sure access to events hasn't been explicitly denied.
+		if checkRules(denyRules, services.KindEvent, services.RO()) {
+			log.Debugf("Role %q explicitly denies events access.", role.GetName())
+			continue
+		}
+		// Next see if the role already has access to events.
+		if checkRules(allowRules, services.KindEvent, services.RO()) {
+			log.Debugf("Role %q already has events access.", role.GetName())
+			continue
+		}
+		// See if the role has access to sessions.
+		if !checkRules(allowRules, services.KindSession, services.RO()) {
+			log.Debugf("Role %q does not have sessions access.", role.GetName())
+			continue
+		}
+		// If we got here, the role does not yet have events access and
+		// has session access so add a rule for events as well.
+		log.Infof("Adding events access to role %q.", role.GetName())
+		allowRules = append(allowRules, services.NewRule(services.KindEvent, services.RO()))
+		role.SetRules(services.Allow, allowRules)
+		err := asrv.UpsertRole(role, backend.Forever)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// checkRules returns true if any of the provided rules contain specified resource/verbs.
+func checkRules(rules []services.Rule, kind string, verbs []string) bool {
+	for _, rule := range rules {
+		if rule.HasResource(kind) || rule.HasResource(services.Wildcard) {
+			for _, verb := range verbs {
+				if rule.HasVerb(verb) || rule.HasVerb(services.Wildcard) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // isFirstStart returns 'true' if the auth server is starting for the 1st time

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -44,6 +44,7 @@ var AdminUserRules = []Rule{
 	NewRule(KindAuthConnector, RW()),
 	NewRule(KindSession, RO()),
 	NewRule(KindTrustedCluster, RW()),
+	NewRule(KindEvent, RO()),
 }
 
 // DefaultImplicitRules provides access to the default set of implicit rules
@@ -859,6 +860,16 @@ func (r *Rule) ProcessActions(parser predicate.Parser) error {
 		fn()
 	}
 	return nil
+}
+
+// HasResource returns true if the rule has the specified resource.
+func (r *Rule) HasResource(resource string) bool {
+	for _, r := range r.Resources {
+		if r == resource {
+			return true
+		}
+	}
+	return false
 }
 
 // HasVerb returns true if the rule has verb,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -184,7 +184,8 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	h.GET("/webapi/sites/:site/namespaces/:namespace/sessions/:sid", h.WithClusterAuth(h.siteSessionGet))  // get active session metadata
 
 	// recorded sessions handlers
-	h.GET("/webapi/sites/:site/events", h.WithClusterAuth(h.siteEventsGet))                                            // get recorded list of sessions (from events)
+	h.GET("/webapi/sites/:site/events", h.WithClusterAuth(h.clusterSearchSessionEvents))                               // get recorded list of sessions (from events)
+	h.GET("/webapi/sites/:site/events/search", h.WithClusterAuth(h.clusterSearchEvents))                               // search site events
 	h.GET("/webapi/sites/:site/namespaces/:namespace/sessions/:sid/events", h.WithClusterAuth(h.siteSessionEventsGet)) // get recorded session's timing information (from events)
 	h.GET("/webapi/sites/:site/namespaces/:namespace/sessions/:sid/stream", h.siteSessionStreamGet)                    // get recorded session's bytes (from events)
 
@@ -1506,7 +1507,7 @@ func (h *Handler) siteSessionGet(w http.ResponseWriter, r *http.Request, p httpr
 
 const maxStreamBytes = 5 * 1024 * 1024
 
-// siteEventsGet allows to search for events on site
+// clusterSearchSessionEvents allows to search for session events on a cluster
 //
 // GET /v1/webapi/sites/:site/events
 //
@@ -1517,7 +1518,7 @@ const maxStreamBytes = 5 * 1024 * 1024
 //             the default backend performs exact search: ?key=value means "event
 //             with a field 'key' with value 'value'
 //
-func (h *Handler) siteEventsGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+func (h *Handler) clusterSearchSessionEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
 	query := r.URL.Query()
 
 	clt, err := ctx.GetUserClient(site)
@@ -1551,6 +1552,78 @@ func (h *Handler) siteEventsGet(w http.ResponseWriter, r *http.Request, p httpro
 		return nil, trace.Wrap(err)
 	}
 	return eventsListGetResponse{Events: el}, nil
+}
+
+// clusterSearchEvents returns all audit log events matching the provided criteria
+//
+// GET /v1/webapi/sites/:site/events/search
+//
+// Query parameters:
+//   "from"   : date range from, encoded as RFC3339
+//   "to"     : date range to, encoded as RFC3339
+//   "include": optional semicolon-separated list of event names to return e.g.
+//              include=session.start;session.end, all are returned if empty
+//   "limit"  : optional maximum number of events to return
+//
+func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error) {
+	values := r.URL.Query()
+	from, err := queryTime(values, "from", time.Now().UTC().AddDate(0, -1, 0))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	to, err := queryTime(values, "to", time.Now().UTC())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	limit, err := queryLimit(values, "limit", defaults.EventsIterationLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	query := url.Values{}
+	if include := values.Get("include"); include != "" {
+		query[events.EventType] = strings.Split(include, ";")
+	}
+	clt, err := ctx.GetUserClient(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	events, err := clt.SearchEvents(from, to, query.Encode(), limit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return eventsListGetResponse{Events: events}, nil
+}
+
+// queryTime parses the query string parameter with the specified name as a
+// RFC3339 time and returns it.
+//
+// If there's no such parameter, specified default value is returned.
+func queryTime(query url.Values, name string, def time.Time) (time.Time, error) {
+	str := query.Get(name)
+	if str == "" {
+		return def, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return time.Time{}, trace.BadParameter("failed to parse %v as RFC3339 time: %v", name, str)
+	}
+	return parsed, nil
+}
+
+// queryLimit returns the limit parameter with the specified name from the
+// query string.
+//
+// If there's no such parameter, specified default limit is returned.
+func queryLimit(query url.Values, name string, def int) (int, error) {
+	str := query.Get(name)
+	if str == "" {
+		return def, nil
+	}
+	limit, err := strconv.Atoi(str)
+	if err != nil {
+		return 0, trace.BadParameter("failed to parse %v as limit: %v", name, str)
+	}
+	return limit, nil
 }
 
 type siteSessionStreamGetResponse struct {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -70,6 +70,7 @@ import (
 	"github.com/gokyle/hotp"
 	"github.com/golang/protobuf/proto"
 	"github.com/jonboulle/clockwork"
+	"github.com/pborman/uuid"
 	"github.com/pquerna/otp/totp"
 	"github.com/tstranex/u2f"
 	. "gopkg.in/check.v1"
@@ -94,9 +95,12 @@ type WebSuite struct {
 	mockU2F     *mocku2f.Key
 	server      *auth.TestTLSServer
 	proxyClient *auth.Client
+	clock       clockwork.Clock
 }
 
-var _ = Suite(&WebSuite{})
+var _ = Suite(&WebSuite{
+	clock: clockwork.NewFakeClock(),
+})
 
 func (s *WebSuite) SetUpSuite(c *C) {
 	var err error
@@ -1388,6 +1392,88 @@ func (s *WebSuite) TestMultipleConnectors(c *C) {
 
 	// make sure the connector we get back is "foo"
 	c.Assert(out.Auth.OIDC.Name, Equals, "foo")
+}
+
+// TestSearchClusterEvents makes sure web API allows querying events by type.
+func (s *WebSuite) TestSearchClusterEvents(c *C) {
+	e1 := events.EventFields{
+		events.EventID:   uuid.New(),
+		events.EventType: "event.1",
+		events.EventTime: s.clock.Now().Format(time.RFC3339),
+	}
+	e2 := events.EventFields{
+		events.EventID:   uuid.New(),
+		events.EventType: "event.2",
+		events.EventTime: s.clock.Now().Format(time.RFC3339),
+	}
+	e3 := events.EventFields{
+		events.EventID:   uuid.New(),
+		events.EventType: "event.3",
+		events.EventTime: s.clock.Now().Format(time.RFC3339),
+	}
+	e4 := events.EventFields{
+		events.EventID:   uuid.New(),
+		events.EventType: "event.3",
+		events.EventTime: s.clock.Now().Format(time.RFC3339),
+	}
+	e5 := events.EventFields{
+		events.EventID:   uuid.New(),
+		events.EventType: "event.1",
+		events.EventTime: s.clock.Now().Format(time.RFC3339),
+	}
+
+	for _, e := range []events.EventFields{e1, e2, e3, e4, e5} {
+		c.Assert(s.proxyClient.EmitAuditEvent(e.GetType(), e), IsNil)
+	}
+
+	testCases := []struct {
+		// Comment is the test case description.
+		Comment string
+		// Query is the search query sent to the API.
+		Query url.Values
+		// Result is the expected returned list of events.
+		Result []events.EventFields
+	}{
+		{
+			Comment: "Empty query",
+			Query:   url.Values{},
+			Result:  []events.EventFields{e1, e2, e3, e4, e5},
+		},
+		{
+			Comment: "Query by single event type",
+			Query:   url.Values{"include": []string{"event.1"}},
+			Result:  []events.EventFields{e1, e5},
+		},
+		{
+			Comment: "Query by two event types",
+			Query:   url.Values{"include": []string{"event.2;event.3"}},
+			Result:  []events.EventFields{e2, e3, e4},
+		},
+		{
+			Comment: "Query with limit",
+			Query:   url.Values{"include": []string{"event.2;event.3"}, "limit": []string{"1"}},
+			Result:  []events.EventFields{e2},
+		},
+	}
+
+	pack := s.authPack(c, "foo")
+	for _, tc := range testCases {
+		result := s.searchEvents(c, pack.clt, tc.Query, []string{"event.1", "event.2", "event.3"})
+		c.Assert(result, DeepEquals, tc.Result, Commentf(tc.Comment))
+	}
+}
+
+func (s *WebSuite) searchEvents(c *C, clt *client.WebClient, query url.Values, filter []string) (result []events.EventFields) {
+	response, err := clt.Get(context.Background(), clt.Endpoint("webapi", "sites", s.server.ClusterName(), "events", "search"), query)
+	c.Assert(err, IsNil)
+	var out eventsListGetResponse
+	c.Assert(json.Unmarshal(response.Bytes(), &out), IsNil)
+	for _, event := range out.Events {
+		if utils.SliceContainsStr(filter, event.GetType()) {
+			result = append(result, event)
+		}
+	}
+	return result
 }
 
 type authProviderMock struct {


### PR DESCRIPTION
Forward-port of https://github.com/gravitational/teleport/pull/2632 to 3.2.