### PR TITLE
Update to Teleport Chart

### DIFF
--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -1,6 +1,8 @@
 name: teleport
-version: 0.0.4
-description: Teleport Enterprise
+apiVersion: v1
+version: 0.0.5
+description: Teleport Enterprise or Community
+icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
 keywords:
-  - Teleport Enterprise
+  - Teleport 
 tillerVersion: ">=2.8.0"

--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport
 apiVersion: v1
 version: 0.0.5
-description: Teleport Enterprise or Community
+description: Setup a Teleport Cluster
 icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
 keywords:
   - Teleport 

--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport
 apiVersion: v1
 version: 0.0.5
-description: Setup a Teleport Cluster
+description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
 keywords:
   - Teleport 

--- a/examples/chart/teleport/HIGHAVAILABILITY.md
+++ b/examples/chart/teleport/HIGHAVAILABILITY.md
@@ -55,7 +55,7 @@ A high availability deployment of Teleport will typically have at least 2 proxy 
   authServiceType: ClusterIP
   auth_public_address: auth.example.com
 ```
-2. Set the connection for the proxies to connect to the auth service in the config section. The auth service is available at the Kubernetes service name and the public address setting.  So if you deploy an app named myexample then the auth service will be available in the Cluster at `myexampleauth` in addition to the public address.
+2. Set the connection for the proxies to connect to the auth service in the config section. The auth service is available at the Kubernetes service name and the public address setting.  So if you deploy an app named `myexample` then the auth service will be available in the Cluster at `myexampleauth` in addition to the public address.
 
 ```yaml
   auth_service_connection:

