### PR TITLE
lib/web: add package-level logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ terraform.tfstate
 # ansible stuff
 ssh.config
 *.retry
+
+# vim-specific files
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ darwin
 
 # editors
 .vscode
+*.swp
 
 # Compiled binaries, Object files, Static and Dynamic libs (Shared Objects)
 out
@@ -56,6 +57,3 @@ terraform.tfstate
 # ansible stuff
 ssh.config
 *.retry
-
-# vim-specific files
-*.swp

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -186,7 +186,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 
 	_, sshPort, err := net.SplitHostPort(cfg.ProxySSHAddr.String())
 	if err != nil {
-		log.WithError(err).Warn("Invalid SSH proxy address, will use default port %v.", defaults.SSHProxyListenPort)
+		log.WithError(err).Warnf("Invalid SSH proxy address, will use default port %v.", defaults.SSHProxyListenPort)
 		sshPort = strconv.Itoa(defaults.SSHProxyListenPort)
 	}
 	h.sshPort = sshPort

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -186,7 +186,8 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 
 	_, sshPort, err := net.SplitHostPort(cfg.ProxySSHAddr.String())
 	if err != nil {
-		log.WithError(err).Warnf("Invalid SSH proxy address, will use default port %v.", defaults.SSHProxyListenPort)
+		log.WithError(err).Warnf("Invalid SSH proxy address %q, will use default port %v.",
+			cfg.ProxySSHAddr.String(), defaults.SSHProxyListenPort)
 		sshPort = strconv.Itoa(defaults.SSHProxyListenPort)
 	}
 	h.sshPort = sshPort

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -282,6 +282,9 @@ func (s *WebSuite) SetUpTest(c *C) {
 	addr := utils.MustParseAddr(s.webServer.Listener.Addr().String())
 	handler.handler.cfg.ProxyWebAddr = *addr
 	handler.handler.cfg.ProxySSHAddr = *proxyAddr
+	_, sshPort, err := net.SplitHostPort(proxyAddr.String())
+	c.Assert(err, IsNil)
+	handler.handler.sshPort = sshPort
 }
 
 func (s *WebSuite) TearDownTest(c *C) {
@@ -999,6 +1002,10 @@ func (s *WebSuite) TestWebsocketPingLoop(c *C) {
 	c.Assert(err, IsNil)
 
 	ws, err := s.makeTerminal(s.authPack(c, "foo"))
+	c.Assert(err, IsNil)
+
+	// flush out raw event (pty texts)
+	err = s.waitForRawEvent(ws, 5*time.Second)
 	c.Assert(err, IsNil)
 
 	var numPings int

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -39,7 +39,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/julienschmidt/httprouter"
-	log "github.com/sirupsen/logrus"
 )
 
 // siteAppsGet returns a list of applications in a form the UI can present.
@@ -100,7 +99,7 @@ func (h *Handler) createAppSession(w http.ResponseWriter, r *http.Request, p htt
 		return nil, trace.Wrap(err, "Unable to resolve FQDN: %v", req.FQDN)
 	}
 
-	log.Debugf("Creating application web session for %v in %v.", result.PublicAddr, result.ClusterName)
+	h.log.Debugf("Creating application web session for %v in %v.", result.PublicAddr, result.ClusterName)
 
 	// Get an auth client connected with the users identity.
 	authClient, err := ctx.GetClient()

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -329,6 +329,7 @@ func newSessionCache(proxyClient auth.ClientI, servers []utils.NetAddr, cipherSu
 		authServers:  servers,
 		closer:       utils.NewCloseBroadcaster(),
 		cipherSuites: cipherSuites,
+		log:          newPackageLogger(),
 	}
 	// periodically close expired and unused sessions
 	go cache.expireSessions()
@@ -338,6 +339,7 @@ func newSessionCache(proxyClient auth.ClientI, servers []utils.NetAddr, cipherSu
 // sessionCache handles web session authentication,
 // and holds in memory contexts associated with each session
 type sessionCache struct {
+	log logrus.FieldLogger
 	sync.Mutex
 	proxyClient auth.ClientI
 	contexts    *ttlmap.TTLMap
@@ -351,7 +353,7 @@ type sessionCache struct {
 
 // Close closes all allocated resources and stops goroutines
 func (s *sessionCache) Close() error {
-	log.Info("Closing session cache.")
+	s.log.Info("Closing session cache.")
 	return s.closer.Close()
 }
 

--- a/lib/web/static.go
+++ b/lib/web/static.go
@@ -27,8 +27,6 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
@@ -78,7 +76,7 @@ func NewStaticFileSystem(debugMode bool) (http.FileSystem, error) {
 				return nil, trace.Wrap(err)
 			}
 		}
-		log.Infof("[Web] Using filesystem for serving web assets: %s", debugAssetsPath)
+		log.Infof("Using filesystem for serving web assets: %s.", debugAssetsPath)
 		return http.Dir(debugAssetsPath), nil
 	}
 
@@ -198,14 +196,14 @@ func (rsc *resource) Stat() (os.FileInfo, error) {
 }
 
 func (rsc *resource) Close() (err error) {
-	log.Debugf("[web] zip::Close(%s)", rsc.file.FileInfo().Name())
+	log.Debugf("zip::Close(%s).", rsc.file.FileInfo().Name())
 	return rsc.reader.Close()
 }
 
 type ResourceMap map[string]*zip.File
 
 func (rm ResourceMap) Open(name string) (http.File, error) {
-	log.Debugf("[web] GET zip:%s", name)
+	log.Debugf("GET zip:%s.", name)
 	f, ok := rm[strings.Trim(name, "/")]
 	if !ok {
 		return nil, trace.Wrap(os.ErrNotExist)
@@ -214,5 +212,8 @@ func (rm ResourceMap) Open(name string) (http.File, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &resource{reader, f, 0}, nil
+	return &resource{
+		reader: reader,
+		file:   f,
+	}, nil
 }

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -1,0 +1,16 @@
+package web
+
+import (
+	"github.com/gravitational/teleport"
+
+	"github.com/gravitational/trace"
+
+	"github.com/sirupsen/logrus"
+)
+
+// newPackageLogger returns a new instance of the logger
+// configured for the package
+func newPackageLogger(subcomponents ...string) logrus.FieldLogger {
+	return logrus.WithField(trace.Component,
+		teleport.Component(append([]string{teleport.ComponentWeb}, subcomponents...)...))
+}

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package web
 
 import (
@@ -7,6 +23,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 )
+
+var log = newPackageLogger()
 
 // newPackageLogger returns a new instance of the logger
 // configured for the package


### PR DESCRIPTION
Add package-level logger that removes the necessity of augmenting the log messages with an explicit `[web]` prefix.

Fixes https://github.com/gravitational/teleport/issues/4110.
Requires https://github.com/gravitational/teleport.e/pull/168.