### PR TITLE
fixes #3061: use variable for docker image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 #   for pre-releases, we use   "1.0.0-beta.2" format
 VERSION=4.2.0-alpha.1
 
+DOCKER_IMAGE ?= quay.io/gravitational/teleport
+
 # These are standard autotools variables, don't change them please
 BUILDDIR ?= build
 BINDIR ?= /usr/local/bin
@@ -318,12 +320,12 @@ install: build
 .PHONY: image
 image:
 	cp ./build.assets/charts/Dockerfile $(BUILDDIR)/
-	cd $(BUILDDIR) && docker build --no-cache . -t quay.io/gravitational/teleport:$(VERSION)
+	cd $(BUILDDIR) && docker build --no-cache . -t $(DOCKER_IMAGE):$(VERSION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e image; fi
 
 .PHONY: publish
 publish:
-	docker push quay.io/gravitational/teleport:$(VERSION)
+	docker push $(DOCKER_IMAGE):$(VERSION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e publish; fi
 
 .PHONY: print-version


### PR DESCRIPTION
This change allows the docker image that is built to be configurable. This is useful for us as we need to be able to build software we use from source. It is also useful for deploying patched versions of teleport without having to manually package them into custom docker image names.