### PR TITLE
Remove GSuite groups reference 

### DIFF
--- a/docs/4.1/admin-guide.md
+++ b/docs/4.1/admin-guide.md
@@ -71,7 +71,7 @@ document will be referring to:
 
 |Concept   | Description
 |----------|------------
-|Node      | Synonym to "server" or "computer", something one can "SSH to". A node must be running the [ `teleport` ](../cli-docs/#teleport) daemon with "node" role/service turned on.
+|Node      | Synonym to "server" or "computer", something one can "SSH to". A node must be running the [ `teleport` ](./cli-docs/#teleport) daemon with "node" role/service turned on.
 |Certificate Authority (CA) | A pair of public/private keys Teleport uses to manage access. A CA can sign a public key of a user or node, establishing their cluster membership.
 |Teleport Cluster | A Teleport Auth Service contains two CAs. One is used to sign user keys and the other signs node keys. A collection of nodes connected to the same CA is called a "cluster".
 |Cluster Name | Every Teleport cluster must have a name. If a name is not supplied via `teleport.yaml` configuration file, a GUID will be generated.**IMPORTANT:** renaming a cluster invalidates its keys and all certificates it had created.
@@ -90,7 +90,7 @@ the following commands:
 |status      | Shows the status of a Teleport connection. This command is only available from inside of an active SSH session.
 |help        | Shows help.
 
-When experimenting, you can quickly start [ `teleport` ](../cli-docs/#teleport)
+When experimenting, you can quickly start [ `teleport` ](./cli-docs/#teleport)
 with verbose logging by typing [ `teleport start -d` ](./cli-docs/#teleport-start)
 .
 
@@ -171,7 +171,7 @@ of them is configurable.
 ## Configuration
 
 You should use a [configuration file](#configuration-file) to configure the
-[ `teleport` ](../cli-docs/#teleport) daemon. For simple experimentation, you can
+[ `teleport` ](./cli-docs/#teleport) daemon. For simple experimentation, you can
 use command line flags with the [ `teleport start` ](./cli-docs/#teleport-start)
 command. Read about all the allowed flags in the [CLI
 Docs](./cli-docs/#teleport-start) or run `teleport start --help`
@@ -493,7 +493,7 @@ following use cases:
 ## Authentication
 
 Teleport uses the concept of "authentication connectors" to authenticate users
-when they execute [ `tsh login` ](../cli-docs/#tsh-login) command. There are three
+when they execute [ `tsh login` ](./cli-docs/#tsh-login) command. There are three
 types of authentication connectors:
 
 ### Local Connector
@@ -658,9 +658,9 @@ Let's look at this table:
 |bob    | bob      | Teleport user 'bob' can login into member nodes only as OS user 'bob'
 |ross   |          | If no OS login is specified, it defaults to the same name as the Teleport user.
 
-To add a new user to Teleport, you have to use the [ `tctl` ](../cli-docs/#tctl)
+To add a new user to Teleport, you have to use the [ `tctl` ](./cli-docs/#tctl)
 tool on the same node where the auth server is running, i.e.
-[ `teleport` ](../cli-docs/#teleport) was started with `--roles=auth` .
+[ `teleport` ](./cli-docs/#teleport) was started with `--roles=auth` .
 
 ``` bsh
 $ tctl users add joe joe,root
@@ -711,7 +711,7 @@ $ tctl users rm joe
 ## Editing Users
 
 Users entries can be manipulated using the generic [resource
-commands](#resources) via [ `tctl` ](../cli-docs/#tctl) . For example, to see the
+commands](#resources) via [ `tctl` ](./cli-docs/#tctl) . For example, to see the
 full list of user records, an administrator can execute:
 
 ``` yaml
@@ -776,7 +776,7 @@ A more secure way to add nodes to a cluster is to generate tokens as they are
 needed. Such token can be used multiple times until its time to live (TTL)
 expires.
 
-Use the [ `tctl` ](../cli-docs/#tctl) tool to register a new invitation token (or
+Use the [ `tctl` ](./cli-docs/#tctl) tool to register a new invitation token (or
 it can also generate a new token for you). In the following example a new token
 is created with a TTL of 5 minutes:
 
@@ -785,7 +785,7 @@ $ tctl nodes add --ttl=5m --roles=node,proxy --token=secret-value
 The invite token: secret-value
 ```
 
-If `--token` is not provided, [ `tctl` ](../cli-docs/#tctl) will generate one:
+If `--token` is not provided, [ `tctl` ](./cli-docs/#tctl) will generate one:
 
 ``` bsh
 # generate a short-lived invitation token for a new node:
@@ -885,7 +885,7 @@ teleport:
 !!! warning "Warning":
     The CA pin becomes invalid if a Teleport administrator
     performs the CA rotation by executing
-    [ `tctl auth rotate` ](../cli-docs/#tctl-auth-rotate) .
+    [ `tctl auth rotate` ](./cli-docs/#tctl-auth-rotate) .
 
 ## Revoking Invitations
 
@@ -912,7 +912,7 @@ The 2nd token with "Node" role was generated to invite a new node to this
 cluster. And the 3rd token was generated to invite a new user.
 
 The latter two tokens can be deleted (revoked) via [`tctl tokens
-del`](../cli-docs/#tctl-tokens-rm) command:
+del`](./cli-docs/#tctl-tokens-rm) command:
 
 ``` yaml
 $ tctl tokens del 696c0471453e75882ff70a761c1a8bfa
@@ -925,7 +925,7 @@ In addition to specifying a custom nodename, Teleport also allows for the
 application of arbitrary key:value pairs to each node, called labels. There are
 two kinds of labels:
 
-1. `static labels` do not change over time, while [ `teleport` ](../cli-docs/#teleport) 
+1. `static labels` do not change over time, while [ `teleport` ](./cli-docs/#teleport) 
     process is running.  Examples of static labels are physical location of nodes, 
     name of the environment (staging vs production), etc.
 
@@ -1090,7 +1090,7 @@ The recorded sessions are stored as raw bytes in the `sessions` directory under
 
 1. `.bytes` file or `.chunks.gz` compressed format represents the raw session bytes and is somewhat
     human-readable, although you are better off using [`tsh
-    play`](../cli-docs/#tsh-play) or the Web UI to replay it.
+    play`](./cli-docs/#tsh-play) or the Web UI to replay it.
 
 2. `.log` file or `.events.gz` compressed file contains the copies of the event log entries that are            related to this session.
 
@@ -1131,7 +1131,7 @@ $ tctl auth export --type=user
 
 To allow access to a single user, copy the above output to
 `~/.ssh/authorized_keys` . To apply this for all users, remove "cert-authority"
-from the start of [ `tctl` ](../cli-docs/#tctl) output and copy it to
+from the start of [ `tctl` ](./cli-docs/#tctl) output and copy it to
 `/etc/ssh/teleport_user_ca.pub` .
 
 Add the following line to `/etc/ssh/sshd_config` :
@@ -1175,7 +1175,7 @@ HostKey /etc/ssh/teleport_host_key
 HostCertificate /etc/ssh/teleport_host_key-cert.pub
 ```
 
-Now you can use [ `tsh ssh user@host.example.com` ](../cli-docs/#tsh) to login
+Now you can use [ `tsh ssh user@host.example.com` ](./cli-docs/#tsh) to login
 into any `sshd` node in the cluster and the session will be recorded. If you
 want to use OpenSSH `ssh` client for logging into `sshd` servers behind a proxy
 in "recording mode", you have to tell the `ssh` client to use the jump host and
@@ -1242,14 +1242,14 @@ A Teleport administrator has two tools to configure a Teleport cluster:
 * The [configuration file](#configuration) is used for static configuration like
   the cluster name.
 
-* The [ `tctl` ](../cli-docs/#tctl) admin tool is used for manipulating dynamic
+* The [ `tctl` ](./cli-docs/#tctl) admin tool is used for manipulating dynamic
   records like Teleport
   users.
 
-[ `tctl` ](../cli-docs/#tctl) has convenient subcommands for dynamic
+[ `tctl` ](./cli-docs/#tctl) has convenient subcommands for dynamic
 configuration, like `tctl users` or `tctl nodes` . However, for dealing with
 more advanced topics, like connecting clusters together or troubleshooting
-trust, [ `tctl` ](../cli-docs/#tctl) offers the more powerful, although
+trust, [ `tctl` ](./cli-docs/#tctl) offers the more powerful, although
 lower-level CLI interface called `resources` .
 
 The concept is borrowed from the REST programming pattern. A cluster is composed
@@ -1268,9 +1268,9 @@ be manipulated with just 3 CLI commands:
 
 | Command       | Description                                                           | Examples                                |
 |---------------|-----------------------------------------------------------------------|-----------------------------------------|
-| [ `tctl get` ](../cli-docs/#tctl=get) | Get one or multiple resources                                         | `tctl get users` or `tctl get user/joe` |
-| [ `tctl rm` ](../cli-docs/#tctl-rm) | Delete a resource by type/name                                        | `tctl rm user/joe` |
-| [ `tctl create` ](../cli-docs/#tctl-create) | Create a new resource from a YAML file. Use `-f` to override / update | `tctl create -f joe.yaml` |
+| [ `tctl get` ](./cli-docs/#tctl=get) | Get one or multiple resources                                         | `tctl get users` or `tctl get user/joe` |
+| [ `tctl rm` ](./cli-docs/#tctl-rm) | Delete a resource by type/name                                        | `tctl rm user/joe` |
+| [ `tctl create` ](./cli-docs/#tctl-create) | Create a new resource from a YAML file. Use `-f` to override / update | `tctl create -f joe.yaml` |
 
 !!! warning "YAML Format":
     By default Teleport uses [YAML format](https://en.wikipedia.org/wiki/YAML)
@@ -1280,7 +1280,7 @@ be manipulated with just 3 CLI commands:
 
 Here's an example how the YAML resource definition for a user Joe might look
 like. It can be retrieved by executing [`tctl get
-user/joe`](../cli-docs/#tctl-get)
+user/joe`](./cli-docs/#tctl-get)
 
 ``` yaml
 kind: user
@@ -1320,7 +1320,7 @@ spec:
     only internally and are not meant to be changed.  Others are reserved for
     future use.
 
-Here's the list of resources currently exposed via [ `tctl` ](../cli-docs/#tctl) :
+Here's the list of resources currently exposed via [ `tctl` ](./cli-docs/#tctl) :
 
 | Resource Kind | Description                                                                                                                                  |
 |---------------|----------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1383,7 +1383,7 @@ $ tsh clusters
 
 ### Selecting the Default Cluster
 
-To avoid using `--cluster` switch with [ `tsh` ](../cli-docs/#tsh) commands, you
+To avoid using `--cluster` switch with [ `tsh` ](./cli-docs/#tsh) commands, you
 can also specify which trusted cluster you want to become the default from the
 start:
 
@@ -1500,7 +1500,7 @@ spec:
       local: ["auditor"] # will be assigned "auditor" role when logging into "east"
 ```
 
-Then, use [ `tctl create` ](../cli-docs/#tctl-create) to add the file:
+Then, use [ `tctl create` ](./cli-docs/#tctl-create) to add the file:
 
 ``` yaml
 $ tctl create cluster.yaml
@@ -1656,7 +1656,7 @@ app](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app
 Be sure to set the "Authorization callback URL" to the same value as
 `redirect_url` in the resource spec.
 
-Finally, create the connector using [ `tctl` ](../cli-docs/#tctl)
+Finally, create the connector using [ `tctl` ](./cli-docs/#tctl)
 [resource](#resources) management command:
 
 ``` yaml
@@ -1924,7 +1924,7 @@ scp_if_ssh = True
 
 Teleport 3.0+ can be configured as a compliance gateway for Kubernetes clusters.
 This allows users to authenticate against a Teleport proxy using [`tsh
-login`](../cli-docs/#tsh) command to retrieve credentials for both SSH and
+login`](./cli-docs/#tsh) command to retrieve credentials for both SSH and
 Kubernetes API.
 
 Below is a high-level diagram of how Teleport can be deployed in front of a
@@ -2005,9 +2005,9 @@ You can take advantage of the [Trusted Clusters](#trusted-clusters) feature of
 Teleport to federate trust across multiple Kubernetes clusters.
 
 When multiple trusted clusters are present behind a Teleport proxy, the
-`kubeconfig` generated by [ `tsh login` ](../cli-docs/#tsh-login) will contain the
+`kubeconfig` generated by [ `tsh login` ](./cli-docs/#tsh-login) will contain the
 Kubernetes API endpoint determined by the `<cluster>` argument to [`tsh
-login`](../cli-docs/#tsh-login) .
+login`](./cli-docs/#tsh-login) .
 
 * There are three Teleport/Kubernetes clusters: "main", "east" and "west". These
 
@@ -2296,7 +2296,7 @@ clients, etc), the following rules apply:
   means you must not attempt to upgrade from 3.3 straight to 3.5. You must
   upgrade to 3.4 first.
 
-* Teleport clients [`tsh`](../cli-docs/#tsh) for users and [`tctl`](../cli-docs/#tctl) for admins 
+* Teleport clients [`tsh`](./cli-docs/#tsh) for users and [`tctl`](./cli-docs/#tctl) for admins 
   may not be compatible
 
 As an extra precaution you might want to backup your application prior to upgrading.We provide
@@ -2335,9 +2335,9 @@ As covered in the [Graceful Restarts](#graceful-restarts) section, Teleport
 supports graceful restarts. To upgrade a host to a newer Teleport version, an
 administrator must:
 
-1. Replace the Teleport binaries, usually [ `teleport` ](../cli-docs/#teleport)
+1. Replace the Teleport binaries, usually [ `teleport` ](./cli-docs/#teleport)
 
-   and [ `tctl` ](../cli-docs/#tctl)
+   and [ `tctl` ](./cli-docs/#tctl)
 
 2. Execute `systemctl restart teleport`
 
@@ -2371,14 +2371,14 @@ The `license_file` path can be either absolute or relative to the configured
 
 ## Troubleshooting
 
-To diagnose problems you can configure [ `teleport` ](../cli-docs/#teleport) to
+To diagnose problems you can configure [ `teleport` ](./cli-docs/#teleport) to
 run with verbose logging enabled by passing it `-d` flag.
 
 !!! tip "NOTE":
     It is not recommended to run Teleport in production with verbose
     logging as it generates a substantial amount of data.
 
-Sometimes you may want to reset [ `teleport` ](../cli-docs/#teleport) to a clean
+Sometimes you may want to reset [ `teleport` ](./cli-docs/#teleport) to a clean
 state. This can be accomplished by erasing everything under `"data_dir"`
 directory. Assuming the default location, `rm -rf /var/lib/teleport/*` will do.
 

--- a/docs/4.1/admin-guide.md
+++ b/docs/4.1/admin-guide.md
@@ -1288,9 +1288,7 @@ version: v2
 metadata:
   name: joe
 spec:
-  roles:
-
-  + admin
+  roles: admin
 
   status:
     # users can be temporarily locked in a Teleport system, but this

--- a/docs/4.1/architecture/teleport_proxy.md
+++ b/docs/4.1/architecture/teleport_proxy.md
@@ -59,7 +59,7 @@ Authority (CA)](./auth/#authentication-in-teleport).:
 3. If Auth Server accepts credentials, it generates a new certificate signed by
    its user CA and sends it back to the Proxy Server. The certificate has a TTL
    which defaults to 24 hours, but can be configured in
-   [`tctl`](./cli-docs/#tctl).
+   [`tctl`](../cli-docs/#tctl).
 4. The Proxy Server returns the user certificate to the client and client stores
    it in `~/.tsh/keys`. The certificate is also added to the local SSH agent if
    one is running.

--- a/docs/4.1/ssh_gsuite.md
+++ b/docs/4.1/ssh_gsuite.md
@@ -53,6 +53,7 @@ spec:
   scope: ['openid', 'email']
   claims_to_roles:
     - {claim: "email", value: "ben@example.com", roles: ["admin"]}
+    - {claim: "email", value: "gus@example.com", roles: ["admin"]}
     - {claim: "email", value: "*@example.com", roles: ["dev"]}
 ```
 

--- a/docs/4.1/ssh_gsuite.md
+++ b/docs/4.1/ssh_gsuite.md
@@ -33,10 +33,6 @@ like:
 
 ![Copy Client Secret](img/gsuite/gsuite-5-copy-client-id.png)
 
-6. To allow for fine grained role based access control (RBAC) you'll first need to
-open an admin API so Teleport can assign groups to roles. Allow Admin SDK via [google.com/apis/api/admin.googleapis.com/overview](https://console.developers.google.com/apis/api/admin.googleapis.com/overview)
-![Turn on Admin SDK](img/gsuite/gsuite-4-admin-sdk.png)
-
 
 
 ## Create a OIDC Connector
@@ -54,14 +50,11 @@ spec:
   client_id: exampleclientid11234.apps.googleusercontent.com
   client_secret: examplesecret
   issuer_url: https://accounts.google.com
-  scope: ['https://www.googleapis.com/auth/admin.directory.group.readonly', 'openid', 'email']
+  scope: ['openid', 'email']
   claims_to_roles:
-    - {claim: "groups", value: "admin@example.com", roles: ["admin"]}
+    - {claim: "email", value: "ben@example.com", roles: ["admin"]}
+    - {claim: "email", value: "*@example.com", roles: ["dev"]}
 ```
-
-!!! important
-    The groups will be fetched only if admins include special auth scope https://www.googleapis.com/auth/admin.directory.group.readonly in the scopes of the connector as shown in the example above.
-
 
 Create the connector using `tctl` tool:
 
@@ -72,6 +65,7 @@ $ tctl create gsuite-connector.yaml
 ## Create Teleport Roles
 
 We are going to create 2 roles:
+
 -  Privileged role admin who is able to login as root and is capable of administrating
 the cluster
 - Non-privileged dev


### PR DESCRIPTION
This a placeholder until we resolve the current GSuite groups setup. In this case, I've hard coded two admins, Ben and Gus. The rest of the org can login but are defined under the Dev Role. This won't scale for large orgs, but might work for smaller teams. 

( ow I also found some broken links in the admin docs, I fixed that at the same time ) 