### PR TITLE
Backport: plumb caller username for CRUD events via contexts

### DIFF
--- a/examples/go-client/main.go
+++ b/examples/go-client/main.go
@@ -46,9 +46,10 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
+	ctx := context.Background()
 	// make an API call to generate a cluster join token for
 	// adding another proxy to a cluster.
-	token, err := client.GenerateToken(auth.GenerateTokenRequest{
+	token, err := client.GenerateToken(ctx, auth.GenerateTokenRequest{
 		Token: "mytoken-proxy",
 		Roles: teleport.Roles{teleport.RoleProxy},
 		TTL:   time.Hour,

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -393,6 +393,7 @@ func SetupUserCreds(tc *client.TeleportClient, proxyHost string, creds UserCreds
 
 // SetupUser sets up user in the cluster
 func SetupUser(process *service.TeleportProcess, username string, roles []services.Role) error {
+	ctx := context.TODO()
 	auth := process.GetAuthServer()
 	teleUser, err := services.NewUser(username)
 	if err != nil {
@@ -407,14 +408,14 @@ func SetupUser(process *service.TeleportProcess, username string, roles []servic
 		roleOptions.ForwardAgent = services.NewBool(true)
 		role.SetOptions(roleOptions)
 
-		err = auth.UpsertRole(role)
+		err = auth.UpsertRole(ctx, role)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		teleUser.AddRole(role.GetMetadata().Name)
 	} else {
 		for _, role := range roles {
-			err := auth.UpsertRole(role)
+			err := auth.UpsertRole(ctx, role)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -567,6 +568,7 @@ func (i *TeleInstance) GenerateConfig(trustedSecrets []*InstanceSecrets, tconf *
 // Unlike Create() it allows for greater customization because it accepts
 // a full Teleport config structure
 func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *service.Config) error {
+	ctx := context.TODO()
 	tconf, err := i.GenerateConfig(trustedSecrets, tconf)
 	if err != nil {
 		return trace.Wrap(err)
@@ -603,14 +605,14 @@ func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *servic
 			roleOptions.ForwardAgent = services.NewBool(true)
 			role.SetOptions(roleOptions)
 
-			err = auth.UpsertRole(role)
+			err = auth.UpsertRole(ctx, role)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 			teleUser.AddRole(role.GetMetadata().Name)
 		} else {
 			for _, role := range user.Roles {
-				err := auth.UpsertRole(role)
+				err := auth.UpsertRole(ctx, role)
 				if err != nil {
 					return trace.Wrap(err)
 				}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1350,6 +1350,7 @@ func (s *IntSuite) TestHA(c *check.C) {
 
 // TestMapRoles tests local to remote role mapping and access patterns
 func (s *IntSuite) TestMapRoles(c *check.C) {
+	ctx := context.Background()
 	tr := utils.NewTracer(utils.ThisFunction()).Start()
 	defer tr.Stop()
 
@@ -1397,7 +1398,7 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = aux.Process.GetAuthServer().UpsertRole(role)
+	err = aux.Process.GetAuthServer().UpsertRole(ctx, role)
 	c.Assert(err, check.IsNil)
 	trustedClusterToken := "trusted-cluster-token"
 	err = main.Process.GetAuthServer().UpsertToken(
@@ -1549,9 +1550,10 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 // retries on connection problems and access denied errors to let caches
 // propagate and services to start
 func tryCreateTrustedCluster(c *check.C, authServer *auth.AuthServer, trustedCluster services.TrustedCluster) {
+	ctx := context.TODO()
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v.", trustedCluster, i)
-		_, err := authServer.UpsertTrustedCluster(trustedCluster)
+		_, err := authServer.UpsertTrustedCluster(ctx, trustedCluster)
 		if err == nil {
 			return
 		}
@@ -1608,6 +1610,7 @@ func (s *IntSuite) TestMultiplexingTrustedClusters(c *check.C) {
 }
 
 func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
+	ctx := context.Background()
 	username := s.me.Username
 
 	clusterMain := "cluster-main"
@@ -1661,7 +1664,7 @@ func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = aux.Process.GetAuthServer().UpsertRole(auxRole)
+	err = aux.Process.GetAuthServer().UpsertRole(ctx, auxRole)
 	c.Assert(err, check.IsNil)
 	trustedClusterToken := "trusted-cluster-token"
 	err = main.Process.GetAuthServer().UpsertToken(
@@ -1732,7 +1735,7 @@ func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
 	c.Assert(err, check.IsNil)
 	for i := 0; i < 10; i++ {
 		time.Sleep(time.Millisecond * 50)
-		err = tc.SSH(context.TODO(), cmd, false)
+		err = tc.SSH(ctx, cmd, false)
 		if err == nil {
 			break
 		}
@@ -1742,7 +1745,7 @@ func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
 
 	// ListNodes expect labels as a value of host
 	tc.Host = ""
-	servers, err := tc.ListNodes(context.TODO())
+	servers, err := tc.ListNodes(ctx)
 	c.Assert(err, check.IsNil)
 	c.Assert(servers, check.HasLen, 2)
 	tc.Host = Loopback
@@ -1758,7 +1761,7 @@ func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
 	c.Assert(err, check.IsNil)
 	for i := 0; i < 10; i++ {
 		time.Sleep(time.Millisecond * 50)
-		err = tc.SSH(context.TODO(), cmd, false)
+		err = tc.SSH(ctx, cmd, false)
 		if err != nil {
 			break
 		}
@@ -1767,9 +1770,9 @@ func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
 
 	// remove trusted cluster from aux cluster side, and recrete right after
 	// this should re-establish connection
-	err = aux.Process.GetAuthServer().DeleteTrustedCluster(trustedCluster.GetName())
+	err = aux.Process.GetAuthServer().DeleteTrustedCluster(ctx, trustedCluster.GetName())
 	c.Assert(err, check.IsNil)
-	_, err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
+	_, err = aux.Process.GetAuthServer().UpsertTrustedCluster(ctx, trustedCluster)
 	c.Assert(err, check.IsNil)
 
 	// check that remote cluster has been re-provisioned
@@ -1792,7 +1795,7 @@ func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
 	tc.Stdout = output
 	for i := 0; i < 10; i++ {
 		time.Sleep(time.Millisecond * 50)
-		err = tc.SSH(context.TODO(), cmd, false)
+		err = tc.SSH(ctx, cmd, false)
 		if err == nil {
 			break
 		}
@@ -1806,6 +1809,7 @@ func (s *IntSuite) trustedClusters(c *check.C, test trustedClusterTest) {
 }
 
 func (s *IntSuite) TestTrustedTunnelNode(c *check.C) {
+	ctx := context.Background()
 	username := s.me.Username
 
 	clusterMain := "cluster-main"
@@ -1850,7 +1854,7 @@ func (s *IntSuite) TestTrustedTunnelNode(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = aux.Process.GetAuthServer().UpsertRole(role)
+	err = aux.Process.GetAuthServer().UpsertRole(ctx, role)
 	c.Assert(err, check.IsNil)
 	trustedClusterToken := "trusted-cluster-token"
 	err = main.Process.GetAuthServer().UpsertToken(
@@ -3283,7 +3287,7 @@ func (s *IntSuite) TestRotateTrustedClusters(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = aux.Process.GetAuthServer().UpsertRole(role)
+	err = aux.Process.GetAuthServer().UpsertRole(ctx, role)
 	c.Assert(err, check.IsNil)
 	trustedClusterToken := "trusted-clsuter-token"
 	err = svc.GetAuthServer().UpsertToken(

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -474,7 +474,7 @@ func (s *KubeSuite) TestKubePortForward(c *check.C) {
 // TestKubeTrustedClustersClientCert tests scenario with trusted clusters
 // using metadata encoded in the certificate
 func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
-
+	ctx := context.Background()
 	clusterMain := "cluster-main"
 	mainConf := s.teleKubeConfig(Host)
 	main := NewInstance(InstanceConfig{
@@ -534,7 +534,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = aux.Process.GetAuthServer().UpsertRole(auxRole)
+	err = aux.Process.GetAuthServer().UpsertRole(ctx, auxRole)
 	c.Assert(err, check.IsNil)
 	trustedClusterToken := "trusted-clsuter-token"
 	err = main.Process.GetAuthServer().UpsertToken(
@@ -558,7 +558,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 	var upsertSuccess bool
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v", trustedCluster, i)
-		_, err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
+		_, err = aux.Process.GetAuthServer().UpsertTrustedCluster(ctx, trustedCluster)
 		if err != nil {
 			if trace.IsConnectionProblem(err) {
 				log.Debugf("retrying on connection problem: %v", err)
@@ -718,7 +718,7 @@ loop:
 			return net.Dial("tcp", fmt.Sprintf("localhost:%v", localPort))
 		},
 	}
-	addr, err := resolver.LookupHost(context.TODO(), "kubernetes.default.svc.cluster.local")
+	addr, err := resolver.LookupHost(ctx, "kubernetes.default.svc.cluster.local")
 	c.Assert(err, check.IsNil)
 	c.Assert(len(addr), check.Not(check.Equals), 0)
 
@@ -742,6 +742,7 @@ loop:
 // using SNI-forwarding
 // DELETE IN(4.3.0)
 func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
+	ctx := context.Background()
 
 	clusterMain := "cluster-main"
 	mainConf := s.teleKubeConfig(Host)
@@ -806,7 +807,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 		},
 	})
 	c.Assert(err, check.IsNil)
-	err = aux.Process.GetAuthServer().UpsertRole(auxRole)
+	err = aux.Process.GetAuthServer().UpsertRole(ctx, auxRole)
 	c.Assert(err, check.IsNil)
 	trustedClusterToken := "trusted-clsuter-token"
 	err = main.Process.GetAuthServer().UpsertToken(
@@ -830,7 +831,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 	var upsertSuccess bool
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v", trustedCluster, i)
-		_, err = aux.Process.GetAuthServer().UpsertTrustedCluster(trustedCluster)
+		_, err = aux.Process.GetAuthServer().UpsertTrustedCluster(ctx, trustedCluster)
 		if err != nil {
 			if trace.IsConnectionProblem(err) {
 				log.Debugf("retrying on connection problem: %v", err)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -580,7 +580,7 @@ func (s *APIServer) upsertTrustedCluster(auth ClientI, w http.ResponseWriter, r 
 		return nil, trace.Wrap(err)
 	}
 
-	out, err := auth.UpsertTrustedCluster(trustedCluster)
+	out, err := auth.UpsertTrustedCluster(r.Context(), trustedCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -622,7 +622,7 @@ func (s *APIServer) getTrustedClusters(auth ClientI, w http.ResponseWriter, r *h
 
 // deleteTrustedCluster deletes a trusted cluster by name.
 func (s *APIServer) deleteTrustedCluster(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	err := auth.DeleteTrustedCluster(p.ByName("name"))
+	err := auth.DeleteTrustedCluster(r.Context(), p.ByName("name"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -958,7 +958,7 @@ func (s *APIServer) generateToken(auth ClientI, w http.ResponseWriter, r *http.R
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	token, err := auth.GenerateToken(req)
+	token, err := auth.GenerateToken(r.Context(), req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1266,7 +1266,7 @@ func (s *APIServer) upsertOIDCConnector(auth ClientI, w http.ResponseWriter, r *
 	if req.TTL != 0 {
 		connector.SetTTL(s, req.TTL)
 	}
-	err = auth.UpsertOIDCConnector(connector)
+	err = auth.UpsertOIDCConnector(r.Context(), connector)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1286,7 +1286,7 @@ func (s *APIServer) getOIDCConnector(auth ClientI, w http.ResponseWriter, r *htt
 }
 
 func (s *APIServer) deleteOIDCConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	err := auth.DeleteOIDCConnector(p.ByName("id"))
+	err := auth.DeleteOIDCConnector(r.Context(), p.ByName("id"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1400,7 +1400,7 @@ func (s *APIServer) createSAMLConnector(auth ClientI, w http.ResponseWriter, r *
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = auth.CreateSAMLConnector(connector)
+	err = auth.CreateSAMLConnector(r.Context(), connector)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1420,7 +1420,7 @@ func (s *APIServer) upsertSAMLConnector(auth ClientI, w http.ResponseWriter, r *
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = auth.UpsertSAMLConnector(connector)
+	err = auth.UpsertSAMLConnector(r.Context(), connector)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1440,7 +1440,7 @@ func (s *APIServer) getSAMLConnector(auth ClientI, w http.ResponseWriter, r *htt
 }
 
 func (s *APIServer) deleteSAMLConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	err := auth.DeleteSAMLConnector(p.ByName("id"))
+	err := auth.DeleteSAMLConnector(r.Context(), p.ByName("id"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1589,7 +1589,7 @@ func (s *APIServer) upsertGithubConnector(auth ClientI, w http.ResponseWriter, r
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := auth.UpsertGithubConnector(connector); err != nil {
+	if err := auth.UpsertGithubConnector(r.Context(), connector); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil
@@ -1646,7 +1646,7 @@ func (s *APIServer) getGithubConnector(auth ClientI, w http.ResponseWriter, r *h
    Success response: {"message": "ok"}
 */
 func (s *APIServer) deleteGithubConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
-	if err := auth.DeleteGithubConnector(p.ByName("id")); err != nil {
+	if err := auth.DeleteGithubConnector(r.Context(), p.ByName("id")); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil
@@ -2099,7 +2099,7 @@ func (s *APIServer) upsertRole(auth ClientI, w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = auth.UpsertRole(role)
+	err = auth.UpsertRole(r.Context(), role)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2132,7 +2132,7 @@ func (s *APIServer) getRoles(auth ClientI, w http.ResponseWriter, r *http.Reques
 
 func (s *APIServer) deleteRole(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	role := p.ByName("role")
-	if err := auth.DeleteRole(role); err != nil {
+	if err := auth.DeleteRole(r.Context(), role); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return message(fmt.Sprintf("role %q deleted", role)), nil

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -821,7 +821,7 @@ func (req *GenerateTokenRequest) CheckAndSetDefaults() error {
 }
 
 // GenerateToken generates multi-purpose authentication token.
-func (a *AuthServer) GenerateToken(req GenerateTokenRequest) (string, error) {
+func (a *AuthServer) GenerateToken(ctx context.Context, req GenerateTokenRequest) (string, error) {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -833,10 +833,11 @@ func (a *AuthServer) GenerateToken(req GenerateTokenRequest) (string, error) {
 		return "", trace.Wrap(err)
 	}
 
+	user := clientUsername(ctx)
 	for _, role := range req.Roles {
 		if role == teleport.RoleTrustedCluster {
 			if err := a.EmitAuditEvent(events.TrustedClusterTokenCreate, events.EventFields{
-				events.EventUser: "unimplemented",
+				events.EventUser: user,
 			}); err != nil {
 				log.Warnf("Failed to emit trusted cluster token create event: %v", err)
 			}
@@ -1358,7 +1359,7 @@ func (a *AuthServer) NewWatcher(ctx context.Context, watch services.Watch) (serv
 }
 
 // DeleteRole deletes a role by name of the role.
-func (a *AuthServer) DeleteRole(name string) error {
+func (a *AuthServer) DeleteRole(ctx context.Context, name string) error {
 	// check if this role is used by CA or Users
 	users, err := a.Identity.GetUsers(false)
 	if err != nil {
@@ -1391,13 +1392,13 @@ func (a *AuthServer) DeleteRole(name string) error {
 		}
 	}
 
-	if err := a.Access.DeleteRole(name); err != nil {
+	if err := a.Access.DeleteRole(ctx, name); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if err := a.EmitAuditEvent(events.RoleDeleted, events.EventFields{
 		events.FieldName: name,
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit role deleted event: %v", err)
 	}
@@ -1406,14 +1407,14 @@ func (a *AuthServer) DeleteRole(name string) error {
 }
 
 // UpsertRole creates or updates role.
-func (a *AuthServer) upsertRole(role services.Role) error {
-	if err := a.UpsertRole(role); err != nil {
+func (a *AuthServer) upsertRole(ctx context.Context, role services.Role) error {
+	if err := a.UpsertRole(ctx, role); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if err := a.EmitAuditEvent(events.RoleCreated, events.EventFields{
 		events.FieldName: role.GetName(),
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit role created event: %v", err)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1463,19 +1463,15 @@ func (a *AuthServer) SetAccessRequestState(ctx context.Context, reqID string, st
 	if err := a.DynamicAccess.SetAccessRequestState(ctx, reqID, state); err != nil {
 		return trace.Wrap(err)
 	}
-	updateBy, err := getUpdateBy(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	fields := events.EventFields{
 		events.AccessRequestID:    reqID,
 		events.AccessRequestState: state.String(),
-		events.UpdatedBy:          updateBy,
+		events.UpdatedBy:          clientUsername(ctx),
 	}
 	if delegator := getDelegator(ctx); delegator != "" {
 		fields[events.AccessRequestDelegator] = delegator
 	}
-	err = a.EmitAuditEvent(events.AccessRequestUpdated, fields)
+	err := a.EmitAuditEvent(events.AccessRequestUpdated, fields)
 	return trace.Wrap(err)
 }
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -808,7 +808,6 @@ func (a *AuthWithRoles) SetAccessRequestState(ctx context.Context, reqID string,
 	if err := a.action(defaults.Namespace, services.KindAccessRequest, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	ctx = withUpdateBy(ctx, a.user.GetName())
 	return a.authServer.SetAccessRequestState(ctx, reqID, state)
 }
 
@@ -857,21 +856,6 @@ func (a *AuthWithRoles) Ping(ctx context.Context) (proto.PingResponse, error) {
 }
 
 type contextKey string
-
-// withUpdateBy creates a child context with the updated_by value set.
-// Helps capture the user who modified a resource.
-func withUpdateBy(ctx context.Context, user string) context.Context {
-	return context.WithValue(ctx, contextKey(events.UpdatedBy), user)
-}
-
-// getUpdateBy attempts to load the context value updated_by.
-func getUpdateBy(ctx context.Context) (string, error) {
-	updateBy, ok := ctx.Value(contextKey(events.UpdatedBy)).(string)
-	if !ok || updateBy == "" {
-		return "", trace.BadParameter("missing value %q", events.UpdatedBy)
-	}
-	return updateBy, nil
-}
 
 // WithDelegator creates a child context with the AccessRequestDelegator
 // value set.  Optionally used by AuthServer.SetAccessRequestState to log
@@ -960,8 +944,6 @@ func (a *AuthWithRoles) DeleteUser(ctx context.Context, user string) error {
 	if err := a.action(defaults.Namespace, services.KindUser, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-
-	ctx = withUpdateBy(ctx, a.user.GetName())
 
 	return a.authServer.DeleteUser(ctx, user)
 }
@@ -1164,8 +1146,6 @@ func (a *AuthWithRoles) UpdateUser(ctx context.Context, user services.User) erro
 	if err := a.action(defaults.Namespace, services.KindUser, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-
-	ctx = withUpdateBy(ctx, a.user.GetName())
 
 	return a.authServer.UpdateUser(ctx, user)
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -307,11 +307,11 @@ func (a *AuthWithRoles) DeactivateCertAuthority(id services.CertAuthID) error {
 }
 
 // GenerateToken generates multi-purpose authentication token.
-func (a *AuthWithRoles) GenerateToken(req GenerateTokenRequest) (string, error) {
+func (a *AuthWithRoles) GenerateToken(ctx context.Context, req GenerateTokenRequest) (string, error) {
 	if err := a.action(defaults.Namespace, services.KindToken, services.VerbCreate); err != nil {
 		return "", trace.Wrap(err)
 	}
-	return a.authServer.GenerateToken(req)
+	return a.authServer.GenerateToken(ctx, req)
 }
 
 func (a *AuthWithRoles) RegisterUsingToken(req RegisterUsingTokenRequest) (*PackedKeys, error) {
@@ -1188,14 +1188,14 @@ func (a *AuthWithRoles) UpsertUser(u services.User) error {
 }
 
 // UpsertOIDCConnector creates or updates an OIDC connector.
-func (a *AuthWithRoles) UpsertOIDCConnector(connector services.OIDCConnector) error {
+func (a *AuthWithRoles) UpsertOIDCConnector(ctx context.Context, connector services.OIDCConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.UpsertOIDCConnector(connector)
+	return a.authServer.UpsertOIDCConnector(ctx, connector)
 }
 
 func (a *AuthWithRoles) GetOIDCConnector(id string, withSecrets bool) (services.OIDCConnector, error) {
@@ -1237,29 +1237,29 @@ func (a *AuthWithRoles) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthRespons
 	return a.authServer.ValidateOIDCAuthCallback(q)
 }
 
-func (a *AuthWithRoles) DeleteOIDCConnector(connectorID string) error {
+func (a *AuthWithRoles) DeleteOIDCConnector(ctx context.Context, connectorID string) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.DeleteOIDCConnector(connectorID)
+	return a.authServer.DeleteOIDCConnector(ctx, connectorID)
 }
 
-func (a *AuthWithRoles) CreateSAMLConnector(connector services.SAMLConnector) error {
+func (a *AuthWithRoles) CreateSAMLConnector(ctx context.Context, connector services.SAMLConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.UpsertSAMLConnector(connector)
+	return a.authServer.UpsertSAMLConnector(ctx, connector)
 }
 
 // UpsertSAMLConnector creates or updates a SAML connector.
-func (a *AuthWithRoles) UpsertSAMLConnector(connector services.SAMLConnector) error {
+func (a *AuthWithRoles) UpsertSAMLConnector(ctx context.Context, connector services.SAMLConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.UpsertSAMLConnector(connector)
+	return a.authServer.UpsertSAMLConnector(ctx, connector)
 }
 
 func (a *AuthWithRoles) GetSAMLConnector(id string, withSecrets bool) (services.SAMLConnector, error) {
@@ -1302,11 +1302,11 @@ func (a *AuthWithRoles) ValidateSAMLResponse(re string) (*SAMLAuthResponse, erro
 }
 
 // DeleteSAMLConnector deletes a SAML connector by name.
-func (a *AuthWithRoles) DeleteSAMLConnector(connectorID string) error {
+func (a *AuthWithRoles) DeleteSAMLConnector(ctx context.Context, connectorID string) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.DeleteSAMLConnector(connectorID)
+	return a.authServer.DeleteSAMLConnector(ctx, connectorID)
 }
 
 func (a *AuthWithRoles) CreateGithubConnector(connector services.GithubConnector) error {
@@ -1317,14 +1317,14 @@ func (a *AuthWithRoles) CreateGithubConnector(connector services.GithubConnector
 }
 
 // UpsertGithubConnector creates or updates a Github connector.
-func (a *AuthWithRoles) UpsertGithubConnector(connector services.GithubConnector) error {
+func (a *AuthWithRoles) UpsertGithubConnector(ctx context.Context, connector services.GithubConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.upsertGithubConnector(connector)
+	return a.authServer.upsertGithubConnector(ctx, connector)
 }
 
 func (a *AuthWithRoles) GetGithubConnector(id string, withSecrets bool) (services.GithubConnector, error) {
@@ -1355,11 +1355,11 @@ func (a *AuthWithRoles) GetGithubConnectors(withSecrets bool) ([]services.Github
 }
 
 // DeleteGithubConnector deletes a Github connector by name.
-func (a *AuthWithRoles) DeleteGithubConnector(connectorID string) error {
+func (a *AuthWithRoles) DeleteGithubConnector(ctx context.Context, connectorID string) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.deleteGithubConnector(connectorID)
+	return a.authServer.deleteGithubConnector(ctx, connectorID)
 }
 
 func (a *AuthWithRoles) CreateGithubAuthRequest(req services.GithubAuthRequest) (*services.GithubAuthRequest, error) {
@@ -1493,7 +1493,7 @@ func (a *AuthWithRoles) CreateRole(role services.Role) error {
 }
 
 // UpsertRole creates or updates role.
-func (a *AuthWithRoles) UpsertRole(role services.Role) error {
+func (a *AuthWithRoles) UpsertRole(ctx context.Context, role services.Role) error {
 	if err := a.action(defaults.Namespace, services.KindRole, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1501,7 +1501,7 @@ func (a *AuthWithRoles) UpsertRole(role services.Role) error {
 		return trace.Wrap(err)
 	}
 
-	return a.authServer.upsertRole(role)
+	return a.authServer.upsertRole(ctx, role)
 }
 
 // GetRole returns role by name
@@ -1517,11 +1517,11 @@ func (a *AuthWithRoles) GetRole(name string) (services.Role, error) {
 }
 
 // DeleteRole deletes role by name
-func (a *AuthWithRoles) DeleteRole(name string) error {
+func (a *AuthWithRoles) DeleteRole(ctx context.Context, name string) error {
 	if err := a.action(defaults.Namespace, services.KindRole, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.DeleteRole(name)
+	return a.authServer.DeleteRole(ctx, name)
 }
 
 // GetClusterConfig gets cluster level configuration.
@@ -1685,7 +1685,7 @@ func (a *AuthWithRoles) GetTrustedCluster(name string) (services.TrustedCluster,
 }
 
 // UpsertTrustedCluster creates or updates a trusted cluster.
-func (a *AuthWithRoles) UpsertTrustedCluster(tc services.TrustedCluster) (services.TrustedCluster, error) {
+func (a *AuthWithRoles) UpsertTrustedCluster(ctx context.Context, tc services.TrustedCluster) (services.TrustedCluster, error) {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1693,7 +1693,7 @@ func (a *AuthWithRoles) UpsertTrustedCluster(tc services.TrustedCluster) (servic
 		return nil, trace.Wrap(err)
 	}
 
-	return a.authServer.UpsertTrustedCluster(tc)
+	return a.authServer.UpsertTrustedCluster(ctx, tc)
 }
 
 func (a *AuthWithRoles) ValidateTrustedCluster(validateRequest *ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error) {
@@ -1702,12 +1702,12 @@ func (a *AuthWithRoles) ValidateTrustedCluster(validateRequest *ValidateTrustedC
 }
 
 // DeleteTrustedCluster deletes a trusted cluster by name.
-func (a *AuthWithRoles) DeleteTrustedCluster(name string) error {
+func (a *AuthWithRoles) DeleteTrustedCluster(ctx context.Context, name string) error {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 
-	return a.authServer.DeleteTrustedCluster(name)
+	return a.authServer.DeleteTrustedCluster(ctx, name)
 }
 
 func (a *AuthWithRoles) UpsertTunnelConnection(conn services.TunnelConnection) error {

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -421,7 +421,6 @@ func (s *AuthServer) createGithubUser(p *createUserParams) (services.User, error
 				existingUser.GetName())
 		}
 
-		ctx = withUpdateBy(ctx, teleport.UserSystem)
 		if err := s.UpdateUser(ctx, user); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -63,14 +63,14 @@ func (s *AuthServer) CreateGithubAuthRequest(req services.GithubAuthRequest) (*s
 }
 
 // upsertGithubConnector creates or updates a Github connector.
-func (s *AuthServer) upsertGithubConnector(connector services.GithubConnector) error {
+func (s *AuthServer) upsertGithubConnector(ctx context.Context, connector services.GithubConnector) error {
 	if err := s.Identity.UpsertGithubConnector(connector); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if err := s.EmitAuditEvent(events.GithubConnectorCreated, events.EventFields{
 		events.FieldName: connector.GetName(),
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit GitHub connector create event: %v", err)
 	}
@@ -79,14 +79,14 @@ func (s *AuthServer) upsertGithubConnector(connector services.GithubConnector) e
 }
 
 // deleteGithubConnector deletes a Github connector by name.
-func (s *AuthServer) deleteGithubConnector(connectorName string) error {
+func (s *AuthServer) deleteGithubConnector(ctx context.Context, connectorName string) error {
 	if err := s.Identity.DeleteGithubConnector(connectorName); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if err := s.EmitAuditEvent(events.GithubConnectorDeleted, events.EventFields{
 		events.FieldName: connectorName,
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit GitHub connector delete event: %v", err)
 	}

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -194,8 +194,10 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	ctx := context.Background()
+
 	// create the default role
-	err = srv.AuthServer.UpsertRole(services.NewAdminRole())
+	err = srv.AuthServer.UpsertRole(ctx, services.NewAdminRole())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -637,13 +639,14 @@ func NewServerIdentity(clt *AuthServer, hostID string, role teleport.Role) (*Ide
 // clt limits required interface to the necessary methods
 // used to pass different clients in tests
 type clt interface {
-	UpsertRole(services.Role) error
+	UpsertRole(context.Context, services.Role) error
 	UpsertUser(services.User) error
 }
 
 // CreateUserRoleAndRequestable creates two roles for a user, one base role with allowed login
 // matching username, and another role with a login matching rolename that can be requested.
 func CreateUserRoleAndRequestable(clt clt, username string, rolename string) (services.User, error) {
+	ctx := context.TODO()
 	user, err := services.NewUser(username)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -653,7 +656,7 @@ func CreateUserRoleAndRequestable(clt clt, username string, rolename string) (se
 	baseRole.SetAccessRequestConditions(services.Allow, services.AccessRequestConditions{
 		Roles: []string{rolename},
 	})
-	err = clt.UpsertRole(baseRole)
+	err = clt.UpsertRole(ctx, baseRole)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -665,7 +668,7 @@ func CreateUserRoleAndRequestable(clt clt, username string, rolename string) (se
 	requestableRole := services.RoleForUser(user)
 	requestableRole.SetName(rolename)
 	requestableRole.SetLogins(services.Allow, []string{rolename})
-	err = clt.UpsertRole(requestableRole)
+	err = clt.UpsertRole(ctx, requestableRole)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -674,13 +677,14 @@ func CreateUserRoleAndRequestable(clt clt, username string, rolename string) (se
 
 // CreateUserAndRole creates user and role and assignes role to a user, used in tests
 func CreateUserAndRole(clt clt, username string, allowedLogins []string) (services.User, services.Role, error) {
+	ctx := context.TODO()
 	user, err := services.NewUser(username)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 	role := services.RoleForUser(user)
 	role.SetLogins(services.Allow, []string{user.GetName()})
-	err = clt.UpsertRole(role)
+	err = clt.UpsertRole(ctx, role)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -694,6 +698,7 @@ func CreateUserAndRole(clt clt, username string, allowedLogins []string) (servic
 
 // CreateUserAndRoleWithoutRoles creates user and role, but does not assign user to a role, used in tests
 func CreateUserAndRoleWithoutRoles(clt clt, username string, allowedLogins []string) (services.User, services.Role, error) {
+	ctx := context.TODO()
 	user, err := services.NewUser(username)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
@@ -704,7 +709,7 @@ func CreateUserAndRoleWithoutRoles(clt clt, username string, allowedLogins []str
 	delete(set, services.KindRole)
 	role.SetRules(services.Allow, set.Slice())
 	role.SetLogins(services.Allow, []string{user.GetName()})
-	err = clt.UpsertRole(role)
+	err = clt.UpsertRole(ctx, role)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -138,14 +138,14 @@ func oidcConfig(conn services.OIDCConnector) oidc.ClientConfig {
 }
 
 // UpsertOIDCConnector creates or updates an OIDC connector.
-func (s *AuthServer) UpsertOIDCConnector(connector services.OIDCConnector) error {
+func (s *AuthServer) UpsertOIDCConnector(ctx context.Context, connector services.OIDCConnector) error {
 	if err := s.Identity.UpsertOIDCConnector(connector); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if err := s.EmitAuditEvent(events.OIDCConnectorCreated, events.EventFields{
 		events.FieldName: connector.GetName(),
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit OIDC connector create event: %v", err)
 	}
@@ -154,14 +154,14 @@ func (s *AuthServer) UpsertOIDCConnector(connector services.OIDCConnector) error
 }
 
 // DeleteOIDCConnector deletes an OIDC connector by name.
-func (s *AuthServer) DeleteOIDCConnector(connectorName string) error {
+func (s *AuthServer) DeleteOIDCConnector(ctx context.Context, connectorName string) error {
 	if err := s.Identity.DeleteOIDCConnector(connectorName); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if err := s.EmitAuditEvent(events.OIDCConnectorDeleted, events.EventFields{
 		events.FieldName: connectorName,
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit OIDC connector delete event: %v", err)
 	}

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -521,7 +521,6 @@ func (a *AuthServer) createOIDCUser(p *createUserParams) (services.User, error) 
 		log.Debugf("Overwriting existing user %q created with %v connector %v.",
 			existingUser.GetName(), connectorRef.Type, connectorRef.ID)
 
-		ctx = withUpdateBy(ctx, teleport.UserSystem)
 		if err := a.UpdateUser(ctx, user); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -468,6 +468,22 @@ type contextUserKey string
 // ContextUser is a user set in the context of the request
 const ContextUser contextUserKey = "teleport-user"
 
+// clientUsername returns the username of a remote HTTP client making the call.
+// If ctx didn't pass through auth middleware or did not come from an HTTP
+// request, teleport.UserSystem is returned.
+func clientUsername(ctx context.Context) string {
+	userI := ctx.Value(ContextUser)
+	userWithIdentity, ok := userI.(IdentityGetter)
+	if !ok {
+		return teleport.UserSystem
+	}
+	identity := userWithIdentity.GetIdentity()
+	if identity.Username == "" {
+		return teleport.UserSystem
+	}
+	return identity.Username
+}
+
 // LocalUser is a local user
 type LocalUser struct {
 	// Username is local username

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -230,7 +230,6 @@ func (a *AuthServer) createSAMLUser(p *createUserParams) (services.User, error) 
 		log.Debugf("Overwriting existing user %q created with %v connector %v.",
 			existingUser.GetName(), connectorRef.Type, connectorRef.ID)
 
-		ctx = withUpdateBy(ctx, teleport.UserSystem)
 		if err := a.UpdateUser(ctx, user); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -35,14 +35,14 @@ import (
 )
 
 // UpsertSAMLConnector creates or updates a SAML connector.
-func (s *AuthServer) UpsertSAMLConnector(connector services.SAMLConnector) error {
+func (s *AuthServer) UpsertSAMLConnector(ctx context.Context, connector services.SAMLConnector) error {
 	if err := s.Identity.UpsertSAMLConnector(connector); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if err := s.EmitAuditEvent(events.SAMLConnectorCreated, events.EventFields{
 		events.FieldName: connector.GetName(),
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit SAML connector create event: %v", err)
 	}
@@ -51,14 +51,14 @@ func (s *AuthServer) UpsertSAMLConnector(connector services.SAMLConnector) error
 }
 
 // DeleteSAMLConnector deletes a SAML connector by name.
-func (s *AuthServer) DeleteSAMLConnector(connectorName string) error {
+func (s *AuthServer) DeleteSAMLConnector(ctx context.Context, connectorName string) error {
 	if err := s.Identity.DeleteSAMLConnector(connectorName); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if err := s.EmitAuditEvent(events.SAMLConnectorDeleted, events.EventFields{
 		events.FieldName: connectorName,
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit SAML connector delete event: %v", err)
 	}

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1448,14 +1448,14 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 	_, err = generateCerts(req.GetName())
 	c.Assert(err, check.NotNil)
 
-	updateCtx := withUpdateBy(context.TODO(), "some-user")
+	ctx := context.Background()
 
 	// verify that user does not have the ability to approve their own request (not a special case, this
 	// user just wasn't created with the necessary roles for request management).
-	c.Assert(userClient.SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_APPROVED), check.NotNil)
+	c.Assert(userClient.SetAccessRequestState(ctx, req.GetName(), services.RequestState_APPROVED), check.NotNil)
 
 	// attempt to apply request in APPROVED state (should succeed)
-	c.Assert(s.server.Auth().SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_APPROVED), check.IsNil)
+	c.Assert(s.server.Auth().SetAccessRequestState(ctx, req.GetName(), services.RequestState_APPROVED), check.IsNil)
 	userCerts, err = generateCerts(req.GetName())
 	c.Assert(err, check.IsNil)
 	// ensure that the requested role was actually applied to the cert
@@ -1464,15 +1464,15 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 	}
 
 	// attempt to apply request in DENIED state (should fail)
-	c.Assert(s.server.Auth().SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_DENIED), check.IsNil)
+	c.Assert(s.server.Auth().SetAccessRequestState(ctx, req.GetName(), services.RequestState_DENIED), check.IsNil)
 	_, err = generateCerts(req.GetName())
 	c.Assert(err, check.NotNil)
 
 	// ensure that once in the DENIED state, a request cannot be set back to PENDING state.
-	c.Assert(s.server.Auth().SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_PENDING), check.NotNil)
+	c.Assert(s.server.Auth().SetAccessRequestState(ctx, req.GetName(), services.RequestState_PENDING), check.NotNil)
 
 	// ensure that once in the DENIED state, a request cannot be set back to APPROVED state.
-	c.Assert(s.server.Auth().SetAccessRequestState(updateCtx, req.GetName(), services.RequestState_APPROVED), check.NotNil)
+	c.Assert(s.server.Auth().SetAccessRequestState(ctx, req.GetName(), services.RequestState_APPROVED), check.NotNil)
 }
 
 func (s *TLSSuite) TestPluginData(c *check.C) {

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -37,7 +37,7 @@ import (
 )
 
 // UpsertTrustedCluster creates or toggles a Trusted Cluster relationship.
-func (a *AuthServer) UpsertTrustedCluster(trustedCluster services.TrustedCluster) (services.TrustedCluster, error) {
+func (a *AuthServer) UpsertTrustedCluster(ctx context.Context, trustedCluster services.TrustedCluster) (services.TrustedCluster, error) {
 	var exists bool
 
 	// It is recommended to omit trusted cluster name because the trusted cluster name
@@ -136,13 +136,13 @@ func (a *AuthServer) UpsertTrustedCluster(trustedCluster services.TrustedCluster
 		}
 	}
 
-	tc, err := a.Presence.UpsertTrustedCluster(trustedCluster)
+	tc, err := a.Presence.UpsertTrustedCluster(ctx, trustedCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	if err := a.EmitAuditEvent(events.TrustedClusterCreate, events.EventFields{
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit trusted cluster create event: %v", err)
 	}
@@ -172,7 +172,7 @@ func (a *AuthServer) checkLocalRoles(roleMap services.RoleMap) error {
 
 // DeleteTrustedCluster removes services.CertAuthority, services.ReverseTunnel,
 // and services.TrustedCluster resources.
-func (a *AuthServer) DeleteTrustedCluster(name string) error {
+func (a *AuthServer) DeleteTrustedCluster(ctx context.Context, name string) error {
 	cn, err := a.GetClusterName()
 	if err != nil {
 		return trace.Wrap(err)
@@ -201,12 +201,12 @@ func (a *AuthServer) DeleteTrustedCluster(name string) error {
 		}
 	}
 
-	if err := a.Presence.DeleteTrustedCluster(name); err != nil {
+	if err := a.Presence.DeleteTrustedCluster(ctx, name); err != nil {
 		return trace.Wrap(err)
 	}
 
 	if err := a.EmitAuditEvent(events.TrustedClusterDelete, events.EventFields{
-		events.EventUser: "unimplemented",
+		events.EventUser: clientUsername(ctx),
 	}); err != nil {
 		log.Warnf("Failed to emit trusted cluster delete event: %v", err)
 	}

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -137,7 +137,7 @@ func (s *AuthServer) DeleteUser(ctx context.Context, user string) error {
 			return trace.Wrap(err)
 		}
 	} else {
-		if err := s.Access.DeleteRole(role.GetName()); err != nil {
+		if err := s.Access.DeleteRole(ctx, role.GetName()); err != nil {
 			if !trace.IsNotFound(err) {
 				return trace.Wrap(err)
 			}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -286,7 +286,7 @@ func New(config Config) (*Cache, error) {
 	}
 	cs.collections = collections
 
-	err = cs.fetch()
+	err = cs.fetch(ctx)
 	if err != nil {
 		// "only recent" behavior does not tolerate
 		// stale data, so it has to initialize itself
@@ -295,7 +295,7 @@ func New(config Config) (*Cache, error) {
 			return nil, trace.Wrap(err)
 		}
 	}
-	go cs.update()
+	go cs.update(ctx)
 	return cs, nil
 }
 
@@ -316,7 +316,7 @@ func (c *Cache) setClosed() {
 	atomic.StoreInt32(&c.closedFlag, 1)
 }
 
-func (c *Cache) update() {
+func (c *Cache) update(ctx context.Context) {
 	retry, err := utils.NewLinear(utils.LinearConfig{
 		Step: c.RetryPeriod / 10,
 		Max:  c.RetryPeriod,
@@ -326,7 +326,7 @@ func (c *Cache) update() {
 		return
 	}
 	for {
-		err := c.fetchAndWatch(retry)
+		err := c.fetchAndWatch(ctx, retry)
 		if err != nil {
 			c.setCacheState(err)
 			if !c.isClosed() {
@@ -429,7 +429,7 @@ func (c *Cache) notify(event CacheEvent) {
 //   we assume that this cache will eventually end up in a correct state
 //   potentially lagging behind the state of the database.
 //
-func (c *Cache) fetchAndWatch(retry utils.Retry) error {
+func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry) error {
 	watcher, err := c.Events.NewWatcher(c.ctx, services.Watch{
 		QueueSize:       c.QueueSize,
 		Name:            c.Component,
@@ -465,7 +465,7 @@ func (c *Cache) fetchAndWatch(retry utils.Retry) error {
 			return trace.BadParameter("expected init event, got %v instead", event.Type)
 		}
 	}
-	err = c.fetch()
+	err = c.fetch(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -479,7 +479,7 @@ func (c *Cache) fetchAndWatch(retry utils.Retry) error {
 		case <-c.ctx.Done():
 			return trace.ConnectionProblem(c.ctx.Err(), "context is closing")
 		case event := <-watcher.Events():
-			err = c.processEvent(event)
+			err = c.processEvent(ctx, event)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -512,22 +512,22 @@ func (c *Cache) Close() error {
 	return nil
 }
 
-func (c *Cache) fetch() error {
+func (c *Cache) fetch(ctx context.Context) error {
 	for _, collection := range c.collections {
-		if err := collection.fetch(); err != nil {
+		if err := collection.fetch(ctx); err != nil {
 			return trace.Wrap(err)
 		}
 	}
 	return nil
 }
 
-func (c *Cache) processEvent(event services.Event) error {
+func (c *Cache) processEvent(ctx context.Context, event services.Event) error {
 	collection, ok := c.collections[event.Resource.GetKind()]
 	if !ok {
 		c.Warningf("Skipping unsupported event %v.", event.Resource.GetKind())
 		return nil
 	}
-	if err := collection.processEvent(event); err != nil {
+	if err := collection.processEvent(ctx, event); err != nil {
 		return trace.Wrap(err)
 	}
 	c.eventsFanout.Emit(event)

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -763,6 +763,7 @@ func (s *CacheSuite) TestUsers(c *check.C) {
 
 // TestRoles tests caching of roles
 func (s *CacheSuite) TestRoles(c *check.C) {
+	ctx := context.Background()
 	p := s.newPackForNode(c)
 	defer p.Close()
 
@@ -777,7 +778,7 @@ func (s *CacheSuite) TestRoles(c *check.C) {
 		Deny: services.RoleConditions{},
 	})
 	c.Assert(err, check.IsNil)
-	err = p.accessS.UpsertRole(role)
+	err = p.accessS.UpsertRole(ctx, role)
 	c.Assert(err, check.IsNil)
 
 	role, err = p.accessS.GetRole(role.GetName())
@@ -798,7 +799,7 @@ func (s *CacheSuite) TestRoles(c *check.C) {
 	// update role
 	role.SetLogins(services.Allow, []string{"admin"})
 	c.Assert(err, check.IsNil)
-	err = p.accessS.UpsertRole(role)
+	err = p.accessS.UpsertRole(ctx, role)
 	c.Assert(err, check.IsNil)
 
 	role, err = p.accessS.GetRole(role.GetName())
@@ -816,7 +817,7 @@ func (s *CacheSuite) TestRoles(c *check.C) {
 	role.SetResourceID(out.GetResourceID())
 	fixtures.DeepCompare(c, role, out)
 
-	err = p.accessS.DeleteRole(role.GetName())
+	err = p.accessS.DeleteRole(ctx, role.GetName())
 	c.Assert(err, check.IsNil)
 
 	select {

--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -81,7 +81,7 @@ func (s *AccessService) CreateRole(role services.Role) error {
 }
 
 // UpsertRole updates parameters about role
-func (s *AccessService) UpsertRole(role services.Role) error {
+func (s *AccessService) UpsertRole(ctx context.Context, role services.Role) error {
 	value, err := services.GetRoleMarshaler().MarshalRole(role)
 	if err != nil {
 		return trace.Wrap(err)
@@ -94,7 +94,7 @@ func (s *AccessService) UpsertRole(role services.Role) error {
 		ID:      role.GetResourceID(),
 	}
 
-	_, err = s.Put(context.TODO(), item)
+	_, err = s.Put(ctx, item)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -118,11 +118,11 @@ func (s *AccessService) GetRole(name string) (services.Role, error) {
 }
 
 // DeleteRole deletes a role from the backend
-func (s *AccessService) DeleteRole(name string) error {
+func (s *AccessService) DeleteRole(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing role name")
 	}
-	err := s.Delete(context.TODO(), backend.Key(rolesPrefix, name, paramsPrefix))
+	err := s.Delete(ctx, backend.Key(rolesPrefix, name, paramsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("role %q is not found", name)

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -409,7 +409,7 @@ func (s *PresenceService) DeleteReverseTunnel(clusterName string) error {
 }
 
 // UpsertTrustedCluster creates or updates a TrustedCluster in the backend.
-func (s *PresenceService) UpsertTrustedCluster(trustedCluster services.TrustedCluster) (services.TrustedCluster, error) {
+func (s *PresenceService) UpsertTrustedCluster(ctx context.Context, trustedCluster services.TrustedCluster) (services.TrustedCluster, error) {
 	if err := trustedCluster.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -417,7 +417,7 @@ func (s *PresenceService) UpsertTrustedCluster(trustedCluster services.TrustedCl
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	_, err = s.Put(context.TODO(), backend.Item{
+	_, err = s.Put(ctx, backend.Item{
 		Key:     backend.Key(trustedClustersPrefix, trustedCluster.GetName()),
 		Value:   value,
 		Expires: trustedCluster.Expiry(),
@@ -463,11 +463,11 @@ func (s *PresenceService) GetTrustedClusters() ([]services.TrustedCluster, error
 }
 
 // DeleteTrustedCluster removes a TrustedCluster from the backend by name.
-func (s *PresenceService) DeleteTrustedCluster(name string) error {
+func (s *PresenceService) DeleteTrustedCluster(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing trusted cluster name")
 	}
-	err := s.Delete(context.TODO(), backend.Key(trustedClustersPrefix, name))
+	err := s.Delete(ctx, backend.Key(trustedClustersPrefix, name))
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("trusted cluster %q is not found", name)

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -58,6 +58,7 @@ func (s *PresenceSuite) TearDownTest(c *check.C) {
 }
 
 func (s *PresenceSuite) TestTrustedClusterCRUD(c *check.C) {
+	ctx := context.Background()
 	presenceBackend := NewPresenceService(s.bk)
 
 	tc, err := services.NewTrustedCluster("foo", services.TrustedClusterSpecV2{
@@ -80,9 +81,9 @@ func (s *PresenceSuite) TestTrustedClusterCRUD(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// create trusted clusters
-	_, err = presenceBackend.UpsertTrustedCluster(tc)
+	_, err = presenceBackend.UpsertTrustedCluster(ctx, tc)
 	c.Assert(err, check.IsNil)
-	_, err = presenceBackend.UpsertTrustedCluster(stc)
+	_, err = presenceBackend.UpsertTrustedCluster(ctx, stc)
 	c.Assert(err, check.IsNil)
 
 	// get trusted cluster make sure it's correct
@@ -101,7 +102,7 @@ func (s *PresenceSuite) TestTrustedClusterCRUD(c *check.C) {
 	c.Assert(allTC, check.HasLen, 2)
 
 	// delete cluster
-	err = presenceBackend.DeleteTrustedCluster("foo")
+	err = presenceBackend.DeleteTrustedCluster(ctx, "foo")
 	c.Assert(err, check.IsNil)
 
 	// make sure it's really gone

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -116,7 +116,7 @@ type Presence interface {
 	DeleteNamespace(name string) error
 
 	// UpsertTrustedCluster creates or updates a TrustedCluster in the backend.
-	UpsertTrustedCluster(TrustedCluster) (TrustedCluster, error)
+	UpsertTrustedCluster(ctx context.Context, tc TrustedCluster) (TrustedCluster, error)
 
 	// GetTrustedCluster returns a single TrustedCluster by name.
 	GetTrustedCluster(string) (TrustedCluster, error)
@@ -125,7 +125,7 @@ type Presence interface {
 	GetTrustedClusters() ([]TrustedCluster, error)
 
 	// DeleteTrustedCluster removes a TrustedCluster from the backend by name.
-	DeleteTrustedCluster(string) error
+	DeleteTrustedCluster(ctx context.Context, name string) error
 
 	// UpsertTunnelConnection upserts tunnel connection
 	UpsertTunnelConnection(TunnelConnection) error

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -17,6 +17,7 @@ limitations under the License.
 package services
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -208,7 +209,7 @@ type Access interface {
 	CreateRole(role Role) error
 
 	// UpsertRole creates or updates role
-	UpsertRole(role Role) error
+	UpsertRole(ctx context.Context, role Role) error
 
 	// DeleteAllRoles deletes all roles
 	DeleteAllRoles() error
@@ -217,7 +218,7 @@ type Access interface {
 	GetRole(name string) (Role, error)
 
 	// DeleteRole deletes role by name
-	DeleteRole(name string) error
+	DeleteRole(ctx context.Context, name string) error
 }
 
 const (

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -553,7 +553,8 @@ func (s *ServicesTestSuite) RolesCRUD(c *check.C) {
 			},
 		},
 	}
-	err = s.Access.UpsertRole(&role)
+	ctx := context.Background()
+	err = s.Access.UpsertRole(ctx, &role)
 	c.Assert(err, check.IsNil)
 	rout, err := s.Access.GetRole(role.Metadata.Name)
 	c.Assert(err, check.IsNil)
@@ -561,14 +562,14 @@ func (s *ServicesTestSuite) RolesCRUD(c *check.C) {
 	fixtures.DeepCompare(c, rout, &role)
 
 	role.Spec.Allow.Logins = []string{"bob"}
-	err = s.Access.UpsertRole(&role)
+	err = s.Access.UpsertRole(ctx, &role)
 	c.Assert(err, check.IsNil)
 	rout, err = s.Access.GetRole(role.Metadata.Name)
 	c.Assert(err, check.IsNil)
 	role.SetResourceID(rout.GetResourceID())
 	c.Assert(rout, check.DeepEquals, &role)
 
-	err = s.Access.DeleteRole(role.Metadata.Name)
+	err = s.Access.DeleteRole(ctx, role.Metadata.Name)
 	c.Assert(err, check.IsNil)
 
 	_, err = s.Access.GetRole(role.Metadata.Name)
@@ -1012,6 +1013,7 @@ func (s *ServicesTestSuite) ClusterConfig(c *check.C, opts ...SuiteOption) {
 
 // Events tests various events variations
 func (s *ServicesTestSuite) Events(c *check.C) {
+	ctx := context.Background()
 	testCases := []eventTest{
 		{
 			name: "Cert authority with secrets",
@@ -1148,13 +1150,13 @@ func (s *ServicesTestSuite) Events(c *check.C) {
 				})
 				c.Assert(err, check.IsNil)
 
-				err = s.Access.UpsertRole(role)
+				err = s.Access.UpsertRole(ctx, role)
 				c.Assert(err, check.IsNil)
 
 				out, err := s.Access.GetRole(role.GetName())
 				c.Assert(err, check.IsNil)
 
-				err = s.Access.DeleteRole(role.GetName())
+				err = s.Access.DeleteRole(ctx, role.GetName())
 				c.Assert(err, check.IsNil)
 
 				return out

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -277,6 +277,7 @@ func (s *SrvSuite) TestAdvertiseAddr(c *C) {
 // TestAgentForwardPermission makes sure if RBAC rules don't allow agent
 // forwarding, we don't start an agent even if requested.
 func (s *SrvSuite) TestAgentForwardPermission(c *C) {
+	ctx := context.Background()
 	// make sure the role does not allow agent forwarding
 	roleName := services.RoleNameForUser(s.user)
 	role, err := s.server.Auth().GetRole(roleName)
@@ -284,7 +285,7 @@ func (s *SrvSuite) TestAgentForwardPermission(c *C) {
 	roleOptions := role.GetOptions()
 	roleOptions.ForwardAgent = services.NewBool(false)
 	role.SetOptions(roleOptions)
-	err = s.server.Auth().UpsertRole(role)
+	err = s.server.Auth().UpsertRole(ctx, role)
 	c.Assert(err, IsNil)
 
 	se, err := s.clt.NewSession()
@@ -304,13 +305,14 @@ func (s *SrvSuite) TestAgentForwardPermission(c *C) {
 
 // TestAgentForward tests agent forwarding via unix sockets
 func (s *SrvSuite) TestAgentForward(c *C) {
+	ctx := context.Background()
 	roleName := services.RoleNameForUser(s.user)
 	role, err := s.server.Auth().GetRole(roleName)
 	c.Assert(err, IsNil)
 	roleOptions := role.GetOptions()
 	roleOptions.ForwardAgent = services.NewBool(true)
 	role.SetOptions(roleOptions)
-	err = s.server.Auth().UpsertRole(role)
+	err = s.server.Auth().UpsertRole(ctx, role)
 	c.Assert(err, IsNil)
 
 	se, err := s.clt.NewSession()
@@ -1171,6 +1173,7 @@ type upack struct {
 }
 
 func (s *SrvSuite) newUpack(username string, allowedLogins []string, allowedLabels services.Labels) (*upack, error) {
+	ctx := context.Background()
 	auth := s.server.Auth()
 	upriv, upub, err := auth.GenerateKeyPair("")
 	if err != nil {
@@ -1186,7 +1189,7 @@ func (s *SrvSuite) newUpack(username string, allowedLogins []string, allowedLabe
 	role.SetRules(services.Allow, rules)
 	role.SetLogins(services.Allow, allowedLogins)
 	role.SetNodeLabels(services.Allow, allowedLabels)
-	err = auth.UpsertRole(role)
+	err = auth.UpsertRole(ctx, role)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -116,7 +117,7 @@ func (c *NodeCommand) Invite(client auth.ClientI) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	token, err := client.GenerateToken(auth.GenerateTokenRequest{Roles: roles, TTL: c.ttl, Token: c.token})
+	token, err := client.GenerateToken(context.TODO(), auth.GenerateTokenRequest{Roles: roles, TTL: c.ttl, Token: c.token})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -256,7 +256,7 @@ func (rc *ResourceCommand) createTrustedCluster(client auth.ClientI, raw service
 		return trace.AlreadyExists("trusted cluster %q already exists", name)
 	}
 
-	out, err := client.UpsertTrustedCluster(tc)
+	out, err := client.UpsertTrustedCluster(context.TODO(), tc)
 	if err != nil {
 		// If force is used and UpsertTrustedCluster returns trace.AlreadyExists,
 		// this means the user tried to upsert a cluster whose exact match already
@@ -303,7 +303,7 @@ func (rc *ResourceCommand) createGithubConnector(client auth.ClientI, raw servic
 		return trace.AlreadyExists("authentication connector %q already exists",
 			connector.GetName())
 	}
-	err = client.UpsertGithubConnector(connector)
+	err = client.UpsertGithubConnector(context.TODO(), connector)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -353,6 +353,7 @@ func (rc *ResourceCommand) Delete(client auth.ClientI) (err error) {
 		return trace.BadParameter("provide a full resource name to delete, for example:\n$ tctl rm cluster/east\n")
 	}
 
+	ctx := context.TODO()
 	switch rc.ref.Kind {
 	case services.KindNode:
 		if err = client.DeleteNode(defaults.Namespace, rc.ref.Name); err != nil {
@@ -360,22 +361,22 @@ func (rc *ResourceCommand) Delete(client auth.ClientI) (err error) {
 		}
 		fmt.Printf("node %v has been deleted\n", rc.ref.Name)
 	case services.KindUser:
-		if err = client.DeleteUser(context.TODO(), rc.ref.Name); err != nil {
+		if err = client.DeleteUser(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("user %q has been deleted\n", rc.ref.Name)
 	case services.KindSAMLConnector:
-		if err = client.DeleteSAMLConnector(rc.ref.Name); err != nil {
+		if err = client.DeleteSAMLConnector(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("SAML connector %v has been deleted\n", rc.ref.Name)
 	case services.KindOIDCConnector:
-		if err = client.DeleteOIDCConnector(rc.ref.Name); err != nil {
+		if err = client.DeleteOIDCConnector(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("OIDC connector %v has been deleted\n", rc.ref.Name)
 	case services.KindGithubConnector:
-		if err = client.DeleteGithubConnector(rc.ref.Name); err != nil {
+		if err = client.DeleteGithubConnector(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("github connector %q has been deleted\n", rc.ref.Name)
@@ -385,7 +386,7 @@ func (rc *ResourceCommand) Delete(client auth.ClientI) (err error) {
 		}
 		fmt.Printf("reverse tunnel %v has been deleted\n", rc.ref.Name)
 	case services.KindTrustedCluster:
-		if err = client.DeleteTrustedCluster(rc.ref.Name); err != nil {
+		if err = client.DeleteTrustedCluster(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)
 		}
 		fmt.Printf("trusted cluster %q has been deleted\n", rc.ref.Name)

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -111,7 +112,7 @@ func (c *TokenCommand) Add(client auth.ClientI) error {
 	}
 
 	// Generate token.
-	token, err := client.GenerateToken(auth.GenerateTokenRequest{
+	token, err := client.GenerateToken(context.TODO(), auth.GenerateTokenRequest{
 		Roles: roles,
 		TTL:   c.ttl,
 		Token: c.value,


### PR DESCRIPTION
This is a backport of https://github.com/gravitational/teleport/pull/3850 into 4.3 branch.