### PR TITLE
Fix auth_service token documentation in GCP Guide

### DIFF
--- a/docs/4.2/gcp_guide.md
+++ b/docs/4.2/gcp_guide.md
@@ -166,9 +166,8 @@ teleport:
     audit_sessions_uri: 'gs://teleport-session-storage-2?credentialsPath=/var/lib/teleport/gcs_creds.json&projectID=example_Teleport-Project-Name'
 auth_service:
   enabled: yes
-  auth_service:
-    tokens:
-    - "proxy,node:EXAMPLE-CLUSTER-JOIN-TOKEN"  
+  tokens:
+  - "proxy,node:EXAMPLE-CLUSTER-JOIN-TOKEN"  
 ```
 
 **2. Setup Proxy**


### PR DESCRIPTION
The example teleport yaml has a extra auth_service that will cause the static tokens to be ignored