### PR TITLE
Add pem_permit.so as last required item in the session PAM section

### DIFF
--- a/docs/4.2/features/ssh-pam.md
+++ b/docs/4.2/features/ssh-pam.md
@@ -242,6 +242,7 @@ Start by creating a file `/etc/pam.d/teleport` with the following contents:
 ```bash
 account   required   pam_exec.so /etc/pam-exec.d/teleport_acct
 session   required   pam_motd.so
+session   required   pam_permit.so
 ```
 
 !!! Note

--- a/docs/4.3/features/ssh-pam.md
+++ b/docs/4.3/features/ssh-pam.md
@@ -246,6 +246,7 @@ Start by creating a file `/etc/pam.d/teleport` with the following contents:
 ```bash
 account   required   pam_exec.so /etc/pam-exec.d/teleport_acct
 session   required   pam_motd.so
+session   required   pam_permit.so
 ```
 
 !!! Note


### PR DESCRIPTION
Signed-off-by: Vlad Ungureanu <vladu@palantir.com>

`pam_motd.so` has the default return value of `PAM_IGNORE` and default behavior of `libpam` is to deny access if there is only one entry in the `session` section. Adding `pam_permit.so` as the last one so it falls through.

props to @awly for discovering this.