### PR TITLE
Ensure all tests run exactly once per package

### DIFF
--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -31,7 +31,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-func TestS3(t *testing.T) { check.TestingT(t) }
+func Test(t *testing.T) { check.TestingT(t) }
 
 type S3Suite struct {
 	handler *Handler

--- a/lib/events/s3sessions/s3handler_thirdparty_test.go
+++ b/lib/events/s3sessions/s3handler_thirdparty_test.go
@@ -20,7 +20,6 @@ package s3sessions
 import (
 	"fmt"
 	"net/http/httptest"
-	"testing"
 
 	"github.com/gravitational/teleport/lib/events/test"
 	"github.com/gravitational/teleport/lib/utils"
@@ -32,8 +31,6 @@ import (
 	"github.com/pborman/uuid"
 	"gopkg.in/check.v1"
 )
-
-func TestS3ThirdParty(t *testing.T) { check.TestingT(t) }
 
 type S3ThirdPartySuite struct {
 	backend gofakes3.Backend

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -40,7 +40,7 @@ import (
 	"gopkg.in/check.v1"
 )
 
-func TestResourceHelpers(t *testing.T) { check.TestingT(t) }
+func Test(t *testing.T) { check.TestingT(t) }
 
 type ResourceSuite struct {
 	bk backend.Backend

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -32,8 +32,6 @@ import (
 	"gopkg.in/check.v1"
 )
 
-func TestLocal(t *testing.T) { check.TestingT(t) }
-
 type ServicesSuite struct {
 	bk    backend.Backend
 	suite *suite.ServicesTestSuite

--- a/lib/services/suite/presence_test.go
+++ b/lib/services/suite/presence_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package suite
 
 import (
+	"testing"
 	"time"
 
 	"github.com/gravitational/teleport/lib/services"
 
 	"gopkg.in/check.v1"
 )
+
+func Test(t *testing.T) { check.TestingT(t) }
 
 type PresenceSuite struct {
 }

--- a/lib/shell/shell_test.go
+++ b/lib/shell/shell_test.go
@@ -17,8 +17,12 @@ limitations under the License.
 package shell
 
 import (
+	"testing"
+
 	"gopkg.in/check.v1"
 )
+
+func Test(t *testing.T) { check.TestingT(t) }
 
 type ShellSuite struct {
 }
@@ -30,14 +34,11 @@ func (s *ShellSuite) TestGetShell(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(shell == "/bin/bash" || shell == "/bin/sh", check.Equals, true)
 
-	_, err = GetLoginShell("non-existent-user")
-	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Matches, "user: unknown user non-existent-user")
-
-	shell, err = GetLoginShell("daemon")
+	shell, err = GetLoginShell("non-existent-user")
 	c.Assert(err, check.IsNil)
-	c.Assert(shell == "/usr/sbin/nologin" ||
-		shell == "/sbin/nologin" ||
-		shell == "/usr/bin/nologin" ||
-		shell == "/usr/bin/false", check.Equals, true)
+	c.Assert(shell, check.Equals, DefaultShell)
+
+	shell, err = GetLoginShell("nobody")
+	c.Assert(err, check.IsNil)
+	c.Assert(shell, check.Matches, ".*(nologin|false)")
 }


### PR DESCRIPTION
With gocheck, tests only run if you call `check.TestingT(t)` from a
dummy `func Test(t *testing.T)`.

Added the missing dummy function call in: `lib/services/suite`,
`lib/shell`. The `lib/shell` tests also turned out to be broken.

If you call the dummy wrapper twice, all tests will run twice.
This was happening in `lib/events/s3sessions` and `lib/services/local`.