### PR TITLE
Various fixes for Teleport Demo environments

### DIFF
--- a/examples/chart/teleport-demo/docker/cloudflare-agent/rootfs/scripts/cloudflare-agent.sh
+++ b/examples/chart/teleport-demo/docker/cloudflare-agent/rootfs/scripts/cloudflare-agent.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+# if you set DEBUG in the kubernetes environment variables, it must be a string "true" rather than a boolean true
 if [[ "${DEBUG}" == true ]]; then
     set -x
 fi
@@ -12,15 +13,14 @@ API_KEY=$(cat /etc/cloudflare/api_key)
 EMAIL=$(cat /etc/cloudflare/email)
 DOMAIN_TO_REGISTER="${CLUSTER_NAME}.${CLOUDFLARE_DOMAIN}"
 
-TLS_ENABLED=$(cat /etc/teleport-tls/enabled)
-LETSENCRYPT_ENABLED=$(cat /etc/teleport-tls/letsencrypt-enabled)
+if [[ "${MODE}" != "delete" ]]; then
+    TLS_ENABLED=$(cat /etc/teleport-tls/enabled)
+    LETSENCRYPT_ENABLED=$(cat /etc/teleport-tls/letsencrypt-enabled)
+fi
 
 if [[ "${DEBUG}" == true ]]; then
-    cloudflareagent_log "Cloudflare credentials:"
-    cloudflareagent_log "API key: ${API_KEY}"
-    cloudflareagent_log "Email: ${EMAIL}"
-    cloudflareagent_log "----"
     cloudflareagent_log "Cluster name: ${CLUSTER_NAME}"
+    cloudflareagent_log "Cluster type: ${CLUSTER_TYPE}"
     cloudflareagent_log "Domain: ${CLOUDFLARE_DOMAIN}"
     cloudflareagent_log "Register: ${DOMAIN_TO_REGISTER}"
     cloudflareagent_log "Cloudflare TTL: ${CLOUDFLARE_TTL}"
@@ -30,88 +30,127 @@ if [[ "${DEBUG}" == true ]]; then
     cloudflareagent_log "Letsencrypt email address: ${LETSENCRYPT_EMAIL}"
     cloudflareagent_log "---"
     cloudflareagent_log "Service name: ${SERVICE_NAME}"
+    cloudflareagent_log "---"
+    cloudflareagent_log "Mode: ${MODE}"
 fi
 
-SERVICE_TYPE=$(kubectl get service ${SERVICE_NAME} -o jsonpath='{.spec.type}')
-if [[ "${SERVICE_TYPE}" != "LoadBalancer" ]]; then
-    cloudflareagent_log "Service '${SERVICE_NAME}' is not using 'LoadBalancer', it's using '${SERVICE_TYPE}'"
-    cloudflareagent_log "This process doesn't need to run so is exiting with success"
-    exit 0
-fi
-
-EXTERNAL_IP=""
-while [ -z "${EXTERNAL_IP}" ]; do
-    cloudflareagent_log "Waiting for external IP address for '${SERVICE_NAME}'..."
-    EXTERNAL_IP=$(kubectl get service ${SERVICE_NAME} --template="{{ range .status.loadBalancer.ingress }}{{ .ip }}{{ end }}")
-    [ -z "${EXTERNAL_IP}" ] && sleep 10
-done
-cloudflareagent_log "External IP for '${SERVICE_NAME}' is ready"
-cloudflareagent_log "${EXTERNAL_IP}"
-
-# look up zone ID for provided domain
-ZONE_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones?name=${CLOUDFLARE_DOMAIN}" | jq -r '.result[].id')
-# exit if we can't get it
-if [[ "${ZONE_ID}" == "null" || "${ZONE_ID}" == "" ]]; then
-    cloudflareagent_log "Couldn't get Cloudflare Zone ID for '${CLOUDFLARE_DOMAIN}' with the provided credentials. Exiting"
-    exit 1
-fi
-
-# set TTL if provided - if not, omit it so cloudflare uses auto
-if [[ "${CLOUDFLARE_TTL}" != "" ]]; then
-    RECORD_CONTENT="{\"type\":\"A\",\"name\":\"${DOMAIN_TO_REGISTER}\",\"content\":\"${EXTERNAL_IP}\",\"proxied\":false,\"ttl\":${CLOUDFLARE_TTL}}"
-else
-    RECORD_CONTENT="{\"type\":\"A\",\"name\":\"${DOMAIN_TO_REGISTER}\",\"content\":\"${EXTERNAL_IP}\",\"proxied\":false}"
-fi
-
-# look up record ID
-RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records?name=${DOMAIN_TO_REGISTER}" | jq -r '.result[].id')
-# if it doesn't exist, create a new record
-if [[ "${RECORD_ID}" == "null" || "${RECORD_ID}" == "" ]]; then
-    cloudflareagent_log "Couldn't get Cloudflare DNS record ID for '${DOMAIN_TO_REGISTER}' within zone '${ZONE_ID}' - creating new record"
-    # create record
-    CREATED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" --data ${RECORD_CONTENT} -X POST "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records" | jq -r '.result.id')
-    # check response
-    if [[ "${CREATED_RECORD_ID}" == "null" || "${CREATED_RECORD_ID}" == "" ]]; then
-        cloudflareagent_log "Couldn't create Cloudflare DNS record for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}'. Exiting"
-        exit 2
-    else
-        cloudflareagent_log "Created Cloudflare DNS record '${CREATED_RECORD_ID}' for '${CLOUDFLARE_DOMAIN}' under '${ZONE_ID}'"
+if [[ "${MODE}" == "create" ]]; then
+    SERVICE_TYPE=$(kubectl get service ${SERVICE_NAME} -o jsonpath='{.spec.type}')
+    if [[ "${SERVICE_TYPE}" != "LoadBalancer" ]]; then
+        cloudflareagent_log "Service '${SERVICE_NAME}' is not using 'LoadBalancer', it's using '${SERVICE_TYPE}'"
+        cloudflareagent_log "This process doesn't need to run so is exiting with success"
+        exit 0
     fi
