### PR TITLE
Release 4.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 4.4.3
+### 4.4.4
 
 This release of Teleport adds enhancements to the Access Workflows API.
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Naming convention:
 #	for stable releases we use "1.0.0" format
 #   for pre-releases, we use   "1.0.0-beta.2" format
-VERSION=4.4.3
+VERSION=4.4.4
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "4.4.3"
+	Version = "4.4.4"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Skipping `4.4.3` because I tagged the wrong commit and release branch history is immutable :face_with_head_bandage: 