### PR TITLE
fix duplicate seek entries.

### DIFF
--- a/lib/reversetunnel/seek/seek.go
+++ b/lib/reversetunnel/seek/seek.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
+	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -235,11 +236,13 @@ type proxyGroup struct {
 
 // run is the "main loop" for the seek process.
 func (p *proxyGroup) run(ctx context.Context) {
+	const logInterval int = 8
 	ticker := time.NewTicker(p.conf.TickRate)
 	defer ticker.Stop()
 	// supply initial status & seek notification.
 	p.notifyStatus(p.Tick())
 	p.notifyShouldSeek()
+	var ticks int
 	for {
 		select {
 		case <-ticker.C:
@@ -247,6 +250,10 @@ func (p *proxyGroup) run(ctx context.Context) {
 			p.notifyStatus(stat)
 			if stat.ShouldSeek() {
 				p.notifyShouldSeek()
+			}
+			ticks++
+			if ticks%logInterval == 0 {
+				log.Debugf("SeekStates(states=%+v,id=%s)", p.GetStates(), p.id)
 			}
 		case proxy := <-p.proxyC:
 			proxies := []string{proxy}
@@ -368,12 +375,28 @@ func (p *proxyGroup) releaseProxy(t time.Time, principals ...string) (ok bool) {
 }
 
 func (p *proxyGroup) resolveName(principals []string) string {
+	const uuidSize int = 36
 	for _, name := range principals {
+		if len(name) >= uuidSize {
+			if uuid.Parse(name[:uuidSize]) != nil {
+				return name[:uuidSize]
+			}
+		}
 		if _, ok := p.states[name]; ok {
 			return name
 		}
 	}
 	return principals[0]
+}
+
+func (p *proxyGroup) GetStates() map[string]seekState {
+	p.Lock()
+	defer p.Unlock()
+	collector := make(map[string]seekState, len(p.states))
+	for proxy, s := range p.states {
+		collector[proxy] = s.state
+	}
+	return collector
 }
 
 // tick ticks all proxy seek states, returning a summary


### PR DESCRIPTION
Preferentially extract and use UUIDs when identifying proxies based on their principals, preventing common issue where entries `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` and `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.clustername` are both created.

Fixes #2987 