--- a/examples/chart/teleport/HIGHAVAILABILITY.md
+++ b/examples/chart/teleport/HIGHAVAILABILITY.md
@@ -1,0 +1,80 @@
+## Configuring High Availability
+
+Running multiple instances of the Authentication Services requires using a high availability storage configuration.  The [documentation](https://gravitational.com/teleport/docs/admin-guide/#high-availability) provides detailed examples using AWS DynamoDB/S3, GCP Firestore/Google storage or an `etcd` cluster. Here we provide detailed steps for an AWS example configuration.
+
+### Prerequisites
+ - Available AWS credentials (/home/<user>/.aws/credentials)
+ - Have AWS credentials that can create and access DyanmoDB details as documented here.
+ - Bucket for storing Sessions as documented [here](https://gravitational.com/teleport/docs/admin-guide/#using-amazon-s3).
+
+### Example High Availability Storage
+1. First add the credentials file as a secret
+```bash
+kubectl create secret generic awscredentials --from-file=~/.aws/credentials
+```
+
+2. Set the DynamoDB and Sessions storage within `values.yaml`
+
+```yaml
+    storage:
+      type: dynamodb
+      region: us-east-1
+      table_name: teleport
+      audit_events_uri: 'dynamodb://teleport_events'
+      audit_sessions_uri: 's3://teleportexample/sessions?region=us-east-1'
+```
+
+3. In the `values.yaml` set the volume and volume mount for AWS credentials only available to the auth service.
+```yaml
+extraAuthVolumes:
+  - name: awscredentials
+    secret:
+      secretName: awscredentials
+
+
+  # - name: ca-certs
+  #   configMap:
+  #     name: ca-certs
+extraAuthVolumeMounts:
+  - mountPath: /root/.aws
+    name: awscredentials
+```
+
+
+
+### Configuring Multiple Instances of Teleport
+
+A high availability deployment of Teleport will typically have at least 2 proxy and 2 auth service instances.  SSH service is typically not enabled on these instances.  To enable separate deployments of the auth and auth services follow these steps.
+
+1. In the configuration section set the `highAvailability` to true.  Also confirm the auth public address and Service Type.
+```yaml
+  highAvailability: true
+  # High availability configuration with proxy and auth servers. No SSH configured service.
+  proxyCount: 2
+  authCount: 2
+  authServiceType: ClusterIP
+  auth_public_address: auth.example.com
+```
+2. Set the connection for the proxies to connect to the auth service in the config section. The auth service is available at the Kubernetes service name and the public address setting.  So if you deploy an app named myexample then the auth service will be available in the Cluster at `myexampleauth` in addition to the public address.
+
+```yaml
+  auth_service_connection:
+    auth_token: dogs-are-much-nicer-than-cats
+    auth_servers:
+    - teleportauth:3025
+    - teleport.example.com:3025
+```
+### Confirming
+
+After configuring both of these options run the install.  In the example below you will see two teleport pods that are the Proxy instances  (teleport-) and two teleport pods that that are the Auth instances (teleportauth-).
+
+``` bash
+$ helm install --name teleport ./
+
+$ kubectl get pods 
+NAME                            READY   STATUS    RESTARTS   AGE
+teleport-d67584df8-8vfls        1/1     Running   0          62m
+teleport-d67584df8-p9l2g        1/1     Running   0          62m
+teleportauth-66455f85ff-7x7g4   1/1     Running   0          62m
+teleportauth-66455f85ff-hgsdj   1/1     Running   0          62m
+```

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -37,7 +37,7 @@ See the comments in the default `values.yaml` and also the [Teleport documentati
 
 If you are deploying the Enterprise version you will require the license file as a secret available to Teleport. To use the community edition of Teleport simply set `enabled: false` under the `license:` settings in `values.yaml`.
 
-Download the `license.pem` from the Teleport dashboard, and then <b>rename it to the filename</b> that this chart expects:
+Download the `license.pem` from the [Teleport dashboard](https://dashboard.gravitational.com/web/login), and then <b>rename it to the filename</b> that this chart expects:
 
 ```
 cp ~/Downloads/license.pem license-enterprise.pem

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -1,29 +1,43 @@
 # Teleport
 
-[Gravitational Teleport](https://github.com/gravitational/teleport) is a modern SSH/Kubernetes API proxy server for remotely accessing clusters of Linux containers and servers via SSH, HTTPS, or Kubernetes API.
+[Gravitational Teleport](https://github.com/gravitational/teleport) is a modern SSH/Kubernetes API proxy server for remotely accessing clusters of Linux containers and servers via SSH, HTTPS, or Kubernetes API.  Community and Enterprise versions of Teleport are available.  You can start with the Community edition with this Chart and in the future update to an Enterprise version for the same deployment.
 
 ## Introduction
 
-This chart deploys Teleport components to your cluster via a Kubernetes `Deployment`.
+This chart deploys Teleport Community or Enterprise components to your cluster via a Kubernetes `Deployment`.
 
 By default this chart is configured as follows:
 
-- 1 replica
+- Enterprise Edition of Teleport
+- 1 instance (replica) of Teleport
+- Directory Storage with no persistent storage.  
 - Record ssh/k8s exec and attach session to the `emptyDir` of the Teleport pod
-- The assumed externally accessible hostname of Teleport is `teleport.example.com`
-- Teleport is accessible only from within your cluster. You need `kubectl port-forward` for external access.
-- TLS is enabled by default on the Proxy
+- The assumed externally accessible hostname of Teleport is `teleport.example.com` 
+- Teleport is accessible only from within your cluster. You need `kubectl port-forward` for external access. Change the Service type in `values.yaml` to options such as LoadBalancer to make it externally accessible.
+- TLS is enabled by default on the Proxy 
 
-See the comments in the default `values.yaml` and also the Teleport documentation for more options.
+
+The `values.yaml` is configurable for multiple options including:
+- Using the Community edition of Teleport (Set license.enabled to false)
+- Using self-signed TLS certificates (Set proxy.tls.usetlssecret to false)
+- Using a specific version of Teleport (See image.tag)
+- Using persistent or high availability storage (See below example).  Persistent or high availability storage is recommended for production usage. 
+- Increasing the replica count for multiple instances (Using High Availability configuration)
+
+See the comments in the default `values.yaml` and also the [Teleport documentation](https://gravitational.com/teleport/docs/) for more options.   
 
 ## Prerequisites
 
 - Kubernetes 1.10+
-- A Teleport license file stored as a Kubernetes Secret object(See below)
+- Teleport license for Enterprise deployments
+- TLS Certificates or optionally use self-signed certificates
 
-### Prepare the license file
+### Prepare a Teleport Enterprise license file
 
-Download the `license.pem` from the Teleport dashboard, and then rename it to the filename that this chart expects:
+
+If you are deploying the Enterprise version you will require the license file as a secret available to Teleport. To use the community edition of Teleport simply set `enabled: false` under the `license:` settings in `values.yaml`.
+
+Download the `license.pem` from the Teleport dashboard, and then <b>rename it to the filename</b> that this chart expects:
 
 ```
 cp ~/Downloads/license.pem license-enterprise.pem
@@ -35,15 +49,16 @@ Store it as a Kubernetes secret:
 kubectl create secret generic license --from-file=license-enterprise.pem
 ```
 
-## Installing the chart
+## TLS Certificates
 
-To install the chart with the release name `teleport`, run:
+### Certificate Usage Configuration
+Teleport can generate self-signed certificates that is useful for first time or non-production deployments. You can set Teleport to use self-signed certificates by setting `usetlssecret: false` under the `proxy.tls settings` in `values.yaml`. You will need to add `--insecure` to some interactions such as `tsh` and browser interaction will require confirming interaction.  Please see our [article](https://gravitational.com/blog/letsencrypt-teleport-ssh/) on generating certificates via Let's Encrypt.
 
-```
-$ helm install --name teleport ./
-```
+If you plan to have TLS terminate at a seperate load balancer  you should set both `proxy.tls.enabled` and `proxy.usetlssecret` to false. 
 
-Teleport proxy generates a TLS key and a cert of its own by default.  You can provide the signed TLS certificates and optionally the TLS Certificate Authority (CA) that signed these certificates.
+
+### Adding TLS Certificates
+You can provide the signed TLS certificates and optionally the TLS Certificate Authority (CA) that signed these certificates.
 In order to instruct the proxy to use the TLS assets brought by you, prepare the following files:
 
 - Your proxy server cert named `proxy-server.pem`
@@ -54,11 +69,18 @@ Then run:
 
 ```
 $ kubectl create secret tls tls-web --cert=proxy-server.pem --key=proxy-server-key.pem
+
 # Run this command if you are providing your own TLS CA
 $ kubectl create configmap ca-certs --from-file=ca.pem
-# Run this to update or install teleport
-$ helm upgrade --install teleport ./
 ```
+## Installing the chart
+
+To install the chart with the release name `teleport`, run:
+
+```
+$ helm install --name teleport ./
+```
+
 
 ## Running locally on minikube
 
@@ -75,6 +97,68 @@ Now, you can run various `tsh` commands against your local Teleport installation
 ```
 $ tsh login --auth=local --user=$USER login
 ```
+
+
+## Configuring High Availability and Multiple Replicas
+
+Running multiple instances of the Authentication Services requires using a high availability storage configuration.  The [documentation](https://gravitational.com/teleport/docs/admin-guide/#high-availability) provides detailed examples on AWS, ETCD and GCP options. Here we provide detailed steps for a AWS example configuration.
+
+### Prerequisites
+ - Available AWS credentials (/home/<user>/.aws/credentials)
+ - Have AWS credentials that can create and access DyanmoDB details as documented here.
+ - Bucket for storing Sessions as documented [here](https://gravitational.com/teleport/docs/admin-guide/#using-amazon-s3).
+
+### Configuring AWS Credentials and Storage
+1. First add the credentials file as a secret
+```bash
+kubectl create secret generic awscredentials --from-file=credentials
+```
+
+2. Set the DynamoDB and Sessions storage within `values.yaml`
+
+```yaml
+    storage:
+      type: dynamodb
+      region: us-east-1
+      table_name: teleport
+      audit_events_uri: 'dynamodb://teleport_events'
+      audit_sessions_uri: 's3://teleportexample/sessions?region=us-east-1'
+```
+
+3. With the `values.yaml` set the volume and volume mount for AWS credentials
+```yaml
+extraVolumes:
+  - name: awscredentials
+    secret:
+      secretName: awscredentials
+
+
+  # - name: ca-certs
+  #   configMap:
+  #     name: ca-certs
+extraVolumeMounts:
+  - mountPath: /root/.aws
+    name: awscredentials
+```
+
+
+
+### Configuring Multiple Instances of Teleport
+
+
+
+## Troubleshooting
+
+### Teleport Pods are not starting
+
+If you the Teleport pods are not starting the most common issue is lack of required volumes (license, TLS certificates).  If you run `kubectl get pods` and the <chart-name>-hostid pod shows as not running that could be the issue.  Run a describe on the pod to see if there are any missing secrets or configurations.
+ Example:
+   `kubectl describe pod teleport-5f5f989b96-9khzq`
+
+  
+### Teleport Pods keep restarting with Error
+The issue may be due to a malformed Teleport configuration file or other configuration issue.  Use the kubectl logs command to see the logs output Example: `kubectl logs -f teleport-5f5f989b96-9khzq` .
+
 
 ## Contributing
 

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -113,7 +113,7 @@ Running multiple instances of the Authentication Services requires using a high 
 ### Example High Availability Storage
 1. First add the credentials file as a secret
 ```bash
-kubectl create secret generic awscredentials --from-file=credentials
+kubectl create secret generic awscredentials --from-file=~/.aws/credentials
 ```
 
 2. Set the DynamoDB and Sessions storage within `values.yaml`

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -28,6 +28,8 @@ The `values.yaml` is configurable for multiple options including:
 
 See the comments in the default `values.yaml` and also the [Teleport documentation](https://gravitational.com/teleport/docs/) for more options.   
 
+See the [High Availability](./HIGHAVAILABILITY.md)(HA) instructions for configuring a HA deployment with this helm chart.
+
 ## Prerequisites
 
 - Kubernetes 1.10+

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -99,9 +99,9 @@ $ tsh login --auth=local --user=$USER login
 ```
 
 
-## Configuring High Availability and Multiple Replicas
+## Configuring High Availability
 
-Running multiple instances of the Authentication Services requires using a high availability storage configuration.  The [documentation](https://gravitational.com/teleport/docs/admin-guide/#high-availability) provides detailed examples on AWS, ETCD and GCP options. Here we provide detailed steps for a AWS example configuration.
+Running multiple instances of the Authentication Services requires using a high availability storage configuration.  The [documentation](https://gravitational.com/teleport/docs/admin-guide/#high-availability) provides detailed examples on AWS, ETCD and GCP options. Here we provide detailed steps for an AWS example configuration.
 
 ### Prerequisites
  - Available AWS credentials (/home/<user>/.aws/credentials)

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -127,7 +127,7 @@ kubectl create secret generic awscredentials --from-file=credentials
 
 3. With the `values.yaml` set the volume and volume mount for AWS credentials
 ```yaml
-extraVolumes:
+extraAuthVolumes:
   - name: awscredentials
     secret:
       secretName: awscredentials
@@ -136,7 +136,7 @@ extraVolumes:
   # - name: ca-certs
   #   configMap:
   #     name: ca-certs
-extraVolumeMounts:
+extraAuthVolumeMounts:
   - mountPath: /root/.aws
     name: awscredentials
 ```

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -125,7 +125,7 @@ kubectl create secret generic awscredentials --from-file=credentials
       audit_sessions_uri: 's3://teleportexample/sessions?region=us-east-1'
 ```
 
-3. With the `values.yaml` set the volume and volume mount for AWS credentials
+3. With the `values.yaml` set the volume and volume mount for AWS credentials only available to the Auth service.
 ```yaml
 extraAuthVolumes:
   - name: awscredentials

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -6,4 +6,141 @@ metadata:
 {{ include "teleport.labels" . | indent 4 }}
 data:
   teleport.yaml: |
-{{ toYaml .Values.config | indent 4 }}
+{{- if .Values.otherConfig.useOtherConfig }} 
+{{ toYaml .Values.otherConfig.teleportConfig | indent 4 }}
+{{- else }}
+    teleport:
+{{- if not .Values.config.highAvailability }}
+      nodename: {{ template "teleport.fullname" . }}
+{{- end }}
+{{- if  .Values.config.auth_service_connection }} 
+{{ toYaml .Values.config.auth_service_connection | indent 6 }}
+{{- end }}
+      pid_file: {{ .Values.config.teleport.pid_file }}
+      data_dir: {{ .Values.config.teleport.data_dir  }}
+{{- if .Values.config.teleport.log }}
+      log:
+{{ toYaml .Values.config.teleport.log | indent 8 }}
+{{- end }}
+      # storage settings included
+      storage:
+{{ toYaml .Values.config.teleport.storage | indent 8 }}
+
+      connection_limits:    
+{{ toYaml .Values.config.teleport.connection_limits | indent 8 }}
+    auth_service:
+{{- if .Values.config.highAvailability }}
+      enabled: false
+{{- else }}
+      enabled: {{ .Values.config.teleport.auth_service.enabled }}
+{{- if .Values.license.enabled }}
+      license_file: {{ .Values.config.teleport.auth_service.license_file }}
+{{- end }}
+      authentication:
+{{ toYaml .Values.config.teleport.auth_service.authentication | indent 8 }}
+      tokens:
+{{ toYaml .Values.config.teleport.auth_service.tokens | indent 8 }}
+
+      public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.authssh.containerPort }}
+      cluster_name: {{ .Values.config.public_address }}
+      listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.authssh.containerPort }}
+      client_idle_timeout: {{ .Values.config.teleport.auth_service.client_idle_timeout }}
+      disconnect_expired_cert: {{ .Values.config.teleport.auth_service.disconnect_expired_cert }}
+      keep_alive_interval: {{ .Values.config.teleport.auth_service.keep_alive_interval }}
+      keep_alive_count_max: {{ .Values.config.teleport.auth_service.keep_alive_count_max }}
+{{- end }}
+      
+    ssh_service:
+{{- if not .Values.config.highAvailability }}
+      enabled: {{ .Values.config.teleport.ssh_service.enabled }}
+{{- else }}
+      enabled: false
+{{- end }}
+      public_addr: {{ template "teleport.fullname" . }}node:{{ .Values.ports.nodessh.containerPort }}
+      listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.nodessh.containerPort }}
+      commands:
+{{ toYaml .Values.config.teleport.ssh_service.commands | indent 8 }}
+      labels:
+{{ toYaml .Values.config.teleport.ssh_service.labels | indent 8 }}
+      enhanced_recording:
+{{ toYaml .Values.config.teleport.ssh_service.enhanced_recording | indent 8 }}
+      pam:
+{{ toYaml .Values.config.teleport.ssh_service.pam | indent 8 }}
+      
+    proxy_service:
+      enabled: {{ .Values.config.teleport.proxy_service.enabled }}
+      public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.proxyweb.containerPort }}
+      web_listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyweb.containerPort }}
+      listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyssh.containerPort }}
+      tunnel_listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxytunnel.containerPort }}
+
+      ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.proxyssh.containerPort }}
+      tunnel_public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.proxytunnel.containerPort }}
+{{- if .Values.proxy.tls.usetlssecret}} 
+      https_key_file: {{ .Values.config.teleport.proxy_service.https_key_file }}
+      https_cert_file: {{ .Values.config.teleport.proxy_service.https_cert_file }}
+{{- end }}      
+
+      # kubernetes section configures
+      # kubernetes proxy protocol support
+      kubernetes:        
+        enabled: {{ .Values.config.teleport.proxy_service.kubernetes.enabled }}
+        public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.proxykube.containerPort }}
+        listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxykube.containerPort }}
+{{- end }}
+{{- if .Values.config.highAvailability }}
+---
+#Configuration for additional deployments used for high performance
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "teleport.fullname" . }}auth
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+data:
+  teleport.yaml: |
+{{- if .Values.otherConfigHA.useOtherConfig }} 
+{{ toYaml .Values.otherConfigHA.teleportConfig | indent 4 }}
+{{- else }}
+    teleport:
+      pid_file: {{ .Values.config.teleport.pid_file }}
+      data_dir: {{ .Values.config.teleport.data_dir  }}
+      # storage settings included
+{{- if .Values.config.teleport.log }}
+      log:
+{{ toYaml .Values.config.teleport.log | indent 8 }}
+{{- end }}
+      storage:
+{{ toYaml .Values.config.teleport.storage | indent 8 }}
+
+      connection_limits:    
+{{ toYaml .Values.config.teleport.connection_limits | indent 8 }}
+    auth_service:
+      enabled: true
+{{- if .Values.license.enabled }}
+      license_file: {{ .Values.config.teleport.auth_service.license_file }}
+{{- end }}
+      authentication:
+{{ toYaml .Values.config.teleport.auth_service.authentication | indent 8 }}
+{{- if .Values.config.teleport.auth_service.tokens }}
+      tokens:
+{{ toYaml .Values.config.teleport.auth_service.tokens | indent 8 }}
+{{- end }}
+
+      public_addr: {{ .Values.config.auth_public_address }}:{{ .Values.ports.authssh.containerPort }}
+      cluster_name: {{ .Values.config.public_address }}
+      
+      listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.authssh.containerPort }}
+
+      client_idle_timeout: {{ .Values.config.teleport.auth_service.client_idle_timeout }}
+      disconnect_expired_cert: {{ .Values.config.teleport.auth_service.disconnect_expired_cert }}
+      keep_alive_interval: {{ .Values.config.teleport.auth_service.keep_alive_interval }}
+      keep_alive_count_max: {{ .Values.config.teleport.auth_service.keep_alive_count_max }}
+      
+    ssh_service:
+      enabled: false
+      
+    proxy_service:
+      enabled: false 
+{{- end }}
+{{- end }}

