### PR TITLE
kube-agent helm chart: use image tag 5.0 instead of 5.0.0

### DIFF
--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
 version: 0.0.1
-appVersion: 5.0.0
+appVersion: "5.0"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:


### PR DESCRIPTION
Automatically picks up the latest patch version.