### PR TITLE
kube: allow startup with a dummy kubeconfig_file

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -90,9 +90,21 @@ running in a kubernetes cluster, but could not init in-cluster kubernetes client
 		return nil, trace.Wrap(err, "failed to generate kubernetes client from kubeconfig: %v", err)
 	}
 	if err := checkImpersonationPermissions(ctx, client.AuthorizationV1().SelfSubjectAccessReviews()); err != nil {
-		return nil, trace.Wrap(err)
+		if kubeconfigPath == "" {
+			return nil, trace.Wrap(err)
+		}
+		// Some users run proxies in root teleport clusters with k8s
+		// integration enabled but no local k8s cluster. They only forward
+		// requests to leaf teleport clusters.
+		//
+		// Before https://github.com/gravitational/teleport/pull/3811,
+		// users needed to add a dummy kubeconfig_file in the root proxy to
+		// get it to start. To allow those users to upgrade without a
+		// config change, log the error but don't fail startup.
+		log.WithError(err).Errorf("Failed to self-verify the kubernetes permissions using kubeconfig file %q; proceeding with startup but kubernetes integration on this proxy might not work; if this is a root proxy in trusted cluster setup and you only plan to forward kubernetes requests to leaf clusters, you can remove 'kubeconfig_file' from 'proxy_service' in your teleport.yaml to suppress this error", kubeconfigPath)
+	} else {
+		log.Debugf("Proxy has all necessary kubernetes impersonation permissions.")
 	}
-	log.Debugf("Proxy has all necessary kubernetes impersonation permissions.")
 
 	targetAddr, err := parseKubeHost(cfg.Host)
 	if err != nil {


### PR DESCRIPTION
Prior to https://github.com/gravitational/teleport/pull/3811, if users
wanted to run a root proxy without k8s clusters but leaf proxies with
k8s, they had to put a dummy `kubeconfig_file` on the root proxy.

The permissions self-test added in
https://github.com/gravitational/teleport/pull/3812 didn't take that
into account.

So, users who keep the old workaround and upgrade to 4.4 will see their
proxies fail to start. To recover, they have to realize that
`kubeconfig_file` can be removed.