### PR TITLE
Configurable timeout for tunnel offline threshold.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -66,7 +66,8 @@ import (
 // SetTestTimeouts affects global timeouts inside Teleport, making connections
 // work faster but consuming more CPU (useful for integration testing)
 func SetTestTimeouts(t time.Duration) {
-	defaults.ReverseTunnelAgentHeartbeatPeriod = t
+	defaults.KeepAliveInterval = t
+	defaults.ResyncInterval = t
 	defaults.ServerKeepAliveTTL = t
 	defaults.SessionRefreshPeriod = t
 	defaults.HeartbeatCheckPeriod = t

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -133,10 +133,10 @@ func DecodeClusterName(serverName string) (string, error) {
 }
 
 // NewAddrDialer returns new dialer from a list of addresses
-func NewAddrDialer(addrs []utils.NetAddr) ContextDialer {
+func NewAddrDialer(addrs []utils.NetAddr, keepAliveInterval time.Duration) ContextDialer {
 	dialer := net.Dialer{
 		Timeout:   defaults.DefaultDialTimeout,
-		KeepAlive: defaults.ReverseTunnelAgentHeartbeatPeriod,
+		KeepAlive: keepAliveInterval,
 	}
 	return ContextDialerFunc(func(in context.Context, network, _ string) (net.Conn, error) {
 		var err error
@@ -198,7 +198,7 @@ func (c *ClientConfig) CheckAndSetDefaults() error {
 		c.KeepAliveCount = defaults.KeepAliveCountMax
 	}
 	if c.Dialer == nil {
-		c.Dialer = NewAddrDialer(c.Addrs)
+		c.Dialer = NewAddrDialer(c.Addrs, c.KeepAlivePeriod)
 	}
 	if c.TLS.ServerName == "" {
 		c.TLS.ServerName = teleport.APIDomain

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -233,12 +233,8 @@ const (
 )
 
 var (
-	// ReverseTunnelAgentHeartbeatPeriod is the period between agent heartbeat messages
-	ReverseTunnelAgentHeartbeatPeriod = 5 * time.Second
-
-	// ReverseTunnelOfflineThreshold is the threshold of missed heartbeats
-	// after which we are going to declare the reverse tunnel offline
-	ReverseTunnelOfflineThreshold = 5 * ReverseTunnelAgentHeartbeatPeriod
+	// ResyncInterval is how often tunnels are resynced.
+	ResyncInterval = 5 * time.Second
 
 	// ServerAnnounceTTL is a period between heartbeats
 	// Median sleep time between node pings is this value / 2 + random

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -161,7 +161,7 @@ func (m *AgentPool) Wait() error {
 }
 
 func (m *AgentPool) processDiscoveryRequests() {
-	ticker := time.NewTicker(defaults.ReverseTunnelAgentHeartbeatPeriod)
+	ticker := time.NewTicker(defaults.ResyncInterval)
 	defer ticker.Stop()
 
 	for {
@@ -298,7 +298,7 @@ func (m *AgentPool) closeAgents(matchKey *agentKey) {
 }
 
 func (m *AgentPool) pollAndSyncAgents() {
-	ticker := time.NewTicker(defaults.ReverseTunnelAgentHeartbeatPeriod)
+	ticker := time.NewTicker(defaults.ResyncInterval)
 	defer ticker.Stop()
 	m.FetchAndSyncAgents()
 	for {

--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -95,6 +95,10 @@ type connConfig struct {
 	// nodeID is used when tunnelType is node and is set
 	// to the node UUID dialing back
 	nodeID string
+
+	// offlineThreshold is how long to wait for a keep alive message before
+	// marking a reverse tunnel connection as invalid.
+	offlineThreshold time.Duration
 }
 
 func newRemoteConn(cfg *connConfig) *remoteConn {
@@ -252,5 +256,6 @@ func (c *remoteConn) sendDiscoveryRequest(req discoveryRequest) error {
 }
 
 func (c *remoteConn) isOnline(conn services.TunnelConnection) bool {
-	return services.TunnelConnectionStatus(c.clock, conn) == teleport.RemoteClusterStatusOnline
+	tunnelStatus := services.TunnelConnectionStatus(c.clock, conn, c.offlineThreshold)
+	return tunnelStatus == teleport.RemoteClusterStatusOnline
 }

--- a/lib/services/tunnelconn.go
+++ b/lib/services/tunnelconn.go
@@ -75,9 +75,9 @@ func LatestTunnelConnection(conns []TunnelConnection) (TunnelConnection, error) 
 
 // TunnelConnectionStatus returns tunnel connection status based on the last
 // heartbeat time recorded for a connection
-func TunnelConnectionStatus(clock clockwork.Clock, conn TunnelConnection) string {
+func TunnelConnectionStatus(clock clockwork.Clock, conn TunnelConnection, offlineThreshold time.Duration) string {
 	diff := clock.Now().Sub(conn.GetLastHeartbeat())
-	if diff < defaults.ReverseTunnelOfflineThreshold {
+	if diff < offlineThreshold {
 		return teleport.RemoteClusterStatusOnline
 	}
 	return teleport.RemoteClusterStatusOffline


### PR DESCRIPTION
**Description**

Added support for a configurable offline threshold based off the keep alive interval and max count for marking a connection from an agent as offline.