### PR TITLE
Add/Set ClusterName prop to Session struct

### DIFF
--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -103,6 +103,8 @@ type Session struct {
 	ServerHostname string `json:"server_hostname"`
 	// ServerAddr of session
 	ServerAddr string `json:"server_addr"`
+	// ClusterName is the name of cluster that this session belongs to.
+	ClusterName string `json:"cluster_name"`
 }
 
 // RemoveParty helper allows to remove a party by it's ID from the

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -485,6 +485,7 @@ func newSession(id rsession.ID, r *SessionRegistry, ctx *ServerContext) (*sessio
 		Namespace:      r.srv.GetNamespace(),
 		ServerHostname: ctx.srv.GetInfo().GetHostname(),
 		ServerAddr:     ctx.srv.GetInfo().GetAddr(),
+		ClusterName:    ctx.ClusterName,
 	}
 
 	term := ctx.GetTerm()

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1008,17 +1008,20 @@ func (s *WebSuite) TestActiveSessions(c *C) {
 	}
 
 	c.Assert(len(sessResp.Sessions), Equals, 1)
-	c.Assert(sessResp.Sessions[0].ID, Equals, sid)
-	c.Assert(sessResp.Sessions[0].Namespace, Equals, s.node.GetNamespace())
-	c.Assert(sessResp.Sessions[0].Parties, NotNil)
-	c.Assert(sessResp.Sessions[0].TerminalParams.H > 0, Equals, true)
-	c.Assert(sessResp.Sessions[0].TerminalParams.W > 0, Equals, true)
-	c.Assert(sessResp.Sessions[0].Login, Equals, pack.login)
-	c.Assert(sessResp.Sessions[0].Created.IsZero(), Equals, false)
-	c.Assert(sessResp.Sessions[0].LastActive.IsZero(), Equals, false)
-	c.Assert(sessResp.Sessions[0].ServerID, Equals, s.srvID)
-	c.Assert(sessResp.Sessions[0].ServerHostname, Equals, s.node.GetInfo().GetHostname())
-	c.Assert(sessResp.Sessions[0].ServerAddr, Equals, s.node.GetInfo().GetAddr())
+
+	sess := sessResp.Sessions[0]
+	c.Assert(sess.ID, Equals, sid)
+	c.Assert(sess.Namespace, Equals, s.node.GetNamespace())
+	c.Assert(sess.Parties, NotNil)
+	c.Assert(sess.TerminalParams.H > 0, Equals, true)
+	c.Assert(sess.TerminalParams.W > 0, Equals, true)
+	c.Assert(sess.Login, Equals, pack.login)
+	c.Assert(sess.Created.IsZero(), Equals, false)
+	c.Assert(sess.LastActive.IsZero(), Equals, false)
+	c.Assert(sess.ServerID, Equals, s.srvID)
+	c.Assert(sess.ServerHostname, Equals, s.node.GetInfo().GetHostname())
+	c.Assert(sess.ServerAddr, Equals, s.node.GetInfo().GetAddr())
+	c.Assert(sess.ClusterName, Equals, s.server.ClusterName())
 }
 
 func (s *WebSuite) TestCloseConnectionsOnLogout(c *C) {


### PR DESCRIPTION
#### Description
- Adds a ClusterName field to Session struct
- Set ClusterName for newSession

#### Screenshot
![screenshot_3](https://user-images.githubusercontent.com/43280172/81120645-03756600-8ee2-11ea-8125-83011d0ac838.png)

#### Related PR
https://github.com/gravitational/webapps/pull/91