### PR TITLE
Jay/docs/ansible

### DIFF
--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1311,6 +1311,7 @@ The configuration for openssh is as follows:
     ```
 
 !!! tip "NOTE"
+
     Additional Teleport and OpenSSH intergration information can be located [HERE](https://goteleport.com/teleport/docs/openssh-teleport/#using-openssh-client)
 
 

--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1286,7 +1286,7 @@ The configuration for openssh is as follows:
         ```
     * Add the output on Ansible node `/.ssh/known_hosts` by modifying the node section to match the nodes you are reaching (note: wildcards are accepted).
     ```bash
-    @cert-authority <NODE(S)> ssh-rsa AAA...REDACTED...TD9 logins=-teleport-nologin-f0d...REDACTED...fb1&type=host
+    @cert-authority <hostname.example.com|hostname|10.0.0.0> ssh-rsa AAA...REDACTED...TD9 logins=-teleport-nologin-f0d...REDACTED...fb1&type=host
     ```
     * Modify ssh config file to include the proxy node and the desired Teleport nodes with `ProxyCommand` or `ProxyJump` parameters configured
 

--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1279,7 +1279,7 @@ There are two recommended scenarios:
 
 The configuration for openssh is as follows:
 
-1. Add hosts to know hosts in Ansible node
+1. Add hosts to known hosts in Ansible node
     * From Teleport Auth Node:
         ```bash
         $ tsh auth export --type=host

--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1312,7 +1312,7 @@ The configuration for openssh is as follows:
 
 !!! tip "NOTE"
 
-    Additional Teleport and OpenSSH integration information can be located [HERE](https://goteleport.com/teleport/docs/openssh-teleport/#using-openssh-client)
+    Additional Teleport and OpenSSH integration information can be located [here](https://goteleport.com/teleport/docs/openssh-teleport/#using-openssh-client)
 
 
 ## Kubernetes Integration

--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1302,7 +1302,7 @@ The configuration for openssh is as follows:
         scp_if_ssh = True
         ```
 
-1. Configure your OpenSSH to connect to Teleport proxy and use `ssh-agent` socket:
+1. Configure your OpenSSH client to connect to Teleport proxy and use `ssh-agent` socket:
     ```bash
     $ eval `ssh-agent`
     $ tsh --proxy=root.example.com login

--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1277,7 +1277,7 @@ There are two recommended scenarios:
 
 2. Ansible connects to Teleport Node using the Teleport Proxy as a jumphost. This method uses Teleport user credentials over port 3022
 
-The configuration for openssh is as follows:
+The configuration for OpenSSH is as follows:
 
 1. Add hosts to known hosts in Ansible node
     * From Teleport Auth Node:

--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1312,7 +1312,7 @@ The configuration for openssh is as follows:
 
 !!! tip "NOTE"
 
-    Additional Teleport and OpenSSH intergration information can be located [HERE](https://goteleport.com/teleport/docs/openssh-teleport/#using-openssh-client)
+    Additional Teleport and OpenSSH integration information can be located [HERE](https://goteleport.com/teleport/docs/openssh-teleport/#using-openssh-client)
 
 
 ## Kubernetes Integration

--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1284,7 +1284,7 @@ The configuration for openssh is as follows:
         ```bash
         $ tsh auth export --type=host
         ```
-    * Add the output on Ansible node `/.ssh/known_hosts` by modifying the node section to match the nodes you are reaching (note: wildcards are accepted).
+    * Add the output on Ansible node `/.ssh/known_hosts` by modifying the host name to match the nodes you are connecting to (note: wildcards are accepted).
     ```bash
     @cert-authority <hostname.example.com|hostname|10.0.0.0> ssh-rsa AAA...REDACTED...TD9 logins=-teleport-nologin-f0d...REDACTED...fb1&type=host
     ```

--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1284,7 +1284,7 @@ The configuration for openssh is as follows:
         ```bash
         $ tsh auth export --type=host
         ```
-    * Add the output on Ansible node `/.ssh/known_hosts` by modifying the node section to match the nodes you are reaching. (Note: wildcards are accepted)
+    * Add the output on Ansible node `/.ssh/known_hosts` by modifying the node section to match the nodes you are reaching (note: wildcards are accepted).
     ```bash
     @cert-authority <NODE(S)> ssh-rsa AAA...REDACTED...TD9 logins=-teleport-nologin-f0d...REDACTED...fb1&type=host
     ```


### PR DESCRIPTION
Expanding on Ansible Integration documentation located in the Admin Guide. Included general setup information which was assumed in the original documentation.