### PR TITLE
Backport: partial revert of negative regexps in RBAC labels

### DIFF
--- a/docs/4.4/enterprise/ssh-rbac.md
+++ b/docs/4.4/enterprise/ssh-rbac.md
@@ -123,11 +123,7 @@ spec:
       'environment': ['test', 'staging']
       # regular expressions are also supported, for example the equivalent
       # of the list example above can be expressed as:
-      'environment': '{{regexp.match("^test|staging$")}}'
-      # or using the simpler legacy syntax:
       'environment': '^test|staging$'
-      # negative regular expressions can be used to avoid strict deny rules:
-      'environment': '{{regexp.not_match("prod")}}'
 
     # defines roles that this user can can request.
     # needed for teleport's request workflow
@@ -261,11 +257,7 @@ spec:
       'environment': ['test', 'staging']
       # regular expressions are also supported, for example the equivalent
       # of the list example above can be expressed as:
-      'environment': '{{regexp.match("^test|staging$")}}'
-      # or using the simpler legacy syntax:
       'environment': '^test|staging$'
-      # negative regular expressions can be used to avoid strict deny rules:
-      'environment': '{{regexp.not_match("prod")}}'
 ```
 
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -749,64 +749,6 @@ func (s *RoleSuite) TestCheckAccess(c *C) {
 				{server: serverC2, login: "admin", hasAccess: true},
 			},
 		},
-		{
-			name: "role matches a regexp label",
-			roles: []RoleV3{
-				RoleV3{
-					Metadata: Metadata{
-						Name:      "name1",
-						Namespace: defaults.Namespace,
-					},
-					Spec: RoleSpecV3{
-						Options: RoleOptions{
-							MaxSessionTTL: Duration(20 * time.Hour),
-						},
-						Allow: RoleConditions{
-							Logins:     []string{"admin"},
-							NodeLabels: Labels{"role": []string{`{{regexp.match("worker.*")}}`}},
-							Namespaces: []string{defaults.Namespace, namespaceC},
-						},
-					},
-				},
-			},
-			checks: []check{
-				{server: serverA, login: "root", hasAccess: false},
-				{server: serverA, login: "admin", hasAccess: false},
-				{server: serverB, login: "root", hasAccess: false},
-				{server: serverB, login: "admin", hasAccess: true},
-				{server: serverC, login: "root", hasAccess: false},
-				{server: serverC, login: "admin", hasAccess: false},
-			},
-		},
-		{
-			name: "role matches a negative regexp label",
-			roles: []RoleV3{
-				RoleV3{
-					Metadata: Metadata{
-						Name:      "name1",
-						Namespace: defaults.Namespace,
-					},
-					Spec: RoleSpecV3{
-						Options: RoleOptions{
-							MaxSessionTTL: Duration(20 * time.Hour),
-						},
-						Allow: RoleConditions{
-							Logins:     []string{"admin"},
-							NodeLabels: Labels{"role": []string{`{{regexp.not_match("db.*")}}`}},
-							Namespaces: []string{defaults.Namespace, namespaceC},
-						},
-					},
-				},
-			},
-			checks: []check{
-				{server: serverA, login: "root", hasAccess: false},
-				{server: serverA, login: "admin", hasAccess: false},
-				{server: serverB, login: "root", hasAccess: false},
-				{server: serverB, login: "admin", hasAccess: true},
-				{server: serverC, login: "root", hasAccess: false},
-				{server: serverC, login: "admin", hasAccess: false},
-			},
-		},
 	}
 	for i, tc := range testCases {
 

--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO(awly): combine Expression and Matcher. It should be possible to write:
+// `{{regexp.match(email.local(external.trait_name))}}`
 package parse
 
 import (


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/4564 into 4.4

This change was not backwards compatible - variable interpolation should
work in node_labels.

This commit partially reverts
https://github.com/gravitational/teleport/pull/4253 and
https://github.com/gravitational/teleport/pull/4430