### PR TITLE
Fixed anti-pattern use of /var/run as the PID dir

### DIFF
--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -5,9 +5,9 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=/usr/local/bin/teleport start --pid-file=/var/run/teleport.pid
+ExecStart=/usr/local/bin/teleport start --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
-PIDFile=/var/run/teleport.pid
+PIDFile=/run/teleport.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixed anti-pattern use of /var/run as the PID dir