### PR TITLE
Test flakes: make tests reentrant

### DIFF
--- a/lib/backend/report_test.go
+++ b/lib/backend/report_test.go
@@ -34,6 +34,7 @@ func TestReporterTopRequestsLimit(t *testing.T) {
 		return int(count)
 	}
 
+	requests.Reset()
 	// At first, the metric should have no values.
 	require.Equal(t, 0, countTopRequests())
 

--- a/lib/backend/report_test.go
+++ b/lib/backend/report_test.go
@@ -33,8 +33,8 @@ func TestReporterTopRequestsLimit(t *testing.T) {
 		}
 		return int(count)
 	}
+	t.Cleanup(requests.Reset)
 
-	requests.Reset()
 	// At first, the metric should have no values.
 	require.Equal(t, 0, countTopRequests())
 

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -131,6 +131,13 @@ func (p *defaultModules) IsBoringBinary() bool {
 	return false
 }
 
+// resetModules resets the modules interface to defaults
+func resetModules() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	modules = &defaultModules{}
+}
+
 // DELETE IN: 5.1.0
 //
 // ExtendAdminUserRules returns true if the "AdminUserRules" set should be
@@ -141,6 +148,6 @@ func (p *defaultModules) ExtendAdminUserRules() bool {
 }
 
 var (
-	mutex           = &sync.Mutex{}
+	mutex   sync.Mutex
 	modules Modules = &defaultModules{}
 )

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -31,6 +31,10 @@ type ModulesSuite struct{}
 
 var _ = check.Suite(&ModulesSuite{})
 
+func (s *ModulesSuite) TearDownTest(c *check.C) {
+	resetModules()
+}
+
 func (s *ModulesSuite) TestDefaultModules(c *check.C) {
 	err := GetModules().EmptyRolesHandler()
 	c.Assert(err, check.IsNil)
@@ -49,9 +53,9 @@ func (s *ModulesSuite) TestDefaultModules(c *check.C) {
 
 	traits := GetModules().TraitsFromLogins("alice", []string{"root"}, []string{"system:masters"}, []string{"alice@example.com"})
 	c.Assert(traits, check.DeepEquals, map[string][]string{
-		teleport.TraitLogins:     []string{"root"},
-		teleport.TraitKubeGroups: []string{"system:masters"},
-		teleport.TraitKubeUsers:  []string{"alice@example.com"},
+		teleport.TraitLogins:     {"root"},
+		teleport.TraitKubeGroups: {"system:masters"},
+		teleport.TraitKubeUsers:  {"alice@example.com"},
 	})
 
 	isBoring := GetModules().IsBoringBinary()


### PR DESCRIPTION
Updated a handful of tests to be able to run tests a specific amount of times.
Requires https://github.com/gravitational/teleport.e/pull/181.