### PR TITLE
Added DynamoDB streams to example policy and ran spell check

### DIFF
--- a/docs/4.0/README.md
+++ b/docs/4.0/README.md
@@ -31,7 +31,7 @@ within multiple organizations.
 ## Who Built Teleport?
 
 Teleport was created by [Gravitational Inc](https://gravitational.com). We have built Teleport 
-by borrowing from our previous experiences at Rackspace. It has been extracted from [Telekube](https://gravitational.com/telekube/), our system for helping our clients to deploy 
+by borrowing from our previous experiences at Rackspace. It has been extracted from [Gravity](https://gravitational.com/gravity/), our system for helping our clients to deploy 
 and remotely manage their SaaS applications on many cloud regions or even on-premise.
 
 ## Resources

--- a/docs/4.0/admin-guide.md
+++ b/docs/4.0/admin-guide.md
@@ -483,7 +483,7 @@ proxy_service:
 
 #### Public Addr
 
-Notice that all three Teleport sevices (proxy, auth, node) have an optional
+Notice that all three Teleport services (proxy, auth, node) have an optional
 `public_addr` property. The public address can take an IP or a DNS name.
 It can also be a list of values:
 
@@ -578,7 +578,7 @@ hardware keys as a second authentication factor. By default U2F is disabled. To 
 * For web-based logins you have to use Google Chrome, as it is the only browser supporting U2F at this time.
 
 ```yaml
-# snippet from /etc/teleport.yaml to show an examlpe configuration of U2F:
+# snippet from /etc/teleport.yaml to show an example configuration of U2F:
 auth_service:
   authentication:
     type: local
@@ -961,7 +961,7 @@ command: ["/bin/uname", "-m"]
 command: ["/bin/uname -m"]
 
 # if you want to pipe several bash commands together, here's how to do it:
-# notice how ' and " are iterchangeable and you can use it for quoting:
+# notice how ' and " are interchangeable and you can use it for quoting:
 command: ["/bin/sh", "-c", "uname -a | egrep -o '[0-9]+\.[0-9]+\.[0-9]+'"]
 ```
 
@@ -971,7 +971,7 @@ command: ["/bin/sh", "-c", "uname -a | egrep -o '[0-9]+\.[0-9]+\.[0-9]+'"]
 Teleport logs every SSH event into its audit log. There are two components of the audit log:
 
 1. **SSH Events:** Teleport logs events like successful user logins along with
-   the metadata like remote IP address, time and the sesion ID.
+   the metadata like remote IP address, time and the session ID.
 2. **Recorded Sessions:** Every SSH shell session is recorded and can be replayed
    later. The recording is done by the nodes themselves, by default, but can be configured
    to be done by the proxy.
@@ -990,7 +990,7 @@ chapters on how to configure the SSH events and recorded sessions to be stored
 on network storage. It is even possible to store the audit log in multiple places at the same time,
 see `audit_events_uri` setting in the sample configuration file above for how to do that.
 
-Let's examing the Teleport audit log using the `dir` backend. The event log is
+Let's examine the Teleport audit log using the `dir` backend. The event log is
 stored in `data_dir` under `log` directory, usually `/var/lib/teleport/log`.
 Each day is represented as a file:
 
@@ -1017,7 +1017,7 @@ Each line represents an event and has the following format:
    "namespace"  : "default",
    // Unique server ID.
    "server_id"  : "f84f7386-5e22-45ff-8f7d-b8079742e63f",
-   // Session ID. Can be used to replay the sesssion.
+   // Session ID. Can be used to replay the session.
    "sid"        : "8d3895b6-e9dd-11e6-94de-40167e68e931",
    // Address of the SSH node
    "addr.local" : "10.5.l.15:3022",
@@ -1220,9 +1220,9 @@ manipulated with just 3 CLI commands:
 
 Command         | Description | Examples
 ----------------|-------------|----------
-`tctl get`      | Get one or multipe resources           | `tctl get users` or `tctl get user/joe`
+`tctl get`      | Get one or multiple resources           | `tctl get users` or `tctl get user/joe`
 `tctl rm`       | Delete a resource by type/name         | `tctl rm user/joe`
-`tctl create`   | Create a new resource from a YAML file. Use `-f` to overide / update | `tctl create -f joe.yaml`
+`tctl create`   | Create a new resource from a YAML file. Use `-f` to override / update | `tctl create -f joe.yaml`
 
 !!! warning "YAML Format":
     By default Teleport uses [YAML format](https://en.wikipedia.org/wiki/YAML)
@@ -1491,7 +1491,7 @@ $ tctl rm tc/east
 
 While accessibility is only granted in one direction, trust is granted in both directions. If you remote "east" from "main", the following will happen:
 
-* Two clusters will be disconnected, becase "main" will drop the inbound SSH tunnel connection from "east" and will not allow a new one.
+* Two clusters will be disconnected, because "main" will drop the inbound SSH tunnel connection from "east" and will not allow a new one.
 * "main" will stop trusting certificates issued by "east".
 * "east" will continue to trust certificates issued by "main".
 
@@ -1520,7 +1520,7 @@ providers such as Github. First, the Teleport auth service must be configured
 to use Github for authentication:
 
 ```yaml
-# snippet from /etc/teleport.yaaml
+# snippet from /etc/teleport.yaml
 auth_service:
   authentication:
       type: github
@@ -2028,7 +2028,7 @@ teleport:
 
 !!! tip "AWS Authentication":
     The configuration examples below contain AWS access keys and secret keys. They are optional,
-    they exist for your convenience but we DO NOT RECOMMEND usign them in
+    they exist for your convenience but we DO NOT RECOMMEND using them in
     production. If Teleport is running on an AWS instance it will automatically
     use the instance IAM role. Teleport also will pick up AWS credentials from
     the `~/.aws` folder, just like the AWS CLI tool.
@@ -2109,7 +2109,7 @@ teleport:
 * The AWS authentication setting above can be omitted if the machine itself is
   running on an EC2 instance with an IAM role.
 * Audit log settings above are optional. If specified, Teleport will store the
-  audit log in DyamoDB and the session recordings **must** be stored in an S3
+  audit log in DynamoDB and the session recordings **must** be stored in an S3
   bucket, i.e. both `audit_xxx` settings must be present. If they are not set,
   Teleport will default to a local file system for the audit log, i.e.
   `/var/lib/teleport/log` on an auth server.
@@ -2131,6 +2131,12 @@ teleport:
             "Effect": "Allow",
             "Action": "dynamodb:*",
             "Resource": "arn:aws:dynamodb:eu-west-1:123456789012:table/prod.teleport.auth"
+        },
+        {
+            "Sid": "AllAPIActionsOnTeleportStreams",
+            "Effect": "Allow",
+            "Action": "dynamodb:*",
+            "Resource": "arn:aws:dynamodb:us-west-2:126027368216:table/prod.teleport.auth/stream/*"
         }
     ]
 }
@@ -2154,7 +2160,7 @@ which makes it easy to tell if a specific version is recommended for production 
 When running multiple binaries of Teleport within a cluster (nodes, proxies,
 clients, etc), the following rules apply:
 
-* Patch versions are always compatible, for example any 4.0.1 compoment will
+* Patch versions are always compatible, for example any 4.0.1 component will
   work with any 4.0.3 component.
 * Other versions are always compatible with their **previous** release. This
   means you must not attempt to upgrade from 3.3 straight to 3.5. You must

--- a/docs/4.0/admin-guide.md
+++ b/docs/4.0/admin-guide.md
@@ -2136,7 +2136,7 @@ teleport:
             "Sid": "AllAPIActionsOnTeleportStreams",
             "Effect": "Allow",
             "Action": "dynamodb:*",
-            "Resource": "arn:aws:dynamodb:us-west-2:126027368216:table/prod.teleport.auth/stream/*"
+            "Resource": "arn:aws:dynamodb:eu-west-1:123456789012:table/prod.teleport.auth/stream/*"
         }
     ]
 }

--- a/docs/4.0/architecture.md
+++ b/docs/4.0/architecture.md
@@ -57,7 +57,7 @@ The following core concepts are integral to understanding the Teleport architect
 
 Teleport supports two types of user accounts:
 
-* **Local users** are created and stored in Teleport's own identitiy storage. A cluster
+* **Local users** are created and stored in Teleport's own identity storage. A cluster
   administrator has to create account entries for every Teleport user.
   Teleport supports second factor authentication (2FA) and it is enforced by default.
   There are two types of 2FA supported:
@@ -438,7 +438,7 @@ to the final destination server, effectively becoming an authorized "man in the
 middle". This allows the proxy server to forward SSH session data to the auth
 server to be recorded, as shown below:
 
-![recorindg-proxy](img/recording-proxy.svg?style=grv-image-center-lg)
+![recording-proxy](img/recording-proxy.svg?style=grv-image-center-lg)
 
 The recording proxy mode, although _less secure_, was added to allow Teleport
 users to enable session recording for OpenSSH's servers running `sshd`, which is

--- a/docs/4.0/enterprise.md
+++ b/docs/4.0/enterprise.md
@@ -83,7 +83,7 @@ See the [SSO for SSH](ssh_sso.md) chapter for more details.
 
 
 !!! tip "Contact Information":
-    For more information about Teleport Enterprise or Telekube please reach out us to `sales@gravitational.com` or fill out the contact for on our [website](http://gravitational.com/demo)
+    For more information about Teleport Enterprise or Gravity please reach out us to `sales@gravitational.com` or fill out the contact for on our [website](http://gravitational.com/demo)
 
 
 ## FedRAMP/FIPS 

--- a/docs/4.0/oidc.md
+++ b/docs/4.0/oidc.md
@@ -214,6 +214,6 @@ diagnosed using Teleport's `stderr` log, which is usually available via:
 $ sudo journalctl -fu teleport
 ```
 
-If you wish to increase the verbocity of Teleport's syslog, you can pass
+If you wish to increase the verbosity of Teleport's syslog, you can pass
 `--debug` flag to `teleport start` command.
 

--- a/docs/4.0/quickstart-enterprise.md
+++ b/docs/4.0/quickstart-enterprise.md
@@ -39,7 +39,7 @@ _"auth.example.com"_  | 10.1.1.10      | This server will be used to run all thr
 _"node.example.com"_  | 10.1.1.11      | This server will only run the SSH service. The vast majority of servers in production will be nodes.
 
 This Quick Start Guide assumes that the both servers are running a [systemd-based](https://www.freedesktop.org/wiki/Software/systemd/)
-Linux distribution such as Debian, Ubuntu or a RHEL deriviative.
+Linux distribution such as Debian, Ubuntu or a RHEL derivative.
 
 ## Installing
 
@@ -206,7 +206,7 @@ role only allows SSH logins as `root@host`.
     clusters.
 
 You probably want to replace "root" with something else. Let's assume there will
-be a local UNIX account called "admin" on all hosts. In this case you cand
+be a local UNIX account called "admin" on all hosts. In this case you can
 dump the role definition YAML into _admin-role.yaml_ file and update "allow/logins"
 to look like this:
 
@@ -236,7 +236,7 @@ which is available for both Android and iPhone.
 
 ## Assigning Roles
 
-To update user's roles, dump the user resoure into a file:
+To update user's roles, dump the user resource into a file:
 
 ```bsh
 $ sudo tctl get users/joe > joe.yaml

--- a/docs/4.0/ssh_adfs.md
+++ b/docs/4.0/ssh_adfs.md
@@ -149,7 +149,7 @@ The `acs` field should match the value you set in ADFS earlier and you can
 obtain the `entity_descriptor_url` from ADFS under _"ADFS -> Service -> Endpoints -> Metadata"_.
 
 The `attributes_to_roles` is used to map attributes to the Teleport roles you
-just creataed. In our situation, we are mapping the _"Group"_ attribute whose full
+just created. In our situation, we are mapping the _"Group"_ attribute whose full
 name is `http://schemas.xmlsoap.org/claims/Group` with a value of _"teleadmins"_
 to the _"admin"_ role. Groups with the value _"teleusers"_ is being mapped to the
 _"users"_ role.
@@ -200,6 +200,6 @@ diagnosed using Teleport's `stderr` log, which is usually available via:
 $ sudo journalctl -fu teleport
 ```
 
-If you wish to increase the verbocity of Teleport's syslog, you can pass
+If you wish to increase the verbosity of Teleport's syslog, you can pass
 `--debug` flag to `teleport start` command.
 

--- a/docs/4.0/ssh_okta.md
+++ b/docs/4.0/ssh_okta.md
@@ -51,7 +51,7 @@ statements (special signed metadata exposed via a SAML XML response).
 ![Configure APP](img/okta-saml-3.png)
 
 !!! tip "Important":
-    Notice that we have set "NameID" to the email format and mappped the groups with
+    Notice that we have set "NameID" to the email format and mapped the groups with
     a wildcard regex in the Group Attribute statements. We have also set the "Audience"
     and SSO URL to the same value.
 

--- a/docs/4.0/ssh_sso.md
+++ b/docs/4.0/ssh_sso.md
@@ -122,7 +122,7 @@ spec:
 ## Multiple SSO Providers
 
 Teleport can also support multiple connectors, i.e. a Teleport administrator
-can define and create multiple connector resoruces using `tctl create` as shown above. 
+can define and create multiple connector resources using `tctl create` as shown above. 
 
 To see all configured connectors, execute this on the auth server:
 

--- a/docs/4.0/trustedclusters.md
+++ b/docs/4.0/trustedclusters.md
@@ -131,7 +131,7 @@ more complicated.
 
 !!! warning "Version Warning":
     The RBAC section is applicable only to Teleport Enterprise. The open source
-    version does not suppport SSH roles.
+    version does not support SSH roles.
 
 When a _trusting_ cluster "east" from the diagram above establishes trust with
 the _trusted_ cluster "main", it needs a way to configure which users from
@@ -302,7 +302,7 @@ following checks:
 There are three common types of problems Teleport administrators can run into when configuring
 trust between two clusters:
 
-* **HTTPS configuration**: when the main cluster uses a self-sgined or invalid HTTPS certificate.
+* **HTTPS configuration**: when the main cluster uses a self-signed or invalid HTTPS certificate.
 
 * **Connectivity problems**: when a trusting cluster "east" does not show up in
   `tsh clusters` output on "main".


### PR DESCRIPTION
Main purpose of this is just to update the example IAM policy to also allow access to DynamoDB streams (which we now use)

I also ran `aspell check admin-guide.md` and fixed all the mistakes. We should DEFINITELY do this as a matter of course when updating all docs.