### PR TITLE
Sasha/iot rollback

### DIFF
--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -604,7 +604,7 @@ func startRollingBackRotation(ca services.CertAuthority) error {
 	// Rotation sets the first key to be the new key
 	// and keep only public keys/certs for the new CA.
 	signingKeys = [][]byte{signingKeys[1]}
-	checkingKeys = [][]byte{checkingKeys[1]}
+	checkingKeys = [][]byte{checkingKeys[1], checkingKeys[0]}
 
 	// Keep the new certificate as trusted
 	// as during the rollback phase, both types of clients may be present in the cluster.

--- a/lib/services/fanout_test.go
+++ b/lib/services/fanout_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFanoutWatcherClose tests fanout watcher close
+// removes it from the buffer
+func TestFanoutWatcherClose(t *testing.T) {
+	eventsCh := make(chan FanoutEvent, 1)
+	f := NewFanout(eventsCh)
+	w, err := f.NewWatcher(context.TODO(),
+		Watch{Name: "test", Kinds: []WatchKind{{Name: "test"}}})
+	assert.NoError(t, err)
+	assert.Equal(t, f.Len(), 1)
+
+	err = w.Close()
+	select {
+	case <-eventsCh:
+	case <-time.After(time.Second):
+		t.Fatalf("Timeout waiting for event")
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, f.Len(), 0)
+}


### PR DESCRIPTION
This commit fixes #4511.

Fanout watcher.Close method was cancelling
the context, but did was not removing the watcher
from the fanout list.

GRPC server was not releasing memory buffers associated
with the streams after clients disconnects.

Goroutines associated with the GRPC server were closed,
but buffers remained in memory:

#4511
grpc/grpc-go#3728 (comment)

In Go, child context created with context.WithValue(parent)
references parent context and parent context references
child context back.

When the parent context is closed, it removes the child references,
but the child keeps referencing the parent context.

If the child context is leaked, objects associated
with the parent context are not garbage collected.

GRPC UnaryInterceptor created context.WithValue(ctx, User)
to add a user and passed this context to methods.

WatchEvents GRPC server created services.Fanout.Watcher
and referenced the child context.

Fanout watcher Close method did not remove the watcher
from the fanout buffer list causing the leak.
