### PR TITLE
Add options to skip connecting to ssh-agent from tsh

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -256,6 +256,10 @@ type Config struct {
 	// Browser can be used to pass the name of a browser to override the system default
 	// (not currently implemented), or set to 'none' to suppress browser opening entirely.
 	Browser string
+
+	// UseLocalSSHAgent will write user certificates to the local ssh-agent (or
+	// similar) socket at $SSH_AUTH_SOCK.
+	UseLocalSSHAgent bool
 }
 
 // CachePolicy defines cache policy for local clients
@@ -269,9 +273,10 @@ type CachePolicy struct {
 // MakeDefaultConfig returns default client config
 func MakeDefaultConfig() *Config {
 	return &Config{
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-		Stdin:  os.Stdin,
+		Stdout:           os.Stdout,
+		Stderr:           os.Stderr,
+		Stdin:            os.Stdin,
+		UseLocalSSHAgent: true,
 	}
 }
 
@@ -834,7 +839,7 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 	} else {
 		// initialize the local agent (auth agent which uses local SSH keys signed by the CA):
 		webProxyHost, _ := tc.WebProxyHostPort()
-		tc.localAgent, err = NewLocalAgent(c.KeysDir, webProxyHost, c.Username)
+		tc.localAgent, err = NewLocalAgent(c.KeysDir, webProxyHost, c.Username, c.UseLocalSSHAgent)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -68,7 +68,7 @@ type LocalKeyAgent struct {
 
 // NewLocalAgent reads all Teleport certificates from disk (using FSLocalKeyStore),
 // creates a LocalKeyAgent, loads all certificates into it, and returns the agent.
-func NewLocalAgent(keyDir string, proxyHost string, username string) (a *LocalKeyAgent, err error) {
+func NewLocalAgent(keyDir, proxyHost, username string, useLocalSSHAgent bool) (a *LocalKeyAgent, err error) {
 	keystore, err := NewFSLocalKeyStore(keyDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -80,10 +80,15 @@ func NewLocalAgent(keyDir string, proxyHost string, username string) (a *LocalKe
 		}),
 		Agent:     agent.NewKeyring(),
 		keyStore:  keystore,
-		sshAgent:  connectToSSHAgent(),
 		noHosts:   make(map[string]bool),
 		username:  username,
 		proxyHost: proxyHost,
+	}
+
+	if useLocalSSHAgent {
+		a.sshAgent = connectToSSHAgent()
+	} else {
+		log.Debug("Skipping connection to the local ssh-agent.")
 	}
 
 	// unload all teleport keys from the agent first to ensure

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -100,7 +100,7 @@ func (s *KeyAgentTestSuite) SetUpTest(c *check.C) {
 //     a teleport key with the teleport username.
 func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
 	// make a new local agent
-	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
+	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username, true)
 	c.Assert(err, check.IsNil)
 
 	// add the key to the local agent, this should write the key
@@ -159,7 +159,7 @@ func (s *KeyAgentTestSuite) TestLoadKey(c *check.C) {
 	userdata := []byte("hello, world")
 
 	// make a new local agent
-	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
+	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username, true)
 	c.Assert(err, check.IsNil)
 
 	// unload any keys that might be in the agent for this user
@@ -217,7 +217,7 @@ func (s *KeyAgentTestSuite) TestLoadKey(c *check.C) {
 
 func (s *KeyAgentTestSuite) TestHostCertVerification(c *check.C) {
 	// Make a new local agent.
-	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
+	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username, true)
 	c.Assert(err, check.IsNil)
 
 	// By default user has not refused any hosts.
@@ -297,7 +297,7 @@ func (s *KeyAgentTestSuite) TestHostCertVerification(c *check.C) {
 
 func (s *KeyAgentTestSuite) TestHostKeyVerification(c *check.C) {
 	// make a new local agent
-	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
+	lka, err := NewLocalAgent(s.keyDir, s.hostname, s.username, true)
 	c.Assert(err, check.IsNil)
 
 	// by default user has not refused any hosts:
@@ -351,7 +351,7 @@ func (s *KeyAgentTestSuite) TestHostKeyVerification(c *check.C) {
 func (s *KeyAgentTestSuite) TestDefaultHostPromptFunc(c *check.C) {
 	keygen := testauthority.New()
 
-	a, err := NewLocalAgent(s.keyDir, s.hostname, s.username)
+	a, err := NewLocalAgent(s.keyDir, s.hostname, s.username, true)
 	c.Assert(err, check.IsNil)
 
 	_, keyBytes, err := keygen.GenerateKeyPair("")


### PR DESCRIPTION
In particular, gpg-agent doesn't support SSH certificates, so writing to
it is potentially disruptive for the user: https://dev.gnupg.org/T1756

User has two options:
- pass `--no-use-local-ssh-agent` for individual calls to tsh
- set `TELEPORT_USE_LOCAL_SSH_AGENT=false` to make it permanent

Fixes #3169