### PR TITLE
Do not emit events in mirror mode.

### DIFF
--- a/examples/etcd/start-etcd.sh
+++ b/examples/etcd/start-etcd.sh
@@ -4,8 +4,11 @@
 #   - server cert is checked by clients
 #   - client cert is checked by the server
 #
-# NOTE: this file is also used to run etcd tests. 
-#       
+# NOTE: this file is also used to run etcd tests.
+#
+
+EXAMPLES_DIR=$GOPATH/src/github.com/gravitational/teleport/examples/etcd
+
 HERE=$(readlink -f $0)
 cd $(dirname $HERE)
 
@@ -13,9 +16,9 @@ mkdir -p data
 etcd --name teleportstorage \
      --data-dir data/etcd \
      --initial-cluster-state new \
-     --cert-file=certs/server-cert.pem \
-     --key-file=certs/server-key.pem \
-     --trusted-ca-file=certs/ca-cert.pem \
+     --cert-file=$EXAMPLES_DIR/certs/server-cert.pem \
+     --key-file=$EXAMPLES_DIR/certs/server-key.pem \
+     --trusted-ca-file=$EXAMPLES_DIR/certs/ca-cert.pem \
      --advertise-client-urls=https://127.0.0.1:2379 \
      --listen-client-urls=https://127.0.0.1:2379 \
      --client-cert-auth

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -65,7 +65,8 @@ func (s *EtcdSuite) SetUpSuite(c *check.C) {
 	b, err := newBackend()
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
-			fmt.Println("WARNING: etcd cluster is not available. Start examples/etcd/start-etcd.sh")
+			fmt.Printf("WARNING: etcd cluster is not available: %v.\n", err)
+			fmt.Printf("WARNING: Start examples/etcd/start-etcd.sh.\n")
 			s.skip = true
 			c.Skip(err.Error())
 		}

--- a/lib/backend/lite/lite_test.go
+++ b/lib/backend/lite/lite_test.go
@@ -145,5 +145,4 @@ func (s *LiteSuite) TestImport(c *check.C) {
 	imported, err = b.Imported(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(imported, check.Equals, true)
-
 }

--- a/lib/backend/lite/litemem_test.go
+++ b/lib/backend/lite/litemem_test.go
@@ -106,3 +106,13 @@ func (s *LiteMemSuite) TestConcurrentOperations(c *check.C) {
 	s.suite.B2 = bk
 	s.suite.ConcurrentOperations(c)
 }
+
+func (s *LiteMemSuite) TestMirror(c *check.C) {
+	mem, err := NewWithConfig(context.Background(), Config{
+		Memory:           true,
+		Mirror:           true,
+		PollStreamPeriod: 300 * time.Millisecond,
+	})
+	c.Assert(err, check.IsNil)
+	s.suite.Mirror(c, mem)
+}

--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -64,6 +64,12 @@ func (l *LiteBackend) runPeriodicOperations() {
 }
 
 func (l *LiteBackend) removeExpiredKeys() error {
+	// In mirror mode, don't expire any elements. This allows the cache to setup
+	// a watch and expire elements as the events roll in.
+	if l.Mirror {
+		return nil
+	}
+
 	now := l.clock.Now().UTC()
 	return l.inTransaction(l.ctx, func(tx *sql.Tx) error {
 		q, err := tx.PrepareContext(l.ctx,

--- a/lib/backend/memory/memory_test.go
+++ b/lib/backend/memory/memory_test.go
@@ -108,3 +108,11 @@ func (s *MemorySuite) TestConcurrentOperations(c *check.C) {
 	s.suite.B2 = bk
 	s.suite.ConcurrentOperations(c)
 }
+
+func (s *MemorySuite) TestMirror(c *check.C) {
+	mem, err := New(Config{
+		Mirror: true,
+	})
+	c.Assert(err, check.IsNil)
+	s.suite.Mirror(c, mem)
+}

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -227,10 +227,9 @@ func (m *AgentPool) tryDiscover(req discoveryRequest) {
 		}
 		if filtered.Equal(agent.DiscoverProxies) {
 			foundAgent = true
-			agent.Debugf("agent is already discovering the same proxies as requested in %v", filtered)
+			agent.Debugf("Agent is already discovering the same proxies as requested in %v.", filtered)
 			return false
 		}
-		agent.Debugf("is obsolete, going to close", agent.getState(), agent.DiscoverProxies)
 		return true
 	})
 

--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -232,6 +232,16 @@ func (c *remoteConn) sendDiscoveryRequest(req discoveryRequest) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	// Log the discovery request being sent. Useful for debugging to know what
+	// proxies the tunnel server thinks exist.
+	names := make([]string, 0, len(req.Proxies))
+	for _, proxy := range req.Proxies {
+		names = append(names, proxy.GetName())
+	}
+	c.log.Debugf("Sending %v discovery request with proxies %q to %v.",
+		req.Type, names, c.sconn.RemoteAddr())
+
 	_, err = discoveryCh.SendRequest(chanDiscoveryReq, false, payload)
 	if err != nil {
 		c.markInvalid(err)

--- a/lib/services/proxywatcher.go
+++ b/lib/services/proxywatcher.go
@@ -136,6 +136,15 @@ func (p *ProxyWatcher) GetCurrent() []Server {
 func (p *ProxyWatcher) setCurrent(proxies []Server) {
 	p.Lock()
 	defer p.Unlock()
+
+	// Log the updated list of proxies. Useful for debugging to verify proxies
+	// are being added and removed from the cluster.
+	names := make([]string, 0, len(proxies))
+	for _, proxy := range proxies {
+		names = append(names, proxy.GetName())
+	}
+	p.Debugf("List of known proxies updated: %q.", names)
+
 	p.current = proxies
 }
 

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -276,7 +276,7 @@ func (h *AuthHandlers) hostKeyCallback(hostname string, remote net.Addr, key ssh
 
 	// If strict host key checking is not enabled, log that Teleport trusted an
 	// insecure key, but allow the request to go through.
-	h.Warn("Insecure configuration! Strict host key checking disabled, allowing login without checking host key of type %v.", key.Type())
+	h.Warnf("Insecure configuration! Strict host key checking disabled, allowing login without checking host key of type %v.", key.Type())
 	return nil
 }
 


### PR DESCRIPTION
**Description**

Update mirror mode (for both the memory and SQLite backends) to no longer emit events when an element expires. This allows caches to handle update/delete logic themselves.

This fixes an issue where services.ProxyWatcher was not getting updates to the list of proxies.