### PR TITLE
fix web sessions ID compatibility

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1502,7 +1502,9 @@ func (h *Handler) siteSessionGenerate(w http.ResponseWriter, r *http.Request, p 
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	req.Session.ID = session.NewID()
+
+	// DELETE IN 4.2: change from session.NewLegacyID() to session.NewID().
+	req.Session.ID = session.NewLegacyID()
 	req.Session.Created = time.Now().UTC()
 	req.Session.LastActive = time.Now().UTC()
 	req.Session.Namespace = namespace

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -57,7 +57,6 @@ type SessionContext struct {
 	remoteClt map[string]auth.ClientI
 	parent    *sessionCache
 	closers   []io.Closer
-	tc        *client.TeleportClient
 }
 
 func (c *SessionContext) AddClosers(closers ...io.Closer) {


### PR DESCRIPTION
Use legacy IDs when generating session IDs for web client.  The version-request mechanism used elsewhere doesn't cover this case since frontend requests a session ID *before* dialing node.
