### PR TITLE
Added application name validation.

### DIFF
--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -129,3 +129,48 @@ func (s *FileTestSuite) TestLegacyAuthenticationSection(c *check.C) {
 	c.Assert(fc.Auth.U2F.Facets, check.HasLen, 1)
 	c.Assert(fc.Auth.U2F.Facets[0], check.Equals, "https://graviton:3080")
 }
+
+// TestAppName makes sure application names are valid subdomains.
+func (s *FileTestSuite) TestAppName(c *check.C) {
+	tests := []struct {
+		desc     check.CommentInterface
+		inName   string
+		outValid bool
+	}{
+		{
+			desc:     check.Commentf("valid subdomain"),
+			inName:   "foo",
+			outValid: true,
+		},
+		{
+			desc:     check.Commentf("subdomain can not start with a dash"),
+			inName:   "-foo",
+			outValid: false,
+		},
+		{
+			desc:     check.Commentf(`subdomain can not contain the exclamation mark character "!"`),
+			inName:   "foo!bar",
+			outValid: false,
+		},
+		{
+			desc:     check.Commentf("subdomain of length 63 characters is valid (maximum length)"),
+			inName:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			outValid: true,
+		},
+		{
+			desc:     check.Commentf("subdomain of length 64 characters is invalid"),
+			inName:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			outValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		a := App{
+			Name:       tt.inName,
+			URI:        "http://localhost:8080",
+			PublicAddr: "foo.example.com",
+		}
+		err := a.CheckAndSetDefaults()
+		c.Assert(err == nil, check.Equals, tt.outValid, tt.desc)
+	}
+}


### PR DESCRIPTION
**Description**

Added validation check that ensures application names are valid DNS subdomains. This is because and application name can potentially be used in the DNS name of the application if either a public address is not provided or the application is accessed via a trusted cluster.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/4819