### PR TITLE
Include node count in cluster info for UI (#2924)

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1356,8 +1356,12 @@ func (h *Handler) getClusters(w http.ResponseWriter, r *http.Request, p httprout
 		return nil, trace.Wrap(err)
 	}
 
-	response := ui.NewAvailableClusters(resource.GetClusterName(),
+	response, err := ui.NewAvailableClusters(resource.GetClusterName(),
 		h.cfg.Proxy.GetSites())
+
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return response, nil
 }


### PR DESCRIPTION
Addresses #2924 by adding a new `node_count` field as part of the cluster descriptions returned by `/v1/webapi/sites`.

Ex:

```json
{
  "current": {
    "name": "one",
    "last_connected": "2020-01-07T00:14:13.936035784Z",
    "status": "online",
    "node_count": 2
  },
  "trusted": [
    {
      "name": "two",
      "last_connected": "2020-01-07T00:13:42.35797554Z",
      "status": "online",
      "node_count": 3
    }
  ]
}
```


*EDIT*: Thanks to @alex-kovoy for pointing out that the below issue was actually an easy fix.  We aready have caching available via `reversetunnel.RemoteSite.CachingAccessPoint`.

#### ~~Potential Performance Issue:~~

~~As implemented, every leaf cluster must have `GetNodes` called against it every time the endpoint is hit.  Assuming a large number of nodes and a large number of concurrent web sessions, this could lead to a pretty sizable overhead for such a simple task.~~

~~Possible fixes:~~
~~**A**: Cache node counts at the API server for a few seconds.~~
~~**B**: Expose an API for getting node count directly from each cluster rather than getting all node resources and then counting them.~~
~~**C**: All of the above.~~

~~I'm leaning towards **A** since it introduces only local complexity.  **B** and **C** are better in theory, but they add more complexity to the API surface and also have implications for cross-cluster version compatibility.~~
