### PR TITLE
Added AAP server process.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -118,6 +118,9 @@ const (
 	// ComponentProxy is SSH proxy (SSH server forwarding connections)
 	ComponentProxy = "proxy"
 
+	// ComponentApp is the application proxy service (AAP).
+	ComponentApp = "app"
+
 	// ComponentDiagnostic is a diagnostic service
 	ComponentDiagnostic = "diag"
 

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -41,12 +41,16 @@ type Announcer interface {
 
 	// NewKeepAliver returns a new instance of keep aliver
 	NewKeepAliver(ctx context.Context) (services.KeepAliver, error)
+
+	// UpsertApp is used by applications to report their presence to the backend.
+	UpsertApp(context.Context, services.Server) (*services.KeepAlive, error)
 }
 
 // ReadAccessPoint is an API interface implemented by a certificate authority (CA)
 type ReadAccessPoint interface {
 	// Closer closes all the resources
 	io.Closer
+
 	// GetReverseTunnels returns  a list of reverse tunnels
 	GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error)
 
@@ -64,6 +68,9 @@ type ReadAccessPoint interface {
 
 	// GetNodes returns a list of registered servers for this cluster.
 	GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error)
+
+	// GetApps returns a list of registered apps for this cluster.
+	GetApps(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]services.Server, error)
 
 	// GetProxies returns a list of proxy servers registered in the cluster
 	GetProxies() ([]services.Server, error)