-# if it does exist, update the existing record
-else
-    cloudflareagent_log "Got Cloudflare DNS record ID '${RECORD_ID}' for '${DOMAIN_TO_REGISTER}' - updating record"
-    # update record
-    UPDATED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" --data ${RECORD_CONTENT} -X PUT "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records/${RECORD_ID}" | jq -r '.result.id')
-    # check response
-    if [[ "${UPDATED_RECORD_ID}" == "null" || "${UPDATED_RECORD_ID}" == "" ]]; then
-        cloudflareagent_log "Couldn't update Cloudflare DNS record for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}'. Exiting"
-        exit 3
-    else
-        cloudflareagent_log "Updated Cloudflare DNS record '${UPDATED_RECORD_ID}' for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}'"
-    fi
-fi
 
-# run certbot if TLS is enabled and letsencrypt is enabled
-if [[ "${TLS_ENABLED}" == "true" ]] && [[ "${LETSENCRYPT_ENABLED}" == "true" ]]; then
-    cloudflareagent_log "TLS/Letsencrypt enabled, running certbot"
-    # create certbot.ini file
-    cat >/tmp/cloudflare-credentials-certbot.ini <<EOF
-    dns_cloudflare_email = ${EMAIL}
-    dns_cloudflare_api_key = ${API_KEY}
+    EXTERNAL_IP=""
+    while [ -z "${EXTERNAL_IP}" ]; do
+        cloudflareagent_log "Waiting for external IP address for '${SERVICE_NAME}'..."
+        EXTERNAL_IP=$(kubectl get service ${SERVICE_NAME} --template="{{ range .status.loadBalancer.ingress }}{{ .ip }}{{ end }}")
+        [ -z "${EXTERNAL_IP}" ] && sleep 10
+    done
+    cloudflareagent_log "External IP for '${SERVICE_NAME}' is ready"
+    cloudflareagent_log "${EXTERNAL_IP}"
+
+    # look up zone ID for provided domain
+    ZONE_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones?name=${CLOUDFLARE_DOMAIN}" | jq -r '.result[].id')
+    # exit if we can't get it
+    if [[ "${ZONE_ID}" == "null" || "${ZONE_ID}" == "" ]]; then
+        cloudflareagent_log "Couldn't get Cloudflare Zone ID for '${CLOUDFLARE_DOMAIN}' with the provided credentials - exiting with error"
+        exit 1
+    fi
+
+    # if this is the main cluster, we use a wildcard record so that kubernetes proxy forwarding from Teleport 3.2 will work
+    if [[ "${CLUSTER_TYPE}" == "primary" ]]; then
+        DOMAIN_TO_REGISTER="*.${DOMAIN_TO_REGISTER}"
+    fi
+
+    # set TTL if provided - if not, omit it so cloudflare uses auto
+    if [[ "${CLOUDFLARE_TTL}" != "" ]]; then
+        RECORD_CONTENT="{\"type\":\"A\",\"name\":\"${DOMAIN_TO_REGISTER}\",\"content\":\"${EXTERNAL_IP}\",\"proxied\":false,\"ttl\":${CLOUDFLARE_TTL}}"
+    else
+        RECORD_CONTENT="{\"type\":\"A\",\"name\":\"${DOMAIN_TO_REGISTER}\",\"content\":\"${EXTERNAL_IP}\",\"proxied\":false}"
+    fi
+
+    # look up record ID
+    RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records?name=${DOMAIN_TO_REGISTER}" | jq -r '.result[].id')
+    # if it doesn't exist, create a new record
+    if [[ "${RECORD_ID}" == "null" || "${RECORD_ID}" == "" ]]; then
+        cloudflareagent_log "Couldn't get Cloudflare DNS record ID for '${DOMAIN_TO_REGISTER}' within zone '${ZONE_ID}' - creating new record"
+        # create record
+        CREATED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" --data ${RECORD_CONTENT} -X POST "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records" | jq -r '.result.id')
+        # check response
+        if [[ "${CREATED_RECORD_ID}" == "null" || "${CREATED_RECORD_ID}" == "" ]]; then
+            cloudflareagent_log "Couldn't create Cloudflare DNS record for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}' - exiting with error"
+            exit 2
+        else
+            cloudflareagent_log "Created Cloudflare DNS record ID '${CREATED_RECORD_ID}' for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}'"
+        fi
+    # if it does exist, update the existing record
+    else
+        cloudflareagent_log "Got Cloudflare DNS record ID '${RECORD_ID}' for '${DOMAIN_TO_REGISTER}' - updating record"
+        # update record
+        UPDATED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" --data ${RECORD_CONTENT} -X PUT "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records/${RECORD_ID}" | jq -r '.result.id')
+        # check response
+        if [[ "${UPDATED_RECORD_ID}" == "null" || "${UPDATED_RECORD_ID}" == "" ]]; then
+            cloudflareagent_log "Couldn't update Cloudflare DNS record for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}' - exiting with error"
+            exit 3
+        else
+            cloudflareagent_log "Updated Cloudflare DNS record ID '${UPDATED_RECORD_ID}' for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}'"
+        fi
+    fi
+
+    # run certbot if TLS is enabled and letsencrypt is enabled
+    if [[ "${TLS_ENABLED}" == "true" ]] && [[ "${LETSENCRYPT_ENABLED}" == "true" ]]; then
+        cloudflareagent_log "TLS/Letsencrypt enabled, running certbot"
+        # create certbot.ini file
+        cat >/tmp/cloudflare-credentials-certbot.ini <<EOF
+        dns_cloudflare_email = ${EMAIL}
+        dns_cloudflare_api_key = ${API_KEY}
 EOF
