### PR TITLE
Revert "Fix shellcheck quotation warnings"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,7 @@ lint-sh: SH_LINT_FLAGS ?=
 lint-sh:
 	find . -type f -name '*.sh' | grep -v vendor | xargs \
 		shellcheck \
+		--exclude=SC2086 \
 		$(SH_LINT_FLAGS)
 
 # This rule triggers re-generation of version.go and gitref.go if Makefile changes

--- a/assets/aws/files/install.sh
+++ b/assets/aws/files/install.sh
@@ -15,20 +15,17 @@ amazon-linux-extras install nginx1.12
 CURL_OPTS="-L --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300"
 
 # Install telegraf to collect stats from influx
-# shellcheck disable=SC2086
-curl ${CURL_OPTS} -o /tmp/telegraf.rpm "https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}-1.x86_64.rpm"
+curl ${CURL_OPTS} -o /tmp/telegraf.rpm https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}-1.x86_64.rpm
 yum install -y /tmp/telegraf.rpm
 rm -f /tmp/telegraf.rpm
 
 # Install grafana
-# shellcheck disable=SC2086
-curl ${CURL_OPTS} -o /tmp/grafana.rpm "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${GRAFANA_VERSION}-1.x86_64.rpm"
+curl ${CURL_OPTS} -o /tmp/grafana.rpm https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${GRAFANA_VERSION}-1.x86_64.rpm
 yum install -y /tmp/grafana.rpm
 rm -f /tmp/grafana.rpm
 
 # Install InfluxDB
-# shellcheck disable=SC2086
-curl ${CURL_OPTS} -o /tmp/influxdb.rpm "https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}.x86_64.rpm"
+curl $CURL_OPTS -o /tmp/influxdb.rpm https://dl.influxdata.com/influxdb/releases/influxdb-${INFLUXDB_VERSION}.x86_64.rpm
 yum install -y /tmp/influxdb.rpm
 rm -f /tmp/influxdb.rpm
 
@@ -41,7 +38,7 @@ pip3 install certbot certbot-dns-route53
 
 # Create teleport user. It is helpful to share the same UID
 # to have the same permissions on shared NFS volumes across auth servers and for consistency.
-useradd -r teleport -u "${TELEPORT_UID}" -d /var/lib/teleport
+useradd -r teleport -u ${TELEPORT_UID} -d /var/lib/teleport
 # Add teleport to adm group to read and write logs
 usermod -a -G adm teleport
 
@@ -56,13 +53,12 @@ pushd /tmp || exit
 if [ -f /tmp/teleport-fips ]; then
     TARBALL_FILENAME="/tmp/files/teleport-ent-v${TELEPORT_VERSION}-linux-amd64-fips-bin.tar.gz"
     # Use a Teleport artifact uploaded from the build machine, if present
-    if [ -f "${TARBALL_FILENAME}" ]; then
+    if [ -f ${TARBALL_FILENAME} ]; then
         echo "Found locally uploaded Enterprise FIPS tarball ${TARBALL_FILENAME}, moving to /tmp/teleport.tar.gz"
-        mv "${TARBALL_FILENAME}" /tmp/teleport.tar.gz
+        mv ${TARBALL_FILENAME} /tmp/teleport.tar.gz
     else
         echo "Installing Enterprise Teleport version ${TELEPORT_VERSION} with FIPS support"
-        # shellcheck disable=SC2086
-        curl ${CURL_OPTS} -o teleport.tar.gz "https://get.gravitational.com/teleport/${TELEPORT_VERSION}/teleport-ent-v${TELEPORT_VERSION}-linux-amd64-fips-bin.tar.gz"
+        curl ${CURL_OPTS} -o teleport.tar.gz https://get.gravitational.com/teleport/${TELEPORT_VERSION}/teleport-ent-v${TELEPORT_VERSION}-linux-amd64-fips-bin.tar.gz
     fi
     tar -xzf teleport.tar.gz
     cp teleport-ent/tctl teleport-ent/tsh teleport-ent/teleport /usr/bin
@@ -73,13 +69,12 @@ else
     if [[ "${TELEPORT_TYPE}" == "oss" ]]; then
         TARBALL_FILENAME="/tmp/files/teleport-v${TELEPORT_VERSION}-linux-amd64-bin.tar.gz"
         # Use a Teleport artifact uploaded from the build machine, if present
-        if [ -f "${TARBALL_FILENAME}" ]; then
+        if [ -f ${TARBALL_FILENAME} ]; then
             echo "Found locally uploaded OSS tarball ${TARBALL_FILENAME}, moving to /tmp/teleport.tar.gz"
