### PR TITLE
Fan out events in async mode for async recordings.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -300,6 +300,10 @@ var (
 	// usually is slow, e.g. once in 30 seconds
 	NetworkBackoffDuration = time.Second * 30
 
+	// AuditBackoffTimeout is a time out before audit logger will
+	// start loosing events
+	AuditBackoffTimeout = 5 * time.Second
+
 	// NetworkRetryDuration is a standard retry on network requests
 	// to retry quickly, e.g. once in one second
 	NetworkRetryDuration = time.Second
@@ -373,6 +377,9 @@ var (
 	// connections. These pings are needed to avoid timeouts on load balancers
 	// that don't respect TCP keep-alives.
 	SPDYPingPeriod = 30 * time.Second
+
+	// AsyncBufferSize is a default buffer size for async emitters
+	AsyncBufferSize = 1024
 )
 
 // Default connection limits, they can be applied separately on any of the Teleport

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 // TestProtoStreamer tests edge cases of proto streamer implementation
@@ -75,38 +77,38 @@ func TestProtoStreamer(t *testing.T) {
 				Uploader:       uploader,
 				MinUploadBytes: tc.minUploadBytes,
 			})
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			sid := session.ID(fmt.Sprintf("test-%v", i))
 			stream, err := streamer.CreateAuditStream(ctx, sid)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			events := tc.events
 			for _, event := range events {
 				err := stream.EmitAuditEvent(ctx, event)
 				if tc.err != nil {
-					assert.IsType(t, tc.err, err)
+					require.IsType(t, tc.err, err)
 					return
 				}
-				assert.Nil(t, err)
+				require.Nil(t, err)
 			}
 			err = stream.Complete(ctx)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			var outEvents []AuditEvent
 			uploads, err := uploader.ListUploads(ctx)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 			parts, err := uploader.GetParts(uploads[0].ID)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			for _, part := range parts {
 				reader := NewProtoReader(bytes.NewReader(part))
 				out, err := reader.ReadAll(ctx)
-				assert.Nil(t, err, "part crash %#v", part)
+				require.Nil(t, err, "part crash %#v", part)
 				outEvents = append(outEvents, out...)
 			}
 
-			assert.Equal(t, events, outEvents)
+			require.Equal(t, events, outEvents)
 		})
 	}
 }
