### PR TITLE
Adds a note about installing for MacOS via Homebrew

### DIFF
--- a/docs/4.3/installation.md
+++ b/docs/4.3/installation.md
@@ -100,12 +100,6 @@ $ helm install teleport teleport/teleport
 
 ## MacOS
 
-=== "Homebrew"
-
-    ```bash
-    $ brew install teleport
-    ```
-
 === "Download"
 
       [Download MacOS .pkg installer](https://gravitational.com/teleport/download) (tsh client only, signed) file, double-click to run the Installer.
@@ -113,6 +107,15 @@ $ helm install teleport teleport/teleport
     !!! note
         This method only installs the `tsh` client for interacting with Teleport clusters.
         If you need the `teleport` server or `tctl` admin tool, use the "Terminal" method instead.
+
+=== "Homebrew"
+
+    ```bash
+    $ brew install teleport
+    ```
+
+    !!! note
+        The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
 
 === "Terminal"
 

--- a/docs/4.3/user-manual.md
+++ b/docs/4.3/user-manual.md
@@ -57,8 +57,11 @@ to call [`tsh login`](cli-docs.md#tsh-login) in the beginning.
 
 - Windows Users: [Download tsh Binary](https://gravitational.com/teleport/download?os=windows)
 - Mac Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=macos)
-- Mac Users with [Brew](https://brew.sh/): `brew install teleport`
+- Mac Users with [Homebrew](https://brew.sh/): `brew install teleport`
 - Linux Users: [Download Linux Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
+
+    !!! note
+        The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
 
 ## User Identities
 

--- a/docs/4.4/installation.md
+++ b/docs/4.4/installation.md
@@ -115,19 +115,22 @@ $ helm install teleport teleport/teleport
 
 ## MacOS
 
+=== "Download"
+
+      [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the Installer.
+
+    !!! note
+        This method only installs the `tsh` client for interacting with Teleport clusters.
+        If you need the `teleport` server or `tctl` admin tool, use the "Terminal" method instead.
+
 === "Homebrew"
 
     ```bash
     $ brew install teleport
     ```
 
-=== "Download"
-
-      [Download MacOS .pkg installer](https://gravitational.com/teleport/download) (tsh client only, signed) file, double-click to run the Installer.
-
     !!! note
-        This method only installs the `tsh` client for interacting with Teleport clusters.
-        If you need the `teleport` server or `tctl` admin tool, use the "Terminal" method instead.
+        The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
 
 === "Terminal"
 

--- a/docs/4.4/user-manual.md
+++ b/docs/4.4/user-manual.md
@@ -57,8 +57,11 @@ to call [`tsh login`](cli-docs.md#tsh-login) in the beginning.
 
 - Windows Users: [Download tsh Binary](https://gravitational.com/teleport/download?os=windows)
 - Mac Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=macos)
-- Mac Users with [Brew](https://brew.sh/): `brew install teleport`
+- Mac Users with [Homebrew](https://brew.sh/): `brew install teleport`
 - Linux Users: [Download Linux Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
+
+    !!! note
+        The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
 
 ## User Identities
 

--- a/docs/5.0/installation.md
+++ b/docs/5.0/installation.md
@@ -115,19 +115,22 @@ $ helm install teleport teleport/teleport
 
 ## MacOS
 
+=== "Download"
+
+      [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the Installer.
+
+    !!! note
+        This method only installs the `tsh` client for interacting with Teleport clusters.
+        If you need the `teleport` server or `tctl` admin tool, use the "Terminal" method instead.
+
 === "Homebrew"
 
     ```bash
     $ brew install teleport
     ```
 
-=== "Download"
-
-      [Download MacOS .pkg installer](https://gravitational.com/teleport/download) (tsh client only, signed) file, double-click to run the Installer.
-
     !!! note
-        This method only installs the `tsh` client for interacting with Teleport clusters.
-        If you need the `teleport` server or `tctl` admin tool, use the "Terminal" method instead.
+        The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
 
 === "Terminal"
 

--- a/docs/5.0/quickstart.md
+++ b/docs/5.0/quickstart.md
@@ -179,11 +179,18 @@ A selection of Two-Factor Authentication apps are.
 
 ## Step 2a: Install Teleport Locally
 
+=== "Mac"
+
+    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the Installer.
+
 === "Mac - Homebrew"
 
     ```bash
-    brew install teleport
+    $ brew install teleport
     ```
+
+    !!! note
+        The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
 
 === "Windows - Powershell"
 

--- a/docs/5.0/user-manual.md
+++ b/docs/5.0/user-manual.md
@@ -57,8 +57,11 @@ to call [`tsh login`](cli-docs.md#tsh-login) in the beginning.
 
 - Windows Users: [Download tsh Binary](https://gravitational.com/teleport/download?os=windows)
 - Mac Users: [Download Mac Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=macos)
-- Mac Users with [Brew](https://brew.sh/): `brew install teleport`
+- Mac Users with [Homebrew](https://brew.sh/): `brew install teleport`
 - Linux Users: [Download Linux Teleport Binary. Includes tsh](https://gravitational.com/teleport/download?os=linux)
+
+    !!! note
+        The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
 
 ## User Identities
 


### PR DESCRIPTION
Adds a note next to Homebrew installation instructions recommending the use of our own packages. Also adds non-Homebrew  installation instructions to 5.0 quickstart docs as they were missing.