### PR TITLE
Docs Version switcher hotfix

### DIFF
--- a/docs/theme/src/docs.js
+++ b/docs/theme/src/docs.js
@@ -11465,7 +11465,7 @@ var handleVerSelector = function handleVerSelector() {
     //var reg = new RegExp("\/ver\/([0-9|\.]+(?=\/.))");
     var reg = new RegExp("/ver/(.*)/");
     var url = window.location.href.replace(reg, '');
-    var newPrefix = isLatest ? "" : "/ver/" + ver + "/";
+    var newPrefix = isLatest ? "" : "/teleport/docs/ver/" + ver + "/";
     return url.replace(window.mkdocs_page_url, newPrefix);
   }
 
@@ -12125,7 +12125,7 @@ var TopNav = /*#__PURE__*/function () {
 
 // extracted by mini-css-extract-plugin
     if(false) { var cssReload; }
-  
+
 
 /***/ }),
 


### PR DESCRIPTION
I need to go and fix this in the theme build pipeline, hotfix for now. ( Also need to write a regex for Gravity Docs & Teleport Docs ) 

Fixes #4073