### PR TITLE
Make Teleport Docker version consistent and use latest version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ and run it under `$USER`, in this case you will not be able to login as someone 
 If you wish to deploy Teleport inside a Docker container:
 
 ```
-# This command will pull the Teleport container image for version 3.2.6
-# Replace 2.7.3 with the version you need:
-$ docker pull quay.io/gravitational/teleport:3.2.6
+# This command will pull the Teleport container image for version 4.0.4
+# Replace 4.0.4 with the version you need:
+$ docker pull quay.io/gravitational/teleport:4.0.4
 ```
+View latest tags on [Quay.io | gravitational/teleport](https://quay.io/repository/gravitational/teleport?tab=tags)
 
 ## Building Teleport
 


### PR DESCRIPTION
The readme is a little inconsistent, and I've added a link to Quay.io. As part of this we do need to add more instructions for people wanting to use this Docker Image. 