### PR TITLE
Add Helm chart with DaemonSet to provide access to underlying host nodes

### DIFF
--- a/examples/chart/teleport-daemonset/.helmignore
+++ b/examples/chart/teleport-daemonset/.helmignore
@@ -1,0 +1,4 @@
+*~
+*.pem
+scripts
+pki

--- a/examples/chart/teleport-daemonset/Chart.yaml
+++ b/examples/chart/teleport-daemonset/Chart.yaml
@@ -1,0 +1,6 @@
+name: teleport
+version: 0.0.4
+description: Teleport Enterprise
+keywords:
+  - Teleport Enterprise
+tillerVersion: ">=2.8.0"

--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -31,7 +31,11 @@ This version of the chart has also been modified to deploy a Kubernetes `DaemonS
 number of host filesystem mounts on every Kubernetes worker node. Each pod will install and set up Teleport to run on the worker
 node itself as a `systemd` service, so that `ssh`-like access to these nodes is possible by logging into the leaf cluster.
 
-The configuration for this is set up in the `daemonset` section of `values.yaml`. You should configure a node join token here.
+The configuration for this is set up in the `daemonset` section of `values.yaml`. You must configure a secure node join token here.
+
+Each node connects back to the auth server of the Teleport leaf cluster running inside Kubernetes by using an exposed `NodePort`.
+This setup may not survive failures of the `kubelet` or other underlying node services, so it should **not** be relied on for
+emergency 'break-glass' access in the event of a failure.
 
 ## Prerequisites
 
@@ -56,7 +60,7 @@ kubectl create secret generic license --from-file=license-enterprise.pem
 ## Installing the chart
 
 Make sure you read `values.yaml` and edit the appropriate sections (particularly the root cluster configuration) before
-installing the chart.
+installing the chart. You must also set a secure node join token for use by your Kubernetes worker nodes.
 
 To install the chart with the release name `teleport`, run:
 
@@ -77,7 +81,7 @@ container:
 kubectl logs deploy/teleport -c teleport-sidecar
 ```
 
-You can view debug logs for the node-level Teleport service with this command:
+You can view debug logs for the Teleport service running on the Kubernetes worker nodes with this command:
 
 ```console
 kubectl logs daemonset/teleport-node

--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -39,9 +39,19 @@ emergency 'break-glass' access in the event of a failure.
 
 ## Prerequisites
 
-- Helm v2.16+
+- Helm v2.16 (Helm v3 is not currently supported)
+  - You must have Tiller working and configured properly inside your cluster
 - Kubernetes 1.10+
 - A Teleport license file stored as a Kubernetes Secret object - see below
+
+On many cloud providers, the `default` service account doesn't have sufficient privileges to deploy charts when used to run
+Tiller. In this situation, you will need to deploy Tiller with `cluster-admin` privileges like this:
+
+```console
+kubectl create serviceaccount --namespace kube-system tiller
+kubectl create clusterrolebinding tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+helm init --service-account tiller --upgrade --wait
+```
 
 ### Prepare the license file
 
@@ -62,10 +72,14 @@ kubectl create secret generic license --from-file=license-enterprise.pem
 Make sure you read `values.yaml` and edit the appropriate sections (particularly the root cluster configuration) before
 installing the chart. You must also set a secure node join token for use by your Kubernetes worker nodes.
 
-To install the chart with the release name `teleport`, run:
+We recommend copying all the parts of `values.yaml` which you need to change to another file called `teleport-values.yaml`,
+then providing this file to Helm using the `-f` parameter on the command line. Helm will take the defaults from
+`values.yaml` and merge them with your changes from the `teleport-values.yaml` file.
+
+To install the chart with the release name `teleport` and extra values from `teleport-values.yaml`, run:
 
 ```console
-helm install --name teleport ./
+helm install --name teleport -f teleport-values.yaml ./
 ```
 
 You can view debug logs for the cluster with this command:
@@ -87,7 +101,7 @@ You can view debug logs for the Teleport service running on the Kubernetes worke
 kubectl logs daemonset/teleport-node
 ```
 
-## Deleting the configured cluster
+## Deleting the chart
 
 If you need to delete the chart, you can use:
 

