### PR TITLE
[branch/5] use fake clock consistently in units tests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/iovisor/gobpf v0.0.1
 	github.com/johannesboyne/gofakes3 v0.0.0-20191228161223-9aee1c78a252
-	github.com/jonboulle/clockwork v0.2.1
+	github.com/jonboulle/clockwork v0.2.2
 	github.com/json-iterator/go v1.1.10
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/go.sum
+++ b/go.sum
@@ -359,8 +359,8 @@ github.com/johannesboyne/gofakes3 v0.0.0-20191228161223-9aee1c78a252/go.mod h1:c
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0 h1:J2SLSdy7HgElq8ekSl2Mxh6vrRNFxqbXGenYH2I02Vs=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
-github.com/jonboulle/clockwork v0.2.1 h1:S/EaQvW6FpWMYAvYvY+OBDvpaM+izu0oiwo5y0MH7U0=
-github.com/jonboulle/clockwork v0.2.1/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -48,12 +48,12 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/wrappers"
-	"github.com/pborman/uuid"
 
 	"github.com/coreos/go-oidc/oauth2"
 	"github.com/coreos/go-oidc/oidc"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/pborman/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	saml2 "github.com/russellhaering/gosaml2"
 	"github.com/tstranex/u2f"
@@ -1839,6 +1839,13 @@ func (a *Server) GetAppServers(ctx context.Context, namespace string, opts ...se
 // GetAppSession is a part of the auth.AccessPoint implementation.
 func (a *Server) GetAppSession(ctx context.Context, req services.GetAppSessionRequest) (services.WebSession, error) {
 	return a.GetCache().GetAppSession(ctx, req)
+}
+
+// WithClock is a functional server option that sets the server's clock
+func WithClock(clock clockwork.Clock) func(*Server) {
+	return func(s *Server) {
+		s.clock = clock
+	}
 }
 
 // authKeepAliver is a keep aliver using auth server directly

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -497,10 +497,15 @@ func startNewRotation(req rotationReq, ca services.CertAuthority) error {
 		sshPublicKey = ssh.MarshalAuthorizedKey(signer.PublicKey())
 		sshPrivateKey = req.privateKey
 
-		tlsPrivateKey, tlsPublicKey, err = tlsca.GenerateSelfSignedCAWithPrivateKey(rsaKey.(*rsa.PrivateKey), pkix.Name{
-			CommonName:   ca.GetClusterName(),
-			Organization: []string{ca.GetClusterName()},
-		}, nil, defaults.CATTL)
+		tlsPrivateKey, tlsPublicKey, err = tlsca.GenerateSelfSignedCAWithConfig(tlsca.GenerateCAConfig{
+			PrivateKey: rsaKey.(*rsa.PrivateKey),
+			Entity: pkix.Name{
+				CommonName:   ca.GetClusterName(),
+				Organization: []string{ca.GetClusterName()},
+			},
+			TTL:   defaults.CATTL,
+			Clock: req.clock,
+		})
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -107,7 +107,7 @@ func (s *Server) generateAppToken(username string, roles []string, uri string, e
 	}
 
 	// Extract the JWT signing key and sign the claims.
-	privateKey, err := ca.JWTSigner()
+	privateKey, err := ca.JWTSigner(s.clock)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -19,7 +19,6 @@ package testauthority
 import (
 	"crypto/rand"
 	random "math/rand"
-	"time"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -29,14 +28,22 @@ import (
 	"github.com/gravitational/teleport/lib/wrappers"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"golang.org/x/crypto/ssh"
 )
 
 type Keygen struct {
+	clock clockwork.Clock
 }
 
+// New creates a new key generator with defaults
 func New() *Keygen {
-	return &Keygen{}
+	return &Keygen{clock: clockwork.NewRealClock()}
+}
+
+// NewWithClock creates a new key generator with the specified configuration
+func NewWithClock(clock clockwork.Clock) *Keygen {
+	return &Keygen{clock: clock}
 }
 
 func (n *Keygen) Close() {
@@ -57,7 +64,7 @@ func (n *Keygen) GenerateHostCert(c services.HostCertParams) ([]byte, error) {
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if c.TTL != 0 {
-		b := time.Now().Add(c.TTL)
+		b := n.clock.Now().Add(c.TTL)
 		validBefore = uint64(b.Unix())
 	}
 	principals := native.BuildPrincipals(c.HostID, c.NodeName, c.ClusterName, c.Roles)
@@ -89,7 +96,7 @@ func (n *Keygen) GenerateUserCert(c services.UserCertParams) ([]byte, error) {
 	}
 	validBefore := uint64(ssh.CertTimeInfinity)
 	if c.TTL != 0 {
-		b := time.Now().Add(c.TTL)
+		b := n.clock.Now().Add(c.TTL)
 		validBefore = uint64(b.Unix())
 	}
 	cert := &ssh.Certificate{

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -228,10 +228,11 @@ func (c *Connector) Close() error {
 // TeleportProcess structure holds the state of the Teleport daemon, controlling
 // execution and configuration of the teleport services: ssh, auth and proxy.
 type TeleportProcess struct {
-	clockwork.Clock
+	Clock clockwork.Clock
 	sync.Mutex
 	Supervisor
 	Config *Config
+
 	// localAuth has local auth server listed in case if this process
 	// has started with auth server role enabled
 	localAuth *auth.Server
@@ -1315,7 +1316,7 @@ func (process *TeleportProcess) initAuthService() error {
 			} else {
 				srv.Spec.Rotation = state.Spec.Rotation
 			}
-			srv.SetTTL(process, defaults.ServerAnnounceTTL)
+			srv.SetTTL(process.Clock, defaults.ServerAnnounceTTL)
 			return &srv, nil
 		},
 		KeepAlivePeriod: defaults.ServerKeepAliveTTL,

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -88,7 +88,7 @@ func (f *processState) update(event Event) {
 	s, ok := f.states[component]
 	if !ok {
 		// Register a new component.
-		s = &componentState{recoveryTime: f.process.Now(), state: stateStarting}
+		s = &componentState{recoveryTime: f.process.Clock.Now(), state: stateStarting}
 		f.states[component] = s
 	}
 
@@ -109,10 +109,10 @@ func (f *processState) update(event Event) {
 			f.process.Debugf("Teleport component %q has started.", component)
 		case stateDegraded:
 			s.state = stateRecovering
-			s.recoveryTime = f.process.Now()
+			s.recoveryTime = f.process.Clock.Now()
 			f.process.Infof("Teleport component %q is recovering from a degraded state.", component)
 		case stateRecovering:
-			if f.process.Now().Sub(s.recoveryTime) > defaults.HeartbeatCheckPeriod*2 {
+			if f.process.Clock.Now().Sub(s.recoveryTime) > defaults.HeartbeatCheckPeriod*2 {
 				s.state = stateOK
 				f.process.Infof("Teleport component %q has recovered from a degraded state.", component)
 			}

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -128,6 +128,7 @@ type UserCertParams struct {
 	ActiveRequests RequestIDs
 }
 
+// Check checks the user certificate parameters
 func (c UserCertParams) Check() error {
 	if len(c.PrivateCASigningKey) == 0 || c.CASigningAlg == "" {
 		return trace.BadParameter("PrivateCASigningKey and CASigningAlg are required")
@@ -240,7 +241,7 @@ type CertAuthority interface {
 	// GetTLSKeyPairs returns first PEM encoded TLS cert
 	GetTLSKeyPairs() []TLSKeyPair
 	// JWTSigner returns the active JWT key used to sign tokens.
-	JWTSigner() (*jwt.Key, error)
+	JWTSigner(clock clockwork.Clock) (*jwt.Key, error)
 	// GetJWTKeyPairs gets all JWT key pairs.
 	GetJWTKeyPairs() []JWTKeyPair
 	// SetJWTKeyPairs sets all JWT key pairs.
@@ -450,7 +451,7 @@ func (ca *CertAuthorityV2) GetTLSKeyPairs() []TLSKeyPair {
 }
 
 // JWTSigner returns the active JWT key used to sign tokens.
-func (ca *CertAuthorityV2) JWTSigner() (*jwt.Key, error) {
+func (ca *CertAuthorityV2) JWTSigner(clock clockwork.Clock) (*jwt.Key, error) {
 	if len(ca.Spec.JWTKeyPairs) == 0 {
 		return nil, trace.BadParameter("no JWT keypairs found")
 	}
@@ -462,6 +463,7 @@ func (ca *CertAuthorityV2) JWTSigner() (*jwt.Key, error) {
 		Algorithm:   defaults.ApplicationTokenAlgorithm,
 		ClusterName: ca.Spec.ClusterName,
 		PrivateKey:  privateKey,
+		Clock:       clock,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -47,7 +47,7 @@ func (s *ServicesSuite) SetUpSuite(c *check.C) {
 func (s *ServicesSuite) SetUpTest(c *check.C) {
 	var err error
 
-	clock := clockwork.NewFakeClockAt(time.Now())
+	clock := clockwork.NewFakeClock()
 
 	s.bk, err = lite.NewWithConfig(context.TODO(), lite.Config{
 		Path:             c.MkDir(),

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -45,7 +45,7 @@ import (
 )
 
 type Suite struct {
-	clock        clockwork.Clock
+	clock        clockwork.FakeClock
 	dataDir      string
 	authServer   *auth.TestAuthServer
 	tlsServer    *auth.TestTLSServer
@@ -75,13 +75,14 @@ func (s *Suite) SetUpSuite(c *check.C) {
 
 	utils.InitLoggerForTests(testing.Verbose())
 
-	s.clock = clockwork.NewFakeClockAt(time.Now())
+	s.clock = clockwork.NewFakeClock()
 	s.dataDir = c.MkDir()
 
 	// Create Auth Server.
 	s.authServer, err = auth.NewTestAuthServer(auth.TestAuthServerConfig{
 		ClusterName: "root.example.com",
 		Dir:         s.dataDir,
+		Clock:       s.clock,
 	})
 	c.Assert(err, check.IsNil)
 	s.tlsServer, err = s.authServer.NewTestTLSServer()
@@ -116,10 +117,13 @@ func (s *Suite) SetUpTest(c *check.C) {
 	// Create a in-memory HTTP server that will respond with a UUID. This value
 	// will be checked in the client later to ensure a connection was made.
 	s.message = uuid.New()
-	s.testhttp = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+	s.testhttp = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, s.message)
 		s.closeFunc()
 	}))
+	s.testhttp.Config.TLSConfig = &tls.Config{Time: s.clock.Now}
+	s.testhttp.Start()
 
 	// Extract the hostport that the in-memory HTTP server is running on.
 	u, err := url.Parse(s.testhttp.URL)
@@ -147,7 +151,7 @@ func (s *Suite) SetUpTest(c *check.C) {
 		Spec: services.ServerSpecV2{
 			Version: teleport.Version,
 			Apps: []*services.App{
-				&services.App{
+				{
 					Name:          "foo",
 					URI:           s.testhttp.URL,
 					PublicAddr:    "foo.example.com",
@@ -166,6 +170,7 @@ func (s *Suite) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	tlsConfig, err := serverIdentity.TLSConfig(nil)
 	c.Assert(err, check.IsNil)
+	tlsConfig.Time = s.clock.Now
 
 	// Generate certificate for user.
 	privateKey, publicKey, err := s.tlsServer.Auth().GenerateKeyPair("")
@@ -286,6 +291,8 @@ func (s *Suite) TestHandleConnection(c *check.C) {
 				RootCAs: s.hostCertPool,
 				// Certificates is the user's application specific certificate.
 				Certificates: []tls.Certificate{s.clientCertificate},
+				// Time defines the time anchor for certificate validation
+				Time: s.clock.Now,
 			},
 		},
 	}

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -29,8 +29,10 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
+
 	"github.com/gravitational/trace"
 
+	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -54,6 +56,11 @@ type AuthHandlers struct {
 	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
 	// configuration.
 	FIPS bool
+
+	// Clock specifies the time provider. Will be used to override the time anchor
+	// for TLS certificate verification.
+	// Defaults to real clock if unspecified
+	Clock clockwork.Clock
 }
 
 // CreateIdentityContext returns an IdentityContext populated with information
@@ -198,9 +205,14 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 	// Check that the user certificate uses supported public key algorithms, was
 	// issued by Teleport, and check the certificate metadata (principals,
 	// timestamp, etc). Fallback to keys is not supported.
+	clock := time.Now
+	if h.Clock != nil {
+		clock = h.Clock.Now
+	}
 	certChecker := utils.CertChecker{
 		CertChecker: ssh.CertChecker{
 			IsUserAuthority: h.IsUserAuthority,
+			Clock:           clock,
 		},
 		FIPS: h.FIPS,
 	}

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -299,6 +299,7 @@ func New(c ServerConfig) (*Server, error) {
 		AccessPoint: c.AuthClient,
 		FIPS:        c.FIPS,
 		Emitter:     c.Emitter,
+		Clock:       c.Clock,
 	}
 
 	// Common term handlers.

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -297,6 +297,15 @@ func (s *Server) HandleConnection(conn net.Conn) {
 // RotationGetter returns rotation state
 type RotationGetter func(role teleport.Role) (*services.Rotation, error)
 
+// SetClock is a functional server option to override the internal
+// clock
+func SetClock(clock clockwork.Clock) ServerOption {
+	return func(s *Server) error {
+		s.clock = clock
+		return nil
+	}
+}
+
 // SetRotationGetter sets rotation state getter
 func SetRotationGetter(getter RotationGetter) ServerOption {
 	return func(s *Server) error {
@@ -542,6 +551,7 @@ func New(addr utils.NetAddr,
 		AccessPoint: s.authService,
 		FIPS:        s.fips,
 		Emitter:     s.StreamEmitter,
+		Clock:       s.clock,
 	}
 
 	// common term handlers

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -92,6 +92,14 @@ func SetSessionStreamPollPeriod(period time.Duration) HandlerOption {
 	}
 }
 
+// SetClock sets the clock on a handler
+func SetClock(clock clockwork.Clock) HandlerOption {
+	return func(h *Handler) error {
+		h.clock = clock
+		return nil
+	}
+}
+
 // Config represents web handler configuration parameters
 type Config struct {
 	// Proxy is a reverse tunnel proxy that handles connections
@@ -171,15 +179,10 @@ func (h *RewritingHandler) Close() error {
 // NewHandler returns a new instance of web proxy handler
 func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	const apiPrefix = "/" + teleport.WebAPIVersion
-	lauth, err := newSessionCache(cfg.ProxyClient, []utils.NetAddr{cfg.AuthServers}, cfg.CipherSuites)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	h := &Handler{
-		cfg:  cfg,
-		auth: lauth,
-		log:  newPackageLogger(),
+		cfg:   cfg,
+		log:   newPackageLogger(),
+		clock: clockwork.NewRealClock(),
 	}
 
 	for _, o := range opts {
@@ -188,6 +191,17 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 		}
 	}
 
+	auth, err := newSessionCache(&sessionCache{
+		proxyClient:  cfg.ProxyClient,
+		authServers:  []utils.NetAddr{cfg.AuthServers},
+		cipherSuites: cfg.CipherSuites,
+		clock:        h.clock,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	h.auth = auth
+
 	_, sshPort, err := net.SplitHostPort(cfg.ProxySSHAddr.String())
 	if err != nil {
 		h.log.WithError(err).Warnf("Invalid SSH proxy address %q, will use default port %v.",
@@ -195,10 +209,6 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 		sshPort = strconv.Itoa(defaults.SSHProxyListenPort)
 	}
 	h.sshPort = sshPort
-
-	if h.clock == nil {
-		h.clock = clockwork.NewRealClock()
-	}
 
 	// ping endpoint is used to check if the server is up. the /webapi/ping
 	// endpoint returns the default authentication method and configuration that
@@ -1190,7 +1200,7 @@ func NewSessionResponse(ctx *SessionContext) (*CreateSessionResponse, error) {
 	return &CreateSessionResponse{
 		Type:      roundtrip.AuthBearer,
 		Token:     webSession.GetBearerToken(),
-		ExpiresIn: int(time.Until(webSession.GetBearerTokenExpiryTime()) / time.Second),
+		ExpiresIn: int(webSession.GetBearerTokenExpiryTime().Sub(ctx.parent.clock.Now()) / time.Second),
 	}, nil
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -99,12 +99,10 @@ type WebSuite struct {
 	mockU2F     *mocku2f.Key
 	server      *auth.TestTLSServer
 	proxyClient *auth.Client
-	clock       clockwork.Clock
+	clock       clockwork.FakeClock
 }
 
-var _ = Suite(&WebSuite{
-	clock: clockwork.NewFakeClock(),
-})
+var _ = Suite(&WebSuite{})
 
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise it will run tests as normal.
@@ -145,11 +143,12 @@ func (s *WebSuite) SetUpTest(c *C) {
 	u, err := user.Current()
 	c.Assert(err, IsNil)
 	s.user = u.Username
+	s.clock = clockwork.NewFakeClock()
 
 	authServer, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{
 		ClusterName: "localhost",
 		Dir:         c.MkDir(),
-		Clock:       clockwork.NewFakeClockAt(time.Date(2017, 05, 10, 18, 53, 0, 0, time.UTC)),
+		Clock:       s.clock,
 	})
 	c.Assert(err, IsNil)
 	s.server, err = authServer.NewTestTLSServer()
@@ -192,6 +191,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		regular.SetEmitter(nodeClient),
 		regular.SetPAMConfig(&pam.Config{Enabled: false}),
 		regular.SetBPF(&bpf.NOP{}),
+		regular.SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 	s.node = node
@@ -244,6 +244,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		regular.SetEmitter(s.proxyClient),
 		regular.SetNamespace(defaults.Namespace),
 		regular.SetBPF(&bpf.NOP{}),
+		regular.SetClock(s.clock),
 	)
 	c.Assert(err, IsNil)
 
@@ -257,7 +258,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 		Context:      context.Background(),
 		HostUUID:     proxyID,
 		Emitter:      s.proxyClient,
-	}, SetSessionStreamPollPeriod(200*time.Millisecond))
+	}, SetSessionStreamPollPeriod(200*time.Millisecond), SetClock(s.clock))
 	c.Assert(err, IsNil)
 
 	s.webServer = httptest.NewUnstartedServer(handler)
@@ -315,9 +316,7 @@ func (s *WebSuite) authPackFromResponse(c *C, re *roundtrip.Response) *authPack 
 	jar.SetCookies(s.url(), re.Cookies())
 
 	session, err := sess.response()
-	if err != nil {
-		panic(err)
-	}
+	c.Assert(err, IsNil)
 	if session.ExpiresIn < 0 {
 		c.Errorf("expected expiry time to be in the future but got %v", session.ExpiresIn)
 	}
@@ -347,7 +346,7 @@ func (s *WebSuite) authPack(c *C, user string) *authPack {
 	s.createUser(c, user, login, pass, otpSecret)
 
 	// create a valid otp token
-	validToken, err := totp.GenerateCode(otpSecret, time.Now())
+	validToken, err := totp.GenerateCode(otpSecret, s.clock.Now())
 	c.Assert(err, IsNil)
 
 	clt := s.client()
@@ -591,10 +590,10 @@ func (s *WebSuite) TestCSRF(c *C) {
 
 func (s *WebSuite) TestPasswordChange(c *C) {
 	pack := s.authPack(c, "foo")
-	fakeClock := clockwork.NewFakeClock()
-	s.server.AuthServer.AuthServer.SetClock(fakeClock)
 
-	validToken, err := totp.GenerateCode(pack.otpSecret, fakeClock.Now())
+	// invalidate the token
+	s.clock.Advance(1 * time.Minute)
+	validToken, err := totp.GenerateCode(pack.otpSecret, s.clock.Now())
 	c.Assert(err, IsNil)
 
 	req := changePasswordReq{
@@ -1346,7 +1345,9 @@ func (s *WebSuite) TestChangePasswordWithTokenOTP(c *C) {
 	secrets, err := s.server.Auth().RotateResetPasswordTokenSecrets(context.TODO(), token.GetName())
 	c.Assert(err, IsNil)
 
-	secondFactorToken, err := totp.GenerateCode(secrets.GetOTPKey(), time.Now())
+	// Advance the clock to invalidate the TOTP token
+	s.clock.Advance(1 * time.Minute)
+	secondFactorToken, err := totp.GenerateCode(secrets.GetOTPKey(), s.clock.Now())
 	c.Assert(err, IsNil)
 
 	data, err := json.Marshal(auth.ChangePasswordWithTokenRequest{
@@ -1816,7 +1817,7 @@ func (s *WebSuite) TestCreateAppSession(c *C) {
 		Spec: services.ServerSpecV2{
 			Version: teleport.Version,
 			Apps: []*services.App{
-				&services.App{
+				{
 					Name:       "panel",
 					PublicAddr: "panel.example.com",
 					URI:        "http://127.0.0.1:8080",
@@ -1901,11 +1902,6 @@ func (s *WebSuite) TestCreateAppSession(c *C) {
 		c.Assert(session.GetUser(), check.Equals, tt.outUsername)
 		c.Assert(session.GetName(), check.Equals, response.CookieValue)
 	}
-}
-
-// TestAppRouting verifies requests get routed correctly: either to the Web UI
-// or an application.
-func (s *WebSuite) TestRouting(c *C) {
 }
 
 type authProviderMock struct {

--- a/vendor/github.com/jonboulle/clockwork/clockwork.go
+++ b/vendor/github.com/jonboulle/clockwork/clockwork.go
@@ -152,7 +152,7 @@ func (fc *fakeClock) NewTicker(d time.Duration) Ticker {
 		clock:  fc,
 		period: d,
 	}
-	go ft.tick()
+	ft.runTickThread()
 	return ft
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -274,7 +274,7 @@ github.com/johannesboyne/gofakes3
 github.com/johannesboyne/gofakes3/backend/s3mem
 github.com/johannesboyne/gofakes3/internal/goskipiter
 github.com/johannesboyne/gofakes3/internal/s3io
-# github.com/jonboulle/clockwork v0.2.1
+# github.com/jonboulle/clockwork v0.2.2
 ## explicit
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.10


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/5263.

I opted to backport these changes minimize changes to a test in web UI disconnects port. Will submit the corresponding PR once this is merged.