### PR TITLE
Update quickstart docs

### DIFF
--- a/docs/5.0/quickstart.md
+++ b/docs/5.0/quickstart.md
@@ -10,9 +10,9 @@ Teleport on Linux machine(s).
 
 ### Prerequisites
 
-* A Linux Machine. With Ports `3023-3025` and `3080` open.
-* A Domain Name, DNS and TLS Certs. We'll provide examples using Let'sEncrypt
-* 25 minutes to complete. 15min is waiting for DNS propagation and TLS certificates.
+* A Linux machine with ports `3023`, `3024`, `3025` and `3080` open.
+* A domain name, DNS and TLS certificates. We'll provide examples using Let's Encrypt.
+* Around 20 minutes to complete; half of this may be waiting for DNS propagation and TLS certificates.
 
 ## Step 1: Install Teleport on a Linux Host
 
@@ -22,12 +22,12 @@ Take a look at the [Teleport Installation](installation.md) page to pick the mos
 === "yum repo / AWS Linux 2"
 
     ```bash
-    yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-    yum install teleport
+    sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+    sudo yum install teleport
 
     # Optional:  Using DNF on newer distributions
-    # dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-    # dnf install teleport
+    # sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+    # sudo dnf install teleport
     ```
 
 === "ARM"
@@ -38,7 +38,7 @@ Take a look at the [Teleport Installation](installation.md) page to pick the mos
         curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
         tar -xzf teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
         cd teleport
-        ./install
+        sudo ./install
         ```
 
     === "ARM64/ARMv8 (64-bit)"
@@ -47,7 +47,7 @@ Take a look at the [Teleport Installation](installation.md) page to pick the mos
         curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
         tar -xzf teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
         cd teleport
-        ./install
+        sudo ./install
         ```
 
 === "Linux Tarball"
@@ -56,109 +56,115 @@ Take a look at the [Teleport Installation](installation.md) page to pick the mos
     curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
     tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
     cd teleport
-    ./install
+    sudo ./install
     ```
 
 ## Step 1b: Configure Teleport
 
-When setting up Teleport, we recommend running it with Teleports YAML configuration file.
+When setting up Teleport, we recommend running it with Teleport's YAML configuration file.
 
 ```bash
-# Concatenate teleport.yaml using a basic demo config.
+# Write a basic demo config to teleport.yaml.
 $ cat > teleport.yaml <<EOF
 teleport:
     data_dir: /var/lib/teleport
 auth_service:
-    enabled: "yes"
+    enabled: true
     cluster_name: "teleport-quickstart"
     listen_addr: 0.0.0.0:3025
     tokens:
     - proxy,node,app:f7adb7ccdf04037bcd2b52ec6010fd6f0caec94ba190b765
 ssh_service:
-    enabled: "yes"
+    enabled: true
     labels:
         env: staging
+app_service:
+    enabled: true
+    debug_app: true
 proxy_service:
-    enabled: "yes"
+    enabled: true
     listen_addr: 0.0.0.0:3023
     web_listen_addr: 0.0.0.0:3080
     tunnel_listen_addr: 0.0.0.0:3024
-    https_keypairs:
-        - key_file:
-        - cert_file:
-app_service:
-    enabled: "yes"
-    debug_app: true
 EOF
 
