### PR TITLE
Fix Docker Quickstart configuration paths

### DIFF
--- a/docker/teleport-ent-quickstart.yml
+++ b/docker/teleport-ent-quickstart.yml
@@ -7,7 +7,7 @@ services:
     container_name: teleport-configure
     entrypoint: /bin/sh
     hostname: localhost
-    command: -c "if [ ! -f /etc/teleport/teleport.yaml ]; then /usr/local/bin/teleport configure > /etc/teleport/teleport.yaml; fi"
+    command: -c "if [ ! -f /etc/teleport/teleport.yaml ]; then teleport configure > /etc/teleport/teleport.yaml; fi"
     volumes:
       - ./teleport/config:/etc/teleport
 
@@ -18,7 +18,7 @@ services:
     container_name: teleport
     entrypoint: /bin/sh
     hostname: localhost
-    command: -c "sleep 1 && /usr/local/bin/teleport start"
+    command: -c "sleep 1 && /usr/local/bin/dumb-init teleport start -c /etc/teleport/teleport.yaml"
     ports:
       - "3023:3023"
       - "3025:3025"

--- a/docker/teleport-quickstart.yml
+++ b/docker/teleport-quickstart.yml
@@ -7,7 +7,7 @@ services:
     container_name: teleport-configure
     entrypoint: /bin/sh
     hostname: localhost
-    command: -c "if [ ! -f /etc/teleport/teleport.yaml ]; then /usr/local/bin/teleport configure > /etc/teleport/teleport.yaml; fi"
+    command: -c "if [ ! -f /etc/teleport/teleport.yaml ]; then teleport configure > /etc/teleport/teleport.yaml; fi"
     volumes:
       - ./teleport/config:/etc/teleport
 

--- a/docker/teleport-quickstart.yml
+++ b/docker/teleport-quickstart.yml
@@ -18,7 +18,7 @@ services:
     container_name: teleport
     entrypoint: /bin/sh
     hostname: localhost
-    command: -c "sleep 1 && /usr/local/bin/teleport start"
+    command: -c "sleep 1 && /usr/local/bin/dumb-init teleport start -c /etc/teleport/teleport.yaml"
     ports:
       - "3023:3023"
       - "3025:3025"


### PR DESCRIPTION
As we're overriding the command used to start Teleport with our quickstart files, we're not providing the correct path to the configuration file. This PR changes the command to match the standard command used for our Docker images (`/usr/local/bin/dumb-init teleport start -c /etc/teleport/teleport.yaml`)

Fixes #4113 