### PR TITLE
Simplify IOT reverse tunnel logic.

### DIFF
--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -104,6 +104,9 @@ type localSite struct {
 
 // GetTunnelsCount always the number of tunnel connections to this cluster.
 func (s *localSite) GetTunnelsCount() int {
+	s.Lock()
+	defer s.Unlock()
+
 	return len(s.remoteConns)
 }
 

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -103,8 +103,8 @@ func (s *remoteSite) getRemoteClient() (auth.ClientI, bool, error) {
 		// authority to verify)
 		tlsConfig.ServerName = auth.EncodeClusterName(s.srv.ClusterName)
 		clt, err := auth.NewTLSClient(auth.ClientConfig{
-			DialContext: s.authServerContextDialer,
-			TLS:         tlsConfig,
+			Dialer: auth.ContextDialerFunc(s.authServerContextDialer),
+			TLS:    tlsConfig,
 		})
 		if err != nil {
 			return nil, false, trace.Wrap(err)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -164,10 +164,10 @@ func (c *SessionContext) newRemoteClient(cluster reversetunnel.RemoteSite) (auth
 }
 
 // clusterDialer returns DialContext function using cluster's dial function
-func clusterDialer(remoteCluster reversetunnel.RemoteSite) auth.DialContext {
-	return func(in context.Context, network, _ string) (net.Conn, error) {
+func clusterDialer(remoteCluster reversetunnel.RemoteSite) auth.ContextDialer {
+	return auth.ContextDialerFunc(func(in context.Context, network, _ string) (net.Conn, error) {
 		return remoteCluster.DialAuthServer()
-	}
+	})
 }
 
 // tryRemoteTLSClient tries creating TLS client and using it (the client may not be available
@@ -227,7 +227,7 @@ func (c *SessionContext) newRemoteTLSClient(cluster reversetunnel.RemoteSite) (a
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return auth.NewTLSClient(auth.ClientConfig{DialContext: clusterDialer(cluster), TLS: tlsConfig})
+	return auth.NewTLSClient(auth.ClientConfig{Dialer: clusterDialer(cluster), TLS: tlsConfig})
 }
 
 // GetUser returns the authenticated teleport user


### PR DESCRIPTION
In case of IOT (whenever teleport nodes are
connecting to the proxy), there is no need
to create ReverseTunnel objects in the backend,
as there is always one reverse tunnel per node.

This commit removes the logic that created
reverse tunnel object in the backed in IOT cases
and refactors some other parts of the code.