### PR TITLE
Add minimum OpenSSH version plus raw/endraw directives

### DIFF
--- a/docs/4.3/openssh-teleport.md
+++ b/docs/4.3/openssh-teleport.md
@@ -200,6 +200,11 @@ Teleport cluster. Teleport supports SSH subsystems and includes a `proxy`
 subsystem that can be used like `netcat` is with `ProxyCommand` to connect
 through a jump host.
 
+!!! warning
+
+    The minimum OpenSSH client version which will work with Teleport is version 6.9.
+    You can view your OpenSSH client version with `ssh -V`.
+
 On your client machine, you need to import the public key of Teleport's host
 certificate. This will allow your OpenSSH client to verify that host certificates
 are signed by Teleport's trusted host CA:

--- a/docs/4.3/openssh-teleport.md
+++ b/docs/4.3/openssh-teleport.md
@@ -18,6 +18,11 @@ existing SSH implementations, such as OpenSSH. This section will cover:
 * Configuring OpenSSH client `ssh` to login into nodes inside a Teleport
   cluster.
 
+  !!! warning
+
+    The minimum OpenSSH version which will work with Teleport is version 6.9.
+    You can view your OpenSSH version with `ssh -V`.
+
 ## Architecture
 ![Node Service ping API](img/openssh-proxy.svg)
 
@@ -199,11 +204,6 @@ It is possible to use the OpenSSH client `ssh` to connect to nodes within a
 Teleport cluster. Teleport supports SSH subsystems and includes a `proxy`
 subsystem that can be used like `netcat` is with `ProxyCommand` to connect
 through a jump host.
-
-!!! warning
-
-    The minimum OpenSSH client version which will work with Teleport is version 6.9.
-    You can view your OpenSSH client version with `ssh -V`.
 
 On your client machine, you need to import the public key of Teleport's host
 certificate. This will allow your OpenSSH client to verify that host certificates

--- a/docs/4.4/enterprise/ssh-rbac.md
+++ b/docs/4.4/enterprise/ssh-rbac.md
@@ -125,11 +125,11 @@ spec:
       'environment': ['test', 'staging']
       # regular expressions are also supported, for example the equivalent
       # of the list example above can be expressed as:
-      'environment': '{{regexp.match("^test|staging$")}}'
+      'environment': '{% raw %}{{regexp.match("^test|staging$")}}{% endraw %}'
       # or using the simpler legacy syntax:
       'environment': '^test|staging$'
       # negative regular expressions can be used to avoid strict deny rules:
-      'environment': '{{regexp.not_match("prod")}}'
+      'environment': '{% raw %}{{regexp.not_match("prod")}}{% endraw %}'
 
     # defines roles that this user can can request.
     # needed for teleport's request workflow
@@ -263,11 +263,11 @@ spec:
       'environment': ['test', 'staging']
       # regular expressions are also supported, for example the equivalent
       # of the list example above can be expressed as:
-      'environment': '{{regexp.match("^test|staging$")}}'
+      'environment': '{% raw %}{{regexp.match("^test|staging$")}}{% endraw %}'
       # or using the simpler legacy syntax:
       'environment': '^test|staging$'
       # negative regular expressions can be used to avoid strict deny rules:
-      'environment': '{{regexp.not_match("prod")}}'
+      'environment': '{% raw %}{{regexp.not_match("prod")}}{% endraw %}'
 ```
 
 

--- a/docs/4.4/openssh-teleport.md
+++ b/docs/4.4/openssh-teleport.md
@@ -200,6 +200,11 @@ Teleport cluster. Teleport supports SSH subsystems and includes a `proxy`
 subsystem that can be used like `netcat` is with `ProxyCommand` to connect
 through a jump host.
 
+!!! warning
+
+    The minimum OpenSSH client version which will work with Teleport is version 6.9.
+    You can view your OpenSSH client version with `ssh -V`.
+
 On your client machine, you need to import the public key of Teleport's host
 certificate. This will allow your OpenSSH client to verify that host certificates
 are signed by Teleport's trusted host CA:

--- a/docs/4.4/openssh-teleport.md
+++ b/docs/4.4/openssh-teleport.md
@@ -18,6 +18,11 @@ existing SSH implementations, such as OpenSSH. This section will cover:
 * Configuring OpenSSH client `ssh` to login into nodes inside a Teleport
   cluster.
 
+  !!! warning
+
+    The minimum OpenSSH version which will work with Teleport is version 6.9.
+    You can view your OpenSSH version with `ssh -V`.
+
 ## Architecture
 ![Node Service ping API](img/openssh-proxy.svg)
 
@@ -199,11 +204,6 @@ It is possible to use the OpenSSH client `ssh` to connect to nodes within a
 Teleport cluster. Teleport supports SSH subsystems and includes a `proxy`
 subsystem that can be used like `netcat` is with `ProxyCommand` to connect
 through a jump host.
-
-!!! warning
-
-    The minimum OpenSSH client version which will work with Teleport is version 6.9.
-    You can view your OpenSSH client version with `ssh -V`.
 
 On your client machine, you need to import the public key of Teleport's host
 certificate. This will allow your OpenSSH client to verify that host certificates


### PR DESCRIPTION
- Adds the minimum OpenSSH version supported by Teleport to the OpenSSH documentation
  - There's a bug that prevents Teleport certificates from working with OpenSSH versions <6.9, as per https://community.gravitational.com/t/teleport-compatibility-with-openssh-v6/840/8 and https://bugzilla.mindrot.org/show_bug.cgi?id=2387 - this affects `sshd` authentication using `TrustedUserCAKeys`
- Adds `{% raw %}`/`{% endraw %}` directives to the new `regexp` examples in the RBAC docs, as `mkdocs` wasn't happy:

```consople
ERROR   -  Error reading page 'enterprise/ssh-rbac.md': 'regexp' is undefined 
Traceback (most recent call last):
  File "/usr/local/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/mkdocs/__main__.py", line 136, in serve_command
    **kwargs
  File "/usr/local/lib/python3.7/site-packages/mkdocs/commands/serve.py", line 141, in serve
    config = builder()
  File "/usr/local/lib/python3.7/site-packages/mkdocs/commands/serve.py", line 136, in builder
    build(config, live_server=live_server, dirty=dirty)
  File "/usr/local/lib/python3.7/site-packages/mkdocs/commands/build.py", line 271, in build
    _populate_page(file.page, config, files, dirty)
  File "/usr/local/lib/python3.7/site-packages/mkdocs/commands/build.py", line 168, in _populate_page
    'page_markdown', page.markdown, page=page, config=config, files=files
  File "/usr/local/lib/python3.7/site-packages/mkdocs/plugins.py", line 94, in run_event
    result = method(item, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/markdownextradata/plugin.py", line 95, in on_page_markdown
    return md_template.render(**config.get("extra"))
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/local/lib/python3.7/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 123, in top-level template code
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 471, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'regexp' is undefined
```