### PR TITLE
Backport: send the correct SNI from tsh to auth server

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -364,6 +364,7 @@ func (a *TestAuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, p
 	}
 	tlsConfig.Certificates = []tls.Certificate{*cert}
 	tlsConfig.RootCAs = pool
+	tlsConfig.ServerName = EncodeClusterName(a.ClusterName)
 	addrs := []utils.NetAddr{{
 		AddrNetwork: addr.Network(),
 		Addr:        addr.String()}}

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -86,6 +86,13 @@ func (k *Key) ClientTLSConfig() (*tls.Config, error) {
 		return nil, trace.Wrap(err, "failed to parse TLS cert and key")
 	}
 	tlsConfig.Certificates = append(tlsConfig.Certificates, tlsCert)
+	// Use Issuer CN from the certificate to populate the correct SNI in
+	// requests.
+	leaf, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to parse TLS cert")
+	}
+	tlsConfig.ServerName = auth.EncodeClusterName(leaf.Issuer.CommonName)
 	return tlsConfig, nil
 }
 

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -251,7 +251,7 @@ func (a *LocalKeyAgent) GetCerts() (*x509.CertPool, error) {
 	return a.keyStore.GetCerts(a.proxyHost)
 }
 
-func (a *LocalKeyAgent) GetCertsPEM() ([]byte, error) {
+func (a *LocalKeyAgent) GetCertsPEM() ([][]byte, error) {
 	return a.keyStore.GetCertsPEM(a.proxyHost)
 }
 

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -69,7 +69,7 @@ func (s *KeyAgentTestSuite) SetUpSuite(c *check.C) {
 	pemBytes, ok := fixtures.PEMBytes["rsa"]
 	c.Assert(ok, check.Equals, true)
 
-	s.tlsca, err = newSelfSignedCA(pemBytes)
+	s.tlsca, _, err = newSelfSignedCA(pemBytes)
 	c.Assert(err, check.IsNil)
 
 	// temporary key to use during tests

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
@@ -37,25 +38,33 @@ import (
 )
 
 type KeyStoreTestSuite struct {
-	storeDir string
-	store    *FSLocalKeyStore
-	keygen   *testauthority.Keygen
-	tlsca    *tlsca.CertAuthority
+	storeDir  string
+	store     *FSLocalKeyStore
+	keygen    *testauthority.Keygen
+	tlsCA     *tlsca.CertAuthority
+	tlsCACert auth.TrustedCerts
 }
 
 var _ = fmt.Printf
 var _ = check.Suite(&KeyStoreTestSuite{})
 
-func newSelfSignedCA(privateKey []byte) (*tlsca.CertAuthority, error) {
+func newSelfSignedCA(privateKey []byte) (*tlsca.CertAuthority, auth.TrustedCerts, error) {
 	rsaKey, err := ssh.ParseRawPrivateKey(privateKey)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, auth.TrustedCerts{}, trace.Wrap(err)
 	}
 	key, cert, err := tlsca.GenerateSelfSignedCAWithPrivateKey(rsaKey.(*rsa.PrivateKey), pkix.Name{
 		CommonName:   "localhost",
 		Organization: []string{"localhost"},
 	}, nil, defaults.CATTL)
-	return tlsca.New(cert, key)
+	if err != nil {
+		return nil, auth.TrustedCerts{}, trace.Wrap(err)
+	}
+	ca, err := tlsca.New(cert, key)
+	if err != nil {
+		return nil, auth.TrustedCerts{}, trace.Wrap(err)
+	}
+	return ca, auth.TrustedCerts{TLSCertificates: [][]byte{cert}}, nil
 }
 
 func (s *KeyStoreTestSuite) SetUpSuite(c *check.C) {
@@ -68,7 +77,7 @@ func (s *KeyStoreTestSuite) SetUpSuite(c *check.C) {
 	c.Assert(s.store, check.NotNil)
 	c.Assert(utils.IsDir(s.store.KeyDir), check.Equals, true)
 
-	s.tlsca, err = newSelfSignedCA(CAPriv)
+	s.tlsCA, s.tlsCACert, err = newSelfSignedCA(CAPriv)
 	c.Assert(err, check.IsNil)
 }
 
@@ -88,13 +97,13 @@ func (s *KeyStoreTestSuite) TestListKeys(c *check.C) {
 	for i := 0; i < keyNum; i++ {
 		key := s.makeSignedKey(c, false)
 		host := fmt.Sprintf("host-%v", i)
-		s.store.AddKey(host, "bob", key)
+		c.Assert(s.addKey(host, "bob", key), check.IsNil)
 		key.ProxyHost = host
 		keys[i] = *key
 	}
 	// add 1 key for "sam"
 	samKey := s.makeSignedKey(c, false)
-	s.store.AddKey("sam.host", "sam", samKey)
+	c.Assert(s.addKey("sam.host", "sam", samKey), check.IsNil)
 
 	// read all bob keys:
 	for i := 0; i < keyNum; i++ {
@@ -115,7 +124,7 @@ func (s *KeyStoreTestSuite) TestKeyCRUD(c *check.C) {
 	key := s.makeSignedKey(c, false)
 
 	// add key:
-	err := s.store.AddKey("host.a", "bob", key)
+	err := s.addKey("host.a", "bob", key)
 	c.Assert(err, check.IsNil)
 
 	// load back and compare:
@@ -140,9 +149,9 @@ func (s *KeyStoreTestSuite) TestDeleteAll(c *check.C) {
 	key := s.makeSignedKey(c, false)
 
 	// add keys
-	err := s.store.AddKey("proxy.example.com", "foo", key)
+	err := s.addKey("proxy.example.com", "foo", key)
 	c.Assert(err, check.IsNil)
-	err = s.store.AddKey("proxy.example.com", "bar", key)
+	err = s.addKey("proxy.example.com", "bar", key)
 	c.Assert(err, check.IsNil)
 
 	// check keys exist
@@ -220,7 +229,7 @@ func (s *KeyStoreTestSuite) makeSignedKey(c *check.C, makeExpired bool) *Key {
 	}
 	subject, err := identity.Subject()
 	c.Assert(err, check.IsNil)
-	tlsCert, err := s.tlsca.GenerateCertificate(tlsca.CertificateRequest{
+	tlsCert, err := s.tlsCA.GenerateCertificate(tlsca.CertificateRequest{
 		Clock:     clock,
 		PublicKey: cryptoPubKey,
 		Subject:   subject,
@@ -239,10 +248,11 @@ func (s *KeyStoreTestSuite) makeSignedKey(c *check.C, makeExpired bool) *Key {
 	})
 	c.Assert(err, check.IsNil)
 	return &Key{
-		Priv:    priv,
-		Pub:     pub,
-		Cert:    cert,
-		TLSCert: tlsCert,
+		Priv:      priv,
+		Pub:       pub,
+		Cert:      cert,
+		TLSCert:   tlsCert,
+		TrustedCA: []auth.TrustedCerts{s.tlsCACert},
 	}
 }
 
@@ -256,7 +266,7 @@ func (s *KeyStoreTestSuite) TestCheckKey(c *check.C) {
 	c.Assert(err, check.IsNil)
 	key.Cert = ssh.MarshalAuthorizedKey(ellipticCertificate)
 
-	err = s.store.AddKey("host.a", "bob", key)
+	err = s.addKey("host.a", "bob", key)
 	c.Assert(err, check.IsNil)
 
 	_, err = s.store.GetKey("host.a", "bob")
@@ -278,11 +288,19 @@ func (s *KeyStoreTestSuite) TestCheckKeyFIPS(c *check.C) {
 	c.Assert(err, check.IsNil)
 	key.Cert = ssh.MarshalAuthorizedKey(ellipticCertificate)
 
-	err = s.store.AddKey("host.a", "bob", key)
+	err = s.addKey("host.a", "bob", key)
 	c.Assert(err, check.IsNil)
 
 	_, err = s.store.GetKey("host.a", "bob")
 	c.Assert(err, check.NotNil)
+}
+
+func (s *KeyStoreTestSuite) addKey(host, user string, key *Key) error {
+	if err := s.store.AddKey(host, user, key); err != nil {
+		return err
+	}
+	// Also write the trusted CA certs for the host.
+	return s.store.SaveCerts(host, []auth.TrustedCerts{s.tlsCACert})
 }
 
 var (

--- a/lib/kube/client/kubeclient.go
+++ b/lib/kube/client/kubeclient.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"runtime"
@@ -49,7 +50,7 @@ func UpdateKubeconfig(tc *client.TeleportClient) error {
 	}
 	config.Clusters[clusterName] = &clientcmdapi.Cluster{
 		Server:                   clusterAddr,
-		CertificateAuthorityData: certAuthorities,
+		CertificateAuthorityData: bytes.Join(certAuthorities, []byte("\n")),
 	}
 
 	lastContext := config.Contexts[clusterName]


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/3872 into 4.2

SNI is used to indicate which cluster's CA to use for client cert
validation. If SNI is not sent, or set as "teleport.cluster.local"
(which is default in the client config), auth server will attempt to
validate against all known CAs.

The list of CA subjects is sent to the client during handshake, before
client sends its own client cert. If this list is too long, handshake
will fail. The limit is 65535 bytes, because TLS wire encoding uses 2
bytes for a length prefix. In teleport, this fits ~520-540 trusted
cluster CAs.

To avoid handshake failures on such large setups, all clients must send
the correct SNI. In some future version, we should enforce this to catch
such issues early. For now, added a debug log to report clients using
the default ServerName. Also added a check for large number of CAs, to
print a helpful error.

Updates https://github.com/gravitational/teleport/issues/3870