### PR TITLE
Add check for empty ClusterNames, ServerHostname in retrieving sessions

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1546,6 +1546,14 @@ func (h *Handler) siteSessionGet(w http.ResponseWriter, r *http.Request, p httpr
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// DELETE IN: 4.5.0
+	// Teleport Nodes < v4.3 does not set clusterName with new sessions,
+	// which 4.3 UI client relies on to set clusterId in URL.
+	if sess.ClusterName == "" {
+		sess.ClusterName = p.ByName("site")
+	}
+
 	return *sess, nil
 }
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1547,7 +1547,7 @@ func (h *Handler) siteSessionGet(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 
-	// DELETE IN: 4.5.0
+	// DELETE IN: 5.0.0
 	// Teleport Nodes < v4.3 does not set clusterName with new sessions,
 	// which 4.3 UI client relies on to set clusterId in URL.
 	if sess.ClusterName == "" {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1060,7 +1060,8 @@ func (s *WebSuite) TestEmptySessionClusterHostnameIsSet(c *C) {
 
 	// Test that empty ClusterName and ServerHostname got set.
 	var sessionResult *session.Session
-	json.Unmarshal(res.Bytes(), &sessionResult)
+	err = json.Unmarshal(res.Bytes(), &sessionResult)
+	c.Assert(err, IsNil)
 	c.Assert(sessionResult.ClusterName, Equals, s.server.ClusterName())
 	c.Assert(sessionResult.ServerHostname, Equals, sess1.ServerID)
 
@@ -1076,7 +1077,8 @@ func (s *WebSuite) TestEmptySessionClusterHostnameIsSet(c *C) {
 	c.Assert(err, IsNil)
 
 	var sessionList *siteSessionsGetResponse
-	json.Unmarshal(res.Bytes(), &sessionList)
+	err = json.Unmarshal(res.Bytes(), &sessionList)
+	c.Assert(err, IsNil)
 
 	s1 := sessionList.Sessions[0]
 	s2 := sessionList.Sessions[1]

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1032,13 +1032,14 @@ func (s *WebSuite) TestActiveSessions(c *C) {
 	c.Assert(sess.ClusterName, Equals, s.server.ClusterName())
 }
 
-// DELETE IN: 4.5.0
-// Tests code snippet from apiserver.(*Handler).siteSessionGet.
+// DELETE IN: 5.0.0
+// Tests the code snippet from apiserver.(*Handler).siteSessionGet that
+// tests empty clusterName is set to URL params "site".
 func (s *WebSuite) TestEmptySessionClusterNameIsSet(c *C) {
 	nodeClient, err := s.server.NewClient(auth.TestBuiltin(teleport.RoleNode))
 	c.Assert(err, IsNil)
 
-	// Create a session with empty ClusterName
+	// Create a session with empty ClusterName.
 	sid := session.NewID()
 	date := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 	sess := session.Session{
@@ -1053,12 +1054,12 @@ func (s *WebSuite) TestEmptySessionClusterNameIsSet(c *C) {
 	err = nodeClient.CreateSession(sess)
 	c.Assert(err, IsNil)
 
-	// Retrieve the session with the empty ClusterName
+	// Retrieve the session with the empty ClusterName.
 	pack := s.authPack(c, "foo")
 	res, err := pack.clt.Get(context.Background(), pack.clt.Endpoint("webapi", "sites", s.server.ClusterName(), "namespaces", "default", "sessions", sid.String()), url.Values{})
 	c.Assert(err, IsNil)
 
-	// Test that empty ClusterName got set to value of the "site" param of URL
+	// Test that empty ClusterName got set to value of the "site" param of URL.
 	var result *session.Session
 	json.Unmarshal(res.Bytes(), &result)
 	c.Assert(result.ClusterName, Equals, s.server.ClusterName())


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/4012

#### Description 
Teleport node's running < v4.3 does not set ClusterName and ServerHostname for session info, which is needed to form session URL in the UI and to display information. This PR handles this incompatibility.

#### Manual Testing
Reproduced issue and tested with Proxy/Auth v4.3 with Node v4.2.11

#### Reliant PR
https://github.com/gravitational/webapps/pull/123