### PR TITLE
Combined Helm chart for kube, app and db services

### DIFF
--- a/docs/5.0/kubernetes-access.md
+++ b/docs/5.0/kubernetes-access.md
@@ -83,6 +83,7 @@ $ helm repo add teleport https://charts.releases.teleport.dev
 helm install teleport-kube-agent teleport/teleport-kube-agent \
   --namespace teleport \
   --create-namespace \
+  --set roles=kube \
   --set proxyAddr=proxy.example.com:3080 \
   --set authToken=$JOIN_TOKEN \
   --set kubeClusterName=$KUBERNETES_CLUSTER_NAME

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,6 +1,6 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: 0.0.1
+version: 0.0.2
 appVersion: "5"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -1,7 +1,10 @@
-# Teleport Kubernetes Agent
+# Teleport Agent chart
 
-This chart is a minimal Teleport agent used to register a Kubernetes cluster
-with an existing Teleport cluster.
+This chart is a Teleport agent used to register any or all of the following services
+with an existing Teleport cluster:
+- Teleport Kubernetes access
+- Teleport Application access
+- Teleport Database access
 
 To use it, you will need:
 - an existing Teleport cluster (at least proxy and auth services)
@@ -12,7 +15,25 @@ To use it, you will need:
   - this chart does not currently support dynamic join tokens; please [file an
     issue](https://github.com/gravitational/teleport/issues/new?labels=type%3A+feature+request&template=feature_request.md)
     if you require support for dynamic tokens
-- choose a name for your Kubernetes cluster, distinct from other registered
+
+## Combining roles
+
+You can combine multiple roles as a comma-separated list: `--set roles=kube\,db\,app`
+
+Note that commas must be escaped if the values are provided on the command line. This is due to the way that
+Helm parses arguments.
+
+You must also provide the settings for each individual role which is enabled as detailed below.
+
+## Backwards compatibility
+
+To provide backwards compatibility with older versions of the `teleport-kube-agent` chart, if you do
+not specify any value for `roles`, the chart will run with only the `kube` role enabled.
+
+## Kubernetes access
+
+To use Teleport Kubernetes access, you will also need:
+- to choose a name for your Kubernetes cluster, distinct from other registered
   clusters (`$KUBERNETES_CLUSTER_NAME`)
 
 To install the agent, run:
@@ -21,6 +42,7 @@ To install the agent, run:
 $ helm install teleport-kube-agent . \
   --create-namespace \
   --namespace teleport \
+  --set roles=kube \
   --set proxyAddr=${PROXY_ENDPOINT?} \
   --set authToken=${JOIN_TOKEN?} \
   --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?}
@@ -28,8 +50,84 @@ $ helm install teleport-kube-agent . \
 
 Set the values in the above command as appropriate for your setup.
 
