### PR TITLE
Backport: etcd prefix fix and migration

### DIFF
--- a/examples/etcd/start-etcd.sh
+++ b/examples/etcd/start-etcd.sh
@@ -7,7 +7,7 @@
 # NOTE: this file is also used to run etcd tests.
 #
 
-EXAMPLES_DIR=$GOPATH/src/github.com/gravitational/teleport/examples/etcd
+EXAMPLES_DIR=$(go env GOPATH)/src/github.com/gravitational/teleport/examples/etcd
 
 HERE=$(readlink -f $0)
 cd $(dirname $HERE)

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -80,6 +80,10 @@ type Backend interface {
 	// CloseWatchers closes all the watchers
 	// without closing the backend
 	CloseWatchers()
+
+	// Migrate performs any data migration necessary between Teleport versions.
+	// Migrate must be called BEFORE using any other methods of the Backend.
+	Migrate(context.Context) error
 }
 
 // Batch implements some batch methods
@@ -331,3 +335,9 @@ const Separator = '/'
 func Key(parts ...string) []byte {
 	return []byte(strings.Join(append([]string{""}, parts...), string(Separator)))
 }
+
+// NoMigrations implements a nop Migrate method of Backend.
+// Backend implementations should embed this when no migrations are necessary.
+type NoMigrations struct{}
+
+func (NoMigrations) Migrate(context.Context) error { return nil }

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -96,6 +96,7 @@ func (cfg *DynamoConfig) CheckAndSetDefaults() error {
 type DynamoDBBackend struct {
 	*log.Entry
 	DynamoConfig
+	backend.NoMigrations
 	svc              *dynamodb.DynamoDB
 	streams          *dynamodbstreams.DynamoDBStreams
 	clock            clockwork.Clock

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -18,6 +18,7 @@ package etcdbk
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"testing"
@@ -26,10 +27,13 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/utils"
+	"go.etcd.io/etcd/clientv3"
 
 	"github.com/gravitational/trace"
 	"gopkg.in/check.v1"
 )
+
+const customPrefix = "/custom"
 
 func TestEtcd(t *testing.T) { check.TestingT(t) }
 
@@ -37,7 +41,6 @@ type EtcdSuite struct {
 	bk     *EtcdBackend
 	suite  test.BackendSuite
 	config backend.Params
-	skip   bool
 }
 
 var _ = check.Suite(&EtcdSuite{})
@@ -48,7 +51,7 @@ func (s *EtcdSuite) SetUpSuite(c *check.C) {
 	// this config must match examples/etcd/teleport.yaml
 	s.config = backend.Params{
 		"peers":         []string{"https://127.0.0.1:2379"},
-		"prefix":        "teleport.secrets",
+		"prefix":        "/teleport",
 		"tls_key_file":  "../../../examples/etcd/certs/client-key.pem",
 		"tls_cert_file": "../../../examples/etcd/certs/client-cert.pem",
 		"tls_ca_file":   "../../../examples/etcd/certs/ca-cert.pem",
@@ -59,13 +62,15 @@ func (s *EtcdSuite) SetUpSuite(c *check.C) {
 		return New(context.Background(), s.config)
 	}
 	s.suite.NewBackend = newBackend
+}
+
+func (s *EtcdSuite) SetUpTest(c *check.C) {
 	// Initiate a backend with a registry
-	b, err := newBackend()
+	b, err := s.suite.NewBackend()
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			fmt.Printf("WARNING: etcd cluster is not available: %v.\n", err)
 			fmt.Printf("WARNING: Start examples/etcd/start-etcd.sh.\n")
-			s.skip = true
 			c.Skip(err.Error())
 		}
 		c.Assert(err, check.IsNil)
@@ -82,24 +87,22 @@ func (s *EtcdSuite) SetUpSuite(c *check.C) {
 	if err != nil && !trace.IsNotFound(err) {
 		if strings.Contains(err.Error(), "connection refused") || trace.IsConnectionProblem(err) {
 			fmt.Println("WARNING: etcd cluster is not available. Start examples/etcd/start-etcd.sh")
-			s.skip = true
 			c.Skip(err.Error())
 		}
 		c.Assert(err, check.IsNil)
 	}
+
+	s.bk.cfg.Key = legacyDefaultPrefix
 }
 
-func (s *EtcdSuite) SetUpTest(c *check.C) {
-	if s.skip {
-		fmt.Println("WARNING: etcd cluster is not available. Start examples/etcd/start-etcd.sh")
-		c.Skip("Etcd is not available")
-	}
-}
-
-func (s *EtcdSuite) TearDownSuite(c *check.C) {
-	if s.bk != nil {
-		c.Assert(s.bk.Close(), check.IsNil)
-	}
+func (s *EtcdSuite) TearDownTest(c *check.C) {
+	ctx := context.Background()
+	_, err := s.bk.client.Delete(ctx, legacyDefaultPrefix, clientv3.WithPrefix())
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Delete(ctx, customPrefix, clientv3.WithPrefix())
+	c.Assert(err, check.IsNil)
+	err = s.bk.Close()
+	c.Assert(err, check.IsNil)
 }
 
 func (s *EtcdSuite) TestCRUD(c *check.C) {
@@ -136,4 +139,149 @@ func (s *EtcdSuite) TestWatchersClose(c *check.C) {
 
 func (s *EtcdSuite) TestLocking(c *check.C) {
 	s.suite.Locking(c)
+}
+
+func (s *EtcdSuite) TestPrefix(c *check.C) {
+	var (
+		ctx  = context.Background()
+		item = backend.Item{
+			Key:   []byte("/foo"),
+			Value: []byte("bar"),
+		}
+	)
+
+	s.bk.cfg.Key = customPrefix
+	_, err := s.bk.Put(ctx, item)
+	c.Assert(err, check.IsNil)
+
+	wantKey := fmt.Sprintf("%s%s", s.bk.cfg.Key, item.Key)
+	s.assertKV(ctx, c, wantKey, string(item.Value))
+}
+
+func (s *EtcdSuite) assertKV(ctx context.Context, c *check.C, key, val string) {
+	c.Logf("assert that key %q contains value %q", key, val)
+	resp, err := s.bk.client.Get(ctx, key)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(resp.Kvs), check.Equals, 1)
+	c.Assert(string(resp.Kvs[0].Key), check.Equals, key)
+	// Note: EtcdBackend stores all values base64-encoded.
+	gotValue, err := base64.StdEncoding.DecodeString(string(resp.Kvs[0].Value))
+	c.Assert(err, check.IsNil)
+	c.Assert(string(gotValue), check.Equals, val)
+}
+
+func (s *EtcdSuite) TestSyncLegacyPrefix(c *check.C) {
+	ctx := context.Background()
+	s.bk.cfg.Key = customPrefix
+
+	reset := func() {
+		_, err := s.bk.client.Delete(ctx, legacyDefaultPrefix, clientv3.WithPrefix())
+		c.Assert(err, check.IsNil)
+		_, err = s.bk.client.Delete(ctx, customPrefix, clientv3.WithPrefix())
+		c.Assert(err, check.IsNil)
+	}
+	snapshot := func() map[string]string {
+		kvs := make(map[string]string)
+
+		resp, err := s.bk.client.Get(ctx, legacyDefaultPrefix, clientv3.WithPrefix())
+		c.Assert(err, check.IsNil)
+		for _, kv := range resp.Kvs {
+			kvs[string(kv.Key)] = string(kv.Value)
+		}
+
+		resp, err = s.bk.client.Get(ctx, customPrefix, clientv3.WithPrefix())
+		c.Assert(err, check.IsNil)
+		for _, kv := range resp.Kvs {
+			kvs[string(kv.Key)] = string(kv.Value)
+		}
+
+		return kvs
+	}
+
+	// Make sure the prefixes start off clean.
+	reset()
+
+	c.Log("both prefixes empty")
+	err := s.bk.syncLegacyPrefix(ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(snapshot(), check.DeepEquals, map[string]string{})
+	reset()
+
+	c.Log("data in custom prefix, no data in legacy prefix; custom prefix should be preserved")
+	_, err = s.bk.client.Put(ctx, customPrefix+"/0", "c0")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, customPrefix+"/1", "c1")
+	c.Assert(err, check.IsNil)
+	err = s.bk.syncLegacyPrefix(ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(snapshot(), check.DeepEquals, map[string]string{
+		customPrefix + "/0": "c0",
+		customPrefix + "/1": "c1",
+	})
+	reset()
+
+	c.Log("no data in custom prefix, data in legacy prefix copied over; custom prefix should be populated")
+	_, err = s.bk.client.Put(ctx, legacyDefaultPrefix+"/0", "l0")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, legacyDefaultPrefix+"/1", "l1")
+	c.Assert(err, check.IsNil)
+	err = s.bk.syncLegacyPrefix(ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(snapshot(), check.DeepEquals, map[string]string{
+		legacyDefaultPrefix + "/0": "l0",
+		legacyDefaultPrefix + "/1": "l1",
+		customPrefix + "/0":        "l0",
+		customPrefix + "/1":        "l1",
+	})
+	reset()
+
+	c.Log("data in both prefixes, custom prefix is newer; custom prefix should be preserved")
+	_, err = s.bk.client.Put(ctx, legacyDefaultPrefix+"/0", "l0")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, legacyDefaultPrefix+"/1", "l1")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, legacyDefaultPrefix+"/3", "l3")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, customPrefix+"/0", "c0")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, customPrefix+"/1", "c1")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, customPrefix+"/2", "c2")
+	c.Assert(err, check.IsNil)
+	err = s.bk.syncLegacyPrefix(ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(snapshot(), check.DeepEquals, map[string]string{
+		legacyDefaultPrefix + "/0": "l0",
+		legacyDefaultPrefix + "/1": "l1",
+		legacyDefaultPrefix + "/3": "l3",
+		customPrefix + "/0":        "c0",
+		customPrefix + "/1":        "c1",
+		customPrefix + "/2":        "c2",
+	})
+	reset()
+
+	c.Log("data in both prefixes, legacy prefix is newer; custom prefix should be replaced")
+	_, err = s.bk.client.Put(ctx, legacyDefaultPrefix+"/0", "l0")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, legacyDefaultPrefix+"/1", "l1")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, customPrefix+"/0", "c0")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, customPrefix+"/1", "c1")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, customPrefix+"/2", "c2")
+	c.Assert(err, check.IsNil)
+	_, err = s.bk.client.Put(ctx, legacyDefaultPrefix+"/3", "l3")
+	c.Assert(err, check.IsNil)
+	err = s.bk.syncLegacyPrefix(ctx)
+	c.Assert(err, check.IsNil)
+	c.Assert(snapshot(), check.DeepEquals, map[string]string{
+		legacyDefaultPrefix + "/0": "l0",
+		legacyDefaultPrefix + "/1": "l1",
+		legacyDefaultPrefix + "/3": "l3",
+		customPrefix + "/0":        "l0",
+		customPrefix + "/1":        "l1",
+		customPrefix + "/3":        "l3",
+	})
+	reset()
 }

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -92,6 +92,7 @@ func (cfg *backendConfig) CheckAndSetDefaults() error {
 type FirestoreBackend struct {
 	*log.Entry
 	backendConfig
+	backend.NoMigrations
 	// svc is the primary Firestore client
 	svc *firestore.Client
 	// clock is the

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -184,6 +184,7 @@ func NewWithConfig(ctx context.Context, cfg Config) (*LiteBackend, error) {
 type LiteBackend struct {
 	Config
 	*log.Entry
+	backend.NoMigrations
 	db *sql.DB
 	// clock is used to generate time,
 	// could be swapped in tests for fixed time

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -116,6 +116,7 @@ type Memory struct {
 	*sync.Mutex
 	*log.Entry
 	Config
+	backend.NoMigrations
 	// tree is a BTree with items
 	tree *btree.BTree
 	// heap is a min heap with expiry records

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -216,6 +216,9 @@ func (s *Reporter) Clock() clockwork.Clock {
 	return s.Backend.Clock()
 }
 
+// Migrate runs the necessary data migrations for this backend.
+func (s *Reporter) Migrate(ctx context.Context) error { return s.Backend.Migrate(ctx) }
+
 // trackRequests tracks top requests, endKey is supplied for ranges
 func (s *Reporter) trackRequest(opType OpType, key []byte, endKey []byte) {
 	if !s.TrackTopRequests {

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -162,3 +162,6 @@ func (s *Sanitizer) Clock() clockwork.Clock {
 func (s *Sanitizer) CloseWatchers() {
 	s.backend.CloseWatchers()
 }
+
+// Migrate runs the necessary data migrations for this backend.
+func (s *Sanitizer) Migrate(ctx context.Context) error { return s.backend.Migrate(ctx) }

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -80,6 +80,7 @@ func (s *Suite) TestSanitizeBucket(c *check.C) {
 }
 
 type nopBackend struct {
+	NoMigrations
 }
 
 func (n *nopBackend) Get(_ context.Context, _ []byte) (*Item, error) {

--- a/lib/backend/wrap.go
+++ b/lib/backend/wrap.go
@@ -136,3 +136,6 @@ func (s *Wrapper) CloseWatchers() {
 func (s *Wrapper) Clock() clockwork.Clock {
 	return s.backend.Clock()
 }
+
+// Migrate runs the necessary data migrations for this backend.
+func (s *Wrapper) Migrate(ctx context.Context) error { return s.backend.Migrate(ctx) }


### PR DESCRIPTION
Squashed version of https://github.com/gravitational/teleport/pull/3798 into 4.3 branch.

See #2883 for context.
This PR makes the etcd backend actually use the prefix specified in config file. It also migrates the data from the old prefix as needed.

Specific changes are:

    always use the teleport.backend.prefix field for etcd storage (instead of hardcoded /teleport)
    at startup, overwrite any config prefix data with data from /teleport iff (a) /teleport has some data and (b) config prefix is empty (initial 4.2->4.3 upgrade) or has older data than /teleport (upgrade 4.2->4.3, downgrade 4.3->4.2, make some data changes and upgrade 4.2->4.3 again)

This startup copying is blocking - teleport won't start until it's complete.

All of this assumes that there's only 1 auth server during an upgrade, per our upgrade docs.

Fixes  #2883