### PR TITLE
Do not clear cookies when bearer token does not match to avoid auto logouts

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1999,8 +1999,6 @@ func (h *Handler) WithClusterAuth(fn ClusterHandler) httprouter.Handle {
 		ctx, err := h.AuthenticateRequest(w, r, true)
 		if err != nil {
 			log.Info(err)
-			// clear session just in case if the authentication request is not valid
-			ClearSession(w)
 			return nil, trace.Wrap(err)
 		}
 		siteName := p.ByName("site")


### PR DESCRIPTION
This partially addresses this issue https://github.com/gravitational/gravity.e/issues/4165 + some clean up as this line does not bring additional security properties.
