### PR TITLE
Add teleport-kube-agent chart and remove unwanted charts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -645,7 +645,10 @@ steps:
     commands:
       - mkdir -p /go/chart
       - cd /go/chart
-      - helm package /go/src/github.com/gravitational/teleport/examples/chart/*
+      - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport
+      - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport-kube-agent
+      # copy index.html to root of the S3 bucket
+      - cp /go/src/github.com/gravitational/teleport/examples/chart/index.html /go/chart
       - helm repo index /go/chart
 
   - name: Upload to S3
@@ -3368,6 +3371,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 6285cfb0d24a5bb3204485288e1630a8bc6ad32c49242175e26ebad1d0f04afa
+hmac: 1cd28db0a5bc857517356e9d836f9e106dd2cb25acc0a4988271f36211f36601
 
 ...

--- a/examples/chart/index.html
+++ b/examples/chart/index.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <title>Teleport Helm chart repo</title>
+  </head>
+  <body>
+    <h1>Teleport Helm chart repo</h1>
+    <h3>Add the repo</h3>
+    <pre>helm repo add teleport https://charts.releases.teleport.dev</pre>
+    <h3>Install a chart</h3>
+    <pre><b><a href="https://github.com/gravitational/teleport/tree/master/examples/chart/teleport">teleport:</a></b> helm install [release-name] teleport/teleport</pre>
+    <pre><b><a href="https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-kube-agent">teleport-kube-agent:</a></b>
+    helm install [release-name] teleport/teleport-kube-agent \
+    --create-namespace \
+    --namespace [namespace] \
+    --set proxyAddr=[proxy endpoint] \
+    --set authToken=[auth token] \
+    --set kubeClusterName=[kubernetes cluster name]</pre>
+  </body>
+</html>

--- a/examples/chart/index.html
+++ b/examples/chart/index.html
@@ -7,9 +7,9 @@
     <h3>Add the repo</h3>
     <pre>helm repo add teleport https://charts.releases.teleport.dev</pre>
     <h3>Install a chart</h3>
-    <pre><b><a href="https://github.com/gravitational/teleport/tree/master/examples/chart/teleport">teleport:</a></b> helm install [release-name] teleport/teleport</pre>
+    <pre><b><a href="https://github.com/gravitational/teleport/tree/master/examples/chart/teleport">teleport:</a></b> helm install ${RELEASE_NAME?} teleport/teleport</pre>
     <pre><b><a href="https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-kube-agent">teleport-kube-agent:</a></b>
-    helm install [release-name] teleport/teleport-kube-agent \
+    helm install ${RELEASE_NAME?} teleport/teleport-kube-agent \
     --create-namespace \
     --namespace ${NAMESPACE?} \
     --set proxyAddr=${PROXY_ENDPOINT?} \

--- a/examples/chart/index.html
+++ b/examples/chart/index.html
@@ -11,9 +11,9 @@
     <pre><b><a href="https://github.com/gravitational/teleport/tree/master/examples/chart/teleport-kube-agent">teleport-kube-agent:</a></b>
     helm install [release-name] teleport/teleport-kube-agent \
     --create-namespace \
-    --namespace [namespace] \
-    --set proxyAddr=[proxy endpoint] \
-    --set authToken=[auth token] \
-    --set kubeClusterName=[kubernetes cluster name]</pre>
+    --namespace ${NAMESPACE?} \
+    --set proxyAddr=${PROXY_ENDPOINT?} \
+    --set authToken=${JOIN_TOKEN?} \
+    --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?}</pre>
   </body>
 </html>

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -21,9 +21,9 @@ To install the agent, run:
 $ helm install teleport-kube-agent . \
   --create-namespace \
   --namespace teleport \
-  --set proxyAddr=$PROXY_ENDPOINT \
-  --set authToken=$JOIN_TOKEN \
-  --set kubeClusterName=$KUBERNETES_CLUSTER_NAME
+  --set proxyAddr=${PROXY_ENDPOINT?} \
+  --set authToken=${JOIN_TOKEN?} \
+  --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?}
 ```
 
 Set the values in the above command as appropriate for your setup.


### PR DESCRIPTION
Changes for the Teleport Helm chart repository (https://charts.releases.teleport.dev)

- Explicitly add `teleport` and `teleport-kube-agent`
- Remove `teleport-daemonset` and `teleport-auto-trustedcluster`
- Add index.html file for S3 bucket
- Add error-if-unset placeholder variables (`${NAMESPACE?}`) to example usages

Fixes #5224