### PR TITLE
Add prometheus metric mirroring /readyz state

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -129,6 +129,9 @@ const (
 	// MetricLostNetworkEvents measures the number of network events that were lost.
 	MetricLostNetworkEvents = "bpf_lost_network_events"
 
+	// MetricState tracks the state of the teleport process.
+	MetricState = "process_state"
+
 	// TagRange is a tag specifying backend requests
 	TagRange = "range"
 


### PR DESCRIPTION
This allows users to get the health of their nodes from prometheus
metrics pipeline instead of polling readyz separately.

Updates #3700