### PR TITLE
(3.2) Restore CreateWebSession method.

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -97,7 +97,7 @@ func NewAPIServer(config *APIConfig) http.Handler {
 	srv.PUT("/:version/users/:user/web/password", srv.withAuth(srv.changePassword))
 	srv.POST("/:version/users/:user/web/password", srv.withAuth(srv.upsertPassword))
 	srv.POST("/:version/users/:user/web/password/check", srv.withAuth(srv.checkPassword))
-	srv.POST("/:version/users/:user/web/sessions", srv.withAuth(srv.extendWebSession))
+	srv.POST("/:version/users/:user/web/sessions", srv.withAuth(srv.createWebSession))
 	srv.POST("/:version/users/:user/web/authenticate", srv.withAuth(srv.authenticateWebUser))
 	srv.POST("/:version/users/:user/ssh/authenticate", srv.withAuth(srv.authenticateSSHUser))
 	srv.GET("/:version/users/:user/web/sessions/:sid", srv.withAuth(srv.getWebSession))
@@ -672,21 +672,24 @@ type createWebSessionReq struct {
 	PrevSessionID string `json:"prev_session_id"`
 }
 
-func (s *APIServer) extendWebSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) createWebSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *createWebSessionReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	user := p.ByName("user")
-	if req.PrevSessionID == "" {
-		return nil, trace.BadParameter("previous session ID missing")
+	if req.PrevSessionID != "" {
+		sess, err := auth.ExtendWebSession(user, req.PrevSessionID)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return sess, nil
 	}
-
-	sess, err := auth.ExtendWebSession(user, req.PrevSessionID)
+	sess, err := auth.CreateWebSession(user)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return sess, nil
+	return rawMessage(services.GetWebSessionMarshaler().MarshalWebSession(sess, services.WithVersion(version)))
 }
 
 func (s *APIServer) authenticateWebUser(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -592,6 +592,13 @@ func (a *AuthWithRoles) GetU2FSignRequest(user string, password []byte) (*u2f.Si
 	return a.authServer.U2FSignRequest(user, password)
 }
 
+func (a *AuthWithRoles) CreateWebSession(user string) (services.WebSession, error) {
+	if err := a.currentUserAction(user); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.authServer.CreateWebSession(user)
+}
+
 func (a *AuthWithRoles) ExtendWebSession(user, prevSessionID string) (services.WebSession, error) {
 	if err := a.currentUserAction(user); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1025,6 +1025,18 @@ func (c *Client) ExtendWebSession(user string, prevSessionID string) (services.W
 	return services.GetWebSessionMarshaler().UnmarshalWebSession(out.Bytes())
 }
 
+// CreateWebSession creates a new web session for a user
+func (c *Client) CreateWebSession(user string) (services.WebSession, error) {
+	out, err := c.PostJSON(
+		c.Endpoint("users", user, "web", "sessions"),
+		createWebSessionReq{},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return services.GetWebSessionMarshaler().UnmarshalWebSession(out.Bytes())
+}
+
 // AuthenticateWebUser authenticates web user, creates and  returns web session
 // in case if authentication is successful
 func (c *Client) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
@@ -2143,6 +2155,8 @@ type WebService interface {
 	// ExtendWebSession creates a new web session for a user based on another
 	// valid web session
 	ExtendWebSession(user string, prevSessionID string) (services.WebSession, error)
+	// CreateWebSession creates a new web session for a user
+	CreateWebSession(user string) (services.WebSession, error)
 	// DeleteWebSession deletes a web session for this user by id
 	DeleteWebSession(user string, sid string) error
 }


### PR DESCRIPTION
* Backport https://github.com/gravitational/teleport/commit/1cc729726effe5212116b7cb51cbcedc50d5e69b to 3.2 to restore `CreateWebSession()` method that gravity uses.
* Restore the old behavior of `CreateWebSession()` to get roles for the specified user rather than identity b/c gravity uses this method to create sessions on behalf of users.
