### PR TITLE
Update Cloudformation to reflect AMI changes

### DIFF
--- a/examples/aws/cloudformation/ent.yaml
+++ b/examples/aws/cloudformation/ent.yaml
@@ -209,14 +209,15 @@ Resources:
             # Set some instance specific environment variables configurations for systemd configuration file
             cat >> /etc/teleport.d/conf <<EOF
             EC2_REGION=${AWS::Region}
+            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
             TELEPORT_CLUSTER_NAME=${DomainName}
-            TELEPORT_DOMAIN_NAME=${DomainName}
-            TELEPORT_S3_BUCKET=${LocalBucketName}
-            TELEPORT_ROLE=auth
-            TELEPORT_LOCKS_TABLE_NAME=${LocalLocksTableName}
+            TELEPORT_DOMAIN_ADMIN_EMAIL=${DomainAdminEmail}
+            TELEPORT_DOMAIN_NAME=${DomainName}            
             TELEPORT_DYNAMO_TABLE_NAME=${LocalMainTableName}
             TELEPORT_DYNAMO_EVENTS_TABLE_NAME=${LocalEventsTableName}
-            TELEPORT_DOMAIN_ADMIN_EMAIL=${DomainAdminEmail}
+            TELEPORT_LOCKS_TABLE_NAME=${LocalLocksTableName}
+            TELEPORT_ROLE=auth
+            TELEPORT_S3_BUCKET=${LocalBucketName}
             TELEPORT_SSM_KEY_ARN=${LocalKeyARN}
             EOF
 
