### PR TITLE
Emit audit events when roles are upserted or deleted

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -2132,7 +2132,7 @@ func (s *APIServer) deleteRole(auth ClientI, w http.ResponseWriter, r *http.Requ
 	if err := auth.DeleteRole(role); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return message(fmt.Sprintf("role '%v' deleted", role)), nil
+	return message(fmt.Sprintf("role %q deleted", role)), nil
 }
 
 func (s *APIServer) getClusterConfig(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -35,7 +35,6 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport"
-	enterpriseevents "github.com/gravitational/teleport/e/lib/events"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -1363,7 +1362,7 @@ func (a *AuthServer) DeleteRole(name string) error {
 		return trace.Wrap(err)
 	}
 
-	a.EmitAuditEvent(enterpriseevents.RoleDeleted, events.EventFields{
+	a.EmitAuditEvent(events.RoleDeleted, events.EventFields{
 		events.FieldName: name,
 		events.EventUser: "unimplemented",
 	})
@@ -1377,7 +1376,7 @@ func (a *AuthServer) upsertRole(role services.Role) error {
 		return trace.Wrap(err)
 	}
 
-	a.EmitAuditEvent(enterpriseevents.RoleCreated, events.EventFields{
+	a.EmitAuditEvent(events.RoleCreated, events.EventFields{
 		events.FieldName: role.GetName(),
 		events.EventUser: "unimplemented",
 	})

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
+	enterpriseevents "github.com/gravitational/teleport/e/lib/events"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
@@ -60,7 +61,6 @@ func (s *AuthSuite) SetUpSuite(c *C) {
 
 func (s *AuthSuite) SetUpTest(c *C) {
 	var err error
-	s.mockedAuditLog = events.NewMockAuditLog(0)
 	s.dataDir = c.MkDir()
 	s.bk, err = lite.NewWithConfig(context.TODO(), lite.Config{Path: s.dataDir})
 	c.Assert(err, IsNil)
@@ -101,6 +101,9 @@ func (s *AuthSuite) SetUpTest(c *C) {
 
 	err = s.a.SetClusterConfig(services.DefaultClusterConfig())
 	c.Assert(err, IsNil)
+
+	s.mockedAuditLog = events.NewMockAuditLog(0)
+	s.a.IAuditLog = s.mockedAuditLog
 }
 
 func (s *AuthSuite) TearDownTest(c *C) {
@@ -587,13 +590,14 @@ func (s *AuthSuite) TestUpdateByWithContext(c *C) {
 }
 
 func (s *AuthSuite) TestCreateAndUpdateUser(c *C) {
-	s.a.IAuditLog = s.mockedAuditLog
 	user, err := services.NewUser("some-user")
 	c.Assert(err, IsNil)
 
 	// test create user
+	createEventEmitted := false
 	s.mockedAuditLog.MockEmitAuditEvent = func(event events.Event, fields events.EventFields) error {
-		c.Assert(event.Code, Equals, events.UserCreateCode)
+		createEventEmitted = true
+		c.Assert(event, DeepEquals, events.UserCreate)
 		c.Assert(fields[events.EventUser], Equals, "some-auth-user")
 		return nil
 	}
@@ -601,6 +605,7 @@ func (s *AuthSuite) TestCreateAndUpdateUser(c *C) {
 	// trigger error
 	err = s.a.CreateUser(context.TODO(), user)
 	c.Assert(err, ErrorMatches, `created by is not set for new user "some-user"`)
+	c.Assert(createEventEmitted, Equals, false)
 
 	// happy path
 	user.SetCreatedBy(services.CreatedBy{
@@ -608,10 +613,13 @@ func (s *AuthSuite) TestCreateAndUpdateUser(c *C) {
 	})
 	err = s.a.CreateUser(context.TODO(), user)
 	c.Assert(err, IsNil)
+	c.Assert(createEventEmitted, Equals, true)
 
 	// test update user
+	updateEventEmitted := false
 	s.mockedAuditLog.MockEmitAuditEvent = func(event events.Event, fields events.EventFields) error {
-		c.Assert(event.Code, Equals, events.UserUpdateCode)
+		updateEventEmitted = true
+		c.Assert(event, DeepEquals, events.UserUpdate)
 		c.Assert(fields[events.EventUser], Equals, "some-context-user")
 		return nil
 	}
@@ -619,4 +627,61 @@ func (s *AuthSuite) TestCreateAndUpdateUser(c *C) {
 	c.Assert(ctx, NotNil)
 	err = s.a.UpdateUser(ctx, user)
 	c.Assert(err, IsNil)
+	c.Assert(updateEventEmitted, Equals, true)
+}
+
+func (s *AuthSuite) TestUpsertDeleteRole(c *C) {
+	// test create new role
+	roleTest, err := services.NewRole("test", services.RoleSpecV3{
+		Options: services.RoleOptions{},
+		Allow:   services.RoleConditions{},
+	})
+	c.Assert(err, IsNil)
+
+	createEventEmitted := false
+	s.mockedAuditLog.MockEmitAuditEvent = func(event events.Event, fields events.EventFields) error {
+		createEventEmitted = true
+		c.Assert(event, DeepEquals, enterpriseevents.RoleCreated)
+		c.Assert(fields[events.FieldName], Equals, "test")
+		return nil
+	}
+
+	err = s.a.upsertRole(roleTest)
+	c.Assert(err, IsNil)
+	c.Assert(createEventEmitted, Equals, true)
+
+	roleRetrieved, err := s.a.GetRole("test")
+	c.Assert(err, IsNil)
+	c.Assert(roleRetrieved.Equals(roleTest), Equals, true)
+
+	// test update role
+	createEventEmitted = false
+	err = s.a.upsertRole(roleTest)
+	c.Assert(err, IsNil)
+	c.Assert(roleRetrieved.Equals(roleTest), Equals, true)
+
+	// test delete role
+	deleteEventEmitted := false
+	s.mockedAuditLog.MockEmitAuditEvent = func(event events.Event, fields events.EventFields) error {
+		deleteEventEmitted = true
+		c.Assert(event, DeepEquals, enterpriseevents.RoleDeleted)
+		c.Assert(fields[events.FieldName], Equals, "test")
+		return nil
+	}
+
+	err = s.a.DeleteRole("test")
+	c.Assert(err, IsNil)
+	c.Assert(deleteEventEmitted, Equals, true)
+
+	// test role has been deleted
+	roleRetrieved, err = s.a.GetRole("test")
+	c.Assert(trace.IsNotFound(err), Equals, true)
+	c.Assert(roleRetrieved, IsNil)
+
+	// test role that doesn't exist
+	deleteEventEmitted = false
+	err = s.a.DeleteRole("test")
+	c.Assert(trace.IsNotFound(err), Equals, true)
+	c.Assert(deleteEventEmitted, Equals, false)
+
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -26,7 +26,6 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
-	enterpriseevents "github.com/gravitational/teleport/e/lib/events"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
@@ -641,7 +640,7 @@ func (s *AuthSuite) TestUpsertDeleteRole(c *C) {
 	createEventEmitted := false
 	s.mockedAuditLog.MockEmitAuditEvent = func(event events.Event, fields events.EventFields) error {
 		createEventEmitted = true
-		c.Assert(event, DeepEquals, enterpriseevents.RoleCreated)
+		c.Assert(event, DeepEquals, events.RoleCreated)
 		c.Assert(fields[events.FieldName], Equals, "test")
 		return nil
 	}
@@ -659,12 +658,13 @@ func (s *AuthSuite) TestUpsertDeleteRole(c *C) {
 	err = s.a.upsertRole(roleTest)
 	c.Assert(err, IsNil)
 	c.Assert(roleRetrieved.Equals(roleTest), Equals, true)
+	c.Assert(createEventEmitted, Equals, true)
 
 	// test delete role
 	deleteEventEmitted := false
 	s.mockedAuditLog.MockEmitAuditEvent = func(event events.Event, fields events.EventFields) error {
 		deleteEventEmitted = true
-		c.Assert(event, DeepEquals, enterpriseevents.RoleDeleted)
+		c.Assert(event, DeepEquals, events.RoleDeleted)
 		c.Assert(fields[events.FieldName], Equals, "test")
 		return nil
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1471,7 +1471,7 @@ func (a *AuthWithRoles) CreateRole(role services.Role) error {
 	return trace.NotImplemented("not implemented")
 }
 
-// UpsertRole creates or updates role
+// UpsertRole creates or updates role.
 func (a *AuthWithRoles) UpsertRole(role services.Role) error {
 	if err := a.action(defaults.Namespace, services.KindRole, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
@@ -1479,7 +1479,8 @@ func (a *AuthWithRoles) UpsertRole(role services.Role) error {
 	if err := a.action(defaults.Namespace, services.KindRole, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.UpsertRole(role)
+
+	return a.authServer.upsertRole(role)
 }
 
 // GetRole returns role by name

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -195,6 +195,9 @@ const (
 	// resetting passwords, creating/updating user, etc.
 	ActionOnBehalfOf = "entity"
 
+	// FieldName contains name, e.g. resource name, etc.
+	FieldName = "name"
+
 	// ExecEvent is an exec command executed by script or user on
 	// the server side
 	ExecEvent        = "exec"

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -290,6 +290,11 @@ const (
 
 	// TCPVersion is the version of TCP (4 or 6).
 	TCPVersion = "version"
+
+	// RoleCreatedEvent fires when role is created/updated.
+	RoleCreatedEvent = "role.created"
+	// RoleDeletedEvent fires when role is deleted.
+	RoleDeletedEvent = "role.deleted"
 )
 
 const (

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -191,9 +191,20 @@ var (
 		Name: ResetPasswordTokenCreateEvent,
 		Code: ResetPasswordTokenCreateCode,
 	}
+	// RoleCreated is emitted when a role is created/updated.
+	RoleCreated = Event{
+		Name: RoleCreatedEvent,
+		Code: RoleCreatedCode,
+	}
+	// RoleDeleted is emitted when a role is deleted.
+	RoleDeleted = Event{
+		Name: RoleDeletedEvent,
+		Code: RoleDeletedCode,
+	}
 )
 
-var (
+// OSS event codes start with "T".
+const (
 	// UserLocalLoginCode is the successful local user login event code.
 	UserLocalLoginCode = "T1000I"
 	// UserLocalLoginFailureCode is the unsuccessful local user login event code.
@@ -260,4 +271,12 @@ var (
 	AccessRequestUpdateCode = "T5001I"
 	// ResetPasswordTokenCreateCode is the token create event code.
 	ResetPasswordTokenCreateCode = "T6000I"
+)
+
+// Enterprise event codes starts with "TE".
+const (
+	// RoleCreatedCode is the role created event code.
+	RoleCreatedCode = "TE1000I"
+	// RoleDeletedCode is the role deleted event code.
+	RoleDeletedCode = "TE2000I"
 )


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/2989

#### Description
For now, `role.created` was used as the event for upsert role. And because I cannot capture the correct user with the current API signature, I used `unimplemented` as a placeholder for the `event user`. Pinging @benarent 
- Added FieldName to events for storing role names
- Added upsertUser to auth layer for easier unit testing
- Cleaned up code in test file

#### Related PR
This PR defines the enterprise only event names and code which was ported from `Gravity/e`, I just changed `G` to `T` for Teleport: https://github.com/gravitational/teleport.e/pull/135

#### Screenshot
upsert role:
![Screenshot from 2020-05-14 16-59-27](https://user-images.githubusercontent.com/43280172/81997386-682c7100-9604-11ea-9842-28915d3cfc68.png)

delete role:
![Screenshot from 2020-05-14 16-59-34](https://user-images.githubusercontent.com/43280172/81997387-68c50780-9604-11ea-84f5-51a51889199e.png)
