### PR TITLE
Adda a helm chart for in-cluster kubernetes_service agent

### DIFF
--- a/docs/5.0/aws-oss-guide.md
+++ b/docs/5.0/aws-oss-guide.md
@@ -334,6 +334,12 @@ rules:
   verbs:
   - impersonate
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - "authorization.k8s.io"
   resources:
   - selfsubjectaccessreviews

--- a/docs/5.0/kubernetes-ssh.md
+++ b/docs/5.0/kubernetes-ssh.md
@@ -173,6 +173,12 @@ rules:
   verbs:
   - impersonate
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - "authorization.k8s.io"
   resources:
   - selfsubjectaccessreviews

--- a/examples/chart/teleport-auto-trustedcluster/Chart.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/Chart.yaml
@@ -1,6 +1,6 @@
 name: teleport-auto-trustedcluster
 apiVersion: v2
-version: 0.0.6
+version: 0.0.7
 description: Teleport trusted cluster installation which automatically joins itself back to the provided root cluster.
 icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
 keywords:

--- a/examples/chart/teleport-auto-trustedcluster/Chart.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/Chart.yaml
@@ -2,6 +2,6 @@ name: teleport-auto-trustedcluster
 apiVersion: v2
 version: 0.0.7
 description: Teleport trusted cluster installation which automatically joins itself back to the provided root cluster.
-icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
+icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:
   - Teleport Enterprise

--- a/examples/chart/teleport-daemonset/Chart.yaml
+++ b/examples/chart/teleport-daemonset/Chart.yaml
@@ -1,6 +1,6 @@
 name: teleport-daemonset
 apiVersion: v2
-version: 0.0.6
+version: 0.0.7
 description: Teleport daemonset installation which provides some access to underlying Kubernetes nodes.
 icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
 keywords:

--- a/examples/chart/teleport-daemonset/Chart.yaml
+++ b/examples/chart/teleport-daemonset/Chart.yaml
@@ -2,6 +2,6 @@ name: teleport-daemonset
 apiVersion: v2
 version: 0.0.7
 description: Teleport daemonset installation which provides some access to underlying Kubernetes nodes.
-icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
+icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:
   - Teleport Enterprise

--- a/examples/chart/teleport-daemonset/templates/clusterrole.yaml
+++ b/examples/chart/teleport-daemonset/templates/clusterrole.yaml
@@ -15,6 +15,12 @@ rules:
   verbs:
   - impersonate
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - "authorization.k8s.io"
   resources:
   - selfsubjectaccessreviews

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
 version: 0.0.1
-appVersion: 5.0.0-rc.2
+appVersion: 5.0.0
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,8 @@
-name: teleport
+name: teleport-kube-agent
 apiVersion: v2
