### PR TITLE
Configure etcd client's message size

### DIFF
--- a/docs/4.4/admin-guide.md
+++ b/docs/4.4/admin-guide.md
@@ -1467,7 +1467,9 @@ teleport:
      # Keep the two values in sync.
      #
      # See https://etcd.io/docs/v3.4.0/dev-guide/limit/ for details
-     max_client_msg_size_bytes: 15728640 # 15MiB
+     #
+     # This bumps the size to 15MiB as an example:
+     etcd_max_client_msg_size_bytes: 15728640
 ```
 
 ### Using Amazon S3

--- a/docs/4.4/admin-guide.md
+++ b/docs/4.4/admin-guide.md
@@ -1458,6 +1458,16 @@ teleport:
      # NOT RECOMMENDED: enables insecure etcd mode in which self-signed
      # certificate will be accepted
      insecure: false
+
+     # Optionally sets the limit on the client message size.
+     # This is usually used to increase the default which is 2MiB
+     # (1.5MiB server's default + gRPC overhead bytes).
+     # Make sure this does not exceed the value for the etcd
+     # server specified with `--max-request-bytes` (1.5MiB by default).
+     # Keep the two values in sync.
+     #
+     # See https://etcd.io/docs/v3.4.0/dev-guide/limit/ for details
+     max_client_msg_size_bytes: 15728640 # 15MiB
 ```
 
 ### Using Amazon S3

--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1449,6 +1449,18 @@ teleport:
      # NOT RECOMMENDED: enables insecure etcd mode in which self-signed
      # certificate will be accepted
      insecure: false
