### PR TITLE
Add X11 Forwarding to Role example doc

### DIFF
--- a/docs/4.3/enterprise/ssh-rbac.md
+++ b/docs/4.3/enterprise/ssh-rbac.md
@@ -99,7 +99,7 @@ spec:
     # determines if the clients will be forcefully disconnected when their
     # certificates expire in the middle of an active SSH session.
     # it overrides the global cluster setting.
-    disconnect_expired_cert: no    
+    disconnect_expired_cert: no
     # permit_x11_forwarding allows users to use X11 forwarding with openssh clients and servers through the proxy
     permit_x11_forwarding: true
 

--- a/docs/4.3/enterprise/ssh-rbac.md
+++ b/docs/4.3/enterprise/ssh-rbac.md
@@ -99,7 +99,9 @@ spec:
     # determines if the clients will be forcefully disconnected when their
     # certificates expire in the middle of an active SSH session.
     # it overrides the global cluster setting.
-    disconnect_expired_cert: no
+    disconnect_expired_cert: no    
+    # permit_x11_forwarding allows users to use X11 forwarding with openssh clients and servers through the proxy
+    permit_x11_forwarding: true
 
   # allow section declares a list of resource/verb combinations that are
   # allowed for the users of this role. by default nothing is allowed.

--- a/docs/4.4/enterprise/ssh-rbac.md
+++ b/docs/4.4/enterprise/ssh-rbac.md
@@ -100,6 +100,8 @@ spec:
     # certificates expire in the middle of an active SSH session.
     # it overrides the global cluster setting.
     disconnect_expired_cert: no
+    # permit_x11_forwarding allows users to use X11 forwarding with openssh clients and servers through the proxy
+    permit_x11_forwarding: true
 
   # allow section declares a list of resource/verb combinations that are
   # allowed for the users of this role. by default nothing is allowed.


### PR DESCRIPTION
X11 forwarding is not mentioned in the docs currently that I could find.  Added to 4.3. and 4.4. role examples.