### PR TITLE
Change AMI owners to use Amazon alias

### DIFF
--- a/assets/marketplace/single-ami.json
+++ b/assets/marketplace/single-ami.json
@@ -25,9 +25,7 @@
             "name": "amzn2-ami-hvm*-ebs",
             "root-device-type": "ebs"
         },
-        "owners": ["137112412989", "591542846629", "801119661308",
-                   "102837901569", "013907871322", "206029621532",
-                   "286198878708", "443319210888"],
+        "owners": ["amazon"],
         "most_recent": true
     },
     "instance_type": "{{user `instance_type`}}",
@@ -64,9 +62,7 @@
             "name": "amzn2-ami-hvm*-ebs",
             "root-device-type": "ebs"
         },
-        "owners": ["137112412989", "591542846629", "801119661308",
-                   "102837901569", "013907871322", "206029621532",
-                   "286198878708", "443319210888"],
+        "owners": ["amazon"],
         "most_recent": true
     },
     "instance_type": "{{user `instance_type`}}",
@@ -103,9 +99,7 @@
             "name": "amzn2-ami-hvm*-ebs",
             "root-device-type": "ebs"
         },
-        "owners": ["137112412989", "591542846629", "801119661308",
-                   "102837901569", "013907871322", "206029621532",
-                   "286198878708", "443319210888"],
+        "owners": ["amazon"],
         "most_recent": true
     },
     "instance_type": "{{user `instance_type`}}",


### PR DESCRIPTION
Newer versions of Packer allow you use to `amazon` as an alias for Amazon-managed/owned AMI base images (as per https://www.packer.io/docs/builders/amazon-ebs.html#source_ami_filter)

I updated to Packer v1.4.5 on the Jenkins server as I was experiencing some issues with snapshots not being ready for tagging before the timeout period.