### PR TITLE
Fix event index for session data.

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"github.com/gravitational/teleport/lib/session"
@@ -169,6 +170,15 @@ const (
 	// ResizeEvent means that some user resized PTY on the client
 	ResizeEvent  = "resize"
 	TerminalSize = "size" // expressed as 'W:H'
+
+	// SessionUploadIndex is a very large number of the event index
+	// to indicate that this is the last event in the chain
+	// used for the last event of the sesion - session upload
+	SessionUploadIndex = math.MaxInt32
+	// SessionDataIndex is a very large number of the event index
+	// to indicate one of the last session events, used to report
+	// data transfer
+	SessionDataIndex = math.MaxInt32 - 1
 )
 
 const (

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -348,7 +347,7 @@ func (l *AuditLog) UploadSessionRecording(r SessionRecording) error {
 	return l.EmitAuditEvent(SessionUpload, EventFields{
 		SessionEventID: string(r.SessionID),
 		URL:            url,
-		EventIndex:     math.MaxInt32,
+		EventIndex:     SessionUploadIndex,
 	})
 }
 

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -485,6 +485,7 @@ func (c *ServerContext) reportStats(conn utils.Stater) {
 		events.EventUser:       c.Identity.TeleportUser,
 		events.LocalAddr:       c.Conn.LocalAddr().String(),
 		events.RemoteAddr:      c.Conn.RemoteAddr().String(),
+		events.EventIndex:      events.SessionDataIndex,
 	}
 	if c.session != nil {
 		eventFields[events.SessionEventID] = c.session.id


### PR DESCRIPTION
Session Data transfer event missed event index,
effectively setting it to 0.

It is not a mistake by itself, however on Dynamo
it resulted this event overwriting SessionStart
event, resulting in incomplete session
event records.

This is not a perfect fix, as the same problem
could be introduced at any other point,
so something more robust should be added in the future
to prevent similar problems from happening.