### PR TITLE
Fix SSH examples in Terraform guides

### DIFF
--- a/docs/4.2/aws-terraform-guide.md
+++ b/docs/4.2/aws-terraform-guide.md
@@ -450,7 +450,7 @@ $ echo ${AUTH_IP}
 [`key_name`](#key_name) variable is available in the current directory, or update the `-i` parameter to point to it:
 
 ```bash
-$ ssh -i ${TF_VAR_key_name}.pem -J ec2-user@${BASTION_IP} ec2-user@${AUTH_IP}
+$ ssh -i ${TF_VAR_key_name}.pem -o ProxyCommand="ssh -i ${TF_VAR_key_name}.pem -W '[%h]:%p' ec2-user@${BASTION_IP}" ec2-user@${AUTH_IP}
 The authenticity of host '1.2.3.4 (1.2.3.4)' can't be established.
 ECDSA key fingerprint is SHA256:vFPnCFliRsRQ1Dk+muIv2B1Owm96hXiihlOUsj5H3bg.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
@@ -843,7 +843,7 @@ elif [[ "${INSTANCE_TYPE}" == "node" ]]; then
 fi
 
 echo "Keypair name: ${TF_VAR_key_name}"
-ssh -i ${TF_VAR_key_name}.pem -J ec2-user@${BASTION_IP} ec2-user@${SERVER_IP}
+ssh -i ${TF_VAR_key_name}.pem -o ProxyCommand="ssh -i ${TF_VAR_key_name}.pem -W '[%h]:%p' ec2-user@${BASTION_IP}" ec2-user@${SERVER_IP}
 ```
 
 Save this as `connect.sh`, run `chmod +x connect.sh` to make it executable, then use it like so:

--- a/docs/4.3/aws-terraform-guide.md
+++ b/docs/4.3/aws-terraform-guide.md
@@ -456,7 +456,7 @@ $ echo ${AUTH_IP}
 [`key_name`](#key_name) variable is available in the current directory, or update the `-i` parameter to point to it:
 
 ```bash
-$ ssh -i ${TF_VAR_key_name}.pem -J ec2-user@${BASTION_IP} ec2-user@${AUTH_IP}
+$ ssh -i ${TF_VAR_key_name}.pem -o ProxyCommand="ssh -i ${TF_VAR_key_name}.pem -W '[%h]:%p' ec2-user@${BASTION_IP}" ec2-user@${AUTH_IP}
 The authenticity of host '1.2.3.4 (1.2.3.4)' can't be established.
 ECDSA key fingerprint is SHA256:vFPnCFliRsRQ1Dk+muIv2B1Owm96hXiihlOUsj5H3bg.
 Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
@@ -836,7 +836,7 @@ elif [[ "${INSTANCE_TYPE}" == "node" ]]; then
 fi
 
 echo "Keypair name: ${TF_VAR_key_name}"
-ssh -i ${TF_VAR_key_name}.pem -J ec2-user@${BASTION_IP} ec2-user@${SERVER_IP}
+ssh -i ${TF_VAR_key_name}.pem -o ProxyCommand="ssh -i ${TF_VAR_key_name}.pem -W '[%h]:%p' ec2-user@${BASTION_IP}" ec2-user@${SERVER_IP}
 ```
 
 Save this as `connect.sh`, run `chmod +x connect.sh` to make it executable, then use it like so:


### PR DESCRIPTION
As pointed out by @stevenGravy, using `-J` to go via an SSH jumphost doesn't work if you're providing the key file on the command line with the `-i` argument - it requires the key to be loaded into the running `ssh-agent`.

This makes the examples work with a key file without requiring `ssh-agent`.