### PR TITLE
fix tsh login with trusted clusters

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -956,6 +956,24 @@ func (tc *TeleportClient) NewWatcher(ctx context.Context, watch services.Watch) 
 	return proxyClient.NewWatcher(ctx, watch)
 }
 
+// WithRootClusterClient provides a functional interface for making calls against the root cluster's
+// auth server.
+func (tc *TeleportClient) WithRootClusterClient(ctx context.Context, do func(clt auth.ClientI) error) error {
+	proxyClient, err := tc.ConnectToProxy(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer proxyClient.Close()
+
+	clt, err := proxyClient.ConnectToRootCluster(ctx, false)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer clt.Close()
+
+	return trace.Wrap(do(clt))
+}
+
 // SSH connects to a node and, if 'command' is specified, executes the command on it,
 // otherwise runs interactive shell
 //

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -945,15 +945,35 @@ func (tc *TeleportClient) GetRole(ctx context.Context, name string) (services.Ro
 	return proxyClient.GetRole(ctx, name)
 }
 
+// watchCloser is a wrapper around a services.Watcher
+// which holds a closer that must be called after the watcher
+// is closed.
+type watchCloser struct {
+	services.Watcher
+	io.Closer
+}
+
+func (w watchCloser) Close() error {
+	return trace.NewAggregate(w.Watcher.Close(), w.Closer.Close())
+}
+
 // NewWatcher sets up a new event watcher.
 func (tc *TeleportClient) NewWatcher(ctx context.Context, watch services.Watch) (services.Watcher, error) {
 	proxyClient, err := tc.ConnectToProxy(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer proxyClient.Close()
 
-	return proxyClient.NewWatcher(ctx, watch)
+	watcher, err := proxyClient.NewWatcher(ctx, watch)
+	if err != nil {
+		proxyClient.Close()
+		return nil, trace.Wrap(err)
+	}
+
+	return watchCloser{
+		Watcher: watcher,
+		Closer:  proxyClient,
+	}, nil
 }
 
 // WithRootClusterClient provides a functional interface for making calls against the root cluster's

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -359,6 +359,19 @@ func (proxy *ProxyClient) ConnectToCurrentCluster(ctx context.Context, quiet boo
 	return proxy.ConnectToCluster(ctx, cluster.Name, quiet)
 }
 
+// ConnectToRootCluster connects to the auth server of the root cluster
+// cluster via proxy. It returns connected and authenticated auth server client
+//
+// if 'quiet' is set to true, no errors will be printed to stdout, otherwise
+// any connection errors are visible to a user.
+func (proxy *ProxyClient) ConnectToRootCluster(ctx context.Context, quiet bool) (auth.ClientI, error) {
+	clusterName, err := proxy.RootClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return proxy.ConnectToCluster(ctx, clusterName, quiet)
+}
+
 // ConnectToCluster connects to the auth server of the given cluster via proxy.
 // It returns connected and authenticated auth server client
 //

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -616,14 +616,26 @@ func onLogin(cf *CLIConf) {
 			tc.Logout()
 			utils.FatalError(err)
 		}
-		for _, roleName := range roleNames {
-			role, err := tc.GetRole(cf.Context, roleName)
-			if err != nil {
-				tc.Logout()
-				utils.FatalError(err)
+		// load all roles from root cluster and collect relevant options.
+		// the normal one-off TeleportClient methods don't re-use the auth server
+		// connection, so we use WithRootClusterClient to speed things up.
+		err = tc.WithRootClusterClient(cf.Context, func(clt auth.ClientI) error {
+			for _, roleName := range roleNames {
+				role, err := clt.GetRole(roleName)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				reason = reason || role.GetOptions().RequestAccess.RequireReason()
+				auto = auto || role.GetOptions().RequestAccess.ShouldAutoRequest()
+				if prompt == "" {
+					prompt = role.GetOptions().RequestPrompt
+				}
 			}
-			reason = reason || role.GetOptions().RequestAccess.RequireReason()
-			auto = auto || role.GetOptions().RequestAccess.ShouldAutoRequest()
+			return nil
+		})
+		if err != nil {
+			tc.Logout()
+			utils.FatalError(err)
 		}
 		if reason && cf.RequestReason == "" {
 			tc.Logout()


### PR DESCRIPTION
Fixes an issue where `tsh login` would generate not found or access denied errors when attempting to login when the previous login was with a trusted cluster.  Ex:

```bash
$ tsh login
If browser window does not open automatically, open it by clicking on the link:
 http://127.0.0.1:46405/2fee557c-7342-44b5-8f59-90e9ad8c3f61
error: role root-admin is not found
```

The recent additions to the Access Workflow API made it necessary for `tsh` to load a user's roles after initial login in order to determine if it should auto-generate an access request.  In the event that the user's certs contained a route-to-cluster directive, `tsh` would attempt to load the roles from the *leaf* cluster, instead of the root cluster.

*edit*: Also added a fix for #4895, which was being triggered due to an early `Close()` call.