### PR TITLE
Refactor discovery protocol

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2046,7 +2046,8 @@ func (s *IntSuite) TestDiscoveryNode(c *check.C) {
 
 	// Once the proxy is removed, only one proxy is left. Wait for the now
 	// invalid tunnel connection to TTL and be removed.
-	waitForTunnelConnections(c, main.Process.GetAuthServer(), Site, 1)
+	waitForActiveTunnelConnections(c, main.Tunnel, Site, 1)
+	waitForActiveTunnelConnections(c, proxyTunnel, Site, 1)
 
 	// requests going via main proxy will fail
 	output, err = runCommand(main, []string{"echo", "hello world"}, cfg, 1)
@@ -2064,7 +2065,7 @@ func (s *IntSuite) TestDiscoveryNode(c *check.C) {
 	lb.AddBackend(*proxyOneAddr)
 
 	// Once the proxy is added a matching tunnel connection should be created.
-	waitForTunnelConnections(c, main.Process.GetAuthServer(), Site, 2)
+	waitForActiveTunnelConnections(c, proxyTunnel, Site, 1)
 
 	output, err = runCommand(main, []string{"echo", "hello world"}, cfg, 40)
 	c.Assert(err, check.IsNil)

--- a/lib/reversetunnel/doc.go
+++ b/lib/reversetunnel/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /*
-package reversetunnel provides interfaces for accessing remote clusters
+Package reversetunnel provides interfaces for accessing remote clusters
    via reverse tunnels and directly.
 
 Reverse Tunnels
@@ -45,8 +45,7 @@ proxies in cluster.
 
 * Initially Proxy Agent connects to Proxy 1.
 * Proxy 1 starts sending information about all available proxies
-that have not received connection from the Proxy Agent yet. This
-process is called "sending discovery request".
+to the the Proxy Agent . This process is called "sending discovery request".
 
 
 +----------+

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -24,6 +24,12 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// ProxyGetter is an service that gets proxies
+type ProxyGetter interface {
+	// GetProxies returns a list of registered proxies
+	GetProxies() ([]Server, error)
+}
+
 // Presence records and reports the presence of all components
 // of the cluster - Nodes, Proxies and SSH nodes
 type Presence interface {
@@ -70,8 +76,8 @@ type Presence interface {
 	// for the specified duration with second resolution if it's >= 1 second
 	UpsertProxy(server Server) error
 
-	// GetProxies returns a list of registered proxies
-	GetProxies() ([]Server, error)
+	// ProxyGetter gets a list of proxies
+	ProxyGetter
 
 	// DeleteProxy deletes proxy by name
 	DeleteProxy(name string) error

--- a/lib/services/proxywatcher.go
+++ b/lib/services/proxywatcher.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+// NewProxyWatcher returns a new instance of changeset
+func NewProxyWatcher(cfg ProxyWatcherConfig) (*ProxyWatcher, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	retry, err := utils.NewLinear(utils.LinearConfig{
+		Step: cfg.RetryPeriod / 10,
+		Max:  cfg.RetryPeriod,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	p := &ProxyWatcher{
+		RWMutex:            &sync.RWMutex{},
+		retry:              retry,
+		ProxyWatcherConfig: cfg,
+		FieldLogger:        cfg.Entry,
+	}
+	go p.watchProxies()
+	return p, nil
+}
+
+// ProxyWatcher is a resource built on top of the events,
+// it monitors the additions and deletions to the proxies
+type ProxyWatcher struct {
+	*sync.RWMutex
+	log.FieldLogger
+	ProxyWatcherConfig
+
+	// retry is used to manage backoff logic for watches
+	retry utils.Retry
+
+	// current is a list of the current servers
+	// as reported by the watcher
+	current []Server
+}
+
+// ProxyWatcherConfig configures proxy watcher
+type ProxyWatcherConfig struct {
+	// Context is a parent context
+	// controlling the lifecycle of the changeset
+	Context context.Context
+	// Component is a component used in logs
+	Component string
+	// RetryPeriod is a retry period on failed watchers
+	RetryPeriod time.Duration
+	// ReloadPeriod is a failed period on failed watches
+	ReloadPeriod time.Duration
+	// Client is used by changeset to monitor proxy updates
+	Client ProxyWatcherClient
+	// Entry is a logging entry
+	Entry log.FieldLogger
+	// ProxiesC is a channel that will be used
+	// by the watcher to push updated list,
+	// it will always receive a fresh list on the start
+	// and the subsequent list of new values
+	// whenever an addition or deletion to the list is detected
+	ProxiesC chan []Server
+}
+
+// CheckAndSetDefaults checks parameters and sets default values
+func (cfg *ProxyWatcherConfig) CheckAndSetDefaults() error {
+	if cfg.Context == nil {
+		return trace.BadParameter("missing parameter Context")
+	}
+	if cfg.Component == "" {
+		return trace.BadParameter("missing parameter Component")
+	}
+	if cfg.Client == nil {
+		return trace.BadParameter("missing parameter Client")
+	}
+	if cfg.ProxiesC == nil {
+		return trace.BadParameter("missing parameter ProxiesC")
+	}
+	if cfg.Entry == nil {
+		cfg.Entry = log.StandardLogger()
+	}
+	if cfg.RetryPeriod == 0 {
+		cfg.RetryPeriod = defaults.HighResPollingPeriod
+	}
+	if cfg.ReloadPeriod == 0 {
+		cfg.ReloadPeriod = defaults.LowResPollingPeriod
+	}
+	return nil
+}
+
+// GetCurrent returns a list of currently active proxies
+func (p *ProxyWatcher) GetCurrent() []Server {
+	p.RLock()
+	defer p.RUnlock()
+	return p.current
+}
+
+// setCurrent sets currently active proxy list
+func (p *ProxyWatcher) setCurrent(proxies []Server) {
+	p.Lock()
+	defer p.Unlock()
+	p.current = proxies
+}
+
+// ProxyWatcherClient is used by changeset to fetch a list
+// of proxies and subscribe to updates
+type ProxyWatcherClient interface {
+	ProxyGetter
+	Events
+}
+
+// watchProxies watches new proxies added and removed to the cluster
+// and when this happens, notifies all connected agents
+// about the proxy set change via discovery requests
+func (p *ProxyWatcher) watchProxies() {
+	for {
+		// Reload period is here to protect against
+		// unknown cache going out of sync problems
+		// that we did not predict.
+		err := p.watch()
+		if err != nil {
+			p.Warningf("Re-init the watcher on error: %v.", trace.Unwrap(err))
+		}
+		p.Debugf("Reloading %v.", p.retry)
+		select {
+		case <-p.retry.After():
+			p.retry.Inc()
+		case <-p.Context.Done():
+			p.Debugf("Closed, returning from update loop.")
+			return
+		}
+	}
+}
+
+// watch sets up the watch on proxies
+func (p *ProxyWatcher) watch() error {
+	watcher, err := p.Client.NewWatcher(p.Context, Watch{
+		Name: p.Component,
+		Kinds: []WatchKind{
+			{
+				Kind: KindProxy,
+			},
+		},
+		MetricComponent: p.Component,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer watcher.Close()
+	reloadC := time.After(p.ReloadPeriod)
+	// before fetch, make sure watcher is synced by receiving init event,
+	// to avoid the scenario:
+	// 1. Cache process:   w = NewWatcher()
+	// 2. Cache process:   c.fetch()
+	// 3. Backend process: addItem()
+	// 4. Cache process:   <- w.Events()
+	//
+	// If there is a way that NewWatcher() on line 1 could
+	// return without subscription established first,
+	// Code line 3 could execute and line 4 could miss event,
+	// wrapping up with out of sync replica.
+	// To avoid this, before doing fetch,
+	// cache process makes sure the connection is established
+	// by receiving init event first.
+	select {
+	case <-watcher.Done():
+		return trace.ConnectionProblem(watcher.Error(), "watcher is closed")
+	case <-reloadC:
+		p.Debugf("Triggering scheduled reload.")
+		return nil
+	case <-p.Context.Done():
+		return trace.ConnectionProblem(p.Context.Err(), "context is closing")
+	case event := <-watcher.Events():
+		if event.Type != backend.OpInit {
+			return trace.BadParameter("expected init event, got %v instead", event.Type)
+		}
+	}
+	proxies, err := p.Client.GetProxies()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	proxySet := make(map[string]Server, len(proxies))
+	for i := range proxies {
+		proxySet[proxies[i].GetName()] = proxies[i]
+	}
+	p.retry.Reset()
+	p.setCurrent(proxies)
+	select {
+	case p.ProxiesC <- proxies:
+	case <-p.Context.Done():
+		return trace.ConnectionProblem(p.Context.Err(), "context is closing")
+	}
+	for {
+		select {
+		case <-watcher.Done():
+			return trace.ConnectionProblem(watcher.Error(), "watcher is closed")
+		case <-reloadC:
+			p.Debugf("Triggering scheduled reload.")
+			return nil
+		case <-p.Context.Done():
+			return trace.ConnectionProblem(p.Context.Err(), "context is closing")
+		case event := <-watcher.Events():
+			updated := p.processEvent(event, proxySet)
+			if updated {
+				proxies = setToList(proxySet)
+				p.setCurrent(proxies)
+				select {
+				case p.ProxiesC <- proxies:
+				case <-p.Context.Done():
+					return trace.ConnectionProblem(p.Context.Err(), "context is closing")
+				}
+			}
+		}
+	}
+}
+
+// processEvent updates proxy map and returns true if the proxies list have been modified -
+// the proxy has been either added or deleted
+func (p *ProxyWatcher) processEvent(event Event, proxies map[string]Server) bool {
+	if event.Resource.GetKind() != KindProxy {
+		p.Warningf("Unexpected event: %v.")
+		return false
+	}
+	switch event.Type {
+	case backend.OpDelete:
+		delete(proxies, event.Resource.GetName())
+		// always return true if the proxy has been deleted to trigger
+		// broadcast cleanup
+		return true
+	case backend.OpPut:
+		_, existed := proxies[event.Resource.GetName()]
+		resource, ok := event.Resource.(Server)
+		if !ok {
+			p.Warningf("unexpected type %T", event.Resource)
+			return false
+		}
+		proxies[event.Resource.GetName()] = resource
+		return !existed
+	default:
+		p.Warningf("Skipping unsupported event type %v.", event.Type)
+		return false
+	}
+}
+
+func setToList(in map[string]Server) []Server {
+	out := make([]Server, 0, len(in))
+	for key := range in {
+		out = append(out, in[key])
+	}
+	return out
+}

--- a/lib/services/tunnelconn.go
+++ b/lib/services/tunnelconn.go
@@ -73,7 +73,7 @@ func LatestTunnelConnection(conns []TunnelConnection) (TunnelConnection, error) 
 	return lastConn, nil
 }
 
-// IsTunnelConnectionStatus returns tunnel connection status based on the last
+// TunnelConnectionStatus returns tunnel connection status based on the last
 // heartbeat time recorded for a connection
 func TunnelConnectionStatus(clock clockwork.Clock, conn TunnelConnection) string {
 	diff := clock.Now().Sub(conn.GetLastHeartbeat())

--- a/lib/utils/loadbalancer.go
+++ b/lib/utils/loadbalancer.go
@@ -72,7 +72,7 @@ type LoadBalancer struct {
 func (l *LoadBalancer) trackConnection(backend NetAddr, conn net.Conn) int64 {
 	l.Lock()
 	defer l.Unlock()
-	l.connID += 1
+	l.connID++
 	tracker, ok := l.connections[backend]
 	if !ok {
 		tracker = make(map[int64]net.Conn)
@@ -107,7 +107,7 @@ func (l *LoadBalancer) AddBackend(b NetAddr) {
 	l.Lock()
 	defer l.Unlock()
 	l.backends = append(l.backends, b)
-	l.Debugf("backends %v", l.backends)
+	l.Debugf("Backends %v.", l.backends)
 }
 
 // RemoveBackend removes backend
@@ -190,23 +190,24 @@ func (l *LoadBalancer) Serve() error {
 			}
 			select {
 			case <-backoffTimer.C:
-				l.Debugf("backoff on network error")
+				l.Debugf("Backoff on network error.")
 			case <-l.ctx.Done():
 				return trace.ConnectionProblem(nil, "context is closing")
 			}
+		} else {
+			go l.forwardConnection(conn)
 		}
-		go l.forwardConnection(conn)
 	}
 }
 
 func (l *LoadBalancer) forwardConnection(conn net.Conn) {
 	err := l.forward(conn)
 	if err != nil {
-		l.Warningf("failed to forward connection: %v", err)
+		l.Warningf("Failed to forward connection: %v.", err)
 	}
 }
 
-// this is to workaround issue https://github.com/golang/go/issues/10527
+// Wait is here to workaround issue https://github.com/golang/go/issues/10527
 // in tests
 func (l *LoadBalancer) Wait() {
 	<-l.waitCtx.Done()


### PR DESCRIPTION
Refactor discovery protocol.

This commit refactors discovery protocol
to make it less dependent on the database and
scale better on large numbers of tunnels.

Reverse tunnel is now always sending
back the list of all proxies registered in the
cluster in the form of discovery requests.

Before this commit, reverse tunnel server was comparing
existing `TunnelConnection` with the Proxies
and sending back the list of proxies that were not
discovered.

This required nodes to register tunnel connections
in the database and servers poll the connections.

On 10K clusters this is not scalable. Instead,
the change assumes that there is not a lot of
proxies so it's OK to send the information about
them back to all connected agents.

Agent pools can make up their own mind about what to
do with the information - they can ignore
the request as long as they observe all agents
connected to the requested proxies.

At the same time, to avoid using too much traffic,
reverse tunnel server only sends the discovery requests
after the first agent heartbeat and in case if
proxy list changes. To make it possible reverse tunnel
sets up a watch on the proxies.