+
+     # Optionally sets the limit on the client message size.
+     # This is usually used to increase the default which is 2MiB
+     # (1.5MiB server's default + gRPC overhead bytes).
+     # Make sure this does not exceed the value for the etcd
+     # server specified with `--max-request-bytes` (1.5MiB by default).
+     # Keep the two values in sync.
+     #
+     # See https://etcd.io/docs/v3.4.0/dev-guide/limit/ for details
+     #
+     # This bumps the size to 15MiB as an example:
+     etcd_max_client_msg_size_bytes: 15728640
 ```
 
 ### Using Amazon S3

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -167,7 +167,7 @@ type Config struct {
 	PasswordFile string `json:"password_file,omitempty"`
 	// MaxClientMsgSizeBytes optionally specifies the size limit on client send message size.
 	// See https://github.com/etcd-io/etcd/blob/221f0cc107cb3497eeb20fb241e1bcafca2e9115/clientv3/config.go#L49
-	MaxClientMsgSizeBytes int `json:"max_client_msg_size_bytes,omitempty"`
+	MaxClientMsgSizeBytes int `json:"etcd_max_client_msg_size_bytes,omitempty"`
 }
 
 // legacyDefaultPrefix was used instead of Config.Key prior to 4.3. It's used

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -368,7 +368,7 @@ func (s *EtcdSuite) TestSyncLegacyPrefix(c *check.C) {
 	s.reset(c)
 }
 
-// CompareAndSwapIssue4786 ensures that the backend reacts with a proper
+// TestCompareAndSwapOversizedValue ensures that the backend reacts with a proper
 // error message if client sends a message exceeding the configured size maximum
 // See https://github.com/gravitational/teleport/issues/4786
 func (s *EtcdSuite) TestCompareAndSwapOversizedValue(c *check.C) {

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -26,8 +26,9 @@ import (
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
-	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
 
 	"github.com/jonboulle/clockwork"
 	"go.etcd.io/etcd/clientv3"
@@ -371,27 +372,28 @@ func (s *EtcdSuite) TestSyncLegacyPrefix(c *check.C) {
 // TestCompareAndSwapOversizedValue ensures that the backend reacts with a proper
 // error message if client sends a message exceeding the configured size maximum
 // See https://github.com/gravitational/teleport/issues/4786
-func (s *EtcdSuite) TestCompareAndSwapOversizedValue(c *check.C) {
+func TestCompareAndSwapOversizedValue(t *testing.T) {
 	// setup
 	const maxClientMsgSize = 128
 	bk, err := New(context.Background(), backend.Params{
-		"peers":                     []string{"https://127.0.0.1:2379"},
-		"prefix":                    "/teleport",
-		"tls_key_file":              "../../../examples/etcd/certs/client-key.pem",
-		"tls_cert_file":             "../../../examples/etcd/certs/client-cert.pem",
-		"tls_ca_file":               "../../../examples/etcd/certs/ca-cert.pem",
-		"dial_timeout":              500 * time.Millisecond,
-		"max_client_msg_size_bytes": maxClientMsgSize,
+		"peers":                          []string{"https://127.0.0.1:2379"},
+		"prefix":                         "/teleport",
+		"tls_key_file":                   "../../../examples/etcd/certs/client-key.pem",
+		"tls_cert_file":                  "../../../examples/etcd/certs/client-cert.pem",
+		"tls_ca_file":                    "../../../examples/etcd/certs/ca-cert.pem",
+		"dial_timeout":                   500 * time.Millisecond,
+		"etcd_max_client_msg_size_bytes": maxClientMsgSize,
 	})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	prefix := test.MakePrefix()
 	// Explicitly exceed the message size
 	value := make([]byte, maxClientMsgSize+1)
 
 	// verify
-	_, err = bk.CompareAndSwap(context.TODO(),
+	_, err = bk.CompareAndSwap(context.Background(),
 		backend.Item{Key: prefix("one"), Value: []byte("1")},
 		backend.Item{Key: prefix("one"), Value: value},
 	)
-	fixtures.ExpectLimitExceeded(c, err)
+	require.True(t, trace.IsLimitExceeded(err))
+	require.Regexp(t, ".*ResourceExhausted.*", err)
 }

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/utils"
+
 	"github.com/jonboulle/clockwork"
 	"go.etcd.io/etcd/clientv3"
-
 	"gopkg.in/check.v1"
 )
 
@@ -54,12 +54,13 @@ func (s *EtcdSuite) SetUpSuite(c *check.C) {
 
 	// this config must match examples/etcd/teleport.yaml
 	s.config = backend.Params{
-		"peers":         []string{"https://127.0.0.1:2379"},
-		"prefix":        "/teleport",
-		"tls_key_file":  "../../../examples/etcd/certs/client-key.pem",
-		"tls_cert_file": "../../../examples/etcd/certs/client-cert.pem",
-		"tls_ca_file":   "../../../examples/etcd/certs/ca-cert.pem",
-		"dial_timeout":  500 * time.Millisecond,
+		"peers":                     []string{"https://127.0.0.1:2379"},
+		"prefix":                    "/teleport",
+		"tls_key_file":              "../../../examples/etcd/certs/client-key.pem",
+		"tls_cert_file":             "../../../examples/etcd/certs/client-cert.pem",
+		"tls_ca_file":               "../../../examples/etcd/certs/ca-cert.pem",
+		"dial_timeout":              500 * time.Millisecond,
+		"max_client_msg_size_bytes": test.EtcdMaxClientMsgSize,
 	}
 
 	newBackend := func() (backend.Backend, error) {
@@ -118,6 +119,11 @@ func (s *EtcdSuite) TestDeleteRange(c *check.C) {
 
 func (s *EtcdSuite) TestCompareAndSwap(c *check.C) {
 	s.suite.CompareAndSwap(c)
+}
+
+// Issue: https://github.com/gravitational/teleport/issues/4786
+func (s *EtcdSuite) TestCompareAndSwapIssue4786(c *check.C) {
+	s.suite.CompareAndSwapIssue4786(c)
 }
 
 func (s *EtcdSuite) TestExpiration(c *check.C) {

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -101,9 +101,9 @@ func (s *BackendSuite) CRUD(c *check.C) {
 	c.Assert(string(out.Value), check.Equals, string(item.Value))
 
 	// put with binary key and value succeeds
-	key := make([]byte, keySize)
+	key := make([]byte, 1024)
 	rand.Read(key)
-	data := make([]byte, valueSize)
+	data := make([]byte, 1024)
 	rand.Read(data)
 	item = backend.Item{Key: prefix(string(key)), Value: data}
 	_, err = s.B.Put(ctx, item)
@@ -249,21 +249,6 @@ func (s *BackendSuite) PutRange(c *check.C) {
 		{Key: prefix("/prefix/b"), Value: []byte("val b")},
 	}
 	ExpectItems(c, result.Items, expected)
-}
-
-// CompareAndSwapIssue4786 ensures that the backend reacts with a proper
-// error message if client sends a message exceeding the configured size maximum
-func (s *BackendSuite) CompareAndSwapIssue4786(c *check.C) {
-	// setup
-	prefix := MakePrefix()
-	// Explicitly exceed the message size
-	var value [EtcdMaxClientMsgSize + 1]byte
-	// verify
-	_, err := s.B.CompareAndSwap(context.TODO(),
-		backend.Item{Key: prefix("one"), Value: []byte("1")},
-		backend.Item{Key: prefix("one"), Value: value[:]},
-	)
-	fixtures.ExpectLimitExceeded(c, err)
 }
 
 // CompareAndSwap tests compare and swap functionality
@@ -764,13 +749,3 @@ func ExpectItems(c *check.C, items, expected []backend.Item) {
 		c.Assert(string(items[i].Value), check.Equals, string(expected[i].Value))
 	}
 }
-
-const (
-	// Keep these values combined below the maximum client message size (EtcdMaxClientMsgSize)
-	keySize   = 1024
-	valueSize = 1024
-
-	// EtcdMaxClientMsgSize specifies the limit for the etcd client's
-	// message size.
-	EtcdMaxClientMsgSize = 4096
-)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -410,6 +410,7 @@ func (s *SrvSuite) TestAgentForward(c *C) {
 		time.Sleep(10 * time.Millisecond)
 		output, _ = ioutil.ReadFile(tmpFile.Name())
 	}
+	c.Assert(output, Not(Equals), "")
 	socketPath := strings.TrimSpace(string(output))
 
 	// try dialing the ssh agent socket:


### PR DESCRIPTION
lib/backend/etcdbk: add a configuration attribute to set the client's send message size limit.
Also fix the possible nil pointer panic in `CompareAndSwap` resulting from the message size limit being exceeded.

This will also need a backport to at least 4.4 if I understand correctly.

Updates https://github.com/gravitational/teleport/issues/4786.