### PR TITLE
etcd: don't confuse prefixes during migration

### DIFF
--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -1631,8 +1631,9 @@ teleport:
      username: username
      password_file: /mnt/secrets/etcd-pass
 
-     # etcd key (location) where teleport will be storing its state under:
-     prefix: teleport
+     # etcd key (location) where teleport will be storing its state under.
+     # make sure it ends with a '/'!
+     prefix: /teleport/
 
      # NOT RECOMMENDED: enables insecure etcd mode in which self-signed
      # certificate will be accepted

--- a/docs/4.3/ibm_cloud_guide.md
+++ b/docs/4.3/ibm_cloud_guide.md
@@ -98,8 +98,9 @@ teleport:
     password_file: '/var/lib/etcd-pass'
     # TLS certificate Name, with file contents from Overview
     tls_ca_file: '/var/lib/teleport/797cfsdf23e-4027-11e9-a020-42025ffb08c8.pem'
-    # etcd key (location) where teleport will be storing its state under:
-    prefix: 'teleport'
+    # etcd key (location) where teleport will be storing its state under.
+    # make sure it ends with a '/'!
+    prefix: '/teleport/'
 ```
 
 ### Storage: IBM Cloud File Storage

--- a/examples/etcd/etcdctl.sh
+++ b/examples/etcd/etcdctl.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+HERE=$(readlink -f $0)
+cd $(dirname $HERE)
+
 ETCDCTL_API=3 etcdctl --cacert=./certs/ca-cert.pem --cert=./certs/client-cert.pem  --key=./certs/client-key.pem  --endpoints=https://127.0.0.1:2379 $@
 

--- a/examples/etcd/start-etcd.sh
+++ b/examples/etcd/start-etcd.sh
@@ -7,8 +7,6 @@
 # NOTE: this file is also used to run etcd tests.
 #
 
-EXAMPLES_DIR=$(go env GOPATH)/src/github.com/gravitational/teleport/examples/etcd
-
 HERE=$(readlink -f $0)
 cd $(dirname $HERE)
 
@@ -16,9 +14,9 @@ mkdir -p data
 etcd --name teleportstorage \
      --data-dir data/etcd \
      --initial-cluster-state new \
-     --cert-file=$EXAMPLES_DIR/certs/server-cert.pem \
-     --key-file=$EXAMPLES_DIR/certs/server-key.pem \
-     --trusted-ca-file=$EXAMPLES_DIR/certs/ca-cert.pem \
+     --cert-file certs/server-cert.pem \
+     --key-file certs/server-key.pem \
+     --trusted-ca-file certs/ca-cert.pem \
      --advertise-client-urls=https://127.0.0.1:2379 \
      --listen-client-urls=https://127.0.0.1:2379 \
      --client-cert-auth

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -168,7 +168,7 @@ type Config struct {
 //
 // DELETE IN 4.4: legacy prefix support for migration of
 // https://github.com/gravitational/teleport/issues/2883
-const legacyDefaultPrefix = "/teleport"
+const legacyDefaultPrefix = "/teleport/"
 
 // GetName returns the name of etcd backend as it appears in 'storage/type' section
 // in Teleport YAML file. This function is a part of backend API

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -206,6 +206,11 @@ func (s *EtcdSuite) assertKV(ctx context.Context, c *check.C, key, val string) {
 }
 
 func (s *EtcdSuite) TestSyncLegacyPrefix(c *check.C) {
+	// Stop the watch goroutine to allow us to modify s.bk.cfg.Key without data
+	// races.
+	s.bk.cancel()
+	<-s.bk.watchDone
+
 	ctx := context.Background()
 	s.bk.cfg.Key = customPrefix1
 	c.Assert(s.bk.cfg.Validate(), check.IsNil)


### PR DESCRIPTION
The prefix fetching logic has a bug: it treats everything starting with
`/teleport` as the legacy prefix data, even if it's `/teleport-foo/bar`.
This is an issue if user specifies `/teleport-foo` as their custom
prefix. Each restart will copy the data from `/teleport-foo/...` to
`/teleport-foo-foo/...`.

Set the legacy prefix const to `/teleport/` instead. This avoids
excessive copying during startup.

Fixes https://github.com/gravitational/teleport/issues/4312