### PR TITLE
Fix golint warnings, part 2

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1545,7 +1545,7 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 // tryCreateTrustedCluster performs several attempts to create a trusted cluster,
 // retries on connection problems and access denied errors to let caches
 // propagate and services to start
-func tryCreateTrustedCluster(c *check.C, authServer *auth.AuthServer, trustedCluster services.TrustedCluster) {
+func tryCreateTrustedCluster(c *check.C, authServer *auth.Server, trustedCluster services.TrustedCluster) {
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v.", trustedCluster, i)
 		_, err := authServer.UpsertTrustedCluster(trustedCluster)
@@ -2422,7 +2422,7 @@ func waitForNodeCount(t *TeleInstance, clusterName string, count int) error {
 }
 
 // waitForTunnelConnections waits for remote tunnels connections
-func waitForTunnelConnections(c *check.C, authServer *auth.AuthServer, clusterName string, expectedCount int) {
+func waitForTunnelConnections(c *check.C, authServer *auth.Server, clusterName string, expectedCount int) {
 	var conns []services.TunnelConnection
 	for i := 0; i < 30; i++ {
 		conns, err := authServer.Presence.GetTunnelConnections(clusterName)

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -125,9 +125,9 @@ type AccessCache interface {
 	GetClusterName(opts ...services.MarshalOption) (services.ClusterName, error)
 }
 
-// AuthCache is a subset of the auth interface hanlding
-// access to the discovery API and static tokens
-type AuthCache interface {
+// Cache is a subset of the auth interface handling access to the discovery API
+// and static tokens
+type Cache interface {
 	ReadAccessPoint
 
 	// GetStaticTokens gets the list of static tokens used to provision nodes.

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -45,13 +45,13 @@ import (
 )
 
 type APIConfig struct {
-	AuthServer     *AuthServer
+	AuthServer     *Server
 	SessionService session.Service
 	AuditLog       events.IAuditLog
 	Authorizer     Authorizer
 }
 
-// APIServer implements http API server for AuthServer interface
+// APIServer implements http API server for Server interface
 type APIServer struct {
 	APIConfig
 	httprouter.Router
@@ -258,7 +258,7 @@ func (s *APIServer) withAuth(handler HandlerWithAuthFunc) httprouter.Handle {
 
 			return nil, trace.AccessDenied(accessDeniedMsg + "[00]")
 		}
-		auth := &AuthWithRoles{
+		auth := &serverWithRoles{
 			authServer: s.AuthServer,
 			user:       authContext.User,
 			checker:    authContext.Checker,

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -45,7 +45,7 @@ func TestAPI(t *testing.T) { TestingT(t) }
 
 type AuthSuite struct {
 	bk      backend.Backend
-	a       *AuthServer
+	a       *Server
 	dataDir string
 }
 
@@ -72,7 +72,7 @@ func (s *AuthSuite) SetUpTest(c *C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, IsNil)
 
 	// set cluster name
@@ -530,7 +530,7 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	authServer, err := NewAuthServer(authConfig)
+	authServer, err := NewServer(authConfig)
 	c.Assert(err, IsNil)
 
 	err = authServer.SetClusterName(clusterName)

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 type GithubSuite struct {
-	a *AuthServer
+	a *Server
 	b backend.Backend
 	c clockwork.FakeClock
 }
@@ -65,7 +65,7 @@ func (s *GithubSuite) SetUpSuite(c *check.C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, check.IsNil)
 }
 

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -92,7 +92,7 @@ type TestAuthServer struct {
 	// TestAuthServer config is configuration used for auth server setup
 	TestAuthServerConfig
 	// AuthServer is an auth server
-	AuthServer *AuthServer
+	AuthServer *Server
 	// AuditLog is an event audit log
 	AuditLog events.IAuditLog
 	// SessionLogger is a session logger
@@ -148,7 +148,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	srv.AuthServer, err = NewAuthServer(&InitConfig{
+	srv.AuthServer, err = NewServer(&InitConfig{
 		Backend:                srv.Backend,
 		Authority:              authority.New(),
 		Access:                 access,
@@ -243,7 +243,7 @@ func (a *TestAuthServer) GenerateUserCert(key []byte, username string, ttl time.
 
 // GenerateCertificate generates certificate for identity,
 // returns private public key pair
-func GenerateCertificate(authServer *AuthServer, identity TestIdentity) ([]byte, []byte, error) {
+func GenerateCertificate(authServer *Server, identity TestIdentity) ([]byte, []byte, error) {
 	switch id := identity.I.(type) {
 	case LocalUser:
 		user, err := authServer.GetUser(id.Username, false)
@@ -385,7 +385,7 @@ type TestTLSServerConfig struct {
 }
 
 // Auth returns auth server used by this TLS server
-func (t *TestTLSServer) Auth() *AuthServer {
+func (t *TestTLSServer) Auth() *Server {
 	return t.AuthServer.AuthServer
 }
 
@@ -447,7 +447,7 @@ func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	accessPoint, err := NewAdminAuthServer(srv.AuthServer.AuthServer, srv.AuthServer.SessionServer, srv.AuthServer.AuditLog)
+	accessPoint, err := newAdminAuthServer(srv.AuthServer.AuthServer, srv.AuthServer.SessionServer, srv.AuthServer.AuditLog)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -622,7 +622,7 @@ func (t *TestTLSServer) Stop() error {
 }
 
 // NewServerIdentity generates new server identity, used in tests
-func NewServerIdentity(clt *AuthServer, hostID string, role teleport.Role) (*Identity, error) {
+func NewServerIdentity(clt *Server, hostID string, role teleport.Role) (*Identity, error) {
 	keys, err := clt.GenerateServerKeys(GenerateServerKeysRequest{
 		HostID:   hostID,
 		NodeName: hostID,

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -140,8 +140,8 @@ type InitConfig struct {
 	CipherSuites []uint16
 }
 
-// Init instantiates and configures an instance of AuthServer
-func Init(cfg InitConfig, opts ...AuthServerOption) (*AuthServer, error) {
+// Init instantiates and configures an instance of Server
+func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	if cfg.DataDir == "" {
 		return nil, trace.BadParameter("DataDir: data dir can not be empty")
 	}
@@ -157,7 +157,7 @@ func Init(cfg InitConfig, opts ...AuthServerOption) (*AuthServer, error) {
 	defer backend.ReleaseLock(context.TODO(), cfg.Backend, domainName)
 
 	// check that user CA and host CA are present and set the certs if needed
-	asrv, err := NewAuthServer(&cfg, opts...)
+	asrv, err := NewServer(&cfg, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -432,7 +432,7 @@ func Init(cfg InitConfig, opts ...AuthServerOption) (*AuthServer, error) {
 	return asrv, nil
 }
 
-func migrateLegacyResources(cfg InitConfig, asrv *AuthServer) error {
+func migrateLegacyResources(cfg InitConfig, asrv *Server) error {
 	err := migrateRemoteClusters(asrv)
 	if err != nil {
 		return trace.Wrap(err)
@@ -448,7 +448,7 @@ func migrateLegacyResources(cfg InitConfig, asrv *AuthServer) error {
 
 // isFirstStart returns 'true' if the auth server is starting for the 1st time
 // on this server.
-func isFirstStart(authServer *AuthServer, cfg InitConfig) (bool, error) {
+func isFirstStart(authServer *Server, cfg InitConfig) (bool, error) {
 	// check if the CA exists?
 	_, err := authServer.GetCertAuthority(
 		services.CertAuthID{
@@ -501,7 +501,7 @@ func checkResourceConsistency(clusterName string, resources ...services.Resource
 }
 
 // GenerateIdentity generates identity for the auth server
-func GenerateIdentity(a *AuthServer, id IdentityID, additionalPrincipals, dnsNames []string) (*Identity, error) {
+func GenerateIdentity(a *Server, id IdentityID, additionalPrincipals, dnsNames []string) (*Identity, error) {
 	keys, err := a.GenerateServerKeys(GenerateServerKeysRequest{
 		HostID:               id.HostUUID,
 		NodeName:             id.NodeName,
@@ -865,7 +865,7 @@ func ReadLocalIdentity(dataDir string, id IdentityID) (*Identity, error) {
 // This migration adds remote cluster resource migrating from 2.5.0
 // where the presence of remote cluster was identified only by presence
 // of host certificate authority with cluster name not equal local cluster name
-func migrateRemoteClusters(asrv *AuthServer) error {
+func migrateRemoteClusters(asrv *Server) error {
 	clusterName, err := asrv.GetClusterName()
 	if err != nil {
 		return trace.Wrap(err)
@@ -917,7 +917,7 @@ func migrateRemoteClusters(asrv *AuthServer) error {
 
 // DELETE IN: 4.3.0.
 // migrateRoleOptions adds the "enhanced_recording" option to all roles.
-func migrateRoleOptions(asrv *AuthServer) error {
+func migrateRoleOptions(asrv *Server) error {
 	roles, err := asrv.GetRoles()
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -164,7 +164,7 @@ func (s *AuthInitSuite) TestBadIdentity(c *C) {
 	c.Assert(trace.IsBadParameter(err), Equals, true, Commentf("%#v", err))
 }
 
-// TestAuthPreference ensures that the act of creating an AuthServer sets
+// TestAuthPreference ensures that the act of creating an Server sets
 // the AuthPreference (type and second factor) on the backend.
 func (s *AuthInitSuite) TestAuthPreference(c *C) {
 	bk, err := lite.New(context.TODO(), backend.Params{"path": s.tempDir})

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -58,7 +58,7 @@ type KubeCSRResponse struct {
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
 // signed certificate if sucessful.
-func (s *AuthServer) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
+func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	if !modules.GetModules().SupportsKubernetes() {
 		return nil, trace.AccessDenied(
 			"this teleport cluster does not support kubernetes, please contact system administrator for support")

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -82,7 +82,7 @@ type SessionCreds struct {
 }
 
 // AuthenticateUser authenticates user based on the request type
-func (s *AuthServer) AuthenticateUser(req AuthenticateUserRequest) error {
+func (s *Server) AuthenticateUser(req AuthenticateUserRequest) error {
 	err := s.authenticateUser(req)
 	if err != nil {
 		s.EmitAuditEvent(events.UserLocalLoginFailure, events.EventFields{
@@ -101,7 +101,7 @@ func (s *AuthServer) AuthenticateUser(req AuthenticateUserRequest) error {
 	return err
 }
 
-func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
+func (s *Server) authenticateUser(req AuthenticateUserRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -162,7 +162,7 @@ func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
 // in case if authentication is successful. In case if existing session id
 // is used to authenticate, returns session associated with the existing session id
 // instead of creating the new one
-func (s *AuthServer) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
+func (s *Server) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
 	clusterConfig, err := s.GetClusterConfig()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -290,7 +290,7 @@ func AuthoritiesToTrustedCerts(authorities []services.CertAuthority) []TrustedCe
 
 // AuthenticateSSHUser authenticates web user, creates and  returns web session
 // in case if authentication is successful
-func (s *AuthServer) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
+func (s *Server) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	clusterConfig, err := s.GetClusterConfig()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -352,7 +352,7 @@ func (s *AuthServer) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginR
 }
 
 // emitNoLocalAuthEvent creates and emits a local authentication is disabled message.
-func (s *AuthServer) emitNoLocalAuthEvent(username string) {
+func (s *Server) emitNoLocalAuthEvent(username string) {
 	fields := events.EventFields{
 		events.AuthAttemptSuccess: false,
 		events.AuthAttemptErr:     noLocalAuth,
@@ -364,7 +364,7 @@ func (s *AuthServer) emitNoLocalAuthEvent(username string) {
 	s.IAuditLog.EmitAuditEvent(events.AuthAttemptFailure, fields)
 }
 
-func (s *AuthServer) createUserWebSession(user services.User) (services.WebSession, error) {
+func (s *Server) createUserWebSession(user services.User) (services.WebSession, error) {
 	// It's safe to extract the roles and traits directly from services.User as	this method
 	// is only used for local accounts.
 	sess, err := s.NewWebSession(user.GetName(), user.GetRoles(), user.GetTraits())

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -99,7 +99,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	// authMiddleware authenticates request assuming TLS client authentication
 	// adds authentication information to the context
 	// and passes it to the API server
-	authMiddleware := &AuthMiddleware{
+	authMiddleware := &Middleware{
 		AccessPoint:   cfg.AccessPoint,
 		AcceptedUsage: cfg.AcceptedUsage,
 	}
@@ -167,8 +167,8 @@ func (t *TLSServer) GetConfigForClient(info *tls.ClientHelloInfo) (*tls.Config, 
 	return tlsCopy, nil
 }
 
-// AuthMiddleware is authentication middleware checking every request
-type AuthMiddleware struct {
+// Middleware is authentication middleware checking every request
+type Middleware struct {
 	// AccessPoint is a caching access point for auth server
 	AccessPoint AccessCache
 	// Handler is HTTP handler called after the middleware checks requests
@@ -183,12 +183,12 @@ type AuthMiddleware struct {
 }
 
 // Wrap sets next handler in chain
-func (a *AuthMiddleware) Wrap(h http.Handler) {
+func (a *Middleware) Wrap(h http.Handler) {
 	a.Handler = h
 }
 
 // GetUser returns authenticated user based on request metadata set by HTTP server
-func (a *AuthMiddleware) GetUser(r *http.Request) (IdentityGetter, error) {
+func (a *Middleware) GetUser(r *http.Request) (IdentityGetter, error) {
 	peers := r.TLS.PeerCertificates
 	if len(peers) > 1 {
 		// when turning intermediaries on, don't forget to verify
@@ -301,7 +301,7 @@ func findSystemRole(roles []string) *teleport.Role {
 }
 
 // ServeHTTP serves HTTP requests
-func (a *AuthMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	baseContext := r.Context()
 	if baseContext == nil {
 		baseContext = context.TODO()

--- a/lib/auth/mocku2f/mocku2f.go
+++ b/lib/auth/mocku2f/mocku2f.go
@@ -125,11 +125,11 @@ func (muk *Key) RegisterResponse(req *u2f.RegisterRequest) (*u2f.RegisterRespons
 		Challenge: req.Challenge,
 		Origin:    req.AppID,
 	}
-	clientDataJson, err := json.Marshal(clientData)
+	clientDataJSON, err := json.Marshal(clientData)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clientDataHash := sha256.Sum256(clientDataJson)
+	clientDataHash := sha256.Sum256(clientDataJSON)
 
 	marshalledPublickey := elliptic.Marshal(elliptic.P256(), muk.privatekey.PublicKey.X, muk.privatekey.PublicKey.Y)
 
@@ -158,7 +158,7 @@ func (muk *Key) RegisterResponse(req *u2f.RegisterRequest) (*u2f.RegisterRespons
 
 	return &u2f.RegisterResponse{
 		RegistrationData: encodeBase64(regData),
-		ClientData:       encodeBase64(clientDataJson),
+		ClientData:       encodeBase64(clientDataJSON),
 	}, nil
 }
 
@@ -175,18 +175,18 @@ func (muk *Key) SignResponse(req *u2f.SignRequest) (*u2f.SignResponse, error) {
 
 	counterBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(counterBytes, muk.counter)
-	muk.counter += 1
+	muk.counter++
 
 	clientData := u2f.ClientData{
 		Typ:       "navigator.id.getAssertion",
 		Challenge: req.Challenge,
 		Origin:    req.AppID,
 	}
-	clientDataJson, err := json.Marshal(clientData)
+	clientDataJSON, err := json.Marshal(clientData)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clientDataHash := sha256.Sum256(clientDataJson)
+	clientDataHash := sha256.Sum256(clientDataJSON)
 
 	var dataToSign []byte
 	dataToSign = append(dataToSign, appIDHash[:]...)
@@ -210,7 +210,7 @@ func (muk *Key) SignResponse(req *u2f.SignRequest) (*u2f.SignResponse, error) {
 	return &u2f.SignResponse{
 		KeyHandle:     req.KeyHandle,
 		SignatureData: encodeBase64(signData),
-		ClientData:    encodeBase64(clientDataJson),
+		ClientData:    encodeBase64(clientDataJSON),
 	}, nil
 }
 

--- a/lib/auth/oidc_test.go
+++ b/lib/auth/oidc_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 type OIDCSuite struct {
-	a *AuthServer
+	a *Server
 	b backend.Backend
 	c clockwork.FakeClock
 }
@@ -65,7 +65,7 @@ func (s *OIDCSuite) SetUpSuite(c *check.C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, check.IsNil)
 }
 

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -32,7 +32,7 @@ type ChangePasswordWithTokenRequest struct {
 }
 
 // ChangePasswordWithToken changes password with token
-func (s *AuthServer) ChangePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.WebSession, error) {
+func (s *Server) ChangePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.WebSession, error) {
 	user, err := s.changePasswordWithToken(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -49,7 +49,7 @@ func (s *AuthServer) ChangePasswordWithToken(ctx context.Context, req ChangePass
 // ResetPassword securely generates a new random password and assigns it to user.
 // This method is used to invalidate existing user password during password
 // reset process.
-func (s *AuthServer) ResetPassword(username string) (string, error) {
+func (s *Server) ResetPassword(username string) (string, error) {
 	user, err := s.GetUser(username, false)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -69,7 +69,7 @@ func (s *AuthServer) ResetPassword(username string) (string, error) {
 }
 
 // ChangePassword changes user passsword
-func (s *AuthServer) ChangePassword(req services.ChangePasswordReq) error {
+func (s *Server) ChangePassword(req services.ChangePasswordReq) error {
 	// validate new password
 	err := services.VerifyPassword(req.NewPassword)
 	if err != nil {
@@ -110,7 +110,7 @@ func (s *AuthServer) ChangePassword(req services.ChangePasswordReq) error {
 
 // CheckPasswordWOToken checks just password without checking OTP tokens
 // used in case of SSH authentication, when token has been validated.
-func (s *AuthServer) CheckPasswordWOToken(user string, password []byte) error {
+func (s *Server) CheckPasswordWOToken(user string, password []byte) error {
 	const errMsg = "invalid username or password"
 
 	err := services.VerifyPassword(password)
@@ -136,7 +136,7 @@ func (s *AuthServer) CheckPasswordWOToken(user string, password []byte) error {
 }
 
 // CheckPassword checks the password and OTP token. Called by tsh or lib/web/*.
-func (s *AuthServer) CheckPassword(user string, password []byte, otpToken string) error {
+func (s *Server) CheckPassword(user string, password []byte, otpToken string) error {
 	err := s.CheckPasswordWOToken(user, password)
 	if err != nil {
 		return trace.Wrap(err)
@@ -148,7 +148,7 @@ func (s *AuthServer) CheckPassword(user string, password []byte, otpToken string
 
 // CheckOTP determines the type of OTP token used (for legacy HOTP support), fetches the
 // appropriate type from the backend, and checks if the token is valid.
-func (s *AuthServer) CheckOTP(user string, otpToken string) error {
+func (s *Server) CheckOTP(user string, otpToken string) error {
 	var err error
 
 	otpType, err := s.getOTPType(user)
@@ -217,7 +217,7 @@ func (s *AuthServer) CheckOTP(user string, otpToken string) error {
 }
 
 // CreateSignupU2FRegisterRequest creates U2F requests
-func (s *AuthServer) CreateSignupU2FRegisterRequest(tokenID string) (u2fRegisterRequest *u2f.RegisterRequest, e error) {
+func (s *Server) CreateSignupU2FRegisterRequest(tokenID string) (u2fRegisterRequest *u2f.RegisterRequest, e error) {
 	cap, err := s.GetAuthPreference()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -249,7 +249,7 @@ func (s *AuthServer) CreateSignupU2FRegisterRequest(tokenID string) (u2fRegister
 
 // getOTPType returns the type of OTP token used, HOTP or TOTP.
 // Deprecated: Remove this method once HOTP support has been removed from Gravity.
-func (s *AuthServer) getOTPType(user string) (string, error) {
+func (s *Server) getOTPType(user string) (string, error) {
 	_, err := s.GetHOTP(user)
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -260,7 +260,7 @@ func (s *AuthServer) getOTPType(user string) (string, error) {
 	return teleport.HOTP, nil
 }
 
-func (s *AuthServer) changePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.User, error) {
+func (s *Server) changePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.User, error) {
 	// Get cluster configuration and check if local auth is allowed.
 	clusterConfig, err := s.GetClusterConfig()
 	if err != nil {
@@ -312,7 +312,7 @@ func (s *AuthServer) changePasswordWithToken(ctx context.Context, req ChangePass
 	return user, nil
 }
 
-func (s *AuthServer) changeUserSecondFactor(req ChangePasswordWithTokenRequest, ResetPasswordToken services.ResetPasswordToken) error {
+func (s *Server) changeUserSecondFactor(req ChangePasswordWithTokenRequest, ResetPasswordToken services.ResetPasswordToken) error {
 	username := ResetPasswordToken.GetUser()
 	cap, err := s.GetAuthPreference()
 	if err != nil {

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -40,7 +40,7 @@ import (
 
 type PasswordSuite struct {
 	bk backend.Backend
-	a  *AuthServer
+	a  *Server
 }
 
 var _ = fmt.Printf
@@ -70,7 +70,7 @@ func (s *PasswordSuite) SetUpTest(c *C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, IsNil)
 
 	err = s.a.SetClusterName(clusterName)

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -29,7 +29,7 @@ import (
 )
 
 // NewAdminContext returns new admin auth context
-func NewAdminContext() (*AuthContext, error) {
+func NewAdminContext() (*Context, error) {
 	authContext, err := contextForBuiltinRole("", nil, teleport.RoleAdmin, fmt.Sprintf("%v", teleport.RoleAdmin))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -49,11 +49,11 @@ func NewRoleAuthorizer(clusterName string, clusterConfig services.ClusterConfig,
 // contextAuthorizer is a helper struct that always authorizes
 // based on predefined context, helpful for tests
 type contextAuthorizer struct {
-	authContext AuthContext
+	authContext Context
 }
 
 // Authorize authorizes user based on identity supplied via context
-func (r *contextAuthorizer) Authorize(ctx context.Context) (*AuthContext, error) {
+func (r *contextAuthorizer) Authorize(ctx context.Context) (*Context, error) {
 	return &r.authContext, nil
 }
 
@@ -74,7 +74,7 @@ func NewAuthorizer(access services.Access, identity services.UserGetter, trust s
 // Authorizer authorizes identity and returns auth context
 type Authorizer interface {
 	// Authorize authorizes user based on identity supplied via context
-	Authorize(ctx context.Context) (*AuthContext, error)
+	Authorize(ctx context.Context) (*Context, error)
 }
 
 // authorizer creates new local authorizer
@@ -84,8 +84,8 @@ type authorizer struct {
 	trust    services.Trust
 }
 
-// AuthContext is authorization context
-type AuthContext struct {
+// Context is authorization context
+type Context struct {
 	// User is the user name
 	User services.User
 	// Checker is access checker
@@ -95,7 +95,7 @@ type AuthContext struct {
 }
 
 // Authorize authorizes user based on identity supplied via context
-func (a *authorizer) Authorize(ctx context.Context) (*AuthContext, error) {
+func (a *authorizer) Authorize(ctx context.Context) (*Context, error) {
 	if ctx == nil {
 		return nil, trace.AccessDenied("missing authentication context")
 	}
@@ -113,7 +113,7 @@ func (a *authorizer) Authorize(ctx context.Context) (*AuthContext, error) {
 	return authContext, nil
 }
 
-func (a *authorizer) fromUser(userI interface{}) (*AuthContext, error) {
+func (a *authorizer) fromUser(userI interface{}) (*Context, error) {
 	switch user := userI.(type) {
 	case LocalUser:
 		return a.authorizeLocalUser(user)
@@ -129,12 +129,12 @@ func (a *authorizer) fromUser(userI interface{}) (*AuthContext, error) {
 }
 
 // authorizeLocalUser returns authz context based on the username
-func (a *authorizer) authorizeLocalUser(u LocalUser) (*AuthContext, error) {
+func (a *authorizer) authorizeLocalUser(u LocalUser) (*Context, error) {
 	return contextForLocalUser(u, a.identity, a.access)
 }
 
 // authorizeRemoteUser returns checker based on cert authority roles
-func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*AuthContext, error) {
+func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*Context, error) {
 	ca, err := a.trust.GetCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: u.ClusterName}, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -173,14 +173,14 @@ func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*AuthContext, error) {
 	// Set the list of roles this user has in the remote cluster.
 	user.SetRoles(roleNames)
 
-	return &AuthContext{
+	return &Context{
 		User:    user,
 		Checker: RemoteUserRoleSet{checker},
 	}, nil
 }
 
 // authorizeBuiltinRole authorizes builtin role
-func (a *authorizer) authorizeBuiltinRole(r BuiltinRole) (*AuthContext, error) {
+func (a *authorizer) authorizeBuiltinRole(r BuiltinRole) (*Context, error) {
 	config, err := r.GetClusterConfig()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -188,7 +188,7 @@ func (a *authorizer) authorizeBuiltinRole(r BuiltinRole) (*AuthContext, error) {
 	return contextForBuiltinRole(r.ClusterName, config, r.Role, r.Username)
 }
 
-func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*AuthContext, error) {
+func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, error) {
 	if r.Role != teleport.RoleProxy {
 		return nil, trace.AccessDenied("access denied for remote %v connecting to cluster", r.Role)
 	}
@@ -230,7 +230,7 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*AuthConte
 		return nil, trace.Wrap(err)
 	}
 	user.SetRoles([]string{string(teleport.RoleRemoteProxy)})
-	return &AuthContext{
+	return &Context{
 		User:    user,
 		Checker: RemoteBuiltinRoleSet{roles},
 	}, nil
@@ -437,7 +437,7 @@ func GetCheckerForBuiltinRole(clusterName string, clusterConfig services.Cluster
 	return nil, trace.NotFound("%v is not reconginzed", role.String())
 }
 
-func contextForBuiltinRole(clusterName string, clusterConfig services.ClusterConfig, r teleport.Role, username string) (*AuthContext, error) {
+func contextForBuiltinRole(clusterName string, clusterConfig services.ClusterConfig, r teleport.Role, username string) (*Context, error) {
 	checker, err := GetCheckerForBuiltinRole(clusterName, clusterConfig, r)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -447,13 +447,13 @@ func contextForBuiltinRole(clusterName string, clusterConfig services.ClusterCon
 		return nil, trace.Wrap(err)
 	}
 	user.SetRoles([]string{string(r)})
-	return &AuthContext{
+	return &Context{
 		User:    user,
 		Checker: BuiltinRoleSet{checker},
 	}, nil
 }
 
-func contextForLocalUser(u LocalUser, identity services.UserGetter, access services.Access) (*AuthContext, error) {
+func contextForLocalUser(u LocalUser, identity services.UserGetter, access services.Access) (*Context, error) {
 	// User has to be fetched to check if it's a blocked username
 	user, err := identity.GetUser(u.Username, false)
 	if err != nil {
@@ -477,7 +477,7 @@ func contextForLocalUser(u LocalUser, identity services.UserGetter, access servi
 	user.SetRoles(roles)
 	user.SetTraits(traits)
 
-	return &AuthContext{
+	return &Context{
 		User:    user,
 		Checker: LocalUserRoleSet{checker},
 	}, nil

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -33,7 +33,7 @@ import (
 // LocalRegister is used to generate host keys when a node or proxy is running
 // within the same process as the Auth Server and as such, does not need to
 // use provisioning tokens.
-func LocalRegister(id IdentityID, authServer *AuthServer, additionalPrincipals, dnsNames []string, remoteAddr string) (*Identity, error) {
+func LocalRegister(id IdentityID, authServer *Server, additionalPrincipals, dnsNames []string, remoteAddr string) (*Identity, error) {
 	// If local registration is happening and no remote address was passed in
 	// (which means no advertise IP was set), use localhost.
 	if remoteAddr == "" {

--- a/lib/auth/resetpasswordtoken.go
+++ b/lib/auth/resetpasswordtoken.go
@@ -94,7 +94,7 @@ func (r *CreateResetPasswordTokenRequest) CheckAndSetDefaults() error {
 }
 
 // CreateResetPasswordToken creates a reset password token
-func (s *AuthServer) CreateResetPasswordToken(ctx context.Context, req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
+func (s *Server) CreateResetPasswordToken(ctx context.Context, req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
 	err := req.CheckAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -134,7 +134,7 @@ func (s *AuthServer) CreateResetPasswordToken(ctx context.Context, req CreateRes
 // This ensures that an attacker that gains the ResetPasswordToken link can not view it,
 // extract the OTP key from the QR code, then allow the user to signup with
 // the same OTP token.
-func (s *AuthServer) RotateResetPasswordTokenSecrets(ctx context.Context, tokenID string) (services.ResetPasswordTokenSecrets, error) {
+func (s *Server) RotateResetPasswordTokenSecrets(ctx context.Context, tokenID string) (services.ResetPasswordTokenSecrets, error) {
 	token, err := s.GetResetPasswordToken(ctx, tokenID)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -160,7 +160,7 @@ func (s *AuthServer) RotateResetPasswordTokenSecrets(ctx context.Context, tokenI
 	return &secrets, nil
 }
 
-func (s *AuthServer) newResetPasswordToken(req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
+func (s *Server) newResetPasswordToken(req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
 	tokenID, err := utils.CryptoRandomHex(TokenLenBytes)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -205,7 +205,7 @@ func formatResetPasswordTokenURL(proxyHost string, tokenID string, reqType strin
 	return u.String(), nil
 }
 
-func (s *AuthServer) deleteResetPasswordTokens(ctx context.Context, username string) error {
+func (s *Server) deleteResetPasswordTokens(ctx context.Context, username string) error {
 	tokens, err := s.GetResetPasswordTokens(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/resetpasswordtoken_test.go
+++ b/lib/auth/resetpasswordtoken_test.go
@@ -33,7 +33,7 @@ import (
 
 type ResetPasswordTokenTest struct {
 	bk backend.Backend
-	a  *AuthServer
+	a  *Server
 }
 
 var _ = fmt.Printf
@@ -63,7 +63,7 @@ func (s *ResetPasswordTokenTest) SetUpTest(c *C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, IsNil)
 
 	err = s.a.SetClusterName(clusterName)

--- a/lib/auth/saml_test.go
+++ b/lib/auth/saml_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 type SAMLSuite struct {
-	a *AuthServer
+	a *Server
 	b backend.Backend
 	c clockwork.FakeClock
 }
@@ -65,7 +65,7 @@ func (s *SAMLSuite) SetUpSuite(c *check.C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, check.IsNil)
 }
 

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -34,7 +34,7 @@ import (
 )
 
 // CreateUser inserts a new user entry in a backend.
-func (s *AuthServer) CreateUser(ctx context.Context, user services.User) error {
+func (s *Server) CreateUser(ctx context.Context, user services.User) error {
 	if err := s.Identity.CreateUser(user); err != nil {
 		return trace.Wrap(err)
 	}
@@ -58,7 +58,7 @@ func (s *AuthServer) CreateUser(ctx context.Context, user services.User) error {
 }
 
 // UpsertUser updates a user.
-func (s *AuthServer) UpsertUser(user services.User) error {
+func (s *Server) UpsertUser(user services.User) error {
 	err := s.Identity.UpsertUser(user)
 	if err != nil {
 		return trace.Wrap(err)
@@ -82,7 +82,7 @@ func (s *AuthServer) UpsertUser(user services.User) error {
 }
 
 // DeleteUser deletes a user.
-func (s *AuthServer) DeleteUser(user string) error {
+func (s *Server) DeleteUser(user string) error {
 	role, err := s.Access.GetRole(services.RoleNameForUser(user))
 	if err != nil {
 		if !trace.IsNotFound(err) {

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -220,7 +220,7 @@ func (f *Forwarder) Close() error {
 // authContext is a context of authenticated user,
 // contains information about user, target cluster and authenticated groups
 type authContext struct {
-	auth.AuthContext
+	auth.Context
 	kubeGroups    map[string]struct{}
 	kubeUsers     map[string]struct{}
 	cluster       cluster
@@ -345,7 +345,7 @@ func (f *Forwarder) withAuth(handler handlerWithAuthFunc) httprouter.Handle {
 	})
 }
 
-func (f *Forwarder) setupContext(ctx auth.AuthContext, req *http.Request, isRemoteUser bool, certExpires time.Time) (*authContext, error) {
+func (f *Forwarder) setupContext(ctx auth.Context, req *http.Request, isRemoteUser bool, certExpires time.Time) (*authContext, error) {
 	roles := ctx.Checker
 
 	clusterConfig, err := f.AccessPoint.GetClusterConfig()
@@ -416,7 +416,7 @@ func (f *Forwarder) setupContext(ctx auth.AuthContext, req *http.Request, isRemo
 	authCtx := &authContext{
 		clientIdleTimeout: roles.AdjustClientIdleTimeout(clusterConfig.GetClientIdleTimeout()),
 		sessionTTL:        sessionTTL,
-		AuthContext:       ctx,
+		Context:           ctx,
 		kubeGroups:        utils.StringsSet(kubeGroups),
 		kubeUsers:         utils.StringsSet(kubeUsers),
 		clusterConfig:     clusterConfig,

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -93,7 +93,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	// authMiddleware authenticates request assuming TLS client authentication
 	// adds authentication information to the context
 	// and passes it to the API server
-	authMiddleware := &auth.AuthMiddleware{
+	authMiddleware := &auth.Middleware{
 		AccessPoint:   cfg.AccessPoint,
 		AcceptedUsage: []string{teleport.UsageKubeOnly},
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -209,7 +209,7 @@ type TeleportProcess struct {
 	Config *Config
 	// localAuth has local auth server listed in case if this process
 	// has started with auth server role enabled
-	localAuth *auth.AuthServer
+	localAuth *auth.Server
 	// backend is the process' backend
 	backend backend.Backend
 	// auditLog is the initialized audit log
@@ -268,7 +268,7 @@ func nextProcessID() int32 {
 }
 
 // GetAuthServer returns the process' auth server
-func (process *TeleportProcess) GetAuthServer() *auth.AuthServer {
+func (process *TeleportProcess) GetAuthServer() *auth.Server {
 	return process.localAuth
 }
 
@@ -734,13 +734,13 @@ func (process *TeleportProcess) notifyParent() {
 	}
 }
 
-func (process *TeleportProcess) setLocalAuth(a *auth.AuthServer) {
+func (process *TeleportProcess) setLocalAuth(a *auth.Server) {
 	process.Lock()
 	defer process.Unlock()
 	process.localAuth = a
 }
 
-func (process *TeleportProcess) getLocalAuth() *auth.AuthServer {
+func (process *TeleportProcess) getLocalAuth() *auth.Server {
 	process.Lock()
 	defer process.Unlock()
 	return process.localAuth
@@ -1029,10 +1029,10 @@ func (process *TeleportProcess) initAuthService() error {
 		AuditLog:       process.auditLog,
 	}
 
-	var authCache auth.AuthCache
+	var authCache auth.Cache
 	if process.Config.CachePolicy.Enabled {
 		cache, err := process.newAccessCache(accessCacheConfig{
-			services:  authServer.AuthServices,
+			services:  authServer.Services,
 			setup:     cache.ForAuth,
 			cacheName: []string{teleport.ComponentAuth},
 			inMemory:  true,
@@ -1043,7 +1043,7 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 		authCache = cache
 	} else {
-		authCache = authServer.AuthServices
+		authCache = authServer.Services
 	}
 	authServer.SetCache(authCache)
 

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -56,7 +56,7 @@ type ExecSuite struct {
 	ctx        *ServerContext
 	localAddr  net.Addr
 	remoteAddr net.Addr
-	a          *auth.AuthServer
+	a          *auth.Server
 }
 
 var _ = check.Suite(&ExecSuite{})
@@ -89,7 +89,7 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Assert(err, check.IsNil)
-	s.a, err = auth.NewAuthServer(&auth.InitConfig{
+	s.a, err = auth.NewServer(&auth.InitConfig{
 		Backend:     bk,
 		Authority:   authority.New(),
 		ClusterName: clusterName,


### PR DESCRIPTION
Fix warnings in `lib/auth/...`

Fixed findings:
```
lib/auth/api.go:130:6               golint  type name will be used as auth.AuthCache by other packages, and that stutters; consider calling this Cache
lib/auth/auth.go:61:6               golint  type name will be used as auth.AuthServerOption by other packages, and that stutters; consider calling this ServerOption
lib/auth/auth.go:133:6              golint  type name will be used as auth.AuthServices by other packages, and that stutters; consider calling this Services
lib/auth/auth.go:182:6              golint  type name will be used as auth.AuthServer by other packages, and that stutters; consider calling this Server
lib/auth/auth.go:349:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:447:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:569:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:624:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:639:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:675:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:716:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:753:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:803:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:878:1              golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1041:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1070:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1132:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1171:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1185:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1210:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1241:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1286:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1290:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1294:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1302:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth.go:1316:1             golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/auth_with_roles.go:42:6    golint  type name will be used as auth.AuthWithRoles by other packages, and that stutters; consider calling this WithRoles
lib/auth/auth_with_roles.go:509:14  golint  should omit 2nd value from range; this loop is equivalent to `for login := range ...`
lib/auth/github.go:84:1             golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/middleware.go:171:6        golint  type name will be used as auth.AuthMiddleware by other packages, and that stutters; consider calling this Middleware
lib/auth/oidc.go:196:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/oidc.go:228:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/oidc.go:384:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/oidc.go:412:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/oidc.go:437:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/oidc.go:585:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/oidc.go:593:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/oidc.go:727:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/oidc.go:852:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/permissions.go:88:6        golint  type name will be used as auth.AuthContext by other packages, and that stutters; consider calling this Context
lib/auth/saml.go:98:1               golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/saml.go:123:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/saml.go:148:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/saml.go:279:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/saml.go:310:1              golint  receiver name a should be consistent with previous receiver name s for AuthServer
lib/auth/trustedcluster.go:459:1    golint  receiver name s should be consistent with previous receiver name a for AuthServer
lib/auth/mocku2f/mocku2f.go:128:2   golint  var `clientDataJson` should be `clientDataJSON`
lib/auth/mocku2f/mocku2f.go:178:2   golint  should replace `muk.counter += 1` with `muk.counter++`
lib/auth/mocku2f/mocku2f.go:185:2   golint  var `clientDataJson` should be `clientDataJSON`
```

Updates #3551