### PR TITLE
Change cron Docker image base to ubuntu

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -231,7 +231,7 @@ steps:
       - echo "$(cat /go/build/PREVIOUS_VERSION_TWO_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt
       - for FILE in /go/build/*.txt; do echo $FILE; cat $FILE; done
       # get Dockerfile
-      - curl -Ls -o /go/build/Dockerfile-cron https://raw.githubusercontent.com/gravitational/teleport/master/build.assets/Dockerfile-cron
+      - curl -Ls -o /go/build/Dockerfile-cron https://raw.githubusercontent.com/gravitational/teleport/${DRONE_SOURCE_BRANCH:-master}/build.assets/Dockerfile-cron
 
   - name: Build and push Teleport containers (CURRENT_VERSION)
     image: docker
@@ -1844,6 +1844,6 @@ steps:
 
 ---
 kind: signature
-hmac: 8a8743b996e9791da890f2c62f08d04c240d108467c5e942df887878ef5f5904
+hmac: 3d28b5458a796f019a790fb4641afbdc02056f64c721bd1984d507999d3730ac
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -240,27 +240,32 @@ steps:
       ARCH: amd64
     settings:
       username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+        # from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+        from_secret: QUAYIO_DOCKER_USERNAME
       password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+        # from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+        from_secret: QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
     commands:
       - export VERSION_TAG=$(cat /go/build/CURRENT_VERSION_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
+      # - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      # - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      # - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-ent"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-ent-fips"
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      #- docker push $OSS_IMAGE_NAME
+      - docker push $OSS_IMAGE_NAME
       # Enterprise
       - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      #- docker push $ENT_IMAGE_NAME
+      - docker push $ENT_IMAGE_NAME
       # Enterprise FIPS
       - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      #- docker push $ENT_FIPS_IMAGE_NAME
+      - docker push $ENT_FIPS_IMAGE_NAME
 
   - name: Build and push Teleport containers (PREVIOUS_VERSION_ONE)
     image: docker
@@ -269,27 +274,32 @@ steps:
       ARCH: amd64
     settings:
       username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+        # from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+        from_secret: QUAYIO_DOCKER_USERNAME
       password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+        # from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+        from_secret: QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
     commands:
       - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_ONE_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
+      # - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      # - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      # - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-ent"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-ent-fips"
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      #- docker push $OSS_IMAGE_NAME
+      - docker push $OSS_IMAGE_NAME
       # Enterprise
       - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      #- docker push $ENT_IMAGE_NAME
+      - docker push $ENT_IMAGE_NAME
       # Enterprise FIPS
       - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      #- docker push $ENT_FIPS_IMAGE_NAME
+      - docker push $ENT_FIPS_IMAGE_NAME
 
   - name: Build and push Teleport containers (PREVIOUS_VERSION_TWO)
     image: docker
@@ -298,27 +308,32 @@ steps:
       ARCH: amd64
     settings:
       username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+        # from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+        from_secret: QUAYIO_DOCKER_USERNAME
       password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+        # from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+        from_secret: QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
     commands:
       - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_TWO_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
+      # - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      # - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      # - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-ent"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-ent-fips"
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      #- docker push $OSS_IMAGE_NAME
+      - docker push $OSS_IMAGE_NAME
       # Enterprise
       - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      #- docker push $ENT_IMAGE_NAME
+      - docker push $ENT_IMAGE_NAME
       # Enterprise FIPS
       - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      #- docker push $ENT_FIPS_IMAGE_NAME
+      - docker push $ENT_FIPS_IMAGE_NAME
 
 services:
   - name: Start Docker
@@ -337,19 +352,9 @@ kind: pipeline
 type: kubernetes
 name: teleport-helm-cron
 
-# trigger:
-#   cron:
-#     - teleport-helm-cron
-# TODO(gus): testing
 trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+  cron:
+    - teleport-helm-cron
 
 workspace:
   path: /go
@@ -375,20 +380,19 @@ steps:
       - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport
       - helm repo index /go/chart
 
-  # TODO(gus): testing
-  # - name: Upload to S3
-  #   image: plugins/s3
-  #   settings:
-  #     bucket: charts.gravitational.io
-  #     access_key:
-  #       from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
-  #     secret_key:
-  #       from_secret: PRODUCTION_CHARTS_AWS_SECRET_ACCESS_KEY
-  #     region: us-east-2
-  #     acl: public-read
-  #     source: /go/chart/*
-  #     target: /
-  #     strip_prefix: /go/chart
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket: charts.gravitational.io
+      access_key:
+        from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: PRODUCTION_CHARTS_AWS_SECRET_ACCESS_KEY
+      region: us-east-2
+      acl: public-read
+      source: /go/chart/*
+      target: /
+      strip_prefix: /go/chart
 
 ---
 kind: pipeline
@@ -1840,6 +1844,6 @@ steps:
 
 ---
 kind: signature
-hmac: 220cb6346fbb7ef80e50600f183469a031a8b1c2122f1dc101c980ed0c587c30
+hmac: 8a8743b996e9791da890f2c62f08d04c240d108467c5e942df887878ef5f5904
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -189,19 +189,9 @@ kind: pipeline
 type: kubernetes
 name: teleport-docker-cron
 
-# trigger:
-#   cron:
-#     - teleport-docker-cron
-# TODO(gus): testing - uncomment push when done
 trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+  cron:
+    - teleport-docker-cron
 
 workspace:
   path: /go
@@ -240,22 +230,17 @@ steps:
       ARCH: amd64
     settings:
       username:
-        # from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-        from_secret: QUAYIO_DOCKER_USERNAME
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
       password:
-        # from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-        from_secret: QUAYIO_DOCKER_PASSWORD
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
     commands:
       - export VERSION_TAG=$(cat /go/build/CURRENT_VERSION_TAG.txt)
-      # - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      # - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      # - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-ent"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-ent-fips"
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
@@ -274,22 +259,17 @@ steps:
       ARCH: amd64
     settings:
       username:
-        # from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-        from_secret: QUAYIO_DOCKER_USERNAME
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
       password:
-        # from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-        from_secret: QUAYIO_DOCKER_PASSWORD
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
     commands:
       - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_ONE_TAG.txt)
-      # - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      # - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      # - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-ent"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-ent-fips"
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
@@ -308,22 +288,17 @@ steps:
       ARCH: amd64
     settings:
       username:
-        # from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-        from_secret: QUAYIO_DOCKER_USERNAME
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
       password:
-        # from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-        from_secret: QUAYIO_DOCKER_PASSWORD
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
     commands:
       - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_TWO_TAG.txt)
-      # - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      # - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      # - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-ent"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-cron:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-ent-fips"
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
@@ -1844,6 +1819,6 @@ steps:
 
 ---
 kind: signature
-hmac: 3d28b5458a796f019a790fb4641afbdc02056f64c721bd1984d507999d3730ac
+hmac: 754cfb8789865f6aa3429b6343632badf6b1895d7b67baa8021734aa3ee1f515
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -187,14 +187,172 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
-name: helm-cron-teleport
+name: teleport-docker-cron
 
+# trigger:
+#   cron:
+#     - teleport-docker-cron
+# TODO(gus): testing - uncomment push when done
 trigger:
-  cron:
-    - helm-cron-teleport
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 workspace:
-  path: /tmp
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Set up variables and Dockerfile
+    image: docker:git
+    environment:
+      # increment these variables when a new major/minor version is released to bump the automatic builds
+      CURRENT_VERSION_ROOT: 4.3
+      PREVIOUS_VERSION_ONE_ROOT: 4.2
+      PREVIOUS_VERSION_TWO_ROOT: 4.1
+    commands:
+      - apk --update --no-cache add curl
+      - mkdir -p /go/build && cd /go/build
+      # CURRENT_VERSION
+      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $CURRENT_VERSION_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/CURRENT_VERSION_TAG.txt
+      - echo "$(cat /go/build/CURRENT_VERSION_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/CURRENT_VERSION_TAG_GENERIC.txt
+      # PREVIOUS_VERSION_ONE
+      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_ONE_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/PREVIOUS_VERSION_ONE_TAG.txt
+      - echo "$(cat /go/build/PREVIOUS_VERSION_ONE_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt
+      # PREVIOUS_VERSION_TWO
+      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_TWO_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/PREVIOUS_VERSION_TWO_TAG.txt
+      - echo "$(cat /go/build/PREVIOUS_VERSION_TWO_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt
+      - for FILE in /go/build/*.txt; do echo $FILE; cat $FILE; done
+      # get Dockerfile
+      - curl -Ls -o /go/build/Dockerfile-cron https://raw.githubusercontent.com/gravitational/teleport/master/build.assets/Dockerfile-cron
+
+  - name: Build and push Teleport containers (CURRENT_VERSION)
+    image: docker
+    environment:
+      OS: linux
+      ARCH: amd64
+    settings:
+      username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - export VERSION_TAG=$(cat /go/build/CURRENT_VERSION_TAG.txt)
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
+      # OSS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      #- docker push $OSS_IMAGE_NAME
+      # Enterprise
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      #- docker push $ENT_IMAGE_NAME
+      # Enterprise FIPS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      #- docker push $ENT_FIPS_IMAGE_NAME
+
+  - name: Build and push Teleport containers (PREVIOUS_VERSION_ONE)
+    image: docker
+    environment:
+      OS: linux
+      ARCH: amd64
+    settings:
+      username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_ONE_TAG.txt)
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
+      # OSS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      #- docker push $OSS_IMAGE_NAME
+      # Enterprise
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      #- docker push $ENT_IMAGE_NAME
+      # Enterprise FIPS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      #- docker push $ENT_FIPS_IMAGE_NAME
+
+  - name: Build and push Teleport containers (PREVIOUS_VERSION_TWO)
+    image: docker
+    environment:
+      OS: linux
+      ARCH: amd64
+    settings:
+      username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_TWO_TAG.txt)
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
+      # OSS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      #- docker push $OSS_IMAGE_NAME
+      # Enterprise
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      #- docker push $ENT_IMAGE_NAME
+      # Enterprise FIPS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      #- docker push $ENT_FIPS_IMAGE_NAME
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: teleport-helm-cron
+
+# trigger:
+#   cron:
+#     - teleport-helm-cron
+# TODO(gus): testing
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
+
+workspace:
+  path: /go
 
 clone:
   disable: true
@@ -203,33 +361,34 @@ steps:
   - name: Check out code
     image: alpine/git
     commands:
-      - mkdir -p /tmp/go/src/github.com/gravitational/teleport
-      - cd /tmp/go/src/github.com/gravitational/teleport
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
 
   - name: Package helm chart
     image: alpine/helm:2.16.9
     commands:
-      - mkdir -p /tmp/chart
-      - cd /tmp/chart
+      - mkdir -p /go/chart
+      - cd /go/chart
       - helm init --client-only
-      - helm package /tmp/go/src/github.com/gravitational/teleport/examples/chart/teleport
-      - helm repo index /tmp/chart
+      - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport
+      - helm repo index /go/chart
 
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket: charts.gravitational.io
-      access_key:
-        from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: PRODUCTION_CHARTS_AWS_SECRET_ACCESS_KEY
-      region: us-east-2
-      acl: public-read
-      source: /tmp/chart/*
-      target: /
-      strip_prefix: /tmp/chart
+  # TODO(gus): testing
+  # - name: Upload to S3
+  #   image: plugins/s3
+  #   settings:
+  #     bucket: charts.gravitational.io
+  #     access_key:
+  #       from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
+  #     secret_key:
+  #       from_secret: PRODUCTION_CHARTS_AWS_SECRET_ACCESS_KEY
+  #     region: us-east-2
+  #     acl: public-read
+  #     source: /go/chart/*
+  #     target: /
+  #     strip_prefix: /go/chart
 
 ---
 kind: pipeline
@@ -1636,144 +1795,6 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: docker-cron
-
-trigger:
-  cron:
-    - docker-cron
-
-workspace:
-  path: /tmp
-
-clone:
-  disable: true
-
-steps:
-  - name: Set up variables and Dockerfile
-    image: alpine
-    environment:
-      # increment these variables when a new major/minor version is released to bump the automatic builds
-      CURRENT_VERSION_ROOT: 4.3
-      PREVIOUS_VERSION_ONE_ROOT: 4.2
-      PREVIOUS_VERSION_TWO_ROOT: 4.1
-    commands:
-      - apk --update --no-cache add curl git
-      - mkdir -p /tmp/build && cd /tmp/build
-      # CURRENT_VERSION
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $CURRENT_VERSION_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /tmp/build/CURRENT_VERSION_TAG.txt
-      - echo "$(cat /tmp/build/CURRENT_VERSION_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt
-      # PREVIOUS_VERSION_ONE
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_ONE_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /tmp/build/PREVIOUS_VERSION_ONE_TAG.txt
-      - echo "$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt
-      # PREVIOUS_VERSION_TWO
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_TWO_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /tmp/build/PREVIOUS_VERSION_TWO_TAG.txt
-      - echo "$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt
-      - for FILE in /tmp/build/*.txt; do echo $FILE; cat $FILE; done
-      # get Dockerfile
-      - curl -Ls -o /tmp/build/Dockerfile-cron https://raw.githubusercontent.com/gravitational/teleport/master/build.assets/Dockerfile-cron
-
-  - name: Build and push Teleport containers (CURRENT_VERSION)
-    image: docker:dind
-    environment:
-      OS: linux
-      ARCH: amd64
-    settings:
-      username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-      password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - export VERSION_TAG=$(cat /tmp/build/CURRENT_VERSION_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
-      # OSS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $OSS_IMAGE_NAME
-      # Enterprise
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_IMAGE_NAME
-      # Enterprise FIPS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_FIPS_IMAGE_NAME
-
-  - name: Build and push Teleport containers (PREVIOUS_VERSION_ONE)
-    image: docker:dind
-    environment:
-      OS: linux
-      ARCH: amd64
-    settings:
-      username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-      password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - export VERSION_TAG=$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
-      # OSS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $OSS_IMAGE_NAME
-      # Enterprise
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_IMAGE_NAME
-      # Enterprise FIPS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_FIPS_IMAGE_NAME
-
-  - name: Build and push Teleport containers (PREVIOUS_VERSION_TWO)
-    image: docker:dind
-    environment:
-      OS: linux
-      ARCH: amd64
-    settings:
-      username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-      password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - export VERSION_TAG=$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
-      # OSS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $OSS_IMAGE_NAME
-      # Enterprise
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_IMAGE_NAME
-      # Enterprise FIPS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_FIPS_IMAGE_NAME
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    privileged: true
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
-  - name: dockersock
-    temp: {}
-
----
-kind: pipeline
-type: kubernetes
 name: promote-artifacts
 
 trigger:
@@ -1819,6 +1840,6 @@ steps:
 
 ---
 kind: signature
-hmac: e3a7822f97d391d9122d024cc3bdafa8f2be9c99c3d4832179a7d11926987ff0
+hmac: 220cb6346fbb7ef80e50600f183469a031a8b1c2122f1dc101c980ed0c587c30
 
 ...

--- a/build.assets/Dockerfile-cron
+++ b/build.assets/Dockerfile-cron
@@ -23,8 +23,7 @@ RUN curl -Ls -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/relea
     chmod +x /usr/local/bin/dumb-init
 
 # Second stage builds final container with teleport binaries.
-# We can't use busybox:glibc as it doesn't provide all of Teleport's glibc library dependencies.
-FROM quay.io/gravitational/alpine-glibc AS teleport
+FROM ubuntu:20.04 AS teleport
 
 # Copy ca-certificates from the package that we installed in the previous stage.
 COPY --from=download /usr/share/ca-certificates /usr/share/ca-certificates


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/4054

Also:
- change most uses of `/tmp` in `.drone.yml` to `/go` as we don't explicitly need a different base directory and it'll make having a generic pipeline setup method easier in future.
- rename cron jobs to be a little more descriptive
- reorder `.drone.yml` so cron jobs are next to each other