### PR TITLE
Backport: upload k8s session recordings regardless of request context

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -644,7 +644,7 @@ func (f *Forwarder) exec(ctx *authContext, w http.ResponseWriter, req *http.Requ
 		recorder, err = events.NewAuditWriter(events.AuditWriterConfig{
 			// Audit stream is using server context, not session context,
 			// to make sure that session is uploaded even after it is closed
-			Context:      request.context,
+			Context:      f.ctx,
 			Streamer:     streamer,
 			Clock:        f.cfg.Clock,
 			SessionID:    sessionID,
@@ -657,7 +657,7 @@ func (f *Forwarder) exec(ctx *authContext, w http.ResponseWriter, req *http.Requ
 			return nil, trace.Wrap(err)
 		}
 		emitter = recorder
-		defer recorder.Close(request.context)
+		defer recorder.Close(f.ctx)
 		request.onResize = func(resize remotecommand.TerminalSize) {
 			params := session.TerminalParams{
 				W: int(resize.Width),


### PR DESCRIPTION
Backport of #5145 into 5.0

The HTTP request context is canceled when the client disconnects. Using
this context in the session recorder prevents it from uploading the
session when it's finished.

Use the server context instead, to prevent lost recordings.

Fixes https://github.com/gravitational/teleport/issues/5144