### PR TITLE
lib/kube/proxy: allow running with k8s support without k8s credentials

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -13,7 +13,7 @@ import (
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/trace"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	authzapi "k8s.io/api/authorization/v1"
 	"k8s.io/client-go/kubernetes"
 	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
@@ -40,12 +40,16 @@ type kubeCreds struct {
 	targetAddr string
 }
 
-func getKubeCreds(kubeconfigPath string) (*kubeCreds, error) {
+func getKubeCreds(log logrus.FieldLogger, kubeconfigPath string) (*kubeCreds, error) {
 	var cfg *rest.Config
 	// no kubeconfig is set, assume auth server is running in the cluster
 	if kubeconfigPath == "" {
 		caPEM, err := ioutil.ReadFile(teleport.KubeCAPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				log.Debugf("kubeconfig_file was not provided in the config and %q doesn't exist; this proxy will still be able to forward requests to trusted leaf Teleport clusters, but not to a Kubernetes cluster directly", teleport.KubeCAPath)
+				return nil, nil
+			}
 			return nil, trace.BadParameter(`auth server assumed that it is
 running in a kubernetes cluster, but %v mounted in pods could not be read: %v,
 set kubeconfig_file if auth server is running outside of the cluster`, teleport.KubeCAPath, err)
@@ -113,6 +117,9 @@ func parseKubeHost(host string) (string, error) {
 }
 
 func (c *kubeCreds) wrapTransport(rt http.RoundTripper) (http.RoundTripper, error) {
+	if c == nil {
+		return rt, nil
+	}
 	return transport.HTTPWrappersForConfig(c.transportConfig, rt)
 }
 

--- a/lib/kube/proxy/roundtrip.go
+++ b/lib/kube/proxy/roundtrip.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/teleport/lib/utils"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -156,7 +157,7 @@ func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	header.Add(httpstream.HeaderConnection, httpstream.HeaderUpgrade)
 	header.Add(httpstream.HeaderUpgrade, streamspdy.HeaderSpdy31)
 
-	if err := setupImpersonationHeaders(&s.authCtx, header); err != nil {
+	if err := setupImpersonationHeaders(log.StandardLogger(), s.authCtx, header); err != nil {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
This simplifies a setup using trusted clusters:
- root teleport cluster as identity source and frontend
- leaf teleport clusters as gateways to individual k8s clusters

In this setup, root cluster doesn't talk to any k8s clusters directly.
It only forwards requests to leaf cluster proxies.

Without this change, users would have to put a dummy kubeconfig file on
root proxies just to enable k8s forwarding. With this change, this is no
longer needed.

Fixes #3087