### PR TITLE
Fix windowsaccountname claim format in ADFS examples

### DIFF
--- a/docs/4.1/ssh_adfs.md
+++ b/docs/4.1/ssh_adfs.md
@@ -110,7 +110,7 @@ spec:
     max_session_ttl: "1h"
   allow:
     # only allow login as either ubuntu or the 'windowsaccountname' claim
-    logins: [ '{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}', ubuntu ]
+    logins: [ '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
@@ -119,9 +119,9 @@ This role declares:
 
 * Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 * Developers can log in as `ubuntu` user
-* Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
+* Notice `{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
-  Also note the double quotes (`"`) around the claim name - these are important.
+  Also note the double quotes (`"`) and square brackets (`[]`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/4.2/enterprise/sso/ssh_adfs.md
+++ b/docs/4.2/enterprise/sso/ssh_adfs.md
@@ -112,7 +112,7 @@ spec:
     max_session_ttl: "1h"
   allow:
     # only allow login as either ubuntu or the 'windowsaccountname' claim
-    logins: [ '{% raw %}{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}{% endraw %}', ubuntu ]
+    logins: [ '{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
@@ -121,9 +121,9 @@ This role declares:
 
 * Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 * Developers can log in as `ubuntu` user
-* Notice `{% raw %}{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}{% endraw %}` login. It configures Teleport to look at
+* Notice `{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
-  Also note the double quotes (`"`) around the claim name - these are important.
+  Also note the double quotes (`"`) and square brackets (`[]`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 

--- a/docs/4.3/enterprise/sso/ssh_adfs.md
+++ b/docs/4.3/enterprise/sso/ssh_adfs.md
@@ -112,7 +112,7 @@ spec:
     max_session_ttl: "1h"
   allow:
     # only allow login as either ubuntu or the 'windowsaccountname' claim
-    logins: [ '{% raw %}{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}{% endraw %}', ubuntu ]
+    logins: [ '{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
@@ -121,9 +121,9 @@ This role declares:
 
 * Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 * Developers can log in as `ubuntu` user
-* Notice `{% raw %}{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}{% endraw %}` login. It configures Teleport to look at
+* Notice `{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}` login. It configures Teleport to look at
   _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
-  Also note the double quotes (`"`) around the claim name - these are important.
+  Also note the double quotes (`"`) and square brackets (`[]`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 


### PR DESCRIPTION
This matches the format used in the test - https://github.com/gravitational/teleport/blob/master/lib/services/role_test.go#L1414-L1418

The example is actually correct in https://gravitational.com/teleport/docs/enterprise/ssh_rbac/ but was incorrect in the ADFS docs.

Fixes #4259



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1190029021439585/1190831893542889) by [Unito](https://www.unito.io/learn-more)
