### PR TITLE
Update keep_alive_interval to reflect default

### DIFF
--- a/docs/4.1/admin-guide.md
+++ b/docs/4.1/admin-guide.md
@@ -363,11 +363,10 @@ auth_service:
     # certificates expire in the middle of an active SSH session. (default is 'no')
     disconnect_expired_cert: no
 
-    # Determines the interval at which Teleport will send keep-alive messages. The
-    # default value mirrors sshd at 15 minutes.  keep_alive_count_max is the number
-    # of missed keep-alive messages before the server tears down the connection to the
-    # client.
-    keep_alive_interval: 15
+    # Determines the interval at which Teleport will send keep-alive messages.
+    # keep_alive_count_max is the number of missed keep-alive messages before
+    # the server tears down the connection to the client.
+    keep_alive_interval: 5m
     keep_alive_count_max: 3
 
     # License file to start auth server with. Note that this setting is ignored

--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -375,11 +375,10 @@ auth_service:
     # certificates expire in the middle of an active SSH session. (default is 'no')
     disconnect_expired_cert: no
 
-    # Determines the interval at which Teleport will send keep-alive messages. The
-    # default value mirrors sshd at 15 minutes.  keep_alive_count_max is the number
-    # of missed keep-alive messages before the server tears down the connection to the
-    # client.
-    keep_alive_interval: 15
+    # Determines the interval at which Teleport will send keep-alive messages.
+    # keep_alive_count_max is the number of missed keep-alive messages before
+    # the server tears down the connection to the client.
+    keep_alive_interval: 5m
     keep_alive_count_max: 3
 
     # License file to start auth server with. Note that this setting is ignored


### PR DESCRIPTION
The actual value is 5 minutes and has been since 4.1.0.