### PR TITLE
Cleanup closed remote cluster sessions from k8s forwarder cache

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -909,10 +909,16 @@ func (f *Forwarder) getClusterSession(ctx authContext) *clusterSession {
 	f.Lock()
 	defer f.Unlock()
 	creds, ok := f.clusterSessions.Get(ctx.key())
-	if ok {
-		return creds.(*clusterSession)
+	if !ok {
+		return nil
 	}
-	return nil
+	s := creds.(*clusterSession)
+	if s.cluster.isRemote && s.cluster.RemoteSite.IsClosed() {
+		f.Debugf("Found an existing clusterSession for remote cluster %q but it has been closed. Discarding it to create a new clusterSession.", ctx.cluster.GetName())
+		f.clusterSessions.Remove(ctx.key())
+		return nil
+	}
+	return s
 }
 
 func (f *Forwarder) serializedNewClusterSession(authContext authContext) (*clusterSession, error) {

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -92,6 +92,9 @@ type RemoteSite interface {
 	// GetTunnelsCount returns the amount of active inbound tunnels
 	// from the remote cluster
 	GetTunnelsCount() int
+	// IsClosed reports whether this RemoteSite has been closed and should no
+	// longer be used.
+	IsClosed() bool
 }
 
 // Server is a TCP/IP SSH server which listens on an SSH endpoint and remote/local

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -191,6 +191,9 @@ func (s *localSite) DialTCP(params DialParams) (net.Conn, error) {
 	return conn, nil
 }
 
+// IsClosed always returns false because localSite is never closed.
+func (s *localSite) IsClosed() bool { return false }
+
 func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 	s.log.Debugf("Dialing with an agent from %v to %v.", params.From, params.To)
 

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -132,6 +132,9 @@ func (p *clusterPeers) DialTCP(params DialParams) (conn net.Conn, err error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial, this proxy has not been discovered yet, try again later")
 }
 
+// IsClosed always returns false because clusterPeers is never closed.
+func (s *clusterPeers) IsClosed() bool { return false }
+
 // newClusterPeer returns new cluster peer
 func newClusterPeer(srv *server, connInfo services.TunnelConnection, offlineThreshold time.Duration) (*clusterPeer, error) {
 	clusterPeer := &clusterPeer{

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -175,6 +175,11 @@ func (s *remoteSite) Close() error {
 	return nil
 }
 
+// IsClosed reports whether this remoteSite has been closed.
+func (s *remoteSite) IsClosed() bool {
+	return s.ctx.Err() != nil
+}
+
 // nextConn returns next connection that is ready
 // and has not been marked as invalid
 // it will close connections marked as invalid


### PR DESCRIPTION
Background:

    Kube forwarder caches `clusterSession` objects for 1hr. These objects
    contain a `reversetunel.RemoteSite` wrapper for remote cluster tunnels.

    When an admin runs `tctl rm rc/leaf` on the root cluster, the tunnel
    gets closed. But kube forwarder cache retains a reference to it, which
    causes all requests to fails saying "node is offline".

    If admin then adds another leaf cluster with the same name, kube
    requests will still fail trying to use the old closed
    `reversetunnel.RemoteSite`, even though a new one has been established.

Fix:

    Check the status of the cached `RemoteSite` before using it. Discard
    it if it was closed.

Updates #3678