### PR TITLE
api dependency reduction - oidc and predicate

### DIFF
--- a/api/defaults/defaults.go
+++ b/api/defaults/defaults.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/api/constants"
-	"gopkg.in/square/go-jose.v2"
 )
 
 const (
@@ -43,10 +42,6 @@ const (
 
 	// MaxCertDuration limits maximum duration of validity of issued cert
 	MaxCertDuration = 30 * time.Hour
-
-	// ApplicationTokenAlgorithm is the default algorithm used to sign
-	// application access tokens.
-	ApplicationTokenAlgorithm = jose.RS256
 
 	// KeepAliveInterval is interval at which Teleport will send keep-alive
 	// messages to the client. The default interval of 5 minutes (300 seconds) is

--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/utils"
 
-	"github.com/coreos/go-oidc/jose"
 	"github.com/gravitational/trace"
 )
 
@@ -416,15 +415,6 @@ type OIDCConnectorSpecV2 struct {
 	GoogleAdminEmail string `json:"google_admin_email,omitempty"`
 }
 
-// GetClaimNames returns a list of claim names from the claim values
-func GetClaimNames(claims jose.Claims) []string {
-	var out []string
-	for claim := range claims {
-		out = append(out, claim)
-	}
-	return out
-}
-
 // ClaimMapping is OIDC claim mapping that maps
 // claim name to teleport roles
 type ClaimMapping struct {
@@ -434,25 +424,6 @@ type ClaimMapping struct {
 	Value string `json:"value"`
 	// Roles is a list of static teleport roles to match.
 	Roles []string `json:"roles,omitempty"`
-}
-
-// OIDCClaimsToTraits converts OIDC-style claims into the standardized
-// teleport trait format.
-func OIDCClaimsToTraits(claims jose.Claims) map[string][]string {
-	traits := make(map[string][]string)
-
-	for claimName := range claims {
-		claimValue, ok, _ := claims.StringClaim(claimName)
-		if ok {
-			traits[claimName] = []string{claimValue}
-		}
-		claimValues, ok, _ := claims.StringsClaim(claimName)
-		if ok {
-			traits[claimName] = claimValues
-		}
-	}
-
-	return traits
 }
 
 // OIDCConnectorSpecV2Schema is a JSON Schema for OIDC Connector

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
-	"github.com/vulcand/predicate"
 )
 
 // Role contains a set of permissions or settings
@@ -676,39 +675,6 @@ func (r *Rule) CheckAndSetDefaults() error {
 	}
 	if len(r.Verbs) == 0 {
 		return trace.BadParameter("missing verbs")
-	}
-	return nil
-}
-
-// MatchesWhere returns true if Where rule matches
-// Empty Where block always matches
-func (r *Rule) MatchesWhere(parser predicate.Parser) (bool, error) {
-	if r.Where == "" {
-		return true, nil
-	}
-	ifn, err := parser.Parse(r.Where)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	fn, ok := ifn.(predicate.BoolPredicate)
-	if !ok {
-		return false, trace.BadParameter("unsupported type: %T", ifn)
-	}
-	return fn(), nil
-}
-
-// ProcessActions processes actions specified for this rule
-func (r *Rule) ProcessActions(parser predicate.Parser) error {
-	for _, action := range r.Actions {
-		ifn, err := parser.Parse(action)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		fn, ok := ifn.(predicate.BoolPredicate)
-		if !ok {
-			return trace.BadParameter("unsupported type: %T", ifn)
-		}
-		fn()
 	}
 	return nil
 }

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
+	"gopkg.in/square/go-jose.v2"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -627,7 +628,7 @@ const (
 	ApplicationTokenKeyType = "RSA"
 	// ApplicationTokenAlgorithm is the default algorithm used to sign
 	// application access tokens.
-	ApplicationTokenAlgorithm = defaults.ApplicationTokenAlgorithm
+	ApplicationTokenAlgorithm = jose.RS256
 )
 
 // WindowsOpenSSHNamedPipe is the address of the named pipe that the

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/utils"
+
 	"github.com/gravitational/trace"
 	"gopkg.in/square/go-jose.v2"
 

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -61,8 +61,7 @@ func GetClaimNames(claims jose.Claims) []string {
 	return out
 }
 
