### PR TITLE
Re-add links to enhanced session recording page

### DIFF
--- a/docs/4.2/admin-guide.md
+++ b/docs/4.2/admin-guide.md
@@ -1051,7 +1051,7 @@ the audit log:
    replayed later. The recording is done by the nodes themselves, by default,
    but can be configured to be done by the proxy.
 
-3. **Optional: Enhanced Session Recording**
+3. **Optional: [Enhanced Session Recording](features/enhanced-session-recording.md)**
 
 Refer to the ["Audit Log" chapter in the Teleport
 Architecture](architecture/teleport-auth.md#audit-log) to learn more about how the audit log and

--- a/docs/4.3/admin-guide.md
+++ b/docs/4.3/admin-guide.md
@@ -812,7 +812,7 @@ the audit log:
    replayed later. The recording is done by the nodes themselves, by default,
    but can be configured to be done by the proxy.
 
-3. **Optional: Enhanced Session Recording**
+3. **Optional: [Enhanced Session Recording](features/enhanced-session-recording.md)**
 
 Refer to the ["Audit Log" chapter in the Teleport
 Architecture](architecture/authentication.md#audit-log) to learn more about how the audit log and


### PR DESCRIPTION
There is a link to the enhanced session recording page in the config file reference in the admin guide, but we removed the config file reference with 4.3 and moved it to a separate section. Added a link back in so it's easier to find the page.