### PR TITLE
Update audit events with additional fields.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ endif
 
 .PHONY: test-package
 test-package: remove-temp-files
-	go test -v -test.parallel=0 ./$(p)
+	go test -v ./$(p)
 
 .PHONY: test-grep-package
 test-grep-package: remove-temp-files

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -905,14 +905,14 @@ func (a *AuthWithRoles) ValidateGithubAuthCallback(q url.Values) (*GithubAuthRes
 	return a.authServer.ValidateGithubAuthCallback(q)
 }
 
-func (a *AuthWithRoles) EmitAuditEvent(eventType string, fields events.EventFields) error {
+func (a *AuthWithRoles) EmitAuditEvent(event events.Event, fields events.EventFields) error {
 	if err := a.action(defaults.Namespace, services.KindEvent, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.action(defaults.Namespace, services.KindEvent, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.alog.EmitAuditEvent(eventType, fields)
+	return a.alog.EmitAuditEvent(event, fields)
 }
 
 func (a *AuthWithRoles) PostSessionSlice(slice events.SessionSlice) error {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -207,7 +207,7 @@ func NewClient(addr string, dialer Dialer, params ...roundtrip.ClientParam) (*Cl
 		dialer = net.Dial
 	}
 	transport := &http.Transport{
-		Dial: dialer,
+		Dial:                  dialer,
 		ResponseHeaderTimeout: defaults.DefaultDialTimeout,
 	}
 	params = append(params,
@@ -1642,10 +1642,12 @@ func (c *Client) ValidateGithubAuthCallback(q url.Values) (*GithubAuthResponse, 
 }
 
 // EmitAuditEvent sends an auditable event to the auth server (part of evets.IAuditLog interface)
-func (c *Client) EmitAuditEvent(eventType string, fields events.EventFields) error {
+func (c *Client) EmitAuditEvent(event events.Event, fields events.EventFields) error {
 	_, err := c.PostJSON(c.Endpoint("events"), &auditEventReq{
-		Type:   eventType,
+		Event:  event,
 		Fields: fields,
+		// Send "type" as well for backwards compatibility.
+		Type: event.Name,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -84,13 +84,13 @@ type GithubAuthResponse struct {
 func (a *AuthServer) ValidateGithubAuthCallback(q url.Values) (*GithubAuthResponse, error) {
 	re, err := a.validateGithubAuthCallback(q)
 	if err != nil {
-		a.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+		a.EmitAuditEvent(events.UserSSOLoginFailure, events.EventFields{
 			events.LoginMethod:        events.LoginMethodGithub,
 			events.AuthAttemptSuccess: false,
 			events.AuthAttemptErr:     err.Error(),
 		})
 	} else {
-		a.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+		a.EmitAuditEvent(events.UserSSOLogin, events.EventFields{
 			events.EventUser:          re.Username,
 			events.AuthAttemptSuccess: true,
 			events.LoginMethod:        events.LoginMethodGithub,
@@ -502,7 +502,7 @@ func (c *githubAPIClient) getTeams() ([]teamResponse, error) {
 
 			// Print warning to Teleport logs as well as the Audit Log.
 			log.Warnf(warningMessage)
-			c.authServer.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+			c.authServer.EmitAuditEvent(events.UserSSOLoginFailure, events.EventFields{
 				events.LoginMethod:        events.LoginMethodGithub,
 				events.AuthAttemptMessage: warningMessage,
 			})

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -85,14 +85,14 @@ type SessionCreds struct {
 func (s *AuthServer) AuthenticateUser(req AuthenticateUserRequest) error {
 	err := s.authenticateUser(req)
 	if err != nil {
-		s.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+		s.EmitAuditEvent(events.UserLocalLoginFailure, events.EventFields{
 			events.EventUser:          req.Username,
 			events.LoginMethod:        events.LoginMethodLocal,
 			events.AuthAttemptSuccess: false,
 			events.AuthAttemptErr:     err.Error(),
 		})
 	} else {
-		s.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+		s.EmitAuditEvent(events.UserLocalLogin, events.EventFields{
 			events.EventUser:          req.Username,
 			events.LoginMethod:        events.LoginMethodLocal,
 			events.AuthAttemptSuccess: true,

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -128,14 +128,14 @@ func (s *AuthServer) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*servi
 func (a *AuthServer) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthResponse, error) {
 	re, err := a.validateOIDCAuthCallback(q)
 	if err != nil {
-		a.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+		a.EmitAuditEvent(events.UserSSOLoginFailure, events.EventFields{
 			events.LoginMethod:        events.LoginMethodOIDC,
 			events.AuthAttemptSuccess: false,
 			// log the original internal error in audit log
 			events.AuthAttemptErr: trace.Unwrap(err).Error(),
 		})
 	} else {
-		a.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+		a.EmitAuditEvent(events.UserSSOLogin, events.EventFields{
 			events.EventUser:          re.Username,
 			events.AuthAttemptSuccess: true,
 			events.LoginMethod:        events.LoginMethodOIDC,
@@ -549,7 +549,7 @@ collect:
 
 			// Print warning to Teleport logs as well as the Audit Log.
 			log.Warnf(warningMessage)
-			g.auditLog.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+			g.auditLog.EmitAuditEvent(events.UserSSOLoginFailure, events.EventFields{
 				events.LoginMethod:        events.LoginMethodOIDC,
 				events.AuthAttemptMessage: warningMessage,
 			})

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -278,13 +278,13 @@ type SAMLAuthResponse struct {
 func (a *AuthServer) ValidateSAMLResponse(samlResponse string) (*SAMLAuthResponse, error) {
 	re, err := a.validateSAMLResponse(samlResponse)
 	if err != nil {
-		a.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+		a.EmitAuditEvent(events.UserSSOLoginFailure, events.EventFields{
 			events.LoginMethod:        events.LoginMethodSAML,
 			events.AuthAttemptSuccess: false,
 			events.AuthAttemptErr:     err.Error(),
 		})
 	} else {
-		a.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+		a.EmitAuditEvent(events.UserSSOLogin, events.EventFields{
 			events.EventUser:          re.Username,
 			events.AuthAttemptSuccess: true,
 			events.LoginMethod:        events.LoginMethodSAML,

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -30,6 +30,12 @@ const (
 	EventType = "event"
 	// EventID is a unique event identifier
 	EventID = "uid"
+	// EventCode is a code that uniquely identifies a particular event type
+	EventCode = "code"
+	// EventSeverity contains event severity (info, warning, error)
+	EventSeverity = "severity"
+	// EventMessage contains human-friendly event message
+	EventMessage = "message"
 	// EventTime is event time
 	EventTime = "time"
 	// EventLogin is OS login
@@ -48,6 +54,13 @@ const (
 	RemoteAddr = "addr.remote"
 	// EventCursor is an event ID (used as cursor value for enumeration, not stored)
 	EventCursor = "id"
+
+	// SeverityInfo represents severity for informational events.
+	SeverityInfo = "info"
+	// SeverityWarning represents severity for events that need attention.
+	SeverityWarning = "warning"
+	// SeverityError represents severity for events caused by an error.
+	SeverityError = "error"
 
 	// EventIndex is an event index as received from the logging server
 	EventIndex = "ei"
@@ -137,12 +150,12 @@ const (
 	AuthAttemptMessage = "message"
 
 	// SCPEvent means data transfer that occurred on the server
-	SCPEvent    = "scp"
-	SCPPath     = "path"
-	SCPLengh    = "len"
-	SCPAction   = "action"
-	SCPUpload   = "upload"
-	SCPDownload = "download"
+	SCPEvent          = "scp"
+	SCPPath           = "path"
+	SCPLengh          = "len"
+	SCPAction         = "action"
+	SCPActionUpload   = "upload"
+	SCPActionDownload = "download"
 
 	// ResizeEvent means that some user resized PTY on the client
 	ResizeEvent  = "resize"
@@ -176,7 +189,7 @@ type IAuditLog interface {
 	io.Closer
 
 	// EmitAuditEvent emits audit event
-	EmitAuditEvent(eventType string, fields EventFields) error
+	EmitAuditEvent(Event, EventFields) error
 
 	// DELETE IN: 2.7.0
 	// This method is no longer necessary as nodes and proxies >= 2.7.0
@@ -242,6 +255,21 @@ func (f EventFields) GetType() string {
 // GetID returns the unique event ID
 func (f EventFields) GetID() string {
 	return f.GetString(EventID)
+}
+
+// GetCode returns the event code
+func (f EventFields) GetCode() string {
+	return f.GetString(EventCode)
+}
+
+// GetTimestamp returns the event timestamp (when it was emitted)
+func (f EventFields) GetTimestamp() time.Time {
+	return f.GetTime(EventTime)
+}
+
+// GetMessage returns the event user message
+func (f EventFields) GetMessage() string {
+	return f.GetString(EventMessage)
 }
 
 // GetString returns a string representation of a logged field

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -313,7 +313,7 @@ func (l *AuditLog) UploadSessionRecording(r SessionRecording) error {
 		return trace.Wrap(err)
 	}
 	l.WithFields(log.Fields{"duration": time.Now().Sub(start), "session-id": r.SessionID}).Debugf("Session upload completed.")
-	return l.EmitAuditEvent(SessionUploadEvent, EventFields{
+	return l.EmitAuditEvent(SessionUpload, EventFields{
 		SessionEventID: string(r.SessionID),
 		URL:            url,
 		EventIndex:     math.MaxInt32,
@@ -349,7 +349,7 @@ func (l *AuditLog) processSlice(sl SessionLogger, slice *SessionSlice) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := l.EmitAuditEvent(chunk.EventType, fields); err != nil {
+		if err := l.EmitAuditEvent(Event{Name: chunk.EventType}, fields); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -842,11 +842,11 @@ func (l *AuditLog) fetchSessionEvents(fileName string, afterN int) ([]EventField
 }
 
 // EmitAuditEvent adds a new event to the log. Part of auth.IAuditLog interface.
-func (l *AuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
+func (l *AuditLog) EmitAuditEvent(event Event, fields EventFields) error {
 	if l.ExternalLog != nil {
-		return l.ExternalLog.EmitAuditEvent(eventType, fields)
+		return l.ExternalLog.EmitAuditEvent(event, fields)
 	}
-	return l.localLog.EmitAuditEvent(eventType, fields)
+	return l.localLog.EmitAuditEvent(event, fields)
 }
 
 // emitEvent emits event for test purposes

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -317,7 +317,7 @@ func (a *AuditTestSuite) TestBasicLogging(c *check.C) {
 	alog.Clock = clockwork.NewFakeClockAt(now)
 
 	// emit regular event:
-	err = alog.EmitAuditEvent("user.joined", EventFields{"apples?": "yes"})
+	err = alog.EmitAuditEvent(Event{Name: "user.joined"}, EventFields{"apples?": "yes"})
 	c.Assert(err, check.IsNil)
 	logfile := alog.localLog.file.Name()
 	c.Assert(alog.Close(), check.IsNil)
@@ -348,7 +348,7 @@ func (a *AuditTestSuite) TestLogRotation(c *check.C) {
 		clock.Advance(duration)
 
 		// emit regular event:
-		err = alog.EmitAuditEvent("user.joined", EventFields{"apples?": "yes"})
+		err = alog.EmitAuditEvent(Event{Name: "user.joined"}, EventFields{"apples?": "yes"})
 		c.Assert(err, check.IsNil)
 		logfile := alog.localLog.file.Name()
 

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+// Event describes an audit log event.
+type Event struct {
+	// Name is the event name.
+	Name string
+	// Code is the unique event code.
+	Code string
+	// Severity is the event severity (info, warning, error).
+	Severity string
+	// Message contains the default event message template.
+	Message string
+}
+
+var (
+	// UserLocalLogin is emitted when a local user successfully logs in.
+	UserLocalLogin = Event{
+		Name:     UserLoginEvent,
+		Code:     UserLocalLoginCode,
+		Severity: SeverityInfo,
+		Message:  "Local user {{.user}} successfully logged in",
+	}
+	// UserLocalLoginFailure is emitted when a local user login attempt fails.
+	UserLocalLoginFailure = Event{
+		Name:     UserLoginEvent,
+		Code:     UserLocalLoginFailureCode,
+		Severity: SeverityWarning,
+		Message:  "Local user {{.user}} login failed: {{.error}}",
+	}
+	// UserSSOLogin is emitted when an SSO user successfully logs in.
+	UserSSOLogin = Event{
+		Name:     UserLoginEvent,
+		Code:     UserSSOLoginCode,
+		Severity: SeverityInfo,
+		Message:  "SSO user {{.user}} successfully logged in",
+	}
+	// UserSSOLoginFailure is emitted when an SSO user login attempt fails.
+	UserSSOLoginFailure = Event{
+		Name:     UserLoginEvent,
+		Code:     UserSSOLoginFailureCode,
+		Severity: SeverityWarning,
+		Message:  "SSO user login failed: {{.error}}",
+	}
+	// SessionStart is emitted when a user starts a new session.
+	SessionStart = Event{
+		Name:     SessionStartEvent,
+		Code:     SessionStartCode,
+		Severity: SeverityInfo,
+		Message:  "User {{.user}} has started a session",
+	}
+	// SessionJoin is emitted when a user joins the session.
+	SessionJoin = Event{
+		Name:     SessionJoinEvent,
+		Code:     SessionJoinCode,
+		Severity: SeverityInfo,
+		Message:  "User {{.user}} has joined the session",
+	}
+	// TerminalResize is emitted when a user resizes the terminal.
+	TerminalResize = Event{
+		Name:     ResizeEvent,
+		Code:     TerminalResizeCode,
+		Severity: SeverityInfo,
+		Message:  "User {{.user}} resized the terminal",
+	}
+	// SessionLeave is emitted when a user leaves the session.
+	SessionLeave = Event{
+		Name:     SessionLeaveEvent,
+		Code:     SessionLeaveCode,
+		Severity: SeverityInfo,
+		Message:  "User {{.user}} has left the session",
+	}
+	// SessionEnd is emitted when a user ends the session.
+	SessionEnd = Event{
+		Name:     SessionEndEvent,
+		Code:     SessionEndCode,
+		Severity: SeverityInfo,
+		Message:  "User {{.user}} has ended the session",
+	}
+	// SessionUpload is emitted after a session recording has been uploaded.
+	SessionUpload = Event{
+		Name:     SessionUploadEvent,
+		Code:     SessionUploadCode,
+		Severity: SeverityInfo,
+		Message:  "Recorded session has been uploaded",
+	}
+	// Subsystem is emitted when a user requests a new subsystem.
+	Subsystem = Event{
+		Name:     SubsystemEvent,
+		Code:     SubsystemCode,
+		Severity: SeverityInfo,
+		Message:  "User {{.user}} requested subsystem {{.name}}",
+	}
+	// SubsystemFailure is emitted when a user subsystem request fails.
+	SubsystemFailure = Event{
+		Name:     SubsystemEvent,
+		Code:     SubsystemFailureCode,
+		Severity: SeverityError,
+		Message:  "User {{.user}} subsystem {{.name}} request failed: {{.exitError}}",
+	}
+	// Exec is emitted when a user executes a command on a node.
+	Exec = Event{
+		Name:     ExecEvent,
+		Code:     ExecCode,
+		Severity: SeverityInfo,
+		Message:  `User {{.user}} executed a command on node {{index . "addr.remote"}}`,
+	}
+	// ExecFailure is emitted when a user command execution fails.
+	ExecFailure = Event{
+		Name:     ExecEvent,
+		Code:     ExecFailureCode,
+		Severity: SeverityError,
+		Message:  `User {{.user}} command execution on node {{index . "addr.remote"}} failed: {{.exitError}}`,
+	}
+	// PortForward is emitted when a user requests port forwarding.
+	PortForward = Event{
+		Name:     PortForwardEvent,
+		Code:     PortForwardCode,
+		Severity: SeverityInfo,
+		Message:  "User {{.user}} started port forwarding",
+	}
+	// PortForwardFailure is emitted when a port forward request fails.
+	PortForwardFailure = Event{
+		Name:     PortForwardEvent,
+		Code:     PortForwardFailureCode,
+		Severity: SeverityError,
+		Message:  "User {{.user}} port forwarding request failed: {{.error}}",
+	}
+	// SCPDownload is emitted when a user downloads a file.
+	SCPDownload = Event{
+		Name:     SCPEvent,
+		Code:     SCPDownloadCode,
+		Severity: SeverityInfo,
+		Message:  `User {{.user}} downloaded a file from node {{index . "addr.remote"}}`,
+	}
+	// SCPDownloadFailure is emitted when a file download fails.
+	SCPDownloadFailure = Event{
+		Name:     SCPEvent,
+		Code:     SCPDownloadFailureCode,
+		Severity: SeverityError,
+		Message:  `User {{.user}} file download attempt from node {{index . "addr.remote"}} failed: {{.exitError}}`,
+	}
+	// SCPUpload is emitted when a user uploads a file.
+	SCPUpload = Event{
+		Name:     SCPEvent,
+		Code:     SCPUploadCode,
+		Severity: SeverityInfo,
+		Message:  `User {{.user}} uploaded a file to node {{index . "addr.remote"}}`,
+	}
+	// SCPUploadFailure is emitted when a file upload fails.
+	SCPUploadFailure = Event{
+		Name:     SCPEvent,
+		Code:     SCPUploadFailureCode,
+		Severity: SeverityError,
+		Message:  `User {{.user}} file upload attempt to node {{index . "addr.remote"}} failed: {{.exitError}}`,
+	}
+	// ClientDisconnect is emitted when a user session is disconnected.
+	ClientDisconnect = Event{
+		Name:     ClientDisconnectEvent,
+		Code:     ClientDisconnectCode,
+		Severity: SeverityInfo,
+		Message:  "User {{.user}} has been disconnected: {{.reason}}",
+	}
+	// AuthAttemptFailure is emitted upon a failed authentication attempt.
+	AuthAttemptFailure = Event{
+		Name:     AuthAttemptEvent,
+		Code:     AuthAttemptFailureCode,
+		Severity: SeverityWarning,
+		Message:  "User {{.user}} failed auth attempt: {{.error}}",
+	}
+)
+
+var (
+	// UserLocalLoginCode is the successful local user login event code.
+	UserLocalLoginCode = "T1000I"
+	// UserLocalLoginFailureCode is the unsuccessful local user login event code.
+	UserLocalLoginFailureCode = "T1000W"
+	// UserSSOLoginCode is the successful SSO user login event code.
+	UserSSOLoginCode = "T1001I"
+	// UserSSOLoginFailureCode is the unsuccessful SSO user login event code.
+	UserSSOLoginFailureCode = "T1001W"
+	// SessionStartCode is the session start event code.
+	SessionStartCode = "T2000I"
+	// SessionJoinCode is the session join event code.
+	SessionJoinCode = "T2001I"
+	// TerminalResizeCode is the terminal resize event code.
+	TerminalResizeCode = "T2002I"
+	// SessionLeaveCode is the session leave event code.
+	SessionLeaveCode = "T2003I"
+	// SessionEndCode is the session end event code.
+	SessionEndCode = "T2004I"
+	// SessionUploadCode is the session upload event code.
+	SessionUploadCode = "T2005I"
+	// SubsystemCode is the subsystem event code.
+	SubsystemCode = "T3001I"
+	// SubsystemFailureCode is the subsystem failure event code.
+	SubsystemFailureCode = "T3001E"
+	// ExecCode is the exec event code.
+	ExecCode = "T3002I"
+	// ExecFailureCode is the exec failure event code.
+	ExecFailureCode = "T3002E"
+	// PortForwardCode is the port forward event code.
+	PortForwardCode = "T3003I"
+	// PortForwardFailureCode is the port forward failure event code.
+	PortForwardFailureCode = "T3003E"
+	// SCPDownloadCode is the file download event code.
+	SCPDownloadCode = "T3004I"
+	// SCPDownloadFailureCode is the file download event failure code.
+	SCPDownloadFailureCode = "T3004E"
+	// SCPUploadCode is the file upload event code.
+	SCPUploadCode = "T3005I"
+	// SCPUploadFailureCode is the file upload failure event code.
+	SCPUploadFailureCode = "T3005E"
+	// ClientDisconnectCode is the client disconnect event code.
+	ClientDisconnectCode = "T3006I"
+	// AuthAttemptFailureCode is the auth attempt failure event code.
+	AuthAttemptFailureCode = "T3007W"
+)

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -40,7 +40,7 @@ func (d *DiscardAuditLog) Close() error {
 	return nil
 }
 
-func (d *DiscardAuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
+func (d *DiscardAuditLog) EmitAuditEvent(event Event, fields EventFields) error {
 	return nil
 }
 func (d *DiscardAuditLog) PostSessionSlice(SessionSlice) error {

--- a/lib/events/fields.go
+++ b/lib/events/fields.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"bytes"
+	"text/template"
+	"time"
+
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+// UpdateEventFields updates passed event fields with additional information
+// common for all event types such as unique IDs, timestamps, codes, etc.
+//
+// This method is a "final stop" for various audit log implementations for
+// updating event fields before it gets persisted in the backend.
+func UpdateEventFields(event Event, fields EventFields, clock clockwork.Clock, uid utils.UID) (err error) {
+	additionalFields := make(map[string]interface{})
+	if fields.GetType() == "" {
+		additionalFields[EventType] = event.Name
+	}
+	if fields.GetID() == "" {
+		additionalFields[EventID] = uid.New()
+	}
+	if fields.GetTimestamp().IsZero() {
+		additionalFields[EventTime] = clock.Now().UTC().Round(time.Second)
+	}
+	if event.Code != "" {
+		additionalFields[EventCode] = event.Code
+	}
+	if event.Severity != "" {
+		additionalFields[EventSeverity] = event.Severity
+	}
+	if event.Message != "" {
+		additionalFields[EventMessage], err = renderEventMessage(event.Message, fields)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	for k, v := range additionalFields {
+		fields[k] = v
+	}
+	return nil
+}
+
+func renderEventMessage(defaultMessage string, fields EventFields) (string, error) {
+	messageTemplate := fields.GetMessage()
+	if messageTemplate == "" {
+		messageTemplate = defaultMessage
+	}
+	template, err := template.New("message").Parse(messageTemplate)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	var b bytes.Buffer
+	if err := template.Execute(&b, fields); err != nil {
+		return "", trace.Wrap(err)
+	}
+	return b.String(), nil
+}

--- a/lib/events/forward.go
+++ b/lib/events/forward.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -45,6 +46,8 @@ type ForwarderConfig struct {
 	ForwardTo IAuditLog
 	// Clock is a clock to set for tests
 	Clock clockwork.Clock
+	// UID is UID generator
+	UID utils.UID
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -57,6 +60,9 @@ func (s *ForwarderConfig) CheckAndSetDefaults() error {
 	}
 	if s.Clock == nil {
 		s.Clock = clockwork.NewRealClock()
+	}
+	if s.UID == nil {
+		s.UID = utils.NewRealUID()
 	}
 	return nil
 }
@@ -106,14 +112,18 @@ func (l *Forwarder) Close() error {
 }
 
 // EmitAuditEvent emits audit event
-func (l *Forwarder) EmitAuditEvent(eventType string, fields EventFields) error {
+func (l *Forwarder) EmitAuditEvent(event Event, fields EventFields) error {
+	err := UpdateEventFields(event, fields, l.Clock, l.UID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	data, err := json.Marshal(fields)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	chunks := []*SessionChunk{
 		{
-			EventType: eventType,
+			EventType: event.Name,
 			Data:      data,
 			Time:      time.Now().UTC().UnixNano(),
 		},

--- a/lib/events/mock.go
+++ b/lib/events/mock.go
@@ -61,7 +61,7 @@ func (d *MockAuditLog) Close() error {
 	return nil
 }
 
-func (d *MockAuditLog) EmitAuditEvent(eventType string, fields EventFields) error {
+func (d *MockAuditLog) EmitAuditEvent(event Event, fields EventFields) error {
 	return nil
 }
 

--- a/lib/events/multilog.go
+++ b/lib/events/multilog.go
@@ -55,10 +55,10 @@ func (m *MultiLog) Close() error {
 }
 
 // EmitAuditEvent emits audit event
-func (m *MultiLog) EmitAuditEvent(eventType string, fields EventFields) error {
+func (m *MultiLog) EmitAuditEvent(event Event, fields EventFields) error {
 	var errors []error
 	for _, log := range m.loggers {
-		errors = append(errors, log.EmitAuditEvent(eventType, fields))
+		errors = append(errors, log.EmitAuditEvent(event, fields))
 	}
 	return trace.NewAggregate(errors...)
 }

--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -314,7 +314,9 @@ func EventFromChunk(sessionID string, chunk *SessionChunk) (EventFields, error) 
 	fields[EventIndex] = chunk.EventIndex
 	fields[EventTime] = eventStart
 	fields[EventType] = chunk.EventType
-	fields[EventID] = uuid.New()
+	if fields[EventID] == "" {
+		fields[EventID] = uuid.New()
+	}
 	return fields, nil
 }
 

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -85,7 +85,7 @@ type EventsSuite struct {
 // SessionEventsCRUD covers session events
 func (s *EventsSuite) SessionEventsCRUD(c *check.C) {
 	// Bob has logged in
-	err := s.Log.EmitAuditEvent(events.UserLoginEvent, events.EventFields{
+	err := s.Log.EmitAuditEvent(events.UserLocalLogin, events.EventFields{
 		events.LoginMethod:        events.LoginMethodSAML,
 		events.AuthAttemptSuccess: true,
 		events.EventUser:          "bob",

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -107,7 +107,7 @@ func (h *AuthHandlers) CheckPortForward(addr string, ctx *ServerContext) error {
 		userErrorMessage := "port forwarding not allowed"
 
 		// emit port forward failure event
-		h.AuditLog.EmitAuditEvent(events.PortForwardEvent, events.EventFields{
+		h.AuditLog.EmitAuditEvent(events.PortForwardFailure, events.EventFields{
 			events.PortForwardAddr:    addr,
 			events.PortForwardSuccess: false,
 			events.PortForwardErr:     systemErrorMessage,
@@ -169,7 +169,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 			events.AuthAttemptErr:     err.Error(),
 		}
 		h.Warnf("failed login attempt %#v", fields)
-		h.AuditLog.EmitAuditEvent(events.AuthAttemptEvent, fields)
+		h.AuditLog.EmitAuditEvent(events.AuthAttemptFailure, fields)
 	}
 
 	certChecker := ssh.CertChecker{IsUserAuthority: h.IsUserAuthority}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -62,7 +62,7 @@ type Server interface {
 	PermitUserEnvironment() bool
 
 	// EmitAuditEvent emits an Audit Event to the Auth Server.
-	EmitAuditEvent(string, events.EventFields)
+	EmitAuditEvent(events.Event, events.EventFields)
 
 	// GetAuditLog returns the Audit Log for this cluster.
 	GetAuditLog() events.IAuditLog

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -194,7 +194,7 @@ func (s *testServer) Component() string {
 func (s *testServer) PermitUserEnvironment() bool {
 	return false
 }
-func (s *testServer) EmitAuditEvent(string, events.EventFields) {
+func (s *testServer) EmitAuditEvent(events.Event, events.EventFields) {
 }
 func (s *testServer) GetAuditLog() events.IAuditLog {
 	return s.auth

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -288,10 +288,10 @@ func (s *Server) Component() string {
 }
 
 // EmitAuditEvent sends an event to the Audit Log.
-func (s *Server) EmitAuditEvent(eventType string, fields events.EventFields) {
+func (s *Server) EmitAuditEvent(event events.Event, fields events.EventFields) {
 	auditLog := s.GetAuditLog()
 	if auditLog != nil {
-		if err := auditLog.EmitAuditEvent(eventType, fields); err != nil {
+		if err := auditLog.EmitAuditEvent(event, fields); err != nil {
 			s.log.Error(err)
 		}
 	} else {
@@ -616,7 +616,7 @@ func (s *Server) handleDirectTCPIPRequest(ch ssh.Channel, req *sshutils.DirectTC
 	defer conn.Close()
 
 	// Emit a port forwarding audit event.
-	s.EmitAuditEvent(events.PortForwardEvent, events.EventFields{
+	s.EmitAuditEvent(events.PortForward, events.EventFields{
 		events.PortForwardAddr:    dstAddr,
 		events.PortForwardSuccess: true,
 		events.EventLogin:         s.identityContext.Login,

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -131,8 +131,11 @@ func (r *remoteSubsystem) Wait() error {
 
 func (r *remoteSubsystem) emitAuditEvent(err error) {
 	srv := r.serverContext.GetServer()
-
-	srv.EmitAuditEvent(events.SubsystemEvent, events.EventFields{
+	event := events.Subsystem
+	if err != nil {
+		event = events.SubsystemFailure
+	}
+	srv.EmitAuditEvent(event, events.EventFields{
 		events.SubsystemName:  r.subsytemName,
 		events.SubsystemError: err,
 		events.EventUser:      r.serverContext.Identity.TeleportUser,

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -150,7 +150,7 @@ func (w *Monitor) Start() {
 				events.SessionServerID: w.ServerID,
 				events.Reason:          fmt.Sprintf("client certificate expired at %v", w.Clock.Now().UTC()),
 			}
-			w.Audit.EmitAuditEvent(events.ClientDisconnectEvent, event)
+			w.Audit.EmitAuditEvent(events.ClientDisconnect, event)
 			w.Entry.Debugf("Disconnecting client: %v", event[events.Reason])
 			w.Conn.Close()
 			return
@@ -172,7 +172,7 @@ func (w *Monitor) Start() {
 						now.Sub(clientLastActive), w.ClientIdleTimeout)
 				}
 				w.Entry.Debugf("Disconnecting client: %v", event[events.Reason])
-				w.Audit.EmitAuditEvent(events.ClientDisconnectEvent, event)
+				w.Audit.EmitAuditEvent(events.ClientDisconnect, event)
 				w.Conn.Close()
 				return
 			}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -666,13 +666,13 @@ func (s *Server) serveAgent(ctx *srv.ServerContext) error {
 
 // EmitAuditEvent logs a given event to the audit log attached to the
 // server who owns these sessions
-func (s *Server) EmitAuditEvent(eventType string, fields events.EventFields) {
-	log.Debugf("server.EmitAuditEvent(%v)", eventType)
+func (s *Server) EmitAuditEvent(event events.Event, fields events.EventFields) {
+	log.Debugf("server.EmitAuditEvent(%v)", event.Name)
 	alog := s.alog
 	if alog != nil {
 		// record the event time with ms precision
 		fields[events.EventTime] = s.clock.Now().In(time.UTC).Round(time.Millisecond)
-		if err := alog.EmitAuditEvent(eventType, fields); err != nil {
+		if err := alog.EmitAuditEvent(event, fields); err != nil {
 			log.Error(trace.DebugReport(err))
 		}
 	} else {
@@ -816,7 +816,7 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 	defer conn.Close()
 
 	// audit event:
-	s.EmitAuditEvent(events.PortForwardEvent, events.EventFields{
+	s.EmitAuditEvent(events.PortForward, events.EventFields{
 		events.PortForwardAddr:    dstAddr,
 		events.PortForwardSuccess: true,
 		events.EventLogin:         ctx.Identity.Login,

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -125,7 +125,7 @@ func (s *SessionRegistry) emitSessionJoinEvent(ctx *ServerContext) {
 	}
 
 	// Emit session join event to Audit Log.
-	ctx.session.recorder.GetAuditLog().EmitAuditEvent(events.SessionJoinEvent, sessionJoinEvent)
+	ctx.session.recorder.GetAuditLog().EmitAuditEvent(events.SessionJoin, sessionJoinEvent)
 
 	// Notify all members of the party that a new member has joined over the
 	// "x-teleport-event" channel.
@@ -196,7 +196,7 @@ func (s *SessionRegistry) emitSessionLeaveEvent(party *party) {
 	}
 
 	// Emit session leave event to Audit Log.
-	party.s.recorder.GetAuditLog().EmitAuditEvent(events.SessionLeaveEvent, sessionLeaveEvent)
+	party.s.recorder.GetAuditLog().EmitAuditEvent(events.SessionLeave, sessionLeaveEvent)
 
 	// Notify all members of the party that a new member has left over the
 	// "x-teleport-event" channel.
@@ -252,7 +252,7 @@ func (s *SessionRegistry) leaveSession(party *party) error {
 		s.Unlock()
 
 		// send an event indicating that this session has ended
-		sess.recorder.GetAuditLog().EmitAuditEvent(events.SessionEndEvent, events.EventFields{
+		sess.recorder.GetAuditLog().EmitAuditEvent(events.SessionEnd, events.EventFields{
 			events.SessionEventID: string(sess.id),
 			events.EventUser:      party.user,
 			events.EventNamespace: s.srv.GetNamespace(),
@@ -321,7 +321,7 @@ func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *S
 
 	// Report the updated window size to the event log (this is so the sessions
 	// can be replayed correctly).
-	ctx.session.recorder.GetAuditLog().EmitAuditEvent(events.ResizeEvent, resizeEvent)
+	ctx.session.recorder.GetAuditLog().EmitAuditEvent(events.TerminalResize, resizeEvent)
 
 	// Update the size of the server side PTY.
 	err := ctx.session.term.SetWinSize(params)
@@ -608,7 +608,7 @@ func (s *session) start(ch ssh.Channel, ctx *ServerContext) error {
 	params := s.term.GetTerminalParams()
 
 	// emit "new session created" event:
-	s.recorder.GetAuditLog().EmitAuditEvent(events.SessionStartEvent, events.EventFields{
+	s.recorder.GetAuditLog().EmitAuditEvent(events.SessionStart, events.EventFields{
 		events.EventNamespace:  ctx.srv.GetNamespace(),
 		events.SessionEventID:  string(s.id),
 		events.SessionServerID: ctx.srv.ID(),

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1587,11 +1587,11 @@ func (h *Handler) clusterSearchEvents(w http.ResponseWriter, r *http.Request, p 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	events, err := clt.SearchEvents(from, to, query.Encode(), limit)
+	fields, err := clt.SearchEvents(from, to, query.Encode(), limit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return eventsListGetResponse{Events: events}, nil
+	return eventsListGetResponse{Events: fields}, nil
 }
 
 // queryTime parses the query string parameter with the specified name as a

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1399,31 +1399,36 @@ func (s *WebSuite) TestSearchClusterEvents(c *C) {
 	e1 := events.EventFields{
 		events.EventID:   uuid.New(),
 		events.EventType: "event.1",
+		events.EventCode: "event.1",
 		events.EventTime: s.clock.Now().Format(time.RFC3339),
 	}
 	e2 := events.EventFields{
 		events.EventID:   uuid.New(),
 		events.EventType: "event.2",
+		events.EventCode: "event.2",
 		events.EventTime: s.clock.Now().Format(time.RFC3339),
 	}
 	e3 := events.EventFields{
 		events.EventID:   uuid.New(),
 		events.EventType: "event.3",
+		events.EventCode: "event.3",
 		events.EventTime: s.clock.Now().Format(time.RFC3339),
 	}
 	e4 := events.EventFields{
 		events.EventID:   uuid.New(),
 		events.EventType: "event.3",
+		events.EventCode: "event.3",
 		events.EventTime: s.clock.Now().Format(time.RFC3339),
 	}
 	e5 := events.EventFields{
 		events.EventID:   uuid.New(),
 		events.EventType: "event.1",
+		events.EventCode: "event.1",
 		events.EventTime: s.clock.Now().Format(time.RFC3339),
 	}
 
 	for _, e := range []events.EventFields{e1, e2, e3, e4, e5} {
-		c.Assert(s.proxyClient.EmitAuditEvent(e.GetType(), e), IsNil)
+		c.Assert(s.proxyClient.EmitAuditEvent(events.Event{Name: e.GetType()}, e), IsNil)
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
This pull request makes sure that each audit event emitted by the system has these additional common fields like described in https://github.com/gravitational/gravity.e/issues/4031:

* The `code` field contains a unique code for each event type in the format described in the above ticket.
* The `severity` field contains event severity.
* The `message` field contains user-friendly short event description.

I have also implemented it in a way so it's easy for Gravity (or anything else, e.g. enterprise Teleport if needed) to inject its own event types.
