### PR TITLE
Added --no-use-local-ssh-agent and TELEPORT_USE_LOCAL_SSH_AGENT to CLI docs

### DIFF
--- a/docs/4.4/cli-docs.md
+++ b/docs/4.4/cli-docs.md
@@ -354,6 +354,7 @@ interval via `--ttl` flag (capped by the server-side configuration).
 | `--browser` | none | `none` | Set to 'none' to suppress opening system default browser for `tsh login` commands
 | `--request-roles`  | none |  | Request one or more extra roles
 | `--request-reason`  | none |  | Reason for requesting additional roles
+| `--no-use-local-ssh-agent` | | | Do not load generated SSH certificates into the local ssh-agent (specified via `$SSH_AUTH_SOCK`). Useful when using `gpg-agent` or Yubikeys. You can also set the `TELEPORT_USE_LOCAL_SSH_AGENT` environment variable to `false` (default `true`)
 
 ### [Global Flags](#tsh-global-flags)
 

--- a/docs/5.0/cli-docs.md
+++ b/docs/5.0/cli-docs.md
@@ -383,6 +383,7 @@ interval via `--ttl` flag (capped by the server-side configuration).
 | `--browser` | none | `none` | Set to 'none' to suppress opening system default browser for `tsh login` commands
 | `--request-roles`  | none |  | Request one or more extra roles
 | `--request-reason`  | none |  | Reason for requesting additional roles
+| `--no-use-local-ssh-agent` | | | Do not load generated SSH certificates into the local ssh-agent (specified via `$SSH_AUTH_SOCK`). Useful when using `gpg-agent` or Yubikeys. You can also set the `TELEPORT_USE_LOCAL_SSH_AGENT` environment variable to `false` (default `true`)
 
 ### [Global Flags](#tsh-global-flags)
 


### PR DESCRIPTION
These were documented on `tsh ssh` but not `tsh login` (where they're arguably more useful)