### PR TITLE
Test flakes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ docs-test-links:
 .PHONY: test
 test: ensure-webassets
 test: FLAGS ?= '-race'
-test: PACKAGES := $(shell go list ./... | grep -v integration)
+test: PACKAGES ?= $(shell go list ./... | grep -v integration)
 test: CHAOS_FOLDERS := $(shell find . -type f -name '*chaos*.go' -not -path '*/vendor/*' | xargs dirname | uniq)
 test: $(VERSRC)
 	go test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -17,9 +17,9 @@ ENV LANGUAGE="en_US.UTF-8" \
     LC_CTYPE="en_US.UTF-8" \
     DEBIAN_FRONTEND="noninteractive"
 
-RUN apt-get update -y --fix-missing && \
+RUN set -ex && apt-get update -y --fix-missing && \
     apt-get -q -y upgrade && \
-    apt-get install -q -y apt-utils curl gcc gcc-multilib git gzip libbpfcc-dev libc6-dev libpam-dev libsqlite3-0 locales make net-tools tar tree zip shellcheck && \
+    apt-get install -q -y apt-utils curl gcc gcc-multilib git gzip libbpfcc-dev libc6-dev libpam-dev libsqlite3-0 locales make net-tools tar tree zip shellcheck dumb-init && \
     dpkg-reconfigure locales && \
     apt-get -y autoclean && apt-get -y clean
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -149,10 +149,10 @@ clean:
 test: FLAGS ?= -cover -race
 test: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) -t $(BUILDBOX) \
-		/bin/bash -c \
+		/usr/bin/dumb-init /bin/bash -c \
 		"examples/etcd/start-etcd.sh & sleep 1; \
 		ssh-agent > external.agent.tmp && source external.agent.tmp; \
-		cd $(SRCDIR) && make TELEPORT_DEBUG=0 FLAGS=\"$(FLAGS)\" clean test"
+		make -C $(SRCDIR) TELEPORT_DEBUG=0 FLAGS=\"$(FLAGS)\" clean test"
 
 .PHONY: integration
 integration: FLAGS ?= -cover

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -145,18 +145,20 @@ clean:
 #
 # Runs tests inside a build container
 #
-.PHONY:test
+.PHONY: test
+test: FLAGS ?= -cover -race
 test: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c \
 		"examples/etcd/start-etcd.sh & sleep 1; \
 		ssh-agent > external.agent.tmp && source external.agent.tmp; \
-		cd $(SRCDIR) && make TELEPORT_DEBUG=0 FLAGS='-cover -race' clean test"
+		cd $(SRCDIR) && make TELEPORT_DEBUG=0 FLAGS=\"$(FLAGS)\" clean test"
 
-.PHONY:integration
+.PHONY: integration
+integration: FLAGS ?= -cover
 integration: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) -t $(BUILDBOX) \
-		/bin/bash -c "make -C $(SRCDIR) FLAGS='-cover' integration"
+		/bin/bash -c "make -C $(SRCDIR) FLAGS=\"$(FLAGS)\" integration"
 
 #
 # Runs linters on new changes inside a build container.

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -102,9 +102,9 @@ type TeleInstance struct {
 	// UploadEventsC is a channel for upload events
 	UploadEventsC chan events.UploadEvent
 
-	// tempDirs is a list of temporary directories that were created that should
-	// be cleaned up after the test has successfully run.
-	tempDirs []string
+	// DataDir specifies the root directory for all state information
+	// used by the instance during a single test
+	DataDir string
 }
 
 type User struct {
@@ -159,6 +159,9 @@ type InstanceConfig struct {
 	Pub []byte
 	// MultiplexProxy uses the same port for web and SSH reverse tunnel proxy
 	MultiplexProxy bool
+	// DataDir specifies the root directory for all state information
+	// used by the instance  during a single test
+	DataDir string
 }
 
 // NewInstance creates a new Teleport process instance.
@@ -223,6 +226,7 @@ func NewInstance(cfg InstanceConfig) *TeleInstance {
 		Ports:         cfg.Ports,
 		Hostname:      cfg.NodeName,
 		UploadEventsC: make(chan events.UploadEvent, 100),
+		DataDir:       cfg.DataDir,
 	}
 	secrets := InstanceSecrets{
 		SiteName:     cfg.ClusterName,
@@ -480,13 +484,10 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 
 // GenerateConfig generates instance config
 func (i *TeleInstance) GenerateConfig(trustedSecrets []*InstanceSecrets, tconf *service.Config) (*service.Config, error) {
-	var err error
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName)
+	dataDir, err := ioutil.TempDir(i.DataDir, "cluster-"+i.Secrets.SiteName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	i.tempDirs = append(i.tempDirs, dataDir)
-
 	if tconf == nil {
 		tconf = service.MakeDefaultConfig()
 	}
@@ -526,18 +527,18 @@ func (i *TeleInstance) GenerateConfig(trustedSecrets []*InstanceSecrets, tconf *
 	tconf.HostUUID = i.Secrets.GetIdentity().ID.HostUUID
 	tconf.SSH.Addr.Addr = net.JoinHostPort(i.Hostname, i.GetPortSSH())
 	tconf.SSH.PublicAddrs = []utils.NetAddr{
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Loopback,
 		},
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Host,
 		},
 	}
 	tconf.Auth.SSHAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortAuth())
 	tconf.Auth.PublicAddrs = []utils.NetAddr{
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        i.Hostname,
 		},
@@ -545,15 +546,15 @@ func (i *TeleInstance) GenerateConfig(trustedSecrets []*InstanceSecrets, tconf *
 	tconf.Proxy.SSHAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortProxy())
 	tconf.Proxy.WebAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortWeb())
 	tconf.Proxy.PublicAddrs = []utils.NetAddr{
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        i.Hostname,
 		},
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Loopback,
 		},
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Host,
 		},
