### PR TITLE
Remove system admin from error message

### DIFF
--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -113,7 +113,7 @@ func (s *AuthServer) createOIDCClient(conn services.OIDCConnector) (*oidc.Client
 		// return user-friendly error hiding the actual error in the event
 		// logs for security purposes
 		return nil, trace.ConnectionProblem(nil,
-			"Failed to login with %v.",
+			"failed to login with %v",
 			conn.GetDisplay())
 	}
 

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -113,7 +113,7 @@ func (s *AuthServer) createOIDCClient(conn services.OIDCConnector) (*oidc.Client
 		// return user-friendly error hiding the actual error in the event
 		// logs for security purposes
 		return nil, trace.ConnectionProblem(nil,
-			"failed to login with %v, please contact your system administrator to check audit logs",
+			"Failed to login with %v.",
 			conn.GetDisplay())
 	}
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -864,7 +864,7 @@ func (h *Handler) oidcCallback(w http.ResponseWriter, r *http.Request, p httprou
 	if err != nil {
 		log.Warningf("[OIDC] Error while processing callback: %v", err)
 
-		message := "Unable to process callback from OIDC provider. Ask your system administrator to check audit logs for details."
+		message := "Unable to process callback from OIDC provider."
 		// redirect to an error page
 		pathToError := url.URL{
 			Path:     "/web/msg/error/login_failed",

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -102,7 +102,7 @@ func (m *Handler) samlACS(w http.ResponseWriter, r *http.Request, p httprouter.P
 	if err != nil {
 		log.Warningf("error while processing callback: %v", err)
 
-		message := "Unable to process callback from SAML provider. Ask your system administrator to check audit logs for details."
+		message := "Unable to process callback from SAML provider."
 		// for not implemented errors it's ok to provide a more specific
 		// message as it could give more guidance on what's not enabled
 		if trace.IsNotImplemented(err) {


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/3774

#### Description
Remove confusing `system admin` word from connector error messages displayed to users.