### PR TITLE
Fix more options for Okta

### DIFF
--- a/docs/2.0/saml.md
+++ b/docs/2.0/saml.md
@@ -56,6 +56,22 @@ We are going to create groups `okta-dev` and `okta-admin`:
 We are going to map these Okta groups to SAML Attribute statements (special signed metadata
 exposed via SAML XML response).
 
+GENERAL
+
+- Single sign on URL `https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
+
+GROUP ATTRIBUTE STATEMENTS
+
+- Name: `groups` | Name format: `Unspecified`
+
+-  Filter: `Matches regex` |  `.*`
+
 ![Configure APP](img/okta-saml-3.png)
 
 **Notice:** We have set NameID to email format and mappped groups with wildcard regex in Group Attribute statements.

--- a/docs/2.3/saml.md
+++ b/docs/2.3/saml.md
@@ -51,6 +51,22 @@ We are going to create two groups: "okta-dev" and "okta-admin":
 We are going to map the Okta groups we've created above to the SAML Attribute
 statements (special signed metadata exposed via a SAML XML response).
 
+GENERAL
+
+- Single sign on URL `https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
+
+GROUP ATTRIBUTE STATEMENTS
+
+- Name: `groups` | Name format: `Unspecified`
+
+-  Filter: `Matches regex` |  `.*`
+
 ![Configure APP](img/okta-saml-3.png)
 
 !!! tip "Important":

--- a/docs/2.4/saml.md
+++ b/docs/2.4/saml.md
@@ -51,6 +51,22 @@ We are going to create two groups: "okta-dev" and "okta-admin":
 We are going to map the Okta groups we've created above to the SAML Attribute
 statements (special signed metadata exposed via a SAML XML response).
 
+GENERAL
+
+- Single sign on URL `https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
+
+GROUP ATTRIBUTE STATEMENTS
+
+- Name: `groups` | Name format: `Unspecified`
+
+-  Filter: `Matches regex` |  `.*`
+
 ![Configure APP](img/okta-saml-3.png)
 
 !!! tip "Important":

--- a/docs/2.5/ssh_okta.md
+++ b/docs/2.5/ssh_okta.md
@@ -47,6 +47,22 @@ We are going to create two groups: "okta-dev" and "okta-admin":
 We are going to map the Okta groups we've created above to the SAML Attribute
 statements (special signed metadata exposed via a SAML XML response).
 
+GENERAL
+
+- Single sign on URL `https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
+
+GROUP ATTRIBUTE STATEMENTS
+
+- Name: `groups` | Name format: `Unspecified`
+
+-  Filter: `Matches regex` |  `.*`
+
 ![Configure APP](img/okta-saml-3.png)
 
 !!! tip "Important":

--- a/docs/2.7/ssh_okta.md
+++ b/docs/2.7/ssh_okta.md
@@ -47,6 +47,22 @@ We are going to create two groups: "okta-dev" and "okta-admin":
 We are going to map the Okta groups we've created above to the SAML Attribute
 statements (special signed metadata exposed via a SAML XML response).
 
+GENERAL
+
+- Single sign on URL `https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
+
+GROUP ATTRIBUTE STATEMENTS
+
+- Name: `groups` | Name format: `Unspecified`
+
+-  Filter: `Matches regex` |  `.*`
+
 ![Configure APP](img/okta-saml-3.png)
 
 !!! tip "Important":

--- a/docs/3.0/ssh_okta.md
+++ b/docs/3.0/ssh_okta.md
@@ -47,6 +47,22 @@ We are going to create two groups: "okta-dev" and "okta-admin":
 We are going to map the Okta groups we've created above to the SAML Attribute
 statements (special signed metadata exposed via a SAML XML response).
 
+GENERAL
+
+- Single sign on URL `https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
+
+GROUP ATTRIBUTE STATEMENTS
+
+- Name: `groups` | Name format: `Unspecified`
+
+-  Filter: `Matches regex` |  `.*`
+
 ![Configure APP](img/okta-saml-3.png)
 
 !!! tip "Important":

--- a/docs/3.1/ssh_okta.md
+++ b/docs/3.1/ssh_okta.md
@@ -48,6 +48,22 @@ We are going to create two groups: "okta-dev" and "okta-admin":
 We are going to map the Okta groups we've created above to the SAML Attribute
 statements (special signed metadata exposed via a SAML XML response).
 
+GENERAL
+
+- Single sign on URL `https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
+
+GROUP ATTRIBUTE STATEMENTS
+
+- Name: `groups` | Name format: `Unspecified`
+
+-  Filter: `Matches regex` |  `.*`
+
 ![Configure APP](img/okta-saml-3.png)
 
 !!! tip "Important":

--- a/docs/3.2/ssh_okta.md
+++ b/docs/3.2/ssh_okta.md
@@ -48,6 +48,22 @@ We are going to create two groups: "okta-dev" and "okta-admin":
 We are going to map the Okta groups we've created above to the SAML Attribute
 statements (special signed metadata exposed via a SAML XML response).
 
+GENERAL
+
+- Single sign on URL `https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
+
+GROUP ATTRIBUTE STATEMENTS
+
+- Name: `groups` | Name format: `Unspecified`
+
+-  Filter: `Matches regex` |  `.*`
+
 ![Configure APP](img/okta-saml-3.png)
 
 !!! tip "Important":

--- a/docs/4.0/ssh_okta.md
+++ b/docs/4.0/ssh_okta.md
@@ -48,6 +48,22 @@ We are going to create two groups: "okta-dev" and "okta-admin":
 We are going to map the Okta groups we've created above to the SAML Attribute
 statements (special signed metadata exposed via a SAML XML response).
 
+GENERAL
+
+- Single sign on URL `https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Audience URI (SP Entity ID)`https://teleport-proxy.example.com:3080/v1/webapi/saml/acs`
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
+
+GROUP ATTRIBUTE STATEMENTS
+
+- Name: `groups` | Name format: `Unspecified`
+
+-  Filter: `Matches regex` |  `.*`
+
 ![Configure APP](img/okta-saml-3.png)
 
 !!! tip "Important":


### PR DESCRIPTION
While looking into https://github.com/gravitational/teleport/issues/3013, it turned out that the problem was that groups are RegEx and I was missing the `.`. This PR marks Okta settings easier to understand since I've provided text examples to support the screenshot. 

![image](https://user-images.githubusercontent.com/559288/65557262-80ba1080-dee7-11e9-9e43-282c2002a66d.png)