-            mv "${TARBALL_FILENAME}" /tmp/teleport.tar.gz
+            mv ${TARBALL_FILENAME} /tmp/teleport.tar.gz
         else
             echo "Installing OSS Teleport version ${TELEPORT_VERSION}"
-            # shellcheck disable=SC2086
-            curl ${CURL_OPTS} -o teleport.tar.gz "https://get.gravitational.com/teleport/${TELEPORT_VERSION}/teleport-v${TELEPORT_VERSION}-linux-amd64-bin.tar.gz"
+            curl ${CURL_OPTS} -o teleport.tar.gz https://get.gravitational.com/teleport/${TELEPORT_VERSION}/teleport-v${TELEPORT_VERSION}-linux-amd64-bin.tar.gz
         fi
         tar -xzf teleport.tar.gz
         cp teleport/tctl teleport/tsh teleport/teleport /usr/bin
@@ -87,13 +82,12 @@ else
     else
         TARBALL_FILENAME="/tmp/files/teleport-ent-v${TELEPORT_VERSION}-linux-amd64-bin.tar.gz"
         # Use a Teleport artifact uploaded from the build machine, if present
-        if [ -f "${TARBALL_FILENAME}" ]; then
+        if [ -f ${TARBALL_FILENAME} ]; then
              echo "Found locally uploaded Enterprise tarball ${TARBALL_FILENAME}, moving to /tmp/teleport.tar.gz"
-            mv "${TARBALL_FILENAME}" /tmp/teleport.tar.gz
+            mv ${TARBALL_FILENAME} /tmp/teleport.tar.gz
         else
             echo "Installing Enterprise Teleport version ${TELEPORT_VERSION}"
-            # shellcheck disable=SC2086
-            curl ${CURL_OPTS} -o teleport.tar.gz "https://get.gravitational.com/teleport/${TELEPORT_VERSION}/teleport-ent-v${TELEPORT_VERSION}-linux-amd64-bin.tar.gz"
+            curl ${CURL_OPTS} -o teleport.tar.gz https://get.gravitational.com/teleport/${TELEPORT_VERSION}/teleport-ent-v${TELEPORT_VERSION}-linux-amd64-bin.tar.gz
         fi
         tar -xzf teleport.tar.gz
         cp teleport-ent/tctl teleport-ent/tsh teleport-ent/teleport /usr/bin

--- a/assets/aws/files/make-amis-public.sh
+++ b/assets/aws/files/make-amis-public.sh
@@ -6,7 +6,6 @@ REGION_LIST="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 a
 
 # Exit if oss/ent parameters not provided
 if [[ "$1" == "" ]]; then
-    # shellcheck disable=SC2086
     echo "Usage: $(basename $0) [oss/ent/ent-fips]"
     exit 1
 else
@@ -42,7 +41,7 @@ BUILD_TIMESTAMP=$(<"${TIMESTAMP_FILE}")
 
 # Write AMI ID for each region to AMI ID file
 for REGION in ${REGION_LIST}; do
-    aws ec2 describe-images --region "${REGION}" --filters "Name=tag:BuildTimestamp,Values=${BUILD_TIMESTAMP}" "Name=tag:BuildType,Values=${AMI_TAG}" > "${BUILD_DIR}/${REGION}.json"
+    aws ec2 describe-images --region ${REGION} --filters "Name=tag:BuildTimestamp,Values=${BUILD_TIMESTAMP}" "Name=tag:BuildType,Values=${AMI_TAG}" > "${BUILD_DIR}/${REGION}.json"
     AMI_ID=$(jq --raw-output '.Images[0].ImageId' "${BUILD_DIR}/${REGION}.json")
     if [[ "${AMI_ID}" == "" || "${AMI_ID}" == "null" ]]; then
         echo "Error: cannot get AMI ID for ${REGION}"
@@ -54,12 +53,12 @@ done
 
 # Make each AMI public (set launchPermission to 'all')
 for REGION in ${REGION_LIST}; do
-    AMI_ID=$(grep "${REGION}" "${BUILD_DIR}/${OUTFILE}.txt" | awk -F= '{print $2}')
+    AMI_ID=$(grep ${REGION} "${BUILD_DIR}/${OUTFILE}.txt" | awk -F= '{print $2}')
     if [[ "${AMI_ID}" == "" || "${AMI_ID}" == "null" ]]; then
         echo "Error: cannot get AMI ID for ${REGION}"
         exit 3
     else
