### PR TITLE
Server data race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,6 @@ require (
 
 replace (
 	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
-	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b
+	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 	github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -104,5 +104,6 @@ require (
 
 replace (
 	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
+	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b
 	github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -195,10 +195,6 @@ github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b/go.mod h1:aUCEOzz
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
-github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
-github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gokyle/hotp v0.0.0-20160218004637-c180d57d286b h1:AD8yGmRk1t0OJ8B4oi0xCwogshBwDR92xKlNu6y+WPY=
 github.com/gokyle/hotp v0.0.0-20160218004637-c180d57d286b/go.mod h1:2vneIL/8eaCHMyWLVLanvIunX/xqc63a0E8LhTDTCRU=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
@@ -298,6 +294,8 @@ github.com/gravitational/license v0.0.0-20180912170534-4f189e3bd6e3 h1:vy9WwUq3H
 github.com/gravitational/license v0.0.0-20180912170534-4f189e3bd6e3/go.mod h1:jaxS7X2ouXfNd2Pxpybd01qNQK15UmkixKj4vtpp7f8=
 github.com/gravitational/oxy v0.0.0-20200916204440-3eb06d921a1d h1:IsbTjCQ4u5mr30ceWZ4GNcrQkp/Y/J9G+s9prmJm1ac=
 github.com/gravitational/oxy v0.0.0-20200916204440-3eb06d921a1d/go.mod h1:ESOxlf8BB2yG3zJ0SfZe9U6wpYu3YF3znxIICg73FYA=
+github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b h1:eb6H7DvHptlvZOOxxNX6JfXsylKuimIFRGv+EqB3wtQ=
+github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b/go.mod h1:nvYIs0zpwkaOfMJVk19T1RNuB29ZB6NrweRnDqTwYEc=
 github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c h1:UwN3jo2EfZSGDchLVqH/EJ2A5GWvKROx3NJNUI6/plg=
 github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c/go.mod h1:rBJeI3JYVzbL7Yw2hYrp4QdKIkncb1pUHo95DyoEGns=
 github.com/gravitational/roundtrip v1.0.0 h1:eb+0EABfSKC8607CQ4oOyWCm9zVIfio/wW78TjQqLSc=
@@ -371,7 +369,6 @@ github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
-github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,8 @@ github.com/gravitational/license v0.0.0-20180912170534-4f189e3bd6e3 h1:vy9WwUq3H
 github.com/gravitational/license v0.0.0-20180912170534-4f189e3bd6e3/go.mod h1:jaxS7X2ouXfNd2Pxpybd01qNQK15UmkixKj4vtpp7f8=
 github.com/gravitational/oxy v0.0.0-20200916204440-3eb06d921a1d h1:IsbTjCQ4u5mr30ceWZ4GNcrQkp/Y/J9G+s9prmJm1ac=
 github.com/gravitational/oxy v0.0.0-20200916204440-3eb06d921a1d/go.mod h1:ESOxlf8BB2yG3zJ0SfZe9U6wpYu3YF3znxIICg73FYA=
-github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b h1:eb6H7DvHptlvZOOxxNX6JfXsylKuimIFRGv+EqB3wtQ=
-github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b/go.mod h1:nvYIs0zpwkaOfMJVk19T1RNuB29ZB6NrweRnDqTwYEc=
+github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf h1:MQ4e8XcxvZTeuOmRl7yE519vcWc2h/lyvYzsvt41cdY=
+github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c h1:UwN3jo2EfZSGDchLVqH/EJ2A5GWvKROx3NJNUI6/plg=
 github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c/go.mod h1:rBJeI3JYVzbL7Yw2hYrp4QdKIkncb1pUHo95DyoEGns=
 github.com/gravitational/roundtrip v1.0.0 h1:eb+0EABfSKC8607CQ4oOyWCm9zVIfio/wW78TjQqLSc=

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -341,7 +341,10 @@ func (a *Agent) run() {
 	defer conn.Close()
 
 	// Successfully connected to remote cluster.
-	a.log.WithField("addr", conn.LocalAddr().String()).WithField("remote-addr", conn.RemoteAddr().String()).Info("Connected.")
+	a.log.WithFields(log.Fields{
+		"addr":        conn.LocalAddr().String(),
+		"remote-addr": conn.RemoteAddr().String(),
+	}).Info("Connected.")
 
 	// wrap up remaining business logic in closure for easy
 	// conditional execution.

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -231,7 +231,7 @@ func filterAndClose(agents []*Agent, matchAgent matchAgentFn) []*Agent {
 	for i := range agents {
 		agent := agents[i]
 		if matchAgent(agent) {
-			agent.Debugf("Pool is closing agent.")
+			agent.log.Debugf("Pool is closing agent.")
 			agent.Close()
 		} else {
 			filtered = append(filtered, agent)

--- a/lib/reversetunnel/discovery.go
+++ b/lib/reversetunnel/discovery.go
@@ -61,6 +61,7 @@ func marshalDiscoveryRequest(req discoveryRequest) ([]byte, error) {
 	var out discoveryRequestRaw
 	m := services.GetServerMarshaler()
 	for _, p := range req.Proxies {
+		p = p.DeepCopy()
 		data, err := m.MarshalServer(p)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/reversetunnel/discovery.go
+++ b/lib/reversetunnel/discovery.go
@@ -61,6 +61,10 @@ func marshalDiscoveryRequest(req discoveryRequest) ([]byte, error) {
 	var out discoveryRequestRaw
 	m := services.GetServerMarshaler()
 	for _, p := range req.Proxies {
+		// Clone the server value to avoid a potential race
+		// since the proxies are shared.
+		// Marshaling attempts to enforce defaults which modifies
+		// the original value.
 		p = p.DeepCopy()
 		data, err := m.MarshalServer(p)
 		if err != nil {

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -76,7 +76,7 @@ func newlocalSite(srv *server, domainName string, client auth.ClientI) (*localSi
 type localSite struct {
 	sync.Mutex
 
-	log        *log.Entry
+	log        log.FieldLogger
 	domainName string
 	srv        *server
 

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -238,6 +238,13 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	if cfg.Component == "" {
 		cfg.Component = teleport.Component(teleport.ComponentProxy, teleport.ComponentServer)
 	}
+	logger := cfg.Log
+	if cfg.Log == nil {
+		logger = log.StandardLogger()
+	}
+	cfg.Log = logger.WithFields(log.Fields{
+		trace.Component: cfg.Component,
+	})
 	return nil
 }
 
@@ -256,18 +263,11 @@ func NewServer(cfg Config) (Server, error) {
 
 	ctx, cancel := context.WithCancel(cfg.Context)
 
-	logger := cfg.Log
-	if cfg.Log == nil {
-		logger = log.StandardLogger()
-	}
-	logger = logger.WithFields(log.Fields{
-		trace.Component: cfg.Component,
-	})
 	proxyWatcher, err := services.NewProxyWatcher(services.ProxyWatcherConfig{
 		Context:   ctx,
 		Component: cfg.Component,
 		Client:    cfg.LocalAuthClient,
-		Entry:     logger,
+		Entry:     cfg.Log,
 		ProxiesC:  make(chan []services.Server, 10),
 	})
 	if err != nil {
@@ -287,7 +287,7 @@ func NewServer(cfg Config) (Server, error) {
 		cancel:           cancel,
 		proxyWatcher:     proxyWatcher,
 		clusterPeers:     make(map[string]*clusterPeers),
-		log:              logger,
+		log:              cfg.Log,
 		offlineThreshold: offlineThreshold,
 	}
 
@@ -310,7 +310,7 @@ func NewServer(cfg Config) (Server, error) {
 		sshutils.AuthMethods{
 			PublicKey: srv.keyAuth,
 		},
-		sshutils.SetLogger(logger),
+		sshutils.SetLogger(cfg.Log),
 		sshutils.SetLimiter(cfg.Limiter),
 		sshutils.SetCiphers(cfg.Ciphers),
 		sshutils.SetKEXAlgorithms(cfg.KEXAlgorithms),

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -183,6 +183,7 @@ type Config struct {
 	// Component is a component used in logs
 	Component string
 
+	// Log specifies the logger
 	Log log.FieldLogger
 
 	// FIPS means Teleport was started in a FedRAMP/FIPS 140-2 compliant

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -24,12 +24,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
 
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 )
 
@@ -91,6 +92,9 @@ type Server interface {
 	LabelsString() string
 	// CheckAndSetDefaults checks and set default values for any missing fields.
 	CheckAndSetDefaults() error
+
+	// DeepCopy creates a clone of this server value
+	DeepCopy() Server
 }
 
 // ServersToV1 converts list of servers to slice of V1 style ones
@@ -368,6 +372,27 @@ func (s *ServerV2) CheckAndSetDefaults() error {
 	}
 
 	return nil
+}
+
+// DeepCopy creates a clone of this server value
+func (s *ServerV2) DeepCopy() Server {
+	return proto.Clone(s).(*ServerV2)
+}
+
+// Implements proto.Merger
+func (r *Metadata) Merge(src proto.Message) {
+	m, ok := src.(*Metadata)
+	if !ok {
+		return
+	}
+	r.Name = m.Name
+	r.Namespace = m.Namespace
+	r.Description = m.Description
+	r.Labels = utils.CopyStringsMap(m.Labels)
+	if m.Expires != nil {
+		expires := m.Expires.Add(0)
+		r.Expires = &expires
+	}
 }
 
 const (

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -380,17 +380,23 @@ func (s *ServerV2) DeepCopy() Server {
 }
 
 // Implements proto.Merger
+func (r *Rotation) Merge(src proto.Message) {
+	s, ok := src.(*Rotation)
+	if !ok {
+		return
+	}
+	*r = *s
+}
+
+// Implements proto.Merger
 func (r *Metadata) Merge(src proto.Message) {
 	m, ok := src.(*Metadata)
 	if !ok {
 		return
 	}
-	r.Name = m.Name
-	r.Namespace = m.Namespace
-	r.Description = m.Description
-	r.Labels = utils.CopyStringsMap(m.Labels)
+	*r = *m
 	if m.Expires != nil {
-		expires := m.Expires.Add(0)
+		expires := *m.Expires
 		r.Expires = &expires
 	}
 }

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -379,6 +379,9 @@ func (s *ServerV2) DeepCopy() Server {
 	return proto.Clone(s).(*ServerV2)
 }
 
+// Merge overwrites r from src and
+// is part of support for cloning Server values
+// using proto.Clone.
 // Implements proto.Merger
 func (r *Rotation) Merge(src proto.Message) {
 	s, ok := src.(*Rotation)
@@ -388,6 +391,9 @@ func (r *Rotation) Merge(src proto.Message) {
 	*r = *s
 }
 
+// Merge overwrites r from src and
+// is part of support for cloning Server values
+// using proto.Clone.
 // Implements proto.Merger
 func (r *Metadata) Merge(src proto.Message) {
 	m, ok := src.(*Metadata)
@@ -395,6 +401,9 @@ func (r *Metadata) Merge(src proto.Message) {
 		return
 	}
 	*r = *m
+	// Manually clone expiry timestamp as proto.Clone
+	// cannot cope with values that contain unexported
+	// attributes (as time.Time does)
 	if m.Expires != nil {
 		expires := *m.Expires
 		r.Expires = &expires

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -382,6 +382,11 @@ func (s *ServerV2) DeepCopy() Server {
 // Merge overwrites r from src and
 // is part of support for cloning Server values
 // using proto.Clone.
+//
+// Note: this does not implement the full Merger interface,
+// specifically, it assumes that r is zero value.
+// See https://github.com/gogo/protobuf/blob/v1.3.1/proto/clone.go#L58-L60
+//
 // Implements proto.Merger
 func (r *Rotation) Merge(src proto.Message) {
 	s, ok := src.(*Rotation)
@@ -394,6 +399,11 @@ func (r *Rotation) Merge(src proto.Message) {
 // Merge overwrites r from src and
 // is part of support for cloning Server values
 // using proto.Clone.
+//
+// Note: this does not implement the full Merger interface,
+// specifically, it assumes that r is zero value.
+// See https://github.com/gogo/protobuf/blob/v1.3.1/proto/clone.go#L58-L60
+//
 // Implements proto.Merger
 func (r *Metadata) Merge(src proto.Message) {
 	m, ok := src.(*Metadata)

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -408,6 +408,12 @@ func (r *Metadata) Merge(src proto.Message) {
 		expires := *m.Expires
 		r.Expires = &expires
 	}
+	if len(m.Labels) != 0 {
+		r.Labels = make(map[string]string)
+		for k, v := range m.Labels {
+			r.Labels[k] = v
+		}
+	}
 }
 
 const (

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -99,3 +99,14 @@ func (s *ServicesSuite) TestLabelKeyValidation(c *check.C) {
 		c.Assert(IsValidLabelKey(tt.label), check.Equals, tt.ok, check.Commentf("tt=%+v", tt))
 	}
 }
+
+func (s *ServicesSuite) TestServerDeepCopy(c *check.C) {
+	expires := time.Now()
+	srv := &ServerV2{
+		Metadata: Metadata{
+			Expires: &expires,
+		},
+	}
+	srv2 := srv.DeepCopy()
+	c.Assert(srv, check.DeepEquals, srv2)
+}

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/check.v1"
 )
 
@@ -102,7 +103,8 @@ func (s *ServicesSuite) TestLabelKeyValidation(c *check.C) {
 	}
 }
 
-func (s *ServicesSuite) TestServerDeepCopy(c *check.C) {
+func TestServerDeepCopy(t *testing.T) {
+	t.Parallel()
 	now := time.Date(1984, time.April, 4, 0, 0, 0, 0, time.UTC)
 	expires := now.Add(1 * time.Hour)
 	srv := &ServerV2{
@@ -158,9 +160,9 @@ func (s *ServicesSuite) TestServerDeepCopy(c *check.C) {
 		},
 	}
 	srv2 := srv.DeepCopy()
-	c.Assert(cmp.Diff(srv, srv2), check.Equals, "")
+	require.Empty(t, cmp.Diff(srv, srv2))
 
-	c.Assert(srv2, check.FitsTypeOf, &ServerV2{})
+	require.IsType(t, srv2, &ServerV2{})
 	// Mutate the second value but expect the original to be unaffected
 	srv2.(*ServerV2).Spec.CmdLabels = map[string]CommandLabelV2{
 		"srv-cmd": {
@@ -171,6 +173,6 @@ func (s *ServicesSuite) TestServerDeepCopy(c *check.C) {
 	expires2 := now.Add(10 * time.Minute)
 	srv2.(*ServerV2).Metadata.Expires = &expires2
 	srv3 := srv.DeepCopy()
-	c.Assert(cmp.Diff(srv, srv3), check.Equals, "")
-	c.Assert(cmp.Diff(srv2, srv3), check.Not(check.Equals), "")
+	require.Empty(t, cmp.Diff(srv, srv3))
+	require.NotEmpty(t, cmp.Diff(srv2, srv3))
 }

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -51,8 +51,9 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/pborman/uuid"
 
+	"github.com/pborman/uuid"
+	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 )
 
@@ -698,6 +699,7 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 	proxySigner, err := sshutils.NewSigner(proxyKeys.Key, proxyKeys.Cert)
 	c.Assert(err, IsNil)
 
+	logger := logrus.WithField("test", "TestProxyReverseTunnel")
 	listener, reverseTunnelAddress := s.mustListen(c)
 	defer listener.Close()
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
@@ -714,6 +716,7 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 		DataDir:                       c.MkDir(),
 		Component:                     teleport.ComponentProxy,
 		Emitter:                       s.proxyClient,
+		Log:                           logger,
 	})
 	c.Assert(err, IsNil)
 	c.Assert(reverseTunnelServer.Start(), IsNil)
@@ -864,6 +867,7 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 	log.Infof("[TEST START] TestProxyRoundRobin")
 
+	logger := logrus.WithField("test", "TestProxyRoundRobin")
 	listener, reverseTunnelAddress := s.mustListen(c)
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ClusterName:                   s.server.ClusterName(),
@@ -878,8 +882,10 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 		DirectClusters:                []reversetunnel.DirectCluster{{Name: s.server.ClusterName(), Client: s.proxyClient}},
 		DataDir:                       c.MkDir(),
 		Emitter:                       s.proxyClient,
+		Log:                           logger,
 	})
 	c.Assert(err, IsNil)
+	logger.WithField("tun-addr", reverseTunnelAddress.String()).Info("Created reverse tunnel server.")
 
 	c.Assert(reverseTunnelServer.Start(), IsNil)
 
@@ -916,6 +922,7 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 		Client:      s.proxyClient,
 		AccessPoint: s.proxyClient,
 		EventsC:     eventsC,
+		Log:         logger,
 	})
 	c.Assert(err, IsNil)
 	rsAgent.Start()
@@ -929,6 +936,7 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 		Client:      s.proxyClient,
 		AccessPoint: s.proxyClient,
 		EventsC:     eventsC,
+		Log:         logger,
 	})
 	c.Assert(err, IsNil)
 	rsAgent2.Start()
@@ -968,6 +976,7 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 // reverse tunnel
 func (s *SrvSuite) TestProxyDirectAccess(c *C) {
 	listener, _ := s.mustListen(c)
+	logger := logrus.WithField("test", "TestProxyDirectAccess")
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ClientTLS:                     s.proxyClient.TLSConfig(),
 		ID:                            hostID,
@@ -981,6 +990,7 @@ func (s *SrvSuite) TestProxyDirectAccess(c *C) {
 		DirectClusters:                []reversetunnel.DirectCluster{{Name: s.server.ClusterName(), Client: s.proxyClient}},
 		DataDir:                       c.MkDir(),
 		Emitter:                       s.proxyClient,
+		Log:                           logger,
 	})
 	c.Assert(err, IsNil)
 

--- a/vendor/github.com/gogo/protobuf/proto/clone.go
+++ b/vendor/github.com/gogo/protobuf/proto/clone.go
@@ -138,13 +138,17 @@ func mergeStruct(out, in reflect.Value) {
 // viaPtr indicates whether the values were indirected through a pointer (implying proto2).
 // prop is set if this is a struct field (it may be nil).
 func mergeAny(out, in reflect.Value, viaPtr bool, prop *Properties) {
-	if in.Type() == protoMessageType {
-		if !in.IsNil() {
-			if out.IsNil() {
-				out.Set(reflect.ValueOf(Clone(in.Interface().(Message))))
-			} else {
-				Merge(out.Interface().(Message), in.Interface().(Message))
+	if in.Type() == protoMessageType || in.Addr().Type().Implements(protoMessageType) {
+		if in.Kind() == reflect.Ptr {
+			if !in.IsNil() {
+				if out.IsNil() {
+					out.Set(reflect.ValueOf(Clone(in.Interface().(Message))))
+				} else {
+					Merge(out.Interface().(Message), in.Interface().(Message))
+				}
 			}
+		} else {
+			Merge(out.Addr().Interface().(Message), in.Addr().Interface().(Message))
 		}
 		return
 	}

--- a/vendor/github.com/gogo/protobuf/proto/clone.go
+++ b/vendor/github.com/gogo/protobuf/proto/clone.go
@@ -138,7 +138,7 @@ func mergeStruct(out, in reflect.Value) {
 // viaPtr indicates whether the values were indirected through a pointer (implying proto2).
 // prop is set if this is a struct field (it may be nil).
 func mergeAny(out, in reflect.Value, viaPtr bool, prop *Properties) {
-	if in.Type() == protoMessageType || in.Addr().Type().Implements(protoMessageType) {
+	if in.Type() == protoMessageType || (in.CanAddr() && in.Addr().Type().Implements(protoMessageType)) {
 		if in.Kind() == reflect.Ptr {
 			if !in.IsNil() {
 				if out.IsNil() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/gizak/termui
 github.com/gizak/termui/widgets
 # github.com/go-logr/logr v0.2.0
 github.com/go-logr/logr
-# github.com/gogo/protobuf v1.3.1
+# github.com/gogo/protobuf v1.3.1 => github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b
 ## explicit
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/jsonpb
@@ -918,4 +918,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
 # github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
+# github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b
 # github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/gizak/termui
 github.com/gizak/termui/widgets
 # github.com/go-logr/logr v0.2.0
 github.com/go-logr/logr
-# github.com/gogo/protobuf v1.3.1 => github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b
+# github.com/gogo/protobuf v1.3.1 => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 ## explicit
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/jsonpb
@@ -918,5 +918,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
 # github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
-# github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201111195440-def42e0f694b
+# github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 # github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1


### PR DESCRIPTION
This PR fixes the data race I spotted the [RoundRobin](https://github.com/gravitational/teleport/blob/dmitri/4653-server-data-race/lib/srv/regular/sshserver_test.go#L866) test.

What's interesting with this changeset is that it prompted a [change](https://github.com/gravitational/protobuf/commit/def42e0f694b04018dd338eb82931be7ac019de0) in `gogo/protobuf` which I implemented in a temporary fork until the issue is resolved upstream. 
I've [submitted](https://github.com/gogo/protobuf/pull/710) a PR upstream.

```
google.protobuf.Timestamp Expires = 5 [
    (gogoproto.stdtime) = true,   // specifically this is causing issues with reflect-based cloning
    (gogoproto.nullable) = false,
    (gogoproto.jsontag) = "started,omitempty"
];
```

Basically, protobuf package provides a reflect-based implementation of [Clone](https://github.com/gogo/protobuf/blob/v1.3.1/proto/clone.go#L45). Attempting it on the Server type unfortunately in the version `v1.3.1` results in:

<details><summary><code>Logs</code></summary>

```
go test -race ./lib/services/... -check.f=ServerDeepCopy

----------------------------------------------------------------------
PANIC: services_test.go:105: ServicesSuite.TestServerDeepCopy

... Panic: reflect: reflect.flag.mustBeAssignable using value obtained using unexported field (PC=0x4674F2)

/home/deemok/dev/go/go/src/runtime/panic.go:975
  in gopanic
/home/deemok/dev/go/go/src/reflect/value.go:244
  in flag.mustBeAssignableSlow
/home/deemok/dev/go/go/src/reflect/value.go:234
  in flag.mustBeAssignable
/home/deemok/dev/go/go/src/reflect/value.go:1526
  in Value.Set
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:161
  in mergeAny
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:108
  in mergeStruct
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:240
  in mergeAny
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:203
  in mergeAny
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:108
  in mergeStruct
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:98
  in Merge
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:151
  in mergeAny
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:108
  in mergeStruct
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:98
  in Merge
/home/deemok/go/src/github.com/gravitational/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:52
  in Clone
server.go:363
  in ServerV2.DeepCopy
services_test.go:160
  in ServicesSuite.TestServerDeepCopy
/home/deemok/dev/go/go/src/reflect/value.go:321
  in Value.Call
/home/deemok/dev/go/go/src/runtime/asm_amd64.s:1373
  in goexit
OOPS: 0 passed, 1 PANICKED
--- FAIL: TestServices (0.00s)
FAIL
FAIL	github.com/gravitational/teleport/lib/services	0.133s
ok  	github.com/gravitational/teleport/lib/services/local	0.053s
ok  	github.com/gravitational/teleport/lib/services/suite	0.071s
FAIL
```
</details>

### Before the change:

<details><summary><code>Output</code></summary>

```
$ go test -race -count=5 ./lib/srv/regular/... -check.f=RoundRobin
WARNING: Error cleaning up temporaries: unlinkat /tmp/check-4324745483838182873/1/log/upload/streaming/default: directory not emptyOK: 1 passed
==================
WARNING: DATA RACE
Read at 0x00c000406360 by goroutine 39:
  github.com/gravitational/teleport/lib/utils.UTC()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/utils/time.go:40 +0x4e
  github.com/gravitational/teleport/lib/services.(*Metadata).CheckAndSetDefaults()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/services/resource.go:728 +0x28c
  github.com/gravitational/teleport/lib/services.(*ServerV2).CheckAndSetDefaults()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/services/server.go:344 +0x56
  github.com/gravitational/teleport/lib/services.(*TeleportServerMarshaler).MarshalServer()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/services/server.go:897 +0x59
  github.com/gravitational/teleport/lib/reversetunnel.marshalDiscoveryRequest()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/discovery.go:65 +0x112
  github.com/gravitational/teleport/lib/reversetunnel.(*remoteConn).sendDiscoveryRequest()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/conn.go:238 +0xb1
  github.com/gravitational/teleport/lib/reversetunnel.(*localSite).handleHeartbeat()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/localsite.go:372 +0xf00

Previous write at 0x00c000406360 by goroutine 164:
  github.com/gravitational/teleport/lib/utils.UTC()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/utils/time.go:45 +0x158
  github.com/gravitational/teleport/lib/services.(*Metadata).CheckAndSetDefaults()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/services/resource.go:728 +0x28c
  github.com/gravitational/teleport/lib/services.(*ServerV2).CheckAndSetDefaults()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/services/server.go:344 +0x56
  github.com/gravitational/teleport/lib/services.(*TeleportServerMarshaler).MarshalServer()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/services/server.go:897 +0x59
  github.com/gravitational/teleport/lib/reversetunnel.marshalDiscoveryRequest()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/discovery.go:65 +0x112
  github.com/gravitational/teleport/lib/reversetunnel.(*remoteConn).sendDiscoveryRequest()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/conn.go:238 +0xb1
  github.com/gravitational/teleport/lib/reversetunnel.(*localSite).handleHeartbeat()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/localsite.go:372 +0xf00

Goroutine 39 (running) created at:
  github.com/gravitational/teleport/lib/reversetunnel.(*server).handleNewService()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/srv.go:659 +0x343
  github.com/gravitational/teleport/lib/reversetunnel.(*server).handleHeartbeat()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/srv.go:627 +0x664
  github.com/gravitational/teleport/lib/reversetunnel.(*server).HandleNewChan()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/srv.go:564 +0x47a

Goroutine 164 (running) created at:
  github.com/gravitational/teleport/lib/reversetunnel.(*server).handleNewService()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/srv.go:659 +0x343
  github.com/gravitational/teleport/lib/reversetunnel.(*server).handleHeartbeat()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/srv.go:627 +0x664
  github.com/gravitational/teleport/lib/reversetunnel.(*server).HandleNewChan()
      /home/deemok/go/src/github.com/gravitational/teleport/lib/reversetunnel/srv.go:564 +0x47a
==================
WARNING: Error cleaning up temporaries: unlinkat /tmp/check-2740103009342231109/1/log/upload/streaming/default: directory not emptyOK: 1 passed
--- FAIL: TestRegular (4.06s)
    testing.go:906: race detected during execution of test
WARNING: Error cleaning up temporaries: unlinkat /tmp/check-8995016276575641803/1/log/upload/streaming/default: directory not emptyOK: 1 passed
OK: 1 passed
WARNING: Error cleaning up temporaries: unlinkat /tmp/check-898860202204764712/1/log/upload/streaming/default: directory not emptyOK: 1 passed
FAIL
FAIL	github.com/gravitational/teleport/lib/srv/regular	23.328s
FAIL
```
</details>

### After the change:

<details><summary><code>Output</code></summary>

```
$ go test -race -count=10 ./lib/srv/regular/... -check.f=RoundRobin
ok  	github.com/gravitational/teleport/lib/srv/regular	45.447s
```
</details>

Fixes https://github.com/gravitational/teleport/issues/4781.
