### PR TITLE
Add Slack notification on failure of `teleport-helm-cron` job

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -663,6 +663,22 @@ steps:
       target: /
       strip_prefix: /go/chart
 
+  - name: Send Slack notification
+    image: plugins/slack
+    settings:
+      webhook:
+        from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+      channel: dev-teleport
+      template: |
+        *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
+        Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+        Author: <https://github.com/{{ build.author }}|{{ build.author }}>
+        <{{ build.link }}|Visit Drone build page ↗>
+        Details: The `teleport-helm-cron` job in Drone failed to publish Helm charts to S3. This is unusual and should be investigated.
+    when:
+      status: [failure]
+
 ---
 kind: pipeline
 type: kubernetes
@@ -3158,6 +3174,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 8f17b3edc11f7c493d4465bccf1e349646b3ce8234919f9af3fec974ba634800
+hmac: 1ff36cee3293e86f8fa22d4aee5da84fb0c8b36d1ebc31d2234f23242a76faea
 
 ...


### PR DESCRIPTION
There were some errors running the `teleport-helm-cron` job in Drone due to S3 permissions being modified. I've since fixed these, but decided it would be a good idea to add a Slack error notification to prompt investigation of the failure (which will fire at most once per day)