### PR TITLE
Set contexts session for execs

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -705,8 +705,8 @@ func buildEnvironment(ctx *ServerContext) []string {
 
 	// If a session has been created try and set TERM, SSH_TTY, and SSH_SESSION_ID.
 	if ctx.session != nil {
-		env = append(env, fmt.Sprintf("TERM=%v", ctx.session.term.GetTermType()))
 		if ctx.session.term != nil {
+			env = append(env, fmt.Sprintf("TERM=%v", ctx.session.term.GetTermType()))
 			env = append(env, fmt.Sprintf("SSH_TTY=%s", ctx.session.term.TTY().Name()))
 		}
 		if ctx.session.id != "" {

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -304,6 +304,20 @@ func (s *SrvSuite) TestAgentForwardPermission(c *C) {
 	c.Assert(strings.Contains(string(output), "SSH_AUTH_SOCK"), Equals, false)
 }
 
+// TestOpenExecSessionSetsSession tests that OpenExecSession()
+// sets ServerContext session.
+func (s *SrvSuite) TestOpenExecSessionSetsSession(c *C) {
+	se, err := s.clt.NewSession()
+	c.Assert(err, IsNil)
+	defer se.Close()
+
+	// This will trigger an exec request, which will start a non-interactive session,
+	// which then triggers setting env for SSH_SESSION_ID.
+	output, err := se.Output("env")
+	c.Assert(err, IsNil)
+	c.Assert(strings.Contains(string(output), teleport.SSHSessionID), Equals, true)
+}
+
 // TestAgentForward tests agent forwarding via unix sockets
 func (s *SrvSuite) TestAgentForward(c *C) {
 	ctx := context.Background()

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -214,6 +214,7 @@ func (s *SessionRegistry) OpenExecSession(channel ssh.Channel, req *ssh.Request,
 
 	// Start a non-interactive session (TTY attached). Close the session if an error
 	// occurs, otherwise it will be closed by the callee.
+	ctx.session = sess
 	err = sess.startExec(channel, ctx)
 	defer sess.Close()
 	if err != nil {
@@ -875,13 +876,11 @@ func (s *session) startExec(channel ssh.Channel, ctx *ServerContext) error {
 			events.EventNamespace:           ctx.srv.GetNamespace(),
 			events.SessionInteractive:       false,
 			events.SessionEnhancedRecording: s.hasEnhancedRecording,
-			events.SessionParticipants: []string{
-				ctx.Identity.TeleportUser,
-			},
-			events.SessionServerHostname: ctx.srv.GetInfo().GetHostname(),
-			events.SessionServerAddr:     ctx.srv.GetInfo().GetAddr(),
-			events.SessionStartTime:      start,
-			events.SessionEndTime:        end,
+			events.SessionServerHostname:    ctx.srv.GetInfo().GetHostname(),
+			events.SessionServerAddr:        ctx.srv.GetInfo().GetAddr(),
+			events.SessionStartTime:         start,
+			events.SessionEndTime:           end,
+			events.EventUser:                ctx.Identity.TeleportUser,
 		}
 		s.emitAuditEvent(events.SessionEnd, eventFields)
 


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/3916
fixes https://github.com/gravitational/teleport/issues/3919

#### Description
- set ctx.session for non-interactive sessions (thank you @fspmarshall for help!)
- replace `session participants list` event field with `single user` event field

#### Screenshot
![image](https://user-images.githubusercontent.com/43280172/86195477-d326fe00-bb05-11ea-8169-98050ddbdf1f.png)
