### PR TITLE
Add linting for Helm charts with example values

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -68,6 +68,11 @@ RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.24.0
      cp golangci-lint-1.24.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ && \
      rm -r golangci-lint*)
 
+# Install helm.
+RUN (mkdir -p helm-tarball && curl -L https://get.helm.sh/helm-v3.5.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C helm-tarball -xz && \
+     cp helm-tarball/$(go env GOOS)-$(go env GOARCH)/helm /bin/ && \
+     rm -r helm-tarball*)
+
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install

--- a/examples/chart/teleport-cluster/.lint/lint-values.yaml
+++ b/examples/chart/teleport-cluster/.lint/lint-values.yaml
@@ -1,0 +1,1 @@
+clusterName: test-cluster-name

--- a/examples/chart/teleport-cluster/templates/psp.yaml
+++ b/examples/chart/teleport-cluster/templates/psp.yaml
@@ -48,7 +48,7 @@ rules:
   resourceNames:
   - {{ .Release.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-psp

--- a/examples/chart/teleport-kube-agent/.lint/lint-values-all-v5.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/lint-values-all-v5.yaml
@@ -1,0 +1,11 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube,app,db
+kubeClusterName: test-kube-cluster-name
+labels:
+  cluster: testing
+apps:
+  - name: grafana
+    uri: http://localhost:3000
+    labels:
+      environment: test

--- a/examples/chart/teleport-kube-agent/.lint/lint-values-all-v6.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/lint-values-all-v6.yaml
@@ -1,0 +1,18 @@
+teleportVersionOverride: 6
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube,app,db
+kubeClusterName: test-kube-cluster-name
+labels:
+  cluster: testing
+apps:
+  - name: grafana
+    uri: http://localhost:3000
+    labels:
+      environment: test
+databases:
+  - name: aurora
+    uri: "postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432"
+    protocol: "postgres"
+    labels:
+      database: staging

--- a/examples/chart/teleport-kube-agent/.lint/lint-values-backwards-compatibility.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/lint-values-backwards-compatibility.yaml
@@ -1,0 +1,3 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name

--- a/examples/chart/teleport-kube-agent/.lint/lint-values-db.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/lint-values-db.yaml
@@ -1,0 +1,10 @@
+teleportVersionOverride: 6
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: db
+databases:
+  - name: aurora
+    uri: "postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432"
+    protocol: "postgres"
+    labels:
+      database: staging

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -111,7 +111,7 @@ $ helm install teleport-kube-agent . \
   --set authToken=${JOIN_TOKEN?} \
   --set "databases[0].name=${DB_NAME?}" \
   --set "databases[0].uri=${DB_URI?}" \
-  --set "databases[0].protocol=${DB_PROTOCOL}"
+  --set "databases[0].protocol=${DB_PROTOCOL?}"
 ```
 
 Set the values in the above command as appropriate for your setup.

--- a/examples/chart/teleport-kube-agent/templates/psp.yaml
+++ b/examples/chart/teleport-kube-agent/templates/psp.yaml
@@ -48,7 +48,7 @@ rules:
   resourceNames:
   - {{ .Release.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-psp

--- a/examples/chart/teleport/templates/service.yaml
+++ b/examples/chart/teleport/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
 {{- if and .Values.service.loadBalancerSourceRanges (eq .Values.service.type "LoadBalancer") }}
   loadBalancerSourceRanges:
 {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
-{{- end }}    
+{{- end }}
   ports:
 {{- range $key, $value := .Values.service.ports }}
 {{ if  or (not $.Values.config.highAvailability) (and ($.Values.config.highAvailability) (not (eq $key "authssh")))   }}
@@ -51,7 +51,7 @@ spec:
 {{- if and .Values.config.authService.loadBalancerSourceRanges (eq .Values.config.authService.type "LoadBalancer") }}
   loadBalancerSourceRanges:
 {{ toYaml .Values.config.authService.loadBalancerSourceRanges | indent 4 }}
-{{- end }}    
+{{- end }}
   ports:
     - name: authssh
       port: {{ .Values.ports.authssh.containerPort }}

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -159,7 +159,7 @@ config:
         enabled: yes
         # Specify a different hostname for the k8s public address (if different to config.public_address)
         # public_addr: teleportkubernetes.example.com
-        
+
 
 # Alternatively you can provide your teleport configuration under teleportConfig with static text. No variable substitution.
 otherConfig:


### PR DESCRIPTION
This was a random idea I had as Helm charts are becoming much more important; we should enforce running `helm lint` with some sample values on all our charts as part of CI to make sure that they don't have obvious typos/errors in.

This PR also:
- runs `helm template` with the same sample values to make sure there aren't any failures there.
- fixes all lint errors/warnings
- reorders linting to run the quicker jobs first
- removes trailing whitespace from Helm charts

We could potentially extend this in future with automatic linting of templated content - this is something that needs a bit more thought however.