### PR TITLE
Fix string escaping in node labeling example

### DIFF
--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -777,7 +777,7 @@ command: ["/bin/uname -m"]
 
 # if you want to pipe several bash commands together, here's how to do it:
 # notice how ' and " are interchangeable and you can use it for quoting:
-command: ["/bin/sh", "-c", "uname -a | egrep -o '[0-9]+\.[0-9]+\.[0-9]+'"]
+command: ["/bin/sh", "-c", "uname -a | egrep -o '[0-9]+\\.[0-9]+\\.[0-9]+'"]
 ```
 
 ## Audit Log


### PR DESCRIPTION
Need to escape backslashes because YAML.