### PR TITLE
Fix typo in ssh-pam.md

### DIFF
--- a/docs/5.0/pages/features/ssh-pam.md
+++ b/docs/5.0/pages/features/ssh-pam.md
@@ -181,7 +181,7 @@ session [success=ok ignore=ignore module_unknown=ignore default=bad]        pam_
 @include common-password
 ```
 
-The default `sshd` will call two `pam_motd` files, one dynamic. That prints the machine
+The default `sshd` will call two `pam_motd` files, one dynamic MOTD that prints the machine
 info, and a static MOTD that can be set by an admin.
 
 ```


### PR DESCRIPTION
Found a typo in the MOTD description while going through the documentation.  Removing the unnecessary period and adding in MOTD for clarity.