### PR TITLE
Improved error message when node is offline.

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1161,8 +1161,7 @@ func (s *IntSuite) TestTwoClustersTunnel(c *check.C) {
 		// Stop "site-A" and try to connect to it again via "site-A" (expect a connection error)
 		a.StopAuth(false)
 		err = tc.SSH(context.TODO(), cmd, false)
-		// debug mode will add more lines, so this check has to be flexible
-		c.Assert(strings.Replace(err.Error(), "\n", "", -1), check.Matches, fmt.Sprintf(`.*%v is offline.*`, a.Secrets.SiteName))
+		c.Assert(err, check.FitsTypeOf, trace.ConnectionProblem(nil, ""))
 
 		// Reset and start "Site-A" again
 		a.Reset()

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -601,7 +601,13 @@ func (s *remoteSite) connThroughTunnel(req *dialReq) (*utils.ChConn, error) {
 	// Didn't connect and no error? This means we didn't have any connected
 	// tunnels to try.
 	if err == nil {
-		err = trace.ConnectionProblem(nil, "%v is offline", s.GetName())
+		// Return the appropriate message if the user is trying to connect to a
+		// cluster or a node.
+		message := fmt.Sprintf("cluster %v is offline", s.GetName())
+		if req.Address != RemoteAuthServer {
+			message = fmt.Sprintf("node %v is offline", req.Address)
+		}
+		err = trace.ConnectionProblem(nil, message)
 	}
 	return nil, err
 }


### PR DESCRIPTION
**Description**

When connecting to a remote cluster, if the connection failed return node is offline or cluster is offline (instead of always cluster is offline) to return a better error to the caller.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/3458