### PR TITLE
Update Teleport docs location for etc/teleport.yaml

### DIFF
--- a/docs/1.3/admin-guide.md
+++ b/docs/1.3/admin-guide.md
@@ -373,7 +373,7 @@ There are two ways to create invitation tokens:
 You can pick your own tokens and add them to the auth server's config file: 
 
 ```bash
-# Config section in `/etc/teleport/teleport.yaml` file for the auth server
+# Config section in `/etc/teleport.yaml` file for the auth server
 auth_service:
     enabled: true
     #

--- a/docs/2.0/admin-guide.md
+++ b/docs/2.0/admin-guide.md
@@ -526,7 +526,7 @@ There are two ways to create invitation tokens:
 You can pick your own tokens and add them to the auth server's config file: 
 
 ```bash
-# Config section in `/etc/teleport/teleport.yaml` file for the auth server
+# Config section in `/etc/teleport.yaml` file for the auth server
 auth_service:
     enabled: true
     #

--- a/docs/2.3/admin-guide.md
+++ b/docs/2.3/admin-guide.md
@@ -552,7 +552,7 @@ There are two ways to create invitation tokens:
 You can pick your own tokens and add them to the auth server's config file:
 
 ```bash
-# Config section in `/etc/teleport/teleport.yaml` file for the auth server
+# Config section in `/etc/teleport.yaml` file for the auth server
 auth_service:
     enabled: true
     #

--- a/docs/2.4/admin-guide.md
+++ b/docs/2.4/admin-guide.md
@@ -586,7 +586,7 @@ There are two ways to create invitation tokens:
 You can pick your own tokens and add them to the auth server's config file:
 
 ```bash
-# Config section in `/etc/teleport/teleport.yaml` file for the auth server
+# Config section in `/etc/teleport.yaml` file for the auth server
 auth_service:
     enabled: true
     #

--- a/docs/2.5/admin-guide.md
+++ b/docs/2.5/admin-guide.md
@@ -631,7 +631,7 @@ Static tokens are defined ahead of time by an administrator and stored
 in the auth server's config file:
 
 ```bash
-# Config section in `/etc/teleport/teleport.yaml` file for the auth server
+# Config section in `/etc/teleport.yaml` file for the auth server
 auth_service:
     enabled: true
     tokens:

--- a/docs/2.7/admin-guide.md
+++ b/docs/2.7/admin-guide.md
@@ -652,7 +652,7 @@ Static tokens are defined ahead of time by an administrator and stored
 in the auth server's config file:
 
 ```bash
-# Config section in `/etc/teleport/teleport.yaml` file for the auth server
+# Config section in `/etc/teleport.yaml` file for the auth server
 auth_service:
     enabled: true
     tokens:

--- a/docs/3.0/admin-guide.md
+++ b/docs/3.0/admin-guide.md
@@ -699,7 +699,7 @@ Static tokens are defined ahead of time by an administrator and stored
 in the auth server's config file:
 
 ```yaml
-# Config section in `/etc/teleport/teleport.yaml` file for the auth server
+# Config section in `/etc/teleport.yaml` file for the auth server
 auth_service:
     enabled: true
     tokens:

--- a/docs/3.1/admin-guide.md
+++ b/docs/3.1/admin-guide.md
@@ -745,7 +745,7 @@ Static tokens are defined ahead of time by an administrator and stored
 in the auth server's config file:
 
 ```yaml
-# Config section in `/etc/teleport/teleport.yaml` file for the auth server
+# Config section in `/etc/teleport.yaml` file for the auth server
 auth_service:
     enabled: true
     tokens:

--- a/docs/3.2/admin-guide.md
+++ b/docs/3.2/admin-guide.md
@@ -745,7 +745,7 @@ Static tokens are defined ahead of time by an administrator and stored
 in the auth server's config file:
 
 ```yaml
-# Config section in `/etc/teleport/teleport.yaml` file for the auth server
+# Config section in `/etc/teleport.yaml` file for the auth server
 auth_service:
     enabled: true
     tokens:


### PR DESCRIPTION
This PR corrects the Admin guide default config location to be `/etc/teleport.yaml` vs `/etc/teleport/teleport.yaml`  as  `/etc/teleport.yaml` is the default location for the config file. 