### PR TITLE
Install pre-built golangci-lint binary for jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ lint:
 		--uniq-by-line=false \
 		--max-same-issues=0 \
 		--max-issues-per-linter 0 \
+		--timeout=5m \
 		--enable $(GO_LINTERS) \
 		$(FLAGS)
 

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -34,7 +34,9 @@ ENV GOPATH="/gopath" \
     PATH="$PATH:/opt/go/bin:/gopath/bin:/gopath/src/github.com/gravitational/teleport/build"
 
 # Install meta-linter.
-RUN go get github.com/golangci/golangci-lint/cmd/golangci-lint
+RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.24.0/golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz ;\
+     cp golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ ;\
+     rm -r golangci-lint*)
 
 VOLUME ["/gopath/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380


### PR DESCRIPTION
https://github.com/golangci/golangci-lint#go cautions against using go
get due to various problems. Downloading a binary also saves on
compilation time and image size.

Also, increase timeout to 5m, linting the repo can take a while on a
throttled CPU.

Updates #3551