### PR TITLE
Backport: s3sessions,gcssessions: don't fail when ensureBucket fails

### DIFF
--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -281,7 +281,8 @@ func (h *Handler) ensureBucket() error {
 		return nil
 	}
 	if !trace.IsNotFound(err) {
-		return trace.Wrap(err)
+		h.Errorf("Failed to ensure that bucket %q exists (%v). GCS session uploads may fail. If you've set up the bucket already and gave Teleport write-only access, feel free to ignore this error.", h.Bucket, err)
+		return nil
 	}
 	err = h.gcsClient.Bucket(h.Config.Bucket).Create(h.clientContext, h.Config.ProjectID, &storage.BucketAttrs{
 		VersioningEnabled: true,

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -296,7 +296,8 @@ func (h *Handler) ensureBucket() error {
 		return nil
 	}
 	if !trace.IsNotFound(err) {
-		return trace.Wrap(err)
+		h.Errorf("Failed to ensure that bucket %q exists (%v). S3 session uploads may fail. If you've set up the bucket already and gave Teleport write-only access, feel free to ignore this error.", h.Bucket, err)
+		return nil
 	}
 	input := &s3.CreateBucketInput{
 		Bucket: aws.String(h.Bucket),


### PR DESCRIPTION
This is a backport of https://github.com/gravitational/teleport/pull/3810 into 4.3 branch.

When S3/GCS credentials given to teleport have write-only access,
fetching the bucket attributes will fail. This shouldn't prevent
Teleport from starting and uploading sessions.
Print a helpful error message instead.