### PR TITLE
Auto assign listener ports in unit tests

### DIFF
--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -276,10 +276,7 @@ func (s *MuxSuite) TestTimeout(c *check.C) {
 // TestUnknownProtocol make sure that multiplexer closes connection
 // with unknown protocol
 func (s *MuxSuite) TestUnknownProtocol(c *check.C) {
-	ports, err := utils.GetFreeTCPPorts(1)
-	c.Assert(err, check.IsNil)
-
-	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", ports[0]))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	c.Assert(err, check.IsNil)
 
 	mux, err := New(Config{

--- a/lib/service/listeners.go
+++ b/lib/service/listeners.go
@@ -86,6 +86,8 @@ func (process *TeleportProcess) ProxyTunnelAddr() (*utils.NetAddr, error) {
 }
 
 func (process *TeleportProcess) registeredListenerAddr(typ listenerType) (*utils.NetAddr, error) {
+	process.Lock()
+	defer process.Unlock()
 	for _, l := range process.registeredListeners {
 		if l.typ == typ {
 			return utils.ParseAddr(l.listener.Addr().String())

--- a/lib/service/listeners.go
+++ b/lib/service/listeners.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+)
+
+// listenerType identifies different registered listeners in
+// process.registeredListeners.
+type listenerType string
+
+var (
+	listenerAuthSSH    = listenerType(teleport.ComponentAuth)
+	listenerNodeSSH    = listenerType(teleport.ComponentNode)
+	listenerProxySSH   = listenerType(teleport.Component(teleport.ComponentProxy, "ssh"))
+	listenerDiagnostic = listenerType(teleport.ComponentDiagnostic)
+	listenerProxyKube  = listenerType(teleport.Component(teleport.ComponentProxy, "kube"))
+	// Proxy can use the same listener for tunnels and web interface
+	// (multiplexing the requests).
+	listenerProxyTunnelAndWeb = listenerType(teleport.Component(teleport.ComponentProxy, "tunnel", "web"))
+	listenerProxyWeb          = listenerType(teleport.Component(teleport.ComponentProxy, "web"))
+	listenerProxyTunnel       = listenerType(teleport.Component(teleport.ComponentProxy, "tunnel"))
+)
+
+// AuthSSHAddr returns auth server SSH endpoint, if configured and started.
+func (process *TeleportProcess) AuthSSHAddr() (*utils.NetAddr, error) {
+	return process.registeredListenerAddr(listenerAuthSSH)
+}
+
+// NodeSSHAddr returns the node SSH endpoint, if configured and started.
+func (process *TeleportProcess) NodeSSHAddr() (*utils.NetAddr, error) {
+	return process.registeredListenerAddr(listenerNodeSSH)
+}
+
+// ProxySSHAddr returns the proxy SSH endpoint, if configured and started.
+func (process *TeleportProcess) ProxySSHAddr() (*utils.NetAddr, error) {
+	return process.registeredListenerAddr(listenerProxySSH)
+}
+
+// DiagnosticAddr returns the diagnostic endpoint, if configured and started.
+func (process *TeleportProcess) DiagnosticAddr() (*utils.NetAddr, error) {
+	return process.registeredListenerAddr(listenerDiagnostic)
+}
+
+// ProxyKubeAddr returns the proxy kubernetes endpoint, if configured and
+// started.
+func (process *TeleportProcess) ProxyKubeAddr() (*utils.NetAddr, error) {
+	return process.registeredListenerAddr(listenerProxyKube)
+}
+
+// ProxyWebAddr returns the proxy web interface endpoint, if configured and
+// started.
+func (process *TeleportProcess) ProxyWebAddr() (*utils.NetAddr, error) {
+	addr, err := process.registeredListenerAddr(listenerProxyTunnelAndWeb)
+	if err == nil {
+		return addr, nil
+	}
+	return process.registeredListenerAddr(listenerProxyWeb)
+}
+
+// ProxyTunnelAddr returns the proxy reverse tunnel endpoint, if configured and
+// started.
+func (process *TeleportProcess) ProxyTunnelAddr() (*utils.NetAddr, error) {
+	addr, err := process.registeredListenerAddr(listenerProxyTunnelAndWeb)
+	if err == nil {
+		return addr, nil
+	}
+	return process.registeredListenerAddr(listenerProxyTunnel)
+}
+
+func (process *TeleportProcess) registeredListenerAddr(typ listenerType) (*utils.NetAddr, error) {
+	for _, l := range process.registeredListeners {
+		if l.typ == typ {
+			return utils.ParseAddr(l.listener.Addr().String())
+		}
+	}
+	return nil, trace.NotFound("no registered address for type %q", typ)
+}

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"strconv"
-
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
@@ -66,31 +64,24 @@ func (s *ServiceTestSuite) TestSelfSignedHTTPS(c *check.C) {
 func (s *ServiceTestSuite) TestMonitor(c *check.C) {
 	fakeClock := clockwork.NewFakeClock()
 
-	ports, err := utils.GetFreeTCPPorts(2)
-	c.Assert(err, check.IsNil)
-	authPort, err := strconv.Atoi(ports.Pop())
-	c.Assert(err, check.IsNil)
-	authAddr, err := utils.ParseHostPortAddr("127.0.0.1", authPort)
-	c.Assert(err, check.IsNil)
-	diagPort, err := strconv.Atoi(ports.Pop())
-	c.Assert(err, check.IsNil)
-	diagAddr, err := utils.ParseHostPortAddr("127.0.0.1", diagPort)
-	c.Assert(err, check.IsNil)
-
-	endpoint := fmt.Sprintf("http://%v/readyz", diagAddr.String())
-
 	cfg := MakeDefaultConfig()
 	cfg.Clock = fakeClock
 	cfg.DataDir = c.MkDir()
-	cfg.DiagnosticAddr = *diagAddr
-	cfg.AuthServers = []utils.NetAddr{*authAddr}
+	cfg.DiagnosticAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
+	cfg.AuthServers = []utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}}
 	cfg.Auth.Enabled = true
 	cfg.Auth.StorageConfig.Params["path"] = c.MkDir()
+	cfg.Auth.SSHAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = false
 
 	process, err := NewTeleport(cfg)
 	c.Assert(err, check.IsNil)
+
+	diagAddr, err := process.DiagnosticAddr()
+	c.Assert(err, check.IsNil)
+	c.Assert(diagAddr, check.NotNil)
+	endpoint := fmt.Sprintf("http://%v/readyz", diagAddr.String())
 
 	// Start Teleport and make sure the status is OK.
 	go process.Run()

--- a/lib/service/signals.go
+++ b/lib/service/signals.go
@@ -200,17 +200,17 @@ func (process *TeleportProcess) closeImportedDescriptors(prefix string) error {
 
 // importOrCreateListener imports listener passed by the parent process (happens during live reload)
 // or creates a new listener if there was no listener registered
-func (process *TeleportProcess) importOrCreateListener(listenerType, address string) (net.Listener, error) {
-	l, err := process.importListener(listenerType, address)
+func (process *TeleportProcess) importOrCreateListener(typ listenerType, address string) (net.Listener, error) {
+	l, err := process.importListener(typ, address)
 	if err == nil {
-		process.Infof("Using file descriptor %v %v passed by the parent process.", listenerType, address)
+		process.Infof("Using file descriptor %v %v passed by the parent process.", typ, address)
 		return l, nil
 	}
 	if !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
-	process.Infof("Service %v is creating new listener on %v.", listenerType, address)
-	return process.createListener(listenerType, address)
+	process.Infof("Service %v is creating new listener on %v.", typ, address)
+	return process.createListener(typ, address)
 }
 
 func (process *TeleportProcess) importSignalPipe() (*os.File, error) {
@@ -230,35 +230,35 @@ func (process *TeleportProcess) importSignalPipe() (*os.File, error) {
 
 // importListener imports listener passed by the parent process, if no listener is found
 // returns NotFound, otherwise removes the file from the list
-func (process *TeleportProcess) importListener(listenerType, address string) (net.Listener, error) {
+func (process *TeleportProcess) importListener(typ listenerType, address string) (net.Listener, error) {
 	process.Lock()
 	defer process.Unlock()
 
 	for i := range process.importedDescriptors {
 		d := process.importedDescriptors[i]
-		if d.Type == listenerType && d.Address == address {
+		if d.Type == string(typ) && d.Address == address {
 			l, err := d.ToListener()
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			process.importedDescriptors = append(process.importedDescriptors[:i], process.importedDescriptors[i+1:]...)
-			process.registeredListeners = append(process.registeredListeners, RegisteredListener{Type: listenerType, Address: address, Listener: l})
+			process.registeredListeners = append(process.registeredListeners, registeredListener{typ: typ, address: address, listener: l})
 			return l, nil
 		}
 	}
 
-	return nil, trace.NotFound("no file descriptor for type %v and address %v has been imported", listenerType, address)
+	return nil, trace.NotFound("no file descriptor for type %v and address %v has been imported", typ, address)
 }
 
 // createListener creates listener and adds to a list of tracked listeners
-func (process *TeleportProcess) createListener(listenerType, address string) (net.Listener, error) {
+func (process *TeleportProcess) createListener(typ listenerType, address string) (net.Listener, error) {
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	process.Lock()
 	defer process.Unlock()
-	r := RegisteredListener{Type: listenerType, Address: address, Listener: listener}
+	r := registeredListener{typ: typ, address: address, listener: listener}
 	process.registeredListeners = append(process.registeredListeners, r)
 	return listener, nil
 }
@@ -269,11 +269,11 @@ func (process *TeleportProcess) ExportFileDescriptors() ([]FileDescriptor, error
 	process.Lock()
 	defer process.Unlock()
 	for _, r := range process.registeredListeners {
-		file, err := utils.GetListenerFile(r.Listener)
+		file, err := utils.GetListenerFile(r.listener)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		out = append(out, FileDescriptor{File: file, Type: r.Type, Address: r.Address})
+		out = append(out, FileDescriptor{File: file, Type: string(r.typ), Address: r.address})
 	}
 	return out, nil
 }
@@ -298,15 +298,15 @@ func importFileDescriptors() ([]FileDescriptor, error) {
 	return files, nil
 }
 
-// RegisteredListener is a listener registered
+// registeredListener is a listener registered
 // within teleport process, can be passed to child process
-type RegisteredListener struct {
+type registeredListener struct {
 	// Type is a listener type, e.g. auth:ssh
-	Type string
+	typ listenerType
 	// Address is an address listener is serving on, e.g. 127.0.0.1:3025
-	Address string
+	address string
 	// Listener is a file listener object
-	Listener net.Listener
+	listener net.Listener
 }
 
 // FileDescriptor is a file descriptor associated

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -616,14 +616,15 @@ func (s *Server) getAdvertiseAddr() *utils.NetAddr {
 func (s *Server) AdvertiseAddr() string {
 	// set if we have explicit --advertise-ip option
 	advertiseAddr := s.getAdvertiseAddr()
+	listenAddr := s.Addr()
 	if advertiseAddr == nil {
-		return s.addr.Addr
+		return listenAddr
 	}
-	_, port, _ := net.SplitHostPort(s.addr.Addr)
+	_, port, _ := net.SplitHostPort(listenAddr)
 	ahost, aport, err := utils.ParseAdvertiseAddr(advertiseAddr.String())
 	if err != nil {
-		log.Warningf("Failed to parse advertise address %q, %v, using default value %q.", advertiseAddr, err, s.addr.Addr)
-		return s.addr.Addr
+		log.Warningf("Failed to parse advertise address %q, %v, using default value %q.", advertiseAddr, err, listenAddr)
+		return listenAddr
 	}
 	if aport == "" {
 		aport = port

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -66,7 +66,6 @@ type SrvSuite struct {
 	up          *upack
 	signer      ssh.Signer
 	user        string
-	freePorts   utils.PortList
 	server      *auth.TestTLSServer
 	proxyClient *auth.Client
 	nodeClient  *auth.Client
@@ -82,7 +81,6 @@ var wildcardAllow = services.Labels{
 	services.Wildcard: []string{services.Wildcard},
 }
 
-var _ = fmt.Printf
 var _ = Suite(&SrvSuite{})
 
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
@@ -99,12 +97,7 @@ func TestMain(m *testing.M) {
 }
 
 func (s *SrvSuite) SetUpSuite(c *C) {
-	var err error
-
 	utils.InitLoggerForTests(testing.Verbose())
-
-	s.freePorts, err = utils.GetFreeTCPPorts(100)
-	c.Assert(err, IsNil)
 }
 
 const hostID = "00000000-0000-0000-0000-000000000000"
@@ -147,16 +140,12 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	s.signer, err = sshutils.NewSigner(certs.Key, certs.Cert)
 	c.Assert(err, IsNil)
 
-	s.srvPort = s.freePorts.Pop()
-	s.srvAddress = "127.0.0.1:" + s.srvPort
-
 	s.nodeClient, err = s.server.NewClient(auth.TestBuiltin(teleport.RoleNode))
 	c.Assert(err, IsNil)
 
-	s.srvHostPort = fmt.Sprintf("%v:%v", s.server.ClusterName(), s.srvPort)
 	nodeDir := c.MkDir()
 	srv, err := New(
-		utils.NetAddr{AddrNetwork: "tcp", Addr: s.srvAddress},
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
 		s.server.ClusterName(),
 		[]ssh.Signer{s.signer},
 		s.nodeClient,
@@ -184,6 +173,11 @@ func (s *SrvSuite) SetUpTest(c *C) {
 	c.Assert(auth.CreateUploaderDir(nodeDir), IsNil)
 	c.Assert(s.srv.Start(), IsNil)
 	c.Assert(s.srv.heartbeat.ForceSend(time.Second), IsNil)
+
+	s.srvAddress = s.srv.Addr()
+	_, s.srvPort, err = net.SplitHostPort(s.srvAddress)
+	c.Assert(err, IsNil)
+	s.srvHostPort = fmt.Sprintf("%v:%v", s.server.ClusterName(), s.srvPort)
 
 	// set up an agent server and a client that uses agent for forwarding
 	keyring := agent.NewKeyring()
@@ -617,12 +611,11 @@ func (s *SrvSuite) testClient(c *C, proxyAddr, targetAddr, remoteAddr string, ss
 	c.Assert(string(out), Equals, "hello\n")
 }
 
-func mustListen(a utils.NetAddr) net.Listener {
-	l, err := net.Listen("tcp", a.Addr)
-	if err != nil {
-		panic(err)
-	}
-	return l
+func (s *SrvSuite) mustListen(c *C) (net.Listener, utils.NetAddr) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	c.Assert(err, IsNil)
+	addr := utils.NetAddr{AddrNetwork: "tcp", Addr: l.Addr().String()}
+	return l, addr
 }
 
 func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
@@ -638,13 +631,13 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 	proxySigner, err := sshutils.NewSigner(proxyKeys.Key, proxyKeys.Cert)
 	c.Assert(err, IsNil)
 
-	reverseTunnelPort := s.freePorts.Pop()
-	reverseTunnelAddress := utils.NetAddr{AddrNetwork: "tcp", Addr: fmt.Sprintf("%v:%v", s.server.ClusterName(), reverseTunnelPort)}
+	listener, reverseTunnelAddress := s.mustListen(c)
+	defer listener.Close()
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ClientTLS:             s.proxyClient.TLSConfig(),
 		ID:                    hostID,
 		ClusterName:           s.server.ClusterName(),
-		Listener:              mustListen(reverseTunnelAddress),
+		Listener:              listener,
 		HostSigners:           []ssh.Signer{proxySigner},
 		LocalAuthClient:       s.proxyClient,
 		LocalAccessPoint:      s.proxyClient,
@@ -721,9 +714,8 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 	s.testClient(c, proxy.Addr(), s.srvHostPort, s.srv.Addr(), sshConfig)
 
 	// adding new node
-	bobAddr := "127.0.0.1:" + s.freePorts.Pop()
 	srv2, err := New(
-		utils.NetAddr{AddrNetwork: "tcp", Addr: bobAddr},
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
 		"bob",
 		[]ssh.Signer{s.signer},
 		s.nodeClient,
@@ -746,7 +738,6 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 		SetAuditLog(s.nodeClient),
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
-		SetUUID(bobAddr),
 		SetBPF(&bpf.NOP{}),
 	)
 	c.Assert(err, IsNil)
@@ -802,16 +793,12 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 	log.Infof("[TEST START] TestProxyRoundRobin")
 
-	reverseTunnelPort := s.freePorts.Pop()
-	reverseTunnelAddress := utils.NetAddr{
-		AddrNetwork: "tcp",
-		Addr:        fmt.Sprintf("%v:%v", s.server.ClusterName(), reverseTunnelPort),
-	}
+	listener, reverseTunnelAddress := s.mustListen(c)
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ClusterName:           s.server.ClusterName(),
 		ClientTLS:             s.proxyClient.TLSConfig(),
 		ID:                    hostID,
-		Listener:              mustListen(reverseTunnelAddress),
+		Listener:              listener,
 		HostSigners:           []ssh.Signer{s.signer},
 		LocalAuthClient:       s.proxyClient,
 		LocalAccessPoint:      s.proxyClient,
@@ -907,15 +894,12 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 // TestProxyDirectAccess tests direct access via proxy bypassing
 // reverse tunnel
 func (s *SrvSuite) TestProxyDirectAccess(c *C) {
-	reverseTunnelAddress := utils.NetAddr{
-		AddrNetwork: "tcp",
-		Addr:        fmt.Sprintf("%v:0", s.server.ClusterName()),
-	}
+	listener, _ := s.mustListen(c)
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ClientTLS:             s.proxyClient.TLSConfig(),
 		ID:                    hostID,
 		ClusterName:           s.server.ClusterName(),
-		Listener:              mustListen(reverseTunnelAddress),
+		Listener:              listener,
 		HostSigners:           []ssh.Signer{s.signer},
 		LocalAuthClient:       s.proxyClient,
 		LocalAccessPoint:      s.proxyClient,
@@ -1033,10 +1017,9 @@ func (s *SrvSuite) TestLimiter(c *C) {
 	)
 	c.Assert(err, IsNil)
 
-	srvAddress := "127.0.0.1:" + s.freePorts.Pop()
 	nodeStateDir := c.MkDir()
 	srv, err := New(
-		utils.NetAddr{AddrNetwork: "tcp", Addr: srvAddress},
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
 		s.server.ClusterName(),
 		[]ssh.Signer{s.signer},
 		s.nodeClient,

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -234,6 +234,8 @@ func SetFIPS(fips bool) ServerOption {
 }
 
 func (s *Server) Addr() string {
+	s.RLock()
+	defer s.RUnlock()
 	if s.listener == nil {
 		return ""
 	}

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -234,6 +234,9 @@ func SetFIPS(fips bool) ServerOption {
 }
 
 func (s *Server) Addr() string {
+	if s.listener == nil {
+		return ""
+	}
 	return s.listener.Addr().String()
 }
 

--- a/lib/utils/loadbalancer.go
+++ b/lib/utils/loadbalancer.go
@@ -170,6 +170,15 @@ func (l *LoadBalancer) Listen() error {
 	return nil
 }
 
+// Addr returns the frontend listener address. Call this after Listen,
+// otherwise Addr returns nil.
+func (l *LoadBalancer) Addr() net.Addr {
+	if l.listener == nil {
+		return nil
+	}
+	return l.listener.Addr()
+}
+
 // Serve starts accepting connections
 func (l *LoadBalancer) Serve() error {
 	defer l.waitCancel()

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -120,6 +120,7 @@ func (s *MainTestSuite) TestMakeClient(c *check.C) {
 			Token:   staticToken,
 		}},
 	})
+	c.Assert(err, check.IsNil)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = true
 	cfg.Auth.SSHAddr = randomLocalAddr


### PR DESCRIPTION
Use OS-assigned ports (listen on port 0) to avoid manually tracking them via `lib/utils`.
Manual tracking causes conflicts when multiple test processes run in parallel.

As part of this, ad helper methods on `service.TeleportProcess` to expose actual listening addresses of all services.

In local testing, I had no trouble with port exhaustion or sockets stuck in `TIME_WAIT`. I suspect that will happen more in integration tests.