-    chmod 600 /tmp/cloudflare-credentials-certbot.ini
-    certbot certonly -n --agree-tos --email ${LETSENCRYPT_EMAIL} --dns-cloudflare --dns-cloudflare-credentials /tmp/cloudflare-credentials-certbot.ini -d ${DOMAIN_TO_REGISTER}
-    FIRST_TIME=true
-else
-    cloudflareagent_log "TLS/Letsencrypt not enabled, exiting"
-    exit 0
-fi
+        chmod 600 /tmp/cloudflare-credentials-certbot.ini
+        certbot certonly -n --agree-tos --email ${LETSENCRYPT_EMAIL} --dns-cloudflare --dns-cloudflare-credentials /tmp/cloudflare-credentials-certbot.ini -d ${DOMAIN_TO_REGISTER}
+        FIRST_TIME=true
+    else
+        cloudflareagent_log "TLS/Letsencrypt not enabled, exiting"
+        exit 0
+    fi
 
-# keep container running in a loop, attempt to renew certificates once a day and then update kubernetes secrets with changed certificates/key
-while true; do
-    date
-    certbot renew
-    kubectl --namespace ${NAMESPACE} create secret generic tls-web --from-file=/etc/letsencrypt/live/${DOMAIN_TO_REGISTER}/fullchain.pem --from-file=/etc/letsencrypt/live/${DOMAIN_TO_REGISTER}/privkey.pem --dry-run -o yaml | kubectl apply -f -
-    # wait a day
-    sleep 86400
-done
+    # keep container running in a loop, attempt to renew certificates once a day and then update kubernetes secrets with changed certificates/key
+    while true; do
+        date
+        certbot renew
+        kubectl --namespace ${NAMESPACE} create secret generic tls-web --from-file=/etc/letsencrypt/live/${DOMAIN_TO_REGISTER}/fullchain.pem --from-file=/etc/letsencrypt/live/${DOMAIN_TO_REGISTER}/privkey.pem --dry-run -o yaml | kubectl apply -f -
+        # wait a day
+        sleep 86400
+    done
+elif [[ "${MODE}" == "delete" ]]; then
+    # look up zone ID for provided domain
+    ZONE_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones?name=${CLOUDFLARE_DOMAIN}" | jq -r '.result[].id')
+    # exit if we can't get it, we don't exit with a failure code when deleting as it's just a best-effort process
+    if [[ "${ZONE_ID}" == "null" || "${ZONE_ID}" == "" ]]; then
+        cloudflareagent_log "Couldn't get Cloudflare Zone ID for '${CLOUDFLARE_DOMAIN}' with the provided credentials - exiting"
+    fi
+
+    # if this is the main cluster, we use a wildcard record so that kubernetes proxy forwarding from Teleport 3.2 will work
+    if [[ "${CLUSTER_TYPE}" == "primary" ]]; then
+        DOMAIN_TO_REGISTER="*.${DOMAIN_TO_REGISTER}"
+    fi
+
+    # look up record ID
+    RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records?name=${DOMAIN_TO_REGISTER}" | jq -r '.result[].id')
+    # if it doesn't exist, just exit
+    if [[ "${RECORD_ID}" == "null" || "${RECORD_ID}" == "" ]]; then
+        cloudflareagent_log "Couldn't get Cloudflare DNS record ID for '${DOMAIN_TO_REGISTER}' within zone '${ZONE_ID}' - exiting"
+    # if it does exist, delete the record
+    else
+        cloudflareagent_log "Got Cloudflare DNS record ID '${RECORD_ID}' for '${DOMAIN_TO_REGISTER}' - deleting record"
+        # delete record
+        DELETED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X DELETE "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records/${RECORD_ID}" | jq -r '.result.id')
+        # check response
+        if [[ "${DELETED_RECORD_ID}" == "null" || "${DELETED_RECORD_ID}" == "" ]]; then
+            cloudflareagent_log "Couldn't delete Cloudflare DNS record for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}' - exiting"
+        else
+            cloudflareagent_log "Deleted Cloudflare DNS record ID '${DELETED_RECORD_ID}' for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}' - done"
+        fi
+    fi
+fi

