### PR TITLE
Test flakes: terminate key agent consistently between tests

### DIFF
--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -37,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/gravitational/trace"
 
@@ -51,6 +53,7 @@ type KeyAgentTestSuite struct {
 	hostname    string
 	clusterName string
 	tlsca       *tlsca.CertAuthority
+	close       func()
 }
 
 var _ = check.Suite(&KeyAgentTestSuite{})
@@ -77,16 +80,16 @@ func (s *KeyAgentTestSuite) SetUpSuite(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// start a debug agent that will be used in tests
-	err = startDebugAgent()
+	s.close, err = startDebugAgent()
 	c.Assert(err, check.IsNil)
 }
 
 func (s *KeyAgentTestSuite) TearDownSuite(c *check.C) {
 	err := os.RemoveAll(s.keyDir)
 	c.Assert(err, check.IsNil)
-}
-
-func (s *KeyAgentTestSuite) SetUpTest(c *check.C) {
+	if s.close != nil {
+		s.close()
+	}
 }
 
 // TestAddKey ensures correct adding of ssh keys. This test checks the following:
@@ -471,39 +474,59 @@ func (s *KeyAgentTestSuite) makeKey(username string, allowedLogins []string, ttl
 	}, nil
 }
 
-func startDebugAgent() error {
-	errorC := make(chan error)
+func startDebugAgent() (closer func(), err error) {
 	rand.Seed(time.Now().Unix())
+	socketpath := filepath.Join(os.TempDir(),
+		fmt.Sprintf("teleport-%d-%d.socket", os.Getpid(), rand.Uint32()))
 
+	listener, err := net.Listen("unix", socketpath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	systemAgent := agent.NewKeyring()
+	os.Setenv(teleport.SSHAuthSock, socketpath)
+
+	startedC := make(chan struct{})
+	doneC := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
 	go func() {
-		socketpath := filepath.Join(os.TempDir(),
-			fmt.Sprintf("teleport-%d-%d.socket", os.Getpid(), rand.Uint32()))
-
-		systemAgent := agent.NewKeyring()
-
-		listener, err := net.Listen("unix", socketpath)
-		if err != nil {
-			errorC <- trace.Wrap(err)
-			return
-		}
-		defer listener.Close()
-
-		os.Setenv(teleport.SSHAuthSock, socketpath)
-
-		// agent is listeninging and environment variable is set unblock now
-		close(errorC)
-
+		defer wg.Done()
+		defer os.Setenv(teleport.SSHAuthSock, "")
+		// agent is listening and environment variable is set, unblock now
+		close(startedC)
 		for {
 			conn, err := listener.Accept()
 			if err != nil {
-				log.Warnf("Unexpected response from listener.Accept: %v", err)
-				continue
+				if !utils.IsUseOfClosedNetworkError(err) {
+					log.Warnf("Unexpected response from listener.Accept: %v", err)
+				}
+				return
 			}
-
-			go agent.ServeAgent(systemAgent, conn)
+			wg.Add(2)
+			go func() {
+				agent.ServeAgent(systemAgent, conn)
+				wg.Done()
+			}()
+			go func() {
+				<-doneC
+				conn.Close()
+				wg.Done()
+			}()
 		}
 	}()
 
+	go func() {
+		<-doneC
+		listener.Close()
+		wg.Done()
+	}()
+
 	// block until agent is started
-	return <-errorC
+	<-startedC
+	return func() {
+		close(doneC)
+		wg.Wait()
+	}, nil
 }

--- a/lib/utils/errors.go
+++ b/lib/utils/errors.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+
+	"github.com/gravitational/teleport"
+)
+
+// IsUseOfClosedNetworkError returns true if the specified error
+// indicates the use of closed network connection
+// TODO(dmitri): replace in go1.16 with `errors.Is(err, net.ErrClosed)`
+func IsUseOfClosedNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), teleport.UseOfClosedNetworkConnection)
+}


### PR DESCRIPTION
Wait for key agent to stop between key agent tests to improve re-entrancy.