### PR TITLE
Add integration test for node registration methods

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -201,18 +201,9 @@ func (s *IntSuite) newTeleportIoT(c *check.C, logins []string) *TeleInstance {
 	nodeConfig := func() *service.Config {
 		tconf := s.defaultServiceConfig()
 		tconf.Hostname = Host
-		tconf.Token = "token"
-		tconf.AuthServers = []utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        net.JoinHostPort(Loopback, main.GetPortWeb()),
-			},
-		}
 
 		tconf.Auth.Enabled = false
-
 		tconf.Proxy.Enabled = false
-
 		tconf.SSH.Enabled = true
 
 		return tconf
@@ -811,7 +802,6 @@ func (s *IntSuite) verifySessionJoin(c *check.C, t *TeleInstance) {
 		err = cl.SSH(context.TODO(), []string{}, false)
 		c.Assert(err, check.IsNil)
 		sessionEndC <- true
-
 	}
 
 	// PersonB: wait for a session to become available, then join:
@@ -2235,19 +2225,14 @@ func (s *IntSuite) TestTrustedTunnelNode(c *check.C) {
 	nodeConfig := func() *service.Config {
 		tconf := s.defaultServiceConfig()
 		tconf.Hostname = tunnelNodeHostname
-		tconf.Token = "token"
-		tconf.AuthServers = []utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        net.JoinHostPort(Loopback, aux.GetPortWeb()),
-			},
-		}
+
 		tconf.Auth.Enabled = false
 		tconf.Proxy.Enabled = false
 		tconf.SSH.Enabled = true
+
 		return tconf
 	}
-	_, err = aux.StartNode(nodeConfig())
+	_, err = aux.StartReverseTunnelNode(nodeConfig())
 	c.Assert(err, check.IsNil)
 
 	// wait for both sites to see each other via their reverse tunnels (for up to 10 seconds)
@@ -2647,23 +2632,14 @@ func (s *IntSuite) TestDiscoveryNode(c *check.C) {
 	nodeConfig := func() *service.Config {
 		tconf := s.defaultServiceConfig()
 		tconf.Hostname = "cluster-main-node"
-		tconf.Token = "token"
-		tconf.AuthServers = []utils.NetAddr{
-			{
-				AddrNetwork: "tcp",
-				Addr:        net.JoinHostPort(Loopback, main.GetPortWeb()),
-			},
-		}
 
 		tconf.Auth.Enabled = false
-
 		tconf.Proxy.Enabled = false
-
 		tconf.SSH.Enabled = true
 
 		return tconf
 	}
-	_, err = main.StartNode(nodeConfig())
+	_, err = main.StartReverseTunnelNode(nodeConfig())
 	c.Assert(err, check.IsNil)
 
 	// Wait for active tunnel connections to be established.

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
 )
 
 // LocalRegister is used to generate host keys when a node or proxy is running
@@ -114,6 +115,14 @@ type HostCredentials func(context.Context, string, bool, RegisterUsingTokenReque
 // tokens to prove a valid auth server was used to issue the joining request
 // as well as a method for the node to validate the auth server.
 func Register(params RegisterParams) (*Identity, error) {
+	return RegisterWithLogger(params, log)
+}
+
+// RegisterWithLogger allows to specify a custom logger and capture logs
+// written during the registration process, primarily for testing purposes.
+func RegisterWithLogger(params RegisterParams, logger logrus.FieldLogger) (*Identity, error) {
+	log := logger.WithField(trace.Component, teleport.ComponentAuth)
+
 	params.setDefaults()
 	// Read in the token. The token can either be passed in or come from a file
 	// on disk.

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -353,7 +353,7 @@ func (process *TeleportProcess) firstTimeConnect(role teleport.Role) (*Connector
 			return nil, trace.Wrap(err)
 		}
 
-		identity, err = auth.Register(auth.RegisterParams{
+		identity, err = auth.RegisterWithLogger(auth.RegisterParams{
 			DataDir:              process.Config.DataDir,
 			Token:                process.Config.Token,
 			ID:                   id,
@@ -367,7 +367,7 @@ func (process *TeleportProcess) firstTimeConnect(role teleport.Role) (*Connector
 			CAPin:                process.Config.CAPin,
 			CAPath:               filepath.Join(defaults.DataDir, defaults.CACertFile),
 			GetHostCredentials:   client.HostCredentials,
-		})
+		}, process.log)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -83,12 +83,12 @@ func InitLoggerForTests(verbose bool) {
 }
 
 // NewLoggerForTests creates a new logger for test environment
-func NewLoggerForTests() *log.Logger {
+func NewLoggerForTests(output io.Writer) *log.Logger {
 	logger := log.New()
 	logger.ReplaceHooks(make(log.LevelHooks))
 	logger.SetFormatter(&trace.TextFormatter{})
 	logger.SetLevel(log.DebugLevel)
-	logger.SetOutput(os.Stderr)
+	logger.SetOutput(output)
 	return logger
 }
 


### PR DESCRIPTION
An integration test for the node registration logic introduced in #5182. Changes needed to allow for logger injection/capture are also included inasmuch as this is the first test that analyzes logs emitted by the Teleport process.