### PR TITLE
Removed GOPATH from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ Make sure you have Golang `v1.14` or newer, then run:
 
 ```bash
 # get the source & build:
-$ mkdir -p $GOPATH/src/github.com/gravitational
-$ cd $GOPATH/src/github.com/gravitational
 $ git clone https://github.com/gravitational/teleport.git
 $ cd teleport
 $ make full


### PR DESCRIPTION
## Purpose 

Do we still need `$ mkdir -p $GOPATH/src/github.com/gravitational`
`$ cd $GOPATH/src/github.com/gravitational`? I tried following the README without these commands and it worked. 



```quin@quin-ThinkPad-P53:~/temp/teleport$ make full
VERSION=4.4.0-dev make -f version.mk setver
make[1]: Entering directory '/home/quin/temp/teleport'
make[1]: Leaving directory '/home/quin/temp/teleport'
---> Building OSS binaries.
make build/teleport build/tctl build/tsh
make[1]: Entering directory '/home/quin/temp/teleport'
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags "  " -o build/teleport  -ldflags '-w -s' ./tool/teleport
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags "  " -o build/tctl  -ldflags '-w -s' ./tool/tctl
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags " " -o build/tsh  -ldflags '-w -s' ./tool/tsh
make[1]: Leaving directory '/home/quin/temp/teleport'
---> Building OSS web assets.
cd webassets/teleport/ ; zip -qr ../../build/webassets.zip .
---> Attaching OSS web assets.
cat build/webassets.zip >> build/teleport
rm -fr build/webassets.zip
zip -q -A build/teleport
```
