### PR TITLE
correct typo in onelogin connector config example

### DIFF
--- a/examples/resources/onelogin-connector.yaml
+++ b/examples/resources/onelogin-connector.yaml
@@ -10,7 +10,7 @@ spec:
   display: OneLogin
   issuer: https://app.onelogin.com/saml/metadata/123456
   sso: https://mycompany.onelogin.com/trust/saml2/http-redirect/sso/123456
-  cert: |
+  entity_descriptor: |
     # Paste in downloaded content from OneLogin Dashboard.
     <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://www.example.com/00000000000000000000">
       <md:IDPSSODescriptor WantAuthnRequestsSigned="false"


### PR DESCRIPTION
in the OneLogin connector config example, `cert:` is used where `entity_descriptor:` should be instead.

note: let me know if I should change the base branch.