### PR TITLE
Run k8s integration tests in Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -129,14 +129,14 @@ steps:
       - chown -R $UID:$GID /go
       - cd /go/src/github.com/gravitational/teleport
       # write kubeconfig to disk for use in kube_integration_test
-      - echo "$INTEGRATION_CI_KUBECONFIG" > /tmp/kubeconfig
+      - echo "$INTEGRATION_CI_KUBECONFIG" > /kubeconfig.ci
       # TOOD(gus): uncomment after testing
       #- make -C build.assets integration
-      - ls -l /tmp
+      - ls -l /
       - |
         docker run --rm=true -v "$(pwd)/":/go/src/github.com/gravitational/teleport \
         -v /tmp:/tmp -w /go/src/github.com/gravitational/teleport -h buildbox \
-        -v /tmp/kubeconfig:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true \
+        -v /kubeconfig.ci:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true \
         -v "$(pwd)/bcc:/usr/include/bcc" -u $(id -u):$(id -g) -t quay.io/gravitational/teleport-buildbox:go1.14.4 \
         /bin/bash -c "ls -l /mnt/kube && ls -l /mnt/kube/config && go test ./integration/... -v -cover -check.f=TestKube"
 
@@ -2800,6 +2800,6 @@ volumes:
 
 ---
 kind: signature
-hmac: f4a253f94f078ea85c2a9738fd70d9e402cd92a42683f958f2aaf7d46729a1f1
+hmac: 99261305f4441b9ce8c77471c75a012ca5aa18e4d206b34dd3b6825b3ab7f8a7
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -119,8 +119,8 @@ steps:
       GOPATH: /go
       INTEGRATION_CI_KUBECONFIG:
         from_secret: INTEGRATION_CI_KUBECONFIG
-      #KUBECONFIG: /mnt/kube/config
-      #TEST_KUBE: true
+      KUBECONFIG: /go/kubeconfig.ci
+      TEST_KUBE: true
     volumes:
       - name: dockersock
         path: /var/run
@@ -2800,6 +2800,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 842c838ac45aae7d714b736d164612e0bdf3212c913d44741686f5edee28de73
+hmac: 4f71245ab61a41f45090e94e76fb34bd1260a57e8687a4af95a289e536d731b4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -130,9 +130,8 @@ steps:
       - echo "$INTEGRATION_CI_KUBECONFIG" > /go/kubeconfig.ci
       - chown -R $UID:$GID /go
       - cd /go/src/github.com/gravitational/teleport
-      # TOOD(gus): uncomment after testing
+      # TOOD(gus): uncomment/remove after testing
       #- make -C build.assets integration
-      - ls -l /go
       - |
         docker run --rm=true -v "$(pwd)/":/go/src/github.com/gravitational/teleport \
         -v /tmp:/tmp -w /go/src/github.com/gravitational/teleport -h buildbox \
@@ -2801,6 +2800,6 @@ volumes:
 
 ---
 kind: signature
-hmac: cc4343de57122bfe006c151620c7a75466cb56ba0fb8aa99e8faad26652893cd
+hmac: 842c838ac45aae7d714b736d164612e0bdf3212c913d44741686f5edee28de73
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -119,8 +119,8 @@ steps:
       GOPATH: /go
       INTEGRATION_CI_KUBECONFIG:
         from_secret: INTEGRATION_CI_KUBECONFIG
-      KUBECONFIG: /mnt/kube/config
-      TEST_KUBE: true
+      #KUBECONFIG: /mnt/kube/config
+      #TEST_KUBE: true
     volumes:
       - name: dockersock
         path: /var/run
@@ -129,15 +129,16 @@ steps:
       - chown -R $UID:$GID /go
       - cd /go/src/github.com/gravitational/teleport
       # write kubeconfig to disk for use in kube_integration_test
-      - echo "$INTEGRATION_CI_KUBECONFIG" > /tmp/kubeconfig.ci
+      - echo "$INTEGRATION_CI_KUBECONFIG" > /tmp/kubeconfig
       # TOOD(gus): uncomment after testing
       #- make -C build.assets integration
+      - ls -l /tmp
       - |
         docker run --rm=true -v "$(pwd)/":/go/src/github.com/gravitational/teleport \
         -v /tmp:/tmp -w /go/src/github.com/gravitational/teleport -h buildbox \
-        -v /tmp/kubeconfig.ci:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true \
+        -v /tmp/kubeconfig:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true \
         -v "$(pwd)/bcc:/usr/include/bcc" -u $(id -u):$(id -g) -t quay.io/gravitational/teleport-buildbox:go1.14.4 \
