### PR TITLE
Fixes configuration with multiple event backends

### DIFF
--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -168,7 +168,9 @@ func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard *dynam
 			if err != nil {
 				return convertError(err)
 			}
-			b.Debugf("Got %v stream shard records.", len(out.Records))
+			if len(out.Records) > 0 {
+				b.Debugf("Got %v new stream shard records.", len(out.Records))
+			}
 			if len(out.Records) == 0 {
 				if out.NextShardIterator == nil {
 					b.Debugf("Shard is closed: %v.", aws.StringValue(shard.ShardId))

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package events
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/stretchr/testify/require"
 )
@@ -105,5 +108,24 @@ func TestProtoStreamer(t *testing.T) {
 
 			require.Equal(t, events, outEvents)
 		})
+	}
+}
+
+func TestWriterEmitter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	events := GenerateTestSession(SessionParams{PrintEvents: 0})
+	buf := &bytes.Buffer{}
+	emitter := NewWriterEmitter(utils.NopWriteCloser(buf))
+
+	for _, event := range events {
+		err := emitter.EmitAuditEvent(ctx, event)
+		require.NoError(t, err)
+	}
+
+	scanner := bufio.NewScanner(buf)
+	for i := 0; scanner.Scan(); i++ {
+		require.Contains(t, scanner.Text(), events[i].GetCode())
 	}
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -902,7 +902,7 @@ func initExternalLog(auditConfig services.AuditConfig) (events.IAuditLog, error)
 			}
 			loggers = append(loggers, logger)
 		case teleport.SchemeStdout:
-			logger := events.NewWriterLog(utils.NopWriteCloser(os.Stdout))
+			logger := events.NewWriterEmitter(utils.NopWriteCloser(os.Stdout))
 			loggers = append(loggers, logger)
 		default:
 			return nil, trace.BadParameter(
@@ -922,7 +922,7 @@ func initExternalLog(auditConfig services.AuditConfig) (events.IAuditLog, error)
 	}
 
 	if len(loggers) > 1 {
-		return events.NewMultiLog(loggers...), nil
+		return events.NewMultiLog(loggers...)
 	}
 
 	return loggers[0], nil


### PR DESCRIPTION
This commit fixes #4598

Config with multiple event backends was crashing on 4.4:

```yaml
  storage:
    audit_events_uri: ['dynamodb://streaming', 'stdout://', 'dynamodb://streaming2']
```