### PR TITLE
Docs for external email identities and Kube Users

### DIFF
--- a/docs/4.3/enterprise/ssh_sso.md
+++ b/docs/4.3/enterprise/ssh_sso.md
@@ -121,12 +121,18 @@ spec:
 
 ## Working with External Email Identity
 
-Along with sending groups, an SSO provider will also provide a users email address. 
-This can be accessed via `{% raw %}{{external.email}}{% endraw %}`. This is helpful to 
-have a continuation of identity, but often the first part of the email. The local part. 
-Is useful to send to other systems as it's unique.  Teleport 4.3 has extended the variable
-interpolation, to extract this local part. 
+Along with sending groups, an SSO provider will also provide a user's email address. 
+In many organizations, the username that a person uses to log into a system is the 
+same as the first part of their email address - the 'local' part. For example, `dave.smith@acme.com`
+ might log in with the username `dave.smith`. Teleport 4.2.6+ adds an easy way to 
+ extract the first part of an email address so it can be used as a username - this 
+ is the `{% raw %}{{email.local}}{% endraw %}` function.
 
+If the email claim from the identity provider (which can be accessed via `{% raw %}{{external.email}}{% endraw %}`) 
+is sent and contains an email address, you can extract the 'local' part of the email 
+address before the @ sign like this: `{% raw %}{{email.local(external.email)}}{% endraw %}`
+
+Here's how this looks in a Teleport role:
 
 ```yaml
 kind: role

--- a/docs/4.3/enterprise/ssh_sso.md
+++ b/docs/4.3/enterprise/ssh_sso.md
@@ -119,6 +119,31 @@ spec:
       '*': '*'
 ```
 
+## Working with External Email Identity
+
+Along with sending groups, an SSO provider will also provide a users email address. 
+This can be accessed via `{% raw %}{{external.email}}{% endraw %}`. This is helpful to 
+have a continuation of identity, but often the first part of the email. The local part. 
+Is useful to send to other systems as it's unique.  Teleport 4.3 has extended the variable
+interpolation, to extract this local part. 
+
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: sso_user
+spec:
+  allow:
+    logins:
+    # Extracts the local part of dave.smith@acme.com, so the login will
+    # now support dave.smith. 
+    - '{% raw %}{{email.local(external.email)}}{% endraw %}'
+    node_labels:
+      '*': '*'
+```
+
+
 ## Multiple SSO Providers
 
 Teleport can also support multiple connectors, i.e. a Teleport administrator
@@ -152,6 +177,7 @@ SAML and OIDC types:
 * [SSH Authentication with OneLogin](../ssh_one_login.md)
 * [SSH Authentication with ADFS](../ssh_adfs.md)
 * [SSH Authentication with OAuth2 / OpenID Connect](../oidc.md)
+
 
 ## SSO Customization 
 

--- a/docs/4.3/kubernetes_ssh.md
+++ b/docs/4.3/kubernetes_ssh.md
@@ -165,9 +165,8 @@ spec:
         - root
       # list of Kubernetes groups this Github team is allowed to connect to
       kubernetes_groups: ["system:masters"]
-      # Optional: If not set users will imperonsate themseleves. 
-      # impersonate a kubernetes user with IAM prefix
-      kubernetes_users: ['barent', 'jane']
+      # Optional: If not set, users will impersonate themselves.
+      # kubernetes_users: ['barent']
 
 ```
 To obtain client ID and client secret from Github, please follow [Github documentation](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) on how to create and register an OAuth app. Be sure to set the "Authorization callback URL" to the same value as redirect_url in the resource spec.

--- a/docs/4.3/kubernetes_ssh.md
+++ b/docs/4.3/kubernetes_ssh.md
@@ -129,6 +129,12 @@ configured. In this guide we'll look at two common configurations:
   In this case, we'll need to map users' groups that come from Okta to Kubernetes
   groups.
 
+## Kubernetes Groups and Users
+
+Teleport provides support for Kubernetes Group `kubernetes_groups: ["system:masters"]` 
+and Kubernetes Users, using `kubernetes_users: ['IAM#barent', 'IAM#jane']`. If a Kubernetes
+user isn't set the user will impersonate themselves. 
+
 ### Github Auth
 
 When configuring Teleport to authenticate against Github, you have to create a
@@ -159,6 +165,10 @@ spec:
         - root
       # list of Kubernetes groups this Github team is allowed to connect to
       kubernetes_groups: ["system:masters"]
+      # Optional: If not set users will imperonsate themseleves. 
+      # impersonate a kubernetes user with IAM prefix
+      kubernetes_users: ['IAM#barent', 'IAM#jane']
+
 ```
 To obtain client ID and client secret from Github, please follow [Github documentation](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) on how to create and register an OAuth app. Be sure to set the "Authorization callback URL" to the same value as redirect_url in the resource spec.
 
@@ -178,6 +188,7 @@ Teleport will log the audit record and record the session.
 !!! note
 
     For more information on integrating Teleport with Github SSO, please see the [Github section in the Admin Manual](admin-guide.md#github-oauth-20).
+
 
 ### Okta Auth
 
@@ -220,6 +231,9 @@ $ tctl create -f admin.yaml
     need to define Kubernetes group membership in Okta (as a trait) and use
     that trait name in the Teleport role.
 
+    Teleport 4.3 has an option to extract the local part from an email claim. This can be helpful
+    since some operating systems don't support the @ symbol. This means by using `logins: ['{% raw %}{{email.local(external.email)}}{% endraw %}']` the resulting output will be `dave.smith` if the email was dave.smith@acme.com. 
+
 Once this is complete, when users execute `tsh login` and go through the usual Okta login
 sequence, their `kubeconfig` will be updated with their Kubernetes credentials.
 
@@ -227,6 +241,4 @@ sequence, their `kubeconfig` will be updated with their Kubernetes credentials.
 
     For more information on integrating Teleport with Okta, please see the
     [Okta integration guide](ssh_okta.md).
-
-    For more information on integrating Teleport with Okta, please see the [Okta  integration guide](ssh_okta.md).
 

--- a/docs/4.3/kubernetes_ssh.md
+++ b/docs/4.3/kubernetes_ssh.md
@@ -132,7 +132,7 @@ configured. In this guide we'll look at two common configurations:
 ## Kubernetes Groups and Users
 
 Teleport provides support for Kubernetes Group `kubernetes_groups: ["system:masters"]` 
-and Kubernetes Users, using `kubernetes_users: ['IAM#barent', 'IAM#jane']`. If a Kubernetes
+and Kubernetes Users, using `kubernetes_users: ['barent', 'jane']`. If a Kubernetes
 user isn't set the user will impersonate themselves. 
 
 ### Github Auth
@@ -167,7 +167,7 @@ spec:
       kubernetes_groups: ["system:masters"]
       # Optional: If not set users will imperonsate themseleves. 
       # impersonate a kubernetes user with IAM prefix
-      kubernetes_users: ['IAM#barent', 'IAM#jane']
+      kubernetes_users: ['barent', 'jane']
 
 ```
 To obtain client ID and client secret from Github, please follow [Github documentation](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) on how to create and register an OAuth app. Be sure to set the "Authorization callback URL" to the same value as redirect_url in the resource spec.


### PR DESCRIPTION
Fix for https://github.com/gravitational/teleport/issues/3421 

RP is against `docs/4.3-base`. 