### PR TITLE
Remove failing CentOS 6 build steps

### DIFF
--- a/build.assets/Dockerfile-centos6
+++ b/build.assets/Dockerfile-centos6
@@ -18,12 +18,6 @@ COPY pam/teleport-success /etc/pam.d
 
 RUN yum makecache fast && yum -y install gcc pam-devel glibc-devel net-tools tree git zip && yum clean all
 
-# Install GCC 6 through devtools. Newer version of GCC is needed for gobpf
-# which uses __has_include.
-RUN yum -y install centos-release-scl && yum -y install devtoolset-6
-ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc
-ENV CXX=/opt/rh/devtoolset-6/root/usr/bin/g++
-
 RUN (groupadd jenkins --gid=$GID -o && useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
      mkdir -p /var/lib/teleport && chown -R jenkins /var/lib/teleport)
 

--- a/build.assets/Dockerfile-centos6-fips
+++ b/build.assets/Dockerfile-centos6-fips
@@ -18,12 +18,6 @@ COPY pam/teleport-success /etc/pam.d
 
 RUN yum makecache fast && yum -y install gcc pam-devel glibc-devel net-tools tree git zip && yum clean all
 
-# Install GCC 6 through devtools. Newer version of GCC is needed for gobpf
-# which uses __has_include.
-RUN yum -y install centos-release-scl && yum -y install devtoolset-6
-ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc
-ENV CXX=/opt/rh/devtoolset-6/root/usr/bin/g++
-
 RUN (groupadd jenkins --gid=$GID -o && useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
      mkdir -p /var/lib/teleport && chown -R jenkins /var/lib/teleport)
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -201,7 +201,7 @@ release-fips: bbox-fips
 #
 .PHONY:release-centos6
 release-centos6: bbox-centos6
-	docker run $(DOCKERFLAGS) $(BCCFLAGS) -i $(NOROOT) $(BBOXCENTOS6) \
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOXCENTOS6) \
 		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME)
 
 #
@@ -210,7 +210,7 @@ release-centos6: bbox-centos6
 #
 .PHONY:release-centos6-fips
 release-centos6-fips: bbox-centos6-fips
-	docker run $(DOCKERFLAGS) $(BCCFLAGS) -i $(NOROOT) $(BBOXCENTOS6FIPS) \
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOXCENTOS6FIPS) \
 		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) FIPS=yes
 
 #


### PR DESCRIPTION
This basically reverts the `Dockerfile` and `Makefile` changes from #3279 due to package dependency failures.