### PR TITLE
Add `internal.kubernetes_users` to `kubernetes_users` on admin role

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -468,6 +468,10 @@ const (
 	// TraitInternalKubeGroupsVariable is the variable used to store allowed
 	// kubernetes groups for local accounts.
 	TraitInternalKubeGroupsVariable = "{{internal.kubernetes_groups}}"
+
+	// TraitInternalKubeUsersVariable is the variable used to store allowed
+	// kubernetes users for local accounts.
+	TraitInternalKubeUsersVariable = "{{internal.kubernetes_users}}"
 )
 
 const (

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -35,6 +35,8 @@ type Modules interface {
 	EmptyRolesHandler() error
 	// DefaultAllowedLogins returns default allowed logins for a new admin role
 	DefaultAllowedLogins() []string
+	// DefaultKubeUsers returns default kuberentes users for a new admin role
+	DefaultKubeUsers() []string
 	// DefaultKubeGroups returns default kuberentes groups for a new admin role
 	DefaultKubeGroups() []string
 	// PrintVersion prints teleport version
@@ -71,6 +73,11 @@ type defaultModules struct{}
 // is created, no-op by default
 func (p *defaultModules) EmptyRolesHandler() error {
 	return nil
+}
+
+// DefaultKubeUsers returns default kuberentes users for a new admin role
+func (p *defaultModules) DefaultKubeUsers() []string {
+	return []string{teleport.TraitInternalKubeUsersVariable}
 }
 
 // DefaultKubeGroups returns default kuberentes groups for a new admin role

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -35,9 +35,9 @@ type Modules interface {
 	EmptyRolesHandler() error
 	// DefaultAllowedLogins returns default allowed logins for a new admin role
 	DefaultAllowedLogins() []string
-	// DefaultKubeUsers returns default kuberentes users for a new admin role
+	// DefaultKubeUsers returns default kubernetes users for a new admin role
 	DefaultKubeUsers() []string
-	// DefaultKubeGroups returns default kuberentes groups for a new admin role
+	// DefaultKubeGroups returns default kubernetes groups for a new admin role
 	DefaultKubeGroups() []string
 	// PrintVersion prints teleport version
 	PrintVersion()
@@ -75,12 +75,12 @@ func (p *defaultModules) EmptyRolesHandler() error {
 	return nil
 }
 
-// DefaultKubeUsers returns default kuberentes users for a new admin role
+// DefaultKubeUsers returns default kubernetes users for a new admin role
 func (p *defaultModules) DefaultKubeUsers() []string {
 	return []string{teleport.TraitInternalKubeUsersVariable}
 }
 
-// DefaultKubeGroups returns default kuberentes groups for a new admin role
+// DefaultKubeGroups returns default kubernetes groups for a new admin role
 func (p *defaultModules) DefaultKubeGroups() []string {
 	return []string{teleport.TraitInternalKubeGroupsVariable}
 }

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -41,6 +41,9 @@ func (s *ModulesSuite) TestDefaultModules(c *check.C) {
 	kubeGroups := GetModules().DefaultKubeGroups()
 	c.Assert(kubeGroups, check.DeepEquals, []string{teleport.TraitInternalKubeGroupsVariable})
 
+	kubeUsers := GetModules().DefaultKubeUsers()
+	c.Assert(kubeUsers, check.DeepEquals, []string{teleport.TraitInternalKubeUsersVariable})
+
 	roles := GetModules().RolesFromLogins([]string{"root"})
 	c.Assert(roles, check.DeepEquals, []string{teleport.AdminRoleName})
 
@@ -82,6 +85,10 @@ func (p *testModules) EmptyRolesHandler() error {
 
 func (p *testModules) DefaultAllowedLogins() []string {
 	return []string{"a", "b"}
+}
+
+func (p *testModules) DefaultKubeUsers() []string {
+	return []string{"c", "d"}
 }
 
 func (p *testModules) DefaultKubeGroups() []string {

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -111,6 +111,7 @@ func NewAdminRole() Role {
 		},
 	}
 	role.SetLogins(Allow, modules.GetModules().DefaultAllowedLogins())
+	role.SetKubeUsers(Allow, modules.GetModules().DefaultKubeUsers())
 	role.SetKubeGroups(Allow, modules.GetModules().DefaultKubeGroups())
 	return role
 }
@@ -391,7 +392,8 @@ func applyValueTraits(val string, traits map[string][]string) ([]string, error) 
 		return []string{val}, nil
 	}
 
-	// For internal traits, only internal.logins and internal.kubernetes_groups is supported at the moment.
+	// For internal traits, only internal.logins, internal.kubernetes_users and
+	// internal.kubernetes_groups is supported at the moment.
 	if variable.Namespace() == teleport.TraitInternalPrefix {
 		if variable.Name() != teleport.TraitLogins && variable.Name() != teleport.TraitKubeGroups && variable.Name() != teleport.TraitKubeUsers {
 			return nil, trace.BadParameter("unsupported variable %q", variable.Name())
@@ -2281,7 +2283,7 @@ const RoleSpecV3SchemaTemplate = `{
         "cert_format": { "type": "string" },
         "client_idle_timeout": { "type": "string" },
         "disconnect_expired_cert": { "type": ["boolean", "string"] },
-        "enhanced_recording": { 
+        "enhanced_recording": {
           "type": "array",
           "items": { "type": "string" }
         }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -393,7 +393,7 @@ func applyValueTraits(val string, traits map[string][]string) ([]string, error) 
 	}
 
 	// For internal traits, only internal.logins, internal.kubernetes_users and
-	// internal.kubernetes_groups is supported at the moment.
+	// internal.kubernetes_groups are supported at the moment.
 	if variable.Namespace() == teleport.TraitInternalPrefix {
 		if variable.Name() != teleport.TraitLogins && variable.Name() != teleport.TraitKubeGroups && variable.Name() != teleport.TraitKubeUsers {
 			return nil, trace.BadParameter("unsupported variable %q", variable.Name())


### PR DESCRIPTION
Using local users, it should be possible to write k8s RBAC bindings for `User` subjects.
Plumb `kubernetes_users` field of teleport user through to k8s client cert.

Also add `--k8s-users` flag to `tctl users add`, which defaults to the local login (same as for SSH).

With this, the UX is:
- admin:
  - `tctl users add awly`, have user go through registration flow
  - create k8s RBAC binding with:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: awly-binding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: some-role-here
subjects:
- kind: User
  name: awly
```
- user:
  - `tsh login`
  - `kubectl ...`, based on what the above role binding allows