### PR TITLE
Add ability to specify leaf cluster when generating kubeconfig via `tctl auth sign`

### DIFF
--- a/docs/4.3/cli-docs.md
+++ b/docs/4.3/cli-docs.md
@@ -711,6 +711,8 @@ Create an identity file(s) for a given user
 `--ttl` | none | relative duration like 5s, 2m, or 3h | TTL (time to live) for the generated certificate
 `--compat` | `""` | `standard` or `oldssh` | OpenSSH compatibility flag
 `--proxy` | `""` |  Address of the teleport proxy. | When --format is set to "kubernetes", this address will be set as cluster address in the generated kubeconfig file
+`--cluster` | `""` |  The name of a leaf cluster. | When --format is set to "kubernetes", the kubeconfig generated will allow access to this leaf cluster.
+
 
 ### [Global Flags](#tctl-global-flags)
 
@@ -740,6 +742,9 @@ $ tctl auth sign --ttl=24h --user=jenkins --out=jenkins.pem
 # create a certificate with a TTL of 1 day for the jenkins user
 # The kubeconfig file can later be used with `kubectl` or compatible tooling.
 $ tctl auth sign --ttl=24h --user=jenkins --out=kubeconfig --format=kubernetes
+# create a certificate with a TTL of 1 day for the jenkins user for a leaf cluster named two
+# The kubeconfig file can later be used with `kubectl` or compatible tooling.
+$ tctl auth sign --ttl=24h --user=jenkins --out=kubeconfig --format=kubernetes --cluster two
 # Exports an identity from the Auth Server in preparation for remote
 # tctl execution.
 $ tctl auth sign --user=admin --out=identity.pem

--- a/docs/4.3/cli-docs.md
+++ b/docs/4.3/cli-docs.md
@@ -711,7 +711,7 @@ Create an identity file(s) for a given user
 `--ttl` | none | relative duration like 5s, 2m, or 3h | TTL (time to live) for the generated certificate
 `--compat` | `""` | `standard` or `oldssh` | OpenSSH compatibility flag
 `--proxy` | `""` |  Address of the teleport proxy. | When --format is set to "kubernetes", this address will be set as cluster address in the generated kubeconfig file
-`--cluster` | `""` |  The name of a leaf cluster. | When --format is set to "kubernetes", the kubeconfig generated will allow access to this leaf cluster.
+`--kube-cluster` | `""` |  The name of a leaf cluster. | When --format is set to "kubernetes", the kubeconfig generated will allow access to this leaf cluster.
 
 
 ### [Global Flags](#tctl-global-flags)
@@ -744,7 +744,7 @@ $ tctl auth sign --ttl=24h --user=jenkins --out=jenkins.pem
 $ tctl auth sign --ttl=24h --user=jenkins --out=kubeconfig --format=kubernetes
 # create a certificate with a TTL of 1 day for the jenkins user for a leaf cluster named two
 # The kubeconfig file can later be used with `kubectl` or compatible tooling.
-$ tctl auth sign --ttl=24h --user=jenkins --out=kubeconfig --format=kubernetes --cluster two
+$ tctl auth sign --ttl=24h --user=jenkins --out=kubeconfig --format=kubernetes --kube-cluster two
 # Exports an identity from the Auth Server in preparation for remote
 # tctl execution.
 $ tctl auth sign --user=admin --out=identity.pem

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -358,7 +358,7 @@ func (a *AuthCommand) generateUserKeys(clusterAPI auth.ClientI) error {
 		return trace.Wrap(err)
 	}
 
