### PR TITLE
Correct FIPS binary question

### DIFF
--- a/docs/4.2/enterprise/ssh_fips.md
+++ b/docs/4.2/enterprise/ssh_fips.md
@@ -145,5 +145,5 @@ is emitted to the Audit Log.
 ## What else does the Teleport FIPS binary enforce? 
 * Supporting configurable TLS versions. This is to ensure that only TLS 1.2 is supported in FedRAMP mode.
 * Removes all uses of non-compliant algorithms like NaCl and replace with compliant algorithms like AES-GCM.
-* Teleport is complied  with [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/2964)
+* Teleport is compiled  with [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/Certificate/2964)
 * User, host and CA certificates (and host keys for recording proxy mode) should only use 2048-bit RSA private keys.


### PR DESCRIPTION
"Complied" was used instead of "compiled" for the BoringCrypto reference.