### PR TITLE
Relax app session cookie same-site policy

### DIFF
--- a/lib/web/app/fragment.go
+++ b/lib/web/app/fragment.go
@@ -68,7 +68,13 @@ func (h *Handler) handleFragment(w http.ResponseWriter, r *http.Request, p httpr
 			Value:    req.CookieValue,
 			HttpOnly: true,
 			Secure:   true,
-			SameSite: http.SameSiteLaxMode,
+			// Set Same-Site policy for the session cookie to None in order to
+			// support redirects that identity providers do during SSO auth.
+			// Otherwise the session cookie won't be sent and the user will
+			// get redirected to the application launcher.
+			//
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+			SameSite: http.SameSiteNoneMode,
 		})
 	default:
 		return trace.BadParameter("unsupported method %q", r.Method)


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/5486.

`Same-Site: Lax` policy causes the session cookie not to be sent on cross-origin requests which breaks SSO provider redirects (for example, if the proxied application uses SSO authentication).

For more information:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite