### PR TITLE
Backport .drone.yml from master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ type: kubernetes
 name: test
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
   UID: 1000
   GID: 1000
 
@@ -151,7 +151,7 @@ clone:
 
 steps:
   - name: Check out code
-    image: golang:1.14.4
+    image: golang:1.13.2
     commands:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
@@ -159,7 +159,7 @@ steps:
       - git checkout $DRONE_COMMIT
 
   - name: Run docs tests
-    image: golang:1.14.4
+    image: golang:1.13.2
     commands:
       - |
         cd /go/src/github.com/gravitational/teleport
@@ -375,7 +375,7 @@ type: kubernetes
 name: build-linux-amd64
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
 
 trigger:
   event:
@@ -479,7 +479,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
 
 trigger:
   event:
@@ -585,7 +585,7 @@ type: kubernetes
 name: build-linux-amd64-centos6
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
 
 trigger:
   event:
@@ -690,7 +690,7 @@ type: kubernetes
 name: build-linux-amd64-centos6-fips
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
 
 trigger:
   event:
@@ -794,7 +794,7 @@ type: kubernetes
 name: build-linux-amd64-rpm
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
 
 trigger:
   event:
@@ -1240,7 +1240,7 @@ type: kubernetes
 name: build-linux-i386
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
 
 trigger:
   event:
@@ -1564,7 +1564,7 @@ type: kubernetes
 name: build-windows
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
 
 trigger:
   event:
@@ -1664,7 +1664,7 @@ type: kubernetes
 name: build-docker-images
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
 
 trigger:
   event:
@@ -1775,7 +1775,7 @@ type: kubernetes
 name: build-buildboxes
 
 environment:
-  RUNTIME: go1.14.4
+  RUNTIME: go1.13.2
   UID: 1000
   GID: 1000
 
@@ -1933,6 +1933,6 @@ steps:
 
 ---
 kind: signature
-hmac: 018dc8d3cc72a5d7ec9db88441ebfe7eb73c4191c7beae2250109c1f27c591f9
+hmac: 77c2acafa930c7beb0be92b4ff207027ac4e405c07423c405cd2c0a30018dfb8
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ type: kubernetes
 name: test
 
 environment:
-  RUNTIME: go1.13.2
+  RUNTIME: go1.14.4
   UID: 1000
   GID: 1000
 
@@ -40,24 +40,19 @@ steps:
       - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f /root/.ssh/id_rsa
       - mkdir -p /go/cache
 
   - name: Build buildbox
     image: docker
-    environment:
-      QUAYIO_DOCKER_USERNAME:
-        from_secret: QUAYIO_DOCKER_USERNAME
-      QUAYIO_DOCKER_PASSWORD:
-        from_secret: QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - docker login -u="$QUAYIO_DOCKER_USERNAME" -p="$QUAYIO_DOCKER_PASSWORD" quay.io
       - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets buildbox
