### PR TITLE
Update app version in teleport kube agent chart to 5.1.0

### DIFF
--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
 version: 0.0.1
-appVersion: "5.0"
+appVersion: "5.1.0"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:


### PR DESCRIPTION
The 5.0 version pulls the 5.0.2, not 5.1.0.  