### PR TITLE
Add instructions for use of HTTP_PROXY with systemd to docs

### DIFF
--- a/docs/2.0/admin-guide.md
+++ b/docs/2.0/admin-guide.md
@@ -974,6 +974,18 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 `scheme://host:port` where scheme is either `https` or `http`. If the
 value is `host:port`, Teleport will prepend `http`.
 
+It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
+probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks:
+
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy.example.com:8080/"
+Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
+Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+```
+
 !!! tip "Note":
     `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
     some reason your proxy runs locally, you'll need to provide some other DNS

--- a/docs/2.0/admin-guide.md
+++ b/docs/2.0/admin-guide.md
@@ -975,9 +975,9 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 value is `host:port`, Teleport will prepend `http`.
 
 It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
-environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
-probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
-variable to avoid use of the proxy when accessing specified hosts/netmasks:
+environment variables must be set within Teleport's environment. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks. When launching Teleport with systemd, this
+will probably involve adding some lines to your systemd unit file:
 
 ```
 [Service]

--- a/docs/2.3/admin-guide.md
+++ b/docs/2.3/admin-guide.md
@@ -991,6 +991,18 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 `scheme://host:port` where scheme is either `https` or `http`. If the
 value is `host:port`, Teleport will prepend `http`.
 
+It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
+probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks:
+
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy.example.com:8080/"
+Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
+Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+```
+
 !!! tip "Note":
     `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
     some reason your proxy runs locally, you'll need to provide some other DNS

--- a/docs/2.3/admin-guide.md
+++ b/docs/2.3/admin-guide.md
@@ -992,9 +992,9 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 value is `host:port`, Teleport will prepend `http`.
 
 It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
-environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
-probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
-variable to avoid use of the proxy when accessing specified hosts/netmasks:
+environment variables must be set within Teleport's environment. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks. When launching Teleport with systemd, this
+will probably involve adding some lines to your systemd unit file:
 
 ```
 [Service]

--- a/docs/2.4/admin-guide.md
+++ b/docs/2.4/admin-guide.md
@@ -1190,6 +1190,18 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 `scheme://host:port` where scheme is either `https` or `http`. If the
 value is `host:port`, Teleport will prepend `http`.
 
+It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
+probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks:
+
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy.example.com:8080/"
+Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
+Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+```
+
 !!! tip "Note":
     `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
     some reason your proxy runs locally, you'll need to provide some other DNS

--- a/docs/2.4/admin-guide.md
+++ b/docs/2.4/admin-guide.md
@@ -1191,9 +1191,9 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 value is `host:port`, Teleport will prepend `http`.
 
 It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
-environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
-probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
-variable to avoid use of the proxy when accessing specified hosts/netmasks:
+environment variables must be set within Teleport's environment. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks. When launching Teleport with systemd, this
+will probably involve adding some lines to your systemd unit file:
 
 ```
 [Service]

--- a/docs/2.5/admin-guide.md
+++ b/docs/2.5/admin-guide.md
@@ -1339,6 +1339,18 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 `scheme://host:port` where scheme is either `https` or `http`. If the
 value is `host:port`, Teleport will prepend `http`.
 
+It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
+probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks:
+
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy.example.com:8080/"
+Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
+Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+```
+
 !!! tip "Note":
     `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
     some reason your proxy runs locally, you'll need to provide some other DNS

--- a/docs/2.5/admin-guide.md
+++ b/docs/2.5/admin-guide.md
@@ -1340,9 +1340,9 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 value is `host:port`, Teleport will prepend `http`.
 
 It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
-environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
-probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
-variable to avoid use of the proxy when accessing specified hosts/netmasks:
+environment variables must be set within Teleport's environment. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks. When launching Teleport with systemd, this
+will probably involve adding some lines to your systemd unit file:
 
 ```
 [Service]

--- a/docs/2.7/admin-guide.md
+++ b/docs/2.7/admin-guide.md
@@ -1367,6 +1367,18 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 `scheme://host:port` where scheme is either `https` or `http`. If the
 value is `host:port`, Teleport will prepend `http`.
 
+It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
+probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks:
+
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy.example.com:8080/"
+Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
+Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+```
+
 !!! tip "Note":
     `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
     some reason your proxy runs locally, you'll need to provide some other DNS

--- a/docs/2.7/admin-guide.md
+++ b/docs/2.7/admin-guide.md
@@ -1368,9 +1368,9 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 value is `host:port`, Teleport will prepend `http`.
 
 It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
-environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
-probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
-variable to avoid use of the proxy when accessing specified hosts/netmasks:
+environment variables must be set within Teleport's environment. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks. When launching Teleport with systemd, this
+will probably involve adding some lines to your systemd unit file:
 
 ```
 [Service]

--- a/docs/3.0/admin-guide.md
+++ b/docs/3.0/admin-guide.md
@@ -1479,6 +1479,18 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 `scheme://host:port` where scheme is either `https` or `http`. If the
 value is `host:port`, Teleport will prepend `http`.
 
+It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
+probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks:
+
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy.example.com:8080/"
+Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
+Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+```
+
 !!! tip "Note":
     `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
     some reason your proxy runs locally, you'll need to provide some other DNS

--- a/docs/3.0/admin-guide.md
+++ b/docs/3.0/admin-guide.md
@@ -1480,9 +1480,9 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 value is `host:port`, Teleport will prepend `http`.
 
 It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
-environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
-probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
-variable to avoid use of the proxy when accessing specified hosts/netmasks:
+environment variables must be set within Teleport's environment. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks. When launching Teleport with systemd, this
+will probably involve adding some lines to your systemd unit file:
 
 ```
 [Service]

--- a/docs/3.1/admin-guide.md
+++ b/docs/3.1/admin-guide.md
@@ -1600,6 +1600,18 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 `scheme://host:port` where scheme is either `https` or `http`. If the
 value is `host:port`, Teleport will prepend `http`.
 
+It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
+probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks:
+
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy.example.com:8080/"
+Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
+Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+```
+
 !!! tip "Note":
     `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
     some reason your proxy runs locally, you'll need to provide some other DNS

--- a/docs/3.1/admin-guide.md
+++ b/docs/3.1/admin-guide.md
@@ -1601,9 +1601,9 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 value is `host:port`, Teleport will prepend `http`.
 
 It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
-environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
-probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
-variable to avoid use of the proxy when accessing specified hosts/netmasks:
+environment variables must be set within Teleport's environment. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks. When launching Teleport with systemd, this
+will probably involve adding some lines to your systemd unit file:
 
 ```
 [Service]

--- a/docs/3.2/admin-guide.md
+++ b/docs/3.2/admin-guide.md
@@ -1586,6 +1586,18 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 `scheme://host:port` where scheme is either `https` or `http`. If the
 value is `host:port`, Teleport will prepend `http`.
 
+It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
+probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks:
+
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy.example.com:8080/"
+Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
+Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+```
+
 !!! tip "Note":
     `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
     some reason your proxy runs locally, you'll need to provide some other DNS

--- a/docs/3.2/admin-guide.md
+++ b/docs/3.2/admin-guide.md
@@ -1587,9 +1587,9 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 value is `host:port`, Teleport will prepend `http`.
 
 It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
-environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
-probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
-variable to avoid use of the proxy when accessing specified hosts/netmasks:
+environment variables must be set within Teleport's environment. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks. When launching Teleport with systemd, this
+will probably involve adding some lines to your systemd unit file:
 
 ```
 [Service]

--- a/docs/4.0/admin-guide.md
+++ b/docs/4.0/admin-guide.md
@@ -1587,6 +1587,18 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 `scheme://host:port` where scheme is either `https` or `http`. If the
 value is `host:port`, Teleport will prepend `http`.
 
+It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
+environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
+probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks:
+
+```
+[Service]
+Environment="HTTP_PROXY=http://proxy.example.com:8080/"
+Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
+Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
+```
+
 !!! tip "Note":
     `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
     some reason your proxy runs locally, you'll need to provide some other DNS

--- a/docs/4.0/admin-guide.md
+++ b/docs/4.0/admin-guide.md
@@ -1588,9 +1588,9 @@ The value of `HTTPS_PROXY` or `HTTP_PROXY` should be in the format
 value is `host:port`, Teleport will prepend `http`.
 
 It's important to note that in order for Teleport to use HTTP CONNECT tunnelling, the `HTTP_PROXY` and `HTTPS_PROXY`
-environment variables must be set within Teleport's environment. When launching Teleport with systemd, this will
-probably involve adding some lines to your systemd unit file. You can also optionally set the `NO_PROXY` environment
-variable to avoid use of the proxy when accessing specified hosts/netmasks:
+environment variables must be set within Teleport's environment. You can also optionally set the `NO_PROXY` environment
+variable to avoid use of the proxy when accessing specified hosts/netmasks. When launching Teleport with systemd, this
+will probably involve adding some lines to your systemd unit file:
 
 ```
 [Service]


### PR DESCRIPTION
Someone on the community Slack had issues with Teleport not working behind a corporate proxy - the issue turned out to be that Teleport was being launched via systemd and the `HTTP_PROXY` environment variable wasn't propagating through from `/etc/environment`. Adding an explicit example for systemd to the documentation may help in future.