### PR TITLE
fix delete event filtering in fanout

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -280,6 +280,12 @@ func (s *CacheSuite) TestWatchers(c *check.C) {
 		{
 			Kind: services.KindCertAuthority,
 		},
+		{
+			Kind: services.KindAccessRequest,
+			Filter: map[string]string{
+				"user": "alice",
+			},
+		},
 	}})
 	c.Assert(err, check.IsNil)
 	defer w.Close()
@@ -298,6 +304,50 @@ func (s *CacheSuite) TestWatchers(c *check.C) {
 	case e := <-w.Events():
 		c.Assert(e.Type, check.Equals, backend.OpPut)
 		c.Assert(e.Resource.GetKind(), check.Equals, services.KindCertAuthority)
+	case <-time.After(time.Second):
+		c.Fatalf("Timeout waiting for event.")
+	}
+
+	// create an access request that matches the supplied filter
+	req, err := services.NewAccessRequest("alice", "dictator")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(p.dynamicAccessS.CreateAccessRequest(context.TODO(), req), check.IsNil)
+
+	select {
+	case e := <-w.Events():
+		c.Assert(e.Type, check.Equals, backend.OpPut)
+		c.Assert(e.Resource.GetKind(), check.Equals, services.KindAccessRequest)
+	case <-time.After(time.Second):
+		c.Fatalf("Timeout waiting for event.")
+	}
+
+	c.Assert(p.dynamicAccessS.DeleteAccessRequest(context.TODO(), req.GetName()), check.IsNil)
+
+	select {
+	case e := <-w.Events():
+		c.Assert(e.Type, check.Equals, backend.OpDelete)
+		c.Assert(e.Resource.GetKind(), check.Equals, services.KindAccessRequest)
+	case <-time.After(time.Second):
+		c.Fatalf("Timeout waiting for event.")
+	}
+
+	// create an access request that does not match the supplied filter
+	req2, err := services.NewAccessRequest("bob", "dictator")
+	c.Assert(err, check.IsNil)
+
+	// create and then delete the non-matching request.
+	c.Assert(p.dynamicAccessS.CreateAccessRequest(context.TODO(), req2), check.IsNil)
+	c.Assert(p.dynamicAccessS.DeleteAccessRequest(context.TODO(), req2.GetName()), check.IsNil)
+
+	// because our filter did not match the request, the create event should never
+	// have been created, meaning that the next event on the pipe is the delete
+	// event (which cannot be filtered out because username is not visible inside
+	// a delete event).
+	select {
+	case e := <-w.Events():
+		c.Assert(e.Type, check.Equals, backend.OpDelete)
+		c.Assert(e.Resource.GetKind(), check.Equals, services.KindAccessRequest)
 	case <-time.After(time.Second):
 		c.Fatalf("Timeout waiting for event.")
 	}

--- a/lib/services/events.go
+++ b/lib/services/events.go
@@ -65,11 +65,9 @@ func (kind WatchKind) Matches(e Event) (bool, error) {
 	if kind.Name != "" && kind.Name != e.Resource.GetName() {
 		return false, nil
 	}
-	if len(kind.Filter) > 0 {
-		// no filters currently match delete events
-		if e.Type != backend.OpPut {
-			return false, nil
-		}
+	// we don't have a good model for filtering non-put events,
+	// so only apply filters to OpPut events.
+	if len(kind.Filter) > 0 && e.Type == backend.OpPut {
 		// Currently only access request make use of filters,
 		// so expect the resource to be an access request.
 		req, ok := e.Resource.(AccessRequest)


### PR DESCRIPTION
The initial implementation of event fanout logic for the cache was incorrectly applying filters to delete events.  Because the deleted resource cannot be inspected during a delete event, it isn't possible to determine if a filter should match.  Instead of matching all delete events and letting the caller determine their relevance (which is how teleport handles this problem elsewhere) the fanout logic was never matching delete events.

Fixes #3806 