### PR TITLE
Don't print an error message on shell exit.

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -409,9 +409,13 @@ func RunCommand() {
 		errorAndExit(errorWriter, teleport.RemoteCommandFailure, err)
 	}
 
-	// Wait for it to exit.
+	// Wait for the command to exit. It doesn't make sense to print an error
+	// message here because the shell has successfully started. If an error
+	// occured during shell execution or the shell exits with an error (like
+	// running exit 2), the shell will print an error if appropriate and return
+	// an exit code.
 	err = cmd.Wait()
-	errorAndExit(errorWriter, exitCode(err), err)
+	os.Exit(exitCode(err))
 }
 
 func (e *localExec) transformSecureCopy() error {


### PR DESCRIPTION
**Description**

If a shell has been successfully started, don't print an error message saying the shell failed to start if it exits with exit code other than 0. If an error occurred during shell execution or the shell will print the message itself and exit with an error.