### PR TITLE
Self-test kube impersonation permissions at startup 

### DIFF
--- a/examples/chart/teleport-auto-trustedcluster/templates/clusterrole.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/templates/clusterrole.yaml
@@ -14,4 +14,10 @@ rules:
   - serviceaccounts
   verbs:
   - impersonate
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create
 {{- end -}}

--- a/examples/chart/teleport-daemonset/templates/clusterrole.yaml
+++ b/examples/chart/teleport-daemonset/templates/clusterrole.yaml
@@ -14,6 +14,12 @@ rules:
   - serviceaccounts
   verbs:
   - impersonate
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create
 {{ if .Values.usePSP -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/chart/teleport-demo/templates/generic/teleport-k8s.yaml
+++ b/examples/chart/teleport-demo/templates/generic/teleport-k8s.yaml
@@ -18,6 +18,12 @@ rules:
   - groups
   verbs:
   - impersonate
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/chart/teleport/templates/clusterrole.yaml
+++ b/examples/chart/teleport/templates/clusterrole.yaml
@@ -14,4 +14,10 @@ rules:
   - serviceaccounts
   verbs:
   - impersonate
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create
 {{- end -}}

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -127,10 +127,10 @@ func checkImpersonationPermissions(sarClient authztypes.SelfSubjectAccessReviewI
 			},
 		})
 		if err != nil {
-			return trace.Wrap(err, "failed to verify impersonation permissions for kubernetes: %v", err)
+			return trace.Wrap(err, "failed to verify impersonation permissions for kubernetes: %v; this may be due to missing the SelfSubjectAccessReview permission on the ClusterRole used by the proxy; please make sure that proxy has all the necessary permissions: https://gravitational.com/teleport/docs/kubernetes_ssh/#impersonation", err)
 		}
 		if !resp.Status.Allowed {
-			return trace.AccessDenied("proxy can't impersonate kubernetes %s at the cluster level", resource)
+			return trace.AccessDenied("proxy can't impersonate kubernetes %s at the cluster level; please make sure that proxy has all the necessary permissions: https://gravitational.com/teleport/docs/kubernetes_ssh/#impersonation", resource)
 		}
 	}
 	return nil

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -18,7 +18,6 @@ package proxy
 
 import (
 	"errors"
-	"testing"
 
 	"gopkg.in/check.v1"
 	authzapi "k8s.io/api/authorization/v1"
@@ -28,8 +27,6 @@ import (
 type AuthSuite struct{}
 
 var _ = check.Suite(AuthSuite{})
-
-func Test(t *testing.T) { check.TestingT(t) }
 
 func (s AuthSuite) TestCheckImpersonationPermissions(c *check.C) {
 	tests := []struct {

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"errors"
+	"testing"
+
+	"gopkg.in/check.v1"
+	authzapi "k8s.io/api/authorization/v1"
+	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
+)
+
+type AuthSuite struct{}
+
+var _ = check.Suite(AuthSuite{})
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+func (s AuthSuite) TestCheckImpersonationPermissions(c *check.C) {
+	tests := []struct {
+		desc             string
+		sarErr           error
+		allowedVerbs     []string
+		allowedResources []string
+
+		wantErr bool
+	}{
+		{
+			desc:    "request failure",
+			sarErr:  errors.New("uh oh"),
+			wantErr: true,
+		},
+		{
+			desc:             "all permissions granted",
+			allowedVerbs:     []string{"impersonate"},
+			allowedResources: []string{"users", "groups", "serviceaccounts"},
+			wantErr:          false,
+		},
+		{
+			desc:             "missing some permissions",
+			allowedVerbs:     []string{"impersonate"},
+			allowedResources: []string{"users"},
+			wantErr:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Log(tt.desc)
+		mock := &mockSARClient{
+			err:              tt.sarErr,
+			allowedVerbs:     tt.allowedVerbs,
+			allowedResources: tt.allowedResources,
+		}
+		err := checkImpersonationPermissions(mock)
+		if tt.wantErr {
+			c.Assert(err, check.NotNil)
+		} else {
+			c.Assert(err, check.IsNil)
+		}
+	}
+}
+
+type mockSARClient struct {
+	authztypes.SelfSubjectAccessReviewInterface
+
+	err              error
+	allowedVerbs     []string
+	allowedResources []string
+}
+
+func (c *mockSARClient) Create(sar *authzapi.SelfSubjectAccessReview) (*authzapi.SelfSubjectAccessReview, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+
+	var verbAllowed, resourceAllowed bool
+	for _, v := range c.allowedVerbs {
+		if v == sar.Spec.ResourceAttributes.Verb {
+			verbAllowed = true
+			break
+		}
+	}
+	for _, r := range c.allowedResources {
+		if r == sar.Spec.ResourceAttributes.Resource {
+			resourceAllowed = true
+			break
+		}
+	}
+
+	sar.Status.Allowed = verbAllowed && resourceAllowed
+	return sar, nil
+}

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"net/http"
+	"sort"
 	"testing"
 	"time"
 
@@ -385,6 +386,10 @@ func (s ForwarderSuite) TestSetupImpersonationHeaders(c *check.C) {
 		c.Log("got error:", err)
 		c.Assert(err != nil, check.Equals, tt.wantErr)
 		if err == nil {
+			// Sort header values to get predictable ordering.
+			for _, vals := range tt.inHeaders {
+				sort.Strings(vals)
+			}
 			c.Assert(tt.inHeaders, check.DeepEquals, tt.wantHeaders)
 		}
 	}


### PR DESCRIPTION
To help operators diagnose mis-configured kubeconfig or k8s RBAC roles,
make proxy verify that impersonation is allowed. If not, fail at
startup.

Note: this requires the proxy to have permissions to create
`SelfSubjectAccessReviews`.

Fixes #3649