### PR TITLE
Append newline to remote end's stderr when replying with an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ VERSION=5.0.0-dev
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
+DOCKER_CACHE_OPTS ?= --no-cache
 
 # These are standard autotools variables, don't change them please
 BUILDDIR ?= build
@@ -362,17 +363,17 @@ remove-temp-files:
 	find . -name flymake_* -delete
 
 # Dockerized build: useful for making Linux releases on OSX
-.PHONY:docker
+.PHONY: docker
 docker:
 	make -C build.assets build
 
 # Dockerized build: useful for making Linux binaries on OSX
-.PHONY:docker-binaries
+.PHONY: docker-binaries
 docker-binaries: clean
 	make -C build.assets build-binaries
 
 # Interactively enters a Docker container (which you can build and run Teleport inside of)
-.PHONY:enter
+.PHONY: enter
 enter:
 	make -C build.assets enter
 
@@ -451,7 +452,7 @@ install: build
 .PHONY: image
 image: clean docker-binaries
 	cp ./build.assets/charts/Dockerfile $(BUILDDIR)/
-	cd $(BUILDDIR) && docker build --no-cache . -t $(DOCKER_IMAGE):$(VERSION)
+	cd $(BUILDDIR) && docker build $(DOCKER_CACHE_OPTS) . -t $(DOCKER_IMAGE):$(VERSION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e image; fi
 
 .PHONY: publish

--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ publish: image
 .PHONY: image-ci
 image-ci: clean docker-binaries
 	cp ./build.assets/charts/Dockerfile $(BUILDDIR)/
-	cd $(BUILDDIR) && docker build --no-cache . -t $(DOCKER_IMAGE_CI):$(VERSION)
+	cd $(BUILDDIR) && docker build $(DOCKER_CACHE_OPTS) . -t $(DOCKER_IMAGE_CI):$(VERSION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e image-ci; fi
 
 .PHONY: publish-ci

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 
 	"golang.org/x/crypto/ssh"
@@ -1158,10 +1159,12 @@ func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
 	// stderr so the output does not mix with the rest of the output if the remote
 	// side is not doing additional formatting for extended data.
 	// See github.com/gravitational/teleport/issues/4542
-	payload := message + "\n"
-	s.stderrWrite(ch, payload)
+	if !strings.HasSuffix(message, "\n") {
+		message = message + "\n"
+	}
+	s.stderrWrite(ch, message)
 	if req.WantReply {
-		if err := req.Reply(false, []byte(payload)); err != nil {
+		if err := req.Reply(false, []byte(message)); err != nil {
 			s.log.Errorf("sending error reply on SSH channel: %v", err)
 		}
 	}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1541,10 +1541,12 @@ func (s *Server) replyError(ch ssh.Channel, req *ssh.Request, err error) {
 	// stderr so the output does not mix with the rest of the output if the remote
 	// side is not doing additional formatting for extended data.
 	// See github.com/gravitational/teleport/issues/4542
-	payload := message + "\n"
-	writeStderr(ch, payload)
+	if !strings.HasSuffix(message, "\n") {
+		message = message + "\n"
+	}
+	writeStderr(ch, message)
 	if req.WantReply {
-		if err := req.Reply(false, []byte(payload)); err != nil {
+		if err := req.Reply(false, []byte(message)); err != nil {
 			log.Warnf("Failed to reply to %q request: %v", req.Type, err)
 		}
 	}

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -181,12 +181,14 @@ func UserMessageFromError(err error) string {
 	if err != nil {
 		// If the error is a trace error, check if it has a user message embedded in
 		// it, if it does, print it, otherwise escape and print the original error.
-		if er, ok := err.(*trace.TraceErr); ok {
-			if er.Message != "" {
-				return fmt.Sprintf("error: %v", EscapeControl(er.Message))
-			}
+		if err, ok := err.(*trace.TraceErr); ok && err.Message != "" {
+			// Avoid escaping an error message that terminates with a newline
+			errMsg := strings.TrimSuffix(err.Message, "\n")
+			return fmt.Sprintf("error: %v", EscapeControl(errMsg))
 		}
-		return fmt.Sprintf("error: %v", EscapeControl(err.Error()))
+		// Avoid escaping an error message that terminates with a newline
+		errMsg := strings.TrimSuffix(err.Error(), "\n")
+		return fmt.Sprintf("error: %v", EscapeControl(errMsg))
 	}
 	return ""
 }

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -140,9 +140,44 @@ func GetIterations() int {
 	return iter
 }
 
-// UserMessageFromError returns user friendly error message from error
+// UserMessageFromError returns user-friendly error message from error.
+// The error message will be formatted for output depending on the debug
+// flag
 func UserMessageFromError(err error) string {
-	// untrusted cert?
+	if err == nil {
+		return ""
+	}
+	if certErr := formatCertError(err); certErr != "" {
+		return certErr
+	}
+	if log.GetLevel() == log.DebugLevel {
+		return trace.DebugReport(err)
+	}
+	return FormatError(err)
+}
+
+// FormatError returns user friendly error message from error.
+// The error message is escaped if necessary
+func FormatError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if certErr := formatCertError(err); certErr != "" {
+		return certErr
+	}
+	// If the error is a trace error, check if it has a user message embedded in
+	// it, if it does, print it, otherwise escape and print the original error.
+	if err, ok := err.(*trace.TraceErr); ok && err.Message != "" {
+		// Avoid escaping an error message that terminates with a newline
+		errMsg := strings.TrimSuffix(err.Message, "\n")
+		return fmt.Sprintf("error: %v", EscapeControl(errMsg))
+	}
+	// Avoid escaping an error message that terminates with a newline
+	errMsg := strings.TrimSuffix(err.Error(), "\n")
+	return fmt.Sprintf("error: %v", EscapeControl(errMsg))
+}
+
+func formatCertError(err error) string {
 	switch innerError := trace.Unwrap(err).(type) {
 	case x509.HostnameError:
 		return fmt.Sprintf("Cannot establish https connection to %s:\n%s\n%s\n",
@@ -174,21 +209,6 @@ func UserMessageFromError(err error) string {
   The certificate presented by the proxy is invalid: %v.
 
   Contact your Teleport system administrator to resolve this issue.`, innerError)
-	}
-	if log.GetLevel() == log.DebugLevel {
-		return trace.DebugReport(err)
-	}
-	if err != nil {
-		// If the error is a trace error, check if it has a user message embedded in
-		// it, if it does, print it, otherwise escape and print the original error.
-		if err, ok := err.(*trace.TraceErr); ok && err.Message != "" {
-			// Avoid escaping an error message that terminates with a newline
-			errMsg := strings.TrimSuffix(err.Message, "\n")
-			return fmt.Sprintf("error: %v", EscapeControl(errMsg))
-		}
-		// Avoid escaping an error message that terminates with a newline
-		errMsg := strings.TrimSuffix(err.Error(), "\n")
-		return fmt.Sprintf("error: %v", EscapeControl(errMsg))
 	}
 	return ""
 }

--- a/lib/web/static.go
+++ b/lib/web/static.go
@@ -91,7 +91,7 @@ func isDebugMode() bool {
 	return v
 }
 
-// LoadWebResources returns a filesystem implementation compatible
+// loadZippedExeAssets returns a filesystem implementation compatible
 // with http.Serve.
 //
 // The "filesystem" is served from a zip file attached at the end of

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1074,32 +1074,33 @@ func onSSH(cf *CLIConf) {
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
 		return tc.SSH(cf.Context, cf.RemoteCommand, cf.LocalExec)
 	})
-	if err != nil {
-		if strings.Contains(utils.UserMessageFromError(err), teleport.NodeIsAmbiguous) {
-			allNodes, err := tc.ListAllNodes(cf.Context)
-			if err != nil {
-				utils.FatalError(err)
-			}
-			var nodes []services.Server
-			for _, node := range allNodes {
-				if node.GetHostname() == tc.Host {
-					nodes = append(nodes, node)
-				}
-			}
-			fmt.Fprintf(os.Stderr, "error: ambiguous host could match multiple nodes\n\n")
-			printNodesAsText(nodes, true)
-			fmt.Fprintf(os.Stderr, "Hint: try addressing the node by unique id (ex: tsh ssh user@node-id)\n")
-			fmt.Fprintf(os.Stderr, "Hint: use 'tsh ls -v' to list all nodes with their unique ids\n")
-			fmt.Fprintf(os.Stderr, "\n")
-			os.Exit(1)
-		}
-		// exit with the same exit status as the failed command:
-		if tc.ExitStatus != 0 {
-			fmt.Fprintln(os.Stderr, utils.UserMessageFromError(err))
-			os.Exit(tc.ExitStatus)
-		} else {
+	if err == nil {
+		return
+	}
+	if strings.Contains(utils.UserMessageFromError(err), teleport.NodeIsAmbiguous) {
+		allNodes, err := tc.ListAllNodes(cf.Context)
+		if err != nil {
 			utils.FatalError(err)
 		}
+		var nodes []services.Server
+		for _, node := range allNodes {
+			if node.GetHostname() == tc.Host {
+				nodes = append(nodes, node)
+			}
+		}
+		fmt.Fprintf(os.Stderr, "error: ambiguous host could match multiple nodes\n\n")
+		printNodesAsText(nodes, true)
+		fmt.Fprintf(os.Stderr, "Hint: try addressing the node by unique id (ex: tsh ssh user@node-id)\n")
+		fmt.Fprintf(os.Stderr, "Hint: use 'tsh ls -v' to list all nodes with their unique ids\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		os.Exit(1)
+	}
+	// exit with the same exit status as the failed command:
+	if tc.ExitStatus != 0 {
+		fmt.Fprintln(os.Stderr, utils.UserMessageFromError(err))
+		os.Exit(tc.ExitStatus)
+	} else {
+		utils.FatalError(err)
 	}
 }
 


### PR DESCRIPTION
Suffix the error with a newline for added formatting when replying to a remote's side with an error.
Strip the newline when outputting the error message in tsh.

Fixes https://github.com/gravitational/teleport/issues/4542 and https://github.com/gravitational/teleport/issues/3205.

Before the change:
```
$ ssh -F ./ssh_config root@teleport-node
node is offline, please try again latersubsystem request failed on channel 0
kex_exchange_identification: Connection closed by remote host
```

After the change:
```
$ ssh -F ./ssh_config root@teleport-node
node is offline, please try again later
subsystem request failed on channel 0
kex_exchange_identification: Connection closed by remote host
```
```
$ tsh ssh root@teleport-node
error: failed connecting to node teleport-node. node is offline, please try again later
```