### PR TITLE
Add isolated proxy-seeking state machine

### DIFF
--- a/lib/reversetunnel/seek/doc.go
+++ b/lib/reversetunnel/seek/doc.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Proxy-Seeking alogirthm
+//
+// Premise: An unknown number of proxies exist behind a "fair"
+// load-balancer. Proxies will share their peerset via gossip, but
+// this gossip is asynchronous and may suffer from ordering/timing
+// issues. Furthermore, rotations may cause a complete and permanent
+// loss of contact with all known proxies.
+//
+// Goals: Ensure that we have one agent managing a connection to each
+// available proxy.  Minimize unnecessary discovery attempts. Recover
+// from bad state (e.g. due to full rotations) in a timely manner.
+// Mitigate resource drain due to failing or unreachable proxies.
+//
+//
+// Each known proxy has an associated entry which stores
+// its seek state (seeking | claimed | backoff).
+//
+// When an agent discovers (connects to) a proxy, it attempts to
+// acquire an exclusive claim to that proxy.  If sucessful, the agent
+// takes responsibility for the proxy, releasing its claim when the
+// connection terminates (regardless of reason).  If another agent
+// has already claimed the proxy, the connection is dropped.
+//
+// Unclaimed entries are subject to expiry.  Expiration timers are
+// refreshed by gossip messages.
+//
+// If a claim is released within a very short interval after being
+// acquired, termination is said to be premature.  Premature
+// termination triggers a backoff phase which pauses discovery
+// attempts for the proxy.  The length of the backoff phase is
+// determined by an incrementing multiplier.  If backoff is entered
+// too often to allow the counter to reset, the backoff phase will
+// grow beyond the expiry limit and the associated entry will be
+// removed.
+//
+//  +---------+
+//  |         |                  acquire
+//  |  START  +------------------------------------------------+
+//  |         |                                                |
+//  +----+----+                                                v
+//       |                                               +-----+-----+
+//       |      refresh               release (ok)       |           |
+//       +-----+--------+   +----------------------------+  Claimed  |
+//             ^        |   |                            |           |
+//             |        v   v                            +--+-----+--+
+//             |    +---+---+---+                           ^     |
+//             |    |           |          acquire          |     |
+//             +----+  Seeking  +---------------------------+     |
+//                  |           |                                 |
+//  +--------+      +---+---+---+                                 |
+//  |        |          |   ^        +-----------+                |
+//  |  STOP  |          |   |  done  |           |  release (err) |
+//  |        |          |   +--------+  Backoff  +<---------------+
+//  +---+----+          |            |           |
+//      ^               |            +-----+-----+
+//      |               v   expire         |
+//      +---------------+------------------+
+//
+package seek

