### PR TITLE
Remove blacklisted HTTP/2 ciphersuites from documentation example

### DIFF
--- a/docs/4.0/admin-guide.md
+++ b/docs/4.0/admin-guide.md
@@ -325,8 +325,6 @@ teleport:
     # List of the supported ciphersuites. If this section is not specified,
     # only the default ciphersuites are enabled.
     ciphersuites:
-       - tls-rsa-with-aes-128-gcm-sha256
-       - tls-rsa-with-aes-256-gcm-sha384
        - tls-ecdhe-rsa-with-aes-128-gcm-sha256
        - tls-ecdhe-ecdsa-with-aes-128-gcm-sha256
        - tls-ecdhe-rsa-with-aes-256-gcm-sha384

--- a/docs/4.1/admin-guide.md
+++ b/docs/4.1/admin-guide.md
@@ -255,7 +255,6 @@ teleport:
     # Cipher algorithms that the server supports. This section only needs to be
     # set if you want to override the defaults.
     ciphers:
-
       - aes128-ctr
       - aes192-ctr
       - aes256-ctr
@@ -265,7 +264,6 @@ teleport:
     # Key exchange algorithms that the server supports. This section only needs
     # to be set if you want to override the defaults.
     kex_algos:
-
       - curve25519-sha256@libssh.org
       - ecdh-sha2-nistp256
       - ecdh-sha2-nistp384
@@ -274,15 +272,12 @@ teleport:
     # Message authentication code (MAC) algorithms that the server supports.
     # This section only needs to be set if you want to override the defaults.
     mac_algos:
-
       - hmac-sha2-256-etm@openssh.com
       - hmac-sha2-256
 
     # List of the supported ciphersuites. If this section is not specified,
     # only the default ciphersuites are enabled.
     ciphersuites:
-       - tls-rsa-with-aes-128-gcm-sha256
-       - tls-rsa-with-aes-256-gcm-sha384
        - tls-ecdhe-rsa-with-aes-128-gcm-sha256
        - tls-ecdhe-ecdsa-with-aes-128-gcm-sha256
        - tls-ecdhe-rsa-with-aes-256-gcm-sha384


### PR DESCRIPTION
These two ciphersuites (`tls-rsa-with-aes-128-gcm-sha256` and `tls-rsa-with-aes-256-gcm-sha384`) are blacklisted by the HTTP/2 spec. The effect of specifying them means that logging into a Teleport cluster via a web browser can result in a redirect loop rather than a successful login. We've had several customers hit this issue over the past couple of days.

Given that people don't actually need to specify ciphersuites at all in 99.99% of cases (and they're also being removed from the sane default selection that we pick automatically in Teleport 4.1.3) I feel like we should remove them to avoid confusing people.