### PR TITLE
Add some clarity about RBAC based on customer feedback

### DIFF
--- a/assets/marketplace/Makefile
+++ b/assets/marketplace/Makefile
@@ -14,7 +14,7 @@ MARKETPLACE_AMI_NAME ?=
 AWS_REGION ?= us-west-2
 
 # Teleport version
-TELEPORT_VERSION ?= 4.1.4
+TELEPORT_VERSION ?= 4.1.6
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007

--- a/assets/marketplace/files/bin/teleport-generate-config
+++ b/assets/marketplace/files/bin/teleport-generate-config
@@ -62,7 +62,7 @@ teleport:
     type: dynamodb
     region: ${EC2_REGION}
     table_name: ${TELEPORT_DYNAMO_TABLE_NAME}
-    audit_table_name: ${TELEPORT_DYNAMO_EVENTS_TABLE_NAME}
+    audit_events_uri: dynamodb://${TELEPORT_DYNAMO_EVENTS_TABLE_NAME}
     audit_sessions_uri: s3://${TELEPORT_S3_BUCKET}/records
 
 ssh_service:

--- a/docs/4.1/enterprise/ssh_rbac.md
+++ b/docs/4.1/enterprise/ssh_rbac.md
@@ -101,12 +101,12 @@ spec:
   allow:
     # logins array defines the OS/UNIX logins a user is allowed to use.
     # a few special variables are supported here (see below)
-    logins: [root, '{{internal.logins}}']
+    logins: [root, "{{internal.logins}}"]
     # if kubernetes integration is enabled, this setting configures which
     # kubernetes groups the users of this role will be assigned to.
     # note that you can refer to a SAML/OIDC trait via the "external" property bag,
     # this allows you to specify Kubernetes group membership in an identity manager:
-    kubernetes_groups: ["system:masters", "{{external.trait_name}}"]]
+    kubernetes_groups: ["system:masters", "{{external.trait_name}}"]
 
     # list of node labels a user will be allowed to connect to:
     node_labels:

--- a/docs/4.1/enterprise/ssh_rbac.md
+++ b/docs/4.1/enterprise/ssh_rbac.md
@@ -106,6 +106,7 @@ spec:
     # kubernetes groups the users of this role will be assigned to.
     # note that you can refer to a SAML/OIDC trait via the "external" property bag,
     # this allows you to specify Kubernetes group membership in an identity manager:
+    # replace "trait_name" here with the actual name of the trait as sent by the identity provider
     kubernetes_groups: ["system:masters", "{{external.trait_name}}"]
 
     # list of node labels a user will be allowed to connect to:
@@ -138,10 +139,13 @@ spec:
 
 The following variables can be used with `logins` field:
 
-Variable                | Description
-------------------------|--------------------------
-`{{internal.logins}}` | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database.
-`{{external.xyz}}`    | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim.
+Variable                  | Description
+--------------------------|--------------------------
+`{{internal.logins}}`     | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database.
+`{{external.trait_name}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). For SAML, this will be expanded with the "trait_name" assertion value. For OIDC, this will be expanded with the value of the "trait_name" claim.
+
+!!! tip "Internal vs external":
+    `internal.logins` is a special unique value which uses Teleport's own internal database, while `trait_name` in `external.trait_name` is intended to be replaced with the name of an actual SAML assertion or OIDC claim as sent by the identity provider.
 
 Both variables above are there to deliver the same benefit: they allow Teleport
 administrators to define allowed OS logins via the user database, be it the
@@ -162,7 +166,6 @@ Assuming you have the following SAML assertion attribute in your response:
 logins:
    - '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}'
 ```
-
 
 ### Role Options
 


### PR DESCRIPTION
We had some feedback from a customer regarding a typo and some bits of our docs where it wasn't clear what to do, so I'm addressing their points.

They also pointed out that `audit_table_name` doesn't appear in the docs any more but an example (along with our AMI generation code) is still using it, so I fixed that too.