### PR TITLE
Signup URL should use proxy public address.

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -624,6 +624,7 @@ func (s *Server) getServerInfo() (services.Server, error) {
 		}
 	}
 	server.SetTTL(s.clock, defaults.ServerAnnounceTTL)
+	server.SetPublicAddr(s.proxyPublicAddr.String())
 	return server, nil
 }
 


### PR DESCRIPTION
**Description**

Set the public address of the proxy in the services.Server resource upon registration. This resource is queries for the public address when generating a signup URL.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2686