### PR TITLE
Fix several goroutine/connection leaks

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -112,7 +113,8 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	server := &TLSServer{
 		TLSServerConfig: cfg,
 		Server: &http.Server{
-			Handler: limiter,
+			Handler:           limiter,
+			ReadHeaderTimeout: defaults.DefaultDialTimeout,
 		},
 		Entry: logrus.WithFields(logrus.Fields{
 			trace.Component: cfg.Component,

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 
 	"github.com/gravitational/trace"
@@ -105,7 +106,8 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	server := &TLSServer{
 		TLSServerConfig: cfg,
 		Server: &http.Server{
-			Handler: limiter,
+			Handler:           limiter,
+			ReadHeaderTimeout: defaults.DefaultDialTimeout * 2,
 		},
 	}
 	server.TLS.GetConfigForClient = server.GetConfigForClient

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -61,7 +61,8 @@ func (t *TunnelAuthDialer) DialContext(ctx context.Context, network string, addr
 		Address: RemoteAuthServer,
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		err2 := sconn.Close()
+		return nil, trace.NewAggregate(err, err2)
 	}
 	return conn, nil
 }
@@ -160,7 +161,7 @@ func connectProxyTransport(sconn ssh.Conn, req *dialReq) (net.Conn, bool, error)
 		return nil, false, trace.Errorf(strings.TrimSpace(string(errMessage)))
 	}
 
-	return utils.NewChConn(sconn, channel), false, nil
+	return utils.NewExclusiveChConn(sconn, channel), false, nil
 }
 
 // proxyTransport runs either in the agent or reverse tunnel itself. It's

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1647,7 +1647,8 @@ func (process *TeleportProcess) initDiagnosticService() error {
 	warnOnErr(process.closeImportedDescriptors(teleport.ComponentDiagnostic))
 
 	server := &http.Server{
-		Handler: mux,
+		Handler:           mux,
+		ReadHeaderTimeout: defaults.DefaultDialTimeout,
 	}
 
 	log.Infof("Starting diagnostic service on %v.", process.Config.DiagnosticAddr.Addr)
@@ -2012,7 +2013,8 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			listeners.web = tls.NewListener(listeners.web, tlsConfig)
 		}
 		webServer = &http.Server{
-			Handler: proxyLimiter,
+			Handler:           proxyLimiter,
+			ReadHeaderTimeout: defaults.DefaultDialTimeout,
 		}
 		process.RegisterCriticalFunc("proxy.web", func() error {
 			utils.Consolef(cfg.Console, teleport.ComponentProxy, "Web proxy service is starting on %v.", cfg.Proxy.WebAddr.Addr)


### PR DESCRIPTION
This commit fixes several gorotuine and connection leaks
by setting header read timeout on http servers and
cleaning up failed connections.