### PR TITLE
Add node access to userACL

### DIFF
--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -43,8 +43,10 @@ type userACL struct {
 	TrustedClusters access `json:"trustedClusters"`
 	// Events defines access to audit logs
 	Events access `json:"events"`
-	// Tokens defines access to creating tokens ie: node join token.
-	Tokens access `json:"nodeToken"`
+	// Tokens defines access to tokens.
+	Tokens access `json:"tokens"`
+	// Nodes defines access to nodes.
+	Nodes access `json:"nodes"`
 	// SSH defines access to servers
 	SSHLogins []string `json:"sshLogins"`
 }
@@ -121,6 +123,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 	eventAccess := newAccess(userRoles, ctx, services.KindEvent)
 	userAccess := newAccess(userRoles, ctx, services.KindUser)
 	tokenAccess := newAccess(userRoles, ctx, services.KindToken)
+	nodeAccess := newAccess(userRoles, ctx, services.KindNode)
 	logins := getLogins(userRoles)
 
 	acl := userACL{
@@ -132,6 +135,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 		SSHLogins:       logins,
 		Users:           userAccess,
 		Tokens:          tokenAccess,
+		Nodes:           nodeAccess,
 	}
 
 	// local user

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -69,6 +69,7 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Roles, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Users, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Tokens, check.DeepEquals, denied)
+	c.Assert(userContext.ACL.Nodes, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
 
 	// test local auth type


### PR DESCRIPTION
part of https://github.com/gravitational/webapps/issues/160

#### Description
Set node access, to allow UI to check if user has permission for node actions.