### PR TITLE
Small Yaml Typo in Docs 

### DIFF
--- a/docs/2.4/admin-guide.md
+++ b/docs/2.4/admin-guide.md
@@ -1116,7 +1116,7 @@ providers such as Github. First, the Teleport auth service must be configured
 to use Github for authentication:
 
 ```bash
-# snippet from /etc/teleport.yaaml
+# snippet from /etc/teleport.yaml
 auth_service:
   authentication:
       type: github

--- a/docs/2.5/admin-guide.md
+++ b/docs/2.5/admin-guide.md
@@ -1265,7 +1265,7 @@ providers such as Github. First, the Teleport auth service must be configured
 to use Github for authentication:
 
 ```bash
-# snippet from /etc/teleport.yaaml
+# snippet from /etc/teleport.yaml
 auth_service:
   authentication:
       type: github

--- a/docs/2.7/admin-guide.md
+++ b/docs/2.7/admin-guide.md
@@ -1293,7 +1293,7 @@ providers such as Github. First, the Teleport auth service must be configured
 to use Github for authentication:
 
 ```bash
-# snippet from /etc/teleport.yaaml
+# snippet from /etc/teleport.yaml
 auth_service:
   authentication:
       type: github

--- a/docs/3.1/admin-guide.md
+++ b/docs/3.1/admin-guide.md
@@ -1522,7 +1522,7 @@ providers such as Github. First, the Teleport auth service must be configured
 to use Github for authentication:
 
 ```yaml
-# snippet from /etc/teleport.yaaml
+# snippet from /etc/teleport.yaml
 auth_service:
   authentication:
       type: github

--- a/docs/3.2/admin-guide.md
+++ b/docs/3.2/admin-guide.md
@@ -1508,7 +1508,7 @@ providers such as Github. First, the Teleport auth service must be configured
 to use Github for authentication:
 
 ```yaml
-# snippet from /etc/teleport.yaaml
+# snippet from /etc/teleport.yaml
 auth_service:
   authentication:
       type: github


### PR DESCRIPTION
Fixes typo in github connector as reported here #2951 