### PR TITLE
Get additional roles from approved access request when extending web session

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -771,7 +771,8 @@ func (s *APIServer) u2fSignRequest(auth ClientI, w http.ResponseWriter, r *http.
 }
 
 type createWebSessionReq struct {
-	PrevSessionID string `json:"prev_session_id"`
+	PrevSessionID   string `json:"prev_session_id"`
+	AccessRequestID string `json:"access_request_id"`
 }
 
 func (s *APIServer) createWebSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
@@ -781,7 +782,7 @@ func (s *APIServer) createWebSession(auth ClientI, w http.ResponseWriter, r *htt
 	}
 	user := p.ByName("user")
 	if req.PrevSessionID != "" {
-		sess, err := auth.ExtendWebSession(user, req.PrevSessionID)
+		sess, err := auth.ExtendWebSession(user, req.PrevSessionID, req.AccessRequestID)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -901,7 +901,7 @@ func (a *Server) getRolesAndExpiryFromAccessRequest(user, accessRequestID string
 		return nil, time.Time{}, trace.BadParameter("access request %q is awaiting approval", accessRequestID)
 	}
 
-	if err := services.ValidateAccessRequest(a, req, false); err != nil {
+	if err := services.ValidateAccessRequest(a, req); err != nil {
 		return nil, time.Time{}, trace.Wrap(err)
 	}
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -827,7 +827,7 @@ func (a *Server) CheckU2FSignResponse(user string, response *u2f.SignResponse) e
 }
 
 // ExtendWebSession creates a new web session for a user based on a valid previous sessionID.
-// Additional roles are appended to intial roles if there is an approved access request.
+// Additional roles are appended to initial roles if there is an approved access request.
 func (a *Server) ExtendWebSession(user, prevSessionID, accessRequestID string, identity tlsca.Identity) (services.WebSession, error) {
 	prevSession, err := a.GetWebSession(user, prevSessionID)
 	if err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -814,11 +814,11 @@ func (a *ServerWithRoles) CreateWebSession(user string) (services.WebSession, er
 	return a.authServer.CreateWebSession(user)
 }
 
-func (a *ServerWithRoles) ExtendWebSession(user, prevSessionID string) (services.WebSession, error) {
+func (a *ServerWithRoles) ExtendWebSession(user, prevSessionID, accessRequestID string) (services.WebSession, error) {
 	if err := a.currentUserAction(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.ExtendWebSession(user, prevSessionID, a.context.Identity.GetIdentity())
+	return a.authServer.ExtendWebSession(user, prevSessionID, accessRequestID, a.context.Identity.GetIdentity())
 }
 
 func (a *ServerWithRoles) GetWebSessionInfo(user string, sid string) (services.WebSession, error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1433,11 +1433,12 @@ func (c *Client) GetU2FSignRequest(user string, password []byte) (*u2f.SignReque
 
 // ExtendWebSession creates a new web session for a user based on another
 // valid web session
-func (c *Client) ExtendWebSession(user string, prevSessionID string) (services.WebSession, error) {
+func (c *Client) ExtendWebSession(user string, prevSessionID string, accessRequestID string) (services.WebSession, error) {
 	out, err := c.PostJSON(
 		c.Endpoint("users", user, "web", "sessions"),
 		createWebSessionReq{
-			PrevSessionID: prevSessionID,
+			PrevSessionID:   prevSessionID,
+			AccessRequestID: accessRequestID,
 		},
 	)
 	if err != nil {
@@ -3188,7 +3189,7 @@ type WebService interface {
 	GetWebSessionInfo(user string, sid string) (services.WebSession, error)
 	// ExtendWebSession creates a new web session for a user based on another
 	// valid web session
-	ExtendWebSession(user string, prevSessionID string) (services.WebSession, error)
+	ExtendWebSession(user string, prevSessionID string, accessRequestID string) (services.WebSession, error)
 	// CreateWebSession creates a new web session for a user
 	CreateWebSession(user string) (services.WebSession, error)
 	// DeleteWebSession deletes a web session for this user by id

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1419,18 +1419,15 @@ func (s *TLSSuite) TestOTPCRUD(c *check.C) {
 // TestWebSessions tests web sessions flow for web user,
 // that logs in, extends web session and tries to perform administratvie action
 // but fails
-func (s *TLSSuite) TestWebSessions(c *check.C) {
+func (s *TLSSuite) TestWebSessionWithoutAccessRequest(c *check.C) {
 	clt, err := s.server.NewClient(TestAdmin())
 	c.Assert(err, check.IsNil)
 
 	user := "user1"
 	pass := []byte("abc123")
 
-	newUser, err := CreateUserRoleAndRequestable(clt, user, "test-request-role")
+	_, _, err = CreateUserAndRole(clt, user, []string{user})
 	c.Assert(err, check.IsNil)
-	c.Assert(newUser.GetRoles(), check.HasLen, 1)
-
-	initialRole := newUser.GetRoles()[0]
 
 	proxy, err := s.server.NewClient(TestBuiltin(teleport.RoleProxy))
 	c.Assert(err, check.IsNil)
@@ -1459,54 +1456,9 @@ func (s *TLSSuite) TestWebSessions(c *check.C) {
 	_, err = web.GetWebSessionInfo(user, ws.GetName())
 	c.Assert(err, check.IsNil)
 
-	// Test without access request.
-	// Cert contains initial role.
 	new, err := web.ExtendWebSession(user, ws.GetName(), "")
 	c.Assert(err, check.IsNil)
 	c.Assert(new, check.NotNil)
-
-	pub, _, _, _, err := ssh.ParseAuthorizedKey(new.GetPub())
-	c.Assert(err, check.IsNil)
-
-	sshcert, ok := pub.(*ssh.Certificate)
-	c.Assert(ok, check.Equals, true)
-
-	roles, _, err := services.ExtractFromCertificate(clt, sshcert)
-	c.Assert(err, check.IsNil)
-	c.Assert(roles, check.DeepEquals, []string{initialRole})
-
-	// Test with approved access request.
-	// Cert should contain the initial role and the role assigned with access request.
-	accessReq, err := services.NewAccessRequest(user, []string{"test-request-role"}...)
-	c.Assert(err, check.IsNil)
-	accessReq.SetState(services.RequestState_APPROVED)
-
-	err = clt.CreateAccessRequest(context.Background(), accessReq)
-	c.Assert(err, check.IsNil)
-
-	sess, err := web.ExtendWebSession(user, ws.GetName(), accessReq.GetMetadata().Name)
-	c.Assert(err, check.IsNil)
-
-	pub, _, _, _, err = ssh.ParseAuthorizedKey(sess.GetPub())
-	c.Assert(err, check.IsNil)
-
-	sshcert, ok = pub.(*ssh.Certificate)
-	c.Assert(ok, check.Equals, true)
-
-	roles, _, err = services.ExtractFromCertificate(clt, sshcert)
-	c.Assert(err, check.IsNil)
-	c.Assert(roles, check.HasLen, 2)
-
-	mappedRole := map[string]string{
-		roles[0]: "",
-		roles[1]: "",
-	}
-
-	_, hasRole := mappedRole[initialRole]
-	c.Assert(hasRole, check.Equals, true)
-
-	_, hasRole = mappedRole["test-request-role"]
-	c.Assert(hasRole, check.Equals, true)
 
 	// Requesting forbidden action for user fails
 	err = web.DeleteUser(context.TODO(), user)
@@ -1520,6 +1472,75 @@ func (s *TLSSuite) TestWebSessions(c *check.C) {
 
 	_, err = web.ExtendWebSession(user, ws.GetName(), "")
 	c.Assert(err, check.NotNil)
+}
+
+func (s *TLSSuite) TestWebSessionWithApprovedAccessRequest(c *check.C) {
+	clt, err := s.server.NewClient(TestAdmin())
+	c.Assert(err, check.IsNil)
+
+	user := "user2"
+	pass := []byte("abc123")
+
+	newUser, err := CreateUserRoleAndRequestable(clt, user, "test-request-role")
+	c.Assert(err, check.IsNil)
+	c.Assert(newUser.GetRoles(), check.HasLen, 1)
+
+	initialRole := newUser.GetRoles()[0]
+	c.Assert(newUser.GetRoles(), check.DeepEquals, []string{"user:user2"})
+
+	proxy, err := s.server.NewClient(TestBuiltin(teleport.RoleProxy))
+	c.Assert(err, check.IsNil)
+
+	// Create a user to create a web session for.
+	req := AuthenticateUserRequest{
+		Username: user,
+		Pass: &PassCreds{
+			Password: pass,
+		},
+	}
+
+	err = clt.UpsertPassword(user, pass)
+	c.Assert(err, check.IsNil)
+
+	ws, err := proxy.AuthenticateWebUser(req)
+	c.Assert(err, check.IsNil)
+
+	web, err := s.server.NewClientFromWebSession(ws)
+	c.Assert(err, check.IsNil)
+
+	// Create a approved access request.
+	accessReq, err := services.NewAccessRequest(user, []string{"test-request-role"}...)
+	c.Assert(err, check.IsNil)
+
+	accessReq.SetState(services.RequestState_APPROVED)
+
+	err = clt.CreateAccessRequest(context.Background(), accessReq)
+	c.Assert(err, check.IsNil)
+
+	sess, err := web.ExtendWebSession(user, ws.GetName(), accessReq.GetMetadata().Name)
+	c.Assert(err, check.IsNil)
+
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(sess.GetPub())
+	c.Assert(err, check.IsNil)
+
+	sshcert, ok := pub.(*ssh.Certificate)
+	c.Assert(ok, check.Equals, true)
+
+	// Roles extracted from cert should contain the initial role and the role assigned with access request.
+	roles, _, err := services.ExtractFromCertificate(clt, sshcert)
+	c.Assert(err, check.IsNil)
+	c.Assert(roles, check.HasLen, 2)
+
+	mappedRole := map[string]string{
+		roles[0]: "",
+		roles[1]: "",
+	}
+
+	_, hasRole := mappedRole[initialRole]
+	c.Assert(hasRole, check.Equals, true)
+
+	_, hasRole = mappedRole["test-request-role"]
+	c.Assert(hasRole, check.Equals, true)
 }
 
 // TestGetCertAuthority tests certificate authority permissions

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -224,6 +224,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	h.POST("/webapi/sessions/app", h.WithAuth(h.createAppSession))
 	h.DELETE("/webapi/sessions", h.WithAuth(h.deleteSession))
 	h.POST("/webapi/sessions/renew", h.WithAuth(h.renewSession))
+	h.POST("/webapi/sessions/renew/:requestId", h.WithAuth(h.renewSession))
 
 	h.GET("/webapi/users/password/token/:token", httplib.MakeHandler(h.getResetPasswordTokenHandle))
 	h.PUT("/webapi/users/password/token", httplib.WithCSRFProtection(h.changePasswordWithToken))
@@ -1259,19 +1260,16 @@ func (h *Handler) logout(w http.ResponseWriter, ctx *SessionContext) error {
 	return nil
 }
 
-// renewSession is called to renew the session that is about to expire
-// it issues the new session and generates new session cookie.
-// It's important to understand that the old session becomes effectively invalid.
+// renewSession is called in two ways:
+// 	- Without requestId: Creates new session that is about to expire.
+// 	- With requestId: Creates new session that includes additional roles assigned with approving access request.
 //
-// POST /v1/webapi/sessions/renew
-//
-// Response
-//
-// {"type": "bearer", "token": "bearer token", "user": {"name": "alex", "allowed_logins": ["admin", "bob"]}, "expires_in": 20}
-//
-//
-func (h *Handler) renewSession(w http.ResponseWriter, r *http.Request, _ httprouter.Params, ctx *SessionContext) (interface{}, error) {
-	newSess, err := ctx.ExtendWebSession()
+// 	It issues the new session and generates new session cookie.
+// 	It's important to understand that the old session becomes effectively invalid.
+func (h *Handler) renewSession(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	requestID := params.ByName("requestId")
+
+	newSess, err := ctx.ExtendWebSession(requestID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -242,8 +242,8 @@ func (c *SessionContext) GetWebSession() services.WebSession {
 
 // ExtendWebSession creates a new web session for this user
 // based on the previous session
-func (c *SessionContext) ExtendWebSession() (services.WebSession, error) {
-	sess, err := c.clt.ExtendWebSession(c.user, c.sess.GetName())
+func (c *SessionContext) ExtendWebSession(accessRequestID string) (services.WebSession, error) {
+	sess, err := c.clt.ExtendWebSession(c.user, c.sess.GetName(), accessRequestID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -33,7 +33,7 @@ type access struct {
 type accessStrategy struct {
 	// Type determines how a user should access teleport resources.
 	// ie: does the user require a request to access resources?
-	Type string `json:"type"`
+	Type services.RequestStrategy `json:"type"`
 	// Prompt is the optional dialogue shown to user,
 	// when a access strategy type requires a reason.
 	Prompt string `json:"prompt"`

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -56,6 +56,8 @@ type userACL struct {
 	Tokens access `json:"tokens"`
 	// Nodes defines access to nodes.
 	Nodes access `json:"nodes"`
+	// AppServers defines access to application servers.
+	AppServers access `json:"appServers"`
 	// SSH defines access to servers
 	SSHLogins []string `json:"sshLogins"`
 }

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -35,7 +35,7 @@ type accessStrategy struct {
 	// ie: does the user require a request to access resources?
 	Type services.RequestStrategy `json:"type"`
 	// Prompt is the optional dialogue shown to user,
-	// when a access strategy type requires a reason.
+	// when the access strategy type requires a reason.
 	Prompt string `json:"prompt"`
 }
 
@@ -56,8 +56,6 @@ type userACL struct {
 	Tokens access `json:"tokens"`
 	// Nodes defines access to nodes.
 	Nodes access `json:"nodes"`
-	// AccessStrategy describes how a user should access teleport resources.
-	AccessStrategy accessStrategy `json:"accessStrategy"`
 	// SSH defines access to servers
 	SSHLogins []string `json:"sshLogins"`
 }
@@ -69,15 +67,18 @@ const (
 	authSSO   authType = "sso"
 )
 
+// UserContext describes a users settings to various resources.
 type UserContext struct {
-	// AuthType is auth method of this user
+	// AuthType is auth method of this user.
 	AuthType authType `json:"authType"`
-	// Name is this user name
+	// Name is this user name.
 	Name string `json:"userName"`
-	// ACL contains user access control list
+	// ACL contains user access control list.
 	ACL userACL `json:"userAcl"`
-	// Cluster contains cluster detail for this user's context
+	// Cluster contains cluster detail for this user's context.
 	Cluster *Cluster `json:"cluster"`
+	// AccessStrategy describes how a user should access teleport resources.
+	AccessStrategy accessStrategy `json:"accessStrategy"`
 }
 
 func getLogins(roleSet services.RoleSet) []string {
@@ -174,7 +175,6 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*UserContex
 		Users:           userAccess,
 		Tokens:          tokenAccess,
 		Nodes:           nodeAccess,
-		AccessStrategy:  requestAccess,
 	}
 
 	// local user
@@ -191,8 +191,9 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*UserContex
 	}
 
 	return &UserContext{
-		Name:     user.GetName(),
-		ACL:      acl,
-		AuthType: authType,
+		Name:           user.GetName(),
+		ACL:            acl,
+		AuthType:       authType,
+		AccessStrategy: requestAccess,
 	}, nil
 }

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -64,6 +64,7 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.Name, check.Equals, "root")
 	c.Assert(userContext.ACL.AuthConnectors, check.DeepEquals, allowed)
 	c.Assert(userContext.ACL.TrustedClusters, check.DeepEquals, allowed)
+	c.Assert(userContext.ACL.AppServers, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Events, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Sessions, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Roles, check.DeepEquals, denied)

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -70,9 +70,11 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Users, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Tokens, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Nodes, check.DeepEquals, denied)
-	c.Assert(userContext.ACL.AccessStrategy.Type, check.Equals, services.RequestStrategyOptional)
-	c.Assert(userContext.ACL.AccessStrategy.Prompt, check.Equals, "")
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
+	c.Assert(userContext.ACL.AccessStrategy, check.DeepEquals, accessStrategy{
+		Type:   services.RequestStrategyOptional,
+		Prompt: "",
+	})
 
 	// test local auth type
 	c.Assert(userContext.AuthType, check.Equals, authLocal)

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -71,7 +71,7 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Tokens, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Nodes, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
-	c.Assert(userContext.ACL.AccessStrategy, check.DeepEquals, accessStrategy{
+	c.Assert(userContext.AccessStrategy, check.DeepEquals, accessStrategy{
 		Type:   services.RequestStrategyOptional,
 		Prompt: "",
 	})

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -70,8 +70,8 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Users, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Tokens, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Nodes, check.DeepEquals, denied)
-	c.Assert(userContext.ACL.Request.RequestStrategy, check.Equals, services.RequestStrategyOptional)
-	c.Assert(userContext.ACL.Request.RequestPrompt, check.Equals, "")
+	c.Assert(userContext.ACL.AccessStrategy.Type, check.Equals, services.RequestStrategyOptional)
+	c.Assert(userContext.ACL.AccessStrategy.Prompt, check.Equals, "")
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
 
 	// test local auth type

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -70,6 +70,8 @@ func (s *UserContextSuite) TestNewUserContext(c *check.C) {
 	c.Assert(userContext.ACL.Users, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Tokens, check.DeepEquals, denied)
 	c.Assert(userContext.ACL.Nodes, check.DeepEquals, denied)
+	c.Assert(userContext.ACL.Request.RequestStrategy, check.Equals, services.RequestStrategyOptional)
+	c.Assert(userContext.ACL.Request.RequestPrompt, check.Equals, "")
 	c.Assert(userContext.ACL.SSHLogins, check.DeepEquals, []string{"a", "b", "d"})
 
 	// test local auth type


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/4384

#### Description
- Add Request field to userACL to determine if user needs to request access and if need to provide reason for access
- Modify `rewnewSession` web handler to be able to pass in access request ID
- Modify `extendWebSession` to accept access request ID. This allows looking up the access request object based on ID and user, so that we can retrieve the additional roles assigned by approver
- Tested
