### PR TITLE
Add support for ProxyJump.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -361,6 +361,9 @@ const (
 	CertExtensionPermitPortForwarding = "permit-port-forwarding"
 	// CertExtensionTeleportRoles is used to propagate teleport roles
 	CertExtensionTeleportRoles = "teleport-roles"
+	// CertExtensionTeleportRouteToCluster is used to encode
+	// the target cluster to route to in the certificate
+	CertExtensionTeleportRouteToCluster = "teleport-route-to-cluster"
 )
 
 const (

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -407,7 +407,7 @@ type certRequest struct {
 }
 
 // GenerateUserTestCerts is used to generate user certificate, used internally for tests
-func (a *AuthServer) GenerateUserTestCerts(key []byte, username string, ttl time.Duration, compatibility string) ([]byte, []byte, error) {
+func (a *AuthServer) GenerateUserTestCerts(key []byte, username string, ttl time.Duration, compatibility, routeToCluster string) ([]byte, []byte, error) {
 	user, err := a.Identity.GetUser(username)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -417,11 +417,12 @@ func (a *AuthServer) GenerateUserTestCerts(key []byte, username string, ttl time
 		return nil, nil, trace.Wrap(err)
 	}
 	certs, err := a.generateUserCert(certRequest{
-		user:          user,
-		roles:         checker,
-		ttl:           ttl,
-		compatibility: compatibility,
-		publicKey:     key,
+		user:           user,
+		roles:          checker,
+		ttl:            ttl,
+		compatibility:  compatibility,
+		publicKey:      key,
+		routeToCluster: routeToCluster,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -501,6 +502,7 @@ func (s *AuthServer) generateUserCert(req certRequest) (*certs, error) {
 		CertificateFormat:     certificateFormat,
 		PermitPortForwarding:  req.roles.CanPortForward(),
 		PermitAgentForwarding: req.roles.CanForwardAgents(),
+		RouteToCluster:        req.routeToCluster,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -110,17 +110,20 @@ func (n *Keygen) GenerateUserCert(c services.UserCertParams) ([]byte, error) {
 	if !c.PermitPortForwarding {
 		delete(cert.Permissions.Extensions, teleport.CertExtensionPermitPortForwarding)
 	}
-	if len(c.Roles) != 0 {
-		// only add roles to the certificate extensions if the standard format was
-		// requested. we allow the option to omit this to support older versions of
-		// OpenSSH due to a bug in <= OpenSSH 7.1
-		// https://bugzilla.mindrot.org/show_bug.cgi?id=2387
-		if c.CertificateFormat == teleport.CertificateFormatStandard {
+	// Only add roles to the certificate extensions if the standard format was
+	// requested. we allow the option to omit this to support older versions of
+	// OpenSSH due to a bug in <= OpenSSH 7.1
+	// https://bugzilla.mindrot.org/show_bug.cgi?id=2387
+	if c.CertificateFormat == teleport.CertificateFormatStandard {
+		if len(c.Roles) != 0 {
 			roles, err := services.MarshalCertRoles(c.Roles)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			cert.Permissions.Extensions[teleport.CertExtensionTeleportRoles] = roles
+		}
+		if c.RouteToCluster != "" {
+			cert.Permissions.Extensions[teleport.CertExtensionTeleportRouteToCluster] = c.RouteToCluster
 		}
 	}
 	if err := cert.SignCert(rand.Reader, signer); err != nil {

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -104,6 +104,10 @@ type UserCertParams struct {
 	Roles []string
 	// CertificateFormat is the format of the SSH certificate.
 	CertificateFormat string
+	// RouteToCluster specifies the target cluster
+	// if present in the certificate, will be used
+	// to route the requests to
+	RouteToCluster string
 }
 
 // CertRoles defines certificate roles

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -54,7 +54,7 @@ type AuthHandlers struct {
 	AccessPoint auth.AccessPoint
 }
 
-// BuildIdentityContext returns an IdentityContext populated with information
+// CreateIdentityContext returns an IdentityContext populated with information
 // about the logged in user on the connection.
 func (h *AuthHandlers) CreateIdentityContext(sconn *ssh.ServerConn) (IdentityContext, error) {
 	identity := IdentityContext{
@@ -72,10 +72,10 @@ func (h *AuthHandlers) CreateIdentityContext(sconn *ssh.ServerConn) (IdentityCon
 	if err != nil {
 		return IdentityContext{}, trace.Wrap(err)
 	}
+	identity.RouteToCluster = certificate.Extensions[teleport.CertExtensionTeleportRouteToCluster]
 	if certificate.ValidBefore != 0 {
 		identity.CertValidBefore = time.Unix(int64(certificate.ValidBefore), 0)
 	}
-
 	certAuthority, err := h.authorityForCert(services.UserCA, certificate.SignatureKey)
 	if err != nil {
 		return IdentityContext{}, trace.Wrap(err)

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -136,6 +136,9 @@ type IdentityContext struct {
 	// CertValidBefore is set to the expiry time of a certificate, or
 	// empty, if cert does not expire
 	CertValidBefore time.Time
+
+	// RouteToCluster is derived from the certificate
+	RouteToCluster string
 }
 
 // GetCertificate parses the SSH certificate bytes and returns a *ssh.Certificate.
@@ -520,6 +523,17 @@ func (c *ServerContext) Close() error {
 	}
 
 	return nil
+}
+
+// CancelContext is a context associated with server context,
+// closed whenever this server context is closed
+func (c *ServerContext) CancelContext() context.Context {
+	return c.cancelContext
+}
+
+// Cancel is a function that triggers closure
+func (c *ServerContext) Cancel() context.CancelFunc {
+	return c.cancel
 }
 
 // SendExecResult sends the result of execution of the "exec" command over the

--- a/lib/srv/keepalive.go
+++ b/lib/srv/keepalive.go
@@ -77,7 +77,7 @@ func StartKeepAliveLoop(p KeepAliveParams) {
 			for _, conn := range p.Conns {
 				ok := sendKeepAliveWithTimeout(conn, defaults.ReadHeadersTimeout, p.CloseContext)
 				if ok {
-					sentCount += 1
+					sentCount++
 				}
 			}
 			if sentCount == len(p.Conns) {

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -777,6 +777,13 @@ func (s *Server) HandleRequest(r *ssh.Request) {
 	}
 }
 
+const (
+	// ChanDirectTCPIP is a direct tcp ip channel
+	ChanDirectTCPIP = "direct-tcpip"
+	// ChanSession is a SSH session channel
+	ChanSession = "session"
+)
+
 // HandleNewChan is called when new channel is opened
 func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {
 	identityContext, err := s.authHandlers.CreateIdentityContext(sconn)
@@ -787,10 +794,28 @@ func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.Ne
 
 	channelType := nch.ChannelType()
 	if s.proxyMode {
+		switch channelType {
+		// Channels of type "direct-tcpip", for proxies, it's equivalent
+		// of teleport proxy: subsystem
+		case ChanDirectTCPIP:
+			req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
+			if err != nil {
+				log.Errorf("Failed to parse request data: %v, err: %v.", string(nch.ExtraData()), err)
+				nch.Reject(ssh.UnknownChannelType, "failed to parse direct-tcpip request")
+				return
+			}
+			ch, _, err := nch.Accept()
+			if err != nil {
+				log.Warnf("Unable to accept channel: %v.", err)
+				nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
+				return
+			}
+			go s.handleProxyJump(wconn, sconn, identityContext, ch, *req)
+			return
 		// Channels of type "session" handle requests that are involved in running
 		// commands on a server. In the case of proxy mode subsystem and agent
 		// forwarding requests occur over the "session" channel.
-		if channelType == "session" {
+		case ChanSession:
 			ch, requests, err := nch.Accept()
 			if err != nil {
 				log.Warnf("Unable to accept channel: %v.", err)
@@ -798,16 +823,17 @@ func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.Ne
 				return
 			}
 			go s.handleSessionRequests(wconn, sconn, identityContext, ch, requests)
-		} else {
+			return
+		default:
 			nch.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
+			return
 		}
-		return
 	}
 
 	switch channelType {
 	// Channels of type "session" handle requests that are involved in running
 	// commands on a server, subsystem requests, and agent forwarding.
-	case "session":
+	case ChanSession:
 		ch, requests, err := nch.Accept()
 		if err != nil {
 			log.Warnf("Unable to accept channel: %v.", err)
@@ -816,7 +842,7 @@ func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.Ne
 		}
 		go s.handleSessionRequests(wconn, sconn, identityContext, ch, requests)
 	// Channels of type "direct-tcpip" handles request for port forwarding.
-	case "direct-tcpip":
+	case ChanDirectTCPIP:
 		req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
 		if err != nil {
 			log.Errorf("Failed to parse request data: %v, err: %v.", string(nch.ExtraData()), err)
@@ -865,7 +891,7 @@ func (s *Server) handleDirectTCPIPRequest(wconn net.Conn, sconn *ssh.ServerConn,
 
 	// If PAM is enabled check the account and open a session.
 	var pamContext *pam.PAM
-	if s.pamConfig.Enabled {
+	if s.pamConfig != nil && s.pamConfig.Enabled {
 		// Note, stdout/stderr is discarded here, otherwise MOTD would be printed to
 		// the users screen during port forwarding.
 		pamContext, err = pam.Open(&pam.Config{
@@ -916,7 +942,7 @@ func (s *Server) handleDirectTCPIPRequest(wconn net.Conn, sconn *ssh.ServerConn,
 	wg.Wait()
 
 	// If PAM is enabled, close the PAM context after port forwarding is complete.
-	if s.pamConfig.Enabled {
+	if s.pamConfig != nil && s.pamConfig.Enabled {
 		err = pamContext.Close()
 		if err != nil {
 			ctx.Errorf("Unable to close PAM context for direct-tcpip request: %v.", err)
@@ -1227,6 +1253,107 @@ func (s *Server) handleRecordingProxy(req *ssh.Request) {
 	log.Debugf("Replied to global request (%v, %v): %v", req.Type, req.WantReply, recordingProxy)
 }
 
+// handleProxyJump handles ProxyJump request that is executed via direct tcp-ip dial on the proxy
+func (s *Server) handleProxyJump(conn net.Conn, sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, req sshutils.DirectTCPIPReq) {
+	// Create context for this channel. This context will be closed when the
+	// session request is complete.
+	ctx, err := srv.NewServerContext(s, sconn, identityContext)
+	if err != nil {
+		log.Errorf("Unable to create connection context: %v.", err)
+		ch.Stderr().Write([]byte("Unable to create connection context."))
+		return
+	}
+	ctx.Connection = conn
+	ctx.IsTestStub = s.isTestStub
+	ctx.AddCloser(ch)
+	defer ctx.Close()
+
+	clusterConfig, err := s.GetAccessPoint().GetClusterConfig()
+	if err != nil {
+		log.Errorf("Unable to fetch cluster config: %v.", err)
+		ch.Stderr().Write([]byte("Unable to fetch cluster configuration."))
+		return
+	}
+
+	// force agent forward, because in recording mode proxy needs
+	// client's agent to authenticate to the target server
+	//
+	// When proxy is in "Recording mode" the following will happen with SSH:
+	//
+	// $ ssh -J user@teleport.proxy:3023 -p 3022 user@target -F ./forward.config
+	//
+	// Where forward.config enables agent forwarding:
+	//
+	// Host teleport.proxy
+	//     ForwardAgent yes
+	//
+	// This will translate to ProxyCommand:
+	//
+	// exec ssh -l user -p 3023 -F ./forward.config -vvv -W 'target:3022' teleport.proxy
+	//
+	// -W means establish direct tcp-ip, and in SSH 2.0 session implementation,
+	// this gets called before agent forwarding is requested:
+	//
+	// https://github.com/openssh/openssh-portable/blob/master/ssh.c#L1884
+	//
+	// so in recording mode, proxy is forced to request agent forwarding
+	// "out of band", before SSH client actually asks for it
+	// which is a hack, but the only way we can think of making it work,
+	// ideas are appreciated.
+	if clusterConfig.GetSessionRecording() == services.RecordAtProxy {
+		err = s.handleAgentForwardProxy(&ssh.Request{}, ctx)
+		if err != nil {
+			log.Warningf("Failed to request agent in recording mode: %v", err)
+			ch.Stderr().Write([]byte("Failed to request agent"))
+			return
+		}
+	}
+
+	// The keep-alive loop will keep pinging the remote server and after it has
+	// missed a certain number of keep-alive requests it will cancel the
+	// closeContext which signals the server to shutdown.
+	go srv.StartKeepAliveLoop(srv.KeepAliveParams{
+		Conns: []srv.RequestSender{
+			sconn,
+		},
+		Interval:     clusterConfig.GetKeepAliveInterval(),
+		MaxCount:     clusterConfig.GetKeepAliveCountMax(),
+		CloseContext: ctx.CancelContext(),
+		// Looks liks this is this the best way to signal
+		// close to the proxy subsystem, as it will close
+		// the channel that proxy subsystem is blocked on.
+		CloseCancel: func() {
+			if err := ctx.Close(); err != nil {
+				log.Warningf("Failed to close: %v.", err)
+			}
+		},
+	})
+
+	subsys, err := newProxySubsys(proxySubsysConfig{
+		host: req.Host,
+		port: fmt.Sprintf("%v", req.Port),
+		srv:  s,
+		ctx:  ctx,
+	})
+	if err != nil {
+		log.Errorf("Unable instantiate proxy subsystem: %v.", err)
+		ch.Stderr().Write([]byte("Unable to instantiate proxy subsystem."))
+		return
+	}
+
+	if err := subsys.Start(sconn, ch, &ssh.Request{}, ctx); err != nil {
+		log.Errorf("Unable to start proxy subsystem: %v.", err)
+		ch.Stderr().Write([]byte("Unable to start proxy subsystem."))
+		return
+	}
+
+	if err := subsys.Wait(); err != nil {
+		log.Errorf("Proxy subsystem failed: %v.", err)
+		ch.Stderr().Write([]byte("Proxy subsystem failed."))
+		return
+	}
+}
+
 func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
 	log.Error(err)
 	message := []byte(utils.UserMessageFromError(err))
@@ -1239,7 +1366,7 @@ func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
 func (s *Server) parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext) (srv.Subsystem, error) {
 	var r sshutils.SubsystemReq
 	if err := ssh.Unmarshal(req.Payload, &r); err != nil {
-		return nil, fmt.Errorf("failed to parse subsystem request, error: %v", err)
+		return nil, trace.BadParameter("failed to parse subsystem request: %v", err)
 	}
 	if s.proxyMode && strings.HasPrefix(r.Name, "proxy:") {
 		return parseProxySubsys(r.Name, s, ctx)

--- a/lib/utils/proxyjump.go
+++ b/lib/utils/proxyjump.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+var reProxyJump = regexp.MustCompile(
+	// optional username, note that outside group
+	`(?:(?P<username>[^@\:]+)@)?(?P<hostport>[^\@]+)`,
+)
+
+// JumpHost is a target jump host
+type JumpHost struct {
+	// Username to login as
+	Username string
+	// Addr is a target addr
+	Addr NetAddr
+}
+
+// ParseProxyJump parses strings like user@host:port,bob@host:port
+func ParseProxyJump(in string) ([]JumpHost, error) {
+	if in == "" {
+		return nil, trace.BadParameter("missing proxyjump")
+	}
+	parts := strings.Split(in, ",")
+	out := make([]JumpHost, 0, len(parts))
+	for _, part := range parts {
+		match := reProxyJump.FindStringSubmatch(strings.TrimSpace(part))
+		if len(match) == 0 {
+			return nil, trace.BadParameter("could not parse %q, expected format user@host:port,user@host:port", in)
+		}
+		addr, err := ParseAddr(match[2])
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		out = append(out, JumpHost{Username: match[1], Addr: *addr})
+	}
+	return out, nil
+}

--- a/lib/utils/proxyjump_test.go
+++ b/lib/utils/proxyjump_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"gopkg.in/check.v1"
+)
+
+func (s *UtilsSuite) TestProxyJumpParsing(c *check.C) {
+	type tc struct {
+		in  string
+		out []JumpHost
+		err error
+	}
+	testCases := []tc{
+		{
+			in:  "host:port",
+			out: []JumpHost{{Addr: NetAddr{Addr: "host:port", AddrNetwork: "tcp"}}},
+		},
+		{
+			in:  "host",
+			out: []JumpHost{{Addr: NetAddr{Addr: "host", AddrNetwork: "tcp"}}},
+		},
+		{
+			in:  "bob@host",
+			out: []JumpHost{{Username: "bob", Addr: NetAddr{Addr: "host", AddrNetwork: "tcp"}}},
+		},
+		{
+			in:  "alice@127.0.0.1:7777",
+			out: []JumpHost{{Username: "alice", Addr: NetAddr{Addr: "127.0.0.1:7777", AddrNetwork: "tcp"}}},
+		},
+		{
+			in:  "alice@127.0.0.1:7777, bob@localhost",
+			out: []JumpHost{{Username: "alice", Addr: NetAddr{Addr: "127.0.0.1:7777", AddrNetwork: "tcp"}}, {Username: "bob", Addr: NetAddr{Addr: "localhost", AddrNetwork: "tcp"}}},
+		},
+		{
+			in:  "alice@[::1]:7777, bob@localhost",
+			out: []JumpHost{{Username: "alice", Addr: NetAddr{Addr: "[::1]:7777", AddrNetwork: "tcp"}}, {Username: "bob", Addr: NetAddr{Addr: "localhost", AddrNetwork: "tcp"}}},
+		},
+	}
+	for i, tc := range testCases {
+		comment := check.Commentf("Test case %v: %q", i, tc.in)
+		re, err := ParseProxyJump(tc.in)
+		if tc.err == nil {
+			c.Assert(err, check.IsNil, comment)
+			c.Assert(re, check.DeepEquals, tc.out)
+		} else {
+			c.Assert(err, check.FitsTypeOf, tc.err)
+		}
+	}
+}


### PR DESCRIPTION
This commit implements #2543

In SSH terms ProxyJump is a shortcut for SSH client
connecting the proxy/jumphost and requesting .port forwarding to the
target node.

This commit adds support for direct-tcpip request support
in teleport proxy service that is an alias to the existing proxy
subsystem and reuses most of the code.

This commit also adds support to "route to cluster" metadata
encoded in SSH certificate making it possible to have client
SSH certificates to include the metadata that will cause the proxy
to route the client requests to a specific cluster.

`tsh ssh -J proxy:port ` is supported in a limited way:

Only one jump host is supported (-J supports chaining
that teleport does not utilise) and tsh will return with error
in case of two jumphosts: -J a,b will not work.

In case if `tsh ssh -J user@proxy` is used, it overrides
the SSH proxy coming from the tsh profile and port-forwarding
is used instead of the existing teleport proxy subsystem