### PR TITLE
The spellcheck fixes didn't work on mac

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -9,9 +9,9 @@ cd "$(dirname $0)" || exit
 rm -f latest.yaml
 
 # find all *.yaml files and convert them to array, pick the latest
-cfiles=$(find . -maxdepth 1 -name '*.yaml' | sort)
-cfiles_array=$(matfile -t array <<< "$cfiles")
-latest_cfile=${cfiles_array[-1]} # becomes "3.1.yaml"
+cfiles=$(ls *.yaml | sort)
+cfiles_array=($cfiles)
+latest_cfile=$(echo ${cfiles_array[-1]}) # becomes "3.1.yaml"
 latest_ver=${latest_cfile%.yaml}         # becomes "3.1"
 
 # build all documentation versions at the same time (4-8x speedup)


### PR DESCRIPTION
Reverting the spellcheck as I'm running into this issue. 
```log
./build.sh: line 13: matfile: command not found
./build.sh: line 14: cfiles_array: bad array subscript
```
