### PR TITLE
Fix triggers for tests to run on PRs only

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2710,6 +2710,6 @@ steps:
 
 ---
 kind: signature
-hmac: 0bd8c93a59273b788e1f17fd2ba281adf813150c7880290cf0215af1dc20c815
+hmac: c7510ab3cfc927731ae7bcce4966eb915bb318693360b4203b07ae5bade2de5b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -217,14 +217,9 @@ type: kubernetes
 name: test-docs-external
 
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    include:
+      - pull_request
   repo:
     include:
       - gravitational/*
@@ -2710,6 +2705,6 @@ steps:
 
 ---
 kind: signature
-hmac: c7510ab3cfc927731ae7bcce4966eb915bb318693360b4203b07ae5bade2de5b
+hmac: bcd363559f085905edc708b7ea225610da0cba0568ee70f8e1417e51013b4c9f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,14 +9,9 @@ environment:
   GID: 1000
 
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    include:
+      - pull_request
   repo:
     include:
       - gravitational/*
@@ -130,26 +125,6 @@ steps:
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets integration
 
-  - name: Send Slack notification for build failures
-    image: plugins/slack
-    settings:
-      webhook:
-        from_secret: SLACK_WEBHOOK
-      channel: teleport-builds
-      template: |
-        {{#if build.pull }}
-          *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}*: <https://github.com/{{ repo.owner }}/{{ repo.name }}/pull/{{ build.pull }}|Pull Request #{{ build.pull }}>
-        {{else}}
-          *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-        {{/if}}
-        Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
-        Author: {{ build.author }}
-        <{{ build.link }}|Visit build page ↗>
-    when:
-      event: [push]
-      status: [failure]
-
 services:
   - name: Start Docker
     image: docker:dind
@@ -168,14 +143,9 @@ type: kubernetes
 name: test-docs-internal
 
 trigger:
-  branch:
-    - master
-    - branch/*
   event:
-    exclude:
-      - cron
-      - promote
-      - rollback
+    include:
+      - pull_request
   repo:
     include:
       - gravitational/*


### PR DESCRIPTION
We need Drone to run on any PRs raised against Teleport, regardless of whether the intent is to merge into master or not. This is how Jenkins works currently.

At the moment, Drone runs on:
- all `push events` for `master` or `branch/*` (so when you actually merge a PR into either branch, as we don't permit direct pushes without a PR)
- all `pull_request` events when the PR is raised against `master` or `branch/*` (which missed any PRs raised against a different branch name)

This (current) setup has the effect of only registering one Github "check" on a PR and one "check" on a push, so there's no duplication. If this branch stipulation is removed but the trigger is left as `push` and `pull_request`, Drone will run twice on every commit to a PR. As such, we need to gate this to only run on `pull_request` events to prevent duplication. This PR achieves that.

Drone running on pushes to `master` isn't super useful currently, and Jenkins doesn't do it. We can look to improve how this works in the context of future Drone improvements (#4031).

The Slack notifications which were previously being delivered are also high noise, low signal. I'm going to disable these for now and will reinstate them once there is a proper artifact test build pipeline being run on commits to `master` (which is more in line with the #teleport-builds channel name)