--- a/examples/chart/teleport/templates/deployment.yaml
+++ b/examples/chart/teleport/templates/deployment.yaml
@@ -8,18 +8,28 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
 spec:
+{{- if not .Values.config.highAvailability }}
   replicas: {{ .Values.replicaCount }}
+{{- else }}
+  replicas: {{ .Values.config.proxyCount }}
+{{- end }}
   strategy:
     type: {{ .Values.strategy }}
   selector:
     matchLabels:
       app: {{ template "teleport.name" . }}
+{{- if .Values.config.highAvailability }}
+      auth: noauth
+{{- end}}
   template:
     metadata:
       labels:
         app: {{ template "teleport.name" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+{{- if .Values.config.highAvailability }}
+        auth: noauth
+{{- end}}
       annotations:
         checksum/config: {{ toYaml .Values.config | sha256sum }}
 {{- if .Values.annotations }}
@@ -29,7 +39,11 @@ spec:
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+{{- if .Values.license.enabled }}
+        image: "{{ .Values.image.enterpriseRepository }}:{{ .Values.image.tag }}"
+{{- else }}
+        image: "{{ .Values.image.communityRepository }}:{{ .Values.image.tag }}"
+{{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
 {{- if .Values.extraArgs }}
@@ -52,7 +66,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-{{- if .Values.proxy.tls.enabled }}
+{{- if .Values.proxy.tls.usetlssecret }}
         - mountPath: /var/lib/certs
           name: {{ template "teleport.fullname" . }}-tls-web
           readOnly: true
@@ -71,7 +85,7 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
 {{- end }}
       volumes:
-{{- if .Values.proxy.tls.enabled }}
+{{- if .Values.proxy.tls.usetlssecret }}
       - name: {{ template "teleport.fullname" . }}-tls-web
         secret:
           secretName: {{ .Values.proxy.tls.secretName }}
@@ -107,3 +121,107 @@ spec:
 {{ toYaml .Values.tolerations | indent 6 }}
 {{- end }}
       serviceAccountName: {{ template "teleport.serviceAccountName" . }}
+{{- if .Values.config.highAvailability }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "teleport.fullname" . }}auth
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+    
+spec:
+  replicas: {{ .Values.config.authCount }}
+  strategy:
+    type: {{ .Values.strategy }}
+  selector:
+    matchLabels:
+      app: {{ template "teleport.name" . }}
+      auth: hasauth
+  template:
+    metadata:
+      labels:
+        app: {{ template "teleport.name" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        auth: hasauth
+      annotations:
+        checksum/config: {{ toYaml .Values.config.auth_public_address | sha256sum }}
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      containers:
+      - name: {{ .Chart.Name }}
+{{- if .Values.license.enabled }}
+        image: "{{ .Values.image.enterpriseRepository }}:{{ .Values.image.tag }}"
+{{- else }}
+        image: "{{ .Values.image.communityRepository }}:{{ .Values.image.tag }}"
+{{- end }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+{{- if .Values.config.authExtraArgs }}
+{{ toYaml .Values.config.authExtraArgs | indent 8 }}
+{{- end }}
+        env:
+{{- range $key, $value := .Values.extraVars }}
+        - name: {{ $key }}
+          value: {{ $value }}
+{{- end }}
+        # See https://gravitational.com/teleport/docs/admin-guide/#ports
+        ports:
+        - name: authssh
+          containerPort: {{ .Values.ports.authssh.containerPort }}
+        resources:
+{{ toYaml .Values.authresources | indent 10 }}
+        volumeMounts:
+        - mountPath: /etc/teleport
+          name: {{ template "teleport.fullname" . }}-config
+          readOnly: true
+{{- if .Values.license.enabled }}
+        - mountPath: {{ .Values.license.mountPath }}
+          name: {{ template "teleport.fullname" . }}-license
+          readOnly: true
+{{- end }}
+        - mountPath: /var/lib/teleport
+          name: {{ template "teleport.fullname" . }}-storage
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+{{- if .Values.extraAuthVolumeMounts }}
+{{ toYaml .Values.extraAuthVolumeMounts | indent 8 }}
+{{- end }}
+      volumes:
+{{- if .Values.license.enabled }}
+      - name: {{ template "teleport.fullname" . }}-license
+        secret:
+          secretName: {{ .Values.license.secretName }}
+{{- end }}
+      - name: {{ template "teleport.fullname" . }}-config
+        configMap:
+          name: {{ template "teleport.fullname" . }}auth
+      - name: {{ template "teleport.fullname" . }}-storage
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{- end }}
+{{- if .Values.extraAuthVolumes }}
+{{ toYaml .Values.extraAuthVolumes | indent 6 }}
+{{- end }}
+{{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 6 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+{{- end }}
+      serviceAccountName: {{ template "teleport.serviceAccountName" . }}
+{{- end }}

--- a/examples/chart/teleport/templates/deployment.yaml
+++ b/examples/chart/teleport/templates/deployment.yaml
@@ -60,8 +60,10 @@ spec:
         # See https://gravitational.com/teleport/docs/admin-guide/#ports
         ports:
 {{- range $key, $port := .Values.ports }}
+{{ if or ( not $.Values.config.highAvailability) (and ($.Values.config.highAvailability) (not (eq $key "authssh") ) ) }}
         - name: {{ $key }}
 {{ toYaml $port | indent 10 }}
+{{ end }}
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/examples/chart/teleport/templates/service.yaml
+++ b/examples/chart/teleport/templates/service.yaml
@@ -15,8 +15,10 @@ spec:
   type: {{ .Values.service.type }}
   ports:
 {{- range $key, $value := .Values.service.ports }}
+{{ if  or (not $.Values.config.highAvailability) (and ($.Values.config.highAvailability) (not (eq $key "authssh")))   }}
     - name: {{ $key }}
 {{ toYaml $value | indent 6 }}
+ {{ end }}
 {{- end }}
 {{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.service.externalTrafficPolicy) }}
   externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"

--- a/examples/chart/teleport/templates/service.yaml
+++ b/examples/chart/teleport/templates/service.yaml
@@ -14,13 +14,45 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  {{- range $key, $value := .Values.service.ports }}
+{{- range $key, $value := .Values.service.ports }}
     - name: {{ $key }}
 {{ toYaml $value | indent 6 }}
-  {{- end }}
+{{- end }}
 {{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.service.externalTrafficPolicy) }}
   externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
 {{- end }}
   selector:
     app: {{ template "teleport.name" . }}
     release: {{ .Release.Name }}
+{{- if .Values.config.highAvailability }}
+    auth: noauth
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "teleport.fullname" . }}auth
+  labels:
+{{ include "teleport.labels" . | indent 4 }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.config.authServiceType }}
+  ports:
+    - name: authssh
+      port: {{ .Values.ports.authssh.containerPort }}
+      targetPort: {{ .Values.ports.authssh.containerPort }}
+      protocol: TCP      
+{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.service.externalTrafficPolicy) }}
+  externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
+{{- end }}
+  selector:
+    app: {{ template "teleport.name" . }}
+    release: {{ .Release.Name }}
+    auth: hasauth
+{{- end }}
+

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -1,6 +1,18 @@
+# Teleport License Usage
+license:
+  ## Set false to run Teleport in Community edition mode
+  enabled: true
+  secretName: license
+  mountPath: /var/lib/license
+
+# Docker image to use
 image:
