### PR TITLE
Skip schema validation for reverse tunnels

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -43,7 +43,7 @@ type Announcer interface {
 // ReadAccessPoint is an API interface implemented by a certificate authority (CA)
 type ReadAccessPoint interface {
 	// GetReverseTunnels returns  a list of reverse tunnels
-	GetReverseTunnels() ([]services.ReverseTunnel, error)
+	GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error)
 
 	// GetClusterName returns cluster name
 	GetClusterName(opts ...services.MarshalOption) (services.ClusterName, error)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1365,8 +1365,8 @@ func (a *AuthServer) GetNodes(namespace string, opts ...services.MarshalOption) 
 }
 
 // GetReverseTunnels is a part of auth.AccessPoint implementation
-func (a *AuthServer) GetReverseTunnels() ([]services.ReverseTunnel, error) {
-	return a.GetCache().GetReverseTunnels()
+func (a *AuthServer) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
+	return a.GetCache().GetReverseTunnels(opts...)
 }
 
 // GetProxies is a part of auth.AccessPoint implementation

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -598,21 +598,21 @@ func (a *AuthWithRoles) UpsertReverseTunnel(r services.ReverseTunnel) error {
 	return a.authServer.UpsertReverseTunnel(r)
 }
 
-func (a *AuthWithRoles) GetReverseTunnel(name string) (services.ReverseTunnel, error) {
+func (a *AuthWithRoles) GetReverseTunnel(name string, opts ...services.MarshalOption) (services.ReverseTunnel, error) {
 	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetReverseTunnel(name)
+	return a.authServer.GetReverseTunnel(name, opts...)
 }
 
-func (a *AuthWithRoles) GetReverseTunnels() ([]services.ReverseTunnel, error) {
+func (a *AuthWithRoles) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
 	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetReverseTunnels()
+	return a.authServer.GetReverseTunnels(opts...)
 }
 
 func (a *AuthWithRoles) DeleteReverseTunnel(domainName string) error {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -223,7 +223,7 @@ func NewClient(addr string, dialer Dialer, params ...roundtrip.ClientParam) (*Cl
 		dialer = net.Dial
 	}
 	transport := &http.Transport{
-		Dial:                  dialer,
+		Dial: dialer,
 		ResponseHeaderTimeout: defaults.DefaultDialTimeout,
 	}
 	params = append(params,
@@ -952,12 +952,12 @@ func (c *Client) UpsertReverseTunnel(tunnel services.ReverseTunnel) error {
 }
 
 // GetReverseTunnel returns reverse tunnel by name
-func (c *Client) GetReverseTunnel(name string) (services.ReverseTunnel, error) {
+func (c *Client) GetReverseTunnel(name string, opts ...services.MarshalOption) (services.ReverseTunnel, error) {
 	return nil, trace.NotImplemented("not implemented")
 }
 
 // GetReverseTunnels returns the list of created reverse tunnels
-func (c *Client) GetReverseTunnels() ([]services.ReverseTunnel, error) {
+func (c *Client) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
 	out, err := c.Get(c.Endpoint("reversetunnels"), url.Values{})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -613,8 +613,8 @@ func (c *Cache) GetNodes(namespace string, opts ...services.MarshalOption) ([]se
 }
 
 // GetReverseTunnels is a part of auth.AccessPoint implementation
-func (c *Cache) GetReverseTunnels() ([]services.ReverseTunnel, error) {
-	return c.presenceCache.GetReverseTunnels()
+func (c *Cache) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
+	return c.presenceCache.GetReverseTunnels(services.AddOptions(opts, services.SkipValidation())...)
 }
 
 // GetProxies is a part of auth.AccessPoint implementation

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -189,7 +189,7 @@ func (c *reverseTunnel) erase() error {
 }
 
 func (c *reverseTunnel) fetch() error {
-	resources, err := c.Presence.GetReverseTunnels()
+	resources, err := c.Presence.GetReverseTunnels(services.SkipValidation())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -360,17 +360,17 @@ func (s *PresenceService) UpsertReverseTunnel(tunnel services.ReverseTunnel) err
 }
 
 // GetReverseTunnel returns reverse tunnel by name
-func (s *PresenceService) GetReverseTunnel(name string) (services.ReverseTunnel, error) {
+func (s *PresenceService) GetReverseTunnel(name string, opts ...services.MarshalOption) (services.ReverseTunnel, error) {
 	item, err := s.Get(context.TODO(), backend.Key(reverseTunnelsPrefix, name))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return services.GetReverseTunnelMarshaler().UnmarshalReverseTunnel(item.Value,
-		services.WithResourceID(item.ID), services.WithExpires(item.Expires))
+		services.AddOptions(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires))...)
 }
 
 // GetReverseTunnels returns a list of registered servers
-func (s *PresenceService) GetReverseTunnels() ([]services.ReverseTunnel, error) {
+func (s *PresenceService) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
 	startKey := backend.Key(reverseTunnelsPrefix)
 	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
@@ -379,7 +379,7 @@ func (s *PresenceService) GetReverseTunnels() ([]services.ReverseTunnel, error) 
 	tunnels := make([]services.ReverseTunnel, len(result.Items))
 	for i, item := range result.Items {
 		tunnel, err := services.GetReverseTunnelMarshaler().UnmarshalReverseTunnel(
-			item.Value, services.WithResourceID(item.ID), services.WithExpires(item.Expires))
+			item.Value, services.AddOptions(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires))...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -77,10 +77,10 @@ type Presence interface {
 	UpsertReverseTunnel(tunnel ReverseTunnel) error
 
 	// GetReverseTunnel returns reverse tunnel by name
-	GetReverseTunnel(name string) (ReverseTunnel, error)
+	GetReverseTunnel(name string, opts ...MarshalOption) (ReverseTunnel, error)
 
 	// GetReverseTunnels returns a list of registered servers
-	GetReverseTunnels() ([]ReverseTunnel, error)
+	GetReverseTunnels(opts ...MarshalOption) ([]ReverseTunnel, error)
 
 	// DeleteReverseTunnel deletes reverse tunnel by it's domain name
 	DeleteReverseTunnel(domainName string) error


### PR DESCRIPTION
This commit skips slow JSON schema validation
for reverse tunnels in some hot spots to
improve scalability.