### PR TITLE
Fix trusted cluster bootstrapping.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -249,13 +249,15 @@ func (a *AuthServer) runPeriodicOperations() {
 		case <-a.closeCtx.Done():
 			return
 		case <-ticker.C:
-			err := a.autoRotateCertAuthorities()
-			if err != nil {
+			if err := a.autoRotateCertAuthorities(); err != nil {
 				if trace.IsCompareFailed(err) {
 					log.Debugf("Cert authority has been updated concurrently: %v.", err)
 				} else {
 					log.Errorf("Failed to perform cert rotation check: %v.", err)
 				}
+			}
+			if err := a.ensureTrustedClusters(); err != nil {
+				log.Errorf("Periodic trusted cluster ops failr: %v", err)
 			}
 		}
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -256,7 +256,7 @@ func (a *AuthServer) runPeriodicOperations() {
 					log.Errorf("Failed to perform cert rotation check: %v.", err)
 				}
 			}
-			if err := a.ensureTrustedClusters(); err != nil {
+			if err := a.EnsureTrustedClusters(); err != nil {
 				log.Errorf("Periodic trusted cluster ops failure: %v", err)
 			}
 		}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -257,7 +257,7 @@ func (a *AuthServer) runPeriodicOperations() {
 				}
 			}
 			if err := a.ensureTrustedClusters(); err != nil {
-				log.Errorf("Periodic trusted cluster ops failr: %v", err)
+				log.Errorf("Periodic trusted cluster ops failure: %v", err)
 			}
 		}
 	}

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -148,7 +148,7 @@ func (a *AuthServer) UpsertTrustedCluster(trustedCluster services.TrustedCluster
 }
 
 // ensureTrustedClusters attempts to ensure that all currently registered
-// trsuted clusters configurations have been correctly applied.
+// trusted clusters configurations have been correctly applied.
 func (a *AuthServer) ensureTrustedClusters() error {
 	tcs, err := a.GetTrustedClusters()
 	if err != nil {
@@ -168,7 +168,7 @@ func (a *AuthServer) ensureTrustedClusters() error {
 	return trace.NewAggregate(errs...)
 }
 
-// ensureEnabled ensures that the supplied trsuted cluster has its
+// ensureEnabled ensures that the supplied trusted cluster has its
 // associated state enabled.  This function will automatically establish
 // trust if trust was not previously established.
 func (a *AuthServer) ensureEnabled(tc services.TrustedCluster) error {
@@ -177,7 +177,7 @@ func (a *AuthServer) ensureEnabled(tc services.TrustedCluster) error {
 		return trace.Wrap(err)
 	}
 	if trace.IsNotFound(err) {
-		// if we could not find CAs to activate, they are either aleardy activated,
+		// if we could not find CAs to activate, they are either already activated,
 		// or trust has not yet been established.
 		cas, err := a.getCertAuthorities(tc)
 		if err != nil && !trace.IsNotFound(err) {

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -139,7 +139,7 @@ func (s *CA) ActivateCertAuthority(id services.CertAuthID) error {
 	item, err := s.Get(context.TODO(), backend.Key(authoritiesPrefix, deactivatedPrefix, string(id.Type), id.DomainName))
 	if err != nil {
 		if trace.IsNotFound(err) {
-			return trace.BadParameter("can not activate cert authority %q which has not been deactivated", id.DomainName)
+			return trace.NotFound("no inactive CA matching %q", id.DomainName)
 		}
 		return trace.Wrap(err)
 	}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -433,7 +433,24 @@ func init() {
 		}
 		return rsc, nil
 	})
-
+	RegisterResourceMarshaler(KindReverseTunnel, func(r Resource, opts ...MarshalOption) ([]byte, error) {
+		rsc, ok := r.(ReverseTunnel)
+		if !ok {
+			return nil, trace.BadParameter("expected ReverseTunnel, got %T", r)
+		}
+		raw, err := GetReverseTunnelMarshaler().MarshalReverseTunnel(rsc, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return raw, nil
+	})
+	RegisterResourceUnmarshaler(KindReverseTunnel, func(b []byte, opts ...MarshalOption) (Resource, error) {
+		rsc, err := GetReverseTunnelMarshaler().UnmarshalReverseTunnel(b, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return rsc, nil
+	})
 	RegisterResourceMarshaler(KindGithubConnector, func(r Resource, opts ...MarshalOption) ([]byte, error) {
 		rsc, ok := r.(GithubConnector)
 		if !ok {


### PR DESCRIPTION
Fixes trusted cluster support when bootstrapping a cluster from the output of a `tctl get all` by adding the `ReverseTunnel` resource to the set of exported resources.  Auth servers automatically generate corresponding reversetunnel entries when adding trusted clusters, but the `--bootstrap` flag bypasses this logic, making it necessary for the resource to be included explicitly.

Fixes #3642 

~*NOTE*: In an ideal world, this shouldn't be necessary.  The existence of the `TrustedCluster` configuration object should *imply* the need for the reversetunnel to exist, and the auth server should be capable of recognizing and fixing this issue (basically, it should behave in a level-triggered manner, rather than an edge-triggered manner).  Achieving this will require some additional tweaks to how we handle `TrustedCluster` configuration.~

*EDIT*: Updated `AuthServer`'s periodic operations to include a call to the new `EnsureTrustedCluster` method which iterates over all `TrustedCluster` configuration objects and attempts to ensure that they are correctly applied.  This change makes it possible to supply *hand written* `TrustedCluster` configuration objects to the `--bootstrap` flag, and also addresses some *potential* issues where teleport could wind up in a bad state due to errors occuring part-way through the application application of an updated `TrustedCluster` configuration object (e.g. by enabling the associated CAs, but failing to create the associated `ReverseTunnel` resource).