@@ -253,6 +254,7 @@ Resources:
             systemctl daemon-reload
             systemctl start --no-block cfn-signal-done.service
           - {
+            LocalAuthServerLB: !GetAtt AuthLB.DNSName,
             LocalMainTableName: !Select [1, !Split ["/", !GetAtt MainTable.Arn]],
             LocalLocksTableName: !Select [1, !Split ["/", !GetAtt LocksTable.Arn]],
             LocalEventsTableName: !Select [1, !Split ["/", !GetAtt EventsTable.Arn]],
@@ -414,11 +416,11 @@ Resources:
             # Set some instance specific environment variables configurations for systemd configuration file
             cat >> /etc/teleport.d/conf <<EOF
             EC2_REGION=${AWS::Region}
+            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
             TELEPORT_CLUSTER_NAME=${DomainName}
             TELEPORT_DOMAIN_NAME=${DomainName}
             TELEPORT_S3_BUCKET=${LocalBucketName}
-            TELEPORT_ROLE=proxy
-            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
+            TELEPORT_ROLE=proxy            
             TELEPORT_SSM_KEY_ARN=${LocalKeyARN}
             EOF
 
@@ -517,11 +519,11 @@ Resources:
             # Set some instance specific environment variables configurations for systemd configuration file
             cat >> /etc/teleport.d/conf <<EOF
             EC2_REGION=${AWS::Region}
+            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
             TELEPORT_CLUSTER_NAME=${DomainName}
             TELEPORT_DOMAIN_NAME=${DomainName}
-            TELEPORT_S3_BUCKET=${LocalBucketName}
             TELEPORT_ROLE=node
-            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
+            TELEPORT_S3_BUCKET=${LocalBucketName}                   
             TELEPORT_SSM_KEY_ARN=${LocalKeyARN}
             EOF
 

--- a/examples/aws/cloudformation/ent.yaml
+++ b/examples/aws/cloudformation/ent.yaml
@@ -419,6 +419,7 @@ Resources:
             TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
             TELEPORT_CLUSTER_NAME=${DomainName}
             TELEPORT_DOMAIN_NAME=${DomainName}
+            TELEPORT_PROXY_SERVER_LB=${LocalProxyServerLB}
             TELEPORT_S3_BUCKET=${LocalBucketName}
             TELEPORT_ROLE=proxy            
             TELEPORT_SSM_KEY_ARN=${LocalKeyARN}
@@ -458,6 +459,7 @@ Resources:
             systemctl start --no-block cfn-signal-done.service
           - {
             LocalAuthServerLB: !GetAtt AuthLB.DNSName,
+            LocalProxyServerLB: !GetAtt ProxyLB.DNSName,
             LocalKeyARN: !GetAtt Key.Arn,
             LocalBucketName: !Select [1, !Split [":::", !GetAtt Bucket.Arn]]
             }

--- a/examples/aws/cloudformation/oss.yaml
+++ b/examples/aws/cloudformation/oss.yaml
@@ -209,14 +209,15 @@ Resources:
             # Set some instance specific environment variables configurations for systemd configuration file
             cat >> /etc/teleport.d/conf <<EOF
             EC2_REGION=${AWS::Region}
+            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
             TELEPORT_CLUSTER_NAME=${DomainName}
+            TELEPORT_DOMAIN_ADMIN_EMAIL=${DomainAdminEmail}
             TELEPORT_DOMAIN_NAME=${DomainName}
-            TELEPORT_S3_BUCKET=${LocalBucketName}
-            TELEPORT_ROLE=auth
-            TELEPORT_LOCKS_TABLE_NAME=${LocalLocksTableName}
             TELEPORT_DYNAMO_TABLE_NAME=${LocalMainTableName}
             TELEPORT_DYNAMO_EVENTS_TABLE_NAME=${LocalEventsTableName}
-            TELEPORT_DOMAIN_ADMIN_EMAIL=${DomainAdminEmail}
+            TELEPORT_LOCKS_TABLE_NAME=${LocalLocksTableName}
+            TELEPORT_S3_BUCKET=${LocalBucketName}
+            TELEPORT_ROLE=auth
             TELEPORT_SSM_KEY_ARN=${LocalKeyARN}
             EOF
 
@@ -253,6 +254,7 @@ Resources:
             systemctl daemon-reload
             systemctl start --no-block cfn-signal-done.service
           - {
+            LocalAuthServerLB: !GetAtt AuthLB.DNSName,
             LocalMainTableName: !Select [1, !Split ["/", !GetAtt MainTable.Arn]],
             LocalLocksTableName: !Select [1, !Split ["/", !GetAtt LocksTable.Arn]],
             LocalEventsTableName: !Select [1, !Split ["/", !GetAtt EventsTable.Arn]],
@@ -414,11 +416,11 @@ Resources:
             # Set some instance specific environment variables configurations for systemd configuration file
             cat >> /etc/teleport.d/conf <<EOF
             EC2_REGION=${AWS::Region}
+            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
             TELEPORT_CLUSTER_NAME=${DomainName}
             TELEPORT_DOMAIN_NAME=${DomainName}
-            TELEPORT_S3_BUCKET=${LocalBucketName}
             TELEPORT_ROLE=proxy
-            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
+            TELEPORT_S3_BUCKET=${LocalBucketName}
             TELEPORT_SSM_KEY_ARN=${LocalKeyARN}
             EOF
 
@@ -517,11 +519,11 @@ Resources:
             # Set some instance specific environment variables configurations for systemd configuration file
             cat >> /etc/teleport.d/conf <<EOF
             EC2_REGION=${AWS::Region}
+            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
             TELEPORT_CLUSTER_NAME=${DomainName}
             TELEPORT_DOMAIN_NAME=${DomainName}
-            TELEPORT_S3_BUCKET=${LocalBucketName}
             TELEPORT_ROLE=node
-            TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
+            TELEPORT_S3_BUCKET=${LocalBucketName}
             TELEPORT_SSM_KEY_ARN=${LocalKeyARN}
             EOF
 

--- a/examples/aws/cloudformation/oss.yaml
+++ b/examples/aws/cloudformation/oss.yaml
@@ -419,6 +419,7 @@ Resources:
             TELEPORT_AUTH_SERVER_LB=${LocalAuthServerLB}
             TELEPORT_CLUSTER_NAME=${DomainName}
             TELEPORT_DOMAIN_NAME=${DomainName}
+            TELEPORT_PROXY_SERVER_LB=${LocalProxyServerLB}
             TELEPORT_ROLE=proxy
             TELEPORT_S3_BUCKET=${LocalBucketName}
             TELEPORT_SSM_KEY_ARN=${LocalKeyARN}
@@ -458,6 +459,7 @@ Resources:
             systemctl start --no-block cfn-signal-done.service
           - {
             LocalAuthServerLB: !GetAtt AuthLB.DNSName,
+            LocalProxyServerLB: !GetAtt ProxyLB.DNSName,
             LocalKeyARN: !GetAtt Key.Arn,
             LocalBucketName: !Select [1, !Split [":::", !GetAtt Bucket.Arn]]
             }


### PR DESCRIPTION
In #3333 we made breaking updates to our AWS AMI scripts. These updates were also made to our reference Terraform code, but not to our Cloudformation template. As such, Cloudformation deployments are currently failing.

There were also changes made in #3302 - these are reflected here too. This is less important as we aren't currently supporting ACM via Cloudformation (lots of work to implement with no current demand for it) but I figure we should be future-proof.