### PR TITLE
Fix truncated audit-log when using DynamoDB

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -503,8 +503,8 @@ func (l *Log) SearchEvents(fromUTC, toUTC time.Time, filter string, limit int) (
 	var lastEvaluatedKey map[string]*dynamodb.AttributeValue
 	var total int
 
-	// Because the maximum size of the dynamo db response size is 900K according to documentation.
-	// We arbitrary limit the total size to 100MB to prevent runaway loops.
+	// Because the maximum size of the dynamo db response size is 900K according to documentation,
+	// we arbitrary limit the total size to 100MB to prevent runaway loops.
 	for pageCount := 0; pageCount < 99; pageCount++ {
 		input := dynamodb.QueryInput{
 			KeyConditionExpression:    aws.String(query),

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -160,10 +160,6 @@ const (
 	// of the events by time
 	indexTimeSearch = "timesearch"
 
-	// maxPageSizeKbs is the maximum size (900KB) of dynamo db response
-	// according to documentation.
-	maxPageSizeKbs = 900
-
 	// DefaultReadCapacityUnits specifies default value for read capacity units
 	DefaultReadCapacityUnits = 10
 
@@ -507,11 +503,9 @@ func (l *Log) SearchEvents(fromUTC, toUTC time.Time, filter string, limit int) (
 	var lastEvaluatedKey map[string]*dynamodb.AttributeValue
 	var total int
 
-	// We iterate over the responses until we roughly hit ~90MB in size.
-	// This is an arbitrary limit to prevent runaway loops.
-	const maxResponseSizeKbs = maxPageSizeKbs * 100
-
-	for responseSize := 0; responseSize < maxResponseSizeKbs; responseSize += maxPageSizeKbs {
+	// Because the maximum size of the dynamo db response size is 900K according to documentation.
+	// We arbitrary limit the total size to 100MB to prevent runaway loops.
+	for pageCount := 0; pageCount < 99; pageCount++ {
 		input := dynamodb.QueryInput{
 			KeyConditionExpression:    aws.String(query),
 			TableName:                 aws.String(l.Tablename),

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -505,7 +505,7 @@ func (l *Log) SearchEvents(fromUTC, toUTC time.Time, filter string, limit int) (
 
 	// Because the maximum size of the dynamo db response size is 900K according to documentation,
 	// we arbitrary limit the total size to 100MB to prevent runaway loops.
-	for pageCount := 0; pageCount < 99; pageCount++ {
+	for pageCount := 0; pageCount < 100; pageCount++ {
 		input := dynamodb.QueryInput{
 			KeyConditionExpression:    aws.String(query),
 			TableName:                 aws.String(l.Tablename),


### PR DESCRIPTION
This is a fix for #4977. Teleport will continue to query DynamoDB until
the response doesn't contain a `LastEvaluatedKey` anymore, which signals
the end of the result set.