### PR TITLE
Added entity_descriptor_url to SAML example.

### DIFF
--- a/docs/4.3/enterprise/sso/ssh_sso.md
+++ b/docs/4.3/enterprise/sso/ssh_sso.md
@@ -95,7 +95,7 @@ spec:
      # regular expressions with capture are also supported. the next line instructs Teleport
      # to assign users to roles `admin-1` if his SAML "group" attribute equals 'ssh_admin_1':
      - { name: "group", value: "^ssh_admin_(.*)$", roles: ["admin-$1"] }
-  
+
   entity_descriptor: |
     <paste SAML XML contents here>
 ```

--- a/docs/4.3/enterprise/sso/ssh_sso.md
+++ b/docs/4.3/enterprise/sso/ssh_sso.md
@@ -96,14 +96,14 @@ spec:
      # to assign users to roles `admin-1` if his SAML "group" attribute equals 'ssh_admin_1':
      - { name: "group", value: "^ssh_admin_(.*)$", roles: ["admin-$1"] }
   
-  # entity_descriptor XML can either be fetched from a URL or included below
-  # entity_descriptor_url: "https://example.com"
   entity_descriptor: |
     <paste SAML XML contents here>
 ```
 
 * See [examples/resources](https://github.com/gravitational/teleport/tree/master/examples/resources)
   directory in the Teleport Github repository for examples of possible connectors.
+* You may use `entity_descriptor_url`, in lieu of `entity_descriptor`, to fetch the entity descriptor from
+your IDP. Though, we recommend "pinning" the entity descriptor by including the XML rather than fetching from a URL.
 
 ### User Logins
 

--- a/docs/4.3/enterprise/sso/ssh_sso.md
+++ b/docs/4.3/enterprise/sso/ssh_sso.md
@@ -95,7 +95,9 @@ spec:
      # regular expressions with capture are also supported. the next line instructs Teleport
      # to assign users to roles `admin-1` if his SAML "group" attribute equals 'ssh_admin_1':
      - { name: "group", value: "^ssh_admin_(.*)$", roles: ["admin-$1"] }
-
+  
+  # entity_descriptor XML can either be fetched from a URL or included below
+  # entity_descriptor_url: "https://example.com"
   entity_descriptor: |
     <paste SAML XML contents here>
 ```


### PR DESCRIPTION
Minor addition to SAML example, `entity_descriptor_url`. [Looks like](https://github.com/gravitational/teleport/blob/master/lib/services/saml.go#L540) we attempt to fetch this first, then parse the `entity_descriptor` value. 

![image](https://user-images.githubusercontent.com/241714/87087525-df434780-c1f8-11ea-9f25-0a73d026fb2e.png)
