### PR TITLE
Extract identityfile formatting/parsing into a separate package

### DIFF
--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package client
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/gravitational/teleport/lib/sshutils"
@@ -76,37 +75,4 @@ func (s *ClientTestSuite) TestNewSession(c *check.C) {
 	c.Assert(ses.env, check.DeepEquals, env)
 	// the session ID must be taken from tne environ map, if passed:
 	c.Assert(string(ses.id), check.Equals, "session-id")
-}
-
-func (s *ClientTestSuite) TestIdentityFileMaking(c *check.C) {
-	keyFilePath := c.MkDir() + "openssh"
-
-	var key Key
-	key.Cert = []byte("cert")
-	key.Priv = []byte("priv")
-	key.Pub = []byte("pub")
-
-	// test OpenSSH-compatible identity file creation:
-	_, err := MakeIdentityFile(keyFilePath, &key, IdentityFormatOpenSSH, nil)
-	c.Assert(err, check.IsNil)
-
-	// key is OK:
-	out, err := ioutil.ReadFile(keyFilePath)
-	c.Assert(err, check.IsNil)
-	c.Assert(string(out), check.Equals, "priv")
-
-	// cert is OK:
-	out, err = ioutil.ReadFile(keyFilePath + "-cert.pub")
-	c.Assert(err, check.IsNil)
-	c.Assert(string(out), check.Equals, "cert")
-
-	// test standard Teleport identity file creation:
-	keyFilePath = c.MkDir() + "file"
-	_, err = MakeIdentityFile(keyFilePath, &key, IdentityFormatFile, nil)
-	c.Assert(err, check.IsNil)
-
-	// key+cert are OK:
-	out, err = ioutil.ReadFile(keyFilePath)
-	c.Assert(err, check.IsNil)
-	c.Assert(string(out), check.Equals, "privcert")
 }

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -87,7 +87,7 @@ func (s *ClientTestSuite) TestIdentityFileMaking(c *check.C) {
 	key.Pub = []byte("pub")
 
 	// test OpenSSH-compatible identity file creation:
-	err := MakeIdentityFile(keyFilePath, &key, IdentityFormatOpenSSH, nil)
+	_, err := MakeIdentityFile(keyFilePath, &key, IdentityFormatOpenSSH, nil)
 	c.Assert(err, check.IsNil)
 
 	// key is OK:
@@ -102,7 +102,7 @@ func (s *ClientTestSuite) TestIdentityFileMaking(c *check.C) {
 
 	// test standard Teleport identity file creation:
 	keyFilePath = c.MkDir() + "file"
-	err = MakeIdentityFile(keyFilePath, &key, IdentityFormatFile, nil)
+	_, err = MakeIdentityFile(keyFilePath, &key, IdentityFormatFile, nil)
 	c.Assert(err, check.IsNil)
 
 	// key+cert are OK:

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Gravitational, Inc.
+Copyright 2020 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package client
+// Package identityfile handles formatting and parsing of identity files.
+package identityfile
 
 import (
 	"bufio"
@@ -23,52 +24,38 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 
 	"github.com/gravitational/trace"
 )
 
-// NewKey generates a new unsigned key. Such key must be signed by a
-// Teleport CA (auth server) before it becomes useful.
-func NewKey() (key *Key, err error) {
-	priv, pub, err := native.GenerateKeyPair("")
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &Key{
-		Priv: priv,
-		Pub:  pub,
-	}, nil
-}
-
-// IdentityFileFormat describes possible file formats how a user identity can be sotred
-type IdentityFileFormat string
+// Format describes possible file formats how a user identity can be stored.
+type Format string
 
 const (
-	// IdentityFormatFile is when a key + cert are stored concatenated into a single file
-	IdentityFormatFile IdentityFileFormat = "file"
+	// FormatFile is when a key + cert are stored concatenated into a single file
+	FormatFile Format = "file"
 
-	// IdentityFormatOpenSSH is OpenSSH-compatible format, when a key and a cert are stored in
+	// FormatOpenSSH is OpenSSH-compatible format, when a key and a cert are stored in
 	// two different files (in the same directory)
-	IdentityFormatOpenSSH IdentityFileFormat = "openssh"
+	FormatOpenSSH Format = "openssh"
 
-	// IdentityFormatTLS is a standard TLS format used by common TLS clients (e.g. GRPC) where
+	// FormatTLS is a standard TLS format used by common TLS clients (e.g. GRPC) where
 	// certificate and key are stored in separate files.
-	IdentityFormatTLS IdentityFileFormat = "tls"
+	FormatTLS Format = "tls"
 
-	// DefaultIdentityFormat is what Teleport uses by default
-	DefaultIdentityFormat = IdentityFormatFile
+	// DefaultFormat is what Teleport uses by default
+	DefaultFormat = FormatFile
 )
 
-// MakeIdentityFile takes a username + their credentials and saves them to disk
+// Write takes a username + their credentials and saves them to disk
 // in a specified format.
 //
 // filePath is used as a base to generate output file names; these names are
 // returned in filesWritten.
-func MakeIdentityFile(filePath string, key *Key, format IdentityFileFormat, certAuthorities []services.CertAuthority) (filesWritten []string, err error) {
+func Write(filePath string, key *client.Key, format Format, certAuthorities []services.CertAuthority) (filesWritten []string, err error) {
 	const (
 		// the files and the dir will be created with these permissions:
 		fileMode = 0600
@@ -82,7 +69,7 @@ func MakeIdentityFile(filePath string, key *Key, format IdentityFileFormat, cert
 	var output io.Writer = os.Stdout
 	switch format {
 	// dump user identity into a single file:
-	case IdentityFormatFile:
+	case FormatFile:
 		filesWritten = append(filesWritten, filePath)
 		f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
 		if err != nil {
@@ -127,7 +114,7 @@ func MakeIdentityFile(filePath string, key *Key, format IdentityFileFormat, cert
 		}
 
 	// dump user identity into separate files:
-	case IdentityFormatOpenSSH:
+	case FormatOpenSSH:
 		keyPath := filePath
 		certPath := keyPath + "-cert.pub"
 		filesWritten = append(filesWritten, keyPath, certPath)
@@ -142,7 +129,7 @@ func MakeIdentityFile(filePath string, key *Key, format IdentityFileFormat, cert
 			return nil, trace.Wrap(err)
 		}
 
-	case IdentityFormatTLS:
+	case FormatTLS:
 		keyPath := filePath + ".key"
 		certPath := filePath + ".crt"
 		casPath := filePath + ".cas"
@@ -169,7 +156,7 @@ func MakeIdentityFile(filePath string, key *Key, format IdentityFileFormat, cert
 		}
 	default:
 		return nil, trace.BadParameter("unsupported identity format: %q, use one of %q, %q, or %q",
-			format, IdentityFormatFile, IdentityFormatOpenSSH, IdentityFormatTLS)
+			format, FormatFile, FormatOpenSSH, FormatTLS)
 	}
 	return filesWritten, nil
 }
@@ -187,9 +174,9 @@ type IdentityFile struct {
 	}
 }
 
-// DecodeIdentityFile attempts to break up the contents of an identity file
+// Decode attempts to break up the contents of an identity file
 // into its respective components.
-func DecodeIdentityFile(r io.Reader) (*IdentityFile, error) {
+func Decode(r io.Reader) (*IdentityFile, error) {
 	scanner := bufio.NewScanner(r)
 	var ident IdentityFile
 	// Subslice of scanner's buffer pointing to current line

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -1,0 +1,46 @@
+package identityfile
+
+import (
+	"io/ioutil"
+
+	"github.com/gravitational/teleport/lib/client"
+	"gopkg.in/check.v1"
+)
+
+type IdentityfileTestSuite struct {
+}
+
+var _ = check.Suite(&IdentityfileTestSuite{})
+
+func (s *IdentityfileTestSuite) TestWrite(c *check.C) {
+	keyFilePath := c.MkDir() + "openssh"
+
+	var key client.Key
+	key.Cert = []byte("cert")
+	key.Priv = []byte("priv")
+	key.Pub = []byte("pub")
+
+	// test OpenSSH-compatible identity file creation:
+	_, err := Write(keyFilePath, &key, FormatOpenSSH, nil)
+	c.Assert(err, check.IsNil)
+
+	// key is OK:
+	out, err := ioutil.ReadFile(keyFilePath)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(out), check.Equals, "priv")
+
+	// cert is OK:
+	out, err = ioutil.ReadFile(keyFilePath + "-cert.pub")
+	c.Assert(err, check.IsNil)
+	c.Assert(string(out), check.Equals, "cert")
+
+	// test standard Teleport identity file creation:
+	keyFilePath = c.MkDir() + "file"
+	_, err = Write(keyFilePath, &key, FormatFile, nil)
+	c.Assert(err, check.IsNil)
+
+	// key+cert are OK:
+	out, err = ioutil.ReadFile(keyFilePath)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(out), check.Equals, "privcert")
+}

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -55,6 +56,20 @@ type Key struct {
 
 	// ClusterName is a cluster name this key is associated with
 	ClusterName string
+}
+
+// NewKey generates a new unsigned key. Such key must be signed by a
+// Teleport CA (auth server) before it becomes useful.
+func NewKey() (key *Key, err error) {
+	priv, pub, err := native.GenerateKeyPair("")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &Key{
+		Priv: priv,
+		Pub:  pub,
+	}, nil
 }
 
 // TLSCAs returns all TLS CA certificates from this key

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -311,13 +311,11 @@ func (a *AuthCommand) generateHostKeys(clusterApi auth.ClientI) error {
 		filePath = principals[0]
 	}
 
-	err = client.MakeIdentityFile(filePath, key, a.outputFormat, nil)
+	filesWritten, err := client.MakeIdentityFile(filePath, key, a.outputFormat, nil)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if a.output != "" {
-		fmt.Printf("\nThe certificate has been written to %s\n", a.output)
-	}
+	fmt.Printf("\nThe credentials have been written to %s\n", strings.Join(filesWritten, ", "))
 	return nil
 }
 
@@ -356,13 +354,11 @@ func (a *AuthCommand) generateUserKeys(clusterApi auth.ClientI) error {
 	}
 
 	// write the cert+private key to the output:
-	err = client.MakeIdentityFile(a.output, key, a.outputFormat, certAuthorities)
+	filesWritten, err := client.MakeIdentityFile(a.output, key, a.outputFormat, certAuthorities)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if a.output != "" {
-		fmt.Printf("\nThe certificate has been written to %s\n", a.output)
-	}
+	fmt.Printf("\nThe credentials have been written to %s\n", strings.Join(filesWritten, ", "))
 	return nil
 }
 

--- a/tool/tsh/common/identity.go
+++ b/tool/tsh/common/identity.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/sshutils"
 
 	"github.com/gravitational/trace"
@@ -48,7 +49,7 @@ func LoadIdentity(idFn string) (*client.Key, ssh.HostKeyCallback, error) {
 		return nil, nil, trace.Wrap(err)
 	}
 	defer f.Close()
-	ident, err := client.DecodeIdentityFile(f)
+	ident, err := identityfile.Decode(f)
 	if err != nil {
 		return nil, nil, trace.Wrap(err, "failed to parse identity file")
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/services"
@@ -137,7 +138,7 @@ type CLIConf struct {
 	IdentityFileOut string
 	// IdentityFormat (used for --format flag for 'tsh login') defines which
 	// format to use with --out to store a fershly retreived certificate
-	IdentityFormat client.IdentityFileFormat
+	IdentityFormat identityfile.Format
 
 	// BindAddr is an address in the form of host:port to bind to
 	// during `tsh login` command
@@ -263,8 +264,8 @@ func Run(args []string, underTest bool) {
 	login.Flag("bind-addr", "Address in the form of host:port to bind to for login command webhook").Envar(bindAddrEnvVar).StringVar(&cf.BindAddr)
 	login.Flag("out", "Identity output").Short('o').AllowDuplicate().StringVar(&cf.IdentityFileOut)
 	login.Flag("format", fmt.Sprintf("Identity format [%s] or %s (for OpenSSH compatibility)",
-		client.DefaultIdentityFormat,
-		client.IdentityFormatOpenSSH)).Default(string(client.DefaultIdentityFormat)).StringVar((*string)(&cf.IdentityFormat))
+		identityfile.DefaultFormat,
+		identityfile.FormatOpenSSH)).Default(string(identityfile.DefaultFormat)).StringVar((*string)(&cf.IdentityFormat))
 	login.Flag("request-roles", "Request one or more extra roles").StringVar(&cf.DesiredRoles)
 	login.Arg("cluster", clusterHelp).StringVar(&cf.SiteName)
 	login.Alias(loginUsageFooter)
@@ -392,7 +393,7 @@ func onLogin(cf *CLIConf) {
 		utils.FatalError(trace.BadParameter("-i flag cannot be used here"))
 	}
 
-	if cf.IdentityFormat != client.IdentityFormatOpenSSH && cf.IdentityFormat != client.IdentityFormatFile {
+	if cf.IdentityFormat != identityfile.FormatOpenSSH && cf.IdentityFormat != identityfile.FormatFile {
 		utils.FatalError(trace.BadParameter("invalid identity format: %s", cf.IdentityFormat))
 	}
 
@@ -472,8 +473,11 @@ func onLogin(cf *CLIConf) {
 		if err != nil {
 			utils.FatalError(err)
 		}
-		client.MakeIdentityFile(cf.IdentityFileOut, key, cf.IdentityFormat, authorities)
-		fmt.Printf("\nThe certificate has been written to %s\n", cf.IdentityFileOut)
+		filesWritten, err := identityfile.Write(cf.IdentityFileOut, key, cf.IdentityFormat, authorities)
+		if err != nil {
+			utils.FatalError(err)
+		}
+		fmt.Printf("\nThe certificate has been written to %s\n", strings.Join(filesWritten, ","))
 		return
 	}
 


### PR DESCRIPTION
Move related code from `lib/client` to `lib/client/identityfile` and clean up the naming.

The main reason is for `identityfile.Write` (former `client.MakeIdentityFile`) to support generating a `kubeconfig`. Using `lib/kube/client` from `lib/client` would create an import cycle. This new package bypasses that problem.

Also, `client.MakeIdentityFile` now reports exactly which files it wrote, to fix the CLI output. Previously, it would only print the base file name, which may not be actually written.

Updates  #2825