### PR TITLE
 Fix transport request marshaling for old clusters.

### DIFF
--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -44,10 +44,14 @@ type DialParams struct {
 	// validates the host certificate.
 	Address string
 
-	// SearchNames is a list of names a server may be known as. Used to search
-	// in the list of nodes that have self registered themselves with the proxy
-	// as nodes that should be connected to over a tunnel.
-	SearchNames []string
+	// Principals are additonal principals that need to be added to the host
+	// certificate. Used by the recording proxy to correctly generate a host
+	// certificate.
+	Principals []string
+
+	// ServerID the hostUUID.clusterName of a Teleport node. Used with nodes
+	// that are connected over a reverse tunnel.
+	ServerID string
 }
 
 // RemoteSite represents remote teleport site that can be accessed via

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -513,8 +513,8 @@ func (s *remoteSite) DialTCP(params DialParams) (net.Conn, error) {
 	s.Debugf("Dialing from %v to %v.", params.From, params.To)
 
 	conn, err := s.connThroughTunnel(&dialReq{
-		Address:     params.To.String(),
-		SearchNames: params.SearchNames,
+		Address:  params.To.String(),
+		ServerID: params.ServerID,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -527,14 +527,14 @@ func (s *remoteSite) dialWithAgent(params DialParams) (net.Conn, error) {
 	s.Debugf("Dialing with an agent from %v to %v.", params.From, params.To)
 
 	// Get a host certificate for the forwarding node from the cache.
-	hostCertificate, err := s.certificateCache.GetHostCertificate(params.Address, params.SearchNames)
+	hostCertificate, err := s.certificateCache.GetHostCertificate(params.Address, params.Principals)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	targetConn, err := s.connThroughTunnel(&dialReq{
-		Address:     params.To.String(),
-		SearchNames: params.SearchNames,
+		Address:  params.To.String(),
+		ServerID: params.ServerID,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -577,8 +577,8 @@ func (s *remoteSite) dialWithAgent(params DialParams) (net.Conn, error) {
 func (s *remoteSite) connThroughTunnel(req *dialReq) (net.Conn, error) {
 	var err error
 
-	s.Debugf("Requesting connection to %v %v in remote cluster %v.",
-		req.Address, req.SearchNames, s.domainName)
+	s.Debugf("Requesting connection to %v [%v] in remote cluster.",
+		req.Address, req.ServerID)
 
 	// Loop through existing remote connections and try and establish a
 	// connection over the "reverse tunnel".
@@ -610,8 +610,8 @@ func (s *remoteSite) chanTransportConn(req *dialReq) (net.Conn, error) {
 	// not respond, times out) then be safe and send request in legacy format.
 	_, err = sendVersionRequest(rconn.sconn, s.ctx)
 	if err != nil {
-		s.Debugf("Connection to %v %v in %v using legacy format.",
-			req.Address, req.SearchNames, s.domainName)
+		s.Debugf("Connection to %v [%v] using legacy format.",
+			req.Address, req.ServerID)
 		req.Legacy = true
 	}
 

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -101,14 +101,16 @@ type dialReq struct {
 	// special non-resolvable address like @remote-auth-server.
 	Address string `json:"address,omitempty"`
 
-	// SearchNames is a list of aliases for the host. SearchNames is used when
+	// ServerID is the hostUUID.clusterName of th enode. ServerID is used when
 	// dialing through a tunnel.
-	SearchNames []string `json:"search_names,omitempty"`
+	ServerID string `json:"server_id,omitempty"`
 
 	// Exclusive indicates if the connection should be closed or only the
 	// channel upon calling close on the net.Conn.
 	Exclusive bool `json:"exclusive"`
 
+	// DELETE IN: 4.1.0
+	// Legacy indicates this request will be marshaled in the old format.
 	Legacy bool `json:"legacy"`
 }
 
@@ -173,7 +175,7 @@ func connectProxyTransport(sconn ssh.Conn, req *dialReq) (net.Conn, bool, error)
 		// passed to us via stderr.
 		errMessage, _ := ioutil.ReadAll(channel.Stderr())
 		if errMessage == nil {
-			errMessage = []byte(fmt.Sprintf("failed connecting to %v %v", req.Address, req.SearchNames))
+			errMessage = []byte(fmt.Sprintf("failed connecting to %v [%v]", req.Address, req.ServerID))
 		}
 		return nil, false, trace.Errorf(strings.TrimSpace(string(errMessage)))
 	}
@@ -213,7 +215,7 @@ func proxyTransport(p *transportParams) {
 	var servers []string
 
 	dreq := parseDialReq(req.Payload)
-	p.log.Debugf("Received out-of-band proxy transport request for %v %v.", dreq.Address, dreq.SearchNames)
+	p.log.Debugf("Received out-of-band proxy transport request for %v [%v].", dreq.Address, dreq.ServerID)
 
 	// Handle special non-resolvable addresses first.
 	switch dreq.Address {
@@ -273,7 +275,7 @@ func proxyTransport(p *transportParams) {
 	// Get a connection to the target address. If a tunnel exists with matching
 	// search names, connection over the tunnel is returned. Otherwise a direct
 	// net.Dial is performed.
-	conn, err := getConn(p, servers, dreq.SearchNames)
+	conn, err := getConn(p, servers, dreq.ServerID)
 	if err != nil {
 		errorMessage := fmt.Sprintf("connection rejected: %v", err)
 		fmt.Fprint(p.channel.Stderr(), errorMessage)
@@ -283,7 +285,7 @@ func proxyTransport(p *transportParams) {
 
 	// Dail was successful.
 	req.Reply(true, []byte("Connected."))
-	p.log.Debugf("Successfully dialed to %v %v, start proxying.", dreq.Address, dreq.SearchNames)
+	p.log.Debugf("Successfully dialed to %v %v, start proxying.", dreq.Address, dreq.ServerID)
 
 	errorCh := make(chan error, 2)
 
@@ -317,11 +319,11 @@ func proxyTransport(p *transportParams) {
 // getConn checks if the local site holds a connection to the target host,
 // and if it does, attempts to dial through the tunnel. Otherwise directly
 // dials to host.
-func getConn(p *transportParams, servers []string, searchNames []string) (net.Conn, error) {
+func getConn(p *transportParams, servers []string, serverID string) (net.Conn, error) {
 	// This function doesn't attempt to dial if a host with one of the
 	// search names is not registered. It's a fast check.
-	p.log.Debugf("Attempting to dial through tunnel with search names %v.", searchNames)
-	conn, err := tunnelDial(p.reverseTunnelServer, p.localClusterName, searchNames)
+	p.log.Debugf("Attempting to dial through tunnel with server ID %v.", serverID)
+	conn, err := tunnelDial(p.reverseTunnelServer, p.localClusterName, serverID)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
@@ -337,13 +339,13 @@ func getConn(p *transportParams, servers []string, searchNames []string) (net.Co
 		return conn, nil
 	}
 
-	p.log.Debugf("Returning connection dialed through tunnel with search names %v.", searchNames)
+	p.log.Debugf("Returning connection dialed through tunnel with server ID %v.", serverID)
 	return conn, nil
 }
 
 // tunnelDial looks up the search names in the local site for a matching tunnel
 // connection. If a connection exists, it's used to dial through the tunnel.
-func tunnelDial(tunnelServer Server, localClusterName string, searchNames []string) (net.Conn, error) {
+func tunnelDial(tunnelServer Server, localClusterName string, serverID string) (net.Conn, error) {
 	// Extract the local site from the tunnel server. If no tunnel server
 	// exists, then exit right away this code may be running outside of a
 	// remote site.
@@ -360,7 +362,7 @@ func tunnelDial(tunnelServer Server, localClusterName string, searchNames []stri
 	}
 
 	conn, err := localCluster.dialTunnel(DialParams{
-		SearchNames: searchNames,
+		ServerID: serverID,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -284,9 +284,12 @@ func (t *proxySubsys) proxyToHost(
 		}
 	}
 
-	// Create a slice of name that will be added into the host certificate.
+	// Create a slice of principals that will be added into the host certificate.
 	// Here t.host is either an IP address or a DNS name as the user requested.
-	searchNames := []string{t.host}
+	principals := []string{t.host}
+
+	// Used to store the server ID (hostUUID.clusterName) of a Teleport node.
+	var serverID string
 
 	// Resolve the IP address to dial to because the hostname may not be
 	// DNS resolvable.
@@ -320,11 +323,12 @@ func (t *proxySubsys) proxyToHost(
 		Addr:        serverAddr,
 	}
 	conn, err := site.Dial(reversetunnel.DialParams{
-		From:        remoteAddr,
-		To:          toAddr,
-		UserAgent:   t.agent,
-		Address:     t.host,
-		SearchNames: searchNames,
+		From:       remoteAddr,
+		To:         toAddr,
+		UserAgent:  t.agent,
+		Address:    t.host,
+		ServerID:   serverID,
+		Principals: principals,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -292,15 +292,17 @@ func (t *proxySubsys) proxyToHost(
 	// DNS resolvable.
 	var serverAddr string
 	if server != nil {
-		serverAddr = server.GetAddr()
+		// Add hostUUID.clusterName to list of principals.
+		serverID = fmt.Sprintf("%v.%v", server.GetName(), t.clusterName)
+		principals = append(principals, serverID)
 
-		// Update the list of principals with the IP address the node self reported
-		// itself as as well as the hostUUID.clusterName.
+		// Add IP address node self reported to list of principals.
+		serverAddr = server.GetAddr()
 		host, _, err := net.SplitHostPort(serverAddr)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		searchNames = append(searchNames, host, fmt.Sprintf("%v.%v", server.GetName(), t.clusterName))
+		principals = append(principals, host)
 	} else {
 		if !specifiedPort {
 			t.port = strconv.Itoa(defaults.SSHServerListenPort)


### PR DESCRIPTION
**Description**

Pass version information between Trusted Clusters using global requests to allow clusters to request the version of Teleport of the remote cluster and then correctly marshal transport requests to that cluster.

When a remote cluster establishes a connection to a local cluster, only instantiate a auth cache if the remote cluster supports it. Older clusters like 3.2 do not support auth caches, because the auth cache relies on the Auth API having support for Watches.

In the proxy subsystem, pass ServerID (hostUUID.clusterName) when calling Dial on a cluster instead of passing SearchNames (list of principals).

Passing SearchNames was ununnecessary, nodes only register themselves by serverID (hostUUID.clusterName) and looking up SearchNames could lead to bugs.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2748