### PR TITLE
Remove blacklisted FIPS ciphersuites, fix local_auth

### DIFF
--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -167,7 +167,12 @@ func (s *AuthServer) AuthenticateWebUser(req AuthenticateUserRequest) (services.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if clusterConfig.GetLocalAuth() == false {
+
+	// Disable all local auth requests,
+	// except session ID renewal requests that are using the same method.
+	// This condition uses Session as a blanket check, because any new method added
+	// to the local auth will be disabled by default.
+	if clusterConfig.GetLocalAuth() == false && req.Session == nil {
 		s.emitNoLocalAuthEvent(req.Username)
 		return nil, trace.AccessDenied(noLocalAuth)
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -525,8 +525,18 @@ const WindowsOpenSSHNamedPipe = `\\.\pipe\openssh-ssh-agent`
 var (
 	// FIPSCipherSuites is a list of supported FIPS compliant TLS cipher suites.
 	FIPSCipherSuites = []uint16{
-		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		//
+		// These two cipers suites:
+		//
+		// tls.TLS_RSA_WITH_AES_128_GCM_SHA256
+		// tls.TLS_RSA_WITH_AES_256_GCM_SHA384
+		//
+		// although supported by FIPS, are blacklisted in http2 spec:
+		//
+		// https://tools.ietf.org/html/rfc7540#appendix-A
+		//
+		// therefore we do not include them in this list.
+		//
 		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -308,6 +308,8 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 					if err == nil {
 						session.Session = base64.StdEncoding.EncodeToString(out)
 					}
+				} else {
+					log.WithError(err).Debugf("Could not authenticate.")
 				}
 			}
 			httplib.SetIndexHTMLHeaders(w.Header())


### PR DESCRIPTION
This commit fixes Web UI in FIPS mode when local_auth is false
and removes two ciphers banned by HTTP2 rfc spec:

https://tools.ietf.org/html/rfc7540#appendix-A

and used by FIPS, causing Teleport GRPC to fail.