### PR TITLE
Fix tsh login issue

### DIFF
--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -136,8 +136,11 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, db tlsca.RouteToDatab
 // access certificates for databases the current profile is logged into.
 func fetchDatabaseCreds(cf *CLIConf, tc *client.TeleportClient) error {
 	profile, err := client.StatusCurrent("", cf.Proxy)
-	if err != nil {
+	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
+	}
+	if trace.IsNotFound(err) {
+		return nil // No currently logged in profiles.
 	}
 	for _, db := range profile.Databases {
 		if err := databaseLogin(cf, tc, db, true); err != nil {

--- a/tool/tsh/db_test.go
+++ b/tool/tsh/db_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFetchDatabaseCreds makes sure fetching database credentials does not
+// trigger an error when there's no logged in profile.
+func TestFetchDatabaseCreds(t *testing.T) {
+	var cf CLIConf
+	cf.UserHost = "localhost"
+	// Randomize proxy name to make sure there's no profile entry.
+	cf.Proxy = uuid.New()
+
+	tc, err := makeClient(&cf, true)
+	require.NoError(t, err)
+
+	err = fetchDatabaseCreds(&cf, tc)
+	require.NoError(t, err)
+}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -702,17 +702,18 @@ func onLogin(cf *CLIConf) {
 		}
 	}
 
+	// Update the command line flag for the proxy to make sure any advertised
+	// settings are picked up.
+	webProxyHost, _ := tc.WebProxyHostPort()
+	cf.Proxy = webProxyHost
+
 	// If the profile is already logged into any database services,
 	// refresh the creds.
 	if err := fetchDatabaseCreds(cf, tc); err != nil {
 		utils.FatalError(err)
 	}
 
-	// Print status to show information of the logged in user. Update the
-	// command line flag (used to print status) for the proxy to make sure any
-	// advertised settings are picked up.
-	webProxyHost, _ := tc.WebProxyHostPort()
-	cf.Proxy = webProxyHost
+	// Print status to show information of the logged in user.
 	onStatus(cf)
 }
 


### PR DESCRIPTION
If `--proxy` differs from the actual proxy public addr during `tsh login`, it fails with the following error:

```
$ tsh --proxy=localhost --user=alice --insecure login
WARNING: You are using insecure connection to SSH proxy https://localhost:3080
Enter password for Teleport user alice:
WARNING: You are using insecure connection to SSH proxy https://proxy.example.com:3080
error: not logged in
```

With the following stack trace:

```
ERROR REPORT:
Original Error: *trace.NotFoundError not logged in
Stack Trace:
	/home/go/src/github.com/gravitational/teleport/lib/client/api.go:578 github.com/gravitational/teleport/lib/client.StatusCurrent
	/home/go/src/github.com/gravitational/teleport/tool/tsh/db.go:138 main.fetchDatabaseCreds
	/home/go/src/github.com/gravitational/teleport/tool/tsh/tsh.go:703 main.onLogin
	/home/go/src/github.com/gravitational/teleport/tool/tsh/tsh.go:440 main.Run
	/home/go/src/github.com/gravitational/teleport/tool/tsh/tsh.go:221 main.main
	/usr/local/go/src/runtime/proc.go:204 runtime.main
	/usr/local/go/src/runtime/asm_amd64.s:1374 runtime.goexit
User Message: not logged in
```

This PR fixes the issue by making sure that fetching database creds uses proxy address that's been updated after login procedure, not the one originally specified on the CLI.