### PR TITLE
Fix windows cross-compilation with CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@ TELEPORT_DEBUG ?= no
 GITTAG=v$(VERSION)
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
 CGOFLAG ?= CGO_ENABLED=1
+# Windows requires extra parameters to cross-compile with CGO.
+ifeq ("$(OS)","windows")
+BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s' -buildmode=exe
+CGOFLAG = CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++
+endif
+
 GO_LINTERS ?= "unused,govet,typecheck,deadcode,goimports,varcheck,structcheck,bodyclose,staticcheck,ineffassign,unconvert,misspell,gosimple,golint"
 
 OS ?= $(shell go env GOOS)

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -19,7 +19,26 @@ ENV LANGUAGE="en_US.UTF-8" \
 
 RUN apt-get update -y --fix-missing && \
     apt-get -q -y upgrade && \
-    apt-get install -q -y apt-utils curl gcc gcc-multilib git gzip libbpfcc-dev libc6-dev libpam-dev libsqlite3-0 locales make net-tools tar tree zip shellcheck && \
+    apt-get install -q -y \
+        apt-utils \
+        curl \
+        gcc \
+        gcc-multilib \
+        git \
+        gzip \
+        libbpfcc-dev \
+        libc6-dev \
+        libpam-dev \
+        libsqlite3-0 \
+        locales \
+        make \
+        mingw-w64 \
+        net-tools \
+        shellcheck \
+        tar \
+        tree \
+        zip \
+        && \
     dpkg-reconfigure locales && \
     apt-get -y autoclean && apt-get -y clean
 


### PR DESCRIPTION
Install `mingw-w64` cross-compiler toolchain in the buildbox and pass
magic flags to `go build` to use it.

Fixes `make -C build.assets release OS=windows`.