### PR TITLE
Use JSON for trait encoding.

### DIFF
--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/wrappers"
 
 	"github.com/gravitational/trace"
 
@@ -273,7 +274,7 @@ func (k *Keygen) GenerateUserCert(c services.UserCertParams) ([]byte, error) {
 	// legacy SSH certificates due to a bug in OpenSSH <= OpenSSH 7.1:
 	// https://bugzilla.mindrot.org/show_bug.cgi?id=2387
 	if c.CertificateFormat == teleport.CertificateFormatStandard {
-		traits, err := c.Traits.Marshal()
+		traits, err := wrappers.MarshalTraits(&c.Traits)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -391,7 +391,7 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 	var traits wrappers.Traits
 	rawTraits, ok := cert.Extensions[teleport.CertExtensionTeleportTraits]
 	if ok {
-		err = traits.Unmarshal([]byte(rawTraits))
+		err = wrappers.UnmarshalTraits([]byte(rawTraits), &traits)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1428,7 +1428,7 @@ func extractTraitsFromCert(cert *ssh.Certificate) (wrappers.Traits, error) {
 		return nil, trace.NotFound("no traits found")
 	}
 	var traits wrappers.Traits
-	err := traits.Unmarshal([]byte(rawTraits))
+	err := wrappers.UnmarshalTraits([]byte(rawTraits), &traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -99,7 +99,7 @@ func (i *Identity) CheckAndSetDefaults() error {
 
 // Subject converts identity to X.509 subject name
 func (id *Identity) Subject() (pkix.Name, error) {
-	rawTraits, err := id.Traits.Marshal()
+	rawTraits, err := wrappers.MarshalTraits(&id.Traits)
 	if err != nil {
 		return pkix.Name{}, trace.Wrap(err)
 	}
@@ -131,7 +131,7 @@ func FromSubject(subject pkix.Name, expires time.Time) (*Identity, error) {
 		i.RouteToCluster = subject.StreetAddress[0]
 	}
 	if len(subject.PostalCode) > 0 {
-		err := i.Traits.Unmarshal([]byte(subject.PostalCode[0]))
+		err := wrappers.UnmarshalTraits([]byte(subject.PostalCode[0]), &i.Traits)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -206,7 +206,7 @@ func (ca *CertAuthority) GenerateCertificate(req CertificateRequest) ([]byte, er
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		// BasicConstraintsValid is true to not allow any intermediate certs.
 		BasicConstraintsValid: true,
-		IsCA: false,
+		IsCA:                  false,
 	}
 
 	// sort out principals into DNS names and IP addresses

--- a/lib/wrappers/wrappers.go
+++ b/lib/wrappers/wrappers.go
@@ -41,6 +41,22 @@ func (l Traits) protoType() *LabelValues {
 	return v
 }
 
+// MarshalTraits will marshal Traits as JSON. Used to embed traits into
+// certificates.
+func MarshalTraits(traits *Traits) ([]byte, error) {
+	return json.Marshal(traits)
+}
+
+// UnmarshalTraits will unmarshal JSON traits. Used to embed traits into
+// certificates.
+func UnmarshalTraits(data []byte, traits *Traits) error {
+	err := json.Unmarshal(data, traits)
+	if err != nil {
+		return traits.Unmarshal(data)
+	}
+	return nil
+}
+
 // Marshal marshals value into protobuf representation
 func (l Traits) Marshal() ([]byte, error) {
 	return proto.Marshal(l.protoType())

--- a/lib/wrappers/wrappers_test.go
+++ b/lib/wrappers/wrappers_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wrappers
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/utils"
+
+	"gopkg.in/check.v1"
+)
+
+type WrappersSuite struct{}
+
+var _ = fmt.Printf
+var _ = check.Suite(&WrappersSuite{})
+
+func TestWrappers(t *testing.T) { check.TestingT(t) }
+
+func (s *WrappersSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests()
+}
+func (s *WrappersSuite) TearDownSuite(c *check.C) {}
+func (s *WrappersSuite) SetUpTest(c *check.C)     {}
+func (s *WrappersSuite) TearDownTest(c *check.C)  {}
+
+func (s *WrappersSuite) TestUnmarshalBackwards(c *check.C) {
+	var traits Traits
+
+	// Attempt to unmarshal protobuf encoded data.
+	protoBytes := "0a120a066c6f67696e7312080a06666f6f6261720a150a116b756265726e657465735f67726f7570731200"
+	data, err := hex.DecodeString(protoBytes)
+	c.Assert(err, check.IsNil)
+	err = UnmarshalTraits(data, &traits)
+	c.Assert(err, check.IsNil)
+	c.Assert(traits["logins"], check.DeepEquals, []string{"foobar"})
+
+	// Attempt to unmarshal JSON encoded data.
+	jsonBytes := `{"logins": ["foobar"]}`
+	err = UnmarshalTraits([]byte(jsonBytes), &traits)
+	c.Assert(err, check.IsNil)
+	c.Assert(traits["logins"], check.DeepEquals, []string{"foobar"})
+}


### PR DESCRIPTION
**Description**

Use JSON for trait encoding. Fallback to protobuf.