### PR TITLE
Adds simpler standalone k8s chart.

### DIFF
--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,0 +1,8 @@
+name: teleport-cluster
+apiVersion: v2
+version: 5.0.0
+appVersion: "5.0"
+description: Teleport is a unified access plane for your infrastructure
+icon: https://goteleport.com/images/logos/logo-teleport-square.svg
+keywords:
+  - Teleport

--- a/examples/chart/teleport-cluster/README.md
+++ b/examples/chart/teleport-cluster/README.md
@@ -1,0 +1,44 @@
+# Teleport Cluster
+
+This chart sets up a single node Teleport cluster.
+It uses a persistent volume claim for storage.
+Great for getting started with Teleport.
+
+## Getting Started
+
+Install Teleport in a separate namespace and provision a web certificate using Letsencrypt:
+
+```bash
+$ helm install teleport-cluster \
+    --set acmeEnabled=true \
+    --set acmeEmail=alice@example.com \
+    --set clusterName=teleport.example.com\
+    --create-namespace \
+    --namespace=teleport-cluster \
+    ./teleport-cluster/
+```
+
+## Uninstalling
+
+```bash
+helm uninstall teleport-cluster
+```
+
+## Arguments Reference
+
+To use The enterprise version, set `--set=enterprise=true` value and create a
+secret `license` in the chart namespace.
+
+Check https://goteleport.com/teleport/docs for more details.
+
+| Name                      | Description                                                                 | Default                                                | Required |
+|---------------------------|-----------------------------------------------------------------------------|--------------------------------------------------------|----------|
+| `clusterName`             | Teleport cluster name (must be an FQDN)                                     |                                                        | yes      |
+| `teleportVersionOverride` | Teleport version                                                            | Current stable version                                 | no       |
+| `image`                   | OSS Docker image                                                            | `quay.io/gravitational/teleport`                       | no       |
+| `enterpriseImage`         | Enterprise Docker image                                                     | `quay.io/gravitational/teleport-ent`                   | no       |
+| `acmeEnabled`             | Enable ACME support in Teleport (Letsencrypt.org)                           | `false`                                                | no       |
+| `acmeEmail`               | Email to use for ACME certificates                                          |                                                        | no       |
+| `acmeURI`                 | ACME server to use for certificates                                         | `https://acme-v02.api.letsencrypt.org/directory`       | no       |
+| `labels.[name]`           | Key-value pairs, for example `--labels.env=local --labels.region=us-west-1` |                                                        | no       |
+| `enterprise`              | Use Teleport Enterprise                                                     | `false`                                                | no       |

--- a/examples/chart/teleport-cluster/templates/clusterrole.yaml
+++ b/examples/chart/teleport-cluster/templates/clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - users
+  - groups
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - create

--- a/examples/chart/teleport-cluster/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-cluster/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -1,0 +1,32 @@
+{{- if not .Values.customConfig -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+data:
+  teleport.yaml: |
+    teleport:
+    auth_service:
+      enabled: true
+      cluster_name: {{ required "clusterName is required in chart values" .Values.clusterName }}
+{{- if .Values.enterprise }}
+      license_file: '/var/lib/license/license-enterprise.pem'
+{{- end }}
+    kubernetes_service:
+      enabled: true
+      listen_addr: 0.0.0.0:3027
+      labels:
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 8 }}
+{{- end }}
+    proxy_service:
+      public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
+      kube_listen_addr: 0.0.0.0:3026
+      enabled: true
+      acme:
+        enabled: {{ .Values.acme }}
+        email: {{ .Values.acmeEmail }}
+        uri: {{ .Values.acmeURI }}
+    ssh_service:
+      enabled: false
+{{- end -}}

