### PR TITLE
[4.4] configure etcd client's message size

### DIFF
--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -162,6 +162,9 @@ type Config struct {
 	// PasswordFile is an optional password file for HTTPS basic authentication,
 	// expects path to a file
 	PasswordFile string `json:"password_file,omitempty"`
+	// MaxClientMsgSizeBytes optionally specifies the size limit on client send message size.
+	// See https://github.com/etcd-io/etcd/blob/221f0cc107cb3497eeb20fb241e1bcafca2e9115/clientv3/config.go#L49
+	MaxClientMsgSizeBytes int `json:"etcd_max_client_msg_size_bytes,omitempty"`
 }
 
 // legacyDefaultPrefix was used instead of Config.Key prior to 4.3. It's used
@@ -313,11 +316,12 @@ func (b *EtcdBackend) reconnect() error {
 	tlsConfig.ClientCAs = certPool
 
 	clt, err := clientv3.New(clientv3.Config{
-		Endpoints:   b.nodes,
-		TLS:         tlsConfig,
-		DialTimeout: b.cfg.DialTimeout,
-		Username:    b.cfg.Username,
-		Password:    b.cfg.Password,
+		Endpoints:          b.nodes,
+		TLS:                tlsConfig,
+		DialTimeout:        b.cfg.DialTimeout,
+		Username:           b.cfg.Username,
+		Password:           b.cfg.Password,
+		MaxCallSendMsgSize: b.cfg.MaxClientMsgSizeBytes,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -490,6 +494,7 @@ func (b *EtcdBackend) CompareAndSwap(ctx context.Context, expected backend.Item,
 		if trace.IsNotFound(err) {
 			return nil, trace.CompareFailed(err.Error())
 		}
+		return nil, trace.Wrap(err)
 	}
 	if !re.Succeeded {
 		return nil, trace.CompareFailed("key %q did not match expected value", string(expected.Key))
@@ -803,6 +808,8 @@ func convertErr(err error) error {
 			return trace.AlreadyExists(err.Error())
 		case codes.FailedPrecondition:
 			return trace.CompareFailed(err.Error())
+		case codes.ResourceExhausted:
+			return trace.LimitExceeded(err.Error())
 		default:
 			return trace.BadParameter(err.Error())
 		}

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
+	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/require"
 	"github.com/jonboulle/clockwork"
 	"go.etcd.io/etcd/clientv3"
 	"gopkg.in/check.v1"
@@ -385,7 +385,7 @@ func (s *EtcdSuite) TestSyncLegacyPrefix(c *check.C) {
 // TestCompareAndSwapOversizedValue ensures that the backend reacts with a proper
 // error message if client sends a message exceeding the configured size maximum
 // See https://github.com/gravitational/teleport/issues/4786
-func TestCompareAndSwapOversizedValue(t *testing.T) {
+func (s *EtcdSuite) TestCompareAndSwapOversizedValue(c *check.C) {
 	// setup
 	const maxClientMsgSize = 128
 	bk, err := New(context.Background(), backend.Params{
@@ -397,7 +397,7 @@ func TestCompareAndSwapOversizedValue(t *testing.T) {
 		"dial_timeout":                   500 * time.Millisecond,
 		"etcd_max_client_msg_size_bytes": maxClientMsgSize,
 	})
-	require.NoError(t, err)
+	c.Assert(err, check.IsNil)
 	prefix := test.MakePrefix()
 	// Explicitly exceed the message size
 	value := make([]byte, maxClientMsgSize+1)
@@ -407,6 +407,5 @@ func TestCompareAndSwapOversizedValue(t *testing.T) {
 		backend.Item{Key: prefix("one"), Value: []byte("1")},
 		backend.Item{Key: prefix("one"), Value: value},
 	)
-	require.True(t, trace.IsLimitExceeded(err))
-	require.Regexp(t, ".*ResourceExhausted.*", err)
+	fixtures.ExpectLimitExceeded(c, err)
 }


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/4800.