### PR TITLE
Pass localAuthEnabled flag to UI

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -660,6 +660,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 	authSettings := ui.WebConfigAuthSettings{
 		Providers:    authProviders,
 		SecondFactor: secondFactor,
+		LocalAuth:    clsCfg.GetLocalAuth(),
 	}
 
 	webCfg := ui.WebConfig{

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -658,9 +658,9 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 	}
 
 	authSettings := ui.WebConfigAuthSettings{
-		Providers:    authProviders,
-		SecondFactor: secondFactor,
-		LocalAuth:    clsCfg.GetLocalAuth(),
+		Providers:        authProviders,
+		SecondFactor:     secondFactor,
+		LocalAuthEnabled: clsCfg.GetLocalAuth(),
 	}
 
 	webCfg := ui.WebConfig{

--- a/lib/web/ui/webconfig.go
+++ b/lib/web/ui/webconfig.go
@@ -61,6 +61,6 @@ type WebConfigAuthSettings struct {
 	SecondFactor string `json:"second_factor,omitempty"`
 	// Providers contains a list of configured auth providers
 	Providers []WebConfigAuthProvider `json:"providers,omitempty"`
-	// LocalAuth enables/disables local logins
+	// LocalAuth is a flag that enables local authentication
 	LocalAuth bool `json:"localAuth,omitempty"`
 }

--- a/lib/web/ui/webconfig.go
+++ b/lib/web/ui/webconfig.go
@@ -61,6 +61,6 @@ type WebConfigAuthSettings struct {
 	SecondFactor string `json:"second_factor,omitempty"`
 	// Providers contains a list of configured auth providers
 	Providers []WebConfigAuthProvider `json:"providers,omitempty"`
-	// LocalAuth is a flag that enables local authentication
-	LocalAuth bool `json:"localAuth,omitempty"`
+	// LocalAuthEnabled is a flag that enables local authentication
+	LocalAuthEnabled bool `json:"localAuthEnabled"`
 }

--- a/lib/web/ui/webconfig.go
+++ b/lib/web/ui/webconfig.go
@@ -61,4 +61,6 @@ type WebConfigAuthSettings struct {
 	SecondFactor string `json:"second_factor,omitempty"`
 	// Providers contains a list of configured auth providers
 	Providers []WebConfigAuthProvider `json:"providers,omitempty"`
+	// LocalAuth enables/disables local logins
+	LocalAuth bool `json:"localAuth,omitempty"`
 }


### PR DESCRIPTION
part of issue #2789 

- Added LocalAuthEnabled prop to WebConfigAuthSetting struct in webconfig.go
- Pass LocalAuthEnabled state as part of webCfg in  apiserver.go

tested in UI:
![Screenshot from 2020-03-09 13-54-12](https://user-images.githubusercontent.com/43280172/76256658-8abd9a80-620d-11ea-94f4-155ed3472088.png)
