### PR TITLE
Always set expiry on server resource in heartbeats

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -220,7 +220,7 @@ func (t *TLSServer) GetServerInfo() (services.Server, error) {
 		name += "-proxy_service"
 	}
 
-	return &services.ServerV2{
+	srv := &services.ServerV2{
 		Kind:    services.KindKubeService,
 		Version: services.V2,
 		Metadata: services.Metadata{
@@ -232,5 +232,7 @@ func (t *TLSServer) GetServerInfo() (services.Server, error) {
 			Version:            teleport.Version,
 			KubernetesClusters: t.fwd.kubeClusters(),
 		},
-	}, nil
+	}
+	srv.SetTTL(t.Clock, defaults.ServerAnnounceTTL)
+	return srv, nil
 }

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -345,6 +345,9 @@ func LabelsAsString(static map[string]string, dynamic map[string]CommandLabelV2)
 
 // CheckAndSetDefaults checks and set default values for any missing fields.
 func (s *ServerV2) CheckAndSetDefaults() error {
+	// TODO(awly): default s.Metadata.Expiry if not set (use
+	// defaults.ServerAnnounceTTL).
+
 	err := s.Metadata.CheckAndSetDefaults()
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
All servers (ssh/kube/app/db) should get cleaned up some time after
deletion. If a server implements `GetServerInfo` without populating
`Expiry`, default expiry to `ServerTTL` in the heartbeat code.

If we don't clean up deleted server objects, things like kube routing
will try to reach obsolete endpoints and users will forever see deleted
kube clusters in `tsh`.