### PR TITLE
Fix a flaky test in lib/srv/app

### DIFF
--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -289,8 +290,14 @@ func (s *Suite) TestHandleConnection(c *check.C) {
 		},
 	}
 
+	var wg sync.WaitGroup
+	wg.Add(1)
+
 	// Handle the connection in another goroutine.
-	go s.appServer.HandleConnection(pw)
+	go func() {
+		s.appServer.HandleConnection(pw)
+		wg.Done()
+	}()
 
 	// Issue request.
 	resp, err := httpClient.Get("https://" + teleport.APIDomain)
@@ -307,6 +314,10 @@ func (s *Suite) TestHandleConnection(c *check.C) {
 	// error here.
 	err = s.appServer.Close()
 	c.Assert(err, check.NotNil)
+
+	// Wait for the application server to actually stop serving before
+	// closing the test. This will make sure the server removes the listeners
+	wg.Wait()
 }
 
 // TestAuthorize verifies that only authorized requests are handled.


### PR DESCRIPTION
This PR fixes the following failure:
```
----------------------------------------------------------------------
FAIL: server_test.go:207: Suite.TearDownTest

server_test.go:212:
    c.Assert(err, check.IsNil)
... value *trace.TraceErr = 
ERROR REPORT:
Original Error: trace.aggregate context canceled
Stack Trace:
	/go/src/github.com/gravitational/teleport/lib/srv/app/server.go:293 github.com/gravitational/teleport/lib/srv/app.(*Server).Close
	/go/src/github.com/gravitational/teleport/lib/srv/app/server_test.go:211 github.com/gravitational/teleport/lib/srv/app.(*Suite).TearDownTest
	/opt/go/src/reflect/value.go:479 reflect.Value.call
	/opt/go/src/reflect/value.go:337 reflect.Value.Call
	/go/src/github.com/gravitational/teleport/vendor/gopkg.in/check.v1/check.go:731 gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1
	/go/src/github.com/gravitational/teleport/vendor/gopkg.in/check.v1/check.go:676 gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1
	/opt/go/src/runtime/asm_amd64.s:1375 runtime.goexit
User Message: 
 ("context canceled")


----------------------------------------------------------------------
PANIC: server_test.go:271: Suite.TestHandleConnection

... Panic: Fixture has panicked (see related PANIC)
OOPS: 2 passed, 1 FAILED, 6 MISSED
--- FAIL: TestApp (4.03s)
FAIL
coverage: 64.5% of statements
FAIL	github.com/gravitational/teleport/lib/srv/app	4.198s
```

Updates https://github.com/gravitational/teleport/issues/4653