### PR TITLE
Seperate milv tests to run independently for internal and external links

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -228,9 +228,9 @@ steps:
           # Check links
           for VERSION in $(cat /tmp/docs-versions-changed.txt); do
             if [ -f docs/$VERSION/milv.config.yaml ]; then
+              go get github.com/magicmatatjahu/milv
               cd docs/$VERSION
               echo "Running milv on docs/$VERSION:"
-              go get github.com/magicmatatjahu/milv
               milv -ignore-external
               echo "------------------------------"
               cd -
@@ -308,9 +308,9 @@ steps:
           # Check links
           for VERSION in $(cat /tmp/docs-versions-changed.txt); do
             if [ -f docs/$VERSION/milv.config.yaml ]; then
+              go get github.com/magicmatatjahu/milv
               cd docs/$VERSION
               echo "Running milv on docs/$VERSION:"
-              go get github.com/magicmatatjahu/milv
               milv -ignore-internal
               echo "------------------------------"
               cd -
@@ -2740,6 +2740,6 @@ steps:
 
 ---
 kind: signature
-hmac: 96c78107ad8813d3635598369381cc2865084e07856f64d6c8ad57418a321d04
+hmac: d172f5c9261b110b566cc0111ff413fc24d50462895a93d33a0707bf753a5744
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -165,7 +165,7 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: test-docs
+name: test-docs-internal
 
 trigger:
   branch:
@@ -215,7 +215,7 @@ steps:
           fi
         fi
 
-  - name: Run docs tests
+  - name: Run docs tests (internal links only)
     image: golang:1.14.4
     commands:
       - |
@@ -231,7 +231,87 @@ steps:
               cd docs/$VERSION
               echo "Running milv on docs/$VERSION:"
               go get -u github.com/magicmatatjahu/milv