--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -1,0 +1,78 @@
+# Teleport
+
+[Gravitational Teleport](https://github.com/gravitational/teleport) is a modern SSH/Kubernetes API proxy server for
+remotely accessing clusters of Linux containers and servers via SSH, HTTPS, or Kubernetes API.
+
+## Introduction
+
+This chart deploys Teleport components to your cluster via a Kubernetes `Deployment`.
+
+By default this chart is configured as follows:
+
+- 1 replica
+- Record ssh/k8s exec and attach session to the `emptyDir` of the Teleport pod
+  - These sessions will also be stored on the root cluster, if used to access this Helm-configured cluster remotely
+- TLS is enabled by default on the Proxy
+  - The leaf cluster will generate its own self-signed certificates
+
+See the comments in the default `values.yaml` and also the Teleport documentation for more options.
+
+### Setting up your trusted cluster configuration
+
+This version of the chart has been modified to automatically connect back to a "root" Teleport cluster when started. This
+enables remote access to and management of this Teleport cluster (the "leaf" cluster) when deployed on a customer site.
+
+You will need to edit the values in the `trustedCluster.extraVars` section of `values.yaml` as appropriate for your cluster.
+There are comments in the file describing what the values need to be set to.
+
+## Prerequisites
+
+- Helm v2.16+
+- Kubernetes 1.10+
+- A Teleport license file stored as a Kubernetes Secret object - see below
+
+### Prepare the license file
+
+Download the `license.pem` from the Teleport dashboard, and then rename it to the filename that this chart expects:
+
+```console
+cp ~/Downloads/license.pem license-enterprise.pem
+```
+
+Store it as a Kubernetes secret:
+
+```console
+kubectl create secret generic license --from-file=license-enterprise.pem
+```
+
+## Installing the chart
+
+Make sure you read `values.yaml` and edit the appropriate sections (particularly the root cluster configuration) before
+installing the chart.
+
+To install the chart with the release name `teleport`, run:
+
+```console
+helm install --name teleport ./
+```
+
+You can view debug logs for the cluster with this command:
+
+```console
+kubectl logs deploy/teleport -c teleport
+```
+
+If you have any issues with the leaf cluster not appearing on the root cluster, look at the logs for the `teleport-sidecar`
+container:
+
+```console
+kubectl logs deploy/teleport -c teleport-sidecar
+```
+
+## Deleting the configured cluster
+
+If you need to delete the chart, you can use:
+
+```console
+helm delete --purge teleport
+```

--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -28,8 +28,8 @@ There are comments in the file describing what the values need to be set to.
 ### DaemonSet information
 
 This version of the chart has also been modified to deploy a Kubernetes `DaemonSet` which will run a privileged pod with a large
-number of host filesystem mounts on every Kubernetes worker node. Each pod will install and set up Teleport to run on the worker node
-itself as a `systemd` service, so that `ssh`-like access to these nodes is possible by logging into the leaf cluster.
+number of host filesystem mounts on every Kubernetes worker node. Each pod will install and set up Teleport to run on the worker
+node itself as a `systemd` service, so that `ssh`-like access to these nodes is possible by logging into the leaf cluster.
 
 The configuration for this is set up in the `daemonset` section of `values.yaml`. You should configure a node join token here.
 

--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -25,6 +25,14 @@ enables remote access to and management of this Teleport cluster (the "leaf" clu
 You will need to edit the values in the `trustedCluster.extraVars` section of `values.yaml` as appropriate for your cluster.
 There are comments in the file describing what the values need to be set to.
 
+### DaemonSet information
+
+This version of the chart has also been modified to deploy a Kubernetes `DaemonSet` which will run a privileged pod with a large
+number of host filesystem mounts on every Kubernetes worker node. Each pod will install and set up Teleport to run on the worker node
+itself as a `systemd` service, so that `ssh`-like access to these nodes is possible by logging into the leaf cluster.
+
+The configuration for this is set up in the `daemonset` section of `values.yaml`. You should configure a node join token here.
+
 ## Prerequisites
 
 - Helm v2.16+
@@ -67,6 +75,12 @@ container:
 
 ```console
 kubectl logs deploy/teleport -c teleport-sidecar
+```
+
+You can view debug logs for the node-level Teleport service with this command:
+
+```console
+kubectl logs daemonset/teleport-node
 ```
 
 ## Deleting the configured cluster

--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -67,6 +67,8 @@ Store it as a Kubernetes secret:
 kubectl create secret generic license --from-file=license-enterprise.pem
 ```
 
+This license will **not** be added to Teleport nodes running via the `DaemonSet`, as a license is only needed when running the auth server role.
+
 ## Installing the chart
 
 Make sure you read `values.yaml` and edit the appropriate sections (particularly the root cluster configuration) before

--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -41,8 +41,9 @@ emergency 'break-glass' access in the event of a failure.
 
 - Helm v2.16 (Helm v3 is not currently supported)
   - You must have Tiller working and configured properly inside your cluster
-- Kubernetes 1.10+
+- Kubernetes 1.14+
 - A Teleport license file stored as a Kubernetes Secret object - see below
+  - This means that by definition, the chart will use an Enterprise version of Teleport
 
 On many cloud providers, the `default` service account doesn't have sufficient privileges to deploy charts when used to run
 Tiller. In this situation, you will need to deploy Tiller with `cluster-admin` privileges like this:
@@ -55,7 +56,7 @@ helm init --service-account tiller --upgrade --wait
 
 ### Prepare the license file
 
-Download the `license.pem` from the Teleport dashboard, and then rename it to the filename that this chart expects:
+Download the `license.pem` from the [Teleport dashboard](https://dashboard.gravitational.com/web/), and then rename it to the filename that this chart expects:
 
 ```console
 cp ~/Downloads/license.pem license-enterprise.pem
@@ -102,6 +103,9 @@ You can view debug logs for the Teleport service running on the Kubernetes worke
 ```console
 kubectl logs daemonset/teleport-node
 ```
+
+If you have multiple worker nodes, look for pods starting with `teleport-node-` in the output of `kubectl get pods` and 
+use `kubectl logs pod/teleport-node-xxxxxx` to view logs from each node separately.
 
 ## Deleting the chart
 

--- a/examples/chart/teleport-daemonset/templates/_helpers.tpl
+++ b/examples/chart/teleport-daemonset/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "teleport.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "teleport.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "teleport.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "teleport.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "teleport.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*  Manage the labels for each entity  */}}
+{{- define "teleport.labels" -}}
+app: {{ template "teleport.name" . }}
+fullname: {{ template "teleport.fullname" . }}
+chart: {{ template "teleport.chart" . }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- end -}}

--- a/examples/chart/teleport-daemonset/templates/clusterrole.yaml
+++ b/examples/chart/teleport-daemonset/templates/clusterrole.yaml
@@ -14,4 +14,22 @@ rules:
   - serviceaccounts
   verbs:
   - impersonate
+{{ if .Values.usePSP -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "teleport.fullname" . }}-psp-clusterrole
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - "policy"
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - {{ template "teleport.fullname" . }}-daemonset-psp
+{{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-daemonset/templates/clusterrole.yaml
+++ b/examples/chart/teleport-daemonset/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "teleport.fullname" . }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - groups
+  - serviceaccounts
+  verbs:
+  - impersonate
+{{- end -}}

--- a/examples/chart/teleport-daemonset/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-daemonset/templates/clusterrolebinding.yaml
@@ -13,4 +13,21 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "teleport.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{ if .Values.usePSP -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "teleport.fullname" . }}-psp-clusterrolebinding
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "teleport.fullname" . }}-psp-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: {{ template "teleport.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-daemonset/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-daemonset/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "teleport.fullname" . }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "teleport.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "teleport.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/examples/chart/teleport-daemonset/templates/config.yaml
+++ b/examples/chart/teleport-daemonset/templates/config.yaml
@@ -54,6 +54,9 @@ data:
     done
     echo "[sidecar] Trusted cluster added. Tailing a never-ending file to keep the sidecar pod running..."
     tail -F /dev/null
+  get-kubelet-labels.sh:
+    #!/bin/bash
+    ps -ef | grep bin/kubelet | tr ' ' '\n' | grep node-labels | cut -d= -f2- | tr ',' '|'
   install-teleport-systemd.sh: |
     #!/bin/bash
     set -euo pipefail
@@ -116,6 +119,11 @@ data:
       echo "[install-teleport-systemd] mkdir -p ${HOST_TELEPORT_STORAGE_PATH}"
       mkdir -p ${HOST_TELEPORT_STORAGE_PATH}
     fi
+
+    CONTAINER_LABELS_SCRIPT_PATH=/usr/local/bin/teleport-scripts/get-kubelet-labels.sh
+    HOST_LABELS_SCRIPT_PATH=/host/usr/local/bin/get-kubelet-labels.sh
+    echo "[install-teleport-systemd] cp ${CONTAINER_LABELS_SCRIPT_PATH} ${HOST_LABELS_SCRIPT_PATH}"
+    cp ${CONTAINER_LABELS_SCRIPT_PATH} ${HOST_LABELS_SCRIPT_PATH}
 
     echo "[install-teleport-systemd] systemctl enable teleport.service"
     systemctl enable teleport.service

--- a/examples/chart/teleport-daemonset/templates/config.yaml
+++ b/examples/chart/teleport-daemonset/templates/config.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "teleport.fullname" . }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+data:
+  teleport.yaml: |
+{{ toYaml .Values.config | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "teleport.fullname" . }}-bootstrap-script
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+data:
+  bootstrap.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    SLEEP_TIME=5
+    OUTPUT_FILE="/tmp/teleport-trustedcluster.yaml"
+    cat << EOF > ${OUTPUT_FILE}
+    ---
+    kind: trusted_cluster
+    metadata:
+      name: root-cluster
+    spec:
+      enabled: true
+      role_map:
+      - local: ['admin']
+        remote: ${ROOT_CLUSTER_ADMIN_ROLE}
+      token: ${ROOT_CLUSTER_JOIN_TOKEN}
+      tunnel_addr: ${ROOT_CLUSTER_TUNNEL_ADDRESS}
+      web_proxy_addr: ${ROOT_CLUSTER_WEB_ADDRESS}
+    version: v2
+    EOF
+    echo "[sidecar] Trusted cluster definition:"
+    cat ${OUTPUT_FILE}
+    echo "[sidecar] Adding trusted cluster definition to Teleport"
+    until tctl create -f ${OUTPUT_FILE}; do
+      echo "[sidecar] Adding trusted cluster failed. Waiting ${SLEEP_TIME} seconds and trying again."
+      sleep ${SLEEP_TIME}
+    done
+    echo "[sidecar] Trusted cluster added. Tailing a never-ending file to keep the sidecar pod running..."
+    tail -F /dev/null

--- a/examples/chart/teleport-daemonset/templates/config.yaml
+++ b/examples/chart/teleport-daemonset/templates/config.yaml
@@ -11,7 +11,17 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "teleport.fullname" . }}-bootstrap-script
+  name: {{ template "teleport.fullname" . }}-daemonset-config
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+data:
+  teleport.yaml: |
+{{ toYaml .Values.daemonset.config | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "teleport.fullname" . }}-bootstrap-scripts
   labels:
 {{ include "teleport.labels" . | indent 4 }}
 data:
