### PR TITLE
Use fake clock consistently in units tests.

### DIFF
--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -90,7 +90,7 @@ type CertAuthority interface {
 	// GetTLSKeyPairs returns first PEM encoded TLS cert
 	GetTLSKeyPairs() []TLSKeyPair
 	// JWTSigner returns the active JWT key used to sign tokens.
-	JWTSigner() (*jwt.Key, error)
+	JWTSigner(jwt.Config) (*jwt.Key, error)
 	// GetJWTKeyPairs gets all JWT key pairs.
 	GetJWTKeyPairs() []JWTKeyPair
 	// SetJWTKeyPairs sets all JWT key pairs.
@@ -221,7 +221,7 @@ func (ca *CertAuthorityV2) GetTLSKeyPairs() []TLSKeyPair {
 }
 
 // JWTSigner returns the active JWT key used to sign tokens.
-func (ca *CertAuthorityV2) JWTSigner() (*jwt.Key, error) {
+func (ca *CertAuthorityV2) JWTSigner(config jwt.Config) (*jwt.Key, error) {
 	if len(ca.Spec.JWTKeyPairs) == 0 {
 		return nil, trace.BadParameter("no JWT keypairs found")
 	}
@@ -229,11 +229,10 @@ func (ca *CertAuthorityV2) JWTSigner() (*jwt.Key, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	key, err := jwt.New(&jwt.Config{
-		Algorithm:   defaults.ApplicationTokenAlgorithm,
-		ClusterName: ca.Spec.ClusterName,
-		PrivateKey:  privateKey,
-	})
+	config.Algorithm = defaults.ApplicationTokenAlgorithm
+	config.ClusterName = ca.Spec.ClusterName
+	config.PrivateKey = privateKey
+	key, err := jwt.New(&config)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/iovisor/gobpf v0.0.1
 	github.com/johannesboyne/gofakes3 v0.0.0-20191228161223-9aee1c78a252
-	github.com/jonboulle/clockwork v0.2.1
+	github.com/jonboulle/clockwork v0.2.2
 	github.com/json-iterator/go v1.1.10
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ github.com/johannesboyne/gofakes3 v0.0.0-20191228161223-9aee1c78a252/go.mod h1:c
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0 h1:J2SLSdy7HgElq8ekSl2Mxh6vrRNFxqbXGenYH2I02Vs=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
-github.com/jonboulle/clockwork v0.2.1 h1:S/EaQvW6FpWMYAvYvY+OBDvpaM+izu0oiwo5y0MH7U0=
-github.com/jonboulle/clockwork v0.2.1/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -49,12 +49,12 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/wrappers"
-	"github.com/pborman/uuid"
 
 	"github.com/coreos/go-oidc/oauth2"
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/pborman/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	saml2 "github.com/russellhaering/gosaml2"
 	"github.com/tstranex/u2f"
@@ -1840,6 +1840,13 @@ func (a *Server) GetAppServers(ctx context.Context, namespace string, opts ...se
 // GetAppSession is a part of the auth.AccessPoint implementation.
 func (a *Server) GetAppSession(ctx context.Context, req services.GetAppSessionRequest) (services.WebSession, error) {
 	return a.GetCache().GetAppSession(ctx, req)
+}
+
+// WithClock is a functional server option that sets the server's clock
+func WithClock(clock clockwork.Clock) func(*Server) {
+	return func(s *Server) {
+		s.clock = clock
+	}
 }
 
 // authKeepAliver is a keep aliver using auth server directly

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -160,7 +160,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 
 	srv.AuthServer, err = NewServer(&InitConfig{
 		Backend:                srv.Backend,
-		Authority:              authority.NewWithConfig(cfg.Clock),
+		Authority:              authority.NewWithClock(cfg.Clock),
 		Access:                 access,
 		Identity:               identity,
 		AuditLog:               srv.AuditLog,

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -19,7 +19,6 @@ package auth
 import (
 	"context"
 	"crypto/x509"
-	"time"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
@@ -30,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 )
 
 // LocalRegister is used to generate host keys when a node or proxy is running
@@ -92,10 +92,16 @@ type RegisterParams struct {
 	CAPath string
 	// GetHostCredentials is a client that can fetch host credentials.
 	GetHostCredentials HostCredentials
-	// Time specifies the time as number of seconds since epoch to use in
-	// client for verifying TLS certificates.
-	// If unspecified, time.Now() will be used
-	Time func() time.Time
+	// Clock specifies the time provider. Will be used to override the time anchor
+	// for TLS certificate verification.
+	// Defaults to real clock if unspecified
+	Clock clockwork.Clock
+}
+
+func (r *RegisterParams) setDefaults() {
+	if r.Clock == nil {
+		r.Clock = clockwork.NewRealClock()
+	}
 }
 
 // CredGetter is an interface for a client that can be used to get host
@@ -108,6 +114,7 @@ type HostCredentials func(context.Context, string, bool, RegisterUsingTokenReque
 // tokens to prove a valid auth server was used to issue the joining request
 // as well as a method for the node to validate the auth server.
 func Register(params RegisterParams) (*Identity, error) {
+	params.setDefaults()
 	// Read in the token. The token can either be passed in or come from a file
 	// on disk.
 	token, err := utils.ReadToken(params.Token)
@@ -224,7 +231,7 @@ func registerThroughAuth(token string, params RegisterParams) (*Identity, error)
 // Server it is connecting to.
 func insecureRegisterClient(params RegisterParams) (*Client, error) {
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
-	tlsConfig.Time = params.Time
+	tlsConfig.Time = params.Clock.Now
 
 	cert, err := readCA(params)
 	if err != nil && !trace.IsNotFound(err) {
@@ -281,7 +288,7 @@ func pinRegisterClient(params RegisterParams) (*Client, error) {
 	// an attacker were to MITM this connection the CA pin will not match below.
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
 	tlsConfig.InsecureSkipVerify = true
-	tlsConfig.Time = params.Time
+	tlsConfig.Time = params.Clock.Now
 	authClient, err := NewClient(client.Config{Addrs: utils.NetAddrsToStrings(params.Servers), TLS: tlsConfig})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -312,7 +319,7 @@ func pinRegisterClient(params RegisterParams) (*Client, error) {
 	// Create another client, but this time with the CA provided to validate
 	// that the Auth Server was issued a certificate by the same CA.
 	tlsConfig = utils.TLSConfig(params.CipherSuites)
-	tlsConfig.Time = params.Time
+	tlsConfig.Time = params.Clock.Now
 	certPool := x509.NewCertPool()
 	certPool.AddCert(tlsCA)
 	tlsConfig.RootCAs = certPool

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -497,13 +497,15 @@ func startNewRotation(req rotationReq, ca services.CertAuthority) error {
 		sshPublicKey = ssh.MarshalAuthorizedKey(signer.PublicKey())
 		sshPrivateKey = req.privateKey
 
-		tlsPrivateKey, tlsPublicKey, err = tlsca.GenerateSelfSignedCAWithPrivateKey(rsaKey.(*rsa.PrivateKey), pkix.Name{
-			CommonName:   ca.GetClusterName(),
-			Organization: []string{ca.GetClusterName()},
-		}, nil, defaults.CATTL)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+		tlsPrivateKey, tlsPublicKey, err = tlsca.GenerateSelfSignedCAWithConfig(tlsca.GenerateCAConfig{
+			PrivateKey: rsaKey.(*rsa.PrivateKey),
+			Entity: pkix.Name{
+				CommonName:   ca.GetClusterName(),
+				Organization: []string{ca.GetClusterName()},
+			},
+			TTL:   defaults.CATTL,
+			Clock: req.clock,
+		})
 
 		jwtPublicKey, jwtPrivateKey, err = utils.MarshalPrivateKey(rsaKey.(*rsa.PrivateKey))
 		if err != nil {

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -506,6 +506,9 @@ func startNewRotation(req rotationReq, ca services.CertAuthority) error {
 			TTL:   defaults.CATTL,
 			Clock: req.clock,
 		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
 
 		jwtPublicKey, jwtPrivateKey, err = utils.MarshalPrivateKey(rsaKey.(*rsa.PrivateKey))
 		if err != nil {

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -107,7 +107,7 @@ func (s *Server) generateAppToken(username string, roles []string, uri string, e
 	}
 
 	// Extract the JWT signing key and sign the claims.
-	privateKey, err := ca.JWTSigner()
+	privateKey, err := ca.JWTSigner(jwt.Config{Clock: s.clock})
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -41,8 +41,8 @@ func New() *Keygen {
 	return &Keygen{clock: clockwork.NewRealClock()}
 }
 
-// NewWithConfig creates a new key generator with the specified configuration
-func NewWithConfig(clock clockwork.Clock) *Keygen {
+// NewWithClock creates a new key generator with the specified configuration
+func NewWithClock(clock clockwork.Clock) *Keygen {
 	return &Keygen{clock: clock}
 }
 

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -19,7 +19,6 @@ package testauthority
 import (
 	"crypto/rand"
 	random "math/rand"
-	"time"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -29,14 +28,22 @@ import (
 	"github.com/gravitational/teleport/lib/wrappers"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"golang.org/x/crypto/ssh"
 )
 
 type Keygen struct {
+	clock clockwork.Clock
 }
 
+// New creates a new key generator with defaults
 func New() *Keygen {
-	return &Keygen{}
+	return &Keygen{clock: clockwork.NewRealClock()}
+}
+
+// NewWithConfig creates a new key generator with the specified configuration
+func NewWithConfig(clock clockwork.Clock) *Keygen {
+	return &Keygen{clock: clock}
 }
 
 func (n *Keygen) Close() {
@@ -57,7 +64,7 @@ func (n *Keygen) GenerateHostCert(c services.HostCertParams) ([]byte, error) {
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if c.TTL != 0 {
-		b := time.Now().Add(c.TTL)
+		b := n.clock.Now().Add(c.TTL)
 		validBefore = uint64(b.Unix())
 	}
 	principals := native.BuildPrincipals(c.HostID, c.NodeName, c.ClusterName, c.Roles)
@@ -89,7 +96,7 @@ func (n *Keygen) GenerateUserCert(c services.UserCertParams) ([]byte, error) {
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if c.TTL != 0 {
-		b := time.Now().Add(c.TTL)
+		b := n.clock.Now().Add(c.TTL)
 		validBefore = uint64(b.Unix())
 	}
 	cert := &ssh.Certificate{

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -2493,7 +2493,7 @@ func (s *TLSSuite) TestRegisterCAPin(c *check.C) {
 		PublicSSHKey:         pub,
 		PublicTLSKey:         pubTLS,
 		CAPin:                caPin,
-		Time:                 s.clock.Now,
+		Clock:                s.clock,
 	})
 	c.Assert(err, check.IsNil)
 
@@ -2511,7 +2511,7 @@ func (s *TLSSuite) TestRegisterCAPin(c *check.C) {
 		PublicSSHKey:         pub,
 		PublicTLSKey:         pubTLS,
 		CAPin:                "sha256:123",
-		Time:                 s.clock.Now,
+		Clock:                s.clock,
 	})
 	c.Assert(err, check.NotNil)
 }
@@ -2550,7 +2550,7 @@ func (s *TLSSuite) TestRegisterCAPath(c *check.C) {
 		PrivateKey:           priv,
 		PublicSSHKey:         pub,
 		PublicTLSKey:         pubTLS,
-		Time:                 s.clock.Now,
+		Clock:                s.clock,
 	})
 	c.Assert(err, check.IsNil)
 
@@ -2582,7 +2582,7 @@ func (s *TLSSuite) TestRegisterCAPath(c *check.C) {
 		PublicSSHKey:         pub,
 		PublicTLSKey:         pubTLS,
 		CAPath:               caPath,
-		Time:                 s.clock.Now,
+		Clock:                s.clock,
 	})
 	c.Assert(err, check.IsNil)
 }

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -192,7 +192,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	}
 	streamer, err := events.NewCheckingStreamer(events.CheckingStreamerConfig{
 		Inner: conn.Client,
-		Clock: process.Clock,
+		Clock: process.GetClock(),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -192,7 +192,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	}
 	streamer, err := events.NewCheckingStreamer(events.CheckingStreamerConfig{
 		Inner: conn.Client,
-		Clock: process.GetClock(),
+		Clock: process.Clock,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -226,10 +226,12 @@ func (c *Connector) Close() error {
 // TeleportProcess structure holds the state of the Teleport daemon, controlling
 // execution and configuration of the teleport services: ssh, auth and proxy.
 type TeleportProcess struct {
-	clockwork.Clock
 	sync.Mutex
 	Supervisor
 	Config *Config
+
+	clock clockwork.Clock
+
 	// localAuth has local auth server listed in case if this process
 	// has started with auth server role enabled
 	localAuth *auth.Server
@@ -307,6 +309,11 @@ func (process *TeleportProcess) GetAuditLog() events.IAuditLog {
 // GetBackend returns the process' backend
 func (process *TeleportProcess) GetBackend() backend.Backend {
 	return process.backend
+}
+
+// GetClock returns the process' clock
+func (process *TeleportProcess) GetClock() clockwork.Clock {
+	return process.clock
 }
 
 func (process *TeleportProcess) findStaticIdentity(id auth.IdentityID) (*auth.Identity, error) {
@@ -617,10 +624,10 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 	}
 
 	process := &TeleportProcess{
-		Clock:               cfg.Clock,
 		Supervisor:          supervisor,
 		Config:              cfg,
 		Identities:          make(map[teleport.Role]*auth.Identity),
+		clock:               cfg.Clock,
 		connectors:          make(map[teleport.Role]*Connector),
 		importedDescriptors: cfg.FileDescriptors,
 		storage:             storage,
@@ -1093,7 +1100,7 @@ func (process *TeleportProcess) initAuthService() error {
 
 	checkingEmitter, err := events.NewCheckingEmitter(events.CheckingEmitterConfig{
 		Inner: events.NewMultiEmitter(events.NewLoggingEmitter(), emitter),
-		Clock: process.Clock,
+		Clock: process.GetClock(),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -1101,7 +1108,7 @@ func (process *TeleportProcess) initAuthService() error {
 
 	checkingStreamer, err := events.NewCheckingStreamer(events.CheckingStreamerConfig{
 		Inner: streamer,
-		Clock: process.Clock,
+		Clock: process.GetClock(),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -1314,7 +1321,7 @@ func (process *TeleportProcess) initAuthService() error {
 			} else {
 				srv.Spec.Rotation = state.Spec.Rotation
 			}
-			srv.SetTTL(process, defaults.ServerAnnounceTTL)
+			srv.SetTTL(process.GetClock(), defaults.ServerAnnounceTTL)
 			return &srv, nil
 		},
 		KeepAlivePeriod: defaults.ServerKeepAliveTTL,
@@ -1552,7 +1559,7 @@ func (process *TeleportProcess) proxyPublicAddr() utils.NetAddr {
 func (process *TeleportProcess) newAsyncEmitter(clt events.Emitter) (*events.AsyncEmitter, error) {
 	emitter, err := events.NewCheckingEmitter(events.CheckingEmitterConfig{
 		Inner: events.NewMultiEmitter(events.NewLoggingEmitter(), clt),
-		Clock: process.Clock,
+		Clock: process.GetClock(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1677,7 +1684,7 @@ func (process *TeleportProcess) initSSH() error {
 
 		streamer, err := events.NewCheckingStreamer(events.CheckingStreamerConfig{
 			Inner: conn.Client,
-			Clock: process.Clock,
+			Clock: process.GetClock(),
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -2320,7 +2327,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	}
 	streamer, err := events.NewCheckingStreamer(events.CheckingStreamerConfig{
 		Inner: conn.Client,
-		Clock: process.Clock,
+		Clock: process.GetClock(),
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -88,7 +88,7 @@ func (f *processState) update(event Event) {
 	s, ok := f.states[component]
 	if !ok {
 		// Register a new component.
-		s = &componentState{recoveryTime: f.process.GetClock().Now(), state: stateStarting}
+		s = &componentState{recoveryTime: f.process.Clock.Now(), state: stateStarting}
 		f.states[component] = s
 	}
 
@@ -109,10 +109,10 @@ func (f *processState) update(event Event) {
 			f.process.log.Debugf("Teleport component %q has started.", component)
 		case stateDegraded:
 			s.state = stateRecovering
-			s.recoveryTime = f.process.GetClock().Now()
+			s.recoveryTime = f.process.Clock.Now()
 			f.process.log.Infof("Teleport component %q is recovering from a degraded state.", component)
 		case stateRecovering:
-			if f.process.GetClock().Now().Sub(s.recoveryTime) > defaults.HeartbeatCheckPeriod*2 {
+			if f.process.Clock.Now().Sub(s.recoveryTime) > defaults.HeartbeatCheckPeriod*2 {
 				s.state = stateOK
 				f.process.log.Infof("Teleport component %q has recovered from a degraded state.", component)
 			}

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -88,7 +88,7 @@ func (f *processState) update(event Event) {
 	s, ok := f.states[component]
 	if !ok {
 		// Register a new component.
-		s = &componentState{recoveryTime: f.process.Now(), state: stateStarting}
+		s = &componentState{recoveryTime: f.process.GetClock().Now(), state: stateStarting}
 		f.states[component] = s
 	}
 
@@ -109,10 +109,10 @@ func (f *processState) update(event Event) {
 			f.process.log.Debugf("Teleport component %q has started.", component)
 		case stateDegraded:
 			s.state = stateRecovering
-			s.recoveryTime = f.process.Now()
+			s.recoveryTime = f.process.GetClock().Now()
 			f.process.log.Infof("Teleport component %q is recovering from a degraded state.", component)
 		case stateRecovering:
-			if f.process.Now().Sub(s.recoveryTime) > defaults.HeartbeatCheckPeriod*2 {
+			if f.process.GetClock().Now().Sub(s.recoveryTime) > defaults.HeartbeatCheckPeriod*2 {
 				s.state = stateOK
 				f.process.log.Infof("Teleport component %q has recovered from a degraded state.", component)
 			}

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -141,7 +141,7 @@ type UserCertParams struct {
 	ActiveRequests RequestIDs
 }
 
-// Check checks the user cert parameters
+// Check checks the user certificate parameters
 func (c UserCertParams) Check() error {
 	if len(c.PrivateCASigningKey) == 0 || c.CASigningAlg == "" {
 		return trace.BadParameter("PrivateCASigningKey and CASigningAlg are required")

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -47,7 +47,7 @@ func (s *ServicesSuite) SetUpSuite(c *check.C) {
 func (s *ServicesSuite) SetUpTest(c *check.C) {
 	var err error
 
-	clock := clockwork.NewFakeClockAt(time.Now())
+	clock := clockwork.NewFakeClock()
 
 	s.bk, err = lite.NewWithConfig(context.TODO(), lite.Config{
 		Path:             c.MkDir(),

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -54,6 +54,10 @@ type AuthHandlers struct {
 	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
 	// configuration.
 	FIPS bool
+
+	// Time is used for verifying time stamps. If unspecified, defaults
+	// to time.Now
+	Time func() time.Time
 }
 
 // CreateIdentityContext returns an IdentityContext populated with information
@@ -201,6 +205,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 	certChecker := utils.CertChecker{
 		CertChecker: ssh.CertChecker{
 			IsUserAuthority: h.IsUserAuthority,
+			Clock:           h.Time,
 		},
 		FIPS: h.FIPS,
 	}

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -205,9 +205,9 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 	// Check that the user certificate uses supported public key algorithms, was
 	// issued by Teleport, and check the certificate metadata (principals,
 	// timestamp, etc). Fallback to keys is not supported.
-	clock := h.Clock.Now
-	if clock == nil {
-		clock = time.Now
+	clock := time.Now
+	if h.Clock != nil {
+		clock = h.Clock.Now
 	}
 	certChecker := utils.CertChecker{
 		CertChecker: ssh.CertChecker{

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -299,7 +299,7 @@ func New(c ServerConfig) (*Server, error) {
 		AccessPoint: c.AuthClient,
 		FIPS:        c.FIPS,
 		Emitter:     c.Emitter,
-		Time:        c.Clock.Now,
+		Clock:       c.Clock,
 	}
 
 	// Common term handlers.

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -299,6 +299,7 @@ func New(c ServerConfig) (*Server, error) {
 		AccessPoint: c.AuthClient,
 		FIPS:        c.FIPS,
 		Emitter:     c.Emitter,
+		Time:        c.Clock.Now,
 	}
 
 	// Common term handlers.

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -551,7 +551,7 @@ func New(addr utils.NetAddr,
 		AccessPoint: s.authService,
 		FIPS:        s.fips,
 		Emitter:     s.StreamEmitter,
-		Time:        s.clock.Now,
+		Clock:       s.clock,
 	}
 
 	// common term handlers

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -297,6 +297,15 @@ func (s *Server) HandleConnection(conn net.Conn) {
 // RotationGetter returns rotation state
 type RotationGetter func(role teleport.Role) (*services.Rotation, error)
 
+// WithClock is a functional server option to override the internal
+// clock
+func WithClock(clock clockwork.Clock) ServerOption {
+	return func(s *Server) error {
+		s.clock = clock
+		return nil
+	}
+}
+
 // SetRotationGetter sets rotation state getter
 func SetRotationGetter(getter RotationGetter) ServerOption {
 	return func(s *Server) error {
@@ -542,6 +551,7 @@ func New(addr utils.NetAddr,
 		AccessPoint: s.authService,
 		FIPS:        s.fips,
 		Emitter:     s.StreamEmitter,
+		Time:        s.clock.Now,
 	}
 
 	// common term handlers

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -297,9 +297,9 @@ func (s *Server) HandleConnection(conn net.Conn) {
 // RotationGetter returns rotation state
 type RotationGetter func(role teleport.Role) (*services.Rotation, error)
 
-// WithClock is a functional server option to override the internal
+// SetClock is a functional server option to override the internal
 // clock
-func WithClock(clock clockwork.Clock) ServerOption {
+func SetClock(clock clockwork.Clock) ServerOption {
 	return func(s *Server) error {
 		s.clock = clock
 		return nil

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -189,7 +189,7 @@ func (s *SrvSuite) SetUpTest(c *C) {
 			},
 		),
 		SetBPF(&bpf.NOP{}),
-		WithClock(s.clock),
+		SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 	s.srv = srv
@@ -741,7 +741,7 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
-		WithClock(s.clock),
+		SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 	c.Assert(proxy.Start(), IsNil)
@@ -819,7 +819,7 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
 		SetEmitter(s.nodeClient),
-		WithClock(s.clock),
+		SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 	c.Assert(srv2.Start(), IsNil)
@@ -909,7 +909,7 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
-		WithClock(s.clock),
+		SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 	c.Assert(proxy.Start(), IsNil)
@@ -1015,7 +1015,7 @@ func (s *SrvSuite) TestProxyDirectAccess(c *C) {
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
-		WithClock(s.clock),
+		SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 	c.Assert(proxy.Start(), IsNil)
@@ -1126,7 +1126,7 @@ func (s *SrvSuite) TestLimiter(c *C) {
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
-		WithClock(s.clock),
+		SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 	c.Assert(srv.Start(), IsNil)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -92,6 +92,14 @@ func SetSessionStreamPollPeriod(period time.Duration) HandlerOption {
 	}
 }
 
+// WithClock sets the clock on a handler
+func WithClock(clock clockwork.Clock) HandlerOption {
+	return func(h *Handler) error {
+		h.clock = clock
+		return nil
+	}
+}
+
 // Config represents web handler configuration parameters
 type Config struct {
 	// Proxy is a reverse tunnel proxy that handles connections
@@ -171,15 +179,10 @@ func (h *RewritingHandler) Close() error {
 // NewHandler returns a new instance of web proxy handler
 func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	const apiPrefix = "/" + teleport.WebAPIVersion
-	lauth, err := newSessionCache(cfg.ProxyClient, []utils.NetAddr{cfg.AuthServers}, cfg.CipherSuites)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	h := &Handler{
-		cfg:  cfg,
-		auth: lauth,
-		log:  newPackageLogger(),
+		cfg:   cfg,
+		log:   newPackageLogger(),
+		clock: clockwork.NewRealClock(),
 	}
 
 	for _, o := range opts {
@@ -188,6 +191,17 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 		}
 	}
 
+	auth, err := newSessionCache(&sessionCache{
+		proxyClient:  cfg.ProxyClient,
+		authServers:  []utils.NetAddr{cfg.AuthServers},
+		cipherSuites: cfg.CipherSuites,
+		clock:        h.clock,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	h.auth = auth
+
 	_, sshPort, err := net.SplitHostPort(cfg.ProxySSHAddr.String())
 	if err != nil {
 		h.log.WithError(err).Warnf("Invalid SSH proxy address %q, will use default port %v.",
@@ -195,10 +209,6 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 		sshPort = strconv.Itoa(defaults.SSHProxyListenPort)
 	}
 	h.sshPort = sshPort
-
-	if h.clock == nil {
-		h.clock = clockwork.NewRealClock()
-	}
 
 	// ping endpoint is used to check if the server is up. the /webapi/ping
 	// endpoint returns the default authentication method and configuration that
@@ -1190,7 +1200,7 @@ func NewSessionResponse(ctx *SessionContext) (*CreateSessionResponse, error) {
 	return &CreateSessionResponse{
 		Type:      roundtrip.AuthBearer,
 		Token:     webSession.GetBearerToken(),
-		ExpiresIn: int(time.Until(webSession.GetBearerTokenExpiryTime()) / time.Second),
+		ExpiresIn: int(webSession.GetBearerTokenExpiryTime().Sub(ctx.parent.clock.Now()) / time.Second),
 	}, nil
 }
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -92,8 +92,8 @@ func SetSessionStreamPollPeriod(period time.Duration) HandlerOption {
 	}
 }
 
-// WithClock sets the clock on a handler
-func WithClock(clock clockwork.Clock) HandlerOption {
+// SetClock sets the clock on a handler
+func SetClock(clock clockwork.Clock) HandlerOption {
 	return func(h *Handler) error {
 		h.clock = clock
 		return nil

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -190,7 +190,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		regular.SetEmitter(nodeClient),
 		regular.SetPAMConfig(&pam.Config{Enabled: false}),
 		regular.SetBPF(&bpf.NOP{}),
-		regular.WithClock(s.clock),
+		regular.SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 	s.node = node
@@ -243,7 +243,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		regular.SetEmitter(s.proxyClient),
 		regular.SetNamespace(defaults.Namespace),
 		regular.SetBPF(&bpf.NOP{}),
-		regular.WithClock(s.clock),
+		regular.SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -257,7 +257,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		Context:      context.Background(),
 		HostUUID:     proxyID,
 		Emitter:      s.proxyClient,
-	}, SetSessionStreamPollPeriod(200*time.Millisecond), WithClock(s.clock))
+	}, SetSessionStreamPollPeriod(200*time.Millisecond), SetClock(s.clock))
 	c.Assert(err, IsNil)
 
 	s.webServer = httptest.NewUnstartedServer(handler)

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -314,23 +314,27 @@ func (c *SessionContext) Close() error {
 }
 
 // newSessionCache returns new instance of the session cache
-func newSessionCache(proxyClient auth.ClientI, servers []utils.NetAddr, cipherSuites []uint16) (*sessionCache, error) {
-	clusterName, err := proxyClient.GetClusterName()
+func newSessionCache(config *sessionCache) (*sessionCache, error) {
+	clusterName, err := config.proxyClient.GetClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	m, err := ttlmap.New(1024, ttlmap.CallOnExpire(closeContext))
+	if config.clock == nil {
+		config.clock = clockwork.NewRealClock()
+	}
+	m, err := ttlmap.New(1024, ttlmap.CallOnExpire(closeContext), ttlmap.Clock(config.clock))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	cache := &sessionCache{
 		clusterName:  clusterName.GetClusterName(),
-		proxyClient:  proxyClient,
+		proxyClient:  config.proxyClient,
 		contexts:     m,
-		authServers:  servers,
+		authServers:  config.authServers,
 		closer:       utils.NewCloseBroadcaster(),
-		cipherSuites: cipherSuites,
+		cipherSuites: config.cipherSuites,
 		log:          newPackageLogger(),
+		clock:        config.clock,
 	}
 	// periodically close expired and unused sessions
 	go cache.expireSessions()
@@ -347,6 +351,7 @@ type sessionCache struct {
 	authServers []utils.NetAddr
 	closer      *utils.CloseBroadcaster
 	clusterName string
+	clock       clockwork.Clock
 
 	// cipherSuites is the list of supported TLS cipher suites.
 	cipherSuites []uint16
@@ -576,6 +581,7 @@ func (s *sessionCache) ValidateSession(user, sid string) (*SessionContext, error
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	tlsConfig.RootCAs = certPool
 	tlsConfig.ServerName = auth.EncodeClusterName(s.clusterName)
+	tlsConfig.Time = s.clock.Now
 
 	userClient, err := auth.NewClient(apiclient.Config{
 		Addrs: utils.NetAddrsToStrings(s.authServers),
@@ -597,7 +603,7 @@ func (s *sessionCache) ValidateSession(user, sid string) (*SessionContext, error
 		}),
 	}
 
-	ttl := utils.ToTTL(clockwork.NewRealClock(), sess.GetBearerTokenExpiryTime())
+	ttl := utils.ToTTL(s.clock, sess.GetBearerTokenExpiryTime())
 	out, err := s.insertContext(user, sid, c, ttl)
 	if err != nil {
 		// this means that someone has just inserted the context, so

--- a/vendor/github.com/jonboulle/clockwork/clockwork.go
+++ b/vendor/github.com/jonboulle/clockwork/clockwork.go
@@ -152,7 +152,7 @@ func (fc *fakeClock) NewTicker(d time.Duration) Ticker {
 		clock:  fc,
 		period: d,
 	}
-	go ft.tick()
+	ft.runTickThread()
 	return ft
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -274,7 +274,7 @@ github.com/johannesboyne/gofakes3
 github.com/johannesboyne/gofakes3/backend/s3mem
 github.com/johannesboyne/gofakes3/internal/goskipiter
 github.com/johannesboyne/gofakes3/internal/s3io
-# github.com/jonboulle/clockwork v0.2.1
+# github.com/jonboulle/clockwork v0.2.2
 ## explicit
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.10


### PR DESCRIPTION
This PR fixes a couple of inconsistencies I stumbled upon when working on an update on the web session unit tests which led to a slew of changes to fix the use of clock.
Considering this a prerequisite to the upcoming web UI disconnects PR. 

Note, this also bumps the clockwork dependency to the latest release that fixes a data race in Ticker.