### PR TITLE
Fix agent forwarding for multi-session connections

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -1265,11 +1265,11 @@ func (s *discardServer) Stop() {
 	s.sshServer.Close()
 }
 
-func (s *discardServer) HandleNewChan(conn net.Conn, sconn *ssh.ServerConn, newChannel ssh.NewChannel) {
+func (s *discardServer) HandleNewChan(ccx *sshutils.ConnectionContext, newChannel ssh.NewChannel) {
 	channel, reqs, err := newChannel.Accept()
 	if err != nil {
-		sconn.Close()
-		conn.Close()
+		ccx.ServerConn.Close()
+		ccx.NetConn.Close()
 		return
 	}
 

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -80,7 +80,7 @@ func (s *MuxSuite) TestMultiplexing(c *check.C) {
 	defer backend1.Close()
 
 	called := false
-	sshHandler := sshutils.NewChanHandlerFunc(func(_ net.Conn, conn *ssh.ServerConn, nch ssh.NewChannel) {
+	sshHandler := sshutils.NewChanHandlerFunc(func(_ *sshutils.ConnectionContext, nch ssh.NewChannel) {
 		called = true
 		nch.Reject(ssh.Prohibited, "nothing to see here")
 	})
@@ -381,7 +381,7 @@ func (s *MuxSuite) TestDisableTLS(c *check.C) {
 	defer backend1.Close()
 
 	called := false
-	sshHandler := sshutils.NewChanHandlerFunc(func(_ net.Conn, conn *ssh.ServerConn, nch ssh.NewChannel) {
+	sshHandler := sshutils.NewChanHandlerFunc(func(_ *sshutils.ConnectionContext, nch ssh.NewChannel) {
 		called = true
 		nch.Reject(ssh.Prohibited, "nothing to see here")
 	})

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -527,11 +527,12 @@ func (s *server) Shutdown(ctx context.Context) error {
 	return s.srv.Shutdown(ctx)
 }
 
-func (s *server) HandleNewChan(conn net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {
+func (s *server) HandleNewChan(ccx *sshutils.ConnectionContext, nch ssh.NewChannel) {
 	// Apply read/write timeouts to the server connection.
-	conn = utils.ObeyIdleTimeout(conn,
+	conn := utils.ObeyIdleTimeout(ccx.NetConn,
 		s.offlineThreshold,
 		"reverse tunnel server")
+	sconn := ccx.ServerConn
 
 	channelType := nch.ChannelType()
 	switch channelType {

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -761,15 +761,18 @@ func (s *Server) serveAgent(ctx *srv.ServerContext) error {
 	}
 
 	// start an agent on a unix socket
-	agentServer := &teleagent.AgentServer{Agent: ctx.GetAgent()}
+	agentServer := &teleagent.AgentServer{Agent: ctx.Parent.GetAgent()}
 	err = agentServer.ListenUnixSocket(socketPath, uid, gid, 0600)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	ctx.SetEnv(teleport.SSHAuthSock, socketPath)
-	ctx.SetEnv(teleport.SSHAgentPID, fmt.Sprintf("%v", pid))
-	ctx.AddCloser(agentServer)
-	ctx.AddCloser(dirCloser)
+	ctx.Parent.SetEnv(teleport.SSHAuthSock, socketPath)
+	ctx.Parent.SetEnv(teleport.SSHAgentPID, fmt.Sprintf("%v", pid))
+	ctx.Parent.AddCloser(agentServer)
+	ctx.Parent.AddCloser(dirCloser)
+	// ensure that SSHAuthSock and SSHAgentPID are imported into
+	// the current child context.
+	ctx.ImportParentEnv()
 	ctx.Debugf("Opened agent channel for Teleport user %v and socket %v.", ctx.Identity.TeleportUser, socketPath)
 	go agentServer.Serve()
 
@@ -816,8 +819,8 @@ func (s *Server) HandleRequest(r *ssh.Request) {
 }
 
 // HandleNewChan is called when new channel is opened
-func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {
-	identityContext, err := s.authHandlers.CreateIdentityContext(sconn)
+func (s *Server) HandleNewChan(ccx *sshutils.ConnectionContext, nch ssh.NewChannel) {
+	identityContext, err := s.authHandlers.CreateIdentityContext(ccx.ServerConn)
 	if err != nil {
 		nch.Reject(ssh.Prohibited, fmt.Sprintf("Unable to create identity from connection: %v", err))
 		return
@@ -841,7 +844,7 @@ func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.Ne
 				nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 				return
 			}
-			go s.handleProxyJump(wconn, sconn, identityContext, ch, *req)
+			go s.handleProxyJump(ccx, identityContext, ch, *req)
 			return
 		// Channels of type "session" handle requests that are involved in running
 		// commands on a server. In the case of proxy mode subsystem and agent
@@ -853,7 +856,7 @@ func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.Ne
 				nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 				return
 			}
-			go s.handleSessionRequests(wconn, sconn, identityContext, ch, requests)
+			go s.handleSessionRequests(ccx, identityContext, ch, requests)
 			return
 		default:
 			nch.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
@@ -871,7 +874,7 @@ func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.Ne
 			nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 			return
 		}
-		go s.handleSessionRequests(wconn, sconn, identityContext, ch, requests)
+		go s.handleSessionRequests(ccx, identityContext, ch, requests)
 	// Channels of type "direct-tcpip" handles request for port forwarding.
 	case teleport.ChanDirectTCPIP:
 		req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
@@ -886,23 +889,22 @@ func (s *Server) HandleNewChan(wconn net.Conn, sconn *ssh.ServerConn, nch ssh.Ne
 			nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 			return
 		}
-		go s.handleDirectTCPIPRequest(wconn, sconn, identityContext, ch, req)
+		go s.handleDirectTCPIPRequest(ccx, identityContext, ch, req)
 	default:
 		nch.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
 	}
 }
 
 // handleDirectTCPIPRequest handles port forwarding requests.
-func (s *Server) handleDirectTCPIPRequest(wconn net.Conn, sconn *ssh.ServerConn, identityContext srv.IdentityContext, channel ssh.Channel, req *sshutils.DirectTCPIPReq) {
+func (s *Server) handleDirectTCPIPRequest(ccx *sshutils.ConnectionContext, identityContext srv.IdentityContext, channel ssh.Channel, req *sshutils.DirectTCPIPReq) {
 	// Create context for this channel. This context will be closed when
 	// forwarding is complete.
-	ctx, err := srv.NewServerContext(s, sconn, identityContext)
+	ctx, err := srv.NewServerContext(ccx, s, identityContext)
 	if err != nil {
 		log.Errorf("Unable to create connection context: %v.", err)
 		channel.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}
-	ctx.Connection = wconn
 	ctx.IsTestStub = s.isTestStub
 	ctx.AddCloser(channel)
 	ctx.ChannelType = teleport.ChanDirectTCPIP
@@ -988,24 +990,23 @@ func (s *Server) handleDirectTCPIPRequest(wconn net.Conn, sconn *ssh.ServerConn,
 		events.PortForwardSuccess: true,
 		events.EventLogin:         ctx.Identity.Login,
 		events.EventUser:          ctx.Identity.TeleportUser,
-		events.LocalAddr:          sconn.LocalAddr().String(),
-		events.RemoteAddr:         sconn.RemoteAddr().String(),
+		events.LocalAddr:          ctx.Conn.LocalAddr().String(),
+		events.RemoteAddr:         ctx.Conn.RemoteAddr().String(),
 	})
 }
 
 // handleSessionRequests handles out of band session requests once the session
 // channel has been created this function's loop handles all the "exec",
 // "subsystem" and "shell" requests.
-func (s *Server) handleSessionRequests(conn net.Conn, sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, in <-chan *ssh.Request) {
+func (s *Server) handleSessionRequests(ccx *sshutils.ConnectionContext, identityContext srv.IdentityContext, ch ssh.Channel, in <-chan *ssh.Request) {
 	// Create context for this channel. This context will be closed when the
 	// session request is complete.
-	ctx, err := srv.NewServerContext(s, sconn, identityContext)
+	ctx, err := srv.NewServerContext(ccx, s, identityContext)
 	if err != nil {
 		log.Errorf("Unable to create connection context: %v.", err)
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}
-	ctx.Connection = conn
 	ctx.IsTestStub = s.isTestStub
 	ctx.AddCloser(ch)
 	ctx.ChannelType = teleport.ChanSession
@@ -1028,7 +1029,7 @@ func (s *Server) handleSessionRequests(conn net.Conn, sconn *ssh.ServerConn, ide
 	// closeContext which signals the server to shutdown.
 	go srv.StartKeepAliveLoop(srv.KeepAliveParams{
 		Conns: []srv.RequestSender{
-			sconn,
+			ctx.Conn,
 		},
 		Interval:     clusterConfig.GetKeepAliveInterval(),
 		MaxCount:     clusterConfig.GetKeepAliveCountMax(),
@@ -1062,7 +1063,7 @@ func (s *Server) handleSessionRequests(conn net.Conn, sconn *ssh.ServerConn, ide
 		case req := <-in:
 			if req == nil {
 				// this will happen when the client closes/drops the connection
-				ctx.Debugf("Client %v disconnected.", sconn.RemoteAddr())
+				ctx.Debugf("Client %v disconnected.", ctx.Conn.RemoteAddr())
 				return
 			}
 			if err := s.dispatch(ch, req, ctx); err != nil {
@@ -1171,7 +1172,7 @@ func (s *Server) handleAgentForwardNode(req *ssh.Request, ctx *srv.ServerContext
 	}
 
 	// save the agent in the context so it can be used later
-	ctx.SetAgent(agent.NewClient(authChannel), authChannel)
+	ctx.Parent.SetAgent(agent.NewClient(authChannel), authChannel)
 
 	// serve an agent on a unix socket on this node
 	err = s.serveAgent(ctx)
@@ -1209,7 +1210,7 @@ func (s *Server) handleAgentForwardProxy(req *ssh.Request, ctx *srv.ServerContex
 	// Save the agent so it can be used when making a proxy subsystem request
 	// later. It will also be used when building a remote connection to the
 	// target node.
-	ctx.SetAgent(agent.NewClient(authChannel), authChannel)
+	ctx.Parent.SetAgent(agent.NewClient(authChannel), authChannel)
 
 	return nil
 }
@@ -1304,16 +1305,15 @@ func (s *Server) handleVersionRequest(req *ssh.Request) {
 }
 
 // handleProxyJump handles ProxyJump request that is executed via direct tcp-ip dial on the proxy
-func (s *Server) handleProxyJump(conn net.Conn, sconn *ssh.ServerConn, identityContext srv.IdentityContext, ch ssh.Channel, req sshutils.DirectTCPIPReq) {
+func (s *Server) handleProxyJump(ccx *sshutils.ConnectionContext, identityContext srv.IdentityContext, ch ssh.Channel, req sshutils.DirectTCPIPReq) {
 	// Create context for this channel. This context will be closed when the
 	// session request is complete.
-	ctx, err := srv.NewServerContext(s, sconn, identityContext)
+	ctx, err := srv.NewServerContext(ccx, s, identityContext)
 	if err != nil {
 		log.Errorf("Unable to create connection context: %v.", err)
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}
-	ctx.Connection = conn
 	ctx.IsTestStub = s.isTestStub
 	ctx.AddCloser(ch)
 	defer ctx.Close()
@@ -1364,7 +1364,7 @@ func (s *Server) handleProxyJump(conn net.Conn, sconn *ssh.ServerConn, identityC
 	// closeContext which signals the server to shutdown.
 	go srv.StartKeepAliveLoop(srv.KeepAliveParams{
 		Conns: []srv.RequestSender{
-			sconn,
+			ctx.Conn,
 		},
 		Interval:     clusterConfig.GetKeepAliveInterval(),
 		MaxCount:     clusterConfig.GetKeepAliveCountMax(),
@@ -1391,7 +1391,7 @@ func (s *Server) handleProxyJump(conn net.Conn, sconn *ssh.ServerConn, identityC
 		return
 	}
 
-	if err := subsys.Start(sconn, ch, &ssh.Request{}, ctx); err != nil {
+	if err := subsys.Start(ctx.Conn, ch, &ssh.Request{}, ctx); err != nil {
 		log.Errorf("Unable to start proxy subsystem: %v.", err)
 		ch.Stderr().Write([]byte("Unable to start proxy subsystem."))
 		return

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -352,8 +352,21 @@ func (s *SrvSuite) TestAgentForward(c *C) {
 	err = client.Close()
 	c.Assert(err, IsNil)
 
-	// make sure the socket is gone after we closed the session
-	se.Close()
+	// make sure the socket persists after the session is closed.
+	// (agents are started from specific sessions, but apply to all
+	// sessions on the connection).
+	err = se.Close()
+	c.Assert(err, IsNil)
+	// Pause to allow closure to propagate.
+	time.Sleep(150 * time.Millisecond)
+	_, err = net.Dial("unix", socketPath)
+	c.Assert(err, IsNil)
+
+	// make sure the socket is gone after we closed the connection.
+	err = s.clt.Close()
+	c.Assert(err, IsNil)
+	// clt must be nullified to prevent double-close during test cleanup
+	s.clt = nil
 	for i := 0; i < 4; i++ {
 		_, err = net.Dial("unix", socketPath)
 		if err != nil {

--- a/lib/sshutils/ctx.go
+++ b/lib/sshutils/ctx.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sshutils
+
+import (
+	"io"
+	"net"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/gravitational/trace"
+)
+
+// ConnectionContext manages connection-level state.
+type ConnectionContext struct {
+	// NetConn is the base connection object.
+	NetConn net.Conn
+
+	// ServerConn is authenticated ssh connection.
+	ServerConn *ssh.ServerConn
+
+	// mu protects the rest of the state
+	mu sync.RWMutex
+
+	// env holds environment variables which should be
+	// set for all channels.
+	env map[string]string
+
+	// agent is a client to remote SSH agent.
+	agent agent.Agent
+
+	// agentCh is SSH channel using SSH agent protocol.
+	agentChannel ssh.Channel
+	// closers is a list of io.Closer that will be called when session closes
+	// this is handy as sometimes client closes session, in this case resources
+	// will be properly closed and deallocated, otherwise they could be kept hanging.
+	closers []io.Closer
+}
+
+// NewConnectionContext creates a new ConnectionContext instance.
+func NewConnectionContext(nconn net.Conn, sconn *ssh.ServerConn) *ConnectionContext {
+	return &ConnectionContext{
+		NetConn:    nconn,
+		ServerConn: sconn,
+		env:        make(map[string]string),
+	}
+}
+
+// SetEnv sets a environment variable within this context.
+func (c *ConnectionContext) SetEnv(key, val string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.env[key] = val
+}
+
+// GetEnv returns a environment variable within this context.
+func (c *ConnectionContext) GetEnv(key string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	val, ok := c.env[key]
+	return val, ok
+}
+
+// ExportEnv writes all env vars to supplied map (used to configure
+// env of child contexts).
+func (c *ConnectionContext) ExportEnv(m map[string]string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for key, val := range c.env {
+		m[key] = val
+	}
+}
+
+// GetAgent returns a agent.Agent which represents the capabilities of an SSH agent,
+// or nil if no agent is available in this context.
+func (c *ConnectionContext) GetAgent() agent.Agent {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.agent
+}
+
+// GetAgentChannel returns the channel over which communication with the agent occurs,
+// or nil if no agent is available in this context.
+func (c *ConnectionContext) GetAgentChannel() ssh.Channel {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.agentChannel
+}
+
+// SetAgent sets the agent and channel over which communication with the agent occurs.
+func (c *ConnectionContext) SetAgent(a agent.Agent, channel ssh.Channel) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.agentChannel != nil {
+		c.agentChannel.Close()
+	}
+	c.agentChannel = channel
+	c.agent = a
+}
+
+// AddCloser adds any closer in ctx that will be called
+// when the underlying connection is closed.
+func (c *ConnectionContext) AddCloser(closer io.Closer) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closers = append(c.closers, closer)
+}
+
+// takeClosers returns all resources that should be closed and sets the properties to null
+// we do this to avoid calling Close() under lock to avoid potential deadlocks
+func (c *ConnectionContext) takeClosers() []io.Closer {
+	// this is done to avoid any operation holding the lock for too long
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	closers := c.closers
+	c.closers = nil
+	if c.agentChannel != nil {
+		closers = append(closers, c.agentChannel)
+		c.agentChannel = nil
+	}
+	return closers
+}
+
+// Close closes associated resources (e.g. agent channel).
+func (c *ConnectionContext) Close() error {
+	var errs []error
+
+	closers := c.takeClosers()
+
+	for _, cl := range closers {
+		if cl == nil {
+			continue
+		}
+
+		err := cl.Close()
+		if err == nil {
+			continue
+		}
+
+		errs = append(errs, err)
+	}
+
+	return trace.NewAggregate(errs...)
+}

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -19,7 +19,6 @@ package sshutils
 import (
 	"context"
 	"fmt"
-	"net"
 	"testing"
 	"time"
 
@@ -52,7 +51,7 @@ func (s *ServerSuite) SetUpSuite(c *check.C) {
 
 func (s *ServerSuite) TestStartStop(c *check.C) {
 	called := false
-	fn := NewChanHandlerFunc(func(_ net.Conn, conn *ssh.ServerConn, nch ssh.NewChannel) {
+	fn := NewChanHandlerFunc(func(_ *ConnectionContext, nch ssh.NewChannel) {
 		called = true
 		nch.Reject(ssh.Prohibited, "nothing to see here")
 	})
@@ -86,13 +85,13 @@ func (s *ServerSuite) TestStartStop(c *check.C) {
 // TestShutdown tests graceul shutdown feature
 func (s *ServerSuite) TestShutdown(c *check.C) {
 	closeContext, cancel := context.WithCancel(context.TODO())
-	fn := NewChanHandlerFunc(func(_ net.Conn, conn *ssh.ServerConn, nch ssh.NewChannel) {
+	fn := NewChanHandlerFunc(func(ccx *ConnectionContext, nch ssh.NewChannel) {
 		ch, _, err := nch.Accept()
 		c.Assert(err, check.IsNil)
 		defer ch.Close()
 		select {
 		case <-closeContext.Done():
-			conn.Close()
+			ccx.ServerConn.Close()
 		}
 	})
 
@@ -136,7 +135,7 @@ func (s *ServerSuite) TestShutdown(c *check.C) {
 }
 
 func (s *ServerSuite) TestConfigureCiphers(c *check.C) {
-	fn := NewChanHandlerFunc(func(_ net.Conn, conn *ssh.ServerConn, nch ssh.NewChannel) {
+	fn := NewChanHandlerFunc(func(_ *ConnectionContext, nch ssh.NewChannel) {
 		nch.Reject(ssh.Prohibited, "nothing to see here")
 	})
 
@@ -182,7 +181,7 @@ func (s *ServerSuite) TestHostSignerFIPS(c *check.C) {
 	_, ellipticSigner, err := utils.CreateEllipticCertificate("foo", ssh.HostCert)
 	c.Assert(err, check.IsNil)
 
-	newChanHandler := NewChanHandlerFunc(func(_ net.Conn, conn *ssh.ServerConn, nch ssh.NewChannel) {
+	newChanHandler := NewChanHandlerFunc(func(_ *ConnectionContext, nch ssh.NewChannel) {
 		nch.Reject(ssh.Prohibited, "nothing to see here")
 	})
 


### PR DESCRIPTION
This PR changes the lifetime of agent forwarding to be scoped to the underlying ssh connection, instead of the specific ssh channel which initially passed the agent forwarding request.

Previous behavior was inconsistent with how openssh handles agent forwarding, and was causing issues with applications which rely on creating multiple separate `exec` sessions on a single connection.

Fixes #3471 