### PR TITLE
Implement OpenSSH-like escape sequences in tsh

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -260,6 +260,11 @@ type Config struct {
 	// UseLocalSSHAgent will write user certificates to the local ssh-agent (or
 	// similar) socket at $SSH_AUTH_SOCK.
 	UseLocalSSHAgent bool
+
+	// EnableEscapeSequences will scan Stdin for SSH escape sequences during
+	// command/shell execution. This also requires Stdin to be an interactive
+	// terminal.
+	EnableEscapeSequences bool
 }
 
 // CachePolicy defines cache policy for local clients
@@ -273,10 +278,11 @@ type CachePolicy struct {
 // MakeDefaultConfig returns default client config
 func MakeDefaultConfig() *Config {
 	return &Config{
-		Stdout:           os.Stdout,
-		Stderr:           os.Stderr,
-		Stdin:            os.Stdin,
-		UseLocalSSHAgent: true,
+		Stdout:                os.Stdout,
+		Stderr:                os.Stderr,
+		Stdin:                 os.Stdin,
+		UseLocalSSHAgent:      true,
+		EnableEscapeSequences: true,
 	}
 }
 
@@ -1469,7 +1475,7 @@ func (tc *TeleportClient) runCommand(
 			if len(nodeAddresses) > 1 {
 				fmt.Printf("Running command on %v:\n", address)
 			}
-			nodeSession, err = newSession(nodeClient, nil, tc.Config.Env, tc.Stdin, tc.Stdout, tc.Stderr, tc.useLegacyID(nodeClient))
+			nodeSession, err = newSession(nodeClient, nil, tc.Config.Env, tc.Stdin, tc.Stdout, tc.Stderr, tc.useLegacyID(nodeClient), tc.EnableEscapeSequences)
 			if err != nil {
 				log.Error(err)
 				return
@@ -1503,7 +1509,7 @@ func (tc *TeleportClient) runCommand(
 // runShell starts an interactive SSH session/shell.
 // sessionID : when empty, creates a new shell. otherwise it tries to join the existing session.
 func (tc *TeleportClient) runShell(nodeClient *NodeClient, sessToJoin *session.Session) error {
-	nodeSession, err := newSession(nodeClient, sessToJoin, tc.Env, tc.Stdin, tc.Stdout, tc.Stderr, tc.useLegacyID(nodeClient))
+	nodeSession, err := newSession(nodeClient, sessToJoin, tc.Env, tc.Stdin, tc.Stdout, tc.Stderr, tc.useLegacyID(nodeClient), tc.EnableEscapeSequences)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/client/client_test.go
+++ b/lib/client/client_test.go
@@ -55,7 +55,7 @@ func (s *ClientTestSuite) TestNewSession(c *check.C) {
 	}
 
 	// defaults:
-	ses, err := newSession(nc, nil, nil, nil, nil, nil, false)
+	ses, err := newSession(nc, nil, nil, nil, nil, nil, false, true)
 	c.Assert(err, check.IsNil)
 	c.Assert(ses, check.NotNil)
 	c.Assert(ses.NodeClient(), check.Equals, nc)
@@ -69,7 +69,7 @@ func (s *ClientTestSuite) TestNewSession(c *check.C) {
 	env := map[string]string{
 		sshutils.SessionEnvVar: "session-id",
 	}
-	ses, err = newSession(nc, nil, env, nil, nil, nil, false)
+	ses, err = newSession(nc, nil, env, nil, nil, nil, false, true)
 	c.Assert(err, check.IsNil)
 	c.Assert(ses, check.NotNil)
 	c.Assert(ses.env, check.DeepEquals, env)

--- a/lib/client/escape/reader.go
+++ b/lib/client/escape/reader.go
@@ -122,7 +122,7 @@ outer:
 
 		// forward contains the characters to add to the internal buffer.
 		forward := readBuf
-		c := byte(readBuf[0])
+		c := readBuf[0]
 		switch prev {
 		case '\r', '\n':
 			// Detect a tilde after a newline.

--- a/lib/client/escape/reader.go
+++ b/lib/client/escape/reader.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package escape implements client-side escape character logic.
+// This logic mimics OpenSSH: https://man.openbsd.org/ssh#ESCAPE_CHARACTERS.
+package escape
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+const (
+	readerBufferLimit = 10 * 1 << 10 // 10MB
+
+	// Note: on a raw terminal, "\r\n" is needed to move a cursor to the start
+	// of next line.
+	helpText = "\r\ntsh escape characters:\r\n  ~? - display a list of escape characters\r\n  ~. - disconnect\r\n"
+)
+
+var (
+	// ErrDisconnect is returned when the user has entered a disconnect
+	// sequence, requesting connection to be interrupted.
+	ErrDisconnect = errors.New("disconnect escape sequence detected")
+	// ErrTooMuchBufferedData is returned when the Reader's internal buffer has
+	// filled over 10MB. Either the consumer of Reader can't keep up with the
+	// data or it's entirely stuck and not consuming the data.
+	ErrTooMuchBufferedData = errors.New("internal buffer has grown too big")
+)
+
+// Reader is an io.Reader wrapper that catches OpenSSH-like escape sequences in
+// the input stream. See NewReader for more info.
+//
+// Reader is safe for concurrent use.
+type Reader struct {
+	inner        io.Reader
+	out          io.Writer
+	onDisconnect func(error)
+	bufferLimit  int
+
+	// cond protects buf and err and also announces to blocked readers that
+	// more data is available.
+	cond sync.Cond
+	buf  []byte
+	err  error
+}
+
+// NewReader creates a new Reader to catch escape sequences from 'in'.
+//
+// Two sequences are supported:
+// - "~?": prints help text to 'out' listing supported sequences
+// - "~.": disconnect stops any future reads from in; after this sequence,
+//   callers can still read any unread data up to this sequence from Reader but
+//   all future Read calls will return ErrDisconnect; onDisconnect will also be
+//   called with ErrDisconnect immediately
+//
+// NewReader starts consuming 'in' immediately in the background. This allows
+// Reader to detect sequences without the caller actively calling Read (such as
+// when it's stuck writing out the received data).
+//
+// Unread data is accumulated in an internal buffer. If this buffer grows to a
+// limit (currently 10MB), Reader will stop permanently. onDisconnect will get
+// called with ErrTooMuchBufferedData. Read can still be called to consume the
+// internal buffer but all future reads after that will return
+// ErrTooMuchBufferedData.
+//
+// If the internal buffer is empty, calls to Read will block until some data is
+// available or an error occurs.
+func NewReader(in io.Reader, out io.Writer, onDisconnect func(error)) *Reader {
+	r := newUnstartedReader(in, out, onDisconnect)
+	go r.runReads()
+	return r
+}
+
+// newUnstartedReader allows unit tests to mutate Reader before runReads
+// starts.
+func newUnstartedReader(in io.Reader, out io.Writer, onDisconnect func(error)) *Reader {
+	return &Reader{
+		inner:        in,
+		out:          out,
+		onDisconnect: onDisconnect,
+		bufferLimit:  readerBufferLimit,
+		cond:         sync.Cond{L: &sync.Mutex{}},
+		// note: no need to pre-allocate buf, it will allocate and grow as
+		// needed in runReads via append.
+	}
+}
+
+func (r *Reader) runReads() {
+	// prev contains the last read escape sequence character.
+	// Possible values are:
+	//   '\r' or '\n' after a fresh newline
+	//   '~' after a newline and ~
+	//   '\000' (null) in any other case
+	prev := byte('\r')
+	// Read one character at a time to simplify the logic.
+	readBuf := make([]byte, 1)
+outer:
+	for {
+		n, err := r.inner.Read(readBuf)
+		if err != nil {
+			r.setErr(err)
+			return
+		}
+		if n == 0 {
+			continue outer
+		}
+
+		// forward contains the characters to add to the internal buffer.
+		forward := readBuf
+		c := byte(readBuf[0])
+		switch prev {
+		case '\r', '\n':
+			// Detect a tilde after a newline.
+			if c == '~' {
+				prev = '~'
+				// Do not send the tilde to remote end right way.
+				continue outer
+			}
+			prev = '\000'
+		case '~':
+			// We saw a newline and a tilde. Time to complete the escape
+			// sequence or abort it.
+			switch c {
+			case '?':
+				r.printHelp()
+				// Reset as if we're right after a newline.
+				prev = '\r'
+				// Do not send the help escape sequence to remote end.
+				continue outer
+			case '.':
+				// Disconnect and abort future reads. Previously-read data is
+				// still available.
+				r.setErr(ErrDisconnect)
+				return
+			case '~':
+				// Escaped tilde, let only one tilde through and reset prev to
+				// ignore all characters until the next newline.
+				prev = '\000'
+			default:
+				// Not an escape sequence. Send over the blocked tilde and
+				// whatever character was typed in.
+				forward = []byte{prev, c}
+				// Reset prev to ignore all characters until the next newline.
+				prev = '\000'
+			}
+		default:
+			// If we're not in an escape sequence, ignore everything until a
+			// newline restarts a new potential sequence.
+			if c == '\r' || c == '\n' {
+				prev = c
+			}
+		}
+
+		// Add new data to internal buffer.
+		r.cond.L.Lock()
+		if len(r.buf)+len(forward) > r.bufferLimit {
+			// Unlock because setErr will want to lock too.
+			r.cond.L.Unlock()
+			r.setErr(ErrTooMuchBufferedData)
+			return
+		}
+		r.buf = append(r.buf, forward...)
+		// Notify blocked Read calls about new data.
+		r.cond.Broadcast()
+		r.cond.L.Unlock()
+	}
+}
+
+// Read fills buf with available data. If no data is available, Read will
+// block.
+func (r *Reader) Read(buf []byte) (int, error) {
+	r.cond.L.Lock()
+	defer r.cond.L.Unlock()
+	// Block until some data was read in runReads.
+	for len(r.buf) == 0 && r.err == nil {
+		r.cond.Wait()
+	}
+
+	// Have some data to return.
+	n := len(r.buf)
+	if n > len(buf) {
+		n = len(buf)
+	}
+	// Write n available bytes to buf and trim them from r.buf.
+	copy(buf, r.buf[:n])
+	r.buf = r.buf[n:]
+
+	return n, r.err
+}
+
+func (r *Reader) setErr(err error) {
+	r.cond.L.Lock()
+	r.err = err
+	r.cond.Broadcast()
+	// Skip EOF, it's a normal clean exit.
+	if err != io.EOF {
+		r.onDisconnect(err)
+	}
+	r.cond.L.Unlock()
+}
+
+func (r *Reader) printHelp() {
+	r.out.Write([]byte(helpText))
+}

--- a/lib/client/escape/reader_test.go
+++ b/lib/client/escape/reader_test.go
@@ -1,0 +1,168 @@
+package escape
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type ReaderSuite struct {
+}
+
+var _ = check.Suite(&ReaderSuite{})
+
+type readerTestCase struct {
+	inStream []byte
+	inErr    error
+
+	wantReadErr       error
+	wantDisconnectErr error
+	wantOut           string
+	wantHelp          string
+}
+
+func (*ReaderSuite) runCase(c *check.C, t readerTestCase) {
+	in := &mockReader{data: t.inStream, finalErr: t.inErr}
+	helpOut := new(bytes.Buffer)
+	out := new(bytes.Buffer)
+	var disconnectErr error
+
+	r := NewReader(in, helpOut, func(err error) {
+		disconnectErr = err
+	})
+
+	_, err := io.Copy(out, r)
+	c.Assert(err, check.Equals, t.wantReadErr)
+	c.Assert(disconnectErr, check.Equals, t.wantDisconnectErr)
+	c.Assert(out.String(), check.Equals, t.wantOut)
+	c.Assert(helpOut.String(), check.Equals, t.wantHelp)
+}
+
+func (s *ReaderSuite) TestNormalReads(c *check.C) {
+	c.Log("normal read")
+	s.runCase(c, readerTestCase{
+		inStream: []byte("hello world"),
+		wantOut:  "hello world",
+	})
+
+	c.Log("incomplete help sequence")
+	s.runCase(c, readerTestCase{
+		inStream: []byte("hello\r~world"),
+		wantOut:  "hello\r~world",
+	})
+
+	c.Log("escaped tilde character")
+	s.runCase(c, readerTestCase{
+		inStream: []byte("hello\r~~world"),
+		wantOut:  "hello\r~world",
+	})
+
+	c.Log("other character between newline and tilde")
+	s.runCase(c, readerTestCase{
+		inStream: []byte("hello\rw~orld"),
+		wantOut:  "hello\rw~orld",
+	})
+
+	c.Log("other character between newline and disconnect sequence")
+	s.runCase(c, readerTestCase{
+		inStream: []byte("hello\rw~.orld"),
+		wantOut:  "hello\rw~.orld",
+	})
+}
+
+func (s *ReaderSuite) TestReadError(c *check.C) {
+	customErr := errors.New("oh no")
+
+	s.runCase(c, readerTestCase{
+		inStream:          []byte("hello world"),
+		inErr:             customErr,
+		wantOut:           "hello world",
+		wantReadErr:       customErr,
+		wantDisconnectErr: customErr,
+	})
+}
+
+func (s *ReaderSuite) TestEscapeHelp(c *check.C) {
+	c.Log("single help sequence between reads")
+	s.runCase(c, readerTestCase{
+		inStream: []byte("hello\r~?world"),
+		wantOut:  "hello\rworld",
+		wantHelp: helpText,
+	})
+
+	c.Log("single help sequence before any data")
+	s.runCase(c, readerTestCase{
+		inStream: []byte("~?hello world"),
+		wantOut:  "hello world",
+		wantHelp: helpText,
+	})
+
+	c.Log("repeated help sequences")
+	s.runCase(c, readerTestCase{
+		inStream: []byte("hello\r~?world\n~?"),
+		wantOut:  "hello\rworld\n",
+		wantHelp: helpText + helpText,
+	})
+}
+
+func (s *ReaderSuite) TestEscapeDisconnect(c *check.C) {
+	c.Log("single disconnect sequence between reads")
+	s.runCase(c, readerTestCase{
+		inStream:          []byte("hello\r~.world"),
+		wantOut:           "hello\r",
+		wantReadErr:       ErrDisconnect,
+		wantDisconnectErr: ErrDisconnect,
+	})
+
+	c.Log("disconnect sequence before any data")
+	s.runCase(c, readerTestCase{
+		inStream:          []byte("~.hello world"),
+		wantReadErr:       ErrDisconnect,
+		wantDisconnectErr: ErrDisconnect,
+	})
+}
+
+func (*ReaderSuite) TestBufferOverflow(c *check.C) {
+	in := &mockReader{data: make([]byte, 100)}
+	helpOut := new(bytes.Buffer)
+	out := new(bytes.Buffer)
+	var disconnectErr error
+
+	r := newUnstartedReader(in, helpOut, func(err error) {
+		disconnectErr = err
+	})
+	r.bufferLimit = 10
+	go r.runReads()
+
+	_, err := io.Copy(out, r)
+	c.Assert(err, check.Equals, ErrTooMuchBufferedData)
+	c.Assert(disconnectErr, check.Equals, ErrTooMuchBufferedData)
+}
+
+type mockReader struct {
+	data     []byte
+	finalErr error
+}
+
+func (r *mockReader) Read(buf []byte) (int, error) {
+	if len(r.data) == 0 {
+		if r.finalErr != nil {
+			return 0, r.finalErr
+		}
+		return 0, io.EOF
+	}
+
+	n := len(buf)
+	if n > len(r.data) {
+		n = len(r.data)
+	}
+	copy(buf, r.data)
+	r.data = r.data[n:]
+	return n, nil
+
+}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -163,6 +163,11 @@ type CLIConf struct {
 	// UseLocalSSHAgent set to false will prevent this client from attempting to
 	// connect to the local ssh-agent (or similar) socket at $SSH_AUTH_SOCK.
 	UseLocalSSHAgent bool
+
+	// EnableEscapeSequences will scan stdin for SSH escape sequences during
+	// command/shell execution. This also requires stdin to be an interactive
+	// terminal.
+	EnableEscapeSequences bool
 }
 
 func main() {
@@ -222,6 +227,9 @@ func Run(args []string) {
 		Envar(useLocalSSHAgentEnvVar).
 		Default("true").
 		BoolVar(&cf.UseLocalSSHAgent)
+	app.Flag("enable-escape-sequences", "Enable support for SSH escape sequences. Type '~?' during an SSH session to list supported sequences. Default is enabled.").
+		Default("true").
+		BoolVar(&cf.EnableEscapeSequences)
 	app.HelpFlag.Short('h')
 	ver := app.Command("version", "Print the version")
 	// ssh
@@ -1093,6 +1101,8 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, erro
 	// This is specifically for gpg-agent, which doesn't support SSH
 	// certificates (https://dev.gnupg.org/T1756)
 	c.UseLocalSSHAgent = cf.UseLocalSSHAgent
+
+	c.EnableEscapeSequences = cf.EnableEscapeSequences
 
 	tc, err := client.NewClient(c)
 	if err != nil {


### PR DESCRIPTION
Only applies to interactive sessions.
Watch the user keyboard input for one of:
- `~?`: print help output for escape sequences
- `~.`: disconnect the current session (for example when stuck due to
  traffic getting black-holed)

The full list of OpenSSH sequences is here:
https://man.openbsd.org/ssh#ESCAPE_CHARACTERS
We only support the two mentioned above for now. If the need arises, it
should be easy to add.

The implementation ended up pretty complicated, read the comment on
`escape.NewReader` for some info and reasoning.

Fixes #2555