### PR TITLE
Extend Trusted Clusters doc to show how to share groups

### DIFF
--- a/docs/4.2/trustedclusters.md
+++ b/docs/4.2/trustedclusters.md
@@ -315,7 +315,7 @@ $ tctl create --force cluster.yaml
 
 Below is an example of how to share a kubernetes group between trusted clusters. 
 
-In this example, we have a root trusted cluster with a role `main` and kubernetes groups:
+In this example, we have a root trusted cluster with a role `root` and kubernetes groups:
 
 ```yaml
 kube_groups: ["system:masters"] 
@@ -325,14 +325,14 @@ SSH logins:
 ```yaml
 logins: ["root"]
 ```
-The leaf cluster can choose to map this `main` cluster to it's own. The `remote-admin` cluster in the trusted cluster config:
+The leaf cluster can choose to map this `root` cluster to it's own. The `admin` cluster in the trusted cluster config:
 
 ```yaml
 role_map:
-  - remote: "main"
-    local: [remote-admin]
+  - remote: "root"
+    local: [admin] 
 ```
-The role `remote-admin` of the leaf cluster can now be set up to use the main cluster role main logins and `kubernetes_groups` using the following variables:
+The role `admin` of the leaf cluster can now be set up to use the root cluster role logins and `kubernetes_groups` using the following variables:
 
 ```yaml
 logins: ['{{internal.logins}}']
@@ -340,7 +340,7 @@ kubernetes_groups: ['{{internal.kubernetes_groups}}']
 ```
 !!! tip "Note"
 
-    In order to pass logins from a root "main" trusted cluster to a leaf cluster, you must use the variable `{{internal.logins}}`. 
+    In order to pass logins from a root trusted cluster to a leaf cluster, you must use the variable `{{internal.logins}}`. 
 
 ## How does it work?
 

--- a/docs/4.2/trustedclusters.md
+++ b/docs/4.2/trustedclusters.md
@@ -318,14 +318,14 @@ Below is an example of how to share a kubernetes group between trusted clusters.
 In this example, we have a root trusted cluster with a role `root` and kubernetes groups:
 
 ```yaml
-kube_groups: ["system:masters"] 
+kubernetes_groups: ["system:masters"] 
 ```
 SSH logins:
 
 ```yaml
 logins: ["root"]
 ```
-The leaf cluster can choose to map this `root` cluster to it's own. The `admin` cluster in the trusted cluster config:
+The leaf cluster can choose to map this `root` cluster to its own cluster. The `admin` cluster in the trusted cluster config:
 
 ```yaml
 role_map:

--- a/docs/4.2/trustedclusters.md
+++ b/docs/4.2/trustedclusters.md
@@ -335,8 +335,8 @@ role_map:
 The role `admin` of the leaf cluster can now be set up to use the root cluster role logins and `kubernetes_groups` using the following variables:
 
 ```yaml
-logins: ['{{internal.logins}}']
-kubernetes_groups: ['{{internal.kubernetes_groups}}']
+logins: ["{{internal.logins}}"]
+kubernetes_groups: ["{{internal.kubernetes_groups}}"]
 ```
 !!! tip "Note"
 

--- a/docs/4.2/trustedclusters.md
+++ b/docs/4.2/trustedclusters.md
@@ -311,6 +311,36 @@ and set `enabled` to "false", then update it:
 ```bsh
 $ tctl create --force cluster.yaml
 ```
+## Sharing Kubernetes groups between Trusted Clusters
+
+Below is an example of how to share a kubernetes group between trusted clusters. 
+
+In this example, we have a root trusted cluster with a role `main` and kubernetes groups:
+
+```yaml
+kube_groups: ["system:masters"] 
+```
+SSH logins:
+
+```yaml
+logins: ["root"]
+```
+The leaf cluster can choose to map this `main` cluster to it's own. The `remote-admin` cluster in the trusted cluster config:
+
+```yaml
+role_map:
+  - remote: "main"
+    local: [remote-admin]
+```
+The role `remote-admin` of the leaf cluster can now be set up to use the main cluster role main logins and `kubernetes_groups` using the following variables:
+
+```yaml
+logins: ['{{internal.logins}}']
+kubernetes_groups: ['{{internal.kubernetes_groups}}']
+```
+!!! tip "Note"
+
+    In order to pass logins from a root "main" trusted cluster to a leaf cluster, you must use the variable `{{internal.logins}}`. 
 
 ## How does it work?
 


### PR DESCRIPTION
This example details how to share kubernetes groups between trusted clusters. Same concept for SAML attributes.

Resolves: #3457