### PR TITLE
Sign .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1078,6 +1078,6 @@ steps:
 
 ---
 kind: signature
-hmac: f5e1815ffbc9cac09bad62e7db6420b65281e4e0a8b2d4187cc0b7e565c95c90
+hmac: e08b6e08d2efb785f03d59ae2c2d0fc9e627f9f5949baa89037958e4afab39bf
 
 ...


### PR DESCRIPTION
Accidentally let `.drone.yml` changes through without updating the signature.