### PR TITLE
Moved SSO outside main Nav

### DIFF
--- a/docs/4.2.yaml
+++ b/docs/4.2.yaml
@@ -31,9 +31,9 @@ extra_javascript: []
 extra:
     version: 4.2
     teleport:
-        version: 4.2.8
+        version: 4.2.9
         golang: 1.13
-        sha: 52c176e403fa330012ba371abe71d9867f76277c0e3e01402fd29e6b95d34fe5
+        sha: 87ef75e6fe62d49dd75e41d43433e43cf38aed6077b991582166a1cd8e9c14e7
 nav:
     - Documentation:
         - Introduction: index.md
@@ -43,28 +43,25 @@ nav:
         - Admin Manual: admin-guide.md
         - Production Guide: production.md
         - FAQ: faq.md
-    - Teleport Advanced Features: 
-        - Enhanced Session Recording: features/enhanced_session_recording.md
-        - Using Teleport with PAM: features/ssh_pam.md
     - Infrastructure Guides:
         - AWS: aws_oss_guide.md
         - AWS HA with Terraform: aws_terraform_guide.md
         - GCP: gcp_guide.md
         - IBM: ibm_cloud_guide.md
         - Kubernetes Guide: kubernetes_ssh.md
-    - Enterprise Guides:
+    - Teleport Enterprise :
         - Introduction: enterprise/index.md
         - Quick Start Guide: enterprise/quickstart-enterprise.md
         - Single sign-on (SSO): enterprise/ssh_sso.md   
         - FedRAMP & FIPS: enterprise/ssh_fips.md        
         - RBAC: enterprise/ssh_rbac.md 
-    - SSO Guides:
-        - Azure Active Directory (AD): ssh_azuread.md
-        - Active Directory (ADFS): ssh_adfs.md
-        - G Suite: ssh_gsuite.md
-        - OneLogin: ssh_one_login.md
-        - OIDC: oidc.md
-        - Okta: ssh_okta.md
+        #- SSO Guides:
+        #    - Azure Active Directory (AD): enterprise/sso/ssh_azuread.md
+        #    - Active Directory (ADFS):  enterprise/sso/ssh_adfs.md
+        #    - G Suite:  enterprise/sso/ssh_gsuite.md
+        #    - OneLogin:  enterprise/sso/ssh_one_login.md
+        #    - OIDC:  enterprise/sso/oidc.md
+        #    - Okta:  enterprise/sso/ssh_okta.md
     - Architecture:
         - Architecture Overview: architecture/teleport_architecture_overview.md
         - Teleport Users: architecture/teleport_users.md
@@ -72,5 +69,8 @@ nav:
         - Teleport Auth: architecture/teleport_auth.md
         - Teleport Proxy: architecture/teleport_proxy.md
         - Trusted Clusters: trustedclusters.md
+    - Teleport Advanced Features: 
+        - Enhanced Session Recording: features/enhanced_session_recording.md
+        - Using Teleport with PAM: features/ssh_pam.md
     - CLI Reference:
         - CLI Reference: cli-docs.md

--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -1219,7 +1219,7 @@ session recording works. By default, the recording is not available if a cluster
 runs `sshd` (the OpenSSH daemon) on the nodes.
 
 To enable session recording for `sshd` nodes, the cluster must be switched to
