### PR TITLE
Add missing error checks, part 1

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -817,7 +817,9 @@ func (s *Server) HandleRequest(r *ssh.Request) {
 		s.handleVersionRequest(r)
 	default:
 		if r.WantReply {
-			r.Reply(false, nil)
+			if err := r.Reply(false, nil); err != nil {
+				log.Warnf("Failed to reply to %q request: %v", r.Type, err)
+			}
 		}
 		log.Debugf("Discarding %q global request: %+v", r.Type, r)
 	}
@@ -827,7 +829,7 @@ func (s *Server) HandleRequest(r *ssh.Request) {
 func (s *Server) HandleNewChan(ccx *sshutils.ConnectionContext, nch ssh.NewChannel) {
 	identityContext, err := s.authHandlers.CreateIdentityContext(ccx.ServerConn)
 	if err != nil {
-		nch.Reject(ssh.Prohibited, fmt.Sprintf("Unable to create identity from connection: %v", err))
+		rejectChannel(nch, ssh.Prohibited, fmt.Sprintf("Unable to create identity from connection: %v", err))
 		return
 	}
 
@@ -840,13 +842,13 @@ func (s *Server) HandleNewChan(ccx *sshutils.ConnectionContext, nch ssh.NewChann
 			req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
 			if err != nil {
 				log.Errorf("Failed to parse request data: %v, err: %v.", string(nch.ExtraData()), err)
-				nch.Reject(ssh.UnknownChannelType, "failed to parse direct-tcpip request")
+				rejectChannel(nch, ssh.UnknownChannelType, "failed to parse direct-tcpip request")
 				return
 			}
 			ch, _, err := nch.Accept()
 			if err != nil {
 				log.Warnf("Unable to accept channel: %v.", err)
-				nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
+				rejectChannel(nch, ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 				return
 			}
 			go s.handleProxyJump(ccx, identityContext, ch, *req)
@@ -858,13 +860,13 @@ func (s *Server) HandleNewChan(ccx *sshutils.ConnectionContext, nch ssh.NewChann
 			ch, requests, err := nch.Accept()
 			if err != nil {
 				log.Warnf("Unable to accept channel: %v.", err)
-				nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
+				rejectChannel(nch, ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 				return
 			}
 			go s.handleSessionRequests(ccx, identityContext, ch, requests)
 			return
 		default:
-			nch.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
+			rejectChannel(nch, ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
 			return
 		}
 	}
@@ -876,7 +878,7 @@ func (s *Server) HandleNewChan(ccx *sshutils.ConnectionContext, nch ssh.NewChann
 		ch, requests, err := nch.Accept()
 		if err != nil {
 			log.Warnf("Unable to accept channel: %v.", err)
-			nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
+			rejectChannel(nch, ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 			return
 		}
 		go s.handleSessionRequests(ccx, identityContext, ch, requests)
@@ -885,18 +887,18 @@ func (s *Server) HandleNewChan(ccx *sshutils.ConnectionContext, nch ssh.NewChann
 		req, err := sshutils.ParseDirectTCPIPReq(nch.ExtraData())
 		if err != nil {
 			log.Errorf("Failed to parse request data: %v, err: %v.", string(nch.ExtraData()), err)
-			nch.Reject(ssh.UnknownChannelType, "failed to parse direct-tcpip request")
+			rejectChannel(nch, ssh.UnknownChannelType, "failed to parse direct-tcpip request")
 			return
 		}
 		ch, _, err := nch.Accept()
 		if err != nil {
 			log.Warnf("Unable to accept channel: %v.", err)
-			nch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
+			rejectChannel(nch, ssh.ConnectionFailed, fmt.Sprintf("unable to accept channel: %v", err))
 			return
 		}
 		go s.handleDirectTCPIPRequest(ccx, identityContext, ch, req)
 	default:
-		nch.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
+		rejectChannel(nch, ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %v", channelType))
 	}
 }
 
@@ -907,7 +909,7 @@ func (s *Server) handleDirectTCPIPRequest(ccx *sshutils.ConnectionContext, ident
 	ctx, err := srv.NewServerContext(ccx, s, identityContext)
 	if err != nil {
 		log.Errorf("Unable to create connection context: %v.", err)
-		channel.Stderr().Write([]byte("Unable to create connection context."))
+		writeStderr(channel, "Unable to create connection context.")
 		return
 	}
 	ctx.IsTestStub = s.isTestStub
@@ -920,7 +922,7 @@ func (s *Server) handleDirectTCPIPRequest(ccx *sshutils.ConnectionContext, ident
 	// Check if the role allows port forwarding for this user.
 	err = s.authHandlers.CheckPortForward(ctx.DstAddr, ctx)
 	if err != nil {
-		channel.Stderr().Write([]byte(err.Error()))
+		writeStderr(channel, err.Error())
 		return
 	}
 
@@ -932,7 +934,7 @@ func (s *Server) handleDirectTCPIPRequest(ccx *sshutils.ConnectionContext, ident
 	// from another process.
 	cmd, err := srv.ConfigureCommand(ctx)
 	if err != nil {
-		channel.Stderr().Write([]byte(err.Error()))
+		writeStderr(channel, err.Error())
 	}
 
 	// Create a pipe for std{in,out} that will be used to transfer data between
@@ -950,7 +952,7 @@ func (s *Server) handleDirectTCPIPRequest(ccx *sshutils.ConnectionContext, ident
 	// to the target host.
 	err = cmd.Start()
 	if err != nil {
-		channel.Stderr().Write([]byte(err.Error()))
+		writeStderr(channel, err.Error())
 		return
 	}
 
@@ -985,7 +987,7 @@ func (s *Server) handleDirectTCPIPRequest(ccx *sshutils.ConnectionContext, ident
 	}
 	err = cmd.Wait()
 	if err != nil {
-		channel.Stderr().Write([]byte(err.Error()))
+		writeStderr(channel, err.Error())
 		return
 	}
 
@@ -1009,7 +1011,7 @@ func (s *Server) handleSessionRequests(ccx *sshutils.ConnectionContext, identity
 	ctx, err := srv.NewServerContext(ccx, s, identityContext)
 	if err != nil {
 		log.Errorf("Unable to create connection context: %v.", err)
-		ch.Stderr().Write([]byte("Unable to create connection context."))
+		writeStderr(ch, "Unable to create connection context.")
 		return
 	}
 	ctx.IsTestStub = s.isTestStub
@@ -1025,7 +1027,7 @@ func (s *Server) handleSessionRequests(ccx *sshutils.ConnectionContext, identity
 	clusterConfig, err := s.GetAccessPoint().GetClusterConfig()
 	if err != nil {
 		log.Errorf("Unable to fetch cluster config: %v.", err)
-		ch.Stderr().Write([]byte("Unable to fetch cluster configuration."))
+		writeStderr(ch, "Unable to fetch cluster configuration.")
 		return
 	}
 
@@ -1051,7 +1053,7 @@ func (s *Server) handleSessionRequests(ccx *sshutils.ConnectionContext, identity
 				ctx.Errorf("Unable to update context: %v.", errorMessage)
 
 				// write the error to channel and close it
-				ch.Stderr().Write([]byte(errorMessage))
+				writeStderr(ch, errorMessage)
 				_, err := ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: teleport.RemoteCommandFailure}))
 				if err != nil {
 					ctx.Errorf("Failed to send exit status %v.", errorMessage)
@@ -1076,7 +1078,9 @@ func (s *Server) handleSessionRequests(ccx *sshutils.ConnectionContext, identity
 				return
 			}
 			if req.WantReply {
-				req.Reply(true, nil)
+				if err := req.Reply(true, nil); err != nil {
+					log.Warnf("Failed to reply to %q request: %v", req.Type, err)
+				}
 			}
 		case result := <-ctx.ExecResultCh:
 			ctx.Debugf("Exec request (%q) complete: %v", result.Command, result.Code)
@@ -1316,7 +1320,7 @@ func (s *Server) handleProxyJump(ccx *sshutils.ConnectionContext, identityContex
 	ctx, err := srv.NewServerContext(ccx, s, identityContext)
 	if err != nil {
 		log.Errorf("Unable to create connection context: %v.", err)
-		ch.Stderr().Write([]byte("Unable to create connection context."))
+		writeStderr(ch, "Unable to create connection context.")
 		return
 	}
 	ctx.IsTestStub = s.isTestStub
@@ -1326,7 +1330,7 @@ func (s *Server) handleProxyJump(ccx *sshutils.ConnectionContext, identityContex
 	clusterConfig, err := s.GetAccessPoint().GetClusterConfig()
 	if err != nil {
 		log.Errorf("Unable to fetch cluster config: %v.", err)
-		ch.Stderr().Write([]byte("Unable to fetch cluster configuration."))
+		writeStderr(ch, "Unable to fetch cluster configuration.")
 		return
 	}
 
@@ -1359,7 +1363,7 @@ func (s *Server) handleProxyJump(ccx *sshutils.ConnectionContext, identityContex
 		err = s.handleAgentForwardProxy(&ssh.Request{}, ctx)
 		if err != nil {
 			log.Warningf("Failed to request agent in recording mode: %v", err)
-			ch.Stderr().Write([]byte("Failed to request agent"))
+			writeStderr(ch, "Failed to request agent")
 			return
 		}
 	}
@@ -1392,29 +1396,31 @@ func (s *Server) handleProxyJump(ccx *sshutils.ConnectionContext, identityContex
 	})
 	if err != nil {
 		log.Errorf("Unable instantiate proxy subsystem: %v.", err)
-		ch.Stderr().Write([]byte("Unable to instantiate proxy subsystem."))
+		writeStderr(ch, "Unable to instantiate proxy subsystem.")
 		return
 	}
 
 	if err := subsys.Start(ctx.Conn, ch, &ssh.Request{}, ctx); err != nil {
 		log.Errorf("Unable to start proxy subsystem: %v.", err)
-		ch.Stderr().Write([]byte("Unable to start proxy subsystem."))
+		writeStderr(ch, "Unable to start proxy subsystem.")
 		return
 	}
 
 	if err := subsys.Wait(); err != nil {
 		log.Errorf("Proxy subsystem failed: %v.", err)
-		ch.Stderr().Write([]byte("Proxy subsystem failed."))
+		writeStderr(ch, "Proxy subsystem failed.")
 		return
 	}
 }
 
 func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
 	log.Error(err)
-	message := []byte(trace.UserMessage(err))
-	ch.Stderr().Write(message)
+	message := trace.UserMessage(err)
+	writeStderr(ch, message)
 	if req.WantReply {
-		req.Reply(false, message)
+		if err := req.Reply(false, []byte(message)); err != nil {
+			log.Warnf("Failed to reply to %q request: %v", req.Type, err)
+		}
 	}
 }
 
@@ -1430,4 +1436,16 @@ func (s *Server) parseSubsystemRequest(req *ssh.Request, ctx *srv.ServerContext)
 		return parseProxySitesSubsys(r.Name, s)
 	}
 	return nil, trace.BadParameter("unrecognized subsystem: %v", r.Name)
+}
+
+func writeStderr(ch ssh.Channel, msg string) {
+	if _, err := fmt.Fprint(ch.Stderr(), msg); err != nil {
+		log.Warnf("Failed writing to ssh.Channel.Stderr(): %v", err)
+	}
+}
+
+func rejectChannel(ch ssh.NewChannel, reason ssh.RejectionReason, msg string) {
+	if err := ch.Reject(reason, msg); err != nil {
+		log.Warnf("Failed to reject new ssh.Channel: %v", err)
+	}
 }

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -767,15 +767,16 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 	c.Assert(err, IsNil)
 	done := make(chan struct{})
 	go func() {
-		io.Copy(stdout, reader)
+		_, err := io.Copy(stdout, reader)
+		c.Assert(err, IsNil)
 		close(done)
 	}()
 
 	// to make sure  labels have the right output
 	s.srv.syncUpdateLabels()
 	srv2.syncUpdateLabels()
-	s.srv.heartbeat.ForceSend(time.Second)
-	s.srv.heartbeat.ForceSend(time.Second)
+	c.Assert(s.srv.heartbeat.ForceSend(time.Second), IsNil)
+	c.Assert(srv2.heartbeat.ForceSend(time.Second), IsNil)
 	// request "list of sites":
 	c.Assert(se3.RequestSubsystem("proxysites"), IsNil)
 	<-done

--- a/lib/srv/termhandlers.go
+++ b/lib/srv/termhandlers.go
@@ -83,7 +83,9 @@ func (t *TermHandlers) HandlePTYReq(ch ssh.Channel, req *ssh.Request, ctx *Serve
 		ctx.SetTerm(term)
 		ctx.termAllocated = true
 	}
-	term.SetWinSize(*params)
+	if err := term.SetWinSize(*params); err != nil {
+		ctx.Errorf("Failed setting window size: %v", err)
+	}
 	term.SetTermType(ptyRequest.Env)
 	term.SetTerminalModes(termModes)
 

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -457,7 +457,10 @@ func (s *Server) HandleConnection(conn net.Conn) {
 			// send keepalive pings to the clients
 		case <-keepAliveTick.C:
 			const wantReply = true
-			sconn.SendRequest(teleport.KeepAliveReqType, wantReply, keepAlivePayload[:])
+			_, _, err = sconn.SendRequest(teleport.KeepAliveReqType, wantReply, keepAlivePayload[:])
+			if err != nil {
+				log.Errorf("Failed sending keepalive request: %v", err)
+			}
 		}
 	}
 }

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -74,8 +74,10 @@ func (s *ServerSuite) TestStartStop(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer clt.Close()
 
-	// call new session to initiate opening new channel
-	clt.NewSession()
+	// Call new session to initiate opening new channel. This should get
+	// rejected and fail.
+	_, err = clt.NewSession()
+	c.Assert(err, check.NotNil)
 
 	c.Assert(srv.Close(), check.IsNil)
 	wait(c, srv)
@@ -115,7 +117,8 @@ func (s *ServerSuite) TestShutdown(c *check.C) {
 	defer clt.Close()
 
 	// call new session to initiate opening new channel
-	clt.NewSession()
+	_, err = clt.NewSession()
+	c.Assert(err, check.IsNil)
 
 	// context will timeout because there is a connection around
 	ctx, ctxc := context.WithTimeout(context.TODO(), 50*time.Millisecond)

--- a/lib/utils/loadbalancer_test.go
+++ b/lib/utils/loadbalancer_test.go
@@ -205,7 +205,8 @@ func (s *LBSuite) TestDropConnections(c *check.C) {
 	c.Assert(out, check.Equals, "backend 1")
 
 	// removing backend results in dropped connection to this backend
-	lb.RemoveBackend(backendAddr)
+	err = lb.RemoveBackend(backendAddr)
+	c.Assert(err, check.IsNil)
 	_, err = RoundtripWithConn(conn)
 	c.Assert(err, check.NotNil)
 }

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -309,7 +309,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 			}
 			httplib.SetIndexHTMLHeaders(w.Header())
 			if err := indexPage.Execute(w, session); err != nil {
-				log.Errorf("failed to execute index page template: %v", err)
+				log.Errorf("Failed to execute index page template: %v", err)
 			}
 		} else {
 			http.NotFound(w, r)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -308,7 +308,9 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 				}
 			}
 			httplib.SetIndexHTMLHeaders(w.Header())
-			indexPage.Execute(w, session)
+			if err := indexPage.Execute(w, session); err != nil {
+				log.Errorf("failed to execute index page template: %v", err)
+			}
 		} else {
 			http.NotFound(w, r)
 		}
@@ -805,8 +807,7 @@ func (h *Handler) githubCallback(w http.ResponseWriter, r *http.Request, p httpr
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		httplib.SafeRedirect(w, r, response.Req.ClientRedirectURL)
-		return nil, nil
+		return nil, httplib.SafeRedirect(w, r, response.Req.ClientRedirectURL)
 	}
 	logger.Infof("Callback is redirecting to console login.")
 	if len(response.Req.PublicKey) == 0 {
@@ -884,8 +885,7 @@ func (h *Handler) oidcCallback(w http.ResponseWriter, r *http.Request, p httprou
 		if err := SetSession(w, response.Username, response.Session.GetName()); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		httplib.SafeRedirect(w, r, response.Req.ClientRedirectURL)
-		return nil, nil
+		return nil, httplib.SafeRedirect(w, r, response.Req.ClientRedirectURL)
 	}
 	log.Infof("oidcCallback redirecting to console login")
 	if len(response.Req.PublicKey) == 0 {
@@ -1126,9 +1126,7 @@ func (h *Handler) logout(w http.ResponseWriter, ctx *SessionContext) error {
 	if err := ctx.Invalidate(); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := ClearSession(w); err != nil {
-		return trace.Wrap(err)
-	}
+	ClearSession(w)
 
 	return nil
 }
@@ -1689,8 +1687,7 @@ func (h *Handler) siteSessionStreamGet(w http.ResponseWriter, r *http.Request, p
 	var site reversetunnel.RemoteSite
 	onError := func(err error) {
 		logger.Debugf("Unable to retrieve session chunk: %v.", err)
-		w.WriteHeader(trace.ErrorToCode(err))
-		w.Write([]byte(err.Error()))
+		http.Error(w, err.Error(), trace.ErrorToCode(err))
 	}
 	// authenticate first:
 	ctx, err := h.AuthenticateRequest(w, r, true)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -448,7 +448,8 @@ func (s *WebSuite) TestSAMLSuccess(c *C) {
 	// now swap the request id to the hardcoded one in fixtures
 	authRequest.ID = fixtures.SAMLOktaAuthRequestID
 	authRequest.CSRFToken = csrfToken
-	s.server.Auth().Identity.CreateSAMLAuthRequest(*authRequest, backend.Forever)
+	err = s.server.Auth().Identity.CreateSAMLAuthRequest(*authRequest, backend.Forever)
+	c.Assert(err, IsNil)
 
 	// now respond with pre-recorded request to the POST url
 	in := &bytes.Buffer{}
@@ -929,7 +930,8 @@ func (s *WebSuite) TestResizeTerminal(c *C) {
 	}
 	envelopeBytes, err := proto.Marshal(envelope)
 	c.Assert(err, IsNil)
-	websocket.Message.Send(ws2, envelopeBytes)
+	err = websocket.Message.Send(ws2, envelopeBytes)
+	c.Assert(err, IsNil)
 
 	// This time the first terminal will see the resize event.
 	err = s.waitForResizeEvent(ws1, 5*time.Second)
@@ -1042,7 +1044,8 @@ func (s *WebSuite) TestCloseConnectionsOnLogout(c *C) {
 
 	// make sure server has replied
 	out := make([]byte, 100)
-	stream.Read(out)
+	_, err = stream.Read(out)
+	c.Assert(err, IsNil)
 
 	_, err = pack.clt.Delete(
 		context.Background(),

--- a/lib/web/cookie.go
+++ b/lib/web/cookie.go
@@ -65,7 +65,7 @@ func SetSession(w http.ResponseWriter, user, sid string) error {
 	return nil
 }
 
-func ClearSession(w http.ResponseWriter) error {
+func ClearSession(w http.ResponseWriter) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session",
 		Value:    "",
@@ -73,5 +73,4 @@ func ClearSession(w http.ResponseWriter) error {
 		HttpOnly: true,
 		Secure:   true,
 	})
-	return nil
 }

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -163,7 +163,9 @@ func (f *fileTransfer) createClient(req fileTransferRequest, httpReq *http.Reque
 	cfg.HostLogin = req.login
 	cfg.SiteName = req.cluster
 	cfg.Namespace = req.namespace
-	cfg.ParseProxyHost(f.proxyHostPort)
+	if err := cfg.ParseProxyHost(f.proxyHostPort); err != nil {
+		return nil, trace.BadParameter("failed to parse proxy address: %v", err)
+	}
 	cfg.Host = hostName
 	cfg.HostPort = hostPort
 	cfg.ClientAddr = httpReq.RemoteAddr

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -130,8 +130,7 @@ func (m *Handler) samlACS(w http.ResponseWriter, r *http.Request, p httprouter.P
 		if err := SetSession(w, response.Username, response.Session.GetName()); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		httplib.SafeRedirect(w, r, response.Req.ClientRedirectURL)
-		return nil, nil
+		return nil, httplib.SafeRedirect(w, r, response.Req.ClientRedirectURL)
 	}
 	l.Debugf("samlCallback redirecting to console login")
 	if len(response.Req.PublicKey) == 0 {

--- a/lib/web/static.go
+++ b/lib/web/static.go
@@ -181,7 +181,9 @@ func (rsc *resource) Seek(offset int64, whence int) (int64, error) {
 	}
 	if pos > 0 {
 		b := make([]byte, pos)
-		rsc.reader.Read(b)
+		if _, err = rsc.reader.Read(b); err != nil {
+			return 0, err
+		}
 	}
 	rsc.pos = pos
 	return pos, nil

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -261,7 +261,9 @@ func (t *TerminalHandler) makeClient(ws *websocket.Conn) (*client.TeleportClient
 	clientConfig.Stderr = stream
 	clientConfig.Stdin = stream
 	clientConfig.SiteName = t.params.Cluster
-	clientConfig.ParseProxyHost(t.params.ProxyHostPort)
+	if err := clientConfig.ParseProxyHost(t.params.ProxyHostPort); err != nil {
+		return nil, trace.BadParameter("failed to parse proxy address: %v", err)
+	}
 	clientConfig.Host = t.hostName
 	clientConfig.HostPort = t.hostPort
 	clientConfig.Env = map[string]string{sshutils.SessionEnvVar: string(t.params.SessionID)}
@@ -386,9 +388,9 @@ func (t *TerminalHandler) streamEvents(ws *websocket.Conn, tc *client.TeleportCl
 
 // windowChange is called when the browser window is resized. It sends a
 // "window-change" channel request to the server.
-func (t *TerminalHandler) windowChange(params *session.TerminalParams) error {
+func (t *TerminalHandler) windowChange(params *session.TerminalParams) {
 	if t.sshSession == nil {
-		return nil
+		return
 	}
 
 	_, err := t.sshSession.SendRequest(
@@ -401,8 +403,6 @@ func (t *TerminalHandler) windowChange(params *session.TerminalParams) error {
 	if err != nil {
 		t.log.Error(err)
 	}
-
-	return trace.Wrap(err)
 }
 
 // writeError displays an error in the terminal window.

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -385,8 +385,8 @@ func (c *samlCollection) writeText(w io.Writer) error {
 	for _, conn := range c.connectors {
 		t.AddRow([]string{conn.GetName(), conn.GetSSO()})
 	}
-	t.AsBuffer().WriteTo(w)
-	return nil
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
 }
 
 func (c *samlCollection) writeJSON(w io.Writer) error {

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -173,6 +173,8 @@ func (c *NodeCommand) ListActive(client auth.ClientI) error {
 		return trace.Wrap(err)
 	}
 	coll := &serverCollection{servers: nodes}
-	coll.writeText(os.Stdout)
+	if err := coll.writeText(os.Stdout); err != nil {
+		return trace.Wrap(err)
+	}
 	return nil
 }

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -121,7 +121,9 @@ func Run(commands []CLICommand) {
 	}
 
 	// configure all commands with Teleport configuration (they share 'cfg')
-	applyConfig(&ccf, cfg)
+	if err := applyConfig(&ccf, cfg); err != nil {
+		utils.FatalError(err)
+	}
 
 	// connect to the auth sever:
 	client, err := connectToAuthService(cfg)

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -57,7 +57,8 @@ func (s *MainTestSuite) SetUpSuite(c *check.C) {
 		panic(err)
 	}
 	s.configFile = filepath.Join(dirname, "teleport.yaml")
-	ioutil.WriteFile(s.configFile, []byte(YAMLConfig), 0770)
+	err = ioutil.WriteFile(s.configFile, []byte(YAMLConfig), 0770)
+	c.Assert(err, check.IsNil)
 
 	// set imprtant defaults to test-mode (non-existing files&locations)
 	defaults.ConfigFilePath = "/tmp/teleport/etc/teleport.yaml"

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -437,7 +437,9 @@ func onLogin(cf *CLIConf) {
 			if err != nil {
 				utils.FatalError(err)
 			}
-			tc.SaveProfile("", "")
+			if err := tc.SaveProfile("", ""); err != nil {
+				utils.FatalError(err)
+			}
 			if err := kubeconfig.UpdateWithClient("", tc); err != nil {
 				utils.FatalError(err)
 			}
@@ -492,7 +494,9 @@ func onLogin(cf *CLIConf) {
 	}
 
 	// Regular login without -i flag.
-	tc.SaveProfile(key.ProxyHost, "")
+	if err := tc.SaveProfile(key.ProxyHost, ""); err != nil {
+		utils.FatalError(err)
+	}
 
 	// Print status to show information of the logged in user. Update the
 	// command line flag (used to print status) for the proxy to make sure any
@@ -848,7 +852,9 @@ func onBenchmark(cf *CLIConf) {
 			fmt.Sprintf("%v ms", result.Histogram.ValueAtQuantile(quantile)),
 		})
 	}
-	io.Copy(os.Stdout, t.AsBuffer())
+	if _, err := io.Copy(os.Stdout, t.AsBuffer()); err != nil {
+		utils.FatalError(err)
+	}
 	fmt.Printf("\n")
 }
 


### PR DESCRIPTION
Most missing checks here aren't terrible, just adding logging around for easier debugging.

Some ignored errors make sense (like writing to `bytes.Buffer`). Depending on how many false positives there are, we could consider enabling this linter and adding `//nolint` annotations.
If not, I'll do a one-time bulk cleanup with these PRs and move on.
This brings down `errcheck` linter count from 306 to 239. Lots more to do.