### PR TITLE
If cluster name is not given, set to default.

### DIFF
--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -185,6 +185,7 @@ func (t *proxySubsys) Start(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Requ
 				return trace.Errorf("no connected sites")
 			}
 			site = sites[0]
+			t.clusterName = site.GetName()
 			t.log.Debugf("Cluster not specified. connecting to default='%s'", site.GetName())
 		}
 		return t.proxyToHost(ctx, site, clientAddr, ch)


### PR DESCRIPTION
**Description**

If a request to the proxy subsystem does not contain the cluster name, set cluster name to the selected site.