### PR TITLE
Move --cluster to its correct location as a command subflag

### DIFF
--- a/docs/2.3/admin-guide.md
+++ b/docs/2.3/admin-guide.md
@@ -865,7 +865,7 @@ This setup works as follows:
    "main" must authenticate "east" (cluster-to-cluster authentication) when the
    tunnel is established, and "east" must trust users connecting from "main"
    (user authentication).
-3. Users of "main" must use `tsh --cluster=east` flag if they want to connect to any nodes in "east".
+3. Users of "main" must use `tsh` commands with the `--cluster=east` flag if they want to connect to any nodes in "east".
 4. Users of "main" can see other trusted clusters connected to "main" by running `tsh clusters`
 
 ### Example Configuration
@@ -963,7 +963,7 @@ main           online
 east           online
 
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------
@@ -971,7 +971,7 @@ db1.east  cf7cc5cd-935e-46f1 10.0.5.2:3022  role=db-master
 db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-slave
 
 # SSH into any node in "east":
-$ tsh --cluster=east ssh root@db1.east
+$ tsh ssh --cluster=east root@db1.east
 ```
 
 ## HTTP CONNECT Proxies

--- a/docs/2.3/user-manual.md
+++ b/docs/2.3/user-manual.md
@@ -384,7 +384,7 @@ Now you can use `--cluster` flag with any `tsh` command. For example, to list SS
 are members of "production" cluster, simply do:
 
 ```bash
-$ tsh --proxy=work --cluster=production ls
+$ tsh --proxy=work ls --cluster=production
 Node Name     Node ID       Address            Labels
 ---------     -------       -------            ------
 db-1          xxxxxxxxx     10.0.20.31:3022    kernel:4.4
@@ -394,7 +394,7 @@ db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 Similarly, if you want to SSH into `db-1` inside "production" cluster:
 
 ```bash
-$ tsh --proxy=work --cluster=production ssh db-1
+$ tsh --proxy=work ssh --cluster=production db-1
 ```
 
 This is possible even if nodes of the "production" cluster are located behind a firewall

--- a/docs/2.4/admin-guide.md
+++ b/docs/2.4/admin-guide.md
@@ -1006,7 +1006,7 @@ This setup works as follows:
    "main" must authenticate "east" (cluster-to-cluster authentication) when the
    tunnel is established, and "east" must trust users connecting from "main"
    (user authentication).
-3. Users of "main" must use `tsh --cluster=east` flag if they want to connect to any nodes in "east".
+3. Users of "main" must use `tsh` commands with the `--cluster=east` flag if they want to connect to any nodes in "east".
 4. Users of "main" can see other trusted clusters connected to "main" by running `tsh clusters`
 
 ### Example Configuration
@@ -1098,7 +1098,7 @@ main           online
 east           online
 
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------
@@ -1106,7 +1106,7 @@ db1.east  cf7cc5cd-935e-46f1 10.0.5.2:3022  role=db-master
 db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-slave
 
 # SSH into any node in "east":
-$ tsh --cluster=east ssh root@db1.east
+$ tsh ssh --cluster=east root@db1.east
 ```
 
 ## Github OAuth 2.0

--- a/docs/2.4/user-manual.md
+++ b/docs/2.4/user-manual.md
@@ -384,7 +384,7 @@ Now you can use `--cluster` flag with any `tsh` command. For example, to list SS
 are members of "production" cluster, simply do:
 
 ```bash
-$ tsh --proxy=work --cluster=production ls
+$ tsh --proxy=work ls --cluster=production
 Node Name     Node ID       Address            Labels
 ---------     -------       -------            ------
 db-1          xxxxxxxxx     10.0.20.31:3022    kernel:4.4
@@ -394,7 +394,7 @@ db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 Similarly, if you want to SSH into `db-1` inside "production" cluster:
 
 ```bash
-$ tsh --proxy=work --cluster=production ssh db-1
+$ tsh --proxy=work ssh --cluster=production db-1
 ```
 
 This is possible even if nodes of the "production" cluster are located behind a firewall

