### PR TITLE
Updated cryptographic primitives documentation.

### DIFF
--- a/docs/3.2/admin-guide.md
+++ b/docs/3.2/admin-guide.md
@@ -267,8 +267,7 @@ teleport:
       - aes192-ctr
       - aes256-ctr
       - aes128-gcm@openssh.com
-      - arcfour256
-      - arcfour128
+      - chacha20-poly1305@openssh.com
 
     # Key exchange algorithms that the server supports. This section only needs
     # to be set if you want to override the defaults.
@@ -277,31 +276,18 @@ teleport:
       - ecdh-sha2-nistp256
       - ecdh-sha2-nistp384
       - ecdh-sha2-nistp521
-      - diffie-hellman-group14-sha1
-      - diffie-hellman-group1-sha1
 
     # Message authentication code (MAC) algorithms that the server supports.
     # This section only needs to be set if you want to override the defaults.
     mac_algos:
       - hmac-sha2-256-etm@openssh.com
       - hmac-sha2-256
-      - hmac-sha1
-      - hmac-sha1-96
 
     # List of the supported ciphersuites. If this section is not specified,
     # only the default ciphersuites are enabled.
     ciphersuites:
-       - tls-rsa-with-aes-128-cbc-sha # default
-       - tls-rsa-with-aes-256-cbc-sha # default
-       - tls-rsa-with-aes-128-cbc-sha256
        - tls-rsa-with-aes-128-gcm-sha256
        - tls-rsa-with-aes-256-gcm-sha384
-       - tls-ecdhe-ecdsa-with-aes-128-cbc-sha
-       - tls-ecdhe-ecdsa-with-aes-256-cbc-sha
-       - tls-ecdhe-rsa-with-aes-128-cbc-sha
-       - tls-ecdhe-rsa-with-aes-256-cbc-sha
-       - tls-ecdhe-ecdsa-with-aes-128-cbc-sha256
-       - tls-ecdhe-rsa-with-aes-128-cbc-sha256
        - tls-ecdhe-rsa-with-aes-128-gcm-sha256
        - tls-ecdhe-ecdsa-with-aes-128-gcm-sha256
        - tls-ecdhe-rsa-with-aes-256-gcm-sha384


### PR DESCRIPTION
**Description**

Updated documentation to reflect the following changes:

* Removed `arcfour128` and `arcfour256` because they are insecure.
* Added `chacha20-poly1305@openssh.com` to the list of supported ciphers.
* Removed `diffie-hellman-group1-sha1` and `diffie-hellman-group14-sha1` from the list of supported KEX. These can be added in manually, but they have been removed from the documentation to discourage their use. See #1856 for more details.
* Removed `hmac-sha1` and `hmac-sha1-96` from the list of supported MACs. These can be added in manually, but they have been removed from the documentation to discourage their use. See #1856 for more details.
* Updated TLS ciphersuites to only reflect supported ciphersuites. See #1974 for more details.