### PR TITLE
YAML error when coping and pasting

### DIFF
--- a/docs/5.0/quickstart.md
+++ b/docs/5.0/quickstart.md
@@ -134,10 +134,10 @@ Replace `teleport.example.com` with the domain name you configured above.
 # Replace `teleport.example.com` with your domain name.
 export TELEPORT_PUBLIC_DNS_NAME="teleport.example.com"
 cat >> /etc/teleport.yaml <<EOF
-  public_addr: $TELEPORT_PUBLIC_DNS_NAME:3080
-  https_keypairs:
-    - key_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/privkey.pem
-      cert_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/fullchain.pem
+    public_addr: $TELEPORT_PUBLIC_DNS_NAME:3080
+    https_keypairs:
+      - key_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/privkey.pem
+        cert_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/fullchain.pem
 EOF
 ```
 


### PR DESCRIPTION
I copied and pasted the quickstart and found that the indentation is off for things to work smoothly out of the box. This fixes it.
