### PR TITLE
teleport-kube-agent: Check whether Teleport version is >=6 before setting db_service key

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -36,6 +36,8 @@ data:
       enabled: false
       {{- end }}
 
+    {{- if semverCompare ">=6" (.teleportVersion | toString) }}
+
     db_service:
       {{- if contains "db" (.Values.roles | toString) }}
       enabled: true
@@ -55,6 +57,7 @@ data:
       {{- else }}
       enabled: false
       {{- end }}
+    {{- end }}
 
     auth_service:
       enabled: false

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -36,6 +36,7 @@ data:
       enabled: false
       {{- end }}
 
+    {{- /* specifying 'db_service' in a config file prior to Teleport 6 results in a parse error */ -}}
     {{- if semverCompare ">=6" (.teleportVersion | toString) }}
 
     db_service:

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{- if .Values.teleportVersionOverride }}
+  {{- $_ := set . "teleportVersion" .Values.teleportVersionOverride }}
+{{- else }}
+  {{- $_ := set . "teleportVersion" .Chart.AppVersion }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,7 +25,7 @@ spec:
     spec:
       containers:
       - name: "teleport"
-        image: "{{ if .Values.enterprise }}{{ .Values.enterpriseImage }}{{ else }}{{ .Values.image }}{{ end }}:{{ if .Values.teleportVersionOverride }}{{ .Values.teleportVersionOverride }}{{ else }}{{ .Chart.AppVersion }}{{ end }}"
+        image: "{{ if .Values.enterprise }}{{ .Values.enterpriseImage }}{{ else }}{{ .Values.image }}{{ end }}:{{ .teleportVersion }}"
         args:
         - "--diag-addr=0.0.0.0:3000"
         {{- if .Values.insecureSkipProxyTLSVerify }}


### PR DESCRIPTION
Also tidy up logic around teleportVersion so it's only set in one place.

Fixes #5406 