@@ -602,7 +603,7 @@ func (i *TeleInstance) CreateEx(trustedSecrets []*InstanceSecrets, tconf *servic
 			return trace.Wrap(err)
 		}
 		// set hardcode traits to trigger new style certificates
-		teleUser.SetTraits(map[string][]string{"testing": []string{"integration"}})
+		teleUser.SetTraits(map[string][]string{"testing": {"integration"}})
 		if len(user.Roles) == 0 {
 			role := services.RoleForUser(teleUser)
 			role.SetLogins(services.Allow, user.AllowedLogins)
@@ -660,12 +661,10 @@ func (i *TeleInstance) StartReverseTunnelNode(tconf *service.Config) (*service.T
 
 // startNode starts a node and connects it to the cluster.
 func (i *TeleInstance) startNode(tconf *service.Config, reverseTunnel bool) (*service.TeleportProcess, error) {
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName)
+	dataDir, err := ioutil.TempDir(i.DataDir, "cluster-"+i.Secrets.SiteName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	i.tempDirs = append(i.tempDirs, dataDir)
-
 	tconf.DataDir = dataDir
 
 	authPort := i.GetPortAuth()
@@ -683,11 +682,11 @@ func (i *TeleInstance) startNode(tconf *service.Config, reverseTunnel bool) (*se
 		RecentTTL: &ttl,
 	}
 	tconf.SSH.PublicAddrs = []utils.NetAddr{
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Loopback,
 		},
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Host,
 		},
@@ -767,11 +766,10 @@ func (i *TeleInstance) StartApp(conf *service.Config) (*service.TeleportProcess,
 // StartNodeAndProxy starts a SSH node and a Proxy Server and connects it to
 // the cluster.
 func (i *TeleInstance) StartNodeAndProxy(name string, sshPort, proxyWebPort, proxySSHPort int) error {
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName)
+	dataDir, err := ioutil.TempDir(i.DataDir, "cluster-"+i.Secrets.SiteName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	i.tempDirs = append(i.tempDirs, dataDir)
 
 	tconf := service.MakeDefaultConfig()
 
@@ -799,11 +797,11 @@ func (i *TeleInstance) StartNodeAndProxy(name string, sshPort, proxyWebPort, pro
 	tconf.SSH.Enabled = true
 	tconf.SSH.Addr.Addr = net.JoinHostPort(i.Hostname, fmt.Sprintf("%v", sshPort))
 	tconf.SSH.PublicAddrs = []utils.NetAddr{
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Loopback,
 		},
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Host,
 		},
@@ -849,11 +847,10 @@ type ProxyConfig struct {
 
 // StartProxy starts another Proxy Server and connects it to the cluster.
 func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, error) {
-	dataDir, err := ioutil.TempDir("", "cluster-"+i.Secrets.SiteName+"-"+cfg.Name)
+	dataDir, err := ioutil.TempDir(i.DataDir, "cluster-"+i.Secrets.SiteName+"-"+cfg.Name)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	i.tempDirs = append(i.tempDirs, dataDir)
 
 	tconf := service.MakeDefaultConfig()
 
@@ -873,11 +870,11 @@ func (i *TeleInstance) StartProxy(cfg ProxyConfig) (reversetunnel.Server, error)
 	tconf.Proxy.Enabled = true
 	tconf.Proxy.SSHAddr.Addr = net.JoinHostPort(i.Hostname, fmt.Sprintf("%v", cfg.SSHPort))
 	tconf.Proxy.PublicAddrs = []utils.NetAddr{
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Loopback,
 		},
-		utils.NetAddr{
+		{
 			AddrNetwork: "tcp",
 			Addr:        Host,
 		},
@@ -1204,12 +1201,6 @@ func (i *TeleInstance) StopAll() error {
 	errors = append(errors, i.StopNodes())
 	errors = append(errors, i.StopProxy())
 	errors = append(errors, i.StopAuth(true))
-
-	// Remove temporary data directories that were created.
-	for _, dir := range i.tempDirs {
-		errors = append(errors, os.RemoveAll(dir))
-	}
-
 	return trace.NewAggregate(errors...)
 }
 
@@ -1520,17 +1511,10 @@ func createAgent(me *user.User, privateKeyByte []byte, certificateBytes []byte) 
 }
 
 func closeAgent(teleAgent *teleagent.AgentServer, socketDirPath string) error {
-	err := teleAgent.Close()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	err = os.RemoveAll(socketDirPath)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
+	return trace.NewAggregate(
+		teleAgent.Close(),
+		os.RemoveAll(socketDirPath),
+	)
 }
 
 func fatalIf(err error) {

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -724,7 +724,6 @@ func (i *TeleInstance) StartApp(conf *service.Config) (*service.TeleportProcess,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	i.tempDirs = append(i.tempDirs, dataDir)
 
 	conf.DataDir = dataDir
 	conf.AuthServers = []utils.NetAddr{

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -152,14 +152,7 @@ func (s *KubeSuite) TearDownSuite(c *check.C) {
 func (s *KubeSuite) TestKubeExec(c *check.C) {
 	tconf := s.teleKubeConfig(Host)
 
-	t := NewInstance(InstanceConfig{
-		ClusterName: Site,
-		HostID:      HostID,
-		NodeName:    Host,
-		Ports:       s.ports.PopIntSlice(5),
-		Priv:        s.priv,
-		Pub:         s.pub,
-	})
+	t := s.newTeleportInstance(c)
 
 	username := s.me.Username
 	kubeGroups := []string{testImpersonationGroup}
@@ -322,14 +315,7 @@ loop:
 func (s *KubeSuite) TestKubeDeny(c *check.C) {
 	tconf := s.teleKubeConfig(Host)
 
-	t := NewInstance(InstanceConfig{
-		ClusterName: Site,
-		HostID:      HostID,
-		NodeName:    Host,
-		Ports:       s.ports.PopIntSlice(5),
-		Priv:        s.priv,
-		Pub:         s.pub,
-	})
+	t := s.newTeleportInstance(c)
 
 	username := s.me.Username
 	kubeGroups := []string{testImpersonationGroup}
@@ -374,14 +360,7 @@ func (s *KubeSuite) TestKubeDeny(c *check.C) {
 func (s *KubeSuite) TestKubePortForward(c *check.C) {
 	tconf := s.teleKubeConfig(Host)
 
-	t := NewInstance(InstanceConfig{
-		ClusterName: Site,
-		HostID:      HostID,
-		NodeName:    Host,
-		Ports:       s.ports.PopIntSlice(5),
-		Priv:        s.priv,
-		Pub:         s.pub,
-	})
+	t := s.newTeleportInstance(c)
 
 	username := s.me.Username
 	kubeGroups := []string{testImpersonationGroup}
@@ -469,14 +448,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 	// Main cluster doesn't need a kubeconfig to forward requests to auxiliary
 	// cluster.
 	mainConf.Proxy.Kube.KubeconfigPath = ""
-	main := NewInstance(InstanceConfig{
-		ClusterName: clusterMain,
-		HostID:      HostID,
-		NodeName:    Host,
-		Ports:       s.ports.PopIntSlice(5),
-		Priv:        s.priv,
-		Pub:         s.pub,
-	})
+	main := s.newNamedTeleportInstance(c, clusterMain)
 
 	// main cluster has a role and user called main-kube
 	username := s.me.Username
@@ -492,14 +464,7 @@ func (s *KubeSuite) TestKubeTrustedClustersClientCert(c *check.C) {
 
 	clusterAux := "cluster-aux"
 	auxConf := s.teleKubeConfig(Host)
-	aux := NewInstance(InstanceConfig{
-		ClusterName: clusterAux,
-		HostID:      HostID,
-		NodeName:    Host,
-		Ports:       s.ports.PopIntSlice(5),
-		Priv:        s.priv,
-		Pub:         s.pub,
-	})
+	aux := s.newNamedTeleportInstance(c, clusterAux)
 
 	lib.SetInsecureDevMode(true)
 	defer lib.SetInsecureDevMode(false)
@@ -725,14 +690,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 
 	clusterMain := "cluster-main"
 	mainConf := s.teleKubeConfig(Host)
-	main := NewInstance(InstanceConfig{
-		ClusterName: clusterMain,
-		HostID:      HostID,
-		NodeName:    Host,
-		Ports:       s.ports.PopIntSlice(5),
-		Priv:        s.priv,
-		Pub:         s.pub,
-	})
+	main := s.newNamedTeleportInstance(c, clusterMain)
 
 	// main cluster has a role and user called main-kube
 	username := s.me.Username
@@ -748,14 +706,7 @@ func (s *KubeSuite) TestKubeTrustedClustersSNI(c *check.C) {
 
 	clusterAux := "cluster-aux"
 	auxConf := s.teleKubeConfig(Host)
-	aux := NewInstance(InstanceConfig{
-		ClusterName: clusterAux,
-		HostID:      HostID,
-		NodeName:    Host,
-		Ports:       s.ports.PopIntSlice(5),
-		Priv:        s.priv,
-		Pub:         s.pub,
-	})
+	aux := s.newNamedTeleportInstance(c, clusterAux)
 
 	lib.SetInsecureDevMode(true)
 	defer lib.SetInsecureDevMode(false)
@@ -1003,14 +954,7 @@ func (s *KubeSuite) TestKubeDisconnect(c *check.C) {
 func (s *KubeSuite) runKubeDisconnectTest(c *check.C, tc disconnectTestCase) {
 	tconf := s.teleKubeConfig(Host)
 
-	t := NewInstance(InstanceConfig{
-		ClusterName: Site,
-		HostID:      HostID,
-		NodeName:    Host,
-		Ports:       s.ports.PopIntSlice(5),
-		Priv:        s.priv,
-		Pub:         s.pub,
-	})
+	t := s.newTeleportInstance(c)
 
 	username := s.me.Username
 	kubeGroups := []string{testImpersonationGroup}
@@ -1100,6 +1044,30 @@ func (s *KubeSuite) teleKubeConfig(hostname string) *service.Config {
 	tconf.Proxy.Kube.KubeconfigPath = s.kubeConfigPath
 
 	return tconf
+}
+
+func (s *KubeSuite) newTeleportInstance(c *check.C) *TeleInstance {
+	return NewInstance(InstanceConfig{
+		ClusterName: Site,
+		HostID:      HostID,
+		NodeName:    Host,
+		Ports:       s.ports.PopIntSlice(5),
+		Priv:        s.priv,
+		Pub:         s.pub,
+		DataDir:     c.MkDir(),
+	})
+}
+
+func (s *KubeSuite) newNamedTeleportInstance(c *check.C, clusterName string) *TeleInstance {
+	return NewInstance(InstanceConfig{
+		ClusterName: clusterName,
+		HostID:      HostID,
+		NodeName:    Host,
+		Ports:       s.ports.PopIntSlice(5),
+		Priv:        s.priv,
+		Pub:         s.pub,
+		DataDir:     c.MkDir(),
+	})
 }
 
 // tlsClientConfig returns TLS configuration for client

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -62,6 +62,7 @@ func (s *EtcdSuite) SetUpSuite(c *check.C) {
 		"tls_cert_file": "../../../examples/etcd/certs/client-cert.pem",
 		"tls_ca_file":   "../../../examples/etcd/certs/ca-cert.pem",
 		"dial_timeout":  500 * time.Millisecond,
+		"key":           legacyDefaultPrefix,
 	}
 
 	newBackend := func() (backend.Backend, error) {
@@ -84,8 +85,6 @@ func (s *EtcdSuite) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.bk = b.(*EtcdBackend)
 	s.suite.B = s.bk
-
-	s.bk.cfg.Key = legacyDefaultPrefix
 }
 
 func (s *EtcdSuite) TearDownTest(c *check.C) {

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -139,7 +139,7 @@ func (s *EtcdSuite) TestWatchersClose(c *check.C) {
 }
 
 func (s *EtcdSuite) TestLocking(c *check.C) {
-	s.suite.Locking(c)
+	s.suite.Locking(c, s.bk)
 }
 
 func (s *EtcdSuite) TestPrefix(c *check.C) {

--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -142,7 +142,7 @@ func (s *FirestoreSuite) TestWatchersClose(c *check.C) {
 }
 
 func (s *FirestoreSuite) TestLocking(c *check.C) {
-	s.suite.Locking(c)
+	s.suite.Locking(c, s.bk)
 }
 
 func (s *FirestoreSuite) TestReadLegacyRecord(c *check.C) {

--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -34,7 +34,7 @@ func AcquireLock(ctx context.Context, backend Backend, lockName string, ttl time
 	key := []byte(filepath.Join(locksPrefix, lockName))
 	for {
 		// Get will clear TTL on a lock
-		backend.Get(ctx, key)
+		backend.Get(ctx, key) //nolint:errcheck
 
 		// CreateVal is atomic:
 		_, err = backend.Create(ctx, Item{Key: key, Value: []byte{1}, Expires: backend.Clock().Now().UTC().Add(ttl)})

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -795,10 +795,6 @@ func (l *Backend) CloseWatchers() {
 	l.buf.Reset()
 }
 
-func (l *Backend) isClosed() bool {
-	return atomic.LoadInt32(&l.closedFlag) == 1
-}
-
 func (l *Backend) setClosed() {
 	atomic.StoreInt32(&l.closedFlag, 1)
 }
@@ -821,51 +817,38 @@ func (l *Backend) inTransaction(ctx context.Context, f func(tx *sql.Tx) error) (
 	if err != nil {
 		return trace.Wrap(convertError(err))
 	}
-	commit := func() error {
-		return tx.Commit()
-	}
-	rollback := func() error {
-		return tx.Rollback()
-	}
 	defer func() {
+		if err == nil {
+			return
+		}
 		if r := recover(); r != nil {
-			l.Errorf("Unexpected panic in inTransaction: %v, trying to rollback.", r)
+			l.Errorf("Panic in inTransaction: %v, trying to rollback: %s.", r, string(debug.Stack()))
 			err = trace.BadParameter("panic: %v", r)
-			if e2 := rollback(); e2 != nil {
-				l.Errorf("Failed to rollback: %v.", e2)
+			if err := tx.Rollback(); err != nil {
+				l.Errorf("Failed to rollback: %v.", err)
 			}
 			return
 		}
-		if err != nil && !trace.IsNotFound(err) {
-			if isConstraintError(trace.Unwrap(err)) {
-				err = trace.AlreadyExists(err.Error())
-			}
-			// transaction aborted by interrupt, no action needed
-			if isInterrupt(trace.Unwrap(err)) {
-				return
-			}
-			if isLockedError(trace.Unwrap(err)) {
-				err = trace.ConnectionProblem(err, "database is locked")
-			}
-			if isReadonlyError(trace.Unwrap(err)) {
-				err = trace.ConnectionProblem(err, "database is in readonly mode")
-			}
-			if !l.isClosed() {
-				if !trace.IsCompareFailed(err) && !trace.IsAlreadyExists(err) && !trace.IsConnectionProblem(err) {
-					l.Warningf("Unexpected error in inTransaction: %v, rolling back.", trace.DebugReport(err))
-				}
-				if e2 := rollback(); e2 != nil {
-					l.Errorf("Failed to rollback too: %v.", e2)
-				}
-			}
+		// transaction aborted by interrupt, no action needed
+		if isInterrupt(trace.Unwrap(err)) {
 			return
 		}
-		if err2 := commit(); err2 != nil {
-			err = trace.Wrap(err2)
+		if err := tx.Rollback(); err != nil {
+			l.Errorf("Failed to rollback: %v.", err)
+		}
+		switch {
+		case isUniqueConstraintError(trace.Unwrap(err)):
+			err = trace.AlreadyExists(err.Error())
+		case isLockedError(trace.Unwrap(err)):
+			err = trace.ConnectionProblem(err, "database is locked")
+		case isReadonlyError(trace.Unwrap(err)):
+			err = trace.ConnectionProblem(err, "database is in readonly mode")
 		}
 	}()
-	err = f(tx)
-	return
+	if err := f(tx); err != nil {
+		return trace.Wrap(err)
+	}
+	return tx.Commit()
 }
 
 func expires(t time.Time) interface{} {
@@ -887,12 +870,12 @@ func isClosedError(err error) bool {
 	return err.Error() == "sql: database is closed"
 }
 
-func isConstraintError(err error) bool {
-	e, ok := trace.Unwrap(err).(sqlite3.Error)
-	if !ok {
-		return false
+func isUniqueConstraintError(err error) bool {
+	if err, ok := trace.Unwrap(err).(sqlite3.Error); ok {
+		return err.ExtendedCode == sqlite3.ErrConstraintUnique ||
+			err.ExtendedCode == sqlite3.ErrConstraintPrimaryKey
 	}
-	return e.Code == sqlite3.ErrConstraint
+	return false
 }
 
 func isLockedError(err error) bool {

--- a/lib/backend/lite/lite_test.go
+++ b/lib/backend/lite/lite_test.go
@@ -99,7 +99,7 @@ func (s *LiteSuite) TestPutRange(c *check.C) {
 }
 
 func (s *LiteSuite) TestLocking(c *check.C) {
-	s.suite.Locking(c)
+	s.suite.Locking(c, s.bk)
 }
 
 // Import tests importing values

--- a/lib/backend/lite/litemem_test.go
+++ b/lib/backend/lite/litemem_test.go
@@ -99,7 +99,7 @@ func (s *LiteMemSuite) TestPutRange(c *check.C) {
 }
 
 func (s *LiteMemSuite) TestLocking(c *check.C) {
-	s.suite.Locking(c)
+	s.suite.Locking(c, s.bk)
 }
 
 func (s *LiteMemSuite) TestConcurrentOperations(c *check.C) {

--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -35,9 +35,6 @@ func (l *Backend) runPeriodicOperations() {
 	for {
 		select {
 		case <-l.ctx.Done():
-			if err := l.closeDatabase(); err != nil {
-				l.Warningf("Error closing database: %v", err)
-			}
 			return
 		case <-t.C:
 			err := l.removeExpiredKeys()

--- a/lib/backend/memory/memory_test.go
+++ b/lib/backend/memory/memory_test.go
@@ -98,7 +98,7 @@ func (s *MemorySuite) TestPutRange(c *check.C) {
 }
 
 func (s *MemorySuite) TestLocking(c *check.C) {
-	s.suite.Locking(c)
+	s.suite.Locking(c, s.bk)
 }
 
 func (s *MemorySuite) TestConcurrentOperations(c *check.C) {

--- a/lib/backend/report_test.go
+++ b/lib/backend/report_test.go
@@ -34,6 +34,7 @@ func TestReporterTopRequestsLimit(t *testing.T) {
 		return int(count)
 	}
 
+	requests.Reset()
 	// At first, the metric should have no values.
 	require.Equal(t, 0, countTopRequests())
 

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -306,7 +306,7 @@ func (s *BackendSuite) Expiration(c *check.C) {
 	ExpectItems(c, items, []backend.Item{itemA})
 }
 
-// addSeconds adds seconds with a seconds precission
+// addSeconds adds seconds with a seconds precision
 // always rounding up to the next second,
 // because TTL engines are usually 1 second precision
 func addSeconds(t time.Time, seconds int64) time.Time {
@@ -334,10 +334,10 @@ func (s *BackendSuite) KeepAlive(c *check.C) {
 	c.Assert(string(out.Value), check.Equals, string(item.Value))
 	c.Assert(string(out.Key), check.Equals, string(item.Key))
 
-	err = s.B.KeepAlive(ctx, *lease, addSeconds(time.Now(), 2))
+	err = s.B.KeepAlive(ctx, *lease, addSeconds(time.Now(), 4))
 	c.Assert(err, check.IsNil)
 
-	// should have expired if not keep alive
+	// should have expired if not kept alive
 	diff := time.Until(addSeconds(time.Now(), 1))
 	time.Sleep(diff + 100*time.Millisecond)
 

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -525,54 +525,54 @@ func (s *BackendSuite) WatchersClose(c *check.C) {
 }
 
 // Locking tests locking logic
-func (s *BackendSuite) Locking(c *check.C, b backend.Backend) {
+func (s *BackendSuite) Locking(c *check.C, bk backend.Backend) {
 	tok1 := "token1"
 	tok2 := "token2"
 	ttl := time.Second * 5
 
 	ctx := context.TODO()
 
-	err := backend.ReleaseLock(ctx, b, tok1)
+	err := backend.ReleaseLock(ctx, bk, tok1)
 	fixtures.ExpectNotFound(c, err)
 
-	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
 	x := int32(7)
 
 	go func() {
 		atomic.StoreInt32(&x, 9)
-		c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
+		c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
 	}()
-	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
 	atomic.AddInt32(&x, 9)
 
 	c.Assert(atomic.LoadInt32(&x), check.Equals, int32(18))
-	c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
+	c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
 
-	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
 	atomic.StoreInt32(&x, 7)
 	go func() {
 		atomic.StoreInt32(&x, 9)
-		c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
+		c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
 	}()
-	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
 	atomic.AddInt32(&x, 9)
 	c.Assert(atomic.LoadInt32(&x), check.Equals, int32(18))
-	c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
+	c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
 
 	y := int32(0)
-	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
-	c.Assert(backend.AcquireLock(ctx, b, tok2, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, bk, tok2, ttl), check.IsNil)
 	go func() {
 		atomic.StoreInt32(&y, 15)
-		c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
-		c.Assert(backend.ReleaseLock(ctx, b, tok2), check.IsNil)
+		c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
+		c.Assert(backend.ReleaseLock(ctx, bk, tok2), check.IsNil)
 	}()
 
-	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
 	c.Assert(atomic.LoadInt32(&y), check.Equals, int32(15))
 
-	c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
-	err = backend.ReleaseLock(ctx, b, tok1)
+	c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
+	err = backend.ReleaseLock(ctx, bk, tok1)
 	fixtures.ExpectNotFound(c, err)
 }
 

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -525,54 +525,54 @@ func (s *BackendSuite) WatchersClose(c *check.C) {
 }
 
 // Locking tests locking logic
-func (s *BackendSuite) Locking(c *check.C) {
+func (s *BackendSuite) Locking(c *check.C, b backend.Backend) {
 	tok1 := "token1"
 	tok2 := "token2"
 	ttl := time.Second * 5
 
 	ctx := context.TODO()
 
-	err := backend.ReleaseLock(ctx, s.B, tok1)
+	err := backend.ReleaseLock(ctx, b, tok1)
 	fixtures.ExpectNotFound(c, err)
 
-	c.Assert(backend.AcquireLock(ctx, s.B, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
 	x := int32(7)
 
 	go func() {
 		atomic.StoreInt32(&x, 9)
-		c.Assert(backend.ReleaseLock(ctx, s.B, tok1), check.IsNil)
+		c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
 	}()
-	c.Assert(backend.AcquireLock(ctx, s.B, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
 	atomic.AddInt32(&x, 9)
 
 	c.Assert(atomic.LoadInt32(&x), check.Equals, int32(18))
-	c.Assert(backend.ReleaseLock(ctx, s.B, tok1), check.IsNil)
+	c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
 
-	c.Assert(backend.AcquireLock(ctx, s.B, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
 	atomic.StoreInt32(&x, 7)
 	go func() {
 		atomic.StoreInt32(&x, 9)
-		c.Assert(backend.ReleaseLock(ctx, s.B, tok1), check.IsNil)
+		c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
 	}()
-	c.Assert(backend.AcquireLock(ctx, s.B, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
 	atomic.AddInt32(&x, 9)
 	c.Assert(atomic.LoadInt32(&x), check.Equals, int32(18))
-	c.Assert(backend.ReleaseLock(ctx, s.B, tok1), check.IsNil)
+	c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
 
 	y := int32(0)
-	c.Assert(backend.AcquireLock(ctx, s.B, tok1, ttl), check.IsNil)
-	c.Assert(backend.AcquireLock(ctx, s.B, tok2, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, b, tok2, ttl), check.IsNil)
 	go func() {
 		atomic.StoreInt32(&y, 15)
-		c.Assert(backend.ReleaseLock(ctx, s.B, tok1), check.IsNil)
-		c.Assert(backend.ReleaseLock(ctx, s.B, tok2), check.IsNil)
+		c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
+		c.Assert(backend.ReleaseLock(ctx, b, tok2), check.IsNil)
 	}()
 
-	c.Assert(backend.AcquireLock(ctx, s.B, tok1, ttl), check.IsNil)
+	c.Assert(backend.AcquireLock(ctx, b, tok1, ttl), check.IsNil)
 	c.Assert(atomic.LoadInt32(&y), check.Equals, int32(15))
 
-	c.Assert(backend.ReleaseLock(ctx, s.B, tok1), check.IsNil)
-	err = backend.ReleaseLock(ctx, s.B, tok1)
+	c.Assert(backend.ReleaseLock(ctx, b, tok1), check.IsNil)
+	err = backend.ReleaseLock(ctx, b, tok1)
 	fixtures.ExpectNotFound(c, err)
 }
 

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -131,6 +131,13 @@ func (p *defaultModules) IsBoringBinary() bool {
 	return false
 }
 
+// resetModules resets the modules interface to defaults
+func resetModules() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	modules = &defaultModules{}
+}
+
 // DELETE IN: 5.1.0
 //
 // ExtendAdminUserRules returns true if the "AdminUserRules" set should be
@@ -141,6 +148,6 @@ func (p *defaultModules) ExtendAdminUserRules() bool {
 }
 
 var (
-	mutex           = &sync.Mutex{}
+	mutex   sync.Mutex
 	modules Modules = &defaultModules{}
 )

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -31,6 +31,10 @@ type ModulesSuite struct{}
 
 var _ = check.Suite(&ModulesSuite{})
 
+func (s *ModulesSuite) TearDownTest(c *check.C) {
+	resetModules()
+}
+
 func (s *ModulesSuite) TestDefaultModules(c *check.C) {
 	err := GetModules().EmptyRolesHandler()
 	c.Assert(err, check.IsNil)
@@ -49,9 +53,9 @@ func (s *ModulesSuite) TestDefaultModules(c *check.C) {
 
 	traits := GetModules().TraitsFromLogins("alice", []string{"root"}, []string{"system:masters"}, []string{"alice@example.com"})
 	c.Assert(traits, check.DeepEquals, map[string][]string{
-		teleport.TraitLogins:     []string{"root"},
-		teleport.TraitKubeGroups: []string{"system:masters"},
-		teleport.TraitKubeUsers:  []string{"alice@example.com"},
+		teleport.TraitLogins:     {"root"},
+		teleport.TraitKubeGroups: {"system:masters"},
+		teleport.TraitKubeUsers:  {"alice@example.com"},
 	})
 
 	isBoring := GetModules().IsBoringBinary()

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1856,7 +1856,7 @@ func (process *TeleportProcess) initUploaderService(accessPoint auth.AccessPoint
 	paths := [][]string{
 		// DELETE IN (5.1.0)
 		// this directory will no longer be used after migration to 5.1.0
-		[]string{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.SessionLogsDir, defaults.Namespace},
+		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.SessionLogsDir, defaults.Namespace},
 		// This directory will remain to be used after migration to 5.1.0
 		streamingDir,
 	}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -752,7 +752,7 @@ Acquire:
 			// however, to assume that we are under high contention and attempt to
 			// spread out retries via random backoff.
 			select {
-			case <-time.After(s.jitter(baseBackoff * time.Duration(i))):
+			case <-time.After(s.jitter(baseBackoff * time.Duration(acquireAttempts))):
 			case <-ctx.Done():
 				return nil, trace.Wrap(ctx.Err())
 			}

--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -59,6 +59,8 @@ type SemaphoreLockConfig struct {
 	TickRate time.Duration
 	// Params holds the semaphore lease acquisition parameters.
 	Params AcquireSemaphoreRequest
+	// Jitter optionally specifies the jitter for retries
+	Jitter utils.Jitter
 }
 
 // CheckAndSetDefaults checks and sets default parameters
@@ -80,6 +82,9 @@ func (l *SemaphoreLockConfig) CheckAndSetDefaults() error {
 	}
 	if l.Params.Expires.IsZero() {
 		l.Params.Expires = time.Now().UTC().Add(l.Expiry)
+	}
+	if l.Jitter == nil {
+		l.Jitter = utils.NewJitter()
 	}
 	if err := l.Params.Check(); err != nil {
 		return trace.Wrap(err)
@@ -232,7 +237,7 @@ func AcquireSemaphoreLock(ctx context.Context, cfg SemaphoreLockConfig) (*Semaph
 	retry, err := utils.NewLinear(utils.LinearConfig{
 		Max:    cfg.Expiry / 4,
 		Step:   cfg.Expiry / 16,
-		Jitter: utils.NewJitter(),
+		Jitter: cfg.Jitter,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
 
@@ -1189,25 +1190,26 @@ func (s *ServicesTestSuite) SemaphoreFlakiness(c *check.C) {
 // to start returning "too much contention" errors at around 100 concurrent
 // attempts.
 func (s *ServicesTestSuite) SemaphoreContention(c *check.C) {
-	const locks int64 = 50
+	const locks = 50
 	const iters = 5
+	cfg := services.SemaphoreLockConfig{
+		Service: s.PresenceS,
+		Expiry:  time.Hour,
+		Params: services.AcquireSemaphoreRequest{
+			SemaphoreKind: services.SemaphoreKindConnection,
+			SemaphoreName: "alice",
+			MaxLeases:     locks,
+		},
+		Jitter: utils.NewJitter(),
+	}
 	for i := 0; i < iters; i++ {
-		cfg := services.SemaphoreLockConfig{
-			Service: s.PresenceS,
-			Expiry:  time.Hour,
-			Params: services.AcquireSemaphoreRequest{
-				SemaphoreKind: services.SemaphoreKindConnection,
-				SemaphoreName: "alice",
-				MaxLeases:     locks,
-			},
-		}
 		// we leak lock handles in the spawned goroutines, so
 		// context-based cancellation is needed to cleanup the
 		// background keepalive activity.
 		ctx, cancel := context.WithCancel(context.TODO())
 		var wg sync.WaitGroup
-		for i := int64(0); i < locks; i++ {
-			wg.Add(1)
+		wg.Add(int(locks))
+		for i := 0; i < locks; i++ {
 			go func() {
 				defer wg.Done()
 				lock, err := services.AcquireSemaphoreLock(ctx, cfg)

--- a/lib/session/session_test.go
+++ b/lib/session/session_test.go
@@ -52,10 +52,13 @@ func (s *SessionSuite) SetUpTest(c *C) {
 	s.clock = clockwork.NewFakeClockAt(time.Date(2016, 9, 8, 7, 6, 5, 0, time.UTC))
 	s.dir = c.MkDir()
 
-	s.bk, err = lite.New(context.TODO(), backend.Params{"path": s.dir})
+	s.bk, err = lite.NewWithConfig(context.TODO(),
+		lite.Config{
+			Path:  s.dir,
+			Clock: s.clock,
+		},
+	)
 	c.Assert(err, IsNil)
-
-	(s.bk.(*lite.Backend)).SetClock(s.clock)
 
 	srv, err := New(s.bk)
 	srv.(*server).clock = s.clock

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -175,7 +175,7 @@ type ServerContext struct {
 	*sshutils.ConnectionContext
 	*log.Entry
 
-	sync.RWMutex
+	mu sync.RWMutex
 
 	// env is a list of environment variables passed to the session.
 	env map[string]string
@@ -387,6 +387,11 @@ func (c *ServerContext) ID() int {
 
 // SessionID returns the ID of the session in the context.
 func (c *ServerContext) SessionID() rsession.ID {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.session == nil {
+		return ""
+	}
 	return c.session.id
 }
 
@@ -398,9 +403,11 @@ func (c *ServerContext) GetServer() Server {
 // CreateOrJoinSession will look in the SessionRegistry for the session ID. If
 // no session is found, a new one is created. If one is found, it is returned.
 func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	// As SSH conversation progresses, at some point a session will be created and
 	// its ID will be added to the environment
-	ssid, found := c.GetEnv(sshutils.SessionEnvVar)
+	ssid, found := c.getEnvWithLock(sshutils.SessionEnvVar)
 	if !found {
 		return nil
 	}
@@ -411,9 +418,9 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 	}
 
 	findSession := func() (*session, bool) {
-		reg.Lock()
-		defer reg.Unlock()
-		return reg.findSession(rsession.ID(ssid))
+		reg.mu.Lock()
+		defer reg.mu.Unlock()
+		return reg.findSessionWithLock(rsession.ID(ssid))
 	}
 
 	// update ctx with a session ID
@@ -421,7 +428,7 @@ func (c *ServerContext) CreateOrJoinSession(reg *SessionRegistry) error {
 	if c.session == nil {
 		log.Debugf("Will create new session for SSH connection %v.", c.ServerConn.RemoteAddr())
 	} else {
-		log.Debugf("Will join session %v for SSH connection %v.", c.session, c.ServerConn.RemoteAddr())
+		log.Debugf("Will join session %v for SSH connection %v.", c.session.id, c.ServerConn.RemoteAddr())
 	}
 
 	return nil
@@ -435,45 +442,47 @@ func (c *ServerContext) TrackActivity(ch ssh.Channel) ssh.Channel {
 
 // GetClientLastActive returns time when client was last active
 func (c *ServerContext) GetClientLastActive() time.Time {
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.clientLastActive
 }
 
 // UpdateClientActivity sets last recorded client activity associated with this context
 // either channel or session
 func (c *ServerContext) UpdateClientActivity() {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.clientLastActive = c.srv.GetClock().Now().UTC()
 }
 
 // AddCloser adds any closer in ctx that will be called
 // whenever server closes session channel
 func (c *ServerContext) AddCloser(closer io.Closer) {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.closers = append(c.closers, closer)
 }
 
 // GetTerm returns a Terminal.
 func (c *ServerContext) GetTerm() Terminal {
-	c.RLock()
-	defer c.RUnlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	return c.term
 }
 
 // SetTerm set a Terminal.
 func (c *ServerContext) SetTerm(t Terminal) {
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	c.term = t
 }
 
 // VisitEnv grants visitor-style access to env variables.
 func (c *ServerContext) VisitEnv(visit func(key, val string)) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	// visit the parent env first since locally defined variables
 	// effectively "override" parent defined variables.
 	c.Parent().VisitEnv(visit)
@@ -484,11 +493,19 @@ func (c *ServerContext) VisitEnv(visit func(key, val string)) {
 
 // SetEnv sets a environment variable within this context.
 func (c *ServerContext) SetEnv(key, val string) {
+	c.mu.Lock()
 	c.env[key] = val
+	c.mu.Unlock()
 }
 
 // GetEnv returns a environment variable within this context.
 func (c *ServerContext) GetEnv(key string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.getEnvWithLock(key)
+}
+
+func (c *ServerContext) getEnvWithLock(key string) (string, bool) {
 	val, ok := c.env[key]
 	if ok {
 		return val, true
@@ -496,12 +513,26 @@ func (c *ServerContext) GetEnv(key string) (string, bool) {
 	return c.Parent().GetEnv(key)
 }
 
+// setSession sets the context's session
+func (c *ServerContext) setSession(sess *session) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.session = sess
+}
+
+// getSession returns the context's session
+func (c *ServerContext) getSession() *session {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.session
+}
+
 // takeClosers returns all resources that should be closed and sets the properties to null
 // we do this to avoid calling Close() under lock to avoid potential deadlocks
 func (c *ServerContext) takeClosers() []io.Closer {
 	// this is done to avoid any operation holding the lock for too long
-	c.Lock()
-	defer c.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	closers := []io.Closer{}
 	if c.term != nil {
@@ -557,8 +588,9 @@ func (c *ServerContext) reportStats(conn utils.Stater) {
 	if !c.srv.UseTunnel() {
 		sessionDataEvent.ConnectionMetadata.LocalAddr = c.ServerConn.LocalAddr().String()
 	}
-	if c.session != nil {
-		sessionDataEvent.SessionMetadata.SessionID = string(c.session.id)
+	sessionID := string(c.SessionID())
+	if sessionID != "" {
+		sessionDataEvent.SessionMetadata.SessionID = sessionID
 	}
 	if err := c.GetServer().EmitAuditEvent(c.GetServer().Context(), sessionDataEvent); err != nil {
 		c.WithError(err).Warn("Failed to emit session data event.")
@@ -735,13 +767,15 @@ func buildEnvironment(ctx *ServerContext) []string {
 	}
 
 	// If a session has been created try and set TERM, SSH_TTY, and SSH_SESSION_ID.
-	if ctx.session != nil {
-		if ctx.session.term != nil {
-			env = append(env, fmt.Sprintf("TERM=%v", ctx.session.term.GetTermType()))
-			env = append(env, fmt.Sprintf("SSH_TTY=%s", ctx.session.term.TTY().Name()))
+	// TODO(dmitri): replace direct uses of session attributes
+	session := ctx.getSession()
+	if session != nil {
+		if session.term != nil {
+			env = append(env, fmt.Sprintf("TERM=%v", session.term.GetTermType()))
+			env = append(env, fmt.Sprintf("SSH_TTY=%s", session.term.TTY().Name()))
 		}
-		if ctx.session.id != "" {
-			env = append(env, fmt.Sprintf("%s=%s", teleport.SSHSessionID, ctx.session.id))
+		if session.id != "" {
+			env = append(env, fmt.Sprintf("%s=%s", teleport.SSHSessionID, session.id))
 		}
 	}
 

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -361,8 +361,9 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 	}
 
 	sessionMeta := events.SessionMetadata{}
-	if ctx.session != nil {
-		sessionMeta.SessionID = string(ctx.session.id)
+	sessionID := string(ctx.SessionID())
+	if sessionID != "" {
+		sessionMeta.SessionID = sessionID
 	}
 
 	userMeta := events.UserMetadata{

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -215,9 +215,7 @@ func (t *proxySubsys) Start(sconn *ssh.ServerConn, ch ssh.Channel, req *ssh.Requ
 	)
 	// did the client pass us a true client IP ahead of time via an environment variable?
 	// (usually the web client would do that)
-	ctx.Lock()
 	trueClientIP, ok := ctx.GetEnv(sshutils.TrueClientAddrVar)
-	ctx.Unlock()
 	if ok {
 		a, err := utils.ParseAddr(trueClientIP)
 		if err == nil {

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -447,14 +447,14 @@ func (s *SrvSuite) TestAgentForward(c *C) {
 	c.Assert(err, IsNil)
 	// clt must be nullified to prevent double-close during test cleanup
 	s.clt = nil
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 10; i++ {
 		_, err = net.Dial("unix", socketPath)
 		if err != nil {
 			return
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	c.Fatalf("expected socket to be closed, still could dial after 150 ms")
+	c.Fatalf("expected socket to be closed, still could dial after 450 ms")
 }
 
 func (s *SrvSuite) TestAllowedUsers(c *C) {

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -634,7 +634,7 @@ func (t *remoteTerminal) prepareRemoteSession(session *ssh.Session, ctx *ServerC
 		teleport.SSHSessionWebproxyAddr: ctx.ProxyPublicAddress(),
 		teleport.SSHTeleportHostUUID:    ctx.srv.ID(),
 		teleport.SSHTeleportClusterName: ctx.ClusterName,
-		teleport.SSHSessionID:           string(ctx.session.id),
+		teleport.SSHSessionID:           string(ctx.SessionID()),
 	}
 
 	for k, v := range envs {

--- a/lib/utils/conv.go
+++ b/lib/utils/conv.go
@@ -19,7 +19,6 @@ package utils
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/gravitational/trace"
 )
@@ -53,10 +52,10 @@ import (
 func ObjectToStruct(in interface{}, out interface{}) error {
 	bytes, err := json.Marshal(in)
 	if err != nil {
-		return trace.Wrap(err, fmt.Sprintf("failed to marshal %v, %v", in, err))
+		return trace.Wrap(err, "failed to marshal %v, %v", in, err)
 	}
 	if err := json.Unmarshal(bytes, out); err != nil {
-		return trace.Wrap(err, fmt.Sprintf("failed to unmarshal %v into %T, %v", in, out, err))
+		return trace.Wrap(err, "failed to unmarshal %v into %T, %v", in, out, err)
 	}
 	return nil
 }


### PR DESCRIPTION
 * Fix a data race in the locking test.
 * Bump the timeout on AgentForward test.

Updates https://github.com/gravitational/teleport/issues/4653.
Requires https://github.com/gravitational/teleport.e/pull/181.