### PR TITLE
Remove reference to deprecated kubeconfig_path in error

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1036,7 +1036,7 @@ func getKubeCreds(kubeconfigPath string) (*kubeCreds, error) {
 		if err != nil {
 			return nil, trace.BadParameter(`auth server assumed that it is
 running in a kubernetes cluster, but %v mounted in pods could not be read: %v,
-set kubeconfig_path if auth server is running outside of the cluster`, teleport.KubeCAPath, err)
+set kubeconfig_file if auth server is running outside of the cluster`, teleport.KubeCAPath, err)
 		}
 
 		cfg, err := kubeutils.GetKubeConfig(os.Getenv(teleport.EnvKubeConfig))


### PR DESCRIPTION
Found a reference to `kubeconfig_path` in the code - we changed this to `kubeconfig_file` back in Teleport 3.2.

@klizhentas The rest of the test still references the auth server even though it's the `proxy_service` config which now 'owns' `kubeconfig_file`  - reckon this is OK?