--- a/lib/reversetunnel/seek/seek.go
+++ b/lib/reversetunnel/seek/seek.go
@@ -1,0 +1,413 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package seek
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+// Key uniquely identifies a seek group
+type Key struct {
+	Cluster string
+	Type    string
+	Addr    utils.NetAddr
+}
+
+// Config describes the various parameters related to a seek operation
+type Config struct {
+	// TickRate defines the maximum amount of time between expiry & seek checks.
+	// Shorter tick rates reduce discovery delay.  Longer tick rates reduce resource
+	// consumption (default: ~4s).
+	TickRate time.Duration
+	// EntryExpiry defines how long a seeker entry should be held without successfully
+	// establishing a healthy connection.  This value should be reasonably long
+	// (default: 3m).
+	EntryExpiry time.Duration
+	// BackoffInterval defines the basline backoff amount observed by seekers.  This value
+	// should be reasonably short (default: 256ms)
+	BackoffInterval time.Duration
+	// BackoffThreshold defines the minimum amount of time that a connection is expected to last
+	// if the conencted peer is generally healthy.  Connections which fail before BackoffThreshold
+	// cause the seekstate to enter backoff (default: 30s)
+	BackoffThreshold time.Duration
+}
+
+func (s *Config) Check() error {
+	if s.TickRate < time.Millisecond {
+		return trace.BadParameter("sub-millisecond tick-rate is not allowed")
+	}
+	if s.EntryExpiry <= 2*s.TickRate {
+		return trace.BadParameter("entry-expiry must be greater than 2x tick-rate")
+	}
+	if s.EntryExpiry <= s.BackoffInterval {
+		return trace.BadParameter("entry-expiry must be greater than backoff-interval")
+	}
+	if s.EntryExpiry <= s.BackoffThreshold {
+		return trace.BadParameter("entry-expiry must be greater than backoff-threshold")
+	}
+	return nil
+}
+
+const (
+	defaultTickRate         = time.Millisecond * 4096
+	defaultEntryExpriy      = time.Minute * 3
+	defaultBackoffInterval  = time.Millisecond * 256
+	defaultBackoffThreshold = time.Second * 30
+)
+
+func (s *Config) CheckAndSetDefaults() error {
+	const granularity = time.Millisecond
+	if s.TickRate < granularity {
+		s.TickRate = defaultTickRate
+	}
+	if s.EntryExpiry < granularity {
+		s.EntryExpiry = defaultEntryExpriy
+	}
+	if s.BackoffInterval < granularity {
+		s.BackoffInterval = defaultBackoffInterval
+	}
+	if s.BackoffThreshold < granularity {
+		s.BackoffThreshold = defaultBackoffThreshold
+	}
+	return s.Check()
+}
+
+// Pool manages a collection of group-level seek operations.
+type Pool struct {
+	m      sync.Mutex
+	conf   Config
+	groups map[Key]GroupHandle
+	seekC  chan Key
+	ctx    context.Context
+}
+
+// NewPool configures a seek pool.
+func NewPool(ctx context.Context, conf Config) (*Pool, error) {
+	if err := conf.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &Pool{
+		conf:   conf,
+		groups: make(map[Key]GroupHandle),
+		seekC:  make(chan Key, 128),
+		ctx:    ctx,
+	}, nil
+}
+
+// Group gets a handle to the seek manager for the specified
+// group.  If none exists, one will be started.
+func (p *Pool) Group(key Key) GroupHandle {
+	p.m.Lock()
+	defer p.m.Unlock()
+	if group, ok := p.groups[key]; ok {
+		return group
+	}
+	group := newGroupHandle(p.ctx, p.conf, p.seekC, key)
+	p.groups[key] = group
+	return group
+}
+
+// Seek channel yields stream of keys indicating which groups
+// are seeking.
+func (p *Pool) Seek() <-chan Key {
+	return p.seekC
+}
+
+// Stop stops one or more group-level seek operations
+func (p *Pool) Stop(group Key, groups ...Key) {
+	p.m.Lock()
+	defer p.m.Unlock()
+	p.stopGroupHandle(group)
+	for _, g := range groups {
+		p.stopGroupHandle(g)
+	}
+}
+
+// Shutdown stops all seek operations
+func (p *Pool) Shutdown() {
+	p.m.Lock()
+	defer p.m.Unlock()
+	for g, _ := range p.groups {
+		p.stopGroupHandle(g)
+	}
+}
+
+func (p *Pool) stopGroupHandle(key Key) {
+	group, ok := p.groups[key]
+	if !ok {
+		return
+	}
+	group.cancel()
+	delete(p.groups, key)
+}
+
+// GroupHandle is a handle to an ongoing seek process.  Each seek process
+// manages a group of related proxies.  This handle allows agents to
+// claim exclusive "locks" for individual proxies and to broadcast
+// gossip to the process.
+type GroupHandle struct {
+	inner  *proxyGroup
+	cancel context.CancelFunc
+	proxyC chan<- string
+	seekC  <-chan Key
+	statC  <-chan Status
+}
+
+func newGroupHandle(ctx context.Context, conf Config, seekC chan Key, id Key) GroupHandle {
+	ctx, cancel := context.WithCancel(ctx)
+	proxyC := make(chan string, 128)
+	statC := make(chan Status, 1)
+	seekers := &proxyGroup{
+		id:     id,
+		conf:   conf,
+		states: make(map[string]seeker),
+		proxyC: proxyC,
+		seekC:  seekC,
+		statC:  statC,
+	}
+	handle := GroupHandle{
+		inner:  seekers,
+		cancel: cancel,
+		proxyC: proxyC,
+		seekC:  seekC,
+		statC:  statC,
+	}
+	go seekers.run(ctx)
+	return handle
+}
+
+// WithProxy is used to wrap the connection-handling logic of an agent,
+// ensuring that it is run if and only if no other agent is already
+// handling this proxy.
+func (s *GroupHandle) WithProxy(do func(), principals ...string) (did bool) {
+	if !s.inner.TryAcquireProxy(principals...) {
+		return false
+	}
+	defer s.inner.ReleaseProxy(principals...)
+	do()
+	return true
+}
+
+// Status channel is regularly updated with the most recent status
+// value.  Consuming status values is optional.
+func (s *GroupHandle) Status() <-chan Status {
+	return s.statC
+}
+
+// Gossip channel must be informed whenever a proxy's identity
+// becomes known via gossip messages.
+func (s *GroupHandle) Gossip() chan<- string {
+	return s.proxyC
+}
+
+// proxyGroup manages all proxy seekers for a group.
+type proxyGroup struct {
+	sync.Mutex
+	id       Key
+	conf     Config
+	states   map[string]seeker
+	proxyC   <-chan string
+	seekC    chan<- Key
+	statC    chan Status
+	lastStat *Status
+}
+
+// run is the "main loop" for the seek process.
+func (p *proxyGroup) run(ctx context.Context) {
+	ticker := time.NewTicker(p.conf.TickRate)
+	defer ticker.Stop()
+	// supply initial status & seek notification.
+	p.notifyStatus(p.Tick())
+	p.notifyShouldSeek()
+	for {
+		select {
+		case <-ticker.C:
+			stat := p.Tick()
+			p.notifyStatus(stat)
+			if stat.ShouldSeek() {
+				p.notifyShouldSeek()
+			}
+		case proxy := <-p.proxyC:
+			proxies := []string{proxy}
+			// Collect any additional proxy messages
+			// without blocking.
+		Collect:
+			for {
+				select {
+				case pr := <-p.proxyC:
+					proxies = append(proxies, pr)
+				default:
+					break Collect
+				}
+			}
+			count := p.RefreshProxy(proxies...)
+			if count > 0 {
+				p.notifyShouldSeek()
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *proxyGroup) Tick() Status {
+	p.Lock()
+	defer p.Unlock()
+	now := time.Now()
+	return p.tick(now)
+}
+
+// RefreshProxy refreshes expiration timers, returning the number of
+// successful refreshes.  If the returned value is greater than zero,
+// then at least one entry is unexpired and in `stateSeeking`.
+// Entries are lazily created for previously unknown proxies.
+func (p *proxyGroup) RefreshProxy(proxies ...string) int {
+	p.Lock()
+	defer p.Unlock()
+	now := time.Now()
+	var count int
+	for _, proxy := range proxies {
+		if p.refreshProxy(now, proxy) {
+			count++
+		}
+	}
+	return count
+}
+
+func (p *proxyGroup) refreshProxy(t time.Time, proxy string) (ok bool) {
+	s := p.states[proxy]
+	if s.transit(t, eventRefresh, &p.conf) {
+		p.states[proxy] = s
+		return true
+	}
+	return false
+}
+
+// notifyShouldSeek sets the seek channel.
+func (p *proxyGroup) notifyShouldSeek() {
+	select {
+	case p.seekC <- p.id:
+	default:
+	}
+}
+
+// notifyStatus clears and sets the status channel.
+func (p *proxyGroup) notifyStatus(s Status) {
+	select {
+	case <-p.statC:
+	default:
+	}
+	select {
+	case p.statC <- s:
+	default:
+	}
+}
+
+// AcquireProxy attempts to acquire the specified proxy.
+func (p *proxyGroup) TryAcquireProxy(principals ...string) (ok bool) {
+	p.Lock()
+	defer p.Unlock()
+	return p.acquireProxy(time.Now(), principals...)
+}
+
+// ReleaseProxy attempts to release the specified proxy.
+func (p *proxyGroup) ReleaseProxy(principals ...string) (ok bool) {
+	p.Lock()
+	defer p.Unlock()
+	return p.releaseProxy(time.Now(), principals...)
+}
+
+func (p *proxyGroup) acquireProxy(t time.Time, principals ...string) (ok bool) {
+	if len(principals) < 1 {
+		return false
+	}
+	name := p.resolveName(principals)
+	s := p.states[name]
+	if !s.transit(t, eventAcquire, &p.conf) {
+		return false
+	}
+	p.states[name] = s
+	return true
+}
+
+func (p *proxyGroup) releaseProxy(t time.Time, principals ...string) (ok bool) {
+	if len(principals) < 1 {
+		return false
+	}
+	name := p.resolveName(principals)
+	s := p.states[name]
+	if !s.transit(t, eventRelease, &p.conf) {
+		return false
+	}
+	if s.state == stateSeeking {
+		p.notifyShouldSeek()
+	}
+	p.states[name] = s
+	return true
+}
+
+func (p *proxyGroup) resolveName(principals []string) string {
+	for _, name := range principals {
+		if _, ok := p.states[name]; ok {
+			return name
+		}
+	}
+	return principals[0]
+}
+
+// tick ticks all proxy seek states, returning a summary
+// status.  This method also serves as the mechanism by which
+// expired entries are removed.
+func (p *proxyGroup) tick(t time.Time) Status {
+	var stat Status
+	for proxy, s := range p.states {
+		// if proxy seeker is in expirable state, handle
+		// the expiry.  expired seekers are removed, and
+		// the soonest future expiry is recorded in stat.
+		if exp, ok := s.expiry(p.conf.EntryExpiry); ok {
+			if t.After(exp) {
+				delete(p.states, proxy)
+				continue
+			}
+		}
+		// poll and record state of proxy seeker.
+		switch state := s.tick(t, &p.conf); state {
+		case stateSeeking:
+			stat.Seeking++
+		case stateClaimed:
+			stat.Claimed++
+		case stateBackoff:
+			stat.Backoff++
+		default:
+			// this should never happen...
+			log.Errorf("Proxy %s in invalid state %q, removing.", proxy, state)
+			delete(p.states, proxy)
+			continue
+		}
+		// seeker.tick may have affected an internal state
+		// transition, so update the entry.
+		p.states[proxy] = s
+	}
+	return stat
+}

--- a/lib/reversetunnel/seek/seek_test.go
+++ b/lib/reversetunnel/seek/seek_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package seek
+
+import (
+	"context"
+	"fmt"
+	"gopkg.in/check.v1"
+	pr "math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+type simpleTestProxies struct {
+	sync.Mutex
+	proxies []testProxy
+}
+
+func (s *simpleTestProxies) AddRandProxies(n int, min time.Duration, max time.Duration) {
+	s.Lock()
+	defer s.Unlock()
+	for i := 0; i < n; i++ {
+		proxy := newTestProxy(prDuration(min, max))
+		s.proxies = append(s.proxies, proxy)
+	}
+}
+
+func (s *simpleTestProxies) RemoveRandProxies(n int) {
+	s.Lock()
+	defer s.Unlock()
+	if len(s.proxies) <= n {
+		s.proxies = nil
+		return
+	}
+	rms := make([]bool, len(s.proxies))
+	rmc := 0
+	for rmc < n {
+		i := pr.Int() % len(s.proxies)
+		if !rms[i] {
+			rms[i] = true
+			rmc++
+		}
+	}
+	filtered := make([]testProxy, 0, len(s.proxies)-n)
+	for i, p := range s.proxies {
+		if !rms[i] {
+			filtered = append(filtered, p)
+		}
+	}
+	s.proxies = filtered
+}
+
+func (s *simpleTestProxies) GetRandProxy() (p testProxy, ok bool) {
+	s.Lock()
+	defer s.Unlock()
+	if len(s.proxies) < 1 {
+		ok = false
+		return
+	}
+	i := pr.Int() % len(s.proxies)
+	return s.proxies[i], true
+}
+
+func (s *simpleTestProxies) Discover(handle GroupHandle) (ok bool) {
+	proxy, ok := s.GetRandProxy()
+	if !ok {
+		panic("discovery called with no available proxies")
+	}
+	timeout := time.After(proxy.life)
+	ok = handle.WithProxy(func() {
+		ticker := time.NewTicker(jitter(time.Millisecond * 256))
+	Loop:
+		for {
+			select {
+			case <-ticker.C:
+				if p, ok := s.GetRandProxy(); ok {
+					handle.Gossip() <- p.principals[0]
+				}
+			case <-timeout:
+				break Loop
+			}
+		}
+	}, proxy.principals...)
+	return
+}
+
+type testProxy struct {
+	principals []string
+	life       time.Duration
+}
+
+func newTestProxy(life time.Duration) testProxy {
+	principals := make([]string, 0, 3)
+	for i := 0; i < 3; i++ {
+		p := fmt.Sprintf("proxy-%d", pr.Int())
+		principals = append(principals, p)
+	}
+	return testProxy{principals, life}
+}
+
+// prMillis generates a pseudorandom duration
+// of [0,max) milliseconds.
+func prMillis(min int64, max int64) time.Duration {
+	n := time.Duration(pr.Int63n(max-min) + min)
+	return n * time.Millisecond
+}
+
+func prDuration(min time.Duration, max time.Duration) time.Duration {
+	mn, mx := int64(min), int64(max)
+	rslt := pr.Int63n(mx-mn) + mn
+	return time.Duration(rslt)
+}
+
+func jitter(t time.Duration) time.Duration {
+	maxJitter := t / 5
+	baseJitter := time.Duration(pr.Uint64())
+	j := baseJitter % maxJitter
+	return t + j
+}
+
+func Test(t *testing.T) {
+	pr.Seed(time.Now().UnixNano())
+	check.TestingT(t)
+}
+
+type StateSuite struct{}
+
+var _ = check.Suite(&StateSuite{})
+
+func (s *StateSuite) TestBasicHealthy(c *check.C) {
+	s.runBasicProxyTest(c, time.Second*16, false)
+}
+
+func (s *StateSuite) TestBasicUnhealthy(c *check.C) {
+	s.runBasicProxyTest(c, time.Second*16, true)
+}
+
+func (s *StateSuite) runBasicProxyTest(c *check.C, timeout time.Duration, allowUnhealthy bool) {
+	const proxyCount = 16
+	timeoutC := time.After(timeout)
+	conf := newConfigOK(jitter(time.Millisecond * 512))
+	pool, err := NewPool(context.TODO(), conf)
+	c.Assert(err, check.IsNil)
+	defer pool.Shutdown()
+	handle := pool.Group(Key{Cluster: "test-cluster"})
+	min, max := time.Duration(0), timeout
+	if !allowUnhealthy {
+		min = conf.BackoffThreshold
+	}
+	if max <= min {
+		min = timeout
+		max = timeout + time.Millisecond
+	}
+	var proxies simpleTestProxies
+	proxies.AddRandProxies(proxyCount, min, max)
+Discover:
+	for {
+		select {
+		case <-pool.Seek():
+			go proxies.Discover(handle)
+		case status := <-handle.Status():
+			c.Logf("Status: %+v", status)
+			if status.Sum() == proxyCount {
+				break Discover
+			}
+		case <-timeoutC:
+			panic("timeout")
+		}
+	}
+}
+
+func (s *StateSuite) TestFullRotation(c *check.C) {
+	const (
+		proxyCount = 8
+		minConnA   = time.Second * 2
+		maxConnA   = time.Second * 3
+		minConnB   = time.Second * 24
+		maxConnB   = time.Second * 25
+		timeout    = time.Second * 30
+	)
+	var proxies simpleTestProxies
+	proxies.AddRandProxies(proxyCount, minConnA, maxConnA)
+	conf := newConfigOK(jitter(time.Millisecond * 128))
+	pool, err := NewPool(context.TODO(), conf)
+	c.Assert(err, check.IsNil)
+	defer pool.Shutdown()
+	handle := pool.Group(Key{Cluster: "test-cluster"})
+	timeoutC := time.After(timeout)
+Loop0:
+	for {
+		select {
+		case key := <-pool.Seek():
+			c.Assert(key, check.DeepEquals, Key{Cluster: "test-cluster"})
+			go proxies.Discover(handle)
+		case status := <-handle.Status():
+			c.Logf("Status0: %+v", status)
+			if status.Sum() == proxyCount {
+				break Loop0
+			}
+		case <-timeoutC:
+			panic("timeout")
+		}
+	}
+	proxies.RemoveRandProxies(proxyCount)
+Loop1:
+	for {
+		select {
+		case status := <-handle.Status():
+			c.Logf("Status1: %+v", status)
+			if status.Claimed < 1 {
+				break Loop1
+			}
+		case <-timeoutC:
+			panic("timeout")
+		}
+	}
+	proxies.AddRandProxies(proxyCount, minConnB, maxConnB)
+Loop2:
+	for {
+		select {
+		case <-pool.Seek():
+			go proxies.Discover(handle)
+		case status := <-handle.Status():
+			c.Logf("Status2: %+v", status)
+			if status.Claimed >= proxyCount {
+				break Loop2
+			}
+		case <-timeoutC:
+			panic("timeout")
+		}
+	}
+}
+
+func (s *StateSuite) BenchmarkBasicSeek(c *check.C) {
+	const proxyCount = 32
+	var proxies simpleTestProxies
+	proxies.AddRandProxies(proxyCount, time.Second*16, time.Second*32)
+	conf := newConfigOK(time.Millisecond * 512)
+	pool, err := NewPool(context.TODO(), conf)
+	c.Assert(err, check.IsNil)
+	defer pool.Shutdown()
+	for i := 0; i < c.N; i++ {
+		key := Key{Cluster: fmt.Sprintf("cluster-%d", i)}
+		handle := pool.Group(key)
+	Discover:
+		for {
+			select {
+			case <-pool.Seek():
+				go proxies.Discover(handle)
+			case status := <-handle.Status():
+				c.Logf("Status: %+v", status)
+				if status.Sum() == proxyCount {
+					break Discover
+				}
+			}
+		}
+		pool.Stop(key)
+	}
+}
+
+func newConfigOK(tickRate time.Duration) Config {
+	conf := Config{
+		TickRate:         tickRate,
+		EntryExpiry:      tickRate * 180,
+		BackoffInterval:  tickRate / 4,
+		BackoffThreshold: tickRate * 30,
+	}
+	if err := conf.Check(); err != nil {
+		panic(err)
+	}
+	return conf
+}

--- a/lib/reversetunnel/seek/state.go
+++ b/lib/reversetunnel/seek/state.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package seek
+
+import (
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// seekState represents the state of a seeker.
+type seekState uint
+
+const (
+	// stateSeeking indicates that we want to connect to this proxy
+	stateSeeking seekState = iota
+	// stateClaimed indicates that an agent has successfully claimed
+	// responsibility for this proxy
+	stateClaimed
+	// stateBackoff indicates that this proxy was claimed but that the
+	// agent responsible for it lost the connection prematurely
+	stateBackoff
+)
+
+func (s seekState) String() string {
+	switch s {
+	case stateSeeking:
+		return "seeking"
+	case stateClaimed:
+		return "claimed"
+	case stateBackoff:
+		return "backoff"
+	default:
+		return fmt.Sprintf("unknown(%d)", s)
+	}
+}
+
+// seekEvent represents an asynchronous event which may change
+// the state of a seeker.
+type seekEvent uint
+
+const (
+	// eventRefresh indicates that a proxy has been indirectly observed (e.g. via gossip).
+	eventRefresh seekEvent = iota
+	// eventAcquire indicates that an agent has connected to this proxy and would like to
+	// take responsibility for it.
+	eventAcquire
+	// eventRelease indicates that the agent responsible for this proxy has lost its
+	// connection to it.
+	eventRelease
+)
+
+func (s seekEvent) String() string {
+	switch s {
+	case eventRefresh:
+		return "refresh"
+	case eventAcquire:
+		return "acquire"
+	case eventRelease:
+		return "release"
+	default:
+		return fmt.Sprintf("unknown(%d)", s)
+	}
+}
+
+// seeker manages the state associated with a proxy.
+type seeker struct {
+	state   seekState
+	at      time.Time
+	backOff uint64
+}
+
+// transit attempts a state transition.  If transit returns true, then
+// a state-transition did occur.
+func (s *seeker) transit(t time.Time, e seekEvent, c *Config) (ok bool) {
+	switch s.state {
+	case stateSeeking:
+		// stateSeeking can either transition to stateClaimed, or
+		// be "refreshed" in order to prevent expiration.
+		switch e {
+		case eventRefresh:
+			if t.After(s.at) {
+				s.at = t
+				return true
+			} else {
+				return false
+			}
+		case eventAcquire:
+			s.state = stateClaimed
+			s.at = t
+			return true
+		case eventRelease:
+			return false
+		default:
+			log.Errorf("Invalid event: %q", e)
+			return false
+		}
+	case stateClaimed:
+		// stateClaimed can either transition into stateSeeking or
+		// stateBackoff depending on whether the claim failed
+		// immediately, or after some period of normal operation.
+		switch e {
+		case eventRefresh, eventAcquire:
+			return false
+		case eventRelease:
+			// If the release event comes within the backoff threshold
+			// then we are potentially dealing with an unhealthy proxy.
+			// The backoff state serves as both backpressure and an
+			// an escape hatch, preventing infinite retry loops.
+			if s.shouldBackoff(t, c.BackoffThreshold) {
+				s.state = stateBackoff
+				s.backOff++
+			} else {
+				s.state = stateSeeking
+				s.backOff = 0
+			}
+			s.at = t
+			return true
+		default:
+			log.Errorf("Invalid event: %q", e)
+			return false
+		}
+	case stateBackoff:
+		// stateBackoff effectively "becomes" stateSeeking
+		// once the backoff period has been observed, so we
+		// either reject all transitions if still within the
+		// backoff period, or accept both stateSeeking and
+		// stateClaimed.
+		switch e {
+		case eventRefresh:
+			if !s.backoffPassed(t, c.BackoffInterval) {
+				return false
+			}
+			s.state = stateSeeking
+			s.at = t
+			return true
+		case eventAcquire:
+			if !s.backoffPassed(t, c.BackoffInterval) {
+				return false
+			}
+			s.state = stateClaimed
+			s.at = t
+			return true
+		case eventRelease:
+			return false
+		default:
+			log.Errorf("Invalid event: %q", e)
+			return false
+		}
+	default:
+		log.Errorf("Invalid state: %q", s.state)
+		return false
+	}
+}
+
+func (s *seeker) backoffPassed(t time.Time, interval time.Duration) bool {
+	end := s.at.Add(interval * time.Duration(s.backOff))
+	return t.After(end)
+}
+
+func (s *seeker) shouldBackoff(t time.Time, threshold time.Duration) bool {
+	cutoff := s.at.Add(threshold)
+	return cutoff.After(t)
+}
+
+// expiry calculates the time at which this entry will expire,
+// if it should be expired at all.
+func (s *seeker) expiry(ttl time.Duration) (exp time.Time, ok bool) {
+	switch s.state {
+	case stateSeeking, stateBackoff:
+		// calculate normal expiry
+		exp = s.at.Add(ttl)
+		ok = true
+	case stateClaimed:
+		// wait for release
+		ok = false
+	default:
+		// invalid, expire entry immediately
+		ok = true
+	}
+	return
+}
+
+// tick calculates the current state, possibly affecting
+// a time-based transition.
+func (s *seeker) tick(t time.Time, c *Config) seekState {
+	if s.state == stateBackoff && s.backoffPassed(t, c.BackoffInterval) {
+		s.state = stateSeeking
+	}
+	return s.state
+}
+
+// Status is a summary of the status of a collection
+// of proxy seek states.
+type Status struct {
+	Seeking int
+	Claimed int
+	Backoff int
+}
+
+// ShouldSeek checks if we should be seeking connections.
+func (s *Status) ShouldSeek() bool {
+	// if we are seeking specific proxies, or we don't currently
+	// have any proxies, then we should seek proxies.
+	if s.Seeking > 0 || s.Claimed < 1 {
+		return true
+	}
+	return false
+}
+
+// Sum returns the sum of all known proxies.
+func (s *Status) Sum() int {
+	if s == nil {
+		return 0
+	}
+	return s.Seeking + s.Claimed + s.Backoff
+}


### PR DESCRIPTION
This commit introduces a new iteration of the proxy discovery
algorithm implemented as a separate component from the main
reversetunnel agent/agentpool system.  This isolation is
intended to improve our ability to test and reason about the
algorithm in isolation from IO and other implementation
details.

Fixes #2832 