### PR TITLE
Correct port for proxy public address example

### DIFF
--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -228,7 +228,7 @@ proxy_service:
   # Defaults to the proxy's hostname if not specified. If running multiple
   # proxies behind a load balancer, this name must point to the load balancer
   # (see public_addr section below)
-  public_addr: TELEPORT_PUBLIC_DNS_NAME:3022
+  public_addr: TELEPORT_PUBLIC_DNS_NAME:3080
 
   # TLS certificate for the HTTPS connection. Configuring these properly is
   # critical for Teleport security.


### PR DESCRIPTION
The public address port is listed in an example as 3022.  It should be 3080.