### PR TITLE
Fix teleport-buildbox docker image name in Dockerfile.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # The base image (buildbox:latest) is built by running `make -C build.assets`
 # from the base repo directory $GOPATH/gravitational.com/teleport
-FROM teleport-buildbox:go1.14.4
+FROM quay.io/gravitational/teleport-buildbox:go1.14.4
 RUN apt-get update
 # DEBUG=1 is needed for the Web UI to be loaded from static assets instead
 # of the binary


### PR DESCRIPTION
There was a change to the teleport-buildbox image name that wasn't reflected in the Dockerfile for local deployment, which caused `make build` in the docker directory to fail.

Fixes #4365