### PR TITLE
Don't log error on tunnel node after its serving agent is stopped

### DIFF
--- a/lib/teleagent/agent.go
+++ b/lib/teleagent/agent.go
@@ -88,7 +88,7 @@ func (a *AgentServer) Serve() error {
 				if strings.Contains(neterr.Error(), "use of closed network connection") {
 					return nil
 				}
-				log.Errorf("got permanent error: %v", err)
+				log.WithError(err).Error("Got permanent error.")
 				return err
 			}
 			if tempDelay == 0 {
@@ -99,7 +99,7 @@ func (a *AgentServer) Serve() error {
 			if max := 1 * time.Second; tempDelay > max {
 				tempDelay = max
 			}
-			log.Errorf("got temp error: %v, will sleep %v", err, tempDelay)
+			log.WithError(err).Errorf("Got temporary error (will sleep %v).", tempDelay)
 			time.Sleep(tempDelay)
 			continue
 		}
@@ -108,7 +108,7 @@ func (a *AgentServer) Serve() error {
 		// get an agent instance for serving this conn
 		instance, err := a.getAgent()
 		if err != nil {
-			log.Errorf("Failed to get agent: %v", err)
+			log.WithError(err).Error("Failed to get agent.")
 			return trace.Wrap(err)
 		}
 

--- a/lib/teleagent/agent.go
+++ b/lib/teleagent/agent.go
@@ -89,7 +89,7 @@ func (a *AgentServer) Serve() error {
 					return nil
 				}
 				log.WithError(err).Error("Got permanent error.")
-				return err
+				return trace.Wrap(err)
 			}
 			if tempDelay == 0 {
 				tempDelay = 5 * time.Millisecond

--- a/lib/teleagent/agent.go
+++ b/lib/teleagent/agent.go
@@ -85,9 +85,10 @@ func (a *AgentServer) Serve() error {
 				return trace.Wrap(err, "unknown error")
 			}
 			if !neterr.Temporary() {
-				if !strings.Contains(neterr.Error(), "use of closed network connection") {
-					log.Errorf("got permanent error: %v", err)
+				if strings.Contains(neterr.Error(), "use of closed network connection") {
+					return nil
 				}
+				log.Errorf("got permanent error: %v", err)
 				return err
 			}
 			if tempDelay == 0 {


### PR DESCRIPTION
Fixes #4252.