### PR TITLE
Add `internal.logins` to `kubernetes_users` on admin role

### DIFF
--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -35,6 +35,8 @@ type Modules interface {
 	EmptyRolesHandler() error
 	// DefaultAllowedLogins returns default allowed logins for a new admin role
 	DefaultAllowedLogins() []string
+	// DefaultKubeUsers returns default kuberentes users for a new admin role
+	DefaultKubeUsers() []string
 	// DefaultKubeGroups returns default kuberentes groups for a new admin role
 	DefaultKubeGroups() []string
 	// PrintVersion prints teleport version
@@ -71,6 +73,11 @@ type defaultModules struct{}
 // is created, no-op by default
 func (p *defaultModules) EmptyRolesHandler() error {
 	return nil
+}
+
+// DefaultKubeUsers returns default kuberentes users for a new admin role
+func (p *defaultModules) DefaultKubeUsers() []string {
+	return []string{teleport.TraitInternalLoginsVariable}
 }
 
 // DefaultKubeGroups returns default kuberentes groups for a new admin role

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -41,6 +41,9 @@ func (s *ModulesSuite) TestDefaultModules(c *check.C) {
 	kubeGroups := GetModules().DefaultKubeGroups()
 	c.Assert(kubeGroups, check.DeepEquals, []string{teleport.TraitInternalKubeGroupsVariable})
 
+	kubeUsers := GetModules().DefaultKubeUsers()
+	c.Assert(kubeUsers, check.DeepEquals, []string{teleport.TraitInternalLoginsVariable})
+
 	roles := GetModules().RolesFromLogins([]string{"root"})
 	c.Assert(roles, check.DeepEquals, []string{teleport.AdminRoleName})
 
@@ -82,6 +85,10 @@ func (p *testModules) EmptyRolesHandler() error {
 
 func (p *testModules) DefaultAllowedLogins() []string {
 	return []string{"a", "b"}
+}
+
+func (p *testModules) DefaultKubeUsers() []string {
+	return []string{"c", "d"}
 }
 
 func (p *testModules) DefaultKubeGroups() []string {

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -111,6 +111,7 @@ func NewAdminRole() Role {
 		},
 	}
 	role.SetLogins(Allow, modules.GetModules().DefaultAllowedLogins())
+	role.SetKubeUsers(Allow, modules.GetModules().DefaultKubeUsers())
 	role.SetKubeGroups(Allow, modules.GetModules().DefaultKubeGroups())
 	return role
 }
@@ -2281,7 +2282,7 @@ const RoleSpecV3SchemaTemplate = `{
         "cert_format": { "type": "string" },
         "client_idle_timeout": { "type": "string" },
         "disconnect_expired_cert": { "type": ["boolean", "string"] },
-        "enhanced_recording": { 
+        "enhanced_recording": {
           "type": "array",
           "items": { "type": "string" }
         }


### PR DESCRIPTION
With OSS version and without using the github connector (only local
auth), logged in user won't have any `kubernetes_groups`. Without
usernames too, user can login but can't use kubectl.

Mimic regular SSH logins in the admin role by adding `internal.logins`
to `kubernetes_users`. This enables creation of RBAC rules for the login
username.

Relevant OSS changes in https://github.com/gravitational/teleport/tree/andrew/kube_users-in-admin-role