### PR TITLE
Add --bind-addr, fixes #2620

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -240,6 +240,9 @@ type Config struct {
 	// CheckVersions will check that client version is compatible
 	// with auth server version when connecting.
 	CheckVersions bool
+
+	// BindAddr is an optional host:port to bind to for SSO redirect flows
+	BindAddr string
 }
 
 // CachePolicy defines cache policy for local clients
@@ -1821,16 +1824,18 @@ func (tc *TeleportClient) directLogin(ctx context.Context, secondFactorType stri
 func (tc *TeleportClient) ssoLogin(ctx context.Context, connectorID string, pub []byte, protocol string) (*auth.SSHLoginResponse, error) {
 	log.Debugf("samlLogin start")
 	// ask the CA (via proxy) to sign our public key:
-	response, err := SSHAgentSSOLogin(
-		ctx,
-		tc.Config.WebProxyAddr,
-		connectorID,
-		pub,
-		tc.KeyTTL,
-		tc.InsecureSkipVerify,
-		loopbackPool(tc.Config.WebProxyAddr),
-		protocol,
-		tc.CertificateFormat)
+	response, err := SSHAgentSSOLogin(SSHLogin{
+		Context:       ctx,
+		ProxyAddr:     tc.Config.WebProxyAddr,
+		ConnectorID:   connectorID,
+		PubKey:        pub,
+		TTL:           tc.KeyTTL,
+		Insecure:      tc.InsecureSkipVerify,
+		Pool:          loopbackPool(tc.Config.WebProxyAddr),
+		Protocol:      protocol,
+		Compatibility: tc.CertificateFormat,
+		BindAddr:      tc.BindAddr,
+	})
 	return response, trace.Wrap(err)
 }
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -132,6 +132,10 @@ type CLIConf struct {
 	// format to use with --out to store a fershly retreived certificate
 	IdentityFormat client.IdentityFileFormat
 
+	// BindAddr is an address in the form of host:port to bind to
+	// during `tsh login` command
+	BindAddr string
+
 	// AuthConnector is the name of the connector to use.
 	AuthConnector string
 
@@ -164,8 +168,9 @@ func main() {
 }
 
 const (
-	clusterEnvVar = "TELEPORT_SITE"
-	clusterHelp   = "Specify the cluster to connect"
+	clusterEnvVar  = "TELEPORT_SITE"
+	clusterHelp    = "Specify the cluster to connect"
+	bindAddrEnvVar = "TELEPORT_LOGIN_BIND_ADDR"
 )
 
 // Run executes TSH client. same as main() but easier to test
@@ -235,6 +240,7 @@ func Run(args []string, underTest bool) {
 	// login logs in with remote proxy and obtains a "session certificate" which gets
 	// stored in ~/.tsh directory
 	login := app.Command("login", "Log in to a cluster and retrieve the session certificate")
+	login.Flag("bind-addr", "Address in the form of host:port to bind to for login command webhook").Envar(bindAddrEnvVar).StringVar(&cf.BindAddr)
 	login.Flag("out", "Identity output").Short('o').StringVar(&cf.IdentityFileOut)
 	login.Flag("format", fmt.Sprintf("Identity format [%s] or %s (for OpenSSH compatibility)",
 		client.DefaultIdentityFormat,
@@ -912,7 +918,7 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 	if options.StrictHostKeyChecking == false {
 		c.HostKeyCallback = client.InsecureSkipHostKeyChecking
 	}
-
+	c.BindAddr = cf.BindAddr
 	return client.NewClient(c)
 }
 


### PR DESCRIPTION
This commit adds `--bind-addr` flag to tsh login
and TELEPORT_LOGIN_BIND_ADDR environment variable
to set up login bind address for SSO redirect flows.

Usage examples:

```
tsh login  --bind-addr=localhost:3333
tsh login --bind-addr=:3333
tsh login --bind-addr=[::1]:3333
TELEPORT_LOGIN_BIND_ADDR=localhost:7777 tsh login
```