### PR TITLE
Add --bind-addr, fixes #2620

### DIFF
--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -18,14 +18,17 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gravitational/teleport"
@@ -65,6 +68,49 @@ func ThisFunction() string {
 	var pc [32]uintptr
 	runtime.Callers(2, pc[:])
 	return runtime.FuncForPC(pc[0]).Name()
+}
+
+// SyncString is a string value
+// that can be concurrently accessed
+type SyncString struct {
+	sync.Mutex
+	string
+}
+
+// Value returns value of the string
+func (s *SyncString) Value() string {
+	s.Lock()
+	defer s.Unlock()
+	return s.string
+}
+
+// Set sets the value of the string
+func (s *SyncString) Set(v string) {
+	s.Lock()
+	defer s.Unlock()
+	s.string = v
+}
+
+// ClickableURL fixes address in url to make sure
+// it's clickable, e.g. it replaces "undefined" address like
+// 0.0.0.0 used in network listeners format with loopback 127.0.0.1
+func ClickableURL(in string) string {
+	out, err := url.Parse(in)
+	if err != nil {
+		return in
+	}
+	host, port, err := net.SplitHostPort(out.Host)
+	if err != nil {
+		return in
+	}
+	ip := net.ParseIP(host)
+	// if address is not an IP, unspecified, e.g. all interfaces 0.0.0.0 or multicast,
+	// replace with localhost that is clickable
+	if len(ip) == 0 || ip.IsUnspecified() || ip.IsMulticast() {
+		out.Host = fmt.Sprintf("127.0.0.1:%v", port)
+		return out.String()
+	}
+	return out.String()
 }
 
 // AsBool converts string to bool, in case of the value is empty

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -144,6 +144,26 @@ func (s *UtilsSuite) TestVersions(c *check.C) {
 	}
 }
 
+// TestClickableURL tests clickable URL conversions
+func (s *UtilsSuite) TestClickableURL(c *check.C) {
+	testCases := []struct {
+		info string
+		in   string
+		out  string
+	}{
+		{info: "original URL is OK", in: "http://127.0.0.1:3000/hello", out: "http://127.0.0.1:3000/hello"},
+		{info: "unspecified IPV6", in: "http://[::]:5050/howdy", out: "http://127.0.0.1:5050/howdy"},
+		{info: "unspecified IPV4", in: "http://0.0.0.0:5050/howdy", out: "http://127.0.0.1:5050/howdy"},
+		{info: "specified IPV4", in: "http://192.168.1.1:5050/howdy", out: "http://192.168.1.1:5050/howdy"},
+		{info: "specified IPV6", in: "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:5050/howdy", out: "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:5050/howdy"},
+	}
+	for i, testCase := range testCases {
+		comment := check.Commentf("test case %v %q", i, testCase.info)
+		out := ClickableURL(testCase.in)
+		c.Assert(out, check.Equals, testCase.out, comment)
+	}
+}
+
 // TestParseSessionsURI parses sessions URI
 func (s *UtilsSuite) TestParseSessionsURI(c *check.C) {
 	testCases := []struct {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -134,6 +134,10 @@ type CLIConf struct {
 	// format to use with --out to store a fershly retreived certificate
 	IdentityFormat client.IdentityFileFormat
 
+	// BindAddr is an address in the form of host:port to bind to
+	// during `tsh login` command
+	BindAddr string
+
 	// AuthConnector is the name of the connector to use.
 	AuthConnector string
 
@@ -166,8 +170,9 @@ func main() {
 }
 
 const (
-	clusterEnvVar = "TELEPORT_SITE"
-	clusterHelp   = "Specify the cluster to connect"
+	clusterEnvVar  = "TELEPORT_SITE"
+	clusterHelp    = "Specify the cluster to connect"
+	bindAddrEnvVar = "TELEPORT_LOGIN_BIND_ADDR"
 )
 
 // Run executes TSH client. same as main() but easier to test
@@ -240,6 +245,7 @@ func Run(args []string, underTest bool) {
 	// login logs in with remote proxy and obtains a "session certificate" which gets
 	// stored in ~/.tsh directory
 	login := app.Command("login", "Log in to a cluster and retrieve the session certificate")
+	login.Flag("bind-addr", "Address in the form of host:port to bind to for login command webhook").Envar(bindAddrEnvVar).StringVar(&cf.BindAddr)
 	login.Flag("out", "Identity output").Short('o').AllowDuplicate().StringVar(&cf.IdentityFileOut)
 	login.Flag("format", fmt.Sprintf("Identity format [%s] or %s (for OpenSSH compatibility)",
 		client.DefaultIdentityFormat,
@@ -917,7 +923,7 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 	if options.StrictHostKeyChecking == false {
 		c.HostKeyCallback = client.InsecureSkipHostKeyChecking
 	}
-
+	c.BindAddr = cf.BindAddr
 	return client.NewClient(c)
 }
 


### PR DESCRIPTION
This commit adds `--bind-addr` flag to tsh login
and TELEPORT_LOGIN_BIND_ADDR environment variable
to set up login bind address for SSO redirect flows.

Usage examples:

```
tsh login  --bind-addr=localhost:3333
tsh login --bind-addr=:3333
tsh login --bind-addr=[::1]:3333
TELEPORT_LOGIN_BIND_ADDR=localhost:7777 tsh login
```

Refactor redirect flow and fix URLs for --bind-addr