### PR TITLE
provide my own configmap

### DIFF
--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -1,3 +1,4 @@
+{{- if eq "" .Values.config.existingConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,37 +11,35 @@ data:
 {{ toYaml .Values.otherConfig.teleportConfig | indent 4 }}
 {{- else }}
     teleport:
-{{- if not .Values.config.highAvailability }}
+    {{- if not .Values.config.highAvailability }}
       nodename: {{ template "teleport.fullname" . }}
-{{- end }}
-{{- if  .Values.config.auth_service_connection }}
-{{ toYaml .Values.config.auth_service_connection | indent 6 }}
-{{- end }}
+    {{- end }}
+    {{- if  .Values.config.auth_service_connection }}
+    {{- toYaml .Values.config.auth_service_connection | nindent 6 }}
+    {{- end }}
       pid_file: {{ .Values.config.teleport.pid_file }}
       data_dir: {{ .Values.config.teleport.data_dir  }}
-{{- if .Values.config.teleport.log }}
+    {{- if .Values.config.teleport.log }}
       log:
-{{ toYaml .Values.config.teleport.log | indent 8 }}
-{{- end }}
+    {{- toYaml .Values.config.teleport.log | nindent 8 }}
+    {{- end }}
       # storage settings included
       storage:
-{{ toYaml .Values.config.teleport.storage | indent 8 }}
-
+    {{- toYaml .Values.config.teleport.storage | nindent 8 }}
       connection_limits:
-{{ toYaml .Values.config.teleport.connection_limits | indent 8 }}
+    {{- toYaml .Values.config.teleport.connection_limits | nindent 8 }}
     auth_service:
-{{- if .Values.config.highAvailability }}
+    {{- if .Values.config.highAvailability }}
       enabled: false
-{{- else }}
+    {{- else }}
       enabled: {{ .Values.config.teleport.auth_service.enabled }}
-{{- if .Values.license.enabled }}
+        {{- if .Values.license.enabled }}
       license_file: {{ .Values.config.teleport.auth_service.license_file }}
-{{- end }}
+        {{- end }}
       authentication:
-{{ toYaml .Values.config.teleport.auth_service.authentication | indent 8 }}
+        {{- toYaml .Values.config.teleport.auth_service.authentication | nindent 8 }}
       tokens:
-{{ toYaml .Values.config.teleport.auth_service.tokens | indent 8 }}
-
+        {{- toYaml .Values.config.teleport.auth_service.tokens | nindent 8 }}
       public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.authssh.port }}
       cluster_name: {{ .Values.config.public_address }}
       listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.authssh.containerPort }}
@@ -48,24 +47,24 @@ data:
       disconnect_expired_cert: {{ .Values.config.teleport.auth_service.disconnect_expired_cert }}
       keep_alive_interval: {{ .Values.config.teleport.auth_service.keep_alive_interval }}
       keep_alive_count_max: {{ .Values.config.teleport.auth_service.keep_alive_count_max }}
-{{- end }}
+    {{- end }}
 
     ssh_service:
-{{- if not .Values.config.highAvailability }}
+    {{- if not .Values.config.highAvailability }}
       enabled: {{ .Values.config.teleport.ssh_service.enabled }}
-{{- else }}
+    {{- else }}
       enabled: false
-{{- end }}
+    {{- end }}
       public_addr: {{ template "teleport.fullname" . }}node:{{ .Values.ports.nodessh.containerPort }}
       listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.nodessh.containerPort }}
       commands:
-{{ toYaml .Values.config.teleport.ssh_service.commands | indent 8 }}
+        {{- toYaml .Values.config.teleport.ssh_service.commands | nindent 8 }}
       labels:
-{{ toYaml .Values.config.teleport.ssh_service.labels | indent 8 }}
+        {{- toYaml .Values.config.teleport.ssh_service.labels | nindent 8 }}
       enhanced_recording:
-{{ toYaml .Values.config.teleport.ssh_service.enhanced_recording | indent 8 }}
+        {{- toYaml .Values.config.teleport.ssh_service.enhanced_recording | nindent 8 }}
       pam:
-{{ toYaml .Values.config.teleport.ssh_service.pam | indent 8 }}
+        {{- toYaml .Values.config.teleport.ssh_service.pam | nindent 8 }}
 
     proxy_service:
       enabled: {{ .Values.config.teleport.proxy_service.enabled }}
@@ -91,6 +90,7 @@ data:
         enabled: {{ .Values.config.teleport.proxy_service.kubernetes.enabled }}
         public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}
         listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxykube.containerPort }}
+{{- end }}
 {{- end }}
 {{- if .Values.config.highAvailability }}
 ---

--- a/examples/chart/teleport/templates/deployment.yaml
+++ b/examples/chart/teleport/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
         secret:
           secretName: {{ .Values.license.secretName }}
 {{- end }}
-      - name: {{ template "teleport.fullname" . }}-config
+      - name: {{ .Values.config.existingConfig | default (printf "%s-config" (include "teleport.fullname" .)) }}
         configMap:
           name: {{ template "teleport.fullname" . }}
       - name: {{ template "teleport.fullname" . }}-storage

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -40,6 +40,9 @@ proxy:
 # configuration
 #
 config:
+  # Inject your own configmap mounted by teleport. This is useful for things like
+  # hydrating a configmap outside of the chart and mounting it into teleport pod.
+  existingConfig: ""
   # used for cluster name, advertise_ip, and public addresses
   # If high availability is set it is only used for the proxy
   public_address: teleport.example.com
@@ -343,4 +346,3 @@ tolerations: []
 #   operator: "Equal"
 #   value: "teleport"
 #   effect: "NoSchedule"
-


### PR DESCRIPTION
    As a developer, I want to customize the setup of the config.yaml
    sent to teleport. The primary use case is to separate credentials
    from application configuration. See #5058

    In lieu of a complete solution, we would like to override the config
    mounted in teleport.