### PR TITLE
Quickstart Tweaks to use deb/rpm repo

### DIFF
--- a/docs/5.0/pages/installation.md
+++ b/docs/5.0/pages/installation.md
@@ -14,7 +14,7 @@ The following examples install the 64-bit version of Teleport binaries, but
 Release](https://gravitational.com/teleport/download/) page for the most
 up-to-date information.
 
-=== "deb repo"
+=== "DEB repo (Debian/Ubuntu/Linux Mint)"
 
     ```bash
     # Install our public key. Fingerprint: 0c5e 8ba5 658e 320d 1b03 1179 c87e d53a 6282 c411
@@ -27,7 +27,7 @@ up-to-date information.
     $ apt install teleport
     ```
 
-=== "rpm repo & Amazon Linux 2"
+=== "RPM repo (CentOS/RHEL/Fedora/Amazon Linux 2)"
 
     ```bash
     $ yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo

--- a/docs/5.0/pages/installation.md
+++ b/docs/5.0/pages/installation.md
@@ -14,57 +14,24 @@ The following examples install the 64-bit version of Teleport binaries, but
 Release](https://gravitational.com/teleport/download/) page for the most
 up-to-date information.
 
-=== "Tarball"
+=== "deb repo"
 
     ```bash
-    $ curl https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz.sha256
-    # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-    $ shasum -a 256 teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-    # Verify that the checksums match
-    $ tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-    $ cd teleport
-    $ ./install
-    $ which teleport
-    /usr/local/bin/teleport
+    # Install our public key. Fingerprint: 0c5e 8ba5 658e 320d 1b03 1179 c87e d53a 6282 c411
+    $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
+    # Add repo to APT
+    $ add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
+    # Update APT Cache
+    $ apt update
+    # Install Teleport
+    $ apt install teleport
     ```
 
-=== "DEB"
+=== "rpm repo & Amazon Linux 2"
 
     ```bash
-    $ curl https://get.gravitational.com/teleport_{{ teleport.version }}_amd64.deb.sha256
-    # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport_{{ teleport.version }}_amd64.deb
-    $ sha256sum teleport_{{ teleport.version }}_amd64.deb
-    # Verify that the checksums match
-    $ dpkg -i teleport_{{ teleport.version }}_amd64.deb
-    $ which teleport
-    /usr/local/bin/teleport
-    ```
-
-=== "RPM"
-
-    ```bash
-    $ curl https://get.gravitational.com/teleport-{{ teleport.version }}-1.x86_64.rpm.sha256
-    # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-{{ teleport.version }}-1.x86_64.rpm
-    $ sha256sum teleport-{{ teleport.version }}-1.x86_64.rpm
-    # Verify that the checksums match
-    $ rpm -i teleport-{{ teleport.version }}-1.x86_64.rpm
-    $ which teleport
-    /usr/local/bin/teleport
-    ```
-
-=== "Amazon Linux 2"
-
-    ```bash
-    $ yum install https://get.gravitational.com/teleport-{{ teleport.version }}-1.x86_64.rpm.sha256
-    $ which teleport
-    /usr/local/bin/teleport
-    $ cd teleport
-    $ sudo ./install
-    $ which teleport
-    /usr/local/bin/teleport
+    $ yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+    $ yum install teleport
     ```
 
 === "ARMv7 (32-bit)"
@@ -78,8 +45,6 @@ up-to-date information.
     $ tar -xzf teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
     $ cd teleport
     $ ./install
-    $ which teleport
-    /usr/local/bin/teleport
     ```
 
 === "ARM64/ARMv8 (64-bit)"
@@ -93,13 +58,24 @@ up-to-date information.
     $ tar -xzf teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
     $ cd teleport
     $ ./install
-    $ which teleport
-    /usr/local/bin/teleport
+    ```
+
+=== "Tarball"
+
+    ```bash
+    $ curl https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz.sha256
+    # <checksum> <filename>
+    $ curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    $ shasum -a 256 teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    # Verify that the checksums match
+    $ tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    $ cd teleport
+    $ ./install
     ```
 
 ## Docker
 
-Please follow our [OSS Docker Quickstart](quickstart-docker.md) or [Enterprise Docker Quickstart](enterprise/quickstart-enterprise.md#run-teleport-enterprise-using-docker) for install and setup instructions.
+Please follow our [OSS Docker Quick Start](quickstart-docker.md) or [Enterprise Docker Quick Start](enterprise/quickstart-enterprise.md#run-teleport-enterprise-using-docker) for install and setup instructions.
 
 ```bash
 $ docker pull quay.io/gravitational/teleport:{{ teleport.version }}

--- a/docs/5.0/pages/installation.md
+++ b/docs/5.0/pages/installation.md
@@ -14,20 +14,20 @@ The following examples install the 64-bit version of Teleport binaries, but
 Release](https://gravitational.com/teleport/download/) page for the most
 up-to-date information.
 
-=== "DEB repo (Debian/Ubuntu/Linux Mint)"
+=== "Debian/Ubuntu (DEB)"
 
     ```bash
-    # Install our public key. Fingerprint: 0c5e 8ba5 658e 320d 1b03 1179 c87e d53a 6282 c411
+    # Install our public key.
     $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
     # Add repo to APT
     $ add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
     # Update APT Cache
-    $ apt update
+    $ apt-get
     # Install Teleport
     $ apt install teleport
     ```
 
-=== "RPM repo (CentOS/RHEL/Fedora/Amazon Linux 2)"
+=== "Amazon Linux 2/RHEL/Fedora (RPM)"
 
     ```bash
     $ yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
@@ -75,7 +75,7 @@ up-to-date information.
 
 ## Docker
 
-Please follow our [OSS Docker Quick Start](quickstart-docker.md) or [Enterprise Docker Quick Start](enterprise/quickstart-enterprise.md#run-teleport-enterprise-using-docker) for install and setup instructions.
+Please follow our [Getting started with Teleport using Docker](quickstart-docker.md) or with [Teleport Enterprise using Docker](enterprise/quickstart-enterprise.md#run-teleport-enterprise-using-docker) for install and setup instructions.
 
 ```bash
 $ docker pull quay.io/gravitational/teleport:{{ teleport.version }}

--- a/docs/5.0/pages/quickstart-docker.md
+++ b/docs/5.0/pages/quickstart-docker.md
@@ -1,5 +1,5 @@
 ---
-title: Teleport Quick Start guide with Docker
+title: Getting started with Teleport using Docker
 description: How to get started with Teleport using Docker for SSH access
 ---
 

--- a/docs/5.0/pages/quickstart.md
+++ b/docs/5.0/pages/quickstart.md
@@ -24,6 +24,10 @@ Take a look at the [Teleport Installation](installation.md) page to pick the mos
     ```bash
     sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
     sudo yum install teleport
+
+    # Optional:  Using DNF on newer distributions
+    # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+    # $ sudo dnf install teleport
     ```
 
 === "DEB repo (Debian/Ubuntu/Linux Mint)"

--- a/docs/5.0/pages/quickstart.md
+++ b/docs/5.0/pages/quickstart.md
@@ -1,9 +1,9 @@
 ---
-title: Teleport Quick Start
-description: The quick start guide for how to set up modern SSH access to cloud or edge infrastructure.
+title: Getting started with Teleport
+description: The getting started with guide for how to set up modern SSH access to cloud or edge infrastructure.
 ---
 
-# Teleport Quick Start
+# Getting started with Teleport
 
 This tutorial will guide you through the steps needed to install and run
 Teleport on Linux machine(s).
@@ -19,7 +19,7 @@ Teleport on Linux machine(s).
 There are several ways to install Teleport.
 Take a look at the [Teleport Installation](installation.md) page to pick the most convenient for you.
 
-=== "RPM repo (CentOS/RHEL/Fedora/Amazon Linux 2)"
+=== "Amazon Linux 2/RHEL (RPM)"
 
     ```bash
     sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
@@ -30,11 +30,11 @@ Take a look at the [Teleport Installation](installation.md) page to pick the mos
     # $ sudo dnf install teleport
     ```
 
-=== "DEB repo (Debian/Ubuntu/Linux Mint)"
+=== "Debian/Ubuntu (DEB)"
 
     ```bash
     add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    apt-update
+    apt-get
     apt install teleport
     ```
 
@@ -76,7 +76,7 @@ teleport:
     data_dir: /var/lib/teleport
 auth_service:
     enabled: true
-    cluster_name: "teleport-quickstart"
+    cluster_name: "teleport"
     listen_addr: 0.0.0.0:3025
     tokens:
     - proxy,node,app:f7adb7ccdf04037bcd2b52ec6010fd6f0caec94ba190b765
@@ -297,7 +297,7 @@ Armed with these details, we'll bootstrap a new host using
     --roles=node \
     --auth-server=https://teleport.example.com:3080 \
     --token=f7adb7ccdf04037bcd2b52ec6010fd6f0caec94ba190b765 \
-    --labels=env=quickstart
+    --labels=env=demo
     ```
 
 === "cloud-config"
@@ -323,7 +323,7 @@ Armed with these details, we'll bootstrap a new host using
             ssh_service:
                 enabled: true
                 labels:
-                    env: quickstart
+                    env: demo
 
     runcmd:
     - 'mkdir -p /tmp/teleport'

--- a/docs/5.0/pages/quickstart.md
+++ b/docs/5.0/pages/quickstart.md
@@ -19,17 +19,20 @@ Teleport on Linux machine(s).
 There are several ways to install Teleport.
 Take a look at the [Teleport Installation](installation.md) page to pick the most convenient for you.
 
-=== "yum repo / AWS Linux 2"
+=== "yum repo"
 
     ```bash
     sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
     sudo yum install teleport
-
-    # Optional:  Using DNF on newer distributions
-    # sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-    # sudo dnf install teleport
     ```
 
+=== "deb repo"
+
+    ```bash
+    add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
+    apt-update
+    apt install teleport
+    ```
 
 === "ARMv7 (32-bit)"
 
@@ -47,8 +50,6 @@ Take a look at the [Teleport Installation](installation.md) page to pick the mos
     tar -xzf teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
     cd teleport
     sudo ./install
-    Teleport binaries have been copied to /usr/local/bin
-    To configure the systemd service for Teleport take a look at examples/systemd/README.md
     ```
 
 === "Linux Tarball"
@@ -58,8 +59,6 @@ Take a look at the [Teleport Installation](installation.md) page to pick the mos
     tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
     cd teleport
     sudo ./install
-    Teleport binaries have been copied to /usr/local/bin
-    To configure the systemd service for Teleport take a look at examples/systemd/README.md
     ```
 
 ## Step 1b: Configure Teleport
@@ -136,8 +135,8 @@ export TELEPORT_PUBLIC_DNS_NAME="teleport.example.com"
 cat >> /etc/teleport.yaml <<EOF
     public_addr: $TELEPORT_PUBLIC_DNS_NAME:3080
     https_keypairs:
-      - key_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/privkey.pem
-        cert_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/fullchain.pem
+    - key_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/privkey.pem
+      cert_file: /etc/letsencrypt/live/$TELEPORT_PUBLIC_DNS_NAME/fullchain.pem
 EOF
 ```
 
@@ -369,7 +368,7 @@ Armed with these details, we'll bootstrap a new host using
 
 ## Next Steps
 
-Congratulations! You've completed the Teleport Quickstart.
+Congratulations! You've completed the Teleport Quick start.
 
 In this guide, you've learned how to install Teleport on a single node and seen a
 few of the most useful features in action. When you're ready to learn how to set
@@ -386,5 +385,6 @@ common Teleport tasks.
 * [Install Teleport](installation.md)
 * [Share Sessions](user-manual.md#sharing-sessions)
 * [Manage Users](admin-guide.md#adding-and-deleting-users)
+* [Github SSO](admin-guide.md#github-oauth-20)
 * [Label Nodes](admin-guide.md#labeling-nodes-and-applications)
 * [Teleport with OpenSSH](admin-guide.md#using-teleport-with-openssh)

--- a/docs/5.0/pages/quickstart.md
+++ b/docs/5.0/pages/quickstart.md
@@ -19,14 +19,14 @@ Teleport on Linux machine(s).
 There are several ways to install Teleport.
 Take a look at the [Teleport Installation](installation.md) page to pick the most convenient for you.
 
-=== "yum repo"
+=== "RPM repo (CentOS/RHEL/Fedora/Amazon Linux 2)"
 
     ```bash
     sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
     sudo yum install teleport
     ```
 
-=== "deb repo"
+=== "DEB repo (Debian/Ubuntu/Linux Mint)"
 
     ```bash
     add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'


### PR DESCRIPTION
This PR updates install and quick start with rpm/deb instructions from https://rpm.releases.teleport.dev/ & https://deb.releases.teleport.dev/  to improve content. 

