### PR TITLE
Added support for admin user and token management.

### DIFF
--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -50,6 +50,12 @@ type Modules interface {
 	SupportsKubernetes() bool
 	// IsBoringBinary checks if the binary was compiled with BoringCrypto.
 	IsBoringBinary() bool
+	// DELETE IN: 5.1.0
+	//
+	// ExtendAdminUserRules returns true if the "AdminUserRules" set should be
+	// extended with additional rules to allow user and token management. Only
+	// needed until 5.1 when user and token management will be added to OSS.
+	ExtendAdminUserRules() bool
 }
 
 // SetModules sets the modules interface
@@ -122,6 +128,15 @@ func (p *defaultModules) SupportsKubernetes() bool {
 
 // IsBoringBinary checks if the binary was compiled with BoringCrypto.
 func (p *defaultModules) IsBoringBinary() bool {
+	return false
+}
+
+// DELETE IN: 5.1.0
+//
+// ExtendAdminUserRules returns true if the "AdminUserRules" set should be
+// extended with additional rules to allow user and token management. Only
+// needed until 5.1 when user and token management will be added to OSS.
+func (p *defaultModules) ExtendAdminUserRules() bool {
 	return false
 }
 

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -56,6 +56,9 @@ func (s *ModulesSuite) TestDefaultModules(c *check.C) {
 
 	isBoring := GetModules().IsBoringBinary()
 	c.Assert(isBoring, check.Equals, false)
+
+	extendAdminRules := GetModules().ExtendAdminUserRules()
+	c.Assert(extendAdminRules, check.Equals, false)
 }
 
 func (s *ModulesSuite) TestTestModules(c *check.C) {
@@ -75,6 +78,9 @@ func (s *ModulesSuite) TestTestModules(c *check.C) {
 
 	isBoring := GetModules().IsBoringBinary()
 	c.Assert(isBoring, check.Equals, true)
+
+	extendAdminRules := GetModules().ExtendAdminUserRules()
+	c.Assert(extendAdminRules, check.Equals, true)
 }
 
 type testModules struct{}
@@ -110,5 +116,9 @@ func (p *testModules) TraitsFromLogins(user string, logins, kubeGroups, kubeUser
 }
 
 func (p *testModules) IsBoringBinary() bool {
+	return true
+}
+
+func (p *testModules) ExtendAdminUserRules() bool {
 	return true
 }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -45,12 +45,29 @@ import (
 
 // AdminUserRules provides access to the default set of rules assigned to
 // all users.
+//
+// DELETE IN: 5.1.0.
+//
+// Once RBAC is open sourced, remove this and rename "ExtendedAdminUserRules" to
+// "AdminUserRules".
 var AdminUserRules = []Rule{
 	NewRule(KindRole, RW()),
 	NewRule(KindAuthConnector, RW()),
 	NewRule(KindSession, RO()),
 	NewRule(KindTrustedCluster, RW()),
 	NewRule(KindEvent, RO()),
+}
+
+// ExtendedAdminUserRules provides access to the default set of rules assigned to
+// all users.
+var ExtendedAdminUserRules = []Rule{
+	NewRule(KindRole, RW()),
+	NewRule(KindAuthConnector, RW()),
+	NewRule(KindSession, RO()),
+	NewRule(KindTrustedCluster, RW()),
+	NewRule(KindEvent, RO()),
+	NewRule(KindUser, RW()),
+	NewRule(KindToken, RW()),
 }
 
 // DefaultImplicitRules provides access to the default set of implicit rules
@@ -91,6 +108,14 @@ func RoleNameForCertAuthority(name string) string {
 // NewAdminRole is the default admin role for all local users if another role
 // is not explicitly assigned (this role applies to all users in OSS version).
 func NewAdminRole() Role {
+	// DELETE IN: 5.1.0
+	//
+	// Only needed until 5.1 when user and token management will be added to OSS.
+	adminRules := CopyRulesSlice(AdminUserRules)
+	if modules.GetModules().ExtendAdminUserRules() {
+		adminRules = CopyRulesSlice(ExtendedAdminUserRules)
+	}
+
 	role := &RoleV3{
 		Kind:    KindRole,
 		Version: V3,
@@ -110,7 +135,7 @@ func NewAdminRole() Role {
 				Namespaces: []string{defaults.Namespace},
 				NodeLabels: Labels{Wildcard: []string{Wildcard}},
 				AppLabels:  Labels{Wildcard: []string{Wildcard}},
-				Rules:      CopyRulesSlice(AdminUserRules),
+				Rules:      adminRules,
 			},
 		},
 	}


### PR DESCRIPTION
**Description**

Updated default admin rule in Enterprise to include `KindUser: RW` and `KindToken: RW` permissions to allow admins to perform user and token management.

OSS will be updated to include `KindUser: RW` and `KindToken: RW` when RBAC is added in https://github.com/gravitational/teleport/pull/4632.

Enterprise reference points to: https://github.com/gravitational/teleport.e/pull/176

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/4638