-["recording proxy" mode](architecture/teleport_proxy.md#recording_proxy_mode).
+["recording proxy" mode](architecture/teleport_proxy.md#recording-proxy-mode).
 In this mode, the recording will be done on the proxy level:
 
 ``` yaml

--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -2045,8 +2045,7 @@ Kubernetes cluster:
 ![teleport-kubernetes-integration](img/teleport-kube.png)
 
 For more detailed information, please take a look at [Kubernetes Integration
-with SSH](admin-guide.md#kubernetes-integration) section in the Architecture
-chapter.
+with SSH](kubernetes_ssh.md) guide.
 
 In the scenario illustrated above a user would execute the following commands:
 

--- a/docs/4.2/enterprise/quickstart-enterprise.md
+++ b/docs/4.2/enterprise/quickstart-enterprise.md
@@ -306,9 +306,9 @@ Take a look at the [SSH via Single Sign-on](ssh_sso.md) chapter to learn the bas
 integrating Teleport with SSO providers. We have the following detailed guides for
 configuring SSO providers:
 
-* [Okta](../ssh_okta.md)
-* [Active Directory](../ssh_adfs.md)
-* [One Login](../ssh_one_login.md)
+* [Okta](sso/ssh_okta.md)
+* [Active Directory](sso/ssh_adfs.md)
+* [One Login](sso/ssh_one_login.md)
 * [Github](../admin-guide.md#github-oauth-20)
 
 Any SAML-compliant provider can be configured with Teleport by following the

--- a/docs/4.2/enterprise/ssh_sso.md
+++ b/docs/4.2/enterprise/ssh_sso.md
@@ -34,6 +34,15 @@ succeeds, Teleport will retrieve an SSH certificate and will store it in
 `~/.tsh/keys/proxy.example.com` directory and also will add it to an 
 [SSH agent](https://en.wikipedia.org/wiki/Ssh-agent) if there's one running.
 
+### SSO Setup Guides
+
+- [Azure Active Directory (AD)](sso/ssh_azuread.md)
+- [Active Directory (ADFS)](sso/ssh_adfs.md) 
+- [G Suite](sso/ssh_gsuite.md)
+- [OneLogin](sso/ssh_one_login.md)
+- [OIDC](sso/oidc.md)
+- [Okta](sso/ssh_okta.md)
+
 ## Configuring SSO
 
 Teleport works with SSO providers by relying on a concept called
@@ -97,6 +106,8 @@ spec:
 * See [examples/resources](https://github.com/gravitational/teleport/tree/master/examples/resources)
   directory in the Teleport Github repository for examples of possible connectors.
 
+
+
 ### User Logins
 
 Often it is required to restrict SSO users to their unique UNIX logins when they
@@ -148,10 +159,10 @@ $ tsh --proxy=proxy.example.com login --auth=local --user=admin
 Refer to the following guides to configure authentication connectors of both
 SAML and OIDC types:
 
-* [SSH Authentication with Okta](../ssh_okta.md)
-* [SSH Authentication with OneLogin](../ssh_one_login.md)
-* [SSH Authentication with ADFS](../ssh_adfs.md)
-* [SSH Authentication with OAuth2 / OpenID Connect](../oidc.md)
+* [SSH Authentication with Okta](sso/ssh_okta.md)
+* [SSH Authentication with OneLogin](sso/ssh_one_login.md)
+* [SSH Authentication with ADFS](sso/ssh_adfs.md)
+* [SSH Authentication with OAuth2 / OpenID Connect](sso/oidc.md)
 
 ## SSO Customization 
 

--- a/docs/4.2/enterprise/ssh_sso.md
+++ b/docs/4.2/enterprise/ssh_sso.md
@@ -1,7 +1,5 @@
 # Single Sign-On (SSO) for SSH
 
-## Introduction
-
 The commercial edition of Teleport allows users to login and retrieve their SSH
 credentials through a [Single Sign-On](https://en.wikipedia.org/wiki/Single_sign-on)
 (SSO) system used by the rest of the organization.
@@ -13,6 +11,15 @@ well as open source products like [Keycloak](http://www.keycloak.org).
 Other identity management systems are supported as long as they provide an
 SSO mechanism based on either [SAML](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
 or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
+
+### SSO Setup Guides
+
+- [Azure Active Directory (AD)](sso/ssh_azuread.md)
+- [Active Directory (ADFS)](sso/ssh_adfs.md) 
+- [G Suite](sso/ssh_gsuite.md)
+- [OneLogin](sso/ssh_one_login.md)
+- [OIDC](sso/oidc.md)
+- [Okta](sso/ssh_okta.md)
 
 
 ## How does SSO work with SSH?
@@ -34,14 +41,6 @@ succeeds, Teleport will retrieve an SSH certificate and will store it in
 `~/.tsh/keys/proxy.example.com` directory and also will add it to an 
 [SSH agent](https://en.wikipedia.org/wiki/Ssh-agent) if there's one running.
 
-### SSO Setup Guides
-
-- [Azure Active Directory (AD)](sso/ssh_azuread.md)
-- [Active Directory (ADFS)](sso/ssh_adfs.md) 
-- [G Suite](sso/ssh_gsuite.md)
-- [OneLogin](sso/ssh_one_login.md)
-- [OIDC](sso/oidc.md)
-- [Okta](sso/ssh_okta.md)
 
 ## Configuring SSO
 

--- a/docs/4.2/enterprise/sso/oidc.md
+++ b/docs/4.2/enterprise/sso/oidc.md
@@ -12,7 +12,7 @@ administrators to define policies like:
 !!! warning "Version Warning"
 
     This guide requires a commercial edition of Teleport. The open source
-    edition of Teleport only supports [Github](admin-guide.md#github-oauth-20) as
+    edition of Teleport only supports [Github](../../admin-guide.md#github-oauth-20) as
     an SSO provider.
 
 ## Enable OIDC Authentication
@@ -57,7 +57,7 @@ should be `https://proxy.example.com:3080/v1/webapi/oidc/callback`
 ## OIDC connector configuration
 
 The next step is to add an OIDC connector to Teleport. The connectors are manipulated
-via `tctl` [resource commands](admin-guide.md#resources). To create a new connector,
+via `tctl` [resource commands](../../admin-guide.md#resources). To create a new connector,
 create a connector resource file in YAML format, for example `oidc-connector.yaml`.
 
 The file contents are shown below. This connector requests the scope `group`
@@ -78,7 +78,7 @@ $ tctl create oidc-connector.yaml
 ## Create Teleport Roles
 
 The next step is to define Teleport roles. They are created using the same
-`tctl` [resource commands](admin-guide.md#resources) as we used for the auth
+`tctl` [resource commands](../../cli-docs.md#tctl-create) as we used for the auth
 connector.
 
 Below are two example roles that are mentioned above, the first is an admin

--- a/docs/4.2/enterprise/sso/oidc.md
+++ b/docs/4.2/enterprise/sso/oidc.md
@@ -11,7 +11,7 @@ administrators to define policies like:
 
 !!! warning "Version Warning"
 
-    This guide requires a commercial edition of Teleport. The open source
+    This guide requires an Enterprise edition of Teleport. The Community
     edition of Teleport only supports [Github](../../admin-guide.md#github-oauth-20) as
     an SSO provider.
 

--- a/docs/4.2/enterprise/sso/ssh_adfs.md
+++ b/docs/4.2/enterprise/sso/ssh_adfs.md
@@ -14,7 +14,7 @@ like:
 
 
     This guide requires a commercial edition of Teleport. The open source
-    edition of Teleport only supports [Github](admin-guide.md#github-oauth-20) as
+    edition of Teleport only supports [Github](../../admin-guide.md#github-oauth-20) as
     an SSO provider.
 
 ## Enable ADFS Authentication
@@ -41,15 +41,15 @@ mapping of the LDAP Attribute `E-Mail-Addresses` to `Name ID`. A group
 membership claim should be used to map users to roles (for example to
 separate normal users and admins).
 
-![Name ID Configuration](img/adfs-1.png)
-![Group Configuration](img/adfs-2.png)
+![Name ID Configuration](../../img/adfs-1.png)
+![Group Configuration](../../img/adfs-2.png)
 
 In addition if you are using dynamic roles (see below), it may be useful to map
 the LDAP Attribute `SAM-Account-Name` to `Windows account name` and create
 another mapping of `E-Mail-Addresses` to `UPN`.
 
-![WAN Configuration](img/adfs-3.png)
-![UPN Configuration](img/adfs-4.png)
+![WAN Configuration](../../img/adfs-3.png)
+![UPN Configuration](../../img/adfs-4.png)
 
 You'll also need to create a Relying Party Trust, use the below information to
 help guide you through the Wizard. Note, for development purposes we recommend
@@ -127,7 +127,7 @@ This role declares:
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 
-Next, create a SAML connector [resource](admin-guide.md#resources):
+Next, create a SAML connector [resource](../../admin-guide.md#resources):
 
 ```yaml
 {!examples/resources/adfs-connector.yaml!}
@@ -139,8 +139,8 @@ obtain the `entity_descriptor_url` from ADFS under _"ADFS -> Service -> Endpoint
 
 The `attributes_to_roles` is used to map attributes to the Teleport roles you
 just created. In our situation, we are mapping the _"Group"_ attribute whose full
-name is `http://schemas.xmlsoap.org/claims/Group` with a value of _"teleadmins"_
-to the _"admin"_ role. Groups with the value _"teleusers"_ is being mapped to the
+name is `http://schemas.xmlsoap.org/claims/Group` with a value of _"admins"_
+to the _"admin"_ role. Groups with the value _"users"_ is being mapped to the
 _"users"_ role.
 
 ## Export the Signing Key

--- a/docs/4.2/enterprise/sso/ssh_azuread.md
+++ b/docs/4.2/enterprise/sso/ssh_azuread.md
@@ -14,7 +14,7 @@ The following steps configure an example SAML authentication connector matching 
 !!! warning "Version Warning"
 
     This guide requires an Enterprise version of Teleport. The open source
-    edition of Teleport only supports [Github](admin-guide.md#github-oauth-20) as
+    edition of Teleport only supports [Github](../../admin-guide.md#github-oauth-20) as
     an SSO provider.
 
 ## Prerequisites:
@@ -31,43 +31,43 @@ Before you get started you’ll need:
 ## Configure Azure AD
 
 1. Select Enterprise Applications from the AzureAD Directory Home
-  ![Select Enterprise Applications From Manage](img/azuread/azuread-1-home.png)
+  ![Select Enterprise Applications From Manage](../../img/azuread/azuread-1-home.png)
   
 2. Select New application
-  ![Select New Applications From Manage](img/azuread/azuread-2-newapp.png)
+  ![Select New Applications From Manage](../../img/azuread/azuread-2-newapp.png)
   
 3. Select a Non-gallery application
-   ![Select Non-gallery application](img/azuread/azuread-3-selectnongalleryapp.png)
+   ![Select Non-gallery application](../../img/azuread/azuread-3-selectnongalleryapp.png)
    
 4. Enter the display name (Ex: Teleport)
-   ![Enter application name](img/azuread/azuread-4-enterappname.png)
+   ![Enter application name](../../img/azuread/azuread-4-enterappname.png)
    
 5.Select properties under Manage and turn off User assignment required
-   ![Turn off user assignment](img/azuread/azuread-5-turnoffuserassign.png)
+   ![Turn off user assignment](../../img/azuread/azuread-5-turnoffuserassign.png)
    
 6. Select Single Sign-on under Manage and choose SAML
-   ![Select SAML](img/azuread/azuread-6-selectsaml.png)
+   ![Select SAML](../../img/azuread/azuread-6-selectsaml.png)
    
 7. Select to edit Basic SAML Configuration
-   ![Edit Basic SAML Configuration](img/azuread/azuread-7-editbasicsaml.png)
+   ![Edit Basic SAML Configuration](../../img/azuread/azuread-7-editbasicsaml.png)
    
 8. Put in the Entity ID and Reply URL the same proxy url https://teleport.example.com:3080/v1/webapi/saml/acs
-   ![Put in Entity ID and Reply URL](img/azuread/azuread-8-entityandreplyurl.png)
+   ![Put in Entity ID and Reply URL](../../img/azuread/azuread-8-entityandreplyurl.png)
    
 9. Edit User Attributes & Claims
 
     i. Edit the Claim Name.  Change the name identifier format to Default. Make sure the source attribute is user.userprincipalname. 
-   ![Confirm Name Identifier](img/azuread/azuread-9a-nameidentifier.png)
+   ![Confirm Name Identifier](../../img/azuread/azuread-9a-nameidentifier.png)
    
     ii. Add a group Claim to have user security groups available to the connector
-   ![Put in Security group claim](img/azuread/azuread-9b-groupclaim.png)
+   ![Put in Security group claim](../../img/azuread/azuread-9b-groupclaim.png)
    
     iii. Add a Claim to pass the username from transforming the AzureAD User name.
-   ![Add a transformed username](img/azuread/azuread-9c-usernameclaim.png)
+   ![Add a transformed username](../../img/azuread/azuread-9c-usernameclaim.png)
    
    
 10. On the SAML Signing Certificate select to download SAML Download the Federation Metadata XML.  
-   ![Download Federation Metadata XML](img/azuread/azuread-10-fedmeatadataxml.png)
+   ![Download Federation Metadata XML](../../img/azuread/azuread-10-fedmeatadataxml.png)
 
 !!! warning "Important"
     
@@ -75,7 +75,7 @@ Before you get started you’ll need:
 
 ## Create a SAML Connector
 
-Now, create a SAML connector [resource](admin-guide.md#resources).  Replace the acs element with your Teleport address, update the group IDs with the actual AzureAD group ID values, and insert the downloaded Federation Metadata XML into the entity_descriptor resource.
+Now, create a SAML connector [resource](../../admin-guide.md#resources).  Replace the acs element with your Teleport address, update the group IDs with the actual AzureAD group ID values, and insert the downloaded Federation Metadata XML into the entity_descriptor resource.
 Write down this template as `azure-connector.yaml`:
 
 ```yaml
@@ -105,7 +105,7 @@ $ tctl create azure-connector.yaml
 
     Teleport will automatically transform the contents of the connector when viewed from the web UI.
 
- ![Sample Connector Transform](img/azuread/azuread-12-sampleconnector.png)
+ ![Sample Connector Transform](../../img/azuread/azuread-12-sampleconnector.png)
  
 ## Create Teleport Roles
 
@@ -167,7 +167,7 @@ auth_service:
   authentication:
     type: saml
 ```
-![Login with Microsoft](img/azuread/azure-11-loginwithmsft.png)
+![Login with Microsoft](../../img/azuread/azure-11-loginwithmsft.png)
 
 The Web UI will now contain a new button: "Login with Microsoft". The CLI is
 the same as before:
@@ -205,4 +205,4 @@ $ sudo journalctl -fu teleport
 ```
 
 If you wish to increase the verbosity of Teleport's syslog, you can pass the
-[`--debug`](cli-docs.md#teleport-start) flag to `teleport start` command.
+[`--debug`](../../cli-docs.md#teleport-start) flag to `teleport start` command.

--- a/docs/4.2/enterprise/sso/ssh_gsuite.md
+++ b/docs/4.2/enterprise/sso/ssh_gsuite.md
@@ -12,7 +12,7 @@ like:
 !!! warning "Version Warning"
 
     This guide requires an enterprise version of Teleport 4.1.4 or greater. The open source
-    edition of Teleport only supports [Github](admin-guide.md#github-oauth-20) as
+    edition of Teleport only supports [Github](../../admin-guide.md#github-oauth-20) as
     an SSO provider.
 
 <iframe width="712" height="400" src="https://www.youtube.com/embed/DG97l8WJ6oU?rel=0&modestbranding=1&widget_referrer=gravitational.com/teleport/docs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; modestbranding; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -35,31 +35,31 @@ Before you get started you’ll need:
 1. Obtain OAuth 2.0 credentials  [https://developers.google.com/identity/protocols/OpenIDConnect](https://developers.google.com/identity/protocols/OpenIDConnect)
 
 2. Create a new Project.
-![Create New Project](img/gsuite/gsuite-1-new-project.png)
+![Create New Project](../../img/gsuite/gsuite-1-new-project.png)
 
 3. Select OAuth client ID.
-![Create OAuth Creds](img/gsuite/gsuite-2-created-creds.png)
+![Create OAuth Creds](../../img/gsuite/gsuite-2-created-creds.png)
 
 4. Make Application Type Public & Setup Domain Verification
-![Setup Application Type](img/gsuite/gsuite-3-oauth.png)
+![Setup Application Type](../../img/gsuite/gsuite-3-oauth.png)
 
 5. Copy OAuth Client ID and Client Secret for YAML Below.
    Note: The redirect_url: `https://teleport.example.com:3080/v1/webapi/oidc/callback`
 
-![Copy Client Secret](img/gsuite/gsuite-5-copy-client-id.png)
+![Copy Client Secret](../../img/gsuite/gsuite-5-copy-client-id.png)
 
 ## Create a Service Account
 
-![Create OAuth Creds](img/gsuite/gsuite-5a-service-account.png)
+![Create OAuth Creds](../../img/gsuite/gsuite-5a-service-account.png)
 Leave Service account users roles, and admin roles as blank.
-![Create OAuth Creds](img/gsuite/gsuite-5b-service-account.png)
+![Create OAuth Creds](../../img/gsuite/gsuite-5b-service-account.png)
 Leave Service account permissions as blank.
-![Create OAuth Creds](img/gsuite/gsuite-5c-service-account.png)
+![Create OAuth Creds](../../img/gsuite/gsuite-5c-service-account.png)
 ### Enable Account Delegation:
-![Create OAuth Creds](img/gsuite/gsuite-5d-service-account-delegation.png)
-![Create OAuth Creds](img/gsuite/gsuite-5e-enable-delegation.png)
+![Create OAuth Creds](../../img/gsuite/gsuite-5d-service-account-delegation.png)
+![Create OAuth Creds](../../img/gsuite/gsuite-5e-enable-delegation.png)
 ### Download Service Account JSON
-![Create OAuth Creds](img/gsuite/gsuite-5f-download-json.png)
+![Create OAuth Creds](../../img/gsuite/gsuite-5f-download-json.png)
 
 This JSON file will need to be uploaded to the Authentication server, and will be later referenced by 
 the OIDC Connector, under `google_service_account_uri`. 
@@ -77,14 +77,14 @@ Within GSuite to access the Manage API client access go to Security -> Settings.
 
 `https://www.googleapis.com/auth/admin.directory.group.member.readonly, https://www.googleapis.com/auth/admin.directory.group.readonly, https://www.googleapis.com/auth/admin.directory.user.readonly`
 
-![Manage API Client Access](img/gsuite/gsuite-6-manage-api-access.png)
+![Manage API Client Access](../../img/gsuite/gsuite-6-manage-api-access.png)
 Google will display the client id and resolve the permission definitions.
-![Create OAuth Creds](img/gsuite/gsuite-6a-manage-access.png)
+![Create OAuth Creds](../../img/gsuite/gsuite-6a-manage-access.png)
 
 
 ## Create a OIDC Connector
 
-Now, create a OIDC connector [resource](admin-guide.md#resources).
+Now, create a OIDC connector [resource](../../admin-guide.md#resources).
 Write down this template as `gsuite-connector.yaml`:
 
 ```yaml
@@ -149,7 +149,7 @@ $ tctl create dev.yaml
 ```
 
 ## Testing
-![Login with Gsuite](img/gsuite/gsuite-7-loginwithgsuite.png)
+![Login with Gsuite](../../img/gsuite/gsuite-7-loginwithgsuite.png)
 
 
 The Web UI will now contain a new button: "Login with GSuite". The CLI is
@@ -188,4 +188,4 @@ $ sudo journalctl -fu teleport
 ```
 
 If you wish to increase the verbosity of Teleport's syslog, you can pass the
-[`--debug`](cli-docs.md#teleport-start) flag to `teleport start` command.
+[`--debug`](../../cli-docs.md#teleport-start) flag to `teleport start` command.

--- a/docs/4.2/enterprise/sso/ssh_okta.md
+++ b/docs/4.2/enterprise/sso/ssh_okta.md
@@ -11,7 +11,7 @@ like:
 !!! warning "Version Warning"
 
     This guide requires a commercial edition of Teleport. The open source
-    edition of Teleport only supports [Github](admin-guide.md#github-oauth-20) as
+    edition of Teleport only supports [Github](../../admin-guide.md#github-oauth-20) as
     an SSO provider.
 
 ## Enable SAML Authentication
@@ -29,19 +29,19 @@ auth_service:
 ## Configure Okta
 First, create a SAML 2.0 Web App in Okta configuration section
 
-![Switch to classic UI](img/okta-saml-0.png)
-![Create APP](img/okta-saml-1.png)
-![Create APP name](img/okta-saml-2.png)
+![Switch to classic UI](../../img/okta-saml-0.png)
+![Create APP](../../img/okta-saml-1.png)
+![Create APP name](../../img/okta-saml-2.png)
 
 **Create Groups**
 
 We are going to create two groups: "okta-dev" and "okta-admin":
 
-![Create Group Devs](img/okta-saml-2.1.png)
+![Create Group Devs](../../img/okta-saml-2.1.png)
 
 ...and the admin:
 
-![Create Group Devs](img/okta-saml-2.2.png)
+![Create Group Devs](../../img/okta-saml-2.2.png)
 
 ### Configure the App
 
@@ -60,7 +60,7 @@ GROUP ATTRIBUTE STATEMENTS
 - Name: `groups` | Name format: `Unspecified`
 -  Filter: `Matches regex` |  `.*`
 
-![Configure APP](img/okta-saml-3.png)
+![Configure APP](../../img/okta-saml-3.png)
 
 !!! tip "Important"
 
@@ -72,17 +72,17 @@ GROUP ATTRIBUTE STATEMENTS
 
 Assign groups and people to your SAML app:
 
-![Configure APP](img/okta-saml-3.1.png)
+![Configure APP](../../img/okta-saml-3.1.png)
 
 Make sure to download the metadata in the form of an XML document. It will be used it to
 configure a Teleport connector:
 
-![Download metadata](img/okta-saml-4.png)
+![Download metadata](../../img/okta-saml-4.png)
 
 
 ## Create a SAML Connector
 
-Now, create a SAML connector [resource](admin-guide.md#resources):
+Now, create a SAML connector [resource](../../admin-guide.md#resources):
 
 ```yaml
 # okta-connector.yaml

--- a/docs/4.2/enterprise/sso/ssh_one_login.md
+++ b/docs/4.2/enterprise/sso/ssh_one_login.md
@@ -12,7 +12,7 @@ like:
 !!! warning "Version Warning"
 
     This guide requires a commercial edition of Teleport. The open source
-    edition of Teleport only supports [Github](admin-guide.md#github-oauth-20) as
+    edition of Teleport only supports [Github](../../admin-guide.md#github-oauth-20) as
     an SSO provider.
 
 ## Enable SAML Authentication
@@ -32,7 +32,7 @@ auth_service:
 Using OneLogin control panel, create a SAML 2.0 Web App in SAML configuration
 section:
 
-![Create APP](img/onelogin-saml-1.png)
+![Create APP](../../img/onelogin-saml-1.png)
 
 !!! tip "Important"
 
@@ -44,13 +44,13 @@ Set `Audience`, `Recipient` and `ACS (Consumer) URL Validator` to the same value
 `https://teleport.example.com/v1/webapi/saml/acs` where `teleport.example.com` is the
 public name of the teleport web proxy service:
 
-![Configure APP](img/onelogin-saml-2.png)
+![Configure APP](../../img/onelogin-saml-2.png)
 
 Teleport needs to assign groups to users. Configure the application with some parameters
 exposed as SAML attribute statements:
 
-![Configure APP](img/onelogin-saml-3.png)
-![Configure APP](img/onelogin-saml-4.png)
+![Configure APP](../../img/onelogin-saml-3.png)
+![Configure APP](../../img/onelogin-saml-4.png)
 
 !!! warning "Important"
 
@@ -58,11 +58,11 @@ exposed as SAML attribute statements:
 
 Add users to the application:
 
-![Configure APP](img/onelogin-saml-5.png)
+![Configure APP](../../img/onelogin-saml-5.png)
 
 ## Create a SAML Connector
 
-Now, create a SAML connector [resource](admin-guide.md#resources).
+Now, create a SAML connector [resource](../../admin-guide.md#resources).
 Write down this template as `onelogin-connector.yaml`:
 
 ```yaml
@@ -71,7 +71,7 @@ Write down this template as `onelogin-connector.yaml`:
 
 To fill in the fields, open `SSO` tab:
 
-![Configure APP](img/onelogin-saml-6.png)
+![Configure APP](../../img/onelogin-saml-6.png)
 
 * `acs` - is the name of the teleport web proxy, e.g. `https://teleport.example.com/v1/webapi/saml/acs`
 * `issuer` - use value from `Issuer URL field`, e.g. `https://app.onelogin.com/saml/metadata/123456`
@@ -83,7 +83,7 @@ To fill in the fields, open `SSO` tab:
 
 * `cert` - download certificate, by clicking "view details link" and add to `cert` section
 
-![Configure APP](img/onelogin-saml-7.png)
+![Configure APP](../../img/onelogin-saml-7.png)
 
 Create the connector using `tctl` tool:
 

--- a/docs/4.2/enterprise/sso/ssh_one_login.md
+++ b/docs/4.2/enterprise/sso/ssh_one_login.md
@@ -11,7 +11,7 @@ like:
 
 !!! warning "Version Warning"
 
-    This guide requires a commercial edition of Teleport. The open source
+    This guide requires an Enterprise edition of Teleport. The community
     edition of Teleport only supports [Github](../../admin-guide.md#github-oauth-20) as
     an SSO provider.
 

--- a/docs/4.2/gcp_guide.md
+++ b/docs/4.2/gcp_guide.md
@@ -210,4 +210,4 @@ proxy_service:
 
 **4. Add Users**
 
-Follow [adding users](enterprise/quickstart-enterprise.md#adding-users) or integrate with [G Suite](/enterprise/sso/ssh_gsuite.md) to provide SSO access.
+Follow [adding users](enterprise/quickstart-enterprise.md#adding-users) or integrate with [G Suite](enterprise/sso/ssh_gsuite.md) to provide SSO access.

--- a/docs/4.2/gcp_guide.md
+++ b/docs/4.2/gcp_guide.md
@@ -210,4 +210,4 @@ proxy_service:
 
 **4. Add Users**
 
-Follow [adding users](enterprise/quickstart-enterprise.md#adding-users) or integrate with [G Suite](ssh_gsuite.md) to provide SSO access.
+Follow [adding users](enterprise/quickstart-enterprise.md#adding-users) or integrate with [G Suite](/enterprise/sso/ssh_gsuite.md) to provide SSO access.

--- a/docs/4.2/index.md
+++ b/docs/4.2/index.md
@@ -86,7 +86,7 @@ integration with identity managers for single sign-on (SSO). Because the
 majority of documentation between the Community and Enterprise Editions overlap,
 we have separated out the documentation that is specific to Teleport Enterprise.
 
-- [Teleport Enterprise Introduction](enterprise) - Overview of the additional capabilities of Teleport Enterprise.
+- [Teleport Enterprise Introduction](enterprise/index.md) - Overview of the additional capabilities of Teleport Enterprise.
 - [Teleport Enterprise Quick Start](enterprise/quickstart-enterprise.md) - A quick tutorial to show off the basic capabilities of Teleport Enterprise.
 A good place to start if you want to jump right in.
 - [RBAC for SSH](enterprise/ssh_rbac.md) - Details on how Teleport Enterprise provides Role-based Access Controls (RBAC) for SSH.
@@ -96,11 +96,8 @@ A good place to start if you want to jump right in.
 
 We also have several guides that go through the most typical configurations and integrations.
 
-- [Okta Integration](ssh_okta.md) - How to integrate Teleport Enterprise with Okta.
-- [ADFS Integration](ssh_adfs.md) - How to integrate Teleport Enterprise with Active Directory.
-- [One Login Integration](ssh_one_login.md) - How to integrate Teleport Enterprise with One Login.
-- [OIDC Integration](oidc.md) - How to integrate Teleport Enterprise with identity providers using OIDC/OAuth2.
 - [Kubernetes Integration](kubernetes_ssh.md) - How to configure Teleport to serve as a unified gateway for Kubernetes clusters and clusters of regular SSH nodes.
+- [AWS Guide](aws_oss_guide.md)
 
 ## Why Build Teleport?
 

--- a/docs/4.2/kubernetes_ssh.md
+++ b/docs/4.2/kubernetes_ssh.md
@@ -125,7 +125,7 @@ configured. In this guide we'll look at two common configurations:
 * **Open source, Teleport Community edition** configured to authenticate users via [Github](admin-guide.md#github-oauth-20).
   In this case, we'll need to map Github teams to Kubernetes groups.
 
-* **Commercial, Teleport Enterprise edition** configured to authenticate users via [Okta SSO](ssh_okta.md).
+* **Commercial, Teleport Enterprise edition** configured to authenticate users via [Okta SSO](enterprise/sso/ssh_okta.md).
   In this case, we'll need to map users' groups that come from Okta to Kubernetes
   groups.
 
@@ -179,7 +179,7 @@ Teleport will log the audit record and record the session.
 
     For more information on integrating Teleport with Github SSO, please see the [Github section in the Admin Manual](admin-guide.md#github-oauth-20).
 
-### Okta Auth
+### Enterprise SSO - Okta Example
 
 With Okta (or any other SAML/OIDC/Active Directory provider), you must update
 Teleport's roles to include the mapping to Kubernetes groups.
@@ -226,6 +226,6 @@ sequence, their `kubeconfig` will be updated with their Kubernetes credentials.
 !!! note
 
     For more information on integrating Teleport with Okta, please see the
-    [Okta integration guide](ssh_okta.md).
+    [Okta integration guide](enterprise/sso/ssh_okta.md).
 
 

--- a/docs/4.2/milv.config.yaml
+++ b/docs/4.2/milv.config.yaml
@@ -52,3 +52,27 @@ files:
     config:
       white-list-internal:
         - "#fedrampfips"
+  - path: "./enterprise/sso/ssh_okta.md"
+    config:
+      white-list-internal:
+        - "#github-oauth-20"
+        - "#resources"
+  - path: "./enterprise/sso/oidc.md"
+    config:
+      white-list-internal:
+        - "#github-oauth-20"
+        - "#resources"
+  - path: "./enterprise/sso/ssh_azuread.md"
+    config:
+      white-list-internal:
+        - "#github-oauth-20"
+        - "#resources"
+  - path: "./enterprise/ssh_sso.md"
+    config:
+      white-list-internal:
+        - "#resources"
+  - path: "./enterprise/oidc.md"
+    config:
+      white-list-internal:
+        - "#resources"
+        - "#github-oauth-20"


### PR DESCRIPTION
The motivation is to make the docs more community friendly, this removes the SSO links from the sidebar and deep links them into the Enterprise pages. I would like to add a 3rd nesting but our current theme doesn't support it, that's why the 4.2.yaml has sections commented out. 

