### PR TITLE
Allow user with at in name

### DIFF
--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -651,18 +651,18 @@ func (r *reader) read() error {
 
 var reSCP = regexp.MustCompile(
 	// optional username, note that outside group
-	// is a non-capturing as it includes @ sign we don't want
-	`(?:(?P<username>[^@]+)@)?` +
+	// is a non-capturing as it includes @ signs we don't want
+	`(?:(?P<username>.+)@)?` +
 		// either some stuff in brackets - [ipv6]
 		// or some stuff without brackets and colons
 		`(?P<host>` +
 		// this says: [stuff in brackets that is not brackets] - loose definition of the IP address
-		`(?:\[[^\[\]]+\])` +
+		`(?:\[[^@\[\]]+\])` +
 		// or
 		`|` +
 		// some stuff without brackets or colons to make sure the OR condition
 		// is not ambiguous
-		`(?:[^\[\:\]]+)` +
+		`(?:[^@\[\:\]]+)` +
 		`)` +
 		// after colon, there is a path that could consist technically of
 		// any char

--- a/lib/sshutils/scp/scp_test.go
+++ b/lib/sshutils/scp/scp_test.go
@@ -349,6 +349,10 @@ func (s *SCPSuite) TestSCPParsing(c *C) {
 			in:   "myusername@myremotehost.com:/home/hope/*",
 			dest: Destination{Login: "myusername", Host: utils.NetAddr{Addr: "myremotehost.com", AddrNetwork: "tcp"}, Path: "/home/hope/*"},
 		},
+		{
+			in:   "complex@example.com@remote.com:/anything.txt",
+			dest: Destination{Login: "complex@example.com", Host: utils.NetAddr{Addr: "remote.com", AddrNetwork: "tcp"}, Path: "/anything.txt"},
+		},
 	}
 	for i, tc := range testCases {
 		comment := Commentf("Test case %v: %q", i, tc.in)

--- a/lib/utils/proxyjump.go
+++ b/lib/utils/proxyjump.go
@@ -25,7 +25,7 @@ import (
 
 var reProxyJump = regexp.MustCompile(
 	// optional username, note that outside group
-	`(?:(?P<username>[^@\:]+)@)?(?P<hostport>[^\@]+)`,
+	`(?:(?P<username>[^\:]+)@)?(?P<hostport>[^\@]+)`,
 )
 
 // JumpHost is a target jump host

--- a/lib/utils/proxyjump_test.go
+++ b/lib/utils/proxyjump_test.go
@@ -51,6 +51,10 @@ func (s *UtilsSuite) TestProxyJumpParsing(c *check.C) {
 			in:  "alice@[::1]:7777, bob@localhost",
 			out: []JumpHost{{Username: "alice", Addr: NetAddr{Addr: "[::1]:7777", AddrNetwork: "tcp"}}, {Username: "bob", Addr: NetAddr{Addr: "localhost", AddrNetwork: "tcp"}}},
 		},
+		{
+			in:  "alice@domain.com@[::1]:7777, bob@localhost@localhost",
+			out: []JumpHost{{Username: "alice@domain.com", Addr: NetAddr{Addr: "[::1]:7777", AddrNetwork: "tcp"}}, {Username: "bob@localhost", Addr: NetAddr{Addr: "localhost", AddrNetwork: "tcp"}}},
+		},
 	}
 	for i, tc := range testCases {
 		comment := check.Commentf("Test case %v: %q", i, tc.in)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -934,9 +934,10 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, erro
 	var labels map[string]string
 	if cf.UserHost != "" {
 		parts := strings.Split(cf.UserHost, "@")
-		if len(parts) > 1 {
-			hostLogin = parts[0]
-			cf.UserHost = parts[1]
+		partsLength := len(parts)
+		if partsLength > 1 {
+			hostLogin = strings.Join(parts[:partsLength-1], "@")
+			cf.UserHost = parts[partsLength-1]
 		}
 		// see if remote host is specified as a set of labels
 		if strings.Contains(cf.UserHost, "=") {

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -102,6 +102,31 @@ func (s *MainTestSuite) TestMakeClient(c *check.C) {
 		},
 	})
 
+	// specific configuration with email like user
+	conf.MinsToLive = 5
+	conf.UserHost = "root@example.com@localhost"
+	conf.NodePort = 46528
+	conf.LocalForwardPorts = []string{"80:remote:180"}
+	conf.DynamicForwardedPorts = []string{":8080"}
+	tc, err = makeClient(&conf, true)
+	c.Assert(err, check.IsNil)
+	c.Assert(tc.Config.KeyTTL, check.Equals, time.Minute*time.Duration(conf.MinsToLive))
+	c.Assert(tc.Config.HostLogin, check.Equals, "root@example.com")
+	c.Assert(tc.Config.LocalForwardPorts, check.DeepEquals, client.ForwardedPorts{
+		{
+			SrcIP:    "127.0.0.1",
+			SrcPort:  80,
+			DestHost: "remote",
+			DestPort: 180,
+		},
+	})
+	c.Assert(tc.Config.DynamicForwardedPorts, check.DeepEquals, client.DynamicForwardedPorts{
+		{
+			SrcIP:   "127.0.0.1",
+			SrcPort: 8080,
+		},
+	})
+
 	randomLocalAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 	const staticToken = "test-static-token"
 


### PR DESCRIPTION
Our usernames are email-like expressions. Therefore we use them in tsh scp or tsh ssh. 
This works out for `root@127.0.0.1:target.txt`
This does not work `root@domain@127.0.0.1:target.txt` as it states that `domain@127.0.0.1` is not a valid host expression. That is correct. The code comments also state that the @ symbol has to be filtered out but some of the current code do the exact opposite as they capture the data up to the first @ which results in having an @ symbol in the host expression. This fixes it by allowing @ in the username.