-        aws ec2 modify-image-attribute --region "${REGION}" --image-id "${AMI_ID}" --launch-permission "Add=[{Group=all}]"
+        aws ec2 modify-image-attribute --region ${REGION} --image-id ${AMI_ID} --launch-permission "Add=[{Group=all}]"
         echo "AMI ID ${AMI_ID} for ${REGION} set to public"
     fi
 done

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-# shellcheck disable=SC2086
 usage() { echo "Usage: $(basename $0) [-t <oss/ent>] [-v <version>] [-p <package type>] <-a [amd64/x86_64]|[386/i386]> <-r go1.9.7|fips> <-s tarball source dir> <-m tsh>" 1>&2; exit 1; }
 while getopts ":t:v:p:a:r:s:m:" o; do
     case "${o}" in
@@ -260,14 +259,14 @@ pushd "$(mktemp -d)"
 PACKAGE_TEMPDIR=$(pwd)
 # automatically clean up on exit
 trap 'rm -rf ${PACKAGE_TEMPDIR}' EXIT
-mkdir -p "${PACKAGE_TEMPDIR}/buildroot"
+mkdir -p ${PACKAGE_TEMPDIR}/buildroot
 
 # implement a rudimentary download cache for repeat builds on the same host
-mkdir -p "${TARBALL_DIRECTORY}"
-if [ ! -f "${TARBALL_DIRECTORY}/${TARBALL_FILENAME}" ]; then
+mkdir -p ${TARBALL_DIRECTORY}
+if [ ! -f ${TARBALL_DIRECTORY}/${TARBALL_FILENAME} ]; then
     if [[ "${DOWNLOAD_IF_NEEDED}" == "true" ]]; then
         echo "Downloading ${URL} to ${TARBALL_DIRECTORY}"
-        curl -sL "${URL}" -o "${TARBALL_DIRECTORY}/${TARBALL_FILENAME}"
+        curl -sL ${URL} -o ${TARBALL_DIRECTORY}/${TARBALL_FILENAME}
     else
         echo "Can't find ${TARBALL_DIRECTORY}/${TARBALL_FILENAME}"
         echo "Downloading from ${DOWNLOAD_ROOT} is disabled when a path is provided with -s"
@@ -278,38 +277,32 @@ else
 fi
 
 # extract necessary files from tarball
-# this line actually relies on word splitting as it's a list of files
-# shellcheck disable=SC2086
-tar -C "$(pwd)" -xvzf "${TARBALL_DIRECTORY}/${TARBALL_FILENAME}" ${FILE_LIST}
+tar -C "$(pwd)" -xvzf ${TARBALL_DIRECTORY}/${TARBALL_FILENAME} ${FILE_LIST}
 
 # move files into correct locations before building the package
 if [[ "${PACKAGE_TYPE}" != "pkg" ]]; then
     if [[ "${LINUX_BINARY_FILE_LIST}" != "" ]]; then
-        mkdir -p "${PACKAGE_TEMPDIR}/buildroot${LINUX_BINARY_DIR}"
-        # this relies on word splitting as it's a list of files
-        # shellcheck disable=SC2086
-        mv -v ${LINUX_BINARY_FILE_LIST} "${PACKAGE_TEMPDIR}/buildroot${LINUX_BINARY_DIR}"
+        mkdir -p ${PACKAGE_TEMPDIR}/buildroot${LINUX_BINARY_DIR}
+        mv -v ${LINUX_BINARY_FILE_LIST} ${PACKAGE_TEMPDIR}/buildroot${LINUX_BINARY_DIR}
     fi
     if [[ "${LINUX_SYSTEMD_FILE_LIST}" != "" ]]; then
-        mkdir -p "${PACKAGE_TEMPDIR}/buildroot${LINUX_SYSTEMD_DIR}"
-        # this relies on word splitting as it's a list of files
-        # shellcheck disable=SC2086
-        mv -v ${LINUX_SYSTEMD_FILE_LIST} "${PACKAGE_TEMPDIR}/buildroot${LINUX_SYSTEMD_DIR}"
+        mkdir -p ${PACKAGE_TEMPDIR}/buildroot${LINUX_SYSTEMD_DIR}
+        mv -v ${LINUX_SYSTEMD_FILE_LIST} ${PACKAGE_TEMPDIR}/buildroot${LINUX_SYSTEMD_DIR}
     fi
     if [[ "${LINUX_CONFIG_FILE}" != "" ]]; then
