### PR TITLE
Fixing golint warnings, batch 1

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1733,7 +1733,7 @@ func (s *IntSuite) TestMapRoles(c *check.C) {
 // tryCreateTrustedCluster performs several attempts to create a trusted cluster,
 // retries on connection problems and access denied errors to let caches
 // propagate and services to start
-func tryCreateTrustedCluster(c *check.C, authServer *auth.AuthServer, trustedCluster services.TrustedCluster) {
+func tryCreateTrustedCluster(c *check.C, authServer *auth.Server, trustedCluster services.TrustedCluster) {
 	ctx := context.TODO()
 	for i := 0; i < 10; i++ {
 		log.Debugf("Will create trusted cluster %v, attempt %v.", trustedCluster, i)
@@ -2613,7 +2613,7 @@ func waitForNodeCount(t *TeleInstance, clusterName string, count int) error {
 }
 
 // waitForTunnelConnections waits for remote tunnels connections
-func waitForTunnelConnections(c *check.C, authServer *auth.AuthServer, clusterName string, expectedCount int) {
+func waitForTunnelConnections(c *check.C, authServer *auth.Server, clusterName string, expectedCount int) {
 	var conns []services.TunnelConnection
 	for i := 0; i < 30; i++ {
 		conns, err := authServer.Presence.GetTunnelConnections(clusterName)

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -132,9 +132,9 @@ type AccessCache interface {
 	GetClusterName(opts ...services.MarshalOption) (services.ClusterName, error)
 }
 
-// AuthCache is a subset of the auth interface hanlding
+// Cache is a subset of the auth interface hanlding
 // access to the discovery API and static tokens
-type AuthCache interface {
+type Cache interface {
 	ReadAccessPoint
 
 	// GetStaticTokens gets the list of static tokens used to provision nodes.

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -45,7 +45,7 @@ import (
 )
 
 type APIConfig struct {
-	AuthServer     *AuthServer
+	AuthServer     *Server
 	SessionService session.Service
 	AuditLog       events.IAuditLog
 	Authorizer     Authorizer
@@ -275,7 +275,7 @@ func (s *APIServer) withAuth(handler HandlerWithAuthFunc) httprouter.Handle {
 
 			return nil, trace.AccessDenied(accessDeniedMsg + "[00]")
 		}
-		auth := &AuthWithRoles{
+		auth := &ServerWithRoles{
 			authServer: s.AuthServer,
 			context:    *authContext,
 			sessions:   s.SessionService,

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -52,7 +52,7 @@ func TestAPI(t *testing.T) { TestingT(t) }
 
 type AuthSuite struct {
 	bk          backend.Backend
-	a           *AuthServer
+	a           *Server
 	dataDir     string
 	mockEmitter *events.MockEmitter
 }
@@ -80,7 +80,7 @@ func (s *AuthSuite) SetUpTest(c *C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, IsNil)
 
 	// set cluster name
@@ -657,7 +657,7 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	authServer, err := NewAuthServer(authConfig)
+	authServer, err := NewServer(authConfig)
 	c.Assert(err, IsNil)
 
 	err = authServer.SetClusterName(clusterName)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -36,33 +36,33 @@ import (
 	"github.com/tstranex/u2f"
 )
 
-// AuthWithRoles is a wrapper around auth service
+// ServerWithRoles is a wrapper around auth service
 // methods that focuses on authorizing every request
-type AuthWithRoles struct {
-	authServer *AuthServer
+type ServerWithRoles struct {
+	authServer *Server
 	sessions   session.Service
 	alog       events.IAuditLog
 	// context holds authorization context
-	context AuthContext
+	context Context
 }
 
-// Context is closed when the auth server shuts down
-func (a *AuthWithRoles) Context() context.Context {
+// CloseContext is closed when the auth server shuts down
+func (a *ServerWithRoles) CloseContext() context.Context {
 	return a.authServer.closeCtx
 }
 
-func (a *AuthWithRoles) actionWithContext(ctx *services.Context, namespace string, resource string, action string) error {
+func (a *ServerWithRoles) actionWithContext(ctx *services.Context, namespace string, resource string, action string) error {
 	return a.context.Checker.CheckAccessToRule(ctx, namespace, resource, action, false)
 }
 
-func (a *AuthWithRoles) action(namespace string, resource string, action string) error {
+func (a *ServerWithRoles) action(namespace string, resource string, action string) error {
 	return a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, action, false)
 }
 
 // currentUserAction is a special checker that allows certain actions for users
 // even if they are not admins, e.g. update their own passwords,
 // or generate certificates, otherwise it will require admin privileges
-func (a *AuthWithRoles) currentUserAction(username string) error {
+func (a *ServerWithRoles) currentUserAction(username string) error {
 	if a.hasLocalUserRole(a.context.Checker) && username == a.context.User.GetName() {
 		return nil
 	}
@@ -74,7 +74,7 @@ func (a *AuthWithRoles) currentUserAction(username string) error {
 // connectors. It first checks if you have access to the specific connector.
 // If not, it checks if the requester has the meta KindAuthConnector access
 // (which grants access to all connectors).
-func (a *AuthWithRoles) authConnectorAction(namespace string, resource string, verb string) error {
+func (a *ServerWithRoles) authConnectorAction(namespace string, resource string, verb string) error {
 	if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, verb, false); err != nil {
 		if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, services.KindAuthConnector, verb, false); err != nil {
 			return trace.Wrap(err)
@@ -85,7 +85,7 @@ func (a *AuthWithRoles) authConnectorAction(namespace string, resource string, v
 
 // hasBuiltinRole checks the type of the role set returned and the name.
 // Returns true if role set is builtin and the name matches.
-func (a *AuthWithRoles) hasBuiltinRole(name string) bool {
+func (a *ServerWithRoles) hasBuiltinRole(name string) bool {
 	return hasBuiltinRole(a.context.Checker, name)
 }
 
@@ -104,7 +104,7 @@ func hasBuiltinRole(checker services.AccessChecker, name string) bool {
 
 // hasRemoteBuiltinRole checks the type of the role set returned and the name.
 // Returns true if role set is remote builtin and the name matches.
-func (a *AuthWithRoles) hasRemoteBuiltinRole(name string) bool {
+func (a *ServerWithRoles) hasRemoteBuiltinRole(name string) bool {
 	if _, ok := a.context.Checker.(RemoteBuiltinRoleSet); !ok {
 		return false
 	}
@@ -116,7 +116,7 @@ func (a *AuthWithRoles) hasRemoteBuiltinRole(name string) bool {
 }
 
 // hasLocalUserRole checks if the type of the role set is a local user or not.
-func (a *AuthWithRoles) hasLocalUserRole(checker services.AccessChecker) bool {
+func (a *ServerWithRoles) hasLocalUserRole(checker services.AccessChecker) bool {
 	if _, ok := checker.(LocalUserRoleSet); !ok {
 		return false
 	}
@@ -125,7 +125,7 @@ func (a *AuthWithRoles) hasLocalUserRole(checker services.AccessChecker) bool {
 
 // AuthenticateWebUser authenticates web user, creates and  returns web session
 // in case if authentication is successful
-func (a *AuthWithRoles) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
+func (a *ServerWithRoles) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
 	// authentication request has it's own authentication, however this limits the requests
 	// types to proxies to make it harder to break
 	if !a.hasBuiltinRole(string(teleport.RoleProxy)) {
@@ -136,7 +136,7 @@ func (a *AuthWithRoles) AuthenticateWebUser(req AuthenticateUserRequest) (servic
 
 // AuthenticateSSHUser authenticates SSH console user, creates and  returns a pair of signed TLS and SSH
 // short lived certificates as a result
-func (a *AuthWithRoles) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
+func (a *ServerWithRoles) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	// authentication request has it's own authentication, however this limits the requests
 	// types to proxies to make it harder to break
 	if !a.hasBuiltinRole(string(teleport.RoleProxy)) {
@@ -145,7 +145,7 @@ func (a *AuthWithRoles) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLog
 	return a.authServer.AuthenticateSSHUser(req)
 }
 
-func (a *AuthWithRoles) GetSessions(namespace string) ([]session.Session, error) {
+func (a *ServerWithRoles) GetSessions(namespace string) ([]session.Session, error) {
 	if err := a.action(namespace, services.KindSSHSession, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -153,21 +153,21 @@ func (a *AuthWithRoles) GetSessions(namespace string) ([]session.Session, error)
 	return a.sessions.GetSessions(namespace)
 }
 
-func (a *AuthWithRoles) GetSession(namespace string, id session.ID) (*session.Session, error) {
+func (a *ServerWithRoles) GetSession(namespace string, id session.ID) (*session.Session, error) {
 	if err := a.action(namespace, services.KindSSHSession, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.sessions.GetSession(namespace, id)
 }
 
-func (a *AuthWithRoles) CreateSession(s session.Session) error {
+func (a *ServerWithRoles) CreateSession(s session.Session) error {
 	if err := a.action(s.Namespace, services.KindSSHSession, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.sessions.CreateSession(s)
 }
 
-func (a *AuthWithRoles) UpdateSession(req session.UpdateRequest) error {
+func (a *ServerWithRoles) UpdateSession(req session.UpdateRequest) error {
 	if err := a.action(req.Namespace, services.KindSSHSession, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -175,19 +175,19 @@ func (a *AuthWithRoles) UpdateSession(req session.UpdateRequest) error {
 }
 
 // DeleteSession removes an active session from the backend.
-func (a *AuthWithRoles) DeleteSession(namespace string, id session.ID) error {
+func (a *ServerWithRoles) DeleteSession(namespace string, id session.ID) error {
 	if err := a.action(namespace, services.KindSSHSession, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.sessions.DeleteSession(namespace, id)
 }
 
-func (a *AuthWithRoles) CreateCertAuthority(ca services.CertAuthority) error {
+func (a *ServerWithRoles) CreateCertAuthority(ca services.CertAuthority) error {
 	return trace.NotImplemented("not implemented")
 }
 
 // RotateCertAuthority starts or restarts certificate authority rotation process.
-func (a *AuthWithRoles) RotateCertAuthority(req RotateRequest) error {
+func (a *ServerWithRoles) RotateCertAuthority(req RotateRequest) error {
 	if err := req.CheckAndSetDefaults(a.authServer.clock); err != nil {
 		return trace.Wrap(err)
 	}
@@ -203,7 +203,7 @@ func (a *AuthWithRoles) RotateCertAuthority(req RotateRequest) error {
 // RotateExternalCertAuthority rotates external certificate authority,
 // this method is called by a remote trusted cluster and is used to update
 // only public keys and certificates of the certificate authority.
-func (a *AuthWithRoles) RotateExternalCertAuthority(ca services.CertAuthority) error {
+func (a *ServerWithRoles) RotateExternalCertAuthority(ca services.CertAuthority) error {
 	if ca == nil {
 		return trace.BadParameter("missing certificate authority")
 	}
@@ -215,7 +215,7 @@ func (a *AuthWithRoles) RotateExternalCertAuthority(ca services.CertAuthority) e
 }
 
 // UpsertCertAuthority updates existing cert authority or updates the existing one.
-func (a *AuthWithRoles) UpsertCertAuthority(ca services.CertAuthority) error {
+func (a *ServerWithRoles) UpsertCertAuthority(ca services.CertAuthority) error {
 	if ca == nil {
 		return trace.BadParameter("missing certificate authority")
 	}
@@ -231,7 +231,7 @@ func (a *AuthWithRoles) UpsertCertAuthority(ca services.CertAuthority) error {
 
 // CompareAndSwapCertAuthority updates existing cert authority if the existing cert authority
 // value matches the value stored in the backend.
-func (a *AuthWithRoles) CompareAndSwapCertAuthority(new, existing services.CertAuthority) error {
+func (a *ServerWithRoles) CompareAndSwapCertAuthority(new, existing services.CertAuthority) error {
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -241,7 +241,7 @@ func (a *AuthWithRoles) CompareAndSwapCertAuthority(new, existing services.CertA
 	return a.authServer.CompareAndSwapCertAuthority(new, existing)
 }
 
-func (a *AuthWithRoles) GetCertAuthorities(caType services.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]services.CertAuthority, error) {
+func (a *ServerWithRoles) GetCertAuthorities(caType services.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]services.CertAuthority, error) {
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -256,7 +256,7 @@ func (a *AuthWithRoles) GetCertAuthorities(caType services.CertAuthType, loadKey
 	return a.authServer.GetCertAuthorities(caType, loadKeys, opts...)
 }
 
-func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
+func (a *ServerWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -268,23 +268,23 @@ func (a *AuthWithRoles) GetCertAuthority(id services.CertAuthID, loadKeys bool, 
 	return a.authServer.GetCertAuthority(id, loadKeys, opts...)
 }
 
-func (a *AuthWithRoles) GetDomainName() (string, error) {
+func (a *ServerWithRoles) GetDomainName() (string, error) {
 	// anyone can read it, no harm in that
 	return a.authServer.GetDomainName()
 }
 
-func (a *AuthWithRoles) GetLocalClusterName() (string, error) {
+func (a *ServerWithRoles) GetLocalClusterName() (string, error) {
 	// anyone can read it, no harm in that
 	return a.authServer.GetLocalClusterName()
 }
 
 // GetClusterCACert returns the CAs for the local cluster without signing keys.
-func (a *AuthWithRoles) GetClusterCACert() (*LocalCAResponse, error) {
+func (a *ServerWithRoles) GetClusterCACert() (*LocalCAResponse, error) {
 	// Allow all roles to get the local CA.
 	return a.authServer.GetClusterCACert()
 }
 
-func (a *AuthWithRoles) UpsertLocalClusterName(clusterName string) error {
+func (a *ServerWithRoles) UpsertLocalClusterName(clusterName string) error {
 	if err := a.action(defaults.Namespace, services.KindAuthServer, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -294,42 +294,42 @@ func (a *AuthWithRoles) UpsertLocalClusterName(clusterName string) error {
 	return a.authServer.UpsertLocalClusterName(clusterName)
 }
 
-func (a *AuthWithRoles) DeleteCertAuthority(id services.CertAuthID) error {
+func (a *ServerWithRoles) DeleteCertAuthority(id services.CertAuthID) error {
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteCertAuthority(id)
 }
 
-func (a *AuthWithRoles) ActivateCertAuthority(id services.CertAuthID) error {
+func (a *ServerWithRoles) ActivateCertAuthority(id services.CertAuthID) error {
 	return trace.NotImplemented("not implemented")
 }
 
-func (a *AuthWithRoles) DeactivateCertAuthority(id services.CertAuthID) error {
+func (a *ServerWithRoles) DeactivateCertAuthority(id services.CertAuthID) error {
 	return trace.NotImplemented("not implemented")
 }
 
 // GenerateToken generates multi-purpose authentication token.
-func (a *AuthWithRoles) GenerateToken(ctx context.Context, req GenerateTokenRequest) (string, error) {
+func (a *ServerWithRoles) GenerateToken(ctx context.Context, req GenerateTokenRequest) (string, error) {
 	if err := a.action(defaults.Namespace, services.KindToken, services.VerbCreate); err != nil {
 		return "", trace.Wrap(err)
 	}
 	return a.authServer.GenerateToken(ctx, req)
 }
 
-func (a *AuthWithRoles) RegisterUsingToken(req RegisterUsingTokenRequest) (*PackedKeys, error) {
+func (a *ServerWithRoles) RegisterUsingToken(req RegisterUsingTokenRequest) (*PackedKeys, error) {
 	// tokens have authz mechanism  on their own, no need to check
 	return a.authServer.RegisterUsingToken(req)
 }
 
-func (a *AuthWithRoles) RegisterNewAuthServer(token string) error {
+func (a *ServerWithRoles) RegisterNewAuthServer(token string) error {
 	// tokens have authz mechanism  on their own, no need to check
 	return a.authServer.RegisterNewAuthServer(token)
 }
 
 // GenerateServerKeys generates new host private keys and certificates (signed
 // by the host certificate authority) for a node.
-func (a *AuthWithRoles) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedKeys, error) {
+func (a *ServerWithRoles) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedKeys, error) {
 	clusterName, err := a.authServer.GetDomainName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -350,7 +350,7 @@ func (a *AuthWithRoles) GenerateServerKeys(req GenerateServerKeysRequest) (*Pack
 }
 
 // UpsertNodes bulk upserts nodes into the backend.
-func (a *AuthWithRoles) UpsertNodes(namespace string, servers []services.Server) error {
+func (a *ServerWithRoles) UpsertNodes(namespace string, servers []services.Server) error {
 	if err := a.action(namespace, services.KindNode, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -360,7 +360,7 @@ func (a *AuthWithRoles) UpsertNodes(namespace string, servers []services.Server)
 	return a.authServer.UpsertNodes(namespace, servers)
 }
 
-func (a *AuthWithRoles) UpsertNode(s services.Server) (*services.KeepAlive, error) {
+func (a *ServerWithRoles) UpsertNode(s services.Server) (*services.KeepAlive, error) {
 	if err := a.action(s.GetNamespace(), services.KindNode, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -370,7 +370,7 @@ func (a *AuthWithRoles) UpsertNode(s services.Server) (*services.KeepAlive, erro
 	return a.authServer.UpsertNode(s)
 }
 
-func (a *AuthWithRoles) KeepAliveNode(ctx context.Context, handle services.KeepAlive) error {
+func (a *ServerWithRoles) KeepAliveNode(ctx context.Context, handle services.KeepAlive) error {
 	if !a.hasBuiltinRole(string(teleport.RoleNode)) {
 		return trace.AccessDenied("[10] access denied")
 	}
@@ -392,7 +392,7 @@ func (a *AuthWithRoles) KeepAliveNode(ctx context.Context, handle services.KeepA
 }
 
 // NewWatcher returns a new event watcher
-func (a *AuthWithRoles) NewWatcher(ctx context.Context, watch services.Watch) (services.Watcher, error) {
+func (a *ServerWithRoles) NewWatcher(ctx context.Context, watch services.Watch) (services.Watcher, error) {
 	if len(watch.Kinds) == 0 {
 		return nil, trace.AccessDenied("can't setup global watch")
 	}
@@ -480,7 +480,7 @@ func (a *AuthWithRoles) NewWatcher(ctx context.Context, watch services.Watch) (s
 }
 
 // filterNodes filters nodes based off the role of the logged in user.
-func (a *AuthWithRoles) filterNodes(nodes []services.Server) ([]services.Server, error) {
+func (a *ServerWithRoles) filterNodes(nodes []services.Server) ([]services.Server, error) {
 	// For certain built-in roles, continue to allow full access and return
 	// the full set of nodes to not break existing clusters during migration.
 	//
@@ -523,7 +523,7 @@ NextNode:
 }
 
 // DeleteAllNodes deletes all nodes in a given namespace
-func (a *AuthWithRoles) DeleteAllNodes(namespace string) error {
+func (a *ServerWithRoles) DeleteAllNodes(namespace string) error {
 	if err := a.action(namespace, services.KindNode, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -531,14 +531,14 @@ func (a *AuthWithRoles) DeleteAllNodes(namespace string) error {
 }
 
 // DeleteNode deletes node in the namespace
-func (a *AuthWithRoles) DeleteNode(namespace, node string) error {
+func (a *ServerWithRoles) DeleteNode(namespace, node string) error {
 	if err := a.action(namespace, services.KindNode, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteNode(namespace, node)
 }
 
-func (a *AuthWithRoles) GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error) {
+func (a *ServerWithRoles) GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error) {
 	if err := a.action(namespace, services.KindNode, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -570,7 +570,7 @@ func (a *AuthWithRoles) GetNodes(namespace string, opts ...services.MarshalOptio
 	return filteredNodes, nil
 }
 
-func (a *AuthWithRoles) UpsertAuthServer(s services.Server) error {
+func (a *ServerWithRoles) UpsertAuthServer(s services.Server) error {
 	if err := a.action(defaults.Namespace, services.KindAuthServer, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -580,7 +580,7 @@ func (a *AuthWithRoles) UpsertAuthServer(s services.Server) error {
 	return a.authServer.UpsertAuthServer(s)
 }
 
-func (a *AuthWithRoles) GetAuthServers() ([]services.Server, error) {
+func (a *ServerWithRoles) GetAuthServers() ([]services.Server, error) {
 	if err := a.action(defaults.Namespace, services.KindAuthServer, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -591,7 +591,7 @@ func (a *AuthWithRoles) GetAuthServers() ([]services.Server, error) {
 }
 
 // DeleteAllAuthServers deletes all auth servers
-func (a *AuthWithRoles) DeleteAllAuthServers() error {
+func (a *ServerWithRoles) DeleteAllAuthServers() error {
 	if err := a.action(defaults.Namespace, services.KindAuthServer, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -599,14 +599,14 @@ func (a *AuthWithRoles) DeleteAllAuthServers() error {
 }
 
 // DeleteAuthServer deletes auth server by name
-func (a *AuthWithRoles) DeleteAuthServer(name string) error {
+func (a *ServerWithRoles) DeleteAuthServer(name string) error {
 	if err := a.action(defaults.Namespace, services.KindAuthServer, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteAuthServer(name)
 }
 
-func (a *AuthWithRoles) UpsertProxy(s services.Server) error {
+func (a *ServerWithRoles) UpsertProxy(s services.Server) error {
 	if err := a.action(defaults.Namespace, services.KindProxy, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -616,7 +616,7 @@ func (a *AuthWithRoles) UpsertProxy(s services.Server) error {
 	return a.authServer.UpsertProxy(s)
 }
 
-func (a *AuthWithRoles) GetProxies() ([]services.Server, error) {
+func (a *ServerWithRoles) GetProxies() ([]services.Server, error) {
 	if err := a.action(defaults.Namespace, services.KindProxy, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -627,7 +627,7 @@ func (a *AuthWithRoles) GetProxies() ([]services.Server, error) {
 }
 
 // DeleteAllProxies deletes all proxies
-func (a *AuthWithRoles) DeleteAllProxies() error {
+func (a *ServerWithRoles) DeleteAllProxies() error {
 	if err := a.action(defaults.Namespace, services.KindProxy, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -635,14 +635,14 @@ func (a *AuthWithRoles) DeleteAllProxies() error {
 }
 
 // DeleteProxy deletes proxy by name
-func (a *AuthWithRoles) DeleteProxy(name string) error {
+func (a *ServerWithRoles) DeleteProxy(name string) error {
 	if err := a.action(defaults.Namespace, services.KindProxy, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteProxy(name)
 }
 
-func (a *AuthWithRoles) UpsertReverseTunnel(r services.ReverseTunnel) error {
+func (a *ServerWithRoles) UpsertReverseTunnel(r services.ReverseTunnel) error {
 	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -652,14 +652,14 @@ func (a *AuthWithRoles) UpsertReverseTunnel(r services.ReverseTunnel) error {
 	return a.authServer.UpsertReverseTunnel(r)
 }
 
-func (a *AuthWithRoles) GetReverseTunnel(name string, opts ...services.MarshalOption) (services.ReverseTunnel, error) {
+func (a *ServerWithRoles) GetReverseTunnel(name string, opts ...services.MarshalOption) (services.ReverseTunnel, error) {
 	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetReverseTunnel(name, opts...)
 }
 
-func (a *AuthWithRoles) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
+func (a *ServerWithRoles) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
 	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -669,21 +669,21 @@ func (a *AuthWithRoles) GetReverseTunnels(opts ...services.MarshalOption) ([]ser
 	return a.authServer.GetReverseTunnels(opts...)
 }
 
-func (a *AuthWithRoles) DeleteReverseTunnel(domainName string) error {
+func (a *ServerWithRoles) DeleteReverseTunnel(domainName string) error {
 	if err := a.action(defaults.Namespace, services.KindReverseTunnel, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteReverseTunnel(domainName)
 }
 
-func (a *AuthWithRoles) DeleteToken(token string) error {
+func (a *ServerWithRoles) DeleteToken(token string) error {
 	if err := a.action(defaults.Namespace, services.KindToken, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteToken(token)
 }
 
-func (a *AuthWithRoles) GetTokens(opts ...services.MarshalOption) ([]services.ProvisionToken, error) {
+func (a *ServerWithRoles) GetTokens(opts ...services.MarshalOption) ([]services.ProvisionToken, error) {
 	if err := a.action(defaults.Namespace, services.KindToken, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -693,14 +693,14 @@ func (a *AuthWithRoles) GetTokens(opts ...services.MarshalOption) ([]services.Pr
 	return a.authServer.GetTokens(opts...)
 }
 
-func (a *AuthWithRoles) GetToken(token string) (services.ProvisionToken, error) {
+func (a *ServerWithRoles) GetToken(token string) (services.ProvisionToken, error) {
 	if err := a.action(defaults.Namespace, services.KindToken, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetToken(token)
 }
 
-func (a *AuthWithRoles) UpsertToken(token services.ProvisionToken) error {
+func (a *ServerWithRoles) UpsertToken(token services.ProvisionToken) error {
 	if err := a.action(defaults.Namespace, services.KindToken, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -710,7 +710,7 @@ func (a *AuthWithRoles) UpsertToken(token services.ProvisionToken) error {
 	return a.authServer.UpsertToken(token)
 }
 
-func (a *AuthWithRoles) UpsertPassword(user string, password []byte) error {
+func (a *ServerWithRoles) UpsertPassword(user string, password []byte) error {
 	if err := a.currentUserAction(user); err != nil {
 		return trace.Wrap(err)
 	}
@@ -718,69 +718,69 @@ func (a *AuthWithRoles) UpsertPassword(user string, password []byte) error {
 }
 
 // ChangePassword updates users password based on the old password.
-func (a *AuthWithRoles) ChangePassword(req services.ChangePasswordReq) error {
+func (a *ServerWithRoles) ChangePassword(req services.ChangePasswordReq) error {
 	if err := a.currentUserAction(req.User); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.ChangePassword(req)
 }
 
-func (a *AuthWithRoles) CheckPassword(user string, password []byte, otpToken string) error {
+func (a *ServerWithRoles) CheckPassword(user string, password []byte, otpToken string) error {
 	if err := a.currentUserAction(user); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.CheckPassword(user, password, otpToken)
 }
 
-func (a *AuthWithRoles) UpsertTOTP(user string, otpSecret string) error {
+func (a *ServerWithRoles) UpsertTOTP(user string, otpSecret string) error {
 	if err := a.currentUserAction(user); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.UpsertTOTP(user, otpSecret)
 }
 
-func (a *AuthWithRoles) PreAuthenticatedSignIn(user string) (services.WebSession, error) {
+func (a *ServerWithRoles) PreAuthenticatedSignIn(user string) (services.WebSession, error) {
 	if err := a.currentUserAction(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.PreAuthenticatedSignIn(user, a.context.Identity.GetIdentity())
 }
 
-func (a *AuthWithRoles) GetU2FSignRequest(user string, password []byte) (*u2f.SignRequest, error) {
+func (a *ServerWithRoles) GetU2FSignRequest(user string, password []byte) (*u2f.SignRequest, error) {
 	// we are already checking password here, no need to extra permission check
 	// anyone who has user's password can generate sign request
 	return a.authServer.U2FSignRequest(user, password)
 }
 
-func (a *AuthWithRoles) CreateWebSession(user string) (services.WebSession, error) {
+func (a *ServerWithRoles) CreateWebSession(user string) (services.WebSession, error) {
 	if err := a.currentUserAction(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.CreateWebSession(user)
 }
 
-func (a *AuthWithRoles) ExtendWebSession(user, prevSessionID string) (services.WebSession, error) {
+func (a *ServerWithRoles) ExtendWebSession(user, prevSessionID string) (services.WebSession, error) {
 	if err := a.currentUserAction(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.ExtendWebSession(user, prevSessionID, a.context.Identity.GetIdentity())
 }
 
-func (a *AuthWithRoles) GetWebSessionInfo(user string, sid string) (services.WebSession, error) {
+func (a *ServerWithRoles) GetWebSessionInfo(user string, sid string) (services.WebSession, error) {
 	if err := a.currentUserAction(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetWebSessionInfo(user, sid)
 }
 
-func (a *AuthWithRoles) DeleteWebSession(user string, sid string) error {
+func (a *ServerWithRoles) DeleteWebSession(user string, sid string) error {
 	if err := a.currentUserAction(user); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteWebSession(user, sid)
 }
 
-func (a *AuthWithRoles) GetAccessRequests(ctx context.Context, filter services.AccessRequestFilter) ([]services.AccessRequest, error) {
+func (a *ServerWithRoles) GetAccessRequests(ctx context.Context, filter services.AccessRequestFilter) ([]services.AccessRequest, error) {
 	// An exception is made to allow users to get their own access requests.
 	if filter.User == "" || a.currentUserAction(filter.User) != nil {
 		if err := a.action(defaults.Namespace, services.KindAccessRequest, services.VerbList); err != nil {
@@ -793,7 +793,7 @@ func (a *AuthWithRoles) GetAccessRequests(ctx context.Context, filter services.A
 	return a.authServer.GetAccessRequests(ctx, filter)
 }
 
-func (a *AuthWithRoles) CreateAccessRequest(ctx context.Context, req services.AccessRequest) error {
+func (a *ServerWithRoles) CreateAccessRequest(ctx context.Context, req services.AccessRequest) error {
 	// An exception is made to allow users to create access *pending* requests for themselves.
 	if !req.GetState().IsPending() || a.currentUserAction(req.GetUser()) != nil {
 		if err := a.action(defaults.Namespace, services.KindAccessRequest, services.VerbCreate); err != nil {
@@ -807,7 +807,7 @@ func (a *AuthWithRoles) CreateAccessRequest(ctx context.Context, req services.Ac
 	return a.authServer.CreateAccessRequest(ctx, req)
 }
 
-func (a *AuthWithRoles) SetAccessRequestState(ctx context.Context, reqID string, state services.RequestState) error {
+func (a *ServerWithRoles) SetAccessRequestState(ctx context.Context, reqID string, state services.RequestState) error {
 	if err := a.action(defaults.Namespace, services.KindAccessRequest, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -815,7 +815,7 @@ func (a *AuthWithRoles) SetAccessRequestState(ctx context.Context, reqID string,
 }
 
 // GetPluginData loads all plugin data matching the supplied filter.
-func (a *AuthWithRoles) GetPluginData(ctx context.Context, filter services.PluginDataFilter) ([]services.PluginData, error) {
+func (a *ServerWithRoles) GetPluginData(ctx context.Context, filter services.PluginDataFilter) ([]services.PluginData, error) {
 	switch filter.Kind {
 	case services.KindAccessRequest:
 		if err := a.action(defaults.Namespace, services.KindAccessRequest, services.VerbList); err != nil {
@@ -831,7 +831,7 @@ func (a *AuthWithRoles) GetPluginData(ctx context.Context, filter services.Plugi
 }
 
 // UpdatePluginData updates a per-resource PluginData entry.
-func (a *AuthWithRoles) UpdatePluginData(ctx context.Context, params services.PluginDataUpdateParams) error {
+func (a *ServerWithRoles) UpdatePluginData(ctx context.Context, params services.PluginDataUpdateParams) error {
 	switch params.Kind {
 	case services.KindAccessRequest:
 		if err := a.action(defaults.Namespace, services.KindAccessRequest, services.VerbUpdate); err != nil {
@@ -844,7 +844,7 @@ func (a *AuthWithRoles) UpdatePluginData(ctx context.Context, params services.Pl
 }
 
 // Ping gets basic info about the auth server.
-func (a *AuthWithRoles) Ping(ctx context.Context) (proto.PingResponse, error) {
+func (a *ServerWithRoles) Ping(ctx context.Context) (proto.PingResponse, error) {
 	// The Ping method does not require special permissions since it only returns
 	// basic status information.  This is an intentional design choice.  Alternative
 	// methods should be used for relaying any sensitive information.
@@ -877,14 +877,14 @@ func getDelegator(ctx context.Context) string {
 	return delegator
 }
 
-func (a *AuthWithRoles) DeleteAccessRequest(ctx context.Context, name string) error {
+func (a *ServerWithRoles) DeleteAccessRequest(ctx context.Context, name string) error {
 	if err := a.action(defaults.Namespace, services.KindAccessRequest, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteAccessRequest(ctx, name)
 }
 
-func (a *AuthWithRoles) GetUsers(withSecrets bool) ([]services.User, error) {
+func (a *ServerWithRoles) GetUsers(withSecrets bool) ([]services.User, error) {
 	if withSecrets {
 		// TODO(fspmarshall): replace admin requirement with VerbReadWithSecrets once we've
 		// migrated to that model.
@@ -918,7 +918,7 @@ func (a *AuthWithRoles) GetUsers(withSecrets bool) ([]services.User, error) {
 	return a.authServer.GetUsers(withSecrets)
 }
 
-func (a *AuthWithRoles) GetUser(name string, withSecrets bool) (services.User, error) {
+func (a *ServerWithRoles) GetUser(name string, withSecrets bool) (services.User, error) {
 	if withSecrets {
 		// TODO(fspmarshall): replace admin requirement with VerbReadWithSecrets once we've
 		// migrated to that model.
@@ -955,7 +955,7 @@ func (a *AuthWithRoles) GetUser(name string, withSecrets bool) (services.User, e
 }
 
 // DeleteUser deletes an existng user in a backend by username.
-func (a *AuthWithRoles) DeleteUser(ctx context.Context, user string) error {
+func (a *ServerWithRoles) DeleteUser(ctx context.Context, user string) error {
 	if err := a.action(defaults.Namespace, services.KindUser, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -963,14 +963,14 @@ func (a *AuthWithRoles) DeleteUser(ctx context.Context, user string) error {
 	return a.authServer.DeleteUser(ctx, user)
 }
 
-func (a *AuthWithRoles) GenerateKeyPair(pass string) ([]byte, []byte, error) {
+func (a *ServerWithRoles) GenerateKeyPair(pass string) ([]byte, []byte, error) {
 	if err := a.action(defaults.Namespace, services.KindKeyPair, services.VerbCreate); err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 	return a.authServer.GenerateKeyPair(pass)
 }
 
-func (a *AuthWithRoles) GenerateHostCert(
+func (a *ServerWithRoles) GenerateHostCert(
 	key []byte, hostID, nodeName string, principals []string, clusterName string, roles teleport.Roles, ttl time.Duration) ([]byte, error) {
 
 	if err := a.action(defaults.Namespace, services.KindHostCert, services.VerbCreate); err != nil {
@@ -980,12 +980,12 @@ func (a *AuthWithRoles) GenerateHostCert(
 }
 
 // NewKeepAliver returns a new instance of keep aliver
-func (a *AuthWithRoles) NewKeepAliver(ctx context.Context) (services.KeepAliver, error) {
+func (a *ServerWithRoles) NewKeepAliver(ctx context.Context) (services.KeepAliver, error) {
 	return nil, trace.NotImplemented("not implemented")
 }
 
 // GenerateUserCerts generates users certificates
-func (a *AuthWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
+func (a *ServerWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
 	var err error
 	var roles []string
 	var traits wrappers.Traits
@@ -1023,7 +1023,7 @@ func (a *AuthWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserCer
 	default:
 		err := trace.AccessDenied("user %q has requested to generate certs for %q.", a.context.User.GetName(), req.Username)
 		log.Warning(err)
-		if err := a.authServer.emitter.EmitAuditEvent(a.Context(), &events.UserLogin{
+		if err := a.authServer.emitter.EmitAuditEvent(a.CloseContext(), &events.UserLogin{
 			Metadata: events.Metadata{
 				Type: events.UserLoginEvent,
 				Code: events.UserLocalLoginFailureCode,
@@ -1114,35 +1114,35 @@ func (a *AuthWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserCer
 	}, nil
 }
 
-func (a *AuthWithRoles) GetSignupU2FRegisterRequest(token string) (u2fRegisterRequest *u2f.RegisterRequest, e error) {
+func (a *ServerWithRoles) GetSignupU2FRegisterRequest(token string) (u2fRegisterRequest *u2f.RegisterRequest, e error) {
 	// signup token are their own authz resource
 	return a.authServer.CreateSignupU2FRegisterRequest(token)
 }
 
-func (a *AuthWithRoles) CreateResetPasswordToken(ctx context.Context, req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
+func (a *ServerWithRoles) CreateResetPasswordToken(ctx context.Context, req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
 	if err := a.action(defaults.Namespace, services.KindUser, services.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.CreateResetPasswordToken(ctx, req)
 }
 
-func (a *AuthWithRoles) GetResetPasswordToken(ctx context.Context, tokenID string) (services.ResetPasswordToken, error) {
+func (a *ServerWithRoles) GetResetPasswordToken(ctx context.Context, tokenID string) (services.ResetPasswordToken, error) {
 	// tokens are their own authz mechanism, no need to double check
 	return a.authServer.GetResetPasswordToken(ctx, tokenID)
 }
 
-func (a *AuthWithRoles) RotateResetPasswordTokenSecrets(ctx context.Context, tokenID string) (services.ResetPasswordTokenSecrets, error) {
+func (a *ServerWithRoles) RotateResetPasswordTokenSecrets(ctx context.Context, tokenID string) (services.ResetPasswordTokenSecrets, error) {
 	// tokens are their own authz mechanism, no need to double check
 	return a.authServer.RotateResetPasswordTokenSecrets(ctx, tokenID)
 }
 
-func (a *AuthWithRoles) ChangePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.WebSession, error) {
+func (a *ServerWithRoles) ChangePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.WebSession, error) {
 	// Token is it's own authentication, no need to double check.
 	return a.authServer.ChangePasswordWithToken(ctx, req)
 }
 
 // CreateUser inserts a new user entry in a backend.
-func (a *AuthWithRoles) CreateUser(ctx context.Context, user services.User) error {
+func (a *ServerWithRoles) CreateUser(ctx context.Context, user services.User) error {
 	if err := a.action(defaults.Namespace, services.KindUser, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1151,7 +1151,7 @@ func (a *AuthWithRoles) CreateUser(ctx context.Context, user services.User) erro
 
 // UpdateUser updates an existing user in a backend.
 // Captures the auth user who modified the user record.
-func (a *AuthWithRoles) UpdateUser(ctx context.Context, user services.User) error {
+func (a *ServerWithRoles) UpdateUser(ctx context.Context, user services.User) error {
 	if err := a.action(defaults.Namespace, services.KindUser, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1159,7 +1159,7 @@ func (a *AuthWithRoles) UpdateUser(ctx context.Context, user services.User) erro
 	return a.authServer.UpdateUser(ctx, user)
 }
 
-func (a *AuthWithRoles) UpsertUser(u services.User) error {
+func (a *ServerWithRoles) UpsertUser(u services.User) error {
 	if err := a.action(defaults.Namespace, services.KindUser, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1177,7 +1177,7 @@ func (a *AuthWithRoles) UpsertUser(u services.User) error {
 }
 
 // UpsertOIDCConnector creates or updates an OIDC connector.
-func (a *AuthWithRoles) UpsertOIDCConnector(ctx context.Context, connector services.OIDCConnector) error {
+func (a *ServerWithRoles) UpsertOIDCConnector(ctx context.Context, connector services.OIDCConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1187,7 +1187,7 @@ func (a *AuthWithRoles) UpsertOIDCConnector(ctx context.Context, connector servi
 	return a.authServer.UpsertOIDCConnector(ctx, connector)
 }
 
-func (a *AuthWithRoles) GetOIDCConnector(id string, withSecrets bool) (services.OIDCConnector, error) {
+func (a *ServerWithRoles) GetOIDCConnector(id string, withSecrets bool) (services.OIDCConnector, error) {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1199,7 +1199,7 @@ func (a *AuthWithRoles) GetOIDCConnector(id string, withSecrets bool) (services.
 	return a.authServer.Identity.GetOIDCConnector(id, withSecrets)
 }
 
-func (a *AuthWithRoles) GetOIDCConnectors(withSecrets bool) ([]services.OIDCConnector, error) {
+func (a *ServerWithRoles) GetOIDCConnectors(withSecrets bool) ([]services.OIDCConnector, error) {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1214,26 +1214,26 @@ func (a *AuthWithRoles) GetOIDCConnectors(withSecrets bool) ([]services.OIDCConn
 	return a.authServer.Identity.GetOIDCConnectors(withSecrets)
 }
 
-func (a *AuthWithRoles) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*services.OIDCAuthRequest, error) {
+func (a *ServerWithRoles) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*services.OIDCAuthRequest, error) {
 	if err := a.action(defaults.Namespace, services.KindOIDCRequest, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.CreateOIDCAuthRequest(req)
 }
 
-func (a *AuthWithRoles) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthResponse, error) {
+func (a *ServerWithRoles) ValidateOIDCAuthCallback(q url.Values) (*OIDCAuthResponse, error) {
 	// auth callback is it's own authz, no need to check extra permissions
 	return a.authServer.ValidateOIDCAuthCallback(q)
 }
 
-func (a *AuthWithRoles) DeleteOIDCConnector(ctx context.Context, connectorID string) error {
+func (a *ServerWithRoles) DeleteOIDCConnector(ctx context.Context, connectorID string) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindOIDC, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteOIDCConnector(ctx, connectorID)
 }
 
-func (a *AuthWithRoles) CreateSAMLConnector(ctx context.Context, connector services.SAMLConnector) error {
+func (a *ServerWithRoles) CreateSAMLConnector(ctx context.Context, connector services.SAMLConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1241,7 +1241,7 @@ func (a *AuthWithRoles) CreateSAMLConnector(ctx context.Context, connector servi
 }
 
 // UpsertSAMLConnector creates or updates a SAML connector.
-func (a *AuthWithRoles) UpsertSAMLConnector(ctx context.Context, connector services.SAMLConnector) error {
+func (a *ServerWithRoles) UpsertSAMLConnector(ctx context.Context, connector services.SAMLConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1251,7 +1251,7 @@ func (a *AuthWithRoles) UpsertSAMLConnector(ctx context.Context, connector servi
 	return a.authServer.UpsertSAMLConnector(ctx, connector)
 }
 
-func (a *AuthWithRoles) GetSAMLConnector(id string, withSecrets bool) (services.SAMLConnector, error) {
+func (a *ServerWithRoles) GetSAMLConnector(id string, withSecrets bool) (services.SAMLConnector, error) {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1263,7 +1263,7 @@ func (a *AuthWithRoles) GetSAMLConnector(id string, withSecrets bool) (services.
 	return a.authServer.Identity.GetSAMLConnector(id, withSecrets)
 }
 
-func (a *AuthWithRoles) GetSAMLConnectors(withSecrets bool) ([]services.SAMLConnector, error) {
+func (a *ServerWithRoles) GetSAMLConnectors(withSecrets bool) ([]services.SAMLConnector, error) {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1278,27 +1278,27 @@ func (a *AuthWithRoles) GetSAMLConnectors(withSecrets bool) ([]services.SAMLConn
 	return a.authServer.Identity.GetSAMLConnectors(withSecrets)
 }
 
-func (a *AuthWithRoles) CreateSAMLAuthRequest(req services.SAMLAuthRequest) (*services.SAMLAuthRequest, error) {
+func (a *ServerWithRoles) CreateSAMLAuthRequest(req services.SAMLAuthRequest) (*services.SAMLAuthRequest, error) {
 	if err := a.action(defaults.Namespace, services.KindSAMLRequest, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.CreateSAMLAuthRequest(req)
 }
 
-func (a *AuthWithRoles) ValidateSAMLResponse(re string) (*SAMLAuthResponse, error) {
+func (a *ServerWithRoles) ValidateSAMLResponse(re string) (*SAMLAuthResponse, error) {
 	// auth callback is it's own authz, no need to check extra permissions
 	return a.authServer.ValidateSAMLResponse(re)
 }
 
 // DeleteSAMLConnector deletes a SAML connector by name.
-func (a *AuthWithRoles) DeleteSAMLConnector(ctx context.Context, connectorID string) error {
+func (a *ServerWithRoles) DeleteSAMLConnector(ctx context.Context, connectorID string) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindSAML, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteSAMLConnector(ctx, connectorID)
 }
 
-func (a *AuthWithRoles) CreateGithubConnector(connector services.GithubConnector) error {
+func (a *ServerWithRoles) CreateGithubConnector(connector services.GithubConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1306,7 +1306,7 @@ func (a *AuthWithRoles) CreateGithubConnector(connector services.GithubConnector
 }
 
 // UpsertGithubConnector creates or updates a Github connector.
-func (a *AuthWithRoles) UpsertGithubConnector(ctx context.Context, connector services.GithubConnector) error {
+func (a *ServerWithRoles) UpsertGithubConnector(ctx context.Context, connector services.GithubConnector) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1316,7 +1316,7 @@ func (a *AuthWithRoles) UpsertGithubConnector(ctx context.Context, connector ser
 	return a.authServer.upsertGithubConnector(ctx, connector)
 }
 
-func (a *AuthWithRoles) GetGithubConnector(id string, withSecrets bool) (services.GithubConnector, error) {
+func (a *ServerWithRoles) GetGithubConnector(id string, withSecrets bool) (services.GithubConnector, error) {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1328,7 +1328,7 @@ func (a *AuthWithRoles) GetGithubConnector(id string, withSecrets bool) (service
 	return a.authServer.Identity.GetGithubConnector(id, withSecrets)
 }
 
-func (a *AuthWithRoles) GetGithubConnectors(withSecrets bool) ([]services.GithubConnector, error) {
+func (a *ServerWithRoles) GetGithubConnectors(withSecrets bool) ([]services.GithubConnector, error) {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1344,26 +1344,26 @@ func (a *AuthWithRoles) GetGithubConnectors(withSecrets bool) ([]services.Github
 }
 
 // DeleteGithubConnector deletes a Github connector by name.
-func (a *AuthWithRoles) DeleteGithubConnector(ctx context.Context, connectorID string) error {
+func (a *ServerWithRoles) DeleteGithubConnector(ctx context.Context, connectorID string) error {
 	if err := a.authConnectorAction(defaults.Namespace, services.KindGithub, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.deleteGithubConnector(ctx, connectorID)
 }
 
-func (a *AuthWithRoles) CreateGithubAuthRequest(req services.GithubAuthRequest) (*services.GithubAuthRequest, error) {
+func (a *ServerWithRoles) CreateGithubAuthRequest(req services.GithubAuthRequest) (*services.GithubAuthRequest, error) {
 	if err := a.action(defaults.Namespace, services.KindGithubRequest, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.CreateGithubAuthRequest(req)
 }
 
-func (a *AuthWithRoles) ValidateGithubAuthCallback(q url.Values) (*GithubAuthResponse, error) {
+func (a *ServerWithRoles) ValidateGithubAuthCallback(q url.Values) (*GithubAuthResponse, error) {
 	return a.authServer.ValidateGithubAuthCallback(q)
 }
 
 // EmitAuditEvent emits a single audit event
-func (a *AuthWithRoles) EmitAuditEvent(ctx context.Context, event events.AuditEvent) error {
+func (a *ServerWithRoles) EmitAuditEvent(ctx context.Context, event events.AuditEvent) error {
 	if err := a.action(defaults.Namespace, services.KindEvent, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1385,7 +1385,7 @@ func (a *AuthWithRoles) EmitAuditEvent(ctx context.Context, event events.AuditEv
 }
 
 // CreateAuditStream creates audit event stream
-func (a *AuthWithRoles) CreateAuditStream(ctx context.Context, sid session.ID) (events.Stream, error) {
+func (a *ServerWithRoles) CreateAuditStream(ctx context.Context, sid session.ID) (events.Stream, error) {
 	if err := a.action(defaults.Namespace, services.KindEvent, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1408,7 +1408,7 @@ func (a *AuthWithRoles) CreateAuditStream(ctx context.Context, sid session.ID) (
 }
 
 // ResumeAuditStream resumes the stream that has been created
-func (a *AuthWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (events.Stream, error) {
+func (a *ServerWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (events.Stream, error) {
 	if err := a.action(defaults.Namespace, services.KindEvent, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1432,7 +1432,7 @@ func (a *AuthWithRoles) ResumeAuditStream(ctx context.Context, sid session.ID, u
 
 // streamWithRoles verifies every event
 type streamWithRoles struct {
-	a        *AuthWithRoles
+	a        *ServerWithRoles
 	serverID string
 	stream   events.Stream
 }
@@ -1474,7 +1474,7 @@ func (s *streamWithRoles) EmitAuditEvent(ctx context.Context, event events.Audit
 	return s.stream.EmitAuditEvent(ctx, event)
 }
 
-func (a *AuthWithRoles) EmitAuditEventLegacy(event events.Event, fields events.EventFields) error {
+func (a *ServerWithRoles) EmitAuditEventLegacy(event events.Event, fields events.EventFields) error {
 	if err := a.action(defaults.Namespace, services.KindEvent, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1484,7 +1484,7 @@ func (a *AuthWithRoles) EmitAuditEventLegacy(event events.Event, fields events.E
 	return a.alog.EmitAuditEventLegacy(event, fields)
 }
 
-func (a *AuthWithRoles) PostSessionSlice(slice events.SessionSlice) error {
+func (a *ServerWithRoles) PostSessionSlice(slice events.SessionSlice) error {
 	if err := a.action(slice.Namespace, services.KindEvent, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1494,7 +1494,7 @@ func (a *AuthWithRoles) PostSessionSlice(slice events.SessionSlice) error {
 	return a.alog.PostSessionSlice(slice)
 }
 
-func (a *AuthWithRoles) UploadSessionRecording(r events.SessionRecording) error {
+func (a *ServerWithRoles) UploadSessionRecording(r events.SessionRecording) error {
 	if err := r.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1507,7 +1507,7 @@ func (a *AuthWithRoles) UploadSessionRecording(r events.SessionRecording) error 
 	return a.alog.UploadSessionRecording(r)
 }
 
-func (a *AuthWithRoles) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
+func (a *ServerWithRoles) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
 	if err := a.action(namespace, services.KindSession, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1515,7 +1515,7 @@ func (a *AuthWithRoles) GetSessionChunk(namespace string, sid session.ID, offset
 	return a.alog.GetSessionChunk(namespace, sid, offsetBytes, maxBytes)
 }
 
-func (a *AuthWithRoles) GetSessionEvents(namespace string, sid session.ID, afterN int, includePrintEvents bool) ([]events.EventFields, error) {
+func (a *ServerWithRoles) GetSessionEvents(namespace string, sid session.ID, afterN int, includePrintEvents bool) ([]events.EventFields, error) {
 	if err := a.action(namespace, services.KindSession, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1523,7 +1523,7 @@ func (a *AuthWithRoles) GetSessionEvents(namespace string, sid session.ID, after
 	return a.alog.GetSessionEvents(namespace, sid, afterN, includePrintEvents)
 }
 
-func (a *AuthWithRoles) SearchEvents(from, to time.Time, query string, limit int) ([]events.EventFields, error) {
+func (a *ServerWithRoles) SearchEvents(from, to time.Time, query string, limit int) ([]events.EventFields, error) {
 	if err := a.action(defaults.Namespace, services.KindEvent, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1531,7 +1531,7 @@ func (a *AuthWithRoles) SearchEvents(from, to time.Time, query string, limit int
 	return a.alog.SearchEvents(from, to, query, limit)
 }
 
-func (a *AuthWithRoles) SearchSessionEvents(from, to time.Time, limit int) ([]events.EventFields, error) {
+func (a *ServerWithRoles) SearchSessionEvents(from, to time.Time, limit int) ([]events.EventFields, error) {
 	if err := a.action(defaults.Namespace, services.KindSession, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1540,7 +1540,7 @@ func (a *AuthWithRoles) SearchSessionEvents(from, to time.Time, limit int) ([]ev
 }
 
 // GetNamespaces returns a list of namespaces
-func (a *AuthWithRoles) GetNamespaces() ([]services.Namespace, error) {
+func (a *ServerWithRoles) GetNamespaces() ([]services.Namespace, error) {
 	if err := a.action(defaults.Namespace, services.KindNamespace, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1551,7 +1551,7 @@ func (a *AuthWithRoles) GetNamespaces() ([]services.Namespace, error) {
 }
 
 // GetNamespace returns namespace by name
-func (a *AuthWithRoles) GetNamespace(name string) (*services.Namespace, error) {
+func (a *ServerWithRoles) GetNamespace(name string) (*services.Namespace, error) {
 	if err := a.action(defaults.Namespace, services.KindNamespace, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1559,7 +1559,7 @@ func (a *AuthWithRoles) GetNamespace(name string) (*services.Namespace, error) {
 }
 
 // UpsertNamespace upserts namespace
-func (a *AuthWithRoles) UpsertNamespace(ns services.Namespace) error {
+func (a *ServerWithRoles) UpsertNamespace(ns services.Namespace) error {
 	if err := a.action(defaults.Namespace, services.KindNamespace, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1570,7 +1570,7 @@ func (a *AuthWithRoles) UpsertNamespace(ns services.Namespace) error {
 }
 
 // DeleteNamespace deletes namespace by name
-func (a *AuthWithRoles) DeleteNamespace(name string) error {
+func (a *ServerWithRoles) DeleteNamespace(name string) error {
 	if err := a.action(defaults.Namespace, services.KindNamespace, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1578,7 +1578,7 @@ func (a *AuthWithRoles) DeleteNamespace(name string) error {
 }
 
 // GetRoles returns a list of roles
-func (a *AuthWithRoles) GetRoles() ([]services.Role, error) {
+func (a *ServerWithRoles) GetRoles() ([]services.Role, error) {
 	if err := a.action(defaults.Namespace, services.KindRole, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1589,12 +1589,12 @@ func (a *AuthWithRoles) GetRoles() ([]services.Role, error) {
 }
 
 // CreateRole creates a role.
-func (a *AuthWithRoles) CreateRole(role services.Role) error {
+func (a *ServerWithRoles) CreateRole(role services.Role) error {
 	return trace.NotImplemented("not implemented")
 }
 
 // UpsertRole creates or updates role.
-func (a *AuthWithRoles) UpsertRole(ctx context.Context, role services.Role) error {
+func (a *ServerWithRoles) UpsertRole(ctx context.Context, role services.Role) error {
 	if err := a.action(defaults.Namespace, services.KindRole, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1606,7 +1606,7 @@ func (a *AuthWithRoles) UpsertRole(ctx context.Context, role services.Role) erro
 }
 
 // GetRole returns role by name
-func (a *AuthWithRoles) GetRole(name string) (services.Role, error) {
+func (a *ServerWithRoles) GetRole(name string) (services.Role, error) {
 	// Current-user exception: we always allow users to read roles
 	// that they hold.  This requirement is checked first to avoid
 	// misleading denial messages in the logs.
@@ -1619,7 +1619,7 @@ func (a *AuthWithRoles) GetRole(name string) (services.Role, error) {
 }
 
 // DeleteRole deletes role by name
-func (a *AuthWithRoles) DeleteRole(ctx context.Context, name string) error {
+func (a *ServerWithRoles) DeleteRole(ctx context.Context, name string) error {
 	if err := a.action(defaults.Namespace, services.KindRole, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1627,7 +1627,7 @@ func (a *AuthWithRoles) DeleteRole(ctx context.Context, name string) error {
 }
 
 // GetClusterConfig gets cluster level configuration.
-func (a *AuthWithRoles) GetClusterConfig(opts ...services.MarshalOption) (services.ClusterConfig, error) {
+func (a *ServerWithRoles) GetClusterConfig(opts ...services.MarshalOption) (services.ClusterConfig, error) {
 	if err := a.action(defaults.Namespace, services.KindClusterConfig, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1635,7 +1635,7 @@ func (a *AuthWithRoles) GetClusterConfig(opts ...services.MarshalOption) (servic
 }
 
 // DeleteClusterConfig deletes cluster config
-func (a *AuthWithRoles) DeleteClusterConfig() error {
+func (a *ServerWithRoles) DeleteClusterConfig() error {
 	if err := a.action(defaults.Namespace, services.KindClusterConfig, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1643,7 +1643,7 @@ func (a *AuthWithRoles) DeleteClusterConfig() error {
 }
 
 // DeleteClusterName deletes cluster name
-func (a *AuthWithRoles) DeleteClusterName() error {
+func (a *ServerWithRoles) DeleteClusterName() error {
 	if err := a.action(defaults.Namespace, services.KindClusterName, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1651,7 +1651,7 @@ func (a *AuthWithRoles) DeleteClusterName() error {
 }
 
 // DeleteStaticTokens deletes static tokens
-func (a *AuthWithRoles) DeleteStaticTokens() error {
+func (a *ServerWithRoles) DeleteStaticTokens() error {
 	if err := a.action(defaults.Namespace, services.KindStaticTokens, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1659,7 +1659,7 @@ func (a *AuthWithRoles) DeleteStaticTokens() error {
 }
 
 // SetClusterConfig sets cluster level configuration.
-func (a *AuthWithRoles) SetClusterConfig(c services.ClusterConfig) error {
+func (a *ServerWithRoles) SetClusterConfig(c services.ClusterConfig) error {
 	if err := a.action(defaults.Namespace, services.KindClusterConfig, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1670,7 +1670,7 @@ func (a *AuthWithRoles) SetClusterConfig(c services.ClusterConfig) error {
 }
 
 // GetClusterName gets the name of the cluster.
-func (a *AuthWithRoles) GetClusterName(opts ...services.MarshalOption) (services.ClusterName, error) {
+func (a *ServerWithRoles) GetClusterName(opts ...services.MarshalOption) (services.ClusterName, error) {
 	if err := a.action(defaults.Namespace, services.KindClusterName, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1678,7 +1678,7 @@ func (a *AuthWithRoles) GetClusterName(opts ...services.MarshalOption) (services
 }
 
 // SetClusterName sets the name of the cluster. SetClusterName can only be called once.
-func (a *AuthWithRoles) SetClusterName(c services.ClusterName) error {
+func (a *ServerWithRoles) SetClusterName(c services.ClusterName) error {
 	if err := a.action(defaults.Namespace, services.KindClusterName, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1689,7 +1689,7 @@ func (a *AuthWithRoles) SetClusterName(c services.ClusterName) error {
 }
 
 // UpsertClusterName sets the name of the cluster.
-func (a *AuthWithRoles) UpsertClusterName(c services.ClusterName) error {
+func (a *ServerWithRoles) UpsertClusterName(c services.ClusterName) error {
 	if err := a.action(defaults.Namespace, services.KindClusterName, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1700,7 +1700,7 @@ func (a *AuthWithRoles) UpsertClusterName(c services.ClusterName) error {
 }
 
 // GetStaticTokens gets the list of static tokens used to provision nodes.
-func (a *AuthWithRoles) GetStaticTokens() (services.StaticTokens, error) {
+func (a *ServerWithRoles) GetStaticTokens() (services.StaticTokens, error) {
 	if err := a.action(defaults.Namespace, services.KindStaticTokens, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1708,7 +1708,7 @@ func (a *AuthWithRoles) GetStaticTokens() (services.StaticTokens, error) {
 }
 
 // SetStaticTokens sets the list of static tokens used to provision nodes.
-func (a *AuthWithRoles) SetStaticTokens(s services.StaticTokens) error {
+func (a *ServerWithRoles) SetStaticTokens(s services.StaticTokens) error {
 	if err := a.action(defaults.Namespace, services.KindStaticTokens, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1718,7 +1718,7 @@ func (a *AuthWithRoles) SetStaticTokens(s services.StaticTokens) error {
 	return a.authServer.SetStaticTokens(s)
 }
 
-func (a *AuthWithRoles) GetAuthPreference() (services.AuthPreference, error) {
+func (a *ServerWithRoles) GetAuthPreference() (services.AuthPreference, error) {
 	if err := a.action(defaults.Namespace, services.KindClusterAuthPreference, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1726,7 +1726,7 @@ func (a *AuthWithRoles) GetAuthPreference() (services.AuthPreference, error) {
 	return a.authServer.GetAuthPreference()
 }
 
-func (a *AuthWithRoles) SetAuthPreference(cap services.AuthPreference) error {
+func (a *ServerWithRoles) SetAuthPreference(cap services.AuthPreference) error {
 	if err := a.action(defaults.Namespace, services.KindClusterAuthPreference, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1738,36 +1738,36 @@ func (a *AuthWithRoles) SetAuthPreference(cap services.AuthPreference) error {
 }
 
 // DeleteAllTokens deletes all tokens
-func (a *AuthWithRoles) DeleteAllTokens() error {
+func (a *ServerWithRoles) DeleteAllTokens() error {
 	return trace.NotImplemented("not implemented")
 }
 
 // DeleteAllCertAuthorities deletes all certificate authorities of a certain type
-func (a *AuthWithRoles) DeleteAllCertAuthorities(caType services.CertAuthType) error {
+func (a *ServerWithRoles) DeleteAllCertAuthorities(caType services.CertAuthType) error {
 	return trace.NotImplemented("not implemented")
 }
 
 // DeleteAllCertNamespaces deletes all namespaces
-func (a *AuthWithRoles) DeleteAllNamespaces() error {
+func (a *ServerWithRoles) DeleteAllNamespaces() error {
 	return trace.NotImplemented("not implemented")
 }
 
 // DeleteAllReverseTunnels deletes all reverse tunnels
-func (a *AuthWithRoles) DeleteAllReverseTunnels() error {
+func (a *ServerWithRoles) DeleteAllReverseTunnels() error {
 	return trace.NotImplemented("not implemented")
 }
 
 // DeleteAllRoles deletes all roles
-func (a *AuthWithRoles) DeleteAllRoles() error {
+func (a *ServerWithRoles) DeleteAllRoles() error {
 	return trace.NotImplemented("not implemented")
 }
 
 // DeleteAllUsers deletes all users
-func (a *AuthWithRoles) DeleteAllUsers() error {
+func (a *ServerWithRoles) DeleteAllUsers() error {
 	return trace.NotImplemented("not implemented")
 }
 
-func (a *AuthWithRoles) GetTrustedClusters() ([]services.TrustedCluster, error) {
+func (a *ServerWithRoles) GetTrustedClusters() ([]services.TrustedCluster, error) {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1778,7 +1778,7 @@ func (a *AuthWithRoles) GetTrustedClusters() ([]services.TrustedCluster, error) 
 	return a.authServer.GetTrustedClusters()
 }
 
-func (a *AuthWithRoles) GetTrustedCluster(name string) (services.TrustedCluster, error) {
+func (a *ServerWithRoles) GetTrustedCluster(name string) (services.TrustedCluster, error) {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1787,7 +1787,7 @@ func (a *AuthWithRoles) GetTrustedCluster(name string) (services.TrustedCluster,
 }
 
 // UpsertTrustedCluster creates or updates a trusted cluster.
-func (a *AuthWithRoles) UpsertTrustedCluster(ctx context.Context, tc services.TrustedCluster) (services.TrustedCluster, error) {
+func (a *ServerWithRoles) UpsertTrustedCluster(ctx context.Context, tc services.TrustedCluster) (services.TrustedCluster, error) {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1798,13 +1798,13 @@ func (a *AuthWithRoles) UpsertTrustedCluster(ctx context.Context, tc services.Tr
 	return a.authServer.UpsertTrustedCluster(ctx, tc)
 }
 
-func (a *AuthWithRoles) ValidateTrustedCluster(validateRequest *ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error) {
+func (a *ServerWithRoles) ValidateTrustedCluster(validateRequest *ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error) {
 	// the token provides it's own authorization and authentication
 	return a.authServer.validateTrustedCluster(validateRequest)
 }
 
 // DeleteTrustedCluster deletes a trusted cluster by name.
-func (a *AuthWithRoles) DeleteTrustedCluster(ctx context.Context, name string) error {
+func (a *ServerWithRoles) DeleteTrustedCluster(ctx context.Context, name string) error {
 	if err := a.action(defaults.Namespace, services.KindTrustedCluster, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1812,7 +1812,7 @@ func (a *AuthWithRoles) DeleteTrustedCluster(ctx context.Context, name string) e
 	return a.authServer.DeleteTrustedCluster(ctx, name)
 }
 
-func (a *AuthWithRoles) UpsertTunnelConnection(conn services.TunnelConnection) error {
+func (a *ServerWithRoles) UpsertTunnelConnection(conn services.TunnelConnection) error {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1822,28 +1822,28 @@ func (a *AuthWithRoles) UpsertTunnelConnection(conn services.TunnelConnection) e
 	return a.authServer.UpsertTunnelConnection(conn)
 }
 
-func (a *AuthWithRoles) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
+func (a *ServerWithRoles) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetTunnelConnections(clusterName, opts...)
 }
 
-func (a *AuthWithRoles) GetAllTunnelConnections(opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
+func (a *ServerWithRoles) GetAllTunnelConnections(opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetAllTunnelConnections(opts...)
 }
 
-func (a *AuthWithRoles) DeleteTunnelConnection(clusterName string, connName string) error {
+func (a *ServerWithRoles) DeleteTunnelConnection(clusterName string, connName string) error {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteTunnelConnection(clusterName, connName)
 }
 
-func (a *AuthWithRoles) DeleteTunnelConnections(clusterName string) error {
+func (a *ServerWithRoles) DeleteTunnelConnections(clusterName string) error {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbList); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1853,7 +1853,7 @@ func (a *AuthWithRoles) DeleteTunnelConnections(clusterName string) error {
 	return a.authServer.DeleteTunnelConnections(clusterName)
 }
 
-func (a *AuthWithRoles) DeleteAllTunnelConnections() error {
+func (a *ServerWithRoles) DeleteAllTunnelConnections() error {
 	if err := a.action(defaults.Namespace, services.KindTunnelConnection, services.VerbList); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1863,39 +1863,39 @@ func (a *AuthWithRoles) DeleteAllTunnelConnections() error {
 	return a.authServer.DeleteAllTunnelConnections()
 }
 
-func (a *AuthWithRoles) CreateRemoteCluster(conn services.RemoteCluster) error {
+func (a *ServerWithRoles) CreateRemoteCluster(conn services.RemoteCluster) error {
 	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbCreate); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.CreateRemoteCluster(conn)
 }
 
-func (a *AuthWithRoles) UpdateRemoteCluster(ctx context.Context, conn services.RemoteCluster) error {
+func (a *ServerWithRoles) UpdateRemoteCluster(ctx context.Context, conn services.RemoteCluster) error {
 	return trace.NotImplemented("not implemented: remote clusters can only be updated by auth server locally")
 }
 
-func (a *AuthWithRoles) GetRemoteCluster(clusterName string) (services.RemoteCluster, error) {
+func (a *ServerWithRoles) GetRemoteCluster(clusterName string) (services.RemoteCluster, error) {
 	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetRemoteCluster(clusterName)
 }
 
-func (a *AuthWithRoles) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
+func (a *ServerWithRoles) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
 	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.authServer.GetRemoteClusters(opts...)
 }
 
-func (a *AuthWithRoles) DeleteRemoteCluster(clusterName string) error {
+func (a *ServerWithRoles) DeleteRemoteCluster(clusterName string) error {
 	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.authServer.DeleteRemoteCluster(clusterName)
 }
 
-func (a *AuthWithRoles) DeleteAllRemoteClusters() error {
+func (a *ServerWithRoles) DeleteAllRemoteClusters() error {
 	if err := a.action(defaults.Namespace, services.KindRemoteCluster, services.VerbList); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1906,7 +1906,7 @@ func (a *AuthWithRoles) DeleteAllRemoteClusters() error {
 }
 
 // AcquireSemaphore acquires lease with requested resources from semaphore.
-func (a *AuthWithRoles) AcquireSemaphore(ctx context.Context, params services.AcquireSemaphoreRequest) (*services.SemaphoreLease, error) {
+func (a *ServerWithRoles) AcquireSemaphore(ctx context.Context, params services.AcquireSemaphoreRequest) (*services.SemaphoreLease, error) {
 	if err := a.action(defaults.Namespace, services.KindSemaphore, services.VerbCreate); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1917,7 +1917,7 @@ func (a *AuthWithRoles) AcquireSemaphore(ctx context.Context, params services.Ac
 }
 
 // KeepAliveSemaphoreLease updates semaphore lease.
-func (a *AuthWithRoles) KeepAliveSemaphoreLease(ctx context.Context, lease services.SemaphoreLease) error {
+func (a *ServerWithRoles) KeepAliveSemaphoreLease(ctx context.Context, lease services.SemaphoreLease) error {
 	if err := a.action(defaults.Namespace, services.KindSemaphore, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1925,7 +1925,7 @@ func (a *AuthWithRoles) KeepAliveSemaphoreLease(ctx context.Context, lease servi
 }
 
 // CancelSemaphoreLease cancels semaphore lease early.
-func (a *AuthWithRoles) CancelSemaphoreLease(ctx context.Context, lease services.SemaphoreLease) error {
+func (a *ServerWithRoles) CancelSemaphoreLease(ctx context.Context, lease services.SemaphoreLease) error {
 	if err := a.action(defaults.Namespace, services.KindSemaphore, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1933,7 +1933,7 @@ func (a *AuthWithRoles) CancelSemaphoreLease(ctx context.Context, lease services
 }
 
 // GetSemaphores returns a list of all semaphores matching the supplied filter.
-func (a *AuthWithRoles) GetSemaphores(ctx context.Context, filter services.SemaphoreFilter) ([]services.Semaphore, error) {
+func (a *ServerWithRoles) GetSemaphores(ctx context.Context, filter services.SemaphoreFilter) ([]services.Semaphore, error) {
 	if err := a.action(defaults.Namespace, services.KindSemaphore, services.VerbReadNoSecrets); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1944,7 +1944,7 @@ func (a *AuthWithRoles) GetSemaphores(ctx context.Context, filter services.Semap
 }
 
 // DeleteSemaphore deletes a semaphore matching the supplied filter.
-func (a *AuthWithRoles) DeleteSemaphore(ctx context.Context, filter services.SemaphoreFilter) error {
+func (a *ServerWithRoles) DeleteSemaphore(ctx context.Context, filter services.SemaphoreFilter) error {
 	if err := a.action(defaults.Namespace, services.KindSemaphore, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1953,7 +1953,7 @@ func (a *AuthWithRoles) DeleteSemaphore(ctx context.Context, filter services.Sem
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
 // signed certificate if successful.
-func (a *AuthWithRoles) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
+func (a *ServerWithRoles) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	// limits the requests types to proxies to make it harder to break
 	if !a.hasBuiltinRole(string(teleport.RoleProxy)) {
 		return nil, trace.AccessDenied("this request can be only executed by a proxy")
@@ -1961,22 +1961,22 @@ func (a *AuthWithRoles) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	return a.authServer.ProcessKubeCSR(req)
 }
 
-func (a *AuthWithRoles) Close() error {
+func (a *ServerWithRoles) Close() error {
 	return a.authServer.Close()
 }
 
-func (a *AuthWithRoles) WaitForDelivery(context.Context) error {
+func (a *ServerWithRoles) WaitForDelivery(context.Context) error {
 	return nil
 }
 
 // NewAdminAuthServer returns auth server authorized as admin,
 // used for auth server cached access
-func NewAdminAuthServer(authServer *AuthServer, sessions session.Service, alog events.IAuditLog) (ClientI, error) {
+func NewAdminAuthServer(authServer *Server, sessions session.Service, alog events.IAuditLog) (ClientI, error) {
 	ctx, err := NewAdminContext()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &AuthWithRoles{
+	return &ServerWithRoles{
 		authServer: authServer,
 		context:    *ctx,
 		alog:       alog,

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -38,12 +38,12 @@ import (
 )
 
 // CreateGithubAuthRequest creates a new request for Github OAuth2 flow
-func (s *AuthServer) CreateGithubAuthRequest(req services.GithubAuthRequest) (*services.GithubAuthRequest, error) {
-	connector, err := s.Identity.GetGithubConnector(req.ConnectorID, true)
+func (a *Server) CreateGithubAuthRequest(req services.GithubAuthRequest) (*services.GithubAuthRequest, error) {
+	connector, err := a.Identity.GetGithubConnector(req.ConnectorID, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	client, err := s.getGithubOAuth2Client(connector)
+	client, err := a.getGithubOAuth2Client(connector)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -54,8 +54,8 @@ func (s *AuthServer) CreateGithubAuthRequest(req services.GithubAuthRequest) (*s
 	req.RedirectURL = client.AuthCodeURL(req.StateToken, "", "")
 	log.WithFields(logrus.Fields{trace.Component: "github"}).Debugf(
 		"Redirect URL: %v.", req.RedirectURL)
-	req.SetTTL(s.GetClock(), defaults.GithubAuthRequestTTL)
-	err = s.Identity.CreateGithubAuthRequest(req)
+	req.SetTTL(a.GetClock(), defaults.GithubAuthRequestTTL)
+	err = a.Identity.CreateGithubAuthRequest(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -63,11 +63,11 @@ func (s *AuthServer) CreateGithubAuthRequest(req services.GithubAuthRequest) (*s
 }
 
 // upsertGithubConnector creates or updates a Github connector.
-func (s *AuthServer) upsertGithubConnector(ctx context.Context, connector services.GithubConnector) error {
-	if err := s.Identity.UpsertGithubConnector(connector); err != nil {
+func (a *Server) upsertGithubConnector(ctx context.Context, connector services.GithubConnector) error {
+	if err := a.Identity.UpsertGithubConnector(connector); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := s.emitter.EmitAuditEvent(s.closeCtx, &events.GithubConnectorCreate{
+	if err := a.emitter.EmitAuditEvent(a.closeCtx, &events.GithubConnectorCreate{
 		Metadata: events.Metadata{
 			Type: events.GithubConnectorCreatedEvent,
 			Code: events.GithubConnectorCreatedCode,
@@ -86,12 +86,12 @@ func (s *AuthServer) upsertGithubConnector(ctx context.Context, connector servic
 }
 
 // deleteGithubConnector deletes a Github connector by name.
-func (s *AuthServer) deleteGithubConnector(ctx context.Context, connectorName string) error {
-	if err := s.Identity.DeleteGithubConnector(connectorName); err != nil {
+func (a *Server) deleteGithubConnector(ctx context.Context, connectorName string) error {
+	if err := a.Identity.DeleteGithubConnector(connectorName); err != nil {
 		return trace.Wrap(err)
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.closeCtx, &events.GithubConnectorDelete{
+	if err := a.emitter.EmitAuditEvent(a.closeCtx, &events.GithubConnectorDelete{
 		Metadata: events.Metadata{
 			Type: events.GithubConnectorDeletedEvent,
 			Code: events.GithubConnectorDeletedCode,
@@ -129,7 +129,7 @@ type GithubAuthResponse struct {
 }
 
 // ValidateGithubAuthCallback validates Github auth callback redirect
-func (a *AuthServer) ValidateGithubAuthCallback(q url.Values) (*GithubAuthResponse, error) {
+func (a *Server) ValidateGithubAuthCallback(q url.Values) (*GithubAuthResponse, error) {
 	re, err := a.validateGithubAuthCallback(q)
 	event := &events.UserLogin{
 		Metadata: events.Metadata{
@@ -167,7 +167,7 @@ type githubAuthResponse struct {
 }
 
 // ValidateGithubAuthCallback validates Github auth callback redirect
-func (s *AuthServer) validateGithubAuthCallback(q url.Values) (*githubAuthResponse, error) {
+func (a *Server) validateGithubAuthCallback(q url.Values) (*githubAuthResponse, error) {
 	logger := log.WithFields(logrus.Fields{trace.Component: "github"})
 	error := q.Get("error")
 	if error != "" {
@@ -183,11 +183,11 @@ func (s *AuthServer) validateGithubAuthCallback(q url.Values) (*githubAuthRespon
 		return nil, trace.OAuth2(oauth2.ErrorInvalidRequest,
 			"missing state query param", q)
 	}
-	req, err := s.Identity.GetGithubAuthRequest(stateToken)
+	req, err := a.Identity.GetGithubAuthRequest(stateToken)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	connector, err := s.Identity.GetGithubConnector(req.ConnectorID, true)
+	connector, err := a.Identity.GetGithubConnector(req.ConnectorID, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -197,7 +197,7 @@ func (s *AuthServer) validateGithubAuthCallback(q url.Values) (*githubAuthRespon
 		return nil, trace.BadParameter(
 			"connector %q has empty teams_to_logins mapping", connector.GetName())
 	}
-	client, err := s.getGithubOAuth2Client(connector)
+	client, err := a.getGithubOAuth2Client(connector)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -212,7 +212,7 @@ func (s *AuthServer) validateGithubAuthCallback(q url.Values) (*githubAuthRespon
 	// by making requests to Github API using the access token
 	claims, err := populateGithubClaims(&githubAPIClient{
 		token:      token.AccessToken,
-		authServer: s,
+		authServer: a,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -224,11 +224,11 @@ func (s *AuthServer) validateGithubAuthCallback(q url.Values) (*githubAuthRespon
 
 	// Calculate (figure out name, roles, traits, session TTL) of user and
 	// create the user in the backend.
-	params, err := s.calculateGithubUser(connector, claims, req)
+	params, err := a.calculateGithubUser(connector, claims, req)
 	if err != nil {
 		return re, trace.Wrap(err)
 	}
-	user, err := s.createGithubUser(params)
+	user, err := a.createGithubUser(params)
 	if err != nil {
 		return re, trace.Wrap(err)
 	}
@@ -246,7 +246,7 @@ func (s *AuthServer) validateGithubAuthCallback(q url.Values) (*githubAuthRespon
 
 	// If the request is coming from a browser, create a web session.
 	if req.CreateWebSession {
-		session, err := s.createWebSession(user, params.sessionTTL)
+		session, err := a.createWebSession(user, params.sessionTTL)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -256,12 +256,12 @@ func (s *AuthServer) validateGithubAuthCallback(q url.Values) (*githubAuthRespon
 
 	// If a public key was provided, sign it and return a certificate.
 	if len(req.PublicKey) != 0 {
-		sshCert, tlsCert, err := s.createSessionCert(user, params.sessionTTL, req.PublicKey, req.Compatibility, req.RouteToCluster, req.KubernetesCluster)
+		sshCert, tlsCert, err := a.createSessionCert(user, params.sessionTTL, req.PublicKey, req.Compatibility, req.RouteToCluster, req.KubernetesCluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		clusterName, err := s.GetClusterName()
+		clusterName, err := a.GetClusterName()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -270,7 +270,7 @@ func (s *AuthServer) validateGithubAuthCallback(q url.Values) (*githubAuthRespon
 		re.auth.TLSCert = tlsCert
 
 		// Return the host CA for this cluster only.
-		authority, err := s.GetCertAuthority(services.CertAuthID{
+		authority, err := a.GetCertAuthority(services.CertAuthID{
 			Type:       services.HostCA,
 			DomainName: clusterName.GetClusterName(),
 		}, false)
@@ -283,23 +283,23 @@ func (s *AuthServer) validateGithubAuthCallback(q url.Values) (*githubAuthRespon
 	return re, nil
 }
 
-func (s *AuthServer) createWebSession(user services.User, sessionTTL time.Duration) (services.WebSession, error) {
+func (a *Server) createWebSession(user services.User, sessionTTL time.Duration) (services.WebSession, error) {
 	// It's safe to extract the roles and traits directly from services.User
 	// because this occurs during the user creation process and services.User
 	// is not fetched from the backend.
-	session, err := s.NewWebSession(user.GetName(), user.GetRoles(), user.GetTraits())
+	session, err := a.NewWebSession(user.GetName(), user.GetRoles(), user.GetTraits())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Session expiry time is the same as the user expiry time.
-	session.SetExpiryTime(s.clock.Now().UTC().Add(sessionTTL))
+	session.SetExpiryTime(a.clock.Now().UTC().Add(sessionTTL))
 
 	// Bearer tokens expire quicker than the overall session time and need to be refreshed.
 	bearerTTL := utils.MinTTL(BearerTokenTTL, sessionTTL)
-	session.SetBearerTokenExpiryTime(s.clock.Now().UTC().Add(bearerTTL))
+	session.SetBearerTokenExpiryTime(a.clock.Now().UTC().Add(bearerTTL))
 
-	err = s.UpsertWebSession(user.GetName(), session)
+	err = a.UpsertWebSession(user.GetName(), session)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -307,16 +307,16 @@ func (s *AuthServer) createWebSession(user services.User, sessionTTL time.Durati
 	return session, nil
 }
 
-func (s *AuthServer) createSessionCert(user services.User, sessionTTL time.Duration, publicKey []byte, compatibility, routeToCluster, kubernetesCluster string) ([]byte, []byte, error) {
+func (a *Server) createSessionCert(user services.User, sessionTTL time.Duration, publicKey []byte, compatibility, routeToCluster, kubernetesCluster string) ([]byte, []byte, error) {
 	// It's safe to extract the roles and traits directly from services.User
 	// because this occurs during the user creation process and services.User
 	// is not fetched from the backend.
-	checker, err := services.FetchRoles(user.GetRoles(), s.Access, user.GetTraits())
+	checker, err := services.FetchRoles(user.GetRoles(), a.Access, user.GetTraits())
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
-	certs, err := s.generateUserCert(certRequest{
+	certs, err := a.generateUserCert(certRequest{
 		user:              user,
 		ttl:               sessionTTL,
 		publicKey:         publicKey,
@@ -361,7 +361,7 @@ type createUserParams struct {
 	sessionTTL time.Duration
 }
 
-func (s *AuthServer) calculateGithubUser(connector services.GithubConnector, claims *services.GithubClaims, request *services.GithubAuthRequest) (*createUserParams, error) {
+func (a *Server) calculateGithubUser(connector services.GithubConnector, claims *services.GithubClaims, request *services.GithubAuthRequest) (*createUserParams, error) {
 	p := createUserParams{
 		connectorName: connector.GetName(),
 		username:      claims.Username,
@@ -378,7 +378,7 @@ func (s *AuthServer) calculateGithubUser(connector services.GithubConnector, cla
 	p.traits = modules.GetModules().TraitsFromLogins(p.username, p.logins, p.kubeGroups, p.kubeUsers)
 
 	// Pick smaller for role: session TTL from role or requested TTL.
-	roles, err := services.FetchRoles(p.roles, s.Access, p.traits)
+	roles, err := services.FetchRoles(p.roles, a.Access, p.traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -388,13 +388,13 @@ func (s *AuthServer) calculateGithubUser(connector services.GithubConnector, cla
 	return &p, nil
 }
 
-func (s *AuthServer) createGithubUser(p *createUserParams) (services.User, error) {
+func (a *Server) createGithubUser(p *createUserParams) (services.User, error) {
 
 	log.WithFields(logrus.Fields{trace.Component: "github"}).Debugf(
 		"Generating dynamic identity %v/%v with logins: %v.",
 		p.connectorName, p.username, p.logins)
 
-	expires := s.GetClock().Now().UTC().Add(p.sessionTTL)
+	expires := a.GetClock().Now().UTC().Add(p.sessionTTL)
 
 	user, err := services.GetUserMarshaler().GenerateUser(&services.UserV2{
 		Kind:    services.KindUser,
@@ -413,7 +413,7 @@ func (s *AuthServer) createGithubUser(p *createUserParams) (services.User, error
 			}},
 			CreatedBy: services.CreatedBy{
 				User: services.UserRef{Name: teleport.UserSystem},
-				Time: s.GetClock().Now().UTC(),
+				Time: a.GetClock().Now().UTC(),
 				Connector: &services.ConnectorRef{
 					Type:     teleport.ConnectorGithub,
 					ID:       p.connectorName,
@@ -426,7 +426,7 @@ func (s *AuthServer) createGithubUser(p *createUserParams) (services.User, error
 		return nil, trace.Wrap(err)
 	}
 
-	existingUser, err := s.GetUser(p.username, false)
+	existingUser, err := a.GetUser(p.username, false)
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
@@ -440,11 +440,11 @@ func (s *AuthServer) createGithubUser(p *createUserParams) (services.User, error
 				existingUser.GetName())
 		}
 
-		if err := s.UpdateUser(ctx, user); err != nil {
+		if err := a.UpdateUser(ctx, user); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	} else {
-		if err := s.CreateUser(ctx, user); err != nil {
+		if err := a.CreateUser(ctx, user); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -485,9 +485,9 @@ func populateGithubClaims(client githubAPIClientI) (*services.GithubClaims, erro
 	return claims, nil
 }
 
-func (s *AuthServer) getGithubOAuth2Client(connector services.GithubConnector) (*oauth2.Client, error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+func (a *Server) getGithubOAuth2Client(connector services.GithubConnector) (*oauth2.Client, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
 	config := oauth2.Config{
 		Credentials: oauth2.ClientCredentials{
 			ID:     connector.GetClientID(),
@@ -498,16 +498,16 @@ func (s *AuthServer) getGithubOAuth2Client(connector services.GithubConnector) (
 		AuthURL:     GithubAuthURL,
 		TokenURL:    GithubTokenURL,
 	}
-	cachedClient, ok := s.githubClients[connector.GetName()]
+	cachedClient, ok := a.githubClients[connector.GetName()]
 	if ok && oauth2ConfigsEqual(cachedClient.config, config) {
 		return cachedClient.client, nil
 	}
-	delete(s.githubClients, connector.GetName())
+	delete(a.githubClients, connector.GetName())
 	client, err := oauth2.NewClient(http.DefaultClient, config)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	s.githubClients[connector.GetName()] = &githubClient{
+	a.githubClients[connector.GetName()] = &githubClient{
 		client: client,
 		config: config,
 	}
@@ -528,7 +528,7 @@ type githubAPIClient struct {
 	// token is the access token retrieved during OAuth2 flow
 	token string
 	// authServer points to the Auth Server.
-	authServer *AuthServer
+	authServer *Server
 }
 
 // userResponse represents response from "user" API call

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 type GithubSuite struct {
-	a *AuthServer
+	a *Server
 	b backend.Backend
 	c clockwork.FakeClock
 }
@@ -65,7 +65,7 @@ func (s *GithubSuite) SetUpSuite(c *check.C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, check.IsNil)
 }
 

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -100,7 +100,7 @@ type TestAuthServer struct {
 	// TestAuthServer config is configuration used for auth server setup
 	TestAuthServerConfig
 	// AuthServer is an auth server
-	AuthServer *AuthServer
+	AuthServer *Server
 	// AuditLog is an event audit log
 	AuditLog events.IAuditLog
 	// SessionLogger is a session logger
@@ -158,7 +158,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	srv.AuthServer, err = NewAuthServer(&InitConfig{
+	srv.AuthServer, err = NewServer(&InitConfig{
 		Backend:                srv.Backend,
 		Authority:              authority.New(),
 		Access:                 access,
@@ -256,7 +256,7 @@ func (a *TestAuthServer) GenerateUserCert(key []byte, username string, ttl time.
 
 // generateCertificate generates certificate for identity,
 // returns private public key pair
-func generateCertificate(authServer *AuthServer, identity TestIdentity) ([]byte, []byte, error) {
+func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []byte, error) {
 	switch id := identity.I.(type) {
 	case LocalUser:
 		user, err := authServer.GetUser(id.Username, false)
@@ -391,7 +391,7 @@ type TestTLSServerConfig struct {
 	// AuthServer is a test auth server used to serve requests
 	AuthServer *TestAuthServer
 	// Limiter is a connection and request limiter
-	Limiter *limiter.LimiterConfig
+	Limiter *limiter.Config
 	// Listener is a listener to serve requests on
 	Listener net.Listener
 	// AcceptedUsage is a list of accepted usage restrictions
@@ -399,7 +399,7 @@ type TestTLSServerConfig struct {
 }
 
 // Auth returns auth server used by this TLS server
-func (t *TestTLSServer) Auth() *AuthServer {
+func (t *TestTLSServer) Auth() *Server {
 	return t.AuthServer.AuthServer
 }
 
@@ -433,7 +433,7 @@ func (cfg *TestTLSServerConfig) CheckAndSetDefaults() error {
 	}
 	// use very permissive limiter configuration by default
 	if cfg.Limiter == nil {
-		cfg.Limiter = &limiter.LimiterConfig{
+		cfg.Limiter = &limiter.Config{
 			MaxConnections:   1000,
 			MaxNumberOfUsers: 1000,
 		}
@@ -635,7 +635,7 @@ func (t *TestTLSServer) Stop() error {
 }
 
 // NewServerIdentity generates new server identity, used in tests
-func NewServerIdentity(clt *AuthServer, hostID string, role teleport.Role) (*Identity, error) {
+func NewServerIdentity(clt *Server, hostID string, role teleport.Role) (*Identity, error) {
 	keys, err := clt.GenerateServerKeys(GenerateServerKeysRequest{
 		HostID:   hostID,
 		NodeName: hostID,

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -350,7 +350,7 @@ func (s *AuthInitSuite) TestCASigningAlg(c *C) {
 		AuthPreference: authPreference,
 	}
 
-	verifyCAs := func(auth *AuthServer, alg string) {
+	verifyCAs := func(auth *Server, alg string) {
 		hostCAs, err := auth.GetCertAuthorities(services.HostCA, false)
 		c.Assert(err, IsNil)
 		for _, ca := range hostCAs {

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -60,7 +60,7 @@ type KubeCSRResponse struct {
 
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
 // signed certificate if successful.
-func (s *AuthServer) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
+func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	if !modules.GetModules().SupportsKubernetes() {
 		return nil, trace.AccessDenied(
 			"this teleport cluster does not support kubernetes, please contact system administrator for support")

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -82,7 +82,7 @@ type SessionCreds struct {
 }
 
 // AuthenticateUser authenticates user based on the request type
-func (s *AuthServer) AuthenticateUser(req AuthenticateUserRequest) error {
+func (s *Server) AuthenticateUser(req AuthenticateUserRequest) error {
 	err := s.authenticateUser(req)
 	event := &events.UserLogin{
 		Metadata: events.Metadata{
@@ -108,7 +108,7 @@ func (s *AuthServer) AuthenticateUser(req AuthenticateUserRequest) error {
 	return err
 }
 
-func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
+func (s *Server) authenticateUser(req AuthenticateUserRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -169,7 +169,7 @@ func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
 // in case if authentication is successful. In case if existing session id
 // is used to authenticate, returns session associated with the existing session id
 // instead of creating the new one
-func (s *AuthServer) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
+func (s *Server) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
 	clusterConfig, err := s.GetClusterConfig()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -301,7 +301,7 @@ func AuthoritiesToTrustedCerts(authorities []services.CertAuthority) []TrustedCe
 
 // AuthenticateSSHUser authenticates an SSH user and returns SSH and TLS
 // certificates for the public key in req.
-func (s *AuthServer) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
+func (s *Server) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	clusterConfig, err := s.GetClusterConfig()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -365,7 +365,7 @@ func (s *AuthServer) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginR
 }
 
 // emitNoLocalAuthEvent creates and emits a local authentication is disabled message.
-func (s *AuthServer) emitNoLocalAuthEvent(username string) {
+func (s *Server) emitNoLocalAuthEvent(username string) {
 	if err := s.emitter.EmitAuditEvent(s.closeCtx, &events.AuthAttempt{
 		Metadata: events.Metadata{
 			Type: events.AuthAttemptEvent,
@@ -383,7 +383,7 @@ func (s *AuthServer) emitNoLocalAuthEvent(username string) {
 	}
 }
 
-func (s *AuthServer) createUserWebSession(user services.User) (services.WebSession, error) {
+func (s *Server) createUserWebSession(user services.User) (services.WebSession, error) {
 	// It's safe to extract the roles and traits directly from services.User as	this method
 	// is only used for local accounts.
 	sess, err := s.NewWebSession(user.GetName(), user.GetRoles(), user.GetTraits())

--- a/lib/auth/oidc_test.go
+++ b/lib/auth/oidc_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 type OIDCSuite struct {
-	a *AuthServer
+	a *Server
 	b backend.Backend
 	c clockwork.FakeClock
 }
@@ -65,7 +65,7 @@ func (s *OIDCSuite) SetUpSuite(c *check.C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, check.IsNil)
 }
 

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -34,7 +34,7 @@ type ChangePasswordWithTokenRequest struct {
 }
 
 // ChangePasswordWithToken changes password with token
-func (s *AuthServer) ChangePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.WebSession, error) {
+func (s *Server) ChangePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.WebSession, error) {
 	user, err := s.changePasswordWithToken(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -51,7 +51,7 @@ func (s *AuthServer) ChangePasswordWithToken(ctx context.Context, req ChangePass
 // ResetPassword securely generates a new random password and assigns it to user.
 // This method is used to invalidate existing user password during password
 // reset process.
-func (s *AuthServer) ResetPassword(username string) (string, error) {
+func (s *Server) ResetPassword(username string) (string, error) {
 	user, err := s.GetUser(username, false)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -71,7 +71,7 @@ func (s *AuthServer) ResetPassword(username string) (string, error) {
 }
 
 // ChangePassword updates users password based on the old password.
-func (s *AuthServer) ChangePassword(req services.ChangePasswordReq) error {
+func (s *Server) ChangePassword(req services.ChangePasswordReq) error {
 	// validate new password
 	if err := services.VerifyPassword(req.NewPassword); err != nil {
 		return trace.Wrap(err)
@@ -126,7 +126,7 @@ func (s *AuthServer) ChangePassword(req services.ChangePasswordReq) error {
 
 // CheckPasswordWOToken checks just password without checking OTP tokens
 // used in case of SSH authentication, when token has been validated.
-func (s *AuthServer) CheckPasswordWOToken(user string, password []byte) error {
+func (s *Server) CheckPasswordWOToken(user string, password []byte) error {
 	const errMsg = "invalid username or password"
 
 	err := services.VerifyPassword(password)
@@ -160,7 +160,7 @@ func (s *AuthServer) CheckPasswordWOToken(user string, password []byte) error {
 }
 
 // CheckPassword checks the password and OTP token. Called by tsh or lib/web/*.
-func (s *AuthServer) CheckPassword(user string, password []byte, otpToken string) error {
+func (s *Server) CheckPassword(user string, password []byte, otpToken string) error {
 	err := s.CheckPasswordWOToken(user, password)
 	if err != nil {
 		return trace.Wrap(err)
@@ -172,7 +172,7 @@ func (s *AuthServer) CheckPassword(user string, password []byte, otpToken string
 
 // CheckOTP determines the type of OTP token used (for legacy HOTP support), fetches the
 // appropriate type from the backend, and checks if the token is valid.
-func (s *AuthServer) CheckOTP(user string, otpToken string) error {
+func (s *Server) CheckOTP(user string, otpToken string) error {
 	var err error
 
 	otpType, err := s.getOTPType(user)
@@ -241,7 +241,7 @@ func (s *AuthServer) CheckOTP(user string, otpToken string) error {
 }
 
 // CreateSignupU2FRegisterRequest creates U2F requests
-func (s *AuthServer) CreateSignupU2FRegisterRequest(tokenID string) (u2fRegisterRequest *u2f.RegisterRequest, e error) {
+func (s *Server) CreateSignupU2FRegisterRequest(tokenID string) (u2fRegisterRequest *u2f.RegisterRequest, e error) {
 	cap, err := s.GetAuthPreference()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -273,7 +273,7 @@ func (s *AuthServer) CreateSignupU2FRegisterRequest(tokenID string) (u2fRegister
 
 // getOTPType returns the type of OTP token used, HOTP or TOTP.
 // Deprecated: Remove this method once HOTP support has been removed from Gravity.
-func (s *AuthServer) getOTPType(user string) (string, error) {
+func (s *Server) getOTPType(user string) (string, error) {
 	_, err := s.GetHOTP(user)
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -284,7 +284,7 @@ func (s *AuthServer) getOTPType(user string) (string, error) {
 	return teleport.HOTP, nil
 }
 
-func (s *AuthServer) changePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.User, error) {
+func (s *Server) changePasswordWithToken(ctx context.Context, req ChangePasswordWithTokenRequest) (services.User, error) {
 	// Get cluster configuration and check if local auth is allowed.
 	clusterConfig, err := s.GetClusterConfig()
 	if err != nil {
@@ -336,7 +336,7 @@ func (s *AuthServer) changePasswordWithToken(ctx context.Context, req ChangePass
 	return user, nil
 }
 
-func (s *AuthServer) changeUserSecondFactor(req ChangePasswordWithTokenRequest, ResetPasswordToken services.ResetPasswordToken) error {
+func (s *Server) changeUserSecondFactor(req ChangePasswordWithTokenRequest, ResetPasswordToken services.ResetPasswordToken) error {
 	username := ResetPasswordToken.GetUser()
 	cap, err := s.GetAuthPreference()
 	if err != nil {

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -43,7 +43,7 @@ import (
 
 type PasswordSuite struct {
 	bk          backend.Backend
-	a           *AuthServer
+	a           *Server
 	mockEmitter *events.MockEmitter
 }
 
@@ -74,7 +74,7 @@ func (s *PasswordSuite) SetUpTest(c *C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, IsNil)
 
 	err = s.a.SetClusterName(clusterName)

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -33,7 +33,7 @@ import (
 // LocalRegister is used to generate host keys when a node or proxy is running
 // within the same process as the Auth Server and as such, does not need to
 // use provisioning tokens.
-func LocalRegister(id IdentityID, authServer *AuthServer, additionalPrincipals, dnsNames []string, remoteAddr string) (*Identity, error) {
+func LocalRegister(id IdentityID, authServer *Server, additionalPrincipals, dnsNames []string, remoteAddr string) (*Identity, error) {
 	// If local registration is happening and no remote address was passed in
 	// (which means no advertise IP was set), use localhost.
 	if remoteAddr == "" {

--- a/lib/auth/resetpasswordtoken.go
+++ b/lib/auth/resetpasswordtoken.go
@@ -95,7 +95,7 @@ func (r *CreateResetPasswordTokenRequest) CheckAndSetDefaults() error {
 }
 
 // CreateResetPasswordToken creates a reset password token
-func (s *AuthServer) CreateResetPasswordToken(ctx context.Context, req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
+func (s *Server) CreateResetPasswordToken(ctx context.Context, req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
 	err := req.CheckAndSetDefaults()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -194,7 +194,7 @@ func formatAccountName(s proxyDomainGetter, username string, authHostname string
 // This ensures that an attacker that gains the ResetPasswordToken link can not view it,
 // extract the OTP key from the QR code, then allow the user to signup with
 // the same OTP token.
-func (s *AuthServer) RotateResetPasswordTokenSecrets(ctx context.Context, tokenID string) (services.ResetPasswordTokenSecrets, error) {
+func (s *Server) RotateResetPasswordTokenSecrets(ctx context.Context, tokenID string) (services.ResetPasswordTokenSecrets, error) {
 	token, err := s.GetResetPasswordToken(ctx, tokenID)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -226,7 +226,7 @@ func (s *AuthServer) RotateResetPasswordTokenSecrets(ctx context.Context, tokenI
 	return &secrets, nil
 }
 
-func (s *AuthServer) newResetPasswordToken(req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
+func (s *Server) newResetPasswordToken(req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error) {
 	var err error
 	var proxyHost string
 
@@ -279,7 +279,7 @@ func formatResetPasswordTokenURL(proxyHost string, tokenID string, reqType strin
 	return u.String(), nil
 }
 
-func (s *AuthServer) deleteResetPasswordTokens(ctx context.Context, username string) error {
+func (s *Server) deleteResetPasswordTokens(ctx context.Context, username string) error {
 	tokens, err := s.GetResetPasswordTokens(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/resetpasswordtoken_test.go
+++ b/lib/auth/resetpasswordtoken_test.go
@@ -35,7 +35,7 @@ import (
 
 type ResetPasswordTokenTest struct {
 	bk          backend.Backend
-	a           *AuthServer
+	a           *Server
 	mockEmitter *events.MockEmitter
 }
 
@@ -62,7 +62,7 @@ func (s *ResetPasswordTokenTest) SetUpTest(c *check.C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, check.IsNil)
 
 	err = s.a.SetClusterName(clusterName)

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -197,7 +197,7 @@ type rotationReq struct {
 // It is possible to switch from automatic to manual by setting the phase
 // to the rollback phase.
 //
-func (a *AuthServer) RotateCertAuthority(req RotateRequest) error {
+func (a *Server) RotateCertAuthority(req RotateRequest) error {
 	if err := req.CheckAndSetDefaults(a.clock); err != nil {
 		return trace.Wrap(err)
 	}
@@ -245,7 +245,7 @@ func (a *AuthServer) RotateCertAuthority(req RotateRequest) error {
 // RotateExternalCertAuthority rotates external certificate authority,
 // this method is called by remote trusted cluster and is used to update
 // only public keys and certificates of the certificate authority.
-func (a *AuthServer) RotateExternalCertAuthority(ca services.CertAuthority) error {
+func (a *Server) RotateExternalCertAuthority(ca services.CertAuthority) error {
 	if ca == nil {
 		return trace.BadParameter("missing certificate authority")
 	}
@@ -287,7 +287,7 @@ func (a *AuthServer) RotateExternalCertAuthority(ca services.CertAuthority) erro
 // autoRotateCertAuthorities automatically rotates cert authorities,
 // does nothing if no rotation parameters were set up
 // or it is too early to rotate per schedule
-func (a *AuthServer) autoRotateCertAuthorities() error {
+func (a *Server) autoRotateCertAuthorities() error {
 	clusterName, err := a.GetClusterName()
 	if err != nil {
 		return trace.Wrap(err)
@@ -307,7 +307,7 @@ func (a *AuthServer) autoRotateCertAuthorities() error {
 	return nil
 }
 
-func (a *AuthServer) autoRotate(ca services.CertAuthority) error {
+func (a *Server) autoRotate(ca services.CertAuthority) error {
 	rotation := ca.GetRotation()
 	// rotation mode is not automatic, nothing to do
 	if rotation.Mode != services.RotationModeAuto {

--- a/lib/auth/saml_test.go
+++ b/lib/auth/saml_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 type SAMLSuite struct {
-	a *AuthServer
+	a *Server
 	b backend.Backend
 	c clockwork.FakeClock
 }
@@ -65,7 +65,7 @@ func (s *SAMLSuite) SetUpSuite(c *check.C) {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	s.a, err = NewAuthServer(authConfig)
+	s.a, err = NewServer(authConfig)
 	c.Assert(err, check.IsNil)
 }
 

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -81,7 +81,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 	assert.Empty(t, cmp.Diff(rc, gotRC))
 }
 
-func newTestAuthServer(t *testing.T) *AuthServer {
+func newTestAuthServer(t *testing.T) *Server {
 	// Create SQLite backend in a temp directory.
 	dataDir, err := ioutil.TempDir("", "teleport")
 	assert.NoError(t, err)
@@ -101,7 +101,7 @@ func newTestAuthServer(t *testing.T) *AuthServer {
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,
 	}
-	a, err := NewAuthServer(authConfig)
+	a, err := NewServer(authConfig)
 	assert.NoError(t, err)
 	t.Cleanup(func() { a.Close() })
 	assert.NoError(t, a.SetClusterConfig(services.DefaultClusterConfig()))

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -34,7 +34,7 @@ import (
 )
 
 // CreateUser inserts a new user entry in a backend.
-func (s *AuthServer) CreateUser(ctx context.Context, user services.User) error {
+func (s *Server) CreateUser(ctx context.Context, user services.User) error {
 	if user.GetCreatedBy().IsEmpty() {
 		user.SetCreatedBy(services.CreatedBy{
 			User: services.UserRef{Name: clientUsername(ctx)},
@@ -78,7 +78,7 @@ func (s *AuthServer) CreateUser(ctx context.Context, user services.User) error {
 }
 
 // UpdateUser updates an existing user in a backend.
-func (s *AuthServer) UpdateUser(ctx context.Context, user services.User) error {
+func (s *Server) UpdateUser(ctx context.Context, user services.User) error {
 	if err := s.Identity.UpdateUser(ctx, user); err != nil {
 		return trace.Wrap(err)
 	}
@@ -112,7 +112,7 @@ func (s *AuthServer) UpdateUser(ctx context.Context, user services.User) error {
 }
 
 // UpsertUser updates a user.
-func (s *AuthServer) UpsertUser(user services.User) error {
+func (s *Server) UpsertUser(user services.User) error {
 	err := s.Identity.UpsertUser(user)
 	if err != nil {
 		return trace.Wrap(err)
@@ -147,7 +147,7 @@ func (s *AuthServer) UpsertUser(user services.User) error {
 }
 
 // DeleteUser deletes an existng user in a backend by username.
-func (s *AuthServer) DeleteUser(ctx context.Context, user string) error {
+func (s *Server) DeleteUser(ctx context.Context, user string) error {
 	role, err := s.Access.GetRole(services.RoleNameForUser(user))
 	if err != nil {
 		if !trace.IsNotFound(err) {

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -38,7 +38,7 @@ type shardEvent struct {
 	err     error
 }
 
-func (b *DynamoDBBackend) asyncPollStreams(ctx context.Context) error {
+func (b *Backend) asyncPollStreams(ctx context.Context) error {
 	retry, err := utils.NewLinear(utils.LinearConfig{
 		Step: b.RetryPeriod / 10,
 		Max:  b.RetryPeriod,
@@ -70,7 +70,7 @@ func (b *DynamoDBBackend) asyncPollStreams(ctx context.Context) error {
 	}
 }
 
-func (b *DynamoDBBackend) pollStreams(externalCtx context.Context) error {
+func (b *Backend) pollStreams(externalCtx context.Context) error {
 	ctx, cancel := context.WithCancel(externalCtx)
 	defer cancel()
 
@@ -130,7 +130,7 @@ func (b *DynamoDBBackend) pollStreams(externalCtx context.Context) error {
 	}
 }
 
-func (b *DynamoDBBackend) findStream(ctx context.Context) (*string, error) {
+func (b *Backend) findStream(ctx context.Context) (*string, error) {
 	status, err := b.svc.DescribeTableWithContext(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(b.Tablename),
 	})
@@ -143,7 +143,7 @@ func (b *DynamoDBBackend) findStream(ctx context.Context) (*string, error) {
 	return status.Table.LatestStreamArn, nil
 }
 
-func (b *DynamoDBBackend) pollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent) error {
+func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent) error {
 	shardIterator, err := b.streams.GetShardIteratorWithContext(ctx, &dynamodbstreams.GetShardIteratorInput{
 		ShardId:           shard.ShardId,
 		ShardIteratorType: aws.String(dynamodbstreams.ShardIteratorTypeLatest),
@@ -199,7 +199,7 @@ func (b *DynamoDBBackend) pollShard(ctx context.Context, streamArn *string, shar
 }
 
 // collectActiveShards collects shards
-func (b *DynamoDBBackend) collectActiveShards(ctx context.Context, streamArn *string) ([]*dynamodbstreams.Shard, error) {
+func (b *Backend) collectActiveShards(ctx context.Context, streamArn *string) ([]*dynamodbstreams.Shard, error) {
 	var out []*dynamodbstreams.Shard
 
 	input := &dynamodbstreams.DescribeStreamInput{
@@ -279,7 +279,7 @@ func toEvent(rec *dynamodbstreams.Record) (*backend.Event, error) {
 	}
 }
 
-func (b *DynamoDBBackend) asyncPollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent) {
+func (b *Backend) asyncPollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent) {
 	var err error
 	defer func() {
 		if err == nil {
@@ -295,7 +295,7 @@ func (b *DynamoDBBackend) asyncPollShard(ctx context.Context, streamArn *string,
 	err = b.pollShard(ctx, streamArn, shard, eventsC)
 }
 
-func (b *DynamoDBBackend) turnOnTimeToLive(ctx context.Context) error {
+func (b *Backend) turnOnTimeToLive(ctx context.Context) error {
 	status, err := b.svc.DescribeTimeToLiveWithContext(ctx, &dynamodb.DescribeTimeToLiveInput{
 		TableName: aws.String(b.Tablename),
 	})
@@ -316,7 +316,7 @@ func (b *DynamoDBBackend) turnOnTimeToLive(ctx context.Context) error {
 	return convertError(err)
 }
 
-func (b *DynamoDBBackend) turnOnStreams(ctx context.Context) error {
+func (b *Backend) turnOnStreams(ctx context.Context) error {
 	status, err := b.svc.DescribeTableWithContext(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(b.Tablename),
 	})

--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -32,7 +32,7 @@ import (
 func TestFirestoreDB(t *testing.T) { check.TestingT(t) }
 
 type FirestoreSuite struct {
-	bk    *FirestoreBackend
+	bk    *Backend
 	suite test.BackendSuite
 }
 
@@ -55,7 +55,7 @@ func (s *FirestoreSuite) SetUpSuite(c *check.C) {
 	}
 	bk, err := newBackend()
 	c.Assert(err, check.IsNil)
-	s.bk = bk.(*FirestoreBackend)
+	s.bk = bk.(*Backend)
 	s.suite.B = s.bk
 	s.suite.NewBackend = newBackend
 }

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -119,7 +119,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 }
 
 // New returns a new instance of sqlite backend
-func New(ctx context.Context, params backend.Params) (*LiteBackend, error) {
+func New(ctx context.Context, params backend.Params) (*Backend, error) {
 	var cfg *Config
 	err := utils.ObjectToStruct(params, &cfg)
 	if err != nil {
@@ -130,7 +130,7 @@ func New(ctx context.Context, params backend.Params) (*LiteBackend, error) {
 
 // NewWithConfig returns a new instance of lite backend using
 // configuration struct as a parameter
-func NewWithConfig(ctx context.Context, cfg Config) (*LiteBackend, error) {
+func NewWithConfig(ctx context.Context, cfg Config) (*Backend, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -158,7 +158,7 @@ func NewWithConfig(ctx context.Context, cfg Config) (*LiteBackend, error) {
 	}
 	closeCtx, cancel := context.WithCancel(ctx)
 	watchStarted, signalWatchStart := context.WithCancel(ctx)
-	l := &LiteBackend{
+	l := &Backend{
 		Config:           cfg,
 		db:               db,
 		Entry:            log.WithFields(log.Fields{trace.Component: BackendName}),
@@ -180,8 +180,8 @@ func NewWithConfig(ctx context.Context, cfg Config) (*LiteBackend, error) {
 	return l, nil
 }
 
-// LiteBackend uses SQLite to implement storage interfaces
-type LiteBackend struct {
+// Backend uses SQLite to implement storage interfaces
+type Backend struct {
 	Config
 	*log.Entry
 	backend.NoMigrations
@@ -202,7 +202,7 @@ type LiteBackend struct {
 
 // showPragmas is used to debug SQLite database connection
 // parameters, when called, logs some key PRAGMA values
-func (l *LiteBackend) showPragmas() error {
+func (l *Backend) showPragmas() error {
 	return l.inTransaction(l.ctx, func(tx *sql.Tx) error {
 		row := tx.QueryRowContext(l.ctx, "PRAGMA synchronous;")
 		var syncValue string
@@ -219,7 +219,7 @@ func (l *LiteBackend) showPragmas() error {
 	})
 }
 
-func (l *LiteBackend) createSchema() error {
+func (l *Backend) createSchema() error {
 	schemas := []string{
 
 		`CREATE TABLE IF NOT EXISTS kv (
@@ -256,7 +256,7 @@ func (l *LiteBackend) createSchema() error {
 	return nil
 }
 
-func (l *LiteBackend) newLease(item backend.Item) *backend.Lease {
+func (l *Backend) newLease(item backend.Item) *backend.Lease {
 	var lease backend.Lease
 	if item.Expires.IsZero() {
 		return &lease
@@ -266,17 +266,17 @@ func (l *LiteBackend) newLease(item backend.Item) *backend.Lease {
 }
 
 // SetClock sets internal backend clock
-func (l *LiteBackend) SetClock(clock clockwork.Clock) {
+func (l *Backend) SetClock(clock clockwork.Clock) {
 	l.clock = clock
 }
 
 // Clock returns clock used by the backend
-func (l *LiteBackend) Clock() clockwork.Clock {
+func (l *Backend) Clock() clockwork.Clock {
 	return l.clock
 }
 
 // Create creates item if it does not exist
-func (l *LiteBackend) Create(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+func (l *Backend) Create(ctx context.Context, i backend.Item) (*backend.Lease, error) {
 	if len(i.Key) == 0 {
 		return nil, trace.BadParameter("missing parameter key")
 	}
@@ -308,7 +308,7 @@ func (l *LiteBackend) Create(ctx context.Context, i backend.Item) (*backend.Leas
 
 // CompareAndSwap compares item with existing item
 // and replaces is with replaceWith item
-func (l *LiteBackend) CompareAndSwap(ctx context.Context, expected backend.Item, replaceWith backend.Item) (*backend.Lease, error) {
+func (l *Backend) CompareAndSwap(ctx context.Context, expected backend.Item, replaceWith backend.Item) (*backend.Lease, error) {
 	if len(expected.Key) == 0 {
 		return nil, trace.BadParameter("missing parameter Key")
 	}
@@ -371,7 +371,7 @@ func id(t time.Time) int64 {
 
 // Put puts value into backend (creates if it does not
 // exists, updates it otherwise)
-func (l *LiteBackend) Put(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+func (l *Backend) Put(ctx context.Context, i backend.Item) (*backend.Lease, error) {
 	if i.Key == nil {
 		return nil, trace.BadParameter("missing parameter key")
 	}
@@ -410,7 +410,7 @@ const (
 )
 
 // Imported returns true if backend already imported data from another backend
-func (l *LiteBackend) Imported(ctx context.Context) (imported bool, err error) {
+func (l *Backend) Imported(ctx context.Context) (imported bool, err error) {
 	err = l.inTransaction(ctx, func(tx *sql.Tx) error {
 		q, err := tx.PrepareContext(ctx,
 			"SELECT imported from meta LIMIT 1")
@@ -430,7 +430,7 @@ func (l *LiteBackend) Imported(ctx context.Context) (imported bool, err error) {
 
 // Import imports elements, makes sure elements are imported only once
 // returns trace.AlreadyExists if elements have been imported
-func (l *LiteBackend) Import(ctx context.Context, items []backend.Item) error {
+func (l *Backend) Import(ctx context.Context, items []backend.Item) error {
 	for i := range items {
 		if items[i].Key == nil {
 			return trace.BadParameter("missing parameter key in item %v", i)
@@ -475,7 +475,7 @@ func (l *LiteBackend) Import(ctx context.Context, items []backend.Item) error {
 
 // PutRange puts range of items into backend (creates if items doe not
 // exists, updates it otherwise)
-func (l *LiteBackend) PutRange(ctx context.Context, items []backend.Item) error {
+func (l *Backend) PutRange(ctx context.Context, items []backend.Item) error {
 	for i := range items {
 		if items[i].Key == nil {
 			return trace.BadParameter("missing parameter key in item %v", i)
@@ -490,7 +490,7 @@ func (l *LiteBackend) PutRange(ctx context.Context, items []backend.Item) error 
 	return nil
 }
 
-func (l *LiteBackend) putRangeInTransaction(ctx context.Context, tx *sql.Tx, items []backend.Item, forceEventsOff bool) error {
+func (l *Backend) putRangeInTransaction(ctx context.Context, tx *sql.Tx, items []backend.Item, forceEventsOff bool) error {
 	var eventsStmt *sql.Stmt
 	var err error
 	if !l.EventsOff {
@@ -522,7 +522,7 @@ func (l *LiteBackend) putRangeInTransaction(ctx context.Context, tx *sql.Tx, ite
 }
 
 // Update updates value in the backend
-func (l *LiteBackend) Update(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+func (l *Backend) Update(ctx context.Context, i backend.Item) (*backend.Lease, error) {
 	if i.Key == nil {
 		return nil, trace.BadParameter("missing parameter key")
 	}
@@ -561,7 +561,7 @@ func (l *LiteBackend) Update(ctx context.Context, i backend.Item) (*backend.Leas
 }
 
 // Get returns a single item or not found error
-func (l *LiteBackend) Get(ctx context.Context, key []byte) (*backend.Item, error) {
+func (l *Backend) Get(ctx context.Context, key []byte) (*backend.Item, error) {
 	if len(key) == 0 {
 		return nil, trace.BadParameter("missing parameter key")
 	}
@@ -576,7 +576,7 @@ func (l *LiteBackend) Get(ctx context.Context, key []byte) (*backend.Item, error
 }
 
 // getInTransaction returns an item, works in transaction
-func (l *LiteBackend) getInTransaction(ctx context.Context, key []byte, tx *sql.Tx, item *backend.Item) error {
+func (l *Backend) getInTransaction(ctx context.Context, key []byte, tx *sql.Tx, item *backend.Item) error {
 	// When in mirror mode, don't set the current time so the SELECT query
 	// returns expired items.
 	var now time.Time
@@ -602,7 +602,7 @@ func (l *LiteBackend) getInTransaction(ctx context.Context, key []byte, tx *sql.
 }
 
 // GetRange returns query range
-func (l *LiteBackend) GetRange(ctx context.Context, startKey []byte, endKey []byte, limit int) (*backend.GetResult, error) {
+func (l *Backend) GetRange(ctx context.Context, startKey []byte, endKey []byte, limit int) (*backend.GetResult, error) {
 	if len(startKey) == 0 {
 		return nil, trace.BadParameter("missing parameter startKey")
 	}
@@ -651,7 +651,7 @@ func (l *LiteBackend) GetRange(ctx context.Context, startKey []byte, endKey []by
 }
 
 // KeepAlive updates TTL on the lease
-func (l *LiteBackend) KeepAlive(ctx context.Context, lease backend.Lease, expires time.Time) error {
+func (l *Backend) KeepAlive(ctx context.Context, lease backend.Lease, expires time.Time) error {
 	if len(lease.Key) == 0 {
 		return trace.BadParameter("lease key is not specified")
 	}
@@ -691,7 +691,7 @@ func (l *LiteBackend) KeepAlive(ctx context.Context, lease backend.Lease, expire
 	})
 }
 
-func (l *LiteBackend) deleteInTransaction(ctx context.Context, key []byte, tx *sql.Tx) error {
+func (l *Backend) deleteInTransaction(ctx context.Context, key []byte, tx *sql.Tx) error {
 	stmt, err := tx.PrepareContext(ctx, "DELETE FROM kv WHERE key = ?")
 	if err != nil {
 		return trace.Wrap(err)
@@ -722,7 +722,7 @@ func (l *LiteBackend) deleteInTransaction(ctx context.Context, key []byte, tx *s
 
 // Delete deletes item by key, returns NotFound error
 // if item does not exist
-func (l *LiteBackend) Delete(ctx context.Context, key []byte) error {
+func (l *Backend) Delete(ctx context.Context, key []byte) error {
 	if len(key) == 0 {
 		return trace.BadParameter("missing parameter key")
 	}
@@ -733,7 +733,7 @@ func (l *LiteBackend) Delete(ctx context.Context, key []byte) error {
 
 // DeleteRange deletes range of items with keys between startKey and endKey
 // Note that elements deleted by range do not produce any events
-func (l *LiteBackend) DeleteRange(ctx context.Context, startKey, endKey []byte) error {
+func (l *Backend) DeleteRange(ctx context.Context, startKey, endKey []byte) error {
 	if len(startKey) == 0 {
 		return trace.BadParameter("missing parameter startKey")
 	}
@@ -771,7 +771,7 @@ func (l *LiteBackend) DeleteRange(ctx context.Context, startKey, endKey []byte) 
 }
 
 // NewWatcher returns a new event watcher
-func (l *LiteBackend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.Watcher, error) {
+func (l *Backend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.Watcher, error) {
 	if l.EventsOff {
 		return nil, trace.BadParameter("events are turned off for this backend")
 	}
@@ -784,32 +784,32 @@ func (l *LiteBackend) NewWatcher(ctx context.Context, watch backend.Watch) (back
 }
 
 // Close closes all associated resources
-func (l *LiteBackend) Close() error {
+func (l *Backend) Close() error {
 	l.cancel()
 	return l.closeDatabase()
 }
 
 // CloseWatchers closes all the watchers
 // without closing the backend
-func (l *LiteBackend) CloseWatchers() {
+func (l *Backend) CloseWatchers() {
 	l.buf.Reset()
 }
 
-func (l *LiteBackend) isClosed() bool {
+func (l *Backend) isClosed() bool {
 	return atomic.LoadInt32(&l.closedFlag) == 1
 }
 
-func (l *LiteBackend) setClosed() {
+func (l *Backend) setClosed() {
 	atomic.StoreInt32(&l.closedFlag, 1)
 }
 
-func (l *LiteBackend) closeDatabase() error {
+func (l *Backend) closeDatabase() error {
 	l.setClosed()
 	l.buf.Close()
 	return l.db.Close()
 }
 
-func (l *LiteBackend) inTransaction(ctx context.Context, f func(tx *sql.Tx) error) (err error) {
+func (l *Backend) inTransaction(ctx context.Context, f func(tx *sql.Tx) error) (err error) {
 	start := time.Now()
 	defer func() {
 		diff := time.Since(start)

--- a/lib/backend/lite/lite_test.go
+++ b/lib/backend/lite/lite_test.go
@@ -32,7 +32,7 @@ import (
 func TestLite(t *testing.T) { check.TestingT(t) }
 
 type LiteSuite struct {
-	bk    *LiteBackend
+	bk    *Backend
 	suite test.BackendSuite
 }
 
@@ -52,7 +52,7 @@ func (s *LiteSuite) SetUpSuite(c *check.C) {
 func (s *LiteSuite) SetUpTest(c *check.C) {
 	bk, err := s.suite.NewBackend()
 	c.Assert(err, check.IsNil)
-	s.bk = bk.(*LiteBackend)
+	s.bk = bk.(*Backend)
 	s.suite.B = s.bk
 }
 
@@ -111,7 +111,7 @@ func (s *LiteSuite) TestImport(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer backendI.Close()
 
-	b := backendI.(*LiteBackend)
+	b := backendI.(*Backend)
 
 	imported, err := b.Imported(ctx)
 	c.Assert(err, check.IsNil)

--- a/lib/backend/lite/litemem_test.go
+++ b/lib/backend/lite/litemem_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 type LiteMemSuite struct {
-	bk    *LiteBackend
+	bk    *Backend
 	suite test.BackendSuite
 }
 
@@ -52,7 +52,7 @@ func (s *LiteMemSuite) SetUpSuite(c *check.C) {
 func (s *LiteMemSuite) SetUpTest(c *check.C) {
 	bk, err := s.suite.NewBackend()
 	c.Assert(err, check.IsNil)
-	s.bk = bk.(*LiteBackend)
+	s.bk = bk.(*Backend)
 	s.suite.B = s.bk
 }
 

--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -27,7 +27,7 @@ import (
 
 const notSet = -2
 
-func (l *LiteBackend) runPeriodicOperations() {
+func (l *Backend) runPeriodicOperations() {
 	t := time.NewTicker(l.PollStreamPeriod)
 	defer t.Stop()
 
@@ -65,7 +65,7 @@ func (l *LiteBackend) runPeriodicOperations() {
 	}
 }
 
-func (l *LiteBackend) removeExpiredKeys() error {
+func (l *Backend) removeExpiredKeys() error {
 	// In mirror mode, don't expire any elements. This allows the cache to setup
 	// a watch and expire elements as the events roll in.
 	if l.Mirror {
@@ -103,7 +103,7 @@ func (l *LiteBackend) removeExpiredKeys() error {
 	})
 }
 
-func (l *LiteBackend) removeOldEvents() error {
+func (l *Backend) removeOldEvents() error {
 	expiryTime := l.clock.Now().UTC().Add(-1 * backend.DefaultEventsTTL)
 	return l.inTransaction(l.ctx, func(tx *sql.Tx) error {
 		stmt, err := tx.PrepareContext(l.ctx, "DELETE FROM events WHERE created <= ?")
@@ -118,7 +118,7 @@ func (l *LiteBackend) removeOldEvents() error {
 	})
 }
 
-func (l *LiteBackend) pollEvents(rowid int64) (int64, error) {
+func (l *Backend) pollEvents(rowid int64) (int64, error) {
 	if rowid == notSet {
 		err := l.inTransaction(l.ctx, func(tx *sql.Tx) error {
 			q, err := tx.PrepareContext(

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -157,7 +157,7 @@ type Config struct {
 	RetryPeriod time.Duration
 	// EventsC is a channel for event notifications,
 	// used in tests
-	EventsC chan CacheEvent
+	EventsC chan Event
 	// OnlyRecent configures cache behavior that always uses
 	// recent values, see OnlyRecent for details
 	OnlyRecent OnlyRecent
@@ -238,8 +238,8 @@ func (c *Config) CheckAndSetDefaults() error {
 	return nil
 }
 
-// CacheEvent is event used in tests
-type CacheEvent struct {
+// Event is event used in tests
+type Event struct {
 	// Type is event type
 	Type string
 	// Event is event processed
@@ -382,7 +382,7 @@ func (c *Cache) setTTL(r services.Resource) {
 	r.SetTTL(c.Clock, c.PreferRecent.MaxTTL)
 }
 
-func (c *Cache) notify(event CacheEvent) {
+func (c *Cache) notify(event Event) {
 	if c.EventsC == nil {
 		return
 	}
@@ -437,7 +437,7 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry) error {
 		MetricComponent: c.MetricComponent,
 	})
 	if err != nil {
-		c.notify(CacheEvent{Type: WatcherFailed})
+		c.notify(Event{Type: WatcherFailed})
 		return trace.Wrap(err)
 	}
 	defer watcher.Close()
@@ -471,7 +471,7 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry) error {
 	}
 	retry.Reset()
 	c.wrapper.SetReadError(nil)
-	c.notify(CacheEvent{Type: WatcherStarted})
+	c.notify(Event{Type: WatcherStarted})
 	for {
 		select {
 		case <-watcher.Done():
@@ -483,7 +483,7 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry) error {
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			c.notify(CacheEvent{Event: event, Type: EventProcessed})
+			c.notify(Event{Event: event, Type: EventProcessed})
 		}
 	}
 }

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -59,7 +59,7 @@ type testPack struct {
 	dataDir      string
 	backend      *backend.Wrapper
 	clock        clockwork.Clock
-	eventsC      chan CacheEvent
+	eventsC      chan Event
 	cache        *Cache
 	cacheBackend backend.Backend
 
@@ -119,7 +119,7 @@ func (s *CacheSuite) newPackWithoutCache(c *check.C, setupConfig SetupConfigFn) 
 		})
 	c.Assert(err, check.IsNil)
 
-	p.eventsC = make(chan CacheEvent, 100)
+	p.eventsC = make(chan Event, 100)
 
 	p.trustS = local.NewCAService(p.backend)
 	p.clusterConfigS = local.NewClusterConfigurationService(p.backend)
@@ -363,11 +363,11 @@ func (s *CacheSuite) TestWatchers(c *check.C) {
 	}
 }
 
-func waitForRestart(c *check.C, eventsC <-chan CacheEvent) {
+func waitForRestart(c *check.C, eventsC <-chan Event) {
 	waitForEvent(c, eventsC, WatcherStarted, WatcherFailed)
 }
 
-func waitForEvent(c *check.C, eventsC <-chan CacheEvent, expectedEvent string, skipEvents ...string) {
+func waitForEvent(c *check.C, eventsC <-chan Event, expectedEvent string, skipEvents ...string) {
 	timeC := time.After(5 * time.Second)
 	for {
 		// wait for watcher to restart

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -598,7 +598,7 @@ func (c *Config) SaveProfile(dir string, makeCurrent bool) error {
 
 	dir = FullProfilePath(dir)
 
-	var cp ClientProfile
+	var cp Profile
 	cp.Username = c.Username
 	cp.WebProxyAddr = c.WebProxyAddr
 	cp.SSHProxyAddr = c.SSHProxyAddr

--- a/lib/client/bench.go
+++ b/lib/client/bench.go
@@ -129,16 +129,16 @@ func (tc *TeleportClient) Benchmark(ctx context.Context, bench Benchmark) (*Benc
 			timeoutC = time.After(waitTime)
 		case measure := <-responseC:
 			if measure.ThreadCompleted {
-				doneThreads += 1
+				doneThreads++
 				if doneThreads == bench.Threads {
 					return &result, nil
 				}
 			} else {
 				if measure.Error != nil {
-					result.RequestsFailed += 1
+					result.RequestsFailed++
 					result.LastError = measure.Error
 				}
-				result.RequestsOriginated += 1
+				result.RequestsOriginated++
 				result.Histogram.RecordValue(int64(measure.End.Sub(measure.Start) / time.Millisecond))
 			}
 		}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -753,13 +753,13 @@ func (proxy *ProxyClient) Close() error {
 
 // ExecuteSCP runs remote scp command(shellCmd) on the remote server and
 // runs local scp handler using SCP Command
-func (client *NodeClient) ExecuteSCP(cmd scp.Command) error {
+func (c *NodeClient) ExecuteSCP(cmd scp.Command) error {
 	shellCmd, err := cmd.GetRemoteShellCmd()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	s, err := client.Client.NewSession()
+	s, err := c.Client.NewSession()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -935,8 +935,8 @@ func (c *NodeClient) dynamicListenAndForward(ctx context.Context, ln net.Listene
 }
 
 // Close closes client and it's operations
-func (client *NodeClient) Close() error {
-	return client.Client.Close()
+func (c *NodeClient) Close() error {
+	return c.Client.Close()
 }
 
 // currentCluster returns the connection to the API of the current cluster

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -24,13 +24,13 @@ const CurrentProfileSymlink = "profile"
 // currently active profile.
 const CurrentProfileFilename = "current-profile"
 
-// ClientProfile is a collection of most frequently used CLI flags
+// Profile is a collection of most frequently used CLI flags
 // for "tsh".
 //
 // Profiles can be stored in a profile file, allowing TSH users to
 // type fewer CLI args.
 //
-type ClientProfile struct {
+type Profile struct {
 	// WebProxyAddr is the host:port the web proxy can be accessed at.
 	WebProxyAddr string `yaml:"web_proxy_addr,omitempty"`
 
@@ -58,10 +58,10 @@ type ClientProfile struct {
 }
 
 // Name returns the name of the profile.
-func (c *ClientProfile) Name() string {
-	addr, _, err := net.SplitHostPort(c.WebProxyAddr)
+func (cp *Profile) Name() string {
+	addr, _, err := net.SplitHostPort(cp.WebProxyAddr)
 	if err != nil {
-		return c.WebProxyAddr
+		return cp.WebProxyAddr
 	}
 
 	return addr
@@ -200,7 +200,7 @@ func FullProfilePath(dir string) string {
 // ProfileFromDir reads the user (yaml) profile from a given directory. If
 // name is empty, this function defaults to loading the currently active
 // profile (if any).
-func ProfileFromDir(dir string, name string) (*ClientProfile, error) {
+func ProfileFromDir(dir string, name string) (*Profile, error) {
 	if dir == "" {
 		return nil, trace.BadParameter("cannot load profile: missing dir")
 	}
@@ -216,19 +216,19 @@ func ProfileFromDir(dir string, name string) (*ClientProfile, error) {
 }
 
 // ProfileFromFile loads the profile from a YAML file
-func ProfileFromFile(filePath string) (*ClientProfile, error) {
+func ProfileFromFile(filePath string) (*Profile, error) {
 	bytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
-	var cp *ClientProfile
+	var cp *Profile
 	if err := yaml.Unmarshal(bytes, &cp); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return cp, nil
 }
 
-func (cp *ClientProfile) SaveToDir(dir string, makeCurrent bool) error {
+func (cp *Profile) SaveToDir(dir string, makeCurrent bool) error {
 	if dir == "" {
 		return trace.BadParameter("cannot save profile: missing dir")
 	}
@@ -241,8 +241,8 @@ func (cp *ClientProfile) SaveToDir(dir string, makeCurrent bool) error {
 	return nil
 }
 
-// SaveToFile saves ClientProfile to the target file.
-func (cp *ClientProfile) SaveToFile(filepath string) error {
+// SaveToFile saves Profile to the target file.
+func (cp *Profile) SaveToFile(filepath string) error {
 	bytes, err := yaml.Marshal(&cp)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/client/profile_test.go
+++ b/lib/client/profile_test.go
@@ -37,7 +37,7 @@ func TestProfileBasics(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	p := &ClientProfile{
+	p := &Profile{
 		WebProxyAddr:          "proxy:3088",
 		SSHProxyAddr:          "proxy:3023",
 		Username:              "testuser",

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -297,7 +297,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 
 	// apply connection throttling:
-	limiters := []*limiter.LimiterConfig{
+	limiters := []*limiter.Config{
 		&cfg.SSH.Limiter,
 		&cfg.Auth.Limiter,
 		&cfg.Proxy.Limiter,

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -509,7 +509,7 @@ const (
 )
 
 // ConfigureLimiter assigns the default parameters to a connection throttler (AKA limiter)
-func ConfigureLimiter(lc *limiter.LimiterConfig) {
+func ConfigureLimiter(lc *limiter.Config) {
 	lc.MaxConnections = LimiterMaxConnections
 	lc.MaxNumberOfUsers = LimiterMaxConcurrentUsers
 }
@@ -640,7 +640,7 @@ var (
 // CheckPasswordLimiter creates a rate limit that can be used to slow down
 // requests that come to the check password endpoint.
 func CheckPasswordLimiter() *limiter.Limiter {
-	limiter, err := limiter.NewLimiter(limiter.LimiterConfig{
+	limiter, err := limiter.NewLimiter(limiter.Config{
 		MaxConnections:   LimiterMaxConnections,
 		MaxNumberOfUsers: LimiterMaxConcurrentUsers,
 		Rates: []limiter.Rate{

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -475,7 +475,7 @@ func (l *FileLog) findInFile(fn string, query url.Values, total *int, limit int)
 		}
 		if accepted || !doFilter {
 			retval = append(retval, ef)
-			*total += 1
+			*total++
 			if limit > 0 && *total >= limit {
 				break
 			}

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -159,9 +159,8 @@ func (cfg *EventsConfig) SetFromParams(params backend.Params) error {
 	err := utils.ObjectToStruct(params, &cfg)
 	if err != nil {
 		return trace.BadParameter("firestore: configuration is invalid: %v", err)
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // SetFromURL establishes values on an EventsConfig from the supplied URI
@@ -192,9 +191,8 @@ func (cfg *EventsConfig) SetFromURL(url *url.URL) error {
 	if projectIDParamString == "" {
 		return trace.BadParameter("parameter %s with value '%s' is invalid",
 			projectID, projectIDParamString)
-	} else {
-		cfg.ProjectID = projectIDParamString
 	}
+	cfg.ProjectID = projectIDParamString
 
 	eventRetentionPeriodParamString := url.Query().Get(eventRetentionPeriodPropertyKey)
 	if eventRetentionPeriodParamString == "" {
@@ -238,9 +236,8 @@ func (cfg *EventsConfig) SetFromURL(url *url.URL) error {
 
 	if url.Host == "" {
 		return trace.BadParameter("host should be set to the collection name for event storage")
-	} else {
-		cfg.CollectionName = url.Host
 	}
+	cfg.CollectionName = url.Host
 
 	return nil
 }

--- a/lib/events/forward.go
+++ b/lib/events/forward.go
@@ -184,12 +184,12 @@ func (l *Forwarder) setupSlice(slice *SessionSlice) ([]*SessionChunk, error) {
 			return nil, trace.BadParameter("missing event type")
 		case SessionCommandEvent, SessionDiskEvent, SessionNetworkEvent:
 			chunk.EventIndex = l.enhancedIndexes[chunk.EventType]
-			l.enhancedIndexes[chunk.EventType] += 1
+			l.enhancedIndexes[chunk.EventType]++
 
 			chunks = append(chunks, chunk)
 		case SessionPrintEvent:
 			chunk.EventIndex = l.eventIndex
-			l.eventIndex += 1
+			l.eventIndex++
 
 			// Filter out chunks with session print events, as this logger forwards
 			// only audit events to the auth server.
@@ -201,7 +201,7 @@ func (l *Forwarder) setupSlice(slice *SessionSlice) ([]*SessionChunk, error) {
 			l.lastChunk = chunk
 		default:
 			chunk.EventIndex = l.eventIndex
-			l.eventIndex += 1
+			l.eventIndex++
 
 			chunks = append(chunks, chunk)
 		}

--- a/lib/events/sessionlog.go
+++ b/lib/events/sessionlog.go
@@ -389,8 +389,8 @@ func (sl *DiskSessionLogger) PostSessionSlice(slice SessionSlice) error {
 	return sl.flush()
 }
 
-// PrintEventFromChunk returns a print event converted from session chunk.
-func PrintEventFromChunk(chunk *SessionChunk) printEvent {
+// printEventFromChunk returns a print event converted from session chunk.
+func printEventFromChunk(chunk *SessionChunk) printEvent {
 	return printEvent{
 		Start:             time.Unix(0, chunk.Time).In(time.UTC).Round(time.Millisecond),
 		Type:              SessionPrintEvent,
@@ -469,7 +469,7 @@ func (sl *DiskSessionLogger) writeEventChunk(sessionID string, chunk *SessionChu
 	// than all other events.
 	switch chunk.EventType {
 	case SessionPrintEvent:
-		bytes, err = utils.FastMarshal(PrintEventFromChunk(chunk))
+		bytes, err = utils.FastMarshal(printEventFromChunk(chunk))
 		if err != nil {
 			return -1, trace.Wrap(err)
 		}

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -315,7 +315,7 @@ func (u *Uploader) Scan() error {
 			}
 			return trace.Wrap(err)
 		}
-		count += 1
+		count++
 	}
 	return nil
 }

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -218,7 +218,7 @@ func (f *Forwarder) Close() error {
 // authContext is a context of authenticated user,
 // contains information about user, target cluster and authenticated groups
 type authContext struct {
-	auth.AuthContext
+	auth.Context
 	kubeGroups    map[string]struct{}
 	kubeUsers     map[string]struct{}
 	cluster       cluster
@@ -344,7 +344,7 @@ func (f *Forwarder) withAuth(handler handlerWithAuthFunc) httprouter.Handle {
 	})
 }
 
-func (f *Forwarder) setupContext(ctx auth.AuthContext, req *http.Request, isRemoteUser bool, certExpires time.Time) (*authContext, error) {
+func (f *Forwarder) setupContext(ctx auth.Context, req *http.Request, isRemoteUser bool, certExpires time.Time) (*authContext, error) {
 	roles := ctx.Checker
 
 	clusterConfig, err := f.AccessPoint.GetClusterConfig()
@@ -422,7 +422,7 @@ func (f *Forwarder) setupContext(ctx auth.AuthContext, req *http.Request, isRemo
 	authCtx := &authContext{
 		clientIdleTimeout: roles.AdjustClientIdleTimeout(clusterConfig.GetClientIdleTimeout()),
 		sessionTTL:        sessionTTL,
-		AuthContext:       ctx,
+		Context:           ctx,
 		kubeGroups:        utils.StringsSet(kubeGroups),
 		kubeUsers:         utils.StringsSet(kubeUsers),
 		clusterConfig:     clusterConfig,

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -53,7 +53,7 @@ func (s ForwarderSuite) TestRequestCertificate(c *check.C) {
 		cluster: cluster{
 			RemoteSite: mockRemoteSite{name: "site a"},
 		},
-		AuthContext: auth.AuthContext{
+		Context: auth.Context{
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
@@ -102,7 +102,7 @@ func (s ForwarderSuite) TestGetClusterSession(c *check.C) {
 			isRemote:   true,
 			RemoteSite: remote,
 		},
-		AuthContext: auth.AuthContext{
+		Context: auth.Context{
 			User: user,
 		},
 	}
@@ -260,7 +260,7 @@ func (s ForwarderSuite) TestAuthenticate(c *check.C) {
 			},
 		})
 		c.Assert(err, check.IsNil)
-		authCtx := auth.AuthContext{
+		authCtx := auth.Context{
 			User:     user,
 			Checker:  roles,
 			Identity: auth.WrapIdentity(tlsca.Identity{RouteToCluster: tt.routeToCluster}),
@@ -444,7 +444,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 
 	c.Log("newClusterSession for a local cluster without kubeconfig")
 	authCtx := authContext{
-		AuthContext: auth.AuthContext{
+		Context: auth.Context{
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
@@ -473,7 +473,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 
 	c.Log("newClusterSession for a local cluster")
 	authCtx = authContext{
-		AuthContext: auth.AuthContext{
+		Context: auth.Context{
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
@@ -501,7 +501,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 
 	c.Log("newClusterSession for a remote cluster")
 	authCtx = authContext{
-		AuthContext: auth.AuthContext{
+		Context: auth.Context{
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
@@ -622,10 +622,10 @@ func (t mockRevTunnel) GetSites() []reversetunnel.RemoteSite {
 }
 
 type mockAuthorizer struct {
-	ctx *auth.AuthContext
+	ctx *auth.Context
 	err error
 }
 
-func (a mockAuthorizer) Authorize(context.Context) (*auth.AuthContext, error) {
+func (a mockAuthorizer) Authorize(context.Context) (*auth.Context, error) {
 	return a.ctx, a.err
 }

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -37,7 +37,7 @@ type TLSServerConfig struct {
 	// TLS is a base TLS configuration
 	TLS *tls.Config
 	// LimiterConfig is limiter config
-	LimiterConfig limiter.LimiterConfig
+	LimiterConfig limiter.Config
 	// AccessPoint is caching access point
 	AccessPoint auth.AccessPoint
 	// Component is used for debugging purposes
@@ -93,7 +93,7 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	// authMiddleware authenticates request assuming TLS client authentication
 	// adds authentication information to the context
 	// and passes it to the API server
-	authMiddleware := &auth.AuthMiddleware{
+	authMiddleware := &auth.Middleware{
 		AccessPoint:   cfg.AccessPoint,
 		AcceptedUsage: []string{teleport.UsageKubeOnly},
 	}

--- a/lib/limiter/connlimiter.go
+++ b/lib/limiter/connlimiter.go
@@ -36,7 +36,7 @@ type ConnectionsLimiter struct {
 
 // NewConnectionsLimiter returns new connection limiter, in case if connection
 // limits are not set, they won't be tracked
-func NewConnectionsLimiter(config LimiterConfig) (*ConnectionsLimiter, error) {
+func NewConnectionsLimiter(config Config) (*ConnectionsLimiter, error) {
 	limiter := ConnectionsLimiter{
 		Mutex:          &sync.Mutex{},
 		maxConnections: config.MaxConnections,

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -33,8 +33,8 @@ type Limiter struct {
 	rateLimiter *RateLimiter
 }
 
-// LimiterConfig sets up rate limits and configuration limits parameters
-type LimiterConfig struct {
+// Config sets up rate limits and configuration limits parameters
+type Config struct {
 	// Rates set ups rate limits
 	Rates []Rate
 	// MaxConnections configures maximum number of connections
@@ -46,7 +46,7 @@ type LimiterConfig struct {
 }
 
 // SetEnv reads LimiterConfig from JSON string
-func (l *LimiterConfig) SetEnv(v string) error {
+func (l *Config) SetEnv(v string) error {
 	if err := json.Unmarshal([]byte(v), l); err != nil {
 		return trace.Wrap(err, "expected JSON encoded remote certificate")
 	}
@@ -54,7 +54,7 @@ func (l *LimiterConfig) SetEnv(v string) error {
 }
 
 // NewLimiter returns new rate and connection limiter
-func NewLimiter(config LimiterConfig) (*Limiter, error) {
+func NewLimiter(config Config) (*Limiter, error) {
 	var err error
 	limiter := Limiter{}
 

--- a/lib/limiter/limiter_test.go
+++ b/lib/limiter/limiter_test.go
@@ -44,7 +44,7 @@ func (s *LimiterSuite) TearDownTest(c *C) {
 
 func (s *LimiterSuite) TestConnectionsLimiter(c *C) {
 	limiter, err := NewLimiter(
-		LimiterConfig{
+		Config{
 			MaxConnections: 0,
 		},
 	)
@@ -65,7 +65,7 @@ func (s *LimiterSuite) TestConnectionsLimiter(c *C) {
 	}
 
 	limiter, err = NewLimiter(
-		LimiterConfig{
+		Config{
 			MaxConnections: 5,
 		},
 	)
@@ -102,7 +102,7 @@ func (s *LimiterSuite) TestRateLimiter(c *C) {
 	}
 
 	limiter, err := NewLimiter(
-		LimiterConfig{
+		Config{
 			Clock: clock,
 			Rates: []Rate{
 				Rate{

--- a/lib/limiter/ratelimiter.go
+++ b/lib/limiter/ratelimiter.go
@@ -47,7 +47,7 @@ type Rate struct {
 }
 
 // NewRateLimiter returns new request rate controller
-func NewRateLimiter(config LimiterConfig) (*RateLimiter, error) {
+func NewRateLimiter(config Config) (*RateLimiter, error) {
 	limiter := RateLimiter{
 		Mutex: &sync.Mutex{},
 	}

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -134,7 +134,7 @@ func (p *clusterPeers) DialTCP(params DialParams) (conn net.Conn, err error) {
 }
 
 // IsClosed always returns false because clusterPeers is never closed.
-func (s *clusterPeers) IsClosed() bool { return false }
+func (p *clusterPeers) IsClosed() bool { return false }
 
 // newClusterPeer returns new cluster peer
 func newClusterPeer(srv *server, connInfo services.TunnelConnection, offlineThreshold time.Duration) (*clusterPeer, error) {

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -217,7 +217,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	}
 	if cfg.Limiter == nil {
 		var err error
-		cfg.Limiter, err = limiter.NewLimiter(limiter.LimiterConfig{})
+		cfg.Limiter, err = limiter.NewLimiter(limiter.Config{})
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -326,7 +326,7 @@ type ProxyConfig struct {
 	// TLSCert is a base64 encoded certificate used by web portal
 	TLSCert string
 
-	Limiter limiter.LimiterConfig
+	Limiter limiter.Config
 
 	// PublicAddrs is a list of the public addresses the proxy advertises
 	// for the HTTP endpoint. The hosts in in PublicAddr are included in the
@@ -488,7 +488,7 @@ type AuthConfig struct {
 	// StorageConfig contains configuration settings for the storage backend.
 	StorageConfig backend.Config
 
-	Limiter limiter.LimiterConfig
+	Limiter limiter.Config
 
 	// NoAudit, when set to true, disables session recording and event audit
 	NoAudit bool
@@ -513,7 +513,7 @@ type SSHConfig struct {
 	Addr                  utils.NetAddr
 	Namespace             string
 	Shell                 string
-	Limiter               limiter.LimiterConfig
+	Limiter               limiter.Config
 	Labels                map[string]string
 	CmdLabels             services.CommandLabels
 	PermitUserEnvironment bool

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -209,7 +209,7 @@ type TeleportProcess struct {
 	Config *Config
 	// localAuth has local auth server listed in case if this process
 	// has started with auth server role enabled
-	localAuth *auth.AuthServer
+	localAuth *auth.Server
 	// backend is the process' backend
 	backend backend.Backend
 	// auditLog is the initialized audit log
@@ -268,7 +268,7 @@ func nextProcessID() int32 {
 }
 
 // GetAuthServer returns the process' auth server
-func (process *TeleportProcess) GetAuthServer() *auth.AuthServer {
+func (process *TeleportProcess) GetAuthServer() *auth.Server {
 	return process.localAuth
 }
 
@@ -734,13 +734,13 @@ func (process *TeleportProcess) notifyParent() {
 	}
 }
 
-func (process *TeleportProcess) setLocalAuth(a *auth.AuthServer) {
+func (process *TeleportProcess) setLocalAuth(a *auth.Server) {
 	process.Lock()
 	defer process.Unlock()
 	process.localAuth = a
 }
 
-func (process *TeleportProcess) getLocalAuth() *auth.AuthServer {
+func (process *TeleportProcess) getLocalAuth() *auth.Server {
 	process.Lock()
 	defer process.Unlock()
 	return process.localAuth
@@ -1109,10 +1109,10 @@ func (process *TeleportProcess) initAuthService() error {
 		Emitter:        checkingEmitter,
 	}
 
-	var authCache auth.AuthCache
+	var authCache auth.Cache
 	if process.Config.CachePolicy.Enabled {
 		cache, err := process.newAccessCache(accessCacheConfig{
-			services:  authServer.AuthServices,
+			services:  authServer.Services,
 			setup:     cache.ForAuth,
 			cacheName: []string{teleport.ComponentAuth},
 			inMemory:  true,
@@ -1123,7 +1123,7 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 		authCache = cache
 	} else {
-		authCache = authServer.AuthServices
+		authCache = authServer.Services
 	}
 	authServer.SetCache(authCache)
 

--- a/lib/service/signals.go
+++ b/lib/service/signals.go
@@ -135,7 +135,7 @@ func (process *TeleportProcess) WaitForSignals(ctx context.Context) error {
 			process.Info("Got request to shutdown, context is closing")
 			return nil
 		case event := <-serviceErrorsC:
-			se, ok := event.Payload.(ServiceExit)
+			se, ok := event.Payload.(ExitEventPayload)
 			if !ok {
 				process.Warningf("Failed to decode service exit event, %T", event.Payload)
 				continue
@@ -146,9 +146,8 @@ func (process *TeleportProcess) WaitForSignals(ctx context.Context) error {
 					process.Errorf("Error when shutting down teleport %v.", err)
 				}
 				return trace.Wrap(se.Error)
-			} else {
-				process.Warningf("Non-critical service %v has exited with error %v, continuing to operate.", se.Service, se.Error)
 			}
+			process.Warningf("Non-critical service %v has exited with error %v, continuing to operate.", se.Service, se.Error)
 		}
 	}
 }

--- a/lib/services/session.go
+++ b/lib/services/session.go
@@ -261,25 +261,25 @@ type WebSessionV1 struct {
 }
 
 // V1 returns V1 version of the resource
-func (s *WebSessionV1) V1() *WebSessionV1 {
-	return s
+func (ws *WebSessionV1) V1() *WebSessionV1 {
+	return ws
 }
 
 // V2 returns V2 version of the resource
-func (s *WebSessionV1) V2() *WebSessionV2 {
+func (ws *WebSessionV1) V2() *WebSessionV2 {
 	return &WebSessionV2{
 		Kind:    KindWebSession,
 		Version: V2,
 		Metadata: Metadata{
-			Name:      s.ID,
+			Name:      ws.ID,
 			Namespace: defaults.Namespace,
 		},
 		Spec: WebSessionSpecV2{
-			Pub:                s.Pub,
-			Priv:               s.Priv,
-			BearerToken:        s.BearerToken,
-			Expires:            s.Expires,
-			BearerTokenExpires: s.Expires,
+			Pub:                ws.Pub,
+			Priv:               ws.Priv,
+			BearerToken:        ws.BearerToken,
+			Expires:            ws.Expires,
+			BearerTokenExpires: ws.Expires,
 		},
 	}
 }

--- a/lib/services/tunnel.go
+++ b/lib/services/tunnel.go
@@ -83,8 +83,8 @@ func (r *ReverseTunnelV2) GetSubKind() string {
 }
 
 // SetSubKind sets resource subkind
-func (o *ReverseTunnelV2) SetSubKind(s string) {
-	o.SubKind = s
+func (r *ReverseTunnelV2) SetSubKind(s string) {
+	r.SubKind = s
 }
 
 // GetResourceID returns resource ID

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -421,9 +421,8 @@ func (s *server) UpdateSession(req UpdateRequest) error {
 				continue
 			}
 			return trace.Wrap(err)
-		} else {
-			return nil
 		}
+		return nil
 	}
 	return trace.ConnectionProblem(nil, "failed concurrently update the session")
 }
@@ -453,7 +452,7 @@ type discardSessionServer struct {
 // NewDiscardSessionServer returns a new discarding session server. It's used
 // with the recording proxy so that nodes don't register active sessions to
 // the backend.
-func NewDiscardSessionServer() *discardSessionServer {
+func NewDiscardSessionServer() Service {
 	return &discardSessionServer{}
 }
 

--- a/lib/session/session_test.go
+++ b/lib/session/session_test.go
@@ -55,7 +55,7 @@ func (s *SessionSuite) SetUpTest(c *C) {
 	s.bk, err = lite.New(context.TODO(), backend.Params{"path": s.dir})
 	c.Assert(err, IsNil)
 
-	(s.bk.(*lite.LiteBackend)).SetClock(s.clock)
+	(s.bk.(*lite.Backend)).SetClock(s.clock)
 
 	srv, err := New(s.bk)
 	srv.(*server).clock = s.clock

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -653,7 +653,7 @@ func (c *ServerContext) String() string {
 
 // ExecCommand takes a *ServerContext and extracts the parts needed to create
 // an *execCommand which can be re-sent to Teleport.
-func (c *ServerContext) ExecCommand() (*execCommand, error) {
+func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 	var pamEnabled bool
 	var pamServiceName string
 
@@ -689,7 +689,7 @@ func (c *ServerContext) ExecCommand() (*execCommand, error) {
 	}
 
 	// Create the execCommand that will be sent to the child process.
-	return &execCommand{
+	return &ExecCommand{
 		Command:               command,
 		DestinationAddress:    c.DstAddr,
 		Username:              c.Identity.TeleportUser,

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -56,7 +56,7 @@ type ExecSuite struct {
 	ctx        *ServerContext
 	localAddr  net.Addr
 	remoteAddr net.Addr
-	a          *auth.AuthServer
+	a          *auth.Server
 }
 
 var _ = check.Suite(&ExecSuite{})
@@ -89,7 +89,7 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	c.Assert(err, check.IsNil)
-	s.a, err = auth.NewAuthServer(&auth.InitConfig{
+	s.a, err = auth.NewServer(&auth.InitConfig{
 		Backend:     bk,
 		Authority:   authority.New(),
 		ClusterName: clusterName,

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -266,7 +266,7 @@ type fakeAnnouncer struct {
 }
 
 func (f *fakeAnnouncer) UpsertNode(s services.Server) (*services.KeepAlive, error) {
-	f.upsertCalls[HeartbeatModeNode] += 1
+	f.upsertCalls[HeartbeatModeNode]++
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -274,12 +274,12 @@ func (f *fakeAnnouncer) UpsertNode(s services.Server) (*services.KeepAlive, erro
 }
 
 func (f *fakeAnnouncer) UpsertProxy(s services.Server) error {
-	f.upsertCalls[HeartbeatModeProxy] += 1
+	f.upsertCalls[HeartbeatModeProxy]++
 	return f.err
 }
 
 func (f *fakeAnnouncer) UpsertAuthServer(s services.Server) error {
-	f.upsertCalls[HeartbeatModeAuth] += 1
+	f.upsertCalls[HeartbeatModeAuth]++
 	return f.err
 }
 
@@ -300,7 +300,7 @@ func (f *fakeAnnouncer) Done() <-chan struct{} {
 // Close closes the watcher and releases
 // all associated resources
 func (f *fakeAnnouncer) Close() error {
-	f.closeCalls += 1
+	f.closeCalls++
 	f.cancel()
 	return nil
 }

--- a/lib/srv/keepalive.go
+++ b/lib/srv/keepalive.go
@@ -75,7 +75,7 @@ func StartKeepAliveLoop(p KeepAliveParams) {
 			// Send a keep alive message on all connections and make sure a response
 			// was received on all.
 			for _, conn := range p.Conns {
-				ok := sendKeepAliveWithTimeout(conn, defaults.ReadHeadersTimeout, p.CloseContext)
+				ok := sendKeepAliveWithTimeout(p.CloseContext, conn, defaults.ReadHeadersTimeout)
 				if ok {
 					sentCount++
 				}
@@ -104,7 +104,7 @@ func StartKeepAliveLoop(p KeepAliveParams) {
 // sendKeepAliveWithTimeout sends a keepalive@openssh.com message to the remote
 // client. A manual timeout is needed here because SendRequest will wait for a
 // response forever.
-func sendKeepAliveWithTimeout(conn RequestSender, timeout time.Duration, closeContext context.Context) bool {
+func sendKeepAliveWithTimeout(closeContext context.Context, conn RequestSender, timeout time.Duration) bool {
 	errorCh := make(chan error, 1)
 
 	go func() {

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -42,9 +42,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// execCommand contains the payload to "teleport exec" which will be used to
+// ExecCommand contains the payload to "teleport exec" which will be used to
 // construct and execute a shell.
-type execCommand struct {
+type ExecCommand struct {
 	// Command is the command to execute. If an interactive session is being
 	// requested, will be empty.
 	Command string `json:"command"`
@@ -115,7 +115,7 @@ func RunCommand() (io.Writer, int, error) {
 	if err != nil {
 		return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
 	}
-	var c execCommand
+	var c ExecCommand
 	err = json.Unmarshal(b.Bytes(), &c)
 	if err != nil {
 		return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
@@ -229,7 +229,7 @@ func RunForward() (io.Writer, int, error) {
 	if err != nil {
 		return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
 	}
-	var c execCommand
+	var c ExecCommand
 	err = json.Unmarshal(b.Bytes(), &c)
 	if err != nil {
 		return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
@@ -322,7 +322,7 @@ func RunAndExit(commandType string) {
 
 // buildCommand constructs a command that will execute the users shell. This
 // function is run by Teleport while it's re-executing.
-func buildCommand(c *execCommand, tty *os.File, pty *os.File, pamEnvironment []string) (*exec.Cmd, error) {
+func buildCommand(c *ExecCommand, tty *os.File, pty *os.File, pamEnvironment []string) (*exec.Cmd, error) {
 	var cmd exec.Cmd
 
 	// Lookup the UID and GID for the user.

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -501,7 +501,7 @@ func New(addr utils.NetAddr,
 		clock:           clockwork.NewRealClock(),
 		dataDir:         dataDir,
 	}
-	s.limiter, err = limiter.NewLimiter(limiter.LimiterConfig{})
+	s.limiter, err = limiter.NewLimiter(limiter.Config{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1070,7 +1070,7 @@ func (s *SrvSuite) TestClientDisconnect(c *C) {
 
 func (s *SrvSuite) TestLimiter(c *C) {
 	limiter, err := limiter.NewLimiter(
-		limiter.LimiterConfig{
+		limiter.Config{
 			MaxConnections: 2,
 			Rates: []limiter.Rate{
 				limiter.Rate{

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -529,7 +529,7 @@ func (t *remoteTerminal) Wait() (*ExecResult, error) {
 }
 
 // Continue does nothing for remote command execution.
-func (r *remoteTerminal) Continue() {}
+func (t *remoteTerminal) Continue() {}
 
 func (t *remoteTerminal) Kill() error {
 	err := t.session.Signal(ssh.SIGKILL)

--- a/lib/srv/term_test.go
+++ b/lib/srv/term_test.go
@@ -47,8 +47,8 @@ func (s *TermSuite) TestGetOwner(c *check.C) {
 	tests := []struct {
 		inUserLookup  LookupUser
 		inGroupLookup LookupGroup
-		outUid        int
-		outGid        int
+		outUID        int
+		outGID        int
 		outMode       os.FileMode
 	}{
 		// Group "tty" exists.
@@ -64,8 +64,8 @@ func (s *TermSuite) TestGetOwner(c *check.C) {
 					Gid: "5",
 				}, nil
 			},
-			outUid:  1000,
-			outGid:  5,
+			outUID:  1000,
+			outGID:  5,
 			outMode: 0600,
 		},
 		// Group "tty" does not exist.
@@ -79,8 +79,8 @@ func (s *TermSuite) TestGetOwner(c *check.C) {
 			inGroupLookup: func(s string) (*user.Group, error) {
 				return &user.Group{}, trace.BadParameter("")
 			},
-			outUid:  1000,
-			outGid:  1000,
+			outUID:  1000,
+			outGID:  1000,
 			outMode: 0620,
 		},
 	}
@@ -89,8 +89,8 @@ func (s *TermSuite) TestGetOwner(c *check.C) {
 		uid, gid, mode, err := getOwner("", tt.inUserLookup, tt.inGroupLookup)
 		c.Assert(err, check.IsNil)
 
-		c.Assert(uid, check.Equals, tt.outUid)
-		c.Assert(gid, check.Equals, tt.outGid)
+		c.Assert(uid, check.Equals, tt.outUID)
+		c.Assert(gid, check.Equals, tt.outGID)
 		c.Assert(mode, check.Equals, tt.outMode)
 	}
 }

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -580,9 +580,8 @@ func sendOK(ch io.ReadWriter) error {
 	_, err := ch.Write([]byte{OKByte})
 	if err != nil {
 		return trace.Wrap(err)
-	} else {
-		return nil
 	}
+	return nil
 }
 
 type state struct {

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -151,7 +151,7 @@ func NewServer(
 		closeContext:   closeContext,
 		closeFunc:      cancel,
 	}
-	s.limiter, err = limiter.NewLimiter(limiter.LimiterConfig{})
+	s.limiter, err = limiter.NewLimiter(limiter.Config{})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -93,11 +93,11 @@ type Identity struct {
 }
 
 // CheckAndSetDefaults checks and sets default values
-func (i *Identity) CheckAndSetDefaults() error {
-	if i.Username == "" {
+func (id *Identity) CheckAndSetDefaults() error {
+	if id.Username == "" {
 		return trace.BadParameter("missing identity username")
 	}
-	if len(i.Groups) == 0 {
+	if len(id.Groups) == 0 {
 		return trace.BadParameter("missing identity groups")
 	}
 	return nil

--- a/lib/utils/anonymizer.go
+++ b/lib/utils/anonymizer.go
@@ -32,23 +32,23 @@ type Anonymizer interface {
 }
 
 // hmacAnonymizer implements anonymization using HMAC
-type hmacAnonymizer struct {
+type HMACAnonymizer struct {
 	// key is the HMAC key
 	key string
 }
 
 // NewHMACAnonymizer returns a new HMAC-based anonymizer
-func NewHMACAnonymizer(key string) (*hmacAnonymizer, error) {
+func NewHMACAnonymizer(key string) (*HMACAnonymizer, error) {
 	if strings.TrimSpace(key) == "" {
 		return nil, trace.BadParameter("HMAC key must not be empty")
 	}
-	return &hmacAnonymizer{
+	return &HMACAnonymizer{
 		key: key,
 	}, nil
 }
 
 // Anonymize anonymizes the provided data using HMAC
-func (a *hmacAnonymizer) Anonymize(data []byte) string {
+func (a *HMACAnonymizer) Anonymize(data []byte) string {
 	h := hmac.New(sha256.New, []byte(a.key))
 	h.Write(data)
 	return base64.StdEncoding.EncodeToString(h.Sum(nil))

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -340,7 +340,7 @@ func (mc *multiCloser) Close() error {
 }
 
 // MultiCloser implements io.Close, it sequentially calls Close() on each object
-func MultiCloser(closers ...io.Closer) *multiCloser {
+func MultiCloser(closers ...io.Closer) io.Closer {
 	return &multiCloser{
 		closers: closers,
 	}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1991,10 +1991,9 @@ func (h *Handler) validateTrustedCluster(w http.ResponseWriter, r *http.Request,
 	if err != nil {
 		if trace.IsAccessDenied(err) {
 			return nil, trace.AccessDenied("access denied: the cluster token has been rejected")
-		} else {
-			log.Error(err)
-			return nil, trace.Wrap(err)
 		}
+		log.Error(err)
+		return nil, trace.Wrap(err)
 	}
 
 	validateResponseRaw, err := validateResponse.ToRaw()

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -54,7 +54,7 @@ const (
 	authSSO   authType = "sso"
 )
 
-type userContext struct {
+type UserContext struct {
 	// AuthType is auth method of this user
 	AuthType authType `json:"authType"`
 	// Name is this user name
@@ -110,7 +110,7 @@ func newAccess(roleSet services.RoleSet, ctx *services.Context, kind string) acc
 }
 
 // NewUserContext returns user context
-func NewUserContext(user services.User, userRoles services.RoleSet) (*userContext, error) {
+func NewUserContext(user services.User, userRoles services.RoleSet) (*UserContext, error) {
 	ctx := &services.Context{User: user}
 	sessionAccess := newAccess(userRoles, ctx, services.KindSession)
 	roleAccess := newAccess(userRoles, ctx, services.KindRole)
@@ -143,7 +143,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 		authType = authSSO
 	}
 
-	return &userContext{
+	return &UserContext{
 		Name:     user.GetName(),
 		ACL:      acl,
 		AuthType: authType,

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -156,7 +156,8 @@ func (c *AccessRequestCommand) Delete(client auth.ClientI) error {
 
 // PrintAccessRequests prints access requests
 func (c *AccessRequestCommand) PrintAccessRequests(client auth.ClientI, reqs []services.AccessRequest, format string) error {
-	if format == teleport.Text {
+	switch format {
+	case teleport.Text:
 		table := asciitable.MakeTable([]string{"Token", "Requestor", "Metadata", "Created At (UTC)", "Status"})
 		now := time.Now()
 		for _, req := range reqs {
@@ -174,12 +175,14 @@ func (c *AccessRequestCommand) PrintAccessRequests(client auth.ClientI, reqs []s
 		}
 		_, err := table.AsBuffer().WriteTo(os.Stdout)
 		return trace.Wrap(err)
-	} else {
+	case teleport.JSON:
 		out, err := json.MarshalIndent(reqs, "", "  ")
 		if err != nil {
 			return trace.Wrap(err, "failed to marshal requests")
 		}
 		fmt.Printf("%s\n", out)
+		return nil
+	default:
+		return trace.BadParameter("unknown format %q, must be one of [%q, %q]", format, teleport.Text, teleport.JSON)
 	}
-	return nil
 }

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -254,12 +254,12 @@ func (a *AuthCommand) GenerateKeys() error {
 }
 
 // GenerateAndSignKeys generates a new keypair and signs it for role
-func (a *AuthCommand) GenerateAndSignKeys(clusterApi auth.ClientI) error {
+func (a *AuthCommand) GenerateAndSignKeys(clusterAPI auth.ClientI) error {
 	switch {
 	case a.genUser != "" && a.genHost == "":
-		return a.generateUserKeys(clusterApi)
+		return a.generateUserKeys(clusterAPI)
 	case a.genUser == "" && a.genHost != "":
-		return a.generateHostKeys(clusterApi)
+		return a.generateHostKeys(clusterAPI)
 	default:
 		return trace.BadParameter("--user or --host must be specified")
 	}
@@ -289,7 +289,7 @@ func (a *AuthCommand) RotateCertAuthority(client auth.ClientI) error {
 	return nil
 }
 
-func (a *AuthCommand) generateHostKeys(clusterApi auth.ClientI) error {
+func (a *AuthCommand) generateHostKeys(clusterAPI auth.ClientI) error {
 	// only format=openssh is supported
 	if a.outputFormat != identityfile.FormatOpenSSH {
 		return trace.BadParameter("invalid --format flag %q, only %q is supported", a.outputFormat, identityfile.FormatOpenSSH)
@@ -304,19 +304,19 @@ func (a *AuthCommand) generateHostKeys(clusterApi auth.ClientI) error {
 		return trace.Wrap(err)
 	}
 
-	cn, err := clusterApi.GetClusterName()
+	cn, err := clusterAPI.GetClusterName()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	clusterName := cn.GetClusterName()
 
-	key.Cert, err = clusterApi.GenerateHostCert(key.Pub,
+	key.Cert, err = clusterAPI.GenerateHostCert(key.Pub,
 		"", "", principals,
 		clusterName, teleport.Roles{teleport.RoleNode}, 0)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	hostCAs, err := clusterApi.GetCertAuthorities(services.HostCA, false)
+	hostCAs, err := clusterAPI.GetCertAuthorities(services.HostCA, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -44,11 +44,11 @@ type roleCollection struct {
 	roles []services.Role
 }
 
-func (c *roleCollection) resources() (r []services.Resource) {
-	for _, resource := range c.roles {
-		r = append(r, resource)
+func (r *roleCollection) resources() (res []services.Resource) {
+	for _, resource := range r.roles {
+		res = append(res, resource)
 	}
-	return r
+	return res
 }
 
 func (r *roleCollection) writeText(w io.Writer) error {
@@ -91,8 +91,8 @@ type namespaceCollection struct {
 	namespaces []services.Namespace
 }
 
-func (c *namespaceCollection) resources() (r []services.Resource) {
-	for _, resource := range c.namespaces {
+func (n *namespaceCollection) resources() (r []services.Resource) {
+	for _, resource := range n.namespaces {
 		r = append(r, &resource)
 	}
 	return r
@@ -150,8 +150,8 @@ type serverCollection struct {
 	servers []services.Server
 }
 
-func (c *serverCollection) resources() (r []services.Resource) {
-	for _, resource := range c.servers {
+func (s *serverCollection) resources() (r []services.Resource) {
+	for _, resource := range s.servers {
 		r = append(r, resource)
 	}
 	return r
@@ -184,32 +184,32 @@ func (s *serverCollection) toMarshal() interface{} {
 	return s.servers
 }
 
-func (r *serverCollection) writeYAML(w io.Writer) error {
-	return utils.WriteYAML(w, r.toMarshal())
+func (s *serverCollection) writeYAML(w io.Writer) error {
+	return utils.WriteYAML(w, s.toMarshal())
 }
 
 type userCollection struct {
 	users []services.User
 }
 
-func (c *userCollection) resources() (r []services.Resource) {
-	for _, resource := range c.users {
+func (u *userCollection) resources() (r []services.Resource) {
+	for _, resource := range u.users {
 		r = append(r, resource)
 	}
 	return r
 }
 
-func (s *userCollection) writeText(w io.Writer) error {
+func (u *userCollection) writeText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{"User"})
-	for _, u := range s.users {
-		t.AddRow([]string{u.GetName()})
+	for _, user := range u.users {
+		t.AddRow([]string{user.GetName()})
 	}
 	fmt.Println(t.AsBuffer().String())
 	return nil
 }
 
-func (s *userCollection) writeJSON(w io.Writer) error {
-	data, err := json.MarshalIndent(s.toMarshal(), "", "    ")
+func (u *userCollection) writeJSON(w io.Writer) error {
+	data, err := json.MarshalIndent(u.toMarshal(), "", "    ")
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -217,23 +217,23 @@ func (s *userCollection) writeJSON(w io.Writer) error {
 	return trace.Wrap(err)
 }
 
-func (s *userCollection) toMarshal() interface{} {
-	if len(s.users) == 1 {
-		return s.users[0]
+func (u *userCollection) toMarshal() interface{} {
+	if len(u.users) == 1 {
+		return u.users[0]
 	}
-	return s.users
+	return u.users
 }
 
-func (r *userCollection) writeYAML(w io.Writer) error {
-	return utils.WriteYAML(w, r.toMarshal())
+func (u *userCollection) writeYAML(w io.Writer) error {
+	return utils.WriteYAML(w, u.toMarshal())
 }
 
 type authorityCollection struct {
 	cas []services.CertAuthority
 }
 
-func (c *authorityCollection) resources() (r []services.Resource) {
-	for _, resource := range c.cas {
+func (a *authorityCollection) resources() (r []services.Resource) {
+	for _, resource := range a.cas {
 		r = append(r, resource)
 	}
 	return r
@@ -289,11 +289,11 @@ type reverseTunnelCollection struct {
 	tunnels []services.ReverseTunnel
 }
 
-func (c *reverseTunnelCollection) resources() (r []services.Resource) {
-	for _, resource := range c.tunnels {
-		r = append(r, resource)
+func (r *reverseTunnelCollection) resources() (res []services.Resource) {
+	for _, resource := range r.tunnels {
+		res = append(res, resource)
 	}
-	return r
+	return res
 }
 
 func (r *reverseTunnelCollection) writeText(w io.Writer) error {


### PR DESCRIPTION
Mostly cosmetic changes:
- making receiver names consistent
- renaming `foo.FooBar` to `foo.Bar` (using package name as prefix)
- removing redundant `else` branches
- changing `a += 1` to `a++`

Updates https://github.com/gravitational/teleport/issues/3551