### PR TITLE
Downgrade buildbox from ubuntu 20.04 to 18.04

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,6 +1,12 @@
 # This Dockerfile makes the "build box": the container used to build official
 # releases of Teleport and its documentation.
-FROM ubuntu:20.04
+
+# Use Ubuntu 18.04 as base to get an older glibc version.
+# Using a newer base image will build against a newer glibc, which creates a
+# runtime requirement for the host to have newer glibc too. For example,
+# teleport built on any newer Ubuntu version will not run on Centos 7 because
+# of this.
+FROM ubuntu:18.04
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -1,6 +1,12 @@
 # This Dockerfile makes the FIPS "build box": the container used to build official
 # FIPS releases of Teleport and its documentation.
-FROM ubuntu:20.04
+
+# Use Ubuntu 18.04 as base to get an older glibc version.
+# Using a newer base image will build against a newer glibc, which creates a
+# runtime requirement for the host to have newer glibc too. For example,
+# teleport built on any newer Ubuntu version will not run on Centos 7 because
+# of this.
+FROM ubuntu:18.04
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -145,7 +145,7 @@ clean:
 #
 .PHONY:test
 test: buildbox
-	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BUILDBOX) \
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c \
 		"examples/etcd/start-etcd.sh & sleep 1; \
 		ssh-agent > external.agent.tmp && source external.agent.tmp; \
@@ -153,7 +153,7 @@ test: buildbox
 
 .PHONY:integration
 integration: buildbox
-	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BUILDBOX) \
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c "make -C $(SRCDIR) FLAGS='-cover' integration"
 
 #
@@ -161,7 +161,7 @@ integration: buildbox
 #
 .PHONY:lint
 lint: buildbox
-	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BUILDBOX) \
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c "make -C $(SRCDIR) lint"
 
 #


### PR DESCRIPTION
The glibc version requirement imposed by 20.04 doesn't mix well with
centos 7.
Ubuntu 20.04: glibc 2.28
Centos 7: glibc 2.17

As a result, teleport binaries build in the buildbox fail to start.
Going down to 18.04 seems to get us back far enough.