### PR TITLE
Fix invalid links in teleport_auth.md

### DIFF
--- a/docs/4.1/architecture/teleport_auth.md
+++ b/docs/4.1/architecture/teleport_auth.md
@@ -108,7 +108,7 @@ by the system's SSH agent if it is running.
 2. If the correct credentials were offered, the Auth Server will generate a
    signed certificate and return it to the client. For users certificates are
    stored in `~/.tsh` by default. If the client uses the [Web
-   UI](./proxy/#web-ui-to-ssh) the signed certificate is associated with a
+   UI](teleport_proxy.md/#connecting-to-a-node) the signed certificate is associated with a
    secure websocket session.
 
 In addition to user's identity, user certificates also contain user roles and

--- a/docs/4.2/architecture/teleport_auth.md
+++ b/docs/4.2/architecture/teleport_auth.md
@@ -108,7 +108,7 @@ by the system's SSH agent if it is running.
 2. If the correct credentials were offered, the Auth Server will generate a
    signed certificate and return it to the client. For users, certificates are
    stored in `~/.tsh` by default. If the client uses the [Web
-   UI](./proxy/#web-ui-to-ssh) the signed certificate is associated with a
+   UI](teleport_proxy.md/#connecting-to-a-node) the signed certificate is associated with a
    secure websocket session.
 
 In addition to a user's identity, user certificates also contain user roles and


### PR DESCRIPTION
As `./proxy/#web-ui-to-ssh` is not a valid link, I changed the link.
Linking to `teleport_proxy.md/#web-to-ssh-proxy` would be better, but that link does not seem to work in [the official documentation page](https://gravitational.com/teleport/docs/architecture/teleport_proxy)

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>