### PR TITLE
Always set proxy public_addr port to 443 when ingress is enabled

### DIFF
--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -1,6 +1,6 @@
 name: teleport
 apiVersion: v2
-version: 0.0.7
+version: 0.0.8
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -70,11 +70,7 @@ data:
     proxy_service:
       enabled: {{ .Values.config.teleport.proxy_service.enabled }}
 {{- if .Values.ingress.enabled }}
-      {{- if .Values.ingress.tls }}
       public_addr: {{ .Values.config.public_address }}:443
-      {{- else }}
-      public_addr: {{ .Values.config.public_address }}:80
-      {{- end -}}
 {{- else }}
       public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyweb.port }}
 {{- end }}


### PR DESCRIPTION
When `ingress` is set to `true` in the Helm chart, we should always just override the port to 443 to allow people to manage their TLS configs externally (with something like `cert-manager`). Before we were conditionally setting this to either 443 or 80 depending on whether `ingress.tls` was set, but given that running Teleport in the open on port 80 would be a terrible idea and I don't know of anyone doing it, there's little point in us supporting this use case.

Fixes #5013