### PR TITLE
fix cert reissue compatibility

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -605,7 +605,6 @@ type rotationStatus struct {
 func checkServerIdentity(conn *Connector, additionalPrincipals []string, dnsNames []string) bool {
 	var principalsChanged bool
 	var dnsNamesChanged bool
-	var oldCertFormat bool
 
 	// Remove 0.0.0.0 (meaning advertise_ip has not) if it exists in the list of
 	// principals. The 0.0.0.0 values tells the auth server to "guess" the nodes
@@ -628,13 +627,8 @@ func checkServerIdentity(conn *Connector, additionalPrincipals []string, dnsName
 		log.Debugf("Rotation in progress, adding %v to x590 DNS names in SAN %v.",
 			dnsNames, conn.ServerIdentity.XCert.DNSNames)
 	}
-	// Older certificates did not necessarily include node id in the principal list.
-	if id, err := conn.ServerIdentity.ID.HostID(); err == nil && !conn.ServerIdentity.HasPrincipals([]string{id}) {
-		oldCertFormat = true
-		log.Debugf("Rotation in progress, certificate does not include host id: %s", id)
-	}
 
-	return principalsChanged || dnsNamesChanged || oldCertFormat
+	return principalsChanged || dnsNamesChanged
 }
 
 // rotate is called to check if rotation should be triggered.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1809,6 +1809,10 @@ func (process *TeleportProcess) getAdditionalPrincipals(role teleport.Role) ([]s
 	case teleport.RoleAuth, teleport.RoleAdmin:
 		addrs = process.Config.Auth.PublicAddrs
 	case teleport.RoleNode:
+		// DELETE IN 5.0: We are manually adding HostUUID here in order
+		// to allow UUID based routing to function with older Auth Servers
+		// which don't automatically add UUID to the principal list.
+		principals = append(principals, process.Config.HostUUID)
 		addrs = process.Config.SSH.PublicAddrs
 		// If advertise IP is set, add it to the list of principals. Otherwise
 		// add in the default (0.0.0.0) which will be replaced by the Auth Server


### PR DESCRIPTION
Fixes an issue where certificate checks were causing nodes to go into an infinite restart loop when dealing with an older auth server.

Previously, nodes were checking for the presence of Host UUID in their cert principals, and triggering re-issue if it did not exist.  This logic caused an infinite loop since older auth servers don't add Host UUID automatically.

After this patch nodes will explicitly add Host UUID to their own principals list, allowing them to ensure that their certificates contain Host UUID even if the Auth Server is outdated.