### PR TITLE
Add docker-compose Teleport quickstart and update docs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -170,7 +170,7 @@ steps:
     commands:
       - |
         cd /go/src/github.com/gravitational/teleport
-        git diff --raw ${DRONE_TARGET_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
+        git diff --raw ${DRONE_TARGET_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | grep -v .yaml | sort | uniq
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           for VERSION in $(cat /tmp/docs-versions-changed.txt); do
@@ -1066,6 +1066,6 @@ steps:
 
 ---
 kind: signature
-hmac: 1f1284ed43d98cc0551ca761dc0b119739c16b016fce58cac60d264597c8348e
+hmac: ff14b58d8b4be7ca2afcb209a8a3fc598b23415b995c18fa6e4fa79a6f6850b9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -170,7 +170,7 @@ steps:
     commands:
       - |
         cd /go/src/github.com/gravitational/teleport
-        git diff --raw ${DRONE_TARGET_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | grep -v .yaml | sort | uniq
+        git diff --raw ${DRONE_TARGET_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | grep -v .yaml | sort | uniq > /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           for VERSION in $(cat /tmp/docs-versions-changed.txt); do
@@ -1066,6 +1066,6 @@ steps:
 
 ---
 kind: signature
-hmac: ff14b58d8b4be7ca2afcb209a8a3fc598b23415b995c18fa6e4fa79a6f6850b9
+hmac: b8bbd4c4c213b24e6a5d4b54a765537b7f54ed9f20a689b39f958cd6442c8af4
 
 ...

--- a/docker/teleport-quickstart.yml
+++ b/docker/teleport-quickstart.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+  configure: &settings
+    image: quay.io/gravitational/teleport:4.3.0-alpha.2
+    container_name: teleport-configure
+    entrypoint: /bin/sh
+    hostname: localhost
+    command: -c "if [ ! /etc/teleport/teleport.yaml ]; then /usr/local/bin/teleport configure > /etc/teleport/teleport.yaml; fi"
+    volumes:
+      - ./teleport/config:/etc/teleport
+
+  teleport:
+    image: quay.io/gravitational/teleport:4.3.0-alpha.2
+    container_name: teleport
+    entrypoint: /bin/sh
+    hostname: localhost
+    command: -c "sleep 1 && /usr/local/bin/teleport start"
+    ports:
+      - "3023:3023"
+      - "3025:3025"
+      - "3080:3080"
+    volumes:
+      - ./teleport/config:/etc/teleport
+      - ./teleport/data:/var/lib/teleport
+    depends_on:
+      - configure

--- a/docker/teleport-quickstart.yml
+++ b/docker/teleport-quickstart.yml
@@ -5,7 +5,7 @@ services:
     container_name: teleport-configure
     entrypoint: /bin/sh
     hostname: localhost
-    command: -c "if [ ! /etc/teleport/teleport.yaml ]; then /usr/local/bin/teleport configure > /etc/teleport/teleport.yaml; fi"
+    command: -c "if [ ! -f /etc/teleport/teleport.yaml ]; then /usr/local/bin/teleport configure > /etc/teleport/teleport.yaml; fi"
     volumes:
       - ./teleport/config:/etc/teleport
 

--- a/docker/teleport-quickstart.yml
+++ b/docker/teleport-quickstart.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
-  configure: &settings
+  configure:
     image: quay.io/gravitational/teleport:4.3.0-alpha.2
     container_name: teleport-configure
     entrypoint: /bin/sh

--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -959,8 +959,8 @@ and 3024 on the proxy. Port 3080 is used to initially fetch the credentials (SSH
 and for discovery (where is the reverse tunnel running, in this case 3024). Port 3024 is used to
 establish a connection to the Auth Server through the proxy.
 
-To enable multiplexing so only one port is used, simply set the `tunnel_listen_addr` the same as the 
-`web_listen_addr` respectively within the `proxy_service`.  Teleport will automatically recognize using the same port and enable multiplexing. If the 
+To enable multiplexing so only one port is used, simply set the `tunnel_listen_addr` the same as the
+`web_listen_addr` respectively within the `proxy_service`.  Teleport will automatically recognize using the same port and enable multiplexing. If the
 log setting is set to DEBUG you will see multiplexing enabled in the server log.
 ```bash
 DEBU [PROC:1]    Setup Proxy: Reverse tunnel proxy and web proxy listen on the same port, multiplexing is on. service/service.go:1944
@@ -1910,9 +1910,9 @@ To connect to the OpenSSH server via `tsh`, add `--port=<ssh port>` with the `ts
 
 Example ssh to `database.work.example.com` as `root` with a OpenSSH server on port 22 via `tsh`:
    tsh ssh --port=22 root@database.work.example.com
-   
+
 !!! warning "Warning"
-  
+
     The principal (username) being used to connect must be listed in the Teleport user/role configuration.
 
 ## Certificate Rotation

--- a/docs/4.2/faq.md
+++ b/docs/4.2/faq.md
@@ -37,7 +37,7 @@ in file configuration). As defined in [Adding a node located behind NAT - Telepo
 
 ### Can nodes use a single port for reverse tunnels?
 
-Yes, Teleport supports multiplexing on a single port.  Set the `tunnel_listen_addr` to use the same port as the `listen_addr` address setting in the `proxy_service` configuration. Teleport will automatically use multiplexing with that configuration.  
+Yes, Teleport supports multiplexing on a single port.  Set the `tunnel_listen_addr` to use the same port as the `listen_addr` address setting in the `proxy_service` configuration. Teleport will automatically use multiplexing with that configuration.
 
 ### What are Teleport's scalability and hardware recommendations?
 

--- a/docs/4.3.yaml
+++ b/docs/4.3.yaml
@@ -37,6 +37,7 @@ extra:
         sha: 1c14362c9ba10f28088c7228b357dc6a70072d3d4afaa5510c70a8734068684c
         plugin:
             version: 0.1.0.alpha
+        latest_docker_image: quay.io/gravitational/teleport:4.3
 nav:
     - Documentation:
         - Introduction: index.md

--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -903,7 +903,7 @@ and 3024 on the proxy. Port 3080 is used to initially fetch the credentials (SSH
 and for discovery (where is the reverse tunnel running, in this case 3024). Port 3024 is used to
 establish a connection to the Auth Server through the proxy.
 
-To enable multiplexing so only one port is used, simply set the `tunnel_listen_addr` the same as the 
+To enable multiplexing so only one port is used, simply set the `tunnel_listen_addr` the same as the
 `web_listen_addr` respectively within the `proxy_service`.  Teleport will automatically recognize using the same port and enable multiplexing. If the log setting is set to DEBUG you will see multiplexing enabled in the server log.
 ```bash
 DEBU [PROC:1]    Setup Proxy: Reverse tunnel proxy and web proxy listen on the same port, multiplexing is on. service/service.go:1944
@@ -1856,15 +1856,15 @@ To allow access for all users:
   + Copy `teleport-user-ca.pub` to `/etc/ssh/teleport-user-ca.pub`
   + Update `sshd` configuration (usually `/etc/ssh/sshd_config` ) to point to
     this file: `TrustedUserCAKeys /etc/ssh/teleport-user-ca.pub`
-    
+
 To connect to the OpenSSH server via `tsh`, add `--port=<ssh port>` with the `tsh ssh` command:
 
 Example ssh to `database.work.example.com` as `root` with a OpenSSH server on port 22 via `tsh`:
    tsh ssh --port=22 root@database.work.example.com
-   
+
 !!! warning "Warning"
-  
-    The principal (username) being used to connect must be listed in the Teleport user/role configuration.    
+
+    The principal (username) being used to connect must be listed in the Teleport user/role configuration.
 
 ## Certificate Rotation
 

--- a/docs/4.3/faq.md
+++ b/docs/4.3/faq.md
@@ -37,7 +37,7 @@ in file configuration). As defined in [Adding a node located behind NAT - Telepo
 
 ### Can nodes use a single port for reverse tunnels?
 
-Yes, Teleport supports multiplexing on a single port.  Set the `tunnel_listen_addr` to use the same port as the `listen_addr` address setting in the `proxy_service` configuration. Teleport will automatically use multiplexing with that configuration. 
+Yes, Teleport supports multiplexing on a single port.  Set the `tunnel_listen_addr` to use the same port as the `listen_addr` address setting in the `proxy_service` configuration. Teleport will automatically use multiplexing with that configuration.
 
 ### What are Teleport's scalability and hardware recommendations?
 

--- a/docs/4.3/milv.config.yaml
+++ b/docs/4.3/milv.config.yaml
@@ -29,6 +29,7 @@ white-list-external:
   - "https://teleport.example.com:8443"
   - "https://teleport.example.com"
   - "https://[route53_domain](#route53_domain"
+  - "https://github.com/gravitational/teleport/blob/master/docker/teleport-quickstart.yml"
 black-list:
   - "./architecture/teleport_architecture.md"
   - "./quickstart__archive.md"

--- a/docs/4.3/quickstart.md
+++ b/docs/4.3/quickstart.md
@@ -307,11 +307,11 @@ For testing, we always recommend that you use the latest release version of Tele
 
 ### Quickstart using docker-compose
 
-The easiest way to start Teleport quickly is to use `docker-compose` with our [`quickstart.yml`](https://github.com/gravitational/teleport/blob/master/docker/quickstart.yml) file:
+The easiest way to start Teleport quickly is to use `docker-compose` with our [`teleport-quickstart.yml`](https://github.com/gravitational/teleport/blob/master/docker/teleport-quickstart.yml) file:
 
 ```bash
 # download the quickstart file from our Github repo
-curl -Lso quickstart.yml https://raw.githubusercontent.com/gravitational/teleport/master/docker/teleport-quickstart.yml
+curl -Lso teleport-quickstart.yml https://raw.githubusercontent.com/gravitational/teleport/master/docker/teleport-quickstart.yml
 
 # start teleport quickstart using docker-compose
 docker-compose -f teleport-quickstart.yml up

--- a/docs/4.3/quickstart.md
+++ b/docs/4.3/quickstart.md
@@ -23,6 +23,11 @@ environment, and showcase a few basic tasks you can do with Teleport.
 **You should not follow this guide if you want to set up Teleport in production.
 Instead follow the [Admin Guide](admin-guide.md)**
 
+## Optional: Quickstart using Docker
+
+The instructions below describe how to install Teleport directly onto your test system. You can also [run Teleport using Docker](#run-teleport-using-docker)
+if you don't want to install Teleport binaries straight away.
+
 ## Step 1: Install Teleport
 
 This guide installs teleport v{{ teleport.version }} on the CLI. Previous versions are documented
@@ -273,6 +278,88 @@ Session URL : https://grav-00:3080/web/cluster/grav-00/node/a3f67090-99cc-45cf-8
 $ echo "Awesome!"
 # check out your shared ssh session between two CLI windows
 ```
+
+## Run Teleport using Docker
+
+We provide pre-built Docker images for every version of Teleport. These images are hosted on quay.io.
+
+- [All tags under `quay.io/gravitational/teleport` are Teleport Community images](https://quay.io/repository/gravitational/teleport?tag=latest&tab=tags)
+- [All tags under `quay.io/gravitational/teleport-ent` are Teleport Enterprise images](https://quay.io/repository/gravitational/teleport-ent?tag=latest&tab=tags)
+
+We currently only offer Docker images for `x86_64` architectures.
+
+### Pick your image
+
+This table gives an idea of how our image naming scheme works. We offer images which point to a static version of Teleport, as well as images which are
+automatically rebuilt every night. These nightly images point to the latest version of Teleport from the current release branch, plus the two previous release branches.
+They are stable, and we recommend their use to easily keep your Teleport installation up to date.
+
+| Image name | Community or Enterprise? | Teleport version | Image automatically updated? | Image base |
+|---|---|---|---|---|
+| `quay.io/gravitational/teleport:4.3` | Community | The latest version of Teleport Community 4.3 | Yes | [alpine](https://hub.docker.com/_/alpine) |
+| `quay.io/gravitational/teleport-ent:4.2` | Enterprise | The latest version of Teleport Enterprise 4.2 | Yes | [alpine](https://hub.docker.com/_/alpine) |
+| `quay.io/gravitational/teleport-ent:4.1-fips` | Enterprise FIPS | The latest version of Teleport Enterprise 4.1 FIPS | Yes | [alpine](https://hub.docker.com/_/alpine) |
+| `quay.io/gravitational/teleport:4.3.0` | Community | 4.3.0 | No | [Ubuntu 18.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:4.2.8` | Enterprise | 4.2.8 | No | [Ubuntu 18.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:4.2.0-fips` | Enterprise FIPS | 4.2.0 | No | [Ubuntu 18.04](https://hub.docker.com/_/ubuntu) |
+
+For testing, we always recommend that you use the latest release version of Teleport, which is currently `{{teleport.latest_docker_image}}`.
+
+### Quickstart using docker-compose
+
+The easiest way to start Teleport quickly is to use `docker-compose` with our [`quickstart.yml`](https://github.com/gravitational/teleport/blob/master/docker/quickstart.yml) file:
+
+```bash
+# download the quickstart file from our Github repo
+curl -Lso quickstart.yml https://raw.githubusercontent.com/gravitational/teleport/master/docker/teleport-quickstart.yml
+
+# start teleport quickstart using docker-compose
+docker-compose -f teleport-quickstart.yml up
+```
+
+- The `docker-compose` quickstart will automatically create a config file for you at `./docker/teleport/config/teleport.yaml`
+- This config is mounted into the container under `/etc/teleport/teleport.yaml`
+- It will also start `teleport` using this config file, with Teleport's data directory set to `./docker/teleport/data` and mounted under `/var/lib/teleport`
+- By default, `docker-compose` will output Teleport's logs to the console for you to observe.
+    - If you would rather run the Teleport container in the background, use `docker-compose -f teleport-quickstart.yml up -d`
+
+### Quickstart using docker run
+
+If you'd prefer to complete these steps manually, here's some sample `docker run` commands:
+
+```bash
+# create local config and data directories for teleport, which will be mounted into the container
+mkdir -p ~/teleport/config ~/teleport/data
+
+# generate a sample teleport config and write it to the local config directory
+# this container will write the config and immediately exit - this is expected
+docker run --hostname localhost --rm --entrypoint=/usr/local/bin/teleport -v ~/teleport/config:/etc/teleport {{teleport.latest_docker_image}} configure > /etc/teleport/teleport.yaml
+
+# start teleport with mounted config and data directories, plus all ports
+docker run --hostname localhost --name teleport -v ~/teleport/config:/etc/teleport -v ~/teleport/data:/var/lib/teleport -p 3023:3023 -p 3025:3025 -p 3080:3080 {{teleport.latest_docker_image}}
+```
+
+### Creating a Teleport user when using Docker quickstart
+
+To create a user inside your Teleport container, use `docker exec`.
+
+This example command will create a Teleport user called `testuser` which is allowed to log in as either OS user `root` or `ubuntu`. Feel free to change these to suit your needs -
+[there are more instructions above in Step 3](#step-3-create-a-user-signup-token) if you'd like additional details):
+
+```bash
+docker exec teleport tctl users add testuser root,ubuntu
+```
+
+When you run this command, Teleport will output a URL which you must open to complete the user signup process:
+
+```bash
+User testuser has been created but requires a password. Share this URL with the user to complete user setup, link is valid for 1h0m0s:
+https://localhost:3080/web/invite/4f2718a52ce107568b191f222ba069f7
+
+NOTE: Make sure localhost:3080 points at a Teleport proxy which users can access.
+```
+
+You can now [follow this guide from Step 4 onwards](#step-4-register-a-user) to create your user and log into Teleport.
 
 ## Next Steps
 


### PR DESCRIPTION
Added a `docker-compose` quickstart file for easily spinning up a one-node Teleport cluster with minimal config/hassle.

Added a section to the docs detailing how to use Docker for the quickstart, and also details about our image naming scheme and how it works.