### PR TITLE
tsh: don't fall back to login when using identity file

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -332,7 +332,11 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) 
 	// Assume that failed handshake is a result of expired credentials,
 	// retry the login procedure
 	if !utils.IsHandshakeFailedError(err) && !utils.IsCertExpiredError(err) && !trace.IsBadParameter(err) && !trace.IsTrustError(err) {
-		return err
+		return trace.Wrap(err)
+	}
+	// Don't try to login when using an identity file.
+	if tc.SkipLocalAuth {
+		return trace.Wrap(err)
 	}
 	log.Debugf("Activating relogin on %v.", err)
 	key, err := tc.Login(ctx, true)


### PR DESCRIPTION
First, this is unexpected behavior. If `tsh` fails using the identity
file, it should tell the user why and exit, instead of masking it.

Second, this can lead to a segfault, since the `TeleportClient` isn't
fully initialized for logins (e.g. uses a half-initialized Agent).