### PR TITLE
Backport missing Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ docker:
 
 # Dockerized build: useful for making Linux binaries on OSX
 .PHONY:docker-binaries
-docker-binaries:
+docker-binaries: clean
 	make -C build.assets build-binaries
 
 # Interactively enters a Docker container (which you can build and run Teleport inside of)
@@ -358,7 +358,7 @@ install: build
 # Docker image build. Always build the binaries themselves within docker (see
 # the "docker" rule) to avoid dependencies on the host libc version.
 .PHONY: image
-image: docker-binaries
+image: clean docker-binaries
 	cp ./build.assets/charts/Dockerfile $(BUILDDIR)/
 	cd $(BUILDDIR) && docker build --no-cache . -t $(DOCKER_IMAGE):$(VERSION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e image; fi

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -56,6 +56,15 @@ build-binaries: buildbox
 		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' all
 
 #
+# Build 'teleport' Enterprise release inside a docker container
+#
+.PHONY:build-enterprise-binaries
+build-enterprise-binaries: buildbox
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOX) \
+		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' all
+
+
+#
 # Builds a Docker container which is used for building official Teleport
 # binaries and docs
 #


### PR DESCRIPTION
Somehow a `Makefile` command got missed during backports. Adding the missing commands back in.