### PR TITLE
Export FIPS_AMI_NAME for Enterprise AMI builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2463,6 +2463,7 @@ steps:
       - cd /go/src/github.com/gravitational/teleport/assets/aws
       - export TELEPORT_VERSION=$(cat /go/.version.txt)
       - export PUBLIC_AMI_NAME=gravitational-teleport-ami-ent-$TELEPORT_VERSION
+      - export FIPS_AMI_NAME=gravitational-teleport-ami-ent-$TELEPORT_VERSION-fips
       - export MARKETPLACE_AMI_NAME=gravitational-teleport-marketplace-ami-ent-$TELEPORT_VERSION
       - |
         if [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
@@ -2659,6 +2660,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7a6deb7d2a98555c3815a08fbe174f239beea543704d3cf32420bfd4d5bacae8
+hmac: 382d9ed0ef2248daf1c75e74c0f1560291365c3671f441894f0ad723406a183f
 
 ...


### PR DESCRIPTION
Adds an extra variable that we're missing from Enterprise AMI builds in Drone.