### PR TITLE
Fix admoniton new lines

### DIFF
--- a/docs/5.0/docs.md
+++ b/docs/5.0/docs.md
@@ -17,6 +17,7 @@ Getting started guides should try hard to keep a busy user engaged. It calls out
 is in the sequence, for example "Step 1 out of 3. Adding a local user."
 
 !!! note
+
     "Getting started" is a better term than "Quickstart".
     Google "Getting started with React" vs "React quickstart"
     and compare the search results.

--- a/docs/5.0/features/ssh-pam.md
+++ b/docs/5.0/features/ssh-pam.md
@@ -266,6 +266,7 @@ to write richer scripts that may change the system in other ways based on
 identity information.
 
 !!! note
+
     The `useradd` location can have a different path then the example below depending on your linux flavor.  Adjust to your particular system as needed from `which useradd` (Ex: `/usr/sbin/useradd` instead of the below example).
 
 ```bash


### PR DESCRIPTION
For the new version of the docs we had to rewrite admoniton plugin from scratch and as part of this process I made new lines after headers mandatory to simplify parsing. On the new site there will be warnings for the wrong syntax, but for now I fixed it by hand.