### PR TITLE
Split remote cluster watching from reversetunnel.AgentPool

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -90,10 +90,10 @@ type TeleInstance struct {
 	Hostname string
 
 	// Internal stuff...
-	Process *service.TeleportProcess
-	Config  *service.Config
-	Tunnel  reversetunnel.Server
-	Pool    *reversetunnel.AgentPool
+	Process              *service.TeleportProcess
+	Config               *service.Config
+	Tunnel               reversetunnel.Server
+	RemoteClusterWatcher *reversetunnel.RemoteClusterTunnelManager
 
 	// Nodes is a list of additional nodes
 	// started with this instance
@@ -950,9 +950,9 @@ func (i *TeleInstance) Start() error {
 				i.Tunnel = ts
 			}
 		case service.ProxyAgentPoolReady:
-			ap, ok := re.Payload.(*reversetunnel.AgentPool)
+			w, ok := re.Payload.(*reversetunnel.RemoteClusterTunnelManager)
 			if ok {
-				i.Pool = ap
+				i.RemoteClusterWatcher = w
 			}
 		}
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2464,7 +2464,7 @@ func waitForProxyCount(t *TeleInstance, clusterName string, count int) error {
 	var counts map[string]int
 	start := time.Now()
 	for time.Since(start) < 17*time.Second {
-		counts = t.Pool.Counts()
+		counts = t.RemoteClusterWatcher.Counts()
 		if counts[clusterName] == count {
 			return nil
 		}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1000,7 +1000,7 @@ func (f *Forwarder) newClusterSession(ctx authContext) (*clusterSession, error) 
 	// remote clusters use special hardcoded URL,
 	// and use a special dialer
 	if ctx.cluster.isRemote {
-		ctx.cluster.targetAddr = reversetunnel.RemoteKubeProxy
+		ctx.cluster.targetAddr = reversetunnel.LocalKubernetes
 	} else {
 		ctx.cluster.targetAddr = f.creds.targetAddr
 	}

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -521,7 +521,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 	sess, err = f.newClusterSession(authCtx)
 	c.Assert(err, check.IsNil)
 	c.Assert(f.clusterSessions.Len(), check.Equals, 2)
-	c.Assert(sess.authContext.cluster.targetAddr, check.Equals, reversetunnel.RemoteKubeProxy)
+	c.Assert(sess.authContext.cluster.targetAddr, check.Equals, reversetunnel.LocalKubernetes)
 	c.Assert(sess.forwarder, check.NotNil)
 	// Make sure newClusterSession obtained a new client cert instead of using
 	// f.creds.

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -18,7 +18,6 @@ package reversetunnel
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -27,7 +26,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -48,17 +46,16 @@ type ServerHandler interface {
 // The agent pool watches the reverse tunnel entries created by the admin and
 // connects/disconnects to added/deleted tunnels.
 type AgentPool struct {
-	sync.Mutex
-	*log.Entry
+	log          *log.Entry
 	cfg          AgentPoolConfig
-	agents       map[agentKey][]*Agent
 	proxyTracker *track.Tracker
 	ctx          context.Context
 	cancel       context.CancelFunc
-	// lastReport is the last time the agent has reported the stats
-	lastReport time.Time
 	// spawnLimiter limits agent spawn rate
 	spawnLimiter utils.Retry
+
+	mu     sync.Mutex
+	agents map[track.Key][]*Agent
 }
 
 // AgentPoolConfig holds configuration parameters for the agent pool
@@ -69,14 +66,12 @@ type AgentPoolConfig struct {
 	// AccessPoint is a lightweight access point
 	// that can optionally cache some values
 	AccessPoint auth.AccessPoint
-	// HostSigners is a list of host signers this agent presents itself as
-	HostSigners []ssh.Signer
+	// HostSigner is a host signer this agent presents itself as
+	HostSigner ssh.Signer
 	// HostUUID is a unique ID of this host
 	HostUUID string
-	// Context is an optional context
-	Context context.Context
-	// Cluster is a cluster name
-	Cluster string
+	// LocalCluster is a cluster name this client is a member of.
+	LocalCluster string
 	// Clock is a clock used to get time, if not set,
 	// system clock is used
 	Clock clockwork.Clock
@@ -90,8 +85,10 @@ type AgentPoolConfig struct {
 	Component string
 	// ReverseTunnelServer holds all reverse tunnel connections.
 	ReverseTunnelServer Server
-	// ProxyAddr if set, points to the address of the ssh proxy
+	// ProxyAddr points to the address of the ssh proxy
 	ProxyAddr string
+	// Cluster is a cluster name of the proxy.
+	Cluster string
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -102,14 +99,11 @@ func (cfg *AgentPoolConfig) CheckAndSetDefaults() error {
 	if cfg.AccessPoint == nil {
 		return trace.BadParameter("missing 'AccessPoint' parameter")
 	}
-	if len(cfg.HostSigners) == 0 {
-		return trace.BadParameter("missing 'HostSigners' parameter")
+	if cfg.HostSigner == nil {
+		return trace.BadParameter("missing 'HostSigner' parameter")
 	}
 	if len(cfg.HostUUID) == 0 {
 		return trace.BadParameter("missing 'HostUUID' parameter")
-	}
-	if cfg.Context == nil {
-		cfg.Context = context.TODO()
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clockwork.NewRealClock()
@@ -118,7 +112,7 @@ func (cfg *AgentPoolConfig) CheckAndSetDefaults() error {
 }
 
 // NewAgentPool returns new isntance of the agent pool
-func NewAgentPool(cfg AgentPoolConfig) (*AgentPool, error) {
+func NewAgentPool(ctx context.Context, cfg AgentPoolConfig) (*AgentPool, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -131,27 +125,32 @@ func NewAgentPool(cfg AgentPoolConfig) (*AgentPool, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	ctx, cancel := context.WithCancel(cfg.Context)
+	proxyAddr, err := utils.ParseAddr(cfg.ProxyAddr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ctx, cancel := context.WithCancel(ctx)
 	pool := &AgentPool{
-		agents:       make(map[agentKey][]*Agent),
+		agents:       make(map[track.Key][]*Agent),
 		proxyTracker: track.New(ctx, track.Config{}),
 		cfg:          cfg,
 		ctx:          ctx,
 		cancel:       cancel,
 		spawnLimiter: retry,
+		log: log.WithFields(log.Fields{
+			trace.Component: teleport.ComponentReverseTunnelAgent,
+			trace.ComponentFields: log.Fields{
+				"cluster": cfg.Cluster,
+			},
+		}),
 	}
-	pool.Entry = log.WithFields(log.Fields{
-		trace.Component: teleport.ComponentReverseTunnelAgent,
-		trace.ComponentFields: log.Fields{
-			"cluster": cfg.Cluster,
-		},
-	})
+	pool.proxyTracker.Start(track.Key{Cluster: cfg.Cluster, Addr: *proxyAddr})
 	return pool, nil
 }
 
 // Start starts the agent pool
 func (m *AgentPool) Start() error {
-	m.Debugf("Starting agent pool %s.%s...", m.cfg.HostUUID, m.cfg.Cluster)
+	m.log.Debugf("Starting agent pool %s.%s...", m.cfg.HostUUID, m.cfg.Cluster)
 	go m.pollAndSyncAgents()
 	go m.processSeekEvents()
 	return nil
@@ -172,19 +171,19 @@ func (m *AgentPool) processSeekEvents() {
 	for {
 		select {
 		case <-m.ctx.Done():
-			m.Debugf("Halting seek event processing (pool closing)")
+			m.log.Debugf("Halting seek event processing (pool closing)")
 			return
 		case lease := <-m.proxyTracker.Acquire():
-			m.Debugf("Seeking: %+v.", lease.Key())
+			m.log.Debugf("Seeking: %+v.", lease.Key())
 			m.withLock(func() {
 				if err := m.addAgent(lease); err != nil {
-					m.WithError(err).Errorf("Failed to add agent.")
+					m.log.WithError(err).Errorf("Failed to add agent.")
 				}
 			})
 		}
 		select {
 		case <-m.ctx.Done():
-			m.Debugf("Halting seek event processing (pool closing)")
+			m.log.Debugf("Halting seek event processing (pool closing)")
 			return
 		case <-limiter.After():
 			limiter.Inc()
@@ -192,37 +191,17 @@ func (m *AgentPool) processSeekEvents() {
 	}
 }
 
-// FetchAndSyncAgents executes one time fetch and sync request
-// (used in tests instead of polling)
-func (m *AgentPool) FetchAndSyncAgents() error {
-	tunnels, err := m.getReverseTunnels()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if err := m.syncAgents(tunnels); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
 func (m *AgentPool) withLock(f func()) {
-	m.Lock()
-	defer m.Unlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	f()
 }
 
 type matchAgentFn func(a *Agent) bool
 
-func (m *AgentPool) closeAgentsIf(matchKey *agentKey, matchAgent matchAgentFn) {
-	if matchKey != nil {
-		m.agents[*matchKey] = filterAndClose(m.agents[*matchKey], matchAgent)
-		if len(m.agents[*matchKey]) == 0 {
-			delete(m.agents, *matchKey)
-		}
-		return
-	}
+func (m *AgentPool) closeAgents() {
 	for key, agents := range m.agents {
-		m.agents[key] = filterAndClose(agents, matchAgent)
+		m.agents[key] = filterAndClose(agents, func(*Agent) bool { return true })
 		if len(m.agents[key]) == 0 {
 			delete(m.agents, key)
 		}
@@ -243,59 +222,35 @@ func filterAndClose(agents []*Agent, matchAgent matchAgentFn) []*Agent {
 	return filtered
 }
 
-func (m *AgentPool) closeAgents(matchKey *agentKey) {
-	m.closeAgentsIf(matchKey, func(*Agent) bool {
-		// close all agents matching the matchKey
-		return true
-	})
-}
-
 func (m *AgentPool) pollAndSyncAgents() {
 	ticker := time.NewTicker(defaults.ResyncInterval)
 	defer ticker.Stop()
-	if err := m.FetchAndSyncAgents(); err != nil {
-		m.Warningf("Failed to get reverse tunnels: %v.", err)
-	}
 	for {
 		select {
 		case <-m.ctx.Done():
-			m.withLock(func() {
-				m.closeAgents(nil)
-			})
-			m.Debugf("Closing.")
+			m.withLock(m.closeAgents)
+			m.log.Debugf("Closing.")
 			return
 		case <-ticker.C:
-			err := m.FetchAndSyncAgents()
-			if err != nil {
-				m.Warningf("Failed to get reverse tunnels: %v.", err)
-				continue
-			}
+			m.withLock(m.removeDisconnected)
 		}
 	}
 }
 
 func (m *AgentPool) addAgent(lease track.Lease) error {
-	// If the component connecting is a proxy, get the cluster name from the
-	// clusterName (where it is the name of the remote cluster). If it's a node, get
-	// the cluster name from the agent pool configuration itself (where it is
-	// the name of the local cluster).
-	key := keyFromLease(lease)
-	clusterName := key.clusterName
-	if key.tunnelType == string(services.NodeTunnel) {
-		clusterName = m.cfg.Cluster
-	}
+	key := lease.Key().(track.Key)
 	agent, err := NewAgent(AgentConfig{
-		Addr:                key.addr,
-		ClusterName:         clusterName,
+		Addr:                key.Addr,
+		ClusterName:         m.cfg.Cluster,
 		Username:            m.cfg.HostUUID,
-		Signers:             m.cfg.HostSigners,
+		Signer:              m.cfg.HostSigner,
 		Client:              m.cfg.Client,
 		AccessPoint:         m.cfg.AccessPoint,
 		Context:             m.ctx,
 		KubeDialAddr:        m.cfg.KubeDialAddr,
 		Server:              m.cfg.Server,
 		ReverseTunnelServer: m.cfg.ReverseTunnelServer,
-		LocalClusterName:    m.cfg.Cluster,
+		LocalClusterName:    m.cfg.LocalCluster,
 		Tracker:             m.proxyTracker,
 		Lease:               lease,
 	})
@@ -304,7 +259,7 @@ func (m *AgentPool) addAgent(lease track.Lease) error {
 		lease.Release()
 		return trace.Wrap(err)
 	}
-	m.Debugf("Adding %v.", agent)
+	m.log.Debugf("Adding %v.", agent)
 	// start the agent in a goroutine. no need to handle Start() errors: Start() will be
 	// retrying itself until the agent is closed
 	go agent.Start()
@@ -315,108 +270,19 @@ func (m *AgentPool) addAgent(lease track.Lease) error {
 // Counts returns a count of the number of proxies a outbound tunnel is
 // connected to. Used in tests to determine if a proxy has been found and/or
 // removed.
-func (m *AgentPool) Counts() map[string]int {
-	m.Lock()
-	defer m.Unlock()
-	out := make(map[string]int)
-	for key, agents := range m.agents {
-		count := 0
-		for _, agent := range agents {
-			if agent.getState() == agentStateConnected {
-				count++
+func (m *AgentPool) Count() int {
+	var out int
+	m.withLock(func() {
+		for _, agents := range m.agents {
+			for _, agent := range agents {
+				if agent.getState() == agentStateConnected {
+					out++
+				}
 			}
 		}
-		out[key.clusterName] += count
-	}
+	})
 
 	return out
-}
-
-// getReverseTunnels always returns a builtin node tunnel
-// that has to be established
-func (m *AgentPool) getReverseTunnels() ([]services.ReverseTunnel, error) {
-	// Proxy uses reverse tunnels for bookkeeping
-	// purposes - to communicate that trusted cluster has been
-	// deleted and all agents have to be closed.
-	// Nodes do not have this need as the agent pool should
-	// exist as long as the node is running.
-	switch m.cfg.Component {
-	case teleport.ComponentProxy:
-		return m.cfg.AccessPoint.GetReverseTunnels()
-	case teleport.ComponentNode:
-		reverseTunnel := services.NewReverseTunnel(
-			m.cfg.Cluster,
-			[]string{m.cfg.ProxyAddr},
-		)
-		reverseTunnel.SetType(services.NodeTunnel)
-		return []services.ReverseTunnel{reverseTunnel}, nil
-	default:
-		return nil, trace.BadParameter("unsupported component %q", m.cfg.Component)
-	}
-}
-
-// reportStats submits report about agents state once in a while at info
-// level. Always logs more detailed information at debug level.
-func (m *AgentPool) reportStats() {
-	var logReport bool
-	if m.cfg.Clock.Now().Sub(m.lastReport) > defaults.ReportingPeriod {
-		m.lastReport = m.cfg.Clock.Now()
-		logReport = true
-	}
-
-	for key, agents := range m.agents {
-		countPerState := map[string]int{
-			agentStateConnecting:   0,
-			agentStateConnected:    0,
-			agentStateDisconnected: 0,
-		}
-		for _, a := range agents {
-			countPerState[a.getState()]++
-		}
-		for state, count := range countPerState {
-			gauge, err := trustedClustersStats.GetMetricWithLabelValues(key.clusterName, state)
-			if err != nil {
-				m.Warningf("Failed to get gauge: %v.", err)
-				continue
-			}
-			gauge.Set(float64(count))
-		}
-		if logReport {
-			m.WithFields(log.Fields{"target": key.clusterName, "stats": countPerState}).Info("Outbound tunnel stats.")
-		} else {
-			m.WithFields(log.Fields{"target": key.clusterName, "stats": countPerState}).Debug("Outbound tunnel stats.")
-		}
-	}
-}
-
-func (m *AgentPool) syncAgents(tunnels []services.ReverseTunnel) error {
-	m.Lock()
-	defer m.Unlock()
-
-	keys, err := tunnelsToAgentKeys(tunnels)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	agentsToAdd, agentsToRemove := diffTunnels(m.agents, keys)
-
-	// remove agents from deleted reverse tunnels
-	for _, key := range agentsToRemove {
-		m.proxyTracker.Stop(agentToTrackingKey(key))
-		m.closeAgents(&key)
-	}
-	// add agents from added reverse tunnels
-	for _, key := range agentsToAdd {
-		m.proxyTracker.Start(agentToTrackingKey(key))
-	}
-
-	// Remove disconnected agents from the list of agents.
-	m.removeDisconnected()
-
-	// Report tunnel statistics.
-	m.reportStats()
-
-	return nil
 }
 
 // removeDisconnected removes disconnected agents from the list of agents.
@@ -435,81 +301,4 @@ func (m *AgentPool) removeDisconnected() {
 			delete(m.agents, agentKey)
 		}
 	}
-}
-
-func tunnelsToAgentKeys(tunnels []services.ReverseTunnel) (map[agentKey]bool, error) {
-	vals := make(map[agentKey]bool)
-	for _, tunnel := range tunnels {
-		keys, err := tunnelToAgentKeys(tunnel)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		for _, key := range keys {
-			vals[key] = true
-		}
-	}
-	return vals, nil
-}
-
-func tunnelToAgentKeys(tunnel services.ReverseTunnel) ([]agentKey, error) {
-	out := make([]agentKey, len(tunnel.GetDialAddrs()))
-	for i, addr := range tunnel.GetDialAddrs() {
-		netaddr, err := utils.ParseAddr(addr)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		out[i] = agentKey{addr: *netaddr, tunnelType: string(tunnel.GetType()), clusterName: tunnel.GetClusterName()}
-	}
-	return out, nil
-}
-
-func diffTunnels(existingTunnels map[agentKey][]*Agent, arrivedKeys map[agentKey]bool) ([]agentKey, []agentKey) {
-	var agentsToRemove, agentsToAdd []agentKey
-	for existingKey := range existingTunnels {
-		if _, ok := arrivedKeys[existingKey]; !ok { // agent was removed
-			agentsToRemove = append(agentsToRemove, existingKey)
-		}
-	}
-
-	for arrivedKey := range arrivedKeys {
-		if _, ok := existingTunnels[arrivedKey]; !ok { // agent was added
-			agentsToAdd = append(agentsToAdd, arrivedKey)
-		}
-	}
-
-	return agentsToAdd, agentsToRemove
-}
-
-// agentKey is used to uniquely identify agents.
-type agentKey struct {
-	// clusterName is a cluster name of this agent
-	clusterName string
-
-	// tunnelType is the type of tunnel, is either node or proxy.
-	tunnelType string
-
-	// addr is the address this tunnel is agent is connected to. For example:
-	// proxy.example.com:3024.
-	addr utils.NetAddr
-}
-
-func keyFromLease(lease track.Lease) agentKey {
-	key := lease.Key().(track.Key)
-	return agentKey{
-		clusterName: key.Cluster,
-		tunnelType:  key.Type,
-		addr:        key.Addr,
-	}
-}
-
-func agentToTrackingKey(key agentKey) track.Key {
-	return track.Key{
-		Cluster: key.clusterName,
-		Type:    key.tunnelType,
-		Addr:    key.addr,
-	}
-}
-
-func (a *agentKey) String() string {
-	return fmt.Sprintf("agentKey(cluster=%v, type=%v, addr=%v)", a.clusterName, a.tunnelType, a.addr.String())
 }

--- a/lib/reversetunnel/cache.go
+++ b/lib/reversetunnel/cache.go
@@ -40,9 +40,9 @@ type certificateCache struct {
 	keygen     sshca.Authority
 }
 
-// NewHostCertificateCache creates a shared host certificate cache that is
+// newHostCertificateCache creates a shared host certificate cache that is
 // used by the forwarding server.
-func NewHostCertificateCache(keygen sshca.Authority, authClient auth.ClientI) (*certificateCache, error) {
+func newHostCertificateCache(keygen sshca.Authority, authClient auth.ClientI) (*certificateCache, error) {
 	cache, err := ttlmap.New(defaults.HostCertCacheSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -55,12 +55,12 @@ func NewHostCertificateCache(keygen sshca.Authority, authClient auth.ClientI) (*
 	}, nil
 }
 
-// GetHostCertificate will fetch a certificate from the cache. If the certificate
+// getHostCertificate will fetch a certificate from the cache. If the certificate
 // is not in the cache, it will be generated, put in the cache, and returned. Mul
 // Multiple callers can arrive and generate a host certificate at the same time.
 // This is a tradeoff to prevent long delays here due to the expensive
 // certificate generation call.
-func (c *certificateCache) GetHostCertificate(addr string, additionalPrincipals []string) (ssh.Signer, error) {
+func (c *certificateCache) getHostCertificate(addr string, additionalPrincipals []string) (ssh.Signer, error) {
 	var certificate ssh.Signer
 	var err error
 	var ok bool

--- a/lib/reversetunnel/discovery.go
+++ b/lib/reversetunnel/discovery.go
@@ -42,41 +42,13 @@ type discoveryRequest struct {
 	Proxies []services.Server `json:"proxies"`
 }
 
-// Proxies is a list of proxies to discover
-type Proxies []services.Server
-
-// String returns text representation of the proxies
-func (proxies Proxies) String() string {
-	var out []string
-	for _, proxy := range proxies {
-		out = append(out, proxy.GetName())
-	}
-	return strings.Join(out, ",")
-}
-
-// Equal compares two lists of proxies as sets
-func (proxies Proxies) Equal(other []services.Server) bool {
-	if len(proxies) != len(other) {
-		return false
-	}
-	proxiesMap, otherMap := make(map[string]bool), make(map[string]bool)
-	for i := range proxies {
-		proxiesMap[proxies[i].GetName()] = true
-	}
-	for i := range other {
-		otherMap[other[i].GetName()] = true
-	}
-	for key := range otherMap {
-		if !proxiesMap[key] {
-			return false
-		}
-	}
-	return true
-}
-
 func (r discoveryRequest) String() string {
+	proxyNames := make([]string, 0, len(r.Proxies))
+	for _, p := range r.Proxies {
+		proxyNames = append(proxyNames, p.GetName())
+	}
 	return fmt.Sprintf("discovery request, cluster name: %v, address: %v, proxies: %v",
-		r.ClusterName, r.ClusterAddr, Proxies(r.Proxies))
+		r.ClusterName, r.ClusterAddr, strings.Join(proxyNames, ","))
 }
 
 type discoveryRequestRaw struct {

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -46,7 +46,7 @@ func newlocalSite(srv *server, domainName string, client auth.ClientI) (*localSi
 	// certificate cache is created in each site (instead of creating it in
 	// reversetunnel.server and passing it along) so that the host certificate
 	// is signed by the correct certificate authority.
-	certificateCache, err := NewHostCertificateCache(srv.Config.KeyGen, client)
+	certificateCache, err := newHostCertificateCache(srv.Config.KeyGen, client)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -212,7 +212,7 @@ func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 	}
 
 	// Get a host certificate for the forwarding node from the cache.
-	hostCertificate, err := s.certificateCache.GetHostCertificate(params.Address, params.Principals)
+	hostCertificate, err := s.certificateCache.getHostCertificate(params.Address, params.Principals)
 	if err != nil {
 		userAgent.Close()
 		return nil, trace.Wrap(err)
@@ -417,7 +417,7 @@ func (s *localSite) chanTransportConn(rconn *remoteConn) (net.Conn, error) {
 
 	conn, markInvalid, err := connectProxyTransport(rconn.sconn, &dialReq{
 		Address: LocalNode,
-	})
+	}, false)
 	if err != nil {
 		if markInvalid {
 			rconn.markInvalid(err)

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -91,9 +91,6 @@ func (c *RemoteClusterTunnelManagerConfig) CheckAndSetDefaults() error {
 	if c.LocalCluster == "" {
 		return trace.BadParameter("missing LocalCluster in RemoteClusterTunnelManagerConfig")
 	}
-	if c.ReverseTunnelServer == nil {
-		return trace.BadParameter("missing ReverseTunnelServer in RemoteClusterTunnelManagerConfig")
-	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()
 	}

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reversetunnel
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
+)
+
+// RemoteClusterTunnelManager manages AgentPools for trusted (remote) clusters. It
+// polls the auth server for ReverseTunnel resources and spins AgentPools for
+// each one as needed.
+//
+// Note: ReverseTunnel resources on the auth server represent the desired
+// tunnels, not actually active ones.
+type RemoteClusterTunnelManager struct {
+	cfg RemoteClusterTunnelManagerConfig
+
+	mu      sync.Mutex
+	pools   map[remoteClusterKey]*AgentPool
+	stopRun func()
+
+	newAgentPool func(ctx context.Context, cluster, addr string) (*AgentPool, error)
+}
+
+type remoteClusterKey struct {
+	cluster string
+	addr    string
+}
+
+// RemoteClusterTunnelManagerConfig is a bundle of parameters used by a
+// RemoteClusterTunnelManager.
+type RemoteClusterTunnelManagerConfig struct {
+	// AuthClient is client to the auth server.
+	AuthClient auth.ClientI
+	// AccessPoint is a lightweight access point that can optionally cache some
+	// values.
+	AccessPoint auth.AccessPoint
+	// HostSigners is a signer for the host private key.
+	HostSigner ssh.Signer
+	// HostUUID is a unique ID of this host
+	HostUUID string
+	// LocalCluster is a cluster name this client is a member of.
+	LocalCluster string
+	// Local ReverseTunnelServer to reach other cluster members connecting to
+	// this proxy over a tunnel.
+	ReverseTunnelServer Server
+	// Clock is a mock-able clock.
+	Clock clockwork.Clock
+	// KubeDialAddr is an optional address of a local kubernetes proxy.
+	KubeDialAddr utils.NetAddr
+}
+
+func (c *RemoteClusterTunnelManagerConfig) CheckAndSetDefaults() error {
+	if c.AuthClient == nil {
+		return trace.BadParameter("missing AuthClient in RemoteClusterTunnelManagerConfig")
+	}
+	if c.AccessPoint == nil {
+		return trace.BadParameter("missing AccessPoint in RemoteClusterTunnelManagerConfig")
+	}
+	if c.HostSigner == nil {
+		return trace.BadParameter("missing HostSigner in RemoteClusterTunnelManagerConfig")
+	}
+	if c.HostUUID == "" {
+		return trace.BadParameter("missing HostUUID in RemoteClusterTunnelManagerConfig")
+	}
+	if c.LocalCluster == "" {
+		return trace.BadParameter("missing LocalCluster in RemoteClusterTunnelManagerConfig")
+	}
+	if c.ReverseTunnelServer == nil {
+		return trace.BadParameter("missing ReverseTunnelServer in RemoteClusterTunnelManagerConfig")
+	}
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+
+	return nil
+}
+
+// NewRemoteClusterTunnelManager creates a new unstarted tunnel manager with
+// the provided config. Call Run() to start the manager.
+func NewRemoteClusterTunnelManager(cfg RemoteClusterTunnelManagerConfig) (*RemoteClusterTunnelManager, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	w := &RemoteClusterTunnelManager{
+		cfg:   cfg,
+		pools: make(map[remoteClusterKey]*AgentPool),
+	}
+	w.newAgentPool = w.realNewAgentPool
+	return w, nil
+}
+
+// Close cleans up all outbound tunnels and stops the manager.
+func (w *RemoteClusterTunnelManager) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for k, pool := range w.pools {
+		pool.Stop()
+		delete(w.pools, k)
+	}
+	if w.stopRun != nil {
+		w.stopRun()
+		w.stopRun = nil
+	}
+
+	return nil
+}
+
+// Run runs the manager polling loop. Run is blocking, start it in a goroutine.
+func (w *RemoteClusterTunnelManager) Run(ctx context.Context) {
+	w.mu.Lock()
+	ctx, w.stopRun = context.WithCancel(ctx)
+	w.mu.Unlock()
+
+	if err := w.Sync(ctx); err != nil {
+		logrus.Warningf("Failed to sync reverse tunnels: %v.", err)
+	}
+
+	ticker := time.NewTicker(defaults.ResyncInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			logrus.Debugf("Closing.")
+			return
+		case <-ticker.C:
+			if err := w.Sync(ctx); err != nil {
+				logrus.Warningf("Failed to sync reverse tunnels: %v.", err)
+				continue
+			}
+		}
+	}
+}
+
+// Sync does a one-time sync of trusted clusters with running agent pools.
+// Non-test code should use Run() instead.
+func (w *RemoteClusterTunnelManager) Sync(ctx context.Context) error {
+	// Fetch desired reverse tunnels and convert them to a set of
+	// remoteClusterKeys.
+	wantTunnels, err := w.cfg.AuthClient.GetReverseTunnels()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	wantClusters := make(map[remoteClusterKey]bool, len(wantTunnels))
+	for _, tun := range wantTunnels {
+		for _, addr := range tun.GetDialAddrs() {
+			wantClusters[remoteClusterKey{cluster: tun.GetClusterName(), addr: addr}] = true
+		}
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Delete pools that are no longer needed.
+	for k, pool := range w.pools {
+		if wantClusters[k] {
+			continue
+		}
+		pool.Stop()
+		delete(w.pools, k)
+	}
+
+	// Start pools that were added since last sync.
+	var errs []error
+	for k := range wantClusters {
+		if _, ok := w.pools[k]; ok {
+			continue
+		}
+
+		pool, err := w.newAgentPool(ctx, k.cluster, k.addr)
+		if err != nil {
+			errs = append(errs, trace.Wrap(err))
+			continue
+		}
+		w.pools[k] = pool
+	}
+	return trace.NewAggregate(errs...)
+}
+
+func (w *RemoteClusterTunnelManager) realNewAgentPool(ctx context.Context, cluster, addr string) (*AgentPool, error) {
+	pool, err := NewAgentPool(ctx, AgentPoolConfig{
+		// Configs for our cluster.
+		Client:              w.cfg.AuthClient,
+		AccessPoint:         w.cfg.AccessPoint,
+		HostSigner:          w.cfg.HostSigner,
+		HostUUID:            w.cfg.HostUUID,
+		LocalCluster:        w.cfg.LocalCluster,
+		Clock:               w.cfg.Clock,
+		KubeDialAddr:        w.cfg.KubeDialAddr,
+		ReverseTunnelServer: w.cfg.ReverseTunnelServer,
+		// RemoteClusterManager only runs on proxies.
+		Component: teleport.ComponentProxy,
+
+		// Configs for remote cluster.
+		Cluster:   cluster,
+		ProxyAddr: addr,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "failed creating reverse tunnel pool for remote cluster %q at address %q: %v", cluster, addr, err)
+	}
+	go pool.Start()
+
+	return pool, nil
+}
+
+// Counts returns the number of tunnels for each remote cluster.
+func (w *RemoteClusterTunnelManager) Counts() map[string]int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	counts := make(map[string]int, len(w.pools))
+	for n, p := range w.pools {
+		counts[n.cluster] += p.Count()
+	}
+	return counts
+}

--- a/lib/reversetunnel/rc_manager_test.go
+++ b/lib/reversetunnel/rc_manager_test.go
@@ -1,0 +1,153 @@
+package reversetunnel
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/services"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteClusterTunnelManagerSync(t *testing.T) {
+	t.Parallel()
+
+	var newAgentPoolErr error
+	w := &RemoteClusterTunnelManager{
+		pools: make(map[remoteClusterKey]*AgentPool),
+		newAgentPool: func(ctx context.Context, cluster, addr string) (*AgentPool, error) {
+			return &AgentPool{
+				cfg:    AgentPoolConfig{Cluster: cluster, ProxyAddr: addr},
+				cancel: func() {},
+			}, newAgentPoolErr
+		},
+	}
+	defer w.Close()
+
+	tests := []struct {
+		desc              string
+		reverseTunnels    []services.ReverseTunnel
+		reverseTunnelsErr error
+		newAgentPoolErr   error
+		wantPools         map[remoteClusterKey]*AgentPool
+		assertErr         assert.ErrorAssertionFunc
+	}{
+		{
+			desc:      "no reverse tunnels",
+			wantPools: map[remoteClusterKey]*AgentPool{},
+			assertErr: assert.NoError,
+		},
+		{
+			desc: "one reverse tunnel with one address",
+			reverseTunnels: []services.ReverseTunnel{
+				services.NewReverseTunnel("cluster-a", []string{"addr-a"}),
+			},
+			wantPools: map[remoteClusterKey]*AgentPool{
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+			},
+			assertErr: assert.NoError,
+		},
+		{
+			desc: "one reverse tunnel added with multiple addresses",
+			reverseTunnels: []services.ReverseTunnel{
+				services.NewReverseTunnel("cluster-a", []string{"addr-a", "addr-b", "addr-c"}),
+			},
+			wantPools: map[remoteClusterKey]*AgentPool{
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-c"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
+			},
+			assertErr: assert.NoError,
+		},
+		{
+			desc: "one reverse tunnel added and one removed",
+			reverseTunnels: []services.ReverseTunnel{
+				services.NewReverseTunnel("cluster-b", []string{"addr-b"}),
+			},
+			wantPools: map[remoteClusterKey]*AgentPool{
+				remoteClusterKey{cluster: "cluster-b", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
+			},
+			assertErr: assert.NoError,
+		},
+		{
+			desc: "multiple reverse tunnels",
+			reverseTunnels: []services.ReverseTunnel{
+				services.NewReverseTunnel("cluster-a", []string{"addr-a", "addr-b", "addr-c"}),
+				services.NewReverseTunnel("cluster-b", []string{"addr-b"}),
+			},
+			wantPools: map[remoteClusterKey]*AgentPool{
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-c"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
+				remoteClusterKey{cluster: "cluster-b", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
+			},
+			assertErr: assert.NoError,
+		},
+		{
+			desc:              "GetReverseTunnels error, keep existing pools",
+			reverseTunnelsErr: errors.New("nah"),
+			wantPools: map[remoteClusterKey]*AgentPool{
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-c"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
+				remoteClusterKey{cluster: "cluster-b", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
+			},
+			assertErr: assert.Error,
+		},
+		{
+			desc: "AgentPool creation fails, keep existing pools",
+			reverseTunnels: []services.ReverseTunnel{
+				services.NewReverseTunnel("cluster-a", []string{"addr-a", "addr-b", "addr-c"}),
+				services.NewReverseTunnel("cluster-b", []string{"addr-b"}),
+				services.NewReverseTunnel("cluster-c", []string{"addr-c1", "addr-c2"}),
+			},
+			newAgentPoolErr: errors.New("nah"),
+			wantPools: map[remoteClusterKey]*AgentPool{
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
+				remoteClusterKey{cluster: "cluster-a", addr: "addr-c"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
+				remoteClusterKey{cluster: "cluster-b", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
+			},
+			assertErr: assert.Error,
+		},
+	}
+
+	ctx := context.TODO()
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			w.cfg.AuthClient = mockAuthClient{
+				reverseTunnels:    tt.reverseTunnels,
+				reverseTunnelsErr: tt.reverseTunnelsErr,
+			}
+			newAgentPoolErr = tt.newAgentPoolErr
+
+			err := w.Sync(ctx)
+			tt.assertErr(t, err)
+
+			assert.Empty(t, cmp.Diff(
+				w.pools,
+				tt.wantPools,
+				// Tweaks to get comparison working with our complex types.
+				cmp.AllowUnexported(remoteClusterKey{}),
+				cmp.Comparer(func(a, b *AgentPool) bool {
+					// Only check the supplied configs of AgentPools.
+					return cmp.Equal(a.cfg, b.cfg)
+				}),
+			))
+		})
+	}
+}
+
+type mockAuthClient struct {
+	auth.ClientI
+
+	reverseTunnels    []services.ReverseTunnel
+	reverseTunnelsErr error
+}
+
+func (c mockAuthClient) GetReverseTunnels(...services.MarshalOption) ([]services.ReverseTunnel, error) {
+	return c.reverseTunnels, c.reverseTunnelsErr
+}

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -958,7 +958,7 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 	// certificate cache is created in each site (instead of creating it in
 	// reversetunnel.server and passing it along) so that the host certificate
 	// is signed by the correct certificate authority.
-	certificateCache, err := NewHostCertificateCache(srv.Config.KeyGen, srv.localAuthClient)
+	certificateCache, err := newHostCertificateCache(srv.Config.KeyGen, srv.localAuthClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/track/tracker.go
+++ b/lib/reversetunnel/track/tracker.go
@@ -31,7 +31,6 @@ type Lease = workpool.Lease
 // Key uniquely identifies a reversetunnel endpoint.
 type Key struct {
 	Cluster string
-	Type    string
 	Addr    utils.NetAddr
 }
 


### PR DESCRIPTION
Separating the responsibilities:
- AgentPool takes a proxy (or LB) endpoint and manages a pool of agents
  for it (each agent is a tunnel to a unique proxy process behind the
  endpoint)
- RemoteClusterWatcher polls the auth server for a list of trusted
  clusters and manages a set of AgentPools, one for each trusted cluster

Previously, AgentPool did both of the above.

Also, bundling some cleanup in the area:
- better error when dialing through tunnel and directly both fail
- rename RemoteKubeProxy to LocalKubernetes to better reflect the
  meaning
- remove some dead code and simplify config structs