### PR TITLE
Remove Marketplace AMI builds, plus other tidying

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2389,7 +2389,6 @@ steps:
       - cd /go/src/github.com/gravitational/teleport/assets/aws
       - export TELEPORT_VERSION=$(cat /go/.version.txt)
       - export PUBLIC_AMI_NAME=gravitational-teleport-ami-oss-$TELEPORT_VERSION
-      - export MARKETPLACE_AMI_NAME=gravitational-teleport-marketplace-ami-oss-$TELEPORT_VERSION
       - |
         if [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
           echo "---> Building production OSS AMIs"
@@ -2494,7 +2493,6 @@ steps:
       - export TELEPORT_VERSION=$(cat /go/.version.txt)
       - export PUBLIC_AMI_NAME=gravitational-teleport-ami-ent-$TELEPORT_VERSION
       - export FIPS_AMI_NAME=gravitational-teleport-ami-ent-$TELEPORT_VERSION-fips
-      - export MARKETPLACE_AMI_NAME=gravitational-teleport-marketplace-ami-ent-$TELEPORT_VERSION
       - |
         if [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
           echo "---> Building production Enterprise AMIs"
@@ -2792,6 +2790,6 @@ volumes:
 
 ---
 kind: signature
-hmac: fada4e800dbad247638e74e9ec61d41597257507fba5f35e18b9182be2278a21
+hmac: 5e2de07e00d59e731a0f9bf76780c40ce8ead1aadee8a68affe89548806176b2
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2790,6 +2790,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 5e2de07e00d59e731a0f9bf76780c40ce8ead1aadee8a68affe89548806176b2
+hmac: c34f1fea8f031d0d113543916eb6a909b54af368d3a2e7217528e982b02878d9
 
 ...

--- a/assets/aws/Jenkinsfile-build-ent
+++ b/assets/aws/Jenkinsfile-build-ent
@@ -20,7 +20,7 @@ pipeline {
         stage('Run Packer to build specified version') {
             steps {
                 dir('assets/aws') {
-                    sh "PUBLIC_AMI_NAME=gravitational-teleport-ami-ent-${params.version} FIPS_AMI_NAME=gravitational-teleport-ami-ent-${params.version}-fips MARKETPLACE_AMI_NAME=gravitational-teleport-marketplace-ami-ent-${params.version} TELEPORT_VERSION=${params.version} make ent-ci-build"
+                    sh "PUBLIC_AMI_NAME=gravitational-teleport-ami-ent-${params.version} FIPS_AMI_NAME=gravitational-teleport-ami-ent-${params.version}-fips TELEPORT_VERSION=${params.version} make ent-ci-build"
                 }
             }
         }

--- a/assets/aws/Jenkinsfile-build-oss
+++ b/assets/aws/Jenkinsfile-build-oss
@@ -20,7 +20,7 @@ pipeline {
         stage('Run Packer to build specified version') {
             steps {
                 dir('assets/aws') {
-                    sh "PUBLIC_AMI_NAME=gravitational-teleport-ami-oss-${params.version} MARKETPLACE_AMI_NAME=gravitational-teleport-marketplace-ami-oss-${params.version} TELEPORT_VERSION=${params.version} make oss-ci-build"
+                    sh "PUBLIC_AMI_NAME=gravitational-teleport-ami-oss-${params.version} TELEPORT_VERSION=${params.version} make oss-ci-build"
                 }
             }
         }

--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -7,9 +7,6 @@ BUILD_SUBNET_ID ?=
 # Public AMI name
 PUBLIC_AMI_NAME ?=
 
-# Marketplace AMI name ?=
-MARKETPLACE_AMI_NAME ?=
-
 # Default build region
 AWS_REGION ?= us-west-2
 
@@ -17,7 +14,7 @@ AWS_REGION ?= us-west-2
 # This must be a _released_ version of Teleport, i.e. one which has binaries
 # available for download on https://gravitational.com/teleport/download
 # Unreleased versions will fail to build.
-TELEPORT_VERSION ?= 4.3.7
+TELEPORT_VERSION ?= 4.4.0-rc.3
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007
@@ -69,10 +66,9 @@ oss-ci-build: check-vars
 oss-ci-build:
 	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) via CI"
 	@echo "Public AMI name: $(PUBLIC_AMI_NAME)"
-	@echo "Marketplace AMI name: $(MARKETPLACE_AMI_NAME)"
 	@echo "BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
 	mkdir -p files/build
-	packer build -force -var ami_name=$(PUBLIC_AMI_NAME) -var marketplace_ami_name=$(MARKETPLACE_AMI_NAME) -var build_timestamp=$(BUILD_TIMESTAMP) -except teleport-aws-linux-fips single-ami.json
+	packer build -force -var ami_name=$(PUBLIC_AMI_NAME) -var build_timestamp=$(BUILD_TIMESTAMP) -except teleport-aws-linux-fips single-ami.json
 	@echo "$(BUILD_TIMESTAMP)" > files/build/oss_build_timestamp.txt
 
 .PHONY: change-amis-to-public-oss
@@ -98,10 +94,9 @@ ent-ci-build:
 	@echo "Building image $(TELEPORT_VERSION) $(TELEPORT_TYPE) via CI"
 	@echo "Public AMI name: $(PUBLIC_AMI_NAME)"
 	@echo "FIPS AMI name: $(FIPS_AMI_NAME)"
-	@echo "Marketplace AMI name: $(MARKETPLACE_AMI_NAME)"
 	@echo "BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)"
 	mkdir -p files/build
-	packer build -force -var ami_name=$(PUBLIC_AMI_NAME) -var fips_ami_name=$(FIPS_AMI_NAME) -var marketplace_ami_name=$(MARKETPLACE_AMI_NAME) -var build_timestamp=$(BUILD_TIMESTAMP) single-ami.json
+	packer build -force -var ami_name=$(PUBLIC_AMI_NAME) -var fips_ami_name=$(FIPS_AMI_NAME) -var build_timestamp=$(BUILD_TIMESTAMP) single-ami.json
 	@echo "$(BUILD_TIMESTAMP)" > files/build/ent_build_timestamp.txt
 
 .PHONY: change-amis-to-public-ent

--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -14,7 +14,7 @@ AWS_REGION ?= us-west-2
 # This must be a _released_ version of Teleport, i.e. one which has binaries
 # available for download on https://gravitational.com/teleport/download
 # Unreleased versions will fail to build.
-TELEPORT_VERSION ?= 4.4.0-rc.3
+TELEPORT_VERSION ?= 4.3.7
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007

--- a/assets/aws/single-ami.json
+++ b/assets/aws/single-ami.json
@@ -53,7 +53,7 @@
     }
   },{
     "name": "teleport-aws-linux-fips",
-    "ami_description": "Gravitational Teleport with FIPS support using AWS Linux AMI for AWS Marketplace",
+    "ami_description": "Gravitational Teleport with FIPS support using AWS Linux AMI",
     "type": "amazon-ebs",
     "region": "{{user `aws_region`}}",
     "source_ami_filter": {
@@ -87,43 +87,6 @@
     },
     "snapshot_tags": {
       "Name": "{{user `fips_ami_name`}}"
-    }
-  },{
-    "name": "teleport-aws-linux-marketplace",
-    "ami_description": "Gravitational Teleport using AWS Linux AMI for AWS Marketplace",
-    "type": "amazon-ebs",
-    "region": "{{user `aws_region`}}",
-    "source_ami_filter": {
-        "filters": {
-            "virtualization-type": "hvm",
-            "name": "amzn2-ami-hvm*-ebs",
-            "root-device-type": "ebs"
-        },
-        "owners": ["amazon"],
-        "most_recent": true
-    },
-    "instance_type": "{{user `instance_type`}}",
-    "ssh_username": "ec2-user",
-    "ami_name": "{{user `marketplace_ami_name` | clean_resource_name}}",
-    "ssh_pty" : true,
-    "associate_public_ip_address": true,
-    "vpc_id": "{{user `vpc`}}",
-    "subnet_id": "{{user `subnet`}}",
-    "ami_regions": "{{user `destination_regions`}}",
-    "force_delete_snapshot": "true",
-    "tags": {
-      "Name": "{{user `marketplace_ami_name`}}",
-      "BuildTimestamp": "{{user `build_timestamp`}}",
-      "BuildType": "marketplace"
-    },
-    "run_tags": {
-      "Name": "{{user `marketplace_ami_name`}}"
-    },
-    "run_volume_tags": {
-      "Name": "{{user `marketplace_ami_name`}}"
-    },
-    "snapshot_tags": {
-      "Name": "{{user `marketplace_ami_name`}}"
     }
   }],
   "provisioners": [{

--- a/assets/aws/update-ami-ids.sh
+++ b/assets/aws/update-ami-ids.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+# shellcheck disable=SC2086
 usage() { echo "Usage: $(basename $0) [-a <AWS account ID>] [-m <cloudformation/terraform>] [-t <oss/ent/ent-fips>] [-r <comma-separated regions>] [-v version]" 1>&2; exit 1; }
 while getopts ":a:m:t:r:v:" o; do
     case "${o}" in
@@ -63,9 +64,9 @@ for REGION in ${REGIONS//,/ }; do
     else
         AMI_ID_STUB="gravitational-teleport-ami-${TYPE}-${VERSION}"
     fi
-    IMAGE_ID=$(aws ec2 describe-images --owners ${AWS_ACCOUNT_ID} --filters "Name=name,Values=${AMI_ID_STUB}" --region ${REGION} | jq -r ".Images[].ImageId")
+    IMAGE_ID=$(aws ec2 describe-images --owners "${AWS_ACCOUNT_ID}" --filters "Name=name,Values=${AMI_ID_STUB}" "Name=is-public,Values=true" --region "${REGION}" | jq -r ".Images[].ImageId")
     if [[ "${IMAGE_ID}" == "" ]]; then
-        echo "Error getting ${TYPE} image ID for Teleport ${VERSION} in region ${REGION}"
+        echo "Error getting ${TYPE} image ID for Teleport ${VERSION} in region ${REGION}. This can happen if the image has not been made public."
         exit 3
     fi
     IMAGE_IDS[${REGION}]=${IMAGE_ID}
@@ -84,15 +85,15 @@ if [[ "${MODE}" == "cloudformation" ]]; then
     fi
     # replace AMI ID in place
     for REGION in ${REGIONS//,/ }; do
-        OLD_AMI_ID=$(grep $REGION $CLOUDFORMATION_PATH | sed -n -E "s/$REGION: \{HVM64 : (ami.*)\}/\1/p" | tr -d " ")
+        OLD_AMI_ID=$(grep "${REGION}" "${CLOUDFORMATION_PATH}" | sed -n -E "s/$REGION: \{HVM64 : (ami.*)\}/\1/p" | tr -d " ")
         NEW_AMI_ID=${IMAGE_IDS[$REGION]}
-        sed -i -E "s/$REGION: \{HVM64 : ami(.*)\}$/$REGION: \{HVM64 : $NEW_AMI_ID\}/g" $CLOUDFORMATION_PATH
+        sed -i -E "s/$REGION: \{HVM64 : ami(.*)\}$/$REGION: \{HVM64 : $NEW_AMI_ID\}/g" ${CLOUDFORMATION_PATH}
         echo "[${TYPE}: ${REGION}] ${OLD_AMI_ID} -> ${NEW_AMI_ID}"
     done
     # update version number
-    sed -i -E "s/# All AMIs from AWS - gravitational-teleport-ami-(.*)/# All AMIs from AWS - gravitational-teleport-ami-${TYPE}-${VERSION}/g" $CLOUDFORMATION_PATH
+    sed -i -E "s/# All AMIs from AWS - gravitational-teleport-ami-(.*)/# All AMIs from AWS - gravitational-teleport-ami-${TYPE}-${VERSION}/g" ${CLOUDFORMATION_PATH}
 elif [[ "${MODE}" == "terraform" ]]; then
-    TERRAFORM_PATH=../../examples/aws/terraform/README.md
+    TERRAFORM_PATH=../../examples/aws/terraform/AMIS.md
     if [[ "${TYPE}" == "oss" ]]; then
         TYPE_STRING="OSS"
     elif [[ "${TYPE}" == "ent" ]]; then
@@ -104,7 +105,7 @@ elif [[ "${MODE}" == "terraform" ]]; then
     for REGION in ${REGIONS//,/ }; do
         OLD_AMI_ID=$(grep -E "# $REGION v(.*) ${TYPE_STRING}" $TERRAFORM_PATH | sed -n -E "s/# $REGION v(.*) ${TYPE_STRING}: (ami.*)/\2/p" | tr -d " ")
         NEW_AMI_ID=${IMAGE_IDS[$REGION]}
-        sed -i -E "s/^# $REGION v(.*) ${TYPE_STRING}: ami(.*)$/# $REGION v${VERSION} ${TYPE_STRING}: $NEW_AMI_ID/g" $TERRAFORM_PATH
+        sed -i -E "s/^# $REGION v(.*) ${TYPE_STRING}: ami(.*)$/# $REGION v${VERSION} ${TYPE_STRING}: $NEW_AMI_ID/g" ${TERRAFORM_PATH}
         echo "[${TYPE}: ${REGION}] ${OLD_AMI_ID} -> ${NEW_AMI_ID}"
     done
 fi

--- a/examples/aws/terraform/AMIS.md
+++ b/examples/aws/terraform/AMIS.md
@@ -1,0 +1,61 @@
+# Public Teleport AMI IDs
+
+For your convenience, this is a list of public Teleport AMI IDs which are published by Gravitational. This list
+is updated when new AMI versions are released.
+
+### OSS
+
+```
+# ap-south-1 v4.3.7 OSS: ami-08f009f8430b5f300
+# ap-northeast-2 v4.3.7 OSS: ami-0f4b5ab15359913ac
+# ap-southeast-1 v4.3.7 OSS: ami-060ad577453b04754
+# ap-southeast-2 v4.3.7 OSS: ami-020df260996c4c297
+# ap-northeast-1 v4.3.7 OSS: ami-0ee948fbdfc89b5a9
+# ca-central-1 v4.3.7 OSS: ami-03c59b6825d2a9b2e
+# eu-central-1 v4.3.7 OSS: ami-053b9678ee5ef3bac
+# eu-west-1 v4.3.7 OSS: ami-0461594797e8796ce
+# eu-west-2 v4.3.7 OSS: ami-03aedc1e918b6d1ae
+# sa-east-1 v4.3.7 OSS: ami-0681e601ce3e4cc1f
+# us-east-1 v4.3.7 OSS: ami-01a0c53eccf8b5219
+# us-east-2 v4.3.7 OSS: ami-0229bfeb0dda41e2c
+# us-west-1 v4.3.7 OSS: ami-045ea9b73ece9a52f
+# us-west-2 v4.3.7 OSS: ami-04b903d46f0b0eb2d
+```
+
+### Enterprise
+
+```
+# ap-south-1 v4.3.7 Enterprise: ami-0947fce276b8c9f7b
+# ap-northeast-2 v4.3.7 Enterprise: ami-00e857277c884612a
+# ap-southeast-1 v4.3.7 Enterprise: ami-0738b45bdd2ed2815
+# ap-southeast-2 v4.3.7 Enterprise: ami-0a8472c74e90bc376
+# ap-northeast-1 v4.3.7 Enterprise: ami-02f0dae2dbcecf5d1
+# ca-central-1 v4.3.7 Enterprise: ami-06c58ee8e1799b6dd
+# eu-central-1 v4.3.7 Enterprise: ami-02b71340b2b0b8e0e
+# eu-west-1 v4.3.7 Enterprise: ami-03fceba6e2cd2247e
+# eu-west-2 v4.3.7 Enterprise: ami-034a41f7790a4cdb5
+# sa-east-1 v4.3.7 Enterprise: ami-0893d62dcacab4183
+# us-east-1 v4.3.7 Enterprise: ami-0ab7648b1e8cc571f
+# us-east-2 v4.3.7 Enterprise: ami-03b616180deb504a0
+# us-west-1 v4.3.7 Enterprise: ami-0ab333fc6a692cdd0
+# us-west-2 v4.3.7 Enterprise: ami-0460521251ad1ec84
+```
+
+### Enterprise FIPS
+
+```
+# ap-south-1 v4.3.7 Enterprise FIPS: ami-0434cc723b9ecf8cd
+# ap-northeast-2 v4.3.7 Enterprise FIPS: ami-05bc06ba2e005dbb2
+# ap-southeast-1 v4.3.7 Enterprise FIPS: ami-037e7e86612a1f7ff
+# ap-southeast-2 v4.3.7 Enterprise FIPS: ami-03999cf047ba0365f
+# ap-northeast-1 v4.3.7 Enterprise FIPS: ami-0859dc8caa76cf8ee
+# ca-central-1 v4.3.7 Enterprise FIPS: ami-0b33db446ed6da3c7
+# eu-central-1 v4.3.7 Enterprise FIPS: ami-0504a864dbd167f82
+# eu-west-1 v4.3.7 Enterprise FIPS: ami-0a729c3053ecaf6ec
+# eu-west-2 v4.3.7 Enterprise FIPS: ami-09bf17361fd3b1c2f
+# sa-east-1 v4.3.7 Enterprise FIPS: ami-02c5e77af235c1d76
+# us-east-1 v4.3.7 Enterprise FIPS: ami-0077437faff5a6ed7
+# us-east-2 v4.3.7 Enterprise FIPS: ami-0f871a52d1d51dccd
+# us-west-1 v4.3.7 Enterprise FIPS: ami-044dda12e27c12927
+# us-west-2 v4.3.7 Enterprise FIPS: ami-09c45fd41eb4a5d49
+```

--- a/examples/aws/terraform/README.md
+++ b/examples/aws/terraform/README.md
@@ -29,68 +29,10 @@ In order to spin up AWS resources using these Terraform examples, you need the f
 
 ## How to get help
 
-If you're having trouble, check out our [Discourse community](https://community.gravitational.com). 
+If you're having trouble, check out our [Discourse community](https://community.gravitational.com).
 
 For bugs related to this code, please [open an issue](https://github.com/gravitational/teleport/issues/new/choose).
 
 ## Public Teleport AMI IDs
 
-For your convenience, this is a list of public Teleport AMI IDs which are published by Gravitational. This list
-is updated when new AMI versions are released.
-
-### OSS
-
-```
-# ap-south-1 v4.3.7 OSS: ami-08f009f8430b5f300
-# ap-northeast-2 v4.3.7 OSS: ami-0f4b5ab15359913ac
-# ap-southeast-1 v4.3.7 OSS: ami-060ad577453b04754
-# ap-southeast-2 v4.3.7 OSS: ami-020df260996c4c297
-# ap-northeast-1 v4.3.7 OSS: ami-0ee948fbdfc89b5a9
-# ca-central-1 v4.3.7 OSS: ami-03c59b6825d2a9b2e
-# eu-central-1 v4.3.7 OSS: ami-053b9678ee5ef3bac
-# eu-west-1 v4.3.7 OSS: ami-0461594797e8796ce
-# eu-west-2 v4.3.7 OSS: ami-03aedc1e918b6d1ae
-# sa-east-1 v4.3.7 OSS: ami-0681e601ce3e4cc1f
-# us-east-1 v4.3.7 OSS: ami-01a0c53eccf8b5219
-# us-east-2 v4.3.7 OSS: ami-0229bfeb0dda41e2c
-# us-west-1 v4.3.7 OSS: ami-045ea9b73ece9a52f
-# us-west-2 v4.3.7 OSS: ami-04b903d46f0b0eb2d
-```
-
-### Enterprise
-
-```
-# ap-south-1 v4.3.7 Enterprise: ami-0947fce276b8c9f7b
-# ap-northeast-2 v4.3.7 Enterprise: ami-00e857277c884612a
-# ap-southeast-1 v4.3.7 Enterprise: ami-0738b45bdd2ed2815
-# ap-southeast-2 v4.3.7 Enterprise: ami-0a8472c74e90bc376
-# ap-northeast-1 v4.3.7 Enterprise: ami-02f0dae2dbcecf5d1
-# ca-central-1 v4.3.7 Enterprise: ami-06c58ee8e1799b6dd
-# eu-central-1 v4.3.7 Enterprise: ami-02b71340b2b0b8e0e
-# eu-west-1 v4.3.7 Enterprise: ami-03fceba6e2cd2247e
-# eu-west-2 v4.3.7 Enterprise: ami-034a41f7790a4cdb5
-# sa-east-1 v4.3.7 Enterprise: ami-0893d62dcacab4183
-# us-east-1 v4.3.7 Enterprise: ami-0ab7648b1e8cc571f
-# us-east-2 v4.3.7 Enterprise: ami-03b616180deb504a0
-# us-west-1 v4.3.7 Enterprise: ami-0ab333fc6a692cdd0
-# us-west-2 v4.3.7 Enterprise: ami-0460521251ad1ec84
-```
-
-### Enterprise FIPS
-
-```
-# ap-south-1 v4.3.7 Enterprise FIPS: ami-0434cc723b9ecf8cd
-# ap-northeast-2 v4.3.7 Enterprise FIPS: ami-05bc06ba2e005dbb2
-# ap-southeast-1 v4.3.7 Enterprise FIPS: ami-037e7e86612a1f7ff
-# ap-southeast-2 v4.3.7 Enterprise FIPS: ami-03999cf047ba0365f
-# ap-northeast-1 v4.3.7 Enterprise FIPS: ami-0859dc8caa76cf8ee
-# ca-central-1 v4.3.7 Enterprise FIPS: ami-0b33db446ed6da3c7
-# eu-central-1 v4.3.7 Enterprise FIPS: ami-0504a864dbd167f82
-# eu-west-1 v4.3.7 Enterprise FIPS: ami-0a729c3053ecaf6ec
-# eu-west-2 v4.3.7 Enterprise FIPS: ami-09bf17361fd3b1c2f
-# sa-east-1 v4.3.7 Enterprise FIPS: ami-02c5e77af235c1d76
-# us-east-1 v4.3.7 Enterprise FIPS: ami-0077437faff5a6ed7
-# us-east-2 v4.3.7 Enterprise FIPS: ami-0f871a52d1d51dccd
-# us-west-1 v4.3.7 Enterprise FIPS: ami-044dda12e27c12927
-# us-west-2 v4.3.7 Enterprise FIPS: ami-09c45fd41eb4a5d49
-```
+Please [see the AMIS.md file](AMIS.md) for a list of public Teleport AMI IDs that you can use.

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -46,7 +46,7 @@ export TF_VAR_cluster_name="teleport.example.com"
 # OSS: aws ec2 describe-images --owners 126027368216 --filters 'Name=name,Values=gravitational-teleport-ami-oss*'
 # Enterprise: aws ec2 describe-images --owners 126027368216 --filters 'Name=name,Values=gravitational-teleport-ami-ent*'
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
-export TF_VAR_ami_name="gravitational-teleport-ami-ent-4.3.6"
+export TF_VAR_ami_name="gravitational-teleport-ami-ent-4.3.7"
 
 # AWS SSH key name to provision in installed instances, should be available in the region
 export TF_VAR_key_name="example"

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -5,7 +5,7 @@ Terraform specifies example provisioning script for Teleport auth, proxy and nod
 Use these examples as possible deployment patterns suggested by Teleport developers.
 
 The scripts set up LetsEncrypt certificates using DNS-01 challenge. This means that users have to control the DNS zone
-via Route 53. ACM can optionally be used too, but Route 53 integration is still required. 
+via Route 53. ACM can optionally be used too, but Route 53 integration is still required.
 
 Teleport join tokens are distributed using SSM parameter store, and certificates are distributed using encrypted S3
 bucket.
@@ -82,62 +82,4 @@ make plan
 
 ## Public Teleport AMI IDs
 
-For your convenience, this is a list of public Teleport AMI IDs which are published by Gravitational. This list
-is updated when new AMI versions are released.
-
-### OSS
-
-```
-# ap-south-1 v4.3.5 OSS: ami-0d277d983018002ec
-# ap-northeast-2 v4.3.5 OSS: ami-072f84faa9242a47e
-# ap-southeast-1 v4.3.5 OSS: ami-02a7715ddf767c966
-# ap-southeast-2 v4.3.5 OSS: ami-0dbdbc8c568567d80
-# ap-northeast-1 v4.3.5 OSS: ami-047135319113ca54d
-# ca-central-1 v4.3.5 OSS: ami-09e9fa154f5d7e676
-# eu-central-1 v4.3.5 OSS: ami-06490e9cd8d95ba09
-# eu-west-1 v4.3.5 OSS: ami-0453fc6afc07a4b34
-# eu-west-2 v4.3.5 OSS: ami-0c93b69dc46ce70a2
-# sa-east-1 v4.3.5 OSS: ami-0e77d1cbf2b80db47
-# us-east-1 v4.3.5 OSS: ami-0a12d80becdd5d1a1
-# us-east-2 v4.3.5 OSS: ami-02b4742f89960ce18
-# us-west-1 v4.3.5 OSS: ami-0598f55e8dc41d652
-# us-west-2 v4.3.5 OSS: ami-0d63a03d1519101b5
-```
-
-### Enterprise
-
-```
-# ap-south-1 v4.3.5 Enterprise: ami-09d50faa4da796ada
-# ap-northeast-2 v4.3.5 Enterprise: ami-091d5e7bdfe387cb7
-# ap-southeast-1 v4.3.5 Enterprise: ami-025f42e94bdeda91f
-# ap-southeast-2 v4.3.5 Enterprise: ami-00ed65891b4770941
-# ap-northeast-1 v4.3.5 Enterprise: ami-0a9bd0ec2aaa77ce9
-# ca-central-1 v4.3.5 Enterprise: ami-0a4830e7882740ca6
-# eu-central-1 v4.3.5 Enterprise: ami-0e77128f1392b2250
-# eu-west-1 v4.3.5 Enterprise: ami-07e76616b360885fb
-# eu-west-2 v4.3.5 Enterprise: ami-036bb80a85cc6acf7
-# sa-east-1 v4.3.5 Enterprise: ami-0c68b2b86b2cc4898
-# us-east-1 v4.3.5 Enterprise: ami-0e08f81f767c62ddd
-# us-east-2 v4.3.5 Enterprise: ami-07925f0b4f361ab01
-# us-west-1 v4.3.5 Enterprise: ami-0627bae15bd3b7fa1
-# us-west-2 v4.3.5 Enterprise: ami-0212214f21f3d7a06
-```
-
-### Enterprise FIPS
-
-```
-# ap-south-1 v4.3.5 Enterprise FIPS: ami-0c2c57c0dc5ae7c46
-# ap-northeast-2 v4.3.5 Enterprise FIPS: ami-0e5c3dc6104bf9dd9
-# ap-southeast-1 v4.3.5 Enterprise FIPS: ami-0ae54863080227132
-# ap-southeast-2 v4.3.5 Enterprise FIPS: ami-0fe72e5c60f6a63ae
-# ap-northeast-1 v4.3.5 Enterprise FIPS: ami-0ec9f8014bb42e674
-# ca-central-1 v4.3.5 Enterprise FIPS: ami-0c3ecff82cf3f5a97
-# eu-central-1 v4.3.5 Enterprise FIPS: ami-05ef481c07e8cc7da
-# eu-west-1 v4.3.5 Enterprise FIPS: ami-0b1bb1d0930b2cedb
-# eu-west-2 v4.3.5 Enterprise FIPS: ami-0599548c2e586e9b2
-# sa-east-1 v4.3.5 Enterprise FIPS: ami-022d9de7679681cd8
-# us-east-1 v4.3.5 Enterprise FIPS: ami-0192074892ea1bca1
-# us-east-2 v4.3.5 Enterprise FIPS: ami-094df13554a9ed48c
-# us-west-1 v4.3.5 Enterprise FIPS: ami-00f70d17feb41e977
-# us-west-2 v4.3.5 Enterprise FIPS: ami-010c200a8731ede9b
-```
+Please [see the AMIS.md file](../AMIS.md) for a list of public Teleport AMI IDs that you can use.

--- a/examples/aws/terraform/starter-cluster/README.md
+++ b/examples/aws/terraform/starter-cluster/README.md
@@ -8,9 +8,9 @@ Do not use this in production! This example should be used for demo, proof-of-co
 
 Teleport AMIs are built so you only need to specify environment variables to bring a fully configured instance online. See `data.tpl` or our [documentation](https://gravitational.com/teleport/docs/aws_oss_guide/#single-oss-teleport-amis-manual-gui-setup) to learn more about supported environment variables.
 
-A series of systemd [units](https://github.com/gravitational/teleport/tree/master/assets/marketplace/files/system) bootstrap the instance, via several bash [scripts](https://github.com/gravitational/teleport/tree/master/assets/marketplace/files/bin).
+A series of systemd [units](https://github.com/gravitational/teleport/tree/master/assets/aws/files/system) bootstrap the instance, via several bash [scripts](https://github.com/gravitational/teleport/tree/master/assets/aws/files/bin).
 
-While this may not be sufficient for all use cases, it's a great proof-of-concept that you can fork and customize to your liking. Check out our AWS AMI [generation code](https://github.com/gravitational/teleport/tree/master/assets/marketplace) if you're interested in adapting this to your requirements.
+While this may not be sufficient for all use cases, it's a great proof-of-concept that you can fork and customize to your liking. Check out our AWS AMI [generation code](https://github.com/gravitational/teleport/tree/master/assets/aws) if you're interested in adapting this to your requirements.
 
 This Terraform example will configure the following AWS resources:
 
@@ -82,7 +82,7 @@ TF_VAR_license_path ?="/path/to/license"
 # OSS: aws ec2 describe-images --owners 126027368216 --filters 'Name=name,Values=gravitational-teleport-ami-oss*'
 # Enterprise: aws ec2 describe-images --owners 126027368216 --filters 'Name=name,Values=gravitational-teleport-ami-ent*'
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
-TF_VAR_ami_name ?="gravitational-teleport-ami-ent-4.2.9"
+TF_VAR_ami_name ?="gravitational-teleport-ami-ent-4.3.7"
 
 # Route 53 hosted zone to use, must be a root zone registered in AWS, e.g. example.com
 TF_VAR_route53_zone ?="example.com"
@@ -111,62 +111,4 @@ make plan
 
 ## Public Teleport AMI IDs
 
-For your convenience, this is a list of public Teleport AMI IDs which are published by Gravitational. This list
-is updated when new AMI versions are released.
-
-### OSS
-
-```
-# ap-south-1 v4.3.5 OSS: ami-0d277d983018002ec
-# ap-northeast-2 v4.3.5 OSS: ami-072f84faa9242a47e
-# ap-southeast-1 v4.3.5 OSS: ami-02a7715ddf767c966
-# ap-southeast-2 v4.3.5 OSS: ami-0dbdbc8c568567d80
-# ap-northeast-1 v4.3.5 OSS: ami-047135319113ca54d
-# ca-central-1 v4.3.5 OSS: ami-09e9fa154f5d7e676
-# eu-central-1 v4.3.5 OSS: ami-06490e9cd8d95ba09
-# eu-west-1 v4.3.5 OSS: ami-0453fc6afc07a4b34
-# eu-west-2 v4.3.5 OSS: ami-0c93b69dc46ce70a2
-# sa-east-1 v4.3.5 OSS: ami-0e77d1cbf2b80db47
-# us-east-1 v4.3.5 OSS: ami-0a12d80becdd5d1a1
-# us-east-2 v4.3.5 OSS: ami-02b4742f89960ce18
-# us-west-1 v4.3.5 OSS: ami-0598f55e8dc41d652
-# us-west-2 v4.3.5 OSS: ami-0d63a03d1519101b5
-```
-
-### Enterprise
-
-```
-# ap-south-1 v4.3.5 Enterprise: ami-09d50faa4da796ada
-# ap-northeast-2 v4.3.5 Enterprise: ami-091d5e7bdfe387cb7
-# ap-southeast-1 v4.3.5 Enterprise: ami-025f42e94bdeda91f
-# ap-southeast-2 v4.3.5 Enterprise: ami-00ed65891b4770941
-# ap-northeast-1 v4.3.5 Enterprise: ami-0a9bd0ec2aaa77ce9
-# ca-central-1 v4.3.5 Enterprise: ami-0a4830e7882740ca6
-# eu-central-1 v4.3.5 Enterprise: ami-0e77128f1392b2250
-# eu-west-1 v4.3.5 Enterprise: ami-07e76616b360885fb
-# eu-west-2 v4.3.5 Enterprise: ami-036bb80a85cc6acf7
-# sa-east-1 v4.3.5 Enterprise: ami-0c68b2b86b2cc4898
-# us-east-1 v4.3.5 Enterprise: ami-0e08f81f767c62ddd
-# us-east-2 v4.3.5 Enterprise: ami-07925f0b4f361ab01
-# us-west-1 v4.3.5 Enterprise: ami-0627bae15bd3b7fa1
-# us-west-2 v4.3.5 Enterprise: ami-0212214f21f3d7a06
-```
-
-### Enterprise FIPS
-
-```
-# ap-south-1 v4.3.5 Enterprise FIPS: ami-0c2c57c0dc5ae7c46
-# ap-northeast-2 v4.3.5 Enterprise FIPS: ami-0e5c3dc6104bf9dd9
-# ap-southeast-1 v4.3.5 Enterprise FIPS: ami-0ae54863080227132
-# ap-southeast-2 v4.3.5 Enterprise FIPS: ami-0fe72e5c60f6a63ae
-# ap-northeast-1 v4.3.5 Enterprise FIPS: ami-0ec9f8014bb42e674
-# ca-central-1 v4.3.5 Enterprise FIPS: ami-0c3ecff82cf3f5a97
-# eu-central-1 v4.3.5 Enterprise FIPS: ami-05ef481c07e8cc7da
-# eu-west-1 v4.3.5 Enterprise FIPS: ami-0b1bb1d0930b2cedb
-# eu-west-2 v4.3.5 Enterprise FIPS: ami-0599548c2e586e9b2
-# sa-east-1 v4.3.5 Enterprise FIPS: ami-022d9de7679681cd8
-# us-east-1 v4.3.5 Enterprise FIPS: ami-0192074892ea1bca1
-# us-east-2 v4.3.5 Enterprise FIPS: ami-094df13554a9ed48c
-# us-west-1 v4.3.5 Enterprise FIPS: ami-00f70d17feb41e977
-# us-west-2 v4.3.5 Enterprise FIPS: ami-010c200a8731ede9b
-```
+Please [see the AMIS.md file](../AMIS.md) for a list of public Teleport AMI IDs that you can use.


### PR DESCRIPTION
- Removed AWS Marketplace AMI builds - these were separate AMIs which we submitted to AWS Marketplace so that they could take control of the images.
  - Removed Marketplace build steps from Jenkins and Drone.
   - We're still keeping our regular public AWS AMIs which we provide to people - this just cuts down on our storage costs and build times.
- Removed the list of AMIs from the Terraform README.md file and moved it to AMIs.md
- Added links to AMIS.md in the two new Terraform subdirectories so that we only need to maintain a list of AMIS in one place.
  - Updated the scripts which create the AMI list to write them to the new AMIS.md file.
- Updated the scripts to also rewrite any  `gravitational-teleport-ami-ent-*` names used as examples for Terraform to the newest version when updating the AMI list.
- Fixed any `shellcheck` complaints.