### PR TITLE
Add keep alive support to GRPC clients.

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -370,7 +370,7 @@ func (a *TestAuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, p
 	addrs := []utils.NetAddr{{
 		AddrNetwork: addr.Network(),
 		Addr:        addr.String()}}
-	return NewTLSClient(addrs, tlsConfig)
+	return NewTLSClient(ClientConfig{Addrs: addrs, TLS: tlsConfig})
 }
 
 // TestTLSServerConfig is a configuration for test TLS server
@@ -521,7 +521,7 @@ func (t *TestTLSServer) NewClientFromWebSession(sess services.WebSession) (*Clie
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	addrs := []utils.NetAddr{utils.FromAddr(t.Listener.Addr())}
-	return NewTLSClient(addrs, tlsConfig)
+	return NewTLSClient(ClientConfig{Addrs: addrs, TLS: tlsConfig})
 }
 
 // CertPool returns cert pool that auth server represents
@@ -557,7 +557,7 @@ func (t *TestTLSServer) ClientTLSConfig(identity TestIdentity) (*tls.Config, err
 // but forces the client to be recreated
 func (t *TestTLSServer) CloneClient(clt *Client) *Client {
 	addr := []utils.NetAddr{{Addr: t.Addr().String(), AddrNetwork: t.Addr().Network()}}
-	newClient, err := NewTLSClient(addr, clt.TLSConfig())
+	newClient, err := NewTLSClient(ClientConfig{Addrs: addr, TLS: clt.TLSConfig()})
 	if err != nil {
 		panic(err)
 	}
@@ -571,7 +571,7 @@ func (t *TestTLSServer) NewClient(identity TestIdentity) (*Client, error) {
 		return nil, trace.Wrap(err)
 	}
 	addrs := []utils.NetAddr{utils.FromAddr(t.Listener.Addr())}
-	return NewTLSClient(addrs, tlsConfig)
+	return NewTLSClient(ClientConfig{Addrs: addrs, TLS: tlsConfig})
 }
 
 // Addr returns address of TLS server

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -228,7 +228,7 @@ func insecureRegisterClient(params RegisterParams) (*Client, error) {
 		log.Infof("Joining remote cluster %v, validating connection with certificate on disk.", cert.Subject.CommonName)
 	}
 
-	client, err := NewTLSClient(params.Servers, tlsConfig)
+	client, err := NewTLSClient(ClientConfig{Addrs: params.Servers, TLS: tlsConfig})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -260,7 +260,7 @@ func pinRegisterClient(params RegisterParams) (*Client, error) {
 	// an attacker were to MITM this connection the CA pin will not match below.
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
 	tlsConfig.InsecureSkipVerify = true
-	client, err := NewTLSClient(params.Servers, tlsConfig)
+	client, err := NewTLSClient(ClientConfig{Addrs: params.Servers, TLS: tlsConfig})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -294,7 +294,7 @@ func pinRegisterClient(params RegisterParams) (*Client, error) {
 	certPool.AddCert(tlsCA)
 	tlsConfig.RootCAs = certPool
 
-	client, err = NewTLSClient(params.Servers, tlsConfig)
+	client, err = NewTLSClient(ClientConfig{Addrs: params.Servers, TLS: tlsConfig})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1645,7 +1645,10 @@ func (s *TLSSuite) TestCipherSuites(c *check.C) {
 		utils.FromAddr(otherServer.Listener.Addr()),
 		utils.FromAddr(s.server.Listener.Addr()),
 	}
-	client, err := NewTLSClient(addrs, tlsConfig)
+	client, err := NewTLSClient(ClientConfig{
+		Addrs: addrs,
+		TLS:   tlsConfig,
+	})
 	c.Assert(err, check.IsNil)
 
 	// Requests should fail.
@@ -1666,7 +1669,7 @@ func (s *TLSSuite) TestTLSFailover(c *check.C) {
 		utils.FromAddr(otherServer.Listener.Addr()),
 		utils.FromAddr(s.server.Listener.Addr()),
 	}
-	client, err := NewTLSClient(addrs, tlsConfig)
+	client, err := NewTLSClient(ClientConfig{Addrs: addrs, TLS: tlsConfig})
 	c.Assert(err, check.IsNil)
 
 	// couple of runs to get enough connections

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -186,7 +186,10 @@ func (proxy *ProxyClient) ConnectToCluster(ctx context.Context, clusterName stri
 	}
 
 	if proxy.teleportClient.SkipLocalAuth {
-		return auth.NewTLSClientWithDialer(dialer, proxy.teleportClient.TLS)
+		return auth.NewTLSClient(auth.ClientConfig{
+			DialContext: dialer,
+			TLS:         proxy.teleportClient.TLS,
+		})
 	}
 
 	// Because Teleport clients can't be configured (yet), they take the default
@@ -212,7 +215,10 @@ func (proxy *ProxyClient) ConnectToCluster(ctx context.Context, clusterName stri
 	if len(tlsConfig.Certificates) == 0 {
 		return nil, trace.BadParameter("no TLS keys found for user %v, please relogin to get new credentials", proxy.teleportClient.Username)
 	}
-	clt, err := auth.NewTLSClientWithDialer(dialer, tlsConfig)
+	clt, err := auth.NewTLSClient(auth.ClientConfig{
+		DialContext: dialer,
+		TLS:         tlsConfig,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -102,7 +102,10 @@ func (s *remoteSite) getRemoteClient() (auth.ClientI, bool, error) {
 		// connecting to the remote one (it is used to find the right certificate
 		// authority to verify)
 		tlsConfig.ServerName = auth.EncodeClusterName(s.srv.ClusterName)
-		clt, err := auth.NewTLSClientWithDialer(s.authServerContextDialer, tlsConfig)
+		clt, err := auth.NewTLSClient(auth.ClientConfig{
+			DialContext: s.authServerContextDialer,
+			TLS:         tlsConfig,
+		})
 		if err != nil {
 			return nil, false, trace.Wrap(err)
 		}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -847,7 +847,10 @@ func (process *TeleportProcess) newClientThroughTunnel(servers []utils.NetAddr, 
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := auth.NewTLSClientWithDialer(reversetunnel.TunnelAuthDialer(proxyAddr, identity.SSHClientConfig()), tlsConfig)
+	clt, err := auth.NewTLSClient(auth.ClientConfig{
+		DialContext: reversetunnel.TunnelAuthDialer(proxyAddr, identity.SSHClientConfig()),
+		TLS:         tlsConfig,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -861,7 +864,9 @@ func (process *TeleportProcess) newClientDirect(authServers []utils.NetAddr, ide
 		return nil, trace.Wrap(err)
 	}
 	if process.Config.ClientTimeout != 0 {
-		return auth.NewTLSClient(authServers, tlsConfig, auth.ClientTimeout(process.Config.ClientTimeout))
+		return auth.NewTLSClient(auth.ClientConfig{
+			Addrs: authServers,
+			TLS:   tlsConfig}, auth.ClientTimeout(process.Config.ClientTimeout))
 	}
-	return auth.NewTLSClient(authServers, tlsConfig)
+	return auth.NewTLSClient(auth.ClientConfig{Addrs: authServers, TLS: tlsConfig})
 }

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015-2017 Gravitational, Inc.
+Copyright 2015-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -146,7 +146,7 @@ func connectToAuthService(cfg *service.Config) (client auth.ClientI, err error) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	client, err = auth.NewTLSClient(cfg.AuthServers, tlsConfig)
+	client, err = auth.NewTLSClient(auth.ClientConfig{Addrs: cfg.AuthServers, TLS: tlsConfig})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This commit turns on KeepAlive support
for GRPC clients to make sure that dropped
connections are detected properly.