### PR TITLE
Change to Ubuntu 20.04 base and improve apt cleanup

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -56,6 +56,15 @@ build-binaries: buildbox
 		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' all
 
 #
+# Build 'teleport' FIPS release inside a docker container
+# This builds Enterprise binaries only.
+#
+.PHONY:build-binaries-fips
+build-binaries-fips: buildbox-fips
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOXFIPS) \
+		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' all
+
+#
 # Builds a Docker container which is used for building official Teleport
 # binaries and docs
 #

--- a/build.assets/charts/Dockerfile
+++ b/build.assets/charts/Dockerfile
@@ -1,23 +1,23 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-# Install dumb-init and ca-certificate. The dumb-init package is to ensure
+# Install dumb-init and ca-certificates. The dumb-init package is to ensure
 # signals and orphaned processes are are handled correctly. The ca-certificate
 # package is installed because the base Ubuntu image does not come with any
 # certificate authorities.
 #
 # Note that /var/lib/apt/lists/* is cleaned up in the same RUN command as
 # "apt-get update" to reduce the size of the image.
-RUN apt-get update && apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y \
-    dumb-init \
-    ca-certificates \
-    && update-ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ca-certificates dumb-init && \
+    update-ca-certificates && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Bundle "teleport", "tctl", and "tsh" binaries into image.
-ADD teleport /usr/local/bin/teleport
-ADD tctl /usr/local/bin/tctl
-ADD tsh /usr/local/bin/tsh
+COPY teleport /usr/local/bin/teleport
+COPY tctl /usr/local/bin/tctl
+COPY tsh /usr/local/bin/tsh
 
 # By setting this entry point, we expose make target as command.
 ENTRYPOINT ["/usr/bin/dumb-init", "teleport", "start", "-c", "/etc/teleport/teleport.yaml"]

--- a/build.assets/charts/Dockerfile-fips
+++ b/build.assets/charts/Dockerfile-fips
@@ -1,23 +1,23 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-# Install dumb-init and ca-certificate. The dumb-init package is to ensure
+# Install dumb-init and ca-certificates. The dumb-init package is to ensure
 # signals and orphaned processes are are handled correctly. The ca-certificate
 # package is installed because the base Ubuntu image does not come with any
 # certificate authorities.
 #
 # Note that /var/lib/apt/lists/* is cleaned up in the same RUN command as
 # "apt-get update" to reduce the size of the image.
-RUN apt-get update && apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y \
-    dumb-init \
-    ca-certificates \
-    && update-ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y ca-certificates dumb-init && \
+    update-ca-certificates && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Bundle "teleport", "tctl", and "tsh" binaries into image.
-ADD teleport /usr/local/bin/teleport
-ADD tctl /usr/local/bin/tctl
-ADD tsh /usr/local/bin/tsh
+COPY teleport /usr/local/bin/teleport
+COPY tctl /usr/local/bin/tctl
+COPY tsh /usr/local/bin/tsh
 
 # By setting this entry point, we expose make target as command.
 ENTRYPOINT ["/usr/bin/dumb-init", "teleport", "start", "-c", "/etc/teleport/teleport.yaml", "--fips"]


### PR DESCRIPTION
Depends on https://github.com/gravitational/teleport.e/pull/141 - will update the e ref here after that PR is merged.

This PR changes the base of our Teleport Docker images to Ubuntu 20.04 (the latest LTS release) to reduce the number of vulnerabilities present in the image.

It also improves our cleanup logic after running `apt-get -y upgrade` to run `apt-get clean` and remove the APT cache. This will result in a smaller final image.