### PR TITLE
Graceful stops in Docker

### DIFF
--- a/build.assets/charts/Dockerfile
+++ b/build.assets/charts/Dockerfile
@@ -19,5 +19,8 @@ COPY teleport /usr/local/bin/teleport
 COPY tctl /usr/local/bin/tctl
 COPY tsh /usr/local/bin/tsh
 
+# Instruct docker to send SIGQUIT instead of SIGTERM on `docker stop`
+STOPSIGNAL SIGQUIT
+
 # By setting this entry point, we expose make target as command.
 ENTRYPOINT ["/usr/bin/dumb-init", "teleport", "start", "-c", "/etc/teleport/teleport.yaml"]


### PR DESCRIPTION
This commit changes the default behaviour when stopping a Docker
container from fast shutdowns to graceful ones. It is a potentially
breaking change for some users and warrants a discussion.

The background for this is that Kubernetes doesn't currently allow
configuring the termination signal it sends to pods. For more on
that, see https://github.com/kubernetes/kubernetes/issues/30051

While this change increases the time it takes for a container to stop,
Docker still sends an additional `SIGKILL` ten seconds after triggering
the termination. This means that the default behaviour still ensures
that the container is terminated _relatively_ quickly.

There are potential workarounds if we decide against changing the
Dockerfile. We could have a seperate image, use `PreStop` hooks, or or
work around the issue in Teleport itself. However, this change is by far
the simplest.