### PR TITLE
Set directory permissions for /var/lib/teleport to 0700 when installed via packages

### DIFF
--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -242,8 +242,10 @@ else
     LINUX_CONFIG_FILE_LIST=""
     if [[ "${PACKAGE_TYPE}" == "rpm" ]]; then
         OUTPUT_FILENAME="${TAR_PATH}-${TELEPORT_VERSION}-1${OPTIONAL_RUNTIME_SECTION}.${ARCH}.rpm"
+        FILE_PERMISSIONS_STANZA="--rpm-use-file-permissions --rpm-user root --rpm-group root "
     elif [[ "${PACKAGE_TYPE}" == "deb" ]]; then
         OUTPUT_FILENAME="${TAR_PATH}_${TELEPORT_VERSION}${OPTIONAL_RUNTIME_SECTION}_${ARCH}.deb"
+        FILE_PERMISSIONS_STANZA="--deb-use-file-permissions --deb-user root --deb-group root "
     fi
 fi
 
@@ -288,7 +290,7 @@ if [[ "${PACKAGE_TYPE}" != "pkg" ]]; then
         CONFIG_FILE_STANZA="--config-files /src/buildroot${LINUX_CONFIG_DIR}/${LINUX_CONFIG_FILE} "
     fi
     # /var/lib/teleport
-    mkdir -p ${TMPDIR}/buildroot${LINUX_DATA_DIR}
+    mkdir -p -m0700 ${TMPDIR}/buildroot${LINUX_DATA_DIR}
 fi
 popd
 
@@ -376,7 +378,8 @@ else
         --provides teleport \
         --prefix / \
         --verbose \
-        ${CONFIG_FILE_STANZA} .
+        ${CONFIG_FILE_STANZA} \
+        ${FILE_PERMISSIONS_STANZA} .
 
     # copy created package back to current directory
     cp ${TMPDIR}/*.${PACKAGE_TYPE} .

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -145,7 +145,7 @@ else
     if [[ "${ARCH}" == "" ]]; then
         usage
     fi
-    
+
     # set docker image appropriately
     if [[ "${PACKAGE_TYPE}" == "deb" ]]; then
         DOCKER_IMAGE="cdrx/fpm-debian:8"
@@ -242,10 +242,10 @@ else
     LINUX_CONFIG_FILE_LIST=""
     if [[ "${PACKAGE_TYPE}" == "rpm" ]]; then
         OUTPUT_FILENAME="${TAR_PATH}-${TELEPORT_VERSION}-1${OPTIONAL_RUNTIME_SECTION}.${ARCH}.rpm"
-        FILE_PERMISSIONS_STANZA="--rpm-use-file-permissions --rpm-user root --rpm-group root "
+        FILE_PERMISSIONS_STANZA="--rpm-user root --rpm-group root --rpm-use-file-permissions "
     elif [[ "${PACKAGE_TYPE}" == "deb" ]]; then
         OUTPUT_FILENAME="${TAR_PATH}_${TELEPORT_VERSION}${OPTIONAL_RUNTIME_SECTION}_${ARCH}.deb"
-        FILE_PERMISSIONS_STANZA="--deb-use-file-permissions --deb-user root --deb-group root "
+        FILE_PERMISSIONS_STANZA="--deb-user root --deb-group root "
     fi
 fi
 


### PR DESCRIPTION
Fixes #3701 

Before (`/var/lib/teleport` mode 755):
```
$ find . -iname "*.rpm" -exec rpm -qp --dump {} \; | grep /var/lib/teleport
/var/lib/teleport 4096 1589492797 00000000000000000000000000000000 040755 root root 0 0 0 X
/var/lib/teleport 4096 1589492825 00000000000000000000000000000000 040755 root root 0 0 0 X

$ find . -iname "*.deb" -exec dpkg -c {} \; | grep /var/lib/teleport
drwxrwxr-x 0/0               0 2020-05-14 18:47 ./var/lib/teleport/
drwxrwxr-x 0/0               0 2020-05-14 18:47 ./var/lib/teleport/
```

After (`/var/lib/teleport` mode 700):
```
$ find . -iname "*.rpm" -exec rpm -qp --dump {} \; | grep /var/lib/teleport
/var/lib/teleport 4096 1589566896 00000000000000000000000000000000 040700 root root 0 0 0 X
/var/lib/teleport 4096 1589566922 00000000000000000000000000000000 040700 root root 0 0 0 X

$ find . -iname "*.deb" -exec dpkg -c {} \; | grep /var/lib/teleport
drwx------ 0/0               0 2020-05-15 15:24 ./var/lib/teleport/
drwx------ 0/0               0 2020-05-15 15:24 ./var/lib/teleport/
```