-	if (a.cluster != "") {
+	if a.cluster != "" {
 		key.ClusterName = a.cluster
 	} else {
 		cn, err := clusterAPI.GetClusterName()
@@ -370,10 +370,10 @@ func (a *AuthCommand) generateUserKeys(clusterAPI auth.ClientI) error {
 
 	// Request signed certs from `auth` server.
 	certs, err := clusterAPI.GenerateUserCerts(context.TODO(), proto.UserCertsRequest{
-		PublicKey: key.Pub,
-		Username:  a.genUser,
-		Expires:   time.Now().UTC().Add(a.genTTL),
-		Format:    certificateFormat,
+		PublicKey:      key.Pub,
+		Username:       a.genUser,
+		Expires:        time.Now().UTC().Add(a.genTTL),
+		Format:         certificateFormat,
 		RouteToCluster: a.cluster,
 	})
 	if err != nil {
@@ -415,7 +415,7 @@ func (a *AuthCommand) checkCluster(clusterAPI auth.ClientI) error {
 	}
 
 	for _, cluster := range clusters {
-		if (cluster.GetMetadata().Name == a.cluster) {
+		if cluster.GetMetadata().Name == a.cluster {
 			return nil
 		}
 	}

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -12,10 +12,14 @@ import (
 	"github.com/gravitational/teleport/lib/auth/proto"
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestAuthSignKubeconfig(t *testing.T) {
+	t.Parallel()
+
 	tmpDir, err := ioutil.TempDir("", "auth_command_test")
 	if err != nil {
 		t.Fatal(err)
@@ -52,47 +56,136 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			TLS: []byte("TLS cert"),
 		},
 		cas: []services.CertAuthority{ca},
+		proxies: []services.Server{
+			&services.ServerV2{
+				Kind:    services.KindNode,
+				Version: services.V2,
+				Metadata: services.Metadata{
+					Name: "proxy",
+				},
+				Spec: services.ServerSpecV2{
+					PublicAddr: "proxy-from-api.example.com:3080",
+				},
+			},
+		},
 	}
-	ac := &AuthCommand{
-		output:       filepath.Join(tmpDir, "kubeconfig"),
-		outputFormat: identityfile.FormatKubernetes,
-		proxyAddr:    "proxy.example.com",
-		cluster:      remoteCluster.GetMetadata().Name,
+	tests := []struct {
+		desc        string
+		ac          AuthCommand
+		wantAddr    string
+		wantCluster string
+		wantError   string
+	}{
+		{
+			desc: "--proxy specified",
+			ac: AuthCommand{
+				output:       filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat: identityfile.FormatKubernetes,
+				proxyAddr:    "proxy-from-flag.example.com",
+			},
+			wantAddr: "proxy-from-flag.example.com",
+		},
+		{
+			desc: "k8s proxy running locally with public_addr",
+			ac: AuthCommand{
+				output:       filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat: identityfile.FormatKubernetes,
+				config: &service.Config{Proxy: service.ProxyConfig{Kube: service.KubeProxyConfig{
+					Enabled:     true,
+					PublicAddrs: []utils.NetAddr{{Addr: "proxy-from-config.example.com:3026"}},
+				}}},
+			},
+			wantAddr: "https://proxy-from-config.example.com:3026",
+		},
+		{
+			desc: "k8s proxy running locally without public_addr",
+			ac: AuthCommand{
+				output:       filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat: identityfile.FormatKubernetes,
+				config: &service.Config{Proxy: service.ProxyConfig{
+					Kube: service.KubeProxyConfig{
+						Enabled: true,
+					},
+					PublicAddrs: []utils.NetAddr{{Addr: "proxy-from-config.example.com:3080"}},
+				}},
+			},
+			wantAddr: "https://proxy-from-config.example.com:3026",
+		},
+		{
+			desc: "k8s proxy from cluster info",
+			ac: AuthCommand{
+				output:       filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat: identityfile.FormatKubernetes,
+				config: &service.Config{Proxy: service.ProxyConfig{
+					Kube: service.KubeProxyConfig{
+						Enabled: false,
+					},
+				}},
+			},
+			wantAddr: "https://proxy-from-api.example.com:3026",
+		},
+		{
+			desc: "--cluster specified with valid cluster",
+			ac: AuthCommand{
+				output:       filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat: identityfile.FormatKubernetes,
+				cluster:      remoteCluster.GetMetadata().Name,
+				config: &service.Config{Proxy: service.ProxyConfig{
+					Kube: service.KubeProxyConfig{
+						Enabled: false,
+					},
+				}},
+			},
+			wantCluster: remoteCluster.GetMetadata().Name,
+		},
+		{
+			desc: "--cluster specified with invalid cluster",
+			ac: AuthCommand{
+				output:       filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat: identityfile.FormatKubernetes,
+				cluster:      "doesnotexist.example.com",
+				config: &service.Config{Proxy: service.ProxyConfig{
+					Kube: service.KubeProxyConfig{
+						Enabled: false,
+					},
+				}},
+			},
+			wantError: "couldn't find leaf cluster named \"doesnotexist.example.com\"",
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			// Generate kubeconfig.
+			if err = tt.ac.generateUserKeys(client); err != nil && tt.wantError == "" {
+				t.Fatalf("generating KubeProxyConfigfig: %v", err)
+			}
 
-	// Generate kubeconfig.
-	if err = ac.generateUserKeys(client); err != nil {
-		t.Fatalf("generating kubeconfig: %v", err)
-	}
+			if tt.wantError != "" && (err == nil || err.Error() != tt.wantError) {
+				t.Errorf("got error %v, want %v", err, tt.wantError)
+			}
 
-	// Validate kubeconfig contents.
-	kc, err := kubeconfig.Load(ac.output)
-	if err != nil {
-		t.Fatalf("loading generated kubeconfig: %v", err)
-	}
-	gotCert := kc.AuthInfos[kc.CurrentContext].ClientCertificateData
-	if !bytes.Equal(gotCert, client.userCerts.TLS) {
-		t.Errorf("got client cert: %q, want %q", gotCert, client.userCerts.TLS)
-	}
-	gotCA := kc.Clusters[kc.CurrentContext].CertificateAuthorityData
-	wantCA := ca.GetTLSKeyPairs()[0].Cert
-	if !bytes.Equal(gotCA, wantCA) {
-		t.Errorf("got CA cert: %q, want %q", gotCA, wantCA)
-	}
-	gotServerAddr := kc.Clusters[kc.CurrentContext].Server
-	if gotServerAddr != ac.proxyAddr {
-		t.Errorf("got server address: %q, want %q", gotServerAddr, ac.proxyAddr)
-	}
-
-	// an error is raised if an invalid cluster is provided
-	ac.cluster = "doesnotexist.example.com"
-	if err = ac.generateUserKeys(client); err == nil {
-		t.Fatalf("expected error when generating kubeconfig with bad leaf clusters")
-	}
-
-	expected := "couldn't find leaf cluster named \"doesnotexist.example.com\""
-	if err.Error() != expected {
-		t.Errorf("Expected error %v, got %v", expected, err)
+			// Validate kubeconfig contents.
+			kc, err := kubeconfig.Load(tt.ac.output)
+			if err != nil {
+				t.Fatalf("loading generated kubeconfig: %v", err)
+			}
+			gotCert := kc.AuthInfos[kc.CurrentContext].ClientCertificateData
+			if !bytes.Equal(gotCert, client.userCerts.TLS) {
+				t.Errorf("got client cert: %q, want %q", gotCert, client.userCerts.TLS)
+			}
+			gotCA := kc.Clusters[kc.CurrentContext].CertificateAuthorityData
+			wantCA := ca.GetTLSKeyPairs()[0].Cert
+			if !bytes.Equal(gotCA, wantCA) {
+				t.Errorf("got CA cert: %q, want %q", gotCA, wantCA)
+			}
+			gotServerAddr := kc.Clusters[kc.CurrentContext].Server
+			if tt.wantAddr != "" && gotServerAddr != tt.wantAddr {
+				t.Errorf("got server address: %q, want %q", gotServerAddr, tt.wantAddr)
+			}
+			if tt.wantCluster != "" && kc.CurrentContext != tt.wantCluster {
+				t.Errorf("got cluster: %q, want %q", kc.CurrentContext, tt.wantCluster)
+			}
+		})
 	}
 }
 
@@ -102,6 +195,7 @@ type mockClient struct {
 	clusterName    services.ClusterName
 	userCerts      *proto.Certs
 	cas            []services.CertAuthority
+	proxies        []services.Server
 	remoteClusters []services.RemoteCluster
 }
 
@@ -114,7 +208,9 @@ func (c mockClient) GenerateUserCerts(context.Context, proto.UserCertsRequest) (
 func (c mockClient) GetCertAuthorities(services.CertAuthType, bool, ...services.MarshalOption) ([]services.CertAuthority, error) {
 	return c.cas, nil
 }
-
+func (c mockClient) GetProxies() ([]services.Server, error) {
+	return c.proxies, nil
+}
 func (c mockClient) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
 	return c.remoteClusters, nil
 }

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -125,11 +125,11 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			wantAddr: "https://proxy-from-api.example.com:3026",
 		},
 		{
-			desc: "--cluster specified with valid cluster",
+			desc: "--kube-cluster specified with valid cluster",
 			ac: AuthCommand{
 				output:       filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat: identityfile.FormatKubernetes,
-				cluster:      remoteCluster.GetMetadata().Name,
+				kubeCluster:  remoteCluster.GetMetadata().Name,
 				config: &service.Config{Proxy: service.ProxyConfig{
 					Kube: service.KubeProxyConfig{
 						Enabled: false,
@@ -139,11 +139,11 @@ func TestAuthSignKubeconfig(t *testing.T) {
 			wantCluster: remoteCluster.GetMetadata().Name,
 		},
 		{
-			desc: "--cluster specified with invalid cluster",
+			desc: "--kube-cluster specified with invalid cluster",
 			ac: AuthCommand{
 				output:       filepath.Join(tmpDir, "kubeconfig"),
 				outputFormat: identityfile.FormatKubernetes,
-				cluster:      "doesnotexist.example.com",
+				kubeCluster:  "doesnotexist.example.com",
 				config: &service.Config{Proxy: service.ProxyConfig{
 					Kube: service.KubeProxyConfig{
 						Enabled: false,

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -45,8 +45,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 	ca.SetTLSKeyPairs([]services.TLSKeyPair{{Cert: []byte("TLS CA cert")}})
 
 	client := mockClient{
-		clusterName: clusterName,
-		remoteClusters: []services.RemoteCluster {remoteCluster},
+		clusterName:    clusterName,
+		remoteClusters: []services.RemoteCluster{remoteCluster},
 		userCerts: &proto.Certs{
 			SSH: []byte("SSH cert"),
 			TLS: []byte("TLS cert"),
@@ -57,7 +57,7 @@ func TestAuthSignKubeconfig(t *testing.T) {
 		output:       filepath.Join(tmpDir, "kubeconfig"),
 		outputFormat: identityfile.FormatKubernetes,
 		proxyAddr:    "proxy.example.com",
-		cluster:	  remoteCluster.GetMetadata().Name,
+		cluster:      remoteCluster.GetMetadata().Name,
 	}
 
 	// Generate kubeconfig.
@@ -92,16 +92,16 @@ func TestAuthSignKubeconfig(t *testing.T) {
 
 	expected := "couldn't find leaf cluster named \"doesnotexist.example.com\""
 	if err.Error() != expected {
-        t.Errorf("Expected error %v, got %v", expected, err)
+		t.Errorf("Expected error %v, got %v", expected, err)
 	}
 }
 
 type mockClient struct {
 	auth.ClientI
 
-	clusterName services.ClusterName
-	userCerts   *proto.Certs
-	cas         []services.CertAuthority
+	clusterName    services.ClusterName
+	userCerts      *proto.Certs
+	cas            []services.CertAuthority
 	remoteClusters []services.RemoteCluster
 }
 


### PR DESCRIPTION
Extend #3614 to add support for generating kubeconfigs for leaf clusters via `tctl auth sign`.  


Fixes #4405 
