### PR TITLE
Refactor API Dependency - lib/backend

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -19,7 +19,6 @@ package client
 import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/backend"
 
 	"github.com/gravitational/trace"
 )
@@ -33,7 +32,7 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 	out := proto.Event{
 		Type: eventType,
 	}
-	if in.Type == backend.OpInit {
+	if in.Type == types.OpInit {
 		return &out, nil
 	}
 	switch r := in.Resource.(type) {
@@ -106,13 +105,13 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 	return &out, nil
 }
 
-func eventTypeToGRPC(in backend.OpType) (proto.Operation, error) {
+func eventTypeToGRPC(in types.OpType) (proto.Operation, error) {
 	switch in {
-	case backend.OpInit:
+	case types.OpInit:
 		return proto.Operation_INIT, nil
-	case backend.OpPut:
+	case types.OpPut:
 		return proto.Operation_PUT, nil
-	case backend.OpDelete:
+	case types.OpDelete:
 		return proto.Operation_DELETE, nil
 	default:
 		return -1, trace.BadParameter("event type %v is not supported", in)
@@ -128,7 +127,7 @@ func EventFromGRPC(in proto.Event) (*types.Event, error) {
 	out := types.Event{
 		Type: eventType,
 	}
-	if eventType == backend.OpInit {
+	if eventType == types.OpInit {
 		return &out, nil
 	}
 	if r := in.GetResourceHeader(); r != nil {
@@ -181,15 +180,15 @@ func EventFromGRPC(in proto.Event) (*types.Event, error) {
 	}
 }
 
-func eventTypeFromGRPC(in proto.Operation) (backend.OpType, error) {
+func eventTypeFromGRPC(in proto.Operation) (types.OpType, error) {
 	switch in {
 	case proto.Operation_INIT:
-		return backend.OpInit, nil
+		return types.OpInit, nil
 	case proto.Operation_PUT:
-		return backend.OpPut, nil
+		return types.OpPut, nil
 	case proto.Operation_DELETE:
-		return backend.OpDelete, nil
+		return types.OpDelete, nil
 	default:
-		return backend.OpInvalid, trace.BadParameter("unsupported operation type: %v", in)
+		return types.OpInvalid, trace.BadParameter("unsupported operation type: %v", in)
 	}
 }

--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/jonboulle/clockwork"
 )
 
@@ -156,40 +157,27 @@ type GetResult struct {
 	Items []Item
 }
 
+// OpType and the OpType constants have been moved to /api/types, and are now imported here
+// for backwards compatibility. These can be removed in a future version.
+// DELETE IN 7.0.0
 // OpType specifies operation type
-type OpType int
+type OpType = types.OpType
 
 const (
 	// OpInvalid is returned for invalid operations
-	OpInvalid OpType = iota - 1
+	OpInvalid = types.OpInvalid
 	// OpInit is returned by the system whenever the system
 	// is initialized, init operation is always sent
 	// as a first event over the channel, so the client
 	// can verify that watch has been established.
-	OpInit
+	OpInit = types.OpInit
 	// OpPut is returned for Put events
-	OpPut
+	OpPut = types.OpPut
 	// OpDelete is returned for Delete events
-	OpDelete
+	OpDelete = types.OpDelete
 	// OpGet is used for tracking, not present in the event stream
-	OpGet
+	OpGet = types.OpGet
 )
-
-// String returns user-friendly description of the operation
-func (o OpType) String() string {
-	switch o {
-	case OpInit:
-		return "Init"
-	case OpPut:
-		return "Put"
-	case OpDelete:
-		return "Delete"
-	case OpGet:
-		return "Get"
-	default:
-		return "unknown"
-	}
-}
 
 // Event is a event containing operation with item
 type Event struct {


### PR DESCRIPTION
The goal of these "Refactor API Dependency" PRs is to remove all possible decencies with the API package, which will reduce the APIs size and possible package incompatibilities for users. This will also make it easier to version the API separately from the rest of Teleport.

Changes:
 - Moved `OpType` type and constant values to `/api/types` to remove the dependency on `lib/backend`.
 - Added type aliases to simplify refactor and allow backwards compatibility - Delete in 7.0

Reference [RFD](https://github.com/gravitational/teleport/pull/4746)