### PR TITLE
Send keep-alive ping frames to the client via websocket connection

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -556,6 +556,9 @@ const (
 
 	// WebsocketResize is receiving a resize request.
 	WebsocketResize = "w"
+
+	// WebsocketPong receives pong from client after sending a server ping.
+	WebsocketPong = "p"
 )
 
 // The following are cryptographic primitives Teleport does not support in

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -556,9 +556,6 @@ const (
 
 	// WebsocketResize is receiving a resize request.
 	WebsocketResize = "w"
-
-	// WebsocketPong receives pong from client after sending a server ping.
-	WebsocketPong = "p"
 )
 
 // The following are cryptographic primitives Teleport does not support in

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1425,6 +1425,20 @@ func (h *Handler) siteNodeConnect(
 	log.Debugf("[WEB] new terminal request for ns=%s, server=%s, login=%s, sid=%s",
 		req.Namespace, req.Server, req.Login, req.SessionID)
 
+	authAccessPoint, err := site.CachingAccessPoint()
+	if err != nil {
+		log.Debugf("Unable to auth access point: %v.", err)
+		return nil, trace.Wrap(err)
+	}
+
+	clusterConfig, err := authAccessPoint.GetClusterConfig()
+	if err != nil {
+		log.Debugf("Unable to fetch cluster config: %v.", err)
+		return nil, trace.Wrap(err)
+	}
+
+	req.KeepAliveInterval = clusterConfig.GetKeepAliveInterval()
+	req.KeepAliveCountMax = clusterConfig.GetKeepAliveCountMax()
 	req.Namespace = namespace
 	req.ProxyHostPort = h.ProxyHostPort()
 	req.Cluster = site.GetName()

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1438,7 +1438,6 @@ func (h *Handler) siteNodeConnect(
 	}
 
 	req.KeepAliveInterval = clusterConfig.GetKeepAliveInterval()
-	req.KeepAliveCountMax = clusterConfig.GetKeepAliveCountMax()
 	req.Namespace = namespace
 	req.ProxyHostPort = h.ProxyHostPort()
 	req.Cluster = site.GetName()

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1427,13 +1427,13 @@ func (h *Handler) siteNodeConnect(
 
 	authAccessPoint, err := site.CachingAccessPoint()
 	if err != nil {
-		log.Debugf("Unable to auth access point: %v.", err)
+		log.Debugf("[WEB] Unable to get auth access point: %v.", err)
 		return nil, trace.Wrap(err)
 	}
 
 	clusterConfig, err := authAccessPoint.GetClusterConfig()
 	if err != nil {
-		log.Debugf("Unable to fetch cluster config: %v.", err)
+		log.Debugf("[WEB] Unable to fetch cluster config: %v.", err)
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -981,7 +981,7 @@ func (s *WebSuite) TestWebsocketPingLoop(c *C) {
 	c.Assert(err, IsNil)
 
 	// flush out raw event (pty texts)
-	err = s.waitForRawEvent(ws, 5*time.Second)
+	err = s.waitForRawEvent(ws, 1*time.Second)
 	c.Assert(err, IsNil)
 
 	// next frames should be just pings sent out by ping loop

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -986,13 +986,13 @@ func (s *WebSuite) TestWebsocketPingLoop(c *C) {
 
 	// next frames should be just pings sent out by ping loop
 	// b/c nothing else should be sending anything at this point
-	frame2, err := ws.NewFrameReader()
+	frame, err := ws.NewFrameReader()
 	c.Assert(err, IsNil)
-	c.Assert(int(frame2.PayloadType()), Equals, websocket.PingFrame)
+	c.Assert(int(frame.PayloadType()), Equals, websocket.PingFrame)
 
-	frame3, err := ws.NewFrameReader()
+	frame, err = ws.NewFrameReader()
 	c.Assert(err, IsNil)
-	c.Assert(int(frame3.PayloadType()), Equals, websocket.PingFrame)
+	c.Assert(int(frame.PayloadType()), Equals, websocket.PingFrame)
 
 	err = ws.Close()
 	c.Assert(err, IsNil)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -964,6 +964,40 @@ func (s *WebSuite) TestTerminal(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *WebSuite) TestWebsocketPingLoop(c *C) {
+	// change cluster default config for keep alive interval to be ran faster
+	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
+		SessionRecording:    services.RecordAtNode,
+		ProxyChecksHostKeys: services.HostKeyCheckYes,
+		KeepAliveInterval:   services.NewDuration(250 * time.Millisecond),
+		LocalAuth:           services.NewBool(true),
+	})
+	c.Assert(err, IsNil)
+
+	err = s.server.Auth().SetClusterConfig(clusterConfig)
+	c.Assert(err, IsNil)
+
+	ws, err := s.makeTerminal(s.authPack(c, "foo"))
+	c.Assert(err, IsNil)
+
+	// flush out raw event (pty texts)
+	err = s.waitForRawEvent(ws, 5*time.Second)
+	c.Assert(err, IsNil)
+
+	// next frames should be just pings sent out by ping loop
+	// b/c nothing else should be sending anything at this point
+	frame2, err := ws.NewFrameReader()
+	c.Assert(err, IsNil)
+	c.Assert(int(frame2.PayloadType()), Equals, websocket.PingFrame)
+
+	frame3, err := ws.NewFrameReader()
+	c.Assert(err, IsNil)
+	c.Assert(int(frame3.PayloadType()), Equals, websocket.PingFrame)
+
+	err = ws.Close()
+	c.Assert(err, IsNil)
+}
+
 func (s *WebSuite) TestWebAgentForward(c *C) {
 	ws, err := s.makeTerminal(s.authPack(c, "foo"))
 	c.Assert(err, IsNil)
@@ -1844,7 +1878,7 @@ func (s *WebSuite) waitForRawEvent(ws *websocket.Conn, timeout time.Duration) er
 	for {
 		select {
 		case <-timeoutContext.Done():
-			return trace.BadParameter("timeout waiting for resize event")
+			return trace.BadParameter("timeout waiting for raw event")
 		case <-doneContext.Done():
 			return nil
 		}

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -71,6 +71,13 @@ type TerminalRequest struct {
 
 	// InteractiveCommand is a command to execut.e
 	InteractiveCommand []string `json:"-"`
+
+	// KeepAliveInterval is the keep-alive interval for server to client connections.
+	KeepAliveInterval time.Duration
+
+	// KeepAliveCountMax is the max number ofr missed keep-alive messages before
+	// server disconnects the client.
+	KeepAliveCountMax int64
 }
 
 // AuthProvider is a subset of the full Auth API.

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -316,8 +316,11 @@ func (t *TerminalHandler) startPingLoop(ws *websocket.Conn) {
 	for {
 		select {
 		case <-tickerCh.C:
+			// Pongs are internally handled by the websocket library.
+			// https://github.com/golang/net/blob/master/websocket/hybi.go#L291
 			if err := codec.Send(ws, nil); err != nil {
 				t.log.Errorf("Unable to send ping frame to web client: %v.", err)
+				t.terminalCancel()
 				return
 			}
 		case <-t.terminalContext.Done():

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -320,7 +320,7 @@ func (t *TerminalHandler) startPingLoop(ws *websocket.Conn) {
 			// https://github.com/golang/net/blob/master/websocket/hybi.go#L291
 			if err := codec.Send(ws, nil); err != nil {
 				t.log.Errorf("Unable to send ping frame to web client: %v.", err)
-				t.terminalCancel()
+				t.Close()
 				return
 			}
 		case <-t.terminalContext.Done():

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -236,6 +236,9 @@ func (t *TerminalHandler) handler(ws *websocket.Conn) {
 
 	t.log.Debugf("Creating websocket stream for %v.", t.params.SessionID)
 
+	// Start sending ping frames through websocket to client.
+	go t.startPingLoop(ws)
+
 	// Pump raw terminal in/out and audit events into the websocket.
 	go t.streamTerminal(ws, tc)
 	go t.streamEvents(ws, tc)
@@ -289,8 +292,6 @@ func (t *TerminalHandler) makeClient(ws *websocket.Conn) (*client.TeleportClient
 	tc.OnShellCreated = func(s *ssh.Session, c *ssh.Client, _ io.ReadWriteCloser) (bool, error) {
 		t.sshSession = s
 		t.windowChange(&t.params.Term)
-
-		go t.startPingLoop(ws)
 
 		return false, nil
 	}

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -320,7 +320,6 @@ func (t *TerminalHandler) startPingLoop(ws *websocket.Conn) {
 			// https://github.com/golang/net/blob/master/websocket/hybi.go#L291
 			if err := codec.Send(ws, nil); err != nil {
 				t.log.Errorf("Unable to send ping frame to web client: %v.", err)
-				t.Close()
 				return
 			}
 		case <-t.terminalContext.Done():

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -320,6 +320,7 @@ func (t *TerminalHandler) startPingLoop(ws *websocket.Conn) {
 			// https://github.com/golang/net/blob/master/websocket/hybi.go#L291
 			if err := codec.Send(ws, nil); err != nil {
 				t.log.Errorf("Unable to send ping frame to web client: %v.", err)
+				t.Close()
 				return
 			}
 		case <-t.terminalContext.Done():

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -316,7 +316,7 @@ func (t *TerminalHandler) startPingLoop(ws *websocket.Conn) {
 		select {
 		case <-tickerCh.C:
 			if err := codec.Send(ws, nil); err != nil {
-				t.log.Errorf("Unable to send ping frame to web client.", err)
+				t.log.Errorf("Unable to send ping frame to web client: %v.", err)
 				return
 			}
 		case <-t.terminalContext.Done():


### PR DESCRIPTION
resolves https://github.com/gravitational/teleport/issues/3024

#### Description
This PR starts a ping loop for each terminal session, that will periodically send a ping frame to the web client through the websocket. This will prevent the connection from becoming idle.

- Get/Set KeepAliveInterval config
- Start ping loops for each new terminal session after `onShellCreated`
- Terminate ping loop when:
  - error sending ping frame
  - session closes
- Tested the ping loops are sending out ping frames. But I couldn't confirm that pong responses are received because pongs are getting swallowed here: https://github.com/golang/net/blob/master/websocket/hybi.go#L297
I did however test it manually that pongs were received from browser for every ping sent out, by placing a fmt.println in the code block that parses for ping/pongs.

#### websocket ping/pong traffic
browser responding with pongs:
![Screenshot from 2020-05-29 15-12-09](https://user-images.githubusercontent.com/43280172/83309749-f5ec8c80-a1be-11ea-96a0-56b89de704c1.png)
