### PR TITLE
Improve message for node or proxy join errors

### DIFF
--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -119,9 +119,13 @@ func Register(params RegisterParams) (*Identity, error) {
 			return nil, trace.Wrap(err)
 		}
 
+		log.Errorf("Failed to register through auth server: %v; falling back to trying the proxy server", err)
+
+		// params.AuthServers could contain a proxy address, to deal with nodes
+		// behind NAT. Try registering using the proxy API.
 		ident, err = registerThroughProxy(token, params)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.Wrap(err, "failed to register through proxy server: %v", err)
 		}
 
 		log.Debugf("Successfully registered through proxy server.")

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -57,8 +57,9 @@ type Config struct {
 	// Token is used to register this Teleport instance with the auth server
 	Token string
 
-	// AuthServers is a list of auth servers nodes, proxies and peer auth servers
-	// connect to
+	// AuthServers is a list of auth servers, proxies and peer auth servers to
+	// connect to. Yes, this is not just auth servers, the field name is
+	// misleading.
 	AuthServers []utils.NetAddr
 
 	// Identities is an optional list of pre-generated key pairs

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1588,12 +1588,14 @@ func (process *TeleportProcess) initSSH() error {
 				warnOnErr(s.Shutdown(payloadContext(payload)))
 			}
 		}
-		if conn.UseTunnel() {
+		if conn != nil && conn.UseTunnel() {
 			agentPool.Stop()
 		}
 
-		// Close BPF service.
-		warnOnErr(ebpf.Close())
+		if ebpf != nil {
+			// Close BPF service.
+			warnOnErr(ebpf.Close())
+		}
 
 		log.Infof("Exited.")
 	})


### PR DESCRIPTION
The node first tries using the token with auth server. If that fails, ittries the same address as a proxy server.
If both fail, user only sees the error from the latter attempt. If using CA pin, this error will be `x509: certificate signed by unknown authority`, which is confusing.
    
Log both errors, and mention that a fallback is happening. The output looks like:
    
    ERRO [AUTH]      Failed to register through auth server: "my-hostname" [3e53a982-afd1-4d2f-8864-54c25fbe5865] can not join the cluster with role Node, the token is not valid; falling back to trying the proxy server auth/register.go:123
    ERRO [PROC:1]    Node failed to establish connection to cluster: failed to register through proxy server: x509: certificate signed by unknown authority. time/sleep.go:149

Fixes #3003
Fixes #3316