### PR TITLE
Send the correct SNI from tsh to auth server

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -366,6 +366,7 @@ func (a *TestAuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, p
 	}
 	tlsConfig.Certificates = []tls.Certificate{*cert}
 	tlsConfig.RootCAs = pool
+	tlsConfig.ServerName = EncodeClusterName(a.ClusterName)
 	addrs := []utils.NetAddr{{
 		AddrNetwork: addr.Network(),
 		Addr:        addr.String()}}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -19,7 +19,6 @@ package client
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -352,28 +351,14 @@ func (proxy *ProxyClient) ConnectToCluster(ctx context.Context, clusterName stri
 		})
 	}
 
-	// Because Teleport clients can't be configured (yet), they take the default
-	// list of cipher suites from Go.
-	tlsConfig := utils.TLSConfig(nil)
 	localAgent := proxy.teleportClient.LocalAgent()
-	pool, err := localAgent.GetCerts()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	tlsConfig.RootCAs = pool
 	key, err := localAgent.GetKey()
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to fetch TLS key for %v", proxy.teleportClient.Username)
 	}
-	if len(key.TLSCert) != 0 {
-		tlsCert, err := tls.X509KeyPair(key.TLSCert, key.Priv)
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to parse TLS cert and key")
-		}
-		tlsConfig.Certificates = append(tlsConfig.Certificates, tlsCert)
-	}
-	if len(tlsConfig.Certificates) == 0 {
-		return nil, trace.BadParameter("no TLS keys found for user %v, please relogin to get new credentials", proxy.teleportClient.Username)
+	tlsConfig, err := key.ClientTLSConfig()
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to generate client TLS config")
 	}
 	clt, err := auth.NewTLSClient(auth.ClientConfig{
 		Dialer: dialer,

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -101,6 +101,13 @@ func (k *Key) ClientTLSConfig() (*tls.Config, error) {
 		return nil, trace.Wrap(err, "failed to parse TLS cert and key")
 	}
 	tlsConfig.Certificates = append(tlsConfig.Certificates, tlsCert)
+	// Use Issuer CN from the certificate to populate the correct SNI in
+	// requests.
+	leaf, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse TLS cert")
+	}
+	tlsConfig.ServerName = auth.EncodeClusterName(leaf.Issuer.CommonName)
 	return tlsConfig, nil
 }
 


### PR DESCRIPTION
SNI is used to indicate which cluster's CA to use for client cert
validation. If SNI is not sent, or set as "teleport.cluster.local"
(which is default in the client config), auth server will attempt to
validate against all known CAs.

The list of CA subjects is sent to the client during handshake, before
client sends its own client cert. If this list is too long, handshake
will fail. The limit is 65535 bytes, because TLS wire encoding uses 2
bytes for a length prefix. In teleport, this fits ~520-540 trusted
cluster CAs.

To avoid handshake failures on such large setups, all clients must send
the correct SNI. In some future version, we should enforce this to catch
such issues early. For now, added a debug log to report clients using
the default ServerName. Also added a check for large number of CAs, to
print a helpful error.

Updates https://github.com/gravitational/teleport/issues/3870