### PR TITLE
Fix minor errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Teleport source code consists of the actual Teleport daemon binary written in Go
 it has a web UI (located in /web directory) written in Javascript. The WebUI is not changed often
 and we keep it checked into Git under `/dist`, so you only need to build Golang:
 
-Make sure you have Golang `v1.12` or newer, then run:
+Make sure you have Golang `v1.13` or newer, then run:
 
 ```bash
 # get the source & build:

--- a/docs/4.2/architecture/teleport_architecture_overview.md
+++ b/docs/4.2/architecture/teleport_architecture_overview.md
@@ -92,7 +92,7 @@ steps are explained below the diagram.
     clarity, but Teleport services do not have to run on separate nodes.
     Teleport can be run as a binary on a single-node cluster with no external
     storage backend. We demonstrate this minimal setup in the [Quickstart
-    Guide](../guides/quickstart).
+    Guide](../quickstart).
 
 ## Detailed Architecture Overview
 

--- a/docs/4.2/architecture/teleport_proxy.md
+++ b/docs/4.2/architecture/teleport_proxy.md
@@ -60,7 +60,7 @@ Authority (CA)](./auth/#authentication-in-teleport).:
 2. The Proxy Server forwards request to the Auth Server.
 3. If Auth Server accepts credentials, it generates a new certificate signed by
    its user CA and sends it back to the Proxy Server. The certificate has a TTL
-   which defaults to 24 hours, but can be configured in
+   which defaults to 12 hours, but can be configured in
    [`tctl`](../cli-docs.md#tctl).
 4. The Proxy Server returns the user certificate to the client and client stores
    it in `~/.tsh/keys`. The certificate is also added to the local SSH agent if
@@ -91,7 +91,7 @@ client `ssh` or using `tsh`:
 
 !!! tip "NOTE": 
     
-    Teleport's proxy command makes it compatible with [SSH jump hosts](https://wiki.gentoo.org/wiki/SSH_jump_host) implemented using OpenSSH's `ProxyCommand`. also supports OpenSSH's ProxyJump/ssh -J implementation as of Teleport 4.1.
+    Teleport's proxy command makes it compatible with [SSH jump hosts](https://wiki.gentoo.org/wiki/SSH_jump_host) implemented using OpenSSH's `ProxyCommand`. Also supports OpenSSH's ProxyJump/ssh -J implementation as of Teleport 4.1.
 
 ## Recording Proxy Mode
 

--- a/docs/4.2/architecture/teleport_proxy.md
+++ b/docs/4.2/architecture/teleport_proxy.md
@@ -91,7 +91,7 @@ client `ssh` or using `tsh`:
 
 !!! tip "NOTE": 
     
-    Teleport's proxy command makes it compatible with [SSH jump hosts](https://wiki.gentoo.org/wiki/SSH_jump_host) implemented using OpenSSH's `ProxyCommand`. Also supports OpenSSH's ProxyJump/ssh -J implementation as of Teleport 4.1.
+    Teleport's proxy command makes it compatible with [SSH jump hosts](https://wiki.gentoo.org/wiki/SSH_jump_host) implemented using OpenSSH's `ProxyCommand`. It also supports OpenSSH's ProxyJump/ssh -J implementation as of Teleport 4.1.
 
 ## Recording Proxy Mode
 

--- a/docs/4.2/architecture/teleport_users.md
+++ b/docs/4.2/architecture/teleport_users.md
@@ -76,12 +76,11 @@ connector and it is enforced by default.
  There are two types of 2FA supported:
 
 * [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
+* [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor)
 
-  is the default. You can use [Google
+  TOTP is the default. You can use [Google
   Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator) or
   [Authy](https://www.authy.com/) or any other TOTP client.
-
-* [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor).
 
 ### External users
 

--- a/docs/4.2/quickstart.md
+++ b/docs/4.2/quickstart.md
@@ -14,7 +14,7 @@ VM.
 
 * In this tutorial you will start a web UI which must be accessible via a web 
   browser. If you run this tutorial on a remote machine without a GUI, first
-  make sure that this machine's IP can be reached over the your network and that
+  make sure that this machine's IP can be reached over your network and that
   it accepts incoming traffic on port `3080` .
 
 * We recommend that you read the [Architecture Guide](architecture) before
@@ -132,9 +132,8 @@ open this URL in a web browser to complete the registration process.
 should be able to open the URL and connect to Teleport Proxy right away.
 
 * If the are working on a remote machine you may need to access the Teleport
-
-  Proxy via the host machine and port `3080` in a web browser. One simple way to
-  do this is to temporarily append `[HOST_IP] grav-00` to `/etc/hosts`
+Proxy via the host machine and port `3080` in a web browser. One simple way to
+do this is to temporarily append `[HOST_IP] grav-00` to `/etc/hosts`
 
 !!! warning "Warning":
     We haven't provisioned any SSL certs for Teleport yet.
@@ -164,10 +163,10 @@ accessible IP.
 
 !!! warning "Warning":
     For the purposes of this quickstart we are using the
-    `--insecure` flag which allows us to skip configuring the HTTP/TLS
+    `--insecure-no-tls` flag which allows us to skip configuring the HTTP/TLS
     certificate for Teleport proxy.
 
-    **Caution**: the `--insecure` flag does **not** skip TLS validation for the Auth Server. The self-signed Auth Server certificate expects to be accessed via one of a set of hostnames (ex. `grav-00` ). If you attempt to access via `localhost` you will probably get this error: `principal "localhost" not in the set of valid principals for given certificate` .
+    **Caution**: the `--insecure-no-tls` flag does **not** skip TLS validation for the Auth Server. The self-signed Auth Server certificate expects to be accessed via one of a set of hostnames (ex. `grav-00` ). If you attempt to access via `localhost` you will probably get this error: `principal "localhost" not in the set of valid principals for given certificate` .
 
     To resolve this error find your hostname with the `hostname` command and use that instead of `localhost` .
 

--- a/docs/4.2/quickstart.md
+++ b/docs/4.2/quickstart.md
@@ -163,10 +163,10 @@ accessible IP.
 
 !!! warning "Warning":
     For the purposes of this quickstart we are using the
-    `--insecure-no-tls` flag which allows us to skip configuring the HTTP/TLS
+    `--insecure` flag which allows us to skip configuring the HTTP/TLS
     certificate for Teleport proxy.
 
-    **Caution**: the `--insecure-no-tls` flag does **not** skip TLS validation for the Auth Server. The self-signed Auth Server certificate expects to be accessed via one of a set of hostnames (ex. `grav-00` ). If you attempt to access via `localhost` you will probably get this error: `principal "localhost" not in the set of valid principals for given certificate` .
+    **Caution**: the `--insecure` flag does **not** skip TLS validation for the Auth Server. The self-signed Auth Server certificate expects to be accessed via one of a set of hostnames (ex. `grav-00` ). If you attempt to access via `localhost` you will probably get this error: `principal "localhost" not in the set of valid principals for given certificate` .
 
     To resolve this error find your hostname with the `hostname` command and use that instead of `localhost` .
 


### PR DESCRIPTION
### Purpose
- fix go version in readme.md
- fix broken link in teleport_architecture_overview.md
- fix spacing issues in teleport_users.md and quickstart.md
- revert `--insecure` back to originally `--insecure-no-tls` in quickstart.md so @webvictim can determine if it should be there
- update 24 hrs TTL default to 12 hrs in teleport_proxy.md