### PR TITLE
Use package-local type for context keys in lib/auth

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -854,15 +854,17 @@ func (a *AuthWithRoles) Ping(ctx context.Context) (proto.PingResponse, error) {
 	}, nil
 }
 
+type contextKey string
+
 // withUpdateBy creates a child context with the updated_by value set.
 // Helps capture the user who modified a resource.
 func withUpdateBy(ctx context.Context, user string) context.Context {
-	return context.WithValue(ctx, events.UpdatedBy, user)
+	return context.WithValue(ctx, contextKey(events.UpdatedBy), user)
 }
 
 // getUpdateBy attempts to load the context value updated_by.
 func getUpdateBy(ctx context.Context) (string, error) {
-	updateBy, ok := ctx.Value(events.UpdatedBy).(string)
+	updateBy, ok := ctx.Value(contextKey(events.UpdatedBy)).(string)
 	if !ok || updateBy == "" {
 		return "", trace.BadParameter("missing value %q", events.UpdatedBy)
 	}
@@ -873,13 +875,13 @@ func getUpdateBy(ctx context.Context) (string, error) {
 // value set.  Optionally used by AuthServer.SetAccessRequestState to log
 // a delegating identity.
 func WithDelegator(ctx context.Context, delegator string) context.Context {
-	return context.WithValue(ctx, events.AccessRequestDelegator, delegator)
+	return context.WithValue(ctx, contextKey(events.AccessRequestDelegator), delegator)
 }
 
 // getDelegator attempts to load the context value AccessRequestDelegator,
 // returning the empty string if no value was found.
 func getDelegator(ctx context.Context) string {
-	delegator, ok := ctx.Value(events.AccessRequestDelegator).(string)
+	delegator, ok := ctx.Value(contextKey(events.AccessRequestDelegator)).(string)
 	if !ok {
 		return ""
 	}


### PR DESCRIPTION
This is a staticcheck finding that slipped in just after staticcheck was
enabled in https://github.com/gravitational/teleport/pull/3651