### PR TITLE
Use clockwork.Ticker instead of time.Ticker in lite backend

### DIFF
--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -18,7 +18,6 @@ package lite
 
 import (
 	"database/sql"
-	"time"
 
 	"github.com/gravitational/teleport/lib/backend"
 
@@ -28,7 +27,7 @@ import (
 const notSet = -2
 
 func (l *LiteBackend) runPeriodicOperations() {
-	t := time.NewTicker(l.PollStreamPeriod)
+	t := l.clock.NewTicker(l.PollStreamPeriod)
 	defer t.Stop()
 
 	rowid := int64(notSet)
@@ -39,7 +38,7 @@ func (l *LiteBackend) runPeriodicOperations() {
 				l.Warningf("Error closing database: %v", err)
 			}
 			return
-		case <-t.C:
+		case <-t.Chan():
 			err := l.removeExpiredKeys()
 			if err != nil {
 				// connection problem means that database is closed

--- a/lib/session/session_test.go
+++ b/lib/session/session_test.go
@@ -52,10 +52,8 @@ func (s *SessionSuite) SetUpTest(c *C) {
 	s.clock = clockwork.NewFakeClockAt(time.Date(2016, 9, 8, 7, 6, 5, 0, time.UTC))
 	s.dir = c.MkDir()
 
-	s.bk, err = lite.New(context.TODO(), backend.Params{"path": s.dir})
+	s.bk, err = lite.NewWithConfig(context.TODO(), lite.Config{Clock: s.clock, Path: s.dir})
 	c.Assert(err, IsNil)
-
-	(s.bk.(*lite.LiteBackend)).SetClock(s.clock)
 
 	srv, err := New(s.bk)
 	srv.(*server).clock = s.clock


### PR DESCRIPTION
This enables us to write tests with custom clocks for this backend