### PR TITLE
Add add and set new attr to Sessions

### DIFF
--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -97,8 +97,12 @@ type Session struct {
 	// LastActive holds the information about when the session
 	// was last active
 	LastActive time.Time `json:"last_active"`
-	// ServerID
+	// ServerID of session
 	ServerID string `json:"server_id"`
+	// ServerHostname of session
+	ServerHostname string `json:"server_hostname"`
+	// ServerAddr of session
+	ServerAddr string `json:"server_addr"`
 }
 
 // RemoveParty helper allows to remove a party by it's ID from the

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -486,12 +486,15 @@ func newSession(id rsession.ID, r *SessionRegistry, ctx *ServerContext) (*sessio
 			W: teleport.DefaultTerminalWidth,
 			H: teleport.DefaultTerminalHeight,
 		},
-		Login:      ctx.Identity.Login,
-		Created:    time.Now().UTC(),
-		LastActive: time.Now().UTC(),
-		ServerID:   ctx.srv.ID(),
-		Namespace:  r.srv.GetNamespace(),
+		Login:          ctx.Identity.Login,
+		Created:        time.Now().UTC(),
+		LastActive:     time.Now().UTC(),
+		ServerID:       ctx.srv.ID(),
+		Namespace:      r.srv.GetNamespace(),
+		ServerHostname: ctx.srv.GetInfo().GetHostname(),
+		ServerAddr:     ctx.srv.GetInfo().GetAddr(),
 	}
+
 	term := ctx.GetTerm()
 	if term != nil {
 		winsize, err := term.GetWinSize()


### PR DESCRIPTION
resolves https://github.com/gravitational/teleport/issues/3543

#### Description
- Add two new fields to Session struct: `ServerHostname` and `ServerAddr`
- Set these fields for newSession

#### Manual Testing
addr and hostname of a session is missing b/c its using a older version of teleport:
![Screenshot from 2020-04-13 21-50-01](https://user-images.githubusercontent.com/43280172/79187711-e4e3e980-7dd1-11ea-9210-3a3c6ec4fbb5.png)
