### PR TITLE
Fixes in DynamoDB event polling

### DIFF
--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -125,7 +125,7 @@ proxy:
     # We assume TLS is terminated in front of the proxy by default
     enabled: true
     # tweak this if you have multiple proxies in a single namespace
-    fullname: tls-web
+    secretName: tls-web
 
 license:
   ## Set false to run Teleport in Community edition mode

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -76,6 +76,10 @@ type Backend interface {
 
 	// Clock returns clock used by this backend
 	Clock() clockwork.Clock
+
+	// CloseWatchers closes all the watchers
+	// without closing the backend
+	CloseWatchers()
 }
 
 // Batch implements some batch methods

--- a/lib/backend/dynamo/dynamo.go
+++ b/lib/backend/dynamo/dynamo.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,4 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
+
 package dynamo

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -244,6 +244,12 @@ func (b *EtcdBackend) Close() error {
 	return b.client.Close()
 }
 
+// CloseWatchers closes all the watchers
+// without closing the backend
+func (b *EtcdBackend) CloseWatchers() {
+	b.buf.Reset()
+}
+
 func (b *EtcdBackend) reconnect() error {
 	clientCertPEM, err := ioutil.ReadFile(b.cfg.TLSCertFile)
 	if err != nil {

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -776,6 +776,12 @@ func (l *LiteBackend) Close() error {
 	return l.closeDatabase()
 }
 
+// CloseWatchers closes all the watchers
+// without closing the backend
+func (l *LiteBackend) CloseWatchers() {
+	l.buf.Reset()
+}
+
 func (l *LiteBackend) isClosed() bool {
 	return atomic.LoadInt32(&l.closedFlag) == 1
 }

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -133,6 +133,12 @@ func (m *Memory) Close() error {
 	return nil
 }
 
+// CloseWatchers closes all the watchers
+// without closing the backend
+func (m *Memory) CloseWatchers() {
+	m.buf.Reset()
+}
+
 // Clock returns clock used by this backend
 func (m *Memory) Clock() clockwork.Clock {
 	return m.Config.Clock

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -205,6 +205,12 @@ func (s *Reporter) Close() error {
 	return s.Backend.Close()
 }
 
+// CloseWatchers closes all the watchers
+// without closing the backend
+func (s *Reporter) CloseWatchers() {
+	s.Backend.CloseWatchers()
+}
+
 // Clock returns clock used by this backend
 func (s *Reporter) Clock() clockwork.Clock {
 	return s.Backend.Clock()

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -162,3 +162,9 @@ func (s *Sanitizer) Close() error {
 func (s *Sanitizer) Clock() clockwork.Clock {
 	return s.backend.Clock()
 }
+
+// CloseWatchers closes all the watchers
+// without closing the backend
+func (s *Sanitizer) CloseWatchers() {
+	s.backend.CloseWatchers()
+}

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -3,14 +3,11 @@ package backend
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/jonboulle/clockwork"
 	"gopkg.in/check.v1"
 )
-
-func TestSanitizer(t *testing.T) { check.TestingT(t) }
 
 type Suite struct {
 }
@@ -132,4 +129,10 @@ func (n *nopBackend) Clock() clockwork.Clock {
 // NewWatcher returns a new event watcher
 func (n *nopBackend) NewWatcher(ctx context.Context, watch Watch) (Watcher, error) {
 	return nil, nil
+}
+
+// CloseWatchers closes all the watchers
+// without closing the backend
+func (n *nopBackend) CloseWatchers() {
+
 }

--- a/lib/backend/wrap.go
+++ b/lib/backend/wrap.go
@@ -132,6 +132,12 @@ func (s *Wrapper) Close() error {
 	return s.backend.Close()
 }
 
+// CloseWatchers closes all the watchers
+// without closing the backend
+func (s *Wrapper) CloseWatchers() {
+	s.backend.CloseWatchers()
+}
+
 // Clock returns clock used by this backend
 func (s *Wrapper) Clock() clockwork.Clock {
 	return s.backend.Clock()

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -329,6 +329,11 @@ func (c *Cache) update() {
 		err := c.fetchAndWatch(retry, time.After(c.ReloadPeriod))
 		if err != nil {
 			c.setCacheState(err)
+			// if cache is experiencing error,
+			// all watchers are out of sync, because
+			// cache has lost its own watcher to the backend
+			// signal closure to reset the watchers
+			c.Backend.CloseWatchers()
 			if !c.isClosed() {
 				c.Warningf("Re-init the cache on error: %v.", err)
 			}

--- a/tool/tctl/common/top_command.go
+++ b/tool/tctl/common/top_command.go
@@ -173,9 +173,9 @@ func (c *TopCommand) render(ctx context.Context, re Report, eventID string) erro
 	t1.TextStyle = ui.NewStyle(ui.ColorBlack)
 	t1.Rows = [][]string{
 		[]string{"Interactive Sessions", humanize.FormatFloat("", re.Cluster.InteractiveSessions)},
-		[]string{"Certificate Generate Active Requests", humanize.FormatFloat("", re.Cluster.GenerateRequests)},
-		[]string{"Certificate Generate Requests/sec", humanize.FormatFloat("", re.Cluster.GenerateRequestsCount.GetFreq())},
-		[]string{"Certificate Generate Throttled Requests/sec", humanize.FormatFloat("", re.Cluster.GenerateRequestsThrottledCount.GetFreq())},
+		[]string{"Cert Gen Active Requests", humanize.FormatFloat("", re.Cluster.GenerateRequests)},
+		[]string{"Cert Gen Requests/sec", humanize.FormatFloat("", re.Cluster.GenerateRequestsCount.GetFreq())},
+		[]string{"Cert Gen Throttled Requests/sec", humanize.FormatFloat("", re.Cluster.GenerateRequestsThrottledCount.GetFreq())},
 	}
 	for _, rc := range re.Cluster.RemoteClusters {
 		t1.Rows = append(t1.Rows, []string{


### PR DESCRIPTION
* Add resest for buffers to close watchers
and reset buffer the state.
* Add reconnect logic to DynamoDB
* Add tests for cache watchers, make sure
the errors of the cache internal watcher propagate to
external watchers.