### PR TITLE
Fix Helm chart public_addr for proxy when using Ingress

### DIFF
--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -104,7 +104,7 @@ You can view debug logs for the Teleport service running on the Kubernetes worke
 kubectl logs daemonset/teleport-node
 ```
 
-If you have multiple worker nodes, look for pods starting with `teleport-node-` in the output of `kubectl get pods` and 
+If you have multiple worker nodes, look for pods starting with `teleport-node-` in the output of `kubectl get pods` and
 use `kubectl logs pod/teleport-node-xxxxxx` to view logs from each node separately.
 
 ## Deleting the chart

--- a/examples/chart/teleport-demo/README.md
+++ b/examples/chart/teleport-demo/README.md
@@ -72,7 +72,7 @@ $ gcloud container clusters get-credentials <cluster-name> --zone <zone> --proje
 $ ./gke-init.sh
 ```
 
-Make sure that you have updated the submodule containing the secrets. When prompted to authenticate, use a 
+Make sure that you have updated the submodule containing the secrets. When prompted to authenticate, use a
 personal access token rather than a password:
 
 ```bash

--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -4,5 +4,5 @@ version: 0.0.5
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
 keywords:
-  - Teleport 
+  - Teleport
 tillerVersion: ">=2.8.0"

--- a/examples/chart/teleport/HIGHAVAILABILITY.md
+++ b/examples/chart/teleport/HIGHAVAILABILITY.md
@@ -71,7 +71,7 @@ After configuring both of these options run the install.  In the example below y
 ``` bash
 $ helm install --name teleport ./
 
-$ kubectl get pods 
+$ kubectl get pods
 NAME                            READY   STATUS    RESTARTS   AGE
 teleport-d67584df8-8vfls        1/1     Running   0          62m
 teleport-d67584df8-p9l2g        1/1     Running   0          62m

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -10,23 +10,23 @@ By default this chart is configured as follows:
 
 - Enterprise Edition of Teleport
 - 1 instance (replica) of Teleport
-- Directory Storage with Ephemeral storage.  
+- Directory Storage with Ephemeral storage.
 - Record ssh/k8s exec and attach session to the `emptyDir` of the Teleport pod
 - The assumed externally accessible hostname of Teleport is `teleport.example.com`
 - There are two ways you can make the Teleport Cluster externally accessible:
   1. Use `kubectl port-forward` for testing.
   2. Change the Service type in `values.yaml` to an option such as LoadBalancer for a more permanent solution.
-- TLS is enabled by default on the Proxy 
+- TLS is enabled by default on the Proxy
 
 
 The `values.yaml` is configurable for multiple options including:
 - Using the Community edition of Teleport (Set license.enabled to false)
 - Using self-signed TLS certificates (Set proxy.tls.usetlssecret to false)
 - Using a specific version of Teleport (See image.tag)
-- Using persistent or high availability storage (See below example).  Persistent or high availability storage is recommended for production usage. 
+- Using persistent or high availability storage (See below example).  Persistent or high availability storage is recommended for production usage.
 - Increasing the replica count for multiple instances (Using High Availability configuration)
 
