### PR TITLE
etcd prefix fix and migration for 4.3

### DIFF
--- a/examples/etcd/start-etcd.sh
+++ b/examples/etcd/start-etcd.sh
@@ -7,7 +7,7 @@
 # NOTE: this file is also used to run etcd tests.
 #
 
-EXAMPLES_DIR=$GOPATH/src/github.com/gravitational/teleport/examples/etcd
+EXAMPLES_DIR=$(go env GOPATH)/src/github.com/gravitational/teleport/examples/etcd
 
 HERE=$(readlink -f $0)
 cd $(dirname $HERE)

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -80,6 +80,10 @@ type Backend interface {
 	// CloseWatchers closes all the watchers
 	// without closing the backend
 	CloseWatchers()
+
+	// Migrate performs any data migration necessary between Teleport versions.
+	// Migrate must be called BEFORE using any other methods of the Backend.
+	Migrate(context.Context) error
 }
 
 // Batch implements some batch methods
@@ -331,3 +335,9 @@ const Separator = '/'
 func Key(parts ...string) []byte {
 	return []byte(strings.Join(append([]string{""}, parts...), string(Separator)))
 }
+
+// NoMigrations implements a nop Migrate method of Backend.
+// Backend implementations should embed this when no migrations are necessary.
+type NoMigrations struct{}
+
+func (NoMigrations) Migrate(context.Context) error { return nil }

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -96,6 +96,7 @@ func (cfg *DynamoConfig) CheckAndSetDefaults() error {
 type DynamoDBBackend struct {
 	*log.Entry
 	DynamoConfig
+	backend.NoMigrations
 	svc              *dynamodb.DynamoDB
 	streams          *dynamodbstreams.DynamoDBStreams
 	clock            clockwork.Clock

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -224,11 +224,6 @@ func New(ctx context.Context, params backend.Params) (*EtcdBackend, error) {
 	if err = b.reconnect(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// DELETE IN 4.4: legacy prefix support for migration of
-	// https://github.com/gravitational/teleport/issues/2883
-	if err := b.syncLegacyPrefix(ctx); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	// Wrap backend in a input sanitizer and return it.
 	return b, nil
 }
@@ -713,6 +708,15 @@ func (b *EtcdBackend) fromEvent(ctx context.Context, e clientv3.Event) (*backend
 	}
 	event.Item.Value = value
 	return event, nil
+}
+
+func (b *EtcdBackend) Migrate(ctx context.Context) error {
+	// DELETE IN 4.4: legacy prefix support for migration of
+	// https://github.com/gravitational/teleport/issues/2883
+	if err := b.syncLegacyPrefix(ctx); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 // DELETE IN 4.4: legacy prefix support for migration of

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -557,7 +557,7 @@ func (b *EtcdBackend) Put(ctx context.Context, item backend.Item) (*backend.Leas
 		start = b.clock.Now()
 		_, err = b.client.Put(
 			ctx,
-			b.prependPrefix(item.Key),
+			b.prependLegacyPrefix(item.Key),
 			base64.StdEncoding.EncodeToString(item.Value),
 			opts...)
 		writeLatencies.Observe(time.Since(start).Seconds())
@@ -630,7 +630,7 @@ func (b *EtcdBackend) Delete(ctx context.Context, key []byte) error {
 	// https://github.com/gravitational/teleport/issues/2883
 	if b.replicateToLegacyPrefix {
 		start = b.clock.Now()
-		re, err = b.client.Delete(ctx, b.prependPrefix(key))
+		re, err = b.client.Delete(ctx, b.prependLegacyPrefix(key))
 		writeLatencies.Observe(time.Since(start).Seconds())
 		writeRequests.Inc()
 		if err != nil {
@@ -661,7 +661,7 @@ func (b *EtcdBackend) DeleteRange(ctx context.Context, startKey, endKey []byte) 
 	// https://github.com/gravitational/teleport/issues/2883
 	if b.replicateToLegacyPrefix {
 		start = b.clock.Now()
-		_, err = b.client.Delete(ctx, b.prependPrefix(startKey), clientv3.WithRange(b.prependPrefix(endKey)))
+		_, err = b.client.Delete(ctx, b.prependLegacyPrefix(startKey), clientv3.WithRange(b.prependLegacyPrefix(endKey)))
 		writeLatencies.Observe(time.Since(start).Seconds())
 		writeRequests.Inc()
 		if err != nil {

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -49,7 +49,7 @@ func (s *EtcdSuite) SetUpSuite(c *check.C) {
 	// this config must match examples/etcd/teleport.yaml
 	s.config = backend.Params{
 		"peers":         []string{"https://127.0.0.1:2379"},
-		"prefix":        "teleport.secrets/",
+		"prefix":        "/teleport",
 		"tls_key_file":  "../../../examples/etcd/certs/client-key.pem",
 		"tls_cert_file": "../../../examples/etcd/certs/client-cert.pem",
 		"tls_ca_file":   "../../../examples/etcd/certs/ca-cert.pem",
@@ -148,6 +148,7 @@ func (s *EtcdSuite) TestPrefix(c *check.C) {
 		}
 	)
 
+	s.bk.cfg.Key = "/custom-prefix"
 	_, err := s.bk.Put(ctx, item)
 	c.Assert(err, check.IsNil)
 	defer s.bk.Delete(ctx, item.Key)

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -92,6 +92,7 @@ func (cfg *backendConfig) CheckAndSetDefaults() error {
 type FirestoreBackend struct {
 	*log.Entry
 	backendConfig
+	backend.NoMigrations
 	// svc is the primary Firestore client
 	svc *firestore.Client
 	// clock is the

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -184,6 +184,7 @@ func NewWithConfig(ctx context.Context, cfg Config) (*LiteBackend, error) {
 type LiteBackend struct {
 	Config
 	*log.Entry
+	backend.NoMigrations
 	db *sql.DB
 	// clock is used to generate time,
 	// could be swapped in tests for fixed time

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -116,6 +116,7 @@ type Memory struct {
 	*sync.Mutex
 	*log.Entry
 	Config
+	backend.NoMigrations
 	// tree is a BTree with items
 	tree *btree.BTree
 	// heap is a min heap with expiry records

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -216,6 +216,9 @@ func (s *Reporter) Clock() clockwork.Clock {
 	return s.Backend.Clock()
 }
 
+// Migrate runs the necessary data migrations for this backend.
+func (s *Reporter) Migrate(ctx context.Context) error { return s.Backend.Migrate(ctx) }
+
 // trackRequests tracks top requests, endKey is supplied for ranges
 func (s *Reporter) trackRequest(opType OpType, key []byte, endKey []byte) {
 	if !s.TrackTopRequests {

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -162,3 +162,6 @@ func (s *Sanitizer) Clock() clockwork.Clock {
 func (s *Sanitizer) CloseWatchers() {
 	s.backend.CloseWatchers()
 }
+
+// Migrate runs the necessary data migrations for this backend.
+func (s *Sanitizer) Migrate(ctx context.Context) error { return s.backend.Migrate(ctx) }

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -80,6 +80,7 @@ func (s *Suite) TestSanitizeBucket(c *check.C) {
 }
 
 type nopBackend struct {
+	NoMigrations
 }
 
 func (n *nopBackend) Get(_ context.Context, _ []byte) (*Item, error) {

--- a/lib/backend/wrap.go
+++ b/lib/backend/wrap.go
@@ -136,3 +136,6 @@ func (s *Wrapper) CloseWatchers() {
 func (s *Wrapper) Clock() clockwork.Clock {
 	return s.backend.Clock()
 }
+
+// Migrate runs the necessary data migrations for this backend.
+func (s *Wrapper) Migrate(ctx context.Context) error { return s.backend.Migrate(ctx) }


### PR DESCRIPTION
See https://github.com/gravitational/teleport/issues/2883 for context.
This PR makes the etcd backend _actually_ use the prefix specified in config file. It also migrates the data from the old prefix as needed.

Specific changes are:
1. always use the `teleport.backend.prefix` field for etcd storage (instead of hardcoded `/teleport`)
2. at startup, overwrite any config prefix data with data from `/teleport` iff (a) `/teleport` has some data and (b) config prefix is empty (initial 4.2->4.3 upgrade) or has older data than `/teleport` (upgrade 4.2->4.3, downgrade 4.3->4.2, make some data changes and upgrade 4.2->4.3 again)

This startup copying is blocking - teleport won't start until it's complete.

All of this assumes that there's only 1 auth server during an upgrade, per our upgrade docs.