### PR TITLE
Use HTTPS for backend connections from LB with Terraform and ACM

### DIFF
--- a/assets/marketplace/Makefile
+++ b/assets/marketplace/Makefile
@@ -14,7 +14,7 @@ MARKETPLACE_AMI_NAME ?=
 AWS_REGION ?= us-west-2
 
 # Teleport version
-TELEPORT_VERSION ?= 4.2.2
+TELEPORT_VERSION ?= 4.2.3
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007

--- a/assets/marketplace/files/system/teleport-acm.service
+++ b/assets/marketplace/files/system/teleport-acm.service
@@ -10,7 +10,7 @@ Type=simple
 Restart=always
 RestartSec=5
 RuntimeDirectory=teleport
-ExecStart=/usr/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3434 --pid-file=/run/teleport/teleport.pid --insecure-no-tls
+ExecStart=/usr/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3434 --pid-file=/run/teleport/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=65536

--- a/assets/marketplace/files/system/teleport-proxy-acm.service
+++ b/assets/marketplace/files/system/teleport-proxy-acm.service
@@ -12,7 +12,7 @@ RestartSec=5
 RuntimeDirectory=teleport
 EnvironmentFile=/etc/teleport.d/conf
 ExecStartPre=/usr/bin/teleport-ssm-get-token
-ExecStart=/usr/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3434 --pid-file=/run/teleport/teleport.pid --insecure-no-tls
+ExecStart=/usr/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3434 --pid-file=/run/teleport/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=65536

--- a/examples/aws/terraform/proxy_network.tf
+++ b/examples/aws/terraform/proxy_network.tf
@@ -202,7 +202,7 @@ resource "aws_lb_target_group" "proxy_web_acm" {
   name     = "${var.cluster_name}-proxy-web"
   port     = 3080
   vpc_id   = aws_vpc.teleport.id
-  protocol = "HTTP"
+  protocol = "HTTPS"
   count    = var.use_acm ? 1 : 0
 
   health_check {


### PR DESCRIPTION
Reported by a customer. AWS ALBs don't validate the SSL certs presented by the backend services they connect to. As we're using an ALB when using ACM:

1) We can use an HTTPS connection and health checks for the target group rather than HTTP
2) We no longer need to use `--insecure-no-tls` on the ACM services in `systemd`