### PR TITLE
Bump teleport version up in helm examples

### DIFF
--- a/examples/chart/teleport-demo/values.yaml
+++ b/examples/chart/teleport-demo/values.yaml
@@ -1,6 +1,6 @@
 ## override these on the helm command line with things like --set teleportVersion=4.2.0
 # teleport version to deploy (must be a valid tag on https://quay.io/repository/gravitational/teleport-ent?tab=tags)
-teleportVersion: 4.2.0
+teleportVersion: 4.2.7
 # name of the 'main' cluster which will be set up and configured - this will also the cluster's namespace
 # DNS will be set up for <clusterName>.<clusterDomain>
 mainClusterName: main

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/gravitational/teleport-ent
-  tag: 3.2.4
+  tag: 4.2.7
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.


### PR DESCRIPTION
Use latest secure version along with taking the smaller version up to version 4.