### PR TITLE
Provides output of bastion, auto scaling groups info in ha terraform

### DIFF
--- a/examples/aws/terraform/ha-autoscale-cluster/output.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/output.tf
@@ -6,7 +6,7 @@
 output "z_bastion_instance_public_ip" {
   value = {
   for instance in aws_instance.bastion:
-  instance.id => format("ip %s %s %s %s",instance.public_ip, ", Add identity file via ssh agent (ssh-add identityfile.pem)\n and you can jump host to servers. \nEx:\nssh -J ec2-user@", instance.public_ip, " ec2-user@<proxy/auth/node ip>") 
+  instance.id => format("ip %s %s%s %s",instance.public_ip, ", Add identity file via ssh agent (ssh-add identityfile.pem)\n and you can jump host to servers. \nEx:\nssh -J ec2-user@", instance.public_ip, " ec2-user@<proxy/auth/node ip>") 
 }
   description = "AWS Bastion EC2 IP. Add AWS identity file to your ssh agent and you can jump host through the bastion.  ssh -J <bastion-ip> <proxy/auth ip>"
 }
@@ -28,7 +28,7 @@ output "monitor_autoscaling_groups" {
   value = aws_autoscaling_group.monitor.*.id
 }
 output "retrieving_autoscaling_group_ips" {
-  value = format("To get the private IPs of the autoscaling ec2 instances set the ASG_VALUE to a above scaling group.\nEx:\nASG_VALUE=teleportoss-auth\naws ec2 describe-instances     --filters \"Name=tag-value,Values=%s\" --region %s  --query 'Reservations[*].Instances[*].[InstanceId,PrivateIpAddress]' --output text", "$${ASG_VALUE}", var.region)
+  value = format("To get the private IPs of the autoscaling ec2 instances set the ASG_VALUE to a above scaling group and run the aws command.\nEx:\nASG_VALUE=teleportoss-auth\naws ec2 describe-instances     --filters \"Name=tag-value,Values=%s\" --region %s  --query 'Reservations[*].Instances[*].[InstanceId,PrivateIpAddress]' --output text", "$${ASG_VALUE}", var.region)
 
 }
 

--- a/examples/aws/terraform/ha-autoscale-cluster/output.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/output.tf
@@ -1,0 +1,35 @@
+//Output providing the bastion public IP, auto scaling group names and how 
+//to get the private IPs to jumphost through the bastion. 
+
+
+
+output "z_bastion_instance_public_ip" {
+  value = {
+  for instance in aws_instance.bastion:
+  instance.id => format("ip %s %s %s %s",instance.public_ip, ", Add identity file via ssh agent (ssh-add identityfile.pem)\n and you can jump host to servers. \nEx:\nssh -J ec2-user@", instance.public_ip, " ec2-user@<proxy/auth/node ip>") 
+}
+  description = "AWS Bastion EC2 IP. Add AWS identity file to your ssh agent and you can jump host through the bastion.  ssh -J <bastion-ip> <proxy/auth ip>"
+}
+
+output "proxy_autoscaling_groups" {
+  value = aws_autoscaling_group.proxy.*.id
+}
+output "proxy_acm_autoscaling_groups" {
+  value = aws_autoscaling_group.proxy_acm.*.id
+}
+output "auth_autoscaling_groups" {
+  value = aws_autoscaling_group.auth.*.id
+}
+output "node_autoscaling_groups" {
+  value = aws_autoscaling_group.node.*.id
+}
+
+output "monitor_autoscaling_groups" {
+  value = aws_autoscaling_group.monitor.*.id
+}
+output "retrieving_autoscaling_group_ips" {
+  value = format("To get the private IPs of the autoscaling ec2 instances set the ASG_VALUE to a above scaling group.\nEx:\nASG_VALUE=teleportoss-auth\naws ec2 describe-instances     --filters \"Name=tag-value,Values=%s\" --region %s  --query 'Reservations[*].Instances[*].[InstanceId,PrivateIpAddress]' --output text", "$${ASG_VALUE}", var.region)
+
+}
+
+


### PR DESCRIPTION
Example new output:

auth_autoscaling_groups = [
  "teleportoss-auth",
]

monitor_autoscaling_groups = [
  "teleportoss-monitor",
]
node_autoscaling_groups = [
  "teleportoss-node",
]
proxy_acm_autoscaling_groups = []
proxy_autoscaling_groups = [
  "teleportoss-proxy",
]
retrieving_autoscaling_group_ips = <<EOT
To get the private IPs of the autoscaling ec2 instances set the ASG_VALUE to a above scaling group and run the aws command.
Ex:
ASG_VALUE=teleportoss-auth
aws ec2 describe-instances     --filters "Name=tag-value,Values=${ASG_VALUE}" --region eu-central-1  --query 'Reservations[*].Instances[*].[InstanceId,PrivateIpAddress]' --output text
EOT
z_bastion_instance_public_ip = {
  "i-0bffbae6b35a06402" = <<-EOT
  ip 3.122.94.153 , Add identity file via ssh agent (ssh-add identityfile.pem)
   and you can jump host to servers. Ex:
  ssh -J ec2-user@ 3.122.94.153  ec2-user@<proxy/auth/node ip>
  EOT
}
