### PR TITLE
Teleport example helm README update

### DIFF
--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -43,19 +43,20 @@ To install the chart with the release name `teleport`, run:
 $ helm install --name teleport ./
 ```
 
-Teleport proxy generates a TLS key and a cert of its own by default.
+Teleport proxy generates a TLS key and a cert of its own by default.  You can provide the signed TLS certificates and optionally the TLS Certificate Authority (CA) that signed these certificates.
 In order to instruct the proxy to use the TLS assets brought by you, prepare the following files:
 
-- Your CA cert named `ca.pem`  (optional depending on values.yaml setting)
 - Your proxy server cert named `proxy-server.pem`
 - Your proxy server key named `proxy-server-key.pem`
+- Your TLS CA cert named `ca.pem`  (Optional. Update the value.yaml extraVars, extraVolumes and extraVolumeMounts to use this)
 
 Then run:
 
 ```
 $ kubectl create secret tls tls-web --cert=proxy-server.pem --key=proxy-server-key.pem
-# ca.pem is not required by default.  Run this command if you have your own Certificate Authority (CA)
+# Run this command if you are providing your own TLS CA
 $ kubectl create configmap ca-certs --from-file=ca.pem
+# Run this to update or install teleport
 $ helm upgrade --install teleport ./
 ```
 

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -46,7 +46,7 @@ $ helm install --name teleport ./
 Teleport proxy generates a TLS key and a cert of its own by default.
 In order to instruct the proxy to use the TLS assets brought by you, prepare the following files:
 
-- Your CA cert named `ca.pem`
+- Your CA cert named `ca.pem`  (optional depending on values.yaml setting)
 - Your proxy server cert named `proxy-server.pem`
 - Your proxy server key named `proxy-server-key.pem`
 
@@ -54,8 +54,9 @@ Then run:
 
 ```
 $ kubectl create secret tls tls-web --cert=proxy-server.pem --key=proxy-server-key.pem
+# ca.pem is not required by default.  Run this command if you have your own Certificate Authority (CA)
 $ kubectl create configmap ca-certs --from-file=ca.pem
-$ helm upgrade --install --name teleport ./
+$ helm upgrade --install teleport ./
 ```
 
 ## Running locally on minikube


### PR DESCRIPTION
The --name in the helm upgrade example was not a valid parameter.  Also put in comments that ca.pem is not required.  It is off by default.