### PR TITLE
 backport: add missing trusted cluster info to TLS certs created at tsh login

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -524,7 +524,9 @@ func (s *AuthServer) generateUserCert(req certRequest) (*certs, error) {
 	}
 
 	kubeGroups, kubeUsers, err := req.checker.CheckKubeGroupsAndUsers(sessionTTL)
-	if err != nil {
+	// NotFound errors are acceptable - this user may have no k8s access
+	// granted and that shouldn't prevent us from issuing a TLS cert.
+	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
 	userCA, err := s.Trust.GetCertAuthority(services.CertAuthID{

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
+	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/coreos/go-oidc/jose"

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -217,6 +217,7 @@ type AuthenticateSSHRequest struct {
 	TTL time.Duration `json:"ttl"`
 	// CompatibilityMode sets certificate compatibility mode with old SSH clients
 	CompatibilityMode string `json:"compatibility_mode"`
+	RouteToCluster    string `json:"route_to_cluster"`
 }
 
 // CheckAndSetDefaults checks and sets default certificate values
@@ -334,12 +335,13 @@ func (s *AuthServer) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginR
 	}
 
 	certs, err := s.generateUserCert(certRequest{
-		user:          user,
-		ttl:           req.TTL,
-		publicKey:     req.PublicKey,
-		compatibility: req.CompatibilityMode,
-		checker:       checker,
-		traits:        user.GetTraits(),
+		user:           user,
+		ttl:            req.TTL,
+		publicKey:      req.PublicKey,
+		compatibility:  req.CompatibilityMode,
+		checker:        checker,
+		traits:         user.GetTraits(),
+		routeToCluster: req.RouteToCluster,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -290,8 +290,8 @@ func AuthoritiesToTrustedCerts(authorities []services.CertAuthority) []TrustedCe
 	return out
 }
 
-// AuthenticateSSHUser authenticates web user, creates and  returns web session
-// in case if authentication is successful
+// AuthenticateSSHUser authenticates an SSH user and returns SSH and TLS
+// certificates for the public key in req.
 func (s *AuthServer) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	clusterConfig, err := s.GetClusterConfig()
 	if err != nil {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1983,17 +1983,17 @@ func (tc *TeleportClient) directLogin(ctx context.Context, secondFactorType stri
 	}
 
 	// ask the CA (via proxy) to sign our public key:
-	response, err := SSHAgentLogin(
-		ctx,
-		tc.WebProxyAddr,
-		tc.Config.Username,
-		password,
-		otpToken,
-		pub,
-		tc.KeyTTL,
-		tc.InsecureSkipVerify,
-		loopbackPool(tc.WebProxyAddr),
-		tc.CertificateFormat)
+	response, err := SSHAgentLogin(ctx, SSHLoginDirect{
+		ProxyAddr:     tc.WebProxyAddr,
+		User:          tc.Config.Username,
+		Password:      password,
+		OTPToken:      otpToken,
+		PubKey:        pub,
+		TTL:           tc.KeyTTL,
+		Insecure:      tc.InsecureSkipVerify,
+		Pool:          loopbackPool(tc.WebProxyAddr),
+		Compatibility: tc.CertificateFormat,
+	})
 
 	return response, trace.Wrap(err)
 }
@@ -2002,8 +2002,7 @@ func (tc *TeleportClient) directLogin(ctx context.Context, secondFactorType stri
 func (tc *TeleportClient) ssoLogin(ctx context.Context, connectorID string, pub []byte, protocol string) (*auth.SSHLoginResponse, error) {
 	log.Debugf("samlLogin start")
 	// ask the CA (via proxy) to sign our public key:
-	response, err := SSHAgentSSOLogin(SSHLogin{
-		Context:       ctx,
+	response, err := SSHAgentSSOLogin(ctx, SSHLoginSSO{
 		ConnectorID:   connectorID,
 		PubKey:        pub,
 		TTL:           tc.KeyTTL,
@@ -2030,16 +2029,16 @@ func (tc *TeleportClient) u2fLogin(ctx context.Context, pub []byte) (*auth.SSHLo
 		return nil, trace.Wrap(err)
 	}
 
-	response, err := SSHAgentU2FLogin(
-		ctx,
-		tc.WebProxyAddr,
-		tc.Config.Username,
-		password,
-		pub,
-		tc.KeyTTL,
-		tc.InsecureSkipVerify,
-		loopbackPool(tc.WebProxyAddr),
-		tc.CertificateFormat)
+	response, err := SSHAgentU2FLogin(ctx, SSHLoginU2F{
+		ProxyAddr:     tc.WebProxyAddr,
+		User:          tc.Config.Username,
+		Password:      password,
+		PubKey:        pub,
+		TTL:           tc.KeyTTL,
+		Insecure:      tc.InsecureSkipVerify,
+		Pool:          loopbackPool(tc.WebProxyAddr),
+		Compatibility: tc.CertificateFormat,
+	})
 
 	return response, trace.Wrap(err)
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1984,15 +1984,16 @@ func (tc *TeleportClient) directLogin(ctx context.Context, secondFactorType stri
 
 	// ask the CA (via proxy) to sign our public key:
 	response, err := SSHAgentLogin(ctx, SSHLoginDirect{
-		ProxyAddr:     tc.WebProxyAddr,
-		User:          tc.Config.Username,
-		Password:      password,
-		OTPToken:      otpToken,
-		PubKey:        pub,
-		TTL:           tc.KeyTTL,
-		Insecure:      tc.InsecureSkipVerify,
-		Pool:          loopbackPool(tc.WebProxyAddr),
-		Compatibility: tc.CertificateFormat,
+		ProxyAddr:      tc.WebProxyAddr,
+		User:           tc.Config.Username,
+		Password:       password,
+		OTPToken:       otpToken,
+		PubKey:         pub,
+		TTL:            tc.KeyTTL,
+		Insecure:       tc.InsecureSkipVerify,
+		Pool:           loopbackPool(tc.WebProxyAddr),
+		Compatibility:  tc.CertificateFormat,
+		RouteToCluster: tc.SiteName,
 	})
 
 	return response, trace.Wrap(err)
@@ -2003,15 +2004,25 @@ func (tc *TeleportClient) ssoLogin(ctx context.Context, connectorID string, pub 
 	log.Debugf("samlLogin start")
 	// ask the CA (via proxy) to sign our public key:
 	response, err := SSHAgentSSOLogin(ctx, SSHLoginSSO{
-		ConnectorID:   connectorID,
-		PubKey:        pub,
-		TTL:           tc.KeyTTL,
-		Protocol:      protocol,
-		Compatibility: tc.CertificateFormat,
-		BindAddr:      tc.BindAddr,
-		ProxyAddr:     tc.WebProxyAddr,
-		Insecure:      tc.InsecureSkipVerify,
-		Pool:          loopbackPool(tc.WebProxyAddr),
+		ConnectorID:    connectorID,
+		PubKey:         pub,
+		TTL:            tc.KeyTTL,
+		Protocol:       protocol,
+		Compatibility:  tc.CertificateFormat,
+		BindAddr:       tc.BindAddr,
+		ProxyAddr:      tc.WebProxyAddr,
+		Insecure:       tc.InsecureSkipVerify,
+		Pool:           loopbackPool(tc.WebProxyAddr),
+		ConnectorID:    connectorID,
+		PubKey:         pub,
+		TTL:            tc.KeyTTL,
+		Protocol:       protocol,
+		Compatibility:  tc.CertificateFormat,
+		BindAddr:       tc.BindAddr,
+		ProxyAddr:      tc.WebProxyAddr,
+		Insecure:       tc.InsecureSkipVerify,
+		Pool:           loopbackPool(tc.WebProxyAddr),
+		RouteToCluster: tc.SiteName,
 	})
 	return response, trace.Wrap(err)
 }
@@ -2030,14 +2041,15 @@ func (tc *TeleportClient) u2fLogin(ctx context.Context, pub []byte) (*auth.SSHLo
 	}
 
 	response, err := SSHAgentU2FLogin(ctx, SSHLoginU2F{
-		ProxyAddr:     tc.WebProxyAddr,
-		User:          tc.Config.Username,
-		Password:      password,
-		PubKey:        pub,
-		TTL:           tc.KeyTTL,
-		Insecure:      tc.InsecureSkipVerify,
-		Pool:          loopbackPool(tc.WebProxyAddr),
-		Compatibility: tc.CertificateFormat,
+		ProxyAddr:      tc.WebProxyAddr,
+		User:           tc.Config.Username,
+		Password:       password,
+		PubKey:         pub,
+		TTL:            tc.KeyTTL,
+		Insecure:       tc.InsecureSkipVerify,
+		Pool:           loopbackPool(tc.WebProxyAddr),
+		Compatibility:  tc.CertificateFormat,
+		RouteToCluster: tc.SiteName,
 	})
 
 	return response, trace.Wrap(err)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1984,16 +1984,18 @@ func (tc *TeleportClient) directLogin(ctx context.Context, secondFactorType stri
 
 	// ask the CA (via proxy) to sign our public key:
 	response, err := SSHAgentLogin(ctx, SSHLoginDirect{
-		ProxyAddr:      tc.WebProxyAddr,
-		User:           tc.Config.Username,
-		Password:       password,
-		OTPToken:       otpToken,
-		PubKey:         pub,
-		TTL:            tc.KeyTTL,
-		Insecure:       tc.InsecureSkipVerify,
-		Pool:           loopbackPool(tc.WebProxyAddr),
-		Compatibility:  tc.CertificateFormat,
-		RouteToCluster: tc.SiteName,
+		SSHLogin: SSHLogin{
+			ProxyAddr:      tc.WebProxyAddr,
+			PubKey:         pub,
+			TTL:            tc.KeyTTL,
+			Insecure:       tc.InsecureSkipVerify,
+			Pool:           loopbackPool(tc.WebProxyAddr),
+			Compatibility:  tc.CertificateFormat,
+			RouteToCluster: tc.SiteName,
+		},
+		User:     tc.Config.Username,
+		Password: password,
+		OTPToken: otpToken,
 	})
 
 	return response, trace.Wrap(err)
@@ -2004,25 +2006,18 @@ func (tc *TeleportClient) ssoLogin(ctx context.Context, connectorID string, pub 
 	log.Debugf("samlLogin start")
 	// ask the CA (via proxy) to sign our public key:
 	response, err := SSHAgentSSOLogin(ctx, SSHLoginSSO{
-		ConnectorID:    connectorID,
-		PubKey:         pub,
-		TTL:            tc.KeyTTL,
-		Protocol:       protocol,
-		Compatibility:  tc.CertificateFormat,
-		BindAddr:       tc.BindAddr,
-		ProxyAddr:      tc.WebProxyAddr,
-		Insecure:       tc.InsecureSkipVerify,
-		Pool:           loopbackPool(tc.WebProxyAddr),
-		ConnectorID:    connectorID,
-		PubKey:         pub,
-		TTL:            tc.KeyTTL,
-		Protocol:       protocol,
-		Compatibility:  tc.CertificateFormat,
-		BindAddr:       tc.BindAddr,
-		ProxyAddr:      tc.WebProxyAddr,
-		Insecure:       tc.InsecureSkipVerify,
-		Pool:           loopbackPool(tc.WebProxyAddr),
-		RouteToCluster: tc.SiteName,
+		SSHLogin: SSHLogin{
+			ProxyAddr:      tc.WebProxyAddr,
+			PubKey:         pub,
+			TTL:            tc.KeyTTL,
+			Insecure:       tc.InsecureSkipVerify,
+			Pool:           loopbackPool(tc.WebProxyAddr),
+			Compatibility:  tc.CertificateFormat,
+			RouteToCluster: tc.SiteName,
+		},
+		ConnectorID: connectorID,
+		Protocol:    protocol,
+		BindAddr:    tc.BindAddr,
 	})
 	return response, trace.Wrap(err)
 }
@@ -2041,15 +2036,17 @@ func (tc *TeleportClient) u2fLogin(ctx context.Context, pub []byte) (*auth.SSHLo
 	}
 
 	response, err := SSHAgentU2FLogin(ctx, SSHLoginU2F{
-		ProxyAddr:      tc.WebProxyAddr,
-		User:           tc.Config.Username,
-		Password:       password,
-		PubKey:         pub,
-		TTL:            tc.KeyTTL,
-		Insecure:       tc.InsecureSkipVerify,
-		Pool:           loopbackPool(tc.WebProxyAddr),
-		Compatibility:  tc.CertificateFormat,
-		RouteToCluster: tc.SiteName,
+		SSHLogin: SSHLogin{
+			ProxyAddr:      tc.WebProxyAddr,
+			PubKey:         pub,
+			TTL:            tc.KeyTTL,
+			Insecure:       tc.InsecureSkipVerify,
+			Pool:           loopbackPool(tc.WebProxyAddr),
+			Compatibility:  tc.CertificateFormat,
+			RouteToCluster: tc.SiteName,
+		},
+		User:     tc.Config.Username,
+		Password: password,
 	})
 
 	return response, trace.Wrap(err)

--- a/lib/client/redirect.go
+++ b/lib/client/redirect.go
@@ -134,11 +134,12 @@ func (rd *Redirector) Start() error {
 	u.RawQuery = query.Encode()
 
 	out, err := rd.proxyClient.PostJSON(rd.context, rd.proxyClient.Endpoint("webapi", rd.Protocol, "login", "console"), SSOLoginConsoleReq{
-		RedirectURL:   u.String(),
-		PublicKey:     rd.PubKey,
-		CertTTL:       rd.TTL,
-		ConnectorID:   rd.ConnectorID,
-		Compatibility: rd.Compatibility,
+		RedirectURL:    u.String(),
+		PublicKey:      rd.PubKey,
+		CertTTL:        rd.TTL,
+		ConnectorID:    rd.ConnectorID,
+		Compatibility:  rd.Compatibility,
+		RouteToCluster: rd.RouteToCluster,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/client/redirect.go
+++ b/lib/client/redirect.go
@@ -34,8 +34,8 @@ import (
 
 // Redirector handles SSH redirect flow with the Teleport server
 type Redirector struct {
-	// SSHLogin contains SSH login parameters
-	SSHLogin
+	// SSHLoginSSO contains SSH login parameters
+	SSHLoginSSO
 	server *httptest.Server
 	mux    *http.ServeMux
 	// redirectURL will be set based on the response from the Teleport
@@ -66,7 +66,7 @@ type Redirector struct {
 }
 
 // NewRedirector returns new local web server redirector
-func NewRedirector(login SSHLogin) (*Redirector, error) {
+func NewRedirector(ctx context.Context, login SSHLoginSSO) (*Redirector, error) {
 	clt, proxyURL, err := initClient(login.ProxyAddr, login.Insecure, login.Pool)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -79,13 +79,13 @@ func NewRedirector(login SSHLogin) (*Redirector, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	context, cancel := context.WithCancel(login.Context)
+	context, cancel := context.WithCancel(ctx)
 	rd := &Redirector{
 		context:     context,
 		cancel:      cancel,
 		proxyClient: clt,
 		proxyURL:    proxyURL,
-		SSHLogin:    login,
+		SSHLoginSSO: login,
 		mux:         http.NewServeMux(),
 		key:         key,
 		shortPath:   "/" + uuid.New(),
@@ -133,7 +133,7 @@ func (rd *Redirector) Start() error {
 	query.Set("secret_key", rd.key.String())
 	u.RawQuery = query.Encode()
 
-	out, err := rd.proxyClient.PostJSON(rd.Context, rd.proxyClient.Endpoint("webapi", rd.Protocol, "login", "console"), SSOLoginConsoleReq{
+	out, err := rd.proxyClient.PostJSON(rd.context, rd.proxyClient.Endpoint("webapi", rd.Protocol, "login", "console"), SSOLoginConsoleReq{
 		RedirectURL:   u.String(),
 		PublicKey:     rd.PubKey,
 		CertTTL:       rd.TTL,

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -143,12 +143,10 @@ type PingResponse struct {
 	MinClientVersion string `json:"min_client_version"`
 }
 
-// SSHLoginSSO contains SSH login parameters for SSO login.
-type SSHLoginSSO struct {
+// SSHLogin contains common SSH login parameters.
+type SSHLogin struct {
 	// ProxyAddr is the target proxy address
 	ProxyAddr string
-	// ConnectorID is the OIDC or SAML connector ID to use
-	ConnectorID string
 	// PubKey is SSH public key to sign
 	PubKey []byte
 	// TTL is requested TTL of the client certificates
@@ -157,10 +155,20 @@ type SSHLoginSSO struct {
 	Insecure bool
 	// Pool is x509 cert pool to use for server certifcate verification
 	Pool *x509.CertPool
-	// Protocol is an optional protocol selection
-	Protocol string
 	// Compatibility sets compatibility mode for SSH certificates
 	Compatibility string
+	// RouteToCluster is an optional cluster name to route the response
+	// credentials to.
+	RouteToCluster string
+}
+
+// SSHLoginSSO contains SSH login parameters for SSO login.
+type SSHLoginSSO struct {
+	SSHLogin
+	// ConnectorID is the OIDC or SAML connector ID to use
+	ConnectorID string
+	// Protocol is an optional protocol selection
+	Protocol string
 	// BindAddr is an optional host:port address to bind
 	// to for SSO login flows
 	BindAddr string
@@ -168,58 +176,27 @@ type SSHLoginSSO struct {
 	// default (not currently implemented), or set to 'none' to suppress
 	// browser opening entirely.
 	Browser string
-	// RouteToCluster is an optional cluster name to route the response
-	// credentials to.
-	RouteToCluster string
 }
 
 // SSHLoginDirect contains SSH login parameters for direct (user/pass/OTP)
 // login.
 type SSHLoginDirect struct {
-	// ProxyAddr is the target proxy address
-	ProxyAddr string
+	SSHLogin
 	// User is the login username.
 	User string
 	// User is the login password.
 	Password string
 	// User is the optional OTP token for the login.
 	OTPToken string
-	// PubKey is SSH public key to sign
-	PubKey []byte
-	// TTL is requested TTL of the client certificates
-	TTL time.Duration
-	// Insecure turns off verification for x509 target proxy
-	Insecure bool
-	// Pool is x509 cert pool to use for server certifcate verification
-	Pool *x509.CertPool
-	// Compatibility sets compatibility mode for SSH certificates
-	Compatibility string
-	// RouteToCluster is an optional cluster name to route the response
-	// credentials to.
-	RouteToCluster string
 }
 
 // SSHLoginU2F contains SSH login parameters for U2F login.
 type SSHLoginU2F struct {
-	// ProxyAddr is the target proxy address
-	ProxyAddr string
+	SSHLogin
 	// User is the login username.
 	User string
 	// User is the login password.
 	Password string
-	// PubKey is SSH public key to sign
-	PubKey []byte
-	// TTL is requested TTL of the client certificates
-	TTL time.Duration
-	// Insecure turns off verification for x509 target proxy
-	Insecure bool
-	// Pool is x509 cert pool to use for server certifcate verification
-	Pool *x509.CertPool
-	// Compatibility sets compatibility mode for SSH certificates
-	Compatibility string
-	// RouteToCluster is an optional cluster name to route the response
-	// credentials to.
-	RouteToCluster string
 }
 
 // ProxySettings contains basic information about proxy settings
@@ -491,7 +468,6 @@ func SSHAgentLogin(ctx context.Context, login SSHLoginDirect) (*auth.SSHLoginRes
 // We then call the official u2f-host binary to perform the signing and pass
 // the signature to the proxy. If the authentication succeeds, we will get a
 // temporary certificate back.
-//func SSHAgentU2FLogin(ctx context.Context, proxyAddr, user, password string, pubKey []byte, ttl time.Duration, insecure bool, pool *x509.CertPool, compatibility string) (*auth.SSHLoginResponse, error) {
 func SSHAgentU2FLogin(ctx context.Context, login SSHLoginU2F) (*auth.SSHLoginResponse, error) {
 	clt, _, err := initClient(login.ProxyAddr, login.Insecure, login.Pool)
 	if err != nil {

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -134,10 +134,8 @@ type PingResponse struct {
 	MinClientVersion string `json:"min_client_version"`
 }
 
-// SSHLogin contains SSH login parameters
-type SSHLogin struct {
-	// Context is an external context
-	Context context.Context
+// SSHLoginSSO contains SSH login parameters for SSO login.
+type SSHLoginSSO struct {
 	// ProxyAddr is the target proxy address
 	ProxyAddr string
 	// ConnectorID is the OIDC or SAML connector ID to use
@@ -157,6 +155,53 @@ type SSHLogin struct {
 	// BindAddr is an optional host:port address to bind
 	// to for SSO login flows
 	BindAddr string
+	// Browser can be used to pass the name of a browser to override the system
+	// default (not currently implemented), or set to 'none' to suppress
+	// browser opening entirely.
+	Browser string
+}
+
+// SSHLoginDirect contains SSH login parameters for direct (user/pass/OTP)
+// login.
+type SSHLoginDirect struct {
+	// ProxyAddr is the target proxy address
+	ProxyAddr string
+	// User is the login username.
+	User string
+	// User is the login password.
+	Password string
+	// User is the optional OTP token for the login.
+	OTPToken string
+	// PubKey is SSH public key to sign
+	PubKey []byte
+	// TTL is requested TTL of the client certificates
+	TTL time.Duration
+	// Insecure turns off verification for x509 target proxy
+	Insecure bool
+	// Pool is x509 cert pool to use for server certifcate verification
+	Pool *x509.CertPool
+	// Compatibility sets compatibility mode for SSH certificates
+	Compatibility string
+}
+
+// SSHLoginU2F contains SSH login parameters for U2F login.
+type SSHLoginU2F struct {
+	// ProxyAddr is the target proxy address
+	ProxyAddr string
+	// User is the login username.
+	User string
+	// User is the login password.
+	Password string
+	// PubKey is SSH public key to sign
+	PubKey []byte
+	// TTL is requested TTL of the client certificates
+	TTL time.Duration
+	// Insecure turns off verification for x509 target proxy
+	Insecure bool
+	// Pool is x509 cert pool to use for server certifcate verification
+	Pool *x509.CertPool
+	// Compatibility sets compatibility mode for SSH certificates
+	Compatibility string
 }
 
 // ProxySettings contains basic information about proxy settings
@@ -335,8 +380,8 @@ func Find(ctx context.Context, proxyAddr string, insecure bool, pool *x509.CertP
 }
 
 // SSHAgentSSOLogin is used by tsh to fetch user credentials using OpenID Connect (OIDC) or SAML.
-func SSHAgentSSOLogin(login SSHLogin) (*auth.SSHLoginResponse, error) {
-	rd, err := NewRedirector(login)
+func SSHAgentSSOLogin(ctx context.Context, login SSHLoginSSO) (*auth.SSHLoginResponse, error) {
+	rd, err := NewRedirector(ctx, login)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -390,24 +435,24 @@ func SSHAgentSSOLogin(login SSHLogin) (*auth.SSHLoginResponse, error) {
 		return nil, trace.Wrap(trace.Errorf("timed out waiting for callback"))
 	case <-rd.Done():
 		log.Debugf("Canceled by user.")
-		return nil, trace.Wrap(login.Context.Err(), "cancelled by user")
+		return nil, trace.Wrap(ctx.Err(), "cancelled by user")
 	}
 }
 
 // SSHAgentLogin is used by tsh to fetch local user credentials.
-func SSHAgentLogin(ctx context.Context, proxyAddr string, user string, password string, otpToken string, pubKey []byte, ttl time.Duration, insecure bool, pool *x509.CertPool, compatibility string) (*auth.SSHLoginResponse, error) {
-	clt, _, err := initClient(proxyAddr, insecure, pool)
+func SSHAgentLogin(ctx context.Context, login SSHLoginDirect) (*auth.SSHLoginResponse, error) {
+	clt, _, err := initClient(login.ProxyAddr, login.Insecure, login.Pool)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	re, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "ssh", "certs"), CreateSSHCertReq{
-		User:          user,
-		Password:      password,
-		OTPToken:      otpToken,
-		PubKey:        pubKey,
-		TTL:           ttl,
-		Compatibility: compatibility,
+		User:          login.User,
+		Password:      login.Password,
+		OTPToken:      login.OTPToken,
+		PubKey:        login.PubKey,
+		TTL:           login.TTL,
+		Compatibility: login.Compatibility,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -427,22 +472,23 @@ func SSHAgentLogin(ctx context.Context, proxyAddr string, user string, password 
 // We then call the official u2f-host binary to perform the signing and pass
 // the signature to the proxy. If the authentication succeeds, we will get a
 // temporary certificate back.
-func SSHAgentU2FLogin(ctx context.Context, proxyAddr, user, password string, pubKey []byte, ttl time.Duration, insecure bool, pool *x509.CertPool, compatibility string) (*auth.SSHLoginResponse, error) {
-	clt, _, err := initClient(proxyAddr, insecure, pool)
+//func SSHAgentU2FLogin(ctx context.Context, proxyAddr, user, password string, pubKey []byte, ttl time.Duration, insecure bool, pool *x509.CertPool, compatibility string) (*auth.SSHLoginResponse, error) {
+func SSHAgentU2FLogin(ctx context.Context, login SSHLoginU2F) (*auth.SSHLoginResponse, error) {
+	clt, _, err := initClient(login.ProxyAddr, login.Insecure, login.Pool)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	u2fSignRequest, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "u2f", "signrequest"), U2fSignRequestReq{
-		User: user,
-		Pass: password,
+		User: login.User,
+		Pass: login.Password,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Pass the JSON-encoded data undecoded to the u2f-host binary
-	facet := "https://" + strings.ToLower(proxyAddr)
+	facet := "https://" + strings.ToLower(login.ProxyAddr)
 	cmd := exec.Command("u2f-host", "-aauthenticate", "-o", facet)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -464,7 +510,7 @@ func SSHAgentU2FLogin(ctx context.Context, proxyAddr, user, password string, pub
 
 	// The origin URL is passed back base64-encoded and the keyHandle is passed back as is.
 	// A very long proxy hostname or keyHandle can overflow a fixed-size buffer.
-	signResponseLen := 500 + len(u2fSignRequest.Bytes()) + len(proxyAddr)*4/3
+	signResponseLen := 500 + len(u2fSignRequest.Bytes()) + len(login.ProxyAddr)*4/3
 	signResponseBuf := make([]byte, signResponseLen)
 	signResponseLen, err = io.ReadFull(stdout, signResponseBuf)
 	// unexpected EOF means we have read the data completely.
@@ -493,11 +539,11 @@ func SSHAgentU2FLogin(ctx context.Context, proxyAddr, user, password string, pub
 	}
 
 	re, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "u2f", "certs"), CreateSSHCertWithU2FReq{
-		User:            user,
+		User:            login.User,
 		U2FSignResponse: *u2fSignResponse,
-		PubKey:          pubKey,
-		TTL:             ttl,
-		Compatibility:   compatibility,
+		PubKey:          login.PubKey,
+		TTL:             login.TTL,
+		Compatibility:   login.Compatibility,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -54,6 +54,9 @@ type SSOLoginConsoleReq struct {
 	CertTTL       time.Duration `json:"cert_ttl"`
 	ConnectorID   string        `json:"connector_id"`
 	Compatibility string        `json:"compatibility,omitempty"`
+	// RouteToCluster is an optional cluster name to route the response
+	// credentials to.
+	RouteToCluster string
 }
 
 // Check makes sure that the request is valid
@@ -101,6 +104,9 @@ type CreateSSHCertReq struct {
 	TTL time.Duration `json:"ttl"`
 	// Compatibility specifies OpenSSH compatibility flags.
 	Compatibility string `json:"compatibility,omitempty"`
+	// RouteToCluster is an optional cluster name to route the response
+	// credentials to.
+	RouteToCluster string
 }
 
 // CreateSSHCertWithU2FReq are passed by web client
@@ -119,6 +125,9 @@ type CreateSSHCertWithU2FReq struct {
 	TTL time.Duration `json:"ttl"`
 	// Compatibility specifies OpenSSH compatibility flags.
 	Compatibility string `json:"compatibility,omitempty"`
+	// RouteToCluster is an optional cluster name to route the response
+	// credentials to.
+	RouteToCluster string
 }
 
 // PingResponse contains data about the Teleport server like supported
@@ -159,6 +168,9 @@ type SSHLoginSSO struct {
 	// default (not currently implemented), or set to 'none' to suppress
 	// browser opening entirely.
 	Browser string
+	// RouteToCluster is an optional cluster name to route the response
+	// credentials to.
+	RouteToCluster string
 }
 
 // SSHLoginDirect contains SSH login parameters for direct (user/pass/OTP)
@@ -182,6 +194,9 @@ type SSHLoginDirect struct {
 	Pool *x509.CertPool
 	// Compatibility sets compatibility mode for SSH certificates
 	Compatibility string
+	// RouteToCluster is an optional cluster name to route the response
+	// credentials to.
+	RouteToCluster string
 }
 
 // SSHLoginU2F contains SSH login parameters for U2F login.
@@ -202,6 +217,9 @@ type SSHLoginU2F struct {
 	Pool *x509.CertPool
 	// Compatibility sets compatibility mode for SSH certificates
 	Compatibility string
+	// RouteToCluster is an optional cluster name to route the response
+	// credentials to.
+	RouteToCluster string
 }
 
 // ProxySettings contains basic information about proxy settings
@@ -447,12 +465,13 @@ func SSHAgentLogin(ctx context.Context, login SSHLoginDirect) (*auth.SSHLoginRes
 	}
 
 	re, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "ssh", "certs"), CreateSSHCertReq{
-		User:          login.User,
-		Password:      login.Password,
-		OTPToken:      login.OTPToken,
-		PubKey:        login.PubKey,
-		TTL:           login.TTL,
-		Compatibility: login.Compatibility,
+		User:           login.User,
+		Password:       login.Password,
+		OTPToken:       login.OTPToken,
+		PubKey:         login.PubKey,
+		TTL:            login.TTL,
+		Compatibility:  login.Compatibility,
+		RouteToCluster: login.RouteToCluster,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -544,6 +563,7 @@ func SSHAgentU2FLogin(ctx context.Context, login SSHLoginU2F) (*auth.SSHLoginRes
 		PubKey:          login.PubKey,
 		TTL:             login.TTL,
 		Compatibility:   login.Compatibility,
+		RouteToCluster:  login.RouteToCluster,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1696,7 +1696,7 @@ func (set RoleSet) CheckKubeGroupsAndUsers(ttl time.Duration) ([]string, []strin
 		return nil, nil, trace.AccessDenied("this user cannot request kubernetes access for %v", ttl)
 	}
 	if len(groups) == 0 && len(users) == 0 {
-		return nil, nil, trace.AccessDenied("this user cannot request kubernetes access, has no assigned groups or users")
+		return nil, nil, trace.NotFound("this user cannot request kubernetes access, has no assigned groups or users")
 	}
 	return utils.StringsSliceFromSet(groups), utils.StringsSliceFromSet(users), nil
 }

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1094,7 +1094,7 @@ func (h *Handler) createSession(w http.ResponseWriter, r *http.Request, p httpro
 		return nil, trace.AccessDenied("unknown second factor type: %q", cap.GetSecondFactor())
 	}
 	if err != nil {
-		return nil, trace.AccessDenied("bad auth credentials")
+		return nil, trace.AccessDenied("bad auth credentials: %v", err)
 	}
 
 	if err := SetSession(w, req.User, webSession.GetName()); err != nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1094,7 +1094,8 @@ func (h *Handler) createSession(w http.ResponseWriter, r *http.Request, p httpro
 		return nil, trace.AccessDenied("unknown second factor type: %q", cap.GetSecondFactor())
 	}
 	if err != nil {
-		return nil, trace.AccessDenied("bad auth credentials: %v", err)
+		log.Warningf("access attempt denied for user %q: %v", req.User, err)
+		return nil, trace.AccessDenied("bad auth credentials")
 	}
 
 	if err := SetSession(w, req.User, webSession.GetName()); err != nil {
@@ -1103,6 +1104,7 @@ func (h *Handler) createSession(w http.ResponseWriter, r *http.Request, p httpro
 
 	ctx, err := h.auth.ValidateSession(req.User, webSession.GetName())
 	if err != nil {
+		log.Warningf("access attempt denied for user %q: %v", req.User, err)
 		return nil, trace.AccessDenied("need auth")
 	}
 

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -463,6 +463,7 @@ func (s *sessionCache) GetCertificateWithoutOTP(c client.CreateSSHCertReq) (*aut
 		PublicKey:         c.PubKey,
 		CompatibilityMode: c.Compatibility,
 		TTL:               c.TTL,
+		RouteToCluster:    c.RouteToCluster,
 	})
 }
 
@@ -478,6 +479,7 @@ func (s *sessionCache) GetCertificateWithOTP(c client.CreateSSHCertReq) (*auth.S
 		PublicKey:         c.PubKey,
 		CompatibilityMode: c.Compatibility,
 		TTL:               c.TTL,
+		RouteToCluster:    c.RouteToCluster,
 	})
 
 }
@@ -493,6 +495,7 @@ func (s *sessionCache) GetCertificateWithU2F(c client.CreateSSHCertWithU2FReq) (
 		PublicKey:         c.PubKey,
 		CompatibilityMode: c.Compatibility,
 		TTL:               c.TTL,
+		RouteToCluster:    c.RouteToCluster,
 	})
 }
 


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/3735 into 4.2.
Original description:

TLS credentials on login appear different from them on re-issue.
Specifically, they are missing kube users/groups in Subject, as well as
`RouteToCluster`.

With this change, user can now do:
```
$ tsh login --proxy=root-proxy leaf-proxy
$ kubectl get ...
```
and kubectl commands will get routed through `root-proxy` to `leaf-proxy`
and contain proper kube principals for the user.

Another fix bundled here is advertising `kube.listen_addr` via proxy `Ping` RPC, along with existing `kube.public_addr`. If `listen_addr` used a custom port, the client wouldn't figure it out.

Fixes #3693