### PR TITLE
Use random ports for loadbalancer and multiplexer tests

### DIFF
--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -276,10 +276,7 @@ func (s *MuxSuite) TestTimeout(c *check.C) {
 // TestUnknownProtocol make sure that multiplexer closes connection
 // with unknown protocol
 func (s *MuxSuite) TestUnknownProtocol(c *check.C) {
-	ports, err := utils.GetFreeTCPPorts(1)
-	c.Assert(err, check.IsNil)
-
-	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", ports[0]))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, check.IsNil)
 
 	mux, err := New(Config{

--- a/lib/utils/loadbalancer.go
+++ b/lib/utils/loadbalancer.go
@@ -271,3 +271,13 @@ func (l *LoadBalancer) forward(conn net.Conn) error {
 
 	return lastErr
 }
+
+// Addr returns the listening address of this LoadBalancer.
+func (l *LoadBalancer) Addr() net.Addr {
+	l.Lock()
+	defer l.Unlock()
+	if l.listener == nil {
+		return nil
+	}
+	return l.listener.Addr()
+}

--- a/lib/utils/loadbalancer_test.go
+++ b/lib/utils/loadbalancer_test.go
@@ -27,6 +27,8 @@ import (
 	"gopkg.in/check.v1"
 )
 
+var localAddrRandomPort = *MustParseAddr("127.0.0.1:0")
+
 type LBSuite struct {
 }
 
@@ -42,19 +44,14 @@ func (s *LBSuite) TestSingleBackendLB(c *check.C) {
 	}))
 	defer backend1.Close()
 
-	ports, err := GetFreeTCPPorts(1)
-	c.Assert(err, check.IsNil)
-
-	frontend := localAddr(ports[0])
-
-	lb, err := NewLoadBalancer(context.TODO(), frontend, urlToNetAddr(backend1.URL))
+	lb, err := NewLoadBalancer(context.TODO(), localAddrRandomPort, urlToNetAddr(backend1.URL))
 	c.Assert(err, check.IsNil)
 	err = lb.Listen()
 	c.Assert(err, check.IsNil)
 	go lb.Serve()
 	defer lb.Close()
 
-	out, err := Roundtrip(frontend.String())
+	out, err := Roundtrip(lb.Addr().String())
 	c.Assert(err, check.IsNil)
 	c.Assert(out, check.Equals, "backend 1")
 }
@@ -72,12 +69,7 @@ func (s *LBSuite) TestTwoBackendsLB(c *check.C) {
 
 	backend1Addr, backend2Addr := urlToNetAddr(backend1.URL), urlToNetAddr(backend2.URL)
 
-	ports, err := GetFreeTCPPorts(1)
-	c.Assert(err, check.IsNil)
-
-	frontend := localAddr(ports[0])
-
-	lb, err := NewLoadBalancer(context.TODO(), frontend)
+	lb, err := NewLoadBalancer(context.TODO(), localAddrRandomPort)
 	c.Assert(err, check.IsNil)
 	err = lb.Listen()
 	c.Assert(err, check.IsNil)
@@ -85,16 +77,16 @@ func (s *LBSuite) TestTwoBackendsLB(c *check.C) {
 	defer lb.Close()
 
 	// no endpoints
-	_, err = Roundtrip(frontend.String())
+	_, err = Roundtrip(lb.Addr().String())
 	c.Assert(err, check.NotNil)
 
 	lb.AddBackend(backend1Addr)
-	out, err := Roundtrip(frontend.String())
+	out, err := Roundtrip(lb.Addr().String())
 	c.Assert(err, check.IsNil)
 	c.Assert(out, check.Equals, "backend 1")
 
 	lb.AddBackend(backend2Addr)
-	out, err = Roundtrip(frontend.String())
+	out, err = Roundtrip(lb.Addr().String())
 	c.Assert(err, check.IsNil)
 	c.Assert(out, check.Equals, "backend 2")
 }
@@ -112,12 +104,7 @@ func (s *LBSuite) TestOneFailingBackend(c *check.C) {
 
 	backend1Addr, backend2Addr := urlToNetAddr(backend1.URL), urlToNetAddr(backend2.URL)
 
-	ports, err := GetFreeTCPPorts(1)
-	c.Assert(err, check.IsNil)
-
-	frontend := localAddr(ports[0])
-
-	lb, err := NewLoadBalancer(context.TODO(), frontend)
+	lb, err := NewLoadBalancer(context.TODO(), localAddrRandomPort)
 	c.Assert(err, check.IsNil)
 	err = lb.Listen()
 	c.Assert(err, check.IsNil)
@@ -127,14 +114,14 @@ func (s *LBSuite) TestOneFailingBackend(c *check.C) {
 	lb.AddBackend(backend1Addr)
 	lb.AddBackend(backend2Addr)
 
-	out, err := Roundtrip(frontend.String())
+	out, err := Roundtrip(lb.Addr().String())
 	c.Assert(err, check.IsNil)
 	c.Assert(out, check.Equals, "backend 1")
 
-	_, err = Roundtrip(frontend.String())
+	_, err = Roundtrip(lb.Addr().String())
 	c.Assert(err, check.NotNil)
 
-	out, err = Roundtrip(frontend.String())
+	out, err = Roundtrip(lb.Addr().String())
 	c.Assert(err, check.IsNil)
 	c.Assert(out, check.Equals, "backend 1")
 }
@@ -145,19 +132,14 @@ func (s *LBSuite) TestClose(c *check.C) {
 	}))
 	defer backend1.Close()
 
-	ports, err := GetFreeTCPPorts(1)
-	c.Assert(err, check.IsNil)
-
-	frontend := localAddr(ports[0])
-
-	lb, err := NewLoadBalancer(context.TODO(), frontend, urlToNetAddr(backend1.URL))
+	lb, err := NewLoadBalancer(context.TODO(), localAddrRandomPort, urlToNetAddr(backend1.URL))
 	c.Assert(err, check.IsNil)
 	err = lb.Listen()
 	c.Assert(err, check.IsNil)
 	go lb.Serve()
 	defer lb.Close()
 
-	out, err := Roundtrip(frontend.String())
+	out, err := Roundtrip(lb.Addr().String())
 	c.Assert(err, check.IsNil)
 	c.Assert(out, check.Equals, "backend 1")
 
@@ -168,7 +150,7 @@ func (s *LBSuite) TestClose(c *check.C) {
 	lb.Wait()
 
 	// requests are failing
-	out, err = Roundtrip(frontend.String())
+	out, err = Roundtrip(lb.Addr().String())
 	c.Assert(err, check.NotNil, check.Commentf("output: %v, err: %v", string(out), err))
 }
 
@@ -178,20 +160,15 @@ func (s *LBSuite) TestDropConnections(c *check.C) {
 	}))
 	defer backend1.Close()
 
-	ports, err := GetFreeTCPPorts(1)
-	c.Assert(err, check.IsNil)
-
-	frontend := localAddr(ports[0])
-
 	backendAddr := urlToNetAddr(backend1.URL)
-	lb, err := NewLoadBalancer(context.TODO(), frontend, backendAddr)
+	lb, err := NewLoadBalancer(context.TODO(), localAddrRandomPort, backendAddr)
 	c.Assert(err, check.IsNil)
 	err = lb.Listen()
 	c.Assert(err, check.IsNil)
 	go lb.Serve()
 	defer lb.Close()
 
-	conn, err := net.Dial("tcp", frontend.String())
+	conn, err := net.Dial("tcp", lb.Addr().String())
 	c.Assert(err, check.IsNil)
 	defer conn.Close()
 


### PR DESCRIPTION
`utils.GetFreeTCPPorts` causes conflicts when multiple unit tests (for
different packages) run in parallel. This results in flakiness,
especially when running `make test`.

A few other packages use `utils.GetFreeTCPPorts`, but they will take
more work to migrate.