### PR TITLE
assign the advertise IP and nodename

### DIFF
--- a/examples/chart/teleport/templates/deployment.yaml
+++ b/examples/chart/teleport/templates/deployment.yaml
@@ -38,7 +38,17 @@ spec:
 {{- if not .Values.proxy.tls.enabled }}
         - --insecure-no-tls
 {{- end }}
+        - --nodename=$(MY_NODE_NAME)
+        - --advertise-ip=$(MY_POD_IP)
         env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
 {{- range $key, $value := .Values.extraVars }}
         - name: {{ $key }}
           value: {{ $value }}


### PR DESCRIPTION
Advertise IP is required to ensure the advertise address
is routable within the k8s fabric.

Node name aligns the pod with the behavior of ssh'ing to
a k8s node. Future work is required to fully provide ssh
access to the node instead of just a pod.

Signed-off-by: Drew Wells <drew.wells00@gmail.com>