### PR TITLE
Add config option to gate pam_authenticate calls

### DIFF
--- a/docs/4.4/features/ssh-pam.md
+++ b/docs/4.4/features/ssh-pam.md
@@ -7,8 +7,8 @@ description: How to configure Teleport SSH access to play nicely with PAM (plugg
 
 Teleport's node service can be configured to integrate with [PAM](https://en.wikipedia.org/wiki/Linux_PAM). This allows Teleport to create user sessions using PAM session profiles.
 
-Teleport only supports the `account` and `session` stack. The `auth` PAM module is
-not currently supported with Teleport.
+Teleport only supports the `auth`, `account` and `session` stack. The `auth`
+stack is optional and not used by default.
 
 
 ## Introduction to Pluggable Authentication Modules
@@ -57,6 +57,9 @@ teleport:
          enabled: true
          # use /etc/pam.d/sshd configuration (the default)
          service_name: "sshd"
+         # use the "auth" modules in the PAM config
+         # "no" by default
+         use_pam_auth: true
 ```
 
 Please note that most Linux distributions come with a number of PAM services in
@@ -286,3 +289,17 @@ ssh_service:
 
 Now attempting to login as an existing user should result in the creation of the
 user and a successful login.
+
+## Additional authentication steps
+
+Using the PAM `auth` modules, it is possible to add additional authentication
+steps during user login. These can include passwords, 2nd factor or even
+biometrics.
+
+Note that Teleport enables strong SSH authentication out of the box using
+certificates. For most users, hardening [the initial Teleport
+authentication](../admin-guide#authentication) (e.g. `tsh login`) is preferred.
+
+By default, `auth` modules are not used to avoid the default system behavior
+(usually using local Unix passwords). You can enable them by setting
+`use_pam_auth` in the `pam` section of your `teleport.yaml`.

--- a/docs/4.4/features/ssh-pam.md
+++ b/docs/4.4/features/ssh-pam.md
@@ -58,7 +58,7 @@ teleport:
          # use /etc/pam.d/sshd configuration (the default)
          service_name: "sshd"
          # use the "auth" modules in the PAM config
-         # "no" by default
+         # "false" by default
          use_pam_auth: true
 ```
 
@@ -298,7 +298,7 @@ biometrics.
 
 Note that Teleport enables strong SSH authentication out of the box using
 certificates. For most users, hardening [the initial Teleport
-authentication](../admin-guide#authentication) (e.g. `tsh login`) is preferred.
+authentication](../admin-guide.md#authentication) (e.g. `tsh login`) is preferred.
 
 By default, `auth` modules are not used to avoid the default system behavior
 (usually using local Unix passwords). You can enable them by setting

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3043,18 +3043,21 @@ func (s *IntSuite) TestPAM(c *check.C) {
 	var tests = []struct {
 		inEnabled     bool
 		inServiceName string
+		inUsePAMAuth  bool
 		outContains   []string
 	}{
 		// 0 - No PAM support, session should work but no PAM related output.
 		{
 			inEnabled:     false,
 			inServiceName: "",
+			inUsePAMAuth:  true,
 			outContains:   []string{},
 		},
 		// 1 - PAM enabled, module account and session functions return success.
 		{
 			inEnabled:     true,
 			inServiceName: "teleport-success",
+			inUsePAMAuth:  true,
 			outContains: []string{
 				"pam_sm_acct_mgmt OK",
 				"pam_sm_authenticate OK",
@@ -3062,16 +3065,29 @@ func (s *IntSuite) TestPAM(c *check.C) {
 				"pam_sm_close_session OK",
 			},
 		},
-		// 2 - PAM enabled, module account functions fail.
+		// 2 - PAM enabled, module account and session functions return success.
+		{
+			inEnabled:     true,
+			inServiceName: "teleport-success",
+			inUsePAMAuth:  false,
+			outContains: []string{
+				"pam_sm_acct_mgmt OK",
+				"pam_sm_open_session OK",
+				"pam_sm_close_session OK",
+			},
+		},
+		// 3 - PAM enabled, module account functions fail.
 		{
 			inEnabled:     true,
 			inServiceName: "teleport-acct-failure",
+			inUsePAMAuth:  true,
 			outContains:   []string{},
 		},
-		// 3 - PAM enabled, module session functions fail.
+		// 4 - PAM enabled, module session functions fail.
 		{
 			inEnabled:     true,
 			inServiceName: "teleport-session-failure",
+			inUsePAMAuth:  true,
 			outContains:   []string{},
 		},
 	}
@@ -3090,6 +3106,7 @@ func (s *IntSuite) TestPAM(c *check.C) {
 			tconf.SSH.Enabled = true
 			tconf.SSH.PAM.Enabled = tt.inEnabled
 			tconf.SSH.PAM.ServiceName = tt.inServiceName
+			tconf.SSH.PAM.UsePAMAuth = tt.inUsePAMAuth
 
 			return c, nil, nil, tconf
 		}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -149,6 +149,7 @@ var (
 		"audit_sessions_uri":      false,
 		"audit_events_uri":        false,
 		"pam":                     true,
+		"use_pam_auth":            false,
 		"service_name":            false,
 		"client_idle_timeout":     false,
 		"session_control_timeout": false,
@@ -738,6 +739,10 @@ type PAM struct {
 
 	// ServiceName is the name of the PAM policy to apply.
 	ServiceName string `yaml:"service_name"`
+
+	// UsePAMAuth specifies whether to trigger the "auth" PAM modules from the
+	// policy.
+	UsePAMAuth bool `yaml:"use_pam_auth"`
 }
 
 // Parse returns a parsed pam.Config.
@@ -750,6 +755,7 @@ func (p *PAM) Parse() *pam.Config {
 	return &pam.Config{
 		Enabled:     enabled,
 		ServiceName: serviceName,
+		UsePAMAuth:  p.UsePAMAuth,
 	}
 }
 

--- a/lib/pam/config.go
+++ b/lib/pam/config.go
@@ -50,6 +50,10 @@ type Config struct {
 	// Stderr is the output stream which the conversation function will use to
 	// report errors to the user.
 	Stderr io.Writer
+
+	// UsePAMAuth specifies whether to trigger the "auth" PAM modules from the
+	// policy.
+	UsePAMAuth bool
 }
 
 // CheckDefaults makes sure the Config structure has minimum required values.

--- a/lib/pam/pam.go
+++ b/lib/pam/pam.go
@@ -350,13 +350,15 @@ func Open(config *Config) (*PAM, error) {
 		return nil, p.codeToError(retval)
 	}
 
-	// Trigger the "auth" PAM hooks for this login.
-	//
-	// These would perform any extra authentication steps configured in the PAM
-	// stack, like per-session 2FA.
-	retval = C._pam_authenticate(pamHandle, p.pamh, 0)
-	if retval != C.PAM_SUCCESS {
-		return nil, p.codeToError(retval)
+	if config.UsePAMAuth {
+		// Trigger the "auth" PAM hooks for this login.
+		//
+		// These would perform any extra authentication steps configured in the PAM
+		// stack, like per-session 2FA.
+		retval = C._pam_authenticate(pamHandle, p.pamh, 0)
+		if retval != C.PAM_SUCCESS {
+			return nil, p.codeToError(retval)
+		}
 	}
 
 	// Trigger the "session" PAM hooks for this login.

--- a/lib/pam/pam_test.go
+++ b/lib/pam/pam_test.go
@@ -191,7 +191,7 @@ func TestAuthDisabled(t *testing.T) {
 		Stderr:      &buf,
 		UsePAMAuth:  false,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer pamContext.Close()
 
 	assertOutput(t, buf.String(), []string{

--- a/lib/pam/pam_test.go
+++ b/lib/pam/pam_test.go
@@ -70,9 +70,10 @@ func TestEcho(t *testing.T) {
 			"TELEPORT_LOGIN":    username,
 			"TELEPORT_ROLES":    "bar baz qux",
 		},
-		Stdin:  &discardReader{},
-		Stdout: &buf,
-		Stderr: &buf,
+		Stdin:      &discardReader{},
+		Stdout:     &buf,
+		Stderr:     &buf,
+		UsePAMAuth: true,
 	})
 	require.NoError(t, err)
 	defer pamContext.Close()
@@ -128,6 +129,7 @@ func TestSuccess(t *testing.T) {
 		Stdin:       &discardReader{},
 		Stdout:      &buf,
 		Stderr:      &buf,
+		UsePAMAuth:  true,
 	})
 	require.NoError(t, err)
 	defer pamContext.Close()
@@ -169,8 +171,33 @@ func TestAuthFailure(t *testing.T) {
 		Stdin:       &discardReader{},
 		Stdout:      &buf,
 		Stderr:      &buf,
+		UsePAMAuth:  true,
 	})
 	require.Error(t, err)
+}
+
+func TestAuthDisabled(t *testing.T) {
+	t.Parallel()
+	checkTestModule(t, "teleport-auth-failure")
+	username := currentUser(t)
+
+	var buf bytes.Buffer
+	pamContext, err := Open(&Config{
+		Enabled:     true,
+		ServiceName: "teleport-auth-failure",
+		Login:       username,
+		Stdin:       &discardReader{},
+		Stdout:      &buf,
+		Stderr:      &buf,
+		UsePAMAuth:  false,
+	})
+	assert.NoError(t, err)
+	defer pamContext.Close()
+
+	assertOutput(t, buf.String(), []string{
+		"pam_sm_acct_mgmt OK",
+		"pam_sm_open_session OK",
+	})
 }
 
 func TestSessionFailure(t *testing.T) {

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -656,6 +656,7 @@ func (c *ServerContext) String() string {
 func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 	var pamEnabled bool
 	var pamServiceName string
+	var pamUseAuth bool
 
 	// If this code is running on a node, check if PAM is enabled or not.
 	if c.srv.Component() == teleport.ComponentNode {
@@ -665,6 +666,7 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 		}
 		pamEnabled = conf.Enabled
 		pamServiceName = conf.ServiceName
+		pamUseAuth = conf.UsePAMAuth
 	}
 
 	// If the identity has roles, extract the role names.
@@ -701,6 +703,7 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 		Environment:           buildEnvironment(c),
 		PAM:                   pamEnabled,
 		ServiceName:           pamServiceName,
+		UsePAMAuth:            pamUseAuth,
 		IsTestStub:            c.IsTestStub,
 	}, nil
 }

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -80,6 +80,10 @@ type ExecCommand struct {
 	// ServiceName is the name of the PAM service requested if PAM is enabled.
 	ServiceName string `json:"service_name"`
 
+	// UsePAMAuth specifies whether to trigger the "auth" PAM modules from the
+	// policy.
+	UsePAMAuth bool `json:"use_pam_auth"`
+
 	// Environment is a list of environment variables to add to the defaults.
 	Environment []string `json:"environment"`
 
@@ -160,6 +164,7 @@ func RunCommand() (io.Writer, int, error) {
 		// Open the PAM context.
 		pamContext, err := pam.Open(&pam.Config{
 			ServiceName: c.ServiceName,
+			UsePAMAuth:  c.UsePAMAuth,
 			Login:       c.Login,
 			// Set Teleport specific environment variables that PAM modules
 			// like pam_script.so can pick up to potentially customize the


### PR DESCRIPTION
Most users won't need this, so the behavior is optional. Default system
configs will usually trigger a password prompt, which is why this
feature is disabled by default.

Updates https://github.com/gravitational/teleport/issues/4551