### PR TITLE
Fixed regression in application access dialing.

### DIFF
--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -1048,11 +1048,13 @@ func isOldCluster(ctx context.Context, conn ssh.Conn) (bool, error) {
 		return false, trace.Wrap(err)
 	}
 
+	// Return true if the version is older than 5.0.0, the check is actually for
+	// 4.5.0, a non-existent version, to allow this check to work during development.
 	remoteClusterVersion, err := semver.NewVersion(version)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	minClusterVersion, err := semver.NewVersion("5.0.0")
+	minClusterVersion, err := semver.NewVersion("4.5.0")
 	if err != nil {
 		return false, trace.Wrap(err)
 	}

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -396,6 +396,11 @@ func (p *transport) getConn(servers []string, r *dialReq) (net.Conn, bool, error
 			return nil, false, trace.Wrap(err)
 		}
 
+		// Connections to applications should never occur over a direct dial, return right away.
+		if r.ConnType == services.AppTunnel {
+			return nil, false, trace.ConnectionProblem(err, "failed to connect to application")
+		}
+
 		errTun := err
 		p.log.Debugf("Attempting to dial directly %v.", servers)
 		conn, err = directDial(servers)

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -158,11 +158,8 @@ func dialFunc(c *transportConfig) func(ctx context.Context, network string, addr
 		}
 
 		conn, err := clusterClient.Dial(reversetunnel.DialParams{
-			// The "From" and "To" addresses are not actually used for tunnel dialing,
-			// they're filled out with "dummy values" that make logs easier to read and
-			// debug within the reverse tunnel subsystem.
 			From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: "@web-proxy"},
-			To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: fmt.Sprintf("@app-%v", c.app.Name)},
+			To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalNode},
 			ServerID: fmt.Sprintf("%v.%v", c.server.GetName(), c.identity.RouteToApp.ClusterName),
 			ConnType: services.AppTunnel,
 		})


### PR DESCRIPTION
**Description**

Pass the target address, in the case of application access `services.LocalNode`, in the Dial request to the reverse tunnel subsystem instead of filling it in within the reverse tunnel subsystem.