### PR TITLE
Test flakes: use fake clock to avoid off by 1 error

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -41,11 +41,12 @@ import (
 	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/trace"
 
 	"github.com/coreos/go-oidc/jose"
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
 	. "gopkg.in/check.v1"
 )
 

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -31,8 +31,6 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
-	"github.com/jonboulle/clockwork"
-
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -48,6 +46,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	. "gopkg.in/check.v1"
 )
@@ -76,7 +75,8 @@ func (s *AuthInitSuite) TearDownTest(c *C) {
 // TestReadIdentity makes parses identity from private key and certificate
 // and checks that all parameters are valid
 func (s *AuthInitSuite) TestReadIdentity(c *C) {
-	t := testauthority.New()
+	clock := clockwork.NewFakeClock()
+	t := testauthority.NewWithClock(clock)
 	priv, pub, err := t.GenerateKeyPair("")
 	c.Assert(err, IsNil)
 
@@ -100,8 +100,8 @@ func (s *AuthInitSuite) TestReadIdentity(c *C) {
 	c.Assert(id.KeyBytes, DeepEquals, priv)
 
 	// test TTL by converting the generated cert to text -> back and making sure ExpireAfter is valid
-	ttl := time.Second * 10
-	expiryDate := time.Now().Add(ttl)
+	ttl := 10 * time.Second
+	expiryDate := clock.Now().Add(ttl)
 	bytes, err := t.GenerateHostCert(services.HostCertParams{
 		PrivateCASigningKey: priv,
 		CASigningAlg:        defaults.CASignatureAlgorithm,


### PR DESCRIPTION
Use fake clock to avoid off by 1 errors with real time.

Fixes https://github.com/gravitational/teleport/issues/5369.