### PR TITLE
Changed redirect endpoint when session is expired.

### DIFF
--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -17,12 +17,15 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 
 	"github.com/julienschmidt/httprouter"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // withRouterAuth authenticates requests then hands the request to a
@@ -47,14 +50,29 @@ func (h *Handler) withAuth(handler handlerAuthFunc) http.HandlerFunc {
 		// If the caller fails to authenticate, redirect the caller to Teleport.
 		session, err := h.authenticate(r.Context(), r)
 		if err != nil {
-			// If this cluster has the public address of the proxy set, re-direct to
-			// the login page. If not, the best that can be done is to show "403 Forbidden"
-			// because Teleport does not know where to re-direct to.
+			// If this cluster has the public address of the proxy set, redirect to the
+			// login page to redirect to the requested application. If not, the best
+			// that can be done is to show "403 Forbidden" because Teleport does not know
+			// the public address of the Web UI which is needed to launch the application.
 			if h.c.WebPublicAddr != "" {
+				addr, err := utils.ParseAddr(r.Host)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				// While the FQDN will be validated when creating an application session,
+				// make sure we don't send something that doesn't at least look like a
+				// FQDN to the frontend application.
+				if errs := validation.IsDNS1123Subdomain(addr.Host()); len(errs) > 0 {
+					var aerrs []error
+					for _, err := range errs {
+						aerrs = append(aerrs, trace.BadParameter(err))
+					}
+					return trace.NewAggregate(aerrs...)
+				}
 				u := url.URL{
 					Scheme: "https",
 					Host:   h.c.WebPublicAddr,
-					Path:   "/web/login",
+					Path:   fmt.Sprintf("/web/launch/%v", addr.Host()),
 				}
 				http.Redirect(w, r, u.String(), http.StatusFound)
 				return nil


### PR DESCRIPTION
**Description**

When the user does not have a session, if the user tries to access a proxied application at it's FQDN, Teleport does best effort resolution.

This fix changes the behavior of what happens when the user has a session but the session is expired. The user was being redirected to the login page. This fix changes the behavior to by in sync with the no-session behavior in doing best effort resolution.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/4559