-        /bin/bash -c "go test ./integration/... -v -cover -check.f=TestKube"
+        /bin/bash -c "ls -l /mnt/kube && ls -l /mnt/kube/config && go test ./integration/... -v -cover -check.f=TestKube"
 
 services:
   - name: Start Docker
@@ -2799,6 +2800,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 1d9715326d051bb1689c91c4d8805b4d355af940e546d3918c35a9ccb8dee088
+hmac: f4a253f94f078ea85c2a9738fd70d9e402cd92a42683f958f2aaf7d46729a1f1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -126,19 +126,20 @@ steps:
         path: /var/run
     commands:
       - apk add --no-cache make
+      # write kubeconfig to disk for use in kube integrations tests
+      - echo "$INTEGRATION_CI_KUBECONFIG" > /go/kubeconfig.ci
       - chown -R $UID:$GID /go
       - cd /go/src/github.com/gravitational/teleport
-      # write kubeconfig to disk for use in kube_integration_test
-      - echo "$INTEGRATION_CI_KUBECONFIG" > /kubeconfig.ci
       # TOOD(gus): uncomment after testing
       #- make -C build.assets integration
-      - ls -l /
+      - ls -l /go
       - |
         docker run --rm=true -v "$(pwd)/":/go/src/github.com/gravitational/teleport \
         -v /tmp:/tmp -w /go/src/github.com/gravitational/teleport -h buildbox \
         -v /kubeconfig.ci:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true \
         -v "$(pwd)/bcc:/usr/include/bcc" -u $(id -u):$(id -g) -t quay.io/gravitational/teleport-buildbox:go1.14.4 \
         /bin/bash -c "ls -l /mnt/kube && ls -l /mnt/kube/config && go test ./integration/... -v -cover -check.f=TestKube"
+      - rm -f /go/kubeconfig.ci
 
 services:
   - name: Start Docker
@@ -2800,6 +2801,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 99261305f4441b9ce8c77471c75a012ca5aa18e4d206b34dd3b6825b3ab7f8a7
+hmac: fc445431ec9e77c48777304c46a9861b4e674b010e8927a3844082d83e8767b2
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -136,7 +136,7 @@ steps:
       - |
         docker run --rm=true -v "$(pwd)/":/go/src/github.com/gravitational/teleport \
         -v /tmp:/tmp -w /go/src/github.com/gravitational/teleport -h buildbox \
-        -v /kubeconfig.ci:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true \
+        -v /go/kubeconfig.ci:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true \
         -v "$(pwd)/bcc:/usr/include/bcc" -u $(id -u):$(id -g) -t quay.io/gravitational/teleport-buildbox:go1.14.4 \
         /bin/bash -c "ls -l /mnt/kube && ls -l /mnt/kube/config && go test ./integration/... -v -cover -check.f=TestKube"
       - rm -f /go/kubeconfig.ci
@@ -2801,6 +2801,6 @@ volumes:
 
 ---
 kind: signature
-hmac: fc445431ec9e77c48777304c46a9861b4e674b010e8927a3844082d83e8767b2
+hmac: cc4343de57122bfe006c151620c7a75466cb56ba0fb8aa99e8faad26652893cd
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -135,7 +135,7 @@ steps:
       - |
         docker run --rm=true -v "$(pwd)/":/go/src/github.com/gravitational/teleport \
         -v /tmp:/tmp -w /go/src/github.com/gravitational/teleport -h buildbox \
-        -v /tmp/kubeconfig.ci:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true
+        -v /tmp/kubeconfig.ci:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true \
         -v "$(pwd)/bcc:/usr/include/bcc" -u $(id -u):$(id -g) -t quay.io/gravitational/teleport-buildbox:go1.14.4 \
         /bin/bash -c "go test ./integration/... -v -cover -check.f=TestKube"
 
@@ -2799,6 +2799,6 @@ volumes:
 
 ---
 kind: signature
-hmac: a32cdd2704164c47e94374900c9c278557f662af3598117382ae7b395f898b0e
+hmac: 1d9715326d051bb1689c91c4d8805b4d355af940e546d3918c35a9ccb8dee088
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -130,14 +130,7 @@ steps:
       - echo "$INTEGRATION_CI_KUBECONFIG" > /go/kubeconfig.ci
       - chown -R $UID:$GID /go
       - cd /go/src/github.com/gravitational/teleport
