### PR TITLE
Reverting commit afae18bb3, but keeping other minor changes

### DIFF
--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -45,8 +45,6 @@ type userACL struct {
 	Events access `json:"events"`
 	// Tokens defines access to tokens.
 	Tokens access `json:"tokens"`
-	// Nodes defines access to nodes.
-	Nodes access `json:"nodes"`
 	// SSH defines access to servers
 	SSHLogins []string `json:"sshLogins"`
 }
@@ -123,7 +121,6 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 	eventAccess := newAccess(userRoles, ctx, services.KindEvent)
 	userAccess := newAccess(userRoles, ctx, services.KindUser)
 	tokenAccess := newAccess(userRoles, ctx, services.KindToken)
-	nodeAccess := newAccess(userRoles, ctx, services.KindNode)
 	logins := getLogins(userRoles)
 
 	acl := userACL{
@@ -135,7 +132,6 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*userContex
 		SSHLogins:       logins,
 		Users:           userAccess,
 		Tokens:          tokenAccess,
-		Nodes:           nodeAccess,
 	}
 
 	// local user

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -69,7 +69,6 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Roles, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Users, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Tokens, check.DeepEquals, denied)
-	c.Assert(userContext.ACL.Nodes, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
 
 	// test local auth type


### PR DESCRIPTION
#### Description
- Removes setting node access for userACL.
- I made a mistake in thinking we needed a node access check for `add server` UI feature. Token access check is the correct permission to check b/c `add server` means to create a node join token.