### PR TITLE
Remove all not-implemented APIs

### DIFF
--- a/api/client/sessions.go
+++ b/api/client/sessions.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 
-	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -58,11 +57,6 @@ func (r *webSessions) List(ctx context.Context) ([]types.WebSession, error) {
 		out = append(out, session)
 	}
 	return out, nil
-}
-
-// Upsert not implemented: can only be called locally.
-func (r *webSessions) Upsert(ctx context.Context, session types.WebSession) error {
-	return trace.NotImplemented(notImplementedMessage)
 }
 
 // Delete deletes the web session specified with the request
@@ -120,11 +114,6 @@ func (r *webTokens) List(ctx context.Context) ([]types.WebToken, error) {
 	return out, nil
 }
 
-// Upsert not implemented: can only be called locally.
-func (r *webTokens) Upsert(ctx context.Context, token types.WebToken) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
 // Delete deletes the web token specified with the request
 func (r *webTokens) Delete(ctx context.Context, req types.DeleteWebTokenRequest) error {
 	_, err := r.c.grpc.DeleteWebToken(ctx, &req)
@@ -146,5 +135,3 @@ func (r *webTokens) DeleteAll(ctx context.Context) error {
 type webTokens struct {
 	c *Client
 }
-
-const notImplementedMessage = "not implemented: can only be called by auth locally"

--- a/api/types/session.go
+++ b/api/types/session.go
@@ -336,14 +336,6 @@ type WebTokenInterface interface {
 	DeleteAll(context.Context) error
 }
 
-// LocalWebTokens manages web tokens on the auth server
-type LocalWebTokens interface {
-	WebTokenInterface
-
-	// Upsert updates existing or inserts a new web token.
-	Upsert(ctx context.Context, token WebToken) error
-}
-
 // WebToken is a time-limited unique token bound to a user's session
 type WebToken interface {
 	// Resource represents common properties for all resources.

--- a/api/types/session.go
+++ b/api/types/session.go
@@ -40,9 +40,6 @@ type WebSessionInterface interface {
 	// List gets all regular web sessions.
 	List(context.Context) ([]WebSession, error)
 
-	// Upsert updates existing or inserts a new web session.
-	Upsert(ctx context.Context, session WebSession) error
-
 	// Delete deletes the web session described by req.
 	Delete(ctx context.Context, req DeleteWebSessionRequest) error
 
@@ -332,14 +329,19 @@ type WebTokenInterface interface {
 	// List gets all web tokens.
 	List(context.Context) ([]WebToken, error)
 
-	// Upsert updates existing or inserts a new web token.
-	Upsert(ctx context.Context, token WebToken) error
-
 	// Delete deletes the web token described by req.
 	Delete(ctx context.Context, req DeleteWebTokenRequest) error
 
 	// DeleteAll removes all web tokens.
 	DeleteAll(context.Context) error
+}
+
+// LocalWebTokens manages web tokens on the auth server
+type LocalWebTokens interface {
+	WebTokenInterface
+
+	// Upsert updates existing or inserts a new web token.
+	Upsert(ctx context.Context, token WebToken) error
 }
 
 // WebToken is a time-limited unique token bound to a user's session

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2792,7 +2792,7 @@ func waitForNodeCount(t *TeleInstance, clusterName string, count int) error {
 func waitForTunnelConnections(c *check.C, authServer *auth.Server, clusterName string, expectedCount int) {
 	var conns []services.TunnelConnection
 	for i := 0; i < 30; i++ {
-		conns, err := authServer.LocalPresence.GetTunnelConnections(clusterName)
+		conns, err := authServer.ServerPresence.GetTunnelConnections(clusterName)
 		if err != nil {
 			c.Fatal(err)
 		}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2792,7 +2792,7 @@ func waitForNodeCount(t *TeleInstance, clusterName string, count int) error {
 func waitForTunnelConnections(c *check.C, authServer *auth.Server, clusterName string, expectedCount int) {
 	var conns []services.TunnelConnection
 	for i := 0; i < 30; i++ {
-		conns, err := authServer.Presence.GetTunnelConnections(clusterName)
+		conns, err := authServer.LocalPresence.GetTunnelConnections(clusterName)
 		if err != nil {
 			c.Fatal(err)
 		}

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -53,14 +53,14 @@ type Announcer interface {
 	UpsertDatabaseServer(context.Context, types.DatabaseServer) (*services.KeepAlive, error)
 }
 
-// LocalAnnouncer manages presence on auth server
-type LocalAnnouncer interface {
+// ServerAnnouncer manages presence on auth server
+type ServerAnnouncer interface {
 	Announcer
-	KeepAliver
+	keepAliver
 }
 
-// KeepAliver creates new keep-alives
-type KeepAliver interface {
+// keepAliver creates new keep-alives
+type keepAliver interface {
 	// NewKeepAliver returns a new instance of keep aliver
 	NewKeepAliver(ctx context.Context) (types.KeepAliver, error)
 }
@@ -165,10 +165,10 @@ type AccessPoint interface {
 	DeleteTunnelConnection(clusterName, connName string) error
 }
 
-// ClientAccessPoint represents an AccessPoint for the client API
+// ClientAccessPoint represents client side AccessPoint
 type ClientAccessPoint interface {
 	AccessPoint
-	KeepAliver
+	keepAliver
 }
 
 // AccessCache is a subset of the interface working on the certificate authorities
@@ -202,24 +202,6 @@ type Cache interface {
 
 	// NewWatcher returns a new event watcher
 	NewWatcher(ctx context.Context, watch services.Watch) (services.Watcher, error)
-}
-
-// CertAuthorityRotator manages rotation of cert authorities
-type CertAuthorityRotator interface {
-	// RotateCertAuthority starts or restarts certificate authority rotation process.
-	RotateCertAuthority(RotateRequest) error
-
-	// RotateExternalCertAuthority rotates external certificate authority,
-	// this method is used to update only public keys and certificates of the
-	// the certificate authorities of trusted clusters.
-	RotateExternalCertAuthority(services.CertAuthority) error
-}
-
-// KeyGenerator generates new server keys
-type KeyGenerator interface {
-	// GenerateServerKeys generates new host private keys and certificates (signed
-	// by the host certificate authority) for a node
-	GenerateServerKeys(GenerateServerKeysRequest) (*PackedKeys, error)
 }
 
 // NewWrapper returns new access point wrapper

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -254,8 +254,34 @@ func NewAPIServer(config *APIConfig) http.Handler {
 	)
 }
 
+// Auth defines the auth server as required by the API server
+type Auth interface {
+	AccessPoint
+	LocalCluster
+	Validation
+	ProvisioningService
+	WebService
+	IdentityService
+	WebAuth
+	DomainNameGetter
+	CertAuthorityRotator
+	KeyGenerator
+
+	services.Presence
+	services.Trust
+	services.ClusterConfiguration
+	services.Access
+
+	session.Service
+
+	events.IAuditLog
+
+	types.WebSessionsGetter
+	types.WebTokensGetter
+}
+
 // HandlerWithAuthFunc is http handler with passed auth context
-type HandlerWithAuthFunc func(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error)
+type HandlerWithAuthFunc func(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error)
 
 func (s *APIServer) withAuth(handler HandlerWithAuthFunc) httprouter.Handle {
 	const accessDeniedMsg = "auth API: access denied "
@@ -280,7 +306,7 @@ func (s *APIServer) withAuth(handler HandlerWithAuthFunc) httprouter.Handle {
 			authServer: s.AuthServer,
 			context:    *authContext,
 			sessions:   s.SessionService,
-			alog:       s.AuthServer.IAuditLog,
+			alog:       s.AuthServer.Services.IAuditLog,
 		}
 		version := p.ByName("version")
 		if version == "" {
@@ -376,7 +402,7 @@ func (s *APIServer) upsertServer(auth services.Presence, role teleport.Role, r *
 }
 
 // keepAliveNode updates node TTL in the backend
-func (s *APIServer) keepAliveNode(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) keepAliveNode(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var handle services.KeepAlive
 	if err := httplib.ReadJSON(r, &handle); err != nil {
 		return nil, trace.Wrap(err)
@@ -393,7 +419,7 @@ type upsertNodesReq struct {
 }
 
 // upsertNodes is used to bulk insert nodes into the backend.
-func (s *APIServer) upsertNodes(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertNodes(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req upsertNodesReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -416,12 +442,12 @@ func (s *APIServer) upsertNodes(auth ClientI, w http.ResponseWriter, r *http.Req
 }
 
 // upsertNode is called by remote SSH nodes when they ping back into the auth service
-func (s *APIServer) upsertNode(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertNode(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	return s.upsertServer(auth, teleport.RoleNode, r, p)
 }
 
 // getNodes returns registered SSH nodes
-func (s *APIServer) getNodes(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getNodes(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	namespace := p.ByName("namespace")
 	if !services.IsValidNamespace(namespace) {
 		return nil, trace.BadParameter("invalid namespace %q", namespace)
@@ -443,7 +469,7 @@ func (s *APIServer) getNodes(auth ClientI, w http.ResponseWriter, r *http.Reques
 }
 
 // deleteAllNodes deletes all nodes
-func (s *APIServer) deleteAllNodes(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteAllNodes(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	namespace := p.ByName("namespace")
 	if !services.IsValidNamespace(namespace) {
 		return nil, trace.BadParameter("invalid namespace %q", namespace)
@@ -456,7 +482,7 @@ func (s *APIServer) deleteAllNodes(auth ClientI, w http.ResponseWriter, r *http.
 }
 
 // deleteNode deletes node
-func (s *APIServer) deleteNode(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteNode(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	namespace := p.ByName("namespace")
 	if !services.IsValidNamespace(namespace) {
 		return nil, trace.BadParameter("invalid namespace %q", namespace)
@@ -473,12 +499,12 @@ func (s *APIServer) deleteNode(auth ClientI, w http.ResponseWriter, r *http.Requ
 }
 
 // upsertProxy is called by remote SSH nodes when they ping back into the auth service
-func (s *APIServer) upsertProxy(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertProxy(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	return s.upsertServer(auth, teleport.RoleProxy, r, p)
 }
 
 // getProxies returns registered proxies
-func (s *APIServer) getProxies(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getProxies(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	servers, err := auth.GetProxies()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -487,7 +513,7 @@ func (s *APIServer) getProxies(auth ClientI, w http.ResponseWriter, r *http.Requ
 }
 
 // deleteAllProxies deletes all proxies
-func (s *APIServer) deleteAllProxies(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteAllProxies(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteAllProxies()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -496,7 +522,7 @@ func (s *APIServer) deleteAllProxies(auth ClientI, w http.ResponseWriter, r *htt
 }
 
 // deleteProxy deletes proxy
-func (s *APIServer) deleteProxy(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteProxy(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	name := p.ByName("name")
 	if name == "" {
 		return nil, trace.BadParameter("missing proxy name")
@@ -509,12 +535,12 @@ func (s *APIServer) deleteProxy(auth ClientI, w http.ResponseWriter, r *http.Req
 }
 
 // upsertAuthServer is called by remote Auth servers when they ping back into the auth service
-func (s *APIServer) upsertAuthServer(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertAuthServer(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	return s.upsertServer(auth, teleport.RoleAuth, r, p)
 }
 
 // getAuthServers returns registered auth servers
-func (s *APIServer) getAuthServers(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getAuthServers(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	servers, err := auth.GetAuthServers()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -540,7 +566,7 @@ type upsertReverseTunnelRawReq struct {
 }
 
 // upsertReverseTunnel is called by admin to create a reverse tunnel to remote proxy
-func (s *APIServer) upsertReverseTunnel(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertReverseTunnel(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req upsertReverseTunnelRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -562,7 +588,7 @@ func (s *APIServer) upsertReverseTunnel(auth ClientI, w http.ResponseWriter, r *
 }
 
 // getReverseTunnels returns a list of reverse tunnels
-func (s *APIServer) getReverseTunnels(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getReverseTunnels(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	reverseTunnels, err := auth.GetReverseTunnels()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -579,7 +605,7 @@ func (s *APIServer) getReverseTunnels(auth ClientI, w http.ResponseWriter, r *ht
 }
 
 // deleteReverseTunnel deletes reverse tunnel
-func (s *APIServer) deleteReverseTunnel(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteReverseTunnel(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	domainName := p.ByName("domain")
 	err := auth.DeleteReverseTunnel(domainName)
 	if err != nil {
@@ -593,7 +619,7 @@ type upsertTrustedClusterReq struct {
 }
 
 // upsertTrustedCluster creates or updates a trusted cluster.
-func (s *APIServer) upsertTrustedCluster(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertTrustedCluster(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *upsertTrustedClusterReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -613,7 +639,7 @@ func (s *APIServer) upsertTrustedCluster(auth ClientI, w http.ResponseWriter, r 
 	return rawMessage(services.MarshalTrustedCluster(out, services.WithVersion(version), services.PreserveResourceID()))
 }
 
-func (s *APIServer) validateTrustedCluster(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) validateTrustedCluster(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var validateRequestRaw ValidateTrustedClusterRequestRaw
 	if err := httplib.ReadJSON(r, &validateRequestRaw); err != nil {
 		return nil, trace.Wrap(err)
@@ -637,16 +663,16 @@ func (s *APIServer) validateTrustedCluster(auth ClientI, w http.ResponseWriter, 
 	return validateResponseRaw, nil
 }
 
-func (s *APIServer) getTrustedCluster(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getTrustedCluster(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	return auth.GetTrustedCluster(p.ByName("name"))
 }
 
-func (s *APIServer) getTrustedClusters(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getTrustedClusters(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	return auth.GetTrustedClusters()
 }
 
 // deleteTrustedCluster deletes a trusted cluster by name.
-func (s *APIServer) deleteTrustedCluster(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteTrustedCluster(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteTrustedCluster(r.Context(), p.ByName("name"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -656,7 +682,7 @@ func (s *APIServer) deleteTrustedCluster(auth ClientI, w http.ResponseWriter, r 
 }
 
 // getTokens returns a list of active provisioning tokens. expired (inactive) tokens are not returned
-func (s *APIServer) getTokens(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getTokens(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	tokens, err := auth.GetTokens()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -665,7 +691,7 @@ func (s *APIServer) getTokens(auth ClientI, w http.ResponseWriter, r *http.Reque
 }
 
 // getTokens returns provisioning token by name
-func (s *APIServer) getToken(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getToken(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	token, err := auth.GetToken(p.ByName("token"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -674,7 +700,7 @@ func (s *APIServer) getToken(auth ClientI, w http.ResponseWriter, r *http.Reques
 }
 
 // deleteToken deletes (revokes) a token by its value
-func (s *APIServer) deleteToken(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteToken(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	token := p.ByName("token")
 	if err := auth.DeleteToken(token); err != nil {
 		return nil, trace.Wrap(err)
@@ -682,7 +708,7 @@ func (s *APIServer) deleteToken(auth ClientI, w http.ResponseWriter, r *http.Req
 	return message(fmt.Sprintf("Token %v deleted", token)), nil
 }
 
-func (s *APIServer) deleteWebSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteWebSession(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	user, sessionID := p.ByName("user"), p.ByName("sid")
 	err := auth.WebSessions().Delete(r.Context(), types.DeleteWebSessionRequest{
 		User:      user,
@@ -694,7 +720,7 @@ func (s *APIServer) deleteWebSession(auth ClientI, w http.ResponseWriter, r *htt
 	return message(fmt.Sprintf("session %q for user %q deleted", sessionID, user)), nil
 }
 
-func (s *APIServer) getWebSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getWebSession(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	user, sid := p.ByName("user"), p.ByName("sid")
 	sess, err := auth.GetWebSessionInfo(r.Context(), user, sid)
 	if err != nil {
@@ -712,7 +738,7 @@ type generateUserCertReq struct {
 }
 
 // DELETE IN: 4.2.0
-func (s *APIServer) generateUserCert(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) generateUserCert(auth Auth, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
 	var req *generateUserCertReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -737,7 +763,7 @@ type signInReq struct {
 	Password string `json:"password"`
 }
 
-func (s *APIServer) u2fSignRequest(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) u2fSignRequest(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *signInReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -756,7 +782,7 @@ type createWebSessionReq struct {
 	AccessRequestID string `json:"access_request_id"`
 }
 
-func (s *APIServer) createWebSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) createWebSession(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *createWebSessionReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -776,7 +802,7 @@ func (s *APIServer) createWebSession(auth ClientI, w http.ResponseWriter, r *htt
 	return rawMessage(services.MarshalWebSession(sess, services.WithVersion(version)))
 }
 
-func (s *APIServer) authenticateWebUser(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) authenticateWebUser(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req AuthenticateUserRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -789,7 +815,7 @@ func (s *APIServer) authenticateWebUser(auth ClientI, w http.ResponseWriter, r *
 	return rawMessage(services.MarshalWebSession(sess, services.WithVersion(version)))
 }
 
-func (s *APIServer) authenticateSSHUser(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) authenticateSSHUser(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req AuthenticateSSHRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -799,7 +825,7 @@ func (s *APIServer) authenticateSSHUser(auth ClientI, w http.ResponseWriter, r *
 }
 
 // changePassword updates users password based on the old password.
-func (s *APIServer) changePassword(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) changePassword(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req services.ChangePasswordReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -816,7 +842,7 @@ type upsertPasswordReq struct {
 	Password string `json:"password"`
 }
 
-func (s *APIServer) upsertPassword(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertPassword(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *upsertPasswordReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -835,7 +861,7 @@ type upsertUserRawReq struct {
 	User json.RawMessage `json:"user"`
 }
 
-func (s *APIServer) upsertUser(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertUser(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *upsertUserRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -857,7 +883,7 @@ type checkPasswordReq struct {
 	OTPToken string `json:"otp_token"`
 }
 
-func (s *APIServer) checkPassword(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) checkPassword(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req checkPasswordReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -871,7 +897,7 @@ func (s *APIServer) checkPassword(auth ClientI, w http.ResponseWriter, r *http.R
 	return message(fmt.Sprintf("%q user password matches", user)), nil
 }
 
-func (s *APIServer) getUser(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getUser(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	user, err := auth.GetUser(p.ByName("user"), false)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -887,7 +913,7 @@ func rawMessage(data []byte, err error) (interface{}, error) {
 	return &m, nil
 }
 
-func (s *APIServer) getUsers(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getUsers(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	users, err := auth.GetUsers(false)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -904,7 +930,7 @@ func (s *APIServer) getUsers(auth ClientI, w http.ResponseWriter, r *http.Reques
 }
 
 // DELETE IN: 5.2 REST method is replaced by grpc method with context.
-func (s *APIServer) deleteUser(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteUser(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	user := p.ByName("user")
 	if err := auth.DeleteUser(r.Context(), user); err != nil {
 		return nil, trace.Wrap(err)
@@ -921,7 +947,7 @@ type generateKeyPairResponse struct {
 	PubKey  string `json:"pubkey"`
 }
 
-func (s *APIServer) generateKeyPair(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) generateKeyPair(auth Auth, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
 	var req *generateKeyPairReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -944,7 +970,7 @@ type generateHostCertReq struct {
 	TTL         time.Duration  `json:"ttl"`
 }
 
-func (s *APIServer) generateHostCert(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) generateHostCert(auth Auth, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
 	var req *generateHostCertReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -958,7 +984,7 @@ func (s *APIServer) generateHostCert(auth ClientI, w http.ResponseWriter, r *htt
 	return string(cert), nil
 }
 
-func (s *APIServer) generateToken(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) generateToken(auth Auth, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
 	var req GenerateTokenRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -970,7 +996,7 @@ func (s *APIServer) generateToken(auth ClientI, w http.ResponseWriter, r *http.R
 	return token, nil
 }
 
-func (s *APIServer) registerUsingToken(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) registerUsingToken(auth Auth, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
 	var req RegisterUsingTokenRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -990,7 +1016,7 @@ type registerNewAuthServerReq struct {
 	Token string `json:"token"`
 }
 
-func (s *APIServer) registerNewAuthServer(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) registerNewAuthServer(auth Auth, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
 	var req *registerNewAuthServerReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1002,7 +1028,7 @@ func (s *APIServer) registerNewAuthServer(auth ClientI, w http.ResponseWriter, r
 	return message("ok"), nil
 }
 
-func (s *APIServer) generateServerKeys(auth ClientI, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) generateServerKeys(auth Auth, w http.ResponseWriter, r *http.Request, _ httprouter.Params, version string) (interface{}, error) {
 	var req GenerateServerKeysRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1019,7 +1045,7 @@ func (s *APIServer) generateServerKeys(auth ClientI, w http.ResponseWriter, r *h
 	return keys, nil
 }
 
-func (s *APIServer) rotateCertAuthority(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) rotateCertAuthority(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req RotateRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1035,7 +1061,7 @@ type upsertCertAuthorityRawReq struct {
 	TTL time.Duration   `json:"ttl"`
 }
 
-func (s *APIServer) upsertCertAuthority(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertCertAuthority(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *upsertCertAuthorityRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1060,7 +1086,7 @@ type rotateExternalCertAuthorityRawReq struct {
 	CA json.RawMessage `json:"ca"`
 }
 
-func (s *APIServer) rotateExternalCertAuthority(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) rotateExternalCertAuthority(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req rotateExternalCertAuthorityRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1075,7 +1101,7 @@ func (s *APIServer) rotateExternalCertAuthority(auth ClientI, w http.ResponseWri
 	return message("ok"), nil
 }
 
-func (s *APIServer) getCertAuthorities(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getCertAuthorities(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	loadKeys, _, err := httplib.ParseBool(r.URL.Query(), "load_keys")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1096,7 +1122,7 @@ func (s *APIServer) getCertAuthorities(auth ClientI, w http.ResponseWriter, r *h
 	return items, nil
 }
 
-func (s *APIServer) getCertAuthority(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getCertAuthority(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	loadKeys, _, err := httplib.ParseBool(r.URL.Query(), "load_keys")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1112,7 +1138,7 @@ func (s *APIServer) getCertAuthority(auth ClientI, w http.ResponseWriter, r *htt
 	return rawMessage(services.MarshalCertAuthority(ca, services.WithVersion(version), services.PreserveResourceID()))
 }
 
-func (s *APIServer) getDomainName(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getDomainName(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	domain, err := auth.GetDomainName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1121,7 +1147,7 @@ func (s *APIServer) getDomainName(auth ClientI, w http.ResponseWriter, r *http.R
 }
 
 // getClusterCACert returns the CAs for the local cluster without signing keys.
-func (s *APIServer) getClusterCACert(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getClusterCACert(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	localCA, err := auth.GetClusterCACert()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1130,7 +1156,7 @@ func (s *APIServer) getClusterCACert(auth ClientI, w http.ResponseWriter, r *htt
 	return localCA, nil
 }
 
-func (s *APIServer) changePasswordWithToken(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) changePasswordWithToken(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req ChangePasswordWithTokenRequest
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1146,7 +1172,7 @@ func (s *APIServer) changePasswordWithToken(auth ClientI, w http.ResponseWriter,
 }
 
 // getU2FAppID returns the U2F AppID in the auth configuration
-func (s *APIServer) getU2FAppID(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getU2FAppID(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	cap, err := auth.GetAuthPreference()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1161,7 +1187,7 @@ func (s *APIServer) getU2FAppID(auth ClientI, w http.ResponseWriter, r *http.Req
 	return universalSecondFactor.AppID, nil
 }
 
-func (s *APIServer) deleteCertAuthority(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteCertAuthority(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	id := services.CertAuthID{
 		DomainName: p.ByName("domain"),
 		Type:       services.CertAuthType(p.ByName("type")),
@@ -1176,7 +1202,7 @@ type createSessionReq struct {
 	Session session.Session `json:"session"`
 }
 
-func (s *APIServer) createSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) createSession(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *createSessionReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1196,7 +1222,7 @@ type updateSessionReq struct {
 	Update session.UpdateRequest `json:"update"`
 }
 
-func (s *APIServer) updateSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) updateSession(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *updateSessionReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1212,7 +1238,7 @@ func (s *APIServer) updateSession(auth ClientI, w http.ResponseWriter, r *http.R
 	return message("ok"), nil
 }
 
-func (s *APIServer) deleteSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteSession(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteSession(p.ByName("namespace"), session.ID(p.ByName("id")))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1220,7 +1246,7 @@ func (s *APIServer) deleteSession(auth ClientI, w http.ResponseWriter, r *http.R
 	return message("ok"), nil
 }
 
-func (s *APIServer) getSessions(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getSessions(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	namespace := p.ByName("namespace")
 	if !services.IsValidNamespace(namespace) {
 		return nil, trace.BadParameter("invalid namespace %q", namespace)
@@ -1232,7 +1258,7 @@ func (s *APIServer) getSessions(auth ClientI, w http.ResponseWriter, r *http.Req
 	return sessions, nil
 }
 
-func (s *APIServer) getSession(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getSession(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	sid, err := session.ParseID(p.ByName("id"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1248,7 +1274,7 @@ func (s *APIServer) getSession(auth ClientI, w http.ResponseWriter, r *http.Requ
 	return se, nil
 }
 
-func (s *APIServer) getSignupU2FRegisterRequest(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getSignupU2FRegisterRequest(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	token := p.ByName("token")
 	u2fRegReq, err := auth.GetSignupU2FRegisterRequest(token)
 	if err != nil {
@@ -1262,7 +1288,7 @@ type upsertOIDCConnectorRawReq struct {
 	TTL       time.Duration   `json:"ttl"`
 }
 
-func (s *APIServer) upsertOIDCConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertOIDCConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *upsertOIDCConnectorRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1284,7 +1310,7 @@ func (s *APIServer) upsertOIDCConnector(auth ClientI, w http.ResponseWriter, r *
 	return message("ok"), nil
 }
 
-func (s *APIServer) getOIDCConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getOIDCConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	withSecrets, _, err := httplib.ParseBool(r.URL.Query(), "with_secrets")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1296,7 +1322,7 @@ func (s *APIServer) getOIDCConnector(auth ClientI, w http.ResponseWriter, r *htt
 	return rawMessage(services.MarshalOIDCConnector(connector, services.WithVersion(version)))
 }
 
-func (s *APIServer) deleteOIDCConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteOIDCConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteOIDCConnector(r.Context(), p.ByName("id"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1304,7 +1330,7 @@ func (s *APIServer) deleteOIDCConnector(auth ClientI, w http.ResponseWriter, r *
 	return message("ok"), nil
 }
 
-func (s *APIServer) getOIDCConnectors(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getOIDCConnectors(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	withSecrets, _, err := httplib.ParseBool(r.URL.Query(), "with_secrets")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1328,7 +1354,7 @@ type createOIDCAuthRequestReq struct {
 	Req services.OIDCAuthRequest `json:"req"`
 }
 
-func (s *APIServer) createOIDCAuthRequest(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) createOIDCAuthRequest(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *createOIDCAuthRequestReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1364,7 +1390,7 @@ type oidcAuthRawResponse struct {
 	HostSigners []json.RawMessage `json:"host_signers"`
 }
 
-func (s *APIServer) validateOIDCAuthCallback(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) validateOIDCAuthCallback(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *validateOIDCAuthCallbackReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1402,7 +1428,7 @@ type createSAMLConnectorRawReq struct {
 	Connector json.RawMessage `json:"connector"`
 }
 
-func (s *APIServer) createSAMLConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) createSAMLConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *createSAMLConnectorRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1425,7 +1451,7 @@ type upsertSAMLConnectorRawReq struct {
 	Connector json.RawMessage `json:"connector"`
 }
 
-func (s *APIServer) upsertSAMLConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertSAMLConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *upsertSAMLConnectorRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1444,7 +1470,7 @@ func (s *APIServer) upsertSAMLConnector(auth ClientI, w http.ResponseWriter, r *
 	return message("ok"), nil
 }
 
-func (s *APIServer) getSAMLConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getSAMLConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	withSecrets, _, err := httplib.ParseBool(r.URL.Query(), "with_secrets")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1456,7 +1482,7 @@ func (s *APIServer) getSAMLConnector(auth ClientI, w http.ResponseWriter, r *htt
 	return rawMessage(services.MarshalSAMLConnector(connector, services.WithVersion(version)))
 }
 
-func (s *APIServer) deleteSAMLConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteSAMLConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteSAMLConnector(r.Context(), p.ByName("id"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1464,7 +1490,7 @@ func (s *APIServer) deleteSAMLConnector(auth ClientI, w http.ResponseWriter, r *
 	return message("ok"), nil
 }
 
-func (s *APIServer) getSAMLConnectors(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getSAMLConnectors(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	withSecrets, _, err := httplib.ParseBool(r.URL.Query(), "with_secrets")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1488,7 +1514,7 @@ type createSAMLAuthRequestReq struct {
 	Req services.SAMLAuthRequest `json:"req"`
 }
 
-func (s *APIServer) createSAMLAuthRequest(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) createSAMLAuthRequest(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *createSAMLAuthRequestReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1524,7 +1550,7 @@ type samlAuthRawResponse struct {
 	TLSCert []byte `json:"tls_cert,omitempty"`
 }
 
-func (s *APIServer) validateSAMLResponse(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) validateSAMLResponse(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *validateSAMLResponseReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1570,7 +1596,7 @@ type createGithubConnectorRawReq struct {
 
    Success response: {"message": "ok"}
 */
-func (s *APIServer) createGithubConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) createGithubConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req createGithubConnectorRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1597,7 +1623,7 @@ type upsertGithubConnectorRawReq struct {
 
    Success response: {"message": "ok"}
 */
-func (s *APIServer) upsertGithubConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertGithubConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req upsertGithubConnectorRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1618,7 +1644,7 @@ func (s *APIServer) upsertGithubConnector(auth ClientI, w http.ResponseWriter, r
 
    Success response: []services.GithubConnector
 */
-func (s *APIServer) getGithubConnectors(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getGithubConnectors(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	withSecrets, _, err := httplib.ParseBool(r.URL.Query(), "with_secrets")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1644,7 +1670,7 @@ func (s *APIServer) getGithubConnectors(auth ClientI, w http.ResponseWriter, r *
 
    Success response: services.GithubConnector
 */
-func (s *APIServer) getGithubConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getGithubConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	withSecrets, _, err := httplib.ParseBool(r.URL.Query(), "with_secrets")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1662,7 +1688,7 @@ func (s *APIServer) getGithubConnector(auth ClientI, w http.ResponseWriter, r *h
 
    Success response: {"message": "ok"}
 */
-func (s *APIServer) deleteGithubConnector(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteGithubConnector(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	if err := auth.DeleteGithubConnector(r.Context(), p.ByName("id")); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1681,7 +1707,7 @@ type createGithubAuthRequestReq struct {
 
    Success response: services.GithubAuthRequest
 */
-func (s *APIServer) createGithubAuthRequest(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) createGithubAuthRequest(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req createGithubAuthRequestReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1725,7 +1751,7 @@ type githubAuthRawResponse struct {
 
    Success response: githubAuthRawResponse
 */
-func (s *APIServer) validateGithubAuthCallback(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) validateGithubAuthCallback(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req validateGithubAuthCallbackReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -1767,7 +1793,7 @@ func (s *APIServer) validateGithubAuthCallback(auth ClientI, w http.ResponseWrit
 //	'from'  : time filter in RFC3339 format
 //	'to'    : time filter in RFC3339 format
 //  ...     : other fields are passed directly to the audit backend
-func (s *APIServer) searchEvents(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) searchEvents(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var err error
 	to := time.Now().In(time.UTC)
 	from := to.AddDate(0, -1, 0) // one month ago
@@ -1808,7 +1834,7 @@ func (s *APIServer) searchEvents(auth ClientI, w http.ResponseWriter, r *http.Re
 }
 
 // searchSessionEvents only allows searching audit log for events related to session playback.
-func (s *APIServer) searchSessionEvents(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) searchSessionEvents(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var err error
 
 	// default values for "to" and "from" fields
@@ -1860,7 +1886,7 @@ type auditEventReq struct {
 }
 
 // HTTP	POST /:version/events
-func (s *APIServer) emitAuditEvent(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) emitAuditEvent(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req auditEventReq
 	err := httplib.ReadJSON(r, &req)
 	if err != nil {
@@ -1897,7 +1923,7 @@ func (s *APIServer) emitAuditEvent(auth ClientI, w http.ResponseWriter, r *http.
 }
 
 // HTTP POST /:version/sessions/:id/slice
-func (s *APIServer) postSessionSlice(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) postSessionSlice(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1935,7 +1961,7 @@ func (s *APIServer) postSessionSlice(auth ClientI, w http.ResponseWriter, r *htt
 }
 
 // HTTP POST /:version/sessions/:id/recording
-func (s *APIServer) uploadSessionRecording(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) uploadSessionRecording(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var files form.Files
 	var namespace, sid string
 
@@ -1996,7 +2022,7 @@ func (s *APIServer) uploadSessionRecording(auth ClientI, w http.ResponseWriter, 
 // Query parameters:
 //   "offset"   : bytes from the beginning
 //   "bytes"    : number of bytes to read (it won't return more than 512Kb)
-func (s *APIServer) getSessionChunk(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getSessionChunk(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	sid, err := session.ParseID(p.ByName("id"))
 	if err != nil {
 		return nil, trace.BadParameter("missing parameter id")
@@ -2033,7 +2059,7 @@ func (s *APIServer) getSessionChunk(auth ClientI, w http.ResponseWriter, r *http
 // HTTP GET /:version/sessions/:id/events?maxage=n
 // Query:
 //    'after' : cursor value to return events newer than N. Defaults to 0, (return all)
-func (s *APIServer) getSessionEvents(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getSessionEvents(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	sid, err := session.ParseID(p.ByName("id"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2058,7 +2084,7 @@ type upsertNamespaceReq struct {
 	Namespace services.Namespace `json:"namespace"`
 }
 
-func (s *APIServer) upsertNamespace(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertNamespace(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *upsertNamespaceReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -2069,7 +2095,7 @@ func (s *APIServer) upsertNamespace(auth ClientI, w http.ResponseWriter, r *http
 	return message("ok"), nil
 }
 
-func (s *APIServer) getNamespaces(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getNamespaces(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	namespaces, err := auth.GetNamespaces()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2077,7 +2103,7 @@ func (s *APIServer) getNamespaces(auth ClientI, w http.ResponseWriter, r *http.R
 	return namespaces, nil
 }
 
-func (s *APIServer) getNamespace(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getNamespace(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	name := p.ByName("namespace")
 	if !services.IsValidNamespace(name) {
 		return nil, trace.BadParameter("invalid namespace %q", name)
@@ -2090,7 +2116,7 @@ func (s *APIServer) getNamespace(auth ClientI, w http.ResponseWriter, r *http.Re
 	return namespace, nil
 }
 
-func (s *APIServer) deleteNamespace(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteNamespace(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	name := p.ByName("namespace")
 	if !services.IsValidNamespace(name) {
 		return nil, trace.BadParameter("invalid namespace %q", name)
@@ -2107,7 +2133,7 @@ type upsertRoleRawReq struct {
 	Role json.RawMessage `json:"role"`
 }
 
-func (s *APIServer) upsertRole(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertRole(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *upsertRoleRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -2126,7 +2152,7 @@ func (s *APIServer) upsertRole(auth ClientI, w http.ResponseWriter, r *http.Requ
 	return message(fmt.Sprintf("'%v' role upserted", role.GetName())), nil
 }
 
-func (s *APIServer) getRole(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getRole(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	role, err := auth.GetRole(p.ByName("role"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2134,7 +2160,7 @@ func (s *APIServer) getRole(auth ClientI, w http.ResponseWriter, r *http.Request
 	return rawMessage(services.MarshalRole(role, services.WithVersion(version), services.PreserveResourceID()))
 }
 
-func (s *APIServer) getRoles(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getRoles(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	roles, err := auth.GetRoles()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2150,7 +2176,7 @@ func (s *APIServer) getRoles(auth ClientI, w http.ResponseWriter, r *http.Reques
 	return out, nil
 }
 
-func (s *APIServer) deleteRole(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteRole(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	role := p.ByName("role")
 	if err := auth.DeleteRole(r.Context(), role); err != nil {
 		return nil, trace.Wrap(err)
@@ -2158,7 +2184,7 @@ func (s *APIServer) deleteRole(auth ClientI, w http.ResponseWriter, r *http.Requ
 	return message(fmt.Sprintf("role %q deleted", role)), nil
 }
 
-func (s *APIServer) getClusterConfig(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getClusterConfig(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	cc, err := auth.GetClusterConfig()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2171,7 +2197,7 @@ type setClusterConfigReq struct {
 	ClusterConfig json.RawMessage `json:"cluster_config"`
 }
 
-func (s *APIServer) setClusterConfig(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) setClusterConfig(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req setClusterConfigReq
 
 	err := httplib.ReadJSON(r, &req)
@@ -2192,7 +2218,7 @@ func (s *APIServer) setClusterConfig(auth ClientI, w http.ResponseWriter, r *htt
 	return message("cluster config set"), nil
 }
 
-func (s *APIServer) getClusterName(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getClusterName(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	cn, err := auth.GetClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2205,7 +2231,7 @@ type setClusterNameReq struct {
 	ClusterName json.RawMessage `json:"cluster_name"`
 }
 
-func (s *APIServer) setClusterName(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) setClusterName(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req setClusterNameReq
 
 	err := httplib.ReadJSON(r, &req)
@@ -2226,7 +2252,7 @@ func (s *APIServer) setClusterName(auth ClientI, w http.ResponseWriter, r *http.
 	return message(fmt.Sprintf("cluster name set: %+v", cn)), nil
 }
 
-func (s *APIServer) getStaticTokens(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getStaticTokens(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	st, err := auth.GetStaticTokens()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2235,7 +2261,7 @@ func (s *APIServer) getStaticTokens(auth ClientI, w http.ResponseWriter, r *http
 	return rawMessage(services.MarshalStaticTokens(st, services.WithVersion(version), services.PreserveResourceID()))
 }
 
-func (s *APIServer) deleteStaticTokens(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteStaticTokens(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteStaticTokens()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2247,7 +2273,7 @@ type setStaticTokensReq struct {
 	StaticTokens json.RawMessage `json:"static_tokens"`
 }
 
-func (s *APIServer) setStaticTokens(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) setStaticTokens(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req setStaticTokensReq
 
 	err := httplib.ReadJSON(r, &req)
@@ -2268,7 +2294,7 @@ func (s *APIServer) setStaticTokens(auth ClientI, w http.ResponseWriter, r *http
 	return message(fmt.Sprintf("static tokens set: %+v", st)), nil
 }
 
-func (s *APIServer) getClusterAuthPreference(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getClusterAuthPreference(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	cap, err := auth.GetAuthPreference()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2281,7 +2307,7 @@ type setClusterAuthPreferenceReq struct {
 	ClusterAuthPreference json.RawMessage `json:"cluster_auth_prerference"`
 }
 
-func (s *APIServer) setClusterAuthPreference(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) setClusterAuthPreference(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req *setClusterAuthPreferenceReq
 
 	err := httplib.ReadJSON(r, &req)
@@ -2307,7 +2333,7 @@ type upsertTunnelConnectionRawReq struct {
 }
 
 // upsertTunnelConnection updates or inserts tunnel connection
-func (s *APIServer) upsertTunnelConnection(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) upsertTunnelConnection(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req upsertTunnelConnectionRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -2323,7 +2349,7 @@ func (s *APIServer) upsertTunnelConnection(auth ClientI, w http.ResponseWriter, 
 }
 
 // getTunnelConnections returns a list of tunnel connections from a cluster
-func (s *APIServer) getTunnelConnections(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getTunnelConnections(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	conns, err := auth.GetTunnelConnections(p.ByName("cluster"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2340,7 +2366,7 @@ func (s *APIServer) getTunnelConnections(auth ClientI, w http.ResponseWriter, r 
 }
 
 // getAllTunnelConnections returns a list of tunnel connections from a cluster
-func (s *APIServer) getAllTunnelConnections(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getAllTunnelConnections(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	conns, err := auth.GetAllTunnelConnections()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2357,7 +2383,7 @@ func (s *APIServer) getAllTunnelConnections(auth ClientI, w http.ResponseWriter,
 }
 
 // deleteTunnelConnection deletes tunnel connection by name
-func (s *APIServer) deleteTunnelConnection(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteTunnelConnection(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteTunnelConnection(p.ByName("cluster"), p.ByName("conn"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2366,7 +2392,7 @@ func (s *APIServer) deleteTunnelConnection(auth ClientI, w http.ResponseWriter, 
 }
 
 // deleteTunnelConnections deletes all tunnel connections for cluster
-func (s *APIServer) deleteTunnelConnections(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteTunnelConnections(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteTunnelConnections(p.ByName("cluster"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2375,7 +2401,7 @@ func (s *APIServer) deleteTunnelConnections(auth ClientI, w http.ResponseWriter,
 }
 
 // deleteAllTunnelConnections deletes all tunnel connections
-func (s *APIServer) deleteAllTunnelConnections(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteAllTunnelConnections(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteAllTunnelConnections()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2389,7 +2415,7 @@ type createRemoteClusterRawReq struct {
 }
 
 // createRemoteCluster creates remote cluster
-func (s *APIServer) createRemoteCluster(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) createRemoteCluster(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req createRemoteClusterRawReq
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
@@ -2405,7 +2431,7 @@ func (s *APIServer) createRemoteCluster(auth ClientI, w http.ResponseWriter, r *
 }
 
 // getRemoteClusters returns a list of remote clusters
-func (s *APIServer) getRemoteClusters(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getRemoteClusters(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	clusters, err := auth.GetRemoteClusters()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2422,7 +2448,7 @@ func (s *APIServer) getRemoteClusters(auth ClientI, w http.ResponseWriter, r *ht
 }
 
 // getRemoteCluster returns a remote cluster by name
-func (s *APIServer) getRemoteCluster(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) getRemoteCluster(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	cluster, err := auth.GetRemoteCluster(p.ByName("cluster"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2431,7 +2457,7 @@ func (s *APIServer) getRemoteCluster(auth ClientI, w http.ResponseWriter, r *htt
 }
 
 // deleteRemoteCluster deletes remote cluster by name
-func (s *APIServer) deleteRemoteCluster(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteRemoteCluster(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteRemoteCluster(p.ByName("cluster"))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2440,7 +2466,7 @@ func (s *APIServer) deleteRemoteCluster(auth ClientI, w http.ResponseWriter, r *
 }
 
 // deleteAllRemoteClusters deletes all remote clusters
-func (s *APIServer) deleteAllRemoteClusters(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) deleteAllRemoteClusters(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	err := auth.DeleteAllRemoteClusters()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2448,7 +2474,7 @@ func (s *APIServer) deleteAllRemoteClusters(auth ClientI, w http.ResponseWriter,
 	return message("ok"), nil
 }
 
-func (s *APIServer) processKubeCSR(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+func (s *APIServer) processKubeCSR(auth Auth, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
 	var req KubeCSR
 
 	if err := httplib.ReadJSON(r, &req); err != nil {

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -260,7 +260,7 @@ type apiServerAuth interface {
 
 	identityService
 	clientCluster
-	provisioningService
+	clientProvisioningService
 	webService
 
 	services.Presence

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -478,7 +478,7 @@ func (s *AuthSuite) TestUserLock(c *C) {
 		c.Assert(err, NotNil)
 	}
 
-	user, err := s.a.Identity.GetUser(username, false)
+	user, err := s.a.LocalIdentity.GetUser(username, false)
 	c.Assert(err, IsNil)
 	c.Assert(user.GetStatus().IsLocked, Equals, true)
 
@@ -921,7 +921,7 @@ func (s *AuthSuite) TestTrustedClusterCRUDEventEmitted(c *C) {
 		ReverseTunnelAddress: "b",
 	})
 	c.Assert(err, IsNil)
-	_, err = s.a.Presence.UpsertTrustedCluster(ctx, tc)
+	_, err = s.a.LocalPresence.UpsertTrustedCluster(ctx, tc)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.a.UpsertCertAuthority(suite.NewTestCA(services.UserCA, "test")), IsNil)
@@ -1082,14 +1082,14 @@ func newTestServices(t *testing.T) Services {
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
 	return Services{
-		Trust:                local.NewCAService(bk),
-		Presence:             local.NewPresenceService(bk),
-		Provisioner:          local.NewProvisioningService(bk),
-		Identity:             local.NewIdentityService(bk),
-		Access:               local.NewAccessService(bk),
-		DynamicAccess:        local.NewDynamicAccessService(bk),
-		ClusterConfiguration: local.NewClusterConfigurationService(bk),
-		Events:               local.NewEventsService(bk),
-		IAuditLog:            events.NewDiscardAuditLog(),
+		LocalTrust:                local.NewCAService(bk),
+		LocalPresence:             local.NewPresenceService(bk),
+		LocalProvisioner:          local.NewProvisioningService(bk),
+		LocalIdentity:             local.NewIdentityService(bk),
+		LocalAccess:               local.NewAccessService(bk),
+		DynamicAccess:             local.NewDynamicAccessService(bk),
+		LocalClusterConfiguration: local.NewClusterConfigurationService(bk),
+		Events:                    local.NewEventsService(bk),
+		IAuditLog:                 events.NewDiscardAuditLog(),
 	}
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -478,7 +478,7 @@ func (s *AuthSuite) TestUserLock(c *C) {
 		c.Assert(err, NotNil)
 	}
 
-	user, err := s.a.LocalIdentity.GetUser(username, false)
+	user, err := s.a.ServerIdentity.GetUser(username, false)
 	c.Assert(err, IsNil)
 	c.Assert(user.GetStatus().IsLocked, Equals, true)
 
@@ -921,7 +921,7 @@ func (s *AuthSuite) TestTrustedClusterCRUDEventEmitted(c *C) {
 		ReverseTunnelAddress: "b",
 	})
 	c.Assert(err, IsNil)
-	_, err = s.a.LocalPresence.UpsertTrustedCluster(ctx, tc)
+	_, err = s.a.ServerPresence.UpsertTrustedCluster(ctx, tc)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.a.UpsertCertAuthority(suite.NewTestCA(services.UserCA, "test")), IsNil)
@@ -1082,14 +1082,14 @@ func newTestServices(t *testing.T) Services {
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)
 	return Services{
-		LocalTrust:                local.NewCAService(bk),
-		LocalPresence:             local.NewPresenceService(bk),
-		LocalProvisioner:          local.NewProvisioningService(bk),
-		LocalIdentity:             local.NewIdentityService(bk),
-		LocalAccess:               local.NewAccessService(bk),
-		DynamicAccess:             local.NewDynamicAccessService(bk),
-		LocalClusterConfiguration: local.NewClusterConfigurationService(bk),
-		Events:                    local.NewEventsService(bk),
-		IAuditLog:                 events.NewDiscardAuditLog(),
+		ServerTrust:                local.NewCAService(bk),
+		ServerPresence:             local.NewPresenceService(bk),
+		ServerProvisioner:          local.NewProvisioningService(bk),
+		ServerIdentity:             local.NewIdentityService(bk),
+		ServerAccess:               local.NewAccessService(bk),
+		DynamicAccess:              local.NewDynamicAccessService(bk),
+		ServerClusterConfiguration: local.NewClusterConfigurationService(bk),
+		Events:                     local.NewEventsService(bk),
+		IAuditLog:                  events.NewDiscardAuditLog(),
 	}
 }

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -224,7 +224,7 @@ func (a *ServerWithRoles) UpsertCertAuthority(ca services.CertAuthority) error {
 	if err := a.actionWithContext(ctx, defaults.Namespace, services.KindCertAuthority, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.Services.LocalTrust.UpsertCertAuthority(ca)
+	return a.authServer.Services.ServerTrust.UpsertCertAuthority(ca)
 }
 
 // CompareAndSwapCertAuthority updates existing cert authority if the existing cert authority
@@ -236,7 +236,7 @@ func (a *ServerWithRoles) CompareAndSwapCertAuthority(new, existing services.Cer
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.Services.LocalTrust.CompareAndSwapCertAuthority(new, existing)
+	return a.authServer.Services.ServerTrust.CompareAndSwapCertAuthority(new, existing)
 }
 
 func (a *ServerWithRoles) GetCertAuthorities(caType services.CertAuthType, loadKeys bool, opts ...services.MarshalOption) ([]services.CertAuthority, error) {
@@ -296,7 +296,7 @@ func (a *ServerWithRoles) DeleteCertAuthority(id services.CertAuthID) error {
 	if err := a.action(defaults.Namespace, services.KindCertAuthority, services.VerbDelete); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.Services.LocalTrust.DeleteCertAuthority(id)
+	return a.authServer.Services.ServerTrust.DeleteCertAuthority(id)
 }
 
 // GenerateToken generates multi-purpose authentication token.
@@ -1088,7 +1088,7 @@ func (a *ServerWithRoles) GetUser(name string, withSecrets bool) (services.User,
 			}
 		}
 	}
-	return a.authServer.Services.LocalIdentity.GetUser(name, withSecrets)
+	return a.authServer.Services.ServerIdentity.GetUser(name, withSecrets)
 }
 
 // DeleteUser deletes an existng user in a backend by username.
@@ -1355,7 +1355,7 @@ func (a *ServerWithRoles) GetOIDCConnector(id string, withSecrets bool) (service
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.Services.LocalIdentity.GetOIDCConnector(id, withSecrets)
+	return a.authServer.Services.ServerIdentity.GetOIDCConnector(id, withSecrets)
 }
 
 func (a *ServerWithRoles) GetOIDCConnectors(withSecrets bool) ([]services.OIDCConnector, error) {
@@ -1370,7 +1370,7 @@ func (a *ServerWithRoles) GetOIDCConnectors(withSecrets bool) ([]services.OIDCCo
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.Services.LocalIdentity.GetOIDCConnectors(withSecrets)
+	return a.authServer.Services.ServerIdentity.GetOIDCConnectors(withSecrets)
 }
 
 func (a *ServerWithRoles) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*services.OIDCAuthRequest, error) {
@@ -1419,7 +1419,7 @@ func (a *ServerWithRoles) GetSAMLConnector(id string, withSecrets bool) (service
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.Services.LocalIdentity.GetSAMLConnector(id, withSecrets)
+	return a.authServer.Services.ServerIdentity.GetSAMLConnector(id, withSecrets)
 }
 
 func (a *ServerWithRoles) GetSAMLConnectors(withSecrets bool) ([]services.SAMLConnector, error) {
@@ -1434,7 +1434,7 @@ func (a *ServerWithRoles) GetSAMLConnectors(withSecrets bool) ([]services.SAMLCo
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.Services.LocalIdentity.GetSAMLConnectors(withSecrets)
+	return a.authServer.Services.ServerIdentity.GetSAMLConnectors(withSecrets)
 }
 
 func (a *ServerWithRoles) CreateSAMLAuthRequest(req services.SAMLAuthRequest) (*services.SAMLAuthRequest, error) {
@@ -1484,7 +1484,7 @@ func (a *ServerWithRoles) GetGithubConnector(id string, withSecrets bool) (servi
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.Services.LocalIdentity.GetGithubConnector(id, withSecrets)
+	return a.authServer.Services.ServerIdentity.GetGithubConnector(id, withSecrets)
 }
 
 func (a *ServerWithRoles) GetGithubConnectors(withSecrets bool) ([]services.GithubConnector, error) {
@@ -1499,7 +1499,7 @@ func (a *ServerWithRoles) GetGithubConnectors(withSecrets bool) ([]services.Gith
 			return nil, trace.Wrap(err)
 		}
 	}
-	return a.authServer.Services.LocalIdentity.GetGithubConnectors(withSecrets)
+	return a.authServer.Services.ServerIdentity.GetGithubConnectors(withSecrets)
 }
 
 // DeleteGithubConnector deletes a Github connector by name.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2423,15 +2423,6 @@ func (a *ServerWithRoles) DeleteAllKubeServices(ctx context.Context) error {
 	return a.authServer.Services.DeleteAllKubeServices(ctx)
 }
 
-// GenerateUserSingleUseCerts exists to satisfy auth.ClientI but is not
-// implemented here.
-//
-// Use auth.GRPCServer.GenerateUserSingleUseCerts or
-// client.Client.GenerateUserSingleUseCerts instead.
-func (a *ServerWithRoles) GenerateUserSingleUseCerts(ctx context.Context) (proto.AuthService_GenerateUserSingleUseCertsClient, error) {
-	return nil, trace.NotImplemented("bug: GenerateUserSingleUseCerts must not be called on auth.ServerWithRoles")
-}
-
 // NewAdminAuthServer returns auth server authorized as admin,
 // used for auth server cached access
 func NewAdminAuthServer(authServer *Server, sessions session.Service, alog events.IAuditLog) (*ServerWithRoles, error) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -2180,12 +2180,6 @@ type IdentityService interface {
 	// returns the resulting certificates.
 	GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error)
 
-	// FIXME(dmitri): move me elsewhere
-	// // GenerateUserSingleUseCerts is like GenerateUserCerts but issues a
-	// // certificate for a single session
-	// // (https://github.com/gravitational/teleport/blob/3a1cf9111c2698aede2056513337f32bfc16f1f1/rfd/0014-session-2FA.md#sessions).
-	// GenerateUserSingleUseCerts(ctx context.Context) (proto.AuthService_GenerateUserSingleUseCertsClient, error)
-
 	// CreateResetPasswordToken creates a new user reset token
 	CreateResetPasswordToken(ctx context.Context, req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error)
 

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -397,11 +397,6 @@ func (c *Client) WaitForDelivery(context.Context) error {
 	return nil
 }
 
-// CreateCertAuthority not implemented: can only be called locally.
-func (c *Client) CreateCertAuthority(ca services.CertAuthority) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
 // RotateCertAuthority starts or restarts certificate authority rotation process.
 func (c *Client) RotateCertAuthority(req RotateRequest) error {
 	caType := "all"
@@ -497,16 +492,6 @@ func (c *Client) DeleteCertAuthority(id services.CertAuthID) error {
 	}
 	_, err := c.Delete(c.Endpoint("authorities", string(id.Type), id.DomainName))
 	return trace.Wrap(err)
-}
-
-// ActivateCertAuthority not implemented: can only be called locally.
-func (c *Client) ActivateCertAuthority(id services.CertAuthID) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeactivateCertAuthority not implemented: can only be called locally.
-func (c *Client) DeactivateCertAuthority(id services.CertAuthID) error {
-	return trace.NotImplemented(notImplementedMessage)
 }
 
 // GenerateToken creates a special provisioning token for a new SSH server
@@ -720,11 +705,6 @@ func (c *Client) UpsertReverseTunnel(tunnel services.ReverseTunnel) error {
 	return trace.Wrap(err)
 }
 
-// GetReverseTunnel not implemented: can only be called locally.
-func (c *Client) GetReverseTunnel(name string, opts ...services.MarshalOption) (services.ReverseTunnel, error) {
-	return nil, trace.NotImplemented(notImplementedMessage)
-}
-
 // GetReverseTunnels returns the list of created reverse tunnels
 func (c *Client) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
 	out, err := c.Get(c.Endpoint("reversetunnels"), url.Values{})
@@ -837,25 +817,10 @@ func (c *Client) DeleteTunnelConnections(clusterName string) error {
 	return trace.Wrap(err)
 }
 
-// DeleteAllTokens not implemented: can only be called locally.
-func (c *Client) DeleteAllTokens() error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
 // DeleteAllTunnelConnections deletes all tunnel connections
 func (c *Client) DeleteAllTunnelConnections() error {
 	_, err := c.Delete(c.Endpoint("tunnelconnections"))
 	return trace.Wrap(err)
-}
-
-// AddUserLoginAttempt logs user login attempt
-func (c *Client) AddUserLoginAttempt(user string, attempt services.LoginAttempt, ttl time.Duration) error {
-	panic("not implemented")
-}
-
-// GetUserLoginAttempts returns user login attempts
-func (c *Client) GetUserLoginAttempts(user string) ([]services.LoginAttempt, error) {
-	panic("not implemented")
 }
 
 // GetRemoteClusters returns a list of remote clusters
@@ -952,16 +917,6 @@ func (c *Client) GetAuthServers() ([]services.Server, error) {
 		re[i] = server
 	}
 	return re, nil
-}
-
-// DeleteAllAuthServers not implemented: can only be called locally.
-func (c *Client) DeleteAllAuthServers() error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAuthServer not implemented: can only be called locally.
-func (c *Client) DeleteAuthServer(name string) error {
-	return trace.NotImplemented(notImplementedMessage)
 }
 
 // UpsertProxy is used by proxies to report their presence
@@ -1799,11 +1754,6 @@ func (c *Client) GetRoles() ([]services.Role, error) {
 	return roles, nil
 }
 
-// CreateRole not implemented: can only be called locally.
-func (c *Client) CreateRole(role services.Role) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
 // UpsertRole creates or updates role
 func (c *Client) UpsertRole(ctx context.Context, role services.Role) error {
 	data, err := services.MarshalRole(role)
@@ -1897,11 +1847,6 @@ func (c *Client) SetClusterName(cn services.ClusterName) error {
 	return nil
 }
 
-// UpsertClusterName not implemented: can only be called locally.
-func (c *Client) UpsertClusterName(cn services.ClusterName) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
 // DeleteStaticTokens deletes static tokens
 func (c *Client) DeleteStaticTokens() error {
 	_, err := c.Delete(c.Endpoint("configuration", "static_tokens"))
@@ -1969,46 +1914,6 @@ func (c *Client) SetAuthPreference(cap services.AuthPreference) error {
 // GetLocalClusterName returns local cluster name
 func (c *Client) GetLocalClusterName() (string, error) {
 	return c.GetDomainName()
-}
-
-// DeleteClusterConfig not implemented: can only be called locally.
-func (c *Client) DeleteClusterConfig() error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteClusterName not implemented: can only be called locally.
-func (c *Client) DeleteClusterName() error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// UpsertLocalClusterName not implemented: can only be called locally.
-func (c *Client) UpsertLocalClusterName(string) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllCertAuthorities not implemented: can only be called locally.
-func (c *Client) DeleteAllCertAuthorities(caType services.CertAuthType) error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllReverseTunnels not implemented: can only be called locally.
-func (c *Client) DeleteAllReverseTunnels() error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllCertNamespaces not implemented: can only be called locally.
-func (c *Client) DeleteAllNamespaces() error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllRoles not implemented: can only be called locally.
-func (c *Client) DeleteAllRoles() error {
-	return trace.NotImplemented(notImplementedMessage)
-}
-
-// DeleteAllUsers not implemented: can only be called locally.
-func (c *Client) DeleteAllUsers() error {
-	return trace.NotImplemented(notImplementedMessage)
 }
 
 func (c *Client) GetTrustedCluster(name string) (services.TrustedCluster, error) {
@@ -2130,11 +2035,6 @@ func (c *Client) GetDatabaseServers(ctx context.Context, namespace string, opts 
 	}
 
 	return resp, nil
-}
-
-// UpsertAppSession not implemented: can only be called locally.
-func (c *Client) UpsertAppSession(ctx context.Context, session services.WebSession) error {
-	return trace.NotImplemented(notImplementedMessage)
 }
 
 // ResumeAuditStream resumes existing audit stream.
@@ -2280,13 +2180,11 @@ type IdentityService interface {
 	// returns the resulting certificates.
 	GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error)
 
-	// GenerateUserSingleUseCerts is like GenerateUserCerts but issues a
-	// certificate for a single session
-	// (https://github.com/gravitational/teleport/blob/3a1cf9111c2698aede2056513337f32bfc16f1f1/rfd/0014-session-2FA.md#sessions).
-	GenerateUserSingleUseCerts(ctx context.Context) (proto.AuthService_GenerateUserSingleUseCertsClient, error)
-
-	// DeleteAllUsers deletes all users
-	DeleteAllUsers() error
+	// FIXME(dmitri): move me elsewhere
+	// // GenerateUserSingleUseCerts is like GenerateUserCerts but issues a
+	// // certificate for a single session
+	// // (https://github.com/gravitational/teleport/blob/3a1cf9111c2698aede2056513337f32bfc16f1f1/rfd/0014-session-2FA.md#sessions).
+	// GenerateUserSingleUseCerts(ctx context.Context) (proto.AuthService_GenerateUserSingleUseCertsClient, error)
 
 	// CreateResetPasswordToken creates a new user reset token
 	CreateResetPasswordToken(ctx context.Context, req CreateResetPasswordTokenRequest) (services.ResetPasswordToken, error)
@@ -2299,6 +2197,14 @@ type IdentityService interface {
 
 	// RotateResetPasswordTokenSecrets rotates token secrets for a given tokenID
 	RotateResetPasswordTokenSecrets(ctx context.Context, tokenID string) (services.ResetPasswordTokenSecrets, error)
+}
+
+// LocalClient represents a client view of the auth server
+type LocalClient interface {
+	IdentityService
+
+	// NewKeepAliver returns a new instance of keep aliver
+	NewKeepAliver(ctx context.Context) (services.KeepAliver, error)
 
 	// GetMFADevices fetches all MFA devices registered for the calling user.
 	GetMFADevices(ctx context.Context, in *proto.GetMFADevicesRequest) (*proto.GetMFADevicesResponse, error)
@@ -2306,6 +2212,16 @@ type IdentityService interface {
 	AddMFADevice(ctx context.Context) (proto.AuthService_AddMFADeviceClient, error)
 	// DeleteMFADevice deletes a MFA device for the calling user.
 	DeleteMFADevice(ctx context.Context) (proto.AuthService_DeleteMFADeviceClient, error)
+}
+
+// LocalCluster represents a client view of the auth server
+type LocalCluster interface {
+	// GetClusterCACert returns the CAs for the local cluster without signing keys.
+	GetClusterCACert() (*LocalCAResponse, error)
+
+	// ProcessKubeCSR processes CSR request against Kubernetes CA, returns
+	// signed certificate if successful.
+	ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error)
 }
 
 // ProvisioningService is a service in control
@@ -2321,9 +2237,6 @@ type ProvisioningService interface {
 	// could be a reset password token or a machine token
 	DeleteToken(token string) error
 
-	// DeleteAllTokens deletes all provisioning tokens
-	DeleteAllTokens() error
-
 	// UpsertToken adds provisioning tokens for the auth server
 	UpsertToken(services.ProvisionToken) error
 
@@ -2335,61 +2248,42 @@ type ProvisioningService interface {
 	RegisterNewAuthServer(token string) error
 }
 
-// ClientI is a client to Auth service
-type ClientI interface {
-	IdentityService
-	ProvisioningService
-	services.Trust
-	events.IAuditLog
-	events.Streamer
-	events.Emitter
-	services.Presence
-	services.Access
-	services.DynamicAccess
-	services.DynamicAccessOracle
-	WebService
-	session.Service
-	services.ClusterConfiguration
-	services.Events
-
-	types.WebSessionsGetter
-	types.WebTokensGetter
-
-	// NewKeepAliver returns a new instance of keep aliver
-	NewKeepAliver(ctx context.Context) (services.KeepAliver, error)
-
-	// RotateCertAuthority starts or restarts certificate authority rotation process.
-	RotateCertAuthority(req RotateRequest) error
-
-	// RotateExternalCertAuthority rotates external certificate authority,
-	// this method is used to update only public keys and certificates of the
-	// the certificate authorities of trusted clusters.
-	RotateExternalCertAuthority(ca services.CertAuthority) error
-
+type Validation interface {
 	// ValidateTrustedCluster validates trusted cluster token with
 	// main cluster, in case if validation is successful, main cluster
 	// adds remote cluster
 	ValidateTrustedCluster(*ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error)
+}
 
-	// GetDomainName returns auth server cluster name
-	GetDomainName() (string, error)
+// ClientI is a client to Auth service
+type ClientI interface {
+	LocalClient
+	KeepAliver
+	WebService
+	Validation
+	WebAuth
+	LocalCluster
+	ProvisioningService
+	DomainNameGetter
+	CertAuthorityRotator
+	KeyGenerator
 
-	// GetClusterCACert returns the CAs for the local cluster without signing keys.
-	GetClusterCACert() (*LocalCAResponse, error)
+	services.Trust
+	services.Presence
+	services.Access
+	services.DynamicAccess
+	services.DynamicAccessOracle
+	services.ClusterConfiguration
+	services.Events
 
-	// GenerateServerKeys generates new host private keys and certificates (signed
-	// by the host certificate authority) for a node
-	GenerateServerKeys(GenerateServerKeysRequest) (*PackedKeys, error)
-	// AuthenticateWebUser authenticates web user, creates and  returns web session
-	// in case if authentication is successful
-	AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error)
-	// AuthenticateSSHUser authenticates SSH console user, creates and  returns a pair of signed TLS and SSH
-	// short lived certificates as a result
-	AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error)
+	events.IAuditLog
+	events.Streamer
+	events.Emitter
 
-	// ProcessKubeCSR processes CSR request against Kubernetes CA, returns
-	// signed certificate if successful.
-	ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error)
+	session.Service
+
+	types.WebSessionsGetter
+	types.WebTokensGetter
 
 	// Ping gets basic info about the auth server.
 	Ping(ctx context.Context) (proto.PingResponse, error)
@@ -2409,4 +2303,18 @@ type ClientI interface {
 	// GetWebToken queries the existing web token described with req.
 	// Implements ReadAccessPoint.
 	GetWebToken(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error)
+}
+
+type DomainNameGetter interface {
+	// GetDomainName returns auth server cluster name
+	GetDomainName() (string, error)
+}
+
+type WebAuth interface {
+	// AuthenticateWebUser authenticates web user, creates and  returns web session
+	// in case if authentication is successful
+	AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error)
+	// AuthenticateSSHUser authenticates SSH console user, creates and  returns a pair of signed TLS and SSH
+	// short lived certificates as a result
+	AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error)
 }

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -2264,9 +2264,9 @@ type clientCluster interface {
 	ValidateTrustedCluster(*ValidateTrustedClusterRequest) (*ValidateTrustedClusterResponse, error)
 }
 
-// provisioningService is a service in control
+// clientProvisioningService is a service in control
 // of adding new nodes, auth servers and proxies to the cluster
-type provisioningService interface {
+type clientProvisioningService interface {
 	// GetTokens returns a list of active invitation tokens for nodes and users
 	GetTokens(opts ...services.MarshalOption) (tokens []services.ProvisionToken, err error)
 
@@ -2292,9 +2292,9 @@ type provisioningService interface {
 type ClientI interface {
 	clientIdentity
 	clientCluster
+	clientProvisioningService
 	keepAliver
 	webService
-	provisioningService
 
 	services.Trust
 	services.Presence

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -126,7 +126,7 @@ func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 	ttl := roles.AdjustSessionTTL(defaults.CertDuration)
 
 	// Generate the TLS certificate.
-	userCA, err := s.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
+	userCA, err := s.Services.ServerTrust.GetCertAuthority(services.CertAuthID{
 		Type:       services.UserCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -126,7 +126,7 @@ func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 	ttl := roles.AdjustSessionTTL(defaults.CertDuration)
 
 	// Generate the TLS certificate.
-	userCA, err := s.Trust.GetCertAuthority(services.CertAuthID{
+	userCA, err := s.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
 		Type:       services.UserCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -40,7 +40,7 @@ import (
 
 // CreateGithubAuthRequest creates a new request for Github OAuth2 flow
 func (a *Server) CreateGithubAuthRequest(req services.GithubAuthRequest) (*services.GithubAuthRequest, error) {
-	connector, err := a.Services.LocalIdentity.GetGithubConnector(req.ConnectorID, true)
+	connector, err := a.Services.ServerIdentity.GetGithubConnector(req.ConnectorID, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -56,7 +56,7 @@ func (a *Server) CreateGithubAuthRequest(req services.GithubAuthRequest) (*servi
 	log.WithFields(logrus.Fields{trace.Component: "github"}).Debugf(
 		"Redirect URL: %v.", req.RedirectURL)
 	req.SetTTL(a.GetClock(), defaults.GithubAuthRequestTTL)
-	err = a.Services.LocalIdentity.CreateGithubAuthRequest(req)
+	err = a.Services.ServerIdentity.CreateGithubAuthRequest(req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -65,7 +65,7 @@ func (a *Server) CreateGithubAuthRequest(req services.GithubAuthRequest) (*servi
 
 // upsertGithubConnector creates or updates a Github connector.
 func (a *Server) upsertGithubConnector(ctx context.Context, connector services.GithubConnector) error {
-	if err := a.Services.LocalIdentity.UpsertGithubConnector(connector); err != nil {
+	if err := a.Services.ServerIdentity.UpsertGithubConnector(connector); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.emitter.EmitAuditEvent(a.closeCtx, &events.GithubConnectorCreate{
@@ -88,7 +88,7 @@ func (a *Server) upsertGithubConnector(ctx context.Context, connector services.G
 
 // deleteGithubConnector deletes a Github connector by name.
 func (a *Server) deleteGithubConnector(ctx context.Context, connectorName string) error {
-	if err := a.Services.LocalIdentity.DeleteGithubConnector(connectorName); err != nil {
+	if err := a.Services.ServerIdentity.DeleteGithubConnector(connectorName); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -197,11 +197,11 @@ func (a *Server) validateGithubAuthCallback(q url.Values) (*githubAuthResponse, 
 		return nil, trace.OAuth2(oauth2.ErrorInvalidRequest,
 			"missing state query param", q)
 	}
-	req, err := a.Services.LocalIdentity.GetGithubAuthRequest(stateToken)
+	req, err := a.Services.ServerIdentity.GetGithubAuthRequest(stateToken)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	connector, err := a.Services.LocalIdentity.GetGithubConnector(req.ConnectorID, true)
+	connector, err := a.Services.ServerIdentity.GetGithubConnector(req.ConnectorID, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -323,7 +323,7 @@ func (a *Server) createSessionCert(user services.User, sessionTTL time.Duration,
 	// It's safe to extract the roles and traits directly from services.User
 	// because this occurs during the user creation process and services.User
 	// is not fetched from the backend.
-	checker, err := services.FetchRoles(user.GetRoles(), a.Services.LocalAccess, user.GetTraits())
+	checker, err := services.FetchRoles(user.GetRoles(), a.Services.ServerAccess, user.GetTraits())
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -390,7 +390,7 @@ func (a *Server) calculateGithubUser(connector services.GithubConnector, claims 
 	p.traits = modules.GetModules().TraitsFromLogins(p.username, p.logins, p.kubeGroups, p.kubeUsers)
 
 	// Pick smaller for role: session TTL from role or requested TTL.
-	roles, err := services.FetchRoles(p.roles, a.Services.LocalAccess, p.traits)
+	roles, err := services.FetchRoles(p.roles, a.Services.ServerAccess, p.traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1607,7 +1607,7 @@ func userSingleUseCertsAuthChallenge(gctx *grpcContext, stream proto.AuthService
 	ctx := stream.Context()
 	auth := gctx.authServer
 	user := gctx.User.GetName()
-	u2fStorage, err := u2f.InMemoryAuthenticationStorage(auth.Identity)
+	u2fStorage, err := u2f.InMemoryAuthenticationStorage(auth.LocalIdentity)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1282,7 +1282,7 @@ func addMFADeviceAuthChallenge(gctx *grpcContext, stream proto.AuthService_AddMF
 	auth := gctx.authServer
 	user := gctx.User.GetName()
 	ctx := stream.Context()
-	u2fStorage, err := u2f.InMemoryAuthenticationStorage(auth.Services.LocalIdentity)
+	u2fStorage, err := u2f.InMemoryAuthenticationStorage(auth.Services.ServerIdentity)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1319,7 +1319,7 @@ func addMFADeviceRegisterChallenge(gctx *grpcContext, stream proto.AuthService_A
 	auth := gctx.authServer
 	user := gctx.User.GetName()
 	ctx := stream.Context()
-	u2fStorage, err := u2f.InMemoryRegistrationStorage(auth.Services.LocalIdentity)
+	u2fStorage, err := u2f.InMemoryRegistrationStorage(auth.Services.ServerIdentity)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1483,7 +1483,7 @@ func deleteMFADeviceAuthChallenge(gctx *grpcContext, stream proto.AuthService_De
 	ctx := stream.Context()
 	auth := gctx.authServer
 	user := gctx.User.GetName()
-	u2fStorage, err := u2f.InMemoryAuthenticationStorage(auth.Services.LocalIdentity)
+	u2fStorage, err := u2f.InMemoryAuthenticationStorage(auth.Services.ServerIdentity)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1607,7 +1607,7 @@ func userSingleUseCertsAuthChallenge(gctx *grpcContext, stream proto.AuthService
 	ctx := stream.Context()
 	auth := gctx.authServer
 	user := gctx.User.GetName()
-	u2fStorage, err := u2f.InMemoryAuthenticationStorage(auth.LocalIdentity)
+	u2fStorage, err := u2f.InMemoryAuthenticationStorage(auth.ServerIdentity)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -171,13 +171,13 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	err = srv.AuthServer.SetClusterConfig(services.DefaultClusterConfig())
+	err = srv.AuthServer.Services.SetClusterConfig(services.DefaultClusterConfig())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// set cluster name in the backend
-	err = srv.AuthServer.SetClusterName(clusterName)
+	err = srv.AuthServer.Services.SetClusterName(clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -188,7 +188,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = srv.AuthServer.SetAuthPreference(authPreference)
+	err = srv.AuthServer.Services.SetAuthPreference(authPreference)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -200,7 +200,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = srv.AuthServer.SetStaticTokens(staticTokens)
+	err = srv.AuthServer.Services.SetStaticTokens(staticTokens)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -208,27 +208,27 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	ctx := context.Background()
 
 	// create the default role
-	err = srv.AuthServer.UpsertRole(ctx, services.NewAdminRole())
+	err = srv.AuthServer.Services.UpsertRole(ctx, services.NewAdminRole())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Setup certificate and signing authorities.
-	if err = srv.AuthServer.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
+	if err = srv.AuthServer.Services.LocalTrust.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
 		Type:        services.HostCA,
 		ClusterName: srv.ClusterName,
 		Clock:       cfg.Clock,
 	})); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err = srv.AuthServer.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
+	if err = srv.AuthServer.Services.LocalTrust.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
 		Type:        services.UserCA,
 		ClusterName: srv.ClusterName,
 		Clock:       cfg.Clock,
 	})); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err = srv.AuthServer.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
+	if err = srv.AuthServer.Services.LocalTrust.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
 		Type:        services.JWTSigner,
 		ClusterName: srv.ClusterName,
 		Clock:       cfg.Clock,
@@ -236,7 +236,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	srv.Authorizer, err = NewAuthorizer(srv.AuthServer.Access, srv.AuthServer.Identity, srv.AuthServer.Trust)
+	srv.Authorizer, err = NewAuthorizer(srv.AuthServer.Services.LocalAccess, srv.AuthServer.Services.LocalIdentity, srv.AuthServer.Services.LocalTrust)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -344,7 +344,7 @@ func (a *TestAuthServer) Trust(remote *TestAuthServer, roleMap services.RoleMap)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = a.AuthServer.UpsertCertAuthority(remoteCA)
+	err = a.AuthServer.Services.LocalTrust.UpsertCertAuthority(remoteCA)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -356,7 +356,7 @@ func (a *TestAuthServer) Trust(remote *TestAuthServer, roleMap services.RoleMap)
 		return trace.Wrap(err)
 	}
 	remoteCA.SetRoleMap(roleMap)
-	err = a.AuthServer.UpsertCertAuthority(remoteCA)
+	err = a.AuthServer.Services.LocalTrust.UpsertCertAuthority(remoteCA)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -214,21 +214,21 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	}
 
 	// Setup certificate and signing authorities.
-	if err = srv.AuthServer.Services.LocalTrust.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
+	if err = srv.AuthServer.Services.ServerTrust.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
 		Type:        services.HostCA,
 		ClusterName: srv.ClusterName,
 		Clock:       cfg.Clock,
 	})); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err = srv.AuthServer.Services.LocalTrust.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
+	if err = srv.AuthServer.Services.ServerTrust.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
 		Type:        services.UserCA,
 		ClusterName: srv.ClusterName,
 		Clock:       cfg.Clock,
 	})); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err = srv.AuthServer.Services.LocalTrust.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
+	if err = srv.AuthServer.Services.ServerTrust.UpsertCertAuthority(suite.NewTestCAWithConfig(suite.TestCAConfig{
 		Type:        services.JWTSigner,
 		ClusterName: srv.ClusterName,
 		Clock:       cfg.Clock,
@@ -236,7 +236,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	srv.Authorizer, err = NewAuthorizer(srv.AuthServer.Services.LocalAccess, srv.AuthServer.Services.LocalIdentity, srv.AuthServer.Services.LocalTrust)
+	srv.Authorizer, err = NewAuthorizer(srv.AuthServer.Services.ServerAccess, srv.AuthServer.Services.ServerIdentity, srv.AuthServer.Services.ServerTrust)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -344,7 +344,7 @@ func (a *TestAuthServer) Trust(remote *TestAuthServer, roleMap services.RoleMap)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = a.AuthServer.Services.LocalTrust.UpsertCertAuthority(remoteCA)
+	err = a.AuthServer.Services.ServerTrust.UpsertCertAuthority(remoteCA)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -356,7 +356,7 @@ func (a *TestAuthServer) Trust(remote *TestAuthServer, roleMap services.RoleMap)
 		return trace.Wrap(err)
 	}
 	remoteCA.SetRoleMap(roleMap)
-	err = a.AuthServer.Services.LocalTrust.UpsertCertAuthority(remoteCA)
+	err = a.AuthServer.Services.ServerTrust.UpsertCertAuthority(remoteCA)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -93,19 +93,19 @@ type InitConfig struct {
 	OIDCConnectors []services.OIDCConnector
 
 	// Trust is a service that manages users and credentials
-	Trust services.LocalTrust
+	Trust services.ServerTrust
 
 	// Presence service is a discovery and hearbeat tracker
-	Presence services.LocalPresence
+	Presence services.ServerPresence
 
 	// Provisioner is a service that keeps track of provisioning tokens
-	Provisioner services.LocalProvisioner
+	Provisioner services.ServerProvisioner
 
 	// Identity is a service that manages users and credentials
-	Identity services.LocalIdentity
+	Identity services.ServerIdentity
 
 	// Access is service controlling access to resources
-	Access services.LocalAccess
+	Access services.ServerAccess
 
 	// DynamicAccess is a service that manages dynamic RBAC.
 	DynamicAccess services.DynamicAccess
@@ -114,7 +114,7 @@ type InitConfig struct {
 	Events services.Events
 
 	// ClusterConfiguration is a services that holds cluster wide configuration.
-	ClusterConfiguration services.LocalClusterConfiguration
+	ClusterConfiguration services.ServerClusterConfiguration
 
 	// Roles is a set of roles to create
 	Roles []services.Role
@@ -215,7 +215,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 		// Don't re-create CA if it already exists, otherwise
 		// the existing cluster configuration will be corrupted;
 		// this part of code is only used in tests.
-		if err := asrv.Services.LocalTrust.CreateCertAuthority(ca); err != nil {
+		if err := asrv.Services.ServerTrust.CreateCertAuthority(ca); err != nil {
 			if !trace.IsAlreadyExists(err) {
 				return nil, trace.Wrap(err)
 			}
@@ -256,7 +256,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	// is trying to change the name.
 	if trace.IsAlreadyExists(err) {
 		// Get current name of cluster from the backend.
-		cn, err := asrv.Services.LocalClusterConfiguration.GetClusterName()
+		cn, err := asrv.Services.ServerClusterConfiguration.GetClusterName()
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -347,7 +347,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 			},
 		}
 
-		if err := asrv.Services.LocalTrust.UpsertCertAuthority(userCA); err != nil {
+		if err := asrv.Services.ServerTrust.UpsertCertAuthority(userCA); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	} else if len(userCA.GetTLSKeyPairs()) == 0 {
@@ -360,7 +360,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 			return nil, trace.Wrap(err)
 		}
 		userCA.SetTLSKeyPairs([]services.TLSKeyPair{{Cert: certPEM, Key: keyPEM}})
-		if err := asrv.Services.LocalTrust.UpsertCertAuthority(userCA); err != nil {
+		if err := asrv.Services.ServerTrust.UpsertCertAuthority(userCA); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -406,7 +406,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 				TLSKeyPairs:  []services.TLSKeyPair{{Cert: certPEM, Key: keyPEM}},
 			},
 		}
-		if err := asrv.Services.LocalTrust.UpsertCertAuthority(hostCA); err != nil {
+		if err := asrv.Services.ServerTrust.UpsertCertAuthority(hostCA); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	} else if len(hostCA.GetTLSKeyPairs()) == 0 {
@@ -427,7 +427,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 			return nil, trace.Wrap(err)
 		}
 		hostCA.SetTLSKeyPairs([]services.TLSKeyPair{{Cert: certPEM, Key: keyPEM}})
-		if err := asrv.Services.LocalTrust.UpsertCertAuthority(hostCA); err != nil {
+		if err := asrv.Services.ServerTrust.UpsertCertAuthority(hostCA); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -447,7 +447,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		if err := asrv.Services.LocalTrust.UpsertCertAuthority(jwtSigner); err != nil {
+		if err := asrv.Services.ServerTrust.UpsertCertAuthority(jwtSigner); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
@@ -78,8 +79,8 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	// with special provisions.
 	log.Debugf("Generating certificate to access remote Kubernetes clusters.")
 
-	hostCA, err := s.GetCertAuthority(services.CertAuthID{
-		Type:       services.HostCA,
+	hostCA, err := s.GetCertAuthority(types.CertAuthID{
+		Type:       types.HostCA,
 		DomainName: req.ClusterName,
 	}, false)
 	if err != nil {
@@ -113,8 +114,8 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	// Get the correct cert TTL based on roles.
 	ttl := roles.AdjustSessionTTL(defaults.CertDuration)
 
-	userCA, err := s.Services.ServerTrust.GetCertAuthority(services.CertAuthID{
-		Type:       services.UserCA,
+	userCA, err := s.Services.ServerTrust.GetCertAuthority(types.CertAuthID{
+		Type:       types.UserCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)
 	if err != nil {

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -113,7 +113,7 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	// Get the correct cert TTL based on roles.
 	ttl := roles.AdjustSessionTTL(defaults.CertDuration)
 
-	userCA, err := s.Trust.GetCertAuthority(services.CertAuthID{
+	userCA, err := s.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
 		Type:       services.UserCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -113,7 +113,7 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	// Get the correct cert TTL based on roles.
 	ttl := roles.AdjustSessionTTL(defaults.CertDuration)
 
-	userCA, err := s.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
+	userCA, err := s.Services.ServerTrust.GetCertAuthority(services.CertAuthID{
 		Type:       services.UserCA,
 		DomainName: clusterName.GetClusterName(),
 	}, true)

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -115,7 +115,7 @@ func (s *Server) authenticateUser(ctx context.Context, req AuthenticateUserReque
 		return trace.Wrap(err)
 	}
 
-	authPreference, err := s.GetAuthPreference()
+	authPreference, err := s.Services.GetAuthPreference()
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -186,7 +186,7 @@ func (s *Server) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebS
 	}
 
 	if req.Session != nil {
-		session, err := s.GetWebSession(context.TODO(), types.GetWebSessionRequest{
+		session, err := s.Services.GetWebSession(context.TODO(), types.GetWebSessionRequest{
 			User:      req.Username,
 			SessionID: req.Session.ID,
 		})

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -146,7 +146,7 @@ func oidcConfig(conn services.OIDCConnector) oidc.ClientConfig {
 
 // UpsertOIDCConnector creates or updates an OIDC connector.
 func (a *Server) UpsertOIDCConnector(ctx context.Context, connector services.OIDCConnector) error {
-	if err := a.Identity.UpsertOIDCConnector(connector); err != nil {
+	if err := a.Services.LocalIdentity.UpsertOIDCConnector(connector); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.emitter.EmitAuditEvent(ctx, &events.OIDCConnectorCreate{
@@ -169,7 +169,7 @@ func (a *Server) UpsertOIDCConnector(ctx context.Context, connector services.OID
 
 // DeleteOIDCConnector deletes an OIDC connector by name.
 func (a *Server) DeleteOIDCConnector(ctx context.Context, connectorName string) error {
-	if err := a.Identity.DeleteOIDCConnector(connectorName); err != nil {
+	if err := a.Services.LocalIdentity.DeleteOIDCConnector(connectorName); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.emitter.EmitAuditEvent(ctx, &events.OIDCConnectorDelete{
@@ -190,7 +190,7 @@ func (a *Server) DeleteOIDCConnector(ctx context.Context, connectorName string) 
 }
 
 func (a *Server) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*services.OIDCAuthRequest, error) {
-	connector, err := a.Identity.GetOIDCConnector(req.ConnectorID, true)
+	connector, err := a.Services.LocalIdentity.GetOIDCConnector(req.ConnectorID, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -229,7 +229,7 @@ func (a *Server) CreateOIDCAuthRequest(req services.OIDCAuthRequest) (*services.
 
 	log.Debugf("OIDC redirect URL: %v.", req.RedirectURL)
 
-	err = a.Identity.CreateOIDCAuthRequest(req, defaults.OIDCAuthRequestTTL)
+	err = a.Services.LocalIdentity.CreateOIDCAuthRequest(req, defaults.OIDCAuthRequestTTL)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -307,12 +307,12 @@ func (a *Server) validateOIDCAuthCallback(q url.Values) (*oidcAuthResponse, erro
 		return nil, trace.Wrap(err)
 	}
 
-	req, err := a.Identity.GetOIDCAuthRequest(stateToken)
+	req, err := a.Services.LocalIdentity.GetOIDCAuthRequest(stateToken)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	connector, err := a.Identity.GetOIDCConnector(req.ConnectorID, true)
+	connector, err := a.Services.LocalIdentity.GetOIDCConnector(req.ConnectorID, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -461,7 +461,7 @@ func (a *Server) calculateOIDCUser(connector services.OIDCConnector, claims jose
 	}
 
 	// Pick smaller for role: session TTL from role or requested TTL.
-	roles, err := services.FetchRoles(p.roles, a.Access, p.traits)
+	roles, err := services.FetchRoles(p.roles, a.Services.LocalAccess, p.traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -505,7 +505,7 @@ func (a *Server) createOIDCUser(p *createUserParams) (services.User, error) {
 	}
 
 	// Get the user to check if it already exists or not.
-	existingUser, err := a.Identity.GetUser(p.username, false)
+	existingUser, err := a.Services.LocalIdentity.GetUser(p.username, false)
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -289,7 +289,7 @@ func (s *Server) CreateSignupU2FRegisterRequest(tokenID string) (*u2f.RegisterCh
 	return u2f.RegisterInit(u2f.RegisterInitParams{
 		StorageKey: tokenID,
 		AppConfig:  *u2fConfig,
-		Storage:    s.Services.LocalIdentity,
+		Storage:    s.Services.ServerIdentity,
 	})
 }
 
@@ -370,7 +370,7 @@ func (s *Server) changeUserSecondFactor(req ChangePasswordWithTokenRequest, Rese
 	case teleport.OFF:
 		return nil
 	case teleport.OTP, teleport.TOTP, teleport.HOTP:
-		secrets, err := s.Services.LocalIdentity.GetResetPasswordTokenSecrets(ctx, req.TokenID)
+		secrets, err := s.Services.ServerIdentity.GetResetPasswordTokenSecrets(ctx, req.TokenID)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -400,7 +400,7 @@ func (s *Server) changeUserSecondFactor(req ChangePasswordWithTokenRequest, Rese
 			ChallengeStorageKey:    req.TokenID,
 			RegistrationStorageKey: username,
 			Resp:                   req.U2FRegisterResponse,
-			Storage:                s.Services.LocalIdentity,
+			Storage:                s.Services.ServerIdentity,
 			Clock:                  s.GetClock(),
 		})
 		return trace.Wrap(err)

--- a/lib/auth/resetpasswordtoken.go
+++ b/lib/auth/resetpasswordtoken.go
@@ -123,7 +123,7 @@ func (s *Server) CreateResetPasswordToken(ctx context.Context, req CreateResetPa
 		return nil, trace.Wrap(err)
 	}
 
-	_, err = s.Services.LocalIdentity.CreateResetPasswordToken(ctx, token)
+	_, err = s.Services.ServerIdentity.CreateResetPasswordToken(ctx, token)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/resetpasswordtoken.go
+++ b/lib/auth/resetpasswordtoken.go
@@ -123,7 +123,7 @@ func (s *Server) CreateResetPasswordToken(ctx context.Context, req CreateResetPa
 		return nil, trace.Wrap(err)
 	}
 
-	_, err = s.Identity.CreateResetPasswordToken(ctx, token)
+	_, err = s.Services.LocalIdentity.CreateResetPasswordToken(ctx, token)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -145,7 +145,7 @@ func (s *Server) CreateResetPasswordToken(ctx context.Context, req CreateResetPa
 		log.WithError(err).Warn("Failed to emit create reset password token event.")
 	}
 
-	return s.GetResetPasswordToken(ctx, token.GetName())
+	return s.Services.GetResetPasswordToken(ctx, token.GetName())
 }
 
 // proxyDomainGetter is a reduced subset of the Auth API for formatAccountName.
@@ -196,7 +196,7 @@ func formatAccountName(s proxyDomainGetter, username string, authHostname string
 // extract the OTP key from the QR code, then allow the user to signup with
 // the same OTP token.
 func (s *Server) RotateResetPasswordTokenSecrets(ctx context.Context, tokenID string) (services.ResetPasswordTokenSecrets, error) {
-	token, err := s.GetResetPasswordToken(ctx, tokenID)
+	token, err := s.Services.GetResetPasswordToken(ctx, tokenID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -222,7 +222,7 @@ func (s *Server) RotateResetPasswordTokenSecrets(ctx context.Context, tokenID st
 	}
 	secrets.SetOTPKey(key.Secret())
 	secrets.SetQRCode(otpQRBuf.Bytes())
-	err = s.UpsertResetPasswordTokenSecrets(ctx, secrets)
+	err = s.Services.UpsertResetPasswordTokenSecrets(ctx, secrets)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -307,7 +307,7 @@ func formatResetPasswordTokenURL(proxyHost string, tokenID string, reqType strin
 }
 
 func (s *Server) deleteResetPasswordTokens(ctx context.Context, username string) error {
-	tokens, err := s.GetResetPasswordTokens(ctx)
+	tokens, err := s.Services.GetResetPasswordTokens(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -317,7 +317,7 @@ func (s *Server) deleteResetPasswordTokens(ctx context.Context, username string)
 			continue
 		}
 
-		err = s.DeleteResetPasswordToken(ctx, token.GetName())
+		err = s.Services.DeleteResetPasswordToken(ctx, token.GetName())
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -213,7 +213,7 @@ func (a *Server) RotateCertAuthority(req RotateRequest) error {
 
 	caTypes := req.Types()
 	for _, caType := range caTypes {
-		existing, err := a.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
+		existing, err := a.Services.ServerTrust.GetCertAuthority(services.CertAuthID{
 			Type:       caType,
 			DomainName: clusterName.GetClusterName(),
 		}, true)
@@ -233,7 +233,7 @@ func (a *Server) RotateCertAuthority(req RotateRequest) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := a.Services.LocalTrust.CompareAndSwapCertAuthority(rotated, existing); err != nil {
+		if err := a.Services.ServerTrust.CompareAndSwapCertAuthority(rotated, existing); err != nil {
 			return trace.Wrap(err)
 		}
 		rotation := rotated.GetRotation()
@@ -265,7 +265,7 @@ func (a *Server) RotateExternalCertAuthority(ca services.CertAuthority) error {
 		return trace.BadParameter("can not rotate local certificate authority")
 	}
 
-	existing, err := a.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
+	existing, err := a.Services.ServerTrust.GetCertAuthority(services.CertAuthID{
 		Type:       ca.GetType(),
 		DomainName: ca.GetClusterName(),
 	}, false)
@@ -283,7 +283,7 @@ func (a *Server) RotateExternalCertAuthority(ca services.CertAuthority) error {
 
 	// use compare and swap to protect from concurrent updates
 	// by trusted cluster API
-	if err := a.Services.LocalTrust.CompareAndSwapCertAuthority(updated, existing); err != nil {
+	if err := a.Services.ServerTrust.CompareAndSwapCertAuthority(updated, existing); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -299,7 +299,7 @@ func (a *Server) autoRotateCertAuthorities() error {
 		return trace.Wrap(err)
 	}
 	for _, caType := range []services.CertAuthType{services.HostCA, services.UserCA, services.JWTSigner} {
-		ca, err := a.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
+		ca, err := a.Services.ServerTrust.GetCertAuthority(services.CertAuthID{
 			Type:       caType,
 			DomainName: clusterName.GetClusterName(),
 		}, true)
@@ -370,7 +370,7 @@ func (a *Server) autoRotate(ca services.CertAuthority) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.Services.LocalTrust.CompareAndSwapCertAuthority(rotated, ca); err != nil {
+	if err := a.Services.ServerTrust.CompareAndSwapCertAuthority(rotated, ca); err != nil {
 		return trace.Wrap(err)
 	}
 	logger.Infof("Cert authority rotation request is completed")

--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -213,7 +213,7 @@ func (a *Server) RotateCertAuthority(req RotateRequest) error {
 
 	caTypes := req.Types()
 	for _, caType := range caTypes {
-		existing, err := a.Trust.GetCertAuthority(services.CertAuthID{
+		existing, err := a.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
 			Type:       caType,
 			DomainName: clusterName.GetClusterName(),
 		}, true)
@@ -233,7 +233,7 @@ func (a *Server) RotateCertAuthority(req RotateRequest) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := a.CompareAndSwapCertAuthority(rotated, existing); err != nil {
+		if err := a.Services.LocalTrust.CompareAndSwapCertAuthority(rotated, existing); err != nil {
 			return trace.Wrap(err)
 		}
 		rotation := rotated.GetRotation()
@@ -265,7 +265,7 @@ func (a *Server) RotateExternalCertAuthority(ca services.CertAuthority) error {
 		return trace.BadParameter("can not rotate local certificate authority")
 	}
 
-	existing, err := a.Trust.GetCertAuthority(services.CertAuthID{
+	existing, err := a.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
 		Type:       ca.GetType(),
 		DomainName: ca.GetClusterName(),
 	}, false)
@@ -283,7 +283,7 @@ func (a *Server) RotateExternalCertAuthority(ca services.CertAuthority) error {
 
 	// use compare and swap to protect from concurrent updates
 	// by trusted cluster API
-	if err := a.CompareAndSwapCertAuthority(updated, existing); err != nil {
+	if err := a.Services.LocalTrust.CompareAndSwapCertAuthority(updated, existing); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -299,7 +299,7 @@ func (a *Server) autoRotateCertAuthorities() error {
 		return trace.Wrap(err)
 	}
 	for _, caType := range []services.CertAuthType{services.HostCA, services.UserCA, services.JWTSigner} {
-		ca, err := a.Trust.GetCertAuthority(services.CertAuthID{
+		ca, err := a.Services.LocalTrust.GetCertAuthority(services.CertAuthID{
 			Type:       caType,
 			DomainName: clusterName.GetClusterName(),
 		}, true)
@@ -370,7 +370,7 @@ func (a *Server) autoRotate(ca services.CertAuthority) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.CompareAndSwapCertAuthority(rotated, ca); err != nil {
+	if err := a.Services.LocalTrust.CompareAndSwapCertAuthority(rotated, ca); err != nil {
 		return trace.Wrap(err)
 	}
 	logger.Infof("Cert authority rotation request is completed")

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -37,7 +37,7 @@ import (
 
 // UpsertSAMLConnector creates or updates a SAML connector.
 func (a *Server) UpsertSAMLConnector(ctx context.Context, connector services.SAMLConnector) error {
-	if err := a.Services.LocalIdentity.UpsertSAMLConnector(connector); err != nil {
+	if err := a.Services.ServerIdentity.UpsertSAMLConnector(connector); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.emitter.EmitAuditEvent(ctx, &events.OIDCConnectorCreate{
@@ -60,7 +60,7 @@ func (a *Server) UpsertSAMLConnector(ctx context.Context, connector services.SAM
 
 // DeleteSAMLConnector deletes a SAML connector by name.
 func (a *Server) DeleteSAMLConnector(ctx context.Context, connectorName string) error {
-	if err := a.Services.LocalIdentity.DeleteSAMLConnector(connectorName); err != nil {
+	if err := a.Services.ServerIdentity.DeleteSAMLConnector(connectorName); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := a.emitter.EmitAuditEvent(ctx, &events.OIDCConnectorDelete{
@@ -82,7 +82,7 @@ func (a *Server) DeleteSAMLConnector(ctx context.Context, connectorName string) 
 }
 
 func (a *Server) CreateSAMLAuthRequest(req services.SAMLAuthRequest) (*services.SAMLAuthRequest, error) {
-	connector, err := a.Services.LocalIdentity.GetSAMLConnector(req.ConnectorID, true)
+	connector, err := a.Services.ServerIdentity.GetSAMLConnector(req.ConnectorID, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -107,7 +107,7 @@ func (a *Server) CreateSAMLAuthRequest(req services.SAMLAuthRequest) (*services.
 		return nil, trace.Wrap(err)
 	}
 
-	err = a.Services.LocalIdentity.CreateSAMLAuthRequest(req, defaults.SAMLAuthRequestTTL)
+	err = a.Services.ServerIdentity.CreateSAMLAuthRequest(req, defaults.SAMLAuthRequestTTL)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -150,7 +150,7 @@ func (a *Server) calculateSAMLUser(connector services.SAMLConnector, assertionIn
 	}
 
 	// Pick smaller for role: session TTL from role or requested TTL.
-	roles, err := services.FetchRoles(p.roles, a.Services.LocalAccess, p.traits)
+	roles, err := services.FetchRoles(p.roles, a.Services.ServerAccess, p.traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -197,7 +197,7 @@ func (a *Server) createSAMLUser(p *createUserParams) (services.User, error) {
 	}
 
 	// Get the user to check if it already exists or not.
-	existingUser, err := a.Services.LocalIdentity.GetUser(p.username, false)
+	existingUser, err := a.Services.ServerIdentity.GetUser(p.username, false)
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
@@ -335,11 +335,11 @@ func (a *Server) validateSAMLResponse(samlResponse string) (*samlAuthResponse, e
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	request, err := a.Services.LocalIdentity.GetSAMLAuthRequest(requestID)
+	request, err := a.Services.ServerIdentity.GetSAMLAuthRequest(requestID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	connector, err := a.Services.LocalIdentity.GetSAMLConnector(request.ConnectorID, true)
+	connector, err := a.Services.ServerIdentity.GetSAMLConnector(request.ConnectorID, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -88,7 +88,7 @@ func (s *Server) CreateAppSession(ctx context.Context, req services.CreateAppSes
 		TLSCert: certs.tls,
 		Expires: s.clock.Now().Add(ttl),
 	})
-	if err = s.Services.LocalIdentity.UpsertAppSession(ctx, session); err != nil {
+	if err = s.Services.ServerIdentity.UpsertAppSession(ctx, session); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	log.Debugf("Generated application web session for %v with TTL %v.", req.Username, ttl)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -38,7 +38,7 @@ import (
 // control is enforced.
 func (s *Server) CreateAppSession(ctx context.Context, req services.CreateAppSessionRequest, user services.User, checker services.AccessChecker) (services.WebSession, error) {
 	// Check that a matching parent web session exists in the backend.
-	parentSession, err := s.GetWebSession(ctx, types.GetWebSessionRequest{
+	parentSession, err := s.Services.GetWebSession(ctx, types.GetWebSessionRequest{
 		User:      req.Username,
 		SessionID: req.ParentSession,
 	})
@@ -88,7 +88,7 @@ func (s *Server) CreateAppSession(ctx context.Context, req services.CreateAppSes
 		TLSCert: certs.tls,
 		Expires: s.clock.Now().Add(ttl),
 	})
-	if err = s.Identity.UpsertAppSession(ctx, session); err != nil {
+	if err = s.Services.LocalIdentity.UpsertAppSession(ctx, session); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	log.Debugf("Generated application web session for %v with TTL %v.", req.Username, ttl)

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -912,7 +912,7 @@ func (s *TLSSuite) TestClusterConfig(c *check.C) {
 	testSuite := &suite.ServicesTestSuite{
 		ConfigS: clt,
 	}
-	testSuite.ClusterConfig(c, suite.SkipDelete())
+	testSuite.ClusterConfig(c)
 }
 
 func (s *TLSSuite) TestTunnelConnectionsCRUD(c *check.C) {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -2919,7 +2919,7 @@ func (s *TLSSuite) TestEventsClusterConfig(c *check.C) {
 	err = s.server.Auth().SetClusterName(clusterName)
 	c.Assert(err, check.IsNil)
 
-	clusterNameResource, err = s.server.Auth().ClusterConfiguration.GetClusterName()
+	clusterNameResource, err = s.server.Auth().Services.LocalClusterConfiguration.GetClusterName()
 	c.Assert(err, check.IsNil)
 	suite.ExpectResource(c, w, 3*time.Second, clusterNameResource)
 }

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -2919,7 +2919,7 @@ func (s *TLSSuite) TestEventsClusterConfig(c *check.C) {
 	err = s.server.Auth().SetClusterName(clusterName)
 	c.Assert(err, check.IsNil)
 
-	clusterNameResource, err = s.server.Auth().Services.LocalClusterConfiguration.GetClusterName()
+	clusterNameResource, err = s.server.Auth().Services.ServerClusterConfiguration.GetClusterName()
 	c.Assert(err, check.IsNil)
 	suite.ExpectResource(c, w, 3*time.Second, clusterNameResource)
 }

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -45,7 +45,7 @@ func (a *Server) UpsertTrustedCluster(ctx context.Context, trustedCluster servic
 	var existingCluster services.TrustedCluster
 	if trustedCluster.GetName() != "" {
 		var err error
-		if existingCluster, err = a.Services.LocalPresence.GetTrustedCluster(trustedCluster.GetName()); err == nil {
+		if existingCluster, err = a.Services.ServerPresence.GetTrustedCluster(trustedCluster.GetName()); err == nil {
 			exists = true
 		}
 	}
@@ -136,7 +136,7 @@ func (a *Server) UpsertTrustedCluster(ctx context.Context, trustedCluster servic
 		}
 	}
 
-	tc, err := a.Services.LocalPresence.UpsertTrustedCluster(ctx, trustedCluster)
+	tc, err := a.Services.ServerPresence.UpsertTrustedCluster(ctx, trustedCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -192,13 +192,13 @@ func (a *Server) DeleteTrustedCluster(ctx context.Context, name string) error {
 		return trace.BadParameter("trusted cluster %q is the name of this root cluster and cannot be removed.", name)
 	}
 
-	if err := a.Services.LocalTrust.DeleteCertAuthority(services.CertAuthID{Type: services.HostCA, DomainName: name}); err != nil {
+	if err := a.Services.ServerTrust.DeleteCertAuthority(services.CertAuthID{Type: services.HostCA, DomainName: name}); err != nil {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
 	}
 
-	if err := a.Services.LocalTrust.DeleteCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: name}); err != nil {
+	if err := a.Services.ServerTrust.DeleteCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: name}); err != nil {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
@@ -210,7 +210,7 @@ func (a *Server) DeleteTrustedCluster(ctx context.Context, name string) error {
 		}
 	}
 
-	if err := a.Services.LocalPresence.DeleteTrustedCluster(ctx, name); err != nil {
+	if err := a.Services.ServerPresence.DeleteTrustedCluster(ctx, name); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -313,7 +313,7 @@ func (a *Server) addCertAuthorities(trustedCluster services.TrustedCluster, remo
 
 		// we use create here instead of upsert to prevent people from wiping out
 		// their own ca if it has the same name as the remote ca
-		err := a.Services.LocalTrust.CreateCertAuthority(remoteCertAuthority)
+		err := a.Services.ServerTrust.CreateCertAuthority(remoteCertAuthority)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -327,12 +327,12 @@ func (a *Server) addCertAuthorities(trustedCluster services.TrustedCluster, remo
 func (a *Server) DeleteRemoteCluster(clusterName string) error {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	_, err := a.Services.LocalPresence.GetRemoteCluster(clusterName)
+	_, err := a.Services.ServerPresence.GetRemoteCluster(clusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	// delete cert authorities associated with the cluster
-	err = a.Services.LocalTrust.DeleteCertAuthority(services.CertAuthID{
+	err = a.Services.ServerTrust.DeleteCertAuthority(services.CertAuthID{
 		Type:       services.HostCA,
 		DomainName: clusterName,
 	})
@@ -346,7 +346,7 @@ func (a *Server) DeleteRemoteCluster(clusterName string) error {
 	}
 	// there should be no User CA in trusted clusters on the main cluster side
 	// per standard automation but clean up just in case
-	err = a.Services.LocalTrust.DeleteCertAuthority(services.CertAuthID{
+	err = a.Services.ServerTrust.DeleteCertAuthority(services.CertAuthID{
 		Type:       services.UserCA,
 		DomainName: clusterName,
 	})
@@ -355,14 +355,14 @@ func (a *Server) DeleteRemoteCluster(clusterName string) error {
 			return trace.Wrap(err)
 		}
 	}
-	return a.Services.LocalPresence.DeleteRemoteCluster(clusterName)
+	return a.Services.ServerPresence.DeleteRemoteCluster(clusterName)
 }
 
 // GetRemoteCluster returns remote cluster by name
 func (a *Server) GetRemoteCluster(clusterName string) (services.RemoteCluster, error) {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	remoteCluster, err := a.Services.LocalPresence.GetRemoteCluster(clusterName)
+	remoteCluster, err := a.Services.ServerPresence.GetRemoteCluster(clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -427,7 +427,7 @@ func (a *Server) updateRemoteClusterStatus(remoteCluster services.RemoteCluster)
 func (a *Server) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
 	// To make sure remote cluster exists - to protect against random
 	// clusterName requests (e.g. when clusterName is set to local cluster name)
-	remoteClusters, err := a.Services.LocalPresence.GetRemoteClusters(opts...)
+	remoteClusters, err := a.Services.ServerPresence.GetRemoteClusters(opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -487,7 +487,7 @@ func (a *Server) validateTrustedCluster(validateRequest *ValidateTrustedClusterR
 
 	// token has been validated, upsert the given certificate authority
 	for _, certAuthority := range validateRequest.CAs {
-		err = a.Services.LocalTrust.UpsertCertAuthority(certAuthority)
+		err = a.Services.ServerTrust.UpsertCertAuthority(certAuthority)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -677,23 +677,23 @@ func (v *ValidateTrustedClusterResponseRaw) ToNative() (*ValidateTrustedClusterR
 // activateCertAuthority will activate both the user and host certificate
 // authority given in the services.TrustedCluster resource.
 func (a *Server) activateCertAuthority(t services.TrustedCluster) error {
-	err := a.Services.LocalTrust.ActivateCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: t.GetName()})
+	err := a.Services.ServerTrust.ActivateCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: t.GetName()})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(a.Services.LocalTrust.ActivateCertAuthority(services.CertAuthID{Type: services.HostCA, DomainName: t.GetName()}))
+	return trace.Wrap(a.Services.ServerTrust.ActivateCertAuthority(services.CertAuthID{Type: services.HostCA, DomainName: t.GetName()}))
 }
 
 // deactivateCertAuthority will deactivate both the user and host certificate
 // authority given in the services.TrustedCluster resource.
 func (a *Server) deactivateCertAuthority(t services.TrustedCluster) error {
-	err := a.Services.LocalTrust.DeactivateCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: t.GetName()})
+	err := a.Services.ServerTrust.DeactivateCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: t.GetName()})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(a.Services.LocalTrust.DeactivateCertAuthority(services.CertAuthID{Type: services.HostCA, DomainName: t.GetName()}))
+	return trace.Wrap(a.Services.ServerTrust.DeactivateCertAuthority(services.CertAuthID{Type: services.HostCA, DomainName: t.GetName()}))
 }
 
 // createReverseTunnel will create a services.ReverseTunnel givenin the

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -45,7 +45,7 @@ func (s *Server) CreateUser(ctx context.Context, user services.User) error {
 	// TODO: ctx is being swallowed here because the current implementation of
 	// s.Identity.CreateUser is an older implementation that does not curently
 	// accept a context.
-	if err := s.Identity.CreateUser(user); err != nil {
+	if err := s.Services.LocalIdentity.CreateUser(user); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -79,7 +79,7 @@ func (s *Server) CreateUser(ctx context.Context, user services.User) error {
 
 // UpdateUser updates an existing user in a backend.
 func (s *Server) UpdateUser(ctx context.Context, user services.User) error {
-	if err := s.Identity.UpdateUser(ctx, user); err != nil {
+	if err := s.Services.LocalIdentity.UpdateUser(ctx, user); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -113,7 +113,7 @@ func (s *Server) UpdateUser(ctx context.Context, user services.User) error {
 
 // UpsertUser updates a user.
 func (s *Server) UpsertUser(user services.User) error {
-	err := s.Identity.UpsertUser(user)
+	err := s.Services.LocalIdentity.UpsertUser(user)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -148,20 +148,20 @@ func (s *Server) UpsertUser(user services.User) error {
 
 // DeleteUser deletes an existng user in a backend by username.
 func (s *Server) DeleteUser(ctx context.Context, user string) error {
-	role, err := s.Access.GetRole(services.RoleNameForUser(user))
+	role, err := s.Services.LocalAccess.GetRole(services.RoleNameForUser(user))
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
 	} else {
-		if err := s.Access.DeleteRole(ctx, role.GetName()); err != nil {
+		if err := s.Services.LocalAccess.DeleteRole(ctx, role.GetName()); err != nil {
 			if !trace.IsNotFound(err) {
 				return trace.Wrap(err)
 			}
 		}
 	}
 
-	err = s.Identity.DeleteUser(ctx, user)
+	err = s.Services.LocalIdentity.DeleteUser(ctx, user)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -45,7 +45,7 @@ func (s *Server) CreateUser(ctx context.Context, user services.User) error {
 	// TODO: ctx is being swallowed here because the current implementation of
 	// s.Identity.CreateUser is an older implementation that does not curently
 	// accept a context.
-	if err := s.Services.LocalIdentity.CreateUser(user); err != nil {
+	if err := s.Services.ServerIdentity.CreateUser(user); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -79,7 +79,7 @@ func (s *Server) CreateUser(ctx context.Context, user services.User) error {
 
 // UpdateUser updates an existing user in a backend.
 func (s *Server) UpdateUser(ctx context.Context, user services.User) error {
-	if err := s.Services.LocalIdentity.UpdateUser(ctx, user); err != nil {
+	if err := s.Services.ServerIdentity.UpdateUser(ctx, user); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -113,7 +113,7 @@ func (s *Server) UpdateUser(ctx context.Context, user services.User) error {
 
 // UpsertUser updates a user.
 func (s *Server) UpsertUser(user services.User) error {
-	err := s.Services.LocalIdentity.UpsertUser(user)
+	err := s.Services.ServerIdentity.UpsertUser(user)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -148,20 +148,20 @@ func (s *Server) UpsertUser(user services.User) error {
 
 // DeleteUser deletes an existng user in a backend by username.
 func (s *Server) DeleteUser(ctx context.Context, user string) error {
-	role, err := s.Services.LocalAccess.GetRole(services.RoleNameForUser(user))
+	role, err := s.Services.ServerAccess.GetRole(services.RoleNameForUser(user))
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return trace.Wrap(err)
 		}
 	} else {
-		if err := s.Services.LocalAccess.DeleteRole(ctx, role.GetName()); err != nil {
+		if err := s.Services.ServerAccess.DeleteRole(ctx, role.GetName()); err != nil {
 			if !trace.IsNotFound(err) {
 				return trace.Wrap(err)
 			}
 		}
 	}
 
-	err = s.Services.LocalIdentity.DeleteUser(ctx, user)
+	err = s.Services.ServerIdentity.DeleteUser(ctx, user)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -269,16 +269,16 @@ type Cache struct {
 	// collections is a map of registered collections by resource Kind/SubKind
 	collections map[resourceKind]collection
 
-	trustCache         services.LocalTrust
-	clusterConfigCache services.LocalClusterConfiguration
-	provisionerCache   services.LocalProvisioner
-	usersCache         services.LocalUsers
-	accessCache        services.LocalAccess
+	trustCache         services.ServerTrust
+	clusterConfigCache services.ServerClusterConfiguration
+	provisionerCache   services.ServerProvisioner
+	usersCache         services.ServerUsers
+	accessCache        services.ServerAccess
 	dynamicAccessCache services.DynamicAccessExt
-	presenceCache      services.LocalPresence
-	appSessionCache    services.LocalAppSession
-	webSessionCache    services.LocalWebSessions
-	webTokenCache      services.LocalWebTokens
+	presenceCache      services.ServerPresence
+	appSessionCache    services.ServerAppSession
+	webSessionCache    services.ServerWebSessions
+	webTokenCache      services.ServerWebTokens
 	eventsFanout       *services.Fanout
 
 	// closed indicates that the cache has been closed

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -269,16 +269,16 @@ type Cache struct {
 	// collections is a map of registered collections by resource Kind/SubKind
 	collections map[resourceKind]collection
 
-	trustCache         services.Trust
-	clusterConfigCache services.ClusterConfiguration
-	provisionerCache   services.Provisioner
-	usersCache         services.UsersService
-	accessCache        services.Access
+	trustCache         services.LocalTrust
+	clusterConfigCache services.LocalClusterConfiguration
+	provisionerCache   services.LocalProvisioner
+	usersCache         services.LocalUsers
+	accessCache        services.LocalAccess
 	dynamicAccessCache services.DynamicAccessExt
-	presenceCache      services.Presence
-	appSessionCache    services.AppSession
-	webSessionCache    types.WebSessionInterface
-	webTokenCache      types.WebTokenInterface
+	presenceCache      services.LocalPresence
+	appSessionCache    services.LocalAppSession
+	webSessionCache    services.LocalWebSessions
+	webTokenCache      services.LocalWebTokens
 	eventsFanout       *services.Fanout
 
 	// closed indicates that the cache has been closed
@@ -392,7 +392,7 @@ type Config struct {
 	// for the cache to watch
 	Watches []services.WatchKind
 	// Events provides events watchers
-	Events services.Events
+	Events types.Events
 	// Trust is a service providing information about certificate
 	// authorities
 	Trust services.Trust

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -65,14 +65,14 @@ type testPack struct {
 	cacheBackend backend.Backend
 
 	eventsS        *proxyEvents
-	trustS         services.LocalTrust
-	provisionerS   services.LocalProvisioner
-	clusterConfigS services.LocalClusterConfiguration
+	trustS         services.ServerTrust
+	provisionerS   services.ServerProvisioner
+	clusterConfigS services.ServerClusterConfiguration
 
 	usersS         services.UsersService
-	accessS        services.LocalAccess
+	accessS        services.ServerAccess
 	dynamicAccessS services.DynamicAccess
-	presenceS      services.LocalPresence
+	presenceS      services.ServerPresence
 	appSessionS    services.AppSession
 	webSessionS    types.WebSessionInterface
 	webTokenS      types.WebTokenInterface

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -65,14 +65,14 @@ type testPack struct {
 	cacheBackend backend.Backend
 
 	eventsS        *proxyEvents
-	trustS         services.Trust
-	provisionerS   services.Provisioner
-	clusterConfigS services.ClusterConfiguration
+	trustS         services.LocalTrust
+	provisionerS   services.LocalProvisioner
+	clusterConfigS services.LocalClusterConfiguration
 
 	usersS         services.UsersService
-	accessS        services.Access
+	accessS        services.LocalAccess
 	dynamicAccessS services.DynamicAccess
-	presenceS      services.Presence
+	presenceS      services.LocalPresence
 	appSessionS    services.AppSession
 	webSessionS    types.WebSessionInterface
 	webTokenS      types.WebTokenInterface

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -116,25 +116,25 @@ type Config struct {
 	PIDFile string
 
 	// Trust is a service that manages users and credentials
-	Trust services.Trust
+	Trust services.LocalTrust
 
 	// Presence service is a discovery and hearbeat tracker
-	Presence services.Presence
+	Presence services.LocalPresence
 
 	// Events is events service
 	Events services.Events
 
 	// Provisioner is a service that keeps track of provisioning tokens
-	Provisioner services.Provisioner
+	Provisioner services.LocalProvisioner
 
 	// Trust is a service that manages users and credentials
-	Identity services.Identity
+	Identity services.LocalIdentity
 
 	// Access is a service that controls access
-	Access services.Access
+	Access services.LocalAccess
 
 	// ClusterConfiguration is a service that provides cluster configuration
-	ClusterConfiguration services.ClusterConfiguration
+	ClusterConfiguration services.LocalClusterConfiguration
 
 	// CipherSuites is a list of TLS ciphersuites that Teleport supports. If
 	// omitted, a Teleport selected list of defaults will be used.

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -116,25 +116,25 @@ type Config struct {
 	PIDFile string
 
 	// Trust is a service that manages users and credentials
-	Trust services.LocalTrust
+	Trust services.ServerTrust
 
 	// Presence service is a discovery and hearbeat tracker
-	Presence services.LocalPresence
+	Presence services.ServerPresence
 
 	// Events is events service
 	Events services.Events
 
 	// Provisioner is a service that keeps track of provisioning tokens
-	Provisioner services.LocalProvisioner
+	Provisioner services.ServerProvisioner
 
 	// Trust is a service that manages users and credentials
-	Identity services.LocalIdentity
+	Identity services.ServerIdentity
 
 	// Access is a service that controls access
-	Access services.LocalAccess
+	Access services.ServerAccess
 
 	// ClusterConfiguration is a service that provides cluster configuration
-	ClusterConfiguration services.LocalClusterConfiguration
+	ClusterConfiguration services.ServerClusterConfiguration
 
 	// CipherSuites is a list of TLS ciphersuites that Teleport supports. If
 	// omitted, a Teleport selected list of defaults will be used.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1425,7 +1425,11 @@ type cacheServices struct {
 type accessCacheConfig struct {
 	// services is a collection
 	// of services to use as a cache base
+
+	// FIXME(dmitri):
+	// services auth.ClientServices
 	services services.Services
+
 	// setup is a function that takes
 	// cache configuration and modifies it
 	setup cache.SetupConfigFn

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1170,7 +1170,7 @@ func (process *TeleportProcess) initAuthService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	authorizer, err := auth.NewAuthorizer(authServer.Services.LocalAccess, authServer.Services.LocalIdentity, authServer.Services.LocalTrust)
+	authorizer, err := auth.NewAuthorizer(authServer.Services.ServerAccess, authServer.Services.ServerIdentity, authServer.Services.ServerTrust)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -24,11 +24,6 @@ type ClusterConfiguration interface {
 	GetClusterName(opts ...MarshalOption) (ClusterName, error)
 	// SetClusterName sets services.ClusterName on the backend.
 	SetClusterName(ClusterName) error
-	// UpsertClusterName upserts cluster name
-	UpsertClusterName(ClusterName) error
-
-	// DeleteClusterName deletes cluster name resource
-	DeleteClusterName() error
 
 	// GetStaticTokens gets services.StaticTokens from the backend.
 	GetStaticTokens() (StaticTokens, error)
@@ -46,6 +41,18 @@ type ClusterConfiguration interface {
 	GetClusterConfig(opts ...MarshalOption) (ClusterConfig, error)
 	// SetClusterConfig sets services.ClusterConfig on the backend.
 	SetClusterConfig(ClusterConfig) error
+}
+
+// LocalClusterConfiguration manages cluster configuration on auth server
+type LocalClusterConfiguration interface {
+	ClusterConfiguration
+
+	// UpsertClusterName upserts cluster name
+	UpsertClusterName(ClusterName) error
+
 	// DeleteClusterConfig deletes cluster config resource
 	DeleteClusterConfig() error
+
+	// DeleteClusterName deletes cluster name resource
+	DeleteClusterName() error
 }

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -43,8 +43,8 @@ type ClusterConfiguration interface {
 	SetClusterConfig(ClusterConfig) error
 }
 
-// LocalClusterConfiguration manages cluster configuration on auth server
-type LocalClusterConfiguration interface {
+// ServerClusterConfiguration manages cluster configuration on auth server
+type ServerClusterConfiguration interface {
 	ClusterConfiguration
 
 	// UpsertClusterName upserts cluster name

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -51,6 +51,12 @@ type UsersService interface {
 	DeleteUser(ctx context.Context, user string) error
 	// GetUsers returns a list of users registered with the local auth server
 	GetUsers(withSecrets bool) ([]User, error)
+}
+
+// LocalUsers manages users on auth server
+type LocalUsers interface {
+	UsersService
+
 	// DeleteAllUsers deletes all users
 	DeleteAllUsers() error
 }
@@ -206,12 +212,42 @@ type Identity interface {
 
 	// GetResetPasswordTokenSecrets returns token secrets
 	GetResetPasswordTokenSecrets(ctx context.Context, tokenID string) (ResetPasswordTokenSecrets, error)
+}
 
-	types.WebSessionsGetter
-	types.WebTokensGetter
+// LocalIdentity represents the Identity on the auth server
+type LocalIdentity interface {
+	Identity
+	LocalAppSession
+	LocalWebSessionsGetter
+	LocalWebTokensGetter
+}
 
-	// AppSession defines application session features.
-	AppSession
+// LocalWebSessionsGetter manages web sessions on auth server
+type LocalWebSessionsGetter interface {
+	// WebSessions returns the web session manager
+	WebSessions() LocalWebSessions
+}
+
+// LocalWebSessions manages web sessions on the auth server
+type LocalWebSessions interface {
+	types.WebSessionInterface
+
+	// Upsert updates existing or inserts a new web session.
+	Upsert(ctx context.Context, session types.WebSession) error
+}
+
+// LocalWebTokensGetter manages web tokens on auth server
+type LocalWebTokensGetter interface {
+	// WebTokens returns the web token manager
+	WebTokens() LocalWebTokens
+}
+
+// LocalWebTokens manages web session on the auth server
+type LocalWebTokens interface {
+	types.WebTokenInterface
+
+	// Upsert updates existing or inserts a new web token.
+	Upsert(ctx context.Context, token types.WebToken) error
 }
 
 // AppSession defines application session features.
@@ -220,12 +256,18 @@ type AppSession interface {
 	GetAppSession(context.Context, GetAppSessionRequest) (WebSession, error)
 	// GetAppSessions gets all application web sessions.
 	GetAppSessions(context.Context) ([]WebSession, error)
-	// UpsertAppSession upserts and application web session.
-	UpsertAppSession(context.Context, WebSession) error
 	// DeleteAppSession removes an application web session.
 	DeleteAppSession(context.Context, DeleteAppSessionRequest) error
 	// DeleteAllAppSessions removes all application web sessions.
 	DeleteAllAppSessions(context.Context) error
+}
+
+// LocalAppSession manages application sessions on auth server
+type LocalAppSession interface {
+	AppSession
+
+	// UpsertAppSession upserts and application web session.
+	UpsertAppSession(context.Context, WebSession) error
 }
 
 // VerifyPassword makes sure password satisfies our requirements (relaxed),

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -217,6 +217,7 @@ type Identity interface {
 // ServerIdentity represents the Identity on the auth server
 type ServerIdentity interface {
 	Identity
+
 	ServerAppSession
 	ServerWebSessionsGetter
 	ServerWebTokensGetter

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -53,8 +53,8 @@ type UsersService interface {
 	GetUsers(withSecrets bool) ([]User, error)
 }
 
-// LocalUsers manages users on auth server
-type LocalUsers interface {
+// ServerUsers manages users on auth server
+type ServerUsers interface {
 	UsersService
 
 	// DeleteAllUsers deletes all users
@@ -214,36 +214,36 @@ type Identity interface {
 	GetResetPasswordTokenSecrets(ctx context.Context, tokenID string) (ResetPasswordTokenSecrets, error)
 }
 
-// LocalIdentity represents the Identity on the auth server
-type LocalIdentity interface {
+// ServerIdentity represents the Identity on the auth server
+type ServerIdentity interface {
 	Identity
-	LocalAppSession
-	LocalWebSessionsGetter
-	LocalWebTokensGetter
+	ServerAppSession
+	ServerWebSessionsGetter
+	ServerWebTokensGetter
 }
 
-// LocalWebSessionsGetter manages web sessions on auth server
-type LocalWebSessionsGetter interface {
+// ServerWebSessionsGetter manages web sessions on auth server
+type ServerWebSessionsGetter interface {
 	// WebSessions returns the web session manager
-	WebSessions() LocalWebSessions
+	WebSessions() ServerWebSessions
 }
 
-// LocalWebSessions manages web sessions on the auth server
-type LocalWebSessions interface {
+// ServerWebSessions manages web sessions on the auth server
+type ServerWebSessions interface {
 	types.WebSessionInterface
 
 	// Upsert updates existing or inserts a new web session.
 	Upsert(ctx context.Context, session types.WebSession) error
 }
 
-// LocalWebTokensGetter manages web tokens on auth server
-type LocalWebTokensGetter interface {
+// ServerWebTokensGetter manages web tokens on auth server
+type ServerWebTokensGetter interface {
 	// WebTokens returns the web token manager
-	WebTokens() LocalWebTokens
+	WebTokens() ServerWebTokens
 }
 
-// LocalWebTokens manages web session on the auth server
-type LocalWebTokens interface {
+// ServerWebTokens manages web session on the auth server
+type ServerWebTokens interface {
 	types.WebTokenInterface
 
 	// Upsert updates existing or inserts a new web token.
@@ -262,8 +262,8 @@ type AppSession interface {
 	DeleteAllAppSessions(context.Context) error
 }
 
-// LocalAppSession manages application sessions on auth server
-type LocalAppSession interface {
+// ServerAppSession manages application sessions on auth server
+type ServerAppSession interface {
 	AppSession
 
 	// UpsertAppSession upserts and application web session.

--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sort"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 
@@ -42,12 +43,12 @@ func (s *AccessService) DeleteAllRoles() error {
 }
 
 // GetRoles returns a list of roles registered with the local auth server
-func (s *AccessService) GetRoles() ([]services.Role, error) {
+func (s *AccessService) GetRoles() ([]types.Role, error) {
 	result, err := s.GetRange(context.TODO(), backend.Key(rolesPrefix), backend.RangeEnd(backend.Key(rolesPrefix)), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out := make([]services.Role, 0, len(result.Items))
+	out := make([]types.Role, 0, len(result.Items))
 	for _, item := range result.Items {
 		role, err := services.UnmarshalRole(item.Value,
 			services.WithResourceID(item.ID), services.WithExpires(item.Expires))
@@ -61,7 +62,7 @@ func (s *AccessService) GetRoles() ([]services.Role, error) {
 }
 
 // CreateRole creates a role on the backend.
-func (s *AccessService) CreateRole(role services.Role) error {
+func (s *AccessService) CreateRole(role types.Role) error {
 	value, err := services.MarshalRole(role)
 	if err != nil {
 		return trace.Wrap(err)
@@ -81,7 +82,7 @@ func (s *AccessService) CreateRole(role services.Role) error {
 }
 
 // UpsertRole updates parameters about role
-func (s *AccessService) UpsertRole(ctx context.Context, role services.Role) error {
+func (s *AccessService) UpsertRole(ctx context.Context, role types.Role) error {
 	value, err := services.MarshalRole(role)
 	if err != nil {
 		return trace.Wrap(err)
@@ -102,7 +103,7 @@ func (s *AccessService) UpsertRole(ctx context.Context, role services.Role) erro
 }
 
 // GetRole returns a role by name
-func (s *AccessService) GetRole(name string) (services.Role, error) {
+func (s *AccessService) GetRole(name string) (types.Role, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing role name")
 	}

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -19,6 +19,7 @@ package local
 import (
 	"context"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 
@@ -38,7 +39,7 @@ func NewClusterConfigurationService(backend backend.Backend) *ClusterConfigurati
 }
 
 // GetClusterName gets the name of the cluster from the backend.
-func (s *ClusterConfigurationService) GetClusterName(opts ...services.MarshalOption) (services.ClusterName, error) {
+func (s *ClusterConfigurationService) GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error) {
 	item, err := s.Get(context.TODO(), backend.Key(clusterConfigPrefix, namePrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -64,7 +65,7 @@ func (s *ClusterConfigurationService) DeleteClusterName() error {
 
 // SetClusterName sets the name of the cluster in the backend. SetClusterName
 // can only be called once on a cluster after which it will return trace.AlreadyExists.
-func (s *ClusterConfigurationService) SetClusterName(c services.ClusterName) error {
+func (s *ClusterConfigurationService) SetClusterName(c types.ClusterName) error {
 	value, err := services.MarshalClusterName(c)
 	if err != nil {
 		return trace.Wrap(err)
@@ -83,7 +84,7 @@ func (s *ClusterConfigurationService) SetClusterName(c services.ClusterName) err
 }
 
 // UpsertClusterName sets the name of the cluster in the backend.
-func (s *ClusterConfigurationService) UpsertClusterName(c services.ClusterName) error {
+func (s *ClusterConfigurationService) UpsertClusterName(c types.ClusterName) error {
 	value, err := services.MarshalClusterName(c)
 	if err != nil {
 		return trace.Wrap(err)
@@ -103,7 +104,7 @@ func (s *ClusterConfigurationService) UpsertClusterName(c services.ClusterName) 
 }
 
 // GetStaticTokens gets the list of static tokens used to provision nodes.
-func (s *ClusterConfigurationService) GetStaticTokens() (services.StaticTokens, error) {
+func (s *ClusterConfigurationService) GetStaticTokens() (types.StaticTokens, error) {
 	item, err := s.Get(context.TODO(), backend.Key(clusterConfigPrefix, staticTokensPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -116,7 +117,7 @@ func (s *ClusterConfigurationService) GetStaticTokens() (services.StaticTokens, 
 }
 
 // SetStaticTokens sets the list of static tokens used to provision nodes.
-func (s *ClusterConfigurationService) SetStaticTokens(c services.StaticTokens) error {
+func (s *ClusterConfigurationService) SetStaticTokens(c types.StaticTokens) error {
 	value, err := services.MarshalStaticTokens(c)
 	if err != nil {
 		return trace.Wrap(err)
@@ -148,7 +149,7 @@ func (s *ClusterConfigurationService) DeleteStaticTokens() error {
 
 // GetAuthPreference fetches the cluster authentication preferences
 // from the backend and return them.
-func (s *ClusterConfigurationService) GetAuthPreference() (services.AuthPreference, error) {
+func (s *ClusterConfigurationService) GetAuthPreference() (types.AuthPreference, error) {
 	item, err := s.Get(context.TODO(), backend.Key(authPrefix, preferencePrefix, generalPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -162,7 +163,7 @@ func (s *ClusterConfigurationService) GetAuthPreference() (services.AuthPreferen
 
 // SetAuthPreference sets the cluster authentication preferences
 // on the backend.
-func (s *ClusterConfigurationService) SetAuthPreference(preferences services.AuthPreference) error {
+func (s *ClusterConfigurationService) SetAuthPreference(preferences types.AuthPreference) error {
 	value, err := services.MarshalAuthPreference(preferences)
 	if err != nil {
 		return trace.Wrap(err)
@@ -182,8 +183,8 @@ func (s *ClusterConfigurationService) SetAuthPreference(preferences services.Aut
 	return nil
 }
 
-// GetClusterConfig gets services.ClusterConfig from the backend.
-func (s *ClusterConfigurationService) GetClusterConfig(opts ...services.MarshalOption) (services.ClusterConfig, error) {
+// GetClusterConfig gets types.ClusterConfig from the backend.
+func (s *ClusterConfigurationService) GetClusterConfig(opts ...services.MarshalOption) (types.ClusterConfig, error) {
 	item, err := s.Get(context.TODO(), backend.Key(clusterConfigPrefix, generalPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -196,7 +197,7 @@ func (s *ClusterConfigurationService) GetClusterConfig(opts ...services.MarshalO
 			services.WithExpires(item.Expires))...)
 }
 
-// DeleteClusterConfig deletes services.ClusterConfig from the backend.
+// DeleteClusterConfig deletes types.ClusterConfig from the backend.
 func (s *ClusterConfigurationService) DeleteClusterConfig() error {
 	err := s.Delete(context.TODO(), backend.Key(clusterConfigPrefix, generalPrefix))
 	if err != nil {
@@ -208,8 +209,8 @@ func (s *ClusterConfigurationService) DeleteClusterConfig() error {
 	return nil
 }
 
-// SetClusterConfig sets services.ClusterConfig on the backend.
-func (s *ClusterConfigurationService) SetClusterConfig(c services.ClusterConfig) error {
+// SetClusterConfig sets types.ClusterConfig on the backend.
+func (s *ClusterConfigurationService) SetClusterConfig(c types.ClusterConfig) error {
 	value, err := services.MarshalClusterConfig(c)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -53,22 +53,28 @@ func (s *ClusterConfigurationSuite) TearDownTest(c *check.C) {
 }
 
 func (s *ClusterConfigurationSuite) TestAuthPreference(c *check.C) {
+	config := NewClusterConfigurationService(s.bk)
 	suite := &suite.ServicesTestSuite{
-		ConfigS: NewClusterConfigurationService(s.bk),
+		ConfigS:      config,
+		LocalConfigS: config,
 	}
 	suite.AuthPreference(c)
 }
 
 func (s *ClusterConfigurationSuite) TestClusterConfig(c *check.C) {
+	config := NewClusterConfigurationService(s.bk)
 	suite := &suite.ServicesTestSuite{
-		ConfigS: NewClusterConfigurationService(s.bk),
+		ConfigS:      config,
+		LocalConfigS: config,
 	}
 	suite.ClusterConfig(c)
 }
 
 func (s *ClusterConfigurationSuite) TestStaticTokens(c *check.C) {
+	config := NewClusterConfigurationService(s.bk)
 	suite := &suite.ServicesTestSuite{
-		ConfigS: NewClusterConfigurationService(s.bk),
+		ConfigS:      config,
+		LocalConfigS: config,
 	}
 	suite.StaticTokens(c)
 }

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -54,28 +54,25 @@ func (s *ClusterConfigurationSuite) TearDownTest(c *check.C) {
 
 func (s *ClusterConfigurationSuite) TestAuthPreference(c *check.C) {
 	config := NewClusterConfigurationService(s.bk)
-	suite := &suite.ServicesTestSuite{
-		ConfigS:      config,
-		LocalConfigS: config,
-	}
+	suite := suite.NewServerTestSuite(suite.ServerServicesTestSuite{
+		ConfigS: config,
+	})
 	suite.AuthPreference(c)
 }
 
 func (s *ClusterConfigurationSuite) TestClusterConfig(c *check.C) {
 	config := NewClusterConfigurationService(s.bk)
-	suite := &suite.ServicesTestSuite{
-		ConfigS:      config,
-		LocalConfigS: config,
-	}
+	suite := suite.NewServerTestSuite(suite.ServerServicesTestSuite{
+		ConfigS: config,
+	})
 	suite.ClusterConfig(c)
 }
 
 func (s *ClusterConfigurationSuite) TestStaticTokens(c *check.C) {
 	config := NewClusterConfigurationService(s.bk)
-	suite := &suite.ServicesTestSuite{
-		ConfigS:      config,
-		LocalConfigS: config,
-	}
+	suite := suite.NewServerTestSuite(suite.ServerServicesTestSuite{
+		ConfigS: config,
+	})
 	suite.StaticTokens(c)
 }
 

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -79,12 +79,12 @@ func (s *PresenceService) DeleteAllNamespaces() error {
 }
 
 // GetNamespaces returns a list of namespaces
-func (s *PresenceService) GetNamespaces() ([]services.Namespace, error) {
+func (s *PresenceService) GetNamespaces() ([]types.Namespace, error) {
 	result, err := s.GetRange(context.TODO(), backend.Key(namespacesPrefix), backend.RangeEnd(backend.Key(namespacesPrefix)), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out := make([]services.Namespace, 0, len(result.Items))
+	out := make([]types.Namespace, 0, len(result.Items))
 	for _, item := range result.Items {
 		if !bytes.HasSuffix(item.Key, []byte(paramsPrefix)) {
 			continue
@@ -101,7 +101,7 @@ func (s *PresenceService) GetNamespaces() ([]services.Namespace, error) {
 }
 
 // UpsertNamespace upserts namespace
-func (s *PresenceService) UpsertNamespace(n services.Namespace) error {
+func (s *PresenceService) UpsertNamespace(n types.Namespace) error {
 	if err := n.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -124,7 +124,7 @@ func (s *PresenceService) UpsertNamespace(n services.Namespace) error {
 }
 
 // GetNamespace returns a namespace by name
-func (s *PresenceService) GetNamespace(name string) (*services.Namespace, error) {
+func (s *PresenceService) GetNamespace(name string) (*types.Namespace, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing namespace name")
 	}
@@ -153,12 +153,12 @@ func (s *PresenceService) DeleteNamespace(namespace string) error {
 	return trace.Wrap(err)
 }
 
-func (s *PresenceService) getServers(ctx context.Context, kind, prefix string) ([]services.Server, error) {
+func (s *PresenceService) getServers(ctx context.Context, kind, prefix string) ([]types.Server, error) {
 	result, err := s.GetRange(ctx, backend.Key(prefix), backend.RangeEnd(backend.Key(prefix)), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	servers := make([]services.Server, len(result.Items))
+	servers := make([]types.Server, len(result.Items))
 	for i, item := range result.Items {
 		server, err := services.UnmarshalServer(
 			item.Value, kind,
@@ -176,7 +176,7 @@ func (s *PresenceService) getServers(ctx context.Context, kind, prefix string) (
 	return servers, nil
 }
 
-func (s *PresenceService) upsertServer(ctx context.Context, prefix string, server services.Server) error {
+func (s *PresenceService) upsertServer(ctx context.Context, prefix string, server types.Server) error {
 	value, err := services.MarshalServer(server)
 	if err != nil {
 		return trace.Wrap(err)
@@ -203,7 +203,7 @@ func (s *PresenceService) DeleteNode(namespace string, name string) error {
 }
 
 // GetNodes returns a list of registered servers
-func (s *PresenceService) GetNodes(namespace string, opts ...services.MarshalOption) ([]services.Server, error) {
+func (s *PresenceService) GetNodes(namespace string, opts ...services.MarshalOption) ([]types.Server, error) {
 	if namespace == "" {
 		return nil, trace.BadParameter("missing namespace value")
 	}
@@ -215,11 +215,11 @@ func (s *PresenceService) GetNodes(namespace string, opts ...services.MarshalOpt
 		return nil, trace.Wrap(err)
 	}
 	// Marshal values into a []services.Server slice.
-	servers := make([]services.Server, len(result.Items))
+	servers := make([]types.Server, len(result.Items))
 	for i, item := range result.Items {
 		server, err := services.UnmarshalServer(
 			item.Value,
-			services.KindNode,
+			types.KindNode,
 			services.AddOptions(opts,
 				services.WithResourceID(item.ID),
 				services.WithExpires(item.Expires))...)
@@ -234,7 +234,7 @@ func (s *PresenceService) GetNodes(namespace string, opts ...services.MarshalOpt
 
 // UpsertNode registers node presence, permanently if TTL is 0 or for the
 // specified duration with second resolution if it's >= 1 second.
-func (s *PresenceService) UpsertNode(server services.Server) (*services.KeepAlive, error) {
+func (s *PresenceService) UpsertNode(server types.Server) (*types.KeepAlive, error) {
 	if server.GetNamespace() == "" {
 		return nil, trace.BadParameter("missing node namespace")
 	}
@@ -252,10 +252,10 @@ func (s *PresenceService) UpsertNode(server services.Server) (*services.KeepAliv
 		return nil, trace.Wrap(err)
 	}
 	if server.Expiry().IsZero() {
-		return &services.KeepAlive{}, nil
+		return &types.KeepAlive{}, nil
 	}
-	return &services.KeepAlive{
-		Type:    services.KeepAlive_NODE,
+	return &types.KeepAlive{
+		Type:    types.KeepAlive_NODE,
 		LeaseID: lease.ID,
 		Name:    server.GetName(),
 	}, nil
@@ -266,7 +266,7 @@ func (s *PresenceService) UpsertNode(server services.Server) (*services.KeepAliv
 // This logic has been moved to KeepAliveServer.
 //
 // KeepAliveNode updates node expiry
-func (s *PresenceService) KeepAliveNode(ctx context.Context, h services.KeepAlive) error {
+func (s *PresenceService) KeepAliveNode(ctx context.Context, h types.KeepAlive) error {
 	if err := h.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -279,7 +279,7 @@ func (s *PresenceService) KeepAliveNode(ctx context.Context, h services.KeepAliv
 
 // UpsertNodes is used for bulk insertion of nodes. Schema validation is
 // always skipped during bulk insertion.
-func (s *PresenceService) UpsertNodes(namespace string, servers []services.Server) error {
+func (s *PresenceService) UpsertNodes(namespace string, servers []types.Server) error {
 	batch, ok := s.Backend.(backend.Batch)
 	if !ok {
 		return trace.BadParameter("backend does not support batch interface")
@@ -316,13 +316,13 @@ func (s *PresenceService) UpsertNodes(namespace string, servers []services.Serve
 }
 
 // GetAuthServers returns a list of registered servers
-func (s *PresenceService) GetAuthServers() ([]services.Server, error) {
-	return s.getServers(context.TODO(), services.KindAuthServer, authServersPrefix)
+func (s *PresenceService) GetAuthServers() ([]types.Server, error) {
+	return s.getServers(context.TODO(), types.KindAuthServer, authServersPrefix)
 }
 
 // UpsertAuthServer registers auth server presence, permanently if ttl is 0 or
 // for the specified duration with second resolution if it's >= 1 second
-func (s *PresenceService) UpsertAuthServer(server services.Server) error {
+func (s *PresenceService) UpsertAuthServer(server types.Server) error {
 	return s.upsertServer(context.TODO(), authServersPrefix, server)
 }
 
@@ -340,13 +340,13 @@ func (s *PresenceService) DeleteAuthServer(name string) error {
 
 // UpsertProxy registers proxy server presence, permanently if ttl is 0 or
 // for the specified duration with second resolution if it's >= 1 second
-func (s *PresenceService) UpsertProxy(server services.Server) error {
+func (s *PresenceService) UpsertProxy(server types.Server) error {
 	return s.upsertServer(context.TODO(), proxiesPrefix, server)
 }
 
 // GetProxies returns a list of registered proxies
-func (s *PresenceService) GetProxies() ([]services.Server, error) {
-	return s.getServers(context.TODO(), services.KindProxy, proxiesPrefix)
+func (s *PresenceService) GetProxies() ([]types.Server, error) {
+	return s.getServers(context.TODO(), types.KindProxy, proxiesPrefix)
 }
 
 // DeleteAllProxies deletes all proxies
@@ -368,7 +368,7 @@ func (s *PresenceService) DeleteAllReverseTunnels() error {
 }
 
 // UpsertReverseTunnel upserts reverse tunnel entry temporarily or permanently
-func (s *PresenceService) UpsertReverseTunnel(tunnel services.ReverseTunnel) error {
+func (s *PresenceService) UpsertReverseTunnel(tunnel types.ReverseTunnel) error {
 	if err := services.ValidateReverseTunnel(tunnel); err != nil {
 		return trace.Wrap(err)
 	}
@@ -386,7 +386,7 @@ func (s *PresenceService) UpsertReverseTunnel(tunnel services.ReverseTunnel) err
 }
 
 // GetReverseTunnel returns reverse tunnel by name
-func (s *PresenceService) GetReverseTunnel(name string, opts ...services.MarshalOption) (services.ReverseTunnel, error) {
+func (s *PresenceService) GetReverseTunnel(name string, opts ...services.MarshalOption) (types.ReverseTunnel, error) {
 	item, err := s.Get(context.TODO(), backend.Key(reverseTunnelsPrefix, name))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -396,13 +396,13 @@ func (s *PresenceService) GetReverseTunnel(name string, opts ...services.Marshal
 }
 
 // GetReverseTunnels returns a list of registered servers
-func (s *PresenceService) GetReverseTunnels(opts ...services.MarshalOption) ([]services.ReverseTunnel, error) {
+func (s *PresenceService) GetReverseTunnels(opts ...services.MarshalOption) ([]types.ReverseTunnel, error) {
 	startKey := backend.Key(reverseTunnelsPrefix)
 	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tunnels := make([]services.ReverseTunnel, len(result.Items))
+	tunnels := make([]types.ReverseTunnel, len(result.Items))
 	for i, item := range result.Items {
 		tunnel, err := services.UnmarshalReverseTunnel(
 			item.Value, services.AddOptions(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires))...)
@@ -423,7 +423,7 @@ func (s *PresenceService) DeleteReverseTunnel(clusterName string) error {
 }
 
 // UpsertTrustedCluster creates or updates a TrustedCluster in the backend.
-func (s *PresenceService) UpsertTrustedCluster(ctx context.Context, trustedCluster services.TrustedCluster) (services.TrustedCluster, error) {
+func (s *PresenceService) UpsertTrustedCluster(ctx context.Context, trustedCluster types.TrustedCluster) (types.TrustedCluster, error) {
 	if err := services.ValidateTrustedCluster(trustedCluster); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -444,7 +444,7 @@ func (s *PresenceService) UpsertTrustedCluster(ctx context.Context, trustedClust
 }
 
 // GetTrustedCluster returns a single TrustedCluster by name.
-func (s *PresenceService) GetTrustedCluster(name string) (services.TrustedCluster, error) {
+func (s *PresenceService) GetTrustedCluster(name string) (types.TrustedCluster, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing trusted cluster name")
 	}
@@ -456,13 +456,13 @@ func (s *PresenceService) GetTrustedCluster(name string) (services.TrustedCluste
 }
 
 // GetTrustedClusters returns all TrustedClusters in the backend.
-func (s *PresenceService) GetTrustedClusters() ([]services.TrustedCluster, error) {
+func (s *PresenceService) GetTrustedClusters() ([]types.TrustedCluster, error) {
 	startKey := backend.Key(trustedClustersPrefix)
 	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out := make([]services.TrustedCluster, len(result.Items))
+	out := make([]types.TrustedCluster, len(result.Items))
 	for i, item := range result.Items {
 		tc, err := services.UnmarshalTrustedCluster(item.Value,
 			services.WithResourceID(item.ID), services.WithExpires(item.Expires))
@@ -491,7 +491,7 @@ func (s *PresenceService) DeleteTrustedCluster(ctx context.Context, name string)
 }
 
 // UpsertTunnelConnection updates or creates tunnel connection
-func (s *PresenceService) UpsertTunnelConnection(conn services.TunnelConnection) error {
+func (s *PresenceService) UpsertTunnelConnection(conn types.TunnelConnection) error {
 	if err := conn.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -512,7 +512,7 @@ func (s *PresenceService) UpsertTunnelConnection(conn services.TunnelConnection)
 }
 
 // GetTunnelConnection returns connection by cluster name and connection name
-func (s *PresenceService) GetTunnelConnection(clusterName, connectionName string, opts ...services.MarshalOption) (services.TunnelConnection, error) {
+func (s *PresenceService) GetTunnelConnection(clusterName, connectionName string, opts ...services.MarshalOption) (types.TunnelConnection, error) {
 	item, err := s.Get(context.TODO(), backend.Key(tunnelConnectionsPrefix, clusterName, connectionName))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -529,7 +529,7 @@ func (s *PresenceService) GetTunnelConnection(clusterName, connectionName string
 }
 
 // GetTunnelConnections returns connections for a trusted cluster
-func (s *PresenceService) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
+func (s *PresenceService) GetTunnelConnections(clusterName string, opts ...services.MarshalOption) ([]types.TunnelConnection, error) {
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing cluster name")
 	}
@@ -538,7 +538,7 @@ func (s *PresenceService) GetTunnelConnections(clusterName string, opts ...servi
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	conns := make([]services.TunnelConnection, len(result.Items))
+	conns := make([]types.TunnelConnection, len(result.Items))
 	for i, item := range result.Items {
 		conn, err := services.UnmarshalTunnelConnection(item.Value,
 			services.AddOptions(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires))...)
@@ -552,14 +552,14 @@ func (s *PresenceService) GetTunnelConnections(clusterName string, opts ...servi
 }
 
 // GetAllTunnelConnections returns all tunnel connections
-func (s *PresenceService) GetAllTunnelConnections(opts ...services.MarshalOption) ([]services.TunnelConnection, error) {
+func (s *PresenceService) GetAllTunnelConnections(opts ...services.MarshalOption) ([]types.TunnelConnection, error) {
 	startKey := backend.Key(tunnelConnectionsPrefix)
 	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	conns := make([]services.TunnelConnection, len(result.Items))
+	conns := make([]types.TunnelConnection, len(result.Items))
 	for i, item := range result.Items {
 		conn, err := services.UnmarshalTunnelConnection(item.Value,
 			services.AddOptions(opts,
@@ -603,7 +603,7 @@ func (s *PresenceService) DeleteAllTunnelConnections() error {
 }
 
 // CreateRemoteCluster creates remote cluster
-func (s *PresenceService) CreateRemoteCluster(rc services.RemoteCluster) error {
+func (s *PresenceService) CreateRemoteCluster(rc types.RemoteCluster) error {
 	value, err := json.Marshal(rc)
 	if err != nil {
 		return trace.Wrap(err)
@@ -622,7 +622,7 @@ func (s *PresenceService) CreateRemoteCluster(rc services.RemoteCluster) error {
 
 // UpdateRemoteCluster updates selected remote cluster fields: expiry and labels
 // other changed fields will be ignored by the method
-func (s *PresenceService) UpdateRemoteCluster(ctx context.Context, rc services.RemoteCluster) error {
+func (s *PresenceService) UpdateRemoteCluster(ctx context.Context, rc types.RemoteCluster) error {
 	if err := rc.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -657,14 +657,14 @@ func (s *PresenceService) UpdateRemoteCluster(ctx context.Context, rc services.R
 }
 
 // GetRemoteClusters returns a list of remote clusters
-func (s *PresenceService) GetRemoteClusters(opts ...services.MarshalOption) ([]services.RemoteCluster, error) {
+func (s *PresenceService) GetRemoteClusters(opts ...services.MarshalOption) ([]types.RemoteCluster, error) {
 	startKey := backend.Key(remoteClustersPrefix)
 	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	clusters := make([]services.RemoteCluster, len(result.Items))
+	clusters := make([]types.RemoteCluster, len(result.Items))
 	for i, item := range result.Items {
 		cluster, err := services.UnmarshalRemoteCluster(item.Value,
 			services.AddOptions(opts, services.WithResourceID(item.ID), services.WithExpires(item.Expires))...)
@@ -677,7 +677,7 @@ func (s *PresenceService) GetRemoteClusters(opts ...services.MarshalOption) ([]s
 }
 
 // getRemoteCluster returns a remote cluster in raw form and unmarshaled
-func (s *PresenceService) getRemoteCluster(clusterName string) (*backend.Item, services.RemoteCluster, error) {
+func (s *PresenceService) getRemoteCluster(clusterName string) (*backend.Item, types.RemoteCluster, error) {
 	if clusterName == "" {
 		return nil, nil, trace.BadParameter("missing parameter cluster name")
 	}
@@ -697,7 +697,7 @@ func (s *PresenceService) getRemoteCluster(clusterName string) (*backend.Item, s
 }
 
 // GetRemoteCluster returns a remote cluster by name
-func (s *PresenceService) GetRemoteCluster(clusterName string) (services.RemoteCluster, error) {
+func (s *PresenceService) GetRemoteCluster(clusterName string) (types.RemoteCluster, error) {
 	_, rc, err := s.getRemoteCluster(clusterName)
 	return rc, trace.Wrap(err)
 }
@@ -723,7 +723,7 @@ func (s *PresenceService) DeleteAllRemoteClusters() error {
 // *same* semaphore, separate semaphores can be modified concurrently without issue).  Note that this function
 // is the only semaphore method that handles retries internally.  This is because this method both blocks
 // user-facing operations, and contains multiple different potential contention points.
-func (s *PresenceService) AcquireSemaphore(ctx context.Context, req services.AcquireSemaphoreRequest) (*services.SemaphoreLease, error) {
+func (s *PresenceService) AcquireSemaphore(ctx context.Context, req types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
 	// this combination of backoff parameters leads to worst-case total time spent
 	// in backoff between 1200ms and 2400ms depending on jitter.  tests are in
 	// place to verify that this is sufficient to resolve a 20-lease contention
@@ -791,7 +791,7 @@ Acquire:
 
 // initSemaphore attempts to initialize/acquire a semaphore which does not yet exist.
 // Returns AlreadyExistsError if the semaphore is concurrently created.
-func (s *PresenceService) initSemaphore(ctx context.Context, key []byte, leaseID string, req services.AcquireSemaphoreRequest) (*services.SemaphoreLease, error) {
+func (s *PresenceService) initSemaphore(ctx context.Context, key []byte, leaseID string, req types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
 	// create a new empty semaphore resource configured to specifically match
 	// this acquire request.
 	sem, err := req.ConfigureSemaphore()
@@ -820,7 +820,7 @@ func (s *PresenceService) initSemaphore(ctx context.Context, key []byte, leaseID
 
 // acquireSemaphore attempts to acquire an existing semaphore.  Returns NotFoundError if no semaphore exists,
 // and CompareFailed if the semaphore was concurrently updated.
-func (s *PresenceService) acquireSemaphore(ctx context.Context, key []byte, leaseID string, req services.AcquireSemaphoreRequest) (*services.SemaphoreLease, error) {
+func (s *PresenceService) acquireSemaphore(ctx context.Context, key []byte, leaseID string, req types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
 	item, err := s.Get(ctx, key)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -856,7 +856,7 @@ func (s *PresenceService) acquireSemaphore(ctx context.Context, key []byte, leas
 
 // KeepAliveSemaphoreLease updates semaphore lease, if the lease expiry is updated,
 // semaphore is renewed
-func (s *PresenceService) KeepAliveSemaphoreLease(ctx context.Context, lease services.SemaphoreLease) error {
+func (s *PresenceService) KeepAliveSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
 	if err := lease.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -907,7 +907,7 @@ func (s *PresenceService) KeepAliveSemaphoreLease(ctx context.Context, lease ser
 }
 
 // CancelSemaphoreLease cancels semaphore lease early.
-func (s *PresenceService) CancelSemaphoreLease(ctx context.Context, lease services.SemaphoreLease) error {
+func (s *PresenceService) CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
 	if err := lease.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -953,7 +953,7 @@ func (s *PresenceService) CancelSemaphoreLease(ctx context.Context, lease servic
 }
 
 // GetSemaphores returns all semaphores matching the supplied filter.
-func (s *PresenceService) GetSemaphores(ctx context.Context, filter services.SemaphoreFilter) ([]services.Semaphore, error) {
+func (s *PresenceService) GetSemaphores(ctx context.Context, filter types.SemaphoreFilter) ([]types.Semaphore, error) {
 	var items []backend.Item
 	if filter.SemaphoreKind != "" && filter.SemaphoreName != "" {
 		// special case: filter corresponds to a single semaphore
@@ -982,7 +982,7 @@ func (s *PresenceService) GetSemaphores(ctx context.Context, filter services.Sem
 		items = result.Items
 	}
 
-	sems := make([]services.Semaphore, 0, len(items))
+	sems := make([]types.Semaphore, 0, len(items))
 
 	for _, item := range items {
 		sem, err := services.UnmarshalSemaphore(item.Value)
@@ -998,7 +998,7 @@ func (s *PresenceService) GetSemaphores(ctx context.Context, filter services.Sem
 }
 
 // DeleteSemaphore deletes a semaphore matching the supplied filter
-func (s *PresenceService) DeleteSemaphore(ctx context.Context, filter services.SemaphoreFilter) error {
+func (s *PresenceService) DeleteSemaphore(ctx context.Context, filter types.SemaphoreFilter) error {
 	if filter.SemaphoreKind == "" || filter.SemaphoreName == "" {
 		return trace.BadParameter("semaphore kind and name must be specified for deletion")
 	}
@@ -1006,15 +1006,15 @@ func (s *PresenceService) DeleteSemaphore(ctx context.Context, filter services.S
 }
 
 // UpsertKubeService registers kubernetes service presence.
-func (s *PresenceService) UpsertKubeService(ctx context.Context, server services.Server) error {
+func (s *PresenceService) UpsertKubeService(ctx context.Context, server types.Server) error {
 	// TODO(awly): verify that no other KubeService has the same kubernetes
 	// cluster names with different labels to avoid RBAC check confusion.
 	return s.upsertServer(ctx, kubeServicesPrefix, server)
 }
 
 // GetKubeServices returns a list of registered kubernetes services.
-func (s *PresenceService) GetKubeServices(ctx context.Context) ([]services.Server, error) {
-	return s.getServers(ctx, services.KindKubeService, kubeServicesPrefix)
+func (s *PresenceService) GetKubeServices(ctx context.Context) ([]types.Server, error) {
+	return s.getServers(ctx, types.KindKubeService, kubeServicesPrefix)
 }
 
 // DeleteKubeService deletes a named kubernetes service.
@@ -1121,7 +1121,7 @@ func (s *PresenceService) DeleteAllDatabaseServers(ctx context.Context, namespac
 }
 
 // GetAppServers gets all application servers.
-func (s *PresenceService) GetAppServers(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]services.Server, error) {
+func (s *PresenceService) GetAppServers(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]types.Server, error) {
 	if namespace == "" {
 		return nil, trace.BadParameter("missing namespace")
 	}
@@ -1134,11 +1134,11 @@ func (s *PresenceService) GetAppServers(ctx context.Context, namespace string, o
 	}
 
 	// Marshal values into a []services.Server slice.
-	servers := make([]services.Server, len(result.Items))
+	servers := make([]types.Server, len(result.Items))
 	for i, item := range result.Items {
 		server, err := services.UnmarshalServer(
 			item.Value,
-			services.KindAppServer,
+			types.KindAppServer,
 			services.AddOptions(opts,
 				services.WithResourceID(item.ID),
 				services.WithExpires(item.Expires))...)
@@ -1152,7 +1152,7 @@ func (s *PresenceService) GetAppServers(ctx context.Context, namespace string, o
 }
 
 // UpsertAppServer adds an application server.
-func (s *PresenceService) UpsertAppServer(ctx context.Context, server services.Server) (*services.KeepAlive, error) {
+func (s *PresenceService) UpsertAppServer(ctx context.Context, server types.Server) (*types.KeepAlive, error) {
 	if err := server.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1171,10 +1171,10 @@ func (s *PresenceService) UpsertAppServer(ctx context.Context, server services.S
 		return nil, trace.Wrap(err)
 	}
 	if server.Expiry().IsZero() {
-		return &services.KeepAlive{}, nil
+		return &types.KeepAlive{}, nil
 	}
-	return &services.KeepAlive{
-		Type:    services.KeepAlive_APP,
+	return &types.KeepAlive{
+		Type:    types.KeepAlive_APP,
 		LeaseID: lease.ID,
 		Name:    server.GetName(),
 	}, nil
@@ -1193,7 +1193,7 @@ func (s *PresenceService) DeleteAllAppServers(ctx context.Context, namespace str
 }
 
 // KeepAliveServer updates expiry time of a server resource.
-func (s *PresenceService) KeepAliveServer(ctx context.Context, h services.KeepAlive) error {
+func (s *PresenceService) KeepAliveServer(ctx context.Context, h types.KeepAlive) error {
 	if err := h.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
@@ -38,7 +39,7 @@ func NewProvisioningService(backend backend.Backend) *ProvisioningService {
 }
 
 // UpsertToken adds provisioning tokens for the auth server
-func (s *ProvisioningService) UpsertToken(p services.ProvisionToken) error {
+func (s *ProvisioningService) UpsertToken(p types.ProvisionToken) error {
 	if err := p.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -69,7 +70,7 @@ func (s *ProvisioningService) DeleteAllTokens() error {
 }
 
 // GetToken finds and returns token by ID
-func (s *ProvisioningService) GetToken(token string) (services.ProvisionToken, error) {
+func (s *ProvisioningService) GetToken(token string) (types.ProvisionToken, error) {
 	if token == "" {
 		return nil, trace.BadParameter("missing parameter token")
 	}
@@ -90,13 +91,13 @@ func (s *ProvisioningService) DeleteToken(token string) error {
 }
 
 // GetTokens returns all active (non-expired) provisioning tokens
-func (s *ProvisioningService) GetTokens(opts ...services.MarshalOption) ([]services.ProvisionToken, error) {
+func (s *ProvisioningService) GetTokens(opts ...services.MarshalOption) ([]types.ProvisionToken, error) {
 	startKey := backend.Key(tokensPrefix)
 	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tokens := make([]services.ProvisionToken, len(result.Items))
+	tokens := make([]types.ProvisionToken, len(result.Items))
 	for i, item := range result.Items {
 		t, err := services.UnmarshalProvisionToken(item.Value,
 			services.AddOptions(opts, services.SkipValidation(),

--- a/lib/services/local/resetpasswordtoken.go
+++ b/lib/services/local/resetpasswordtoken.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 
@@ -27,14 +28,14 @@ import (
 )
 
 // GetResetPasswordTokens returns all ResetPasswordTokens
-func (s *IdentityService) GetResetPasswordTokens(ctx context.Context) ([]services.ResetPasswordToken, error) {
+func (s *IdentityService) GetResetPasswordTokens(ctx context.Context) ([]types.ResetPasswordToken, error) {
 	startKey := backend.Key(passwordTokensPrefix)
 	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	var tokens []services.ResetPasswordToken
+	var tokens []types.ResetPasswordToken
 	for _, item := range result.Items {
 		if !bytes.HasSuffix(item.Key, []byte(paramsPrefix)) {
 			continue
@@ -64,7 +65,7 @@ func (s *IdentityService) DeleteResetPasswordToken(ctx context.Context, tokenID 
 }
 
 // GetResetPasswordToken returns a token by its ID
-func (s *IdentityService) GetResetPasswordToken(ctx context.Context, tokenID string) (services.ResetPasswordToken, error) {
+func (s *IdentityService) GetResetPasswordToken(ctx context.Context, tokenID string) (types.ResetPasswordToken, error) {
 	item, err := s.Get(ctx, backend.Key(passwordTokensPrefix, tokenID, paramsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -82,7 +83,7 @@ func (s *IdentityService) GetResetPasswordToken(ctx context.Context, tokenID str
 }
 
 // CreateResetPasswordToken creates a token that is used for signups and resets
-func (s *IdentityService) CreateResetPasswordToken(ctx context.Context, token services.ResetPasswordToken) (services.ResetPasswordToken, error) {
+func (s *IdentityService) CreateResetPasswordToken(ctx context.Context, token types.ResetPasswordToken) (types.ResetPasswordToken, error) {
 	if err := token.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -106,7 +107,7 @@ func (s *IdentityService) CreateResetPasswordToken(ctx context.Context, token se
 }
 
 // GetResetPasswordTokenSecrets returns token secrets
-func (s *IdentityService) GetResetPasswordTokenSecrets(ctx context.Context, tokenID string) (services.ResetPasswordTokenSecrets, error) {
+func (s *IdentityService) GetResetPasswordTokenSecrets(ctx context.Context, tokenID string) (types.ResetPasswordTokenSecrets, error) {
 	item, err := s.Get(ctx, backend.Key(passwordTokensPrefix, tokenID, secretsPrefix))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -124,7 +125,7 @@ func (s *IdentityService) GetResetPasswordTokenSecrets(ctx context.Context, toke
 }
 
 // UpsertResetPasswordTokenSecrets upserts token secrets
-func (s *IdentityService) UpsertResetPasswordTokenSecrets(ctx context.Context, secrets services.ResetPasswordTokenSecrets) error {
+func (s *IdentityService) UpsertResetPasswordTokenSecrets(ctx context.Context, secrets types.ResetPasswordTokenSecrets) error {
 	if err := secrets.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -35,7 +35,7 @@ import (
 //
 // NOTE: This function is non-atomic and performs no internal synchronization;
 // backend must be locked by caller when operating in parallel environment.
-func CreateResources(ctx context.Context, b backend.Backend, resources ...services.Resource) error {
+func CreateResources(ctx context.Context, b backend.Backend, resources ...types.Resource) error {
 	items, err := ItemsFromResources(resources...)
 	if err != nil {
 		return trace.Wrap(err)
@@ -62,7 +62,7 @@ func CreateResources(ctx context.Context, b backend.Backend, resources ...servic
 
 // ItemsFromResources attempts to convert resources into instances of backend.Item.
 // NOTE: this is not necessarily a 1-to-1 conversion.
-func ItemsFromResources(resources ...services.Resource) ([]backend.Item, error) {
+func ItemsFromResources(resources ...types.Resource) ([]backend.Item, error) {
 	var allItems []backend.Item
 	for _, rsc := range resources {
 		items, err := itemsFromResource(rsc)
@@ -77,27 +77,27 @@ func ItemsFromResources(resources ...services.Resource) ([]backend.Item, error) 
 // ItemsFromResource attempts to construct one or more instances of `backend.Item` from
 // a given resource.  If `rsc` is not one of the supported resource types,
 // a `trace.NotImplementedError` is returned.
-func itemsFromResource(resource services.Resource) ([]backend.Item, error) {
+func itemsFromResource(resource types.Resource) ([]backend.Item, error) {
 	var item *backend.Item
 	var extItems []backend.Item
 	var err error
 	switch r := resource.(type) {
-	case services.User:
+	case types.User:
 		item, err = itemFromUser(r)
 		if auth := r.GetLocalAuth(); err == nil && auth != nil {
 			extItems, err = itemsFromLocalAuthSecrets(r.GetName(), *auth)
 		}
-	case services.CertAuthority:
+	case types.CertAuthority:
 		item, err = itemFromCertAuthority(r)
-	case services.TrustedCluster:
+	case types.TrustedCluster:
 		item, err = itemFromTrustedCluster(r)
-	case services.GithubConnector:
+	case types.GithubConnector:
 		item, err = itemFromGithubConnector(r)
-	case services.Role:
+	case types.Role:
 		item, err = itemFromRole(r)
-	case services.OIDCConnector:
+	case types.OIDCConnector:
 		item, err = itemFromOIDCConnector(r)
-	case services.SAMLConnector:
+	case types.SAMLConnector:
 		item, err = itemFromSAMLConnector(r)
 	default:
 		return nil, trace.NotImplemented("cannot itemFrom resource of type %T", resource)
@@ -113,8 +113,8 @@ func itemsFromResource(resource services.Resource) ([]backend.Item, error) {
 
 // ItemsToResources converts one or more items into one or more resources.
 // NOTE: This is not necessarily a 1-to-1 conversion, and order is not preserved.
-func ItemsToResources(items ...backend.Item) ([]services.Resource, error) {
-	var resources []services.Resource
+func ItemsToResources(items ...backend.Item) ([]types.Resource, error) {
+	var resources []types.Resource
 	// User resources may be split across multiple items, so we must extract them first.
 	users, rem, err := collectUserItems(items)
 	if err != nil {
@@ -140,27 +140,27 @@ func ItemsToResources(items ...backend.Item) ([]services.Resource, error) {
 // itemToResource attempts to decode the supplied `backend.Item` as one
 // of the supported resource types.  If the resource's `kind` does not match
 // one of the supported resource types, `trace.NotImplementedError` is returned.
-func itemToResource(item backend.Item) (services.Resource, error) {
+func itemToResource(item backend.Item) (types.Resource, error) {
 	var u services.UnknownResource
 	if err := u.UnmarshalJSON(item.Value); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var rsc services.Resource
+	var rsc types.Resource
 	var err error
 	switch kind := u.GetKind(); kind {
-	case services.KindUser:
+	case types.KindUser:
 		rsc, err = itemToUser(item)
-	case services.KindCertAuthority:
+	case types.KindCertAuthority:
 		rsc, err = itemToCertAuthority(item)
-	case services.KindTrustedCluster:
+	case types.KindTrustedCluster:
 		rsc, err = itemToTrustedCluster(item)
-	case services.KindGithubConnector:
+	case types.KindGithubConnector:
 		rsc, err = itemToGithubConnector(item)
-	case services.KindRole:
+	case types.KindRole:
 		rsc, err = itemToRole(item)
-	case services.KindOIDCConnector:
+	case types.KindOIDCConnector:
 		rsc, err = itemToOIDCConnector(item)
-	case services.KindSAMLConnector:
+	case types.KindSAMLConnector:
 		rsc, err = itemToSAMLConnector(item)
 	case types.KindMFADevice:
 		rsc, err = itemToMFADevice(item)
@@ -177,7 +177,7 @@ func itemToResource(item backend.Item) (services.Resource, error) {
 
 // itemFromUser attempts to encode the supplied user as an
 // instance of `backend.Item` suitable for storage.
-func itemFromUser(user services.User) (*backend.Item, error) {
+func itemFromUser(user types.User) (*backend.Item, error) {
 	if err := services.ValidateUser(user); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -196,7 +196,7 @@ func itemFromUser(user services.User) (*backend.Item, error) {
 
 // itemToUser attempts to decode the supplied `backend.Item` as
 // a user resource.
-func itemToUser(item backend.Item) (services.User, error) {
+func itemToUser(item backend.Item) (types.User, error) {
 	user, err := services.UnmarshalUser(
 		item.Value,
 		services.WithResourceID(item.ID),
@@ -213,7 +213,7 @@ func itemToUser(item backend.Item) (services.User, error) {
 
 // itemFromCertAuthority attempts to encode the supplied certificate authority
 // as an instance of `backend.Item` suitable for storage.
-func itemFromCertAuthority(ca services.CertAuthority) (*backend.Item, error) {
+func itemFromCertAuthority(ca types.CertAuthority) (*backend.Item, error) {
 	if err := services.ValidateCertAuthority(ca); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -232,7 +232,7 @@ func itemFromCertAuthority(ca services.CertAuthority) (*backend.Item, error) {
 
 // itemToCertAuthority attempts to decode the supplied `backend.Item` as
 // a certificate authority resource (NOTE: does not filter secrets).
-func itemToCertAuthority(item backend.Item) (services.CertAuthority, error) {
+func itemToCertAuthority(item backend.Item) (types.CertAuthority, error) {
 	ca, err := services.UnmarshalCertAuthority(
 		item.Value,
 		services.WithResourceID(item.ID),
@@ -249,7 +249,7 @@ func itemToCertAuthority(item backend.Item) (services.CertAuthority, error) {
 
 // itemFromTrustedCluster attempts to encode the supplied trusted cluster
 // as an instance of `backend.Item` suitable for storage.
-func itemFromTrustedCluster(tc services.TrustedCluster) (*backend.Item, error) {
+func itemFromTrustedCluster(tc types.TrustedCluster) (*backend.Item, error) {
 	if err := tc.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -268,7 +268,7 @@ func itemFromTrustedCluster(tc services.TrustedCluster) (*backend.Item, error) {
 
 // itemToTrustedCluster attempts to decode the supplied `backend.Item` as
 // a trusted cluster resource.
-func itemToTrustedCluster(item backend.Item) (services.TrustedCluster, error) {
+func itemToTrustedCluster(item backend.Item) (types.TrustedCluster, error) {
 	tc, err := services.UnmarshalTrustedCluster(
 		item.Value,
 		services.WithResourceID(item.ID),
@@ -282,7 +282,7 @@ func itemToTrustedCluster(item backend.Item) (services.TrustedCluster, error) {
 
 // itemFromGithubConnector attempts to encode the supplied github connector
 // as an instance of `backend.Item` suitable for storage.
-func itemFromGithubConnector(gc services.GithubConnector) (*backend.Item, error) {
+func itemFromGithubConnector(gc types.GithubConnector) (*backend.Item, error) {
 	if err := gc.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -301,7 +301,7 @@ func itemFromGithubConnector(gc services.GithubConnector) (*backend.Item, error)
 
 // itemToGithubConnector attempts to decode the supplied `backend.Item` as
 // a github connector resource.
-func itemToGithubConnector(item backend.Item) (services.GithubConnector, error) {
+func itemToGithubConnector(item backend.Item) (types.GithubConnector, error) {
 	// XXX: The `GithubConnectorMarshaler` interface is an outlier in that it
 	// does not support marshal options (e.g. `WithResourceID(..)`).  Support should
 	// be added unless this is an intentional omission.
@@ -314,7 +314,7 @@ func itemToGithubConnector(item backend.Item) (services.GithubConnector, error) 
 
 // itemFromRole attempts to encode the supplied role as an
 // instance of `backend.Item` suitable for storage.
-func itemFromRole(role services.Role) (*backend.Item, error) {
+func itemFromRole(role types.Role) (*backend.Item, error) {
 	value, err := services.MarshalRole(role)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -331,7 +331,7 @@ func itemFromRole(role services.Role) (*backend.Item, error) {
 
 // itemToRole attempts to decode the supplied `backend.Item` as
 // a role resource.
-func itemToRole(item backend.Item) (services.Role, error) {
+func itemToRole(item backend.Item) (types.Role, error) {
 	role, err := services.UnmarshalRole(
 		item.Value,
 		services.WithResourceID(item.ID),
@@ -345,7 +345,7 @@ func itemToRole(item backend.Item) (services.Role, error) {
 
 // itemFromOIDCConnector attempts to encode the supplied connector as an
 // instance of `backend.Item` suitable for storage.
-func itemFromOIDCConnector(connector services.OIDCConnector) (*backend.Item, error) {
+func itemFromOIDCConnector(connector types.OIDCConnector) (*backend.Item, error) {
 	if err := connector.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -364,7 +364,7 @@ func itemFromOIDCConnector(connector services.OIDCConnector) (*backend.Item, err
 
 // itemToOIDCConnector attempts to decode the supplied `backend.Item` as
 // an oidc connector resource.
-func itemToOIDCConnector(item backend.Item) (services.OIDCConnector, error) {
+func itemToOIDCConnector(item backend.Item) (types.OIDCConnector, error) {
 	connector, err := services.UnmarshalOIDCConnector(
 		item.Value,
 		services.WithResourceID(item.ID),
@@ -378,7 +378,7 @@ func itemToOIDCConnector(item backend.Item) (services.OIDCConnector, error) {
 
 // itemFromSAMLConnector attempts to encode the supplied connector as an
 // instance of `backend.Item` suitable for storage.
-func itemFromSAMLConnector(connector services.SAMLConnector) (*backend.Item, error) {
+func itemFromSAMLConnector(connector types.SAMLConnector) (*backend.Item, error) {
 	if err := services.ValidateSAMLConnector(connector); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -397,7 +397,7 @@ func itemFromSAMLConnector(connector services.SAMLConnector) (*backend.Item, err
 
 // itemToSAMLConnector attempts to decode the supplied `backend.Item` as
 // a saml connector resource.
-func itemToSAMLConnector(item backend.Item) (services.SAMLConnector, error) {
+func itemToSAMLConnector(item backend.Item) (types.SAMLConnector, error) {
 	connector, err := services.UnmarshalSAMLConnector(
 		item.Value,
 		services.WithResourceID(item.ID),
@@ -418,7 +418,7 @@ func itemToMFADevice(item backend.Item) (*types.MFADevice, error) {
 // userFromUserItems is an extended variant of itemToUser which can be used
 // with the `userItems` collector to include additional backend.Item values
 // such as password hash or u2f registration.
-func userFromUserItems(name string, items userItems) (services.User, error) {
+func userFromUserItems(name string, items userItems) (types.User, error) {
 	if items.params == nil {
 		return nil, trace.BadParameter("cannot itemTo user %q without primary item %q", name, paramsPrefix)
 	}
@@ -437,8 +437,8 @@ func userFromUserItems(name string, items userItems) (services.User, error) {
 	return user, nil
 }
 
-func itemToLocalAuthSecrets(items userItems) (*services.LocalAuthSecrets, error) {
-	var auth services.LocalAuthSecrets
+func itemToLocalAuthSecrets(items userItems) (*types.LocalAuthSecrets, error) {
+	var auth types.LocalAuthSecrets
 	if items.pwd != nil {
 		auth.PasswordHash = items.pwd.Value
 	}
@@ -466,7 +466,7 @@ func itemToLocalAuthSecrets(items userItems) (*services.LocalAuthSecrets, error)
 		if err := json.Unmarshal(items.u2fRegistration.Value, &raw); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		auth.U2FRegistration = &services.U2FRegistrationData{
+		auth.U2FRegistration = &types.U2FRegistrationData{
 			Raw:       raw.Raw,
 			KeyHandle: raw.KeyHandle,
 			PubKey:    raw.MarshalledPubKey,
@@ -488,7 +488,7 @@ func itemToLocalAuthSecrets(items userItems) (*services.LocalAuthSecrets, error)
 	return &auth, nil
 }
 
-func itemsFromLocalAuthSecrets(user string, auth services.LocalAuthSecrets) ([]backend.Item, error) {
+func itemsFromLocalAuthSecrets(user string, auth types.LocalAuthSecrets) ([]backend.Item, error) {
 	var items []backend.Item
 	if err := services.ValidateLocalAuthSecrets(&auth); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -33,7 +33,7 @@ import (
 
 type ServicesSuite struct {
 	bk    backend.Backend
-	suite *suite.ServicesTestSuite
+	suite *suite.ServerServicesTestSuite
 }
 
 var _ = check.Suite(&ServicesSuite{})
@@ -65,31 +65,33 @@ func (s *ServicesSuite) SetUpTest(c *check.C) {
 	provisioner := NewProvisioningService(s.bk)
 	trust := NewCAService(s.bk)
 
-	s.suite = &suite.ServicesTestSuite{
-		CAS:                trust,
-		LocalTrust:         trust,
-		PresenceS:          presenceService,
-		ProvisioningS:      provisioner,
-		LocalProvisioningS: provisioner,
-		WebS:               NewIdentityService(s.bk),
-		Access:             NewAccessService(s.bk),
-		EventsS:            eventsService,
-		ChangesC:           make(chan interface{}),
-		ConfigS:            config,
-		LocalConfigS:       config,
-		Clock:              clock,
-		NewProxyWatcher: func() (*services.ProxyWatcher, error) {
-			return services.NewProxyWatcher(services.ProxyWatcherConfig{
-				Context:     context.TODO(),
-				Component:   "test",
-				RetryPeriod: 200 * time.Millisecond,
-				Client: &client{
-					PresenceService: presenceService,
-					EventsService:   eventsService,
-				},
-				ProxiesC: make(chan []services.Server, 10),
-			})
+	s.suite = &suite.ServerServicesTestSuite{
+		ServicesTestSuite: suite.ServicesTestSuite{
+			CAS:           trust,
+			PresenceS:     presenceService,
+			ProvisioningS: provisioner,
+			WebS:          NewIdentityService(s.bk),
+			Access:        NewAccessService(s.bk),
+			EventsS:       eventsService,
+			ChangesC:      make(chan interface{}),
+			ConfigS:       config,
+			Clock:         clock,
+			NewProxyWatcher: func() (*services.ProxyWatcher, error) {
+				return services.NewProxyWatcher(services.ProxyWatcherConfig{
+					Context:     context.TODO(),
+					Component:   "test",
+					RetryPeriod: 200 * time.Millisecond,
+					Client: &client{
+						PresenceService: presenceService,
+						EventsService:   eventsService,
+					},
+					ProxiesC: make(chan []services.Server, 10),
+				})
+			},
 		},
+		Trust:         trust,
+		ProvisioningS: provisioner,
+		ConfigS:       config,
 	}
 }
 

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -61,17 +61,23 @@ func (s *ServicesSuite) SetUpTest(c *check.C) {
 
 	eventsService := NewEventsService(s.bk)
 	presenceService := NewPresenceService(s.bk)
+	config := NewClusterConfigurationService(s.bk)
+	provisioner := NewProvisioningService(s.bk)
+	trust := NewCAService(s.bk)
 
 	s.suite = &suite.ServicesTestSuite{
-		CAS:           NewCAService(s.bk),
-		PresenceS:     presenceService,
-		ProvisioningS: NewProvisioningService(s.bk),
-		WebS:          NewIdentityService(s.bk),
-		Access:        NewAccessService(s.bk),
-		EventsS:       eventsService,
-		ChangesC:      make(chan interface{}),
-		ConfigS:       NewClusterConfigurationService(s.bk),
-		Clock:         clock,
+		CAS:                trust,
+		LocalTrust:         trust,
+		PresenceS:          presenceService,
+		ProvisioningS:      provisioner,
+		LocalProvisioningS: provisioner,
+		WebS:               NewIdentityService(s.bk),
+		Access:             NewAccessService(s.bk),
+		EventsS:            eventsService,
+		ChangesC:           make(chan interface{}),
+		ConfigS:            config,
+		LocalConfigS:       config,
+		Clock:              clock,
 		NewProxyWatcher: func() (*services.ProxyWatcher, error) {
 			return services.NewProxyWatcher(services.ProxyWatcherConfig{
 				Context:     context.TODO(),

--- a/lib/services/local/session.go
+++ b/lib/services/local/session.go
@@ -64,7 +64,7 @@ func (s *IdentityService) GetAppSessions(ctx context.Context) ([]types.WebSessio
 }
 
 // UpsertAppSession creates an application web session.
-func (s *IdentityService) UpsertAppSession(ctx context.Context, session services.WebSession) error {
+func (s *IdentityService) UpsertAppSession(ctx context.Context, session types.WebSession) error {
 	value, err := services.MarshalWebSession(session)
 	if err != nil {
 		return trace.Wrap(err)
@@ -82,7 +82,7 @@ func (s *IdentityService) UpsertAppSession(ctx context.Context, session services
 }
 
 // DeleteAppSession removes an application web session.
-func (s *IdentityService) DeleteAppSession(ctx context.Context, req services.DeleteAppSessionRequest) error {
+func (s *IdentityService) DeleteAppSession(ctx context.Context, req types.DeleteAppSessionRequest) error {
 	if err := s.Delete(ctx, backend.Key(appsPrefix, sessionsPrefix, req.SessionID)); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/session.go
+++ b/lib/services/local/session.go
@@ -99,7 +99,7 @@ func (s *IdentityService) DeleteAllAppSessions(ctx context.Context) error {
 }
 
 // WebSessions returns the web sessions manager.
-func (s *IdentityService) WebSessions() types.WebSessionInterface {
+func (s *IdentityService) WebSessions() services.LocalWebSessions {
 	return &webSessions{backend: s.Backend, log: s.log}
 }
 
@@ -212,7 +212,7 @@ type webSessions struct {
 }
 
 // WebTokens returns the web token manager.
-func (s *IdentityService) WebTokens() types.WebTokenInterface {
+func (s *IdentityService) WebTokens() services.LocalWebTokens {
 	return &webTokens{backend: s.Backend, log: s.log}
 }
 

--- a/lib/services/local/session.go
+++ b/lib/services/local/session.go
@@ -99,7 +99,7 @@ func (s *IdentityService) DeleteAllAppSessions(ctx context.Context) error {
 }
 
 // WebSessions returns the web sessions manager.
-func (s *IdentityService) WebSessions() services.LocalWebSessions {
+func (s *IdentityService) WebSessions() services.ServerWebSessions {
 	return &webSessions{backend: s.Backend, log: s.log}
 }
 
@@ -212,7 +212,7 @@ type webSessions struct {
 }
 
 // WebTokens returns the web token manager.
-func (s *IdentityService) WebTokens() services.LocalWebTokens {
+func (s *IdentityService) WebTokens() services.ServerWebTokens {
 	return &webTokens{backend: s.Backend, log: s.log}
 }
 

--- a/lib/services/local/trust.go
+++ b/lib/services/local/trust.go
@@ -3,6 +3,7 @@ package local
 import (
 	"context"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 
@@ -23,13 +24,13 @@ func NewCAService(b backend.Backend) *CA {
 }
 
 // DeleteAllCertAuthorities deletes all certificate authorities of a certain type
-func (s *CA) DeleteAllCertAuthorities(caType services.CertAuthType) error {
+func (s *CA) DeleteAllCertAuthorities(caType types.CertAuthType) error {
 	startKey := backend.Key(authoritiesPrefix, string(caType))
 	return s.DeleteRange(context.TODO(), startKey, backend.RangeEnd(startKey))
 }
 
 // CreateCertAuthority updates or inserts a new certificate authority
-func (s *CA) CreateCertAuthority(ca services.CertAuthority) error {
+func (s *CA) CreateCertAuthority(ca types.CertAuthority) error {
 	if err := services.ValidateCertAuthority(ca); err != nil {
 		return trace.Wrap(err)
 	}
@@ -54,7 +55,7 @@ func (s *CA) CreateCertAuthority(ca services.CertAuthority) error {
 }
 
 // UpsertCertAuthority updates or inserts a new certificate authority
-func (s *CA) UpsertCertAuthority(ca services.CertAuthority) error {
+func (s *CA) UpsertCertAuthority(ca types.CertAuthority) error {
 	if err := services.ValidateCertAuthority(ca); err != nil {
 		return trace.Wrap(err)
 	}
@@ -79,7 +80,7 @@ func (s *CA) UpsertCertAuthority(ca services.CertAuthority) error {
 // CompareAndSwapCertAuthority updates the cert authority value
 // if the existing value matches existing parameter, returns nil if succeeds,
 // trace.CompareFailed otherwise.
-func (s *CA) CompareAndSwapCertAuthority(new, existing services.CertAuthority) error {
+func (s *CA) CompareAndSwapCertAuthority(new, existing types.CertAuthority) error {
 	if err := services.ValidateCertAuthority(new); err != nil {
 		return trace.Wrap(err)
 	}
@@ -114,7 +115,7 @@ func (s *CA) CompareAndSwapCertAuthority(new, existing services.CertAuthority) e
 }
 
 // DeleteCertAuthority deletes particular certificate authority
-func (s *CA) DeleteCertAuthority(id services.CertAuthID) error {
+func (s *CA) DeleteCertAuthority(id types.CertAuthID) error {
 	if err := id.Check(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -135,7 +136,7 @@ func (s *CA) DeleteCertAuthority(id services.CertAuthID) error {
 
 // ActivateCertAuthority moves a CertAuthority from the deactivated list to
 // the normal list.
-func (s *CA) ActivateCertAuthority(id services.CertAuthID) error {
+func (s *CA) ActivateCertAuthority(id types.CertAuthID) error {
 	item, err := s.Get(context.TODO(), backend.Key(authoritiesPrefix, deactivatedPrefix, string(id.Type), id.DomainName))
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -165,7 +166,7 @@ func (s *CA) ActivateCertAuthority(id services.CertAuthID) error {
 
 // DeactivateCertAuthority moves a CertAuthority from the normal list to
 // the deactivated list.
-func (s *CA) DeactivateCertAuthority(id services.CertAuthID) error {
+func (s *CA) DeactivateCertAuthority(id types.CertAuthID) error {
 	certAuthority, err := s.GetCertAuthority(id, true)
 	if err != nil {
 		if trace.IsNotFound(err) {
@@ -200,7 +201,7 @@ func (s *CA) DeactivateCertAuthority(id services.CertAuthID) error {
 
 // GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 // controls if signing keys are loaded
-func (s *CA) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (services.CertAuthority, error) {
+func (s *CA) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error) {
 	if err := id.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -220,16 +221,16 @@ func (s *CA) GetCertAuthority(id services.CertAuthID, loadSigningKeys bool, opts
 	return ca, nil
 }
 
-func setSigningKeys(ca services.CertAuthority, loadSigningKeys bool) {
+func setSigningKeys(ca types.CertAuthority, loadSigningKeys bool) {
 	if loadSigningKeys {
 		return
 	}
-	services.RemoveCASecrets(ca)
+	types.RemoveCASecrets(ca)
 }
 
 // GetCertAuthorities returns a list of authorities of a given type
 // loadSigningKeys controls whether signing keys should be loaded or not
-func (s *CA) GetCertAuthorities(caType services.CertAuthType, loadSigningKeys bool, opts ...services.MarshalOption) ([]services.CertAuthority, error) {
+func (s *CA) GetCertAuthorities(caType types.CertAuthType, loadSigningKeys bool, opts ...services.MarshalOption) ([]types.CertAuthority, error) {
 	if err := caType.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -241,8 +242,8 @@ func (s *CA) GetCertAuthorities(caType services.CertAuthType, loadSigningKeys bo
 		return nil, trace.Wrap(err)
 	}
 
-	// Marshal values into a []services.CertAuthority slice.
-	cas := make([]services.CertAuthority, len(result.Items))
+	// Marshal values into a []types.CertAuthority slice.
+	cas := make([]types.CertAuthority, len(result.Items))
 	for i, item := range result.Items {
 		ca, err := services.UnmarshalCertAuthority(
 			item.Value, services.AddOptions(opts,

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -28,9 +28,6 @@ type Presence interface {
 	// Semaphores is responsible for semaphore handling
 	Semaphores
 
-	// UpsertLocalClusterName upserts local domain
-	UpsertLocalClusterName(name string) error
-
 	// GetLocalClusterName upserts local domain
 	GetLocalClusterName() (string, error)
 
@@ -65,12 +62,6 @@ type Presence interface {
 	// for the specified duration with second resolution if it's >= 1 second
 	UpsertAuthServer(server Server) error
 
-	// DeleteAuthServer deletes auth server by name
-	DeleteAuthServer(name string) error
-
-	// DeleteAllAuthServers deletes all auth servers
-	DeleteAllAuthServers() error
-
 	// UpsertProxy registers proxy server presence, permanently if ttl is 0 or
 	// for the specified duration with second resolution if it's >= 1 second
 	UpsertProxy(server Server) error
@@ -87,26 +78,17 @@ type Presence interface {
 	// UpsertReverseTunnel upserts reverse tunnel entry temporarily or permanently
 	UpsertReverseTunnel(tunnel ReverseTunnel) error
 
-	// GetReverseTunnel returns reverse tunnel by name
-	GetReverseTunnel(name string, opts ...MarshalOption) (ReverseTunnel, error)
-
 	// GetReverseTunnels returns a list of registered servers
 	GetReverseTunnels(opts ...MarshalOption) ([]ReverseTunnel, error)
 
 	// DeleteReverseTunnel deletes reverse tunnel by it's domain name
 	DeleteReverseTunnel(domainName string) error
 
-	// DeleteAllReverseTunnels deletes all reverse tunnels
-	DeleteAllReverseTunnels() error
-
 	// GetNamespaces returns a list of namespaces
 	GetNamespaces() ([]Namespace, error)
 
 	// GetNamespace returns namespace by name
 	GetNamespace(name string) (*Namespace, error)
-
-	// DeleteAllNamespaces deletes all namespaces
-	DeleteAllNamespaces() error
 
 	// UpsertNamespace upserts namespace
 	UpsertNamespace(Namespace) error
@@ -197,4 +179,27 @@ type Presence interface {
 
 	// DeleteAllKubeServices deletes all registered kubernetes services.
 	DeleteAllKubeServices(context.Context) error
+}
+
+// LocalPresence manages Teleport components on the auth server
+type LocalPresence interface {
+	Presence
+
+	// DeleteAuthServer deletes auth server by name
+	DeleteAuthServer(name string) error
+
+	// DeleteAllAuthServers deletes all auth servers
+	DeleteAllAuthServers() error
+
+	// DeleteAllNamespaces deletes all namespaces
+	DeleteAllNamespaces() error
+
+	// DeleteAllReverseTunnels deletes all reverse tunnels
+	DeleteAllReverseTunnels() error
+
+	// GetReverseTunnel returns reverse tunnel by name
+	GetReverseTunnel(name string, opts ...MarshalOption) (ReverseTunnel, error)
+
+	// UpsertLocalClusterName upserts local domain
+	UpsertLocalClusterName(name string) error
 }

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -181,8 +181,8 @@ type Presence interface {
 	DeleteAllKubeServices(context.Context) error
 }
 
-// LocalPresence manages Teleport components on the auth server
-type LocalPresence interface {
+// ServerPresence manages Teleport components on the auth server
+type ServerPresence interface {
 	Presence
 
 	// DeleteAuthServer deletes auth server by name

--- a/lib/services/provisioning.go
+++ b/lib/services/provisioning.go
@@ -36,11 +36,16 @@ type Provisioner interface {
 	// DeleteToken deletes provisioning token
 	DeleteToken(token string) error
 
-	// DeleteAllTokens deletes all provisioning tokens
-	DeleteAllTokens() error
-
 	// GetTokens returns all non-expired tokens
 	GetTokens(opts ...MarshalOption) ([]ProvisionToken, error)
+}
+
+// LocalProvisioner manages nodes and tokens on the auth server
+type LocalProvisioner interface {
+	Provisioner
+
+	// DeleteAllTokens deletes all provisioning tokens
+	DeleteAllTokens() error
 }
 
 // MustCreateProvisionToken returns a new valid provision token

--- a/lib/services/provisioning.go
+++ b/lib/services/provisioning.go
@@ -40,8 +40,8 @@ type Provisioner interface {
 	GetTokens(opts ...MarshalOption) ([]ProvisionToken, error)
 }
 
-// LocalProvisioner manages nodes and tokens on the auth server
-type LocalProvisioner interface {
+// ServerProvisioner manages nodes and tokens on the auth server
+type ServerProvisioner interface {
 	Provisioner
 
 	// DeleteAllTokens deletes all provisioning tokens

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -237,20 +237,25 @@ type Access interface {
 	// GetRoles returns a list of roles
 	GetRoles() ([]Role, error)
 
-	// CreateRole creates a role
-	CreateRole(role Role) error
-
 	// UpsertRole creates or updates role
 	UpsertRole(ctx context.Context, role Role) error
-
-	// DeleteAllRoles deletes all roles
-	DeleteAllRoles() error
 
 	// GetRole returns role by name
 	GetRole(name string) (Role, error)
 
 	// DeleteRole deletes role by name
 	DeleteRole(ctx context.Context, name string) error
+}
+
+// LocalAccess manages roles and permissions on the auth server
+type LocalAccess interface {
+	Access
+
+	// CreateRole creates a role
+	CreateRole(role Role) error
+
+	// DeleteAllRoles deletes all roles
+	DeleteAllRoles() error
 }
 
 const (

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -247,8 +247,8 @@ type Access interface {
 	DeleteRole(ctx context.Context, name string) error
 }
 
-// LocalAccess manages roles and permissions on the auth server
-type LocalAccess interface {
+// ServerAccess manages roles and permissions on the auth server
+type ServerAccess interface {
 	Access
 
 	// CreateRole creates a role

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -50,7 +50,7 @@ import (
 //
 // Once RBAC is open sourced, remove this and rename "ExtendedAdminUserRules" to
 // "AdminUserRules".
-var AdminUserRules = []Rule{
+var AdminUserRules = []types.Rule{
 	NewRule(KindRole, RW()),
 	NewRule(KindAuthConnector, RW()),
 	NewRule(KindSession, RO()),
@@ -60,7 +60,7 @@ var AdminUserRules = []Rule{
 
 // ExtendedAdminUserRules provides access to the default set of rules assigned to
 // all users.
-var ExtendedAdminUserRules = []Rule{
+var ExtendedAdminUserRules = []types.Rule{
 	NewRule(KindRole, RW()),
 	NewRule(KindAuthConnector, RW()),
 	NewRule(KindSession, RO()),
@@ -72,7 +72,7 @@ var ExtendedAdminUserRules = []Rule{
 
 // DefaultImplicitRules provides access to the default set of implicit rules
 // assigned to all roles.
-var DefaultImplicitRules = []Rule{
+var DefaultImplicitRules = []types.Rule{
 	NewRule(KindNode, RO()),
 	NewRule(KindProxy, RO()),
 	NewRule(KindAuthServer, RO()),
@@ -89,7 +89,7 @@ var DefaultImplicitRules = []Rule{
 
 // DefaultCertAuthorityRules provides access the minimal set of resources
 // needed for a certificate authority to function.
-var DefaultCertAuthorityRules = []Rule{
+var DefaultCertAuthorityRules = []types.Rule{
 	NewRule(KindSession, RO()),
 	NewRule(KindNode, RO()),
 	NewRule(KindAuthServer, RO()),
@@ -294,7 +294,7 @@ func ValidateRole(r Role) error {
 }
 
 // validateRule parses the where and action fields to validate the rule.
-func validateRule(r Rule) error {
+func validateRule(r types.Rule) error {
 	if len(r.Where) != 0 {
 		parser, err := NewWhereParser(&Context{})
 		if err != nil {
@@ -501,7 +501,7 @@ func applyValueTraits(val string, traits map[string][]string) ([]string, error) 
 
 // ruleScore is a sorting score of the rule, the larger the score, the more
 // specific the rule is
-func ruleScore(r *Rule) int {
+func ruleScore(r *types.Rule) int {
 	score := 0
 	// wildcard rules are less specific
 	if utils.SliceContainsStr(r.Resources, Wildcard) {
@@ -539,15 +539,15 @@ func ruleScore(r *Rule) int {
 // than the same rule without where section.
 // * Rule that has actions list is more specific than
 // rule without actions list.
-func CompareRuleScore(r *Rule, o *Rule) bool {
+func CompareRuleScore(r *types.Rule, o *types.Rule) bool {
 	return ruleScore(r) > ruleScore(o)
 }
 
 // RuleSet maps resource to a set of rules defined for it
-type RuleSet map[string][]Rule
+type RuleSet map[string][]types.Rule
 
 // MakeRuleSet creates a new rule set from a list
-func MakeRuleSet(rules []Rule) RuleSet {
+func MakeRuleSet(rules []types.Rule) RuleSet {
 	set := make(RuleSet)
 	for _, rule := range rules {
 		for _, resource := range rule.Resources {
@@ -615,7 +615,7 @@ func (set RuleSet) Match(whereParser predicate.Parser, actionsParser predicate.P
 
 // matchesWhere returns true if Where rule matches.
 // Empty Where block always matches.
-func matchesWhere(r *Rule, parser predicate.Parser) (bool, error) {
+func matchesWhere(r *types.Rule, parser predicate.Parser) (bool, error) {
 	if r.Where == "" {
 		return true, nil
 	}
@@ -631,7 +631,7 @@ func matchesWhere(r *Rule, parser predicate.Parser) (bool, error) {
 }
 
 // processActions processes actions specified for this rule
-func processActions(r *Rule, parser predicate.Parser) error {
+func processActions(r *types.Rule, parser predicate.Parser) error {
 	for _, action := range r.Actions {
 		ifn, err := parser.Parse(action)
 		if err != nil {
@@ -647,8 +647,8 @@ func processActions(r *Rule, parser predicate.Parser) error {
 }
 
 // Slice returns slice from a set
-func (set RuleSet) Slice() []Rule {
-	var out []Rule
+func (set RuleSet) Slice() []types.Rule {
+	var out []types.Rule
 	for _, rules := range set {
 		out = append(out, rules...)
 	}

--- a/lib/services/services.go
+++ b/lib/services/services.go
@@ -23,12 +23,13 @@ type Services interface {
 	UsersService
 	Provisioner
 	Trust
-	Events
 	ClusterConfiguration
 	Access
 	DynamicAccess
 	Presence
 	AppSession
+
+	types.Events
 	types.WebSessionsGetter
 	types.WebTokensGetter
 }

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -132,20 +132,35 @@ func NewTestCAWithConfig(config TestCAConfig) *services.CertAuthorityV2 {
 // for services. It is used for local implementations and implementations
 // using GRPC to guarantee consistency between local and remote services
 type ServicesTestSuite struct {
-	Access             services.Access
-	CAS                services.Trust
-	LocalTrust         services.ServerTrust
-	PresenceS          services.Presence
-	ProvisioningS      services.Provisioner
-	LocalProvisioningS services.ServerProvisioner
-	WebS               services.ServerIdentity
-	ConfigS            services.ClusterConfiguration
-	LocalConfigS       services.ServerClusterConfiguration
-	EventsS            services.Events
-	UsersS             services.UsersService
-	ChangesC           chan interface{}
-	Clock              clockwork.FakeClock
-	NewProxyWatcher    services.NewProxyWatcherFunc
+	Access          services.Access
+	CAS             services.Trust
+	PresenceS       services.Presence
+	ProvisioningS   services.Provisioner
+	WebS            services.ServerIdentity
+	ConfigS         services.ClusterConfiguration
+	EventsS         services.Events
+	UsersS          services.UsersService
+	ChangesC        chan interface{}
+	Clock           clockwork.FakeClock
+	NewProxyWatcher services.NewProxyWatcherFunc
+}
+
+// NewServerTestSuite returns a new server's test suite using the given
+// suite as a template
+func NewServerTestSuite(tpl ServerServicesTestSuite) ServerServicesTestSuite {
+	tpl.ServicesTestSuite.CAS = tpl.Trust
+	tpl.ServicesTestSuite.ProvisioningS = tpl.ProvisioningS
+	tpl.ServicesTestSuite.ConfigS = tpl.ConfigS
+	return tpl
+}
+
+// ServerServicesTestSuite is an acceptance test suite for auth server-specific APIs
+type ServerServicesTestSuite struct {
+	ServicesTestSuite
+
+	Trust         services.ServerTrust
+	ProvisioningS services.ServerProvisioner
+	ConfigS       services.ServerClusterConfiguration
 }
 
 func (s *ServicesTestSuite) Users() services.UsersService {
@@ -276,7 +291,189 @@ func (s *ServicesTestSuite) LoginAttempts(c *check.C) {
 	c.Assert(services.LastFailed(2, attempts), check.Equals, true)
 }
 
-func (s *ServicesTestSuite) CertAuthCRUD(c *check.C) {
+// ClusterConfig tests cluster configuration
+func (s *ServicesTestSuite) ClusterConfig(c *check.C) {
+	config, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
+		ClientIdleTimeout:     services.NewDuration(17 * time.Second),
+		DisconnectExpiredCert: services.NewBool(true),
+		ClusterID:             "27",
+		SessionRecording:      services.RecordAtProxy,
+		Audit: services.AuditConfig{
+			Region:           "us-west-1",
+			Type:             "dynamodb",
+			AuditSessionsURI: "file:///home/log",
+			AuditTableName:   "audit_table_name",
+			AuditEventsURI:   []string{"dynamodb://audit_table_name", "file:///home/log"},
+		},
+	})
+	c.Assert(err, check.IsNil)
+
+	err = s.ConfigS.SetClusterConfig(config)
+	c.Assert(err, check.IsNil)
+
+	gotConfig, err := s.ConfigS.GetClusterConfig()
+	c.Assert(err, check.IsNil)
+	config.SetResourceID(gotConfig.GetResourceID())
+	fixtures.DeepCompare(c, config, gotConfig)
+}
+
+// EventsClusterConfig tests cluster config resource events
+func (s *ServerServicesTestSuite) EventsClusterConfig(c *check.C) {
+	testCases := []eventTest{
+		{
+			name: "Cluster config",
+			kind: services.WatchKind{
+				Kind: services.KindClusterConfig,
+			},
+			crud: func() services.Resource {
+				config, err := services.NewClusterConfig(services.ClusterConfigSpecV3{})
+				c.Assert(err, check.IsNil)
+
+				err = s.ConfigS.SetClusterConfig(config)
+				c.Assert(err, check.IsNil)
+
+				out, err := s.ConfigS.GetClusterConfig()
+				c.Assert(err, check.IsNil)
+
+				err = s.ConfigS.DeleteClusterConfig()
+				c.Assert(err, check.IsNil)
+
+				return out
+			},
+		},
+		{
+			name: "Cluster name",
+			kind: services.WatchKind{
+				Kind: services.KindClusterName,
+			},
+			crud: func() services.Resource {
+				clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
+					ClusterName: "example.com",
+				})
+				c.Assert(err, check.IsNil)
+
+				err = s.ConfigS.SetClusterName(clusterName)
+				c.Assert(err, check.IsNil)
+
+				out, err := s.ConfigS.GetClusterName()
+				c.Assert(err, check.IsNil)
+
+				err = s.ConfigS.DeleteClusterName()
+				c.Assert(err, check.IsNil)
+				return out
+			},
+		},
+	}
+	s.runEventsTests(c, testCases)
+}
+
+// ClusterConfig tests server-side cluster configuration
+func (s *ServerServicesTestSuite) ClusterConfig(c *check.C) {
+	s.ServicesTestSuite.ClusterConfig(c)
+	// Server-side test
+	err := s.ConfigS.DeleteClusterConfig()
+	c.Assert(err, check.IsNil)
+
+	_, err = s.ConfigS.GetClusterConfig()
+	fixtures.ExpectNotFound(c, err)
+
+	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
+		ClusterName: "example.com",
+	})
+	c.Assert(err, check.IsNil)
+
+	err = s.ConfigS.SetClusterName(clusterName)
+	c.Assert(err, check.IsNil)
+
+	gotName, err := s.ConfigS.GetClusterName()
+	c.Assert(err, check.IsNil)
+	clusterName.SetResourceID(gotName.GetResourceID())
+	fixtures.DeepCompare(c, clusterName, gotName)
+
+	err = s.ConfigS.DeleteClusterName()
+	c.Assert(err, check.IsNil)
+
+	_, err = s.ConfigS.GetClusterName()
+	fixtures.ExpectNotFound(c, err)
+
+	err = s.ConfigS.UpsertClusterName(clusterName)
+	c.Assert(err, check.IsNil)
+
+	gotName, err = s.ConfigS.GetClusterName()
+	c.Assert(err, check.IsNil)
+	clusterName.SetResourceID(gotName.GetResourceID())
+	fixtures.DeepCompare(c, clusterName, gotName)
+}
+
+func (s *ServerServicesTestSuite) TokenCRUD(c *check.C) {
+	_, err := s.ProvisioningS.GetToken("token")
+	fixtures.ExpectNotFound(c, err)
+
+	t, err := services.NewProvisionToken("token", teleport.Roles{teleport.RoleAuth, teleport.RoleNode}, time.Time{})
+	c.Assert(err, check.IsNil)
+
+	c.Assert(s.ProvisioningS.UpsertToken(t), check.IsNil)
+
+	token, err := s.ProvisioningS.GetToken("token")
+	c.Assert(err, check.IsNil)
+	c.Assert(token.GetRoles().Include(teleport.RoleAuth), check.Equals, true)
+	c.Assert(token.GetRoles().Include(teleport.RoleNode), check.Equals, true)
+	c.Assert(token.GetRoles().Include(teleport.RoleProxy), check.Equals, false)
+	diff := s.Clock.Now().UTC().Add(defaults.ProvisioningTokenTTL).Second() - token.Expiry().Second()
+	if diff > 1 {
+		c.Fatalf("expected diff to be within one second, got %v instead", diff)
+	}
+
+	c.Assert(s.ProvisioningS.DeleteToken("token"), check.IsNil)
+
+	_, err = s.ProvisioningS.GetToken("token")
+	fixtures.ExpectNotFound(c, err)
+
+	// check tokens backwards compatibility and marshal/unmarshal
+	expiry := time.Now().UTC().Add(time.Hour)
+	v1 := &services.ProvisionTokenV1{
+		Token:   "old",
+		Roles:   teleport.Roles{teleport.RoleNode, teleport.RoleProxy},
+		Expires: expiry,
+	}
+	v2, err := services.NewProvisionToken(v1.Token, v1.Roles, expiry)
+	c.Assert(err, check.IsNil)
+
+	// Tokens in different version formats are backwards and forwards
+	// compatible
+	fixtures.DeepCompare(c, v1.V2(), v2)
+	fixtures.DeepCompare(c, v2.V1(), v1)
+
+	// Marshal V1, unmarshal V2
+	data, err := services.MarshalProvisionToken(v2, services.WithVersion(services.V1))
+	c.Assert(err, check.IsNil)
+
+	out, err := services.UnmarshalProvisionToken(data)
+	c.Assert(err, check.IsNil)
+	fixtures.DeepCompare(c, out, v2)
+
+	// Test delete all tokens
+	t, err = services.NewProvisionToken("token1", teleport.Roles{teleport.RoleAuth, teleport.RoleNode}, time.Time{})
+	c.Assert(err, check.IsNil)
+	c.Assert(s.ProvisioningS.UpsertToken(t), check.IsNil)
+
+	t, err = services.NewProvisionToken("token2", teleport.Roles{teleport.RoleAuth, teleport.RoleNode}, time.Time{})
+	c.Assert(err, check.IsNil)
+	c.Assert(s.ProvisioningS.UpsertToken(t), check.IsNil)
+
+	tokens, err := s.ProvisioningS.GetTokens()
+	c.Assert(err, check.IsNil)
+	c.Assert(tokens, check.HasLen, 2)
+
+	err = s.ProvisioningS.DeleteAllTokens()
+	c.Assert(err, check.IsNil)
+
+	tokens, err = s.ProvisioningS.GetTokens()
+	c.Assert(err, check.IsNil)
+	c.Assert(tokens, check.HasLen, 0)
+}
+
+func (s *ServerServicesTestSuite) CertAuthCRUD(c *check.C) {
 	ca := NewTestCA(services.UserCA, "example.com")
 	c.Assert(s.CAS.UpsertCertAuthority(ca), check.IsNil)
 
@@ -306,7 +503,7 @@ func (s *ServicesTestSuite) CertAuthCRUD(c *check.C) {
 
 	// test compare and swap
 	ca = NewTestCA(services.UserCA, "example.com")
-	c.Assert(s.LocalTrust.CreateCertAuthority(ca), check.IsNil)
+	c.Assert(s.Trust.CreateCertAuthority(ca), check.IsNil)
 
 	clock := clockwork.NewFakeClock()
 	newCA := *ca
@@ -591,74 +788,6 @@ func (s *ServicesTestSuite) WebSessionCRUD(c *check.C) {
 
 	_, err = s.WebS.WebSessions().Get(context.TODO(), req)
 	fixtures.ExpectNotFound(c, err)
-}
-
-func (s *ServicesTestSuite) TokenCRUD(c *check.C) {
-	_, err := s.ProvisioningS.GetToken("token")
-	fixtures.ExpectNotFound(c, err)
-
-	t, err := services.NewProvisionToken("token", teleport.Roles{teleport.RoleAuth, teleport.RoleNode}, time.Time{})
-	c.Assert(err, check.IsNil)
-
-	c.Assert(s.ProvisioningS.UpsertToken(t), check.IsNil)
-
-	token, err := s.ProvisioningS.GetToken("token")
-	c.Assert(err, check.IsNil)
-	c.Assert(token.GetRoles().Include(teleport.RoleAuth), check.Equals, true)
-	c.Assert(token.GetRoles().Include(teleport.RoleNode), check.Equals, true)
-	c.Assert(token.GetRoles().Include(teleport.RoleProxy), check.Equals, false)
-	diff := s.Clock.Now().UTC().Add(defaults.ProvisioningTokenTTL).Second() - token.Expiry().Second()
-	if diff > 1 {
-		c.Fatalf("expected diff to be within one second, got %v instead", diff)
-	}
-
-	c.Assert(s.ProvisioningS.DeleteToken("token"), check.IsNil)
-
-	_, err = s.ProvisioningS.GetToken("token")
-	fixtures.ExpectNotFound(c, err)
-
-	// check tokens backwards compatibility and marshal/unmarshal
-	expiry := time.Now().UTC().Add(time.Hour)
-	v1 := &services.ProvisionTokenV1{
-		Token:   "old",
-		Roles:   teleport.Roles{teleport.RoleNode, teleport.RoleProxy},
-		Expires: expiry,
-	}
-	v2, err := services.NewProvisionToken(v1.Token, v1.Roles, expiry)
-	c.Assert(err, check.IsNil)
-
-	// Tokens in different version formats are backwards and forwards
-	// compatible
-	fixtures.DeepCompare(c, v1.V2(), v2)
-	fixtures.DeepCompare(c, v2.V1(), v1)
-
-	// Marshal V1, unmarshal V2
-	data, err := services.MarshalProvisionToken(v2, services.WithVersion(services.V1))
-	c.Assert(err, check.IsNil)
-
-	out, err := services.UnmarshalProvisionToken(data)
-	c.Assert(err, check.IsNil)
-	fixtures.DeepCompare(c, out, v2)
-
-	// Test delete all tokens
-	t, err = services.NewProvisionToken("token1", teleport.Roles{teleport.RoleAuth, teleport.RoleNode}, time.Time{})
-	c.Assert(err, check.IsNil)
-	c.Assert(s.ProvisioningS.UpsertToken(t), check.IsNil)
-
-	t, err = services.NewProvisionToken("token2", teleport.Roles{teleport.RoleAuth, teleport.RoleNode}, time.Time{})
-	c.Assert(err, check.IsNil)
-	c.Assert(s.ProvisioningS.UpsertToken(t), check.IsNil)
-
-	tokens, err := s.ProvisioningS.GetTokens()
-	c.Assert(err, check.IsNil)
-	c.Assert(tokens, check.HasLen, 2)
-
-	err = s.LocalProvisioningS.DeleteAllTokens()
-	c.Assert(err, check.IsNil)
-
-	tokens, err = s.ProvisioningS.GetTokens()
-	c.Assert(err, check.IsNil)
-	c.Assert(tokens, check.HasLen, 0)
 }
 
 func (s *ServicesTestSuite) RolesCRUD(c *check.C) {
@@ -1073,96 +1202,6 @@ func (s *ServicesTestSuite) StaticTokens(c *check.C) {
 
 	_, err = s.ConfigS.GetStaticTokens()
 	fixtures.ExpectNotFound(c, err)
-}
-
-// Options provides functional arguments
-// to turn certain parts of the test suite off
-type Options struct {
-	// SkipDelete turns off deletes in tests
-	SkipDelete bool
-}
-
-// Option is a functional suite option
-type Option func(s *Options)
-
-// SkipDelete instructs tests to skip testing delete features
-func SkipDelete() Option {
-	return func(s *Options) {
-		s.SkipDelete = true
-	}
-}
-
-// CollectOptions collects suite options
-func CollectOptions(opts ...Option) Options {
-	var suiteOpts Options
-	for _, o := range opts {
-		o(&suiteOpts)
-	}
-	return suiteOpts
-}
-
-// ClusterConfig tests cluster configuration
-func (s *ServicesTestSuite) ClusterConfig(c *check.C, opts ...Option) {
-	config, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
-		ClientIdleTimeout:     services.NewDuration(17 * time.Second),
-		DisconnectExpiredCert: services.NewBool(true),
-		ClusterID:             "27",
-		SessionRecording:      services.RecordAtProxy,
-		Audit: services.AuditConfig{
-			Region:           "us-west-1",
-			Type:             "dynamodb",
-			AuditSessionsURI: "file:///home/log",
-			AuditTableName:   "audit_table_name",
-			AuditEventsURI:   []string{"dynamodb://audit_table_name", "file:///home/log"},
-		},
-	})
-	c.Assert(err, check.IsNil)
-
-	err = s.ConfigS.SetClusterConfig(config)
-	c.Assert(err, check.IsNil)
-
-	gotConfig, err := s.ConfigS.GetClusterConfig()
-	c.Assert(err, check.IsNil)
-	config.SetResourceID(gotConfig.GetResourceID())
-	fixtures.DeepCompare(c, config, gotConfig)
-
-	// Some parts (e.g. auth server) will not function
-	// without cluster name or cluster config
-	if CollectOptions(opts...).SkipDelete {
-		return
-	}
-	err = s.LocalConfigS.DeleteClusterConfig()
-	c.Assert(err, check.IsNil)
-
-	_, err = s.ConfigS.GetClusterConfig()
-	fixtures.ExpectNotFound(c, err)
-
-	clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-		ClusterName: "example.com",
-	})
-	c.Assert(err, check.IsNil)
-
-	err = s.ConfigS.SetClusterName(clusterName)
-	c.Assert(err, check.IsNil)
-
-	gotName, err := s.ConfigS.GetClusterName()
-	c.Assert(err, check.IsNil)
-	clusterName.SetResourceID(gotName.GetResourceID())
-	fixtures.DeepCompare(c, clusterName, gotName)
-
-	err = s.LocalConfigS.DeleteClusterName()
-	c.Assert(err, check.IsNil)
-
-	_, err = s.ConfigS.GetClusterName()
-	fixtures.ExpectNotFound(c, err)
-
-	err = s.LocalConfigS.UpsertClusterName(clusterName)
-	c.Assert(err, check.IsNil)
-
-	gotName, err = s.ConfigS.GetClusterName()
-	c.Assert(err, check.IsNil)
-	clusterName.SetResourceID(gotName.GetResourceID())
-	fixtures.DeepCompare(c, clusterName, gotName)
 }
 
 // sem wrapper is a helper for overriding the keepalive
@@ -1667,56 +1706,6 @@ func (s *ServicesTestSuite) Events(c *check.C) {
 				err = s.PresenceS.DeleteNamespace(ns.Metadata.Name)
 				c.Assert(err, check.IsNil)
 
-				return out
-			},
-		},
-	}
-	s.runEventsTests(c, testCases)
-}
-
-// EventsClusterConfig tests cluster config resource events
-func (s *ServicesTestSuite) EventsClusterConfig(c *check.C) {
-	testCases := []eventTest{
-		{
-			name: "Cluster config",
-			kind: services.WatchKind{
-				Kind: services.KindClusterConfig,
-			},
-			crud: func() services.Resource {
-				config, err := services.NewClusterConfig(services.ClusterConfigSpecV3{})
-				c.Assert(err, check.IsNil)
-
-				err = s.ConfigS.SetClusterConfig(config)
-				c.Assert(err, check.IsNil)
-
-				out, err := s.ConfigS.GetClusterConfig()
-				c.Assert(err, check.IsNil)
-
-				err = s.LocalConfigS.DeleteClusterConfig()
-				c.Assert(err, check.IsNil)
-
-				return out
-			},
-		},
-		{
-			name: "Cluster name",
-			kind: services.WatchKind{
-				Kind: services.KindClusterName,
-			},
-			crud: func() services.Resource {
-				clusterName, err := services.NewClusterName(services.ClusterNameSpecV2{
-					ClusterName: "example.com",
-				})
-				c.Assert(err, check.IsNil)
-
-				err = s.ConfigS.SetClusterName(clusterName)
-				c.Assert(err, check.IsNil)
-
-				out, err := s.ConfigS.GetClusterName()
-				c.Assert(err, check.IsNil)
-
-				err = s.LocalConfigS.DeleteClusterName()
-				c.Assert(err, check.IsNil)
 				return out
 			},
 		},

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -134,13 +134,13 @@ func NewTestCAWithConfig(config TestCAConfig) *services.CertAuthorityV2 {
 type ServicesTestSuite struct {
 	Access             services.Access
 	CAS                services.Trust
-	LocalTrust         services.LocalTrust
+	LocalTrust         services.ServerTrust
 	PresenceS          services.Presence
 	ProvisioningS      services.Provisioner
-	LocalProvisioningS services.LocalProvisioner
-	WebS               services.LocalIdentity
+	LocalProvisioningS services.ServerProvisioner
+	WebS               services.ServerIdentity
 	ConfigS            services.ClusterConfiguration
-	LocalConfigS       services.LocalClusterConfiguration
+	LocalConfigS       services.ServerClusterConfiguration
 	EventsS            services.Events
 	UsersS             services.UsersService
 	ChangesC           chan interface{}

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -46,8 +46,8 @@ type Trust interface {
 	GetCertAuthorities(caType CertAuthType, loadSigningKeys bool, opts ...MarshalOption) ([]CertAuthority, error)
 }
 
-// LocalTrust manages certificate authorities on the auth server
-type LocalTrust interface {
+// ServerTrust manages certificate authorities on the auth server
+type ServerTrust interface {
 	Trust
 
 	// CreateCertAuthority inserts a new certificate authority

--- a/lib/services/trust.go
+++ b/lib/services/trust.go
@@ -26,9 +26,6 @@ package services
 // Remote authorities have only public keys available, so they can
 // be only used to validate
 type Trust interface {
-	// CreateCertAuthority inserts a new certificate authority
-	CreateCertAuthority(ca CertAuthority) error
-
 	// UpsertCertAuthority updates or inserts a new certificate authority
 	UpsertCertAuthority(ca CertAuthority) error
 
@@ -40,9 +37,6 @@ type Trust interface {
 	// DeleteCertAuthority deletes particular certificate authority
 	DeleteCertAuthority(id CertAuthID) error
 
-	// DeleteAllCertAuthorities deletes cert authorities of a certain type
-	DeleteAllCertAuthorities(caType CertAuthType) error
-
 	// GetCertAuthority returns certificate authority by given id. Parameter loadSigningKeys
 	// controls if signing keys are loaded
 	GetCertAuthority(id CertAuthID, loadSigningKeys bool, opts ...MarshalOption) (CertAuthority, error)
@@ -50,6 +44,14 @@ type Trust interface {
 	// GetCertAuthorities returns a list of authorities of a given type
 	// loadSigningKeys controls whether signing keys should be loaded or not
 	GetCertAuthorities(caType CertAuthType, loadSigningKeys bool, opts ...MarshalOption) ([]CertAuthority, error)
+}
+
+// LocalTrust manages certificate authorities on the auth server
+type LocalTrust interface {
+	Trust
+
+	// CreateCertAuthority inserts a new certificate authority
+	CreateCertAuthority(ca CertAuthority) error
 
 	// ActivateCertAuthority moves a CertAuthority from the deactivated list to
 	// the normal list.
@@ -58,4 +60,7 @@ type Trust interface {
 	// DeactivateCertAuthority moves a CertAuthority from the normal list to
 	// the deactivated list.
 	DeactivateCertAuthority(id CertAuthID) error
+
+	// DeleteAllCertAuthorities deletes cert authorities of a certain type
+	DeleteAllCertAuthorities(caType CertAuthType) error
 }

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -57,7 +57,7 @@ type Config struct {
 	AuthClient *auth.Client
 
 	// AccessPoint is a caching client connected to the Auth Server.
-	AccessPoint auth.AccessPoint
+	AccessPoint auth.ClientAccessPoint
 
 	// TLSConfig is the *tls.Config for this server.
 	TLSConfig *tls.Config

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -52,7 +52,7 @@ type Config struct {
 	// AuthClient is a client directly connected to the Auth server.
 	AuthClient *auth.Client
 	// AccessPoint is a caching client connected to the Auth Server.
-	AccessPoint auth.AccessPoint
+	AccessPoint auth.ClientAccessPoint
 	// StreamEmitter is a non-blocking audit events emitter.
 	StreamEmitter events.StreamEmitter
 	// TLSConfig is the *tls.Config for this server.

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -157,7 +157,7 @@ type HeartbeatConfig struct {
 	// Component is a name of component used in logs
 	Component string
 	// Announcer is used to announce presence
-	Announcer auth.Announcer
+	Announcer auth.LocalAnnouncer
 	// GetServerInfo returns server information
 	GetServerInfo GetServerInfoFn
 	// ServerTTL is a server TTL used in announcements

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -157,7 +157,7 @@ type HeartbeatConfig struct {
 	// Component is a name of component used in logs
 	Component string
 	// Announcer is used to announce presence
-	Announcer auth.LocalAnnouncer
+	Announcer auth.ServerAnnouncer
 	// GetServerInfo returns server information
 	GetServerInfo GetServerInfoFn
 	// ServerTTL is a server TTL used in announcements

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -73,7 +73,7 @@ type Server struct {
 	srv           *sshutils.Server
 	shell         string
 	getRotation   RotationGetter
-	authService   auth.AccessPoint
+	authService   auth.ClientAccessPoint
 	reg           *srv.SessionRegistry
 	sessionServer rsession.Service
 	limiter       *limiter.Limiter
@@ -473,7 +473,7 @@ func SetOnHeartbeat(fn func(error)) ServerOption {
 func New(addr utils.NetAddr,
 	hostname string,
 	signers []ssh.Signer,
-	authService auth.AccessPoint,
+	authService auth.ClientAccessPoint,
 	dataDir string,
 	advertiseAddr string,
 	proxyPublicAddr utils.NetAddr,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -469,7 +469,7 @@ func (s *WebSuite) TestSAMLSuccess(c *C) {
 	// now swap the request id to the hardcoded one in fixtures
 	authRequest.ID = fixtures.SAMLOktaAuthRequestID
 	authRequest.CSRFToken = csrfToken
-	err = s.server.Auth().Services.LocalIdentity.CreateSAMLAuthRequest(*authRequest, backend.Forever)
+	err = s.server.Auth().Services.ServerIdentity.CreateSAMLAuthRequest(*authRequest, backend.Forever)
 	c.Assert(err, IsNil)
 
 	// now respond with pre-recorded request to the POST url

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -469,7 +469,7 @@ func (s *WebSuite) TestSAMLSuccess(c *C) {
 	// now swap the request id to the hardcoded one in fixtures
 	authRequest.ID = fixtures.SAMLOktaAuthRequestID
 	authRequest.CSRFToken = csrfToken
-	err = s.server.Auth().Identity.CreateSAMLAuthRequest(*authRequest, backend.Forever)
+	err = s.server.Auth().Services.LocalIdentity.CreateSAMLAuthRequest(*authRequest, backend.Forever)
 	c.Assert(err, IsNil)
 
 	// now respond with pre-recorded request to the POST url


### PR DESCRIPTION
This PR removes all APIs that had to resort to not implemented errors to conform to specific interfaces - this mainly concerns the split between the auth server local context and the `ClientI` interface.

I tried to keep the explicit field access that I used when working on this as it simplifies reading the code.
This was a major pain point previously and I'm super happy how it turned out but I need some naming suggestions.