### PR TITLE
Add jobs for Drone MacOS/ARM exec runners

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1662,6 +1662,7 @@ steps:
 
   - name: Clean up exec runner storage (post)
     commands:
+      - cd /tmp
       - rm -rf /tmp/tarball/go
 
 ---
@@ -1777,6 +1778,7 @@ steps:
 
   - name: Clean up exec runner storage (post)
     commands:
+      - cd /tmp
       - rm -rf /tmp/teleport-pkg/go
 
 ---
@@ -1892,6 +1894,7 @@ steps:
 
   - name: Clean up exec runner storage (post)
     commands:
+      - cd /tmp
       - rm -rf /tmp/teleport-pkg-tsh/go
 
 ---
@@ -1996,6 +1999,7 @@ steps:
 
   - name: Clean up exec runner storage (post)
     commands:
+      - cd /tmp
       - rm -rf /dev/shm/tmp/go
 
 ---
@@ -2373,6 +2377,6 @@ steps:
 
 ---
 kind: signature
-hmac: cf01d9ed48a432879b9194c5d55bdbf8bdc5cd3869cc56c2675a7cd3a8843c16
+hmac: 9a1fe55fbd3bb2e4f4cf7f2513bb061e7444d3bfdbbf222e3b10592f71e40f5d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,9 +7,6 @@ platform:
   os: darwin
   arch: amd64
 
-environment:
-  RUNTIME: go1.13.2
-
 trigger:
   branch:
     - master
@@ -81,7 +78,89 @@ steps:
       AWS_REGION: us-west-2
     commands:
       - cd /tmp/go/artifacts
-      - aws s3 . sync s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
+      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
+
+---
+kind: pipeline
+type: exec
+name: arm-test
+
+platform:
+  os: linux
+  arch: arm
+
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
+
+workspace:
+  path: /tmp/go
+
+clone:
+  disable: true
+
+steps:
+  - name: Clean up exec runner
+    commands:
+      - rm -rf /tmp/go/src /tmp/go/artifacts /tmp/go/.*.txt
+
+  - name: Check out code
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /tmp/go/src/github.com/gravitational/teleport
+      - cd /tmp/go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout $DRONE_COMMIT
+      - echo $DRONE_SOURCE_BRANCH > /tmp/go/.drone_source_branch.txt
+      # fetch enterprise submodules
+      - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
+      - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f ~/.ssh/id_rsa
+      - mkdir -p /tmp/go/cache /tmp/go/artifacts
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/go/.version.txt; fi; cat /tmp/go/.version.txt
+
+  - name: Build Mac release artifacts
+    environment:
+      GOPATH: /tmp/go
+      OS: linux
+      ARCH: arm
+    commands:
+      - cd /tmp/go/src/github.com/gravitational/teleport
+      - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
+
+  - name: Copy Mac artifacts
+    commands:
+      - cd /tmp/go/src/github.com/gravitational/teleport
+      # copy release archives to artifact directory
+      - mkdir -p /tmp/go/artifacts
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
+      # generate checksums (for mac)
+      - cd /tmp/go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+
+  - name: Upload to S3
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - cd /tmp/go/artifacts
+      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
 ---
 kind: pipeline
@@ -2026,6 +2105,6 @@ steps:
 
 ---
 kind: signature
-hmac: 0c6c6a0bd0e1fb67efcd8b18319fc10b1a871d569481912277e963b0bf5cd444
+hmac: cb065c51e4288414d02f512c9c5b48961c43535e6324457c64d4b8e90c9b8f95
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1877,8 +1877,8 @@ steps:
     commands:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
-      # list keychains
-      - security list-keychains -d user -s login.keychain
+      # set HOME explicitly (as Drone overrides it normally)
+      - export HOME=/Users/build
       # unlock login keychain
       - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
       # show available certificates
@@ -2395,6 +2395,6 @@ steps:
 
 ---
 kind: signature
-hmac: 5cbeba7ca02fb0c92f2724d9f5cbe33bb006e7ada3a868d52c4866283d6c3a73
+hmac: 61639e30457faaab13f75030606e5e51ad31298b2f0ad3c21b7f3be8b1eb9066
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1607,7 +1607,7 @@ clone:
 steps:
   - name: Clean up exec runner storage (pre)
     commands:
-      - chmod -R u+rw /tmp/tarball/go
+      - chmod -R u+rw /tmp/tarball
       - rm -rf /tmp/tarball/go
 
   - name: Check out code
@@ -1663,7 +1663,7 @@ steps:
 
   - name: Clean up exec runner storage (post)
     commands:
-      - chmod -R u+rw /tmp/tarball/go
+      - chmod -R u+rw /tmp/tarball
       - rm -rf /tmp/tarball/go
 
 ---
@@ -1707,7 +1707,7 @@ clone:
 steps:
   - name: Clean up exec runner storage (pre)
     commands:
-      - chmod -R u+rw /tmp/teleport-pkg/go
+      - chmod -R u+rw /tmp/teleport-pkg
       - rm -rf /tmp/teleport-pkg/go
 
   - name: Check out code
@@ -1780,7 +1780,7 @@ steps:
 
   - name: Clean up exec runner storage (post)
     commands:
-      - chmod -R u+rw /tmp/teleport-pkg/go
+      - chmod -R u+rw /tmp/teleport-pkg
       - rm -rf /tmp/teleport-pkg/go
 
 ---
@@ -1824,7 +1824,7 @@ clone:
 steps:
   - name: Clean up exec runner storage (pre)
     commands:
-      - chmod -R u+rw /tmp/teleport-pkg-tsh/go
+      - chmod -R u+rw /tmp/teleport-pkg-tsh
       - rm -rf /tmp/teleport-pkg-tsh/go
 
   - name: Check out code
@@ -1897,7 +1897,7 @@ steps:
 
   - name: Clean up exec runner storage (post)
     commands:
-      - chmod -R u+rw /tmp/teleport-pkg-tsh/go
+      - chmod -R u+rw /tmp/teleport-pkg-tsh
       - rm -rf /tmp/teleport-pkg-tsh/go
 
 ---
@@ -1946,7 +1946,7 @@ clone:
 steps:
   - name: Clean up exec runner storage (pre)
     commands:
-      - chmod -R u+rw /dev/shm/tmp/go
+      - chmod -R u+rw /dev/shm/tmp
       - rm -rf /dev/shm/tmp/go
 
   - name: Check out code
@@ -2003,7 +2003,7 @@ steps:
 
   - name: Clean up exec runner storage (post)
     commands:
-      - chmod -R u+rw /dev/shm/tmp/go
+      - chmod -R u+rw /dev/shm/tmp
       - rm -rf /dev/shm/tmp/go
 
 ---
@@ -2381,6 +2381,6 @@ steps:
 
 ---
 kind: signature
-hmac: dded50c0841689a0b070940837ded012f33cc88fb8fce4ecbd3f5dfa6a10c922
+hmac: af2ba0a74b925140c84e0e5fb864c543cb44a4db92d1a4d983784925000692eb
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1570,24 +1570,15 @@ platform:
   os: darwin
   arch: amd64
 
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
 
-# depends_on:
-#   - test
+depends_on:
+  - test
 
 workspace:
   path: /tmp/tarball
@@ -1670,21 +1661,12 @@ platform:
   os: darwin
   arch: amd64
 
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
 
 depends_on:
   - build-darwin-amd64
@@ -1789,21 +1771,12 @@ platform:
   os: darwin
   arch: amd64
 
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
 
 depends_on:
   - build-darwin-amd64
@@ -2377,6 +2350,6 @@ steps:
 
 ---
 kind: signature
-hmac: b7fef605f7f6e34eeea8fc1691eb02d4777af78c45f00ae4a110b8e6ea0b3630
+hmac: 9c3f7a0e413d1b252160fba8cdd51e8965ac801f28145ad5b4cd76e107d98efc
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,187 +1,5 @@
 ---
 kind: pipeline
-type: exec
-name: mac-test
-
-concurrency:
-  limit: 1
-
-platform:
-  os: darwin
-  arch: amd64
-
-trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    exclude:
-      - cron
-      - promote
-      - rollback
-
-workspace:
-  path: /tmp/go
-
-clone:
-  disable: true
-
-steps:
-  - name: Clean up exec runner storage
-    commands:
-      - rm -rf /tmp/go/artifacts /tmp/go/cache /tmp/go/src /tmp/go/.*.txt
-
-  - name: Check out code
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /tmp/go/src/github.com/gravitational/teleport
-      - cd /tmp/go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/teleport.git .
-      - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /tmp/go/.drone_source_branch.txt
-      # fetch enterprise submodules
-      - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
-      - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f ~/.ssh/id_rsa
-      - mkdir -p /tmp/go/artifacts /tmp/go/cache
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/go/.version.txt; fi; cat /tmp/go/.version.txt
-
-  - name: Build Mac release artifacts
-    environment:
-      GOPATH: /tmp/go
-      GOCACHE: /tmp/go/cache
-      OS: darwin
-      ARCH: amd64
-    commands:
-      - cd /tmp/go/src/github.com/gravitational/teleport
-      - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
-
-  - name: Copy Mac artifacts
-    commands:
-      - cd /tmp/go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - mkdir -p /tmp/go/artifacts
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
-      # generate checksums (for mac)
-      - cd /tmp/go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - cd /tmp/go/artifacts
-      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
-
----
-kind: pipeline
-type: exec
-name: arm-test
-
-concurrency:
-  limit: 1
-
-platform:
-  os: linux
-  arch: arm
-
-# use ramfs for go build cache
-# saves wear and tear on the SD card, plus it's faster
-environment:
-  TMPDIR: /dev/shm
-
-trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    exclude:
-      - cron
-      - promote
-      - rollback
-
-workspace:
-  path: /dev/shm/tmp
-
-clone:
-  disable: true
-
-steps:
-  - name: Clean up exec runner
-    commands:
-      - rm -rf /dev/shm/tmp/go/artifacts /dev/shm/tmp/go/cache /dev/shm/tmp/go/src /dev/shm/tmp/go/.*.txt
-
-  - name: Check out code
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /dev/shm/tmp/go/src/github.com/gravitational/teleport
-      - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/teleport.git .
-      - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /dev/shm/tmp/go/.drone_source_branch.txt
-      # fetch enterprise submodules
-      - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
-      - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f ~/.ssh/id_rsa
-      - mkdir -p /dev/shm/tmp/go/cache /dev/shm/tmp/go/artifacts
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /dev/shm/tmp/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /dev/shm/tmp/go/.version.txt; fi; cat /dev/shm/tmp/go/.version.txt
-
-  - name: Build ARM release artifacts
-    environment:
-      GOPATH: /dev/shm/tmp/go
-      GOCACHE: /dev/shm/tmp/go/cache
-      OS: linux
-      ARCH: arm
-    commands:
-      - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
-      - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
-
-  - name: Copy ARM artifacts
-    commands:
-      - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - mkdir -p /dev/shm/tmp/go/artifacts
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /dev/shm/tmp/go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /dev/shm/tmp/go/artifacts \;
-      # generate checksums
-      - cd /dev/shm/tmp/go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - cd /dev/shm/tmp/go/artifacts
-      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
-
-  # arm-specific step to avoid wasting RAM
-  - name: Clean up ramfs
-    commands:
-      - rm -rf /dev/shm/tmp/go
-
----
-kind: pipeline
 type: kubernetes
 name: test
 
@@ -1750,6 +1568,407 @@ volumes:
 
 ---
 kind: pipeline
