### PR TITLE
Add nodeID to heartbeat debug log

### DIFF
--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -376,9 +376,9 @@ func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-ch
 				}
 			}
 			if roundtrip != 0 {
-				s.log.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (nodeID: %q)", rconn.conn.RemoteAddr(), rconn.nodeID)
+				s.log.WithFields(log.Fields{"latency": roundtrip, "nodeID": rconn.nodeID}).Debugf("Ping <- %v", rconn.conn.RemoteAddr())
 			} else {
-				log.Debugf("Ping <- %v (nodeID: %q)", rconn.conn.RemoteAddr(), rconn.nodeID)
+				s.log.WithFields(log.Fields{"nodeID": rconn.nodeID}).Debugf("Ping <- %v", rconn.conn.RemoteAddr())
 			}
 			tm := time.Now().UTC()
 			rconn.setLastHeartbeat(tm)

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -376,9 +376,9 @@ func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-ch
 				}
 			}
 			if roundtrip != 0 {
-				s.log.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v.", rconn.conn.RemoteAddr())
+				s.log.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (%v)", rconn.conn.RemoteAddr(), rconn.nodeID)
 			} else {
-				log.Debugf("Ping <- %v.", rconn.conn.RemoteAddr())
+				log.Debugf("Ping <- %v (%v)", rconn.conn.RemoteAddr(), rconn.nodeID)
 			}
 			tm := time.Now().UTC()
 			rconn.setLastHeartbeat(tm)

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -376,9 +376,9 @@ func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-ch
 				}
 			}
 			if roundtrip != 0 {
-				s.log.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (%v)", rconn.conn.RemoteAddr(), rconn.nodeID)
+				s.log.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (nodeID: %v)", rconn.conn.RemoteAddr(), rconn.nodeID)
 			} else {
-				log.Debugf("Ping <- %v (%v)", rconn.conn.RemoteAddr(), rconn.nodeID)
+				log.Debugf("Ping <- %v (nodeID: %v)", rconn.conn.RemoteAddr(), rconn.nodeID)
 			}
 			tm := time.Now().UTC()
 			rconn.setLastHeartbeat(tm)

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -376,9 +376,9 @@ func (s *localSite) handleHeartbeat(rconn *remoteConn, ch ssh.Channel, reqC <-ch
 				}
 			}
 			if roundtrip != 0 {
-				s.log.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (nodeID: %v)", rconn.conn.RemoteAddr(), rconn.nodeID)
+				s.log.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (nodeID: %q)", rconn.conn.RemoteAddr(), rconn.nodeID)
 			} else {
-				log.Debugf("Ping <- %v (nodeID: %v)", rconn.conn.RemoteAddr(), rconn.nodeID)
+				log.Debugf("Ping <- %v (nodeID: %q)", rconn.conn.RemoteAddr(), rconn.nodeID)
 			}
 			tm := time.Now().UTC()
 			rconn.setLastHeartbeat(tm)

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -364,9 +364,9 @@ func (s *remoteSite) handleHeartbeat(conn *remoteConn, ch ssh.Channel, reqC <-ch
 				}
 			}
 			if roundtrip != 0 {
-				s.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (%v)", conn.conn.RemoteAddr(), conn.nodeID)
+				s.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (nodeID: %v)", conn.conn.RemoteAddr(), conn.nodeID)
 			} else {
-				s.Debugf("Ping <- %v (%v)", conn.conn.RemoteAddr(), conn.nodeID)
+				s.Debugf("Ping <- %v (nodeID: %v)", conn.conn.RemoteAddr(), conn.nodeID)
 			}
 			tm := time.Now().UTC()
 			conn.setLastHeartbeat(tm)

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -364,9 +364,9 @@ func (s *remoteSite) handleHeartbeat(conn *remoteConn, ch ssh.Channel, reqC <-ch
 				}
 			}
 			if roundtrip != 0 {
-				s.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (nodeID: %q)", conn.conn.RemoteAddr(), conn.nodeID)
+				s.WithFields(log.Fields{"latency": roundtrip, "nodeID": conn.nodeID}).Debugf("Ping <- %v", conn.conn.RemoteAddr())
 			} else {
-				s.Debugf("Ping <- %v (nodeID: %q)", conn.conn.RemoteAddr(), conn.nodeID)
+				s.WithFields(log.Fields{"nodeID": conn.nodeID}).Debugf("Ping <- %v", conn.conn.RemoteAddr())
 			}
 			tm := time.Now().UTC()
 			conn.setLastHeartbeat(tm)

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -364,9 +364,9 @@ func (s *remoteSite) handleHeartbeat(conn *remoteConn, ch ssh.Channel, reqC <-ch
 				}
 			}
 			if roundtrip != 0 {
-				s.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (nodeID: %v)", conn.conn.RemoteAddr(), conn.nodeID)
+				s.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (nodeID: %q)", conn.conn.RemoteAddr(), conn.nodeID)
 			} else {
-				s.Debugf("Ping <- %v (nodeID: %v)", conn.conn.RemoteAddr(), conn.nodeID)
+				s.Debugf("Ping <- %v (nodeID: %q)", conn.conn.RemoteAddr(), conn.nodeID)
 			}
 			tm := time.Now().UTC()
 			conn.setLastHeartbeat(tm)

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -364,9 +364,9 @@ func (s *remoteSite) handleHeartbeat(conn *remoteConn, ch ssh.Channel, reqC <-ch
 				}
 			}
 			if roundtrip != 0 {
-				s.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v.", conn.conn.RemoteAddr())
+				s.WithFields(log.Fields{"latency": roundtrip}).Debugf("Ping <- %v (%v)", conn.conn.RemoteAddr(), conn.nodeID)
 			} else {
-				s.Debugf("Ping <- %v.", conn.conn.RemoteAddr())
+				s.Debugf("Ping <- %v (%v)", conn.conn.RemoteAddr(), conn.nodeID)
 			}
 			tm := time.Now().UTC()
 			conn.setLastHeartbeat(tm)


### PR DESCRIPTION
Useful to correlate TCP connections on the proxy node to actual nodes