### PR TITLE
Split Docker/AMI jobs into separate build and publish steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2744,6 +2744,8 @@ steps:
   - name: Make AMIs public
     image: hashicorp/packer
     environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
@@ -2803,6 +2805,6 @@ volumes:
 
 ---
 kind: signature
-hmac: c13090d0e62168ba4ae989fc389acb6f057516890b4d3a50cb33b0fdf117b42d
+hmac: 6d54983ce8f323b3e2a81c0f524500a5d42ae6f00e70ae69bad1feb809303209
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,9 +17,8 @@ environment:
 #     include:
 #       - gravitational/*
 trigger:
-  event:
-    cron:
-      - none
+  cron:
+    - none
 
 workspace:
   path: /go
@@ -156,9 +155,8 @@ name: test-docs-internal
 #     include:
 #       - gravitational/*
 trigger:
-  event:
-    cron:
-      - none
+  cron:
+    - none
 
 workspace:
   path: /go
@@ -235,9 +233,8 @@ name: test-docs-external
 #     include:
 #       - gravitational/*
 trigger:
-  event:
-    cron:
-      - none
+  cron:
+    - none
 
 workspace:
   path: /go
@@ -2843,6 +2840,6 @@ steps:
 
 ---
 kind: signature
-hmac: dbda1f77dc85e5fee3533c8d14aabf0ca8d0991ecad0ba681a3b0fd99327944e
+hmac: 64bd533c312addc61ef4d1103a0c6993b6c907385e1bb49110ae0d13f5ca7f8a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2800,8 +2800,20 @@ steps:
       target: teleport/${DRONE_TAG##v}/
       strip_prefix: /go/src/github.com/gravitational/teleport/
 
+services:
+  - name: Start Docker
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
 ---
 kind: signature
-hmac: a90135d3bec1007d40be600a0f1c8faf0d267dd699aca9596f256f40ae7fb5cf
+hmac: 1b875a0603c3eb8711a2ec71abb517aafbc363a0dc9bc44af44e415a69bc18fb
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -495,10 +495,6 @@ trigger:
     include:
       - gravitational/*
 
-# TODO(gus): testing
-# depends_on:
-#  - test
-
 workspace:
   path: /go
 
@@ -603,10 +599,6 @@ trigger:
   repo:
     include:
       - gravitational/*
-
-#TODO(gus): testing
-# depends_on:
-#   - test
 
 workspace:
   path: /go
@@ -713,9 +705,6 @@ trigger:
     include:
       - gravitational/*
 
-depends_on:
-  - test
-
 workspace:
   path: /go
 
@@ -820,9 +809,6 @@ trigger:
   repo:
     include:
       - gravitational/*
-
-depends_on:
-  - test
 
 workspace:
   path: /go
@@ -1383,9 +1369,6 @@ trigger:
     include:
       - gravitational/*
 
-depends_on:
-  - test
-
 workspace:
   path: /go
 
@@ -1720,9 +1703,6 @@ trigger:
     include:
       - gravitational/*
 
-depends_on:
-  - test
-
 workspace:
   path: /tmp/build-darwin-amd64
 
@@ -2053,9 +2033,6 @@ trigger:
     include:
       - gravitational/*
 
-depends_on:
-  - test
-
 workspace:
   path: /dev/shm/tmp
 
@@ -2141,9 +2118,6 @@ trigger:
   repo:
     include:
       - gravitational/*
-
-depends_on:
-  - test
 
 workspace:
   path: /go
@@ -2250,10 +2224,6 @@ trigger:
   repo:
     include:
       - gravitational/*
-
-#TODO(gus): testing
-# depends_on:
-#   - test
 
 workspace:
   path: /go
@@ -2366,9 +2336,7 @@ trigger:
     include:
       - gravitational/*
 
-#TODO(gus): testing
 depends_on:
-#   - test
   - build-linux-amd64
 
 workspace:
@@ -2470,9 +2438,7 @@ trigger:
     include:
       - gravitational/*
 
-#TODO(gus): testing
 depends_on:
-#   - test
   - build-linux-amd64
   - build-linux-amd64-fips
 
@@ -2702,6 +2668,35 @@ clone:
   disable: true
 
 steps:
+  - name: Download artifacts from S3
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - mkdir -p /go/artifacts
+      - aws s3 sync s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/ /go/artifacts/
+
+  - name: Upload artifacts to production S3
+    image: plugins/s3
+    settings:
+      bucket:
+        from_secret: PRODUCTION_AWS_S3_BUCKET
+      access_key:
+        from_secret: PRODUCTION_AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: PRODUCTION_AWS_SECRET_ACCESS_KEY
+      region: us-east-1
+      acl: public-read
+      source: /go/artifacts/*
+      target: teleport/${DRONE_TAG##v}/
+      strip_prefix: /go/artifacts/
+
   - name: Pull/retag Docker images
     image: docker
     settings:
@@ -2780,35 +2775,6 @@ steps:
         make change-amis-to-public-ent
         make change-amis-to-public-ent-fips
 
-  - name: Download artifacts from S3
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - mkdir -p /go/artifacts
-      - aws s3 sync s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/ /go/artifacts/
-
-  - name: Upload artifacts to production S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: PRODUCTION_AWS_S3_BUCKET
-      access_key:
-        from_secret: PRODUCTION_AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: PRODUCTION_AWS_SECRET_ACCESS_KEY
-      region: us-east-1
-      acl: public-read
-      source: /go/artifacts/*
-      target: teleport/${DRONE_TAG##v}/
-      strip_prefix: /go/artifacts/
-
 services:
   - name: Start Docker
     image: docker:dind
@@ -2823,6 +2789,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 3c51835ee58df7251c07115efbcad88dae4ec43535e38f4492615f1f54a38c06
+hmac: 9d25d641a1e262e02f87aa627c5cd7d87b7d4d7e5a61d471e34d43fad222f5a3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2702,7 +2702,7 @@ clone:
   disable: true
 
 steps:
-  - name: Pull and retag Docker images
+  - name: Pull/retag Docker images
     image: docker
     settings:
       docker_staging_username:
@@ -2751,7 +2751,7 @@ steps:
         git fetch origin +refs/tags/${DRONE_TAG}:
         git checkout -qf FETCH_HEAD
 
-  - name: Download saved AMI timestamps
+  - name: Download AMI timestamps
     image: docker
     environment:
       AWS_S3_BUCKET:
@@ -2773,14 +2773,14 @@ steps:
       AWS_SECRET_ACCESS_KEY:
         from_secret: PRODUCTION_AWS_SECRET_ACCESS_KEY
     commands:
-      - apk add --no-cache aws-cli make
+      - apk add --no-cache aws-cli bash jq make
       - cd /go/src/github.com/gravitational/teleport/assets/aws
       - |
         make change-amis-to-public-oss
         make change-amis-to-public-ent
         make change-amis-to-public-ent-fips
 
-  - name: Download artifacts from S3 artifact publishing bucket
+  - name: Download artifacts from S3
     image: amazon/aws-cli
     environment:
       AWS_S3_BUCKET:
@@ -2791,9 +2791,10 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
+      - mkdir -p /go/artifacts
       - aws s3 sync s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/ /go/artifacts/
 
-  - name: Upload artifacts to production S3 bucket with public read access
+  - name: Upload artifacts to production S3
     image: plugins/s3
     settings:
       bucket:
@@ -2822,6 +2823,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 6ec0dd8a02448e07951db3dfea9177f7fc3bc128bbc740bb37fe41f67b8d930b
+hmac: 3c51835ee58df7251c07115efbcad88dae4ec43535e38f4492615f1f54a38c06
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2741,6 +2741,15 @@ steps:
       - docker push quay.io/gravitational/teleport-ent:$${VERSION}
       - docker push quay.io/gravitational/teleport-ent:$${VERSION}-fips
 
+  - name: Check out code
+    image: docker:git
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport /go/cache
+      - cd /go/src/github.com/gravitational/teleport
+      - git init && git remote add origin ${DRONE_REMOTE_URL}
+      - git fetch origin +refs/tags/${DRONE_TAG}:
+      - git checkout -qf FETCH_HEAD
+
   - name: Make AMIs public
     image: hashicorp/packer
     environment:
@@ -2753,15 +2762,11 @@ steps:
     commands:
       - apk add --no-cache aws-cli jq make
       - mkdir -p /go/src/github.com/gravitational/teleport/assets/aws/files/build
+      - aws s3 sync s3://$AWS_S3_BUCKET/teleport/ami/${DRONE_TAG##v}/ /go/src/github.com/gravitational/teleport/assets/aws/files/build
       - cd /go/src/github.com/gravitational/teleport/assets/aws
-      - aws s3 sync s3://$AWS_S3_BUCKET/teleport/ami/${DRONE_TAG##v}/ ./files/build/
-      - |
-        echo "---> Making OSS AMIs public"
-        make change-amis-to-public-oss
-        echo "---> Making Enterprise AMIs public"
-        make change-amis-to-public-ent
-        echo "---> Making Enterprise FIPS AMIs public"
-        make change-amis-to-public-ent-fips
+      - make change-amis-to-public-oss
+      - make change-amis-to-public-ent
+      - make change-amis-to-public-ent-fips
 
   - name: Download artifacts from S3 artifact publishing bucket
     image: amazon/aws-cli
@@ -2805,6 +2810,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 6d54983ce8f323b3e2a81c0f524500a5d42ae6f00e70ae69bad1feb809303209
+hmac: d12e5e9f74d1bdc3c2d82271583b30a2aed5eeb15e4566b4c1925558afad994f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2319,7 +2319,7 @@ steps:
       # set version
       - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
-  - name: Build OSS/Enterprise Docker images
+  - name: Build/push OSS/Enterprise Docker images
     image: docker
     environment:
       UID: 1000
@@ -2343,7 +2343,7 @@ steps:
       - cd /go/src/github.com/gravitational/teleport
       - make image-ci publish-ci
 
-  - name: Build FIPS Docker image
+  - name: Build/push FIPS Docker image
     image: docker
     environment:
       UID: 1000
@@ -2840,6 +2840,6 @@ steps:
 
 ---
 kind: signature
-hmac: 64bd533c312addc61ef4d1103a0c6993b6c907385e1bb49110ae0d13f5ca7f8a
+hmac: fb74a5b64ecb8be839f14d51aa731e6cc26a6c88661c2bd7c64d5c4d98aabb38
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2271,18 +2271,27 @@ name: build-docker-images
 environment:
   RUNTIME: go1.14.4
 
+#TODO(gus): testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+#   repo:
+#     include:
+#       - gravitational/*
 trigger:
   event:
-    - tag
-  ref:
     include:
-      - refs/tags/v*
+      - pull_request
   repo:
     include:
       - gravitational/*
 
-depends_on:
-  - test
+#TODO(gus): testing
+# depends_on:
+#   - test
 
 workspace:
   path: /go
@@ -2834,6 +2843,6 @@ steps:
 
 ---
 kind: signature
-hmac: cef07f133c51a0b3a83e8a26d5131d064c246fbd74769c2a8fa7a2e8dbe94684
+hmac: dbda1f77dc85e5fee3533c8d14aabf0ca8d0991ecad0ba681a3b0fd99327944e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2702,6 +2702,76 @@ clone:
   disable: true
 
 steps:
+  - name: Pull and retag Docker images
+    image: docker
+    settings:
+      docker_staging_username:
+        from_secret: QUAYIO_DOCKER_USERNAME
+      docker_staging_password:
+        from_secret: QUAYIO_DOCKER_PASSWORD
+      docker_production_username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      docker_production_password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - export VERSION=${DRONE_TAG##v}
+      - |
+        # authenticate with staging credentials
+        docker login -u="$PLUGIN_DOCKER_STAGING_USERNAME" -p="$PLUGIN_DOCKER_STAGING_PASSWORD" quay.io
+      - |
+        # pull 'temporary' CI-built images
+        echo "---> Pulling OSS $${VERSION}"
+        docker pull quay.io/gravitational/teleport-ci:$${VERSION}
+        echo "---> Pulling Enterprise $${VERSION}"
+        docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}
+        echo "---> Pulling Enterprise FIPS $${VERSION}"
+        docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips
+      - |
+        # retag images to production naming
+        echo "--->Tagging OSS $${VERSION}"
+        docker tag quay.io/gravitational/teleport-ci:$${VERSION} quay.io/gravitational/teleport:$${VERSION}
+        echo "---> Tagging Enterprise $${VERSION}"
+        docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION} quay.io/gravitational/teleport-ent:$${VERSION}
+        echo "---> Tagging Enterprise FIPS $${VERSION}"
+        docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips quay.io/gravitational/teleport-ent:$${VERSION}-fips
+      - |
+        # reauthenticate with production credentials
+        docker logout quay.io && docker login -u="$PLUGIN_DOCKER_PRODUCTION_USERNAME" -p="$PLUGIN_DOCKER_PRODUCTION_PASSWORD" quay.io
+      - |
+        # push production images
+        echo "---> Pushing OSS $${VERSION}"
+        docker push quay.io/gravitational/teleport:$${VERSION}
+        echo "---> Pushing Enterprise $${VERSION}"
+        docker push quay.io/gravitational/teleport-ent:$${VERSION}
+        echo "---> Pushing Enterprise FIPS $${VERSION}"
+        docker push quay.io/gravitational/teleport-ent:$${VERSION}-fips
+
+  - name: Make AMIs public
+    image: hashicorp/packer
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache aws-cli jq make
+      - mkdir -p /go/src/github.com/gravitational/teleport/assets/aws/files/build
+      - cd /go/src/github.com/gravitational/teleport/assets/aws
+      - aws s3 sync s3://$AWS_S3_BUCKET/teleport/ami/${DRONE_TAG##v}/ ./files/build/
+      - |
+        echo "---> Making OSS AMIs public"
+        make change-amis-to-public-oss
+        echo "---> Making Enterprise AMIs public"
+        make change-amis-to-public-ent
+        echo "---> Making Enterprise FIPS AMIs public"
+        make change-amis-to-public-ent-fips
+
   - name: Download artifacts from S3 artifact publishing bucket
     image: amazon/aws-cli
     environment:
@@ -2730,64 +2800,8 @@ steps:
       target: teleport/${DRONE_TAG##v}/
       strip_prefix: /go/src/github.com/gravitational/teleport/
 
-  - name: Pull and retag Docker images
-    image: docker
-    settings:
-      docker_staging_username:
-        from_secret: QUAYIO_DOCKER_USERNAME
-      docker_staging_password:
-        from_secret: QUAYIO_DOCKER_PASSWORD
-      docker_production_username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-      docker_production_password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - export VERSION=${DRONE_TAG##v}
-      # authenticate with staging credentials
-      - docker login -u="$PLUGIN_DOCKER_STAGING_USERNAME" -p="$PLUGIN_DOCKER_STAGING_PASSWORD" quay.io
-      # pull 'temporary' CI-built images
-      - docker pull quay.io/gravitational/teleport-ci:$${VERSION}
-      - docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}
-      - docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips
-      # retag images to production naming
-      - docker tag quay.io/gravitational/teleport-ci:$${VERSION} quay.io/gravitational/teleport:$${VERSION}
-      - docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION} quay.io/gravitational/teleport-ent:$${VERSION}
-      - docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips quay.io/gravitational/teleport-ent:$${VERSION}-fips
-      # reauthenticate with production credentials
-      - docker logout quay.io && docker login -u="$PLUGIN_DOCKER_PRODUCTION_USERNAME" -p="$PLUGIN_DOCKER_PRODUCTION_PASSWORD" quay.io
-      # push production images
-      - docker push quay.io/gravitational/teleport:$${VERSION}
-      - docker push quay.io/gravitational/teleport-ent:$${VERSION}
-      - docker push quay.io/gravitational/teleport-ent:$${VERSION}-fips
-
-  - name: Make AMIs public
-    image: hashicorp/packer
-    environment:
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache aws-cli jq make
-      - mkdir -p /go/src/github.com/gravitational/teleport/assets/aws/files/build
-      - cd /go/src/github.com/gravitational/teleport/assets/aws
-      - aws s3 sync s3://$AWS_S3_BUCKET/teleport/ami/${DRONE_TAG##v}/ ./files/build/
-      - |
-        echo "---> Making OSS AMIs public"
-        make change-amis-to-public-oss
-        echo "---> Making Enterprise AMIs public"
-        make change-amis-to-public-ent
-        echo "---> Making Enterprise FIPS AMIs public"
-        make change-amis-to-public-ent-fips
-
 ---
 kind: signature
-hmac: 7bc5cc105ebfa9277166fb76b5c9ac171388096e79174e0d949ecfbd602bbd22
+hmac: a90135d3bec1007d40be600a0f1c8faf0d267dd699aca9596f256f40ae7fb5cf
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2744,11 +2744,12 @@ steps:
   - name: Check out code
     image: docker:git
     commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport /go/cache
-      - cd /go/src/github.com/gravitational/teleport
-      - git init && git remote add origin ${DRONE_REMOTE_URL}
-      - git fetch origin +refs/tags/${DRONE_TAG}:
-      - git checkout -qf FETCH_HEAD
+      - |
+        mkdir -p /go/src/github.com/gravitational/teleport /go/cache
+        cd /go/src/github.com/gravitational/teleport
+        git init && git remote add origin ${DRONE_REMOTE_URL}
+        git fetch origin +refs/tags/${DRONE_TAG}:
+        git checkout -qf FETCH_HEAD
 
   - name: Make AMIs public
     image: hashicorp/packer
@@ -2764,9 +2765,10 @@ steps:
       - mkdir -p /go/src/github.com/gravitational/teleport/assets/aws/files/build
       - aws s3 sync s3://$AWS_S3_BUCKET/teleport/ami/${DRONE_TAG##v}/ /go/src/github.com/gravitational/teleport/assets/aws/files/build
       - cd /go/src/github.com/gravitational/teleport/assets/aws
-      - make change-amis-to-public-oss
-      - make change-amis-to-public-ent
-      - make change-amis-to-public-ent-fips
+      - |
+        make change-amis-to-public-oss
+        make change-amis-to-public-ent
+        make change-amis-to-public-ent-fips
 
   - name: Download artifacts from S3 artifact publishing bucket
     image: amazon/aws-cli
@@ -2810,6 +2812,6 @@ volumes:
 
 ---
 kind: signature
-hmac: d12e5e9f74d1bdc3c2d82271583b30a2aed5eeb15e4566b4c1925558afad994f
+hmac: a337276a6c297e42498ef31bb5b05733397882759a97d38948a60e4a86f908ab
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,10 @@ environment:
 #   repo:
 #     include:
 #       - gravitational/*
+trigger:
+  event:
+    cron:
+      - none
 
 workspace:
   path: /go
@@ -151,6 +155,10 @@ name: test-docs-internal
 #   repo:
 #     include:
 #       - gravitational/*
+trigger:
+  event:
+    cron:
+      - none
 
 workspace:
   path: /go
@@ -226,6 +234,10 @@ name: test-docs-external
 #   repo:
 #     include:
 #       - gravitational/*
+trigger:
+  event:
+    cron:
+      - none
 
 workspace:
   path: /go
@@ -507,8 +519,8 @@ trigger:
       - gravitational/*
 
 #TODO(gus): testing
-depends_on:
-  - test
+#depends_on:
+#  - test
 
 workspace:
   path: /go
@@ -2822,6 +2834,6 @@ steps:
 
 ---
 kind: signature
-hmac: 832c98715adf053c2ee98d2a2b7b958cd9b55584c4a2efddc9d77ddb19a8ff5c
+hmac: cef07f133c51a0b3a83e8a26d5131d064c246fbd74769c2a8fa7a2e8dbe94684
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2717,6 +2717,8 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
+      # wait for docker to start
+      - sleep 3
       - export VERSION=${DRONE_TAG##v}
       # authenticate with staging credentials
       - docker login -u="$PLUGIN_DOCKER_STAGING_USERNAME" -p="$PLUGIN_DOCKER_STAGING_PASSWORD" quay.io
@@ -2801,6 +2803,6 @@ volumes:
 
 ---
 kind: signature
-hmac: e968fb18fc7e231150ecc80dfa67d96210258dff5cb9a07876c81cd937c72c88
+hmac: c13090d0e62168ba4ae989fc389acb6f057516890b4d3a50cb33b0fdf117b42d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -589,7 +589,6 @@ name: build-linux-amd64-fips
 environment:
   RUNTIME: go1.14.4
 
-TODO(gus): testing
 trigger:
   event:
     - tag
@@ -2304,9 +2303,6 @@ steps:
       # Normally, the version is set and exported by the root Makefile and then inherited,
       # but this is not the case for FIPS builds (which only run in e/Makefile)
       - export VERSION=$(cat /go/.version.txt)
-      # TODO
-      # this should be changed to "make -C e image-fips publish-fips" when we want to
-      # actually cut over to building public-facing Docker images using Drone
       - make -C e image-fips-ci publish-fips-ci
 
 services:
@@ -2789,6 +2785,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 9d25d641a1e262e02f87aa627c5cd7d87b7d4d7e5a61d471e34d43fad222f5a3
+hmac: 84006d57b84f2b04e0cc751bd1b297712ce960d257a189f98cd6b6301a348a4b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,13 +8,14 @@ environment:
   UID: 1000
   GID: 1000
 
-trigger:
-  event:
-    include:
-      - pull_request
-  repo:
-    include:
-      - gravitational/*
+#TODO(gus): testing
+# trigger:
+#   event:
+#     include:
+#       - pull_request
+#   repo:
+#     include:
+#       - gravitational/*
 
 workspace:
   path: /go
@@ -142,13 +143,14 @@ kind: pipeline
 type: kubernetes
 name: test-docs-internal
 
-trigger:
-  event:
-    include:
-      - pull_request
-  repo:
-    include:
-      - gravitational/*
+#TODO(gus): testing
+# trigger:
+#   event:
+#     include:
+#       - pull_request
+#   repo:
+#     include:
+#       - gravitational/*
 
 workspace:
   path: /go
@@ -216,13 +218,14 @@ kind: pipeline
 type: kubernetes
 name: test-docs-external
 
-trigger:
-  event:
-    include:
-      - pull_request
-  repo:
-    include:
-      - gravitational/*
+#TODO(gus): testing
+# trigger:
+#   event:
+#     include:
+#       - pull_request
+#   repo:
+#     include:
+#       - gravitational/*
 
 workspace:
   path: /go
@@ -485,16 +488,25 @@ name: build-linux-amd64
 environment:
   RUNTIME: go1.14.4
 
+#TODO(gus): testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+#   repo:
+#     include:
+#       - gravitational/*
 trigger:
   event:
-    - tag
-  ref:
     include:
-      - refs/tags/v*
+      - pull_request
   repo:
     include:
       - gravitational/*
 
+#TODO(gus): testing
 depends_on:
   - test
 
@@ -592,18 +604,27 @@ name: build-linux-amd64-fips
 environment:
   RUNTIME: go1.14.4
 
+#TODO(gus): testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+#   repo:
+#     include:
+#       - gravitational/*
 trigger:
   event:
-    - tag
-  ref:
     include:
-      - refs/tags/v*
+      - pull_request
   repo:
     include:
       - gravitational/*
 
-depends_on:
-  - test
+#TODO(gus): testing
+# depends_on:
+#   - test
 
 workspace:
   path: /go
@@ -2352,18 +2373,27 @@ kind: pipeline
 type: kubernetes
 name: build-oss-amis
 
+#TODO(gus): testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+#   repo:
+#     include:
+#       - gravitational/*
 trigger:
   event:
-    - tag
-  ref:
     include:
-      - refs/tags/v*
+      - pull_request
   repo:
     include:
       - gravitational/*
 
+#TODO(gus): testing
 depends_on:
-  - test
+#   - test
   - build-linux-amd64
 
 workspace:
@@ -2455,18 +2485,27 @@ kind: pipeline
 type: kubernetes
 name: build-ent-amis
 
+#TODO(gus): testing
+# trigger:
+#   event:
+#     - tag
+#   ref:
+#     include:
+#       - refs/tags/v*
+#   repo:
+#     include:
+#       - gravitational/*
 trigger:
   event:
-    - tag
-  ref:
     include:
-      - refs/tags/v*
+      - pull_request
   repo:
     include:
       - gravitational/*
 
+#TODO(gus): testing
 depends_on:
-  - test
+#   - test
   - build-linux-amd64
   - build-linux-amd64-fips
 
@@ -2783,6 +2822,6 @@ steps:
 
 ---
 kind: signature
-hmac: 4899206ba9ce0f2971a5c36855a89a025d26067cf8db610ae52e8adf55fbeca3
+hmac: 832c98715adf053c2ee98d2a2b7b958cd9b55584c4a2efddc9d77ddb19a8ff5c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2718,36 +2718,26 @@ steps:
         path: /var/run
     commands:
       - export VERSION=${DRONE_TAG##v}
-      - |
-        # authenticate with staging credentials
-        docker login -u="$PLUGIN_DOCKER_STAGING_USERNAME" -p="$PLUGIN_DOCKER_STAGING_PASSWORD" quay.io
-      - |
-        # pull 'temporary' CI-built images
-        echo "---> Pulling OSS $${VERSION}"
-        docker pull quay.io/gravitational/teleport-ci:$${VERSION}
-        echo "---> Pulling Enterprise $${VERSION}"
-        docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}
-        echo "---> Pulling Enterprise FIPS $${VERSION}"
-        docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips
-      - |
-        # retag images to production naming
-        echo "--->Tagging OSS $${VERSION}"
-        docker tag quay.io/gravitational/teleport-ci:$${VERSION} quay.io/gravitational/teleport:$${VERSION}
-        echo "---> Tagging Enterprise $${VERSION}"
-        docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION} quay.io/gravitational/teleport-ent:$${VERSION}
-        echo "---> Tagging Enterprise FIPS $${VERSION}"
-        docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips quay.io/gravitational/teleport-ent:$${VERSION}-fips
-      - |
-        # reauthenticate with production credentials
-        docker logout quay.io && docker login -u="$PLUGIN_DOCKER_PRODUCTION_USERNAME" -p="$PLUGIN_DOCKER_PRODUCTION_PASSWORD" quay.io
-      - |
-        # push production images
-        echo "---> Pushing OSS $${VERSION}"
-        docker push quay.io/gravitational/teleport:$${VERSION}
-        echo "---> Pushing Enterprise $${VERSION}"
-        docker push quay.io/gravitational/teleport-ent:$${VERSION}
-        echo "---> Pushing Enterprise FIPS $${VERSION}"
-        docker push quay.io/gravitational/teleport-ent:$${VERSION}-fips
+      # authenticate with staging credentials
+      - docker login -u="$PLUGIN_DOCKER_STAGING_USERNAME" -p="$PLUGIN_DOCKER_STAGING_PASSWORD" quay.io
+      # pull 'temporary' CI-built images
+      - echo "---> Pulling images for $${VERSION}"
+      - docker pull quay.io/gravitational/teleport-ci:$${VERSION}
+      - docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}
+      - docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips
+      # retag images to production naming
+      - echo "---> Tagging images for $${VERSION}"
+      - docker tag quay.io/gravitational/teleport-ci:$${VERSION} quay.io/gravitational/teleport:$${VERSION}
+      - docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION} quay.io/gravitational/teleport-ent:$${VERSION}
+      - docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips quay.io/gravitational/teleport-ent:$${VERSION}-fips
+      # reauthenticate with production credentials
+      - docker logout quay.io
+      - docker login -u="$PLUGIN_DOCKER_PRODUCTION_USERNAME" -p="$PLUGIN_DOCKER_PRODUCTION_PASSWORD" quay.io
+      # push production images
+      - echo "---> Pushing images for $${VERSION}"
+      - docker push quay.io/gravitational/teleport:$${VERSION}
+      - docker push quay.io/gravitational/teleport-ent:$${VERSION}
+      - docker push quay.io/gravitational/teleport-ent:$${VERSION}-fips
 
   - name: Make AMIs public
     image: hashicorp/packer
@@ -2756,9 +2746,6 @@ steps:
         from_secret: AWS_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_SECRET_ACCESS_KEY
-    volumes:
-      - name: dockersock
-        path: /var/run
     commands:
       - apk add --no-cache aws-cli jq make
       - mkdir -p /go/src/github.com/gravitational/teleport/assets/aws/files/build
@@ -2814,6 +2801,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 1b875a0603c3eb8711a2ec71abb517aafbc363a0dc9bc44af44e415a69bc18fb
+hmac: e968fb18fc7e231150ecc80dfa67d96210258dff5cb9a07876c81cd937c72c88
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,17 +8,13 @@ environment:
   UID: 1000
   GID: 1000
 
-#TODO(gus): testing
-# trigger:
-#   event:
-#     include:
-#       - pull_request
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
-  cron:
-    - none
+  event:
+    include:
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
 
 workspace:
   path: /go
@@ -146,17 +142,13 @@ kind: pipeline
 type: kubernetes
 name: test-docs-internal
 
-#TODO(gus): testing
-# trigger:
-#   event:
-#     include:
-#       - pull_request
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
-  cron:
-    - none
+  event:
+    include:
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
 
 workspace:
   path: /go
@@ -224,17 +216,13 @@ kind: pipeline
 type: kubernetes
 name: test-docs-external
 
-#TODO(gus): testing
-# trigger:
-#   event:
-#     include:
-#       - pull_request
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
-  cron:
-    - none
+  event:
+    include:
+      - pull_request
+  repo:
+    include:
+      - gravitational/*
 
 workspace:
   path: /go
@@ -497,26 +485,18 @@ name: build-linux-amd64
 environment:
   RUNTIME: go1.14.4
 
-#TODO(gus): testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
   event:
+    - tag
+  ref:
     include:
-      - pull_request
+      - refs/tags/v*
   repo:
     include:
       - gravitational/*
 
-#TODO(gus): testing
-#depends_on:
+# TODO(gus): testing
+# depends_on:
 #  - test
 
 workspace:
@@ -613,20 +593,13 @@ name: build-linux-amd64-fips
 environment:
   RUNTIME: go1.14.4
 
-#TODO(gus): testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
-#   repo:
-#     include:
-#       - gravitational/*
+TODO(gus): testing
 trigger:
   event:
+    - tag
+  ref:
     include:
-      - pull_request
+      - refs/tags/v*
   repo:
     include:
       - gravitational/*
@@ -2268,20 +2241,12 @@ name: build-docker-images
 environment:
   RUNTIME: go1.14.4
 
-#TODO(gus): testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
   event:
+    - tag
+  ref:
     include:
-      - pull_request
+      - refs/tags/v*
   repo:
     include:
       - gravitational/*
@@ -2391,20 +2356,12 @@ kind: pipeline
 type: kubernetes
 name: build-oss-amis
 
-#TODO(gus): testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
   event:
+    - tag
+  ref:
     include:
-      - pull_request
+      - refs/tags/v*
   repo:
     include:
       - gravitational/*
@@ -2503,20 +2460,12 @@ kind: pipeline
 type: kubernetes
 name: build-ent-amis
 
-#TODO(gus): testing
-# trigger:
-#   event:
-#     - tag
-#   ref:
-#     include:
-#       - refs/tags/v*
-#   repo:
-#     include:
-#       - gravitational/*
 trigger:
   event:
+    - tag
+  ref:
     include:
-      - pull_request
+      - refs/tags/v*
   repo:
     include:
       - gravitational/*
@@ -2840,6 +2789,6 @@ steps:
 
 ---
 kind: signature
-hmac: fb74a5b64ecb8be839f14d51aa731e6cc26a6c88661c2bd7c64d5c4d98aabb38
+hmac: b4957d7c1fbb14c8f055dc6a8f551238ff5e6d8de4baa5a92d37bc4cad0550c9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2290,9 +2290,9 @@ steps:
       ARCH: amd64
     settings:
       username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+        from_secret: QUAYIO_DOCKER_USERNAME
       password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+        from_secret: QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
@@ -2302,10 +2302,7 @@ steps:
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
       - cd /go/src/github.com/gravitational/teleport
-      # TODO
-      # this should be changed to "make image publish" when we want to actually cut over
-      # to building public-facing Docker images using Drone
-      - make image
+      - make image-ci publish-ci
 
   - name: Build FIPS Docker image
     image: docker
@@ -2317,9 +2314,9 @@ steps:
       ARCH: amd64
     settings:
       username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+        from_secret: QUAYIO_DOCKER_USERNAME
       password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+        from_secret: QUAYIO_DOCKER_PASSWORD
     volumes:
       - name: dockersock
         path: /var/run
@@ -2336,7 +2333,7 @@ steps:
       # TODO
       # this should be changed to "make -C e image-fips publish-fips" when we want to
       # actually cut over to building public-facing Docker images using Drone
-      - make -C e image-fips
+      - make -C e image-fips-ci publish-fips-ci
 
 services:
   - name: Start Docker
@@ -2420,13 +2417,26 @@ steps:
       - |
         if [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
           echo "---> Building production OSS AMIs"
+          echo "---> Note: these AMIs will not be made public until the 'promote' step is run"
           make oss-ci-build
-          echo "---> Making OSS AMIs public"
-          make change-amis-to-public-oss
         else
           echo "---> Building debug OSS AMIs"
           make oss
         fi
+
+  - name: Sync OSS build timestamp to S3
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat /go/.version.txt)
+      - aws s3 cp /go/src/github.com/gravitational/teleport/assets/aws/files/build/oss_build_timestamp.txt s3://$AWS_S3_BUCKET/teleport/ami/$${VERSION}/
 
 services:
   - name: Start Docker
@@ -2513,15 +2523,26 @@ steps:
       - |
         if [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
           echo "---> Building production Enterprise AMIs"
+          echo "---> Note: these AMIs will not be made public until the 'promote' step is run"
           make ent-ci-build
-          echo "---> Making Enterprise AMIs public"
-          make change-amis-to-public-ent
-          echo "---> Making Enterprise FIPS AMIs public"
-          make change-amis-to-public-ent-fips
         else
           echo "---> Building debug Enterprise AMIs"
           make ent
         fi
+
+  - name: Sync Enterprise build timestamp to S3
+    image: amazon/aws-cli
+    environment:
+      AWS_S3_BUCKET:
+        from_secret: AWS_S3_BUCKET
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+      AWS_REGION: us-west-2
+    commands:
+      - export VERSION=$(cat /go/.version.txt)
+      - aws s3 cp /go/src/github.com/gravitational/teleport/assets/aws/files/build/ent_build_timestamp.txt s3://$AWS_S3_BUCKET/teleport/ami/$${VERSION}/
 
 services:
   - name: Start Docker
@@ -2657,7 +2678,7 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: promote-artifacts
+name: promote-build
 
 trigger:
   event:
@@ -2703,8 +2724,65 @@ steps:
       target: teleport/${DRONE_TAG##v}/
       strip_prefix: /go/src/github.com/gravitational/teleport/
 
+  - name: Pull and retag Docker images
+    image: docker
+    settings:
+      docker_staging_username:
+        from_secret: QUAYIO_DOCKER_USERNAME
+      docker_staging_password:
+        from_secret: QUAYIO_DOCKER_PASSWORD
+      docker_production_username:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
+      docker_production_password:
+        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - chown -R $UID:$GID /go
+      - export VERSION=${DRONE_TAG##v}
+      # authenticate with staging credentials
+      - docker login -u="$PLUGIN_DOCKER_STAGING_USERNAME" -p="$PLUGIN_DOCKER_STAGING_PASSWORD" quay.io
+      # pull 'temporary' CI-built images
+      - docker pull quay.io/gravitational/teleport-ci:$${VERSION}
+      - docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}
+      - docker pull quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips
+      # retag images to production naming
+      - docker tag quay.io/gravitational/teleport-ci:$${VERSION} quay.io/gravitational/teleport:$${VERSION}
+      - docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION} quay.io/gravitational/teleport-ent:$${VERSION}
+      - docker tag quay.io/gravitational/teleport-ent-ci:$${VERSION}-fips quay.io/gravitational/teleport-ent:$${VERSION}-fips
+      # reauthenticate with production credentials
+      - docker logout quay.io && docker login -u="$PLUGIN_DOCKER_PRODUCTION_USERNAME" -p="$PLUGIN_DOCKER_PRODUCTION_PASSWORD" quay.io
+      # push production images
+      - docker push quay.io/gravitational/teleport:$${VERSION}
+      - docker push quay.io/gravitational/teleport-ent:$${VERSION}
+      - docker push quay.io/gravitational/teleport-ent:$${VERSION}-fips
+
+  - name: Make AMIs public
+    image: hashicorp/packer
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: AWS_SECRET_ACCESS_KEY
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache aws-cli jq make
+      - mkdir -p /go/src/github.com/gravitational/teleport/assets/aws/files/build
+      - cd /go/src/github.com/gravitational/teleport/assets/aws
+      - aws s3 sync s3://$AWS_S3_BUCKET/teleport/ami/${DRONE_TAG##v}/ ./files/build/
+      - |
+        echo "---> Making OSS AMIs public"
+        make change-amis-to-public-oss
+        echo "---> Making Enterprise AMIs public"
+        make change-amis-to-public-ent
+        echo "---> Making Enterprise FIPS AMIs public"
+        make change-amis-to-public-ent-fips
+
 ---
 kind: signature
-hmac: bcd363559f085905edc708b7ea225610da0cba0568ee70f8e1417e51013b4c9f
+hmac: 4899206ba9ce0f2971a5c36855a89a025d26067cf8db610ae52e8adf55fbeca3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2745,7 +2745,6 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
-      - chown -R $UID:$GID /go
       - export VERSION=${DRONE_TAG##v}
       # authenticate with staging credentials
       - docker login -u="$PLUGIN_DOCKER_STAGING_USERNAME" -p="$PLUGIN_DOCKER_STAGING_PASSWORD" quay.io
@@ -2789,6 +2788,6 @@ steps:
 
 ---
 kind: signature
-hmac: b4957d7c1fbb14c8f055dc6a8f551238ff5e6d8de4baa5a92d37bc4cad0550c9
+hmac: 7bc5cc105ebfa9277166fb76b5c9ac171388096e79174e0d949ecfbd602bbd22
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2696,7 +2696,7 @@ trigger:
       - gravitational/*
 
 workspace:
-  path: /go/src/github.com/gravitational/teleport
+  path: /go
 
 clone:
   disable: true
@@ -2745,14 +2745,14 @@ steps:
     image: docker:git
     commands:
       - |
-        mkdir -p /go/src/github.com/gravitational/teleport /go/cache
+        mkdir -p /go/src/github.com/gravitational/teleport
         cd /go/src/github.com/gravitational/teleport
         git init && git remote add origin ${DRONE_REMOTE_URL}
         git fetch origin +refs/tags/${DRONE_TAG}:
         git checkout -qf FETCH_HEAD
 
-  - name: Make AMIs public
-    image: hashicorp/packer
+  - name: Download saved AMI timestamps
+    image: docker
     environment:
       AWS_S3_BUCKET:
         from_secret: AWS_S3_BUCKET
@@ -2761,9 +2761,19 @@ steps:
       AWS_SECRET_ACCESS_KEY:
         from_secret: AWS_SECRET_ACCESS_KEY
     commands:
-      - apk add --no-cache aws-cli jq make
+      - apk add --no-cache aws-cli
       - mkdir -p /go/src/github.com/gravitational/teleport/assets/aws/files/build
       - aws s3 sync s3://$AWS_S3_BUCKET/teleport/ami/${DRONE_TAG##v}/ /go/src/github.com/gravitational/teleport/assets/aws/files/build
+
+  - name: Make AMIs public
+    image: docker
+    environment:
+      AWS_ACCESS_KEY_ID:
+        from_secret: PRODUCTION_AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY:
+        from_secret: PRODUCTION_AWS_SECRET_ACCESS_KEY
+    commands:
+      - apk add --no-cache aws-cli make
       - cd /go/src/github.com/gravitational/teleport/assets/aws
       - |
         make change-amis-to-public-oss
@@ -2781,7 +2791,7 @@ steps:
         from_secret: AWS_SECRET_ACCESS_KEY
       AWS_REGION: us-west-2
     commands:
-      - aws s3 sync s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/ .
+      - aws s3 sync s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}/ /go/artifacts/
 
   - name: Upload artifacts to production S3 bucket with public read access
     image: plugins/s3
@@ -2794,9 +2804,9 @@ steps:
         from_secret: PRODUCTION_AWS_SECRET_ACCESS_KEY
       region: us-east-1
       acl: public-read
-      source: /go/src/github.com/gravitational/teleport/*
+      source: /go/artifacts/*
       target: teleport/${DRONE_TAG##v}/
-      strip_prefix: /go/src/github.com/gravitational/teleport/
+      strip_prefix: /go/artifacts/
 
 services:
   - name: Start Docker
@@ -2812,6 +2822,6 @@ volumes:
 
 ---
 kind: signature
-hmac: a337276a6c297e42498ef31bb5b05733397882759a97d38948a60e4a86f908ab
+hmac: 6ec0dd8a02448e07951db3dfea9177f7fc3bc128bbc740bb37fe41f67b8d930b
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.2
+VERSION=4.4.0-dev.3
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.9
+VERSION=4.4.0-dev.10
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.3
+VERSION=4.4.0-dev.4
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.5
+VERSION=4.4.0-dev.6
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.6
+VERSION=4.4.0-dev.7
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 #   for pre-releases, we use   "1.0.0-beta.2" format
 VERSION=4.4.0-dev
 
+DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 
 # These are standard autotools variables, don't change them please
@@ -414,6 +415,22 @@ image: clean docker-binaries
 publish: image
 	docker push $(DOCKER_IMAGE):$(VERSION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e publish; fi
+
+# Docker image build in CI.
+# This is run to build and push Docker images to a private repository as part of the build process.
+# When we are ready to make the images public after testing (i.e. when publishing a release), we pull these
+# images down, retag them and push them up to the production repo so they're available for use.
+# This job can be removed/consolidated after we switch over completely from using Jenkins to using Drone.
+.PHONY: image-ci
+image-ci: clean docker-binaries
+	cp ./build.assets/charts/Dockerfile $(BUILDDIR)/
+	cd $(BUILDDIR) && docker build --no-cache . -t $(DOCKER_IMAGE_CI):$(VERSION)
+	if [ -f e/Makefile ]; then $(MAKE) -C e image-ci; fi
+
+.PHONY: publish-ci
+publish-ci: image-ci
+	docker push $(DOCKER_IMAGE_CI):$(VERSION)
+	if [ -f e/Makefile ]; then $(MAKE) -C e publish-ci; fi
 
 .PHONY: print-version
 print-version:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.7
+VERSION=4.4.0-dev.8
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.10
+VERSION=4.4.0-dev
 
-DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
+DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 
 # These are standard autotools variables, don't change them please
 BUILDDIR ?= build

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.4
+VERSION=4.4.0-dev.5
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.1
+VERSION=4.4.0-dev.2
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.11
+VERSION=4.4.0-dev
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev.8
+VERSION=4.4.0-dev.9
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev
+VERSION=4.4.0-dev.11
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.0-dev
+VERSION=4.4.0-dev.1
 
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 DOCKER_IMAGE ?= quay.io/gravitational/teleport

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.4"
+	Version = "4.4.0-dev.5"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.7"
+	Version = "4.4.0-dev.8"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev"
+	Version = "4.4.0-dev.1"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.6"
+	Version = "4.4.0-dev.7"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.11"
+	Version = "4.4.0-dev"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.8"
+	Version = "4.4.0-dev.9"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev"
+	Version = "4.4.0-dev.11"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.9"
+	Version = "4.4.0-dev.10"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.3"
+	Version = "4.4.0-dev.4"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.5"
+	Version = "4.4.0-dev.6"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.10"
+	Version = "4.4.0-dev"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.2"
+	Version = "4.4.0-dev.3"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.0-dev.1"
+	Version = "4.4.0-dev.2"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Relevant to #3936 

Currently in Drone:
- Docker images are built when a Git tag is pushed, but they're not published (as this would make the images available for public consumption - we haven't cut over to Drone fully yet, so Jenkins is still responsible for building Docker images)
- AMIs are built and made public when a Git tag is pushed, which is in conflict with what Jenkins is doing.

This PR makes the following changes to the jobs that run on a `tag` event:
- Build and push Docker images to a separate private CI repo, so they can be tested before publishing.
- Build AMIs, but don't make them public.

It also makes the following changes to the job that runs on a `promote` event:
- Download Docker images from the private CI repo, retag them to the production version and push them to the production repo for use
- Make the AMIs built as part of the `tag` event public.

This also removes the dependency on the `test` pipeline for all `tag` jobs - essentially, we don't re-run the linter and unit/integration tests on the tag, as the commit will already have been tested.