### PR TITLE
Improve error logging for trusted cluster token validation

### DIFF
--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -439,7 +439,15 @@ func (a *Server) GetRemoteClusters(opts ...services.MarshalOption) ([]services.R
 	return remoteClusters, nil
 }
 
-func (a *Server) validateTrustedCluster(validateRequest *ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error) {
+func (a *Server) validateTrustedCluster(validateRequest *ValidateTrustedClusterRequest) (resp *ValidateTrustedClusterResponse, err error) {
+	defer func() {
+		if err != nil {
+			log.WithError(err).Info("Trusted cluster validation failed")
+		}
+	}()
+
+	log.Debugf("Received validate request: token=%v, CAs=%v", validateRequest.Token, validateRequest.CAs)
+
 	domainName, err := a.GetDomainName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -450,9 +458,6 @@ func (a *Server) validateTrustedCluster(validateRequest *ValidateTrustedClusterR
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	// log the remote certificate authorities we are adding
-	log.Debugf("Received validate request: token=%v, CAs=%v", validateRequest.Token, validateRequest.CAs)
 
 	// add remote cluster resource to keep track of the remote cluster
 	var remoteClusterName string

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1989,10 +1989,10 @@ func (h *Handler) validateTrustedCluster(w http.ResponseWriter, r *http.Request,
 
 	validateResponse, err := h.auth.ValidateTrustedCluster(validateRequest)
 	if err != nil {
+		log.WithError(err).Error("Failed validating trusted cluster")
 		if trace.IsAccessDenied(err) {
 			return nil, trace.AccessDenied("access denied: the cluster token has been rejected")
 		}
-		log.Error(err)
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Auth server and proxy should internally log the full error message
without masking it.