### PR TITLE
Return a better error on session recording lookup

### DIFF
--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -560,6 +560,11 @@ func readSessionIndex(dataDir string, authServers []string, namespace string, si
 			return nil, trace.Wrap(err)
 		}
 	}
+
+	if len(index.indexFiles) == 0 {
+		return nil, trace.NotFound("session %q not found", sid)
+	}
+
 	index.sort()
 	return &index, nil
 }


### PR DESCRIPTION
Instead of `0 not found`, return an error earlier, when loading index
files.

Updates https://github.com/gravitational/teleport/issues/3894