### PR TITLE
re-init proxywatcher on empty proxy list

### DIFF
--- a/lib/services/proxywatcher.go
+++ b/lib/services/proxywatcher.go
@@ -237,6 +237,11 @@ func (p *ProxyWatcher) watch() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	if len(proxies) == 0 {
+		// at least 1 proxy aught to exist; yield back to the outer
+		// retry loop and try again.
+		return trace.NotFound("empty proxy list")
+	}
 	proxySet := make(map[string]Server, len(proxies))
 	for i := range proxies {
 		proxySet[proxies[i].GetName()] = proxies[i]


### PR DESCRIPTION
Changes `ProxyWatcher.watch()` to treat an empty proxy list as an error and yield back to the outer retry/backoff loop.

Previously, `ProxyWatcher` would accept an empty proxy list as a valid state, and rely on the event system to detect proxies as they were created.  Based on #4066, it appears that it is possible to stay in the empty state for multiple minutes after at least one proxy has successfully registered (though replicating this issue is very difficult).  This most likely cause of this issue is that the cache currently allows reads of partially loaded state, meaning that reads against the cache can return successfully when not all data is available.  The cache issue will be addressed in a future PR, but regardless of the underlying cause, it is better to have the `ProxyWatcher` perform retries on empty proxy list.

No new tests are added in this PR since this fix doesn't actually change any meaningful behavior outside of the aforementioned race that is currently very difficult to replicate.

Fixes #4066