### PR TITLE
fix: open with RDWR for exclusive file lock

### DIFF
--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -219,7 +219,7 @@ func (u *Uploader) emitEvent(e UploadEvent) {
 }
 
 func (u *Uploader) uploadFile(lockFilePath string, sessionID session.ID) error {
-	lockFile, err := os.Open(lockFilePath)
+	lockFile, err := os.OpenFile(lockFilePath, os.O_RDWR, 0)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}


### PR DESCRIPTION
In order to place an exclusive lock on NFS storage, the file must be
opened for writing.

Fixes gravitational/teleport#3779

Signed-off-by: Dominic Evans <dominic.evans@uk.ibm.com>