### PR TITLE
Backoff on network errors and mark corrupted records.

### DIFF
--- a/lib/events/convert.go
+++ b/lib/events/convert.go
@@ -444,6 +444,9 @@ func FromOneOf(in OneOf) (AuditEvent, error) {
 	} else if e := in.GetSAMLConnectorDelete(); e != nil {
 		return e, nil
 	} else {
+		if in.Event == nil {
+			return nil, trace.BadParameter("failed to parse event, session record is corrupted")
+		}
 		return nil, trace.BadParameter("received unsupported event %T", in.Event)
 	}
 }

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -177,7 +177,8 @@ func TestChaosUpload(t *testing.T) {
 				scansCh <- trace.Wrap(err)
 				return
 			}
-			scansCh <- trace.Wrap(uploader.Scan())
+			_, err := uploader.Scan()
+			scansCh <- trace.Wrap(err)
 		}()
 	}
 
@@ -205,7 +206,7 @@ func TestChaosUpload(t *testing.T) {
 
 	for i := 0; i < parallelStreams; i++ {
 		// do scans to catch remaining uploads
-		err = uploader.Scan()
+		_, err = uploader.Scan()
 		assert.NoError(t, err)
 
 		// wait for the upload events

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -314,4 +314,6 @@ const (
 	tarExt = ".tar"
 	// checkpointExt is a suffix for checkpoint extensions
 	checkpointExt = ".checkpoint"
+	// errorExt is a suffix for files storing session errors
+	errorExt = ".error"
 )

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -59,6 +59,8 @@ type UploadEvent struct {
 	UploadID string
 	// Error is set in case if event resulted in error
 	Error error
+	// Created is a time of when the event has been created
+	Created time.Time
 }
 
 // UploaderConfig sets up configuration for uploader service


### PR DESCRIPTION
Uploader retries slower on network errors and picks the pace
after any upload has succeeded.

Records that were corrupted, will never get uploaded.

The uploader will create streams indefinitely, clogging the auth server
with streams. Now uploader writes marker for bad session uploads
and does not attempt to reupload.
