### PR TITLE
Change log about missing kube clusters on login to debug

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -609,7 +609,7 @@ func (a *Server) generateUserCert(req certRequest) (*certs, error) {
 			if !trace.IsNotFound(err) {
 				return nil, trace.Wrap(err)
 			}
-			log.WithError(err).Warning("Failed setting default kubernetes cluster for user login (user did not provide a cluster); leaving KubernetesCluster extension in the TLS certificate empty")
+			log.WithError(err).Debug("Failed setting default kubernetes cluster for user login (user did not provide a cluster); leaving KubernetesCluster extension in the TLS certificate empty")
 		}
 	}
 	// generate TLS certificate


### PR DESCRIPTION
This is a totally OK situation in clusters without k8s integration, so
it shouldn't be a warning.

Updates https://github.com/gravitational/teleport/issues/4928