### PR TITLE
Fix wrongly formatted headers

### DIFF
--- a/docs/3.1/ssh-one-login.md
+++ b/docs/3.1/ssh-one-login.md
@@ -1,4 +1,4 @@
-<h1>SSH Authentication with One Login</h1>
+# SSH Authentication with One Login
 
 This guide will cover how to configure [One Login](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/3.1/ssh-rbac.md
+++ b/docs/3.1/ssh-rbac.md
@@ -1,4 +1,4 @@
-<h1>Role Based Access Control for SSH</h1>
+# Role Based Access Control for SSH
 
 ## Introduction
 

--- a/docs/3.1/ssh-sso.md
+++ b/docs/3.1/ssh-sso.md
@@ -1,4 +1,4 @@
-<h1>Single Sign-On (SSO) for SSH</h1>
+# Single Sign-On (SSO) for SSH
 
 ## Introduction
 

--- a/docs/3.2/ssh-one-login.md
+++ b/docs/3.2/ssh-one-login.md
@@ -1,4 +1,4 @@
-<h1>SSH Authentication with One Login</h1>
+# SSH Authentication with One Login
 
 This guide will cover how to configure [One Login](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/3.2/ssh-rbac.md
+++ b/docs/3.2/ssh-rbac.md
@@ -1,4 +1,4 @@
-<h1>Role Based Access Control for SSH</h1>
+# Role Based Access Control for SSH
 
 ## Introduction
 

--- a/docs/3.2/ssh-sso.md
+++ b/docs/3.2/ssh-sso.md
@@ -1,4 +1,4 @@
-<h1>Single Sign-On (SSO) for SSH</h1>
+# Single Sign-On (SSO) for SSH
 
 ## Introduction
 

--- a/docs/4.0/ssh-one-login.md
+++ b/docs/4.0/ssh-one-login.md
@@ -1,4 +1,4 @@
-<h1>SSH Authentication with OneLogin</h1>
+# SSH Authentication with OneLogin
 
 This guide will cover how to configure [OneLogin](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.0/ssh-rbac.md
+++ b/docs/4.0/ssh-rbac.md
@@ -1,4 +1,4 @@
-<h1>Role Based Access Control for SSH</h1>
+# Role Based Access Control for SSH
 
 ## Introduction
 

--- a/docs/4.0/ssh-sso.md
+++ b/docs/4.0/ssh-sso.md
@@ -1,4 +1,4 @@
-<h1>Single Sign-On (SSO) for SSH</h1>
+# Single Sign-On (SSO) for SSH
 
 ## Introduction
 

--- a/docs/4.1/architecture/teleport-architecture-overview.md
+++ b/docs/4.1/architecture/teleport-architecture-overview.md
@@ -1,4 +1,4 @@
-## Architecture Introduction
+# Architecture Introduction
 
 This guide is for those looking for a deeper understanding of Teleport. If you
 are looking for hands-on instructions on how to set up Teleport for your team,

--- a/docs/4.1/architecture/teleport-nodes.md
+++ b/docs/4.1/architecture/teleport-nodes.md
@@ -1,4 +1,4 @@
-## Teleport Nodes
+# Teleport Nodes
 
 **Table of Contents**
 

--- a/docs/4.1/architecture/teleport-proxy.md
+++ b/docs/4.1/architecture/teleport-proxy.md
@@ -1,4 +1,4 @@
-## The Proxy Service
+# The Proxy Service
 
 **Table of Contents**
 

--- a/docs/4.1/architecture/teleport-users.md
+++ b/docs/4.1/architecture/teleport-users.md
@@ -1,4 +1,4 @@
-## Teleport Users
+# Teleport Users
 
 <!-- TODO: This doc is incomplete, pending addition of Enterprise topics -->
 

--- a/docs/4.1/ssh-one-login.md
+++ b/docs/4.1/ssh-one-login.md
@@ -1,4 +1,4 @@
-<h1>SSH Authentication with OneLogin</h1>
+# SSH Authentication with OneLogin
 
 This guide will cover how to configure [OneLogin](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.2/architecture/teleport-architecture-overview.md
+++ b/docs/4.2/architecture/teleport-architecture-overview.md
@@ -1,4 +1,4 @@
-## Architecture Introduction
+# Architecture Introduction
 
 This guide is for those looking for a deeper understanding of Teleport. If you
 are looking for hands-on instructions on how to set up Teleport for your team,

--- a/docs/4.2/architecture/teleport-nodes.md
+++ b/docs/4.2/architecture/teleport-nodes.md
@@ -1,4 +1,4 @@
-## Teleport Nodes
+# Teleport Nodes
 
 **Table of Contents**
 

--- a/docs/4.2/architecture/teleport-proxy.md
+++ b/docs/4.2/architecture/teleport-proxy.md
@@ -1,4 +1,4 @@
-## The Proxy Service
+# The Proxy Service
 
 **Table of Contents**
 

--- a/docs/4.2/architecture/teleport-users.md
+++ b/docs/4.2/architecture/teleport-users.md
@@ -1,4 +1,4 @@
-## Teleport Users
+# Teleport Users
 
 <!-- TODO: This doc is incomplete, pending addition of Enterprise topics -->
 

--- a/docs/4.2/enterprise/sso/ssh-one-login.md
+++ b/docs/4.2/enterprise/sso/ssh-one-login.md
@@ -1,4 +1,4 @@
-<h1>SSH Authentication with OneLogin</h1>
+# SSH Authentication with OneLogin
 
 This guide will cover how to configure [OneLogin](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role


### PR DESCRIPTION
While working on redesign I fond out that some pages are missing both frontmatter `title` field or use `<h1>` instead of `#` for main header. This PR normalizes all such cases to use `#` everywere.