### PR TITLE
Various docs fixes

### DIFF
--- a/docs/5.0/admin-guide.md
+++ b/docs/5.0/admin-guide.md
@@ -1296,9 +1296,8 @@ examples and instructions.
 
 !!! tip "Tip"
 
-    Before continuing, please make sure to take a look at the
-    [Cluster State section](architecture/nodes.md#cluster-state) in the Teleport
-    Architecture documentation.
+    Before continuing, please make sure to take a look at the [Cluster State section](architecture/nodes.md#cluster-state)
+    in the Teleport Architecture documentation.
 
 Usually there are two ways to achieve high availability. You can "outsource"
 this function to the infrastructure. For example, using a highly available
@@ -1476,9 +1475,8 @@ teleport:
 
 !!! tip "Tip"
 
-    Before continuing, please make sure to take a look at the
-    [cluster state section](architecture/nodes.md#cluster-state) in Teleport
-    Architecture documentation.
+    Before continuing, please make sure to take a look at the [Cluster State section](architecture/nodes.md#cluster-state)
+    in Teleport Architecture documentation.
 
 !!! tip "AWS Authentication"
 
@@ -1514,8 +1512,8 @@ running on an EC2 instance with an IAM role.
 
 !!! tip "Tip"
 
-    Before continuing, please make sure to take a look at the
-    [cluster state section](architecture/nodes.md#cluster-state) in Teleport Architecture documentation.
+    Before continuing, please make sure to take a look at the [Cluster State section](architecture/nodes.md#cluster-state)
+    in Teleport Architecture documentation.
 
 If you are running Teleport on AWS, you can use
 [DynamoDB](https://aws.amazon.com/dynamodb/) as a storage back-end to achieve
@@ -1666,9 +1664,8 @@ To enable these options you will need to update the [IAM Role for Teleport](aws-
 
 !!! tip "Tip"
 
-    Before continuing, please make sure to take a look at the
-    [cluster state section](architecture/nodes.md#cluster-state) in Teleport
-    Architecture documentation.
+    Before continuing, please make sure to take a look at the [Cluster State section](architecture/nodes.md#cluster-state)
+    in Teleport Architecture documentation.
 
 
 Google Cloud Storage (GCS) can only be used as a storage for the recorded
@@ -1689,8 +1686,8 @@ teleport:
 
 !!! tip "Tip"
 
-    Before continuing, please make sure to take a look at the
-    [cluster state section](architecture/nodes.md#cluster-state) in Teleport Architecture documentation.
+    Before continuing, please make sure to take a look at the [Cluster State section](architecture/nodes.md#cluster-state)
+    in Teleport Architecture documentation.
 
 If you are running Teleport on GCP, you can use
 [Firestore](https://cloud.google.com/firestore/) as a storage back-end to achieve

--- a/docs/5.0/features/enhanced-session-recording.md
+++ b/docs/5.0/features/enhanced-session-recording.md
@@ -133,6 +133,7 @@ We recommend installing BCC tools using your distribution's package manager wher
     This script can be used to compile BCC tools from source on Ubuntu and Debian hosts.
 
     !!! warning
+
         We recommend this method only as a last resort if installing the `bpfcc-tools` package does not work.
         Compiling from source can take a long time and may break if your kernel version changes.
 
@@ -174,6 +175,7 @@ We recommend installing BCC tools using your distribution's package manager wher
     This script can be used to compile BCC tools from source on CentOS and RHEL hosts.
 
     !!! warning
+
         We recommend this method only as a last resort if installing the `bcc-tools` package does not work.
         Compiling from source can take a long time and may break if your kernel version changes.
 

--- a/docs/5.0/features/enhanced-session-recording.md
+++ b/docs/5.0/features/enhanced-session-recording.md
@@ -170,7 +170,7 @@ We recommend installing BCC tools using your distribution's package manager wher
     echo "Install is complete, try running /usr/share/bcc/tools/execsnoop to verify install."
     ```
 
-=== "CentOS"
+=== "CentOS (compile from source)"
 
     This script can be used to compile BCC tools from source on CentOS and RHEL hosts.
 

--- a/docs/5.0/gcp-guide.md
+++ b/docs/5.0/gcp-guide.md
@@ -94,7 +94,7 @@ When creating the Bucket we would recommend setting it up as `Dual-region` and w
 `Standard` storage class. Provide access using a `Uniform` access control with a Google-managed
 key.
 
-When setting up `audit_session_uri` use `gs://` session prefix.
+When setting up `audit_sessions_uri` use `gs://` session prefix.
 
 ```yaml
 storage:

--- a/docs/5.0/ibm-cloud-guide.md
+++ b/docs/5.0/ibm-cloud-guide.md
@@ -112,9 +112,9 @@ We recommend using [IBM Cloud File Storage](https://www.ibm.com/cloud/file-stora
 
 2. Create a new bucket.
 3. Setup [HMAC Credentials](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-uhc-hmac-credentials-main)
-4. Update audit session URI `audit_sessions_uri:` 's3://BUCKET-NAME/readonly/records?endpoint=s3.us-east.cloud-object-storage.appdomain.cloud&region=ibm'
+4. Update audit sessions URI: `audit_sessions_uri: 's3://BUCKET-NAME/readonly/records?endpoint=s3.us-east.cloud-object-storage.appdomain.cloud&region=ibm'`
 
-When setting up `audit_session_uri` use `s3://` session prefix.
+When setting up `audit_sessions_uri` use `s3://` session prefix.
 
 The credentials are used from `~/.aws/credentials` and should be created with HMAC option:
 


### PR DESCRIPTION
The lack of a newline was causing a rendering issue:

![2021-02-03-103222__831x105__maim](https://user-images.githubusercontent.com/897821/106761372-223c9080-660b-11eb-9dd6-92556ed15873.png)

Also fixes the title of the CentOS script tab header to be less confusing.