### PR TITLE
Update account name for OTP token.

### DIFF
--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -781,20 +781,20 @@ func (s SortedReverseTunnels) Swap(i, j int) {
 // version will also be returned.
 //
 // Returns empty value if there are no proxies.
-func GuessProxyHostAndVersion(proxies []Server) (string, string) {
-	if len(proxies) < 1 {
-		return "", ""
+func GuessProxyHostAndVersion(proxies []Server) (string, string, error) {
+	if len(proxies) == 0 {
+		return "", "", trace.NotFound("list of proxies empty")
 	}
 
-	// find the first proxy with a public address set
+	// Find the first proxy with a public address set and return it.
 	for _, proxy := range proxies {
 		proxyHost := proxy.GetPublicAddr()
 		if proxyHost != "" {
-			return proxyHost, proxy.GetTeleportVersion()
+			return proxyHost, proxy.GetTeleportVersion(), nil
 		}
 	}
 
+	// No proxies have a public address set, return guessed value.
 	guessProxyHost := fmt.Sprintf("%v:%v", proxies[0].GetHostname(), defaults.HTTPListenPort)
-
-	return guessProxyHost, proxies[0].GetTeleportVersion()
+	return guessProxyHost, proxies[0].GetTeleportVersion(), nil
 }

--- a/lib/web/ui/cluster.go
+++ b/lib/web/ui/cluster.go
@@ -79,7 +79,10 @@ func GetClusterDetails(site reversetunnel.RemoteSite) (*Cluster, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	proxyHost, proxyVersion := services.GuessProxyHostAndVersion(proxies)
+	proxyHost, proxyVersion, err := services.GuessProxyHostAndVersion(proxies)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	authServers, err := clt.GetAuthServers()
 	if err != nil {


### PR DESCRIPTION
**Description**

Update account name in OTP token to first attempt to get the public address of one of the proxies, if not available then fallback to the hostname of the first proxy, if not available then fallback to the name of the cluster, if not available fallback to the hostname of the auth server.

**Related PRs**

Originally implemented in by @sh7dm https://github.com/gravitational/teleport/pull/3485.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/3318