### PR TITLE
Track SSH client activity per ssh.Channel

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -422,6 +422,12 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 	return nil
 }
 
+// TrackActivity keeps track of all activity on ssh.Channel. The caller should
+// use the returned ssh.Channel instead of the original one.
+func (c *ServerContext) TrackActivity(ch ssh.Channel) ssh.Channel {
+	return newTrackingChannel(ch, c)
+}
+
 // GetClientLastActive returns time when client was last active
 func (c *ServerContext) GetClientLastActive() time.Time {
 	c.RLock()
@@ -742,25 +748,4 @@ func closeAll(closers ...io.Closer) error {
 	}
 
 	return trace.NewAggregate(errs...)
-}
-
-// NewTrackingReader returns a new instance of
-// activity tracking reader.
-func NewTrackingReader(ctx *ServerContext, r io.Reader) *TrackingReader {
-	return &TrackingReader{ctx: ctx, r: r}
-}
-
-// TrackingReader wraps the writer
-// and every time write occurs, updates
-// the activity in the server context
-type TrackingReader struct {
-	ctx *ServerContext
-	r   io.Reader
-}
-
-// Read passes the read through to internal
-// reader, and updates activity of the server context
-func (a *TrackingReader) Read(b []byte) (int, error) {
-	a.ctx.UpdateClientActivity()
-	return a.r.Read(b)
 }

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -666,6 +666,8 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ch ssh.Channel, r
 	scx.DstAddr = fmt.Sprintf("%v:%d", req.Host, req.Port)
 	defer scx.Close()
 
+	ch = scx.TrackActivity(ch)
+
 	// Check if the role allows port forwarding for this user.
 	err = s.authHandlers.CheckPortForward(scx.DstAddr, scx)
 	if err != nil {
@@ -743,6 +745,8 @@ func (s *Server) handleSessionRequests(ctx context.Context, ch ssh.Channel, in <
 	scx.AddCloser(ch)
 	scx.ChannelType = teleport.ChanSession
 	defer scx.Close()
+
+	ch = scx.TrackActivity(ch)
 
 	// Create a "session" channel on the remote host.
 	remoteSession, err := s.remoteClient.NewSession()

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -264,7 +264,7 @@ func (t *proxySubsys) proxyToSite(
 			t.close(err)
 		}()
 		defer conn.Close()
-		_, err = io.Copy(conn, srv.NewTrackingReader(ctx, ch))
+		_, err = io.Copy(conn, ch)
 
 	}()
 
@@ -438,7 +438,7 @@ func (t *proxySubsys) proxyToHost(
 			t.close(err)
 		}()
 		defer conn.Close()
-		_, err = io.Copy(conn, srv.NewTrackingReader(ctx, ch))
+		_, err = io.Copy(conn, ch)
 	}()
 
 	return nil

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -943,6 +943,8 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 	scx.DstAddr = net.JoinHostPort(req.Host, strconv.Itoa(int(req.Port)))
 	defer scx.Close()
 
+	channel = scx.TrackActivity(channel)
+
 	// Check if the role allows port forwarding for this user.
 	err = s.authHandlers.CheckPortForward(scx.DstAddr, scx)
 	if err != nil {
@@ -1054,6 +1056,8 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 	scx.AddCloser(ch)
 	scx.ChannelType = teleport.ChanSession
 	defer scx.Close()
+
+	ch = scx.TrackActivity(ch)
 
 	clusterConfig, err := s.GetAccessPoint().GetClusterConfig()
 	if err != nil {
@@ -1345,6 +1349,8 @@ func (s *Server) handleProxyJump(ctx context.Context, ccx *sshutils.ConnectionCo
 	scx.IsTestStub = s.isTestStub
 	scx.AddCloser(ch)
 	defer scx.Close()
+
+	ch = scx.TrackActivity(ch)
 
 	clusterConfig, err := s.GetAccessPoint().GetClusterConfig()
 	if err != nil {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1227,7 +1227,6 @@ func (p *party) getLastActive() time.Time {
 
 func (p *party) Read(bytes []byte) (int, error) {
 	p.updateActivity()
-	p.ctx.UpdateClientActivity()
 	return p.ch.Read(bytes)
 }
 


### PR DESCRIPTION
This is the lowest-level transport we have after SSH session is
established. Any data going either direction indicates some activity.

Note: we also track writes from server to client as activity. If a user
starts a script that prints something every minute and steps away, the
session should keep going as long as `client_idle_timeout > 1m`.

This also fixes things like large SCP transfers.

Fixes https://github.com/gravitational/teleport/issues/3933