### PR TITLE
correct public web address port in eks example

### DIFF
--- a/examples/aws/eks/teleport.yaml
+++ b/examples/aws/eks/teleport.yaml
@@ -27,7 +27,7 @@ export TELEPORT_CLUSTER_NAME="[teleport-cluster-name]"
       listen_addr: 0.0.0.0:3023
       web_listen_addr: 0.0.0.0:3080
       tunnel_listen_addr: 0.0.0.0:3024
-      public_addr: $TELEPORT_PUBLIC_DNS_NAME:3022
+      public_addr: $TELEPORT_PUBLIC_DNS_NAME:3080
       # TLS certificate for the HTTPS connection. Configuring these properly is
       # critical for Teleport security.
       https_key_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/privkey.pem


### PR DESCRIPTION
Correction to the public web address to use 3080 instead of 3022. This is also being pulled into the docs as an example.