### PR TITLE
Drone tweaks to pull base buildboxes in more places to speed up ARM builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,8 +66,8 @@ steps:
           export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/${DRONE_REPO_NAME}/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
           echo "---> Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
           # if the source repo for the PR matches DRONE_REPO, then this is not a PR raised from a fork
-          if [ "$${PR_REPO}" = "${DRONE_REPO}" ]; then
-            mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+          if [ "$${PR_REPO}" = "${DRONE_REPO}" ] || [ "${DRONE_REPO}" = "gravitational/teleport-private" ]; then
+            mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
             ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
             git submodule update --init e
             # do a recursive submodule checkout to get both webassets and webassets/e
@@ -4372,6 +4372,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 6b6af26602fd7de68f473e27ecf6bb98e37b2ef2d5df3484cd5e1d2f88c6655d
+hmac: 316386d14b171635c1189a65e7d840ac85fccc37a91c228d6b4f569043f7ab79
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -471,13 +471,12 @@ steps:
     settings:
       webhook:
         from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-      channel: dev-teleport
       template: |
         *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-        `linux-amd64` artifact build failed.
+        `${DRONE_STAGE_NAME}` artifact build failed.
         *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
         Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}>
         <{{ build.link }}|Visit Drone build page ↗>
     when:
@@ -569,13 +568,12 @@ steps:
     settings:
       webhook:
         from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-      channel: dev-teleport
       template: |
         *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-        `linux-386` artifact build failed.
+        `${DRONE_STAGE_NAME}` artifact build failed.
         *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
         Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}>
         <{{ build.link }}|Visit Drone build page ↗>
     when:
@@ -671,13 +669,12 @@ steps:
     settings:
       webhook:
         from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-      channel: dev-teleport
       template: |
         *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-        `linux-amd64-fips` artifact build failed.
+        `${DRONE_STAGE_NAME}` artifact build failed.
         *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
         Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}>
         <{{ build.link }}|Visit Drone build page ↗>
     when:
@@ -769,13 +766,12 @@ steps:
     settings:
       webhook:
         from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-      channel: dev-teleport
       template: |
         *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-        `windows-amd64` artifact build failed.
+        `${DRONE_STAGE_NAME}` artifact build failed.
         *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
         Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}>
         <{{ build.link }}|Visit Drone build page ↗>
     when:
@@ -886,10 +882,9 @@ steps:
         export DRONE_BUILD_LINK="${DRONE_SYSTEM_PROTO}://${DRONE_SYSTEM_HOSTNAME}/${DRONE_REPO_OWNER}/${DRONE_REPO_NAME}/${DRONE_BUILD_NUMBER}"
         export GOOS=$(go env GOOS)
         export GOARCH=$(go env GOARCH)
-        curl -sL -X POST -H 'Content-type: application/json' --data "{\"text\":\"Warning: \`$GOOS-$GOARCH\` artifact build failed - please investigate immediately!\nBranch: \`${DRONE_BRANCH}\`\nCommit: \`${DRONE_COMMIT_SHA}\`\nLink: $DRONE_BUILD_LINK\"}" $SLACK_WEBHOOK
+        curl -sL -X POST -H 'Content-type: application/json' --data "{\"text\":\"Warning: \`$GOOS-$GOARCH\` artifact build failed for [\`${DRONE_REPO_NAME}\`] - please investigate immediately!\nBranch: \`${DRONE_BRANCH}\`\nCommit: \`${DRONE_COMMIT_SHA}\`\nLink: $DRONE_BUILD_LINK\"}" $SLACK_WEBHOOK
     when:
       status: [failure]
-
 ---
 kind: pipeline
 type: kubernetes
@@ -966,13 +961,12 @@ steps:
     settings:
       webhook:
         from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-      channel: dev-teleport
       template: |
         *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-        `linux-arm` artifact build failed.
+        `${DRONE_STAGE_NAME}` artifact build failed.
         *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
         Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}>
         <{{ build.link }}|Visit Drone build page ↗>
     when:
@@ -1068,13 +1062,12 @@ steps:
     settings:
       webhook:
         from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-      channel: dev-teleport
       template: |
         *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-        `linux-arm-fips` artifact build failed.
+        `${DRONE_STAGE_NAME}` artifact build failed.
         *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
         Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}>
         <{{ build.link }}|Visit Drone build page ↗>
     when:
@@ -1167,13 +1160,12 @@ steps:
     settings:
       webhook:
         from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-      channel: dev-teleport
       template: |
         *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-        `linux-arm64` artifact build failed.
