### PR TITLE
Propagate username updates in tsh

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -610,6 +610,10 @@ func onLogin(cf *CLIConf) {
 		utils.FatalError(err)
 	}
 
+	// the login operation may update the username and should be considered the more
+	// "authoritative" source.
+	cf.Username = tc.Username
+
 	// TODO(fspmarshall): Refactor access request & cert reissue logic to allow
 	// access requests to be applied to identity files.
 


### PR DESCRIPTION
`tsh` was sometimes using the incorrect username when generating access requests from a fresh state (i.e. if no `~/.tsh` previously existed).  This is because some login methods (e.g. `oidc`) update the username, but the updated username was not being propagated back up to `tsh`'s top-level configuration.

Fixes #5316 