### PR TITLE
Fix syntax and indentation in PAM docs

### DIFF
--- a/docs/4.2/features/ssh-pam.md
+++ b/docs/4.2/features/ssh-pam.md
@@ -45,13 +45,12 @@ Teleport currently supports account management and session management.
 To enable PAM on a given Linux machine, update `/etc/teleport.yaml` with:
 
 ```yaml
-teleport:
-   ssh_service:
-      pam:
-         # "no" by default
-         enabled: true
-         # use /etc/pam.d/sshd configuration (the default)
-         service_name: "sshd"
+ssh_service:
+  pam:
+    # "no" by default
+    enabled: true
+    # use /etc/pam.d/sshd configuration (the default)
+    service_name: "sshd"
 ```
 
 Please note that most Linux distributions come with a number of PAM services in
@@ -275,9 +274,9 @@ setting the service_name.
 
 ```yaml
 ssh_service:
-   pam:
-     enabled: true
-     service_name: "teleport"
+  pam:
+    enabled: true
+    service_name: "teleport"
 ```
 
 Now attempting to login as an existing user should result in the creation of the

--- a/docs/4.3/features/ssh-pam.md
+++ b/docs/4.3/features/ssh-pam.md
@@ -50,13 +50,12 @@ Teleport currently supports account management and session management.
 To enable PAM on a given Linux machine, update `/etc/teleport.yaml` with:
 
 ```yaml
-teleport:
-   ssh_service:
-      pam:
-         # "no" by default
-         enabled: true
-         # use /etc/pam.d/sshd configuration (the default)
-         service_name: "sshd"
+ssh_service:
+  pam:
+    # "no" by default
+    enabled: true
+    # use /etc/pam.d/sshd configuration (the default)
+    service_name: "sshd"
 ```
 
 Please note that most Linux distributions come with a number of PAM services in
@@ -279,9 +278,9 @@ setting the service_name.
 
 ```yaml
 ssh_service:
-   pam:
-     enabled: true
-     service_name: "teleport"
+  pam:
+    enabled: true
+    service_name: "teleport"
 ```
 
 Now attempting to login as an existing user should result in the creation of the

--- a/docs/4.4/features/ssh-pam.md
+++ b/docs/4.4/features/ssh-pam.md
@@ -50,16 +50,15 @@ Teleport currently supports account management and session management.
 To enable PAM on a given Linux machine, update `/etc/teleport.yaml` with:
 
 ```yaml
-teleport:
-   ssh_service:
-      pam:
-         # "no" by default
-         enabled: true
-         # use /etc/pam.d/sshd configuration (the default)
-         service_name: "sshd"
-         # use the "auth" modules in the PAM config
-         # "false" by default
-         use_pam_auth: true
+ssh_service:
+  pam:
+    # "no" by default
+    enabled: true
+    # use /etc/pam.d/sshd configuration (the default)
+    service_name: "sshd"
+    # use the "auth" modules in the PAM config
+    # "false" by default
+    use_pam_auth: true
 ```
 
 Please note that most Linux distributions come with a number of PAM services in
@@ -282,9 +281,9 @@ setting the service_name.
 
 ```yaml
 ssh_service:
-   pam:
-     enabled: true
-     service_name: "teleport"
+  pam:
+    enabled: true
+    service_name: "teleport"
 ```
 
 Now attempting to login as an existing user should result in the creation of the


### PR DESCRIPTION
Was looking at the PAM docs and realised that `ssh_service` is at the root of the config file rather than a sub-key of `teleport`. Also some indentation was messed up, so fixed that too.