--- a/examples/chart/teleport-demo/docker/cloudflare-agent/rootfs/scripts/cloudflare-agent.sh
+++ b/examples/chart/teleport-demo/docker/cloudflare-agent/rootfs/scripts/cloudflare-agent.sh
@@ -9,6 +9,87 @@ function cloudflareagent_log() {
     echo "[cloudflare-agent] $*"
 }
 
+function process_record() {
+    local RUN_MODE="$1"
+    local REGISTER_DOMAIN="$2"
+    local DNS_RECORD_CONTENT="$3"
+
+    if [[ "${DEBUG}" == "true" ]]; then
+        cloudflareagent_log "register_record()"
+        cloudflareagent_log "RUN_MODE: ${RUN_MODE}"
+        cloudflareagent_log "REGISTER_DOMAIN: ${REGISTER_DOMAIN}"
+        cloudflareagent_log "DNS_RECORD_CONTENT: ${DNS_RECORD_CONTENT}"
+        cloudflareagent_log "---"
+    fi
+
+    if [[ "${REGISTER_DOMAIN}" == "" ]]; then
+        cloudflareagent_log "Domain to register not provided, exiting with error"
+        exit 4
+    fi
+
+    if [[ "${RUN_MODE}" == "create" ]] && [[ "${DNS_RECORD_CONTENT}" == "" ]]; then
+            cloudflareagent_log "Running in create mode and record content not provided, exiting with error"
+            exit 5
+    fi
+
+    # look up zone ID for provided domain
+    ZONE_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones?name=${CLOUDFLARE_DOMAIN}" | jq -r '.result[].id')
+    # exit if we can't get it
+    if [[ "${ZONE_ID}" == "null" || "${ZONE_ID}" == "" ]]; then
+        if [[ "${RUN_MODE}" == "create" ]]; then
+            cloudflareagent_log "[create] Couldn't get Cloudflare Zone ID for '${CLOUDFLARE_DOMAIN}' with the provided credentials - exiting with error"
+            exit 1
+        elif [[ "${RUN_MODE}" == "delete" ]]; then
+            cloudflareagent_log "[delete] Couldn't get Cloudflare Zone ID for '${CLOUDFLARE_DOMAIN}' with the provided credentials - exiting"
+            return
+        fi
+    fi
+
+    # look up record ID
+    RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records?name=${REGISTER_DOMAIN}" | jq -r '.result[].id')
+    # if it doesn't exist, create/delete a new record
+    if [[ "${RECORD_ID}" == "null" || "${RECORD_ID}" == "" ]]; then
+        if [[ "${RUN_MODE}" == "create" ]]; then
+            cloudflareagent_log "[create] Couldn't get Cloudflare DNS record ID for '${REGISTER_DOMAIN}' within zone '${ZONE_ID}' - creating new record"
+            # create record
+            CREATED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" --data ${DNS_RECORD_CONTENT} -X POST "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records" | jq -r '.result.id')
+            # check response
+            if [[ "${CREATED_RECORD_ID}" == "null" || "${CREATED_RECORD_ID}" == "" ]]; then
+                cloudflareagent_log "Couldn't create Cloudflare DNS record for '${REGISTER_DOMAIN}' under '${ZONE_ID}' - exiting with error"
+                exit 2
+            else
+                cloudflareagent_log "Created Cloudflare DNS record ID '${CREATED_RECORD_ID}' for '${REGISTER_DOMAIN}' under '${ZONE_ID}'"
+            fi
+        elif [[ "${RUN_MODE}" == "delete" ]]; then
+            cloudflareagent_log "[delete] Couldn't get Cloudflare DNS record ID for '${REGISTER_DOMAIN}' within zone '${ZONE_ID}' - exiting"
+        fi
+    # if it does exist, update/delete the existing record
+    else
+        if [[ "${RUN_MODE}" == "create" ]]; then
+            cloudflareagent_log "[create] Got Cloudflare DNS record ID '${RECORD_ID}' for '${REGISTER_DOMAIN}' - updating record"
+            # update record
+            UPDATED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" --data ${DNS_RECORD_CONTENT} -X PUT "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records/${RECORD_ID}" | jq -r '.result.id')
+            # check response
+            if [[ "${UPDATED_RECORD_ID}" == "null" || "${UPDATED_RECORD_ID}" == "" ]]; then
+                cloudflareagent_log "Couldn't update Cloudflare DNS record for '${REGISTER_DOMAIN}' under '${ZONE_ID}' - exiting with error"
+                exit 3
+            else
+                cloudflareagent_log "Updated Cloudflare DNS record ID '${UPDATED_RECORD_ID}' for '${REGISTER_DOMAIN}' under '${ZONE_ID}'"
+            fi
+        elif [[ "${RUN_MODE}" == "delete" ]]; then
+            cloudflareagent_log "[delete] Got Cloudflare DNS record ID '${RECORD_ID}' for '${REGISTER_DOMAIN}' - deleting record"
+            # update record
+            UPDATED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X DELETE "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records/${RECORD_ID}" | jq -r '.result.id')
+            # check response
+            if [[ "${UPDATED_RECORD_ID}" == "null" || "${UPDATED_RECORD_ID}" == "" ]]; then
+                cloudflareagent_log "Couldn't delete Cloudflare DNS record for '${REGISTER_DOMAIN}' under '${ZONE_ID}' - exiting"
+            else
+                cloudflareagent_log "Deleted Cloudflare DNS record ID '${UPDATED_RECORD_ID}' for '${REGISTER_DOMAIN}' under '${ZONE_ID}'"
+            fi
+        fi
+    fi
+}
+
 # default to creation mode if the MODE variable isn't set (to ensure container compatibility with older installations)
 if [[ "${MODE}" == "" ]]; then
     MODE="create"
