### PR TITLE
Add temporary check for mismatch proxy/auth version

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -292,10 +292,10 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 			if err != nil {
 				log.WithError(err).Debugf("Could not ping auth server")
 			} else {
-				proxyVersion := strings.Index(teleport.Version, "4.")
-				authVersion := strings.Index(res.GetServerVersion(), "5.")
+				isProxyV4x := strings.Index(teleport.Version, "4.") == 0
+				isAuthV5x := strings.Index(res.GetServerVersion(), "5.") == 0
 
-				if authVersion == 0 && proxyVersion == 0 {
+				if isAuthV5x && isProxyV4x {
 					message := "There is a version mismatch between your proxy and auth services. Please upgrade your proxy service to version 5.0.0 or higher."
 					pathToError := url.URL{
 						Path:     "/web/msg/error",

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -286,7 +286,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 		// check proxy and auth node versions (breaking change from v5).
 		// If there is a mismatch with the current proxy client, redirect users to an error page to update proxy.
 		//
-		// TODO remove this block after shipping v4.3
+		// DELETE IN 5.0: this block only serves to notify users of v4.3+ to upgrade to v5.0.0
 		if strings.HasPrefix(r.URL.Path, "/web/newuser") {
 			res, err := h.auth.Ping(context.TODO())
 			if err != nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -296,7 +296,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 				isAuthV5x := strings.Index(res.GetServerVersion(), "5.") == 0
 
 				if isAuthV5x && isProxyV4x {
-					message := "There is a version mismatch between your proxy and auth services. Please upgrade your proxy service to version 5.0.0 or higher."
+					message := fmt.Sprintf("Your Teleport proxy and auth service versions are incompatible. Please upgrade your Teleport proxy service to version %v", res.GetServerVersion())
 					pathToError := url.URL{
 						Path:     "/web/msg/error",
 						RawQuery: url.Values{"details": []string{message}}.Encode(),

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/proto"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
@@ -471,6 +472,11 @@ func (s *sessionCache) GetCertificateWithU2F(c client.CreateSSHCertWithU2FReq) (
 
 func (s *sessionCache) GetUserInviteInfo(token string) (user string, otpQRCode []byte, err error) {
 	return s.proxyClient.GetSignupTokenData(token)
+}
+
+// Ping gets basic info about the auth server.
+func (s *sessionCache) Ping(ctx context.Context) (proto.PingResponse, error) {
+	return s.proxyClient.Ping(ctx)
 }
 
 func (s *sessionCache) GetUserInviteU2FRegisterRequest(token string) (*u2f.RegisterRequest, error) {


### PR DESCRIPTION
resolves https://github.com/gravitational/teleport/issues/3313

#### Description 
Notifies new users who has proxy (4.3) and auth (5.0) version mismatch to upgrade their proxy servers, by redirecting their invite URL to an error page.

#### Manual check
![Screenshot from 2020-03-20 15-35-02](https://user-images.githubusercontent.com/43280172/77211476-52e20d00-6ac1-11ea-8a70-8592177dacc8.png)
![Screenshot from 2020-03-20 15-34-52](https://user-images.githubusercontent.com/43280172/77211489-5d9ca200-6ac1-11ea-8e26-c205a19c4f3e.png)
