### PR TITLE
OSS RBAC

### DIFF
--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -33,6 +33,8 @@ import (
 type CertAuthority interface {
 	// ResourceWithSecrets sets common resource properties
 	ResourceWithSecrets
+	// SetMetadata sets CA metadata
+	SetMetadata(meta Metadata)
 	// GetID returns certificate authority ID -
 	// combined type and name
 	GetID() CertAuthID
@@ -175,6 +177,11 @@ func (ca *CertAuthorityV2) GetJWTKeyPairs() []JWTKeyPair {
 // SetJWTKeyPairs sets all JWT keypairs used to sign a JWT.
 func (ca *CertAuthorityV2) SetJWTKeyPairs(keyPairs []JWTKeyPair) {
 	ca.Spec.JWTKeyPairs = keyPairs
+}
+
+// SetMetadata sets object metadata
+func (ca *CertAuthorityV2) SetMetadata(meta Metadata) {
+	ca.Metadata = meta
 }
 
 // GetMetadata returns object metadata

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -30,6 +30,9 @@ const (
 	// Wildcard is a special wildcard character matching everything
 	Wildcard = "*"
 
+	// True holds "true" string value
+	True = "true"
+
 	// KindNamespace is a namespace
 	KindNamespace = "namespace"
 

--- a/api/types/github.go
+++ b/api/types/github.go
@@ -29,6 +29,8 @@ import (
 type GithubConnector interface {
 	// ResourceWithSecrets is a common interface for all resources
 	ResourceWithSecrets
+	// SetMetadata sets object metadata
+	SetMetadata(meta Metadata)
 	// CheckAndSetDefaults validates the connector and sets some defaults
 	CheckAndSetDefaults() error
 	// GetClientID returns the connector client ID
@@ -175,6 +177,11 @@ func (c *GithubConnectorV3) SetExpiry(expires time.Time) {
 // DELETE IN 7.0.0
 func (c *GithubConnectorV3) SetTTL(clock Clock, ttl time.Duration) {
 	c.Metadata.SetTTL(clock, ttl)
+}
+
+// SetMetadata sets connector metadata
+func (c *GithubConnectorV3) SetMetadata(meta Metadata) {
+	c.Metadata = meta
 }
 
 // GetMetadata returns the connector metadata

--- a/api/types/trustedcluster.go
+++ b/api/types/trustedcluster.go
@@ -31,6 +31,8 @@ import (
 type TrustedCluster interface {
 	// Resource provides common resource properties
 	Resource
+	// SetMetadata sets object metadata
+	SetMetadata(meta Metadata)
 	// GetEnabled returns the state of the TrustedCluster.
 	GetEnabled() bool
 	// SetEnabled enables (handshake and add ca+reverse tunnel) or disables TrustedCluster.
@@ -191,6 +193,11 @@ func (c *TrustedClusterV2) SetRoleMap(m RoleMap) {
 // GetMetadata returns object metadata
 func (c *TrustedClusterV2) GetMetadata() Metadata {
 	return c.Metadata
+}
+
+// SetMetadata sets object metadata
+func (c *TrustedClusterV2) SetMetadata(meta Metadata) {
+	c.Metadata = meta
 }
 
 // SetExpiry sets expiry time for the object

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -30,6 +30,8 @@ import (
 type User interface {
 	// ResourceWithSecrets provides common resource properties
 	ResourceWithSecrets
+	// SetMetadata sets object metadata
+	SetMetadata(meta Metadata)
 	// GetOIDCIdentities returns a list of connected OIDC identities
 	GetOIDCIdentities() []ExternalIdentity
 	// GetSAMLIdentities returns a list of connected SAML identities
@@ -121,6 +123,11 @@ func (u *UserV2) SetResourceID(id int64) {
 // GetMetadata returns object metadata
 func (u *UserV2) GetMetadata() Metadata {
 	return u.Metadata
+}
+
+// SetMetadata sets object metadata
+func (u *UserV2) SetMetadata(meta Metadata) {
+	u.Metadata = meta
 }
 
 // SetExpiry sets expiry time for the object

--- a/constants.go
+++ b/constants.go
@@ -546,6 +546,12 @@ const Root = "root"
 // another role is not explicitly assigned (Enterprise only).
 const AdminRoleName = "admin"
 
+// OSSUserRoleName is a role created for open source user
+const OSSUserRoleName = "ossuser"
+
+// OSSMigratedV6 is a label to mark migrated OSS users and resources
+const OSSMigratedV6 = "migrate-v6.0"
+
 // MinClientVersion is the minimum client version required by the server.
 const MinClientVersion = "3.0.0"
 

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017-2020 Gravitational, Inc.
+Copyright 2017-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -386,8 +385,12 @@ func (a *Server) calculateGithubUser(connector services.GithubConnector, claims 
 			"user %q does not belong to any teams configured in %q connector",
 			claims.Username, connector.GetName())
 	}
-	p.roles = modules.GetModules().RolesFromLogins(p.logins)
-	p.traits = modules.GetModules().TraitsFromLogins(p.username, p.logins, p.kubeGroups, p.kubeUsers)
+	p.roles = p.logins
+	p.traits = map[string][]string{
+		teleport.TraitLogins:     []string{p.username},
+		teleport.TraitKubeGroups: p.kubeGroups,
+		teleport.TraitKubeUsers:  p.kubeUsers,
+	}
 
 	// Pick smaller for role: session TTL from role or requested TTL.
 	roles, err := services.FetchRoles(p.roles, a.Access, p.traits)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,11 +29,13 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/u2f"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -476,7 +478,12 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 }
 
 func migrateLegacyResources(ctx context.Context, cfg InitConfig, asrv *Server) error {
-	err := migrateRemoteClusters(asrv)
+	err := migrateOSS(ctx, asrv)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = migrateRemoteClusters(asrv)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -491,6 +498,182 @@ func migrateLegacyResources(ctx context.Context, cfg InitConfig, asrv *Server) e
 	}
 
 	return nil
+}
+
+const migrationAbortedMessage = "migration to RBAC has aborted because of the backend error, restart teleport to try again"
+
+// migrateOSS performs migration to enable role-based access controls
+// to open source users. It creates a less privileged role 'ossuser'
+// and migrates all users and trusted cluster mappings to it
+// this function can be called multiple times
+// DELETE IN(7.0)
+func migrateOSS(ctx context.Context, asrv *Server) error {
+	if modules.GetModules().BuildType() != modules.BuildOSS {
+		return nil
+	}
+	role := services.NewOSSUserRole()
+	err := asrv.CreateRole(role)
+	createdRoles := 0
+	if err != nil {
+		if !trace.IsAlreadyExists(err) {
+			return trace.Wrap(err, migrationAbortedMessage)
+		}
+		// Role is created, assume that migration has been completed.
+		// To re-run the migration, users can delete the role.
+		return nil
+	}
+	if err == nil {
+		createdRoles++
+		log.Infof("Enabling RBAC in OSS Teleport. Migrating users, roles and trusted clusters.")
+	}
+	migratedUsers, err := migrateOSSUsers(ctx, role, asrv)
+	if err != nil {
+		return trace.Wrap(err, migrationAbortedMessage)
+	}
+
+	migratedTcs, err := migrateOSSTrustedClusters(ctx, role, asrv)
+	if err != nil {
+		return trace.Wrap(err, migrationAbortedMessage)
+	}
+
+	migratedConns, err := migrateOSSGithubConns(ctx, role, asrv)
+	if err != nil {
+		return trace.Wrap(err, migrationAbortedMessage)
+	}
+
+	if createdRoles > 0 || migratedUsers > 0 || migratedTcs > 0 || migratedConns > 0 {
+		log.Infof("Migration completed. Created %v roles, updated %v users, %v trusted clusters and %v Github connectors.",
+			createdRoles, migratedUsers, migratedTcs, migratedConns)
+	}
+
+	return nil
+}
+
+const remoteWildcardPattern = "^.+$"
+
+// migrateOSSTrustedClusters updates role mappings in trusted clusters
+// OSS Trusted clusters had no explicit mapping from remote roles, to local roles.
+// Map all remote roles to local OSS user role.
+func migrateOSSTrustedClusters(ctx context.Context, role types.Role, asrv *Server) (int, error) {
+	migratedTcs := 0
+	tcs, err := asrv.GetTrustedClusters()
+	if err != nil {
+		return migratedTcs, trace.Wrap(err, migrationAbortedMessage)
+	}
+
+	for _, tc := range tcs {
+		meta := tc.GetMetadata()
+		_, ok := meta.Labels[teleport.OSSMigratedV6]
+		if ok {
+			continue
+		}
+		setLabels(&meta.Labels, teleport.OSSMigratedV6, types.True)
+		roleMap := []types.RoleMapping{{Remote: remoteWildcardPattern, Local: []string{role.GetName()}}}
+		tc.SetRoleMap(roleMap)
+		tc.SetMetadata(meta)
+		if _, err := asrv.Presence.UpsertTrustedCluster(ctx, tc); err != nil {
+			return migratedTcs, trace.Wrap(err, migrationAbortedMessage)
+		}
+		for _, catype := range []services.CertAuthType{services.UserCA, services.HostCA} {
+			ca, err := asrv.GetCertAuthority(services.CertAuthID{Type: catype, DomainName: tc.GetName()}, true)
+			if err != nil {
+				return migratedTcs, trace.Wrap(err, migrationAbortedMessage)
+			}
+			meta := ca.GetMetadata()
+			_, ok := meta.Labels[teleport.OSSMigratedV6]
+			if ok {
+				continue
+			}
+			setLabels(&meta.Labels, teleport.OSSMigratedV6, types.True)
+			ca.SetRoleMap(roleMap)
+			ca.SetMetadata(meta)
+			err = asrv.UpsertCertAuthority(ca)
+			if err != nil {
+				return migratedTcs, trace.Wrap(err, migrationAbortedMessage)
+			}
+		}
+		migratedTcs++
+	}
+	return migratedTcs, nil
+}
+
+// migrateOSSUsers assigns all OSS users to a less privileged role
+// All OSS users were using implicit admin role. Migrate all users to less privileged
+// role that is read only and only lets users use assigned logins.
+func migrateOSSUsers(ctx context.Context, role types.Role, asrv *Server) (int, error) {
+	migratedUsers := 0
+	users, err := asrv.GetUsers(true)
+	if err != nil {
+		return migratedUsers, trace.Wrap(err, migrationAbortedMessage)
+	}
+
+	for _, user := range users {
+		meta := user.GetMetadata()
+		_, ok := meta.Labels[teleport.OSSMigratedV6]
+		if ok {
+			continue
+		}
+		setLabels(&meta.Labels, teleport.OSSMigratedV6, types.True)
+		user.SetRoles([]string{role.GetName()})
+		user.SetMetadata(meta)
+		if err := asrv.UpsertUser(user); err != nil {
+			return migratedUsers, trace.Wrap(err, migrationAbortedMessage)
+		}
+		migratedUsers++
+	}
+
+	return migratedUsers, nil
+}
+
+func setLabels(v *map[string]string, key, val string) {
+	if *v == nil {
+		*v = map[string]string{
+			key: val,
+		}
+		return
+	}
+	(*v)[key] = val
+}
+
+func migrateOSSGithubConns(ctx context.Context, role types.Role, asrv *Server) (int, error) {
+	migratedConns := 0
+	// Migrate Github's OSS teams_to_logins to teams_to_roles.
+	// To do that, create a new role per connector's teams_to_logins entry
+	conns, err := asrv.GetGithubConnectors(true)
+	if err != nil {
+		return migratedConns, trace.Wrap(err)
+	}
+	for _, conn := range conns {
+		meta := conn.GetMetadata()
+		_, ok := meta.Labels[teleport.OSSMigratedV6]
+		if ok {
+			continue
+		}
+		setLabels(&meta.Labels, teleport.OSSMigratedV6, types.True)
+		conn.SetMetadata(meta)
+		// replace every team with a new role
+		teams := conn.GetTeamsToLogins()
+		newTeams := make([]types.TeamMapping, len(teams))
+		for i, team := range teams {
+			r := services.NewOSSGithubRole(team.Logins, team.KubeUsers, team.KubeGroups)
+			err := asrv.CreateRole(r)
+			if err != nil {
+				return migratedConns, trace.Wrap(err)
+			}
+			newTeams[i] = types.TeamMapping{
+				Organization: team.Organization,
+				Team:         team.Team,
+				Logins:       []string{r.GetName()},
+			}
+		}
+		conn.SetTeamsToLogins(newTeams)
+		if err := asrv.UpsertGithubConnector(conn); err != nil {
+			return migratedConns, trace.Wrap(err)
+		}
+		migratedConns++
+	}
+
+	return migratedConns, nil
 }
 
 // isFirstStart returns 'true' if the auth server is starting for the 1st time

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -40,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -48,39 +47,17 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
-	. "gopkg.in/check.v1"
 )
-
-type AuthInitSuite struct {
-	tempDir string
-}
-
-var _ = Suite(&AuthInitSuite{})
-
-func (s *AuthInitSuite) SetUpSuite(c *C) {
-	utils.InitLoggerForTests(testing.Verbose())
-}
-
-func (s *AuthInitSuite) SetUpTest(c *C) {
-	var err error
-	s.tempDir, err = ioutil.TempDir("", "auth-init-test-")
-	c.Assert(err, IsNil)
-}
-
-func (s *AuthInitSuite) TearDownTest(c *C) {
-	err := os.RemoveAll(s.tempDir)
-	c.Assert(err, IsNil)
-}
 
 // TestReadIdentity makes parses identity from private key and certificate
 // and checks that all parameters are valid
-func (s *AuthInitSuite) TestReadIdentity(c *C) {
+func TestReadIdentity(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	t := testauthority.NewWithClock(clock)
-	priv, pub, err := t.GenerateKeyPair("")
-	c.Assert(err, IsNil)
+	a := testauthority.NewWithClock(clock)
+	priv, pub, err := a.GenerateKeyPair("")
+	require.NoError(t, err)
 
-	cert, err := t.GenerateHostCert(services.HostCertParams{
+	cert, err := a.GenerateHostCert(services.HostCertParams{
 		PrivateCASigningKey: priv,
 		CASigningAlg:        defaults.CASignatureAlgorithm,
 		PublicHostKey:       pub,
@@ -90,19 +67,19 @@ func (s *AuthInitSuite) TestReadIdentity(c *C) {
 		Roles:               teleport.Roles{teleport.RoleNode},
 		TTL:                 0,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	id, err := ReadSSHIdentityFromKeyPair(priv, cert)
-	c.Assert(err, IsNil)
-	c.Assert(id.ClusterName, Equals, "example.com")
-	c.Assert(id.ID, DeepEquals, IdentityID{HostUUID: "id1.example.com", Role: teleport.RoleNode})
-	c.Assert(id.CertBytes, DeepEquals, cert)
-	c.Assert(id.KeyBytes, DeepEquals, priv)
+	require.NoError(t, err)
+	require.Equal(t, id.ClusterName, "example.com")
+	require.Equal(t, id.ID, IdentityID{HostUUID: "id1.example.com", Role: teleport.RoleNode})
+	require.Equal(t, id.CertBytes, cert)
+	require.Equal(t, id.KeyBytes, priv)
 
 	// test TTL by converting the generated cert to text -> back and making sure ExpireAfter is valid
 	ttl := 10 * time.Second
 	expiryDate := clock.Now().Add(ttl)
-	bytes, err := t.GenerateHostCert(services.HostCertParams{
+	bytes, err := a.GenerateHostCert(services.HostCertParams{
 		PrivateCASigningKey: priv,
 		CASigningAlg:        defaults.CASignatureAlgorithm,
 		PublicHostKey:       pub,
@@ -112,25 +89,25 @@ func (s *AuthInitSuite) TestReadIdentity(c *C) {
 		Roles:               teleport.Roles{teleport.RoleNode},
 		TTL:                 ttl,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	pk, _, _, _, err := ssh.ParseAuthorizedKey(bytes)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	copy, ok := pk.(*ssh.Certificate)
-	c.Assert(ok, Equals, true)
-	c.Assert(uint64(expiryDate.Unix()), Equals, copy.ValidBefore)
+	require.True(t, ok)
+	require.Equal(t, uint64(expiryDate.Unix()), copy.ValidBefore)
 }
 
-func (s *AuthInitSuite) TestBadIdentity(c *C) {
-	t := testauthority.New()
-	priv, pub, err := t.GenerateKeyPair("")
-	c.Assert(err, IsNil)
+func TestBadIdentity(t *testing.T) {
+	a := testauthority.New()
+	priv, pub, err := a.GenerateKeyPair("")
+	require.NoError(t, err)
 
 	// bad cert type
 	_, err = ReadSSHIdentityFromKeyPair(priv, pub)
-	c.Assert(trace.IsBadParameter(err), Equals, true, Commentf("%#v", err))
+	require.IsType(t, trace.BadParameter(""), err)
 
 	// missing authority domain
-	cert, err := t.GenerateHostCert(services.HostCertParams{
+	cert, err := a.GenerateHostCert(services.HostCertParams{
 		PrivateCASigningKey: priv,
 		CASigningAlg:        defaults.CASignatureAlgorithm,
 		PublicHostKey:       pub,
@@ -140,13 +117,13 @@ func (s *AuthInitSuite) TestBadIdentity(c *C) {
 		Roles:               teleport.Roles{teleport.RoleNode},
 		TTL:                 0,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	_, err = ReadSSHIdentityFromKeyPair(priv, cert)
-	c.Assert(trace.IsBadParameter(err), Equals, true, Commentf("%#v", err))
+	require.IsType(t, trace.BadParameter(""), err)
 
 	// missing host uuid
-	cert, err = t.GenerateHostCert(services.HostCertParams{
+	cert, err = a.GenerateHostCert(services.HostCertParams{
 		PrivateCASigningKey: priv,
 		CASigningAlg:        defaults.CASignatureAlgorithm,
 		PublicHostKey:       pub,
@@ -156,13 +133,13 @@ func (s *AuthInitSuite) TestBadIdentity(c *C) {
 		Roles:               teleport.Roles{teleport.RoleNode},
 		TTL:                 0,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	_, err = ReadSSHIdentityFromKeyPair(priv, cert)
-	c.Assert(trace.IsBadParameter(err), Equals, true, Commentf("%#v", err))
+	require.IsType(t, trace.BadParameter(""), err)
 
 	// unrecognized role
-	cert, err = t.GenerateHostCert(services.HostCertParams{
+	cert, err = a.GenerateHostCert(services.HostCertParams{
 		PrivateCASigningKey: priv,
 		CASigningAlg:        defaults.CASignatureAlgorithm,
 		PublicHostKey:       pub,
@@ -172,17 +149,19 @@ func (s *AuthInitSuite) TestBadIdentity(c *C) {
 		Roles:               teleport.Roles{teleport.Role("bad role")},
 		TTL:                 0,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	_, err = ReadSSHIdentityFromKeyPair(priv, cert)
-	c.Assert(trace.IsBadParameter(err), Equals, true, Commentf("%#v", err))
+	require.IsType(t, trace.BadParameter(""), err)
 }
 
 // TestAuthPreference ensures that the act of creating an AuthServer sets
 // the AuthPreference (type and second factor) on the backend.
-func (s *AuthInitSuite) TestAuthPreference(c *C) {
-	bk, err := lite.New(context.TODO(), backend.Params{"path": s.tempDir})
-	c.Assert(err, IsNil)
+func TestAuthPreference(t *testing.T) {
+	tempDir := t.TempDir()
+
+	bk, err := lite.New(context.TODO(), backend.Params{"path": tempDir})
+	require.NoError(t, err)
 
 	ap, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
 		Type:         "local",
@@ -192,19 +171,20 @@ func (s *AuthInitSuite) TestAuthPreference(c *C) {
 			Facets: []string{"bar", "baz"},
 		},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "me.localhost",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
+
 	staticTokens, err := services.NewStaticTokens(services.StaticTokensSpecV2{
 		StaticTokens: []services.ProvisionTokenV1{},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	ac := InitConfig{
-		DataDir:        s.tempDir,
+		DataDir:        tempDir,
 		HostUUID:       "00000000-0000-0000-0000-000000000000",
 		NodeName:       "foo",
 		Backend:        bk,
@@ -215,35 +195,38 @@ func (s *AuthInitSuite) TestAuthPreference(c *C) {
 		AuthPreference: ap,
 	}
 	as, err := Init(ac)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer as.Close()
 
 	cap, err := as.GetAuthPreference()
-	c.Assert(err, IsNil)
-	c.Assert(cap.GetType(), Equals, "local")
-	c.Assert(cap.GetSecondFactor(), Equals, constants.SecondFactorU2F)
+	require.NoError(t, err)
+	require.Equal(t, cap.GetType(), "local")
+	require.Equal(t, cap.GetSecondFactor(), constants.SecondFactorU2F)
+
 	u, err := cap.GetU2F()
-	c.Assert(err, IsNil)
-	c.Assert(u.AppID, Equals, "foo")
-	c.Assert(u.Facets, DeepEquals, []string{"bar", "baz"})
+	require.NoError(t, err)
+	require.Equal(t, u.AppID, "foo")
+	require.Equal(t, u.Facets, []string{"bar", "baz"})
 }
 
-func (s *AuthInitSuite) TestClusterID(c *C) {
-	bk, err := lite.New(context.TODO(), backend.Params{"path": c.MkDir()})
-	c.Assert(err, IsNil)
+func TestClusterID(t *testing.T) {
+	tempDir := t.TempDir()
+
+	bk, err := lite.New(context.TODO(), backend.Params{"path": tempDir})
+	require.NoError(t, err)
 
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "me.localhost",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	authPreference, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
 		Type: "local",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	authServer, err := Init(InitConfig{
-		DataDir:        c.MkDir(),
+		DataDir:        t.TempDir(),
 		HostUUID:       "00000000-0000-0000-0000-000000000000",
 		NodeName:       "foo",
 		Backend:        bk,
@@ -253,17 +236,17 @@ func (s *AuthInitSuite) TestClusterID(c *C) {
 		StaticTokens:   services.DefaultStaticTokens(),
 		AuthPreference: authPreference,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer authServer.Close()
 
 	cc, err := authServer.GetClusterConfig()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	clusterID := cc.GetClusterID()
-	c.Assert(clusterID, Not(Equals), "")
+	require.NotEqual(t, clusterID, "")
 
 	// do it again and make sure cluster ID hasn't changed
 	authServer, err = Init(InitConfig{
-		DataDir:        c.MkDir(),
+		DataDir:        t.TempDir(),
 		HostUUID:       "00000000-0000-0000-0000-000000000000",
 		NodeName:       "foo",
 		Backend:        bk,
@@ -273,31 +256,31 @@ func (s *AuthInitSuite) TestClusterID(c *C) {
 		StaticTokens:   services.DefaultStaticTokens(),
 		AuthPreference: authPreference,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer authServer.Close()
 
 	cc, err = authServer.GetClusterConfig()
-	c.Assert(err, IsNil)
-	c.Assert(cc.GetClusterID(), Equals, clusterID)
+	require.NoError(t, err)
+	require.Equal(t, cc.GetClusterID(), clusterID)
 }
 
 // TestClusterName ensures that a cluster can not be renamed.
-func (s *AuthInitSuite) TestClusterName(c *C) {
-	bk, err := lite.New(context.TODO(), backend.Params{"path": c.MkDir()})
-	c.Assert(err, IsNil)
+func TestClusterName(t *testing.T) {
+	bk, err := lite.New(context.TODO(), backend.Params{"path": t.TempDir()})
+	require.NoError(t, err)
 
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "me.localhost",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	authPreference, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
 		Type: "local",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	authServer, err := Init(InitConfig{
-		DataDir:        c.MkDir(),
+		DataDir:        t.TempDir(),
 		HostUUID:       "00000000-0000-0000-0000-000000000000",
 		NodeName:       "foo",
 		Backend:        bk,
@@ -307,7 +290,7 @@ func (s *AuthInitSuite) TestClusterName(c *C) {
 		StaticTokens:   services.DefaultStaticTokens(),
 		AuthPreference: authPreference,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer authServer.Close()
 
 	// Start the auth server with a different cluster name. The auth server
@@ -315,10 +298,10 @@ func (s *AuthInitSuite) TestClusterName(c *C) {
 	clusterName, err = services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "dev.localhost",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	authServer, err = Init(InitConfig{
-		DataDir:        c.MkDir(),
+		DataDir:        t.TempDir(),
 		HostUUID:       "00000000-0000-0000-0000-000000000000",
 		NodeName:       "foo",
 		Backend:        bk,
@@ -328,30 +311,30 @@ func (s *AuthInitSuite) TestClusterName(c *C) {
 		StaticTokens:   services.DefaultStaticTokens(),
 		AuthPreference: authPreference,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer authServer.Close()
 
 	cn, err := authServer.GetClusterName()
-	c.Assert(err, IsNil)
-	c.Assert(cn.GetClusterName(), Equals, "me.localhost")
+	require.NoError(t, err)
+	require.Equal(t, cn.GetClusterName(), "me.localhost")
 }
 
-func (s *AuthInitSuite) TestCASigningAlg(c *C) {
-	bk, err := lite.New(context.TODO(), backend.Params{"path": c.MkDir()})
-	c.Assert(err, IsNil)
+func TestCASigningAlg(t *testing.T) {
+	bk, err := lite.New(context.TODO(), backend.Params{"path": t.TempDir()})
+	require.NoError(t, err)
 
 	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
 		ClusterName: "me.localhost",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	authPreference, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
 		Type: "local",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	conf := InitConfig{
-		DataDir:        c.MkDir(),
+		DataDir:        t.TempDir(),
 		HostUUID:       "00000000-0000-0000-0000-000000000000",
 		NodeName:       "foo",
 		Backend:        bk,
@@ -364,34 +347,34 @@ func (s *AuthInitSuite) TestCASigningAlg(c *C) {
 
 	verifyCAs := func(auth *Server, alg string) {
 		hostCAs, err := auth.GetCertAuthorities(services.HostCA, false)
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 		for _, ca := range hostCAs {
-			c.Assert(sshutils.GetSigningAlgName(ca), Equals, alg)
+			require.Equal(t, sshutils.GetSigningAlgName(ca), alg)
 		}
 		userCAs, err := auth.GetCertAuthorities(services.UserCA, false)
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 		for _, ca := range userCAs {
-			c.Assert(sshutils.GetSigningAlgName(ca), Equals, alg)
+			require.Equal(t, sshutils.GetSigningAlgName(ca), alg)
 		}
 	}
 
 	// Start a new server without specifying a signing alg.
 	auth, err := Init(conf)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	verifyCAs(auth, ssh.SigAlgoRSASHA2512)
 
-	c.Assert(auth.Close(), IsNil)
+	require.NoError(t, auth.Close())
 
 	// Reset the auth server state.
-	conf.Backend, err = lite.New(context.TODO(), backend.Params{"path": c.MkDir()})
-	c.Assert(err, IsNil)
-	conf.DataDir = c.MkDir()
+	conf.Backend, err = lite.New(context.TODO(), backend.Params{"path": t.TempDir()})
+	require.NoError(t, err)
+	conf.DataDir = t.TempDir()
 
 	// Start a new server with non-default signing alg.
 	signingAlg := ssh.SigAlgoRSA
 	conf.CASigningAlg = &signingAlg
 	auth, err = Init(conf)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer auth.Close()
 	verifyCAs(auth, ssh.SigAlgoRSA)
 
@@ -399,7 +382,7 @@ func (s *AuthInitSuite) TestCASigningAlg(c *C) {
 	// CA.
 	signingAlg = ssh.SigAlgoRSASHA2256
 	auth, err = Init(conf)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	verifyCAs(auth, ssh.SigAlgoRSA)
 }
 
@@ -496,6 +479,177 @@ func TestMigrateMFADevices(t *testing.T) {
 	users, err = as.GetUsers(true)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(users, wantUsers, cmpOpts...))
+}
+
+// TestMigrateOSS tests migration of OSS users, github connectors
+// and trusted clusters
+func TestMigrateOSS(t *testing.T) {
+	utils.InitLoggerForTests(testing.Verbose())
+
+	ctx := context.Background()
+
+	t.Run("EmptyCluster", func(t *testing.T) {
+		as := newTestAuthServer(t)
+		clock := clockwork.NewFakeClock()
+		as.SetClock(clock)
+
+		err := migrateOSS(ctx, as)
+		require.NoError(t, err)
+
+		// Second call should not fail
+		err = migrateOSS(ctx, as)
+		require.NoError(t, err)
+
+		// OSS user role was created
+		_, err = as.GetRole(teleport.OSSUserRoleName)
+		require.NoError(t, err)
+	})
+
+	t.Run("User", func(t *testing.T) {
+		as := newTestAuthServer(t)
+		clock := clockwork.NewFakeClock()
+		as.SetClock(clock)
+
+		user, _, err := CreateUserAndRole(as, "alice", []string{"alice"})
+		require.NoError(t, err)
+
+		err = migrateOSS(ctx, as)
+		require.NoError(t, err)
+
+		out, err := as.GetUser(user.GetName(), false)
+		require.NoError(t, err)
+		require.Equal(t, []string{teleport.OSSUserRoleName}, out.GetRoles())
+		require.Equal(t, types.True, out.GetMetadata().Labels[teleport.OSSMigratedV6])
+
+		err = migrateOSS(ctx, as)
+		require.NoError(t, err)
+	})
+
+	t.Run("TrustedCluster", func(t *testing.T) {
+		clusterName := "test.localhost"
+		as := newTestAuthServer(t, clusterName)
+		clock := clockwork.NewFakeClock()
+		as.SetClock(clock)
+
+		foo, err := services.NewTrustedCluster("foo", services.TrustedClusterSpecV2{
+			Enabled:              false,
+			Token:                "qux",
+			ProxyAddress:         "quux",
+			ReverseTunnelAddress: "quuz",
+		})
+		require.NoError(t, err)
+
+		value, err := services.MarshalTrustedCluster(foo)
+		require.NoError(t, err)
+
+		_, err = as.bk.Put(ctx, backend.Item{
+			Key:   []byte("/trustedclusters/foo"),
+			Value: value,
+		})
+		require.NoError(t, err)
+
+		for _, name := range []string{clusterName, foo.GetName()} {
+			for _, catype := range []services.CertAuthType{services.UserCA, services.HostCA} {
+				causer := suite.NewTestCA(catype, name)
+				err = as.UpsertCertAuthority(causer)
+				require.NoError(t, err)
+			}
+		}
+
+		err = migrateOSS(ctx, as)
+		require.NoError(t, err)
+
+		out, err := as.GetTrustedCluster(foo.GetName())
+		require.NoError(t, err)
+		mapping := types.RoleMap{{Remote: remoteWildcardPattern, Local: []string{teleport.OSSUserRoleName}}}
+		require.Equal(t, mapping, out.GetRoleMap())
+
+		for _, catype := range []services.CertAuthType{services.UserCA, services.HostCA} {
+			ca, err := as.GetCertAuthority(services.CertAuthID{Type: catype, DomainName: foo.GetName()}, true)
+			require.NoError(t, err)
+			require.Equal(t, mapping, ca.GetRoleMap())
+			require.Equal(t, types.True, ca.GetMetadata().Labels[teleport.OSSMigratedV6])
+		}
+
+		// root cluster CA are not updated
+		for _, catype := range []services.CertAuthType{services.UserCA, services.HostCA} {
+			ca, err := as.GetCertAuthority(services.CertAuthID{Type: catype, DomainName: clusterName}, true)
+			require.NoError(t, err)
+			_, found := ca.GetMetadata().Labels[teleport.OSSMigratedV6]
+			require.False(t, found)
+		}
+
+		err = migrateOSS(ctx, as)
+		require.NoError(t, err)
+	})
+
+	t.Run("GithubConnector", func(t *testing.T) {
+		as := newTestAuthServer(t)
+		clock := clockwork.NewFakeClock()
+		as.SetClock(clock)
+
+		connector := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
+			ClientID:     "aaa",
+			ClientSecret: "bbb",
+			RedirectURL:  "https://localhost:3080/v1/webapi/github/callback",
+			Display:      "Github",
+			TeamsToLogins: []types.TeamMapping{
+				{
+					Organization: "gravitational",
+					Team:         "admins",
+					Logins:       []string{"admin", "dev"},
+					KubeGroups:   []string{"system:masters", "kube-devs"},
+					KubeUsers:    []string{"alice@example.com"},
+				},
+				{
+					Organization: "gravitational",
+					Team:         "devs",
+					Logins:       []string{"dev", "test"},
+					KubeGroups:   []string{"kube-devs"},
+				},
+			},
+		})
+
+		err := as.CreateGithubConnector(connector)
+		require.NoError(t, err)
+
+		err = migrateOSS(ctx, as)
+		require.NoError(t, err)
+
+		out, err := as.GetGithubConnector(connector.GetName(), false)
+		require.NoError(t, err)
+		require.Equal(t, types.True, out.GetMetadata().Labels[teleport.OSSMigratedV6])
+
+		// Teams to logins mapping were converted to roles
+		mappings := out.GetTeamsToLogins()
+		require.Len(t, mappings, 2)
+		require.Len(t, mappings[0].Logins, 1)
+
+		r, err := as.GetRole(mappings[0].Logins[0])
+		require.NoError(t, err)
+		require.Equal(t, connector.GetTeamsToLogins()[0].Logins, r.GetLogins(types.Allow))
+		require.Equal(t, connector.GetTeamsToLogins()[0].KubeGroups, r.GetKubeGroups(types.Allow))
+		require.Equal(t, connector.GetTeamsToLogins()[0].KubeUsers, r.GetKubeUsers(types.Allow))
+		require.Len(t, mappings[0].KubeGroups, 0)
+		require.Len(t, mappings[0].KubeUsers, 0)
+
+		require.Len(t, mappings[1].Logins, 1)
+		r2, err := as.GetRole(mappings[1].Logins[0])
+		require.NoError(t, err)
+		require.Equal(t, connector.GetTeamsToLogins()[1].Logins, r2.GetLogins(types.Allow))
+		require.Equal(t, connector.GetTeamsToLogins()[1].KubeGroups, r2.GetKubeGroups(types.Allow))
+		require.Len(t, mappings[1].KubeGroups, 0)
+		require.Len(t, mappings[1].KubeUsers, 0)
+
+		// Second run should not recreate the role or alter its mappings.
+		err = migrateOSS(ctx, as)
+		require.NoError(t, err)
+
+		out, err = as.GetGithubConnector(connector.GetName(), false)
+		require.NoError(t, err)
+		require.Equal(t, mappings, out.GetTeamsToLogins())
+	})
+
 }
 
 func newUserWithAuth(t *testing.T, name string, auth *types.LocalAuthSecrets) services.User {

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018-2019 Gravitational, Inc.
+Copyright 2018-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ type KubeCSRResponse struct {
 // ProcessKubeCSR processes CSR request against Kubernetes CA, returns
 // signed certificate if successful.
 func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
-	if !modules.GetModules().SupportsKubernetes() {
+	if !modules.GetModules().Features().Kubernetes {
 		return nil, trace.AccessDenied(
 			"this teleport cluster does not support kubernetes, please contact system administrator for support")
 	}

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -85,18 +85,22 @@ func TestRemoteClusterStatus(t *testing.T) {
 	require.Empty(t, cmp.Diff(rc, gotRC))
 }
 
-func newTestAuthServer(t *testing.T) *Server {
+func newTestAuthServer(t *testing.T, name ...string) *Server {
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
 	t.Cleanup(func() { bk.Close() })
 
+	clusterName := "me.localhost"
+	if len(name) != 0 {
+		clusterName = name[0]
+	}
 	// Create a cluster with minimal viable config.
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
+	clusterNameRes, err := services.NewClusterName(services.ClusterNameSpecV2{
+		ClusterName: clusterName,
 	})
 	require.NoError(t, err)
 	authConfig := &InitConfig{
-		ClusterName:            clusterName,
+		ClusterName:            clusterNameRes,
 		Backend:                bk,
 		Authority:              authority.New(),
 		SkipPeriodicOperations: true,

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,37 +26,45 @@ import (
 	"github.com/gravitational/teleport"
 )
 
+// Features provides supported and unsupported features
+type Features struct {
+	// Kubernetes enables Kubernetes Access product
+	Kubernetes bool
+	// App enables Application Access product
+	App bool
+	// DB enables database access product
+	DB bool
+	// OIDC enables OIDC connectors
+	OIDC bool
+	// SAML enables SAML connectors
+	SAML bool
+	// AccessControls enables FIPS access controls
+	AccessControls bool
+	// AdvancedAccessWorkflows enables advanced access workflows
+	AdvancedAccessWorkflows bool
+	// Cloud enables some cloud-related features
+	Cloud bool
+}
+
 // Modules defines interface that external libraries can implement customizing
 // default teleport behavior
 type Modules interface {
-	// EmptyRoles handler is called when a new trusted cluster with empty roles
-	// is being created
-	EmptyRolesHandler() error
-	// DefaultAllowedLogins returns default allowed logins for a new admin role
-	DefaultAllowedLogins() []string
-	// DefaultKubeUsers returns default kubernetes users for a new admin role
-	DefaultKubeUsers() []string
-	// DefaultKubeGroups returns default kubernetes groups for a new admin role
-	DefaultKubeGroups() []string
 	// PrintVersion prints teleport version
 	PrintVersion()
-	// RolesFromLogins returns roles for external user based on the logins
-	// extracted from the connector
-	RolesFromLogins([]string) []string
-	// TraitsFromLogins returns traits for external user based on the logins
-	// and kubernetes groups extracted from the connector
-	TraitsFromLogins(user string, logins []string, kubeGroups []string, kubeUsers []string) map[string][]string
-	// SupportsKubernetes returns true if this cluster supports kubernetes
-	SupportsKubernetes() bool
 	// IsBoringBinary checks if the binary was compiled with BoringCrypto.
 	IsBoringBinary() bool
-	// DELETE IN: 5.1.0
-	//
-	// ExtendAdminUserRules returns true if the "AdminUserRules" set should be
-	// extended with additional rules to allow user and token management. Only
-	// needed until 5.1 when user and token management will be added to OSS.
-	ExtendAdminUserRules() bool
+	// Features returns supported features
+	Features() Features
+	// BuildType returns build type (OSS or Enterprise)
+	BuildType() string
 }
+
+const (
+	// BuildOSS specifies open source build type
+	BuildOSS = "oss"
+	// BuildEnterprise specifies enterprise build type
+	BuildEnterprise = "ent"
+)
 
 // SetModules sets the modules interface
 func SetModules(m Modules) {
@@ -74,25 +82,9 @@ func GetModules() Modules {
 
 type defaultModules struct{}
 
-// EmptyRolesHandler is called when a new trusted cluster with empty roles
-// is created, no-op by default
-func (p *defaultModules) EmptyRolesHandler() error {
-	return nil
-}
-
-// DefaultKubeUsers returns default kubernetes users for a new admin role
-func (p *defaultModules) DefaultKubeUsers() []string {
-	return []string{teleport.TraitInternalKubeUsersVariable}
-}
-
-// DefaultKubeGroups returns default kubernetes groups for a new admin role
-func (p *defaultModules) DefaultKubeGroups() []string {
-	return []string{teleport.TraitInternalKubeGroupsVariable}
-}
-
-// DefaultAllowedLogins returns allowed logins for a new admin role
-func (p *defaultModules) DefaultAllowedLogins() []string {
-	return []string{teleport.TraitInternalLoginsVariable}
+// BuildType returns build type (OSS or Enterprise)
+func (p *defaultModules) BuildType() string {
+	return BuildOSS
 }
 
 // PrintVersion prints the Teleport version.
@@ -100,50 +92,17 @@ func (p *defaultModules) PrintVersion() {
 	fmt.Printf("Teleport v%s git:%s %s\n", teleport.Version, teleport.Gitref, runtime.Version())
 }
 
-// RolesFromLogins returns roles for external user based on the logins
-// extracted from the connector
-//
-// By default there is only one role, "admin", so logins are ignored and
-// instead used as allowed logins (see TraitsFromLogins below).
-func (p *defaultModules) RolesFromLogins(logins []string) []string {
-	return []string{teleport.AdminRoleName}
-}
-
-// TraitsFromLogins returns traits for external user based on the logins
-// extracted from the connector
-//
-// By default logins are treated as allowed logins user traits.
-func (p *defaultModules) TraitsFromLogins(_ string, logins, kubeGroups, kubeUsers []string) map[string][]string {
-	return map[string][]string{
-		teleport.TraitLogins:     logins,
-		teleport.TraitKubeGroups: kubeGroups,
-		teleport.TraitKubeUsers:  kubeUsers,
+// Features returns supported features
+func (p *defaultModules) Features() Features {
+	return Features{
+		Kubernetes: true,
+		DB:         true,
+		App:        true,
 	}
-}
-
-// SupportsKubernetes returns true if this cluster supports kubernetes
-func (p *defaultModules) SupportsKubernetes() bool {
-	return true
 }
 
 // IsBoringBinary checks if the binary was compiled with BoringCrypto.
 func (p *defaultModules) IsBoringBinary() bool {
-	return false
-}
-
-// resetModules resets the modules interface to defaults
-func resetModules() {
-	mutex.Lock()
-	defer mutex.Unlock()
-	modules = &defaultModules{}
-}
-
-// DELETE IN: 5.1.0
-//
-// ExtendAdminUserRules returns true if the "AdminUserRules" set should be
-// extended with additional rules to allow user and token management. Only
-// needed until 5.1 when user and token management will be added to OSS.
-func (p *defaultModules) ExtendAdminUserRules() bool {
 	return false
 }
 

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,110 +19,10 @@ package modules
 import (
 	"testing"
 
-	"github.com/gravitational/teleport"
-
-	"github.com/gravitational/trace"
-	check "gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
-func TestModules(t *testing.T) { check.TestingT(t) }
-
-type ModulesSuite struct{}
-
-var _ = check.Suite(&ModulesSuite{})
-
-func (s *ModulesSuite) TearDownTest(c *check.C) {
-	resetModules()
-}
-
-func (s *ModulesSuite) TestDefaultModules(c *check.C) {
-	err := GetModules().EmptyRolesHandler()
-	c.Assert(err, check.IsNil)
-
-	logins := GetModules().DefaultAllowedLogins()
-	c.Assert(logins, check.DeepEquals, []string{teleport.TraitInternalLoginsVariable})
-
-	kubeGroups := GetModules().DefaultKubeGroups()
-	c.Assert(kubeGroups, check.DeepEquals, []string{teleport.TraitInternalKubeGroupsVariable})
-
-	kubeUsers := GetModules().DefaultKubeUsers()
-	c.Assert(kubeUsers, check.DeepEquals, []string{teleport.TraitInternalKubeUsersVariable})
-
-	roles := GetModules().RolesFromLogins([]string{"root"})
-	c.Assert(roles, check.DeepEquals, []string{teleport.AdminRoleName})
-
-	traits := GetModules().TraitsFromLogins("alice", []string{"root"}, []string{"system:masters"}, []string{"alice@example.com"})
-	c.Assert(traits, check.DeepEquals, map[string][]string{
-		teleport.TraitLogins:     {"root"},
-		teleport.TraitKubeGroups: {"system:masters"},
-		teleport.TraitKubeUsers:  {"alice@example.com"},
-	})
-
-	isBoring := GetModules().IsBoringBinary()
-	c.Assert(isBoring, check.Equals, false)
-
-	extendAdminRules := GetModules().ExtendAdminUserRules()
-	c.Assert(extendAdminRules, check.Equals, false)
-}
-
-func (s *ModulesSuite) TestTestModules(c *check.C) {
-	SetModules(&testModules{})
-
-	err := GetModules().EmptyRolesHandler()
-	c.Assert(trace.IsNotFound(err), check.Equals, true)
-
-	logins := GetModules().DefaultAllowedLogins()
-	c.Assert(logins, check.DeepEquals, []string{"a", "b"})
-
-	roles := GetModules().RolesFromLogins([]string{"root"})
-	c.Assert(roles, check.DeepEquals, []string{"root"})
-
-	traits := GetModules().TraitsFromLogins("alice", []string{"root"}, []string{"system:masters"}, []string{"alice@example.com"})
-	c.Assert(traits, check.IsNil)
-
-	isBoring := GetModules().IsBoringBinary()
-	c.Assert(isBoring, check.Equals, true)
-
-	extendAdminRules := GetModules().ExtendAdminUserRules()
-	c.Assert(extendAdminRules, check.Equals, true)
-}
-
-type testModules struct{}
-
-func (p *testModules) EmptyRolesHandler() error {
-	return trace.NotFound("no roles specified")
-}
-
-func (p *testModules) DefaultAllowedLogins() []string {
-	return []string{"a", "b"}
-}
-
-func (p *testModules) DefaultKubeUsers() []string {
-	return []string{"c", "d"}
-}
-
-func (p *testModules) DefaultKubeGroups() []string {
-	return []string{"kube:test"}
-}
-
-func (p *testModules) SupportsKubernetes() bool {
-	return true
-}
-
-func (p *testModules) PrintVersion() {}
-
-func (p *testModules) RolesFromLogins(logins []string) []string {
-	return logins
-}
-
-func (p *testModules) TraitsFromLogins(user string, logins, kubeGroups, kubeUsers []string) map[string][]string {
-	return nil
-}
-
-func (p *testModules) IsBoringBinary() bool {
-	return true
-}
-
-func (p *testModules) ExtendAdminUserRules() bool {
-	return true
+func TestOSSModules(t *testing.T) {
+	require.False(t, GetModules().IsBoringBinary())
+	require.Equal(t, BuildOSS, GetModules().BuildType())
 }

--- a/lib/services/github.go
+++ b/lib/services/github.go
@@ -73,6 +73,12 @@ var TeamMappingSchema = `{
         "items": {
           "type": "string"
         }
+      },
+      "kubernetes_users": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     }
   }`

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/parse"
@@ -42,21 +41,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/vulcand/predicate"
 )
-
-// AdminUserRules provides access to the default set of rules assigned to
-// all users.
-//
-// DELETE IN: 5.1.0.
-//
-// Once RBAC is open sourced, remove this and rename "ExtendedAdminUserRules" to
-// "AdminUserRules".
-var AdminUserRules = []Rule{
-	NewRule(KindRole, RW()),
-	NewRule(KindAuthConnector, RW()),
-	NewRule(KindSession, RO()),
-	NewRule(KindTrustedCluster, RW()),
-	NewRule(KindEvent, RO()),
-}
 
 // ExtendedAdminUserRules provides access to the default set of rules assigned to
 // all users.
@@ -111,13 +95,7 @@ func RoleNameForCertAuthority(name string) string {
 // NewAdminRole is the default admin role for all local users if another role
 // is not explicitly assigned (this role applies to all users in OSS version).
 func NewAdminRole() Role {
-	// DELETE IN: 5.1.0
-	//
-	// Only needed until 5.1 when user and token management will be added to OSS.
-	adminRules := CopyRulesSlice(AdminUserRules)
-	if modules.GetModules().ExtendAdminUserRules() {
-		adminRules = CopyRulesSlice(ExtendedAdminUserRules)
-	}
+	adminRules := CopyRulesSlice(ExtendedAdminUserRules)
 
 	role := &RoleV3{
 		Kind:    KindRole,
@@ -146,9 +124,9 @@ func NewAdminRole() Role {
 			},
 		},
 	}
-	role.SetLogins(Allow, modules.GetModules().DefaultAllowedLogins())
-	role.SetKubeUsers(Allow, modules.GetModules().DefaultKubeUsers())
-	role.SetKubeGroups(Allow, modules.GetModules().DefaultKubeGroups())
+	role.SetLogins(Allow, []string{teleport.TraitInternalLoginsVariable, teleport.Root})
+	role.SetKubeUsers(Allow, []string{teleport.TraitInternalKubeUsersVariable})
+	role.SetKubeGroups(Allow, []string{teleport.TraitInternalKubeGroupsVariable})
 	return role
 }
 
@@ -201,10 +179,92 @@ func RoleForUser(u User) Role {
 				AppLabels:        Labels{Wildcard: []string{Wildcard}},
 				KubernetesLabels: Labels{Wildcard: []string{Wildcard}},
 				DatabaseLabels:   Labels{Wildcard: []string{Wildcard}},
-				Rules:            CopyRulesSlice(AdminUserRules),
+				Rules: []Rule{
+					NewRule(KindRole, RW()),
+					NewRule(KindAuthConnector, RW()),
+					NewRule(KindSession, RO()),
+					NewRule(KindTrustedCluster, RW()),
+					NewRule(KindEvent, RO()),
+				},
 			},
 		},
 	}
+}
+
+// NewOSSUserRole is a role for enabling RBAC for open source users.
+// This is a limited role
+func NewOSSUserRole(name ...string) Role {
+	role := &RoleV3{
+		Kind:    KindRole,
+		Version: V3,
+		Metadata: Metadata{
+			Name:      teleport.OSSUserRoleName,
+			Namespace: defaults.Namespace,
+		},
+		Spec: RoleSpecV3{
+			Options: RoleOptions{
+				CertificateFormat: teleport.CertificateFormatStandard,
+				MaxSessionTTL:     NewDuration(defaults.MaxCertDuration),
+				PortForwarding:    NewBoolOption(true),
+				ForwardAgent:      NewBool(true),
+				BPF:               defaults.EnhancedEvents(),
+			},
+			Allow: RoleConditions{
+				Namespaces:       []string{defaults.Namespace},
+				NodeLabels:       Labels{Wildcard: []string{Wildcard}},
+				AppLabels:        Labels{Wildcard: []string{Wildcard}},
+				KubernetesLabels: Labels{Wildcard: []string{Wildcard}},
+				DatabaseLabels:   Labels{Wildcard: []string{Wildcard}},
+				DatabaseNames:    []string{teleport.TraitInternalDBNamesVariable},
+				DatabaseUsers:    []string{teleport.TraitInternalDBUsersVariable},
+				Rules: []Rule{
+					NewRule(KindEvent, RO()),
+					NewRule(KindSession, RO()),
+				},
+			},
+		},
+	}
+	role.SetLogins(Allow, []string{teleport.TraitInternalLoginsVariable})
+	role.SetKubeUsers(Allow, []string{teleport.TraitInternalKubeUsersVariable})
+	role.SetKubeGroups(Allow, []string{teleport.TraitInternalKubeGroupsVariable})
+	return role
+}
+
+// NewOSSGithubRole creates a role for enabling RBAC for open source Github users
+func NewOSSGithubRole(logins []string, kubeUsers []string, kubeGroups []string) Role {
+	role := &RoleV3{
+		Kind:    KindRole,
+		Version: V3,
+		Metadata: Metadata{
+			Name:      "github-" + uuid.New(),
+			Namespace: defaults.Namespace,
+		},
+		Spec: RoleSpecV3{
+			Options: RoleOptions{
+				CertificateFormat: teleport.CertificateFormatStandard,
+				MaxSessionTTL:     NewDuration(defaults.MaxCertDuration),
+				PortForwarding:    NewBoolOption(true),
+				ForwardAgent:      NewBool(true),
+				BPF:               defaults.EnhancedEvents(),
+			},
+			Allow: RoleConditions{
+				Namespaces:       []string{defaults.Namespace},
+				NodeLabels:       Labels{Wildcard: []string{Wildcard}},
+				AppLabels:        Labels{Wildcard: []string{Wildcard}},
+				KubernetesLabels: Labels{Wildcard: []string{Wildcard}},
+				DatabaseLabels:   Labels{Wildcard: []string{Wildcard}},
+				DatabaseNames:    []string{teleport.TraitInternalDBNamesVariable},
+				DatabaseUsers:    []string{teleport.TraitInternalDBUsersVariable},
+				Rules: []Rule{
+					NewRule(KindEvent, RO()),
+				},
+			},
+		},
+	}
+	role.SetLogins(Allow, logins)
+	role.SetKubeUsers(Allow, kubeUsers)
+	role.SetKubeGroups(Allow, kubeGroups)
+	return role
 }
 
 // RoleForCertAuthority creates role using services.CertAuthority.

--- a/tool/tctl/common/usage.go
+++ b/tool/tctl/common/usage.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015-2017 Gravitational, Inc.
+Copyright 2015-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,26 +18,23 @@ package common
 
 const (
 	GlobalHelpString = "CLI Admin tool for the Teleport Auth service. Runs on a host where Teleport Auth is running."
-	AddUserHelp      = `Notes:
+
+	AddUserHelp = `Notes:
 
   1. tctl will generate a signup token and give you a URL to share with a user.
      A user will have to complete account creation by visiting the URL.
 
-  2. A Teleport user account is not the same as a local UNIX users on SSH nodes.
-     You must assign a list of allowed local users for every Teleport login.
+  2. The allowed logins of the account only apply if a role uses them by including
+     '{{ internal.logins }}' variable in a role definition.
 
 Examples:
 
-  > tctl users add joe admin,nginx
+  > tctl users add --roles=admin,dba joe
 
-  This creates a Teleport account 'joe' who can login as 'admin' or 'nginx' 
-  to any SSH node connected to this auth server.
-
-  > tctl users add joe
-
-  If the list of local users is not given, 'joe' will only be able to connect
-  as 'joe' to SSH nodes.
+  This creates a Teleport account 'joe' who will assume the roles 'admin' and 'dba'
+  To see the permissions of 'admin' role, execute 'tctl get role/admin'
 `
+
 	AddNodeHelp = `Notes:
   This command generates and prints an invitation token another node can use to 
   join the cluster. 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1816,13 +1816,6 @@ func printProfiles(debug bool, profile *client.ProfileStatus, profiles []*client
 	for _, p := range profiles {
 		printStatus(debug, p, false)
 	}
-
-	// If we are printing profile, add a note that even though roles are listed
-	// here, they are only available in Enterprise.
-	if profile != nil || len(profiles) > 0 {
-		fmt.Printf("\n* RBAC is only available in Teleport Enterprise\n")
-		fmt.Printf("  https://goteleport.com/teleport/docs/enterprise\n")
-	}
 }
 
 // host is a utility function that extracts

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -56,8 +57,38 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+type cliModules struct{}
+
+// BuildType returns build type (OSS or Enterprise)
+func (p *cliModules) BuildType() string {
+	return "CLI"
+}
+
+// PrintVersion prints the Teleport version.
+func (p *cliModules) PrintVersion() {
+	fmt.Printf("Teleport CLI\n")
+}
+
+// Features returns supported features
+func (p *cliModules) Features() modules.Features {
+	return modules.Features{
+		Kubernetes:              true,
+		DB:                      true,
+		App:                     true,
+		AdvancedAccessWorkflows: true,
+		AccessControls:          true,
+	}
+}
+
+// IsBoringBinary checks if the binary was compiled with BoringCrypto.
+func (p *cliModules) IsBoringBinary() bool {
+	return false
+}
+
 func TestOIDCLogin(t *testing.T) {
 	os.RemoveAll(client.FullProfilePath(""))
+
+	modules.SetModules(&cliModules{})
 
 	defer os.RemoveAll(client.FullProfilePath(""))
 


### PR DESCRIPTION
Implements [RFD 7](https://github.com/gravitational/teleport/blob/master/rfd/0007-rbac-oss.md)

OSS users can use roles. Some FedRamp related role options
are limited to enterprise.

All users are migrated to a new role "ossuser".

This role is a limited access role downgrading all users
from OSS role "admin".

All trusted clusters are mapped to "ossuser" as well.

Github connector maps teams to generated roles.

For transition period, format `tctl users add alice` works
alongside with `tctl users add alice --roles=admin`, but prints

Enterprise PR:

https://github.com/gravitational/teleport.e/pull/211