--- a/examples/chart/teleport-cluster/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/deployment.yaml
@@ -26,14 +26,6 @@ spec:
         {{- if .Values.insecureSkipProxyTLSVerify }}
         - "--insecure"
         {{- end }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - all
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 9807
         ports:
         - name: diag
           containerPort: 3000
@@ -53,21 +45,26 @@ spec:
           periodSeconds: 5 # poll health every 5s
           failureThreshold: 12 # consider agent unhealthy after 60s (12 * 5s)
         volumeMounts:
+{{- if .Values.enterprise }}
+        - mountPath: /var/lib/license
+          name: "license"
+          readOnly: true
+{{- end }}
         - mountPath: /etc/teleport
           name: "config"
-          readOnly: true
-        - mountPath: /etc/teleport-secrets
-          name: "auth-token"
           readOnly: true
         - mountPath: /var/lib/teleport
           name: "data"
       volumes:
+{{- if .Values.enterprise }}
+      - name: license
+        secret:
+          secretName: "license"
+{{- end }}
       - name: "config"
         configMap:
           name: {{ .Release.Name }}
-      - name: "auth-token"
-        secret:
-          secretName: {{ .Values.secretName }}
       - name: "data"
-        emptyDir: {}
-      serviceAccountName: {{ .Values.serviceAccountName }}
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}
+      serviceAccountName: {{ .Release.Name }}

--- a/examples/chart/teleport-cluster/templates/psp.yaml
+++ b/examples/chart/teleport-cluster/templates/psp.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.podSecurityPolicy.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  runAsUser:
+    rule: MustRunAsNonRoot
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+  volumes:
+  - '*'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-psp
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-psp
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}
+{{- end -}}

--- a/examples/chart/teleport-cluster/templates/pvc.yaml
+++ b/examples/chart/teleport-cluster/templates/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/examples/chart/teleport-cluster/templates/service.yaml
+++ b/examples/chart/teleport-cluster/templates/service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  type: LoadBalancer
+  ports:
+    - name: https
+      port: 443
+      targetPort: 3080
+      protocol: TCP
+    - name: sshproxy
+      port: 3023
+      targetPort: 3023
+      protocol: TCP
+    - name: k8s
+      port: 3026
+      targetPort: 3026
+      protocol: TCP
+    - name: sshtun
+      port: 3024
+      targetPort: 3024
+      protocol: TCP
+  selector:
+    app: {{ .Release.Name }}

--- a/examples/chart/teleport-cluster/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -1,0 +1,48 @@
+##################################################
+# Values that must always be provided by the user.
+##################################################
+
+# clusterName is a unique cluster name.
+# This value cannot be changed after your cluster starts.
+# Use fully qualified domain name to access your cluster,
+# for example: teleport.example.com
+clusterName:
+
+##################################################
+# Values that you may need to change.
+##################################################
+
+# Version of teleport image, if different from appVersion in Chart.yaml.
+teleportVersionOverride: ""
+
+# ACME is a protocol for getting Web X.509 certificates
+# acme enables acme protocol
+acme: false
+acmeEmail: ""
+acmeURI: ""
+
+# Set enterprise to true to use enterprise image
+enterprise: false
+
+# If true, create & use Pod Security Policy resources
+# https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: true
+
+# Set customConfig to true to use a custom config. Create
+# a config resource, name it as release name and place it in the chart namespace.
+customConfig: false
+
+# Labels is a map of key-value pairs about this cluster
+labels: {}
+
+##################################################
+# Values that you shouldn't need to change.
+##################################################
+
+# Container image for the agent.
+image: quay.io/gravitational/teleport
+# Enterprise version of the image
+enterpriseImage: quay.io/gravitational/teleport-ent
+# Number of replicas for the agent deployment.
+replicaCount: 1

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -11,7 +11,10 @@ data:
     kubernetes_service:
       enabled: true
       kube_cluster_name: {{ required "kubeClusterName is required in chart values" .Values.kubeClusterName }}
-
+      labels:
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 8 }}
+{{- end }}
     auth_service:
       enabled: false
     ssh_service:

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -22,7 +22,10 @@ insecureSkipProxyTLSVerify: false
 # If true, create & use Pod Security Policy resources
 # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 podSecurityPolicy:
-  enabled: false
+  enabled: true
+
+# Labels is a map of key values pairs about this cluster
+labels: {}
 
 ##################################################
 # Values that you shouldn't need to change.


### PR DESCRIPTION
A new chart teleport-cluster helps users to get started
with Teleport on Kubernetes. It uses single node deployment with
persitent volumens and supports ACME.

A new quickstart guide will use this chart.