### PR TITLE
Use strict teleport.yaml validation in warning mode

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -19,6 +19,7 @@ package config
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -256,6 +257,8 @@ func ReadConfig(reader io.Reader) (*FileConfig, error) {
 		}
 		return &fc, nil
 	}
+	// Remove all newlines in the YAML error, to avoid escaping when printing.
+	strictUnmarshalErr = errors.New(strings.Replace(strictUnmarshalErr.Error(), "\n", "", -1))
 	// DELETE IN 7.0: during 6.0, users should notice any issues that passed
 	// old validation but not the new strict one. With 7.0, we should always
 	// enforce the strict validation.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -233,8 +234,33 @@ func ReadConfig(reader io.Reader) (*FileConfig, error) {
 		return nil, trace.Wrap(err, "failed reading Teleport configuration")
 	}
 	var fc FileConfig
+
+	// New validation in 6.0:
+	//
+	// Try strict unmarshal first (fails if any yaml entry doesn't map to a
+	// FileConfig field).
+	//
+	// If strict unmarshal failed, there may be some innocent mis-placed config
+	// fields. Fall back to the old validation first.
+	//
+	// If the old validation fails too, then we'll report the above error
+	// because the config is definitely invalid.
+	//
+	// If the old validation succeeds, we'll log the above error, but won't
+	// enforce it yet to let users fix the problem
+	strictUnmarshalErr := yaml.UnmarshalStrict(bytes, &fc)
+	if strictUnmarshalErr == nil {
+		// don't start Teleport with invalid ciphers, kex algorithms, or mac algorithms.
+		if err = fc.CheckAndSetDefaults(); err != nil {
+			return nil, trace.BadParameter("failed to parse Teleport configuration: %v", err)
+		}
+		return &fc, nil
+	}
+	// DELETE IN 7.0: during 6.0, users should notice any issues that passed
+	// old validation but not the new strict one. With 7.0, we should always
+	// enforce the strict validation.
 	if err = yaml.Unmarshal(bytes, &fc); err != nil {
-		return nil, trace.BadParameter("failed to parse Teleport configuration: %v", err)
+		return nil, trace.BadParameter("failed to parse Teleport configuration: %v", strictUnmarshalErr)
 	}
 	// don't start Teleport with invalid ciphers, kex algorithms, or mac algorithms.
 	err = fc.CheckAndSetDefaults()
@@ -265,11 +291,20 @@ func ReadConfig(reader io.Reader) (*FileConfig, error) {
 	// validate configuration keys:
 	var tmp YAMLMap
 	if err = yaml.Unmarshal(bytes, &tmp); err != nil {
-		return nil, trace.BadParameter("error parsing YAML config")
+		return nil, trace.BadParameter("error parsing YAML config: %v", err)
 	}
 	if err = validateKeys(tmp); err != nil {
-		return nil, trace.Wrap(err)
+		// Both old an new validations failed. Report the new strict validation
+		// error.
+		return nil, trace.Wrap(strictUnmarshalErr)
 	}
+	// New strict validation failed but old one succeeded. There's something
+	// wrong with the config, but don't prevent it from starting up.
+	logrus.Errorf("Teleport configuration is invalid: %v.", strictUnmarshalErr)
+	logrus.Error("This error will be enforced in the next Teleport release.")
+	// Also add a short but noticeable sleep, to nudge users to pay attention
+	// to logs.
+	time.Sleep(5 * time.Second)
 	return &fc, nil
 }
 


### PR DESCRIPTION
Strict YAML validation catches the cases where a valid config key is
placed in the wrong location in the config. These errors were not
caught by the old validation.
The failure is always reported, but only fails startup when both old and
new validations fail. This will let the users fix their configs during
6.0 release and we will start enforcing it in 7.0.

Example:
```yaml
auth_service:
  data_dir: "/foo" # this field must live under "teleport:", not "auth_service:"
```

Output:
```
$ teleport start -c teleport-invalid.yaml
ERRO             "Teleport configuration is invalid: yaml: unmarshal errors:\n  line 6: field data_dir not found in type config.Auth." config/fileconf.go:303
ERRO             This error will be enforced in the next Teleport release. config/fileconf.go:304
[AUTH]         Auth service 5.0.0-dev:v4.4.0-alpha.1-262-g307040886-dirty is starting on 0.0.0.0:3025.
... continues startup ...
```

Updates https://github.com/gravitational/teleport/issues/5056