### PR TITLE
Adds support for custom OIDC prompts (#3409)

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -361,6 +361,18 @@ const (
 	DebugLevel = "debug"
 )
 
+const (
+	// These values are from https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+
+	// OIDCPromptSelectAccount instructs the Authorization Server to
+	// prompt the End-User to select a user account.
+	OIDCPromptSelectAccount = "select_account"
+
+	// OIDCAccessTypeOnline indicates that OIDC flow should be performed
+	// with Authorization server and user connected online
+	OIDCAccessTypeOnline = "online"
+)
+
 // Component generates "component:subcomponent1:subcomponent2" strings used
 // in debugging
 func Component(components ...string) string {

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -163,8 +163,9 @@ func (s *AuthServer) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*servi
 	}
 
 	req.StateToken = stateToken
-	// online is OIDC online scope, "select_account" forces user to always select account
-	req.RedirectURL = oauthClient.AuthCodeURL(req.StateToken, "online", "select_account")
+
+	// online indicates that this login should only work online
+	req.RedirectURL = oauthClient.AuthCodeURL(req.StateToken, teleport.OIDCAccessTypeOnline, connector.GetPrompt())
 
 	// if the connector has an Authentication Context Class Reference (ACR) value set,
 	// update redirect url and add it as a query value.


### PR DESCRIPTION
This commit adds support for custom OIDC prompt values.

Read about possible prompt values here:

https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

Three cases are possible:

* Prompt value is not set, this defaults to
OIDC prompt value to select_account value to preserve backwards
compatibility.

```yaml
kind: oidc
version: v2
metadata:
  name: connector
spec:
  prompt: 'login consent'
```

* Prompt value is set to empty string, it will be omitted
from the auth request.

```yaml
kind: oidc
version: v2
metadata:
  name: connector
spec:
  prompt: ''
```

* Prompt value is set to non empty string, it will be included
in the auth request as is.

```yaml
kind: oidc
version: v2
metadata:
  name: connector
spec:
  prompt: 'login consent'
```

Tested with Auth0 OIDC connector on teleport 4.2 enterprise.