### PR TITLE
Improve label format enforcement

### DIFF
--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -307,6 +307,12 @@ func (s *ServerV2) CheckAndSetDefaults() error {
 		return trace.Wrap(err)
 	}
 
+	for key := range s.Spec.CmdLabels {
+		if !IsValidLabelKey(key) {
+			return trace.BadParameter("invalid label key: %q", key)
+		}
+	}
+
 	return nil
 }
 

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -80,3 +80,22 @@ func (s *ServicesSuite) TestCommandLabels(c *check.C) {
 	label.Command[0] = "/bin/ls"
 	c.Assert(label.Command[0], check.Not(check.Equals), out["a"].GetCommand())
 }
+
+func (s *ServicesSuite) TestLabelKeyValidation(c *check.C) {
+	tts := []struct {
+		label string
+		ok    bool
+	}{
+		{label: "somelabel", ok: true},
+		{label: "foo.bar", ok: true},
+		{label: "this-that", ok: true},
+		{label: "8675309", ok: true},
+		{label: "", ok: false},
+		{label: "spam:eggs", ok: false},
+		{label: "cats dogs", ok: false},
+		{label: "wut?", ok: false},
+	}
+	for _, tt := range tts {
+		c.Assert(IsValidLabelKey(tt.label), check.Equals, tt.ok, check.Commentf("tt=%+v", tt))
+	}
+}


### PR DESCRIPTION
Label key format requirements were only being enforced by json schema, which is only run on a subset of *deserializing* operations, and (unsurprisingly) only when the the format of origin is json.  As a result, invalid labels were not detected when passing through the GRPC API, being inserted into the backend, or when propagating through the event system.  This resulted in teleport working mostly correctly up until the point where it is *restarted*, at which point initialization of the auth server cache would fail, causing startup to fail.

This PR addresses the specific issue of labels, but I'm working on drafting an issue about the broader problem of inconsistent validation.  I'm generally of the opinion that json schema validation in teleport does more harm than good, and I think problems like this are a prime example of why validation logic should not be tied to a specific serialization format.

Partially addresses #4034 