### PR TITLE
Admin guide minor cleanup

### DIFF
--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -10,7 +10,7 @@ To install, download the official binaries from the [Teleport
 Downloads](https://gravitational.com/teleport/download/) section on our web site
 and run:
 
-```
+``` bash
 $ tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
 $ sudo make install
 ```
@@ -107,7 +107,7 @@ with verbose logging by typing [`teleport start -d`](cli-docs.md#teleport-start)
 In production, we recommend starting teleport daemon via an init system like
 `systemd` . Here's the recommended Teleport service unit file for systemd:
 
-``` yaml
+``` systemd
 [Unit]
 Description=Teleport SSH Service
 After=network.target
@@ -233,7 +233,6 @@ teleport:
     #  auth_servers:
     #     - teleport-proxy.example.com:3080
     auth_servers:
-
         - 10.1.0.5:3025
         - 10.1.0.6:3025
 
@@ -354,7 +353,6 @@ auth_service:
     # We recommend to use tools like `pwgen` to generate sufficiently random
     # tokens of 32+ byte length.
     tokens:
-
         - "proxy,node:xxxxx"
         - "auth:yyyy"
 
@@ -421,7 +419,6 @@ ssh_service:
     # this command will add a label 'arch=x86_64' to a node
 
     - name: arch
-
       command: ['/bin/uname', '-p']
       period: 1h0m0s
 
@@ -656,7 +653,7 @@ pointing to a JSON file that mirrors `facets` in the auth config.
 For logging in via the CLI, you must first install
 [u2f-host](https://developers.yubico.com/libu2f-host/). Installing:
 
-``` yaml
+``` bash
 # OSX:
 $ brew install libu2f-host
 
@@ -666,8 +663,8 @@ $ apt-get install u2f-host
 
 Then invoke `tsh ssh` as usual to authenticate:
 
-```
-tsh --proxy <proxy-addr> ssh <hostname>
+``` bash
+$ tsh --proxy <proxy-addr> ssh <hostname>
 ```
 
 !!! tip "Version Warning"
@@ -694,20 +691,20 @@ Let's look at this table:
 |------------------|---------------|-----------------------------
 |joe    | joe, root | Teleport user 'joe' can login into member nodes as OS user 'joe' or 'root'
 |bob    | bob      | Teleport user 'bob' can login into member nodes only as OS user 'bob'
-|ross   |          | If no OS login is specified, it defaults to the same name as the Teleport user.
+|ross   |          | If no OS login is specified, it defaults to the same name as the Teleport user - 'ross'.
 
 To add a new user to Teleport, you have to use the [`tctl`](cli-docs.md#tctl)
 tool on the same node where the auth server is running, i.e.
 [`teleport`](cli-docs.md#teleport) was started with `--roles=auth` .
 
-``` bsh
+``` bash
 $ tctl users add joe joe,root
 ```
 
 Teleport generates an auto-expiring token (with a TTL of 1 hour) and prints the
 token URL which must be used before the TTL expires.
 
-``` bsh
+``` bash
 Signup token has been created. Share this URL with the user:
 https://<proxy>:3080/web/newuser/xxxxxxxxxxxx
 
@@ -723,7 +720,7 @@ need to log back in with her credentials. This TTL can be configured to a
 different value. Once authenticated, the account will become visible via `tctl`
 :
 
-``` bsh
+``` bash
 $ tctl users ls
 
 User           Allowed Logins
@@ -736,13 +733,13 @@ joe            joe,root
 Joe would then use the `tsh` client tool to log in to member node "luna" via
 bastion "work" _as root_:
 
-``` yaml
+``` bash
 $ tsh --proxy=work --user=joe root@luna
 ```
 
 To delete this user:
 
-``` yaml
+``` bash
 $ tctl users rm joe
 ```
 
@@ -752,13 +749,13 @@ Users entries can be manipulated using the generic [resource
 commands](#resources) via [`tctl`](cli-docs.md#tctl) . For example, to see the
 full list of user records, an administrator can execute:
 
-``` yaml
+``` bash
 $ tctl get users
 ```
 
 To edit the user "joe":
 
-``` yaml
+``` bash
 # dump the user definition into a file:
 $ tctl get user/joe > joe.yaml
 # ... edit the contents of joe.yaml
@@ -818,14 +815,14 @@ Use the [`tctl`](cli-docs.md#tctl) tool to register a new invitation token (or
 it can also generate a new token for you). In the following example a new token
 is created with a TTL of 5 minutes:
 
-``` bsh
+``` bash
 $ tctl nodes add --ttl=5m --roles=node,proxy --token=secret-value
 The invite token: secret-value
 ```
 
 If `--token` is not provided, [`tctl`](cli-docs.md#tctl) will generate one:
 
-``` bsh
+``` bash
 # generate a short-lived invitation token for a new node:
 $ tctl nodes add --ttl=5m --roles=node,proxy
 The invite token: e94d68a8a1e5821dbd79d03a960644f0
@@ -845,7 +842,7 @@ $ tctl tokens rm e94d68a8a1e5821dbd79d03a960644f0
 Both static and short-lived tokens are used the same way. Execute the following
 command on a new node to add it to a cluster:
 
-``` bsh
+``` bash
 # adding a new regular SSH node to the cluster:
 $ teleport start --roles=node --token=secret-token-value --auth-server=10.0.10.5
 
@@ -859,7 +856,7 @@ $ teleport start --roles=proxy --token=secret-token-value --auth-server=10.0.10.
 As new nodes come online, they start sending ping requests every few seconds to
 the CA of the cluster. This allows users to explore cluster membership and size:
 
-``` bsh
+``` bash
 $ tctl nodes ls
 
 Node Name     Node ID                                  Address            Labels
@@ -882,7 +879,7 @@ the command: [`tctl nodes ls`](cli-docs.md#tctl-nodes-ls).
 
 #### Remove a Node Immediately
 If you need to remove a node immediately, stop the node process and run [`tctl rm node/<UUID>`](cli-docs.md#tctl-rm):
-``` bsh
+``` bash
 # STOP the node process first
 
 # get the UUID of the node you want to remove
@@ -912,8 +909,9 @@ e.g. `10.0.10.5` .
 
 To prevent this from happening, you need to supply every new node with an
 additional bit of information about the auth server. This technique is called
-"CA Pinning". It works by asking the auth server to produce a "CA Pin", which is
-a hashed value of its private key, i.e. it cannot be forged by an attacker.
+"CA Pinning". It works by asking the auth server to produce a "CA Pin", which
+is a hashed value of its public key, i.e. for which an attacker can't forge a
+matching private key.
 
 On the auth server:
 
@@ -968,7 +966,7 @@ As you have seen above, Teleport uses tokens to invite users to a cluster
 Both types of tokens can be revoked before they can be used. To see a list of
 outstanding tokens, run this command:
 
-``` bsh
+``` bash
 $ tctl tokens ls
 
 Token                                Role       Expiry Time (UTC)
@@ -987,7 +985,7 @@ cluster. And the 3rd token was generated to invite a new user.
 The latter two tokens can be deleted (revoked) via [`tctl tokens
 del`](cli-docs.md#tctl-tokens-rm) command:
 
-``` yaml
+``` bash
 $ tctl tokens del 696c0471453e75882ff70a761c1a8bfa
 Token 696c0471453e75882ff70a761c1a8bfa has been deleted
 ```
@@ -1001,11 +999,11 @@ Teleport Node Tunneling lets you add a node to an existing Teleport Cluster. Thi
 useful for IoT applications or for managing a couple of servers in a different network.  
 
 Similar to [Adding Nodes to Cluster](#adding-nodes-to-the-cluster), use `tctl` to
-create a single-use token for a node, but this time you'll replace the auth server IP with
-the URL of the Proxy Server. In the Example below, we've replaced the auth server IP with the Proxy#adding-nodes-to-the-cluster
-web endpoint `teleport.example.com`.  
+create a single-use token for a node, but this time you'll replace the auth
+server IP with the URL of the Proxy Server. In the Example below, we've
+replaced the auth server IP with the Proxy web endpoint `teleport.example.com`.
 
-```bash
+``` bash
 $ sudo tctl nodes add
 
 The invite token: n92bb958ce97f761da978d08c35c54a5c
@@ -1041,7 +1039,7 @@ There are two ways to configure node labels.
 To define labels as command line arguments, use `--labels` flag like shown
 below. This method works well for static labels or simple commands:
 
-``` yaml
+``` bash
 $ teleport start --labels uptime=[1m:"uptime -p"],kernel=[1h:"uname -r"]
 ```
 
@@ -1127,7 +1125,7 @@ Let's examine the Teleport audit log using the `dir` backend. The event log is
 stored in `data_dir` under `log` directory, usually `/var/lib/teleport/log` .
 Each day is represented as a file:
 
-``` yaml
+``` bash
 $ ls -l /var/lib/teleport/log/
 total 104
 -rw-r----- 1 root root  31638 Jan 22 20:00 2017-01-23.00:00:00.log
@@ -1198,9 +1196,10 @@ The recorded sessions are stored as raw bytes in the `sessions` directory under
     human-readable, although you are better off using [`tsh
     play`](cli-docs.md#tsh-play) or the Web UI to replay it.
 
-2. `.log` file or `.events.gz` compressed file contains the copies of the event log entries that are            related to this session.
+2. `.log` file or `.events.gz` compressed file contains the copies of the event
+   log entries that are related to this session.
 
-``` yaml
+``` bash
 $ ls /var/lib/teleport/log/sessions/default
 -rw-r----- 1 root root 506192 Feb 4 00:46 4c146ec8-eab6-11e6-b1b3-40167e68e931.session.bytes
 -rw-r----- 1 root root  44943 Feb 4 00:46 4c146ec8-eab6-11e6-b1b3-40167e68e931.session.log
@@ -1208,7 +1207,7 @@ $ ls /var/lib/teleport/log/sessions/default
 
 To replay this session via CLI:
 
-``` yaml
+``` bash
 $ tsh --proxy=proxy play 4c146ec8-eab6-11e6-b1b3-40167e68e931
 ```
 
@@ -1231,7 +1230,7 @@ auth_service:
 Next, `sshd` must be told to allow users to log in with certificates generated
 by the Teleport User CA. Start by exporting the Teleport CA public key:
 
-``` yaml
+``` bash
 $ tctl auth export --type=user
 ```
 
@@ -1268,7 +1267,7 @@ auth_service:
 The recommended solution is to ask Teleport to issue valid host certificates for
 all OpenSSH nodes. To generate a host certificate run this on your auth server:
 
-``` yaml
+``` bash
 $ tctl auth sign \
       --host=node.example.com \
       --format=openssh
@@ -1288,11 +1287,11 @@ in "recording mode", you have to tell the `ssh` client to use the jump host and
 enable the agent forwarding, otherwise a recording proxy will not be able to
 terminate the SSH connection to record it:
 
-``` bsh
+``` bash
 # Note that agent forwarding is enabled twice: one from a client to a proxy
 # (mandatory if using a recording proxy), and then optionally from a proxy
 # to the end server if you want your agent running on the end server or not
-ssh -o "ForwardAgent yes" \
+$ ssh -o "ForwardAgent yes" \
     -o "ProxyCommand ssh -o 'ForwardAgent yes' -p 3023 %r@p.example.com -s proxy:%h:%p" \
     user@host.example.com
 ```
@@ -1309,7 +1308,7 @@ It's important to remember that SSH agent forwarding must be enabled on the
 client. Verify that a Teleport certificate is loaded into the agent after
 logging in:
 
-``` bsh
+``` bash
 # Login as Joe
 $ tsh login --proxy=proxy.example.com joe
 # see if the certificate is present (look for "teleport:joe") at the end of the cert
@@ -1328,7 +1327,7 @@ When using a Teleport proxy in "recording mode", be aware of OpenSSH built-in
 rate limiting. On large number of proxy connections you may encounter errors
 like:
 
-``` bsh
+``` bash
 channel 0: open failed: connect failed: ssh: handshake failed: EOF
 ```
 
@@ -1349,8 +1348,7 @@ A Teleport administrator has two tools to configure a Teleport cluster:
   the cluster name.
 
 * The [`tctl`](cli-docs.md#tctl) admin tool is used for manipulating dynamic
-  records like Teleport
-  users.
+  records like Teleport users.
 
 [`tctl`](cli-docs.md#tctl) has convenient subcommands for dynamic
 configuration, like `tctl users` or `tctl nodes` . However, for dealing with
@@ -1407,7 +1405,6 @@ spec:
     # these are "allowed logins" which are usually specified as the
     # last argument to `tctl users add`
     logins:
-
     - joe
     - root
 
@@ -1438,7 +1435,7 @@ Here's the list of resources currently exposed via [`tctl`](cli-docs.md#tctl) :
 
 **Examples:**
 
-``` yaml
+``` bash
 # list all connectors:
 $ tctl get connectors
 
@@ -1472,7 +1469,7 @@ to have a direct connection to other clusters' proxy servers. Trusted clusters
 also have their own restrictions on user access. The user experience looks like
 this:
 
-``` yaml
+``` bash
 # login using the "main" cluster credentials:
 $ tsh login --proxy=main.example.com
 
@@ -1493,7 +1490,7 @@ To avoid using `--cluster` switch with [`tsh`](cli-docs.md#tsh) commands, you
 can also specify which trusted cluster you want to become the default from the
 start:
 
-``` yaml
+``` bash
 # login into "main" but request "east" to be the default for subsequent
 # tsh commands:
 $ tsh login --proxy=main.example.com east
@@ -1567,7 +1564,7 @@ auth_service:
 If you wish to use auto-expiring cluster tokens, execute this CLI command on the
 "main" side:
 
-``` yaml
+``` bash
 $ tctl tokens add --type=trusted_cluster
 The cluster invite token: generated-token-to-add-new-clusters
 ```
@@ -1606,7 +1603,7 @@ spec:
 
 Then, use [`tctl create`](cli-docs.md#tctl-create) to add the file:
 
-``` yaml
+``` bash
 $ tctl create cluster.yaml
 ```
 
@@ -1629,7 +1626,7 @@ users from the "main" (trusted cluster) can now access nodes in the "east"
 (trusting cluster). Users in the "east" cluster will not be able to access the
 "main" cluster.
 
-``` bsh
+``` bash
 # login into the main cluster:
 $ tsh --proxy=proxy.main login joe
 
@@ -1659,13 +1656,13 @@ To temporarily disable trust between clusters, i.e.to disconnect the "east"
 cluster from "main", edit the YAML definition of the trusted cluster resource
 and set `enabled` to "false", then update it:
 
-``` yaml
+``` bash
 $ tctl create --force cluster.yaml
 ```
 
 If you want to _permanently_ disconnect one cluster from the other:
 
-``` yaml
+``` bash
 # execute this command on "main" side to disconnect "east":
 $ tctl rm tc/east
 ```
@@ -1677,12 +1674,13 @@ directions. If you remove "east" from "main", the following will happen:
   tunnel connection from "east" and will not allow a new one.
 
 * "main" will stop trusting certificates issued by "east".
+
 * "east" will continue to trust certificates issued by "main".
 
 If you wish to permanently remove all trust relationships and the connections
 between both clusters:
 
-``` yaml
+``` bash
 # execute on "main":
 $ tctl rm tc/east
 # execute on "east":
@@ -1738,7 +1736,6 @@ spec:
       team: admins # Github team name within that organization
       # allowed logins for users in this org/team
       logins:
-
         - root
 
       # List of Kubernetes groups this Github team is allowed to connect to
@@ -1762,7 +1759,7 @@ the resource spec.
 Finally, create the connector using [`tctl`](cli-docs.md#tctl)
 [resource](#resources) management command:
 
-``` yaml
+``` bash
 $ tctl create github.yaml
 ```
 
@@ -1877,14 +1874,14 @@ On your client machine, you need to import these keys. It will allow your
 OpenSSH client to verify that host's certificates are signed by the trusted CA
 key:
 
-``` yaml
+``` bash
 $ cat cluster_node_keys >> ~/.ssh/known_hosts
 ```
 
 Make sure you are running OpenSSH's `ssh-agent` , and have logged in to the
 Teleport proxy:
 
-``` yaml
+``` bash
 $ eval `ssh-agent`
 $ tsh --proxy=work.example.com login
 ```
@@ -1899,7 +1896,7 @@ Lastly, configure the OpenSSH client to use the Teleport proxy when connecting
 to nodes with matching names. Edit `~/.ssh/config` for your user or
 `/etc/ssh/ssh_config` for global changes:
 
-``` bsh
+``` bash
 # work.example.com is the jump host (proxy). credentials will be obtained from the
 # openssh agent.
 Host work.example.com
@@ -1925,7 +1922,7 @@ Host *.remote-cluster.example.com
 When everything is configured properly, you can use ssh to connect to any node
 behind `work.example.com` :
 
-``` bsh
+``` bash
 $ ssh root@database.work.example.com
 ```
 
@@ -1944,7 +1941,7 @@ you have to configure `sshd` to trust the Teleport CA.
 
 Export the Teleport CA certificate into a file:
 
-``` bsh
+``` bash
 $ tctl auth export --type=user > teleport-user-ca.pub
 ```
 
@@ -1969,7 +1966,7 @@ will show you how to implement certificate rotation in practice.
 The easiest way to start the rotation is to execute this command on a cluster's
 _auth server_:
 
-``` bsh
+``` bash
 $ tctl auth rotate
 ```
 
@@ -1978,7 +1975,7 @@ period_ of 48 hours.
 
 This can be customized, i.e.
 
-``` bsh
+``` bash
 # rotate only user certificates with a grace period of 200 hours:
 $ tctl auth rotate --type=user --grace-period=200h
 
@@ -2001,7 +1998,7 @@ certificate for itself before the grace period ends.
 
 To check the status of certificate rotation:
 
-``` bsh
+``` bash
 $ tctl status
 ```
 
@@ -2015,9 +2012,9 @@ $ tctl status
 
 !!! warning "CA Pinning Warning"
 
-    If you are using [CA Pinning](#untrusted-auth-servers)
-    when adding new nodes, the CA pin will
-    changes after the rotation.
+    If you are using [CA Pinning](#untrusted-auth-servers) when adding new
+    nodes, the CA pin will changes after the rotation. Make sure you use the
+    _new_ CA pin when adding nodes after rotation.
 
 ## Ansible Integration
 
@@ -2028,7 +2025,7 @@ Teleport Proxy:
 * configure your OpenSSH to connect to Teleport proxy and use `ssh-agent` socket
 * enable scp mode in the Ansible config file (default is `/etc/ansible/ansible.cfg` ):
 
-```bsh
+```bash
 scp_if_ssh = True
 ```
 
@@ -2050,17 +2047,17 @@ chapter.
 
 In the scenario illustrated above a user would execute the following commands:
 
-```bsh
+``` bash
 # Authentication step to retrieve the certificates. tsh login places the SSH
 # certificate into ~/.tsh as usual and updates ~/.kube/config on your local
 # client with Kubernetes credentials:
-[client] $ tsh --proxy=teleport.example.com login
+$ tsh --proxy=teleport.example.com login
 
 # You can execute SSH commands on your local client to access SSH nodes:
-[client] $ tsh ssh login@ssh-node
+$ tsh ssh login@ssh-node
 
 # You can also execute any kubectl commands on your local client to access the Kubernetes cluster:
-[client] $ kubectl get pods
+$ kubectl get pods
 ```
 
 ### Kubernetes/Teleport Configuration
@@ -2093,7 +2090,7 @@ API endpoint. This can be done either by:
 When adding new local users you have to specify which Kubernetes groups they
 belong to:
 
-``` bsh
+``` bash
 $ tctl users add joe --k8s-groups="system:masters"
 ```
 
@@ -2116,7 +2113,7 @@ which contains some more specific examples and instructions.
 ### Multiple Kubernetes Clusters
 
 You can take advantage of the [Trusted Clusters](#trusted-clusters) feature of
-Teleport to federate trust across multiple Kubernetes clusters.
+Teleport to access multiple Kubernetes clusters from a root Teleport cluster.
 
 When multiple trusted clusters are present behind a Teleport proxy, the
 `kubeconfig` generated by [`tsh login`](cli-docs.md#tsh-login) will contain the
@@ -2132,7 +2129,7 @@ login`](cli-docs.md#tsh-login).
 
 In this scenario, users usually login using this command:
 
-``` bsh
+``` bash
 # Using login without arguments
 $ tsh --proxy=main.example.com login
 
@@ -2170,7 +2167,7 @@ highly available secrets back-end first. Also, you must tell each node in a
 cluster that there is more than one auth server available. There are two ways to
 do this:
 
-  + Use a load balancer to to create a single auth API access point (AP) and
+  * Use a load balancer to create a single auth API access point (AP) and
     specify this AP in `auth_servers` section of Teleport configuration for all
     nodes in a cluster. This load balancer should do TCP level forwarding.
 
@@ -2196,9 +2193,9 @@ Teleport will handle its own SSL on top of that with its own certificates.
 !!! tip "NOTE"
 
     If you terminate TLS with your own certificate at a load
-    balancer you'll need to Teleport with `--insecure`
+    balancer you'll need to run Teleport with `--insecure`
 
-If your load balancer supports health checks, configure it to hit the
+If your load balancer supports HTTP health checks, configure it to hit the
 `/webapi/ping` endpoint on the proxy. This endpoint will reply `200 OK` if the
 proxy is running without problems.
 
@@ -2385,7 +2382,7 @@ teleport:
 }
 ```
 
-### Using GCP Storage
+### Using GCS
 
 !!! tip "Tip"
 
@@ -2394,15 +2391,16 @@ teleport:
     Architecture documentation.
 
 
-GCP object storage can only be used as a storage for the recorded sessions. GCP Storage 
-cannot store the audit log or the cluster state. Below is an example of how to
-configure a Teleport auth server to store the recorded sessions in an GCP bucket.
+Google Cloud Storage (GCS) can only be used as a storage for the recorded
+sessions. GCS cannot store the audit log or the cluster state. Below is an
+example of how to configure a Teleport auth server to store the recorded
+sessions in a GCS bucket.
 
 ``` yaml
 teleport:
   storage:
-      # Path to GCP Storage to store the recorded sessions in.
-      audit_sessions_uri: "sgs://Example_TELEPORT_STORAGE/records"
+      # Path to GCS to store the recorded sessions in.
+      audit_sessions_uri: "gs://Example_TELEPORT_STORAGE/records"
       credentials_path: /var/lib/teleport/gcs_creds
 ```
 
@@ -2421,8 +2419,9 @@ high availability. Firestore back-end supports two types of Teleport data:
 * Cluster state
 * Audit log events
 
-Firestore cannot store the recorded sessions. You are advised to use GCP Storage for
-that as shown above. To configure Teleport to use Firestore:
+Firestore cannot store the recorded sessions. You are advised to use Google
+Cloud Storage (GCS) for that as shown above. To configure Teleport to use
+Firestore:
 
 * Configure all Teleport Auth servers to use Firestore back-end in the "storage"
   section of `teleport.yaml` as shown below.
@@ -2456,19 +2455,20 @@ teleport:
 
 * Replace `Example_GCP_Project_Name` and `Example_TELEPORT_FIRESTORE_TABLE_NAME`
   with your own settings. Teleport will create the table automatically.
-  
+
 * `Example_TELEPORT_FIRESTORE_TABLE_NAME` and `Example_TELEPORT_FIRESTORE_EVENTS_TABLE_NAME`
   **must** be different Firestore tables. The schema is different for each. Using the same
   table name for both will result in errors.
-  
-* The AWS authentication setting above can be omitted if the machine itself is
-  running on an EC2 instance with an IAM role.
+
+* The GCP authentication setting above can be omitted if the machine itself is
+  running on a GCE instance with a Service Account that has access to the
+  Firestore table.
 
 * Audit log settings above are optional. If specified, Teleport will store the
   audit log in Firestore and the session recordings **must** be stored in a GCP
   bucket, i.e.both `audit_xxx` settings must be present. If they are not set,
   Teleport will default to a local file  system for the audit log, i.e.
-`/var/lib/teleport/log` on an auth server.
+  `/var/lib/teleport/log` on an auth server.
 
 
 ## Upgrading Teleport
@@ -2500,8 +2500,8 @@ clients, etc), the following rules apply:
   means you must not attempt to upgrade from 3.3 straight to 3.5. You must
   upgrade to 3.4 first.
 
-* Teleport clients [`tsh`](cli-docs.md#tsh) for users and [`tctl`](cli-docs.md#tctl) for admins 
-  may not be compatible
+* Teleport clients [`tsh`](cli-docs.md#tsh) for users and [`tctl`](cli-docs.md#tctl) for admins
+  may not be compatible with different versions of the `teleport` service.
 
 As an extra precaution you might want to backup your application prior to upgrading. We provide more instructions in [Backup before upgrading](#backup-before-upgrading).
 
@@ -2566,22 +2566,22 @@ When backing up Teleport you'll need to backup up your auth server's `data_dir/s
 
 **Example of backing up and restoring a cluster.**
 
-```
+``` bash
 # export dynamic configuration state from old cluster
-tctl get all > state.yaml
+$ tctl get all > state.yaml
 
 # prepare a new uninitialized backend (make sure to port
 # any non-default config values from the old config file)
-mkdir fresh && cat > fresh.yaml << EOF
+$ mkdir fresh && cat > fresh.yaml << EOF
 teleport:
   data_dir: fresh
 EOF
 
 # bootstrap fresh server (kill the old one first!)
-teleport start --config fresh.yaml --bootstrap state.yaml
+$ teleport start --config fresh.yaml --bootstrap state.yaml
 
 # from another terminal, verify state transferred correctly
-tctl --config fresh.yaml get all
+$ tctl --config fresh.yaml get all
 # <your state here!>
 ```
 
@@ -2653,7 +2653,7 @@ directory. Assuming the default location, `rm -rf /var/lib/teleport/*` will do.
 Teleport also supports HTTP endpoints for monitoring purposes. They are disabled
 by default, but you can enable them:
 
-``` yaml
+``` bash
 $ teleport start --diag-addr=127.0.0.1:3000
 ```
 


### PR DESCRIPTION
- fix code block language indicators
- make shell prompts consistent
- use "GCS" instead of "GCP Storage", it's the official name
- other misc tweaks