### PR TITLE
Break endless retry loop.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -275,6 +275,12 @@ const (
 	// JSON means JSON serialization format
 	JSON = "json"
 
+	// YAML means YAML serialization format
+	YAML = "yaml"
+
+	// Text means text serialization format
+	Text = "text"
+
 	// LinuxAdminGID is the ID of the standard adm group on linux
 	LinuxAdminGID = 4
 

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -193,6 +193,7 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*AuthConte
 					services.NewRule(services.KindCertAuthority, services.ReadNoSecrets()),
 					services.NewRule(services.KindNamespace, services.RO()),
 					services.NewRule(services.KindUser, services.RO()),
+					services.NewRule(services.KindRole, services.RO()),
 					services.NewRule(services.KindAuthServer, services.RO()),
 					services.NewRule(services.KindReverseTunnel, services.RO()),
 					services.NewRule(services.KindTunnelConnection, services.RO()),

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -337,7 +337,7 @@ func (c *Cache) update() {
 			// signal closure to reset the watchers
 			c.Backend.CloseWatchers()
 			if !c.isClosed() {
-				c.Warningf("Re-init the cache on error: %v.", err)
+				c.Warningf("Re-init the cache on error: %v.", trace.Unwrap(err))
 			}
 		}
 		c.Debugf("Reloading %v.", retry)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -722,6 +722,7 @@ func (c *NodeClient) dynamicListenAndForward(ctx context.Context, ln net.Listene
 	}
 }
 
+// Close closes client and it's operations
 func (client *NodeClient) Close() error {
 	return client.Client.Close()
 }

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -238,7 +239,10 @@ func (fs *FSLocalKeyStore) GetKey(proxyHost string, username string) (*Key, erro
 	// Validate the key loaded from disk.
 	err = key.CheckCert()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		// KeyStore should return expired certificates as well
+		if !utils.IsCertExpiredError(err) {
+			return nil, trace.Wrap(err)
+		}
 	}
 	sshCertExpiration, err := key.CertValidBefore()
 	if err != nil {

--- a/lib/client/profile_test.go
+++ b/lib/client/profile_test.go
@@ -42,11 +42,11 @@ func (s *ProfileTestSuite) TestEverything(c *check.C) {
 	pfile := path.Join(home, "test.yaml")
 
 	// save to a file:
-	err := p.SaveTo("", pfile, 0)
+	err := p.SaveTo(ProfileLocation{Path: pfile})
 	c.Assert(err, check.IsNil)
 
 	// try to save to non-existent dir, should get an error
-	err = p.SaveTo("", "/bad/directory/profile.yaml", 0)
+	err = p.SaveTo(ProfileLocation{Path: "/bad/directory/profile.yaml"})
 	c.Assert(err, check.NotNil)
 
 	// make sure there is no symlink:
@@ -55,7 +55,7 @@ func (s *ProfileTestSuite) TestEverything(c *check.C) {
 	c.Assert(os.IsNotExist(err), check.Equals, true)
 
 	// save again, this time with a symlink:
-	p.SaveTo("", pfile, ProfileMakeCurrent)
+	p.SaveTo(ProfileLocation{Path: pfile, Options: ProfileMakeCurrent})
 	stat, err := os.Stat(symlink)
 	c.Assert(err, check.IsNil)
 	c.Assert(stat.Size() > 10, check.Equals, true)
@@ -72,7 +72,7 @@ func (s *ProfileTestSuite) TestEverything(c *check.C) {
 
 	// Save with alias
 	aliasPath := path.Join(home, "alias.yaml")
-	err = p.SaveTo(aliasPath, pfile, ProfileMakeCurrent)
+	err = p.SaveTo(ProfileLocation{AliasPath: aliasPath, Path: pfile, Options: ProfileMakeCurrent})
 	c.Assert(err, check.IsNil)
 
 	// Load from alias works

--- a/lib/services/invite.go
+++ b/lib/services/invite.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"time"
+)
+
+// InviteTokenV3 is an invite token spec format V3
+type InviteTokenV3 struct {
+	// Kind is a resource kind - always resource.
+	Kind string `json:"kind"`
+
+	// SubKind is a resource sub kind
+	SubKind string `json:"sub_kind,omitempty"`
+
+	// Version is a resource version.
+	Version string `json:"version"`
+
+	// Metadata is metadata about the resource.
+	Metadata Metadata `json:"metadata"`
+
+	// Spec is a spec of the invite token
+	Spec InviteTokenSpecV3 `json:"spec"`
+}
+
+// InviteTokenSpecV3 is a spec for invite token
+type InviteTokenSpecV3 struct {
+	// URL is a helper invite token URL
+	URL string `json:"url"`
+}
+
+// NewInviteToken returns a new instance of the invite token
+func NewInviteToken(token, signupURL string, expires time.Time) *InviteTokenV3 {
+	tok := InviteTokenV3{
+		Kind:    KindInviteToken,
+		Version: V3,
+		Metadata: Metadata{
+			Name: token,
+		},
+		Spec: InviteTokenSpecV3{
+			URL: signupURL,
+		},
+	}
+	if !expires.IsZero() {
+		tok.Metadata.SetExpiry(expires)
+	}
+	return &tok
+}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -159,6 +159,9 @@ const (
 	// to proxy
 	KindRemoteCluster = "remote_cluster"
 
+	// KindInviteToken is a local user invite token
+	KindInviteToken = "invite_token"
+
 	// KindIdenity is local on disk identity resource
 	KindIdentity = "identity"
 

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -275,7 +275,19 @@ func MultiCloser(closers ...io.Closer) *multiCloser {
 // IsHandshakeFailedError specifies whether this error indicates
 // failed handshake
 func IsHandshakeFailedError(err error) bool {
+	if err == nil {
+		return false
+	}
 	return strings.Contains(trace.Unwrap(err).Error(), "ssh: handshake failed")
+}
+
+// IsCertExpiredError specifies whether this error indicates
+// expired SSH certificate
+func IsCertExpiredError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(trace.Unwrap(err).Error(), "ssh: cert has expired")
 }
 
 // IsShellFailedError specifies whether this error indicates


### PR DESCRIPTION
Previous Login code path was calling itself recursively.
In some cases that lead to endless loops with browser
opening up forever.

This commit factors out retry logic to RetryWithLogin
decorator handler that is used by CLI explicitly.

Client code became better as a result as there are no
hidden side effects.