### PR TITLE
Changes helm charts to use X.Y version of docker tag

### DIFF
--- a/examples/chart/teleport-auto-trustedcluster/values.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/gravitational/teleport-ent
   # This tag reflects the version of Teleport to deploy
-  tag: 4.4.0
+  tag: 4.4
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/gravitational/teleport-ent
   # This tag reflects the version of Teleport to deploy
-  tag: 4.4.0
+  tag: 4.4
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -12,7 +12,7 @@ image:
   # Used if license is disabled
   communityRepository: quay.io/gravitational/teleport
   # Version of Teleport
-  tag: 4.4.0
+  tag: 4.4
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.


### PR DESCRIPTION
Using X.Y tag for the docker tag will pull the latest (4.4 on Nov 12, 2020 would pull 4.4.4).  