### PR TITLE
Remove more complicated remote proxy, proxy jump

### DIFF
--- a/docs/4.2/architecture/teleport_proxy.md
+++ b/docs/4.2/architecture/teleport_proxy.md
@@ -91,7 +91,7 @@ client `ssh` or using `tsh`:
 
 !!! tip "NOTE"
     
-    Teleport's proxy command makes it compatible with [SSH jump hosts](https://wiki.gentoo.org/wiki/SSH_jump_host) implemented using OpenSSH's `ProxyCommand`. It also supports OpenSSH's ProxyJump/ssh -J implementation as of Teleport 4.1.
+    Teleport's proxy command makes it compatible with [SSH jump hosts](https://wiki.gentoo.org/wiki/SSH_jump_host) implemented using OpenSSH's `ProxyCommand`. It also supports OpenSSH's ProxyJump/ssh -J implementation as of Teleport 4.1. See [User Manual](../user-manual.md#ssh-proxy-configuration)
 
 ## Recording Proxy Mode
 

--- a/docs/4.2/user-manual.md
+++ b/docs/4.2/user-manual.md
@@ -319,6 +319,7 @@ While implementing ProxyJump for Teleport, we have extended the feature to `tsh`
 `$ tsh ssh -J proxy.example.com telenode`
 
 Known limits:
+
 - Only one jump host is supported (`-J` supports chaining that Teleport does not utilise)
 and tsh will return with error in case of two jumphosts: `-J` proxy-1.example.com,proxy-2.example.com
 will not work.
@@ -512,13 +513,6 @@ below:
 Host db
     Port 3022
     ProxyJump proxy.example.com:3023
-
-# When connecting to a node behind a trusted cluster named "remote-cluster",
-# the name of the trusted cluster must be appended to the proxy subsystem
-# after '@':
-Host *.remote-cluster.example.com
-   Port 3022
-   ProxyJump proxy.example.com:3023@remote-cluster
 ```
 
 The configuration above is all you need to `ssh root@db` if there's an


### PR DESCRIPTION
- [x] Remove `Host *.remote-cluster.example.com` example
- [ ] Add info for how to use it with remote clusters. 