### PR TITLE
Fix whitespace errors in docs causing linter failures

### DIFF
--- a/docs/4.3/features/enhanced-session-recording.md
+++ b/docs/4.3/features/enhanced-session-recording.md
@@ -199,7 +199,7 @@ Run the following script to download the prerequisites to build BCC tools, build
     ```
 
 === "Amazon Linux"
-    
+
     **Example Script to install relevant bcc packages for Amazon 2 Linux**
 
 

--- a/docs/4.4/features/enhanced-session-recording.md
+++ b/docs/4.4/features/enhanced-session-recording.md
@@ -199,7 +199,7 @@ Run the following script to download the prerequisites to build BCC tools, build
     ```
 
 === "Amazon Linux"
-    
+
     **Example Script to install relevant bcc packages for Amazon 2 Linux**
 
 


### PR DESCRIPTION
We all need to turn on whitespace trimming in our editors, or just run `make docs-fix-whitespace` before committing.