### PR TITLE
Remove extra PAM steps from buildbox builds

### DIFF
--- a/build.assets/Dockerfile-centos6
+++ b/build.assets/Dockerfile-centos6
@@ -40,9 +40,6 @@ ENV GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
-COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
-COPY pam/teleport-* /etc/pam.d/
-
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install

--- a/build.assets/Dockerfile-centos6-fips
+++ b/build.assets/Dockerfile-centos6-fips
@@ -40,9 +40,6 @@ ENV GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
-COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
-COPY pam/teleport-* /etc/pam.d/
-
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -38,9 +38,6 @@ ENV GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
-COPY pam/pam_teleport.so /lib/x86_64-linux-gnu/security
-COPY pam/teleport-* /etc/pam.d/
-
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install


### PR DESCRIPTION
Somehow (I think in a merge conflict fix I did) both old and new PAM steps got included in the FIPS, CentOS 6 and CentOS 6 FIPS buildbox Dockerfiles. This is causing the buildbox push steps to fail when we merge to `master`. This fixes the error.