### PR TITLE
Remove threads flag from soak test commands

### DIFF
--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -514,8 +514,8 @@ Using `tsh bench` tool, perform the soak tests and benchmark tests on the follow
 Run 4hour soak test with a mix of interactive/non-interactive sessions:
 
 ```
-tsh bench --duration=4h --threads=10 user@teleport-monster-6757d7b487-x226b ls
-tsh bench -i --duration=4h --threads=10 user@teleport-monster-6757d7b487-x226b ps uax
+tsh bench --duration=4h user@teleport-monster-6757d7b487-x226b ls
+tsh bench -i --duration=4h user@teleport-monster-6757d7b487-x226b ps uax
 ```
 
 Observe prometheus metrics for goroutines, open files, RAM, CPU, Timers and make sure there are no leaks


### PR DESCRIPTION
We no longer have `--threads` flag as an option to run with `tsh bench`. 