### PR TITLE
Backport: set TTL on kube_service resources

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -220,7 +220,7 @@ func (t *TLSServer) GetServerInfo() (services.Server, error) {
 		name += "-proxy_service"
 	}
 
-	return &services.ServerV2{
+	srv := &services.ServerV2{
 		Kind:    services.KindKubeService,
 		Version: services.V2,
 		Metadata: services.Metadata{
@@ -232,5 +232,7 @@ func (t *TLSServer) GetServerInfo() (services.Server, error) {
 			Version:            teleport.Version,
 			KubernetesClusters: t.fwd.kubeClusters(),
 		},
-	}, nil
+	}
+	srv.SetTTL(t.Clock, defaults.ServerAnnounceTTL)
+	return srv, nil
 }

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -345,6 +345,9 @@ func LabelsAsString(static map[string]string, dynamic map[string]CommandLabelV2)
 
 // CheckAndSetDefaults checks and set default values for any missing fields.
 func (s *ServerV2) CheckAndSetDefaults() error {
+	// TODO(awly): default s.Metadata.Expiry if not set (use
+	// defaults.ServerAnnounceTTL).
+
 	err := s.Metadata.CheckAndSetDefaults()
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Bacport of #5008 into 5.0.

Without this, deleted kube_services linger in the backend and show up as
obsolete kubernetes clusters in tsh.

Ideally, this TTL logic should be enforced centrally, but I'd like to
fix the bug first, and do a larger refactoring later.