### PR TITLE
cache read safety

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -18,7 +18,7 @@ package cache
 
 import (
 	"context"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/gravitational/teleport"
@@ -31,10 +31,16 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
+	"go.uber.org/atomic"
 )
+
+func tombstoneKey() []byte {
+	return backend.Key("cache", teleport.Version, "tombstone", "ok")
+}
 
 // ForAuth sets up watch configuration for the auth server
 func ForAuth(cfg Config) Config {
+	cfg.target = "auth"
 	cfg.Watches = []services.WatchKind{
 		{Kind: services.KindCertAuthority, LoadSecrets: true},
 		{Kind: services.KindClusterName},
@@ -46,6 +52,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: services.KindNamespace},
 		{Kind: services.KindNode},
 		{Kind: services.KindProxy},
+		{Kind: services.KindAuthServer},
 		{Kind: services.KindReverseTunnel},
 		{Kind: services.KindTunnelConnection},
 		{Kind: services.KindAccessRequest},
@@ -60,6 +67,7 @@ func ForAuth(cfg Config) Config {
 
 // ForProxy sets up watch configuration for proxy
 func ForProxy(cfg Config) Config {
+	cfg.target = "proxy"
 	cfg.Watches = []services.WatchKind{
 		{Kind: services.KindCertAuthority, LoadSecrets: false},
 		{Kind: services.KindClusterName},
@@ -83,6 +91,7 @@ func ForProxy(cfg Config) Config {
 
 // ForRemoteProxy sets up watch configuration for remote proxies.
 func ForRemoteProxy(cfg Config) Config {
+	cfg.target = "remote-proxy"
 	cfg.Watches = []services.WatchKind{
 		{Kind: services.KindCertAuthority, LoadSecrets: false},
 		{Kind: services.KindClusterName},
@@ -107,6 +116,7 @@ func ForRemoteProxy(cfg Config) Config {
 //
 // ForOldRemoteProxy sets up watch configuration for older remote proxies.
 func ForOldRemoteProxy(cfg Config) Config {
+	cfg.target = "remote-proxy-old"
 	cfg.Watches = []services.WatchKind{
 		{Kind: services.KindCertAuthority, LoadSecrets: false},
 		{Kind: services.KindClusterName},
@@ -119,7 +129,6 @@ func ForOldRemoteProxy(cfg Config) Config {
 		{Kind: services.KindAuthServer},
 		{Kind: services.KindReverseTunnel},
 		{Kind: services.KindTunnelConnection},
-		{Kind: services.KindKubeService},
 	}
 	cfg.QueueSize = defaults.ProxyQueueSize
 	return cfg
@@ -127,6 +136,7 @@ func ForOldRemoteProxy(cfg Config) Config {
 
 // ForNode sets up watch configuration for node
 func ForNode(cfg Config) Config {
+	cfg.target = "node"
 	cfg.Watches = []services.WatchKind{
 		{Kind: services.KindCertAuthority, LoadSecrets: false},
 		{Kind: services.KindClusterName},
@@ -144,6 +154,7 @@ func ForNode(cfg Config) Config {
 
 // ForKubernetes sets up watch configuration for a kubernetes service.
 func ForKubernetes(cfg Config) Config {
+	cfg.target = "kube"
 	cfg.Watches = []services.WatchKind{
 		{Kind: services.KindCertAuthority, LoadSecrets: false},
 		{Kind: services.KindClusterName},
@@ -159,6 +170,7 @@ func ForKubernetes(cfg Config) Config {
 
 // ForApps sets up watch configuration for apps.
 func ForApps(cfg Config) Config {
+	cfg.target = "apps"
 	cfg.Watches = []services.WatchKind{
 		{Kind: services.KindCertAuthority, LoadSecrets: false},
 		{Kind: services.KindClusterName},
@@ -184,8 +196,39 @@ type SetupConfigFn func(c Config) Config
 // This which can be used if the upstream AccessPoint goes offline
 type Cache struct {
 	Config
+
 	// Entry is a logging entry
 	*log.Entry
+
+	// rw is used to prevent reads of invalid cache states.  From a
+	// memory-safety perspective, this RWMutex is just used to protect
+	// the `ok` field.  *However*, cache reads must hold the read lock
+	// for the duration of the read, not just when checking the `ok`
+	// field.  Since the write lock must be held in order to modify
+	// the `ok` field, this serves to ensure that all in-progress reads
+	// complete *before* a reset can begin.
+	rw sync.RWMutex
+	// ok indicates whether the cache is in a valid state for reads.
+	// If `ok` is `false`, reads are forwarded directly to the backend.
+	ok bool
+
+	// generation is a counter that is incremented each time a healthy
+	// state is established.  A generation of zero means that a healthy
+	// state was never established.  Note that a generation of zero does
+	// not preclude `ok` being true in the case that we have loaded a
+	// previously healthy state from the backend.
+	generation *atomic.Uint64
+
+	// initOnce protects initC and initErr.
+	initOnce sync.Once
+	// initC is closed on the first attempt to initialize the
+	// cache, whether or not it is successful.  Once initC
+	// has returned, initErr is safe to read.
+	initC chan struct{}
+	// initErr is set if the first attempt to initialize the cache
+	// fails.
+	initErr error
+
 	// wrapper is a wrapper around cache backend that
 	// allows to set backend into failure mode,
 	// intercepting all calls and returning errors instead
@@ -208,12 +251,105 @@ type Cache struct {
 	appSessionCache    services.AppSession
 	eventsFanout       *services.Fanout
 
-	// closedFlag is set to indicate that the services are closed
-	closedFlag int32
+	// closed indicates that the cache has been closed
+	closed *atomic.Bool
+}
+
+func (c *Cache) setInitError(err error) {
+	c.initOnce.Do(func() {
+		c.initErr = err
+		close(c.initC)
+	})
+}
+
+// setReadOK updates Cache.ok, which determines whether the
+// cache is accessible for reads.
+func (c *Cache) setReadOK(ok bool) {
+	if ok == c.getReadOK() {
+		return
+	}
+	c.rw.Lock()
+	defer c.rw.Unlock()
+	c.ok = ok
+}
+
+func (c *Cache) getReadOK() (ok bool) {
+	c.rw.RLock()
+	defer c.rw.RUnlock()
+	return c.ok
+}
+
+// read acquires the cache read lock and selects the appropriate
+// target for read operations.  The returned guard *must* be
+// released to prevent deadlocks.
+func (c *Cache) read() (readGuard, error) {
+	if c.closed.Load() {
+		return readGuard{}, trace.Errorf("cache is closed")
+	}
+	c.rw.RLock()
+	if c.ok {
+		return readGuard{
+			trust:         c.trustCache,
+			clusterConfig: c.clusterConfigCache,
+			provisioner:   c.provisionerCache,
+			users:         c.usersCache,
+			access:        c.accessCache,
+			dynamicAccess: c.dynamicAccessCache,
+			presence:      c.presenceCache,
+			appSession:    c.appSessionCache,
+			release:       c.rw.RUnlock,
+		}, nil
+	}
+	c.rw.RUnlock()
+	return readGuard{
+		trust:         c.Config.Trust,
+		clusterConfig: c.Config.ClusterConfig,
+		provisioner:   c.Config.Provisioner,
+		users:         c.Config.Users,
+		access:        c.Config.Access,
+		dynamicAccess: c.Config.DynamicAccess,
+		presence:      c.Config.Presence,
+		appSession:    c.Config.AppSession,
+		release:       nil,
+	}, nil
+}
+
+// readGuard holds references to a "backend".  if the referenced
+// backed is the cache, then readGuard also holds the release
+// function for the read lock, and ensures that it is not
+// double-called.
+type readGuard struct {
+	trust         services.Trust
+	clusterConfig services.ClusterConfiguration
+	provisioner   services.Provisioner
+	users         services.UsersService
+	access        services.Access
+	dynamicAccess services.DynamicAccess
+	presence      services.Presence
+	appSession    services.AppSession
+	release       func()
+	released      bool
+}
+
+// Release releases the read lock if it is held.  This method
+// can be called multiple times, but is not thread-safe.
+func (r *readGuard) Release() {
+	if r.release != nil && !r.released {
+		r.release()
+		r.released = true
+	}
+}
+
+// IsCacheRead checks if this readGuard holds a cache reference.
+func (r *readGuard) IsCacheRead() bool {
+	return r.release != nil
 }
 
 // Config defines cache configuration parameters
 type Config struct {
+	// target is an identifying string that allows errors to
+	// indicate the target presets used (e.g. "auth").
+	target string
 	// Context is context for parent operations
 	Context context.Context
 	// Watches provides a list of resources
@@ -242,6 +378,12 @@ type Config struct {
 	Backend backend.Backend
 	// RetryPeriod is a period between cache retries on failures
 	RetryPeriod time.Duration
+	// WatcherInitTimeout is the maximum acceptable delay for an
+	// OpInit after a watcher has been started (default=1m).
+	WatcherInitTimeout time.Duration
+	// CacheInitTimeout is the maximum amount of time that cache.New
+	// will block, waiting for initialization (default=20s).
+	CacheInitTimeout time.Duration
 	// EventsC is a channel for event notifications,
 	// used in tests
 	EventsC chan Event
@@ -319,6 +461,12 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.RetryPeriod == 0 {
 		c.RetryPeriod = defaults.HighResPollingPeriod
 	}
+	if c.WatcherInitTimeout == 0 {
+		c.WatcherInitTimeout = time.Minute
+	}
+	if c.CacheInitTimeout == 0 {
+		c.CacheInitTimeout = time.Second * 20
+	}
 	if c.Component == "" {
 		c.Component = teleport.ComponentCache
 	}
@@ -341,6 +489,9 @@ const (
 	WatcherStarted = "watcher_started"
 	// WatcherFailed is emitted when event watcher has failed
 	WatcherFailed = "watcher_failed"
+	// TombstoneWritten is emitted if cache is closed in a healthy
+	// state and successfully writes its tombstone.
+	TombstoneWritten = "tombstone_written"
 )
 
 // New creates a new instance of Cache
@@ -355,6 +506,8 @@ func New(config Config) (*Cache, error) {
 		ctx:                ctx,
 		cancel:             cancel,
 		Config:             config,
+		generation:         atomic.NewUint64(0),
+		initC:              make(chan struct{}),
 		trustCache:         local.NewCAService(wrapper),
 		clusterConfigCache: local.NewClusterConfigurationService(wrapper),
 		provisionerCache:   local.NewProvisioningService(wrapper),
@@ -367,23 +520,71 @@ func New(config Config) (*Cache, error) {
 		Entry: log.WithFields(log.Fields{
 			trace.Component: config.Component,
 		}),
+		closed: atomic.NewBool(false),
 	}
 	collections, err := setupCollections(cs, config.Watches)
 	if err != nil {
+		cs.Close()
 		return nil, trace.Wrap(err)
 	}
 	cs.collections = collections
 
-	err = cs.fetch(ctx)
-	if err != nil {
-		// "only recent" behavior does not tolerate
-		// stale data, so it has to initialize itself
-		// with recent data on startup or fail
-		if cs.OnlyRecent.Enabled {
-			return nil, trace.Wrap(err)
+	// if the ok tombstone is present, set the initial read state of the cache
+	// to ok. this tombstone's presence indicates that we are dealing with an
+	// on-disk cache produced by the same teleport version which gracefully shutdown
+	// while in an ok state.  We delete the tombstone rather than check for its
+	// presence to ensure self-healing in the event that the tombstone wasn't actually
+	// valid.  Note that setting the cache's read state to ok does not cause us to skip
+	// our normal init logic, it just means that reads against the local cache will
+	// be allowed in the event the init step fails before it starts applying.
+	// Note also that we aren't setting our event fanout system to an initialized state
+	// or incrementing the generation counter; this cache isn't so much "healthy" as it is
+	// "slightly preferable to an unreachable auth server".
+	err = cs.wrapper.Delete(ctx, tombstoneKey())
+	switch {
+	case err == nil:
+		if !cs.OnlyRecent.Enabled {
+			cs.setReadOK(true)
 		}
+	case trace.IsNotFound(err):
+		// do nothing
+	default:
+		cs.Close()
+		return nil, trace.Wrap(err)
 	}
-	go cs.update(ctx)
+
+	retry, err := utils.NewLinear(utils.LinearConfig{
+		Step: cs.Config.RetryPeriod / 10,
+		Max:  cs.Config.RetryPeriod,
+	})
+	if err != nil {
+		cs.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	go cs.update(ctx, retry)
+
+	select {
+	case <-cs.initC:
+		if cs.initErr != nil && cs.OnlyRecent.Enabled {
+			cs.Close()
+			return nil, trace.Wrap(cs.initErr)
+		}
+		if cs.initErr == nil {
+			cs.Infof("Cache %q first init succeeded.", cs.Config.target)
+		} else {
+			cs.WithError(cs.initErr).Warnf("Cache %q first init failed, continuing re-init attempts in background.", cs.Config.target)
+		}
+	case <-ctx.Done():
+		cs.Close()
+		return nil, trace.Wrap(ctx.Err(), "context closed during cache init")
+	case <-time.After(cs.Config.CacheInitTimeout):
+		if cs.OnlyRecent.Enabled {
+			cs.Close()
+			return nil, trace.ConnectionProblem(nil, "timeout waiting for cache init")
+		}
+		cs.Warningf("Cache init is taking too long, will continue in background.")
+	}
 	return cs, nil
 }
 
@@ -393,64 +594,68 @@ func New(config Config) (*Cache, error) {
 // to handle subscribers connected to the in-memory caches
 // instead of reading from the backend.
 func (c *Cache) NewWatcher(ctx context.Context, watch services.Watch) (services.Watcher, error) {
+Outer:
+	for _, requested := range watch.Kinds {
+		for _, configured := range c.Config.Watches {
+			if requested.Kind == configured.Kind {
+				continue Outer
+			}
+		}
+		return nil, trace.BadParameter("cache %q does not support watching resource %q", c.Config.target, requested.Kind)
+	}
 	return c.eventsFanout.NewWatcher(ctx, watch)
 }
 
-func (c *Cache) isClosed() bool {
-	return atomic.LoadInt32(&c.closedFlag) == 1
-}
-
-func (c *Cache) setClosed() {
-	atomic.StoreInt32(&c.closedFlag, 1)
-}
-
-func (c *Cache) update(ctx context.Context) {
-	retry, err := utils.NewLinear(utils.LinearConfig{
-		Step: c.RetryPeriod / 10,
-		Max:  c.RetryPeriod,
-	})
-	if err != nil {
-		c.Errorf("Bad retry parameters: %v", err)
-		return
-	}
+func (c *Cache) update(ctx context.Context, retry utils.Retry) {
+	defer func() {
+		c.Debugf("Cache is closing, returning from update loop.")
+		// ensure that close operations have been run
+		c.Close()
+		// run tombstone operations in an orphaned context
+		tombCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+		c.writeTombstone(tombCtx)
+	}()
+	timer := time.NewTimer(c.Config.WatcherInitTimeout)
 	for {
-		err := c.fetchAndWatch(ctx, retry)
+		err := c.fetchAndWatch(ctx, retry, timer)
+		c.setInitError(err)
+		if c.isClosing() {
+			return
+		}
 		if err != nil {
-			c.setCacheState(ctx, err)
-			if !c.isClosed() {
-				c.Warningf("Re-init the cache on error: %v.", trace.Unwrap(err))
+			c.Warningf("Re-init the cache on error: %v.", trace.Unwrap(err))
+			if c.OnlyRecent.Enabled {
+				c.setReadOK(false)
 			}
 		}
-		// if cache is reloading,
-		// all watchers will be out of sync, because
-		// cache will reload its own watcher to the backend,
-		// so signal closure to reset the watchers
-		c.eventsFanout.CloseWatchers()
 		// events cache should be closed as well
 		c.Debugf("Reloading %v.", retry)
 		select {
 		case <-retry.After():
 			retry.Inc()
 		case <-c.ctx.Done():
-			c.Debugf("Closed, returning from update loop.")
 			return
 		}
 	}
 }
 
-// setCacheState for "only recent" cache behavior will erase
-// the cache and set error mode to refuse to serve stale data,
-// otherwise does nothing
-func (c *Cache) setCacheState(ctx context.Context, err error) {
-	if !c.OnlyRecent.Enabled {
+// writeTombstone writes the cache tombstone.
+func (c *Cache) writeTombstone(ctx context.Context) {
+	if !c.getReadOK() || c.generation.Load() == 0 {
+		// state is unhealthy or was loaded from a previously
+		// entombed state; do nothing.
 		return
 	}
-	if err := c.eraseAll(ctx); err != nil {
-		if !c.isClosed() {
-			c.Warningf("Failed to erase the data: %v.", err)
-		}
+	item := backend.Item{
+		Key:   tombstoneKey(),
+		Value: []byte("{}"),
 	}
-	c.wrapper.SetReadError(trace.ConnectionProblem(err, "cache is unavailable"))
+	if _, err := c.wrapper.Create(ctx, item); err != nil {
+		c.Warningf("Failed to set tombstone: %v", err)
+	} else {
+		c.notify(ctx, Event{Type: TombstoneWritten})
+	}
 }
 
 // setTTL overrides TTL supplied by the resource
@@ -470,14 +675,14 @@ func (c *Cache) setTTL(r services.Resource) {
 	r.SetTTL(c.Clock, c.PreferRecent.MaxTTL)
 }
 
-func (c *Cache) notify(event Event) {
+func (c *Cache) notify(ctx context.Context, event Event) {
 	if c.EventsC == nil {
 		return
 	}
 	select {
 	case c.EventsC <- event:
 		return
-	case <-c.ctx.Done():
+	case <-ctx.Done():
 		return
 	}
 }
@@ -517,7 +722,7 @@ func (c *Cache) notify(event Event) {
 //   we assume that this cache will eventually end up in a correct state
 //   potentially lagging behind the state of the database.
 //
-func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry) error {
+func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry, timer *time.Timer) error {
 	watcher, err := c.Events.NewWatcher(c.ctx, services.Watch{
 		QueueSize:       c.QueueSize,
 		Name:            c.Component,
@@ -525,10 +730,20 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry) error {
 		MetricComponent: c.MetricComponent,
 	})
 	if err != nil {
-		c.notify(Event{Type: WatcherFailed})
+		c.notify(c.ctx, Event{Type: WatcherFailed})
 		return trace.Wrap(err)
 	}
 	defer watcher.Close()
+
+	// ensure that the timer is stopped and drained
+	timer.Stop()
+	select {
+	case <-timer.C:
+	default:
+	}
+	// set timer to watcher init timeout
+	timer.Reset(c.Config.WatcherInitTimeout)
+
 	// before fetch, make sure watcher is synced by receiving init event,
 	// to avoid the scenario:
 	// 1. Cache process:   w = NewWatcher()
@@ -552,14 +767,39 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry) error {
 		if event.Type != backend.OpInit {
 			return trace.BadParameter("expected init event, got %v instead", event.Type)
 		}
+	case <-timer.C:
+		return trace.ConnectionProblem(nil, "timeout waiting for watcher init")
 	}
-	err = c.fetch(ctx)
+	apply, err := c.fetch(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	// apply will mutate cache, and possibly leave it in an invalid state
+	// if an error occurs, so ensure that cache is not read.
+	c.setReadOK(false)
+	err = apply(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// apply was successful; cache is now readable.
+	c.generation.Inc()
+	c.setReadOK(true)
+	c.setInitError(nil)
+
+	// watchers have been queuing up since the last time
+	// the cache was in a healthy state; broadcast OpInit.
+	// It is very important that OpInit is not broadcast until
+	// after we've placed the cache into a readable state.  This ensures
+	// that any derivative caches do not peform their fetch operations
+	// until this cache has finished its apply operations.
+	c.eventsFanout.SetInit()
+	defer c.eventsFanout.Reset()
+
 	retry.Reset()
-	c.wrapper.SetReadError(nil)
-	c.notify(Event{Type: WatcherStarted})
+
+	c.notify(c.ctx, Event{Type: WatcherStarted})
 	for {
 		select {
 		case <-watcher.Done():
@@ -571,18 +811,9 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry) error {
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			c.notify(Event{Event: event, Type: EventProcessed})
+			c.notify(c.ctx, Event{Event: event, Type: EventProcessed})
 		}
 	}
-}
-
-// eraseAll erases all the data from cache collections
-func (c *Cache) eraseAll(ctx context.Context) error {
-	var errors []error
-	for _, collection := range c.collections {
-		errors = append(errors, collection.erase(ctx))
-	}
-	return trace.NewAggregate(errors...)
 }
 
 func (c *Cache) watchKinds() []services.WatchKind {
@@ -593,20 +824,48 @@ func (c *Cache) watchKinds() []services.WatchKind {
 	return out
 }
 
+// isClosing checks if the cache has begun closing.
+func (c *Cache) isClosing() bool {
+	if c.closed.Load() {
+		// closing due to Close being called
+		return true
+	}
+
+	select {
+	case <-c.ctx.Done():
+		// closing due to context cancellation
+		return true
+	default:
+		// not closing
+		return false
+	}
+}
+
 // Close closes all outstanding and active cache operations
 func (c *Cache) Close() error {
+	c.closed.Store(true)
 	c.cancel()
-	c.setClosed()
+	c.eventsFanout.Close()
 	return nil
 }
 
-func (c *Cache) fetch(ctx context.Context) error {
+func (c *Cache) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
+	applyfns := make([]func(ctx context.Context) error, 0, len(c.collections))
 	for _, collection := range c.collections {
-		if err := collection.fetch(ctx); err != nil {
-			return trace.Wrap(err)
+		applyfn, err := collection.fetch(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
+		applyfns = append(applyfns, applyfn)
 	}
-	return nil
+	return func(ctx context.Context) error {
+		for _, applyfn := range applyfns {
+			if err := applyfn(ctx); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *Cache) processEvent(ctx context.Context, event services.Event) error {
@@ -625,121 +884,228 @@ func (c *Cache) processEvent(ctx context.Context, event services.Event) error {
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
 func (c *Cache) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
-	ca, err := c.trustCache.GetCertAuthority(id, loadSigningKeys, services.AddOptions(opts, services.SkipValidation())...)
-	// this is to prevent unexpected situations during cache reload
-	if trace.IsNotFound(err) {
-		return c.Trust.GetCertAuthority(id, loadSigningKeys, services.AddOptions(opts, services.SkipValidation())...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return ca, err
+	defer rg.Release()
+	ca, err := rg.trust.GetCertAuthority(id, loadSigningKeys, services.AddOptions(opts, services.SkipValidation())...)
+	if trace.IsNotFound(err) && rg.IsCacheRead() {
+		// release read lock early
+		rg.Release()
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if ca, err := c.Config.Trust.GetCertAuthority(id, loadSigningKeys, services.AddOptions(opts, services.SkipValidation())...); err == nil {
+			return ca, nil
+		}
+	}
+	return ca, trace.Wrap(err)
 }
 
 // GetCertAuthorities returns a list of authorities of a given type
 // loadSigningKeys controls whether signing keys should be loaded or not
 func (c *Cache) GetCertAuthorities(caType services.CertAuthType, loadSigningKeys bool, opts ...services.MarshalOption) ([]services.CertAuthority, error) {
-	return c.trustCache.GetCertAuthorities(caType, loadSigningKeys, services.AddOptions(opts, services.SkipValidation())...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.trust.GetCertAuthorities(caType, loadSigningKeys, services.AddOptions(opts, services.SkipValidation())...)
 }
 
 // GetStaticTokens gets the list of static tokens used to provision nodes.
 func (c *Cache) GetStaticTokens() (services.StaticTokens, error) {
-	return c.clusterConfigCache.GetStaticTokens()
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.clusterConfig.GetStaticTokens()
 }
 
 // GetTokens returns all active (non-expired) provisioning tokens
 func (c *Cache) GetTokens(opts ...services.MarshalOption) ([]services.ProvisionToken, error) {
-	return c.provisionerCache.GetTokens(services.AddOptions(opts, services.SkipValidation())...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.provisioner.GetTokens(services.AddOptions(opts, services.SkipValidation())...)
 }
 
 // GetToken finds and returns token by ID
-func (c *Cache) GetToken(token string) (services.ProvisionToken, error) {
-	t, err := c.provisionerCache.GetToken(token)
-	if trace.IsNotFound(err) {
-		return c.Provisioner.GetToken(token)
+func (c *Cache) GetToken(name string) (services.ProvisionToken, error) {
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return t, err
+	defer rg.Release()
+
+	token, err := rg.provisioner.GetToken(name)
+	if trace.IsNotFound(err) && rg.IsCacheRead() {
+		// release read lock early
+		rg.Release()
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if token, err := c.Config.Provisioner.GetToken(name); err == nil {
+			return token, nil
+		}
+	}
+	return token, trace.Wrap(err)
 }
 
 // GetClusterConfig gets services.ClusterConfig from the backend.
 func (c *Cache) GetClusterConfig(opts ...services.MarshalOption) (services.ClusterConfig, error) {
-	config, err := c.clusterConfigCache.GetClusterConfig(services.AddOptions(opts, services.SkipValidation())...)
-	if trace.IsNotFound(err) {
-		return c.ClusterConfig.GetClusterConfig(opts...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return config, err
+	defer rg.Release()
+	return rg.clusterConfig.GetClusterConfig(services.AddOptions(opts, services.SkipValidation())...)
 }
 
 // GetClusterName gets the name of the cluster from the backend.
 func (c *Cache) GetClusterName(opts ...services.MarshalOption) (services.ClusterName, error) {
-	clusterName, err := c.clusterConfigCache.GetClusterName(services.AddOptions(opts, services.SkipValidation())...)
-	if trace.IsNotFound(err) {
-		return c.ClusterConfig.GetClusterName(opts...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return clusterName, err
+	defer rg.Release()
+	return rg.clusterConfig.GetClusterName(services.AddOptions(opts, services.SkipValidation())...)
 }
 
 // GetRoles is a part of auth.AccessPoint implementation
 func (c *Cache) GetRoles() ([]services.Role, error) {
-	return c.accessCache.GetRoles()
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.access.GetRoles()
 }
 
 // GetRole is a part of auth.AccessPoint implementation
 func (c *Cache) GetRole(name string) (services.Role, error) {
-	role, err := c.accessCache.GetRole(name)
-	if trace.IsNotFound(err) {
-		return c.Access.GetRole(name)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	role, err := rg.access.GetRole(name)
+	if trace.IsNotFound(err) && rg.IsCacheRead() {
+		// release read lock early
+		rg.Release()
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if role, err := c.Config.Access.GetRole(name); err == nil {
+			return role, nil
+		}
 	}
 	return role, err
 }
 
 // GetNamespace returns namespace
 func (c *Cache) GetNamespace(name string) (*services.Namespace, error) {
-	return c.presenceCache.GetNamespace(name)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetNamespace(name)
 }
 
 // GetNamespaces is a part of auth.AccessPoint implementation
 func (c *Cache) GetNamespaces() ([]services.Namespace, error) {
-	return c.presenceCache.GetNamespaces()
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetNamespaces()
 }
 
 // GetNodes is a part of auth.AccessPoint implementation
 func (c *Cache) GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error) {
-	return c.presenceCache.GetNodes(namespace, opts...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetNodes(namespace, opts...)
 }
 
 // GetAuthServers returns a list of registered servers
 func (c *Cache) GetAuthServers() ([]services.Server, error) {
-	return c.presenceCache.GetAuthServers()
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetAuthServers()
 }
 
 // GetReverseTunnels is a part of auth.AccessPoint implementation
 func (c *Cache) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
-	return c.presenceCache.GetReverseTunnels(services.AddOptions(opts, services.SkipValidation())...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetReverseTunnels(services.AddOptions(opts, services.SkipValidation())...)
 }
 
 // GetProxies is a part of auth.AccessPoint implementation
 func (c *Cache) GetProxies() ([]services.Server, error) {
-	return c.presenceCache.GetProxies()
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetProxies()
 }
 
 // GetRemoteClusters returns a list of remote clusters
 func (c *Cache) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
-	return c.presenceCache.GetRemoteClusters(opts...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetRemoteClusters(opts...)
 }
 
 // GetRemoteCluster returns a remote cluster by name
 func (c *Cache) GetRemoteCluster(clusterName string) (services.RemoteCluster, error) {
-	return c.presenceCache.GetRemoteCluster(clusterName)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetRemoteCluster(clusterName)
 }
 
 // GetUser is a part of auth.AccessPoint implementation.
 func (c *Cache) GetUser(name string, withSecrets bool) (user services.User, err error) {
 	if withSecrets { // cache never tracks user secrets
-		return c.Users.GetUser(name, withSecrets)
+		return c.Config.Users.GetUser(name, withSecrets)
 	}
-	u, err := c.usersCache.GetUser(name, withSecrets)
-	if trace.IsNotFound(err) {
-		return c.Users.GetUser(name, withSecrets)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	return u, err
+	defer rg.Release()
+
+	user, err = rg.users.GetUser(name, withSecrets)
+	if trace.IsNotFound(err) && rg.IsCacheRead() {
+		// release read lock early
+		rg.Release()
+		// fallback is sane because method is never used
+		// in construction of derivative caches.
+		if user, err := c.Config.Users.GetUser(name, withSecrets); err == nil {
+			return user, nil
+		}
+	}
+	return user, trace.Wrap(err)
 }
 
 // GetUsers is a part of auth.AccessPoint implementation
@@ -747,34 +1113,64 @@ func (c *Cache) GetUsers(withSecrets bool) (users []services.User, err error) {
 	if withSecrets { // cache never tracks user secrets
 		return c.Users.GetUsers(withSecrets)
 	}
-	return c.usersCache.GetUsers(withSecrets)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.users.GetUsers(withSecrets)
 }
 
 // GetTunnelConnections is a part of auth.AccessPoint implementation
 // GetTunnelConnections are not using recent cache as they are designed
 // to be called periodically and always return fresh data
 func (c *Cache) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
-	return c.presenceCache.GetTunnelConnections(clusterName, opts...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetTunnelConnections(clusterName, opts...)
 }
 
 // GetAllTunnelConnections is a part of auth.AccessPoint implementation
 // GetAllTunnelConnections are not using recent cache, as they are designed
 // to be called periodically and always return fresh data
 func (c *Cache) GetAllTunnelConnections(opts ...services.MarshalOption) (conns []services.TunnelConnection, err error) {
-	return c.presenceCache.GetAllTunnelConnections(opts...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetAllTunnelConnections(opts...)
 }
 
 // GetKubeServices is a part of auth.AccessPoint implementation
 func (c *Cache) GetKubeServices(ctx context.Context) ([]services.Server, error) {
-	return c.presenceCache.GetKubeServices(ctx)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetKubeServices(ctx)
 }
 
 // GetAppServers gets all application servers.
 func (c *Cache) GetAppServers(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]services.Server, error) {
-	return c.presenceCache.GetAppServers(ctx, namespace, opts...)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.presence.GetAppServers(ctx, namespace, opts...)
 }
 
 // GetAppSession gets an application web session.
 func (c *Cache) GetAppSession(ctx context.Context, req services.GetAppSessionRequest) (services.WebSession, error) {
-	return c.appSessionCache.GetAppSession(ctx, req)
+	rg, err := c.read()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer rg.Release()
+	return rg.appSession.GetAppSession(ctx, req)
 }

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -30,8 +30,10 @@ import (
 // collection is responsible for managing collection
 // of resources updates
 type collection interface {
-	// fetch fetches resources
-	fetch(ctx context.Context) error
+	// fetch fetches resources and returns a function which
+	// will apply said resources to the cache.  fetch *must*
+	// not mutate cache state outside of the apply function.
+	fetch(ctx context.Context) (apply func(ctx context.Context) error, err error)
 	// process processes event
 	processEvent(ctx context.Context, e services.Event) error
 	// watchKind returns a watch
@@ -158,20 +160,22 @@ func (r *accessRequest) erase(ctx context.Context) error {
 	return nil
 }
 
-func (r *accessRequest) fetch(ctx context.Context) error {
+func (r *accessRequest) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := r.DynamicAccess.GetAccessRequests(ctx, services.AccessRequestFilter{})
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := r.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		if err := r.dynamicAccessCache.UpsertAccessRequest(ctx, resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := r.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			if err := r.dynamicAccessCache.UpsertAccessRequest(ctx, resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (r *accessRequest) processEvent(ctx context.Context, event services.Event) error {
@@ -221,20 +225,22 @@ func (c *tunnelConnection) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *tunnelConnection) fetch(ctx context.Context) error {
+func (c *tunnelConnection) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Presence.GetAllTunnelConnections()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		if err := c.presenceCache.UpsertTunnelConnection(resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			if err := c.presenceCache.UpsertTunnelConnection(resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *tunnelConnection) processEvent(ctx context.Context, event services.Event) error {
@@ -284,20 +290,22 @@ func (c *remoteCluster) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *remoteCluster) fetch(ctx context.Context) error {
+func (c *remoteCluster) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Presence.GetRemoteClusters()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		if err := c.presenceCache.CreateRemoteCluster(resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			if err := c.presenceCache.CreateRemoteCluster(resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *remoteCluster) processEvent(ctx context.Context, event services.Event) error {
@@ -354,21 +362,23 @@ func (c *reverseTunnel) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *reverseTunnel) fetch(ctx context.Context) error {
+func (c *reverseTunnel) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Presence.GetReverseTunnels(services.SkipValidation())
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		c.setTTL(resource)
-		if err := c.presenceCache.UpsertReverseTunnel(resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			c.setTTL(resource)
+			if err := c.presenceCache.UpsertReverseTunnel(resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *reverseTunnel) processEvent(ctx context.Context, event services.Event) error {
@@ -418,23 +428,25 @@ func (c *proxy) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *proxy) fetch(ctx context.Context) error {
+func (c *proxy) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Presence.GetProxies()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-
-	for _, resource := range resources {
-		c.setTTL(resource)
-		if err := c.presenceCache.UpsertProxy(resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+
+		for _, resource := range resources {
+			c.setTTL(resource)
+			if err := c.presenceCache.UpsertProxy(resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *proxy) processEvent(ctx context.Context, event services.Event) error {
@@ -484,23 +496,25 @@ func (c *authServer) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *authServer) fetch(ctx context.Context) error {
+func (c *authServer) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Presence.GetAuthServers()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-
-	for _, resource := range resources {
-		c.setTTL(resource)
-		if err := c.presenceCache.UpsertAuthServer(resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+
+		for _, resource := range resources {
+			c.setTTL(resource)
+			if err := c.presenceCache.UpsertAuthServer(resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *authServer) processEvent(ctx context.Context, event services.Event) error {
@@ -550,21 +564,23 @@ func (c *node) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *node) fetch(ctx context.Context) error {
+func (c *node) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Presence.GetNodes(defaults.Namespace)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		c.setTTL(resource)
-		if _, err := c.presenceCache.UpsertNode(resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			c.setTTL(resource)
+			if _, err := c.presenceCache.UpsertNode(resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *node) processEvent(ctx context.Context, event services.Event) error {
@@ -614,21 +630,23 @@ func (c *namespace) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *namespace) fetch(ctx context.Context) error {
+func (c *namespace) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Presence.GetNamespaces()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		c.setTTL(&resource)
-		if err := c.presenceCache.UpsertNamespace(resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			c.setTTL(&resource)
+			if err := c.presenceCache.UpsertNamespace(resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *namespace) processEvent(ctx context.Context, event services.Event) error {
@@ -688,47 +706,58 @@ func (c *certAuthority) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *certAuthority) fetch(ctx context.Context) error {
-	if err := c.updateCertAuthorities(services.HostCA); err != nil {
-		return trace.Wrap(err)
+func (c *certAuthority) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
+	applyHostCAs, err := c.fetchCertAuthorities(services.HostCA)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	if err := c.updateCertAuthorities(services.UserCA); err != nil {
-		return trace.Wrap(err)
+
+	applyUserCAs, err := c.fetchCertAuthorities(services.UserCA)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-	if err := c.updateCertAuthorities(services.JWTSigner); err != nil {
-		// DELETE IN: 5.1
-		//
-		// All clusters will support JWT signers in 5.1.
-		if strings.Contains(err.Error(), "authority type is not supported") {
-			return nil
+
+	applyJWTSigners, err := c.fetchCertAuthorities(services.JWTSigner)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return func(ctx context.Context) error {
+		if err := applyHostCAs(ctx); err != nil {
+			return trace.Wrap(err)
 		}
-		return trace.Wrap(err)
-	}
-	return nil
+		if err := applyUserCAs(ctx); err != nil {
+			return trace.Wrap(err)
+		}
+		return trace.Wrap(applyJWTSigners(ctx))
+	}, nil
 }
 
-func (c *certAuthority) updateCertAuthorities(caType services.CertAuthType) error {
+func (c *certAuthority) fetchCertAuthorities(caType services.CertAuthType) (apply func(ctx context.Context) error, err error) {
 	authorities, err := c.Trust.GetCertAuthorities(caType, c.watch.LoadSecrets, services.SkipValidation())
 	if err != nil {
 		// DELETE IN: 5.1
 		//
 		// All clusters will support JWT signers in 5.1.
-		if !strings.Contains(err.Error(), "authority type is not supported") {
-			return trace.Wrap(err)
+		if strings.Contains(err.Error(), "authority type is not supported") {
+			return func(ctx context.Context) error { return nil }, nil
 		}
+		return nil, trace.Wrap(err)
 	}
-	if err := c.trustCache.DeleteAllCertAuthorities(caType); err != nil {
-		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
+	return func(ctx context.Context) error {
+		if err := c.trustCache.DeleteAllCertAuthorities(caType); err != nil {
+			if !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
 		}
-	}
-	for _, resource := range authorities {
-		c.setTTL(resource)
-		if err := c.trustCache.UpsertCertAuthority(resource); err != nil {
-			return trace.Wrap(err)
+		for _, resource := range authorities {
+			c.setTTL(resource)
+			if err := c.trustCache.UpsertCertAuthority(resource); err != nil {
+				return trace.Wrap(err)
+			}
 		}
-	}
-	return nil
+		return nil
+	}, nil
 }
 
 func (c *certAuthority) processEvent(ctx context.Context, event services.Event) error {
@@ -751,12 +780,6 @@ func (c *certAuthority) processEvent(ctx context.Context, event services.Event) 
 		resource, ok := event.Resource.(services.CertAuthority)
 		if !ok {
 			return trace.BadParameter("unexpected type %T", event.Resource)
-		}
-		// DELETE IN: 5.1.
-		//
-		// All clusters will support JWT signers in 5.1.
-		if resource.GetType() == services.JWTSigner {
-			return nil
 		}
 		c.setTTL(resource)
 		if err := c.trustCache.UpsertCertAuthority(resource); err != nil {
@@ -788,23 +811,31 @@ func (c *staticTokens) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *staticTokens) fetch(ctx context.Context) error {
+func (c *staticTokens) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
+	var noTokens bool
 	staticTokens, err := c.ClusterConfig.GetStaticTokens()
 	if err != nil {
 		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
-		if err := c.erase(ctx); err != nil {
+		noTokens = true
+	}
+	return func(ctx context.Context) error {
+		// either zero or one instance exists, so we either erase or
+		// update, but not both.
+		if noTokens {
+			if err := c.erase(ctx); err != nil {
+				return trace.Wrap(err)
+			}
+			return nil
+		}
+		c.setTTL(staticTokens)
+		err = c.clusterConfigCache.SetStaticTokens(staticTokens)
+		if err != nil {
 			return trace.Wrap(err)
 		}
 		return nil
-	}
-	c.setTTL(staticTokens)
-	err = c.clusterConfigCache.SetStaticTokens(staticTokens)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+	}, nil
 }
 
 func (c *staticTokens) processEvent(ctx context.Context, event services.Event) error {
@@ -854,21 +885,23 @@ func (c *provisionToken) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *provisionToken) fetch(ctx context.Context) error {
+func (c *provisionToken) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	tokens, err := c.Provisioner.GetTokens()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range tokens {
-		c.setTTL(resource)
-		if err := c.provisionerCache.UpsertToken(resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range tokens {
+			c.setTTL(resource)
+			if err := c.provisionerCache.UpsertToken(resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *provisionToken) processEvent(ctx context.Context, event services.Event) error {
@@ -919,24 +952,32 @@ func (c *clusterConfig) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *clusterConfig) fetch(ctx context.Context) error {
+func (c *clusterConfig) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
+	var noConfig bool
 	clusterConfig, err := c.ClusterConfig.GetClusterConfig()
 	if err != nil {
 		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
-		if err := c.erase(ctx); err != nil {
-			return trace.Wrap(err)
+		noConfig = true
+	}
+	return func(ctx context.Context) error {
+		// either zero or one instance exists, so we either erase or
+		// update, but not both.
+		if noConfig {
+			if err := c.erase(ctx); err != nil {
+				return trace.Wrap(err)
+			}
+			return nil
+		}
+		c.setTTL(clusterConfig)
+		if err := c.clusterConfigCache.SetClusterConfig(clusterConfig); err != nil {
+			if !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
 		}
 		return nil
-	}
-	c.setTTL(clusterConfig)
-	if err := c.clusterConfigCache.SetClusterConfig(clusterConfig); err != nil {
-		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-	}
-	return nil
+	}, nil
 }
 
 func (c *clusterConfig) processEvent(ctx context.Context, event services.Event) error {
@@ -987,24 +1028,32 @@ func (c *clusterName) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *clusterName) fetch(ctx context.Context) error {
+func (c *clusterName) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
+	var noName bool
 	clusterName, err := c.ClusterConfig.GetClusterName()
 	if err != nil {
 		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
-		if err := c.erase(ctx); err != nil {
-			return trace.Wrap(err)
+		noName = true
+	}
+	return func(ctx context.Context) error {
+		// either zero or one instance exists, so we either erase or
+		// update, but not both.
+		if noName {
+			if err := c.erase(ctx); err != nil {
+				return trace.Wrap(err)
+			}
+			return nil
+		}
+		c.setTTL(clusterName)
+		if err := c.clusterConfigCache.UpsertClusterName(clusterName); err != nil {
+			if !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
 		}
 		return nil
-	}
-	c.setTTL(clusterName)
-	if err := c.clusterConfigCache.UpsertClusterName(clusterName); err != nil {
-		if !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-	}
-	return nil
+	}, nil
 }
 
 func (c *clusterName) processEvent(ctx context.Context, event services.Event) error {
@@ -1054,21 +1103,23 @@ func (c *user) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *user) fetch(ctx context.Context) error {
+func (c *user) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Users.GetUsers(false)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		c.setTTL(resource)
-		if err := c.usersCache.UpsertUser(resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			c.setTTL(resource)
+			if err := c.usersCache.UpsertUser(resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *user) processEvent(ctx context.Context, event services.Event) error {
@@ -1119,21 +1170,23 @@ func (c *role) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *role) fetch(ctx context.Context) error {
+func (c *role) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Access.GetRoles()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		c.setTTL(resource)
-		if err := c.accessCache.UpsertRole(ctx, resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			c.setTTL(resource)
+			if err := c.accessCache.UpsertRole(ctx, resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *role) processEvent(ctx context.Context, event services.Event) error {
@@ -1183,21 +1236,23 @@ func (a *appServer) erase(ctx context.Context) error {
 	return nil
 }
 
-func (a *appServer) fetch(ctx context.Context) error {
+func (a *appServer) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := a.Presence.GetAppServers(ctx, defaults.Namespace)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := a.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		a.setTTL(resource)
-		if _, err := a.presenceCache.UpsertAppServer(ctx, resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := a.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			a.setTTL(resource)
+			if _, err := a.presenceCache.UpsertAppServer(ctx, resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (a *appServer) processEvent(ctx context.Context, event services.Event) error {
@@ -1245,21 +1300,23 @@ func (a *appSession) erase(ctx context.Context) error {
 	return nil
 }
 
-func (a *appSession) fetch(ctx context.Context) error {
+func (a *appSession) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := a.AppSession.GetAppSessions(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	if err := a.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, resource := range resources {
-		a.setTTL(resource)
-		if err := a.appSessionCache.UpsertAppSession(ctx, resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := a.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+		for _, resource := range resources {
+			a.setTTL(resource)
+			if err := a.appSessionCache.UpsertAppSession(ctx, resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (a *appSession) processEvent(ctx context.Context, event services.Event) error {
@@ -1309,23 +1366,24 @@ func (c *kubeService) erase(ctx context.Context) error {
 	return nil
 }
 
-func (c *kubeService) fetch(ctx context.Context) error {
+func (c *kubeService) fetch(ctx context.Context) (apply func(ctx context.Context) error, err error) {
 	resources, err := c.Presence.GetKubeServices(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-
-	if err := c.erase(ctx); err != nil {
-		return trace.Wrap(err)
-	}
-
-	for _, resource := range resources {
-		c.setTTL(resource)
-		if err := c.presenceCache.UpsertKubeService(ctx, resource); err != nil {
+	return func(ctx context.Context) error {
+		if err := c.erase(ctx); err != nil {
 			return trace.Wrap(err)
 		}
-	}
-	return nil
+
+		for _, resource := range resources {
+			c.setTTL(resource)
+			if err := c.presenceCache.UpsertKubeService(ctx, resource); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}, nil
 }
 
 func (c *kubeService) processEvent(ctx context.Context, event services.Event) error {


### PR DESCRIPTION
Fixes #4183


This PR makes various changes to the cache system designed to prevent individual reads from returning categorically incorrect results (i.e. some combination of resources that would never have been returned by a read from the real backend), and to ensure that derivative caches (caches watching caches) converge toward an internally consistent state.  Note that this PR does not prevent results returned by cache reads from being old, and does not guarantee any particular temporal relationship between individual reads of separate key ranges.

#### Highlights

- Reads and resets are now mutually exclusive; a reset cannot occur during a read and a read cannot occur during a reset.
- Watchers created against an initializing or resetting cache do not receive their OpInit events until *after* the cache finishes resetting, meaning that reads performed after an OpInit is received are guaranteed to have a "happens after" time relationship to the event stream's starting point.
- Unhealthy caches forward reads to the upstream state (cache or backend).

#### Notes

Two separate reads are not guaranteed to be returned from the same "state".  Say that a client performs three reads in parallel.  During that time, the cache resets.  Each read may come from the pre-reset state of the cache, the post-reset state of the cache, or directly from the upstream state that the cache is replicating.  Each individual read will be *internally consistent* in that all resources pulled during that read came from the same state, but relative to one another there are no guarantees.

Similarly, reads performed after a watcher's `OpInit` event is received are guaranteed to have a "happens after" relationship to the event stream's starting point, but there are no guarantees about how *far* after.  If the target cache resets after the event stream starts, the watcher will receive an error, but that error may arrive *after* reads have been successfully executed against the post-reset state.  The implication of this is that downstream caches may temporarily display a mixed level of "staleness" between key ranges, but they will self-correct as resets propagate through the event system.

#### Future Work

I've currently left the resource expiry logic as-is, but I think there might be a better way to handle it.  Given that the resource expiry guarantees offered by the backend are so weak (a resource can continue to persist for a long time past its assigned expiry), it may be better to never expire resources in the cache.  If we lose connectivity with the auth server, it may be better to fully preserve the last known state, rather than trying to apply expiries that we have no way of knowing were actually observed.  If anything, assigning a global limit on how stale of a cache state we will accept, and then treating the entire cache as invalid after that point, might be a better way of doing things.  At the very least, it will allow us to be certain of the root cause of errors (a "cache is expired" error is unambiguous, but a "not found" error can mean any number of things).

Down the road, I would like to see us segregate secrets and resources into separate key ranges.  Because we have resource types which *may* contain secrets, we must introspect and potentially modify resources in order to correctly apply RBAC controls.  If we could apply RBAC controls against key ranges, then the entire cache could be modeled as a simple hashmap.  This would hugely simplify the cache and improve performance.  It would also open the door for supporting separately pluggable secret storage backends, which would be nice.