### PR TITLE
Add higher LimitNOFILE limit to Teleport unit file

### DIFF
--- a/examples/systemd/teleport.service
+++ b/examples/systemd/teleport.service
@@ -9,6 +9,7 @@ EnvironmentFile=-/etc/default/teleport
 ExecStart=/usr/local/bin/teleport start --pid-file=/run/teleport.pid
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/run/teleport.pid
+LimitNOFILE=8192
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Several customers with larger clusters have reported that Teleport runs out of file descriptors when lots of nodes connect. The default limit is 1024, so I figure increasing this by a factor of 8 should prevent this issue in many cases. It also adds an obvious hint in the unit file that "this is where you should change the open file limit", as `systemd` doesn't care about anything you set in `/etc/security/limits.conf` or `/etc/security/limits.d`.