### PR TITLE
Add SessionCreate to launchd example

### DIFF
--- a/examples/launchd/teleport.plist
+++ b/examples/launchd/teleport.plist
@@ -20,6 +20,8 @@
    <integer>30</integer>
    <key>SuccessfulExit</key>
    <false/>
+   <key>SessionCreate</key>
+   <true/>
 <key>StandardOutPath</key>
 <string>/var/log/teleport-stdout.log</string>
 <key>StandardErrorPath</key>


### PR DESCRIPTION
By default, sessions launched with Teleport aren't seen as "interactive" by MacOS. This means that they can't get access to the logged in user's `login` keychain and can't interact with various system processes.

This PR adds the `SessionCreate` directive to the example Teleport plist file so that any sessions Teleport spawns will get interactive privileges and be able to access the keychain, etc. The default "remote login" service (`sshd`) on Mac is launched in the same way.