### PR TITLE
Add KillMode=process to systemd unit files running Teleport node

### DIFF
--- a/assets/aws/files/system/teleport-acm.service
+++ b/assets/aws/files/system/teleport-acm.service
@@ -12,5 +12,6 @@ RestartSec=5
 RuntimeDirectory=teleport
 ExecStart=/usr/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3434 --pid-file=/run/teleport/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=65536

--- a/assets/aws/files/system/teleport-node.service
+++ b/assets/aws/files/system/teleport-node.service
@@ -13,6 +13,7 @@ RuntimeDirectory=teleport
 ExecStartPre=/usr/bin/teleport-ssm-get-token
 ExecStart=/usr/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3434 --pid-file=/run/teleport/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=65536
 

--- a/assets/aws/files/system/teleport.service
+++ b/assets/aws/files/system/teleport.service
@@ -13,6 +13,7 @@ RuntimeDirectory=teleport
 ExecStartPre=/usr/bin/teleport-all-pre-start
 ExecStart=/usr/bin/teleport start --config=/etc/teleport.yaml --diag-addr=127.0.0.1:3434 --pid-file=/run/teleport/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport/teleport.pid
 LimitNOFILE=65536
 

--- a/build.assets/pkg/init-scripts/systemd/system/teleport.service
+++ b/build.assets/pkg/init-scripts/systemd/system/teleport.service
@@ -7,6 +7,7 @@ Type=simple
 Restart=on-failure
 ExecStart=/usr/local/bin/teleport start --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport.pid
 
 [Install]

--- a/docs/3.1/admin-guide.md
+++ b/docs/3.1/admin-guide.md
@@ -78,6 +78,7 @@ Type=simple
 Restart=on-failure
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --pid-file=/var/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/var/run/teleport.pid
 
 [Install]

--- a/docs/3.2/admin-guide.md
+++ b/docs/3.2/admin-guide.md
@@ -78,6 +78,7 @@ Type=simple
 Restart=on-failure
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --pid-file=/var/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/var/run/teleport.pid
 
 [Install]

--- a/docs/4.0/admin-guide.md
+++ b/docs/4.0/admin-guide.md
@@ -108,6 +108,7 @@ Type=simple
 Restart=on-failure
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport.pid
 
 [Install]

--- a/docs/4.1/admin-guide.md
+++ b/docs/4.1/admin-guide.md
@@ -114,6 +114,7 @@ Type=simple
 Restart=on-failure
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --pid-file=/var/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/var/run/teleport.pid
 
 [Install]

--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -60,6 +60,7 @@ Type=simple
 Restart=on-failure
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport.pid
 
 [Install]

--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -60,6 +60,7 @@ Type=simple
 Restart=on-failure
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport.pid
 
 [Install]

--- a/examples/chart/teleport-daemonset/templates/config.yaml
+++ b/examples/chart/teleport-daemonset/templates/config.yaml
@@ -75,6 +75,7 @@ data:
     Restart=on-failure
     ExecStart=/usr/local/bin/teleport start -c /etc/teleport/teleport.yaml --pid-file=/run/teleport.pid
     ExecReload=/bin/kill -HUP \$MAINPID
+    KillMode=process
     PIDFile=/run/teleport.pid
 
     [Install]

--- a/examples/systemd/fips/teleport.service
+++ b/examples/systemd/fips/teleport.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Teleport SSH Service FIPS 
+Description=Teleport SSH Service FIPS
 After=network.target
 
 [Service]
@@ -8,6 +8,7 @@ Restart=on-failure
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --fips --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport.pid
 
 [Install]

--- a/examples/systemd/production/node/teleport.service
+++ b/examples/systemd/production/node/teleport.service
@@ -12,6 +12,7 @@ Restart=on-failure
 # if none is set
 ExecStart=/usr/local/bin/teleport start --roles=node --config=/etc/teleport.yaml --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport.pid
 
 [Install]

--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -8,6 +8,7 @@ Restart=on-failure
 EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
 PIDFile=/run/teleport.pid
 
 [Install]

--- a/vagrant/teleport.service
+++ b/vagrant/teleport.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Teleport SSH server
-After=network.target 
+After=network.target
 
 [Service]
 Type=simple
@@ -8,6 +8,7 @@ Restart=always
 RestartSec=5
 ExecStartPre=/bin/mkdir -p -m0700 /var/lib/teleport
 ExecStart=/usr/local/bin/teleport start -c /opt/teleport/teleport.yaml
+KillMode=process
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
Normally, processes started from a shell which was spawned by a Teleport node process will have their parent PID set to that of the Teleport node process.

This leads to situations where you can start a process, exit your shell and the process will continue running, but then a future `systemctl restart teleport` will kills off the Teleport process and all its children will be killed too - meaning that the long-running process that was started via a previous Teleport session will die unexpectedly.

This PR adds `KillMode=process` to systemd unit files for Teleport which might be used to run Teleport node processes. This is the same behaviour that `sshd` uses to avoid unexpectedly killing child processes - instead, the child processes will become orphans and should be reparented to PID 1 by the `init` process.

The possible downside of this fix is that it will become possible to lose track of processes which have been spawned via Teleport sessions. This should be mitigated by the fact that the `init` process will reparent those orphan processes and they will be managed there instead. In situations where a process is already being "correctly" managed (i.e. a critical, long-running database process or similar) then `systemd` or another init system should already be ensuring that these processes are correctly parented and there will be no observable change.

Fixes #2355