### PR TITLE
Add missing URL

### DIFF
--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -370,7 +370,7 @@ ssh_service:
     permit_user_env: false
 
     # Enhanced Session Recording was introduced with Teleport 4.2. For more details
-    # see
+    # see https://gravitational.com/teleport/docs/features/enhanced_session_recording
     enhanced_recording:
        # Enable or disable enhanced auditing for this node. Default value:
        # false.

--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -362,7 +362,7 @@ ssh_service:
     permit_user_env: false
 
     # Enhanced Session Recording was introduced with Teleport 4.2. For more details
-    # see
+    # see https://gravitational.com/teleport/docs/features/enhanced_session_recording
     enhanced_recording:
        # Enable or disable enhanced auditing for this node. Default value:
        # false.


### PR DESCRIPTION
A URL was missing, so I assumed it was a URL to `enhanced session recording`