### PR TITLE
Update package URL to link to Teleport docs

### DIFF
--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -62,7 +62,7 @@ LINUX_DATA_DIR=/var/lib/teleport
 
 # extra package information for linux
 MAINTAINER="info@gravitational.com"
-LICENSE="Apache License 2.0"
+LICENSE="Apache-2.0"
 VENDOR="Gravitational"
 DESCRIPTION="Gravitational Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API"
 URL="https://gravitational.com/teleport/docs"

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -65,6 +65,7 @@ MAINTAINER="ops@gravitational.com"
 LICENSE="Apache License 2.0"
 VENDOR="Gravitational"
 DESCRIPTION="Gravitational Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API"
+URL="https://gravitational.com/teleport/docs"
 
 # signing IDs to use for mac (must be pre-loaded into the keychain on the build box)
 DEVELOPER_ID_APPLICATION="Developer ID Application: Gravitational Inc." # used for signing binaries
@@ -163,17 +164,21 @@ fi
 FILENAME_ARCH=${ARCH}
 if [[ "${ARCH}" == "i386" ]]; then
     FILENAME_ARCH="386"
+    TEXT_ARCH="32-bit"
 elif [[ "${ARCH}" == "386" ]]; then
     ARCH="i386"
+    TEXT_ARCH="32-bit"
 elif [[ "${ARCH}" == "x86_64" ]]; then
     FILENAME_ARCH="amd64"
     if [[ "${PACKAGE_TYPE}" == "rpm" ]]; then
         ARCH="x86_64"
     fi
+    TEXT_ARCH="64-bit"
 elif [[ "${ARCH}" == "amd64" ]]; then
     if [[ "${PACKAGE_TYPE}" == "rpm" ]]; then
         ARCH="x86_64"
     fi
+    TEXT_ARCH="64-bit"
 fi
 
 # set optional runtime section for filename
@@ -186,25 +191,23 @@ fi
 # set variables appropriately depending on type of package being built
 if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
     TARBALL_FILENAME="teleport-ent-v${TELEPORT_VERSION}-${PLATFORM}-${FILENAME_ARCH}${OPTIONAL_RUNTIME_SECTION}-bin.tar.gz"
-    URL="${DOWNLOAD_ROOT}/${TARBALL_FILENAME}"
     TAR_PATH="teleport-ent"
     if [[ "${RUNTIME}" == "go1.9.7" ]]; then
-        TYPE_DESCRIPTION="[Enterprise edition, built with Go 1.9.7]"
+        TYPE_DESCRIPTION="[${TEXT_ARCH} Enterprise edition, built with Go 1.9.7]"
     elif [[ "${RUNTIME}" == "fips" ]]; then
-        TYPE_DESCRIPTION="[Enterprise edition, built with FIPS support]"
+        TYPE_DESCRIPTION="[${TEXT_ARCH} Enterprise edition, built with FIPS support]"
     else
-        TYPE_DESCRIPTION="[Enterprise edition]"
+        TYPE_DESCRIPTION="[${TEXT_ARCH} Enterprise edition]"
     fi
 else
     TARBALL_FILENAME="teleport-v${TELEPORT_VERSION}-${PLATFORM}-${FILENAME_ARCH}${OPTIONAL_RUNTIME_SECTION}-bin.tar.gz"
-    URL="${DOWNLOAD_ROOT}/${TARBALL_FILENAME}"
     TAR_PATH="teleport"
     if [[ "${RUNTIME}" == "go1.9.7" ]]; then
-        TYPE_DESCRIPTION="[Open source edition, built with Go 1.9.7]"
+        TYPE_DESCRIPTION="[${TEXT_ARCH} Open source edition, built with Go 1.9.7]"
     elif [[ "${RUNTIME}" == "fips" ]]; then
-        TYPE_DESCRIPTION="[Open source edition, built with FIPS support]"
+        TYPE_DESCRIPTION="[${TEXT_ARCH} Open source edition, built with FIPS support]"
     else
-        TYPE_DESCRIPTION="[Open source edition]"
+        TYPE_DESCRIPTION="[${TEXT_ARCH} Open source edition]"
     fi
 fi
 

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -65,7 +65,7 @@ MAINTAINER="info@gravitational.com"
 LICENSE="Apache-2.0"
 VENDOR="Gravitational"
 DESCRIPTION="Gravitational Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API"
-URL="https://gravitational.com/teleport/docs"
+DOCS_URL="https://gravitational.com/teleport/docs"
 
 # signing IDs to use for mac (must be pre-loaded into the keychain on the build box)
 DEVELOPER_ID_APPLICATION="Developer ID Application: Gravitational Inc." # used for signing binaries
@@ -191,6 +191,7 @@ fi
 # set variables appropriately depending on type of package being built
 if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
     TARBALL_FILENAME="teleport-ent-v${TELEPORT_VERSION}-${PLATFORM}-${FILENAME_ARCH}${OPTIONAL_RUNTIME_SECTION}-bin.tar.gz"
+    URL="${DOWNLOAD_ROOT}/${TARBALL_FILENAME}"
     TAR_PATH="teleport-ent"
     if [[ "${RUNTIME}" == "go1.9.7" ]]; then
         TYPE_DESCRIPTION="[${TEXT_ARCH} Enterprise edition, built with Go 1.9.7]"
@@ -201,6 +202,7 @@ if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
     fi
 else
     TARBALL_FILENAME="teleport-v${TELEPORT_VERSION}-${PLATFORM}-${FILENAME_ARCH}${OPTIONAL_RUNTIME_SECTION}-bin.tar.gz"
+    URL="${DOWNLOAD_ROOT}/${TARBALL_FILENAME}"
     TAR_PATH="teleport"
     if [[ "${RUNTIME}" == "go1.9.7" ]]; then
         TYPE_DESCRIPTION="[${TEXT_ARCH} Open source edition, built with Go 1.9.7]"
@@ -363,7 +365,7 @@ else
         --name ${TAR_PATH} \
         --version "${TELEPORT_VERSION}" \
         --maintainer "${MAINTAINER}" \
-        --url "${URL}" \
+        --url "${DOCS_URL}" \
         --license "${LICENSE}" \
         --vendor "${VENDOR}" \
         --description "${DESCRIPTION} ${TYPE_DESCRIPTION}" \

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -61,7 +61,7 @@ LINUX_CONFIG_DIR=/etc
 LINUX_DATA_DIR=/var/lib/teleport
 
 # extra package information for linux
-MAINTAINER="ops@gravitational.com"
+MAINTAINER="info@gravitational.com"
 LICENSE="Apache License 2.0"
 VENDOR="Gravitational"
 DESCRIPTION="Gravitational Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API"


### PR DESCRIPTION
Also adds an architecture hint to the package description.

Fixes #3261 