### PR TITLE
Add local aliases to default host cert principals

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -636,3 +636,18 @@ const (
 
 // RSAKeySize is the size of the RSA key.
 const RSAKeySize = 2048
+
+// A principal name for use in SSH certificates.
+type Principal string
+
+const (
+	// The localhost domain, for talking to a proxy or node on the same
+	// machine.
+	PrincipalLocalhost Principal = "localhost"
+	// The IPv4 loopback address, for talking to a proxy or node on the same
+	// machine.
+	PrincipalLoopbackV4 Principal = "127.0.0.1"
+	// The IPv6 loopback address, for talking to a proxy or node on the same
+	// machine.
+	PrincipalLoopbackV6 Principal = "::1"
+)

--- a/docs/4.2/quickstart.md
+++ b/docs/4.2/quickstart.md
@@ -177,16 +177,12 @@ accessible IP.
     `--insecure` flag which allows us to skip configuring the HTTP/TLS
     certificate for Teleport proxy.
 
-    **Caution**: the `--insecure` flag does **not** skip TLS validation for the Auth Server. The self-signed Auth Server certificate expects to be accessed via one of a set of hostnames (ex. `grav-00` ). If you attempt to access via `localhost` you will probably get this error: `principal "localhost" not in the set of valid principals for given certificate` .
-
-    To resolve this error find your hostname with the `hostname` command and use that instead of `localhost` .
-
     Never use `--insecure` in production unless you terminate SSL at a load balancer. You must configure a HTTP/TLS certificate for the Proxy. [Learn more in our SSL/TLS for Teleport Proxy - Production Guide](production.md#ssltls-for-teleport-proxy)
 
 
 ``` bash
 # here grav-00 is a resolvable hostname on the same network
-# --proxy can be an IP, hostname, or URL
+# --proxy can be an IP, hostname, or URL; you can also use "localhost" for this quickstart
 # --user (not shown) by default, is implicitly set to your last login, or primary OS username
 # if your primary OS user isn't teleport, you need to explicitly set by including: --user=teleport
 [teleport@grav-00 ~]$ tsh --proxy=grav-00 --insecure login

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -310,6 +310,12 @@ func (k *Keygen) GenerateUserCert(c services.UserCertParams) ([]byte, error) {
 	return ssh.MarshalAuthorizedKey(cert), nil
 }
 
+const (
+	principalLocalhost  = "localhost"
+	principalLoopbackV4 = "127.0.0.1"
+	principalLoopbackV6 = "::1"
+)
+
 // BuildPrincipals takes a hostID, nodeName, clusterName, and role and builds a list of
 // principals to insert into a certificate. This function is backward compatible with
 // older clients which means:
@@ -338,6 +344,15 @@ func BuildPrincipals(hostID string, nodeName string, clusterName string, roles t
 		principals = append(principals, fmt.Sprintf("%s.%s", nodeName, clusterName))
 		principals = append(principals, nodeName)
 	}
+
+	// Add localhost and loopback addresses to allow connecting to proxy/host
+	// on the local machine. This should only matter for quickstart and local
+	// development.
+	principals = append(principals,
+		string(teleport.PrincipalLocalhost),
+		string(teleport.PrincipalLoopbackV4),
+		string(teleport.PrincipalLoopbackV6),
+	)
 
 	// deduplicate (in-case hostID and nodeName are the same) and return
 	return utils.Deduplicate(principals)


### PR DESCRIPTION
Adding following principals:
- `localhost`
- `127.0.0.1`
- `::1`

With these, `tsh` (both `ssh` and `join`) works with a local proxy
without any SSH handshake errors.

Removed the warning from quickstart docs, but keeping `--proxy=grav-00`
since that implies to the reader that proxy is usually remote.

Fixes #2910