### PR TITLE
Add output options for `tsh ls`

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -297,6 +297,9 @@ const (
 	// Text means text serialization format
 	Text = "text"
 
+	// Names is for formatting node names in plain text
+	Names = "names"
+
 	// LinuxAdminGID is the ID of the standard adm group on linux
 	LinuxAdminGID = 4
 


### PR DESCRIPTION
Changes:
- New flag --output for `tsh ls` - possible values are `json`, `names`, `text` (default)
- Refactored node printing functions and logic to be simpler and more readable

Additional notes: 
 - `tsh ls` will ignore `-v` if --output is provided, unless output=table (default)
 - an error will be returned if an invalid output is provided

resolves #3660 
Related: #1696