### PR TITLE
Propagate log level from command line

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -249,6 +249,12 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 	}
 	cfg.Log = logger
 
+	// Apply logging configuration for the global logger instance
+	// DELETE this when global logger instance is no longer in use.
+	//
+	// Logging configuration has already been validated above
+	_ = applyLogConfig(fc.Logger, log.StandardLogger())
+
 	// apply cache policy for node and proxy
 	cachePolicy, err := fc.CachePolicy.Parse()
 	if err != nil {
@@ -373,7 +379,7 @@ func applyLogConfig(loggerConfig Log, logger *log.Logger) error {
 	case "warn", "warning":
 		logger.SetLevel(log.WarnLevel)
 	default:
-		return trace.BadParameter("unsupported logger severity: '%v'", loggerConfig.Severity)
+		return trace.BadParameter("unsupported logger severity: %q", loggerConfig.Severity)
 	}
 	return nil
 }
@@ -1018,6 +1024,7 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 		// logger severity in file configuration.
 		if fileConf == nil {
 			log.SetLevel(log.DebugLevel)
+			cfg.Log.SetLevel(log.DebugLevel)
 		} else {
 			fileConf.Logger.Severity = teleport.DebugLevel
 		}

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -114,6 +114,8 @@ type Logger interface {
 	// GetLevel specifies the level at which this logger
 	// value is logging
 	GetLevel() log.Level
+	// SetLevel sets the logger's level to the specified value
+	SetLevel(level log.Level)
 }
 
 // FatalError is for CLI front-ends: it detects gravitational/trace debugging
@@ -256,6 +258,11 @@ type LeveledOutputFunc func(args ...interface{})
 // GetLevel returns the level of the underlying logger
 func (r *logWrapper) GetLevel() logrus.Level {
 	return r.Entry.Logger.GetLevel()
+}
+
+// SetLevel sets the logging level to the given value
+func (r *logWrapper) SetLevel(level logrus.Level) {
+	r.Entry.Logger.SetLevel(level)
 }
 
 // logWrapper wraps a log entry.


### PR DESCRIPTION
This PR fixes a regression I introduced in https://github.com/gravitational/teleport/pull/4849/files#diff-054e31280a78f4aea4759cd740f8d8bcecf563679d7fe6b79991fdb944e8c611R600-R603 when I did not notice that log level was still using the global logger instance.