-        mkdir -p "${PACKAGE_TEMPDIR}/buildroot${LINUX_CONFIG_DIR}"
-        mv -v "${LINUX_CONFIG_FILE}" "${PACKAGE_TEMPDIR}/buildroot${LINUX_CONFIG_DIR}"
+        mkdir -p ${PACKAGE_TEMPDIR}/buildroot${LINUX_CONFIG_DIR}
+        mv -v ${LINUX_CONFIG_FILE} ${PACKAGE_TEMPDIR}/buildroot${LINUX_CONFIG_DIR}
         CONFIG_FILE_STANZA="--config-files /src/buildroot${LINUX_CONFIG_DIR}/${LINUX_CONFIG_FILE} "
     fi
     # /var/lib/teleport
     # shellcheck disable=SC2174
-    mkdir -p -m0700 "${PACKAGE_TEMPDIR}/buildroot${LINUX_DATA_DIR}"
+    mkdir -p -m0700 ${PACKAGE_TEMPDIR}/buildroot${LINUX_DATA_DIR}
 fi
 popd
 
 if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
     # erase any existing versions of the package in the output directory first
-    rm -f "${PKG_FILENAME}"
+    rm -f ${PKG_FILENAME}
 
     if [[ "${SIGN_PKG}" == "true" ]]; then
         # run codesign to sign binaries
@@ -319,31 +312,31 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
                 -v \
                 --timestamp \
                 --options runtime \
-                "${PACKAGE_TEMPDIR}/${FILE}"
+                ${PACKAGE_TEMPDIR}/${FILE}
         done
     fi
 
     # build the package for OS X
     pkgbuild \
-        --root "${PACKAGE_TEMPDIR}/${TAR_PATH}" \
+        --root ${PACKAGE_TEMPDIR}/${TAR_PATH} \
         --identifier ${BUNDLE_ID} \
-        --version "${TELEPORT_VERSION}" \
+        --version ${TELEPORT_VERSION} \
         --install-location /usr/local/bin \
-        "${PKG_FILENAME}"
+        ${PKG_FILENAME}
 
     if [[ "${SIGN_PKG}" == "true" ]]; then
         # mark package as unsigned first
-        mv "${PKG_FILENAME}" "${PKG_FILENAME}.unsigned"
+        mv ${PKG_FILENAME} ${PKG_FILENAME}.unsigned
 
         # run productsign to sign package
         productsign \
             --sign "${DEVELOPER_ID_INSTALLER}" \
             --timestamp \
-            "${PKG_FILENAME}.unsigned" \
-            "${PKG_FILENAME}"
+            ${PKG_FILENAME}.unsigned \
+            ${PKG_FILENAME}
 
         # remove unsigned package after successful signing
-        rm -f "${PKG_FILENAME}.unsigned"
+        rm -f ${PKG_FILENAME}.unsigned
     fi
 
     # write gon config file
@@ -358,25 +351,25 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
                 \"username\": \"${APPLE_USERNAME}\",
                 \"password\": \"${APPLE_PASSWORD}\"
             }
-        }" > "${PACKAGE_TEMPDIR}/gon-config.json"
+        }" > ${PACKAGE_TEMPDIR}/gon-config.json
 
         # notarise built package using gon
-        gon "${PACKAGE_TEMPDIR}/gon-config.json"
+        gon ${PACKAGE_TEMPDIR}/gon-config.json
     fi
 
     # checksum created packages
     for PACKAGE in *."${PACKAGE_TYPE}"; do
-        shasum -a 256 "${PACKAGE}" > "${PACKAGE}.sha256"
+        shasum -a 256 ${PACKAGE} > ${PACKAGE}.sha256
     done
 else
     # erase any existing packages of the same type/version/arch in the output directory first
-    rm -vf "${OUTPUT_FILENAME}"
+    rm -vf ${OUTPUT_FILENAME}
 
     # build for other platforms
-    docker run -v "${PACKAGE_TEMPDIR}:/src" --rm ${DOCKER_IMAGE} \
+    docker run -v ${PACKAGE_TEMPDIR}:/src --rm ${DOCKER_IMAGE} \
         fpm \
         --input-type dir \
-        --output-type "${PACKAGE_TYPE}" \
+        --output-type ${PACKAGE_TYPE} \
         --name ${TAR_PATH} \
         --version "${TELEPORT_VERSION}" \
         --maintainer "${MAINTAINER}" \
