### PR TITLE
Add kubernetes_service option to teleport helm chart

### DIFF
--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -1,6 +1,6 @@
 name: teleport
 apiVersion: v2
-version: 0.0.9
+version: 0.0.10
 appVersion: "5"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -115,6 +115,7 @@ data:
     kubernetes_service:
 {{ toYaml .Values.config.teleport.kubernetes_service  | indent 6 }}
 {{- end }}
+{{- end }}
 
 {{- if .Values.config.highAvailability }}
 ---

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -93,17 +93,27 @@ data:
       https_cert_file: {{ .Values.config.teleport.proxy_service.https_cert_file }}
 {{- end }}
 
+{{- if .Values.config.teleport.proxy_service.kubernetes }}
       # kubernetes section configures
       # kubernetes proxy protocol support
       kubernetes:
         enabled: {{ .Values.config.teleport.proxy_service.kubernetes.enabled }}
-{{- if .Values.config.teleport.proxy_service.kubernetes.public_addr }}
+   {{- if .Values.config.teleport.proxy_service.kubernetes.public_addr }}
         public_addr: {{ .Values.config.teleport.proxy_service.kubernetes.public_addr }}{{ if not (contains ":" .Values.config.teleport.proxy_service.kubernetes.public_addr) }}:{{ .Values.service.ports.proxykube.port }}{{ end }}
-{{- else }}
+   {{- else }}
         public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.proxykube.port }}
-{{- end }}
+   {{- end }}
         listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxykube.containerPort }}
+
+
+{{- else if .Values.config.teleport.kubernetes_service }}
+      #kube_service declaration
+      kube_listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxykube.containerPort }}
+    kubernetes_service:
+{{ toYaml .Values.config.teleport.kubernetes_service  | indent 8 }}
 {{- end }}
+{{- end }}
+
 {{- if .Values.config.highAvailability }}
 ---
 #Configuration for additional deployments used for high performance

--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -109,9 +109,11 @@ data:
 {{- else if .Values.config.teleport.kubernetes_service }}
       #kube_service declaration
       kube_listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.proxykube.containerPort }}
-    kubernetes_service:
-{{ toYaml .Values.config.teleport.kubernetes_service  | indent 8 }}
 {{- end }}
+
+{{- if .Values.config.teleport.kubernetes_service }}
+    kubernetes_service:
+{{ toYaml .Values.config.teleport.kubernetes_service  | indent 6 }}
 {{- end }}
 
 {{- if .Values.config.highAvailability }}

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -164,7 +164,7 @@ config:
     # kubernetes_service:
       # enabled: true            
       # labels:
-      #   type: staging        
+      #   example-label: example-value
       # listen_addr: 0.0.0.0:3027
       # Optionally use a volume mounted kubeconfig to connect to other clusters
       # kubeconfig_file: /var/lib/teleport/kubefiles/kubeconfig        

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -91,7 +91,7 @@ config:
       # We recommend to use tools like `pwgen` to generate sufficiently random
       # tokens of 32+ byte length.
       tokens:
-      - proxy,node:dogs-are-much-nicer-than-cats
+      - proxy,node,kube:dogs-are-much-nicer-than-cats
       - trusted_cluster:trains-are-superior-to-cars
 
       # Determines if SSH sessions to cluster nodes are forcefully terminated

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -165,6 +165,7 @@ config:
       # enabled: true            
       # labels:
       #   type: staging        
+      # listen_addr: 0.0.0.0:3027
       # Optionally use a volume mounted kubeconfig to connect to other clusters
       # kubeconfig_file: /var/lib/teleport/kubefiles/kubeconfig        
 

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -160,7 +160,7 @@ config:
         # Specify a different hostname for the k8s public address (if different to config.public_address)
         # public_addr: teleportkubernetes.example.com
         
-    # To use a kubernetes_service remove kubernetes under proxy_service        
+    # To use a kubernetes_service uncomment this section        
     # kubernetes_service:
       # enabled: true            
       # labels:

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -160,6 +160,13 @@ config:
         # Specify a different hostname for the k8s public address (if different to config.public_address)
         # public_addr: teleportkubernetes.example.com
         
+    # To use a kubernetes_service remove kubernetes under proxy_service        
+    # kubernetes_service:
+      # enabled: true            
+      # labels:
+      #   type: staging        
+      # Optionally use a volume mounted kubeconfig to connect to other clusters
+      # kubeconfig_file: /var/lib/teleport/kubefiles/kubeconfig        
 
 # Alternatively you can provide your teleport configuration under teleportConfig with static text. No variable substitution.
 otherConfig:


### PR DESCRIPTION
Allows for using kubernetes_service option instead of kubernetes enabled under proxy.  This allows for pointing at multiple other k8s clusters with a kubeconfig.