### PR TITLE
Add/Implement node join token endpoint

### DIFF
--- a/lib/web/ui/token.go
+++ b/lib/web/ui/token.go
@@ -29,3 +29,12 @@ type ResetPasswordToken struct {
 	// Expiry is token expiration time
 	Expiry time.Time `json:"expiry,omitempty"`
 }
+
+// NodeJoinToken contains node token fields for the UI.
+type NodeJoinToken struct {
+	// TokenID is token ID.
+	TokenID string `json:"tokenId"`
+	// Expires is when the token will expire,
+	// ie: "4h" means expires in 4 hours.
+	Expires string `json:"expires"`
+}

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -43,6 +43,8 @@ type userACL struct {
 	TrustedClusters access `json:"trustedClusters"`
 	// Events defines access to audit logs
 	Events access `json:"events"`
+	// Tokens defines access to creating tokens ie: node join token.
+	Tokens access `json:"nodeToken"`
 	// SSH defines access to servers
 	SSHLogins []string `json:"sshLogins"`
 }
@@ -118,6 +120,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 	trustedClusterAccess := newAccess(userRoles, ctx, services.KindTrustedCluster)
 	eventAccess := newAccess(userRoles, ctx, services.KindEvent)
 	userAccess := newAccess(userRoles, ctx, services.KindUser)
+	tokenAccess := newAccess(userRoles, ctx, services.KindToken)
 	logins := getLogins(userRoles)
 
 	acl := userACL{
@@ -128,6 +131,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 		Events:          eventAccess,
 		SSHLogins:       logins,
 		Users:           userAccess,
+		Tokens:          tokenAccess,
 	}
 
 	// local user

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -68,6 +68,7 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Sessions, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Roles, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Users, check.DeepEquals, denied)
+	c.Assert(userContext.ACL.Tokens, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
 
 	// test local auth type


### PR DESCRIPTION
resolves https://github.com/gravitational/cloud/issues/77

#### Description
- Add a `Tokens` field to `userACL` struct to define a users access to creating tokens
- Create an endpoint for creating node join token
- Implement endpoint to return a token and expiry time
- Unit tested (refactored some functions for reusability)