### PR TITLE
config key to reuse connection

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -607,6 +607,9 @@ func applySSHConfig(fc *FileConfig, cfg *service.Config) error {
 	if fc.SSH.PermitUserEnvironment {
 		cfg.SSH.PermitUserEnvironment = true
 	}
+	if fc.SSH.ReuseConnIotMode {
+		cfg.SSH.ReuseConnIotMode = true
+	}
 	if fc.SSH.PAM != nil {
 		cfg.SSH.PAM = fc.SSH.PAM.Parse()
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -162,6 +162,7 @@ var (
 		"disk_buffer_size":        false,
 		"network_buffer_size":     false,
 		"cgroup_path":             false,
+		"reuse_conn_iot_mode":     false,
 	}
 )
 
@@ -712,6 +713,7 @@ type SSH struct {
 	Commands              []CommandLabel    `yaml:"commands,omitempty"`
 	PermitUserEnvironment bool              `yaml:"permit_user_env,omitempty"`
 	PAM                   *PAM              `yaml:"pam,omitempty"`
+	ReuseConnIotMode      bool              `yaml:"reuse_conn_iot_mode,omitempty"`
 	// PublicAddr sets SSH host principals for SSH service
 	PublicAddr utils.Strings `yaml:"public_addr,omitempty"`
 

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -434,6 +434,7 @@ type SSHConfig struct {
 	Labels                map[string]string
 	CmdLabels             services.CommandLabels
 	PermitUserEnvironment bool
+	ReuseConnIotMode      bool
 
 	// PAM holds PAM configuration for Teleport.
 	PAM *pam.Config

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -874,10 +874,17 @@ func tunnelAddr(settings client.ProxySettings) (string, error) {
 
 func (process *TeleportProcess) newClientThroughTunnel(servers []utils.NetAddr, identity *auth.Identity) (*auth.Client, error) {
 	// Discover address of SSH reverse tunnel server.
-	proxyAddr, err := process.findReverseTunnel(servers)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	proxyAddr := ""
+	if process.Config.SSH.ReuseConnIotMode == true {
+		proxyAddr = servers[0].String()
+	} else {
+		ret, err := process.findReverseTunnel(servers)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		proxyAddr = ret
 	}
+
 	log.Debugf("Discovered address for reverse tunnel server: %v.", proxyAddr)
 
 	tlsConfig, err := identity.TLSConfig(process.Config.CipherSuites)


### PR DESCRIPTION
Regarding ticket 1684.
A reference patch that allows us to route teleport traffic via websocket tunnel.