### PR TITLE
Correct the user name in the tctl auth sign step

### DIFF
--- a/docs/5.0/enterprise/workflow/ssh-approval-jira-cloud.md
+++ b/docs/5.0/enterprise/workflow/ssh-approval-jira-cloud.md
@@ -59,7 +59,7 @@ $ tctl create -f rscs.yaml
 Teleport Plugin use the `access-plugin-jira` role and user to perform the approval. We export the identity files, using [`tctl auth sign`](https://gravitational.com/teleport/docs/cli-docs/#tctl-auth-sign).
 
 ```bash
-$ tctl auth sign --format=tls --user=access-plugin --out=auth --ttl=8760h
+$ tctl auth sign --format=tls --user=access-plugin-jira --out=auth --ttl=8760h
 # ...
 ```
 


### PR DESCRIPTION
make it match the user name created above.

Fixes https://github.com/gravitational/teleport/issues/5311