-  repository: quay.io/gravitational/teleport-ent
-  tag: 4.2.7
+  #Used if license is enabled
+  enterpriseRepository: quay.io/gravitational/teleport-ent
+  #Used if license is disabled
+  communityRepository: quay.io/gravitational/teleport
+  #Version of Teleport
+  tag: 4.2.10
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.
@@ -10,53 +22,149 @@ image:
 
 labels: {}
 
-# Pod annotations
-annotations: {}
-## See https://github.com/uswitch/kiam#overview
-## To enable AWS API access from teleport, use kube2iam or kiam, annotate the namespace, and then set something like:
-# iam.amazonaws.com/role: teleport-dynamodb-and-s3-access
 
-replicaCount: 1
-strategy: RollingUpdate
+# Teleport Proxy configuration
+proxy:
+  tls:
+    # We assume TLS is terminated in front of the proxy by default
+    enabled: true
+    # Set this to false if you want to use Teleport's generated self-signed certificates
+    usetlssecret: true
+    # tweak this if you have multiple proxies in a single namespace
+    secretName: tls-web
 
-## Affinity for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-# affinity: {}
-#
-## For the sake of security, make specific node group(s) dedicated to Teleport
-#   nodeAffinity:
-#     requiredDuringSchedulingIgnoredDuringExecution:
-#       nodeSelectorTerms:
-#       - matchExpressions:
-#         - key: gravitational.io/dedicated
-#           operator: In
-#           values:
-#           - teleport
-#
-## For high availability, distribute teleport pods to nodes as evenly as possible
-#   podAntiAffinity:
-#     preferredDuringSchedulingIgnoredDuringExecution:
-#     - podAffinityTerm:
-#         labelSelector:
-#           matchExpressions:
-#           - key: app
-#             operator: In
-#             values:
-#             - teleport
-#         topologyKey: kubernetes.io/hostname
 