--- a/docs/2.5/admin-guide.md
+++ b/docs/2.5/admin-guide.md
@@ -1099,7 +1099,7 @@ $ tsh ssh host
 
 # SSH into the host located in another cluster called "east"
 # The connection is established through main.example.com:
-$ tsh --cluster=east ssh host
+$ tsh ssh --cluster=east host
 
 # See what other clusters are available
 $ tsh clusters
@@ -1227,7 +1227,7 @@ main           online
 east           online
 
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------
@@ -1235,7 +1235,7 @@ db1.east  cf7cc5cd-935e-46f1 10.0.5.2:3022  role=db-master
 db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-slave
 
 # SSH into any node in "east":
-$ tsh --cluster=east ssh root@db1.east
+$ tsh ssh --cluster=east root@db1.east
 ```
 
 ### Disabling Trust

--- a/docs/2.5/trustedclusters.md
+++ b/docs/2.5/trustedclusters.md
@@ -43,7 +43,7 @@ $ tsh ssh host
 
 # SSH into the host located in another cluster called "east"
 # The connection is established through main.example.com:
-$ tsh --cluster=east ssh host
+$ tsh ssh --cluster=east host
 
 # See what other clusters are available
 $ tsh clusters
@@ -210,7 +210,7 @@ east           online
 
 ```bash
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------
@@ -220,7 +220,7 @@ db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-slave
 
 ```bash
 # SSH into any node in "east":
-$ tsh --cluster=east ssh root@db1.east
+$ tsh ssh --cluster=east root@db1.east
 ```
 
 

--- a/docs/2.5/user-manual.md
+++ b/docs/2.5/user-manual.md
@@ -429,7 +429,7 @@ Now you can use `--cluster` flag with any `tsh` command. For example, to list SS
 are members of "production" cluster, simply do:
 
 ```bash
-$ tsh --proxy=work --cluster=production ls
+$ tsh --proxy=work ls --cluster=production
 Node Name     Node ID       Address            Labels
 ---------     -------       -------            ------
 db-1          xxxxxxxxx     10.0.20.31:3022    kernel:4.4
@@ -439,7 +439,7 @@ db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 Similarly, if you want to SSH into `db-1` inside "production" cluster:
 
 ```bash
-$ tsh --proxy=work --cluster=production ssh db-1
+$ tsh --proxy=work ssh --cluster=production db-1
 ```
 
 This is possible even if nodes of the "production" cluster are located behind a firewall

--- a/docs/2.7/admin-guide.md
+++ b/docs/2.7/admin-guide.md
@@ -1127,7 +1127,7 @@ $ tsh ssh host
 
 # SSH into the host located in another cluster called "east"
 # The connection is established through main.example.com:
-$ tsh --cluster=east ssh host
+$ tsh ssh --cluster=east host
 
 # See what other clusters are available
 $ tsh clusters
@@ -1255,7 +1255,7 @@ main           online
 east           online
 
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------

--- a/docs/2.7/trustedclusters.md
+++ b/docs/2.7/trustedclusters.md
@@ -43,7 +43,7 @@ $ tsh ssh host
 
 # SSH into the host located in another cluster called "east"
 # The connection is established through main.example.com:
-$ tsh --cluster=east ssh host
+$ tsh ssh --cluster=east host
 
 # See what other clusters are available
 $ tsh clusters
@@ -210,7 +210,7 @@ east           online
 
 ```bash
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------
@@ -220,7 +220,7 @@ db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-slave
 
 ```bash
 # SSH into any node in "east":
-$ tsh --cluster=east ssh root@db1.east
+$ tsh ssh --cluster=east root@db1.east
 ```
 
 

--- a/docs/2.7/user-manual.md
+++ b/docs/2.7/user-manual.md
@@ -429,7 +429,7 @@ Now you can use `--cluster` flag with any `tsh` command. For example, to list SS
 are members of "production" cluster, simply do:
 
 ```bash
-$ tsh --proxy=work --cluster=production ls
+$ tsh --proxy=work ls --cluster=production
 Node Name     Node ID       Address            Labels
 ---------     -------       -------            ------
 db-1          xxxxxxxxx     10.0.20.31:3022    kernel:4.4
@@ -439,7 +439,7 @@ db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 Similarly, if you want to SSH into `db-1` inside "production" cluster:
 
 ```bash