+        `${DRONE_STAGE_NAME}` artifact build failed.
         *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
         Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}>
         <{{ build.link }}|Visit Drone build page ↗>
     when:
@@ -1269,13 +1261,12 @@ steps:
     settings:
       webhook:
         from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-      channel: dev-teleport
       template: |
         *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-        `linux-arm64-fips` artifact build failed.
+        `${DRONE_STAGE_NAME}` artifact build failed.
         *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
         Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
         Author: <https://github.com/{{ build.author }}|{{ build.author }}>
         <{{ build.link }}|Visit Drone build page ↗>
     when:
@@ -1580,7 +1571,6 @@ steps:
     settings:
       webhook:
         from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-      channel: dev-teleport
       template: |
         *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
         Details: The `teleport-helm-cron` job in Drone failed to publish Helm charts to S3. This is unusual and should be investigated.
@@ -4382,6 +4372,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 7b030b24bc7ef6305ac7f8e84fda5fb8d37d9f765dee6f8eb5e0672e654df72d
+hmac: 6b6af26602fd7de68f473e27ecf6bb98e37b2ef2d5df3484cd5e1d2f88c6655d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -384,7 +384,7 @@ trigger:
       - branch/*
   repo:
     include:
-      - gravitational/*
+      - gravitational/teleport
 
 clone:
   disable: true
@@ -1302,7 +1302,7 @@ trigger:
     - teleport-docker-cron
   repo:
     include:
-      - gravitational/*
+      - gravitational/teleport
 
 workspace:
   path: /go
@@ -1515,7 +1515,7 @@ trigger:
     - teleport-helm-cron
   repo:
     include:
-      - gravitational/*
+      - gravitational/teleport
 
 workspace:
   path: /go
@@ -3942,7 +3942,7 @@ trigger:
     - push
   repo:
     include:
-      - gravitational/*
+      - gravitational/teleport
 
 workspace:
   path: /go/src/github.com/gravitational/teleport
@@ -4382,6 +4382,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 697517fea1b0909854f4f1cb39790a37a099b66c5dc2d38e7258de0b4c497cc2
+hmac: 7b030b24bc7ef6305ac7f8e84fda5fb8d37d9f765dee6f8eb5e0672e654df72d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1057,7 +1057,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+      - docker pull quay.io/gravitational/teleport-buildbox-fips:$RUNTIME || true
       - docker pull quay.io/gravitational/teleport-buildbox-arm-fips:$RUNTIME || true
       - cd /go/src/github.com/gravitational/teleport
       - export VERSION=$(cat /go/.version.txt)
@@ -1258,7 +1258,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
+      - docker pull quay.io/gravitational/teleport-buildbox-fips:$RUNTIME || true
       - docker pull quay.io/gravitational/teleport-buildbox-arm-fips:$RUNTIME || true
       - cd /go/src/github.com/gravitational/teleport
       - export VERSION=$(cat /go/.version.txt)
@@ -3264,6 +3264,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
+      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
       - docker pull quay.io/gravitational/teleport-buildbox-arm:$RUNTIME || true
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets release-arm
@@ -3364,6 +3365,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
+      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
       - docker pull quay.io/gravitational/teleport-buildbox-arm:$RUNTIME || true
       - cd /go/src/github.com/gravitational/teleport
       - make -C build.assets release-arm64
@@ -3465,6 +3467,7 @@ steps:
     commands:
       - apk add --no-cache make
       - chown -R $UID:$GID /go
+      - docker pull quay.io/gravitational/teleport-buildbox-fips:$RUNTIME || true
       - docker pull quay.io/gravitational/teleport-buildbox-arm-fips:$RUNTIME || true
       - cd /go/src/github.com/gravitational/teleport
       - export VERSION=$(cat /go/.version.txt)
@@ -4379,6 +4382,6 @@ volumes:
 
 ---
 kind: signature
-hmac: ae1c9456686b7053f9f0a24b30f42bceda00fff2905e2c081779966db4b40113
+hmac: 697517fea1b0909854f4f1cb39790a37a099b66c5dc2d38e7258de0b4c497cc2
 
 ...


### PR DESCRIPTION
Argh, spotted a few other places that buildboxes should be pulled to make proper use of cache. This also now correctly pulls the `teleport-buildbox-fips` image for ARM FIPS builds rather than `teleport-buildbox`.

Also integrates a few other changes:
- makes the repo name more specific for certain steps where duplication is undesirable
- adds the repo name into Slack notifications for disambiguation purposes
- special cases the Enterprise code checkout