### PR TITLE
Backport #3982 to branch/4.3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1028,6 +1028,6 @@ steps:
 
 ---
 kind: signature
-hmac: f5e1815ffbc9cac09bad62e7db6420b65281e4e0a8b2d4187cc0b7e565c95c90
+hmac: 0e70d638dcfea64019ed991453a1ccccf5825a268d795d6da1d5b83ab8309aa3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ clone:
 
 steps:
   - name: Check out code
-    image: golang:1.13.2
+    image: docker:git
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
@@ -44,67 +44,64 @@ steps:
       - rm -f /root/.ssh/id_rsa
       - mkdir -p /go/cache
 
-  - name: Run linter
-    image: docker:dind
+  - name: Build buildbox
+    image: docker
     environment:
-      GOPATH: /gopath
+      QUAYIO_DOCKER_USERNAME:
+        from_secret: QUAYIO_DOCKER_USERNAME
+      QUAYIO_DOCKER_PASSWORD:
+        from_secret: QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - >-
-        docker run --rm=true
-        -e GOCACHE=$GOPATH/cache
-        -v /go/cache:$GOPATH/cache
-        -v /go/src/github.com/gravitational/teleport:$GOPATH/src/github.com/gravitational/teleport
-        -w $GOPATH/src/github.com/gravitational/teleport
-        -h testbox
-        -u $UID:$GID
-        -t quay.io/gravitational/teleport-buildbox:$RUNTIME
-        /bin/bash -c "make lint"
+      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" quay.io
+      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets buildbox
+
+  - name: Run linter
+    image: docker
+    environment:
+      GOPATH: /go
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make
+      - chown -R $UID:$GID /go
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets lint
 
   - name: Run unit tests
-    image: docker:dind
+    image: docker
     environment:
-      GOPATH: /gopath
+      GOPATH: /go
     volumes:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - >-
-        docker run --rm=true
-        -e GOCACHE=$GOPATH/cache
-        -v /go/cache:$GOPATH/cache
-        -v /go/src/github.com/gravitational/teleport:$GOPATH/src/github.com/gravitational/teleport
-        -w $GOPATH/src/github.com/gravitational/teleport
-        -h testbox
-        -u $UID:$GID
-        -t quay.io/gravitational/teleport-buildbox:$RUNTIME
-        /bin/bash -c "make FLAGS='-cover -count 1' test"
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets test
 
   - name: Run integration tests
-    image: docker:dind
+    image: docker
     environment:
-      GOPATH: /gopath
+      GOPATH: /go
     volumes:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - >-
-        docker run --rm=true
-        -e GOCACHE=$GOPATH/cache
-        -v /go/cache:$GOPATH/cache
-        -v /go/src/github.com/gravitational/teleport:$GOPATH/src/github.com/gravitational/teleport
-        -w $GOPATH/src/github.com/gravitational/teleport
-        -h testbox
-        -u $UID:$GID
-        -t quay.io/gravitational/teleport-buildbox:$RUNTIME
-        /bin/bash -c "make FLAGS='-cover -count 1' integration"
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets integration
 
-  - name: Send Slack notification
+  - name: Send Slack notification for build failures
     image: plugins/slack
     settings:
       webhook:
@@ -170,7 +167,7 @@ steps:
     commands:
       - |
         cd /go/src/github.com/gravitational/teleport
