### PR TITLE
Update tctl CLI output messages

### DIFF
--- a/roles.go
+++ b/roles.go
@@ -144,7 +144,7 @@ func (r *Role) Set(v string) error {
 func (r *Role) String() string {
 	switch string(*r) {
 	case string(RoleSignup):
-		return "User signup"
+		return "Password"
 	case string(RoleTrustedCluster), string(LegacyClusterTokenType):
 		return "trusted_cluster"
 	default:

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -57,10 +57,12 @@ type UserCommand struct {
 
 // Initialize allows UserCommand to plug itself into the CLI parser
 func (u *UserCommand) Initialize(app *kingpin.Application, config *service.Config) {
+	const helpPrefix string = "[Teleport DB users only]"
+
 	u.config = config
 	users := app.Command("users", "Manage user accounts")
 
-	u.userAdd = users.Command("add", "Generate a user invitation token")
+	u.userAdd = users.Command("add", "Generate a user invitation token "+helpPrefix)
 	u.userAdd.Arg("account", "Teleport user account name").Required().StringVar(&u.login)
 	u.userAdd.Arg("local-logins", "Local UNIX users this account can log in as [login]").
 		Default("").StringVar(&u.allowedLogins)
@@ -77,14 +79,14 @@ func (u *UserCommand) Initialize(app *kingpin.Application, config *service.Confi
 	u.userUpdate.Flag("set-roles", "Roles to assign to this user").
 		Default("").StringVar(&u.roles)
 
-	u.userList = users.Command("ls", "List all user accounts")
+	u.userList = users.Command("ls", "List all user accounts "+helpPrefix)
 	u.userList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).StringVar(&u.format)
 
 	u.userDelete = users.Command("rm", "Deletes user accounts").Alias("del")
 	u.userDelete.Arg("logins", "Comma-separated list of user logins to delete").
 		Required().StringVar(&u.login)
 
-	u.userResetPassword = users.Command("reset", "Reset user password and generate a new token")
+	u.userResetPassword = users.Command("reset", "Reset user password and generate a new token "+helpPrefix)
 	u.userResetPassword.Arg("account", "Teleport user account name").Required().StringVar(&u.login)
 	u.userResetPassword.Flag("ttl", fmt.Sprintf("Set expiration time for token, default is %v, maximum is %v",
 		defaults.ChangePasswordTokenTTL, defaults.MaxChangePasswordTokenTTL)).
@@ -135,7 +137,7 @@ func (u *UserCommand) ResetPassword(client auth.ClientI) error {
 func (u *UserCommand) PrintResetPasswordToken(token services.ResetPasswordToken, format string) error {
 	err := u.printResetPasswordToken(token,
 		format,
-		"Reset password token has been created and is valid for %v. Share this URL with the user to complete password reset process:\n%v\n\n",
+		"User %v has been reset. Share this URL with the user to complete password reset, link is valid for %v:\n%v\n\n",
 	)
 
 	if err != nil {
@@ -149,7 +151,7 @@ func (u *UserCommand) PrintResetPasswordToken(token services.ResetPasswordToken,
 func (u *UserCommand) PrintResetPasswordTokenAsInvite(token services.ResetPasswordToken, format string) error {
 	err := u.printResetPasswordToken(token,
 		format,
-		"Invite token has been created and is valid for %v. Share this URL with the user to complete user setup:\n%v\n\n")
+		"User %v has been created but requires a password. Share this URL with the user to complete user setup, link is valid for %v:\n%v\n\n")
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -165,7 +167,7 @@ func (u *UserCommand) printResetPasswordToken(token services.ResetPasswordToken,
 
 	if format == teleport.Text {
 		ttl := token.Expiry().Sub(time.Now().UTC()).Round(time.Second)
-		fmt.Printf(messageFormat, ttl, url)
+		fmt.Printf(messageFormat, token.GetUser(), ttl, url)
 		fmt.Printf("NOTE: Make sure %v points at a Teleport proxy which users can access.\n", url.Host)
 	} else if u.format == teleport.JSON {
 		err := printTokenAsJSON(token)


### PR DESCRIPTION
Part of issue https://github.com/gravitational/teleport/issues/3363

- `tctl users add` and `tctl users reset` outputs different messages
- `[Teleport DB users only]` prefix added to `users reset`
- `tctl tokens ls` lists password token as type `Password` instead of `User Signup`

### OSS output
![oss-v2](https://user-images.githubusercontent.com/43280172/76659557-fcf6ed80-6533-11ea-8e76-925c7089a8c5.png)


### Enterprise output
![e](https://user-images.githubusercontent.com/43280172/76659530-ea7cb400-6533-11ea-9b5a-fae9b28f8cee.png)
