### PR TITLE
Refactor API Dependencies - clockwork

### DIFF
--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"github.com/pborman/uuid"
 )
 
@@ -277,7 +276,7 @@ func (r *AccessRequestV3) SetExpiry(expiry time.Time) {
 }
 
 // SetTTL sets TTL
-func (r *AccessRequestV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (r *AccessRequestV3) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -275,7 +275,9 @@ func (r *AccessRequestV3) SetExpiry(expiry time.Time) {
 	r.Metadata.SetExpiry(expiry)
 }
 
-// SetTTL sets TTL
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (r *AccessRequestV3) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"github.com/pquerna/otp/totp"
 	"github.com/tstranex/u2f"
 )
@@ -152,7 +151,7 @@ func (c *AuthPreferenceV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using the provided clock.
-func (c *AuthPreferenceV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (c *AuthPreferenceV2) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -151,6 +151,8 @@ func (c *AuthPreferenceV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (c *AuthPreferenceV2) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -542,7 +542,7 @@ func (r *Rotation) String() string {
 }
 
 // CheckAndSetDefaults checks and sets default rotation parameters.
-func (r *Rotation) CheckAndSetDefaults(clock Clock) error {
+func (r *Rotation) CheckAndSetDefaults() error {
 	switch r.Phase {
 	case "", RotationPhaseRollback, RotationPhaseUpdateClients, RotationPhaseUpdateServers:
 	default:

--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // CertAuthority is a host or user certificate authority that
@@ -213,7 +212,7 @@ func (ca *CertAuthorityV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (ca *CertAuthorityV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (ca *CertAuthorityV2) SetTTL(clock Clock, ttl time.Duration) {
 	ca.Metadata.SetTTL(clock, ttl)
 }
 
@@ -543,7 +542,7 @@ func (r *Rotation) String() string {
 }
 
 // CheckAndSetDefaults checks and sets default rotation parameters.
-func (r *Rotation) CheckAndSetDefaults(clock clockwork.Clock) error {
+func (r *Rotation) CheckAndSetDefaults(clock Clock) error {
 	switch r.Phase {
 	case "", RotationPhaseRollback, RotationPhaseUpdateClients, RotationPhaseUpdateServers:
 	default:
@@ -592,7 +591,7 @@ func (r *Rotation) Merge(src proto.Message) {
 
 // GenerateSchedule generates schedule based on the time period, using
 // even time periods between rotation phases.
-func GenerateSchedule(clock clockwork.Clock, gracePeriod time.Duration) (*RotationSchedule, error) {
+func GenerateSchedule(clock Clock, gracePeriod time.Duration) (*RotationSchedule, error) {
 	if gracePeriod <= 0 {
 		return nil, trace.BadParameter("invalid grace period %q, provide value > 0", gracePeriod)
 	}
@@ -604,7 +603,7 @@ func GenerateSchedule(clock clockwork.Clock, gracePeriod time.Duration) (*Rotati
 }
 
 // CheckAndSetDefaults checks and sets default values of the rotation schedule.
-func (s *RotationSchedule) CheckAndSetDefaults(clock clockwork.Clock) error {
+func (s *RotationSchedule) CheckAndSetDefaults(clock Clock) error {
 	if s.UpdateServers.IsZero() {
 		return trace.BadParameter("phase %q has no time switch scheduled", RotationPhaseUpdateServers)
 	}

--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -598,9 +598,9 @@ func GenerateSchedule(now time.Time, gracePeriod time.Duration) (*RotationSchedu
 		return nil, trace.BadParameter("invalid grace period %q, provide value > 0", gracePeriod)
 	}
 	return &RotationSchedule{
-		UpdateClients: now.UTC().Add(gracePeriod / 3).UTC(),
-		UpdateServers: now.UTC().Add((gracePeriod * 2) / 3).UTC(),
-		Standby:       now.UTC().Add(gracePeriod).UTC(),
+		UpdateClients: now.UTC().Add(gracePeriod / 3),
+		UpdateServers: now.UTC().Add((gracePeriod * 2) / 3),
+		Standby:       now.UTC().Add(gracePeriod),
 	}, nil
 }
 

--- a/api/types/clusterconfig.go
+++ b/api/types/clusterconfig.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // ClusterConfig defines cluster level configuration. This is a configuration
@@ -252,7 +251,7 @@ func (c *ClusterConfigV3) SetExpiry(expires time.Time) {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (c *ClusterConfigV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (c *ClusterConfigV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/clusterconfig.go
+++ b/api/types/clusterconfig.go
@@ -250,7 +250,9 @@ func (c *ClusterConfigV3) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (c *ClusterConfigV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/clustername.go
+++ b/api/types/clustername.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // ClusterName defines the name of the cluster. This is a configuration
@@ -111,7 +110,7 @@ func (c *ClusterNameV2) SetExpiry(expires time.Time) {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (c *ClusterNameV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (c *ClusterNameV2) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/clustername.go
+++ b/api/types/clustername.go
@@ -109,7 +109,9 @@ func (c *ClusterNameV2) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (c *ClusterNameV2) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/databaseserver.go
+++ b/api/types/databaseserver.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // DatabaseServer represents a database access server.
@@ -157,7 +156,7 @@ func (s *DatabaseServerV3) Expiry() time.Time {
 }
 
 // SetTTL sets the resource TTL.
-func (s *DatabaseServerV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (s *DatabaseServerV3) SetTTL(clock Clock, ttl time.Duration) {
 	s.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/databaseserver.go
+++ b/api/types/databaseserver.go
@@ -155,7 +155,9 @@ func (s *DatabaseServerV3) Expiry() time.Time {
 	return s.Metadata.Expiry()
 }
 
-// SetTTL sets the resource TTL.
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (s *DatabaseServerV3) SetTTL(clock Clock, ttl time.Duration) {
 	s.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/github.go
+++ b/api/types/github.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // GithubConnector defines an interface for a Github OAuth2 connector
@@ -174,7 +173,7 @@ func (c *GithubConnectorV3) SetExpiry(expires time.Time) {
 }
 
 // SetTTL sets the connector TTL
-func (c *GithubConnectorV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (c *GithubConnectorV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/github.go
+++ b/api/types/github.go
@@ -172,7 +172,9 @@ func (c *GithubConnectorV3) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets the connector TTL
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (c *GithubConnectorV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/license.go
+++ b/api/types/license.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // License defines teleport License Information
@@ -167,7 +166,7 @@ func (c *LicenseV3) SetExpiry(t time.Time) {
 }
 
 // SetTTL sets Expires header using current clock
-func (c *LicenseV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (c *LicenseV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/license.go
+++ b/api/types/license.go
@@ -165,7 +165,9 @@ func (c *LicenseV3) SetExpiry(t time.Time) {
 	c.Metadata.SetExpiry(t)
 }
 
-// SetTTL sets Expires header using current clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (c *LicenseV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/namespace.go
+++ b/api/types/namespace.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // NewNamespace returns new namespace
@@ -102,7 +101,7 @@ func (n *Namespace) SetExpiry(expires time.Time) {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (n *Namespace) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (n *Namespace) SetTTL(clock Clock, ttl time.Duration) {
 	n.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/namespace.go
+++ b/api/types/namespace.go
@@ -100,7 +100,9 @@ func (n *Namespace) SetExpiry(expires time.Time) {
 	n.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (n *Namespace) SetTTL(clock Clock, ttl time.Duration) {
 	n.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/coreos/go-oidc/jose"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // OIDCConnector specifies configuration for Open ID Connect compatible external
@@ -214,7 +213,7 @@ func (o *OIDCConnectorV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (o *OIDCConnectorV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (o *OIDCConnectorV2) SetTTL(clock Clock, ttl time.Duration) {
 	o.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -212,7 +212,9 @@ func (o *OIDCConnectorV2) Expiry() time.Time {
 	return o.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (o *OIDCConnectorV2) SetTTL(clock Clock, ttl time.Duration) {
 	o.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/plugin_data.go
+++ b/api/types/plugin_data.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // PluginData is used by plugins to store per-resource state.  An instance of PluginData
@@ -107,7 +106,7 @@ func (r *PluginDataV3) SetExpiry(expiry time.Time) {
 }
 
 // SetTTL sets the resource time to live
-func (r *PluginDataV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (r *PluginDataV3) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/plugin_data.go
+++ b/api/types/plugin_data.go
@@ -105,7 +105,9 @@ func (r *PluginDataV3) SetExpiry(expiry time.Time) {
 	r.Metadata.SetExpiry(expiry)
 }
 
-// SetTTL sets the resource time to live
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (r *PluginDataV3) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // Provisioner governs adding new nodes to the cluster
@@ -188,7 +187,7 @@ func (p *ProvisionTokenV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (p *ProvisionTokenV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (p *ProvisionTokenV2) SetTTL(clock Clock, ttl time.Duration) {
 	p.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -186,7 +186,9 @@ func (p *ProvisionTokenV2) Expiry() time.Time {
 	return p.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (p *ProvisionTokenV2) SetTTL(clock Clock, ttl time.Duration) {
 	p.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/remotecluster.go
+++ b/api/types/remotecluster.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // RemoteCluster represents a remote cluster that has connected via reverse tunnel
@@ -137,7 +136,7 @@ func (c *RemoteClusterV3) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (c *RemoteClusterV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (c *RemoteClusterV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/remotecluster.go
+++ b/api/types/remotecluster.go
@@ -135,7 +135,9 @@ func (c *RemoteClusterV3) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (c *RemoteClusterV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/resetpasswordtoken.go
+++ b/api/types/resetpasswordtoken.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // ResetPasswordToken represents a temporary token used to reset passwords
@@ -110,7 +109,7 @@ func (u *ResetPasswordTokenV3) SetExpiry(t time.Time) {
 }
 
 // SetTTL sets Expires header using current clock
-func (u *ResetPasswordTokenV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (u *ResetPasswordTokenV3) SetTTL(clock Clock, ttl time.Duration) {
 	u.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/resetpasswordtoken.go
+++ b/api/types/resetpasswordtoken.go
@@ -108,7 +108,9 @@ func (u *ResetPasswordTokenV3) SetExpiry(t time.Time) {
 	u.Metadata.SetExpiry(t)
 }
 
-// SetTTL sets Expires header using current clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (u *ResetPasswordTokenV3) SetTTL(clock Clock, ttl time.Duration) {
 	u.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/resetpasswordtokensecrets.go
+++ b/api/types/resetpasswordtokensecrets.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // ResetPasswordTokenSecrets contains token secrets
@@ -110,7 +109,7 @@ func (u *ResetPasswordTokenSecretsV3) SetExpiry(t time.Time) {
 }
 
 // SetTTL sets Expires header using current clock
-func (u *ResetPasswordTokenSecretsV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (u *ResetPasswordTokenSecretsV3) SetTTL(clock Clock, ttl time.Duration) {
 	u.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/resetpasswordtokensecrets.go
+++ b/api/types/resetpasswordtokensecrets.go
@@ -108,7 +108,9 @@ func (u *ResetPasswordTokenSecretsV3) SetExpiry(t time.Time) {
 	u.Metadata.SetExpiry(t)
 }
 
-// SetTTL sets Expires header using current clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (u *ResetPasswordTokenSecretsV3) SetTTL(clock Clock, ttl time.Duration) {
 	u.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // Resource represents common properties for all resources.
@@ -50,7 +49,7 @@ type Resource interface {
 	// SetExpiry sets object expiry
 	SetExpiry(time.Time)
 	// SetTTL sets Expires header using current clock
-	SetTTL(clock clockwork.Clock, ttl time.Duration)
+	SetTTL(clock Clock, ttl time.Duration)
 	// GetMetadata returns object metadata
 	GetMetadata() Metadata
 	// GetResourceID returns resource ID
@@ -67,6 +66,11 @@ type ResourceWithSecrets interface {
 	// has had all secrets removed.  If the current resource has
 	// already had its secrets removed, this may be a no-op.
 	WithoutSecrets() Resource
+}
+
+// Clock is used to track TTL of resources
+type Clock interface {
+	Now() time.Time
 }
 
 // GetVersion returns resource version
@@ -105,7 +109,7 @@ func (h *ResourceHeader) SetExpiry(t time.Time) {
 }
 
 // SetTTL sets Expires header using current clock
-func (h *ResourceHeader) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (h *ResourceHeader) SetTTL(clock Clock, ttl time.Duration) {
 	h.Metadata.SetTTL(clock, ttl)
 }
 
@@ -168,7 +172,7 @@ func (m *Metadata) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (m *Metadata) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (m *Metadata) SetTTL(clock Clock, ttl time.Duration) {
 	expireTime := clock.Now().UTC().Add(ttl)
 	m.Expires = &expireTime
 }

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -48,7 +48,9 @@ type Resource interface {
 	Expiry() time.Time
 	// SetExpiry sets object expiry
 	SetExpiry(time.Time)
-	// SetTTL sets Expires header using current clock
+	// SetTTL sets Expires header using the provided clock.
+	// Use SetExpiry instead.
+	// DELETE IN 7.0.0
 	SetTTL(clock Clock, ttl time.Duration)
 	// GetMetadata returns object metadata
 	GetMetadata() Metadata
@@ -108,7 +110,9 @@ func (h *ResourceHeader) SetExpiry(t time.Time) {
 	h.Metadata.SetExpiry(t)
 }
 
-// SetTTL sets Expires header using current clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (h *ResourceHeader) SetTTL(clock Clock, ttl time.Duration) {
 	h.Metadata.SetTTL(clock, ttl)
 }
@@ -171,7 +175,9 @@ func (m *Metadata) Expiry() time.Time {
 	return *m.Expires
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (m *Metadata) SetTTL(clock Clock, ttl time.Duration) {
 	expireTime := clock.Now().UTC().Add(ttl)
 	m.Expires = &expireTime

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -70,7 +70,9 @@ type ResourceWithSecrets interface {
 	WithoutSecrets() Resource
 }
 
-// Clock is used to track TTL of resources
+// Clock is used to track TTL of resources.
+// This is only used in SetTTL which is deprecated.
+// DELETE IN 7.0.0
 type Clock interface {
 	Now() time.Time
 }

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -225,7 +225,9 @@ func (r *RoleV3) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }
 
-// SetTTL sets TTL header using realtime clock.
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (r *RoleV3) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"github.com/vulcand/predicate"
 )
 
@@ -227,7 +226,7 @@ func (r *RoleV3) Expiry() time.Time {
 }
 
 // SetTTL sets TTL header using realtime clock.
-func (r *RoleV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (r *RoleV3) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -309,7 +309,7 @@ func (o *SAMLConnectorV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (o *SAMLConnectorV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (o *SAMLConnectorV2) SetTTL(clock Clock, ttl time.Duration) {
 	o.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -308,7 +308,9 @@ func (o *SAMLConnectorV2) Expiry() time.Time {
 	return o.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (o *SAMLConnectorV2) SetTTL(clock Clock, ttl time.Duration) {
 	o.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/semaphore.go
+++ b/api/types/semaphore.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // SemaphoreKindConnection is the semaphore kind used by
@@ -265,7 +264,7 @@ func (c *SemaphoreV3) SetExpiry(expires time.Time) {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (c *SemaphoreV3) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (c *SemaphoreV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/semaphore.go
+++ b/api/types/semaphore.go
@@ -263,7 +263,9 @@ func (c *SemaphoreV3) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (c *SemaphoreV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // Server represents a Node, Proxy or Auth server in a Teleport cluster
@@ -152,7 +151,7 @@ func (s *ServerV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (s *ServerV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (s *ServerV2) SetTTL(clock Clock, ttl time.Duration) {
 	s.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -150,7 +150,9 @@ func (s *ServerV2) Expiry() time.Time {
 	return s.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (s *ServerV2) SetTTL(clock Clock, ttl time.Duration) {
 	s.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/session.go
+++ b/api/types/session.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // WebSession stores key and value used to authenticate with SSH
@@ -127,7 +126,7 @@ func (ws *WebSessionV2) SetExpiry(expiry time.Time) {
 }
 
 // SetTTL Sets resource TTL
-func (ws *WebSessionV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (ws *WebSessionV2) SetTTL(clock Clock, ttl time.Duration) {
 	ws.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/session.go
+++ b/api/types/session.go
@@ -125,7 +125,9 @@ func (ws *WebSessionV2) SetExpiry(expiry time.Time) {
 	ws.Metadata.SetExpiry(expiry)
 }
 
-// SetTTL Sets resource TTL
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (ws *WebSessionV2) SetTTL(clock Clock, ttl time.Duration) {
 	ws.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/statictokens.go
+++ b/api/types/statictokens.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // StaticTokens define a list of static []ProvisionToken used to provision a
@@ -126,7 +125,7 @@ func (c *StaticTokensV2) SetExpiry(expires time.Time) {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (c *StaticTokensV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (c *StaticTokensV2) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/statictokens.go
+++ b/api/types/statictokens.go
@@ -124,7 +124,9 @@ func (c *StaticTokensV2) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (c *StaticTokensV2) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/trustedcluster.go
+++ b/api/types/trustedcluster.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // TrustedCluster holds information needed for a cluster that can not be directly
@@ -209,7 +208,7 @@ func (c *TrustedClusterV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (c *TrustedClusterV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (c *TrustedClusterV2) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/trustedcluster.go
+++ b/api/types/trustedcluster.go
@@ -207,7 +207,9 @@ func (c *TrustedClusterV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (c *TrustedClusterV2) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/tunnel.go
+++ b/api/types/tunnel.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // ReverseTunnel is SSH reverse tunnel established between a local Proxy
@@ -113,7 +112,7 @@ func (r *ReverseTunnelV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (r *ReverseTunnelV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (r *ReverseTunnelV2) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/tunnel.go
+++ b/api/types/tunnel.go
@@ -111,7 +111,9 @@ func (r *ReverseTunnelV2) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (r *ReverseTunnelV2) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/tunnelconn.go
+++ b/api/types/tunnelconn.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // TunnelConnection is SSH reverse tunnel connection
@@ -132,7 +131,7 @@ func (r *TunnelConnectionV2) Expiry() time.Time {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (r *TunnelConnectionV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (r *TunnelConnectionV2) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/tunnelconn.go
+++ b/api/types/tunnelconn.go
@@ -130,7 +130,9 @@ func (r *TunnelConnectionV2) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (r *TunnelConnectionV2) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
 
 // User represents teleport embedded user or external user
@@ -133,7 +132,7 @@ func (u *UserV2) SetExpiry(expires time.Time) {
 }
 
 // SetTTL sets Expires header using realtime clock
-func (u *UserV2) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (u *UserV2) SetTTL(clock Clock, ttl time.Duration) {
 	u.Metadata.SetTTL(clock, ttl)
 }
 

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -131,7 +131,9 @@ func (u *UserV2) SetExpiry(expires time.Time) {
 	u.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using realtime clock
+// SetTTL sets Expires header using the provided clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (u *UserV2) SetTTL(clock Clock, ttl time.Duration) {
 	u.Metadata.SetTTL(clock, ttl)
 }

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -346,7 +346,7 @@ func (s *APIServer) upsertServer(auth services.Presence, role teleport.Role, r *
 	// on the socket, but keep the original port:
 	server.SetAddr(utils.ReplaceLocalhost(server.GetAddr(), r.RemoteAddr))
 	if req.TTL != 0 {
-		server.SetTTL(s, req.TTL)
+		server.SetExpiry(s.Now().UTC().Add(req.TTL))
 	}
 	switch role {
 	case teleport.RoleNode:
@@ -549,7 +549,7 @@ func (s *APIServer) upsertReverseTunnel(auth ClientI, w http.ResponseWriter, r *
 		return nil, trace.Wrap(err)
 	}
 	if req.TTL != 0 {
-		tun.SetTTL(s, req.TTL)
+		tun.SetExpiry(s.Now().UTC().Add(req.TTL))
 	}
 	if err := auth.UpsertReverseTunnel(tun); err != nil {
 		return nil, trace.Wrap(err)
@@ -1038,7 +1038,7 @@ func (s *APIServer) upsertCertAuthority(auth ClientI, w http.ResponseWriter, r *
 		return nil, trace.Wrap(err)
 	}
 	if req.TTL != 0 {
-		ca.SetTTL(s, req.TTL)
+		ca.SetExpiry(s.Now().UTC().Add(req.TTL))
 	}
 	if err = services.ValidateCertAuthority(ca); err != nil {
 		return nil, trace.Wrap(err)
@@ -1265,7 +1265,7 @@ func (s *APIServer) upsertOIDCConnector(auth ClientI, w http.ResponseWriter, r *
 		return nil, trace.Wrap(err)
 	}
 	if req.TTL != 0 {
-		connector.SetTTL(s, req.TTL)
+		connector.SetExpiry(s.Now().UTC().Add(req.TTL))
 	}
 	err = auth.UpsertOIDCConnector(r.Context(), connector)
 	if err != nil {

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -96,12 +96,12 @@ func (r *RotateRequest) CheckAndSetDefaults(clock clockwork.Clock) error {
 	}
 	if r.Schedule == nil {
 		var err error
-		r.Schedule, err = services.GenerateSchedule(clock, *r.GracePeriod)
+		r.Schedule, err = services.GenerateSchedule(clock.Now(), *r.GracePeriod)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	} else {
-		if err := r.Schedule.CheckAndSetDefaults(clock); err != nil {
+		if err := r.Schedule.CheckAndSetDefaults(clock.Now()); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -696,7 +696,7 @@ func (c *Cache) setTTL(r services.Resource) {
 		return
 	}
 	// set max TTL on the resources
-	r.SetTTL(c.Clock, c.PreferRecent.MaxTTL)
+	r.SetExpiry(c.Clock.Now().UTC().Add(c.PreferRecent.MaxTTL))
 }
 
 func (c *Cache) notify(ctx context.Context, event Event) {

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -233,6 +233,6 @@ func (t *TLSServer) GetServerInfo() (services.Resource, error) {
 			KubernetesClusters: t.fwd.kubeClusters(),
 		},
 	}
-	srv.SetTTL(t.Clock, defaults.ServerAnnounceTTL)
+	srv.SetExpiry(t.Clock.Now().UTC().Add(defaults.ServerAnnounceTTL))
 	return srv, nil
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1331,7 +1331,7 @@ func (process *TeleportProcess) initAuthService() error {
 			} else {
 				srv.Spec.Rotation = state.Spec.Rotation
 			}
-			srv.SetTTL(process.Clock, defaults.ServerAnnounceTTL)
+			srv.SetExpiry(process.Clock.Now().UTC().Add(defaults.ServerAnnounceTTL))
 			return &srv, nil
 		},
 		KeepAlivePeriod: defaults.ServerKeepAliveTTL,

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -171,7 +171,7 @@ func TestDatabaseServersCRUD(t *testing.T) {
 	require.Equal(t, 0, len(out))
 
 	// Upsert server with TTL.
-	server.SetTTL(clock, time.Hour)
+	server.SetExpiry(clock.Now().UTC().Add(time.Hour))
 	lease, err = presence.UpsertDatabaseServer(ctx, server)
 	require.NoError(t, err)
 	require.Equal(t, &types.KeepAlive{

--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -43,7 +43,7 @@ func (s *ProvisioningService) UpsertToken(p services.ProvisionToken) error {
 		return trace.Wrap(err)
 	}
 	if p.Expiry().IsZero() || p.Expiry().Sub(s.Clock().Now().UTC()) < time.Second {
-		p.SetTTL(s.Clock(), defaults.ProvisioningTokenTTL)
+		p.SetExpiry(s.Clock().Now().UTC().Add(defaults.ProvisioningTokenTTL))
 	}
 	data, err := services.MarshalProvisionToken(p)
 	if err != nil {

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 
 	"github.com/gravitational/trace"
@@ -282,7 +283,7 @@ func (r *EmptyResource) Expiry() time.Time {
 }
 
 // SetTTL sets TTL header using realtime clock.
-func (r *EmptyResource) SetTTL(clock Clock, ttl time.Duration) {
+func (r *EmptyResource) SetTTL(clock types.Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }
 

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
 	"github.com/vulcand/predicate"
 	"github.com/vulcand/predicate/builder"
@@ -283,7 +282,7 @@ func (r *EmptyResource) Expiry() time.Time {
 }
 
 // SetTTL sets TTL header using realtime clock.
-func (r *EmptyResource) SetTTL(clock clockwork.Clock, ttl time.Duration) {
+func (r *EmptyResource) SetTTL(clock Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }
 

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -283,6 +283,8 @@ func (r *EmptyResource) Expiry() time.Time {
 }
 
 // SetTTL sets TTL header using realtime clock.
+// Use SetExpiry instead.
+// DELETE IN 7.0.0
 func (r *EmptyResource) SetTTL(clock types.Clock, ttl time.Duration) {
 	r.Metadata.SetTTL(clock, ttl)
 }

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -244,7 +244,7 @@ func (s *Server) GetServerInfo() (services.Resource, error) {
 	s.server.SetApps(apps)
 
 	// Update the TTL.
-	s.server.SetTTL(s.c.Clock, defaults.ServerAnnounceTTL)
+	s.server.SetExpiry(s.c.Clock.Now().UTC().Add(defaults.ServerAnnounceTTL))
 
 	// Update rotation state.
 	rotation, err := s.c.GetRotation(teleport.RoleApp)

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -239,7 +239,7 @@ func (s *Server) getServerInfoFunc(server types.DatabaseServer) func() (services
 			}
 		}
 		// Update TTL.
-		server.SetTTL(s.cfg.Clock, defaults.ServerAnnounceTTL)
+		server.SetExpiry(s.cfg.Clock.Now().UTC().Add(defaults.ServerAnnounceTTL))
 		// Make sure to return a new object, because it gets cached by
 		// heartbeat and will always compare as equal otherwise.
 		return server.Copy(), nil

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -115,7 +115,7 @@ func TestHeartbeatKeepAlive(t *testing.T) {
 				ServerTTL:       600 * time.Second,
 				Clock:           clock,
 				GetServerInfo: func() (services.Resource, error) {
-					server.SetTTL(clock, defaults.ServerAnnounceTTL)
+					server.SetExpiry(clock.Now().UTC().Add(defaults.ServerAnnounceTTL))
 					return server, nil
 				},
 			})
@@ -232,7 +232,7 @@ func TestHeartbeatAnnounce(t *testing.T) {
 							Hostname: "2",
 						},
 					}
-					srv.SetTTL(clock, defaults.ServerAnnounceTTL)
+					srv.SetExpiry(clock.Now().UTC().Add(defaults.ServerAnnounceTTL))
 					return srv, nil
 				},
 			})

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -732,7 +732,7 @@ func (s *Server) getServerInfo() (services.Resource, error) {
 			server.SetRotation(*rotation)
 		}
 	}
-	server.SetTTL(s.clock, defaults.ServerAnnounceTTL)
+	server.SetExpiry(s.clock.Now().UTC().Add(defaults.ServerAnnounceTTL))
 	server.SetPublicAddr(s.proxyPublicAddr.String())
 	return server, nil
 }


### PR DESCRIPTION
The goal of these "Refactor API Dependency" PRs is to remove all possible decencies with the API package, which will reduce the APIs size and possible package incompatibilities for users. This will also make it easier to version the API separately from the rest of Teleport.

### Changes
- Add a new `Clock` interface to use in `SetTTL` methods instead of `clockwork.Clock`.
- Replace other uses of `clockwork.Clock` with `time.Time` in `GenerateSchedule` and `RotationSchedule.CheckAndSetDefaults`.
- Removed unused `clock` from `Rotation.CheckAndSetDefaults`.

### Deprecation Note
- `SetTTL` and the new `Clock` interface are now deprecated, and `SetExpiry` should be used instead.

### Reference 
[RFD](https://github.com/gravitational/teleport/pull/4746)