### PR TITLE
api dependency reduction - uuid

### DIFF
--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/pborman/uuid"
 )
 
 // AccessRequest is a request for temporarily granted roles
@@ -75,12 +74,12 @@ type AccessRequest interface {
 }
 
 // NewAccessRequest assembled an AccessRequest resource.
-func NewAccessRequest(user string, roles ...string) (AccessRequest, error) {
+func NewAccessRequest(name string, user string, roles ...string) (AccessRequest, error) {
 	req := AccessRequestV3{
 		Kind:    KindAccessRequest,
 		Version: V3,
 		Metadata: Metadata{
-			Name: uuid.New(),
+			Name: name,
 		},
 		Spec: AccessRequestSpecV3{
 			User:  user,
@@ -212,9 +211,6 @@ func (r *AccessRequestV3) Check() error {
 	}
 	if r.GetName() == "" {
 		return trace.BadParameter("access request id not set")
-	}
-	if uuid.Parse(r.GetName()) == nil {
-		return trace.BadParameter("invalid access request id %q", r.GetName())
 	}
 	if r.GetUser() == "" {
 		return trace.BadParameter("access request user name not set")

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -929,7 +929,7 @@ func (a *Server) getRolesAndExpiryFromAccessRequest(user, accessRequestID string
 		return nil, time.Time{}, trace.BadParameter("access request %q is awaiting approval", accessRequestID)
 	}
 
-	if err := services.ValidateAccessRequest(a, req); err != nil {
+	if err := services.ValidateAccessRequestForUser(a, req); err != nil {
 		return nil, time.Time{}, trace.Wrap(err)
 	}
 
@@ -1625,7 +1625,7 @@ func (a *Server) upsertRole(ctx context.Context, role services.Role) error {
 }
 
 func (a *Server) CreateAccessRequest(ctx context.Context, req services.AccessRequest) error {
-	err := services.ValidateAccessRequest(a, req,
+	err := services.ValidateAccessRequestForUser(a, req,
 		// if request is in state pending, role expansion must be applied
 		services.ExpandRoles(req.GetState().IsPending()),
 		// always apply system annotations before storing new requests

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1096,7 +1096,7 @@ func (a *ServerWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserC
 				}
 				return nil, trace.AccessDenied("access-request %q is awaiting approval", reqID)
 			}
-			if err := services.ValidateAccessRequest(a.authServer, accessReq); err != nil {
+			if err := services.ValidateAccessRequestForUser(a.authServer, accessReq); err != nil {
 				return nil, trace.Wrap(err)
 			}
 			aexp := accessReq.GetAccessExpiry()

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -365,6 +365,9 @@ func (g *GRPCServer) CreateAccessRequest(ctx context.Context, req *services.Acce
 	if err != nil {
 		return nil, trail.ToGRPC(err)
 	}
+	if err := services.ValidateAccessRequest(req); err != nil {
+		return nil, trail.ToGRPC(err)
+	}
 	if err := auth.ServerWithRoles.CreateAccessRequest(ctx, req); err != nil {
 		return nil, trail.ToGRPC(err)
 	}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -40,7 +40,7 @@ func ValidateAccessRequest(ar AccessRequest) error {
 	return nil
 }
 
-// NewAccessRequest assembled an AccessRequest resource.
+// NewAccessRequest assembles an AccessRequest resource.
 func NewAccessRequest(user string, roles ...string) (AccessRequest, error) {
 	req, err := types.NewAccessRequest(uuid.New(), user, roles...)
 	if err != nil {

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/parse"
 
@@ -27,6 +28,29 @@ import (
 
 	"github.com/pborman/uuid"
 )
+
+// ValidateAccessRequest validates the AccessRequest and sets default values
+func ValidateAccessRequest(ar AccessRequest) error {
+	if err := ar.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+	if uuid.Parse(ar.GetName()) == nil {
+		return trace.BadParameter("invalid access request id %q", ar.GetName())
+	}
+	return nil
+}
+
+// NewAccessRequest assembled an AccessRequest resource.
+func NewAccessRequest(user string, roles ...string) (AccessRequest, error) {
+	req, err := types.NewAccessRequest(uuid.New(), user, roles...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := ValidateAccessRequest(req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return req, nil
+}
 
 // RequestIDs is a collection of IDs for privilege escalation requests.
 type RequestIDs struct {
@@ -406,11 +430,11 @@ func ApplySystemAnnotations(annotate bool) ValidateRequestOption {
 	}
 }
 
-// ValidateAccessRequest validates an access request against the associated users's
+// ValidateAccessRequestForUser validates an access request against the associated users's
 // *statically assigned* roles. If expandRoles is true, it will also expand wildcard
 // requests, setting their role list to include all roles the user is allowed to request.
 // Expansion should be performed before an access request is initially placed in the backend.
-func ValidateAccessRequest(getter UserAndRoleGetter, req AccessRequest, opts ...ValidateRequestOption) error {
+func ValidateAccessRequestForUser(getter UserAndRoleGetter, req AccessRequest, opts ...ValidateRequestOption) error {
 	v, err := NewRequestValidator(getter, req.GetUser(), opts...)
 	if err != nil {
 		return trace.Wrap(err)
@@ -459,7 +483,7 @@ func UnmarshalAccessRequest(data []byte, opts ...MarshalOption) (AccessRequest, 
 			return nil, trace.Wrap(err)
 		}
 	}
-	if err := req.CheckAndSetDefaults(); err != nil {
+	if err := ValidateAccessRequest(&req); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	if cfg.ID != 0 {

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -41,7 +41,7 @@ func NewDynamicAccessService(backend backend.Backend) *DynamicAccessService {
 
 // CreateAccessRequest stores a new access request.
 func (s *DynamicAccessService) CreateAccessRequest(ctx context.Context, req services.AccessRequest) error {
-	if err := req.CheckAndSetDefaults(); err != nil {
+	if err := services.ValidateAccessRequest(req); err != nil {
 		return trace.Wrap(err)
 	}
 	item, err := itemFromAccessRequest(req)
@@ -199,7 +199,7 @@ func (s *DynamicAccessService) DeleteAllAccessRequests(ctx context.Context) erro
 }
 
 func (s *DynamicAccessService) UpsertAccessRequest(ctx context.Context, req services.AccessRequest) error {
-	if err := req.CheckAndSetDefaults(); err != nil {
+	if err := services.ValidateAccessRequest(req); err != nil {
 		return trace.Wrap(err)
 	}
 	item, err := itemFromAccessRequest(req)

--- a/lib/services/types.go
+++ b/lib/services/types.go
@@ -124,8 +124,6 @@ type (
 )
 
 var (
-	NewAccessRequest = types.NewAccessRequest
-
 	RequestStrategyOptional = types.RequestStrategyOptional
 	RequestStrategyReason   = types.RequestStrategyReason
 	RequestStrategyAlways   = types.RequestStrategyAlways

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -213,7 +213,7 @@ func (c *AccessRequestCommand) Create(client auth.ClientI) error {
 	req.SetRequestReason(c.reason)
 
 	if c.dryRun {
-		err = services.ValidateAccessRequest(client, req, services.ExpandRoles(true), services.ApplySystemAnnotations(true))
+		err = services.ValidateAccessRequestForUser(client, req, services.ExpandRoles(true), services.ApplySystemAnnotations(true))
 		if err != nil {
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
Right now all validation is happening immediately after calling `NewAccessRequest`, and then in a few additional places in the call stack. This PR just fixes the issue with the immediate validation on the client side, which requires `req.Metadata.Name = uuid.New()` to be called.

The more long term fix to this issue is to refactor our `New` functions and validation strategy, to do more work on the server side rather than front loading it to the client. For example, `types.NewAccessRequest` should only require `user` and `roles` to pass basic validation on the client side. And then at some point deeper in the call stack on the server side, before inserting the Access Request, it should be fully validated, and have default values set (including `req.Metadata.Name = uuid.New()`). 

Changes:
 - `uuid.New()` is now called in `services.NewAccessRequest`, and `types.NewAccessRequest` takes name as an argument. It would be best to move the uuid setting out of the client side altogether, but would require refactoring Access request name/id to be set to a field other than `AccessRequest.Metatdata.Name`, which cannot be left empty on the client side.
 - `uuid.Parse()` is now called in `services.ValidateAccessRequest` which is now called in many places instead of `AccessRequest.Check()`.