### PR TITLE
Test flakes: lib/srv/regular, time-sensitive assertion

### DIFF
--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -453,14 +453,14 @@ func (s *SrvSuite) TestAgentForward(c *C) {
 	c.Assert(err, IsNil)
 	// clt must be nullified to prevent double-close during test cleanup
 	s.clt = nil
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 10; i++ {
 		_, err = net.Dial("unix", socketPath)
 		if err != nil {
 			return
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	c.Fatalf("expected socket to be closed, still could dial after 150 ms")
+	c.Fatalf("expected socket to be closed, still could dial after 450 ms")
 }
 
 func (s *SrvSuite) TestAllowedUsers(c *C) {


### PR DESCRIPTION
Since this is written as more of a black box test and the invasive approaches of configuring test-specific functionality seemed a lot more complex, I opted to increase the test time frame to account for environments with above average load.

Updates https://github.com/gravitational/teleport/issues/5333.