### PR TITLE
Update to Helm v3 and package all charts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -640,19 +640,18 @@ steps:
       - git clone https://github.com/gravitational/teleport.git .
       - git checkout ${DRONE_COMMIT}
 
-  - name: Package helm chart
-    image: alpine/helm:2.16.9
+  - name: Package helm charts
+    image: alpine/helm:latest
     commands:
       - mkdir -p /go/chart
       - cd /go/chart
-      - helm init --client-only
-      - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport
+      - helm package /go/src/github.com/gravitational/teleport/examples/chart/*
       - helm repo index /go/chart
 
   - name: Upload to S3
     image: plugins/s3
     settings:
-      bucket: charts.gravitational.io
+      bucket: PRODUCTION_CHARTS_AWS_S3_BUCKET
       access_key:
         from_secret: PRODUCTION_CHARTS_AWS_ACCESS_KEY_ID
       secret_key:
@@ -3158,6 +3157,6 @@ volumes:
 
 ---
 kind: signature
-hmac: a85a99a9decf13e8ce9de7545269267f97f1a3a8a4a6934f83e213fda87b330d
+hmac: 91cc9b08c0507201616798c8b9a04669fa6538f3a413572eec76955f30431634
 
 ...

--- a/examples/chart/teleport-auto-trustedcluster/Chart.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/Chart.yaml
@@ -1,6 +1,7 @@
-name: teleport
-version: 0.0.4
-description: Teleport Enterprise
+name: teleport-auto-trustedcluster
+apiVersion: v2
+version: 0.0.6
+description: Teleport trusted cluster installation which automatically joins itself back to the provided root cluster.
+icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
 keywords:
   - Teleport Enterprise
-tillerVersion: ">=2.8.0"

--- a/examples/chart/teleport-auto-trustedcluster/README.md
+++ b/examples/chart/teleport-auto-trustedcluster/README.md
@@ -28,7 +28,7 @@ There are comments in the file describing what the values need to be set to.
 ## Prerequisites
 
 - Helm v3
-- Kubernetes 1.10+
+- Kubernetes 1.13+
 - A Teleport license file stored as a Kubernetes Secret object - see below
 
 ### Prepare the license file

--- a/examples/chart/teleport-auto-trustedcluster/README.md
+++ b/examples/chart/teleport-auto-trustedcluster/README.md
@@ -28,7 +28,7 @@ There are comments in the file describing what the values need to be set to.
 ## Prerequisites
 
 - Helm v3
-- Kubernetes 1.13+
+- Kubernetes 1.14+
 - A Teleport license file stored as a Kubernetes Secret object - see below
 
 ### Prepare the license file

--- a/examples/chart/teleport-auto-trustedcluster/README.md
+++ b/examples/chart/teleport-auto-trustedcluster/README.md
@@ -27,7 +27,7 @@ There are comments in the file describing what the values need to be set to.
 
 ## Prerequisites
 
-- Helm v2.16+
+- Helm v3
 - Kubernetes 1.10+
 - A Teleport license file stored as a Kubernetes Secret object - see below
 
@@ -53,7 +53,7 @@ installing the chart.
 To install the chart with the release name `teleport`, run:
 
 ```console
-helm install --name teleport ./
+helm install teleport ./
 ```
 
 You can view debug logs for the cluster with this command:
@@ -74,5 +74,5 @@ kubectl logs deploy/teleport -c teleport-sidecar
 If you need to delete the chart, you can use:
 
 ```console
-helm delete --purge teleport
+helm uninstall teleport
 ```

--- a/examples/chart/teleport-auto-trustedcluster/templates/deployment.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/templates/deployment.yaml
@@ -93,6 +93,9 @@ spec:
       - name: {{ template "teleport.fullname" . }}-config
         configMap:
           name: {{ template "teleport.fullname" . }}
+      - name: {{ template "teleport.fullname" . }}-bootstrap-script
+        configMap:
+          name: {{ template "teleport.fullname" . }}-bootstrap-script
       - name: {{ template "teleport.fullname" . }}-storage
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/examples/chart/teleport-auto-trustedcluster/values.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/gravitational/teleport-ent
   # This tag reflects the version of Teleport to deploy
-  tag: 4.4.0
+  tag: 4.4
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.
@@ -24,8 +24,8 @@ config:
     enabled: yes
     license_file: /var/lib/license/license-enterprise.pem
     # This will be the name that appears in the root cluster for management, so
-    # it should be descriptive and contain the name of the customer.
-    cluster_name: add-customer-name-here
+    # it should be descriptive.
+    cluster_name: add-leaf-cluster-name-here
 
   ssh_service:
     enabled: yes

--- a/examples/chart/teleport-daemonset/Chart.yaml
+++ b/examples/chart/teleport-daemonset/Chart.yaml
@@ -1,6 +1,7 @@
-name: teleport
-version: 0.0.4
-description: Teleport Enterprise
+name: teleport-daemonset
+apiVersion: v2
+version: 0.0.6
+description: Teleport daemonset installation which provides some access to underlying Kubernetes nodes.
+icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
 keywords:
   - Teleport Enterprise
-tillerVersion: ">=2.8.0"

--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -37,6 +37,8 @@ Each node connects back to the auth server of the Teleport leaf cluster running 
 This setup may not survive failures of the `kubelet` or other underlying node services, so it should **not** be relied on for
 emergency 'break-glass' access in the event of a failure.
 
+Note: this chart does **not** work as-is on CoreOS-based distributions (e.g. GKE's Container-Optimized OS) which mount `/usr/local/bin` read-only.
+
 ## Prerequisites
 
 - Helm v3

--- a/examples/chart/teleport-daemonset/README.md
+++ b/examples/chart/teleport-daemonset/README.md
@@ -39,20 +39,10 @@ emergency 'break-glass' access in the event of a failure.
 
 ## Prerequisites
 
-- Helm v2.16 (Helm v3 is not currently supported)
-  - You must have Tiller working and configured properly inside your cluster
+- Helm v3
 - Kubernetes 1.14+
 - A Teleport license file stored as a Kubernetes Secret object - see below
   - This means that by definition, the chart will use an Enterprise version of Teleport
-
-On many cloud providers, the `default` service account doesn't have sufficient privileges to deploy charts when used to run
-Tiller. In this situation, you will need to deploy Tiller with `cluster-admin` privileges like this:
-
-```console
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-helm init --service-account tiller --upgrade --wait
-```
 
 ### Prepare the license file
 
@@ -82,7 +72,7 @@ then providing this file to Helm using the `-f` parameter on the command line. H
 To install the chart with the release name `teleport` and extra values from `teleport-values.yaml`, run:
 
 ```console
-helm install --name teleport -f teleport-values.yaml ./
+helm install teleport -f teleport-values.yaml ./
 ```
 
 You can view debug logs for the cluster with this command:
@@ -112,5 +102,5 @@ use `kubectl logs pod/teleport-node-xxxxxx` to view logs from each node separate
 If you need to delete the chart, you can use:
 
 ```console
-helm delete --purge teleport
+helm uninstall teleport
 ```

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/gravitational/teleport-ent
   # This tag reflects the version of Teleport to deploy
-  tag: 4.4.0
+  tag: 4.4
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.

--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -1,8 +1,7 @@
 name: teleport
-apiVersion: v1
-version: 0.0.5
+apiVersion: v2
+version: 0.0.6
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
 keywords:
   - Teleport
-tillerVersion: ">=2.8.0"

--- a/examples/chart/teleport/HIGHAVAILABILITY.md
+++ b/examples/chart/teleport/HIGHAVAILABILITY.md
@@ -66,10 +66,10 @@ A high availability deployment of Teleport will typically have at least 2 proxy 
 ```
 ### Confirming
 
-After configuring both of these options run the install.  In the example below you will see two teleport pods that are the Proxy instances  (teleport-) and two teleport pods that that are the Auth instances (teleportauth-).
+After configuring both of these options run the install.  In the example below you will see two teleport pods that are the Proxy instances (`teleport-`) and two teleport pods that that are the Auth instances (`teleportauth-`).
 
 ``` bash
-$ helm install --name teleport ./
+$ helm install teleport ./
 
 $ kubectl get pods
 NAME                            READY   STATUS    RESTARTS   AGE

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -32,6 +32,7 @@ See the [High Availability](./HIGHAVAILABILITY.md)(HA) instructions for configur
 
 ## Prerequisites
 
+- Helm v3
 - Kubernetes 1.10+
 - Teleport license for Enterprise deployments
 - TLS Certificates or optionally use self-signed certificates
@@ -82,7 +83,7 @@ $ kubectl create configmap ca-certs --from-file=ca.pem
 To install the chart with the release name `teleport`, run:
 
 ```
-$ helm install --name teleport ./
+$ helm install teleport ./
 ```
 
 
@@ -115,87 +116,10 @@ Now, you can run various `tsh` commands against your local Teleport installation
 $ tsh login --auth=local --user=$USER login
 ```
 
-
 ## Configuring High Availability
 
-Running multiple instances of the Authentication Services requires using a high availability storage configuration.  The [documentation](https://gravitational.com/teleport/docs/admin-guide/#high-availability) provides detailed examples using AWS DynamoDB/S3, GCP Firestore/Google storage or an `etcd` cluster. Here we provide detailed steps for an AWS example configuration.
+See the [High Availability (HA)](HIGHAVAILABILITY.md) instructions for configuring a HA deployment with this helm chart.
 
-### Prerequisites
- - Available AWS credentials (/home/<user>/.aws/credentials)
- - Have AWS credentials that can create and access DyanmoDB details as documented here.
- - Bucket for storing Sessions as documented [here](https://gravitational.com/teleport/docs/admin-guide/#using-amazon-s3).
-
-### Example High Availability Storage
-1. First add the credentials file as a secret
-```bash
-kubectl create secret generic awscredentials --from-file=~/.aws/credentials
-```
-
-2. Set the DynamoDB and Sessions storage within `values.yaml`
-
-```yaml
-    storage:
-      type: dynamodb
-      region: us-east-1
-      table_name: teleport
-      audit_events_uri: 'dynamodb://teleport_events'
-      audit_sessions_uri: 's3://teleportexample/sessions?region=us-east-1'
-```
-
-3. In the `values.yaml` set the volume and volume mount for AWS credentials only available to the auth service.
-```yaml
-extraAuthVolumes:
-  - name: awscredentials
-    secret:
-      secretName: awscredentials
-
-
-  # - name: ca-certs
-  #   configMap:
-  #     name: ca-certs
-extraAuthVolumeMounts:
-  - mountPath: /root/.aws
-    name: awscredentials
-```
-
-
-
-### Configuring Multiple Instances of Teleport
-
-A high availability deployment of Teleport will typically have at least 2 proxy and 2 auth service instances.  SSH service is typically not enabled on these instances.  To enable separate deployments of the auth and auth services follow these steps.
-
-1. In the configuration section set the `highAvailability` to true.  Also confirm the auth public address and Service Type.
-```yaml
-  highAvailability: true
-  # High availability configuration with proxy and auth servers. No SSH configured service.
-  proxyCount: 2
-  authCount: 2
-  authServiceType: ClusterIP
-  auth_public_address: auth.example.com
-```
-2. Set the connection for the proxies to connect to the auth service in the config section. The auth service is available at the Kubernetes service name and the public address setting.  So if you deploy an app named myexample then the auth service will be available in the Cluster at `myexampleauth` in addition to the public address.
-
-```yaml
-  auth_service_connection:
-    auth_token: dogs-are-much-nicer-than-cats
-    auth_servers:
-    - teleportauth:3025
-    - teleport.example.com:3025
-```
-### Confirming
-
-After configuring both of these options run the install.  In the example below you will see two teleport pods that are the Proxy instances  (teleport-) and two teleport pods that that are the Auth instances (teleportauth-).
-
-``` bash
-$ helm install --name teleport ./
-
-$ kubectl get pods
-NAME                            READY   STATUS    RESTARTS   AGE
-teleport-d67584df8-8vfls        1/1     Running   0          62m
-teleport-d67584df8-p9l2g        1/1     Running   0          62m
-teleportauth-66455f85ff-7x7g4   1/1     Running   0          62m
-teleportauth-66455f85ff-hgsdj   1/1     Running   0          62m
-```
 
 ## Troubleshooting
 
@@ -207,7 +131,7 @@ If you the Teleport pods are not starting the most common issue is lack of requi
 
 
 ### Teleport Pods keep restarting with Error
-The issue may be due to a malformed Teleport configuration file or other configuration issue.  Use the kubectl logs command to see the logs output.
+The issue may be due to a malformed Teleport configuration file or other configuration issue.  Use the `kubectl logs` command to see the log output.
 Example:
 `kubectl logs -f teleport-5f5f989b96-9khzq` .
 

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -33,7 +33,7 @@ See the [High Availability](./HIGHAVAILABILITY.md)(HA) instructions for configur
 ## Prerequisites
 
 - Helm v3
-- Kubernetes 1.13+
+- Kubernetes 1.14+
 - Teleport license for Enterprise deployments
 - TLS Certificates or optionally use self-signed certificates
 
@@ -87,15 +87,15 @@ $ helm install teleport ./
 ```
 
 
-## Downloading the chart from the Gravitational repo
+## Downloading the chart from the Teleport Helm repo
 
-Gravitational hosts this Helm chart at https://charts.gravitational.io - it is updated from `master` every night.
+Gravitational hosts this Helm chart at https://charts.releases.teleport.dev - it is updated from `master` every night.
 
 To add the chart and use it, you can run these commands:
 
 ```console
-$ helm repo add gravitational https://charts.gravitational.io
-$ helm install teleport gravitational/teleport
+$ helm repo add teleport https://charts.releases.teleport.dev
+$ helm install teleport teleport/teleport
 ```
 
 You will still need a correctly configured `values.yaml` file for this to work.

--- a/examples/chart/teleport/README.md
+++ b/examples/chart/teleport/README.md
@@ -33,7 +33,7 @@ See the [High Availability](./HIGHAVAILABILITY.md)(HA) instructions for configur
 ## Prerequisites
 
 - Helm v3
-- Kubernetes 1.10+
+- Kubernetes 1.13+
 - Teleport license for Enterprise deployments
 - TLS Certificates or optionally use self-signed certificates
 

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -12,7 +12,7 @@ image:
   # Used if license is disabled
   communityRepository: quay.io/gravitational/teleport
   # Version of Teleport
-  tag: 4.4.0
+  tag: 4.4
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.


### PR DESCRIPTION
Updates #3656 
Fixes #4256 

- Updates Helm charts and docs to support Helm v3
- Updates default image to be latest `4.4` tag rather than a specific version
- Fix error with `bootstrap-scripts` mount for `teleport-auto-trustedcluster`
- Update Drone cron job to publish all Helm charts to Gravitational chart repo
  - Also gives each chart a unique name so they can be published/installed separately
- Tidy up docs and remove duplication of HA section