### PR TITLE
tool/tctl/common: fix dropped error

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -443,6 +443,9 @@ func (c *connectorsCollection) writeText(w io.Writer) error {
 
 	if len(c.saml) > 0 {
 		_, err := io.WriteString(w, "\nSAML:\n")
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		sc := &samlCollection{connectors: c.saml}
 		err = sc.writeText(w)
 		if err != nil {


### PR DESCRIPTION
This picks up a dropped error in `tool/tctl/common`.