### PR TITLE
Don't set ctty on the executed shell process

### DIFF
--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -426,7 +426,8 @@ func buildCommand(c *execCommand, tty *os.File, pty *os.File, pamEnvironment []s
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			Setsid:  true,
 			Setctty: true,
-			Ctty:    int(tty.Fd()),
+			// Note: leaving Ctty empty will default it to stdin fd, which is
+			// set to our tty above.
 		}
 	} else {
 		cmd.Stdin = os.Stdin


### PR DESCRIPTION
See https://github.com/golang/go/issues/29458 and
https://go-review.googlesource.com/c/go/+/231638.

Go 1.15 added a check for a child spawning bug, where ctty was set to a
wrong file descriptor.
`Ctty` in `SysProcAttr` should be set to a file descriptor _in a child
process_, but we were setting it to a file descriptor _in a parent
process_. This was working by accident, but is now caught by `os/exec`.

Instead, leave it as 0, which will default it to the file descriptor of
stdin. In our case, stdin is already set to the tty.