### PR TITLE
Refactor API Dependencies - lib/session

### DIFF
--- a/api/client/auditstreamer.go
+++ b/api/client/auditstreamer.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/session"
 
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
@@ -53,21 +52,21 @@ func (c *Client) createOrResumeAuditStream(ctx context.Context, request proto.Au
 }
 
 // ResumeAuditStream resumes existing audit stream.
-func (c *Client) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (events.Stream, error) {
+func (c *Client) ResumeAuditStream(ctx context.Context, sessionID, uploadID string) (events.Stream, error) {
 	return c.createOrResumeAuditStream(ctx, proto.AuditStreamRequest{
 		Request: &proto.AuditStreamRequest_ResumeStream{
 			ResumeStream: &proto.ResumeStream{
-				SessionID: string(sid),
+				SessionID: sessionID,
 				UploadID:  uploadID,
 			}},
 	})
 }
 
 // CreateAuditStream creates new audit stream.
-func (c *Client) CreateAuditStream(ctx context.Context, sid session.ID) (events.Stream, error) {
+func (c *Client) CreateAuditStream(ctx context.Context, sessionID string) (events.Stream, error) {
 	return c.createOrResumeAuditStream(ctx, proto.AuditStreamRequest{
 		Request: &proto.AuditStreamRequest_CreateStream{
-			CreateStream: &proto.CreateStream{SessionID: string(sid)}},
+			CreateStream: &proto.CreateStream{SessionID: sessionID}},
 	})
 }
 

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -2105,6 +2105,16 @@ func (c *Client) UpsertAppSession(ctx context.Context, session services.WebSessi
 	return trace.NotImplemented(notImplementedMessage)
 }
 
+// ResumeAuditStream resumes existing audit stream.
+func (c *Client) ResumeAuditStream(ctx context.Context, sid session.ID, uploadID string) (events.Stream, error) {
+	return c.APIClient.ResumeAuditStream(ctx, string(sid), uploadID)
+}
+
+// CreateAuditStream creates new audit stream.
+func (c *Client) CreateAuditStream(ctx context.Context, sid session.ID) (events.Stream, error) {
+	return c.APIClient.CreateAuditStream(ctx, string(sid))
+}
+
 // WebService implements features used by Web UI clients
 type WebService interface {
 	// GetWebSessionInfo checks if a web sesion is valid, returns session id in case if


### PR DESCRIPTION
The goal of these "Refactor API Dependency" PRs is to remove all possible decencies with the API package, which will reduce the APIs size and possible package incompatibilities for users. This will also make it easier to version the API separately from the rest of Teleport.

Changes:
- Change api Endpoints `ResumeAuditStream` and `CreateAuditStream` to take a `string` instead of `session.ID`.
- Add `ResumeAuditStream` and `CreateAuditStream` functions to original client which still takes a `session.ID`.

These new functions can now be deprecated in the future without instantly breaking the `CientI` interface.

Reference [RFD](https://github.com/gravitational/teleport/pull/4746)