### PR TITLE
Don't mask etcd errors.

### DIFF
--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -646,8 +646,7 @@ func convertErr(err error) error {
 			return trace.BadParameter(err.Error())
 		}
 	}
-	// bad cluster endpoints, which are not etcd servers
-	return trace.ConnectionProblem(err, "bad cluster endpoints")
+	return trace.ConnectionProblem(err, err.Error())
 }
 
 func fromType(eventType mvccpb.Event_EventType) backend.OpType {


### PR DESCRIPTION
**Description**

Teleport sometimes masks the underlying error returned by etcd. For example, if your database is full, Teleport will fail to start with the following error message.

```
User Message: bad cluster endpoints, initialization failed
```

When the underlying error returned from etcd is:

```
etcdserver: mvcc: database space exceeded.
```

This PR propagates the error from etcd back up.