### PR TITLE
Fix kubeconfig generator script and tidy up odd mention of 'jenkins'

### DIFF
--- a/examples/gke-auth/get-kubeconfig.sh
+++ b/examples/gke-auth/get-kubeconfig.sh
@@ -49,7 +49,7 @@ cat > csr <<EOF
 {
   "hosts": [
   ],
-  "CN": "jenkins",
+  "CN": "teleport",
   "names": [{
         "O": "system:masters"
     }],
@@ -76,7 +76,7 @@ spec:
   usages:
   - digital signature
   - key encipherment
-  - server auth
+  - client auth
 EOF
 kubectl certificate approve ${REQUEST_ID}
 
@@ -100,13 +100,13 @@ clusters:
 contexts:
 - context:
     cluster: k8s
-    user: jenkins
+    user: teleport
   name: k8s
 current-context: k8s
 kind: Config
 preferences: {}
 users:
-- name: jenkins
+- name: teleport
   user:
     client-certificate-data: $(cat server.crt | base64 ${BASE64_WRAP_FLAG})
     client-key-data: $(cat server-key.pem | base64 ${BASE64_WRAP_FLAG})


### PR DESCRIPTION
The `kubeconfig` generator script that we provide for people running Teleport outside of their Kubernetes cluster doesn't work out of the box because it's requesting `server auth` and not `client auth` as it should.

This should fix an issue found by a customer.