+type: exec
+name: build-darwin-amd64
+
+concurrency:
+  limit: 1
+
+platform:
+  os: darwin
+  arch: amd64
+
+# TODO(gus): testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
+
+# depends_on:
+#   - test
+
+workspace:
+  path: /tmp/tarball
+
+clone:
+  disable: true
+
+steps:
+  - name: Clean up exec runner storage
+    commands:
+      - rm -rf go
+
+  - name: Check out code
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p go/src/github.com/gravitational/teleport
+      - cd go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout $DRONE_COMMIT
+      - echo $DRONE_SOURCE_BRANCH > go/.drone_source_branch.txt
+      # fetch enterprise submodules
+      - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
+      - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f ~/.ssh/id_rsa
+      - mkdir -p go/artifacts go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
+
+  - name: Build Mac release artifacts
+    environment:
+      GOPATH: /tmp/tarball/go
+      GOCACHE: /tmp/tarball/go/cache
+      OS: darwin
+      ARCH: amd64
+    commands:
+      - cd go/src/github.com/gravitational/teleport
+      - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
+
+  - name: Copy Mac artifacts
+    commands:
+      - cd go/src/github.com/gravitational/teleport
+      # copy release archives to artifact directory
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} go/artifacts \;
+      # generate checksums (for mac)
+      - cd go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+
+  - name: Upload to S3
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - cd go/artifacts
+      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
+
+  - name: Clean up exec runner storage
+    commands:
+      - rm -rf go
+
+---
+kind: pipeline
+type: exec
+name: build-darwin-amd64-pkg
+
+concurrency:
+  limit: 1
+
+platform:
+  os: darwin
+  arch: amd64
+
+# TODO(gus): testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
+
+# depends_on:
+#   - test
+
+workspace:
+  path: /tmp/teleportpkg
+
+clone:
+  disable: true
+
+steps:
+  - name: Clean up exec runner storage
+    commands:
+      - rm -rf go
+
+  - name: Check out code
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p go/src/github.com/gravitational/teleport
+      - cd go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout $DRONE_COMMIT
+      - echo $DRONE_SOURCE_BRANCH > go/.drone_source_branch.txt
+      # fetch enterprise submodules
+      - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
+      - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f ~/.ssh/id_rsa
+      - mkdir -p go/artifacts go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
+
+  - name: Build Mac pkg release artifacts
+    environment:
+      GOPATH: /tmp/teleportpkg/go
+      GOCACHE: /tmp/teleportpkg/go/cache
+      OS: darwin
+      ARCH: amd64
+    commands:
+      - cd go/src/github.com/gravitational/teleport
+      - make pkg OS=$OS ARCH=$ARCH
+      - make -C e pkg OS=$OS ARCH=$ARCH
+
+  - name: Copy Mac pkg artifacts
+    commands:
+      - cd go/src/github.com/gravitational/teleport
+      # copy release archives to artifact directory
+      - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
+      # generate checksums (for mac)
+      - cd go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+
+  - name: Upload to S3
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - cd go/artifacts
+      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
+
+  - name: Clean up exec runner storage
+    commands:
+      - rm -rf go
+
+---
+kind: pipeline
+type: exec
+name: build-darwin-amd64-pkg-tsh
+
+concurrency:
+  limit: 1
+
+platform:
+  os: darwin
+  arch: amd64
+
+# TODO(gus): testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
+
+# depends_on:
+#   - test
+
+workspace:
+  path: /tmp/teleportpkgtsh
+
+clone:
+  disable: true
+
+steps:
+  - name: Clean up exec runner storage
+    commands:
+      - rm -rf go
+
+  - name: Check out code
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p go/src/github.com/gravitational/teleport
+      - cd go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout $DRONE_COMMIT
+      - echo $DRONE_SOURCE_BRANCH > go/.drone_source_branch.txt
+      # fetch enterprise submodules
+      - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
+      - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f ~/.ssh/id_rsa
+      - mkdir -p go/artifacts go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
+
+  - name: Build Mac tsh pkg release artifacts
+    environment:
+      OS: darwin
+      ARCH: amd64
+      APPLE_USERNAME:
+        from_secret: APPLE_USERNAME
+      APPLE_PASSWORD:
+        from_secret: APPLE_PASSWORD
+    commands:
+      - cd go/src/github.com/gravitational/teleport
+      - make pkg-tsh OS=$OS ARCH=$ARCH
+
+  - name: Copy Mac tsh pkg artifacts
+    commands:
+      - cd go/src/github.com/gravitational/teleport
+      # copy release archives to artifact directory
+      - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
+      # generate checksums (for mac)
+      - cd go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+
+  - name: Upload to S3
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - cd go/artifacts
+      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
+
+  - name: Clean up exec runner storage
+    commands:
+      - rm -rf go
+
+---
+kind: pipeline
+type: exec
+name: build-arm
+
+concurrency:
+  limit: 1
+
+platform:
+  os: linux
+  arch: arm
+
+# use ramfs for go build cache
+# saves wear and tear on the SD card, plus it's faster
+environment:
+  TMPDIR: /dev/shm
+
+# TODO(gus): testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
+
+workspace:
+  path: /dev/shm/tmp
+
+clone:
+  disable: true
+
+steps:
+  - name: Clean up exec runner storage
+    commands:
+      - rm -rf go
+
+  - name: Check out code
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p go/src/github.com/gravitational/teleport
+      - cd go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout $DRONE_COMMIT
+      - echo $DRONE_SOURCE_BRANCH > go/.drone_source_branch.txt
+      # fetch enterprise submodules
+      - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
+      - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f ~/.ssh/id_rsa
+      - mkdir -p go/artifacts go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
+
+  - name: Build ARM release artifacts
+    environment:
+      GOPATH: /dev/shm/tmp/go
+      GOCACHE: /dev/shm/tmp/go/cache
+      OS: linux
+      ARCH: arm
+    commands:
+      - cd go/src/github.com/gravitational/teleport
+      - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
+
+  - name: Copy ARM artifacts
+    commands:
+      - cd go/src/github.com/gravitational/teleport
+      # copy release archives to artifact directory
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} go/artifacts \;
+      # generate checksums
+      - cd go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+
+  - name: Upload to S3
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - cd go/artifacts
+      - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
+
+  - name: Clean up exec runner storage
+    commands:
+      - rm -rf go
+
+---
+kind: pipeline
 type: kubernetes
 name: build-windows
 
@@ -2123,6 +2342,6 @@ steps:
 
 ---
 kind: signature
-hmac: 74a433c3fce0c2027bd3b5e2cfc135e21cf03b26ad461d75327fd1b23d987cdd
+hmac: c6480a59aa3194d7980c8d97f90a8d34a80a8ae8f788b171f4c9b2c789cfe0e1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1814,8 +1814,8 @@ trigger:
       - promote
       - rollback
 
-depends_on:
-  - build-darwin-amd64
+# depends_on:
+#   - build-darwin-amd64
 
 workspace:
   path: /tmp/teleport-pkg-tsh
@@ -1877,6 +1877,9 @@ steps:
     commands:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
+      # list keychains
+      - whoami
+      - security list-keychains
       # unlock login keychain
       - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
       # show available certificates
@@ -2393,6 +2396,6 @@ steps:
 
 ---
 kind: signature
-hmac: a9811d4cb0dd48724c518927882246e7e46f8e0f1dd5bc0c72c9a8e1d192c2f0
+hmac: 4e1dc27a7b6379674ef4bbc0f77149df1e8d5733f7c91adda7e5a08ff3a3b00c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1760,8 +1760,8 @@ steps:
     commands:
       - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
+      - find build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
+      - find e/build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
       # generate checksums (for mac)
       - cd /tmp/teleport-pkg/go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
@@ -1879,7 +1879,7 @@ steps:
     commands:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg-tsh/go/artifacts \;
+      - find build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg-tsh/go/artifacts \;
       # generate checksums (for mac)
       - cd /tmp/teleport-pkg-tsh/go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
@@ -2382,6 +2382,6 @@ steps:
 
 ---
 kind: signature
-hmac: ae9334c1b9641af8028d66ea5a015bb7683a6213fa51c88b99f1f45bf207a7d9
+hmac: ab410e59955e90816a5e8791dbf96c788ae83ea07ecf18b1c3be27304a115ef8
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1570,21 +1570,12 @@ platform:
   os: darwin
   arch: amd64
 
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
 
 depends_on:
   - test
@@ -1670,27 +1661,18 @@ platform:
   os: darwin
   arch: amd64
 
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
 
 depends_on:
   - build-darwin-amd64
 
 workspace:
-  path: /tmp/teleport-pkg
+  path: /tmp/build-darwin-amd64-pkg
 
 clone:
   disable: true
@@ -1698,8 +1680,8 @@ clone:
 steps:
   - name: Set up exec runner storage
     commands:
-      - mkdir -p /tmp/teleport-pkg
-      - chmod -R u+rw /tmp/teleport-pkg
+      - mkdir -p /tmp/build-darwin-amd64-pkg
+      - chmod -R u+rw /tmp/build-darwin-amd64-pkg
       - rm -rf /tmp/build-darwin-amd64-pkg/go
 
   - name: Check out code
@@ -1774,7 +1756,7 @@ steps:
 
   - name: Clean up exec runner storage
     commands:
-      - chmod -R u+rw /tmp/teleport-pkg
+      - chmod -R u+rw /tmp/build-darwin-amd64-pkg
       - rm -rf /tmp/build-darwin-amd64-pkg/go
 
 ---
@@ -1789,21 +1771,12 @@ platform:
   os: darwin
   arch: amd64
 
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
 
 depends_on:
   - build-darwin-amd64
@@ -2377,6 +2350,6 @@ steps:
 
 ---
 kind: signature
-hmac: 3492260da309c84c95a5a18fb5e5d252738ca4a49f05b706c17adabfea772d33
+hmac: daf7a1bc352cabcb4c4ac54bf5d879f2bf69ac093d94ddaf6cb2c847e13e393c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1814,8 +1814,8 @@ trigger:
       - promote
       - rollback
 
-# depends_on:
-#   - build-darwin-amd64
+depends_on:
+  - build-darwin-amd64
 
 workspace:
   path: /tmp/teleport-pkg-tsh
