### PR TITLE
Update docs aws terraform ami example to 4.3.5 from 4.2.3

### DIFF
--- a/docs/4.3/aws-terraform-guide.md
+++ b/docs/4.3/aws-terraform-guide.md
@@ -154,11 +154,11 @@ cluster from scratch, so choose carefully.
 
 ### ami_name
 
-Setting `export TF_VAR_ami_name="gravitational-teleport-ami-ent-4.3.5"`
+Setting `export TF_VAR_ami_name="gravitational-teleport-ami-ent-{{ teleport.version }}"`
 
 Gravitational automatically builds and publishes OSS, Enterprise and Enterprise FIPS 140-2 AMIs when we
 release a new version of Teleport. The AMI names follow the format: `gravitational-teleport-ami-<type>-<version>`
-where `<type>` is either `oss` or `ent` (Enterprise) and `version` is the version of Teleport e.g. `4.3.5`.
+where `<type>` is either `oss` or `ent` (Enterprise) and `version` is the version of Teleport e.g. `{{ teleport.version }}`.
 
 FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix.
 

--- a/docs/4.3/aws-terraform-guide.md
+++ b/docs/4.3/aws-terraform-guide.md
@@ -154,11 +154,11 @@ cluster from scratch, so choose carefully.
 
 ### ami_name
 
-Setting `export TF_VAR_ami_name="gravitational-teleport-ami-ent-4.2.3"`
+Setting `export TF_VAR_ami_name="gravitational-teleport-ami-ent-4.3.5"`
 
 Gravitational automatically builds and publishes OSS, Enterprise and Enterprise FIPS 140-2 AMIs when we
 release a new version of Teleport. The AMI names follow the format: `gravitational-teleport-ami-<type>-<version>`
-where `<type>` is either `oss` or `ent` (Enterprise) and `version` is the version of Teleport e.g. `4.2.3`.
+where `<type>` is either `oss` or `ent` (Enterprise) and `version` is the version of Teleport e.g. `4.3.5`.
 
 FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix.
 


### PR DESCRIPTION
updating ami version as done in the github README for the AWS terraform example.