### PR TITLE
Update ADFS docs

### DIFF
--- a/docs/2.5/ssh_adfs.md
+++ b/docs/2.5/ssh_adfs.md
@@ -111,6 +111,8 @@ spec:
   allow:
     # only allow login as either ubuntu or the username claim
     logins: [ "{{external.username}}", ubuntu ]
+    node_labels:
+      "access": "relaxed"
 ```
 
 This role declares:
@@ -132,7 +134,7 @@ metadata:
 spec:
   # display allows to set the caption of the "login" button
   # in the Web interface
-  display: "Login with MS Active Directory"
+  display: "MS Active Directory"
   provider: "adfs"
   acs: "https://localhost:3080/v1/webapi/saml/acs"
   entity_descriptor_url: "https://adfs.example.com/FederationMetadata/2007-06/FederationMetadata.xml"

--- a/docs/2.5/ssh_adfs.md
+++ b/docs/2.5/ssh_adfs.md
@@ -117,7 +117,7 @@ spec:
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.

--- a/docs/2.5/ssh_adfs.md
+++ b/docs/2.5/ssh_adfs.md
@@ -109,8 +109,8 @@ spec:
     # regular users can only be guests and their certificates will have a TTL of 1 hour:
     max_session_ttl: "1h"
   allow:
-    # only allow login as either ubuntu or the username claim
-    logins: [ "{{external.username}}", ubuntu ]
+    # only allow login as either ubuntu or the 'windowsaccountname' claim
+    logins: [ '{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
@@ -119,8 +119,8 @@ This role declares:
 
 * Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
 * Developers can log in as `ubuntu` user
-* Notice `{{external.username}}` login. It configures Teleport to look at
-  _"username"_ ADFS claim and use that field as an allowed login for each user.
+* Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
+  _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/2.5/ssh_adfs.md
+++ b/docs/2.5/ssh_adfs.md
@@ -121,6 +121,7 @@ This role declares:
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
+  Also note the double quotes (`"`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/2.7/ssh_adfs.md
+++ b/docs/2.7/ssh_adfs.md
@@ -111,6 +111,8 @@ spec:
   allow:
     # only allow login as either ubuntu or the username claim
     logins: [ "{{external.username}}", ubuntu ]
+    node_labels:
+      "access": "relaxed"
 ```
 
 This role declares:
@@ -132,7 +134,7 @@ metadata:
 spec:
   # display allows to set the caption of the "login" button
   # in the Web interface
-  display: "Login with MS Active Directory"
+  display: "MS Active Directory"
   provider: "adfs"
   acs: "https://localhost:3080/v1/webapi/saml/acs"
   entity_descriptor_url: "https://adfs.example.com/FederationMetadata/2007-06/FederationMetadata.xml"

--- a/docs/2.7/ssh_adfs.md
+++ b/docs/2.7/ssh_adfs.md
@@ -117,7 +117,7 @@ spec:
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.

--- a/docs/2.7/ssh_adfs.md
+++ b/docs/2.7/ssh_adfs.md
@@ -109,8 +109,8 @@ spec:
     # regular users can only be guests and their certificates will have a TTL of 1 hour:
     max_session_ttl: "1h"
   allow:
-    # only allow login as either ubuntu or the username claim
-    logins: [ "{{external.username}}", ubuntu ]
+    # only allow login as either ubuntu or the 'windowsaccountname' claim
+    logins: [ '{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
@@ -119,8 +119,8 @@ This role declares:
 
 * Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
 * Developers can log in as `ubuntu` user
-* Notice `{{external.username}}` login. It configures Teleport to look at
-  _"username"_ ADFS claim and use that field as an allowed login for each user.
+* Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
+  _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/2.7/ssh_adfs.md
+++ b/docs/2.7/ssh_adfs.md
@@ -121,6 +121,7 @@ This role declares:
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
+  Also note the double quotes (`"`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/3.0/ssh_adfs.md
+++ b/docs/3.0/ssh_adfs.md
@@ -109,18 +109,18 @@ spec:
     # regular users can only be guests and their certificates will have a TTL of 1 hour:
     max_session_ttl: "1h"
   allow:
