### PR TITLE
Fetch advertised proxy addresses when using an identity file

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -894,7 +894,7 @@ func onSCP(cf *CLIConf) {
 
 // makeClient takes the command-line configuration and constructs & returns
 // a fully configured TeleportClient object
-func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, err error) {
+func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, error) {
 	// Parse OpenSSH style options.
 	options, err := parseOptions(cf.Options)
 	if err != nil {
@@ -1074,7 +1074,22 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (tc *client.TeleportClient, e
 	// Don't execute remote command, used when port forwarding.
 	c.NoRemoteExec = cf.NoRemoteExec
 
-	return client.NewClient(c)
+	tc, err := client.NewClient(c)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// If identity file was provided, we skip loading the local profile info
+	// (above). This profile info provides the proxy-advertised listening
+	// addresses.
+	// To compensate, when using an identity file, explicitly fetch these
+	// addresses from the proxy (this is what Ping does).
+	if cf.IdentityFileIn != "" {
+		log.Debug("Pinging the proxy to fetch listening addresses for non-web ports.")
+		if _, err := tc.Ping(cf.Context); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	return tc, nil
 }
 
 func parseCertificateCompatibilityFlag(compatibility string, certificateFormat string) (string, error) {


### PR DESCRIPTION
Proxy advertises its preferred web/ssh/kube addresses via the `Ping`
endpoint. `tsh` hits this endpoint on login and caches addresses on disk
(in profile, along with credentials).
For all subsequent commands, `tsh` loads the cached information from
disk.

When using an identity file, `tsh` skips loading the profile (and it can
be missing entirely). In this case, we need to `Ping` the proxy
explicitly to fetch the correct public addresses for a proxy.

Fixes #3513