### PR TITLE
Use ServerConn to retrieve ip address of node

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -484,7 +484,7 @@ func newSession(id rsession.ID, r *SessionRegistry, ctx *ServerContext) (*sessio
 		ServerID:       ctx.srv.ID(),
 		Namespace:      r.srv.GetNamespace(),
 		ServerHostname: ctx.srv.GetInfo().GetHostname(),
-		ServerAddr:     ctx.srv.GetInfo().GetAddr(),
+		ServerAddr:     ctx.ServerConn.LocalAddr().String(),
 		ClusterName:    ctx.ClusterName,
 	}
 


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/3829#event-3454666851

#### Description
- Use ServerConn to retrieve the ip address of node the client is connected to
- Using ServerContext can be empty (or `::`) if the `advertise_ip` in config is not set