### PR TITLE
Add a depth limit to RBAC expression parser

### DIFF
--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -140,7 +140,7 @@ func NewExpression(variable string) (*Expression, error) {
 	}
 
 	// walk the ast tree and gather the variable parts
-	result, err := walk(expr)
+	result, err := walk(expr, 0)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -202,7 +202,7 @@ func NewMatcher(value string) (m Matcher, err error) {
 	}
 
 	// walk the ast tree and gather the variable parts
-	result, err := walk(expr)
+	result, err := walk(expr, 0)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -289,6 +289,10 @@ type transformer interface {
 	transform(in string) (string, error)
 }
 
+// maxASTDepth is the maximum depth of the AST that func walk will traverse.
+// The limit exists to protect against DoS via malicious inputs.
+const maxASTDepth = 1000
+
 type walkResult struct {
 	parts     []string
 	transform transformer
@@ -296,7 +300,11 @@ type walkResult struct {
 }
 
 // walk will walk the ast tree and gather all the variable parts into a slice and return it.
-func walk(node ast.Node) (*walkResult, error) {
+func walk(node ast.Node, depth int) (*walkResult, error) {
+	if depth > maxASTDepth {
+		return nil, trace.LimitExceeded("expression exceeds the maximum allowed depth")
+	}
+
 	var result walkResult
 
 	switch n := node.(type) {
@@ -324,7 +332,7 @@ func walk(node ast.Node) (*walkResult, error) {
 					return nil, trace.BadParameter("expected 1 argument for %v.%v got %v", namespace, fn, len(n.Args))
 				}
 				result.transform = emailLocalTransformer{}
-				ret, err := walk(n.Args[0])
+				ret, err := walk(n.Args[0], depth+1)
 				if err != nil {
 					return nil, trace.Wrap(err)
 				}
@@ -367,25 +375,25 @@ func walk(node ast.Node) (*walkResult, error) {
 			return nil, trace.BadParameter("unsupported function %T", n.Fun)
 		}
 	case *ast.IndexExpr:
-		ret, err := walk(n.X)
+		ret, err := walk(n.X, depth+1)
 		if err != nil {
 			return nil, err
 		}
 		result.parts = append(result.parts, ret.parts...)
-		ret, err = walk(n.Index)
+		ret, err = walk(n.Index, depth+1)
 		if err != nil {
 			return nil, err
 		}
 		result.parts = append(result.parts, ret.parts...)
 		return &result, nil
 	case *ast.SelectorExpr:
-		ret, err := walk(n.X)
+		ret, err := walk(n.X, depth+1)
 		if err != nil {
 			return nil, err
 		}
 		result.parts = append(result.parts, ret.parts...)
 
-		ret, err = walk(n.Sel)
+		ret, err = walk(n.Sel, depth+1)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Our current parsing code runtime grows exponentially with nested
selectors (e.g. '{{a.b.c.d.e.f}}'), mostly due to memory churn from
slice allocations. With 100,000 levels of selectors, parsing takes ~80s
on my machine.
If an attacker can submit these expressions for parsing, they can DoS
the auth server with relatively small payloads (<1MB).

All real-world expressions are <10 AST nodes deep. Add a sanity check of
1000 levels to protect against malicious inputs.

We can optimize the code later on, but it's not very useful for real
world performance.