### PR TITLE
Fixing extra s/admins/admin in examples resources 

### DIFF
--- a/examples/resources/github.yaml
+++ b/examples/resources/github.yaml
@@ -1,7 +1,7 @@
 kind: github
 version: v3
 metadata:
-  name: new_github_connector
+  name: github
 spec:
   # Github OAuth app client ID
   client_id: <client-id>
@@ -16,6 +16,6 @@ spec:
   # mapping of Github team memberships to Teleport cluster roles
   teams_to_logins:
     - organization: <github-org>
-      team: admins
+      team: <github-team>
       logins:
         - "admin"

--- a/examples/resources/oidc-connector.yaml
+++ b/examples/resources/oidc-connector.yaml
@@ -17,4 +17,4 @@ spec:
   issuer_url: https://<issuer-url>
   scope: [<scope value>]
   claims_to_roles:
-    - {claim: "hd", value: "example.com", roles: ["admins"]}
+    - {claim: "hd", value: "example.com", roles: ["admin"]}


### PR DESCRIPTION
Part fix for https://github.com/gravitational/teleport/issues/4682