### PR TITLE
Stop test execution early for changes to docs only

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -79,6 +79,24 @@ steps:
           fi
         fi
 
+  - name: Optionally skip tests
+    image: docker:git
+    commands:
+    - |
+        cd /go/src/github.com/gravitational/teleport
+        # show output of git diff --raw for reference
+        git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master}
+        # check whether there are any changes which don't touch "docs/*" or "*.md"
+        git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -Ev '^docs/' | grep -Ev '.md$' | grep -v ^$ | wc -l > /tmp/.change_count.txt
+        export CHANGE_COUNT=$(cat /tmp/.change_count.txt | tr -d '\n')
+        if [ $$CHANGE_COUNT -gt 0 ]; then
+          echo "---> $$CHANGE_COUNT changes to code were detected, tests will run"
+        else
+          echo "---> $$CHANGE_COUNT changes to code detected, tests will not run"
+          # https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+          exit 78
+        fi
+
   - name: Build buildbox
     image: docker
     volumes:
@@ -2660,6 +2678,6 @@ steps:
 
 ---
 kind: signature
-hmac: 382d9ed0ef2248daf1c75e74c0f1560291365c3671f441894f0ad723406a183f
+hmac: e98133f134428a273efefdb686f42eca3d655f6c71710ec61e46aab2dca551df
 
 ...


### PR DESCRIPTION
This is currently blocked on a bug in Drone - https://discourse.drone.io/t/using-exit-code-78-with-kubernetes-runner-doesnt-stop-execution/7937

As such, I'm just going to leave the code here with a closed PR until the bug is fixed or addressed.