### PR TITLE
Allow port forwarding to be disabled.

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -128,6 +128,10 @@ func NewImplicitRole() Role {
 		Spec: RoleSpecV3{
 			Options: RoleOptions{
 				MaxSessionTTL: MaxDuration(),
+				// PortForwarding has to be set to false in the default-implicit-role
+				// otherwise all roles will be allowed to forward ports (since we default
+				// to true in the check).
+				PortForwarding: NewBoolOption(false),
 			},
 			Allow: RoleConditions{
 				Namespaces: []string{defaults.Namespace},


### PR DESCRIPTION
**Description**

If the option for port forwarding is not specified, it's enabled by default. Port forwarding is not specified in the `default-implicit-role`. Since it's included in all role sets, port forwarding is always enabled for all roles.

To fix this, port forwarding in the `default-implicit-role` is set to false.