-# Move teleport.yaml to /etc/teleport.yaml
-$  mv teleport.yaml /etc
+# Write teleport.yaml to /etc/teleport.yaml (Teleport's default config location)
+$ sudo mv teleport.yaml /etc
 ```
 
-## Step 1c: Configure Domain Name & Obtain TLS Certs using Let's Encrypt
+## Step 1c: Configure Domain Name and obtain TLS certificates using Let's Encrypt
 
-Teleport requires a secure public endpoint for the Teleport UI and for end users to connect to. A domain name and TLS are required for Teleport. We'll use Let's Encrypt to obtain a free TLS certificate.
+Teleport requires a secure public endpoint for the Teleport UI and for end users to connect to.
+A domain name and TLS certificates are also required. We'll use Let's Encrypt to obtain a free TLS certificate.
 
 DNS Setup:<br>
-For this setup, we'll simply use a `A` or `CNAME` record pointing to the IP/FQDN of the machine with Teleport installed.
+For this setup, we'll simply use an `A` or `CNAME` record pointing to the IP/FQDN of the machine with Teleport installed.
 
 TLS Setup:<br>
-If you already have TLS certs you can use those certificates, or if using a new domain
-we recommend using Certbot; which is free and simple to setup. Follow [certbot instructions](https://certbot.eff.org/) for how to obtain a certificate for your distro.
+If you already have TLS certificates available you can use those. If using a new domain we recommend using `certbot`, which is free and
+simple to set up. Follow [certbot instructions](https://certbot.eff.org/) for how to obtain a certificate for your distro.
 
 !!! tip "Using Certbot to obtain Wildcard Certs"
 
-    Let's Encrypt provides free wildcard certificates. If using [certbot](https://certbot.eff.org/)
-    with DNS challenge the below script will make setup easy. Replace with your email
-    _foo@example.com_ and URL for Teleport _teleport.example.com_
-
+    Let's Encrypt provides free wildcard certificates. Below is an example command to
+    use [certbot](https://certbot.eff.org/) with DNS challenge.
+    Replace `foo@example.com` with your email address.
+    Replace `teleport.example.com` with the domain name you want to use to access Teleport.
 
       ```sh
-      certbot certonly --manual \
+      certbot certonly \
+        --manual \
         --preferred-challenges=dns \
-        --email foo@example.com \
-        --server https://acme-v02.api.letsencrypt.org/directory \
         --agree-tos \
         --manual-public-ip-logging-ok \
+        --email foo@example.com \
         -d "teleport.example.com, *.teleport.example.com"
       ```
 
-**Update `teleport.yaml`<br>**
-Once you've obtain the certificates from LetsEncrypt.  The below command will add
-update Teleport `public_addr` and update the location of the LetsEncrypt key pairs.
+**Update `teleport.yaml`**<br>
+Once you've obtained certificates from Let's Encrypt, the below commands will update Teleport's
+config file to use your newly configured domain and TLS certificates.
 
-Replace `teleport.example.com` with the location of your proxy.
+Replace `teleport.example.com` with the domain name you configured above.
 
 ```bash
 # Replace `teleport.example.com` with your domain name.
 export TELEPORT_PUBLIC_DNS_NAME="teleport.example.com"
-cat >> /etc/teleport.yaml <<EOL
+cat >> /etc/teleport.yaml <<EOF
   public_addr: $TELEPORT_PUBLIC_DNS_NAME:3080
   https_keypairs:
     - key_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/privkey.pem
-    - cert_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/fullchain.pem
-EOL
+      cert_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/fullchain.pem
+EOF
 ```
 
-Visit: `https://teleport.example.com:3080/`
+Once you've updated the config file, you should restart Teleport to pick up the changes:
+
+`sudo systemctl restart teleport`
+
+You can access Teleport's web UI on port 3080.
+Replace `teleport.example.com` with your domain: `https://teleport.example.com:3080/`
 
 !!! success
 
-    Teleport is now up and running
+    Teleport is now up and running.
 
 
-## Step 2: Create User & Setup 2FA
+## Step 2: Create a Teleport user and set up 2-factor authentication
 
-Create a new user `teleport-admin`, with the Principles `root, ubuntu, ec2-user`
+In this example, we'll create a new Teleport user `teleport-admin` which is allowed to log into
+SSH hosts as any of the principals `root`, `ubuntu` or `ec2-user`.
 
 ```bash
-# tctl is an administrative tool that can configure Teleport auth service.
-tctl users add teleport-admin root,ubuntu, ec2-user
+# tctl is an administrative tool that is used to configure Teleport's auth service.
+sudo tctl users add teleport-admin root,ubuntu,ec2-user
 ```
 
-Teleport will always enforces Two-Factor Authentication and support OTP and Hardware Tokens (U2F).The quick start has been setup with OTP. For setup you'll need an OTP app.
+Teleport will always enforce the use of 2-factor authentication by default. It supports one-time
+passwords (OTP) and hardware tokens (U2F). This quick start will use OTP - you'll need an OTP-compatible
+app which can scan a QR code.
 
