### PR TITLE
Start /readyz state tracking in stateStarting instead of stateOK

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1741,6 +1741,10 @@ func (process *TeleportProcess) initDiagnosticService() error {
 			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]interface{}{
 				"status": "teleport is recovering from a degraded state, check logs for details",
 			})
+		case stateStarting:
+			roundtrip.ReplyJSON(w, http.StatusBadRequest, map[string]interface{}{
+				"status": "teleport is starting and hasn't joined the cluster yet",
+			})
 		// 200
 		case stateOK:
 			roundtrip.ReplyJSON(w, http.StatusOK, map[string]interface{}{


### PR DESCRIPTION
This only matters for nodes. The new stateStarting will be in effect
until the node successfully joins the cluster. This means that /readyz
for nodes will return '400 Bad Request' instead of '200 OK' until it
joins.

Updates #3700