### PR TITLE
Backport: Always register access requests against root cluster

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -892,7 +892,12 @@ func executeAccessRequest(cf *CLIConf) error {
 	req.SetRequestReason(cf.RequestReason)
 	fmt.Fprintf(os.Stderr, "Seeking request approval... (id: %s)\n", req.GetName())
 
-	res, err := getRequestResolution(cf, tc, req)
+	var res services.AccessRequest
+	// always create access request against the root cluster
+	err = tc.WithRootClusterClient(cf.Context, func(clt auth.ClientI) error {
+		res, err = getRequestResolution(cf, clt, req)
+		return trace.Wrap(err)
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1593,13 +1598,13 @@ func host(in string) string {
 }
 
 // getRequestResolution registers an access request with the auth server and waits for it to be resolved.
-func getRequestResolution(cf *CLIConf, tc *client.TeleportClient, req services.AccessRequest) (services.AccessRequest, error) {
+func getRequestResolution(cf *CLIConf, clt auth.ClientI, req services.AccessRequest) (services.AccessRequest, error) {
 	// set up request watcher before submitting the request to the admin server
 	// in order to avoid potential race.
 	filter := services.AccessRequestFilter{
-		User: tc.Username,
+		User: req.GetUser(),
 	}
-	watcher, err := tc.NewWatcher(cf.Context, services.Watch{
+	watcher, err := clt.NewWatcher(cf.Context, services.Watch{
 		Name: "await-request-approval",
 		Kinds: []services.WatchKind{
 			services.WatchKind{
@@ -1612,7 +1617,7 @@ func getRequestResolution(cf *CLIConf, tc *client.TeleportClient, req services.A
 		return nil, trace.Wrap(err)
 	}
 	defer watcher.Close()
-	if err := tc.CreateAccessRequest(cf.Context, req); err != nil {
+	if err := clt.CreateAccessRequest(cf.Context, req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 Loop:


### PR DESCRIPTION
Backport of #5226 