### PR TITLE
Remove toc_depth

### DIFF
--- a/docs/4.2.yaml
+++ b/docs/4.2.yaml
@@ -21,7 +21,6 @@ markdown_extensions:
   - footnotes
   - toc:
       marker: '[TOC]'
-      toc_depth: 2
 extra_css: []
 plugins:
     - search:


### PR DESCRIPTION
This is causing too many broken links and issues with not being able to deeplink the correct parts of docs. We can probably come up with a better way to fix this, but for now we should just restore the old behaviour.