### PR TITLE
Allow IoT mode proxies

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -923,9 +923,11 @@ func (i *TeleInstance) Start() error {
 		expectedEvents = append(expectedEvents, service.AuthTLSReady)
 	}
 	if i.Config.Proxy.Enabled {
-		expectedEvents = append(expectedEvents, service.ProxyReverseTunnelReady)
+		if !i.Config.Proxy.DisableReverseTunnel {
+			expectedEvents = append(expectedEvents, service.ProxyReverseTunnelReady)
+			expectedEvents = append(expectedEvents, service.ProxyAgentPoolReady)
+		}
 		expectedEvents = append(expectedEvents, service.ProxySSHReady)
-		expectedEvents = append(expectedEvents, service.ProxyAgentPoolReady)
 		if !i.Config.Proxy.DisableWebService {
 			expectedEvents = append(expectedEvents, service.ProxyWebServerReady)
 		}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -792,11 +792,6 @@ func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity 
 	log.Debugf("Attempting to connect to Auth Server directly.")
 	_, err = directClient.GetLocalClusterName()
 	if err != nil {
-		// Only attempt to connect through the proxy for nodes.
-		if identity.ID.Role != teleport.RoleNode {
-			return nil, trace.Unwrap(err)
-		}
-
 		log.Debugf("Attempting to connect to Auth Server through tunnel.")
 		tunnelClient, err := process.newClientThroughTunnel(authServers, identity)
 		if err != nil {


### PR DESCRIPTION
The client-side check in teleport process registration with auth-server
was assuming that only IoT nodes can join this way.

For Kubernetes, we need proxies to connect the same way, when running
inside restricted Kubernetes clusters.

Updates https://github.com/gravitational/teleport/issues/3952
Updates https://github.com/gravitational/teleport/issues/3667