### PR TITLE
Emit audit event when creating a new token for trusted_cluster

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -811,6 +811,15 @@ func (s *AuthServer) GenerateToken(req GenerateTokenRequest) (string, error) {
 	if err := s.Provisioner.UpsertToken(token); err != nil {
 		return "", trace.Wrap(err)
 	}
+
+	for _, role := range req.Roles {
+		if role == teleport.RoleTrustedCluster {
+			s.EmitAuditEvent(events.TrustedClusterTokenCreate, events.EventFields{
+				events.EventUser: "unimplemented",
+			})
+		}
+	}
+
 	return req.Token, nil
 }
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -799,22 +799,22 @@ func (req *GenerateTokenRequest) CheckAndSetDefaults() error {
 	return nil
 }
 
-// GenerateToken generates multi-purpose authentication token
-func (s *AuthServer) GenerateToken(req GenerateTokenRequest) (string, error) {
+// GenerateToken generates multi-purpose authentication token.
+func (a *AuthServer) GenerateToken(req GenerateTokenRequest) (string, error) {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return "", trace.Wrap(err)
 	}
-	token, err := services.NewProvisionToken(req.Token, req.Roles, s.clock.Now().UTC().Add(req.TTL))
+	token, err := services.NewProvisionToken(req.Token, req.Roles, a.clock.Now().UTC().Add(req.TTL))
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	if err := s.Provisioner.UpsertToken(token); err != nil {
+	if err := a.Provisioner.UpsertToken(token); err != nil {
 		return "", trace.Wrap(err)
 	}
 
 	for _, role := range req.Roles {
 		if role == teleport.RoleTrustedCluster {
-			s.EmitAuditEvent(events.TrustedClusterTokenCreate, events.EventFields{
+			a.EmitAuditEvent(events.TrustedClusterTokenCreate, events.EventFields{
 				events.EventUser: "unimplemented",
 			})
 		}

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -370,8 +370,18 @@ func (s *AuthSuite) TestGenerateTokenEventsEmitted(c *C) {
 		return nil
 	}
 
-	// test trusted cluster token
+	// test trusted cluster token emit
 	_, err := s.a.GenerateToken(GenerateTokenRequest{Roles: teleport.Roles{teleport.RoleTrustedCluster}})
+	c.Assert(err, IsNil)
+	c.Assert(eventEmitted, Equals, true)
+
+	// test emit with multiple roles
+	eventEmitted = false
+	_, err = s.a.GenerateToken(GenerateTokenRequest{Roles: teleport.Roles{
+		teleport.RoleNode,
+		teleport.RoleTrustedCluster,
+		teleport.RoleAuth,
+	}})
 	c.Assert(err, IsNil)
 	c.Assert(eventEmitted, Equals, true)
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -363,27 +363,20 @@ func (s *AuthSuite) TestBadTokens(c *C) {
 }
 
 func (s *AuthSuite) TestGenerateTokenEventsEmitted(c *C) {
-	eventEmitted := false
-	s.mockedAuditLog.MockEmitAuditEvent = func(event events.Event, fields events.EventFields) error {
-		eventEmitted = true
-		c.Assert(event, DeepEquals, events.TrustedClusterTokenCreate)
-		return nil
-	}
-
 	// test trusted cluster token emit
 	_, err := s.a.GenerateToken(GenerateTokenRequest{Roles: teleport.Roles{teleport.RoleTrustedCluster}})
 	c.Assert(err, IsNil)
-	c.Assert(eventEmitted, Equals, true)
+	c.Assert(s.mockedAuditLog.EmittedEvent.EventType, DeepEquals, events.TrustedClusterTokenCreate)
+	s.mockedAuditLog.Reset()
 
 	// test emit with multiple roles
-	eventEmitted = false
 	_, err = s.a.GenerateToken(GenerateTokenRequest{Roles: teleport.Roles{
 		teleport.RoleNode,
 		teleport.RoleTrustedCluster,
 		teleport.RoleAuth,
 	}})
 	c.Assert(err, IsNil)
-	c.Assert(eventEmitted, Equals, true)
+	c.Assert(s.mockedAuditLog.EmittedEvent.EventType, DeepEquals, events.TrustedClusterTokenCreate)
 }
 
 func (s *AuthSuite) TestBuildRolesInvalid(c *C) {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -561,7 +561,7 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 	// try and set static tokens, this should be successful because the last
 	// one to upsert tokens wins
 	staticTokens, err := services.NewStaticTokens(services.StaticTokensSpecV2{
-		StaticTokens: []services.ProvisionTokenV1{services.ProvisionTokenV1{
+		StaticTokens: []services.ProvisionTokenV1{{
 			Token: "bar",
 			Roles: teleport.Roles{teleport.Role("baz")},
 		}},
@@ -577,7 +577,7 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 	c.Assert(cn.GetClusterName(), Equals, "me.localhost")
 	st, err = s.a.GetStaticTokens()
 	c.Assert(err, IsNil)
-	c.Assert(st.GetStaticTokens(), DeepEquals, services.ProvisionTokensFromV1([]services.ProvisionTokenV1{services.ProvisionTokenV1{
+	c.Assert(st.GetStaticTokens(), DeepEquals, services.ProvisionTokensFromV1([]services.ProvisionTokenV1{{
 		Token: "bar",
 		Roles: teleport.Roles{teleport.Role("baz")},
 	}}))
@@ -586,7 +586,7 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 	// new static tokens
 	st, err = authServer.GetStaticTokens()
 	c.Assert(err, IsNil)
-	c.Assert(st.GetStaticTokens(), DeepEquals, services.ProvisionTokensFromV1([]services.ProvisionTokenV1{services.ProvisionTokenV1{
+	c.Assert(st.GetStaticTokens(), DeepEquals, services.ProvisionTokensFromV1([]services.ProvisionTokenV1{{
 		Token: "bar",
 		Roles: teleport.Roles{teleport.Role("baz")},
 	}}))

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -306,6 +306,7 @@ func (a *AuthWithRoles) DeactivateCertAuthority(id services.CertAuthID) error {
 	return trace.NotImplemented("not implemented")
 }
 
+// GenerateToken generates multi-purpose authentication token.
 func (a *AuthWithRoles) GenerateToken(req GenerateTokenRequest) (string, error) {
 	if err := a.action(defaults.Namespace, services.KindToken, services.VerbCreate); err != nil {
 		return "", trace.Wrap(err)

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -300,6 +300,10 @@ const (
 	TrustedClusterCreateEvent = "trusted_cluster.create"
 	// TrustedClusterDeleteEvent is the event for removing a trusted cluster.
 	TrustedClusterDeleteEvent = "trusted_cluster.delete"
+	// TrustedClusterTokenCreateEvent is the event for
+	// creating new join token for a trusted cluster.
+	TrustedClusterTokenCreateEvent = "trusted_cluster_token.create"
+
 	// GithubConnectorCreatedEvent fires when a Github connector is created/updated.
 	GithubConnectorCreatedEvent = "github.created"
 	// GithubConnectorDeletedEvent fires when a Github connector is deleted.

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -211,6 +211,12 @@ var (
 		Name: TrustedClusterDeleteEvent,
 		Code: TrustedClusterDeleteCode,
 	}
+	// TrustedClusterTokenCreate is emitted when a new join
+	// token for trusted cluster is created.
+	TrustedClusterTokenCreate = Event{
+		Name: TrustedClusterTokenCreateEvent,
+		Code: TrustedClusterTokenCreateCode,
+	}
 	// GithubConnectorCreated is emitted when a Github connector is created/updated.
 	GithubConnectorCreated = Event{
 		Name: GithubConnectorCreatedEvent,
@@ -315,6 +321,9 @@ const (
 	TrustedClusterCreateCode = "T7000I"
 	// TrustedClusterDeleteCode is the event code for removing a trusted cluster.
 	TrustedClusterDeleteCode = "T7001I"
+	// TrustedClusterTokenCreateCode is the event code for
+	// creating new join token for a trusted cluster.
+	TrustedClusterTokenCreateCode = "T7002I"
 	// GithubConnectorCreatedCode is the Github connector created event code.
 	GithubConnectorCreatedCode = "T8001I"
 	// GithubConnectorDeletedCode is the Github connector deleted event code.


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/2989

#### Description
- Create code and event name for trusted cluster token create
- Emit event for `tctl tokens add --type=trusted_cluster`
- Test it was emitted

#### Screenshot
![Screenshot from 2020-05-18 15-53-44](https://user-images.githubusercontent.com/43280172/82267339-e482c500-9920-11ea-8634-13291a81016b.png)
