### PR TITLE
tctl: users add/ls and tokens ls json output

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -275,6 +275,12 @@ const (
 	// JSON means JSON serialization format
 	JSON = "json"
 
+	// YAML means YAML serialization format
+	YAML = "yaml"
+
+	// Text means text serialization format
+	Text = "text"
+
 	// LinuxAdminGID is the ID of the standard adm group on linux
 	LinuxAdminGID = 4
 

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -193,6 +193,7 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*AuthConte
 					services.NewRule(services.KindCertAuthority, services.ReadNoSecrets()),
 					services.NewRule(services.KindNamespace, services.RO()),
 					services.NewRule(services.KindUser, services.RO()),
+					services.NewRule(services.KindRole, services.RO()),
 					services.NewRule(services.KindAuthServer, services.RO()),
 					services.NewRule(services.KindReverseTunnel, services.RO()),
 					services.NewRule(services.KindTunnelConnection, services.RO()),

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -337,7 +337,7 @@ func (c *Cache) update() {
 			// signal closure to reset the watchers
 			c.Backend.CloseWatchers()
 			if !c.isClosed() {
-				c.Warningf("Re-init the cache on error: %v.", err)
+				c.Warningf("Re-init the cache on error: %v.", trace.Unwrap(err))
 			}
 		}
 		c.Debugf("Reloading %v.", retry)

--- a/lib/services/invite.go
+++ b/lib/services/invite.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"time"
+)
+
+// InviteTokenV3 is an invite token spec format V3
+type InviteTokenV3 struct {
+	// Kind is a resource kind - always resource.
+	Kind string `json:"kind"`
+
+	// SubKind is a resource sub kind
+	SubKind string `json:"sub_kind,omitempty"`
+
+	// Version is a resource version.
+	Version string `json:"version"`
+
+	// Metadata is metadata about the resource.
+	Metadata Metadata `json:"metadata"`
+
+	// Spec is a spec of the invite token
+	Spec InviteTokenSpecV3 `json:"spec"`
+}
+
+// InviteTokenSpecV3 is a spec for invite token
+type InviteTokenSpecV3 struct {
+	// URL is a helper invite token URL
+	URL string `json:"url"`
+}
+
+// NewInviteToken returns a new instance of the invite token
+func NewInviteToken(token, signupURL string, expires time.Time) *InviteTokenV3 {
+	tok := InviteTokenV3{
+		Kind:    KindInviteToken,
+		Version: V3,
+		Metadata: Metadata{
+			Name: token,
+		},
+		Spec: InviteTokenSpecV3{
+			URL: signupURL,
+		},
+	}
+	if !expires.IsZero() {
+		tok.Metadata.SetExpiry(expires)
+	}
+	return &tok
+}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -159,6 +159,9 @@ const (
 	// to proxy
 	KindRemoteCluster = "remote_cluster"
 
+	// KindInviteToken is a local user invite token
+	KindInviteToken = "invite_token"
+
 	// KindIdenity is local on disk identity resource
 	KindIdentity = "identity"
 


### PR DESCRIPTION
This commit adds --format flag (that is already present in other subcommands) support for `tctl users ls` and `tctl tokens ls`