### PR TITLE
Refactor db access audit logger for better reuse

### DIFF
--- a/lib/srv/db/common/audit.go
+++ b/lib/srv/db/common/audit.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/defaults"
+	libevents "github.com/gravitational/teleport/lib/events"
+
+	"github.com/gravitational/trace"
+)
+
+// AuditConfig is the audit events emitter configuration.
+type AuditConfig struct {
+	// StreamWriter is used to emit audit events.
+	StreamWriter libevents.StreamWriter
+}
+
+// Check validates the config.
+func (c *AuditConfig) Check() error {
+	if c.StreamWriter == nil {
+		return trace.BadParameter("missing StreamWriter")
+	}
+	return nil
+}
+
+// Audit provides methods for emitting database access audit events.
+type Audit struct {
+	// cfg is the audit events emitter configuration.
+	cfg AuditConfig
+}
+
+// NewAudit returns a new instance of the audit events emitter.
+func NewAudit(config AuditConfig) (*Audit, error) {
+	if err := config.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &Audit{
+		cfg: config,
+	}, nil
+}
+
+// OnSessionStart emits an audit event when database session starts.
+func (a *Audit) OnSessionStart(ctx context.Context, session Session, err error) error {
+	event := &events.DatabaseSessionStart{
+		Metadata: events.Metadata{
+			Type: libevents.DatabaseSessionStartEvent,
+			Code: libevents.DatabaseSessionStartCode,
+		},
+		ServerMetadata: events.ServerMetadata{
+			ServerID:        session.Server.GetHostID(),
+			ServerNamespace: defaults.Namespace,
+		},
+		UserMetadata: events.UserMetadata{
+			User: session.Identity.Username,
+		},
+		SessionMetadata: events.SessionMetadata{
+			SessionID: session.ID,
+		},
+		Status: events.Status{
+			Success: true,
+		},
+		DatabaseMetadata: events.DatabaseMetadata{
+			DatabaseService:  session.Server.GetName(),
+			DatabaseProtocol: session.Server.GetProtocol(),
+			DatabaseURI:      session.Server.GetURI(),
+			DatabaseName:     session.DatabaseName,
+			DatabaseUser:     session.DatabaseUser,
+		},
+	}
+	if err != nil {
+		event.Metadata.Code = libevents.DatabaseSessionStartFailureCode
+		event.Status = events.Status{
+			Success:     false,
+			Error:       trace.Unwrap(err).Error(),
+			UserMessage: err.Error(),
+		}
+	}
+	return a.cfg.StreamWriter.EmitAuditEvent(ctx, event)
+}
+
+// OnSessionEnd emits an audit event when database session ends.
+func (a *Audit) OnSessionEnd(ctx context.Context, session Session) error {
+	return a.cfg.StreamWriter.EmitAuditEvent(ctx, &events.DatabaseSessionEnd{
+		Metadata: events.Metadata{
+			Type: libevents.DatabaseSessionEndEvent,
+			Code: libevents.DatabaseSessionEndCode,
+		},
+		UserMetadata: events.UserMetadata{
+			User: session.Identity.Username,
+		},
+		SessionMetadata: events.SessionMetadata{
+			SessionID: session.ID,
+		},
+		DatabaseMetadata: events.DatabaseMetadata{
+			DatabaseService:  session.Server.GetName(),
+			DatabaseProtocol: session.Server.GetProtocol(),
+			DatabaseURI:      session.Server.GetURI(),
+			DatabaseName:     session.DatabaseName,
+			DatabaseUser:     session.DatabaseUser,
+		},
+	})
+}
+
+// OnQuery emits an audit event when a database query is executed.
+func (a *Audit) OnQuery(ctx context.Context, session Session, query string) error {
+	return a.cfg.StreamWriter.EmitAuditEvent(ctx, &events.DatabaseSessionQuery{
+		Metadata: events.Metadata{
+			Type: libevents.DatabaseSessionQueryEvent,
+			Code: libevents.DatabaseSessionQueryCode,
+		},
+		UserMetadata: events.UserMetadata{
+			User: session.Identity.Username,
+		},
+		SessionMetadata: events.SessionMetadata{
+			SessionID: session.ID,
+		},
+		DatabaseMetadata: events.DatabaseMetadata{
+			DatabaseService:  session.Server.GetName(),
+			DatabaseProtocol: session.Server.GetProtocol(),
+			DatabaseURI:      session.Server.GetURI(),
+			DatabaseName:     session.DatabaseName,
+			DatabaseUser:     session.DatabaseUser,
+		},
+		DatabaseQuery: query,
+	})
+}

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -30,6 +30,8 @@ import (
 type Session struct {
 	// ID is the unique session ID.
 	ID string
+	// ClusterName is the cluster the database service is a part of.
+	ClusterName string
 	// Server is the database server handling the connection.
 	Server types.DatabaseServer
 	// Identity is the identity of the connecting Teleport user.

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -415,6 +415,7 @@ func (s *Server) authorize(ctx context.Context) (*common.Session, error) {
 	id := uuid.New()
 	return &common.Session{
 		ID:                id,
+		ClusterName:       identity.RouteToCluster,
 		Server:            server,
 		Identity:          identity,
 		DatabaseUser:      identity.RouteToDatabase.Username,

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -368,15 +368,20 @@ func (s *Server) dispatch(sessionCtx *common.Session, streamWriter events.Stream
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	audit, err := common.NewAudit(common.AuditConfig{
+		StreamWriter: streamWriter,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	switch sessionCtx.Server.GetProtocol() {
 	case defaults.ProtocolPostgres:
 		return &postgres.Engine{
-			Auth:           auth,
-			OnSessionStart: s.emitSessionStartEventFn(streamWriter),
-			OnSessionEnd:   s.emitSessionEndEventFn(streamWriter),
-			OnQuery:        s.emitQueryEventFn(streamWriter),
-			Clock:          s.cfg.Clock,
-			Log:            sessionCtx.Log,
+			Auth:    auth,
+			Audit:   audit,
+			Context: s.closeContext,
+			Clock:   s.cfg.Clock,
+			Log:     sessionCtx.Log,
 		}, nil
 	}
 	return nil, trace.BadParameter("unsupported database protocol %q",


### PR DESCRIPTION
Another small refactoring PR which will allow for better reuse of the audit events emitting logic for MySQL integration.