### PR TITLE
Extract error from u2f library when registering fails

### DIFF
--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -354,6 +354,8 @@ func (s *AuthServer) changeUserSecondFactor(req ChangePasswordWithTokenRequest, 
 		u2fRes := req.U2FRegisterResponse
 		reg, err := u2f.Register(u2fRes, *challenge, &u2f.Config{SkipAttestationVerify: true})
 		if err != nil {
+			// u2f is a 3rd party library and sends back a string based error
+			// Need to wrap its error with trace defined error to unmarshall error msg correctly
 			return trace.BadParameter(err.Error())
 		}
 

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -354,7 +354,7 @@ func (s *AuthServer) changeUserSecondFactor(req ChangePasswordWithTokenRequest, 
 		u2fRes := req.U2FRegisterResponse
 		reg, err := u2f.Register(u2fRes, *challenge, &u2f.Config{SkipAttestationVerify: true})
 		if err != nil {
-			return trace.AccessDenied(err.Error())
+			return trace.BadParameter(err.Error())
 		}
 
 		err = s.UpsertU2FRegistration(username, reg)

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -354,8 +354,8 @@ func (s *AuthServer) changeUserSecondFactor(req ChangePasswordWithTokenRequest, 
 		u2fRes := req.U2FRegisterResponse
 		reg, err := u2f.Register(u2fRes, *challenge, &u2f.Config{SkipAttestationVerify: true})
 		if err != nil {
-			// u2f is a 3rd party library and sends back a string based error
-			// Need to wrap its error with trace defined error to unmarshall error msg correctly
+			// U2F is a 3rd party library and sends back a string based error. Wrap this error with a
+			// trace.BadParameter error to allow the Web UI to unmarshal it correctly.
 			return trace.BadParameter(err.Error())
 		}
 

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -354,7 +354,7 @@ func (s *AuthServer) changeUserSecondFactor(req ChangePasswordWithTokenRequest, 
 		u2fRes := req.U2FRegisterResponse
 		reg, err := u2f.Register(u2fRes, *challenge, &u2f.Config{SkipAttestationVerify: true})
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.AccessDenied(err.Error())
 		}
 
 		err = s.UpsertU2FRegistration(username, reg)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -282,30 +282,6 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 			return
 		}
 
-		// check proxy and auth node versions (breaking change from v5).
-		// If there is a mismatch with the current proxy client, redirect users to an error page to update proxy.
-		//
-		// DELETE IN 5.0: this block only serves to notify users of v4.3+ to upgrade to v5.0.0
-		if strings.HasPrefix(r.URL.Path, "/web/newuser") {
-			res, err := h.auth.Ping(context.TODO())
-			if err != nil {
-				log.WithError(err).Debugf("Could not ping auth server")
-			} else {
-				isProxyV4x := strings.Index(teleport.Version, "4.") == 0
-				isAuthV5x := strings.Index(res.GetServerVersion(), "5.") == 0
-
-				if isAuthV5x && isProxyV4x {
-					message := fmt.Sprintf("Your Teleport proxy and auth service versions are incompatible. Please upgrade your Teleport proxy service to version %v", res.GetServerVersion())
-					pathToError := url.URL{
-						Path:     "/web/msg/error",
-						RawQuery: url.Values{"details": []string{message}}.Encode(),
-					}
-					http.Redirect(w, r, pathToError.String(), http.StatusFound)
-					return
-				}
-			}
-		}
-
 		// serve Web UI:
 		if strings.HasPrefix(r.URL.Path, "/web/app") {
 			httplib.SetStaticFileHeaders(w.Header())


### PR DESCRIPTION
part of issue https://github.com/gravitational/teleport/issues/3554

#### Description
- Fix how error message is being sent back when u2f fails to register
- Remove proxy/auth version mismatch check since hornet merged unto 4.3

#### Manual Testing
Before:
![Screenshot from 2020-04-16 09-36-48](https://user-images.githubusercontent.com/43280172/79482583-e413a900-7fc5-11ea-8e9d-24352a816b70.png)

After:
![Screenshot from 2020-04-15 19-46-25](https://user-images.githubusercontent.com/43280172/79409379-ab86b780-7f52-11ea-97b9-c6af3dcaca25.png)
