### PR TITLE
Fix Drone signature

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1933,6 +1933,6 @@ steps:
 
 ---
 kind: signature
-hmac: 6966b3013ec023233eaac5b570186e75375ae7ee51da4b6954a59dfb2b989840
+hmac: 018dc8d3cc72a5d7ec9db88441ebfe7eb73c4191c7beae2250109c1f27c591f9
 
 ...


### PR DESCRIPTION
Sometimes when we have big merges, the signature in `.drone.yml` doesn't get updated/committed properly. This was one of those cases (from #4029)