### PR TITLE
Modify script example to pull k8s config in docs

### DIFF
--- a/docs/4.3/kubernetes-ssh.md
+++ b/docs/4.3/kubernetes-ssh.md
@@ -108,7 +108,7 @@ To generate the `kubeconfig_file` for the Teleport proxy service:
 
 ```bash
 # Download the script.
-$ curl -o get-kubeconfig.sh https://github.com/gravitational/teleport/blob/master/examples/k8s-auth/get-kubeconfig.sh
+$ curl -o get-kubeconfig.sh https://raw.githubusercontent.com/gravitational/teleport/master/examples/k8s-auth/get-kubeconfig.sh
 
 # Make it executable.
 $ chmod +x get-kubeconfig.sh

--- a/docs/4.4/kubernetes-ssh.md
+++ b/docs/4.4/kubernetes-ssh.md
@@ -108,7 +108,7 @@ To generate the `kubeconfig_file` for the Teleport proxy service:
 
 ```bash
 # Download the script.
-$ curl -o get-kubeconfig.sh https://github.com/gravitational/teleport/blob/master/examples/k8s-auth/get-kubeconfig.sh
+$ curl -o get-kubeconfig.sh https://raw.githubusercontent.com/gravitational/teleport/master/examples/k8s-auth/get-kubeconfig.sh
 
 # Make it executable.
 $ chmod +x get-kubeconfig.sh


### PR DESCRIPTION
The curl example to pull down the get-kubeconfig.sh was using the default url.  This would  retrieve the HTML from github not just the script.  Modified to use the raw url in 4.3 and 4.4 docs.