@@ -24,8 +105,10 @@ if [[ "${MODE}" == "create" ]]; then
 fi
 
 if [[ "${DEBUG}" == true ]]; then
+    cloudflareagent_log "Mode: ${MODE}"
     cloudflareagent_log "Cluster name: ${CLUSTER_NAME}"
     cloudflareagent_log "Cluster type: ${CLUSTER_TYPE}"
+    cloudflareagent_log "Service name: ${SERVICE_NAME}"
     cloudflareagent_log "Domain: ${CLOUDFLARE_DOMAIN}"
     cloudflareagent_log "Register: ${DOMAIN_TO_REGISTER}"
     cloudflareagent_log "Cloudflare TTL: ${CLOUDFLARE_TTL}"
@@ -34,14 +117,12 @@ if [[ "${DEBUG}" == true ]]; then
     cloudflareagent_log "Letsencrypt enabled: ${LETSENCRYPT_ENABLED}"
     cloudflareagent_log "Letsencrypt email address: ${LETSENCRYPT_EMAIL}"
     cloudflareagent_log "---"
-    cloudflareagent_log "Service name: ${SERVICE_NAME}"
-    cloudflareagent_log "---"
-    cloudflareagent_log "Mode: ${MODE}"
 fi
 
-# if this is the main cluster, we create a wildcard record so that kubernetes proxy forwarding from Teleport 3.2 will work
+# if this is the main cluster, we also create a wildcard record so that kubernetes proxy forwarding from Teleport 3.2 will work
+WILDCARD_DOMAIN_TO_REGISTER=""
 if [[ "${CLUSTER_TYPE}" == "primary" ]]; then
-    DOMAIN_TO_REGISTER="*.${DOMAIN_TO_REGISTER}"
+    WILDCARD_DOMAIN_TO_REGISTER="*.${DOMAIN_TO_REGISTER}"
 fi
 
 if [[ "${MODE}" == "create" ]]; then
@@ -61,47 +142,23 @@ if [[ "${MODE}" == "create" ]]; then
     cloudflareagent_log "External IP for '${SERVICE_NAME}' is ready"
     cloudflareagent_log "${EXTERNAL_IP}"
 
-    # look up zone ID for provided domain
-    ZONE_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones?name=${CLOUDFLARE_DOMAIN}" | jq -r '.result[].id')
-    # exit if we can't get it
-    if [[ "${ZONE_ID}" == "null" || "${ZONE_ID}" == "" ]]; then
-        cloudflareagent_log "Couldn't get Cloudflare Zone ID for '${CLOUDFLARE_DOMAIN}' with the provided credentials - exiting with error"
-        exit 1
-    fi
-
     # set TTL if provided - if not, omit it so cloudflare uses auto
     if [[ "${CLOUDFLARE_TTL}" != "" ]]; then
         RECORD_CONTENT="{\"type\":\"A\",\"name\":\"${DOMAIN_TO_REGISTER}\",\"content\":\"${EXTERNAL_IP}\",\"proxied\":false,\"ttl\":${CLOUDFLARE_TTL}}"
