### PR TITLE
Set users acl and refactor token event

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1101,14 +1101,6 @@ func (a *AuthWithRoles) CreateResetPasswordToken(ctx context.Context, req Create
 		return nil, trace.Wrap(err)
 	}
 
-	if err := a.EmitAuditEvent(events.ResetPasswordTokenCreated, events.EventFields{
-		events.FieldName:             req.Name,
-		events.ResetPasswordTokenTTL: req.TTL.String(),
-		events.EventUser:             a.user.GetName(),
-	}); err != nil {
-		log.Warnf("Failed to emit create reset password token event: %v", err)
-	}
-
 	return a.authServer.CreateResetPasswordToken(ctx, req)
 }
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -51,6 +51,7 @@ var AdminUserRules = []Rule{
 	NewRule(KindSession, RO()),
 	NewRule(KindTrustedCluster, RW()),
 	NewRule(KindEvent, RO()),
+	NewRule(KindUser, RO()),
 }
 
 // DefaultImplicitRules provides access to the default set of implicit rules

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -51,7 +51,6 @@ var AdminUserRules = []Rule{
 	NewRule(KindSession, RO()),
 	NewRule(KindTrustedCluster, RW()),
 	NewRule(KindEvent, RO()),
-	NewRule(KindUser, RO()),
 }
 
 // DefaultImplicitRules provides access to the default set of implicit rules

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -328,7 +328,6 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 			httplib.Rewrite("/webapi/sites/([^/]+)/sessions", "/webapi/sites/$1/namespaces/default/sessions"),
 			httplib.Rewrite("/webapi/sites/([^/]+)/nodes", "/webapi/sites/$1/namespaces/default/nodes"),
 			httplib.Rewrite("/webapi/sites/([^/]+)/connect", "/webapi/sites/$1/namespaces/default/connect"),
-			httplib.Rewrite("/webapi/sites/([^/]+)/users", "/webapi/sites/$1/namespaces/default/users"),
 		),
 		handler: h,
 	}, nil

--- a/lib/web/ui/resetpasswordtoken.go
+++ b/lib/web/ui/resetpasswordtoken.go
@@ -18,16 +18,18 @@ package ui
 
 import "time"
 
-// ResetPasswordToken describes ResetPasswordToken UI object
+// ResetPasswordToken contains data about user and their password setup.
 type ResetPasswordToken struct {
-	// TokenID is token ID
+	// TokenID is the value of token.
 	TokenID string `json:"tokenId"`
-	// User is user name associated with this token
+	// User is user name associated with this token.
 	User string `json:"user"`
-	// QRCode is a QR code value
+	// QRCode is a QR code value.
 	QRCode []byte `json:"qrCode,omitempty"`
-	// URL is token URL
+	// URL is password setup URL.
 	URL string `json:"url,omitempty"`
-	// Expiry is token expiration time
+	// Expiry is token expiration time.
 	Expiry time.Time `json:"expiry,omitempty"`
+	// Expires is duration when token expires in format HoursMinutesSeconds
+	Expires string `json:"expires,omitempty"`
 }

--- a/lib/web/ui/resetpasswordtoken.go
+++ b/lib/web/ui/resetpasswordtoken.go
@@ -18,18 +18,14 @@ package ui
 
 import "time"
 
-// ResetPasswordToken contains data about user and their password setup.
+// ResetPasswordToken describes ResetPasswordToken UI object
 type ResetPasswordToken struct {
-	// TokenID is the value of token.
+	// TokenID is token ID
 	TokenID string `json:"tokenId"`
-	// User is user name associated with this token.
+	// User is user name associated with this token
 	User string `json:"user"`
-	// QRCode is a QR code value.
+	// QRCode is a QR code value
 	QRCode []byte `json:"qrCode,omitempty"`
-	// URL is password setup URL.
-	URL string `json:"url,omitempty"`
-	// Expiry is token expiration time.
+	// Expiry is token expiration time
 	Expiry time.Time `json:"expiry,omitempty"`
-	// Expires is duration when token expires in format HoursMinutesSeconds
-	Expires string `json:"expires,omitempty"`
 }

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -37,6 +37,8 @@ type userACL struct {
 	AuthConnectors access `json:"authConnectors"`
 	// Roles defines access to roles
 	Roles access `json:"roles"`
+	// Users defines access to users.
+	Users access `json:"users"`
 	// TrustedClusters defines access to trusted clusters
 	TrustedClusters access `json:"trustedClusters"`
 	// Events defines access to audit logs
@@ -115,6 +117,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 	authConnectors := newAccess(userRoles, ctx, services.KindAuthConnector)
 	trustedClusterAccess := newAccess(userRoles, ctx, services.KindTrustedCluster)
 	eventAccess := newAccess(userRoles, ctx, services.KindEvent)
+	userAccess := newAccess(userRoles, ctx, services.KindUser)
 	logins := getLogins(userRoles)
 
 	acl := userACL{
@@ -124,6 +127,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 		Roles:           roleAccess,
 		Events:          eventAccess,
 		SSHLogins:       logins,
+		Users:           userAccess,
 	}
 
 	// local user

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -67,6 +67,7 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Events, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Sessions, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Roles, check.DeepEquals, denied)
+	c.Assert(userContext.ACL.Users, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
 
 	// test local auth type


### PR DESCRIPTION
#### Description
Most were ported from https://github.com/gravitational/teleport/pull/4150

This PR sets the users ACL for the user in context:
- defined access users to control level of permission on what a user can perform against other users in UI
- plugged users rule as part of admin role by default (read only)
- refactor how events are emitted when creating resetting password
- Update `createResetPasswordToken` handler, struct (remove some fields), and endpoint (remove namespace)

#### Reliant PR
https://github.com/gravitational/teleport.e/pull/156