### PR TITLE
Change buildbox containers to use CentOS 7 base

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,27 +1,24 @@
 # This Dockerfile makes the "build box": the container used to build official
 # releases of Teleport and its documentation.
 
-# Use Ubuntu 18.04 as base to get an older glibc version.
+# Use CentOS 7 as a base to get an older glibc version (glibc 2.18).
+# This version is compatible with just about every distro other than CentOS 6.
 # Using a newer base image will build against a newer glibc, which creates a
-# runtime requirement for the host to have newer glibc too. For example,
-# teleport built on any newer Ubuntu version will not run on Centos 7 because
-# of this.
-FROM ubuntu:18.04
+# runtime requirement for the host to have newer glibc too.
+FROM centos:7
 
-COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile
 
 ENV LANGUAGE="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
-    LC_CTYPE="en_US.UTF-8" \
-    DEBIAN_FRONTEND="noninteractive"
+    LC_CTYPE="en_US.UTF-8"
 
-RUN apt-get update -y --fix-missing && \
-    apt-get -q -y upgrade && \
-    apt-get install -q -y apt-utils curl gcc gcc-multilib git gzip libbpfcc-dev libc6-dev libpam-dev libsqlite3-0 locales make net-tools tar tree zip shellcheck && \
-    dpkg-reconfigure locales && \
-    apt-get -y autoclean && apt-get -y clean
+# The EPEL repo provides shellcheck.
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum -y update && \
+    yum -y install bcc-devel curl gcc git glibc-devel make net-tools pam-devel ShellCheck tar tree zip && \
+    yum -y clean all
 
 ARG UID
 ARG GID

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -14,10 +14,8 @@ ENV LANGUAGE="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
     LC_CTYPE="en_US.UTF-8"
 
-# The EPEL repo provides shellcheck.
-RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    yum -y update && \
-    yum -y install bcc-devel curl gcc git glibc-devel make net-tools pam-devel ShellCheck tar tree zip && \
+RUN yum -y update && \
+    yum -y install bcc-devel curl gcc git glibc-devel make net-tools pam-devel tar tree zip && \
     yum -y clean all
 
 ARG UID
@@ -45,6 +43,11 @@ ENV GOPATH="/go" \
 RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.24.0/golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz && \
      cp golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ && \
      rm -r golangci-lint*)
+
+# Install shellcheck.
+RUN (curl -L https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.$(go env GOOS).$(uname -m).tar.xz | tar -xJ && \
+     cp shellcheck-v0.7.1/shellcheck /bin/ && \
+     rm -r shellcheck*)
 
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -1,27 +1,23 @@
 # This Dockerfile makes the FIPS "build box": the container used to build official
 # FIPS releases of Teleport and its documentation.
 
-# Use Ubuntu 18.04 as base to get an older glibc version.
+# Use CentOS 7 as a base to get an older glibc version (glibc 2.18).
+# This version is compatible with just about every distro other than CentOS 6.
 # Using a newer base image will build against a newer glibc, which creates a
-# runtime requirement for the host to have newer glibc too. For example,
-# teleport built on any newer Ubuntu version will not run on Centos 7 because
-# of this.
-FROM ubuntu:18.04
+# runtime requirement for the host to have newer glibc too.
+FROM centos:7
 
-COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile
 
 ENV LANGUAGE="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
-    LC_CTYPE="en_US.UTF-8" \
-    DEBIAN_FRONTEND="noninteractive"
+    LC_CTYPE="en_US.UTF-8"
 
-RUN apt-get update -y --fix-missing && \
-    apt-get -q -y upgrade && \
-    apt-get install -q -y apt-utils curl gcc git gzip libbpfcc-dev libc6-dev libpam-dev libsqlite3-0 locales make net-tools tar tree zip && \
-    dpkg-reconfigure locales && \
-    apt-get -y autoclean && apt-get -y clean
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum -y update && \
+    yum -y install bcc-devel curl gcc git glibc-devel make net-tools pam-devel ShellCheck tar tree zip && \
+    yum -y clean all
 
 ARG UID
 ARG GID

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -14,9 +14,8 @@ ENV LANGUAGE="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
     LC_CTYPE="en_US.UTF-8"
 
-RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    yum -y update && \
-    yum -y install bcc-devel curl gcc git glibc-devel make net-tools pam-devel ShellCheck tar tree zip && \
+RUN yum -y update && \
+    yum -y install bcc-devel curl gcc git glibc-devel make net-tools pam-devel tar tree zip && \
     yum -y clean all
 
 ARG UID

--- a/go.mod
+++ b/go.mod
@@ -107,5 +107,5 @@ require (
 replace (
 	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
-	github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1
+	github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.2-0.20210111215708-6d954a21a7a0
 )

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/gravitational/go-oidc v0.0.3 h1:VKhztRfuXq5KVcAPAEagF2y9rjoNgEXvZ/5Ps
 github.com/gravitational/go-oidc v0.0.3/go.mod h1:SevmOUNdOB0aD9BAIgjptZ6oHkKxMZZgA70nwPfgU/w=
 github.com/gravitational/gobpf v0.0.1 h1:1NufkXUOOt/farCC4juGZ8FFU1qmA+2Zb4lPaVfUFoE=
 github.com/gravitational/gobpf v0.0.1/go.mod h1:464Ee3TMfw+IBUVWy7xyb4ud4nJkrU7RzE/GjhEGY+c=
+github.com/gravitational/gobpf v0.0.2-0.20210111215708-6d954a21a7a0 h1:lNnL1/89KN39HnnDBTuvQLDCFYMkQ13UGMi0kz0RWA0=
+github.com/gravitational/gobpf v0.0.2-0.20210111215708-6d954a21a7a0/go.mod h1:464Ee3TMfw+IBUVWy7xyb4ud4nJkrU7RzE/GjhEGY+c=
 github.com/gravitational/kingpin v2.1.11-0.20190130013101-742f2714c145+incompatible h1:CfyZl3nyo9K5lLqOmqvl9/IElY1UCnOWKZiQxJ8HKdA=
 github.com/gravitational/kingpin v2.1.11-0.20190130013101-742f2714c145+incompatible/go.mod h1:LWxG30M3FcrjhOn3T4zz7JmBoQJ45MWZmOXgy9Ganoc=
 github.com/gravitational/license v0.0.0-20180912170534-4f189e3bd6e3 h1:vy9WwUq3H7XCCkQzExIwxQNNTCYRGayyTHFcayL1KHg=

--- a/vendor/github.com/iovisor/gobpf/bcc/module.go
+++ b/vendor/github.com/iovisor/gobpf/bcc/module.go
@@ -32,10 +32,14 @@ import (
 // #include <dlfcn.h>
 // #include <stdbool.h>
 //
-// #if __has_include(<bcc/bcc_common.h>)
-//   #include <bcc/bcc_common.h>
+// #ifdef __has_include
+//   #if __has_include(<bcc/bcc_common.h>)
+//     #include <bcc/bcc_common.h>
+//   #else
+//     #include <bcc/bpf_common.h>
+//   #endif
 // #else
-//   #include <bcc/bpf_common.h>
+//   #include <bcc/bcc_common.h>
 // #endif
 // #include <bcc/libbpf.h>
 //

--- a/vendor/github.com/iovisor/gobpf/bcc/perf.go
+++ b/vendor/github.com/iovisor/gobpf/bcc/perf.go
@@ -26,10 +26,14 @@ import (
 // #cgo CFLAGS: -I/usr/include/bcc/compat
 // #cgo LDFLAGS: -ldl
 //
-// #if __has_include(<bcc/bcc_common.h>)
-//   #include <bcc/bcc_common.h>
+// #ifdef __has_include
+//   #if __has_include(<bcc/bcc_common.h>)
+//     #include <bcc/bcc_common.h>
+//   #else
+//     #include <bcc/bpf_common.h>
+//   #endif
 // #else
-//   #include <bcc/bpf_common.h>
+//   #include <bcc/bcc_common.h>
 // #endif
 // #include <bcc/libbpf.h>
 // #include <bcc/perf_reader.h>

--- a/vendor/github.com/iovisor/gobpf/bcc/sym.c
+++ b/vendor/github.com/iovisor/gobpf/bcc/sym.c
@@ -15,10 +15,14 @@
 #include "_cgo_export.h"
 #include <stdio.h>
 #include <stdbool.h>
-#if __has_include(<bcc/bcc_common.h>)
-  #include <bcc/bcc_common.h>
+#ifdef __has_include
+  #if __has_include(<bcc/bcc_common.h>)
+    #include <bcc/bcc_common.h>
+  #else
+    #include <bcc/bpf_common.h>
+  #endif
 #else
-  #include <bcc/bpf_common.h>
+  #include <bcc/bcc_common.h>
 #endif
 #include <bcc/libbpf.h>
 #include <dlfcn.h>
@@ -138,7 +142,7 @@ int init_symlookup(void *handle) {
     symlookup[BPF_TABLE_NAME                 ] = dlsym(handle, "bpf_table_name");
     symlookup[BPF_UPDATE_ELEM                ] = dlsym(handle, "bpf_update_elem");
     symlookup[PERF_READER_FD                 ] = dlsym(handle, "perf_reader_fd");
-    symlookup[PERF_READER_POLL               ] = dlsym(handle, "perf_reader_poll");                    
+    symlookup[PERF_READER_POLL               ] = dlsym(handle, "perf_reader_poll");
 
     // Make sure all symbols were resolvable.
     int i;

--- a/vendor/github.com/iovisor/gobpf/bcc/symbol.go
+++ b/vendor/github.com/iovisor/gobpf/bcc/symbol.go
@@ -24,10 +24,14 @@ import (
 // #cgo CFLAGS: -I/usr/include/bcc/compat
 // #cgo LDFLAGS: -ldl
 //
-// #if __has_include(<bcc/bcc_common.h>)
-//   #include <bcc/bcc_common.h>
+// #ifdef __has_include
+//   #if __has_include(<bcc/bcc_common.h>)
+//     #include <bcc/bcc_common.h>
+//   #else
+//     #include <bcc/bpf_common.h>
+//   #endif
 // #else
-//   #include <bcc/bpf_common.h>
+//   #include <bcc/bcc_common.h>
 // #endif
 // #include <bcc/libbpf.h>
 // #include <bcc/bcc_syms.h>

--- a/vendor/github.com/iovisor/gobpf/bcc/table.go
+++ b/vendor/github.com/iovisor/gobpf/bcc/table.go
@@ -25,10 +25,14 @@ import (
 // #cgo CFLAGS: -I/usr/include/bcc/compat
 // #cgo LDFLAGS: -ldl
 //
-// #if __has_include(<bcc/bcc_common.h>)
-//   #include <bcc/bcc_common.h>
+// #ifdef __has_include
+//   #if __has_include(<bcc/bcc_common.h>)
+//     #include <bcc/bcc_common.h>
+//   #else
+//     #include <bcc/bpf_common.h>
+//   #endif
 // #else
-//   #include <bcc/bpf_common.h>
+//   #include <bcc/bcc_common.h>
 // #endif
 // #include <bcc/libbpf.h>
 //

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -265,7 +265,7 @@ github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/imdario/mergo v0.3.5
 github.com/imdario/mergo
-# github.com/iovisor/gobpf v0.0.1 => github.com/gravitational/gobpf v0.0.1
+# github.com/iovisor/gobpf v0.0.1 => github.com/gravitational/gobpf v0.0.2-0.20210111215708-6d954a21a7a0
 ## explicit
 github.com/iovisor/gobpf/bcc
 github.com/iovisor/gobpf/pkg/cpuonline
@@ -953,4 +953,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
 # github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
-# github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1
+# github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.2-0.20210111215708-6d954a21a7a0


### PR DESCRIPTION
This PR changes the buildbox for regular/FIPS builds to use a CentOS 7 base image. This reduces Teleport's required glibc version from 2.27 to 2.18.

I initially installed the EPEL repo to install shellcheck, but the version packaged there is v0.3.8 and shellcheck is currently up to v0.7.1, so I decided to install the binary version of shellcheck instead.

Depends on https://github.com/gravitational/gobpf/pull/1

Fixes #5338 

