### PR TITLE
[3.2] Wrap transport when kube proxy runs in-cluster.

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -10,6 +10,7 @@ COPY pam/teleport-acct-failure /etc/pam.d
 COPY pam/teleport-session-failure /etc/pam.d
 COPY pam/teleport-success /etc/pam.d
 
+RUN apt-get update
 RUN apt-get install -q -y libpam-dev
 RUN apt-get install -q -y libc6-dev-i386
 RUN apt-get install -q -y net-tools


### PR DESCRIPTION
This PR fixes the issue with Teleport's Kubernetes proxy sending empty credentials to the API server when running in-cluster.

When Teleport runs inside Kubernetes cluster, it uses "in-cluster configuration" which provides a wrapper for transport that adds service account token to requests. This wrapper was not used and thus Teleport was not providing any credentials when making impersonation requests to the API server, which could be seen in the audit log - the "user" field was empty.

I've tested both local and remote cluster paths using Gravity (i.e. via Ops Center + cluster).