### PR TITLE
Better errors for invalid OIDC connectors, fixes #2690

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -97,6 +97,11 @@ const (
 	// DefaultThrottleTimeout is a timemout used to throttle failed auth servers
 	DefaultThrottleTimeout = 10 * time.Second
 
+	// WebHeadersTimeout is a timeout that is set for web requests
+	// before browsers raise "Timeout waiting web headers" error in
+	// the browser
+	WebHeadersTimeout = 10 * time.Second
+
 	// DefaultIdleConnectionDuration indicates for how long Teleport will hold
 	// the SSH connection open if there are no reads/writes happening over it.
 	// 15 minutes default is compliant with PCI DSS standards

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -690,7 +690,13 @@ func (h *Handler) oidcLoginWeb(w http.ResponseWriter, r *http.Request, p httprou
 			CheckUser:         true,
 		})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		// redirect to an error page
+		pathToError := url.URL{
+			Path:     "/web/msg/error/login_failed",
+			RawQuery: url.Values{"details": []string{err.Error()}}.Encode(),
+		}
+		http.Redirect(w, r, pathToError.String(), http.StatusFound)
+		return nil, nil
 	}
 	http.Redirect(w, r, response.RedirectURL, http.StatusFound)
 	return nil, nil


### PR DESCRIPTION
Invalid or inaccessible OIDC connectors were preventing
all other logins to work, as they were grabbing mutex
and making a network call.

Besides, the error was not informative as the user
saw "web headers timeout" error in the browser.

This fix makes sure that:

* Connector errors are isolated to the connector name
and other flows are not blocked
* Error is presented to user in a reasonable way and
provides instructions
* Administrator can see the error in the audit logs.