@@ -121,11 +123,132 @@ func TestWriterEmitter(t *testing.T) {
 
 	for _, event := range events {
 		err := emitter.EmitAuditEvent(ctx, event)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	scanner := bufio.NewScanner(buf)
 	for i := 0; scanner.Scan(); i++ {
-		assert.Contains(t, scanner.Text(), events[i].GetCode())
+		require.Contains(t, scanner.Text(), events[i].GetCode())
+	}
+}
+
+func TestAsyncEmitter(t *testing.T) {
+	clock := clockwork.NewRealClock()
+	events := GenerateTestSession(SessionParams{PrintEvents: 20})
+
+	// Slow tests that async emitter does not block
+	// on slow emitters
+	t.Run("Slow", func(t *testing.T) {
+		emitter, err := NewAsyncEmitter(AsyncEmitterConfig{
+			Inner: &slowEmitter{clock: clock, timeout: time.Hour},
+		})
+		require.NoError(t, err)
+		defer emitter.Close()
+		ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+		defer cancel()
+		for _, event := range events {
+			err := emitter.EmitAuditEvent(ctx, event)
+			require.NoError(t, err)
+		}
+		require.NoError(t, ctx.Err())
+	})
+
+	// Receive makes sure all events are recevied in the same order as they are sent
+	t.Run("Receive", func(t *testing.T) {
+		chanEmitter := &channelEmitter{eventsCh: make(chan AuditEvent, len(events))}
+		emitter, err := NewAsyncEmitter(AsyncEmitterConfig{
+			Inner: chanEmitter,
+		})
+
+		require.NoError(t, err)
+		defer emitter.Close()
+		ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+		defer cancel()
+		for _, event := range events {
+			err := emitter.EmitAuditEvent(ctx, event)
+			require.NoError(t, err)
+		}
+
+		for i := 0; i < len(events); i++ {
+			select {
+			case event := <-chanEmitter.eventsCh:
+				require.Equal(t, events[i], event)
+			case <-time.After(time.Second):
+				t.Fatalf("timeout at event %v", i)
+			}
+		}
+	})
+
+	// Close makes sure that close cancels operations and context
+	t.Run("Close", func(t *testing.T) {
+		counter := &counterEmitter{}
+		emitter, err := NewAsyncEmitter(AsyncEmitterConfig{
+			Inner:      counter,
+			BufferSize: len(events),
+		})
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+		defer cancel()
+
+		emitsDoneC := make(chan struct{}, len(events))
+		for _, e := range events {
+			go func(event AuditEvent) {
+				emitter.EmitAuditEvent(ctx, event)
+				emitsDoneC <- struct{}{}
+			}(e)
+		}
+
+		// context will not wait until all events have been submitted
+		emitter.Close()
+		require.True(t, int(counter.count.Load()) <= len(events))
+
+		// make sure context is done to prevent context leaks
+		select {
+		case <-emitter.ctx.Done():
+		default:
+			t.Fatal("Context leak, should be closed")
+		}
+
+		// make sure all emit calls returned after context is done
+		for range events {
+			select {
+			case <-time.After(time.Second):
+				t.Fatal("Timed out waiting for emit events.")
+			case <-emitsDoneC:
+			}
+		}
+	})
+}
+
+type slowEmitter struct {
+	clock   clockwork.Clock
+	timeout time.Duration
+}
+
+func (s *slowEmitter) EmitAuditEvent(ctx context.Context, event AuditEvent) error {
+	<-s.clock.After(s.timeout)
+	return nil
+}
+
+type counterEmitter struct {
+	count atomic.Int64
+}
+
+func (c *counterEmitter) EmitAuditEvent(ctx context.Context, event AuditEvent) error {
+	c.count.Inc()
+	return nil
+}
+
+type channelEmitter struct {
+	eventsCh chan AuditEvent
+}
+
+func (c *channelEmitter) EmitAuditEvent(ctx context.Context, event AuditEvent) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case c.eventsCh <- event:
+		return nil
 	}
 }

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -1,0 +1,47 @@
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/lib/session"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamerCompleteEmpty makes sure that streamer Complete function
+// does not hang if streamer did not get a without getting a single event
+func TestStreamerCompleteEmpty(t *testing.T) {
+	uploader := NewMemoryUploader()
+
+	streamer, err := NewProtoStreamer(ProtoStreamerConfig{
+		Uploader: uploader,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	events := GenerateTestSession(SessionParams{PrintEvents: 1})
+	sid := session.ID(events[0].(SessionMetadataGetter).GetSessionID())
+
+	stream, err := streamer.CreateAuditStream(ctx, sid)
+	require.NoError(t, err)
+
+	err = stream.Complete(ctx)
+	require.NoError(t, err)
+
+	doneC := make(chan struct{})
+	go func() {
+		defer close(doneC)
+		stream.Complete(ctx)
+		stream.Close(ctx)
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for emitter to complete")
+	case <-doneC:
+	}
+}

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1041,7 +1041,7 @@ func (s *session) newStreamer(ctx *ServerContext) (events.Streamer, error) {
 	}
 	// TeeStreamer sends non-print and non disk events
 	// to the audit log in async mode, while buffering all
-	// events on disk for further upload at the end of the session
+	// events on disk for further upload at the end of the session.
 	return events.NewTeeStreamer(fileStreamer, ctx.srv), nil
 }
 


### PR DESCRIPTION
This commit fixes #4695.

Teleport in async recording mode sends all events to disk,
and uploads them to the server later.

It uploads some events synchronously to the audit log so
they show up in the global event log right away.

However if the auth server is slow, the fanout blocks the session.

This commit makes the fanout of some events to be fast,
but nonblocking and never fail so sessions will not hang
unless the disk writes hang.

It also adds ability to debug GRPC connection state
when running in debug mode.

To start sending GRPC connection state logs,
set environment variables:

GRPC_GO_LOG_SEVERITY_LEVEL=info GRPC_GO_LOG_VERBOSITY_LEVEL=99 teleport start -d