### PR TITLE
Remove 'var _ = fmt.Printf' from *_test.go files

### DIFF
--- a/lib/asciitable/table_test.go
+++ b/lib/asciitable/table_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package asciitable
 
 import (
-	"fmt"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -28,7 +27,6 @@ func TestAsciiTable(t *testing.T) { check.TestingT(t) }
 type TableTestSuite struct {
 }
 
-var _ = fmt.Printf
 var _ = check.Suite(&TableTestSuite{})
 
 const fullTable = `Name          Motto                            Age  

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509/pkix"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -60,7 +59,6 @@ type AuthSuite struct {
 }
 
 var _ = Suite(&AuthSuite{})
-var _ = fmt.Printf
 
 func (s *AuthSuite) SetUpSuite(c *C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -18,7 +18,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"testing"
 	"time"
@@ -42,7 +41,6 @@ type GithubSuite struct {
 	c           clockwork.FakeClock
 }
 
-var _ = fmt.Printf
 var _ = check.Suite(&GithubSuite{})
 
 func (s *GithubSuite) SetUpSuite(c *check.C) {

--- a/lib/auth/native/native_test.go
+++ b/lib/auth/native/native_test.go
@@ -18,7 +18,6 @@ package native
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -41,7 +40,6 @@ type NativeSuite struct {
 }
 
 var _ = check.Suite(&NativeSuite{})
-var _ = fmt.Printf
 
 func (s *NativeSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/auth/oidc_test.go
+++ b/lib/auth/oidc_test.go
@@ -18,7 +18,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -38,7 +37,6 @@ type OIDCSuite struct {
 	c clockwork.FakeClock
 }
 
-var _ = fmt.Printf
 var _ = check.Suite(&OIDCSuite{})
 
 func (s *OIDCSuite) SetUpSuite(c *check.C) {

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -19,7 +19,6 @@ package auth
 import (
 	"context"
 	"encoding/base32"
-	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -48,7 +47,6 @@ type PasswordSuite struct {
 	mockEmitter *events.MockEmitter
 }
 
-var _ = fmt.Printf
 var _ = Suite(&PasswordSuite{})
 
 func (s *PasswordSuite) SetUpSuite(c *C) {

--- a/lib/auth/saml_test.go
+++ b/lib/auth/saml_test.go
@@ -18,7 +18,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -38,7 +37,6 @@ type SAMLSuite struct {
 	c clockwork.FakeClock
 }
 
-var _ = fmt.Printf
 var _ = check.Suite(&SAMLSuite{})
 
 func (s *SAMLSuite) SetUpSuite(c *check.C) {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -61,8 +61,6 @@ type TLSSuite struct {
 }
 
 var _ = check.Suite(&TLSSuite{})
-var _ = testing.Verbose
-var _ = fmt.Printf
 
 func (s *TLSSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/backend/lite/litemem_test.go
+++ b/lib/backend/lite/litemem_test.go
@@ -18,7 +18,6 @@ package lite
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -35,8 +34,6 @@ type LiteMemSuite struct {
 }
 
 var _ = check.Suite(&LiteMemSuite{})
-var _ = testing.Verbose
-var _ = fmt.Printf
 
 func (s *LiteMemSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/jonboulle/clockwork"
@@ -13,7 +12,6 @@ type Suite struct {
 }
 
 var _ = check.Suite(&Suite{})
-var _ = fmt.Printf
 
 func (s *Suite) SetUpSuite(c *check.C) {
 }

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -41,7 +41,6 @@ import (
 
 type Suite struct{}
 
-var _ = fmt.Printf
 var _ = check.Suite(&Suite{})
 
 func TestBPF(t *testing.T) { check.TestingT(t) }

--- a/lib/bpf/common_test.go
+++ b/lib/bpf/common_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package bpf
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/gravitational/teleport/lib/defaults"
@@ -28,7 +27,6 @@ import (
 
 type CommonSuite struct{}
 
-var _ = fmt.Printf
 var _ = check.Suite(&CommonSuite{})
 
 func (s *CommonSuite) SetUpSuite(c *check.C) {

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package cgroup
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -33,7 +32,6 @@ import (
 
 type Suite struct{}
 
-var _ = fmt.Printf
 var _ = check.Suite(&Suite{})
 
 func TestControlGroups(t *testing.T) { check.TestingT(t) }

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -54,7 +54,6 @@ type KeyAgentTestSuite struct {
 }
 
 var _ = check.Suite(&KeyAgentTestSuite{})
-var _ = fmt.Printf
 
 func (s *KeyAgentTestSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"encoding/base64"
-	"fmt"
 
 	"gopkg.in/check.v1"
 )
@@ -27,7 +26,6 @@ type FileTestSuite struct {
 }
 
 var _ = check.Suite(&FileTestSuite{})
-var _ = fmt.Printf
 
 func (s *FileTestSuite) SetUpSuite(c *check.C) {
 }

--- a/lib/secret/secret_test.go
+++ b/lib/secret/secret_test.go
@@ -18,7 +18,6 @@ package secret
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/gravitational/teleport/lib/utils"
@@ -31,7 +30,6 @@ func TestSecret(t *testing.T) { check.TestingT(t) }
 type SecretSuite struct{}
 
 var _ = check.Suite(&SecretSuite{})
-var _ = fmt.Printf
 
 func (s *SecretSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/services/license_test.go
+++ b/lib/services/license_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package services
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -31,8 +30,6 @@ type LicenseSuite struct {
 }
 
 var _ = check.Suite(&LicenseSuite{})
-var _ = testing.Verbose
-var _ = fmt.Printf
 
 func (l *LicenseSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -38,8 +37,6 @@ type ClusterConfigurationSuite struct {
 }
 
 var _ = check.Suite(&ClusterConfigurationSuite{})
-var _ = testing.Verbose
-var _ = fmt.Printf
 
 func (s *ClusterConfigurationSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -41,8 +40,6 @@ type PresenceSuite struct {
 }
 
 var _ = check.Suite(&PresenceSuite{})
-var _ = testing.Verbose
-var _ = fmt.Printf
 
 func (s *PresenceSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/base32"
 	"encoding/base64"
-	"fmt"
 	"testing"
 	"time"
 
@@ -46,7 +45,6 @@ type ResourceSuite struct {
 	bk backend.Backend
 }
 
-var _ = fmt.Printf
 var _ = check.Suite(&ResourceSuite{})
 
 func (r *ResourceSuite) SetUpSuite(c *check.C) {

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -37,7 +36,6 @@ type ServicesSuite struct {
 	suite *suite.ServicesTestSuite
 }
 
-var _ = fmt.Printf
 var _ = check.Suite(&ServicesSuite{})
 
 func (s *ServicesSuite) SetUpSuite(c *check.C) {

--- a/lib/services/map_test.go
+++ b/lib/services/map_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package services
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/gravitational/teleport"
@@ -30,7 +29,6 @@ import (
 type RoleMapSuite struct{}
 
 var _ = check.Suite(&RoleMapSuite{})
-var _ = fmt.Printf
 
 func (s *RoleMapSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/services/resetpasswordtoken_test.go
+++ b/lib/services/resetpasswordtoken_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package services
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -28,7 +27,6 @@ import (
 type ResetPasswordTokenSuite struct{}
 
 var _ = check.Suite(&ResetPasswordTokenSuite{})
-var _ = fmt.Printf
 
 func (r *ResetPasswordTokenSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/services/saml_test.go
+++ b/lib/services/saml_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package services
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -32,7 +31,6 @@ import (
 type SAMLSuite struct{}
 
 var _ = check.Suite(&SAMLSuite{})
-var _ = fmt.Printf
 
 func (s *SAMLSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/services/wrappers_test.go
+++ b/lib/services/wrappers_test.go
@@ -18,7 +18,6 @@ package services
 
 import (
 	"encoding/hex"
-	"fmt"
 	"testing"
 
 	"github.com/gravitational/teleport/api/types/wrappers"
@@ -28,7 +27,6 @@ import (
 
 type WrappersSuite struct{}
 
-var _ = fmt.Printf
 var _ = check.Suite(&WrappersSuite{})
 
 func TestWrappers(t *testing.T) { check.TestingT(t) }

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -62,7 +62,6 @@ type ExecSuite struct {
 }
 
 var _ = check.Suite(&ExecSuite{})
-var _ = fmt.Printf
 
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise it will run tests as normal.

--- a/lib/srv/keepalive_test.go
+++ b/lib/srv/keepalive_test.go
@@ -18,7 +18,6 @@ package srv
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -32,7 +31,6 @@ import (
 
 type KeepAliveSuite struct{}
 
-var _ = fmt.Printf
 var _ = check.Suite(&KeepAliveSuite{})
 
 func TestSrv(t *testing.T) { check.TestingT(t) }

--- a/lib/srv/term_test.go
+++ b/lib/srv/term_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package srv
 
 import (
-	"fmt"
 	"os"
 	"os/user"
 	"testing"
@@ -33,8 +32,6 @@ type TermSuite struct {
 }
 
 var _ = check.Suite(&TermSuite{})
-var _ = testing.Verbose
-var _ = fmt.Printf
 
 func (s *TermSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -37,7 +37,6 @@ type ServerSuite struct {
 	signer ssh.Signer
 }
 
-var _ = fmt.Printf
 var _ = check.Suite(&ServerSuite{})
 
 func (s *ServerSuite) SetUpSuite(c *check.C) {

--- a/lib/utils/certs_test.go
+++ b/lib/utils/certs_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"fmt"
 	"io/ioutil"
 
 	"github.com/gravitational/trace"
@@ -27,7 +26,6 @@ import (
 
 type CertsSuite struct{}
 
-var _ = fmt.Printf
 var _ = check.Suite(&CertsSuite{})
 
 func (s *CertsSuite) TestRejectsInvalidPEMData(c *check.C) {

--- a/lib/utils/checker_test.go
+++ b/lib/utils/checker_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"fmt"
 
 	"golang.org/x/crypto/ssh"
 
@@ -32,7 +31,6 @@ import (
 
 type CheckerSuite struct{}
 
-var _ = fmt.Printf
 var _ = check.Suite(&CheckerSuite{})
 
 // TestValidate checks what algorithm are supported in regular (non-FIPS) mode.

--- a/lib/utils/environment_test.go
+++ b/lib/utils/environment_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package utils
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -27,7 +26,6 @@ import (
 type EnvironmentSuite struct{}
 
 var _ = check.Suite(&EnvironmentSuite{})
-var _ = fmt.Printf
 
 func (s *EnvironmentSuite) SetUpSuite(c *check.C) {
 	InitLoggerForTests(testing.Verbose())

--- a/lib/utils/kernel_test.go
+++ b/lib/utils/kernel_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -27,7 +26,6 @@ import (
 
 type KernelSuite struct{}
 
-var _ = fmt.Printf
 var _ = check.Suite(&KernelSuite{})
 
 func (s *KernelSuite) SetUpSuite(c *check.C) {

--- a/lib/utils/linking_test.go
+++ b/lib/utils/linking_test.go
@@ -17,14 +17,11 @@ limitations under the License.
 package utils
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
 	"gopkg.in/check.v1"
 )
-
-var _ = fmt.Printf
 
 type WebLinksSuite struct {
 }

--- a/lib/utils/proxy/proxy_test.go
+++ b/lib/utils/proxy/proxy_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package proxy
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -31,7 +30,6 @@ func TestProxy(t *testing.T) { check.TestingT(t) }
 type ProxySuite struct{}
 
 var _ = check.Suite(&ProxySuite{})
-var _ = fmt.Printf
 
 func (s *ProxySuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/utils/socks/socks_test.go
+++ b/lib/utils/socks/socks_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package socks
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"testing"
@@ -36,7 +35,6 @@ func TestSocks(t *testing.T) { check.TestingT(t) }
 type SOCKSSuite struct{}
 
 var _ = check.Suite(&SOCKSSuite{})
-var _ = fmt.Printf
 
 func (s *SOCKSSuite) SetUpSuite(c *check.C) {
 	utils.InitLoggerForTests(testing.Verbose())

--- a/lib/utils/unpack_test.go
+++ b/lib/utils/unpack_test.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"archive/tar"
-	"fmt"
 	"testing"
 
 	"gopkg.in/check.v1"
@@ -26,7 +25,6 @@ import (
 
 type UnpackSuite struct{}
 
-var _ = fmt.Printf
 var _ = check.Suite(&UnpackSuite{})
 
 func (s *UnpackSuite) SetUpSuite(c *check.C) {


### PR DESCRIPTION
These declarations serve no purpose, likely leftover from old debugging.