### PR TITLE
Workflow Documentation Fixes

### DIFF
--- a/docs/4.3/enterprise/workflow/ssh_approval_slack.md
+++ b/docs/4.3/enterprise/workflow/ssh_approval_slack.md
@@ -145,7 +145,7 @@ Teleport Slack uses a config file in TOML format. Generate a boilerplate config 
 running the following command:
 
 ```bash
-$ teleport-slack configure > teleport-slacbot.toml
+$ teleport-slack configure > teleport-slackbot.toml
 $ sudo mv teleport-slack.toml /etc
 ```
 

--- a/docs/4.3/enterprise/workflow/ssh_approval_slack.md
+++ b/docs/4.3/enterprise/workflow/ssh_approval_slack.md
@@ -145,7 +145,7 @@ Teleport Slack uses a config file in TOML format. Generate a boilerplate config 
 running the following command:
 
 ```bash
-$ teleport-slack configure > teleport-slackbot.toml
+$ teleport-slack configure > teleport-slack.toml
 $ sudo mv teleport-slack.toml /etc
 ```
 

--- a/examples/resources/plugins/teleport-slack.toml
+++ b/examples/resources/plugins/teleport-slack.toml
@@ -6,9 +6,9 @@ client_crt = "/var/lib/teleport/plugins/slack/auth.crt" # Teleport GRPC client c
 root_cas = "/var/lib/teleport/plugins/slack/auth.cas"   # Teleport cluster CA certs
 
 [slack]
-token = "api_token"             # Slack Bot OAuth token
-secret = "signing-secret-value" # Slack API Signing Secret
-channel = "channel-name"        # Slack Channel name to post requests to
+token = "xoxb-xxxxx-xxxxx-xxxxx" # Slack Bot OAuth token (starts with xoxb)
+secret = "signing-secret-value"  # Slack API Signing Secret
+channel = "channel-name"         # Slack Channel name to post requests to
 
 [http]
 # listen_addr = ":8081" # Network address in format [addr]:port on which callback server listens, e.g. 0.0.0.0:443

--- a/examples/systemd/plugins/teleport-jira.service
+++ b/examples/systemd/plugins/teleport-jira.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=/usr/local/bin/teleport-jira start --config=/etc/teleport-jira.toml --pid-file=/run/teleport-jira.pid
+ExecStart=/usr/local/bin/teleport-jira start --config=/etc/teleport-jira.toml
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport-jira.pid
 

--- a/examples/systemd/plugins/teleport-mattermost.service
+++ b/examples/systemd/plugins/teleport-mattermost.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=/usr/local/bin/teleport-mattermost start --config=/etc/teleport-mattermost.toml --pid-file=/run/teleport-mattermost.pid
+ExecStart=/usr/local/bin/teleport-mattermost start --config=/etc/teleport-mattermost.toml
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport-mattermost.pid
 

--- a/examples/systemd/plugins/teleport-pagerduty.service
+++ b/examples/systemd/plugins/teleport-pagerduty.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=/usr/local/bin/teleport-pagerduty start --config=/etc/teleport-pagerduty.toml --pid-file=/run/teleport-pagerduty.pid
+ExecStart=/usr/local/bin/teleport-pagerduty start --config=/etc/teleport-pagerduty.toml
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport-pagerduty.pid
 

--- a/examples/systemd/plugins/teleport-slack.service
+++ b/examples/systemd/plugins/teleport-slack.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart=/usr/local/bin/teleport-slack start --config=/etc/teleport-slack.toml --pid-file=/run/teleport-slack.pid
+ExecStart=/usr/local/bin/teleport-slack start --config=/etc/teleport-slack.toml
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport-slack.pid
 


### PR DESCRIPTION
Various documentation and example fixes for workflow approval.

1. Fixes typo in generating example Slack toml.
2. Adds hint in example Slack toml for Slack oAuth token.
3. Removes `--pid-file` from example systemd units, as this flag is not valid. 
```
teleport-slack[30762]: ERRO   Terminating due to error error:unknown long flag '--pid-file' utils/bail.go:12
```