### PR TITLE
Change location of /releases/ to downloads

### DIFF
--- a/docs/4.1/installation.md
+++ b/docs/4.1/installation.md
@@ -4,7 +4,7 @@ Teleport core service [`teleport`](cli-docs.md#teleport) and admin tools [`tctl`
 
 The Teleport client [`tsh`](cli-docs.md#tsh) and Web UI are available for **Linux, Mac**
 and **Windows** operating systems. Our examples install Teleport v4.1.0 but you can 
-install any version listed in our [Release History](https://gravitational.com/teleport/releases/).
+install any version listed in our [Release History](https://gravitational.com/teleport/download/).
 
 **Table of Contents**
 

--- a/docs/4.1/quickstart.md
+++ b/docs/4.1/quickstart.md
@@ -30,7 +30,7 @@ Instead follow the [Admin Guide](admin-guide.md))**
 ## Step 1: Install Teleport
 
 This guide installs teleport v4.1.0 on the CLI. Previous versions are documented
-in [Release History](https://gravitational.com/teleport/releases/). You can
+in [Release History](https://gravitational.com/teleport/download/). You can
 download pre-built binaries from our
 [Downloads](https://gravitational.com/teleport/download/) page or you can [build
 it from source](./installation/#installing-from-source).

--- a/docs/4.2/installation.md
+++ b/docs/4.2/installation.md
@@ -4,7 +4,7 @@ Teleport core service [`teleport`](cli-docs.md#teleport) and admin tool [`tctl`]
 
 The Teleport client [`tsh`](cli-docs.md#tsh) and Web UI are available for **Linux, Mac**
 and **Windows** operating systems. Our examples install Teleport v{{ teleport.version }} but you can 
-install any version listed in our [Release History](https://gravitational.com/teleport/releases/).
+install any version listed in our [Release History](https://gravitational.com/teleport/download/).
 
 
 ## Checksums

--- a/docs/4.2/quickstart.md
+++ b/docs/4.2/quickstart.md
@@ -28,7 +28,7 @@ environment, and showcase a few basic tasks you can do with Teleport. For additi
 ## Step 1: Install Teleport
 
 This guide installs teleport v{{ teleport.version }} on the CLI. Previous versions are documented
-in [Release History](https://gravitational.com/teleport/releases/). You can
+in [Release History](https://gravitational.com/teleport/download/). You can
 download pre-built binaries from our
 [Downloads](https://gravitational.com/teleport/download/) page or you can [build
 it from source](installation.md#installing-from-source).


### PR DESCRIPTION
We recently updated our Downloads page, and have consolidated 'releases' and Downloads. This PR reflects that change. 