### PR TITLE
Document dropped ciphersuites in 4.0+ 

### DIFF
--- a/docs/3.0/admin-guide.md
+++ b/docs/3.0/admin-guide.md
@@ -288,8 +288,10 @@ teleport:
        - tls-rsa-with-aes-128-cbc-sha # default
        - tls-rsa-with-aes-256-cbc-sha # default
        - tls-rsa-with-aes-128-cbc-sha256
-       - tls-rsa-with-aes-128-gcm-sha256
-       - tls-rsa-with-aes-256-gcm-sha384
+       # Note: These two ciphersuites are unsupported when upgrading to Teleport
+       # 4.0+ see https://community.gravitational.com/t/drop-ciphersuites-blacklisted-by-http-2-spec/446
+       #- tls-rsa-with-aes-128-gcm-sha256
+       #- tls-rsa-with-aes-256-gcm-sha384
        - tls-ecdhe-ecdsa-with-aes-128-cbc-sha
        - tls-ecdhe-ecdsa-with-aes-256-cbc-sha
        - tls-ecdhe-rsa-with-aes-128-cbc-sha

--- a/docs/3.1/admin-guide.md
+++ b/docs/3.1/admin-guide.md
@@ -294,8 +294,10 @@ teleport:
        - tls-rsa-with-aes-128-cbc-sha # default
        - tls-rsa-with-aes-256-cbc-sha # default
        - tls-rsa-with-aes-128-cbc-sha256
-       - tls-rsa-with-aes-128-gcm-sha256
-       - tls-rsa-with-aes-256-gcm-sha384
+       # Note: These two ciphersuites are unsupported when upgrading to Teleport
+       # 4.0+ see https://community.gravitational.com/t/drop-ciphersuites-blacklisted-by-http-2-spec/446
+       #- tls-rsa-with-aes-128-gcm-sha256
+       #- tls-rsa-with-aes-256-gcm-sha384
        - tls-ecdhe-ecdsa-with-aes-128-cbc-sha
        - tls-ecdhe-ecdsa-with-aes-256-cbc-sha
        - tls-ecdhe-rsa-with-aes-128-cbc-sha

--- a/docs/3.2/admin-guide.md
+++ b/docs/3.2/admin-guide.md
@@ -286,8 +286,10 @@ teleport:
     # List of the supported ciphersuites. If this section is not specified,
     # only the default ciphersuites are enabled.
     ciphersuites:
-       - tls-rsa-with-aes-128-gcm-sha256
-       - tls-rsa-with-aes-256-gcm-sha384
+       # Note: These two ciphersuites are unsupported when upgrading to Teleport
+       # 4.0+ see https://community.gravitational.com/t/drop-ciphersuites-blacklisted-by-http-2-spec/446
+       #- tls-rsa-with-aes-128-gcm-sha256
+       #- tls-rsa-with-aes-256-gcm-sha384
        - tls-ecdhe-rsa-with-aes-128-gcm-sha256
        - tls-ecdhe-ecdsa-with-aes-128-gcm-sha256
        - tls-ecdhe-rsa-with-aes-256-gcm-sha384

--- a/docs/4.0/admin-guide.md
+++ b/docs/4.0/admin-guide.md
@@ -2203,6 +2203,11 @@ clients, etc), the following rules apply:
 * Teleport clients (`tsh` for users and `tctl` for admins) may not be compatible if older than the auth or the proxy server. They will print an error if there is an incompatibility.
 * While 4.0 is a major release. 3.2 can be upgraded to 4.0 using the same upgrade sequence below. 
 
+!!! warning "Upgrading to Teleport 4.0+":
+    Teleport 4.0+ switched to GRPC and HTTP/2 as an API protocol. The HTTP2 Spec banned
+    two previously recommend ciphers. `tls-rsa-with-aes-128-gcm-sha256` &     `tls-rsa-with-aes-256-gcm-sha384`, make sure these are removed from `teleport.yaml` 
+    [Visit our community for more details](https://community.gravitational.com/t/drop-ciphersuites-blacklisted-by-http-2-spec/446)
+
 ### Upgrade Sequence
 
 When upgrading a single Teleport cluster:

--- a/docs/4.1/admin-guide.md
+++ b/docs/4.1/admin-guide.md
@@ -2297,8 +2297,12 @@ clients, etc), the following rules apply:
 * Teleport clients [`tsh`](./cli-docs/#tsh) for users and [`tctl`](./cli-docs/#tctl) for admins 
   may not be compatible
 
-As an extra precaution you might want to backup your application prior to upgrading.We provide
-more instructionsin [Backing up Dynamic Configuration](#backing-up-dynamic-configuration).
+As an extra precaution you might want to backup your application prior to upgrading. We provide more instructionsin [Backing up Dynamic Configuration](#backing-up-dynamic-configuration).
+
+!!! warning "Upgrading to Teleport 4.0+":
+    Teleport 4.0+ switched to GRPC and HTTP/2 as an API protocol. The HTTP2 Spec banned
+    two previously recommend ciphers. `tls-rsa-with-aes-128-gcm-sha256` &     `tls-rsa-with-aes-256-gcm-sha384`, make sure these are removed from `teleport.yaml` 
+    [Visit our community for more details](https://community.gravitational.com/t/drop-ciphersuites-blacklisted-by-http-2-spec/446)
 
 ### Upgrade Sequence
 


### PR DESCRIPTION
This PR makes this issue, publicly discoverable during the upgrade process. https://community.gravitational.com/t/drop-ciphersuites-blacklisted-by-http-2-spec/446  