-    # only allow login as either ubuntu or the username claim
-    logins: [ "{{external.username}}", ubuntu ]
+    # only allow login as either ubuntu or the 'windowsaccountname' claim
+    logins: [ '{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
 * Developers can log in as `ubuntu` user
-* Notice `{{external.username}}` login. It configures Teleport to look at
-  _"username"_ ADFS claim and use that field as an allowed login for each user.
+* Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
+  _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/3.0/ssh_adfs.md
+++ b/docs/3.0/ssh_adfs.md
@@ -111,6 +111,8 @@ spec:
   allow:
     # only allow login as either ubuntu or the username claim
     logins: [ "{{external.username}}", ubuntu ]
+    node_labels:
+      "access": "relaxed"
 ```
 
 This role declares:
@@ -132,7 +134,7 @@ metadata:
 spec:
   # display allows to set the caption of the "login" button
   # in the Web interface
-  display: "Login with MS Active Directory"
+  display: "MS Active Directory"
   provider: "adfs"
   acs: "https://localhost:3080/v1/webapi/saml/acs"
   entity_descriptor_url: "https://adfs.example.com/FederationMetadata/2007-06/FederationMetadata.xml"

--- a/docs/3.0/ssh_adfs.md
+++ b/docs/3.0/ssh_adfs.md
@@ -117,7 +117,7 @@ spec:
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.

--- a/docs/3.0/ssh_adfs.md
+++ b/docs/3.0/ssh_adfs.md
@@ -121,6 +121,7 @@ This role declares:
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
+  Also note the double quotes (`"`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/3.1/ssh_adfs.md
+++ b/docs/3.1/ssh_adfs.md
@@ -109,18 +109,18 @@ spec:
     # regular users can only be guests and their certificates will have a TTL of 1 hour:
     max_session_ttl: "1h"
   allow:
-    # only allow login as either ubuntu or the username claim
-    logins: [ "{{external.username}}", ubuntu ]
+    # only allow login as either ubuntu or the 'windowsaccountname' claim
+    logins: [ '{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
 * Developers can log in as `ubuntu` user
-* Notice `{{external.username}}` login. It configures Teleport to look at
-  _"username"_ ADFS claim and use that field as an allowed login for each user.
+* Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
+  _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/3.1/ssh_adfs.md
+++ b/docs/3.1/ssh_adfs.md
@@ -111,6 +111,8 @@ spec:
   allow:
     # only allow login as either ubuntu or the username claim
     logins: [ "{{external.username}}", ubuntu ]
+    node_labels:
+      "access": "relaxed"
 ```
 
 This role declares:
@@ -132,7 +134,7 @@ metadata:
 spec:
   # display allows to set the caption of the "login" button
   # in the Web interface
-  display: "Login with MS Active Directory"
+  display: "MS Active Directory"
   provider: "adfs"
   acs: "https://localhost:3080/v1/webapi/saml/acs"
   entity_descriptor_url: "https://adfs.example.com/FederationMetadata/2007-06/FederationMetadata.xml"

--- a/docs/3.1/ssh_adfs.md
+++ b/docs/3.1/ssh_adfs.md
@@ -117,7 +117,7 @@ spec:
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.

--- a/docs/3.1/ssh_adfs.md
+++ b/docs/3.1/ssh_adfs.md
@@ -121,6 +121,7 @@ This role declares:
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
+  Also note the double quotes (`"`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/3.2/ssh_adfs.md
+++ b/docs/3.2/ssh_adfs.md
@@ -109,18 +109,18 @@ spec:
     # regular users can only be guests and their certificates will have a TTL of 1 hour:
     max_session_ttl: "1h"
   allow:
-    # only allow login as either ubuntu or the username claim
-    logins: [ "{{external.username}}", ubuntu ]
+    # only allow login as either ubuntu or the 'windowsaccountname' claim
+    logins: [ '{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
 * Developers can log in as `ubuntu` user
-* Notice `{{external.username}}` login. It configures Teleport to look at
-  _"username"_ ADFS claim and use that field as an allowed login for each user.
+* Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
+  _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/3.2/ssh_adfs.md
+++ b/docs/3.2/ssh_adfs.md
@@ -111,6 +111,8 @@ spec:
   allow:
     # only allow login as either ubuntu or the username claim
     logins: [ "{{external.username}}", ubuntu ]
+    node_labels:
+      "access": "relaxed"
 ```
 
 This role declares:
@@ -132,7 +134,7 @@ metadata:
 spec:
   # display allows to set the caption of the "login" button
   # in the Web interface
-  display: "Login with MS Active Directory"
+  display: "MS Active Directory"
   provider: "adfs"
   acs: "https://localhost:3080/v1/webapi/saml/acs"
   entity_descriptor_url: "https://adfs.example.com/FederationMetadata/2007-06/FederationMetadata.xml"

--- a/docs/3.2/ssh_adfs.md
+++ b/docs/3.2/ssh_adfs.md
@@ -117,7 +117,7 @@ spec:
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.

--- a/docs/3.2/ssh_adfs.md
+++ b/docs/3.2/ssh_adfs.md
@@ -121,6 +121,7 @@ This role declares:
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
+  Also note the double quotes (`"`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/4.0/ssh_adfs.md
+++ b/docs/4.0/ssh_adfs.md
@@ -109,18 +109,18 @@ spec:
     # regular users can only be guests and their certificates will have a TTL of 1 hour:
     max_session_ttl: "1h"
   allow:
-    # only allow login as either ubuntu or the username claim
-    logins: [ "{{external.username}}", ubuntu ]
+    # only allow login as either ubuntu or the 'windowsaccountname' claim
+    logins: [ '{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
 * Developers can log in as `ubuntu` user
-* Notice `{{external.username}}` login. It configures Teleport to look at
-  _"username"_ ADFS claim and use that field as an allowed login for each user.
+* Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
+  _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/4.0/ssh_adfs.md
+++ b/docs/4.0/ssh_adfs.md
@@ -111,6 +111,8 @@ spec:
   allow:
     # only allow login as either ubuntu or the username claim
     logins: [ "{{external.username}}", ubuntu ]
+    node_labels:
+      "access": "relaxed"
 ```
 
 This role declares:
@@ -132,7 +134,7 @@ metadata:
 spec:
   # display allows to set the caption of the "login" button
   # in the Web interface
-  display: "Login with MS Active Directory"
+  display: "MS Active Directory"
   provider: "adfs"
   acs: "https://localhost:3080/v1/webapi/saml/acs"
   entity_descriptor_url: "https://adfs.example.com/FederationMetadata/2007-06/FederationMetadata.xml"

--- a/docs/4.0/ssh_adfs.md
+++ b/docs/4.0/ssh_adfs.md
@@ -117,7 +117,7 @@ spec:
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label. 
+* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.

--- a/docs/4.0/ssh_adfs.md
+++ b/docs/4.0/ssh_adfs.md
@@ -121,6 +121,7 @@ This role declares:
 * Developers can log in as `ubuntu` user
 * Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
+  Also note the double quotes (`"`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 


### PR DESCRIPTION
- The docs say that the user role only allows logins to nodes with the `access: relaxed` label, but there's nothing in the role to actually enforce that. Fixed it.

- The text in `display` is prepended by `Login with` in Teleport already, so "Login with MS Active Directory" is redundant and results in duplication:

![2019-09-27-165214__384x674__maim](https://user-images.githubusercontent.com/897821/65801429-7d28c280-e14f-11e9-8675-0980d6c6d7d0.png)

Fixed that too.

- I realised that we don't have an example of using a 'long-form' `http://schemas.microsoft.com/ws/2008/06/identity/claims/blahblahblah` ADFS claim format anywhere in the docs, so took the opportunity to add one.