### PR TITLE
Fix data races triggered by integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,12 +201,13 @@ test: $(VERSRC)
 	go test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
 
 #
-# integration tests. need a TTY to work and not compatible with a race detector
+# Integration tests. Need a TTY to work.
 #
 .PHONY: integration
+integration: FLAGS ?= -v -race
 integration:
 	@echo KUBECONFIG is: $(KUBECONFIG), TEST_KUBE: $(TEST_KUBE)
-	go test -v -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" ./integration/...
+	go test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" ./integration/... $(FLAGS)
 
 #
 # Lint the Go code.

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -239,7 +239,7 @@ func (s *KubeSuite) TestKubeExec(c *check.C) {
 		command:      []string{"/bin/sh"},
 		stdout:       out,
 		tty:          true,
-		stdin:        &term,
+		stdin:        term,
 	})
 	c.Assert(err, check.IsNil)
 
@@ -281,7 +281,7 @@ loop:
 		command:      []string{"/bin/sh"},
 		stdout:       out,
 		tty:          true,
-		stdin:        &term,
+		stdin:        term,
 	})
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Matches, ".*impersonation request has been denied.*")
@@ -298,7 +298,7 @@ loop:
 		command:      []string{"/bin/sh"},
 		stdout:       out,
 		tty:          true,
-		stdin:        &term,
+		stdin:        term,
 	})
 	c.Assert(err, check.IsNil)
 }
@@ -610,7 +610,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 		command:      []string{"/bin/sh"},
 		stdout:       out,
 		tty:          true,
-		stdin:        &term,
+		stdin:        term,
 	})
 	c.Assert(err, check.IsNil)
 
@@ -652,7 +652,7 @@ loop:
 		command:      []string{"/bin/sh"},
 		stdout:       out,
 		tty:          true,
-		stdin:        &term,
+		stdin:        term,
 	})
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Matches, ".*impersonation request has been denied.*")
@@ -871,7 +871,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 		command:      []string{"/bin/sh"},
 		stdout:       out,
 		tty:          true,
-		stdin:        &term,
+		stdin:        term,
 	})
 	c.Assert(err, check.IsNil)
 
@@ -913,7 +913,7 @@ loop:
 		command:      []string{"/bin/sh"},
 		stdout:       out,
 		tty:          true,
-		stdin:        &term,
+		stdin:        term,
 	})
 	c.Assert(err, check.NotNil)
 	c.Assert(err.Error(), check.Matches, ".*impersonation request has been denied.*")
@@ -1058,14 +1058,14 @@ func (s *KubeSuite) runKubeDisconnectTest(c *check.C, tc disconnectTestCase) {
 			podNamespace: pod.Namespace,
 			container:    kubeDNSContainer,
 			command:      []string{"/bin/sh"},
-			stdout:       &term,
+			stdout:       term,
 			tty:          true,
-			stdin:        &term,
+			stdin:        term,
 		})
 	}()
 
 	// lets type something followed by "enter" and then hang the session
-	enterInput(c, &term, "echo boring platapus\r\n", ".*boring platapus.*")
+	enterInput(c, term, "echo boring platapus\r\n", ".*boring platapus.*")
 	time.Sleep(tc.disconnectTimeout)
 	select {
 	case <-time.After(tc.disconnectTimeout):

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -313,9 +313,11 @@ func (m *AgentPool) addAgent(key agentKey, discoverProxies []services.Server) er
 func (m *AgentPool) Counts() map[string]int {
 	out := make(map[string]int)
 
-	for key, agents := range m.agents {
-		out[key.clusterName] += len(agents)
-	}
+	m.withLock(func() {
+		for key, agents := range m.agents {
+			out[key.clusterName] += len(agents)
+		}
+	})
 
 	return out
 }


### PR DESCRIPTION
Note to reviewers: review individual commits, each one fixes one data race.

Fixed races:
- `integration.Terminal`
- `reversetunnel.AgentPool`
- `utils.SyncBuffer`

Also enable the race detector on `make integration` by default.
These don't seem to help with integration test failure rates, but still good to eliminate unpredictable bugs.