@@ -385,20 +378,20 @@ else
         --vendor "${VENDOR}" \
         --description "${DESCRIPTION} ${TYPE_DESCRIPTION}" \
         --architecture ${ARCH} \
-        --package "${OUTPUT_FILENAME}" \
+        --package ${OUTPUT_FILENAME} \
         --chdir /src/buildroot \
         --directories ${LINUX_DATA_DIR} \
         --provides teleport \
         --prefix / \
         --verbose \
-        "${CONFIG_FILE_STANZA}" \
-        "${FILE_PERMISSIONS_STANZA}" .
+        ${CONFIG_FILE_STANZA} \
+        ${FILE_PERMISSIONS_STANZA} .
 
     # copy created package back to current directory
-    cp "${PACKAGE_TEMPDIR}/*.${PACKAGE_TYPE}" .
+    cp ${PACKAGE_TEMPDIR}/*."${PACKAGE_TYPE}" .
 
     # checksum created packages
     for FILE in *."${PACKAGE_TYPE}"; do
-        sha256sum "${FILE}" > "${FILE}.sha256"
+        sha256sum ${FILE} > ${FILE}.sha256
     done
 fi

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -5,8 +5,7 @@
 #     * edit 8.1.yaml
 #     * edit theme/scripts.html and update docVersions variable
 
-# shellcheck disable=SC2046
-cd $(dirname "$0") || exit
+cd "$(dirname $0)" || exit
 rm -f latest.yaml
 
 # find all *.yaml files and convert them to array, pick the latest
@@ -16,12 +15,12 @@ latest_cfile=${cfiles_array[-1]} # becomes "3.1.yaml"
 latest_ver=${latest_cfile%.yaml}         # becomes "3.1"
 
 # build all documentation versions at the same time (4-8x speedup)
-parallel --will-cite mkdocs build --config-file ::: "$cfiles"
+parallel --will-cite mkdocs build --config-file ::: $cfiles
 
 # drop the 'latest.yml' symlink to the latest version so `mkdocs serve` will
 # automatically serve the latest
 echo "Latest version: $latest_ver"
-ln -fs "$latest_cfile" latest.yaml
+ln -fs $latest_cfile latest.yaml
 
 # copy the index file which serves /docs requests and redirects
 # visitors to the latest verion of QuickStart
@@ -30,6 +29,6 @@ cp index.html ../build/docs/index.html
 # create a symlink called 'latest' to the latest directory, like "3.1"
 cd ../build/docs || exit
 rm -f latest
-ln -s "$latest_ver" latest
+ln -s $latest_ver latest
 
 echo "The docs have been built and saved in 'build/docs'"

--- a/docs/run.sh
+++ b/docs/run.sh
@@ -6,8 +6,7 @@
 #     * edit theme/base.html and update docVersions variable
 PORT=6600
 
-# shellcheck disable=SC2046
-cd $(dirname "$0") || exit
+cd "$(dirname $0)" || exit
 ./build.sh || exit $?
 
 echo -e "\n\n----> LIVE EDIT HERE: http://localhost:$PORT/"

--- a/examples/etcd/etcdctl.sh
+++ b/examples/etcd/etcdctl.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-HERE=$(readlink -f "$0")
-# shellcheck disable=SC2046
-cd $(dirname "$HERE") || exit
+HERE=$(readlink -f $0)
+cd "$(dirname $HERE)" || exit
 
 ETCDCTL_API=3 etcdctl --cacert=./certs/ca-cert.pem --cert=./certs/client-cert.pem  --key=./certs/client-key.pem  --endpoints=https://127.0.0.1:2379 "$@"

--- a/examples/etcd/start-etcd-insecure.sh
+++ b/examples/etcd/start-etcd-insecure.sh
@@ -6,9 +6,8 @@
 #
 # NOTE: this file is also used to run etcd tests.
 #
-HERE=$(readlink -f "$0")
-# shellcheck disable=SC2046
-cd $(dirname "$HERE") || exit
+HERE=$(readlink -f $0)
+cd "$(dirname $HERE)" || exit
 
 mkdir -p data
 etcd --name teleportstorage \

--- a/examples/etcd/start-etcd.sh
+++ b/examples/etcd/start-etcd.sh
@@ -7,9 +7,8 @@
 # NOTE: this file is also used to run etcd tests.
 #
 
-HERE=$(readlink -f "$0")
-# shellcheck disable=SC2046
-cd $(dirname "$HERE") || exit
+HERE=$(readlink -f $0)
+cd "$(dirname $HERE)" || exit
 
 mkdir -p data
 etcd --name teleportstorage \

--- a/examples/etcd/start-teleport-insecure.sh
+++ b/examples/etcd/start-teleport-insecure.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
 # Example of how Teleport must be started to connect to etcd
-HERE=$(readlink -f "$0")
-# shellcheck disable=SC2046
-cd $(dirname "$HERE") || exit
+HERE=$(readlink -f $0)
+cd "$(dirname $HERE)" || exit
 
 teleport start -c teleport-insecure-etcd.yaml -d

--- a/examples/etcd/start-teleport.sh
+++ b/examples/etcd/start-teleport.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 #
 # Example of how Teleport must be started to connect to etcd
-HERE=$(readlink -f "$0")
-# shellcheck disable=SC2046
-cd $(dirname "$HERE") || exit
+HERE=$(readlink -f $0)
+cd "$(dirname $HERE)" || exit
 
 teleport start -c teleport.yaml -d

--- a/examples/gke-auth/get-kubeconfig.sh
+++ b/examples/gke-auth/get-kubeconfig.sh
@@ -92,9 +92,9 @@ spec:
   - key encipherment
   - client auth
 EOF
-kubectl certificate approve "${REQUEST_ID}"
+kubectl certificate approve ${REQUEST_ID}
 
-kubectl get csr "${REQUEST_ID}" -o jsonpath='{.status.certificate}' \
+kubectl get csr ${REQUEST_ID} -o jsonpath='{.status.certificate}' \
     | base64 ${BASE64_DECODE_FLAG} > server.crt
 
 kubectl -n kube-system exec "$(kubectl get pods -n kube-system -l k8s-app=kube-dns  -o jsonpath='{.items[0].metadata.name}')" -c kubedns -- /bin/cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt > ca.crt
@@ -108,7 +108,7 @@ cat > kubeconfig <<EOF
 apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: $(base64 "${BASE64_WRAP_FLAG}" ca.crt)
+    certificate-authority-data: $(base64 ${BASE64_WRAP_FLAG} ca.crt)
     server: ${CURRENT_CLUSTER_ADDR}
   name: k8s
 contexts:
@@ -122,8 +122,8 @@ preferences: {}
 users:
 - name: $USER
   user:
-    client-certificate-data: $(base64 "${BASE64_WRAP_FLAG}" server.crt)
-    client-key-data: $(base64 "${BASE64_WRAP_FLAG}" server-key.pem)
+    client-certificate-data: $(base64 ${BASE64_WRAP_FLAG} server.crt)
+    client-key-data: $(base64 ${BASE64_WRAP_FLAG} server-key.pem)
 EOF
 
 popd

--- a/examples/k8s-auth/get-kubeconfig.sh
+++ b/examples/k8s-auth/get-kubeconfig.sh
@@ -96,11 +96,11 @@ subjects:
   namespace: ${NAMESPACE}
 EOF
 # Get the service account token and CA cert.
-SA_SECRET_NAME=$(kubectl get -n "${NAMESPACE}" "sa/${TELEPORT_SA}" -o "jsonpath={.secrets[0]..name}")
+SA_SECRET_NAME=$(kubectl get -n ${NAMESPACE} sa/${TELEPORT_SA} -o "jsonpath={.secrets[0]..name}")
 # Note: service account token is stored base64-encoded in the secret but must
 # be plaintext in kubeconfig.
-SA_TOKEN=$(kubectl get -n "${NAMESPACE}" "secrets/${SA_SECRET_NAME}" -o "jsonpath={.data['token']}" | base64 "${BASE64_DECODE_FLAG}")
-CA_CERT=$(kubectl get -n "${NAMESPACE}" "secrets/${SA_SECRET_NAME}" -o "jsonpath={.data['ca\.crt']}")
+SA_TOKEN=$(kubectl get -n ${NAMESPACE} secrets/${SA_SECRET_NAME} -o "jsonpath={.data['token']}" | base64 ${BASE64_DECODE_FLAG})
+CA_CERT=$(kubectl get -n ${NAMESPACE} secrets/${SA_SECRET_NAME} -o "jsonpath={.data['ca\.crt']}")
 
 # Extract cluster IP from the current context
 CURRENT_CONTEXT=$(kubectl config current-context)


### PR DESCRIPTION
This reverts commit f06e9204d14425b82d0c3855e1ed2561e7b65e6a.

#4456 has caused two releases to fail now and I don't have the time to go and look through exactly why it's happening. Given that all the scripts worked fine beforehand, I think we can leave one linter check disabled until some other time.