### PR TITLE
tsh login error contextual message

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1663,7 +1663,12 @@ func (tc *TeleportClient) LogoutAll() error {
 // If 'activateKey' is true, saves the received session cert into the local
 // keystore (and into the ssh-agent) for future use.
 //
-func (tc *TeleportClient) Login(ctx context.Context, activateKey bool) (*Key, error) {
+func (tc *TeleportClient) Login(ctx context.Context, activateKey bool) (key *Key, err error) {
+	defer func() {
+		// Wrap error with user friendly message about tsh profile context
+		err = trace.WrapWithMessage(err, "for user %v on %v", tc.Username, tc.WebProxyAddr)
+	}()
+
 	// preserve original web proxy host that could have
 	webProxyHost, _ := tc.WebProxyHostPort()
 
@@ -1676,7 +1681,7 @@ func (tc *TeleportClient) Login(ctx context.Context, activateKey bool) (*Key, er
 
 	// generate a new keypair. the public key will be signed via proxy if client's
 	// password+OTP are valid
-	key, err := NewKey()
+	key, err = NewKey()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Wrap TeleportClient.Login error with a contextual message about the login attempt. 

Before: 
`error: Get "https://proxy.example.com:3080/v1/webapi/ping": dial tcp 127.0.0.1:3080: connect: connection refused`

After:
`error: Get "https://proxy.example.com:3080/v1/webapi/ping": dial tcp 127.0.0.1:3080: connect: connection refused, for user teleport on proxy.example.com:3080`

Closes #3010 