### PR TITLE
Add Helm chart packaging for Teleport

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -191,17 +191,11 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: helm-package
+name: helm-cron-teleport
 
-# TODO(gus): just for testing, this will be cronned when ready
 trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    include:
-      - push
-      - pull_request
+  cron:
+    - helm-cron-teleport
 
 workspace:
   path: /tmp
@@ -1119,6 +1113,6 @@ steps:
 
 ---
 kind: signature
-hmac: 009eda484e393258748c38d3bca97ffdb35f4d5bd044404a695ab62d1102b14b
+hmac: 10c217c8b4af3b3632704387142bf1005ae54be70e3aa7b9cd7e26b3ddfebb19
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -222,8 +222,8 @@ steps:
     image: alpine/helm:2.16.9
     commands:
       - mkdir -p /tmp/chart
+      - cd /tmp/chart
       - helm package /tmp/go/src/github.com/gravitational/teleport/examples/chart/teleport
-      - cp /tmp/go/src/github.com/gravitational/teleport/examples/chart/teleport/teleport*.tgz /tmp/chart
       - helm repo index /tmp/chart
 
   - name: Upload to S3
@@ -1118,6 +1118,6 @@ steps:
 
 ---
 kind: signature
-hmac: fec5761332f240e3032576c06de9117f7576cd2b206470a8c82d0f5e5b7719a5
+hmac: dd58b39b1c9dec717a9f616555c51cb4c99200f3b5b19d9a6effcd1bc725053a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -191,6 +191,58 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
+name: helm-package
+
+# TODO(gus): just for testing, this will be cronned when ready
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    include:
+      - push
+      - pull_request
+
+workspace:
+  path: /tmp
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: alpine/git
+    commands:
+      - mkdir -p /tmp/go/src/github.com/gravitational/teleport
+      - cd /tmp/go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout $DRONE_COMMIT
+
+  - name: Package helm chart
+    image: alpine/helm:2.16.9
+    commands:
+      - mkdir -p /tmp/chart
+      - helm package /tmp/go/src/github.com/gravitational/teleport
+      - cp /tmp/go/src/github.com/gravitational/teleport/teleport*.tgz /tmp/chart
+      - helm repo index /tmp/chart
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /tmp/chart/*
+      target: teleport/chart/
+      strip_prefix: /tmp/chart
+
+---
+kind: pipeline
+type: kubernetes
 name: build-linux-amd64
 
 environment:
@@ -1066,6 +1118,6 @@ steps:
 
 ---
 kind: signature
-hmac: 1f1284ed43d98cc0551ca761dc0b119739c16b016fce58cac60d264597c8348e
+hmac: 259e9f8ccc8e0a8c14ef58581e2aef273bb8840867e7d0eefada60cb74a7715b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -226,9 +226,9 @@ steps:
     settings:
       bucket: charts.gravitational.io
       access_key:
-        from_secret: AWS_ACCESS_KEY_ID
+        from_secret: PRODUCTION_AWS_ACCESS_KEY_ID
       secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
+        from_secret: PRODUCTION_AWS_SECRET_ACCESS_KEY
       region: us-east-2
       acl: public-read
       source: /tmp/chart/*
@@ -1113,6 +1113,6 @@ steps:
 
 ---
 kind: signature
-hmac: 10c217c8b4af3b3632704387142bf1005ae54be70e3aa7b9cd7e26b3ddfebb19
+hmac: 9880accdbb7e5e5371e33dc6cd193eb764a765d97eaa310b650ab2c7840cfc2b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -226,9 +226,9 @@ steps:
     settings:
       bucket: charts.gravitational.io
       access_key:
-        from_secret: PRODUCTION_AWS_ACCESS_KEY_ID
+        from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
       secret_key:
-        from_secret: PRODUCTION_AWS_SECRET_ACCESS_KEY
+        from_secret: PRODUCTION_CHARTS_AWS_SECRET_ACCESS_KEY
       region: us-east-2
       acl: public-read
       source: /tmp/chart/*
@@ -1113,6 +1113,6 @@ steps:
 
 ---
 kind: signature
-hmac: 9880accdbb7e5e5371e33dc6cd193eb764a765d97eaa310b650ab2c7840cfc2b
+hmac: 098b4e9dccb6bbb075bf39b404b3f5c64e982566fd58a6b4f390fd0b93a7a75d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -235,7 +235,7 @@ steps:
         from_secret: AWS_ACCESS_KEY_ID
       secret_key:
         from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
+      region: us-east-2
       acl: public-read
       source: /tmp/chart/*
       target: teleport/chart/
@@ -1119,6 +1119,6 @@ steps:
 
 ---
 kind: signature
-hmac: c60f83a1a7af20ae4dcad79badd3cdda47e4ce137ba75129f5c7ae7eb7762de1
+hmac: 9938136a9097ddca379da6a5823aca8f9c53e805de1755edc3f31bbd1da81da9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -223,6 +223,7 @@ steps:
     commands:
       - mkdir -p /tmp/chart
       - cd /tmp/chart
+      - helm init --client-only
       - helm package /tmp/go/src/github.com/gravitational/teleport/examples/chart/teleport
       - helm repo index /tmp/chart
 
@@ -1118,6 +1119,6 @@ steps:
 
 ---
 kind: signature
-hmac: dd58b39b1c9dec717a9f616555c51cb4c99200f3b5b19d9a6effcd1bc725053a
+hmac: 0530c11805081f6b4e79582b8f8a93a50791232b1d2f1dcddef91457b3a06416
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -238,7 +238,7 @@ steps:
       region: us-east-2
       acl: public-read
       source: /tmp/chart/*
-      target: teleport/chart/
+      target: /
       strip_prefix: /tmp/chart
 
 ---
@@ -1119,6 +1119,6 @@ steps:
 
 ---
 kind: signature
-hmac: 9938136a9097ddca379da6a5823aca8f9c53e805de1755edc3f31bbd1da81da9
+hmac: 009eda484e393258748c38d3bca97ffdb35f4d5bd044404a695ab62d1102b14b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -230,13 +230,13 @@ steps:
   - name: Upload to S3
     image: plugins/s3
     settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
+      bucket: charts.gravitational.io
       access_key:
         from_secret: AWS_ACCESS_KEY_ID
       secret_key:
         from_secret: AWS_SECRET_ACCESS_KEY
       region: us-west-2
+      acl: public-read
       source: /tmp/chart/*
       target: teleport/chart/
       strip_prefix: /tmp/chart
@@ -1119,6 +1119,6 @@ steps:
 
 ---
 kind: signature
-hmac: 0530c11805081f6b4e79582b8f8a93a50791232b1d2f1dcddef91457b3a06416
+hmac: c60f83a1a7af20ae4dcad79badd3cdda47e4ce137ba75129f5c7ae7eb7762de1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -222,8 +222,8 @@ steps:
     image: alpine/helm:2.16.9
     commands:
       - mkdir -p /tmp/chart
-      - helm package /tmp/go/src/github.com/gravitational/teleport
-      - cp /tmp/go/src/github.com/gravitational/teleport/teleport*.tgz /tmp/chart
+      - helm package /tmp/go/src/github.com/gravitational/teleport/examples/chart/teleport
+      - cp /tmp/go/src/github.com/gravitational/teleport/examples/chart/teleport/teleport*.tgz /tmp/chart
       - helm repo index /tmp/chart
 
   - name: Upload to S3
@@ -1118,6 +1118,6 @@ steps:
 
 ---
 kind: signature
-hmac: 259e9f8ccc8e0a8c14ef58581e2aef273bb8840867e7d0eefada60cb74a7715b
+hmac: fec5761332f240e3032576c06de9117f7576cd2b206470a8c82d0f5e5b7719a5
 
 ...

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -60,6 +60,19 @@ $ kubectl create configmap ca-certs --from-file=ca.pem
 $ helm upgrade --install teleport ./
 ```
 
+## Downloading the chart from the Gravitational repo
+
+Gravitational hosts this Helm chart at http://charts.gravitational.io - it is updated from `master` every night.
+
+To add the chart and use it, you can run these commands:
+
+```console
+$ helm repo add gravitational http://charts.gravitational.io
+$ helm install teleport gravitational/teleport
+```
+
+You will still need a correctly configured `values.yaml` file for this to work.
+
 ## Running locally on minikube
 
 Grab the test setup from the community project [teleport-on-minikube](http://github.com/mumoshu/teleport-on-minikube) and run:


### PR DESCRIPTION
Fixes #3883
Fixes #2623
References #3499
References #3656 

Adds a nightly cron job in Drone which downloads the Teleport Helm chart from https://github.com/gravitational/teleport/tree/master/examples/chart/teleport, packages it, creates an index file and uploads it to a public S3 bucket.

The charts are hosted at http://charts.gravitational.io/

They can be added to Helm and used like so:

```console
$ helm repo add gravitational http://charts.gravitational.io
$ helm install teleport gravitational/teleport
```

This chart doesn't work out of the box (i.e. you still require a `values.yaml` file for it to work) but it's a start.
