### PR TITLE
Bump AMI and add more comments

### DIFF
--- a/assets/marketplace/cloudformation/Makefile
+++ b/assets/marketplace/cloudformation/Makefile
@@ -7,11 +7,11 @@ BUILD_SUBNET_ID ?=
 # Override for AMI name if needed
 BUILD_AMI_NAME ?=
 
-# Default build region
+# Default build region. us-west-2 = US West (Oregon)
 AWS_REGION ?= us-west-2
 
-# Teleport version
-TELEPORT_VERSION ?= 3.1.1
+# Teleport version 
+TELEPORT_VERSION ?= 4.0.0
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007

--- a/assets/marketplace/cloudformation/ent.yaml
+++ b/assets/marketplace/cloudformation/ent.yaml
@@ -67,10 +67,14 @@ Mappings:
     t2.micro: {Arch: HVM64}
 
   AWSRegionArch2AMI:
-    eu-west-1: {HVM64 : ami-63ddee1a}
-    us-east-1: {HVM64 : ami-3adb4b45}
-    us-east-2: {HVM64 : ami-0c80bd69}
-    us-west-2: {HVM64 : ami-0d0b7675}
+    # eu-west-1 = EU ( Ireland )
+    # us-east-1 = US East ( N. Virginia )
+    # us-east-2 = US East ( Ohio )
+    # us-west-2 = US West (Oregon)
+    eu-west-1: {HVM64 : ami-0f70de18c1fe41570}
+    us-east-1: {HVM64 : ami-0451a392c57b14c70}
+    us-east-2: {HVM64 : ami-01a31e9f38c31a96d}
+    us-west-2: {HVM64 : ami-050e66e8273b91f0e}
 
 Resources:
 # Auth server setup

--- a/assets/marketplace/cloudformation/oss.yaml
+++ b/assets/marketplace/cloudformation/oss.yaml
@@ -67,10 +67,15 @@ Mappings:
     t2.micro: {Arch: HVM64}
 
   AWSRegionArch2AMI:
-    eu-west-1: {HVM64 : ami-63ddee1a}
-    us-east-1: {HVM64 : ami-3adb4b45}
-    us-east-2: {HVM64 : ami-0c80bd69}
-    us-west-2: {HVM64 : ami-0d0b7675}
+    # eu-west-1 = EU (Ireland)
+    # us-east-1 = US East (N. Virginia)
+    # us-east-2 = US East (Ohio)
+    # us-west-2 = US West (Oregon)
+    # All AMI from AWS Marketplace aws-marketplace/gravitational-teleport-marketplace-ami-oss-4.0.0-xxx
+    eu-west-1: {HVM64 : ami-0514b7b893dfa3503}
+    us-east-1: {HVM64 : ami-04e79542e3e5fbf02}
+    us-east-2: {HVM64 : ami-09d157e6ec5e4dc76}
+    us-west-2: {HVM64 : ami-0514b7b893dfa3503}
 
 Resources:
 # Auth server setup


### PR DESCRIPTION
I've gone through the process of trying out the Cloudformation templates. 

The VPC Template works well.

![image](https://user-images.githubusercontent.com/559288/61570486-ba7f1e80-aa41-11e9-8a89-4934babd5e67.png)

But when building the OSS 

```
 export STACK=teleport-test-cf-build-servers
export STACK_PARAMS="\
ParameterKey=VPC,ParameterValue=vpc-0620a2e41044da019 \
ParameterKey=ProxySubnetA,ParameterValue=subnet-0c17e7afd88203232 \
ParameterKey=ProxySubnetB,ParameterValue=subnet-01827607d3d3d1ee7 \
ParameterKey=AuthSubnetA,ParameterValue=subnet-0e4c13f0e8890b7c2 \
ParameterKey=AuthSubnetB,ParameterValue=subnet-009da6f9d519197d5 \
ParameterKey=NodeSubnetA,ParameterValue=subnet-08cbe5ab5438ab783 \
ParameterKey=NodeSubnetB,ParameterValue=subnet-06fa978a3008ff54c         \
ParameterKey=KeyName,ParameterValue=benarentpub \
ParameterKey=DomainName,ParameterValue=teleport-cf.benarent.co.uk \
ParameterKey=DomainAdminEmail,ParameterValue=benarent@gmail.com.com \
ParameterKey=HostedZoneID,ParameterValue=Z2Q4CPFIZYH877"
make create-stack
```

![image](https://user-images.githubusercontent.com/559288/61570516-f31ef800-aa41-11e9-8ba4-5f572e5792f1.png)
![image](https://user-images.githubusercontent.com/559288/61570517-f74b1580-aa41-11e9-89d1-131636a2b65e.png)

^ . It looks like the auth server gets connected but the health check doesn't work? ( Could this be because I switched out the AMIs? 

