### PR TITLE
Add event code documentation and clean up event code

### DIFF
--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -249,7 +249,17 @@ var (
 	}
 )
 
-// OSS event codes start with "T".
+// There is no strict algorithm for picking an event code, however existing
+// event codes are currently loosely categorized as follows:
+//
+//  * OSS event codes start with "T" and belongs in this const block.
+//
+//  * Enterprise event codes start with "TE", and is in another const block.
+//
+//  * Related events are grouped starting with the same number.
+//		eg: All user related events are grouped under 1xxx.
+//
+//  * Suffix code with one of these letters: I (info), W (warn), E (error).
 const (
 	// UserLocalLoginCode is the successful local user login event code.
 	UserLocalLoginCode = "T1000I"
@@ -259,14 +269,15 @@ const (
 	UserSSOLoginCode = "T1001I"
 	// UserSSOLoginFailureCode is the unsuccessful SSO user login event code.
 	UserSSOLoginFailureCode = "T1001W"
-	// UserUpdateCode is the user update event code.
-	UserUpdateCode = "T1002I"
-	// UserDeleteCode is the user delete event code.
-	UserDeleteCode = "T1003I"
 	// UserCreateCode is the user create event code.
-	UserCreateCode = "T1004I"
+	UserCreateCode = "T1002I"
+	// UserUpdateCode is the user update event code.
+	UserUpdateCode = "T1003I"
+	// UserDeleteCode is the user delete event code.
+	UserDeleteCode = "T1004I"
 	// UserPasswordChangeCode is an event code for when user changes their own password.
 	UserPasswordChangeCode = "T1005I"
+
 	// SessionStartCode is the session start event code.
 	SessionStartCode = "T2000I"
 	// SessionJoinCode is the session join event code.
@@ -281,6 +292,7 @@ const (
 	SessionUploadCode = "T2005I"
 	// SessionDataCode is the session data event code.
 	SessionDataCode = "T2006I"
+
 	// SubsystemCode is the subsystem event code.
 	SubsystemCode = "T3001I"
 	// SubsystemFailureCode is the subsystem failure event code.
@@ -305,18 +317,22 @@ const (
 	ClientDisconnectCode = "T3006I"
 	// AuthAttemptFailureCode is the auth attempt failure event code.
 	AuthAttemptFailureCode = "T3007W"
+
 	// SessionCommandCode is a session command code.
 	SessionCommandCode = "T4000I"
 	// SessionDiskCode is a session disk code.
 	SessionDiskCode = "T4001I"
 	// SessionNetworkCode is a session network code.
 	SessionNetworkCode = "T4002I"
+
 	// AccessRequestCreateCode is the the access request creation code.
 	AccessRequestCreateCode = "T5000I"
 	// AccessRequestUpdateCode is the access request state update code.
 	AccessRequestUpdateCode = "T5001I"
+
 	// ResetPasswordTokenCreateCode is the token create event code.
 	ResetPasswordTokenCreateCode = "T6000I"
+
 	// TrustedClusterCreateCode is the event code for creating a trusted cluster.
 	TrustedClusterCreateCode = "T7000I"
 	// TrustedClusterDeleteCode is the event code for removing a trusted cluster.
@@ -324,24 +340,27 @@ const (
 	// TrustedClusterTokenCreateCode is the event code for
 	// creating new join token for a trusted cluster.
 	TrustedClusterTokenCreateCode = "T7002I"
+
 	// GithubConnectorCreatedCode is the Github connector created event code.
-	GithubConnectorCreatedCode = "T8001I"
+	GithubConnectorCreatedCode = "T8000I"
 	// GithubConnectorDeletedCode is the Github connector deleted event code.
-	GithubConnectorDeletedCode = "T8002I"
+	GithubConnectorDeletedCode = "T8001I"
 )
 
-// Enterprise event codes starts with "TE".
+// Enterprise event codes.
 const (
 	// RoleCreatedCode is the role created event code.
 	RoleCreatedCode = "TE1000I"
 	// RoleDeletedCode is the role deleted event code.
-	RoleDeletedCode = "TE2000I"
+	RoleDeletedCode = "TE1001I"
+
 	// OIDCConnectorCreatedCode is the OIDC connector created event code.
-	OIDCConnectorCreatedCode = "TE1001I"
+	OIDCConnectorCreatedCode = "TE2000I"
 	// OIDCConnectorDeletedCode is the OIDC connector deleted event code.
 	OIDCConnectorDeletedCode = "TE2001I"
+
 	// SAMLConnectorCreatedCode is the SAML connector created event code.
-	SAMLConnectorCreatedCode = "TE1002I"
+	SAMLConnectorCreatedCode = "TE3000I"
 	// SAMLConnectorDeletedCode is the SAML connector deleted event code.
-	SAMLConnectorDeletedCode = "TE2002I"
+	SAMLConnectorDeletedCode = "TE3001I"
 )

--- a/lib/events/codes.go
+++ b/lib/events/codes.go
@@ -252,9 +252,9 @@ var (
 // There is no strict algorithm for picking an event code, however existing
 // event codes are currently loosely categorized as follows:
 //
-//  * OSS event codes start with "T" and belongs in this const block.
+//  * OSS event codes start with "T" and belong in this const block.
 //
-//  * Enterprise event codes start with "TE", and is in another const block.
+//  * Enterprise event codes start with "TE", and are in another const block.
 //
 //  * Related events are grouped starting with the same number.
 //		eg: All user related events are grouped under 1xxx.


### PR DESCRIPTION
#### Description
I noticed gravity had a documentation on how their gravity event code was formulated. I initially tried to sync teleport with their pattern, but teleport deviates from their pattern too much. So I just added a documentation on the current pattern so it stays consistent.