### PR TITLE
Implement utmp/wtmp support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -149,6 +149,25 @@ steps:
       - cd /tmpfs/go/src/github.com/gravitational/teleport
       - make -C build.assets test
 
+  # some integration tests can only be run as root, so we handle
+  # these separately using a build tag
+  - name: Run root-only integration tests
+    image: docker
+    environment:
+      GOCACHE: /tmpfs/go/cache
+      GOPATH: /tmpfs/go
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: tmp-integration
+        path: /tmp
+      - name: tmpfs
+        path: /tmpfs
+    commands:
+      - apk add --no-cache make
+      - cd /tmpfs/go/src/github.com/gravitational/teleport
+      - make -C build.assets integration-root
+
   - name: Run integration tests
     image: docker
     environment:
@@ -167,7 +186,7 @@ steps:
         path: /tmpfs
     commands:
       - apk add --no-cache make
-      # write kubeconfig to disk for use in kube integrations tests
+      # write kubeconfig to disk for use in kube integration tests
       - echo "$INTEGRATION_CI_KUBECONFIG" > "$KUBECONFIG"
       - chown -R $UID:$GID /tmpfs/go
       - cd /tmpfs/go/src/github.com/gravitational/teleport
@@ -4372,6 +4391,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 316386d14b171635c1189a65e7d840ac85fccc37a91c228d6b4f569043f7ab79
+hmac: 6a5acaa383f34c9905f752bccae72b029386ff1536a6c45465c88b8fc6f611ca
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,7 @@ test: $(VERSRC)
 
 #
 # Integration tests. Need a TTY to work.
+# Any tests which need to run as root must be skipped during regular integration testing.
 #
 .PHONY: integration
 integration: FLAGS ?= -v -race
@@ -294,6 +295,17 @@ integration: PACKAGES := $(shell go list ./... | grep integration)
 integration:
 	@echo KUBECONFIG is: $(KUBECONFIG), TEST_KUBE: $(TEST_KUBE)
 	go test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" $(PACKAGES) $(FLAGS)
