### PR TITLE
Update CentOS 6 buildboxes to use vault packages

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -25,19 +25,19 @@ RUN apt-get update -y --fix-missing && \
 
 ARG UID
 ARG GID
-RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
-RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
+RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Install Go.
 ARG RUNTIME
-RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz;\
-    mkdir -p /go/src/github.com/gravitational/teleport;\
-    chmod a+w /go;\
-    chmod a+w /var/lib;\
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz && \
+    mkdir -p /go/src/github.com/gravitational/teleport && \
+    chmod a+w /go && \
+    chmod a+w /var/lib && \
     chmod a-w /
 
 ENV GOPATH="/go" \
@@ -45,8 +45,8 @@ ENV GOPATH="/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
 # Install meta-linter.
-RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.24.0/golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz ;\
-     cp golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ ;\
+RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.24.0/golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz && \
+     cp golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ && \
      rm -r golangci-lint*)
 
 # Install PAM module and policies for testing.

--- a/build.assets/Dockerfile-centos6
+++ b/build.assets/Dockerfile-centos6
@@ -7,6 +7,8 @@ ENV LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LC_CTYPE=en_US.UTF-8
 
+# Replace regular CentOS 6 mirror list with vault.centos.org, as CentOS 6 is EOL
+# and regular mirrors aren't hosted any more.
 RUN sed -i 's%^mirrorlist%#mirrorlist%g' /etc/yum.repos.d/* && \
     sed -i 's%#baseurl=http://mirror.centos.org%baseurl=http://vault.centos.org%g' /etc/yum.repos.d/* && \
     yum makecache fast && \
@@ -15,19 +17,19 @@ RUN sed -i 's%^mirrorlist%#mirrorlist%g' /etc/yum.repos.d/* && \
 
 ARG UID
 ARG GID
-RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
-RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
+RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Install Go.
 ARG RUNTIME
-RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz;\
-    mkdir -p /go/src/github.com/gravitational/teleport;\
-    chmod a+w /go;\
-    chmod a+w /var/lib;\
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz && \
+    mkdir -p /go/src/github.com/gravitational/teleport && \
+    chmod a+w /go && \
+    chmod a+w /var/lib && \
     chmod a-w /
 
 ENV GOPATH="/go" \

--- a/build.assets/Dockerfile-centos6
+++ b/build.assets/Dockerfile-centos6
@@ -7,7 +7,9 @@ ENV LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LC_CTYPE=en_US.UTF-8
 
-RUN yum makecache fast && \
+RUN sed -i 's%^mirrorlist%#mirrorlist%g' /etc/yum.repos.d/* && \
+    sed -i 's%#baseurl=http://mirror.centos.org%baseurl=http://vault.centos.org%g' /etc/yum.repos.d/* && \
+    yum makecache fast && \
     yum -y install gcc pam-devel glibc-devel net-tools tree git zip && \
     yum clean all
 
@@ -20,21 +22,13 @@ RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
-# 1) Install binary go runtime for bootstrapping
-# 2) Get source for the correct Go boringcrypto runtime and compile it with Go bootstrap runtime
-# 3) Erase Go bootstrap runtime and create build directories
-# 4) Print compiled Go version
+# Install Go.
 ARG RUNTIME
-ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
-RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
-    mkdir -p /opt && cd /opt && curl https://dl.google.com/go/${RUNTIME}.src.tar.gz | tar xz && \
-    cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
-    rm -rf /go-bootstrap && \
-    mkdir -p /go/src/github.com/gravitational/teleport && \
-    chmod a+w /go && \
-    chmod a+w /var/lib && \
-    chmod a-w / && \
-    /opt/go/bin/go version
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz;\
+    mkdir -p /go/src/github.com/gravitational/teleport;\
+    chmod a+w /go;\
+    chmod a+w /var/lib;\
+    chmod a-w /
 
 ENV GOPATH="/go" \
     GOROOT="/opt/go" \

--- a/build.assets/Dockerfile-centos6-fips
+++ b/build.assets/Dockerfile-centos6-fips
@@ -7,6 +7,8 @@ ENV LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LC_CTYPE=en_US.UTF-8
 
+# Replace regular CentOS 6 mirror list with vault.centos.org, as CentOS 6 is EOL
+# and regular mirrors aren't hosted any more.
 RUN sed -i 's%^mirrorlist%#mirrorlist%g' /etc/yum.repos.d/* && \
     sed -i 's%#baseurl=http://mirror.centos.org%baseurl=http://vault.centos.org%g' /etc/yum.repos.d/* && \
     yum makecache fast && \
@@ -15,11 +17,11 @@ RUN sed -i 's%^mirrorlist%#mirrorlist%g' /etc/yum.repos.d/* && \
 
 ARG UID
 ARG GID
-RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
-RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
+RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # BoringCrypto (unlike regular Go) requires glibc 2.14, so we have to build from source.

--- a/build.assets/Dockerfile-centos6-fips
+++ b/build.assets/Dockerfile-centos6-fips
@@ -7,7 +7,9 @@ ENV LANGUAGE=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LC_CTYPE=en_US.UTF-8
 
-RUN yum makecache fast && \
+RUN sed -i 's%^mirrorlist%#mirrorlist%g' /etc/yum.repos.d/* && \
+    sed -i 's%#baseurl=http://mirror.centos.org%baseurl=http://vault.centos.org%g' /etc/yum.repos.d/* && \
+    yum makecache fast && \
     yum -y install gcc pam-devel glibc-devel net-tools tree git zip && \
     yum clean all
 
@@ -20,6 +22,7 @@ RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
+# BoringCrypto (unlike regular Go) requires glibc 2.14, so we have to build from source.
 # 1) Install binary go runtime for bootstrapping
 # 2) Get source for the correct Go boringcrypto runtime and compile it with Go bootstrap runtime
 # 3) Erase Go bootstrap runtime and create build directories

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -25,19 +25,19 @@ RUN apt-get update -y --fix-missing && \
 
 ARG UID
 ARG GID
-RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
-RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\
+RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Install Go.
 ARG RUNTIME
-RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${RUNTIME}b5.linux-amd64.tar.gz | tar xz;\
-    mkdir -p /go/src/github.com/gravitational/teleport;\
-    chmod a+w /go;\
-    chmod a+w /var/lib;\
+RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${RUNTIME}b5.linux-amd64.tar.gz | tar xz && \
+    mkdir -p /go/src/github.com/gravitational/teleport && \
+    chmod a+w /go && \
+    chmod a+w /var/lib && \
     chmod a-w /
 
 ENV GOPATH="/go" \


### PR DESCRIPTION
This PR:
- Modifies the mirror list used by CentOS 6 buildboxes to pull from vault.centos.org instead (as the regular mirrors are rightly showing a deprecation message)
- Stops building Go from source and uses the prebuilt Go binary for regular CentOS 6 builds
  - We still need to build from source for FIPS binaries because BoringCrypto depends on glibc 2.14 (and CentOS 6 only provides 2.12)
- Changes `;` to `&&` in all buildbox steps to prevent inadvertently continuing if there's a failure to download/untar/chown/rm etc.
  - Tested this by rebuilding all buildboxes and releases, works fine.