### PR TITLE
Backport: fix a nil pointer dereference in firestore index creation

### DIFF
--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -712,11 +712,14 @@ func EnsureIndexes(ctx context.Context, adminSvc *apiv1.FirestoreAdminClient, tu
 			return ConvertGRPCError(err)
 		}
 
-		meta := adminpb.IndexOperationMetadata{}
-		if err := proto.Unmarshal(operation.Metadata.Value, &meta); err != nil {
-			return trace.Wrap(err)
+		// operation can be nil if error code is codes.AlreadyExists.
+		if operation != nil {
+			meta := adminpb.IndexOperationMetadata{}
+			if err := proto.Unmarshal(operation.Metadata.Value, &meta); err != nil {
+				return trace.Wrap(err)
+			}
+			tuplesToIndexNames[tuple] = meta.Index
 		}
-		tuplesToIndexNames[tuple] = meta.Index
 	}
 
 	// Instead of polling the Index state, we should wait for the Operation to


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/4041 into 4.3

https://github.com/gravitational/teleport/pull/3766 removed a nil
pointer check when creating firestore indexes. This was a legitimate
check, for when indexes already exist.

Tested this manually. Unit testing is trickier because the firestore
emulator in gcloud doesn't support indexes.