### PR TITLE
Tweaks for k8s support detection in tsh

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -496,7 +496,7 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 		Cluster:        clusterName,
 		Traits:         traits,
 		ActiveRequests: activeRequests,
-		KubeEnabled:    tlsID.KubernetesCluster != "" && (len(tlsID.KubernetesUsers) > 0 || len(tlsID.KubernetesGroups) > 0),
+		KubeEnabled:    profile.KubeProxyAddr != "",
 		KubeCluster:    tlsID.KubernetesCluster,
 		KubeUsers:      tlsID.KubernetesUsers,
 		KubeGroups:     tlsID.KubernetesGroups,
@@ -2024,6 +2024,10 @@ func (tc *TeleportClient) applyProxySettings(proxySettings ProxySettings) error 
 			webProxyHost, _ := tc.WebProxyHostPort()
 			tc.KubeProxyAddr = net.JoinHostPort(webProxyHost, strconv.Itoa(defaults.KubeListenPort))
 		}
+	} else {
+		// Zero the field, in case there was a previous value set (e.g. loaded
+		// from profile directory).
+		tc.KubeProxyAddr = ""
 	}
 
 	// Read in settings for HTTP endpoint of the proxy.

--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -80,6 +80,15 @@ func UpdateWithClient(ctx context.Context, path string, tc *client.TeleportClien
 		return trace.Wrap(err)
 	}
 
+	// Fetch proxy's advertised ports to check for k8s support.
+	if _, err := tc.Ping(ctx); err != nil {
+		return trace.Wrap(err)
+	}
+	if tc.KubeProxyAddr == "" {
+		// Kubernetes support disabled, don't touch kubeconfig.
+		return nil
+	}
+
 	// TODO(awly): unit test this.
 	if tshBinary != "" {
 		v.Exec = &ExecValues{

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1521,7 +1521,9 @@ func printStatus(debug bool, p *client.ProfileStatus, isActive bool) {
 	fmt.Printf("  Logins:             %v\n", strings.Join(p.Logins, ", "))
 	if p.KubeEnabled {
 		fmt.Printf("  Kubernetes:         enabled\n")
-		fmt.Printf("  Kubernetes cluster: %q\n", p.KubeCluster)
+		if p.KubeCluster != "" {
+			fmt.Printf("  Kubernetes cluster: %q\n", p.KubeCluster)
+		}
 		if len(p.KubeUsers) > 0 {
 			fmt.Printf("  Kubernetes users:   %v\n", strings.Join(p.KubeUsers, ", "))
 		}


### PR DESCRIPTION
- detect whether k8s support is on based on proxy advertising a k8s port
- make sure proxy advertised k8s port is updated on re-login
- don't touch user's kubeconfig if k8s support is disabled in proxy

How this shows up:
- `tsh login/status` print `Kubernetes: enabled` when the proxy has a k8s port open, even if no `kubernetes_serivce`s are registered (e.g. root trusted cluster or older proxy)
- if you see `Kubernetes: enabled` in `tsh login` output, then your `kubeconfig` was updated and vice versa
  - previously you could get it updated even if `Kubernetes: disabled`
- `tsh login` after you've disabled `kube_listen_addr` on the proxy updates to `Kubernetes: disabled`

Fixes https://github.com/gravitational/teleport/issues/4945