### PR TITLE
Add support for kubernetes identity file format

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -696,6 +696,13 @@ func (c *Config) KubeProxyHostPort() (string, int) {
 	return webProxyHost, defaults.KubeProxyListenPort
 }
 
+// KubeClusterAddr returns a public HTTPS address of the proxy for use by
+// Kubernetes clients.
+func (c *Config) KubeClusterAddr() string {
+	host, port := c.KubeProxyHostPort()
+	return fmt.Sprintf("https://%s:%d", host, port)
+}
+
 // WebProxyHostPort returns the host and port of the web proxy.
 func (c *Config) WebProxyHostPort() (string, int) {
 	if c.WebProxyAddr != "" {

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -21,7 +21,7 @@ func (s *IdentityfileTestSuite) TestWrite(c *check.C) {
 	key.Pub = []byte("pub")
 
 	// test OpenSSH-compatible identity file creation:
-	_, err := Write(keyFilePath, &key, FormatOpenSSH, nil)
+	_, err := Write(keyFilePath, &key, FormatOpenSSH, nil, "")
 	c.Assert(err, check.IsNil)
 
 	// key is OK:
@@ -36,7 +36,7 @@ func (s *IdentityfileTestSuite) TestWrite(c *check.C) {
 
 	// test standard Teleport identity file creation:
 	keyFilePath = c.MkDir() + "file"
-	_, err = Write(keyFilePath, &key, FormatFile, nil)
+	_, err = Write(keyFilePath, &key, FormatFile, nil, "")
 	c.Assert(err, check.IsNil)
 
 	// key+cert are OK:

--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -62,7 +62,7 @@ func UpdateWithClient(path string, tc *client.TeleportClient) error {
 // If `path` is empty, Update will try to guess it based on the environment or
 // known defaults.
 func Update(path string, v Values) error {
-	config, err := load(path)
+	config, err := Load(path)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -109,7 +109,7 @@ func Update(path string, v Values) error {
 // known defaults.
 func Remove(path, name string) error {
 	// Load existing kubeconfig from disk.
-	config, err := load(path)
+	config, err := Load(path)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -133,9 +133,9 @@ func Remove(path, name string) error {
 	return save(path, *config)
 }
 
-// load tries to read a kubeconfig file and if it can't, returns an error.
+// Load tries to read a kubeconfig file and if it can't, returns an error.
 // One exception, missing files result in empty configs, not an error.
-func load(path string) (*clientcmdapi.Config, error) {
+func Load(path string) (*clientcmdapi.Config, error) {
 	filename, err := finalPath(path)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/kube/kubeconfig/kubeconfig_test.go
+++ b/lib/kube/kubeconfig/kubeconfig_test.go
@@ -117,7 +117,7 @@ func (s *KubeconfigSuite) TearDownTest(c *check.C) {
 }
 
 func (s *KubeconfigSuite) TestLoad(c *check.C) {
-	config, err := load(s.kubeconfigPath)
+	config, err := Load(s.kubeconfigPath)
 	c.Assert(err, check.IsNil)
 	c.Assert(*config, check.DeepEquals, s.initialConfig)
 }
@@ -156,7 +156,7 @@ func (s *KubeconfigSuite) TestSave(c *check.C) {
 	err := save(s.kubeconfigPath, cfg)
 	c.Assert(err, check.IsNil)
 
-	config, err := load(s.kubeconfigPath)
+	config, err := Load(s.kubeconfigPath)
 	c.Assert(err, check.IsNil)
 	c.Assert(*config, check.DeepEquals, cfg)
 }
@@ -196,7 +196,7 @@ func (s *KubeconfigSuite) TestUpdate(c *check.C) {
 	}
 	wantConfig.CurrentContext = clusterName
 
-	config, err := load(s.kubeconfigPath)
+	config, err := Load(s.kubeconfigPath)
 	c.Assert(err, check.IsNil)
 	c.Assert(*config, check.DeepEquals, wantConfig)
 }


### PR DESCRIPTION
There are two new ways you can generate a kubeconfig:
- `tctl auth sign --user=foo --format=kubernetes --out=kubeconfig` for
  admins
- `tsh login --format=kubernetes -o kubeconfig` for users

This allows admins to generate long-lived kubeconfigs for e.g. CI
systems.

A tricky part is getting the kubernetes endpoint for a proxy in `tctl`.
It does its best to guess the address, but falls back to asking user to
pass `--proxy` flag.
It looks like right now, the proxy info available via the auth server's
API doesn't have kubernetes public_addr for proxies.

Fixes #2825