-# Tolerations for pod assignment
-# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: []
+# Teleport configuration
+# See the admin guide for full details
+# https://gravitational.com/teleport/docs/admin-guide/#configuration-file
 #
-# - key: "dedicated"
-#   operator: "Equal"
-#   value: "teleport"
-#   effect: "NoExecute"
-# - key: "dedicated"
-#   operator: "Equal"
-#   value: "teleport"
-#   effect: "NoSchedule"
+# The following variables and parts are included in the templates/config.yaml for the teleport proxy/auth
+# configuration
+#
+config:
+  # used for cluster name, advertise_ip, and public addresses
+  # If high availability is set it is only used for the proxy
+  public_address: teleport.example.com
+  #used for listen addreses in proxy, auth and ssh
+  listen_addr: 0.0.0.0
+
+  # Set to true  to have separate proxy and auth instances for high availability.
+  # You must use non-dir storage for high availability or you can only have 1 auth instance .
+  highAvailability: false
+  # High availability configuration with proxy and auth servers. No SSH configured service.
+  proxyCount: 2
+  authCount: 2
+  authServiceType: ClusterIP
+  auth_public_address: auth.example.com
+
+# Set for proxies in high availability, single proxy and ssh service only deployments
+# auth_service_connection: 
+#   auth_token: dogs-are-much-nicer-than-cats
+#   auth_servers:
+#   - teleportauth:3025
+#   - auth.example.com:3025
+
+
+  teleport:
+    pid_file: /var/run/teleport.pid
+    log:
+      output: stderr
+      severity: INFO
+    data_dir: /var/lib/teleport
+    storage:
+      type: dir
+            
+    # Teleport throttles all connections to avoid abuse. These settings allow
+    # you to adjust the default limits
+    connection_limits:
+      max_connections: 1000
+      max_users: 250
+
+    auth_service:
+      enabled: yes
+      license_file: /var/lib/license/license-enterprise.pem
+      authentication:
+        type: local
+
+      # We recommend to use tools like `pwgen` to generate sufficiently random
+      # tokens of 32+ byte length.
+      tokens:
+      - proxy,node:dogs-are-much-nicer-than-cats
+      - trusted_cluster:trains-are-superior-to-cars
+
+    # Determines if SSH sessions to cluster nodes are forcefully terminated
+    # after no activity from a client (idle client).
+    # Examples: "30m", "1h" or "1h30m"
+      client_idle_timeout: never
+
+    # Determines if the clients will be forcefully disconnected when their
+    # certificates expire in the middle of an active SSH session. (default is 'no')
+      disconnect_expired_cert: no
+
+    # Determines the interval at which Teleport will send keep-alive messages.
+    # keep_alive_count_max is the number of missed keep-alive messages before
+    # the server tears down the connection to the client.
+      keep_alive_interval: 5m
+      keep_alive_count_max: 3
+
+    ssh_service:
+      enabled: yes
+      public_addr: 127.0.0.1
+      commands:
+      - command:
+        - uptime
+        - -p
+        name: uptime
+        period: 30m
+      labels:
+        type: auth
+
+      enhanced_recording:
+       # Enable or disable enhanced auditing for this node. Default value:
+       # false.  See 
+        enabled: false
+
+       # command_buffer_size is optional with a default value of 8 pages.
+        command_buffer_size: 8
+
+       # disk_buffer_size is optional with default value of 128 pages.
+        disk_buffer_size: 128
+
+       # network_buffer_size is optional with default value of 8 pages.
+        network_buffer_size: 8
+
+       # Controls where cgroupv2 hierarchy is mounted. Default value:
+       # /cgroup2.
+        cgroup_path: /cgroup2
+
+    # configures PAM integration. Note that additional volumes of the PAM configuration
+    # will be required.
+      pam:
+        enabled: no
+        service_name: teleport
+
+    proxy_service:
+      enabled: yes
+    #Used if  proxy.tls.usetlssecret is set to true, otherwise the values are not included in teleport.yaml
+      https_key_file: /var/lib/certs/tls.key
+      https_cert_file: /var/lib/certs/tls.crt
+
+    # kubernetes section configures
+    # kubernetes proxy protocol support
+      kubernetes:
+        enabled: yes
+
+#Alternatively you can provide your teleport configuration under teleportConfig with static text.  No variable substituion
+otherConfig:
+  useOtherConfig: false
+  teleportConfig:
+    # place a full teleport.yaml configuration here
+
+# Teleport configuration for high availability deployment 
+otherConfigHA:
+  useOtherConfig: false
+  teleportConfig:
+    # place a full teleport.yaml configuration here
 
 service:
   type: ClusterIP