@@ -1892,9 +1892,9 @@ steps:
       # delete temporary tarball artifacts so we don't re-upload them in the next stage
       - rm -rf /tmp/teleport-pkg-tsh/go/artifacts/*.tar.gz
       # copy release archives to artifact directory
-      - find build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg-tsh/go/artifacts \;
+      - find build -maxdepth 1 -iname "tsh*.pkg" -print -exec cp {} /tmp/teleport-pkg-tsh/go/artifacts \;
       # generate checksums (for mac)
-      - cd /tmp/teleport-pkg-tsh/go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+      - cd /tmp/teleport-pkg-tsh/go/artifacts && for FILE in tsh*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -2395,6 +2395,6 @@ steps:
 
 ---
 kind: signature
-hmac: 61639e30457faaab13f75030606e5e51ad31298b2f0ad3c21b7f3be8b1eb9066
+hmac: a550ded35e4cd3a3f4ce6380d65782a38d9412b28743a05c02ba5da3cd66aae0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1602,7 +1602,7 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (pre)
     commands:
       - rm -rf go
 
@@ -1658,7 +1658,7 @@ steps:
       - cd go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (post)
     commands:
       - rm -rf go
 
@@ -1933,7 +1933,7 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (pre)
     commands:
       - rm -rf go
 
@@ -1989,7 +1989,7 @@ steps:
       - cd go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (post)
     commands:
       - rm -rf go
 
@@ -2368,6 +2368,6 @@ steps:
 
 ---
 kind: signature
-hmac: 3550babe2bfca1c550da6f009d7244a616d8617afb96abafb3270dc6ebce6012
+hmac: 67acf7e3d9af161db5ce30da4b543f26381178b956e53c597acdb902a94020f3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1871,10 +1871,17 @@ steps:
         from_secret: APPLE_USERNAME
       APPLE_PASSWORD:
         from_secret: APPLE_PASSWORD
+      BUILDBOX_PASSWORD:
+        from_secret: BUILDBOX_PASSWORD
       OSS_TARBALL_PATH: /tmp/teleport-pkg-tsh/go/artifacts
     commands:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
+      # unlock login keychain
+      - security unlock-keychain -p ${BUILDBOX_PASSWORD} login.keychain
+      # show available certificates
+      - security find-identity -v
+      # build pkg
       - make pkg-tsh OS=$OS ARCH=$ARCH
 
   - name: Copy Mac tsh pkg artifacts
@@ -2386,6 +2393,6 @@ steps:
 
 ---
 kind: signature
-hmac: 8dae4cb1e37177ce9f4bfc2591081101cc89b144148f2a2f0606bc7640acf939
+hmac: b2ea442b4d92e41b7a433c75412ea4a80fbd8f2030f5963ef2ca929b695a8b72
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1578,7 +1578,7 @@ platform:
   os: darwin
   arch: amd64
 
-# TODO(gus): testing
+# TODO(gus): testing, add depends_on back
 # trigger:
 #   event:
 #     - tag
@@ -1594,9 +1594,6 @@ trigger:
       - cron
       - promote
       - rollback
-
-# depends_on:
-#   - test
 
 workspace:
   path: /tmp/tarball
@@ -1677,7 +1674,7 @@ platform:
   os: darwin
   arch: amd64
 
-# TODO(gus): testing
+# TODO(gus): testing, add depends on test
 # trigger:
 #   event:
 #     - tag
@@ -1694,13 +1691,11 @@ trigger:
       - promote
       - rollback
 
-# depends_on:
-#   - test
 depends_on:
   - build-darwin-amd64
 
 workspace:
-  path: /tmp/teleportpkg
+  path: /tmp/teleport-pkg
 
 clone:
   disable: true
@@ -1749,8 +1744,8 @@ steps:
     environment:
       OS: darwin
       ARCH: amd64
-      OSS_TARBALL_PATH: /tmp/teleportpkg/go/artifacts
-      ENT_TARBALL_PATH: /tmp/teleportpkg/go/artifacts
+      OSS_TARBALL_PATH: /tmp/teleport-pkg/go/artifacts
+      ENT_TARBALL_PATH: /tmp/teleport-pkg/go/artifacts
     commands:
       - cd go/src/github.com/gravitational/teleport
       - make pkg OS=$OS ARCH=$ARCH
@@ -1763,7 +1758,7 @@ steps:
       - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
       - find e/ -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
       # generate checksums (for mac)
-      - cd go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+      - cd go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -1794,7 +1789,7 @@ platform:
   os: darwin
   arch: amd64
 
-# TODO(gus): testing
+# TODO(gus): testing, add depends on test
 # trigger:
 #   event:
 #     - tag
@@ -1811,13 +1806,11 @@ trigger:
       - promote
       - rollback
 
-# depends_on:
-#   - test
 depends_on:
   - build-darwin-amd64
 
 workspace:
-  path: /tmp/teleportpkgtsh
+  path: /tmp/teleport-pkg-tsh
 
 clone:
   disable: true
@@ -1847,7 +1840,7 @@ steps:
       - mkdir -p go/artifacts go/cache
       - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
 
-  - name: Download built tarball artifacts from S3
+  - name: Download built tarball artifact from S3
     environment:
       AWS_S3_BUCKET:
         from_secret: AWS_S3_BUCKET
@@ -1860,7 +1853,6 @@ steps:
       - export VERSION=$(cat go/.version.txt)
       - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz go/artifacts/
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-darwin-amd64-bin.tar.gz go/artifacts/
 
   - name: Build Mac tsh pkg release artifacts
     environment:
@@ -1870,7 +1862,7 @@ steps:
         from_secret: APPLE_USERNAME
       APPLE_PASSWORD:
         from_secret: APPLE_PASSWORD
-      OSS_TARBALL_PATH: /tmp/teleportpkgtsh/go/artifacts
+      OSS_TARBALL_PATH: /tmp/teleport-pkg-tsh/go/artifacts
     commands:
       - cd go/src/github.com/gravitational/teleport
       - make pkg-tsh OS=$OS ARCH=$ARCH
@@ -1880,9 +1872,8 @@ steps:
       - cd go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
       - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
       # generate checksums (for mac)
-      - cd go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+      - cd go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -1918,7 +1909,7 @@ platform:
 environment:
   TMPDIR: /dev/shm
 
-# TODO(gus): testing
+# TODO(gus): testing, add depends on test
 # trigger:
 #   event:
 #     - tag
@@ -2377,6 +2368,6 @@ steps:
 
 ---
 kind: signature
-hmac: 38f3151fea90db7f36c5e8d1500e7d2a38eae14ac1f2c404da645a4ebefbc04d
+hmac: 9e54e0486f0dc13e65065dd47dd2a1578b975d55ba2056088b7093df9efee26d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1878,7 +1878,7 @@ steps:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
       # unlock login keychain
-      - security unlock-keychain -p $${BUILDBOX_PASSWORD} /Users/build/Library/Keychains/login.keychain-db
+      - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
       # show available certificates
       - security find-identity -v
       # build pkg
@@ -2393,6 +2393,6 @@ steps:
 
 ---
 kind: signature
-hmac: 6dcfbe256e05d1b267aed5280a1b67d670cba529936a9edf658cdaa96c3a743e
+hmac: a9811d4cb0dd48724c518927882246e7e46f8e0f1dd5bc0c72c9a8e1d192c2f0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1570,18 +1570,27 @@ platform:
   os: darwin
   arch: amd64
 
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 depends_on:
   - test
 
 workspace:
-  path: /tmp/tarball
+  path: /tmp/build-darwin-amd64
 
 clone:
   disable: true
@@ -1589,17 +1598,17 @@ clone:
 steps:
   - name: Set up exec runner storage
     commands:
-      - mkdir -p /tmp/tarball
-      - chmod -R u+rw /tmp/tarball
-      - rm -rf /tmp/tarball/go
+      - mkdir -p /tmp/build-darwin-amd64
+      - chmod -R u+rw /tmp/build-darwin-amd64
+      - rm -rf /tmp/build-darwin-amd64/go
 
   - name: Check out code
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p /tmp/tarball/go/src/github.com/gravitational/teleport
-      - cd /tmp/tarball/go/src/github.com/gravitational/teleport
+      - mkdir -p /tmp/build-darwin-amd64/go/src/github.com/gravitational/teleport
+      - cd /tmp/build-darwin-amd64/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
       # fetch enterprise submodules
@@ -1609,27 +1618,27 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p /tmp/tarball/go/artifacts /tmp/tarball/go/cache
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/tarball/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/tarball/go/.version.txt; fi; cat /tmp/tarball/go/.version.txt
+      - mkdir -p /tmp/build-darwin-amd64/go/artifacts /tmp/build-darwin-amd64/go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/build-darwin-amd64/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/build-darwin-amd64/go/.version.txt; fi; cat /tmp/build-darwin-amd64/go/.version.txt
 
   - name: Build Mac release artifacts
     environment:
-      GOPATH: /tmp/tarball/go
-      GOCACHE: /tmp/tarball/go/cache
+      GOPATH: /tmp/build-darwin-amd64/go
+      GOCACHE: /tmp/build-darwin-amd64/go/cache
       OS: darwin
       ARCH: amd64
     commands:
-      - cd /tmp/tarball/go/src/github.com/gravitational/teleport
+      - cd /tmp/build-darwin-amd64/go/src/github.com/gravitational/teleport
       - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
 
   - name: Copy Mac artifacts
     commands:
-      - cd /tmp/tarball/go/src/github.com/gravitational/teleport
+      - cd /tmp/build-darwin-amd64/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/tarball/go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/tarball/go/artifacts \;
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/build-darwin-amd64/go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/build-darwin-amd64/go/artifacts \;
       # generate checksums (for mac)
-      - cd /tmp/tarball/go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+      - cd /tmp/build-darwin-amd64/go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -1641,13 +1650,13 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - cd /tmp/tarball/go/artifacts
+      - cd /tmp/build-darwin-amd64/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
   - name: Clean up exec runner storage (post)
     commands:
-      - chmod -R u+rw /tmp/tarball
-      - rm -rf /tmp/tarball/go
+      - chmod -R u+rw /tmp/build-darwin-amd64
+      - rm -rf /tmp/build-darwin-amd64/go
 
 ---
 kind: pipeline
@@ -1661,12 +1670,21 @@ platform:
   os: darwin
   arch: amd64
 
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 depends_on:
   - build-darwin-amd64
@@ -1682,18 +1700,18 @@ steps:
     commands:
       - mkdir -p /tmp/teleport-pkg
       - chmod -R u+rw /tmp/teleport-pkg
-      - rm -rf /tmp/teleport-pkg/go
+      - rm -rf /tmp/build-darwin-amd64-pkg/go
 
   - name: Check out code
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
-      - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
+      - mkdir -p /tmp/build-darwin-amd64-pkg/go/src/github.com/gravitational/teleport
+      - cd /tmp/build-darwin-amd64-pkg/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /tmp/teleport-pkg/go/.drone_source_branch.txt
+      - echo $DRONE_SOURCE_BRANCH > /tmp/build-darwin-amd64-pkg/go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -1701,8 +1719,8 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p /tmp/teleport-pkg/go/artifacts /tmp/teleport-pkg/go/cache
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/teleport-pkg/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/teleport-pkg/go/.version.txt; fi; cat /tmp/teleport-pkg/go/.version.txt
+      - mkdir -p /tmp/build-darwin-amd64-pkg/go/artifacts /tmp/build-darwin-amd64-pkg/go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/build-darwin-amd64-pkg/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/build-darwin-amd64-pkg/go/.version.txt; fi; cat /tmp/build-darwin-amd64-pkg/go/.version.txt
 
   - name: Download built tarball artifacts from S3
     environment:
@@ -1714,32 +1732,32 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - export VERSION=$(cat /tmp/teleport-pkg/go/.version.txt)
+      - export VERSION=$(cat /tmp/build-darwin-amd64-pkg/go/.version.txt)
       - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz /tmp/teleport-pkg/go/artifacts/
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-darwin-amd64-bin.tar.gz /tmp/teleport-pkg/go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz /tmp/build-darwin-amd64-pkg/go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-darwin-amd64-bin.tar.gz /tmp/build-darwin-amd64-pkg/go/artifacts/
 
   - name: Build Mac pkg release artifacts
     environment:
       OS: darwin
       ARCH: amd64
-      OSS_TARBALL_PATH: /tmp/teleport-pkg/go/artifacts
-      ENT_TARBALL_PATH: /tmp/teleport-pkg/go/artifacts
+      OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
+      ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
     commands:
-      - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /tmp/teleport-pkg/go/.version.txt)
+      - cd /tmp/build-darwin-amd64-pkg/go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /tmp/build-darwin-amd64-pkg/go/.version.txt)
       - make pkg OS=$OS ARCH=$ARCH
 
   - name: Copy Mac pkg artifacts
     commands:
-      - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
+      - cd /tmp/build-darwin-amd64-pkg/go/src/github.com/gravitational/teleport
       # delete temporary tarball artifacts so we don't re-upload them in the next stage
-      - rm -rf /tmp/teleport-pkg/go/artifacts/*.tar.gz
+      - rm -rf /tmp/build-darwin-amd64-pkg/go/artifacts/*.tar.gz
       # copy release archives to artifact directory
-      - find build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
-      - find e/build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
+      - find build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/build-darwin-amd64-pkg/go/artifacts \;
+      - find e/build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/build-darwin-amd64-pkg/go/artifacts \;
       # generate checksums (for mac)
-      - cd /tmp/teleport-pkg/go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+      - cd /tmp/build-darwin-amd64-pkg/go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -1751,13 +1769,13 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - cd /tmp/teleport-pkg/go/artifacts
+      - cd /tmp/build-darwin-amd64-pkg/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
   - name: Clean up exec runner storage
     commands:
       - chmod -R u+rw /tmp/teleport-pkg
-      - rm -rf /tmp/teleport-pkg/go
+      - rm -rf /tmp/build-darwin-amd64-pkg/go
 
 ---
 kind: pipeline
@@ -1771,18 +1789,27 @@ platform:
   os: darwin
   arch: amd64
 
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 depends_on:
   - build-darwin-amd64
 
 workspace:
-  path: /tmp/teleport-pkg-tsh
+  path: /tmp/build-darwin-amd64-pkg-tsh
 
 clone:
   disable: true
@@ -1790,20 +1817,20 @@ clone:
 steps:
   - name: Set up exec runner storage
     commands:
-      - mkdir -p /tmp/teleport-pkg-tsh
-      - chmod -R u+rw /tmp/teleport-pkg-tsh
-      - rm -rf /tmp/teleport-pkg-tsh/go
+      - mkdir -p /tmp/build-darwin-amd64-pkg-tsh
+      - chmod -R u+rw /tmp/build-darwin-amd64-pkg-tsh
+      - rm -rf /tmp/build-darwin-amd64-pkg-tsh/go
 
   - name: Check out code
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
-      - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
+      - mkdir -p /tmp/build-darwin-amd64-pkg-tsh/go/src/github.com/gravitational/teleport
+      - cd /tmp/build-darwin-amd64-pkg-tsh/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /tmp/teleport-pkg-tsh/go/.drone_source_branch.txt
+      - echo $DRONE_SOURCE_BRANCH > /tmp/build-darwin-amd64-pkg-tsh/go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -1811,8 +1838,8 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p /tmp/teleport-pkg-tsh/go/artifacts /tmp/teleport-pkg-tsh/go/cache
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/teleport-pkg-tsh/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/teleport-pkg-tsh/go/.version.txt; fi; cat /tmp/teleport-pkg-tsh/go/.version.txt
+      - mkdir -p /tmp/build-darwin-amd64-pkg-tsh/go/artifacts /tmp/build-darwin-amd64-pkg-tsh/go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/build-darwin-amd64-pkg-tsh/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/build-darwin-amd64-pkg-tsh/go/.version.txt; fi; cat /tmp/build-darwin-amd64-pkg-tsh/go/.version.txt
 
   - name: Download built tarball artifact from S3
     environment:
@@ -1824,9 +1851,9 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - export VERSION=$(cat /tmp/teleport-pkg-tsh/go/.version.txt)
+      - export VERSION=$(cat /tmp/build-darwin-amd64-pkg-tsh/go/.version.txt)
       - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz /tmp/teleport-pkg-tsh/go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz /tmp/build-darwin-amd64-pkg-tsh/go/artifacts/
 
   - name: Build Mac tsh pkg release artifacts
     environment:
@@ -1838,9 +1865,9 @@ steps:
         from_secret: APPLE_PASSWORD
       BUILDBOX_PASSWORD:
         from_secret: BUILDBOX_PASSWORD
-      OSS_TARBALL_PATH: /tmp/teleport-pkg-tsh/go/artifacts
+      OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     commands:
-      - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
+      - cd /tmp/build-darwin-amd64-pkg-tsh/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
       # set HOME explicitly (as Drone overrides it normally)
       - export HOME=/Users/build
@@ -1853,13 +1880,13 @@ steps:
 
   - name: Copy Mac tsh pkg artifacts
     commands:
-      - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
+      - cd /tmp/build-darwin-amd64-pkg-tsh/go/src/github.com/gravitational/teleport
       # delete temporary tarball artifacts so we don't re-upload them in the next stage
-      - rm -rf /tmp/teleport-pkg-tsh/go/artifacts/*.tar.gz
+      - rm -rf /tmp/build-darwin-amd64-pkg-tsh/go/artifacts/*.tar.gz
       # copy release archives to artifact directory
-      - find build -maxdepth 1 -iname "tsh*.pkg" -print -exec cp {} /tmp/teleport-pkg-tsh/go/artifacts \;
+      - find build -maxdepth 1 -iname "tsh*.pkg" -print -exec cp {} /tmp/build-darwin-amd64-pkg-tsh/go/artifacts \;
       # generate checksums (for mac)
-      - cd /tmp/teleport-pkg-tsh/go/artifacts && for FILE in tsh*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+      - cd /tmp/build-darwin-amd64-pkg-tsh/go/artifacts && for FILE in tsh*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -1871,13 +1898,13 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - cd /tmp/teleport-pkg-tsh/go/artifacts
+      - cd /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
   - name: Clean up exec runner storage
     commands:
-      - chmod -R u+rw /tmp/teleport-pkg-tsh
-      - rm -rf /tmp/teleport-pkg-tsh/go
+      - chmod -R u+rw /tmp/build-darwin-amd64-pkg-tsh
+      - rm -rf /tmp/build-darwin-amd64-pkg-tsh/go
 
 ---
 kind: pipeline
@@ -2350,6 +2377,6 @@ steps:
 
 ---
 kind: signature
-hmac: 9c3f7a0e413d1b252160fba8cdd51e8965ac801f28145ad5b4cd76e107d98efc
+hmac: 3492260da309c84c95a5a18fb5e5d252738ca4a49f05b706c17adabfea772d33
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1759,6 +1759,8 @@ steps:
   - name: Copy Mac pkg artifacts
     commands:
       - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
+      # delete temporary tarball artifacts so we don't re-upload them in the next stage
+      - rm -rf /tmp/teleport-pkg/go/artifacts/*.tar.gz
       # copy release archives to artifact directory
       - find build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
       - find e/build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
@@ -1878,6 +1880,8 @@ steps:
   - name: Copy Mac tsh pkg artifacts
     commands:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
+      # delete temporary tarball artifacts so we don't re-upload them in the next stage
+      - rm -rf /tmp/teleport-pkg-tsh/go/artifacts/*.tar.gz
       # copy release archives to artifact directory
       - find build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg-tsh/go/artifacts \;
       # generate checksums (for mac)
@@ -2382,6 +2386,6 @@ steps:
 
 ---
 kind: signature
-hmac: ab410e59955e90816a5e8791dbf96c788ae83ea07ecf18b1c3be27304a115ef8
+hmac: 8dae4cb1e37177ce9f4bfc2591081101cc89b144148f2a2f0606bc7640acf939
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1878,8 +1878,7 @@ steps:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
       # list keychains
-      - whoami
-      - security list-keychains
+      - security list-keychains -d user -s login.keychain
       # unlock login keychain
       - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
       # show available certificates
@@ -2396,6 +2395,6 @@ steps:
 
 ---
 kind: signature
-hmac: 4e1dc27a7b6379674ef4bbc0f77149df1e8d5733f7c91adda7e5a08ff3a3b00c
+hmac: 5cbeba7ca02fb0c92f2724d9f5cbe33bb006e7ada3a868d52c4866283d6c3a73
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1755,7 +1755,6 @@ steps:
       - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat /tmp/teleport-pkg/go/.version.txt)
       - make pkg OS=$OS ARCH=$ARCH
-      - make -C e pkg OS=$OS ARCH=$ARCH
 
   - name: Copy Mac pkg artifacts
     commands:
@@ -2383,6 +2382,6 @@ steps:
 
 ---
 kind: signature
-hmac: aee66a659924d9ad42c65175bdff65d969f2876d38629c04a62f2e7349cec1af
+hmac: ae9334c1b9641af8028d66ea5a015bb7683a6213fa51c88b99f1f45bf207a7d9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,18 +66,17 @@ steps:
       - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
+    environment:
+      AWS_S3_BUCKET:
         from_secret: AWS_S3_BUCKET
-      access_key:
+      AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
+      AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG}
-      strip_prefix: /go/artifacts/
+      AWS_REGION: us-west-2
+    commands:
+      - cd /go/artifacts
+      - aws s3 . sync s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
 ---
 kind: pipeline
@@ -89,15 +88,19 @@ environment:
   UID: 1000
   GID: 1000
 
+# TOOD(gus): testing
+# trigger:
+#   branch:
+#     - master
+#     - branch/*
+#   event:
+#     exclude:
+#       - cron
+#       - promote
+#       - rollback
 trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+  cron:
+    - never
 
 workspace:
   path: /go
@@ -214,15 +217,19 @@ kind: pipeline
 type: kubernetes
 name: test-docs
 
+# TOOD(gus): testing
+# trigger:
+#   branch:
+#     - master
+#     - branch/*
+#   event:
+#     exclude:
+#       - cron
+#       - promote
+#       - rollback
 trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+  cron:
+    - never
 
 workspace:
   path: /go
@@ -2014,6 +2021,6 @@ steps:
 
 ---
 kind: signature
-hmac: 4be25d10a366a83da10ba9b4a3c0073a3ecd6bb9a621d59dadf17518fc806c0c
+hmac: 8a29abb1705ceac1a66ade938fb540252083c407f7dd59aa6c486eabcbc65f7b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,19 +8,15 @@ environment:
   UID: 1000
   GID: 1000
 
-# TOOD(gus): testing
-# trigger:
-#   branch:
-#     - master
-#     - branch/*
-#   event:
-#     exclude:
-#       - cron
-#       - promote
-#       - rollback
 trigger:
-  cron:
-    - never
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 workspace:
   path: /go
@@ -137,19 +133,15 @@ kind: pipeline
 type: kubernetes
 name: test-docs
 
-# TOOD(gus): testing
-# trigger:
-#   branch:
-#     - master
-#     - branch/*
-#   event:
-#     exclude:
-#       - cron
-#       - promote
-#       - rollback
 trigger:
-  cron:
-    - never
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 workspace:
   path: /go
@@ -1578,25 +1570,15 @@ platform:
   os: darwin
   arch: amd64
 
-# TODO(gus): testing, add depends_on back
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
 
-# depends_on:
-#   - test
+depends_on:
+  - test
 
 workspace:
   path: /tmp/tarball
@@ -1678,22 +1660,12 @@ platform:
   os: darwin
   arch: amd64
 
-# TODO(gus): testing, add depends on test
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
 
 depends_on:
   - build-darwin-amd64
@@ -1797,22 +1769,12 @@ platform:
   os: darwin
   arch: amd64
 
-# TODO(gus): testing, add depends on test
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
 
 depends_on:
   - build-darwin-amd64
@@ -1937,18 +1899,9 @@ trigger:
   ref:
     include:
       - refs/tags/v*
-# trigger:
-#   branch:
-#     - master
-#     - branch/*
-#   event:
-#     exclude:
-#       - cron
-#       - promote
-#       - rollback
 
-# depends_on:
-#   - test
+depends_on:
+  - test
 
 workspace:
   path: /dev/shm/tmp
@@ -2394,6 +2347,6 @@ steps:
 
 ---
 kind: signature
-hmac: 86adbe07fbca0bfc2ce9e04cf7c9f4047f8c8ed36eabb05e1ace37331c5e2bc6
+hmac: 33e01e87ed4040be858bcddec5e5b1ada607054afd10ad131caa37a27cf82053
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1878,7 +1878,7 @@ steps:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
       # unlock login keychain
-      - security unlock-keychain -p ${BUILDBOX_PASSWORD} login.keychain
+      - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
       # show available certificates
       - security find-identity -v
       # build pkg
@@ -2393,6 +2393,6 @@ steps:
 
 ---
 kind: signature
-hmac: b2ea442b4d92e41b7a433c75412ea4a80fbd8f2030f5963ef2ca929b695a8b72
+hmac: a9811d4cb0dd48724c518927882246e7e46f8e0f1dd5bc0c72c9a8e1d192c2f0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1595,6 +1595,9 @@ trigger:
       - promote
       - rollback
 
+# depends_on:
+#   - test
+
 workspace:
   path: /tmp/tarball
 
@@ -1604,18 +1607,17 @@ clone:
 steps:
   - name: Clean up exec runner storage (pre)
     commands:
-      - rm -rf go
+      - rm -rf /tmp/tarball/go
 
   - name: Check out code
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p go/src/github.com/gravitational/teleport
-      - cd go/src/github.com/gravitational/teleport
+      - mkdir -p /tmp/tarball/go/src/github.com/gravitational/teleport
+      - cd /tmp/tarball/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -1623,8 +1625,8 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p go/artifacts go/cache
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
+      - mkdir -p /tmp/tarball/go/artifacts /tmp/tarball/go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/tarball/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/tarball/go/.version.txt; fi; cat /tmp/tarball/go/.version.txt
 
   - name: Build Mac release artifacts
     environment:
@@ -1633,17 +1635,17 @@ steps:
       OS: darwin
       ARCH: amd64
     commands:
-      - cd go/src/github.com/gravitational/teleport
+      - cd /tmp/tarball/go/src/github.com/gravitational/teleport
       - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
 
   - name: Copy Mac artifacts
     commands:
-      - cd go/src/github.com/gravitational/teleport
+      - cd /tmp/tarball/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} go/artifacts \;
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/tarball/go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/tarball/go/artifacts \;
       # generate checksums (for mac)
-      - cd go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+      - cd /tmp/tarball/go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -1655,12 +1657,12 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - cd go/artifacts
+      - cd /tmp/tarball/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
   - name: Clean up exec runner storage (post)
     commands:
-      - rm -rf go
+      - rm -rf /tmp/tarball/go
 
 ---
 kind: pipeline
@@ -1703,18 +1705,18 @@ clone:
 steps:
   - name: Clean up exec runner storage (pre)
     commands:
-      - rm -rf go
+      - rm -rf /tmp/teleport-pkg/go
 
   - name: Check out code
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p go/src/github.com/gravitational/teleport
-      - cd go/src/github.com/gravitational/teleport
+      - mkdir -p /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
+      - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > go/.drone_source_branch.txt
+      - echo $DRONE_SOURCE_BRANCH > /tmp/teleport-pkg/go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -1722,8 +1724,8 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p go/artifacts go/cache
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
+      - mkdir -p /tmp/teleport-pkg/go/artifacts /tmp/teleport-pkg/go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/teleport-pkg/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/teleport-pkg/go/.version.txt; fi; cat /tmp/teleport-pkg/go/.version.txt
 
   - name: Download built tarball artifacts from S3
     environment:
@@ -1735,10 +1737,10 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - export VERSION=$(cat go/.version.txt)
+      - export VERSION=$(cat /tmp/teleport-pkg/go/.version.txt)
       - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz go/artifacts/
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-darwin-amd64-bin.tar.gz go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz /tmp/teleport-pkg/go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-darwin-amd64-bin.tar.gz /tmp/teleport-pkg/go/artifacts/
 
   - name: Build Mac pkg release artifacts
     environment:
@@ -1747,18 +1749,18 @@ steps:
       OSS_TARBALL_PATH: /tmp/teleport-pkg/go/artifacts
       ENT_TARBALL_PATH: /tmp/teleport-pkg/go/artifacts
     commands:
-      - cd go/src/github.com/gravitational/teleport
+      - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
       - make pkg OS=$OS ARCH=$ARCH
       - make -C e pkg OS=$OS ARCH=$ARCH
 
   - name: Copy Mac pkg artifacts
     commands:
-      - cd go/src/github.com/gravitational/teleport
+      - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
+      - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg/go/artifacts \;
       # generate checksums (for mac)
-      - cd go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+      - cd /tmp/teleport-pkg/go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -1770,12 +1772,12 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - cd go/artifacts
+      - cd /tmp/teleport-pkg/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
   - name: Clean up exec runner storage (post)
     commands:
-      - rm -rf go
+      - rm -rf /tmp/teleport-pkg/go
 
 ---
 kind: pipeline
@@ -1818,18 +1820,18 @@ clone:
 steps:
   - name: Clean up exec runner storage (pre)
     commands:
-      - rm -rf go
+      - rm -rf /tmp/teleport-pkg-tsh/go
 
   - name: Check out code
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p go/src/github.com/gravitational/teleport
-      - cd go/src/github.com/gravitational/teleport
+      - mkdir -p /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
+      - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > go/.drone_source_branch.txt
+      - echo $DRONE_SOURCE_BRANCH > /tmp/teleport-pkg-tsh/go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -1837,8 +1839,8 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p go/artifacts go/cache
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
+      - mkdir -p /tmp/teleport-pkg-tsh/go/artifacts /tmp/teleport-pkg-tsh/go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/teleport-pkg-tsh/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/teleport-pkg-tsh/go/.version.txt; fi; cat /tmp/teleport-pkg-tsh/go/.version.txt
 
   - name: Download built tarball artifact from S3
     environment:
@@ -1850,9 +1852,9 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - export VERSION=$(cat go/.version.txt)
+      - export VERSION=$(cat /tmp/teleport-pkg-tsh/go/.version.txt)
       - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz /tmp/teleport-pkg-tsh/go/artifacts/
 
   - name: Build Mac tsh pkg release artifacts
     environment:
@@ -1864,16 +1866,16 @@ steps:
         from_secret: APPLE_PASSWORD
       OSS_TARBALL_PATH: /tmp/teleport-pkg-tsh/go/artifacts
     commands:
-      - cd go/src/github.com/gravitational/teleport
+      - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       - make pkg-tsh OS=$OS ARCH=$ARCH
 
   - name: Copy Mac tsh pkg artifacts
     commands:
-      - cd go/src/github.com/gravitational/teleport
+      - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} go/artifacts \;
+      - find . -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/teleport-pkg-tsh/go/artifacts \;
       # generate checksums (for mac)
-      - cd go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
+      - cd /tmp/teleport-pkg-tsh/go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -1885,12 +1887,12 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - cd go/artifacts
+      - cd /tmp/teleport-pkg-tsh/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
   - name: Clean up exec runner storage (post)
     commands:
-      - rm -rf go
+      - rm -rf /tmp/teleport-pkg-tsh/go
 
 ---
 kind: pipeline
@@ -1926,6 +1928,9 @@ trigger:
       - promote
       - rollback
 
+# depends_on:
+#   - test
+
 workspace:
   path: /dev/shm/tmp
 
@@ -1935,18 +1940,18 @@ clone:
 steps:
   - name: Clean up exec runner storage (pre)
     commands:
-      - rm -rf go
+      - rm -rf /dev/shm/tmp/go
 
   - name: Check out code
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p go/src/github.com/gravitational/teleport
-      - cd go/src/github.com/gravitational/teleport
+      - mkdir -p /dev/shm/tmp/go/src/github.com/gravitational/teleport
+      - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > go/.drone_source_branch.txt
+      - echo $DRONE_SOURCE_BRANCH > /dev/shm/tmp/go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -1954,8 +1959,8 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p go/artifacts go/cache
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
+      - mkdir -p /dev/shm/tmp/go/artifacts /dev/shm/tmp/go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /dev/shm/tmp/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /dev/shm/tmp/go/.version.txt; fi; cat /dev/shm/tmp/go/.version.txt
 
   - name: Build ARM release artifacts
     environment:
@@ -1964,17 +1969,17 @@ steps:
       OS: linux
       ARCH: arm
     commands:
-      - cd go/src/github.com/gravitational/teleport
+      - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
       - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
 
   - name: Copy ARM artifacts
     commands:
-      - cd go/src/github.com/gravitational/teleport
+      - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} go/artifacts \;
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /dev/shm/tmp/go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /dev/shm/tmp/go/artifacts \;
       # generate checksums
-      - cd go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+      - cd /dev/shm/tmp/go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -1986,12 +1991,12 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - cd go/artifacts
+      - cd /dev/shm/tmp/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
   - name: Clean up exec runner storage (post)
     commands:
-      - rm -rf go
+      - rm -rf /dev/shm/tmp/go
 
 ---
 kind: pipeline
@@ -2368,6 +2373,6 @@ steps:
 
 ---
 kind: signature
-hmac: 67acf7e3d9af161db5ce30da4b543f26381178b956e53c597acdb902a94020f3
+hmac: cf01d9ed48a432879b9194c5d55bdbf8bdc5cd3869cc56c2675a7cd3a8843c16
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p /tmp/go/cache
+      - mkdir -p /tmp/go/cache /tmp/go/artifacts
       - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/go/.version.txt; fi; cat /tmp/go/.version.txt
 
   - name: Build Mac release artifacts
@@ -64,10 +64,11 @@ steps:
     commands:
       - cd /tmp/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
+      - mkdir -p /tmp/go/artifacts
       - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
       - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
-      # generate checksums
-      - cd /tmp/go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+      # generate checksums (for mac)
+      - cd /tmp/go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -2025,6 +2026,6 @@ steps:
 
 ---
 kind: signature
-hmac: f23284cd4d009d727e861741114ce9488d3287aecb56ad266469759e64437b91
+hmac: 0c6c6a0bd0e1fb67efcd8b18319fc10b1a871d569481912277e963b0bf5cd444
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,9 @@ kind: pipeline
 type: exec
 name: mac-test
 
+concurrency:
+  limit: 1
+
 platform:
   os: darwin
   arch: amd64
@@ -24,9 +27,9 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner
+  - name: Clean up exec runner storage
     commands:
-      - rm -rf /tmp/go/src /tmp/go/artifacts /tmp/go/.*.txt
+      - rm -rf /tmp/go/artifacts /tmp/go/cache /tmp/go/src /tmp/go/.*.txt
 
   - name: Check out code
     environment:
@@ -45,12 +48,13 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p /tmp/go/cache /tmp/go/artifacts
+      - mkdir -p /tmp/go/artifacts /tmp/go/cache
       - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/go/.version.txt; fi; cat /tmp/go/.version.txt
 
   - name: Build Mac release artifacts
     environment:
       GOPATH: /tmp/go
+      GOCACHE: /tmp/go/cache
       OS: darwin
       ARCH: amd64
     commands:
@@ -85,9 +89,17 @@ kind: pipeline
 type: exec
 name: arm-test
 
+concurrency:
+  limit: 1
+
 platform:
   os: linux
   arch: arm
+
+# use ramfs for go build cache
+# saves wear and tear on the SD card, plus it's faster
+environment:
+  TMPDIR: /dev/shm
 
 trigger:
   branch:
@@ -100,7 +112,7 @@ trigger:
       - rollback
 
 workspace:
-  path: /tmp/go
+  path: /dev/shm/tmp/go
 
 clone:
   disable: true
@@ -108,18 +120,18 @@ clone:
 steps:
   - name: Clean up exec runner
     commands:
-      - rm -rf /tmp/go/src /tmp/go/artifacts /tmp/go/.*.txt
+      - rm -rf /dev/shm/tmp/go/artifacts /dev/shm/tmp/go/cache /dev/shm/tmp/go/src /dev/shm/tmp/go/.*.txt
 
   - name: Check out code
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p /tmp/go/src/github.com/gravitational/teleport
-      - cd /tmp/go/src/github.com/gravitational/teleport
+      - mkdir -p /dev/shm/tmp/go/src/github.com/gravitational/teleport
+      - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /tmp/go/.drone_source_branch.txt
+      - echo $DRONE_SOURCE_BRANCH > /dev/shm/tmp/go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -127,27 +139,28 @@ steps:
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
       - rm -f ~/.ssh/id_rsa
-      - mkdir -p /tmp/go/cache /tmp/go/artifacts
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/go/.version.txt; fi; cat /tmp/go/.version.txt
+      - mkdir -p /dev/shm/tmp/go/cache /dev/shm/tmp/go/artifacts
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /dev/shm/tmp/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /dev/shm/tmp/go/.version.txt; fi; cat /dev/shm/tmp/go/.version.txt
 
-  - name: Build Mac release artifacts
+  - name: Build ARM release artifacts
     environment:
-      GOPATH: /tmp/go
+      GOPATH: /dev/shm/tmp/go
+      GOCACHE: /dev/shm/tmp/go/cache
       OS: linux
       ARCH: arm
     commands:
-      - cd /tmp/go/src/github.com/gravitational/teleport
+      - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
       - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
 
-  - name: Copy Mac artifacts
+  - name: Copy ARM artifacts
     commands:
-      - cd /tmp/go/src/github.com/gravitational/teleport
+      - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - mkdir -p /tmp/go/artifacts
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
-      # generate checksums (for mac)
-      - cd /tmp/go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+      - mkdir -p /dev/shm/tmp/go/artifacts
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /dev/shm/tmp/go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /dev/shm/tmp/go/artifacts \;
+      # generate checksums
+      - cd /dev/shm/tmp/go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -159,8 +172,13 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - cd /tmp/go/artifacts
+      - cd /dev/shm/tmp/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
+
+  # arm-specific step to avoid wasting RAM
+  - name: Clean up ramfs
+    commands:
+      - rm -rf /dev/shm/tmp
 
 ---
 kind: pipeline
@@ -2105,6 +2123,6 @@ steps:
 
 ---
 kind: signature
-hmac: cb065c51e4288414d02f512c9c5b48961c43535e6324457c64d4b8e90c9b8f95
+hmac: 557275bfb86209e682f80e69bbe97705a159e58fb6e01aaf2c3321e2e95e77cb
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -112,7 +112,7 @@ trigger:
       - rollback
 
 workspace:
-  path: /dev/shm/tmp/go
+  path: /dev/shm/tmp
 
 clone:
   disable: true
@@ -2123,6 +2123,6 @@ steps:
 
 ---
 kind: signature
-hmac: 0e8101913647453cfb16b41aa592a375f8c919c6d79aa73b7335735ccd3afdcc
+hmac: 74a433c3fce0c2027bd3b5e2cfc135e21cf03b26ad461d75327fd1b23d987cdd
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1665,7 +1665,7 @@ steps:
 ---
 kind: pipeline
 type: exec
-name: build-darwin-amd64-pkg
+name: build-darwin-pkg
 
 concurrency:
   limit: 1
@@ -1780,7 +1780,7 @@ steps:
 ---
 kind: pipeline
 type: exec
-name: build-darwin-amd64-pkg-tsh
+name: build-darwin-tsh
 
 concurrency:
   limit: 1
@@ -2368,6 +2368,6 @@ steps:
 
 ---
 kind: signature
-hmac: 9e54e0486f0dc13e65065dd47dd2a1578b975d55ba2056088b7093df9efee26d
+hmac: 156b5734379b049ef93d524fc0161f106760711d22436b3f28d2761f4985163b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -178,7 +178,7 @@ steps:
   # arm-specific step to avoid wasting RAM
   - name: Clean up ramfs
     commands:
-      - rm -rf /dev/shm/tmp
+      - rm -rf /dev/shm/tmp/go
 
 ---
 kind: pipeline
@@ -2123,6 +2123,6 @@ steps:
 
 ---
 kind: signature
-hmac: 557275bfb86209e682f80e69bbe97705a159e58fb6e01aaf2c3321e2e95e77cb
+hmac: 0e8101913647453cfb16b41aa592a375f8c919c6d79aa73b7335735ccd3afdcc
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,86 @@
 ---
 kind: pipeline
+type: exec
+name: mac-test
+
+platform:
+  os: darwin
+  arch: amd64
+
+environment:
+  RUNTIME: go1.13.2
+
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git clone https://github.com/gravitational/teleport.git .
+      - git checkout $DRONE_COMMIT
+      - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
+      # fetch enterprise submodules
+      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      - mkdir -p /go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Build Mac release artifacts
+    environment:
+      GOPATH: /go
+      OS: darwin
+      ARCH: amd64
+    commands:
+      - cd /go/src/github.com/gravitational/teleport
+      - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
+
+  - name: Copy Mac artifacts
+    commands:
+      - cd /go/src/github.com/gravitational/teleport
+      # copy release archives to artifact directory
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+      # generate checksums
+      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+
+  - name: Upload to S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: AWS_S3_BUCKET
+      access_key:
+        from_secret: AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      region: us-west-2
+      source: /go/artifacts/*
+      target: teleport/tag/${DRONE_TAG}
+      strip_prefix: /go/artifacts/
+
+---
+kind: pipeline
 type: kubernetes
 name: test
 
@@ -1933,6 +2014,6 @@ steps:
 
 ---
 kind: signature
-hmac: 018dc8d3cc72a5d7ec9db88441ebfe7eb73c4191c7beae2250109c1f27c591f9
+hmac: 4be25d10a366a83da10ba9b4a3c0073a3ecd6bb9a621d59dadf17518fc806c0c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1753,6 +1753,7 @@ steps:
       ENT_TARBALL_PATH: /tmp/teleport-pkg/go/artifacts
     commands:
       - cd /tmp/teleport-pkg/go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /tmp/teleport-pkg/go/.version.txt)
       - make pkg OS=$OS ARCH=$ARCH
       - make -C e pkg OS=$OS ARCH=$ARCH
 
@@ -1872,6 +1873,7 @@ steps:
       OSS_TARBALL_PATH: /tmp/teleport-pkg-tsh/go/artifacts
     commands:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
       - make pkg-tsh OS=$OS ARCH=$ARCH
 
   - name: Copy Mac tsh pkg artifacts
@@ -2381,6 +2383,6 @@ steps:
 
 ---
 kind: signature
-hmac: af2ba0a74b925140c84e0e5fb864c543cb44a4db92d1a4d983784925000692eb
+hmac: aee66a659924d9ad42c65175bdff65d969f2876d38629c04a62f2e7349cec1af
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1605,8 +1605,9 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (pre)
     commands:
+      - chmod -R u+rw /tmp/tarball/go
       - rm -rf /tmp/tarball/go
 
   - name: Check out code
@@ -1660,6 +1661,11 @@ steps:
       - cd /tmp/tarball/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
+  - name: Clean up exec runner storage (post)
+    commands:
+      - chmod -R u+rw /tmp/tarball/go
+      - rm -rf /tmp/tarball/go
+
 ---
 kind: pipeline
 type: exec
@@ -1699,8 +1705,9 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (pre)
     commands:
+      - chmod -R u+rw /tmp/teleport-pkg/go
       - rm -rf /tmp/teleport-pkg/go
 
   - name: Check out code
@@ -1771,6 +1778,11 @@ steps:
       - cd /tmp/teleport-pkg/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
+  - name: Clean up exec runner storage (post)
+    commands:
+      - chmod -R u+rw /tmp/teleport-pkg/go
+      - rm -rf /tmp/teleport-pkg/go
+
 ---
 kind: pipeline
 type: exec
@@ -1810,8 +1822,9 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (pre)
     commands:
+      - chmod -R u+rw /tmp/teleport-pkg-tsh/go
       - rm -rf /tmp/teleport-pkg-tsh/go
 
   - name: Check out code
@@ -1882,6 +1895,11 @@ steps:
       - cd /tmp/teleport-pkg-tsh/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
+  - name: Clean up exec runner storage (post)
+    commands:
+      - chmod -R u+rw /tmp/teleport-pkg-tsh/go
+      - rm -rf /tmp/teleport-pkg-tsh/go
+
 ---
 kind: pipeline
 type: exec
@@ -1926,8 +1944,9 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (pre)
     commands:
+      - chmod -R u+rw /dev/shm/tmp/go
       - rm -rf /dev/shm/tmp/go
 
   - name: Check out code
@@ -1981,6 +2000,11 @@ steps:
     commands:
       - cd /dev/shm/tmp/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
+
+  - name: Clean up exec runner storage (post)
+    commands:
+      - chmod -R u+rw /dev/shm/tmp/go
+      - rm -rf /dev/shm/tmp/go
 
 ---
 kind: pipeline
@@ -2357,6 +2381,6 @@ steps:
 
 ---
 kind: signature
-hmac: 8673b1b23b7f30328e9fbc4d6c5b6a9535bd0a881156c1a694a1f55ef10adcb6
+hmac: dded50c0841689a0b070940837ded012f33cc88fb8fce4ecbd3f5dfa6a10c922
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1696,6 +1696,8 @@ trigger:
 
 # depends_on:
 #   - test
+depends_on:
+  - build-darwin-amd64
 
 workspace:
   path: /tmp/teleportpkg
@@ -1728,12 +1730,27 @@ steps:
       - mkdir -p go/artifacts go/cache
       - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
 
+  - name: Download built tarball artifacts from S3
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat go/.version.txt)
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-darwin-amd64-bin.tar.gz go/artifacts/
+
   - name: Build Mac pkg release artifacts
     environment:
-      GOPATH: /tmp/teleportpkg/go
-      GOCACHE: /tmp/teleportpkg/go/cache
       OS: darwin
       ARCH: amd64
+      OSS_TARBALL_PATH: /tmp/teleportpkg/go/artifacts
+      ENT_TARBALL_PATH: /tmp/teleportpkg/go/artifacts
     commands:
       - cd go/src/github.com/gravitational/teleport
       - make pkg OS=$OS ARCH=$ARCH
@@ -1796,6 +1813,8 @@ trigger:
 
 # depends_on:
 #   - test
+depends_on:
+  - build-darwin-amd64
 
 workspace:
   path: /tmp/teleportpkgtsh
@@ -1828,6 +1847,21 @@ steps:
       - mkdir -p go/artifacts go/cache
       - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > go/.version.txt; fi; cat go/.version.txt
 
+  - name: Download built tarball artifacts from S3
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat go/.version.txt)
+      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG}/"; else export S3_PATH="tag/"; fi
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-darwin-amd64-bin.tar.gz go/artifacts/
+      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-darwin-amd64-bin.tar.gz go/artifacts/
+
   - name: Build Mac tsh pkg release artifacts
     environment:
       OS: darwin
@@ -1836,6 +1870,7 @@ steps:
         from_secret: APPLE_USERNAME
       APPLE_PASSWORD:
         from_secret: APPLE_PASSWORD
+      OSS_TARBALL_PATH: /tmp/teleportpkgtsh/go/artifacts
     commands:
       - cd go/src/github.com/gravitational/teleport
       - make pkg-tsh OS=$OS ARCH=$ARCH
@@ -2342,6 +2377,6 @@ steps:
 
 ---
 kind: signature
-hmac: c6480a59aa3194d7980c8d97f90a8d34a80a8ae8f788b171f4c9b2c789cfe0e1
+hmac: 38f3151fea90db7f36c5e8d1500e7d2a38eae14ac1f2c404da645a4ebefbc04d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1605,7 +1605,7 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage (pre)
+  - name: Clean up exec runner storage
     commands:
       - rm -rf /tmp/tarball/go
 
@@ -1660,11 +1660,6 @@ steps:
       - cd /tmp/tarball/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
-  - name: Clean up exec runner storage (post)
-    commands:
-      - cd /tmp
-      - rm -rf /tmp/tarball/go
-
 ---
 kind: pipeline
 type: exec
@@ -1704,7 +1699,7 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage (pre)
+  - name: Clean up exec runner storage
     commands:
       - rm -rf /tmp/teleport-pkg/go
 
@@ -1776,11 +1771,6 @@ steps:
       - cd /tmp/teleport-pkg/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
-  - name: Clean up exec runner storage (post)
-    commands:
-      - cd /tmp
-      - rm -rf /tmp/teleport-pkg/go
-
 ---
 kind: pipeline
 type: exec
@@ -1820,7 +1810,7 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage (pre)
+  - name: Clean up exec runner storage
     commands:
       - rm -rf /tmp/teleport-pkg-tsh/go
 
@@ -1892,11 +1882,6 @@ steps:
       - cd /tmp/teleport-pkg-tsh/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
-  - name: Clean up exec runner storage (post)
-    commands:
-      - cd /tmp
-      - rm -rf /tmp/teleport-pkg-tsh/go
-
 ---
 kind: pipeline
 type: exec
@@ -1941,7 +1926,7 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage (pre)
+  - name: Clean up exec runner storage
     commands:
       - rm -rf /dev/shm/tmp/go
 
@@ -1996,11 +1981,6 @@ steps:
     commands:
       - cd /dev/shm/tmp/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
-
-  - name: Clean up exec runner storage (post)
-    commands:
-      - cd /tmp
-      - rm -rf /dev/shm/tmp/go
 
 ---
 kind: pipeline
@@ -2377,6 +2357,6 @@ steps:
 
 ---
 kind: signature
-hmac: 9a1fe55fbd3bb2e4f4cf7f2513bb061e7444d3bfdbbf222e3b10592f71e40f5d
+hmac: 8673b1b23b7f30328e9fbc4d6c5b6a9535bd0a881156c1a694a1f55ef10adcb6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1691,8 +1691,8 @@ trigger:
       - promote
       - rollback
 
-# depends_on:
-#   - build-darwin-amd64
+depends_on:
+  - build-darwin-amd64
 
 workspace:
   path: /tmp/teleport-pkg
@@ -1701,7 +1701,7 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (pre)
     commands:
       - rm -rf go
 
@@ -1773,7 +1773,7 @@ steps:
       - cd go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (post)
     commands:
       - rm -rf go
 
@@ -1806,8 +1806,8 @@ trigger:
       - promote
       - rollback
 
-# depends_on:
-#   - build-darwin-amd64
+depends_on:
+  - build-darwin-amd64
 
 workspace:
   path: /tmp/teleport-pkg-tsh
@@ -1816,7 +1816,7 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (pre)
     commands:
       - rm -rf go
 
@@ -1888,7 +1888,7 @@ steps:
       - cd go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
-  - name: Clean up exec runner storage
+  - name: Clean up exec runner storage (post)
     commands:
       - rm -rf go
 
@@ -2368,6 +2368,6 @@ steps:
 
 ---
 kind: signature
-hmac: f3744c79396aaea4dcca2ef55d3b5cda2037baa22e160f248ba68fd36e8c03d8
+hmac: 3550babe2bfca1c550da6f009d7244a616d8617afb96abafb3270dc6ebce6012
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,49 +21,53 @@ trigger:
       - rollback
 
 workspace:
-  path: /go
+  path: /tmp/go
 
 clone:
   disable: true
 
 steps:
+  - name: Clean up exec runner
+    commands:
+      - rm -rf /tmp/go/src /tmp/go/artifacts /tmp/go/.*.txt
+
   - name: Check out code
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
+      - mkdir -p /tmp/go/src/github.com/gravitational/teleport
+      - cd /tmp/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
+      - echo $DRONE_SOURCE_BRANCH > /tmp/go/.drone_source_branch.txt
       # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
+      - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
       - git submodule update --init e
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      - mkdir -p /go/cache
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+      - rm -f ~/.ssh/id_rsa
+      - mkdir -p /tmp/go/cache
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG}" > /tmp/go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /tmp/go/.version.txt; fi; cat /tmp/go/.version.txt
 
   - name: Build Mac release artifacts
     environment:
-      GOPATH: /go
+      GOPATH: /tmp/go
       OS: darwin
       ARCH: amd64
     commands:
-      - cd /go/src/github.com/gravitational/teleport
+      - cd /tmp/go/src/github.com/gravitational/teleport
       - make clean release OS=$OS ARCH=$ARCH RUNTIME=$RUNTIME
 
   - name: Copy Mac artifacts
     commands:
-      - cd /go/src/github.com/gravitational/teleport
+      - cd /tmp/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
+      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/go/artifacts \;
       # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+      - cd /tmp/go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 
   - name: Upload to S3
     environment:
@@ -75,7 +79,7 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - cd /go/artifacts
+      - cd /tmp/go/artifacts
       - aws s3 . sync s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
 ---
@@ -2021,6 +2025,6 @@ steps:
 
 ---
 kind: signature
-hmac: 8a29abb1705ceac1a66ade938fb540252083c407f7dd59aa6c486eabcbc65f7b
+hmac: f23284cd4d009d727e861741114ce9488d3287aecb56ad266469759e64437b91
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1878,7 +1878,7 @@ steps:
       - cd /tmp/teleport-pkg-tsh/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
       # unlock login keychain
-      - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
+      - security unlock-keychain -p $${BUILDBOX_PASSWORD} /Users/build/Library/Keychains/login.keychain-db
       # show available certificates
       - security find-identity -v
       # build pkg
@@ -2393,6 +2393,6 @@ steps:
 
 ---
 kind: signature
-hmac: a9811d4cb0dd48724c518927882246e7e46f8e0f1dd5bc0c72c9a8e1d192c2f0
+hmac: 6dcfbe256e05d1b267aed5280a1b67d670cba529936a9edf658cdaa96c3a743e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1570,15 +1570,24 @@ platform:
   os: darwin
   arch: amd64
 
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
-depends_on:
-  - test
+# depends_on:
+#   - test
 
 workspace:
   path: /tmp/tarball
@@ -1587,8 +1596,9 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage (pre)
+  - name: Set up exec runner storage
     commands:
+      - mkdir -p /tmp/tarball
       - chmod -R u+rw /tmp/tarball
       - rm -rf /tmp/tarball/go
 
@@ -1660,12 +1670,21 @@ platform:
   os: darwin
   arch: amd64
 
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 depends_on:
   - build-darwin-amd64
@@ -1677,8 +1696,9 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage (pre)
+  - name: Set up exec runner storage
     commands:
+      - mkdir -p /tmp/teleport-pkg
       - chmod -R u+rw /tmp/teleport-pkg
       - rm -rf /tmp/teleport-pkg/go
 
@@ -1752,7 +1772,7 @@ steps:
       - cd /tmp/teleport-pkg/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
-  - name: Clean up exec runner storage (post)
+  - name: Clean up exec runner storage
     commands:
       - chmod -R u+rw /tmp/teleport-pkg
       - rm -rf /tmp/teleport-pkg/go
@@ -1769,12 +1789,21 @@ platform:
   os: darwin
   arch: amd64
 
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 depends_on:
   - build-darwin-amd64
@@ -1786,8 +1815,9 @@ clone:
   disable: true
 
 steps:
-  - name: Clean up exec runner storage (pre)
+  - name: Set up exec runner storage
     commands:
+      - mkdir -p /tmp/teleport-pkg-tsh
       - chmod -R u+rw /tmp/teleport-pkg-tsh
       - rm -rf /tmp/teleport-pkg-tsh/go
 
@@ -1871,7 +1901,7 @@ steps:
       - cd /tmp/teleport-pkg-tsh/go/artifacts
       - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/$DRONE_TAG
 
-  - name: Clean up exec runner storage (post)
+  - name: Clean up exec runner storage
     commands:
       - chmod -R u+rw /tmp/teleport-pkg-tsh
       - rm -rf /tmp/teleport-pkg-tsh/go
@@ -2347,6 +2377,6 @@ steps:
 
 ---
 kind: signature
-hmac: 33e01e87ed4040be858bcddec5e5b1ada607054afd10ad131caa37a27cf82053
+hmac: b7fef605f7f6e34eeea8fc1691eb02d4777af78c45f00ae4a110b8e6ea0b3630
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1665,7 +1665,7 @@ steps:
 ---
 kind: pipeline
 type: exec
-name: build-darwin-pkg
+name: build-darwin-amd64-pkg
 
 concurrency:
   limit: 1
@@ -1691,8 +1691,8 @@ trigger:
       - promote
       - rollback
 
-depends_on:
-  - build-darwin-amd64
+# depends_on:
+#   - build-darwin-amd64
 
 workspace:
   path: /tmp/teleport-pkg
@@ -1780,7 +1780,7 @@ steps:
 ---
 kind: pipeline
 type: exec
-name: build-darwin-tsh
+name: build-darwin-amd64-pkg-tsh
 
 concurrency:
   limit: 1
@@ -1806,8 +1806,8 @@ trigger:
       - promote
       - rollback
 
-depends_on:
-  - build-darwin-amd64
+# depends_on:
+#   - build-darwin-amd64
 
 workspace:
   path: /tmp/teleport-pkg-tsh
@@ -2368,6 +2368,6 @@ steps:
 
 ---
 kind: signature
-hmac: 156b5734379b049ef93d524fc0161f106760711d22436b3f28d2761f4985163b
+hmac: f3744c79396aaea4dcca2ef55d3b5cda2037baa22e160f248ba68fd36e8c03d8
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1931,22 +1931,21 @@ platform:
 environment:
   TMPDIR: /dev/shm
 
-# TODO(gus): testing, add depends on test
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+# trigger:
+#   branch:
+#     - master
+#     - branch/*
+#   event:
+#     exclude:
+#       - cron
+#       - promote
+#       - rollback
 
 # depends_on:
 #   - test
@@ -2395,6 +2394,6 @@ steps:
 
 ---
 kind: signature
-hmac: a550ded35e4cd3a3f4ce6380d65782a38d9412b28743a05c02ba5da3cd66aae0
+hmac: 86adbe07fbca0bfc2ce9e04cf7c9f4047f8c8ed36eabb05e1ace37331c5e2bc6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1576,6 +1576,9 @@ trigger:
   ref:
     include:
       - refs/tags/v*
+  repo:
+    include:
+      - gravitational/*
 
 depends_on:
   - test
@@ -1667,6 +1670,9 @@ trigger:
   ref:
     include:
       - refs/tags/v*
+  repo:
+    include:
+      - gravitational/*
 
 depends_on:
   - build-darwin-amd64
@@ -1777,6 +1783,9 @@ trigger:
   ref:
     include:
       - refs/tags/v*
+  repo:
+    include:
+      - gravitational/*
 
 depends_on:
   - build-darwin-amd64
@@ -1841,7 +1850,7 @@ steps:
       OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
     commands:
       - cd /tmp/build-darwin-amd64-pkg-tsh/go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat tmp/teleport-pkg-tsh/go/.version.txt)
+      - export VERSION=$(cat /tmp/build-darwin-amd64-pkg-tsh/go/.version.txt)
       # set HOME explicitly (as Drone overrides it normally)
       - export HOME=/Users/build
       # unlock login keychain
@@ -1902,6 +1911,9 @@ trigger:
   ref:
     include:
       - refs/tags/v*
+  repo:
+    include:
+      - gravitational/*
 
 depends_on:
   - test
@@ -2350,6 +2362,6 @@ steps:
 
 ---
 kind: signature
-hmac: daf7a1bc352cabcb4c4ac54bf5d879f2bf69ac093d94ddaf6cb2c847e13e393c
+hmac: f3225fcf25d1a6893b79e3dd4282c9058a57a8f27743c86da571f6129ecaaa46
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1570,15 +1570,25 @@ platform:
   os: darwin
   arch: amd64
 
+# TODO(gus): replace trigger, commented for testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+#   repo:
+#     include:
+#       - gravitational/*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
-  repo:
-    include:
-      - gravitational/*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 depends_on:
   - test
@@ -1629,8 +1639,8 @@ steps:
     commands:
       - cd /tmp/build-darwin-amd64/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/build-darwin-amd64/go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /tmp/build-darwin-amd64/go/artifacts \;
+      - cp teleport*.tar.gz /tmp/build-darwin-amd64/go/artifacts
+      - cp e/teleport-ent*.tar.gz /tmp/build-darwin-amd64/go/artifacts
       # generate checksums (for mac)
       - cd /tmp/build-darwin-amd64/go/artifacts && for FILE in teleport*.tar.gz; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
@@ -1664,15 +1674,25 @@ platform:
   os: darwin
   arch: amd64
 
+# TODO(gus): replace trigger, commented for testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+#   repo:
+#     include:
+#       - gravitational/*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
-  repo:
-    include:
-      - gravitational/*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 depends_on:
   - build-darwin-amd64
@@ -1742,8 +1762,8 @@ steps:
       # delete temporary tarball artifacts so we don't re-upload them in the next stage
       - rm -rf /tmp/build-darwin-amd64-pkg/go/artifacts/*.tar.gz
       # copy release archives to artifact directory
-      - find build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/build-darwin-amd64-pkg/go/artifacts \;
-      - find e/build -maxdepth 1 -iname "teleport*.pkg" -print -exec cp {} /tmp/build-darwin-amd64-pkg/go/artifacts \;
+      - cp build/teleport*.pkg /tmp/build-darwin-amd64-pkg/go/artifacts
+      - cp e/build/teleport-ent*.pkg /tmp/build-darwin-amd64-pkg/go/artifacts
       # generate checksums (for mac)
       - cd /tmp/build-darwin-amd64-pkg/go/artifacts && for FILE in teleport*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
@@ -1775,17 +1795,27 @@ concurrency:
 
 platform:
   os: darwin
-  arch: amd64
+  arch: amd
 
+# TODO(gus): replace trigger, commented for testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+#   repo:
+#     include:
+#       - gravitational/*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
-  repo:
-    include:
-      - gravitational/*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 depends_on:
   - build-darwin-amd64
@@ -1866,7 +1896,7 @@ steps:
       # delete temporary tarball artifacts so we don't re-upload them in the next stage
       - rm -rf /tmp/build-darwin-amd64-pkg-tsh/go/artifacts/*.tar.gz
       # copy release archives to artifact directory
-      - find build -maxdepth 1 -iname "tsh*.pkg" -print -exec cp {} /tmp/build-darwin-amd64-pkg-tsh/go/artifacts \;
+      - cp build/tsh*.pkg /tmp/build-darwin-amd64-pkg-tsh/go/artifacts
       # generate checksums (for mac)
       - cd /tmp/build-darwin-amd64-pkg-tsh/go/artifacts && for FILE in tsh*.pkg; do shasum -a 256 $FILE > $FILE.sha256; done && ls -l
 
@@ -1905,15 +1935,25 @@ platform:
 environment:
   TMPDIR: /dev/shm
 
+# TODO(gus): replace trigger, commented for testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+#   repo:
+#     include:
+#       - gravitational/*
 trigger:
+  branch:
+    - master
+    - branch/*
   event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
-  repo:
-    include:
-      - gravitational/*
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 depends_on:
   - test
@@ -1964,8 +2004,8 @@ steps:
     commands:
       - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /dev/shm/tmp/go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /dev/shm/tmp/go/artifacts \;
+      - cp teleport*.tar.gz /dev/shm/tmp/go/artifacts
+      - cp e/teleport-ent*.tar.gz" /dev/shm/tmp/go/artifacts
       # generate checksums
       - cd /dev/shm/tmp/go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 
@@ -2362,6 +2402,6 @@ steps:
 
 ---
 kind: signature
-hmac: f3225fcf25d1a6893b79e3dd4282c9058a57a8f27743c86da571f6129ecaaa46
+hmac: b0111607db2f98a2172cffc50252d1808c62ff81b0f9fd514aac52fd7b307d46
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,15 +8,19 @@ environment:
   UID: 1000
   GID: 1000
 
+# TODO(gus): restore triggers, commented for testing
+# trigger:
+#   branch:
+#     - master
+#     - branch/*
+#   event:
+#     exclude:
+#       - cron
+#       - promote
+#       - rollback
 trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+  cron:
+    - never
 
 workspace:
   path: /go
@@ -133,15 +137,19 @@ kind: pipeline
 type: kubernetes
 name: test-docs
 
+# TODO(gus): restore triggers, commented for testing
+# trigger:
+#   branch:
+#     - master
+#     - branch/*
+#   event:
+#     exclude:
+#       - cron
+#       - promote
+#       - rollback
 trigger:
-  branch:
-    - master
-    - branch/*
-  event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+  cron:
+    - never
 
 workspace:
   path: /go
@@ -1795,7 +1803,7 @@ concurrency:
 
 platform:
   os: darwin
-  arch: amd
+  arch: amd64
 
 # TODO(gus): replace trigger, commented for testing
 # trigger:

--- a/.drone.yml
+++ b/.drone.yml
@@ -2410,6 +2410,6 @@ steps:
 
 ---
 kind: signature
-hmac: b0111607db2f98a2172cffc50252d1808c62ff81b0f9fd514aac52fd7b307d46
+hmac: 7f16b23a7a4e0f1e38fb2e0ed5ef2f2582866b366901ef2325ee4d4fbe159152
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,19 +8,15 @@ environment:
   UID: 1000
   GID: 1000
 
-# TODO(gus): restore triggers, commented for testing
-# trigger:
-#   branch:
-#     - master
-#     - branch/*
-#   event:
-#     exclude:
-#       - cron
-#       - promote
-#       - rollback
 trigger:
-  cron:
-    - never
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 workspace:
   path: /go
@@ -137,19 +133,15 @@ kind: pipeline
 type: kubernetes
 name: test-docs
 
-# TODO(gus): restore triggers, commented for testing
-# trigger:
-#   branch:
-#     - master
-#     - branch/*
-#   event:
-#     exclude:
-#       - cron
-#       - promote
-#       - rollback
 trigger:
-  cron:
-    - never
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
 
 workspace:
   path: /go
@@ -1578,25 +1570,15 @@ platform:
   os: darwin
   arch: amd64
 
-# TODO(gus): replace trigger, commented for testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+  repo:
+    include:
+      - gravitational/*
 
 depends_on:
   - test
@@ -1682,25 +1664,15 @@ platform:
   os: darwin
   arch: amd64
 
-# TODO(gus): replace trigger, commented for testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+  repo:
+    include:
+      - gravitational/*
 
 depends_on:
   - build-darwin-amd64
@@ -1805,25 +1777,15 @@ platform:
   os: darwin
   arch: amd64
 
-# TODO(gus): replace trigger, commented for testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+  repo:
+    include:
+      - gravitational/*
 
 depends_on:
   - build-darwin-amd64
@@ -1943,25 +1905,15 @@ platform:
 environment:
   TMPDIR: /dev/shm
 
-# TODO(gus): replace trigger, commented for testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    - tag
+  ref:
+    include:
+      - refs/tags/v*
+  repo:
+    include:
+      - gravitational/*
 
 depends_on:
   - test
@@ -2410,6 +2362,6 @@ steps:
 
 ---
 kind: signature
-hmac: 6dd9da78171ea7f849aecbc43c2cd895fb6618fac025d4211beb94bd3206c37f
+hmac: 3f2380e4436102f8f24e4a07cfa57373c8e0ed734ab6558cdb1bce6797719982
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2013,7 +2013,7 @@ steps:
       - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
       # copy release archives to artifact directory
       - cp teleport*.tar.gz /dev/shm/tmp/go/artifacts
-      - cp e/teleport-ent*.tar.gz" /dev/shm/tmp/go/artifacts
+      - cp e/teleport-ent*.tar.gz /dev/shm/tmp/go/artifacts
       # generate checksums
       - cd /dev/shm/tmp/go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 
@@ -2410,6 +2410,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7f16b23a7a4e0f1e38fb2e0ed5ef2f2582866b366901ef2325ee4d4fbe159152
+hmac: 6dd9da78171ea7f849aecbc43c2cd895fb6618fac025d4211beb94bd3206c37f
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ ifneq ("$(wildcard /usr/include/security/pam_appl.h)","")
 PAM_TAG = pam
 PAM_MESSAGE = "with PAM support"
 endif
+endif
 
 # PAM headers for Darwin live under /usr/local/include/security instead, as SIP
 # prevents us from modifying/creating /usr/include/security on newer versions of MacOS

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ FIPS_MESSAGE := "with FIPS support"
 endif
 
 # PAM support will only be built into Teleport if headers exist at build time.
-PAM_MESSAGE = "without PAM support"
+PAM_MESSAGE := "without PAM support"
 ifneq ("$(OS)","darwin")
 ifneq ("$(wildcard /usr/include/security/pam_appl.h)","")
-PAM_TAG = pam
-PAM_MESSAGE = "with PAM support"
+PAM_TAG := pam
+PAM_MESSAGE := "with PAM support"
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,9 @@ ifneq ("$(OS)","darwin")
 ifneq ("$(wildcard /usr/include/security/pam_appl.h)","")
 PAM_TAG := pam
 PAM_MESSAGE := "with PAM support"
-endif
-endif
-
+else
 # PAM headers for Darwin live under /usr/local/include/security instead, as SIP
 # prevents us from modifying/creating /usr/include/security on newer versions of MacOS
-ifeq ("$(OS)","darwin")
 ifneq ("$(wildcard /usr/local/include/security/pam_appl.h)","")
 PAM_TAG := pam
 PAM_MESSAGE := "with PAM support"

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ endif
 
 # PAM support will only be built into Teleport if headers exist at build time.
 PAM_MESSAGE := "without PAM support"
-ifneq ("$(OS)","darwin")
 ifneq ("$(wildcard /usr/include/security/pam_appl.h)","")
 PAM_TAG := pam
 PAM_MESSAGE := "with PAM support"

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,21 @@ FIPS_MESSAGE := "with FIPS support"
 endif
 
 # PAM support will only be built into Teleport if headers exist at build time.
-PAM_MESSAGE := "without PAM support"
+PAM_MESSAGE = "without PAM support"
+ifneq ("$(OS)","darwin")
 ifneq ("$(wildcard /usr/include/security/pam_appl.h)","")
+PAM_TAG = pam
+PAM_MESSAGE = "with PAM support"
+endif
+
+# PAM headers for Darwin live under /usr/local/include/security instead, as SIP
+# prevents us from modifying/creating /usr/include/security on newer versions of MacOS
+ifeq ("$(OS)","darwin")
+ifneq ("$(wildcard /usr/local/include/security/pam_appl.h)","")
 PAM_TAG := pam
 PAM_MESSAGE := "with PAM support"
+CGOFLAG := $(CGOFLAG) -I/usr/local/include/security
+endif
 endif
 
 # BPF support will only be built into Teleport if headers exist at build time.

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ ifeq ("$(OS)","darwin")
 ifneq ("$(wildcard /usr/local/include/security/pam_appl.h)","")
 PAM_TAG := pam
 PAM_MESSAGE := "with PAM support"
-CGOFLAG := $(CGOFLAG) CGO_CFLAGS="-I/usr/local/include/security"
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ifeq ("$(OS)","darwin")
 ifneq ("$(wildcard /usr/local/include/security/pam_appl.h)","")
 PAM_TAG := pam
 PAM_MESSAGE := "with PAM support"
-CGOFLAG := $(CGOFLAG) -I/usr/local/include/security
+CGOFLAG := $(CGOFLAG) CGO_CFLAGS="-I/usr/local/include/security"
 endif
 endif
 

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -75,20 +75,20 @@ DEVELOPER_ID_INSTALLER="Developer ID Installer: Gravitational Inc." # used for s
 DOWNLOAD_ROOT="https://get.gravitational.com"
 
 # check that curl is installed
-if [ ! $(type curl) ]; then
+if [[ ! $(type curl) ]]; then
     echo "curl must be installed"
     exit 2
 fi
 
 # check that tar is installed
-if [ ! $(type tar) ]; then
+if [[ ! $(type tar) ]]; then
     echo "tar must be installed"
     exit 11
 fi
 
 # check that docker is installed when fpm is needed to build
 if [[ "${PACKAGE_TYPE}" != "pkg" ]]; then
-    if [ ! $(type docker) ]; then
+    if [[ ! $(type docker) ]]; then
         echo "docker must be installed to build non-OSX packages"
         exit 3
     fi
@@ -110,26 +110,26 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
     fi
     PLATFORM="darwin"
     ARCH="amd64"
-    if [ ! $(type pkgbuild) ]; then
+    if [[ ! $(type pkgbuild) ]]; then
         echo "You need to install pkgbuild"
         echo "Run: xcode-select --install"
         exit 5
     fi
 
     if [[ "${BUILD_MODE}" == "tsh" ]]; then
-        if [ ! $(type codesign) ]; then
+        if [[ ! $(type codesign) ]]; then
             echo "You need to install codesign"
             echo "Run: xcode-select --install or sudo xcode-select --reset"
             exit 6
         fi
 
-        if [ ! $(type productsign) ]; then
+        if [[ ! $(type productsign) ]]; then
             echo "You need to install productsign"
             echo "Run: xcode-select --install or sudo xcode-select --reset"
             exit 7
         fi
 
-        if [ ! $(type gon) ]; then
+        if [[ ! $(type gon) ]]; then
             echo "You need to install gon"
             echo "Install a binary from https://github.com/mitchellh/gon and make sure it's present in the system PATH"
             exit 8


### PR DESCRIPTION
Adds jobs for:
- Building teleport .tar.gz on MacOS
- Building teleport .pkg on MacOS
- Building signed/notarized tsh .pkg on MacOS
- Building teleport .tar.gz on ARMv7

Drone runner setup is handled by https://github.com/gravitational/ops/pull/164

Ticks off more issues in https://github.com/gravitational/teleport/issues/3936