### PR TITLE
Trusted cluster YAML fix during testing.

### DIFF
--- a/docs/3.0/trustedclusters.md
+++ b/docs/3.0/trustedclusters.md
@@ -155,17 +155,17 @@ First, we need to create a special role for main users on "east":
 ```yaml
 # save this into main-user-role.yaml on the east cluster and execute:
 # tctl create main-user-role.yaml
-- kind: role
-  version: v3
-  metadata:
-    name: local-admin
-  spec:
-    allow:
-      node_labels:
-        '*': '*'
-    deny:
-      node_labels:
-        "environment": "production"
+kind: role
+version: v3
+metadata:
+  name: local-admin
+spec:
+  allow:
+    node_labels:
+      '*': '*'
+  deny:
+    node_labels:
+      "environment": "production"
 ```
 
 Now, we need to establish trust between roles "main:admin" and "east:local-admin". This is

--- a/docs/3.1/trustedclusters.md
+++ b/docs/3.1/trustedclusters.md
@@ -155,17 +155,17 @@ First, we need to create a special role for main users on "east":
 ```yaml
 # save this into main-user-role.yaml on the east cluster and execute:
 # tctl create main-user-role.yaml
-- kind: role
-  version: v3
-  metadata:
-    name: local-admin
-  spec:
-    allow:
-      node_labels:
-        '*': '*'
-    deny:
-      node_labels:
-        "environment": "production"
+kind: role
+version: v3
+metadata:
+  name: local-admin
+spec:
+  allow:
+    node_labels:
+      '*': '*'
+  deny:
+    node_labels:
+      "environment": "production"
 ```
 
 Now, we need to establish trust between roles "main:admin" and "east:local-admin". This is

--- a/docs/3.2/trustedclusters.md
+++ b/docs/3.2/trustedclusters.md
@@ -188,17 +188,17 @@ First, we need to create a special role for main users on "east":
 ```yaml
 # save this into main-user-role.yaml on the east cluster and execute:
 # tctl create main-user-role.yaml
-- kind: role
-  version: v3
-  metadata:
-    name: local-admin
-  spec:
-    allow:
-      node_labels:
-        '*': '*'
-    deny:
-      node_labels:
-        "environment": "production"
+kind: role
+version: v3
+metadata:
+  name: local-admin
+spec:
+  allow:
+    node_labels:
+      '*': '*'
+  deny:
+    node_labels:
+      "environment": "production"
 ```
 
 Now, we need to establish trust between roles "main:admin" and "east:local-admin". This is

--- a/docs/4.0/trustedclusters.md
+++ b/docs/4.0/trustedclusters.md
@@ -161,17 +161,17 @@ First, we need to create a special role for main users on "east":
 ```yaml
 # save this into main-user-role.yaml on the east cluster and execute:
 # tctl create main-user-role.yaml
-- kind: role
-  version: v3
-  metadata:
-    name: local-admin
-  spec:
-    allow:
-      node_labels:
-        '*': '*'
-    deny:
-      node_labels:
-        "environment": "production"
+kind: role
+version: v3
+metadata:
+  name: local-admin
+spec:
+  allow:
+    node_labels:
+      '*': '*'
+  deny:
+    node_labels:
+      "environment": "production"
 ```
 
 Now, we need to establish trust between roles "main:admin" and "east:local-admin". This is


### PR DESCRIPTION
Fixes yaml example, if copied and pasted it would throw an error. `Original Error: yaml.YAMLSyntaxError error unmarshaling JSON: json: cannot unmarshal array into Go value of type services.ResourceHeader` due to the extra `-`