### PR TITLE
Plumb github username to TraitsFromLogins

### DIFF
--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -356,7 +356,7 @@ func (s *AuthServer) calculateGithubUser(connector services.GithubConnector, cla
 			claims.Username, connector.GetName())
 	}
 	p.roles = modules.GetModules().RolesFromLogins(p.logins)
-	p.traits = modules.GetModules().TraitsFromLogins(p.logins, p.kubeGroups, p.kubeUsers)
+	p.traits = modules.GetModules().TraitsFromLogins(p.username, p.logins, p.kubeGroups, p.kubeUsers)
 
 	// Pick smaller for role: session TTL from role or requested TTL.
 	roles, err := services.FetchRoles(p.roles, s.Access, p.traits)

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -46,7 +46,7 @@ type Modules interface {
 	RolesFromLogins([]string) []string
 	// TraitsFromLogins returns traits for external user based on the logins
 	// and kubernetes groups extracted from the connector
-	TraitsFromLogins(logins []string, kubeGroups []string, kubeUsers []string) map[string][]string
+	TraitsFromLogins(user string, logins []string, kubeGroups []string, kubeUsers []string) map[string][]string
 	// SupportsKubernetes returns true if this cluster supports kubernetes
 	SupportsKubernetes() bool
 	// IsBoringBinary checks if the binary was compiled with BoringCrypto.
@@ -114,7 +114,7 @@ func (p *defaultModules) RolesFromLogins(logins []string) []string {
 // extracted from the connector
 //
 // By default logins are treated as allowed logins user traits.
-func (p *defaultModules) TraitsFromLogins(logins []string, kubeGroups, kubeUsers []string) map[string][]string {
+func (p *defaultModules) TraitsFromLogins(_ string, logins, kubeGroups, kubeUsers []string) map[string][]string {
 	return map[string][]string{
 		teleport.TraitLogins:     logins,
 		teleport.TraitKubeGroups: kubeGroups,

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -47,7 +47,7 @@ func (s *ModulesSuite) TestDefaultModules(c *check.C) {
 	roles := GetModules().RolesFromLogins([]string{"root"})
 	c.Assert(roles, check.DeepEquals, []string{teleport.AdminRoleName})
 
-	traits := GetModules().TraitsFromLogins([]string{"root"}, []string{"system:masters"}, []string{"alice@example.com"})
+	traits := GetModules().TraitsFromLogins("alice", []string{"root"}, []string{"system:masters"}, []string{"alice@example.com"})
 	c.Assert(traits, check.DeepEquals, map[string][]string{
 		teleport.TraitLogins:     []string{"root"},
 		teleport.TraitKubeGroups: []string{"system:masters"},
@@ -70,7 +70,7 @@ func (s *ModulesSuite) TestTestModules(c *check.C) {
 	roles := GetModules().RolesFromLogins([]string{"root"})
 	c.Assert(roles, check.DeepEquals, []string{"root"})
 
-	traits := GetModules().TraitsFromLogins([]string{"root"}, []string{"system:masters"}, []string{"alice@example.com"})
+	traits := GetModules().TraitsFromLogins("alice", []string{"root"}, []string{"system:masters"}, []string{"alice@example.com"})
 	c.Assert(traits, check.IsNil)
 
 	isBoring := GetModules().IsBoringBinary()
@@ -105,7 +105,7 @@ func (p *testModules) RolesFromLogins(logins []string) []string {
 	return logins
 }
 
-func (p *testModules) TraitsFromLogins(logins []string, kubeGroups []string, kubeUsers []string) map[string][]string {
+func (p *testModules) TraitsFromLogins(user string, logins, kubeGroups, kubeUsers []string) map[string][]string {
 	return nil
 }
 


### PR DESCRIPTION
This lets TraitsFromLogins to use that username for extra traits. No
changes in community edition, this will be used in enterprise.