-$ tsh --proxy=work --cluster=production ssh db-1
+$ tsh --proxy=work ssh --cluster=production db-1
 ```
 
 This is possible even if nodes of the "production" cluster are located behind a firewall

--- a/docs/3.0/admin-guide.md
+++ b/docs/3.0/admin-guide.md
@@ -1203,7 +1203,7 @@ $ tsh ssh host
 
 # SSH into the host located in another cluster called "east"
 # The connection is established through main.example.com:
-$ tsh --cluster=east ssh host
+$ tsh ssh --cluster=east host
 
 # See what other clusters are available
 $ tsh clusters
@@ -1342,7 +1342,7 @@ main           online
 east           online
 
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------
@@ -1350,7 +1350,7 @@ db1.east  cf7cc5cd-935e-46f1 10.0.5.2:3022  role=db-master
 db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-slave
 
 # SSH into any node in "east":
-$ tsh --cluster=east ssh root@db1.east
+$ tsh ssh --cluster=east root@db1.east
 ```
 
 ### Disabling Trust

--- a/docs/3.0/user-manual.md
+++ b/docs/3.0/user-manual.md
@@ -424,7 +424,7 @@ Now you can use `--cluster` flag with any `tsh` command. For example, to list SS
 are members of the "production" cluster, simply do:
 
 ```bash
-$ tsh --proxy=work --cluster=production ls
+$ tsh --proxy=work ls --cluster=production
 Node Name     Node ID       Address            Labels
 ---------     -------       -------            ------
 db-1          xxxxxxxxx     10.0.20.31:3022    kernel:4.4
@@ -434,7 +434,7 @@ db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 Similarly, if you want to SSH into `db-1` inside the "production" cluster:
 
 ```bash
-$ tsh --proxy=work --cluster=production ssh db-1
+$ tsh --proxy=work ssh --cluster=production db-1
 ```
 
 This is possible even if nodes of the "production" cluster are located behind a firewall

--- a/docs/3.1/admin-guide.md
+++ b/docs/3.1/admin-guide.md
@@ -1324,7 +1324,7 @@ $ tsh ssh host
 
 # SSH into the host located in another cluster called "east"
 # The connection is established through main.example.com:
-$ tsh --cluster=east ssh host
+$ tsh ssh --cluster=east host
 
 # See what other clusters are available
 $ tsh clusters
@@ -1463,7 +1463,7 @@ main           online
 east           online
 
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------
@@ -1471,7 +1471,7 @@ db1.east  cf7cc5cd-935e-46f1 10.0.5.2:3022  role=db-master
 db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-slave
 
 # SSH into any node in "east":
-$ tsh --cluster=east ssh root@db1.east
+$ tsh ssh --cluster=east root@db1.east
 ```
 
 ### Disabling Trust

--- a/docs/3.1/user-manual.md
+++ b/docs/3.1/user-manual.md
@@ -470,7 +470,7 @@ Now you can use `--cluster` flag with any `tsh` command. For example, to list SS
 are members of the "production" cluster, simply do:
 
 ```bash
-$ tsh --proxy=work --cluster=production ls
+$ tsh --proxy=work ls --cluster=production
 Node Name     Node ID       Address            Labels
 ---------     -------       -------            ------
 db-1          xxxxxxxxx     10.0.20.31:3022    kernel:4.4
@@ -480,7 +480,7 @@ db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 Similarly, if you want to SSH into `db-1` inside the "production" cluster:
 
 ```bash
