### PR TITLE
Explicitly cast time values to int64 to enable 32-bit builds.

### DIFF
--- a/lib/sshutils/scp/stat_linux.go
+++ b/lib/sshutils/scp/stat_linux.go
@@ -28,5 +28,5 @@ func atime(fi os.FileInfo) time.Time {
 }
 
 func timespecToTime(ts syscall.Timespec) time.Time {
-	return time.Unix(ts.Sec, ts.Nsec)
+	return time.Unix(int64(ts.Sec), int64(ts.Nsec)) //nolint:unconvert
 }


### PR DESCRIPTION
Addresses [this comment](https://github.com/gravitational/teleport/pull/4764#issuecomment-759539109).
Updates https://github.com/gravitational/teleport/pull/4764.