### PR TITLE
proxy: add proxy_ssh_sessions_total metric

### DIFF
--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -50,7 +50,7 @@ var (
 	serverSessions = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: teleport.MetricServerInteractiveSessions,
-			Help: "Number of active sessions",
+			Help: "Number of active sessions to this host",
 		},
 	)
 )

--- a/metrics.go
+++ b/metrics.go
@@ -34,6 +34,9 @@ const (
 	// MetricServerInteractiveSessions measures interactive sessions in flight
 	MetricServerInteractiveSessions = "server_interactive_sessions_total"
 
+	// MetricProxySSHSessions measures sessions in flight on the proxy
+	MetricProxySSHSessions = "proxy_ssh_sessions_total"
+
 	// MetricRemoteClusters measures connected remote clusters
 	MetricRemoteClusters = "remote_clusters"
 


### PR DESCRIPTION
This is similar to `server_interactive_sessions_total`, but tracks all
SSH sessions through a proxy.

Fixes https://github.com/gravitational/teleport/issues/3755