### PR TITLE
Fix all connector references in docs

### DIFF
--- a/docs/3.1/admin-guide.md
+++ b/docs/3.1/admin-guide.md
@@ -1284,19 +1284,30 @@ connector       | Authentication connectors for [single sign-on](ssh_sso) (SSO) 
 
 **Examples:**
 
-```yaml
+```bash
 # list all connectors:
 $ tctl get connectors
 
-# dump a connector called "okta":
-$ tctl get connectors/okta
+# dump a SAML connector called "okta":
+$ tctl get saml/okta
 
-# delete a connector called "okta":
-$ tctl rm connectors/okta
+# delete a SAML connector called "okta":
+$ tctl rm saml/okta
+
+# delete an OIDC connector called "gsuite":
+$ tctl rm oidc/gsuite
+
+# delete a github connector called "myteam":
+$ tctl rm github/myteam
 
 # delete a local user called "admin":
 $ tctl rm users/admin
 ```
+
+!!! note
+    Although `tctl get connectors` will show you every connector, when working with an individual
+    connector you must use the correct `kind`, such as `saml` or `oidc`. You can see each
+    connector's `kind` at the top of its YAML output from `tctl get connectors`.
 
 ## Trusted Clusters
 

--- a/docs/3.2/admin-guide.md
+++ b/docs/3.2/admin-guide.md
@@ -1277,19 +1277,30 @@ connector       | Authentication connectors for [single sign-on](ssh_sso) (SSO) 
 
 **Examples:**
 
-```yaml
+```bash
 # list all connectors:
 $ tctl get connectors
 
-# dump a connector called "okta":
-$ tctl get connectors/okta
+# dump a SAML connector called "okta":
+$ tctl get saml/okta
 
-# delete a connector called "okta":
-$ tctl rm connectors/okta
+# delete a SAML connector called "okta":
+$ tctl rm saml/okta
+
+# delete an OIDC connector called "gsuite":
+$ tctl rm oidc/gsuite
+
+# delete a github connector called "myteam":
+$ tctl rm github/myteam
 
 # delete a local user called "admin":
 $ tctl rm users/admin
 ```
+
+!!! note
+    Although `tctl get connectors` will show you every connector, when working with an individual
+    connector you must use the correct `kind`, such as `saml` or `oidc`. You can see each
+    connector's `kind` at the top of its YAML output from `tctl get connectors`.
 
 ## Trusted Clusters
 

--- a/docs/4.0/admin-guide.md
+++ b/docs/4.0/admin-guide.md
@@ -1316,19 +1316,30 @@ connector       | Authentication connectors for [single sign-on](ssh_sso) (SSO) 
 
 **Examples:**
 
-```yaml
+```bash
 # list all connectors:
 $ tctl get connectors
 
-# dump a connector called "okta":
-$ tctl get connectors/okta
+# dump a SAML connector called "okta":
+$ tctl get saml/okta
 
-# delete a connector called "okta":
-$ tctl rm connectors/okta
+# delete a SAML connector called "okta":
+$ tctl rm saml/okta
+
+# delete an OIDC connector called "gsuite":
+$ tctl rm oidc/gsuite
+
+# delete a github connector called "myteam":
+$ tctl rm github/myteam
 
 # delete a local user called "admin":
 $ tctl rm users/admin
 ```
+
+!!! note
+    Although `tctl get connectors` will show you every connector, when working with an individual
+    connector you must use the correct `kind`, such as `saml` or `oidc`. You can see each
+    connector's `kind` at the top of its YAML output from `tctl get connectors`.
 
 ## Trusted Clusters
 

--- a/docs/4.1/admin-guide.md
+++ b/docs/4.1/admin-guide.md
@@ -1357,21 +1357,33 @@ Here's the list of resources currently exposed via [ `tctl` ](cli-docs.md#tctl) 
 | role          | A role assumed by users. The open source Teleport only includes one role: "admin", but Enterprise teleport users can define their own roles.|
 | connector     | Authentication connectors for [single sign-on](enterprise/ssh_sso.md) (SSO) for SAML, OIDC and Github.|
 
+
 **Examples:**
 
-``` yaml
+```bash
 # list all connectors:
 $ tctl get connectors
 
-# dump a connector called "okta":
-$ tctl get connectors/okta
+# dump a SAML connector called "okta":
+$ tctl get saml/okta
 
-# delete a connector called "okta":
-$ tctl rm connectors/okta
+# delete a SAML connector called "okta":
+$ tctl rm saml/okta
+
+# delete an OIDC connector called "gsuite":
+$ tctl rm oidc/gsuite
+
+# delete a github connector called "myteam":
+$ tctl rm github/myteam
 
 # delete a local user called "admin":
 $ tctl rm users/admin
 ```