-        git diff --raw ${DRONE_TARGET_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
+        git diff --raw ${DRONE_COMMIT}..${DRONE_TARGET_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           for VERSION in $(cat /tmp/docs-versions-changed.txt); do
@@ -735,7 +732,6 @@ type: kubernetes
 name: build-buildboxes
 
 environment:
-  REPO: quay.io
   RUNTIME: go1.13.2
   UID: 1000
   GID: 1000
@@ -773,18 +769,11 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" $REPO
+      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" quay.io
       - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - >-
-        docker build
-        --build-arg UID=$UID
-        --build-arg GID=$GID
-        --build-arg RUNTIME=$RUNTIME
-        --cache-from quay.io/gravitational/teleport-buildbox:$RUNTIME
-        -f /go/src/github.com/gravitational/teleport/build.assets/Dockerfile
-        -t quay.io/gravitational/teleport-buildbox:$RUNTIME
-        /go/src/github.com/gravitational/teleport/build.assets
+      - make -C build.assets buildbox
       - docker push quay.io/gravitational/teleport-buildbox:$RUNTIME
 
   - name: Build and push buildbox-fips container
@@ -798,18 +787,11 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" $REPO
+      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" quay.io
       - docker pull quay.io/gravitational/teleport-buildbox-fips:$RUNTIME || true
-      - >-
-        docker build
-        --build-arg UID=$UID
-        --build-arg GID=$GID
-        --build-arg RUNTIME=$RUNTIME
-        --cache-from quay.io/gravitational/teleport-buildbox-fips:$RUNTIME
-        -f /go/src/github.com/gravitational/teleport/build.assets/Dockerfile-fips
-        -t quay.io/gravitational/teleport-buildbox-fips:$RUNTIME
-        /go/src/github.com/gravitational/teleport/build.assets
+      - make -C build.assets buildbox-fips
       - docker push quay.io/gravitational/teleport-buildbox-fips:$RUNTIME
 
   - name: Build and push buildbox-centos6 container
@@ -823,18 +805,11 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" $REPO
+      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" quay.io
       - docker pull quay.io/gravitational/teleport-buildbox-centos6:$RUNTIME || true
-      - >-
-        docker build
-        --build-arg UID=$UID
-        --build-arg GID=$GID
-        --build-arg RUNTIME=$RUNTIME
-        --cache-from quay.io/gravitational/teleport-buildbox-centos6:$RUNTIME
-        -f /go/src/github.com/gravitational/teleport/build.assets/Dockerfile-centos6
-        -t quay.io/gravitational/teleport-buildbox-centos6:$RUNTIME
-        /go/src/github.com/gravitational/teleport/build.assets
+      - make -C build.assets buildbox-centos6
       - docker push quay.io/gravitational/teleport-buildbox-centos6:$RUNTIME
 
   - name: Build and push buildbox-centos6-fips container
@@ -848,18 +823,11 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" $REPO
+      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" quay.io
       - docker pull quay.io/gravitational/teleport-buildbox-centos6-fips:$RUNTIME || true
-      - >-
-        docker build
-        --build-arg UID=$UID
-        --build-arg GID=$GID
-        --build-arg RUNTIME=$RUNTIME
-        --cache-from quay.io/gravitational/teleport-buildbox-centos6-fips:$RUNTIME
-        -f /go/src/github.com/gravitational/teleport/build.assets/Dockerfile-centos6-fips
-        -t quay.io/gravitational/teleport-buildbox-centos6-fips:$RUNTIME
-        /go/src/github.com/gravitational/teleport/build.assets
+      - make -C build.assets buildbox-centos6-fips
       - docker push quay.io/gravitational/teleport-buildbox-centos6-fips:$RUNTIME
 
 services:
@@ -878,9 +846,6 @@ volumes:
 kind: pipeline
 type: kubernetes
 name: docker-cron
-
-environment:
-  REPO: quay.io
 
 trigger:
   cron:
@@ -921,7 +886,6 @@ steps:
     environment:
       OS: linux
       ARCH: amd64
-      REPO: quay.io
     settings:
       username:
         from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
@@ -932,10 +896,10 @@ steps:
         path: /var/run
     commands:
       - export VERSION_TAG=$(cat /tmp/build/CURRENT_VERSION_TAG.txt)
-      - export OSS_IMAGE_NAME="$REPO/gravitational/teleport:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="$REPO/gravitational/teleport-ent:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="$REPO/gravitational/teleport-ent:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" $REPO
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
       - docker push $OSS_IMAGE_NAME
@@ -951,7 +915,6 @@ steps:
     environment:
       OS: linux
       ARCH: amd64
-      REPO: quay.io
     settings:
       username:
         from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
@@ -962,10 +925,10 @@ steps:
         path: /var/run
     commands:
       - export VERSION_TAG=$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG.txt)
-      - export OSS_IMAGE_NAME="$REPO/gravitational/teleport:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="$REPO/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="$REPO/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" $REPO
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
       - docker push $OSS_IMAGE_NAME
@@ -981,7 +944,6 @@ steps:
     environment:
       OS: linux
       ARCH: amd64
-      REPO: quay.io
     settings:
       username:
         from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
@@ -992,10 +954,10 @@ steps:
         path: /var/run
     commands:
       - export VERSION_TAG=$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG.txt)
