### PR TITLE
Fix up clone logic and doc tests for forks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,10 +37,10 @@ steps:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
       - git init && git remote add origin ${DRONE_REMOTE_URL}
-      # use the Github API to check whether this PR comes from a forked repo or not
-      # if it does, we specifically fetch the PR ref before checking out and don't add the Enterprise submodule
       - |
-        # by default, we assume this is a fork until we know otherwise
+        # use the Github API to check whether this PR comes from a forked repo or not
+        # if it does, we specifically fetch the PR ref before checking out and don't add the Enterprise submodule
+        # by default, we assume this is a fork (fail safe) until we know otherwise
         export DRONE_NO_FORK=false
         # handle PRs
         if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
@@ -48,7 +48,7 @@ steps:
           export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
           echo "Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
           # if the source repo for the PR doesn't match DRONE_REPO, then this is a PR raised from a fork
-          if [ "$${PR_REPO}" == "${DRONE_REPO}" ]; then
+          if [ "$${PR_REPO}" = "${DRONE_REPO}" ]; then
             export DRONE_NO_FORK=true
           fi
           git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
@@ -69,7 +69,7 @@ steps:
       - mkdir -p /go/cache
       # only clone Enterprise code if this isn't a fork
       - |
-        if [ "$${DRONE_NO_FORK}" == "true" ]; then
+        if [ "$${DRONE_NO_FORK}" = "true" ]; then
           mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
           ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
           git submodule update --init e
@@ -2464,6 +2464,6 @@ steps:
 
 ---
 kind: signature
-hmac: 028f6e0c295b556e5bb8be19f3300fa8ea6e7878805be94e6e20e2646e50be0d
+hmac: c2cc0f7c66f1580fc74e1b506def3dbc484b017ee4749dfbeb13d9281adafa75
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -42,7 +42,7 @@ steps:
       - |
         export DRONE_FORK=false
         # handle PRs
-        if [ "${DRONE_BUILD_EVENT}" == "pull_request" ]; then
+        if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
           apk add --no-cache curl jq
           export PR_REPO=$(curl https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name)
           # if the source repo for the PR doesn't match DRONE_REPO, then this is a PR raised from a fork
@@ -54,7 +54,7 @@ steps:
           git fetch origin ${DRONE_COMMIT_REF}:
           git merge ${DRONE_COMMIT}
         # handle tags
