### PR TITLE
Enable more linters: `ineffassign`, `unconvert`, `misspell`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ TELEPORT_DEBUG ?= no
 GITTAG=v$(VERSION)
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
 CGOFLAG ?= CGO_ENABLED=1
-GO_LINTERS ?= "unused,govet,typecheck,deadcode,goimports,varcheck,structcheck,bodyclose,staticcheck"
+GO_LINTERS ?= "unused,govet,typecheck,deadcode,goimports,varcheck,structcheck,bodyclose,staticcheck,ineffassign,unconvert,misspell"
 
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)

--- a/constants.go
+++ b/constants.go
@@ -424,7 +424,7 @@ const (
 const MaxEnvironmentFileLines = 1000
 
 // MaxResourceSize is the maximum size (in bytes) of a serialized resource.  This limit is
-// typically only enforced aginst resources that are likely to arbitrarily grow (e.g. PluginData).
+// typically only enforced against resources that are likely to arbitrarily grow (e.g. PluginData).
 const MaxResourceSize = 1000000
 
 const (

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -192,7 +192,7 @@ func NewInstance(cfg InstanceConfig) *TeleInstance {
 		NodeName:            cfg.NodeName,
 		ClusterName:         cfg.ClusterName,
 		Roles:               teleport.Roles{teleport.RoleAdmin},
-		TTL:                 time.Duration(time.Hour * 24),
+		TTL:                 24 * time.Hour,
 	})
 	fatalIf(err)
 	tlsCA, err := tlsca.New(tlsCACert, tlsCAKey)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -736,8 +736,8 @@ func (s *IntSuite) TestInteractive(c *check.C) {
 	waitFor(sessionEndC, time.Second*10)
 
 	// make sure the output of B is mirrored in A
-	outputOfA := string(personA.Output(100))
-	outputOfB := string(personB.Output(100))
+	outputOfA := personA.Output(100)
+	outputOfB := personB.Output(100)
 	c.Assert(strings.Contains(outputOfA, outputOfB), check.Equals, true)
 }
 
@@ -784,7 +784,7 @@ func (s *IntSuite) TestShutdown(c *check.C) {
 		var matched bool
 		var output string
 		for {
-			output = string(replaceNewlines(person.Output(1000)))
+			output = replaceNewlines(person.Output(1000))
 			matched, _ = regexp.MatchString(pattern, output)
 			if matched {
 				break
@@ -944,7 +944,7 @@ func enterInput(c *check.C, person *Terminal, command, pattern string) {
 	var matched bool
 	var output string
 	for {
-		output = string(replaceNewlines(person.Output(1000)))
+		output = replaceNewlines(person.Output(1000))
 		matched, _ = regexp.MatchString(pattern, output)
 		if matched {
 			break
@@ -2936,7 +2936,7 @@ func (s *IntSuite) TestPAM(c *check.C) {
 		// If any output is expected, check to make sure it was output.
 		if len(tt.outContains) > 0 {
 			for _, expectedOutput := range tt.outContains {
-				output := string(termSession.Output(100))
+				output := termSession.Output(100)
 				c.Assert(strings.Contains(output, expectedOutput), check.Equals, true)
 			}
 		}
@@ -3522,7 +3522,7 @@ func runAndMatch(tc *client.TeleportClient, attempts int, command []string, patt
 			continue
 		}
 		out := output.String()
-		out = string(replaceNewlines(out))
+		out = replaceNewlines(out)
 		matched, _ := regexp.MatchString(pattern, out)
 		if matched {
 			return nil

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -314,7 +314,7 @@ loop:
 }
 
 // TestKubeDeny makes sure that deny rule conflicting with allow
-// rule takes precendence
+// rule takes precedence
 func (s *KubeSuite) TestKubeDeny(c *check.C) {
 	tconf := s.teleKubeConfig(Host)
 

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -627,7 +627,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	data := out.Bytes()
-	c.Assert(string(data), check.Equals, string(pod.Namespace))
+	c.Assert(string(data), check.Equals, pod.Namespace)
 
 	// interactive command, allocate pty
 	term := NewTerminal(250)
@@ -897,7 +897,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	data := out.Bytes()
-	c.Assert(string(data), check.Equals, string(pod.Namespace))
+	c.Assert(string(data), check.Equals, pod.Namespace)
 
 	// interactive command, allocate pty
 	term := NewTerminal(250)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -959,7 +959,7 @@ func (s *APIServer) generateToken(auth ClientI, w http.ResponseWriter, r *http.R
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return string(token), nil
+	return token, nil
 }
 
 func (s *APIServer) registerUsingToken(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1017,7 +1017,7 @@ func (s *AuthServer) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedK
 	if req.Roles.Include(teleport.RoleAuth) || req.Roles.Include(teleport.RoleAdmin) {
 		certRequest.DNSNames = append(certRequest.DNSNames, "*."+teleport.APIDomain, teleport.APIDomain)
 	}
-	// Unlike additional pricinpals, DNS Names is x509 specific
+	// Unlike additional principals, DNS Names is x509 specific
 	// and is limited to auth servers and proxies
 	if req.Roles.Include(teleport.RoleAuth) || req.Roles.Include(teleport.RoleAdmin) || req.Roles.Include(teleport.RoleProxy) {
 		certRequest.DNSNames = append(certRequest.DNSNames, req.DNSNames...)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1057,7 +1057,7 @@ func (a *AuthWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserCer
 			}
 			roles = append(roles, accessReq.GetRoles()...)
 		}
-		// nothing prevents an access-request from including roles already posessed by the
+		// nothing prevents an access-request from including roles already possessed by the
 		// user, so we must make sure to trim duplicate roles.
 		roles = utils.Deduplicate(roles)
 	}
@@ -1775,7 +1775,7 @@ func (a *AuthWithRoles) DeleteAllRemoteClusters() error {
 }
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
-// signed certificate if sucessful.
+// signed certificate if successful.
 func (a *AuthWithRoles) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	// limits the requests types to proxies to make it harder to break
 	if !a.hasBuiltinRole(string(teleport.RoleProxy)) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -2038,7 +2038,7 @@ func (c *Client) PostSessionSlice(slice events.SessionSlice) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	r, err := http.NewRequest("POST", c.Endpoint("namespaces", slice.Namespace, "sessions", string(slice.SessionID), "slice"), bytes.NewReader(data))
+	r, err := http.NewRequest("POST", c.Endpoint("namespaces", slice.Namespace, "sessions", slice.SessionID, "slice"), bytes.NewReader(data))
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -357,7 +357,7 @@ func (c *Client) Delete(u string) (*roundtrip.Response, error) {
 }
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
-// signed certificate if sucessful.
+// signed certificate if successful.
 func (c *Client) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -2888,7 +2888,7 @@ type ClientI interface {
 	AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error)
 
 	// ProcessKubeCSR processes CSR request against Kubernetes CA, returns
-	// signed certificate if sucessful.
+	// signed certificate if successful.
 	ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error)
 
 	// Ping gets basic info about the auth server.

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -59,7 +59,7 @@ type KubeCSRResponse struct {
 }
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
-// signed certificate if sucessful.
+// signed certificate if successful.
 func (s *AuthServer) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	if !modules.GetModules().SupportsKubernetes() {
 		return nil, trace.AccessDenied(

--- a/lib/auth/native/native.go
+++ b/lib/auth/native/native.go
@@ -219,7 +219,7 @@ func (k *Keygen) GenerateHostCert(c services.HostCertParams) ([]byte, error) {
 	}
 	cert.Permissions.Extensions = make(map[string]string)
 	cert.Permissions.Extensions[utils.CertExtensionRole] = c.Roles.String()
-	cert.Permissions.Extensions[utils.CertExtensionAuthority] = string(c.ClusterName)
+	cert.Permissions.Extensions[utils.CertExtensionAuthority] = c.ClusterName
 
 	// sign host certificate with private signing key of certificate authority
 	if err := cert.SignCert(rand.Reader, signer); err != nil {

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -299,7 +299,7 @@ func (s *AuthServer) changePasswordWithToken(ctx context.Context, req ChangePass
 	}
 
 	// Set a new password.
-	err = s.UpsertPassword(username, []byte(req.Password))
+	err = s.UpsertPassword(username, req.Password)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -70,7 +70,7 @@ func NewCircularBuffer(ctx context.Context, size int) (*CircularBuffer, error) {
 func (c *CircularBuffer) Reset() {
 	c.Lock()
 	defer c.Unlock()
-	// could close mulitple times
+	// could close multiple times
 	c.watchers.walk(func(w *BufferWatcher) {
 		w.closeWatcher()
 	})
@@ -306,7 +306,7 @@ const (
 
 // closeAndRemove closes the watcher, could
 // be called multiple times, removes the watcher
-// from the buffer queue syncronously (used in tests)
+// from the buffer queue synchronously (used in tests)
 // or asyncronously, used in prod, to avoid potential deadlocks
 func (w *BufferWatcher) closeAndRemove(sync bool) error {
 	w.closeWatcher()

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -161,7 +161,7 @@ type Config struct {
 	DialTimeout time.Duration `json:"dial_timeout,omitempty"`
 	// Username is an optional username for HTTPS basic authentication
 	Username string `json:"username,omitempty"`
-	// Password is initalized from password file, and is not read from the config
+	// Password is initialized from password file, and is not read from the config
 	Password string `json:"-"`
 	// PasswordFile is an optional password file for HTTPS basic authentication,
 	// expects path to a file

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -92,7 +92,7 @@ func (s *EtcdSuite) SetUpSuite(c *check.C) {
 func (s *EtcdSuite) SetUpTest(c *check.C) {
 	if s.skip {
 		fmt.Println("WARNING: etcd cluster is not available. Start examples/etcd/start-etcd.sh")
-		c.Skip("Etcd is not avialable")
+		c.Skip("Etcd is not available")
 	}
 }
 

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -90,7 +90,7 @@ func (s *BackendSuite) CRUD(c *check.C) {
 	err = s.B.Delete(ctx, item.Key)
 	fixtures.ExpectNotFound(c, err)
 
-	// put new item suceeds
+	// put new item succeeds
 	item = backend.Item{Key: prefix("/put"), Value: []byte("world")}
 	_, err = s.B.Put(ctx, item)
 	c.Assert(err, check.IsNil)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -416,7 +416,7 @@ func (c *Cache) notify(event CacheEvent) {
 //   a. We assume that events are ordered in regards to the
 //   individual key operations which is the guarantees both Etcd and DynamodDB
 //   provide.
-//   b. Thanks to the init event sent by the server on a sucessfull connect,
+//   b. Thanks to the init event sent by the server on a successful connect,
 //   and guarantees 1 and 2a, client assumes that once it connects and receives an event,
 //   it will not miss any events, however it can receive stale events.
 //   Event could be stale, if it relates to a change that happened before
@@ -426,7 +426,7 @@ func (c *Cache) notify(event CacheEvent) {
 //   read the value a=2 and then received events 1 and 2 and 3.
 //   The cache will replay all events 1, 2 and 3 and end up in the correct
 //   state 3. If we had a consistent revision number, we could
-//   have skipped 1 and 2, but in the absense of such mechanism in Dynamo
+//   have skipped 1 and 2, but in the absence of such mechanism in Dynamo
 //   we assume that this cache will eventually end up in a correct state
 //   potentially lagging behind the state of the database.
 //

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -415,7 +415,7 @@ func (s *CacheSuite) preferRecent(c *check.C) {
 	p.backend.SetReadError(nil)
 
 	// wait for watcher to restart successfully; ignoring any failed
-	// attempts which ocurred before backend became healthy again.
+	// attempts which occurred before backend became healthy again.
 	waitForEvent(c, p.eventsC, WatcherStarted, WatcherFailed)
 
 	// new value is available now

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -34,7 +34,7 @@ type collection interface {
 	// process processes event
 	processEvent(e services.Event) error
 	// watchKind returns a watch
-	// requried for this collection
+	// required for this collection
 	watchKind() services.WatchKind
 	// erase erases all data in the collection
 	erase() error

--- a/lib/cache/doc.go
+++ b/lib/cache/doc.go
@@ -22,7 +22,7 @@ limitations under the License.
 //
 // This approach allows cache to be up to date without
 // time based expiration and avoid re-fetching all
-// resources reducing bandwitdh.
+// resources reducing bandwidth.
 //
 // There are two types of cache backends used:
 //

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2234,7 +2234,7 @@ func (tc *TeleportClient) getServerVersion(nodeClient *NodeClient) (string, erro
 // passwordFromConsole reads from stdin without echoing typed characters to stdout
 func passwordFromConsole() (string, error) {
 	fd := syscall.Stdin
-	state, err := terminal.GetState(int(fd))
+	state, err := terminal.GetState(fd)
 
 	// intercept Ctr+C and restore terminal
 	sigCh := make(chan os.Signal, 1)
@@ -2246,7 +2246,7 @@ func passwordFromConsole() (string, error) {
 		go func() {
 			select {
 			case <-sigCh:
-				terminal.Restore(int(fd), state)
+				terminal.Restore(fd, state)
 				os.Exit(1)
 			case <-closeCh:
 			}
@@ -2256,7 +2256,7 @@ func passwordFromConsole() (string, error) {
 		close(closeCh)
 	}()
 
-	bytes, err := terminal.ReadPassword(int(fd))
+	bytes, err := terminal.ReadPassword(fd)
 	return string(bytes), err
 }
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -166,7 +166,7 @@ func (proxy *ProxyClient) GenerateCertsForCluster(ctx context.Context, routeToCl
 	return trace.Wrap(err)
 }
 
-// ReissueParams encodes optional paramters for
+// ReissueParams encodes optional parameters for
 // user certificate reissue.
 type ReissueParams struct {
 	RouteToCluster string

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -75,7 +75,6 @@ func Write(filePath string, key *client.Key, format Format, certAuthorities []se
 		return nil, trace.BadParameter("identity location is not specified")
 	}
 
-	var output io.Writer = os.Stdout
 	switch format {
 	// dump user identity into a single file:
 	case FormatFile:
@@ -84,19 +83,18 @@ func Write(filePath string, key *client.Key, format Format, certAuthorities []se
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		output = f
 		defer f.Close()
 
 		// write key:
-		if err := writeWithNewline(output, key.Priv); err != nil {
+		if err := writeWithNewline(f, key.Priv); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		// append ssh cert:
-		if err := writeWithNewline(output, key.Cert); err != nil {
+		if err := writeWithNewline(f, key.Cert); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		// append tls cert:
-		if err := writeWithNewline(output, key.TLSCert); err != nil {
+		if err := writeWithNewline(f, key.TLSCert); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		// append trusted host certificate authorities
@@ -107,13 +105,13 @@ func Write(filePath string, key *client.Key, format Format, certAuthorities []se
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
-				if err := writeWithNewline(output, []byte(data)); err != nil {
+				if err := writeWithNewline(f, []byte(data)); err != nil {
 					return nil, trace.Wrap(err)
 				}
 			}
 			// append tls ca certificates
 			for _, keyPair := range ca.GetTLSKeyPairs() {
-				if err := writeWithNewline(output, keyPair.Cert); err != nil {
+				if err := writeWithNewline(f, keyPair.Cert); err != nil {
 					return nil, trace.Wrap(err)
 				}
 			}

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -215,7 +215,7 @@ func (s *KeyStoreTestSuite) makeSignedKey(c *check.C, makeExpired bool) *Key {
 	priv, pub, _ = s.keygen.GenerateKeyPair("")
 	username := "vincento"
 	allowedLogins := []string{username, "root"}
-	ttl := time.Duration(time.Minute * 20)
+	ttl := 20 * time.Minute
 	if makeExpired {
 		ttl = -ttl
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -203,7 +203,7 @@ const (
 
 	// AccountLockInterval defines a time interval during which a user account
 	// is locked after MaxLoginAttempts
-	AccountLockInterval = time.Duration(20 * time.Minute)
+	AccountLockInterval = 20 * time.Minute
 
 	// Namespace is default namespace
 	Namespace = "default"

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -486,7 +486,7 @@ func (a *AuditTestSuite) forwardAndUpload(c *check.C, fakeClock clockwork.Clock,
 	upload(c, uploadDir, fakeClock, alog)
 
 	compare := func() error {
-		history, err := alog.GetSessionEvents(defaults.Namespace, session.ID(sessionID), 0, true)
+		history, err := alog.GetSessionEvents(defaults.Namespace, sessionID, 0, true)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -503,7 +503,7 @@ func (a *AuditTestSuite) forwardAndUpload(c *check.C, fakeClock clockwork.Clock,
 		}
 
 		// fetch all bytes
-		buff, err := alog.GetSessionChunk(defaults.Namespace, session.ID(sessionID), 0, 5000)
+		buff, err := alog.GetSessionChunk(defaults.Namespace, sessionID, 0, 5000)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -512,7 +512,7 @@ func (a *AuditTestSuite) forwardAndUpload(c *check.C, fakeClock clockwork.Clock,
 		}
 
 		// with offset
-		buff, err = alog.GetSessionChunk(defaults.Namespace, session.ID(sessionID), 2, 5000)
+		buff, err = alog.GetSessionChunk(defaults.Namespace, sessionID, 2, 5000)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -633,7 +633,7 @@ func newGzipWriter(file *os.File) *gzipWriter {
 }
 
 const (
-	// eventsSuffix is the suffix of the archive that contians session events.
+	// eventsSuffix is the suffix of the archive that contains session events.
 	eventsSuffix = "events.gz"
 
 	// chunksSuffix is the suffix of the archive that contains session chunks.

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -128,7 +128,7 @@ func (s *EventsSuite) SessionEventsCRUD(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// read the session event
-	history, err = s.Log.GetSessionEvents(defaults.Namespace, session.ID(sessionID), 0, false)
+	history, err = s.Log.GetSessionEvents(defaults.Namespace, sessionID, 0, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(history, check.HasLen, 2)
 	c.Assert(history[0].GetString(events.EventType), check.Equals, events.SessionStartEvent)

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -87,7 +87,7 @@ type ForwarderConfig struct {
 	Context context.Context
 	// KubeconfigPath is a path to kubernetes configuration
 	KubeconfigPath string
-	// Clock is a server clock, could be overriden in tests
+	// Clock is a server clock, could be overridden in tests
 	Clock clockwork.Clock
 }
 

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -44,7 +44,7 @@ type DialParams struct {
 	// validates the host certificate.
 	Address string
 
-	// Principals are additonal principals that need to be added to the host
+	// Principals are additional principals that need to be added to the host
 	// certificate. Used by the recording proxy to correctly generate a host
 	// certificate.
 	Principals []string

--- a/lib/reversetunnel/conn.go
+++ b/lib/reversetunnel/conn.go
@@ -52,7 +52,7 @@ type remoteConn struct {
 	// be made on it.
 	invalid int32
 
-	// lastError is the last error that occured before this connection became
+	// lastError is the last error that occurred before this connection became
 	// invalid.
 	lastError error
 

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -331,7 +331,7 @@ func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-ch
 		case proxies := <-rconn.newProxiesC:
 			req := discoveryRequest{
 				ClusterName: s.srv.ClusterName,
-				Type:        string(rconn.tunnelType),
+				Type:        rconn.tunnelType,
 				Proxies:     proxies,
 			}
 			if err := rconn.sendDiscoveryRequest(req); err != nil {

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -326,7 +326,7 @@ func (s *remoteSite) handleHeartbeat(conn *remoteConn, ch ssh.Channel, reqC <-ch
 		case proxies := <-conn.newProxiesC:
 			req := discoveryRequest{
 				ClusterName: s.srv.ClusterName,
-				Type:        string(conn.tunnelType),
+				Type:        conn.tunnelType,
 				Proxies:     proxies,
 			}
 			if err := conn.sendDiscoveryRequest(req); err != nil {

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pborman/uuid"
 )
 
-// RequestIDs is a collection of IDs for privelege escalation requests.
+// RequestIDs is a collection of IDs for privilege escalation requests.
 type RequestIDs struct {
 	AccessRequests []string `json:"access_requests,omitempty"`
 }
@@ -162,7 +162,7 @@ type DynamicAccessExt interface {
 	DynamicAccess
 	// UpsertAccessRequest creates or updates an access request.
 	UpsertAccessRequest(ctx context.Context, req AccessRequest) error
-	// DeleteAllAccessRequests deletes all existant access requests.
+	// DeleteAllAccessRequests deletes all existent access requests.
 	DeleteAllAccessRequests(ctx context.Context) error
 }
 

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -40,7 +40,7 @@ type UserGetter interface {
 	GetUser(user string, withSecrets bool) (User, error)
 }
 
-// UsersService is reponsible for basic user management
+// UsersService is responsible for basic user management
 type UsersService interface {
 	UserGetter
 	// UpdateUser updates an existing user.

--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -512,7 +512,7 @@ func itemsFromLocalAuthSecrets(user string, auth services.LocalAuthSecrets) ([]b
 // TODO: convert username/suffix ops to work on bytes by default; string/byte conversion
 // has order N cost.
 
-// fullUsersPrefix is the entire string preceeding the name of a user in a key
+// fullUsersPrefix is the entire string preceding the name of a user in a key
 var fullUsersPrefix string = string(backend.Key(webPrefix, usersPrefix)) + "/"
 
 // splitUsernameAndSuffix is a helper for extracting usernames and suffixes from

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -46,7 +46,7 @@ type RuleContext interface {
 }
 
 var (
-	// ResourceNameExpr is the identifer that specifies resource name.
+	// ResourceNameExpr is the identifier that specifies resource name.
 	ResourceNameExpr = builder.Identifier("resource.metadata.name")
 	// CertAuthorityTypeExpr is a function call that returns
 	// cert authority type.
@@ -186,7 +186,7 @@ func (ctx *Context) String() string {
 const (
 	// UserIdentifier represents user registered identifier in the rules
 	UserIdentifier = "user"
-	// ResourceIdentifier represents resource registered identifer in the rules
+	// ResourceIdentifier represents resource registered identifier in the rules
 	ResourceIdentifier = "resource"
 )
 

--- a/lib/services/proxywatcher.go
+++ b/lib/services/proxywatcher.go
@@ -161,7 +161,7 @@ func (p *ProxyWatcher) Done() <-chan struct{} {
 	return p.ctx.Done()
 }
 
-// Close closes proxy watcher and cancells all the functions
+// Close closes proxy watcher and cancels all the functions
 func (p *ProxyWatcher) Close() error {
 	p.cancel()
 	return nil

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2194,7 +2194,7 @@ func (b *BoolOption) UnmarshalJSON(data []byte) error {
 
 // MarshalYAML marshals bool into yaml value
 func (b *BoolOption) MarshalYAML() (interface{}, error) {
-	return bool(b.Value), nil
+	return b.Value, nil
 }
 
 func (b *BoolOption) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -501,7 +501,7 @@ func NewTerminalParamsFromInt(w int, h int) (*TerminalParams, error) {
 	if h > maxSize || h < minSize {
 		return nil, trace.BadParameter("bad height")
 	}
-	return &TerminalParams{W: int(w), H: int(h)}, nil
+	return &TerminalParams{W: w, H: h}, nil
 }
 
 const (

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -58,7 +58,7 @@ const (
 	// HeartbeatStateAnnounce is set when full
 	// state has to be announced back to the auth server
 	HeartbeatStateAnnounce KeepAliveState = iota
-	// HeartbeatStateAnnounceWait is set after successfull
+	// HeartbeatStateAnnounceWait is set after successful
 	// announce, heartbeat will wait until server updates
 	// information, or time for next announce comes
 	HeartbeatStateAnnounceWait KeepAliveState = iota
@@ -297,7 +297,7 @@ func (h *Heartbeat) fetch() error {
 		return trace.Wrap(err)
 	}
 	switch h.state {
-	// in case of successfull state fetch, move to announce from init
+	// in case of successful state fetch, move to announce from init
 	case HeartbeatStateInit:
 		h.current = server
 		h.reset(HeartbeatStateAnnounce)

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -236,7 +236,7 @@ func (s *HeartbeatSuite) heartbeatAnnounce(c *check.C, mode HeartbeatMode, kind 
 	c.Assert(hb.state, check.Equals, HeartbeatStateAnnounceWait)
 	c.Assert(hb.nextAnnounce, check.Equals, clock.Now().UTC().Add(hb.KeepAlivePeriod))
 
-	// once announce is successfull, next announce is set on schedule
+	// once announce is successful, next announce is set on schedule
 	announcer.err = nil
 	clock.Advance(hb.KeepAlivePeriod + time.Second)
 	err = hb.fetchAndAnnounce()

--- a/lib/srv/keepalive.go
+++ b/lib/srv/keepalive.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// RequestSender is an interface that impliments SendRequest. It is used so
+// RequestSender is an interface that implements SendRequest. It is used so
 // server and client connections can be passed to functions to send requests.
 type RequestSender interface {
 	// SendRequest is used to send a out-of-band request.

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -41,7 +41,7 @@ type ActivityTracker interface {
 
 // TrackingConn is an interface representing tracking connection
 type TrackingConn interface {
-	// LocalAddr returns local addres
+	// LocalAddr returns local address
 	LocalAddr() net.Addr
 	// RemoteAddr returns remote address
 	RemoteAddr() net.Addr

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -201,7 +201,7 @@ func RunCommand() (io.Writer, int, error) {
 
 	// Wait for the command to exit. It doesn't make sense to print an error
 	// message here because the shell has successfully started. If an error
-	// occured during shell execution or the shell exits with an error (like
+	// occurred during shell execution or the shell exits with an error (like
 	// running exit 2), the shell will print an error if appropriate and return
 	// an exit code.
 	err = cmd.Wait()

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -623,7 +623,7 @@ func (s *Server) AdvertiseAddr() string {
 	if aport == "" {
 		aport = port
 	}
-	return net.JoinHostPort(ahost, port)
+	return net.JoinHostPort(ahost, aport)
 }
 
 func (s *Server) getRole() teleport.Role {

--- a/lib/sshutils/req.go
+++ b/lib/sshutils/req.go
@@ -79,7 +79,7 @@ func (p *PTYReqParams) TerminalModes() (ssh.TerminalModes, error) {
 	chunkSize := 5
 	for i := 0; i < len(p.Modes); i = i + chunkSize {
 		// the first byte of the chunk is the key
-		key := uint8(p.Modes[i])
+		key := p.Modes[i]
 
 		// a key with value 0 means is the termination of the stream
 		if key == 0 {

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -217,11 +217,9 @@ func (cmd *command) GetRemoteShellCmd() (string, error) {
 	}
 
 	// "impersonate" scp to a server
-	shellCmd := "/usr/bin/scp -t"
-	if cmd.Flags.Source == true {
+	shellCmd := "/usr/bin/scp -f"
+	if cmd.Flags.Source {
 		shellCmd = "/usr/bin/scp -t"
-	} else {
-		shellCmd = "/usr/bin/scp -f"
 	}
 
 	if cmd.Flags.Recursive {

--- a/lib/utils/conv.go
+++ b/lib/utils/conv.go
@@ -55,7 +55,7 @@ func ObjectToStruct(in interface{}, out interface{}) error {
 	if err != nil {
 		return trace.Wrap(err, fmt.Sprintf("failed to marshal %v, %v", in, err))
 	}
-	if err := json.Unmarshal([]byte(bytes), out); err != nil {
+	if err := json.Unmarshal(bytes, out); err != nil {
 		return trace.Wrap(err, fmt.Sprintf("failed to unmarshal %v into %T, %v", in, out, err))
 	}
 	return nil

--- a/lib/utils/jsontools.go
+++ b/lib/utils/jsontools.go
@@ -118,7 +118,7 @@ func WriteYAML(w io.Writer, values interface{}) error {
 	return nil
 }
 
-// isDoc detects whether value constitues a document
+// isDoc detects whether value constitutes a document
 func isDoc(val reflect.Value) bool {
 	iterations := 0
 	for val.Kind() == reflect.Interface || val.Kind() == reflect.Ptr {

--- a/lib/utils/loadbalancer_test.go
+++ b/lib/utils/loadbalancer_test.go
@@ -169,7 +169,7 @@ func (s *LBSuite) TestClose(c *check.C) {
 
 	// requests are failing
 	out, err = Roundtrip(frontend.String())
-	c.Assert(err, check.NotNil, check.Commentf("output: %v, err: %v", string(out), err))
+	c.Assert(err, check.NotNil, check.Commentf("output: %s, err: %v", out, err))
 }
 
 func (s *LBSuite) TestDropConnections(c *check.C) {

--- a/lib/utils/workpool/workpool_test.go
+++ b/lib/utils/workpool/workpool_test.go
@@ -82,7 +82,7 @@ func (s *WorkSuite) TestFull(c *check.C) {
 	// release their leases.
 	g1done := make(chan struct{})
 	// timeout channel indicating all of group one should
-	// have acquired thier leases.
+	// have acquired their leases.
 	g1timeout := make(chan struct{})
 	go func() {
 		time.Sleep(time.Millisecond * 500)

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -513,7 +513,7 @@ func (t *TerminalHandler) read(out []byte, ws *websocket.Conn) (n int, err error
 		return 0, trace.Wrap(err)
 	}
 
-	switch string(envelope.GetType()) {
+	switch envelope.GetType() {
 	case defaults.WebsocketRaw:
 		n := copy(out, data)
 		// if payload size is greater than [out], store the remaining


### PR DESCRIPTION
All changes are purely cosmetic, except for `lib/srv/regular/sshserver.go` - this appears to be an actual bug fix.
Looks like we never advertised the custom listening port (`aport`), if it differed from regular listening port (`port`).

Updates #3551