### PR TITLE
Plumb RouteToCluster through SSO login flows

### DIFF
--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -368,7 +368,7 @@ func (a *AuthServer) validateOIDCAuthCallback(q url.Values) (*oidcAuthResponse, 
 
 	// If a public key was provided, sign it and return a certificate.
 	if len(req.PublicKey) != 0 {
-		sshCert, tlsCert, err := a.createSessionCert(user, params.sessionTTL, req.PublicKey, req.Compatibility)
+		sshCert, tlsCert, err := a.createSessionCert(user, params.sessionTTL, req.PublicKey, req.Compatibility, req.RouteToCluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -424,7 +424,7 @@ func (a *AuthServer) validateSAMLResponse(samlResponse string) (*samlAuthRespons
 
 	// If a public key was provided, sign it and return a certificate.
 	if len(request.PublicKey) != 0 {
-		sshCert, tlsCert, err := a.createSessionCert(user, params.sessionTTL, request.PublicKey, request.Compatibility)
+		sshCert, tlsCert, err := a.createSessionCert(user, params.sessionTTL, request.PublicKey, request.Compatibility, request.RouteToCluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -300,6 +300,8 @@ type GithubAuthRequest struct {
 	Compatibility string `json:"compatibility,omitempty"`
 	// Expires is a global expiry time header can be set on any resource in the system.
 	Expires *time.Time `json:"expires,omitempty"`
+	// RouteToCluster is the name of Teleport cluster to issue credentials for.
+	RouteToCluster string `json:"route_to_cluster,omitempty"`
 }
 
 // SetTTL sets Expires header using realtime clock
@@ -381,6 +383,9 @@ type OIDCAuthRequest struct {
 
 	// Compatibility specifies OpenSSH compatibility flags.
 	Compatibility string `json:"compatibility,omitempty"`
+
+	// RouteToCluster is the name of Teleport cluster to issue credentials for.
+	RouteToCluster string `json:"route_to_cluster,omitempty"`
 }
 
 // Check returns nil if all parameters are great, err otherwise
@@ -443,6 +448,9 @@ type SAMLAuthRequest struct {
 
 	// Compatibility specifies OpenSSH compatibility flags.
 	Compatibility string `json:"compatibility,omitempty"`
+
+	// RouteToCluster is the name of Teleport cluster to issue credentials for.
+	RouteToCluster string `json:"route_to_cluster,omitempty"`
 }
 
 // Check returns nil if all parameters are great, err otherwise

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -770,6 +770,7 @@ func (h *Handler) githubLoginConsole(w http.ResponseWriter, r *http.Request, p h
 			CertTTL:           req.CertTTL,
 			ClientRedirectURL: req.RedirectURL,
 			Compatibility:     req.Compatibility,
+			RouteToCluster:    req.RouteToCluster,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -848,6 +849,7 @@ func (h *Handler) oidcLoginConsole(w http.ResponseWriter, r *http.Request, p htt
 			CertTTL:           req.CertTTL,
 			CheckUser:         true,
 			Compatibility:     req.Compatibility,
+			RouteToCluster:    req.RouteToCluster,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -82,6 +82,7 @@ func (m *Handler) samlSSOConsole(w http.ResponseWriter, r *http.Request, p httpr
 			PublicKey:         req.PublicKey,
 			CertTTL:           req.CertTTL,
 			Compatibility:     req.Compatibility,
+			RouteToCluster:    req.RouteToCluster,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This lets the user log into a leaf cluster directly via tsh and
provision the correct k8s credentials for it.

Updates https://github.com/gravitational/teleport/issues/3693