### PR TITLE
Remove retrieving nodes and proxy for cluster details

### DIFF
--- a/lib/web/ui/cluster.go
+++ b/lib/web/ui/cluster.go
@@ -50,9 +50,13 @@ type Cluster struct {
 func NewClusters(remoteClusters []reversetunnel.RemoteSite) ([]Cluster, error) {
 	clusters := []Cluster{}
 	for _, site := range remoteClusters {
-		cluster, err := GetClusterDetails(site)
-		if err != nil {
-			return nil, trace.Wrap(err)
+		// Other fields such as node count, url, and proxy/auth versions are not set
+		// because each cluster will need to make network calls to retrieve information
+		// which does not scale well (ie: 1k clusters, each request will take seconds).
+		cluster := &Cluster{
+			Name:          site.GetName(),
+			LastConnected: site.GetLastConnected(),
+			Status:        site.GetStatus(),
 		}
 
 		clusters = append(clusters, *cluster)


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/4322

#### Description
Remove retrieval of the following when getting cluster list:
- nodes (for counting num nodes)
- proxies (for determining proxy url and version)

### Related PR
https://github.com/gravitational/webapps/pull/148 (merge first)