### PR TITLE
Close access point cache on cluster disconnect. (4.0)

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -18,6 +18,9 @@ package auth
 
 import (
 	"context"
+	"io"
+
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/services"
 )
@@ -42,6 +45,8 @@ type Announcer interface {
 
 // ReadAccessPoint is an API interface implemented by a certificate authority (CA)
 type ReadAccessPoint interface {
+	// Closer closes all the resources
+	io.Closer
 	// GetReverseTunnels returns  a list of reverse tunnels
 	GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error)
 
@@ -152,6 +157,13 @@ func NewWrapper(writer AccessPoint, cache ReadAccessPoint) AccessPoint {
 type Wrapper struct {
 	ReadAccessPoint
 	Write AccessPoint
+}
+
+// Close closes all associated resources
+func (w *Wrapper) Close() error {
+	err := w.Write.Close()
+	err2 := w.ReadAccessPoint.Close()
+	return trace.NewAggregate(err, err2)
 }
 
 // UpsertNode is part of auth.AccessPoint implementation

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -169,6 +169,9 @@ func (s *remoteSite) Close() error {
 		s.connections[i].Close()
 	}
 	s.connections = []*remoteConn{}
+	if s.remoteAccessPoint != nil {
+		return s.remoteAccessPoint.Close()
+	}
 	return nil
 }
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1582,7 +1582,7 @@ type userGetter struct {
 	traits map[string][]string
 }
 
-func (f *userGetter) GetUser(name string, secrets bool) (User, error) {
+func (f *userGetter) GetUser(name string) (User, error) {
 	user, err := NewUser(name)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This commit fixes goroutine leak - whenever
a leaf cluster disconnects from the root cluster,
the caching access point cache update loop has to be closed
as well.