### PR TITLE
Delayed access-request PR cleanup.

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -195,7 +195,7 @@ func (g *GRPCServer) GetAccessRequests(ctx context.Context, f *services.AccessRe
 	if f != nil {
 		filter = *f
 	}
-	reqs, err := auth.AuthWithRoles.GetAccessRequests(filter)
+	reqs, err := auth.AuthWithRoles.GetAccessRequests(ctx, filter)
 	if err != nil {
 		return nil, trail.ToGRPC(err)
 	}
@@ -218,7 +218,7 @@ func (g *GRPCServer) CreateAccessRequest(ctx context.Context, req *services.Acce
 	if err != nil {
 		return nil, trail.ToGRPC(err)
 	}
-	if err := auth.AuthWithRoles.CreateAccessRequest(req); err != nil {
+	if err := auth.AuthWithRoles.CreateAccessRequest(ctx, req); err != nil {
 		return nil, trail.ToGRPC(err)
 	}
 	return &empty.Empty{}, nil
@@ -229,7 +229,7 @@ func (g *GRPCServer) DeleteAccessRequest(ctx context.Context, id *proto.RequestI
 	if err != nil {
 		return nil, trail.ToGRPC(err)
 	}
-	if err := auth.AuthWithRoles.DeleteAccessRequest(id.ID); err != nil {
+	if err := auth.AuthWithRoles.DeleteAccessRequest(ctx, id.ID); err != nil {
 		return nil, trail.ToGRPC(err)
 	}
 	return &empty.Empty{}, nil
@@ -240,7 +240,7 @@ func (g *GRPCServer) SetAccessRequestState(ctx context.Context, req *proto.Reque
 	if err != nil {
 		return nil, trail.ToGRPC(err)
 	}
-	if err := auth.SetAccessRequestState(req.ID, req.State); err != nil {
+	if err := auth.AuthWithRoles.SetAccessRequestState(ctx, req.ID, req.State); err != nil {
 		return nil, trail.ToGRPC(err)
 	}
 	return &empty.Empty{}, nil

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1383,13 +1383,13 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 	req, err := services.NewAccessRequest(user, role)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(userClient.CreateAccessRequest(req), check.IsNil)
+	c.Assert(userClient.CreateAccessRequest(context.TODO(), req), check.IsNil)
 
 	// sanity check; ensure that roles for which no `allow` directive
 	// exists cannot be requested.
 	badReq, err := services.NewAccessRequest(user, "some-fake-role")
 	c.Assert(err, check.IsNil)
-	c.Assert(userClient.CreateAccessRequest(badReq), check.NotNil)
+	c.Assert(userClient.CreateAccessRequest(context.TODO(), badReq), check.NotNil)
 
 	// generateCerts executes a GenerateUserCerts request, optionally applying
 	// one or more access-requests to the certificate.
@@ -1424,12 +1424,14 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 	_, err = generateCerts(req.GetName())
 	c.Assert(err, check.NotNil)
 
+	updateCtx := withUpdateBy(context.TODO(), "some-user")
+
 	// verify that user does not have the ability to approve their own request (not a special case, this
 	// user just wasn't created with the necessary roles for request management).
-	c.Assert(userClient.SetAccessRequestState(req.GetName(), services.RequestState_APPROVED), check.NotNil)
+	c.Assert(userClient.SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_APPROVED), check.NotNil)
 
 	// attempt to apply request in APPROVED state (should succeed)
-	c.Assert(s.server.Auth().SetAccessRequestState(req.GetName(), services.RequestState_APPROVED), check.IsNil)
+	c.Assert(s.server.Auth().SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_APPROVED), check.IsNil)
 	userCerts, err = generateCerts(req.GetName())
 	c.Assert(err, check.IsNil)
 	// ensure that the requested role was actually applied to the cert
@@ -1438,15 +1440,15 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 	}
 
 	// attempt to apply request in DENIED state (should fail)
-	c.Assert(s.server.Auth().SetAccessRequestState(req.GetName(), services.RequestState_DENIED), check.IsNil)
+	c.Assert(s.server.Auth().SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_DENIED), check.IsNil)
 	_, err = generateCerts(req.GetName())
 	c.Assert(err, check.NotNil)
 
 	// ensure that once in the DENIED state, a request cannot be set back to PENDING state.
-	c.Assert(s.server.Auth().SetAccessRequestState(req.GetName(), services.RequestState_PENDING), check.NotNil)
+	c.Assert(s.server.Auth().SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_PENDING), check.NotNil)
 
 	// ensure that once in the DENIED state, a request cannot be set back to APPROVED state.
-	c.Assert(s.server.Auth().SetAccessRequestState(req.GetName(), services.RequestState_APPROVED), check.NotNil)
+	c.Assert(s.server.Auth().SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_APPROVED), check.NotNil)
 }
 
 // TestGenerateCerts tests edge cases around authorization of

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -897,6 +897,7 @@ func (tc *TeleportClient) ReissueUserCerts(ctx context.Context, params ReissuePa
 	return proxyClient.ReissueUserCerts(ctx, params)
 }
 
