### PR TITLE
changing 'apt-get' to 'apt-get update'

### DIFF
--- a/docs/5.0/pages/installation.md
+++ b/docs/5.0/pages/installation.md
@@ -22,7 +22,7 @@ up-to-date information.
     # Add repo to APT
     $ add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
     # Update APT Cache
-    $ apt-get
+    $ apt-get update
     # Install Teleport
     $ apt install teleport
     ```

--- a/docs/5.0/pages/quickstart.md
+++ b/docs/5.0/pages/quickstart.md
@@ -34,7 +34,7 @@ Take a look at the [Teleport Installation](installation.md) page to pick the mos
 
     ```bash
     add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    apt-get
+    apt-get update
     apt install teleport
     ```
 


### PR DESCRIPTION
Tiny apparent documentation bug, I'm pretty sure `apt-get update` was the intention.