### PR TITLE
Post-release checklist for 5.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3174,6 +3174,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 721bac14bfd76f9a0f76344ace31f01c984e936d4b226f76e132e39cc51a1304
+hmac: 48bfe0ed0cb5c95f714ddc2cb483fac84586dadc09fe8e65f9d967ac458f8d2b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -320,7 +320,7 @@ clone:
 
 steps:
   - name: Check out code
-    image: golang:1.14.4
+    image: golang:1.15.5
     volumes:
       - name: tmpfs
         path: /tmpfs
@@ -351,7 +351,7 @@ steps:
         fi
 
   - name: Run docs tests (internal links only)
-    image: golang:1.14.4
+    image: golang:1.15.5
     volumes:
       - name: tmpfs
         path: /tmpfs
@@ -405,7 +405,7 @@ clone:
 
 steps:
   - name: Check out code
-    image: golang:1.14.4
+    image: golang:1.15.5
     volumes:
       - name: tmpfs
         path: /tmpfs
@@ -436,7 +436,7 @@ steps:
         fi
 
   - name: Run docs tests (external links only)
-    image: golang:1.14.4
+    image: golang:1.15.5
     failure: ignore
     volumes:
       - name: tmpfs
@@ -494,9 +494,9 @@ steps:
     environment:
       # increment these variables when a new major/minor version is released to bump the automatic builds
       # this only needs to be done on the master branch, as that's the branch that the Drone cron is configured for
-      CURRENT_VERSION_ROOT: v4.4
-      PREVIOUS_VERSION_ONE_ROOT: v4.3
-      PREVIOUS_VERSION_TWO_ROOT: v4.2
+      CURRENT_VERSION_ROOT: v5.0
+      PREVIOUS_VERSION_ONE_ROOT: v4.4
+      PREVIOUS_VERSION_TWO_ROOT: v4.3
     commands:
       - apk --update --no-cache add curl
       - mkdir -p /go/build && cd /go/build
@@ -3174,6 +3174,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 1ff36cee3293e86f8fa22d4aee5da84fb0c8b36d1ebc31d2234f23242a76faea
+hmac: 721bac14bfd76f9a0f76344ace31f01c984e936d4b226f76e132e39cc51a1304
 
 ...

--- a/docker/teleport-ent-quickstart.yml
+++ b/docker/teleport-ent-quickstart.yml
@@ -3,7 +3,7 @@ services:
   # The configure container starts, generates a config, writes it to
   # /etc/teleport/teleport.yaml and then immediately exits.
   configure:
-    image: quay.io/gravitational/teleport-ent:4.4
+    image: quay.io/gravitational/teleport-ent:5.0
     container_name: teleport-configure
     entrypoint: /bin/sh
     hostname: localhost
@@ -14,7 +14,7 @@ services:
   # This container depends on the config written by the configure container above, so it
   # sleeps for a second on startup to allow the configure container to run first.
   teleport:
-    image: quay.io/gravitational/teleport-ent:4.4
+    image: quay.io/gravitational/teleport-ent:5.0
     container_name: teleport
     entrypoint: /bin/sh
     hostname: localhost

--- a/docker/teleport-quickstart.yml
+++ b/docker/teleport-quickstart.yml
@@ -3,7 +3,7 @@ services:
   # The configure container starts, generates a config, writes it to
   # /etc/teleport/teleport.yaml and then immediately exits.
   configure:
-    image: quay.io/gravitational/teleport:4.4
+    image: quay.io/gravitational/teleport:5.0
     container_name: teleport-configure
     entrypoint: /bin/sh
     hostname: localhost
@@ -14,7 +14,7 @@ services:
   # This container depends on the config written by the configure container above, so it
   # sleeps for a second on startup to allow the configure container to run first.
   teleport:
-    image: quay.io/gravitational/teleport:4.4
+    image: quay.io/gravitational/teleport:5.0
     container_name: teleport
     entrypoint: /bin/sh
     hostname: localhost

--- a/docs/5.0.yaml
+++ b/docs/5.0.yaml
@@ -33,9 +33,8 @@ extra_javascript: []
 extra:
     version: 5.0
     teleport:
-        version: 5.0.0-rc.2
+        version: 5.0.0
         golang: 1.15
-        sha: 6b8ce3746c3a6e430e45b608f0bda41bf3d79a44b2677e31a40000a2857e857b
         plugin:
             version: 0.2.0
         latest_oss_docker_image: quay.io/gravitational/teleport:5.0

--- a/examples/chart/teleport-auto-trustedcluster/values.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/gravitational/teleport-ent
   # This tag reflects the version of Teleport to deploy
-  tag: 4.4
+  tag: 5.0
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/gravitational/teleport-ent
   # This tag reflects the version of Teleport to deploy
-  tag: 4.4
+  tag: 5.0
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -12,7 +12,7 @@ image:
   # Used if license is disabled
   communityRepository: quay.io/gravitational/teleport
   # Version of Teleport
-  tag: 4.4
+  tag: 5.0
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.


### PR DESCRIPTION
## Post-release Checklist

This checklist is to be run after cutting a release.

- [x] Create PR to update default Teleport version, hash and Docker image tags in Teleport docs
- [x] Create PR to update default Teleport image referenced in docker/teleport-quickstart.yml and docker/teleport-ent-quickstart.yml (if this is a new major/minor release)
- [x] Create PR to update default AMI versions in Makefile and AMIs.md under https://github.com/gravitational/teleport/blob/master/assets/aws - done in https://github.com/gravitational/teleport/pull/4981
- [x] Create PR to update default Teleport version in Helm charts (https://github.com/gravitational/teleport/blob/master/examples/chart)
- [x] Update `CURRENT_VERSION_ROOT` and other previous versions in Drone `teleport-docker-cron` job (for a major release)