### PR TITLE
Backport: ensure that disconnects propagate through port-forwarded tunnel

### DIFF
--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -947,6 +947,8 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 	if err != nil {
 		writeStderr(channel, err.Error())
 	}
+	// Propagate stderr from the spawned Teleport process to log any errors.
+	cmd.Stderr = os.Stderr
 
 	// Create a pipe for std{in,out} that will be used to transfer data between
 	// parent and child.
@@ -971,6 +973,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 	// pipe to channel.
 	errorCh := make(chan error, 2)
 	go func() {
+		defer channel.Close()
 		defer pw.Close()
 		defer pr.Close()
 
@@ -978,6 +981,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 		errorCh <- err
 	}()
 	go func() {
+		defer channel.Close()
 		defer pw.Close()
 		defer pr.Close()
 


### PR DESCRIPTION
This is a backport of https://github.com/gravitational/teleport/pull/3801 into 4.3

When a client terminates, it should propagate over to the server on
remote host without it attempting to write. The defered cleanup wasn't
closing all the right connections to make this happen.

When a server terminates, re-execed teleport might not notice until
client sends new data. Re-execed teleport should exit on first observed
error in either direction and not wait for both ends.

Fixes #3749