### PR TITLE
Refactor AccessRequest and ClusterName creation and validation logic.

### DIFF
--- a/api/types/clustername.go
+++ b/api/types/clustername.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
-
 	"github.com/gravitational/trace"
 )
 
@@ -41,21 +39,12 @@ type ClusterName interface {
 }
 
 // NewClusterName is a convenience wrapper to create a ClusterName resource.
-func NewClusterName(spec ClusterNameSpecV2) (ClusterName, error) {
-	cn := ClusterNameV2{
-		Kind:    KindClusterName,
-		Version: V2,
-		Metadata: Metadata{
-			Name:      MetaNameClusterName,
-			Namespace: defaults.Namespace,
+func NewClusterName(clusterName string) ClusterName {
+	return &ClusterNameV2{
+		Spec: ClusterNameSpecV2{
+			ClusterName: clusterName,
 		},
-		Spec: spec,
 	}
-	if err := cn.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &cn, nil
 }
 
 // GetVersion returns resource version
@@ -132,17 +121,15 @@ func (c *ClusterNameV2) GetClusterName() string {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults.
 func (c *ClusterNameV2) CheckAndSetDefaults() error {
-	// make sure we have defaults for all metadata fields
-	err := c.Metadata.CheckAndSetDefaults()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
+	c.Kind = KindClusterName
+	c.Version = V2
+	c.Metadata.Name = MetaNameClusterName
 	if c.Spec.ClusterName == "" {
 		return trace.BadParameter("cluster name is required")
 	}
 
-	return nil
+	err := c.Metadata.CheckAndSetDefaults()
+	return trace.Wrap(err)
 }
 
 // String represents a human readable version of the cluster name.

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -503,9 +503,7 @@ func (i *TeleInstance) GenerateConfig(trustedSecrets []*InstanceSecrets, tconf *
 	tconf.DataDir = dataDir
 	tconf.UploadEventsC = i.UploadEventsC
 	tconf.CachePolicy.Enabled = true
-	tconf.Auth.ClusterName, err = services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: i.Secrets.SiteName,
-	})
+	tconf.Auth.ClusterName, err = services.NewClusterName(i.Secrets.SiteName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -961,7 +961,7 @@ func (a *Server) getRolesAndExpiryFromAccessRequest(user, accessRequestID string
 		return nil, time.Time{}, trace.BadParameter("access request %q is awaiting approval", accessRequestID)
 	}
 
-	if err := services.ValidateAccessRequest(a, req); err != nil {
+	if err := services.ValidateAccessRequestForUser(a, req); err != nil {
 		return nil, time.Time{}, trace.Wrap(err)
 	}
 
@@ -1657,7 +1657,7 @@ func (a *Server) upsertRole(ctx context.Context, role services.Role) error {
 }
 
 func (a *Server) CreateAccessRequest(ctx context.Context, req services.AccessRequest) error {
-	err := services.ValidateAccessRequest(a, req,
+	err := services.ValidateAccessRequestForUser(a, req,
 		// if request is in state pending, role expansion must be applied
 		services.ExpandRoles(req.GetState().IsPending()),
 		// always apply system annotations before storing new requests

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -72,9 +72,7 @@ func (s *AuthSuite) SetUpTest(c *C) {
 	s.bk, err = lite.NewWithConfig(context.TODO(), lite.Config{Path: s.dataDir})
 	c.Assert(err, IsNil)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, IsNil)
 	authConfig := &InitConfig{
 		ClusterName:            clusterName,
@@ -762,9 +760,7 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 
 	// try and set cluster name, this should fail because you can only set the
 	// cluster name once
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "foo.localhost",
-	})
+	clusterName, err := services.NewClusterName("foo.localhost")
 	c.Assert(err, IsNil)
 	// use same backend but start a new auth server with different config.
 	authConfig := &InitConfig{

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1096,7 +1096,7 @@ func (a *ServerWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserC
 				}
 				return nil, trace.AccessDenied("access-request %q is awaiting approval", reqID)
 			}
-			if err := services.ValidateAccessRequest(a.authServer, accessReq); err != nil {
+			if err := services.ValidateAccessRequestForUser(a.authServer, accessReq); err != nil {
 				return nil, trace.Wrap(err)
 			}
 			aexp := accessReq.GetAccessExpiry()

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -58,9 +58,7 @@ func (s *GithubSuite) SetUpSuite(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, check.IsNil)
 
 	authConfig := &InitConfig{

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -151,9 +151,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	access := local.NewAccessService(srv.Backend)
 	identity := local.NewIdentityService(srv.Backend)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: cfg.ClusterName,
-	})
+	clusterName, err := services.NewClusterName(cfg.ClusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -179,9 +179,7 @@ func (s *AuthInitSuite) TestAuthPreference(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, IsNil)
 	staticTokens, err := services.NewStaticTokens(services.StaticTokensSpecV2{
 		StaticTokens: []services.ProvisionTokenV1{},
@@ -217,9 +215,7 @@ func (s *AuthInitSuite) TestClusterID(c *C) {
 	bk, err := lite.New(context.TODO(), backend.Params{"path": c.MkDir()})
 	c.Assert(err, IsNil)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, IsNil)
 
 	authPreference, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
@@ -271,9 +267,7 @@ func (s *AuthInitSuite) TestClusterName(c *C) {
 	bk, err := lite.New(context.TODO(), backend.Params{"path": c.MkDir()})
 	c.Assert(err, IsNil)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, IsNil)
 
 	authPreference, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
@@ -297,9 +291,7 @@ func (s *AuthInitSuite) TestClusterName(c *C) {
 
 	// Start the auth server with a different cluster name. The auth server
 	// should start, but with the original name.
-	clusterName, err = services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "dev.localhost",
-	})
+	clusterName, err = services.NewClusterName("dev.localhost")
 	c.Assert(err, IsNil)
 
 	authServer, err = Init(InitConfig{
@@ -325,9 +317,7 @@ func (s *AuthInitSuite) TestCASigningAlg(c *C) {
 	bk, err := lite.New(context.TODO(), backend.Params{"path": c.MkDir()})
 	c.Assert(err, IsNil)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, IsNil)
 
 	authPreference, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -40,9 +40,7 @@ func TestMiddlewareGetUser(t *testing.T) {
 	)
 	s := newTestServices(t)
 	// Set up local cluster name in the backend.
-	cn, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: localClusterName,
-	})
+	cn, err := services.NewClusterName(localClusterName)
 	require.NoError(t, err)
 	require.NoError(t, s.UpsertClusterName(cn))
 

--- a/lib/auth/oidc_test.go
+++ b/lib/auth/oidc_test.go
@@ -54,9 +54,7 @@ func (s *OIDCSuite) SetUpSuite(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, check.IsNil)
 
 	authConfig := &InitConfig{

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -62,9 +62,7 @@ func (s *PasswordSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// set cluster name
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, IsNil)
 	authConfig := &InitConfig{
 		ClusterName:            clusterName,

--- a/lib/auth/resetpasswordtoken_test.go
+++ b/lib/auth/resetpasswordtoken_test.go
@@ -53,9 +53,7 @@ func (s *ResetPasswordTokenTest) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// set cluster name
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, check.IsNil)
 	authConfig := &InitConfig{
 		ClusterName:            clusterName,

--- a/lib/auth/saml_test.go
+++ b/lib/auth/saml_test.go
@@ -54,9 +54,7 @@ func (s *SAMLSuite) SetUpSuite(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	c.Assert(err, check.IsNil)
 
 	authConfig := &InitConfig{

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -98,9 +98,7 @@ func newTestAuthServer(t *testing.T) *Server {
 	t.Cleanup(func() { bk.Close() })
 
 	// Create a cluster with minimal viable config.
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "me.localhost",
-	})
+	clusterName, err := services.NewClusterName("me.localhost")
 	require.NoError(t, err)
 	authConfig := &InitConfig{
 		ClusterName:            clusterName,

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -844,9 +844,7 @@ func (s *CacheSuite) TestClusterConfig(c *check.C) {
 	fixtures.DeepCompare(c, clusterConfig, out)
 
 	// update cluster name resource metadata
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "example.com",
-	})
+	clusterName, err := services.NewClusterName("example.com")
 	c.Assert(err, check.IsNil)
 	err = p.clusterConfigS.SetClusterName(clusterName)
 	c.Assert(err, check.IsNil)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -685,9 +685,7 @@ func (c ClusterName) Parse() (services.ClusterName, error) {
 	if string(c) == "" {
 		return nil, nil
 	}
-	return services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: string(c),
-	})
+	return services.NewClusterName(string(c))
 }
 
 type StaticTokens []StaticToken

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -607,9 +607,7 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 
 	// if user did not provide auth domain name, use this host's name
 	if cfg.Auth.Enabled && cfg.Auth.ClusterName == nil {
-		cfg.Auth.ClusterName, err = services.NewClusterName(services.ClusterNameSpecV2{
-			ClusterName: cfg.Hostname,
-		})
+		cfg.Auth.ClusterName, err = services.NewClusterName(cfg.Hostname)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -37,6 +37,9 @@ func TestAccessRequestMarshaling(t *testing.T) {
 	req2, err := UnmarshalAccessRequest(marshaled)
 	require.NoError(t, err)
 
+	err = ValidateAccessRequest(req2)
+	require.NoError(t, err)
+
 	require.True(t, req1.Equals(req2))
 }
 

--- a/lib/services/clustername.go
+++ b/lib/services/clustername.go
@@ -19,9 +19,19 @@ package services
 import (
 	"fmt"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 )
+
+// NewClusterName assembles a validated ClusterName resource
+func NewClusterName(clusterName string) (types.ClusterName, error) {
+	cn := types.NewClusterName(clusterName)
+	if err := cn.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return cn, nil
+}
 
 // ClusterNameSpecSchemaTemplate is a template for ClusterName schema.
 const ClusterNameSpecSchemaTemplate = `{

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -41,7 +41,7 @@ func NewDynamicAccessService(backend backend.Backend) *DynamicAccessService {
 
 // CreateAccessRequest stores a new access request.
 func (s *DynamicAccessService) CreateAccessRequest(ctx context.Context, req services.AccessRequest) error {
-	if err := req.CheckAndSetDefaults(); err != nil {
+	if err := services.ValidateAccessRequest(req); err != nil {
 		return trace.Wrap(err)
 	}
 	item, err := itemFromAccessRequest(req)
@@ -199,7 +199,7 @@ func (s *DynamicAccessService) DeleteAllAccessRequests(ctx context.Context) erro
 }
 
 func (s *DynamicAccessService) UpsertAccessRequest(ctx context.Context, req services.AccessRequest) error {
-	if err := req.CheckAndSetDefaults(); err != nil {
+	if err := services.ValidateAccessRequest(req); err != nil {
 		return trace.Wrap(err)
 	}
 	item, err := itemFromAccessRequest(req)
@@ -389,6 +389,9 @@ func itemToAccessRequest(item backend.Item, opts ...services.MarshalOption) (ser
 		item.Value,
 		opts...,
 	)
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1120,9 +1120,7 @@ func (s *ServicesTestSuite) ClusterConfig(c *check.C, opts ...Option) {
 	_, err = s.ConfigS.GetClusterConfig()
 	fixtures.ExpectNotFound(c, err)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "example.com",
-	})
+	clusterName, err := services.NewClusterName("example.com")
 	c.Assert(err, check.IsNil)
 
 	err = s.ConfigS.SetClusterName(clusterName)
@@ -1687,9 +1685,7 @@ func (s *ServicesTestSuite) EventsClusterConfig(c *check.C) {
 				Kind: services.KindClusterName,
 			},
 			crud: func() services.Resource {
-				clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-					ClusterName: "example.com",
-				})
+				clusterName, err := services.NewClusterName("example.com")
 				c.Assert(err, check.IsNil)
 
 				err = s.ConfigS.SetClusterName(clusterName)

--- a/lib/services/types.go
+++ b/lib/services/types.go
@@ -124,8 +124,6 @@ type (
 )
 
 var (
-	NewAccessRequest = types.NewAccessRequest
-
 	RequestStrategyOptional = types.RequestStrategyOptional
 	RequestStrategyReason   = types.RequestStrategyReason
 	RequestStrategyAlways   = types.RequestStrategyAlways
@@ -186,10 +184,6 @@ var (
 
 // clustername.go
 type ClusterName = types.ClusterName
-
-var (
-	NewClusterName = types.NewClusterName
-)
 
 // duration.go
 type Duration = types.Duration

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -85,12 +85,9 @@ func (s *ExecSuite) SetUpSuite(c *check.C) {
 	bk, err := lite.NewWithConfig(context.TODO(), lite.Config{Path: c.MkDir()})
 	c.Assert(err, check.IsNil)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "localhost",
-	})
+	clusterName, err := services.NewClusterName("localhost")
 	c.Assert(err, check.IsNil)
 
-	c.Assert(err, check.IsNil)
 	s.a, err = auth.NewServer(&auth.InitConfig{
 		Backend:     bk,
 		Authority:   authority.New(),

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -213,8 +213,7 @@ func (c *AccessRequestCommand) Create(client auth.ClientI) error {
 	req.SetRequestReason(c.reason)
 
 	if c.dryRun {
-		err = services.ValidateAccessRequest(client, req, services.ExpandRoles(true), services.ApplySystemAnnotations(true))
-		if err != nil {
+		if err := services.ValidateAccessRequestForUser(client, req, services.ExpandRoles(true), services.ApplySystemAnnotations(true)); err != nil {
 			return trace.Wrap(err)
 		}
 		return trace.Wrap(c.PrintAccessRequests(client, []services.AccessRequest{req}, "json"))

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -29,12 +29,8 @@ func TestAuthSignKubeconfig(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "example.com",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	clusterName, err := services.NewClusterName("example.com")
+	require.NoError(t, err)
 
 	remoteCluster, err := services.NewRemoteCluster("leaf.example.com")
 	if err != nil {
@@ -228,9 +224,7 @@ func (c mockClient) GenerateDatabaseCert(context.Context, *proto.DatabaseCertReq
 
 func TestCheckKubeCluster(t *testing.T) {
 	const teleportCluster = "local-teleport"
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: teleportCluster,
-	})
+	clusterName, err := services.NewClusterName(teleportCluster)
 	require.NoError(t, err)
 	client := mockClient{
 		clusterName: clusterName,

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -966,7 +966,7 @@ func executeAccessRequest(cf *CLIConf) error {
 	}
 	req, err := services.NewAccessRequest(cf.Username, roles...)
 	if err != nil {
-		return trace.Wrap(err)
+		trace.Wrap(err)
 	}
 	req.SetRequestReason(cf.RequestReason)
 	fmt.Fprintf(os.Stderr, "Seeking request approval... (id: %s)\n", req.GetName())


### PR DESCRIPTION
Right now the validation strategy of resources by the Teleport client and server is unclear and hard to use.

### Validation Layers

The layers of validation are not clear. Most resource have a single `CheckAndSetDefaults` method, which completes all validation. However, we should not expect a client request to have a fully valid type, since the server may need to, or at least should, edit the resource post request.

**Layers of validation necessary**
 - Request Layer - Should only require user provided values, For example, `AccessRequest` should just need `user` and `roles`. Metadata, uuid, and state can all be set by different service functions.
   - We should use `New[Type]` functions to make it easy for a user to know exactly what values they need to provide, and also make it clear what values are optionally provided.
 - Backend Layer - Metadata, and other required values should all be set. This needs to happen before inserting resources, and redundancy should be kept to a minimum.

### Where to validate

Where we are validation:
 - `types.New[Type]` functions
 - unmarshalers -  which are used in:
   - converting items from the backend
   - unmarshaling json from http requests
 - sometimes before database insertion
 - various other places (redundancy issues)

The pattern of validation is unclear and inconsistent, and every single spot above is doing backend layer validation, which causes redundancy and a lack of validation layer separation.

Where we should validate:
 - upon receiving/sending a request - This could happen on the client side or server side, but consistently right after send/receive.
 - before inserting resources to the backend

### Setting defaults

Setting defaults has been intertwined with Validation. This makes sense in the sense that they often occur at the same time, but this is not always the case. Basic defaults can be set at any time we choose (request/backend layer), but some business logic defaults should only be set after the request layer. 

For example, access request state and uuid should be set somewhere in the backend layer, possibly right before insertion.





