### PR TITLE
Support tctl through a proxy

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -356,7 +356,7 @@ func (proxy *ProxyClient) ConnectToCluster(ctx context.Context, clusterName stri
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to fetch TLS key for %v", proxy.teleportClient.Username)
 	}
-	tlsConfig, err := key.ClientTLSConfig()
+	tlsConfig, err := key.ClientTLSConfig(nil)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to generate client TLS config")
 	}

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -311,6 +311,10 @@ func (k *Key) CheckCert() error {
 
 // HostKeyCallback returns an ssh.HostKeyCallback that validates host
 // keys/certs against SSH CAs in the Key.
+//
+// If not CAs are present in the Key, the returned ssh.HostKeyCallback is nil.
+// This causes golang.org/x/crypto/ssh to prompt the user to verify host key
+// fingerprint (same as OpenSSH does for an unknown host).
 func (k *Key) HostKeyCallback() (ssh.HostKeyCallback, error) {
 	var trustedKeys []ssh.PublicKey
 	for _, caCert := range k.SSHCAs() {

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -663,61 +663,83 @@ func (s *server) getTrustedCAKeysByID(id services.CertAuthID) ([]ssh.PublicKey, 
 	return ca.Checkers()
 }
 
-func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (perm *ssh.Permissions, err error) {
 	logger := s.WithFields(log.Fields{
 		"remote": conn.RemoteAddr(),
 		"user":   conn.User(),
 	})
+	// The crypto/x/ssh package won't log the returned error for us, do it
+	// manually.
+	defer func() {
+		if err != nil {
+			logger.Warnf("Failed to authenticate client, err: %v.", err)
+		}
+	}()
 
 	cert, ok := key.(*ssh.Certificate)
 	if !ok {
-		logger.Warningf("server doesn't support provided key type")
 		return nil, trace.BadParameter("server doesn't support provided key type")
 	}
 
+	var clusterName, certRole, certType string
+	var caType services.CertAuthType
 	switch cert.CertType {
 	case ssh.HostCert:
-		authDomain, ok := cert.Extensions[utils.CertExtensionAuthority]
-		if !ok || authDomain == "" {
-			err := trace.BadParameter("missing authority domainName parameter")
-			logger.Warnf("Failed to authenticate host, err: %v.", err)
-			return nil, trace.Wrap(err)
+		var ok bool
+		clusterName, ok = cert.Extensions[utils.CertExtensionAuthority]
+		if !ok || clusterName == "" {
+			return nil, trace.BadParameter("certificate missing %q extension", utils.CertExtensionAuthority)
 		}
-		certRole, ok := cert.Extensions[utils.CertExtensionRole]
+		certRole, ok = cert.Extensions[utils.CertExtensionRole]
 		if !ok || certRole == "" {
-			err := trace.BadParameter("certificate missing role")
-			logger.Warnf("Failed to authenticate host, err: %v.", err)
-			return nil, trace.Wrap(err)
+			return nil, trace.BadParameter("certificate missing %q extension", utils.CertExtensionRole)
 		}
-		err := s.checkHostCert(logger, conn.User(), authDomain, cert)
+		certType = extCertTypeHost
+		caType = services.HostCA
+	case ssh.UserCert:
+		var ok bool
+		clusterName, ok = cert.Extensions[teleport.CertExtensionTeleportRouteToCluster]
+		if !ok || clusterName == "" {
+			clusterName = s.ClusterName
+		}
+		encRoles, ok := cert.Extensions[teleport.CertExtensionTeleportRoles]
+		if !ok || encRoles == "" {
+			return nil, trace.BadParameter("certificate missing %q extension", teleport.CertExtensionTeleportRoles)
+		}
+		roles, err := services.UnmarshalCertRoles(encRoles)
 		if err != nil {
-			logger.Warnf("Failed to authenticate host, err: %v.", err)
 			return nil, trace.Wrap(err)
 		}
-		return &ssh.Permissions{
-			Extensions: map[string]string{
-				extHost:      conn.User(),
-				extCertType:  extCertTypeHost,
-				extCertRole:  certRole,
-				extAuthority: authDomain,
-			},
-		}, nil
+		if len(roles) == 0 {
+			return nil, trace.BadParameter("certificate missing roles in %q extension", teleport.CertExtensionTeleportRoles)
+		}
+		certRole = roles[0]
+		certType = extCertTypeUser
+		caType = services.UserCA
 	default:
-		return nil, trace.BadParameter("unsupported cert type: %v", cert.CertType)
+		return nil, trace.BadParameter("unsupported cert type: %v.", cert.CertType)
 	}
+
+	if err := s.checkClientCert(logger, conn.User(), clusterName, cert, caType); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &ssh.Permissions{
+		Extensions: map[string]string{
+			extHost:      conn.User(),
+			extCertType:  certType,
+			extCertRole:  certRole,
+			extAuthority: clusterName,
+		},
+	}, nil
 }
 
-// checkHostCert verifies that host certificate is signed
-// by the recognized certificate authority
-func (s *server) checkHostCert(logger *log.Entry, user string, clusterName string, cert *ssh.Certificate) error {
-	if cert.CertType != ssh.HostCert {
-		return trace.BadParameter("expected host cert, got wrong cert type: %d", cert.CertType)
-	}
-
+// checkClientCert verifies that client certificate is signed by the recognized
+// certificate authority.
+func (s *server) checkClientCert(logger *log.Entry, user string, clusterName string, cert *ssh.Certificate, caType services.CertAuthType) error {
 	// fetch keys of the certificate authority to check
 	// if there is a match
 	keys, err := s.getTrustedCAKeysByID(services.CertAuthID{
-		Type:       services.HostCA,
+		Type:       caType,
 		DomainName: clusterName,
 	})
 	if err != nil {
@@ -974,6 +996,7 @@ const (
 	extCertType     = "certtype@teleport"
 	extAuthority    = "auth@teleport"
 	extCertTypeHost = "host"
+	extCertTypeUser = "user"
 	extCertRole     = "role"
 
 	versionRequest = "x-teleport-version"

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -1,0 +1,129 @@
+package reversetunnel
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/testlog"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestServerKeyAuth(t *testing.T) {
+	ca := testauthority.New()
+	priv, pub, err := ca.GenerateKeyPair("")
+	assert.NoError(t, err)
+
+	s := &server{
+		Entry: testlog.FailureOnly(t),
+		localAccessPoint: mockAccessPoint{ca: services.NewCertAuthority(
+			services.HostCA,
+			"cluster-name",
+			[][]byte{priv},
+			[][]byte{pub},
+			nil,
+			services.CertAuthoritySpecV2_RSA_SHA2_256,
+		)},
+	}
+	con := mockSSHConnMetadata{}
+	tests := []struct {
+		desc           string
+		key            ssh.PublicKey
+		wantExtensions map[string]string
+		wantErr        assert.ErrorAssertionFunc
+	}{
+		{
+			desc: "host cert",
+			key: func() ssh.PublicKey {
+				rawCert, err := ca.GenerateHostCert(services.HostCertParams{
+					PrivateCASigningKey: priv,
+					CASigningAlg:        defaults.CASignatureAlgorithm,
+					PublicHostKey:       pub,
+					HostID:              "host-id",
+					NodeName:            con.User(),
+					ClusterName:         "host-cluster-name",
+					Roles:               teleport.Roles{teleport.RoleNode},
+				})
+				assert.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				assert.NoError(t, err)
+				return key
+			}(),
+			wantExtensions: map[string]string{
+				extHost:      con.User(),
+				extCertType:  extCertTypeHost,
+				extCertRole:  string(teleport.RoleNode),
+				extAuthority: "host-cluster-name",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			desc: "user cert",
+			key: func() ssh.PublicKey {
+				rawCert, err := ca.GenerateUserCert(services.UserCertParams{
+					PrivateCASigningKey: priv,
+					CASigningAlg:        defaults.CASignatureAlgorithm,
+					PublicUserKey:       pub,
+					Username:            con.User(),
+					AllowedLogins:       []string{con.User()},
+					Roles:               []string{"dev", "admin"},
+					RouteToCluster:      "user-cluster-name",
+					CertificateFormat:   teleport.CertificateFormatStandard,
+				})
+				assert.NoError(t, err)
+				key, _, _, _, err := ssh.ParseAuthorizedKey(rawCert)
+				assert.NoError(t, err)
+				return key
+			}(),
+			wantExtensions: map[string]string{
+				extHost:      con.User(),
+				extCertType:  extCertTypeUser,
+				extCertRole:  "dev",
+				extAuthority: "user-cluster-name",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			desc: "not a cert",
+			key: func() ssh.PublicKey {
+				key, _, _, _, err := ssh.ParseAuthorizedKey(pub)
+				assert.NoError(t, err)
+				return key
+			}(),
+			wantErr: assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			perm, err := s.keyAuth(con, tt.key)
+			tt.wantErr(t, err)
+			if err == nil {
+				assert.Empty(t, cmp.Diff(perm, &ssh.Permissions{Extensions: tt.wantExtensions}))
+			}
+		})
+	}
+}
+
+type mockSSHConnMetadata struct {
+	ssh.ConnMetadata
+}
+
+func (mockSSHConnMetadata) User() string         { return "conn-user" }
+func (mockSSHConnMetadata) RemoteAddr() net.Addr { return &net.TCPAddr{} }
+
+type mockAccessPoint struct {
+	auth.AccessPoint
+	ca services.CertAuthority
+}
+
+func (ap mockAccessPoint) GetCertAuthority(id services.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
+	return ap.ca, nil
+}

--- a/lib/utils/testlog/log.go
+++ b/lib/utils/testlog/log.go
@@ -1,0 +1,30 @@
+// Package testlog provides custom loggers for use in tests.
+package testlog
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// FailureOnly returns a logger that only prints the logs to STDERR when the
+// test fails.
+func FailureOnly(t *testing.T) *logrus.Entry {
+	// Collect all the output in buf.
+	buf := &bytes.Buffer{}
+	log := logrus.New()
+	log.Out = buf
+
+	// Register a cleanup callback which prints buf iff t has failed.
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		fmt.Fprintln(os.Stderr, buf.String())
+	})
+
+	return logrus.NewEntry(log)
+}

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -109,7 +109,7 @@ func Run(commands []CLICommand) {
 	app.Flag("identity", "Path to the identity file exported with 'tctl auth sign'").
 		Short('i').
 		StringVar(&ccf.IdentityFilePath)
-	app.Flag("insecure", "When specifying a proxy address in --auth-server, do not verify it's TLS certificate. Danger: any data you send can be intercepted or modified by an attacker.").
+	app.Flag("insecure", "When specifying a proxy address in --auth-server, do not verify its TLS certificate. Danger: any data you send can be intercepted or modified by an attacker.").
 		BoolVar(&ccf.Insecure)
 
 	// "version" command is always available:

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -17,18 +17,24 @@ limitations under the License.
 package common
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
-	"strings"
+	"strconv"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/tsh/common"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
@@ -43,10 +49,13 @@ type GlobalCLIFlags struct {
 	ConfigFile string
 	// ConfigString is the base64-encoded string with Teleport configuration
 	ConfigString string
-	// AuthServerAddr lists addresses of auth servers to connect to
+	// AuthServerAddr lists addresses of auth or proxy servers to connect to,
 	AuthServerAddr []string
 	// IdentityFilePath is the path to the identity file
 	IdentityFilePath string
+	// Insecure, when set, skips validation of server TLS certificate when
+	// connecting through a proxy (specified in AuthServerAddr).
+	Insecure bool
 }
 
 // CLICommand interface must be implemented by every CLI command
@@ -95,11 +104,13 @@ func Run(commands []CLICommand) {
 	app.Flag("config-string",
 		"Base64 encoded configuration string").Hidden().Envar(defaults.ConfigEnvar).StringVar(&ccf.ConfigString)
 	app.Flag("auth-server",
-		fmt.Sprintf("Address of the auth server [%v]. Can be supplied multiple times", defaults.AuthConnectAddr().Addr)).
+		fmt.Sprintf("Address of the auth server or the proxy [%v]. Can be supplied multiple times", defaults.AuthConnectAddr().Addr)).
 		StringsVar(&ccf.AuthServerAddr)
 	app.Flag("identity", "Path to the identity file exported with 'tctl auth sign'").
 		Short('i').
 		StringVar(&ccf.IdentityFilePath)
+	app.Flag("insecure", "When specifying a proxy address in --auth-server, do not verify it's TLS certificate. Danger: any data you send can be intercepted or modified by an attacker.").
+		BoolVar(&ccf.Insecure)
 
 	// "version" command is always available:
 	ver := app.Command("version", "Print cluster version")
@@ -108,9 +119,6 @@ func Run(commands []CLICommand) {
 	// parse CLI commands+flags:
 	selectedCmd, err := app.Parse(os.Args[1:])
 	if err != nil {
-		if strings.Contains(err.Error(), "unknown long flag") {
-			err = trace.Wrap(err, "make sure role used in flag has a corresponding Teleport role in RBAC, an example RBAC role can be seen here: %q", "https://gravitational.com/teleport/docs/enterprise/ssh_rbac/#roles")
-		}
 		utils.FatalError(err)
 	}
 
@@ -121,14 +129,19 @@ func Run(commands []CLICommand) {
 	}
 
 	// configure all commands with Teleport configuration (they share 'cfg')
-	if err := applyConfig(&ccf, cfg); err != nil {
+	clientConfig, err := applyConfig(&ccf, cfg)
+	if err != nil {
 		utils.FatalError(err)
 	}
 
+	ctx := context.Background()
 	// connect to the auth sever:
-	client, err := connectToAuthService(cfg)
+	client, err := connectToAuthService(ctx, cfg, clientConfig)
 	if err != nil {
-		utils.FatalError(err)
+		utils.Consolef(os.Stderr, teleport.ComponentClient,
+			"Cannot connect to the auth server: %v.\nIs the auth server running on %q?",
+			err, cfg.AuthServers[0].Addr)
+		os.Exit(1)
 	}
 
 	// execute whatever is selected:
@@ -144,8 +157,14 @@ func Run(commands []CLICommand) {
 	}
 }
 
+type authServiceClientConfig struct {
+	tlsConfig *tls.Config
+	sshConfig *ssh.ClientConfig
+}
+
 // connectToAuthService creates a valid client connection to the auth service
-func connectToAuthService(cfg *service.Config) (client auth.ClientI, err error) {
+//
+func connectToAuthService(ctx context.Context, cfg *service.Config, clientConfig *authServiceClientConfig) (auth.ClientI, error) {
 	// connect to the local auth server by default:
 	cfg.Auth.Enabled = true
 	if len(cfg.AuthServers) == 0 {
@@ -154,73 +173,138 @@ func connectToAuthService(cfg *service.Config) (client auth.ClientI, err error) 
 		}
 	}
 
-	identity, err := getIdentity(cfg)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	tlsConfig, err := identity.TLSConfig(cfg.CipherSuites)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	logrus.Debugf("Connecting to auth servers: %v.", cfg.AuthServers)
 
-	client, err = auth.NewTLSClient(auth.ClientConfig{Addrs: cfg.AuthServers, TLS: tlsConfig})
+	// Try connecting to the auth server directly over TLS.
+	client, err := auth.NewTLSClient(auth.ClientConfig{Addrs: cfg.AuthServers, TLS: clientConfig.tlsConfig})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "failed direct dial to auth server: %v", err)
 	}
 
 	// Check connectivity by calling something on the client.
 	_, err = client.GetClusterName()
 	if err != nil {
-		utils.Consolef(os.Stderr, teleport.ComponentClient,
-			"Cannot connect to the auth server: %v.\nIs the auth server running on %v?",
-			err, cfg.AuthServers[0].Addr)
-		os.Exit(1)
+		err = trace.Wrap(err, "failed direct dial to auth server: %v", err)
+		if clientConfig.sshConfig == nil {
+			// No identity file was provided, don't try dialing via a reverse
+			// tunnel on the proxy.
+			return nil, err
+		}
+
+		// If direct dial failed, we may have a proxy address in
+		// cfg.AuthServers. Try connecting to the reverse tunnel endpoint and
+		// make a client over that.
+		//
+		// TODO(awly): this logic should be implemented once, in the auth
+		// package, and reused in IoT nodes.
+
+		errs := []error{err}
+
+		// Figure out the reverse tunnel address on the proxy first.
+		tunAddr, err := findReverseTunnel(ctx, cfg.AuthServers, clientConfig.tlsConfig.InsecureSkipVerify)
+		if err != nil {
+			errs = append(errs, trace.Wrap(err, "failed lookup of proxy reverse tunnel address: %v", err))
+			return nil, trace.NewAggregate(errs...)
+		}
+		// reversetunnel.TunnelAuthDialer will take care of creating a net.Conn
+		// within an SSH tunnel.
+		client, err = auth.NewTLSClient(auth.ClientConfig{
+			Dialer: &reversetunnel.TunnelAuthDialer{
+				ProxyAddr:    tunAddr,
+				ClientConfig: clientConfig.sshConfig,
+			},
+			TLS: clientConfig.tlsConfig,
+		})
+		if err != nil {
+			errs = append(errs, trace.Wrap(err, "failed dial to auth server through reverse tunnel: %v", err))
+			return nil, trace.NewAggregate(errs...)
+		}
+		// Check connectivity by calling something on the client.
+		if _, err := client.GetClusterName(); err != nil {
+			errs = append(errs, trace.Wrap(err, "failed dial to auth server through reverse tunnel: %v", err))
+			return nil, trace.NewAggregate(errs...)
+		}
 	}
 	return client, nil
 }
 
-// getIdentity returns auth.Identity to use when connecting to auth server
-func getIdentity(cfg *service.Config) (*auth.Identity, error) {
-	// If identity was provided in the configuration, use it
-	if len(cfg.Identities) != 0 {
-		return cfg.Identities[0], nil
-	}
-	// Otherwise, assume we're running on the auth node and read the host-local
-	// identity from Teleport data directory
-	identity, err := auth.ReadLocalIdentity(filepath.Join(cfg.DataDir, teleport.ComponentProcess), auth.IdentityID{Role: teleport.RoleAdmin, HostUUID: cfg.HostUUID})
-	if err != nil {
-		// The "admin" identity is not present? This means the tctl is running
-		// NOT on the auth server
-		if trace.IsNotFound(err) {
-			return nil, trace.AccessDenied("tctl must be either used on the auth " +
-				"server or provided with the identity file via --identity flag")
+// findReverseTunnel uses the web proxy to discover where the SSH reverse tunnel
+// server is running.
+func findReverseTunnel(ctx context.Context, addrs []utils.NetAddr, insecureTLS bool) (string, error) {
+	var errs []error
+	for _, addr := range addrs {
+		// In insecure mode, any certificate is accepted. In secure mode the hosts
+		// CAs are used to validate the certificate on the proxy.
+		resp, err := client.Find(ctx, addr.String(), insecureTLS, nil)
+		if err == nil {
+			return tunnelAddr(addr, resp.Proxy)
 		}
-		return nil, trace.Wrap(err)
+		errs = append(errs, err)
 	}
-	return identity, nil
+	return "", trace.NewAggregate(errs...)
+}
+
+// tunnelAddr returns the tunnel address in the following preference order:
+//  1. Reverse Tunnel Public Address.
+//  2. SSH Proxy Public Address.
+//  3. HTTP Proxy Public Address.
+//  4. Tunnel Listen Address.
+func tunnelAddr(webAddr utils.NetAddr, settings client.ProxySettings) (string, error) {
+	// Extract the port the tunnel server is listening on.
+	netAddr, err := utils.ParseHostPortAddr(settings.SSH.TunnelListenAddr, defaults.SSHProxyTunnelListenPort)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	tunnelPort := netAddr.Port(defaults.SSHProxyTunnelListenPort)
+
+	// If a tunnel public address is set, nothing else has to be done, return it.
+	if settings.SSH.TunnelPublicAddr != "" {
+		return settings.SSH.TunnelPublicAddr, nil
+	}
+
+	// If a tunnel public address has not been set, but a related HTTP or SSH
+	// public address has been set, extract the hostname but use the port from
+	// the tunnel listen address.
+	if settings.SSH.SSHPublicAddr != "" {
+		addr, err := utils.ParseHostPortAddr(settings.SSH.SSHPublicAddr, tunnelPort)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		return net.JoinHostPort(addr.Host(), strconv.Itoa(tunnelPort)), nil
+	}
+	if settings.SSH.PublicAddr != "" {
+		addr, err := utils.ParseHostPortAddr(settings.SSH.PublicAddr, tunnelPort)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		return net.JoinHostPort(addr.Host(), strconv.Itoa(tunnelPort)), nil
+	}
+
+	// If nothing is set, fallback to the address we dialed.
+	return net.JoinHostPort(webAddr.Host(), strconv.Itoa(tunnelPort)), nil
 }
 
 // applyConfig takes configuration values from the config file and applies
-// them to 'service.Config' object
-func applyConfig(ccf *GlobalCLIFlags, cfg *service.Config) error {
+// them to 'service.Config' object.
+//
+// The returned authServiceClientConfig has the credentials needed to dial the
+// auth server.
+func applyConfig(ccf *GlobalCLIFlags, cfg *service.Config) (*authServiceClientConfig, error) {
 	// load /etc/teleport.yaml and apply it's values:
 	fileConf, err := config.ReadConfigFile(ccf.ConfigFile)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	// if configuration is passed as an environment variable,
 	// try to decode it and override the config file
 	if ccf.ConfigString != "" {
 		fileConf, err = config.ReadFromString(ccf.ConfigString)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 	if err = config.ApplyFileConfig(fileConf, cfg); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	// --debug flag
 	if ccf.Debug {
@@ -232,7 +316,7 @@ func applyConfig(ccf *GlobalCLIFlags, cfg *service.Config) error {
 	if len(ccf.AuthServerAddr) != 0 {
 		cfg.AuthServers, err = utils.ParseAddrs(ccf.AuthServerAddr)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 	// If auth server is not provided on the command line or in file
@@ -240,27 +324,47 @@ func applyConfig(ccf *GlobalCLIFlags, cfg *service.Config) error {
 	if len(cfg.AuthServers) == 0 {
 		cfg.AuthServers, err = utils.ParseAddrs([]string{defaults.AuthConnectAddr().Addr})
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
+	authConfig := new(authServiceClientConfig)
 	// --identity flag
 	if ccf.IdentityFilePath != "" {
-		key, _, err := common.LoadIdentity(ccf.IdentityFilePath)
+		key, err := common.LoadIdentity(ccf.IdentityFilePath)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
-		identity, err := auth.ReadTLSIdentityFromKeyPair(key.Priv, key.TLSCert, key.TLSCAs())
+
+		authConfig.tlsConfig, err = key.ClientTLSConfig(cfg.CipherSuites)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
-		cfg.Identities = append(cfg.Identities, identity)
+		authConfig.sshConfig, err = key.ClientSSHConfig()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	} else {
 		// read the host UUID only in case the identity was not provided,
 		// because it will be used for reading local auth server identity
 		cfg.HostUUID, err = utils.ReadHostUUID(cfg.DataDir)
 		if err != nil {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
+		}
+		identity, err := auth.ReadLocalIdentity(filepath.Join(cfg.DataDir, teleport.ComponentProcess), auth.IdentityID{Role: teleport.RoleAdmin, HostUUID: cfg.HostUUID})
+		if err != nil {
+			// The "admin" identity is not present? This means the tctl is running
+			// NOT on the auth server
+			if trace.IsNotFound(err) {
+				return nil, trace.AccessDenied("tctl must be either used on the auth server or provided with the identity file via --identity flag")
+			}
+			return nil, trace.Wrap(err)
+		}
+		authConfig.tlsConfig, err = identity.TLSConfig(cfg.CipherSuites)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 	}
-	return nil
+	authConfig.tlsConfig.InsecureSkipVerify = ccf.Insecure
+
+	return authConfig, nil
 }

--- a/tool/tsh/common/identity.go
+++ b/tool/tsh/common/identity.go
@@ -20,13 +20,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
-	"net"
 	"os"
 
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/identityfile"
-	"github.com/gravitational/teleport/lib/sshutils"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -36,22 +34,18 @@ import (
 // LoadIdentity loads the private key + certificate from a file
 // Returns:
 //	 - client key: user's private key+cert
-//   - host auth callback: function to validate the host (may be null)
 //   - error, if something happens when reading the identity file
-//
-// If the "host auth callback" is not returned, user will be prompted to
-// trust the proxy server.
-func LoadIdentity(idFn string) (*client.Key, ssh.HostKeyCallback, error) {
+func LoadIdentity(idFn string) (*client.Key, error) {
 	logrus.Infof("Reading identity file: %v", idFn)
 
 	f, err := os.Open(idFn)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	defer f.Close()
 	ident, err := identityfile.Decode(f)
 	if err != nil {
-		return nil, nil, trace.Wrap(err, "failed to parse identity file")
+		return nil, trace.Wrap(err, "failed to parse identity file")
 	}
 	// did not find the certificate in the file? look in a separate file with
 	// -cert.pub prefix
@@ -60,66 +54,52 @@ func LoadIdentity(idFn string) (*client.Key, ssh.HostKeyCallback, error) {
 		logrus.Infof("Certificate not found in %s. Looking in %s.", idFn, certFn)
 		ident.Certs.SSH, err = ioutil.ReadFile(certFn)
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 	// validate both by parsing them:
 	privKey, err := ssh.ParseRawPrivateKey(ident.PrivateKey)
 	if err != nil {
-		return nil, nil, trace.BadParameter("invalid identity: %s. %v", idFn, err)
+		return nil, trace.BadParameter("invalid identity: %s. %v", idFn, err)
 	}
 	signer, err := ssh.NewSignerFromKey(privKey)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	// validate TLS Cert (if present):
 	if len(ident.Certs.TLS) > 0 {
 		_, err := tls.X509KeyPair(ident.Certs.TLS, ident.PrivateKey)
 		if err != nil {
-			return nil, nil, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 	// Validate TLS CA certs (if present).
 	var trustedCA []auth.TrustedCerts
 	if len(ident.CACerts.TLS) > 0 {
-		var trustedCerts auth.TrustedCerts
+		if len(trustedCA) == 0 {
+			trustedCA = make([]auth.TrustedCerts, 1)
+		}
+		trustedCA[0].TLSCertificates = ident.CACerts.TLS
+
 		pool := x509.NewCertPool()
 		for i, certPEM := range ident.CACerts.TLS {
 			if !pool.AppendCertsFromPEM(certPEM) {
-				return nil, nil, trace.BadParameter("identity file contains invalid TLS CA cert (#%v)", i+1)
+				return nil, trace.BadParameter("identity file contains invalid TLS CA cert (#%v)", i+1)
 			}
-			trustedCerts.TLSCertificates = append(trustedCerts.TLSCertificates, certPEM)
 		}
-		trustedCA = []auth.TrustedCerts{trustedCerts}
 	}
-	var hostAuthFunc ssh.HostKeyCallback = nil
-	// validate CA (cluster) cert
+	// validate CA (cluster) certs
 	if len(ident.CACerts.SSH) > 0 {
-		var trustedKeys []ssh.PublicKey
-		for _, caCert := range ident.CACerts.SSH {
-			_, _, publicKey, _, _, err := ssh.ParseKnownHosts(caCert)
-			if err != nil {
-				return nil, nil, trace.BadParameter("CA cert parsing error: %v. cert line :%v",
-					err.Error(), string(caCert))
-			}
-			trustedKeys = append(trustedKeys, publicKey)
+		if len(trustedCA) == 0 {
+			trustedCA = make([]auth.TrustedCerts, 1)
 		}
+		trustedCA[0].HostCertificates = ident.CACerts.SSH
 
-		// found CA cert in the indentity file? construct the host key checking function
-		// and return it:
-		hostAuthFunc = func(host string, a net.Addr, hostKey ssh.PublicKey) error {
-			clusterCert, ok := hostKey.(*ssh.Certificate)
-			if ok {
-				hostKey = clusterCert.SignatureKey
+		for _, caCert := range ident.CACerts.SSH {
+			_, _, _, _, _, err := ssh.ParseKnownHosts(caCert)
+			if err != nil {
+				return nil, trace.BadParameter("CA cert parsing error: %v. cert line :%v", err.Error(), string(caCert))
 			}
-			for _, trustedKey := range trustedKeys {
-				if sshutils.KeysEqual(trustedKey, hostKey) {
-					return nil
-				}
-			}
-			err = trace.AccessDenied("host %v is untrusted", host)
-			logrus.Error(err)
-			return err
 		}
 	}
 	return &client.Key{
@@ -128,5 +108,5 @@ func LoadIdentity(idFn string) (*client.Key, ssh.HostKeyCallback, error) {
 		Cert:      ident.Certs.SSH,
 		TLSCert:   ident.Certs.TLS,
 		TrustedCA: trustedCA,
-	}, hostAuthFunc, nil
+	}, nil
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -556,7 +556,7 @@ func setupNoninteractiveClient(tc *client.TeleportClient, key *client.Key) error
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	tc.TLS, err = key.ClientTLSConfig()
+	tc.TLS, err = key.ClientTLSConfig(nil)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1021,7 +1021,11 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, erro
 			hostAuthFunc ssh.HostKeyCallback
 		)
 		// read the ID file and create an "auth method" from it:
-		key, hostAuthFunc, err = common.LoadIdentity(cf.IdentityFileIn)
+		key, err = common.LoadIdentity(cf.IdentityFileIn)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		hostAuthFunc, err := key.HostKeyCallback()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1058,7 +1062,7 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, erro
 		}
 
 		if len(key.TLSCert) > 0 {
-			c.TLS, err = key.ClientTLSConfig()
+			c.TLS, err = key.ClientTLSConfig(nil)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1224,7 +1228,7 @@ func authFromIdentity(k *client.Key) (ssh.AuthMethod, error) {
 
 // onShow reads an identity file (a public SSH key or a cert) and dumps it to stdout
 func onShow(cf *CLIConf) {
-	key, _, err := common.LoadIdentity(cf.IdentityFileIn)
+	key, err := common.LoadIdentity(cf.IdentityFileIn)
 	if err != nil {
 		utils.FatalError(err)
 	}


### PR DESCRIPTION
Use the reverse tunnel endpoint, similar to IoT nodes, to connect to the
auth server. Also add an `--insecure` flag, similar to tsh, for testing
with self-signed certs on the proxy.

Fixes https://github.com/gravitational/teleport/issues/3431