### PR TITLE
Add backend engineers to root-level .go files CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 /docs/ @benarent @webvictim
 
 # Backend Engineering.
+/*.go @klizhentas @russjones @fspmarshall @webvictim @awly
 /e/ @klizhentas @russjones @fspmarshall @webvictim @awly
 /fixtures/ @klizhentas @russjones @fspmarshall @webvictim @awly
 /integration/ @klizhentas @russjones @fspmarshall @webvictim @awly


### PR DESCRIPTION
This should only match the `.go` files in the root of the repo, which is
logically the same as `/lib` and `/tool` code.