### PR TITLE
Document the new `--use-local-ssh-agent` flag for tsh

### DIFF
--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -1266,11 +1266,14 @@ $ tsh login --proxy=proxy.example.com joe
 $ ssh-add -L
 ```
 
-!!! warning "GNOME Keyring SSH Agent"
+!!! warning "GNOME Keyring SSH Agent and GPG Agent"
 
-    It is well-known that Gnome Keyring SSH
-    agent, used by many popular Linux desktops like Ubuntu, does not support SSH
-    certificates. We recommend using the `ssh-agent` command from `openssh-client` package.
+    It is well-known that Gnome Keyring SSH agent, used by many popular Linux
+    desktops like Ubuntu, and gpg-agent from GnuPG do not support SSH
+    certificates. We recommend using the `ssh-agent` from OpenSSH.
+    Alternatively, you can disable SSH agent integration entirely using
+    `--no-use-local-ssh-agent` flag or `TELEPORT_USE_LOCAL_SSH_AGENT=false`
+    environment variable with `tsh`.
 
 ### OpenSSH Rate Limiting
 

--- a/docs/4.3/user-manual.md
+++ b/docs/4.3/user-manual.md
@@ -149,6 +149,10 @@ $ ssh-add -L
 SSH agent can be used to feed the certificate to other SSH clients, for example
 to OpenSSH `ssh`.
 
+If you wish to disable SSH agent integration, pass `--no-use-local-ssh-agent`
+to `tsh`. You can also set the `TELEPORT_USE_LOCAL_SSH_AGENT` environment
+variable to `false` in your shell profile to make this permanent.
+
 ### Identity Files
 
 [`tsh login`](cli-docs.md#tsh-login) can also save the user certificate into a


### PR DESCRIPTION
The flag is used to bypass the local SSH agent even when it's running.
Specifically, this helps with agents that don't support certs.

The flag was added in #3721

Updates #3169