### PR TITLE
Backport: DynamoDB respect HTTP Connect proxies (#4271)

### DIFF
--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -222,6 +222,7 @@ func New(ctx context.Context, params backend.Params) (*DynamoDBBackend, error) {
 	// handshakes performed.
 	httpClient := &http.Client{
 		Transport: &http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
 			MaxIdleConns:        defaults.HTTPMaxIdleConns,
 			MaxIdleConnsPerHost: defaults.HTTPMaxIdleConnsPerHost,
 		},


### PR DESCRIPTION
* DynamoDB: Build http transport from defaults before manipulating parameters, this allows the transport to be pre-populated with proxy information if set by HTTPS_PROXY/NO_PROXY environment variables.

Backport of https://github.com/gravitational/teleport/pull/4271 into 4.3