-version: 0.0.7
+version: 0.0.1
+appVersion: 5.0.0-rc.2
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
-icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
+icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:
   - Teleport

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -1,0 +1,35 @@
+# Teleport Kubernetes Agent
+
+This chart is a minimal Teleport agent used to register a Kubernetes cluster
+with an existing Teleport cluster.
+
+To use it, you will need:
+- an existing Teleport cluster (at least proxy and auth services)
+- a reachable proxy endpoint (`$PROXY_ENDPOINT`)
+- a [static join
+  token](https://goteleport.com/teleport/docs/admin-guide/#adding-nodes-to-the-cluster)
+  for this Teleport cluster (`$JOIN_TOKEN`)
+  - this chart does not currently support dynamic join tokens; please [file an
+    issue](https://github.com/gravitational/teleport/issues/new?labels=type%3A+feature+request&template=feature_request.md)
+    if you require support for dynamic tokens
+- choose a name for your Kubernetes cluster, distinct from other registered
+  clusters (`$KUBERNETES_CLUSTER_NAME`)
+
+To install the agent, run:
+
+```sh
+$ helm install teleport-kube-agent . \
+  --namespace teleport \
+  --set proxyAddr=$PROXY_ENDPOINT \
+  --set authToken=$JOIN_TOKEN \
+  --set kubeClusterName=$KUBERNETES_CLUSTER_NAME
+```
+
+Set the values in the above command as appropriate for your setup.
+
+After installing, the new cluster should show up in `tsh kube ls` after a few
+minutes. If the new cluster doesn't show up, look into the agent logs with:
+
+```sh
+$ kubectl logs -n teleport deployment/teleport-kube-agent
+```

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -19,6 +19,7 @@ To install the agent, run:
 
 ```sh
 $ helm install teleport-kube-agent . \
+  --create-namespace \
   --namespace teleport \
   --set proxyAddr=$PROXY_ENDPOINT \
   --set authToken=$JOIN_TOKEN \

--- a/examples/chart/teleport-kube-agent/templates/clusterrole.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrole.yaml
@@ -1,10 +1,7 @@
-{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "teleport.fullname" . }}
-  labels:
-{{ include "teleport.labels" . | indent 4 }}
+  name: {{ .Values.clusterRoleName }}
 rules:
 - apiGroups:
   - ""
@@ -26,4 +23,3 @@ rules:
   - selfsubjectaccessreviews
   verbs:
   - create
-{{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.clusterRoleBindingName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.clusterRoleName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   teleport.yaml: |
     teleport:
-      auth_token: {{ required "authToken is required in chart values" .Values.authToken }}
+      auth_token: "/etc/teleport-secrets/auth-token"
       auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
 
     kubernetes_service:

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+data:
+  teleport.yaml: |
+    teleport:
+      auth_token: {{ required "authToken is required in chart values" .Values.authToken }}
+      auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
+
+    kubernetes_service:
+      enabled: true
+      kube_cluster_name: {{ required "kubeClusterName is required in chart values" .Values.kubeClusterName }}
+
+    auth_service:
+      enabled: false
+    ssh_service:
+      enabled: false
+    proxy_service:
+      enabled: false

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
+  annotations:
+    # ConfigMap checksum, to recreate deployment on config changes.
+    checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -45,12 +48,18 @@ spec:
         - mountPath: /etc/teleport
           name: "config"
           readOnly: true
+        - mountPath: /etc/teleport-secrets
+          name: "auth-token"
+          readOnly: true
         - mountPath: /var/lib/teleport
           name: "data"
       volumes:
       - name: "config"
         configMap:
           name: {{ .Release.Name }}
+      - name: "auth-token"
+        secret:
+          secretName: {{ .Values.secretName }}
       - name: "data"
         emptyDir: {}
       serviceAccountName: {{ .Values.serviceAccountName }}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: "teleport"
+        image: "{{ .Values.image }}:{{ if .Values.teleportVersionOverride }}{{ .Values.teleportVersionOverride }}{{ else }}{{ .Chart.AppVersion }}{{ end }}"
+        args:
+        - "--diag-addr=0.0.0.0:3000"
+        {{- if .Values.insecureSkipProxyTLSVerify }}
+        - "--insecure"
+        {{- end }}
+        ports:
+        - name: diag
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: diag
+          initialDelaySeconds: 5 # wait 5s for agent to start
+          periodSeconds: 5 # poll health every 5s
+          failureThreshold: 6 # consider agent unhealthy after 30s (6 * 5s)
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: diag
+          initialDelaySeconds: 5 # wait 5s for agent to register
+          periodSeconds: 5 # poll health every 5s
+          failureThreshold: 12 # consider agent unhealthy after 60s (12 * 5s)
+        volumeMounts:
+        - mountPath: /etc/teleport
+          name: "config"
+          readOnly: true
+        - mountPath: /var/lib/teleport
+          name: "data"
+      volumes:
+      - name: "config"
+        configMap:
+          name: {{ .Release.Name }}
+      - name: "data"
+        emptyDir: {}
+      serviceAccountName: {{ .Values.serviceAccountName }}

--- a/examples/chart/teleport-kube-agent/templates/secret.yaml
+++ b/examples/chart/teleport-kube-agent/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secretName }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  auth-token: |
+    {{ required "authToken is required in chart values" .Values.authToken }}

--- a/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -1,0 +1,36 @@
+##################################################
+# Values that must always be provided by the user.
+##################################################
+
+# Join token for the cluster.
+authToken:
+# Address of the teleport proxy with port (usually :3080).
+proxyAddr:
+# Name for this kubernetes cluster to be used by teleport users.
+kubeClusterName:
+
+##################################################
+# Values that you may need to change.
+##################################################
+
+# Version of teleport image, if different from appVersion in Chart.yaml.
+teleportVersionOverride: ""
+# When set to true, the agent will skip the verification of proxy TLS
+# certificate.
+insecureSkipProxyTLSVerify: false
+
+##################################################
+# Values that you shouldn't need to change.
+##################################################
+
+# Container image for the agent. Since this runs without the auth_service, we
+# don't need the enterprise version.
+image: quay.io/gravitational/teleport
+# Number of replicas for the agent deployment.
+replicaCount: 1
+# Name of the ClusterRole, used by the agent's service account.
+clusterRoleName: teleport-kube-agent
+# Name of the ClusterRoleBinding, used by the agent's service account.
+clusterRoleBindingName: teleport-kube-agent
+# Name of the service account used by the agent.
+serviceAccountName: teleport-kube-agent

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -34,3 +34,5 @@ clusterRoleName: teleport-kube-agent
 clusterRoleBindingName: teleport-kube-agent
 # Name of the service account used by the agent.
 serviceAccountName: teleport-kube-agent
+# Name of the Secret to store the teleport join token.
+secretName: teleport-kube-agent-join-token

--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -2,6 +2,6 @@ name: teleport
 apiVersion: v2
 version: 0.0.7
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
-icon: https://gravitational.com/gravitational/images/logos/company-logos/teleport-symbol-400x400.png
+icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:
   - Teleport

--- a/examples/chart/teleport/templates/clusterrole.yaml
+++ b/examples/chart/teleport/templates/clusterrole.yaml
@@ -15,6 +15,12 @@ rules:
   verbs:
   - impersonate
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - "authorization.k8s.io"
   resources:
   - selfsubjectaccessreviews

--- a/examples/k8s-auth/get-kubeconfig.sh
+++ b/examples/k8s-auth/get-kubeconfig.sh
@@ -75,6 +75,12 @@ rules:
   verbs:
   - impersonate
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - "authorization.k8s.io"
   resources:
   - selfsubjectaccessreviews


### PR DESCRIPTION
This is a simplified version of the teleport chart, intended to only run
a "stateless" `kubernetes_service` instance within a kubernetes cluster.
This instance joins an externally-managed teleport cluster, given a
proxy address and a join token. The connection is always over a reverse
tunnel, per our recommended approach.

The chart is opinionated and only lets the user modify the bare minimum.

Usage:
```
$ helm install teleport-agent . \
  --namespace teleport \
  --set proxyAddr=$PROXY_ENDPOINT \
  --set authToken=$JOIN_TOKEN \
  --set kubeClusterName=$KUBERNETES_CLUSTER_NAME
```

Also, add `pods/get` permission to `ClusterRole`s everywhere. It's not mandatory, but lets us collect more info for session audit logs in 5.0

Updates https://github.com/gravitational/teleport/issues/4883