### PR TITLE
Handle duplicate node names & support UUID based proxying (Version 2)

### DIFF
--- a/assets/marketplace/files/bin/teleport-generate-config
+++ b/assets/marketplace/files/bin/teleport-generate-config
@@ -17,12 +17,6 @@ LOCAL_HOSTNAME=${LOCAL_HOSTNAME//./-}
 # Source variables from user-data
 source /etc/teleport.d/conf
 
-# Set host UUID so auth server picks it up, as each auth server's
-# logs are stored in individual folder /var/lib/teleport/log/<host_uuid>/
-# and it will be easy to log forwarders to locate them on every auth server
-# note though, that host_uuid MUST be unique, otherwise all sorts of unintended
-# things will happen.
-echo ${LOCAL_HOSTNAME} > /var/lib/teleport/host_uuid
 chown -R teleport:adm /var/lib/teleport
 touch /etc/teleport.yaml
 chmod 664 /etc/teleport.yaml

--- a/constants.go
+++ b/constants.go
@@ -566,6 +566,10 @@ const (
 	// UseOfClosedNetworkConnection is a special string some parts of
 	// go standard lib are using that is the only way to identify some errors
 	UseOfClosedNetworkConnection = "use of closed network connection"
+
+	// NodeIsAmbiguous serves as an identifying error string indicating that
+	// the proxy subsystem found multiple nodes matching the specified hostname.
+	NodeIsAmbiguous = "err-node-is-ambiguous"
 )
 
 const (

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -590,6 +590,90 @@ func (s *IntSuite) TestInteroperability(c *check.C) {
 	}
 }
 
+// TestUUIDBasedProxy verifies that attempts to proxy to nodes using ambiguous
+// hostnames fails with the correct error, and that proxying by UUID succeeds.
+func (s *IntSuite) TestUUIDBasedProxy(c *check.C) {
+	var err error
+	tr := utils.NewTracer(utils.ThisFunction()).Start()
+	defer tr.Stop()
+
+	t := s.newTeleport(c, nil, true)
+	defer t.Stop(true)
+
+	site := t.GetSiteAPI(Site)
+
+	// addNode adds a node to the teleport instance, returning its uuid.
+	// All nodes added this way have the same hostname.
+	addNode := func() (string, error) {
+		nodeSSHPort := s.getPorts(1)[0]
+		tconf := service.MakeDefaultConfig()
+
+		tconf.Hostname = Host
+
+		tconf.SSH.Enabled = true
+		tconf.SSH.Addr.Addr = net.JoinHostPort(t.Hostname, fmt.Sprintf("%v", nodeSSHPort))
+
+		node, err := t.StartNode(tconf)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		ident, err := node.GetIdentity(teleport.RoleNode)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		return ident.ID.HostID()
+	}
+
+	// add two nodes with the same hostname.
+	uuid1, err := addNode()
+	c.Assert(err, check.IsNil)
+
+	uuid2, err := addNode()
+	c.Assert(err, check.IsNil)
+
+	// wait up to 10 seconds for supplied node names to show up.
+	waitForNodes := func(site auth.ClientI, nodes ...string) error {
+		tickCh := time.Tick(500 * time.Millisecond)
+		stopCh := time.After(10 * time.Second)
+	Outer:
+		for _, nodeName := range nodes {
+			for {
+				select {
+				case <-tickCh:
+					nodesInSite, err := site.GetNodes(defaults.Namespace, services.SkipValidation())
+					if err != nil && !trace.IsNotFound(err) {
+						return trace.Wrap(err)
+					}
+					for _, node := range nodesInSite {
+						if node.GetName() == nodeName {
+							continue Outer
+						}
+					}
+				case <-stopCh:
+					return trace.BadParameter("waited 10s, did find node %s", nodeName)
+				}
+			}
+		}
+		return nil
+	}
+
+	err = waitForNodes(site, uuid1, uuid2)
+	c.Assert(err, check.IsNil)
+
+	// attempting to run a command by hostname should generate NodeIsAmbiguous error.
+	_, err = runCommand(t, []string{"echo", "Hello there!"}, ClientConfig{Login: s.me.Username, Cluster: Site, Host: Host}, 1)
+	c.Assert(err, check.NotNil)
+	if !strings.Contains(err.Error(), teleport.NodeIsAmbiguous) {
+		c.Errorf("Expected %s, got %s", teleport.NodeIsAmbiguous, err.Error())
+	}
+
+	// attempting to run a command by uuid should succeed.
+	_, err = runCommand(t, []string{"echo", "Hello there!"}, ClientConfig{Login: s.me.Username, Cluster: Site, Host: uuid1}, 1)
+	c.Assert(err, check.IsNil)
+}
+
 // TestInteractive covers SSH into shell and joining the same session from another client
 func (s *IntSuite) TestInteractive(c *check.C) {
 	tr := utils.NewTracer(utils.ThisFunction()).Start()

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -330,6 +330,7 @@ func BuildPrincipals(hostID string, nodeName string, clusterName string, roles t
 	// always include the hostID, this is what teleport uses internally to find nodes
 	principals := []string{
 		fmt.Sprintf("%v.%v", hostID, clusterName),
+		hostID,
 	}
 
 	// nodeName is the DNS name, this is for OpenSSH interoperability

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -120,7 +120,7 @@ func (s *NativeSuite) TestBuildPrincipals(c *check.C) {
 			"",
 			"example.com",
 			teleport.Roles{teleport.RoleNode},
-			[]string{"11111111-1111-1111-1111-111111111111.example.com"},
+			[]string{"11111111-1111-1111-1111-111111111111.example.com", "11111111-1111-1111-1111-111111111111"},
 		},
 		// 2 - dual principals
 		{
@@ -128,7 +128,7 @@ func (s *NativeSuite) TestBuildPrincipals(c *check.C) {
 			"proxy",
 			"example.com",
 			teleport.Roles{teleport.RoleProxy},
-			[]string{"22222222-2222-2222-2222-222222222222.example.com", "proxy.example.com", "proxy"},
+			[]string{"22222222-2222-2222-2222-222222222222.example.com", "22222222-2222-2222-2222-222222222222", "proxy.example.com", "proxy"},
 		},
 		// 3 - deduplicate principals
 		{

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1410,6 +1410,17 @@ func (tc *TeleportClient) ListNodes(ctx context.Context) ([]services.Server, err
 	return proxyClient.FindServersByLabels(ctx, tc.Namespace, tc.Labels)
 }
 
+// ListAllNodes is the same as ListNodes except that it ignores labels.
+func (tc *TeleportClient) ListAllNodes(ctx context.Context) ([]services.Server, error) {
+	proxyClient, err := tc.ConnectToProxy(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer proxyClient.Close()
+
+	return proxyClient.FindServersByLabels(ctx, tc.Namespace, nil)
+}
+
 // runCommand executes a given bash command on a bunch of remote nodes
 func (tc *TeleportClient) runCommand(
 	ctx context.Context, siteName string, nodeAddresses []string, proxyClient *ProxyClient, command []string) error {

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -153,6 +153,10 @@ func (s *localSite) DialAuthServer() (conn net.Conn, err error) {
 		return nil, trace.Wrap(err)
 	}
 
+	if len(authServers) < 1 {
+		return nil, trace.ConnectionProblem(nil, "no auth servers available")
+	}
+
 	// try and dial to one of them, as soon as we are successful, return the net.Conn
 	for _, authServer := range authServers {
 		conn, err = net.DialTimeout("tcp", authServer.GetAddr(), defaults.DefaultDialTimeout)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -555,6 +555,10 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 		}
 	}
 
+	if uuid.Parse(cfg.HostUUID) == nil {
+		log.Warnf("Host UUID %q is not a true UUID (not eligible for UUID-based proxying)", cfg.HostUUID)
+	}
+
 	// if user started auth and another service (without providing the auth address for
 	// that service, the address of the in-process auth will be used
 	if cfg.Auth.Enabled && len(cfg.AuthServers) == 0 {

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -179,7 +179,7 @@ func (s *ServiceTestSuite) TestCheckPrincipals(c *check.C) {
 		},
 	}
 	for _, tt := range tests {
-		ok := checkPrincipals(testConnector, tt.inPrincipals, tt.inDNS)
+		ok := checkServerIdentity(testConnector, tt.inPrincipals, tt.inDNS)
 		c.Assert(ok, check.Equals, tt.outRegenerate)
 	}
 }

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -101,7 +101,7 @@ func NewTerminal(req TerminalRequest, authProvider AuthProvider, ctx *SessionCon
 		return nil, trace.Wrap(err)
 	}
 
-	// DELETE IN 5.0:
+	// DELETE IN: 5.0
 	//
 	// All proxies will support lookup by uuid, so host/port lookup
 	// and fallback can be dropped entirely.

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -101,6 +101,10 @@ func NewTerminal(req TerminalRequest, authProvider AuthProvider, ctx *SessionCon
 		return nil, trace.Wrap(err)
 	}
 
+	// DELETE IN 5.0:
+	//
+	// All proxies will support lookup by uuid, so host/port lookup
+	// and fallback can be dropped entirely.
 	hostName, hostPort, err := resolveServerHostPort(req.Server, servers)
 	if err != nil {
 		return nil, trace.BadParameter("invalid server name %q: %v", req.Server, err)
@@ -114,6 +118,7 @@ func NewTerminal(req TerminalRequest, authProvider AuthProvider, ctx *SessionCon
 		ctx:          ctx,
 		hostName:     hostName,
 		hostPort:     hostPort,
+		hostUUID:     req.Server,
 		authProvider: authProvider,
 		encoder:      unicode.UTF8.NewEncoder(),
 		decoder:      unicode.UTF8.NewDecoder(),
@@ -140,6 +145,9 @@ type TerminalHandler struct {
 
 	// hostPort is the port of the server.
 	hostPort int
+
+	// hostUUID is the UUID of the server.
+	hostUUID string
 
 	// sshSession holds the "shell" SSH channel to the node.
 	sshSession *ssh.Session
@@ -291,6 +299,20 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 	// Establish SSH connection to the server. This function will block until
 	// either an error occurs or it completes successfully.
 	err := tc.SSH(t.terminalContext, t.params.InteractiveCommand, false)
+
+	// TODO IN: 5.0
+	//
+	// Make connecting by UUID the default instead of the fallback.
+	//
+	if err != nil && strings.Contains(err.Error(), teleport.NodeIsAmbiguous) {
+		t.log.Debugf("Ambiguous hostname %q, attempting to connect by UUID (%q)", t.hostName, t.hostUUID)
+		tc.Host = t.hostUUID
+		// We don't technically need to zero the HostPort, but future version won't look up
+		// HostPort when connecting by UUID, so its best to keep behavior consistent.
+		tc.HostPort = 0
+		err = tc.SSH(t.terminalContext, t.params.InteractiveCommand, false)
+	}
+
 	if err != nil {
 		t.log.Warnf("Unable to stream terminal: %v.", err)
 		er := t.writeError(err, ws)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -650,7 +650,38 @@ func onListNodes(cf *CLIConf) {
 		return nodes[i].GetHostname() < nodes[j].GetHostname()
 	})
 
-	switch cf.Verbose {
+	showNodes(nodes, cf.Verbose)
+}
+
+func executeAccessRequest(cf *CLIConf) {
+	if cf.DesiredRoles == "" {
+		utils.FatalError(trace.BadParameter("one or more roles must be specified"))
+	}
+	roles := strings.Split(cf.DesiredRoles, ",")
+	tc, err := makeClient(cf, true)
+	if err != nil {
+		utils.FatalError(err)
+	}
+	if cf.Username == "" {
+		cf.Username = tc.Username
+	}
+	req, err := services.NewAccessRequest(cf.Username, roles...)
+	if err != nil {
+		utils.FatalError(err)
+	}
+	fmt.Fprintf(os.Stderr, "Seeking request approval... (id: %s)\n", req.GetName())
+	if err := getRequestApproval(cf, tc, req); err != nil {
+		utils.FatalError(err)
+	}
+	fmt.Fprintf(os.Stderr, "Approval received, getting updated certificates...\n\n")
+	if err := reissueWithRequests(cf, tc, req.GetName()); err != nil {
+		utils.FatalError(err)
+	}
+	onStatus(cf)
+}
+
+func showNodes(nodes []services.Server, verbose bool) {
+	switch verbose {
 	// In verbose mode, print everything on a single line and include the Node
 	// ID (UUID). Useful for machines that need to parse the output of "tsh ls".
 	case true:
@@ -687,33 +718,6 @@ func onListNodes(cf *CLIConf) {
 		}
 		fmt.Println(t.AsBuffer().String())
 	}
-}
-
-func executeAccessRequest(cf *CLIConf) {
-	if cf.DesiredRoles == "" {
-		utils.FatalError(trace.BadParameter("one or more roles must be specified"))
-	}
-	roles := strings.Split(cf.DesiredRoles, ",")
-	tc, err := makeClient(cf, true)
-	if err != nil {
-		utils.FatalError(err)
-	}
-	if cf.Username == "" {
-		cf.Username = tc.Username
-	}
-	req, err := services.NewAccessRequest(cf.Username, roles...)
-	if err != nil {
-		utils.FatalError(err)
-	}
-	fmt.Fprintf(os.Stderr, "Seeking request approval... (id: %s)\n", req.GetName())
-	if err := getRequestApproval(cf, tc, req); err != nil {
-		utils.FatalError(err)
-	}
-	fmt.Fprintf(os.Stderr, "Approval received, getting updated certificates...\n\n")
-	if err := reissueWithRequests(cf, tc, req.GetName()); err != nil {
-		utils.FatalError(err)
-	}
-	onStatus(cf)
 }
 
 // chunkLabels breaks labels into sized chunks. Used to improve readability
@@ -783,6 +787,24 @@ func onSSH(cf *CLIConf) {
 		return tc.SSH(cf.Context, cf.RemoteCommand, cf.LocalExec)
 	})
 	if err != nil {
+		if strings.Contains(utils.UserMessageFromError(err), teleport.NodeIsAmbiguous) {
+			allNodes, err := tc.ListAllNodes(cf.Context)
+			if err != nil {
+				utils.FatalError(err)
+			}
+			var nodes []services.Server
+			for _, node := range allNodes {
+				if node.GetHostname() == tc.Host {
+					nodes = append(nodes, node)
+				}
+			}
+			fmt.Fprintf(os.Stderr, "error: ambiguous host could match multiple nodes\n\n")
+			showNodes(nodes, true)
+			fmt.Fprintf(os.Stderr, "Hint: try addressing the node by unique id (ex: tsh ssh user@node-id)\n")
+			fmt.Fprintf(os.Stderr, "Hint: use 'tsh ls -v' to list all nodes with their unique ids\n")
+			fmt.Fprintf(os.Stderr, "\n")
+			os.Exit(1)
+		}
 		// exit with the same exit status as the failed command:
 		if tc.ExitStatus != 0 {
 			fmt.Fprintln(os.Stderr, utils.UserMessageFromError(err))


### PR DESCRIPTION
This PR implements an alternative strategy to the original UUID based routing strategy seen in #3340.  Rather than explicitly routing by UUID, this implementation checks if the supplied hostname *appears* to be a UUID and guesses the intended behavior:

```
$ tsh ssh alice@example.com
error: ambiguous host could match multiple nodes
  
Node  Name  Node ID                              Address        Labels
----------- ------------------------------------ -------------- ---------
example.com ae79f375-633e-4a81-941e-83faf4a3c966 127.0.0.1:3022 foo=bar
example.com 17a980a9-ce32-4c95-a5c4-c4b4717851e9 127.0.0.1:4022 spam=eggs            
  
Hint: try addressing the node by unique id (ex: tsh ssh user@node-id)
Hint: use 'tsh ls -v' to list all nodes with their unique ids

$ tsh ssh alice@17a980a9-ce32-4c95-a5c4-c4b4717851e9
```

By treating UUIDS *as* hostnames, this PR is (mostly) much simpler than #3340.  There is, however, one major exception:  because clients treat UUIDs as hostnames, certificates now need to include UUIDs.  This PR is currently a WIP since it does not yet include any mechanism for forcing nodes to get their certificates re-issued with UUIDs.

Fixes #2396 