### PR TITLE
Reduce API Dependencies - lib/modules

### DIFF
--- a/api/types/trustedcluster.go
+++ b/api/types/trustedcluster.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/defaults"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
@@ -133,19 +132,6 @@ func (c *TrustedClusterV2) CheckAndSetDefaults() error {
 	// This is to force users to migrate
 	if len(c.Spec.Roles) != 0 && len(c.Spec.RoleMap) != 0 {
 		return trace.BadParameter("should set either 'roles' or 'role_map', not both")
-	}
-	// we are not mentioning Roles parameter because we are deprecating it
-	if len(c.Spec.Roles) == 0 && len(c.Spec.RoleMap) == 0 {
-		if err := modules.GetModules().EmptyRolesHandler(); err != nil {
-			return trace.Wrap(err)
-		}
-		// OSS teleport uses 'admin' by default:
-		c.Spec.RoleMap = RoleMap{
-			RoleMapping{
-				Remote: teleport.AdminRoleName,
-				Local:  []string{teleport.AdminRoleName},
-			},
-		}
 	}
 	// Imply that by default proxy listens on the same port for
 	// web and reverse tunnel connections

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -598,7 +598,9 @@ func (s *APIServer) upsertTrustedCluster(auth ClientI, w http.ResponseWriter, r 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
+	if err := services.ValidateTrustedCluster(trustedCluster); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	out, err := auth.UpsertTrustedCluster(r.Context(), trustedCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -423,7 +423,7 @@ func (s *PresenceService) DeleteReverseTunnel(clusterName string) error {
 
 // UpsertTrustedCluster creates or updates a TrustedCluster in the backend.
 func (s *PresenceService) UpsertTrustedCluster(ctx context.Context, trustedCluster services.TrustedCluster) (services.TrustedCluster, error) {
-	if err := trustedCluster.CheckAndSetDefaults(); err != nil {
+	if err := services.ValidateTrustedCluster(trustedCluster); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	value, err := services.GetTrustedClusterMarshaler().Marshal(trustedCluster)

--- a/lib/services/trustedcluster.go
+++ b/lib/services/trustedcluster.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/modules"
+
+	"github.com/gravitational/trace"
+)
+
+// ValidateTrustedCluster checks and sets Trusted Cluster defaults
+func ValidateTrustedCluster(tc TrustedCluster) error {
+	if err := tc.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// we are not mentioning Roles parameter because we are deprecating it
+	if len(tc.GetRoles()) == 0 && len(tc.GetRoleMap()) == 0 {
+		if err := modules.GetModules().EmptyRolesHandler(); err != nil {
+			return trace.Wrap(err)
+		}
+		// OSS teleport uses 'admin' by default:
+		tc.SetRoleMap(RoleMap{
+			RoleMapping{
+				Remote: teleport.AdminRoleName,
+				Local:  []string{teleport.AdminRoleName},
+			},
+		})
+	}
+
+	return nil
+}


### PR DESCRIPTION
Changes:
  - Move some logic that depended on `lib/modules` from `CheckAndSetDefaults` logic to 'lib/services.CheckAndSetTrustedClusterDefaults`.