### PR TITLE
Emit audit events when upserting/deleting auth connectors

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1174,6 +1174,7 @@ func (a *AuthWithRoles) UpsertUser(u services.User) error {
 	return a.authServer.UpsertUser(u)
 }
 
+// UpsertOIDCConnector creates or updates an OIDC connector.
 func (a *AuthWithRoles) UpsertOIDCConnector(connector services.OIDCConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
@@ -1237,6 +1238,7 @@ func (a *AuthWithRoles) CreateSAMLConnector(connector services.SAMLConnector) er
 	return a.authServer.UpsertSAMLConnector(connector)
 }
 
+// UpsertSAMLConnector creates or updates a SAML connector.
 func (a *AuthWithRoles) UpsertSAMLConnector(connector services.SAMLConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
@@ -1286,6 +1288,7 @@ func (a *AuthWithRoles) ValidateSAMLResponse(re string) (*SAMLAuthResponse, erro
 	return a.authServer.ValidateSAMLResponse(re)
 }
 
+// DeleteSAMLConnector deletes a SAML connector by name.
 func (a *AuthWithRoles) DeleteSAMLConnector(connectorID string) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
@@ -1300,11 +1303,15 @@ func (a *AuthWithRoles) CreateGithubConnector(connector services.GithubConnector
 	return a.authServer.CreateGithubConnector(connector)
 }
 
+// UpsertGithubConnector creates or updates a Github connector.
 func (a *AuthWithRoles) UpsertGithubConnector(connector services.GithubConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.UpsertGithubConnector(connector)
+	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+	return a.authServer.upsertGithubConnector(connector)
 }
 
 func (a *AuthWithRoles) GetGithubConnector(id string, withSecrets bool) (services.GithubConnector, error) {
@@ -1334,11 +1341,12 @@ func (a *AuthWithRoles) GetGithubConnectors(withSecrets bool) ([]services.Github
 	return a.authServer.Identity.GetGithubConnectors(withSecrets)
 }
 
-func (a *AuthWithRoles) DeleteGithubConnector(id string) error {
+// DeleteGithubConnector deletes a Github connector by name.
+func (a *AuthWithRoles) DeleteGithubConnector(connectorID string) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.DeleteGithubConnector(id)
+	return a.authServer.deleteGithubConnector(connectorID)
 }
 
 func (a *AuthWithRoles) CreateGithubAuthRequest(req services.GithubAuthRequest) (*services.GithubAuthRequest, error) {

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -62,6 +62,34 @@ func (s *AuthServer) CreateGithubAuthRequest(req services.GithubAuthRequest) (*s
 	return &req, nil
 }
 
+// upsertGithubConnector creates or updates a Github connector.
+func (s *AuthServer) upsertGithubConnector(connector services.GithubConnector) error {
+	if err := s.Identity.UpsertGithubConnector(connector); err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.EmitAuditEvent(events.GithubConnectorCreated, events.EventFields{
+		events.FieldName: connector.GetName(),
+		events.EventUser: "unimplemented",
+	})
+
+	return nil
+}
+
+// deleteGithubConnector deletes a Github connector by name.
+func (s *AuthServer) deleteGithubConnector(id string) error {
+	if err := s.Identity.DeleteGithubConnector(id); err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.EmitAuditEvent(events.GithubConnectorDeleted, events.EventFields{
+		events.FieldName: id,
+		events.EventUser: "unimplemented",
+	})
+
+	return nil
+}
+
 // GithubAuthResponse represents Github auth callback validation response
 type GithubAuthResponse struct {
 	// Username is the name of authenticated user

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -77,13 +77,13 @@ func (s *AuthServer) upsertGithubConnector(connector services.GithubConnector) e
 }
 
 // deleteGithubConnector deletes a Github connector by name.
-func (s *AuthServer) deleteGithubConnector(id string) error {
-	if err := s.Identity.DeleteGithubConnector(id); err != nil {
+func (s *AuthServer) deleteGithubConnector(connectorName string) error {
+	if err := s.Identity.DeleteGithubConnector(connectorName); err != nil {
 		return trace.Wrap(err)
 	}
 
 	s.EmitAuditEvent(events.GithubConnectorDeleted, events.EventFields{
-		events.FieldName: id,
+		events.FieldName: connectorName,
 		events.EventUser: "unimplemented",
 	})
 

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -135,12 +135,32 @@ func oidcConfig(conn services.OIDCConnector) oidc.ClientConfig {
 	}
 }
 
+// UpsertOIDCConnector creates or updates an OIDC connector.
 func (s *AuthServer) UpsertOIDCConnector(connector services.OIDCConnector) error {
-	return s.Identity.UpsertOIDCConnector(connector)
+	if err := s.Identity.UpsertOIDCConnector(connector); err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.EmitAuditEvent(events.OIDCConnectorCreated, events.EventFields{
+		events.FieldName: connector.GetName(),
+		events.EventUser: "unimplemented",
+	})
+
+	return nil
 }
 
+// DeleteOIDCConnector deletes an OIDC connector by name.
 func (s *AuthServer) DeleteOIDCConnector(connectorName string) error {
-	return s.Identity.DeleteOIDCConnector(connectorName)
+	if err := s.Identity.DeleteOIDCConnector(connectorName); err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.EmitAuditEvent(events.OIDCConnectorDeleted, events.EventFields{
+		events.FieldName: connectorName,
+		events.EventUser: "unimplemented",
+	})
+
+	return nil
 }
 
 func (s *AuthServer) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*services.OIDCAuthRequest, error) {

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -138,18 +138,10 @@ func (s *PasswordSuite) TestChangePassword(c *C) {
 	s.a.SetClock(fakeClock)
 	req.NewPassword = []byte("abce456")
 
-	// test change password event
-	eventEmitted := false
-	s.mockedAuditLog.MockEmitAuditEvent = func(event events.Event, fields events.EventFields) error {
-		eventEmitted = true
-		c.Assert(event, DeepEquals, events.UserPasswordChange)
-		c.Assert(fields[events.EventUser], Equals, "user1")
-		return nil
-	}
-
 	err = s.a.ChangePassword(req)
 	c.Assert(err, IsNil)
-	c.Assert(eventEmitted, Equals, true)
+	c.Assert(s.mockedAuditLog.EmittedEvents.EventType, DeepEquals, events.UserPasswordChange)
+	c.Assert(s.mockedAuditLog.EmittedEvents.Fields[events.EventUser], Equals, "user1")
 
 	s.shouldLockAfterFailedAttempts(c, req)
 

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -140,8 +140,8 @@ func (s *PasswordSuite) TestChangePassword(c *C) {
 
 	err = s.a.ChangePassword(req)
 	c.Assert(err, IsNil)
-	c.Assert(s.mockedAuditLog.EmittedEvents.EventType, DeepEquals, events.UserPasswordChange)
-	c.Assert(s.mockedAuditLog.EmittedEvents.Fields[events.EventUser], Equals, "user1")
+	c.Assert(s.mockedAuditLog.EmittedEvent.EventType, DeepEquals, events.UserPasswordChange)
+	c.Assert(s.mockedAuditLog.EmittedEvent.Fields[events.EventUser], Equals, "user1")
 
 	s.shouldLockAfterFailedAttempts(c, req)
 

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -34,12 +34,32 @@ import (
 	saml2 "github.com/russellhaering/gosaml2"
 )
 
+// UpsertSAMLConnector creates or updates a SAML connector.
 func (s *AuthServer) UpsertSAMLConnector(connector services.SAMLConnector) error {
-	return s.Identity.UpsertSAMLConnector(connector)
+	if err := s.Identity.UpsertSAMLConnector(connector); err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.EmitAuditEvent(events.SAMLConnectorCreated, events.EventFields{
+		events.FieldName: connector.GetName(),
+		events.EventUser: "unimplemented",
+	})
+
+	return nil
 }
 
+// DeleteSAMLConnector deletes a SAML connector by name.
 func (s *AuthServer) DeleteSAMLConnector(connectorName string) error {
-	return s.Identity.DeleteSAMLConnector(connectorName)
+	if err := s.Identity.DeleteSAMLConnector(connectorName); err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.EmitAuditEvent(events.SAMLConnectorDeleted, events.EventFields{
+		events.FieldName: connectorName,
+		events.EventUser: "unimplemented",
+	})
+
+	return nil
 }
 
 func (s *AuthServer) CreateSAMLAuthRequest(req services.SAMLAuthRequest) (*services.SAMLAuthRequest, error) {

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -300,6 +300,18 @@ const (
 	TrustedClusterCreateEvent = "trusted_cluster.create"
 	// TrustedClusterDeleteEvent is the event for removing a trusted cluster.
 	TrustedClusterDeleteEvent = "trusted_cluster.delete"
+	// GithubConnectorCreatedEvent fires when a Github connector is created/updated.
+	GithubConnectorCreatedEvent = "github.created"
+	// GithubConnectorDeletedEvent fires when a Github connector is deleted.
+	GithubConnectorDeletedEvent = "github.deleted"
+	// OIDCConnectorCreatedEvent fires when OIDC connector is created/updated.
+	OIDCConnectorCreatedEvent = "oidc.created"
+	// OIDCConnectorDeletedEvent fires when OIDC connector is deleted.
+	OIDCConnectorDeletedEvent = "oidc.deleted"
+	// SAMLConnectorCreatedEvent fires when SAML connector is created/updated.
+	SAMLConnectorCreatedEvent = "saml.created"
+	// SAMLConnectorDeletedEvent fires when SAML connector is deleted.
+	SAMLConnectorDeletedEvent = "saml.deleted"
 )
 
 const (

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -210,6 +210,7 @@ var (
 	TrustedClusterDelete = Event{
 		Name: TrustedClusterDeleteEvent,
 		Code: TrustedClusterDeleteCode,
+	}
 	// GithubConnectorCreated is emitted when a Github connector is created/updated.
 	GithubConnectorCreated = Event{
 		Name: GithubConnectorCreatedEvent,

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -210,6 +210,35 @@ var (
 	TrustedClusterDelete = Event{
 		Name: TrustedClusterDeleteEvent,
 		Code: TrustedClusterDeleteCode,
+	// GithubConnectorCreated is emitted when a Github connector is created/updated.
+	GithubConnectorCreated = Event{
+		Name: GithubConnectorCreatedEvent,
+		Code: GithubConnectorCreatedCode,
+	}
+	// GithubConnectorDeleted is emitted when a Github connector is deleted.
+	GithubConnectorDeleted = Event{
+		Name: GithubConnectorDeletedEvent,
+		Code: GithubConnectorDeletedCode,
+	}
+	// OIDCConnectorCreated is emitted when an OIDC connector is created/updated.
+	OIDCConnectorCreated = Event{
+		Name: OIDCConnectorCreatedEvent,
+		Code: OIDCConnectorCreatedCode,
+	}
+	// OIDCConnectorDeleted is emitted when an OIDC connector is deleted.
+	OIDCConnectorDeleted = Event{
+		Name: OIDCConnectorDeletedEvent,
+		Code: OIDCConnectorDeletedCode,
+	}
+	// SAMLConnectorCreated is emitted when a SAML connector is created/updated.
+	SAMLConnectorCreated = Event{
+		Name: SAMLConnectorCreatedEvent,
+		Code: SAMLConnectorCreatedCode,
+	}
+	// SAMLConnectorDeleted is emitted when a SAML connector is deleted.
+	SAMLConnectorDeleted = Event{
+		Name: SAMLConnectorDeletedEvent,
+		Code: SAMLConnectorDeletedCode,
 	}
 )
 
@@ -285,6 +314,10 @@ const (
 	TrustedClusterCreateCode = "T7000I"
 	// TrustedClusterDeleteCode is the event code for removing a trusted cluster.
 	TrustedClusterDeleteCode = "T7001I"
+	// GithubConnectorCreatedCode is the Github connector created event code.
+	GithubConnectorCreatedCode = "T8001I"
+	// GithubConnectorDeletedCode is the Github connector deleted event code.
+	GithubConnectorDeletedCode = "T8002I"
 )
 
 // Enterprise event codes starts with "TE".
@@ -293,4 +326,12 @@ const (
 	RoleCreatedCode = "TE1000I"
 	// RoleDeletedCode is the role deleted event code.
 	RoleDeletedCode = "TE2000I"
+	// OIDCConnectorCreatedCode is the OIDC connector created event code.
+	OIDCConnectorCreatedCode = "TE1001I"
+	// OIDCConnectorDeletedCode is the OIDC connector deleted event code.
+	OIDCConnectorDeletedCode = "TE2001I"
+	// SAMLConnectorCreatedCode is the SAML connector created event code.
+	SAMLConnectorCreatedCode = "TE1002I"
+	// SAMLConnectorDeletedCode is the SAML connector deleted event code.
+	SAMLConnectorDeletedCode = "TE2002I"
 )

--- a/lib/events/mock.go
+++ b/lib/events/mock.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// NewMockAuditLog returns an instance of MockAuditLog.
 func NewMockAuditLog(capacity int) *MockAuditLog {
 	return &MockAuditLog{
 		SlicesC:         make(chan *SessionSlice, capacity),
@@ -33,13 +34,19 @@ func NewMockAuditLog(capacity int) *MockAuditLog {
 	}
 }
 
+// Events holds the event type and event fields.
+type Events struct {
+	EventType Event
+	Fields    EventFields
+}
+
 // MockAuditLog is audit log used for tests
 type MockAuditLog struct {
 	sync.Mutex
-	returnError        error
-	FailedAttemptsC    chan *SessionSlice
-	SlicesC            chan *SessionSlice
-	MockEmitAuditEvent func(event Event, fields EventFields) error
+	returnError     error
+	FailedAttemptsC chan *SessionSlice
+	SlicesC         chan *SessionSlice
+	EmittedEvents   *Events
 }
 
 func (d *MockAuditLog) SetError(e error) {
@@ -62,12 +69,11 @@ func (d *MockAuditLog) Close() error {
 	return nil
 }
 
+// EmitAuditEvent is a mock to record events in a slice of Events.
 func (d *MockAuditLog) EmitAuditEvent(event Event, fields EventFields) error {
-	if d.MockEmitAuditEvent == nil {
-		return trace.BadParameter("MockEmitAuditEvent is not implemented")
-	}
+	d.EmittedEvents = &Events{event, fields}
 
-	return d.MockEmitAuditEvent(event, fields)
+	return nil
 }
 
 func (d *MockAuditLog) UploadSessionRecording(SessionRecording) error {
@@ -97,4 +103,9 @@ func (d *MockAuditLog) SearchEvents(fromUTC, toUTC time.Time, query string, limi
 
 func (d *MockAuditLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int) ([]EventFields, error) {
 	return make([]EventFields, 0), nil
+}
+
+// Reset resets state to zero values.
+func (d *MockAuditLog) Reset() {
+	d.EmittedEvents = nil
 }

--- a/lib/events/mock.go
+++ b/lib/events/mock.go
@@ -34,19 +34,19 @@ func NewMockAuditLog(capacity int) *MockAuditLog {
 	}
 }
 
-// Events holds the event type and event fields.
-type Events struct {
+// EmittedEvent holds the event type and event fields.
+type EmittedEvent struct {
 	EventType Event
 	Fields    EventFields
 }
 
-// MockAuditLog is audit log used for tests
+// MockAuditLog is audit log used for tests.
 type MockAuditLog struct {
 	sync.Mutex
 	returnError     error
 	FailedAttemptsC chan *SessionSlice
 	SlicesC         chan *SessionSlice
-	EmittedEvents   *Events
+	EmittedEvent    *EmittedEvent
 }
 
 func (d *MockAuditLog) SetError(e error) {
@@ -69,9 +69,9 @@ func (d *MockAuditLog) Close() error {
 	return nil
 }
 
-// EmitAuditEvent is a mock to record events in a slice of Events.
-func (d *MockAuditLog) EmitAuditEvent(event Event, fields EventFields) error {
-	d.EmittedEvents = &Events{event, fields}
+// EmitAuditEvent is a mock that records even and fields inside a struct.
+func (d *MockAuditLog) EmitAuditEvent(ev Event, fields EventFields) error {
+	d.EmittedEvent = &EmittedEvent{ev, fields}
 
 	return nil
 }
@@ -107,5 +107,5 @@ func (d *MockAuditLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int) 
 
 // Reset resets state to zero values.
 func (d *MockAuditLog) Reset() {
-	d.EmittedEvents = nil
+	d.EmittedEvent = nil
 }


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/2989

#### Description
- Add event name and codes for github, saml, oidc connectors
- Emit events for each
- Tested events were emitted after upsert/delete actions

