### PR TITLE
Backport: etcd: don't confuse prefixes during migration

### DIFF
--- a/examples/etcd/etcdctl.sh
+++ b/examples/etcd/etcdctl.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+HERE=$(readlink -f $0)
+cd $(dirname $HERE)
+
 ETCDCTL_API=3 etcdctl --cacert=./certs/ca-cert.pem --cert=./certs/client-cert.pem  --key=./certs/client-key.pem  --endpoints=https://127.0.0.1:2379 $@
 

--- a/examples/etcd/start-etcd.sh
+++ b/examples/etcd/start-etcd.sh
@@ -7,8 +7,6 @@
 # NOTE: this file is also used to run etcd tests.
 #
 
-EXAMPLES_DIR=$(go env GOPATH)/src/github.com/gravitational/teleport/examples/etcd
-
 HERE=$(readlink -f $0)
 cd $(dirname $HERE)
 
@@ -16,9 +14,9 @@ mkdir -p data
 etcd --name teleportstorage \
      --data-dir data/etcd \
      --initial-cluster-state new \
-     --cert-file=$EXAMPLES_DIR/certs/server-cert.pem \
-     --key-file=$EXAMPLES_DIR/certs/server-key.pem \
-     --trusted-ca-file=$EXAMPLES_DIR/certs/ca-cert.pem \
+     --cert-file certs/server-cert.pem \
+     --key-file certs/server-key.pem \
+     --trusted-ca-file certs/ca-cert.pem \
      --advertise-client-urls=https://127.0.0.1:2379 \
      --listen-client-urls=https://127.0.0.1:2379 \
      --client-cert-auth

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -168,7 +168,7 @@ type Config struct {
 //
 // DELETE IN 4.4: legacy prefix support for migration of
 // https://github.com/gravitational/teleport/issues/2883
-const legacyDefaultPrefix = "/teleport"
+const legacyDefaultPrefix = "/teleport/"
 
 // GetName returns the name of etcd backend as it appears in 'storage/type' section
 // in Teleport YAML file. This function is a part of backend API

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -206,6 +206,11 @@ func (s *EtcdSuite) assertKV(ctx context.Context, c *check.C, key, val string) {
 }
 
 func (s *EtcdSuite) TestSyncLegacyPrefix(c *check.C) {
+	// Stop the watch goroutine to allow us to modify s.bk.cfg.Key without data
+	// races.
+	s.bk.cancel()
+	<-s.bk.watchDone
+
 	ctx := context.Background()
 	s.bk.cfg.Key = customPrefix1
 	c.Assert(s.bk.cfg.Validate(), check.IsNil)


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/4299 to 4.3

Fixes https://github.com/gravitational/teleport/issues/4312