### PR TITLE
Update k8s impersonation RBAC example to mention selfsubjectaccessreview

### DIFF
--- a/docs/4.3/kubernetes_ssh.md
+++ b/docs/4.3/kubernetes_ssh.md
@@ -92,6 +92,12 @@ rules:
   - serviceaccounts
   verbs:
   - impersonate
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This is a new requirement in 4.3 and was lost in rebasing.
The proxy needs this to self-test permissions at startup.