### PR TITLE
YubiKey Example

### DIFF
--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -481,7 +481,8 @@ connector. There are three possible values (types) of 2FA:
      or [Authy](https://www.authy.com/) or any other TOTP client.
 
   + `u2f` implements [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor)
-    standard for utilizing hardware (USB) keys for second factor.
+    standard for utilizing hardware (USB) keys for second factor. You can use [YubiKeys](https://www.yubico.com/),
+   [solokeys](https://solokeys.com/) or any other hardware token.
 
   + `off` turns off second factor authentication.
 
@@ -537,7 +538,7 @@ auth_service:
     type: oidc
 ```
 
-### FIDO U2F
+### Hardware Keys - YubiKey FIDO U2F
 
 Teleport supports [FIDO U2F](https://www.yubico.com/about/background/fido/)
 hardware keys as a second authentication factor. By default U2F is disabled. To

--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -482,7 +482,7 @@ connector. There are three possible values (types) of 2FA:
 
   + `u2f` implements [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor)
     standard for utilizing hardware (USB) keys for second factor. You can use [YubiKeys](https://www.yubico.com/),
-   [solokeys](https://solokeys.com/) or any other hardware token.
+   [SoloKeys](https://solokeys.com/) or any other hardware token which implements the FIDO U2F standard.
 
   + `off` turns off second factor authentication.
 

--- a/docs/4.3/architecture/teleport_users.md
+++ b/docs/4.3/architecture/teleport_users.md
@@ -72,10 +72,10 @@ connector and it is enforced by default.
 
  There are two types of 2FA supported:
 
-* [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
-* [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor)
+* [TOTP - e.g. Google Authenticator](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
+* [U2F - e.g. YubiKey](https://en.wikipedia.org/wiki/Universal_2nd_Factor)
 
-  TOTP is the default. You can use [Google
+  `TOTP` is the default. You can use [Google
   Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator) or
   [Authy](https://www.authy.com/) or any other TOTP client.
 


### PR DESCRIPTION
I noticed an increased search traffic for `YubiKey`  via our Github stats. This make it a little easier for new users to know that FIDO U2F = YubiKey. Added a small note about solokeys but YubiKey have have won the hardware market for now. 
