### PR TITLE
Open source users, roles, github, trusted cluster

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -78,7 +78,7 @@ func (a *ServerWithRoles) currentUserAction(username string) error {
 // If not, it checks if the requester has the meta KindAuthConnector access
 // (which grants access to all connectors).
 func (a *ServerWithRoles) authConnectorAction(namespace string, resource string, verb string) error {
-	if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, verb, false); err != nil {
+	if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, verb, true); err != nil {
 		if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, services.KindAuthConnector, verb, false); err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -62,8 +62,6 @@ import (
 	lemma_secret "github.com/mailgun/lemma/secret"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
-
-	"github.com/gravitational/teleport/lib/secret"
 )
 
 // Handler is HTTP web proxy handler

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/httplib/csrf"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
@@ -55,6 +56,7 @@ import (
 
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
+
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
 	lemma_secret "github.com/mailgun/lemma/secret"
@@ -329,20 +331,20 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	// Issue host credentials.
 	h.POST("/webapi/host/credentials", httplib.MakeHandler(h.hostCredentials))
 
-	h.GET("/webapi/resources/roles", h.WithAuth(h.getRolesHandle))
-	h.PUT("/webapi/resources/roles", h.WithAuth(h.upsertRoleHandle))
-	h.POST("/webapi/resources/roles", h.WithAuth(h.upsertRoleHandle))
-	h.DELETE("/webapi/resources/roles/:name", h.WithAuth(h.deleteRole))
+	h.GET("/webapi/roles", h.WithAuth(h.getRolesHandle))
+	h.PUT("/webapi/roles", h.WithAuth(h.upsertRoleHandle))
+	h.POST("/webapi/roles", h.WithAuth(h.upsertRoleHandle))
+	h.DELETE("/webapi/roles/:name", h.WithAuth(h.deleteRole))
 
-	h.GET("/webapi/resources/github", h.WithAuth(h.getGithubConnectorsHandle))
-	h.PUT("/webapi/resources/github", h.WithAuth(h.upsertGithubConnectorHandle))
-	h.POST("/webapi/resources/github", h.WithAuth(h.upsertGithubConnectorHandle))
-	h.DELETE("/webapi/resources/github/:name", h.WithAuth(h.deleteGithubConnector))
+	h.GET("/webapi/github", h.WithAuth(h.getGithubConnectorsHandle))
+	h.PUT("/webapi/github", h.WithAuth(h.upsertGithubConnectorHandle))
+	h.POST("/webapi/github", h.WithAuth(h.upsertGithubConnectorHandle))
+	h.DELETE("/webapi/github/:name", h.WithAuth(h.deleteGithubConnector))
 
-	h.GET("/webapi/resources/trustedcluster", h.WithAuth(h.getTrustedClustersHandle))
-	h.PUT("/webapi/resources/trustedcluster", h.WithAuth(h.upsertTrustedClusterHandle))
-	h.POST("/webapi/resources/trustedcluster", h.WithAuth(h.upsertTrustedClusterHandle))
-	h.DELETE("/webapi/resources/trustedcluster/:name", h.WithAuth(h.deleteTrustedCluster))
+	h.GET("/webapi/trustedcluster", h.WithAuth(h.getTrustedClustersHandle))
+	h.PUT("/webapi/trustedcluster", h.WithAuth(h.upsertTrustedClusterHandle))
+	h.POST("/webapi/trustedcluster", h.WithAuth(h.upsertTrustedClusterHandle))
+	h.DELETE("/webapi/trustedcluster/:name", h.WithAuth(h.deleteTrustedCluster))
 
 	// if Web UI is enabled, check the assets dir:
 	var indexPage *template.Template

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 Gravitational, Inc.
+Copyright 2015-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -252,6 +252,11 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	h.POST("/webapi/sessions/renew", h.WithAuth(h.renewSession))
 	h.POST("/webapi/sessions/renew/:requestId", h.WithAuth(h.renewSession))
 
+	h.POST("/webapi/users", h.WithAuth(h.createUserHandle))
+	h.PUT("/webapi/users", h.WithAuth(h.updateUserHandle))
+	h.GET("/webapi/users", h.WithAuth(h.getUsersHandle))
+	h.DELETE("/webapi/users/:username", h.WithAuth(h.deleteUserHandle))
+
 	h.GET("/webapi/users/password/token/:token", httplib.MakeHandler(h.getResetPasswordTokenHandle))
 	h.PUT("/webapi/users/password/token", httplib.WithCSRFProtection(h.changePasswordWithToken))
 	h.PUT("/webapi/users/password", h.WithAuth(h.changePassword))
@@ -323,6 +328,21 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 
 	// Issue host credentials.
 	h.POST("/webapi/host/credentials", httplib.MakeHandler(h.hostCredentials))
+
+	h.GET("/webapi/resources/roles", h.WithAuth(h.getRolesHandle))
+	h.PUT("/webapi/resources/roles", h.WithAuth(h.upsertRoleHandle))
+	h.POST("/webapi/resources/roles", h.WithAuth(h.upsertRoleHandle))
+	h.DELETE("/webapi/resources/roles/:name", h.WithAuth(h.deleteRole))
+
+	h.GET("/webapi/resources/github", h.WithAuth(h.getGithubConnectorsHandle))
+	h.PUT("/webapi/resources/github", h.WithAuth(h.upsertGithubConnectorHandle))
+	h.POST("/webapi/resources/github", h.WithAuth(h.upsertGithubConnectorHandle))
+	h.DELETE("/webapi/resources/github/:name", h.WithAuth(h.deleteGithubConnector))
+
+	h.GET("/webapi/resources/trustedcluster", h.WithAuth(h.getTrustedClustersHandle))
+	h.PUT("/webapi/resources/trustedcluster", h.WithAuth(h.upsertTrustedClusterHandle))
+	h.POST("/webapi/resources/trustedcluster", h.WithAuth(h.upsertTrustedClusterHandle))
+	h.DELETE("/webapi/resources/trustedcluster/:name", h.WithAuth(h.deleteTrustedCluster))
 
 	// if Web UI is enabled, check the assets dir:
 	var indexPage *template.Template
@@ -446,7 +466,7 @@ func (h *Handler) Close() error {
 }
 
 func (h *Handler) getUserStatus(w http.ResponseWriter, r *http.Request, _ httprouter.Params, c *SessionContext) (interface{}, error) {
-	return ok(), nil
+	return OK(), nil
 }
 
 // getUserContext returns user context
@@ -1276,7 +1296,7 @@ func (h *Handler) deleteSession(w http.ResponseWriter, r *http.Request, _ httpro
 		return nil, trace.Wrap(err)
 	}
 
-	return ok(), nil
+	return OK(), nil
 }
 
 func (h *Handler) logout(w http.ResponseWriter, ctx *SessionContext) error {
@@ -2279,7 +2299,8 @@ func message(msg string) interface{} {
 	return map[string]interface{}{"message": msg}
 }
 
-func ok() interface{} {
+// OK is a response that indicates request was successful.
+func OK() interface{} {
 	return message("ok")
 }
 

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -78,7 +78,7 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 		return nil, trace.Wrap(err)
 	}
 
-	return ok(), nil
+	return OK(), nil
 }
 
 type fileTransfer struct {

--- a/lib/web/password.go
+++ b/lib/web/password.go
@@ -65,7 +65,7 @@ func (h *Handler) changePassword(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 
-	return ok(), nil
+	return OK(), nil
 }
 
 // u2fChangePasswordRequest is called to get U2F challedge for changing a user password

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package web
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/web/ui"
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func (h *Handler) getRolesHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return getRoles(clt)
+}
+
+func getRoles(clt resourcesAPIGetter) ([]ui.ResourceItem, error) {
+	roles, err := clt.GetRoles()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.NewRoles(roles)
+}
+
+func (h *Handler) deleteRole(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	roleName := params.ByName("name")
+	if err := clt.DeleteRole(r.Context(), roleName); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return OK(), nil
+}
+
+func (h *Handler) upsertRoleHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var req ui.ResourceItem
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return upsertRole(r.Context(), clt, req.Content, r.Method)
+}
+
+func upsertRole(ctx context.Context, clt resourcesAPIGetter, content, httpMethod string) (*ui.ResourceItem, error) {
+	extractedRes, err := ExtractResourceAndValidate(content)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if extractedRes.Kind != types.KindRole {
+		return nil, trace.BadParameter("resource kind %q is invalid", extractedRes.Kind)
+	}
+
+	_, err = clt.GetRole(extractedRes.Metadata.Name)
+	if err := CheckResourceUpsertableByError(err, httpMethod, extractedRes.Metadata.Name); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	role, err := services.GetRoleMarshaler().UnmarshalRole(extractedRes.Raw)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := clt.UpsertRole(ctx, role); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.NewResourceItem(role)
+}
+
+func (h *Handler) getGithubConnectorsHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return getGithubConnectors(clt)
+}
+
+func getGithubConnectors(clt resourcesAPIGetter) ([]ui.ResourceItem, error) {
+	connectors, err := clt.GetGithubConnectors(true)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.NewGithubConnectors(connectors)
+}
+
+func (h *Handler) deleteGithubConnector(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	connectorName := params.ByName("name")
+	if err := clt.DeleteGithubConnector(r.Context(), connectorName); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return OK(), nil
+}
+
+func (h *Handler) upsertGithubConnectorHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var req ui.ResourceItem
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return upsertGithubConnector(r.Context(), clt, req.Content, r.Method)
+}
+
+func upsertGithubConnector(ctx context.Context, clt resourcesAPIGetter, content, httpMethod string) (*ui.ResourceItem, error) {
+	extractedRes, err := ExtractResourceAndValidate(content)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if extractedRes.Kind != types.KindGithubConnector {
+		return nil, trace.BadParameter("resource kind %q is invalid", extractedRes.Kind)
+	}
+
+	_, err = clt.GetGithubConnector(extractedRes.Metadata.Name, false)
+	if err := CheckResourceUpsertableByError(err, httpMethod, extractedRes.Metadata.Name); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	connector, err := services.GetGithubConnectorMarshaler().Unmarshal(extractedRes.Raw)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := clt.UpsertGithubConnector(ctx, connector); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.NewResourceItem(connector)
+}
+
+func (h *Handler) getTrustedClustersHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return getTrustedClusters(clt)
+}
+
+func getTrustedClusters(clt resourcesAPIGetter) ([]ui.ResourceItem, error) {
+	trustedClusters, err := clt.GetTrustedClusters()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.NewTrustedClusters(trustedClusters)
+}
+
+func (h *Handler) deleteTrustedCluster(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tcName := params.ByName("name")
+	if err := clt.DeleteTrustedCluster(r.Context(), tcName); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return OK(), nil
+}
+
+func (h *Handler) upsertTrustedClusterHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var req ui.ResourceItem
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return upsertTrustedCluster(r.Context(), clt, req.Content, r.Method)
+}
+
+func upsertTrustedCluster(ctx context.Context, clt resourcesAPIGetter, content, httpMethod string) (*ui.ResourceItem, error) {
+	extractedRes, err := ExtractResourceAndValidate(content)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if extractedRes.Kind != types.KindTrustedCluster {
+		return nil, trace.BadParameter("resource kind %q is invalid", extractedRes.Kind)
+	}
+
+	_, err = clt.GetTrustedCluster(extractedRes.Metadata.Name)
+	if err := CheckResourceUpsertableByError(err, httpMethod, extractedRes.Metadata.Name); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tc, err := services.GetTrustedClusterMarshaler().Unmarshal(extractedRes.Raw)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	_, err = clt.UpsertTrustedCluster(ctx, tc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.NewResourceItem(tc)
+}
+
+// CheckResourceUpsertableByError checks if the resource is upsertable by the state of error with
+// the request http method used.
+func CheckResourceUpsertableByError(err error, httpMethod, resourceName string) error {
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+
+	exists := err == nil
+	if exists && httpMethod == http.MethodPost {
+		return trace.AlreadyExists("resource name %q already exists", resourceName)
+	}
+
+	if !exists && httpMethod == http.MethodPut {
+		return trace.NotFound("cannot find resource with name %q", resourceName)
+	}
+
+	return nil
+}
+
+// ExtractResourceAndValidate extracts resource information from given string and validates basic fields.
+func ExtractResourceAndValidate(yaml string) (*services.UnknownResource, error) {
+	var unknownRes services.UnknownResource
+	reader := strings.NewReader(yaml)
+	decoder := kyaml.NewYAMLOrJSONDecoder(reader, 32*1024)
+
+	if err := decoder.Decode(&unknownRes); err != nil {
+		return nil, trace.BadParameter("not a valid resource declaration")
+	}
+
+	if err := unknownRes.Metadata.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &unknownRes, nil
+}
+
+type resourcesAPIGetter interface {
+	// GetRole returns role by name
+	GetRole(name string) (types.Role, error)
+	// GetRoles returns a list of roles
+	GetRoles() ([]types.Role, error)
+	// UpsertRole creates or updates role
+	UpsertRole(ctx context.Context, role types.Role) error
+	// UpsertGithubConnector creates or updates a Github connector
+	UpsertGithubConnector(ctx context.Context, connector services.GithubConnector) error
+	// GetGithubConnectors returns all configured Github connectors
+	GetGithubConnectors(withSecrets bool) ([]services.GithubConnector, error)
+	// GetGithubConnector returns the specified Github connector
+	GetGithubConnector(id string, withSecrets bool) (services.GithubConnector, error)
+	// DeleteGithubConnector deletes the specified Github connector
+	DeleteGithubConnector(ctx context.Context, id string) error
+	// UpsertTrustedCluster creates or updates a TrustedCluster in the backend.
+	UpsertTrustedCluster(ctx context.Context, tc types.TrustedCluster) (types.TrustedCluster, error)
+	// GetTrustedCluster returns a single TrustedCluster by name.
+	GetTrustedCluster(string) (types.TrustedCluster, error)
+	// GetTrustedClusters returns all TrustedClusters in the backend.
+	GetTrustedClusters() ([]types.TrustedCluster, error)
+	// DeleteTrustedCluster removes a TrustedCluster from the backend by name.
+	DeleteTrustedCluster(ctx context.Context, name string) error
+}

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -25,7 +25,9 @@ import (
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
+
 	"github.com/gravitational/trace"
+
 	"github.com/julienschmidt/httprouter"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -294,11 +296,11 @@ type resourcesAPIGetter interface {
 	// UpsertRole creates or updates role
 	UpsertRole(ctx context.Context, role types.Role) error
 	// UpsertGithubConnector creates or updates a Github connector
-	UpsertGithubConnector(ctx context.Context, connector services.GithubConnector) error
+	UpsertGithubConnector(ctx context.Context, connector types.GithubConnector) error
 	// GetGithubConnectors returns all configured Github connectors
-	GetGithubConnectors(withSecrets bool) ([]services.GithubConnector, error)
+	GetGithubConnectors(withSecrets bool) ([]types.GithubConnector, error)
 	// GetGithubConnector returns the specified Github connector
-	GetGithubConnector(id string, withSecrets bool) (services.GithubConnector, error)
+	GetGithubConnector(id string, withSecrets bool) (types.GithubConnector, error)
 	// DeleteGithubConnector deletes the specified Github connector
 	DeleteGithubConnector(ctx context.Context, id string) error
 	// UpsertTrustedCluster creates or updates a TrustedCluster in the backend.

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -91,7 +91,7 @@ func upsertRole(ctx context.Context, clt resourcesAPIGetter, content, httpMethod
 		return nil, trace.Wrap(err)
 	}
 
-	role, err := services.GetRoleMarshaler().UnmarshalRole(extractedRes.Raw)
+	role, err := services.UnmarshalRole(extractedRes.Raw)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -164,7 +164,7 @@ func upsertGithubConnector(ctx context.Context, clt resourcesAPIGetter, content,
 		return nil, trace.Wrap(err)
 	}
 
-	connector, err := services.GetGithubConnectorMarshaler().Unmarshal(extractedRes.Raw)
+	connector, err := services.UnmarshalGithubConnector(extractedRes.Raw)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -237,7 +237,7 @@ func upsertTrustedCluster(ctx context.Context, clt resourcesAPIGetter, content, 
 		return nil, trace.Wrap(err)
 	}
 
-	tc, err := services.GetTrustedClusterMarshaler().Unmarshal(extractedRes.Raw)
+	tc, err := services.UnmarshalTrustedCluster(extractedRes.Raw)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/web/ui"
+
 	"github.com/gravitational/trace"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -18,7 +18,6 @@ package web
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/gravitational/teleport/api/types"
@@ -43,10 +42,10 @@ version: v3`
 	require.NotNil(t, extractedResource)
 
 	// Test missing name.
-	badContent := `kind: role
+	invalidContent := `kind: role
 metadata:
   name:`
-	extractedResource, err = ExtractResourceAndValidate(badContent)
+	extractedResource, err = ExtractResourceAndValidate(invalidContent)
 	require.Nil(t, extractedResource)
 	require.True(t, trace.IsBadParameter(err))
 	require.Contains(t, err.Error(), "Name")
@@ -69,17 +68,17 @@ func TestCheckResourceUpsertableByError(t *testing.T) {
 	require.True(t, trace.IsNotFound(err))
 }
 
-func TestNewResourceItem(t *testing.T) {
-	// Test github resource.
+func TestNewResourceItemGithub(t *testing.T) {
 	githubConn := types.NewGithubConnector("githubName", types.GithubConnectorSpecV3{})
 	item, err := ui.NewResourceItem(githubConn)
 	require.Nil(t, err)
-	require.Equal(t, item.ID, fmt.Sprintf("%s:%s", types.KindGithubConnector, "githubName"))
+	require.Equal(t, item.ID, "github:githubName")
 	require.Equal(t, item.Kind, types.KindGithubConnector)
 	require.Equal(t, item.Name, "githubName")
 	require.Contains(t, item.Content, types.KindGithubConnector)
+}
 
-	// Test role resource.
+func TestNewResourceItemRole(t *testing.T) {
 	role, err := types.NewRole("roleName", types.RoleSpecV3{
 		Allow: types.RoleConditions{
 			Logins: []string{"test"},
@@ -87,20 +86,21 @@ func TestNewResourceItem(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	item, err = ui.NewResourceItem(role)
+	item, err := ui.NewResourceItem(role)
 	require.Nil(t, err)
-	require.Equal(t, item.ID, fmt.Sprintf("%s:%s", types.KindRole, "roleName"))
+	require.Equal(t, item.ID, "role:roleName")
 	require.Equal(t, item.Kind, types.KindRole)
 	require.Equal(t, item.Name, "roleName")
 	require.Contains(t, item.Content, types.KindRole)
+}
 
-	// Test trusted cluster resource.
+func TestNewResourceItemTrustedCluster(t *testing.T) {
 	cluster, err := types.NewTrustedCluster("tcName", types.TrustedClusterSpecV2{})
 	require.Nil(t, err)
 
-	item, err = ui.NewResourceItem(cluster)
+	item, err := ui.NewResourceItem(cluster)
 	require.Nil(t, err)
-	require.Equal(t, item.ID, fmt.Sprintf("%s:%s", types.KindTrustedCluster, "tcName"))
+	require.Equal(t, item.ID, "trusted_cluster:tcName")
 	require.Equal(t, item.Kind, types.KindTrustedCluster)
 	require.Equal(t, item.Name, "tcName")
 	require.Contains(t, item.Content, types.KindTrustedCluster)
@@ -138,10 +138,10 @@ func TestUpsertRole(t *testing.T) {
 	}
 
 	// Test bad request kind.
-	badKind := `kind: bad-kind
+	invalidKind := `kind: invalid-kind
 metadata:
   name: test`
-	role, err := upsertRole(context.Background(), m, badKind, "")
+	role, err := upsertRole(context.Background(), m, invalidKind, "")
 	require.Nil(t, role)
 	require.True(t, trace.IsBadParameter(err))
 	require.Contains(t, err.Error(), "kind")
@@ -192,10 +192,10 @@ func TestUpsertGithubConnector(t *testing.T) {
 	}
 
 	// Test bad request kind.
-	badKind := `kind: bad-kind
+	invalidKind := `kind: invalid-kind
 metadata:
   name: test`
-	conn, err := upsertGithubConnector(context.Background(), m, badKind, "")
+	conn, err := upsertGithubConnector(context.Background(), m, invalidKind, "")
 	require.Nil(t, conn)
 	require.True(t, trace.IsBadParameter(err))
 	require.Contains(t, err.Error(), "kind")
@@ -248,10 +248,10 @@ func TestUpsertTrustedCluster(t *testing.T) {
 	}
 
 	// Test bad request kind.
-	badKind := `kind: bad-kind
+	invalidKind := `kind: invalid-kind
 metadata:
   name: test`
-	conn, err := upsertTrustedCluster(context.Background(), m, badKind, "")
+	conn, err := upsertTrustedCluster(context.Background(), m, invalidKind, "")
 	require.Nil(t, conn)
 	require.True(t, trace.IsBadParameter(err))
 	require.Contains(t, err.Error(), "kind")

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -1,0 +1,370 @@
+/**
+ * Copyright 2021 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package web
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/web/ui"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractResourceAndValidate(t *testing.T) {
+	goodContent := `kind: role
+metadata:
+  name: test
+spec:
+  allow:
+    logins:
+    - testing
+version: v3`
+	extractedResource, err := ExtractResourceAndValidate(goodContent)
+	require.Nil(t, err)
+	require.NotNil(t, extractedResource)
+
+	// Test missing name.
+	badContent := `kind: role
+metadata:
+  name:`
+	extractedResource, err = ExtractResourceAndValidate(badContent)
+	require.Nil(t, extractedResource)
+	require.True(t, trace.IsBadParameter(err))
+	require.Contains(t, err.Error(), "Name")
+}
+
+func TestCheckResourceUpsertableByError(t *testing.T) {
+	err := CheckResourceUpsertableByError(trace.BadParameter(""), "POST", "")
+	require.True(t, trace.IsBadParameter(err))
+
+	err = CheckResourceUpsertableByError(nil, "POST", "")
+	require.True(t, trace.IsAlreadyExists(err))
+
+	err = CheckResourceUpsertableByError(trace.NotFound(""), "POST", "")
+	require.Nil(t, err)
+
+	err = CheckResourceUpsertableByError(nil, "PUT", "")
+	require.Nil(t, err)
+
+	err = CheckResourceUpsertableByError(trace.NotFound(""), "PUT", "")
+	require.True(t, trace.IsNotFound(err))
+}
+
+func TestNewResourceItem(t *testing.T) {
+	// Test github resource.
+	githubConn := types.NewGithubConnector("githubName", types.GithubConnectorSpecV3{})
+	item, err := ui.NewResourceItem(githubConn)
+	require.Nil(t, err)
+	require.Equal(t, item.ID, fmt.Sprintf("%s:%s", types.KindGithubConnector, "githubName"))
+	require.Equal(t, item.Kind, types.KindGithubConnector)
+	require.Equal(t, item.Name, "githubName")
+	require.Contains(t, item.Content, types.KindGithubConnector)
+
+	// Test role resource.
+	role, err := types.NewRole("roleName", types.RoleSpecV3{
+		Allow: types.RoleConditions{
+			Logins: []string{"test"},
+		},
+	})
+	require.Nil(t, err)
+
+	item, err = ui.NewResourceItem(role)
+	require.Nil(t, err)
+	require.Equal(t, item.ID, fmt.Sprintf("%s:%s", types.KindRole, "roleName"))
+	require.Equal(t, item.Kind, types.KindRole)
+	require.Equal(t, item.Name, "roleName")
+	require.Contains(t, item.Content, types.KindRole)
+
+	// Test trusted cluster resource.
+	cluster, err := types.NewTrustedCluster("tcName", types.TrustedClusterSpecV2{})
+	require.Nil(t, err)
+
+	item, err = ui.NewResourceItem(cluster)
+	require.Nil(t, err)
+	require.Equal(t, item.ID, fmt.Sprintf("%s:%s", types.KindTrustedCluster, "tcName"))
+	require.Equal(t, item.Kind, types.KindTrustedCluster)
+	require.Equal(t, item.Name, "tcName")
+	require.Contains(t, item.Content, types.KindTrustedCluster)
+}
+
+func TestGetRoles(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	m.mockGetRoles = func() ([]types.Role, error) {
+		role, err := types.NewRole("test", types.RoleSpecV3{
+			Allow: types.RoleConditions{
+				Logins: []string{"test"},
+			},
+		})
+		require.Nil(t, err)
+
+		return []types.Role{role}, nil
+	}
+
+	// Test response is converted to ui objects.
+	roles, err := getRoles(m)
+	require.Nil(t, err)
+	require.Len(t, roles, 1)
+	require.Contains(t, roles[0].Content, "name: test")
+}
+
+func TestUpsertRole(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	m.mockUpsertRole = func(ctx context.Context, role types.Role) error {
+		return nil
+	}
+	m.mockGetRole = func(name string) (types.Role, error) {
+		return nil, trace.NotFound("")
+	}
+
+	// Test bad request kind.
+	badKind := `kind: bad-kind
+metadata:
+  name: test`
+	role, err := upsertRole(context.Background(), m, badKind, "")
+	require.Nil(t, role)
+	require.True(t, trace.IsBadParameter(err))
+	require.Contains(t, err.Error(), "kind")
+
+	goodContent := `kind: role
+metadata:
+  name: test
+spec:
+  allow:
+    logins:
+    - testing
+version: v3`
+
+	// Test POST (create) role.
+	role, err = upsertRole(context.Background(), m, goodContent, "POST")
+	require.Nil(t, err)
+	require.Contains(t, role.Content, "name: test")
+
+	// Test error with PUT (update) with non existing role.
+	role, err = upsertRole(context.Background(), m, goodContent, "PUT")
+	require.Nil(t, role)
+	require.True(t, trace.IsNotFound(err))
+}
+
+func TestGetGithubConnectors(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	m.mockGetGithubConnectors = func(withSecrets bool) ([]types.GithubConnector, error) {
+		connector := types.NewGithubConnector("test", types.GithubConnectorSpecV3{})
+
+		return []types.GithubConnector{connector}, nil
+	}
+
+	// Test response is converted to ui objects.
+	connectors, err := getGithubConnectors(m)
+	require.Nil(t, err)
+	require.Len(t, connectors, 1)
+	require.Contains(t, connectors[0].Content, "name: test")
+}
+
+func TestUpsertGithubConnector(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+	m.mockUpsertGithubConnector = func(ctx context.Context, connector types.GithubConnector) error {
+		return nil
+	}
+	m.mockGetGithubConnector = func(id string, withSecrets bool) (types.GithubConnector, error) {
+		return nil, trace.NotFound("")
+	}
+
+	// Test bad request kind.
+	badKind := `kind: bad-kind
+metadata:
+  name: test`
+	conn, err := upsertGithubConnector(context.Background(), m, badKind, "")
+	require.Nil(t, conn)
+	require.True(t, trace.IsBadParameter(err))
+	require.Contains(t, err.Error(), "kind")
+
+	goodContent := `kind: github
+metadata:
+  name: test
+spec:
+  client_id: <client-id>
+  client_secret: <client-secret>
+  display: Github
+  redirect_url: https://<cluster-url>/v1/webapi/github/callback
+  teams_to_logins:
+  - logins:
+    - admins
+    organization: <github-org>
+    team: admins
+version: v3`
+
+	// Test POST (create) connector.
+	connector, err := upsertGithubConnector(context.Background(), m, goodContent, "POST")
+	require.Nil(t, err)
+	require.Contains(t, connector.Content, "name: test")
+}
+
+func TestGetTrustedClusters(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+
+	m.mockGetTrustedClusters = func() ([]types.TrustedCluster, error) {
+		cluster, err := types.NewTrustedCluster("test", types.TrustedClusterSpecV2{})
+		require.Nil(t, err)
+
+		return []types.TrustedCluster{cluster}, nil
+	}
+
+	// Test response is converted to ui objects.
+	tcs, err := getTrustedClusters(m)
+	require.Nil(t, err)
+	require.Len(t, tcs, 1)
+	require.Contains(t, tcs[0].Content, "name: test")
+}
+
+func TestUpsertTrustedCluster(t *testing.T) {
+	m := &mockedResourceAPIGetter{}
+	m.mockUpsertTrustedCluster = func(ctx context.Context, tc types.TrustedCluster) (types.TrustedCluster, error) {
+		return nil, nil
+	}
+	m.mockGetTrustedCluster = func(name string) (types.TrustedCluster, error) {
+		return nil, trace.NotFound("")
+	}
+
+	// Test bad request kind.
+	badKind := `kind: bad-kind
+metadata:
+  name: test`
+	conn, err := upsertTrustedCluster(context.Background(), m, badKind, "")
+	require.Nil(t, conn)
+	require.True(t, trace.IsBadParameter(err))
+	require.Contains(t, err.Error(), "kind")
+
+	// Test create (POST).
+	goodContent := `kind: trusted_cluster
+metadata:
+  name: test
+spec:
+  role_map:
+  - local:
+    - admin
+    remote: admin
+version: v2`
+	tc, err := upsertTrustedCluster(context.Background(), m, goodContent, "POST")
+	require.Nil(t, err)
+	require.Contains(t, tc.Content, "name: test")
+}
+
+type mockedResourceAPIGetter struct {
+	mockGetRole               func(name string) (types.Role, error)
+	mockGetRoles              func() ([]types.Role, error)
+	mockUpsertRole            func(ctx context.Context, role types.Role) error
+	mockUpsertGithubConnector func(ctx context.Context, connector types.GithubConnector) error
+	mockGetGithubConnectors   func(withSecrets bool) ([]types.GithubConnector, error)
+	mockGetGithubConnector    func(id string, withSecrets bool) (types.GithubConnector, error)
+	mockDeleteGithubConnector func(ctx context.Context, id string) error
+	mockUpsertTrustedCluster  func(ctx context.Context, tc types.TrustedCluster) (types.TrustedCluster, error)
+	mockGetTrustedCluster     func(string) (types.TrustedCluster, error)
+	mockGetTrustedClusters    func() ([]types.TrustedCluster, error)
+	mockDeleteTrustedCluster  func(ctx context.Context, name string) error
+}
+
+func (m *mockedResourceAPIGetter) GetRole(name string) (types.Role, error) {
+	if m.mockGetRole != nil {
+		return m.mockGetRole(name)
+	}
+	return nil, trace.NotImplemented("mockGetRole not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetRoles() ([]types.Role, error) {
+	if m.mockGetRoles != nil {
+		return m.mockGetRoles()
+	}
+	return nil, trace.NotImplemented("mockGetRoles not implemented")
+}
+
+func (m *mockedResourceAPIGetter) UpsertRole(ctx context.Context, role types.Role) error {
+	if m.mockUpsertRole != nil {
+		return m.mockUpsertRole(ctx, role)
+	}
+
+	return trace.NotImplemented("mockUpsertRole not implemented")
+}
+
+func (m *mockedResourceAPIGetter) UpsertGithubConnector(ctx context.Context, connector types.GithubConnector) error {
+	if m.mockUpsertGithubConnector != nil {
+		return m.mockUpsertGithubConnector(ctx, connector)
+	}
+
+	return trace.NotImplemented("mockUpsertGithubConnector not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetGithubConnectors(withSecrets bool) ([]types.GithubConnector, error) {
+	if m.mockGetGithubConnectors != nil {
+		return m.mockGetGithubConnectors(false)
+	}
+
+	return nil, trace.NotImplemented("mockGetGithubConnectors not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetGithubConnector(id string, withSecrets bool) (types.GithubConnector, error) {
+	if m.mockGetGithubConnector != nil {
+		return m.mockGetGithubConnector(id, false)
+	}
+
+	return nil, trace.NotImplemented("mockGetGithubConnector not implemented")
+}
+
+func (m *mockedResourceAPIGetter) DeleteGithubConnector(ctx context.Context, id string) error {
+	if m.mockDeleteGithubConnector != nil {
+		return m.mockDeleteGithubConnector(ctx, id)
+	}
+
+	return trace.NotImplemented("mockDeleteGithubConnector not implemented")
+}
+
+func (m *mockedResourceAPIGetter) UpsertTrustedCluster(ctx context.Context, tc types.TrustedCluster) (types.TrustedCluster, error) {
+	if m.mockUpsertTrustedCluster != nil {
+		return m.mockUpsertTrustedCluster(ctx, tc)
+	}
+
+	return nil, trace.NotImplemented("mockUpsertTrustedCluster not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetTrustedCluster(name string) (types.TrustedCluster, error) {
+	if m.mockGetTrustedCluster != nil {
+		return m.mockGetTrustedCluster(name)
+	}
+
+	return nil, trace.NotImplemented("mockGetTrustedCluster not implemented")
+}
+
+func (m *mockedResourceAPIGetter) GetTrustedClusters() ([]types.TrustedCluster, error) {
+	if m.mockGetTrustedClusters != nil {
+		return m.mockGetTrustedClusters()
+	}
+
+	return nil, trace.NotImplemented("mockGetTrustedClusters not implemented")
+}
+
+func (m *mockedResourceAPIGetter) DeleteTrustedCluster(ctx context.Context, name string) error {
+	if m.mockDeleteTrustedCluster != nil {
+		return m.mockDeleteTrustedCluster(ctx, name)
+	}
+
+	return trace.NotImplemented("mockDeleteTrustedCluster not implemented")
+}

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -69,16 +69,55 @@ func TestCheckResourceUpsertableByError(t *testing.T) {
 }
 
 func TestNewResourceItemGithub(t *testing.T) {
+	const contents = `kind: github
+metadata:
+  name: githubName
+spec:
+  client_id: ""
+  client_secret: ""
+  display: ""
+  redirect_url: ""
+  teams_to_logins: null
+version: v3
+`
 	githubConn := types.NewGithubConnector("githubName", types.GithubConnectorSpecV3{})
 	item, err := ui.NewResourceItem(githubConn)
 	require.Nil(t, err)
-	require.Equal(t, item.ID, "github:githubName")
-	require.Equal(t, item.Kind, types.KindGithubConnector)
-	require.Equal(t, item.Name, "githubName")
-	require.Contains(t, item.Content, types.KindGithubConnector)
+	require.Equal(t, item, &ui.ResourceItem{
+		ID:      "github:githubName",
+		Kind:    types.KindGithubConnector,
+		Name:    "githubName",
+		Content: contents,
+	})
 }
 
 func TestNewResourceItemRole(t *testing.T) {
+	const contents = `kind: role
+metadata:
+  name: roleName
+spec:
+  allow:
+    app_labels:
+      '*': '*'
+    db_labels:
+      '*': '*'
+    kubernetes_labels:
+      '*': '*'
+    logins:
+    - test
+    node_labels:
+      '*': '*'
+  deny: {}
+  options:
+    cert_format: standard
+    enhanced_recording:
+    - command
+    - network
+    forward_agent: false
+    max_session_ttl: 30h0m0s
+    port_forwarding: true
+version: v3
+`
 	role, err := types.NewRole("roleName", types.RoleSpecV3{
 		Allow: types.RoleConditions{
 			Logins: []string{"test"},
@@ -88,22 +127,36 @@ func TestNewResourceItemRole(t *testing.T) {
 
 	item, err := ui.NewResourceItem(role)
 	require.Nil(t, err)
-	require.Equal(t, item.ID, "role:roleName")
-	require.Equal(t, item.Kind, types.KindRole)
-	require.Equal(t, item.Name, "roleName")
-	require.Contains(t, item.Content, types.KindRole)
+	require.Equal(t, item, &ui.ResourceItem{
+		ID:      "role:roleName",
+		Kind:    types.KindRole,
+		Name:    "roleName",
+		Content: contents,
+	})
 }
 
 func TestNewResourceItemTrustedCluster(t *testing.T) {
+	const contents = `kind: trusted_cluster
+metadata:
+  name: tcName
+spec:
+  enabled: false
+  token: ""
+  tunnel_addr: ""
+  web_proxy_addr: ""
+version: v2
+`
 	cluster, err := types.NewTrustedCluster("tcName", types.TrustedClusterSpecV2{})
 	require.Nil(t, err)
 
 	item, err := ui.NewResourceItem(cluster)
 	require.Nil(t, err)
-	require.Equal(t, item.ID, "trusted_cluster:tcName")
-	require.Equal(t, item.Kind, types.KindTrustedCluster)
-	require.Equal(t, item.Name, "tcName")
-	require.Contains(t, item.Content, types.KindTrustedCluster)
+	require.Equal(t, item, &ui.ResourceItem{
+		ID:      "trusted_cluster:tcName",
+		Kind:    types.KindTrustedCluster,
+		Name:    "tcName",
+		Content: contents,
+	})
 }
 
 func TestGetRoles(t *testing.T) {
@@ -148,7 +201,7 @@ metadata:
 
 	goodContent := `kind: role
 metadata:
-  name: test
+  name: test-goodcontent
 spec:
   allow:
     logins:
@@ -158,7 +211,7 @@ version: v3`
 	// Test POST (create) role.
 	role, err = upsertRole(context.Background(), m, goodContent, "POST")
 	require.Nil(t, err)
-	require.Contains(t, role.Content, "name: test")
+	require.Contains(t, role.Content, "name: test-goodcontent")
 
 	// Test error with PUT (update) with non existing role.
 	role, err = upsertRole(context.Background(), m, goodContent, "PUT")
@@ -202,7 +255,7 @@ metadata:
 
 	goodContent := `kind: github
 metadata:
-  name: test
+  name: test-goodcontent
 spec:
   client_id: <client-id>
   client_secret: <client-secret>
@@ -218,7 +271,7 @@ version: v3`
 	// Test POST (create) connector.
 	connector, err := upsertGithubConnector(context.Background(), m, goodContent, "POST")
 	require.Nil(t, err)
-	require.Contains(t, connector.Content, "name: test")
+	require.Contains(t, connector.Content, "name: test-goodcontent")
 }
 
 func TestGetTrustedClusters(t *testing.T) {
@@ -259,7 +312,7 @@ metadata:
 	// Test create (POST).
 	goodContent := `kind: trusted_cluster
 metadata:
-  name: test
+  name: test-goodcontent
 spec:
   role_map:
   - local:
@@ -268,7 +321,7 @@ spec:
 version: v2`
 	tc, err := upsertTrustedCluster(context.Background(), m, goodContent, "POST")
 	require.Nil(t, err)
-	require.Contains(t, tc.Content, "name: test")
+	require.Contains(t, tc.Content, "name: test-goodcontent")
 }
 
 type mockedResourceAPIGetter struct {

--- a/lib/web/ui/resource.go
+++ b/lib/web/ui/resource.go
@@ -19,9 +19,11 @@ package ui
 import (
 	"fmt"
 
-	yaml "github.com/ghodss/yaml"
 	"github.com/gravitational/teleport/api/types"
+
 	"github.com/gravitational/trace"
+
+	yaml "github.com/ghodss/yaml"
 )
 
 // ResourceItem is UI representation of a resource (roles, trusted clusters, auth connectors).

--- a/lib/web/ui/resource.go
+++ b/lib/web/ui/resource.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ui
+
+import (
+	"fmt"
+
+	yaml "github.com/ghodss/yaml"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+)
+
+// ResourceItem is UI representation of a resource (roles, trusted clusters, auth connectors).
+type ResourceItem struct {
+	// ID is a resource ID which is a composed value based on kind and name.
+	// It is a composed value because while a resource name is unique to that resource,
+	// the name can be the same for different resource type.
+	ID string `json:"id"`
+	// Kind is a resource kind.
+	Kind string `json:"kind"`
+	// Name is a resource name.
+	Name string `json:"name"`
+	// Content is resource yaml content.
+	Content string `json:"content"`
+}
+
+// NewResourceItem creates UI objects for a resource.
+func NewResourceItem(resource types.Resource) (*ResourceItem, error) {
+	data, err := yaml.Marshal(resource)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	kind := resource.GetKind()
+	name := resource.GetName()
+
+	return &ResourceItem{
+		ID:      fmt.Sprintf("%v:%v", kind, name),
+		Kind:    kind,
+		Name:    name,
+		Content: string(data[:]),
+	}, nil
+
+}
+
+// NewRoles creates resource item for each role.
+func NewRoles(roles []types.Role) ([]ResourceItem, error) {
+	items := make([]ResourceItem, 0, len(roles))
+	for _, role := range roles {
+		item, err := NewResourceItem(role)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		items = append(items, *item)
+	}
+
+	return items, nil
+}
+
+// NewGithubConnectors creates resource item for each github connector.
+func NewGithubConnectors(connectors []types.GithubConnector) ([]ResourceItem, error) {
+	items := make([]ResourceItem, 0, len(connectors))
+	for _, connector := range connectors {
+		item, err := NewResourceItem(connector)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		items = append(items, *item)
+	}
+
+	return items, nil
+}
+
+// NewTrustedClusters creates resource item for each cluster.
+func NewTrustedClusters(clusters []types.TrustedCluster) ([]ResourceItem, error) {
+	items := make([]ResourceItem, 0, len(clusters))
+	for _, cluster := range clusters {
+		item, err := NewResourceItem(cluster)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		items = append(items, *item)
+	}
+
+	return items, nil
+}

--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -18,6 +18,7 @@ package ui
 
 import (
 	"github.com/gravitational/teleport/lib/services"
+
 	"github.com/gravitational/trace"
 )
 

--- a/lib/web/ui/user.go
+++ b/lib/web/ui/user.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ui
+
+import (
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+)
+
+// User contains data needed by the web UI to display locally saved users.
+type User struct {
+	// Name is the user name.
+	Name string `json:"name"`
+	// Roles is the list of roles user belongs to.
+	Roles []string `json:"roles"`
+	// AuthType is the type of auth service
+	// that the user was authenticated through.
+	AuthType string `json:"authType"`
+}
+
+// NewUser creates UI user object
+func NewUser(teleUser services.User) (*User, error) {
+	if teleUser == nil {
+		return nil, trace.BadParameter("missing teleUser")
+	}
+
+	authType := "local"
+	if teleUser.GetCreatedBy().Connector != nil {
+		authType = teleUser.GetCreatedBy().Connector.Type
+	}
+
+	return &User{
+		Name:     teleUser.GetName(),
+		Roles:    teleUser.GetRoles(),
+		AuthType: authType,
+	}, nil
+}

--- a/lib/web/users.go
+++ b/lib/web/users.go
@@ -25,7 +25,9 @@ import (
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
+
 	"github.com/gravitational/trace"
+
 	"github.com/julienschmidt/httprouter"
 )
 

--- a/lib/web/users.go
+++ b/lib/web/users.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package web
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/web/ui"
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+)
+
+func (h *Handler) updateUserHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return updateUser(r, clt, ctx.GetUser())
+}
+
+func (h *Handler) createUserHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return createUser(r, clt, ctx.GetUser())
+}
+
+func (h *Handler) getUsersHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return getUsers(clt)
+}
+
+func (h *Handler) deleteUserHandle(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
+	clt, err := ctx.GetClient()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := deleteUser(r, params, clt, ctx.GetUser()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return OK(), nil
+}
+
+func createUser(r *http.Request, m userAPIGetter, createdBy string) (*ui.User, error) {
+	var req *saveUserRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := req.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	user, err := services.NewUser(req.Name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	user.SetRoles(req.Roles)
+	user.SetTraits(map[string][]string{
+		teleport.TraitLogins: req.Logins,
+	})
+
+	user.SetCreatedBy(services.CreatedBy{
+		User: services.UserRef{Name: createdBy},
+		Time: time.Now().UTC(),
+	})
+
+	if err := m.CreateUser(r.Context(), user); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.NewUser(user)
+}
+
+func updateUser(r *http.Request, m userAPIGetter, createdBy string) (*ui.User, error) {
+	var req *saveUserRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := req.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	user, err := m.GetUser(req.Name, false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user.SetRoles(req.Roles)
+
+	if err := m.UpdateUser(r.Context(), user); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.NewUser(user)
+}
+
+func getUsers(m userAPIGetter) ([]ui.User, error) {
+	users, err := m.GetUsers(false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var uiUsers []ui.User
+	for _, u := range users {
+		uiuser, err := ui.NewUser(u)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		uiUsers = append(uiUsers, *uiuser)
+	}
+
+	return uiUsers, nil
+}
+
+func deleteUser(r *http.Request, params httprouter.Params, m userAPIGetter, user string) error {
+	username := params.ByName("username")
+	if username == "" {
+		return trace.BadParameter("missing user name")
+	}
+
+	if username == user {
+		return trace.BadParameter("cannot delete own user account")
+	}
+
+	if err := m.DeleteUser(r.Context(), username); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+type userAPIGetter interface {
+	// GetUser returns user by name
+	GetUser(name string, withSecrets bool) (services.User, error)
+	// CreateUser creates a new user
+	CreateUser(ctx context.Context, user services.User) error
+	// UpdateUser updates a user
+	UpdateUser(ctx context.Context, user services.User) error
+	// GetUsers returns a list of users
+	GetUsers(withSecrets bool) ([]services.User, error)
+	// DeleteUser deletes a user by name.
+	DeleteUser(ctx context.Context, user string) error
+}
+
+type saveUserRequest struct {
+	Name   string   `json:"name"`
+	Roles  []string `json:"roles"`
+	Logins []string `json:"logins,omitempty"`
+}
+
+func (r *saveUserRequest) checkAndSetDefaults() error {
+	if r.Name == "" {
+		return trace.BadParameter("missing user name")
+	}
+	if len(r.Roles) == 0 {
+		return trace.BadParameter("missing roles")
+	}
+	return nil
+}

--- a/lib/web/users_test.go
+++ b/lib/web/users_test.go
@@ -24,7 +24,9 @@ import (
 	"testing"
 
 	"github.com/gravitational/teleport/lib/services"
+
 	"github.com/gravitational/trace"
+
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/require"
 )

--- a/lib/web/users_test.go
+++ b/lib/web/users_test.go
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2021 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestParameters(t *testing.T) {
+	r := saveUserRequest{
+		Name:   "",
+		Roles:  nil,
+		Logins: nil,
+	}
+	require.True(t, trace.IsBadParameter(r.checkAndSetDefaults()))
+
+	r = saveUserRequest{
+		Name:   "",
+		Roles:  []string{"testrole"},
+		Logins: nil,
+	}
+	require.True(t, trace.IsBadParameter(r.checkAndSetDefaults()))
+
+	r = saveUserRequest{
+		Name:   "username",
+		Roles:  nil,
+		Logins: nil,
+	}
+	require.True(t, trace.IsBadParameter(r.checkAndSetDefaults()))
+
+	r = saveUserRequest{
+		Name:   "username",
+		Roles:  []string{"testrole"},
+		Logins: nil,
+	}
+	require.Nil(t, r.checkAndSetDefaults())
+}
+
+func TestCRUDs(t *testing.T) {
+	u := saveUserRequest{
+		Name:   "testname",
+		Roles:  []string{"testrole"},
+		Logins: nil,
+	}
+
+	m := &mockedUserAPIGetter{}
+	m.mockCreateUser = func(ctx context.Context, user services.User) error {
+		return nil
+	}
+
+	m.mockGetUser = func(name string, withSecrets bool) (services.User, error) {
+		return services.NewUser(name)
+	}
+
+	m.mockUpdateUser = func(ctx context.Context, user services.User) error {
+		return nil
+	}
+
+	m.mockGetUsers = func(withSecrets bool) ([]services.User, error) {
+		u, err := services.NewUser("testname")
+		return []services.User{u}, err
+	}
+
+	m.mockDeleteUser = func(ctx context.Context, user string) error {
+		return nil
+	}
+
+	// test create
+	user, err := createUser(newRequest(t, u), m, "")
+	require.Nil(t, err)
+	require.Equal(t, "testname", user.Name)
+	require.Equal(t, "local", user.AuthType)
+	require.Contains(t, user.Roles, "testrole")
+
+	// test update
+	u.Roles = []string{"newrole"}
+	user, err = updateUser(newRequest(t, u), m, "")
+	require.Nil(t, err)
+	require.Contains(t, user.Roles, "newrole")
+
+	// test list
+	users, err := getUsers(m)
+	require.Nil(t, err)
+	require.Len(t, users, 1)
+	require.Equal(t, "testname", users[0].Name)
+
+	// test delete
+	param := httprouter.Params{httprouter.Param{Key: "username", Value: "testname"}}
+	req, err := http.NewRequest("", "/:username", nil)
+	require.Nil(t, err)
+
+	err = deleteUser(req, param, m, "self")
+	require.Nil(t, err)
+}
+
+func TestCRUDErrors(t *testing.T) {
+	m := &mockedUserAPIGetter{}
+	m.mockCreateUser = func(ctx context.Context, user services.User) error {
+		return trace.AlreadyExists("")
+	}
+
+	m.mockGetUser = func(name string, withSecrets bool) (services.User, error) {
+		return nil, trace.NotFound("")
+	}
+
+	m.mockUpdateUser = func(ctx context.Context, user services.User) error {
+		return trace.NotFound("")
+	}
+
+	m.mockGetUsers = func(withSecrets bool) ([]services.User, error) {
+		return nil, trace.AccessDenied("")
+	}
+
+	m.mockDeleteUser = func(ctx context.Context, user string) error {
+		return trace.NotFound("")
+	}
+
+	u := saveUserRequest{
+		Name:   "testname",
+		Roles:  []string{"testrole"},
+		Logins: nil,
+	}
+
+	// update errors
+	user, err := updateUser(newRequest(t, u), m, "")
+	require.True(t, trace.IsNotFound(err))
+	require.Nil(t, user)
+
+	// create errors
+	user, err = createUser(newRequest(t, u), m, "")
+	require.True(t, trace.IsAlreadyExists(err))
+	require.Nil(t, user)
+
+	users, err := getUsers(m)
+	require.True(t, trace.IsAccessDenied(err))
+	require.Nil(t, users)
+
+	// delete errors
+	param := httprouter.Params{httprouter.Param{Key: "username", Value: "testname"}}
+	req, err := http.NewRequest("", "/:username", nil)
+	require.Nil(t, err)
+
+	err = deleteUser(req, param, m, "self")
+	require.True(t, trace.IsNotFound(err))
+
+	// deleting self error
+	param = httprouter.Params{httprouter.Param{Key: "username", Value: "self"}}
+	req, err = http.NewRequest("", "/:username", nil)
+	require.Nil(t, err)
+
+	err = deleteUser(req, param, m, "self")
+	require.True(t, trace.IsBadParameter(err))
+}
+
+// newRequest creates http request with given body
+func newRequest(t *testing.T, body interface{}) *http.Request {
+	reqBody, err := json.Marshal(body)
+	require.Nil(t, err)
+
+	req, err := http.NewRequest("", "", bytes.NewBuffer(reqBody))
+	require.Nil(t, err)
+
+	return req
+}
+
+type mockedUserAPIGetter struct {
+	mockGetUser    func(name string, withSecrets bool) (services.User, error)
+	mockCreateUser func(ctx context.Context, user services.User) error
+	mockUpdateUser func(ctx context.Context, user services.User) error
+	mockGetUsers   func(withSecrets bool) ([]services.User, error)
+	mockDeleteUser func(ctx context.Context, user string) error
+}
+
+func (m *mockedUserAPIGetter) GetUser(name string, withSecrets bool) (services.User, error) {
+	if m.mockGetUser != nil {
+		return m.mockGetUser(name, withSecrets)
+	}
+	return nil, trace.NotImplemented("mockGetUser not implemented")
+}
+
+func (m *mockedUserAPIGetter) CreateUser(ctx context.Context, user services.User) error {
+	if m.mockCreateUser != nil {
+		return m.mockCreateUser(ctx, user)
+	}
+	return trace.NotImplemented("mockCreateUser not implemented")
+}
+
+func (m *mockedUserAPIGetter) UpdateUser(ctx context.Context, user services.User) error {
+	if m.mockUpdateUser != nil {
+		return m.mockUpdateUser(ctx, user)
+	}
+	return trace.NotImplemented("mockUpdateUser not implemented")
+}
+
+func (m *mockedUserAPIGetter) GetUsers(withSecrets bool) ([]services.User, error) {
+	if m.mockGetUsers != nil {
+		return m.mockGetUsers(withSecrets)
+	}
+	return nil, trace.NotImplemented("mockGetUsers not implemented")
+}
+
+func (m *mockedUserAPIGetter) DeleteUser(ctx context.Context, name string) error {
+	if m.mockDeleteUser != nil {
+		return m.mockDeleteUser(ctx, name)
+	}
+
+	return trace.NotImplemented("mockDeleteUser not implemented")
+}


### PR DESCRIPTION
part of https://github.com/gravitational/webapps/issues/220

#### Description
- User related files were copied and pasted from enterprise (no additional change was made)
- Made seperate endpoints and handlers for CRUD actions for roles, trusted clusters and github connectors
- Exported ok() function so enterprise can also use it
- Created unit tests
- Silence rbac auth connector access denial logs on first check failure (creates confusing log messages)