### PR TITLE
Allow RemoteProxy to read local Roles

### DIFF
--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -193,6 +193,7 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*AuthConte
 					services.NewRule(services.KindCertAuthority, services.ReadNoSecrets()),
 					services.NewRule(services.KindNamespace, services.RO()),
 					services.NewRule(services.KindUser, services.RO()),
+					services.NewRule(services.KindRole, services.RO()),
 					services.NewRule(services.KindAuthServer, services.RO()),
 					services.NewRule(services.KindReverseTunnel, services.RO()),
 					services.NewRule(services.KindTunnelConnection, services.RO()),

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -337,7 +337,7 @@ func (c *Cache) update() {
 			// signal closure to reset the watchers
 			c.Backend.CloseWatchers()
 			if !c.isClosed() {
-				c.Warningf("Re-init the cache on error: %v.", err)
+				c.Warningf("Re-init the cache on error: %v.", trace.Unwrap(err))
 			}
 		}
 		c.Debugf("Reloading %v.", retry)


### PR DESCRIPTION
RemoteProxy is allowed to read users, but not roles,
what breaks streaming caching that is set up to fetch users
and roles.

This commit allows remote proxy to read roles and users.