### PR TITLE
Check etcd version when initializing auth service with etcd

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -375,6 +375,9 @@ const (
 
 	// DebugLevel is a debug logging level name
 	DebugLevel = "debug"
+
+	// MinimumEtcdVersion is the minimum version of etcd supported by Teleport
+	MinimumEtcdVersion = "3.3.0"
 )
 
 const (

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -34,6 +34,8 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
@@ -217,9 +219,28 @@ func New(ctx context.Context, params backend.Params) (*EtcdBackend, error) {
 		watchDone:        make(chan struct{}),
 		buf:              buf,
 	}
+
 	if err = b.reconnect(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// Check that the etcd nodes are at least the minimum version supported
+	timeout, cancel := context.WithTimeout(ctx, time.Second*3*time.Duration(len(cfg.Nodes)))
+	defer cancel()
+	for _, n := range cfg.Nodes {
+		status, err := b.client.Status(timeout, n)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		ver := semver.New(status.Version)
+		min := semver.New(teleport.MinimumEtcdVersion)
+		if ver.LessThan(*min) {
+			return nil, trace.BadParameter("unsupported version of etcd %v for node %v, must be %v or greater",
+				status.Version, n, teleport.MinimumEtcdVersion)
+		}
+	}
+
 	// Wrap backend in a input sanitizer and return it.
 	return b, nil
 }


### PR DESCRIPTION
Add check and error when starting teleport with an outdated etcd node. Only etcd version 3.3 and up is supported, as stated in https://gravitational.com/teleport/docs/admin-guide/.

Fixes #3579 

Remake of https://github.com/gravitational/teleport/pull/4457 to deal with rebase issue