### PR TITLE
Rename database role to db

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -450,7 +450,7 @@ const (
 	// RoleApp is an application proxy.
 	RoleApp = "app"
 	// RoleDatabase is a database proxy role.
-	RoleDatabase = "database"
+	RoleDatabase = "db"
 )
 
 const (

--- a/roles.go
+++ b/roles.go
@@ -57,7 +57,7 @@ const (
 	// RoleApp is a role for a app proxy in the cluster.
 	RoleApp Role = "App"
 	// RoleDatabase is a role for a database proxy in the cluster.
-	RoleDatabase Role = "Database"
+	RoleDatabase Role = "Db"
 )
 
 // this constant exists for backwards compatibility reasons, needed to upgrade to 2.3

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -98,7 +98,7 @@ Fill out and run this command on a node to start proxying the database:
    --auth-server={{.auth_server}} \
    --db-name={{.db_name}} \
    --db-protocol={{.db_protocol}} \
-   --db-uri={{.db_uri}} 
+   --db-uri={{.db_uri}}
 
 Please note:
 


### PR DESCRIPTION
Rename `database` role to `db` for consistency with other short role names (`app`, `auth`, etc). Closes https://github.com/gravitational/teleport/issues/5349.