-      # TOOD(gus): uncomment/remove after testing
-      #- make -C build.assets integration
-      - |
-        docker run --rm=true -v "$(pwd)/":/go/src/github.com/gravitational/teleport \
-        -v /tmp:/tmp -w /go/src/github.com/gravitational/teleport -h buildbox \
-        -v /go/kubeconfig.ci:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true \
-        -v "$(pwd)/bcc:/usr/include/bcc" -u $(id -u):$(id -g) -t quay.io/gravitational/teleport-buildbox:go1.14.4 \
-        /bin/bash -c "ls -l /mnt/kube && ls -l /mnt/kube/config && go test ./integration/... -v -cover -check.f=TestKube"
+      - make -C build.assets integration
       - rm -f /go/kubeconfig.ci
 
 services:
@@ -2800,6 +2793,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 4f71245ab61a41f45090e94e76fb34bd1260a57e8687a4af95a289e536d731b4
+hmac: a5149325e44c6e01bd02df93a3b5ba2ebc6f73b2776947bb239fd8bfc298318e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -126,11 +126,11 @@ steps:
     commands:
       - apk add --no-cache make
       # write kubeconfig to disk for use in kube integrations tests
-      - echo "$INTEGRATION_CI_KUBECONFIG" > /go/kubeconfig.ci
+      - echo "$INTEGRATION_CI_KUBECONFIG" > "$KUBECONFIG"
       - chown -R $UID:$GID /go
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets integration
-      - rm -f /go/kubeconfig.ci
+      - rm -f "$KUBECONFIG"
 
 services:
   - name: Start Docker
@@ -2792,6 +2792,6 @@ volumes:
 
 ---
 kind: signature
-hmac: d274d308b282db08a4cd0fcf098657c59a272cc450e7429752cdf1c0a6de5383
+hmac: f47f415ffb75d0ef2f5ecfb6bd9b982f8f0c50fe6eaee28fbc6a6950b9c5e0f1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -74,48 +74,53 @@ steps:
           fi
         fi
 
-  - name: Build buildbox
-    image: docker
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets buildbox
+  # TODO(gus): uncomment after testing
+  # - name: Build buildbox
+  #   image: docker
+  #   volumes:
+  #     - name: dockersock
+  #       path: /var/run
+  #   commands:
+  #     - apk add --no-cache make
+  #     - chown -R $UID:$GID /go
+  #     - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+  #     - cd /go/src/github.com/gravitational/teleport
+  #     - make -C build.assets buildbox
 
-  - name: Run linter
-    image: docker
-    environment:
-      GOPATH: /go
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets lint
+  # - name: Run linter
+  #   image: docker
+  #   environment:
+  #     GOPATH: /go
+  #   volumes:
+  #     - name: dockersock
+  #       path: /var/run
+  #   commands:
+  #     - apk add --no-cache make
+  #     - chown -R $UID:$GID /go
+  #     - cd /go/src/github.com/gravitational/teleport
+  #     - make -C build.assets lint
 
-  - name: Run unit and chaos tests
-    image: docker
-    environment:
-      GOPATH: /go
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets test
+  # - name: Run unit tests
+  #   image: docker
+  #   environment:
+  #     GOPATH: /go
+  #   volumes:
+  #     - name: dockersock
+  #       path: /var/run
+  #   commands:
+  #     - apk add --no-cache make
+  #     - chown -R $UID:$GID /go
+  #     - cd /go/src/github.com/gravitational/teleport
+  #     - make -C build.assets test
 
   - name: Run integration tests
     image: docker
     environment:
       GOPATH: /go
+      INTEGRATION_CI_KUBECONFIG:
+        from_secret: INTEGRATION_CI_KUBECONFIG
+      KUBECONFIG: /mnt/kube/config
+      TEST_KUBE: true
     volumes:
       - name: dockersock
         path: /var/run
@@ -123,7 +128,16 @@ steps:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
       - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets integration
+      # write kubeconfig to disk for use in kube_integration_test
+      - echo "$INTEGRATION_CI_KUBECONFIG" > /tmp/kubeconfig.ci
+      # TOOD(gus): uncomment after testing
+      #- make -C build.assets integration
+      - |
+        docker run --rm=true -v "$(pwd)/":/go/src/github.com/gravitational/teleport \
+        -v /tmp:/tmp -w /go/src/github.com/gravitational/teleport -h buildbox \
+        -v /tmp/kubeconfig.ci:/mnt/kube/config -e KUBECONFIG=/mnt/kube/config -e TEST_KUBE=true
+        -v "$(pwd)/bcc:/usr/include/bcc" -u $(id -u):$(id -g) -t quay.io/gravitational/teleport-buildbox:go1.14.4 \
+        /bin/bash -c "go test ./integration/... -v -cover -check.f=TestKube"
 
 services:
   - name: Start Docker
