### PR TITLE
errcheck: fix findings in lib/backend, lib/client

### DIFF
--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -294,9 +294,8 @@ func (w *BufferWatcher) Close() error {
 }
 
 // closeWatcher closes watcher
-func (w *BufferWatcher) closeWatcher() error {
+func (w *BufferWatcher) closeWatcher() {
 	w.cancel()
-	return nil
 }
 
 const (
@@ -308,14 +307,13 @@ const (
 // be called multiple times, removes the watcher
 // from the buffer queue synchronously (used in tests)
 // or asyncronously, used in prod, to avoid potential deadlocks
-func (w *BufferWatcher) closeAndRemove(sync bool) error {
+func (w *BufferWatcher) closeAndRemove(sync bool) {
 	w.closeWatcher()
 	if sync {
 		w.buffer.removeWatcherWithLock(w)
 	} else {
 		go w.buffer.removeWatcherWithLock(w)
 	}
-	return nil
 }
 
 func newWatcherTree() *watcherTree {

--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -35,7 +35,9 @@ func (l *LiteBackend) runPeriodicOperations() {
 	for {
 		select {
 		case <-l.ctx.Done():
-			l.closeDatabase()
+			if err := l.closeDatabase(); err != nil {
+				l.Warningf("Error closing database: %v", err)
+			}
 			return
 		case <-t.C:
 			err := l.removeExpiredKeys()

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -353,9 +353,9 @@ func (c *Cache) update() {
 // setCacheState for "only recent" cache behavior will erase
 // the cache and set error mode to refuse to serve stale data,
 // otherwise does nothing
-func (c *Cache) setCacheState(err error) error {
+func (c *Cache) setCacheState(err error) {
 	if !c.OnlyRecent.Enabled {
-		return err
+		return
 	}
 	if err := c.eraseAll(); err != nil {
 		if !c.isClosed() {
@@ -363,7 +363,6 @@ func (c *Cache) setCacheState(err error) error {
 		}
 	}
 	c.wrapper.SetReadError(trace.ConnectionProblem(err, "cache is unavailable"))
-	return err
 }
 
 // setTTL overrides TTL supplied by the resource

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1021,7 +1021,7 @@ func (tc *TeleportClient) SSH(ctx context.Context, command []string, runLocally 
 	return tc.runShell(nodeClient, nil)
 }
 
-func (tc *TeleportClient) startPortForwarding(ctx context.Context, nodeClient *NodeClient) error {
+func (tc *TeleportClient) startPortForwarding(ctx context.Context, nodeClient *NodeClient) {
 	if len(tc.Config.LocalForwardPorts) > 0 {
 		for _, fp := range tc.Config.LocalForwardPorts {
 			addr := net.JoinHostPort(fp.SrcIP, strconv.Itoa(fp.SrcPort))
@@ -1044,7 +1044,6 @@ func (tc *TeleportClient) startPortForwarding(ctx context.Context, nodeClient *N
 			go nodeClient.dynamicListenAndForward(ctx, socket)
 		}
 	}
-	return nil
 }
 
 // Join connects to the existing/active SSH session

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -85,7 +85,9 @@ func (proxy *ProxyClient) GetSites() ([]services.Site, error) {
 	}
 	done := make(chan struct{})
 	go func() {
-		io.Copy(stdout, reader)
+		if _, err := io.Copy(stdout, reader); err != nil {
+			log.Warningf("Error reading STDOUT from proxy: %v", err)
+		}
 		close(done)
 	}()
 	// this function is async because,

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -204,9 +204,9 @@ func (s *KeyAgentTestSuite) TestLoadKey(c *check.C) {
 	sshPublicKey := sshSigner.PublicKey()
 
 	// verify data signed by both the teleport agent and system agent was signed correctly
-	sshPublicKey.Verify(userdata, teleportAgentSignature)
+	err = sshPublicKey.Verify(userdata, teleportAgentSignature)
 	c.Assert(err, check.IsNil)
-	sshPublicKey.Verify(userdata, systemAgentSignature)
+	err = sshPublicKey.Verify(userdata, systemAgentSignature)
 	c.Assert(err, check.IsNil)
 
 	// unload all keys from the teleport agent and system agent

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -287,7 +287,6 @@ func (fs *FSLocalKeyStore) SaveCerts(proxy string, cas []auth.TrustedCerts) erro
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer fp.Sync()
 	defer fp.Close()
 	for _, ca := range cas {
 		for _, cert := range ca.TLSCertificates {
@@ -301,7 +300,7 @@ func (fs *FSLocalKeyStore) SaveCerts(proxy string, cas []auth.TrustedCerts) erro
 			}
 		}
 	}
-	return nil
+	return fp.Sync()
 }
 
 // GetCertsPEM returns trusted TLS certificates of certificate authorities PEM
@@ -364,7 +363,6 @@ func (fs *FSLocalKeyStore) AddKnownHostKeys(hostname string, hostKeys []ssh.Publ
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer fp.Sync()
 	defer fp.Close()
 	// read all existing entries into a map (this removes any pre-existing dupes)
 	entries := make(map[string]int)
@@ -397,7 +395,7 @@ func (fs *FSLocalKeyStore) AddKnownHostKeys(hostname string, hostKeys []ssh.Publ
 	for _, line := range output {
 		fmt.Fprintf(fp, "%s\n", line)
 	}
-	return nil
+	return fp.Sync()
 }
 
 // GetKnownHostKeys returns all known public keys from 'known_hosts'

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -172,7 +172,8 @@ func (s *KeyStoreTestSuite) TestDeleteAll(c *check.C) {
 }
 
 func (s *KeyStoreTestSuite) TestKnownHosts(c *check.C) {
-	os.MkdirAll(s.store.KeyDir, 0777)
+	err := os.MkdirAll(s.store.KeyDir, 0777)
+	c.Assert(err, check.IsNil)
 	pub, _, _, _, err := ssh.ParseAuthorizedKey(CAPub)
 	c.Assert(err, check.IsNil)
 
@@ -193,8 +194,10 @@ func (s *KeyStoreTestSuite) TestKnownHosts(c *check.C) {
 
 	// check against dupes:
 	before, _ := s.store.GetKnownHostKeys("")
-	s.store.AddKnownHostKeys("example.org", []ssh.PublicKey{pub2})
-	s.store.AddKnownHostKeys("example.org", []ssh.PublicKey{pub2})
+	err = s.store.AddKnownHostKeys("example.org", []ssh.PublicKey{pub2})
+	c.Assert(err, check.IsNil)
+	err = s.store.AddKnownHostKeys("example.org", []ssh.PublicKey{pub2})
+	c.Assert(err, check.IsNil)
 	after, _ := s.store.GetKnownHostKeys("")
 	c.Assert(len(before), check.Equals, len(after))
 

--- a/lib/client/profile_test.go
+++ b/lib/client/profile_test.go
@@ -55,7 +55,8 @@ func (s *ProfileTestSuite) TestEverything(c *check.C) {
 	c.Assert(os.IsNotExist(err), check.Equals, true)
 
 	// save again, this time with a symlink:
-	p.SaveTo(ProfileLocation{Path: pfile, Options: ProfileMakeCurrent})
+	err = p.SaveTo(ProfileLocation{Path: pfile, Options: ProfileMakeCurrent})
+	c.Assert(err, check.IsNil)
 	stat, err := os.Stat(symlink)
 	c.Assert(err, check.IsNil)
 	c.Assert(stat.Size() > 10, check.Equals, true)

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -280,7 +280,9 @@ func (ns *NodeSession) allocateTerminal(termType string, s *ssh.Session) (io.Rea
 		go ns.updateTerminalSize(s)
 	}
 	go func() {
-		io.Copy(os.Stderr, stderr)
+		if _, err := io.Copy(os.Stderr, stderr); err != nil {
+			log.Debugf("Error reading remote STDERR: %v", err)
+		}
 	}()
 	return utils.NewPipeNetConn(
 		reader,

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -807,7 +807,9 @@ func (l *AuditLog) getSessionChunk(namespace string, sid session.ID, offsetBytes
 	defer reader.Close()
 
 	// seek to 'offset' from the beginning
-	reader.Seek(int64(offsetBytes)-fileOffset, 0)
+	if _, err := reader.Seek(int64(offsetBytes)-fileOffset, 0); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	// copy up to maxBytes from the offset position:
 	var buff bytes.Buffer


### PR DESCRIPTION
Most common culprit so far is `EmitAuditEvent`. Perhaps it should always log errors internally?