+        if [[ "${WILDCARD_DOMAIN_TO_REGISTER}" != "" ]]; then
+            WILDCARD_RECORD_CONTENT="{\"type\":\"A\",\"name\":\"${WILDCARD_DOMAIN_TO_REGISTER}\",\"content\":\"${EXTERNAL_IP}\",\"proxied\":false,\"ttl\":${CLOUDFLARE_TTL}}"
+        fi
     else
         RECORD_CONTENT="{\"type\":\"A\",\"name\":\"${DOMAIN_TO_REGISTER}\",\"content\":\"${EXTERNAL_IP}\",\"proxied\":false}"
+        if [[ "${WILDCARD_DOMAIN_TO_REGISTER}" != "" ]]; then
+            WILDCARD_RECORD_CONTENT="{\"type\":\"A\",\"name\":\"${WILDCARD_DOMAIN_TO_REGISTER}\",\"content\":\"${EXTERNAL_IP}\",\"proxied\":false}"
+        fi
     fi
 
-    # look up record ID
-    RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records?name=${DOMAIN_TO_REGISTER}" | jq -r '.result[].id')
-    # if it doesn't exist, create a new record
-    if [[ "${RECORD_ID}" == "null" || "${RECORD_ID}" == "" ]]; then
-        cloudflareagent_log "Couldn't get Cloudflare DNS record ID for '${DOMAIN_TO_REGISTER}' within zone '${ZONE_ID}' - creating new record"
-        # create record
-        CREATED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" --data ${RECORD_CONTENT} -X POST "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records" | jq -r '.result.id')
-        # check response
-        if [[ "${CREATED_RECORD_ID}" == "null" || "${CREATED_RECORD_ID}" == "" ]]; then
-            cloudflareagent_log "Couldn't create Cloudflare DNS record for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}' - exiting with error"
-            exit 2
-        else
-            cloudflareagent_log "Created Cloudflare DNS record ID '${CREATED_RECORD_ID}' for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}'"
-        fi
-    # if it does exist, update the existing record
-    else
-        cloudflareagent_log "Got Cloudflare DNS record ID '${RECORD_ID}' for '${DOMAIN_TO_REGISTER}' - updating record"
-        # update record
-        UPDATED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" --data ${RECORD_CONTENT} -X PUT "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records/${RECORD_ID}" | jq -r '.result.id')
-        # check response
-        if [[ "${UPDATED_RECORD_ID}" == "null" || "${UPDATED_RECORD_ID}" == "" ]]; then
-            cloudflareagent_log "Couldn't update Cloudflare DNS record for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}' - exiting with error"
-            exit 3
-        else
-            cloudflareagent_log "Updated Cloudflare DNS record ID '${UPDATED_RECORD_ID}' for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}'"
-        fi
+    # do registration
+    process_record create "${DOMAIN_TO_REGISTER}" "${RECORD_CONTENT}"
+    if [[ "${WILDCARD_DOMAIN_TO_REGISTER}" != "" ]]; then
+        process_record create "${WILDCARD_DOMAIN_TO_REGISTER}" "${WILDCARD_RECORD_CONTENT}"
     fi
 
     # run certbot if TLS is enabled and letsencrypt is enabled
@@ -129,28 +186,9 @@ EOF
         sleep 86400
     done
 elif [[ "${MODE}" == "delete" ]]; then
-    # look up zone ID for provided domain
-    ZONE_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones?name=${CLOUDFLARE_DOMAIN}" | jq -r '.result[].id')
-    # exit if we can't get it, we don't exit with a failure code when deleting as it's just a best-effort process
-    if [[ "${ZONE_ID}" == "null" || "${ZONE_ID}" == "" ]]; then
-        cloudflareagent_log "Couldn't get Cloudflare Zone ID for '${CLOUDFLARE_DOMAIN}' with the provided credentials - exiting"
-    fi
-
-    # look up record ID
-    RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X GET "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records?name=${DOMAIN_TO_REGISTER}" | jq -r '.result[].id')
-    # if it doesn't exist, just exit
-    if [[ "${RECORD_ID}" == "null" || "${RECORD_ID}" == "" ]]; then
-        cloudflareagent_log "Couldn't get Cloudflare DNS record ID for '${DOMAIN_TO_REGISTER}' within zone '${ZONE_ID}' - exiting"
-    # if it does exist, delete the record
-    else
-        cloudflareagent_log "Got Cloudflare DNS record ID '${RECORD_ID}' for '${DOMAIN_TO_REGISTER}' - deleting record"
-        # delete record
-        DELETED_RECORD_ID=$(curl -s -H "Content-Type: application/json" -H "X-Auth-Key: ${API_KEY}" -H "X-Auth-Email: ${EMAIL}" -X DELETE "https://api.cloudflare.com/client/v${API_VERSION}/zones/${ZONE_ID}/dns_records/${RECORD_ID}" | jq -r '.result.id')
-        # check response
-        if [[ "${DELETED_RECORD_ID}" == "null" || "${DELETED_RECORD_ID}" == "" ]]; then
-            cloudflareagent_log "Couldn't delete Cloudflare DNS record for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}' - exiting"
-        else
-            cloudflareagent_log "Deleted Cloudflare DNS record ID '${DELETED_RECORD_ID}' for '${DOMAIN_TO_REGISTER}' under '${ZONE_ID}' - done"
-        fi
+    # do deletion
+    process_record delete "${DOMAIN_TO_REGISTER}"
+    if [[ "${WILDCARD_DOMAIN_TO_REGISTER}" != "" ]]; then
+        process_record delete "${WILDCARD_DOMAIN_TO_REGISTER}"
     fi
 fi

