### PR TITLE
Update etcd image to 3.4.X version for example

### DIFF
--- a/examples/etcd/docker-compose.yml
+++ b/examples/etcd/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   etcd0:
-    image: quay.io/coreos/etcd:v3.1.16
+    image: quay.io/coreos/etcd:v3.4.13
     ports:
       - 2379
     networks:
@@ -35,7 +35,7 @@ services:
       - --client-cert-auth
       - --peer-client-cert-auth            
   etcd1:
-    image: quay.io/coreos/etcd:v3.1.16
+    image: quay.io/coreos/etcd:v3.4.13
     ports:
       - 2379
     networks:
@@ -69,7 +69,7 @@ services:
       - --client-cert-auth
       - --peer-client-cert-auth                  
   etcd2:
-    image: quay.io/coreos/etcd:v3.1.16
+    image: quay.io/coreos/etcd:v3.4.13
     networks:
       etcd:
         ipv4_address: 172.11.1.3


### PR DESCRIPTION
Updating to match a version higher then the 3.3+ version we document requiring. 
