### PR TITLE
tsh scp to use target directory correctly

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1514,10 +1514,6 @@ func (tc *TeleportClient) SCP(ctx context.Context, args []string, port int, flag
 			return trace.Wrap(err)
 		}
 
-		if len(filesToUpload) == 1 && utils.IsFile(filesToUpload[0]) {
-			flags.Recursive = false
-		}
-
 		// copy everything except the last arg (that's destination)
 		for _, src := range filesToUpload {
 			scpConfig := scp.Config{

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1463,21 +1463,24 @@ func (tc *TeleportClient) SCP(ctx context.Context, args []string, port int, flag
 	}
 	defer proxyClient.Close()
 
+	var progressWriter io.Writer
+	if !quiet {
+		progressWriter = tc.Stdout
+	}
+
 	// helper function connects to the src/target node:
-	connectToNode := func(addr string) (*NodeClient, error) {
+	connectToNode := func(addr, hostLogin string) (*NodeClient, error) {
 		// determine which cluster we're connecting to:
 		siteInfo, err := proxyClient.currentCluster()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+		if hostLogin == "" {
+			hostLogin = tc.Config.HostLogin
+		}
 		return proxyClient.ConnectToNode(ctx,
 			NodeAddr{Addr: addr, Namespace: tc.Namespace, Cluster: siteInfo.Name},
-			tc.HostLogin, false)
-	}
-
-	var progressWriter io.Writer
-	if !quiet {
-		progressWriter = tc.Stdout
+			hostLogin, false)
 	}
 
 	// gets called to convert SSH error code to tc.ExitStatus
@@ -1488,89 +1491,102 @@ func (tc *TeleportClient) SCP(ctx context.Context, args []string, port int, flag
 		}
 		return err
 	}
-	var exitErr error
+
+	tpl := scp.Config{
+		User:           tc.Username,
+		ProgressWriter: progressWriter,
+		Flags:          flags,
+	}
+
+	var config *scpConfig
 	// upload:
 	if isRemoteDest(last) {
-		filesToUpload := args[:len(args)-1]
-
-		// If more than a single file were provided, scp must be in directory mode
-		// and the target on the remote host needs to be a directory.
-		var directoryMode bool
-		if len(filesToUpload) > 1 {
-			directoryMode = true
-		}
-
-		dest, err := scp.ParseSCPDestination(last)
+		config, err = tc.uploadConfig(ctx, tpl, port, args)
 		if err != nil {
 			return trace.Wrap(err)
-		}
-		if dest.Login != "" {
-			tc.HostLogin = dest.Login
-		}
-		addr := net.JoinHostPort(dest.Host.Host(), strconv.Itoa(port))
-
-		client, err := connectToNode(addr)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		// copy everything except the last arg (that's destination)
-		for _, src := range filesToUpload {
-			scpConfig := scp.Config{
-				User:           tc.Username,
-				ProgressWriter: progressWriter,
-				RemoteLocation: dest.Path,
-				Flags:          flags,
-			}
-			scpConfig.Flags.Target = []string{src}
-			scpConfig.Flags.DirectoryMode = directoryMode
-
-			cmd, err := scp.CreateUploadCommand(scpConfig)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-
-			err = client.ExecuteSCP(ctx, cmd)
-			if err != nil {
-				exitErr = err
-			}
 		}
 	} else {
-		// download:
-		src, err := scp.ParseSCPDestination(first)
+		config, err = tc.downloadConfig(ctx, tpl, port, args)
 		if err != nil {
 			return trace.Wrap(err)
-		}
-		addr := net.JoinHostPort(src.Host.Host(), strconv.Itoa(port))
-		if src.Login != "" {
-			tc.HostLogin = src.Login
-		}
-		client, err := connectToNode(addr)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		// copy everything except the last arg (that's destination)
-		for _, dest := range args[1:] {
-			scpConfig := scp.Config{
-				User:           tc.Username,
-				Flags:          flags,
-				RemoteLocation: src.Path,
-				ProgressWriter: progressWriter,
-			}
-			scpConfig.Flags.Target = []string{dest}
-
-			cmd, err := scp.CreateDownloadCommand(scpConfig)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-
-			err = client.ExecuteSCP(ctx, cmd)
-			if err != nil {
-				exitErr = err
-			}
 		}
 	}
-	return onError(exitErr)
+
+	client, err := connectToNode(config.addr, config.hostLogin)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return onError(client.ExecuteSCP(ctx, config.cmd))
+}
+
+func (tc *TeleportClient) uploadConfig(ctx context.Context, tpl scp.Config, port int, args []string) (config *scpConfig, err error) {
+	filesToUpload := args[:len(args)-1]
+	// copy everything except the last arg (the destination)
+	destPath := args[len(args)-1]
+
+	// If more than a single file were provided, scp must be in directory mode
+	// and the target on the remote host needs to be a directory.
+	var directoryMode bool
+	if len(filesToUpload) > 1 {
+		directoryMode = true
+	}
+
+	dest, addr, err := getSCPDestination(destPath, port)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tpl.RemoteLocation = dest.Path
+	tpl.Flags.Target = filesToUpload
+	tpl.Flags.DirectoryMode = directoryMode
+
+	cmd, err := scp.CreateUploadCommand(tpl)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &scpConfig{
+		cmd:       cmd,
+		addr:      addr,
+		hostLogin: dest.Login,
+	}, nil
+}
+
+func (tc *TeleportClient) downloadConfig(ctx context.Context, tpl scp.Config, port int, args []string) (config *scpConfig, err error) {
+	src, addr, err := getSCPDestination(args[0], port)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tpl.RemoteLocation = src.Path
+	tpl.Flags.Target = args[1:]
+
+	cmd, err := scp.CreateDownloadCommand(tpl)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &scpConfig{
+		cmd:       cmd,
+		addr:      addr,
+		hostLogin: src.Login,
+	}, nil
+}
+
+type scpConfig struct {
+	cmd       scp.Command
+	addr      string
+	hostLogin string
+}
+
+func getSCPDestination(target string, port int) (dest *scp.Destination, addr string, err error) {
+	dest, err = scp.ParseSCPDestination(target)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	addr = net.JoinHostPort(dest.Host.Host(), strconv.Itoa(port))
+	return dest, addr, nil
 }
 
 func isRemoteDest(name string) bool {

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -639,7 +639,7 @@ func (c *ServerContext) SendExecResult(r ExecResult) {
 	select {
 	case c.ExecResultCh <- r:
 	default:
-		log.Infof("blocked on sending exec result %v", r)
+		c.Infof("Blocked on sending exec result %v.", r)
 	}
 }
 
@@ -649,7 +649,7 @@ func (c *ServerContext) SendSubsystemResult(r SubsystemResult) {
 	select {
 	case c.SubsystemResultCh <- r:
 	default:
-		c.Infof("blocked on sending subsystem result")
+		c.Info("Blocked on sending subsystem result.")
 	}
 }
 

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -149,20 +149,14 @@ func (e *localExec) Start(channel ssh.Channel) (*ExecResult, error) {
 
 	// Connect stdout and stderr to the channel so the user can interact with
 	// the command.
-	e.Cmd.Stderr = channel.Stderr()
-	e.Cmd.Stdout = channel
+	e.Cmd.Stderr = io.MultiWriter(os.Stderr, channel.Stderr())
+	e.Cmd.Stdout = io.MultiWriter(os.Stdout, channel)
 
 	// Copy from the channel (client input) into stdin of the process.
 	inputWriter, err := e.Cmd.StdinPipe()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	go func() {
-		if _, err := io.Copy(inputWriter, channel); err != nil {
-			e.Ctx.Warningf("Failed to forward data from SSH channel to local command %q stdin: %v", e.GetCommand(), err)
-		}
-		inputWriter.Close()
-	}()
 
 	// Start the command.
 	err = e.Cmd.Start()
@@ -178,6 +172,13 @@ func (e *localExec) Start(channel ssh.Channel) (*ExecResult, error) {
 		}, trace.ConvertSystemError(err)
 	}
 
+	go func() {
+		if _, err := io.Copy(inputWriter, channel); err != nil {
+			e.Ctx.Warnf("Failed to forward data from SSH channel to local command %q stdin: %v", e.GetCommand(), err)
+		}
+		inputWriter.Close()
+	}()
+
 	e.Ctx.Infof("Started local command execution: %q", e.Command)
 
 	return nil, nil
@@ -186,7 +187,7 @@ func (e *localExec) Start(channel ssh.Channel) (*ExecResult, error) {
 // Wait will block while the command executes.
 func (e *localExec) Wait() *ExecResult {
 	if e.Cmd.Process == nil {
-		e.Ctx.Errorf("no process")
+		e.Ctx.Error("No process.")
 	}
 
 	// Block until the command is finished executing.

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -90,6 +90,8 @@ type Config struct {
 	// RunOnServer is low level API flag that indicates that
 	// this command will be run on the server
 	RunOnServer bool
+	// Log optionally specifies the logger
+	Log log.FieldLogger
 }
 
 // Command is an API that describes command operations
@@ -167,10 +169,25 @@ func CreateUploadCommand(cfg Config) (Command, error) {
 
 // CheckAndSetDefaults checks and sets default values
 func (c *Config) CheckAndSetDefaults() error {
+	logger := c.Log
+	if logger == nil {
+		logger = log.StandardLogger()
+	}
+	c.Log = logger.WithFields(log.Fields{
+		trace.Component: "SCP",
+		trace.ComponentFields: log.Fields{
+			"LocalAddr":      c.Flags.LocalAddr,
+			"RemoteAddr":     c.Flags.RemoteAddr,
+			"Target":         c.Flags.Target,
+			"PreserveAttrs":  c.Flags.PreserveAttrs,
+			"User":           c.User,
+			"RunOnServer":    c.RunOnServer,
+			"RemoteLocation": c.RemoteLocation,
+		},
+	})
 	if c.FileSystem == nil {
 		c.FileSystem = &localFileSystem{}
 	}
-
 	if c.User == "" {
 		return trace.BadParameter("missing User parameter")
 	}
@@ -186,31 +203,17 @@ func CreateCommand(cfg Config) (Command, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	cmd := command{
+	return &command{
 		Config: cfg,
-	}
-
-	cmd.log = log.WithFields(log.Fields{
-		trace.Component: "SCP",
-		trace.ComponentFields: log.Fields{
-			"LocalAddr":      cfg.Flags.LocalAddr,
-			"RemoteAddr":     cfg.Flags.RemoteAddr,
-			"Target":         cfg.Flags.Target,
-			"PreserveAttrs":  cfg.Flags.PreserveAttrs,
-			"User":           cfg.User,
-			"RunOnServer":    cfg.RunOnServer,
-			"RemoteLocation": cfg.RemoteLocation,
-		},
-	})
-
-	return &cmd, nil
+		log:    cfg.Log,
+	}, nil
 }
 
 // Command mimics behavior of SCP command line tool
 // to teleport can pretend it launches real SCP behind the scenes
 type command struct {
 	Config
-	log *log.Entry
+	log log.FieldLogger
 }
 
 // Execute implements SSH file copy (SCP). It is called on both tsh (client)
@@ -333,7 +336,7 @@ func (cmd *command) sendDir(r *reader, ch io.ReadWriter, fileInfo FileInfo) erro
 	if _, err = fmt.Fprintf(ch, "E\n"); err != nil {
 		return trace.Wrap(err)
 	}
-	return r.read()
+	return trace.Wrap(r.read())
 }
 
 func (cmd *command) sendFile(r *reader, ch io.ReadWriter, fileInfo FileInfo) error {
@@ -386,23 +389,25 @@ func (cmd *command) serveSink(ch io.ReadWriter) error {
 	// directory.
 	if cmd.Flags.DirectoryMode {
 		if len(cmd.Flags.Target) != 1 {
-			return trace.BadParameter("in directory mode, only single upload target is allowed but %v provided", len(cmd.Flags.Target))
+			return trace.BadParameter("in directory mode, only single upload target is allowed but %q provided",
+				cmd.Flags.Target)
 		}
-
-		fi, err := os.Stat(cmd.Flags.Target[0])
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if mode := fi.Mode(); !mode.IsDir() {
+		if !cmd.FileSystem.IsDir(cmd.Flags.Target[0]) {
 			return trace.BadParameter("target path must be a directory")
 		}
+	}
+
+	rootDir := localDir
+	if len(cmd.Flags.Target) != 0 && cmd.FileSystem.IsDir(cmd.Flags.Target[0]) {
+		rootDir = newPathFromDir(cmd.Flags.Target[0])
 	}
 
 	if err := sendOK(ch); err != nil {
 		return trace.Wrap(err)
 	}
+
 	var st state
-	st.path = localDir
+	st.path = rootDir
 	var b [1]byte
 	scanner := bufio.NewScanner(ch)
 	for {
@@ -478,14 +483,13 @@ func (cmd *command) processCommand(ch io.ReadWriter, st *state, b byte, line str
 func (cmd *command) receiveFile(st *state, fc newFileCmd, ch io.ReadWriter) error {
 	cmd.log.Debugf("scp.receiveFile(%v): %v", cmd.Flags.Target, fc.Name)
 
-	// if the destination path is a folder, we should save the file to that folder, but
-	// only if 'recursive' is set
-
-	path := cmd.Flags.Target[0]
-	if cmd.Flags.Recursive || cmd.FileSystem.IsDir(path) {
-		path = st.makePath(fc.Name)
+	// Unless target specifies a file, use the file name from the command
+	filename := fc.Name
+	if !cmd.Flags.Recursive && !cmd.FileSystem.IsDir(cmd.Flags.Target[0]) {
+		filename = cmd.Flags.Target[0]
 	}
 
+	path := st.makePath(filename)
 	writer, err := cmd.FileSystem.CreateFile(path, fc.Length)
 	if err != nil {
 		return trace.Wrap(err)
@@ -504,7 +508,6 @@ func (cmd *command) receiveFile(st *state, fc newFileCmd, ch io.ReadWriter) erro
 
 	n, err := io.CopyN(writer, ch, int64(fc.Length))
 	if err != nil {
-		cmd.log.Error(err)
 		return trace.Wrap(err)
 	}
 
@@ -528,15 +531,9 @@ func (cmd *command) receiveFile(st *state, fc newFileCmd, ch io.ReadWriter) erro
 
 func (cmd *command) receiveDir(st *state, fc newFileCmd, ch io.ReadWriter) error {
 	cmd.log.Debugf("scp.receiveDir(%v): %v", cmd.Flags.Target, fc.Name)
-	targetDir := cmd.Flags.Target[0]
 
-	// copying into an existing directory? append to it:
-	if cmd.FileSystem.IsDir(targetDir) {
-		targetDir = st.makePath(fc.Name)
-	}
 	st.push(fc.Name, st.stat)
-
-	err := cmd.FileSystem.MkDir(targetDir, int(fc.Mode))
+	err := cmd.FileSystem.MkDir(st.path.join(), int(fc.Mode))
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
@@ -597,6 +594,10 @@ func (cmd *command) updateDirTimes(path pathSegments) error {
 		}
 	}
 	return nil
+}
+
+func (r newFileCmd) String() string {
+	return fmt.Sprintf("newFileCmd(mode=%o,len=%d,name=%v)", r.Mode, r.Length, r.Name)
 }
 
 type newFileCmd struct {
@@ -675,15 +676,19 @@ type state struct {
 	stat *mtimeCmd
 }
 
-func (r pathSegments) join() string {
+func (r pathSegments) join(elems ...string) string {
 	path := make([]string, 0, len(r))
 	for _, s := range r {
 		path = append(path, s.dir)
 	}
-	return filepath.Join(path...)
+	return filepath.Join(append(path, elems...)...)
 }
 
-var localDir = pathSegments{{dir: "."}}
+var localDir = newPathFromDir(".")
+
+func newPathFromDir(dir string) pathSegments {
+	return pathSegments{{dir: dir}}
+}
 
 type pathSegments []pathSegment
 
@@ -710,7 +715,7 @@ func (st *state) pop() pathSegments {
 }
 
 func (st *state) makePath(filename string) string {
-	return filepath.Join(st.path.join(), filename)
+	return st.path.join(filename)
 }
 
 func newReader(r io.Reader) *reader {

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -378,7 +378,7 @@ func (cmd *command) sendFile(r *reader, ch io.ReadWriter, fileInfo FileInfo) err
 func (cmd *command) sendErr(ch io.Writer, err error) {
 	out := fmt.Sprintf("%c%s\n", byte(ErrByte), err)
 	if _, err := ch.Write([]byte(out)); err != nil {
-		cmd.log.Debugf("failed sending SCP error message to the remote side: %v", err)
+		cmd.log.Debugf("Failed sending SCP error message to the remote side: %v.", err)
 	}
 }
 

--- a/lib/sshutils/scp/scp.go
+++ b/lib/sshutils/scp/scp.go
@@ -398,7 +398,7 @@ func (cmd *command) serveSink(ch io.ReadWriter) error {
 	}
 
 	rootDir := localDir
-	if len(cmd.Flags.Target) != 0 && cmd.FileSystem.IsDir(cmd.Flags.Target[0]) {
+	if cmd.hasTargetDir() {
 		rootDir = newPathFromDir(cmd.Flags.Target[0])
 	}
 
@@ -594,6 +594,10 @@ func (cmd *command) updateDirTimes(path pathSegments) error {
 		}
 	}
 	return nil
+}
+
+func (cmd *command) hasTargetDir() bool {
+	return len(cmd.Flags.Target) != 0 && cmd.FileSystem.IsDir(cmd.Flags.Target[0])
 }
 
 func (r newFileCmd) String() string {

--- a/lib/sshutils/scp/scp_test.go
+++ b/lib/sshutils/scp/scp_test.go
@@ -241,7 +241,6 @@ func TestReceiveIntoExistingDirectory(t *testing.T) {
 	)
 	sourceFS := newTestFS(
 		logger,
-		// Use timestamps extending backwards to test time application
 		newDir("dir",
 			newFile("dir/file", "file contents"),
 			newDir("dir/dir2",
@@ -250,21 +249,18 @@ func TestReceiveIntoExistingDirectory(t *testing.T) {
 	)
 	expectedFS := newTestFS(
 		logger,
-		// Use timestamps extending backwards to test time application
+		// Source is copied into an existing directory
 		newDir("dir/dir",
 			newFile("dir/dir/file", "file contents"),
 			newDir("dir/dir/dir2",
 				newFile("dir/dir/dir2/file2", "file2 contents")),
 		),
 	)
-	cmd, err := CreateCommand(config)
-	require.NoError(t, err)
-
 	sourceDir := t.TempDir()
 	source := filepath.Join(sourceDir, config.Flags.Target[0])
 	args := append(args("-v", "-f", "-r", "-p"), source)
 
-	cmd, err = CreateCommand(config)
+	cmd, err := CreateCommand(config)
 	require.NoError(t, err)
 
 	writeData(t, sourceDir, sourceFS)

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -75,10 +75,19 @@ func (r *RemoveDirCloser) Close() error {
 }
 
 // IsDir is a helper function to quickly check if a given path is a valid directory
-func IsDir(dirPath string) bool {
-	fi, err := os.Stat(dirPath)
+func IsDir(path string) bool {
+	fi, err := os.Stat(path)
 	if err == nil {
 		return fi.IsDir()
+	}
+	return false
+}
+
+// IsFile is a convenience helper to check if the given path is a regular file
+func IsFile(path string) bool {
+	fi, err := os.Stat(path)
+	if err == nil {
+		return fi.Mode().IsRegular()
 	}
 	return false
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1410,7 +1410,7 @@ func onSCP(cf *CLIConf) error {
 		PreserveAttrs: cf.PreserveAttrs,
 	}
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
-		return tc.SCP(context.TODO(), cf.CopySpec, int(cf.NodePort), flags, cf.Quiet)
+		return tc.SCP(cf.Context, cf.CopySpec, int(cf.NodePort), flags, cf.Quiet)
 	})
 	if err != nil {
 		// exit with the same exit status as the failed command:

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1412,16 +1412,15 @@ func onSCP(cf *CLIConf) error {
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
 		return tc.SCP(cf.Context, cf.CopySpec, int(cf.NodePort), flags, cf.Quiet)
 	})
-	if err != nil {
-		// exit with the same exit status as the failed command:
-		if tc.ExitStatus != 0 {
-			fmt.Fprintln(os.Stderr, utils.UserMessageFromError(err))
-			os.Exit(tc.ExitStatus)
-		} else {
-			return trace.Wrap(err)
-		}
+	if err == nil {
+		return nil
 	}
-	return nil
+	// exit with the same exit status as the failed command:
+	if tc.ExitStatus != 0 {
+		fmt.Fprintln(os.Stderr, utils.UserMessageFromError(err))
+		os.Exit(tc.ExitStatus)
+	}
+	return trace.Wrap(err)
 }
 
 // makeClient takes the command-line configuration and constructs & returns


### PR DESCRIPTION
Fixes the scp behavior error I introduced when working on adding support for preserving file times [here](https://github.com/gravitational/teleport/issues/2889).

This now takes target directory into account in sink mode as previously.

Also, while looking into https://github.com/gravitational/teleport/issues/3235 I noticed that the low disk space condition is not reported properly to the user. Now, the error is exposed to show what's failed.
Additionally, when copying big(ger) files, I noticed that interrupting the command did not work and only exited once the file copy was completed:

```
tsh scp -r files/1g.img root@teleport-node:/root/
^C
```

### Copying a large file to the node that's low on space:

Before:
```
$ tsh scp -r files/1g.img root@teleport-node:/root/files/
error: Process exited with status 1
```
With multiple files:
```
$ tsh scp -r files/* root@teleport-node:/root/files/
error: Process exited with status 1
```

After:
```
$ tsh scp  files/1g.img root@teleport-node:/root/files
error: write /root/files/1g.img: no space left on device
error: Process exited with status 1
```
With multiple files:
```
$ tsh scp files/* root@teleport-node:/root/files
error: write /root/files/1g.img: no space left on device
error: write /root/files/2g.img: no space left on device
error: write /root/files/test1.img: no space left on device
error: write /root/files/test2.img: no space left on device
error: write /root/files/test.img: no space left on device
error: Process exited with status 1
```

Fixes https://github.com/gravitational/teleport/issues/5497.
Updates https://github.com/gravitational/teleport/issues/3235.