+// CreateAccessRequest registers a new access request with the auth server.
 func (tc *TeleportClient) CreateAccessRequest(ctx context.Context, req services.AccessRequest) error {
 	proxyClient, err := tc.ConnectToProxy(ctx)
 	if err != nil {
@@ -905,6 +906,7 @@ func (tc *TeleportClient) CreateAccessRequest(ctx context.Context, req services.
 	return proxyClient.CreateAccessRequest(ctx, req)
 }
 
+// GetAccessRequests loads all access requests matching the supplied filter.
 func (tc *TeleportClient) GetAccessRequests(ctx context.Context, filter services.AccessRequestFilter) ([]services.AccessRequest, error) {
 	proxyClient, err := tc.ConnectToProxy(ctx)
 	if err != nil {
@@ -913,6 +915,7 @@ func (tc *TeleportClient) GetAccessRequests(ctx context.Context, filter services
 	return proxyClient.GetAccessRequests(ctx, filter)
 }
 
+// NewWatcher sets up a new event watcher.
 func (tc *TeleportClient) NewWatcher(ctx context.Context, watch services.Watch) (services.Watcher, error) {
 	proxyClient, err := tc.ConnectToProxy(ctx)
 	if err != nil {

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -231,27 +231,29 @@ func (proxy *ProxyClient) ReissueUserCerts(ctx context.Context, params ReissuePa
 	return trace.Wrap(err)
 }
 
-// CreateAccessRequest attempts to create a new request for escalated privilege.
+// CreateAccessRequest registers a new access request with the auth server.
 func (proxy *ProxyClient) CreateAccessRequest(ctx context.Context, req services.AccessRequest) error {
 	site, err := proxy.ConnectToCurrentCluster(ctx, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	return site.CreateAccessRequest(req)
+	return site.CreateAccessRequest(ctx, req)
 }
 
+// GetAccessRequests loads all access requests matching the spupplied filter.
 func (proxy *ProxyClient) GetAccessRequests(ctx context.Context, filter services.AccessRequestFilter) ([]services.AccessRequest, error) {
 	site, err := proxy.ConnectToCurrentCluster(ctx, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	reqs, err := site.GetAccessRequests(filter)
+	reqs, err := site.GetAccessRequests(ctx, filter)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return reqs, nil
 }
 
+// NewWatcher sets up a new event watcher.
 func (proxy *ProxyClient) NewWatcher(ctx context.Context, watch services.Watch) (services.Watcher, error) {
 	site, err := proxy.ConnectToCurrentCluster(ctx, false)
 	if err != nil {

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -36,7 +36,7 @@ func NewDynamicAccessService(backend backend.Backend) *AccessService {
 	return &AccessService{Backend: backend}
 }
 
-func (s *AccessService) CreateAccessRequest(req services.AccessRequest) error {
+func (s *AccessService) CreateAccessRequest(ctx context.Context, req services.AccessRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -44,14 +44,14 @@ func (s *AccessService) CreateAccessRequest(req services.AccessRequest) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if _, err := s.Create(context.TODO(), item); err != nil {
+	if _, err := s.Create(ctx, item); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-func (s *AccessService) SetAccessRequestState(name string, state services.RequestState) error {
-	item, err := s.Get(context.TODO(), accessRequestKey(name))
+func (s *AccessService) SetAccessRequestState(ctx context.Context, name string, state services.RequestState) error {
+	item, err := s.Get(ctx, accessRequestKey(name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("cannot set state of access request %q (not found)", name)
@@ -74,14 +74,14 @@ func (s *AccessService) SetAccessRequestState(name string, state services.Reques
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if _, err := s.CompareAndSwap(context.TODO(), *item, newItem); err != nil {
+	if _, err := s.CompareAndSwap(ctx, *item, newItem); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-func (s *AccessService) GetAccessRequest(name string) (services.AccessRequest, error) {
-	item, err := s.Get(context.TODO(), accessRequestKey(name))
+func (s *AccessService) GetAccessRequest(ctx context.Context, name string) (services.AccessRequest, error) {
+	item, err := s.Get(ctx, accessRequestKey(name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return nil, trace.NotFound("access request %q not found", name)
@@ -95,8 +95,20 @@ func (s *AccessService) GetAccessRequest(name string) (services.AccessRequest, e
 	return req, nil
 }
 
-func (s *AccessService) GetAccessRequests(filter services.AccessRequestFilter) ([]services.AccessRequest, error) {
-	result, err := s.GetRange(context.TODO(), backend.Key(accessRequestsPrefix), backend.RangeEnd(backend.Key(accessRequestsPrefix)), backend.NoLimit)
+func (s *AccessService) GetAccessRequests(ctx context.Context, filter services.AccessRequestFilter) ([]services.AccessRequest, error) {
+	// Filters which specify ID are a special case since they will match exactly zero or one
+	// possible requests.
+	if filter.ID != "" {
+		req, err := s.GetAccessRequest(ctx, filter.ID)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !filter.Match(req) {
+			return nil, nil
+		}
+		return []services.AccessRequest{req}, nil
+	}
+	result, err := s.GetRange(ctx, backend.Key(accessRequestsPrefix), backend.RangeEnd(backend.Key(accessRequestsPrefix)), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -110,8 +122,6 @@ func (s *AccessService) GetAccessRequests(filter services.AccessRequestFilter) (
 			return nil, trace.Wrap(err)
 		}
 		if !filter.Match(req) {
-			// TODO(fspmarshall): optimize filtering to
-			// avoid full query/iteration in some cases.
 			continue
 		}
 		requests = append(requests, req)
@@ -119,8 +129,8 @@ func (s *AccessService) GetAccessRequests(filter services.AccessRequestFilter) (
 	return requests, nil
 }
 
-func (s *AccessService) DeleteAccessRequest(name string) error {
-	err := s.Delete(context.TODO(), accessRequestKey(name))
+func (s *AccessService) DeleteAccessRequest(ctx context.Context, name string) error {
+	err := s.Delete(ctx, accessRequestKey(name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("cannot delete access request %q (not found)", name)

--- a/lib/services/types.pb.go
+++ b/lib/services/types.pb.go
@@ -34,10 +34,17 @@ const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 type RequestState int32
 
 const (
-	RequestState_NONE     RequestState = 0
-	RequestState_PENDING  RequestState = 1
+	// NONE variant exists to allow RequestState to be explicitly omitted
+	// in certain circumstances (e.g. in an AccessRequestFilter).
+	RequestState_NONE RequestState = 0
+	// PENDING variant is the default for newly created requests.
+	RequestState_PENDING RequestState = 1
+	// APPROVED variant indicates that a request has been accepted by
+	// an administrating party.
 	RequestState_APPROVED RequestState = 2
-	RequestState_DENIED   RequestState = 3
+	// DENIED variant indicates that a request has been rejected by
+	// an administrating party.
+	RequestState_DENIED RequestState = 3
 )
 
 var RequestState_name = map[int32]string{
@@ -57,7 +64,7 @@ func (x RequestState) String() string {
 	return proto.EnumName(RequestState_name, int32(x))
 }
 func (RequestState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{0}
+	return fileDescriptor_types_c96a02d876242e74, []int{0}
 }
 
 type KeepAlive struct {
@@ -78,7 +85,7 @@ func (m *KeepAlive) Reset()         { *m = KeepAlive{} }
 func (m *KeepAlive) String() string { return proto.CompactTextString(m) }
 func (*KeepAlive) ProtoMessage()    {}
 func (*KeepAlive) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{0}
+	return fileDescriptor_types_c96a02d876242e74, []int{0}
 }
 func (m *KeepAlive) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -131,7 +138,7 @@ func (m *Metadata) Reset()         { *m = Metadata{} }
 func (m *Metadata) String() string { return proto.CompactTextString(m) }
 func (*Metadata) ProtoMessage()    {}
 func (*Metadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{1}
+	return fileDescriptor_types_c96a02d876242e74, []int{1}
 }
 func (m *Metadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -190,7 +197,7 @@ type Rotation struct {
 func (m *Rotation) Reset()      { *m = Rotation{} }
 func (*Rotation) ProtoMessage() {}
 func (*Rotation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{2}
+	return fileDescriptor_types_c96a02d876242e74, []int{2}
 }
 func (m *Rotation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -237,7 +244,7 @@ func (m *RotationSchedule) Reset()         { *m = RotationSchedule{} }
 func (m *RotationSchedule) String() string { return proto.CompactTextString(m) }
 func (*RotationSchedule) ProtoMessage()    {}
 func (*RotationSchedule) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{3}
+	return fileDescriptor_types_c96a02d876242e74, []int{3}
 }
 func (m *RotationSchedule) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -286,7 +293,7 @@ func (m *ResourceHeader) Reset()         { *m = ResourceHeader{} }
 func (m *ResourceHeader) String() string { return proto.CompactTextString(m) }
 func (*ResourceHeader) ProtoMessage()    {}
 func (*ResourceHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{4}
+	return fileDescriptor_types_c96a02d876242e74, []int{4}
 }
 func (m *ResourceHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -335,7 +342,7 @@ type ServerV2 struct {
 func (m *ServerV2) Reset()      { *m = ServerV2{} }
 func (*ServerV2) ProtoMessage() {}
 func (*ServerV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{5}
+	return fileDescriptor_types_c96a02d876242e74, []int{5}
 }
 func (m *ServerV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -388,7 +395,7 @@ func (m *ServerSpecV2) Reset()         { *m = ServerSpecV2{} }
 func (m *ServerSpecV2) String() string { return proto.CompactTextString(m) }
 func (*ServerSpecV2) ProtoMessage()    {}
 func (*ServerSpecV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{6}
+	return fileDescriptor_types_c96a02d876242e74, []int{6}
 }
 func (m *ServerSpecV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -435,7 +442,7 @@ func (m *CommandLabelV2) Reset()         { *m = CommandLabelV2{} }
 func (m *CommandLabelV2) String() string { return proto.CompactTextString(m) }
 func (*CommandLabelV2) ProtoMessage()    {}
 func (*CommandLabelV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{7}
+	return fileDescriptor_types_c96a02d876242e74, []int{7}
 }
 func (m *CommandLabelV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -479,7 +486,7 @@ func (m *TLSKeyPair) Reset()         { *m = TLSKeyPair{} }
 func (m *TLSKeyPair) String() string { return proto.CompactTextString(m) }
 func (*TLSKeyPair) ProtoMessage()    {}
 func (*TLSKeyPair) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{8}
+	return fileDescriptor_types_c96a02d876242e74, []int{8}
 }
 func (m *TLSKeyPair) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -528,7 +535,7 @@ type CertAuthorityV2 struct {
 func (m *CertAuthorityV2) Reset()      { *m = CertAuthorityV2{} }
 func (*CertAuthorityV2) ProtoMessage() {}
 func (*CertAuthorityV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{9}
+	return fileDescriptor_types_c96a02d876242e74, []int{9}
 }
 func (m *CertAuthorityV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -591,7 +598,7 @@ func (m *CertAuthoritySpecV2) Reset()         { *m = CertAuthoritySpecV2{} }
 func (m *CertAuthoritySpecV2) String() string { return proto.CompactTextString(m) }
 func (*CertAuthoritySpecV2) ProtoMessage()    {}
 func (*CertAuthoritySpecV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{10}
+	return fileDescriptor_types_c96a02d876242e74, []int{10}
 }
 func (m *CertAuthoritySpecV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -636,7 +643,7 @@ func (m *RoleMapping) Reset()         { *m = RoleMapping{} }
 func (m *RoleMapping) String() string { return proto.CompactTextString(m) }
 func (*RoleMapping) ProtoMessage()    {}
 func (*RoleMapping) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{11}
+	return fileDescriptor_types_c96a02d876242e74, []int{11}
 }
 func (m *RoleMapping) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -683,7 +690,7 @@ type ProvisionTokenV1 struct {
 func (m *ProvisionTokenV1) Reset()      { *m = ProvisionTokenV1{} }
 func (*ProvisionTokenV1) ProtoMessage() {}
 func (*ProvisionTokenV1) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{12}
+	return fileDescriptor_types_c96a02d876242e74, []int{12}
 }
 func (m *ProvisionTokenV1) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -732,7 +739,7 @@ type ProvisionTokenV2 struct {
 func (m *ProvisionTokenV2) Reset()      { *m = ProvisionTokenV2{} }
 func (*ProvisionTokenV2) ProtoMessage() {}
 func (*ProvisionTokenV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{13}
+	return fileDescriptor_types_c96a02d876242e74, []int{13}
 }
 func (m *ProvisionTokenV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -776,7 +783,7 @@ func (m *ProvisionTokenSpecV2) Reset()         { *m = ProvisionTokenSpecV2{} }
 func (m *ProvisionTokenSpecV2) String() string { return proto.CompactTextString(m) }
 func (*ProvisionTokenSpecV2) ProtoMessage()    {}
 func (*ProvisionTokenSpecV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{14}
+	return fileDescriptor_types_c96a02d876242e74, []int{14}
 }
 func (m *ProvisionTokenSpecV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -825,7 +832,7 @@ type StaticTokensV2 struct {
 func (m *StaticTokensV2) Reset()      { *m = StaticTokensV2{} }
 func (*StaticTokensV2) ProtoMessage() {}
 func (*StaticTokensV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{15}
+	return fileDescriptor_types_c96a02d876242e74, []int{15}
 }
 func (m *StaticTokensV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -868,7 +875,7 @@ func (m *StaticTokensSpecV2) Reset()         { *m = StaticTokensSpecV2{} }
 func (m *StaticTokensSpecV2) String() string { return proto.CompactTextString(m) }
 func (*StaticTokensSpecV2) ProtoMessage()    {}
 func (*StaticTokensSpecV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{16}
+	return fileDescriptor_types_c96a02d876242e74, []int{16}
 }
 func (m *StaticTokensSpecV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -917,7 +924,7 @@ type ClusterNameV2 struct {
 func (m *ClusterNameV2) Reset()      { *m = ClusterNameV2{} }
 func (*ClusterNameV2) ProtoMessage() {}
 func (*ClusterNameV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{17}
+	return fileDescriptor_types_c96a02d876242e74, []int{17}
 }
 func (m *ClusterNameV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -960,7 +967,7 @@ func (m *ClusterNameSpecV2) Reset()         { *m = ClusterNameSpecV2{} }
 func (m *ClusterNameSpecV2) String() string { return proto.CompactTextString(m) }
 func (*ClusterNameSpecV2) ProtoMessage()    {}
 func (*ClusterNameSpecV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{18}
+	return fileDescriptor_types_c96a02d876242e74, []int{18}
 }
 func (m *ClusterNameSpecV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1009,7 +1016,7 @@ type ClusterConfigV3 struct {
 func (m *ClusterConfigV3) Reset()      { *m = ClusterConfigV3{} }
 func (*ClusterConfigV3) ProtoMessage() {}
 func (*ClusterConfigV3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{19}
+	return fileDescriptor_types_c96a02d876242e74, []int{19}
 }
 func (m *ClusterConfigV3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1072,7 +1079,7 @@ func (m *ClusterConfigSpecV3) Reset()         { *m = ClusterConfigSpecV3{} }
 func (m *ClusterConfigSpecV3) String() string { return proto.CompactTextString(m) }
 func (*ClusterConfigSpecV3) ProtoMessage()    {}
 func (*ClusterConfigSpecV3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{20}
+	return fileDescriptor_types_c96a02d876242e74, []int{20}
 }
 func (m *ClusterConfigSpecV3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1125,7 +1132,7 @@ func (m *AuditConfig) Reset()         { *m = AuditConfig{} }
 func (m *AuditConfig) String() string { return proto.CompactTextString(m) }
 func (*AuditConfig) ProtoMessage()    {}
 func (*AuditConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{21}
+	return fileDescriptor_types_c96a02d876242e74, []int{21}
 }
 func (m *AuditConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1175,7 +1182,7 @@ func (m *Namespace) Reset()         { *m = Namespace{} }
 func (m *Namespace) String() string { return proto.CompactTextString(m) }
 func (*Namespace) ProtoMessage()    {}
 func (*Namespace) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{22}
+	return fileDescriptor_types_c96a02d876242e74, []int{22}
 }
 func (m *Namespace) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1215,7 +1222,7 @@ func (m *NamespaceSpec) Reset()         { *m = NamespaceSpec{} }
 func (m *NamespaceSpec) String() string { return proto.CompactTextString(m) }
 func (*NamespaceSpec) ProtoMessage()    {}
 func (*NamespaceSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{23}
+	return fileDescriptor_types_c96a02d876242e74, []int{23}
 }
 func (m *NamespaceSpec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1264,7 +1271,7 @@ type AccessRequestV3 struct {
 func (m *AccessRequestV3) Reset()      { *m = AccessRequestV3{} }
 func (*AccessRequestV3) ProtoMessage() {}
 func (*AccessRequestV3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{24}
+	return fileDescriptor_types_c96a02d876242e74, []int{24}
 }
 func (m *AccessRequestV3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1314,7 +1321,7 @@ func (m *AccessRequestSpecV3) Reset()         { *m = AccessRequestSpecV3{} }
 func (m *AccessRequestSpecV3) String() string { return proto.CompactTextString(m) }
 func (*AccessRequestSpecV3) ProtoMessage()    {}
 func (*AccessRequestSpecV3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{25}
+	return fileDescriptor_types_c96a02d876242e74, []int{25}
 }
 func (m *AccessRequestSpecV3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1360,7 +1367,7 @@ func (m *AccessRequestFilter) Reset()         { *m = AccessRequestFilter{} }
 func (m *AccessRequestFilter) String() string { return proto.CompactTextString(m) }
 func (*AccessRequestFilter) ProtoMessage()    {}
 func (*AccessRequestFilter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{26}
+	return fileDescriptor_types_c96a02d876242e74, []int{26}
 }
 func (m *AccessRequestFilter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1409,7 +1416,7 @@ type RoleV3 struct {
 func (m *RoleV3) Reset()      { *m = RoleV3{} }
 func (*RoleV3) ProtoMessage() {}
 func (*RoleV3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{27}
+	return fileDescriptor_types_c96a02d876242e74, []int{27}
 }
 func (m *RoleV3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1455,7 +1462,7 @@ func (m *RoleSpecV3) Reset()         { *m = RoleSpecV3{} }
 func (m *RoleSpecV3) String() string { return proto.CompactTextString(m) }
 func (*RoleSpecV3) ProtoMessage()    {}
 func (*RoleSpecV3) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{28}
+	return fileDescriptor_types_c96a02d876242e74, []int{28}
 }
 func (m *RoleSpecV3) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1514,7 +1521,7 @@ func (m *RoleOptions) Reset()         { *m = RoleOptions{} }
 func (m *RoleOptions) String() string { return proto.CompactTextString(m) }
 func (*RoleOptions) ProtoMessage()    {}
 func (*RoleOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{29}
+	return fileDescriptor_types_c96a02d876242e74, []int{29}
 }
 func (m *RoleOptions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1568,7 +1575,7 @@ func (m *RoleConditions) Reset()         { *m = RoleConditions{} }
 func (m *RoleConditions) String() string { return proto.CompactTextString(m) }
 func (*RoleConditions) ProtoMessage()    {}
 func (*RoleConditions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{30}
+	return fileDescriptor_types_c96a02d876242e74, []int{30}
 }
 func (m *RoleConditions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1610,7 +1617,7 @@ func (m *AccessRequestConditions) Reset()         { *m = AccessRequestConditions
 func (m *AccessRequestConditions) String() string { return proto.CompactTextString(m) }
 func (*AccessRequestConditions) ProtoMessage()    {}
 func (*AccessRequestConditions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{31}
+	return fileDescriptor_types_c96a02d876242e74, []int{31}
 }
 func (m *AccessRequestConditions) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1659,7 +1666,7 @@ func (m *Rule) Reset()         { *m = Rule{} }
 func (m *Rule) String() string { return proto.CompactTextString(m) }
 func (*Rule) ProtoMessage()    {}
 func (*Rule) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{32}
+	return fileDescriptor_types_c96a02d876242e74, []int{32}
 }
 func (m *Rule) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1701,7 +1708,7 @@ func (m *BoolValue) Reset()         { *m = BoolValue{} }
 func (m *BoolValue) String() string { return proto.CompactTextString(m) }
 func (*BoolValue) ProtoMessage()    {}
 func (*BoolValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{33}
+	return fileDescriptor_types_c96a02d876242e74, []int{33}
 }
 func (m *BoolValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1750,7 +1757,7 @@ type UserV2 struct {
 func (m *UserV2) Reset()      { *m = UserV2{} }
 func (*UserV2) ProtoMessage() {}
 func (*UserV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{34}
+	return fileDescriptor_types_c96a02d876242e74, []int{34}
 }
 func (m *UserV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1813,7 +1820,7 @@ func (m *UserSpecV2) Reset()         { *m = UserSpecV2{} }
 func (m *UserSpecV2) String() string { return proto.CompactTextString(m) }
 func (*UserSpecV2) ProtoMessage()    {}
 func (*UserSpecV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{35}
+	return fileDescriptor_types_c96a02d876242e74, []int{35}
 }
 func (m *UserSpecV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1858,7 +1865,7 @@ type ExternalIdentity struct {
 func (m *ExternalIdentity) Reset()      { *m = ExternalIdentity{} }
 func (*ExternalIdentity) ProtoMessage() {}
 func (*ExternalIdentity) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{36}
+	return fileDescriptor_types_c96a02d876242e74, []int{36}
 }
 func (m *ExternalIdentity) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1906,7 +1913,7 @@ func (m *LoginStatus) Reset()         { *m = LoginStatus{} }
 func (m *LoginStatus) String() string { return proto.CompactTextString(m) }
 func (*LoginStatus) ProtoMessage()    {}
 func (*LoginStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{37}
+	return fileDescriptor_types_c96a02d876242e74, []int{37}
 }
 func (m *LoginStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1951,7 +1958,7 @@ type CreatedBy struct {
 func (m *CreatedBy) Reset()      { *m = CreatedBy{} }
 func (*CreatedBy) ProtoMessage() {}
 func (*CreatedBy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{38}
+	return fileDescriptor_types_c96a02d876242e74, []int{38}
 }
 func (m *CreatedBy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1997,7 +2004,7 @@ func (m *U2FRegistrationData) Reset()         { *m = U2FRegistrationData{} }
 func (m *U2FRegistrationData) String() string { return proto.CompactTextString(m) }
 func (*U2FRegistrationData) ProtoMessage()    {}
 func (*U2FRegistrationData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{39}
+	return fileDescriptor_types_c96a02d876242e74, []int{39}
 }
 func (m *U2FRegistrationData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2045,7 +2052,7 @@ func (m *LocalAuthSecrets) Reset()         { *m = LocalAuthSecrets{} }
 func (m *LocalAuthSecrets) String() string { return proto.CompactTextString(m) }
 func (*LocalAuthSecrets) ProtoMessage()    {}
 func (*LocalAuthSecrets) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{40}
+	return fileDescriptor_types_c96a02d876242e74, []int{40}
 }
 func (m *LocalAuthSecrets) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2091,7 +2098,7 @@ func (m *ConnectorRef) Reset()         { *m = ConnectorRef{} }
 func (m *ConnectorRef) String() string { return proto.CompactTextString(m) }
 func (*ConnectorRef) ProtoMessage()    {}
 func (*ConnectorRef) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{41}
+	return fileDescriptor_types_c96a02d876242e74, []int{41}
 }
 func (m *ConnectorRef) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2133,7 +2140,7 @@ func (m *UserRef) Reset()         { *m = UserRef{} }
 func (m *UserRef) String() string { return proto.CompactTextString(m) }
 func (*UserRef) ProtoMessage()    {}
 func (*UserRef) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{42}
+	return fileDescriptor_types_c96a02d876242e74, []int{42}
 }
 func (m *UserRef) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2183,7 +2190,7 @@ func (m *ReverseTunnelV2) Reset()         { *m = ReverseTunnelV2{} }
 func (m *ReverseTunnelV2) String() string { return proto.CompactTextString(m) }
 func (*ReverseTunnelV2) ProtoMessage()    {}
 func (*ReverseTunnelV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{43}
+	return fileDescriptor_types_c96a02d876242e74, []int{43}
 }
 func (m *ReverseTunnelV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2230,7 +2237,7 @@ func (m *ReverseTunnelSpecV2) Reset()         { *m = ReverseTunnelSpecV2{} }
 func (m *ReverseTunnelSpecV2) String() string { return proto.CompactTextString(m) }
 func (*ReverseTunnelSpecV2) ProtoMessage()    {}
 func (*ReverseTunnelSpecV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{44}
+	return fileDescriptor_types_c96a02d876242e74, []int{44}
 }
 func (m *ReverseTunnelSpecV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2279,7 +2286,7 @@ type TunnelConnectionV2 struct {
 func (m *TunnelConnectionV2) Reset()      { *m = TunnelConnectionV2{} }
 func (*TunnelConnectionV2) ProtoMessage() {}
 func (*TunnelConnectionV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{45}
+	return fileDescriptor_types_c96a02d876242e74, []int{45}
 }
 func (m *TunnelConnectionV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2327,7 +2334,7 @@ func (m *TunnelConnectionSpecV2) Reset()         { *m = TunnelConnectionSpecV2{}
 func (m *TunnelConnectionSpecV2) String() string { return proto.CompactTextString(m) }
 func (*TunnelConnectionSpecV2) ProtoMessage()    {}
 func (*TunnelConnectionSpecV2) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_e2396f0bdbc60acd, []int{46}
+	return fileDescriptor_types_c96a02d876242e74, []int{46}
 }
 func (m *TunnelConnectionSpecV2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -14240,9 +14247,9 @@ var (
 	ErrIntOverflowTypes   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("types.proto", fileDescriptor_types_e2396f0bdbc60acd) }
+func init() { proto.RegisterFile("types.proto", fileDescriptor_types_c96a02d876242e74) }
 
-var fileDescriptor_types_e2396f0bdbc60acd = []byte{
+var fileDescriptor_types_c96a02d876242e74 = []byte{
 	// 3717 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xdc, 0x3a, 0x4d, 0x73, 0x1c, 0xc7,
 	0x75, 0xdc, 0x0f, 0x00, 0xbb, 0x6f, 0x01, 0x10, 0x6c, 0x80, 0xe4, 0xf2, 0x43, 0x1c, 0x68, 0x14,

--- a/lib/services/types.proto
+++ b/lib/services/types.proto
@@ -390,9 +390,16 @@ message AccessRequestV3  {
 
 // RequestState represents the state of a request for escalated privilege.
 enum RequestState {
+    // NONE variant exists to allow RequestState to be explicitly omitted
+    // in certain circumstances (e.g. in an AccessRequestFilter).
     NONE = 0;
+    // PENDING variant is the default for newly created requests.
     PENDING = 1;
+    // APPROVED variant indicates that a request has been accepted by
+    // an administrating party.
     APPROVED = 2;
+    // DENIED variant indicates that a request has been rejected by
+    // an administrating party.
     DENIED = 3;
 }
 

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -90,7 +91,7 @@ func (c *AccessRequestCommand) TryRun(cmd string, client auth.ClientI) (match bo
 }
 
 func (c *AccessRequestCommand) List(client auth.ClientI) error {
-	reqs, err := client.GetAccessRequests(services.AccessRequestFilter{})
+	reqs, err := client.GetAccessRequests(context.TODO(), services.AccessRequestFilter{})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -102,7 +103,7 @@ func (c *AccessRequestCommand) List(client auth.ClientI) error {
 
 func (c *AccessRequestCommand) Approve(client auth.ClientI) error {
 	for _, reqID := range strings.Split(c.reqIDs, ",") {
-		if err := client.SetAccessRequestState(reqID, services.RequestState_APPROVED); err != nil {
+		if err := client.SetAccessRequestState(context.TODO(), reqID, services.RequestState_APPROVED); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -111,7 +112,7 @@ func (c *AccessRequestCommand) Approve(client auth.ClientI) error {
 
 func (c *AccessRequestCommand) Deny(client auth.ClientI) error {
 	for _, reqID := range strings.Split(c.reqIDs, ",") {
-		if err := client.SetAccessRequestState(reqID, services.RequestState_DENIED); err != nil {
+		if err := client.SetAccessRequestState(context.TODO(), reqID, services.RequestState_DENIED); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -124,7 +125,7 @@ func (c *AccessRequestCommand) Create(client auth.ClientI) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := client.CreateAccessRequest(req); err != nil {
+	if err := client.CreateAccessRequest(context.TODO(), req); err != nil {
 		return trace.Wrap(err)
 	}
 	fmt.Printf("%s\n", req.GetName())
@@ -133,7 +134,7 @@ func (c *AccessRequestCommand) Create(client auth.ClientI) error {
 
 func (c *AccessRequestCommand) Delete(client auth.ClientI) error {
 	for _, reqID := range strings.Split(c.reqIDs, ",") {
-		if err := client.DeleteAccessRequest(reqID); err != nil {
+		if err := client.DeleteAccessRequest(context.TODO(), reqID); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/tool/tsh/common/identity.go
+++ b/tool/tsh/common/identity.go
@@ -17,11 +17,8 @@ limitations under the License.
 package common
 
 import (
-	"bufio"
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -51,7 +48,7 @@ func LoadIdentity(idFn string) (*client.Key, ssh.HostKeyCallback, error) {
 		return nil, nil, trace.Wrap(err)
 	}
 	defer f.Close()
-	ident, err := decodeIdentity(f)
+	ident, err := client.DecodeIdentityFile(f)
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "failed to parse identity file")
 	}
@@ -131,89 +128,4 @@ func LoadIdentity(idFn string) (*client.Key, ssh.HostKeyCallback, error) {
 		TLSCert:   ident.Certs.TLS,
 		TrustedCA: trustedCA,
 	}, hostAuthFunc, nil
-}
-
-// rawIdentity encodes the basic components of an identity file.
-type rawIdentity struct {
-	PrivateKey []byte
-	Certs      struct {
-		SSH []byte
-		TLS []byte
-	}
-	CACerts struct {
-		SSH [][]byte
-		TLS [][]byte
-	}
-}
-
-// decodeIdentity attempts to break up the contents of an identity file
-// into its respective components.
-func decodeIdentity(r io.Reader) (*rawIdentity, error) {
-	scanner := bufio.NewScanner(r)
-	var ident rawIdentity
-	// Subslice of scanner's buffer pointing to current line
-	// with leading and trailing whitespace trimmed.
-	var line []byte
-	// Attempt to scan to the next line.
-	scanln := func() bool {
-		if !scanner.Scan() {
-			line = nil
-			return false
-		}
-		line = bytes.TrimSpace(scanner.Bytes())
-		return true
-	}
-	// Check if the current line starts with prefix `p`.
-	peekln := func(p string) bool {
-		return bytes.HasPrefix(line, []byte(p))
-	}
-	// Get an "owned" copy of the current line.
-	cloneln := func() []byte {
-		ln := make([]byte, len(line))
-		copy(ln, line)
-		return ln
-	}
-	// Scan through all lines of identity file.  Lines with a known prefix
-	// are copied out of the scanner's buffer.  All others are ignored.
-	for scanln() {
-		switch {
-		case peekln("ssh"):
-			ident.Certs.SSH = cloneln()
-		case peekln("@cert-authority"):
-			ident.CACerts.SSH = append(ident.CACerts.SSH, cloneln())
-		case peekln("-----BEGIN"):
-			// Current line marks the beginning of a PEM block.  Consume all
-			// lines until a corresponding END is found.
-			var pemBlock []byte
-			for {
-				pemBlock = append(pemBlock, line...)
-				pemBlock = append(pemBlock, '\n')
-				if peekln("-----END") {
-					break
-				}
-				if !scanln() {
-					// If scanner has terminated in the middle of a PEM block, either
-					// the reader encountered an error, or the PEM block is a fragment.
-					if err := scanner.Err(); err != nil {
-						return nil, trace.Wrap(err)
-					}
-					return nil, trace.BadParameter("invalid PEM block (fragment)")
-				}
-			}
-			// Decide where to place the pem block based on
-			// which pem blocks have already been found.
-			switch {
-			case ident.PrivateKey == nil:
-				ident.PrivateKey = pemBlock
-			case ident.Certs.TLS == nil:
-				ident.Certs.TLS = pemBlock
-			default:
-				ident.CACerts.TLS = append(ident.CACerts.TLS, pemBlock)
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &ident, nil
 }


### PR DESCRIPTION
Cleanup and QoL improvements that were held back from the main access-request PR (#3131) in favor of getting `rc.1` out in a timely manner.