### PR TITLE
Fixed panic when NewServerContext returns error.

### DIFF
--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -615,7 +615,7 @@ func (s *Server) handleDirectTCPIPRequest(ch ssh.Channel, req *sshutils.DirectTC
 	// forwarding is complete.
 	ctx, err := srv.NewServerContext(s, s.sconn, s.identityContext)
 	if err != nil {
-		ctx.Errorf("Unable to create connection context: %v.", err)
+		s.log.Errorf("Unable to create connection context: %v.", err)
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}
@@ -678,7 +678,7 @@ func (s *Server) handleSessionRequests(ch ssh.Channel, in <-chan *ssh.Request) {
 	// done on the server's terminating side.
 	ctx, err := srv.NewServerContext(s, s.sconn, s.identityContext)
 	if err != nil {
-		ctx.Errorf("Unable to create connection context: %v.", err)
+		s.log.Errorf("Unable to create connection context: %v.", err)
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -773,7 +773,7 @@ func (s *Server) handleDirectTCPIPRequest(sconn *ssh.ServerConn, identityContext
 	// forwarding is complete.
 	ctx, err := srv.NewServerContext(s, sconn, identityContext)
 	if err != nil {
-		ctx.Errorf("Unable to create connection context: %v.", err)
+		log.Errorf("Unable to create connection context: %v.", err)
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}
@@ -866,7 +866,7 @@ func (s *Server) handleSessionRequests(sconn *ssh.ServerConn, identityContext sr
 	// session request is complete.
 	ctx, err := srv.NewServerContext(s, sconn, identityContext)
 	if err != nil {
-		ctx.Errorf("Unable to create connection context: %v.", err)
+		log.Errorf("Unable to create connection context: %v.", err)
 		ch.Stderr().Write([]byte("Unable to create connection context."))
 		return
 	}


### PR DESCRIPTION
**Description**

If `NewServerContext` returns an error, then the error is logged using the returned context which is `nil` causing a panic.

This change always uses the logger attached to the server instead.