### PR TITLE
Enable linters: deadcode,goimports,govet,typecheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ TELEPORT_DEBUG ?= no
 GITTAG=v$(VERSION)
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
 CGOFLAG ?= CGO_ENABLED=1
+GO_LINTERS ?= "unused,govet,typecheck,deadcode,goimports"
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
@@ -219,8 +220,10 @@ lint:
 		--disable-all \
 		--exclude-use-default \
 		--skip-dirs vendor \
+		--uniq-by-line=false \
+		--max-same-issues=0 \
 		--max-issues-per-linter 0 \
-		--enable unused \
+		--enable $(GO_LINTERS) \
 		$(FLAGS)
 
 # This rule triggers re-generation of version.go and gitref.go if Makefile changes

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -26,7 +26,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
@@ -57,7 +56,6 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
-	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
@@ -1416,24 +1414,6 @@ func closeAgent(teleAgent *teleagent.AgentServer, socketDirPath string) error {
 	}
 
 	return nil
-}
-
-// createWebClient builds a *client.WebClient that is used to simulate
-// browser requests.
-func createWebClient(cluster *TeleInstance, opts ...roundtrip.ClientParam) (*client.WebClient, error) {
-	// Craft URL to Web UI.
-	u := &url.URL{
-		Scheme: "https",
-		Host:   cluster.Config.Proxy.WebAddr.Addr,
-	}
-
-	opts = append(opts, roundtrip.HTTPClient(client.NewInsecureWebClient()))
-	wc, err := client.NewWebClient(u.String(), opts...)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return wc, nil
 }
 
 func fatalIf(err error) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1091,7 +1091,7 @@ func (a *AuthWithRoles) CreateResetPasswordToken(ctx context.Context, req Create
 	a.EmitAuditEvent(events.ResetPasswordTokenCreated, events.EventFields{
 		events.ResetPasswordTokenFor: req.Name,
 		events.ResetPasswordTokenTTL: req.TTL.String(),
-		events.EventUser:    a.user.GetName(),
+		events.EventUser:             a.user.GetName(),
 	})
 
 	return a.authServer.CreateResetPasswordToken(ctx, req)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"testing"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -34,7 +35,6 @@ import (
 
 	"github.com/gravitational/trace"
 	. "gopkg.in/check.v1"
-	"testing"
 )
 
 type AuthInitSuite struct {

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -310,12 +310,6 @@ func (k *Keygen) GenerateUserCert(c services.UserCertParams) ([]byte, error) {
 	return ssh.MarshalAuthorizedKey(cert), nil
 }
 
-const (
-	principalLocalhost  = "localhost"
-	principalLoopbackV4 = "127.0.0.1"
-	principalLoopbackV6 = "::1"
-)
-
 // BuildPrincipals takes a hostID, nodeName, clusterName, and role and builds a list of
 // principals to insert into a certificate. This function is backward compatible with
 // older clients which means:

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -968,7 +968,6 @@ const (
 	extCertType     = "certtype@teleport"
 	extAuthority    = "auth@teleport"
 	extCertTypeHost = "host"
-	extCertTypeUser = "user"
 	extCertRole     = "role"
 
 	versionRequest = "x-teleport-version"

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -145,6 +145,7 @@ func NewSupervisor(id string) Supervisor {
 	reloadContext, signalReload := context.WithCancel(context.TODO())
 
 	srv := &LocalSupervisor{
+		state:        stateCreated,
 		id:           id,
 		services:     []Service{},
 		wg:           &sync.WaitGroup{},

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -19,6 +19,7 @@ package local
 import (
 	"context"
 	"fmt"
+	"testing"
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
@@ -28,7 +29,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"gopkg.in/check.v1"
-	"testing"
 )
 
 type PresenceSuite struct {

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1426,6 +1426,7 @@ skiploop:
 	}
 
 	for _, tc := range testCases {
+		c.Logf("test case %q", tc.name)
 		resource := tc.crud()
 
 		ExpectResource(c, w, 3*time.Second, resource)

--- a/lib/sshutils/signer.go
+++ b/lib/sshutils/signer.go
@@ -18,6 +18,7 @@ package sshutils
 
 import (
 	"crypto"
+
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/trace"

--- a/lib/tlsca/parsegen.go
+++ b/lib/tlsca/parsegen.go
@@ -71,8 +71,8 @@ func GenerateSelfSignedCAWithPrivateKey(priv *rsa.PrivateKey, entity pkix.Name, 
 		NotAfter:              notAfter,
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
-		IsCA:     true,
-		DNSNames: dnsNames,
+		IsCA:                  true,
+		DNSNames:              dnsNames,
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)

--- a/lib/utils/jsontools.go
+++ b/lib/utils/jsontools.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/ghodss/yaml"
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 

--- a/lib/web/ui/cluster.go
+++ b/lib/web/ui/cluster.go
@@ -46,6 +46,7 @@ type Cluster struct {
 	ProxyVersion string `json:"proxyVersion"`
 }
 
+//nolint:unused,deadcode
 var log = logrus.WithFields(logrus.Fields{
 	trace.Component: teleport.ComponentProxy,
 })

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -97,7 +97,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *service.
 
 	rc.getCmd = app.Command("get", "Print a YAML declaration of various Teleport resources")
 	rc.getCmd.Arg("resources", "Resource spec: 'type/[name][,...]' or 'all'").Required().SetValue(&rc.refs)
-	rc.getCmd.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(formatYAML).StringVar(&rc.format)
+	rc.getCmd.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&rc.format)
 	rc.getCmd.Flag("namespace", "Namespace of the resources").Hidden().Default(defaults.Namespace).StringVar(&rc.namespace)
 	rc.getCmd.Flag("with-secrets", "Include secrets in resources like certificate authorities or OIDC connectors").Default("false").BoolVar(&rc.withSecrets)
 
@@ -162,7 +162,7 @@ func (rc *ResourceCommand) Get(client auth.ClientI) error {
 }
 
 func (rc *ResourceCommand) GetMany(client auth.ClientI) error {
-	if rc.format != formatYAML {
+	if rc.format != teleport.YAML {
 		return trace.BadParameter("mixed resource types only support YAML formatting")
 	}
 	var resources []services.Resource
@@ -532,12 +532,6 @@ func (rc *ResourceCommand) getCollection(client auth.ClientI) (c ResourceCollect
 	}
 	return nil, trace.BadParameter("'%v' is not supported", rc.ref.Kind)
 }
-
-const (
-	formatYAML = "yaml"
-	formatText = "text"
-	formatJSON = "json"
-)
 
 // UpsertVerb generates the correct string form of a verb based on the action taken
 func UpsertVerb(exists bool, force bool) string {


### PR DESCRIPTION
And fix the relevant findings for these linters.

Also, set extra flags for `golangci-lint run` to make sure no findings
are suppressed.

Updates #3551