### PR TITLE
Add support for access request resource to cache 

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -48,6 +48,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: services.KindProxy},
 		{Kind: services.KindReverseTunnel},
 		{Kind: services.KindTunnelConnection},
+		{Kind: services.KindAccessRequest},
 	}
 	cfg.QueueSize = defaults.AuthQueueSize
 	return cfg
@@ -118,6 +119,7 @@ type Cache struct {
 	provisionerCache   services.Provisioner
 	usersCache         services.UsersService
 	accessCache        services.Access
+	dynamicAccessCache services.DynamicAccessExt
 	presenceCache      services.Presence
 	eventsCache        services.Events
 
@@ -145,6 +147,8 @@ type Config struct {
 	Users services.UsersService
 	// Access is an access service
 	Access services.Access
+	// DynamicAccess is a dynamic access service
+	DynamicAccess services.DynamicAccess
 	// Presence is a presence service
 	Presence services.Presence
 	// Backend is a backend for local cache
@@ -274,6 +278,7 @@ func New(config Config) (*Cache, error) {
 		provisionerCache:   local.NewProvisioningService(wrapper),
 		usersCache:         local.NewIdentityService(wrapper),
 		accessCache:        local.NewAccessService(wrapper),
+		dynamicAccessCache: local.NewDynamicAccessService(wrapper),
 		presenceCache:      local.NewPresenceService(wrapper),
 		eventsCache:        local.NewEventsService(config.Backend),
 		Entry: log.WithFields(log.Fields{

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -68,9 +68,10 @@ type testPack struct {
 	provisionerS   services.Provisioner
 	clusterConfigS services.ClusterConfiguration
 
-	usersS    services.UsersService
-	accessS   services.Access
-	presenceS services.Presence
+	usersS         services.UsersService
+	accessS        services.Access
+	dynamicAccessS services.DynamicAccess
+	presenceS      services.Presence
 }
 
 func (t *testPack) Close() {
@@ -127,6 +128,7 @@ func (s *CacheSuite) newPackWithoutCache(c *check.C, setupConfig SetupConfigFn) 
 	p.presenceS = local.NewPresenceService(p.backend)
 	p.usersS = local.NewIdentityService(p.backend)
 	p.accessS = local.NewAccessService(p.backend)
+	p.dynamicAccessS = local.NewDynamicAccessService(p.backend)
 	return p
 }
 
@@ -143,6 +145,7 @@ func (s *CacheSuite) newPack(c *check.C, setupConfig func(c Config) Config) *tes
 		Trust:         p.trustS,
 		Users:         p.usersS,
 		Access:        p.accessS,
+		DynamicAccess: p.dynamicAccessS,
 		Presence:      p.presenceS,
 		RetryPeriod:   200 * time.Millisecond,
 		EventsC:       p.eventsC,
@@ -206,6 +209,7 @@ func (s *CacheSuite) TestOnlyRecentInit(c *check.C) {
 		Trust:         p.trustS,
 		Users:         p.usersS,
 		Access:        p.accessS,
+		DynamicAccess: p.dynamicAccessS,
 		Presence:      p.presenceS,
 		RetryPeriod:   200 * time.Millisecond,
 		EventsC:       p.eventsC,
@@ -355,6 +359,7 @@ func (s *CacheSuite) preferRecent(c *check.C) {
 		Trust:         p.trustS,
 		Users:         p.usersS,
 		Access:        p.accessS,
+		DynamicAccess: p.dynamicAccessS,
 		Presence:      p.presenceS,
 		RetryPeriod:   200 * time.Millisecond,
 		EventsC:       p.eventsC,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1314,6 +1314,7 @@ func (process *TeleportProcess) newAccessCache(cfg accessCacheConfig) (*cache.Ca
 		Trust:           cfg.services,
 		Users:           cfg.services,
 		Access:          cfg.services,
+		DynamicAccess:   cfg.services,
 		Presence:        cfg.services,
 		Component:       teleport.Component(append(cfg.cacheName, process.id, teleport.ComponentCache)...),
 		MetricComponent: teleport.Component(append(cfg.cacheName, teleport.ComponentCache)...),

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -152,6 +152,16 @@ type DynamicAccess interface {
 	DeleteAccessRequest(ctx context.Context, reqID string) error
 }
 
+// DynamicAccessExt is an extended dynamic access interface
+// used to implement some auth server internals.
+type DynamicAccessExt interface {
+	DynamicAccess
+	// UpsertAccessRequest creates or updates an access request.
+	UpsertAccessRequest(ctx context.Context, req AccessRequest) error
+	// DeleteAllAccessRequests deletes all existant access requests.
+	DeleteAllAccessRequests(ctx context.Context) error
+}
+
 // AccessRequest is a request for temporarily granted roles
 type AccessRequest interface {
 	Resource

--- a/lib/services/services.go
+++ b/lib/services/services.go
@@ -24,5 +24,6 @@ type Services interface {
 	Events
 	ClusterConfiguration
 	Access
+	DynamicAccess
 	Presence
 }

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -84,6 +84,8 @@ func (c *AccessRequestCommand) TryRun(cmd string, client auth.ClientI) (match bo
 		err = c.Deny(client)
 	case c.requestCreate.FullCommand():
 		err = c.Create(client)
+	case c.requestDelete.FullCommand():
+		err = c.Delete(client)
 	default:
 		return false, nil
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1327,20 +1327,32 @@ Loop:
 	for {
 		select {
 		case event := <-watcher.Events():
-			if event.Type != backend.OpPut {
+			switch event.Type {
+			case backend.OpInit:
+				log.Infof("Access-request watcher initialized...")
 				continue Loop
+			case backend.OpPut:
+				r, ok := event.Resource.(*services.AccessRequestV3)
+				if !ok {
+					return trace.BadParameter("unexpected resource type %T", event.Resource)
+				}
+				if r.GetName() != req.GetName() || r.GetState().IsPending() {
+					log.Infof("Skipping put event id=%s,state=%s.", r.GetName(), r.GetState())
+					continue Loop
+				}
+				if !r.GetState().IsApproved() {
+					return trace.Errorf("request %s has been set to %s", r.GetName(), r.GetState().String())
+				}
+				return nil
+			case backend.OpDelete:
+				if event.Resource.GetName() != req.GetName() {
+					log.Infof("Skipping delete event id=%s", event.Resource.GetName())
+					continue Loop
+				}
+				return trace.Errorf("request %s has expired or been deleted...", event.Resource.GetName())
+			default:
+				log.Warnf("Skipping unknown event type %s", event.Type)
 			}
-			r, ok := event.Resource.(*services.AccessRequestV3)
-			if !ok {
-				return trace.Errorf("unexpected resource type %T", event.Resource)
-			}
-			if r.GetName() != req.GetName() || r.GetState().IsPending() {
-				continue Loop
-			}
-			if !r.GetState().IsApproved() {
-				return trace.Errorf("request %s has been set to %s", r.GetName(), r.GetState().String())
-			}
-			return nil
 		case <-watcher.Done():
 			utils.FatalError(watcher.Error())
 		}


### PR DESCRIPTION
Cache was missing support for access requests, causing watchers to hang indefinitely without receiving events when cache was in use.

Fixes #3213