-$ tsh --proxy=work --cluster=production ssh db-1
+$ tsh --proxy=work ssh --cluster=production db-1
 ```
 
 This is possible even if nodes of the "production" cluster are located behind a firewall

--- a/docs/3.2/admin-guide.md
+++ b/docs/3.2/admin-guide.md
@@ -1449,7 +1449,7 @@ main           online
 east           online
 
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------
@@ -1457,7 +1457,7 @@ db1.east  cf7cc5cd-935e-46f1 10.0.5.2:3022  role=db-master
 db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-slave
 
 # SSH into any node in "east":
-$ tsh --cluster=east ssh root@db1.east
+$ tsh ssh --cluster=east root@db1.east
 ```
 
 ### Disabling Trust

--- a/docs/3.2/user-manual.md
+++ b/docs/3.2/user-manual.md
@@ -470,7 +470,7 @@ Now you can use `--cluster` flag with any `tsh` command. For example, to list SS
 are members of the "production" cluster, simply do:
 
 ```bash
-$ tsh --proxy=work --cluster=production ls
+$ tsh --proxy=work ls --cluster=production
 Node Name     Node ID       Address            Labels
 ---------     -------       -------            ------
 db-1          xxxxxxxxx     10.0.20.31:3022    kernel:4.4
@@ -480,7 +480,7 @@ db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 Similarly, if you want to SSH into `db-1` inside the "production" cluster:
 
 ```bash
-$ tsh --proxy=work --cluster=production ssh db-1
+$ tsh --proxy=work ssh --cluster=production db-1
 ```
 
 This is possible even if nodes of the "production" cluster are located behind a firewall

--- a/docs/4.0/admin-guide.md
+++ b/docs/4.0/admin-guide.md
@@ -1311,7 +1311,7 @@ $ tsh ssh host
 
 # SSH into the host located in another cluster called "east"
 # The connection is established through main.example.com:
-$ tsh --cluster=east ssh host
+$ tsh ssh --cluster=east host
 
 # See what other clusters are available
 $ tsh clusters
@@ -1450,7 +1450,7 @@ main           online
 east           online
 
 # see the list of machines (nodes) behind the eastern cluster:
-$ tsh --cluster=east ls
+$ tsh ls --cluster=east
 
 Node Name Node ID            Address        Labels
 --------- ------------------ -------------- -----------
@@ -1458,7 +1458,7 @@ db1.east  cf7cc5cd-935e-46f1 10.0.5.2:3022  role=db-master
 db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-slave
 
 # SSH into any node in "east":
-$ tsh --cluster=east ssh root@db1.east
+$ tsh ssh --cluster=east root@db1.east
 ```
 
 ### Disabling Trust

--- a/docs/4.0/user-manual.md
+++ b/docs/4.0/user-manual.md
@@ -470,7 +470,7 @@ Now you can use `--cluster` flag with any `tsh` command. For example, to list SS
 are members of the "production" cluster, simply do:
 
 ```bash
-$ tsh --proxy=work --cluster=production ls
+$ tsh --proxy=work ls --cluster=production
 Node Name     Node ID       Address            Labels
 ---------     -------       -------            ------
 db-1          xxxxxxxxx     10.0.20.31:3022    kernel:4.4
@@ -480,7 +480,7 @@ db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 Similarly, if you want to SSH into `db-1` inside the "production" cluster:
 
 ```bash
-$ tsh --proxy=work --cluster=production ssh db-1
+$ tsh --proxy=work ssh --cluster=production db-1
 ```
 
 This is possible even if nodes of the "production" cluster are located behind a firewall

--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -165,7 +165,7 @@ tsh --proxy=proxy.example.com --user=<username> --insecure ssh -p 22 node.exampl
 tsh --proxy=proxy.example.com --user=<username> --insecure ssh -A -p 22 node.example.com
 
 # the --cluster flag is used to connect to a node in a remote cluster.
-tsh --proxy=proxy.example.com --user=<username> --insecure --cluster=foo.com ssh -p 22 node.foo.com
+tsh --proxy=proxy.example.com --user=<username> --insecure ssh --cluster=foo.com -p 22 node.foo.com
 ```
 
 ## Web UI


### PR DESCRIPTION
Came across this one on the community forums today. I coincidentally also got notified by a potential customer that this part of the docs was wrong.