### PR TITLE
Collect CPU, Heap, and Goroutine profiles when running tsh bench 

### DIFF
--- a/lib/benchmark/benchmark.go
+++ b/lib/benchmark/benchmark.go
@@ -59,7 +59,7 @@ type Config struct {
 	MinimumWindow time.Duration
 	// MinimumMeasurments is the min amount of requests
 	MinimumMeasurements int
-	// CollectProfiles collects cpu, heap, and goroutin profiles
+	// CollectProfiles collects cpu, heap, and goroutine profiles
 	CollectProfiles bool
 	// ProfilePath is the path where the profiles should be saved
 	ProfilePath string
@@ -153,11 +153,6 @@ func ExportLatencyProfile(path string, h *hdrhistogram.Histogram, ticks int32, v
 		return "", trace.Wrap(err)
 	}
 	return fo.Name(), nil
-}
-
-//BenchmarkCLI ...
-func (c *Config) BenchmarkCLI(ctx context.Context, tc *client.TeleportClient) (Result, error) {
-	return Result{}, nil
 }
 
 // Benchmark connects to remote server and executes requests in parallel according

--- a/lib/benchmark/profile_collection.go
+++ b/lib/benchmark/profile_collection.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benchmark
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	client "github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/trace"
+)
+
+// collectProfiles collects cpu, heap, and goroutine profiles
+func collectProfiles(ctx context.Context, prefix, localDirectory, remoteUser string, tc *client.TeleportClient) error {
+	localDirectory = path.Clean(localDirectory)
+	profiles := []string{"cpu.profile http://127.0.0.1:3434/debug/pprof/profile", "goroutine.profile http://127.0.0.1:3434/debug/pprof/goroutine", "heap.profile http://127.0.0.1:3434/debug/pprof/heap"}
+	files := []string{"cpu.profile", "goroutine.profile", "heap.profile"}
+	for i := range profiles {
+		profiles[i] = fmt.Sprintf("%s %s %s_%s", "curl", "-o", prefix, profiles[i])
+		files[i] = fmt.Sprintf("%s_%s", prefix, files[i])
+	}
+	config := tc.Config
+	client, err := client.NewClient(&config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	out := &bytes.Buffer{}
+	tc.Stdout = out
+	tc.Stderr = out
+	err = statusOK(tc, out)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for i := range profiles {
+		err = client.SSH(context.TODO(), strings.Split(profiles[i], " "), false)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	err = scpProfiles(files, remoteUser, localDirectory, tc)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// statusOK checks diagnostic endpoint status code on the remote server
+func statusOK(tc *client.TeleportClient, out *bytes.Buffer) error {
+	command := []string{"curl", "-s", "-w", "\"%{http_code}\n \"", "http://127.0.0.1:3434/debug/pprof/", "-o", "/dev/null"}
+	err := tc.SSH(context.TODO(), command, false)
+	if (err == nil) && !(strings.Contains(out.String(), "200")) {
+		return nil
+	}
+	return trace.Wrap(err, ": make sure --diag-addr and -d flags are enabled on server start up")
+}
+
+// scpProfiles securely copies all profiles from remote server to local
+func scpProfiles(files []string, user, local string, tc *client.TeleportClient) error {
+	var remote string
+	config := tc.Config
+	client, err := client.NewClient(&config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for i := range files {
+		remote = fmt.Sprintf("%s@%s:%s", user, tc.Host, files[i])
+		fmt.Println("securley copying... ", remote, " --> ", local)
+		err := client.SCP(context.TODO(), []string{remote, local}, tc.HostPort, false, true)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}

--- a/lib/benchmark/profile_collection.go
+++ b/lib/benchmark/profile_collection.go
@@ -30,9 +30,6 @@ import (
 )
 
 const (
-	// CPU command takes 30 seconds, a minute will be added to the benchmark (before and after, collecting the profiles during happens concurrently).
-	// If you cancel the benchmark during collecting cpu data, you will need to wait until the cpu command is done on the remote server (no more than ~30s)
-	// Benchmarks will need to be at least one minute long if you would like to collect profiles.
 	cpuEndpoint          = "http://127.0.0.1:3434/debug/pprof/profile"
 	goroutineEndpoint    = "http://127.0.0.1:3434/debug/pprof/goroutine"
 	heapEndpoint         = "http://127.0.0.1:3434/debug/pprof/heap"

--- a/lib/benchmark/profile_collection.go
+++ b/lib/benchmark/profile_collection.go
@@ -19,20 +19,31 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path"
+	"log"
+	"os"
 	"strings"
 
-	client "github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/trace"
 )
 
+const (
+	cpuEndpoint       = "http://127.0.0.1:3434/debug/pprof/profile"
+	goroutineEndpoint = "http://127.0.0.1:3434/debug/pprof/goroutine"
+	heapEndpoint      = "http://127.0.0.1:3434/debug/pprof/heap"
+)
+
 // collectProfiles collects cpu, heap, and goroutine profiles
-func collectProfiles(ctx context.Context, prefix, localDirectory, remoteUser string, tc *client.TeleportClient) error {
-	localDirectory = path.Clean(localDirectory)
-	profiles := []string{"cpu.profile http://127.0.0.1:3434/debug/pprof/profile", "goroutine.profile http://127.0.0.1:3434/debug/pprof/goroutine", "heap.profile http://127.0.0.1:3434/debug/pprof/heap"}
+func collectProfiles(ctx context.Context, prefix, path, remoteUser string, tc *client.TeleportClient) error {
+	var profileCommands = new([3]string)
+	endpoints := []string{cpuEndpoint, goroutineEndpoint, heapEndpoint}
 	files := []string{"cpu.profile", "goroutine.profile", "heap.profile"}
-	for i := range profiles {
-		profiles[i] = fmt.Sprintf("%s %s %s_%s", "curl", "-o", prefix, profiles[i])
+	ok, err := exists(path)
+	if !ok || err != nil {
+		return trace.Wrap(err)
+	}
+	for i := range endpoints {
+		profileCommands[i] = fmt.Sprintf("%s %s_%s %s", "curl -o", prefix, files[i], endpoints[i])
 		files[i] = fmt.Sprintf("%s_%s", prefix, files[i])
 	}
 	config := tc.Config
@@ -47,23 +58,31 @@ func collectProfiles(ctx context.Context, prefix, localDirectory, remoteUser str
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	for i := range profiles {
-		err = client.SSH(context.TODO(), strings.Split(profiles[i], " "), false)
+	for i := range profileCommands {
+		err = client.SSH(context.TODO(), strings.Split(profileCommands[i], " "), false)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	}
-	err = scpProfiles(files, remoteUser, localDirectory, tc)
+	err = scpProfiles(files, path, tc)
 	if err != nil {
-		return err
+		return trace.Wrap(err)
 	}
 	return nil
 }
 
+// exists checks if path exists
+func exists(path string) (bool, error) {
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return false, trace.Wrap(err)
+	}
+	return true, nil
+}
+
 // statusOK checks diagnostic endpoint status code on the remote server
 func statusOK(tc *client.TeleportClient, out *bytes.Buffer) error {
-	command := []string{"curl", "-s", "-w", "\"%{http_code}\n \"", "http://127.0.0.1:3434/debug/pprof/", "-o", "/dev/null"}
-	err := tc.SSH(context.TODO(), command, false)
+	command := fmt.Sprint("curl -s -w \"%{http_code}\n\" http://127.0.0.1:3434/debug/pprof/ -o /dev/null")
+	err := tc.SSH(context.TODO(), strings.Split(command, " "), false)
 	if (err == nil) && !(strings.Contains(out.String(), "200")) {
 		return nil
 	}
@@ -71,7 +90,7 @@ func statusOK(tc *client.TeleportClient, out *bytes.Buffer) error {
 }
 
 // scpProfiles securely copies all profiles from remote server to local
-func scpProfiles(files []string, user, local string, tc *client.TeleportClient) error {
+func scpProfiles(files []string, path string, tc *client.TeleportClient) error {
 	var remote string
 	config := tc.Config
 	client, err := client.NewClient(&config)
@@ -79,9 +98,9 @@ func scpProfiles(files []string, user, local string, tc *client.TeleportClient) 
 		return trace.Wrap(err)
 	}
 	for i := range files {
-		remote = fmt.Sprintf("%s@%s:%s", user, tc.Host, files[i])
-		fmt.Println("securley copying... ", remote, " --> ", local)
-		err := client.SCP(context.TODO(), []string{remote, local}, tc.HostPort, false, true)
+		remote = fmt.Sprintf("%s@%s:%s", tc.HostLogin, tc.Host, files[i])
+		log.Println("securley copying... ", remote, " --> ", path)
+		err := client.SCP(context.TODO(), []string{remote, path}, tc.HostPort, false, true)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -128,6 +128,8 @@ type CLIConf struct {
 	BenchTicks int32
 	// BenchValueScale value at which to scale the values recorded
 	BenchValueScale float64
+	// BenchCollectProfiles collects cpu, heap, and goroutine profiles of server bench is running against
+	BenchCollectProfiles bool
 	// Context is a context to control execution
 	Context context.Context
 	// Gops starts gops agent on a specified address
@@ -331,9 +333,10 @@ func Run(args []string) {
 	bench.Flag("rate", "Requests per second rate").Default("10").IntVar(&cf.BenchRate)
 	bench.Flag("interactive", "Create interactive SSH session").BoolVar(&cf.BenchInteractive)
 	bench.Flag("export", "Export the latency profile").BoolVar(&cf.BenchExport)
-	bench.Flag("path", "Directory to save the latency profile to, default path is the current directory").Default(".").StringVar(&cf.BenchExportPath)
+	bench.Flag("path", "Directory to save the latency/metric profiles to, default path is the current directory").Default(".").StringVar(&cf.BenchExportPath)
 	bench.Flag("ticks", "Ticks per half distance").Default("100").Int32Var(&cf.BenchTicks)
 	bench.Flag("scale", "Value scale in which to scale the recorded values").Default("1.0").Float64Var(&cf.BenchValueScale)
+	bench.Flag("profiles", "Collect cpu, goroutine, and heap profiles").BoolVar(&cf.BenchCollectProfiles)
 
 	// show key
 	show := app.Command("show", "Read an identity from file and print to stdout").Hidden()
@@ -1113,6 +1116,8 @@ func onBenchmark(cf *CLIConf) {
 		Command:       cf.RemoteCommand,
 		MinimumWindow: cf.BenchDuration,
 		Rate:          cf.BenchRate,
+		CollectProfiles: cf.BenchCollectProfiles,
+		ProfilePath: cf.BenchExportPath,
 	}
 	result, err := cnf.Benchmark(cf.Context, tc)
 	if err != nil {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1113,11 +1113,11 @@ func onBenchmark(cf *CLIConf) {
 		utils.FatalError(err)
 	}
 	cnf := benchmark.Config{
-		Command:       cf.RemoteCommand,
-		MinimumWindow: cf.BenchDuration,
-		Rate:          cf.BenchRate,
+		Command:         cf.RemoteCommand,
+		MinimumWindow:   cf.BenchDuration,
+		Rate:            cf.BenchRate,
 		CollectProfiles: cf.BenchCollectProfiles,
-		ProfilePath: cf.BenchExportPath,
+		ProfilePath:     cf.BenchExportPath,
 	}
 	result, err := cnf.Benchmark(cf.Context, tc)
 	if err != nil {


### PR DESCRIPTION
## Purpose
Automating the collection of  cpu, heap, and goroutine profiles when running `tsh bench`

## Implementation 
`tsh bench` can now collect cpu, heap, and goroutine profiles if specified by the user with the `--profiles` flag. It will collect these metrics before, during, and after the run, this will add ~1 minute to the run. 



### Notes
If you cancel the benchmark during collecting data, you will need to wait until the command is done on the remote server otherwise the command will not work on the remote machine if it is already running. If there is another way I should handle this (i.e. a cleanup function, best way to do this?), please let me know. 

`tsh bench` runs will need to be at least one minute long, if you would like to collect profiles, because the collecting cpu data takes 30s to collect.

If there is an error with collecting profiles during the run, currently it returns from the `Benchmark()` function. This is still up in the air because if there is a long benchmark (for example 4 hours) it will stop. 

