### PR TITLE
backport: kube: always enable proxy protocol support

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/utils"
@@ -153,15 +154,30 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 
 // Serve takes TCP listener, upgrades to TLS using config and starts serving
 func (t *TLSServer) Serve(listener net.Listener) error {
+	// Wrap listener with a multiplexer to get Proxy Protocol support.
+	mux, err := multiplexer.New(multiplexer.Config{
+		Context:             t.Context,
+		Listener:            listener,
+		Clock:               t.Clock,
+		EnableProxyProtocol: true,
+		DisableSSH:          true,
+		ID:                  t.Component,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	go mux.Serve()
+	defer mux.Close()
+
 	t.mu.Lock()
-	t.listener = listener
+	t.listener = mux.TLS()
 	t.mu.Unlock()
 
 	if t.heartbeat != nil {
 		go t.heartbeat.Run()
 	}
 
-	return t.Server.Serve(tls.NewListener(listener, t.TLS))
+	return t.Server.Serve(tls.NewListener(mux.TLS(), t.TLS))
 }
 
 // Close closes the server and cleans up all resources.


### PR DESCRIPTION
Backport of #5299 into 5.0.
