### PR TITLE
Add kubernetes_cluster to all kube-related events

### DIFF
--- a/lib/events/events.pb.go
+++ b/lib/events/events.pb.go
@@ -49,7 +49,7 @@ func (m *Metadata) Reset()         { *m = Metadata{} }
 func (m *Metadata) String() string { return proto.CompactTextString(m) }
 func (*Metadata) ProtoMessage()    {}
 func (*Metadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{0}
+	return fileDescriptor_events_69f4748188040cdb, []int{0}
 }
 func (m *Metadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -91,7 +91,7 @@ func (m *SessionMetadata) Reset()         { *m = SessionMetadata{} }
 func (m *SessionMetadata) String() string { return proto.CompactTextString(m) }
 func (*SessionMetadata) ProtoMessage()    {}
 func (*SessionMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{1}
+	return fileDescriptor_events_69f4748188040cdb, []int{1}
 }
 func (m *SessionMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -135,7 +135,7 @@ func (m *UserMetadata) Reset()         { *m = UserMetadata{} }
 func (m *UserMetadata) String() string { return proto.CompactTextString(m) }
 func (*UserMetadata) ProtoMessage()    {}
 func (*UserMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{2}
+	return fileDescriptor_events_69f4748188040cdb, []int{2}
 }
 func (m *UserMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -186,7 +186,7 @@ func (m *ServerMetadata) Reset()         { *m = ServerMetadata{} }
 func (m *ServerMetadata) String() string { return proto.CompactTextString(m) }
 func (*ServerMetadata) ProtoMessage()    {}
 func (*ServerMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{3}
+	return fileDescriptor_events_69f4748188040cdb, []int{3}
 }
 func (m *ServerMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -232,7 +232,7 @@ func (m *ConnectionMetadata) Reset()         { *m = ConnectionMetadata{} }
 func (m *ConnectionMetadata) String() string { return proto.CompactTextString(m) }
 func (*ConnectionMetadata) ProtoMessage()    {}
 func (*ConnectionMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{4}
+	return fileDescriptor_events_69f4748188040cdb, []int{4}
 }
 func (m *ConnectionMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -261,6 +261,49 @@ func (m *ConnectionMetadata) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ConnectionMetadata proto.InternalMessageInfo
 
+// KubernetesClusterMetadata contains common metadata for kubernetes-related
+// events.
+type KubernetesClusterMetadata struct {
+	// KubernetesCluster is a kubernetes cluster name.
+	KubernetesCluster    string   `protobuf:"bytes,1,opt,name=KubernetesCluster,proto3" json:"kubernetes_cluster,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *KubernetesClusterMetadata) Reset()         { *m = KubernetesClusterMetadata{} }
+func (m *KubernetesClusterMetadata) String() string { return proto.CompactTextString(m) }
+func (*KubernetesClusterMetadata) ProtoMessage()    {}
+func (*KubernetesClusterMetadata) Descriptor() ([]byte, []int) {
+	return fileDescriptor_events_69f4748188040cdb, []int{5}
+}
+func (m *KubernetesClusterMetadata) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *KubernetesClusterMetadata) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_KubernetesClusterMetadata.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (dst *KubernetesClusterMetadata) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_KubernetesClusterMetadata.Merge(dst, src)
+}
+func (m *KubernetesClusterMetadata) XXX_Size() int {
+	return m.Size()
+}
+func (m *KubernetesClusterMetadata) XXX_DiscardUnknown() {
+	xxx_messageInfo_KubernetesClusterMetadata.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_KubernetesClusterMetadata proto.InternalMessageInfo
+
 // SessionStart is a session start event
 type SessionStart struct {
 	// Metadata is a common event metadata
@@ -274,17 +317,19 @@ type SessionStart struct {
 	// ConnectionMetadata holds information about the connection
 	ConnectionMetadata `protobuf:"bytes,5,opt,name=Connection,embedded=Connection" json:""`
 	// TerminalSize is expressed as 'W:H'
-	TerminalSize         string   `protobuf:"bytes,6,opt,name=TerminalSize,proto3" json:"size,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	TerminalSize string `protobuf:"bytes,6,opt,name=TerminalSize,proto3" json:"size,omitempty"`
+	// Kubernetes has information about a kubernetes cluster, if applicable.
+	KubernetesClusterMetadata `protobuf:"bytes,7,opt,name=Kubernetes,embedded=Kubernetes" json:""`
+	XXX_NoUnkeyedLiteral      struct{} `json:"-"`
+	XXX_unrecognized          []byte   `json:"-"`
+	XXX_sizecache             int32    `json:"-"`
 }
 
 func (m *SessionStart) Reset()         { *m = SessionStart{} }
 func (m *SessionStart) String() string { return proto.CompactTextString(m) }
 func (*SessionStart) ProtoMessage()    {}
 func (*SessionStart) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{5}
+	return fileDescriptor_events_69f4748188040cdb, []int{6}
 }
 func (m *SessionStart) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -324,17 +369,19 @@ type SessionJoin struct {
 	// ServerMetadata is a common server metadata
 	ServerMetadata `protobuf:"bytes,4,opt,name=Server,embedded=Server" json:""`
 	// ConnectionMetadata holds information about the connection
-	ConnectionMetadata   `protobuf:"bytes,5,opt,name=Connection,embedded=Connection" json:""`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	ConnectionMetadata `protobuf:"bytes,5,opt,name=Connection,embedded=Connection" json:""`
+	// Kubernetes has information about a kubernetes cluster, if applicable.
+	KubernetesClusterMetadata `protobuf:"bytes,6,opt,name=Kubernetes,embedded=Kubernetes" json:""`
+	XXX_NoUnkeyedLiteral      struct{} `json:"-"`
+	XXX_unrecognized          []byte   `json:"-"`
+	XXX_sizecache             int32    `json:"-"`
 }
 
 func (m *SessionJoin) Reset()         { *m = SessionJoin{} }
 func (m *SessionJoin) String() string { return proto.CompactTextString(m) }
 func (*SessionJoin) ProtoMessage()    {}
 func (*SessionJoin) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{6}
+	return fileDescriptor_events_69f4748188040cdb, []int{7}
 }
 func (m *SessionJoin) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -388,7 +435,7 @@ func (m *SessionPrint) Reset()         { *m = SessionPrint{} }
 func (m *SessionPrint) String() string { return proto.CompactTextString(m) }
 func (*SessionPrint) ProtoMessage()    {}
 func (*SessionPrint) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{7}
+	return fileDescriptor_events_69f4748188040cdb, []int{8}
 }
 func (m *SessionPrint) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -443,7 +490,7 @@ func (m *SessionReject) Reset()         { *m = SessionReject{} }
 func (m *SessionReject) String() string { return proto.CompactTextString(m) }
 func (*SessionReject) ProtoMessage()    {}
 func (*SessionReject) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{8}
+	return fileDescriptor_events_69f4748188040cdb, []int{9}
 }
 func (m *SessionReject) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -485,17 +532,19 @@ type Resize struct {
 	// ServerMetadata is a common server metadata
 	ServerMetadata `protobuf:"bytes,5,opt,name=Server,embedded=Server" json:""`
 	// TerminalSize is expressed as 'W:H'
-	TerminalSize         string   `protobuf:"bytes,6,opt,name=TerminalSize,proto3" json:"size,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	TerminalSize string `protobuf:"bytes,6,opt,name=TerminalSize,proto3" json:"size,omitempty"`
+	// Kubernetes has information about a kubernetes cluster, if applicable.
+	KubernetesClusterMetadata `protobuf:"bytes,7,opt,name=Kubernetes,embedded=Kubernetes" json:""`
+	XXX_NoUnkeyedLiteral      struct{} `json:"-"`
+	XXX_unrecognized          []byte   `json:"-"`
+	XXX_sizecache             int32    `json:"-"`
 }
 
 func (m *Resize) Reset()         { *m = Resize{} }
 func (m *Resize) String() string { return proto.CompactTextString(m) }
 func (*Resize) ProtoMessage()    {}
 func (*Resize) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{9}
+	return fileDescriptor_events_69f4748188040cdb, []int{10}
 }
 func (m *Resize) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -547,17 +596,19 @@ type SessionEnd struct {
 	// StartTime is the timestamp at which the session began.
 	StartTime time.Time `protobuf:"bytes,9,opt,name=StartTime,stdtime" json:"session_start,omitempty"`
 	// EndTime is the timestamp at which the session ended.
-	EndTime              time.Time `protobuf:"bytes,10,opt,name=EndTime,stdtime" json:"session_stop,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
-	XXX_unrecognized     []byte    `json:"-"`
-	XXX_sizecache        int32     `json:"-"`
+	EndTime time.Time `protobuf:"bytes,10,opt,name=EndTime,stdtime" json:"session_stop,omitempty"`
+	// Kubernetes has information about a kubernetes cluster, if applicable.
+	KubernetesClusterMetadata `protobuf:"bytes,11,opt,name=Kubernetes,embedded=Kubernetes" json:""`
+	XXX_NoUnkeyedLiteral      struct{} `json:"-"`
+	XXX_unrecognized          []byte   `json:"-"`
+	XXX_sizecache             int32    `json:"-"`
 }
 
 func (m *SessionEnd) Reset()         { *m = SessionEnd{} }
 func (m *SessionEnd) String() string { return proto.CompactTextString(m) }
 func (*SessionEnd) ProtoMessage()    {}
 func (*SessionEnd) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{10}
+	return fileDescriptor_events_69f4748188040cdb, []int{11}
 }
 func (m *SessionEnd) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -603,7 +654,7 @@ func (m *BPFMetadata) Reset()         { *m = BPFMetadata{} }
 func (m *BPFMetadata) String() string { return proto.CompactTextString(m) }
 func (*BPFMetadata) ProtoMessage()    {}
 func (*BPFMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{11}
+	return fileDescriptor_events_69f4748188040cdb, []int{12}
 }
 func (m *BPFMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -649,7 +700,7 @@ func (m *Status) Reset()         { *m = Status{} }
 func (m *Status) String() string { return proto.CompactTextString(m) }
 func (*Status) ProtoMessage()    {}
 func (*Status) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{12}
+	return fileDescriptor_events_69f4748188040cdb, []int{13}
 }
 func (m *Status) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -708,7 +759,7 @@ func (m *SessionCommand) Reset()         { *m = SessionCommand{} }
 func (m *SessionCommand) String() string { return proto.CompactTextString(m) }
 func (*SessionCommand) ProtoMessage()    {}
 func (*SessionCommand) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{13}
+	return fileDescriptor_events_69f4748188040cdb, []int{14}
 }
 func (m *SessionCommand) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -764,7 +815,7 @@ func (m *SessionDisk) Reset()         { *m = SessionDisk{} }
 func (m *SessionDisk) String() string { return proto.CompactTextString(m) }
 func (*SessionDisk) ProtoMessage()    {}
 func (*SessionDisk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{14}
+	return fileDescriptor_events_69f4748188040cdb, []int{15}
 }
 func (m *SessionDisk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -822,7 +873,7 @@ func (m *SessionNetwork) Reset()         { *m = SessionNetwork{} }
 func (m *SessionNetwork) String() string { return proto.CompactTextString(m) }
 func (*SessionNetwork) ProtoMessage()    {}
 func (*SessionNetwork) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{15}
+	return fileDescriptor_events_69f4748188040cdb, []int{16}
 }
 func (m *SessionNetwork) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -876,7 +927,7 @@ func (m *SessionData) Reset()         { *m = SessionData{} }
 func (m *SessionData) String() string { return proto.CompactTextString(m) }
 func (*SessionData) ProtoMessage()    {}
 func (*SessionData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{16}
+	return fileDescriptor_events_69f4748188040cdb, []int{17}
 }
 func (m *SessionData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -926,7 +977,7 @@ func (m *SessionLeave) Reset()         { *m = SessionLeave{} }
 func (m *SessionLeave) String() string { return proto.CompactTextString(m) }
 func (*SessionLeave) ProtoMessage()    {}
 func (*SessionLeave) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{17}
+	return fileDescriptor_events_69f4748188040cdb, []int{18}
 }
 func (m *SessionLeave) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -976,7 +1027,7 @@ func (m *UserLogin) Reset()         { *m = UserLogin{} }
 func (m *UserLogin) String() string { return proto.CompactTextString(m) }
 func (*UserLogin) ProtoMessage()    {}
 func (*UserLogin) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{18}
+	return fileDescriptor_events_69f4748188040cdb, []int{19}
 }
 func (m *UserLogin) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1026,7 +1077,7 @@ func (m *ResourceMetadata) Reset()         { *m = ResourceMetadata{} }
 func (m *ResourceMetadata) String() string { return proto.CompactTextString(m) }
 func (*ResourceMetadata) ProtoMessage()    {}
 func (*ResourceMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{19}
+	return fileDescriptor_events_69f4748188040cdb, []int{20}
 }
 func (m *ResourceMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1076,7 +1127,7 @@ func (m *UserCreate) Reset()         { *m = UserCreate{} }
 func (m *UserCreate) String() string { return proto.CompactTextString(m) }
 func (*UserCreate) ProtoMessage()    {}
 func (*UserCreate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{20}
+	return fileDescriptor_events_69f4748188040cdb, []int{21}
 }
 func (m *UserCreate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1122,7 +1173,7 @@ func (m *UserDelete) Reset()         { *m = UserDelete{} }
 func (m *UserDelete) String() string { return proto.CompactTextString(m) }
 func (*UserDelete) ProtoMessage()    {}
 func (*UserDelete) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{21}
+	return fileDescriptor_events_69f4748188040cdb, []int{22}
 }
 func (m *UserDelete) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1166,7 +1217,7 @@ func (m *UserPasswordChange) Reset()         { *m = UserPasswordChange{} }
 func (m *UserPasswordChange) String() string { return proto.CompactTextString(m) }
 func (*UserPasswordChange) ProtoMessage()    {}
 func (*UserPasswordChange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{22}
+	return fileDescriptor_events_69f4748188040cdb, []int{23}
 }
 func (m *UserPasswordChange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1227,7 +1278,7 @@ func (m *AccessRequestCreate) Reset()         { *m = AccessRequestCreate{} }
 func (m *AccessRequestCreate) String() string { return proto.CompactTextString(m) }
 func (*AccessRequestCreate) ProtoMessage()    {}
 func (*AccessRequestCreate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{23}
+	return fileDescriptor_events_69f4748188040cdb, []int{24}
 }
 func (m *AccessRequestCreate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1277,7 +1328,7 @@ func (m *PortForward) Reset()         { *m = PortForward{} }
 func (m *PortForward) String() string { return proto.CompactTextString(m) }
 func (*PortForward) ProtoMessage()    {}
 func (*PortForward) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{24}
+	return fileDescriptor_events_69f4748188040cdb, []int{25}
 }
 func (m *PortForward) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1325,7 +1376,7 @@ func (m *X11Forward) Reset()         { *m = X11Forward{} }
 func (m *X11Forward) String() string { return proto.CompactTextString(m) }
 func (*X11Forward) ProtoMessage()    {}
 func (*X11Forward) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{25}
+	return fileDescriptor_events_69f4748188040cdb, []int{26}
 }
 func (m *X11Forward) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1371,7 +1422,7 @@ func (m *CommandMetadata) Reset()         { *m = CommandMetadata{} }
 func (m *CommandMetadata) String() string { return proto.CompactTextString(m) }
 func (*CommandMetadata) ProtoMessage()    {}
 func (*CommandMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{26}
+	return fileDescriptor_events_69f4748188040cdb, []int{27}
 }
 func (m *CommandMetadata) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1413,17 +1464,19 @@ type Exec struct {
 	// ServerMetadata is a common server metadata
 	ServerMetadata `protobuf:"bytes,5,opt,name=Server,embedded=Server" json:""`
 	// CommandMetadata is a common command metadata
-	CommandMetadata      `protobuf:"bytes,6,opt,name=Command,embedded=Command" json:""`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	CommandMetadata `protobuf:"bytes,6,opt,name=Command,embedded=Command" json:""`
+	// Kubernetes has information about a kubernetes cluster, if applicable.
+	KubernetesClusterMetadata `protobuf:"bytes,7,opt,name=Kubernetes,embedded=Kubernetes" json:""`
+	XXX_NoUnkeyedLiteral      struct{} `json:"-"`
+	XXX_unrecognized          []byte   `json:"-"`
+	XXX_sizecache             int32    `json:"-"`
 }
 
 func (m *Exec) Reset()         { *m = Exec{} }
 func (m *Exec) String() string { return proto.CompactTextString(m) }
 func (*Exec) ProtoMessage()    {}
 func (*Exec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{27}
+	return fileDescriptor_events_69f4748188040cdb, []int{28}
 }
 func (m *Exec) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1479,7 +1532,7 @@ func (m *SCP) Reset()         { *m = SCP{} }
 func (m *SCP) String() string { return proto.CompactTextString(m) }
 func (*SCP) ProtoMessage()    {}
 func (*SCP) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{28}
+	return fileDescriptor_events_69f4748188040cdb, []int{29}
 }
 func (m *SCP) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1529,7 +1582,7 @@ func (m *Subsystem) Reset()         { *m = Subsystem{} }
 func (m *Subsystem) String() string { return proto.CompactTextString(m) }
 func (*Subsystem) ProtoMessage()    {}
 func (*Subsystem) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{29}
+	return fileDescriptor_events_69f4748188040cdb, []int{30}
 }
 func (m *Subsystem) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1581,7 +1634,7 @@ func (m *ClientDisconnect) Reset()         { *m = ClientDisconnect{} }
 func (m *ClientDisconnect) String() string { return proto.CompactTextString(m) }
 func (*ClientDisconnect) ProtoMessage()    {}
 func (*ClientDisconnect) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{30}
+	return fileDescriptor_events_69f4748188040cdb, []int{31}
 }
 func (m *ClientDisconnect) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1629,7 +1682,7 @@ func (m *AuthAttempt) Reset()         { *m = AuthAttempt{} }
 func (m *AuthAttempt) String() string { return proto.CompactTextString(m) }
 func (*AuthAttempt) ProtoMessage()    {}
 func (*AuthAttempt) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{31}
