### PR TITLE
Allow managing local users and adding a server via web ui

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -261,6 +261,9 @@ const (
 	// InactivityFlushPeriod is a period of inactivity
 	// that triggers upload of the data - flush.
 	InactivityFlushPeriod = 5 * time.Minute
+
+	// NodeJoinTokenTTL is when a token for nodes expires.
+	NodeJoinTokenTTL = 4 * time.Hour
 )
 
 var (

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -43,6 +43,8 @@ type userACL struct {
 	TrustedClusters access `json:"trustedClusters"`
 	// Events defines access to audit logs
 	Events access `json:"events"`
+	// Tokens defines access to creating tokens ie: node join token.
+	Tokens access `json:"nodeToken"`
 	// SSH defines access to servers
 	SSHLogins []string `json:"sshLogins"`
 }
@@ -118,6 +120,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*UserContex
 	trustedClusterAccess := newAccess(userRoles, ctx, services.KindTrustedCluster)
 	eventAccess := newAccess(userRoles, ctx, services.KindEvent)
 	userAccess := newAccess(userRoles, ctx, services.KindUser)
+	tokenAccess := newAccess(userRoles, ctx, services.KindToken)
 	logins := getLogins(userRoles)
 
 	acl := userACL{
@@ -128,6 +131,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*UserContex
 		Events:          eventAccess,
 		SSHLogins:       logins,
 		Users:           userAccess,
+		Tokens:          tokenAccess,
 	}
 
 	// local user

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -43,8 +43,10 @@ type userACL struct {
 	TrustedClusters access `json:"trustedClusters"`
 	// Events defines access to audit logs
 	Events access `json:"events"`
-	// Tokens defines access to creating tokens ie: node join token.
-	Tokens access `json:"nodeToken"`
+	// Tokens defines access to tokens.
+	Tokens access `json:"tokens"`
+	// Nodes defines access to nodes.
+	Nodes access `json:"nodes"`
 	// SSH defines access to servers
 	SSHLogins []string `json:"sshLogins"`
 }
@@ -121,6 +123,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*UserContex
 	eventAccess := newAccess(userRoles, ctx, services.KindEvent)
 	userAccess := newAccess(userRoles, ctx, services.KindUser)
 	tokenAccess := newAccess(userRoles, ctx, services.KindToken)
+	nodeAccess := newAccess(userRoles, ctx, services.KindNode)
 	logins := getLogins(userRoles)
 
 	acl := userACL{
@@ -132,6 +135,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*UserContex
 		SSHLogins:       logins,
 		Users:           userAccess,
 		Tokens:          tokenAccess,
+		Nodes:           nodeAccess,
 	}
 
 	// local user

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -69,6 +69,7 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Roles, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Users, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Tokens, check.DeepEquals, denied)
+	c.Assert(userContext.ACL.Nodes, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
 
 	// test local auth type

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -68,6 +68,7 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Sessions, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Roles, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Users, check.DeepEquals, denied)
+	c.Assert(userContext.ACL.Tokens, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
 
 	// test local auth type


### PR DESCRIPTION
This PR includes:
1. Updated e-reference which contains the following changes:
  1.1 Local user management
  1.2. Add Node Dialog 
2. Adds additional attributes to userACL (web ui) object .