### PR TITLE
Fixes cert authority rollback for IOT nodes.

### DIFF
--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -604,7 +604,7 @@ func startRollingBackRotation(ca services.CertAuthority) error {
 	// Rotation sets the first key to be the new key
 	// and keep only public keys/certs for the new CA.
 	signingKeys = [][]byte{signingKeys[1]}
-	checkingKeys = [][]byte{checkingKeys[1]}
+	checkingKeys = [][]byte{checkingKeys[1], checkingKeys[0]}
 
 	// Keep the new certificate as trusted
 	// as during the rollback phase, both types of clients may be present in the cluster.


### PR DESCRIPTION
IOT nodes could not reconnect in rollback state because
cert authority was missing the new SSH public key.

IOT nodes were authenticating using new certificate
and were rejected.