### PR TITLE
Check MFA device name uniqueness

### DIFF
--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -379,12 +379,10 @@ func (s *Server) changeUserSecondFactor(req ChangePasswordWithTokenRequest, Rese
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := s.UpsertMFADevice(ctx, username, dev); err != nil {
+		if err := s.checkTOTP(ctx, username, req.SecondFactorToken, dev); err != nil {
 			return trace.Wrap(err)
 		}
-
-		err = s.checkOTP(username, req.SecondFactorToken)
-		if err != nil {
+		if err := s.UpsertMFADevice(ctx, username, dev); err != nil {
 			return trace.Wrap(err)
 		}
 

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -799,6 +799,19 @@ func (s *ServicesTestSuite) U2FCRUD(c *check.C) {
 	registrationOut, err := u2f.DeviceToRegistration(devs[0].GetU2F())
 	c.Assert(err, check.IsNil)
 	c.Assert(&registration, check.DeepEquals, registrationOut)
+
+	// Attempt to upsert the same device name with a different ID.
+	dev.Id = uuid.New()
+	err = s.WebS.UpsertMFADevice(ctx, user1, dev)
+	c.Assert(trace.IsAlreadyExists(err), check.Equals, true)
+
+	// Attempt to upsert a new device with different name and ID.
+	dev.Metadata.Name = "u2f-2"
+	err = s.WebS.UpsertMFADevice(ctx, user1, dev)
+	c.Assert(err, check.IsNil)
+	devs, err = s.WebS.GetMFADevices(ctx, user1)
+	c.Assert(err, check.IsNil)
+	c.Assert(devs, check.HasLen, 2)
 }
 
 func (s *ServicesTestSuite) SAMLCRUD(c *check.C) {


### PR DESCRIPTION
Device uniqueness is checked on `GetUsers`, so if a duplicate name
appears, any operations touching users will fail.
Check device name uniqueness on `UpsertMFADevice` to avoid this.

Also, swap the OTP device creation order on user signup/reset: only
upsert the device after validating the token.