### PR TITLE
Release 4.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.2.12
+
+This release of Teleport contains a security fix.
+
+* Mitigated [CVE-2020-15216](https://nvd.nist.gov/vuln/detail/CVE-2020-15216) by updating github.com/russellhaering/goxmldsig.
+
 ## 4.2.11
 
 This release of Teleport contains multiple bug fixes.
@@ -1235,7 +1241,7 @@ This release focus was to increase Teleport user experience in the following are
 
 Teleport 2.0.5 contains a variety of security fixes. We strongly encourage anyone running Teleport 2.0.0 and above to upgrade to 2.0.5.
 
-The most pressing issues (a phishing attack which can potentially be used to extract plaintext credentials and an attack where an already authenticated user can escalate privileges) can be resolved by upgrading the web proxy. However, however all nodes need to be upgraded to mitigate all vulnerabilities. 
+The most pressing issues (a phishing attack which can potentially be used to extract plaintext credentials and an attack where an already authenticated user can escalate privileges) can be resolved by upgrading the web proxy. However, however all nodes need to be upgraded to mitigate all vulnerabilities.
 
 ### Bugfixes
 
@@ -1379,8 +1385,8 @@ certificates did not work correctly in this release due to #529
 ### Bugfixes
 
 * Wrong url to register new users. #497
-* Logged in users inherit Teleport supplemental groups bug security. #507 
-* Joining a session running on a trusted cluster does not work. #504 
+* Logged in users inherit Teleport supplemental groups bug security. #507
+* Joining a session running on a trusted cluster does not work. #504
 
 ## 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This release of Teleport contains a security fix.
 
 * Mitigated [CVE-2020-15216](https://nvd.nist.gov/vuln/detail/CVE-2020-15216) by updating github.com/russellhaering/goxmldsig.
 
+### Details
+A vulnerability was discovered in the `github.com/russellhaering/goxmldsig` library which is used by Teleport to validate the
+signatures of XML files used to configure SAML 2.0 connectors. With a carefully crafted XML file, an attacker can completely
+bypass XML signature validation and pass off an altered file as a signed one.
+
+### Actions
+The `goxmldsig` library has been updated upstream and Teleport 4.2.12 includes the fix. Any Enterprise SSO users using Okta,
+Active Directory, OneLogin or custom SAML connectors should upgrade their auth servers to version 4.2.12 and restart Teleport.
+
+If you are unable to upgrade immediately, we suggest deleting SAML connectors for all clusters until the updates can be applied.
+
 ## 4.2.11
 
 This release of Teleport contains multiple bug fixes.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.2.11
+VERSION=4.2.12
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.2.11"
+	Version = "4.2.12"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
## 4.2.12

This release of Teleport contains a security fix.

* Mitigated [CVE-2020-15216](https://nvd.nist.gov/vuln/detail/CVE-2020-15216) by updating github.com/russellhaering/goxmldsig.

### Details
A vulnerability was discovered in the `github.com/russellhaering/goxmldsig` library which is used by Teleport to validate the
signatures of XML files used to configure SAML 2.0 connectors. With a carefully crafted XML file, an attacker can completely
bypass XML signature validation and pass off an altered file as a signed one.

### Actions
The `goxmldsig` library has been updated upstream and Teleport 4.2.12 includes the fix. Any Enterprise SSO users using Okta,
Active Directory, OneLogin or custom SAML connectors should upgrade their auth servers to version 4.2.12 and restart Teleport.

If you are unable to upgrade immediately, we suggest deleting SAML connectors for all clusters until the updates can be applied.