### PR TITLE
Upgrade github.com/gravitataional/trace to v1.1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/gravitational/oxy v0.0.0-20200916204440-3eb06d921a1d
 	github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c
 	github.com/gravitational/roundtrip v1.0.0
-	github.com/gravitational/trace v1.1.12
+	github.com/gravitational/trace v1.1.13
 	github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/iovisor/gobpf v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/gravitational/oxy v0.0.0-20200916204440-3eb06d921a1d
 	github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c
 	github.com/gravitational/roundtrip v1.0.0
-	github.com/gravitational/trace v1.1.6
+	github.com/gravitational/trace v1.1.12
 	github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/iovisor/gobpf v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c h1:UwN3jo2
 github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c/go.mod h1:rBJeI3JYVzbL7Yw2hYrp4QdKIkncb1pUHo95DyoEGns=
 github.com/gravitational/roundtrip v1.0.0 h1:eb+0EABfSKC8607CQ4oOyWCm9zVIfio/wW78TjQqLSc=
 github.com/gravitational/roundtrip v1.0.0/go.mod h1:qccpLd30tAJVSpx7aOEEnws4ZT3njPwdbtT8lNQxbAs=
-github.com/gravitational/trace v1.1.12 h1:xSOH8YJTy5AuQy4E7m/j6pTRm41cnufrnFCJfGIR80E=
-github.com/gravitational/trace v1.1.12/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
+github.com/gravitational/trace v1.1.13 h1:4vSuBtVQCbUGj28dm5ke8UPnuejcxeSlz9GEW9X7HIM=
+github.com/gravitational/trace v1.1.13/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c h1:C2iWDiod8vQ3YnOiCdMP9qYeg2UifQ8KSk36r0NswSE=
 github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c/go.mod h1:erKVikttPjeHKDCQZcqowEqiccy23cJAqPadZgfjNm8=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c h1:UwN3jo2
 github.com/gravitational/reporting v0.0.0-20180907002058-ac7b85c75c4c/go.mod h1:rBJeI3JYVzbL7Yw2hYrp4QdKIkncb1pUHo95DyoEGns=
 github.com/gravitational/roundtrip v1.0.0 h1:eb+0EABfSKC8607CQ4oOyWCm9zVIfio/wW78TjQqLSc=
 github.com/gravitational/roundtrip v1.0.0/go.mod h1:qccpLd30tAJVSpx7aOEEnws4ZT3njPwdbtT8lNQxbAs=
-github.com/gravitational/trace v1.1.6 h1:01TsXO7s2/hAEi+7bDlyXV6uBxlPd75udfrK2XNZD/g=
-github.com/gravitational/trace v1.1.6/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
+github.com/gravitational/trace v1.1.12 h1:xSOH8YJTy5AuQy4E7m/j6pTRm41cnufrnFCJfGIR80E=
+github.com/gravitational/trace v1.1.12/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c h1:C2iWDiod8vQ3YnOiCdMP9qYeg2UifQ8KSk36r0NswSE=
 github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c/go.mod h1:erKVikttPjeHKDCQZcqowEqiccy23cJAqPadZgfjNm8=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/vendor/github.com/gravitational/trace/errors.go
