### PR TITLE
Updated default admin role.

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -75,6 +75,7 @@ var ExtendedAdminUserRules = []Rule{
 // assigned to all roles.
 var DefaultImplicitRules = []Rule{
 	NewRule(KindNode, RO()),
+	NewRule(KindProxy, RO()),
 	NewRule(KindAuthServer, RO()),
 	NewRule(KindReverseTunnel, RO()),
 	NewRule(KindCertAuthority, ReadNoSecrets()),


### PR DESCRIPTION
**Description**

Updated default admin role to support reading `services.KindProxy`. This is needed by `tctl` when using credentials from `~/.tsh` to generate an application join message.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/4877