### PR TITLE
Remove Homebrew as an option for Mac in docs

### DIFF
--- a/docs/4.3/installation.md
+++ b/docs/4.3/installation.md
@@ -100,12 +100,6 @@ $ helm install teleport teleport/teleport
 
 ## MacOS
 
-=== "Homebrew"
-
-    ```bash
-    $ brew install teleport
-    ```
-
 === "Download"
 
       [Download MacOS .pkg installer](https://gravitational.com/teleport/download) (tsh client only, signed) file, double-click to run the Installer.

--- a/docs/4.3/user-manual.md
+++ b/docs/4.3/user-manual.md
@@ -57,7 +57,6 @@ to call [`tsh login`](cli-docs.md#tsh-login) in the beginning.
 
 - Windows Users: [Download tsh Binary](https://gravitational.com/teleport/download?os=windows)
 - Mac Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=macos)
-- Mac Users with [Brew](https://brew.sh/): `brew install teleport`
 - Linux Users: [Download Linux Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
 
 ## User Identities

--- a/docs/4.4/installation.md
+++ b/docs/4.4/installation.md
@@ -115,12 +115,6 @@ $ helm install teleport teleport/teleport
 
 ## MacOS
 
-=== "Homebrew"
-
-    ```bash
-    $ brew install teleport
-    ```
-
 === "Download"
 
       [Download MacOS .pkg installer](https://gravitational.com/teleport/download) (tsh client only, signed) file, double-click to run the Installer.

--- a/docs/4.4/user-manual.md
+++ b/docs/4.4/user-manual.md
@@ -57,7 +57,6 @@ to call [`tsh login`](cli-docs.md#tsh-login) in the beginning.
 
 - Windows Users: [Download tsh Binary](https://gravitational.com/teleport/download?os=windows)
 - Mac Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=macos)
-- Mac Users with [Brew](https://brew.sh/): `brew install teleport`
 - Linux Users: [Download Linux Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
 
 ## User Identities

--- a/docs/5.0/installation.md
+++ b/docs/5.0/installation.md
@@ -115,12 +115,6 @@ $ helm install teleport teleport/teleport
 
 ## MacOS
 
-=== "Homebrew"
-
-    ```bash
-    $ brew install teleport
-    ```
-
 === "Download"
 
       [Download MacOS .pkg installer](https://gravitational.com/teleport/download) (tsh client only, signed) file, double-click to run the Installer.

--- a/docs/5.0/quickstart.md
+++ b/docs/5.0/quickstart.md
@@ -179,10 +179,15 @@ A selection of Two-Factor Authentication apps are.
 
 ## Step 2a: Install Teleport Locally
 
-=== "Mac - Homebrew"
+=== "Mac"
 
-    ```bash
-    brew install teleport
+    Please note that due to a [technical limitation](https://github.com/gravitational/teleport/issues/3158), our MacOS Teleport packages are not currently signed.
+
+    ```
+    curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-darwin-amd64-bin.tar.gz
+    tar -xzf teleport-v{{ teleport.version }}-darwin-amd64-bin.tar.gz
+    cd teleport
+    ./install
     ```
 
 === "Windows - Powershell"
@@ -212,7 +217,7 @@ Prior to launch you must authenticate.
 === "Local Cluster - tsh"
 
     ```
-    # Replace teleport.example.com:3080 with your cluster  address.
+    # Replace teleport.example.com:3080 with your cluster address.
     tsh login --proxy=teleport.example.com:3080 --user=teleport-admin
     ```
 

--- a/docs/5.0/user-manual.md
+++ b/docs/5.0/user-manual.md
@@ -57,7 +57,6 @@ to call [`tsh login`](cli-docs.md#tsh-login) in the beginning.
 
 - Windows Users: [Download tsh Binary](https://gravitational.com/teleport/download?os=windows)
 - Mac Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=macos)
-- Mac Users with [Brew](https://brew.sh/): `brew install teleport`
 - Linux Users: [Download Linux Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
 
 ## User Identities


### PR DESCRIPTION
We don't control the Teleport package in [Homebrew](https://brew.sh/) and there is [an outstanding issue](https://github.com/Homebrew/homebrew-core/issues/65004) which means that the Teleport 4.4.5 package is currently broken. There has also been a [similar issue in the past](https://github.com/Homebrew/homebrew-core/issues/45234) - it seems related to a bug in MacOS 10.15+ `tar` .

We shouldn't be recommending that people install our software using third-party methods we have no control or visibility over.