### PR TITLE
Expose auth server in integration tests.

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -63,6 +63,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	Loopback = "127.0.0.1"
+	Host     = "localhost"
+)
+
 // SetTestTimeouts affects global timeouts inside Teleport, making connections
 // work faster but consuming more CPU (useful for integration testing)
 func SetTestTimeouts(t time.Duration) {
@@ -507,6 +512,12 @@ func (i *TeleInstance) GenerateConfig(trustedSecrets []*InstanceSecrets, tconf *
 		},
 	}
 	tconf.Auth.SSHAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortAuth())
+	tconf.Auth.PublicAddrs = []utils.NetAddr{
+		utils.NetAddr{
+			AddrNetwork: "tcp",
+			Addr:        i.Hostname,
+		},
+	}
 	tconf.Proxy.SSHAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortProxy())
 	tconf.Proxy.WebAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortWeb())
 	tconf.Proxy.PublicAddrs = []utils.NetAddr{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -64,8 +64,6 @@ import (
 )
 
 const (
-	Loopback = "127.0.0.1"
-	Host     = "localhost"
 	HostID   = "00000000-0000-0000-0000-000000000000"
 	Site     = "local-site"
 


### PR DESCRIPTION
Hi, I want to backport some changes from https://github.com/gravitational/teleport-plugins/pull/4.
For plugins to connect to auth server, its `public_addr` should be set.
I also pulled some constants from `integration_test.go` file to `helpers.go` because they're used there.