### PR TITLE
Add --format=json playback option

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -306,6 +306,9 @@ const (
 	// Text means text serialization format
 	Text = "text"
 
+	// PTY is a raw pty session capture format
+	PTY = "pty"
+
 	// Names is for formatting node names in plain text
 	Names = "names"
 

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -21,9 +21,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -128,4 +132,61 @@ func TestWriterEmitter(t *testing.T) {
 	for i := 0; scanner.Scan(); i++ {
 		require.Contains(t, scanner.Text(), events[i].GetCode())
 	}
+}
+
+// TestExport tests export to JSON format.
+func TestExport(t *testing.T) {
+	sid := session.NewID()
+	events := GenerateTestSession(SessionParams{PrintEvents: 1, SessionID: sid.String()})
+	uploader := NewMemoryUploader()
+	streamer, err := NewProtoStreamer(ProtoStreamerConfig{
+		Uploader: uploader,
+	})
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+	stream, err := streamer.CreateAuditStream(ctx, sid)
+	require.NoError(t, err)
+
+	for _, event := range events {
+		err := stream.EmitAuditEvent(ctx, event)
+		require.NoError(t, err)
+	}
+	err = stream.Complete(ctx)
+	require.NoError(t, err)
+
+	uploads, err := uploader.ListUploads(ctx)
+	require.NoError(t, err)
+	parts, err := uploader.GetParts(uploads[0].ID)
+	require.NoError(t, err)
+
+	f, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	var readers []io.Reader
+	for _, part := range parts {
+		readers = append(readers, bytes.NewReader(part))
+		_, err := f.Write(part)
+		require.NoError(t, err)
+	}
+	reader := NewProtoReader(io.MultiReader(readers...))
+	outEvents, err := reader.ReadAll(ctx)
+	require.NoError(t, err)
+
+	_, err = f.Seek(0, 0)
+	require.NoError(t, err)
+
+	buf := &bytes.Buffer{}
+	err = Export(ctx, f, buf, teleport.JSON)
+	require.NoError(t, err)
+
+	count := 0
+	snl := bufio.NewScanner(buf)
+	for snl.Scan() {
+		require.Contains(t, snl.Text(), outEvents[count].GetCode())
+		count++
+	}
+	require.NoError(t, snl.Err())
+	require.Equal(t, len(outEvents), count)
 }

--- a/lib/events/playback.go
+++ b/lib/events/playback.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -68,6 +69,57 @@ func DetectFormat(r io.ReadSeeker) (*Header, error) {
 		return nil, trace.ConvertSystemError(err)
 	}
 	return &Header{Tar: true}, nil
+}
+
+// Export exports session file events to json, text or yaml
+func Export(ctx context.Context, rs io.ReadSeeker, w io.Writer, exportFormat string) error {
+	switch exportFormat {
+	case teleport.Text:
+	case teleport.JSON:
+	default:
+		return trace.BadParameter("unsupported format %q, %q is the only supported format", exportFormat, teleport.JSON)
+	}
+
+	format, err := DetectFormat(rs)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = rs.Seek(0, 0)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	switch {
+	case format.Proto == true:
+		protoReader := NewProtoReader(rs)
+		for {
+			event, err := protoReader.Read(ctx)
+			if err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return trace.Wrap(err)
+			}
+			switch exportFormat {
+			case teleport.JSON:
+				data, err := utils.FastMarshal(event)
+				if err != nil {
+					return trace.ConvertSystemError(err)
+				}
+				_, err = fmt.Fprintln(w, string(data))
+				if err != nil {
+					return trace.ConvertSystemError(err)
+				}
+			default:
+				return trace.BadParameter("unsupported format %q, %q is the only supported format", exportFormat, teleport.JSON)
+			}
+		}
+
+	case format.Tar == true:
+		return trace.BadParameter(
+			"to review the events in format of teleport before version 4.4, extract the tarball and look inside")
+	default:
+		return trace.BadParameter("usupported format %v", format)
+	}
 }
 
 // WriteForPlayback reads events from audit reader

--- a/lib/events/playback.go
+++ b/lib/events/playback.go
@@ -71,10 +71,9 @@ func DetectFormat(r io.ReadSeeker) (*Header, error) {
 	return &Header{Tar: true}, nil
 }
 
-// Export exports session file events to json, text or yaml
+// Export converts session files from binary/protobuf to text/JSON.
 func Export(ctx context.Context, rs io.ReadSeeker, w io.Writer, exportFormat string) error {
 	switch exportFormat {
-	case teleport.Text:
 	case teleport.JSON:
 	default:
 		return trace.BadParameter("unsupported format %q, %q is the only supported format", exportFormat, teleport.JSON)
@@ -113,12 +112,11 @@ func Export(ctx context.Context, rs io.ReadSeeker, w io.Writer, exportFormat str
 				return trace.BadParameter("unsupported format %q, %q is the only supported format", exportFormat, teleport.JSON)
 			}
 		}
-
 	case format.Tar == true:
 		return trace.BadParameter(
 			"to review the events in format of teleport before version 4.4, extract the tarball and look inside")
 	default:
-		return trace.BadParameter("usupported format %v", format)
+		return trace.BadParameter("unsupported format %v", format)
 	}
 }
 


### PR DESCRIPTION
@fspmarshall @russjones I was debugging new format playback files, and built this function:

This commit fixes #4577, updates #1580

```bash
$ tsh play --format=json ~/play/0c0b81ed-91a9-4a2a-8d7c-7495891a6ca0.tar | jq '.event
"print"
"print"
"session.disk"
```

In the future I will add `tsh play ~/....` to complete #1580, but for now we have a useful tool to introspect sessions.