### PR TITLE
Fix firestore events interface and init stage.

### DIFF
--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -26,8 +26,26 @@ import (
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/utils"
 
+	"github.com/stretchr/testify/assert"
+	adminpb "google.golang.org/genproto/googleapis/firestore/admin/v1"
+	"google.golang.org/protobuf/proto"
+
 	"gopkg.in/check.v1"
 )
+
+// TestMarshal tests index operation metadata marshal and unmarshal
+// to verify backwards compatibility. Gogoproto is incompatible with ApiV2 protoc-gen-go code.
+//
+// Track the issue here: https://github.com/gogo/protobuf/issues/678
+//
+func TestMarshal(t *testing.T) {
+	meta := adminpb.IndexOperationMetadata{}
+	data, err := proto.Marshal(&meta)
+	assert.NoError(t, err)
+	out := adminpb.IndexOperationMetadata{}
+	err = proto.Unmarshal(data, &out)
+	assert.NoError(t, err)
+}
 
 func TestFirestoreDB(t *testing.T) { check.TestingT(t) }
 
@@ -42,7 +60,7 @@ func (s *FirestoreSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())
 
 	if !emulatorRunning() {
-		c.Skip("firestore emulator not running, start it with: gcloud beta emulators firestore start --host-port=localhost:8618")
+		c.Skip("Firestore emulator is not running, start it with: gcloud beta emulators firestore start --host-port=localhost:8618")
 	}
 
 	newBackend := func() (backend.Backend, error) {

--- a/lib/events/firestoreevents/firestoreevents_test.go
+++ b/lib/events/firestoreevents/firestoreevents_test.go
@@ -41,7 +41,7 @@ func (s *FirestoreeventsSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests()
 
 	if !emulatorRunning() {
-		c.Skip("firestore emulator not running, start it with: gcloud beta emulators firestore start --host-port=localhost:8618")
+		c.Skip("Firestore emulator is not running, start it with: gcloud beta emulators firestore start --host-port=localhost:8618")
 	}
 
 	fakeClock := clockwork.NewFakeClock()


### PR DESCRIPTION
This comit fixes #4508

Gogoproto is not compatible with APIv2 protoc-gen-go.
Track the issue here: https://github.com/gogo/protobuf/issues/678
Meanwhile, this commit switches to google protobuf to unmarshal firebase struct.

Add a missing method EmitAuditEvent causing teleport to crash
with firestore events backend.