### PR TITLE
Bump MkDocs Theme

### DIFF
--- a/build.assets/docs.dockerfile
+++ b/build.assets/docs.dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/mkdocs-base:1.0.3-1
+FROM quay.io/gravitational/mkdocs-base:1.1.2-1
 
 ARG UID
 ARG GID

--- a/docs/4.1.yaml
+++ b/docs/4.1.yaml
@@ -37,9 +37,9 @@ nav:
     - Enterprise Guides:
         - Introduction: enterprise/index.md
         - Quick Start Guide: enterprise/quickstart-enterprise.md
-        - Single sign-on (SSO): enterprise/ssh_sso.md   
-        - FedRAMP & FIPS: enterprise/ssh_fips.md        
-        - RBAC: enterprise/ssh_rbac.md 
+        - Single sign-on (SSO): enterprise/ssh_sso.md
+        - FedRAMP & FIPS: enterprise/ssh_fips.md
+        - RBAC: enterprise/ssh_rbac.md
     - SSO Guides:
         - Active Directory (ADFS): ssh_adfs.md
         - G Suite: ssh_gsuite.md

--- a/docs/4.2.yaml
+++ b/docs/4.2.yaml
@@ -25,8 +25,7 @@ extra_css: []
 plugins:
     - search:
         separator: '[\s\-\.]'
-    - markdownextradata: {
-    }
+    - markdownextradata: {}
 extra_javascript: []
 extra:
     version: 4.2

--- a/docs/4.3.yaml
+++ b/docs/4.3.yaml
@@ -26,8 +26,7 @@ extra_css: []
 plugins:
     - search:
         separator: '[\s\-\.]'
-    - markdownextradata: {
-    }
+    - markdownextradata: {}
 extra_javascript: []
 extra:
     version: 4.3

--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -366,7 +366,7 @@ tsh bench -i --duration=4h --threads=10 user@teleport-monster-6757d7b487-x226b p
 
 Observe prometheus metrics for goroutines, open files, RAM, CPU, Timers and make sure there are no leaks
 
-- [ ] Verify that prometheus metrics are accurate. 
+- [ ] Verify that prometheus metrics are accurate.
 
 **Breaking load tests**
 


### PR DESCRIPTION
- [x] Bump to 1.1.2 https://www.mkdocs.org/about/release-notes/, which has some small fixes and should also improve our search for the time being. 

Tested locally, and updated other mkdocs plugins in the docker image. 