@@ -120,58 +228,8 @@ ports:
   proxytunnel:
     containerPort: 3024
 
-# Teleport Proxy configuration
-proxy:
-  tls:
-    # We assume TLS is terminated in front of the proxy by default
-    enabled: true
-    # tweak this if you have multiple proxies in a single namespace
-    secretName: tls-web
 
-license:
-  ## Set false to run Teleport in Community edition mode
-  enabled: true
-  secretName: license
-  mountPath: /var/lib/license
 
-# See the admin guide for full details
-# https://gravitational.com/teleport/docs/admin-guide/#configuration-file
-config:
-  teleport:
-    log:
-      output: stderr
-      severity: DEBUG
-    data_dir: /var/lib/teleport
-    storage:
-      type: dir
-
-  auth_service:
-    enabled: yes
-    license_file: /var/lib/license/license-enterprise.pem
-    authentication:
-      type: oidc
-    public_addr: teleport.example.com:3025
-    cluster_name: teleport.example.com
-
-  ssh_service:
-    enabled: yes
-    public_addr: teleport.example.com:3022
-
-  proxy_service:
-    enabled: yes
-    public_addr: teleport.example.com
-    web_listen_addr: 0.0.0.0:3080
-    listen_addr: 0.0.0.0:3023
-    https_key_file: /var/lib/certs/tls.key
-    https_cert_file: /var/lib/certs/tls.crt
-    # kubernetes section configures
-    # kubernetes proxy protocol support
-    kubernetes:
-      enabled: yes
-      listen_addr: 0.0.0.0:3026
-      # public_addr is used to set values
-      # setup in kubeconfig after tsh login
-      # public_addr: [kubeproxy.example.com:443]
 
 ## Additional container arguments
 extraArgs: []
