### PR TITLE
Fixed panic when NewServerContext returns error.

### DIFF
--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -669,7 +669,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ch ssh.Channel, r
 	// forwarding is complete.
 	ctx, scx, err := srv.NewServerContext(ctx, s.connectionContext, s, s.identityContext)
 	if err != nil {
-		scx.Errorf("Unable to create connection context: %v.", err)
+		s.log.Errorf("Unable to create connection context: %v.", err)
 		s.stderrWrite(ch, "Unable to create connection context.")
 		return
 	}


### PR DESCRIPTION
**Description**

If `NewServerContext` returns an error, then the error is logged using the returned context which is `nil` causing a panic.

This change always uses the logger attached to the server instead.