### PR TITLE
Update k8s access and migration docs role example to remove extra brackets

### DIFF
--- a/docs/5.0/kubernetes-5.0-migration.md
+++ b/docs/5.0/kubernetes-5.0-migration.md
@@ -353,8 +353,8 @@ spec:
   allow:
     logins: ['{% raw %}{{internal.logins}}{% endraw %}']
     # Define the Kubernetes users and groups mapped to users with this role.
-    kubernetes_users: ["{% raw %}{{internal.kubernetes_users}}{% endraw %}"]]
-    kubernetes_groups: ["some-group", "{% raw %}{{internal.kubernetes_groups}}{% endraw %}"]]
+    kubernetes_users: ["{% raw %}{{internal.kubernetes_users}}{% endraw %}"]
+    kubernetes_groups: ["some-group", "{% raw %}{{internal.kubernetes_groups}}{% endraw %}"]
 
     # List of kubernetes labels a user will be allowed to connect to:
     kubernetes_labels:

--- a/docs/5.0/kubernetes-access.md
+++ b/docs/5.0/kubernetes-access.md
@@ -362,7 +362,7 @@ spec:
     # kubernetes groups the users of this role will be assigned to.
     # note that you can refer to a SAML/OIDC trait via the "external" property bag,
     # this allows you to specify Kubernetes group membership in an identity manager:
-    kubernetes_groups: ["system:masters", "{% raw %}{{external.trait_name}}{% endraw %}"]]
+    kubernetes_groups: ["system:masters", "{% raw %}{{external.trait_name}}{% endraw %}"]
 ```
 
 To add `kubernetes_groups` setting to an existing Teleport role, you can either


### PR DESCRIPTION
The role example has extra square brackets that causes it not to work if used.