### PR TITLE
removed .Hidden() method to show --permit-user-env on start --help 

### DIFF
--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -118,7 +118,7 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 	start.Flag("diag-addr",
 		"Start diangonstic prometheus and healthz endpoint.").Hidden().StringVar(&ccf.DiagnosticAddr)
 	start.Flag("permit-user-env",
-		"Enables reading of ~/.tsh/environment when creating a session").Hidden().BoolVar(&ccf.PermitUserEnvironment)
+		"Enables reading of ~/.tsh/environment when creating a session").BoolVar(&ccf.PermitUserEnvironment)
 	start.Flag("insecure",
 		"Insecure mode disables certificate validation").BoolVar(&ccf.InsecureMode)
 	start.Flag("fips",


### PR DESCRIPTION
## Purpose 
To show --permit-user-env on `teleport start --help` manual

## Implementation 
Removed hidden method applied 

Fixed #3075 

## Testing 

``` ./build/teleport start --help
usage: teleport start [<flags>]

Starts the Teleport service.

Flags:
  -d, --debug            Enable verbose logging to stderr
      --insecure-no-tls  Disable TLS for the web socket
  -r, --roles            Comma-separated list of roles to start with
                         [proxy,node,auth]
      --pid-file         Full path to the PID file. By default no PID file will
                         be created
      --advertise-ip     IP to advertise to clients if running behind NAT
  -l, --listen-ip        IP address to bind to [0.0.0.0]
      --auth-server      Address of the auth server [127.0.0.1:3025]
      --token            Invitation token to register with an auth server [none]
      --ca-pin           CA pin to validate the Auth Server
      --nodename         Name of this node, defaults to hostname
  -c, --config           Path to a configuration file [/etc/teleport.yaml]
      --bootstrap        Path to bootstrap file (ignored if already initialized)
      --labels           List of labels for this node
      --permit-user-env  Enables reading of ~/.tsh/environment when creating a
                         session
      --insecure         Insecure mode disables certificate validation
      --fips             Start Teleport in FedRAMP/FIPS 140-2 mode.

Aliases:
Notes:
  --roles=node,proxy,auth

  This flag tells Teleport which services to run. By default it runs all three. 
  In a production environment you may want to separate them.

  --token=xyz

  This token is needed to connect a node to an auth server. Obtain it by running 
  "tctl nodes add" on the auth server. It's used once and ignored afterwards.

Examples:

> teleport start 
  By default without any configuration, teleport starts running as a single-node
  cluster. It's the equivalent of running with --roles=node,proxy,auth 

> teleport start --roles=node --auth-server=10.1.0.1 --token=xyz --nodename=db
  Starts a node named 'db' running in strictly SSH mode role, joining the cluster 
  serviced by the auth server running on 10.1.0.1

> teleport start --roles=node --auth-server=10.1.0.1 --labels=db=master
  Same as the above, but the node runs with db=master label and can be connected
  to using that label in addition to its name.
```