### PR TITLE
Fix build error in examples/go-client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,12 +193,10 @@ run-docs:
 # tests everything: called by Jenkins
 #
 .PHONY: test
-test: FLAGS ?=
+test: FLAGS ?= '-race'
+test: PACKAGES := $(shell go list ./... | grep -v integration)
 test: $(VERSRC)
-	go test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" ./tool/tsh/... \
-			   ./lib/... \
-			   ./tool/teleport... $(FLAGS) $(ADDFLAGS)
-	go vet ./tool/... ./lib/...
+	go test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
 
 #
 # integration tests. need a TTY to work and not compatible with a race detector


### PR DESCRIPTION
The API of auth package changed in an incompatible way. Fix the usage.

Also, change the definition of `make test` to prevent this from happening.
Use `go list` to get the list of all packages instead of listing them manually.
Also, use the race detector with `go test` as a second pass, since it's not enabled by default.