@@ -2785,6 +2799,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 46f777cd44caf6593159d4eb85b91242739a50a16e948f321757c68c33faa31d
+hmac: a32cdd2704164c47e94374900c9c278557f662af3598117382ae7b395f898b0e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -86,32 +86,31 @@ steps:
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets buildbox
 
-  # TODO(gus): uncomment after testing
-  # - name: Run linter
-  #   image: docker
-  #   environment:
-  #     GOPATH: /go
-  #   volumes:
-  #     - name: dockersock
-  #       path: /var/run
-  #   commands:
-  #     - apk add --no-cache make
-  #     - chown -R $UID:$GID /go
-  #     - cd /go/src/github.com/gravitational/teleport
-  #     - make -C build.assets lint
+  - name: Run linter
+    image: docker
+    environment:
+      GOPATH: /go
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make
+      - chown -R $UID:$GID /go
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets lint
 
-  # - name: Run unit tests
-  #   image: docker
-  #   environment:
-  #     GOPATH: /go
-  #   volumes:
-  #     - name: dockersock
-  #       path: /var/run
-  #   commands:
-  #     - apk add --no-cache make
-  #     - chown -R $UID:$GID /go
-  #     - cd /go/src/github.com/gravitational/teleport
-  #     - make -C build.assets test
+  - name: Run unit tests
+    image: docker
+    environment:
+      GOPATH: /go
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make
+      - chown -R $UID:$GID /go
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets test
 
   - name: Run integration tests
     image: docker
@@ -2793,6 +2792,6 @@ volumes:
 
 ---
 kind: signature
-hmac: b8af3885750f7d36b69756fbffea8b1e91f6d51bedcd15831b9ddaca715686be
+hmac: d274d308b282db08a4cd0fcf098657c59a272cc450e7429752cdf1c0a6de5383
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -74,19 +74,19 @@ steps:
           fi
         fi
 
-  # TODO(gus): uncomment after testing
-  # - name: Build buildbox
-  #   image: docker
-  #   volumes:
-  #     - name: dockersock
-  #       path: /var/run
-  #   commands:
-  #     - apk add --no-cache make
-  #     - chown -R $UID:$GID /go
-  #     - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-  #     - cd /go/src/github.com/gravitational/teleport
-  #     - make -C build.assets buildbox
+  - name: Build buildbox
+    image: docker
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make
+      - chown -R $UID:$GID /go
+      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      - make -C build.assets buildbox
 
+  # TODO(gus): uncomment after testing
   # - name: Run linter
   #   image: docker
   #   environment:
@@ -2793,6 +2793,6 @@ volumes:
 
 ---
 kind: signature
-hmac: a5149325e44c6e01bd02df93a3b5ba2ebc6f73b2776947bb239fd8bfc298318e
+hmac: b8af3885750f7d36b69756fbffea8b1e91f6d51bedcd15831b9ddaca715686be
 
 ...

--- a/fixtures/ci-teleport-rbac/ci-teleport.yaml
+++ b/fixtures/ci-teleport-rbac/ci-teleport.yaml
@@ -1,0 +1,87 @@
+# defines the permissions needed for Teleport k8s integration tests to run in a cluster
+# clusterrole granting overarching privileges
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ci-teleport
+rules:
+- apiGroups: [""]
+  resources: ["users", "groups", "serviceaccounts"]
+  verbs: ["impersonate"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["create", "delete"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["selfsubjectaccessreviews", "selfsubjectrulesreviews"]
+  verbs: ["create"]
+---
+# role to allow pod operations in kube-system namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ci-teleport-sa
+  namespace: kube-system
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+---
+# role to allow pod operations via impersonation in kube-system namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ci-teleport-group
+  namespace: kube-system
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["pods/portforward"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ci-teleport
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ci-teleport
+subjects:
+- kind: ServiceAccount
+  name: teleport-sa
+  namespace: ci-teleport
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ci-teleport-sa
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ci-teleport-sa
+subjects:
+- kind: ServiceAccount
+  name: teleport-sa
+  namespace: ci-teleport
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ci-teleport-group
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ci-teleport-group
+subjects:
+- kind: Group
+  name: teleport-ci-test-group

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -175,7 +175,7 @@ func (s *KubeSuite) TestKubeExec(c *check.C) {
 		username:      username,
 		kubeUsers:     kubeUsers,
 		kubeGroups:    kubeGroups,
-		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system: masters"}},
+		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system:masters"}},
 	})
 	c.Assert(err, check.IsNil)
 
@@ -456,7 +456,7 @@ func (s *KubeSuite) TestKubePortForward(c *check.C) {
 		t:             t,
 		username:      username,
 		kubeGroups:    kubeGroups,
-		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system: masters"}},
+		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system:masters"}},
 	})
 	c.Assert(err, check.IsNil)
 
@@ -592,7 +592,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 		t:              main,
 		username:       username,
 		kubeGroups:     mainKubeGroups,
-		impersonation:  &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system: masters"}},
+		impersonation:  &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system:masters"}},
 		routeToCluster: clusterAux,
 	})
 	c.Assert(err, check.IsNil)
