### PR TITLE
Relax restrictive traits schema, fixes #3053

### DIFF
--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -277,7 +277,7 @@ const UserSpecV2SchemaTemplate = `{
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^[a-zA-Z/.0-9-_:]+$": {
+        "^.+$": {
           "type": ["array", "null"],
           "items": {
             "type": "string"


### PR DESCRIPTION
This commit relaxes restriction on traits names
that breaks OIDC claims using URL format or @ symbols.