### PR TITLE
Release 4.3.4-dev.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.3.3
+VERSION=4.3.4-dev.2
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -63,6 +63,14 @@ build-enterprise-binaries: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOX) \
 		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' all
 
+#
+# Build 'teleport' FIPS release inside a docker container
+# This builds Enterprise binaries only.
+#
+.PHONY:build-binaries-fips
+build-binaries-fips: buildbox-fips
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOXFIPS) \
+		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' all
 
 #
 # Builds a Docker container which is used for building official Teleport

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.3.3"
+	Version = "4.3.4-dev.2"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Also backport missing `build-binaries-fips` command.