### PR TITLE
(3.0) Fix server id.

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -2379,6 +2379,14 @@ func (s *APIServer) getServerID(r *http.Request) (string, error) {
 		return "", trace.Wrap(err)
 	}
 
+	// The username extracted from the node's identity (x.509 certificate)
+	// is expected to consist of "<server-id>.<cluster-name>" so strip the
+	// cluster name suffix to get the server id.
+	//
+	// Note that as of right now Teleport expects server id to be a uuid4
+	// but older Gravity clusters used to override it with strings like
+	// "192_168_1_1.<cluster-name>" so this code can't rely on it being
+	// uuid4 to account for clusters upgraded from older versions.
 	return strings.TrimSuffix(role.Username, "."+clusterName), nil
 }
 

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -878,7 +878,7 @@ func (s *TLSSuite) TestValidateUploadSessionRecording(c *check.C) {
 		},
 	}
 	for _, tt := range tests {
-		clt, err := s.server.NewClient(TestServerID(s.server.Identity.ID.HostUUID))
+		clt, err := s.server.NewClient(TestServerID(serverID))
 		c.Assert(err, check.IsNil)
 
 		sessionID := session.NewID()
@@ -974,7 +974,7 @@ func (s *TLSSuite) TestValidatePostSessionSlice(c *check.C) {
 		},
 	}
 	for _, tt := range tests {
-		clt, err := s.server.NewClient(TestServerID(s.server.Identity.ID.HostUUID))
+		clt, err := s.server.NewClient(TestServerID(serverID))
 		c.Assert(err, check.IsNil)
 
 		date := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Will fix https://github.com/gravitational/gravity/issues/1207 (after revendoring).

Needs forward ports to 3.2 and other active Teleport branches.