### PR TITLE
Unit tests for lib/kube/proxy

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -663,7 +663,7 @@ const (
 )
 
 func (f *Forwarder) setupForwardingHeaders(ctx *authContext, sess *clusterSession, req *http.Request) error {
-	if err := setupImpersonationHeaders(f.Entry, ctx, req.Header); err != nil {
+	if err := setupImpersonationHeaders(ctx, req.Header); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -677,12 +677,13 @@ func (f *Forwarder) setupForwardingHeaders(ctx *authContext, sess *clusterSessio
 	req.Header.Add("X-Forwarded-Proto", "https")
 	req.Header.Add("X-Forwarded-Host", req.Host)
 	req.Header.Add("X-Forwarded-Path", req.URL.Path)
+	req.Header.Add("X-Forwarded-For", req.RemoteAddr)
 
 	return nil
 }
 
 // setupImpersonationHeaders sets up Impersonate-User and Impersonate-Group headers
-func setupImpersonationHeaders(log log.FieldLogger, ctx *authContext, headers http.Header) error {
+func setupImpersonationHeaders(ctx *authContext, headers http.Header) error {
 	var impersonateUser string
 	var impersonateGroups []string
 	for header, values := range headers {

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -276,6 +276,7 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 		isRemoteUser = true
 	case auth.BuiltinRole:
 		f.Warningf("Denying proxy access to unauthenticated user of type %T - this can sometimes be caused by inadvertently using an HTTP load balancer instead of a TCP load balancer on the Kubernetes port.", userTypeI)
+		return nil, trace.AccessDenied(accessDeniedMsg)
 	default:
 		f.Warningf("Denying proxy access to unsupported user type: %T.", userTypeI)
 		return nil, trace.AccessDenied(accessDeniedMsg)

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -276,14 +276,6 @@ func (s ForwarderSuite) TestAuthenticate(c *check.C) {
 	}
 }
 
-func (s ForwarderSuite) TestExec(c *check.C) {
-	c.Fatal("TODO")
-}
-
-func (s ForwarderSuite) TestPortForward(c *check.C) {
-	c.Fatal("TODO")
-}
-
 func (s ForwarderSuite) TestSetupImpersonationHeaders(c *check.C) {
 	tests := []struct {
 		desc          string

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	log "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -157,7 +156,7 @@ func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	header.Add(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
 	header.Add(httpstream.HeaderUpgrade, streamspdy.HeaderSpdy31)
 
-	if err := setupImpersonationHeaders(log.StandardLogger(), &s.authCtx, header); err != nil {
+	if err := setupImpersonationHeaders(&s.authCtx, header); err != nil {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
In addition to tests, two small tweaks:
- deny authentication for teleport services (nodes/proxies/auth), only local and remote users allowed
- add `X-Forwarded-For` header to propagate real client IP to k8s

Fixes #3573