### PR TITLE
When exporting a kubeconfig, overwrite the target file

### DIFF
--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -61,6 +61,9 @@ const (
 	DefaultFormat = FormatFile
 )
 
+// KnownFormats is a list of all above formats.
+var KnownFormats = []Format{FormatFile, FormatOpenSSH, FormatTLS, FormatKubernetes, FormatDatabase}
+
 const (
 	// The files created by Write will have these permissions.
 	writeFileMode = 0600
@@ -206,8 +209,7 @@ func Write(cfg WriteConfig) (filesWritten []string, err error) {
 		}
 
 	default:
-		return nil, trace.BadParameter("unsupported identity format: %q, use one of %q, %q, %q, %q or %q",
-			cfg.Format, FormatFile, FormatOpenSSH, FormatTLS, FormatKubernetes, FormatDatabase)
+		return nil, trace.BadParameter("unsupported identity format: %q, use one of %q", cfg.Format, KnownFormats)
 	}
 	return filesWritten, nil
 }

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
@@ -59,48 +60,64 @@ const (
 	DefaultFormat = FormatFile
 )
 
-// Write takes a username + their credentials and saves them to disk
-// in a specified format.
-//
-// clusterAddr is only used with FormatKubernetes.
-//
-// filePath is used as a base to generate output file names; these names are
-// returned in filesWritten.
-func Write(filePath string, key *client.Key, format Format, clusterAddr string) (filesWritten []string, err error) {
-	const (
-		// the files and the dir will be created with these permissions:
-		fileMode = 0600
-		dirMode  = 0700
-	)
+const (
+	// The files created by Write will have these permissions.
+	writeFileMode = 0600
+)
 
-	if filePath == "" {
+// WriteConfig holds the necessary information to write an identity file.
+type WriteConfig struct {
+	// OutputPath is the output path for the identity file. Note that some
+	// formats (like FormatOpenSSH and FormatTLS) write multiple output files
+	// and use OutputPath as a prefix.
+	OutputPath string
+	// Key contains the credentials to write to the identity file.
+	Key *client.Key
+	// Format is the output format for the identity file.
+	Format Format
+	// KubeProxyAddr is the public address of the proxy with its kubernetes
+	// port. KubeProxyAddr is only used when Format is FormatKubernetes.
+	KubeProxyAddr string
+	// OverwriteDestination forces all existing destination files to be
+	// overwritten. When false, user will be prompted for confirmation of
+	// overwite first.
+	OverwriteDestination bool
+}
+
+// Write writes user credentials to disk in a specified format.
+// It returns the names of the files successfully written.
+func Write(cfg WriteConfig) (filesWritten []string, err error) {
+	if cfg.OutputPath == "" {
 		return nil, trace.BadParameter("identity output path is not specified")
 	}
 
-	switch format {
+	switch cfg.Format {
 	// dump user identity into a single file:
 	case FormatFile:
-		filesWritten = append(filesWritten, filePath)
-		f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
+		if err := checkOverwrite(cfg.OutputPath, cfg.OverwriteDestination); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		filesWritten = append(filesWritten, cfg.OutputPath)
+		f, err := os.OpenFile(cfg.OutputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, writeFileMode)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		defer f.Close()
 
 		// write key:
-		if err := writeWithNewline(f, key.Priv); err != nil {
+		if err := writeWithNewline(f, cfg.Key.Priv); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		// append ssh cert:
-		if err := writeWithNewline(f, key.Cert); err != nil {
+		if err := writeWithNewline(f, cfg.Key.Cert); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		// append tls cert:
-		if err := writeWithNewline(f, key.TLSCert); err != nil {
+		if err := writeWithNewline(f, cfg.Key.TLSCert); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		// append trusted host certificate authorities
-		for _, ca := range key.TrustedCA {
+		for _, ca := range cfg.Key.TrustedCA {
 			// append ssh ca certificates
 			for _, publicKey := range ca.HostCertificates {
 				data, err := sshutils.MarshalAuthorizedHostsFormat(ca.ClusterName, publicKey, nil)
@@ -121,59 +138,70 @@ func Write(filePath string, key *client.Key, format Format, clusterAddr string) 
 
 	// dump user identity into separate files:
 	case FormatOpenSSH:
-		keyPath := filePath
+		keyPath := cfg.OutputPath
 		certPath := keyPath + "-cert.pub"
 		filesWritten = append(filesWritten, keyPath, certPath)
 
-		err = ioutil.WriteFile(certPath, key.Cert, fileMode)
+		err = writeFile(certPath, cfg.Key.Cert, cfg.OverwriteDestination)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		err = ioutil.WriteFile(keyPath, key.Priv, fileMode)
+		err = writeFile(keyPath, cfg.Key.Priv, cfg.OverwriteDestination)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
 	case FormatTLS, FormatDatabase:
-		keyPath := filePath + ".key"
-		certPath := filePath + ".crt"
-		casPath := filePath + ".cas"
+		keyPath := cfg.OutputPath + ".key"
+		certPath := cfg.OutputPath + ".crt"
+		casPath := cfg.OutputPath + ".cas"
 		filesWritten = append(filesWritten, keyPath, certPath, casPath)
 
-		err = ioutil.WriteFile(certPath, key.TLSCert, fileMode)
+		err = writeFile(certPath, cfg.Key.TLSCert, cfg.OverwriteDestination)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		err = ioutil.WriteFile(keyPath, key.Priv, fileMode)
+		err = writeFile(keyPath, cfg.Key.Priv, cfg.OverwriteDestination)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		var caCerts []byte
-		for _, ca := range key.TrustedCA {
+		for _, ca := range cfg.Key.TrustedCA {
 			for _, cert := range ca.TLSCertificates {
 				caCerts = append(caCerts, cert...)
 			}
 		}
-		err = ioutil.WriteFile(casPath, caCerts, fileMode)
+		err = writeFile(casPath, caCerts, cfg.OverwriteDestination)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
 	case FormatKubernetes:
-		filesWritten = append(filesWritten, filePath)
-		if err := kubeconfig.Update(filePath, kubeconfig.Values{
-			TeleportClusterName: key.ClusterName,
-			ClusterAddr:         clusterAddr,
-			Credentials:         key,
+		if err := checkOverwrite(cfg.OutputPath, cfg.OverwriteDestination); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		// Clean up the existing file, if it exists.
+		//
+		// kubeconfig.Update would try to parse it and merge in new
+		// credentials, which is now what we want.
+		if err := os.Remove(cfg.OutputPath); err != nil && !os.IsNotExist(err) {
+			return nil, trace.Wrap(err)
+		}
+
+		filesWritten = append(filesWritten, cfg.OutputPath)
+		if err := kubeconfig.Update(cfg.OutputPath, kubeconfig.Values{
+			TeleportClusterName: cfg.Key.ClusterName,
+			ClusterAddr:         cfg.KubeProxyAddr,
+			Credentials:         cfg.Key,
 		}); err != nil {
 			return nil, trace.Wrap(err)
 		}
 
 	default:
 		return nil, trace.BadParameter("unsupported identity format: %q, use one of %q, %q, %q, %q or %q",
-			format, FormatFile, FormatOpenSSH, FormatTLS, FormatKubernetes, FormatDatabase)
+			cfg.Format, FormatFile, FormatOpenSSH, FormatTLS, FormatKubernetes, FormatDatabase)
 	}
 	return filesWritten, nil
 }
@@ -188,6 +216,44 @@ func writeWithNewline(w io.Writer, data []byte) error {
 		}
 	}
 	return nil
+}
+
+func writeFile(path string, data []byte, forceOverwrite bool) error {
+	if err := checkOverwrite(path, forceOverwrite); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := ioutil.WriteFile(path, data, writeFileMode); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func checkOverwrite(path string, force bool) error {
+	// Check if destination file exists.
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		// File doesn't exist, proceed.
+		return nil
+	}
+	if err != nil {
+		// Something else went wrong, fail.
+		return trace.Wrap(err)
+	}
+	if force {
+		// File exists but we're asked not to prompt, proceed.
+		return nil
+	}
+
+	// File exists, prompt user whether to overwrite.
+	fmt.Fprintf(os.Stderr, "Destination file %q exists. Overwrite it? [y/N]: ", path)
+	scan := bufio.NewScanner(os.Stdin)
+	if !scan.Scan() {
+		return trace.WrapWithMessage(scan.Err(), "failed reading prompt response")
+	}
+	if strings.ToLower(strings.TrimSpace(scan.Text())) == "y" {
+		return nil
+	}
+	return trace.Errorf("NOT overwriting destination file %q", path)
 }
 
 // IdentityFile represents the basic components of an identity file.

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -232,7 +232,7 @@ func writeFile(path string, data []byte) error {
 
 func checkOverwrite(force bool, paths ...string) error {
 	var existingFiles []string
-	// Check if destination files exists.
+	// Check if the destination file exists.
 	for _, path := range paths {
 		_, err := os.Stat(path)
 		if os.IsNotExist(err) {
@@ -250,7 +250,7 @@ func checkOverwrite(force bool, paths ...string) error {
 		return nil
 	}
 
-	// File exists, prompt user whether to overwrite.
+	// Some files exist, prompt user whether to overwrite.
 	overwrite, err := prompt.Confirmation(os.Stderr, os.Stdin, fmt.Sprintf("Destination file(s) %s exist. Overwrite?", strings.Join(existingFiles, ", ")))
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/utils/prompt/confirmation.go
+++ b/lib/utils/prompt/confirmation.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package prompt implements CLI prompts to the user.
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+// Confirmation prompts the user for a yes/no confirmation for question.
+// The prompt is written to out and the answer is read from in.
+//
+// question should be a plain sentece without "[yes/no]"-type hints at the end.
+func Confirmation(out io.Writer, in io.Reader, question string) (bool, error) {
+	fmt.Fprintf(out, "%s [y/N]: ", question)
+	scan := bufio.NewScanner(in)
+	if !scan.Scan() {
+		return false, trace.WrapWithMessage(scan.Err(), "failed reading prompt response")
+	}
+	switch strings.ToLower(strings.TrimSpace(scan.Text())) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -49,6 +49,7 @@ type AuthCommand struct {
 	proxyAddr                  string
 	leafCluster                string
 	kubeCluster                string
+	signOverwrite              bool
 
 	rotateGracePeriod time.Duration
 	rotateType        string
@@ -89,6 +90,7 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *service.Confi
 		DurationVar(&a.genTTL)
 	a.authSign.Flag("compat", "OpenSSH compatibility flag").StringVar(&a.compatibility)
 	a.authSign.Flag("proxy", `Address of the teleport proxy. When --format is set to "kubernetes", this address will be set as cluster address in the generated kubeconfig file`).StringVar(&a.proxyAddr)
+	a.authSign.Flag("overwrite", "Whether to overwrite existing destination files. When not set, user will be prompted before overwriting any existing file.").BoolVar(&a.signOverwrite)
 	// --kube-cluster was an unfortunately chosen flag name, before teleport
 	// supported kubernetes_service and registered kubernetes clusters that are
 	// not trusted teleport clusters.
@@ -344,7 +346,12 @@ func (a *AuthCommand) generateHostKeys(clusterAPI auth.ClientI) error {
 		filePath = principals[0]
 	}
 
-	filesWritten, err := identityfile.Write(filePath, key, a.outputFormat, "")
+	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+		OutputPath:           filePath,
+		Key:                  key,
+		Format:               a.outputFormat,
+		OverwriteDestination: a.signOverwrite,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -376,7 +383,12 @@ func (a *AuthCommand) generateDatabaseKeys(clusterAPI auth.ClientI) error {
 	}
 	key.TLSCert = resp.Cert
 	key.TrustedCA = []auth.TrustedCerts{{TLSCertificates: resp.CACerts}}
-	filesWritten, err := identityfile.Write(a.output, key, a.outputFormat, "")
+	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+		OutputPath:           a.output,
+		Key:                  key,
+		Format:               a.outputFormat,
+		OverwriteDestination: a.signOverwrite,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -441,7 +453,13 @@ func (a *AuthCommand) generateUserKeys(clusterAPI auth.ClientI) error {
 	key.TrustedCA = auth.AuthoritiesToTrustedCerts(hostCAs)
 
 	// write the cert+private key to the output:
-	filesWritten, err := identityfile.Write(a.output, key, a.outputFormat, a.proxyAddr)
+	filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+		OutputPath:           a.output,
+		Key:                  key,
+		Format:               a.outputFormat,
+		KubeProxyAddr:        a.proxyAddr,
+		OverwriteDestination: a.signOverwrite,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -82,17 +82,19 @@ func TestAuthSignKubeconfig(t *testing.T) {
 		{
 			desc: "--proxy specified",
 			ac: AuthCommand{
-				output:       filepath.Join(tmpDir, "kubeconfig"),
-				outputFormat: identityfile.FormatKubernetes,
-				proxyAddr:    "proxy-from-flag.example.com",
+				output:        filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat:  identityfile.FormatKubernetes,
+				signOverwrite: true,
+				proxyAddr:     "proxy-from-flag.example.com",
 			},
 			wantAddr: "proxy-from-flag.example.com",
 		},
 		{
 			desc: "k8s proxy running locally with public_addr",
 			ac: AuthCommand{
-				output:       filepath.Join(tmpDir, "kubeconfig"),
-				outputFormat: identityfile.FormatKubernetes,
+				output:        filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat:  identityfile.FormatKubernetes,
+				signOverwrite: true,
 				config: &service.Config{Proxy: service.ProxyConfig{Kube: service.KubeProxyConfig{
 					Enabled:     true,
 					PublicAddrs: []utils.NetAddr{{Addr: "proxy-from-config.example.com:3026"}},
@@ -103,8 +105,9 @@ func TestAuthSignKubeconfig(t *testing.T) {
 		{
 			desc: "k8s proxy running locally without public_addr",
 			ac: AuthCommand{
-				output:       filepath.Join(tmpDir, "kubeconfig"),
-				outputFormat: identityfile.FormatKubernetes,
+				output:        filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat:  identityfile.FormatKubernetes,
+				signOverwrite: true,
 				config: &service.Config{Proxy: service.ProxyConfig{
 					Kube: service.KubeProxyConfig{
 						Enabled: true,
@@ -117,8 +120,9 @@ func TestAuthSignKubeconfig(t *testing.T) {
 		{
 			desc: "k8s proxy from cluster info",
 			ac: AuthCommand{
-				output:       filepath.Join(tmpDir, "kubeconfig"),
-				outputFormat: identityfile.FormatKubernetes,
+				output:        filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat:  identityfile.FormatKubernetes,
+				signOverwrite: true,
 				config: &service.Config{Proxy: service.ProxyConfig{
 					Kube: service.KubeProxyConfig{
 						Enabled: false,
@@ -130,9 +134,10 @@ func TestAuthSignKubeconfig(t *testing.T) {
 		{
 			desc: "--kube-cluster specified with valid cluster",
 			ac: AuthCommand{
-				output:       filepath.Join(tmpDir, "kubeconfig"),
-				outputFormat: identityfile.FormatKubernetes,
-				leafCluster:  remoteCluster.GetMetadata().Name,
+				output:        filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat:  identityfile.FormatKubernetes,
+				signOverwrite: true,
+				leafCluster:   remoteCluster.GetMetadata().Name,
 				config: &service.Config{Proxy: service.ProxyConfig{
 					Kube: service.KubeProxyConfig{
 						Enabled: false,
@@ -144,9 +149,10 @@ func TestAuthSignKubeconfig(t *testing.T) {
 		{
 			desc: "--kube-cluster specified with invalid cluster",
 			ac: AuthCommand{
-				output:       filepath.Join(tmpDir, "kubeconfig"),
-				outputFormat: identityfile.FormatKubernetes,
-				leafCluster:  "doesnotexist.example.com",
+				output:        filepath.Join(tmpDir, "kubeconfig"),
+				outputFormat:  identityfile.FormatKubernetes,
+				signOverwrite: true,
+				leafCluster:   "doesnotexist.example.com",
 				config: &service.Config{Proxy: service.ProxyConfig{
 					Kube: service.KubeProxyConfig{
 						Enabled: false,
@@ -160,7 +166,7 @@ func TestAuthSignKubeconfig(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			// Generate kubeconfig.
 			if err = tt.ac.generateUserKeys(client); err != nil && tt.wantError == "" {
-				t.Fatalf("generating KubeProxyConfigfig: %v", err)
+				t.Fatalf("generating KubeProxyConfig: %v", err)
 			}
 
 			if tt.wantError != "" && (err == nil || err.Error() != tt.wantError) {
@@ -335,10 +341,11 @@ func TestGenerateDatabaseKeys(t *testing.T) {
 	}
 
 	ac := AuthCommand{
-		output:       filepath.Join(tmpDir, "db"),
-		outputFormat: identityfile.FormatDatabase,
-		genHost:      "example.com",
-		genTTL:       time.Hour,
+		output:        filepath.Join(tmpDir, "db"),
+		outputFormat:  identityfile.FormatDatabase,
+		signOverwrite: true,
+		genHost:       "example.com",
+		genTTL:        time.Hour,
 	}
 
 	err := ac.GenerateAndSignKeys(client)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -156,6 +156,10 @@ type CLIConf struct {
 	// IdentityFormat (used for --format flag for 'tsh login') defines which
 	// format to use with --out to store a fershly retreived certificate
 	IdentityFormat identityfile.Format
+	// IdentityOverwrite when true will overwrite any existing identity file at
+	// IdentityFileOut. When false, user will be prompted before overwriting
+	// any files.
+	IdentityOverwrite bool
 
 	// BindAddr is an address in the form of host:port to bind to
 	// during `tsh login` command
@@ -341,6 +345,7 @@ func Run(args []string) {
 		identityfile.FormatOpenSSH,
 		identityfile.FormatKubernetes,
 	)).Default(string(identityfile.DefaultFormat)).StringVar((*string)(&cf.IdentityFormat))
+	login.Flag("overwrite", "Whether to overwrite the existing identity file, if present.").BoolVar(&cf.IdentityOverwrite)
 	login.Flag("request-roles", "Request one or more extra roles").StringVar(&cf.DesiredRoles)
 	login.Flag("request-reason", "Reason for requesting additional roles").StringVar(&cf.RequestReason)
 	login.Arg("cluster", clusterHelp).StringVar(&cf.SiteName)
@@ -634,7 +639,13 @@ func onLogin(cf *CLIConf) {
 		}
 		key.TrustedCA = auth.AuthoritiesToTrustedCerts(authorities)
 
-		filesWritten, err := identityfile.Write(cf.IdentityFileOut, key, cf.IdentityFormat, tc.KubeClusterAddr())
+		filesWritten, err := identityfile.Write(identityfile.WriteConfig{
+			OutputPath:           cf.IdentityFileOut,
+			Key:                  key,
+			Format:               cf.IdentityFormat,
+			KubeProxyAddr:        tc.KubeClusterAddr(),
+			OverwriteDestination: cf.IdentityOverwrite,
+		})
 		if err != nil {
 			utils.FatalError(err)
 		}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -345,7 +345,7 @@ func Run(args []string) {
 		identityfile.FormatOpenSSH,
 		identityfile.FormatKubernetes,
 	)).Default(string(identityfile.DefaultFormat)).StringVar((*string)(&cf.IdentityFormat))
-	login.Flag("overwrite", "Whether to overwrite the existing identity file, if present.").BoolVar(&cf.IdentityOverwrite)
+	login.Flag("overwrite", "Whether to overwrite the existing identity file.").BoolVar(&cf.IdentityOverwrite)
 	login.Flag("request-roles", "Request one or more extra roles").StringVar(&cf.DesiredRoles)
 	login.Flag("request-reason", "Reason for requesting additional roles").StringVar(&cf.RequestReason)
 	login.Arg("cluster", clusterHelp).StringVar(&cf.SiteName)


### PR DESCRIPTION
Running `tctl auth sign --format=kubernetes --out=filepath` or `tsh login
--format=kubernetes --out=filepath` should overwrite the target
`filepath` regardless of its existing contents.

Without this, the command could fail if parsing the existing file as a
kubeconfig fails.

Fixes https://github.com/gravitational/teleport/issues/4409