### PR TITLE
Update AMI to handle EC2 instances with no public IP

### DIFF
--- a/assets/marketplace/Makefile
+++ b/assets/marketplace/Makefile
@@ -14,7 +14,7 @@ MARKETPLACE_AMI_NAME ?=
 AWS_REGION ?= us-west-2
 
 # Teleport version
-TELEPORT_VERSION ?= 4.0.0
+TELEPORT_VERSION ?= 4.0.4
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007

--- a/assets/marketplace/files/bin/teleport-generate-config
+++ b/assets/marketplace/files/bin/teleport-generate-config
@@ -203,7 +203,13 @@ elif [[ "${TELEPORT_ROLE}" == "monitor" ]]; then
 
 else
     echo "No Teleport role provided via TELEPORT_ROLE; using all-in-one config"
-    PUBLIC_IP=$(curl http://169.254.169.254/latest/meta-data/public-ipv4)
+    # if the instance doesn't have a public IPv4 address, we get a 404 from the metadata
+    # which will break the generated config, so we use the local IP instead
+    if curl -sS -i http://169.254.169.254/latest/meta-data/public-ipv4 | grep -q 404; then
+      PUBLIC_IP=${LOCAL_IP}
+    else
+      PUBLIC_IP=$(curl -sS http://169.254.169.254/latest/meta-data/public-ipv4)
+    fi
 
     # tunnel_listen_addr needs to be changed if we're using ACM as the listener cannot understand HTTP, only HTTPS
     if [[ "${USE_ACM}" == "true" ]]; then


### PR DESCRIPTION
Fixed an issue where the default all-in-one config for Teleport on AWS Marketplace wasn't working out of the box if the instance didn't have a public IP address. Also bumped Teleport version to 4.0.4.