### PR TITLE
Set public_addr for ssh_service on demo instances

### DIFF
--- a/examples/chart/teleport-demo/templates/auth-config.yaml
+++ b/examples/chart/teleport-demo/templates/auth-config.yaml
@@ -25,6 +25,7 @@ data:
 
     ssh_service:
       enabled: yes
+      public_addr: 127.0.0.1:3022
       {{- if .Values.teleportLabels.auth.static }}
       labels:
       {{- range $key, $value := .Values.teleportLabels.auth.static }}
@@ -160,6 +161,7 @@ data:
 
     ssh_service:
       enabled: yes
+      public_addr: 127.0.0.1:3022
       {{- if $root.Values.teleportLabels.auth.static }}
       labels:
       {{- range $key, $value := $root.Values.teleportLabels.auth.static }}


### PR DESCRIPTION
This should allow us to use the `tsh join` command during demos rather than getting the current `127.0.0.1 is not in the list of valid principals` error.

Related to #3195 