### PR TITLE
Add benches for GetNodes and GetClusterDetails

### DIFF
--- a/lib/services/local/perf_test.go
+++ b/lib/services/local/perf_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/lite"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// BenchmarkGetNodes verifies the performance of the GetNodes operation
+// on local (sqlite) databases (as used by the cache system).
+func BenchmarkGetNodes(b *testing.B) {
+
+	type testCase struct {
+		validation, memory bool
+		nodes              int
+	}
+
+	var tts []testCase
+
+	for _, validation := range []bool{true, false} {
+		for _, memory := range []bool{true, false} {
+			for _, nodes := range []int{100, 1000, 10000} {
+				tts = append(tts, testCase{
+					validation: validation,
+					memory:     memory,
+					nodes:      nodes,
+				})
+			}
+		}
+	}
+
+	for _, tt := range tts {
+		// create a descriptive name for the sub-benchmark.
+		name := fmt.Sprintf("tt(validation=%v,memory=%v,nodes=%d)", tt.validation, tt.memory, tt.nodes)
+
+		// run the sub benchmark
+		b.Run(name, func(sb *testing.B) {
+
+			sb.StopTimer() // stop timer while running setup
+
+			// set up marshal options
+			var opts []services.MarshalOption
+			if !tt.validation {
+				opts = append(opts, services.SkipValidation())
+			}
+
+			// configure the backend instance
+			var bk backend.Backend
+			var err error
+			if tt.memory {
+				bk, err = memory.New(memory.Config{})
+				assert.NoError(b, err)
+			} else {
+				dir, err := ioutil.TempDir("", "teleport")
+				assert.NoError(b, err)
+				defer os.RemoveAll(dir)
+
+				bk, err = lite.NewWithConfig(context.TODO(), lite.Config{
+					Path: dir,
+				})
+				assert.NoError(b, err)
+			}
+			defer bk.Close()
+
+			svc := NewPresenceService(bk)
+			// seed the test nodes
+			insertNodes(b, svc, tt.nodes)
+
+			sb.StartTimer() // restart timer for benchmark operations
+
+			benchmarkGetNodes(sb, svc, tt.nodes, opts...)
+
+			sb.StopTimer() // stop timer to exclude deferred cleanup
+		})
+	}
+}
+
+// insertNodes inserts a collection of test nodes into a backend.
+func insertNodes(t assert.TestingT, svc services.Presence, nodeCount int) {
+	const labelCount = 10
+	labels := make(map[string]string, labelCount)
+	for i := 0; i < labelCount; i++ {
+		labels[fmt.Sprintf("label-key-%d", i)] = fmt.Sprintf("label-val-%d", i)
+	}
+	for i := 0; i < nodeCount; i++ {
+		name, addr := fmt.Sprintf("node-%d", i), fmt.Sprintf("node%d.example.com", i)
+		node := &services.ServerV2{
+			Kind:    services.KindNode,
+			Version: services.V2,
+			Metadata: services.Metadata{
+				Name:      name,
+				Namespace: defaults.Namespace,
+				Labels:    labels,
+			},
+			Spec: services.ServerSpecV2{
+				Addr:       addr,
+				PublicAddr: addr,
+			},
+		}
+		_, err := svc.UpsertNode(node)
+		assert.NoError(t, err)
+	}
+}
+
+// benchmarkGetNodes runs GetNodes b.N times.
+func benchmarkGetNodes(b *testing.B, svc services.Presence, nodeCount int, opts ...services.MarshalOption) {
+	var nodes []services.Server
+	var err error
+	for i := 0; i < b.N; i++ {
+		nodes, err = svc.GetNodes(defaults.Namespace, opts...)
+		assert.NoError(b, err)
+	}
+	// do *something* with the loop result.  probably unnecessary since the loop
+	// contains I/O, but I don't know enough about the optimizer to be 100% certain
+	// about that.
+	assert.Equal(b, nodeCount, len(nodes))
+}

--- a/lib/web/ui/cluster.go
+++ b/lib/web/ui/cluster.go
@@ -84,13 +84,13 @@ func NewClustersFromRemote(remoteClusters []services.RemoteCluster) ([]Cluster, 
 }
 
 // GetClusterDetails retrieves and sets details about a cluster
