### PR TITLE
Add make rules for linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,22 @@ integration:
 	@echo KUBECONFIG is: $(KUBECONFIG), TEST_KUBE: $(TEST_KUBE)
 	go test -v -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" ./integration/...
 
+#
+# Lint the Go code.
+# By default lint scans the entire repo. Pass FLAGS='--new' to only scan local
+# changes (or last commit).
+#
+.PHONY: lint
+lint: FLAGS ?=
+lint:
+	golangci-lint run \
+		--disable-all \
+		--exclude-use-default \
+		--skip-dirs vendor \
+		--max-issues-per-linter 0 \
+		--enable unused \
+		$(FLAGS)
+
 # This rule triggers re-generation of version.go and gitref.go if Makefile changes
 $(VERSRC): Makefile
 	VERSION=$(VERSION) $(MAKE) -f version.mk setver

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -69,7 +69,7 @@ bbox-fips:
 		--tag $(BBOXFIPS) -f Dockerfile-fips .
 
 #
-# Builds a Docker container for CentOS 6 builds 
+# Builds a Docker container for CentOS 6 builds
 #
 .PHONY:bbox-centos6
 bbox-centos6:
@@ -124,6 +124,14 @@ test: bbox
 integration: bbox
 	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
 		/bin/bash -c "make -C $(SRCDIR) FLAGS='-cover' integration"
+
+#
+# Runs linters on new changes inside a build container.
+#
+.PHONY:lint
+lint: bbox
+	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
+		/bin/bash -c "make -C $(SRCDIR) lint"
 
 #
 # Builds docs

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -1441,12 +1441,3 @@ func fatalIf(err error) {
 		log.Fatalf("%v at %v", string(debug.Stack()), err)
 	}
 }
-
-func makeKey() (priv, pub []byte) {
-	k, err := native.New(context.TODO(), native.PrecomputeKeys(0))
-	if err != nil {
-		panic(err)
-	}
-	priv, pub, _ = k.GenerateKeyPair("")
-	return priv, pub
-}

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -48,7 +48,7 @@ import (
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/check.v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -1167,8 +1167,6 @@ func kubeProxyClient(cfg kubeProxyConfig) (*kubernetes.Clientset, *rest.Config, 
 }
 
 const (
-	testTimeout = 1 * time.Minute
-
 	testNamespace = "teletest"
 )
 
@@ -1189,10 +1187,6 @@ type kubeExecArgs struct {
 	stderr       io.Writer
 	stdin        io.Reader
 	tty          bool
-}
-
-func toBoolString(val bool) string {
-	return fmt.Sprintf("%t", val)
 }
 
 type kubePortForwardArgs struct {

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -41,7 +41,6 @@ type UserCommand struct {
 	allowedLogins string
 	kubeGroups    string
 	roles         string
-	identities    []string
 	ttl           time.Duration
 
 	// format is the output format, e.g. text or json

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -18,11 +18,8 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -37,7 +34,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -1100,104 +1096,6 @@ func refuseArgs(command string, args []string) {
 		}
 
 	}
-}
-
-// loadIdentity loads the private key + certificate from a file
-// Returns:
-//	 - client key: user's private key+cert
-//   - host auth callback: function to validate the host (may be null)
-//   - error, if somthing happens when reading the identityf file
-//
-// If the "host auth callback" is not returned, user will be prompted to
-// trust the proxy server.
-func loadIdentity(idFn string) (*client.Key, ssh.HostKeyCallback, error) {
-	log.Infof("Reading identity file: %v", idFn)
-
-	f, err := os.Open(idFn)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	defer f.Close()
-	ident, err := client.DecodeIdentityFile(f)
-	if err != nil {
-		return nil, nil, trace.Wrap(err, "failed to parse identity file")
-	}
-	// did not find the certificate in the file? look in a separate file with
-	// -cert.pub prefix
-	if len(ident.Certs.SSH) == 0 {
-		certFn := idFn + "-cert.pub"
-		log.Infof("Certificate not found in %s. Looking in %s.", idFn, certFn)
-		ident.Certs.SSH, err = ioutil.ReadFile(certFn)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-	}
-	// validate both by parsing them:
-	privKey, err := ssh.ParseRawPrivateKey(ident.PrivateKey)
-	if err != nil {
-		return nil, nil, trace.BadParameter("invalid identity: %s. %v", idFn, err)
-	}
-	signer, err := ssh.NewSignerFromKey(privKey)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	// validate TLS Cert (if present):
-	if len(ident.Certs.TLS) > 0 {
-		_, err := tls.X509KeyPair(ident.Certs.TLS, ident.PrivateKey)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-	}
-	// Validate TLS CA certs (if present).
-	var trustedCA []auth.TrustedCerts
-	if len(ident.CACerts.TLS) > 0 {
-		var trustedCerts auth.TrustedCerts
-		pool := x509.NewCertPool()
-		for i, certPEM := range ident.CACerts.TLS {
-			if !pool.AppendCertsFromPEM(certPEM) {
-				return nil, nil, trace.BadParameter("identity file contains invalid TLS CA cert (#%v)", i+1)
-			}
-			trustedCerts.TLSCertificates = append(trustedCerts.TLSCertificates, certPEM)
-		}
-		trustedCA = []auth.TrustedCerts{trustedCerts}
-	}
-	var hostAuthFunc ssh.HostKeyCallback = nil
-	// validate CA (cluster) cert
-	if len(ident.CACerts.SSH) > 0 {
-		var trustedKeys []ssh.PublicKey
-		for _, caCert := range ident.CACerts.SSH {
-			_, _, publicKey, _, _, err := ssh.ParseKnownHosts(caCert)
-			if err != nil {
-				return nil, nil, trace.BadParameter("CA cert parsing error: %v. cert line :%v",
-					err.Error(), string(caCert))
-			}
-			trustedKeys = append(trustedKeys, publicKey)
-		}
-
-		// found CA cert in the indentity file? construct the host key checking function
-		// and return it:
-		hostAuthFunc = func(host string, a net.Addr, hostKey ssh.PublicKey) error {
-			clusterCert, ok := hostKey.(*ssh.Certificate)
-			if ok {
-				hostKey = clusterCert.SignatureKey
-			}
-			for _, trustedKey := range trustedKeys {
-				if sshutils.KeysEqual(trustedKey, hostKey) {
-					return nil
-				}
-			}
-			err = trace.AccessDenied("host %v is untrusted", host)
-			log.Error(err)
-			return err
-		}
-	}
-	return &client.Key{
-		Priv:      ident.PrivateKey,
-		Pub:       signer.PublicKey().Marshal(),
-		Cert:      ident.Certs.SSH,
-		TLSCert:   ident.Certs.TLS,
-		TrustedCA: trustedCA,
-	}, hostAuthFunc, nil
 }
 
 // authFromIdentity returns a standard ssh.Authmethod for a given identity file


### PR DESCRIPTION
Top-level `make lint` rule that scans everything and a CI-specific rule
for Jenkins.
Currently only enable "unused", since it's reliable. The list will
expand.

Also clean up stragglers that somehow slipped through in #3552.

Updates #3551