### PR TITLE
Make agent channel setup lazy.

### DIFF
--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package multiplexer
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -80,7 +81,7 @@ func (s *MuxSuite) TestMultiplexing(c *check.C) {
 	defer backend1.Close()
 
 	called := false
-	sshHandler := sshutils.NewChanHandlerFunc(func(_ *sshutils.ConnectionContext, nch ssh.NewChannel) {
+	sshHandler := sshutils.NewChanHandlerFunc(func(_ context.Context, _ *sshutils.ConnectionContext, nch ssh.NewChannel) {
 		called = true
 		err := nch.Reject(ssh.Prohibited, "nothing to see here")
 		c.Assert(err, check.IsNil)
@@ -380,7 +381,7 @@ func (s *MuxSuite) TestDisableTLS(c *check.C) {
 	defer backend1.Close()
 
 	called := false
-	sshHandler := sshutils.NewChanHandlerFunc(func(_ *sshutils.ConnectionContext, nch ssh.NewChannel) {
+	sshHandler := sshutils.NewChanHandlerFunc(func(_ context.Context, _ *sshutils.ConnectionContext, nch ssh.NewChannel) {
 		called = true
 		err := nch.Reject(ssh.Prohibited, "nothing to see here")
 		c.Assert(err, check.IsNil)

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -22,9 +22,8 @@ import (
 	"net"
 	"time"
 
-	"golang.org/x/crypto/ssh/agent"
-
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/teleagent"
 )
 
 // DialParams is a list of parameters used to Dial to a node within a cluster.
@@ -35,9 +34,9 @@ type DialParams struct {
 	// To is the destination address.
 	To net.Addr
 
-	// UserAgent is SSH agent used to connect to the remote host. Used by the
+	// GetUserAgent gets an SSH agent for use in connecting to the remote host. Used by the
 	// forwarding proxy.
-	UserAgent agent.Agent
+	GetUserAgent teleagent.Getter
 
 	// Address is used by the forwarding proxy to generate a host certificate for
 	// the target node. This is needed because while dialing occurs via IP

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -170,9 +170,6 @@ func (s *localSite) Dial(params DialParams) (net.Conn, error) {
 		return nil, trace.Wrap(err)
 	}
 	if clusterConfig.GetSessionRecording() == services.RecordAtProxy {
-		if params.UserAgent == nil {
-			return nil, trace.BadParameter("user agent missing")
-		}
 		return s.dialWithAgent(params)
 	}
 
@@ -195,18 +192,29 @@ func (s *localSite) DialTCP(params DialParams) (net.Conn, error) {
 func (s *localSite) IsClosed() bool { return false }
 
 func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
+	if params.GetUserAgent == nil {
+		return nil, trace.BadParameter("user agent getter missing")
+	}
 	s.log.Debugf("Dialing with an agent from %v to %v.", params.From, params.To)
+
+	// request user agent connection
+	userAgent, err := params.GetUserAgent()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	// If server ID matches a node that has self registered itself over the tunnel,
 	// return a connection to that node. Otherwise net.Dial to the target host.
 	targetConn, useTunnel, err := s.getConn(params)
 	if err != nil {
+		userAgent.Close()
 		return nil, trace.Wrap(err)
 	}
 
 	// Get a host certificate for the forwarding node from the cache.
 	hostCertificate, err := s.certificateCache.GetHostCertificate(params.Address, params.Principals)
 	if err != nil {
+		userAgent.Close()
 		return nil, trace.Wrap(err)
 	}
 
@@ -215,7 +223,7 @@ func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 	// once conn is closed.
 	serverConfig := forward.ServerConfig{
 		AuthClient:      s.client,
-		UserAgent:       params.UserAgent,
+		UserAgent:       userAgent,
 		TargetConn:      targetConn,
 		SrcAddr:         params.From,
 		DstAddr:         params.To,

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -527,7 +527,7 @@ func (s *server) Shutdown(ctx context.Context) error {
 	return s.srv.Shutdown(ctx)
 }
 
-func (s *server) HandleNewChan(ccx *sshutils.ConnectionContext, nch ssh.NewChannel) {
+func (s *server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionContext, nch ssh.NewChannel) {
 	// Apply read/write timeouts to the server connection.
 	conn := utils.ObeyIdleTimeout(ccx.NetConn,
 		s.offlineThreshold,

--- a/lib/reversetunnel/track/tracker_test.go
+++ b/lib/reversetunnel/track/tracker_test.go
@@ -78,11 +78,15 @@ func (s *simpleTestProxies) GetRandProxy() (p testProxy, ok bool) {
 }
 
 func (s *simpleTestProxies) Discover(tracker *Tracker, lease Lease) (ok bool) {
-	defer lease.Release()
 	proxy, ok := s.GetRandProxy()
 	if !ok {
 		panic("discovery called with no available proxies")
 	}
+	return s.ProxyLoop(tracker, lease, proxy)
+}
+
+func (s *simpleTestProxies) ProxyLoop(tracker *Tracker, lease Lease, proxy testProxy) (ok bool) {
+	defer lease.Release()
 	timeout := time.After(proxy.life)
 	ok = tracker.WithProxy(func() {
 		ticker := time.NewTicker(jitter(time.Millisecond * 100))
@@ -165,7 +169,7 @@ Discover:
 				break Discover
 			}
 		case <-timeoutC:
-			panic("timeout")
+			c.Fatal("timeout")
 		}
 	}
 }
@@ -193,7 +197,14 @@ Loop0:
 		select {
 		case lease := <-tracker.Acquire():
 			c.Assert(lease.Key().(Key), check.DeepEquals, key)
-			go proxies.Discover(tracker, lease)
+			// get our "discovered" proxy in the foreground
+			// to prevent race with the call to RemoveRandProxies
+			// that comes after this loop.
+			proxy, ok := proxies.GetRandProxy()
+			if !ok {
+				c.Fatal("failed to get test proxy")
+			}
+			go proxies.ProxyLoop(tracker, lease, proxy)
 		case <-ticker.C:
 			counts := tracker.wp.Get(key)
 			c.Logf("Counts0: %+v", counts)
@@ -201,7 +212,7 @@ Loop0:
 				break Loop0
 			}
 		case <-timeoutC:
-			panic("timeout")
+			c.Fatal("timeout")
 		}
 	}
 	proxies.RemoveRandProxies(proxyCount)
@@ -215,7 +226,7 @@ Loop1:
 				break Loop1
 			}
 		case <-timeoutC:
-			panic("timeout")
+			c.Fatal("timeout")
 		}
 	}
 	proxies.AddRandProxies(proxyCount, minConnB, maxConnB)
@@ -231,7 +242,7 @@ Loop2:
 				break Loop2
 			}
 		case <-timeoutC:
-			panic("timeout")
+			c.Fatal("timeout")
 		}
 	}
 }

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -115,8 +115,8 @@ func (h *AuthHandlers) CheckPortForward(addr string, ctx *ServerContext) error {
 			events.PortForwardErr:     systemErrorMessage,
 			events.EventLogin:         ctx.Identity.Login,
 			events.EventUser:          ctx.Identity.TeleportUser,
-			events.LocalAddr:          ctx.Conn.LocalAddr().String(),
-			events.RemoteAddr:         ctx.Conn.RemoteAddr().String(),
+			events.LocalAddr:          ctx.ServerConn.LocalAddr().String(),
+			events.RemoteAddr:         ctx.ServerConn.RemoteAddr().String(),
 		}); err != nil {
 			h.Warnf("Failed to emit port forward deny audit event: %v", err)
 		}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
@@ -170,11 +169,12 @@ func (c IdentityContext) GetCertificate() (*ssh.Certificate, error) {
 // used to access resources on the underlying server. SessionContext can also
 // be used to attach resources that should be closed once the session closes.
 type ServerContext struct {
+	// ConnectionContext is the parent context which manages connection-level
+	// resources.
+	*sshutils.ConnectionContext
 	*log.Entry
 
 	sync.RWMutex
-
-	Parent *sshutils.ConnectionContext
 
 	// env is a list of environment variables passed to the session.
 	env map[string]string
@@ -195,12 +195,6 @@ type ServerContext struct {
 	// this is handy as sometimes client closes session, in this case resources
 	// will be properly closed and deallocated, otherwise they could be kept hanging.
 	closers []io.Closer
-
-	// Conn is the underlying *ssh.ServerConn.
-	Conn *ssh.ServerConn
-
-	// Connection is the underlying net.Conn for the connection.
-	Connection net.Conn
 
 	// Identity holds the identity of the user that is currently logged in on
 	// the Conn.
@@ -246,9 +240,6 @@ type ServerContext struct {
 	// on client inactivity, set to 0 if not setup
 	clientIdleTimeout time.Duration
 
-	// cancelContext signals closure to all outstanding operations
-	cancelContext context.Context
-
 	// cancel is called whenever server context is closed
 	cancel context.CancelFunc
 
@@ -286,96 +277,102 @@ type ServerContext struct {
 }
 
 // NewServerContext creates a new *ServerContext which is used to pass and
-// manage resources.
-func NewServerContext(ccx *sshutils.ConnectionContext, srv Server, identityContext IdentityContext) (*ServerContext, error) {
+// manage resources, and an associated context.Context which is canceled when
+// the ServerContext is closed.  The ctx parameter should be a child of the ctx
+// associated with the scope of the parent ConnectionContext to ensure that
+// cancellation of the ConnectionContext propagates to the ServerContext.
+func NewServerContext(ctx context.Context, parent *sshutils.ConnectionContext, srv Server, identityContext IdentityContext) (context.Context, *ServerContext, error) {
 	clusterConfig, err := srv.GetAccessPoint().GetClusterConfig()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
-	cancelContext, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(ctx)
 
-	ctx := &ServerContext{
-		Parent:            ccx,
+	child := &ServerContext{
+		ConnectionContext: parent,
 		id:                int(atomic.AddInt32(&ctxID, int32(1))),
 		env:               make(map[string]string),
 		srv:               srv,
-		Connection:        ccx.NetConn,
-		Conn:              ccx.ServerConn,
 		ExecResultCh:      make(chan ExecResult, 10),
 		SubsystemResultCh: make(chan SubsystemResult, 10),
-		ClusterName:       ccx.ServerConn.Permissions.Extensions[utils.CertTeleportClusterName],
+		ClusterName:       parent.ServerConn.Permissions.Extensions[utils.CertTeleportClusterName],
 		ClusterConfig:     clusterConfig,
 		Identity:          identityContext,
 		clientIdleTimeout: identityContext.RoleSet.AdjustClientIdleTimeout(clusterConfig.GetClientIdleTimeout()),
-		cancelContext:     cancelContext,
 		cancel:            cancel,
 	}
 
 	disconnectExpiredCert := identityContext.RoleSet.AdjustDisconnectExpiredCert(clusterConfig.GetDisconnectExpiredCert())
 	if !identityContext.CertValidBefore.IsZero() && disconnectExpiredCert {
-		ctx.disconnectExpiredCert = identityContext.CertValidBefore
+		child.disconnectExpiredCert = identityContext.CertValidBefore
 	}
 
 	fields := log.Fields{
-		"local":        ctx.Conn.LocalAddr(),
-		"remote":       ctx.Conn.RemoteAddr(),
-		"login":        ctx.Identity.Login,
-		"teleportUser": ctx.Identity.TeleportUser,
-		"id":           ctx.id,
+		"local":        child.ServerConn.LocalAddr(),
+		"remote":       child.ServerConn.RemoteAddr(),
+		"login":        child.Identity.Login,
+		"teleportUser": child.Identity.TeleportUser,
+		"id":           child.id,
 	}
-	if !ctx.disconnectExpiredCert.IsZero() {
-		fields["cert"] = ctx.disconnectExpiredCert
+	if !child.disconnectExpiredCert.IsZero() {
+		fields["cert"] = child.disconnectExpiredCert
 	}
-	if ctx.clientIdleTimeout != 0 {
-		fields["idle"] = ctx.clientIdleTimeout
+	if child.clientIdleTimeout != 0 {
+		fields["idle"] = child.clientIdleTimeout
 	}
-	ctx.Entry = log.WithFields(log.Fields{
+	child.Entry = log.WithFields(log.Fields{
 		trace.Component:       srv.Component(),
 		trace.ComponentFields: fields,
 	})
 
-	if !ctx.disconnectExpiredCert.IsZero() || ctx.clientIdleTimeout != 0 {
+	if !child.disconnectExpiredCert.IsZero() || child.clientIdleTimeout != 0 {
 		mon, err := NewMonitor(MonitorConfig{
-			DisconnectExpiredCert: ctx.disconnectExpiredCert,
-			ClientIdleTimeout:     ctx.clientIdleTimeout,
-			Clock:                 ctx.srv.GetClock(),
-			Tracker:               ctx,
-			Conn:                  ctx.Conn,
-			Context:               cancelContext,
-			TeleportUser:          ctx.Identity.TeleportUser,
-			Login:                 ctx.Identity.Login,
-			ServerID:              ctx.srv.ID(),
-			Audit:                 ctx.srv.GetAuditLog(),
-			Entry:                 ctx.Entry,
+			DisconnectExpiredCert: child.disconnectExpiredCert,
+			ClientIdleTimeout:     child.clientIdleTimeout,
+			Clock:                 child.srv.GetClock(),
+			Tracker:               child,
+			Conn:                  child.ServerConn,
+			Context:               ctx,
+			TeleportUser:          child.Identity.TeleportUser,
+			Login:                 child.Identity.Login,
+			ServerID:              child.srv.ID(),
+			Audit:                 child.srv.GetAuditLog(),
+			Entry:                 child.Entry,
 		})
 		if err != nil {
-			ctx.Close()
-			return nil, trace.Wrap(err)
+			child.Close()
+			return nil, nil, trace.Wrap(err)
 		}
 		go mon.Start()
 	}
 
 	// Create pipe used to send command to child process.
-	ctx.cmdr, ctx.cmdw, err = os.Pipe()
+	child.cmdr, child.cmdw, err = os.Pipe()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		child.Close()
+		return nil, nil, trace.Wrap(err)
 	}
-	ctx.AddCloser(ctx.cmdr)
-	ctx.AddCloser(ctx.cmdw)
+	child.AddCloser(child.cmdr)
+	child.AddCloser(child.cmdw)
 
 	// Create pipe used to signal continue to child process.
-	ctx.contr, ctx.contw, err = os.Pipe()
+	child.contr, child.contw, err = os.Pipe()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		child.Close()
+		return nil, nil, trace.Wrap(err)
 	}
-	ctx.AddCloser(ctx.contr)
-	ctx.AddCloser(ctx.contw)
+	child.AddCloser(child.contr)
+	child.AddCloser(child.contw)
 
-	// gather environment variables from parent.
-	ctx.ImportParentEnv()
+	return ctx, child, nil
+}
 
-	return ctx, nil
+// Parent grants access to the connection-level context of which this
+// is a subcontext.  Useful for unambiguously accessing methods which
+// this subcontext overrides (e.g. child.Parent().SetEnv(...)).
+func (c *ServerContext) Parent() *sshutils.ConnectionContext {
+	return c.ConnectionContext
 }
 
 // ID returns ID of this context
@@ -417,9 +414,9 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 	// update ctx with a session ID
 	c.session, _ = findSession()
 	if c.session == nil {
-		log.Debugf("Will create new session for SSH connection %v.", c.Conn.RemoteAddr())
+		log.Debugf("Will create new session for SSH connection %v.", c.ServerConn.RemoteAddr())
 	} else {
-		log.Debugf("Will join session %v for SSH connection %v.", c.session, c.Conn.RemoteAddr())
+		log.Debugf("Will join session %v for SSH connection %v.", c.session, c.ServerConn.RemoteAddr())
 	}
 
 	return nil
@@ -448,24 +445,6 @@ func (c *ServerContext) AddCloser(closer io.Closer) {
 	c.closers = append(c.closers, closer)
 }
 
-// GetAgent returns a agent.Agent which represents the capabilities of an SSH agent,
-// or nil if no agent is available in this context.
-func (c *ServerContext) GetAgent() agent.Agent {
-	if c.Parent == nil {
-		return nil
-	}
-	return c.Parent.GetAgent()
-}
-
-// GetAgentChannel returns the channel over which communication with the agent occurs,
-// or nil if no agent is available in this context.
-func (c *ServerContext) GetAgentChannel() ssh.Channel {
-	if c.Parent == nil {
-		return nil
-	}
-	return c.Parent.GetAgentChannel()
-}
-
 // GetTerm returns a Terminal.
 func (c *ServerContext) GetTerm() Terminal {
 	c.RLock()
@@ -482,6 +461,16 @@ func (c *ServerContext) SetTerm(t Terminal) {
 	c.term = t
 }
 
+// VisitEnv grants visitor-style access to env variables.
+func (c *ServerContext) VisitEnv(visit func(key, val string)) {
+	// visit the parent env first since locally defined variables
+	// effectively "override" parent defined variables.
+	c.Parent().VisitEnv(visit)
+	for key, val := range c.env {
+		visit(key, val)
+	}
+}
+
 // SetEnv sets a environment variable within this context.
 func (c *ServerContext) SetEnv(key, val string) {
 	c.env[key] = val
@@ -490,13 +479,10 @@ func (c *ServerContext) SetEnv(key, val string) {
 // GetEnv returns a environment variable within this context.
 func (c *ServerContext) GetEnv(key string) (string, bool) {
 	val, ok := c.env[key]
-	return val, ok
-}
-
-// ImportParentEnv is used to re-synchronize env vars after
-// parent context has been updated.
-func (c *ServerContext) ImportParentEnv() {
-	c.Parent.ExportEnv(c.env)
+	if ok {
+		return val, true
+	}
+	return c.Parent().GetEnv(key)
 }
 
 // takeClosers returns all resources that should be closed and sets the properties to null
@@ -543,11 +529,11 @@ func (c *ServerContext) reportStats(conn utils.Stater) {
 		events.SessionServerID: c.GetServer().HostUUID(),
 		events.EventLogin:      c.Identity.Login,
 		events.EventUser:       c.Identity.TeleportUser,
-		events.RemoteAddr:      c.Conn.RemoteAddr().String(),
+		events.RemoteAddr:      c.ServerConn.RemoteAddr().String(),
 		events.EventIndex:      events.SessionDataIndex,
 	}
 	if !c.srv.UseTunnel() {
-		eventFields[events.LocalAddr] = c.Conn.LocalAddr().String()
+		eventFields[events.LocalAddr] = c.ServerConn.LocalAddr().String()
 	}
 	if c.session != nil {
 		eventFields[events.SessionEventID] = c.session.id
@@ -564,7 +550,7 @@ func (c *ServerContext) reportStats(conn utils.Stater) {
 func (c *ServerContext) Close() error {
 	// If the underlying connection is holding tracking information, report that
 	// to the audit log at close.
-	if stats, ok := c.Connection.(*utils.TrackingConn); ok {
+	if stats, ok := c.NetConn.(*utils.TrackingConn); ok {
 		defer c.reportStats(stats)
 	}
 
@@ -580,14 +566,10 @@ func (c *ServerContext) Close() error {
 	return nil
 }
 
-// CancelContext is a context associated with server context,
-// closed whenever this server context is closed
-func (c *ServerContext) CancelContext() context.Context {
-	return c.cancelContext
-}
-
-// Cancel is a function that triggers closure
-func (c *ServerContext) Cancel() context.CancelFunc {
+// CancelFunc gets the context.CancelFunc associated with
+// this context.  Not a substitute for calling the
+// ServerContext.Close method.
+func (c *ServerContext) CancelFunc() context.CancelFunc {
 	return c.cancel
 }
 
@@ -638,7 +620,7 @@ func (c *ServerContext) ProxyPublicAddress() string {
 }
 
 func (c *ServerContext) String() string {
-	return fmt.Sprintf("ServerContext(%v->%v, user=%v, id=%v)", c.Conn.RemoteAddr(), c.Conn.LocalAddr(), c.Conn.User(), c.id)
+	return fmt.Sprintf("ServerContext(%v->%v, user=%v, id=%v)", c.ServerConn.RemoteAddr(), c.ServerConn.LocalAddr(), c.ServerConn.User(), c.id)
 }
 
 // ExecCommand takes a *ServerContext and extracts the parts needed to create
@@ -700,18 +682,18 @@ func (c *ServerContext) ExecCommand() (*execCommand, error) {
 func buildEnvironment(ctx *ServerContext) []string {
 	var env []string
 
-	// Apply environment variables passed in from client.
-	for k, v := range ctx.env {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
+	// gather all dynamically defined environment variables
+	ctx.VisitEnv(func(key, val string) {
+		env = append(env, fmt.Sprintf("%s=%s", key, val))
+	})
 
 	// Parse the local and remote addresses to build SSH_CLIENT and
 	// SSH_CONNECTION environment variables.
-	remoteHost, remotePort, err := net.SplitHostPort(ctx.Conn.RemoteAddr().String())
+	remoteHost, remotePort, err := net.SplitHostPort(ctx.ServerConn.RemoteAddr().String())
 	if err != nil {
 		log.Debugf("Failed to split remote address: %v.", err)
 	} else {
-		localHost, localPort, err := net.SplitHostPort(ctx.Conn.LocalAddr().String())
+		localHost, localPort, err := net.SplitHostPort(ctx.ServerConn.LocalAddr().String())
 		if err != nil {
 			log.Debugf("Failed to split local address: %v.", err)
 		} else {

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -248,8 +248,8 @@ func (e *localExec) transformSecureCopy() error {
 	}
 	e.Command = fmt.Sprintf("%s scp --remote-addr=%s --local-addr=%s %v",
 		teleportBin,
-		e.Ctx.Conn.RemoteAddr().String(),
-		e.Ctx.Conn.LocalAddr().String(),
+		e.Ctx.ServerConn.RemoteAddr().String(),
+		e.Ctx.ServerConn.LocalAddr().String(),
 		strings.Join(args[1:], " "))
 
 	return nil
@@ -367,8 +367,8 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 	fields := events.EventFields{
 		events.EventUser:      ctx.Identity.TeleportUser,
 		events.EventLogin:     ctx.Identity.Login,
-		events.LocalAddr:      ctx.Conn.LocalAddr().String(),
-		events.RemoteAddr:     ctx.Conn.RemoteAddr().String(),
+		events.LocalAddr:      ctx.ServerConn.LocalAddr().String(),
+		events.RemoteAddr:     ctx.ServerConn.RemoteAddr().String(),
 		events.EventNamespace: ctx.srv.GetNamespace(),
 		// Due to scp being inherently vulnerable to command injection, always
 		// make sure the full command and exit code is recorded for accountability.

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -112,8 +112,9 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 
 	s.usr, _ = user.Current()
 	s.ctx = &ServerContext{
-		IsTestStub:  true,
-		ClusterName: "localhost",
+		ConnectionContext: &sshutils.ConnectionContext{},
+		IsTestStub:        true,
+		ClusterName:       "localhost",
 		srv: &fakeServer{
 			accessPoint: s.a,
 			auditLog:    &fakeLog{},
@@ -123,7 +124,7 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 	s.ctx.Identity.Login = s.usr.Username
 	s.ctx.session = &session{id: "xxx", term: &fakeTerminal{f: f}}
 	s.ctx.Identity.TeleportUser = "galt"
-	s.ctx.Conn = &ssh.ServerConn{Conn: s}
+	s.ctx.ServerConn = &ssh.ServerConn{Conn: s}
 	s.ctx.ExecRequest = &localExec{Ctx: s.ctx}
 	s.ctx.request = &ssh.Request{
 		Type: sshutils.ExecRequest,
@@ -257,7 +258,8 @@ func (s *ExecSuite) TestContinue(c *check.C) {
 	// Create a fake context that will be used to configure a command that will
 	// re-exec "ls".
 	ctx := &ServerContext{
-		IsTestStub: true,
+		ConnectionContext: &sshutils.ConnectionContext{},
+		IsTestStub:        true,
 		srv: &fakeServer{
 			accessPoint: s.a,
 			auditLog:    &fakeLog{},
@@ -266,7 +268,7 @@ func (s *ExecSuite) TestContinue(c *check.C) {
 	}
 	ctx.Identity.Login = s.usr.Username
 	ctx.Identity.TeleportUser = "galt"
-	ctx.Conn = &ssh.ServerConn{Conn: s}
+	ctx.ServerConn = &ssh.ServerConn{Conn: s}
 	ctx.ExecRequest = &localExec{
 		Ctx:     ctx,
 		Command: lsPath,

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -128,12 +128,12 @@ func (s *SessionRegistry) emitSessionJoinEvent(ctx *ServerContext) {
 		events.EventNamespace:  s.srv.GetNamespace(),
 		events.EventLogin:      ctx.Identity.Login,
 		events.EventUser:       ctx.Identity.TeleportUser,
-		events.RemoteAddr:      ctx.Conn.RemoteAddr().String(),
+		events.RemoteAddr:      ctx.ServerConn.RemoteAddr().String(),
 		events.SessionServerID: ctx.srv.HostUUID(),
 	}
 	// Local address only makes sense for non-tunnel nodes.
 	if !ctx.srv.UseTunnel() {
-		sessionJoinEvent[events.LocalAddr] = ctx.Conn.LocalAddr().String()
+		sessionJoinEvent[events.LocalAddr] = ctx.ServerConn.LocalAddr().String()
 	}
 
 	// Emit session join event to Audit Log.
@@ -672,14 +672,14 @@ func (s *session) startInteractive(ch ssh.Channel, ctx *ServerContext) error {
 		events.SessionServerID:       ctx.srv.HostUUID(),
 		events.EventLogin:            ctx.Identity.Login,
 		events.EventUser:             ctx.Identity.TeleportUser,
-		events.RemoteAddr:            ctx.Conn.RemoteAddr().String(),
+		events.RemoteAddr:            ctx.ServerConn.RemoteAddr().String(),
 		events.TerminalSize:          params.Serialize(),
 		events.SessionServerHostname: ctx.srv.GetInfo().GetHostname(),
 		events.SessionServerLabels:   ctx.srv.GetInfo().GetAllLabels(),
 	}
 	// Local address only makes sense for non-tunnel nodes.
 	if !ctx.srv.UseTunnel() {
-		eventFields[events.LocalAddr] = ctx.Conn.LocalAddr().String()
+		eventFields[events.LocalAddr] = ctx.ServerConn.LocalAddr().String()
 	}
 	s.emitAuditEvent(events.SessionStart, eventFields)
 
@@ -787,13 +787,13 @@ func (s *session) startExec(channel ssh.Channel, ctx *ServerContext) error {
 		events.SessionServerID:       ctx.srv.HostUUID(),
 		events.EventLogin:            ctx.Identity.Login,
 		events.EventUser:             ctx.Identity.TeleportUser,
-		events.RemoteAddr:            ctx.Conn.RemoteAddr().String(),
+		events.RemoteAddr:            ctx.ServerConn.RemoteAddr().String(),
 		events.SessionServerHostname: ctx.srv.GetInfo().GetHostname(),
 		events.SessionServerLabels:   ctx.srv.GetInfo().GetAllLabels(),
 	}
 	// Local address only makes sense for non-tunnel nodes.
 	if !ctx.srv.UseTunnel() {
-		eventFields[events.LocalAddr] = ctx.Conn.LocalAddr().String()
+		eventFields[events.LocalAddr] = ctx.ServerConn.LocalAddr().String()
 	}
 	s.emitAuditEvent(events.SessionStart, eventFields)
 
@@ -1188,12 +1188,12 @@ func newParty(s *session, ch ssh.Channel, ctx *ServerContext) *party {
 		user:      ctx.Identity.TeleportUser,
 		login:     ctx.Identity.Login,
 		serverID:  s.registry.srv.ID(),
-		site:      ctx.Conn.RemoteAddr().String(),
+		site:      ctx.ServerConn.RemoteAddr().String(),
 		id:        rsession.NewID(),
 		ch:        ch,
 		ctx:       ctx,
 		s:         s,
-		sconn:     ctx.Conn,
+		sconn:     ctx.ServerConn,
 		termSizeC: make(chan []byte, 5),
 		closeC:    make(chan bool),
 	}

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -51,7 +51,7 @@ func (s *ServerSuite) SetUpSuite(c *check.C) {
 
 func (s *ServerSuite) TestStartStop(c *check.C) {
 	called := false
-	fn := NewChanHandlerFunc(func(_ *ConnectionContext, nch ssh.NewChannel) {
+	fn := NewChanHandlerFunc(func(_ context.Context, _ *ConnectionContext, nch ssh.NewChannel) {
 		called = true
 		err := nch.Reject(ssh.Prohibited, "nothing to see here")
 		c.Assert(err, check.IsNil)
@@ -88,7 +88,7 @@ func (s *ServerSuite) TestStartStop(c *check.C) {
 // TestShutdown tests graceul shutdown feature
 func (s *ServerSuite) TestShutdown(c *check.C) {
 	closeContext, cancel := context.WithCancel(context.TODO())
-	fn := NewChanHandlerFunc(func(ccx *ConnectionContext, nch ssh.NewChannel) {
+	fn := NewChanHandlerFunc(func(_ context.Context, ccx *ConnectionContext, nch ssh.NewChannel) {
 		ch, _, err := nch.Accept()
 		c.Assert(err, check.IsNil)
 		defer ch.Close()
@@ -138,7 +138,7 @@ func (s *ServerSuite) TestShutdown(c *check.C) {
 }
 
 func (s *ServerSuite) TestConfigureCiphers(c *check.C) {
-	fn := NewChanHandlerFunc(func(_ *ConnectionContext, nch ssh.NewChannel) {
+	fn := NewChanHandlerFunc(func(_ context.Context, _ *ConnectionContext, nch ssh.NewChannel) {
 		err := nch.Reject(ssh.Prohibited, "nothing to see here")
 		c.Assert(err, check.IsNil)
 	})
@@ -185,7 +185,7 @@ func (s *ServerSuite) TestHostSignerFIPS(c *check.C) {
 	_, ellipticSigner, err := utils.CreateEllipticCertificate("foo", ssh.HostCert)
 	c.Assert(err, check.IsNil)
 
-	newChanHandler := NewChanHandlerFunc(func(_ *ConnectionContext, nch ssh.NewChannel) {
+	newChanHandler := NewChanHandlerFunc(func(_ context.Context, _ *ConnectionContext, nch ssh.NewChannel) {
 		err := nch.Reject(ssh.Prohibited, "nothing to see here")
 		c.Assert(err, check.IsNil)
 	})


### PR DESCRIPTION
Changes agent channel setup behavior to be consistent with openssh by having servers lazily request agent channels when they are needed, rather than immediately starting a single connection-wide channel as soon as forwarding is requested.

Fixes an issue introduced in #3613 which caused openssh clients to hang on exit due to persistent agent channel.