-      - export OSS_IMAGE_NAME="$REPO/gravitational/teleport:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="$REPO/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="$REPO/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" $REPO
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
       - docker push $OSS_IMAGE_NAME
@@ -1066,6 +1028,6 @@ steps:
 
 ---
 kind: signature
-hmac: 1f1284ed43d98cc0551ca761dc0b119739c16b016fce58cac60d264597c8348e
+hmac: f5e1815ffbc9cac09bad62e7db6420b65281e4e0a8b2d4187cc0b7e565c95c90
 
 ...

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,12 @@
 * @klizhentas @russjones
 
 # Release Engineering.
-/assets/ @webvictim @russjones
-/build.assets/ @webvictim @russjones
-/docker/ @webvictim @russjones
-/examples/ @webvictim @russjones
-/vagrant/ @webvictim @russjones
+/assets/ @webvictim @russjones @awly
+/build.assets/ @webvictim @russjones @awly
+/docker/ @webvictim @russjones @awly
+/examples/ @webvictim @russjones @awly
+/vagrant/ @webvictim @russjones @awly
+.drone.yml @webvictim @russjones @awly
 
 # Product.
 *.md @benarent @webvictim
@@ -23,5 +24,5 @@
 /vendor/ @klizhentas @russjones @fspmarshall @webvictim @awly
 
 # Frontend Engineering.
-/lib/web/ @alex-kovoy @russjones @fspmarshall @webvictim @awly
-/web/ @alex-kovoy
+/lib/web/ @alex-kovoy @russjones @fspmarshall @webvictim @awly @kimlisa
+/web/ @alex-kovoy @kimlisa

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,21 +1,26 @@
 # This Dockerfile makes the "build box": the container used to build official
 # releases of Teleport and its documentation.
-FROM quay.io/gravitational/buildbox-base:1.0
+FROM ubuntu:20.04
+
+COPY locale.gen /etc/locale.gen
+COPY profile /etc/profile
+
+ENV LANGUAGE="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8" \
+    LC_CTYPE="en_US.UTF-8" \
+    DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update -y --fix-missing && \
+    apt-get -q -y upgrade && \
+    apt-get install -q -y apt-utils curl gcc git gzip libbpfcc-dev libc6-dev libpam-dev libsqlite3-0 locales make net-tools tar tree zip && \
+    dpkg-reconfigure locales && \
+    apt-get -y autoclean && apt-get -y clean
 
 ARG UID
 ARG GID
-
-COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
-COPY pam/teleport-acct-echo /etc/pam.d
-COPY pam/teleport-acct-failure /etc/pam.d
-COPY pam/teleport-success /etc/pam.d
-COPY pam/teleport-session-failure /etc/pam.d
-COPY pam/teleport-session-environment /etc/pam.d
-
-RUN apt-get update; apt-get install -q -y libpam-dev libc6-dev-i386 net-tools tree
-
-RUN (groupadd jenkins --gid=$GID -o && useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
-     mkdir -p -m0700 /var/lib/teleport && chown -R jenkins /var/lib/teleport)
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
+     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
@@ -24,19 +29,22 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
 # Install Go.
 ARG RUNTIME
 RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz;\
