### PR TITLE
Update error message + docs when adding local users

### DIFF
--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -2047,6 +2047,10 @@ belong to:
 $ tctl users add joe --k8s-groups="system:masters"
 ```
 
+!!! tip "NOTE"
+
+    The above command is for the Teleport OSS version. Teleport Enterprise customers manage `k8s-groups` through RBAC.
+
 If using Teleport Community SSO with Github, Kubernetes groups can be assigned
 to Github teams with a Teleport connector. See example above in [Github OAuth
 2.0 Example](#github-oauth-20) for more information on how to setup Github SSO

--- a/examples/resources/k8s-groups.yaml
+++ b/examples/resources/k8s-groups.yaml
@@ -1,0 +1,29 @@
+#
+# Example: Default k8s-groups Role
+#
+kind: role
+metadata:
+  name: k8s-groups
+spec:
+  options:
+    max_session_ttl: 30h0m0s
+    forward_agent: true
+    cert_format: standard
+    enhanced_recording:
+    - command
+    - network
+  allow:
+    logins: [root, '{{internal.logins}}']
+    kubernetes_groups: ["system:masters", "{{external.trait_name}}"]]
+    node_labels:
+      '*': '*'
+    rules:
+    - resources: [role]
+      verbs: [list, create, read, update, delete]
+    - resources: [auth_connector]
+      verbs: [connect, list, create, read, update, delete]
+    - resources: [session]
+      verbs: [list, read]
+    - resources: [trusted_cluster]
+      verbs: [connect, list, create, read, update, delete]
+  deny: {}

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
@@ -107,6 +108,9 @@ func Run(commands []CLICommand) {
 	// parse CLI commands+flags:
 	selectedCmd, err := app.Parse(os.Args[1:])
 	if err != nil {
+		if strings.Contains(err.Error(), "unknown long flag") {
+			err = trace.Wrap(err, "make sure role used in flag has a corresponding Teleport role in RBAC, an example RBAC role can be seen here: %q", "https://gravitational.com/teleport/docs/enterprise/ssh_rbac/#roles")
+		}
 		utils.FatalError(err)
 	}
 


### PR DESCRIPTION
When adding local users  error handling wasn't clear reporting `error: unknown long flag ...`. This PR updates the docs + adds more context to error

Resolves: #3083