-A selection of Two-Factor Authentication apps are.
+Here's a selection of compatible Two-Factor authentication apps:
 
  - [Authy](https://authy.com/download/)
  - [Google Authenticator](https://www.google.com/landing/2step/)
@@ -168,20 +174,20 @@ A selection of Two-Factor Authentication apps are.
 
 !!! info "OS User Mappings"
 
-    The OS user `root, ubuntu, ec2-user` must exist! On Linux, if it
-    does not already exist, create it with `adduser teleport`. If you do not have
-    the permission to create new users on the Linux Host, run `tctl users add teleport
-    <your-username> ` to explicitly map ` teleport` to an existing OS user. If you
-    do not map to a real OS user you will get authentication errors later on in
+    The OS users that you specify (`root`, `ubuntu` and `ec2-user` in our examples) must exist!
+    On Linux, if a user does not already exist, you can create it with `adduser <login>`. If you
+    do not have the permission to create new users on the Linux host, run `tctl users add teleport
+    $(whoami)` to explicitly allow Teleport to authenticate as the user that you are currently logged
+    in as. If you do not map to an existing OS user,  you will get authentication errors later on in
     this tutorial!
 
 ![Teleport UI Dashboard](img/quickstart/teleport-nodes.png)
 
-## Step 2a: Install Teleport Locally
+## Step 2a: Install a Teleport client locally
 
 === "Mac"
 
-    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the Installer.
+    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the installer.
 
 === "Mac - Homebrew"
 
@@ -196,30 +202,31 @@ A selection of Two-Factor Authentication apps are.
 
     ```bash
     curl -O teleport-v{{ teleport.version }}-windows-amd64-bin.zip https://get.gravitational.com/teleport-v{{ teleport.version }}-windows-amd64-bin.zip
-    # Move `tsh` to your %PATH%
+    # Unzip the archive and move `tsh.exe` to your %PATH%
     ```
 
 === "Linux"
 
-    For more options please see our [installation page](installation.md).
+    For more options (including RPM/DEB packages and downloads for i386/ARM/ARM64) please see our [installation page](installation.md).
 
     ```bash
     curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
     tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
     cd teleport
-    ./install
+    sudo ./install
     ```
 
-## Step 3: Login Using `tsh`
+## Step 3: Log in using `tsh`
 
-`tsh` is our client tool. It helps you login, obtains credentials and list servers,applications and Kubernetes clusters.
+`tsh` is our client tool. It helps you log into Teleport clusters and obtain short-lived credentials. It can also be used to
+list servers, applications and Kubernetes clusters registered with Teleport.
 
 Prior to launch you must authenticate.
 
 === "Local Cluster - tsh"
 
     ```
-    # Replace teleport.example.com:3080 with your cluster  address.
+    # Replace teleport.example.com:3080 with your Teleport cluster's public address as configured above.
     tsh login --proxy=teleport.example.com:3080 --user=teleport-admin
     ```
 
@@ -238,42 +245,42 @@ Prior to launch you must authenticate.
 === "tsh ls & ssh"
 
     ```
-    # list all servers connected to Teleport
+    # list all SSH servers connected to Teleport
     tsh ls
 
-    # ssh as 'root' into node named `node-name`. replace with values from
+    # ssh into `node-name` as `root`
     tsh ssh root@node-name
     ```
 
 ### Add a Node to the Cluster
 
-When you setup Teleport earlier we setup a strong static token for nodes, apps
-and `tokens`. We've used a static token to make setup easier but you can also
-obtain dyanmic short lived tokens using `tctl`
+When you set up Teleport earlier, we configured a strong static token for nodes and apps.
+We've used a static token to make set up easier for this example, but you can also
+obtain short-lived dynamic tokens using `tctl` as shown below.
 
 === "Example Static Token"
 
     ```yaml
     #...
     #    tokens:
-    #    - proxy,node,app:f7adb7ccdf04037bcd2b52ec6010fd6f0caec94ba190b765
+    #    - node:f7adb7ccdf04037bcd2b52ec6010fd6f0caec94ba190b765
     #...
     ```
 
 === "Example Dynamic Token"
 
     ```bash
-    tctl tokens add --type=node
+    sudo tctl tokens add --type=node
     ```
 
 Armed with these details, we'll bootstrap a new host using
 
 === "teleport start"
 
-    Install Teleport on the target node, then start using.
+    Install Teleport on the target node, then start it using a command as shown below:
 
     ```bash
-    teleport start \
+    sudo teleport start \
     --roles=node \
     --auth-server=https://teleport.example.com:3080 \
     --token=f7adb7ccdf04037bcd2b52ec6010fd6f0caec94ba190b765 \
@@ -282,7 +289,7 @@ Armed with these details, we'll bootstrap a new host using
 
 === "cloud-config"
 
-    Replace `auth_servers` with the IP and port of your Teleport Cluster
+    Replace `auth_servers` with the hostname and port of your Teleport cluster as configured above.
 
     ```ini
     #cloud-config
@@ -297,51 +304,52 @@ Armed with these details, we'll bootstrap a new host using
                 auth_servers:
                     - "https://teleport.example.com:3080"
             auth_service:
-                enabled: "false"
-            ssh_service:
-                enabled: "true"
-                labels:
-                    host: test-machine
+                enabled: false
             proxy_service:
-                enabled: "false"
+                enabled: false
+            ssh_service:
+                enabled: true
+                labels:
+                    env: quickstart
 
     runcmd:
-    - 'mkdir -p /run/teleport'
-    - 'cd /run/teleport && curl -O https://get.gravitational.com/teleport_{{ teleport.version }}_amd64.deb'
-    - 'dpkg -i /run/teleport/teleport_5.0.0-{{ teleport.version }}_amd64.deb'
+    - 'mkdir -p /tmp/teleport'
+    - 'cd /tmp/teleport && curl -O https://get.gravitational.com/teleport_{{ teleport.version }}_amd64.deb'
+    - 'dpkg -i /tmp/teleport/teleport_5.0.0-{{ teleport.version }}_amd64.deb'
     - 'systemctl enable teleport.service'
     - 'systemctl start teleport.service'
     ```
 
-### Add an Application to the Cluster
+### Add an Application to your Teleport cluster
 
-When you setup Teleport earlier we setup a strong static token for nodes, **apps**
-and `tokens`. We've used a static token to make setup easier but you can also
-obtain dyanmic short lived tokens using `tctl`
+When you set up Teleport earlier, we configured a strong static token for nodes and apps.
+We've used a static token to make set up easier for this example, but you can also
+obtain short-lived dynamic tokens using `tctl` as shown below.
 
 === "Example Static Token"
 
     ```yaml
     #...
     #    tokens:
-    #    - proxy,node,app:f7adb7ccdf04037bcd2b52ec6010fd6f0caec94ba190b765
+    #    - app:f7adb7ccdf04037bcd2b52ec6010fd6f0caec94ba190b765
     #...
     ```
 
 === "Example Dynamic Token"
 
     ```bash
-    tctl tokens add --type=app
+    sudo tctl tokens add --type=app
     ```
 
 Armed with these details, we'll bootstrap a new host using
 
 === "teleport start"
 
-    Install Teleport on a target node, then start using. Review an update `auth-server, app-name, app-uri` before running this comment.
+    Install Teleport on the target node, then start it using a command as shown below.
+    Review and update `auth-server`, `app-name` and `app-uri` before running this command.
 
     ```bash
-    teleport start \
+    sudo teleport start \
     --roles=app \
     --token=f7adb7ccdf04037bcd2b52ec6010fd6f0caec94ba190b765 \
     --auth-server=teleport.example.com:3080 \
@@ -353,8 +361,8 @@ Armed with these details, we'll bootstrap a new host using
 
 Congratulations! You've completed the Teleport Quickstart.
 
-In this guide you've learned how to install Teleport on a single-node and seen a
-few of the most practical features in action. When you're ready to learn how to set
+In this guide, you've learned how to install Teleport on a single node and seen a
+few of the most useful features in action. When you're ready to learn how to set
 up Teleport for your team, we recommend that you read our [Admin Guide](admin-guide.md)
 to get all the important details. This guide will lay out everything you need to
 safely run Teleport in production, including SSL certificates, security considerations,


### PR DESCRIPTION
Updates #5000 

The docs are still pretty fragmented between the use of `systemd` and not, but this should address the most fundamental concerns from the linked issue as a starting point.

- [x] Certs in teleport proxy service section are not updated so /etc/teleport.yaml is not valid
- [x] Does not show starting Teleport with sudo or root or using systemd.
- [x] Teleport is installed at /usr/local/bin that is not in root's path (or other executables like tctl)