### PR TITLE
Refactor db proxy/engine for easier reuse

### DIFF
--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -393,6 +393,6 @@ func detectProto(in []byte) (int, error) {
 	case bytes.HasPrefix(in, postgresSSLRequest), bytes.HasPrefix(in, postgresCancelRequest):
 		return ProtoPostgres, nil
 	default:
-		return ProtoUnknown, trace.BadParameter("unknown protocol prefix: %#v", in)
+		return ProtoUnknown, trace.BadParameter("multiplexer failed to detect connection protocol, first few bytes were: %#v", in)
 	}
 }

--- a/lib/srv/db/auth/auth.go
+++ b/lib/srv/db/auth/auth.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/native"
+	"github.com/gravitational/teleport/lib/srv/db/session"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/service/rds/rdsutils"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+)
+
+// AuthenticatorConfig is the database access authenticator configuration.
+type AuthenticatorConfig struct {
+	// AuthClient is the cluster auth client.
+	AuthClient *auth.Client
+	// Credentials are the AWS credentials used to generate RDS auth tokens.
+	Credentials *credentials.Credentials
+	// RDSCACerts contains AWS RDS root certificates.
+	RDSCACerts map[string][]byte
+	// Clock is the clock implementation.
+	Clock clockwork.Clock
+}
+
+// CheckAndSetDefaults validates the config and sets defaults.
+func (c *AuthenticatorConfig) CheckAndSetDefaults() error {
+	if c.AuthClient == nil {
+		return trace.BadParameter("missing AuthClient")
+	}
+	if c.Credentials == nil {
+		return trace.BadParameter("missing Credentials")
+	}
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+	return nil
+}
+
+// Authenticator provides utilities for authenticating and authorizing access
+// to databases.
+type Authenticator struct {
+	cfg AuthenticatorConfig
+	log logrus.FieldLogger
+}
+
+// NewAuthenticator returns a new instance of database access authenticator.
+func NewAuthenticator(config AuthenticatorConfig) (*Authenticator, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &Authenticator{
+		cfg: config,
+		log: logrus.WithField(trace.Component, "db:auth"),
+	}, nil
+}
+
+// GetRDSAuthToken returns authorization token that will be used as a password
+// when connecting to RDS and Aurora databases.
+func (a *Authenticator) GetRDSAuthToken(sessionCtx *session.Context) (string, error) {
+	a.log.Debugf("Generating auth token for %s.", sessionCtx)
+	return rdsutils.BuildAuthToken(
+		sessionCtx.Server.GetURI(),
+		sessionCtx.Server.GetRegion(),
+		sessionCtx.DatabaseUser,
+		a.cfg.Credentials)
+}
+
+// GetTLSConfig builds the client TLS configuration for the session.
+//
+// For RDS/Aurora, the config must contain RDS root certificate as a trusted
+// authority. For onprem we generate a client certificate signed by the host
+// CA used to authenticate.
+func (a *Authenticator) GetTLSConfig(ctx context.Context, sessionCtx *session.Context) (*tls.Config, error) {
+	addr, err := utils.ParseAddr(sessionCtx.Server.GetURI())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsConfig := &tls.Config{
+		ServerName: addr.Host(),
+		RootCAs:    x509.NewCertPool(),
+	}
+	// Add CA certificate to the trusted pool if it's present, e.g. when
+	// connecting to RDS/Aurora which require AWS CA.
+	if len(sessionCtx.Server.GetCA()) != 0 {
+		if !tlsConfig.RootCAs.AppendCertsFromPEM(sessionCtx.Server.GetCA()) {
+			return nil, trace.BadParameter("failed to append CA certificate to the pool")
+		}
+	} else if sessionCtx.Server.IsRDS() {
+		if rdsCA, ok := a.cfg.RDSCACerts[sessionCtx.Server.GetRegion()]; ok {
+			if !tlsConfig.RootCAs.AppendCertsFromPEM(rdsCA) {
+				return nil, trace.BadParameter("failed to append CA certificate to the pool")
+			}
+		} else {
+			a.log.Warnf("No RDS CA certificate for %v.", sessionCtx.Server)
+		}
+	}
+	// RDS/Aurora auth is done via an auth token so don't generate a client
+	// certificate and exit here.
+	if sessionCtx.Server.IsRDS() {
+		return tlsConfig, nil
+	}
+	// Otherwise, when connecting to an onprem database, generate a client
+	// certificate. The database instance should be configured with
+	// Teleport's CA obtained with 'tctl auth sign --type=db'.
+	cert, cas, err := a.getClientCert(ctx, sessionCtx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsConfig.Certificates = []tls.Certificate{*cert}
+	for _, ca := range cas {
+		if !tlsConfig.RootCAs.AppendCertsFromPEM(ca) {
+			return nil, trace.BadParameter("failed to append CA certificate to the pool")
+		}
+	}
+	return tlsConfig, nil
+}
+
+// getClientCert signs an ephemeral client certificate used by this
+// server to authenticate with the database instance.
+func (a *Authenticator) getClientCert(ctx context.Context, sessionCtx *session.Context) (cert *tls.Certificate, cas [][]byte, err error) {
+	privateBytes, _, err := native.GenerateKeyPair("")
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	// Postgres requires the database username to be encoded as a common
+	// name in the client certificate.
+	subject := pkix.Name{CommonName: sessionCtx.DatabaseUser}
+	csr, err := tlsca.GenerateCertificateRequestPEM(subject, privateBytes)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	// TODO(r0mant): Cache database certificates to avoid expensive generate
+	// operation on each connection.
+	a.log.Debugf("Generating client certificate for %s.", sessionCtx)
+	resp, err := a.cfg.AuthClient.GenerateDatabaseCert(ctx, &proto.DatabaseCertRequest{
+		CSR: csr,
+		TTL: proto.Duration(sessionCtx.Identity.Expires.Sub(a.cfg.Clock.Now())),
+	})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	clientCert, err := tls.X509KeyPair(resp.Cert, privateBytes)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return &clientCert, resp.CACerts, nil
+}

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -111,12 +111,12 @@ func (a *Auth) GetTLSConfig(ctx context.Context, sessionCtx *Session) (*tls.Conf
 	// connecting to RDS/Aurora which require AWS CA.
 	if len(sessionCtx.Server.GetCA()) != 0 {
 		if !tlsConfig.RootCAs.AppendCertsFromPEM(sessionCtx.Server.GetCA()) {
-			return nil, trace.BadParameter("failed to append CA certificate to the pool")
+			return nil, trace.BadParameter("invalid server CA certificate")
 		}
 	} else if sessionCtx.Server.IsRDS() {
 		if rdsCA, ok := a.cfg.RDSCACerts[sessionCtx.Server.GetRegion()]; ok {
 			if !tlsConfig.RootCAs.AppendCertsFromPEM(rdsCA) {
-				return nil, trace.BadParameter("failed to append CA certificate to the pool")
+				return nil, trace.BadParameter("invalid RDS CA certificate")
 			}
 		} else {
 			a.cfg.Log.Warnf("No RDS CA certificate for %v.", sessionCtx.Server)

--- a/lib/srv/db/common/doc.go
+++ b/lib/srv/db/common/doc.go
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 // Package common provides common utilities used by all supported database
-// implementation.
+// implementations.
 package common

--- a/lib/srv/db/common/doc.go
+++ b/lib/srv/db/common/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package common provides common utilities used by all supported database
+// implementation.
+package common

--- a/lib/srv/db/common/interfaces.go
+++ b/lib/srv/db/common/interfaces.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"io"
+	"net"
+)
+
+// Proxy defines an interface a database proxy should implement.
+type Proxy interface {
+	// HandleConnection takes the client connection, handles all database
+	// specific startup actions and starts proxying to remote server.
+	HandleConnection(context.Context, net.Conn) error
+}
+
+// Service defines an interface for connecting to a remote database service.
+type Service interface {
+	// Connect is used to connect to remote database server over reverse tunnel.
+	Connect(context.Context) (net.Conn, error)
+	// Proxy starts proxying between client and service connections.
+	Proxy(ctx context.Context, clientConn, serviceConn io.ReadWriteCloser) error
+}
+
+// Engine defines an interface for specific database protocol engine such
+// as Postgres or MySQL.
+type Engine interface {
+	// HandleConnection takes the connection from the proxy and starts
+	// proxying it to the particular database instance.
+	HandleConnection(context.Context, *Session, net.Conn) error
+}

--- a/lib/srv/db/common/interfaces.go
+++ b/lib/srv/db/common/interfaces.go
@@ -40,7 +40,7 @@ type Service interface {
 // Engine defines an interface for specific database protocol engine such
 // as Postgres or MySQL.
 type Engine interface {
-	// HandleConnection takes the connection from the proxy and starts
-	// proxying it to the particular database instance.
+	// HandleConnection proxies the connection received from the proxy to
+	// the particular database instance.
 	HandleConnection(context.Context, *Session, net.Conn) error
 }

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package session
+package common
 
 import (
 	"fmt"
@@ -26,8 +26,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Context combines parameters for a database connection session.
-type Context struct {
+// Session combines parameters for a database connection session.
+type Session struct {
 	// ID is the unique session ID.
 	ID string
 	// Server is the database server handling the connection.
@@ -47,7 +47,7 @@ type Context struct {
 }
 
 // String returns string representation of the session parameters.
-func (c *Context) String() string {
+func (c *Session) String() string {
 	return fmt.Sprintf("db[%v] identity[%v] dbUser[%v] dbName[%v]",
 		c.Server.GetName(), c.Identity.Username, c.DatabaseUser, c.DatabaseName)
 }

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -37,7 +37,7 @@ import (
 // connections coming over reverse tunnel from the proxy and proxies
 // them between the proxy and the Postgres database instance.
 //
-// Implements common.DatabaseEngine.
+// Implements common.Engine.
 type Engine struct {
 	// Auth handles database access authentication.
 	Auth *common.Auth

--- a/lib/srv/db/postgres/proxy.go
+++ b/lib/srv/db/postgres/proxy.go
@@ -33,7 +33,7 @@ import (
 // Proxy proxies connections from Postgres clients to database services
 // over reverse tunnel. It runs inside Teleport proxy service.
 //
-// Implements common.DatabaseProxy.
+// Implements common.Proxy.
 type Proxy struct {
 	// TLSConfig is the proxy TLS configuration.
 	TLSConfig *tls.Config

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -172,7 +172,7 @@ func (s *ProxyServer) postgresProxy() *postgres.Proxy {
 // The passed in context is expected to contain the identity information
 // decoded from the client certificate by auth.Middleware.
 //
-// Implements connect.Service.
+// Implements common.Service.
 func (s *ProxyServer) Connect(ctx context.Context) (net.Conn, error) {
 	authContext, err := s.authorize(ctx)
 	if err != nil {
@@ -201,7 +201,7 @@ func (s *ProxyServer) Connect(ctx context.Context) (net.Conn, error) {
 // Proxy starts proxying all traffic received from Postgres client between
 // this proxy and Teleport database service over reverse tunnel.
 //
-// Implements connect.Service.
+// Implements common.Service.
 func (s *ProxyServer) Proxy(ctx context.Context, clientConn, serviceConn io.ReadWriteCloser) (retErr error) {
 	errCh := make(chan error, 2)
 	go func() {

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -111,8 +111,8 @@ func (c *Config) CheckAndSetDefaults() error {
 	return nil
 }
 
-// Server is an application server. It authenticates requests from the web
-// proxy and forwards them to internal applications.
+// Server is a database server. It accepts database client requests coming over
+// reverse tunnel from Teleport proxy and proxies them to databases.
 type Server struct {
 	// cfg is the database server configuration.
 	cfg Config
@@ -134,7 +134,7 @@ type Server struct {
 	log *logrus.Entry
 }
 
-// New returns a new application server.
+// New returns a new database server.
 func New(ctx context.Context, config Config) (*Server, error) {
 	err := config.CheckAndSetDefaults()
 	if err != nil {

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -318,8 +318,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	// service.
 	err = s.handleConnection(ctx, tlsConn)
 	if err != nil {
-		log.WithError(err).Errorf("Failed to handle connection: %v.",
-			trace.DebugReport(err))
+		log.WithError(err).Error("Failed to handle connection.")
 		return
 	}
 }


### PR DESCRIPTION
Another refactoring PR to prepare for MySQL integration. No functionality change, just restructuring and shuffling things around:

* Move out common auth parts such as generating db client certificates and RDS tokens into a separate `Authenticator` that can be reused between different database engines.
* Move out common parts out of Postgres-specific proxy into ProxyServer so they can also be reused (such as, proxying traffic between proxy and database service).
* Address remaining comments on https://github.com/gravitational/teleport/pull/5005 which @klizhentas submitted after I had already merged it.
