### PR TITLE
Add tunnel listener and target group to Terraform example for use with ACM

### DIFF
--- a/assets/marketplace/Makefile
+++ b/assets/marketplace/Makefile
@@ -14,7 +14,7 @@ MARKETPLACE_AMI_NAME ?=
 AWS_REGION ?= us-west-2
 
 # Teleport version
-TELEPORT_VERSION ?= 4.2.1
+TELEPORT_VERSION ?= 4.2.2
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007

--- a/assets/marketplace/files/bin/teleport-generate-config
+++ b/assets/marketplace/files/bin/teleport-generate-config
@@ -145,8 +145,15 @@ EOF
     # if we have an SSH proxy LB address, append it
     if [[ "${TELEPORT_PROXY_SERVER_LB}" != "" ]]; then
         echo "  ssh_public_addr: ${TELEPORT_PROXY_SERVER_LB}:3023" >> /etc/teleport.yaml
-        # also set tunnel public address
-        echo "  tunnel_public_addr: ${TELEPORT_PROXY_SERVER_LB}:${TUNNEL_LISTEN_PORT}" >> /etc/teleport.yaml
+        # when using ACM, we have to set up a dedicated listener and target group as
+        # SSL termination is handled by the ACM ALB and it can't multiplex the tunnel connections
+        if [[ "${USE_ACM}" == "true" ]]; then
+          echo "  tunnel_public_addr: ${TELEPORT_PROXY_SERVER_LB}:${TUNNEL_LISTEN_PORT}" >> /etc/teleport.yaml
+        # when ACM is not being used, Teleport handles SSL termination itself and so tunnel connections
+        # can be multiplexed over the same connection as regular web proxy traffic
+        else
+          echo "  tunnel_public_addr: ${TELEPORT_DOMAIN_NAME}:443" >> /etc/teleport.yaml
+        fi
     fi
 
     # if we are using letsencrypt (i.e. not ACM) then append config lines
@@ -271,8 +278,15 @@ EOF
     # if we have an SSH proxy LB address, append it
     if [[ "${TELEPORT_PROXY_SERVER_LB}" != "" ]]; then
         echo "  ssh_public_addr: ${TELEPORT_PROXY_SERVER_LB}" >> /etc/teleport.yaml
-        # also set tunnel public address
-        echo "  tunnel_public_addr: ${TELEPORT_PROXY_SERVER_LB}:${TUNNEL_LISTEN_PORT}" >> /etc/teleport.yaml
+        # when using ACM, we have to set up a dedicated listener and target group as
+        # SSL termination is handled by the ACM ALB and it can't multiplex the tunnel connections
+        if [[ "${USE_ACM}" == "true" ]]; then
+          echo "  tunnel_public_addr: ${TELEPORT_PROXY_SERVER_LB}:${TUNNEL_LISTEN_PORT}" >> /etc/teleport.yaml
+        # when ACM is not being used, Teleport handles SSL termination itself and so tunnel connections
+        # can be multiplexed over the same connection as regular web proxy traffic
+        else
+          echo "  tunnel_public_addr: ${TELEPORT_EXTERNAL_HOSTNAME:-$PUBLIC_IP}:${TELEPORT_EXTERNAL_PORT:-3080}" >> /etc/teleport.yaml
+        fi
     fi
 
     # if we are using letsencrypt, append config lines

--- a/assets/marketplace/files/bin/teleport-generate-config
+++ b/assets/marketplace/files/bin/teleport-generate-config
@@ -127,7 +127,7 @@ teleport:
     type: dir
     path: /var/lib/teleport/backend
   auth_servers:
-    - ${TELEPORT_AUTH_SERVER_LB}
+    - ${TELEPORT_AUTH_SERVER_LB}:3025
 
 auth_service:
   enabled: no
@@ -144,7 +144,9 @@ proxy_service:
 EOF
     # if we have an SSH proxy LB address, append it
     if [[ "${TELEPORT_PROXY_SERVER_LB}" != "" ]]; then
-        echo "  ssh_public_addr: ${TELEPORT_PROXY_SERVER_LB}" >> /etc/teleport.yaml
+        echo "  ssh_public_addr: ${TELEPORT_PROXY_SERVER_LB}:3023" >> /etc/teleport.yaml
+        # also set tunnel public address
+        echo "  tunnel_public_addr: ${TELEPORT_PROXY_SERVER_LB}:${TUNNEL_LISTEN_PORT}" >> /etc/teleport.yaml
     fi
 
     # if we are using letsencrypt (i.e. not ACM) then append config lines
@@ -186,7 +188,7 @@ teleport:
     type: dir
     path: /var/lib/teleport/backend
   auth_servers:
-    - ${TELEPORT_AUTH_SERVER_LB}
+    - ${TELEPORT_AUTH_SERVER_LB}:3025
 
 auth_service:
   enabled: no
@@ -269,6 +271,8 @@ EOF
     # if we have an SSH proxy LB address, append it
     if [[ "${TELEPORT_PROXY_SERVER_LB}" != "" ]]; then
         echo "  ssh_public_addr: ${TELEPORT_PROXY_SERVER_LB}" >> /etc/teleport.yaml
