### PR TITLE
Updated README AMI example to 4.3.5 from 4.2.3

### DIFF
--- a/examples/aws/terraform/README.md
+++ b/examples/aws/terraform/README.md
@@ -33,7 +33,7 @@ export TF_VAR_cluster_name="teleport.example.com"
 # OSS: aws ec2 describe-images --owners 126027368216 --filters 'Name=name,Values=gravitational-teleport-ami-oss*'
 # Enterprise: aws ec2 describe-images --owners 126027368216 --filters 'Name=name,Values=gravitational-teleport-ami-ent*'
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
-export TF_VAR_ami_name="gravitational-teleport-ami-ent-4.2.3"
+export TF_VAR_ami_name="gravitational-teleport-ami-ent-4.3.5"
 
 # AWS SSH key name to provision in installed instances, should be available in the region
 export TF_VAR_key_name="example"


### PR DESCRIPTION
Some clients are copying this in directly and using the 4.2.3 version of the latest 4.3.X version.  Updating