-func GetClusterDetails(site reversetunnel.RemoteSite) (*Cluster, error) {
+func GetClusterDetails(site reversetunnel.RemoteSite, opts ...services.MarshalOption) (*Cluster, error) {
 	clt, err := site.CachingAccessPoint()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	nodes, err := clt.GetNodes(defaults.Namespace)
+	nodes, err := clt.GetNodes(defaults.Namespace, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/ui/perf_test.go
+++ b/lib/web/ui/perf_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ui
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/lite"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+const clusterName = "bench.example.com"
+
+func BenchmarkGetClusterDetails(b *testing.B) {
+	const authCount = 6
+	const proxyCount = 6
+
+	type testCase struct {
+		validation, memory bool
+		nodes              int
+	}
+
+	var tts []testCase
+
+	for _, validation := range []bool{true, false} {
+		for _, memory := range []bool{true, false} {
+			for _, nodes := range []int{100, 1000, 10000} {
+				tts = append(tts, testCase{
+					validation: validation,
+					memory:     memory,
+					nodes:      nodes,
+				})
+			}
+		}
+	}
+
+	for _, tt := range tts {
+		// create a descriptive name for the sub-benchmark.
+		name := fmt.Sprintf("tt(validation=%v,memory=%v,nodes=%d)", tt.validation, tt.memory, tt.nodes)
+
+		// run the sub benchmark
+		b.Run(name, func(sb *testing.B) {
+
+			sb.StopTimer() // stop timer while running setup
+
+			// set up marshal options
+			var opts []services.MarshalOption
+			if !tt.validation {
+				opts = append(opts, services.SkipValidation())
+			}
+
+			// configure the backend instance
+			var bk backend.Backend
+			var err error
+			if tt.memory {
+				bk, err = memory.New(memory.Config{})
+				assert.NoError(b, err)
+			} else {
+				dir, err := ioutil.TempDir("", "teleport")
+				assert.NoError(b, err)
+				defer os.RemoveAll(dir)
+
+				bk, err = lite.NewWithConfig(context.TODO(), lite.Config{
+					Path: dir,
+				})
+				assert.NoError(b, err)
+			}
+			defer bk.Close()
+
+			svc := local.NewPresenceService(bk)
+
+			// seed the test nodes
+			insertServers(b, svc, services.KindNode, tt.nodes)
+			insertServers(b, svc, services.KindProxy, proxyCount)
+			insertServers(b, svc, services.KindAuthServer, authCount)
+
+			site := &mockRemoteSite{
+				accessPoint: &mockAccessPoint{
+					presence: svc,
+				},
+			}
+
+			sb.StartTimer() // restart timer for benchmark operations
+
+			benchmarkGetClusterDetails(sb, site, tt.nodes, opts...)
+
+			sb.StopTimer() // stop timer to exclude deferred cleanup
+		})
+	}
+}
+
+// insertServers inserts a collection of servers into a backend.
+func insertServers(t assert.TestingT, svc services.Presence, kind string, count int) {
+	const labelCount = 10
+	labels := make(map[string]string, labelCount)
+	for i := 0; i < labelCount; i++ {
+		labels[fmt.Sprintf("label-key-%d", i)] = fmt.Sprintf("label-val-%d", i)
+	}
+	for i := 0; i < count; i++ {
+		name := uuid.New()
+		addr := fmt.Sprintf("%s.%s", name, clusterName)
+		server := &services.ServerV2{
+			Kind:    kind,
+			Version: services.V2,
+			Metadata: services.Metadata{
+				Name:      name,
+				Namespace: defaults.Namespace,
+				Labels:    labels,
+			},
+			Spec: services.ServerSpecV2{
+				Addr:       addr,
+				PublicAddr: addr,
+				Version:    teleport.Version,
+			},
+		}
+		var err error
+		switch kind {
+		case services.KindNode:
+			_, err = svc.UpsertNode(server)
+		case services.KindProxy:
+			err = svc.UpsertProxy(server)
+		case services.KindAuthServer:
+			err = svc.UpsertAuthServer(server)
+		default:
+			t.Errorf("Unexpected server kind: %s", kind)
+		}
+		assert.NoError(t, err)
+	}
+}
+
+func benchmarkGetClusterDetails(b *testing.B, site reversetunnel.RemoteSite, nodes int, opts ...services.MarshalOption) {
+	var cluster *Cluster
+	var err error
+	for i := 0; i < b.N; i++ {
+		cluster, err = GetClusterDetails(site, opts...)
+		assert.NoError(b, err)
+	}
+	assert.NotNil(b, cluster)
+	assert.Equal(b, nodes, cluster.NodeCount)
+}
+
+type mockRemoteSite struct {
+	reversetunnel.RemoteSite
+	accessPoint auth.AccessPoint
+}
+
+func (m *mockRemoteSite) CachingAccessPoint() (auth.AccessPoint, error) {
+	return m.accessPoint, nil
+}
+
+func (m *mockRemoteSite) GetName() string {
+	return clusterName
+}
+
+func (m *mockRemoteSite) GetLastConnected() time.Time {
+	return time.Now()
+}
+
+func (m *mockRemoteSite) GetStatus() string {
+	return teleport.RemoteClusterStatusOnline
+}
+
+type mockAccessPoint struct {
+	auth.AccessPoint
+	presence *local.PresenceService
+}
+
+func (m *mockAccessPoint) GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error) {
+	return m.presence.GetNodes(namespace, opts...)
+}
+
+func (m *mockAccessPoint) GetProxies() ([]services.Server, error) {
+	return m.presence.GetProxies()
+}
+
+func (m *mockAccessPoint) GetAuthServers() ([]services.Server, error) {
+	return m.presence.GetAuthServers()
+}


### PR DESCRIPTION
Adds simple benchmarks which evaluate the performance of `GetNodes` and `GetClusterDetails` against `lite` and `in-memory` backends both with and without validation.  All benchmarks are run with `10k` nodes.

The goal of this is to provide better insight into #4322.

Here is a typical output on my dev box (i7/16gb):

```
BenchmarkGetNodes/tt(validation=true,memory=true,nodes=100)-8         	      34	  32473238 ns/op
BenchmarkGetNodes/tt(validation=true,memory=true,nodes=1000)-8        	       3	 339247768 ns/op
BenchmarkGetNodes/tt(validation=true,memory=true,nodes=10000)-8       	       1	3138642395 ns/op
BenchmarkGetNodes/tt(validation=true,memory=false,nodes=100)-8        	      36	  32590363 ns/op
BenchmarkGetNodes/tt(validation=true,memory=false,nodes=1000)-8       	       4	 316626610 ns/op
BenchmarkGetNodes/tt(validation=true,memory=false,nodes=10000)-8      	       1	3198807945 ns/op
BenchmarkGetNodes/tt(validation=false,memory=true,nodes=100)-8        	     716	   1479543 ns/op
BenchmarkGetNodes/tt(validation=false,memory=true,nodes=1000)-8       	      75	  14975820 ns/op
BenchmarkGetNodes/tt(validation=false,memory=true,nodes=10000)-8      	       7	 153797438 ns/op
BenchmarkGetNodes/tt(validation=false,memory=false,nodes=100)-8       	     645	   1817183 ns/op
BenchmarkGetNodes/tt(validation=false,memory=false,nodes=1000)-8      	      67	  17765981 ns/op
BenchmarkGetNodes/tt(validation=false,memory=false,nodes=10000)-8     	       6	 181457618 ns/op
```
```
BenchmarkGetClusterDetails/tt(validation=true,memory=true,nodes=100)-8         	      33	  33961582 ns/op
BenchmarkGetClusterDetails/tt(validation=true,memory=true,nodes=1000)-8        	       3	 343550440 ns/op
BenchmarkGetClusterDetails/tt(validation=true,memory=true,nodes=10000)-8       	       1	3169219665 ns/op
BenchmarkGetClusterDetails/tt(validation=true,memory=false,nodes=100)-8        	      36	  33198960 ns/op
BenchmarkGetClusterDetails/tt(validation=true,memory=false,nodes=1000)-8       	       4	 314592800 ns/op
BenchmarkGetClusterDetails/tt(validation=true,memory=false,nodes=10000)-8      	       1	3183693461 ns/op
BenchmarkGetClusterDetails/tt(validation=false,memory=true,nodes=100)-8        	     685	   1659939 ns/op
BenchmarkGetClusterDetails/tt(validation=false,memory=true,nodes=1000)-8       	      78	  15109309 ns/op
BenchmarkGetClusterDetails/tt(validation=false,memory=true,nodes=10000)-8      	       7	 154426517 ns/op
BenchmarkGetClusterDetails/tt(validation=false,memory=false,nodes=100)-8       	     528	   2182579 ns/op
BenchmarkGetClusterDetails/tt(validation=false,memory=false,nodes=1000)-8      	      67	  18101743 ns/op
BenchmarkGetClusterDetails/tt(validation=false,memory=false,nodes=10000)-8     	       6	 193907948 ns/op
```

Note that the addition of json-schema validation accounts for an approximately 18X increase in runtime for an otherwise equivalent case, and json-schema validation *was* active for #4322.

Given the fact that the above benchmarks are running a simplified approximation of the `CachingAccessPoint` on a machine that is under no other load, I think it is easy to see how a large cluster could take multiple seconds for all of its nodes to be loaded and validated (a 10k cluster takes >3 seconds even under the optimistic conditions of these benchmarks).

Based on the above findings, I did make one tweak to remove validation from the remaining call to `GetClusterDetails`, but I think these benchmarks make a good case for phasing out json-schema entirely when we have the time.  We've already stopped using schema validation on writes, meaning that any errors that schema validation *does* catch result in teleport entering a bad state since the errors emerge when *reading* data that is already in the backend.  The `CheckAndSetDefault` methods are significantly more performant, and generally superior since they allow us to perform validation independent of serialization format.