+        # also set tunnel public address
+        echo "  tunnel_public_addr: ${TELEPORT_PROXY_SERVER_LB}:${TUNNEL_LISTEN_PORT}" >> /etc/teleport.yaml
     fi
 
     # if we are using letsencrypt, append config lines

--- a/assets/marketplace/files/bin/teleport-generate-config
+++ b/assets/marketplace/files/bin/teleport-generate-config
@@ -151,6 +151,7 @@ EOF
           echo "  tunnel_public_addr: ${TELEPORT_PROXY_SERVER_LB}:${TUNNEL_LISTEN_PORT}" >> /etc/teleport.yaml
         # when ACM is not being used, Teleport handles SSL termination itself and so tunnel connections
         # can be multiplexed over the same connection as regular web proxy traffic
+        # this is automatically enabled when Teleport's web and tunnel listeners are configured to use the same port
         else
           echo "  tunnel_public_addr: ${TELEPORT_DOMAIN_NAME}:443" >> /etc/teleport.yaml
         fi
@@ -284,6 +285,7 @@ EOF
           echo "  tunnel_public_addr: ${TELEPORT_PROXY_SERVER_LB}:${TUNNEL_LISTEN_PORT}" >> /etc/teleport.yaml
         # when ACM is not being used, Teleport handles SSL termination itself and so tunnel connections
         # can be multiplexed over the same connection as regular web proxy traffic
+        # this is automatically enabled when Teleport's web and tunnel listeners are configured to use the same port
         else
           echo "  tunnel_public_addr: ${TELEPORT_EXTERNAL_HOSTNAME:-$PUBLIC_IP}:${TELEPORT_EXTERNAL_PORT:-3080}" >> /etc/teleport.yaml
         fi

--- a/examples/aws/terraform/acm.tf
+++ b/examples/aws/terraform/acm.tf
@@ -2,7 +2,7 @@
 // import the existing ACM certificate with:
 // terraform import aws_acm_certificate.cert <certificate_arn>
 // NOTE: using non-Amazon issued certificates in this manner is a bad idea as they cannot be automatically recreated by
-// Terraform if they are deleted. In this instance we recommend setting up ACM on the proxy 2load balancer yourself.
+// Terraform if they are deleted. In this instance we recommend setting up ACM on the proxy load balancer yourself.
 
 // Define an ACM cert we can use for the proxy
 resource "aws_acm_certificate" "cert" {

--- a/examples/aws/terraform/node_asg.tf
+++ b/examples/aws/terraform/node_asg.tf
@@ -38,7 +38,7 @@ data "template_file" "node_user_data" {
     region = "${var.region}"
     cluster_name = "${var.cluster_name}"
     telegraf_version = "${var.telegraf_version}"
-    auth_server_addr = "${aws_lb.auth.dns_name}:3025"
+    auth_server_addr = "${aws_lb.auth.dns_name}"
     influxdb_addr = "http://${aws_lb.monitor.dns_name}:8086"
     use_acm = "${var.use_acm}"
   }

--- a/examples/aws/terraform/proxy_asg.tf
+++ b/examples/aws/terraform/proxy_asg.tf
@@ -48,7 +48,7 @@ resource "aws_autoscaling_group" "proxy_acm" {
   launch_configuration      = "${aws_launch_configuration.proxy.name}"
   vpc_zone_identifier       = ["${aws_subnet.public.*.id}"]
   // Auto scaling group is associated with load balancer
-  target_group_arns         = ["${aws_lb_target_group.proxy_proxy.arn}", "${aws_lb_target_group.proxy_web_acm.arn}"]
+  target_group_arns         = ["${aws_lb_target_group.proxy_proxy.arn}", "${aws_lb_target_group.proxy_tunnel_acm.arn}", "${aws_lb_target_group.proxy_web_acm.arn}"]
   count                     = "${var.use_acm ? 1 : 0}"
 
   tag {
@@ -76,8 +76,8 @@ data "template_file" "proxy_user_data" {
   vars {
     region = "${var.region}"
     cluster_name = "${var.cluster_name}"
-    auth_server_addr = "${aws_lb.auth.dns_name}:3025"
-    proxy_server_lb_addr = "${aws_lb.proxy.dns_name}:3023"
+    auth_server_addr = "${aws_lb.auth.dns_name}"
+    proxy_server_lb_addr = "${aws_lb.proxy.dns_name}"
     influxdb_addr = "http://${aws_lb.monitor.dns_name}:8086"
     email = "${var.email}"
     domain_name = "${var.route53_domain}"


### PR DESCRIPTION
A customer recently discovered that our Terraform example code doesn't make it possible to use trusted clusters with ACM "out of the box". If they'd been using Letsencrypt, this would have been possible without any modifications due to Teleport's ability to multiplex tunnel and web traffic over the same port. This multiplexing doesn't work when using ACM because it requires the use of an ALB for AWS to terminate the SSL traffic (rather than passing the traffic straight through via NLB as it does for Letsencrypt, allowing Teleport to inspect the traffic and determine the correct protocol)

This PR adds the extra listener and target group needed to make tunnel connections work straight away with ACM and facilitate the use of trusted clusters. It also fixes a couple of typos and bumps the Teleport version in the AMI `Makefile`.