### PR TITLE
Emit node hostname as part of session.end event

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -297,6 +297,7 @@ func (s *SessionRegistry) leaveSession(party *party) error {
 			events.SessionInteractive:       true,
 			events.SessionEnhancedRecording: sess.hasEnhancedRecording,
 			events.SessionParticipants:      sess.exportParticipants(),
+			events.SessionServerHostname:    s.srv.GetInfo().GetHostname(),
 		}
 		sess.recorder.GetAuditLog().EmitAuditEvent(events.SessionEnd, eventFields)
 
@@ -863,6 +864,7 @@ func (s *session) startExec(channel ssh.Channel, ctx *ServerContext) error {
 			events.SessionParticipants: []string{
 				ctx.Identity.TeleportUser,
 			},
+			events.SessionServerHostname: ctx.srv.GetInfo().GetHostname(),
 		}
 		s.recorder.GetAuditLog().EmitAuditEvent(events.SessionEnd, eventFields)
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1006,6 +1006,16 @@ func (s *WebSuite) TestActiveSessions(c *C) {
 
 	c.Assert(len(sessResp.Sessions), Equals, 1)
 	c.Assert(sessResp.Sessions[0].ID, Equals, sid)
+	c.Assert(sessResp.Sessions[0].Namespace, Equals, s.node.GetNamespace())
+	c.Assert(sessResp.Sessions[0].Parties, NotNil)
+	c.Assert(sessResp.Sessions[0].TerminalParams.H > 0, Equals, true)
+	c.Assert(sessResp.Sessions[0].TerminalParams.W > 0, Equals, true)
+	c.Assert(sessResp.Sessions[0].Login, Equals, pack.login)
+	c.Assert(sessResp.Sessions[0].Created.IsZero(), Equals, false)
+	c.Assert(sessResp.Sessions[0].LastActive.IsZero(), Equals, false)
+	c.Assert(sessResp.Sessions[0].ServerID, Equals, s.srvID)
+	c.Assert(sessResp.Sessions[0].ServerHostname, Equals, s.node.GetInfo().GetHostname())
+	c.Assert(sessResp.Sessions[0].ServerAddr, Equals, s.node.GetInfo().GetAddr())
 }
 
 func (s *WebSuite) TestCloseConnectionsOnLogout(c *C) {


### PR DESCRIPTION
part of issue https://github.com/gravitational/teleport/issues/3537

#### Definition
- Add `server_hostname` to event fields

#### Manual Testing
![Screenshot from 2020-04-14 19-26-45](https://user-images.githubusercontent.com/43280172/79292559-45346300-7e86-11ea-90fe-d3c076311d5d.png)

#### Related PR
Display node hostname: https://github.com/gravitational/webapps/pull/75