### PR TITLE
Update master branch version tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.2.2-alpha.1
+VERSION=master
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=master
+VERSION=4.4.0-dev
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.2.2-alpha.1"
+	Version = "master"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "master"
+	Version = "4.4.0-dev"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Fixes #3868 

The version output when building off this branch is currently a little weird:

```
$ build/teleport version
Teleport vmaster git:v4.2.0-alpha.5-451-g7b09521d4 go1.13.2
```

It should get better when we actually release v4.3.0 so there's a more recent tag for it to pull from, rather than saying "you're 451 commits ahead of 4.2.0-alpha.5". The `7b09521d4` part is this commit.