### PR TITLE
Reduce RBAC log spam

### DIFF
--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -754,7 +754,7 @@ func (s *TLSSuite) TestNopUser(c *check.C) {
 	fixtures.ExpectAccessDenied(c, err)
 }
 
-// TestOwnRole tests that user can read roles assigned to them
+// TestOwnRole tests that user can read roles assigned to them (used by web UI)
 func (s *TLSSuite) TestReadOwnRole(c *check.C) {
 	clt, err := s.server.NewClient(TestAdmin())
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
This commit eliminates a number of spurious Access Denied log messages.

A number of Auth Server methods provide special exceptions to the normal RBAC rules, but checking those rules was generating invalid Access Denied log messages in cases where access was not actually denied.

I'm *pretty sure* that this fixes #2920, though I wasn't able to replicate the exact log entry quoted in that issue, so there may be additional spurious logs being generated somewhere else.