### PR TITLE
Reduce cache flakyness

### DIFF
--- a/lib/services/fanout.go
+++ b/lib/services/fanout.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gravitational/teleport/lib/backend"
+
+	"github.com/gravitational/trace"
+)
+
+const defaultQueueSize = 64
+
+type fanoutEntry struct {
+	kind    WatchKind
+	watcher *fanoutWatcher
+}
+
+// Matches attempts to determine if the supplied event matches
+// this WatchKind.  If the WatchKind is misconfigured, or the
+// event appears malformed, an error is returned.
+func (kind WatchKind) Matches(e Event) (bool, error) {
+	if kind.Kind != e.Resource.GetKind() {
+		return false, nil
+	}
+	if kind.Name != "" && kind.Name != e.Resource.GetName() {
+		return false, nil
+	}
+	if len(kind.Filter) > 0 {
+		// no filters currently match delete events
+		if e.Type != backend.OpPut {
+			return false, nil
+		}
+		// Currently only access request make use of filters,
+		// so expect the resource to be an access request.
+		req, ok := e.Resource.(AccessRequest)
+		if !ok {
+			return false, trace.BadParameter("unfilterable resource type: %T", e.Resource)
+		}
+		var filter AccessRequestFilter
+		if err := filter.FromMap(kind.Filter); err != nil {
+			return false, trace.Wrap(err)
+		}
+		return filter.Match(req), nil
+	}
+	return true, nil
+}
+
+type Fanout struct {
+	sync.Mutex
+	watchers map[string][]fanoutEntry
+}
+
+func NewFanout() *Fanout {
+	return &Fanout{
+		watchers: make(map[string][]fanoutEntry),
+	}
+}
+
+func (f *Fanout) NewWatcher(ctx context.Context, watch Watch) (Watcher, error) {
+	f.Lock()
+	defer f.Unlock()
+	w, err := newFanoutWatcher(ctx, watch)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := w.emit(Event{Type: backend.OpInit}); err != nil {
+		w.cancel()
+		return nil, trace.Wrap(err)
+	}
+	f.addWatcher(w)
+	return w, nil
+}
+
+func (f *Fanout) Emit(events ...Event) {
+	f.Lock()
+	defer f.Unlock()
+	for _, event := range events {
+		var remove []*fanoutWatcher
+	Inner:
+		for _, entry := range f.watchers[event.Resource.GetKind()] {
+			match, err := entry.kind.Matches(event)
+			if err != nil {
+				entry.watcher.setError(err)
+				remove = append(remove, entry.watcher)
+				continue Inner
+			}
+			if !match {
+				continue Inner
+			}
+			if err := entry.watcher.emit(event); err != nil {
+				remove = append(remove, entry.watcher)
+				continue Inner
+			}
+		}
+		for _, w := range remove {
+			f.removeWatcher(w)
+			w.cancel()
+		}
+	}
+}
+
+func (f *Fanout) CloseWatchers() {
+	f.Lock()
+	defer f.Unlock()
+	for kind, entries := range f.watchers {
+		for _, entry := range entries {
+			entry.watcher.cancel()
+		}
+		delete(f.watchers, kind)
+	}
+	f.watchers = make(map[string][]fanoutEntry)
+}
+
+func (f *Fanout) addWatcher(w *fanoutWatcher) {
+	for _, kind := range w.watch.Kinds {
+		entries := f.watchers[kind.Kind]
+		entries = append(entries, fanoutEntry{
+			kind:    kind,
+			watcher: w,
+		})
+		f.watchers[kind.Kind] = entries
+	}
+}
+
+func (f *Fanout) removeWatcher(w *fanoutWatcher) bool {
+	var found bool
+	for _, kind := range w.watch.Kinds {
+		entries := f.watchers[kind.Kind]
+	Inner:
+		for i, entry := range entries {
+			if entry.watcher == w {
+				found = true
+				entries = append(entries[:i], entries[i+1:]...)
+				break Inner
+			}
+		}
+		switch len(entries) {
+		case 0:
+			delete(f.watchers, kind.Kind)
+		default:
+			f.watchers[kind.Kind] = entries
+		}
+	}
+	return found
+}
+
+func newFanoutWatcher(ctx context.Context, watch Watch) (*fanoutWatcher, error) {
+	if len(watch.Kinds) < 1 {
+		return nil, trace.BadParameter("must specify at least one resource kind to watch")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	if watch.QueueSize < 1 {
+		watch.QueueSize = defaultQueueSize
+	}
+	return &fanoutWatcher{
+		watch:  watch,
+		eventC: make(chan Event, watch.QueueSize),
+		cancel: cancel,
+		ctx:    ctx,
+	}, nil
+}
+
+type fanoutWatcher struct {
+	emux   sync.Mutex
+	err    error
+	watch  Watch
+	eventC chan Event
+	cancel context.CancelFunc
+	ctx    context.Context
+}
+
+func (w *fanoutWatcher) emit(event Event) error {
+	select {
+	case <-w.ctx.Done():
+		return trace.Wrap(w.ctx.Err(), "watcher closed")
+	case w.eventC <- event:
+		return nil
+	default:
+		return trace.BadParameter("buffer overflow")
+	}
+}
+
+func (w *fanoutWatcher) Events() <-chan Event {
+	return w.eventC
+}
+
+func (w *fanoutWatcher) Done() <-chan struct{} {
+	return w.ctx.Done()
+}
+
+func (w *fanoutWatcher) Close() error {
+	w.cancel()
+	return nil
+}
+
+func (w *fanoutWatcher) setError(err error) {
+	w.emux.Lock()
+	defer w.emux.Unlock()
+	w.err = err
+}
+
+func (w *fanoutWatcher) getError() error {
+	w.emux.Lock()
+	defer w.emux.Unlock()
+	return w.err
+}
+
+func (w *fanoutWatcher) Error() error {
+	return w.getError()
+}


### PR DESCRIPTION
Supersedes #3415 

- [x] Cache performs direct in-memory fanout of events and no longer generates spurious events on cache init/reset.
- [ ] Cache "locks" during inits/resets s.t. reads cannot be performed on partial state.