### PR TITLE
Bump Go to 1.15.5

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ type: kubernetes
 name: test
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
   UID: 1000
   GID: 1000
 
@@ -202,7 +202,7 @@ type: kubernetes
 name: build-on-push
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
   UID: 1000
   GID: 1000
 
@@ -669,7 +669,7 @@ type: kubernetes
 name: build-linux-amd64
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
 
 trigger:
   event:
@@ -772,7 +772,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
 
 trigger:
   event:
@@ -876,7 +876,7 @@ type: kubernetes
 name: build-linux-amd64-centos6
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
 
 trigger:
   event:
@@ -980,7 +980,7 @@ type: kubernetes
 name: build-linux-amd64-centos6-fips
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
 
 trigger:
   event:
@@ -1562,7 +1562,7 @@ type: kubernetes
 name: build-linux-i386
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
 
 trigger:
   event:
@@ -2417,7 +2417,7 @@ type: kubernetes
 name: build-windows
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
 
 trigger:
   event:
@@ -2522,7 +2522,7 @@ type: kubernetes
 name: build-docker-images
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
 
 trigger:
   event:
@@ -2835,7 +2835,7 @@ type: kubernetes
 name: build-buildboxes
 
 environment:
-  RUNTIME: go1.15.3
+  RUNTIME: go1.15.5
   UID: 1000
   GID: 1000
 
@@ -3158,6 +3158,6 @@ volumes:
 
 ---
 kind: signature
-hmac: d83c8dcc9ed2e3ac56c112411f25f096e5b5c896c3fe7269e92deb0b76bf6aeb
+hmac: 8f17b3edc11f7c493d4465bccf1e349646b3ce8234919f9af3fec974ba634800
 
 ...

--- a/build.assets/Dockerfile-centos6-fips
+++ b/build.assets/Dockerfile-centos6-fips
@@ -27,7 +27,7 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
 ARG RUNTIME
 ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
 RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
-    mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${RUNTIME}b4.src.tar.gz | tar xz && \
+    mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${RUNTIME}b5.src.tar.gz | tar xz && \
     cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
     rm -rf /go-bootstrap && \
     mkdir -p /go/src/github.com/gravitational/teleport && \

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -34,7 +34,7 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
 
 # Install Go.
 ARG RUNTIME
-RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${RUNTIME}b4.linux-amd64.tar.gz | tar xz;\
+RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${RUNTIME}b5.linux-amd64.tar.gz | tar xz;\
     mkdir -p /go/src/github.com/gravitational/teleport;\
     chmod a+w /go;\
     chmod a+w /var/lib;\

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -16,7 +16,7 @@ TEST_KUBE ?=
 
 OS ?= linux
 ARCH ?= amd64
-RUNTIME ?= go1.15.3
+RUNTIME ?= go1.15.5
 
 UID ?= $$(id -u)
 GID ?= $$(id -g)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # The base image (buildbox:latest) is built by running `make -C build.assets`
 # from the base repo directory $GOPATH/gravitational.com/teleport
-FROM quay.io/gravitational/teleport-buildbox:go1.15.3
+FROM quay.io/gravitational/teleport-buildbox:go1.15.5
 RUN apt-get update
 # DEBUG=1 is needed for the Web UI to be loaded from static assets instead
 # of the binary


### PR DESCRIPTION
BoringCrypto now supports 1.15.5, so we can bump up to that version across the board.

Also fixes a change in BoringCrypto download URLs which now use `b5` as a suffix rather than `b4` (as the BoringCrypto version has been bumped)