### PR TITLE
Fix ExecSuite.TestOSCommandPrep test when running as root user

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -42,6 +42,8 @@ import (
 const (
 	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin"
 	defaultEnvPath       = "PATH=" + defaultPath
+	defaultSuPath        = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	defaultEnvSuPath     = "PATH=" + defaultSuPath
 	defaultTerm          = "xterm"
 	defaultLoginDefsPath = "/etc/login.defs"
 )
@@ -421,21 +423,25 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 }
 
 // getDefaultEnvPath returns the default value of PATH environment variable for
-// new logins (prior to shell) based on login.defs. Returns a strings which
+// new logins (prior to shell) based on login.defs. Returns a string which
 // looks like "PATH=/usr/bin:/bin"
 func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	envPath := defaultEnvPath
-	envSuPath := defaultEnvPath
+	envSuPath := defaultEnvSuPath
 
 	// open file, if it doesn't exist return a default path and move on
 	f, err := os.Open(loginDefsPath)
+	defer f.Close()
 	if err != nil {
+		if uid == "0" {
+			log.Infof("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvSuPath)
+			return defaultEnvSuPath
+		}
 		log.Infof("Unable to open %q: %v: returning default path: %q", loginDefsPath, err, defaultEnvPath)
 		return defaultEnvPath
 	}
-	defer f.Close()
 
-	// read path to login.defs file /etc/login.defs line by line:
+	// read path from login.defs file (/etc/login.defs) line by line:
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -445,7 +451,7 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 			continue
 		}
 
-		// look for a line that starts with ENV_SUPATH or ENV_PATH
+		// look for a line that starts with ENV_PATH or ENV_SUPATH
 		fields := strings.Fields(line)
 		if len(fields) > 1 {
 			if fields[0] == "ENV_PATH" {
@@ -460,6 +466,10 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	// if any error occurs while reading the file, return the default value
 	err = scanner.Err()
 	if err != nil {
+		if uid == "0" {
+			log.Warnf("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvSuPath)
+			return defaultEnvSuPath
+		}
 		log.Warnf("Unable to read %q: %v: returning default path: %q", loginDefsPath, err, defaultEnvPath)
 		return defaultEnvPath
 	}
@@ -468,7 +478,7 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	// ENV_PATH first, then the default path.
 	if uid == "0" {
 		if envSuPath == defaultEnvPath {
-			return envPath
+			return defaultEnvPath
 		}
 		return envSuPath
 	}

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -42,8 +42,8 @@ import (
 const (
 	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin"
 	defaultEnvPath       = "PATH=" + defaultPath
-	defaultSuPath        = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	defaultEnvSuPath     = "PATH=" + defaultSuPath
+	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	defaultEnvRootPath   = "PATH=" + defaultRootPath
 	defaultTerm          = "xterm"
 	defaultLoginDefsPath = "/etc/login.defs"
 )
@@ -427,14 +427,14 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 // looks like "PATH=/usr/bin:/bin"
 func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	envPath := defaultEnvPath
-	envSuPath := defaultEnvSuPath
+	envRootPath := defaultEnvRootPath
 
 	// open file, if it doesn't exist return a default path and move on
 	f, err := os.Open(loginDefsPath)
 	if err != nil {
 		if uid == "0" {
-			log.Infof("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvSuPath)
-			return defaultEnvSuPath
+			log.Infof("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvRootPath)
+			return defaultEnvRootPath
 		}
 		log.Infof("Unable to open %q: %v: returning default path: %q", loginDefsPath, err, defaultEnvPath)
 		return defaultEnvPath
@@ -458,7 +458,7 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 				envPath = fields[1]
 			}
 			if fields[0] == "ENV_SUPATH" {
-				envSuPath = fields[1]
+				envRootPath = fields[1]
 			}
 		}
 	}
@@ -467,8 +467,8 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	err = scanner.Err()
 	if err != nil {
 		if uid == "0" {
-			log.Warnf("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvSuPath)
-			return defaultEnvSuPath
+			log.Warnf("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvRootPath)
+			return defaultEnvRootPath
 		}
 		log.Warnf("Unable to read %q: %v: returning default path: %q", loginDefsPath, err, defaultEnvPath)
 		return defaultEnvPath
@@ -477,10 +477,7 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	// if requesting path for uid 0 and no ENV_SUPATH is given, fallback to
 	// ENV_PATH first, then the default path.
 	if uid == "0" {
-		if envSuPath == defaultEnvPath {
-			return defaultEnvPath
-		}
-		return envSuPath
+		return envRootPath
 	}
 	return envPath
 }

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -431,7 +431,6 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 
 	// open file, if it doesn't exist return a default path and move on
 	f, err := os.Open(loginDefsPath)
-	defer f.Close()
 	if err != nil {
 		if uid == "0" {
 			log.Infof("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvSuPath)
@@ -440,6 +439,7 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 		log.Infof("Unable to open %q: %v: returning default path: %q", loginDefsPath, err, defaultEnvPath)
 		return defaultEnvPath
 	}
+	defer f.Close()
 
 	// read path from login.defs file (/etc/login.defs) line by line:
 	scanner := bufio.NewScanner(f)

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -145,7 +145,7 @@ func (s *ExecSuite) TearDownSuite(c *check.C) {
 func (s *ExecSuite) TestOSCommandPrep(c *check.C) {
 	expectedEnv := []string{
 		"LANG=en_US.UTF-8",
-		getDefaultEnvPath("1000", defaultLoginDefsPath),
+		getDefaultEnvPath(strconv.Itoa(os.Geteuid()), defaultLoginDefsPath),
 		fmt.Sprintf("HOME=%s", s.usr.HomeDir),
 		fmt.Sprintf("USER=%s", s.usr.Username),
 		"SHELL=/bin/sh",


### PR DESCRIPTION
While trying to implement the Teleport test pipeline in Drone, I noticed that we have a weird bug where if you run the tests in CI as `root` (which Drone does) and `ENV_SUPATH` is set in `/etc/login.defs`, the `ExecSuite.TestOSCommandPrep` test fails. This is because regardless of which actual user is running the command, we were always setting the expected path based on UID 1000.

```
FAIL: exec_test.go:145: 

exec_test.go:172:
c.Assert(cmd.Env, check.DeepEquals, expectedEnv)
... obtained []string = []string{"LANG=en_US.UTF-8", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "HOME=/root", "USER=root", "SHELL=/bin/sh", "SSH_CLIENT=10.0.0.5 4817 3022", "SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022", "TERM=xterm", "SSH_TTY=/dev/pts/0", "SSH_SESSION_ID=xxx", "SSH_SESSION_WEBPROXY_ADDR=<proxyhost>:3080", "SSH_TELEPORT_HOST_UUID=00000000-0000-0000-0000-000000000000", "SSH_TELEPORT_CLUSTER_NAME=localhost", "SSH_TELEPORT_USER=galt"}
... expected []string = []string{"LANG=en_US.UTF-8", "PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games", "HOME=/root", "USER=root", "SHELL=/bin/sh", "SSH_CLIENT=10.0.0.5 4817 3022", "SSH_CONNECTION=10.0.0.5 4817 127.0.0.1 3022", "TERM=xterm", "SSH_TTY=/dev/pts/0", "SSH_SESSION_ID=xxx", "SSH_SESSION_WEBPROXY_ADDR=<proxyhost>:3080", "SSH_TELEPORT_HOST_UUID=00000000-0000-0000-0000-000000000000", "SSH_TELEPORT_CLUSTER_NAME=localhost", "SSH_TELEPORT_USER=galt"}
```