### PR TITLE
Always emit session related events with host UUID.

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -448,17 +448,14 @@ func (s *IntSuite) TestAuditOn(c *check.C) {
 		c.Assert(start.GetString(events.SessionEventID) != "", check.Equals, true)
 		c.Assert(start.GetString(events.TerminalSize) != "", check.Equals, true)
 
-		// if session are being recorded at nodes, then the event server_id field
-		// should contain the ID of the node. if sessions are being recorded at the
-		// proxy, then server_id is random so we can't check it, but it should not
-		// the server_id of any of the nodes we know about.
-		switch tt.inRecordLocation {
-		case services.RecordAtNode:
-			c.Assert(start.GetString(events.SessionServerID), check.Equals, nodeProcess.Config.HostUUID)
-		case services.RecordAtProxy:
-			c.Assert(start.GetString(events.SessionServerID), check.Not(check.Equals), nodeProcess.Config.HostUUID)
-			c.Assert(start.GetString(events.SessionServerID), check.Not(check.Equals), t.Process.Config.HostUUID)
+		// If session are being recorded at nodes, the SessionServerID should contain
+		// the ID of the node. If sessions are being recorded at the proxy, then
+		// SessionServerID should be that of the proxy.
+		expectedServerID := nodeProcess.Config.HostUUID
+		if tt.inRecordLocation == services.RecordAtProxy {
+			expectedServerID = t.Process.Config.HostUUID
 		}
+		c.Assert(start.GetString(events.SessionServerID), check.Equals, expectedServerID)
 
 		// make sure data is recorded properly
 		out := &bytes.Buffer{}

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -1938,9 +1938,9 @@ func (s *APIServer) emitAuditEvent(auth ClientI, w http.ResponseWriter, r *http.
 	}
 	err = events.ValidateEvent(req.Fields, serverID)
 	if err != nil {
-		log.Warnf("Rejecting audit event from %v: %v. System may be under attack, a "+
+		log.Warnf("Rejecting audit event %v from %v: %v. System may be under attack, a "+
 			"node is attempting to submit events for an identity other than its own.",
-			serverID, err)
+			req.Type, serverID, err)
 		return nil, trace.AccessDenied("failed to validate event")
 	}
 
@@ -1984,9 +1984,9 @@ func (s *APIServer) postSessionSlice(auth ClientI, w http.ResponseWriter, r *htt
 		}
 		err := events.ValidateEvent(f, serverID)
 		if err != nil {
-			log.Warnf("Rejecting audit event from %v: %v. System may be under attack, a "+
+			log.Warnf("Rejecting audit event %v from %v: %v. System may be under attack, a "+
 				"node is attempting to submit events for an identity other than its own.",
-				serverID, err)
+				f.GetType(), serverID, err)
 			return nil, trace.AccessDenied("failed to validate event")
 		}
 	}

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -226,6 +226,7 @@ func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		DataDir:         s.srv.Config.DataDir,
 		Address:         params.Address,
 		UseTunnel:       useTunnel,
+		HostUUID:        s.srv.ID,
 	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -562,6 +562,7 @@ func (s *remoteSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		Address:         params.Address,
 		UseTunnel:       targetConn.UseTunnel(),
 		FIPS:            s.srv.FIPS,
+		HostUUID:        s.srv.ID,
 	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1582,7 +1582,7 @@ type userGetter struct {
 	traits map[string][]string
 }
 
-func (f *userGetter) GetUser(name string) (User, error) {
+func (f *userGetter) GetUser(name string, secrets bool) (User, error) {
 	user, err := NewUser(name)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -71,6 +71,10 @@ type Server interface {
 	// ID is the unique ID of the server.
 	ID() string
 
+	// HostUUID is the UUID of the underlying host. For the the forwarding
+	// server this is the proxy the forwarding server is running in.
+	HostUUID() string
+
 	// GetNamespace returns the namespace the server was created in.
 	GetNamespace() string
 
@@ -487,7 +491,7 @@ func (c *ServerContext) reportStats(conn utils.Stater) {
 	eventFields := events.EventFields{
 		events.DataTransmitted: rxBytes,
 		events.DataReceived:    txBytes,
-		events.SessionServerID: c.GetServer().ID(),
+		events.SessionServerID: c.GetServer().HostUUID(),
 		events.EventLogin:      c.Identity.Login,
 		events.EventUser:       c.Identity.TeleportUser,
 		events.RemoteAddr:      c.Conn.RemoteAddr().String(),

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -320,6 +320,10 @@ func (f *fakeServer) ID() string {
 	return f.id
 }
 
+func (f *fakeServer) HostUUID() string {
+	return f.id
+}
+
 func (f *fakeServer) GetNamespace() string {
 	return ""
 }

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -134,6 +134,10 @@ type Server struct {
 	closeCancel  context.CancelFunc
 
 	clock clockwork.Clock
+
+	// hostUUID is the UUID of the underlying proxy that the forwarding server
+	// is running in.
+	hostUUID string
 }
 
 // ServerConfig is the configuration needed to create an instance of a Server.
@@ -172,6 +176,10 @@ type ServerConfig struct {
 	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
 	// configuration.
 	FIPS bool
+
+	// HostUUID is the UUID of the underlying proxy that the forwarding server
+	// is running in.
+	HostUUID string
 }
 
 // CheckDefaults makes sure all required parameters are passed in.
@@ -242,6 +250,7 @@ func New(c ServerConfig) (*Server, error) {
 		sessionServer:   c.AuthClient,
 		dataDir:         c.DataDir,
 		clock:           c.Clock,
+		hostUUID:        c.HostUUID,
 	}
 
 	// Set the ciphers, KEX, and MACs that the in-memory server will send to the
@@ -288,6 +297,12 @@ func (s *Server) GetDataDir() string {
 // ID returns the ID of the proxy that creates the in-memory forwarding server.
 func (s *Server) ID() string {
 	return s.id
+}
+
+// HostUUID is the UUID of the underlying proxy that the forwarding server
+// is running in.
+func (s *Server) HostUUID() string {
+	return s.hostUUID
 }
 
 // GetNamespace returns the namespace the forwarding server resides in.

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -567,6 +567,12 @@ func (s *Server) ID() string {
 	return s.uuid
 }
 
+// HostUUID is the ID of the server. This value is the same as ID, it is
+// different from the forwarding server.
+func (s *Server) HostUUID() string {
+	return s.uuid
+}
+
 // PermitUserEnvironment returns if ~/.tsh/environment will be read before a
 // session is created by this server.
 func (s *Server) PermitUserEnvironment() bool {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -120,7 +120,7 @@ func (s *SessionRegistry) emitSessionJoinEvent(ctx *ServerContext) {
 		events.EventLogin:      ctx.Identity.Login,
 		events.EventUser:       ctx.Identity.TeleportUser,
 		events.RemoteAddr:      ctx.Conn.RemoteAddr().String(),
-		events.SessionServerID: ctx.srv.ID(),
+		events.SessionServerID: ctx.srv.HostUUID(),
 	}
 	// Local address only makes sense for non-tunnel nodes.
 	if !ctx.srv.UseTunnel() {
@@ -194,7 +194,7 @@ func (s *SessionRegistry) emitSessionLeaveEvent(party *party) {
 		events.EventType:       events.SessionLeaveEvent,
 		events.SessionEventID:  party.id.String(),
 		events.EventUser:       party.user,
-		events.SessionServerID: party.serverID,
+		events.SessionServerID: party.ctx.srv.HostUUID(),
 		events.EventNamespace:  s.srv.GetNamespace(),
 	}
 
@@ -257,7 +257,7 @@ func (s *SessionRegistry) leaveSession(party *party) error {
 		// send an event indicating that this session has ended
 		sess.recorder.GetAuditLog().EmitAuditEvent(events.SessionEnd, events.EventFields{
 			events.SessionEventID:  string(sess.id),
-			events.SessionServerID: party.ctx.srv.ID(),
+			events.SessionServerID: party.ctx.srv.HostUUID(),
 			events.EventUser:       party.user,
 			events.EventNamespace:  s.srv.GetNamespace(),
 		})
@@ -318,7 +318,7 @@ func (s *SessionRegistry) NotifyWinChange(params rsession.TerminalParams, ctx *S
 		events.EventType:       events.ResizeEvent,
 		events.EventNamespace:  s.srv.GetNamespace(),
 		events.SessionEventID:  sid,
-		events.SessionServerID: ctx.srv.ID(),
+		events.SessionServerID: ctx.srv.HostUUID(),
 		events.EventLogin:      ctx.Identity.Login,
 		events.EventUser:       ctx.Identity.TeleportUser,
 		events.TerminalSize:    params.Serialize(),
@@ -616,7 +616,7 @@ func (s *session) start(ch ssh.Channel, ctx *ServerContext) error {
 	eventFields := events.EventFields{
 		events.EventNamespace:  ctx.srv.GetNamespace(),
 		events.SessionEventID:  string(s.id),
-		events.SessionServerID: ctx.srv.ID(),
+		events.SessionServerID: ctx.srv.HostUUID(),
 		events.EventLogin:      ctx.Identity.Login,
 		events.EventUser:       ctx.Identity.TeleportUser,
 		events.RemoteAddr:      ctx.Conn.RemoteAddr().String(),


### PR DESCRIPTION
**Description**

When emitting session related events, emit them with the ID of the host not of the server. This is because the forwarding server has a randomly generated ID that will note validate with TLS identity that connects to the Auth Server.