-              milv
+              milv -ignore-external
+              echo "------------------------------"
+              cd -
+            else
+              echo "No milv config found, skipping docs/$VERSION"
+            fi
+          done
+          else echo "No changes to docs detected, not running tests"
+        fi
+
+---
+kind: pipeline
+type: kubernetes
+name: test-docs-external
+
+trigger:
+  branch:
+    - master
+    - branch/*
+  event:
+    exclude:
+      - cron
+      - promote
+      - rollback
+  repo:
+    include:
+      - gravitational/*
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: golang:1.14.4
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport
+      - cd /go/src/github.com/gravitational/teleport
+      - git init && git remote add origin ${DRONE_REMOTE_URL}
+      - |
+        # handle pull requests
+        if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
+          git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+          git checkout ${DRONE_COMMIT_BRANCH}
+          git fetch origin ${DRONE_COMMIT_REF}:
+          git merge ${DRONE_COMMIT}
+        # handle tags
+        elif [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
+          git fetch origin +refs/tags/${DRONE_TAG}:
+          git checkout -qf FETCH_HEAD
+        # handle pushes/other events
+        else
+          if [ "${DRONE_COMMIT_BRANCH}" = "" ]; then
+            git fetch origin
+            git checkout -qf ${DRONE_COMMIT_SHA}
+          else
+            git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+            git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
+          fi
+        fi
+
+  - name: Run docs tests (external links only)
+    image: golang:1.14.4
+    failure: ignore
+    commands:
+      - |
+        cd /go/src/github.com/gravitational/teleport
+        git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
+        if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
+          echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
+          # Check trailing whitespace
+          make docs-test-whitespace
+          # Check links
+          for VERSION in $(cat /tmp/docs-versions-changed.txt); do
+            if [ -f docs/$VERSION/milv.config.yaml ]; then
+              cd docs/$VERSION
+              echo "Running milv on docs/$VERSION:"
+              go get -u github.com/magicmatatjahu/milv
+              milv -ignore-internal
               echo "------------------------------"
               cd -
             else
@@ -2660,6 +2740,6 @@ steps:
 
 ---
 kind: signature
-hmac: 382d9ed0ef2248daf1c75e74c0f1560291365c3671f441894f0ad723406a183f
+hmac: 179641ffc8418799a4fbd3a8281dc3fb8168222b0e79af818bf6b7d62f707aaf
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -230,7 +230,7 @@ steps:
             if [ -f docs/$VERSION/milv.config.yaml ]; then
               cd docs/$VERSION
               echo "Running milv on docs/$VERSION:"
-              go get -u github.com/magicmatatjahu/milv 2>&1 >/dev/null
+              go get github.com/magicmatatjahu/milv
               milv -ignore-external
               echo "------------------------------"
               cd -
@@ -310,7 +310,7 @@ steps:
             if [ -f docs/$VERSION/milv.config.yaml ]; then
               cd docs/$VERSION
               echo "Running milv on docs/$VERSION:"
-              go get -u github.com/magicmatatjahu/milv 2>&1 >/dev/null
+              go get github.com/magicmatatjahu/milv
               milv -ignore-internal
               echo "------------------------------"
               cd -
@@ -2740,6 +2740,6 @@ steps:
 
 ---
 kind: signature
-hmac: a8e99b9adf265649ae2688790a617f8fbc78fd36b443bd1ae6e971caa5613831
+hmac: 96c78107ad8813d3635598369381cc2865084e07856f64d6c8ad57418a321d04
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -88,7 +88,7 @@ steps:
         #git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs' | grep -v ^$ | wc -l > /tmp/.change_count.txt
         # temporarily suppress .drone.yml changes to test early exit
         git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs' | grep -v ^$ | grep -v .drone.yml | wc -l > /tmp/.change_count.txt
-        if [ $(cat /tmp/.change_count.txt | wc -l) -gt 0 ]; then
+        if [ $(cat /tmp/.change_count.txt) -gt 0 ]; then
           echo "$(cat /tmp/.change_count.txt | tr -d '\n') changes to code were detected, tests will run"
         else
           echo "$(cat /tmp/.change_count.txt | tr -d '\n') changes to code detected, tests will not run"
@@ -2757,6 +2757,6 @@ steps:
 
 ---
 kind: signature
-hmac: 0fff198d611f5de7773f8c480c119ab0035d83446de59a5623f37c3c2384bf76
+hmac: 4fa9878085e2e421ea183229d2bf97991766b2460dfc389fa6d258fd9178e16d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -79,6 +79,19 @@ steps:
           fi
         fi
 
+  - name: Check whether tests need to run
+    image: docker:git
+    commands:
+    - |
+        git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master}
+        if [ $(git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs' | grep -v ^$ | wc -l) -gt 0 ]; then
+          echo "Changes to code were detected, tests will run"
+        else
+          echo "No changes to code detected, tests will not run"
+          # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+          exit 78
+        fi
+
   - name: Build buildbox
     image: docker
     volumes:
@@ -2740,6 +2753,6 @@ steps:
 
 ---
 kind: signature
-hmac: 179641ffc8418799a4fbd3a8281dc3fb8168222b0e79af818bf6b7d62f707aaf
+hmac: 1ddbabcec0d02e591dee443b2a0dbcf519a8139497f98aae35e6e53953712a4b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -230,7 +230,7 @@ steps:
             if [ -f docs/$VERSION/milv.config.yaml ]; then
               cd docs/$VERSION
               echo "Running milv on docs/$VERSION:"
-              go get -u github.com/magicmatatjahu/milv 2>&1 >dev/null
+              go get -u github.com/magicmatatjahu/milv 2>&1 >/dev/null
               milv -ignore-external
               echo "------------------------------"
               cd -
@@ -310,7 +310,7 @@ steps:
             if [ -f docs/$VERSION/milv.config.yaml ]; then
               cd docs/$VERSION
               echo "Running milv on docs/$VERSION:"
-              go get -u github.com/magicmatatjahu/milv 2>&1 >dev/null
+              go get -u github.com/magicmatatjahu/milv 2>&1 >/dev/null
               milv -ignore-internal
               echo "------------------------------"
               cd -
@@ -2740,6 +2740,6 @@ steps:
 
 ---
 kind: signature
-hmac: 7d7d91230c2f459de1837c3a131d3ef248ecec151a65f79885394bdd86c71837
+hmac: a8e99b9adf265649ae2688790a617f8fbc78fd36b443bd1ae6e971caa5613831
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -79,16 +79,19 @@ steps:
           fi
         fi
 
-  - name: Check whether tests need to run
+  - name: Skip tests if appropriate
     image: docker:git
     commands:
     - |
         cd /go/src/github.com/gravitational/teleport
         git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master}
-        if [ $(git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs' | grep -v ^$ | wc -l) -gt 0 ]; then
-          echo "Changes to code were detected, tests will run"
+        #git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs' | grep -v ^$ | wc -l > /tmp/.change_count.txt
+        # temporarily suppress .drone.yml changes to test early exit
+        git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs' | grep -v ^$ | grep -v .drone.yml | wc -l > /tmp/.change_count.txt
+        if [ $(cat /tmp/.change_count.txt | wc -l) -gt 0 ]; then
+          echo "$(cat /tmp/.change_count.txt | tr -d '\n') changes to code were detected, tests will run"
         else
-          echo "No changes to code detected, tests will not run"
+          echo "$(cat /tmp/.change_count.txt | tr -d '\n') changes to code detected, tests will not run"
           # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
           exit 78
         fi
@@ -2754,6 +2757,6 @@ steps:
 
 ---
 kind: signature
-hmac: 5609421ca66b84a279d6640675a82880c5b7ccc3aef7c88952c2e0d3f7bec96a
+hmac: 0fff198d611f5de7773f8c480c119ab0035d83446de59a5623f37c3c2384bf76
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -232,7 +232,7 @@ steps:
               cd docs/$VERSION
               echo "---> Running milv on docs/$VERSION:"
               milv -ignore-external
-              echo -e "------------------------------\n"
+              echo "------------------------------\n"
               cd -
             else
               echo "---> No milv config found, skipping docs/$VERSION"
@@ -312,7 +312,7 @@ steps:
               cd docs/$VERSION
               echo "---> Running milv on docs/$VERSION:"
               milv -ignore-internal
-              echo -e "------------------------------\n"
+              echo "------------------------------\n"
               cd -
             else
               echo "---> No milv config found, skipping docs/$VERSION"
@@ -2740,6 +2740,6 @@ steps:
 
 ---
 kind: signature
-hmac: 9674b59b0e4245ddc35d6f6d59b93bc772abf83f7913dde68e72a070882f1559
+hmac: 0bd8c93a59273b788e1f17fd2ba281adf813150c7880290cf0215af1dc20c815
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -79,23 +79,6 @@ steps:
           fi
         fi
 
-  - name: Skip tests if appropriate
-    image: docker:git
-    commands:
-    - |
-        cd /go/src/github.com/gravitational/teleport
-        git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master}
-        #git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs' | grep -v ^$ | wc -l > /tmp/.change_count.txt
-        # temporarily suppress .drone.yml changes to test early exit
-        git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs' | grep -v ^$ | grep -v .drone.yml | wc -l > /tmp/.change_count.txt
-        if [ $(cat /tmp/.change_count.txt) -gt 0 ]; then
-          echo "$(cat /tmp/.change_count.txt | tr -d '\n') changes to code were detected, tests will run"
-        else
-          echo "$(cat /tmp/.change_count.txt | tr -d '\n') changes to code detected, tests will not run"
-          # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
-          exit 78
-        fi
-
   - name: Build buildbox
     image: docker
     volumes:
@@ -2757,6 +2740,6 @@ steps:
 
 ---
 kind: signature
-hmac: 478f81a30abb92494278517dd81439757c5fc84e3bcc2193126bc21f986fdb37
+hmac: 7d7d91230c2f459de1837c3a131d3ef248ecec151a65f79885394bdd86c71837
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,7 +66,7 @@ steps:
         if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
           apk add --no-cache curl jq
           export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/teleport/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
-          echo "Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
+          echo "---> Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
           # if the source repo for the PR matches DRONE_REPO, then this is not a PR raised from a fork
           if [ "$${PR_REPO}" = "${DRONE_REPO}" ]; then
             mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
@@ -222,7 +222,7 @@ steps:
         cd /go/src/github.com/gravitational/teleport
         git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
-          echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
+          echo "---> Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           # Check trailing whitespace
           make docs-test-whitespace
           # Check links
@@ -230,15 +230,15 @@ steps:
             if [ -f docs/$VERSION/milv.config.yaml ]; then
               go get github.com/magicmatatjahu/milv
               cd docs/$VERSION
-              echo "Running milv on docs/$VERSION:"
+              echo "---> Running milv on docs/$VERSION:"
               milv -ignore-external
-              echo "------------------------------"
+              echo -e "------------------------------\n"
               cd -
             else
-              echo "No milv config found, skipping docs/$VERSION"
+              echo "---> No milv config found, skipping docs/$VERSION"
             fi
           done
-          else echo "No changes to docs detected, not running tests"
+          else echo "---> No changes to docs detected, not running tests"
         fi
 
 ---
@@ -302,7 +302,7 @@ steps:
         cd /go/src/github.com/gravitational/teleport
         git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
         if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
-          echo "Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
+          echo "---> Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
           # Check trailing whitespace
           make docs-test-whitespace
           # Check links
@@ -310,15 +310,15 @@ steps:
             if [ -f docs/$VERSION/milv.config.yaml ]; then
               go get github.com/magicmatatjahu/milv
               cd docs/$VERSION
-              echo "Running milv on docs/$VERSION:"
+              echo "---> Running milv on docs/$VERSION:"
               milv -ignore-internal
-              echo "------------------------------"
+              echo -e "------------------------------\n"
               cd -
             else
-              echo "No milv config found, skipping docs/$VERSION"
+              echo "---> No milv config found, skipping docs/$VERSION"
             fi
           done
-          else echo "No changes to docs detected, not running tests"
+          else echo "---> No changes to docs detected, not running tests"
         fi
 
 ---
@@ -2454,12 +2454,12 @@ steps:
       - export MARKETPLACE_AMI_NAME=gravitational-teleport-marketplace-ami-oss-$TELEPORT_VERSION
       - |
         if [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
-          echo "Building production OSS AMIs"
+          echo "---> Building production OSS AMIs"
           make oss-ci-build
-          echo "Making OSS AMIs public"
+          echo "---> Making OSS AMIs public"
           make change-amis-to-public-oss
         else
-          echo "Building debug OSS AMIs"
+          echo "---> Building debug OSS AMIs"
           make oss
         fi
 
@@ -2547,14 +2547,14 @@ steps:
       - export MARKETPLACE_AMI_NAME=gravitational-teleport-marketplace-ami-ent-$TELEPORT_VERSION
       - |
         if [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
-          echo "Building production Enterprise AMIs"
+          echo "---> Building production Enterprise AMIs"
           make ent-ci-build
-          echo "Making Enterprise AMIs public"
+          echo "---> Making Enterprise AMIs public"
           make change-amis-to-public-ent
-          echo "Making Enterprise FIPS AMIs public"
+          echo "---> Making Enterprise FIPS AMIs public"
           make change-amis-to-public-ent-fips
         else
-          echo "Building debug Enterprise AMIs"
+          echo "---> Building debug Enterprise AMIs"
           make ent
         fi
 
@@ -2740,6 +2740,6 @@ steps:
 
 ---
 kind: signature
-hmac: d172f5c9261b110b566cc0111ff413fc24d50462895a93d33a0707bf753a5744
+hmac: 9674b59b0e4245ddc35d6f6d59b93bc772abf83f7913dde68e72a070882f1559
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -247,7 +247,7 @@ steps:
             if [ -f docs/$VERSION/milv.config.yaml ]; then
               cd docs/$VERSION
               echo "Running milv on docs/$VERSION:"
-              go get -u github.com/magicmatatjahu/milv
+              go get -u github.com/magicmatatjahu/milv 2>&1 >dev/null
               milv -ignore-external
               echo "------------------------------"
               cd -
@@ -327,7 +327,7 @@ steps:
             if [ -f docs/$VERSION/milv.config.yaml ]; then
               cd docs/$VERSION
               echo "Running milv on docs/$VERSION:"
-              go get -u github.com/magicmatatjahu/milv
+              go get -u github.com/magicmatatjahu/milv 2>&1 >dev/null
               milv -ignore-internal
               echo "------------------------------"
               cd -
@@ -2757,6 +2757,6 @@ steps:
 
 ---
 kind: signature
-hmac: 4fa9878085e2e421ea183229d2bf97991766b2460dfc389fa6d258fd9178e16d
+hmac: 478f81a30abb92494278517dd81439757c5fc84e3bcc2193126bc21f986fdb37
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -83,6 +83,7 @@ steps:
     image: docker:git
     commands:
     - |
+        cd /go/src/github.com/gravitational/teleport
         git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master}
         if [ $(git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs' | grep -v ^$ | wc -l) -gt 0 ]; then
           echo "Changes to code were detected, tests will run"
@@ -2753,6 +2754,6 @@ steps:
 
 ---
 kind: signature
-hmac: 1ddbabcec0d02e591dee443b2a0dbcf519a8139497f98aae35e6e53953712a4b
+hmac: 5609421ca66b84a279d6640675a82880c5b7ccc3aef7c88952c2e0d3f7bec96a
 
 ...

--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -2648,4 +2648,3 @@ If you need help, please ask on our [community forum](https://community.gravitat
 For commercial support, you can create a ticket through the [customer dashboard](https://dashboard.gravitational.com/).
 
 For more information about custom features, or to try our [Enterprise edition](enterprise/index.md) of Teleport, please reach out to us at [sales@gravitational.com](mailto:sales@gravitational.com).
-

--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -2648,3 +2648,4 @@ If you need help, please ask on our [community forum](https://community.gravitat
 For commercial support, you can create a ticket through the [customer dashboard](https://dashboard.gravitational.com/).
 
 For more information about custom features, or to try our [Enterprise edition](enterprise/index.md) of Teleport, please reach out to us at [sales@gravitational.com](mailto:sales@gravitational.com).
+


### PR DESCRIPTION
As we've seen a lot of external link tests failing recently, I'm proposing a change to split the `test-docs` job into two separate jobs:

* `test-docs-internal`, which will only test internal links inside the docs to make sure that we're linking to correct anchors/pages
* `test-docs-external`, which will try to load all external links.
  * This step is marked with `failure: ignore`, so that a temporary failure to load a link outside of the docs (which is the vast majority of the failures we see) won't fail the entire CI job.
  * Unfortunately this may lead to broken links not being spotted in a timely fashion, but there is a plan (at some point) to introduce an external service which will load and validate all the links on our website, so hopefully we won't need `milv` to test external links at some point in the future.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1190029021439585/1190780562117236) by [Unito](https://www.unito.io/learn-more)
