### PR TITLE
Fix staticcheck findings, part 1

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1089,7 +1089,7 @@ func (s *IntSuite) TestTwoClustersTunnel(c *check.C) {
 
 		// wait for both sites to see each other via their reverse tunnels (for up to 10 seconds)
 		abortTime := time.Now().Add(time.Second * 10)
-		for len(b.Tunnel.GetSites()) < 2 && len(b.Tunnel.GetSites()) < 2 {
+		for len(a.Tunnel.GetSites()) < 2 && len(b.Tunnel.GetSites()) < 2 {
 			time.Sleep(time.Millisecond * 200)
 			if time.Now().After(abortTime) {
 				c.Fatalf("Two clusters do not see each other: tunnels are not working.")
@@ -1423,7 +1423,7 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 
 	// wait for both sites to see each other via their reverse tunnels (for up to 10 seconds)
 	abortTime := time.Now().Add(time.Second * 10)
-	for len(main.Tunnel.GetSites()) < 2 && len(main.Tunnel.GetSites()) < 2 {
+	for len(main.Tunnel.GetSites()) < 2 && len(aux.Tunnel.GetSites()) < 2 {
 		time.Sleep(time.Millisecond * 2000)
 		if time.Now().After(abortTime) {
 			c.Fatalf("two clusters do not see each other: tunnels are not working")
@@ -1627,6 +1627,7 @@ func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
 			Logins: []string{"superuser"},
 		},
 	})
+	c.Assert(err, check.IsNil)
 
 	main.AddUserWithRole(username, devsRole, adminsRole)
 
@@ -1688,7 +1689,7 @@ func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
 
 	// wait for both sites to see each other via their reverse tunnels (for up to 10 seconds)
 	abortTime := time.Now().Add(time.Second * 10)
-	for len(main.Tunnel.GetSites()) < 2 && len(main.Tunnel.GetSites()) < 2 {
+	for len(main.Tunnel.GetSites()) < 2 && len(aux.Tunnel.GetSites()) < 2 {
 		time.Sleep(time.Millisecond * 2000)
 		if time.Now().After(abortTime) {
 			c.Fatalf("two clusters do not see each other: tunnels are not working")
@@ -1892,7 +1893,7 @@ func (s *IntSuite) TestTrustedTunnelNode(c *check.C) {
 
 	// wait for both sites to see each other via their reverse tunnels (for up to 10 seconds)
 	abortTime := time.Now().Add(time.Second * 10)
-	for len(main.Tunnel.GetSites()) < 2 && len(main.Tunnel.GetSites()) < 2 {
+	for len(main.Tunnel.GetSites()) < 2 && len(aux.Tunnel.GetSites()) < 2 {
 		time.Sleep(time.Millisecond * 2000)
 		if time.Now().After(abortTime) {
 			c.Fatalf("two clusters do not see each other: tunnels are not working")
@@ -2182,7 +2183,7 @@ func (s *IntSuite) TestDiscovery(c *check.C) {
 	waitForActiveTunnelConnections(c, secondProxy, "cluster-remote", 1)
 
 	// Requests going via main proxy should fail.
-	output, err = runCommand(main, []string{"echo", "hello world"}, cfg, 1)
+	_, err = runCommand(main, []string{"echo", "hello world"}, cfg, 1)
 	c.Assert(err, check.NotNil)
 
 	// Requests going via second proxy should succeed.
@@ -2337,7 +2338,7 @@ func (s *IntSuite) TestDiscoveryNode(c *check.C) {
 	output, err = runCommand(main, []string{"echo", "hello world"}, cfg, 1)
 	c.Assert(err, check.IsNil)
 	c.Assert(output, check.Equals, "hello world\n")
-	output, err = runCommand(main, []string{"echo", "hello world"}, cfgProxy, 1)
+	_, err = runCommand(main, []string{"echo", "hello world"}, cfgProxy, 1)
 	c.Assert(err, check.NotNil)
 
 	// Add second proxy to LB, both should have a connection.

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -158,6 +158,7 @@ func (s *KubeSuite) TestKubeExec(c *check.C) {
 			KubeUsers:  []string{"alice@example.com"},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	t.AddUserWithRole(username, role)
 
 	err = t.CreateEx(nil, tconf)
@@ -329,6 +330,7 @@ func (s *KubeSuite) TestKubeDeny(c *check.C) {
 			KubeUsers:  []string{"alice@example.com"},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	t.AddUserWithRole(username, role)
 
 	err = t.CreateEx(nil, tconf)
@@ -369,6 +371,7 @@ func (s *KubeSuite) TestKubePortForward(c *check.C) {
 			KubeGroups: []string{teleport.KubeSystemMasters},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	t.AddUserWithRole(username, role)
 
 	err = t.CreateEx(nil, tconf)
@@ -386,6 +389,7 @@ func (s *KubeSuite) TestKubePortForward(c *check.C) {
 	pods, err := s.CoreV1().Pods(kubeSystemNamespace).List(metav1.ListOptions{
 		LabelSelector: kubeDNSLabels.AsSelector().String(),
 	})
+	c.Assert(err, check.IsNil)
 	c.Assert(len(pods.Items), check.Not(check.Equals), int(0))
 
 	pod := pods.Items[0]
@@ -468,6 +472,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 			KubeGroups: []string{teleport.KubeSystemMasters},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	main.AddUserWithRole(username, mainRole)
 
 	clusterAux := "cluster-aux"
@@ -545,7 +550,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 
 	// wait for both sites to see each other via their reverse tunnels (for up to 10 seconds)
 	abortTime := time.Now().Add(time.Second * 10)
-	for len(main.Tunnel.GetSites()) < 2 && len(main.Tunnel.GetSites()) < 2 {
+	for len(main.Tunnel.GetSites()) < 2 && len(aux.Tunnel.GetSites()) < 2 {
 		time.Sleep(time.Millisecond * 2000)
 		if time.Now().After(abortTime) {
 			c.Fatalf("two clusters do not see each other: tunnels are not working")
@@ -579,6 +584,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 	pods, err := proxyClient.CoreV1().Pods(kubeSystemNamespace).List(metav1.ListOptions{
 		LabelSelector: kubeDNSLabels.AsSelector().String(),
 	})
+	c.Assert(err, check.IsNil)
 	c.Assert(len(pods.Items), check.Not(check.Equals), int(0))
 
 	// Exec through proxy and collect output
@@ -730,6 +736,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 			KubeGroups: []string{teleport.KubeSystemMasters},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	main.AddUserWithRole(username, mainRole)
 
 	clusterAux := "cluster-aux"
@@ -811,7 +818,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 
 	// wait for both sites to see each other via their reverse tunnels (for up to 10 seconds)
 	abortTime := time.Now().Add(time.Second * 10)
-	for len(main.Tunnel.GetSites()) < 2 && len(main.Tunnel.GetSites()) < 2 {
+	for len(main.Tunnel.GetSites()) < 2 && len(aux.Tunnel.GetSites()) < 2 {
 		time.Sleep(time.Millisecond * 2000)
 		if time.Now().After(abortTime) {
 			c.Fatalf("two clusters do not see each other: tunnels are not working")
@@ -840,6 +847,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 	pods, err := proxyClient.CoreV1().Pods(kubeSystemNamespace).List(metav1.ListOptions{
 		LabelSelector: kubeDNSLabels.AsSelector().String(),
 	})
+	c.Assert(err, check.IsNil)
 	c.Assert(len(pods.Items), check.Not(check.Equals), int(0))
 
 	// Exec through proxy and collect output
@@ -1012,6 +1020,7 @@ func (s *KubeSuite) runKubeDisconnectTest(c *check.C, tc disconnectTestCase) {
 			KubeGroups: []string{teleport.KubeSystemMasters},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	t.AddUserWithRole(username, role)
 
 	err = t.CreateEx(nil, tconf)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -2467,6 +2467,8 @@ func message(msg string) map[string]interface{} {
 	return map[string]interface{}{"message": msg}
 }
 
+type contextParamsKey string
+
 // contextParams is the name of of the key that holds httprouter.Params in
 // a context.
-const contextParams = "params"
+const contextParams contextParamsKey = "params"

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -116,7 +116,7 @@ func (s *AuthSuite) TestSessions(c *C) {
 	user := "user1"
 	pass := []byte("abc123")
 
-	ws, err := s.a.AuthenticateWebUser(AuthenticateUserRequest{
+	_, err := s.a.AuthenticateWebUser(AuthenticateUserRequest{
 		Username: user,
 		Pass:     &PassCreds{Password: pass},
 	})
@@ -128,7 +128,7 @@ func (s *AuthSuite) TestSessions(c *C) {
 	err = s.a.UpsertPassword(user, pass)
 	c.Assert(err, IsNil)
 
-	ws, err = s.a.AuthenticateWebUser(AuthenticateUserRequest{
+	ws, err := s.a.AuthenticateWebUser(AuthenticateUserRequest{
 		Username: user,
 		Pass:     &PassCreds{Password: pass},
 	})
@@ -157,7 +157,7 @@ func (s *AuthSuite) TestUserLock(c *C) {
 	user := "user1"
 	pass := []byte("abc123")
 
-	ws, err := s.a.AuthenticateWebUser(AuthenticateUserRequest{
+	_, err := s.a.AuthenticateWebUser(AuthenticateUserRequest{
 		Username: user,
 		Pass:     &PassCreds{Password: pass},
 	})
@@ -170,7 +170,7 @@ func (s *AuthSuite) TestUserLock(c *C) {
 	c.Assert(err, IsNil)
 
 	// successful log in
-	ws, err = s.a.AuthenticateWebUser(AuthenticateUserRequest{
+	ws, err := s.a.AuthenticateWebUser(AuthenticateUserRequest{
 		Username: user,
 		Pass:     &PassCreds{Password: pass},
 	})
@@ -239,9 +239,6 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 	c.Assert(keys, IsNil)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `node "bad-node-name" \[bad-host-id\] can not join the cluster, the token does not allow "Proxy" role`)
-
-	roles, err = s.a.ValidateToken(tok)
-	c.Assert(err, IsNil)
 
 	// generate predefined token
 	customToken := "custom-token"

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -854,15 +854,17 @@ func (a *AuthWithRoles) Ping(ctx context.Context) (proto.PingResponse, error) {
 	}, nil
 }
 
+type accessRequestContextKey string
+
 // withUpdateBy creates a child context with the AccessRequestUpdateBy
 // value set.  Expected by AuthServer.SetAccessRequestState.
 func withUpdateBy(ctx context.Context, user string) context.Context {
-	return context.WithValue(ctx, events.AccessRequestUpdateBy, user)
+	return context.WithValue(ctx, accessRequestContextKey(events.AccessRequestUpdateBy), user)
 }
 
 // getUpdateBy attempts to load the context value AccessRequestUpdateBy.
 func getUpdateBy(ctx context.Context) (string, error) {
-	updateBy, ok := ctx.Value(events.AccessRequestUpdateBy).(string)
+	updateBy, ok := ctx.Value(accessRequestContextKey(events.AccessRequestUpdateBy)).(string)
 	if !ok || updateBy == "" {
 		return "", trace.BadParameter("missing value %q", events.AccessRequestUpdateBy)
 	}
@@ -873,13 +875,13 @@ func getUpdateBy(ctx context.Context) (string, error) {
 // value set.  Optionally used by AuthServer.SetAccessRequestState to log
 // a delegating identity.
 func WithDelegator(ctx context.Context, delegator string) context.Context {
-	return context.WithValue(ctx, events.AccessRequestDelegator, delegator)
+	return context.WithValue(ctx, accessRequestContextKey(events.AccessRequestDelegator), delegator)
 }
 
 // getDelegator attempts to load the context value AccessRequestDelegator,
 // returning the empty string if no value was found.
 func getDelegator(ctx context.Context) string {
-	delegator, ok := ctx.Value(events.AccessRequestDelegator).(string)
+	delegator, ok := ctx.Value(accessRequestContextKey(events.AccessRequestDelegator)).(string)
 	if !ok {
 		return ""
 	}

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -228,6 +228,7 @@ func (s *PasswordSuite) TestChangePasswordWithTokenOTP(c *C) {
 	token, err := s.a.CreateResetPasswordToken(context.TODO(), CreateResetPasswordTokenRequest{
 		Name: username,
 	})
+	c.Assert(err, IsNil)
 
 	secrets, err := s.a.RotateResetPasswordTokenSecrets(context.TODO(), token.GetName())
 	c.Assert(err, IsNil)

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -483,8 +483,10 @@ func contextForLocalUser(u LocalUser, identity services.UserGetter, access servi
 	}, nil
 }
 
+type contextUserKey string
+
 // ContextUser is a user set in the context of the request
-const ContextUser = "teleport-user"
+const ContextUser contextUserKey = "teleport-user"
 
 // LocalUser is a local user
 type LocalUser struct {

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -295,7 +295,7 @@ func (a *AuthServer) ValidateSAMLResponse(samlResponse string) (*SAMLAuthRespons
 		events.AuthAttemptSuccess: true,
 		events.LoginMethod:        events.LoginMethodSAML,
 	}
-	if re != nil && re.attributeStatements != nil {
+	if re.attributeStatements != nil {
 		fields[events.IdentityAttributes] = re.attributeStatements
 	}
 	a.EmitAuditEvent(events.UserSSOLogin, fields)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -107,6 +107,7 @@ func (s *TLSSuite) TestRemoteBuiltinRole(c *check.C) {
 
 	// after trust is established, things are good
 	err = s.server.AuthServer.Trust(remoteServer, nil)
+	c.Assert(err, check.IsNil)
 
 	_, err = remoteProxy.GetNodes(defaults.Namespace, services.SkipValidation())
 	c.Assert(err, check.IsNil)
@@ -193,6 +194,7 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 
 	// after trust is established, things are good
 	err = s.server.AuthServer.Trust(remoteServer, nil)
+	c.Assert(err, check.IsNil)
 
 	remoteProxy, err := remoteServer.NewRemoteClient(
 		TestBuiltin(teleport.RoleProxy), s.server.Addr(), certPool)
@@ -357,7 +359,7 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// new clients work as well
-	newProxy, err := s.server.NewClient(TestBuiltin(teleport.RoleProxy))
+	_, err = s.server.NewClient(TestBuiltin(teleport.RoleProxy))
 	c.Assert(err, check.IsNil)
 
 	// advance rotation by clock
@@ -377,7 +379,7 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// new clients work as well
-	newProxy, err = s.server.NewClient(TestBuiltin(teleport.RoleProxy))
+	newProxy, err := s.server.NewClient(TestBuiltin(teleport.RoleProxy))
 	c.Assert(err, check.IsNil)
 
 	_, err = newProxy.GetNodes(defaults.Namespace, services.SkipValidation())
@@ -386,6 +388,7 @@ func (s *TLSSuite) TestAutoRotation(c *check.C) {
 	// complete rotation - advance rotation by clock
 	clock.Advance(gracePeriod/3 + time.Minute)
 	err = s.server.Auth().autoRotateCertAuthorities()
+	c.Assert(err, check.IsNil)
 	ca, err = s.server.Auth().GetCertAuthority(services.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       services.HostCA,
@@ -1072,6 +1075,7 @@ func (s *TLSSuite) TestSharedSessions(c *check.C) {
 	// emit two events: "one" and "two" for this session, and event "three"
 	// for some other session
 	err = os.MkdirAll(filepath.Join(uploadDir, "upload", "sessions", defaults.Namespace), 0755)
+	c.Assert(err, check.IsNil)
 	forwarder, err := events.NewForwarder(events.ForwarderConfig{
 		Namespace:      defaults.Namespace,
 		SessionID:      sess.ID,
@@ -1261,6 +1265,7 @@ func (s *TLSSuite) TestWebSessions(c *check.C) {
 	fixtures.ExpectAccessDenied(c, err)
 
 	err = clt.UpsertPassword(user, pass)
+	c.Assert(err, check.IsNil)
 
 	// success with password set up
 	ws, err := proxy.AuthenticateWebUser(req)
@@ -1694,6 +1699,7 @@ func (s *TLSSuite) TestGenerateCerts(c *check.C) {
 		Expires:   time.Now().Add(1 * time.Hour).UTC(),
 		Format:    teleport.CertificateFormatStandard,
 	})
+	c.Assert(err, check.IsNil)
 	parsedCert, _ = parseCert(userCerts.SSH)
 
 	// user should get agent forwarding

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -160,7 +160,7 @@ func (c *NodeCommand) Invite(client auth.ClientI) error {
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal token")
 		}
-		fmt.Printf(string(out))
+		fmt.Print(string(out))
 	}
 	return nil
 }

--- a/tool/tctl/common/status_command.go
+++ b/tool/tctl/common/status_command.go
@@ -107,7 +107,7 @@ func (c *StatusCommand) Status(client auth.ClientI) error {
 		table.AddRow([]string{"CA pin", caPin})
 		return table.AsBuffer().String()
 	}
-	fmt.Printf(view())
+	fmt.Print(view())
 
 	// in debug mode, output mode of remote certificate authorities
 	if c.config.Debug {
@@ -123,7 +123,7 @@ func (c *StatusCommand) Status(client auth.ClientI) error {
 			}
 			return "Remote clusters\n\n" + table.AsBuffer().String()
 		}
-		fmt.Printf(view())
+		fmt.Print(view())
 	}
 	return nil
 }

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -198,13 +198,13 @@ func (c *TokenCommand) List(client auth.ClientI) error {
 			}
 			return table.AsBuffer().String()
 		}
-		fmt.Printf(tokensView())
+		fmt.Print(tokensView())
 	} else {
 		data, err := json.MarshalIndent(tokens, "", "  ")
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal tokens")
 		}
-		fmt.Printf(string(data))
+		fmt.Print(string(data))
 	}
 	return nil
 }

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -245,7 +245,7 @@ func printTokenAsJSON(token services.ResetPasswordToken) error {
 	if err != nil {
 		return trace.Wrap(err, "failed to marshal reset password token")
 	}
-	fmt.Printf(string(out))
+	fmt.Print(string(out))
 	return nil
 }
 
@@ -291,7 +291,7 @@ func (u *UserCommand) List(client auth.ClientI) error {
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal users")
 		}
-		fmt.Printf(string(out))
+		fmt.Print(string(out))
 	}
 	return nil
 }

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -87,6 +87,7 @@ func (s *MainTestSuite) TestRolesFlag(c *check.C) {
 	c.Assert(conf.SSH.Enabled, check.Equals, true)
 	c.Assert(conf.Auth.Enabled, check.Equals, false)
 	c.Assert(conf.Proxy.Enabled, check.Equals, false)
+	c.Assert(cmd, check.Equals, "start")
 
 	cmd, conf = Run(Options{
 		Args:     []string{"start", "--roles=proxy"},
@@ -95,6 +96,7 @@ func (s *MainTestSuite) TestRolesFlag(c *check.C) {
 	c.Assert(conf.SSH.Enabled, check.Equals, false)
 	c.Assert(conf.Auth.Enabled, check.Equals, false)
 	c.Assert(conf.Proxy.Enabled, check.Equals, true)
+	c.Assert(cmd, check.Equals, "start")
 
 	cmd, conf = Run(Options{
 		Args:     []string{"start", "--roles=auth"},

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -167,7 +167,7 @@ type CLIConf struct {
 
 func main() {
 	cmdLineOrig := os.Args[1:]
-	cmdLine := []string{}
+	var cmdLine []string
 
 	// lets see: if the executable name is 'ssh' or 'scp' we convert
 	// that to "tsh ssh" or "tsh scp"


### PR DESCRIPTION
Fixing staticcheck findings in:
- `integration/...`
- `tool/...`
- `lib/auth/...`

Most of these are unhandled errors in tests and using plain strings as `context.WithValue` keys.
See individual commit messages for what findings were fixed.

There re still ~70 left in other packages, so not enabling the linter in Makefile yet.

Updates #3551