### PR TITLE
extend session.end event

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -92,6 +92,15 @@ const (
 	// SessionServerHostname is the hostname of the server the session occurred on.
 	SessionServerHostname = "server_hostname"
 
+	// SessionServerAddr is the address of the server the session occurred on.
+	SessionServerAddr = "server_addr"
+
+	// SessionStartTime is the timestamp at which the session began.
+	SessionStartTime = "session_start"
+
+	// SessionEndTime is the timestamp at which the session ended.
+	SessionEndTime = "session_stop"
+
 	// SessionEnhancedRecording is used to indicate if the recording was an
 	// enhanced recording or not.
 	SessionEnhancedRecording = "enhanced_recording"


### PR DESCRIPTION
Adds three new fields to the `session.end` event:

```
{
    "server_addr":  "<host>:<port>",
    "session_start": "<timestamp>",
    "session_stop": "<timestamp>",
    # ...
}
```

See #3542 