@@ -143,9 +138,10 @@ trigger:
     - master
     - branch/*
   event:
-    include:
-      - push
-      - pull_request
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 workspace:
   path: /go
@@ -155,7 +151,7 @@ clone:
 
 steps:
   - name: Check out code
-    image: golang:1.13.2
+    image: golang:1.14.4
     commands:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
@@ -163,13 +159,16 @@ steps:
       - git checkout $DRONE_COMMIT
 
   - name: Run docs tests
-    image: golang:1.13.2
+    image: golang:1.14.4
     commands:
       - |
         cd /go/src/github.com/gravitational/teleport
         git diff --raw ${DRONE_COMMIT}..${DRONE_TARGET_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
+          # Check trailing whitespace
+          make docs-test-whitespace
+          # Check links
           for VERSION in $(cat /tmp/docs-versions-changed.txt); do
             if [ -f docs/$VERSION/milv.config.yaml ]; then
               cd docs/$VERSION
@@ -188,10 +187,195 @@ steps:
 ---
 kind: pipeline
 type: kubernetes
+name: teleport-docker-cron
+
+trigger:
+  cron:
+    - teleport-docker-cron
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Set up variables and Dockerfile
+    image: docker:git
+    environment:
+      # increment these variables when a new major/minor version is released to bump the automatic builds
+      CURRENT_VERSION_ROOT: 4.3
+      PREVIOUS_VERSION_ONE_ROOT: 4.2
+      PREVIOUS_VERSION_TWO_ROOT: 4.1
+    commands:
+      - apk --update --no-cache add curl
+      - mkdir -p /go/build && cd /go/build
+      # CURRENT_VERSION
+      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $CURRENT_VERSION_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/CURRENT_VERSION_TAG.txt
+      - echo "$(cat /go/build/CURRENT_VERSION_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/CURRENT_VERSION_TAG_GENERIC.txt
+      # PREVIOUS_VERSION_ONE
+      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_ONE_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/PREVIOUS_VERSION_ONE_TAG.txt
+      - echo "$(cat /go/build/PREVIOUS_VERSION_ONE_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt
+      # PREVIOUS_VERSION_TWO
+      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_TWO_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/PREVIOUS_VERSION_TWO_TAG.txt
+      - echo "$(cat /go/build/PREVIOUS_VERSION_TWO_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt
+      - for FILE in /go/build/*.txt; do echo $FILE; cat $FILE; done
+      # get Dockerfile
+      - curl -Ls -o /go/build/Dockerfile-cron https://raw.githubusercontent.com/gravitational/teleport/${DRONE_SOURCE_BRANCH:-master}/build.assets/Dockerfile-cron
+
+  - name: Build and push Teleport containers (CURRENT_VERSION)
+    image: docker
+    environment:
+      OS: linux
+      ARCH: amd64
+    settings:
+      username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - export VERSION_TAG=$(cat /go/build/CURRENT_VERSION_TAG.txt)
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
+      # OSS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      - docker push $OSS_IMAGE_NAME
+      # Enterprise
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      - docker push $ENT_IMAGE_NAME
+      # Enterprise FIPS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      - docker push $ENT_FIPS_IMAGE_NAME
+
+  - name: Build and push Teleport containers (PREVIOUS_VERSION_ONE)
+    image: docker
+    environment:
+      OS: linux
+      ARCH: amd64
+    settings:
+      username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_ONE_TAG.txt)
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
+      # OSS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      - docker push $OSS_IMAGE_NAME
+      # Enterprise
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      - docker push $ENT_IMAGE_NAME
+      # Enterprise FIPS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      - docker push $ENT_FIPS_IMAGE_NAME
+
+  - name: Build and push Teleport containers (PREVIOUS_VERSION_TWO)
+    image: docker
+    environment:
+      OS: linux
+      ARCH: amd64
+    settings:
+      username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_TWO_TAG.txt)
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
+      # OSS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      - docker push $OSS_IMAGE_NAME
+      # Enterprise
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      - docker push $ENT_IMAGE_NAME
+      # Enterprise FIPS
+      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
+      - docker push $ENT_FIPS_IMAGE_NAME
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: teleport-helm-cron
+
+trigger:
+  cron:
+    - teleport-helm-cron
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: alpine/git
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout $DRONE_COMMIT
+
+  - name: Package helm chart
+    image: alpine/helm:2.16.9
+    commands:
+      - mkdir -p /go/chart
+      - cd /go/chart
+      - helm init --client-only
+      - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport
+      - helm repo index /go/chart
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket: charts.gravitational.io
+      access_key:
+        from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: PRODUCTION_CHARTS_AWS_SECRET_ACCESS_KEY
+      region: us-east-2
+      acl: public-read
+      source: /go/chart/*
+      target: /
+      strip_prefix: /go/chart
+
+---
+kind: pipeline
+type: kubernetes
 name: build-linux-amd64
 
 environment:
-  RUNTIME: go1.13.2
+  RUNTIME: go1.14.4
 
 trigger:
   event:
@@ -219,54 +403,47 @@ steps:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
-      - git checkout $DRONE_TAG
-      - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
-      - echo $DRONE_TAG > /go/.drone_tag
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
       # fetch enterprise submodules
       - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f /root/.ssh/id_rsa
       # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
+      - mkdir -p /go/cache /go/artifacts/e
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
   - name: Build release artifacts
-    image: docker:git
+    image: docker
     environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
       UID: 1000
       GID: 1000
-      GOPATH: /gopath
+      GOPATH: /go
       OS: linux
       ARCH: amd64
     volumes:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - >-
-        docker run --rm=true
-        -e GOCACHE=$GOPATH/cache
-        -v /go/cache:$GOPATH/cache
-        -v /go/src/github.com/gravitational/teleport:$GOPATH/src/github.com/gravitational/teleport
-        -w $GOPATH/src/github.com/gravitational/teleport
-        -h buildbox
-        -u $UID:$GID
-        -t quay.io/gravitational/teleport-buildbox:$RUNTIME
-        /bin/bash -c "/usr/bin/make release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME"
+      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
 
   - name: Copy artifacts
-    image: docker:git
+    image: docker
     commands:
       - cd /go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
       - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      - find e -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # rename artifacts
-      - mv /go/artifacts/teleport-$DRONE_TAG-linux-amd64-bin.tar.gz /go/artifacts/teleport-$DRONE_TAG-linux-amd64-bin.tar.gz
-      - mv /go/artifacts/teleport-ent-$DRONE_TAG-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-$DRONE_TAG-linux-amd64-bin.tar.gz
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts/e \;
+      # rename artifact
+      - export VERSION=$(cat /go/.version.txt)
+      - mv /go/artifacts/e/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz
       # generate checksums
       - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 
@@ -302,7 +479,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 
 environment:
-  RUNTIME: go1.13.2
+  RUNTIME: go1.14.4
 
 trigger:
   event:
@@ -330,24 +507,26 @@ steps:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
-      - git checkout $DRONE_TAG
-      - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
-      - echo $DRONE_TAG > /go/.drone_tag
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+      - echo $DRONE_TAG > /go/.drone_tag.txt
       # fetch enterprise submodules
       - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f /root/.ssh/id_rsa
       # create necessary directories
       - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
   - name: Build FIPS release artifacts
-    image: docker:git
+    image: docker
     environment:
       UID: 1000
       GID: 1000
-      GOPATH: /gopath
+      GOPATH: /go
       OS: linux
       ARCH: amd64
       FIPS: "yes"
@@ -355,26 +534,22 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - >-
-        docker run --rm=true
-        -e GOCACHE=$GOPATH/cache
-        -v /go/cache:$GOPATH/cache
-        -v /go/src/github.com/gravitational/teleport:$GOPATH/src/github.com/gravitational/teleport
-        -w $GOPATH/src/github.com/gravitational/teleport
-        -h buildbox
-        -u $UID:$GID
-        -t quay.io/gravitational/teleport-buildbox-fips:$RUNTIME
-        /bin/bash -c "/usr/bin/make release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME FIPS=$FIPS"
+      - docker pull quay.io/gravitational/teleport-buildbox-fips:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /go/.version.txt)
+      - make -C build.assets release-fips VERSION=$VERSION OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME FIPS=$FIPS
 
   - name: Copy FIPS artifacts
-    image: docker:git
+    image: docker
     commands:
       - cd /go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find e -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # rename artifacts
-      - mv /go/artifacts/teleport-ent-$DRONE_TAG-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-$DRONE_TAG-linux-amd64-fips-bin.tar.gz
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+      # rename artifact
+      - export VERSION=$(cat /go/.version.txt)
+      - mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz
       # generate checksums
       - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 
@@ -410,7 +585,7 @@ type: kubernetes
 name: build-linux-amd64-centos6
 
 environment:
-  RUNTIME: go1.13.2
+  RUNTIME: go1.14.4
 
 trigger:
   event:
@@ -438,52 +613,48 @@ steps:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
-      - git checkout $DRONE_TAG
-      - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
-      - echo $DRONE_TAG > /go/.drone_tag
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
       # fetch enterprise submodules
       - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f /root/.ssh/id_rsa
       # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
+      - mkdir -p /go/cache /go/artifacts/e
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
   - name: Build CentOS 6 release artifacts
-    image: docker:git
+    image: docker
     environment:
       UID: 1000
       GID: 1000
-      GOPATH: /gopath
+      GOPATH: /go
       OS: linux
       ARCH: amd64
     volumes:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - >-
-        docker run --rm=true
-        -e GOCACHE=$GOPATH/cache
-        -v /go/cache:$GOPATH/cache
-        -v /go/src/github.com/gravitational/teleport:$GOPATH/src/github.com/gravitational/teleport
-        -w $GOPATH/src/github.com/gravitational/teleport
-        -h buildbox
-        -u $UID:$GID
-        -t quay.io/gravitational/teleport-buildbox-centos6:$RUNTIME
-        /bin/bash -c "/usr/bin/make release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME"
+      - docker pull quay.io/gravitational/teleport-buildbox-centos6:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets release-centos6 OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
 
   - name: Copy CentOS 6 artifacts
-    image: docker:git
+    image: docker
     commands:
       - cd /go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
       - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      - find e -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts/e \;
       # rename artifacts
-      - mv /go/artifacts/teleport-$DRONE_TAG-linux-amd64-bin.tar.gz /go/artifacts/teleport-$DRONE_TAG-linux-amd64-centos6-bin.tar.gz
-      - mv /go/artifacts/teleport-ent-$DRONE_TAG-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-$DRONE_TAG-linux-amd64-centos6-bin.tar.gz
+      - export VERSION=$(cat /go/.version.txt)
+      - mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-v$${VERSION}-linux-amd64-centos6-bin.tar.gz
+      - mv /go/artifacts/e/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-bin.tar.gz
       # generate checksums
       - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 
@@ -519,7 +690,7 @@ type: kubernetes
 name: build-linux-amd64-centos6-fips
 
 environment:
-  RUNTIME: go1.13.2
+  RUNTIME: go1.14.4
 
 trigger:
   event:
@@ -547,24 +718,25 @@ steps:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
-      - git checkout $DRONE_TAG
-      - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
-      - echo $DRONE_TAG > /go/.drone_tag
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
       # fetch enterprise submodules
       - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f /root/.ssh/id_rsa
       # create necessary directories
       - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
   - name: Build CentOS 6 FIPS release artifacts
-    image: docker:git
+    image: docker
     environment:
       UID: 1000
       GID: 1000
-      GOPATH: /gopath
+      GOPATH: /go
       OS: linux
       ARCH: amd64
       FIPS: "yes"
@@ -572,28 +744,793 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - >-
-        docker run --rm=true
-        -e GOCACHE=$GOPATH/cache
-        -v /go/cache:$GOPATH/cache
-        -v /go/src/github.com/gravitational/teleport:$GOPATH/src/github.com/gravitational/teleport
-        -w $GOPATH/src/github.com/gravitational/teleport
-        -h buildbox
-        -u $UID:$GID
-        -t quay.io/gravitational/teleport-buildbox-centos6-fips:$RUNTIME
-        /bin/bash -c "/usr/bin/make release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME FIPS=$FIPS"
+      - docker pull quay.io/gravitational/teleport-buildbox-centos6-fips:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets release-centos6-fips OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME FIPS=$FIPS
 
   - name: Copy CentOS 6 FIPS artifacts
-    image: docker:git
+    image: docker
     commands:
       - cd /go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find e -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
       # rename artifact
-      - mv /go/artifacts/teleport-ent-$DRONE_TAG-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-$DRONE_TAG-linux-amd64-centos6-fips-bin.tar.gz
+      - export VERSION=$(cat /go/.version.txt)
+      - mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-fips-bin.tar.gz
       # generate checksums
       - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /go/artifacts/*
+      target: teleport/tag/${DRONE_TAG}
+      strip_prefix: /go/artifacts/
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: build-linux-amd64-rpm
+
+environment:
+  RUNTIME: go1.14.4
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+
+depends_on:
+  - build-linux-amd64
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: docker:git
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+      # fetch enterprise submodules
+      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      # create necessary directories
+      - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Download built tarball artifacts from S3
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat /go/.version.txt)
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
+
+  - name: Build RPM artifacts
+    image: docker
+    environment:
+      ARCH: amd64
+      TMPDIR: /go
+      OSS_TARBALL_PATH: /go/artifacts
+      ENT_TARBALL_PATH: /go/artifacts
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache bash curl go make tar
+      - cd /go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /go/.version.txt)
+      - make rpm
+
+  - name: Copy RPM artifacts
+    image: docker
+    commands:
+      - cd /go/src/github.com/gravitational/teleport
+      # copy release archives (and checksums) to artifact directory
+      - find build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+      - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /go/artifacts/*
+      target: teleport/tag/${DRONE_TAG}
+      strip_prefix: /go/artifacts/
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: build-linux-amd64-fips-rpm
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+
+depends_on:
+  - build-linux-amd64-fips
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: docker:git
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+      # fetch enterprise submodules
+      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      # create necessary directories
+      - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Download built tarball artifacts from S3
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat /go/.version.txt)
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/
+
+  - name: Build FIPS RPM artifacts
+    image: docker
+    environment:
+      ARCH: amd64
+      FIPS: "yes"
+      # weird quirk of FIPS package builds
+      RUNTIME: fips
+      TMPDIR: /go
+      ENT_TARBALL_PATH: /go/artifacts
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache bash curl make tar
+      - cd /go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /go/.version.txt)
+      # build enterprise only
+      - make -C e rpm
+
+  - name: Copy FIPS RPM artifacts
+    image: docker
+    commands:
+      - cd /go/src/github.com/gravitational/teleport
+      # copy release archives (and checksums) to artifact directory
+      - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /go/artifacts/*
+      target: teleport/tag/${DRONE_TAG}
+      strip_prefix: /go/artifacts/
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: build-linux-amd64-deb
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+
+depends_on:
+  - build-linux-amd64
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: docker:git
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+      # fetch enterprise submodules
+      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      # create necessary directories
+      - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Download built tarball artifacts from S3
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat /go/.version.txt)
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
+
+  - name: Build DEB artifacts
+    image: docker
+    environment:
+      ARCH: amd64
+      TMPDIR: /go
+      OSS_TARBALL_PATH: /go/artifacts
+      ENT_TARBALL_PATH: /go/artifacts
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache bash curl make tar
+      - cd /go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /go/.version.txt)
+      - make deb
+
+  - name: Copy DEB artifacts
+    image: docker
+    commands:
+      - cd /go/src/github.com/gravitational/teleport
+      # copy release archives (and checksums) to artifact directory
+      - find build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
+      - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /go/artifacts/*
+      target: teleport/tag/${DRONE_TAG}
+      strip_prefix: /go/artifacts/
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: build-linux-amd64-fips-deb
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+
+depends_on:
+  - build-linux-amd64-fips
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: docker:git
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+      # fetch enterprise submodules
+      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      # create necessary directories
+      - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Download built tarball artifacts from S3
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat /go/.version.txt)
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/
+
+  - name: Build FIPS DEB artifacts
+    image: docker
+    environment:
+      ARCH: amd64
+      FIPS: "yes"
+      # weird quirk with FIPS package builds
+      RUNTIME: "fips"
+      TMPDIR: /go
+      ENT_TARBALL_PATH: /go/artifacts
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache bash curl make tar
+      - cd /go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /go/.version.txt)
+      # build enterprise only
+      - make -C e deb
+
+  - name: Copy FIPS DEB artifacts
+    image: docker
+    commands:
+      - cd /go/src/github.com/gravitational/teleport
+      # copy release archives (and checksums) to artifact directory
+      - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
+      - ls -l /go/artifacts
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /go/artifacts/*
+      target: teleport/tag/${DRONE_TAG}
+      strip_prefix: /go/artifacts/
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: build-linux-i386
+
+environment:
+  RUNTIME: go1.14.4
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+
+depends_on:
+  - test
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: docker:git
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+      # fetch enterprise submodules
+      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      # create necessary directories
+      - mkdir -p /go/cache /go/artifacts/e
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Build i386 release artifacts
+    image: docker
+    environment:
+      UID: 1000
+      GID: 1000
+      GOPATH: /go
+      OS: linux
+      ARCH: "386"
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make
+      - chown -R $UID:$GID /go
+      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
+
+  - name: Copy artifacts
+    image: docker
+    commands:
+      - cd /go/src/github.com/gravitational/teleport
+      # copy release archives to artifact directory
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts/e \;
+      # rename artifacts
+      - export VERSION=$(cat /go/.version.txt)
+      - mv /go/artifacts/e/teleport-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-386-bin.tar.gz
+      # generate checksums
+      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /go/artifacts/*
+      target: teleport/tag/${DRONE_TAG}
+      strip_prefix: /go/artifacts/
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: build-linux-i386-rpm
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+
+depends_on:
+  - build-linux-i386
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: docker:git
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+      # fetch enterprise submodules
+      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      # create necessary directories
+      - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Download built tarball artifacts from S3
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat /go/.version.txt)
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
+
+  - name: Build i386 RPM artifacts
+    image: docker
+    environment:
+      ARCH: "386"
+      TMPDIR: /go
+      OSS_TARBALL_PATH: /go/artifacts
+      ENT_TARBALL_PATH: /go/artifacts
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache bash curl make tar
+      - cd /go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /go/.version.txt)
+      - make rpm
+
+  - name: Copy i386 RPM artifacts
+    image: docker
+    commands:
+      - cd /go/src/github.com/gravitational/teleport
+      # copy release archives (and checksums) to artifact directory
+      - find build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+      - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /go/artifacts/*
+      target: teleport/tag/${DRONE_TAG}
+      strip_prefix: /go/artifacts/
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: build-linux-i386-deb
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+
+depends_on:
+  - build-linux-i386
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: docker:git
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+      # fetch enterprise submodules
+      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      # create necessary directories
+      - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Download built tarball artifacts from S3
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat /go/.version.txt)
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
+
+  - name: Build i386 DEB artifacts
+    image: docker
+    environment:
+      ARCH: "386"
+      TMPDIR: /go
+      OSS_TARBALL_PATH: /go/artifacts
+      ENT_TARBALL_PATH: /go/artifacts
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache bash curl make tar
+      - cd /go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /go/.version.txt)
+      - make deb
+
+  - name: Copy i386 DEB artifacts
+    image: docker
+    commands:
+      - cd /go/src/github.com/gravitational/teleport
+      # copy release archives (and checksums) to artifact directory
+      - find build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
+      - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
 
   - name: Upload to S3
     image: plugins/s3
@@ -627,7 +1564,7 @@ type: kubernetes
 name: build-windows
 
 environment:
-  RUNTIME: go1.13.2
+  RUNTIME: go1.14.4
 
 trigger:
   event:
@@ -655,43 +1592,38 @@ steps:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
-      - git checkout $DRONE_TAG
-      - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
-      - echo $DRONE_TAG > /go/.drone_tag
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
       # fetch enterprise submodules
       - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
       - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f /root/.ssh/id_rsa
       # create necessary directories
       - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
   - name: Build Windows release artifacts
-    image: docker:git
+    image: docker
     environment:
       UID: 1000
       GID: 1000
-      GOPATH: /gopath
+      GOPATH: /go
       OS: windows
     volumes:
       - name: dockersock
         path: /var/run
     commands:
+      - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - >-
-        docker run --rm=true
-        -e GOCACHE=$GOPATH/cache
-        -v /go/cache:$GOPATH/cache
-        -v /go/src/github.com/gravitational/teleport:$GOPATH/src/github.com/gravitational/teleport
-        -w $GOPATH/src/github.com/gravitational/teleport
-        -h buildbox
-        -u $UID:$GID
-        -t quay.io/gravitational/teleport-buildbox:$RUNTIME
-        /bin/bash -c "/usr/bin/make release OS=$OS"
+      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets release-windows OS=$OS
 
   - name: Copy Windows artifacts
-    image: docker:git
+    image: docker
     commands:
       - cd /go/src/github.com/gravitational/teleport
       # copy release archives to build directory
@@ -729,10 +1661,121 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
+name: build-docker-images
+
+environment:
+  RUNTIME: go1.14.4
+
+trigger:
+  event:
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: docker:git
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+      # fetch enterprise submodules
+      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      # create necessary directories
+      - mkdir -p /go/cache /go/artifacts
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Build OSS/Enterprise Docker images
+    image: docker
+    environment:
+      UID: 1000
+      GID: 1000
+      GOPATH: /go
+      OS: linux
+      ARCH: amd64
+    settings:
+      username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make
+      - chown -R $UID:$GID /go
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
+      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      # TODO
+      # this should be changed to "make image publish" when we want to actually cut over
+      # to building public-facing Docker images using Drone
+      - make image
+
+  - name: Build FIPS Docker image
+    image: docker
+    environment:
+      UID: 1000
+      GID: 1000
+      GOPATH: /go
+      OS: linux
+      ARCH: amd64
+    settings:
+      username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make
+      - chown -R $UID:$GID /go
+      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
+      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      # version needs to be set manually when running in the e directory
+      - export VERSION=$(cat /go/.version.txt)
+      # TODO
+      # this should be changed to "make -C e image-fips publish-fips" when we want to
+      # actually cut over to building public-facing Docker images using Drone
+      - make -C e image-fips
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
 name: build-buildboxes
 
 environment:
-  RUNTIME: go1.13.2
+  RUNTIME: go1.14.4
   UID: 1000
   GID: 1000
 
@@ -759,7 +1802,7 @@ steps:
       - git checkout $DRONE_COMMIT
 
   - name: Build and push buildbox container
-    image: docker:git
+    image: docker
     environment:
       QUAYIO_DOCKER_USERNAME:
         from_secret: QUAYIO_DOCKER_USERNAME
@@ -777,7 +1820,7 @@ steps:
       - docker push quay.io/gravitational/teleport-buildbox:$RUNTIME
 
   - name: Build and push buildbox-fips container
-    image: docker:git
+    image: docker
     environment:
       QUAYIO_DOCKER_USERNAME:
         from_secret: QUAYIO_DOCKER_USERNAME
@@ -795,7 +1838,7 @@ steps:
       - docker push quay.io/gravitational/teleport-buildbox-fips:$RUNTIME
 
   - name: Build and push buildbox-centos6 container
-    image: docker:git
+    image: docker
     environment:
       QUAYIO_DOCKER_USERNAME:
         from_secret: QUAYIO_DOCKER_USERNAME
@@ -813,7 +1856,7 @@ steps:
       - docker push quay.io/gravitational/teleport-buildbox-centos6:$RUNTIME
 
   - name: Build and push buildbox-centos6-fips container
-    image: docker:git
+    image: docker
     environment:
       QUAYIO_DOCKER_USERNAME:
         from_secret: QUAYIO_DOCKER_USERNAME
@@ -845,145 +1888,7 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: docker-cron
-
-trigger:
-  cron:
-    - docker-cron
-
-workspace:
-  path: /tmp
-
-clone:
-  disable: true
-
-steps:
-  - name: Set up variables and Dockerfile
-    image: alpine
-    environment:
-      # increment these variables when a new major/minor version is released to bump the automatic builds
-      CURRENT_VERSION_ROOT: 4.2
-      PREVIOUS_VERSION_ONE_ROOT: 4.1
-      PREVIOUS_VERSION_TWO_ROOT: 4.0
-    commands:
-      - apk --update --no-cache add curl git
-      - mkdir -p /tmp/build && cd /tmp/build
-      # CURRENT_VERSION
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $CURRENT_VERSION_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /tmp/build/CURRENT_VERSION_TAG.txt
-      - echo "$(cat /tmp/build/CURRENT_VERSION_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt
-      # PREVIOUS_VERSION_ONE
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_ONE_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /tmp/build/PREVIOUS_VERSION_ONE_TAG.txt
-      - echo "$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt
-      # PREVIOUS_VERSION_TWO
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_TWO_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /tmp/build/PREVIOUS_VERSION_TWO_TAG.txt
-      - echo "$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt
-      - for FILE in /tmp/build/*.txt; do echo $FILE; cat $FILE; done
-      # get Dockerfile
-      - curl -Ls -o /tmp/build/Dockerfile-cron https://raw.githubusercontent.com/gravitational/teleport/master/build.assets/Dockerfile-cron
-
-  - name: Build and push Teleport containers (CURRENT_VERSION)
-    image: docker:dind
-    environment:
-      OS: linux
-      ARCH: amd64
-    settings:
-      username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-      password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - export VERSION_TAG=$(cat /tmp/build/CURRENT_VERSION_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/CURRENT_VERSION_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
-      # OSS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $OSS_IMAGE_NAME
-      # Enterprise
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_IMAGE_NAME
-      # Enterprise FIPS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_FIPS_IMAGE_NAME
-
-  - name: Build and push Teleport containers (PREVIOUS_VERSION_ONE)
-    image: docker:dind
-    environment:
-      OS: linux
-      ARCH: amd64
-    settings:
-      username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-      password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - export VERSION_TAG=$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
-      # OSS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $OSS_IMAGE_NAME
-      # Enterprise
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_IMAGE_NAME
-      # Enterprise FIPS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_FIPS_IMAGE_NAME
-
-  - name: Build and push Teleport containers (PREVIOUS_VERSION_TWO)
-    image: docker:dind
-    environment:
-      OS: linux
-      ARCH: amd64
-    settings:
-      username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-      password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - export VERSION_TAG=$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /tmp/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
-      # OSS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $OSS_IMAGE_NAME
-      # Enterprise
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_IMAGE_NAME
-      # Enterprise FIPS
-      - docker build --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /tmp/build/Dockerfile-cron /tmp/build
-      - docker push $ENT_FIPS_IMAGE_NAME
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    privileged: true
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
-  - name: dockersock
-    temp: {}
-
----
-kind: pipeline
-type: kubernetes
-name: promote-artifact
+name: promote-artifacts
 
 trigger:
   event:
@@ -998,7 +1903,7 @@ clone:
   disable: true
 
 steps:
-  - name: Download artifact from S3 artifact publishing bucket
+  - name: Download artifacts from S3 artifact publishing bucket
     image: amazon/aws-cli
     environment:
       AWS_S3_BUCKET:
@@ -1011,7 +1916,7 @@ steps:
     commands:
       - aws s3 sync s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG/ .
 
-  - name: Upload artifact to production S3 bucket with public read access
+  - name: Upload artifacts to production S3 bucket with public read access
     image: plugins/s3
     settings:
       bucket:
@@ -1028,6 +1933,6 @@ steps:
 
 ---
 kind: signature
-hmac: 0e70d638dcfea64019ed991453a1ccccf5825a268d795d6da1d5b83ab8309aa3
+hmac: 018dc8d3cc72a5d7ec9db88441ebfe7eb73c4191c7beae2250109c1f27c591f9
 
 ...


### PR DESCRIPTION
Backporting all recent changes to `.drone.yml` from `master` to `branch/4.3` so that we can test the release pipelines properly when 4.3.1 is cut.