### PR TITLE
Tip on our enhanced session recording page. 

### DIFF
--- a/docs/4.2/architecture/teleport_architecture_overview.md
+++ b/docs/4.2/architecture/teleport_architecture_overview.md
@@ -88,6 +88,8 @@ steps are explained below the diagram.
 4. Authorize Client Access to Node
 
 !!! tip "Tip"
+
+
     In the diagram above we show each Teleport service separately for
     clarity, but Teleport services do not have to run on separate nodes.
     Teleport can be run as a binary on a single-node cluster with no external
@@ -104,6 +106,8 @@ steps are explained in detail below the diagram.
 ![Teleport Everything](../img/everything.svg)
 
 !!! note "Caution"
+
+
     The Teleport Admin tool, `tctl` , must be physically present
     on the same machine where Teleport Auth is running. Adding new nodes or
     inviting new users to the cluster is only possible using this tool.
@@ -144,6 +148,7 @@ therefore it is critical for a secure configuration of Teleport to install a
 proper HTTPS certificate on a proxy.
 
 !!! warning "Warning"
+
     Do not use self-signed SSL/HTTPS certificates in production!
 
 If the credentials are correct, the auth server generates and signs a new
@@ -169,6 +174,8 @@ and the requested node. The destination node then begins recording the session,
 sending the session history to the auth server to be stored.
 
 !!! note "Note"
+
+
     Teleport may also be configured to have the session recording
     occur on the proxy, see [Audit Log](../admin-guide.md#audit-log) for more
     information.

--- a/docs/4.2/architecture/teleport_auth.md
+++ b/docs/4.2/architecture/teleport_auth.md
@@ -202,6 +202,8 @@ events and submit them to the auth server. The events recorded include:
 * session IDs
 
 !!! warning "Compatibility Warning":
+
+
     Because all SSH events like `exec` or `session_start` are reported by the
     Teleport node service, they will not be logged if you are using OpenSSH
     `sshd` daemon on your nodes.
@@ -215,6 +217,8 @@ Teleport users are encouraged to export the events into external, long term
 storage.
 
 !!! info "Deployment Considerations":
+
+
     If multiple Teleport auth servers are used
     to service the same cluster (HA mode) a network file system must be used for
     `/var/lib/teleport/log` to allow them to combine all audit events into the

--- a/docs/4.2/features/enhanced_session_recording.md
+++ b/docs/4.2/features/enhanced_session_recording.md
@@ -1,6 +1,6 @@
 # Enhanced Session Recording
 
-Teleport standard session recordings only capture what is echoed to a terminal. 
+Teleport [standard session recordings](https://gravitational.com/teleport/docs/architecture/teleport_nodes/#session-recording) only capture what is echoed to a terminal. 
 This has inherent advantages, for example because no input is captured, Teleport
 session recordings typically do not contain passwords that were entered into a terminal.
 
@@ -22,11 +22,17 @@ ingest and perform monitoring/alerting on.
     Enhanced Session Recording requires all parts of the Teleport system to be running
     4.2+. 
 
+
 # Requirements:
 
 ## 1. Check / Patch Kernel
 Teleport 4.2+ with Enhanced Session Recording requires Linux kernel 4.18 (or above) as 
 well as kernel headers. 
+
+!!! tip
+
+    Our Standard Session Recording works with older Linux Kernels. View our [audit log docs](https://gravitational.com/teleport/docs/architecture/teleport_auth/#audit-log) for more details. 
+    
 
 You can check your kernel version using the `uname` command. The output should look 
 something like the following.

--- a/docs/4.2/trustedclusters.md
+++ b/docs/4.2/trustedclusters.md
@@ -347,10 +347,8 @@ There are three common types of problems Teleport administrators can run into wh
 trust between two clusters:
 
 * **HTTPS configuration**: when the main cluster uses a self-signed or invalid HTTPS certificate.
-
 * **Connectivity problems**: when a trusting cluster "east" does not show up in
   `tsh clusters` output on "main".
-
 * **Access problems**: when users from "main" get "access denied" error messages
   trying to connect to nodes on "east".
 


### PR DESCRIPTION
Mostly adding this Tip https://github.com/gravitational/teleport/compare/benarent/docs/session-recording?expand=1#diff-9d0a75a36e1c7ac616395dc8edc0b7e9R32 that lets people know that they don't need a new kernel for our standard session recording. 