-See the comments in the default `values.yaml` and also the [Teleport documentation](https://gravitational.com/teleport/docs/) for more options.   
+See the comments in the default `values.yaml` and also the [Teleport documentation](https://gravitational.com/teleport/docs/) for more options.
 
 See the [High Availability](./HIGHAVAILABILITY.md)(HA) instructions for configuring a HA deployment with this helm chart.
 
@@ -58,7 +58,7 @@ kubectl create secret generic license --from-file=license-enterprise.pem
 ### Certificate Usage Configuration
 Teleport can generate self-signed certificates that are useful for first time or non-production deployments. You can set Teleport to use self-signed certificates by setting `usetlssecret: false` under the `proxy.tls settings` in `values.yaml`. You will need to add `--insecure` to some interactions such as `tsh` and browser interaction will require you to accept the self-signed certificate.  Please see our [article](https://gravitational.com/blog/letsencrypt-teleport-ssh/) on generating certificates via Let's Encrypt as a method to generate signed TLS certificates.
 
-If you plan to have TLS terminate at a seperate load balancer, you should set both `proxy.tls.enabled` and `proxy.usetlssecret` to false. 
+If you plan to have TLS terminate at a seperate load balancer, you should set both `proxy.tls.enabled` and `proxy.usetlssecret` to false.
 
 
 ### Adding TLS Certificates
@@ -189,7 +189,7 @@ After configuring both of these options run the install.  In the example below y
 ``` bash
 $ helm install --name teleport ./
 
-$ kubectl get pods 
+$ kubectl get pods
 NAME                            READY   STATUS    RESTARTS   AGE
 teleport-d67584df8-8vfls        1/1     Running   0          62m
 teleport-d67584df8-p9l2g        1/1     Running   0          62m
@@ -205,7 +205,7 @@ If you the Teleport pods are not starting the most common issue is lack of requi
  Example:
    `kubectl describe pod teleport-5f5f989b96-9khzq`
 
-  
+
 ### Teleport Pods keep restarting with Error
 The issue may be due to a malformed Teleport configuration file or other configuration issue.  Use the kubectl logs command to see the logs output.
 Example:

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -41,7 +41,7 @@ data:
       tokens:
 {{ toYaml .Values.config.teleport.auth_service.tokens | indent 8 }}
 
-      public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.authssh.containerPort }}
+      public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.authssh.port }}
       cluster_name: {{ .Values.config.public_address }}
       listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.authssh.containerPort }}
       client_idle_timeout: {{ .Values.config.teleport.auth_service.client_idle_timeout }}
@@ -69,13 +69,12 @@ data:
       
     proxy_service:
       enabled: {{ .Values.config.teleport.proxy_service.enabled }}
-      public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.proxyweb.containerPort }}
+      public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyweb.port }}
       web_listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyweb.containerPort }}
       listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyssh.containerPort }}
       tunnel_listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxytunnel.containerPort }}
-
-      ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.proxyssh.containerPort }}
-      tunnel_public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.proxytunnel.containerPort }}
+      ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyssh.port }}
+      tunnel_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxytunnel.port }}
 {{- if .Values.proxy.tls.usetlssecret}} 
       https_key_file: {{ .Values.config.teleport.proxy_service.https_key_file }}
       https_cert_file: {{ .Values.config.teleport.proxy_service.https_cert_file }}
@@ -85,7 +84,7 @@ data:
       # kubernetes proxy protocol support
       kubernetes:        
         enabled: {{ .Values.config.teleport.proxy_service.kubernetes.enabled }}
-        public_addr: {{ .Values.config.public_address }}:{{ .Values.ports.proxykube.containerPort }}
+        public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}
         listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxykube.containerPort }}
 {{- end }}
 {{- if .Values.config.highAvailability }}
@@ -127,11 +126,9 @@ data:
 {{ toYaml .Values.config.teleport.auth_service.tokens | indent 8 }}
 {{- end }}
 
-      public_addr: {{ .Values.config.auth_public_address }}:{{ .Values.ports.authssh.containerPort }}
+      public_addr: {{ .Values.config.auth_public_address }}:{{ .Values.service.ports.authssh.port }}
       cluster_name: {{ .Values.config.public_address }}
-      
       listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.authssh.containerPort }}
-
       client_idle_timeout: {{ .Values.config.teleport.auth_service.client_idle_timeout }}
       disconnect_expired_cert: {{ .Values.config.teleport.auth_service.disconnect_expired_cert }}
       keep_alive_interval: {{ .Values.config.teleport.auth_service.keep_alive_interval }}

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -73,6 +73,7 @@ data:
       web_listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyweb.containerPort }}
       listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyssh.containerPort }}
       tunnel_listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxytunnel.containerPort }}
+
       ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyssh.port }}
       tunnel_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxytunnel.port }}
 {{- if .Values.proxy.tls.usetlssecret}} 

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -6,14 +6,14 @@ metadata:
 {{ include "teleport.labels" . | indent 4 }}
 data:
   teleport.yaml: |
-{{- if .Values.otherConfig.useOtherConfig }} 
+{{- if .Values.otherConfig.useOtherConfig }}
 {{ toYaml .Values.otherConfig.teleportConfig | indent 4 }}
 {{- else }}
     teleport:
 {{- if not .Values.config.highAvailability }}
       nodename: {{ template "teleport.fullname" . }}
 {{- end }}
-{{- if  .Values.config.auth_service_connection }} 
+{{- if  .Values.config.auth_service_connection }}
 {{ toYaml .Values.config.auth_service_connection | indent 6 }}
 {{- end }}
       pid_file: {{ .Values.config.teleport.pid_file }}
@@ -26,7 +26,7 @@ data:
       storage:
 {{ toYaml .Values.config.teleport.storage | indent 8 }}
 
-      connection_limits:    
+      connection_limits:
 {{ toYaml .Values.config.teleport.connection_limits | indent 8 }}
     auth_service:
 {{- if .Values.config.highAvailability }}
@@ -49,7 +49,7 @@ data:
       keep_alive_interval: {{ .Values.config.teleport.auth_service.keep_alive_interval }}
       keep_alive_count_max: {{ .Values.config.teleport.auth_service.keep_alive_count_max }}
 {{- end }}
-      
+
     ssh_service:
 {{- if not .Values.config.highAvailability }}
       enabled: {{ .Values.config.teleport.ssh_service.enabled }}
@@ -66,24 +66,32 @@ data:
 {{ toYaml .Values.config.teleport.ssh_service.enhanced_recording | indent 8 }}
       pam:
 {{ toYaml .Values.config.teleport.ssh_service.pam | indent 8 }}
-      
+
     proxy_service:
       enabled: {{ .Values.config.teleport.proxy_service.enabled }}
+{{- if .Values.ingress.enabled }}
+      {{- if .Values.ingress.tls }}
+      public_addr: {{ .Values.config.public_address }}:443
+      {{- else }}
+      public_addr: {{ .Values.config.public_address }}:80
+      {{- end -}}
+{{- else }}
       public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyweb.port }}
+{{- end }}
       web_listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyweb.containerPort }}
       listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyssh.containerPort }}
       tunnel_listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxytunnel.containerPort }}
 
       ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyssh.port }}
       tunnel_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxytunnel.port }}
-{{- if .Values.proxy.tls.usetlssecret}} 
+{{- if .Values.proxy.tls.usetlssecret}}
       https_key_file: {{ .Values.config.teleport.proxy_service.https_key_file }}
       https_cert_file: {{ .Values.config.teleport.proxy_service.https_cert_file }}
-{{- end }}      
+{{- end }}
 
       # kubernetes section configures
       # kubernetes proxy protocol support
-      kubernetes:        
+      kubernetes:
         enabled: {{ .Values.config.teleport.proxy_service.kubernetes.enabled }}
         public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}
         listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxykube.containerPort }}
@@ -99,7 +107,7 @@ metadata:
 {{ include "teleport.labels" . | indent 4 }}
 data:
   teleport.yaml: |
-{{- if .Values.otherConfigHA.useOtherConfig }} 
+{{- if .Values.otherConfigHA.useOtherConfig }}
 {{ toYaml .Values.otherConfigHA.teleportConfig | indent 4 }}
 {{- else }}
     teleport:
@@ -113,7 +121,7 @@ data:
       storage:
 {{ toYaml .Values.config.teleport.storage | indent 8 }}
 
-      connection_limits:    
+      connection_limits:
 {{ toYaml .Values.config.teleport.connection_limits | indent 8 }}
     auth_service:
       enabled: true
@@ -134,11 +142,11 @@ data:
       disconnect_expired_cert: {{ .Values.config.teleport.auth_service.disconnect_expired_cert }}
       keep_alive_interval: {{ .Values.config.teleport.auth_service.keep_alive_interval }}
       keep_alive_count_max: {{ .Values.config.teleport.auth_service.keep_alive_count_max }}
-      
+
     ssh_service:
       enabled: false
-      
+
     proxy_service:
-      enabled: false 
+      enabled: false
 {{- end }}
 {{- end }}

--- a/examples/chart/teleport/templates/deployment.yaml
+++ b/examples/chart/teleport/templates/deployment.yaml
@@ -134,7 +134,7 @@ metadata:
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | indent 4 }}
 {{- end }}
-    
+
 spec:
   replicas: {{ .Values.config.authCount }}
   strategy:

--- a/examples/chart/teleport/templates/ingress.yaml
+++ b/examples/chart/teleport/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- $servicePort := .Values.service.ports.proxyweb.port -}}
+{{- $servicePort := .Values.service.ports.proxyweb.targetPort -}}
 {{- $serviceName := include "teleport.fullname" . -}}
 {{- if .Values.ingress.enabled }}
 ---

--- a/examples/chart/teleport/templates/service.yaml
+++ b/examples/chart/teleport/templates/service.yaml
@@ -48,7 +48,7 @@ spec:
     - name: authssh
       port: {{ .Values.ports.authssh.containerPort }}
       targetPort: {{ .Values.ports.authssh.containerPort }}
-      protocol: TCP      
+      protocol: TCP
 {{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.service.externalTrafficPolicy) }}
   externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
 {{- end }}

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -22,17 +22,15 @@ image:
 
 labels: {}
 
-
 # Teleport Proxy configuration
 proxy:
   tls:
-    # We assume TLS is terminated in front of the proxy by default
+    # We assume that Teleport will handle TLS termination by default
     enabled: true
     # Set this to false if you want to use Teleport's generated self-signed certificates
     usetlssecret: true
     # tweak this if you have multiple proxies in a single namespace
     secretName: tls-web
-
 
 # Teleport configuration
 # See the admin guide for full details
@@ -48,22 +46,21 @@ config:
   #used for listen addreses in proxy, auth and ssh
   listen_addr: 0.0.0.0
 
-  # Set to true  to have separate proxy and auth instances for high availability.
-  # You must use non-dir storage for high availability or you can only have 1 auth instance .
+  # Set to true to have separate proxy and auth instances for high availability.
+  # You must use non-dir storage for high availability or you can only have 1 auth instance.
   highAvailability: false
-  # High availability configuration with proxy and auth servers. No SSH configured service.
+  # High availability configuration with proxy and auth servers. No configured SSH service.
   proxyCount: 2
   authCount: 2
   authServiceType: ClusterIP
   auth_public_address: auth.example.com
 
 # Set for proxies in high availability, single proxy and ssh service only deployments
-# auth_service_connection: 
+# auth_service_connection:
 #   auth_token: dogs-are-much-nicer-than-cats
 #   auth_servers:
 #   - teleportauth:3025
 #   - auth.example.com:3025
-
 
   teleport:
     pid_file: /var/run/teleport.pid
@@ -73,7 +70,7 @@ config:
     data_dir: /var/lib/teleport
     storage:
       type: dir
-            
+
     # Teleport throttles all connections to avoid abuse. These settings allow
     # you to adjust the default limits
     connection_limits:
@@ -92,18 +89,18 @@ config:
       - proxy,node:dogs-are-much-nicer-than-cats
       - trusted_cluster:trains-are-superior-to-cars
 
-    # Determines if SSH sessions to cluster nodes are forcefully terminated
-    # after no activity from a client (idle client).
-    # Examples: "30m", "1h" or "1h30m"
+      # Determines if SSH sessions to cluster nodes are forcefully terminated
+      # after no activity from a client (idle client).
+      # Examples: "30m", "1h" or "1h30m"
       client_idle_timeout: never
 
-    # Determines if the clients will be forcefully disconnected when their
-    # certificates expire in the middle of an active SSH session. (default is 'no')
+      # Determines if the clients will be forcefully disconnected when their
+      # certificates expire in the middle of an active SSH session. (default is 'no')
       disconnect_expired_cert: no
 
-    # Determines the interval at which Teleport will send keep-alive messages.
-    # keep_alive_count_max is the number of missed keep-alive messages before
-    # the server tears down the connection to the client.
+      # Determines the interval at which Teleport will send keep-alive messages.
+      # keep_alive_count_max is the number of missed keep-alive messages before
+      # the server tears down the connection to the client.
       keep_alive_interval: 5m
       keep_alive_count_max: 3
 
@@ -120,47 +117,46 @@ config:
         type: auth
 
       enhanced_recording:
-       # Enable or disable enhanced auditing for this node. Default value:
-       # false.  See 
+        # Enable or disable enhanced auditing for this node. Default value:
+        # false.  See
         enabled: false
 
-       # command_buffer_size is optional with a default value of 8 pages.
+        # command_buffer_size is optional with a default value of 8 pages.
         command_buffer_size: 8
 
-       # disk_buffer_size is optional with default value of 128 pages.
+        # disk_buffer_size is optional with default value of 128 pages.
         disk_buffer_size: 128
 
-       # network_buffer_size is optional with default value of 8 pages.
+        # network_buffer_size is optional with default value of 8 pages.
         network_buffer_size: 8
 
-       # Controls where cgroupv2 hierarchy is mounted. Default value:
-       # /cgroup2.
+        # Controls where cgroupv2 hierarchy is mounted. Default value:
+        # /cgroup2.
         cgroup_path: /cgroup2
 
-    # configures PAM integration. Note that additional volumes of the PAM configuration
-    # will be required.
+      # Configures PAM integration. Note that additional volumes of the PAM configuration
+      # will be required.
       pam:
         enabled: no
         service_name: teleport
 
     proxy_service:
       enabled: yes
-    #Used if  proxy.tls.usetlssecret is set to true, otherwise the values are not included in teleport.yaml
+      # Used if  proxy.tls.usetlssecret is set to true, otherwise the values are not included in teleport.yaml
       https_key_file: /var/lib/certs/tls.key
       https_cert_file: /var/lib/certs/tls.crt
 
-    # kubernetes section configures
-    # kubernetes proxy protocol support
+      # kubernetes section configures kubernetes proxy protocol support
       kubernetes:
         enabled: yes
 
-# Alternatively you can provide your teleport configuration under teleportConfig with static text.  No variable substituion
+# Alternatively you can provide your teleport configuration under teleportConfig with static text. No variable substitution.
 otherConfig:
   useOtherConfig: false
   teleportConfig:
     # place a full teleport.yaml configuration here
 
-# Teleport configuration for high availability deployment 
+# Teleport configuration for high availability deployment
 otherConfigHA:
   useOtherConfig: false
   teleportConfig:
@@ -228,9 +224,6 @@ ports:
   proxytunnel:
     containerPort: 3024
 
-
-
-
 ## Additional container arguments
 extraArgs: []
 
@@ -241,34 +234,33 @@ extraVars: {}
   # SSL_CERT_FILE: "/var/lib/ca-certs/ca.pem"
 
 # Add additional volumes and mounts, for example to read other log files on the host
-extraVolumes: [] 
-
-
+extraVolumes: []
   # - name: ca-certs
   #   configMap:
   #     name: ca-certs
-extraVolumeMounts: []
 
+extraVolumeMounts: []
   # - name: ca-certs
   #   mountPath: /var/lib/ca-certs
   #   readOnly: true
-  
+
 # Volume mounts only for the auth service in high availability deployments
 extraAuthVolumes: []
-extraAuthVolumeMounts: []  
+extraAuthVolumeMounts: []
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 200Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 100Mi
-# Specify for the seperate auth service deployment
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#  cpu: 100m
+#  memory: 200Mi
+# requests:
+#  cpu: 100m
+#  memory: 100Mi
+
+# Specify resources for the seperate auth service deployment
 authresources: {}
 
 rbac:


### PR DESCRIPTION
When using an `Ingress` to front your Teleport cluster in Kubernetes, access will be via port 443 (HTTPS) or 80 (HTTP - not recommended). Unfortunately, the Helm chart makes the assumption that you'll always be on port 3080 and this breaks `tsh` logins at the command line. This fixes that problem by specifically overriding the `public_addr` of `proxy_service` when using an `Ingress`.

I also changed all other `public_addr` settings in the main Helm chart to use the configured service port, rather than the `containerPort`. This means that other traffic will be directed correctly if people change the default ports in their config.

I also found a lot of random trailing spaces and blank tabs, so the PR removes all of those that I could find under our Helm charts too.

Fixes #4080 