### PR TITLE
Add database access getting started guide

### DIFF
--- a/docs/5.0/preview/database-access.md
+++ b/docs/5.0/preview/database-access.md
@@ -38,6 +38,151 @@ With Database Access users can:
 Your browser does not support the video tag.
 </video>
 
+## Getting Started
+
+In this guide we will use Teleport Database Access to connect to a PostgreSQL
+flavored AWS Aurora database. Here's an overview of what we will do:
+
+1. Configure AWS Aurora database with IAM authentication.
+2. Download and install Teleport and connect it to the Aurora database.
+3. Connect to the Aurora database via Teleport.
+
+### Step 1/3. Setup Aurora
+
+In order to allow Teleport connections to an Aurora instance, it needs to support
+IAM authentication.
+
+If you don't have a database provisioned yet, create an instance of an Aurora
+PostgreSQL in the [RDS control panel](https://console.aws.amazon.com/rds/home).
+Make sure to choose "Standard create" database creation method and enable
+"Password and IAM database authentication" in the Database Authentication dialog.
+
+For existing Aurora instances, the status of IAM authentication is displayed on
+the Configuration tab and can be enabled by modifying the database instance.
+
+Next, create the following IAM policy attached to a user whose credentials a
+Teleport process will be using to allow it to connect to the database:
+
+```json
+{
+   "Version": "2012-10-17",
+   "Statement": [
+      {
+         "Effect": "Allow",
+         "Action": [
+             "rds-db:connect"
+         ],
+         "Resource": [
+             "arn:aws:rds-db:<region>:<account-id>:dbuser:<resource-id>/*"
+         ]
+      }
+   ]
+}
+```
+
+!!! note "Resource ID"
+    Database resource ID is shown on the Configuration tab of a particular
+    database instance in RDS control panel, under "Resource id". For regular
+    RDS database it starts with `db-` prefix. For Aurora, use the database
+    cluster resource ID (`cluster-`), not individual instance ID.
+
+Finally, connect to the database and create a database account with IAM auth
+support (or update an existing one). Once connected, execute the following
+SQL statements to create a new database account and allow IAM auth for it:
+
+```sql
+CREATE USER alice;
+GRANT rds_iam TO alice;
+```
+
+For more information about connecting to the PostgreSQL instance directly,
+see Amazon [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ConnectToPostgreSQLInstance.html).
+
+See a more detailed description of these steps in the [reference](#aws-rdsaurora-postgresql) below.
+
+### Step 2/3. Setup Teleport
+
+Teleport Database Access is available starting from `6.0.0-alpha.1` pre-release.
+
+Download the appropriate version of Teleport for your platform from the table
+below, or visit our [downloads page](https://goteleport.com/teleport/download).
+
+{% raw %}{{!docs/5.0/preview/releases-table.md!}}{% endraw %}
+
+!!! warning
+    Note, pre-releases are not suitable for production usage!
+
+Start Teleport using the following command and point it to your Aurora database
+instance. Make sure to update the database endpoint and region appropriately.
+
+```shell
+sudo teleport start \
+  --roles=proxy,auth,db \
+  --db-name=aurora \
+  --db-protocol=postgres \
+  --db-uri=postgres-aurora-instance-1.abcdefghijklm.us-west-1.rds.amazonaws.com:5432 \
+  --db-aws-region=us-west-1
+```
+
+!!! note "AWS credentials"
+    The node where the Teleport process is started should have AWS credentials
+    configured with the policy from [step 1](#step-13-setup-aurora).
+
+Create a Teleport user that is allowed to connect to a particular database
+(e.g. `postgres`) within the Aurora instance as a particular database account
+(e.g. `alice`).
+
+```shell
+sudo tctl users add alice root \
+  --db-names=postgres \
+  --db-users=alice
+```
+
+### Step 3/3. Connect to Database
+
+Now that Aurora is configured with IAM authentication, Teleport is running and
+the local user is created, we're ready to connect to the database.
+
+Log into Teleport with the user we've just created. Make sure to use `tsh`
+version `6.0.0-alpha.2` or newer that includes Database Access support.
+
+For simplicity, we're using an `--insecure` flag to accept Teleport's
+self-signed certificate. For production usage make sure to configure proxy
+with a proper certificate/key pair. See Teleport's general
+[quickstart guide](../quickstart.md#step-1c-configure-domain-name-and-obtain-tls-certificates-using-lets-encrypt).
+
+```shell
+tsh login --insecure --proxy=localhost:3080 --user=alice
+```
+
+Now we can inspect available databases and retrieve credentials for the
+configured Aurora instance:
+
+```shell
+tsh db ls
+tsh db login aurora
+```
+
+Finally, connect to the database using `psql` command shown in the output of
+`tsh db login` command, which may look like this:
+
+```shell
+psql "service=<cluster>-aurora user=alice dbname=postgres"
+```
+
+### Next Steps
+
+Congratulations on completing the Teleport Database Access getting started
+guide!
+
+For the next steps, dive deeper into the topics relevant to your Database
+Access use-case, for example:
+
+* Learn how to connect to a [self-hosted database](#self-hosted-postgresql).
+* Learn how to configure Database Access via Teleport [configuration file](#configure-teleport).
+* Learn about Database Access [RBAC](#rbac).
+* See [frequently asked questions](#faq).
+
 ## Diagram
 
 The following diagram shows an example Database Access setup:
@@ -52,8 +197,9 @@ The following diagram shows an example Database Access setup:
 
 ## Release Schedule
 
-Teleport Database Access is under active development. The alpha release will
-include support for PostgreSQL, including Amazon RDS and Aurora.
+Teleport Database Access is under active development and is available starting
+from `6.0.0-alpha.1` release. The alpha version includes support for self-hosted
+PostgreSQL as well as PostgreSQL compatible AWS RDS and Aurora.
 
 See [release schedule](./upcoming-releases.md#release-schedule).
 
@@ -204,13 +350,15 @@ for more information.
 
 ## Configure Teleport
 
-First, head over to the Teleport [downloads page](https://goteleport.com/teleport/download/)
-and download the latest version of Teleport.
+Teleport Database Access is available starting from `6.0.0-alpha.1` pre-release.
+
+Download the appropriate version of Teleport for your platform from the table
+below, or visit our [downloads page](https://goteleport.com/teleport/download).
+
+{% raw %}{{!docs/5.0/preview/releases-table.md!}}{% endraw %}
 
 !!! warning
-
-    As of this writing, no Teleport release with Database Access has been
-    published yet.
+    Note, pre-releases are not suitable for production usage!
 
 Follow the installation [instructions](../installation.md).
 
@@ -252,7 +400,7 @@ file and can be launched using a single CLI command:
 
 ```sh
 $ teleport start --debug \
-   --roles=database \
+   --roles=db \
    --token=cbdeeab9-6f88-436d-a673-44d14bd86bb7 \
    --auth-server=teleport.example.com:3080 \
    --db-name=test \
@@ -270,7 +418,7 @@ be generated for a database service:
 
 ```sh
 $ tctl tokens add \
-    --type=database \
+    --type=db \
     --db-name=test \
     --db-protocol=postgres \
     --db-uri=db.example.com:5432

--- a/docs/5.0/preview/releases-table.md
+++ b/docs/5.0/preview/releases-table.md
@@ -1,0 +1,23 @@
+
+=== "Teleport Community Edition"
+    | OPERATING SYSTEM | CHECKSUM | DOWNLOAD LINK |
+    |-|-|-|
+    | Linux 32-bit | [SHA256](https://get.gravitational.com/teleport-v6.0.0-alpha.2-linux-386-bin.tar.gz.sha256) | [teleport-v6.0.0-alpha.2-linux-386-bin.tar.gz](https://get.gravitational.com/teleport-v6.0.0-alpha.2-linux-386-bin.tar.gz) |
+    | Linux 64-bit | [SHA256](https://get.gravitational.com/teleport-v6.0.0-alpha.2-linux-amd64-bin.tar.gz.sha256) | [teleport-v6.0.0-alpha.2-linux-amd64-bin.tar.gz](https://get.gravitational.com/teleport-v6.0.0-alpha.2-linux-amd64-bin.tar.gz) |
+    | Linux 64-bit (RHEL/CentOS 6.x compatible) | [SHA256](https://get.gravitational.com/teleport-v6.0.0-alpha.2-linux-amd64-centos6-bin.tar.gz.sha256) | [teleport-v6.0.0-alpha.2-linux-amd64-centos6-bin.tar.gz](https://get.gravitational.com/teleport-v6.0.0-alpha.2-linux-amd64-centos6-bin.tar.gz) |
+    | Linux ARMv7 | [SHA256](https://get.gravitational.com/teleport-v6.0.0-alpha.2-linux-arm-bin.tar.gz.sha256) | [teleport-v6.0.0-alpha.2-linux-arm-bin.tar.gz](https://get.gravitational.com/teleport-v6.0.0-alpha.2-linux-arm-bin.tar.gz) |
+    | Linux 64-bit DEB | [SHA256](https://get.gravitational.com/teleport_6.0.0-alpha.2_amd64.deb.sha256) | [teleport_v6.0.0-alpha.2_amd64.deb](https://get.gravitational.com/teleport_6.0.0-alpha.2_amd64.deb) |
+    | Linux 32-bit DEB | [SHA256](https://get.gravitational.com/teleport_6.0.0-alpha.2_i386.deb.sha256) | [teleport_v6.0.0-alpha.2_i386.deb](https://get.gravitational.com/teleport_6.0.0-alpha.2_amd64.deb) |
+    | Linux 64-bit RPM | [SHA256](https://get.gravitational.com/teleport-6.0.0-alpha.2-1.x86_64.rpm.sha256) | [teleport-6.0.0-alpha.2-1.x86_64.rpm](https://get.gravitational.com/teleport-6.0.0-alpha.2-1.x86_64.rpm)
+    | Docker Image | [SHA256](https://quay.io/repository/gravitational/teleport?tab=tags) | `docker pull quay.io/gravitational/teleport:6.0.0-alpha.2` |
+=== "Teleport Enterprise Edition"
+    | OPERATING SYSTEM | CHECKSUM | DOWNLOAD LINK |
+    |-|-|-|
+    | Linux 32-bit | [SHA256](https://get.gravitational.com/teleport-ent-v6.0.0-alpha.2-linux-386-bin.tar.gz.sha256) | [teleport-ent-v6.0.0-alpha.2-linux-386-bin.tar.gz](https://get.gravitational.com/teleport-ent-v6.0.0-alpha.2-linux-386-bin.tar.gz) |
+    | Linux 64-bit | [SHA256](https://get.gravitational.com/teleport-ent-v6.0.0-alpha.2-linux-amd64-bin.tar.gz.sha256) | [teleport-ent-v6.0.0-alpha.2-linux-amd64-bin.tar.gz](https://get.gravitational.com/teleport-ent-v6.0.0-alpha.2-linux-amd64-bin.tar.gz) |
+    | Linux 64-bit (RHEL/CentOS 6.x compatible) | [SHA256](https://get.gravitational.com/teleport-ent-v6.0.0-alpha.2-linux-amd64-centos6-bin.tar.gz.sha256) | [teleport-ent-v6.0.0-alpha.2-linux-amd64-centos6-bin.tar.gz](https://get.gravitational.com/teleport-ent-v6.0.0-alpha.2-linux-amd64-centos6-bin.tar.gz) |
+    | Linux ARMv7 | [SHA256](https://get.gravitational.com/teleport-ent-v6.0.0-alpha.2-linux-arm-bin.tar.gz.sha256) | [teleport-ent-v6.0.0-alpha.2-linux-arm-bin.tar.gz](https://get.gravitational.com/teleport-ent-v6.0.0-alpha.2-linux-arm-bin.tar.gz) |
+    | Linux 64-bit DEB | [SHA256](https://get.gravitational.com/teleport-ent_6.0.0-alpha.2_amd64.deb.sha256) | [teleport-ent_v6.0.0-alpha.2_amd64.deb](https://get.gravitational.com/teleport-ent_6.0.0-alpha.2_amd64.deb) |
+    | Linux 32-bit DEB | [SHA256](https://get.gravitational.com/teleport-ent_6.0.0-alpha.2_i386.deb.sha256) | [teleport-ent_v6.0.0-alpha.2_i386.deb](https://get.gravitational.com/teleport-ent_6.0.0-alpha.2_i386.deb) |
+    | Linux 64-bit RPM | [SHA256](https://get.gravitational.com/teleport-ent-6.0.0-alpha.2-1.x86_64.rpm.sha256) | [teleport-ent-6.0.0-alpha.2-1.x86_64.rpm](https://get.gravitational.com/teleport-ent-6.0.0-alpha.2-1.x86_64.rpm)
+    | Docker Image | [SHA256](https://quay.io/repository/gravitational/teleport-ent?tab=tags) | `docker pull quay.io/gravitational/teleport-ent:6.0.0-alpha.2` |


### PR DESCRIPTION
In preparation for the first alpha release with database access, I've added a short-ish getting started guide. Existing database access documentation is more of a reference as it's pretty extensive with a lot of details that makes it hard to follow for new users.

I also noticed that Sasha submitted https://github.com/gravitational/teleport/pull/5305 so tried to follow suggestions from there as well, I'm open to tweaking it further if needed.