-// OIDCClaimsToTraits converts OIDC-style claims into the standardized
-// teleport trait format.
+// OIDCClaimsToTraits converts OIDC-style claims into teleport-specific trait format
 func OIDCClaimsToTraits(claims jose.Claims) map[string][]string {
 	traits := make(map[string][]string)
 

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -19,6 +19,7 @@ package services
 import (
 	"net/url"
 
+	"github.com/coreos/go-oidc/jose"
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
@@ -49,4 +50,32 @@ func ValidateOIDCConnector(oc types.OIDCConnector) error {
 		}
 	}
 	return nil
+}
+
+// GetClaimNames returns a list of claim names from the claim values
+func GetClaimNames(claims jose.Claims) []string {
+	var out []string
+	for claim := range claims {
+		out = append(out, claim)
+	}
+	return out
+}
+
+// OIDCClaimsToTraits converts OIDC-style claims into the standardized
+// teleport trait format.
+func OIDCClaimsToTraits(claims jose.Claims) map[string][]string {
+	traits := make(map[string][]string)
+
+	for claimName := range claims {
+		claimValue, ok, _ := claims.StringClaim(claimName)
+		if ok {
+			traits[claimName] = []string{claimValue}
+		}
+		claimValues, ok, _ := claims.StringsClaim(claimName)
+		if ok {
+			traits[claimName] = claimValues
+		}
+	}
+
+	return traits
 }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -540,18 +540,12 @@ func CompareRuleScore(r *Rule, o *Rule) bool {
 // RuleSet maps resource to a set of rules defined for it
 type RuleSet map[string][]Rule
 
-// MakeRuleSet converts slice of rules to the set of rules
+// MakeRuleSet creates a new rule set from a list
 func MakeRuleSet(rules []Rule) RuleSet {
 	set := make(RuleSet)
 	for _, rule := range rules {
 		for _, resource := range rule.Resources {
-			rules, ok := set[resource]
-			if !ok {
-				set[resource] = []Rule{rule}
-			} else {
-				rules = append(rules, rule)
-				set[resource] = rules
-			}
+			set[resource] = append(set[resource], rule)
 		}
 	}
 	for resource := range set {
@@ -613,8 +607,8 @@ func (set RuleSet) Match(whereParser predicate.Parser, actionsParser predicate.P
 	return false, nil
 }
 
-// matchesWhere returns true if Where rule matches
-// Empty Where block always matches
+// matchesWhere returns true if Where rule matches.
+// Empty Where block always matches.
 func matchesWhere(r *Rule, parser predicate.Parser) (bool, error) {
 	if r.Where == "" {
 		return true, nil
@@ -625,7 +619,7 @@ func matchesWhere(r *Rule, parser predicate.Parser) (bool, error) {
 	}
 	fn, ok := ifn.(predicate.BoolPredicate)
 	if !ok {
-		return false, trace.BadParameter("unsupported type: %T", ifn)
+		return false, trace.BadParameter("invalid predicate type for where expression: %v", r.Where)
 	}
 	return fn(), nil
 }
@@ -639,7 +633,7 @@ func processActions(r *Rule, parser predicate.Parser) error {
 		}
 		fn, ok := ifn.(predicate.BoolPredicate)
 		if !ok {
-			return trace.BadParameter("unsupported type: %T", ifn)
+			return trace.BadParameter("invalid predicate type for action expression: %v", action)
 		}
 		fn()
 	}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -540,62 +540,6 @@ func CompareRuleScore(r *Rule, o *Rule) bool {
 // RuleSet maps resource to a set of rules defined for it
 type RuleSet map[string][]Rule
 
-// Match tests if the resource name and verb are in a given list of rules.
-// More specific rules will be matched first. See Rule.IsMoreSpecificThan
-// for exact specs on whether the rule is more or less specific.
-//
-// Specifying order solves the problem on having multiple rules, e.g. one wildcard
-// rule can override more specific rules with 'where' sections that can have
-// 'actions' lists with side effects that will not be triggered otherwise.
-//
-func (set RuleSet) Match(whereParser predicate.Parser, actionsParser predicate.Parser, resource string, verb string) (bool, error) {
-	// empty set matches nothing
-	if len(set) == 0 {
-		return false, nil
-	}
-
-	// check for matching resource by name
-	// the most specific rule should win
-	rules := set[resource]
-	for _, rule := range rules {
-		match, err := rule.MatchesWhere(whereParser)
-		if err != nil {
-			return false, trace.Wrap(err)
-		}
-		if match && (rule.HasVerb(Wildcard) || rule.HasVerb(verb)) {
-			if err := rule.ProcessActions(actionsParser); err != nil {
-				return true, trace.Wrap(err)
-			}
-			return true, nil
-		}
-	}
-
-	// check for wildcard resource matcher
-	for _, rule := range set[Wildcard] {
-		match, err := rule.MatchesWhere(whereParser)
-		if err != nil {
-			return false, trace.Wrap(err)
-		}
-		if match && (rule.HasVerb(Wildcard) || rule.HasVerb(verb)) {
-			if err := rule.ProcessActions(actionsParser); err != nil {
-				return true, trace.Wrap(err)
-			}
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-// Slice returns slice from a set
-func (set RuleSet) Slice() []Rule {
-	var out []Rule
-	for _, rules := range set {
-		out = append(out, rules...)
-	}
-	return out
-}
-
 // MakeRuleSet converts slice of rules to the set of rules
 func MakeRuleSet(rules []Rule) RuleSet {
 	set := make(RuleSet)
@@ -620,6 +564,95 @@ func MakeRuleSet(rules []Rule) RuleSet {
 		set[resource] = rules
 	}
 	return set
+}
+
+// Match tests if the resource name and verb are in a given list of rules.
+// More specific rules will be matched first. See Rule.IsMoreSpecificThan
+// for exact specs on whether the rule is more or less specific.
+//
+// Specifying order solves the problem on having multiple rules, e.g. one wildcard
+// rule can override more specific rules with 'where' sections that can have
+// 'actions' lists with side effects that will not be triggered otherwise.
+//
+func (set RuleSet) Match(whereParser predicate.Parser, actionsParser predicate.Parser, resource string, verb string) (bool, error) {
+	// empty set matches nothing
+	if len(set) == 0 {
+		return false, nil
+	}
+
+	// check for matching resource by name
+	// the most specific rule should win
+	rules := set[resource]
+	for _, rule := range rules {
+		match, err := matchesWhere(&rule, whereParser)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		if match && (rule.HasVerb(Wildcard) || rule.HasVerb(verb)) {
+			if err := processActions(&rule, actionsParser); err != nil {
+				return true, trace.Wrap(err)
+			}
+			return true, nil
+		}
+	}
+
+	// check for wildcard resource matcher
+	for _, rule := range set[Wildcard] {
+		match, err := matchesWhere(&rule, whereParser)
+		if err != nil {
+			return false, trace.Wrap(err)
+		}
+		if match && (rule.HasVerb(Wildcard) || rule.HasVerb(verb)) {
+			if err := processActions(&rule, actionsParser); err != nil {
+				return true, trace.Wrap(err)
+			}
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// matchesWhere returns true if Where rule matches
+// Empty Where block always matches
+func matchesWhere(r *Rule, parser predicate.Parser) (bool, error) {
+	if r.Where == "" {
+		return true, nil
+	}
+	ifn, err := parser.Parse(r.Where)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	fn, ok := ifn.(predicate.BoolPredicate)
+	if !ok {
+		return false, trace.BadParameter("unsupported type: %T", ifn)
+	}
+	return fn(), nil
+}
+
+// processActions processes actions specified for this rule
+func processActions(r *Rule, parser predicate.Parser) error {
+	for _, action := range r.Actions {
+		ifn, err := parser.Parse(action)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fn, ok := ifn.(predicate.BoolPredicate)
+		if !ok {
+			return trace.BadParameter("unsupported type: %T", ifn)
+		}
+		fn()
+	}
+	return nil
+}
+
+// Slice returns slice from a set
+func (set RuleSet) Slice() []Rule {
+	var out []Rule
+	for _, rules := range set {
+		out = append(out, rules...)
+	}
+	return out
 }
 
 // AccessChecker interface implements access checks for given role or role set

--- a/lib/services/types.go
+++ b/lib/services/types.go
@@ -270,9 +270,6 @@ var (
 	NewOIDCConnector          = types.NewOIDCConnector
 	SetOIDCConnectorMarshaler = types.SetOIDCConnectorMarshaler
 	GetOIDCConnectorMarshaler = types.GetOIDCConnectorMarshaler
-
-	GetClaimNames      = types.GetClaimNames
-	OIDCClaimsToTraits = types.OIDCClaimsToTraits
 )
 
 // plugin_data.go


### PR DESCRIPTION
Move functions and logic in `api/types` with external dependencies on `oidc` or `predicate` into `lib/services`.

Needs to be rebased to master after #5363 is merged