### PR TITLE
Retrieve cluster details for user context

### DIFF
--- a/lib/auth/resetpasswordtoken.go
+++ b/lib/auth/resetpasswordtoken.go
@@ -171,7 +171,7 @@ func (s *AuthServer) newResetPasswordToken(req CreateResetPasswordTokenRequest) 
 		log.Errorf("Unable to retrieve proxy list: %v", err)
 	}
 
-	proxyHost := services.GuessProxyHost(proxies)
+	proxyHost, _ := services.GuessProxyHostAndVersion(proxies)
 	url, err := formatResetPasswordTokenURL(proxyHost, tokenID, req.Type)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -382,6 +382,7 @@ const ServerSpecV2Schema = `{
   "type": "object",
   "additionalProperties": false,
   "properties": {
+	"version": {"type": "string"},
     "addr": {"type": "string"},
     "public_addr": {"type": "string"},
     "hostname": {"type": "string"},
@@ -773,23 +774,27 @@ func (s SortedReverseTunnels) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-// GuessProxyHost tries to find the first proxy with a public
-// address configured. If no proxies are configured, it will return a
-// guessed value by concatenating the first proxy's hostname with default port number.
+// GuessProxyHostAndVersion tries to find the first proxy with a public
+// address configured and return that public addr and version.
+// If no proxies are configured, it will return a guessed value by concatenating
+// the first proxy's hostname with default port number, and the first proxy's
+// version will also be returned.
 //
 // Returns empty value if there are no proxies.
-func GuessProxyHost(proxies []Server) string {
+func GuessProxyHostAndVersion(proxies []Server) (string, string) {
 	if len(proxies) < 1 {
-		return ""
+		return "", ""
 	}
 
 	// find the first proxy with a public address set
 	for _, proxy := range proxies {
 		proxyHost := proxy.GetPublicAddr()
 		if proxyHost != "" {
-			return proxyHost
+			return proxyHost, proxy.GetTeleportVersion()
 		}
 	}
 
-	return fmt.Sprintf("%v:%v", proxies[0].GetHostname(), defaults.HTTPListenPort)
+	guessProxyHost := fmt.Sprintf("%v:%v", proxies[0].GetHostname(), defaults.HTTPListenPort)
+
+	return guessProxyHost, proxies[0].GetTeleportVersion()
 }

--- a/lib/services/servers_test.go
+++ b/lib/services/servers_test.go
@@ -110,3 +110,28 @@ func (s *ServerSuite) TestServersCompare(c *check.C) {
 	}
 	c.Assert(CompareServers(node, &node2), check.Equals, Different)
 }
+
+func (s *ServerSuite) TestGuessProxyHostAndVersion(c *check.C) {
+	// nil proxies
+	host, version := GuessProxyHostAndVersion(nil)
+	c.Assert(host, check.Equals, "")
+	c.Assert(version, check.Equals, "")
+
+	// no public addr set
+	proxyA := ServerV2{}
+	proxyA.Spec.Hostname = "test-A"
+	proxyA.Spec.Version = "test-A"
+
+	host, version = GuessProxyHostAndVersion([]Server{&proxyA})
+	c.Assert(host, check.Equals, fmt.Sprintf("%v:%v", proxyA.Spec.Hostname, defaults.HTTPListenPort))
+	c.Assert(version, check.Equals, proxyA.Spec.Version)
+
+	// with a proxy with public addr set
+	proxyB := ServerV2{}
+	proxyB.Spec.PublicAddr = "test-B"
+	proxyB.Spec.Version = "test-B"
+
+	host, version = GuessProxyHostAndVersion([]Server{&proxyA, &proxyB})
+	c.Assert(host, check.Equals, proxyB.Spec.PublicAddr)
+	c.Assert(version, check.Equals, proxyB.Spec.Version)
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -385,7 +385,11 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 
-	userContext.Version = teleport.Version
+	userContext.Cluster, err = ui.GetClusterDetails(site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return userContext, nil
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -87,9 +87,10 @@ func TestWeb(t *testing.T) {
 }
 
 type WebSuite struct {
-	node  *regular.Server
-	proxy *regular.Server
-	srvID string
+	node        *regular.Server
+	proxy       *regular.Server
+	proxyTunnel reversetunnel.Server
+	srvID       string
 
 	user      string
 	webServer *httptest.Server
@@ -218,6 +219,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		DataDir:               c.MkDir(),
 	})
 	c.Assert(err, IsNil)
+	s.proxyTunnel = revTunServer
 
 	// proxy server:
 	proxyPort := s.freePorts[len(s.freePorts)-1]
@@ -1611,6 +1613,28 @@ func (s *WebSuite) searchEvents(c *C, clt *client.WebClient, query url.Values, f
 		}
 	}
 	return result
+}
+
+func (s *WebSuite) TestGetClusterDetails(c *C) {
+	site, err := s.proxyTunnel.GetSite(s.server.ClusterName())
+	c.Assert(err, IsNil)
+	c.Assert(site, NotNil)
+
+	cluster, err := ui.GetClusterDetails(site)
+	c.Assert(err, IsNil)
+	c.Assert(cluster.Name, Equals, s.server.ClusterName())
+	c.Assert(cluster.ProxyVersion, Equals, teleport.Version)
+	c.Assert(cluster.PublicURL, Equals, fmt.Sprintf("%v:%v", s.server.ClusterName(), defaults.HTTPListenPort))
+	c.Assert(cluster.Status, Equals, teleport.RemoteClusterStatusOnline)
+	c.Assert(cluster.LastConnected, NotNil)
+
+	nodes, err := s.proxyClient.GetNodes(defaults.Namespace)
+	c.Assert(err, IsNil)
+	c.Assert(nodes, HasLen, cluster.NodeCount)
+
+	// Expected empty, b/c test auth server doesn't set up
+	// heartbeat which where ServerSpecV2 version would've been set
+	c.Assert(cluster.AuthVersion, Equals, "")
 }
 
 type authProviderMock struct {

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ui
 
 import (
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -58,8 +57,8 @@ type userContext struct {
 	Name string `json:"userName"`
 	// ACL contains user access control list
 	ACL userACL `json:"userAcl"`
-	// Version is the version of Teleport that is running.
-	Version string `json:"version"`
+	// Cluster contains cluster detail for this user's context
+	Cluster *Cluster `json:"cluster"`
 }
 
 func getLogins(roleSet services.RoleSet) []string {
@@ -140,6 +139,5 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 		Name:     user.GetName(),
 		ACL:      acl,
 		AuthType: authType,
-		Version:  teleport.Version,
 	}, nil
 }


### PR DESCRIPTION
resolves https://github.com/gravitational/teleport/issues/3480

### Description
- Change `GuessProxyHost` to `GuessProxyHostAndVersion`, to also return the selected proxy's version
- Add `ProxyVersion` to Cluster struct
- Add `Cluster` field in `userContext` struct for cluster detail to also be returned when getting user context info
- Separated getting/setting Cluster details for each cluster in `NewClusters` for reuse
- Unit test `GuessProxyHostAndVersion` and `GetClusterDetails`

### Manual Testing
**retrieving clusters:**
![Screenshot from 2020-04-03 16-47-11](https://user-images.githubusercontent.com/43280172/78413124-df64f300-75ca-11ea-8242-c449f3919696.png)

**retrieving user context:**
![Screenshot from 2020-04-03 16-47-28](https://user-images.githubusercontent.com/43280172/78413127-dffd8980-75ca-11ea-9a99-aa8f340d2fdc.png)

### Related PR
ui part of issue: https://github.com/gravitational/webapps/pull/63