### PR TITLE
Allows specifying different public addresses for ssh, tunnel and k8s

### DIFF
--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -1,6 +1,6 @@
 name: teleport
 apiVersion: v2
-version: 0.0.8
+version: 0.0.9
 appVersion: "5"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -98,7 +98,7 @@ data:
       kubernetes:
         enabled: {{ .Values.config.teleport.proxy_service.kubernetes.enabled }}
 {{- if .Values.config.teleport.proxy_service.kubernetes.public_addr }}
-        public_addr: {{ .Values.config.teleport.proxy_service.kubernetes.public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.kubernetes.public_addr )}}:{{.Values.service.ports.proxykube.port }}{{ end }}
+        public_addr: {{ .Values.config.teleport.proxy_service.kubernetes.public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.kubernetes.public_addr) }}:{{ .Values.service.ports.proxykube.port }}{{ end }}
 {{- else }}
         public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}
 {{- end }}

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -77,7 +77,7 @@ data:
       web_listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyweb.containerPort }}
       listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyssh.containerPort }}
       tunnel_listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxytunnel.containerPort }}
-{{- if  .Values.config.teleport.proxy_service.ssh_public_addr }}
+{{- if .Values.config.teleport.proxy_service.ssh_public_addr }}
       ssh_public_addr: {{ .Values.config.teleport.proxy_service.ssh_public_addr }}:{{ .Values.service.ports.proxyssh.port }}
 {{- else }}
       ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyssh.port }}

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -82,7 +82,7 @@ data:
 {{- else }}
       ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyssh.port }}
 {{- end }}
-{{- if  .Values.config.teleport.proxy_service.ssh_public_addr }}
+{{- if .Values.config.teleport.proxy_service.ssh_public_addr }}
       tunnel_public_addr: {{ .Values.config.teleport.proxy_service.tunnel_public_addr }}:{{ .Values.service.ports.proxytunnel.port }}
 {{- else }}
       tunnel_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxytunnel.port }}

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -78,7 +78,7 @@ data:
       listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyssh.containerPort }}
       tunnel_listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxytunnel.containerPort }}
 {{- if .Values.config.teleport.proxy_service.ssh_public_addr }}
-      ssh_public_addr: {{ .Values.config.teleport.proxy_service.ssh_public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.ssh_public_addr )}}:{{.Values.service.ports.proxyssh.port }}{{ end }}
+      ssh_public_addr: {{ .Values.config.teleport.proxy_service.ssh_public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.ssh_public_addr) }}:{{ .Values.service.ports.proxyssh.port }}{{ end }}
 {{- else }}
       ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyssh.port }}
 {{- end }}

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -83,7 +83,7 @@ data:
       ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyssh.port }}
 {{- end }}
 {{- if .Values.config.teleport.proxy_service.tunnel_public_addr }}
-      tunnel_public_addr: {{ .Values.config.teleport.proxy_service.tunnel_public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.tunnel_public_addr )}}:{{.Values.service.ports.proxytunnel.port }}{{ end }}
+      tunnel_public_addr: {{ .Values.config.teleport.proxy_service.tunnel_public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.tunnel_public_addr) }}:{{ .Values.service.ports.proxytunnel.port }}{{ end }}
 {{- else }}
       tunnel_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxytunnel.port }}
 {{- end }}

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -78,16 +78,16 @@ data:
       listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyssh.containerPort }}
       tunnel_listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxytunnel.containerPort }}
 {{- if .Values.config.teleport.proxy_service.ssh_public_addr }}
-      ssh_public_addr: {{ .Values.config.teleport.proxy_service.ssh_public_addr }}:{{ .Values.service.ports.proxyssh.port }}
+      ssh_public_addr: {{ .Values.config.teleport.proxy_service.ssh_public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.ssh_public_addr )}}:{{.Values.service.ports.proxyssh.port }}{{ end }}
 {{- else }}
       ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyssh.port }}
 {{- end }}
-{{- if .Values.config.teleport.proxy_service.ssh_public_addr }}
-      tunnel_public_addr: {{ .Values.config.teleport.proxy_service.tunnel_public_addr }}:{{ .Values.service.ports.proxytunnel.port }}
+{{- if .Values.config.teleport.proxy_service.tunnel_public_addr }}
+      tunnel_public_addr: {{ .Values.config.teleport.proxy_service.tunnel_public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.tunnel_public_addr )}}:{{.Values.service.ports.proxytunnel.port }}{{ end }}
 {{- else }}
       tunnel_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxytunnel.port }}
 {{- end }}
