### PR TITLE
Fix build on windows

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2265,7 +2265,11 @@ func (tc *TeleportClient) getServerVersion(nodeClient *NodeClient) (string, erro
 
 // passwordFromConsole reads from stdin without echoing typed characters to stdout
 func passwordFromConsole() (string, error) {
-	fd := syscall.Stdin
+	// syscall.Stdin is not an int on windows. The linter will complain only on
+	// linux where syscall.Stdin is an int.
+	//
+	// nolint:unconvert
+	fd := int(syscall.Stdin)
 	state, err := terminal.GetState(fd)
 
 	// intercept Ctr+C and restore terminal

--- a/lib/client/session_windows.go
+++ b/lib/client/session_windows.go
@@ -35,13 +35,16 @@ type NodeSession struct {
 	ExitMsg string
 }
 
-func newSession(client *NodeClient,
+func newSession(
+	client *NodeClient,
 	joinSession *session.Session,
 	env map[string]string,
 	stdin io.Reader,
 	stdout io.Writer,
 	stderr io.Writer,
-	legacyID bool) (*NodeSession, error) {
+	legacyID bool,
+	enableEscapeSequences bool,
+) (*NodeSession, error) {
 
 	return nil, trace.BadParameter("sessions not supported on Windows")
 }


### PR DESCRIPTION
Two inconsistencies between linux and windows-specific code paths.
Interestingly, `os.Stdin/Stdout/Stderr` in the standard library are
different types under linux and windows.

Fixes #3817