### PR TITLE
[5.0] configure etcd client's message size

### DIFF
--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -165,6 +165,9 @@ type Config struct {
 	// PasswordFile is an optional password file for HTTPS basic authentication,
 	// expects path to a file
 	PasswordFile string `json:"password_file,omitempty"`
+	// MaxClientMsgSizeBytes optionally specifies the size limit on client send message size.
+	// See https://github.com/etcd-io/etcd/blob/221f0cc107cb3497eeb20fb241e1bcafca2e9115/clientv3/config.go#L49
+	MaxClientMsgSizeBytes int `json:"etcd_max_client_msg_size_bytes,omitempty"`
 }
 
 // legacyDefaultPrefix was used instead of Config.Key prior to 4.3. It's used
@@ -335,12 +338,13 @@ func (b *EtcdBackend) reconnect(ctx context.Context) error {
 	tlsConfig.ClientCAs = certPool
 
 	clt, err := clientv3.New(clientv3.Config{
-		Endpoints:   b.nodes,
-		TLS:         tlsConfig,
-		DialTimeout: b.cfg.DialTimeout,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
-		Username:    b.cfg.Username,
-		Password:    b.cfg.Password,
+		Endpoints:          b.nodes,
+		TLS:                tlsConfig,
+		DialTimeout:        b.cfg.DialTimeout,
+		DialOptions:        []grpc.DialOption{grpc.WithBlock()},
+		Username:           b.cfg.Username,
+		Password:           b.cfg.Password,
+		MaxCallSendMsgSize: b.cfg.MaxClientMsgSizeBytes,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -513,6 +517,7 @@ func (b *EtcdBackend) CompareAndSwap(ctx context.Context, expected backend.Item,
 		if trace.IsNotFound(err) {
 			return nil, trace.CompareFailed(err.Error())
 		}
+		return nil, trace.Wrap(err)
 	}
 	if !re.Succeeded {
 		return nil, trace.CompareFailed("key %q did not match expected value", string(expected.Key))
@@ -826,6 +831,8 @@ func convertErr(err error) error {
 			return trace.AlreadyExists(err.Error())
 		case codes.FailedPrecondition:
 			return trace.CompareFailed(err.Error())
+		case codes.ResourceExhausted:
+			return trace.LimitExceeded(err.Error())
 		default:
 			return trace.BadParameter(err.Error())
 		}

--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -27,9 +27,11 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/test"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/jonboulle/clockwork"
-	"go.etcd.io/etcd/clientv3"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/clientv3"
 	"gopkg.in/check.v1"
 )
 
@@ -365,4 +367,33 @@ func (s *EtcdSuite) TestSyncLegacyPrefix(c *check.C) {
 		backupPrefix + "/2":       "c2",
 	})
 	s.reset(c)
+}
+
+// TestCompareAndSwapOversizedValue ensures that the backend reacts with a proper
+// error message if client sends a message exceeding the configured size maximum
+// See https://github.com/gravitational/teleport/issues/4786
+func TestCompareAndSwapOversizedValue(t *testing.T) {
+	// setup
+	const maxClientMsgSize = 128
+	bk, err := New(context.Background(), backend.Params{
+		"peers":                          []string{"https://127.0.0.1:2379"},
+		"prefix":                         "/teleport",
+		"tls_key_file":                   "../../../examples/etcd/certs/client-key.pem",
+		"tls_cert_file":                  "../../../examples/etcd/certs/client-cert.pem",
+		"tls_ca_file":                    "../../../examples/etcd/certs/ca-cert.pem",
+		"dial_timeout":                   500 * time.Millisecond,
+		"etcd_max_client_msg_size_bytes": maxClientMsgSize,
+	})
+	require.NoError(t, err)
+	prefix := test.MakePrefix()
+	// Explicitly exceed the message size
+	value := make([]byte, maxClientMsgSize+1)
+
+	// verify
+	_, err = bk.CompareAndSwap(context.Background(),
+		backend.Item{Key: prefix("one"), Value: []byte("1")},
+		backend.Item{Key: prefix("one"), Value: value},
+	)
+	require.True(t, trace.IsLimitExceeded(err))
+	require.Regexp(t, ".*ResourceExhausted.*", err)
 }


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/4800.