-        elif [ "${DRONE_BUILD_EVENT}" == "tag" ]; then
+        elif [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
           git fetch origin +refs/tags/${DRONE_TAG}:
           git checkout -qf FETCH_HEAD
         # handle pushes/other events
@@ -67,7 +67,7 @@ steps:
       - mkdir -p /go/cache
       # only clone Enterprise code if this isn't a fork
       - |
-        if [ "$${DRONE_FORK}" == "false" ]; then
+        if [ "$${DRONE_FORK}" = "false" ]; then
           mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
           ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
           git submodule update --init e
@@ -192,13 +192,13 @@ steps:
       - git init && git remote add origin ${DRONE_REMOTE_URL}
       - |
         # handle pull requests
-        if [ "${DRONE_BUILD_EVENT}" == "pull_request" ]; then
+        if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
           git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
           git checkout ${DRONE_COMMIT_BRANCH}
           git fetch origin ${DRONE_COMMIT_REF}:
           git merge ${DRONE_COMMIT}
         # handle tags
-        elif [ "${DRONE_BUILD_EVENT}" == "tag" ]; then
+        elif [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
           git fetch origin +refs/tags/${DRONE_TAG}:
           git checkout -qf FETCH_HEAD
         # handle pushes/other events
@@ -2462,6 +2462,6 @@ steps:
 
 ---
 kind: signature
-hmac: f326951fe513237a860e855baccc4e6ef87af6bea98b10d65053e5992c8ee151
+hmac: 7ed58f4e372d519457cf55df3f97aa85ba910d872a0414b3764cdd0b54c2f662
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -184,7 +184,7 @@ steps:
         fi
         # We only run milv on subdirectories with a .milv.config.yaml file, so
         # filter the list here to remove irrelevant extra entries
-        git diff --raw ${DRONE_COMMIT}..${DIFF_REF} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq | grep -Ev'(\.md$|\.yaml$|theme)' > /tmp/docs-versions-changed.txt
+        git diff --raw ${DRONE_COMMIT}..$${DIFF_REF} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq | grep -Ev'(\.md$|\.yaml$|theme)' > /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           # Check trailing whitespace
@@ -2437,6 +2437,6 @@ steps:
 
 ---
 kind: signature
-hmac: 1a2383070410fb7d703b67515a995aa12927b38d2db98f168d14688d3a0655bc
+hmac: 9d13a97204ea2f4badaac398fe36bdb41edbc5d3f59890bde90d47169da9d75d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,6 +17,9 @@ trigger:
       - cron
       - promote
       - rollback
+  repo:
+    include:
+      - gravitational/*
 
 workspace:
   path: /go
@@ -27,33 +30,51 @@ clone:
 steps:
   - name: Check out code
     image: docker:git
-    commands:
-      - mkdir -p /go/src/github.com/${DRONE_REPO}
-      - cd /go/src/github.com/${DRONE_REPO}
-      - git clone https://github.com/${DRONE_REPO}.git .
-      - git checkout $DRONE_COMMIT
-      - echo ${DRONE_SOURCE_BRANCH} > /go/.drone_source_branch.txt
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init webassets || true
-      - mkdir -p /go/cache
-
-  - name: Check out Enterprise code
-    image: docker:git
     environment:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - cd /go/src/github.com/${DRONE_REPO}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git remote add origin ${DRONE_REMOTE_URL}
+      # use the Github API to check whether this PR comes from a forked repo or not
+      # if it does, we specifically fetch the PR ref before checking out and don't add the Enterprise submodule
+      - |
+        export DRONE_FORK=false
+        # handle PRs
+        if [ "{$DRONE_BUILD_EVENT}" == "pull_request" ]; then
+          apk add --no-cache curl jq
+          export PR_REPO=$(curl https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name)
+          # if the source repo for the PR doesn't match DRONE_REPO, then this is a PR raised from a fork
+          if [ "$PR_REPO" != "${DRONE_REPO}" ]; then
+            export DRONE_FORK=true
+          fi
+          git fetch ${FLAGS} origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+          git checkout ${DRONE_COMMIT_BRANCH}
+          git fetch origin ${DRONE_COMMIT_REF}:
+          git merge ${DRONE_COMMIT}
+        # handle tags
+        elif [ "${DRONE_BUILD_EVENT}" == "tag" ]; then
+          git fetch origin +refs/tags/${DRONE_TAG}:
+          git checkout -qf FETCH_HEAD
+        # handle pushes/other events
+        else
+          git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+          git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
+        fi
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-    when:
-      repo:
-        include: ["gravitational/*"]
+      - git submodule update --init webassets || true
+      - mkdir -p /go/cache
+      # only clone Enterprise code if this isn't a fork
+      - |
+        if [ "$${DRONE_FORK}" == "false" ]; then
+          mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+          ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+          git submodule update --init e
+          # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+          git submodule update --init --recursive webassets || true
+          rm -f /root/.ssh/id_rsa
+        fi
 
   - name: Build buildbox
     image: docker
@@ -64,7 +85,7 @@ steps:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
       - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - cd /go/src/github.com/${DRONE_REPO}
+      - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets buildbox
 
   - name: Run linter
@@ -77,7 +98,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - cd /go/src/github.com/${DRONE_REPO}
+      - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets lint
 
   - name: Run unit tests
@@ -90,7 +111,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - cd /go/src/github.com/${DRONE_REPO}
+      - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets test
 
   - name: Run integration tests
@@ -103,7 +124,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - cd /go/src/github.com/${DRONE_REPO}
+      - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets integration
 
   - name: Send Slack notification for build failures
@@ -152,6 +173,9 @@ trigger:
       - cron
       - promote
       - rollback
+  repo:
+    include:
+      - gravitational/*
 
 workspace:
   path: /go
@@ -163,29 +187,32 @@ steps:
   - name: Check out code
     image: golang:1.14.4
     commands:
-      - mkdir -p /go/src/github.com/${DRONE_REPO}
-      - cd /go/src/github.com/${DRONE_REPO}
-      - git clone https://github.com/${DRONE_REPO}.git .
-      - git checkout $DRONE_COMMIT
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git remote add origin ${DRONE_REMOTE_URL}
+      - |
+        # handle pull requests
+        if [ "{$DRONE_BUILD_EVENT}" == "pull_request" ]; then
+          git fetch ${FLAGS} origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+          git checkout ${DRONE_COMMIT_BRANCH}
+          git fetch origin ${DRONE_COMMIT_REF}:
+          git merge ${DRONE_COMMIT}
+        # handle tags
+        elif [ "${DRONE_BUILD_EVENT}" == "tag" ]; then
+          git fetch origin +refs/tags/${DRONE_TAG}:
+          git checkout -qf FETCH_HEAD
+        # handle pushes/other events
+        else
+          git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+          git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
+        fi
 
   - name: Run docs tests
     image: golang:1.14.4
     commands:
       - |
-        cd /go/src/github.com/${DRONE_REPO}
-        # If we're running against a fork rather than the gravitational/teleport repo
-        # then check that repo out as 'upstream' to compare with it
-        if [ "$(git remote get-url origin)" != "https://github.com/gravitational/teleport.git" ]; then
-          git remote add upstream https://github.com/gravitational/teleport.git
-          git fetch upstream
-          export DIFF_REF="upstream/${DRONE_TARGET_BRANCH:-master}"
-        else
-          export DIFF_REF="origin/${DRONE_TARGET_BRANCH:-master}"
-        fi
-        # We only run milv on subdirectories with a .milv.config.yaml file, so
-        # filter the list here to remove irrelevant extra entries
-        git diff --raw ${DRONE_COMMIT}..$${DIFF_REF} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
-        cat /tmp/docs-versions-changed.txt
+        cd /go/src/github.com/gravitational/teleport
+        git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           # Check trailing whitespace
@@ -1760,7 +1787,6 @@ steps:
       - cd /tmp/build-darwin-amd64-pkg/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /tmp/build-darwin-amd64-pkg/go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -1873,7 +1899,6 @@ steps:
       - cd /tmp/build-darwin-amd64-pkg-tsh/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /tmp/build-darwin-amd64-pkg-tsh/go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -2000,7 +2025,6 @@ steps:
       - cd /dev/shm/tmp/go/src/github.com/gravitational/teleport
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /dev/shm/tmp/go/.drone_source_branch.txt
       # fetch enterprise submodules
       - mkdir -m 0700 ~/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa
       - ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts
@@ -2438,6 +2462,6 @@ steps:
 
 ---
 kind: signature
-hmac: d2c952ebccced9859c7d8ea51992f2c43929ef3f35965c2c40537ac58d4ef990
+hmac: a7cc8736e418c2b39c621dfb87ae6702f8216840a5f8e77f69e1de0692aced11
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,14 +40,15 @@ steps:
       # use the Github API to check whether this PR comes from a forked repo or not
       # if it does, we specifically fetch the PR ref before checking out and don't add the Enterprise submodule
       - |
-        export DRONE_FORK=false
+        export DRONE_NO_FORK=false
         # handle PRs
         if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
           apk add --no-cache curl jq
           export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
+          echo "Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
           # if the source repo for the PR doesn't match DRONE_REPO, then this is a PR raised from a fork
-          if [ "$${PR_REPO}" != "${DRONE_REPO}" ]; then
-            export DRONE_FORK=true
+          if [ "$${PR_REPO}" == "${DRONE_REPO}" ]; then
+            export DRONE_NO_FORK=true
           fi
           git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
           git checkout ${DRONE_COMMIT_BRANCH}
@@ -67,7 +68,7 @@ steps:
       - mkdir -p /go/cache
       # only clone Enterprise code if this isn't a fork
       - |
-        if [ "$${DRONE_FORK}" = "false" ]; then
+        if [ "$${DRONE_NO_FORK}" == "true" ]; then
           mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
           ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
           git submodule update --init e
@@ -2462,6 +2463,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7e7c30fa4507fdd89adcdca5dac9be3288084c9b4ce485cad70a18dd1414cfc4
+hmac: ca4a8ed2ca4d49989e7eaec92277585eef1ba411732f8ddc16e0fdcd447b5adc
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -42,14 +42,14 @@ steps:
       - |
         export DRONE_FORK=false
         # handle PRs
-        if [ "{$DRONE_BUILD_EVENT}" == "pull_request" ]; then
+        if [ "${DRONE_BUILD_EVENT}" == "pull_request" ]; then
           apk add --no-cache curl jq
           export PR_REPO=$(curl https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name)
           # if the source repo for the PR doesn't match DRONE_REPO, then this is a PR raised from a fork
           if [ "$PR_REPO" != "${DRONE_REPO}" ]; then
             export DRONE_FORK=true
           fi
-          git fetch ${FLAGS} origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+          git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
           git checkout ${DRONE_COMMIT_BRANCH}
           git fetch origin ${DRONE_COMMIT_REF}:
           git merge ${DRONE_COMMIT}
@@ -192,8 +192,8 @@ steps:
       - git init && git remote add origin ${DRONE_REMOTE_URL}
       - |
         # handle pull requests
-        if [ "{$DRONE_BUILD_EVENT}" == "pull_request" ]; then
-          git fetch ${FLAGS} origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+        if [ "${DRONE_BUILD_EVENT}" == "pull_request" ]; then
+          git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
           git checkout ${DRONE_COMMIT_BRANCH}
           git fetch origin ${DRONE_COMMIT_REF}:
           git merge ${DRONE_COMMIT}
@@ -2462,6 +2462,6 @@ steps:
 
 ---
 kind: signature
-hmac: 77d6a76b6327715a1930f4ea187a42b608f44790bf26228ebfd89afb566e763d
+hmac: f326951fe513237a860e855baccc4e6ef87af6bea98b10d65053e5992c8ee151
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -184,7 +184,7 @@ steps:
         fi
         # We only run milv on subdirectories with a .milv.config.yaml file, so
         # filter the list here to remove irrelevant extra entries
-        git diff --raw ${DRONE_COMMIT}..$${DIFF_REF} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq | grep -Ev'(\.md$|\.yaml$|theme)' > /tmp/docs-versions-changed.txt
+        git diff --raw ${DRONE_COMMIT}..$${DIFF_REF} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq | grep -Ev '(\.md$|\.yaml$|theme)' > /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           # Check trailing whitespace
@@ -2437,6 +2437,6 @@ steps:
 
 ---
 kind: signature
-hmac: 1940c6d5b95e41f04e7dbc968a2c44267ef11b6e9fcc4239bb4f639ed60923d4
+hmac: f1d97ff0b197553754103382a231d99601e26da121f10618132e549ecec9b62d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -34,23 +34,12 @@ steps:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
+      - mkdir -p /go/src/github.com/gravitational/teleport /go/cache
       - cd /go/src/github.com/gravitational/teleport
       - git init && git remote add origin ${DRONE_REMOTE_URL}
       - |
-        # use the Github API to check whether this PR comes from a forked repo or not
-        # if it does, we specifically fetch the PR ref before checking out and don't add the Enterprise submodule
-        # by default, we assume this is a fork (fail safe) until we know otherwise
-        export DRONE_NO_FORK=false
-        # handle PRs
+        # handle pull requests
         if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
-          apk add --no-cache curl jq
-          export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
-          echo "Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
-          # if the source repo for the PR doesn't match DRONE_REPO, then this is a PR raised from a fork
-          if [ "$${PR_REPO}" = "${DRONE_REPO}" ]; then
-            export DRONE_NO_FORK=true
-          fi
           git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
           git checkout ${DRONE_COMMIT_BRANCH}
           git fetch origin ${DRONE_COMMIT_REF}:
@@ -66,16 +55,23 @@ steps:
         fi
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init webassets || true
-      - mkdir -p /go/cache
-      # only clone Enterprise code if this isn't a fork
+      # use the Github API to check whether this PR comes from a forked repo or not
+      # if it does, don't check out the Enterprise code
       - |
-        if [ "$${DRONE_NO_FORK}" = "true" ]; then
-          mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-          ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-          git submodule update --init e
-          # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-          git submodule update --init --recursive webassets || true
-          rm -f /root/.ssh/id_rsa
+        if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
+          apk add --no-cache curl jq
+          export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
+          echo "Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
+          # if the source repo for the PR matches DRONE_REPO, then this is not a PR raised from a fork
+          if [ "$${PR_REPO}" = "${DRONE_REPO}" ]; then
+            mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+            ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+            git submodule update --init e
+            # do a recursive submodule checkout to get both webassets and webassets/e
+            # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+            git submodule update --init --recursive webassets || true
+            rm -f /root/.ssh/id_rsa
+          fi
         fi
 
   - name: Build buildbox
@@ -2464,6 +2460,6 @@ steps:
 
 ---
 kind: signature
-hmac: c2cc0f7c66f1580fc74e1b506def3dbc484b017ee4749dfbeb13d9281adafa75
+hmac: d1c6e2ab7d749df9355098ba9dee100c1b3c1ad81e5c1083ed80ff44485f4734
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -184,7 +184,7 @@ steps:
         fi
         # We only run milv on subdirectories with a .milv.config.yaml file, so
         # filter the list here to remove irrelevant extra entries
-        git diff --raw ${DRONE_COMMIT}..$${DIFF_REF} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq | grep -Ev '(\.md$|\.yaml$|theme)' > /tmp/docs-versions-changed.txt
+        git diff --raw ${DRONE_COMMIT}..$${DIFF_REF} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
         cat /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
@@ -2438,6 +2438,6 @@ steps:
 
 ---
 kind: signature
-hmac: 9b4cde39589d9a8ce9b5bbb98ae288da0cfc776794c3aa14bd4243bca905aab1
+hmac: d2c952ebccced9859c7d8ea51992f2c43929ef3f35965c2c40537ac58d4ef990
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,9 +28,9 @@ steps:
   - name: Check out code
     image: docker:git
     commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/teleport.git .
+      - mkdir -p /go/src/github.com/$DRONE_REPO
+      - cd /go/src/github.com/$DRONE_REPO
+      - git clone https://github.com/$DRONE_REPO.git .
       - git checkout $DRONE_COMMIT
       - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
@@ -43,7 +43,7 @@ steps:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - cd /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/$DRONE_REPO
       # fetch enterprise submodules
       - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
@@ -64,7 +64,7 @@ steps:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
       - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/$DRONE_REPO
       - make -C build.assets buildbox
 
   - name: Run linter
@@ -77,7 +77,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - cd /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/$DRONE_REPO
       - make -C build.assets lint
 
   - name: Run unit tests
@@ -90,7 +90,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - cd /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/$DRONE_REPO
       - make -C build.assets test
 
   - name: Run integration tests
@@ -103,7 +103,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - cd /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/$DRONE_REPO
       - make -C build.assets integration
 
   - name: Send Slack notification for build failures
@@ -163,17 +163,28 @@ steps:
   - name: Check out code
     image: golang:1.14.4
     commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/teleport.git .
+      - mkdir -p /go/src/github.com/$DRONE_REPO
+      - cd /go/src/github.com/$DRONE_REPO
+      - git clone https://github.com/$DRONE_REPO.git .
       - git checkout $DRONE_COMMIT
 
   - name: Run docs tests
     image: golang:1.14.4
     commands:
       - |
-        cd /go/src/github.com/gravitational/teleport
-        git diff --raw ${DRONE_COMMIT}..${DRONE_TARGET_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
+        cd /go/src/github.com/$DRONE_REPO
+        # If we're running against a fork rather than the gravitational/teleport repo
+        # then check that repo out as 'upstream' to compare with it
+        if [[ "$(git remote get-url origin)" != "https://github.com/gravitational/teleport.git" ]]; then
+          git remote add upstream https://github.com/gravitational/teleport.git
+          git fetch upstream
+          export DIFF_REF="upstream/${DRONE_TARGET_BRANCH:-master}"
+        else
+          export DIFF_REF="origin/${DRONE_TARGET_BRANCH:-master}"
+        fi
+        # We only run milv on subdirectories with a .milv.config.yaml file, so
+        # filter the list here to remove irrelevant extra entries
+        git diff --raw ${DRONE_COMMIT}..${DIFF_REF} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq | grep -Ev'(\.md$|\.yaml$|theme)' > /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           # Check trailing whitespace
@@ -2426,6 +2437,6 @@ steps:
 
 ---
 kind: signature
-hmac: 51a74c966af0424f054f4903279844cb68d6ec956c04eb4e933d5e1ad323659d
+hmac: 1a2383070410fb7d703b67515a995aa12927b38d2db98f168d14688d3a0655bc
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,9 +44,9 @@ steps:
         # handle PRs
         if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
           apk add --no-cache curl jq
-          export PR_REPO=$(curl https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name)
+          export PR_REPO=$(curl https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
           # if the source repo for the PR doesn't match DRONE_REPO, then this is a PR raised from a fork
-          if [ ! "$PR_REPO" = "${DRONE_REPO}" ]; then
+          if [ "$${PR_REPO}" != "${DRONE_REPO}" ]; then
             export DRONE_FORK=true
           fi
           git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
@@ -2462,6 +2462,6 @@ steps:
 
 ---
 kind: signature
-hmac: 4f0a0cf3f6064912a4417876edaa00583eaabae79e88eebf61f907d25c674b55
+hmac: 0d1710a7cbeaa8b4c10da249c4f6ebcaaf1a082ff9630e3d5491aafd9610e9c2
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -46,7 +46,7 @@ steps:
           apk add --no-cache curl jq
           export PR_REPO=$(curl https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name)
           # if the source repo for the PR doesn't match DRONE_REPO, then this is a PR raised from a fork
-          if [ "$PR_REPO" != "${DRONE_REPO}" ]; then
+          if [ ! "$PR_REPO" = "${DRONE_REPO}" ]; then
             export DRONE_FORK=true
           fi
           git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
@@ -2462,6 +2462,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7ed58f4e372d519457cf55df3f97aa85ba910d872a0414b3764cdd0b54c2f662
+hmac: 4f0a0cf3f6064912a4417876edaa00583eaabae79e88eebf61f907d25c674b55
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,6 +40,7 @@ steps:
       # use the Github API to check whether this PR comes from a forked repo or not
       # if it does, we specifically fetch the PR ref before checking out and don't add the Enterprise submodule
       - |
+        # by default, we assume this is a fork until we know otherwise
         export DRONE_NO_FORK=false
         # handle PRs
         if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
@@ -2463,6 +2464,6 @@ steps:
 
 ---
 kind: signature
-hmac: ca4a8ed2ca4d49989e7eaec92277585eef1ba411732f8ddc16e0fdcd447b5adc
+hmac: 028f6e0c295b556e5bb8be19f3300fa8ea6e7878805be94e6e20e2646e50be0d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -175,7 +175,7 @@ steps:
         cd /go/src/github.com/$DRONE_REPO
         # If we're running against a fork rather than the gravitational/teleport repo
         # then check that repo out as 'upstream' to compare with it
-        if [[ "$(git remote get-url origin)" != "https://github.com/gravitational/teleport.git" ]]; then
+        if [ "$(git remote get-url origin)" != "https://github.com/gravitational/teleport.git" ]; then
           git remote add upstream https://github.com/gravitational/teleport.git
           git fetch upstream
           export DIFF_REF="upstream/${DRONE_TARGET_BRANCH:-master}"
@@ -2437,6 +2437,6 @@ steps:
 
 ---
 kind: signature
-hmac: 9d13a97204ea2f4badaac398fe36bdb41edbc5d3f59890bde90d47169da9d75d
+hmac: 1940c6d5b95e41f04e7dbc968a2c44267ef11b6e9fcc4239bb4f639ed60923d4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -50,8 +50,13 @@ steps:
           git checkout -qf FETCH_HEAD
         # handle pushes/other events
         else
-          git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
-          git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
+          if [ "${DRONE_COMMIT_BRANCH}" = "" ]; then
+            git fetch origin
+            git checkout -qf ${DRONE_COMMIT_SHA}
+          else
+            git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+            git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
+          fi
         fi
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init webassets || true
@@ -201,8 +206,13 @@ steps:
           git checkout -qf FETCH_HEAD
         # handle pushes/other events
         else
-          git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
-          git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
+          if [ "${DRONE_COMMIT_BRANCH}" = "" ]; then
+            git fetch origin
+            git checkout -qf ${DRONE_COMMIT_SHA}
+          else
+            git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+            git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
+          fi
         fi
 
   - name: Run docs tests
@@ -2460,6 +2470,6 @@ steps:
 
 ---
 kind: signature
-hmac: d1c6e2ab7d749df9355098ba9dee100c1b3c1ad81e5c1083ed80ff44485f4734
+hmac: bb577a9d32f255ad4be2c1081c3be223398f6a2880856a0378d295c61247ebb3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,7 @@ steps:
     commands:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
-      - git remote add origin ${DRONE_REMOTE_URL}
+      - git init && git remote add origin ${DRONE_REMOTE_URL}
       # use the Github API to check whether this PR comes from a forked repo or not
       # if it does, we specifically fetch the PR ref before checking out and don't add the Enterprise submodule
       - |
@@ -189,7 +189,7 @@ steps:
     commands:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
-      - git remote add origin ${DRONE_REMOTE_URL}
+      - git init && git remote add origin ${DRONE_REMOTE_URL}
       - |
         # handle pull requests
         if [ "{$DRONE_BUILD_EVENT}" == "pull_request" ]; then
@@ -2462,6 +2462,6 @@ steps:
 
 ---
 kind: signature
-hmac: a7cc8736e418c2b39c621dfb87ae6702f8216840a5f8e77f69e1de0692aced11
+hmac: 77d6a76b6327715a1930f4ea187a42b608f44790bf26228ebfd89afb566e763d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,7 +44,7 @@ steps:
         # handle PRs
         if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
           apk add --no-cache curl jq
-          export PR_REPO=$(curl https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
+          export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
           # if the source repo for the PR doesn't match DRONE_REPO, then this is a PR raised from a fork
           if [ "$${PR_REPO}" != "${DRONE_REPO}" ]; then
             export DRONE_FORK=true

--- a/.drone.yml
+++ b/.drone.yml
@@ -2462,6 +2462,6 @@ steps:
 
 ---
 kind: signature
-hmac: 0d1710a7cbeaa8b4c10da249c4f6ebcaaf1a082ff9630e3d5491aafd9610e9c2
+hmac: 7e7c30fa4507fdd89adcdca5dac9be3288084c9b4ce485cad70a18dd1414cfc4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,11 +28,11 @@ steps:
   - name: Check out code
     image: docker:git
     commands:
-      - mkdir -p /go/src/github.com/$DRONE_REPO
-      - cd /go/src/github.com/$DRONE_REPO
-      - git clone https://github.com/$DRONE_REPO.git .
+      - mkdir -p /go/src/github.com/${DRONE_REPO}
+      - cd /go/src/github.com/${DRONE_REPO}
+      - git clone https://github.com/${DRONE_REPO}.git .
       - git checkout $DRONE_COMMIT
-      - echo $DRONE_SOURCE_BRANCH > /go/.drone_source_branch.txt
+      - echo ${DRONE_SOURCE_BRANCH} > /go/.drone_source_branch.txt
       # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
       - git submodule update --init webassets || true
       - mkdir -p /go/cache
@@ -43,7 +43,7 @@ steps:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - cd /go/src/github.com/$DRONE_REPO
+      - cd /go/src/github.com/${DRONE_REPO}
       # fetch enterprise submodules
       - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
       - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
@@ -64,7 +64,7 @@ steps:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
       - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - cd /go/src/github.com/$DRONE_REPO
+      - cd /go/src/github.com/${DRONE_REPO}
       - make -C build.assets buildbox
 
   - name: Run linter
@@ -77,7 +77,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - cd /go/src/github.com/$DRONE_REPO
+      - cd /go/src/github.com/${DRONE_REPO}
       - make -C build.assets lint
 
   - name: Run unit tests
@@ -90,7 +90,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - cd /go/src/github.com/$DRONE_REPO
+      - cd /go/src/github.com/${DRONE_REPO}
       - make -C build.assets test
 
   - name: Run integration tests
@@ -103,7 +103,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - cd /go/src/github.com/$DRONE_REPO
+      - cd /go/src/github.com/${DRONE_REPO}
       - make -C build.assets integration
 
   - name: Send Slack notification for build failures
@@ -163,16 +163,16 @@ steps:
   - name: Check out code
     image: golang:1.14.4
     commands:
-      - mkdir -p /go/src/github.com/$DRONE_REPO
-      - cd /go/src/github.com/$DRONE_REPO
-      - git clone https://github.com/$DRONE_REPO.git .
+      - mkdir -p /go/src/github.com/${DRONE_REPO}
+      - cd /go/src/github.com/${DRONE_REPO}
+      - git clone https://github.com/${DRONE_REPO}.git .
       - git checkout $DRONE_COMMIT
 
   - name: Run docs tests
     image: golang:1.14.4
     commands:
       - |
-        cd /go/src/github.com/$DRONE_REPO
+        cd /go/src/github.com/${DRONE_REPO}
         # If we're running against a fork rather than the gravitational/teleport repo
         # then check that repo out as 'upstream' to compare with it
         if [ "$(git remote get-url origin)" != "https://github.com/gravitational/teleport.git" ]; then
@@ -185,6 +185,7 @@ steps:
         # We only run milv on subdirectories with a .milv.config.yaml file, so
         # filter the list here to remove irrelevant extra entries
         git diff --raw ${DRONE_COMMIT}..$${DIFF_REF} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq | grep -Ev '(\.md$|\.yaml$|theme)' > /tmp/docs-versions-changed.txt
+        cat /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
           echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           # Check trailing whitespace
@@ -2437,6 +2438,6 @@ steps:
 
 ---
 kind: signature
-hmac: f1d97ff0b197553754103382a231d99601e26da121f10618132e549ecec9b62d
+hmac: 9b4cde39589d9a8ce9b5bbb98ae288da0cfc776794c3aa14bd4243bca905aab1
 
 ...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gravitational Teleport (webvictim branch 2)
+# Gravitational Teleport
 
 Gravitational Teleport is a modern security gateway for remotely accessing:
 * Clusters of Linux servers via SSH or SSH-over-HTTPS in a browser.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gravitational Teleport
+# Gravitational Teleport (webvictim branch 2)
 
 Gravitational Teleport is a modern security gateway for remotely accessing:
 * Clusters of Linux servers via SSH or SSH-over-HTTPS in a browser.


### PR DESCRIPTION
This PR changes the clone logic for the `test` and `test-docs` pipelines - this is needed so that we can fetch the correct ref to check out commits on PRs which come from forks. I didn't see the point in only overriding the logic for PRs specifically, so all the clone logic for `test` and `test-docs` now matches that used by Drone's inbuilt git commands (which we have to disable, because it doesn't support submodules). This makes it a little more like the way that Jenkins handles PR commits, too, but it's more efficient as we're only fetching relevant refs rather than all of them.
- https://github.com/drone/drone-git/blob/master/posix/clone-commit
- https://github.com/drone/drone-git/blob/master/posix/clone-tag
- https://github.com/drone/drone-git/blob/master/posix/clone-pull-request

This also means that we'll be attempting to merge any code in PRs into `master` as part of the test process, so the tests will fail if the merge can't be done cleanly. This will encourage us to fix any merge conflicts on a branch before tests will pass.

This also adds a GET command run against the Github API and parsed through `jq`, which will tell us whether a PR comes from `gravitational/teleport` or another repo (meaning that it's a fork). When running on a fork, we don't check out Enterprise code and just run all tests against OSS. Ideally Drone would have a conditional flag which would allow us to gate the Enterprise checkout completely based on fork status, but unfortunately this functionality is currently missing. This is the best I can manage without starting to look into custom admission plugins for Drone.

The PR also removes some mentions of `$DRONE_SOURCE_BRANCH` which we don't use any more, and fixes the diff comparison logic for `test-docs` so that it compares against branches on `origin` rather than expecting them to be locally checked out with the correct names.

Relevant to #3936