### PR TITLE
Remove port number from account name in OTP URLs

### DIFF
--- a/lib/auth/resetpasswordtoken.go
+++ b/lib/auth/resetpasswordtoken.go
@@ -21,7 +21,9 @@ import (
 	"context"
 	"fmt"
 	"image/png"
+	"net"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/gravitational/teleport/lib/defaults"
@@ -165,6 +167,13 @@ func formatAccountName(s proxyDomainGetter, username string, authHostname string
 		proxyHost, _, err = services.GuessProxyHostAndVersion(proxies)
 		if err != nil {
 			return "", trace.Wrap(err)
+		}
+		// Remove port number if present. OTP URL parsers won't handle it.
+		if strings.Contains(proxyHost, ":") {
+			proxyHost, _, err = net.SplitHostPort(proxyHost)
+			if err != nil {
+				return "", trace.Wrap(err)
+			}
 		}
 	}
 

--- a/lib/auth/resetpasswordtoken_test.go
+++ b/lib/auth/resetpasswordtoken_test.go
@@ -193,6 +193,21 @@ func (s *ResetPasswordTokenTest) TestFormatAccountName(c *check.C) {
 			outError:       false,
 		},
 		{
+			description: "proxies with public address with port number",
+			inDebugAuth: &debugAuth{
+				proxies: []services.Server{
+					&services.ServerV2{
+						Spec: services.ServerSpecV2{
+							PublicAddr: "foo:8080",
+							Version:    "bar",
+						},
+					},
+				},
+			},
+			outAccountName: "foo@foo",
+			outError:       false,
+		},
+		{
 			description: "proxies with no public address",
 			inDebugAuth: &debugAuth{
 				proxies: []services.Server{
@@ -204,7 +219,7 @@ func (s *ResetPasswordTokenTest) TestFormatAccountName(c *check.C) {
 					},
 				},
 			},
-			outAccountName: "foo@baz:3080",
+			outAccountName: "foo@baz",
 			outError:       false,
 		},
 		{


### PR DESCRIPTION
OTP apps might not handle port number there. And it's not useful for
them anyway. Strip it from the formatted account name.

Updates #3855