### PR TITLE
Add kube_listen_addr to proxy_service

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -166,6 +166,7 @@ var (
 		"cgroup_path":             false,
 		"kubernetes_service":      true,
 		"kube_cluster_name":       false,
+		"kube_listen_addr":        false,
 	}
 )
 
@@ -811,6 +812,9 @@ type Proxy struct {
 	ProxyProtocol string `yaml:"proxy_protocol,omitempty"`
 	// KubeProxy configures kubernetes protocol support of the proxy
 	Kube KubeProxy `yaml:"kubernetes,omitempty"`
+	// KubeAddr is a shorthand for enabling the Kubernetes endpoint without a
+	// local Kubernetes cluster.
+	KubeAddr string `yaml:"kube_listen_addr,omitempty"`
 
 	// PublicAddr sets the hostport the proxy advertises for the HTTP endpoint.
 	// The hosts in PublicAddr are included in the list of host principals

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -350,6 +350,8 @@ type ProxyConfig struct {
 	Kube KubeProxyConfig
 }
 
+// KubeAddr returns the address for the Kubernetes endpoint on this proxy that
+// can be reached by clients.
 func (c ProxyConfig) KubeAddr() (string, error) {
 	if !c.Kube.Enabled {
 		return "", trace.NotFound("kubernetes support not enabled on this proxy")
@@ -377,15 +379,9 @@ type KubeProxyConfig struct {
 	// ListenAddr is the address to listen on for incoming kubernetes requests.
 	ListenAddr utils.NetAddr
 
-	// KubeAPIAddr is address of kubernetes API server
-	APIAddr utils.NetAddr
-
 	// ClusterOverride causes all traffic to go to a specific remote
 	// cluster, used only in tests
 	ClusterOverride string
-
-	// CACert is a PEM encoded kubernetes CA certificate
-	CACert []byte
 
 	// PublicAddrs is a list of the public addresses the Teleport Kube proxy can be accessed by,
 	// it also affects the host principals and routing logic


### PR DESCRIPTION
This is a shorthand for the larger kubernetes section:
```
proxy_service:
  kube_listen_addr: "0.0.0.0:3026"
```
if equivalent to:
```
proxy_service:
  kubernetes:
    enabled: yes
    listen_addr: "0.0.0.0:3026"
```

This shorthand is meant to be used with the new `kubernetes_service`:
https://github.com/gravitational/teleport/pull/4455
It reduces confusion when both `proxy_service` and `kubernetes_service`
are configured in the same process.

Updates https://github.com/gravitational/teleport/issues/3952