+	return fileDescriptor_events_69f4748188040cdb, []int{32}
 }
 func (m *AuthAttempt) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1675,7 +1728,7 @@ func (m *ResetPasswordTokenCreate) Reset()         { *m = ResetPasswordTokenCrea
 func (m *ResetPasswordTokenCreate) String() string { return proto.CompactTextString(m) }
 func (*ResetPasswordTokenCreate) ProtoMessage()    {}
 func (*ResetPasswordTokenCreate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{32}
+	return fileDescriptor_events_69f4748188040cdb, []int{33}
 }
 func (m *ResetPasswordTokenCreate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1721,7 +1774,7 @@ func (m *RoleCreate) Reset()         { *m = RoleCreate{} }
 func (m *RoleCreate) String() string { return proto.CompactTextString(m) }
 func (*RoleCreate) ProtoMessage()    {}
 func (*RoleCreate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{33}
+	return fileDescriptor_events_69f4748188040cdb, []int{34}
 }
 func (m *RoleCreate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1767,7 +1820,7 @@ func (m *RoleDelete) Reset()         { *m = RoleDelete{} }
 func (m *RoleDelete) String() string { return proto.CompactTextString(m) }
 func (*RoleDelete) ProtoMessage()    {}
 func (*RoleDelete) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{34}
+	return fileDescriptor_events_69f4748188040cdb, []int{35}
 }
 func (m *RoleDelete) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1813,7 +1866,7 @@ func (m *TrustedClusterCreate) Reset()         { *m = TrustedClusterCreate{} }
 func (m *TrustedClusterCreate) String() string { return proto.CompactTextString(m) }
 func (*TrustedClusterCreate) ProtoMessage()    {}
 func (*TrustedClusterCreate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{35}
+	return fileDescriptor_events_69f4748188040cdb, []int{36}
 }
 func (m *TrustedClusterCreate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1859,7 +1912,7 @@ func (m *TrustedClusterDelete) Reset()         { *m = TrustedClusterDelete{} }
 func (m *TrustedClusterDelete) String() string { return proto.CompactTextString(m) }
 func (*TrustedClusterDelete) ProtoMessage()    {}
 func (*TrustedClusterDelete) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{36}
+	return fileDescriptor_events_69f4748188040cdb, []int{37}
 }
 func (m *TrustedClusterDelete) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1906,7 +1959,7 @@ func (m *TrustedClusterTokenCreate) Reset()         { *m = TrustedClusterTokenCr
 func (m *TrustedClusterTokenCreate) String() string { return proto.CompactTextString(m) }
 func (*TrustedClusterTokenCreate) ProtoMessage()    {}
 func (*TrustedClusterTokenCreate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{37}
+	return fileDescriptor_events_69f4748188040cdb, []int{38}
 }
 func (m *TrustedClusterTokenCreate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1952,7 +2005,7 @@ func (m *GithubConnectorCreate) Reset()         { *m = GithubConnectorCreate{} }
 func (m *GithubConnectorCreate) String() string { return proto.CompactTextString(m) }
 func (*GithubConnectorCreate) ProtoMessage()    {}
 func (*GithubConnectorCreate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{38}
+	return fileDescriptor_events_69f4748188040cdb, []int{39}
 }
 func (m *GithubConnectorCreate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1998,7 +2051,7 @@ func (m *GithubConnectorDelete) Reset()         { *m = GithubConnectorDelete{} }
 func (m *GithubConnectorDelete) String() string { return proto.CompactTextString(m) }
 func (*GithubConnectorDelete) ProtoMessage()    {}
 func (*GithubConnectorDelete) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{39}
+	return fileDescriptor_events_69f4748188040cdb, []int{40}
 }
 func (m *GithubConnectorDelete) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2044,7 +2097,7 @@ func (m *OIDCConnectorCreate) Reset()         { *m = OIDCConnectorCreate{} }
 func (m *OIDCConnectorCreate) String() string { return proto.CompactTextString(m) }
 func (*OIDCConnectorCreate) ProtoMessage()    {}
 func (*OIDCConnectorCreate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{40}
+	return fileDescriptor_events_69f4748188040cdb, []int{41}
 }
 func (m *OIDCConnectorCreate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2090,7 +2143,7 @@ func (m *OIDCConnectorDelete) Reset()         { *m = OIDCConnectorDelete{} }
 func (m *OIDCConnectorDelete) String() string { return proto.CompactTextString(m) }
 func (*OIDCConnectorDelete) ProtoMessage()    {}
 func (*OIDCConnectorDelete) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{41}
+	return fileDescriptor_events_69f4748188040cdb, []int{42}
 }
 func (m *OIDCConnectorDelete) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2136,7 +2189,7 @@ func (m *SAMLConnectorCreate) Reset()         { *m = SAMLConnectorCreate{} }
 func (m *SAMLConnectorCreate) String() string { return proto.CompactTextString(m) }
 func (*SAMLConnectorCreate) ProtoMessage()    {}
 func (*SAMLConnectorCreate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{42}
+	return fileDescriptor_events_69f4748188040cdb, []int{43}
 }
 func (m *SAMLConnectorCreate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2182,7 +2235,7 @@ func (m *SAMLConnectorDelete) Reset()         { *m = SAMLConnectorDelete{} }
 func (m *SAMLConnectorDelete) String() string { return proto.CompactTextString(m) }
 func (*SAMLConnectorDelete) ProtoMessage()    {}
 func (*SAMLConnectorDelete) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{43}
+	return fileDescriptor_events_69f4748188040cdb, []int{44}
 }
 func (m *SAMLConnectorDelete) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2234,17 +2287,19 @@ type KubeRequest struct {
 	// ResourceName is the API resource name.
 	ResourceName string `protobuf:"bytes,10,opt,name=ResourceName,proto3" json:"resource_name,omitempty"`
 	// ResponseCode is the HTTP response code for this request.
-	ResponseCode         int32    `protobuf:"varint,11,opt,name=ResponseCode,proto3" json:"response_code"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	ResponseCode int32 `protobuf:"varint,11,opt,name=ResponseCode,proto3" json:"response_code"`
+	// Kubernetes has information about a kubernetes cluster, if applicable.
+	KubernetesClusterMetadata `protobuf:"bytes,12,opt,name=Kubernetes,embedded=Kubernetes" json:""`
+	XXX_NoUnkeyedLiteral      struct{} `json:"-"`
+	XXX_unrecognized          []byte   `json:"-"`
+	XXX_sizecache             int32    `json:"-"`
 }
 
 func (m *KubeRequest) Reset()         { *m = KubeRequest{} }
 func (m *KubeRequest) String() string { return proto.CompactTextString(m) }
 func (*KubeRequest) ProtoMessage()    {}
 func (*KubeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{44}
+	return fileDescriptor_events_69f4748188040cdb, []int{45}
 }
 func (m *KubeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2296,7 +2351,7 @@ func (m *AppSessionStart) Reset()         { *m = AppSessionStart{} }
 func (m *AppSessionStart) String() string { return proto.CompactTextString(m) }
 func (*AppSessionStart) ProtoMessage()    {}
 func (*AppSessionStart) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{45}
+	return fileDescriptor_events_69f4748188040cdb, []int{46}
 }
 func (m *AppSessionStart) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2351,7 +2406,7 @@ func (m *AppSessionChunk) Reset()         { *m = AppSessionChunk{} }
 func (m *AppSessionChunk) String() string { return proto.CompactTextString(m) }
 func (*AppSessionChunk) ProtoMessage()    {}
 func (*AppSessionChunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{46}
+	return fileDescriptor_events_69f4748188040cdb, []int{47}
 }
 func (m *AppSessionChunk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2399,7 +2454,7 @@ func (m *AppSessionRequest) Reset()         { *m = AppSessionRequest{} }
 func (m *AppSessionRequest) String() string { return proto.CompactTextString(m) }
 func (*AppSessionRequest) ProtoMessage()    {}
 func (*AppSessionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{47}
+	return fileDescriptor_events_69f4748188040cdb, []int{48}
 }
 func (m *AppSessionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2482,7 +2537,7 @@ func (m *OneOf) Reset()         { *m = OneOf{} }
 func (m *OneOf) String() string { return proto.CompactTextString(m) }
 func (*OneOf) ProtoMessage()    {}
 func (*OneOf) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{48}
+	return fileDescriptor_events_69f4748188040cdb, []int{49}
 }
 func (m *OneOf) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3749,7 +3804,7 @@ func (m *StreamStatus) Reset()         { *m = StreamStatus{} }
 func (m *StreamStatus) String() string { return proto.CompactTextString(m) }
 func (*StreamStatus) ProtoMessage()    {}
 func (*StreamStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_events_14ceaf32bd4b10a2, []int{49}
+	return fileDescriptor_events_69f4748188040cdb, []int{50}
 }
 func (m *StreamStatus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3785,6 +3840,7 @@ func init() {
 	proto.RegisterType((*ServerMetadata)(nil), "events.ServerMetadata")
 	proto.RegisterMapType((map[string]string)(nil), "events.ServerMetadata.ServerLabelsEntry")
 	proto.RegisterType((*ConnectionMetadata)(nil), "events.ConnectionMetadata")
+	proto.RegisterType((*KubernetesClusterMetadata)(nil), "events.KubernetesClusterMetadata")
 	proto.RegisterType((*SessionStart)(nil), "events.SessionStart")
 	proto.RegisterType((*SessionJoin)(nil), "events.SessionJoin")
 	proto.RegisterType((*SessionPrint)(nil), "events.SessionPrint")
@@ -4044,6 +4100,33 @@ func (m *ConnectionMetadata) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *KubernetesClusterMetadata) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *KubernetesClusterMetadata) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.KubernetesCluster) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintEvents(dAtA, i, uint64(len(m.KubernetesCluster)))
+		i += copy(dAtA[i:], m.KubernetesCluster)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
 func (m *SessionStart) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -4105,6 +4188,14 @@ func (m *SessionStart) MarshalTo(dAtA []byte) (int, error) {
 		i = encodeVarintEvents(dAtA, i, uint64(len(m.TerminalSize)))
 		i += copy(dAtA[i:], m.TerminalSize)
 	}
+	dAtA[i] = 0x3a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.KubernetesClusterMetadata.Size()))
+	n7, err := m.KubernetesClusterMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n7
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -4129,43 +4220,51 @@ func (m *SessionJoin) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n7, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n7
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n8, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n8, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n8
-	dAtA[i] = 0x1a
+	dAtA[i] = 0x12
 	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n9, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n9, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n9
-	dAtA[i] = 0x22
+	dAtA[i] = 0x1a
 	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n10, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n10, err := m.SessionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n10
-	dAtA[i] = 0x2a
+	dAtA[i] = 0x22
 	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n11, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n11, err := m.ServerMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n11
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
+	n12, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n12
+	dAtA[i] = 0x32
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.KubernetesClusterMetadata.Size()))
+	n13, err := m.KubernetesClusterMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n13
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -4190,11 +4289,11 @@ func (m *SessionPrint) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n12, err := m.Metadata.MarshalTo(dAtA[i:])
+	n14, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n12
+	i += n14
 	if m.ChunkIndex != 0 {
 		dAtA[i] = 0x10
 		i++
@@ -4245,35 +4344,35 @@ func (m *SessionReject) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n13, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n13
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n14, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n14
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n15, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	n15, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n15
-	dAtA[i] = 0x22
+	dAtA[i] = 0x12
 	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n16, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n16, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n16
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n17, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n17
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
+	n18, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n18
 	if len(m.Reason) > 0 {
 		dAtA[i] = 0x2a
 		i++
@@ -4309,49 +4408,57 @@ func (m *Resize) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n17, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n17
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n18, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n18
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n19, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	n19, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n19
-	dAtA[i] = 0x22
+	dAtA[i] = 0x12
 	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n20, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n20, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n20
-	dAtA[i] = 0x2a
+	dAtA[i] = 0x1a
 	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n21, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n21, err := m.SessionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n21
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
+	n22, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n22
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n23, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n23
 	if len(m.TerminalSize) > 0 {
 		dAtA[i] = 0x32
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(len(m.TerminalSize)))
 		i += copy(dAtA[i:], m.TerminalSize)
 	}
+	dAtA[i] = 0x3a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.KubernetesClusterMetadata.Size()))
+	n24, err := m.KubernetesClusterMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n24
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -4376,43 +4483,43 @@ func (m *SessionEnd) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n22, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n22
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n23, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n23
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n24, err := m.SessionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n24
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n25, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	n25, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n25
-	dAtA[i] = 0x2a
+	dAtA[i] = 0x12
 	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n26, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n26, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n26
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n27, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n27
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
+	n28, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n28
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n29, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n29
 	if m.EnhancedRecording {
 		dAtA[i] = 0x30
 		i++
@@ -4451,19 +4558,27 @@ func (m *SessionEnd) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x4a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.StartTime)))
-	n27, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.StartTime, dAtA[i:])
+	n30, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.StartTime, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n27
+	i += n30
 	dAtA[i] = 0x52
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.EndTime)))
-	n28, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.EndTime, dAtA[i:])
+	n31, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.EndTime, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n28
+	i += n31
+	dAtA[i] = 0x5a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.KubernetesClusterMetadata.Size()))
+	n32, err := m.KubernetesClusterMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n32
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -4568,43 +4683,43 @@ func (m *SessionCommand) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n29, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n29
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n30, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n30
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n31, err := m.SessionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n31
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n32, err := m.ServerMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n32
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.BPFMetadata.Size()))
-	n33, err := m.BPFMetadata.MarshalTo(dAtA[i:])
+	n33, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n33
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n34, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n34
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n35, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n35
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n36, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n36
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.BPFMetadata.Size()))
+	n37, err := m.BPFMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n37
 	if m.PPID != 0 {
 		dAtA[i] = 0x30
 		i++
@@ -4660,43 +4775,43 @@ func (m *SessionDisk) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n34, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n34
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n35, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n35
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n36, err := m.SessionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n36
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n37, err := m.ServerMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n37
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.BPFMetadata.Size()))
-	n38, err := m.BPFMetadata.MarshalTo(dAtA[i:])
+	n38, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n38
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n39, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n39
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n40, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n40
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n41, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n41
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.BPFMetadata.Size()))
+	n42, err := m.BPFMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n42
 	if len(m.Path) > 0 {
 		dAtA[i] = 0x32
 		i++
@@ -4737,43 +4852,43 @@ func (m *SessionNetwork) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n39, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n39
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n40, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n40
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n41, err := m.SessionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n41
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n42, err := m.ServerMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n42
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.BPFMetadata.Size()))
-	n43, err := m.BPFMetadata.MarshalTo(dAtA[i:])
+	n43, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n43
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n44, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n44
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n45, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n45
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n46, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n46
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.BPFMetadata.Size()))
+	n47, err := m.BPFMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n47
 	if len(m.SrcAddr) > 0 {
 		dAtA[i] = 0x32
 		i++
@@ -4820,43 +4935,43 @@ func (m *SessionData) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n44, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n44
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n45, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n45
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n46, err := m.SessionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n46
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n47, err := m.ServerMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n47
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n48, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	n48, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n48
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n49, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n49
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n50, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n50
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n51, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n51
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
+	n52, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n52
 	if m.BytesTransmitted != 0 {
 		dAtA[i] = 0x30
 		i++
@@ -4891,43 +5006,43 @@ func (m *SessionLeave) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n49, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n49
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n50, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n50
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n51, err := m.SessionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n51
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n52, err := m.ServerMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n52
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n53, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	n53, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n53
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n54, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n54
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n55, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n55
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n56, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n56
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
+	n57, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n57
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -4952,27 +5067,27 @@ func (m *UserLogin) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n54, err := m.Metadata.MarshalTo(dAtA[i:])
+	n58, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n54
+	i += n58
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n55, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n59, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n55
+	i += n59
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Status.Size()))
-	n56, err := m.Status.MarshalTo(dAtA[i:])
+	n60, err := m.Status.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n56
+	i += n60
 	if len(m.Method) > 0 {
 		dAtA[i] = 0x22
 		i++
@@ -4983,11 +5098,11 @@ func (m *UserLogin) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.IdentityAttributes.Size()))
-		n57, err := m.IdentityAttributes.MarshalTo(dAtA[i:])
+		n61, err := m.IdentityAttributes.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n57
+		i += n61
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -5019,11 +5134,11 @@ func (m *ResourceMetadata) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.Expires)))
-	n58, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Expires, dAtA[i:])
+	n62, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Expires, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n58
+	i += n62
 	if len(m.UpdatedBy) > 0 {
 		dAtA[i] = 0x1a
 		i++
@@ -5060,27 +5175,27 @@ func (m *UserCreate) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n59, err := m.Metadata.MarshalTo(dAtA[i:])
+	n63, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n59
+	i += n63
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n60, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n64, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n60
+	i += n64
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n61, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n65, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n61
+	i += n65
 	if len(m.Roles) > 0 {
 		for _, s := range m.Roles {
 			dAtA[i] = 0x22
@@ -5126,27 +5241,27 @@ func (m *UserDelete) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n62, err := m.Metadata.MarshalTo(dAtA[i:])
+	n66, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n62
+	i += n66
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n63, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n67, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n63
+	i += n67
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n64, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n68, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n64
+	i += n68
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5171,19 +5286,19 @@ func (m *UserPasswordChange) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n65, err := m.Metadata.MarshalTo(dAtA[i:])
+	n69, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n65
+	i += n69
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n66, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n70, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n66
+	i += n70
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5208,27 +5323,27 @@ func (m *AccessRequestCreate) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n67, err := m.Metadata.MarshalTo(dAtA[i:])
+	n71, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n67
+	i += n71
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n68, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n72, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n68
+	i += n72
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n69, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n73, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n69
+	i += n73
 	if len(m.Roles) > 0 {
 		for _, s := range m.Roles {
 			dAtA[i] = 0x22
@@ -5272,11 +5387,11 @@ func (m *AccessRequestCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x4a
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.Annotations.Size()))
-		n70, err := m.Annotations.MarshalTo(dAtA[i:])
+		n74, err := m.Annotations.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n70
+		i += n74
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -5295,65 +5410,6 @@ func (m *PortForward) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *PortForward) MarshalTo(dAtA []byte) (int, error) {
-	var i int
-	_ = i
-	var l int
-	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n71, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n71
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n72, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n72
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n73, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n73
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.Status.Size()))
-	n74, err := m.Status.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n74
-	if len(m.Addr) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintEvents(dAtA, i, uint64(len(m.Addr)))
-		i += copy(dAtA[i:], m.Addr)
-	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
-}
-
-func (m *X11Forward) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *X11Forward) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -5390,6 +5446,65 @@ func (m *X11Forward) MarshalTo(dAtA []byte) (int, error) {
 		return 0, err
 	}
 	i += n78
+	if len(m.Addr) > 0 {
+		dAtA[i] = 0x2a
+		i++
+		i = encodeVarintEvents(dAtA, i, uint64(len(m.Addr)))
+		i += copy(dAtA[i:], m.Addr)
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *X11Forward) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *X11Forward) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	dAtA[i] = 0xa
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
+	n79, err := m.Metadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n79
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n80, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n80
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
+	n81, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n81
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.Status.Size()))
+	n82, err := m.Status.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n82
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5453,51 +5568,59 @@ func (m *Exec) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n79, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n79
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n80, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n80
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n81, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n81
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n82, err := m.SessionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n82
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n83, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	n83, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n83
-	dAtA[i] = 0x32
+	dAtA[i] = 0x12
 	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.CommandMetadata.Size()))
-	n84, err := m.CommandMetadata.MarshalTo(dAtA[i:])
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n84, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n84
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
+	n85, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n85
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n86, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n86
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n87, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n87
+	dAtA[i] = 0x32
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.CommandMetadata.Size()))
+	n88, err := m.CommandMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n88
+	dAtA[i] = 0x3a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.KubernetesClusterMetadata.Size()))
+	n89, err := m.KubernetesClusterMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n89
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5522,51 +5645,51 @@ func (m *SCP) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n85, err := m.Metadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n85
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n86, err := m.UserMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n86
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n87, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n87
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n88, err := m.SessionMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n88
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n89, err := m.ServerMetadata.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n89
-	dAtA[i] = 0x32
-	i++
-	i = encodeVarintEvents(dAtA, i, uint64(m.CommandMetadata.Size()))
-	n90, err := m.CommandMetadata.MarshalTo(dAtA[i:])
+	n90, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
 	i += n90
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
+	n91, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n91
+	dAtA[i] = 0x1a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
+	n92, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n92
+	dAtA[i] = 0x22
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
+	n93, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n93
+	dAtA[i] = 0x2a
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
+	n94, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n94
+	dAtA[i] = 0x32
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.CommandMetadata.Size()))
+	n95, err := m.CommandMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n95
 	if len(m.Path) > 0 {
 		dAtA[i] = 0x3a
 		i++
@@ -5603,27 +5726,27 @@ func (m *Subsystem) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n91, err := m.Metadata.MarshalTo(dAtA[i:])
+	n96, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n91
+	i += n96
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n92, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n97, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n92
+	i += n97
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n93, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	n98, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n93
+	i += n98
 	if len(m.Name) > 0 {
 		dAtA[i] = 0x22
 		i++
@@ -5660,35 +5783,35 @@ func (m *ClientDisconnect) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n94, err := m.Metadata.MarshalTo(dAtA[i:])
+	n99, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n94
+	i += n99
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n95, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n100, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n95
+	i += n100
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n96, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	n101, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n96
+	i += n101
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n97, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	n102, err := m.ServerMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n97
+	i += n102
 	if len(m.Reason) > 0 {
 		dAtA[i] = 0x2a
 		i++
@@ -5719,35 +5842,35 @@ func (m *AuthAttempt) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n98, err := m.Metadata.MarshalTo(dAtA[i:])
+	n103, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n98
+	i += n103
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n99, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n104, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n99
+	i += n104
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n100, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	n105, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n100
+	i += n105
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Status.Size()))
-	n101, err := m.Status.MarshalTo(dAtA[i:])
+	n106, err := m.Status.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n101
+	i += n106
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5772,27 +5895,27 @@ func (m *ResetPasswordTokenCreate) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n102, err := m.Metadata.MarshalTo(dAtA[i:])
+	n107, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n102
+	i += n107
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n103, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n108, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n103
+	i += n108
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n104, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n109, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n104
+	i += n109
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5817,27 +5940,27 @@ func (m *RoleCreate) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n105, err := m.Metadata.MarshalTo(dAtA[i:])
+	n110, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n105
+	i += n110
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n106, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n111, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n106
+	i += n111
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n107, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n112, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n107
+	i += n112
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5862,27 +5985,27 @@ func (m *RoleDelete) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n108, err := m.Metadata.MarshalTo(dAtA[i:])
+	n113, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n108
+	i += n113
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n109, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n114, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n109
+	i += n114
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n110, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n115, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n110
+	i += n115
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5907,27 +6030,27 @@ func (m *TrustedClusterCreate) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n111, err := m.Metadata.MarshalTo(dAtA[i:])
+	n116, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n111
+	i += n116
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n112, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n117, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n112
+	i += n117
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n113, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n118, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n113
+	i += n118
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5952,27 +6075,27 @@ func (m *TrustedClusterDelete) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n114, err := m.Metadata.MarshalTo(dAtA[i:])
+	n119, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n114
+	i += n119
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n115, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n120, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n115
+	i += n120
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n116, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n121, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n116
+	i += n121
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -5997,27 +6120,27 @@ func (m *TrustedClusterTokenCreate) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n117, err := m.Metadata.MarshalTo(dAtA[i:])
+	n122, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n117
+	i += n122
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n118, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n123, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n118
+	i += n123
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n119, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n124, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n119
+	i += n124
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -6042,27 +6165,27 @@ func (m *GithubConnectorCreate) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n120, err := m.Metadata.MarshalTo(dAtA[i:])
+	n125, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n120
+	i += n125
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n121, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n126, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n121
+	i += n126
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n122, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n127, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n122
+	i += n127
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -6087,27 +6210,27 @@ func (m *GithubConnectorDelete) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n123, err := m.Metadata.MarshalTo(dAtA[i:])
+	n128, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n123
+	i += n128
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n124, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n129, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n124
+	i += n129
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n125, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n130, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n125
+	i += n130
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -6132,27 +6255,27 @@ func (m *OIDCConnectorCreate) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n126, err := m.Metadata.MarshalTo(dAtA[i:])
+	n131, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n126
+	i += n131
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n127, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n132, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n127
+	i += n132
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n128, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n133, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n128
+	i += n133
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -6177,27 +6300,27 @@ func (m *OIDCConnectorDelete) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n129, err := m.Metadata.MarshalTo(dAtA[i:])
+	n134, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n129
+	i += n134
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n130, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n135, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n130
+	i += n135
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n131, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n136, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n131
+	i += n136
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -6222,27 +6345,27 @@ func (m *SAMLConnectorCreate) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n132, err := m.Metadata.MarshalTo(dAtA[i:])
+	n137, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n132
+	i += n137
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n133, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n138, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n133
+	i += n138
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n134, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n139, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n134
+	i += n139
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -6267,27 +6390,27 @@ func (m *SAMLConnectorDelete) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n135, err := m.Metadata.MarshalTo(dAtA[i:])
+	n140, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n135
+	i += n140
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ResourceMetadata.Size()))
-	n136, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
+	n141, err := m.ResourceMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n136
+	i += n141
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n137, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n142, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n137
+	i += n142
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -6312,35 +6435,35 @@ func (m *KubeRequest) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n138, err := m.Metadata.MarshalTo(dAtA[i:])
+	n143, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n138
+	i += n143
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n139, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n144, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n139
+	i += n144
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n140, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	n145, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n140
+	i += n145
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n141, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	n146, err := m.ServerMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n141
+	i += n146
 	if len(m.RequestPath) > 0 {
 		dAtA[i] = 0x2a
 		i++
@@ -6382,6 +6505,14 @@ func (m *KubeRequest) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.ResponseCode))
 	}
+	dAtA[i] = 0x62
+	i++
+	i = encodeVarintEvents(dAtA, i, uint64(m.KubernetesClusterMetadata.Size()))
+	n147, err := m.KubernetesClusterMetadata.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n147
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -6406,43 +6537,43 @@ func (m *AppSessionStart) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n142, err := m.Metadata.MarshalTo(dAtA[i:])
+	n148, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n142
+	i += n148
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n143, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n149, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n143
+	i += n149
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n144, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	n150, err := m.SessionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n144
+	i += n150
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n145, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	n151, err := m.ServerMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n145
+	i += n151
 	dAtA[i] = 0x2a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n146, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	n152, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n146
+	i += n152
 	if len(m.PublicAddr) > 0 {
 		dAtA[i] = 0x3a
 		i++
@@ -6473,43 +6604,43 @@ func (m *AppSessionChunk) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n147, err := m.Metadata.MarshalTo(dAtA[i:])
+	n153, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n147
+	i += n153
 	dAtA[i] = 0x12
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.UserMetadata.Size()))
-	n148, err := m.UserMetadata.MarshalTo(dAtA[i:])
+	n154, err := m.UserMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n148
+	i += n154
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.SessionMetadata.Size()))
-	n149, err := m.SessionMetadata.MarshalTo(dAtA[i:])
+	n155, err := m.SessionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n149
+	i += n155
 	dAtA[i] = 0x22
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ServerMetadata.Size()))
-	n150, err := m.ServerMetadata.MarshalTo(dAtA[i:])
+	n156, err := m.ServerMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n150
+	i += n156
 	dAtA[i] = 0x2a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.ConnectionMetadata.Size()))
-	n151, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
+	n157, err := m.ConnectionMetadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n151
+	i += n157
 	if len(m.SessionChunkID) > 0 {
 		dAtA[i] = 0x32
 		i++
@@ -6540,11 +6671,11 @@ func (m *AppSessionRequest) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0xa
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(m.Metadata.Size()))
-	n152, err := m.Metadata.MarshalTo(dAtA[i:])
+	n158, err := m.Metadata.MarshalTo(dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n152
+	i += n158
 	if m.StatusCode != 0 {
 		dAtA[i] = 0x10
 		i++
@@ -6584,11 +6715,11 @@ func (m *OneOf) MarshalTo(dAtA []byte) (int, error) {
 	var l int
 	_ = l
 	if m.Event != nil {
-		nn153, err := m.Event.MarshalTo(dAtA[i:])
+		nn159, err := m.Event.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += nn153
+		i += nn159
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -6602,11 +6733,11 @@ func (m *OneOf_UserLogin) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0xa
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.UserLogin.Size()))
-		n154, err := m.UserLogin.MarshalTo(dAtA[i:])
+		n160, err := m.UserLogin.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n154
+		i += n160
 	}
 	return i, nil
 }
@@ -6616,11 +6747,11 @@ func (m *OneOf_UserCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.UserCreate.Size()))
-		n155, err := m.UserCreate.MarshalTo(dAtA[i:])
+		n161, err := m.UserCreate.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n155
+		i += n161
 	}
 	return i, nil
 }
@@ -6630,11 +6761,11 @@ func (m *OneOf_UserDelete) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1a
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.UserDelete.Size()))
-		n156, err := m.UserDelete.MarshalTo(dAtA[i:])
+		n162, err := m.UserDelete.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n156
+		i += n162
 	}
 	return i, nil
 }
@@ -6644,11 +6775,11 @@ func (m *OneOf_UserPasswordChange) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x22
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.UserPasswordChange.Size()))
-		n157, err := m.UserPasswordChange.MarshalTo(dAtA[i:])
+		n163, err := m.UserPasswordChange.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n157
+		i += n163
 	}
 	return i, nil
 }
@@ -6658,11 +6789,11 @@ func (m *OneOf_SessionStart) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2a
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionStart.Size()))
-		n158, err := m.SessionStart.MarshalTo(dAtA[i:])
+		n164, err := m.SessionStart.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n158
+		i += n164
 	}
 	return i, nil
 }
@@ -6672,11 +6803,11 @@ func (m *OneOf_SessionJoin) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x32
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionJoin.Size()))
-		n159, err := m.SessionJoin.MarshalTo(dAtA[i:])
+		n165, err := m.SessionJoin.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n159
+		i += n165
 	}
 	return i, nil
 }
@@ -6686,11 +6817,11 @@ func (m *OneOf_SessionPrint) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x3a
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionPrint.Size()))
-		n160, err := m.SessionPrint.MarshalTo(dAtA[i:])
+		n166, err := m.SessionPrint.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n160
+		i += n166
 	}
 	return i, nil
 }
@@ -6700,11 +6831,11 @@ func (m *OneOf_SessionReject) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x42
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionReject.Size()))
-		n161, err := m.SessionReject.MarshalTo(dAtA[i:])
+		n167, err := m.SessionReject.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n161
+		i += n167
 	}
 	return i, nil
 }
@@ -6714,11 +6845,11 @@ func (m *OneOf_Resize) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x4a
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.Resize.Size()))
-		n162, err := m.Resize.MarshalTo(dAtA[i:])
+		n168, err := m.Resize.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n162
+		i += n168
 	}
 	return i, nil
 }
@@ -6728,11 +6859,11 @@ func (m *OneOf_SessionEnd) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x52
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionEnd.Size()))
-		n163, err := m.SessionEnd.MarshalTo(dAtA[i:])
+		n169, err := m.SessionEnd.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n163
+		i += n169
 	}
 	return i, nil
 }
@@ -6742,11 +6873,11 @@ func (m *OneOf_SessionCommand) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x5a
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionCommand.Size()))
-		n164, err := m.SessionCommand.MarshalTo(dAtA[i:])
+		n170, err := m.SessionCommand.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n164
+		i += n170
 	}
 	return i, nil
 }
@@ -6756,11 +6887,11 @@ func (m *OneOf_SessionDisk) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x62
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionDisk.Size()))
-		n165, err := m.SessionDisk.MarshalTo(dAtA[i:])
+		n171, err := m.SessionDisk.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n165
+		i += n171
 	}
 	return i, nil
 }
@@ -6770,11 +6901,11 @@ func (m *OneOf_SessionNetwork) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x6a
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionNetwork.Size()))
-		n166, err := m.SessionNetwork.MarshalTo(dAtA[i:])
+		n172, err := m.SessionNetwork.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n166
+		i += n172
 	}
 	return i, nil
 }
@@ -6784,11 +6915,11 @@ func (m *OneOf_SessionData) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x72
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionData.Size()))
-		n167, err := m.SessionData.MarshalTo(dAtA[i:])
+		n173, err := m.SessionData.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n167
+		i += n173
 	}
 	return i, nil
 }
@@ -6798,11 +6929,11 @@ func (m *OneOf_SessionLeave) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x7a
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SessionLeave.Size()))
-		n168, err := m.SessionLeave.MarshalTo(dAtA[i:])
+		n174, err := m.SessionLeave.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n168
+		i += n174
 	}
 	return i, nil
 }
@@ -6814,11 +6945,11 @@ func (m *OneOf_PortForward) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.PortForward.Size()))
-		n169, err := m.PortForward.MarshalTo(dAtA[i:])
+		n175, err := m.PortForward.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n169
+		i += n175
 	}
 	return i, nil
 }
@@ -6830,11 +6961,11 @@ func (m *OneOf_X11Forward) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.X11Forward.Size()))
-		n170, err := m.X11Forward.MarshalTo(dAtA[i:])
+		n176, err := m.X11Forward.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n170
+		i += n176
 	}
 	return i, nil
 }
@@ -6846,11 +6977,11 @@ func (m *OneOf_SCP) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SCP.Size()))
-		n171, err := m.SCP.MarshalTo(dAtA[i:])
+		n177, err := m.SCP.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n171
+		i += n177
 	}
 	return i, nil
 }
@@ -6862,11 +6993,11 @@ func (m *OneOf_Exec) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.Exec.Size()))
-		n172, err := m.Exec.MarshalTo(dAtA[i:])
+		n178, err := m.Exec.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n172
+		i += n178
 	}
 	return i, nil
 }
@@ -6878,11 +7009,11 @@ func (m *OneOf_Subsystem) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.Subsystem.Size()))
-		n173, err := m.Subsystem.MarshalTo(dAtA[i:])
+		n179, err := m.Subsystem.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n173
+		i += n179
 	}
 	return i, nil
 }
@@ -6894,11 +7025,11 @@ func (m *OneOf_ClientDisconnect) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.ClientDisconnect.Size()))
-		n174, err := m.ClientDisconnect.MarshalTo(dAtA[i:])
+		n180, err := m.ClientDisconnect.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n174
+		i += n180
 	}
 	return i, nil
 }
@@ -6910,11 +7041,11 @@ func (m *OneOf_AuthAttempt) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.AuthAttempt.Size()))
-		n175, err := m.AuthAttempt.MarshalTo(dAtA[i:])
+		n181, err := m.AuthAttempt.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n175
+		i += n181
 	}
 	return i, nil
 }
@@ -6926,11 +7057,11 @@ func (m *OneOf_AccessRequestCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.AccessRequestCreate.Size()))
-		n176, err := m.AccessRequestCreate.MarshalTo(dAtA[i:])
+		n182, err := m.AccessRequestCreate.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n176
+		i += n182
 	}
 	return i, nil
 }
@@ -6942,11 +7073,11 @@ func (m *OneOf_ResetPasswordTokenCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.ResetPasswordTokenCreate.Size()))
-		n177, err := m.ResetPasswordTokenCreate.MarshalTo(dAtA[i:])
+		n183, err := m.ResetPasswordTokenCreate.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n177
+		i += n183
 	}
 	return i, nil
 }
@@ -6958,11 +7089,11 @@ func (m *OneOf_RoleCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.RoleCreate.Size()))
-		n178, err := m.RoleCreate.MarshalTo(dAtA[i:])
+		n184, err := m.RoleCreate.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n178
+		i += n184
 	}
 	return i, nil
 }
@@ -6974,11 +7105,11 @@ func (m *OneOf_RoleDelete) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.RoleDelete.Size()))
-		n179, err := m.RoleDelete.MarshalTo(dAtA[i:])
+		n185, err := m.RoleDelete.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n179
+		i += n185
 	}
 	return i, nil
 }
@@ -6990,11 +7121,11 @@ func (m *OneOf_TrustedClusterCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.TrustedClusterCreate.Size()))
-		n180, err := m.TrustedClusterCreate.MarshalTo(dAtA[i:])
+		n186, err := m.TrustedClusterCreate.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n180
+		i += n186
 	}
 	return i, nil
 }
@@ -7006,11 +7137,11 @@ func (m *OneOf_TrustedClusterDelete) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.TrustedClusterDelete.Size()))
-		n181, err := m.TrustedClusterDelete.MarshalTo(dAtA[i:])
+		n187, err := m.TrustedClusterDelete.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n181
+		i += n187
 	}
 	return i, nil
 }
@@ -7022,11 +7153,11 @@ func (m *OneOf_TrustedClusterTokenCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.TrustedClusterTokenCreate.Size()))
-		n182, err := m.TrustedClusterTokenCreate.MarshalTo(dAtA[i:])
+		n188, err := m.TrustedClusterTokenCreate.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n182
+		i += n188
 	}
 	return i, nil
 }
@@ -7038,11 +7169,11 @@ func (m *OneOf_GithubConnectorCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.GithubConnectorCreate.Size()))
-		n183, err := m.GithubConnectorCreate.MarshalTo(dAtA[i:])
+		n189, err := m.GithubConnectorCreate.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n183
+		i += n189
 	}
 	return i, nil
 }
@@ -7054,11 +7185,11 @@ func (m *OneOf_GithubConnectorDelete) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x1
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.GithubConnectorDelete.Size()))
-		n184, err := m.GithubConnectorDelete.MarshalTo(dAtA[i:])
+		n190, err := m.GithubConnectorDelete.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n184
+		i += n190
 	}
 	return i, nil
 }
@@ -7070,11 +7201,11 @@ func (m *OneOf_OIDCConnectorCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.OIDCConnectorCreate.Size()))
-		n185, err := m.OIDCConnectorCreate.MarshalTo(dAtA[i:])
+		n191, err := m.OIDCConnectorCreate.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n185
+		i += n191
 	}
 	return i, nil
 }
@@ -7086,11 +7217,11 @@ func (m *OneOf_OIDCConnectorDelete) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.OIDCConnectorDelete.Size()))
-		n186, err := m.OIDCConnectorDelete.MarshalTo(dAtA[i:])
+		n192, err := m.OIDCConnectorDelete.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n186
+		i += n192
 	}
 	return i, nil
 }
@@ -7102,11 +7233,11 @@ func (m *OneOf_SAMLConnectorCreate) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SAMLConnectorCreate.Size()))
-		n187, err := m.SAMLConnectorCreate.MarshalTo(dAtA[i:])
+		n193, err := m.SAMLConnectorCreate.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n187
+		i += n193
 	}
 	return i, nil
 }
@@ -7118,11 +7249,11 @@ func (m *OneOf_SAMLConnectorDelete) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.SAMLConnectorDelete.Size()))
-		n188, err := m.SAMLConnectorDelete.MarshalTo(dAtA[i:])
+		n194, err := m.SAMLConnectorDelete.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n188
+		i += n194
 	}
 	return i, nil
 }
@@ -7134,11 +7265,11 @@ func (m *OneOf_KubeRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.KubeRequest.Size()))
-		n189, err := m.KubeRequest.MarshalTo(dAtA[i:])
+		n195, err := m.KubeRequest.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n189
+		i += n195
 	}
 	return i, nil
 }
@@ -7150,11 +7281,11 @@ func (m *OneOf_AppSessionStart) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.AppSessionStart.Size()))
-		n190, err := m.AppSessionStart.MarshalTo(dAtA[i:])
+		n196, err := m.AppSessionStart.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n190
+		i += n196
 	}
 	return i, nil
 }
@@ -7166,11 +7297,11 @@ func (m *OneOf_AppSessionChunk) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.AppSessionChunk.Size()))
-		n191, err := m.AppSessionChunk.MarshalTo(dAtA[i:])
+		n197, err := m.AppSessionChunk.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n191
+		i += n197
 	}
 	return i, nil
 }
@@ -7182,11 +7313,11 @@ func (m *OneOf_AppSessionRequest) MarshalTo(dAtA []byte) (int, error) {
 		dAtA[i] = 0x2
 		i++
 		i = encodeVarintEvents(dAtA, i, uint64(m.AppSessionRequest.Size()))
-		n192, err := m.AppSessionRequest.MarshalTo(dAtA[i:])
+		n198, err := m.AppSessionRequest.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
-		i += n192
+		i += n198
 	}
 	return i, nil
 }
@@ -7219,11 +7350,11 @@ func (m *StreamStatus) MarshalTo(dAtA []byte) (int, error) {
 	dAtA[i] = 0x1a
 	i++
 	i = encodeVarintEvents(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdTime(m.LastUploadTime)))
-	n193, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.LastUploadTime, dAtA[i:])
+	n199, err := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.LastUploadTime, dAtA[i:])
 	if err != nil {
 		return 0, err
 	}
-	i += n193
+	i += n199
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -7349,6 +7480,19 @@ func (m *ConnectionMetadata) Size() (n int) {
 	return n
 }
 
+func (m *KubernetesClusterMetadata) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.KubernetesCluster)
+	if l > 0 {
+		n += 1 + l + sovEvents(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
 func (m *SessionStart) Size() (n int) {
 	var l int
 	_ = l
@@ -7366,6 +7510,8 @@ func (m *SessionStart) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovEvents(uint64(l))
 	}
+	l = m.KubernetesClusterMetadata.Size()
+	n += 1 + l + sovEvents(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -7384,6 +7530,8 @@ func (m *SessionJoin) Size() (n int) {
 	l = m.ServerMetadata.Size()
 	n += 1 + l + sovEvents(uint64(l))
 	l = m.ConnectionMetadata.Size()
+	n += 1 + l + sovEvents(uint64(l))
+	l = m.KubernetesClusterMetadata.Size()
 	n += 1 + l + sovEvents(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -7459,6 +7607,8 @@ func (m *Resize) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovEvents(uint64(l))
 	}
+	l = m.KubernetesClusterMetadata.Size()
+	n += 1 + l + sovEvents(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -7493,6 +7643,8 @@ func (m *SessionEnd) Size() (n int) {
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.StartTime)
 	n += 1 + l + sovEvents(uint64(l))
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.EndTime)
+	n += 1 + l + sovEvents(uint64(l))
+	l = m.KubernetesClusterMetadata.Size()
 	n += 1 + l + sovEvents(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -7894,6 +8046,8 @@ func (m *Exec) Size() (n int) {
 	n += 1 + l + sovEvents(uint64(l))
 	l = m.CommandMetadata.Size()
 	n += 1 + l + sovEvents(uint64(l))
+	l = m.KubernetesClusterMetadata.Size()
+	n += 1 + l + sovEvents(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -8208,6 +8362,8 @@ func (m *KubeRequest) Size() (n int) {
 	if m.ResponseCode != 0 {
 		n += 1 + sovEvents(uint64(m.ResponseCode))
 	}
+	l = m.KubernetesClusterMetadata.Size()
+	n += 1 + l + sovEvents(uint64(l))
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -9475,6 +9631,86 @@ func (m *ConnectionMetadata) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *KubernetesClusterMetadata) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowEvents
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: KubernetesClusterMetadata: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: KubernetesClusterMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KubernetesCluster", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthEvents
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.KubernetesCluster = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipEvents(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthEvents
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *SessionStart) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -9683,6 +9919,36 @@ func (m *SessionStart) Unmarshal(dAtA []byte) error {
 			}
 			m.TerminalSize = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KubernetesClusterMetadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthEvents
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.KubernetesClusterMetadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipEvents(dAtA[iNdEx:])
@@ -9881,6 +10147,36 @@ func (m *SessionJoin) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.ConnectionMetadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KubernetesClusterMetadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthEvents
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.KubernetesClusterMetadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -10521,6 +10817,36 @@ func (m *Resize) Unmarshal(dAtA []byte) error {
 			}
 			m.TerminalSize = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KubernetesClusterMetadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthEvents
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.KubernetesClusterMetadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipEvents(dAtA[iNdEx:])
@@ -10848,6 +11174,36 @@ func (m *SessionEnd) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := github_com_gogo_protobuf_types.StdTimeUnmarshal(&m.EndTime, dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KubernetesClusterMetadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthEvents
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.KubernetesClusterMetadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -14281,6 +14637,36 @@ func (m *Exec) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KubernetesClusterMetadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthEvents
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.KubernetesClusterMetadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipEvents(dAtA[iNdEx:])
@@ -17196,6 +17582,36 @@ func (m *KubeRequest) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KubernetesClusterMetadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvents
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthEvents
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.KubernetesClusterMetadata.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipEvents(dAtA[iNdEx:])
@@ -19369,213 +19785,218 @@ var (
 	ErrIntOverflowEvents   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("events.proto", fileDescriptor_events_14ceaf32bd4b10a2) }
+func init() { proto.RegisterFile("events.proto", fileDescriptor_events_69f4748188040cdb) }
 
-var fileDescriptor_events_14ceaf32bd4b10a2 = []byte{
-	// 3271 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x5c, 0xcf, 0x73, 0x1c, 0x47,
-	0xf5, 0xdf, 0xdf, 0x3f, 0x7a, 0xd7, 0xb6, 0x34, 0x92, 0xed, 0xb1, 0x63, 0x7b, 0xe4, 0x71, 0xe2,
-	0xaf, 0x5d, 0x49, 0xec, 0xb2, 0xa2, 0xc4, 0xf9, 0xa6, 0xbe, 0xdf, 0x72, 0xb4, 0x2b, 0x39, 0x2b,
-	0x22, 0x5b, 0x4b, 0x4b, 0x0e, 0xb9, 0x10, 0xd5, 0x68, 0xa7, 0xbd, 0x1a, 0xbc, 0x3b, 0xb3, 0xe9,
-	0xe9, 0x95, 0x25, 0x9f, 0xa0, 0xe0, 0xc0, 0x21, 0x55, 0x50, 0xe1, 0x42, 0x15, 0x07, 0xb8, 0x70,
-	0xe3, 0x00, 0x39, 0x71, 0x07, 0xaa, 0x0c, 0x14, 0x90, 0x0a, 0x5c, 0x59, 0xc0, 0xdc, 0xf6, 0x4f,
-	0xa0, 0x8a, 0x82, 0xea, 0xd7, 0x3d, 0x3b, 0x3d, 0xb3, 0x23, 0x3b, 0xb1, 0x5c, 0xa5, 0x92, 0xa3,
-	0x93, 0xb5, 0xef, 0x57, 0x4f, 0xbf, 0xf7, 0xba, 0xe7, 0xbd, 0x4f, 0xf7, 0x18, 0x55, 0xc9, 0x16,
-	0x71, 0x99, 0x7f, 0xa5, 0x47, 0x3d, 0xe6, 0x69, 0x05, 0xf1, 0xeb, 0xf4, 0x74, 0xdb, 0x6b, 0x7b,
-	0x40, 0xba, 0xca, 0xff, 0x12, 0xdc, 0xd3, 0x46, 0xdb, 0xf3, 0xda, 0x1d, 0x72, 0x15, 0x7e, 0x6d,
-	0xf4, 0xef, 0x5e, 0x65, 0x4e, 0x97, 0xf8, 0xcc, 0xea, 0xf6, 0xa4, 0xc0, 0x99, 0xb8, 0x80, 0xcf,
-	0x68, 0xbf, 0xc5, 0x04, 0xd7, 0xfc, 0x4b, 0x1a, 0x95, 0x6e, 0x11, 0x66, 0xd9, 0x16, 0xb3, 0xb4,
-	0x33, 0x28, 0xbf, 0xe4, 0xda, 0x64, 0x5b, 0x4f, 0xcf, 0xa4, 0x2f, 0x65, 0x6b, 0x85, 0xe1, 0xc0,
-	0xc8, 0x10, 0x07, 0x0b, 0xa2, 0x76, 0x16, 0xe5, 0xd6, 0x76, 0x7a, 0x44, 0xcf, 0xcc, 0xa4, 0x2f,
-	0x95, 0x6b, 0xe5, 0xe1, 0xc0, 0xc8, 0xc3, 0x93, 0x61, 0x20, 0x6b, 0xe7, 0x51, 0x66, 0x69, 0x41,
-	0xcf, 0x02, 0x73, 0x72, 0x38, 0x30, 0x8e, 0xf4, 0x1d, 0xfb, 0x15, 0xaf, 0xeb, 0x30, 0xd2, 0xed,
-	0xb1, 0x1d, 0x9c, 0x59, 0x5a, 0xd0, 0x2e, 0xa2, 0x5c, 0xdd, 0xb3, 0x89, 0x9e, 0x03, 0x21, 0x6d,
-	0x38, 0x30, 0x8e, 0xb6, 0x3c, 0x9b, 0x28, 0x52, 0xc0, 0xd7, 0xde, 0x46, 0xb9, 0x35, 0xa7, 0x4b,
-	0xf4, 0xfc, 0x4c, 0xfa, 0x52, 0x65, 0xf6, 0xf4, 0x15, 0x31, 0x83, 0x2b, 0xc1, 0x0c, 0xae, 0xac,
-	0x05, 0x53, 0xac, 0x4d, 0x3c, 0x1c, 0x18, 0xa9, 0xe1, 0xc0, 0xc8, 0xf1, 0x59, 0x7f, 0xff, 0x6f,
-	0x46, 0x1a, 0x83, 0xa6, 0xf9, 0x26, 0x3a, 0xb6, 0x4a, 0x7c, 0xdf, 0xf1, 0xdc, 0xd1, 0xe4, 0x5e,
-	0x42, 0x65, 0x49, 0x5a, 0x5a, 0x80, 0x09, 0x96, 0x6b, 0xc5, 0xe1, 0xc0, 0xc8, 0xfa, 0x8e, 0x8d,
-	0x43, 0x8e, 0xf9, 0x35, 0x54, 0xbd, 0xe3, 0x13, 0xaa, 0xf8, 0x24, 0xc7, 0x7f, 0x4b, 0x8d, 0x12,
-	0x1f, 0xab, 0xef, 0x13, 0x8a, 0x81, 0xaa, 0x5d, 0x46, 0xf9, 0x65, 0xaf, 0xed, 0xb8, 0xd2, 0x29,
-	0x53, 0xc3, 0x81, 0x71, 0xac, 0xc3, 0x09, 0xca, 0x9c, 0x84, 0x84, 0xf9, 0xf3, 0x2c, 0x3a, 0xba,
-	0x4a, 0xe8, 0x96, 0x62, 0x7b, 0x9e, 0x3f, 0x25, 0xa7, 0xdc, 0xb6, 0xba, 0xc4, 0xef, 0x59, 0x2d,
-	0x22, 0x87, 0x39, 0x39, 0x1c, 0x18, 0x53, 0x6e, 0x40, 0x54, 0x6c, 0xc5, 0xe5, 0xb5, 0xcb, 0xa8,
-	0x24, 0x48, 0x4b, 0x0b, 0xf2, 0x19, 0x8e, 0x0c, 0x07, 0x46, 0xd9, 0x07, 0xda, 0xba, 0x63, 0xe3,
-	0x11, 0x5b, 0x5b, 0x0c, 0xc6, 0x6f, 0x78, 0x3e, 0xe3, 0xc6, 0x65, 0xb0, 0xce, 0x0e, 0x07, 0xc6,
-	0x29, 0xa9, 0xb0, 0x29, 0x59, 0xca, 0x90, 0x31, 0x25, 0xed, 0x7f, 0x11, 0x12, 0x94, 0x79, 0xdb,
-	0xa6, 0x32, 0x94, 0xa7, 0x86, 0x03, 0xe3, 0xb8, 0x34, 0x61, 0xd9, 0x36, 0x55, 0xd4, 0x15, 0x61,
-	0xad, 0x8b, 0xaa, 0xe2, 0xd7, 0xb2, 0xb5, 0x41, 0x3a, 0xbe, 0x9e, 0x9f, 0xc9, 0x5e, 0xaa, 0xcc,
-	0x5e, 0xba, 0x22, 0xd3, 0x3d, 0xea, 0x9d, 0x2b, 0xaa, 0xe8, 0xa2, 0xcb, 0xe8, 0x4e, 0xcd, 0x90,
-	0xd1, 0x3e, 0x29, 0x87, 0xea, 0x00, 0x4f, 0x19, 0x2c, 0x62, 0xfe, 0xf4, 0x0d, 0x34, 0x39, 0x66,
-	0x43, 0x9b, 0x40, 0xd9, 0x7b, 0x64, 0x47, 0xf8, 0x19, 0xf3, 0x3f, 0xb5, 0x69, 0x94, 0xdf, 0xb2,
-	0x3a, 0x7d, 0x99, 0xd8, 0x58, 0xfc, 0x78, 0x2b, 0xf3, 0x66, 0xda, 0xfc, 0x65, 0x1a, 0x69, 0x75,
-	0xcf, 0x75, 0x49, 0x8b, 0xa9, 0x99, 0xf4, 0x06, 0x2a, 0x2f, 0x7b, 0x2d, 0xab, 0x03, 0x0e, 0x10,
-	0x01, 0xd3, 0x87, 0x03, 0x63, 0x9a, 0xcf, 0xfc, 0x4a, 0x87, 0x73, 0x94, 0x47, 0x0a, 0x45, 0xb9,
-	0xe7, 0x30, 0xe9, 0x7a, 0x8c, 0x80, 0x62, 0x26, 0xf4, 0x1c, 0x28, 0x52, 0x60, 0xa9, 0x9e, 0x0b,
-	0x85, 0xb5, 0xab, 0xa8, 0xd4, 0xe4, 0xd9, 0xdf, 0xf2, 0x3a, 0x32, 0x6a, 0x90, 0x6a, 0xb0, 0x22,
-	0x14, 0x95, 0x91, 0x90, 0xf9, 0xed, 0x2c, 0xf7, 0x35, 0x24, 0xf5, 0x2a, 0xb3, 0x28, 0xd3, 0xde,
-	0x0a, 0xd7, 0x39, 0x3c, 0x73, 0x65, 0x76, 0x22, 0xf0, 0x7b, 0x40, 0xaf, 0x55, 0xb9, 0x7f, 0x3f,
-	0x1d, 0x18, 0xe9, 0xe1, 0xc0, 0x48, 0xe1, 0x92, 0x32, 0x61, 0xb1, 0x06, 0x32, 0xa0, 0x37, 0x1d,
-	0xe8, 0xa9, 0xeb, 0x24, 0xa6, 0x2b, 0x56, 0xc7, 0x0d, 0x54, 0x94, 0xcf, 0x00, 0x0f, 0x5d, 0x99,
-	0x3d, 0x19, 0x86, 0x3a, 0xb2, 0x38, 0x63, 0xda, 0x81, 0x96, 0xf6, 0x7f, 0xa8, 0x20, 0x22, 0x08,
-	0x79, 0x56, 0x99, 0x3d, 0x91, 0x9c, 0x2a, 0x31, 0x75, 0xa9, 0xa3, 0x35, 0x10, 0x0a, 0xa3, 0x37,
-	0xda, 0x4c, 0xa4, 0x85, 0xf1, 0xb8, 0xc6, 0xac, 0x28, 0xba, 0xda, 0x1b, 0xa8, 0xba, 0x46, 0x68,
-	0xd7, 0x71, 0xad, 0xce, 0xaa, 0xf3, 0x80, 0xe8, 0x85, 0x70, 0x03, 0xf3, 0x9d, 0x07, 0x6a, 0xd0,
-	0x22, 0x72, 0xe6, 0xef, 0x32, 0xa8, 0x22, 0xe7, 0xf2, 0x15, 0xcf, 0x71, 0x0f, 0x83, 0xb0, 0x87,
-	0x20, 0x98, 0x1f, 0x65, 0x46, 0x29, 0xdd, 0xa4, 0x8e, 0xbb, 0xb7, 0x94, 0xbe, 0x88, 0x50, 0x7d,
-	0xb3, 0xef, 0xde, 0x13, 0xef, 0xbb, 0x4c, 0xf8, 0xbe, 0x6b, 0x39, 0x58, 0xe1, 0xf0, 0x97, 0xde,
-	0x02, 0xb7, 0xcf, 0x5d, 0x57, 0xad, 0x95, 0x1f, 0x0a, 0x4b, 0xe9, 0x57, 0x31, 0x90, 0x35, 0x03,
-	0xe5, 0x6b, 0x3b, 0x8c, 0xf8, 0xe0, 0x9a, 0xac, 0x78, 0x29, 0x6e, 0x70, 0x02, 0x16, 0x74, 0x6d,
-	0x0e, 0x4d, 0x2e, 0x90, 0x8e, 0xb5, 0x73, 0xcb, 0xe9, 0x74, 0x1c, 0x9f, 0xb4, 0x3c, 0xd7, 0xf6,
-	0xc1, 0x0b, 0x72, 0xb8, 0xae, 0x8f, 0xc7, 0x05, 0x34, 0x13, 0x15, 0x56, 0xee, 0xde, 0xf5, 0x09,
-	0x83, 0x4c, 0xcb, 0xd6, 0xd0, 0x70, 0x60, 0x14, 0x3c, 0xa0, 0x60, 0xc9, 0x31, 0x3f, 0xcb, 0xa0,
-	0x23, 0xd2, 0x1d, 0x98, 0x7c, 0x83, 0xb4, 0xf6, 0x67, 0x89, 0x87, 0xc9, 0x91, 0xdd, 0x73, 0x72,
-	0xe4, 0xf6, 0xb0, 0x42, 0x4d, 0x54, 0xc0, 0xc4, 0xf2, 0x65, 0x8a, 0x95, 0x85, 0xc7, 0x28, 0x50,
-	0xb0, 0xe4, 0x68, 0xe7, 0x51, 0xf1, 0x96, 0xb5, 0xed, 0x74, 0xfb, 0x5d, 0xe9, 0x56, 0x78, 0xff,
-	0x77, 0xad, 0x6d, 0x1c, 0xd0, 0xcd, 0x7f, 0x67, 0xb8, 0x1d, 0xbe, 0xa6, 0x0f, 0xe6, 0x5a, 0x7d,
-	0x76, 0x0e, 0x0d, 0x03, 0x9b, 0x7f, 0x8a, 0xc0, 0x3e, 0xed, 0x86, 0xf9, 0x8b, 0x3c, 0xaf, 0x2e,
-	0x60, 0x2e, 0x8b, 0xae, 0x7d, 0x18, 0x83, 0xbd, 0xc4, 0x60, 0x01, 0x4d, 0x2e, 0xba, 0x9b, 0x96,
-	0xdb, 0x22, 0x36, 0x26, 0x2d, 0x8f, 0xda, 0x8e, 0xdb, 0x86, 0x40, 0x94, 0x6a, 0x27, 0x86, 0x03,
-	0x43, 0x23, 0x92, 0xb9, 0x4e, 0x03, 0x2e, 0x1e, 0x57, 0xd0, 0xae, 0xa1, 0xca, 0x92, 0xcb, 0x08,
-	0xb5, 0x5a, 0xcc, 0xd9, 0x22, 0x7a, 0x11, 0xf4, 0x8f, 0x0d, 0x07, 0x46, 0xc5, 0x09, 0xc9, 0x58,
-	0x95, 0xd1, 0xe6, 0x50, 0xb5, 0x69, 0x51, 0xe6, 0xb4, 0x9c, 0x9e, 0xe5, 0x32, 0x5f, 0x2f, 0xcd,
-	0x64, 0x2f, 0x95, 0x6b, 0x13, 0xc3, 0x81, 0x51, 0xed, 0x29, 0x74, 0x1c, 0x91, 0xd2, 0xbe, 0x8e,
-	0xca, 0x50, 0xa9, 0x40, 0xe5, 0x5f, 0x7e, 0x62, 0xe5, 0x7f, 0x21, 0xac, 0x05, 0xc1, 0xed, 0xeb,
-	0x3e, 0x57, 0x0e, 0x13, 0x0b, 0x9a, 0x81, 0xd0, 0xa2, 0xf6, 0x3e, 0x2a, 0x2e, 0xba, 0x36, 0x18,
-	0x47, 0x4f, 0x34, 0x6e, 0x4a, 0xe3, 0x27, 0x42, 0xe3, 0x5e, 0x2f, 0x66, 0x3b, 0x30, 0x67, 0x3e,
-	0x40, 0x95, 0x5a, 0xf3, 0xe6, 0x28, 0xef, 0x4e, 0xa1, 0x6c, 0x53, 0x76, 0x18, 0x39, 0xb1, 0xc3,
-	0xf4, 0x1c, 0x1b, 0x73, 0x1a, 0x2f, 0xd6, 0xeb, 0x6d, 0xea, 0xf5, 0x7b, 0xb2, 0x58, 0xcf, 0x89,
-	0x62, 0xbd, 0x05, 0x34, 0x28, 0xd6, 0x03, 0xb6, 0xf6, 0x12, 0x2a, 0x36, 0xa9, 0xd7, 0xa6, 0x56,
-	0x57, 0xd6, 0x7b, 0x95, 0xe1, 0xc0, 0x28, 0xf6, 0x04, 0x09, 0x07, 0x3c, 0xf3, 0x07, 0x69, 0x54,
-	0x58, 0x65, 0x16, 0xeb, 0xfb, 0x5c, 0x63, 0xb5, 0xdf, 0x6a, 0x11, 0xdf, 0x87, 0xb1, 0x4b, 0x42,
-	0xc3, 0x17, 0x24, 0x1c, 0xf0, 0x78, 0xc7, 0xb2, 0x48, 0xa9, 0x47, 0xd5, 0x8e, 0x85, 0x70, 0x82,
-	0xda, 0xb1, 0x80, 0x84, 0x76, 0x1d, 0x55, 0xc4, 0x6a, 0xf1, 0x7d, 0xab, 0x1d, 0x74, 0x0b, 0xc7,
-	0x87, 0x03, 0x63, 0xb2, 0x2b, 0x48, 0x8a, 0x8a, 0x2a, 0x69, 0xfe, 0x0a, 0x5a, 0x1d, 0xf0, 0x5c,
-	0xdd, 0xeb, 0x76, 0xad, 0x83, 0xba, 0x92, 0xf7, 0x56, 0xf9, 0xbc, 0x86, 0xb2, 0xb5, 0xe6, 0x4d,
-	0xb9, 0x74, 0xa7, 0x02, 0x55, 0x25, 0x55, 0x62, 0x7a, 0x5c, 0x9a, 0xb7, 0x9b, 0x4d, 0x9e, 0x3e,
-	0x05, 0x48, 0x0f, 0x68, 0x37, 0x7b, 0x3c, 0x7f, 0x80, 0x0a, 0x5c, 0x8b, 0x6d, 0xc2, 0x2a, 0x94,
-	0xcd, 0x68, 0xcf, 0x62, 0x9b, 0x18, 0xa8, 0x9c, 0x3b, 0x4f, 0xdb, 0x5b, 0x72, 0xbd, 0x01, 0xd7,
-	0xa2, 0xed, 0x2d, 0x0c, 0x54, 0xed, 0x2a, 0xef, 0x3e, 0x58, 0x9f, 0xba, 0xd0, 0x82, 0xf3, 0x05,
-	0x96, 0x17, 0xeb, 0x98, 0x02, 0x75, 0x9d, 0x77, 0xe2, 0x58, 0x11, 0x31, 0x7f, 0x9a, 0x1d, 0x15,
-	0xaf, 0x0b, 0x8e, 0x7f, 0xef, 0x30, 0x84, 0x5f, 0x20, 0x84, 0x3c, 0x48, 0x85, 0xc4, 0x20, 0x19,
-	0x28, 0x7f, 0xb3, 0x63, 0xb5, 0x7d, 0x88, 0x61, 0x5e, 0x54, 0x8c, 0x77, 0x39, 0x01, 0x0b, 0x7a,
-	0x2c, 0x4e, 0xa5, 0x27, 0xc7, 0xe9, 0xaf, 0xe1, 0x6a, 0xbb, 0x4d, 0xd8, 0x7d, 0x8f, 0x1e, 0x86,
-	0xea, 0xf3, 0x86, 0xea, 0x22, 0x2a, 0xae, 0xd2, 0x16, 0xb4, 0xe3, 0x22, 0x5a, 0xd5, 0xe1, 0xc0,
-	0x28, 0xf9, 0xb4, 0x05, 0x28, 0x06, 0x0e, 0x98, 0x5c, 0x6e, 0xc1, 0x67, 0x20, 0x57, 0x0c, 0xe5,
-	0x6c, 0x9f, 0x49, 0x39, 0xc9, 0x94, 0x72, 0x4d, 0x8f, 0x32, 0x19, 0xb8, 0x91, 0x5c, 0xcf, 0xa3,
-	0x0c, 0x07, 0x4c, 0xed, 0x65, 0x84, 0xd6, 0xea, 0xcd, 0xf7, 0x08, 0x05, 0x77, 0x89, 0xb5, 0x08,
-	0xdb, 0xf5, 0x96, 0x20, 0x61, 0x85, 0x6d, 0xfe, 0x4c, 0x59, 0x87, 0x3c, 0x40, 0x87, 0x4d, 0xe4,
-	0x1e, 0x4a, 0xaa, 0x59, 0x34, 0x01, 0x8d, 0xd9, 0x1a, 0xb5, 0x5c, 0xbf, 0xeb, 0x30, 0x46, 0x6c,
-	0xb9, 0xd7, 0x42, 0x3b, 0xc6, 0xb6, 0xf1, 0x18, 0x5f, 0x7b, 0x05, 0x1d, 0x01, 0x1a, 0x26, 0x2d,
-	0xe2, 0x6c, 0x11, 0x1b, 0x72, 0x40, 0x2a, 0xd0, 0x6d, 0x1c, 0x65, 0x9a, 0xbf, 0x0f, 0xdb, 0xd4,
-	0x65, 0x62, 0x6d, 0x91, 0xc3, 0x78, 0xed, 0xa5, 0xe9, 0xff, 0x34, 0x83, 0xca, 0x7c, 0x46, 0x80,
-	0xa1, 0xee, 0x8b, 0x2b, 0xe7, 0x82, 0x0a, 0x4b, 0x7a, 0xf2, 0xe8, 0xc8, 0x13, 0x40, 0x1d, 0xf3,
-	0x80, 0xa8, 0xc6, 0x5e, 0x41, 0x85, 0x5b, 0x84, 0x6d, 0x7a, 0xb6, 0x44, 0x48, 0xa7, 0x87, 0x03,
-	0x63, 0xa2, 0x0b, 0x14, 0xa5, 0x6a, 0x92, 0x32, 0xda, 0x3d, 0xa4, 0x2d, 0xd9, 0xc4, 0x65, 0x0e,
-	0xdb, 0x99, 0x67, 0x8c, 0x3a, 0x1b, 0x7d, 0x46, 0x7c, 0xe9, 0xb7, 0x93, 0x63, 0x75, 0xea, 0x2a,
-	0x00, 0xf8, 0x35, 0x13, 0x30, 0xc7, 0x91, 0x78, 0x68, 0xf6, 0x5f, 0x03, 0xa3, 0x20, 0x64, 0x70,
-	0x82, 0x59, 0xf3, 0x51, 0x1a, 0x4d, 0x60, 0xe2, 0x7b, 0x7d, 0xda, 0x22, 0x0a, 0x1e, 0x92, 0xbb,
-	0x6d, 0x75, 0x03, 0xfc, 0x19, 0x1a, 0xb5, 0x18, 0x0e, 0x0c, 0x7c, 0x6d, 0x09, 0x15, 0x17, 0xb7,
-	0x7b, 0x0e, 0x25, 0xbe, 0x74, 0xe4, 0xe3, 0xca, 0xe8, 0x29, 0x59, 0x46, 0x17, 0x89, 0x50, 0x91,
-	0x75, 0xb3, 0xf8, 0xa1, 0xbd, 0x81, 0xca, 0x77, 0x7a, 0xb6, 0xc5, 0x88, 0x5d, 0xdb, 0x91, 0xc5,
-	0x25, 0xc0, 0xa8, 0x7d, 0x41, 0x5c, 0xdf, 0xd8, 0x51, 0x61, 0xd4, 0x91, 0xa8, 0x76, 0x01, 0x65,
-	0xd7, 0xd6, 0x96, 0xa5, 0x5f, 0xe1, 0xa4, 0x81, 0x31, 0x15, 0x71, 0xe5, 0x5c, 0xf3, 0xe3, 0x0c,
-	0x42, 0x3c, 0x7c, 0x75, 0x4a, 0x2c, 0xb6, 0x3f, 0x6b, 0xb0, 0x86, 0x4a, 0x81, 0x9b, 0x65, 0xea,
-	0xe8, 0x81, 0x6e, 0xdc, 0xfd, 0xf1, 0xb1, 0x03, 0x3e, 0xaf, 0x16, 0xb0, 0xd7, 0x01, 0x7c, 0x29,
-	0x1b, 0x1c, 0xba, 0x50, 0x4e, 0xc0, 0x82, 0xae, 0xbd, 0x8c, 0xca, 0x72, 0xb5, 0x78, 0x54, 0x42,
-	0x1f, 0xa2, 0xa7, 0x08, 0x88, 0x38, 0xe4, 0x9b, 0xbf, 0x4e, 0x0b, 0xa7, 0x2c, 0x90, 0x0e, 0x39,
-	0xb8, 0x4e, 0x31, 0xbf, 0x9b, 0x46, 0x1a, 0x37, 0xd6, 0xb4, 0x7c, 0xff, 0xbe, 0x47, 0xed, 0xfa,
-	0xa6, 0xe5, 0xb6, 0xf7, 0x65, 0x3a, 0xe6, 0xc7, 0x39, 0x34, 0x35, 0x2f, 0x3a, 0x2c, 0xf2, 0x61,
-	0x9f, 0xf8, 0xec, 0x80, 0xe7, 0xdb, 0xe5, 0x68, 0xbe, 0x41, 0x77, 0x08, 0xf9, 0xa6, 0x76, 0x87,
-	0x22, 0xf3, 0x5e, 0x44, 0x65, 0x39, 0xe7, 0xa5, 0x05, 0x99, 0x79, 0xf0, 0x46, 0x74, 0x6c, 0x1c,
-	0x32, 0xb4, 0x57, 0x51, 0x55, 0xfe, 0xe0, 0x1b, 0x63, 0x00, 0x04, 0x41, 0x1e, 0xfb, 0x9c, 0x80,
-	0x23, 0x6c, 0xed, 0x75, 0x54, 0xe6, 0xc9, 0xd9, 0xb6, 0x78, 0x3a, 0x17, 0xc3, 0xb3, 0x30, 0x3b,
-	0x20, 0xaa, 0x5b, 0xc2, 0x48, 0x92, 0xef, 0xb6, 0x12, 0xfd, 0x2b, 0x85, 0xbb, 0xad, 0x40, 0xff,
-	0xd4, 0xdd, 0x56, 0xe2, 0x80, 0x1f, 0xa0, 0xca, 0xbc, 0xeb, 0x7a, 0xcc, 0xe2, 0x6f, 0x18, 0x5f,
-	0x62, 0x0d, 0xbb, 0x6e, 0xb3, 0x17, 0xe0, 0x84, 0x26, 0x94, 0x4f, 0xdc, 0x67, 0x55, 0x83, 0xe6,
-	0x8f, 0x33, 0xa8, 0xc2, 0xcb, 0xbc, 0x9b, 0x1e, 0xbd, 0x6f, 0xd1, 0xfd, 0xe9, 0x7d, 0xa3, 0x6f,
-	0xe0, 0xec, 0x1e, 0x2a, 0xa6, 0xf0, 0xfd, 0x97, 0xfb, 0x02, 0xef, 0x3f, 0xde, 0x8b, 0xf2, 0x72,
-	0x39, 0x1f, 0x36, 0x41, 0x50, 0x2a, 0x03, 0xd5, 0xfc, 0x66, 0x06, 0xa1, 0xf7, 0xaf, 0x5d, 0xfb,
-	0x12, 0x3b, 0xc8, 0xfc, 0x51, 0x1a, 0x1d, 0x93, 0xe0, 0x88, 0x72, 0x44, 0x5d, 0x94, 0x24, 0xf9,
-	0x1e, 0x86, 0x9e, 0xa0, 0x25, 0x48, 0x38, 0xe0, 0x69, 0xb3, 0xa8, 0xb4, 0xb8, 0xed, 0x30, 0xe8,
-	0x0f, 0x05, 0x8a, 0x23, 0xf0, 0x3c, 0x49, 0x53, 0xcf, 0x03, 0x03, 0x39, 0xed, 0xd5, 0x00, 0xf6,
-	0xc9, 0x86, 0x8b, 0x8a, 0x2b, 0x2c, 0x26, 0x42, 0x3f, 0xe6, 0x77, 0xb2, 0x28, 0xb7, 0xb8, 0x4d,
-	0x5a, 0x07, 0x3c, 0x34, 0x4a, 0x19, 0x9c, 0xdb, 0x63, 0x19, 0xfc, 0x34, 0x08, 0xec, 0x8d, 0x30,
-	0x9e, 0x85, 0xe8, 0xf0, 0xb1, 0xc8, 0xc7, 0x87, 0x97, 0x6c, 0xf3, 0x37, 0x59, 0x94, 0x5d, 0xad,
-	0x37, 0x0f, 0xa3, 0xb0, 0x9f, 0x51, 0x78, 0x02, 0xea, 0x66, 0xa2, 0xc2, 0xbc, 0xf0, 0x51, 0x29,
-	0x3c, 0x79, 0xb2, 0x80, 0x82, 0x25, 0xc7, 0xfc, 0x28, 0x83, 0xca, 0xab, 0xfd, 0x0d, 0x7f, 0xc7,
-	0x67, 0xa4, 0x7b, 0xc0, 0xa3, 0x79, 0x46, 0x76, 0x0a, 0xb9, 0xd0, 0x1b, 0xbc, 0x53, 0x90, 0xfd,
-	0xc1, 0x85, 0x60, 0x9f, 0x51, 0x6a, 0xd1, 0xd1, 0x3e, 0x13, 0xec, 0x2e, 0x9f, 0x64, 0xd0, 0x44,
-	0xbd, 0xe3, 0x10, 0x97, 0x2d, 0x38, 0xbe, 0xac, 0x54, 0x0f, 0xb8, 0x57, 0xf6, 0xd6, 0x2f, 0x7f,
-	0x8e, 0xd3, 0x4b, 0xf3, 0x5b, 0x19, 0x54, 0x99, 0xef, 0xb3, 0xcd, 0x79, 0x06, 0x5b, 0xf5, 0x97,
-	0xf2, 0xa5, 0xf9, 0x59, 0x1a, 0xe9, 0x98, 0xf8, 0x84, 0x05, 0xa5, 0xff, 0x9a, 0x77, 0x8f, 0xb8,
-	0xcf, 0xa0, 0xe6, 0x56, 0x6b, 0xe7, 0xcc, 0x53, 0xd6, 0xce, 0x81, 0x53, 0xb3, 0x5f, 0xb0, 0x87,
-	0xe0, 0x5d, 0x19, 0x2f, 0xa9, 0x9f, 0x93, 0x69, 0x3c, 0x83, 0xe6, 0x72, 0x3f, 0xa7, 0xf1, 0xc7,
-	0x34, 0x9a, 0x5e, 0xa3, 0x7d, 0x9f, 0x11, 0xbb, 0xde, 0xe1, 0xff, 0xd0, 0x03, 0x1e, 0x97, 0xf1,
-	0x09, 0x1d, 0xf0, 0x08, 0xfd, 0x39, 0x8d, 0x4e, 0x45, 0x27, 0xf4, 0x3c, 0xec, 0x02, 0x7f, 0x4a,
-	0xa3, 0xe3, 0xef, 0x38, 0x6c, 0xb3, 0xbf, 0x31, 0xc2, 0x6b, 0x9e, 0xbf, 0x19, 0x1d, 0xf0, 0xcc,
-	0xfb, 0x43, 0x1a, 0x4d, 0xad, 0x2c, 0x2d, 0xd4, 0x9f, 0x97, 0x08, 0x8d, 0xcd, 0xe7, 0x39, 0x88,
-	0xcf, 0xea, 0xfc, 0xad, 0xe5, 0xe7, 0x29, 0x3e, 0x91, 0xf9, 0x1c, 0xf0, 0xf8, 0x7c, 0x92, 0x47,
-	0x95, 0x77, 0xfb, 0x1b, 0x44, 0x42, 0x7e, 0x5f, 0xea, 0x92, 0x7f, 0x16, 0x55, 0xa4, 0x1b, 0xa0,
-	0xb7, 0x14, 0x75, 0x3f, 0xdc, 0x91, 0xa2, 0x82, 0xbc, 0x0e, 0x3d, 0xa6, 0x2a, 0xc4, 0x5b, 0xaf,
-	0xf7, 0x08, 0xdd, 0x50, 0x6f, 0x16, 0x6c, 0x11, 0xba, 0x81, 0x81, 0xaa, 0x2d, 0x87, 0xc7, 0x3a,
-	0xf3, 0xcd, 0xa5, 0x77, 0xa8, 0xd7, 0xef, 0xc9, 0x96, 0x75, 0x66, 0x38, 0x30, 0xce, 0x50, 0xc9,
-	0x5b, 0xb7, 0x7a, 0xce, 0x3a, 0x5c, 0x33, 0x52, 0x60, 0x9f, 0x31, 0x4d, 0xed, 0x36, 0x9a, 0x0c,
-	0x68, 0xe1, 0xd7, 0x09, 0xa5, 0x04, 0x73, 0x49, 0x9f, 0x29, 0x8c, 0xab, 0x6a, 0x37, 0x50, 0x35,
-	0x20, 0xbe, 0xeb, 0xb8, 0x36, 0xa0, 0xae, 0xe5, 0xda, 0x0b, 0xc3, 0x81, 0x71, 0x72, 0x64, 0xea,
-	0x9e, 0xe3, 0xaa, 0xa7, 0x63, 0x11, 0x05, 0xd5, 0x00, 0xf4, 0x9f, 0x28, 0xc1, 0x40, 0xec, 0xc8,
-	0x2a, 0xa2, 0xa0, 0xbd, 0x0e, 0x06, 0x7a, 0x9e, 0xeb, 0x13, 0x80, 0xce, 0x2a, 0x70, 0xec, 0x0e,
-	0x07, 0x48, 0x54, 0xd2, 0xc5, 0xe5, 0x8a, 0x88, 0x98, 0xf9, 0x9f, 0x0c, 0x3a, 0x36, 0xdf, 0xeb,
-	0x1d, 0x5e, 0xa6, 0x7f, 0x56, 0x47, 0xf0, 0x57, 0x11, 0x6a, 0xf6, 0x37, 0x3a, 0x4e, 0x4b, 0xb9,
-	0x4f, 0x01, 0x17, 0x5c, 0x7a, 0x40, 0x15, 0x57, 0x2a, 0x14, 0x11, 0xf3, 0xa3, 0xac, 0x1a, 0x01,
-	0xb8, 0x9c, 0x7d, 0x18, 0x81, 0xfc, 0x9e, 0x76, 0xae, 0xa3, 0xaa, 0x33, 0xe5, 0x75, 0x33, 0x79,
-	0x6c, 0x12, 0x5c, 0x79, 0x6c, 0x71, 0xd6, 0xba, 0x63, 0xe3, 0x98, 0xac, 0xf9, 0xdb, 0x34, 0x9a,
-	0x0c, 0xc3, 0xf1, 0x2c, 0xf6, 0xf2, 0xab, 0x08, 0x89, 0x06, 0x7f, 0x04, 0x69, 0x1f, 0x11, 0x19,
-	0xe1, 0x03, 0x55, 0x5e, 0x79, 0x0a, 0x45, 0x46, 0x88, 0x5c, 0x36, 0x11, 0x91, 0xbb, 0x8c, 0x4a,
-	0xd8, 0xba, 0xff, 0xd5, 0x3e, 0xa1, 0x3b, 0x12, 0xa5, 0x02, 0x18, 0x8a, 0x5a, 0xf7, 0xd7, 0x3f,
-	0xe4, 0x44, 0x3c, 0x62, 0x9b, 0xdf, 0x9b, 0x46, 0xf9, 0x15, 0x97, 0xac, 0xdc, 0xd5, 0xae, 0x29,
-	0xf7, 0x0c, 0xe4, 0x04, 0x26, 0xd5, 0xcc, 0x00, 0x46, 0x23, 0x85, 0x95, 0xdb, 0x08, 0x73, 0xea,
-	0x11, 0xb3, 0xcc, 0x26, 0x4d, 0xd5, 0x11, 0x9c, 0x46, 0x0a, 0xab, 0x47, 0xd1, 0x73, 0xea, 0x19,
-	0xac, 0x4c, 0xa4, 0x88, 0x96, 0xe0, 0x04, 0x5a, 0xf2, 0x95, 0xbf, 0x9c, 0x74, 0xe4, 0x19, 0xbf,
-	0x5c, 0x3c, 0x2e, 0xd1, 0x48, 0xe1, 0xe4, 0xa3, 0xd2, 0xc8, 0xc7, 0x41, 0x32, 0x99, 0xa6, 0x63,
-	0xe9, 0x0c, 0xbc, 0x46, 0x0a, 0x47, 0x3f, 0x24, 0xba, 0x1e, 0xf9, 0xa4, 0x45, 0x42, 0xaa, 0x53,
-	0x31, 0x55, 0xce, 0x6a, 0xa4, 0x70, 0xec, 0xe3, 0x97, 0xc8, 0xe7, 0x1b, 0xb0, 0xf2, 0xc7, 0x07,
-	0x05, 0x9e, 0x32, 0xa8, 0xf8, 0xd4, 0xe3, 0xff, 0x63, 0xdf, 0x3a, 0xc0, 0x9b, 0xa8, 0x32, 0x7b,
-	0x3c, 0xa6, 0x2c, 0x98, 0x8d, 0x14, 0x8e, 0x7d, 0x19, 0x71, 0x29, 0xb8, 0xd5, 0x2f, 0x0f, 0xfb,
-	0x8e, 0x2a, 0x25, 0x8f, 0xf3, 0x80, 0x7b, 0x29, 0xb8, 0xf5, 0x3f, 0xa7, 0xde, 0x3f, 0x97, 0x37,
-	0x85, 0xb5, 0xd8, 0x28, 0x8b, 0xae, 0xcd, 0xa3, 0xa3, 0xdc, 0x53, 0x7f, 0x3b, 0x7e, 0xdf, 0x15,
-	0x5e, 0x2e, 0x91, 0x05, 0xae, 0x72, 0x1b, 0x29, 0x1c, 0xbf, 0x1f, 0x7b, 0x3d, 0x72, 0xd7, 0x52,
-	0xaf, 0x26, 0x7a, 0x95, 0xb3, 0x14, 0xaf, 0xc2, 0xad, 0xcc, 0xb7, 0xe3, 0x97, 0xff, 0xf4, 0x23,
-	0x89, 0x43, 0x4b, 0xae, 0x32, 0x74, 0x70, 0x59, 0xf0, 0x7a, 0xe4, 0x7a, 0x99, 0x7e, 0x34, 0x79,
-	0x68, 0x8b, 0x59, 0xea, 0xd0, 0xe2, 0x22, 0x5a, 0xe4, 0xa2, 0x93, 0x7e, 0x2c, 0x31, 0xa0, 0xc0,
-	0x53, 0x02, 0x2a, 0x2e, 0x45, 0x5d, 0x8f, 0x1c, 0x91, 0xea, 0x13, 0xd1, 0x41, 0x15, 0x16, 0x1f,
-	0x54, 0x3d, 0x4c, 0x9d, 0x53, 0x4f, 0x0e, 0xf5, 0xc9, 0x68, 0x80, 0x42, 0x0e, 0x0f, 0x90, 0x72,
-	0xc2, 0x68, 0xc0, 0x39, 0x8a, 0xae, 0x81, 0x78, 0x65, 0xf4, 0x84, 0xf5, 0x66, 0x23, 0x85, 0xe1,
-	0x84, 0xc5, 0x14, 0xe7, 0x5d, 0xfa, 0x14, 0x48, 0x54, 0x03, 0x09, 0x4e, 0x6b, 0xa4, 0xb0, 0x38,
-	0x0b, 0xbb, 0xa6, 0x80, 0xf8, 0xfa, 0x74, 0x74, 0x8b, 0x18, 0x31, 0xf8, 0x16, 0x11, 0x42, 0xfd,
-	0x37, 0xc7, 0x81, 0x6e, 0xfd, 0x78, 0xb4, 0xea, 0x8e, 0xf3, 0x1b, 0x29, 0x3c, 0x0e, 0x8e, 0x5f,
-	0x8f, 0x60, 0xbf, 0xfa, 0x89, 0xa8, 0xbb, 0x14, 0x16, 0x77, 0x97, 0x8a, 0x12, 0xaf, 0x24, 0xde,
-	0x4f, 0xd0, 0x4f, 0x82, 0x81, 0x17, 0x46, 0x06, 0xc6, 0x45, 0x1a, 0x29, 0x9c, 0x78, 0xb3, 0xe1,
-	0x83, 0xdd, 0x11, 0x58, 0x5d, 0x07, 0xab, 0x33, 0xca, 0xe2, 0x4a, 0x94, 0x6b, 0xa4, 0xf0, 0xee,
-	0x28, 0xee, 0x9c, 0x0a, 0x86, 0xea, 0xa7, 0xa2, 0xf1, 0x0d, 0x39, 0x3c, 0xbe, 0x0a, 0x68, 0x3a,
-	0xa7, 0x62, 0x8f, 0xfa, 0xe9, 0x71, 0xad, 0x70, 0x53, 0x55, 0x30, 0x4a, 0x9c, 0x0c, 0xf5, 0xe9,
-	0x2f, 0x80, 0xfe, 0x99, 0x40, 0x3f, 0x49, 0xa6, 0x91, 0xc2, 0xc9, 0x30, 0x21, 0x4e, 0x46, 0xdb,
-	0xf4, 0x33, 0x8f, 0xb3, 0x39, 0x7a, 0xba, 0x64, 0xa4, 0xce, 0x7a, 0x0c, 0xe0, 0xa5, 0x9f, 0x05,
-	0xc3, 0xe7, 0x93, 0x0d, 0x47, 0xbd, 0xfe, 0x18, 0xd8, 0xec, 0xce, 0x2e, 0xe8, 0x93, 0x7e, 0x0e,
-	0xcc, 0x9f, 0x0d, 0xcc, 0x27, 0x0a, 0x35, 0x52, 0x78, 0x17, 0xec, 0xea, 0xce, 0x2e, 0x10, 0x90,
-	0x6e, 0x3c, 0xd6, 0xec, 0xc8, 0x1f, 0xbb, 0x00, 0x48, 0x2b, 0x89, 0x38, 0x8c, 0x3e, 0x13, 0xcd,
-	0xea, 0x04, 0x11, 0x9e, 0xd5, 0x49, 0x08, 0xce, 0x4a, 0x22, 0x10, 0xa2, 0x9f, 0x7f, 0x8c, 0xc1,
-	0xd1, 0x33, 0x26, 0x42, 0x28, 0x2b, 0x89, 0x48, 0x84, 0x6e, 0x46, 0x0d, 0x26, 0x88, 0x70, 0x83,
-	0x49, 0x18, 0xc6, 0x4a, 0x22, 0x14, 0xa0, 0x5f, 0x78, 0x8c, 0xc1, 0xf0, 0x09, 0x93, 0x40, 0x84,
-	0xeb, 0x91, 0x5e, 0x5c, 0x7f, 0x31, 0xba, 0xa5, 0x28, 0x2c, 0xbe, 0xa5, 0xa8, 0x5d, 0x7b, 0x7d,
-	0xac, 0x1f, 0xd2, 0x5f, 0x8a, 0x96, 0xc3, 0x31, 0x76, 0x23, 0x85, 0xc7, 0x3a, 0xa8, 0xfa, 0x58,
-	0x49, 0xaf, 0x5f, 0xdc, 0xcd, 0x08, 0xb0, 0xa3, 0x46, 0x44, 0x13, 0xb0, 0x94, 0x50, 0x88, 0xea,
-	0xff, 0x03, 0x66, 0x4e, 0x8d, 0x9b, 0x09, 0xa7, 0x33, 0xae, 0x55, 0x2b, 0xa2, 0xfc, 0x22, 0x57,
-	0x30, 0x7f, 0x92, 0x46, 0xd5, 0x55, 0x46, 0x89, 0xd5, 0x95, 0x37, 0x59, 0x4e, 0xa3, 0xd2, 0x9d,
-	0x5e, 0xc7, 0xb3, 0xec, 0xe0, 0xbf, 0x0d, 0xc0, 0xa3, 0xdf, 0xda, 0x45, 0x74, 0x74, 0xd9, 0xf2,
-	0x19, 0x68, 0x2a, 0x5f, 0x92, 0xe2, 0x18, 0x55, 0x5b, 0x16, 0x72, 0x42, 0x0f, 0xbe, 0x41, 0xca,
-	0x3e, 0xf1, 0xf2, 0x64, 0x89, 0x17, 0xcb, 0x70, 0x63, 0x32, 0xa6, 0x5b, 0x9b, 0x7e, 0xf8, 0x8f,
-	0x73, 0xa9, 0x87, 0x8f, 0xce, 0xa5, 0x3f, 0x7d, 0x74, 0x2e, 0xfd, 0xf7, 0x47, 0xe7, 0xd2, 0x3f,
-	0xfc, 0xe7, 0xb9, 0xd4, 0x46, 0x01, 0x6c, 0xbc, 0xf6, 0xdf, 0x00, 0x00, 0x00, 0xff, 0xff, 0xba,
-	0xd9, 0x73, 0xb3, 0x3d, 0x42, 0x00, 0x00,
+var fileDescriptor_events_69f4748188040cdb = []byte{
+	// 3346 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x5c, 0xcf, 0x6f, 0x1b, 0xc7,
+	0xf5, 0xe7, 0x6f, 0x91, 0x43, 0xd9, 0x96, 0x46, 0xb2, 0xbd, 0x76, 0x6c, 0xaf, 0xbc, 0x4e, 0xfc,
+	0xb5, 0x91, 0xc4, 0x86, 0x15, 0x25, 0xce, 0x37, 0x68, 0xe1, 0x88, 0x94, 0x1c, 0xaa, 0x91, 0x2d,
+	0x76, 0x24, 0xa7, 0xb9, 0x34, 0xc2, 0x8a, 0x3b, 0xa6, 0xb6, 0x22, 0x77, 0x99, 0xdd, 0xa1, 0x2c,
+	0xf9, 0xd4, 0x1f, 0x97, 0x1e, 0x02, 0xb4, 0x48, 0x2f, 0x05, 0x72, 0x68, 0x2f, 0xbd, 0xf5, 0x50,
+	0xf4, 0xd4, 0x7b, 0x5b, 0xc0, 0x45, 0xd1, 0x34, 0x48, 0xd3, 0x63, 0xd9, 0xd6, 0xbd, 0xf1, 0x4f,
+	0xe8, 0xa5, 0xc5, 0xbc, 0x99, 0xe5, 0xce, 0x2e, 0x57, 0x72, 0x12, 0x1a, 0x50, 0xe5, 0xe8, 0x26,
+	0xbe, 0x5f, 0xb3, 0xf3, 0xde, 0x9b, 0xd9, 0xf7, 0x3e, 0x33, 0x2b, 0x34, 0x4e, 0xb7, 0xa9, 0xc3,
+	0xfc, 0x6b, 0x1d, 0xcf, 0x65, 0x2e, 0x2e, 0x88, 0x5f, 0x67, 0xa7, 0x9b, 0x6e, 0xd3, 0x05, 0xd2,
+	0x75, 0xfe, 0x97, 0xe0, 0x9e, 0xd5, 0x9b, 0xae, 0xdb, 0x6c, 0xd1, 0xeb, 0xf0, 0x6b, 0xa3, 0x7b,
+	0xff, 0x3a, 0xb3, 0xdb, 0xd4, 0x67, 0x66, 0xbb, 0x23, 0x05, 0xce, 0xc5, 0x05, 0x7c, 0xe6, 0x75,
+	0x1b, 0x4c, 0x70, 0x8d, 0xcf, 0xd2, 0xa8, 0x78, 0x87, 0x32, 0xd3, 0x32, 0x99, 0x89, 0xcf, 0xa1,
+	0xfc, 0x92, 0x63, 0xd1, 0x1d, 0x2d, 0x3d, 0x93, 0xbe, 0x92, 0xad, 0x14, 0xfa, 0x3d, 0x3d, 0x43,
+	0x6d, 0x22, 0x88, 0xf8, 0x3c, 0xca, 0xad, 0xed, 0x76, 0xa8, 0x96, 0x99, 0x49, 0x5f, 0x29, 0x55,
+	0x4a, 0xfd, 0x9e, 0x9e, 0x87, 0x27, 0x23, 0x40, 0xc6, 0x17, 0x51, 0x66, 0x69, 0x41, 0xcb, 0x02,
+	0x73, 0xb2, 0xdf, 0xd3, 0x8f, 0x75, 0x6d, 0xeb, 0x25, 0xb7, 0x6d, 0x33, 0xda, 0xee, 0xb0, 0x5d,
+	0x92, 0x59, 0x5a, 0xc0, 0x97, 0x51, 0xae, 0xea, 0x5a, 0x54, 0xcb, 0x81, 0x10, 0xee, 0xf7, 0xf4,
+	0xe3, 0x0d, 0xd7, 0xa2, 0x8a, 0x14, 0xf0, 0xf1, 0x9b, 0x28, 0xb7, 0x66, 0xb7, 0xa9, 0x96, 0x9f,
+	0x49, 0x5f, 0x29, 0xcf, 0x9e, 0xbd, 0x26, 0x66, 0x70, 0x2d, 0x98, 0xc1, 0xb5, 0xb5, 0x60, 0x8a,
+	0x95, 0x89, 0x47, 0x3d, 0x3d, 0xd5, 0xef, 0xe9, 0x39, 0x3e, 0xeb, 0x1f, 0xff, 0x5d, 0x4f, 0x13,
+	0xd0, 0x34, 0x5e, 0x47, 0x27, 0x56, 0xa9, 0xef, 0xdb, 0xae, 0x33, 0x98, 0xdc, 0x0b, 0xa8, 0x24,
+	0x49, 0x4b, 0x0b, 0x30, 0xc1, 0x52, 0x65, 0xac, 0xdf, 0xd3, 0xb3, 0xbe, 0x6d, 0x91, 0x90, 0x63,
+	0x7c, 0x0b, 0x8d, 0xdf, 0xf3, 0xa9, 0xa7, 0xf8, 0x24, 0xc7, 0x7f, 0x4b, 0x8d, 0x22, 0x1f, 0xab,
+	0xeb, 0x53, 0x8f, 0x00, 0x15, 0x5f, 0x45, 0xf9, 0x65, 0xb7, 0x69, 0x3b, 0xd2, 0x29, 0x53, 0xfd,
+	0x9e, 0x7e, 0xa2, 0xc5, 0x09, 0xca, 0x9c, 0x84, 0x84, 0xf1, 0xab, 0x2c, 0x3a, 0xbe, 0x4a, 0xbd,
+	0x6d, 0xc5, 0xf6, 0x3c, 0x7f, 0x4a, 0x4e, 0xb9, 0x6b, 0xb6, 0xa9, 0xdf, 0x31, 0x1b, 0x54, 0x0e,
+	0x73, 0xba, 0xdf, 0xd3, 0xa7, 0x9c, 0x80, 0xa8, 0xd8, 0x8a, 0xcb, 0xe3, 0xab, 0xa8, 0x28, 0x48,
+	0x4b, 0x0b, 0xf2, 0x19, 0x8e, 0xf5, 0x7b, 0x7a, 0xc9, 0x07, 0xda, 0xba, 0x6d, 0x91, 0x01, 0x1b,
+	0x2f, 0x06, 0xe3, 0xd7, 0x5c, 0x9f, 0x71, 0xe3, 0x32, 0x58, 0xe7, 0xfb, 0x3d, 0xfd, 0x8c, 0x54,
+	0xd8, 0x94, 0x2c, 0x65, 0xc8, 0x98, 0x12, 0xfe, 0x7f, 0x84, 0x04, 0x65, 0xde, 0xb2, 0x3c, 0x19,
+	0xca, 0x33, 0xfd, 0x9e, 0x7e, 0x52, 0x9a, 0x30, 0x2d, 0xcb, 0x53, 0xd4, 0x15, 0x61, 0xdc, 0x46,
+	0xe3, 0xe2, 0xd7, 0xb2, 0xb9, 0x41, 0x5b, 0xbe, 0x96, 0x9f, 0xc9, 0x5e, 0x29, 0xcf, 0x5e, 0xb9,
+	0x26, 0xd3, 0x3d, 0xea, 0x9d, 0x6b, 0xaa, 0xe8, 0xa2, 0xc3, 0xbc, 0xdd, 0x8a, 0x2e, 0xa3, 0x7d,
+	0x5a, 0x0e, 0xd5, 0x02, 0x9e, 0x32, 0x58, 0xc4, 0xfc, 0xd9, 0x5b, 0x68, 0x72, 0xc8, 0x06, 0x9e,
+	0x40, 0xd9, 0x2d, 0xba, 0x2b, 0xfc, 0x4c, 0xf8, 0x9f, 0x78, 0x1a, 0xe5, 0xb7, 0xcd, 0x56, 0x57,
+	0x26, 0x36, 0x11, 0x3f, 0xde, 0xc8, 0xbc, 0x9e, 0x36, 0x7e, 0x93, 0x46, 0xb8, 0xea, 0x3a, 0x0e,
+	0x6d, 0x30, 0x35, 0x93, 0x5e, 0x43, 0xa5, 0x65, 0xb7, 0x61, 0xb6, 0xc0, 0x01, 0x22, 0x60, 0x5a,
+	0xbf, 0xa7, 0x4f, 0xf3, 0x99, 0x5f, 0x6b, 0x71, 0x8e, 0xf2, 0x48, 0xa1, 0x28, 0xf7, 0x1c, 0xa1,
+	0x6d, 0x97, 0x51, 0x50, 0xcc, 0x84, 0x9e, 0x03, 0x45, 0x0f, 0x58, 0xaa, 0xe7, 0x42, 0x61, 0x7c,
+	0x1d, 0x15, 0xeb, 0x3c, 0xfb, 0x1b, 0x6e, 0x4b, 0x46, 0x0d, 0x52, 0x0d, 0x56, 0x84, 0xa2, 0x32,
+	0x10, 0x32, 0xb6, 0xd0, 0x99, 0xb7, 0xbb, 0x1b, 0xd4, 0x73, 0x28, 0xa3, 0x7e, 0xb5, 0xd5, 0xf5,
+	0x99, 0x92, 0x77, 0x77, 0xd1, 0xe4, 0x10, 0x53, 0x4e, 0x64, 0xa6, 0xdf, 0xd3, 0xcf, 0x6d, 0x0d,
+	0x98, 0xeb, 0x0d, 0xc1, 0x55, 0xc6, 0x18, 0x56, 0x35, 0x3e, 0xcb, 0xf2, 0xc0, 0xc2, 0x0a, 0x5a,
+	0x65, 0xa6, 0xc7, 0xf0, 0x1b, 0xe1, 0xa6, 0x02, 0x76, 0xcb, 0xb3, 0x13, 0x41, 0x90, 0x03, 0x7a,
+	0x65, 0x9c, 0x07, 0xf3, 0x93, 0x9e, 0x9e, 0xee, 0xf7, 0xf4, 0x14, 0x29, 0x2a, 0xde, 0x15, 0x0b,
+	0x2e, 0x03, 0x7a, 0xd3, 0x81, 0x9e, 0xba, 0x28, 0x63, 0xba, 0x62, 0x29, 0xde, 0x42, 0x63, 0xf2,
+	0x19, 0xc0, 0x43, 0xe5, 0xd9, 0xd3, 0x61, 0x5e, 0x45, 0x76, 0x82, 0x98, 0x76, 0xa0, 0x85, 0xbf,
+	0x86, 0x0a, 0x22, 0x5d, 0x20, 0xa9, 0xcb, 0xb3, 0xa7, 0x92, 0xf3, 0x32, 0xa6, 0x2e, 0x75, 0x70,
+	0x0d, 0xa1, 0x30, 0x55, 0x06, 0x3b, 0x97, 0xb4, 0x30, 0x9c, 0x44, 0x31, 0x2b, 0x8a, 0x2e, 0x7e,
+	0x0d, 0x8d, 0xaf, 0x51, 0xaf, 0x6d, 0x3b, 0x66, 0x6b, 0xd5, 0x7e, 0x48, 0xb5, 0x42, 0xb8, 0x5b,
+	0xfa, 0xf6, 0x43, 0x35, 0x43, 0x22, 0x72, 0x78, 0x05, 0xa1, 0x30, 0x34, 0xda, 0x18, 0x3c, 0xc1,
+	0xc5, 0xe0, 0x09, 0xf6, 0x4c, 0x86, 0xf8, 0x83, 0x84, 0x82, 0xc6, 0x47, 0x59, 0x54, 0x96, 0xce,
+	0xf9, 0x86, 0x6b, 0x3b, 0x47, 0x51, 0x1d, 0x25, 0xaa, 0xd1, 0xe8, 0x14, 0x46, 0x8f, 0xce, 0x07,
+	0x99, 0xc1, 0xa2, 0xab, 0x7b, 0xb6, 0x33, 0xda, 0xa2, 0xbb, 0x8c, 0x50, 0x75, 0xb3, 0xeb, 0x6c,
+	0x89, 0xd7, 0x7f, 0x26, 0x7c, 0xfd, 0x37, 0x6c, 0xa2, 0x70, 0x78, 0x0d, 0xb0, 0xc0, 0xed, 0xf3,
+	0x58, 0x8c, 0x57, 0x4a, 0x8f, 0x84, 0xa5, 0xf4, 0xcb, 0x04, 0xc8, 0x58, 0x47, 0xf9, 0xca, 0x2e,
+	0x9f, 0x5f, 0x0e, 0x2c, 0x40, 0x8d, 0xb0, 0xc1, 0x09, 0x44, 0xd0, 0xf1, 0x1c, 0x9a, 0x5c, 0xa0,
+	0x2d, 0x73, 0xf7, 0x8e, 0xdd, 0x6a, 0xd9, 0x3e, 0x6d, 0xb8, 0x8e, 0xe5, 0x83, 0x5b, 0xe5, 0x70,
+	0x6d, 0x9f, 0x0c, 0x0b, 0x60, 0x03, 0x15, 0x56, 0xee, 0xdf, 0xf7, 0x29, 0x03, 0xbf, 0x65, 0x2b,
+	0xa8, 0xdf, 0xd3, 0x0b, 0x2e, 0x50, 0x88, 0xe4, 0x18, 0x9f, 0x66, 0xd0, 0x31, 0xe9, 0x0e, 0x42,
+	0xbf, 0x43, 0x1b, 0x07, 0xb3, 0x09, 0x85, 0xd9, 0x96, 0x1d, 0x39, 0xdb, 0x72, 0x23, 0x64, 0x9b,
+	0x81, 0x0a, 0x84, 0x9a, 0xbe, 0xcc, 0xd9, 0x92, 0xf0, 0x98, 0x07, 0x14, 0x22, 0x39, 0xf8, 0x22,
+	0x1a, 0xbb, 0x63, 0xee, 0xd8, 0xed, 0x6e, 0x5b, 0xba, 0x15, 0xca, 0xa1, 0xb6, 0xb9, 0x43, 0x02,
+	0xba, 0xf1, 0x71, 0x96, 0xdb, 0xe1, 0xbb, 0xce, 0xe1, 0x5c, 0xfc, 0x4f, 0xcf, 0xa1, 0x61, 0x60,
+	0xf3, 0x5f, 0x22, 0xb0, 0xff, 0x33, 0x5b, 0xfa, 0xf7, 0x0b, 0xbc, 0x7a, 0x03, 0xe7, 0x2c, 0x3a,
+	0xd6, 0x51, 0x50, 0x47, 0x09, 0xea, 0x02, 0x9a, 0x5c, 0x74, 0x36, 0x4d, 0xa7, 0x41, 0x2d, 0x42,
+	0x1b, 0xae, 0x67, 0xd9, 0x4e, 0x13, 0x22, 0x5b, 0xac, 0x9c, 0xea, 0xf7, 0x74, 0x4c, 0x25, 0x73,
+	0xdd, 0x0b, 0xb8, 0x64, 0x58, 0x01, 0xdf, 0x40, 0xe5, 0x25, 0x87, 0x51, 0xcf, 0x6c, 0x30, 0x7b,
+	0x9b, 0x42, 0x8c, 0x8b, 0x95, 0x13, 0xfd, 0x9e, 0x5e, 0xb6, 0x43, 0x32, 0x51, 0x65, 0xf0, 0x1c,
+	0x1a, 0xaf, 0x9b, 0x1e, 0xb3, 0x1b, 0x76, 0xc7, 0x74, 0x98, 0xaf, 0x15, 0x67, 0xb2, 0x57, 0x4a,
+	0x95, 0x89, 0x7e, 0x4f, 0x1f, 0xef, 0x28, 0x74, 0x12, 0x91, 0xc2, 0xdf, 0x46, 0x25, 0x28, 0xce,
+	0xa0, 0xb3, 0x2a, 0x3d, 0xb1, 0xb3, 0xba, 0x14, 0xd6, 0xda, 0xe0, 0xf6, 0x75, 0x9f, 0x2b, 0x87,
+	0x99, 0x0a, 0xcd, 0x56, 0x68, 0x11, 0xbf, 0x8b, 0xc6, 0x16, 0x1d, 0x0b, 0x8c, 0xa3, 0x27, 0x1a,
+	0x37, 0xa4, 0xf1, 0x53, 0xa1, 0x71, 0xb7, 0x13, 0xb3, 0x1d, 0x98, 0x8b, 0x2d, 0x82, 0xf2, 0xe8,
+	0x8b, 0xe0, 0x21, 0x2a, 0x57, 0xea, 0xb7, 0x07, 0x89, 0x7c, 0x06, 0x65, 0xeb, 0xb2, 0x25, 0xcc,
+	0x89, 0x3d, 0xb0, 0x63, 0x5b, 0x84, 0xd3, 0x78, 0x77, 0x55, 0x6d, 0x7a, 0x6e, 0xb7, 0x23, 0xbb,
+	0xab, 0x9c, 0xe8, 0xae, 0x1a, 0x40, 0x83, 0xee, 0x2a, 0x60, 0xe3, 0x17, 0xd0, 0x58, 0xdd, 0x73,
+	0x9b, 0x9e, 0xd9, 0x96, 0x05, 0x7a, 0xb9, 0xdf, 0xd3, 0xc7, 0x3a, 0x82, 0x44, 0x02, 0x9e, 0xf1,
+	0x93, 0x34, 0x2a, 0xac, 0x32, 0x93, 0x75, 0x7d, 0xae, 0xb1, 0xda, 0x6d, 0x34, 0xa8, 0xef, 0xc3,
+	0xd8, 0x45, 0xa1, 0xe1, 0x0b, 0x12, 0x09, 0x78, 0xbc, 0xc5, 0x5c, 0xf4, 0x3c, 0xd7, 0x53, 0x5b,
+	0x4c, 0xca, 0x09, 0x6a, 0x8b, 0x09, 0x12, 0xf8, 0x26, 0x2a, 0x8b, 0xe5, 0xe7, 0xfb, 0x66, 0x33,
+	0x68, 0xef, 0x4e, 0xf6, 0x7b, 0xfa, 0x64, 0x5b, 0x90, 0x14, 0x15, 0x55, 0xd2, 0xf8, 0x2d, 0xf4,
+	0xa6, 0x10, 0x8a, 0xaa, 0xdb, 0x6e, 0x9b, 0x87, 0x75, 0x6b, 0x18, 0xad, 0xd8, 0x7b, 0x05, 0x65,
+	0x2b, 0xf5, 0xdb, 0x72, 0x2f, 0x98, 0x0a, 0x54, 0x95, 0x54, 0x89, 0xe9, 0x71, 0x69, 0x7c, 0x0e,
+	0xe5, 0xea, 0x3c, 0x7d, 0x0a, 0x90, 0x1e, 0x80, 0x0f, 0x74, 0x78, 0xfe, 0x00, 0x15, 0xb8, 0x26,
+	0xdb, 0x84, 0x65, 0x2d, 0xd1, 0x83, 0x8e, 0xc9, 0x36, 0x09, 0x50, 0x39, 0x77, 0xde, 0x6b, 0x6e,
+	0xcb, 0x05, 0x0c, 0x5c, 0xd3, 0x6b, 0x6e, 0x13, 0xa0, 0xe2, 0xeb, 0xbc, 0x5d, 0x64, 0x5d, 0xcf,
+	0x01, 0xcc, 0x84, 0xaf, 0xd8, 0xbc, 0xd8, 0x18, 0x3c, 0xa0, 0xae, 0x37, 0x5c, 0x8b, 0x12, 0x45,
+	0xc4, 0xf8, 0x45, 0x58, 0xaf, 0x2f, 0xd8, 0xfe, 0xd6, 0x51, 0x08, 0xbf, 0x40, 0x08, 0x79, 0x90,
+	0x0a, 0x89, 0x41, 0xd2, 0x51, 0xfe, 0x76, 0xcb, 0x6c, 0x8a, 0xd7, 0x6f, 0x5e, 0xd4, 0xb4, 0xf7,
+	0x39, 0x81, 0x08, 0x7a, 0x2c, 0x4e, 0xc5, 0x27, 0xc7, 0xe9, 0x6f, 0xe1, 0x6a, 0xbb, 0x4b, 0xd9,
+	0x03, 0xd7, 0x3b, 0x0a, 0xd5, 0xe7, 0x0d, 0xd5, 0x65, 0x34, 0xb6, 0xea, 0x35, 0x00, 0x3f, 0x11,
+	0xd1, 0x1a, 0xef, 0xf7, 0xf4, 0xa2, 0xef, 0x35, 0x00, 0x76, 0x22, 0x01, 0x93, 0xcb, 0x2d, 0xf8,
+	0x0c, 0xe4, 0xc6, 0x42, 0x39, 0xcb, 0x67, 0x52, 0x4e, 0x32, 0xa5, 0x5c, 0xdd, 0xf5, 0x98, 0x0c,
+	0xdc, 0x40, 0xae, 0xe3, 0x7a, 0x8c, 0x04, 0x4c, 0xfc, 0x22, 0x42, 0x6b, 0xd5, 0xfa, 0x3b, 0xd4,
+	0x03, 0x77, 0x89, 0xb5, 0x08, 0xdb, 0xf5, 0xb6, 0x20, 0x11, 0x85, 0x6d, 0xfc, 0x52, 0x59, 0x87,
+	0x3c, 0x40, 0x47, 0x7d, 0xf3, 0x08, 0x35, 0xda, 0x2c, 0x9a, 0x80, 0xd6, 0x71, 0xcd, 0x33, 0x1d,
+	0xbf, 0x6d, 0x33, 0x46, 0x2d, 0xb9, 0xd7, 0x42, 0xc3, 0xc8, 0x76, 0xc8, 0x10, 0x1f, 0xbf, 0x84,
+	0x8e, 0x01, 0x8d, 0xd0, 0x06, 0xb5, 0xb7, 0xa9, 0x05, 0x39, 0x20, 0x15, 0xbc, 0x1d, 0x12, 0x65,
+	0x1a, 0x7f, 0x0c, 0x1b, 0xe9, 0x65, 0x6a, 0x6e, 0xd3, 0xa3, 0x78, 0x8d, 0x10, 0x2f, 0xe3, 0x93,
+	0x0c, 0x2a, 0xf1, 0x19, 0x01, 0xe8, 0x7d, 0x20, 0xae, 0x9c, 0x0b, 0x2a, 0x2c, 0xe9, 0xc9, 0xe3,
+	0x03, 0x4f, 0x00, 0x75, 0xc8, 0x03, 0xa2, 0x1a, 0x7b, 0x09, 0x15, 0xee, 0x50, 0xb6, 0xe9, 0x5a,
+	0x12, 0xd2, 0x9e, 0xee, 0xf7, 0xf4, 0x89, 0x36, 0x50, 0x94, 0xaa, 0x49, 0xca, 0xe0, 0x2d, 0x84,
+	0x97, 0x2c, 0xea, 0x30, 0x9b, 0xed, 0xce, 0x33, 0xe6, 0xd9, 0x1b, 0x5d, 0x5e, 0x9b, 0xe6, 0x65,
+	0xe4, 0xe2, 0x85, 0xef, 0x2a, 0x9c, 0xb8, 0x54, 0x0c, 0x00, 0x89, 0x07, 0xe2, 0xa1, 0xd9, 0x7f,
+	0xf7, 0xf4, 0x82, 0x90, 0x21, 0x09, 0x66, 0x8d, 0xc7, 0x69, 0x34, 0x41, 0xa8, 0xef, 0x76, 0xbd,
+	0x06, 0x55, 0x10, 0x9b, 0xdc, 0x5d, 0xb3, 0x1d, 0x1c, 0x18, 0x40, 0x2b, 0x19, 0x03, 0xee, 0x81,
+	0x8f, 0x97, 0xd0, 0xd8, 0xe2, 0x4e, 0xc7, 0xf6, 0xa8, 0x2f, 0x1d, 0xb9, 0x5f, 0x5d, 0x3e, 0x25,
+	0xeb, 0xf2, 0x31, 0x2a, 0x54, 0x64, 0x21, 0x2e, 0x7e, 0xe0, 0xd7, 0x50, 0xe9, 0x5e, 0xc7, 0x32,
+	0x19, 0xb5, 0x2a, 0xbb, 0xb2, 0xb8, 0x04, 0xdc, 0xbb, 0x2b, 0x88, 0xeb, 0x1b, 0xbb, 0x2a, 0xee,
+	0x3d, 0x10, 0xc5, 0x97, 0x50, 0x76, 0x6d, 0x6d, 0x59, 0xfa, 0x15, 0x8e, 0x86, 0x18, 0x53, 0x21,
+	0x72, 0xce, 0x35, 0x3e, 0xcc, 0x20, 0xc4, 0xc3, 0x57, 0xf5, 0xa8, 0xc9, 0x0e, 0x66, 0x0d, 0x56,
+	0x50, 0x31, 0x70, 0xb3, 0x4c, 0x1d, 0x2d, 0xd0, 0x8d, 0xbb, 0x3f, 0x3e, 0x76, 0xc0, 0xe7, 0xd5,
+	0x02, 0x71, 0x5b, 0x80, 0x80, 0x65, 0x83, 0x53, 0x32, 0x8f, 0x13, 0x88, 0xa0, 0xe3, 0x17, 0x51,
+	0x49, 0xae, 0x16, 0xd7, 0x93, 0xe0, 0x8c, 0xe8, 0x29, 0x02, 0x22, 0x09, 0xf9, 0xc6, 0xef, 0xd2,
+	0xc2, 0x29, 0x0b, 0xb4, 0x45, 0x0f, 0xaf, 0x53, 0x8c, 0x1f, 0xa6, 0x11, 0xe6, 0xc6, 0xea, 0xa6,
+	0xef, 0x3f, 0x70, 0x3d, 0xab, 0xba, 0x69, 0x3a, 0xcd, 0x03, 0x99, 0x8e, 0xf1, 0x61, 0x0e, 0x4d,
+	0xcd, 0x8b, 0x0e, 0x8b, 0xbe, 0xdf, 0xa5, 0x3e, 0x3b, 0xe4, 0xf9, 0x76, 0x35, 0x9a, 0x6f, 0xd0,
+	0x1d, 0x42, 0xbe, 0xa9, 0xdd, 0xa1, 0xc8, 0xbc, 0xe7, 0x51, 0x49, 0xce, 0x79, 0x69, 0x41, 0x66,
+	0x1e, 0xbc, 0x11, 0x6d, 0x8b, 0x84, 0x0c, 0xfc, 0x32, 0x1a, 0x97, 0x3f, 0xf8, 0xc6, 0x18, 0x40,
+	0x55, 0x90, 0xc7, 0x3e, 0x27, 0x90, 0x08, 0x1b, 0xbf, 0x8a, 0x4a, 0x3c, 0x39, 0x9b, 0x26, 0x4f,
+	0xe7, 0xb1, 0xf0, 0xf0, 0xd2, 0x0a, 0x88, 0xea, 0x96, 0x30, 0x90, 0xe4, 0xbb, 0xad, 0xc4, 0x27,
+	0x8b, 0xe1, 0x6e, 0x2b, 0xf0, 0x49, 0x75, 0xb7, 0x95, 0x48, 0xe5, 0x7b, 0xa8, 0x3c, 0xef, 0x38,
+	0x2e, 0x33, 0xf9, 0x1b, 0xc6, 0x97, 0xe0, 0xc5, 0x9e, 0xdb, 0xec, 0x25, 0x38, 0x52, 0x0b, 0xe5,
+	0x13, 0xf7, 0x59, 0xd5, 0xa0, 0xf1, 0xb3, 0x0c, 0x2a, 0xf3, 0x32, 0xef, 0xb6, 0xeb, 0x3d, 0x30,
+	0xbd, 0x83, 0xe9, 0x7d, 0xa3, 0x6f, 0xe0, 0xec, 0x08, 0x15, 0x53, 0xf8, 0xfe, 0xcb, 0x7d, 0x81,
+	0xf7, 0x1f, 0xef, 0x45, 0x79, 0xb9, 0x9c, 0x0f, 0x9b, 0x20, 0x28, 0x95, 0x81, 0x6a, 0x7c, 0x37,
+	0x83, 0xd0, 0xbb, 0x37, 0x6e, 0x7c, 0x85, 0x1d, 0x64, 0x7c, 0x94, 0x46, 0x27, 0x24, 0x38, 0xa2,
+	0xdc, 0x29, 0x18, 0x93, 0x24, 0xf9, 0x1e, 0x86, 0x9e, 0xa0, 0x21, 0x48, 0x24, 0xe0, 0xe1, 0x59,
+	0x54, 0x5c, 0xdc, 0xb1, 0x19, 0xf4, 0x87, 0x02, 0xc5, 0x11, 0x00, 0xa1, 0xa4, 0xa9, 0x07, 0xb8,
+	0x81, 0x1c, 0x7e, 0x39, 0x80, 0x7d, 0xb2, 0xe1, 0xa2, 0xe2, 0x0a, 0x8b, 0x89, 0xd0, 0x8f, 0xf1,
+	0xd7, 0x2c, 0xca, 0x2d, 0xee, 0xd0, 0xc6, 0x21, 0x0f, 0x8d, 0x52, 0x06, 0xe7, 0x46, 0x2c, 0x83,
+	0xbf, 0x0c, 0xa4, 0x7b, 0x2b, 0x8c, 0x67, 0x21, 0x3a, 0x7c, 0x2c, 0xf2, 0xf1, 0xe1, 0x83, 0x48,
+	0x3f, 0x75, 0xc0, 0xfe, 0xf7, 0x59, 0x94, 0x5d, 0xad, 0xd6, 0x8f, 0xc2, 0x7a, 0xa0, 0x61, 0xdd,
+	0x1f, 0xc6, 0x33, 0x50, 0x61, 0x5e, 0xf8, 0xa8, 0x18, 0x1e, 0xb6, 0x99, 0x40, 0x21, 0x92, 0x63,
+	0x7c, 0x90, 0x41, 0xa5, 0xd5, 0xee, 0x86, 0xbf, 0xeb, 0x33, 0xda, 0x3e, 0xe4, 0xd1, 0x3c, 0x27,
+	0x5b, 0x8f, 0x5c, 0xe8, 0x0d, 0xde, 0x7a, 0xc8, 0x86, 0xe3, 0x52, 0xb0, 0x71, 0x29, 0xc5, 0xed,
+	0x60, 0xe3, 0x0a, 0xb6, 0xab, 0x5f, 0x67, 0xd0, 0x44, 0xb5, 0x65, 0x53, 0x87, 0x2d, 0xd8, 0xbe,
+	0x2c, 0x7d, 0x0f, 0xb9, 0x57, 0x46, 0x6b, 0xc0, 0x3f, 0xc7, 0x81, 0xad, 0xf1, 0xbd, 0x0c, 0x2a,
+	0xcf, 0x77, 0xd9, 0xe6, 0x3c, 0x83, 0xbd, 0xff, 0x2b, 0xf9, 0x16, 0xfe, 0x34, 0x8d, 0x34, 0x42,
+	0x7d, 0xca, 0x82, 0x5e, 0x62, 0xcd, 0xdd, 0xa2, 0xce, 0x53, 0x28, 0xe2, 0xd5, 0x62, 0x3c, 0xf3,
+	0x25, 0x8b, 0xf1, 0xc0, 0xa9, 0xd9, 0x2f, 0xd8, 0x94, 0xf0, 0x36, 0x8f, 0xd7, 0xe8, 0xcf, 0xc8,
+	0x34, 0x9e, 0x42, 0xb7, 0x7a, 0x90, 0xd3, 0xf8, 0x38, 0x8d, 0xa6, 0xd7, 0x3c, 0xfe, 0x82, 0xb6,
+	0xe4, 0x7b, 0xfa, 0x90, 0xc7, 0x65, 0x78, 0x42, 0x87, 0x3c, 0x42, 0x7f, 0x49, 0xa3, 0x33, 0xd1,
+	0x09, 0x3d, 0x0b, 0xbb, 0xc0, 0x9f, 0xd3, 0xe8, 0xe4, 0x5b, 0x36, 0xdb, 0xec, 0x6e, 0x0c, 0x00,
+	0xa0, 0x67, 0x6f, 0x46, 0x87, 0x3c, 0xf3, 0xfe, 0x94, 0x46, 0x53, 0x2b, 0x4b, 0x0b, 0xd5, 0x67,
+	0x25, 0x42, 0x43, 0xf3, 0x79, 0x06, 0xe2, 0xb3, 0x3a, 0x7f, 0x67, 0xf9, 0x59, 0x8a, 0x4f, 0x64,
+	0x3e, 0x87, 0x3c, 0x3e, 0x3f, 0x28, 0xa0, 0x32, 0xef, 0x6e, 0x25, 0x86, 0xf8, 0x95, 0x2e, 0xf9,
+	0x67, 0x51, 0x59, 0xba, 0x01, 0x7a, 0x4b, 0x51, 0xf7, 0xc3, 0x2d, 0x2e, 0x4f, 0x90, 0xd7, 0xa1,
+	0xc7, 0x54, 0x85, 0x78, 0xeb, 0xf5, 0x0e, 0xf5, 0x36, 0xd4, 0xab, 0x0a, 0xdb, 0xd4, 0xdb, 0x20,
+	0x40, 0xc5, 0xcb, 0xe1, 0x39, 0xd1, 0x7c, 0x7d, 0xe9, 0x2d, 0xcf, 0xed, 0x76, 0x64, 0xcb, 0x0a,
+	0xd7, 0xfa, 0x3d, 0xc9, 0x5b, 0x37, 0x3b, 0xf6, 0x3a, 0xdc, 0x5b, 0x52, 0x70, 0xa4, 0x21, 0x4d,
+	0x7c, 0x17, 0x4d, 0x06, 0xb4, 0xf0, 0xfb, 0x94, 0x62, 0x82, 0xb9, 0xa4, 0x0f, 0x55, 0x86, 0x55,
+	0xf1, 0x2d, 0x34, 0x1e, 0x10, 0xdf, 0xb6, 0x1d, 0x0b, 0x60, 0xdc, 0x52, 0xe5, 0xb9, 0x7e, 0x4f,
+	0x3f, 0x3d, 0x30, 0xb5, 0x65, 0x3b, 0xea, 0x71, 0x5b, 0x44, 0x41, 0x35, 0x00, 0xfd, 0x27, 0x4a,
+	0x30, 0x10, 0x3b, 0x03, 0x8b, 0x28, 0xe0, 0x57, 0xc1, 0x40, 0xc7, 0x75, 0x7c, 0x0a, 0x58, 0x5c,
+	0x19, 0xce, 0xf1, 0xe1, 0x44, 0xca, 0x93, 0x74, 0x71, 0x5b, 0x23, 0x22, 0x16, 0x03, 0x75, 0xc6,
+	0x47, 0x07, 0x75, 0xfe, 0x93, 0x41, 0x27, 0xe6, 0x3b, 0x9d, 0xa3, 0x4f, 0x26, 0x9e, 0xd6, 0x25,
+	0x81, 0xeb, 0x08, 0xd5, 0xbb, 0x1b, 0x2d, 0xbb, 0xa1, 0xdc, 0xf8, 0x80, 0x2b, 0x38, 0x1d, 0xa0,
+	0x8a, 0x4b, 0x1f, 0x8a, 0x88, 0xf1, 0x41, 0x56, 0x8d, 0x00, 0x5c, 0x70, 0x3f, 0x8a, 0x40, 0x7e,
+	0xa4, 0xad, 0xf0, 0xb8, 0xea, 0x4c, 0x79, 0x21, 0x4e, 0x1e, 0xec, 0x04, 0xb7, 0x3c, 0x1b, 0x9c,
+	0xb5, 0x6e, 0x5b, 0x24, 0x26, 0x6b, 0xfc, 0x21, 0x8d, 0x26, 0xc3, 0x70, 0x3c, 0x8d, 0x97, 0xc3,
+	0x75, 0x84, 0x04, 0x62, 0x30, 0x00, 0xdd, 0x8f, 0x89, 0x8c, 0xf0, 0x81, 0x2a, 0x2f, 0x65, 0x85,
+	0x22, 0x03, 0x88, 0x2f, 0x9b, 0x08, 0xf1, 0x5d, 0x45, 0x45, 0x62, 0x3e, 0xf8, 0x66, 0x97, 0x7a,
+	0xbb, 0x12, 0xf6, 0x02, 0x5c, 0xcb, 0x33, 0x1f, 0xac, 0xbf, 0xcf, 0x89, 0x64, 0xc0, 0x36, 0x7e,
+	0x34, 0x8d, 0xf2, 0x2b, 0x0e, 0x5d, 0xb9, 0x8f, 0x6f, 0x28, 0x37, 0x21, 0xe4, 0x04, 0x26, 0xd5,
+	0xcc, 0x00, 0x46, 0x2d, 0x45, 0x94, 0xfb, 0x12, 0x73, 0xea, 0x21, 0xb8, 0xcc, 0x26, 0xac, 0xea,
+	0x08, 0x4e, 0x2d, 0x45, 0xd4, 0xc3, 0xf2, 0x39, 0xf5, 0x94, 0x58, 0x26, 0x52, 0x44, 0x4b, 0x70,
+	0x02, 0x2d, 0x59, 0x43, 0x2c, 0x27, 0x1d, 0xca, 0xc6, 0xef, 0x53, 0x0f, 0x4b, 0xd4, 0x52, 0x24,
+	0xf9, 0x30, 0x37, 0xf2, 0x09, 0x98, 0x4c, 0xa6, 0xe9, 0x58, 0x3a, 0x03, 0xaf, 0x96, 0x22, 0xd1,
+	0xcf, 0xc5, 0x6e, 0x46, 0xbe, 0x33, 0x92, 0x18, 0xed, 0x54, 0x4c, 0x95, 0xb3, 0x6a, 0x29, 0x12,
+	0xfb, 0x22, 0x29, 0xf2, 0x09, 0x8c, 0x04, 0xdc, 0xe3, 0x83, 0x02, 0x4f, 0x19, 0x54, 0x7c, 0x2e,
+	0xf3, 0xf5, 0xd8, 0xf7, 0x22, 0xf0, 0x6a, 0x2b, 0xcf, 0x9e, 0x8c, 0x29, 0x0b, 0x66, 0x2d, 0x45,
+	0x62, 0x5f, 0x97, 0x5c, 0x09, 0xbe, 0x8c, 0x90, 0xc7, 0x91, 0xc7, 0x95, 0x1a, 0xca, 0x7e, 0xc8,
+	0xbd, 0x14, 0x7c, 0x39, 0x31, 0xa7, 0x5e, 0xb9, 0x97, 0x97, 0xa3, 0x71, 0x6c, 0x94, 0x45, 0xc7,
+	0xe2, 0xd1, 0x51, 0xae, 0xe6, 0xbf, 0x19, 0xbf, 0x91, 0x2b, 0x6f, 0x3e, 0x9f, 0x8a, 0x69, 0x4a,
+	0x6e, 0x2d, 0x45, 0xe2, 0x37, 0x78, 0x6f, 0x46, 0x6e, 0x83, 0xca, 0xf7, 0x56, 0xdc, 0xab, 0x9c,
+	0xa5, 0x78, 0x15, 0xee, 0x8d, 0xbe, 0x19, 0xbf, 0x9e, 0xa8, 0x1d, 0x4b, 0x1c, 0x5a, 0x72, 0x95,
+	0xa1, 0x83, 0xeb, 0x8c, 0x37, 0x23, 0x17, 0xe0, 0xb4, 0xe3, 0xc9, 0x43, 0x9b, 0xcc, 0x54, 0x87,
+	0x16, 0x57, 0xe5, 0x22, 0x57, 0xb1, 0xb4, 0x13, 0x89, 0x01, 0x05, 0x9e, 0x12, 0x50, 0x71, 0x6d,
+	0xeb, 0x66, 0xe4, 0x10, 0x57, 0x9b, 0x88, 0x0e, 0xaa, 0xb0, 0xf8, 0xa0, 0xea, 0x71, 0xef, 0x9c,
+	0x7a, 0xb6, 0xa9, 0x4d, 0x46, 0x03, 0x14, 0x72, 0x78, 0x80, 0x94, 0x33, 0x50, 0x1d, 0x0e, 0x66,
+	0x34, 0x0c, 0xe2, 0xe5, 0xc1, 0x13, 0x56, 0xeb, 0xb5, 0x14, 0x81, 0x23, 0x1b, 0x43, 0x9c, 0xc8,
+	0x69, 0x53, 0x20, 0x31, 0x1e, 0x48, 0x70, 0x5a, 0x2d, 0x45, 0xc4, 0x69, 0xdd, 0x0d, 0xe5, 0x54,
+	0x40, 0x9b, 0x8e, 0x6e, 0x11, 0x03, 0x06, 0xdf, 0x22, 0xc2, 0xb3, 0x83, 0xdb, 0xc3, 0xc8, 0xb9,
+	0x76, 0x32, 0x5a, 0xc6, 0xc7, 0xf9, 0xb5, 0x14, 0x19, 0x46, 0xdb, 0x6f, 0x46, 0xc0, 0x64, 0xed,
+	0x54, 0xd4, 0x5d, 0x0a, 0x8b, 0xbb, 0x4b, 0x85, 0x9d, 0x57, 0x12, 0x6f, 0x50, 0x68, 0xa7, 0xc1,
+	0xc0, 0x73, 0x03, 0x03, 0xc3, 0x22, 0xb5, 0x14, 0x49, 0xbc, 0x7b, 0xf1, 0xde, 0xde, 0x90, 0xae,
+	0xa6, 0x81, 0xd5, 0x19, 0x65, 0x71, 0x25, 0xca, 0xd5, 0x52, 0x64, 0x6f, 0x58, 0x78, 0x4e, 0x45,
+	0x57, 0xb5, 0x33, 0xd1, 0xf8, 0x86, 0x1c, 0x1e, 0x5f, 0x05, 0x85, 0x9d, 0x53, 0xc1, 0x4c, 0xed,
+	0xec, 0xb0, 0x56, 0xb8, 0xa9, 0x2a, 0xa0, 0x27, 0x49, 0xc6, 0x0e, 0xb5, 0xe7, 0x40, 0xff, 0x5c,
+	0xa0, 0x9f, 0x24, 0x53, 0x4b, 0x91, 0x64, 0xdc, 0x91, 0x24, 0xc3, 0x77, 0xda, 0xb9, 0xfd, 0x6c,
+	0x0e, 0x9e, 0x2e, 0x19, 0xfa, 0x33, 0xf7, 0x41, 0xd0, 0xb4, 0xf3, 0xd1, 0x12, 0x77, 0x4f, 0xc1,
+	0x5a, 0x8a, 0xec, 0x83, 0xc3, 0xdd, 0xdb, 0x03, 0xce, 0xd2, 0x2e, 0x80, 0xf9, 0xf3, 0x81, 0xf9,
+	0x44, 0xa1, 0x5a, 0x8a, 0xec, 0x01, 0x86, 0xdd, 0xdb, 0x03, 0x53, 0xd2, 0xf4, 0x7d, 0xcd, 0x0e,
+	0xfc, 0xb1, 0x07, 0x22, 0xb5, 0x92, 0x08, 0xec, 0x68, 0x33, 0xd1, 0xac, 0x4e, 0x10, 0xe1, 0x59,
+	0x9d, 0x04, 0x09, 0xad, 0x24, 0x22, 0x2b, 0xda, 0xc5, 0x7d, 0x0c, 0x0e, 0x9e, 0x31, 0x11, 0x93,
+	0x59, 0x49, 0x84, 0x36, 0x34, 0x23, 0x6a, 0x30, 0x41, 0x84, 0x1b, 0x4c, 0x02, 0x45, 0x56, 0x12,
+	0xb1, 0x05, 0xed, 0xd2, 0x3e, 0x06, 0xc3, 0x27, 0x4c, 0x42, 0x25, 0x6e, 0x46, 0x9a, 0x7b, 0xed,
+	0xf9, 0xe8, 0x96, 0xa2, 0xb0, 0xf8, 0x96, 0xa2, 0xc2, 0x00, 0xd5, 0xa1, 0x7e, 0x48, 0x7b, 0x21,
+	0x5a, 0x0e, 0xc7, 0xd8, 0xb5, 0x14, 0x19, 0xea, 0xa0, 0xaa, 0x43, 0x25, 0xbd, 0x76, 0x79, 0x2f,
+	0x23, 0xc0, 0x8e, 0x1a, 0x11, 0x4d, 0xc0, 0x52, 0x42, 0x21, 0xaa, 0xfd, 0x1f, 0x98, 0x39, 0x33,
+	0x6c, 0x26, 0x9c, 0xce, 0xb0, 0x56, 0x65, 0x0c, 0xe5, 0x17, 0xb9, 0x82, 0xf1, 0xf3, 0x34, 0x1a,
+	0x5f, 0x65, 0x1e, 0x35, 0xdb, 0xf2, 0xae, 0xcd, 0x59, 0x54, 0xbc, 0xd7, 0x69, 0xb9, 0xa6, 0x15,
+	0xfc, 0x27, 0x0a, 0x32, 0xf8, 0x8d, 0x2f, 0xa3, 0xe3, 0xcb, 0xa6, 0xcf, 0x40, 0x53, 0xf9, 0x1a,
+	0x97, 0xc4, 0xa8, 0x78, 0x59, 0xc8, 0x09, 0x3d, 0xf8, 0xec, 0x2a, 0xfb, 0xc4, 0xeb, 0x9d, 0x45,
+	0x5e, 0x2c, 0xc3, 0x9d, 0xce, 0x98, 0x6e, 0x65, 0xfa, 0xd1, 0x3f, 0x2f, 0xa4, 0x1e, 0x3d, 0xbe,
+	0x90, 0xfe, 0xe4, 0xf1, 0x85, 0xf4, 0x3f, 0x1e, 0x5f, 0x48, 0xff, 0xf4, 0x5f, 0x17, 0x52, 0x1b,
+	0x05, 0xb0, 0xf1, 0xca, 0x7f, 0x03, 0x00, 0x00, 0xff, 0xff, 0x18, 0x75, 0x4c, 0x16, 0x90, 0x44,
+	0x00, 0x00,
 }

--- a/lib/events/events.proto
+++ b/lib/events/events.proto
@@ -75,6 +75,13 @@ message ConnectionMetadata {
     string Protocol = 3 [ (gogoproto.jsontag) = "proto,omitempty" ];
 }
 
+// KubernetesClusterMetadata contains common metadata for kubernetes-related
+// events.
+message KubernetesClusterMetadata {
+    // KubernetesCluster is a kubernetes cluster name.
+    string KubernetesCluster = 1 [ (gogoproto.jsontag) = "kubernetes_cluster,omitempty" ];
+}
+
 // SessionStart is a session start event
 message SessionStart {
     // Metadata is a common event metadata
@@ -99,6 +106,10 @@ message SessionStart {
 
     // TerminalSize is expressed as 'W:H'
     string TerminalSize = 6 [ (gogoproto.jsontag) = "size,omitempty" ];
+
+    // Kubernetes has information about a kubernetes cluster, if applicable.
+    KubernetesClusterMetadata Kubernetes = 7
+        [ (gogoproto.nullable) = false, (gogoproto.embed) = true, (gogoproto.jsontag) = "" ];
 }
 
 // SessionJoin emitted when another user joins a session
@@ -121,6 +132,10 @@ message SessionJoin {
 
     // ConnectionMetadata holds information about the connection
     ConnectionMetadata Connection = 5
+        [ (gogoproto.nullable) = false, (gogoproto.embed) = true, (gogoproto.jsontag) = "" ];
+
+    // Kubernetes has information about a kubernetes cluster, if applicable.
+    KubernetesClusterMetadata Kubernetes = 6
         [ (gogoproto.nullable) = false, (gogoproto.embed) = true, (gogoproto.jsontag) = "" ];
 }
 
@@ -200,6 +215,10 @@ message Resize {
 
     // TerminalSize is expressed as 'W:H'
     string TerminalSize = 6 [ (gogoproto.jsontag) = "size,omitempty" ];
+
+    // Kubernetes has information about a kubernetes cluster, if applicable.
+    KubernetesClusterMetadata Kubernetes = 7
+        [ (gogoproto.nullable) = false, (gogoproto.embed) = true, (gogoproto.jsontag) = "" ];
 }
 
 // SessionEnd is a session end event
@@ -248,6 +267,10 @@ message SessionEnd {
         (gogoproto.nullable) = false,
         (gogoproto.jsontag) = "session_stop,omitempty"
     ];
+
+    // Kubernetes has information about a kubernetes cluster, if applicable.
+    KubernetesClusterMetadata Kubernetes = 11
+        [ (gogoproto.nullable) = false, (gogoproto.embed) = true, (gogoproto.jsontag) = "" ];
 }
 
 // BPFMetadata is a common BPF process metadata
@@ -632,6 +655,10 @@ message Exec {
     // CommandMetadata is a common command metadata
     CommandMetadata Command = 6
         [ (gogoproto.nullable) = false, (gogoproto.embed) = true, (gogoproto.jsontag) = "" ];
+
+    // Kubernetes has information about a kubernetes cluster, if applicable.
+    KubernetesClusterMetadata Kubernetes = 7
+        [ (gogoproto.nullable) = false, (gogoproto.embed) = true, (gogoproto.jsontag) = "" ];
 }
 
 // SCP is emitted when data transfer has occurred between server and client
@@ -944,6 +971,10 @@ message KubeRequest {
     string ResourceName = 10 [ (gogoproto.jsontag) = "resource_name,omitempty" ];
     // ResponseCode is the HTTP response code for this request.
     int32 ResponseCode = 11 [ (gogoproto.jsontag) = "response_code" ];
+
+    // Kubernetes has information about a kubernetes cluster, if applicable.
+    KubernetesClusterMetadata Kubernetes = 12
+        [ (gogoproto.nullable) = false, (gogoproto.embed) = true, (gogoproto.jsontag) = "" ];
 }
 
 // AppSessionStart is emitted when a user is issued an application certificate.

--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -67,11 +67,7 @@ type ExecValues struct {
 // If `path` is empty, UpdateWithClient will try to guess it based on the
 // environment or known defaults.
 func UpdateWithClient(ctx context.Context, path string, tc *client.TeleportClient, tshBinary string) error {
-	v := Values{
-		Exec: &ExecValues{
-			TshBinaryPath: tshBinary,
-		},
-	}
+	var v Values
 
 	v.ClusterAddr = tc.KubeClusterAddr()
 	v.TeleportClusterName, _ = tc.KubeProxyHostPort()
@@ -86,7 +82,10 @@ func UpdateWithClient(ctx context.Context, path string, tc *client.TeleportClien
 
 	// TODO(awly): unit test this.
 	if tshBinary != "" {
-		v.Exec.TshBinaryInsecure = tc.InsecureSkipVerify
+		v.Exec = &ExecValues{
+			TshBinaryPath:     tshBinary,
+			TshBinaryInsecure: tc.InsecureSkipVerify,
+		}
 
 		// Fetch the list of known kubernetes clusters.
 		pc, err := tc.ConnectToProxy(ctx)
@@ -107,6 +106,14 @@ func UpdateWithClient(ctx context.Context, path string, tc *client.TeleportClien
 		v.Exec.SelectCluster, err = kubeutils.CheckOrSetKubeCluster(ctx, ac, tc.KubernetesCluster, v.TeleportClusterName)
 		if err != nil && !trace.IsNotFound(err) {
 			return trace.Wrap(err)
+		}
+
+		// If there are no registered k8s clusters, we may have an older
+		// teleport cluster. Fall back to the old kubeconfig, with static
+		// credentials from v.Credentials.
+		if len(v.Exec.KubeClusters) == 0 {
+			log.Debug("Disabling exec plugin mode for kubeconfig because this Teleport cluster has no Kubernetes clusters.")
+			v.Exec = nil
 		}
 	}
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -651,6 +651,9 @@ func (f *Forwarder) exec(ctx *authContext, w http.ResponseWriter, req *http.Requ
 					Login: ctx.User.GetName(),
 				},
 				TerminalSize: params.Serialize(),
+				KubernetesClusterMetadata: events.KubernetesClusterMetadata{
+					KubernetesCluster: ctx.kubeCluster,
+				},
 			}
 
 			// Report the updated window size to the event log (this is so the sessions
@@ -703,6 +706,9 @@ func (f *Forwarder) exec(ctx *authContext, w http.ResponseWriter, req *http.Requ
 				Protocol:   events.EventProtocolKube,
 			},
 			TerminalSize: termParams.Serialize(),
+			KubernetesClusterMetadata: events.KubernetesClusterMetadata{
+				KubernetesCluster: ctx.kubeCluster,
+			},
 		}
 		if err := emitter.EmitAuditEvent(f.Context, sessionStartEvent); err != nil {
 			f.WithError(err).Warn("Failed to emit event.")
@@ -770,6 +776,9 @@ func (f *Forwarder) exec(ctx *authContext, w http.ResponseWriter, req *http.Requ
 			Participants: []string{ctx.User.GetName()},
 			StartTime:    sessionStart,
 			EndTime:      f.Clock.Now().UTC(),
+			KubernetesClusterMetadata: events.KubernetesClusterMetadata{
+				KubernetesCluster: ctx.kubeCluster,
+			},
 		}
 		if err := emitter.EmitAuditEvent(f.Context, sessionEndEvent); err != nil {
 			f.WithError(err).Warn("Failed to emit session end event.")
@@ -798,6 +807,9 @@ func (f *Forwarder) exec(ctx *authContext, w http.ResponseWriter, req *http.Requ
 			},
 			CommandMetadata: events.CommandMetadata{
 				Command: strings.Join(request.cmd, " "),
+			},
+			KubernetesClusterMetadata: events.KubernetesClusterMetadata{
+				KubernetesCluster: ctx.kubeCluster,
 			},
 		}
 		if err != nil {
@@ -1057,6 +1069,9 @@ func (f *Forwarder) catchAll(ctx *authContext, w http.ResponseWriter, req *http.
 		RequestPath:  req.URL.Path,
 		Verb:         req.Method,
 		ResponseCode: int32(w.(*responseStatusRecorder).getStatus()),
+		KubernetesClusterMetadata: events.KubernetesClusterMetadata{
+			KubernetesCluster: ctx.kubeCluster,
+		},
 	}
 	r := parseResourcePath(req.URL.Path)
 	if r.skipEvent {


### PR DESCRIPTION
Also, fix a regression in tsh, where it wouldn't update the kubeconfig
on older clusters without kubernetes_service.

Updates https://github.com/gravitational/teleport/issues/3952
Updates https://github.com/gravitational/teleport/issues/3528