### PR TITLE
Update docker dir doc and Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,19 @@ $ sudo teleport start
 In a production environment Teleport must run as root. But to play, just do `chown $USER /var/lib/teleport` 
 and run it under `$USER`, in this case you will not be able to login as someone else though.
 
-If you wish to deploy Teleport inside a Docker container:
+## Docker
 
+### Deploy Teleport
+If you wish to deploy Teleport inside a Docker container:
 ```
 # This command will pull the Teleport container image for version 4.2.0
 # Replace 4.2.0 with the version you need:
 $ docker pull quay.io/gravitational/teleport:4.2.0
 ```
 View latest tags on [Quay.io | gravitational/teleport](https://quay.io/repository/gravitational/teleport?tab=tags)
+
+### For Local Testing and Development
+Follow instructions at [docker/README](docker/README.md)
 
 ## Building Teleport
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # The base image (buildbox:latest) is built by running `make -C build.assets` 
 # from the base repo directory $GOPATH/gravitational.com/teleport
-FROM teleport-buildbox:latest
+FROM teleport-buildbox:go1.13.2
 RUN apt-get update
 # DEBUG=1 is needed for the Web UI to be loaded from static assets instead 
 # of the binary

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,15 +5,17 @@ for testing & development purposes.
 
 ### Building 
 
-First, you need to build `teleport:latest` Docker image. This image is built
-when you type `make build` BUT...
+First, you need to build `teleport:latest` Docker image.
 
-But you have to build the base image first, by running `make docker`
-from `$GOPATH/github.com/gravitational/teleport` (repository base dir).
+Run the following commands from `$GOPATH/github.com/gravitational/teleport` (repository base dir):
+
+```bash
+$ make docker
+$ cd docker
+$ make build
+```
 
 ### Starting 
-
-Type:
 
 ```bash
 $ make up
@@ -25,8 +27,6 @@ This will start two Teleport clusters:
 * Three-node cluster `two`, accessible now on https://localhost:5080
 
 ### Stopping
-
-Type:
 
 ```bash
 $ make stop

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,7 +29,7 @@ This will start two Teleport clusters:
 ### Stopping
 
 ```bash
-$ make stop
+$ make down
 ```
 
 ### SSH


### PR DESCRIPTION
#### Reason:
- The inconsistent tag name from `teleport-buildbox` fails to build teleport cluster

#### Changes made to remove error:
- Edit docker/Dockerfile `teleport-buildbox` tag from `latest` to `go1.13.2` because running `make docker` command from root, produces a `teleport-buildbox` image tagged with `go1.13.2`. 
