### PR TITLE
Fix doc whitespace error preventing test from passing

### DIFF
--- a/docs/4.3/architecture/authentication.md
+++ b/docs/4.3/architecture/authentication.md
@@ -109,7 +109,7 @@ by the system's SSH agent if it is running.
 
 2. If the correct credentials were offered, the Auth Server will generate a
    signed certificate and return it to the client. For users, certificates are
-   stored in `~/.tsh` by default. If the client uses the Web UI the signed certificate 
+   stored in `~/.tsh` by default. If the client uses the Web UI the signed certificate
    is associated with a secure websocket session.
 
 In addition to a user's identity, user certificates also contain user roles and

--- a/docs/4.3/architecture/proxy.md
+++ b/docs/4.3/architecture/proxy.md
@@ -51,7 +51,7 @@ client SSH connection:
 
 Teleport Proxy implements a special method to let clients get short-lived
 authentication certificates signed by the Certificate Authority (CA) provided by
-the [Auth Service](../authentication#authentication-in-teleport).
+the [Auth Service](authentication.md#authentication-in-teleport).
 
 ![Teleport Proxy SSH](../img/proxy-ssh-1.svg)
 

--- a/docs/4.3/architecture/proxy.md
+++ b/docs/4.3/architecture/proxy.md
@@ -50,7 +50,7 @@ client SSH connection:
 **Getting Client Certificates**
 
 Teleport Proxy implements a special method to let clients get short-lived
-authentication certificates signed by the Certificate Authority (CA) provided by 
+authentication certificates signed by the Certificate Authority (CA) provided by
 the [Auth Service](../authentication#authentication-in-teleport).
 
 ![Teleport Proxy SSH](../img/proxy-ssh-1.svg)


### PR DESCRIPTION
#### Description
Fix white space errors that is preventing drone from passing test: https://drone.gravitational.io/gravitational/teleport/1320/2/2
I'm assuming this error came from ev accidently pushing to master without a PR



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1190029021439585/1190130665843592) by [Unito](https://www.unito.io/learn-more)
