### PR TITLE
Added error checking to Application Access CLI.

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1012,6 +1012,13 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 		}
 	}
 
+	// If this process is trying to join a cluster as an application service,
+	// make sure application name and URI are provided.
+	if utils.SliceContainsStr(splitRoles(clf.Roles), defaults.RoleApp) &&
+		(clf.AppName == "" || clf.AppURI == "") {
+		return trace.BadParameter("application name (--app-name) and URI (--app-uri) flags are both required to join application proxy to the cluster")
+	}
+
 	// If application name was specified on command line, add to file
 	// configuration where it will be validated.
 	if clf.AppName != "" {
@@ -1312,7 +1319,7 @@ func fileExists(fp string) bool {
 
 // validateRoles makes sure that value upassed to --roles flag is valid
 func validateRoles(roles string) error {
-	for _, role := range strings.Split(roles, ",") {
+	for _, role := range splitRoles(roles) {
 		switch role {
 		case defaults.RoleAuthService,
 			defaults.RoleNode,
@@ -1324,4 +1331,9 @@ func validateRoles(roles string) error {
 		}
 	}
 	return nil
+}
+
+// splitRoles splits in the format roles expects.
+func splitRoles(roles string) []string {
+	return strings.Split(roles, ",")
 }

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1136,10 +1136,32 @@ app_service:
 func (s *ConfigTestSuite) TestAppsCLF(c *check.C) {
 	tests := []struct {
 		desc      check.CommentInterface
+		inRoles   string
 		inAppName string
 		inAppURI  string
 		outError  error
 	}{
+		{
+			desc:      check.Commentf("role provided, valid name and uri"),
+			inRoles:   defaults.RoleApp,
+			inAppName: "foo",
+			inAppURI:  "http://localhost:8080",
+			outError:  nil,
+		},
+		{
+			desc:      check.Commentf("role provided, name not provided"),
+			inRoles:   defaults.RoleApp,
+			inAppName: "",
+			inAppURI:  "http://localhost:8080",
+			outError:  trace.BadParameter(""),
+		},
+		{
+			desc:      check.Commentf("role provided, uri not provided"),
+			inRoles:   defaults.RoleApp,
+			inAppName: "foo",
+			inAppURI:  "",
+			outError:  trace.BadParameter(""),
+		},
 		{
 			desc:      check.Commentf("valid name and uri"),
 			inAppName: "foo",
@@ -1161,6 +1183,7 @@ func (s *ConfigTestSuite) TestAppsCLF(c *check.C) {
 
 	for _, tt := range tests {
 		clf := CommandLineFlags{
+			Roles:   tt.inRoles,
 			AppName: tt.inAppName,
 			AppURI:  tt.inAppURI,
 		}


### PR DESCRIPTION
**Description**

Check if both application name and URI are provided when attempting to join an application service process to a cluster.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/4941