### PR TITLE
Ensure that disconnects propagate through port-forwarded tunnel

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -950,6 +950,8 @@ func (s *Server) handleDirectTCPIPRequest(ccx *sshutils.ConnectionContext, ident
 	if err != nil {
 		writeStderr(channel, err.Error())
 	}
+	// Propagate stderr from the spawned Teleport process to log any errors.
+	cmd.Stderr = os.Stderr
 
 	// Create a pipe for std{in,out} that will be used to transfer data between
 	// parent and child.
@@ -974,6 +976,7 @@ func (s *Server) handleDirectTCPIPRequest(ccx *sshutils.ConnectionContext, ident
 	// pipe to channel.
 	errorCh := make(chan error, 2)
 	go func() {
+		defer channel.Close()
 		defer pw.Close()
 		defer pr.Close()
 
@@ -981,6 +984,7 @@ func (s *Server) handleDirectTCPIPRequest(ccx *sshutils.ConnectionContext, ident
 		errorCh <- err
 	}()
 	go func() {
+		defer channel.Close()
 		defer pw.Close()
 		defer pr.Close()
 


### PR DESCRIPTION
When a client terminates, it should propagate over to the server on
remote host without it attempting to write. The defered cleanup wasn't
closing all the right connections to make this happen.

When a server terminates, re-execed teleport might not notice until
client sends new data. Re-execed teleport should exit on first observed
error in either direction and not wait for both ends.

Fixes #3749