-      
+
 {{- if .Values.proxy.tls.usetlssecret}}
       https_key_file: {{ .Values.config.teleport.proxy_service.https_key_file }}
       https_cert_file: {{ .Values.config.teleport.proxy_service.https_cert_file }}
@@ -97,11 +97,11 @@ data:
       # kubernetes proxy protocol support
       kubernetes:
         enabled: {{ .Values.config.teleport.proxy_service.kubernetes.enabled }}
-{{- if .Values.config.teleport.proxy_service.kubernetes.public_addr }}        
-        public_addr: {{ .Values.config.teleport.proxy_service.kubernetes.public_addr }}:{{ .Values.service.ports.proxykube.port }}
+{{- if .Values.config.teleport.proxy_service.kubernetes.public_addr }}
+        public_addr: {{ .Values.config.teleport.proxy_service.kubernetes.public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.kubernetes.public_addr )}}:{{.Values.service.ports.proxykube.port }}{{ end }}
 {{- else }}
-        public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}        
-{{- end }}        
+        public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}
+{{- end }}
         listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxykube.containerPort }}
 {{- end }}
 {{- if .Values.config.highAvailability }}

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -77,9 +77,17 @@ data:
       web_listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyweb.containerPort }}
       listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxyssh.containerPort }}
       tunnel_listen_addr:  {{ .Values.config.listen_addr }}:{{ .Values.ports.proxytunnel.containerPort }}
-
+{{- if  .Values.config.teleport.proxy_service.ssh_public_addr }}
+      ssh_public_addr: {{ .Values.config.teleport.proxy_service.ssh_public_addr }}:{{ .Values.service.ports.proxyssh.port }}
+{{- else }}
       ssh_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxyssh.port }}
+{{- end }}
+{{- if  .Values.config.teleport.proxy_service.ssh_public_addr }}
+      tunnel_public_addr: {{ .Values.config.teleport.proxy_service.tunnel_public_addr }}:{{ .Values.service.ports.proxytunnel.port }}
+{{- else }}
       tunnel_public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxytunnel.port }}
+{{- end }}
+      
 {{- if .Values.proxy.tls.usetlssecret}}
       https_key_file: {{ .Values.config.teleport.proxy_service.https_key_file }}
       https_cert_file: {{ .Values.config.teleport.proxy_service.https_cert_file }}
@@ -89,7 +97,11 @@ data:
       # kubernetes proxy protocol support
       kubernetes:
         enabled: {{ .Values.config.teleport.proxy_service.kubernetes.enabled }}
-        public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}
+{{- if  .Values.config.teleport.proxy_service.kubernetes.public_addr }}        
+        public_addr: {{ .Values.config.teleport.proxy_service.kubernetes.public_addr }}:{{ .Values.service.ports.proxykube.port }}
+{{- else }}
+        public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}        
+{{- end }}        
         listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxykube.containerPort }}
 {{- end }}
 {{- if .Values.config.highAvailability }}

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -97,7 +97,7 @@ data:
       # kubernetes proxy protocol support
       kubernetes:
         enabled: {{ .Values.config.teleport.proxy_service.kubernetes.enabled }}
-{{- if  .Values.config.teleport.proxy_service.kubernetes.public_addr }}        
+{{- if .Values.config.teleport.proxy_service.kubernetes.public_addr }}        
         public_addr: {{ .Values.config.teleport.proxy_service.kubernetes.public_addr }}:{{ .Values.service.ports.proxykube.port }}
 {{- else }}
         public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}        

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -151,8 +151,8 @@ config:
       https_key_file: /var/lib/certs/tls.key
       https_cert_file: /var/lib/certs/tls.crt
       #Specify different address for the ssh and tunnel public address if different then the config.public_address