+
+#
+# Integration tests which need to be run as root in order to complete successfully
+# are run separately to all other integration tests. Need a TTY to work.
+#
+INTEGRATION_ROOT_REGEX := ^TestRoot
+.PHONY: integration-root
+integration-root: FLAGS ?= -v -race
+integration-root: PACKAGES := $(shell go list ./... | grep integration)
+integration-root:
+	go test -run "$(INTEGRATION_ROOT_REGEX)" $(PACKAGES) $(FLAGS)
 
 #
 # Lint the Go code.

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -188,6 +188,11 @@ integration: buildbox
 	docker run $(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c "make -C $(SRCDIR) FLAGS='-cover' integration"
 
+.PHONY:integration-root
+integration-root: buildbox
+	docker run $(DOCKERFLAGS) $(BCCFLAGS) -t $(BUILDBOX) \
+		/bin/bash -c "make -C $(SRCDIR) FLAGS='-cover' integration-root"
+
 #
 # Runs linters on new changes inside a build container.
 #

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5096,10 +5096,15 @@ func hasPAMPolicy() bool {
 	return true
 }
 
-// isRoot returns a boolean if the test is being run as root or not. Tests
-// for this package must be run as root.
+// isRoot returns a boolean if the test is being run as root or not.
+func isRoot() bool {
+	return os.Geteuid() == 0
+}
+
+// canTestBPF runs checks to determine whether BPF tests will run or not.
+// Tests for this package must be run as root.
 func canTestBPF() error {
-	if os.Geteuid() != 0 {
+	if !isRoot() {
 		return trace.BadParameter("not root")
 	}
 

--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/bpf"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/pam"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/regular"
+	"github.com/gravitational/teleport/lib/srv/uacc"
+	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+// teleportTestUser is additional user used for tests
+const teleportTestUser = "teleport-test"
+
+// wildcardAllow is used in tests to allow access to all labels.
+var wildcardAllow = services.Labels{
+	services.Wildcard: []string{services.Wildcard},
+}
+
+type SrvCtx struct {
+	srv        *regular.Server
+	signer     ssh.Signer
+	server     *auth.TestTLSServer
+	testServer *auth.TestAuthServer
+	clock      clockwork.FakeClock
+	nodeClient *auth.Client
+	nodeID     string
+	utmpPath   string
+}
+
+// TestRootUTMPEntryExists verifies that user accounting is done on supported systems.
+func TestRootUTMPEntryExists(t *testing.T) {
+	if !isRoot() {
+		t.Skip("This test will be skipped because tests are not being run as root.")
+	}
+
+	s := newSrvCtx(t)
+	up, err := newUpack(s, teleportTestUser, []string{teleportTestUser}, wildcardAllow)
+	require.NoError(t, err)
+
+	sshConfig := &ssh.ClientConfig{
+		User:            teleportTestUser,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
+		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+	}
+
+	client, err := ssh.Dial("tcp", s.srv.Addr(), sshConfig)
+	require.NoError(t, err)
+	defer func() {
+		err := client.Close()
+		require.NoError(t, err)
+	}()
+
+	se, err := client.NewSession()
+	require.NoError(t, err)
+	defer se.Close()
+
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          0,     // disable echoing
+		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
+		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
+	}
+
+	require.NoError(t, se.RequestPty("xterm", 80, 80, modes), nil)
+	err = se.Shell()
+	require.NoError(t, err)
+
+	start := time.Now()
+	for time.Since(start) < 5*time.Minute {
+		time.Sleep(time.Second)
+		entryExists := uacc.UserWithPtyInDatabase(s.utmpPath, teleportTestUser)
+		if entryExists == nil {
+			break
+		}
+		if !trace.IsNotFound(entryExists) {
+			require.NoError(t, err)
+		}
+	}
+}
+
+// upack holds all ssh signing artefacts needed for signing and checking user keys
+type upack struct {
+	// key is a raw private user key
+	key []byte
+
+	// pkey is parsed private SSH key
+	pkey interface{}
+
+	// pub is a public user key
+	pub []byte
+
+	// cert is a certificate signed by user CA
+	cert []byte
+
+	// pcert is a parsed SSH Certificae
+	pcert *ssh.Certificate
+
+	// signer is a signer that answers signing challenges using private key
+	signer ssh.Signer
+
+	// certSigner is a signer that answers signing challenges using private
+	// key and a certificate issued by user certificate authority
+	certSigner ssh.Signer
+}
+
+const hostID = "00000000-0000-0000-0000-000000000000"
+
+func TouchFile(name string) error {
+	file, err := os.OpenFile(name, os.O_RDONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+// This returns the utmp path.
+func newSrvCtx(t *testing.T) *SrvCtx {
+	s := &SrvCtx{}
+
+	t.Cleanup(func() {
+		if s.server != nil {
+			require.NoError(t, s.server.Close())
+		}
+		if s.srv != nil {
+			require.NoError(t, s.srv.Close())
+		}
+	})
+
+	s.clock = clockwork.NewFakeClock()
+	tempdir := t.TempDir()
+
+	authServer, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{
+		ClusterName: "localhost",
+		Dir:         tempdir,
+		Clock:       s.clock,
+	})
+	require.NoError(t, err)
+	s.server, err = authServer.NewTestTLSServer()
+	require.NoError(t, err)
+	s.testServer = authServer
+
+	// set up host private key and certificate
+	certs, err := s.server.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
+		HostID:   hostID,
+		NodeName: s.server.ClusterName(),
+		Roles:    teleport.Roles{teleport.RoleNode},
+	})
+	require.NoError(t, err)
+
+	// set up user CA and set up a user that has access to the server
+	s.signer, err = sshutils.NewSigner(certs.Key, certs.Cert)
+	require.NoError(t, err)
+
+	s.nodeID = uuid.New()
+	s.nodeClient, err = s.server.NewClient(auth.TestIdentity{
+		I: auth.BuiltinRole{
+			Role:     teleport.RoleNode,
+			Username: s.nodeID,
+		},
+	})
+	require.NoError(t, err)
+
+	uaccDir := t.TempDir()
+	utmpPath := path.Join(uaccDir, "utmp")
+	wtmpPath := path.Join(uaccDir, "wtmp")
+	err = TouchFile(utmpPath)
+	require.NoError(t, err)
+	err = TouchFile(wtmpPath)
+	require.NoError(t, err)
+	s.utmpPath = utmpPath
+
+	nodeDir := t.TempDir()
+	srv, err := regular.New(
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
+		s.server.ClusterName(),
+		[]ssh.Signer{s.signer},
+		s.nodeClient,
+		nodeDir,
+		"",
+		utils.NetAddr{},
+		regular.SetUUID(s.nodeID),
+		regular.SetNamespace(defaults.Namespace),
+		regular.SetEmitter(s.nodeClient),
+		regular.SetShell("/bin/sh"),
+		regular.SetSessionServer(s.nodeClient),
+		regular.SetPAMConfig(&pam.Config{Enabled: false}),
+		regular.SetLabels(
+			map[string]string{"foo": "bar"},
+			services.CommandLabels{
+				"baz": &services.CommandLabelV2{
+					Period:  services.NewDuration(time.Millisecond),
+					Command: []string{"expr", "1", "+", "3"}},
+			},
+		),
+		regular.SetBPF(&bpf.NOP{}),
+		regular.SetClock(s.clock),
+		regular.SetUtmpPath(utmpPath, utmpPath),
+	)
+	require.NoError(t, err)
+	s.srv = srv
+	require.NoError(t, auth.CreateUploaderDir(nodeDir))
+	require.NoError(t, s.srv.Start())
+	return s
+}
+
+func newUpack(s *SrvCtx, username string, allowedLogins []string, allowedLabels services.Labels) (*upack, error) {
+	ctx := context.Background()
+	auth := s.server.Auth()
+	upriv, upub, err := auth.GenerateKeyPair("")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user, err := services.NewUser(username)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	role := services.RoleForUser(user)
+	rules := role.GetRules(services.Allow)
+	rules = append(rules, services.NewRule(services.Wildcard, services.RW()))
+	role.SetRules(services.Allow, rules)
+	opts := role.GetOptions()
+	opts.PermitX11Forwarding = services.NewBool(true)
+	role.SetOptions(opts)
+	role.SetLogins(services.Allow, allowedLogins)
+	role.SetNodeLabels(services.Allow, allowedLabels)
+	err = auth.UpsertRole(ctx, role)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user.AddRole(role.GetName())
+	err = auth.UpsertUser(user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ucert, err := s.testServer.GenerateUserCert(upub, user.GetName(), 5*time.Minute, teleport.CertificateFormatStandard)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	upkey, err := ssh.ParseRawPrivateKey(upriv)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	usigner, err := ssh.NewSignerFromKey(upkey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pcert, _, _, _, err := ssh.ParseAuthorizedKey(ucert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ucertSigner, err := ssh.NewCertSigner(pcert.(*ssh.Certificate), usigner)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &upack{
+		key:        upriv,
+		pkey:       upkey,
+		pub:        upub,
+		cert:       ucert,
+		pcert:      pcert.(*ssh.Certificate),
+		signer:     usigner,
+		certSigner: ucertSigner,
+	}, nil
+}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/pam"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/srv/uacc"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -120,6 +121,9 @@ type Server interface {
 
 	// Context returns server shutdown context
 	Context() context.Context
+
+	// GetUtmpPath returns the path of the user accounting database and log. Returns empty for system defaults.
+	GetUtmpPath() (utmp, wtmp string)
 }
 
 // IdentityContext holds all identity information associated with the user
@@ -722,6 +726,11 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 		requestType = c.request.Type
 	}
 
+	uaccMetadata, err := newUaccMetadata(c)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Create the execCommand that will be sent to the child process.
 	return &ExecCommand{
 		Command:               command,
@@ -737,6 +746,7 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 		ServiceName:           pamServiceName,
 		UsePAMAuth:            pamUseAuth,
 		IsTestStub:            c.IsTestStub,
+		UaccMetadata:          *uaccMetadata,
 	}, nil
 }
 
@@ -806,4 +816,21 @@ func closeAll(closers ...io.Closer) error {
 	}
 
 	return trace.NewAggregate(errs...)
+}
+
+func newUaccMetadata(c *ServerContext) (*UaccMetadata, error) {
+	hostname := c.srv.GetInfo().GetHostname()
+	remoteAddr := c.ConnectionContext.ServerConn.Conn.RemoteAddr()
+	preparedAddr, err := uacc.PrepareAddr(remoteAddr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	utmpPath, wtmpPath := c.srv.GetUtmpPath()
+
+	return &UaccMetadata{
+		Hostname:   hostname,
+		RemoteAddr: preparedAddr,
+		UtmpPath:   utmpPath,
+		WtmpPath:   wtmpPath,
+	}, nil
 }

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend/lite"
@@ -466,7 +467,31 @@ func (f *fakeServer) GetClock() clockwork.Clock {
 }
 
 func (f *fakeServer) GetInfo() services.Server {
-	return nil
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "localhost"
+	}
+
+	return &services.ServerV2{
+		Kind:    services.KindNode,
+		Version: services.V2,
+		Metadata: services.Metadata{
+			Name:      "",
+			Namespace: "",
+			Labels:    make(map[string]string),
+		},
+		Spec: services.ServerSpecV2{
+			CmdLabels: make(map[string]types.CommandLabelV2),
+			Addr:      "",
+			Hostname:  hostname,
+			UseTunnel: false,
+			Version:   teleport.Version,
+		},
+	}
+}
+
+func (f *fakeServer) GetUtmpPath() (string, string) {
+	return "", ""
 }
 
 func (f *fakeServer) UseTunnel() bool {

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -412,6 +412,13 @@ func (s *Server) GetClock() clockwork.Clock {
 	return s.clock
 }
 
+// GetUtmpPath returns returns the optional override of the utmp and wtmp path.
+// These values are never set for the forwarding server because utmp and wtmp
+// are updated by the target server and not the forwarding server.
+func (s *Server) GetUtmpPath() (string, string) {
+	return "", ""
+}
+
 func (s *Server) Serve() {
 	config := &ssh.ServerConfig{}
 

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/pam"
 	"github.com/gravitational/teleport/lib/shell"
+	"github.com/gravitational/teleport/lib/srv/uacc"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -93,6 +94,24 @@ type ExecCommand struct {
 
 	// IsTestStub is used by tests to mock the shell.
 	IsTestStub bool `json:"is_test_stub"`
+
+	// UaccMetadata contains metadata needed for user accounting.
+	UaccMetadata
+}
+
+// UaccMetadata contains information the child needs from the parent for user accounting.
+type UaccMetadata struct {
+	// The hostname of the node.
+	Hostname string `json:"hostname"`
+
+	// RemoteAddr is the address of the remote host.
+	RemoteAddr [4]int32 `json:"remote_addr"`
+
+	// UtmpPath is the path of the system utmp database.
+	UtmpPath string `json:"utmp_path,omitempty"`
+
+	// WtmpPath is the path of the system wtmp log.
+	WtmpPath string `json:"wtmp_path,omitempty"`
 }
 
 // RunCommand reads in the command to run from the parent process (over a
@@ -127,6 +146,7 @@ func RunCommand() (io.Writer, int, error) {
 
 	var tty *os.File
 	var pty *os.File
+	var ttyName string
 
 	// If a terminal was requested, file descriptor 4 and 5 always point to the
 	// PTY and TTY. Extract them and set the controlling TTY. Otherwise, connect
@@ -138,6 +158,14 @@ func RunCommand() (io.Writer, int, error) {
 			return errorWriter, teleport.RemoteCommandFailure, trace.BadParameter("pty and tty not found")
 		}
 		errorWriter = tty
+		ttyName, err = os.Readlink(tty.Name())
+		if err != nil {
+			return errorWriter, teleport.RemoteCommandFailure, trace.BadParameter("failed to resolve tty soft link: %v", err)
+		}
+		err = uacc.Open(c.UtmpPath, c.WtmpPath, c.Login, c.Hostname, c.RemoteAddr, ttyName)
+		if err != nil && !trace.IsAccessDenied(err) {
+			return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
+		}
 	}
 
 	// If PAM is enabled, open a PAM context. This has to be done before anything
@@ -212,6 +240,12 @@ func RunCommand() (io.Writer, int, error) {
 	// running exit 2), the shell will print an error if appropriate and return
 	// an exit code.
 	err = cmd.Wait()
+
+	uaccErr := uacc.Close(c.UtmpPath, c.WtmpPath, ttyName)
+	if uaccErr != nil && !trace.IsAccessDenied(uaccErr) {
+		return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(uaccErr)
+	}
+
 	return ioutil.Discard, exitCode(err), trace.Wrap(err)
 }
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -153,6 +153,12 @@ type Server struct {
 
 	// onHeartbeat is a callback for heartbeat status.
 	onHeartbeat func(error)
+
+	// utmpPath is the path to the user accounting database.
+	utmpPath string
+
+	// wtmpPath is the path to the user accounting log.
+	wtmpPath string
 }
 
 // GetClock returns server clock implementation
@@ -178,6 +184,11 @@ func (s *Server) GetSessionServer() rsession.Service {
 		return rsession.NewDiscardSessionServer()
 	}
 	return s.sessionServer
+}
+
+// GetUtmpPath returns the optional override of the utmp and wtmp path.
+func (s *Server) GetUtmpPath() (string, string) {
+	return s.utmpPath, s.wtmpPath
 }
 
 // GetPAM returns the PAM configuration for this server.
@@ -296,6 +307,15 @@ func (s *Server) HandleConnection(conn net.Conn) {
 
 // RotationGetter returns rotation state
 type RotationGetter func(role teleport.Role) (*services.Rotation, error)
+
+// SetUtmpPath is a functional server option to override the user accounting database and log path.
+func SetUtmpPath(utmpPath, wtmpPath string) ServerOption {
+	return func(s *Server) error {
+		s.utmpPath = utmpPath
+		s.wtmpPath = wtmpPath
+		return nil
+	}
+}
 
 // SetClock is a functional server option to override the internal
 // clock

--- a/lib/srv/uacc/uacc.h
+++ b/lib/srv/uacc/uacc.h
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef UACC_C
+#define UACC_C
+
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <utmp.h>
+#include <errno.h>
+#include <stdbool.h>
+
+#define SELECT_UTMP_PATH(x) x != NULL ? x : _PATH_UTMP
+#define SELECT_WTMP_PATH(x) x != NULL ? x : _PATH_WTMP
+
+int UACC_UTMP_MISSING_PERMISSIONS = 1;
+int UACC_UTMP_WRITE_ERROR = 2;
+int UACC_UTMP_READ_ERROR = 3;
+int UACC_UTMP_FAILED_OPEN = 4;
+int UACC_UTMP_ENTRY_DOES_NOT_EXIST = 5;
+int UACC_UTMP_FAILED_TO_SELECT_FILE = 6;
+
+// I initially attempted to use the login/logout BSD functions but ran into a string of unexpected behaviours such as
+// errno being set to undocument values along with wierd return values in certain cases. They also modify the utmp database
+// in a way we don't want. We want to insert a USER_PROCESS entry directly before we do PAM/cgroup setup and launch the shell
+// without any middleman. I brought this information with my issues and requirements to the IRC and was told that I would be
+// better off using the setutent/pututline low level manipulation functions - joel.
+
+// `strncpy` is used a bit in this code and this comment attempts to briefly explain why. Back when C interfaces and libraries were
+// being standardized a choice was to make the NUL terminator optional for strings occupying fixed-size buffers in certain interfaces.
+// This decision is one of the origins of `strncpy` which has the special property that it will not write a NUL terminator if the
+// source string excluding the NUL terminator is of equal or greater length in comparison to the limit parameter.
+
+// The max byte length of the C string representing the TTY name.
+static int max_len_tty_name() {
+    return UT_LINESIZE;
+}
+
+// Low level C function to add a new USER_PROCESS entry to the database.
+// This function does not perform any argument validation.
+static int uacc_add_utmp_entry(const char *utmp_path, const char *wtmp_path, const char *username, const char *hostname, const int32_t remote_addr_v6[4], const char *tty_name, const char *id, int32_t tv_sec, int32_t tv_usec) {
+    if (utmpname(SELECT_UTMP_PATH(utmp_path)) != 0) {
+        return UACC_UTMP_FAILED_TO_SELECT_FILE;
+    }
+    struct utmp entry;
+    entry.ut_type = USER_PROCESS;
+    strncpy((char*) &entry.ut_line, tty_name, UT_LINESIZE);
+    strncpy((char*) &entry.ut_id, id, sizeof(entry.ut_id));
+    entry.ut_pid = getpid();
+    strncpy((char*) &entry.ut_host, hostname, sizeof(entry.ut_host));
+    strncpy((char*) &entry.ut_user, username, sizeof(entry.ut_user));
+    entry.ut_session = 1;
+    entry.ut_tv.tv_sec = tv_sec;
+    entry.ut_tv.tv_usec = tv_usec;
+    memcpy(&entry.ut_addr_v6, &remote_addr_v6, sizeof(int32_t) * 4);
+    errno = 0;
+    setutent();
+    if (errno != 0) {
+        return UACC_UTMP_FAILED_OPEN;
+    }
+    if (pututline(&entry) == NULL) {
+        endutent();
+        return errno == EPERM || errno == EACCES ? UACC_UTMP_MISSING_PERMISSIONS : UACC_UTMP_WRITE_ERROR;
+    }
+    endutent();
+    updwtmp(SELECT_WTMP_PATH(wtmp_path), &entry);
+    return 0;
+}
+
+// Low level C function to mark a database entry as DEAD_PROCESS.
+// This function does not perform string argument validation.
+static int uacc_mark_utmp_entry_dead(const char *utmp_path, const char *wtmp_path, const char *tty_name) {
+    if (utmpname(SELECT_UTMP_PATH(utmp_path)) != 0) {
+        return UACC_UTMP_FAILED_TO_SELECT_FILE;
+    }
+    errno = 0;
+    setutent();
+    if (errno != 0) {
+        return UACC_UTMP_FAILED_OPEN;
+    }
+    struct utmp line;
+    strncpy((char*) &line.ut_line, tty_name, UT_LINESIZE);
+    struct utmp *entry_t = getutline(&line);
+    if (entry_t == NULL) {
+        return UACC_UTMP_READ_ERROR;
+    }
+    struct utmp entry;
+    memcpy(&entry, entry_t, sizeof(struct utmp));
+    entry.ut_type = DEAD_PROCESS;
+    errno = 0;
+    setutent();
+    if (errno != 0) {
+        return UACC_UTMP_FAILED_OPEN;
+    }
+    if (pututline(&entry) == NULL) {
+        endutent();
+        return errno == EPERM || errno == EACCES ? UACC_UTMP_MISSING_PERMISSIONS : UACC_UTMP_WRITE_ERROR;
+    }
+    endutent();
+    updwtmp(SELECT_WTMP_PATH(wtmp_path), &entry);
+    return 0;
+}
+
+// Low level C function to check the database for an entry for a given user.
+// This function does not perform string argument validation.
+static int uacc_has_entry_with_user(const char *utmp_path, const char *user) {
+    if (utmpname(SELECT_UTMP_PATH(utmp_path)) != 0) {
+        return UACC_UTMP_FAILED_TO_SELECT_FILE;
+    }
+    errno = 0;
+    setutent();
+    if (errno != 0) {
+        return UACC_UTMP_FAILED_OPEN;
+    }
+    struct utmp *entry = getutent();
+    while (entry != NULL) {
+        if (entry->ut_type == USER_PROCESS && strcmp(user, entry->ut_user) == 0) {
+            endutent();
+            return 0;
+        }
+        entry = getutent();
+    }
+    endutent();
+    return errno == 0 ? UACC_UTMP_ENTRY_DOES_NOT_EXIST : errno;
+}
+
+#endif

--- a/lib/srv/uacc/uacc_linux.go
+++ b/lib/srv/uacc/uacc_linux.go
@@ -1,0 +1,196 @@
+// +build linux
+
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package uacc concerns itself with updating the user account database and log on nodes
+that a client connects to with an interactive session.
+*/
+package uacc
+
+// #include <stdlib.h>
+// #include "uacc.h"
+import "C"
+
+import (
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/gravitational/trace"
+)
+
+// Due to thread safety design in glibc we must serialize all access to the accounting database.
+var accountDb sync.Mutex
+
+// Max length of username and hostname as defined by glibc.
+const nameMaxLen = 255
+
+// Open writes a new entry to the utmp database with a tag of `USER_PROCESS`.
+// This should be called when an interactive session is started.
+//
+// `username`: Name of the user the interactive session is running under.
+// `hostname`: Name of the system the user is logged into.
+// `remoteAddrV6`: IPv6 address of the remote host.
+// `ttyName`: Name of the TTY including the `/dev/` prefix.
+func Open(utmpPath, wtmpPath string, username, hostname string, remote [4]int32, ttyName string) error {
+	// String parameter validation.
+	if len(username) > nameMaxLen {
+		return trace.BadParameter("username length exceeds OS limits")
+	}
+	if len(hostname) > nameMaxLen {
+		return trace.BadParameter("hostname length exceeds OS limits")
+	}
+	if len(ttyName) > (int)(C.max_len_tty_name()-1) {
+		return trace.BadParameter("tty name length exceeds OS limits")
+	}
+
+	// Convert Go strings into C strings that we can pass over ffi.
+	var cUtmpPath *C.char = nil
+	var cWtmpPath *C.char = nil
+	if len(utmpPath) > 0 {
+		cUtmpPath = C.CString(utmpPath)
+		defer C.free(unsafe.Pointer(cUtmpPath))
+	}
+	if len(wtmpPath) > 0 {
+		cWtmpPath = C.CString(wtmpPath)
+		defer C.free(unsafe.Pointer(cWtmpPath))
+	}
+	cUsername := C.CString(username)
+	defer C.free(unsafe.Pointer(cUsername))
+	cHostname := C.CString(hostname)
+	defer C.free(unsafe.Pointer(cHostname))
+	cTtyName := C.CString(strings.TrimPrefix(ttyName, "/dev/"))
+	defer C.free(unsafe.Pointer(cTtyName))
+	cIDName := C.CString(strings.TrimPrefix(ttyName, "/dev/pts/"))
+	defer C.free(unsafe.Pointer(cIDName))
+
+	// Convert IPv6 array into C integer format.
+	cIP := [4]C.int{}
+	for i := 0; i < 4; i++ {
+		cIP[i] = (C.int)(remote[i])
+	}
+
+	timestamp := time.Now()
+	secondsElapsed := (C.int32_t)(timestamp.Unix())
+	microsFraction := (C.int32_t)((timestamp.UnixNano() % int64(time.Second)) / int64(time.Microsecond))
+
+	accountDb.Lock()
+	status := C.uacc_add_utmp_entry(cUtmpPath, cWtmpPath, cUsername, cHostname, &cIP[0], cTtyName, cIDName, secondsElapsed, microsFraction)
+	accountDb.Unlock()
+
+	switch status {
+	case C.UACC_UTMP_MISSING_PERMISSIONS:
+		return trace.AccessDenied("missing permissions to write to utmp/wtmp")
+	case C.UACC_UTMP_WRITE_ERROR:
+		return trace.AccessDenied("failed to add entry to utmp database")
+	case C.UACC_UTMP_FAILED_OPEN:
+		return trace.AccessDenied("failed to open user account database")
+	case C.UACC_UTMP_FAILED_TO_SELECT_FILE:
+		return trace.BadParameter("failed to select file")
+	default:
+		if status != 0 {
+			return trace.Errorf("unknown error with code %d", status)
+		}
+
+		return nil
+	}
+}
+
+// Close marks an entry in the utmp database as DEAD_PROCESS.
+// This should be called when an interactive session exits.
+//
+// The `ttyName` parameter must be the name of the TTY including the `/dev/` prefix.
+func Close(utmpPath, wtmpPath string, ttyName string) error {
+	// String parameter validation.
+	if len(ttyName) > (int)(C.max_len_tty_name()-1) {
+		return trace.BadParameter("tty name length exceeds OS limits")
+	}
+
+	// Convert Go strings into C strings that we can pass over ffi.
+	var cUtmpPath *C.char = nil
+	var cWtmpPath *C.char = nil
+	if len(utmpPath) > 0 {
+		cUtmpPath = C.CString(utmpPath)
+		defer C.free(unsafe.Pointer(cUtmpPath))
+	}
+	if len(wtmpPath) > 0 {
+		cWtmpPath = C.CString(wtmpPath)
+		defer C.free(unsafe.Pointer(cWtmpPath))
+	}
+	cTtyName := C.CString(strings.TrimPrefix(ttyName, "/dev/"))
+	defer C.free(unsafe.Pointer(cTtyName))
+
+	accountDb.Lock()
+	status := C.uacc_mark_utmp_entry_dead(cUtmpPath, cWtmpPath, cTtyName)
+	accountDb.Unlock()
+
+	switch status {
+	case C.UACC_UTMP_MISSING_PERMISSIONS:
+		return trace.AccessDenied("missing permissions to write to utmp/wtmp")
+	case C.UACC_UTMP_WRITE_ERROR:
+		return trace.AccessDenied("failed to add entry to utmp database")
+	case C.UACC_UTMP_READ_ERROR:
+		return trace.AccessDenied("failed to read and search utmp database")
+	case C.UACC_UTMP_FAILED_OPEN:
+		return trace.AccessDenied("failed to open user account database")
+	case C.UACC_UTMP_FAILED_TO_SELECT_FILE:
+		return trace.BadParameter("failed to select file")
+	default:
+		if status != 0 {
+			return trace.Errorf("unknown error with code %d", status)
+		}
+
+		return nil
+	}
+}
+
+// UserWithPtyInDatabase checks the user accounting database for the existence of an USER_PROCESS entry with the given username.
+func UserWithPtyInDatabase(utmpPath string, username string) error {
+	if len(username) > nameMaxLen {
+		return trace.BadParameter("username length exceeds OS limits")
+	}
+
+	// Convert Go strings into C strings that we can pass over ffi.
+	var cUtmpPath *C.char = nil
+	if len(utmpPath) > 0 {
+		cUtmpPath = C.CString(utmpPath)
+		defer C.free(unsafe.Pointer(cUtmpPath))
+	}
+	cUsername := C.CString(username)
+	defer C.free(unsafe.Pointer(cUsername))
+
+	accountDb.Lock()
+	status := C.uacc_has_entry_with_user(cUtmpPath, cUsername)
+	accountDb.Unlock()
+
+	switch status {
+	case C.UACC_UTMP_FAILED_OPEN:
+		return trace.AccessDenied("failed to open user account database")
+	case C.UACC_UTMP_ENTRY_DOES_NOT_EXIST:
+		return trace.NotFound("user not found")
+	case C.UACC_UTMP_FAILED_TO_SELECT_FILE:
+		return trace.BadParameter("failed to select file")
+	default:
+		if status != 0 {
+			return trace.Errorf("unknown error with code %d", status)
+		}
+
+		return nil
+	}
+}

--- a/lib/srv/uacc/uacc_stub.go
+++ b/lib/srv/uacc/uacc_stub.go
@@ -1,0 +1,43 @@
+// +build !linux
+
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package uacc concerns itself with updating the user account database and log on nodes
+that a client connects to with an interactive session.
+
+This is a stub version that doesn't do anything and exists purely for compatability purposes with systems we don't support.
+
+We do not support macOS yet because they introduced ASL for user accounting with Mac OS X 10.6 (Snow Leopard)
+and integrating with that takes additional effort.
+*/
+package uacc
+
+// Open is a stub function.
+func Open(utmpPath, wtmpPath string, username, hostname string, remote [4]int32, ttyName string) error {
+	return nil
+}
+
+// Close is a stub function.
+func Close(utmpPath, wtmpPath string, ttyName string) error {
+	return nil
+}
+
+// UserWithPtyInDatabase is a stub function.
+func UserWithPtyInDatabase(utmpPath string, username string) error {
+	return nil
+}

--- a/lib/srv/uacc/uacc_utils.go
+++ b/lib/srv/uacc/uacc_utils.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package uacc
+
+import (
+	"encoding/binary"
+	"net"
+
+	"github.com/gravitational/trace"
+)
+
+// PrepareAddr parses and transforms a net.Addr into a format usable by other uacc functions.
+func PrepareAddr(addr net.Addr) ([4]int32, error) {
+	stringIP, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return [4]int32{}, trace.Wrap(err)
+	}
+	ip := net.ParseIP(stringIP)
+	rawV6 := ip.To16()
+	groupedV6 := [4]int32{}
+	for i := range groupedV6 {
+		groupedV6[i] = int32(binary.LittleEndian.Uint32(rawV6[i*4 : (i+1)*4]))
+	}
+	return groupedV6, nil
+}


### PR DESCRIPTION
This PR introduces support for updating utmp and wtmp files on Linux with current and past interactive sessions.

This is a best-effort feature. It is only enabled on platforms where utmp/wtmp exists and will do nothing otherwise. If it lacks permissions to modify the user accounting database a warning will be logged instead of taking down the service as this is not a critical feature that needs to be enabled in all cases.

Fixes #3987