### PR TITLE
update enterprise quick start role example to 5.0 version

### DIFF
--- a/docs/5.0/enterprise/quickstart-enterprise.md
+++ b/docs/5.0/enterprise/quickstart-enterprise.md
@@ -214,10 +214,6 @@ spec:
       verbs: [list, create, read, update, delete]
   deny: {}
   options:
-    cert_format: standard
-    enhanced_recording:
-    - command
-    - network
     forward_agent: true
     max_session_ttl: 30h0m0s
     port_forwarding: true

--- a/docs/5.0/enterprise/quickstart-enterprise.md
+++ b/docs/5.0/enterprise/quickstart-enterprise.md
@@ -185,18 +185,18 @@ metadata:
 spec:
   allow:
     logins:
-    - '{% raw %}{{internal.logins}}{% endraw %}'
+    - '{{internal.logins}}'
     - root
     node_labels:
       '*': '*'
     app_labels:
       '*': '*'
     kubernetes_groups:
-    - '{% raw %}{{internal.kubernetes_groups}}{% endraw %}'
+    - '{{internal.kubernetes_groups}}'
     kubernetes_labels:
       '*': '*'
     kubernetes_users:
-    - '{% raw %}{{internal.kubernetes_users}}{% endraw %}'
+    - '{{internal.kubernetes_users}}'
     rules:
     - resources: [role]
       verbs: [list, create, read, update, delete]
@@ -225,7 +225,7 @@ role only allows SSH logins as `root@host`.
 
 !!! note "Note"
 
-    Ignore `{% raw %}{{internal.logins}}{% endraw %}` "allowed login" for now. It exists for
+    Ignore `{{internal.logins}}` "allowed login" for now. It exists for
     compatibility purposes when upgrading existing open source Teleport
     clusters.
 

--- a/docs/5.0/enterprise/quickstart-enterprise.md
+++ b/docs/5.0/enterprise/quickstart-enterprise.md
@@ -180,7 +180,7 @@ representation for brevity):
 ```yaml
 
 kind: role
-metadata:  
+metadata:
   name: admin
 spec:
   allow:
@@ -188,7 +188,7 @@ spec:
     - '{% raw %}{{internal.logins}}{% endraw %}'
     - root
     node_labels:
-      '*': '*'  
+      '*': '*'
     app_labels:
       '*': '*'
     kubernetes_groups:
@@ -207,7 +207,7 @@ spec:
     - resources: [session]
       verbs: [list, read]
     - resources: [event]
-      verbs: [list, read]      
+      verbs: [list, read]
     - resources: [trusted_cluster]
       verbs: [list, create, read, update, delete]
     - resources: [token]

--- a/docs/5.0/enterprise/quickstart-enterprise.md
+++ b/docs/5.0/enterprise/quickstart-enterprise.md
@@ -178,34 +178,50 @@ The output will look like this (re-formatted here to use compact YAML
 representation for brevity):
 
 ```yaml
+
 kind: role
-version: v3
-metadata:
+metadata:  
   name: admin
 spec:
-  options:
-    cert_format: standard
-    forward_agent: true
-    max_session_ttl: 30h0m0s
-    port_forwarding: true
-  # allow rules:
   allow:
     logins:
     - '{% raw %}{{internal.logins}}{% endraw %}'
     - root
     node_labels:
+      '*': '*'  
+    app_labels:
       '*': '*'
+    kubernetes_groups:
+    - '{% raw %}{{internal.kubernetes_groups}}{% endraw %}'
+    kubernetes_labels:
+      '*': '*'
+    kubernetes_users:
+    - '{% raw %}{{internal.kubernetes_users}}{% endraw %}'
     rules:
     - resources: [role]
       verbs: [list, create, read, update, delete]
     - resources: [auth_connector]
       verbs: [list, create, read, update, delete]
+    - resources: [user]
+      verbs: [list, create, read, update, delete]
     - resources: [session]
       verbs: [list, read]
+    - resources: [event]
+      verbs: [list, read]      
     - resources: [trusted_cluster]
       verbs: [list, create, read, update, delete]
-  # no deny rules are present, the admin role must have access to everything)
+    - resources: [token]
+      verbs: [list, create, read, update, delete]
   deny: {}
+  options:
+    cert_format: standard
+    enhanced_recording:
+    - command
+    - network
+    forward_agent: true
+    max_session_ttl: 30h0m0s
+    port_forwarding: true
+version: v3
 ```
 
 Pay attention to the _allow/logins_ field in the role definition: by default, this
@@ -226,6 +242,10 @@ to look like this:
 allow:
    logins: [admin]
 ```
+
+!!! note "Note"
+
+    See the [Kubernetes Guide](../kubernetes-access.md) and [Application Guide](../application-access.md) for enabling access to additional resources.
 
 Then send it back into Teleport:
 


### PR DESCRIPTION
includes k8s, app elements along with resources required for admins (tokens,...).  Also refers to other guides the user may be looking into providing access besides ssh.