### PR TITLE
Have another go at enabling build caching

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -89,6 +89,7 @@ steps:
   - name: Run linter
     image: docker
     environment:
+      GOCACHE: /go/cache
       GOPATH: /go
     volumes:
       - name: dockersock
@@ -102,6 +103,7 @@ steps:
   - name: Run unit and chaos tests
     image: docker
     environment:
+      GOCACHE: /go/cache
       GOPATH: /go
     volumes:
       - name: dockersock
@@ -115,6 +117,7 @@ steps:
   - name: Run integration tests
     image: docker
     environment:
+      GOCACHE: /go/cache
       GOPATH: /go
       INTEGRATION_CI_KUBECONFIG:
         from_secret: INTEGRATION_CI_KUBECONFIG
@@ -2885,6 +2888,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 7faeabe8d31da052de4744f5fbc4849a8f727157a8d8e0914a6e86e7b1e371d6
+hmac: 0bb27537c4baaa08f7aa7466e14a6b023ffa09aafed4ab761dd6354f1613b2a3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ trigger:
       - gravitational/*
 
 workspace:
-  path: /go/src/github.com/gravitational/teleport
+  path: /go
 
 clone:
   disable: true
@@ -89,39 +89,39 @@ steps:
   - name: Run linter
     image: docker
     environment:
-      GOCACHE: /go/cache
+      GOCACHE: /gocache
       GOPATH: /go
     volumes:
       - name: dockersock
         path: /var/run
       - name: gocache
-        path: /go/cache
+        path: /gocache
     commands:
       - apk add --no-cache make
-      - chown -R $UID:$GID /go
+      - chown -R $UID:$GID /go /gocache
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets lint
 
   - name: Run unit and chaos tests
     image: docker
     environment:
-      GOCACHE: /go/cache
+      GOCACHE: /gocache
       GOPATH: /go
     volumes:
       - name: dockersock
         path: /var/run
       - name: gocache
-        path: /go/cache
+        path: /gocache
     commands:
       - apk add --no-cache make
-      - chown -R $UID:$GID /go
+      - chown -R $UID:$GID /go /gocache
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets test
 
   - name: Run integration tests
     image: docker
     environment:
-      GOCACHE: /go/cache
+      GOCACHE: /gocache
       GOPATH: /go
       INTEGRATION_CI_KUBECONFIG:
         from_secret: INTEGRATION_CI_KUBECONFIG
@@ -130,15 +130,15 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
-      - name: tmp-integration
-        path: /tmp
       - name: gocache
         path: /gocache
+      - name: tmp-integration
+        path: /tmp
     commands:
       - apk add --no-cache make
       # write kubeconfig to disk for use in kube integrations tests
       - echo "$INTEGRATION_CI_KUBECONFIG" > "$KUBECONFIG"
-      - chown -R $UID:$GID /go
+      - chown -R $UID:$GID /go /gocache
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets integration
       - rm -f "$KUBECONFIG"
@@ -200,7 +200,7 @@ steps:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport /go/cache
+      - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
       - git init && git remote add origin ${DRONE_REMOTE_URL}
       - git fetch origin
@@ -2896,6 +2896,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 2478e26be15aed95b977691f41e230631774b69100f0039fd9e55ac510e1d53c
+hmac: 8e96a929b43722d5432a28834ad6907ef379311faf1ad83b82bf0a8aa540b508
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -89,39 +89,40 @@ steps:
   - name: Run linter
     image: docker
     environment:
-      GOCACHE: /gocache
+      GOCACHE: /go/cache
       GOPATH: /go
     volumes:
       - name: dockersock
         path: /var/run
       - name: gocache
-        path: /gocache
+        path: /go/cache
     commands:
       - apk add --no-cache make
-      - chown -R $UID:$GID /go /gocache
+      - chown -R $UID:$GID /go
+      - ls -lR /go
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets lint
 
   - name: Run unit and chaos tests
     image: docker
     environment:
-      GOCACHE: /gocache
+      GOCACHE: /go/cache
       GOPATH: /go
     volumes:
       - name: dockersock
         path: /var/run
       - name: gocache
-        path: /gocache
+        path: /go/cache
     commands:
       - apk add --no-cache make
-      - chown -R $UID:$GID /go /gocache
+      - chown -R $UID:$GID /go
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets test
 
   - name: Run integration tests
     image: docker
     environment:
-      GOCACHE: /gocache
+      GOCACHE: /go/cache
       GOPATH: /go
       INTEGRATION_CI_KUBECONFIG:
         from_secret: INTEGRATION_CI_KUBECONFIG
@@ -131,14 +132,14 @@ steps:
       - name: dockersock
         path: /var/run
       - name: gocache
-        path: /gocache
+        path: /go/cache
       - name: tmp-integration
         path: /tmp
     commands:
       - apk add --no-cache make
       # write kubeconfig to disk for use in kube integrations tests
       - echo "$INTEGRATION_CI_KUBECONFIG" > "$KUBECONFIG"
-      - chown -R $UID:$GID /go /gocache
+      - chown -R $UID:$GID /go
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets integration
       - rm -f "$KUBECONFIG"
@@ -2896,6 +2897,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 8e96a929b43722d5432a28834ad6907ef379311faf1ad83b82bf0a8aa540b508
+hmac: 8e5767b7ca472b253011f96f62d841b1c352ec7d108101c26bfb0d774ac08de8
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,7 +17,7 @@ trigger:
       - gravitational/*
 
 workspace:
-  path: /go
+  path: /go/src/github.com/gravitational/teleport
 
 clone:
   disable: true
@@ -29,7 +29,7 @@ steps:
       GITHUB_PRIVATE_KEY:
         from_secret: GITHUB_PRIVATE_KEY
     commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport /go/cache
+      - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
       - git init && git remote add origin ${DRONE_REMOTE_URL}
       - |
@@ -94,6 +94,8 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
+      - name: gocache
+        path: /go/cache
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
@@ -108,6 +110,8 @@ steps:
     volumes:
       - name: dockersock
         path: /var/run
+      - name: gocache
+        path: /go/cache
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
@@ -128,6 +132,8 @@ steps:
         path: /var/run
       - name: tmp-integration
         path: /tmp
+      - name: gocache
+        path: /gocache
     commands:
       - apk add --no-cache make
       # write kubeconfig to disk for use in kube integrations tests
@@ -152,6 +158,8 @@ volumes:
   - name: tmp-dind
     temp: {}
   - name: tmp-integration
+    temp: {}
+  - name: gocache
     temp: {}
 
 ---
@@ -2888,6 +2896,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 0bb27537c4baaa08f7aa7466e14a6b023ffa09aafed4ab761dd6354f1613b2a3
+hmac: 2478e26be15aed95b977691f41e230631774b69100f0039fd9e55ac510e1d53c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -90,6 +90,7 @@ steps:
     image: docker
     environment:
       GOCACHE: /go/cache
+      GOGC: off
       GOPATH: /go
     volumes:
       - name: dockersock
@@ -2896,6 +2897,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 4c963d2aeba79b5a65810b0db8631958165707360f67c1eb7f72a1219f01e814
+hmac: ecc45670e77825c186ba4eaec480eaf64f8850ab52f05b5168a9af5697d77c16
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -99,7 +99,6 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - ls -lR /go
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets lint
 
@@ -2897,6 +2896,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 8e5767b7ca472b253011f96f62d841b1c352ec7d108101c26bfb0d774ac08de8
+hmac: 4c963d2aeba79b5a65810b0db8631958165707360f67c1eb7f72a1219f01e814
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,15 @@ endif
 clean:
 	@echo "---> Cleaning up OSS build artifacts."
 	rm -rf $(BUILDDIR)
-	-go clean -cache
 	rm -rf $(GOPKGDIR)
 	rm -rf teleport
 	rm -rf *.gz
 	rm -rf *.zip
 	rm -f gitref.go
+# don't clean the cache if the cache directory has been explicitly set
+ifndef GOCACHE
+	go clean -cache
+endif
 
 #
 # make release - Produces a binary release tarball.

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -35,6 +35,10 @@ ifeq ("$(DRONE)","true")
 UID := 1000
 GID := 1000
 NOROOT := -u 1000:1000
+# mount the go cache into the container if we're running in CI
+ifneq ("$(GOCACHE)", "")
+DOCKERFLAGS := $(DOCKERFLAGS) -v $(GOCACHE):/go/cache -e GOCACHE=/go/cache
+endif
 endif
 export
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -35,6 +35,10 @@ ifeq ("$(DRONE)","true")
 UID := 1000
 GID := 1000
 NOROOT := -u 1000:1000
+# pass through GOGC value if running in CI (uses more RAM for quicker runs)
+ifneq ("$(GOGC)", "")
+DOCKERFLAGS := $(DOCKERFLAGS) -e GOGC=$(GOGC)
+endif
 # mount the go cache into the container if we're running in CI
 ifneq ("$(GOCACHE)", "")
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(GOCACHE):/go/cache -e GOCACHE=/go/cache


### PR DESCRIPTION
- Sets `GOGC` to `off` to try and [speed up the linter at the cost of higher memory usage](https://golangci-lint.run/usage/performance/). The difference is pretty marginal - there's only 5 seconds or so in it. The linter's default setting is pretty aggressive so there isn't much more to squeeze out - we're better off just using machines with faster CPUs (which we're now also doing)
- Adds an `emptyDir` for `/go/cache` and mounts it as a volume so it can be shared by the separate containers running the linter, unit tests and integration tests. Also sets the `GOCACHE` environment variable to direct Go to use this volume and disables the running of `go clean -cache` when the `GOCACHE` environment variable is set (which the `Makefile` otherwise does by default)
  - I had hoped this would result in massive speed-ups, but I'm not seeing any difference between this and a recent PR which doesn't have the same changes enabled. These changes also seemed to also make it harder to get the unit/integration tests to pass - I had to retry 5 or 6 times. This may just be the red herring of flakiness, however.

I think overall this PR isn't worth reviewing/merging because the gains are so marginal. Full test runs are down around ~9 minutes in ideal conditions now we have our faster CI workers and I think most gains beyond this are far more likely to come from speeding up network access (by using a Docker repo which is colocated closer to the build cluster and pre-caching more) but most of all, active parallelisation of our existing tests.