### PR TITLE
relax local log restrictions & improve file log errors

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -817,17 +817,19 @@ func initUploadHandler(auditConfig services.AuditConfig) (events.UploadHandler, 
 }
 
 // initExternalLog initializes external storage, if the storage is not
-// setup, returns nil
+// setup, returns (nil, nil).
 func initExternalLog(auditConfig services.AuditConfig) (events.IAuditLog, error) {
+	//
+	// DELETE IN: 5.0
+	// We could probably just remove AuditTableName now (its been deprecated for a while), but
+	// its probably more polite to delete it on a major release transition.
+	//
 	if auditConfig.AuditTableName != "" {
 		log.Warningf("Please note that 'audit_table_name' is deprecated and will be removed in several releases. Use audit_events_uri: '%v://%v' instead.", dynamo.GetName(), auditConfig.AuditTableName)
 		if len(auditConfig.AuditEventsURI) != 0 {
 			return nil, trace.BadParameter("Detected configuration specifying 'audit_table_name' and 'audit_events_uri' at the same time. Please migrate your config to use 'audit_events_uri' only.")
 		}
 		auditConfig.AuditEventsURI = []string{fmt.Sprintf("%v://%v", dynamo.GetName(), auditConfig.AuditTableName)}
-	}
-	if len(auditConfig.AuditEventsURI) > 0 && !auditConfig.ShouldUploadSessions() {
-		return nil, trace.BadParameter("please specify audit_sessions_uri when using external audit backends")
 	}
 	var hasNonFileLog bool
 	var loggers []events.IAuditLog
@@ -866,6 +868,12 @@ func initExternalLog(auditConfig services.AuditConfig) (events.IAuditLog, error)
 			}
 			loggers = append(loggers, logger)
 		case teleport.SchemeFile:
+			if uri.Path == "" {
+				return nil, trace.BadParameter("unsupported audit uri: %q (missing path component)", uri)
+			}
+			if uri.Host != "" && uri.Host != "localhost" {
+				return nil, trace.BadParameter("unsupported audit uri: %q (nonlocal host component: %q)", uri, uri.Host)
+			}
 			if err := os.MkdirAll(uri.Path, teleport.SharedDirMode); err != nil {
 				return nil, trace.ConvertSystemError(err)
 			}
@@ -885,28 +893,22 @@ func initExternalLog(auditConfig services.AuditConfig) (events.IAuditLog, error)
 				uri.Scheme, dynamo.GetName(), teleport.SchemeFile)
 		}
 	}
-	// only file external loggers are prohibited (they are not supposed
-	// to be used on their own, only in combo with external loggers)
-	// they also don't implement certain features, so they are going
-	// to be inefficient
-	switch len(loggers) {
-	case 0:
-		return nil, trace.NotFound("no external log is defined")
-	case 1:
-		if !hasNonFileLog {
-			return nil, trace.BadParameter(
-				"file:// or stdout:// log can not be used on it's own, " +
-					"can be only used in combination with external session logs, e.g. dynamodb://")
-		}
-		return loggers[0], nil
-	default:
-		if !hasNonFileLog {
-			return nil, trace.BadParameter(
-				"file:// or stdout:// log can not be used on it's own, " +
-					"can be only used in combination with external session logs, e.g. dynamodb://")
-		}
+
+	if len(loggers) < 1 {
+		return nil, nil
+	}
+
+	if !auditConfig.ShouldUploadSessions() && hasNonFileLog {
+		// if audit events are being exported, session recordings should
+		// be exported as well.
+		return nil, trace.BadParameter("please specify audit_sessions_uri when using external audit backends")
+	}
+
+	if len(loggers) > 1 {
 		return events.NewMultiLog(loggers...), nil
 	}
+
+	return loggers[0], nil
 }
 
 // initAuthService can be called to initialize auth server service
@@ -952,11 +954,11 @@ func (process *TeleportProcess) initAuthService() error {
 			}
 		}
 
+		// initialize external loggers.  may return (nil, nil) if no
+		// external loggers have been defined.
 		externalLog, err := initExternalLog(auditConfig)
 		if err != nil {
-			if !trace.IsNotFound(err) {
-				return trace.Wrap(err)
-			}
+			return trace.Wrap(err)
 		}
 
 		auditServiceConfig := events.AuditLogConfig{


### PR DESCRIPTION
Previously, `teleport` would refuse to start if `audit_events_uri` only contained only file-based loggers, or if `audit_events_uri` was defined, but `audit_sessions_uri` was not.  This was intended to prevent accidental misuse, but disallowed to legitimate use of `audit_events_uri` for overriding the default event output path.

This PR partially relaxes the above restrictions, allowing the use of `audit_events_uri`, but still requiring that audit events are uploaded if session recordings are being uploaded.

Fixes #3771 