### PR TITLE
Bumps Quickstart Version.

### DIFF
--- a/docs/4.2.yaml
+++ b/docs/4.2.yaml
@@ -31,9 +31,9 @@ extra_javascript: []
 extra:
     version: 4.2
     teleport:
-        version: 4.2.3
+        version: 4.2.6
         golang: 1.13
-        sha: 1c14362c9ba10f28088c7228b357dc6a70072d3d4afaa5510c70a8734068684c
+        sha: 0aefb3cfa0477c7d95ba45d0efd0bdc5be8f4ab09f36e25e50ae433831fa8cfe
 nav:
     - Documentation:
         - Introduction: index.md

--- a/docs/4.2/enterprise/ssh_rbac.md
+++ b/docs/4.2/enterprise/ssh_rbac.md
@@ -140,7 +140,7 @@ The following variables can be used with `logins` field:
 
 Variable                | Description
 ------------------------|--------------------------
-`{% raw %}{{internal.logins}}{% endraw %} | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database.
+`{% raw %}{{internal.logins}}{% endraw %}` | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database.
 `{% raw %}{{external.xyz}}{% endraw %}`    | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim.
 
 Both variables above are there to deliver the same benefit: they allow Teleport


### PR DESCRIPTION
We should find a way to automate this, but for now this file represents the latest Teleport binary version.  I've also sneaked in a minor fix to RBAC info 