### PR TITLE
Update go-mysql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -111,5 +111,5 @@ replace (
 	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 	github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1
-	github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20210212004040-43bb2767cdd8
+	github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77
 )

--- a/go.mod
+++ b/go.mod
@@ -111,5 +111,5 @@ replace (
 	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 	github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1
-	github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20201221203007-8ef34676bbc0
+	github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20210212004040-43bb2767cdd8
 )

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/gravitational/go-mysql v1.1.1-0.20201221203007-8ef34676bbc0 h1:oN3ip7
 github.com/gravitational/go-mysql v1.1.1-0.20201221203007-8ef34676bbc0/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
 github.com/gravitational/go-mysql v1.1.1-0.20210212004040-43bb2767cdd8 h1:MI86GrervmRuE+8QcOPFX7ArqVk3lHHy0Hv5sR/Lmwo=
 github.com/gravitational/go-mysql v1.1.1-0.20210212004040-43bb2767cdd8/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
+github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77 h1:ivambM2XeST8qfxeSm+0Y8CP/DlNbS3o/9tSF2KtGFk=
+github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
 github.com/gravitational/go-oidc v0.0.3 h1:VKhztRfuXq5KVcAPAEagF2y9rjoNgEXvZ/5PsRX9qt8=
 github.com/gravitational/go-oidc v0.0.3/go.mod h1:SevmOUNdOB0aD9BAIgjptZ6oHkKxMZZgA70nwPfgU/w=
 github.com/gravitational/gobpf v0.0.1 h1:1NufkXUOOt/farCC4juGZ8FFU1qmA+2Zb4lPaVfUFoE=

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,8 @@ github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70 h1:To76nCJtM3DI
 github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70/go.mod h1:88hFR45MpUd23d2vNWE/dYtesU50jKsbz0I9kH7UaBY=
 github.com/gravitational/go-mysql v1.1.1-0.20201221203007-8ef34676bbc0 h1:oN3ip7mSVgX+14rc13yJh+rUpdzmO/DHJH+GzX9+dnY=
 github.com/gravitational/go-mysql v1.1.1-0.20201221203007-8ef34676bbc0/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
+github.com/gravitational/go-mysql v1.1.1-0.20210212004040-43bb2767cdd8 h1:MI86GrervmRuE+8QcOPFX7ArqVk3lHHy0Hv5sR/Lmwo=
+github.com/gravitational/go-mysql v1.1.1-0.20210212004040-43bb2767cdd8/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
 github.com/gravitational/go-oidc v0.0.3 h1:VKhztRfuXq5KVcAPAEagF2y9rjoNgEXvZ/5PsRX9qt8=
 github.com/gravitational/go-oidc v0.0.3/go.mod h1:SevmOUNdOB0aD9BAIgjptZ6oHkKxMZZgA70nwPfgU/w=
 github.com/gravitational/gobpf v0.0.1 h1:1NufkXUOOt/farCC4juGZ8FFU1qmA+2Zb4lPaVfUFoE=

--- a/vendor/github.com/siddontang/go-mysql/server/conn.go
+++ b/vendor/github.com/siddontang/go-mysql/server/conn.go
@@ -44,6 +44,8 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 	p.AddUser(user, password)
 	salt, _ := RandomBuf(20)
 
+	defaultServer := NewDefaultServer()
+
 	var packetConn *packet.Conn
 	if defaultServer.tlsConfig != nil {
 		packetConn = packet.NewTLSConn(conn)

--- a/vendor/github.com/siddontang/go-mysql/server/server_conf.go
+++ b/vendor/github.com/siddontang/go-mysql/server/server_conf.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/siddontang/go-mysql/mysql"
 )
 
-var defaultServer = NewDefaultServer()
-
 // Defines a basic MySQL server with configs.
 //
 // We do not aim at implementing the whole MySQL connection suite to have the best compatibilities for the clients.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -422,7 +422,7 @@ github.com/siddontang/go/sync2
 # github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07
 github.com/siddontang/go-log/log
 github.com/siddontang/go-log/loggers
-# github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20201221203007-8ef34676bbc0
+# github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20210212004040-43bb2767cdd8
 ## explicit
 github.com/siddontang/go-mysql/client
 github.com/siddontang/go-mysql/mysql

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -422,7 +422,7 @@ github.com/siddontang/go/sync2
 # github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07
 github.com/siddontang/go-log/log
 github.com/siddontang/go-log/loggers
-# github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20210212004040-43bb2767cdd8
+# github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77
 ## explicit
 github.com/siddontang/go-mysql/client
 github.com/siddontang/go-mysql/mysql


### PR DESCRIPTION
Update go-mysql vendored library to take in this fix: https://github.com/gravitational/go-mysql/pull/1.

It fixes the `tsh ssh` performance issue:

```
➜  ~ hyperfine --min-runs 10 'tsh ssh root@mbp hostname'
Benchmark #1: tsh ssh root@mbp hostname
  Time (mean ± σ):      92.0 ms ±   3.4 ms    [User: 25.2 ms, System: 16.6 ms]
  Range (min … max):    87.5 ms … 103.0 ms    32 runs
```

I'll revendor again when that PR gets merged.