### PR TITLE
Remove inline [TOC] blocks

### DIFF
--- a/docs/4.1/architecture/teleport-architecture-overview.md
+++ b/docs/4.1/architecture/teleport-architecture-overview.md
@@ -4,10 +4,6 @@ This guide is for those looking for a deeper understanding of Teleport. If you
 are looking for hands-on instructions on how to set up Teleport for your team,
 check out the [Admin Guide](../admin-guide.md)
 
-**Table of Contents**
-
-[TOC]
-
 ## Design Principles
 
 Teleport was designed in accordance with the following principles:

--- a/docs/4.1/architecture/teleport-auth.md
+++ b/docs/4.1/architecture/teleport-auth.md
@@ -4,10 +4,6 @@ This document outlines the Teleport Authentication Service and Certificate
 Management. It explains how Users and Nodes are identified and granted access to
 Nodes and Services.
 
-**Table of Contents**
-
-[TOC]
-
 ## Authentication vs. Authorization
 
 Teleport Auth handles both authentication and authorization. These topics are

--- a/docs/4.1/architecture/teleport-nodes.md
+++ b/docs/4.1/architecture/teleport-nodes.md
@@ -1,9 +1,5 @@
 # Teleport Nodes
 
-**Table of Contents**
-
-[TOC]
-
 ## The Node Service
 
 A regular node becomes a Teleport Node when the node joins a cluster with an

--- a/docs/4.1/architecture/teleport-proxy.md
+++ b/docs/4.1/architecture/teleport-proxy.md
@@ -1,9 +1,5 @@
 # The Proxy Service
 
-**Table of Contents**
-
-[TOC]
-
 The proxy is a stateless service which performs three main functions in a
 Teleport cluster:
 

--- a/docs/4.1/architecture/teleport-users.md
+++ b/docs/4.1/architecture/teleport-users.md
@@ -2,10 +2,6 @@
 
 <!-- TODO: This doc is incomplete, pending addition of Enterprise topics -->
 
-**Table of Contents**
-
-[TOC]
-
 ## Types of Users
 
 Unlike traditional SSH, Teleport introduces the concept of a User Account. A

--- a/docs/4.1/enterprise/ssh-fips.md
+++ b/docs/4.1/enterprise/ssh-fips.md
@@ -3,10 +3,6 @@ With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
 the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high
 level overview of how Teleport FIPS mode works and how it can help your company to become FedRAMP certified.
 
-**Table of Contents**
-
-[TOC]
-
 ### Obtain FedRAMP certification with Teleport
 Teleport includes new FedRAMP and FIPS 140-2 features to support companies that sell into
 government agencies.

--- a/docs/4.1/installation.md
+++ b/docs/4.1/installation.md
@@ -6,10 +6,6 @@ The Teleport client [`tsh`](cli-docs.md#tsh) and Web UI are available for **Linu
 and **Windows** operating systems. Our examples install Teleport v4.1.0 but you can
 install any version listed in our [Release History](https://gravitational.com/teleport/download/).
 
-**Table of Contents**
-
-[TOC]
-
 ## Checksums
 
 Gravitational Teleport provides a checksum from the Downloads page.  This should

--- a/docs/4.1/quickstart.md
+++ b/docs/4.1/quickstart.md
@@ -6,10 +6,6 @@ This tutorial will guide you through the steps needed to install and run
 Teleport on a single node which could be your local machine but we recommend a
 VM.
 
-**Table of Contents**
-
-[TOC]
-
 ### Prerequisites
 
 * In this tutorial you will start a web UI which must be accessible via a web

--- a/docs/4.2/architecture/teleport-architecture-overview.md
+++ b/docs/4.2/architecture/teleport-architecture-overview.md
@@ -4,10 +4,6 @@ This guide is for those looking for a deeper understanding of Teleport. If you
 are looking for hands-on instructions on how to set up Teleport for your team,
 check out the [Admin Guide](../admin-guide.md)
 
-**Table of Contents**
-
-[TOC]
-
 ## Design Principles
 
 Teleport was designed in accordance with the following principles:

--- a/docs/4.2/architecture/teleport-nodes.md
+++ b/docs/4.2/architecture/teleport-nodes.md
@@ -1,9 +1,5 @@
 # Teleport Nodes
 
-**Table of Contents**
-
-[TOC]
-
 ## The Node Service
 
 A regular node becomes a Teleport Node when the node joins a cluster with a

--- a/docs/4.2/architecture/teleport-proxy.md
+++ b/docs/4.2/architecture/teleport-proxy.md
@@ -1,9 +1,5 @@
 # The Proxy Service
 
-**Table of Contents**
-
-[TOC]
-
 The proxy is a stateless service which performs three main functions in a
 Teleport cluster:
 

--- a/docs/4.2/architecture/teleport-users.md
+++ b/docs/4.2/architecture/teleport-users.md
@@ -2,10 +2,6 @@
 
 <!-- TODO: This doc is incomplete, pending addition of Enterprise topics -->
 
-**Table of Contents**
-
-[TOC]
-
 ## Types of Users
 
 Unlike traditional SSH, Teleport introduces the concept of a User Account. A

--- a/docs/4.2/enterprise/ssh-fips.md
+++ b/docs/4.2/enterprise/ssh-fips.md
@@ -3,10 +3,6 @@ With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
 the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high
 level overview of how Teleport FIPS mode works and how it can help your company to become FedRAMP certified.
 
-**Table of Contents**
-
-[TOC]
-
 ### Obtain FedRAMP certification with Teleport
 Teleport includes new FedRAMP and FIPS 140-2 features to support companies that sell into
 government agencies.

--- a/docs/4.2/production.md
+++ b/docs/4.2/production.md
@@ -4,8 +4,6 @@ This guide provides more in-depth details for running Teleport in Production.
 
 <!-- TODO: Minimal Config example -->
 
-[TOC]
-
 ## Prerequisites
 
 * Read the [Architecture Overview](architecture/teleport-architecture-overview.md)

--- a/docs/4.3/aws-terraform-guide.md
+++ b/docs/4.3/aws-terraform-guide.md
@@ -8,8 +8,6 @@ description: How to configure Teleport in highly available (HA) mode for AWS dep
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to use and administrate the resulting Teleport deployment.
 
-[TOC]
-
 ## Prerequisites
 
 Our code requires Terraform 0.12+. You can [download Terraform here](https://www.terraform.io/downloads.html). We will assume that you have

--- a/docs/4.4/aws-terraform-guide.md
+++ b/docs/4.4/aws-terraform-guide.md
@@ -8,8 +8,6 @@ description: How to configure Teleport in highly available (HA) mode for AWS dep
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to use and administrate the resulting Teleport deployment.
 
-[TOC]
-
 ## Prerequisites
 
 Our code requires Terraform 0.12+. You can [download Terraform here](https://www.terraform.io/downloads.html). We will assume that you have

--- a/docs/5.0/aws-terraform-guide.md
+++ b/docs/5.0/aws-terraform-guide.md
@@ -8,8 +8,6 @@ description: How to configure Teleport in highly available (HA) mode for AWS dep
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to use and administrate the resulting Teleport deployment.
 
-[TOC]
-
 ## Prerequisites
 
 Our code requires Terraform 0.12+. You can [download Terraform here](https://www.terraform.io/downloads.html). We will assume that you have


### PR DESCRIPTION
Docs have TOC that is always visible at the right side of the docs. Inline on is redundant.