--- a/examples/chart/teleport-demo/templates/cloudflare-agent-job.yaml
+++ b/examples/chart/teleport-demo/templates/cloudflare-agent-job.yaml
@@ -24,10 +24,14 @@ spec:
             value: "{{ .Values.cloudflare.apiVersion }}"
           - name: CLUSTER_NAME
             value: {{ template "teleport.fullname" . }}-{{ .Values.mainClusterName }}
+          - name: CLUSTER_TYPE
+            value: primary
           - name: CLOUDFLARE_DOMAIN
             value: "{{ .Values.cloudflare.domain }}"
           - name: LETSENCRYPT_EMAIL
             value: "{{ .Values.letsencrypt.email }}"
+          - name: MODE
+            value: create
           - name: SERVICE_NAME
             value: {{ template "teleport.fullname" . }}-{{ .Values.mainClusterName }}
           - name: NAMESPACE
@@ -39,12 +43,12 @@ spec:
             value: "{{ .Values.cloudflare.ttl }}"
           {{- end }}
         volumeMounts:
-        - mountPath: /etc/cloudflare
-          name: cloudflare-credentials
-          readOnly: true
-        - mountPath: /etc/teleport-tls
-          name: teleport-tls
-          readOnly: true
+          - mountPath: /etc/cloudflare
+            name: cloudflare-credentials
+            readOnly: true
+          - mountPath: /etc/teleport-tls
+            name: teleport-tls
+            readOnly: true
       volumes:
         - name: cloudflare-credentials
           secret:
@@ -66,6 +70,62 @@ spec:
 {{ toYaml .Values.tolerations | indent 6 }}
 {{- end }}
       serviceAccountName: {{ template "teleport.serviceAccountName" . }}-{{ .Values.mainClusterName }}