@@ -183,11 +241,14 @@ extraVars: {}
   # SSL_CERT_FILE: "/var/lib/ca-certs/ca.pem"
 
 # Add additional volumes and mounts, for example to read other log files on the host
-extraVolumes: []
+extraVolumes: [] 
+
+
   # - name: ca-certs
   #   configMap:
   #     name: ca-certs
 extraVolumeMounts: []
+
   # - name: ca-certs
   #   mountPath: /var/lib/ca-certs
   #   readOnly: true
@@ -203,6 +264,8 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 100Mi
+# Specify for the seperate auth service deployment
+authresources: {}
 
 rbac:
   # Specifies whether RBAC resources should be created
@@ -235,3 +298,53 @@ persistence:
 
 # set this to false to avoid running into issues for proxies that run in a separate k8s cluster
 automountServiceAccountToken: true
+
+# Pod annotations
+annotations: {}
+## See https://github.com/uswitch/kiam#overview
+## To enable AWS API access from teleport, use kube2iam or kiam, annotate the namespace, and then set something like:
+# iam.amazonaws.com/role: teleport-dynamodb-and-s3-access
+
+#Replica count is not recommended to increase
+replicaCount: 1
+strategy: RollingUpdate
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity: {}
+#
+## For the sake of security, make specific node group(s) dedicated to Teleport
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#       - matchExpressions:
+#         - key: gravitational.io/dedicated
+#           operator: In
+#           values:
+#           - teleport
+#
+## For high availability, distribute teleport pods to nodes as evenly as possible
+#   podAntiAffinity:
+#     preferredDuringSchedulingIgnoredDuringExecution:
+#     - podAffinityTerm:
+#         labelSelector:
+#           matchExpressions:
+#           - key: app
+#             operator: In
+#             values:
+#             - teleport
+#         topologyKey: kubernetes.io/hostname
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+#
+# - key: "dedicated"
+#   operator: "Equal"
+#   value: "teleport"
+#   effect: "NoExecute"
+# - key: "dedicated"
+#   operator: "Equal"
+#   value: "teleport"
+#   effect: "NoSchedule"
+

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -252,6 +252,10 @@ extraVolumeMounts: []
   # - name: ca-certs
   #   mountPath: /var/lib/ca-certs
   #   readOnly: true
+  
+# Volume mounts only for the auth service in high availability deployments
+extraAuthVolumes: []
+extraAuthVolumeMounts: []  
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Provides the following updates:

 - Single place to set public address (teleport.example.com)
- Dynamically determined teleport configuration or static configuration
 - Usable for Teleport Community or Enterprise
- High availability configuration with separate deployments for proxy and auth
- Allows for using self-signed certificates
- Documentation updates for new features and streamlined deployment