@@ -100,6 +107,7 @@ type ReadAccessPoint interface {
 type AccessPoint interface {
 	// ReadAccessPoint provides methods to read data
 	ReadAccessPoint
+
 	// Announcer adds methods used to announce presence
 	Announcer
 
@@ -184,6 +192,11 @@ func (w *Wrapper) NewKeepAliver(ctx context.Context) (services.KeepAliver, error
 // UpsertProxy is part of auth.AccessPoint implementation
 func (w *Wrapper) UpsertProxy(s services.Server) error {
 	return w.Write.UpsertProxy(s)
+}
+
+// UpsertApp is part of the auth.AccessPoint implementation.
+func (w *Wrapper) UpsertApp(ctx context.Context, app services.Server) (*services.KeepAlive, error) {
+	return w.Write.UpsertApp(ctx, app)
 }
 
 // UpsertTunnelConnection is a part of auth.AccessPoint implementation

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -361,7 +361,7 @@ func (s *APIServer) keepAliveNode(auth ClientI, w http.ResponseWriter, r *http.R
 	if err := httplib.ReadJSON(r, &handle); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := auth.KeepAliveNode(r.Context(), handle); err != nil {
+	if err := auth.KeepAliveResource(r.Context(), handle); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return message("ok"), nil

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1612,7 +1612,7 @@ func (k *authKeepAliver) forwardKeepAlives() {
 		case <-k.ctx.Done():
 			return
 		case keepAlive := <-k.keepAlivesC:
-			err := k.a.KeepAliveNode(k.ctx, keepAlive)
+			err := k.a.KeepAliveResource(k.ctx, keepAlive)
 			if err != nil {
 				k.closeWithError(err)
 				return

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -720,8 +720,17 @@ func (c *Client) UpsertNode(s services.Server) (*services.KeepAlive, error) {
 	return keepAlive, nil
 }
 
-// KeepAliveNode updates node keep alive information
+// DELETE IN: 5.1.0
+//
+// This logic has been moved to KeepAliveResource.
+//
+// KeepAliveNode updates node keep alive information.
 func (c *Client) KeepAliveNode(ctx context.Context, keepAlive services.KeepAlive) error {
+	return trace.BadParameter("not implemented, use StreamKeepAlives instead")
+}
+
+// KeepAliveResource is not implemented.
+func (c *Client) KeepAliveResource(ctx context.Context, keepAlive services.KeepAlive) error {
 	return trace.BadParameter("not implemented, use StreamKeepAlives instead")
 }
 

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -65,7 +65,7 @@ func (g *GRPCServer) SendKeepAlives(stream proto.AuthService_SendKeepAlivesServe
 			g.Debugf("Failed to receive heartbeat: %v", err)
 			return trail.ToGRPC(err)
 		}
-		err = auth.KeepAliveNode(stream.Context(), *keepAlive)
+		err = auth.KeepAliveResource(stream.Context(), *keepAlive)
 		if err != nil {
 			return trail.ToGRPC(err)
 		}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -944,7 +944,6 @@ func migrateRoleOptions(ctx context.Context, asrv *AuthServer) error {
 	for _, role := range roles {
 		options := role.GetOptions()
 		if options.BPF == nil {
-			fmt.Printf("--> Migrating role %v. Added default enhanced events.", role.GetName())
 			log.Debugf("Migrating role %v. Added default enhanced events.", role.GetName())
 			options.BPF = defaults.EnhancedEvents()
 		} else {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1449,6 +1449,18 @@ func (tc *TeleportClient) ListNodes(ctx context.Context) ([]services.Server, err
 	return proxyClient.FindServersByLabels(ctx, tc.Namespace, tc.Labels)
 }
 
+// ListApps returns a list of applications available. Applications returned
+// depends on the role of the caller.
+func (c *TeleportClient) ListApps(ctx context.Context) ([]services.Server, error) {
+	proxyClient, err := c.ConnectToProxy(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer proxyClient.Close()
+
+	return proxyClient.GetApps(ctx, c.Namespace)
+}
+
 // ListAllNodes is the same as ListNodes except that it ignores labels.
 func (tc *TeleportClient) ListAllNodes(ctx context.Context) ([]services.Server, error) {
 	proxyClient, err := tc.ConnectToProxy(ctx)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -296,6 +296,21 @@ func (proxy *ProxyClient) FindServersByLabels(ctx context.Context, namespace str
 	return nodes, nil
 }
 
+// GetApps returns a list of applications registered in this cluster.
+func (c *ProxyClient) GetApps(ctx context.Context, namespace string) ([]services.Server, error) {
+	authClient, err := c.CurrentClusterAccessPoint(ctx, false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	apps, err := authClient.GetApps(ctx, namespace, services.SkipValidation())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return apps, nil
+}
+
 // CurrentClusterAccessPoint returns cluster access point to the currently
 // selected cluster and is used for discovery
 // and could be cached based on the access policy

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -701,10 +701,16 @@ func applyAppsConfig(fc *FileConfig, cfg *service.Config) error {
 			}
 		}
 
+		// Parse the protocol from human readable format to a GRPC enum.
+		protocol, err := services.ParseProtocol(application.Protocol)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
 		// Add the application to the list of proxied applications.
 		cfg.Apps.Apps = append(cfg.Apps.Apps, service.App{
 			Name:          application.Name,
-			Protocol:      application.Protocol,
+			Protocol:      protocol,
 			InternalAddr:  *uriAddr,
 			PublicAddr:    *publicAddr,
 			StaticLabels:  labels,
@@ -954,7 +960,7 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 
 		cfg.Apps.Apps = append(cfg.Apps.Apps, service.App{
 			Name:          clf.AppName,
-			Protocol:      teleport.ServerProtocolHTTPS,
+			Protocol:      services.ServerSpecV2_HTTPS,
 			InternalAddr:  *uriAddr,
 			PublicAddr:    *publicAddr,
 			StaticLabels:  make(map[string]string),

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -691,7 +691,7 @@ func makeConfigFixture() string {
 
 	// Application service.
 	conf.Apps.EnabledFlag = "yes"
-	conf.Apps.Apps = []App{
+	conf.Apps.Apps = []*App{
 		{
 			Name:       "foo",
 			Protocol:   teleport.ServerProtocolHTTPS,

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -795,7 +795,7 @@ type Apps struct {
 	Service `yaml:",inline"`
 
 	// Apps is a list of applications that will be run by this service.
-	Apps []App `yaml:"apps"`
+	Apps []*App `yaml:"apps"`
 }
 
 // App is the specific application that will be proxied by the application
@@ -822,7 +822,7 @@ type App struct {
 	Commands []CommandLabel `yaml:"commands,omitempty"`
 }
 
-func (a App) CheckAndSetDefaults() error {
+func (a *App) CheckAndSetDefaults() error {
 	if a.Protocol == "" {
 		a.Protocol = teleport.ServerProtocolHTTPS
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -117,6 +117,9 @@ const (
 	// before cutting the connections forcefully.
 	DefaultGracefulShutdownTimeout = 5 * time.Minute
 
+	// AppsStartTimeout is how long all applications have to startup.
+	AppsStartTimeout = 30 * time.Second
+
 	// ShutdownPollPeriod is a polling period for graceful shutdowns of SSH servers
 	ShutdownPollPeriod = 500 * time.Millisecond
 

--- a/lib/labels/labels.go
+++ b/lib/labels/labels.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package labels provides a way to get dynamic labels. Used by SSH, App,
+// and Kubernetes servers.
+package labels
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// DynamicConfig is the configuration for dynamic labels.
+type DynamicConfig struct {
+	// Labels is the list of dynamic labels to update.
+	Labels services.CommandLabels
+
+	// Log is a component logger.
+	Log *logrus.Entry
+}
+
+// CheckAndSetDefaults makes sure valid values were passed in to create
+// dynamic labels.
+func (c *DynamicConfig) CheckAndSetDefaults() error {
+	if c.Log == nil {
+		c.Log = logrus.NewEntry(logrus.StandardLogger())
+	}
+
+	// Loop over all labels and make sure the key name is valid and the interval
+	// is valid as well. If the interval is not valid, update the value.
+	labels := c.Labels.Clone()
+	for name, label := range labels {
+		if len(label.GetCommand()) == 0 {
+			return trace.BadParameter("command missing")
+
+		}
+		if !services.IsValidLabelKey(name) {
+			return trace.BadParameter("invalid label key: %q", name)
+		}
+
+		if label.GetPeriod() < time.Second {
+			label.SetPeriod(time.Second)
+			labels[name] = label
+			c.Log.Warnf("Label period can't be less that 1 second. Period for label %q was set to 1 second.", name)
+		}
+	}
+	c.Labels = labels
+
+	return nil
+}
+
+// Dynamic allow defining a set of labels whose output is the result
+// of some command execution. Dynamic labels can be configured to update
+// periodically to provide updated information.
+type Dynamic struct {
+	mu sync.Mutex
+	c  *DynamicConfig
+
+	closeContext context.Context
+	closeFunc    context.CancelFunc
+}
+
+// NewDynamic returns new Dynamic that can be configured to run
+// asynchronously in a loop or synchronously.
+func NewDynamic(ctx context.Context, config *DynamicConfig) (*Dynamic, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	closeContext, closeFunc := context.WithCancel(ctx)
+
+	return &Dynamic{
+		c:            config,
+		closeContext: closeContext,
+		closeFunc:    closeFunc,
+	}, nil
+}
+
+// Get returns the list of updated dynamic labels.
+func (l *Dynamic) Get() map[string]services.CommandLabel {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	out := make(map[string]services.CommandLabel, len(l.c.Labels))
+	for name, label := range l.c.Labels {
+		out[name] = label.Clone()
+	}
+
+	return out
+}
+
+// Sync will block and synchronously update dynamic labels. Used in tests.
+func (l *Dynamic) Sync() {
+	for name, label := range l.Get() {
+		l.updateLabel(name, label)
+	}
+}
+
+// Start will start a loop that continually keeps dynamic labels updated.
+func (l *Dynamic) Start() {
+	for name, label := range l.Get() {
+		go l.periodicUpdateLabel(name, label)
+	}
+}
+
+// Close will free up all resources and stop the keeping dynamic labels updated.
+func (l *Dynamic) Close() {
+	l.closeFunc()
+}
+
+// periodicUpdateLabel ticks at the update period defined for each label and
+// updates its value.
+func (l *Dynamic) periodicUpdateLabel(name string, label services.CommandLabel) {
+	ticker := time.NewTicker(label.GetPeriod())
+	defer ticker.Stop()
+
+	for {
+		l.updateLabel(name, label.Clone())
+		select {
+		case <-ticker.C:
+		case <-l.closeContext.Done():
+			return
+		}
+	}
+}
+
+// updateLabel will run a command the update the value of a label.
+func (l *Dynamic) updateLabel(name string, label services.CommandLabel) {
+	out, err := exec.Command(label.GetCommand()[0], label.GetCommand()[1:]...).Output()
+	if err != nil {
+		l.c.Log.Errorf("Failed run command and update label: %v.", err)
+		label.SetResult(err.Error() + " output: " + string(out))
+	} else {
+		label.SetResult(strings.TrimSpace(string(out)))
+	}
+
+	// Perform the actual label update under a lock.
+	l.setLabel(name, label)
+}
+
+// setLabel updates the value of a particular label under a lock.
+func (l *Dynamic) setLabel(name string, value services.CommandLabel) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.c.Labels[name] = value
+}

--- a/lib/labels/labels_test.go
+++ b/lib/labels/labels_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package labels
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/pborman/uuid"
+	"gopkg.in/check.v1"
+)
+
+type LabelSuite struct {
+}
+
+var _ = check.Suite(&LabelSuite{})
+
+func TestLabels(t *testing.T) { check.TestingT(t) }
+
+func (s *LabelSuite) SetUpSuite(c *check.C) {
+	utils.InitLoggerForTests(testing.Verbose())
+}
+
+func (s *LabelSuite) TearDownSuite(c *check.C) {}
+func (s *LabelSuite) SetUpTest(c *check.C)     {}
+func (s *LabelSuite) TearDownTest(c *check.C)  {}
+
+func (s *LabelSuite) TestSync(c *check.C) {
+	// Create dynamic labels and sync right away.
+	l, err := NewDynamic(context.Background(), &DynamicConfig{
+		Labels: map[string]services.CommandLabel{
+			"foo": &services.CommandLabelV2{
+				Period:  services.NewDuration(1 * time.Second),
+				Command: []string{"expr", "1", "+", "3"},
+			},
+		},
+	})
+	c.Assert(err, check.IsNil)
+	l.Sync()
+
+	// Check that the result contains the output of the command.
+	c.Assert(l.Get()["foo"].GetResult(), check.Equals, "4")
+}
+
+func (s *LabelSuite) TestStart(c *check.C) {
+	// Create dynamic labels and setup async update.
+	l, err := NewDynamic(context.Background(), &DynamicConfig{
+		Labels: map[string]services.CommandLabel{
+			"foo": &services.CommandLabelV2{
+				Period:  services.NewDuration(1 * time.Second),
+				Command: []string{"expr", "1", "+", "3"},
+			},
+		},
+	})
+	c.Assert(err, check.IsNil)
+	l.Start()
+
+	// Wait a maximum of 5 seconds for dynamic labels to be updated.
+	select {
+	case <-time.Tick(50 * time.Millisecond):
+		val, ok := l.Get()["foo"]
+		c.Assert(ok, check.Equals, true)
+		if val.GetResult() == "4" {
+			break
+		}
+	case <-time.After(5 * time.Second):
+		c.Fatalf("Timed out waiting for label to be updated.")
+	}
+}
+
+// TestInvalidCommand makes sure that invalid commands return a error message.
+func (s *LabelSuite) TestInvalidCommand(c *check.C) {
+	// Create invalid labels and sync right away.
+	l, err := NewDynamic(context.Background(), &DynamicConfig{
+		Labels: map[string]services.CommandLabel{
+			"foo": &services.CommandLabelV2{
+				Period:  services.NewDuration(1 * time.Second),
+				Command: []string{uuid.New()}},
+		},
+	})
+	c.Assert(err, check.IsNil)
+	l.Sync()
+
+	// Check that the output contains that the command was not found.
+	val, ok := l.Get()["foo"]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(strings.Contains(val.GetResult(), "output:"), check.Equals, true)
+}

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -83,7 +83,7 @@ type AgentConfig struct {
 	KubeDialAddr utils.NetAddr
 	// Server is a SSH server that can handle a connection (perform a handshake
 	// then process). Only set with the agent is running within a node.
-	Server ServerHandler
+	Server ConnHandler
 	// ReverseTunnelServer holds all reverse tunnel connections.
 	ReverseTunnelServer Server
 	// LocalClusterName is the name of the cluster this agent is running in.
@@ -531,6 +531,9 @@ const (
 	// LocalNode is a special non-resolvable address that indicates the request
 	// wants to connect to a dialed back node.
 	LocalNode = "@local-node"
+	// LocalApp is special non-resolvable address that indicates the request
+	// wants to connection to a dialed back app.
+	LocalApp = "@local-app"
 	// RemoteAuthServer is a special non-resolvable address that indicates client
 	// requests a connection to the remote auth server.
 	RemoteAuthServer = "@remote-auth-server"

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -36,11 +36,10 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// ServerHandler implements an interface which can handle a connection
-// (perform a handshake then process). This is needed because importing
-// lib/srv in lib/reversetunnel causes a circular import.
-type ServerHandler interface {
-	// HandleConnection performs a handshake then process the connection.
+// ConnHandler handles incoming net.Conn connections for different protocols.
+type ConnHandler interface {
+	// HandleConnection accepts incoming connections and either forwards them
+	// or processes them based off the protocol implemented.
 	HandleConnection(conn net.Conn)
 }
 
@@ -84,7 +83,10 @@ type AgentPoolConfig struct {
 	KubeDialAddr utils.NetAddr
 	// Server is a SSH server that can handle a connection (perform a handshake
 	// then process). Only set with the agent is running within a node.
-	Server ServerHandler
+	Server ConnHandler
+	// AppServer is an application proxy (AAP) that forwards requests to the
+	// target node.
+	AppServer ConnHandler
 	// Component is the Teleport component this agent pool is running in. It can
 	// either be proxy (trusted clusters) or node (dial back).
 	Component string

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -458,14 +458,15 @@ type AppsConfig struct {
 }
 
 // App is the specific application that will be proxied by the application
-// service.
+// service. This needs to exist because if the "config" package tries to
+// directly create a services.App it will get into circular imports.
 type App struct {
 	// Name of the application.
 	Name string `yaml:"name"`
 
 	// Protocol used to proxy this application. At the moment only HTTPS is
 	// supported.
-	Protocol string `yaml:"protocol"`
+	Protocol services.ServerSpecV2_ServerProtocolType `yaml:"protocol"`
 
 	// InternalAddr is the internal address of the application.
 	InternalAddr utils.NetAddr `yaml:"internal_addr"`

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -58,6 +58,10 @@ type Presence interface {
 	// UpsertNodes bulk inserts nodes.
 	UpsertNodes(namespace string, servers []Server) error
 
+	// DELETE IN: 5.1.0
+	//
+	// This logic has been moved to KeepAliveResource.
+	//
 	// KeepAliveNode updates node TTL in the storage
 	KeepAliveNode(ctx context.Context, h KeepAlive) error
 
@@ -173,6 +177,9 @@ type Presence interface {
 
 	// DeleteApp deletes a specific application within a namespace.
 	DeleteApp(context.Context, string, string) error
+
+	// KeepAliveResource updates TTL of the resource in the backend.
+	KeepAliveResource(ctx context.Context, h KeepAlive) error
 }
 
 // NewNamespace returns new namespace
@@ -217,7 +224,7 @@ func (s *KeepAlive) GetType() string {
 
 func (s *KeepAlive) CheckAndSetDefaults() error {
 	if s.IsEmpty() {
-		return trace.BadParameter("no lease ID or server name is specified")
+		return trace.BadParameter("invalid keep alive, missing lease ID and resource name")
 	}
 	if s.Namespace == "" {
 		s.Namespace = defaults.Namespace

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -620,7 +620,7 @@ func (u *UnknownResource) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-// Resource represents common properties for resources
+// Resource represents common properties for all resources.
 type Resource interface {
 	// GetKind returns resource kind
 	GetKind() string

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// app package runs the AAP server process. It keeps dynamic labels updated,
+// heart beat it's presence, and forward connections between the tunnel and
+// the target host.
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/labels"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+)
+
+type RotationGetter func(role teleport.Role) (*services.Rotation, error)
+
+// Config is the configuration for an application server.
+type Config struct {
+	// Clock used to control time.
+	Clock clockwork.Clock
+
+	// AccessPoint is a client connected to the Auth Server with the identity
+	// teleport.RoleApp.
+	AccessPoint auth.AccessPoint
+
+	// GetRotation returns the certificate rotation state.
+	GetRotation RotationGetter
+
+	// App is the application this server will proxy.
+	App services.Server
+}
+
+// CheckAndSetDefaults makes sure the configuration has the minimum required
+// to function.
+func (c *Config) CheckAndSetDefaults() error {
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+
+	if c.AccessPoint == nil {
+		return trace.BadParameter("access point is missing")
+	}
+	if c.GetRotation == nil {
+		return trace.BadParameter("rotation getter is missing")
+	}
+	if c.App == nil {
+		return trace.BadParameter("app is missing")
+	}
+	return nil
+}
+
+// Server is an application server.
+type Server struct {
+	config *Config
+
+	log          *logrus.Entry
+	closeContext context.Context
+	closeFunc    context.CancelFunc
+
+	dynamicLabels *labels.Dynamic
+	heartbeat     *srv.Heartbeat
+
+	keepAlive time.Duration
+
+	activeConns int64
+}
+
+// New returns a new application server.
+func New(ctx context.Context, config *Config) (*Server, error) {
+	componentName := fmt.Sprintf("%v.%v", teleport.ComponentApp, config.App.GetName())
+
+	err := config.CheckAndSetDefaults()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	s := &Server{
+		config: config,
+		log: logrus.WithFields(logrus.Fields{
+			trace.Component: componentName,
+		}),
+	}
+
+	s.closeContext, s.closeFunc = context.WithCancel(ctx)
+
+	// Create dynamic labels and sync them right away. This makes sure that the
+	// first heartbeat has correct dynamic labels.
+	s.dynamicLabels, err = labels.NewDynamic(s.closeContext, &labels.DynamicConfig{
+		Labels: config.App.GetCmdLabels(),
+		Log:    s.log,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	s.dynamicLabels.Sync()
+
+	// Create heartbeat loop so applications keep sending presence to backend.
+	s.heartbeat, err = srv.NewHeartbeat(srv.HeartbeatConfig{
+		Mode:            srv.HeartbeatModeApp,
+		Context:         s.closeContext,
+		Component:       componentName,
+		Announcer:       config.AccessPoint,
+		GetServerInfo:   s.GetServerInfo,
+		KeepAlivePeriod: defaults.ServerKeepAliveTTL,
+		AnnouncePeriod:  defaults.ServerAnnounceTTL/2 + utils.RandomDuration(defaults.ServerAnnounceTTL/2),
+		CheckPeriod:     defaults.HeartbeatCheckPeriod,
+		ServerTTL:       defaults.ServerAnnounceTTL,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Pick up TCP keep-alive settings from the cluster level.
+	clusterConfig, err := s.config.AccessPoint.GetClusterConfig()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	s.keepAlive = clusterConfig.GetKeepAliveInterval()
+
+	return s, nil
+}
+
+// GetServerInfo returns a services.Server representing the application. Used
+// in heartbeat code.
+func (s *Server) GetServerInfo() (services.Server, error) {
+	// Return a updated list of dynamic labels.
+	s.config.App.SetCmdLabels(s.dynamicLabels.Get())
+
+	// Update the TTL.
+	s.config.App.SetTTL(s.config.Clock, defaults.ServerAnnounceTTL)
+
+	// Update rotation state.
+	rotation, err := s.config.GetRotation(teleport.RoleApp)
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			s.log.Warningf("Failed to get rotation state: %v.", err)
+		}
+	} else {
+		s.config.App.SetRotation(*rotation)
+	}
+
+	return s.config.App, nil
+}
+
+// Start starts heart beating the presence of service.Apps that this
+// server is proxying along with any dynamic labels.
+func (s *Server) Start() {
+	go s.dynamicLabels.Start()
+	go s.heartbeat.Run()
+}
+
+// Serve accepts incoming connections on the Listener and calls the handler.
+func (s *Server) HandleConnection(channelConn net.Conn) {
+	// Establish connection to target server.
+	d := net.Dialer{
+		KeepAlive: s.keepAlive,
+	}
+	targetConn, err := d.DialContext(s.closeContext, "tcp", s.config.App.GetInternalAddr())
+	if err != nil {
+		s.log.Errorf("Failed to connect to %v: %v.", s.config.App.GetName(), err)
+		channelConn.Close()
+	}
+
+	// Keep a count of the number of active connections. Used in tests to check
+	// for goroutine leaks.
+	atomic.AddInt64(&s.activeConns, 1)
+	defer atomic.AddInt64(&s.activeConns, -1)
+
+	errorCh := make(chan error, 2)
+
+	// Copy data between channel connection and connection to target application.
+	go func() {
+		defer targetConn.Close()
+		defer channelConn.Close()
+
+		_, err := io.Copy(targetConn, channelConn)
+		errorCh <- err
+	}()
+	go func() {
+		defer targetConn.Close()
+		defer channelConn.Close()
+
+		_, err := io.Copy(channelConn, targetConn)
+		errorCh <- err
+	}()
+
+	// Block until copy is complete in either direction. The other direction
+	// will get cleaned up automatically.
+	if err = <-errorCh; err != nil && err != io.EOF {
+		s.log.Errorf("Connection to %v closed due to an error: %v.", s.config.App.GetName(), err)
+	}
+}
+
+// activeConnections returns the number of active connections being proxied.
+// Used in tests.
+func (s *Server) activeConnections() int64 {
+	return atomic.LoadInt64(&s.activeConns)
+}
+
+// Close will shut the server down and unblock any resources.
+func (s *Server) Close() error {
+	err := s.heartbeat.Close()
+	s.dynamicLabels.Close()
+	s.closeFunc()
+
+	return trace.Wrap(err)
+}
+
+// Wait will block while the server is running.
+func (s *Server) Wait() error {
+	<-s.closeContext.Done()
+	return s.closeContext.Err()
+}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/jonboulle/clockwork"
+	"github.com/pborman/uuid"
+
+	"gopkg.in/check.v1"
+)
+
+type Suite struct {
+	clock      clockwork.Clock
+	authServer *auth.TestAuthServer
+	tlsServer  *auth.TestTLSServer
+	authClient *auth.Client
+	appServer  *Server
+	app        services.Server
+
+	closeContext context.Context
+	closeFunc    context.CancelFunc
+	message      string
+	hostport     string
+	testhttp     *httptest.Server
+}
+
+var _ = check.Suite(&Suite{})
+
+func TestApp(t *testing.T) { check.TestingT(t) }
+
+func (s *Suite) SetUpSuite(c *check.C) {
+	var err error
+
+	utils.InitLoggerForTests(testing.Verbose())
+
+	s.clock = clockwork.NewFakeClockAt(time.Now())
+
+	// Create Auth Server.
+	s.authServer, err = auth.NewTestAuthServer(auth.TestAuthServerConfig{
+		ClusterName: "localhost",
+		Dir:         c.MkDir(),
+	})
+	c.Assert(err, check.IsNil)
+	s.tlsServer, err = s.authServer.NewTestTLSServer()
+	c.Assert(err, check.IsNil)
+
+	// Create a client with a machine role of RoleApp.
+	s.authClient, err = s.tlsServer.NewClient(auth.TestBuiltin(teleport.RoleApp))
+	c.Assert(err, check.IsNil)
+}
+
+func (s *Suite) TearDownSuite(c *check.C) {
+	err := s.authClient.Close()
+	c.Assert(err, check.IsNil)
+
+	err = s.tlsServer.Close()
+	c.Assert(err, check.IsNil)
+}
+
+func (s *Suite) SetUpTest(c *check.C) {
+	s.closeContext, s.closeFunc = context.WithCancel(context.Background())
+
+	// Create a in-memory HTTP server that will respond with a UUID. This value
+	// will be checked in the client later to ensure a connection was made.
+	s.message = uuid.New()
+	s.testhttp = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, s.message)
+		s.closeFunc()
+	}))
+
+	// Extract the hostport that the in-memory HTTP server is running on.
+	u, err := url.Parse(s.testhttp.URL)
+	c.Assert(err, check.IsNil)
+	s.hostport = u.Host
+
+	// Create a services.App that will be used for each tests.
+	staticLabels := map[string]string{
+		"bar": "baz",
+	}
+	dynamicLabels := map[string]services.CommandLabel{
+		"qux": &services.CommandLabelV2{
+			Period:  services.NewDuration(time.Second),
+			Command: []string{"expr", "1", "+", "3"},
+		},
+	}
+	s.app = &services.ServerV2{
+		Kind:    services.KindApp,
+		Version: services.V2,
+		Metadata: services.Metadata{
+			Namespace: defaults.Namespace,
+			Name:      "foo",
+			Labels:    staticLabels,
+		},
+		Spec: services.ServerSpecV2{
+			Protocol:     services.ServerSpecV2_HTTPS,
+			InternalAddr: s.hostport,
+			PublicAddr:   "foo.example.com",
+			CmdLabels:    services.LabelsToV2(dynamicLabels),
+			Version:      teleport.Version,
+		},
+	}
+
+	s.appServer, err = New(context.Background(), &Config{
+		Clock:       s.clock,
+		AccessPoint: s.authClient,
+		GetRotation: testRotationGetter,
+		App:         s.app,
+	})
+	c.Assert(err, check.IsNil)
+
+	s.appServer.Start()
+	err = s.appServer.heartbeat.ForceSend(time.Second)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *Suite) TearDownTest(c *check.C) {
+	err := s.appServer.Close()
+	c.Assert(err, check.IsNil)
+
+	s.testhttp.Close()
+}
+
+// TestStart makes sure after the server has started a correct services.App
+// has been created.
+func (s *Suite) TestStart(c *check.C) {
+	// Fetch the services.App that the service heartbeat.
+	apps, err := s.authServer.AuthServer.GetApps(context.Background(), defaults.Namespace)
+	c.Assert(err, check.IsNil)
+	c.Assert(apps, check.HasLen, 1)
+	app := apps[0]
+
+	// Check that the services.App that was heartbeat is correct. For example,
+	// check that the dynamic labels have been evaluated.
+	c.Assert(app.GetName(), check.Equals, "foo")
+	c.Assert(app.GetInternalAddr(), check.Equals, s.hostport)
+	c.Assert(app.GetPublicAddr(), check.Equals, "foo.example.com")
+	c.Assert(app.GetLabels(), check.DeepEquals, map[string]string{
+		"bar": "baz",
+	})
+	dynamicLabel, ok := app.GetCmdLabels()["qux"]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(dynamicLabel.GetResult(), check.Equals, "4")
+
+	// Check the expiry time is correct.
+	c.Assert(s.clock.Now().Before(app.Expiry()), check.Equals, true)
+	c.Assert(s.clock.Now().Add(2*defaults.ServerAnnounceTTL).After(app.Expiry()), check.Equals, true)
+}
+
+// TestWaitStop makes sure the server will block and unlock.
+func (s *Suite) TestWaitStop(c *check.C) {
+	// Make sure that wait will block while the server is running.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		s.appServer.Wait()
+		cancel()
+	}()
+	select {
+	case <-ctx.Done():
+		c.Fatalf("Wait failed to block.")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	// Close should unblock wait.
+	err := s.appServer.Close()
+	c.Assert(err, check.IsNil)
+	err = s.appServer.Wait()
+	c.Assert(err, check.Equals, context.Canceled)
+}
+
+// TestHandleConnection makes sure the application server forwards
+// connections to the target host and accurately keeps track of connections.
+func (s *Suite) TestHandleConnection(c *check.C) {
+	// Create a net.Pipe. The "server" end will be passed to the application
+	// server while the client end will be used by the http.Client to read/write
+	// a request.
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	// Process the connection.
+	go s.appServer.HandleConnection(serverConn)
+
+	// Perform a simple HTTP GET against the application server.
+	httpTransport := &http.Transport{
+		Dial: func(network, addr string) (net.Conn, error) {
+			return clientConn, nil
+		},
+	}
+	httpClient := http.Client{
+		Transport: httpTransport,
+	}
+	resp, err := httpClient.Get("http://foo.example.com")
+	c.Assert(err, check.IsNil)
+	defer resp.Body.Close()
+
+	// Make sure the response contains the UUID that the server replied with earlier.
+	body, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, check.IsNil)
+	c.Assert(strings.TrimSpace(string(body)), check.Equals, s.message)
+
+	// Application server is proxying a single connection, count should be 1.
+	c.Assert(s.appServer.activeConnections(), check.Equals, int64(1))
+
+	// Break connection from client side.
+	clientConn.Close()
+
+	// Wait a few seconds for the count to go down to 0.
+	ticker := time.Tick(50 * time.Millisecond)
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case <-ticker:
+			if s.appServer.activeConnections() == 0 {
+				return
+			}
+		case <-timeout:
+			c.Fatalf("Timed out waiting for active connection count to come to 0.")
+		}
+	}
+}
+
+func testRotationGetter(role teleport.Role) (*services.Rotation, error) {
+	return &services.Rotation{}, nil
+}

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -57,17 +57,17 @@ const (
 	HeartbeatStateInit KeepAliveState = iota
 	// HeartbeatStateAnnounce is set when full
 	// state has to be announced back to the auth server
-	HeartbeatStateAnnounce KeepAliveState = iota
+	HeartbeatStateAnnounce
 	// HeartbeatStateAnnounceWait is set after successful
 	// announce, heartbeat will wait until server updates
 	// information, or time for next announce comes
-	HeartbeatStateAnnounceWait KeepAliveState = iota
+	HeartbeatStateAnnounceWait
 	// HeartbeatStateKeepAlive is set when
 	// only sending keep alives is necessary
-	HeartbeatStateKeepAlive KeepAliveState = iota
+	HeartbeatStateKeepAlive
 	// HeartbeatStateKeepAliveWait is set when
 	// heartbeat will waiting until it's time to send keep alive
-	HeartbeatStateKeepAliveWait KeepAliveState = iota
+	HeartbeatStateKeepAliveWait
 )
 
 // HeartbeatMode represents the mode of the heartbeat
@@ -77,7 +77,7 @@ type HeartbeatMode int
 // CheckAndSetDefaults checks values and sets defaults
 func (h HeartbeatMode) CheckAndSetDefaults() error {
 	switch h {
-	case HeartbeatModeNode, HeartbeatModeProxy, HeartbeatModeAuth:
+	case HeartbeatModeNode, HeartbeatModeProxy, HeartbeatModeAuth, HeartbeatModeApp:
 		return nil
 	default:
 		return trace.BadParameter("unrecognized mode")
@@ -93,6 +93,8 @@ func (h HeartbeatMode) String() string {
 		return "Proxy"
 	case HeartbeatModeAuth:
 		return "Auth"
+	case HeartbeatModeApp:
+		return "App"
 	default:
 		return fmt.Sprintf("<unknown: %v>", int(h))
 	}
@@ -108,6 +110,8 @@ const (
 	// HeartbeatModeAuth sets heartbeat to auth
 	// that does not support keep alives
 	HeartbeatModeAuth HeartbeatMode = iota
+	// HeartbeatModeApp sets heartbeat to apps and will use keep alives.
+	HeartbeatModeApp HeartbeatMode = iota
 )
 
 // NewHeartbeat returns a new instance of heartbeat
@@ -136,7 +140,7 @@ type GetServerInfoFn func() (services.Server, error)
 
 // HeartbeatConfig is a heartbeat configuration
 type HeartbeatConfig struct {
-	// Mode sets one of the proxy, auth or node moes
+	// Mode sets one of the proxy, auth or node modes.
 	Mode HeartbeatMode
 	// Context is parent context that signals
 	// heartbeat cancel
@@ -375,23 +379,43 @@ func (h *Heartbeat) announce() error {
 			h.notifySend()
 			h.setState(HeartbeatStateAnnounceWait)
 			return nil
+		case HeartbeatModeNode:
+			keepAlive, err := h.Announcer.UpsertNode(h.current)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			h.notifySend()
+			keepAliver, err := h.Announcer.NewKeepAliver(h.cancelCtx)
+			if err != nil {
+				h.reset(HeartbeatStateInit)
+				return trace.Wrap(err)
+			}
+			h.nextAnnounce = h.Clock.Now().UTC().Add(h.AnnouncePeriod)
+			h.nextKeepAlive = h.Clock.Now().UTC().Add(h.KeepAlivePeriod)
+			h.keepAlive = keepAlive
+			h.keepAliver = keepAliver
+			h.setState(HeartbeatStateKeepAliveWait)
+			return nil
+		case HeartbeatModeApp:
+			keepAlive, err := h.Announcer.UpsertApp(h.cancelCtx, h.current)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			h.notifySend()
+			keepAliver, err := h.Announcer.NewKeepAliver(h.cancelCtx)
+			if err != nil {
+				h.reset(HeartbeatStateInit)
+				return trace.Wrap(err)
+			}
+			h.nextAnnounce = h.Clock.Now().UTC().Add(h.AnnouncePeriod)
+			h.nextKeepAlive = h.Clock.Now().UTC().Add(h.KeepAlivePeriod)
+			h.keepAlive = keepAlive
+			h.keepAliver = keepAliver
+			h.setState(HeartbeatStateKeepAliveWait)
+			return nil
+		default:
+			return trace.BadParameter("unknown mode %q", h.Mode)
 		}
-		keepAlive, err := h.Announcer.UpsertNode(h.current)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		h.notifySend()
-		keepAliver, err := h.Announcer.NewKeepAliver(h.cancelCtx)
-		if err != nil {
-			h.reset(HeartbeatStateInit)
-			return trace.Wrap(err)
-		}
-		h.nextAnnounce = h.Clock.Now().UTC().Add(h.AnnouncePeriod)
-		h.nextKeepAlive = h.Clock.Now().UTC().Add(h.KeepAlivePeriod)
-		h.keepAlive = keepAlive
-		h.keepAliver = keepAliver
-		h.setState(HeartbeatStateKeepAliveWait)
-		return nil
 	case HeartbeatStateKeepAlive:
 		keepAlive := *h.keepAlive
 		keepAlive.Expires = h.Clock.Now().UTC().Add(h.ServerTTL)

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -50,116 +50,128 @@ func (s *HeartbeatSuite) TestHeartbeatAnnounce(c *check.C) {
 	s.heartbeatAnnounce(c, HeartbeatModeAuth, services.KindAuthServer)
 }
 
-// TestHeartbeatKeepAlive tests keep alive cycle used for nodes
+// TestHeartbeatKeepAlive tests keep alive cycle used for nodes and apps.
 func (s *HeartbeatSuite) TestHeartbeatKeepAlive(c *check.C) {
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
-	clock := clockwork.NewFakeClock()
-	announcer := newFakeAnnouncer(ctx)
-
-	srv := &services.ServerV2{
-		Kind:    services.KindNode,
-		Version: services.V2,
-		Metadata: services.Metadata{
-			Namespace: defaults.Namespace,
-			Name:      "1",
+	var tests = []struct {
+		inKind string
+	}{
+		{
+			inKind: services.KindNode,
 		},
-		Spec: services.ServerSpecV2{
-			Addr:     "127.0.0.1:1234",
-			Hostname: "2",
+		{
+			inKind: services.KindApp,
 		},
 	}
-	hb, err := NewHeartbeat(HeartbeatConfig{
-		Context:         ctx,
-		Mode:            HeartbeatModeNode,
-		Component:       "test",
-		Announcer:       announcer,
-		CheckPeriod:     time.Second,
-		AnnouncePeriod:  60 * time.Second,
-		KeepAlivePeriod: 10 * time.Second,
-		ServerTTL:       600 * time.Second,
-		Clock:           clock,
-		GetServerInfo: func() (services.Server, error) {
-			srv.SetTTL(clock, defaults.ServerAnnounceTTL)
-			return srv, nil
-		},
-	})
-	c.Assert(err, check.IsNil)
-	c.Assert(hb.state, check.Equals, HeartbeatStateInit)
+	for _, tt := range tests {
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		clock := clockwork.NewFakeClock()
+		announcer := newFakeAnnouncer(ctx)
 
-	// on the first run, heartbeat will move to announce state,
-	// will call announce right away
-	err = hb.fetch()
-	c.Assert(err, check.IsNil)
-	c.Assert(hb.state, check.Equals, HeartbeatStateAnnounce)
+		srv := &services.ServerV2{
+			Kind:    tt.inKind,
+			Version: services.V2,
+			Metadata: services.Metadata{
+				Namespace: defaults.Namespace,
+				Name:      "1",
+			},
+			Spec: services.ServerSpecV2{
+				Addr:     "127.0.0.1:1234",
+				Hostname: "2",
+			},
+		}
+		hb, err := NewHeartbeat(HeartbeatConfig{
+			Context:         ctx,
+			Mode:            HeartbeatModeNode,
+			Component:       "test",
+			Announcer:       announcer,
+			CheckPeriod:     time.Second,
+			AnnouncePeriod:  60 * time.Second,
+			KeepAlivePeriod: 10 * time.Second,
+			ServerTTL:       600 * time.Second,
+			Clock:           clock,
+			GetServerInfo: func() (services.Server, error) {
+				srv.SetTTL(clock, defaults.ServerAnnounceTTL)
+				return srv, nil
+			},
+		})
+		c.Assert(err, check.IsNil)
+		c.Assert(hb.state, check.Equals, HeartbeatStateInit)
 
-	err = hb.announce()
-	c.Assert(err, check.IsNil)
-	c.Assert(announcer.upsertCalls[hb.Mode], check.Equals, 1)
-	c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
-	c.Assert(hb.nextKeepAlive, check.Equals, clock.Now().UTC().Add(hb.KeepAlivePeriod))
+		// on the first run, heartbeat will move to announce state,
+		// will call announce right away
+		err = hb.fetch()
+		c.Assert(err, check.IsNil)
+		c.Assert(hb.state, check.Equals, HeartbeatStateAnnounce)
 
-	// next call will not move to announce, because time is not up yet
-	err = hb.fetchAndAnnounce()
-	c.Assert(err, check.IsNil)
-	c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
+		err = hb.announce()
+		c.Assert(err, check.IsNil)
+		c.Assert(announcer.upsertCalls[hb.Mode], check.Equals, 1)
+		c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
+		c.Assert(hb.nextKeepAlive, check.Equals, clock.Now().UTC().Add(hb.KeepAlivePeriod))
 
-	// advance time, and heartbeat will move to keep alive
-	clock.Advance(hb.KeepAlivePeriod + time.Second)
-	err = hb.fetch()
-	c.Assert(err, check.IsNil)
-	c.Assert(hb.state, check.Equals, HeartbeatStateKeepAlive)
-	err = hb.announce()
-	c.Assert(err, check.IsNil)
-	c.Assert(announcer.keepAlivesC, check.HasLen, 1)
-	c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
-	c.Assert(hb.nextKeepAlive, check.Equals, clock.Now().UTC().Add(hb.KeepAlivePeriod))
+		// next call will not move to announce, because time is not up yet
+		err = hb.fetchAndAnnounce()
+		c.Assert(err, check.IsNil)
+		c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
 
-	// update server info, system should switch to announce state
-	srv = &services.ServerV2{
-		Kind:    services.KindNode,
-		Version: services.V2,
-		Metadata: services.Metadata{
-			Namespace: defaults.Namespace,
-			Name:      "1",
-			Labels:    map[string]string{"a": "b"},
-		},
-		Spec: services.ServerSpecV2{
-			Addr:     "127.0.0.1:1234",
-			Hostname: "2",
-		},
+		// advance time, and heartbeat will move to keep alive
+		clock.Advance(hb.KeepAlivePeriod + time.Second)
+		err = hb.fetch()
+		c.Assert(err, check.IsNil)
+		c.Assert(hb.state, check.Equals, HeartbeatStateKeepAlive)
+		err = hb.announce()
+		c.Assert(err, check.IsNil)
+		c.Assert(announcer.keepAlivesC, check.HasLen, 1)
+		c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
+		c.Assert(hb.nextKeepAlive, check.Equals, clock.Now().UTC().Add(hb.KeepAlivePeriod))
+
+		// update server info, system should switch to announce state
+		srv = &services.ServerV2{
+			Kind:    services.KindNode,
+			Version: services.V2,
+			Metadata: services.Metadata{
+				Namespace: defaults.Namespace,
+				Name:      "1",
+				Labels:    map[string]string{"a": "b"},
+			},
+			Spec: services.ServerSpecV2{
+				Addr:     "127.0.0.1:1234",
+				Hostname: "2",
+			},
+		}
+		err = hb.fetch()
+		c.Assert(err, check.IsNil)
+		c.Assert(hb.state, check.Equals, HeartbeatStateAnnounce)
+		err = hb.announce()
+		c.Assert(err, check.IsNil)
+		c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
+		c.Assert(hb.nextKeepAlive, check.Equals, clock.Now().UTC().Add(hb.KeepAlivePeriod))
+
+		// in case of any error while sending keep alive, system should fail
+		// and go back to init state
+		announcer.keepAlivesC = make(chan services.KeepAlive)
+		announcer.err = trace.ConnectionProblem(nil, "ooops")
+		announcer.Close()
+		clock.Advance(hb.KeepAlivePeriod + time.Second)
+		err = hb.fetch()
+		c.Assert(err, check.IsNil)
+		c.Assert(hb.state, check.Equals, HeartbeatStateKeepAlive)
+		err = hb.announce()
+		fixtures.ExpectConnectionProblem(c, err)
+		c.Assert(hb.state, check.Equals, HeartbeatStateInit)
+		c.Assert(announcer.upsertCalls[hb.Mode], check.Equals, 2)
+
+		// on the next run, system will try to reannounce
+		announcer.err = nil
+		err = hb.fetch()
+		c.Assert(err, check.IsNil)
+		c.Assert(hb.state, check.Equals, HeartbeatStateAnnounce)
+		err = hb.announce()
+		c.Assert(err, check.IsNil)
+		c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
+		c.Assert(announcer.upsertCalls[hb.Mode], check.Equals, 3)
 	}
-	err = hb.fetch()
-	c.Assert(err, check.IsNil)
-	c.Assert(hb.state, check.Equals, HeartbeatStateAnnounce)
-	err = hb.announce()
-	c.Assert(err, check.IsNil)
-	c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
-	c.Assert(hb.nextKeepAlive, check.Equals, clock.Now().UTC().Add(hb.KeepAlivePeriod))
-
-	// in case of any error while sending keep alive, system should fail
-	// and go back to init state
-	announcer.keepAlivesC = make(chan services.KeepAlive)
-	announcer.err = trace.ConnectionProblem(nil, "ooops")
-	announcer.Close()
-	clock.Advance(hb.KeepAlivePeriod + time.Second)
-	err = hb.fetch()
-	c.Assert(err, check.IsNil)
-	c.Assert(hb.state, check.Equals, HeartbeatStateKeepAlive)
-	err = hb.announce()
-	fixtures.ExpectConnectionProblem(c, err)
-	c.Assert(hb.state, check.Equals, HeartbeatStateInit)
-	c.Assert(announcer.upsertCalls[hb.Mode], check.Equals, 2)
-
-	// on the next run, system will try to reannounce
-	announcer.err = nil
-	err = hb.fetch()
-	c.Assert(err, check.IsNil)
-	c.Assert(hb.state, check.Equals, HeartbeatStateAnnounce)
-	err = hb.announce()
-	c.Assert(err, check.IsNil)
-	c.Assert(hb.state, check.Equals, HeartbeatStateKeepAliveWait)
-	c.Assert(announcer.upsertCalls[hb.Mode], check.Equals, 3)
 }
 
 func (s *HeartbeatSuite) heartbeatAnnounce(c *check.C, mode HeartbeatMode, kind string) {
@@ -263,6 +275,14 @@ type fakeAnnouncer struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
 	keepAlivesC chan<- services.KeepAlive
+}
+
+func (f *fakeAnnouncer) UpsertApp(ctx context.Context, s services.Server) (*services.KeepAlive, error) {
+	f.upsertCalls[HeartbeatModeApp] += 1
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &services.KeepAlive{}, nil
 }
 
 func (f *fakeAnnouncer) UpsertNode(s services.Server) (*services.KeepAlive, error) {

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -40,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/bpf"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/pam"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -79,9 +79,11 @@ type Server struct {
 	sessionServer rsession.Service
 	limiter       *limiter.Limiter
 
-	labels      map[string]string                //static server labels
-	cmdLabels   map[string]services.CommandLabel //dymanic server labels
-	labelsMutex *sync.Mutex
+	// labels are static labels.
+	labels map[string]string
+
+	// dynamicLabels are the result of command execution.
+	dynamicLabels *labels.Dynamic
 
 	proxyMode bool
 	proxyTun  reversetunnel.Server
@@ -251,8 +253,10 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 // Start starts server
 func (s *Server) Start() error {
-	if len(s.getCommandLabels()) > 0 {
-		s.updateLabels()
+	// If the server has dynamic labels defined, start a loop that will
+	// asynchronously keep them updated.
+	if s.dynamicLabels != nil {
+		go s.dynamicLabels.Start()
 	}
 
 	// If the server requested connections to it arrive over a reverse tunnel,
@@ -275,9 +279,12 @@ func (s *Server) Start() error {
 
 // Serve servers service on started listener
 func (s *Server) Serve(l net.Listener) error {
-	if len(s.getCommandLabels()) > 0 {
-		s.updateLabels()
+	// If the server has dynamic labels defined, start a loop that will
+	// asynchronously keep them updated.
+	if s.dynamicLabels != nil {
+		go s.dynamicLabels.Start()
 	}
+
 	go s.heartbeat.Run()
 	return s.srv.Serve(l)
 }
@@ -334,16 +341,17 @@ func SetProxyMode(tsrv reversetunnel.Server) ServerOption {
 }
 
 // SetLabels sets dynamic and static labels that server will report to the
-// auth servers
-func SetLabels(labels map[string]string,
-	cmdLabels services.CommandLabels) ServerOption {
+// auth servers.
+func SetLabels(staticLabels map[string]string, cmdLabels services.CommandLabels) ServerOption {
 	return func(s *Server) error {
+		var err error
+
 		// clone and validate labels and cmdLabels.  in theory,
 		// only cmdLabels should experience concurrent writes,
 		// but this operation is only run once on startup
 		// so a little defensive cloning is harmless.
-		labelsClone := make(map[string]string, len(labels))
-		for name, label := range labels {
+		labelsClone := make(map[string]string, len(staticLabels))
+		for name, label := range staticLabels {
 			if !services.IsValidLabelKey(name) {
 				return trace.BadParameter("invalid label key: %q", name)
 			}
@@ -351,18 +359,14 @@ func SetLabels(labels map[string]string,
 		}
 		s.labels = labelsClone
 
-		cmdLabels = cmdLabels.Clone()
-		for name, label := range cmdLabels {
-			if !services.IsValidLabelKey(name) {
-				return trace.BadParameter("invalid label key: %q", name)
-			}
-			if label.GetPeriod() < time.Second {
-				label.SetPeriod(time.Second)
-				cmdLabels[name] = label
-				log.Warningf("label period can't be less that 1 second. Period for label '%v' was set to 1 second", name)
-			}
+		// Create dynamic labels.
+		s.dynamicLabels, err = labels.NewDynamic(s.ctx, &labels.DynamicConfig{
+			Labels: cmdLabels,
+		})
+		if err != nil {
+			return trace.Wrap(err)
 		}
-		s.cmdLabels = cmdLabels
+
 		return nil
 	}
 }
@@ -476,7 +480,6 @@ func New(addr utils.NetAddr,
 		addr:            addr,
 		authService:     authService,
 		hostname:        hostname,
-		labelsMutex:     &sync.Mutex{},
 		proxyPublicAddr: proxyPublicAddr,
 		uuid:            uuid,
 		cancel:          cancel,
@@ -660,6 +663,15 @@ func (s *Server) getRole() teleport.Role {
 	return teleport.RoleNode
 }
 
+// getDynamicLabels returns all dynamic labels. If no dynamic labels are
+// defined, return an empty set.
+func (s *Server) getDynamicLabels() map[string]services.CommandLabelV2 {
+	if s.dynamicLabels == nil {
+		return make(map[string]services.CommandLabelV2)
+	}
+	return services.LabelsToV2(s.dynamicLabels.Get())
+}
+
 // GetInfo returns a services.Server that represents this server.
 func (s *Server) GetInfo() services.Server {
 	// Only set the address for non-tunnel nodes.
@@ -677,7 +689,7 @@ func (s *Server) GetInfo() services.Server {
 			Labels:    s.labels,
 		},
 		Spec: services.ServerSpecV2{
-			CmdLabels: services.LabelsToV2(s.getCommandLabels()),
+			CmdLabels: s.getDynamicLabels(),
 			Addr:      addr,
 			Hostname:  s.hostname,
 			UseTunnel: s.useTunnel,
@@ -703,56 +715,9 @@ func (s *Server) getServerInfo() (services.Server, error) {
 	return server, nil
 }
 
-func (s *Server) updateLabels() {
-	for name, label := range s.getCommandLabels() {
-		go s.periodicUpdateLabel(name, label.Clone())
-	}
-}
-
+// syncUpdateLabels synchronously updates dynamic labels. Only used in tests.
 func (s *Server) syncUpdateLabels() {
-	for name, label := range s.getCommandLabels() {
-		s.updateLabel(name, label)
-	}
-}
-
-func (s *Server) updateLabel(name string, label services.CommandLabel) {
-	out, err := exec.Command(label.GetCommand()[0], label.GetCommand()[1:]...).Output()
-	if err != nil {
-		log.Errorf(err.Error())
-		label.SetResult(err.Error() + " output: " + string(out))
-	} else {
-		label.SetResult(strings.TrimSpace(string(out)))
-	}
-	s.setCommandLabel(name, label)
-}
-
-func (s *Server) periodicUpdateLabel(name string, label services.CommandLabel) {
-	t := time.NewTicker(label.GetPeriod())
-	defer t.Stop()
-	for {
-		s.updateLabel(name, label.Clone())
-		select {
-		case <-t.C:
-		case <-s.ctx.Done():
-			return
-		}
-	}
-}
-
-func (s *Server) setCommandLabel(name string, value services.CommandLabel) {
-	s.labelsMutex.Lock()
-	defer s.labelsMutex.Unlock()
-	s.cmdLabels[name] = value
-}
-
-func (s *Server) getCommandLabels() map[string]services.CommandLabel {
-	s.labelsMutex.Lock()
-	defer s.labelsMutex.Unlock()
-	out := make(map[string]services.CommandLabel, len(s.cmdLabels))
-	for key, val := range s.cmdLabels {
-		out[key] = val.Clone()
-	}
-	return out
+	s.dynamicLabels.Sync()
 }
 
 // serveAgent will build the a sock path for this user and serve an SSH agent on unix socket.

--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"os"
+
+	"github.com/gravitational/kingpin"
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+)
+
+// AppsCommand implements "tctl apps" group of commands.
+type AppsCommand struct {
+	config *service.Config
+
+	// format is the output format (text, json, or yaml)
+	format string
+
+	// appsList implements the "tctl apps ls" subcommand.
+	appsList *kingpin.CmdClause
+}
+
+// Initialize allows AppsCommand to plug itself into the CLI parser
+func (c *AppsCommand) Initialize(app *kingpin.Application, config *service.Config) {
+	c.config = config
+
+	apps := app.Command("apps", "Operate on applications registered with the cluster.")
+	c.appsList = apps.Command("ls", "List all applications registered with the cluster.")
+	c.appsList.Flag("format", "Output format, 'text', 'json', or 'yaml'").Default("text").StringVar(&c.format)
+}
+
+// TryRun attempts to run subcommands like "apps ls".
+func (c *AppsCommand) TryRun(cmd string, client auth.ClientI) (match bool, err error) {
+	switch cmd {
+	case c.appsList.FullCommand():
+		err = c.ListApps(client)
+	default:
+		return false, nil
+	}
+	return true, trace.Wrap(err)
+}
+
+// ListApps prints the list of applications that have recently sent heartbeats
+// to the cluster.
+func (c *AppsCommand) ListApps(client auth.ClientI) error {
+	apps, err := client.GetApps(context.TODO(), defaults.Namespace, services.SkipValidation())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	coll := &appCollection{apps: apps}
+
+	switch c.format {
+	case teleport.Text:
+		err = coll.writeText(os.Stdout)
+	case teleport.JSON:
+		err = coll.writeJSON(os.Stdout)
+	case teleport.YAML:
+		err = coll.writeYAML(os.Stdout)
+	default:
+		return trace.BadParameter("unknown format %q", c.format)
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -642,3 +642,42 @@ func (c *remoteClusterCollection) toMarshal() interface{} {
 func (c *remoteClusterCollection) writeYAML(w io.Writer) error {
 	return utils.WriteYAML(w, c.toMarshal())
 }
+
+type appCollection struct {
+	apps []services.Server
+}
+
+func (a *appCollection) resources() (r []services.Resource) {
+	for _, resource := range a.apps {
+		r = append(r, resource)
+	}
+	return r
+}
+
+func (a *appCollection) writeText(w io.Writer) error {
+	t := asciitable.MakeTable([]string{"Application", "Internal Address", "Public Address", "Labels"})
+	for _, app := range a.apps {
+		t.AddRow([]string{
+			app.GetName(), app.GetInternalAddr(), app.GetPublicAddr(), app.LabelsString(),
+		})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func (a *appCollection) writeJSON(w io.Writer) error {
+	data, err := json.MarshalIndent(a.toMarshal(), "", "    ")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = w.Write(data)
+	return trace.Wrap(err)
+}
+
+func (a *appCollection) toMarshal() interface{} {
+	return a.apps
+}
+
+func (a *appCollection) writeYAML(w io.Writer) error {
+	return utils.WriteYAML(w, a.toMarshal())
+}

--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -30,6 +30,7 @@ func main() {
 		&common.StatusCommand{},
 		&common.TopCommand{},
 		&common.AccessRequestCommand{},
+		&common.AppsCommand{},
 	}
 	common.Run(commands)
 }


### PR DESCRIPTION
**Description** 

Added AAP server process that starts up and heart beat the applications presence to the Auth Server and connections a channel connection with a `net.Conn` to the target server.

Refactored dynamic labels out from the regular SSH server and into its own package so it can be re-used by both the SSH server as well as the application server.

Updated heart beat code to support heart beats for different kinds of `services.Server` (SSH as well as application).

**Related Issues**

https://github.com/gravitational/teleport/issues/3951