### PR TITLE
Backport: Add fallback values for empty ClusterNames, ServerHostname when retrieving sessions

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1514,6 +1514,20 @@ func (h *Handler) siteSessionsGet(w http.ResponseWriter, r *http.Request, p http
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// DELETE IN: 5.0.0
+	// Teleport Nodes < v4.3 does not set ClusterName, ServerHostname with new sessions,
+	// which 4.3 UI client relies on to create URL's and display node inform.
+	clusterName := p.ByName("site")
+	for i, session := range sessions {
+		if session.ClusterName == "" {
+			sessions[i].ClusterName = clusterName
+		}
+		if session.ServerHostname == "" {
+			sessions[i].ServerHostname = session.ServerID
+		}
+	}
+
 	return siteSessionsGetResponse{Sessions: sessions}, nil
 }
 
@@ -1546,6 +1560,17 @@ func (h *Handler) siteSessionGet(w http.ResponseWriter, r *http.Request, p httpr
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// DELETE IN: 5.0.0
+	// Teleport Nodes < v4.3 does not set ClusterName, ServerHostname with new sessions,
+	// which 4.3 UI client relies on to create URL's and display node inform.
+	if sess.ClusterName == "" {
+		sess.ClusterName = p.ByName("site")
+	}
+	if sess.ServerHostname == "" {
+		sess.ServerHostname = sess.ServerID
+	}
+
 	return *sess, nil
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1032,6 +1032,63 @@ func (s *WebSuite) TestActiveSessions(c *C) {
 	c.Assert(sess.ClusterName, Equals, s.server.ClusterName())
 }
 
+// DELETE IN: 5.0.0
+// Tests the code snippet from apiserver.(*Handler).siteSessionGet/siteSessionsGet
+// that tests empty ClusterName and ServerHostname gets set.
+func (s *WebSuite) TestEmptySessionClusterHostnameIsSet(c *C) {
+	nodeClient, err := s.server.NewClient(auth.TestBuiltin(teleport.RoleNode))
+	c.Assert(err, IsNil)
+
+	// Create a session with empty ClusterName.
+	sess1 := session.Session{
+		ClusterName:    "",
+		ServerID:       string(session.NewID()),
+		ID:             session.NewID(),
+		Namespace:      defaults.Namespace,
+		Login:          "foo",
+		Created:        time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		LastActive:     time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+		TerminalParams: session.TerminalParams{W: 100, H: 100},
+	}
+	err = nodeClient.CreateSession(sess1)
+	c.Assert(err, IsNil)
+
+	// Retrieve the session with the empty ClusterName.
+	pack := s.authPack(c, "baz")
+	res, err := pack.clt.Get(context.Background(), pack.clt.Endpoint("webapi", "sites", s.server.ClusterName(), "namespaces", "default", "sessions", sess1.ID.String()), url.Values{})
+	c.Assert(err, IsNil)
+
+	// Test that empty ClusterName and ServerHostname got set.
+	var sessionResult *session.Session
+	err = json.Unmarshal(res.Bytes(), &sessionResult)
+	c.Assert(err, IsNil)
+	c.Assert(sessionResult.ClusterName, Equals, s.server.ClusterName())
+	c.Assert(sessionResult.ServerHostname, Equals, sess1.ServerID)
+
+	// Create another session to test sessions list.
+	sess2 := sess1
+	sess2.ID = session.NewID()
+	sess2.ServerID = string(session.NewID())
+	err = nodeClient.CreateSession(sess2)
+	c.Assert(err, IsNil)
+
+	// Retrieve sessions list.
+	res, err = pack.clt.Get(context.Background(), pack.clt.Endpoint("webapi", "sites", s.server.ClusterName(), "namespaces", "default", "sessions"), url.Values{})
+	c.Assert(err, IsNil)
+
+	var sessionList *siteSessionsGetResponse
+	err = json.Unmarshal(res.Bytes(), &sessionList)
+	c.Assert(err, IsNil)
+
+	s1 := sessionList.Sessions[0]
+	s2 := sessionList.Sessions[1]
+
+	c.Assert(s1.ClusterName, Equals, s.server.ClusterName())
+	c.Assert(s2.ClusterName, Equals, s.server.ClusterName())
+	c.Assert(s1.ServerHostname, Equals, s1.ServerID)
+	c.Assert(s2.ServerHostname, Equals, s2.ServerID)
+}
+
 func (s *WebSuite) TestCloseConnectionsOnLogout(c *C) {
 	sid := session.NewID()
 	pack := s.authPack(c, "foo")


### PR DESCRIPTION
Backport of #4027 to 4.3