### PR TITLE
Prevent a username oracle via user lockout checks

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -578,6 +578,12 @@ func (s *AuthServer) generateUserCert(req certRequest) (*certs, error) {
 func (s *AuthServer) WithUserLock(username string, authenticateFn func() error) error {
 	user, err := s.Identity.GetUser(username, false)
 	if err != nil {
+		if trace.IsNotFound(err) {
+			// If user is not found, still call authenticateFn. It should
+			// always return an error. This prevents username oracles and
+			// timing attacks.
+			return authenticateFn()
+		}
 		return trace.Wrap(err)
 	}
 	status := user.GetStatus()

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -126,7 +126,7 @@ func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
 			// provide obscure message on purpose, while logging the real
 			// error server side
 			log.Debugf("Failed to authenticate: %v.", err)
-			return trace.AccessDenied(err.Error())
+			return trace.AccessDenied("invalid username or password")
 		}
 		return nil
 	case req.U2F != nil:

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -119,7 +119,8 @@ func (s *PasswordSuite) TestTiming(c *C) {
 	var elapsedNotExists time.Duration
 	for i := 0; i < 10; i++ {
 		start := time.Now()
-		s.a.CheckPasswordWOToken("blah", []byte(password))
+		err = s.a.CheckPasswordWOToken("blah", []byte(password))
+		c.Assert(err, NotNil)
 		elapsed := time.Since(start)
 		elapsedNotExists = elapsedNotExists + elapsed
 	}
@@ -128,6 +129,16 @@ func (s *PasswordSuite) TestTiming(c *C) {
 	elapsedDifference := elapsedExists/10 - elapsedNotExists/10
 	comment := Commentf("elapsed difference (%v) greater than 40 ms", elapsedDifference)
 	c.Assert(elapsedDifference.Seconds() < 0.040, Equals, true, comment)
+}
+
+func (s *PasswordSuite) TestUserNotFound(c *C) {
+	username := "unknown-user"
+	password := "barbaz"
+
+	err := s.a.CheckPasswordWOToken(username, []byte(password))
+	c.Assert(err, NotNil)
+	// Make sure the error is not a NotFound. That would be a username oracle.
+	c.Assert(trace.IsBadParameter(err), Equals, true)
 }
 
 func (s *PasswordSuite) TestChangePassword(c *C) {


### PR DESCRIPTION
User lockout check (auth.WithUserLock) would fail early in case a login
for unknown user was requested. The error is "user not found".
This can be used to enumerate the available Teleport users.
Even if the error message was more generic, timing can be trivially used
to infer whether a password was checked (bcrypt takes a while).

To avoid this, run the regular authentication flow regardless if the
user was found and return the generic "username or password invalid"
error.

Relatedly, fix a bug in the password verification. There's a timing
mitigation logic that replaces the expected password hash with a fake
one to perform a full bcrypt check. This fake has was for password
"barbaz".
If a login was requested for unknown user with password "barbaz", the
check would pass. Fortunately, the above user existence check in
auth.WithUserLock prevented this code path.