+  backoffLimit: 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "teleport.fullname" . }}-{{ .Values.mainClusterName }}-cloudflare-cleaner
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app: cloudflare-cleaner
+    spec:
+      containers:
+      - name: cloudflare-cleaner
+        image: {{ .Values.cloudflareagent.image.repository }}:{{ tpl .Values.cloudflareagent.image.tag . }}
+        imagePullPolicy: {{ .Values.cloudflareagent.image.pullPolicy }}
+        env:
+          - name: API_VERSION
+            value: "{{ .Values.cloudflare.apiVersion }}"
+          - name: CLUSTER_NAME
+            value: {{ template "teleport.fullname" . }}-{{ .Values.mainClusterName }}
+          - name: CLUSTER_TYPE
+            value: primary
+          - name: CLOUDFLARE_DOMAIN
+            value: "{{ .Values.cloudflare.domain }}"
+          - name: MODE
+            value: delete
+        volumeMounts:
+          - mountPath: /etc/cloudflare
+            name: cloudflare-credentials
+            readOnly: true
+      volumes:
+        - name: cloudflare-credentials
+          secret:
+            secretName: {{ template "teleport.fullname" . }}-cloudflare-credentials
+      restartPolicy: Never
+{{- if .Values.cloudflareagent.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.cloudflareagent.image.pullSecrets | indent 6 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}
+      serviceAccountName: {{ template "teleport.serviceAccountName" . }}-cleaner
   backoffLimit: 0
 
 {{- if not (eq (index .Values.extraClusterNames 0) "") -}}
@@ -98,10 +158,14 @@ spec:
             value: "{{ $root.Values.cloudflare.apiVersion }}"
           - name: CLUSTER_NAME
             value: {{ template "teleport.fullname" $root }}-{{ . }}
+          - name: CLUSTER_TYPE
+            value: secondary
           - name: CLOUDFLARE_DOMAIN
             value: "{{ $root.Values.cloudflare.domain }}"
           - name: LETSENCRYPT_EMAIL
             value: "{{ $root.Values.letsencrypt.email }}"
+          - name: MODE
+            value: create
           - name: SERVICE_NAME
             value: {{ template "teleport.fullname" $root }}-{{ . }}
           - name: NAMESPACE
@@ -113,12 +177,12 @@ spec:
             value: "{{ $root.Values.cloudflare.ttl }}"
           {{- end }}
         volumeMounts:
-        - mountPath: /etc/cloudflare
-          name: cloudflare-credentials
-          readOnly: true
-        - mountPath: /etc/teleport-tls
-          name: teleport-tls
-          readOnly: true
+          - mountPath: /etc/cloudflare
+            name: cloudflare-credentials
+            readOnly: true
+          - mountPath: /etc/teleport-tls
+            name: teleport-tls
+            readOnly: true
       volumes:
         - name: cloudflare-credentials
           secret:
@@ -140,6 +204,62 @@ spec:
 {{ toYaml $root.Values.tolerations | indent 6 }}
 {{- end }}
       serviceAccountName: {{ template "teleport.serviceAccountName" $root }}-{{ . }}
+  backoffLimit: 0
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "teleport.fullname" $root }}-{{ . }}-cloudflare-cleaner
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+{{ include "teleport.labels" $root | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  template:
+    metadata:
+      namespace: {{ $root.Release.Namespace }}
+      labels:
+        app: cloudflare-cleaner
+    spec:
+      containers:
+      - name: cloudflare-cleaner
+        image: {{ $root.Values.cloudflareagent.image.repository }}:{{ tpl $root.Values.cloudflareagent.image.tag $root }}
+        imagePullPolicy: {{ $root.Values.cloudflareagent.image.pullPolicy }}
+        env:
+          - name: API_VERSION
+            value: "{{ $root.Values.cloudflare.apiVersion }}"
+          - name: CLUSTER_NAME
+            value: {{ template "teleport.fullname" $root }}-{{ . }}
+          - name: CLUSTER_TYPE
+            value: secondary
+          - name: CLOUDFLARE_DOMAIN
+            value: "{{ $root.Values.cloudflare.domain }}"
+          - name: MODE
+            value: delete
+        volumeMounts:
+          - mountPath: /etc/cloudflare
+            name: cloudflare-credentials
+            readOnly: true
+      volumes:
+        - name: cloudflare-credentials
+          secret:
+            secretName: {{ template "teleport.fullname" $root }}-cloudflare-credentials
+      restartPolicy: Never
+{{- if $root.Values.cloudflareagent.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml $root.Values.cloudflareagent.image.pullSecrets | indent 6 }}
+{{- end }}
+{{- if $root.Values.affinity }}
+      affinity:
+{{ toYaml $root.Values.affinity | indent 8 }}
+{{- end }}
+{{- if $root.Values.tolerations }}
+      tolerations:
+{{ toYaml $root.Values.tolerations | indent 6 }}
+{{- end }}
+      serviceAccountName: {{ template "teleport.serviceAccountName" $root }}-cleaner
   backoffLimit: 0
 {{- end -}}
 {{- end }}

--- a/examples/chart/teleport-demo/templates/generic/clusterrole.yaml
+++ b/examples/chart/teleport-demo/templates/generic/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "teleport.fullname" . }}-nscleaner
+  name: {{ template "teleport.fullname" . }}-cleaner
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "teleport.labels" . | indent 4 }}
@@ -26,6 +26,16 @@ rules:
   verbs:
   - delete
   - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - {{ template "teleport.fullname" . }}-cloudflare-credentials
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/examples/chart/teleport-demo/templates/generic/clusterrolebinding.yaml
+++ b/examples/chart/teleport-demo/templates/generic/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "teleport.fullname" . }}-nscleaner
+  name: {{ template "teleport.fullname" . }}-cleaner
   labels:
 {{ include "teleport.labels" . | indent 4 }}
   annotations:
@@ -12,10 +12,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "teleport.fullname" . }}-nscleaner
+  name: {{ template "teleport.fullname" . }}-cleaner
 subjects:
 - kind: ServiceAccount
-  name: {{ template "teleport.serviceAccountName" . }}-nscleaner
+  name: {{ template "teleport.serviceAccountName" . }}-cleaner
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/chart/teleport-demo/templates/generic/namespace.yaml
+++ b/examples/chart/teleport-demo/templates/generic/namespace.yaml
@@ -66,5 +66,5 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
 {{- end }}
-      serviceAccountName: {{ template "teleport.serviceAccountName" . }}-nscleaner
+      serviceAccountName: {{ template "teleport.serviceAccountName" . }}-cleaner
   backoffLimit: 0

--- a/examples/chart/teleport-demo/templates/generic/secret.yaml
+++ b/examples/chart/teleport-demo/templates/generic/secret.yaml
@@ -1,3 +1,23 @@
+# put cloudflare credentials in release namespace for use in a post-delete hook
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "teleport.fullname" . }}-cloudflare-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: Opaque
+data:
+  api_key: {{ .Values.secrets.cloudflare.api_key | b64enc | quote }}
+  email: {{ .Values.secrets.cloudflare.email | b64enc | quote }}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/examples/chart/teleport-demo/templates/generic/serviceaccount.yaml
+++ b/examples/chart/teleport-demo/templates/generic/serviceaccount.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "teleport.serviceAccountName" . }}-nscleaner
+  name: {{ template "teleport.serviceAccountName" . }}-cleaner
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "teleport.labels" . | indent 4 }}
   annotations:


### PR DESCRIPTION
* Create wildcard DNS record for the main cluster as well as single A record so we can use Kubernetes forwarding to remote clusters via proxy properly
* Automatically delete created Cloudflare DNS records via pre-delete hook when the chart is deleted to keep the zone tidy
* Don't explicitly print Cloudflare API credentials in debug mode (they're logged along with the curl commands anyway)