-#     ssh_public_addr: teleportssh.example.com
-#     tunnel_public_addr: teleporttunnel.example.com
+    # ssh_public_addr: teleportssh.example.com
+    # tunnel_public_addr: teleporttunnel.example.com
 
       # kubernetes section configures kubernetes proxy protocol support
       kubernetes:

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -157,7 +157,7 @@ config:
       # kubernetes section configures kubernetes proxy protocol support
       kubernetes:
         enabled: yes
-        # Specify different address for the k8s public address if different then the config.public_address
+        # Specify a different hostname for the k8s public address (if different to config.public_address)
       # public_addr: teleportkubernetes.example.com
         
 

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -150,10 +150,16 @@ config:
       # Used if  proxy.tls.usetlssecret is set to true, otherwise the values are not included in teleport.yaml
       https_key_file: /var/lib/certs/tls.key
       https_cert_file: /var/lib/certs/tls.crt
+      #Specify different address for the ssh and tunnel public address if different then the config.public_address
+#     ssh_public_addr: teleportssh.example.com
+#     tunnel_public_addr: teleporttunnel.example.com
 
       # kubernetes section configures kubernetes proxy protocol support
       kubernetes:
         enabled: yes
+        #Specify different address for the k8s public address if different then the config.public_address
+#       public_addr: teleportkubernetes.example.com
+        
 
 # Alternatively you can provide your teleport configuration under teleportConfig with static text. No variable substitution.
 otherConfig:

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -151,8 +151,8 @@ config:
       https_key_file: /var/lib/certs/tls.key
       https_cert_file: /var/lib/certs/tls.crt
       # Specify a different hostname for the ssh and tunnel public address (if different to config.public_address)
-    # ssh_public_addr: teleportssh.example.com
-    # tunnel_public_addr: teleporttunnel.example.com
+      # ssh_public_addr: teleportssh.example.com
+      # tunnel_public_addr: teleporttunnel.example.com
 
       # kubernetes section configures kubernetes proxy protocol support
       kubernetes:

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -158,7 +158,7 @@ config:
       kubernetes:
         enabled: yes
         # Specify a different hostname for the k8s public address (if different to config.public_address)
-      # public_addr: teleportkubernetes.example.com
+        # public_addr: teleportkubernetes.example.com
         
 
 # Alternatively you can provide your teleport configuration under teleportConfig with static text. No variable substitution.

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -150,7 +150,7 @@ config:
       # Used if  proxy.tls.usetlssecret is set to true, otherwise the values are not included in teleport.yaml
       https_key_file: /var/lib/certs/tls.key
       https_cert_file: /var/lib/certs/tls.crt
-      # Specify different address for the ssh and tunnel public address if different then the config.public_address
+      # Specify a different hostname for the ssh and tunnel public address (if different to config.public_address)
     # ssh_public_addr: teleportssh.example.com
     # tunnel_public_addr: teleporttunnel.example.com
 

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -150,7 +150,7 @@ config:
       # Used if  proxy.tls.usetlssecret is set to true, otherwise the values are not included in teleport.yaml
       https_key_file: /var/lib/certs/tls.key
       https_cert_file: /var/lib/certs/tls.crt
-      #Specify different address for the ssh and tunnel public address if different then the config.public_address
+      # Specify different address for the ssh and tunnel public address if different then the config.public_address
     # ssh_public_addr: teleportssh.example.com
     # tunnel_public_addr: teleporttunnel.example.com
 

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -157,7 +157,7 @@ config:
       # kubernetes section configures kubernetes proxy protocol support
       kubernetes:
         enabled: yes
-        #Specify different address for the k8s public address if different then the config.public_address
+        # Specify different address for the k8s public address if different then the config.public_address
       # public_addr: teleportkubernetes.example.com
         
 

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -158,7 +158,7 @@ config:
       kubernetes:
         enabled: yes
         #Specify different address for the k8s public address if different then the config.public_address
-#       public_addr: teleportkubernetes.example.com
+      # public_addr: teleportkubernetes.example.com
         
 
 # Alternatively you can provide your teleport configuration under teleportConfig with static text. No variable substitution.
@@ -356,4 +356,3 @@ tolerations: []
 #   operator: "Equal"
 #   value: "teleport"
 #   effect: "NoSchedule"
-


### PR DESCRIPTION
In some cases the public addresses for ssh, tunnel and k8s will be different then the web address.  Added variables to allow that.