### PR TITLE
Removes -ti flag for docker builds of docs

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -173,7 +173,7 @@ lint: buildbox
 #
 .PHONY:docs
 docs: docsbox
-	docker run --rm=true -ti $(NOROOT) \
+	docker run --rm=true $(NOROOT) \
 		-v $$(pwd)/..:$(DOCSDIR) \
 		-v /tmp:/tmp \
 		-w $(DOCSDIR) \


### PR DESCRIPTION
Quick fix to remove `-ti` requirement for docker builds of docs that prevents running in CI systems