@@ -44,3 +54,77 @@ data:
     done
     echo "[sidecar] Trusted cluster added. Tailing a never-ending file to keep the sidecar pod running..."
     tail -F /dev/null
+  install-teleport-systemd.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    echo "[install-teleport-systemd] Installing systemd binaries inside container"
+    apt-get -y update && apt-get -y install systemd
+
+    HOST_SYSTEMD_UNIT_PATH=/etc/systemd/system/teleport.service
+    echo "[install-teleport-systemd] Writing ${HOST_SYSTEMD_UNIT_PATH} to host filesystem"
+    cat << EOF > ${HOST_SYSTEMD_UNIT_PATH}
+    [Unit]
+    Description=Teleport SSH Service
+    After=network.target
+
+    [Service]
+    Type=simple
+    Restart=on-failure
+    ExecStart=/usr/local/bin/teleport start -c /etc/teleport/teleport.yaml --pid-file=/run/teleport.pid
+    ExecReload=/bin/kill -HUP \$MAINPID
+    PIDFile=/run/teleport.pid
+
+    [Install]
+    WantedBy=multi-user.target
+    EOF
+
+    echo "[install-teleport-systemd] ${HOST_SYSTEMD_UNIT_PATH}:"
+    cat ${HOST_SYSTEMD_UNIT_PATH}
+
+    echo "[install-teleport-systemd] systemctl daemon-reload"
+    systemctl daemon-reload
+
+    CONTAINER_TELEPORT_BINARY_PATH=/usr/local/bin/teleport
+    HOST_TELEPORT_BINARY_PATH=/host/usr/local/bin/teleport
+    if [ -f /host/usr/local/bin/teleport ]; then
+      echo "[install-teleport-systemd] systemctl stop teleport.service"
+      systemctl stop teleport.service
+      echo "[install-teleport-systemd] rm -f ${HOST_TELEPORT_BINARY_PATH}"
+      rm -f ${HOST_TELEPORT_BINARY_PATH}
+    fi
+    echo "[install-teleport-systemd] cp ${CONTAINER_TELEPORT_BINARY_PATH} ${HOST_TELEPORT_BINARY_PATH}"
+    cp ${CONTAINER_TELEPORT_BINARY_PATH} ${HOST_TELEPORT_BINARY_PATH}
+    echo "[install-teleport-systemd] ${HOST_TELEPORT_BINARY_PATH}:"
+    ls -l ${HOST_TELEPORT_BINARY_PATH}
+    echo "[install-teleport-systemd] ${HOST_TELEPORT_BINARY_PATH} version:"
+    ${HOST_TELEPORT_BINARY_PATH} version
+
+    CONTAINER_TELEPORT_CONFIG_PATH=/etc/teleport/teleport.yaml
+    HOST_TELEPORT_CONFIG_PATH=/host/etc/teleport/teleport.yaml
+    echo "[install-teleport-systemd] Writing Teleport config (${HOST_TELEPORT_CONFIG_PATH}) to host filesystem"
+    cp ${CONTAINER_TELEPORT_CONFIG_PATH} ${HOST_TELEPORT_CONFIG_PATH}
+    echo "[install-teleport-systemd] Teleport config:"
+    cat ${HOST_TELEPORT_CONFIG_PATH}
+
+    HOST_TELEPORT_STORAGE_PATH=/host/var/lib/teleport
+    echo "[install-teleport-systemd] ${HOST_TELEPORT_STORAGE_PATH}:"
+    ls -l ${HOST_TELEPORT_STORAGE_PATH}
+    if [ -d ${HOST_TELEPORT_STORAGE_PATH}/cache ]; then
+      echo "[install-teleport-systemd] Found cached credentials on the node, removing"
+      echo "[install-teleport-systemd] rm -rf ${HOST_TELEPORT_STORAGE_PATH}/*"
+      rm -rf ${HOST_TELEPORT_STORAGE_PATH}/*
+      echo "[install-teleport-systemd] mkdir -p ${HOST_TELEPORT_STORAGE_PATH}"
+      mkdir -p ${HOST_TELEPORT_STORAGE_PATH}
+    fi
+
+    echo "[install-teleport-systemd] systemctl enable teleport.service"
+    systemctl enable teleport.service
+
+    echo "[install-teleport-systemd] systemctl start teleport.service"
+    systemctl start teleport.service
+
+    echo "[install-teleport-systemd] systemctl status teleport.service:"
+    systemctl status teleport.service
+
+    echo "[install-teleport-systemd] Teleport started. Tailing log..."
+    tail -F /var/log/teleport.log

--- a/examples/chart/teleport-daemonset/templates/daemonset.yaml
+++ b/examples/chart/teleport-daemonset/templates/daemonset.yaml
@@ -8,10 +8,6 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
 spec:
-  tolerations:
-  - key: node-role.kubernetes.io/master
-    operator: "Exists"
-    effect: "NoSchedule"
   selector:
     matchLabels:
       app: {{ template "teleport.name" . }}-node
@@ -27,11 +23,15 @@ spec:
 {{ toYaml .Values.daemonset.Annotations | indent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.daemonset.runOnMasters }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: "Exists"
+        effect: "NoSchedule"
+    {{- end }}
       hostPID: true
       hostIPC: true
       hostNetwork: true
-      securityContext:
-        privileged: true
       containers:
       - name: {{ .Chart.Name }}-systemd-installer
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/examples/chart/teleport-daemonset/templates/daemonset.yaml
+++ b/examples/chart/teleport-daemonset/templates/daemonset.yaml
@@ -89,22 +89,18 @@ spec:
       - name: {{ template "teleport.fullname" . }}-daemonset-config
         configMap:
           name: {{ template "teleport.fullname" . }}-daemonset-config
-      - name: {{ template "teleport.fullname" . }}-daemonset-host-config
-        hostPath:
-          path: /etc/teleport
-          type: DirectoryOrCreate
       - name: {{ template "teleport.fullname" . }}-daemonset-host-etc-systemd-system
         hostPath:
           path: /etc/systemd/system
           type: Directory
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-config
+        hostPath:
+          path: /etc/teleport
+          type: DirectoryOrCreate
       - name: {{ template "teleport.fullname" . }}-daemonset-host-run
         hostPath:
           path: /run
           type: Directory
-      - name: {{ template "teleport.fullname" . }}-daemonset-host-storage
-        hostPath:
-          path: /var/lib/teleport
-          type: DirectoryOrCreate
       - name: {{ template "teleport.fullname" . }}-daemonset-host-sys-fs-cgroup
         hostPath:
           path: /sys/fs/cgroup
@@ -116,6 +112,10 @@ spec:
       - name: {{ template "teleport.fullname" . }}-daemonset-host-usr-local-bin
         hostPath:
           path: /usr/local/bin
+          type: DirectoryOrCreate
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-storage
+        hostPath:
+          path: /var/lib/teleport
           type: DirectoryOrCreate
       - name: {{ template "teleport.fullname" . }}-daemonset-host-var-log-teleportlog
         hostPath:

--- a/examples/chart/teleport-daemonset/templates/daemonset.yaml
+++ b/examples/chart/teleport-daemonset/templates/daemonset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ template "teleport.fullname" . }}-daemonset
+  name: {{ template "teleport.fullname" . }}-node
   labels:
 {{ include "teleport.labels" . | indent 4 }}
 {{- if .Values.labels }}
@@ -13,11 +13,11 @@ spec:
     effect: NoSchedule
   selector:
     matchLabels:
-      app: {{ template "teleport.name" . }}-daemonset
+      app: {{ template "teleport.name" . }}-node
   template:
     metadata:
       labels:
-        app: {{ template "teleport.name" . }}-daemonset
+        app: {{ template "teleport.name" . }}-node
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
       annotations:
@@ -45,25 +45,25 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-        - mountPath: /etc/teleport
-          name: {{ template "teleport.fullname" . }}-daemonset-config
-          readOnly: true
 {{- if .Values.license.enabled }}
         - mountPath: {{ .Values.license.mountPath }}
           name: {{ template "teleport.fullname" . }}-license
           readOnly: true
 {{- end }}
+        - mountPath: /etc/teleport
+          name: {{ template "teleport.fullname" . }}-daemonset-config
+          readOnly: true
         - mountPath: /usr/local/bin/teleport-scripts
           name: {{ template "teleport.fullname" . }}-bootstrap-scripts
           readOnly: true
         - mountPath: /host/etc/teleport
           name: {{ template "teleport.fullname" . }}-daemonset-host-config
-        - mountPath: /host/var/lib/teleport
-          name: {{ template "teleport.fullname" . }}-daemonset-host-storage
         - mountPath: /etc/systemd/system
           name: {{ template "teleport.fullname" . }}-daemonset-host-etc-systemd-system
         - mountPath: /run
           name: {{ template "teleport.fullname" . }}-daemonset-host-run
+        - mountPath: /host/var/lib/teleport
+          name: {{ template "teleport.fullname" . }}-daemonset-host-storage
         - mountPath: /sys/fs/cgroup
           name: {{ template "teleport.fullname" . }}-daemonset-host-sys-fs-cgroup
           readOnly: true
@@ -71,10 +71,10 @@ spec:
           name: {{ template "teleport.fullname" . }}-daemonset-host-sys-fs-cgroup-systemd
         - mountPath: /host/usr/local/bin
           name: {{ template "teleport.fullname" . }}-daemonset-host-usr-local-bin
-        - mountPath: /var/run/dbus
-          name: {{ template "teleport.fullname" . }}-daemonset-host-var-run-dbus
         - mountPath: /var/log/teleport.log
           name: {{ template "teleport.fullname" . }}-daemonset-host-var-log-teleportlog
+        - mountPath: /var/run/dbus
+          name: {{ template "teleport.fullname" . }}-daemonset-host-var-run-dbus
 {{- if .Values.daemonset.extraVolumeMounts }}
 {{ toYaml .Values.daemonset.extraVolumeMounts | indent 8 }}
 {{- end }}
@@ -94,10 +94,6 @@ spec:
         hostPath:
           path: /etc/teleport
           type: DirectoryOrCreate
-      - name: {{ template "teleport.fullname" . }}-daemonset-host-storage
-        hostPath:
-          path: /var/lib/teleport
-          type: DirectoryOrCreate
       - name: {{ template "teleport.fullname" . }}-daemonset-host-etc-systemd-system
         hostPath:
           path: /etc/systemd/system
@@ -106,6 +102,10 @@ spec:
         hostPath:
           path: /run
           type: Directory
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-storage
+        hostPath:
+          path: /var/lib/teleport
+          type: DirectoryOrCreate
       - name: {{ template "teleport.fullname" . }}-daemonset-host-sys-fs-cgroup
         hostPath:
           path: /sys/fs/cgroup
@@ -118,13 +118,13 @@ spec:
         hostPath:
           path: /usr/local/bin
           type: DirectoryOrCreate
-      - name: {{ template "teleport.fullname" . }}-daemonset-host-var-run-dbus
-        hostPath:
-          path: /var/run/dbus
       - name: {{ template "teleport.fullname" . }}-daemonset-host-var-log-teleportlog
         hostPath:
           path: /var/log/teleport.log
           type: FileOrCreate
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 6 }}
 {{- end }}

--- a/examples/chart/teleport-daemonset/templates/daemonset.yaml
+++ b/examples/chart/teleport-daemonset/templates/daemonset.yaml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "teleport.fullname" . }}-daemonset
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+spec:
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
+  selector:
+    matchLabels:
+      app: {{ template "teleport.name" . }}-daemonset
+  template:
+    metadata:
+      labels:
+        app: {{ template "teleport.name" . }}-daemonset
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      annotations:
+        checksum/config: {{ toYaml .Values.config | sha256sum }}
+{{- if .Values.daemonset.Annotations }}
+{{ toYaml .Values.daemonset.Annotations | indent 8 }}
+{{- end }}
+    spec:
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      securityContext:
+        privileged: true
+      containers:
+      - name: {{ .Chart.Name }}-systemd-installer
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/usr/bin/dumb-init"]
+        args: ["/bin/bash", "/usr/local/bin/teleport-scripts/install-teleport-systemd.sh"]
+        env:
+        {{- range $key, $value := .Values.daemonset.extraVars }}
+        - name: {{ $key }}
+          value: {{ $value }}
+        {{- end}}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - mountPath: /etc/teleport
+          name: {{ template "teleport.fullname" . }}-daemonset-config
+          readOnly: true
+{{- if .Values.license.enabled }}
+        - mountPath: {{ .Values.license.mountPath }}
+          name: {{ template "teleport.fullname" . }}-license
+          readOnly: true
+{{- end }}
+        - mountPath: /usr/local/bin/teleport-scripts
+          name: {{ template "teleport.fullname" . }}-bootstrap-scripts
+          readOnly: true
+        - mountPath: /host/etc/teleport
+          name: {{ template "teleport.fullname" . }}-daemonset-host-config
+        - mountPath: /host/var/lib/teleport
+          name: {{ template "teleport.fullname" . }}-daemonset-host-storage
+        - mountPath: /etc/systemd/system
+          name: {{ template "teleport.fullname" . }}-daemonset-host-etc-systemd-system
+        - mountPath: /run
+          name: {{ template "teleport.fullname" . }}-daemonset-host-run
+        - mountPath: /sys/fs/cgroup
+          name: {{ template "teleport.fullname" . }}-daemonset-host-sys-fs-cgroup
+          readOnly: true
+        - mountPath: /sys/fs/cgroup/systemd
+          name: {{ template "teleport.fullname" . }}-daemonset-host-sys-fs-cgroup-systemd
+        - mountPath: /host/usr/local/bin
+          name: {{ template "teleport.fullname" . }}-daemonset-host-usr-local-bin
+        - mountPath: /var/run/dbus
+          name: {{ template "teleport.fullname" . }}-daemonset-host-var-run-dbus
+        - mountPath: /var/log/teleport.log
+          name: {{ template "teleport.fullname" . }}-daemonset-host-var-log-teleportlog
+{{- if .Values.daemonset.extraVolumeMounts }}
+{{ toYaml .Values.daemonset.extraVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+{{- if .Values.license.enabled }}
+      - name: {{ template "teleport.fullname" . }}-license
+        secret:
+          secretName: {{ .Values.license.secretName }}
+{{- end }}
+      - name: {{ template "teleport.fullname" . }}-bootstrap-scripts
+        configMap:
+          name: {{ template "teleport.fullname" . }}-bootstrap-scripts
+      - name: {{ template "teleport.fullname" . }}-daemonset-config
+        configMap:
+          name: {{ template "teleport.fullname" . }}-daemonset-config
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-config
+        hostPath:
+          path: /etc/teleport
+          type: DirectoryOrCreate
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-storage
+        hostPath:
+          path: /var/lib/teleport
+          type: DirectoryOrCreate
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-etc-systemd-system
+        hostPath:
+          path: /etc/systemd/system
+          type: Directory
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-run
+        hostPath:
+          path: /run
+          type: Directory
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-sys-fs-cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-sys-fs-cgroup-systemd
+        hostPath:
+          path: /sys/fs/cgroup/systemd
+          type: Directory
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-usr-local-bin
+        hostPath:
+          path: /usr/local/bin
+          type: DirectoryOrCreate
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: {{ template "teleport.fullname" . }}-daemonset-host-var-log-teleportlog
+        hostPath:
+          path: /var/log/teleport.log
+          type: FileOrCreate
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+{{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 6 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}
+      serviceAccountName: {{ template "teleport.serviceAccountName" . }}

--- a/examples/chart/teleport-daemonset/templates/daemonset.yaml
+++ b/examples/chart/teleport-daemonset/templates/daemonset.yaml
@@ -10,7 +10,8 @@ metadata:
 spec:
   tolerations:
   - key: node-role.kubernetes.io/master
-    effect: NoSchedule
+    operator: "Exists"
+    effect: "NoSchedule"
   selector:
     matchLabels:
       app: {{ template "teleport.name" . }}-node

--- a/examples/chart/teleport-daemonset/templates/daemonset.yaml
+++ b/examples/chart/teleport-daemonset/templates/daemonset.yaml
@@ -30,8 +30,6 @@ spec:
         effect: "NoSchedule"
     {{- end }}
       hostPID: true
-      hostIPC: true
-      hostNetwork: true
       containers:
       - name: {{ .Chart.Name }}-systemd-installer
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/examples/chart/teleport-daemonset/templates/daemonset.yaml
+++ b/examples/chart/teleport-daemonset/templates/daemonset.yaml
@@ -72,6 +72,7 @@ spec:
           name: {{ template "teleport.fullname" . }}-daemonset-host-usr-local-bin
         - mountPath: /var/log/teleport.log
           name: {{ template "teleport.fullname" . }}-daemonset-host-var-log-teleportlog
+          readOnly: true
         - mountPath: /var/run/dbus
           name: {{ template "teleport.fullname" . }}-daemonset-host-var-run-dbus
 {{- if .Values.daemonset.extraVolumeMounts }}

--- a/examples/chart/teleport-daemonset/templates/deployment.yaml
+++ b/examples/chart/teleport-daemonset/templates/deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "teleport.fullname" . }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.strategy }}
+  selector:
+    matchLabels:
+      app: {{ template "teleport.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "teleport.name" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      annotations:
+        checksum/config: {{ toYaml .Values.config | sha256sum }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      containers:
+      - name: {{ .Chart.Name }}-sidecar
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/usr/bin/dumb-init"]
+        args: ["/bin/bash", "/usr/local/bin/teleport-scripts/bootstrap.sh"]
+        env:
+        {{- range $key, $value := .Values.trustedCluster.extraVars }}
+        - name: {{ $key }}
+          value: {{ $value }}
+        {{- end}}
+        volumeMounts:
+        - mountPath: /usr/local/bin/teleport-scripts
+          name: {{ template "teleport.fullname" . }}-bootstrap-script
+          readOnly: true
+        - mountPath: /etc/teleport
+          name: {{ template "teleport.fullname" . }}-config
+          readOnly: true
+        - mountPath: /var/lib/teleport
+          name: {{ template "teleport.fullname" . }}-storage
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+{{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 8 }}
+{{- end }}
+{{- if not .Values.proxy.tls.enabled }}
+        - --insecure-no-tls
+{{- end }}
+        env:
+{{- range $key, $value := .Values.extraVars }}
+        - name: {{ $key }}
+          value: {{ $value }}
+{{- end }}
+        # See https://gravitational.com/teleport/docs/admin-guide/#ports
+        ports:
+{{- range $key, $port := .Values.ports }}
+        - name: {{ $key }}
+{{ toYaml $port | indent 10 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        - mountPath: /etc/teleport
+          name: {{ template "teleport.fullname" . }}-config
+          readOnly: true
+{{- if .Values.license.enabled }}
+        - mountPath: {{ .Values.license.mountPath }}
+          name: {{ template "teleport.fullname" . }}-license
+          readOnly: true
+{{- end }}
+        - mountPath: /var/lib/teleport
+          name: {{ template "teleport.fullname" . }}-storage
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+{{- if .Values.license.enabled }}
+      - name: {{ template "teleport.fullname" . }}-license
+        secret:
+          secretName: {{ .Values.license.secretName }}
+{{- end }}
+      - name: {{ template "teleport.fullname" . }}-config
+        configMap:
+          name: {{ template "teleport.fullname" . }}
+      - name: {{ template "teleport.fullname" . }}-storage
+        {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (printf "%s-%s" (include "teleport.fullname" .) "storage") }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+{{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 6 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}
+      serviceAccountName: {{ template "teleport.serviceAccountName" . }}

--- a/examples/chart/teleport-daemonset/templates/deployment.yaml
+++ b/examples/chart/teleport-daemonset/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- end}}
         volumeMounts:
         - mountPath: /usr/local/bin/teleport-scripts
-          name: {{ template "teleport.fullname" . }}-bootstrap-script
+          name: {{ template "teleport.fullname" . }}-bootstrap-scripts
           readOnly: true
         - mountPath: /etc/teleport
           name: {{ template "teleport.fullname" . }}-config
@@ -100,6 +100,9 @@ spec:
         {{- else }}
         emptyDir: {}
         {{- end }}
+      - name: {{ template "teleport.fullname" . }}-bootstrap-scripts
+        configMap:
+          name: {{ template "teleport.fullname" . }}-bootstrap-scripts
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 6 }}
 {{- end }}

--- a/examples/chart/teleport-daemonset/templates/ingress.yaml
+++ b/examples/chart/teleport-daemonset/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- $servicePort := .Values.service.ports.proxyweb.port -}}
+{{- $serviceName := include "teleport.fullname" . -}}
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "teleport.fullname" . }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  {{- range $host, $paths := .Values.ingress.hosts }}
+  - host: {{ $host }}
+    http:
+      paths:
+      {{- range $paths }}
+      - path: {{ . }}
+        backend:
+          serviceName: {{ $serviceName }}
+          servicePort: {{ $servicePort }}
+      {{- end -}}
+  {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/examples/chart/teleport-daemonset/templates/psp.yaml
+++ b/examples/chart/teleport-daemonset/templates/psp.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.usePSP -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "teleport.fullname" . }}-daemonset-psp
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+spec:
+  allowedHostPaths:
+  - pathPrefix: "/etc/systemd/system"
+  - pathPrefix: "/etc/teleport"
+  - pathPrefix: "/run"
+  - pathPrefix: "/sys/fs/cgroup"
+  - pathPrefix: "/sys/fs/cgroup/systemd"
+  - pathPrefix: "/usr/local/bin"
+  - pathPrefix: "/var/lib/teleport"
+  - pathPrefix: "/var/log/teleport.log"
+    readOnly: true
+  - pathPrefix: "/var/run/dbus"
+  fsGroup:
+    rule: 'RunAsAny'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: true
+  privileged: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - persistentVolumeClaim
+  - secret
+  - projected
+{{- end -}}

--- a/examples/chart/teleport-daemonset/templates/pv.yaml
+++ b/examples/chart/teleport-daemonset/templates/pv.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.persistence.pdName -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.persistence.pdName }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+spec:
+  capacity:
+    storage: {{ .Values.persistence.storageSize }}
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  claimRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ template "teleport.fullname" . }}-storage
+  gcePersistentDisk:
+    pdName: {{ .Values.persistnce.pdName }}
+    fsType: {{ .Values.persistence.fsType }}
+{{- end }}

--- a/examples/chart/teleport-daemonset/templates/pvc.yaml
+++ b/examples/chart/teleport-daemonset/templates/pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "teleport.fullname" . }}-storage
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.storageSize | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/examples/chart/teleport-daemonset/templates/service.yaml
+++ b/examples/chart/teleport-daemonset/templates/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "teleport.fullname" . }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  {{- range $key, $value := .Values.service.ports }}
+    - name: {{ $key }}
+{{ toYaml $value | indent 6 }}
+  {{- end }}
+{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.service.externalTrafficPolicy) }}
+  externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
+{{- end }}
+  selector:
+    app: {{ template "teleport.name" . }}
+    release: {{ .Release.Name }}

--- a/examples/chart/teleport-daemonset/templates/service.yaml
+++ b/examples/chart/teleport-daemonset/templates/service.yaml
@@ -24,3 +24,25 @@ spec:
   selector:
     app: {{ template "teleport.name" . }}
     release: {{ .Release.Name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "teleport.fullname" . }}-auth-nodeport
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: NodePort
+  ports:
+    - port: {{ .Values.service.ports.authssh.port }}
+      nodePort: 32025
+  selector:
+    app: {{ template "teleport.name" . }}
+    release: {{ .Release.Name }}

--- a/examples/chart/teleport-daemonset/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-daemonset/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "teleport.serviceAccountName" . }}
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- end -}}

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -84,6 +84,9 @@ daemonset:
 
     proxy_service:
       enabled: no
+  # Change this to true to run a Teleport node on Kubernetes masters.
+  # This has not been tested and may not work.
+  runOnMasters: false
 
 # Hopefully shouldn't need to change anything below here!
 labels: {}

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -81,6 +81,10 @@ daemonset:
       labels:
         node-type: kubernetes-worker
         running-on: host
+      commands:
+      - name: kubelet-labels
+        command: ['/bin/bash', '/usr/local/bin/get-kubelet-labels.sh']
+        period: 15m0s
 
     proxy_service:
       enabled: no

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -1,0 +1,245 @@
+image:
+  repository: quay.io/gravitational/teleport-ent
+  # This tag reflects the version of Teleport to deploy
+  tag: 4.2.9
+  pullPolicy: IfNotPresent
+  # Optionally specify an array of imagePullSecrets.
+  # Secrets must be manually created in the namespace.
+  # ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  pullSecrets:
+  # - name: myRegistryKeySecretName
+
+# Teleport and trusted cluster configuration section
+# See the admin guide for full details - https://gravitational.com/teleport/docs/admin-guide/#configuration-file
+# INSTRUCTIONS
+# Replace 'add-leaf-cluster-name-here' with a valid name for the leaf cluster.
+config:
+  teleport:
+    log:
+      output: stderr
+      severity: DEBUG
+
+  auth_service:
+    enabled: yes
+    license_file: /var/lib/license/license-enterprise.pem
+    # This will be the name that appears in the root cluster for management, so
+    # it should be descriptive.
+    cluster_name: add-leaf-cluster-name-here
+
+  ssh_service:
+    enabled: yes
+
+  proxy_service:
+    enabled: yes
+    web_listen_addr: 0.0.0.0:3080
+    listen_addr: 0.0.0.0:3023
+    kubernetes:
+      enabled: yes
+      listen_addr: 0.0.0.0:3026
+
+# Trusted cluster configuration
+# See https://gravitational.com/teleport/docs/trustedclusters for help
+# INSTRUCTIONS
+# Set these values as appropriate for the root cluster you want to join this leaf cluster back to.
+trustedCluster:
+  extraVars:
+    # The name of the role on the root cluster which should be granted admin permissions on this leaf cluster
+    ROOT_CLUSTER_ADMIN_ROLE: "admin"
+    # A trusted cluster join token, generated on the root cluster with 'tctl tokens add --type=trusted_cluster'
+    # See https://gravitational.com/teleport/docs/trustedclusters/#static-join-tokens for static tokens
+    ROOT_CLUSTER_JOIN_TOKEN: "trusted-cluster-join-token-goes-here"
+    # The tunnel address of the root cluster (usually on port 3024)
+    ROOT_CLUSTER_TUNNEL_ADDRESS: "root-cluster.example.com:3024"
+    # The web proxy address of the root cluster (usually on port 3080 or 443)
+    ROOT_CLUSTER_WEB_ADDRESS: "root-cluster.example.com:3080"
+
+# Hopefully shouldn't need to change anything below here!
+labels: {}
+
+# Pod annotations
+annotations: {}
+## See https://github.com/uswitch/kiam#overview
+## To enable AWS API access from teleport, use kube2iam or kiam, annotate the namespace, and then set something like:
+# iam.amazonaws.com/role: teleport-dynamodb-and-s3-access
+
+replicaCount: 1
+strategy: RollingUpdate
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity: {}
+#
+## For the sake of security, make specific node group(s) dedicated to Teleport
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#       - matchExpressions:
+#         - key: gravitational.io/dedicated
+#           operator: In
+#           values:
+#           - teleport
+#
+## For high availability, distribute teleport pods to nodes as evenly as possible
+#   podAntiAffinity:
+#     preferredDuringSchedulingIgnoredDuringExecution:
+#     - podAffinityTerm:
+#         labelSelector:
+#           matchExpressions:
+#           - key: app
+#             operator: In
+#             values:
+#             - teleport
+#         topologyKey: kubernetes.io/hostname
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+#
+# - key: "dedicated"
+#   operator: "Equal"
+#   value: "teleport"
+#   effect: "NoExecute"
+# - key: "dedicated"
+#   operator: "Equal"
+#   value: "teleport"
+#   effect: "NoSchedule"
+
+service:
+  type: ClusterIP
+  ports:
+    proxyweb:
+      port: 3080
+      targetPort: 3080
+      protocol: TCP
+    authssh:
+      port: 3025
+      targetPort: 3025
+      protocol: TCP
+    proxykube:
+      port: 3026
+      targetPort: 3026
+      protocol: TCP
+    proxyssh:
+      port: 3023
+      targetPort: 3023
+      protocol: TCP
+    proxytunnel:
+      port: 3024
+      targetPort: 3024
+      protocol: TCP
+  annotations: {}
+  ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
+  externalTrafficPolicy: ""
+
+  ## See https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws-sd.md#verify-that-externaldns-works-service-example
+  # Set something like the below in order to instruct external-dns to create a Route53 record set for your ELB on AWS:
+  # external-dns.alpha.kubernetes.io/hostname: teleport.my-org.com
+
+# Use ingress in addition to service to terminate TLS outside of Teleport while using external-dns
+# You can safely use `service` only and disable `ingress`, when you just want to terminate TLS outside of Teleporty
+ingress:
+  enabled: false
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   # See https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html#supported-annotations
+  #   kubernetes.io/tls-acme: "true"
+  # hosts:
+  #   teleport.example.com:
+  #   - /
+  # # Secrets must be manually created in the namespace
+  # tls:
+  #  - secretName: teleport-ingress-tls
+  #    hosts:
+  #    - teleport.example.com
+
+ports:
+  proxyweb:
+    containerPort: 3080
+  authssh:
+    containerPort: 3025
+  proxykube:
+    containerPort: 3026
+  proxyssh:
+    containerPort: 3023
+  nodessh:
+    containerPort: 3022
+  proxytunnel:
+    containerPort: 3024
+
+# Teleport Proxy configuration
+proxy:
+  tls:
+    # We assume TLS is terminated in front of the proxy by default
+    enabled: true
+
+license:
+  ## Set false to run Teleport in Community edition mode
+  enabled: true
+  secretName: license
+  mountPath: /var/lib/license
+
+## Additional container arguments
+extraArgs: []
+
+# A map of additional environment variables
+extraVars: {}
+  # Provide the path to your own CA cert if you would like to use to
+  # validate the certificate chain presented by the proxy
+  # SSL_CERT_FILE: "/var/lib/ca-certs/ca.pem"
+
+# Add additional volumes and mounts, for example to read other log files on the host
+extraVolumes:
+  - name: teleport-bootstrap-script
+    configMap:
+      name: teleport-bootstrap-script
+  # - name: ca-certs
+  #   configMap:
+  #     name: ca-certs
+extraVolumeMounts: []
+  # - name: ca-certs
+  #   mountPath: /var/lib/ca-certs
+  #   readOnly: true
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 200Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 100Mi
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+persistence:
+  enabled: false
+  accessMode: ReadWriteOnce
+  ## If defined, storageClass: <storageClass>
+  ## If set to "-", storageClass: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClass spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # existingClaim:
+  # annotations:
+  #  "helm.sh/resource-policy": keep
+  # storageClass: "-"
+  storageSize: 8Gi
+  # If PersistentDisk already exists you can create a PV for it by including the 2 following keypairs.
+  # pdName: teleport-data-disk
+  # fsType: ext4
+
+# set this to false to avoid running into issues for proxies that run in a separate k8s cluster
+automountServiceAccountToken: true

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -79,6 +79,7 @@ daemonset:
     ssh_service:
       enabled: yes
       labels:
+        node-type: kubernetes-worker
         running-on: host
 
     proxy_service:

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -22,6 +22,10 @@ config:
   auth_service:
     enabled: yes
     license_file: /var/lib/license/license-enterprise.pem
+    tokens:
+    - "node:static-join-token-for-nodes-edit-and-copy-to-daemonset-config-below"
+    # this needs to be set to localhost so the daemonset's node can join the cluster successfully
+    public_addr: ['localhost']
     # This will be the name that appears in the root cluster for management, so
     # it should be descriptive.
     cluster_name: add-leaf-cluster-name-here
@@ -52,6 +56,33 @@ trustedCluster:
     ROOT_CLUSTER_TUNNEL_ADDRESS: "root-cluster.example.com:3024"
     # The web proxy address of the root cluster (usually on port 3080 or 443)
     ROOT_CLUSTER_WEB_ADDRESS: "root-cluster.example.com:3080"
+
+# Daemonset Teleport node configuration
+# INSTRUCTIONS
+# The auth_token here MUST match the value of auth_service.tokens.node above so that the node can join the cluster
+# The public_addr of auth_service must also be set to 'localhost' to allow a connection from the host to the
+# in-cluster auth service's NodePort
+daemonset:
+  config:
+    teleport:
+      log:
+        # WARNING: Do not change this path or the daemonset will fail to run
+        output: /var/log/teleport.log
+        severity: DEBUG
+      auth_token: "static-join-token-for-nodes-edit-and-copy-to-daemonset-config-below"
+      auth_servers:
+      - localhost:32025
+
+    auth_service:
+      enabled: no
+
+    ssh_service:
+      enabled: yes
+      labels:
+        running-on: host
+
+    proxy_service:
+      enabled: no
 
 # Hopefully shouldn't need to change anything below here!
 labels: {}
@@ -188,10 +219,7 @@ extraVars: {}
   # SSL_CERT_FILE: "/var/lib/ca-certs/ca.pem"
 
 # Add additional volumes and mounts, for example to read other log files on the host
-extraVolumes:
-  - name: teleport-bootstrap-script
-    configMap:
-      name: teleport-bootstrap-script
+extraVolumes: []
   # - name: ca-certs
   #   configMap:
   #     name: ca-certs

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -104,6 +104,9 @@ annotations: {}
 replicaCount: 1
 strategy: RollingUpdate
 
+# Whether or not to define and use a PodSecurityPolicy
+usePSP: false
+
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 # affinity: {}


### PR DESCRIPTION
One use case that's requested with Teleport is to run the auth and proxy inside a Kubernetes cluster, but also provide access to the underlying Kubernetes worker nodes via Teleport's SSH functionality.

This Helm chart copies the existing Helm chart at https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-auto-trustedcluster (which itself is a copy of https://github.com/gravitational/teleport/tree/master/examples/chart/teleport with functionality added to automatically link a leaf cluster back up to a root cluster) and adds a `DaemonSet` to it. This `DaemonSet` will run a Teleport node on every Kubernetes worker, connecting it back to the Teleport cluster running inside Kubernetes using an exposed `NodePort`.

As per the documentation in the README, this solution is not safe to rely on for 'break-glass' emergency access to worker nodes in the event of problems with a Teleport cluster. It should be viewed as a best-effort solution in lieu of a worker node Teleport installation which is connected back to a Teleport cluster over the public internet instead.