### PR TITLE
Improve error message for IoT node without a tunnel

### DIFF
--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -18,6 +18,7 @@ package reversetunnel
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -52,6 +53,14 @@ type DialParams struct {
 	// ServerID the hostUUID.clusterName of a Teleport node. Used with nodes
 	// that are connected over a reverse tunnel.
 	ServerID string
+}
+
+func (params DialParams) String() string {
+	to := params.To.String()
+	if to == "" {
+		to = params.ServerID
+	}
+	return fmt.Sprintf("from: %q to: %q", params.From, to)
 }
 
 // RemoteSite represents remote teleport site that can be accessed via

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1411,7 +1411,7 @@ func (s *Server) handleProxyJump(ccx *sshutils.ConnectionContext, identityContex
 
 func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
 	log.Error(err)
-	message := []byte(utils.UserMessageFromError(err))
+	message := []byte(trace.UserMessage(err))
 	ch.Stderr().Write(message)
 	if req.WantReply {
 		req.Reply(false, message)


### PR DESCRIPTION
When a node doesn't have an active tunnel, the error should say so
clearly. This is reflected in 2 places:
- proxy error log
- tsh user output

Also, use trace.UserMessage instead of utils.UserMessageFromError.
utils.UserMessageFromError will return a full stack trace when calling
process (proxy) is in debug mode. The user shouldn't see this.

Fixes #3467