### PR TITLE
Fix Client IP issues.

### DIFF
--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -561,7 +561,7 @@ func (s *server) handleTransport(sconn *ssh.ServerConn, nch ssh.NewChannel) {
 		return
 	}
 
-	go proxyTransport(&transportParams{
+	t := &transport{
 		log:              s.Entry,
 		closeContext:     s.ctx,
 		authClient:       s.LocalAccessPoint,
@@ -569,7 +569,8 @@ func (s *server) handleTransport(sconn *ssh.ServerConn, nch ssh.NewChannel) {
 		requestCh:        requestCh,
 		component:        teleport.ComponentReverseTunnelServer,
 		localClusterName: s.ClusterName,
-	})
+	}
+	go t.start()
 }
 
 func (s *server) handleHeartbeat(conn net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -471,7 +471,6 @@ func ApplyDefaults(cfg *Config) {
 
 	// defaults for the SSH service:
 	cfg.SSH.Enabled = true
-	cfg.SSH.Addr = *defaults.SSHServerListenAddr()
 	cfg.SSH.Shell = defaults.DefaultShell
 	defaults.ConfigureLimiter(&cfg.SSH.Limiter)
 	cfg.SSH.PAM = &pam.Config{Enabled: false}

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -49,7 +49,6 @@ func (s *ConfigSuite) TestDefaultConfig(c *check.C) {
 
 	localAuthAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "0.0.0.0:3025"}
 	localProxyAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "0.0.0.0:3023"}
-	localSSHAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "0.0.0.0:3022"}
 
 	// data dir, hostname and auth server
 	c.Assert(config.DataDir, check.Equals, defaults.DataDir)
@@ -67,7 +66,6 @@ func (s *ConfigSuite) TestDefaultConfig(c *check.C) {
 
 	// SSH section
 	ssh := config.SSH
-	c.Assert(ssh.Addr, check.DeepEquals, localSSHAddr)
 	c.Assert(ssh.Limiter.MaxConnections, check.Equals, int64(defaults.LimiterMaxConnections))
 	c.Assert(ssh.Limiter.MaxNumberOfUsers, check.Equals, defaults.LimiterMaxConcurrentUsers)
 

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -107,6 +107,10 @@ type Server interface {
 
 	// GetInfo returns a services.Server that represents this server.
 	GetInfo() services.Server
+
+	// UseTunnel used to determine if this node has connected to this cluster
+	// using reverse tunnel.
+	UseTunnel() bool
 }
 
 // IdentityContext holds all identity information associated with the user
@@ -483,9 +487,11 @@ func (c *ServerContext) reportStats(conn utils.Stater) {
 		events.SessionServerID: c.GetServer().ID(),
 		events.EventLogin:      c.Identity.Login,
 		events.EventUser:       c.Identity.TeleportUser,
-		events.LocalAddr:       c.Conn.LocalAddr().String(),
 		events.RemoteAddr:      c.Conn.RemoteAddr().String(),
 		events.EventIndex:      events.SessionDataIndex,
+	}
+	if !c.srv.UseTunnel() {
+		eventFields[events.LocalAddr] = c.Conn.LocalAddr().String()
 	}
 	if c.session != nil {
 		eventFields[events.SessionEventID] = c.session.id

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -315,3 +315,7 @@ func (f *fakeServer) GetClock() clockwork.Clock {
 func (f *fakeServer) GetInfo() services.Server {
 	return nil
 }
+
+func (f *fakeServer) UseTunnel() bool {
+	return false
+}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -183,6 +183,12 @@ func (s *Server) GetPAM() (*pam.Config, error) {
 	return s.pamConfig, nil
 }
 
+// UseTunnel used to determine if this node has connected to this cluster
+// using reverse tunnel.
+func (s *Server) UseTunnel() bool {
+	return s.useTunnel
+}
+
 // isAuditedAtProxy returns true if sessions are being recorded at the proxy
 // and this is a Teleport node.
 func (s *Server) isAuditedAtProxy() bool {
@@ -594,6 +600,12 @@ func (s *Server) getRole() teleport.Role {
 
 // GetInfo returns a services.Server that represents this server.
 func (s *Server) GetInfo() services.Server {
+	// Only set the address for non-tunnel nodes.
+	var addr string
+	if !s.useTunnel {
+		addr = s.AdvertiseAddr()
+	}
+
 	return &services.ServerV2{
 		Kind:    services.KindNode,
 		Version: services.V2,
@@ -604,7 +616,7 @@ func (s *Server) GetInfo() services.Server {
 		},
 		Spec: services.ServerSpecV2{
 			CmdLabels: services.LabelsToV2(s.getCommandLabels()),
-			Addr:      s.AdvertiseAddr(),
+			Addr:      addr,
 			Hostname:  s.hostname,
 			UseTunnel: s.useTunnel,
 		},

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -475,8 +475,11 @@ type AuthMethods struct {
 }
 
 func (s *Server) checkArguments(a utils.NetAddr, h NewChanHandler, hostSigners []ssh.Signer, ah AuthMethods) error {
-	if a.Addr == "" || a.AddrNetwork == "" {
-		return trace.BadParameter("addr: specify network and the address for listening socket")
+	// If the server is not in tunnel mode, an address must be specified.
+	if s.listener != nil {
+		if a.Addr == "" || a.AddrNetwork == "" {
+			return trace.BadParameter("addr: specify network and the address for listening socket")
+		}
 	}
 
 	if h == nil {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -611,8 +611,13 @@ func onListNodes(cf *CLIConf) {
 	case true:
 		t := asciitable.MakeTable([]string{"Node Name", "Node ID", "Address", "Labels"})
 		for _, n := range nodes {
+			addr := n.GetAddr()
+			if n.GetUseTunnel() {
+				addr = "⟵ Tunnel"
+			}
+
 			t.AddRow([]string{
-				n.GetHostname(), n.GetName(), n.GetAddr(), n.LabelsString(),
+				n.GetHostname(), n.GetName(), addr, n.LabelsString(),
 			})
 		}
 		fmt.Println(t.AsBuffer().String())
@@ -621,6 +626,7 @@ func onListNodes(cf *CLIConf) {
 	case false:
 		t := asciitable.MakeTable([]string{"Node Name", "Address", "Labels"})
 		for _, n := range nodes {
+
 			labelChunks := chunkLabels(n.GetAllLabels(), 2)
 			for i, v := range labelChunks {
 				var hostname string
@@ -628,6 +634,9 @@ func onListNodes(cf *CLIConf) {
 				if i == 0 {
 					hostname = n.GetHostname()
 					addr = n.GetAddr()
+					if n.GetUseTunnel() {
+						addr = "⟵ Tunnel"
+					}
 				}
 				t.AddRow([]string{hostname, addr, strings.Join(v, ", ")})
 			}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -626,7 +626,6 @@ func onListNodes(cf *CLIConf) {
 	case false:
 		t := asciitable.MakeTable([]string{"Node Name", "Address", "Labels"})
 		for _, n := range nodes {
-
 			labelChunks := chunkLabels(n.GetAllLabels(), 2)
 			for i, v := range labelChunks {
 				var hostname string


### PR DESCRIPTION
**Description**

Don't heartbeat address for nodes connected to clusters over a reverse tunnel. Print warning to users if `listen_addr` or `public_addr` are set as these are not used.

Pass connection to target node, even if it's a node connected over a reverse tunnel, to the forwarding server.

Fixes https://github.com/gravitational/teleport/issues/2751