### PR TITLE
Updated to reflect a better --insecure flag

### DIFF
--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -2192,7 +2192,7 @@ Teleport will handle its own SSL on top of that with its own certificates.
 !!! tip "NOTE"
 
     If you terminate TLS with your own certificate at a load
-    balancer you'll need to run Teleport with `--insecure`
+    balancer you'll need to run Teleport with `--insecure-no-tls`
 
 If your load balancer supports HTTP health checks, configure it to hit the
 `/webapi/ping` endpoint on the proxy. This endpoint will reply `200 OK` if the


### PR DESCRIPTION
Via a customer, If you terminate TLS with your own certificate at a load balancer you need to tell Teleport. 

`--insecure-no-tls` = 

> Tells proxy to not generate default self-signed TLS certificates. This is useful when running Teleport on kubernetes (behind reverse proxy) or behind things like AWS ELBs, GCP LBs or Azure Load Balancers where SSL termination is provided externally.