### PR TITLE
Refactor postgres service file handling, add db config command

### DIFF
--- a/lib/client/db/postgres/servicefile.go
+++ b/lib/client/db/postgres/servicefile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Gravitational, Inc.
+Copyright 2020-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,90 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pgservicefile
+package postgres
 
 import (
-	"fmt"
-	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
 
-	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/client/db/profile"
 
 	"github.com/gravitational/trace"
 	"gopkg.in/ini.v1"
 )
-
-// Add updates Postgres connection service file at the default location with
-// the connection information for the provided profile.
-func Add(cluster, name, user, database string, profile client.ProfileStatus, quiet bool) error {
-	serviceFile, err := Load()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	addr, err := utils.ParseAddr(profile.ProxyURL.Host)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	connectProfile := ConnectProfile{
-		Name:        serviceName(cluster, name),
-		Host:        addr.Host(),
-		Port:        addr.Port(defaults.HTTPListenPort),
-		User:        user,
-		Database:    database,
-		SSLMode:     SSLModeVerifyFull, // TODO(r0mant): Support insecure mode.
-		SSLRootCert: profile.CACertPath(),
-		SSLCert:     profile.DatabaseCertPath(name),
-		SSLKey:      profile.KeyPath(),
-	}
-	err = serviceFile.Upsert(connectProfile)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if quiet {
-		return nil
-	}
-	return tshMessageTpl.Execute(os.Stdout, connectProfile)
-}
-
-// Env returns environment variables for the provided Postgres service from
-// the default connection service file.
-func Env(cluster, name string) (map[string]string, error) {
-	serviceFile, err := Load()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	env, err := serviceFile.Env(serviceName(cluster, name))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return env, nil
-}
-
-// Delete deletes specified connection profile from the default Postgres
-// service file.
-func Delete(cluster, name string) error {
-	serviceFile, err := Load()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	err = serviceFile.Delete(serviceName(cluster, name))
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
-// serviceName constructs the Postgres connection service name from the
-// Teleport cluster name and the database service name.
-func serviceName(cluster, name string) string {
-	return fmt.Sprintf("%v-%v", cluster, name)
-}
 
 // ServiceFile represents Postgres connection service file.
 //
@@ -150,7 +80,7 @@ func LoadFromPath(path string) (*ServiceFile, error) {
 // parameter:
 //
 //   $ psql "service=postgres <other parameters>"
-func (s *ServiceFile) Upsert(profile ConnectProfile) error {
+func (s *ServiceFile) Upsert(profile profile.ConnectProfile) error {
 	section := s.iniFile.Section(profile.Name)
 	if section != nil {
 		s.iniFile.DeleteSection(profile.Name)
@@ -167,10 +97,14 @@ func (s *ServiceFile) Upsert(profile ConnectProfile) error {
 	if profile.Database != "" {
 		section.NewKey("dbname", profile.Database)
 	}
-	section.NewKey("sslmode", profile.SSLMode)
-	section.NewKey("sslrootcert", profile.SSLRootCert)
-	section.NewKey("sslcert", profile.SSLCert)
-	section.NewKey("sslkey", profile.SSLKey)
+	if profile.Insecure {
+		section.NewKey("sslmode", SSLModeVerifyCA)
+	} else {
+		section.NewKey("sslmode", SSLModeVerifyFull)
+	}
+	section.NewKey("sslrootcert", profile.CACertPath)
+	section.NewKey("sslcert", profile.CertPath)
+	section.NewKey("sslkey", profile.KeyPath)
 	ini.PrettyFormat = false // Pretty format breaks psql.
 	return s.iniFile.SaveTo(s.path)
 }
@@ -240,36 +174,17 @@ func (s *ServiceFile) Delete(name string) error {
 	return s.iniFile.SaveTo(s.path)
 }
 
-// ConnectProfile represents a single connection profile in the service file.
-type ConnectProfile struct {
-	// Name is the profile name.
-	Name string
-	// Host is the host to connect to.
-	Host string
-	// Port is the port number to connect to.
-	Port int
-	// User is an optional database user name.
-	User string
-	// Database is an optional database name.
-	Database string
-	// SSLMode is the SSL connection mode.
-	SSLMode string
-	// SSLRootCert is the CA certificate path.
-	SSLRootCert string
-	// SSLCert is the client certificate path.
-	SSLCert string
-	// SSLKey is the client key path.
-	SSLKey string
-}
+const (
+	// SSLModeVerifyFull is the Postgres SSL "verify-full" mode.
+	SSLModeVerifyFull = "verify-full"
+	// SSLModeVerifyCA is the Postgres SSL "verify-ca" mode.
+	SSLModeVerifyCA = "verify-ca"
+	// pgServiceFile is the default name of the Postgres service file.
+	pgServiceFile = ".pg_service.conf"
+)
 
-// pgServiceFile is the default name of the Postgres service file.
-const pgServiceFile = ".pg_service.conf"
-
-// SSLModeVerifyFull is the Postgres SSL "verify-full" mode.
-const SSLModeVerifyFull = "verify-full"
-
-// tshMessage is printed after Postgres service file has been updated.
-var tshMessageTpl = template.Must(template.New("").Parse(`
+// Message is printed after Postgres service file has been updated.
+var Message = template.Must(template.New("").Parse(`
 Connection information for PostgreSQL database "{{.Name}}" has been saved.
 
 You can now connect to the database using the following command:

--- a/lib/client/db/postgres/servicefile.go
+++ b/lib/client/db/postgres/servicefile.go
@@ -176,8 +176,14 @@ func (s *ServiceFile) Delete(name string) error {
 
 const (
 	// SSLModeVerifyFull is the Postgres SSL "verify-full" mode.
+	//
+	// See Postgres SSL docs for more info:
+	// https://www.postgresql.org/docs/current/libpq-ssl.html
 	SSLModeVerifyFull = "verify-full"
 	// SSLModeVerifyCA is the Postgres SSL "verify-ca" mode.
+	//
+	// See Postgres SSL docs for more info:
+	// https://www.postgresql.org/docs/current/libpq-ssl.html
 	SSLModeVerifyCA = "verify-ca"
 	// pgServiceFile is the default name of the Postgres service file.
 	pgServiceFile = ".pg_service.conf"

--- a/lib/client/db/postgres/servicefile_test.go
+++ b/lib/client/db/postgres/servicefile_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Gravitational, Inc.
+Copyright 2020-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pgservicefile
+package postgres
 
 import (
 	"path/filepath"
 	"strconv"
 	"testing"
+
+	"github.com/gravitational/teleport/lib/client/db/profile"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -31,16 +33,16 @@ func TestServiceFile(t *testing.T) {
 	serviceFile, err := LoadFromPath(path)
 	require.NoError(t, err)
 
-	profile := ConnectProfile{
-		Name:        "test",
-		Host:        "localhost",
-		Port:        5342,
-		User:        "postgres",
-		Database:    "postgres",
-		SSLMode:     "on",
-		SSLRootCert: "ca.pem",
-		SSLCert:     "cert.pem",
-		SSLKey:      "key.pem",
+	profile := profile.ConnectProfile{
+		Name:       "test",
+		Host:       "localhost",
+		Port:       5342,
+		User:       "postgres",
+		Database:   "postgres",
+		Insecure:   false,
+		CACertPath: "ca.pem",
+		CertPath:   "cert.pem",
+		KeyPath:    "key.pem",
 	}
 
 	err = serviceFile.Upsert(profile)
@@ -53,10 +55,10 @@ func TestServiceFile(t *testing.T) {
 		"PGPORT":        strconv.Itoa(profile.Port),
 		"PGUSER":        profile.User,
 		"PGDATABASE":    profile.Database,
-		"PGSSLMODE":     profile.SSLMode,
-		"PGSSLROOTCERT": profile.SSLRootCert,
-		"PGSSLCERT":     profile.SSLCert,
-		"PGSSLKEY":      profile.SSLKey,
+		"PGSSLMODE":     SSLModeVerifyFull,
+		"PGSSLROOTCERT": profile.CACertPath,
+		"PGSSLCERT":     profile.CertPath,
+		"PGSSLKEY":      profile.KeyPath,
 	}, env)
 
 	err = serviceFile.Delete(profile.Name)

--- a/lib/client/db/profile.go
+++ b/lib/client/db/profile.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package db contains methods for working with database connection profiles
+// that combine connection parameters for a particular database.
+//
+// For Postgres it's the connection service file:
+//   https://www.postgresql.org/docs/current/libpq-pgservice.html
+package db
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/db/postgres"
+	"github.com/gravitational/teleport/lib/client/db/profile"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/tlsca"
+
+	"github.com/gravitational/trace"
+)
+
+// Add updates database connection profile file.
+func Add(tc *client.TeleportClient, db tlsca.RouteToDatabase, clientProfile client.ProfileStatus, quiet bool) error {
+	profileFile, err := load(db)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	host, port := tc.WebProxyHostPort()
+	connectProfile := profile.ConnectProfile{
+		Name:       profileName(tc.SiteName, db.ServiceName),
+		Host:       host,
+		Port:       port,
+		User:       db.Username,
+		Database:   db.Database,
+		Insecure:   tc.InsecureSkipVerify,
+		CACertPath: clientProfile.CACertPath(),
+		CertPath:   clientProfile.DatabaseCertPath(db.ServiceName),
+		KeyPath:    clientProfile.KeyPath(),
+	}
+	err = profileFile.Upsert(connectProfile)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if quiet {
+		return nil
+	}
+	switch db.Protocol {
+	case defaults.ProtocolPostgres:
+		return postgres.Message.Execute(os.Stdout, connectProfile)
+	}
+	return nil
+}
+
+// Env returns environment variables for the specified database profile.
+func Env(tc *client.TeleportClient, db tlsca.RouteToDatabase) (map[string]string, error) {
+	profileFile, err := load(db)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	env, err := profileFile.Env(profileName(tc.SiteName, db.ServiceName))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return env, nil
+}
+
+// Delete removes the specified database connection profile.
+func Delete(tc *client.TeleportClient, db tlsca.RouteToDatabase) error {
+	profileFile, err := load(db)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = profileFile.Delete(profileName(tc.SiteName, db.ServiceName))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// load loads the appropriate database connection profile.
+func load(db tlsca.RouteToDatabase) (profile.ConnectProfileFile, error) {
+	switch db.Protocol {
+	case defaults.ProtocolPostgres:
+		return postgres.Load()
+	}
+	return nil, trace.BadParameter("unsupported database protocol %q",
+		db.Protocol)
+}
+
+// profileName constructs the Postgres connection service name from the
+// Teleport cluster name and the database service name.
+func profileName(cluster, name string) string {
+	return fmt.Sprintf("%v-%v", cluster, name)
+}

--- a/lib/client/db/profile/profile.go
+++ b/lib/client/db/profile/profile.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+// ConnectProfileFile is a common interface for database connection profiles.
+type ConnectProfileFile interface {
+	// Upsert saves the provided connection profile.
+	Upsert(profile ConnectProfile) error
+	// Env returns the specified connection profile as environment variables.
+	Env(name string) (map[string]string, error)
+	// Delete removes the specified connection profile.
+	Delete(name string) error
+}
+
+// ConnectProfile represents a database connection profile parameters.
+type ConnectProfile struct {
+	// Name is the profile name.
+	Name string
+	// Host is the host to connect to.
+	Host string
+	// Port is the port number to connect to.
+	Port int
+	// User is an optional database user name.
+	User string
+	// Database is an optional database name.
+	Database string
+	// Insecure is whether to skip certificate validation.a
+	Insecure bool
+	// CACertPath is the CA certificate path.
+	CACertPath string
+	// CertPath is the client certificate path.
+	CertPath string
+	// KeyPath is the client key path.
+	KeyPath string
+}

--- a/lib/client/db/profile/profile.go
+++ b/lib/client/db/profile/profile.go
@@ -38,7 +38,7 @@ type ConnectProfile struct {
 	User string
 	// Database is an optional database name.
 	Database string
-	// Insecure is whether to skip certificate validation.a
+	// Insecure is whether to skip certificate validation.
 	Insecure bool
 	// CACertPath is the CA certificate path.
 	CACertPath string

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// onListDatabases handles "tsh db ls" command.
+// onListDatabases implements "tsh db ls" command.
 func onListDatabases(cf *CLIConf) {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -61,7 +61,7 @@ func onListDatabases(cf *CLIConf) {
 	showDatabases(tc.SiteName, servers, profile.Databases, cf.Verbose)
 }
 
-// onDatabaseLogin handles "tsh db login" command.
+// onDatabaseLogin implements "tsh db login" command.
 func onDatabaseLogin(cf *CLIConf) {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -148,7 +148,7 @@ func fetchDatabaseCreds(cf *CLIConf, tc *client.TeleportClient) error {
 	return nil
 }
 
-// onDatabaseLogout handles "tsh db logout" command.
+// onDatabaseLogout implements "tsh db logout" command.
 func onDatabaseLogout(cf *CLIConf) {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -199,7 +199,7 @@ func databaseLogout(tc *client.TeleportClient, db tlsca.RouteToDatabase) error {
 	return nil
 }
 
-// onDatabaseEnv handles "tsh db env" command.
+// onDatabaseEnv implements "tsh db env" command.
 func onDatabaseEnv(cf *CLIConf) {
 	tc, err := makeClient(cf, false)
 	if err != nil {
@@ -218,7 +218,7 @@ func onDatabaseEnv(cf *CLIConf) {
 	}
 }
 
-// onDatabaseConfig handles "tsh db config" command.
+// onDatabaseConfig implements "tsh db config" command.
 func onDatabaseConfig(cf *CLIConf) {
 	tc, err := makeClient(cf, false)
 	if err != nil {

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -24,8 +24,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/client/pgservicefile"
-	"github.com/gravitational/teleport/lib/defaults"
+	dbprofile "github.com/gravitational/teleport/lib/client/db"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -59,7 +58,7 @@ func onListDatabases(cf *CLIConf) {
 	sort.Slice(servers, func(i, j int) bool {
 		return servers[i].GetName() < servers[j].GetName()
 	})
-	showDatabases(servers, profile.Databases, cf.Verbose)
+	showDatabases(tc.SiteName, servers, profile.Databases, cf.Verbose)
 }
 
 // onDatabaseLogin handles "tsh db login" command.
@@ -120,14 +119,10 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, db tlsca.RouteToDatab
 	if err != nil {
 		utils.FatalError(err)
 	}
-	// Perform database-specific actions such as updating Postgres
-	// connection service file.
-	switch db.Protocol {
-	case defaults.ProtocolPostgres:
-		err := pgservicefile.Add(tc.SiteName, db.ServiceName, db.Username, db.Database, *profile, quiet)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+	// Update the database-specific connection profile file.
+	err = dbprofile.Add(tc, db, *profile, quiet)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 	return nil
 }
@@ -191,17 +186,13 @@ func onDatabaseLogout(cf *CLIConf) {
 }
 
 func databaseLogout(tc *client.TeleportClient, db tlsca.RouteToDatabase) error {
-	// First perform database-specific actions, such as remove connection
-	// information from Postgres service file.
-	switch db.Protocol {
-	case defaults.ProtocolPostgres:
-		err := pgservicefile.Delete(tc.SiteName, db.ServiceName)
-		if err != nil {
-			return trace.Wrap(err)
-		}
+	// First remove respective connection profile.
+	err := dbprofile.Delete(tc, db)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 	// Then remove the certificate from the keystore.
-	err := tc.LogoutDatabase(db.ServiceName)
+	err = tc.LogoutDatabase(db.ServiceName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -210,27 +201,77 @@ func databaseLogout(tc *client.TeleportClient, db tlsca.RouteToDatabase) error {
 
 // onDatabaseEnv handles "tsh db env" command.
 func onDatabaseEnv(cf *CLIConf) {
-	profile, err := client.StatusCurrent("", cf.Proxy)
+	tc, err := makeClient(cf, false)
 	if err != nil {
 		utils.FatalError(err)
 	}
-	if len(profile.Databases) == 0 {
-		utils.FatalError(trace.BadParameter("Please login using 'tsh db login' first"))
+	database, err := pickActiveDatabase(cf)
+	if err != nil {
+		utils.FatalError(err)
 	}
-	database := cf.DatabaseService
-	if database == "" {
-		services := profile.DatabaseServices()
-		if len(services) > 1 {
-			utils.FatalError(trace.BadParameter("Multiple databases are available (%v), please select the one to print environment for via --db flag",
-				strings.Join(services, ", ")))
-		}
-		database = services[0]
-	}
-	env, err := pgservicefile.Env(profile.Cluster, database)
+	env, err := dbprofile.Env(tc, *database)
 	if err != nil {
 		utils.FatalError(err)
 	}
 	for k, v := range env {
 		fmt.Printf("export %v=%v\n", k, v)
 	}
+}
+
+// onDatabaseConfig handles "tsh db config" command.
+func onDatabaseConfig(cf *CLIConf) {
+	tc, err := makeClient(cf, false)
+	if err != nil {
+		utils.FatalError(err)
+	}
+	profile, err := client.StatusCurrent("", cf.Proxy)
+	if err != nil {
+		utils.FatalError(err)
+	}
+	database, err := pickActiveDatabase(cf)
+	if err != nil {
+		utils.FatalError(err)
+	}
+	host, port := tc.WebProxyHostPort()
+	fmt.Printf(`Name:      %v
+Host:      %v
+Port:      %v
+User:      %v
+Database:  %v
+CA:        %v
+Cert:      %v
+Key:       %v
+`,
+		database.ServiceName, host, port, database.Username,
+		database.Database, profile.CACertPath(),
+		profile.DatabaseCertPath(database.ServiceName), profile.KeyPath())
+}
+
+// pickActiveDatabase returns the database the current profile is logged into.
+//
+// If logged into multiple databases, returns an error unless one specified
+// explicily via --db flag.
+func pickActiveDatabase(cf *CLIConf) (*tlsca.RouteToDatabase, error) {
+	profile, err := client.StatusCurrent("", cf.Proxy)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if len(profile.Databases) == 0 {
+		return nil, trace.NotFound("Please login using 'tsh db login' first")
+	}
+	name := cf.DatabaseService
+	if name == "" {
+		services := profile.DatabaseServices()
+		if len(services) > 1 {
+			return nil, trace.BadParameter("Multiple databases are available (%v), please select one using --db flag",
+				strings.Join(services, ", "))
+		}
+		name = services[0]
+	}
+	for _, db := range profile.Databases {
+		if db.ServiceName == name {
+			return &db, nil
+		}
+	}
+	return nil, trace.NotFound("Not logged into database %q", name)
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1149,11 +1149,11 @@ func formatConnectCommand(cluster string, active tlsca.RouteToDatabase) string {
 		case active.Username != "" && active.Database != "":
 			return fmt.Sprintf(`psql "service=%v"`, service)
 		case active.Username != "":
-			return fmt.Sprintf(`psql "service=%v dbname="`, service)
+			return fmt.Sprintf(`psql "service=%v dbname=<database>"`, service)
 		case active.Database != "":
-			return fmt.Sprintf(`psql "service=%v user="`, service)
+			return fmt.Sprintf(`psql "service=%v user=<user>"`, service)
 		}
-		return fmt.Sprintf(`psql "service=%v user= dbname="`, service)
+		return fmt.Sprintf(`psql "service=%v user=<user> dbname=<database>"`, service)
 	}
 	return ""
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -41,8 +41,8 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/benchmark"
 	"github.com/gravitational/teleport/lib/client"
+	dbprofile "github.com/gravitational/teleport/lib/client/db"
 	"github.com/gravitational/teleport/lib/client/identityfile"
-	"github.com/gravitational/teleport/lib/client/pgservicefile"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
@@ -301,6 +301,8 @@ func Run(args []string) {
 	dbLogout.Arg("db", "Database to remove credentials for.").StringVar(&cf.DatabaseService)
 	dbEnv := db.Command("env", "Print environment variables for the configured database.")
 	dbEnv.Flag("db", "Database to print environment for if logged into multiple.").StringVar(&cf.DatabaseService)
+	dbConfig := db.Command("config", "Print database connection information. Useful when configuring GUI clients.")
+	dbConfig.Flag("db", "Database to print information for if logged into multiple.").StringVar(&cf.DatabaseService)
 
 	// join
 	join := app.Command("join", "Join the active SSH session")
@@ -461,6 +463,8 @@ func Run(args []string) {
 		onDatabaseLogout(&cf)
 	case dbEnv.FullCommand():
 		onDatabaseEnv(&cf)
+	case dbConfig.FullCommand():
+		onDatabaseConfig(&cf)
 	default:
 		// This should only happen when there's a missing switch case above.
 		err = trace.BadParameter("command %q not configured", command)
@@ -838,7 +842,7 @@ func onLogout(cf *CLIConf) {
 		if profile != nil {
 			for _, db := range profile.Databases {
 				log.Debugf("Logging %v out of database %v.", profile.Name, db)
-				err = pgservicefile.Delete(profile.Cluster, db.ServiceName)
+				err = dbprofile.Delete(tc, db)
 				if err != nil {
 					utils.FatalError(err)
 					return
@@ -900,7 +904,7 @@ func onLogout(cf *CLIConf) {
 		for _, profile := range profiles {
 			for _, db := range profile.Databases {
 				log.Debugf("Logging %v out of database %v.", profile.Name, db)
-				err = pgservicefile.Delete(profile.Cluster, db.ServiceName)
+				err = dbprofile.Delete(tc, db)
 				if err != nil {
 					utils.FatalError(err)
 					return
@@ -1091,41 +1095,67 @@ func showApps(servers []services.Server, verbose bool) {
 	}
 }
 
-func showDatabases(servers []types.DatabaseServer, active []tlsca.RouteToDatabase, verbose bool) {
+func showDatabases(cluster string, servers []types.DatabaseServer, active []tlsca.RouteToDatabase, verbose bool) {
 	if verbose {
-		t := asciitable.MakeTable([]string{"Name", "Description", "URI", "Labels"})
+		t := asciitable.MakeTable([]string{"Name", "Description", "Protocol", "URI", "Labels", "Connect"})
 		for _, server := range servers {
 			name := server.GetName()
+			var connect string
 			for _, a := range active {
 				if a.ServiceName == name {
 					name = formatActiveDB(a)
+					connect = formatConnectCommand(cluster, a)
 				}
 			}
 			t.AddRow([]string{
 				name,
 				server.GetDescription(),
+				server.GetProtocol(),
 				server.GetURI(),
 				server.LabelsString(),
+				connect,
 			})
 		}
 		fmt.Println(t.AsBuffer().String())
 	} else {
-		t := asciitable.MakeTable([]string{"Name", "Description", "Labels"})
+		t := asciitable.MakeTable([]string{"Name", "Description", "Labels", "Connect"})
 		for _, server := range servers {
 			name := server.GetName()
+			var connect string
 			for _, a := range active {
 				if a.ServiceName == name {
 					name = formatActiveDB(a)
+					connect = formatConnectCommand(cluster, a)
 				}
 			}
 			t.AddRow([]string{
 				name,
 				server.GetDescription(),
 				server.LabelsString(),
+				connect,
 			})
 		}
 		fmt.Println(t.AsBuffer().String())
 	}
+}
+
+// formatConnectCommand formats an appropriate database connection command
+// for a user based on the provided database parameters.
+func formatConnectCommand(cluster string, active tlsca.RouteToDatabase) string {
+	switch active.Protocol {
+	case defaults.ProtocolPostgres:
+		service := fmt.Sprintf("%v-%v", cluster, active.ServiceName)
+		switch {
+		case active.Username != "" && active.Database != "":
+			return fmt.Sprintf(`psql "service=%v"`, service)
+		case active.Username != "":
+			return fmt.Sprintf(`psql "service=%v dbname="`, service)
+		case active.Database != "":
+			return fmt.Sprintf(`psql "service=%v user="`, service)
+		}
+		return fmt.Sprintf(`psql "service=%v user= dbname="`, service)
+	}
+	return ""
 }
 
 func formatActiveDB(active tlsca.RouteToDatabase) string {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -300,9 +300,9 @@ func Run(args []string) {
 	dbLogout := db.Command("logout", "Remove database credentials.")
 	dbLogout.Arg("db", "Database to remove credentials for.").StringVar(&cf.DatabaseService)
 	dbEnv := db.Command("env", "Print environment variables for the configured database.")
-	dbEnv.Flag("db", "Database to print environment for if logged into multiple.").StringVar(&cf.DatabaseService)
+	dbEnv.Flag("db", "Print environment for the specified database.").StringVar(&cf.DatabaseService)
 	dbConfig := db.Command("config", "Print database connection information. Useful when configuring GUI clients.")
-	dbConfig.Flag("db", "Database to print information for if logged into multiple.").StringVar(&cf.DatabaseService)
+	dbConfig.Flag("db", "Print information for the specified database.").StringVar(&cf.DatabaseService)
 
 	// join
 	join := app.Command("join", "Join the active SSH session")

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -366,7 +366,7 @@ func TestFormatConnectCommand(t *testing.T) {
 				ServiceName: "test",
 				Protocol:    defaults.ProtocolPostgres,
 			},
-			command: `psql "service=root-test user= dbname="`,
+			command: `psql "service=root-test user=<user> dbname=<database>"`,
 		},
 		{
 			comment: "default user is specified",
@@ -375,7 +375,7 @@ func TestFormatConnectCommand(t *testing.T) {
 				Protocol:    defaults.ProtocolPostgres,
 				Username:    "postgres",
 			},
-			command: `psql "service=root-test dbname="`,
+			command: `psql "service=root-test dbname=<database>"`,
 		},
 		{
 			comment: "default database is specified",
@@ -384,7 +384,7 @@ func TestFormatConnectCommand(t *testing.T) {
 				Protocol:    defaults.ProtocolPostgres,
 				Database:    "postgres",
 			},
-			command: `psql "service=root-test user="`,
+			command: `psql "service=root-test user=<user>"`,
 		},
 		{
 			comment: "default user/database are specified",


### PR DESCRIPTION
This PR belongs to a series of smaller self-contained database access PRs that I will be submitting to land various QoL improvements and refactorings to help keep future MySQL integration PR smaller.

This PR includes:

* Refactor and reorganize Postgres connection service file handling a bit to make adding MySQL [option file](https://dev.mysql.com/doc/refman/8.0/en/option-files.html) easier.

* While being at it, also added support for `--insecure` flag for Postgres service file. Closes https://github.com/gravitational/teleport/issues/5026.

* `tsh db ls` command output now includes an example connect command to make it easier for users to learn how to connect to a database (can just copy-paste). Example:

```
➜  ~ tsh db ls
Name                               Description            Labels    Connect
---------------------------------- ---------------------- --------- -------------------------
> local (user: postgres, db: test) PostgreSQL 13.0: Local env=local psql "service=root-local"
```

* Add `tsh db config` command that prints database connection information in text form. I realized the need for a command like this when configuring GUI clients - they often require entering paths for certificates for example, and regular users may not know where Teleport stores them on their machine. Example:

```
➜  ~ tsh db config
Name:      local
Host:      root.gravitational.io
Port:      3080
User:      postgres
Database:  test
CA:        /Users/r0mant/.tsh/keys/root.gravitational.io/certs.pem
Cert:      /Users/r0mant/.tsh/keys/root.gravitational.io/r0mant-db/root/local-x509.pem
Key:       /Users/r0mant/.tsh/keys/root.gravitational.io/r0mant
```