### PR TITLE
Update HA docs

### DIFF
--- a/docs/4.3/config-reference.md
+++ b/docs/4.3/config-reference.md
@@ -70,9 +70,12 @@ teleport:
         # By default teleport uses the `data_dir` directory on a local filesystem
         type: dir
 
-        # Array of locations where the audit log events will be stored. by
-        # default they are stored in `/var/lib/teleport/log`
-        audit_events_uri: ['file:///var/lib/teleport/log', 'dynamodb://events_table_name', 'firestore://events_table_name', 'stdout://']
+        # List of locations where the audit log events will be stored. By default,
+        # they are stored in `/var/lib/teleport/log`
+        # When specifying multiple destinations like this, make sure that any highly-available
+        # storage methods (like DynamoDB or Firestore) are specified first, as this is what the
+        # Teleport web UI uses as its source of events to display.
+        audit_events_uri: ['dynamodb://events_table_name', 'firestore://events_table_name', 'file:///var/lib/teleport/log', 'stdout://']
 
         # Use this setting to configure teleport to store the recorded sessions in
         # an AWS S3 bucket or use GCP Storage with 'gs://'. See "Using Amazon S3"


### PR DESCRIPTION
- Reordered `audit_events_uri` entries to make sure that the HA destination is always listed first in the examples - this prevents a reported issue where audit events don't appear in the web UI after a restart.
- Added notes about making sure HA destinations always appear first
- Added a warning explaining that `etcd` can't be used to store audit events after this was pointed out.
- Added missing mentions of Firestore where etcd and DynamoDB appeared.