### PR TITLE
Only check certificate algorithms in FIPS mode.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -49,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/shell"
@@ -2144,4 +2145,10 @@ func ParseDynamicPortForwardSpec(spec []string) (DynamicForwardedPorts, error) {
 // "StrictHostKeyChecking yes".
 func InsecureSkipHostKeyChecking(host string, remote net.Addr, key ssh.PublicKey) error {
 	return nil
+}
+
+// isFIPS returns if the binary was build with BoringCrypto, which implies
+// FedRAMP/FIPS 140-2 mode for tsh.
+func isFIPS() bool {
+	return modules.GetModules().IsBoringBinary()
 }

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -245,9 +245,12 @@ func (k *Key) CheckCert() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	// A valid principal is always passed in because the principals are not being
 	// checked here, but rather the validity period, signature, and algorithms.
-	certChecker := utils.CertChecker{}
+	certChecker := utils.CertChecker{
+		FIPS: isFIPS(),
+	}
 	err = certChecker.CheckCert(cert.ValidPrincipals[0], cert)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -269,6 +269,7 @@ func (a *LocalKeyAgent) CheckHostSignature(addr string, remote net.Addr, key ssh
 			IsHostAuthority: a.checkHostCertificate,
 			HostKeyFallback: a.checkHostKey,
 		},
+		FIPS: isFIPS(),
 	}
 	err := certChecker.CheckHostKey(addr, remote, key)
 	if err != nil {

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -561,6 +561,7 @@ func (s *remoteSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		DataDir:         s.srv.Config.DataDir,
 		Address:         params.Address,
 		UseTunnel:       targetConn.UseTunnel(),
+		FIPS:            s.srv.FIPS,
 	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1428,6 +1428,7 @@ func (process *TeleportProcess) initSSH() error {
 			regular.SetPAMConfig(cfg.SSH.PAM),
 			regular.SetRotationGetter(process.getRotation),
 			regular.SetUseTunnel(conn.UseTunnel()),
+			regular.SetFIPS(cfg.FIPS),
 		)
 		if err != nil {
 			return trace.Wrap(err)
@@ -1972,6 +1973,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				MACAlgorithms: cfg.MACAlgorithms,
 				DataDir:       process.Config.DataDir,
 				PollingPeriod: process.Config.PollingPeriod,
+				FIPS:          cfg.FIPS,
 			})
 		if err != nil {
 			return trace.Wrap(err)
@@ -2081,6 +2083,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		regular.SetMACAlgorithms(cfg.MACAlgorithms),
 		regular.SetNamespace(defaults.Namespace),
 		regular.SetRotationGetter(process.getRotation),
+		regular.SetFIPS(cfg.FIPS),
 	)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -52,6 +52,10 @@ type AuthHandlers struct {
 
 	// AccessPoint is used to access the Auth Server.
 	AccessPoint auth.AccessPoint
+
+	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
+	// configuration.
+	FIPS bool
 }
 
 // BuildIdentityContext returns an IdentityContext populated with information
@@ -178,6 +182,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 		CertChecker: ssh.CertChecker{
 			IsUserAuthority: h.IsUserAuthority,
 		},
+		FIPS: h.FIPS,
 	}
 	permissions, err := certChecker.Authenticate(conn, key)
 	if err != nil {
@@ -254,6 +259,7 @@ func (h *AuthHandlers) HostKeyAuth(addr string, remote net.Addr, key ssh.PublicK
 			IsHostAuthority: h.IsHostAuthority,
 			HostKeyFallback: h.hostKeyCallback,
 		},
+		FIPS: h.FIPS,
 	}
 	err := certChecker.CheckHostKey(addr, remote, key)
 	if err != nil {

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -168,6 +168,10 @@ type ServerConfig struct {
 
 	// Clock is an optoinal clock to override default real time clock
 	Clock clockwork.Clock
+
+	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
+	// configuration.
+	FIPS bool
 }
 
 // CheckDefaults makes sure all required parameters are passed in.
@@ -261,6 +265,7 @@ func New(c ServerConfig) (*Server, error) {
 		Component:   teleport.ComponentForwardingNode,
 		AuditLog:    c.AuthClient,
 		AccessPoint: c.AuthClient,
+		FIPS:        c.FIPS,
 	}
 
 	// Common term handlers.

--- a/lib/utils/checker_test.go
+++ b/lib/utils/checker_test.go
@@ -35,9 +35,10 @@ type CheckerSuite struct{}
 var _ = fmt.Printf
 var _ = check.Suite(&CheckerSuite{})
 
-// TestValidate makes sure the public key is a valid algorithm
-// that Teleport supports.
+// TestValidate checks what algorithm are supported in regular (non-FIPS) mode.
 func (s *CheckerSuite) TestValidate(c *check.C) {
+	checker := CertChecker{}
+
 	rsaKey, err := rsa.GenerateKey(rand.Reader, teleport.RSAKeySize)
 	c.Assert(err, check.IsNil)
 	smallRSAKey, err := rsa.GenerateKey(rand.Reader, 1024)
@@ -49,20 +50,56 @@ func (s *CheckerSuite) TestValidate(c *check.C) {
 	cryptoKey := rsaKey.Public()
 	sshKey, err := ssh.NewPublicKey(cryptoKey)
 	c.Assert(err, check.IsNil)
-	err = validate(sshKey)
+	err = checker.validate(sshKey)
+	c.Assert(err, check.IsNil)
+
+	// 1024-bit RSA keys are valid.
+	cryptoKey = smallRSAKey.Public()
+	sshKey, err = ssh.NewPublicKey(cryptoKey)
+	c.Assert(err, check.IsNil)
+	err = checker.validate(sshKey)
+	c.Assert(err, check.IsNil)
+
+	// ECDSA keys are valid.
+	cryptoKey = ellipticKey.Public()
+	sshKey, err = ssh.NewPublicKey(cryptoKey)
+	c.Assert(err, check.IsNil)
+	err = checker.validate(sshKey)
+	c.Assert(err, check.IsNil)
+}
+
+// TestValidate makes sure the public key is a valid algorithm
+// that Teleport supports while in FIPS mode.
+func (s *CheckerSuite) TestValidateFIPS(c *check.C) {
+	checker := CertChecker{
+		FIPS: true,
+	}
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, teleport.RSAKeySize)
+	c.Assert(err, check.IsNil)
+	smallRSAKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	c.Assert(err, check.IsNil)
+	ellipticKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	c.Assert(err, check.IsNil)
+
+	// 2048-bit RSA keys are valid.
+	cryptoKey := rsaKey.Public()
+	sshKey, err := ssh.NewPublicKey(cryptoKey)
+	c.Assert(err, check.IsNil)
+	err = checker.validate(sshKey)
 	c.Assert(err, check.IsNil)
 
 	// 1024-bit RSA keys are not valid.
 	cryptoKey = smallRSAKey.Public()
 	sshKey, err = ssh.NewPublicKey(cryptoKey)
 	c.Assert(err, check.IsNil)
-	err = validate(sshKey)
+	err = checker.validate(sshKey)
 	c.Assert(err, check.NotNil)
 
 	// ECDSA keys are not valid.
 	cryptoKey = ellipticKey.Public()
 	sshKey, err = ssh.NewPublicKey(cryptoKey)
 	c.Assert(err, check.IsNil)
-	err = validate(sshKey)
+	err = checker.validate(sshKey)
 	c.Assert(err, check.NotNil)
 }


### PR DESCRIPTION
**Description**

Update `utils.CertChecker` to only check key and certificate algorithms when in FIPS mode. Otherwise accept keys and certificates generated with any algorithm.