### PR TITLE
Replace "Entity" with "Name" in audit events

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1120,7 +1120,7 @@ func (a *AuthWithRoles) CreateResetPasswordToken(ctx context.Context, req Create
 	}
 
 	if err := a.EmitAuditEvent(events.ResetPasswordTokenCreated, events.EventFields{
-		events.ActionOnBehalfOf:      req.Name,
+		events.FieldName:             req.Name,
 		events.ResetPasswordTokenTTL: req.TTL.String(),
 		events.EventUser:             a.user.GetName(),
 	}); err != nil {

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -55,11 +55,11 @@ func (s *AuthServer) CreateUser(ctx context.Context, user services.User) error {
 	}
 
 	if err := s.EmitAuditEvent(events.UserCreate, events.EventFields{
-		events.EventUser:        createdBy.User.Name,
-		events.UserExpires:      user.Expiry(),
-		events.UserRoles:        user.GetRoles(),
-		events.ActionOnBehalfOf: user.GetName(),
-		events.UserConnector:    connectorName,
+		events.EventUser:     createdBy.User.Name,
+		events.UserExpires:   user.Expiry(),
+		events.UserRoles:     user.GetRoles(),
+		events.FieldName:     user.GetName(),
+		events.UserConnector: connectorName,
 	}); err != nil {
 		log.Warnf("Failed to emit user create event: %v", err)
 	}
@@ -86,11 +86,11 @@ func (s *AuthServer) UpdateUser(ctx context.Context, user services.User) error {
 	}
 
 	if err := s.EmitAuditEvent(events.UserUpdate, events.EventFields{
-		events.EventUser:        updateBy,
-		events.UserExpires:      user.Expiry(),
-		events.UserRoles:        user.GetRoles(),
-		events.ActionOnBehalfOf: user.GetName(),
-		events.UserConnector:    connectorName,
+		events.EventUser:     updateBy,
+		events.FieldName:     user.GetName(),
+		events.UserExpires:   user.Expiry(),
+		events.UserRoles:     user.GetRoles(),
+		events.UserConnector: connectorName,
 	}); err != nil {
 		log.Warnf("Failed to emit user update event: %v", err)
 	}
@@ -151,8 +151,8 @@ func (s *AuthServer) DeleteUser(ctx context.Context, user string) error {
 
 	// If the user was successfully deleted, emit an event.
 	if err := s.EmitAuditEvent(events.UserDelete, events.EventFields{
-		events.ActionOnBehalfOf: user,
-		events.EventUser:        deletedBy,
+		events.FieldName: user,
+		events.EventUser: deletedBy,
 	}); err != nil {
 		log.Warnf("Failed to emit user delete event: %v", err)
 	}

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -191,10 +191,6 @@ const (
 	// ResetPasswordTokenTTL is TTL of reset password token.
 	ResetPasswordTokenTTL = "ttl"
 
-	// ActionOnBehalfOf is the name of the user, whom record is being modified:
-	// resetting passwords, creating/updating user, etc.
-	ActionOnBehalfOf = "entity"
-
 	// FieldName contains name, e.g. resource name, etc.
 	FieldName = "name"
 


### PR DESCRIPTION
Since we use "name" event field to store a resource name, it's better to be consistent. This is part of the new code (will be backported to 4.3 branch as well)