### PR TITLE
Added Google to  storage back-end options list

### DIFF
--- a/docs/4.3/architecture/teleport_auth.md
+++ b/docs/4.3/architecture/teleport_auth.md
@@ -224,9 +224,9 @@ back-ends as shown in the table below:
 
 Data Type        | Supported Back-ends       | Notes
 -----------------|---------------------------|---------
-Cluster state    | `dir`, `etcd`, `dynamodb` | Multi-server (HA) configuration is only supported using `etcd` and `dynamodb` back-ends.
-Audit Log Events | `dir`, `dynamodb`         | If `dynamodb` is used for the audit log events, `s3` back-end **must** be used for the recorded sessions.
-Recorded Sessions| `dir`, `s3`               | `s3` is mandatory if `dynamodb` is used for the audit log.
+Cluster state    | `dir`, `etcd`, `dynamodb`,`firestore` | Multi-server (HA) configuration is only supported using `etcd`, `dynamodb`, and `firestore` back-ends.
+Audit Log Events | `dir`, `dynamodb`, `firestore`         | If `dynamodb` is used for the audit log events, `s3` back-end **must** be used for the recorded sessions.
+Recorded Sessions| `dir`, `s3`, `gcp`               | `s3` is mandatory if `dynamodb` is used for the audit log.
 
 !!! tip "Note"
 

--- a/docs/4.3/architecture/teleport_auth.md
+++ b/docs/4.3/architecture/teleport_auth.md
@@ -226,7 +226,7 @@ Data Type        | Supported Back-ends       | Notes
 -----------------|---------------------------|---------
 Cluster state    | `dir`, `etcd`, `dynamodb`,`firestore` | Multi-server (HA) configuration is only supported using `etcd`, `dynamodb`, and `firestore` back-ends.
 Audit Log Events | `dir`, `dynamodb`, `firestore`         | If `dynamodb` is used for the audit log events, `s3` back-end **must** be used for the recorded sessions.
-Recorded Sessions| `dir`, `s3`, `gcp`               | `s3` is mandatory if `dynamodb` is used for the audit log.
+Recorded Sessions| `dir`, `s3`, `gs`               | `s3` is mandatory if `dynamodb` is used for the audit log. `gs` is Google storage.
 
 !!! tip "Note"
 

--- a/docs/4.3/architecture/teleport_auth.md
+++ b/docs/4.3/architecture/teleport_auth.md
@@ -226,7 +226,7 @@ Data Type        | Supported Back-ends       | Notes
 -----------------|---------------------------|---------
 Cluster state    | `dir`, `etcd`, `dynamodb`,`firestore` | Multi-server (HA) configuration is only supported using `etcd`, `dynamodb`, and `firestore` back-ends.
 Audit Log Events | `dir`, `dynamodb`, `firestore`         | If `dynamodb` is used for the audit log events, `s3` back-end **must** be used for the recorded sessions.
-Recorded Sessions| `dir`, `s3`, `gs`               | `s3` is mandatory if `dynamodb` is used for the audit log. `gs` is Google storage.
+Recorded Sessions| `dir`, `s3`              | `s3` is mandatory if `dynamodb` is used for the audit log. For Google Cloud storage use `audit_sessions_uri: 'gs://`
 
 !!! tip "Note"
 


### PR DESCRIPTION
The google firestore and gcp storage were not listed as options