### PR TITLE
Fixes Broken images and Footer on Teleport Docs.

### DIFF
--- a/docs/4.1/installation.md
+++ b/docs/4.1/installation.md
@@ -13,7 +13,7 @@ install any version listed in our [Release History](https://gravitational.com/te
 Gravitational Teleport provides a checksum from the Downloads page.  This should
 be used to verify the integrity of our binary.
 
-![Teleport Checksum](../img/teleport-sha.png)
+![Teleport Checksum](./img/teleport-sha.png)
 
 If you download Teleport via an automated system, you can programmatically
 obtain the checksum  by adding `.sha256` to the binary. This is the method shown

--- a/docs/4.1/intro.md
+++ b/docs/4.1/intro.md
@@ -32,7 +32,7 @@ environments, not servers. Below is the list of most popular Teleport features:
 Teleport is available through the free, open source edition ("Teleport Community Edition")
 or a commercial edition ("Teleport Enterprise Edition").
 
-![teleport diagram](/images/diagram-teleport.png)
+![teleport diagram](https://gravitational.com/images/diagram-teleport.png)
 
 ## Operating System Support
 

--- a/docs/theme/src/docs.css
+++ b/docs/theme/src/docs.css
@@ -9367,7 +9367,7 @@ ol.linenums {
 *
 */
 .launchpad {
-  background-image: url("./images/footer-bg.svg");
+  background-image: url("../images/footer-bg.svg");
   background-repeat: no-repeat;
   background-position: top center;
   background-size: cover;

--- a/docs/theme/src/docs.css
+++ b/docs/theme/src/docs.css
@@ -9367,7 +9367,7 @@ ol.linenums {
 *
 */
 .launchpad {
-  background-image: url("/images/footer-bg.svg");
+  background-image: url("./images/footer-bg.svg");
   background-repeat: no-repeat;
   background-position: top center;
   background-size: cover;


### PR DESCRIPTION
This PR captures the last few parts from the theme refresh. Some of these were Ok locally but not rendering correctly on the production version. I've tested this on staging, and apart from cache invalidation issues, everything is working correctly. 