### PR TITLE
Add keep_alive_interval to AMI config

### DIFF
--- a/assets/marketplace/files/bin/teleport-generate-config
+++ b/assets/marketplace/files/bin/teleport-generate-config
@@ -259,7 +259,7 @@ auth_service:
   enabled: yes
   keep_alive_interval: 1m
   keep_alive_count_max: 3
-  listen_addr: 0.0.0.0:3025  
+  listen_addr: 0.0.0.0:3025
   authentication:
     ${AUTHENTICATION_STANZA}
 

--- a/assets/marketplace/files/bin/teleport-generate-config
+++ b/assets/marketplace/files/bin/teleport-generate-config
@@ -68,6 +68,8 @@ proxy_service:
 auth_service:
   enabled: yes
   public_addr: ${TELEPORT_AUTH_SERVER_LB}:3025
+  keep_alive_interval: 1m
+  keep_alive_count_max: 3
   listen_addr: 0.0.0.0:3025
   authentication:
     ${AUTHENTICATION_STANZA}
@@ -255,7 +257,9 @@ teleport:
 
 auth_service:
   enabled: yes
-  listen_addr: 0.0.0.0:3025
+  keep_alive_interval: 1m
+  keep_alive_count_max: 3
+  listen_addr: 0.0.0.0:3025  
   authentication:
     ${AUTHENTICATION_STANZA}
 


### PR DESCRIPTION
As per #3392, we should set a lower `keep_alive_interval` for AMI-based deployments on AWS to keep connections going through NLBs. The default is supposed to be 5 minutes already, but a few people have mentioned issued with this lately.