### PR TITLE
Fix JWK kty from "rsa" to "RSA"

### DIFF
--- a/docs/5.0/application-access.md
+++ b/docs/5.0/application-access.md
@@ -279,7 +279,7 @@ _Example jwks.json_
 {
   "keys": [
     {
-      "kty": "rsa",
+      "kty": "RSA",
       "n": "xk-0VSVZY76QGqeN9TD-FJp32s8jZrpsalnRoFwlZ_JwPbbd5-_bPKcz8o2tv1eJS0Ll6ePxRCyK68Jz2UC4V4RiYaqJCRq_qVpDQMB1sQ7p9M-8qvT82FJ-Rv-W4RNe3xRmBSFDYdXaFm51Uk8OIYfv-oZ0kGptKpkNY390aJOzjHPH2MqSvhk9Xn8GwM8kEbpSllavdJCRPCeNVGJXiSCsWrOA_wsv_jqBP6g3UOA9GnI8R6HR14OxV3C184vb3NxIqxtrW0C4W6UtSbMDcKcNCgajq2l56pHO8In5GoPCrHqlo379LE5QqpXeeHj8uqcjeGdxXTuPrRq1AuBpvQ",
       "e": "AQAB",
       "alg": "RS256"

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -615,7 +615,8 @@ const (
 
 const (
 	// ApplicationTokenKeyType is the type of asymmetric key used to sign tokens.
-	ApplicationTokenKeyType = "rsa"
+	// See https://tools.ietf.org/html/rfc7518#section-6.1 for possible values.
+	ApplicationTokenKeyType = "RSA"
 	// ApplicationTokenAlgorithm is the default algorithm used to sign
 	// application access tokens.
 	ApplicationTokenAlgorithm = jose.RS256


### PR DESCRIPTION
JWKS libraries expect it to be "RSA", not "rsa", example: https://github.com/auth0/node-jwks-rsa/blob/6cfa98f8ac045b7cd1dd07fd5ac01b00d82d60cf/src/JwksClient.js#L79-L81

According to RFCs, "kty" field seems to be case-sensitive, though there cannot be names matching in a case-insensitive manner: https://tools.ietf.org/html/rfc7518#section-7.4.1