@@ -744,7 +744,7 @@ loop:
 
 }
 
-// TestKubeTrustedClustersSNI tests scenario with trusted clsuters
+// TestKubeTrustedClustersSNI tests scenario with trusted clusters
 // using SNI-forwarding
 // DELETE IN(4.3.0)
 func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
@@ -815,7 +815,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = aux.Process.GetAuthServer().UpsertRole(ctx, auxRole)
 	c.Assert(err, check.IsNil)
-	trustedClusterToken := "trusted-clsuter-token"
+	trustedClusterToken := "trusted-cluster-token"
 	err = main.Process.GetAuthServer().UpsertToken(
 		services.MustCreateProvisionToken(trustedClusterToken, []teleport.Role{teleport.RoleTrustedCluster}, time.Time{}))
 	c.Assert(err, check.IsNil)
@@ -865,7 +865,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 		t:             main,
 		username:      username,
 		kubeGroups:    mainKubeGroups,
-		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system: masters"}},
+		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system:masters"}},
 	})
 	c.Assert(err, check.IsNil)
 

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -124,6 +124,7 @@ func (s *KubeSuite) SetUpSuite(c *check.C) {
 }
 
 const kubeSystemNamespace = "kube-system"
+const testImpersonationGroup = "teleport-ci-test-group"
 
 var kubeDNSLabels = labels.Set{"k8s-app": "kube-dns"}
 
@@ -175,7 +176,7 @@ func (s *KubeSuite) TestKubeExec(c *check.C) {
 		username:      username,
 		kubeUsers:     kubeUsers,
 		kubeGroups:    kubeGroups,
-		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system:masters"}},
+		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{testImpersonationGroup}},
 	})
 	c.Assert(err, check.IsNil)
 
@@ -456,7 +457,7 @@ func (s *KubeSuite) TestKubePortForward(c *check.C) {
 		t:             t,
 		username:      username,
 		kubeGroups:    kubeGroups,
-		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system:masters"}},
+		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{testImpersonationGroup}},
 	})
 	c.Assert(err, check.IsNil)
 
@@ -592,7 +593,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 		t:              main,
 		username:       username,
 		kubeGroups:     mainKubeGroups,
-		impersonation:  &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system:masters"}},
+		impersonation:  &rest.ImpersonationConfig{UserName: "bob", Groups: []string{testImpersonationGroup}},
 		routeToCluster: clusterAux,
 	})
 	c.Assert(err, check.IsNil)
@@ -763,7 +764,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 
 	// main cluster has a role and user called main-kube
 	username := s.me.Username
-	mainKubeGroups := []string{teleport.KubeSystemMasters}
+	mainKubeGroups := []string{testImpersonationGroup}
 	mainRole, err := services.NewRole("main-kube", services.RoleSpecV3{
 		Allow: services.RoleConditions{
 			Logins:     []string{username},
@@ -865,7 +866,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 		t:             main,
 		username:      username,
 		kubeGroups:    mainKubeGroups,
-		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{"system:masters"}},
+		impersonation: &rest.ImpersonationConfig{UserName: "bob", Groups: []string{testImpersonationGroup}},
 	})
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
- Sets `KUBECONFIG` and `TEST_KUBE` environment variables in Drone runs so Kubernetes tests run
- Replaces the use of `system:masters` with a different, less privileged group for impersonation tests
- Adds some Kubernetes RBAC YAML directives which give only the privileges needed for the tests to run
  - These aren't automatically applied, they're just put into fixtures as a reference for any lucky soul who might want to move Teleport CI elsewhere in future

Behind the scenes:
- disabled legacy auth in the CI cluster so full RBAC can be used

For some reason the k8s tests have carried on working in Jenkins throughout even when I expected them to break. My guess is that the Jenkins k8s `ServiceAccount` is being granted more permissions than Drone has (as I thought they were running in the same cluster). At any rate, the outcome is fine as Jenkins will no longer be used for Teleport CI soon.