### PR TITLE
Allow tsh to connect to legacy clusters.

### DIFF
--- a/lib/secret/secret.go
+++ b/lib/secret/secret.go
@@ -108,6 +108,14 @@ func (k Key) Open(ciphertext []byte) ([]byte, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	// Attempting to call aesgcm.Open with a invalid nonce will cause it to panic.
+	// To make sure that doesn't happen even handling invalid ciphertext
+	// (for example, for legacy secret package or attacker controlled data),
+	// reject invalid sized nonces.
+	if len(data.Nonce) != aesgcm.NonceSize() {
+		return nil, trace.BadParameter("invalid nonce sice, only %v supported", aesgcm.NonceSize())
+	}
+
 	plaintext, err := aesgcm.Open(nil, data.Nonce, data.Ciphertext, nil)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
**Description**

While moving from lemma (NaCl based) to the new internal secret package (AES-GCM based), Teleport was updated to allow older tsh clients to connect to newer proxies. Support to allow newer tsh clients to connect to older proxies was omitted.

To allow newer tsh clients to connect to older proxies, Teleport attempts to decrypt the response payload using the new secret package, and if it fails, attempts to use the legacy lemma package.

In addition, the secret key that tsh generates is encoded in the new as well as older format when submitting the client submits the request to Teleport.