### PR TITLE
Fix session.rejected event emission

### DIFF
--- a/lib/events/fields.go
+++ b/lib/events/fields.go
@@ -42,8 +42,8 @@ func ValidateServerMetadata(event AuditEvent, serverID string) error {
 	if getter.GetServerID() != serverID {
 		return trace.BadParameter("server %q can't emit event with server ID %q", serverID, getter.GetServerID())
 	}
-	if !services.IsValidNamespace(getter.GetServerNamespace()) {
-		return trace.BadParameter("invalid namespace %q", getter.GetServerNamespace())
+	if ns := getter.GetServerNamespace(); ns != "" && !services.IsValidNamespace(ns) {
+		return trace.BadParameter("invalid namespace %q", ns)
 	}
 	return nil
 }

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -913,7 +913,8 @@ func (s *Server) HandleNewConn(ctx context.Context, ccx *sshutils.ConnectionCont
 					RemoteAddr: ccx.ServerConn.RemoteAddr().String(),
 				},
 				ServerMetadata: events.ServerMetadata{
-					ServerID: s.uuid,
+					ServerID:        s.uuid,
+					ServerNamespace: s.GetNamespace(),
 				},
 				Reason:  events.SessionRejectedReasonMaxConnections,
 				Maximum: maxConnections,
@@ -1011,7 +1012,8 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 						RemoteAddr: ccx.ServerConn.RemoteAddr().String(),
 					},
 					ServerMetadata: events.ServerMetadata{
-						ServerID: s.uuid,
+						ServerID:        s.uuid,
+						ServerNamespace: s.GetNamespace(),
 					},
 					Reason:  events.SessionRejectedReasonMaxSessions,
 					Maximum: max,


### PR DESCRIPTION
The `session.rejected` audit event was not being emitted because it did not include a `ServerNamespace` parameter.  This PR both adds the namespace to `session.rejected`, and also removes the requirement for namespace to be present, since a missing namespace can reasonably be assumed to be `default`.