### PR TITLE
Typos in User Manual regarding description for Linux download link and support for single SSH jumphost.

### DIFF
--- a/docs/4.3/user-manual.md
+++ b/docs/4.3/user-manual.md
@@ -352,9 +352,6 @@ $ tsh ssh -J proxy.example.com telenode
 
 Known limits:
 
-* Only one jump host is supported (`-J` supports chaining that Teleport does not utilise)
-and tsh will return with error in case of two jumphosts: `-J` proxy-1.example.com,proxy-2.example.com
-will not work.
 * Only one jump host is supported (`-J` supports chaining that Teleport does not utilise) and `tsh` will return with error in the case of two jumphosts, i.e. `-J proxy-1.example.com,proxy-2.example.com` will not work.
 * When `tsh ssh -J user@proxy` is used, it overrides the SSH proxy defined in the tsh profile and port forwarding is used instead of the existing Teleport proxy subsystem.
 

--- a/docs/4.3/user-manual.md
+++ b/docs/4.3/user-manual.md
@@ -58,7 +58,7 @@ to call [`tsh login`](cli-docs.md#tsh-login) in the beginning.
 - Windows Users: [Download tsh Binary](https://gravitational.com/teleport/download?os=windows)
 - Mac Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=macos)
 - Mac Users with [Brew](https://brew.sh/): `brew install teleport`
-- Linux Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
+- Linux Users: [Download Linux Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
 
 ## User Identities
 

--- a/docs/4.4/user-manual.md
+++ b/docs/4.4/user-manual.md
@@ -352,9 +352,6 @@ $ tsh ssh -J proxy.example.com telenode
 
 Known limits:
 
-* Only one jump host is supported (`-J` supports chaining that Teleport does not utilise)
-and tsh will return with error in case of two jumphosts: `-J` proxy-1.example.com,proxy-2.example.com
-will not work.
 * Only one jump host is supported (`-J` supports chaining that Teleport does not utilise) and `tsh` will return with error in the case of two jumphosts, i.e. `-J proxy-1.example.com,proxy-2.example.com` will not work.
 * When `tsh ssh -J user@proxy` is used, it overrides the SSH proxy defined in the tsh profile and port forwarding is used instead of the existing Teleport proxy subsystem.
 

--- a/docs/4.4/user-manual.md
+++ b/docs/4.4/user-manual.md
@@ -58,7 +58,7 @@ to call [`tsh login`](cli-docs.md#tsh-login) in the beginning.
 - Windows Users: [Download tsh Binary](https://gravitational.com/teleport/download?os=windows)
 - Mac Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=macos)
 - Mac Users with [Brew](https://brew.sh/): `brew install teleport`
-- Linux Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
+- Linux Users: [Download Linux Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
 
 ## User Identities
 


### PR DESCRIPTION
From the User Manual, under "Installing tsh":

Linux Users: Download Mac Teleport Binary. Includes tsh

Should be:

Linux Users: Download Linux Teleport Binary. Includes tsh
