### PR TITLE
Backport: support port-only spec in dynamic port forwarding

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2423,6 +2423,12 @@ func ParseDynamicPortForwardSpec(spec []string) (DynamicForwardedPorts, error) {
 	result := make(DynamicForwardedPorts, 0, len(spec))
 
 	for _, str := range spec {
+		// Check whether this is only the port number, like "1080".
+		// net.SplitHostPort would fail on that unless there's a colon in
+		// front.
+		if !strings.Contains(str, ":") {
+			str = ":" + str
+		}
 		host, port, err := net.SplitHostPort(str)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -185,9 +185,24 @@ func (s *APITestSuite) TestDynamicPortsParsing(c *check.C) {
 			output:  DynamicForwardedPorts{},
 		},
 		{
-			spec:    []string{"8080"},
+			spec:    []string{"localhost"},
 			isError: true,
 			output:  DynamicForwardedPorts{},
+		},
+		{
+			spec:    []string{"localhost:123:456"},
+			isError: true,
+			output:  DynamicForwardedPorts{},
+		},
+		{
+			spec:    []string{"8080"},
+			isError: false,
+			output: DynamicForwardedPorts{
+				DynamicForwardedPort{
+					SrcIP:   "127.0.0.1",
+					SrcPort: 8080,
+				},
+			},
 		},
 		{
 			spec:    []string{":8080"},
@@ -195,6 +210,21 @@ func (s *APITestSuite) TestDynamicPortsParsing(c *check.C) {
 			output: DynamicForwardedPorts{
 				DynamicForwardedPort{
 					SrcIP:   "127.0.0.1",
+					SrcPort: 8080,
+				},
+			},
+		},
+		{
+			spec:    []string{":8080:8081"},
+			isError: true,
+			output:  DynamicForwardedPorts{},
+		},
+		{
+			spec:    []string{"[::1]:8080"},
+			isError: false,
+			output: DynamicForwardedPorts{
+				DynamicForwardedPort{
+					SrcIP:   "::1",
 					SrcPort: 8080,
 				},
 			},


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/3888 into 4.3

Example command: "tsh ssh -D 8080 foo@bar".
OpenSSH supports this, but tsh would fail to parse it.

Also add a few other test cases for other specs.