### PR TITLE
Minor architecture docs tweaks

### DIFF
--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -1218,8 +1218,8 @@ session recording works. By default, the recording is not available if a cluster
 runs `sshd` (the OpenSSH daemon) on the nodes.
 
 To enable session recording for `sshd` nodes, the cluster must be switched to
-"recording proxy" mode. In this mode, the recording will be done on the proxy
-level:
+["recording proxy" mode](architecture/teleport_proxy.md#recording_proxy_mode).
+In this mode, the recording will be done on the proxy level:
 
 ``` yaml
 # snippet from /etc/teleport.yaml

--- a/docs/4.2/architecture/teleport_architecture_overview.md
+++ b/docs/4.2/architecture/teleport_architecture_overview.md
@@ -45,8 +45,8 @@ Here are definitions of the key concepts you will use in Teleport.
 | Certificate Authority (CA) | A Certificate Authority issues SSL certificates in the form of public/private keypairs.
 | [Teleport Node](teleport_nodes.md)    | A Teleport Node is a regular node that is running the Teleport Node service. Teleport Nodes can be accessed by authorized Teleport Users. A Teleport Node is always considered a member of a Teleport Cluster, even if it's a single-node cluster.
 | [Teleport User](teleport_users.md)    | A Teleport User represents someone who needs access to a Teleport Cluster. Users have stored usernames and passwords, and are mapped to OS users on each node. User data is stored locally or in an external store.
-| Teleport Cluster | A Teleport Cluster is comprised of one or more nodes, each of which hold public keys signed by the same [Auth Server CA](teleport_auth.md). The CA cryptographically signs the public key of a node, establishing cluster membership.
-| [Teleport CA](teleport_auth.md) | Teleport operates two internal CAs as a function of the Auth service. One is used to sign User public keys and the other signs Node public keys. Each certificate is used to prove identity, cluster membership and manage access.
+| Teleport Cluster | A Teleport Cluster is comprised of one or more nodes, each of which hold certificates signed by the same [Auth Server CA](teleport_auth.md). The CA cryptographically signs the certificate of a node, establishing cluster membership.
+| [Teleport CA](teleport_auth.md) | Teleport operates two internal CAs as a function of the Auth service. One is used to sign User certificates and the other signs Node certificates. Each certificate is used to prove identity, cluster membership and manage access.
 
 ## Teleport Services
 
@@ -118,7 +118,7 @@ steps are explained in detail below the diagram.
 
 The client tries to establish an SSH connection to a proxy using the CLI
 interface or a web browser. When establishing a connection, the client offers
-its public key. Clients must always connect through a proxy for two reasons:
+its certificate. Clients must always connect through a proxy for two reasons:
 
 1. Individual nodes may not always be reachable from outside a secure network.
 2. Proxies always record SSH sessions and keep track of active user sessions.
@@ -135,9 +135,9 @@ auth server.
 
 ![Client obtains new certificate](../img/cert_invalid.svg)
 
-If there was no key previously offered (first time login) or if the certificate
-has expired, the proxy denies the connection and asks the client to login
-interactively using a password and a 2nd factor if enabled.
+If there was no certificate previously offered (first time login) or if the
+certificate has expired, the proxy denies the connection and asks the client to
+login interactively using a password and a 2nd factor if enabled.
 
 Teleport supports
 [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en),
@@ -152,8 +152,8 @@ proper HTTPS certificate on a proxy.
     Do not use self-signed SSL/HTTPS certificates in production!
 
 If the credentials are correct, the auth server generates and signs a new
-certificate and returns it to the client via the proxy. The client stores this key
-and will use it for subsequent logins. The key will automatically expire after
+certificate and returns it to the client via the proxy. The client stores this certificate
+and will use it for subsequent logins. The certificate will automatically expire after
 12 hours by default. This [TTL](https://en.wikipedia.org/wiki/Time_to_live) can be [configured](../cli-docs.md#tctl-users-add)
 to another value by the cluster administrator.
 
@@ -185,8 +185,7 @@ sending the session history to the auth server to be stored.
 ![Node Membership Authentication](../img/node_cluster_auth.svg)
 
 When the node receives a connection request, it checks with the Auth Server to
-validate the node's public key certificate and validate the Node's cluster
-membership.
+validate the node's certificate and validate the Node's cluster membership.
 
 If the node certificate is valid, the node is allowed to access the Auth Server
 API which provides access to information about nodes and users in the cluster.
@@ -219,11 +218,11 @@ $ tsh --proxy=p scp -P example.txt user@host/destination/dir
 ```
 
 Unlike `ssh`, `tsh` is very opinionated about authentication: it always uses
-auto-expiring keys and it always connects to Teleport nodes via a proxy.
+auto-expiring certificates and it always connects to Teleport nodes via a proxy.
 
-When `tsh` logs in, the auto-expiring key is stored in `~/.tsh` and is valid for
-12 hours by default, unless you specify another interval via the `--ttl` flag
-(capped by the server-side configuration).
+When `tsh` logs in, the auto-expiring certificate is stored in `~/.tsh` and is
+valid for 12 hours by default, unless you specify another interval via the
+`--ttl` flag (capped by the server-side configuration).
 
 You can learn more about `tsh` in the [User Manual](../user-manual.md).
 

--- a/docs/4.2/architecture/teleport_auth.md
+++ b/docs/4.2/architecture/teleport_auth.md
@@ -199,9 +199,11 @@ events and submits them to the auth server. The events recorded include:
 
 !!! warning "Compatibility Warning"
 
-    Because all SSH events like `exec` or `session_start` are reported by the
-    Teleport node service, they will not be logged if you are using OpenSSH
-    `sshd` daemon on your nodes.
+    Because all SSH events like `exec` or `session_start` are by default
+    reported by the Teleport node service, they will not be logged if you are
+    using OpenSSH `sshd` daemon on your nodes. [Recording proxy
+    mode](teleport_proxy.md#recording_proxy_mode) can be used to log audit
+    events when using OpenSSH on your nodes.
 
 Only an SSH server can report what's happening to the Teleport auth server.
 The audit log is a JSON file which is by default stored on the auth server's
@@ -217,41 +219,6 @@ storage.
     to service the same cluster (HA mode) a network file system must be used for
     `/var/lib/teleport/log` to allow them to combine all audit events into the
     same audit log. [Learn how to deploy Teleport in HA Mode.](../admin-guide.md#high-availability))
-
-## Recording Proxy Mode
-
-In this mode, the proxy terminates (decrypts) the SSH connection using the
-certificate supplied by the client via SSH agent forwarding and then establishes
-its own SSH connection to the final destination server, effectively becoming an
-authorized "man in the middle". This allows the proxy server to forward SSH
-session data to the auth server to be recorded, as shown below:
-
-![recording-proxy](../img/recording-proxy.svg)
-
-The recording proxy mode, although _less secure_, was added to allow Teleport
-users to enable session recording for OpenSSH's servers running `sshd`, which is
-helpful when gradually transitioning large server fleets to Teleport.
-
-We consider the "recording proxy mode" to be less secure for two reasons:
-
-1. It grants additional privileges to the Teleport proxy. In the default mode,
-   the proxy stores no secrets and cannot "see" the decrypted data. This makes a
-   proxy less critical to the security of the overall cluster. But if an
-   attacker gains physical access to a proxy node running in the "recording"
-   mode, they will be able to see the decrypted traffic and client keys stored
-   in proxy's process memory.
-2. Recording proxy mode requires the SSH agent forwarding. Agent forwarding is
-   required because without it, a proxy will not be able to establish the 2nd
-   connection to the destination node.
-
-However, there are advantages of proxy-based session recording too. When
-sessions are recorded at the nodes, a root user can add iptables rules to
-prevent sessions logs from reaching the Auth Server. With sessions recorded at
-the proxy, users with root privileges on nodes have no way of disabling the
-audit.
-
-See the [admin guide](../admin-guide.md#recorded-sessions) to learn how to turn on the
-recording proxy mode.
 
 ## Storage Back-Ends
 

--- a/docs/4.2/architecture/teleport_nodes.md
+++ b/docs/4.2/architecture/teleport_nodes.md
@@ -52,7 +52,7 @@ This certificate contains information about the node including:
 * The node **role** (i.e. `node,proxy`) encoded as a certificate extension
 * The cert **TTL** (time-to-live)
 
-A Teleport Cluster is a set of one or more machines whose public keys are signed
+A Teleport Cluster is a set of one or more machines whose certificates are signed
 by the same certificate authority (CA) operating in the Auth Server. A
 certificate is issued to a node when it joins the cluster for the first time.
 Learn more about this process in the [Auth
@@ -99,10 +99,10 @@ By default, nodes submit SSH session traffic to the Auth server
 for storage. These recorded sessions can be replayed later via `tsh play`
 command or in a web browser.
 
-Some Teleport users mistakenly believe that audit and session recording happen
-by default on the Teleport proxy server. This is not the case because a proxy
-cannot see the encrypted traffic, it is encrypted end-to-end, i.e. from an SSH
-client to an SSH server/node, see the diagram below:
+Some Teleport users assume that audit and session recording happen by default
+on the Teleport proxy server. This is not the case in default configuration
+because a proxy cannot see the encrypted traffic, it is encrypted end-to-end,
+i.e. from an SSH client to an SSH server/node, see the diagram below:
 
 ![session-recording-diagram](../img/session-recording.svg)
 
@@ -112,9 +112,8 @@ Teleport proxy to enable "recording proxy mode".
 ## Trusted Clusters
 
 Teleport Auth Service can allow 3rd party users or nodes to connect to cluster
-nodes if their public keys are signed by a trusted CA. A "trusted cluster" is a
-pair of public keys of the trusted CA. It can be configured via `teleport.yaml`
-file.
+nodes if their certificates are signed by a trusted CA. A "trusted cluster" is
+a public key of the trusted CA. It can be configured via `teleport.yaml` file.
 
 <!--TODO: incomplete, write more on this-->
 

--- a/docs/4.2/architecture/teleport_proxy.md
+++ b/docs/4.2/architecture/teleport_proxy.md
@@ -101,6 +101,8 @@ its own SSH connection to the final destination server, effectively becoming an
 authorized "man in the middle". This allows the proxy server to forward SSH
 session data to the auth server to be recorded, as shown below:
 
+![recording-proxy](../img/recording-proxy.svg)
+
 The recording proxy mode, although _less secure_, was added to allow Teleport
 users to enable session recording for OpenSSH's servers running `sshd`, which is
 helpful when gradually transitioning large server fleets to Teleport.
@@ -123,8 +125,9 @@ prevent sessions logs from reaching the Auth Server. With sessions recorded at
 the proxy, users with root privileges on nodes have no way of disabling the
 audit.
 
-See the [admin guide](../admin-guide.md#recorded-sessions) to learn how to turn on
-the recording proxy mode.
+See the [admin guide](../admin-guide.md#recorded-sessions) to learn how to turn
+on the recording proxy mode. Note that the recording more is configured on the
+Auth Server.
 
 ## More Concepts
 

--- a/docs/4.2/architecture/teleport_users.md
+++ b/docs/4.2/architecture/teleport_users.md
@@ -63,7 +63,7 @@ is present on all nodes.
 joe | root, joe | grav-00, grav-01, grav-02
 tara | tara | grav-01, grav-02
 teleport | teleport  | grav-00, grav-02
-sandra | ops | grav-00, grav-02
+sandra | ops | grav-00, grav-01
 
 Teleport supports second factor authentication (2FA) when using a local auth
 connector and it is enforced by default.

--- a/docs/4.2/enterprise/index.md
+++ b/docs/4.2/enterprise/index.md
@@ -20,7 +20,7 @@ The table below gives a quick overview of the benefits of Teleport Enterprise.
 
 ## RBAC
 
-Role Based Access Control ("RBAC") allows Teleport administrators to grant granular access permissions to users. An example of an RBAC policy might be:  _"admins can do anything, 
+Role Based Access Control ("RBAC") allows Teleport administrators to grant granular access permissions to users. An example of an RBAC policy might be:  "admins can do anything,
 developers must never touch production servers, and interns can only SSH into
 staging servers as guests".
 
@@ -135,7 +135,7 @@ spec:
 ```
 
 **DBA Role**
-This role lets the contractor request the role DBA. 
+This role limits the contractor to request the role DBA for 1hr.
 
 ```yaml
 kind: role

--- a/docs/4.2/img/user_mappings.svg
+++ b/docs/4.2/img/user_mappings.svg
@@ -79,7 +79,7 @@
         </text>
         <rect id="Rectangle" fill="#FFFFFF" x="312" y="369" width="188" height="18"></rect>
         <text id="root,tara,teleport," font-family="LucidaGrande, Lucida Grande" font-size="13" font-weight="normal" fill="#4A4A4A">
-            <tspan x="318.922607" y="383">root,tara,teleport, sandra</tspan>
+            <tspan x="344.495361" y="383">root,tara,teleport</tspan>
         </text>
         <g id="Shadow-Box" transform="translate(4.000000, 110.000000)">
             <g>


### PR DESCRIPTION
- consistently use "certificate" instead of "public key"
- make diagram in "local users" section match the text (user "sandra"
  doesn't have access to "grav-02")
- de-duplicate docs on session streaming between auth and proxy pages