+
+!!! note
+    Although `tctl get connectors` will show you every connector, when working with an individual
+    connector you must use the correct `kind`, such as `saml` or `oidc`. You can see each
+    connector's `kind` at the top of its YAML output from `tctl get connectors`.
 
 ## Trusted Clusters
 

--- a/docs/4.1/cli-docs.md
+++ b/docs/4.1/cli-docs.md
@@ -729,14 +729,14 @@ Delete a resource
 ### Arguments
 
 * `[<resource-type/resource-name>]` Resource to delete
-    - `<resource type>` Type of a resource [for example: `connector,user,cluster,token` ]
+    - `<resource type>` Type of a resource [for example: `saml,oidc,github,user,cluster,token` ]
     - `<resource name>` Resource name to delete
 
 ### Examples
 
 ``` bsh
-# delete a connector called "okta":
-$ tctl rm connectors/okta
+# delete a SAML connector called "okta":
+$ tctl rm saml/okta
 
 # delete a local user called "admin":
 $ tctl rm users/admin

--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -1384,19 +1384,30 @@ Here's the list of resources currently exposed via [`tctl`](cli-docs.md#tctl) :
 
 **Examples:**
 
-``` bash
+```bash
 # list all connectors:
 $ tctl get connectors
 
-# dump a connector called "okta":
-$ tctl get connectors/okta
+# dump a SAML connector called "okta":
+$ tctl get saml/okta
 
-# delete a connector called "okta":
-$ tctl rm connectors/okta
+# delete a SAML connector called "okta":
+$ tctl rm saml/okta
+
+# delete an OIDC connector called "gsuite":
+$ tctl rm oidc/gsuite
+
+# delete a github connector called "myteam":
+$ tctl rm github/myteam
 
 # delete a local user called "admin":
 $ tctl rm users/admin
 ```
+
+!!! note
+    Although `tctl get connectors` will show you every connector, when working with an individual
+    connector you must use the correct `kind`, such as `saml` or `oidc`. You can see each
+    connector's `kind` at the top of its YAML output from `tctl get connectors`.
 
 ## Trusted Clusters
 

--- a/docs/4.2/cli-docs.md
+++ b/docs/4.2/cli-docs.md
@@ -792,14 +792,14 @@ Delete a resource
 ### Arguments
 
 * `[<resource-type/resource-name>]` Resource to delete
-    - `<resource type>` Type of a resource [for example: `connector,user,cluster,token` ]
+    - `<resource type>` Type of a resource [for example: `saml,oidc,github,user,cluster,token` ]
     - `<resource name>` Resource name to delete
 
 ### Examples
 
 ``` bsh
-# delete a connector called "okta":
-$ tctl rm connectors/okta
+# delete a SAML connector called "okta":
+$ tctl rm saml/okta
 
 # delete a local user called "admin":
 $ tctl rm users/admin

--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -1329,19 +1329,30 @@ Here's the list of resources currently exposed via [ `tctl` ](cli-docs.md#tctl) 
 
 **Examples:**
 
-``` yaml
+```bash
 # list all connectors:
 $ tctl get connectors
 
-# dump a connector called "okta":
-$ tctl get connectors/okta
+# dump a SAML connector called "okta":
+$ tctl get saml/okta
 
-# delete a connector called "okta":
-$ tctl rm connectors/okta
+# delete a SAML connector called "okta":
+$ tctl rm saml/okta
+
+# delete an OIDC connector called "gsuite":
+$ tctl rm oidc/gsuite
+
+# delete a github connector called "myteam":
+$ tctl rm github/myteam
 
 # delete a local user called "admin":
 $ tctl rm users/admin
 ```
+
+!!! note
+    Although `tctl get connectors` will show you every connector, when working with an individual
+    connector you must use the correct `kind`, such as `saml` or `oidc`. You can see each
+    connector's `kind` at the top of its YAML output from `tctl get connectors`.
 
 ## Trusted Clusters
 

--- a/docs/4.3/cli-docs.md
+++ b/docs/4.3/cli-docs.md
@@ -796,14 +796,14 @@ Delete a resource
 ### Arguments
 
 * `[<resource-type/resource-name>]` Resource to delete
-    - `<resource type>` Type of a resource [for example: `connector,user,cluster,token` ]
+    - `<resource type>` Type of a resource [for example: `saml,oidc,github,user,cluster,token` ]
     - `<resource name>` Resource name to delete
 
 ### Examples
 
 ``` bsh
-# delete a connector called "okta":
-$ tctl rm connectors/okta
+# delete a SAML connector called "okta":
+$ tctl rm saml/okta
 
 # delete a local user called "admin":
 $ tctl rm users/admin


### PR DESCRIPTION
The CLI examples of how to get/remove SAML/OIDC connectors in our docs were broken. This PR fixes that.

Although you can `tctl get connectors`, you can't `tctl rm connector/name` or `tctl get connector/name` - you have to use `tctl rm saml/name`,`tctl rm oidc/name` or `tctl rm github/name` as appropriate.