-    mkdir -p /gopath/src/github.com/gravitational/teleport;\
-    chmod a+w /gopath;\
+    mkdir -p /go/src/github.com/gravitational/teleport;\
+    chmod a+w /go;\
     chmod a+w /var/lib;\
     chmod a-w /
 
-ENV GOPATH="/gopath" \
+ENV GOPATH="/go" \
     GOROOT="/opt/go" \
-    PATH="$PATH:/opt/go/bin:/gopath/bin:/gopath/src/github.com/gravitational/teleport/build"
+    PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
 # Install meta-linter.
 RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.24.0/golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz ;\
      cp golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ ;\
      rm -r golangci-lint*)
 
-VOLUME ["/gopath/src/github.com/gravitational/teleport"]
+COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
+COPY pam/teleport-* /etc/pam.d/
+
+VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-centos6
+++ b/build.assets/Dockerfile-centos6
@@ -2,24 +2,19 @@
 # releases of Teleport and its documentation.
 FROM centos:6
 
+ENV LANGUAGE=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LC_CTYPE=en_US.UTF-8
+
+RUN yum makecache fast && \
+    yum -y install gcc pam-devel glibc-devel net-tools tree git zip && \
+    yum clean all
+
 ARG UID
 ARG GID
-ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
-
-ENV LANGUAGE=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
-ENV LC_CTYPE=en_US.UTF-8
-
-COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
-COPY pam/teleport-acct-failure /etc/pam.d
-COPY pam/teleport-session-failure /etc/pam.d
-COPY pam/teleport-success /etc/pam.d
-
-RUN yum makecache fast && yum -y install gcc pam-devel glibc-devel net-tools tree git zip && yum clean all
-
-RUN (groupadd jenkins --gid=$GID -o && useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
-     mkdir -p -m0700 /var/lib/teleport && chown -R jenkins /var/lib/teleport)
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
+     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
@@ -30,19 +25,23 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
 # 3) Erase Go bootstrap runtime and create build directories
 # 4) Print compiled Go version
 ARG RUNTIME
+ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
 RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
     mkdir -p /opt && cd /opt && curl https://dl.google.com/go/${RUNTIME}.src.tar.gz | tar xz && \
     cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
     rm -rf /go-bootstrap && \
-    mkdir -p /gopath/src/github.com/gravitational/teleport && \
-    chmod a+w /gopath && \
+    mkdir -p /go/src/github.com/gravitational/teleport && \
+    chmod a+w /go && \
     chmod a+w /var/lib && \
     chmod a-w / && \
     /opt/go/bin/go version
 
-ENV GOPATH="/gopath" \
+ENV GOPATH="/go" \
     GOROOT="/opt/go" \
-    PATH="$PATH:/opt/go/bin:/gopath/bin:/gopath/src/github.com/gravitational/teleport/build"
+    PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
-VOLUME ["/gopath/src/github.com/gravitational/teleport"]
+COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
+COPY pam/teleport-* /etc/pam.d/
+
+VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-centos6-fips
+++ b/build.assets/Dockerfile-centos6-fips
@@ -2,24 +2,19 @@
 # releases of Teleport and its documentation.
 FROM centos:6
 
+ENV LANGUAGE=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LC_CTYPE=en_US.UTF-8
+
+RUN yum makecache fast && \
+    yum -y install gcc pam-devel glibc-devel net-tools tree git zip && \
+    yum clean all
+
 ARG UID
 ARG GID
-ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
-
-ENV LANGUAGE=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
-ENV LC_CTYPE=en_US.UTF-8
-
-COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
-COPY pam/teleport-acct-failure /etc/pam.d
-COPY pam/teleport-session-failure /etc/pam.d
-COPY pam/teleport-success /etc/pam.d
-
-RUN yum makecache fast && yum -y install gcc pam-devel glibc-devel net-tools tree git zip && yum clean all
-
-RUN (groupadd jenkins --gid=$GID -o && useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
-     mkdir -p -m0700 /var/lib/teleport && chown -R jenkins /var/lib/teleport)
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
+     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
@@ -30,19 +25,23 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
 # 3) Erase Go bootstrap runtime and create build directories
 # 4) Print compiled Go version
 ARG RUNTIME
+ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
 RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
     mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${RUNTIME}b4.src.tar.gz | tar xz && \
     cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
     rm -rf /go-bootstrap && \
-    mkdir -p /gopath/src/github.com/gravitational/teleport && \
-    chmod a+w /gopath && \
+    mkdir -p /go/src/github.com/gravitational/teleport && \
+    chmod a+w /go && \
     chmod a+w /var/lib && \
     chmod a-w / && \
     /opt/go/bin/go version
 
-ENV GOPATH="/gopath" \
+ENV GOPATH="/go" \
     GOROOT="/opt/go" \
-    PATH="$PATH:/opt/go/bin:/gopath/bin:/gopath/src/github.com/gravitational/teleport/build"
+    PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
-VOLUME ["/gopath/src/github.com/gravitational/teleport"]
+COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
+COPY pam/teleport-* /etc/pam.d/
+
+VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -1,19 +1,26 @@
 # This Dockerfile makes the FIPS "build box": the container used to build official
 # FIPS releases of Teleport and its documentation.
-FROM quay.io/gravitational/buildbox-base:1.0
+FROM ubuntu:20.04
+
+COPY locale.gen /etc/locale.gen
+COPY profile /etc/profile
+
+ENV LANGUAGE="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8" \
+    LC_CTYPE="en_US.UTF-8" \
+    DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update -y --fix-missing && \
+    apt-get -q -y upgrade && \
+    apt-get install -q -y apt-utils curl gcc git gzip libbpfcc-dev libc6-dev libpam-dev libsqlite3-0 locales make net-tools tar tree zip && \
+    dpkg-reconfigure locales && \
+    apt-get -y autoclean && apt-get -y clean
 
 ARG UID
 ARG GID
-
-COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
-COPY pam/teleport-acct-failure /etc/pam.d
-COPY pam/teleport-session-failure /etc/pam.d
-COPY pam/teleport-success /etc/pam.d
-
-RUN apt-get update; apt-get install -q -y libpam-dev libc6-dev-i386 net-tools tree
-
-RUN (groupadd jenkins --gid=$GID -o && useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
-     mkdir -p -m0700 /var/lib/teleport && chown -R jenkins /var/lib/teleport)
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
+     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
@@ -22,14 +29,17 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
 # Install Go.
 ARG RUNTIME
 RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${RUNTIME}b4.linux-amd64.tar.gz | tar xz;\
-    mkdir -p /gopath/src/github.com/gravitational/teleport;\
-    chmod a+w /gopath;\
+    mkdir -p /go/src/github.com/gravitational/teleport;\
+    chmod a+w /go;\
     chmod a+w /var/lib;\
     chmod a-w /
 
-ENV GOPATH="/gopath" \
+ENV GOPATH="/go" \
     GOROOT="/opt/go" \
-    PATH="$PATH:/opt/go/bin:/gopath/bin:/gopath/src/github.com/gravitational/teleport/build"
+    PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
-VOLUME ["/gopath/src/github.com/gravitational/teleport"]
+COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
+COPY pam/teleport-* /etc/pam.d/
+
+VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -6,7 +6,7 @@ DOCSHOST=teleport-docs
 DOCSDIR=/teleport
 
 HOSTNAME=buildbox
-SRCDIR=/gopath/src/github.com/gravitational/teleport
+SRCDIR=/go/src/github.com/gravitational/teleport
 DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME)
 BCCFLAGS := -v "$$(pwd)/bcc:/usr/include/bcc"
 ADDFLAGS=-ldflags -w
@@ -18,13 +18,23 @@ OS ?= linux
 ARCH ?= amd64
 RUNTIME ?= go1.13.2
 
