### PR TITLE
Test flakes: scp broken pipe

### DIFF
--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -403,10 +403,10 @@ func (cmd *command) serveSink(ch io.ReadWriter) error {
 	}
 	var st state
 	st.path = localDir
-	var b = make([]byte, 1)
+	var b [1]byte
 	scanner := bufio.NewScanner(ch)
 	for {
-		n, err := ch.Read(b)
+		n, err := ch.Read(b[:])
 		if err != nil {
 			if err == io.EOF {
 				return nil


### PR DESCRIPTION
I observed behavior with scp in source mode (`-f`) when it sporadically fails to write to stderr with `EPIPE`.

Changes:
 * Wait on scp process at the end of the test.
 * Service the stderr pipe to avoid 'broken pipe' in scp side.

Fixes https://github.com/gravitational/teleport/issues/5417.