### PR TITLE
Update database access docs

### DIFF
--- a/docs/5.0/preview/database-access.md
+++ b/docs/5.0/preview/database-access.md
@@ -42,26 +42,91 @@ The following diagram shows an example Database Access setup:
 
 ![Teleport database access diagram](../img/dbaccess.svg)
 
-## Schedule
+## Release Schedule
 
-!!! info
+Teleport Database Access is under active development. The alpha release will
+include support for PostgreSQL, including Amazon RDS and Aurora.
 
-    Teleport Database Access is under active development.
-    The alpha release will include support for PostgreSQL, including Amazon RDS and Aurora.
+See [release schedule](./upcoming-releases.md#release-schedule).
 
-[Database Access Release Schedule](./upcoming-releases.md#release-schedule)
+## Configure PostgreSQL
 
-## Setup
+### Self-Hosted PostgreSQL
 
-Let's setup a sample Teleport Database Access deployment.
+!!! note
+    This section explains how to configure a self-hosted instance of PostgreSQL
+    to work with Teleport Database Access. For information about configuring
+    AWS RDS/Aurora see the [section below](#aws-rdsaurora-postgresql).
 
-We will create a Teleport cluster and connect a PostgreSQL-flavored AWS Aurora
-database to it via Teleport database proxy.
+#### Create Certificate/Key Pair
 
-### Setup Aurora
+Teleport uses mutual TLS for authentication to PostgreSQL instances. As such,
+self-hosted PostgreSQL instances must be configured with Teleport's certificate
+authority and a certificate/key pair that Teleport can validate.
 
-Teleport Database Access uses IAM authentication with AWS RDS and Aurora
-databases which can be enabled with the following steps.
+To create these secrets, use `tctl auth sign` command. Note that it requires a
+running Teleport cluster and [should be run](https://goteleport.com/teleport/docs/architecture/overview/#tctl)
+on the auth server.
+
+```sh
+# Export Teleport's certificate authority and generate certificate/key pair
+# for host db.example.com with a one year validity period.
+$ tctl auth sign --format=db --host=db.example.com --out=server --ttl=8760h
+```
+
+Flag descriptions:
+
+* `--format=db`: instructs the command to produce secrets in the format suitable
+  for configuring a database server.
+* `--host=db.example.com`: server name to encode in the certificate, should
+  match the hostname Teleport will be connecting to the database at.
+* `--out=server`: name prefix for output files.
+* `--ttl=8760h`: certificate validity period.
+
+The command will create 3 files: `server.cas` with Teleport's certificate
+authority and `server.crt`/`server.key` with generated certificate/key pair.
+
+!!! note "Certificate Rotation"
+    Teleport signs database certificates with the host authority. As such,
+    when performing [host certificates rotation](../admin-guide.md#certificate-rotation),
+    the database certificates must be updated as well.
+
+#### Configure PostgreSQL Server
+
+To configure PostgreSQL server to accept TLS connections, add the following
+to PostgreSQL configuration file `postgresql.conf`:
+
+```conf
+ssl = on
+ssl_cert_file = '/path/to/server.crt'
+ssl_key_file = '/path/to/server.key'
+ssl_ca_file = '/path/toa/server.cas'
+```
+
+See [Secure TCP/IP Connections with SSL](https://www.postgresql.org/docs/current/ssl-tcp.html)
+in PostgreSQL documentation for more details.
+
+Additionally, PostgreSQL should be configured to require client certificate
+authentication from clients connecting over TLS. This can be done by adding
+the following entries to PostgreSQL host-based authentication file `pg_hba.conf`:
+
+```conf
+hostssl all             all             ::/0                    cert
+hostssl all             all             0.0.0.0/0               cert
+```
+
+See [The pg_hba.conf File](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
+in PostgreSQL documentation for more details.
+
+### AWS RDS/Aurora PostgreSQL
+
+!!! note
+    This section explains how to configure a PostgreSQL-flavored instance of
+    AWS RDS or Aurora database to work with Teleport Database Access. For
+    information about configuring a self-hosted PostgreSQL see the [section above](#self-hosted-postgresql).
+
+Teleport Database Access for AWS RDS and Aurora uses IAM authentication which
+can be enabled with the following steps.
 
 #### Enable IAM Authentication
 
@@ -95,6 +160,21 @@ database service will be using, for example:
 }
 ```
 
+The resource ARN in the policy has the following format:
+
+```
+arn:aws:rds-db:<region>:<account-id>:dbuser:<db-cluster-resource-id>/<db-user-name>
+```
+
+Parameters:
+
+* `region`: AWS region where the database cluster is deployed.
+* `account-id`: AWS account ID the database cluster is deployed under.
+* `db-cluster-resource-id`: identifier for the database cluster, can be found
+  under Configuration section in the RDS control panel.
+* `db-user-name`: name of the database account to associate with IAM
+  authentication. Can be a wildcard.
+
 See [Creating and using an IAM policy for IAM database access](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html)
 for more information.
 
@@ -111,9 +191,9 @@ GRANT rds_iam TO alice;
 See [Creating a database account using IAM authentication](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.DBAccounts.html)
 for more information.
 
-### Install Teleport
+## Configure Teleport
 
-First, head over to the Teleport [downloads page](https://gravitational.com/teleport/download/)
+First, head over to the Teleport [downloads page](https://goteleport.com/teleport/download/)
 and download the latest version of Teleport.
 
 !!! warning
@@ -121,9 +201,9 @@ and download the latest version of Teleport.
     As of this writing, no Teleport release with Database Access has been
     published yet.
 
-Follow the installation [instructions](https://gravitational.com/teleport/docs/installation/).
+Follow the installation [instructions](../installation.md).
 
-### Start Teleport
+### Start Auth/Proxy Service
 
 Create a configuration file for a Teleport service that will be running
 auth and proxy servers:
@@ -137,7 +217,7 @@ auth_service:
   cluster_name: "test"
   listen_addr: 0.0.0.0:3025
   tokens:
-  - proxy,node,database:qwe123
+  - proxy,node,database:cbdeeab9-6f88-436d-a673-44d14bd86bb7
 proxy_service:
   enabled: "yes"
   listen_addr: 0.0.0.0:3023
@@ -154,31 +234,67 @@ Start the service:
 $ teleport start --debug --config=/path/to/teleport.yaml
 ```
 
-### Start Teleport Database Service
+### Start Database Service with CLI Flags
 
-Create configuration file for a database service:
+For a quick try-out, Teleport database service doesn't require a configuration
+file and can be launched using a single CLI command:
+
+```sh
+$ teleport start --debug \
+   --roles=database \
+   --token=cbdeeab9-6f88-436d-a673-44d14bd86bb7 \
+   --auth-server=teleport.example.com:3080 \
+   --db-name=test \
+   --db-protocol=postgres \
+   --db-uri=db.example.com:5432 \
+   --labels=env=test
+```
+
+Note that the `--auth-server` flag must point to cluster's proxy endpoint
+because database service always connects back to the cluster over a reverse
+tunnel.
+
+Instead of using a static auth token, a short-lived dynamic token can also
+be generated for a database service:
+
+```sh
+$ tctl tokens add \
+    --type=database \
+    --db-name=test \
+    --db-protocol=postgres \
+    --db-uri=db.example.com:5432
+```
+
+### Start Database Service with Config File
+
+Below is an example of a database service configuration file that proxies
+a single AWS Aurora database:
 
 ```yaml
 teleport:
   data_dir: /var/lib/teleport-db
   nodename: test
   # Auth token to connect to the auth server.
-  auth_token: qwe123
-  # Proxy address to connect to.
+  auth_token: cbdeeab9-6f88-436d-a673-44d14bd86bb7
+  # Proxy address to connect to. Note that it has to be the proxy address
+  # because database service always connects to the cluster over reverse
+  # tunnel.
   auth_servers:
   - teleport.example.com:3080
 db_service:
   enabled: "yes"
+  # This section contains definitions of all databases proxied by this
+  # service, can contain multiple items.
   databases:
     # Name of the database proxy instance, used to reference in CLI.
-  - name: "postgres-aurora"
+  - name: "aurora"
     # Free-form description of the database proxy instance.
     description: "AWS Aurora instance of PostgreSQL 13.0"
     # Database protocol.
     protocol: "postgres"
-    # Database address.
+    # Database address, example of a AWS Aurora endpoint in this case.
     uri: "postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432"
-    # AWS specific configuration.
+    # AWS specific configuration, only required for RDS and Aurora.
     aws:
       # Region the database is deployed in.
       region: us-east-1
@@ -193,29 +309,162 @@ proxy_service:
   enabled: "no"
 ```
 
-Start the service:
+!!! tip
+    A single Teleport process can run multiple different services, for example
+    multiple database access proxies as well as running other services such an
+    SSH service or an application access proxy.
+
+Start the database service:
 
 ```sh
 $ teleport start --debug --config=/path/to/teleport-db.yaml
 ```
 
-### Login
+### AWS Credentials
 
-After the setup, log into the cluster and see the registered database proxy:
+When setting up Teleport database service with AWS RDS or Aurora, it must have
+an IAM role allowing it to connect to that particular database instance. An
+example of such a policy is shown in the [AWS RDS/Aurora](#aws-rdsaurora-postgresql)
+section above. See [Creating and using an IAM policy for IAM database access](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html)
+in AWS documentation.
+
+Teleport database service uses the default credential provider chain to find AWS
+credentials. See [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials)
+for more information.
+
+## Connect
+
+Once the database service has joined the cluster, login to see the available
+databases:
 
 ```sh
 $ tsh login --proxy=teleport.example.com:3080
 $ tsh db ls
+Name   Description Labels
+------ ----------- --------
+aurora AWS Aurora  env=dev
 ```
 
-### Connect
+Note that you will only be able to see databases your role has access to. See
+[RBAC](#rbac) section for more details.
 
-Log into the database and connect using `psql`:
+To connect to a particular database server, first retrieve credentials from
+Teleport using `tsh db login` command:
 
 ```sh
-$ tsh db login postgres
-$ psql "service=postgres-aurora user=<db-user> database=<db-name>"
+$ tsh db login aurora
 ```
+
+!!! tip
+    You can be logged into multiple databases simultaneously.
+
+You can optionally specify the database name and the user to use by default
+when connecting to the database instance:
+
+```sh
+$ tsh db login --db-user=postgres --db-name=postgres aurora
+```
+
+When logging into a PostgreSQL database, `tsh` automatically configures a section
+in the [connection service file](https://www.postgresql.org/docs/current/libpq-pgservice.html)
+with the name of `<cluster-name>-<database-service-name>`.
+
+Suppose the cluster name is "root", then you can connect to the database using
+the following `psql` command:
+
+```sh
+# Use default database user/name.
+$ psql "service=root-aurora"
+# Specify database name/user explicitly.
+$ psql "service=root-aurora user=alice dbname=metrics"
+```
+
+To log out of the database and remove credentials:
+
+```sh
+# Log out of a particular database instance.
+$ tsh db logout aurora
+# Log out of all database instances.
+$ tsh db logout
+```
+
+## RBAC
+
+Teleport's "role" resource provides the following instruments for restricting
+database access:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: developer
+spec:
+  allow:
+    # Label selectors for database instances this role has access to. These
+    # will be matched against the static/dynamic labels set on the database
+    # service.
+    db_labels:
+      environment: ["dev", "stage"]
+    # Database names this role will be able to connect to. Note: this is not
+    # the same as the "name" field in "db_service", this is the database names
+    # within a particular database instance.
+    db_names: ["main", "metrics", "postgres"]
+    # Database users this role can connect as.
+    db_users: ["alice", "bob"]
+```
+
+It is possible to use wildcards to match any database names/users. For example,
+the following role permits access to any database/user within a production
+database except for the internal "postgres" database/user:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: developer
+spec:
+  allow:
+    db_labels:
+      environment: ["dev", "prod"]
+    db_names: ["*"]
+    db_users: ["*"]
+  deny:
+    db_labels:
+      environment: ["dev", "prod"]
+    db_names: ["postgres"]
+    db_users: ["postgres"]
+```
+
+Similar to other role fields, these support templating variables to allow
+propagating information from identity providers:
+
+```yaml
+spec:
+  allow:
+    db_names: ["{% raw %}{{internal.db_names}}{% endraw %}", "{% raw %}{{external.xxx}}{% endraw %}"]
+    db_users: ["{% raw %}{{internal.db_users}}{% endraw %}", "{% raw %}{{external.yyy}}{% endraw %}"]
+```
+
+See general [RBAC](../enterprise/ssh-rbac.md) documentation for more details.
+
+## FAQ
+
+### Which database protocols does Teleport Database Access support?
+
+Currently Teleport Database Access Preview supports only PostgreSQL.
+
+MySQL support is planned for [Teleport 6.0 release](./upcoming-releases.md#release-schedule),
+with other databases to follow over the course of 2021 and beyond.
+
+### Which PostgreSQL protocol features are not supported?
+
+The following PostgreSQL protocol features aren't currently supported:
+
+* [Canceling requests in progress](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.9).
+  Cancel requests issued by the PostgreSQL clients connected to Teleport proxy
+  won't be passed to the database server.
+* Any of the [authentication methods](https://www.postgresql.org/docs/current/auth-methods.html)
+  except for client certificate authentication.
 
 ## Demo
 
@@ -225,10 +474,9 @@ $ psql "service=postgres-aurora user=<db-user> database=<db-name>"
 Your browser does not support the video tag.
 </video>
 
-
 ## RFD
 
-Please refer to the [RFD document](https://github.com/gravitational/teleport/blob/roman/rfd/dba/rfd/0011-database-access.md)
+Please refer to the [RFD document](https://github.com/gravitational/teleport/blob/024fd582e62560ffc925cd4b4d42c156043c041b/rfd/0011-database-access.md)
 for a more in-depth description of the feature scope and design.
 
 ## Feedback


### PR DESCRIPTION
A few updates/enhancements to the database access preview docs to make them more complete and useful for general audience:

* Add a section on configuring a self-hosted Postgres server.
* Add a section on starting database service w/o configuration file and generating dynamic tokens.
* Add more information around CLI UX.
* Add a section about RBAC.
* Fix RFD link.