-After installing, the new cluster should show up in `tsh kube ls` after a few
-minutes. If the new cluster doesn't show up, look into the agent logs with:
+## Application access
+
+To use Teleport Application access, you will also need:
+- the name of an application that you would like to proxy (`$APP_NAME`)
+- the URI to connect to the application from the node where this chart is deployed (`$APP_URI`)
+
+To install the agent, run:
+
+```sh
+$ helm install teleport-kube-agent . \
+  --create-namespace \
+  --namespace teleport \
+  --set roles=app \
+  --set proxyAddr=${PROXY_ENDPOINT?} \
+  --set authToken=${JOIN_TOKEN?} \
+  --set "apps[0].name=${APP_NAME?}" \
+  --set "apps[0].uri=${APP_URI?}"
+```
+
+Set the values in the above command as appropriate for your setup.
+
+These are the supported values for the `apps` map:
+
+| Key | Description | Example | Default | Required |
+| --- | --- | --- | --- | --- |
+| `name` | Name of the app to be accessed | `apps[0].name=grafana` | | Yes |
+| `uri` | URI of the app to be accessed | `apps[0].uri=http://localhost:3000` | | Yes |
+| `public_addr` | Public address used to access the app | `apps[0].public_addr=grafana.teleport.example.com` | | No |
+| `labels.[name]` | Key-value pairs to set against the app for grouping/RBAC | `apps[0].labels.env=local,apps[0].labels.region=us-west-1` | | No |
+| `insecure_skip_verify` | Whether to skip validation of TLS certificates presented by backend apps | `apps[0].insecure_skip_verify=true` | `false` | No |
+| `rewrite.redirect` | A list of URLs to rewrite to the public address of the app service | `apps[0].rewrite.redirect[0]=https://192.168.1.1` | | No
+
+You can add multiple apps using `apps[1].name`, `apps[1].uri`, `apps[2].name`, `apps[2].uri` etc.
+
+After installing, the new application should show up in `tsh apps ls` after a few minutes.
+
+## Database access
+
+To use Teleport database access, you will also need:
+- the name of an database that you would like to proxy (`$DB_NAME`)
+- the URI to connect to the database from the node where this chart is deployed (`$DB_URI`)
+- the database protocol used for the database (`$DB_PROTOCOL`)
+
+To install the agent, run:
+
+```sh
+$ helm install teleport-kube-agent . \
+  --create-namespace \
+  --namespace teleport \
+  --set roles=db \
+  --set proxyAddr=${PROXY_ENDPOINT?} \
+  --set authToken=${JOIN_TOKEN?} \
+  --set "databases[0].name=${DB_NAME?}" \
+  --set "databases[0].uri=${DB_URI?}" \
+  --set "databases[0].protocol=${DB_PROTOCOL}"
+```
+
+Set the values in the above command as appropriate for your setup.
+
+These are the supported values for the `databases` map:
+
+| Key | Description | Example | Default | Required |
+| --- | --- | --- | --- | --- |
+| `name` | Name of the database to be accessed | `databases[0].name=aurora` | | Yes |
+| `uri` | URI of the database to be accessed | `databases[0].uri=postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432` | | Yes |
+| `protocol` | Database protocol | `databases[0].protocol=postgresql` | | Yes |
+| `description` | Free-form description of the database proxy instance | `databases[0].description='AWS Aurora instance of PostgreSQL 13.0'` | | No |
+| `aws.region` | AWS-specific region configuration (only used for RDS/Aurora) | `databases[0].aws.region=us-east-1` | | No |
+| `labels.[name]` | Key-value pairs to set against the database for grouping/RBAC | `databases[0].labels.db=postgres-dev,apps[0].labels.region=us-east-1` | | No |
+
+You can add multiple databases using `databases[1].name`, `databases[1].uri`, `databases[1].protocol`,
+`databases[2].name`, `databases[2].uri`, `databases[2].protocol` etc.
+
+After installing, the new database should show up in `tsh db ls` after a few minutes.
+
+## Troubleshooting
+
+If the service for a given role doesn't show up, look into the agent logs with:
 
 ```sh
 $ kubectl logs -n teleport deployment/teleport-kube-agent

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -50,6 +50,13 @@ $ helm install teleport-kube-agent . \
 
 Set the values in the above command as appropriate for your setup.
 
+You can also optionally set labels for your Kubernetes cluster using the
+format `--set "labels.key=value"` - for example: `--set "labels.env=development,labels.region=us-west-1"`
+
+Note that due to backwards compatbility, the `labels` value **only** applies to the Teleport
+Kubernetes service. To set labels for applications or databases, use the different formats
+detailed below.
+
 ## Application access
 
 To use Teleport Application access, you will also need:

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -12,6 +12,9 @@ data:
       {{- if or (contains "kube" (.Values.roles | toString)) (empty .Values.roles) }}
       enabled: true
       kube_cluster_name: {{ required "kubeClusterName is required in chart values when kube role is enabled, see README" .Values.kubeClusterName }}
+        {{- if .Values.labels }}
+      labels: {{ toYaml .Values.labels | nindent 8 }}
+        {{- end }}
       {{- else }}
       enabled: false
       {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -9,12 +9,50 @@ data:
       auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
 
     kubernetes_service:
+      {{- if or (contains "kube" (.Values.roles | toString)) (empty .Values.roles) }}
       enabled: true
-      kube_cluster_name: {{ required "kubeClusterName is required in chart values" .Values.kubeClusterName }}
-      labels:
-{{- if .Values.labels }}
-{{ toYaml .Values.labels | indent 8 }}
-{{- end }}
+      kube_cluster_name: {{ required "kubeClusterName is required in chart values when kube role is enabled, see README" .Values.kubeClusterName }}
+      {{- else }}
+      enabled: false
+      {{- end }}
+
+    app_service:
+      {{- if contains "app" (.Values.roles | toString) }}
+      enabled: true
+      apps:
+        {{- range $app := .Values.apps }}
+          {{- if not (hasKey $app "name") }}
+            {{- fail "'name' is required for all 'apps' in chart values when app role is enabled, see README" }}
+          {{- end }}
+          {{- if not (hasKey $app "uri") }}
+            {{- fail "'uri' is required for all 'apps' in chart values when app role is enabled, see README" }}
+          {{- end }}
+        {{- end }}
+      {{- required "'apps' map is required in chart values when app role is enabled, see README" .Values.apps | toYaml | nindent 8 }}
+      {{- else }}
+      enabled: false
+      {{- end }}
+
+    db_service:
+      {{- if contains "db" (.Values.roles | toString) }}
+      enabled: true
+      databases:
+        {{- range $db := .Values.databases }}
+          {{- if not (hasKey $db "name") }}
+            {{- fail "'name' is required for all 'databases' in chart values when db role is enabled, see README" }}
+          {{- end }}
+          {{- if not (hasKey $db "uri") }}
+            {{- fail "'uri' is required for all 'databases' is required in chart values when db role is enabled, see README" }}
+          {{- end }}
+          {{- if not (hasKey $db "protocol") }}
+            {{- fail "'protocol' is required for all 'databases' in chart values when db role is enabled, see README" }}
+          {{- end }}
+        {{- end }}
+        {{- required "'databases' map is required in chart values when db role is enabled, see README" .Values.databases | toYaml | nindent 8 }}
+      {{- else }}
+      enabled: false
+      {{- end }}
+
     auth_service:
       enabled: false
     ssh_service:

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -1,17 +1,45 @@
-##################################################
+################################################################
 # Values that must always be provided by the user.
-##################################################
+################################################################
 
 # Join token for the cluster.
 authToken:
 # Address of the teleport proxy with port (usually :3080).
 proxyAddr:
+# Comma-separated list of roles to enable (any of: kube,db,app)
+roles:
+
+################################################################
+# Values that must be provided if Kubernetes access is enabled.
+################################################################
+
 # Name for this kubernetes cluster to be used by teleport users.
 kubeClusterName:
 
-##################################################
+################################################################
+# Values that must be provided if Application access is enabled.
+################################################################
+
+# Details of at least one app to be proxied. Example:
+# apps:
+#  - name: grafana
+#    uri: http://localhost:3000
+apps:
+
+################################################################
+# Values that must be provided if Database access is enabled.
+################################################################
+
+# Details of at least one database to be proxied. Example:
+# databases:
+#  - name: aurora
+#    uri: "postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432"
+#    protocol: "postgres"
+databases:
+
+################################################################
 # Values that you may need to change.
-##################################################
+################################################################
 
 # Version of teleport image, if different from appVersion in Chart.yaml.
 teleportVersionOverride: ""
@@ -27,9 +55,9 @@ podSecurityPolicy:
 # Labels is a map of key values pairs about this cluster
 labels: {}
 
-##################################################
+################################################################
 # Values that you shouldn't need to change.
-##################################################
+################################################################
 
 # Container image for the agent. Since this runs without the auth_service, we
 # don't need the enterprise version.


### PR DESCRIPTION
As per @klizhentas' comments on https://github.com/gravitational/teleport/pull/5340, this combines `teleport-kube-agent`, `teleport-app-agent` and the inevitable `teleport-db-agent` into one chart.

View commit b3aa003 by itself if you just want to see a diff against the `teleport-kube-agent` chart. The other commit renames the chart and loses the history.

You could install all three services with a command like this:

```console
helm install \
  teleport-agent ./examples/chart/teleport-agent/. \
  -n teleport-agent --create-namespace \  
  --set "roles=app\,db\,kube" \
  --set authToken=token \
  --set proxyAddr=teleport.example.com:3080 \
  --set teleportVersionOverride=6.0.0-alpha.1 \
  --set "apps[0].name=grafana" \
  --set "apps[0].uri=http://localhost:3000" \
  --set "apps[1].name=anothergrafana" \
  --set "apps[1].uri=http://differenthost:3000" \
  --set "databases[0].name=aurora" \
  --set "databases[0].uri=postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432" \
  --set "databases[0].protocol=postgres" \
  --set "databases[0].aws.region=us-east-1" \
  --set kubeClusterName=testkube
```

Gotchas:
- commas in `--set roles` must be escaped at the command line, and the whole value must be quoted - this is a [Helm limitation/feature](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set)
- values containing `[]` must be quoted on the command line
- you must set `teleportVersionOverride` to a 6.x version for database access to work

Another note - because of the aforementioned `--set` behaviour, you can also set multiple values like this:
`--set "apps[0].name=grafana,apps[0].uri=http://localhost:3000"`
`--set "databases[0].name=aurora,databases[0].uri=test,databases[0].protocol=postgres"`

This felt harder to read and understand, however, so I decided to use multiple `--set` values instead.