### PR TITLE
Support viewing cluster config with `tctl get cluster_config`

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -777,6 +777,8 @@ func ParseShortcut(in string) (string, error) {
 		return KindSemaphore, nil
 	case KindKubeService, "kube_services":
 		return KindKubeService, nil
+	case KindClusterConfig:
+		return KindClusterConfig, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -491,11 +491,11 @@ func (c *clusterConfigCollection) resources() (r []services.Resource) {
 
 func (c *clusterConfigCollection) writeText(w io.Writer) error {
 	t := asciitable.MakeTable([]string{
-		"Cluster ID", "Session Recording", "Proxy Checks Host Keys?",
+		"Cluster ID", "Session Recording Mode", "Local Auth",
 	})
 	for _, c := range c.configs {
 		t.AddRow([]string{
-			c.GetClusterID(), c.GetSessionRecording(), c.GetProxyChecksHostKeys(),
+			c.GetClusterID(), c.GetSessionRecording(), strconv.FormatBool(c.GetLocalAuth()),
 		})
 	}
 	_, err := t.AsBuffer().WriteTo(w)

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -477,3 +477,27 @@ func (a *appCollection) toMarshal() interface{} {
 func (a *appCollection) writeYAML(w io.Writer) error {
 	return utils.WriteYAML(w, a.toMarshal())
 }
+
+type clusterConfigCollection struct {
+	configs []services.ClusterConfig
+}
+
+func (c *clusterConfigCollection) resources() (r []services.Resource) {
+	for _, resource := range c.configs {
+		r = append(r, resource)
+	}
+	return r
+}
+
+func (c *clusterConfigCollection) writeText(w io.Writer) error {
+	t := asciitable.MakeTable([]string{
+		"Cluster ID", "Session Recording", "Proxy Checks Host Keys?",
+	})
+	for _, c := range c.configs {
+		t.AddRow([]string{
+			c.GetClusterID(), c.GetSessionRecording(), c.GetProxyChecksHostKeys(),
+		})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -682,8 +682,15 @@ func (rc *ResourceCommand) getCollection(client auth.ClientI) (c ResourceCollect
 			return nil, trace.Wrap(err)
 		}
 		return &serverCollection{servers: servers}, nil
+	case services.KindClusterConfig:
+		config, err := client.GetClusterConfig()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		configs := []services.ClusterConfig{config}
+		return &clusterConfigCollection{configs: configs}, nil
 	}
-	return nil, trace.BadParameter("'%v' is not supported", rc.ref.Kind)
+	return nil, trace.BadParameter("getting resources of type %q is not supported", rc.ref.Kind)
 }
 
 // UpsertVerb generates the correct string form of a verb based on the action taken


### PR DESCRIPTION
A first step towards resource-based dynamic configuration (#5147), this PR adds support for `tctl`-getting the `services.ClusterConfig` resource.

### `tctl get cluster_config`
```
kind: cluster_config
metadata:
  id: 1608236248009338844
  name: cluster-config
spec:
  audit: {}
  client_idle_timeout: 0s
  cluster_id: eaf63d41-a135-439b-8701-318aedd0660a
  disconnect_expired_cert: false
  keep_alive_count_max: 3
  keep_alive_interval: 5m0s
  local_auth: true
  proxy_checks_host_keys: "yes"
  session_control_timeout: 0s
  session_recording: node
version: v3
```

### `tctl get cluster_config --format=text` 
```
Cluster ID                           Session Recording Mode Local Auth 
------------------------------------ ---------------------- ---------- 
eaf63d41-a135-439b-8701-318aedd0660a node                   true       
```