### PR TITLE
Update default keep_alive_interval

### DIFF
--- a/docs/4.3/config_reference.md
+++ b/docs/4.3/config_reference.md
@@ -193,11 +193,12 @@ auth_service:
     # certificates expire in the middle of an active SSH session. (default is 'no')
     disconnect_expired_cert: no
 
-    # Determines the interval at which Teleport will send keep-alive messages. The
-    # default value mirrors sshd at 15 minutes.  keep_alive_count_max is the number
-    # of missed keep-alive messages before the server tears down the connection to the
-    # client.
-    keep_alive_interval: 15
+    # Determines the interval at which Teleport will send keep-alive messages. The default
+    # is set to 5 minutes (300 seconds) to stay lower than the common load balancer timeout
+    # of 350 seconds.
+    # keep_alive_count_max is the number of missed keep-alive messages before the server
+    # tears down the connection to the client.
+    keep_alive_interval: 5m
     keep_alive_count_max: 3
 
     # License file to start auth server with. Note that this setting is ignored


### PR DESCRIPTION
While working on an issue I realised that the default value for `keep_alive_interval` in the configuration reference is incorrect. We say it's 15 minutes, but the default is actually 5 minutes (https://github.com/gravitational/teleport/blob/master/lib/defaults/defaults.go#L315-L324)