+++ b/vendor/github.com/gravitational/trace/errors.go
@@ -317,10 +317,10 @@ type ConnectionProblemError struct {
 
 // Error is debug - friendly error message
 func (c *ConnectionProblemError) Error() string {
-	if c.Err == nil {
+	if c.Message != "" {
 		return c.Message
 	}
-	return c.Err.Error()
+	return UserMessage(c.Err)
 }
 
 // IsConnectionProblemError indicates that this error is of ConnectionProblemError type
@@ -328,8 +328,16 @@ func (c *ConnectionProblemError) IsConnectionProblemError() bool {
 	return true
 }
 
-// OrigError returns original error (in this case this is the error itself)
+// Unwrap returns the wrapped error if any
+func (c *ConnectionProblemError) Unwrap() error {
+	return c.Err
+}
+
+// OrigError returns original error
 func (c *ConnectionProblemError) OrigError() error {
+	if c.Err != nil {
+		return c.Err
+	}
 	return c
 }
 
@@ -378,6 +386,14 @@ func IsLimitExceeded(e error) bool {
 	return ok
 }
 
+// Trust returns new instance of TrustError
+func Trust(err error, message string, args ...interface{}) Error {
+	return newTrace(&TrustError{
+		Message: fmt.Sprintf(message, args...),
+		Err:     err,
+	}, 2)
+}
+
 // TrustError indicates trust-related validation error (e.g. untrusted cert)
 type TrustError struct {
 	// Err is original error
@@ -387,7 +403,10 @@ type TrustError struct {
 
 // Error returns log-friendly error description
 func (t *TrustError) Error() string {
-	return t.Err.Error()
+	if t.Message != "" {
+		return t.Message
+	}
+	return UserMessage(t.Err)
 }
 
 // IsTrustError indicates that this error is of TrustError type
@@ -395,8 +414,16 @@ func (*TrustError) IsTrustError() bool {
 	return true
 }
 
+// Unwrap returns the wrapped error if any
+func (t *TrustError) Unwrap() error {
+	return t.Err
+}
+
 // OrigError returns original error (in this case this is the error itself)
 func (t *TrustError) OrigError() error {
+	if t.Err != nil {
+		return t.Err
+	}
 	return t
 }
 
@@ -449,7 +476,7 @@ func IsEOF(e error) bool {
 	return Unwrap(e) == io.EOF
 }
 
-// Retry return new instance of RetryError which indicates a transient error type
+// Retry returns new instance of RetryError which indicates a transient error type
 func Retry(err error, message string, args ...interface{}) Error {
 	return newTrace(&RetryError{
 		Message: fmt.Sprintf(message, args...),
@@ -465,10 +492,10 @@ type RetryError struct {
 
 // Error is debug-friendly error message
 func (c *RetryError) Error() string {
-	if c.Err == nil {
+	if c.Message != "" {
 		return c.Message
 	}
-	return c.Err.Error()
+	return UserMessage(c.Err)
 }
 
 // IsRetryError indicates that this error is of RetryError type
@@ -476,8 +503,16 @@ func (c *RetryError) IsRetryError() bool {
 	return true
 }
 
+// Unwrap returns the wrapped error if any
+func (c *RetryError) Unwrap() error {
+	return c.Err
+}
+
 // OrigError returns original error (in this case this is the error itself)
 func (c *RetryError) OrigError() error {
+	if c.Err != nil {
+		return c.Err
+	}
 	return c
 }
 

--- a/vendor/github.com/gravitational/trace/errors.go
+++ b/vendor/github.com/gravitational/trace/errors.go
@@ -26,10 +26,10 @@ import (
 )
 
 // NotFound returns new instance of not found error
-func NotFound(message string, args ...interface{}) error {
-	return WrapWithMessage(&NotFoundError{
+func NotFound(message string, args ...interface{}) Error {
+	return newTrace(&NotFoundError{
 		Message: fmt.Sprintf(message, args...),
-	}, message, args...)
+	}, 2)
 }
 
 // NotFoundError indicates that object has not been found
@@ -56,23 +56,22 @@ func (e *NotFoundError) OrigError() error {
 }
 
 // IsNotFound returns whether this error is of NotFoundError type
-func IsNotFound(e error) bool {
-	type nf interface {
+func IsNotFound(err error) bool {
+	err = Unwrap(err)
+	_, ok := err.(interface {
 		IsNotFoundError() bool
-	}
-	err := Unwrap(e)
-	_, ok := err.(nf)
+	})
 	if !ok {
 		return os.IsNotExist(err)
 	}
-	return ok
+	return true
 }
 
 // AlreadyExists returns a new instance of AlreadyExists error
-func AlreadyExists(message string, args ...interface{}) error {
-	return WrapWithMessage(&AlreadyExistsError{
-		fmt.Sprintf(message, args...),
-	}, message, args...)
+func AlreadyExists(message string, args ...interface{}) Error {
+	return newTrace(&AlreadyExistsError{
+		Message: fmt.Sprintf(message, args...),
+	}, 2)
 }
 
 // AlreadyExistsError indicates that there's a duplicate object that already
@@ -110,10 +109,10 @@ func IsAlreadyExists(e error) bool {
 }
 
 // BadParameter returns a new instance of BadParameterError
-func BadParameter(message string, args ...interface{}) error {
-	return WrapWithMessage(&BadParameterError{
+func BadParameter(message string, args ...interface{}) Error {
+	return newTrace(&BadParameterError{
 		Message: fmt.Sprintf(message, args...),
-	}, message, args...)
+	}, 2)
 }
 
 // BadParameterError indicates that something is wrong with passed
@@ -147,10 +146,10 @@ func IsBadParameter(e error) bool {
 }
 
 // NotImplemented returns a new instance of NotImplementedError
-func NotImplemented(message string, args ...interface{}) error {
-	return WrapWithMessage(&NotImplementedError{
+func NotImplemented(message string, args ...interface{}) Error {
+	return newTrace(&NotImplementedError{
 		Message: fmt.Sprintf(message, args...),
-	}, message, args...)
+	}, 2)
 }
 
 // NotImplementedError defines an error condition to describe the result
@@ -184,8 +183,10 @@ func IsNotImplemented(e error) bool {
 }
 
 // CompareFailed returns new instance of CompareFailedError
-func CompareFailed(message string, args ...interface{}) error {
-	return WrapWithMessage(&CompareFailedError{Message: fmt.Sprintf(message, args...)}, message, args...)
+func CompareFailed(message string, args ...interface{}) Error {
+	return newTrace(&CompareFailedError{
+		Message: fmt.Sprintf(message, args...),
+	}, 2)
 }
 
 // CompareFailedError indicates a failed comparison (e.g. bad password or hash)
@@ -222,10 +223,10 @@ func IsCompareFailed(e error) bool {
 }
 
 // AccessDenied returns new instance of AccessDeniedError
-func AccessDenied(message string, args ...interface{}) error {
-	return WrapWithMessage(&AccessDeniedError{
+func AccessDenied(message string, args ...interface{}) Error {
+	return newTrace(&AccessDeniedError{
 		Message: fmt.Sprintf(message, args...),
-	}, message, args...)
+	}, 2)
 }
 
 // AccessDeniedError indicates denied access
@@ -252,11 +253,10 @@ func (e *AccessDeniedError) OrigError() error {
 }
 
 // IsAccessDenied detects if this error is of AccessDeniedError type
-func IsAccessDenied(e error) bool {
-	type ad interface {
+func IsAccessDenied(err error) bool {
+	_, ok := Unwrap(err).(interface {
 		IsAccessDeniedError() bool
-	}
-	_, ok := Unwrap(e).(ad)
+	})
 	return ok
 }
 
@@ -266,41 +266,47 @@ func ConvertSystemError(err error) error {
 	innerError := Unwrap(err)
 
 	if os.IsExist(innerError) {
-		return WrapWithMessage(&AlreadyExistsError{Message: innerError.Error()}, innerError.Error())
+		return newTrace(&AlreadyExistsError{
+			Message: innerError.Error(),
+		}, 2)
 	}
 	if os.IsNotExist(innerError) {
-		return WrapWithMessage(&NotFoundError{Message: innerError.Error()}, innerError.Error())
+		return newTrace(&NotFoundError{
+			Message: innerError.Error(),
+		}, 2)
 	}
 	if os.IsPermission(innerError) {
-		return WrapWithMessage(&AccessDeniedError{Message: innerError.Error()}, innerError.Error())
+		return newTrace(&AccessDeniedError{
+			Message: innerError.Error(),
+		}, 2)
 	}
 	switch realErr := innerError.(type) {
 	case *net.OpError:
-		return WrapWithMessage(&ConnectionProblemError{
-			Message: realErr.Error(),
-			Err:     realErr}, realErr.Error())
+		return newTrace(&ConnectionProblemError{
+			Err: realErr,
+		}, 2)
 	case *os.PathError:
 		message := fmt.Sprintf("failed to execute command %v error:  %v", realErr.Path, realErr.Err)
-		return WrapWithMessage(&AccessDeniedError{
+		return newTrace(&AccessDeniedError{
 			Message: message,
-		}, message)
+		}, 2)
 	case x509.SystemRootsError, x509.UnknownAuthorityError:
-		return wrapWithDepth(&TrustError{Err: innerError}, 2)
+		return newTrace(&TrustError{Err: innerError}, 2)
 	}
 	if _, ok := innerError.(net.Error); ok {
-		return WrapWithMessage(&ConnectionProblemError{
-			Message: innerError.Error(),
-			Err:     innerError}, innerError.Error())
+		return newTrace(&ConnectionProblemError{
+			Err: innerError,
+		}, 2)
 	}
 	return err
 }
 
 // ConnectionProblem returns new instance of ConnectionProblemError
-func ConnectionProblem(err error, message string, args ...interface{}) error {
-	return WrapWithMessage(&ConnectionProblemError{
+func ConnectionProblem(err error, message string, args ...interface{}) Error {
+	return newTrace(&ConnectionProblemError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
-	}, message, args...)
+	}, 2)
 }
 
 // ConnectionProblemError indicates a network related problem
@@ -337,10 +343,10 @@ func IsConnectionProblem(e error) bool {
 }
 
 // LimitExceeded returns whether new instance of LimitExceededError
-func LimitExceeded(message string, args ...interface{}) error {
-	return WrapWithMessage(&LimitExceededError{
+func LimitExceeded(message string, args ...interface{}) Error {
+	return newTrace(&LimitExceededError{
 		Message: fmt.Sprintf(message, args...),
-	}, message, args...)
+	}, 2)
 }
 
 // LimitExceededError indicates rate limit or connection limit problem
@@ -405,11 +411,11 @@ func IsTrustError(e error) bool {
 
 // OAuth2 returns new instance of OAuth2Error
 func OAuth2(code, message string, query url.Values) Error {
-	return WrapWithMessage(&OAuth2Error{
+	return newTrace(&OAuth2Error{
 		Code:    code,
 		Message: message,
 		Query:   query,
-	}, message)
+	}, 2)
 }
 
 // OAuth2Error defined an error used in OpenID Connect Flow (OIDC)
@@ -444,11 +450,11 @@ func IsEOF(e error) bool {
 }
 
 // Retry return new instance of RetryError which indicates a transient error type
-func Retry(err error, message string, args ...interface{}) error {
-	return WrapWithMessage(&RetryError{
+func Retry(err error, message string, args ...interface{}) Error {
+	return newTrace(&RetryError{
 		Message: fmt.Sprintf(message, args...),
 		Err:     err,
-	}, message, args...)
+	}, 2)
 }
 
 // RetryError indicates a transient error type

--- a/vendor/github.com/gravitational/trace/httplib.go
+++ b/vendor/github.com/gravitational/trace/httplib.go
@@ -8,19 +8,21 @@ import (
 
 // WriteError sets up HTTP error response and writes it to writer w
 func WriteError(w http.ResponseWriter, err error) {
-	if IsAggregate(err) {
-		for i := 0; i < maxHops; i++ {
-			var aggErr Aggregate
-			var ok bool
-			if aggErr, ok = Unwrap(err).(Aggregate); !ok {
-				break
-			}
-			errors := aggErr.Errors()
-			if len(errors) == 0 {
-				break
-			}
-			err = errors[0]
+	if !IsAggregate(err) {
+		replyJSON(w, ErrorToCode(err), err)
+		return
+	}
+	for i := 0; i < maxHops; i++ {
+		var aggErr Aggregate
+		var ok bool
+		if aggErr, ok = Unwrap(err).(Aggregate); !ok {
+			break
 		}
+		errors := aggErr.Errors()
+		if len(errors) == 0 {
+			break
+		}
+		err = errors[0]
 	}
 	replyJSON(w, ErrorToCode(err), err)
 }
@@ -54,62 +56,49 @@ func ErrorToCode(err error) int {
 // ReadError converts http error to internal error type
 // based on HTTP response code and HTTP body contents
 // if status code does not indicate error, it will return nil
-func ReadError(statusCode int, re []byte) error {
-	var e error
-	switch statusCode {
-	case http.StatusNotFound:
-		e = &NotFoundError{Message: string(re)}
-	case http.StatusBadRequest:
-		e = &BadParameterError{Message: string(re)}
-	case http.StatusNotImplemented:
-		e = &NotImplementedError{Message: string(re)}
-	case http.StatusPreconditionFailed:
-		e = &CompareFailedError{Message: string(re)}
-	case http.StatusForbidden:
-		e = &AccessDeniedError{Message: string(re)}
-	case http.StatusConflict:
-		e = &AlreadyExistsError{Message: string(re)}
-	case http.StatusTooManyRequests:
-		e = &LimitExceededError{Message: string(re)}
-	case http.StatusGatewayTimeout:
-		e = &ConnectionProblemError{Message: string(re)}
-	default:
-		if statusCode < 200 || statusCode > 299 {
-			return Errorf(string(re))
-		}
+func ReadError(statusCode int, respBytes []byte) error {
+	if statusCode >= http.StatusOK && statusCode < http.StatusBadRequest {
 		return nil
 	}
-	return unmarshalError(e, re)
+	var err error
+	switch statusCode {
+	case http.StatusNotFound:
+		err = &NotFoundError{}
+	case http.StatusBadRequest:
+		err = &BadParameterError{}
+	case http.StatusNotImplemented:
+		err = &NotImplementedError{}
+	case http.StatusPreconditionFailed:
+		err = &CompareFailedError{}
+	case http.StatusForbidden:
+		err = &AccessDeniedError{}
+	case http.StatusConflict:
+		err = &AlreadyExistsError{}
+	case http.StatusTooManyRequests:
+		err = &LimitExceededError{}
+	case http.StatusGatewayTimeout:
+		err = &ConnectionProblemError{}
+	default:
+		err = &RawTrace{}
+	}
+	return wrapProxy(unmarshalError(err, respBytes))
 }
 
 func replyJSON(w http.ResponseWriter, code int, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-
 	var out []byte
-	if IsDebug() {
-		// trace error can marshal itself,
-		// otherwise capture error message and marshal it explicitly
-		var obj interface{} = err
-		if _, ok := err.(*TraceErr); !ok {
-			obj = message{Message: err.Error()}
-		}
-		out, err = json.MarshalIndent(obj, "", "    ")
-		if err != nil {
-			out = []byte(fmt.Sprintf(`{"message": "internal marshal error: %v"}`, err))
-		}
-	} else {
-		innerError := err
-		if terr, ok := err.(Error); ok {
-			innerError = terr.OrigError()
-		}
-		out, err = json.Marshal(message{Message: innerError.Error()})
+	// trace error can marshal itself,
+	// otherwise capture error message and marshal it explicitly
+	var obj interface{} = err
+	if _, ok := err.(*TraceErr); !ok {
+		obj = RawTrace{Message: err.Error()}
+	}
+	out, err = json.MarshalIndent(obj, "", "    ")
+	if err != nil {
+		out = []byte(fmt.Sprintf(`{"message": "internal marshal error: %v"}`, err))
 	}
 	w.Write(out)
-}
-
-type message struct {
-	Message string `json:"message"`
 }
 
 func unmarshalError(err error, responseBody []byte) error {
@@ -121,12 +110,17 @@ func unmarshalError(err error, responseBody []byte) error {
 		return err
 	}
 	if len(raw.Traces) != 0 && len(raw.Err) != 0 {
-		// try to capture traces, if there are any
 		err2 := json.Unmarshal(raw.Err, err)
 		if err2 != nil {
 			return err
 		}
-		return &TraceErr{Traces: raw.Traces, Err: err, Message: raw.Message}
+		return &TraceErr{
+			Traces:   raw.Traces,
+			Err:      err,
+			Message:  raw.Message,
+			Messages: raw.Messages,
+			Fields:   raw.Fields,
+		}
 	}
 	json.Unmarshal(responseBody, err)
 	return err

--- a/vendor/github.com/gravitational/trace/log.go
+++ b/vendor/github.com/gravitational/trace/log.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"regexp"
+	"runtime"
 	rundebug "runtime/debug"
 	"sort"
 	"strconv"
@@ -31,7 +33,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
-	"runtime"
 )
 
 const (
@@ -73,6 +74,9 @@ type TextFormatter struct {
 	ComponentPadding int
 	// EnableColors enables colored output
 	EnableColors bool
+	// FormatCaller is a function to return (part) of source file path for output.
+	// Defaults to filePathAndLine() if unspecified
+	FormatCaller func() (caller string)
 }
 
 // Format implements logrus.Formatter interface and adds file and line
@@ -83,12 +87,13 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 			return
 		}
 	}()
-	var file string
-	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo, nil)
-		file = t.Loc()
+
+	formatCaller := tf.FormatCaller
+	if formatCaller == nil {
+		formatCaller = formatCallerWithPathAndLine
 	}
 
+	caller := formatCaller()
 	w := &writer{}
 
 	// time
@@ -112,15 +117,7 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 	}
 	w.writeField(strings.ToUpper(padMax(e.Level.String(), DefaultLevelPadding)), color)
 
-	// component, always output
-	componentI, ok := e.Data[Component]
-	if !ok {
-		componentI = ""
-	}
-	component, ok := componentI.(string)
-	if !ok {
-		component = fmt.Sprintf("%v", componentI)
-	}
+	// always output the component field if available
 	padding := DefaultComponentPadding
 	if tf.ComponentPadding != 0 {
 		padding = tf.ComponentPadding
@@ -128,8 +125,10 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 	if w.Len() > 0 {
 		w.WriteByte(' ')
 	}
-	if component != "" {
-		component = fmt.Sprintf("[%v]", component)
+	value := e.Data[Component]
+	var component string
+	if reflect.ValueOf(value).IsValid() {
+		component = fmt.Sprintf("[%v]", value)
 	}
 	component = strings.ToUpper(padMax(component, padding))
 	if component[len(component)-1] != ' ' {
@@ -147,9 +146,9 @@ func (tf *TextFormatter) Format(e *log.Entry) (data []byte, err error) {
 		w.writeMap(e.Data)
 	}
 
-	// file, if present, always last
-	if file != "" {
-		w.writeField(file, noColor)
+	// caller, if present, always last
+	if caller != "" {
+		w.writeField(caller, noColor)
 	}
 
 	w.WriteByte('\n')
@@ -165,8 +164,8 @@ type JSONFormatter struct {
 
 // Format implements logrus.Formatter interface
 func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
-	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo, nil)
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
 		new := e.WithFields(log.Fields{
 			FileField:     t.Loc(),
 			FunctionField: t.FuncName(),
@@ -176,22 +175,45 @@ func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 		new.Message = e.Message
 		e = new
 	}
-	return (&j.JSONFormatter).Format(e)
+	return j.JSONFormatter.Format(e)
 }
 
-var r = regexp.MustCompile(`github\.com/(S|s)irupsen/logrus`)
+// formatCallerWithPathAndLine formats the caller in the form path/segment:<line number>
+// for output in the log
+func formatCallerWithPathAndLine() (path string) {
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
+		return t.Loc()
+	}
+	return ""
+}
 
-func findFrame() int {
-	for i := 3; i < 10; i++ {
-		_, file, _, ok := runtime.Caller(i)
-		if !ok {
-			return -1
-		}
-		if !r.MatchString(file) {
-			return i
+var frameIgnorePattern = regexp.MustCompile(`github\.com/(S|s)irupsen/logrus`)
+
+// findFrames positions the stack pointer to the first
+// function that does not match the frameIngorePattern
+// and returns the rest of the stack frames
+func findFrame() *frameCursor {
+	var buf [32]uintptr
+	// Skip enough frames to start at user code.
+	// This number is a mere hint to the following loop
+	// to start as close to user code as possible and getting it right is not mandatory.
+	// The skip count might need to get updated if the call to findFrame is
+	// moved up/down the call stack
+	n := runtime.Callers(4, buf[:])
+	pcs := buf[:n]
+	frames := runtime.CallersFrames(pcs)
+	for i := 0; i < n; i++ {
+		frame, _ := frames.Next()
+		if !frameIgnorePattern.MatchString(frame.File) {
+			return &frameCursor{
+				current: &frame,
+				rest:    frames,
+				n:       n,
+			}
 		}
 	}
-	return -1
+	return nil
 }
 
 const (
@@ -214,19 +236,28 @@ func (w *writer) writeField(value interface{}, color int) {
 }
 
 func (w *writer) writeValue(value interface{}, color int) {
-	stringVal, ok := value.(string)
-	if !ok {
-		stringVal = fmt.Sprint(value)
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+		if needsQuoting(s) {
+			s = fmt.Sprintf("%q", v)
+		}
+	default:
+		s = fmt.Sprintf("%v", v)
 	}
 	if color != noColor {
-		stringVal = fmt.Sprintf("\x1b[%dm%s\x1b[0m", color, stringVal)
-		w.WriteString(stringVal)
-		return
+		s = fmt.Sprintf("\x1b[%dm%s\x1b[0m", color, s)
 	}
-	if !needsQuoting(stringVal) {
-		w.WriteString(stringVal)
-	} else {
-		w.WriteString(fmt.Sprintf("%q", stringVal))
+	w.WriteString(s)
+}
+
+func (w *writer) writeError(value interface{}) {
+	switch err := value.(type) {
+	case Error:
+		w.WriteString(fmt.Sprintf("[%v]", err.DebugReport()))
+	default:
+		w.WriteString(fmt.Sprintf("[%v]", value))
 	}
 }
 
@@ -236,6 +267,10 @@ func (w *writer) writeKeyValue(key string, value interface{}) {
 	}
 	w.WriteString(key)
 	w.WriteByte(':')
+	if key == log.ErrorKey {
+		w.writeError(value)
+		return
+	}
 	w.writeValue(value, noColor)
 }
 
@@ -252,11 +287,11 @@ func (w *writer) writeMap(m map[string]interface{}) {
 		if key == Component {
 			continue
 		}
-		switch val := m[key].(type) {
+		switch value := m[key].(type) {
 		case log.Fields:
-			w.writeMap(val)
+			w.writeMap(value)
 		default:
-			w.writeKeyValue(key, val)
+			w.writeKeyValue(key, value)
 		}
 	}
 }

--- a/vendor/github.com/gravitational/trace/trace.go
+++ b/vendor/github.com/gravitational/trace/trace.go
@@ -72,6 +72,12 @@ func Unwrap(err error) error {
 	return err
 }
 
+// UserMessager returns a user message associated with the error
+type UserMessager interface {
+	// UserMessage returns the user message associated with the error if any
+	UserMessage() string
+}
+
 // ErrorWrapper wraps another error
 type ErrorWrapper interface {
 	// OrigError returns the wrapped error
@@ -89,7 +95,7 @@ func UserMessage(err error) string {
 	if err == nil {
 		return ""
 	}
-	if wrap, ok := err.(Error); ok {
+	if wrap, ok := err.(UserMessager); ok {
 		return wrap.UserMessage()
 	}
 	return err.Error()
@@ -454,6 +460,7 @@ type Error interface {
 	error
 	ErrorWrapper
 	DebugReporter
+	UserMessager
 
 	// AddMessage adds formatted user-facing message
 	// to the error, depends on the implementation,
@@ -467,9 +474,6 @@ type Error interface {
 
 	// AddFields adds a map of additional fields to the error
 	AddFields(fields map[string]interface{}) *TraceErr
-
-	// UserMessage returns user-friendly error message
-	UserMessage() string
 
 	// GetFields returns any fields that have been added to the error
 	GetFields() map[string]interface{}

--- a/vendor/github.com/gravitational/trace/trace.go
+++ b/vendor/github.com/gravitational/trace/trace.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ limitations under the License.
 package trace
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -40,7 +42,7 @@ func SetDebug(enabled bool) {
 	}
 }
 
-// IsDebug returns true if debug mode is on, false otherwize
+// IsDebug returns true if debug mode is on
 func IsDebug() bool {
 	return atomic.LoadInt32(&debug) == 1
 }
@@ -48,20 +50,38 @@ func IsDebug() bool {
 // Wrap takes the original error and wraps it into the Trace struct
 // memorizing the context of the error.
 func Wrap(err error, args ...interface{}) Error {
+	if err == nil {
+		return nil
+	}
 	if len(args) > 0 {
 		format := args[0]
 		args = args[1:]
 		return WrapWithMessage(err, format, args...)
 	}
-	return wrapWithDepth(err, 2)
+	if traceErr, ok := err.(Error); ok {
+		return traceErr
+	}
+	return newTrace(err, 2)
 }
 
-// Unwrap unwraps error to it's original error
+// Unwrap returns the original error the given error wraps
 func Unwrap(err error) error {
-	if terr, ok := err.(Error); ok {
-		return terr.OrigError()
+	if err, ok := err.(ErrorWrapper); ok {
+		return err.OrigError()
 	}
 	return err
+}
+
+// ErrorWrapper wraps another error
+type ErrorWrapper interface {
+	// OrigError returns the wrapped error
+	OrigError() error
+}
+
+// DebugReporter formats an error for display
+type DebugReporter interface {
+	// DebugReport formats an error for display
+	DebugReport() string
 }
 
 // UserMessage returns user-friendly part of the error
@@ -75,38 +95,57 @@ func UserMessage(err error) string {
 	return err.Error()
 }
 
+// UserMessageWithFields returns user-friendly error with key-pairs as part of the message
+func UserMessageWithFields(err error) string {
+	if err == nil {
+		return ""
+	}
+	if wrap, ok := err.(Error); ok {
+		if len(wrap.GetFields()) == 0 {
+			return wrap.UserMessage()
+		}
+
+		var kvps []string
+		for k, v := range wrap.GetFields() {
+			kvps = append(kvps, fmt.Sprintf("%v=%q", k, v))
+		}
+		return fmt.Sprintf("%v %v", strings.Join(kvps, " "), wrap.UserMessage())
+	}
+	return err.Error()
+}
+
 // DebugReport returns debug report with all known information
 // about the error including stack trace if it was captured
 func DebugReport(err error) string {
 	if err == nil {
 		return ""
 	}
-	if wrap, ok := err.(Error); ok {
-		return wrap.DebugReport()
+	if reporter, ok := err.(DebugReporter); ok {
+		return reporter.DebugReport()
 	}
 	return err.Error()
 }
 
-// WrapWithMessage wraps the original error into Error and adds user message if any
-func WrapWithMessage(err error, message interface{}, args ...interface{}) Error {
-	trace := wrapWithDepth(err, 3)
-	if trace != nil {
-		trace.AddUserMessage(message, args...)
+// GetFields returns any fields that have been added to the error message
+func GetFields(err error) map[string]interface{} {
+	if err == nil {
+		return map[string]interface{}{}
 	}
-	return trace
+	if wrap, ok := err.(Error); ok {
+		return wrap.GetFields()
+	}
+	return map[string]interface{}{}
 }
 
-func wrapWithDepth(err error, depth int) Error {
-	if err == nil {
-		return nil
-	}
+// WrapWithMessage wraps the original error into Error and adds user message if any
+func WrapWithMessage(err error, message interface{}, args ...interface{}) Error {
 	var trace Error
-	if wrapped, ok := err.(Error); ok {
-		trace = wrapped
+	if traceErr, ok := err.(Error); ok {
+		trace = traceErr
 	} else {
-		trace = newTrace(depth+1, err)
+		trace = newTrace(err, 3)
 	}
-
+	trace.AddUserMessage(message, args...)
 	return trace
 }
 
@@ -115,40 +154,65 @@ func wrapWithDepth(err error, depth int) Error {
 // callee, line number and function that simplifies debugging
 func Errorf(format string, args ...interface{}) (err error) {
 	err = fmt.Errorf(format, args...)
-	trace := wrapWithDepth(err, 2)
-	trace.AddUserMessage(format, args...)
-	return trace
+	return newTrace(err, 2)
 }
 
 // Fatalf - If debug is false Fatalf calls Errorf. If debug is
 // true Fatalf calls panic
 func Fatalf(format string, args ...interface{}) error {
 	if IsDebug() {
-		panic(fmt.Sprintf(format, args))
+		panic(fmt.Sprintf(format, args...))
 	} else {
-		return Errorf(format, args)
+		return Errorf(format, args...)
 	}
 }
 
-func newTrace(depth int, err error) *TraceErr {
-	var pc [32]uintptr
-	count := runtime.Callers(depth+1, pc[:])
+func newTrace(err error, depth int) *TraceErr {
+	var buf [32]uintptr
+	n := runtime.Callers(depth+1, buf[:])
+	pcs := buf[:n]
+	frames := runtime.CallersFrames(pcs)
+	cursor := frameCursor{
+		rest: frames,
+		n:    n,
+	}
+	return newTraceFromFrames(cursor, err)
+}
 
-	traces := make(Traces, count)
-	for i := 0; i < count; i++ {
-		fn := runtime.FuncForPC(pc[i])
-		filePath, line := fn.FileLine(pc[i])
-		traces[i] = Trace{
-			Func: fn.Name(),
-			Path: filePath,
-			Line: line,
+func newTraceFromFrames(cursor frameCursor, err error) *TraceErr {
+	traces := make(Traces, 0, cursor.n)
+	if cursor.current != nil {
+		traces = append(traces, frameToTrace(*cursor.current))
+	}
+	for {
+		frame, more := cursor.rest.Next()
+		traces = append(traces, frameToTrace(frame))
+		if !more {
+			break
 		}
 	}
 	return &TraceErr{
-		err,
-		traces,
-		"",
+		Err:    err,
+		Traces: traces,
 	}
+}
+
+func frameToTrace(frame runtime.Frame) Trace {
+	return Trace{
+		Func: frame.Function,
+		Path: frame.File,
+		Line: frame.Line,
+	}
+}
+
+type frameCursor struct {
+	// current specifies the current stack frame.
+	// if omitted, rest contains the complete stack
+	current *runtime.Frame
+	// rest specifies the rest of stack frames to explore
+	rest *runtime.Frames
+	// n specifies the total number of stack frames
+	n int
 }
 
 // Traces is a list of trace entries
@@ -220,46 +284,136 @@ func (t *Trace) String() string {
 	return fmt.Sprintf("%v:%v", file, t.Line)
 }
 
+// MarshalJSON marshals this error as JSON-encoded payload
+func (r *TraceErr) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return nil, nil
+	}
+	type marshalableError TraceErr
+	err := marshalableError(*r)
+	err.Err = &RawTrace{Message: r.Err.Error()}
+	return json.Marshal(err)
+}
+
 // TraceErr contains error message and some additional
 // information about the error origin
 type TraceErr struct {
-	Err     error `json:"error"`
-	Traces  `json:"traces"`
-	Message string `json:"message,omitemtpy"`
+	// Err is the underlying error that TraceErr wraps
+	Err error `json:"error"`
+	// Traces is a slice of stack trace entries for the error
+	Traces `json:"traces,omitempty"`
+	// Message is an optional message that can be wrapped with the original error.
+	//
+	// This field is obsolete, replaced by messages list below.
+	Message string `json:"message,omitempty"`
+	// Messages is a list of user messages added to this error.
+	Messages []string `json:"messages,omitempty"`
+	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
+	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
+// Fields maps arbitrary keys to values inside an error
+type Fields map[string]interface{}
+
+// Error returns the error message this trace describes.
+// Implements error
+func (r *RawTrace) Error() string {
+	return r.Message
+}
+
+// RawTrace describes the error trace on the wire
 type RawTrace struct {
-	Err     json.RawMessage `json:"error"`
-	Traces  `json:"traces"`
-	Message string `json:"message"`
+	// Err specifies the original error
+	Err json.RawMessage `json:"error,omitempty"`
+	// Traces lists the stack traces at the moment the error was recorded
+	Traces `json:"traces,omitempty"`
+	// Message specifies the optional user-facing message
+	Message string `json:"message,omitempty"`
+	// Messages is a list of user messages added to this error.
+	Messages []string `json:"messages,omitempty"`
+	// Fields is a list of key-value-pairs that can be wrapped with the error to give additional context
+	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
 // AddUserMessage adds user-friendly message describing the error nature
-func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) {
+func (e *TraceErr) AddUserMessage(formatArg interface{}, rest ...interface{}) *TraceErr {
 	newMessage := fmt.Sprintf(fmt.Sprintf("%v", formatArg), rest...)
-	if len(e.Message) == 0 {
-		e.Message = newMessage
-	} else {
-		e.Message = strings.Join([]string{e.Message, newMessage}, ", ")
+	e.Messages = append(e.Messages, newMessage)
+	return e
+}
+
+// AddFields adds the given map of fields to the error being reported
+func (e *TraceErr) AddFields(fields map[string]interface{}) *TraceErr {
+	if e.Fields == nil {
+		e.Fields = make(map[string]interface{}, len(fields))
 	}
+	for k, v := range fields {
+		e.Fields[k] = v
+	}
+	return e
+}
+
+// AddField adds a single field to the error wrapper as context for the error
+func (e *TraceErr) AddField(k string, v interface{}) *TraceErr {
+	if e.Fields == nil {
+		e.Fields = make(map[string]interface{}, 1)
+	}
+	e.Fields[k] = v
+	return e
 }
 
 // UserMessage returns user-friendly error message
 func (e *TraceErr) UserMessage() string {
+	if len(e.Messages) > 0 {
+		// Format all collected messages in the reverse order, with each error
+		// on its own line with appropriate indentation so they form a tree and
+		// it's easy to see the cause and effect.
+		var buf bytes.Buffer
+		fmt.Fprintln(&buf, e.Messages[len(e.Messages)-1])
+		index, indent := len(e.Messages)-1, 1
+		for ; index > 0; index, indent = index-1, indent+1 {
+			fmt.Fprintf(&buf, "%v%v\n", strings.Repeat("\t", indent), e.Messages[index-1])
+		}
+		fmt.Fprintf(&buf, "%v%v", strings.Repeat("\t", indent), UserMessage(e.Err))
+		return buf.String()
+	}
 	if e.Message != "" {
+		// For backwards compatibility return the old user message if it's present.
 		return e.Message
 	}
 	return UserMessage(e.Err)
 }
 
-// DebugReport returns develeoper-friendly error report
+// DebugReport returns developer-friendly error report
 func (e *TraceErr) DebugReport() string {
-	return fmt.Sprintf("\nERROR REPORT:\nOriginal Error: %T %v\nStack Trace:\n%v\nUser Message: %v\n", e.Err, e.Err.Error(), e.Traces.String(), e.Message)
+	var buf bytes.Buffer
+	err := reportTemplate.Execute(&buf, errorReport{
+		OrigErrType:    fmt.Sprintf("%T", e.Err),
+		OrigErrMessage: e.Err.Error(),
+		Fields:         e.Fields,
+		StackTrace:     e.Traces.String(),
+		UserMessage:    e.UserMessage(),
+	})
+	if err != nil {
+		return fmt.Sprint("error generating debug report: ", err.Error())
+	}
+	return buf.String()
 }
 
 // Error returns user-friendly error message when not in debug mode
 func (e *TraceErr) Error() string {
 	return e.UserMessage()
+}
+
+func (e *TraceErr) GetFields() map[string]interface{} {
+	return e.Fields
+}
+
+// Unwrap returns the error this TraceErr wraps. The returned error may also
+// wrap another one, Unwrap doesn't recursively get the inner-most error like
+// OrigError does.
+func (e *TraceErr) Unwrap() error {
+	return e.Err
 }
 
 // OrigError returns original wrapped error
@@ -273,9 +427,11 @@ func (e *TraceErr) OrigError() error {
 		if !ok {
 			break
 		}
-		if newerr.OrigError() != err {
-			err = newerr.OrigError()
+		next := newerr.OrigError()
+		if next == nil || next == err {
+			break
 		}
+		err = next
 	}
 	return err
 }
@@ -291,23 +447,32 @@ const maxHops = 50
 
 // Error is an interface that helps to adapt usage of trace in the code
 // When applications define new error types, they can implement the interface
-// So error handlers can use OrigError() to retrieve error from the wrapper
+//
+// Error handlers can use Unwrap() to retrieve error from the wrapper, or
+// errors.Is()/As() to compare it to another value.
 type Error interface {
 	error
-	// OrigError returns original error wrapped in this error
-	OrigError() error
+	ErrorWrapper
+	DebugReporter
+
 	// AddMessage adds formatted user-facing message
 	// to the error, depends on the implementation,
 	// usually works as fmt.Sprintf(formatArg, rest...)
 	// but implementations can choose another way, e.g. treat
 	// arguments as structured args
-	AddUserMessage(formatArg interface{}, rest ...interface{})
+	AddUserMessage(formatArg interface{}, rest ...interface{}) *TraceErr
+
+	// AddField adds additional field information to the error
+	AddField(key string, value interface{}) *TraceErr
+
+	// AddFields adds a map of additional fields to the error
+	AddFields(fields map[string]interface{}) *TraceErr
 
 	// UserMessage returns user-friendly error message
 	UserMessage() string
 
-	// DebugReport returns develeoper-friendly error report
-	DebugReport() string
+	// GetFields returns any fields that have been added to the error
+	GetFields() map[string]interface{}
 }
 
 // NewAggregate creates a new aggregate instance from the specified
@@ -323,7 +488,7 @@ func NewAggregate(errs ...error) error {
 	if len(nonNils) == 0 {
 		return nil
 	}
-	return wrapWithDepth(aggregate(nonNils), 2)
+	return newTrace(aggregate(nonNils), 2)
 }
 
 // NewAggregateFromChannel creates a new aggregate instance from the provided
@@ -382,3 +547,75 @@ func IsAggregate(err error) bool {
 	_, ok := Unwrap(err).(Aggregate)
 	return ok
 }
+
+// wrapProxy wraps the specified error as a new error trace
+func wrapProxy(err error) Error {
+	if err == nil {
+		return nil
+	}
+	return proxyError{
+		// Do not include ReadError in the trace
+		TraceErr: newTrace(err, 3),
+	}
+}
+
+// DebugReport formats the underlying error for display
+// Implements DebugReporter
+func (r proxyError) DebugReport() string {
+	var wrappedErr *TraceErr
+	var ok bool
+	if wrappedErr, ok = r.TraceErr.Err.(*TraceErr); !ok {
+		return DebugReport(r.TraceErr)
+	}
+	var buf bytes.Buffer
+	//nolint:errcheck
+	reportTemplate.Execute(&buf, errorReport{
+		OrigErrType:    fmt.Sprintf("%T", wrappedErr.Err),
+		OrigErrMessage: wrappedErr.Err.Error(),
+		Fields:         wrappedErr.Fields,
+		StackTrace:     wrappedErr.Traces.String(),
+		UserMessage:    wrappedErr.UserMessage(),
+		Caught:         r.TraceErr.Traces.String(),
+	})
+	return buf.String()
+}
+
+// GoString formats this trace object for use with
+// with the "%#v" format string
+func (r proxyError) GoString() string {
+	return r.DebugReport()
+}
+
+// proxyError wraps another error
+type proxyError struct {
+	*TraceErr
+}
+
+type errorReport struct {
+	// OrigErrType specifies the error type as text
+	OrigErrType string
+	// OrigErrMessage specifies the original error's message
+	OrigErrMessage string
+	// Fields lists any additional fields attached to the error
+	Fields map[string]interface{}
+	// StackTrace specifies the call stack
+	StackTrace string
+	// UserMessage is the user-facing message (if any)
+	UserMessage string
+	// Caught optionally specifies the stack trace where the error
+	// has been recorded after coming over the wire
+	Caught string
+}
+
+var reportTemplate = template.Must(template.New("debugReport").Parse(reportTemplateText))
+var reportTemplateText = `
+ERROR REPORT:
+Original Error: {{.OrigErrType}} {{.OrigErrMessage}}
+{{if .Fields}}Fields:
+{{range $key, $value := .Fields}}  {{$key}}: {{$value}}
+{{end}}{{end}}Stack Trace:
+{{.StackTrace}}
+{{if .Caught}}Caught:
+{{.Caught}}
+User Message: {{.UserMessage}}
+{{else}}User Message: {{.UserMessage}}{{end}}`

--- a/vendor/github.com/gravitational/trace/udphook.go
+++ b/vendor/github.com/gravitational/trace/udphook.go
@@ -67,8 +67,8 @@ type Frame struct {
 func (elk *UDPHook) Fire(e *log.Entry) error {
 	// Make a copy to safely modify
 	entry := e.WithFields(nil)
-	if frameNo := findFrame(); frameNo != -1 {
-		t := newTrace(frameNo-1, nil)
+	if cursor := findFrame(); cursor != nil {
+		t := newTraceFromFrames(*cursor, nil)
 		entry.Data[FileField] = t.String()
 		entry.Data[FunctionField] = t.Func()
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,7 +249,7 @@ github.com/gravitational/reporting/types
 # github.com/gravitational/roundtrip v1.0.0
 ## explicit
 github.com/gravitational/roundtrip
-# github.com/gravitational/trace v1.1.12
+# github.com/gravitational/trace v1.1.13
 ## explicit
 github.com/gravitational/trace
 github.com/gravitational/trace/trail

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,7 +249,7 @@ github.com/gravitational/reporting/types
 # github.com/gravitational/roundtrip v1.0.0
 ## explicit
 github.com/gravitational/roundtrip
-# github.com/gravitational/trace v1.1.6
+# github.com/gravitational/trace v1.1.12
 ## explicit
 github.com/gravitational/trace
 github.com/gravitational/trace/trail


### PR DESCRIPTION
Supersedes @awly's [PR](https://github.com/gravitational/teleport/pull/5167).

We were a few versions behind. In particular this versions lets us use
stdlib's `errors.Is/As` to inspect errors.

Fixes the regression with ConnectionProblem not returning the expected user message in `Error` which should also fix the integration failure I've reported for https://github.com/gravitational/teleport/pull/5167.