### PR TITLE
More build pipeline fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2284,11 +2284,10 @@ steps:
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
       - cd /go/src/github.com/gravitational/teleport
-      # VERSION and GITTAG need to be set manually when running in the e directory.
-      # Normally, these are exported by the root Makefile and inherited, but this is
-      # not the case for FIPS builds (which only run in e)
+      # VERSION needs to be set manually when running in the e directory.
+      # Normally, the version is set and exported by the root Makefile and then inherited,
+      # but this is not the case for FIPS builds (which only run in e/Makefile)
       - export VERSION=$(cat /go/.version.txt)
-      - export GITTAG=v$${VERSION}
       # TODO
       # this should be changed to "make -C e image-fips publish-fips" when we want to
       # actually cut over to building public-facing Docker images using Drone
@@ -2660,6 +2659,6 @@ steps:
 
 ---
 kind: signature
-hmac: 61d0ae75cd3dd6af099263508e029fc8ad434134c2bbd8807fdd02c94fe26841
+hmac: 7a6deb7d2a98555c3815a08fbe174f239beea543704d3cf32420bfd4d5bacae8
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2284,8 +2284,11 @@ steps:
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
       - cd /go/src/github.com/gravitational/teleport
-      # version needs to be set manually when running in the e directory
+      # VERSION and GITTAG need to be set manually when running in the e directory.
+      # Normally, these are exported by the root Makefile and inherited, but this is
+      # not the case for FIPS builds (which only run in e)
       - export VERSION=$(cat /go/.version.txt)
+      - export GITTAG=v$${VERSION}
       # TODO
       # this should be changed to "make -C e image-fips publish-fips" when we want to
       # actually cut over to building public-facing Docker images using Drone
@@ -2657,6 +2660,6 @@ steps:
 
 ---
 kind: signature
-hmac: ff4ee42fbbd81274a113a42ae3d84b0095c1b8de902c483afc8ba492e68989ab
+hmac: 61d0ae75cd3dd6af099263508e029fc8ad434134c2bbd8807fdd02c94fe26841
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -867,9 +867,6 @@ kind: pipeline
 type: kubernetes
 name: build-linux-amd64-rpm
 
-environment:
-  RUNTIME: go1.14.4
-
 trigger:
   event:
     - tag
@@ -2660,6 +2657,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7476944e39bc210494289efb55d4fa4efc195c7d7ca04fc08c7f3e7d8f707279
+hmac: ff4ee42fbbd81274a113a42ae3d84b0095c1b8de902c483afc8ba492e68989ab
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -632,7 +632,7 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       region: us-west-2
       source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG}
+      target: teleport/tag/${DRONE_TAG##v}
       strip_prefix: /go/artifacts/
 
 services:
@@ -2660,6 +2660,6 @@ steps:
 
 ---
 kind: signature
-hmac: c7f142a3bf5f477f5e30163dd87a143b503a230617be28794def564f120e8ca1
+hmac: 7476944e39bc210494289efb55d4fa4efc195c7d7ca04fc08c7f3e7d8f707279
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -61,7 +61,7 @@ build-binaries: buildbox
 .PHONY:build-enterprise-binaries
 build-enterprise-binaries: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOX) \
-		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' full
+		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=$(GITTAG) full
 
 #
 # Build 'teleport' FIPS release inside a docker container
@@ -70,7 +70,7 @@ build-enterprise-binaries: buildbox
 .PHONY:build-binaries-fips
 build-binaries-fips: buildbox-fips
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOXFIPS) \
-		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' FIPS=yes full
+		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=$(GITTAG) FIPS=yes full
 
 #
 # Builds a Docker container which is used for building official Teleport

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -61,7 +61,7 @@ build-binaries: buildbox
 .PHONY:build-enterprise-binaries
 build-enterprise-binaries: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOX) \
-		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=$(GITTAG) full
+		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=v$(VERSION) full
 
 #
 # Build 'teleport' FIPS release inside a docker container
@@ -70,7 +70,7 @@ build-enterprise-binaries: buildbox
 .PHONY:build-binaries-fips
 build-binaries-fips: buildbox-fips
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOXFIPS) \
-		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=$(GITTAG) FIPS=yes full
+		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=v$(VERSION) FIPS=yes full
 
 #
 # Builds a Docker container which is used for building official Teleport

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -53,7 +53,7 @@ build: buildbox
 .PHONY:build-binaries
 build-binaries: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOX) \
-		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' all
+		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' full
 
 #
 # Build 'teleport' Enterprise release inside a docker container
@@ -61,7 +61,7 @@ build-binaries: buildbox
 .PHONY:build-enterprise-binaries
 build-enterprise-binaries: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOX) \
-		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' all
+		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' full
 
 #
 # Build 'teleport' FIPS release inside a docker container
@@ -70,7 +70,7 @@ build-enterprise-binaries: buildbox
 .PHONY:build-binaries-fips
 build-binaries-fips: buildbox-fips
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) $(BUILDBOXFIPS) \
-		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' all
+		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' FIPS=yes full
 
 #
 # Builds a Docker container which is used for building official Teleport


### PR DESCRIPTION
- We have a surplus `v` in the path for uploaded FIPS artifacts which prevents uploads to S3 from working correctly.
- We are specifying `RUNTIME` for an RPM build that doesn't need it, which is confusing the RPM build script.
- When building Docker images using `make image` or `make -C e image-fips`, it's always been assumed that these commands are run by Jenkins, which has an external script that will set the `VERSION` and `GITTAG` variables. This isn't  a safe or healthy assumption, so we're now being more explicit about passing the variables around when they're needed.
- Jenkins also has an external script to set `FIPS=yes` when requesting that binaries are built, which we shouldn't assume exists. If we're running the `build-binaries-fips` command, it needs to set `FIPS=yes` itself.
- The `build-binaries` and `build-binaries-fips` commands previously called `make all` which doesn't add the web assets to Teleport binaries. They now call `make full`, which **does** add the web assets. This was an oversight on my part.
  - Docker builds previously worked in Jenkins by what seems to be sheer fluke - because the `make image` command is wrapped by another script that builds the binaries before it's invoked (and `make clean` was never previously run before `make image`), it was just picking up those leftover binaries for the Docker image.
  - After things got tidied up in the `Makefile` to make way for the introduction of Drone, this assumption for Jenkins didn't hold true any more. It's now explicit that `make image` and `make -C e image-fips` need to build their own binaries beforehand.

Fixes #4203