### PR TITLE
Backport: Use the absolute tsh path in kube exec plugin

### DIFF
--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/gravitational/kingpin"
@@ -223,7 +222,7 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 		//
 		// Re-generate kubeconfig contexts and try selecting this kube cluster
 		// again.
-		if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, os.Args[0]); err != nil {
+		if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
 			return trace.Wrap(err)
 		}
 		if err := kubeconfig.SelectContext(currentTeleportCluster, c.kubeCluster); err != nil {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -189,6 +189,9 @@ type CLIConf struct {
 	// command/shell execution. This also requires stdin to be an interactive
 	// terminal.
 	EnableEscapeSequences bool
+
+	// executablePath is the absolute path to the current executable.
+	executablePath string
 }
 
 func main() {
@@ -387,6 +390,11 @@ func Run(args []string) {
 		}
 	}
 
+	cf.executablePath, err = os.Executable()
+	if err != nil {
+		utils.FatalError(err)
+	}
+
 	switch command {
 	case ver.FullCommand():
 		utils.PrintVersion()
@@ -508,7 +516,7 @@ func onLogin(cf *CLIConf) {
 		// in case if nothing is specified, re-fetch kube clusters and print
 		// current status
 		case cf.Proxy == "" && cf.SiteName == "" && cf.DesiredRoles == "" && cf.IdentityFileOut == "":
-			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, os.Args[0]); err != nil {
+			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
 				utils.FatalError(err)
 			}
 			printProfiles(cf.Debug, profile, profiles)
@@ -516,7 +524,7 @@ func onLogin(cf *CLIConf) {
 		// in case if parameters match, re-fetch kube clusters and print
 		// current status
 		case host(cf.Proxy) == host(profile.ProxyURL.Host) && cf.SiteName == profile.Cluster && cf.DesiredRoles == "":
-			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, os.Args[0]); err != nil {
+			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
 				utils.FatalError(err)
 			}
 			printProfiles(cf.Debug, profile, profiles)
@@ -536,7 +544,7 @@ func onLogin(cf *CLIConf) {
 			if err := tc.SaveProfile("", true); err != nil {
 				utils.FatalError(err)
 			}
-			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, os.Args[0]); err != nil {
+			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
 				utils.FatalError(err)
 			}
 			onStatus(cf)
@@ -548,7 +556,7 @@ func onLogin(cf *CLIConf) {
 			if err := executeAccessRequest(cf); err != nil {
 				utils.FatalError(err)
 			}
-			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, os.Args[0]); err != nil {
+			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
 				utils.FatalError(err)
 			}
 			onStatus(cf)
@@ -598,7 +606,7 @@ func onLogin(cf *CLIConf) {
 
 	// If the proxy is advertising that it supports Kubernetes, update kubeconfig.
 	if tc.KubeProxyAddr != "" {
-		if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, os.Args[0]); err != nil {
+		if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
 			utils.FatalError(err)
 		}
 	}
@@ -1662,7 +1670,7 @@ func reissueWithRequests(cf *CLIConf, tc *client.TeleportClient, reqIDs ...strin
 	if err := tc.SaveProfile("", true); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, os.Args[0]); err != nil {
+	if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil


### PR DESCRIPTION
Backport of #4973 into 5.0

Using `os.Args[0]` is unreliable - it could be a relative path (e.g.
running `./build/tsh login ...`). Use `os.Executable()` instead, which
should give an absolute path (minus resolving symlinks).

Fixes https://github.com/gravitational/teleport/issues/4968