-BBOX=teleport-buildbox:$(RUNTIME)
-BBOXFIPS=teleport-buildbox-fips:$(RUNTIME)
-BBOXCENTOS6=teleport-buildbox-centos6:$(RUNTIME)
-BBOXCENTOS6FIPS=teleport-buildbox-centos6-fips:$(RUNTIME)
+UID ?= $$(id -u)
+GID ?= $$(id -g)
+
+BUILDBOX=quay.io/gravitational/teleport-buildbox:$(RUNTIME)
+BUILDBOXFIPS=quay.io/gravitational/teleport-buildbox-fips:$(RUNTIME)
+BUILDBOXCENTOS6=quay.io/gravitational/teleport-buildbox-centos6:$(RUNTIME)
+BUILDBOXCENTOS6FIPS=quay.io/gravitational/teleport-buildbox-centos6-fips:$(RUNTIME)
 
 ifneq ("$(KUBECONFIG)","")
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(KUBECONFIG):/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=$(TEST_KUBE)
+endif
+
+# conditionally force the use of UID/GID 1000:1000 if we're running in Drone
+ifeq ("$(DRONE)","true")
+UID := 1000
+GID := 1000
+NOROOT := -u 1000:1000
 endif
 export
 
@@ -33,62 +43,66 @@ export
 # Build 'teleport' release inside a docker container
 #
 .PHONY:build
-build: bbox
-	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BBOX) \
+build: buildbox
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOX) \
 		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' release
 
 #
 # Build 'teleport' release inside a docker container
 #
 .PHONY:build-binaries
-build-binaries: bbox
-	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BBOX) \
+build-binaries: buildbox
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOX) \
 		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' all
 
 #
 # Builds a Docker container which is used for building official Teleport
 # binaries and docs
 #
-.PHONY:bbox
-bbox:
+.PHONY:buildbox
+buildbox:
 	docker build \
-		--build-arg UID=$$(id -u) \
-		--build-arg GID=$$(id -g) \
+		--build-arg UID=$(UID) \
+		--build-arg GID=$(GID) \
 		--build-arg RUNTIME=$(RUNTIME) \
-		--tag $(BBOX) .
+		--cache-from $(BUILDBOX) \
+		--tag $(BUILDBOX) .
 
 #
 # Builds a Docker buildbox for FIPS
 #
-.PHONY:bbox-fips
-bbox-fips:
+.PHONY:buildbox-fips
+buildbox-fips:
 	docker build \
-		--build-arg UID=$$(id -u) \
-		--build-arg GID=$$(id -g) \
+		--build-arg UID=$(UID) \
+		--build-arg GID=$(GID) \
 		--build-arg RUNTIME=$(RUNTIME) \
-		--tag $(BBOXFIPS) -f Dockerfile-fips .
+		--cache-from $(BUILDBOXFIPS) \
+		--tag $(BUILDBOXFIPS) -f Dockerfile-fips .
 
 #
 # Builds a Docker container for CentOS 6 builds
 #
-.PHONY:bbox-centos6
-bbox-centos6:
+.PHONY:buildbox-centos6
+buildbox-centos6:
 	docker build \
-		--build-arg UID=$$(id -u) \
-		--build-arg GID=$$(id -g) \
+		--build-arg UID=$(UID) \
+		--build-arg GID=$(GID) \
 		--build-arg RUNTIME=$(RUNTIME) \
-		--tag $(BBOXCENTOS6) -f Dockerfile-centos6 .
+		--cache-from $(BUILDBOXCENTOS6) \
+		--tag $(BUILDBOXCENTOS6) -f Dockerfile-centos6 .
 
 #
 # Builds a Docker buildbox for CentOS 6 FIPS builds
 #
-.PHONY:bbox-centos6-fips
-bbox-centos6-fips:
+.PHONY:buildbox-centos6-fips
+buildbox-centos6-fips:
 	docker build \
