### PR TITLE
Added support to save cluster to profile.

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -134,6 +134,16 @@ func (proxy *ProxyClient) GenerateCertsForCluster(ctx context.Context, routeToCl
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	// Before requesting a certificate, check if the requested cluster is valid.
+	_, err = clt.GetCertAuthority(services.CertAuthID{
+		Type:       services.HostCA,
+		DomainName: routeToCluster,
+	}, false)
+	if err != nil {
+		return trace.NotFound("cluster %v not found", routeToCluster)
+	}
+
 	req := proto.UserCertsRequest{
 		Username:       cert.KeyId,
 		PublicKey:      key.Pub,


### PR DESCRIPTION
**Description**

Upon calling `tsh login <clusterName>`, Teleport will save the cluster name in `~/.tsh/profile`. This value will then be used similar to the `--cluster` flag to select which cluster to run a tsh subcommand on.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/2671