### PR TITLE
Add support for tls certificate update

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -83,6 +83,9 @@ type CommandLineFlags struct {
 	// --insecure-no-tls flag
 	DisableTLS bool
 
+	// --proxy-tls-reload-interval-sec flag
+	ProxyTLSReloadIntervalSeconds int
+
 	// --labels flag
 	Labels string
 	// --pid-file flag
@@ -914,6 +917,11 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 	// apply --insecure-no-tls flag:
 	if clf.DisableTLS {
 		cfg.Proxy.DisableTLS = clf.DisableTLS
+	}
+
+	// apply --tls-reload-interval-sec flag:
+	if clf.ProxyTLSReloadIntervalSeconds != 0 {
+		cfg.Proxy.TLSReloadIntervalSeconds = time.Duration(clf.ProxyTLSReloadIntervalSeconds) * time.Second
 	}
 
 	// apply --debug flag to config:

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -334,6 +334,10 @@ var (
 	// ProxyQueueSize is proxy service queue size
 	ProxyQueueSize = 8192
 
+	// ProxyTLSReloadIntervalSeconds is interval seconds to reload TLS
+	// certificate for proxy
+	ProxyTLSReloadIntervalSeconds = 300
+
 	// NodeQueueSize is node service queue size
 	NodeQueueSize = 128
 )

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -313,6 +313,10 @@ type ProxyConfig struct {
 	// list of host principals on the TLS and SSH certificate.
 	SSHPublicAddrs []utils.NetAddr
 
+	// TLSReloadIntervalSeconds is interval seconds to reload TLS
+	// certificate for proxy
+	TLSReloadIntervalSeconds time.Duration
+
 	// TunnelPublicAddrs is a list of the public addresses the proxy advertises
 	// for the tunnel endpoint. The hosts in in PublicAddr are included in the
 	// list of host principals on the TLS and SSH certificate.
@@ -482,6 +486,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Proxy.SSHAddr = *defaults.ProxyListenAddr()
 	cfg.Proxy.WebAddr = *defaults.ProxyWebListenAddr()
 	cfg.Proxy.ReverseTunnelListenAddr = *defaults.ReverseTunnelListenAddr()
+	cfg.Proxy.TLSReloadIntervalSeconds = time.Duration(defaults.ProxyTLSReloadIntervalSeconds) * time.Second
 	defaults.ConfigureLimiter(&cfg.Proxy.Limiter)
 
 	// Kubernetes proxy service defaults.

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -74,7 +74,7 @@ func CreateTLSConfiguration(certFile, keyFile string, cipherSuites []uint16) (*t
 		return nil, trace.BadParameter("certificate is not accessible by '%v'", certFile)
 	}
 	if _, err := os.Stat(keyFile); err != nil {
-		return nil, trace.BadParameter("certificate is not accessible by '%v'", certFile)
+		return nil, trace.BadParameter("key is not accessible by '%v'", keyFile)
 	}
 
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -81,6 +81,8 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 		BoolVar(&ccf.Debug)
 	start.Flag("insecure-no-tls", "Disable TLS for the web socket").
 		BoolVar(&ccf.DisableTLS)
+	start.Flag("proxy-tls-reload-interval-sec", "Reload interval seconds for proxy server TLS certificate").
+		IntVar(&ccf.ProxyTLSReloadIntervalSeconds)
 	start.Flag("roles",
 		fmt.Sprintf("Comma-separated list of roles to start with [%s]", strings.Join(defaults.StartRoles, ","))).
 		Short('r').


### PR DESCRIPTION
This pull request addresses #3198.

In this pull request, the following changes are made.
- Add goroutine to load x509 certificate and add `tlsConfig.GetCertificate` handler to apply the loaded x509 certificate.
- Add cli option to adjust the interval of updating tls certificates.