-		--build-arg UID=$$(id -u) \
-		--build-arg GID=$$(id -g) \
+		--build-arg UID=$(UID) \
+		--build-arg GID=$(GID) \
 		--build-arg RUNTIME=$(RUNTIME) \
-		--tag $(BBOXCENTOS6FIPS) -f Dockerfile-centos6-fips .
+		--cache-from $(BUILDBOXCENTOS6FIPS) \
+		--tag $(BUILDBOXCENTOS6FIPS) -f Dockerfile-centos6-fips .
 
 #
 # Builds a Docker container for building mkdocs documentation
@@ -106,31 +120,31 @@ docsbox:
 #
 .PHONY:clean
 clean:
-	docker image rm --force $(BBOX)
+	docker image rm --force $(BUILDBOX)
 	docker image rm --force $(DOCSBOX)
 
 #
 # Runs tests inside a build container
 #
 .PHONY:test
-test: bbox
-	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
+test: buildbox
+	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c \
 		"examples/etcd/start-etcd.sh & sleep 1; \
 		ssh-agent > external.agent.tmp && source external.agent.tmp; \
 		cd $(SRCDIR) && make TELEPORT_DEBUG=0 FLAGS='-cover -race' clean test"
 
 .PHONY:integration
-integration: bbox
-	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
+integration: buildbox
+	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c "make -C $(SRCDIR) FLAGS='-cover' integration"
 
 #
 # Runs linters on new changes inside a build container.
 #
 .PHONY:lint
-lint: bbox
-	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BBOX) \
+lint: buildbox
+	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c "make -C $(SRCDIR) lint"
 
 #
@@ -174,16 +188,16 @@ run-docs: docsbox
 # Starts shell inside the build container
 #
 .PHONY:enter
-enter: bbox
+enter: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) -ti $(NOROOT) \
-		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BBOX) /bin/bash
+		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX) /bin/bash
 
 #
 # Create a Teleport package using the build container.
 #
 .PHONY:release
-release: bbox
-	docker run $(DOCKERFLAGS) $(BCCFLAGS) -i $(NOROOT) $(BBOX) \
+release: buildbox
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) -i $(NOROOT) $(BUILDBOX) \
 		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME)
 
 #
@@ -191,17 +205,17 @@ release: bbox
 # This is a special case because it only builds and packages the Enterprise FIPS binaries, no OSS.
 #
 .PHONY:release-fips
-release-fips: bbox-fips
+release-fips: buildbox-fips
 	@if [ -z ${VERSION} ]; then echo "VERSION is not set"; exit 1; fi
-	docker run $(DOCKERFLAGS) $(BCCFLAGS) -i $(NOROOT) $(BBOXFIPS) \
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) -i $(NOROOT) $(BUILDBOXFIPS) \
 		/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION)
 
 #
 # Create a Teleport package for CentOS 6 using the build container.
 #
 .PHONY:release-centos6
-release-centos6: bbox-centos6
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOXCENTOS6) \
+release-centos6: buildbox-centos6
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOXCENTOS6) \
 		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME)
 
 #
@@ -209,14 +223,14 @@ release-centos6: bbox-centos6
 # This is a special case because it only builds and packages the Enterprise FIPS binaries, no OSS.
 #
 .PHONY:release-centos6-fips
-release-centos6-fips: bbox-centos6-fips
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOXCENTOS6FIPS) \
+release-centos6-fips: buildbox-centos6-fips
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOXCENTOS6FIPS) \
 		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) FIPS=yes
 
 #
 # Create a Windows Teleport package using the build container.
 #
 .PHONY:release-windows
-release-windows: bbox
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BBOX) \
+release-windows: buildbox
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX) \
 		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=windows


### PR DESCRIPTION
Tests on Drone for `branch/4.3` are currently failing due to breaking changes to the Teleport buildbox image (the use of `/go` rather than `/gopath`)

This backports #3982 to `branch/4.3`.