### PR TITLE
Better error message for IdP initated logins.

### DIFF
--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -245,8 +245,9 @@ func parseSAMLInResponseTo(response string) (string, error) {
 	el := doc.Root()
 	responseTo := el.SelectAttr("InResponseTo")
 	if responseTo == nil {
-		log.Errorf("Teleport does not support initiating login from an SAML identity provider, login must be initiated from either the Teleport Web UI or CLI.")
-		return "", trace.BadParameter("identity provider initiated flows are not supported")
+		message := "teleport does not support initiating login from a SAML identity provider, login must be initiated from either the Teleport Web UI or CLI"
+		log.Infof(message)
+		return "", trace.NotImplemented(message)
 	}
 	if responseTo.Value == "" {
 		return "", trace.BadParameter("InResponseTo can not be empty")

--- a/lib/utils/cap.go
+++ b/lib/utils/cap.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Capitalize returns a copy of the string
+// with first rune converted to capital letter
+func Capitalize(s string) string {
+	// Use a closure here to remember state.
+	// Hackish but effective. Depends on Map scanning in order and calling
+	// the closure once per rune.
+	done := false
+	return strings.Map(
+		func(r rune) rune {
+			if done {
+				return r
+			}
+			done = true
+			return unicode.ToTitle(r)
+		},
+		s)
+}

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -36,6 +36,23 @@ type UtilsSuite struct {
 
 var _ = check.Suite(&UtilsSuite{})
 
+// TestCapitalize tests capitalize function
+func (s *UtilsSuite) TestCapitalize(c *check.C) {
+	type testCase struct {
+		in  string
+		out string
+	}
+	cases := []testCase{
+		{in: "hello there", out: "Hello there"},
+		{in: " ", out: " "},
+		{in: "", out: ""},
+	}
+	for i, tc := range cases {
+		comment := check.Commentf("Test case %v", i)
+		c.Assert(Capitalize(tc.in), check.Equals, tc.out, comment)
+	}
+}
+
 // TestLinear tests retry logic
 func (s *UtilsSuite) TestLinear(c *check.C) {
 	r, err := NewLinear(LinearConfig{

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/form"
 	"github.com/gravitational/trace"
@@ -102,6 +103,11 @@ func (m *Handler) samlACS(w http.ResponseWriter, r *http.Request, p httprouter.P
 		log.Warningf("error while processing callback: %v", err)
 
 		message := "Unable to process callback from SAML provider. Ask your system administrator to check audit logs for details."
+		// for not implemented errors it's ok to provide a more specific
+		// message as it could give more guidance on what's not enabled
+		if trace.IsNotImplemented(err) {
+			message = utils.Capitalize(err.Error()) + "."
+		}
 
 		// redirect to an error page
 		pathToError := url.URL{


### PR DESCRIPTION
Fixes #2648

Teleport does not support SAML identity provider
initiated logins, this commit gives a better
error message to the user instructing them
what to do.