### PR TITLE
Don't include port in host certificate principals.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -865,10 +865,16 @@ func (s *AuthServer) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedK
 	// If the request contains 0.0.0.0, this implies an advertise IP was not
 	// specified on the node. Try and guess what the address by replacing 0.0.0.0
 	// with the RemoteAddr as known to the Auth Server.
-	req.AdditionalPrincipals = utils.ReplaceInSlice(
-		req.AdditionalPrincipals,
-		defaults.AnyAddress,
-		req.RemoteAddr)
+	if utils.SliceContainsStr(req.AdditionalPrincipals, defaults.AnyAddress) {
+		remoteHost, err := utils.Host(req.RemoteAddr)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		req.AdditionalPrincipals = utils.ReplaceInSlice(
+			req.AdditionalPrincipals,
+			defaults.AnyAddress,
+			remoteHost)
+	}
 
 	var cryptoPubKey crypto.PublicKey
 	var privateKeyPEM, pubSSHKey []byte


### PR DESCRIPTION
**Description**

When attempting to guess the IP address of a remote host to add to the host certificate, always remove the port.

Improve logging, so it's clear when a nodes host certificate changes due to the principals list being updated.