### PR TITLE
[BUG] Backported cert auth fix from 3.2-g to 3.0-g

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -29,7 +29,6 @@ import (
 	"crypto/subtle"
 	"crypto/x509"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"math/rand"
 	"net/url"
 	"sync"
@@ -53,6 +52,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	saml2 "github.com/russellhaering/gosaml2"
 	"github.com/tstranex/u2f"
+	"golang.org/x/crypto/ssh"
 )
 
 // AuthServerOption allows setting options as functional arguments to AuthServer
@@ -625,12 +625,12 @@ func (s *AuthServer) ExtendWebSession(user string, prevSessionID string, identit
 
 // CreateWebSession creates a new web session for user without any
 // checks, is used by admins
-func (s *AuthServer) CreateWebSession(user string, identity *tlsca.Identity) (services.WebSession, error) {
-	roles, traits, err := services.ExtractFromIdentity(s, identity)
+func (s *AuthServer) CreateWebSession(user string) (services.WebSession, error) {
+	u, err := s.GetUser(user)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	sess, err := s.NewWebSession(user, roles, traits)
+	sess, err := s.NewWebSession(user, u.GetRoles(), u.GetTraits())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -582,7 +582,7 @@ func (a *AuthWithRoles) CreateWebSession(user string) (services.WebSession, erro
 	if err := a.currentUserAction(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.CreateWebSession(user, &a.identity)
+	return a.authServer.CreateWebSession(user)
 }
 
 func (a *AuthWithRoles) ExtendWebSession(user, prevSessionID string) (services.WebSession, error) {


### PR DESCRIPTION
Backported cert auth fix from 3.2-g

Specifically I backported https://github.com/gravitational/teleport/commit/de3929eb86f7cc3411acde9ff93ed7c528e8f5d4

This is also being tracked in Gravity here https://github.com/gravitational/gravity/issues/1015