### PR TITLE
checksum must be on pod, not deployment

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        # ConfigMap checksum, to recreate deployment on config changes.
+        # ConfigMap checksum, to recreate the pod on config changes.
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
       labels:
         app: {{ .Release.Name }}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
-  annotations:
-    # ConfigMap checksum, to recreate deployment on config changes.
-    checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -15,6 +12,9 @@ spec:
       app: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        # ConfigMap checksum, to recreate deployment on config changes.
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
       labels:
         app: {{ .Release.Name }}
     spec:


### PR DESCRIPTION
Currently, the pod will not rotate in the agent when the config is changed.  This PR alters this to match the scheme in the main chart.