### PR TITLE
Prevent a panic in tsh kube login when logged out

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -504,6 +504,7 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 }
 
 // Status returns the active profile as well as a list of available profiles.
+// If not profile is active, Status returns a nil error and nil profile.
 func Status(profileDir string, proxyHost string) (*ProfileStatus, []*ProfileStatus, error) {
 	var err error
 	var profile *ProfileStatus

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -226,10 +225,12 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 	profile, _, err := client.Status("", cf.Proxy)
 	if err != nil {
 		if trace.IsNotFound(err) {
-			fmt.Println("Not logged in.")
-			return nil
+			return trace.AccessDenied("not logged in")
 		}
-		utils.FatalError(err)
+		return trace.Wrap(err)
+	}
+	if profile == nil {
+		return trace.AccessDenied("not logged in")
 	}
 	kc, err := kubeconfig.Load("")
 	if err != nil {


### PR DESCRIPTION
Turns out, client.Status can return a nil error *and* profile.
Handle nil profile separately and return a simple error.

Updates https://github.com/gravitational/teleport/issues/4884