### PR TITLE
Update Makefile version on master branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=5.0.0-dev
+VERSION=6.0.0-dev
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "5.0.0-dev"
+	Version = "6.0.0-dev"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
We didn't update the version in the `Makefile` on `master` when cutting 5.1.