### PR TITLE
Removed redirect

### DIFF
--- a/docs/5.0.yaml
+++ b/docs/5.0.yaml
@@ -29,9 +29,6 @@ plugins:
     - search:
         separator: '[\s\-\.]'
     - markdownextradata: {}
-    - redirects:
-        redirect_maps:
-          'kubernetes-ssh.md': 'kubernetes-access.md'
 extra_javascript: []
 extra:
     # this version is used for the docs switcher, not for Teleport


### PR DESCRIPTION
Redirects should not be done through the yaml file. This is causing an error in SemRush. We use nginx for all permanent redirects, the change here is causing a "meta tag refresh" which is a bad practice for SEO.

Please review and merge. Thanks. 