### PR TITLE
Normalizing frontmatter

### DIFF
--- a/docs/3.1/pages/admin-guide.md
+++ b/docs/3.1/pages/admin-guide.md
@@ -1,4 +1,6 @@
-# Teleport Admin Manual
+---
+title: Teleport Admin Manual
+---
 
 This manual covers the installation and configuration of Teleport and the ongoing
 management of a Teleport cluster. It assumes that the reader has good understanding

--- a/docs/3.1/pages/architecture.md
+++ b/docs/3.1/pages/architecture.md
@@ -1,4 +1,6 @@
-# Teleport Architecture
+---
+title: Teleport Architecture
+---
 
 This document covers the underlying design principles of Teleport and a
 detailed description of Teleport architecture.

--- a/docs/3.1/pages/enterprise.md
+++ b/docs/3.1/pages/enterprise.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise
+---
+title: Teleport Enterprise
+---
 
 This section will give an overview of Teleport Enterprise, the commercial product built around
 the open source Teleport Community core. For those that want to jump right in, you can play with

--- a/docs/3.1/pages/faq.md
+++ b/docs/3.1/pages/faq.md
@@ -1,4 +1,6 @@
-# FAQ
+---
+title: FAQ
+---
 
 ### Can I use Teleport in production today?
 

--- a/docs/3.1/pages/index.md
+++ b/docs/3.1/pages/index.md
@@ -1,4 +1,6 @@
-# Introduction
+---
+title: Introduction
+---
 
 ## What is Teleport?
 

--- a/docs/3.1/pages/kubernetes-ssh.md
+++ b/docs/3.1/pages/kubernetes-ssh.md
@@ -1,4 +1,6 @@
-# Kubernetes and SSH Integration Guide
+---
+title: Kubernetes and SSH Integration Guide
+---
 
 Teleport v.3.0+ has the
 ability to act as a compliance gateway for managing privileged access to Kubernetes clusters. This enables the following capabilities:

--- a/docs/3.1/pages/oidc.md
+++ b/docs/3.1/pages/oidc.md
@@ -1,4 +1,6 @@
-# OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
+title: OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
 
 This guide will cover how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
 (also known as OIDC) to issue SSH credentials to a specific groups of users.

--- a/docs/3.1/pages/quickstart-enterprise.md
+++ b/docs/3.1/pages/quickstart-enterprise.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise Quick Start
+---
+title: Teleport Enterprise Quick Start
+---
 
 Welcome to the Quick Start Guide for Teleport Enterprise.
 

--- a/docs/3.1/pages/quickstart.md
+++ b/docs/3.1/pages/quickstart.md
@@ -1,4 +1,6 @@
-# Quick Start Guide
+---
+title: Quick Start Guide
+---
 
 Welcome to the Teleport Quick Start Guide!
 

--- a/docs/3.1/pages/ssh-adfs.md
+++ b/docs/3.1/pages/ssh-adfs.md
@@ -1,4 +1,6 @@
-# SSH Authentication with ADFS
+---
+title: SSH Authentication with ADFS
+---
 
 This guide will cover how to configure Active Directory Federation Services
 [ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services) to issue

--- a/docs/3.1/pages/ssh-okta.md
+++ b/docs/3.1/pages/ssh-okta.md
@@ -1,4 +1,6 @@
-# SSH Authentication with Okta
+---
+title: SSH Authentication with Okta
+---
 
 This guide will cover how to configure [Okta](https://www.okta.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/3.1/pages/ssh-one-login.md
+++ b/docs/3.1/pages/ssh-one-login.md
@@ -1,4 +1,6 @@
-# SSH Authentication with One Login
+---
+title: SSH Authentication with One Login
+---
 
 This guide will cover how to configure [One Login](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/3.1/pages/ssh-rbac.md
+++ b/docs/3.1/pages/ssh-rbac.md
@@ -1,4 +1,6 @@
-# Role Based Access Control for SSH
+---
+title: Role Based Access Control for SSH
+---
 
 ## Introduction
 

--- a/docs/3.1/pages/ssh-sso.md
+++ b/docs/3.1/pages/ssh-sso.md
@@ -1,4 +1,6 @@
-# Single Sign-On (SSO) for SSH
+---
+title: Single Sign-On (SSO) for SSH
+---
 
 ## Introduction
 

--- a/docs/3.1/pages/trustedclusters.md
+++ b/docs/3.1/pages/trustedclusters.md
@@ -1,4 +1,6 @@
-# Trusted Clusters
+---
+title: Trusted Clusters
+---
 
 If you haven't already looked at the introduction to [Trusted Clusters](admin-guide.md#trusted-clusters)
 in the Admin Guide we recommend you review that for an overview before continuing with this guide.

--- a/docs/3.1/pages/user-manual.md
+++ b/docs/3.1/pages/user-manual.md
@@ -1,4 +1,6 @@
-# Teleport User Manual
+---
+title: Teleport User Manual
+---
 
 This User Manual covers usage of the Teleport client tool, `tsh`. In this
 document you will learn how to:

--- a/docs/3.2/pages/admin-guide.md
+++ b/docs/3.2/pages/admin-guide.md
@@ -1,4 +1,6 @@
-# Teleport Admin Manual
+---
+title: Teleport Admin Manual
+---
 
 This manual covers the installation and configuration of Teleport and the ongoing
 management of a Teleport cluster. It assumes that the reader has good understanding

--- a/docs/3.2/pages/architecture.md
+++ b/docs/3.2/pages/architecture.md
@@ -1,4 +1,6 @@
-# Teleport Architecture
+---
+title: Teleport Architecture
+---
 
 This document covers the underlying design principles of Teleport and a
 detailed description of Teleport architecture.

--- a/docs/3.2/pages/enterprise.md
+++ b/docs/3.2/pages/enterprise.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise
+---
+title: Teleport Enterprise
+---
 
 This section will give an overview of Teleport Enterprise, the commercial product built around
 the open source Teleport Community core. For those that want to jump right in, you can play with

--- a/docs/3.2/pages/faq.md
+++ b/docs/3.2/pages/faq.md
@@ -1,4 +1,6 @@
-# FAQ
+---
+title: FAQ
+---
 
 ### Can I use Teleport in production today?
 

--- a/docs/3.2/pages/index.md
+++ b/docs/3.2/pages/index.md
@@ -1,4 +1,6 @@
-# Introduction
+---
+title: Introduction
+---
 
 ## What is Teleport?
 

--- a/docs/3.2/pages/kubernetes-ssh.md
+++ b/docs/3.2/pages/kubernetes-ssh.md
@@ -1,4 +1,6 @@
-# Kubernetes and SSH Integration Guide
+---
+title: Kubernetes and SSH Integration Guide
+---
 
 Teleport v.3.0+ has the ability to act as a compliance gateway for managing privileged access to Kubernetes clusters. This enables the following capabilities:
 

--- a/docs/3.2/pages/oidc.md
+++ b/docs/3.2/pages/oidc.md
@@ -1,4 +1,6 @@
-# OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
+title: OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
 
 This guide will cover how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
 (also known as OIDC) to issue SSH credentials to a specific groups of users.

--- a/docs/3.2/pages/quickstart-enterprise.md
+++ b/docs/3.2/pages/quickstart-enterprise.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise Quick Start
+---
+title: Teleport Enterprise Quick Start
+---
 
 Welcome to the Quick Start Guide for Teleport Enterprise.
 

--- a/docs/3.2/pages/quickstart.md
+++ b/docs/3.2/pages/quickstart.md
@@ -1,4 +1,6 @@
-# Quick Start Guide
+---
+title: Quick Start Guide
+---
 
 Welcome to the Teleport Quick Start Guide!
 

--- a/docs/3.2/pages/ssh-adfs.md
+++ b/docs/3.2/pages/ssh-adfs.md
@@ -1,4 +1,6 @@
-# SSH Authentication with ADFS
+---
+title: SSH Authentication with ADFS
+---
 
 This guide will cover how to configure Active Directory Federation Services
 [ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services) to issue

--- a/docs/3.2/pages/ssh-okta.md
+++ b/docs/3.2/pages/ssh-okta.md
@@ -1,4 +1,6 @@
-# SSH Authentication with Okta
+---
+title: SSH Authentication with Okta
+---
 
 This guide will cover how to configure [Okta](https://www.okta.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/3.2/pages/ssh-one-login.md
+++ b/docs/3.2/pages/ssh-one-login.md
@@ -1,4 +1,6 @@
-# SSH Authentication with One Login
+---
+title: SSH Authentication with One Login
+---
 
 This guide will cover how to configure [One Login](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/3.2/pages/ssh-rbac.md
+++ b/docs/3.2/pages/ssh-rbac.md
@@ -1,4 +1,6 @@
-# Role Based Access Control for SSH
+---
+title: Role Based Access Control for SSH
+---
 
 ## Introduction
 

--- a/docs/3.2/pages/ssh-sso.md
+++ b/docs/3.2/pages/ssh-sso.md
@@ -1,4 +1,6 @@
-# Single Sign-On (SSO) for SSH
+---
+title: Single Sign-On (SSO) for SSH
+---
 
 ## Introduction
 

--- a/docs/3.2/pages/trustedclusters.md
+++ b/docs/3.2/pages/trustedclusters.md
@@ -1,4 +1,6 @@
-# Trusted Clusters
+---
+title: Trusted Clusters
+---
 
 If you haven't already looked at the introduction to [Trusted Clusters](admin-guide.md#trusted-clusters)
 in the Admin Guide we recommend you review that for an overview before continuing with this guide.

--- a/docs/3.2/pages/user-manual.md
+++ b/docs/3.2/pages/user-manual.md
@@ -1,4 +1,6 @@
-# Teleport User Manual
+---
+title: Teleport User Manual
+---
 
 This User Manual covers usage of the Teleport client tool, `tsh`. In this
 document you will learn how to:

--- a/docs/4.0/pages/admin-guide.md
+++ b/docs/4.0/pages/admin-guide.md
@@ -1,4 +1,6 @@
-# Teleport Admin Manual
+---
+title: Teleport Admin Manual
+---
 
 This manual covers the installation and configuration of Teleport and the ongoing
 management of a Teleport cluster. It assumes that the reader has good understanding

--- a/docs/4.0/pages/architecture.md
+++ b/docs/4.0/pages/architecture.md
@@ -1,4 +1,6 @@
-# Teleport Architecture
+---
+title: Teleport Architecture
+---
 
 This document covers the underlying design principles of Teleport and a
 detailed description of Teleport architecture.

--- a/docs/4.0/pages/aws-ent-guide.md
+++ b/docs/4.0/pages/aws-ent-guide.md
@@ -1,1 +1,3 @@
-# Setting up and running Teleport on AWS
+---
+title: Setting up and running Teleport on AWS
+---

--- a/docs/4.0/pages/aws-oss-guide.md
+++ b/docs/4.0/pages/aws-oss-guide.md
@@ -1,4 +1,6 @@
-# Running Teleport on AWS
+---
+title: Running Teleport on AWS
+---
 
 We've created this guide to give customers a high level overview of how to use Teleport
 on Amazon Web Services (AWS). This guide provides a high level introduction leading to
@@ -11,7 +13,8 @@ We have split this guide into:
 - [Setting up Teleport Enterprise on AWS](#running-teleport-enterprise-on-aws)
 - [Teleport AWS Tips & Tricks](#teleport-aws-tips-tricks)
 
-### Teleport on AWS FAQ
+## Teleport on AWS FAQ
+
 **Why would you want to use Teleport with AWS?**
 
 At some point you'll want to log into the system using SSH
@@ -43,7 +46,7 @@ for the below.
 
 This guide will cover how to setup, configure and run Teleport on [AWS](https://aws.amazon.com/).
 
-#### AWS Services required to run Teleport in HA
+### AWS Services required to run Teleport in HA
 
 - [EC2 / Autoscale](#ec2-autoscale)
 - [DynamoDB](#dynamodb)

--- a/docs/4.0/pages/enterprise.md
+++ b/docs/4.0/pages/enterprise.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise
+---
+title: Teleport Enterprise
+---
 
 This section will give an overview of Teleport Enterprise, the commercial product built around
 the open source Teleport Community core. For those that want to jump right in, you can play with

--- a/docs/4.0/pages/faq.md
+++ b/docs/4.0/pages/faq.md
@@ -1,5 +1,6 @@
-
-# FAQ
+---
+title: FAQ
+---
 
 ### Can I use Teleport in production today?
 

--- a/docs/4.0/pages/index.md
+++ b/docs/4.0/pages/index.md
@@ -1,4 +1,6 @@
-# Introduction
+---
+title: Introduction
+---
 
 ## What is Teleport?
 

--- a/docs/4.0/pages/kubernetes-ssh.md
+++ b/docs/4.0/pages/kubernetes-ssh.md
@@ -1,4 +1,6 @@
-# Kubernetes and SSH Integration Guide
+---
+title: Kubernetes and SSH Integration Guide
+---
 
 Teleport v.3.0+ has the ability to act as a compliance gateway for managing privileged access to Kubernetes clusters. This enables the following capabilities:
 

--- a/docs/4.0/pages/oidc.md
+++ b/docs/4.0/pages/oidc.md
@@ -1,4 +1,6 @@
-# OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
+title: OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
 
 This guide will cover how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
 (also known as OIDC) to issue SSH credentials to a specific groups of users.

--- a/docs/4.0/pages/quickstart-enterprise.md
+++ b/docs/4.0/pages/quickstart-enterprise.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise Quick Start
+---
+title: Teleport Enterprise Quick Start
+---
 
 Welcome to the Quick Start Guide for Teleport Enterprise.
 

--- a/docs/4.0/pages/quickstart.md
+++ b/docs/4.0/pages/quickstart.md
@@ -1,4 +1,6 @@
-# Quick Start Guide
+---
+title: Quick Start Guide
+---
 
 Welcome to the Teleport Quick Start Guide!
 

--- a/docs/4.0/pages/ssh-adfs.md
+++ b/docs/4.0/pages/ssh-adfs.md
@@ -1,4 +1,6 @@
-# SSH Authentication with ADFS
+---
+title: SSH Authentication with ADFS
+---
 
 This guide will cover how to configure Active Directory Federation Services
 [ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services) to issue

--- a/docs/4.0/pages/ssh-gsuite.md
+++ b/docs/4.0/pages/ssh-gsuite.md
@@ -1,4 +1,6 @@
-# SSH Authentication with G Suite
+---
+title: SSH Authentication with G Suite
+---
 
 This guide will cover how to configure [G Suite](https://gsuite.google.com) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.0/pages/ssh-okta.md
+++ b/docs/4.0/pages/ssh-okta.md
@@ -1,4 +1,6 @@
-# SSH Authentication with Okta
+---
+title: SSH Authentication with Okta
+---
 
 This guide will cover how to configure [Okta](https://www.okta.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.0/pages/ssh-one-login.md
+++ b/docs/4.0/pages/ssh-one-login.md
@@ -1,4 +1,6 @@
-# SSH Authentication with OneLogin
+---
+title: SSH Authentication with OneLogin
+---
 
 This guide will cover how to configure [OneLogin](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.0/pages/ssh-rbac.md
+++ b/docs/4.0/pages/ssh-rbac.md
@@ -1,4 +1,6 @@
-# Role Based Access Control for SSH
+---
+title: Role Based Access Control for SSH
+---
 
 ## Introduction
 

--- a/docs/4.0/pages/ssh-sso.md
+++ b/docs/4.0/pages/ssh-sso.md
@@ -1,4 +1,6 @@
-# Single Sign-On (SSO) for SSH
+---
+title: Single Sign-On (SSO) for SSH
+---
 
 ## Introduction
 

--- a/docs/4.0/pages/trustedclusters.md
+++ b/docs/4.0/pages/trustedclusters.md
@@ -1,4 +1,6 @@
-# Trusted Clusters
+---
+title: Trusted Clusters
+---
 
 The design of trusted clusters allows Teleport users to connect to compute infrastructure
 located behind firewalls without any open TCP ports. The real world usage examples of this

--- a/docs/4.0/pages/user-manual.md
+++ b/docs/4.0/pages/user-manual.md
@@ -1,4 +1,6 @@
-# Teleport User Manual
+---
+title: Teleport User Manual
+---
 
 This User Manual covers usage of the Teleport client tool, `tsh`. In this
 document you will learn how to:

--- a/docs/4.1/pages/admin-guide.md
+++ b/docs/4.1/pages/admin-guide.md
@@ -1,4 +1,6 @@
-# Teleport Admin Manual
+---
+title: Teleport Admin Manual
+---
 
 This manual covers the installation and configuration of Teleport and the
 ongoing management of a Teleport cluster. It assumes that the reader has good

--- a/docs/4.1/pages/architecture/teleport-architecture-overview.md
+++ b/docs/4.1/pages/architecture/teleport-architecture-overview.md
@@ -1,4 +1,6 @@
-# Architecture Introduction
+---
+title: Architecture Introduction
+---
 
 This guide is for those looking for a deeper understanding of Teleport. If you
 are looking for hands-on instructions on how to set up Teleport for your team,

--- a/docs/4.1/pages/architecture/teleport-auth.md
+++ b/docs/4.1/pages/architecture/teleport-auth.md
@@ -1,4 +1,6 @@
-# Teleport Authentication Service
+---
+title: Teleport Authentication Service
+---
 
 This document outlines the Teleport Authentication Service and Certificate
 Management. It explains how Users and Nodes are identified and granted access to

--- a/docs/4.1/pages/architecture/teleport-nodes.md
+++ b/docs/4.1/pages/architecture/teleport-nodes.md
@@ -1,4 +1,6 @@
-# Teleport Nodes
+---
+title: Teleport Nodes
+---
 
 ## The Node Service
 

--- a/docs/4.1/pages/architecture/teleport-proxy.md
+++ b/docs/4.1/pages/architecture/teleport-proxy.md
@@ -1,4 +1,6 @@
-# The Proxy Service
+---
+title: The Proxy Service
+---
 
 The proxy is a stateless service which performs three main functions in a
 Teleport cluster:

--- a/docs/4.1/pages/architecture/teleport-users.md
+++ b/docs/4.1/pages/architecture/teleport-users.md
@@ -1,4 +1,6 @@
-# Teleport Users
+---
+title: Teleport Users
+---
 
 <!-- TODO: This doc is incomplete, pending addition of Enterprise topics -->
 

--- a/docs/4.1/pages/aws-ent-guide.md
+++ b/docs/4.1/pages/aws-ent-guide.md
@@ -1,1 +1,3 @@
-# Setting up and running Teleport on AWS
+---
+title: Setting up and running Teleport on AWS
+---

--- a/docs/4.1/pages/aws-oss-guide.md
+++ b/docs/4.1/pages/aws-oss-guide.md
@@ -1,4 +1,6 @@
-# Running Teleport on AWS
+---
+title: Running Teleport on AWS
+---
 
 We've created this guide to give customers a high level overview of how to use Teleport
 on Amazon Web Services (AWS). This guide provides a high level introduction leading to

--- a/docs/4.1/pages/cli-docs.md
+++ b/docs/4.1/pages/cli-docs.md
@@ -1,4 +1,6 @@
-# CLI Docs
+---
+title: CLI Docs
+---
 
 ## teleport
 

--- a/docs/4.1/pages/enterprise/index.md
+++ b/docs/4.1/pages/enterprise/index.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise
+---
+title: Teleport Enterprise
+---
 
 This section will give an overview of Teleport Enterprise, the commercial product built around
 the open source Teleport Community core. For those that want to jump right in, you can play

--- a/docs/4.1/pages/enterprise/quickstart-enterprise.md
+++ b/docs/4.1/pages/enterprise/quickstart-enterprise.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise Quick Start
+---
+title: Teleport Enterprise Quick Start
+---
 
 Welcome to the Quick Start Guide for Teleport Enterprise.
 

--- a/docs/4.1/pages/enterprise/ssh-fips.md
+++ b/docs/4.1/pages/enterprise/ssh-fips.md
@@ -1,4 +1,7 @@
-# FedRAMP / FIPS
+---
+title: FedRAMP / FIPS
+---
+
 With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
 the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high
 level overview of how Teleport FIPS mode works and how it can help your company to become FedRAMP certified.

--- a/docs/4.1/pages/enterprise/ssh-rbac.md
+++ b/docs/4.1/pages/enterprise/ssh-rbac.md
@@ -1,4 +1,6 @@
-# Role Based Access Control for SSH
+---
+title: Role Based Access Control for SSH
+---
 
 ## Introduction
 

--- a/docs/4.1/pages/enterprise/ssh-sso.md
+++ b/docs/4.1/pages/enterprise/ssh-sso.md
@@ -1,4 +1,6 @@
-# Single Sign-On (SSO) for SSH
+---
+title: Single Sign-On (SSO) for SSH
+---
 
 ## Introduction
 

--- a/docs/4.1/pages/faq.md
+++ b/docs/4.1/pages/faq.md
@@ -1,5 +1,6 @@
-
-# FAQ
+---
+title: FAQ
+---
 
 ### Can I use Teleport in production today?
 

--- a/docs/4.1/pages/index.md
+++ b/docs/4.1/pages/index.md
@@ -1,4 +1,6 @@
-# Introduction
+---
+title: Introduction
+---
 
 ## What is Teleport?
 

--- a/docs/4.1/pages/installation.md
+++ b/docs/4.1/pages/installation.md
@@ -1,4 +1,6 @@
-# Installation
+---
+title: Installation
+---
 
 Teleport core service [`teleport`](cli-docs.md#teleport) and admin tools [`tctl`](cli-docs.md#tctl) has been designed to run on **Linux** and **Mac** operating systems.
 

--- a/docs/4.1/pages/kubernetes-ssh.md
+++ b/docs/4.1/pages/kubernetes-ssh.md
@@ -1,4 +1,6 @@
-# Kubernetes and SSH Integration Guide
+---
+title: Kubernetes and SSH Integration Guide
+---
 
 Teleport v.3.0+ has the ability to act as a compliance gateway for managing privileged access to Kubernetes clusters. This enables the following capabilities:
 

--- a/docs/4.1/pages/oidc.md
+++ b/docs/4.1/pages/oidc.md
@@ -1,4 +1,6 @@
-# OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
+title: OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
 
 This guide will cover how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
 (also known as OIDC) to issue SSH credentials to a specific groups of users.

--- a/docs/4.1/pages/quickstart.md
+++ b/docs/4.1/pages/quickstart.md
@@ -1,4 +1,6 @@
-# Quickstart
+---
+title: Quickstart
+---
 
 Welcome to the Teleport Quickstart!
 

--- a/docs/4.1/pages/ssh-adfs.md
+++ b/docs/4.1/pages/ssh-adfs.md
@@ -1,4 +1,6 @@
-# SSH Authentication with ADFS
+---
+title: SSH Authentication with ADFS
+---
 
 This guide will cover how to configure Active Directory Federation Services
 [ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services) to issue

--- a/docs/4.1/pages/ssh-gsuite.md
+++ b/docs/4.1/pages/ssh-gsuite.md
@@ -1,4 +1,6 @@
-# SSH Authentication with G Suite
+---
+title: SSH Authentication with G Suite
+---
 
 This guide will cover how to configure [G Suite](https://gsuite.google.com) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.1/pages/ssh-okta.md
+++ b/docs/4.1/pages/ssh-okta.md
@@ -1,4 +1,6 @@
-# SSH Authentication with Okta
+---
+title: SSH Authentication with Okta
+---
 
 This guide will cover how to configure [Okta](https://www.okta.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.1/pages/ssh-one-login.md
+++ b/docs/4.1/pages/ssh-one-login.md
@@ -1,4 +1,6 @@
-# SSH Authentication with OneLogin
+---
+title: SSH Authentication with OneLogin
+---
 
 This guide will cover how to configure [OneLogin](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.1/pages/trustedclusters.md
+++ b/docs/4.1/pages/trustedclusters.md
@@ -1,4 +1,6 @@
-# Trusted Clusters
+---
+title: Trusted Clusters
+---
 
 The design of trusted clusters allows Teleport users to connect to compute infrastructure
 located behind firewalls without any open TCP ports. The real world usage examples of this

--- a/docs/4.1/pages/user-manual.md
+++ b/docs/4.1/pages/user-manual.md
@@ -1,4 +1,6 @@
-# Teleport User Manual
+---
+title: Teleport User Manual
+---
 
 This User Manual covers usage of the Teleport client tool, `tsh`. In this
 document you will learn how to:

--- a/docs/4.2/pages/admin-guide.md
+++ b/docs/4.2/pages/admin-guide.md
@@ -1,4 +1,6 @@
-# Teleport Admin Manual
+---
+title: Teleport Admin Manual
+---
 
 This manual covers the installation and configuration of Teleport and the
 ongoing management of a Teleport cluster. It assumes that the reader has good

--- a/docs/4.2/pages/architecture/teleport-architecture-overview.md
+++ b/docs/4.2/pages/architecture/teleport-architecture-overview.md
@@ -1,4 +1,6 @@
-# Architecture Introduction
+---
+title: Architecture Introduction
+---
 
 This guide is for those looking for a deeper understanding of Teleport. If you
 are looking for hands-on instructions on how to set up Teleport for your team,

--- a/docs/4.2/pages/architecture/teleport-auth.md
+++ b/docs/4.2/pages/architecture/teleport-auth.md
@@ -1,4 +1,6 @@
-# Teleport Authentication Service
+---
+title: Teleport Authentication Service
+---
 
 This document outlines the Teleport Authentication Service and Certificate
 Management. It explains how Users and Nodes are identified and granted access to

--- a/docs/4.2/pages/architecture/teleport-nodes.md
+++ b/docs/4.2/pages/architecture/teleport-nodes.md
@@ -1,4 +1,6 @@
-# Teleport Nodes
+---
+title: Teleport Nodes
+---
 
 ## The Node Service
 

--- a/docs/4.2/pages/architecture/teleport-proxy.md
+++ b/docs/4.2/pages/architecture/teleport-proxy.md
@@ -1,4 +1,6 @@
-# The Proxy Service
+---
+title: The Proxy Service
+---
 
 The proxy is a stateless service which performs three main functions in a
 Teleport cluster:

--- a/docs/4.2/pages/architecture/teleport-users.md
+++ b/docs/4.2/pages/architecture/teleport-users.md
@@ -1,4 +1,6 @@
-# Teleport Users
+---
+title: Teleport Users
+---
 
 <!-- TODO: This doc is incomplete, pending addition of Enterprise topics -->
 

--- a/docs/4.2/pages/aws-oss-guide.md
+++ b/docs/4.2/pages/aws-oss-guide.md
@@ -1,4 +1,6 @@
-# Running Teleport on AWS
+---
+title: Running Teleport on AWS
+---
 
 We've created this guide to give customers a high level overview of how to use Teleport
 on Amazon Web Services (AWS). This guide provides a high level introduction leading to

--- a/docs/4.2/pages/aws-terraform-guide.md
+++ b/docs/4.2/pages/aws-terraform-guide.md
@@ -1,4 +1,6 @@
-# Running Teleport Enterprise in HA mode on AWS
+---
+title: Running Teleport Enterprise in HA mode on AWS
+---
 
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to use and administrate the resulting Teleport deployment.

--- a/docs/4.2/pages/cli-docs.md
+++ b/docs/4.2/pages/cli-docs.md
@@ -1,4 +1,6 @@
-# CLI Docs
+---
+title: CLI Docs
+---
 
 [teleport](#teleport)<br />
 [tsh](#tsh)<br />

--- a/docs/4.2/pages/enterprise/index.md
+++ b/docs/4.2/pages/enterprise/index.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise
+---
+title: Teleport Enterprise
+---
 
 This section will give an overview of Teleport Enterprise, the commercial product built around
 the open source Teleport Community core. For those that want to jump right in, you can play

--- a/docs/4.2/pages/enterprise/quickstart-enterprise.md
+++ b/docs/4.2/pages/enterprise/quickstart-enterprise.md
@@ -1,4 +1,6 @@
-# Teleport Enterprise Quick Start
+---
+title: Teleport Enterprise Quick Start
+---
 
 Welcome to the Quick Start Guide for Teleport Enterprise.
 

--- a/docs/4.2/pages/enterprise/ssh-fips.md
+++ b/docs/4.2/pages/enterprise/ssh-fips.md
@@ -1,4 +1,7 @@
-# FedRAMP / FIPS
+---
+title: FedRAMP / FIPS
+---
+
 With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
 the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high
 level overview of how Teleport FIPS mode works and how it can help your company to become FedRAMP certified.

--- a/docs/4.2/pages/enterprise/ssh-rbac.md
+++ b/docs/4.2/pages/enterprise/ssh-rbac.md
@@ -1,4 +1,6 @@
-# Role Based Access Control for SSH
+---
+title: Role Based Access Control for SSH
+---
 
 ## Introduction
 

--- a/docs/4.2/pages/enterprise/ssh-sso.md
+++ b/docs/4.2/pages/enterprise/ssh-sso.md
@@ -1,4 +1,6 @@
-# Single Sign-On (SSO) for SSH
+---
+title: Single Sign-On (SSO) for SSH
+---
 
 The commercial edition of Teleport allows users to login and retrieve their SSH
 credentials through a [Single Sign-On](https://en.wikipedia.org/wiki/Single_sign-on)
@@ -12,7 +14,7 @@ Other identity management systems are supported as long as they provide an
 SSO mechanism based on either [SAML](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
 or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
-### SSO Setup Guides
+## SSO Setup Guides
 
 - [Azure Active Directory (AD)](sso/ssh-azuread.md)
 - [Active Directory (ADFS)](sso/ssh-adfs.md)

--- a/docs/4.2/pages/enterprise/sso/oidc.md
+++ b/docs/4.2/pages/enterprise/sso/oidc.md
@@ -1,4 +1,6 @@
-# OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
+title: OAuth2 / OpenID Connect (OIDC) Authentication for SSH
+---
 
 This guide will cover how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
 (also known as OIDC) to issue SSH credentials to a specific groups of users.

--- a/docs/4.2/pages/enterprise/sso/ssh-adfs.md
+++ b/docs/4.2/pages/enterprise/sso/ssh-adfs.md
@@ -1,4 +1,6 @@
-# SSH Authentication with ADFS
+---
+title: SSH Authentication with ADFS
+---
 
 This guide will cover how to configure Active Directory Federation Services
 [ADFS](https://en.wikipedia.org/wiki/Active_Directory_Federation_Services) to issue

--- a/docs/4.2/pages/enterprise/sso/ssh-azuread.md
+++ b/docs/4.2/pages/enterprise/sso/ssh-azuread.md
@@ -1,4 +1,6 @@
-# SSH Authentication with Azure Active Directory (AD)
+---
+title: SSH Authentication with Azure Active Directory (AD)
+---
 
 This guide will cover how to configure [Microsoft Azure Active Directory](https://azure.microsoft.com/en-us/services/active-directory/) to issue
 SSH credentials to specific groups of users with a SAML Authentication Connector. When used in combination with role

--- a/docs/4.2/pages/enterprise/sso/ssh-gsuite.md
+++ b/docs/4.2/pages/enterprise/sso/ssh-gsuite.md
@@ -1,4 +1,6 @@
-# SSH Authentication with G Suite
+---
+title: SSH Authentication with G Suite
+---
 
 This guide will cover how to configure [G Suite](https://gsuite.google.com) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.2/pages/enterprise/sso/ssh-okta.md
+++ b/docs/4.2/pages/enterprise/sso/ssh-okta.md
@@ -1,4 +1,6 @@
-# SSH Authentication with Okta
+---
+title: SSH Authentication with Okta
+---
 
 This guide will cover how to configure [Okta](https://www.okta.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.2/pages/enterprise/sso/ssh-one-login.md
+++ b/docs/4.2/pages/enterprise/sso/ssh-one-login.md
@@ -1,4 +1,6 @@
-# SSH Authentication with OneLogin
+---
+title: SSH Authentication with OneLogin
+---
 
 This guide will cover how to configure [OneLogin](https://www.onelogin.com/) to issue
 SSH credentials to specific groups of users. When used in combination with role

--- a/docs/4.2/pages/faq.md
+++ b/docs/4.2/pages/faq.md
@@ -1,5 +1,6 @@
-
-# FAQ
+---
+title: FAQ
+---
 
 ### Can I use Teleport in production today?
 

--- a/docs/4.2/pages/features/enhanced-session-recording.md
+++ b/docs/4.2/pages/features/enhanced-session-recording.md
@@ -1,4 +1,6 @@
-# Enhanced Session Recording
+---
+title: Enhanced Session Recording
+---
 
 Teleport [standard session recordings](https://gravitational.com/teleport/docs/architecture/nodes/#session-recording) only capture what is echoed to a terminal.
 This has inherent advantages, for example because no input is captured, Teleport

--- a/docs/4.2/pages/features/ssh-pam.md
+++ b/docs/4.2/pages/features/ssh-pam.md
@@ -1,4 +1,6 @@
-# Using Teleport with Pluggable Authentication Modules (PAM)
+---
+title: Using Teleport with Pluggable Authentication Modules (PAM)
+---
 
 Teleport's node service can be configured to integrate with [PAM](https://en.wikipedia.org/wiki/Linux_PAM). This allows Teleport to create user sessions using PAM session profiles.
 

--- a/docs/4.2/pages/gcp-guide.md
+++ b/docs/4.2/pages/gcp-guide.md
@@ -1,4 +1,6 @@
-# Running Teleport on GCP
+---
+title: Running Teleport on GCP
+---
 
 We've created this guide to give customers a high level overview of how to use Teleport
 on [Google Cloud](https://cloud.google.com/gcp/) (GCP). This guide provides a high level

--- a/docs/4.2/pages/ibm-cloud-guide.md
+++ b/docs/4.2/pages/ibm-cloud-guide.md
@@ -1,4 +1,6 @@
-# Running Teleport on IBM Cloud
+---
+title: Running Teleport on IBM Cloud
+---
 
 We've created this guide to give customers a high level overview of how to use Teleport
 on the [IBM Cloud](https://www.ibm.com/cloud). This guide provides a high level

--- a/docs/4.2/pages/index.md
+++ b/docs/4.2/pages/index.md
@@ -1,4 +1,6 @@
-# Introduction
+---
+title: Introduction
+---
 
 ## What is Teleport?
 

--- a/docs/4.2/pages/installation.md
+++ b/docs/4.2/pages/installation.md
@@ -1,4 +1,6 @@
-# Installation
+---
+title: Installation
+---
 
 Teleport core service [`teleport`](cli-docs.md#teleport) and admin tool [`tctl`](cli-docs.md#tctl) have been designed to run on **Linux** and **Mac** operating systems.
 

--- a/docs/4.2/pages/kubernetes-ssh.md
+++ b/docs/4.2/pages/kubernetes-ssh.md
@@ -1,4 +1,6 @@
-# Kubernetes and SSH Integration Guide
+---
+title: Kubernetes and SSH Integration Guide
+---
 
 Teleport v.3.0+ has the ability to act as a compliance gateway for managing privileged access to Kubernetes clusters. This enables the following capabilities:
 

--- a/docs/4.2/pages/production.md
+++ b/docs/4.2/pages/production.md
@@ -1,4 +1,6 @@
-# Production Guide
+---
+title: Production Guide
+---
 
 This guide provides more in-depth details for running Teleport in Production.
 

--- a/docs/4.2/pages/quickstart.md
+++ b/docs/4.2/pages/quickstart.md
@@ -1,12 +1,12 @@
-# Quickstart
+---
+title: Quickstart
+---
 
 Welcome to the Teleport Quickstart!
 
 This tutorial will guide you through the steps needed to install and run
 Teleport on a single node, which could be your local machine but we recommend a
 VM.
-
-
 
 ### Prerequisites
 

--- a/docs/4.2/pages/trustedclusters.md
+++ b/docs/4.2/pages/trustedclusters.md
@@ -1,4 +1,6 @@
-# Trusted Clusters
+---
+title: Trusted Clusters
+---
 
 The design of trusted clusters allows Teleport users to connect to compute infrastructure
 located behind firewalls without any open TCP ports. The real world usage examples of this

--- a/docs/4.2/pages/user-manual.md
+++ b/docs/4.2/pages/user-manual.md
@@ -1,4 +1,6 @@
-# Teleport User Manual
+---
+title: Teleport User Manual
+---
 
 This User Manual covers usage of the Teleport client tool, `tsh`. In this
 document you will learn how to:

--- a/docs/4.3/pages/admin-guide.md
+++ b/docs/4.3/pages/admin-guide.md
@@ -3,8 +3,6 @@ title: Teleport Admin Manual
 description: Admin manual for how to configure identity-aware SSH, certificate-based SSH authentication, set up SSO for SSH, SSO for Kubernetes, and more.
 ---
 
-# Teleport Admin Manual
-
 This manual covers the installation and configuration of Teleport and the
 ongoing management of a Teleport cluster. It assumes that the reader has good
 understanding of Linux administration.

--- a/docs/4.3/pages/api-reference.md
+++ b/docs/4.3/pages/api-reference.md
@@ -3,8 +3,6 @@ title: Teleport API Reference
 description: The detailed guide to Teleport API
 ---
 
-# Teleport API Reference
-
 Teleport is currently working on documenting our API.
 
 !!! warning

--- a/docs/4.3/pages/architecture/authentication.md
+++ b/docs/4.3/pages/architecture/authentication.md
@@ -1,14 +1,12 @@
 ---
 title: Teleport Authentication Service, SSH and Kubernetes certificates
 description: This chapter explains the concept of a Teleport Auth Service and Certificate Authority (CA) to issue SSH and Kubernetes certificates.
+h1: Teleport Authentication Service
 ---
-
-# Teleport Authentication Service
 
 This document outlines the Teleport Authentication Service and Certificate
 Management. It explains how Users and Nodes are identified and granted access to
 Nodes and Services.
-
 
 ## Authentication vs. Authorization
 

--- a/docs/4.3/pages/architecture/nodes.md
+++ b/docs/4.3/pages/architecture/nodes.md
@@ -3,8 +3,6 @@ title: Teleport Nodes
 description: This chapter explains the concept of a Teleport Node and Teleport manages SSH and Kubernetes nodes.
 ---
 
-# Teleport Nodes
-
 Teleport calls any computing device (server, VM, AWS intance, etc) a "node".
 
 ## The Node Service

--- a/docs/4.3/pages/architecture/overview.md
+++ b/docs/4.3/pages/architecture/overview.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Architecture Overview
 description: Basic concepts and architecture of Teleport. What is an SSH cluster? How certificate-based SSH authentication works? How SSH audit works?
+h1: Architecture Introduction
 ---
-
-# Architecture Introduction
 
 This guide is for those looking for a deeper understanding of Teleport. If you
 are looking for hands-on instructions on how to set up Teleport for your team,

--- a/docs/4.3/pages/architecture/proxy.md
+++ b/docs/4.3/pages/architecture/proxy.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Proxy Service
 description: How Teleport implements SSH and Kubernetes access via a Proxy
+h1: The Proxy Service
 ---
-
-# The Proxy Service
 
 The proxy is a stateless service which performs three main functions in a
 Teleport cluster:

--- a/docs/4.3/pages/architecture/users.md
+++ b/docs/4.3/pages/architecture/users.md
@@ -3,10 +3,7 @@ title: Teleport Users
 description: This chapter explains the concept of a Teleport User and how it's different from operating system (OS) users or Kubernetes users.
 ---
 
-# Teleport Users
-
 <!-- TODO: This doc is incomplete, pending addition of Enterprise topics -->
-
 
 ## Types of Users
 

--- a/docs/4.3/pages/aws-oss-guide.md
+++ b/docs/4.3/pages/aws-oss-guide.md
@@ -3,8 +3,6 @@ title: Running Teleport on AWS
 description: How to install and configure Gravitational Teleport on AWS for SSH and Kubernetes access.
 ---
 
-# Running Teleport on AWS
-
 We've created this guide to give customers a high level overview of how to use Teleport
 on Amazon Web Services (AWS). This guide provides a high level introduction leading to
 a deep dive into how to setup and run Teleport in production.

--- a/docs/4.3/pages/aws-terraform-guide.md
+++ b/docs/4.3/pages/aws-terraform-guide.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport HA mode on AWS
 description: How to configure Teleport in highly available (HA) mode for AWS deployments
+h1: Running Teleport Enterprise in HA mode on AWS
 ---
-
-# Running Teleport Enterprise in HA mode on AWS
 
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to use and administrate the resulting Teleport deployment.

--- a/docs/4.3/pages/cli-docs.md
+++ b/docs/4.3/pages/cli-docs.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport CLI Reference
 description: The detailed guide for Teleport command line (CLI) tools
+h1: Command Line (CLI) Reference
 ---
-
-# Command Line (CLI) Reference
 
 Teleport is made up of three CLI tools.
 

--- a/docs/4.3/pages/config-reference.md
+++ b/docs/4.3/pages/config-reference.md
@@ -3,8 +3,6 @@ title: Teleport Configuration Reference
 description: The detailed guide for configuring Teleport for SSH and Kubernetes access
 ---
 
-# Teleport Configuration Reference
-
 ## teleport.yaml
 
 Teleport uses the YAML file format for configuration. A full configuration reference

--- a/docs/4.3/pages/enterprise/introduction.md
+++ b/docs/4.3/pages/enterprise/introduction.md
@@ -3,8 +3,6 @@ title: Teleport Enterprise
 description: Introduction to features and benefits of using Teleport Enterprise. Why upgrade to Teleport Enterprise?
 ---
 
-# Teleport Enterprise
-
 This section will give an overview of Teleport Enterprise, the commercial product built around
 the open source Teleport Community core. For those that want to jump right in, you can play
 with the [Quick Start Guide for Teleport Enterprise](quickstart-enterprise.md).

--- a/docs/4.3/pages/enterprise/quickstart-enterprise.md
+++ b/docs/4.3/pages/enterprise/quickstart-enterprise.md
@@ -3,8 +3,6 @@ title: Teleport Enterprise Quick Start
 description: How to set up and configure Teleport Enterprise for SSH and Kubernetes access
 ---
 
-# Teleport Enterprise Quick Start
-
 Welcome to the Quick Start Guide for Teleport Enterprise.
 
 The goal of this document is to show off the basic capabilities of Teleport.

--- a/docs/4.3/pages/enterprise/ssh-kubernetes-fedramp.md
+++ b/docs/4.3/pages/enterprise/ssh-kubernetes-fedramp.md
@@ -1,10 +1,8 @@
 ---
 title: FedRAMP compliance for SSH and Kubernetes
 description: How to configure SSH and Kubernetes access to be FedRAMP compliant, including support for FIPS 140-2
+h1: FedRAMP for SSH and Kubernetes Access
 ---
-
-
-# FedRAMP for SSH and Kubernetes Access
 
 With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
 the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high

--- a/docs/4.3/pages/enterprise/ssh-rbac.md
+++ b/docs/4.3/pages/enterprise/ssh-rbac.md
@@ -1,9 +1,8 @@
 ---
 title: Role Based Access Control for SSH and Kubernetes
 description: How to configure Teleport to provide unified Role Based Access Control for SSH and Kubernetes
+h1: Role Based Access Control for SSH & K8s
 ---
-
-# Role Based Access Control for SSH & K8s
 
 ## Introduction
 

--- a/docs/4.3/pages/enterprise/sso/oidc.md
+++ b/docs/4.3/pages/enterprise/sso/oidc.md
@@ -1,9 +1,8 @@
 ---
 title: OAuth2 and OIDC authentication for SSH
 description: How to configure SSH access with OAuth2 or OIDC (OpenID connect) using Teleport
+h1: OAuth2 / OIDC Authentication for SSH
 ---
-
-# OAuth2 / OIDC Authentication for SSH
 
 This guide will cover how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
 (also known as OIDC) to issue SSH credentials to a specific groups of users.

--- a/docs/4.3/pages/enterprise/sso/ssh-adfs.md
+++ b/docs/4.3/pages/enterprise/sso/ssh-adfs.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication With ADFS How To
 description: How to configure SSH access with Active Directory (ADFS) using Teleport
+h1: SSH Authentication with ADFS
 ---
-
-# SSH Authentication with ADFS
 
 ## Active Directory as an SSO provider for SSH authentication
 

--- a/docs/4.3/pages/enterprise/sso/ssh-azuread.md
+++ b/docs/4.3/pages/enterprise/sso/ssh-azuread.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication with Active Directory (AD) on Azure
 description: How to configure SSH access with Active Directory (AD) on Azure using Teleport
+h1: SSH Authentication with Azure Active Directory (AD)
 ---
-
-# SSH Authentication with Azure Active Directory (AD)
 
 This guide will cover how to configure [Microsoft Azure Active Directory](https://azure.microsoft.com/en-us/services/active-directory/) to issue
 SSH credentials to specific groups of users with a SAML Authentication Connector. When used in combination with role

--- a/docs/4.3/pages/enterprise/sso/ssh-gsuite.md
+++ b/docs/4.3/pages/enterprise/sso/ssh-gsuite.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication With Google Apps (G Suite)
 description: How to configure SSH access with Google Apps (also known as G Suite) using Teleport
+h1: SSH Authentication with G Suite (Google Apps)
 ---
-
-# SSH Authentication with G Suite (Google Apps)
 
 ## Google Apps as SSO for SSH
 

--- a/docs/4.3/pages/enterprise/sso/ssh-okta.md
+++ b/docs/4.3/pages/enterprise/sso/ssh-okta.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication With Okta as an SSO provider
 description: How to configure SSH access using Okta for SSO
+h1: SSH Authentication with Okta
 ---
-
-# SSH Authentication with Okta
 
 ## How to use Okta as a single sign-on (SSO) provider for SSH
 

--- a/docs/4.3/pages/enterprise/sso/ssh-one-login.md
+++ b/docs/4.3/pages/enterprise/sso/ssh-one-login.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication with One Login as an SSO provider
 description: How to configure SSH access using One Login as an SSO provider
+h1: SSH Authentication with OneLogin
 ---
-
-# SSH Authentication with OneLogin
 
 ## Using OneLogin as a single sign-on (SSO) provider for SSH
 

--- a/docs/4.3/pages/enterprise/sso/ssh-sso.md
+++ b/docs/4.3/pages/enterprise/sso/ssh-sso.md
@@ -1,9 +1,8 @@
 ---
 title: SSO for SSH
 description: How to set up single sign-on (SSO) for SSH using Gravitational Teleport
+h1: Single Sign-On (SSO) for SSH
 ---
-
-# Single Sign-On (SSO) for SSH
 
 The commercial edition of Teleport allows users to login and retrieve their SSH
 credentials through a [Single Sign-On](https://en.wikipedia.org/wiki/Single_sign-on)

--- a/docs/4.3/pages/enterprise/workflow/index.md
+++ b/docs/4.3/pages/enterprise/workflow/index.md
@@ -1,10 +1,8 @@
 ---
 title: Approval Workflows for SSH and Kubernetes Access
 description: How to customize SSH and Kubernetes access using Teleport.
+h1: Teleport Approval Workflows
 ---
-
-# Teleport Approval Workflows
-
 #### Approving Workflow using an External Integration
 - [Integrating Teleport with Slack](ssh-approval-slack.md)
 - [Integrating Teleport with Mattermost](ssh-approval-mattermost.md)

--- a/docs/4.3/pages/enterprise/workflow/ssh-approval-jira-cloud.md
+++ b/docs/4.3/pages/enterprise/workflow/ssh-approval-jira-cloud.md
@@ -1,9 +1,8 @@
 ---
 title: SSH login approval using Jira and Teleport
 description: How to configure SSH login approval using Jira and Teleport
+h1: SSH login approvals using Jira
 ---
-
-# SSH login approvals using Jira
 
 ## Teleport Jira Plugin Setup
 

--- a/docs/4.3/pages/enterprise/workflow/ssh-approval-jira-server.md
+++ b/docs/4.3/pages/enterprise/workflow/ssh-approval-jira-server.md
@@ -1,9 +1,8 @@
 ---
 title: SSH login approval using Jira Server and Teleport
 description: How to configure SSH login approval using Jira Server and Teleport
+h1: SSH login approvals using Jira Server
 ---
-
-# SSH login approvals using Jira Server
 
 ## Teleport Jira Server Plugin Setup
 

--- a/docs/4.3/pages/enterprise/workflow/ssh-approval-mattermost.md
+++ b/docs/4.3/pages/enterprise/workflow/ssh-approval-mattermost.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport integration with Mattermost
 description: This guide explains how to setup a Mattermost plugin for Teleport for privilege elevation approvals.
+h1: Teleport Mattermost Plugin Setup
 ---
-
-# Teleport Mattermost Plugin Setup
 
 This guide will talk through how to setup Teleport with Mattermost. Teleport to
 Mattermost integration allows teams to approve or deny Teleport access requests

--- a/docs/4.3/pages/enterprise/workflow/ssh-approval-pagerduty.md
+++ b/docs/4.3/pages/enterprise/workflow/ssh-approval-pagerduty.md
@@ -1,9 +1,8 @@
 ---
 title: SSH login approval via Pager Duty
 description: How to configure SSH login approval using PagerDuty and Teleport
+h1: SSH Login Approval using PagerDuty
 ---
-
-# SSH Login Approval using PagerDuty
 
 ## Teleport Pagerduty Plugin Setup
 

--- a/docs/4.3/pages/enterprise/workflow/ssh-approval-slack.md
+++ b/docs/4.3/pages/enterprise/workflow/ssh-approval-slack.md
@@ -1,9 +1,9 @@
 ---
 title: Teleport integration with Slack
 description: This guide explains how to setup a Slack plugin for Teleport for privilege elevation approvals.
+h1: Teleport Slack Plugin Setup
 ---
 
-# Teleport Slack Plugin Setup
 This guide will talk through how to setup Teleport with Slack. Teleport to Slack integration allows you to treat Teleport access and permission requests via Slack message and inline interactive components.
 
 !!! warning

--- a/docs/4.3/pages/faq.md
+++ b/docs/4.3/pages/faq.md
@@ -1,10 +1,8 @@
 ---
 title: Teleport FAQ
 description: Frequently Asked Questions about using Teleport for SSH and Kubernetes access
+h1: FAQ
 ---
-
-
-# FAQ
 
 ## Community FAQ
 

--- a/docs/4.3/pages/features/enhanced-session-recording.md
+++ b/docs/4.3/pages/features/enhanced-session-recording.md
@@ -1,9 +1,9 @@
 ---
 title: Session Recording for SSH and Kubernetes
 description: How to record your SSH and Kubernetes sessions into the audit log.
+h1: Enhanced Session Recording
 ---
 
-# Enhanced Session Recording
 Teleport [SSH and Kubernetes session recording](../architecture/nodes.md#session-recording)
 feature captures what is echoed to a terminal.
 

--- a/docs/4.3/pages/features/ssh-pam.md
+++ b/docs/4.3/pages/features/ssh-pam.md
@@ -1,9 +1,8 @@
 ---
 title: Configuring Teleport SSH with PAM (pluggable authentication modules)
 description: How to configure Teleport SSH access to play nicely with PAM (pluggable authentication modules)
+h1: Pluggable Authentication Modules (PAM)
 ---
-
-# Pluggable Authentication Modules (PAM)
 
 Teleport's node service can be configured to integrate with [PAM](https://en.wikipedia.org/wiki/Linux_PAM). This allows Teleport to create user sessions using PAM session profiles.
 

--- a/docs/4.3/pages/gcp-guide.md
+++ b/docs/4.3/pages/gcp-guide.md
@@ -3,8 +3,6 @@ title: Running Teleport on GCP
 description: How to install and configure Gravitational Teleport on GCP for SSH and Kubernetes access.
 ---
 
-# Running Teleport on GCP
-
 We've created this guide to give customers a high level overview of how to use Teleport
 on [Google Cloud](https://cloud.google.com/gcp/) (GCP). This guide provides a high level
 introduction leading to a deep dive into how to setup and run Teleport in production.

--- a/docs/4.3/pages/ibm-cloud-guide.md
+++ b/docs/4.3/pages/ibm-cloud-guide.md
@@ -3,8 +3,6 @@ title: Running Teleport on IBM Cloud
 description: How to install and configure Gravitational Teleport on IBM cloud for SSH and Kubernetes access.
 ---
 
-# Running Teleport on IBM Cloud
-
 We've created this guide to give customers a high level overview of how to use Teleport
 on the [IBM Cloud](https://www.ibm.com/cloud). This guide provides a high level
 introduction leading to a deep dive into how to setup and run Teleport in production.

--- a/docs/4.3/pages/index.md
+++ b/docs/4.3/pages/index.md
@@ -1,9 +1,8 @@
 ---
 title: Introduction to Teleport
 description: How to install and quickly get up and running with Gravitational Teleport to set up SSH and Kubernetes access to cloud environments.
+h1: Introduction
 ---
-
-# Introduction
 
 ## What is Teleport?
 

--- a/docs/4.3/pages/installation.md
+++ b/docs/4.3/pages/installation.md
@@ -1,9 +1,8 @@
 ---
 title: Installing Teleport
 description: The guide for installing Teleport on servers and into Kubernetes clusters
+h1: Installation
 ---
-
-# Installation
 
 Teleport core service [`teleport`](cli-docs.md#teleport) and admin tool [`tctl`](cli-docs.md#tctl) have been designed to run on **Linux** and **Mac** operating systems. The Teleport user client [`tsh`](cli-docs.md#tsh) and UI are available for **Linux, Mac** and **Windows** operating systems.
 

--- a/docs/4.3/pages/kubernetes-ssh.md
+++ b/docs/4.3/pages/kubernetes-ssh.md
@@ -1,9 +1,8 @@
 ---
 title: Kubernetes Access Guide
 description: How to set up and configure Teleport for Kubernetes access with SSO and RBAC
+h1: Teleport Kubernetes Access Guide
 ---
-
-# Teleport Kubernetes Access Guide
 
 Teleport has the ability to act as a compliance gateway for managing privileged
 access to Kubernetes clusters. This enables the following capabilities:

--- a/docs/4.3/pages/metrics-logs-reference.md
+++ b/docs/4.3/pages/metrics-logs-reference.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Metrics
 description: How to set up Prometheus to monitor Teleport for SSH and Kubernetes access
+h1: Metrics
 ---
-
-# Metrics
 
 ## Teleport Prometheus Endpoint
 

--- a/docs/4.3/pages/openssh-teleport.md
+++ b/docs/4.3/pages/openssh-teleport.md
@@ -3,8 +3,6 @@ title: Using Teleport with OpenSSH
 description: How to use Teleport on legacy systems with OpenSSH and sshd
 ---
 
-# Using Teleport with OpenSSH
-
 Teleport is fully compatible with OpenSSH and can be quickly setup to record and
 audit all SSH activity. Using Teleport and OpenSSH has the advantage of getting you up
 and running, but in the long run we would recommend replacing `sshd` with `teleport`.

--- a/docs/4.3/pages/production.md
+++ b/docs/4.3/pages/production.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Production Guide
 description: How to configure SSH and Kubernetes access with SSO on AWS, GCE and your own infrastructure.
+h1: Production Guide
 ---
-
-# Production Guide
 
 This guide provides more in-depth details for running Teleport in Production.
 

--- a/docs/4.3/pages/quickstart-docker.md
+++ b/docs/4.3/pages/quickstart-docker.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Quick Start guide with Docker
 description: How to get started with Teleport using Docker for SSH access
+h1: Run Teleport using Docker
 ---
-
-# Run Teleport using Docker
 
 We provide pre-built Docker images for every version of Teleport. These images are hosted on quay.io.
 

--- a/docs/4.3/pages/quickstart.md
+++ b/docs/4.3/pages/quickstart.md
@@ -3,8 +3,6 @@ title: Teleport Quick Start
 description: The quick start guide for how to set up modern SSH access to cloud or edge infrastructure.
 ---
 
-# Teleport Quick Start
-
 This tutorial will guide you through the steps needed to install and run
 Teleport on a single node, which could be your local machine but we recommend a
 VM.

--- a/docs/4.3/pages/trustedclusters.md
+++ b/docs/4.3/pages/trustedclusters.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Trusted Clusters
 description: How to configure access and trust between two SSH and Kubernetes environments
+h1: Trusted Clusters
 ---
-
-# Trusted Clusters
 
 The design of trusted clusters allows Teleport users to connect to compute infrastructure
 located behind firewalls without any open TCP ports. The real world usage examples of this

--- a/docs/4.3/pages/user-manual.md
+++ b/docs/4.3/pages/user-manual.md
@@ -3,8 +3,6 @@ title: Teleport User Manual
 description: Manual for how to manage user identities, share sessions for SSH and Kubernetes access using the command line and the Web UI.
 ---
 
-# Teleport User Manual
-
 This User Manual covers usage of the Teleport client tool, `tsh` and Teleport's Web interface.
 
 In this document you will learn how to:

--- a/docs/4.4/pages/admin-guide.md
+++ b/docs/4.4/pages/admin-guide.md
@@ -3,8 +3,6 @@ title: Teleport Admin Manual
 description: Admin manual for how to configure identity-aware SSH, certificate-based SSH authentication, set up SSO for SSH, SSO for Kubernetes, and more.
 ---
 
-# Teleport Admin Manual
-
 This manual covers the installation and configuration of Teleport and the
 ongoing management of a Teleport cluster. It assumes that the reader has good
 understanding of Linux administration.

--- a/docs/4.4/pages/api-reference.md
+++ b/docs/4.4/pages/api-reference.md
@@ -3,8 +3,6 @@ title: Teleport API Reference
 description: The detailed guide to Teleport API
 ---
 
-# Teleport API Reference
-
 In most cases, you can interact with Teleport using our CLI tools, [tsh](cli-docs.md#tsh) and [tctl](cli-docs.md#tctl). However, there are some scenarios where you may need to interact with Teleport programmatically. For this purpose, you can directly use the same API that `tctl` and `tsh` use.
 
 !!! note

--- a/docs/4.4/pages/architecture/authentication.md
+++ b/docs/4.4/pages/architecture/authentication.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Authentication Service, SSH and Kubernetes certificates
 description: This chapter explains the concept of a Teleport Auth Service and Certificate Authority (CA) to issue SSH and Kubernetes certificates.
+h1: Teleport Authentication Service
 ---
-
-# Teleport Authentication Service
 
 This document outlines the Teleport Authentication Service and Certificate
 Management. It explains how Users and Nodes are identified and granted access to

--- a/docs/4.4/pages/architecture/nodes.md
+++ b/docs/4.4/pages/architecture/nodes.md
@@ -3,8 +3,6 @@ title: Teleport Nodes
 description: This chapter explains the concept of a Teleport Node and Teleport manages SSH and Kubernetes nodes.
 ---
 
-# Teleport Nodes
-
 Teleport calls any computing device (server, VM, AWS intance, etc) a "node".
 
 ## The Node Service

--- a/docs/4.4/pages/architecture/overview.md
+++ b/docs/4.4/pages/architecture/overview.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Architecture Overview
 description: Basic concepts and architecture of Teleport. What is an SSH cluster? How certificate-based SSH authentication works? How SSH audit works?
+h1: Architecture Introduction
 ---
-
-# Architecture Introduction
 
 This guide is for those looking for a deeper understanding of Teleport. If you
 are looking for hands-on instructions on how to set up Teleport for your team,

--- a/docs/4.4/pages/architecture/proxy.md
+++ b/docs/4.4/pages/architecture/proxy.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Proxy Service
 description: How Teleport implements SSH and Kubernetes access via a Proxy
+h1: The Proxy Service
 ---
-
-# The Proxy Service
 
 The proxy is a stateless service which performs three main functions in a
 Teleport cluster:

--- a/docs/4.4/pages/architecture/users.md
+++ b/docs/4.4/pages/architecture/users.md
@@ -3,10 +3,7 @@ title: Teleport Users
 description: This chapter explains the concept of a Teleport User and how it's different from operating system (OS) users or Kubernetes users.
 ---
 
-# Teleport Users
-
 <!-- TODO: This doc is incomplete, pending addition of Enterprise topics -->
-
 
 ## Types of Users
 

--- a/docs/4.4/pages/aws-oss-guide.md
+++ b/docs/4.4/pages/aws-oss-guide.md
@@ -3,8 +3,6 @@ title: Running Teleport on AWS
 description: How to install and configure Gravitational Teleport on AWS for SSH and Kubernetes access.
 ---
 
-# Running Teleport on AWS
-
 We've created this guide to give customers a high level overview of how to use Teleport
 on Amazon Web Services (AWS). This guide provides a high level introduction leading to
 a deep dive into how to setup and run Teleport in production.

--- a/docs/4.4/pages/aws-terraform-guide.md
+++ b/docs/4.4/pages/aws-terraform-guide.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport HA mode on AWS
 description: How to configure Teleport in highly available (HA) mode for AWS deployments
+h1: Running Teleport Enterprise in HA mode on AWS
 ---
-
-# Running Teleport Enterprise in HA mode on AWS
 
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to use and administrate the resulting Teleport deployment.

--- a/docs/4.4/pages/cli-docs.md
+++ b/docs/4.4/pages/cli-docs.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport CLI Reference
 description: The detailed guide for Teleport command line (CLI) tools
+h1: Command Line (CLI) Reference
 ---
-
-# Command Line (CLI) Reference
 
 Teleport is made up of three CLI tools.
 

--- a/docs/4.4/pages/config-reference.md
+++ b/docs/4.4/pages/config-reference.md
@@ -3,8 +3,6 @@ title: Teleport Configuration Reference
 description: The detailed guide for configuring Teleport for SSH and Kubernetes access
 ---
 
-# Teleport Configuration Reference
-
 ## teleport.yaml
 
 Teleport uses the YAML file format for configuration. A full configuration reference

--- a/docs/4.4/pages/enterprise/introduction.md
+++ b/docs/4.4/pages/enterprise/introduction.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Enterprise
 description: Introduction to features and benefits of using Teleport Enterprise. Why upgrade to Teleport Enterprise?
+h1: Teleport Enterprise
 ---
-
-# Teleport Enterprise
 
 This section will give an overview of Teleport Enterprise, the commercial product built around
 the open source Teleport Community core. For those that want to jump right in, you can play

--- a/docs/4.4/pages/enterprise/quickstart-enterprise.md
+++ b/docs/4.4/pages/enterprise/quickstart-enterprise.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Enterprise Quick Start
 description: How to set up and configure Teleport Enterprise for SSH and Kubernetes access
+h1: Teleport Enterprise Quick Start
 ---
-
-# Teleport Enterprise Quick Start
 
 Welcome to the Quick Start Guide for Teleport Enterprise.
 

--- a/docs/4.4/pages/enterprise/ssh-kubernetes-fedramp.md
+++ b/docs/4.4/pages/enterprise/ssh-kubernetes-fedramp.md
@@ -1,10 +1,8 @@
 ---
 title: FedRAMP compliance for SSH and Kubernetes
 description: How to configure SSH and Kubernetes access to be FedRAMP compliant, including support for FIPS 140-2
+h1: FedRAMP for SSH and Kubernetes Access
 ---
-
-
-# FedRAMP for SSH and Kubernetes Access
 
 With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
 the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high

--- a/docs/4.4/pages/enterprise/ssh-rbac.md
+++ b/docs/4.4/pages/enterprise/ssh-rbac.md
@@ -1,9 +1,8 @@
 ---
 title: Role Based Access Control for SSH and Kubernetes
 description: How to configure Teleport to provide unified Role Based Access Control for SSH and Kubernetes
+h1: Role Based Access Control for SSH & K8s
 ---
-
-# Role Based Access Control for SSH & K8s
 
 ## Introduction
 

--- a/docs/4.4/pages/enterprise/sso/oidc.md
+++ b/docs/4.4/pages/enterprise/sso/oidc.md
@@ -1,9 +1,8 @@
 ---
 title: OAuth2 and OIDC authentication for SSH
 description: How to configure SSH access with OAuth2 or OIDC (OpenID connect) using Teleport
+h1: OAuth2 / OIDC Authentication for SSH
 ---
-
-# OAuth2 / OIDC Authentication for SSH
 
 This guide will cover how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
 (also known as OIDC) to issue SSH credentials to a specific groups of users.

--- a/docs/4.4/pages/enterprise/sso/ssh-adfs.md
+++ b/docs/4.4/pages/enterprise/sso/ssh-adfs.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication With ADFS How To
 description: How to configure SSH access with Active Directory (ADFS) using Teleport
+h1: SSH Authentication with ADFS
 ---
-
-# SSH Authentication with ADFS
 
 ## Active Directory as an SSO provider for SSH authentication
 

--- a/docs/4.4/pages/enterprise/sso/ssh-azuread.md
+++ b/docs/4.4/pages/enterprise/sso/ssh-azuread.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication with Active Directory (AD) on Azure
 description: How to configure SSH access with Active Directory (AD) on Azure using Teleport
+h1: SSH Authentication with Azure Active Directory (AD)
 ---
-
-# SSH Authentication with Azure Active Directory (AD)
 
 This guide will cover how to configure [Microsoft Azure Active Directory](https://azure.microsoft.com/en-us/services/active-directory/) to issue
 SSH credentials to specific groups of users with a SAML Authentication Connector. When used in combination with role

--- a/docs/4.4/pages/enterprise/sso/ssh-gsuite.md
+++ b/docs/4.4/pages/enterprise/sso/ssh-gsuite.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication With Google Apps (G Suite)
 description: How to configure SSH access with Google Apps (also known as G Suite) using Teleport
+h1: SSH Authentication with G Suite (Google Apps)
 ---
-
-# SSH Authentication with G Suite (Google Apps)
 
 ## Google Apps as SSO for SSH
 

--- a/docs/4.4/pages/enterprise/sso/ssh-okta.md
+++ b/docs/4.4/pages/enterprise/sso/ssh-okta.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication With Okta as an SSO provider
 description: How to configure SSH access using Okta for SSO
+h1: SSH Authentication with Okta
 ---
-
-# SSH Authentication with Okta
 
 ## How to use Okta as a single sign-on (SSO) provider for SSH
 

--- a/docs/4.4/pages/enterprise/sso/ssh-one-login.md
+++ b/docs/4.4/pages/enterprise/sso/ssh-one-login.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication with One Login as an SSO provider
 description: How to configure SSH access using One Login as an SSO provider
+h1: SSH Authentication with OneLogin
 ---
-
-# SSH Authentication with OneLogin
 
 ## Using OneLogin as a single sign-on (SSO) provider for SSH
 

--- a/docs/4.4/pages/enterprise/sso/ssh-sso.md
+++ b/docs/4.4/pages/enterprise/sso/ssh-sso.md
@@ -1,9 +1,8 @@
 ---
 title: SSO for SSH
 description: How to set up single sign-on (SSO) for SSH using Gravitational Teleport
+h1: Single Sign-On (SSO) for SSH
 ---
-
-# Single Sign-On (SSO) for SSH
 
 The commercial edition of Teleport allows users to login and retrieve their SSH
 credentials through a [Single Sign-On](https://en.wikipedia.org/wiki/Single_sign-on)

--- a/docs/4.4/pages/enterprise/workflow/index.md
+++ b/docs/4.4/pages/enterprise/workflow/index.md
@@ -1,9 +1,8 @@
 ---
 title: Approval Workflows for SSH and Kubernetes Access
 description: How to customize SSH and Kubernetes access using Teleport.
+h1: Teleport Approval Workflows
 ---
-
-# Teleport Approval Workflows
 
 #### Approving Workflow using an External Integration
 - [Integrating Teleport with Slack](ssh-approval-slack.md)

--- a/docs/4.4/pages/enterprise/workflow/ssh-approval-jira-cloud.md
+++ b/docs/4.4/pages/enterprise/workflow/ssh-approval-jira-cloud.md
@@ -1,9 +1,8 @@
 ---
 title: SSH login approval using Jira and Teleport
 description: How to configure SSH login approval using Jira and Teleport
+h1: SSH login approvals using Jira
 ---
-
-# SSH login approvals using Jira
 
 ## Teleport Jira Plugin Setup
 

--- a/docs/4.4/pages/enterprise/workflow/ssh-approval-jira-server.md
+++ b/docs/4.4/pages/enterprise/workflow/ssh-approval-jira-server.md
@@ -1,9 +1,8 @@
 ---
 title: SSH login approval using Jira Server and Teleport
 description: How to configure SSH login approval using Jira Server and Teleport
+h1: SSH login approvals using Jira Server
 ---
-
-# SSH login approvals using Jira Server
 
 ## Teleport Jira Server Plugin Setup
 

--- a/docs/4.4/pages/enterprise/workflow/ssh-approval-mattermost.md
+++ b/docs/4.4/pages/enterprise/workflow/ssh-approval-mattermost.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport integration with Mattermost
 description: This guide explains how to setup a Mattermost plugin for Teleport for privilege elevation approvals.
+h1: Teleport Mattermost Plugin Setup
 ---
-
-# Teleport Mattermost Plugin Setup
 
 This guide will talk through how to setup Teleport with Mattermost. Teleport to
 Mattermost integration allows teams to approve or deny Teleport access requests

--- a/docs/4.4/pages/enterprise/workflow/ssh-approval-pagerduty.md
+++ b/docs/4.4/pages/enterprise/workflow/ssh-approval-pagerduty.md
@@ -1,9 +1,8 @@
 ---
 title: SSH login approval via Pager Duty
 description: How to configure SSH login approval using PagerDuty and Teleport
+h1: SSH Login Approval using PagerDuty
 ---
-
-# SSH Login Approval using PagerDuty
 
 ## Teleport Pagerduty Plugin Setup
 

--- a/docs/4.4/pages/enterprise/workflow/ssh-approval-slack.md
+++ b/docs/4.4/pages/enterprise/workflow/ssh-approval-slack.md
@@ -1,9 +1,9 @@
 ---
 title: Teleport integration with Slack
 description: This guide explains how to setup a Slack plugin for Teleport for privilege elevation approvals.
+h1: Teleport Slack Plugin Setup
 ---
 
-# Teleport Slack Plugin Setup
 This guide will talk through how to setup Teleport with Slack. Teleport to Slack integration allows you to treat Teleport access and permission requests via Slack message and inline interactive components.
 
 !!! warning

--- a/docs/4.4/pages/faq.md
+++ b/docs/4.4/pages/faq.md
@@ -1,10 +1,8 @@
 ---
 title: Teleport FAQ
 description: Frequently Asked Questions about using Teleport for SSH and Kubernetes access
+h1: FAQ
 ---
-
-
-# FAQ
 
 ## Community FAQ
 

--- a/docs/4.4/pages/features/enhanced-session-recording.md
+++ b/docs/4.4/pages/features/enhanced-session-recording.md
@@ -1,9 +1,9 @@
 ---
 title: Session Recording for SSH and Kubernetes
 description: How to record your SSH and Kubernetes sessions into the audit log.
+h1: Enhanced Session Recording
 ---
 
-# Enhanced Session Recording
 Teleport [SSH and Kubernetes session recording](../architecture/nodes.md#session-recording)
 feature captures what is echoed to a terminal.
 

--- a/docs/4.4/pages/features/ssh-pam.md
+++ b/docs/4.4/pages/features/ssh-pam.md
@@ -1,15 +1,13 @@
 ---
 title: Configuring Teleport SSH with PAM (pluggable authentication modules)
 description: How to configure Teleport SSH access to play nicely with PAM (pluggable authentication modules)
+h1: Pluggable Authentication Modules (PAM)
 ---
-
-# Pluggable Authentication Modules (PAM)
 
 Teleport's node service can be configured to integrate with [PAM](https://en.wikipedia.org/wiki/Linux_PAM). This allows Teleport to create user sessions using PAM session profiles.
 
 Teleport only supports the `auth`, `account` and `session` stack. The `auth`
 stack is optional and not used by default.
-
 
 ## Introduction to Pluggable Authentication Modules
 

--- a/docs/4.4/pages/gcp-guide.md
+++ b/docs/4.4/pages/gcp-guide.md
@@ -1,9 +1,8 @@
 ---
 title: Running Teleport on GCP
 description: How to install and configure Gravitational Teleport on GCP for SSH and Kubernetes access.
+h1: Running Teleport on GCP
 ---
-
-# Running Teleport on GCP
 
 We've created this guide to give customers a high level overview of how to use Teleport
 on [Google Cloud](https://cloud.google.com/gcp/) (GCP). This guide provides a high level

--- a/docs/4.4/pages/ibm-cloud-guide.md
+++ b/docs/4.4/pages/ibm-cloud-guide.md
@@ -3,8 +3,6 @@ title: Running Teleport on IBM Cloud
 description: How to install and configure Gravitational Teleport on IBM cloud for SSH and Kubernetes access.
 ---
 
-# Running Teleport on IBM Cloud
-
 We've created this guide to give customers a high level overview of how to use Teleport
 on the [IBM Cloud](https://www.ibm.com/cloud). This guide provides a high level
 introduction leading to a deep dive into how to setup and run Teleport in production.

--- a/docs/4.4/pages/index.md
+++ b/docs/4.4/pages/index.md
@@ -1,10 +1,8 @@
 ---
 title: Introduction to Teleport
 description: How to install and quickly get up and running with Gravitational Teleport to set up SSH and Kubernetes access to cloud environments.
+h1: Introduction
 ---
-
-# Introduction
-
 ## What is Teleport?
 
 Gravitational Teleport is a gateway for managing access to clusters of Linux

--- a/docs/4.4/pages/installation.md
+++ b/docs/4.4/pages/installation.md
@@ -1,9 +1,8 @@
 ---
 title: Installing Teleport
 description: The guide for installing Teleport on servers and into Kubernetes clusters
+h1: Installation
 ---
-
-# Installation
 
 Teleport core service [`teleport`](cli-docs.md#teleport) and admin tool [`tctl`](cli-docs.md#tctl) have been designed to run on **Linux** and **Mac** operating systems. The Teleport user client [`tsh`](cli-docs.md#tsh) and UI are available for **Linux, Mac** and **Windows** operating systems.
 

--- a/docs/4.4/pages/kubernetes-ssh.md
+++ b/docs/4.4/pages/kubernetes-ssh.md
@@ -1,9 +1,8 @@
 ---
 title: Kubernetes Access Guide
 description: How to set up and configure Teleport for Kubernetes access with SSO and RBAC
+h1: Teleport Kubernetes Access Guide
 ---
-
-# Teleport Kubernetes Access Guide
 
 Teleport has the ability to act as a compliance gateway for managing privileged
 access to Kubernetes clusters. This enables the following capabilities:

--- a/docs/4.4/pages/metrics-logs-reference.md
+++ b/docs/4.4/pages/metrics-logs-reference.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Metrics
 description: How to set up Prometheus to monitor Teleport for SSH and Kubernetes access
+h1: Metrics
 ---
-
-# Metrics
 
 ## Teleport Prometheus Endpoint
 

--- a/docs/4.4/pages/openssh-teleport.md
+++ b/docs/4.4/pages/openssh-teleport.md
@@ -3,8 +3,6 @@ title: Using Teleport with OpenSSH
 description: How to use Teleport on legacy systems with OpenSSH and sshd
 ---
 
-# Using Teleport with OpenSSH
-
 Teleport is fully compatible with OpenSSH and can be quickly setup to record and
 audit all SSH activity. Using Teleport and OpenSSH has the advantage of getting you up
 and running, but in the long run we would recommend replacing `sshd` with `teleport`.

--- a/docs/4.4/pages/preview/teleport-application-access.md
+++ b/docs/4.4/pages/preview/teleport-application-access.md
@@ -1,4 +1,6 @@
-# Teleport Application Access Preview
+---
+title: Teleport Application Access Preview
+---
 
 Teleport is currently beta testing an application access proxy. Teleport Application Access has been designed to secure internal web applications, letting you provide secure access while improving both visibility and control for access.
 

--- a/docs/4.4/pages/preview/teleport-database-access.md
+++ b/docs/4.4/pages/preview/teleport-database-access.md
@@ -1,4 +1,6 @@
-# Teleport Database Access Preview
+---
+title: Teleport Database Access Preview
+---
 
 Teleport Database Access allows organizations to use Teleport as a proxy to
 provide secure access to their databases while improving both visibility and

--- a/docs/4.4/pages/production.md
+++ b/docs/4.4/pages/production.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Production Guide
 description: How to configure SSH and Kubernetes access with SSO on AWS, GCE and your own infrastructure.
+h1: Production Guide
 ---
-
-# Production Guide
 
 This guide provides more in-depth details for running Teleport in Production.
 

--- a/docs/4.4/pages/quickstart-docker.md
+++ b/docs/4.4/pages/quickstart-docker.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Quick Start guide with Docker
 description: How to get started with Teleport using Docker for SSH access
+h1: Run Teleport using Docker
 ---
-
-# Run Teleport using Docker
 
 We provide pre-built Docker images for every version of Teleport. These images are hosted on quay.io.
 

--- a/docs/4.4/pages/quickstart.md
+++ b/docs/4.4/pages/quickstart.md
@@ -3,8 +3,6 @@ title: Teleport Quick Start
 description: The quick start guide for how to set up modern SSH access to cloud or edge infrastructure.
 ---
 
-# Teleport Quick Start
-
 This tutorial will guide you through the steps needed to install and run
 Teleport on a single node, which could be your local machine but we recommend a
 VM.

--- a/docs/4.4/pages/trustedclusters.md
+++ b/docs/4.4/pages/trustedclusters.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Trusted Clusters
 description: How to configure access and trust between two SSH and Kubernetes environments
+h1: Trusted Clusters
 ---
-
-# Trusted Clusters
 
 The design of trusted clusters allows Teleport users to connect to compute infrastructure
 located behind firewalls without any open TCP ports. The real world usage examples of this

--- a/docs/4.4/pages/user-manual.md
+++ b/docs/4.4/pages/user-manual.md
@@ -3,8 +3,6 @@ title: Teleport User Manual
 description: Manual for how to manage user identities, share sessions for SSH and Kubernetes access using the command line and the Web UI.
 ---
 
-# Teleport User Manual
-
 This User Manual covers usage of the Teleport client tool, `tsh` and Teleport's Web interface.
 
 In this document you will learn how to:

--- a/docs/5.0/pages/admin-guide.md
+++ b/docs/5.0/pages/admin-guide.md
@@ -3,8 +3,6 @@ title: Teleport Admin Manual
 description: Admin manual for how to configure identity-aware SSH, certificate-based SSH authentication, set up SSO for SSH, SSO for Kubernetes, and more.
 ---
 
-# Teleport Admin Manual
-
 This manual covers the installation and configuration of Teleport and the
 ongoing management of a Teleport cluster. It assumes that the reader has good
 understanding of Linux administration.

--- a/docs/5.0/pages/api-reference.md
+++ b/docs/5.0/pages/api-reference.md
@@ -3,8 +3,6 @@ title: Teleport API Reference
 description: The detailed guide to Teleport API
 ---
 
-# Teleport API Reference
-
 In most cases, you can interact with Teleport using our CLI tools, [tsh](cli-docs.md#tsh) and [tctl](cli-docs.md#tctl). However, there are some scenarios where you may need to interact with Teleport programmatically. For this purpose, you can directly use the same API that `tctl` and `tsh` use.
 
 !!! note

--- a/docs/5.0/pages/application-access.md
+++ b/docs/5.0/pages/application-access.md
@@ -1,11 +1,11 @@
 ---
 title: Application Access Guide
 description: How to set up and configure Teleport for Application access with SSO and RBAC
+h1: Upcoming Teleport Releases
 ---
 
-# Teleport Application Access
-
 ## Introduction
+
 Teleport Application Access has been designed to provide secure access to internal dashboards and applications, building on Teleport's strong foundations of security and identity. You can now put applications onto the internet safely and securely.
 
 You can secure any web application using application access:

--- a/docs/5.0/pages/architecture/authentication.md
+++ b/docs/5.0/pages/architecture/authentication.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Authentication Service, SSH and Kubernetes certificates
 description: This chapter explains the concept of a Teleport Auth Service and Certificate Authority (CA) to issue SSH and Kubernetes certificates.
+h1: Teleport Authentication Service
 ---
-
-# Teleport Authentication Service
 
 This document outlines the Teleport Authentication Service and Certificate
 Management. It explains how Users and Nodes are identified and granted access to

--- a/docs/5.0/pages/architecture/nodes.md
+++ b/docs/5.0/pages/architecture/nodes.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Nodes
 description: This chapter explains the concept of a Teleport Node and Teleport manages SSH and Kubernetes nodes.
+h1: Teleport Nodes
 ---
-
-# Teleport Nodes
 
 Teleport calls any computing device (server, VM, AWS intance, etc) a "node".
 

--- a/docs/5.0/pages/architecture/overview.md
+++ b/docs/5.0/pages/architecture/overview.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Architecture Overview
 description: Basic concepts and architecture of Teleport. What is an SSH cluster? How certificate-based SSH authentication works? How SSH audit works?
+h1: Architecture Introduction
 ---
-
-# Architecture Introduction
 
 This guide is for those looking for a deeper understanding of Teleport. If you
 are looking for hands-on instructions on how to set up Teleport for your team,

--- a/docs/5.0/pages/architecture/proxy.md
+++ b/docs/5.0/pages/architecture/proxy.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Proxy Service
 description: How Teleport implements SSH and Kubernetes access via a Proxy
+h1: The Proxy Service
 ---
-
-# The Proxy Service
 
 The proxy is a stateless service which performs three main functions in a
 Teleport cluster:

--- a/docs/5.0/pages/architecture/users.md
+++ b/docs/5.0/pages/architecture/users.md
@@ -1,12 +1,10 @@
 ---
 title: Teleport Users
 description: This chapter explains the concept of a Teleport User and how it's different from operating system (OS) users or Kubernetes users.
+h1: Teleport Users
 ---
 
-# Teleport Users
-
 <!-- TODO: This doc is incomplete, pending addition of Enterprise topics -->
-
 
 ## Types of Users
 

--- a/docs/5.0/pages/aws-oss-guide.md
+++ b/docs/5.0/pages/aws-oss-guide.md
@@ -3,8 +3,6 @@ title: Running Teleport on AWS
 description: How to install and configure Gravitational Teleport on AWS for SSH and Kubernetes access.
 ---
 
-# Running Teleport on AWS
-
 We've created this guide to give customers a high level overview of how to use Teleport
 on Amazon Web Services (AWS). This guide provides a high level introduction leading to
 a deep dive into how to setup and run Teleport in production.

--- a/docs/5.0/pages/aws-terraform-guide.md
+++ b/docs/5.0/pages/aws-terraform-guide.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport HA mode on AWS
 description: How to configure Teleport in highly available (HA) mode for AWS deployments
+h1: Running Teleport Enterprise in HA mode on AWS
 ---
-
-# Running Teleport Enterprise in HA mode on AWS
 
 This guide is designed to accompany our [reference Terraform code](https://github.com/gravitational/teleport/tree/master/examples/aws/terraform/ha-autoscale-cluster#terraform-based-provisioning-example-amazon-single-ami)
 and describe how to use and administrate the resulting Teleport deployment.

--- a/docs/5.0/pages/cli-docs.md
+++ b/docs/5.0/pages/cli-docs.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport CLI Reference
 description: The detailed guide for Teleport command line (CLI) tools
+h1: Command Line (CLI) Reference
 ---
-
-# Command Line (CLI) Reference
 
 Teleport is made up of three CLI tools.
 

--- a/docs/5.0/pages/config-reference.md
+++ b/docs/5.0/pages/config-reference.md
@@ -3,8 +3,6 @@ title: Teleport Configuration Reference
 description: The detailed guide for configuring Teleport for SSH and Kubernetes access
 ---
 
-# Teleport Configuration Reference
-
 ## teleport.yaml
 
 Teleport uses the YAML file format for configuration. A full configuration reference

--- a/docs/5.0/pages/docs.md
+++ b/docs/5.0/pages/docs.md
@@ -1,4 +1,6 @@
-# Quickstart
+---
+title: Quickstart
+---
 
 Documentation is hard. Without structure over time it turns into a random collection of articles.
 

--- a/docs/5.0/pages/docs/best-practices.md
+++ b/docs/5.0/pages/docs/best-practices.md
@@ -1,4 +1,6 @@
-# Docs Best Practices
+---
+title: Docs Best Practices
+---
 
 ## Content
 

--- a/docs/5.0/pages/enterprise/introduction.md
+++ b/docs/5.0/pages/enterprise/introduction.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Enterprise
 description: Introduction to features and benefits of using Teleport Enterprise. Why upgrade to Teleport Enterprise?
+h1: Teleport Enterprise
 ---
-
-# Teleport Enterprise
 
 This section will give an overview of Teleport Enterprise, the commercial product built around
 the open source Teleport Community core. For those that want to jump right in, you can play

--- a/docs/5.0/pages/enterprise/quickstart-enterprise.md
+++ b/docs/5.0/pages/enterprise/quickstart-enterprise.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Enterprise Quick Start
 description: How to set up and configure Teleport Enterprise for SSH and Kubernetes access
+h1: Teleport Enterprise Quick Start
 ---
-
-# Teleport Enterprise Quick Start
 
 Welcome to the Quick Start Guide for Teleport Enterprise.
 

--- a/docs/5.0/pages/enterprise/ssh-kubernetes-fedramp.md
+++ b/docs/5.0/pages/enterprise/ssh-kubernetes-fedramp.md
@@ -1,10 +1,8 @@
 ---
 title: FedRAMP compliance for SSH and Kubernetes
 description: How to configure SSH and Kubernetes access to be FedRAMP compliant, including support for FIPS 140-2
+h1: FedRAMP for SSH and Kubernetes Access
 ---
-
-
-# FedRAMP for SSH and Kubernetes Access
 
 With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
 the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high

--- a/docs/5.0/pages/enterprise/ssh-rbac.md
+++ b/docs/5.0/pages/enterprise/ssh-rbac.md
@@ -1,10 +1,8 @@
 ---
 title: Role Based Access Control for SSH and Kubernetes
 description: How to configure Teleport to provide unified Role Based Access Control for SSH and Kubernetes
+h1: Role Based Access Control for SSH & K8s
 ---
-
-# Role Based Access Control for SSH & K8s
-
 ## Introduction
 
 Role Based Access Control (RBAC) gives Teleport administrators more

--- a/docs/5.0/pages/enterprise/sso/oidc.md
+++ b/docs/5.0/pages/enterprise/sso/oidc.md
@@ -1,9 +1,8 @@
 ---
 title: OAuth2 and OIDC authentication for SSH
 description: How to configure SSH access with OAuth2 or OIDC (OpenID connect) using Teleport
+h1: OAuth2 / OIDC Authentication for SSH
 ---
-
-# OAuth2 / OIDC Authentication for SSH
 
 This guide will cover how to configure an SSO provider using [OpenID Connect](http://openid.net/connect/)
 (also known as OIDC) to issue SSH credentials to a specific groups of users.

--- a/docs/5.0/pages/enterprise/sso/ssh-adfs.md
+++ b/docs/5.0/pages/enterprise/sso/ssh-adfs.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication With ADFS How To
 description: How to configure SSH access with Active Directory (ADFS) using Teleport
+h1: SSH Authentication with ADFS
 ---
-
-# SSH Authentication with ADFS
 
 ## Active Directory as an SSO provider for SSH authentication
 

--- a/docs/5.0/pages/enterprise/sso/ssh-azuread.md
+++ b/docs/5.0/pages/enterprise/sso/ssh-azuread.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication with Active Directory (AD) on Azure
 description: How to configure SSH access with Active Directory (AD) on Azure using Teleport
+h1: SSH Authentication with Azure Active Directory (AD)
 ---
-
-# SSH Authentication with Azure Active Directory (AD)
 
 This guide will cover how to configure [Microsoft Azure Active Directory](https://azure.microsoft.com/en-us/services/active-directory/) to issue
 SSH credentials to specific groups of users with a SAML Authentication Connector. When used in combination with role

--- a/docs/5.0/pages/enterprise/sso/ssh-gsuite.md
+++ b/docs/5.0/pages/enterprise/sso/ssh-gsuite.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication With Google Apps (G Suite)
 description: How to configure SSH access with Google Apps (also known as G Suite) using Teleport
+h1: SSH Authentication with G Suite (Google Apps)
 ---
-
-# SSH Authentication with G Suite (Google Apps)
 
 ## Google Apps as SSO for SSH
 

--- a/docs/5.0/pages/enterprise/sso/ssh-okta.md
+++ b/docs/5.0/pages/enterprise/sso/ssh-okta.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication With Okta as an SSO provider
 description: How to configure SSH access using Okta for SSO
+h1: SSH Authentication with Okta
 ---
-
-# SSH Authentication with Okta
 
 ## How to use Okta as a single sign-on (SSO) provider for SSH
 

--- a/docs/5.0/pages/enterprise/sso/ssh-one-login.md
+++ b/docs/5.0/pages/enterprise/sso/ssh-one-login.md
@@ -1,9 +1,8 @@
 ---
 title: SSH Authentication with One Login as an SSO provider
 description: How to configure SSH access using One Login as an SSO provider
+h1: SSH Authentication with OneLogin
 ---
-
-# SSH Authentication with OneLogin
 
 ## Using OneLogin as a single sign-on (SSO) provider for SSH
 

--- a/docs/5.0/pages/enterprise/sso/ssh-sso.md
+++ b/docs/5.0/pages/enterprise/sso/ssh-sso.md
@@ -1,9 +1,8 @@
 ---
 title: SSO for SSH
 description: How to set up single sign-on (SSO) for SSH using Gravitational Teleport
+h1: Single Sign-On (SSO) for SSH
 ---
-
-# Single Sign-On (SSO) for SSH
 
 The commercial edition of Teleport allows users to login and retrieve their SSH
 credentials through a [Single Sign-On](https://en.wikipedia.org/wiki/Single_sign-on)

--- a/docs/5.0/pages/enterprise/workflow/index.md
+++ b/docs/5.0/pages/enterprise/workflow/index.md
@@ -1,9 +1,8 @@
 ---
 title: Access Workflows for SSH and Kubernetes Access
 description: How to customize SSH and Kubernetes access using Teleport.
+h1: Teleport Access Workflows
 ---
-
-# Teleport Access Workflows
 
 #### Approving Workflow using an External Integration
 - [Integrating Teleport with Slack](ssh-approval-slack.md)

--- a/docs/5.0/pages/enterprise/workflow/ssh-approval-jira-cloud.md
+++ b/docs/5.0/pages/enterprise/workflow/ssh-approval-jira-cloud.md
@@ -1,9 +1,8 @@
 ---
 title: SSH login approval using Jira and Teleport
 description: How to configure SSH login approval using Jira and Teleport
+h1: SSH login approvals using Jira
 ---
-
-# SSH login approvals using Jira
 
 ## Teleport Jira Plugin Setup
 

--- a/docs/5.0/pages/enterprise/workflow/ssh-approval-jira-server.md
+++ b/docs/5.0/pages/enterprise/workflow/ssh-approval-jira-server.md
@@ -1,9 +1,8 @@
 ---
 title: SSH login approval using Jira Server and Teleport
 description: How to configure SSH login approval using Jira Server and Teleport
+h1: SSH login approvals using Jira Server
 ---
-
-# SSH login approvals using Jira Server
 
 ## Teleport Jira Server Plugin Setup
 

--- a/docs/5.0/pages/enterprise/workflow/ssh-approval-mattermost.md
+++ b/docs/5.0/pages/enterprise/workflow/ssh-approval-mattermost.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport integration with Mattermost
 description: This guide explains how to setup a Mattermost plugin for Teleport for privilege elevation approvals.
+h1: Teleport Mattermost Plugin Setup
 ---
-
-# Teleport Mattermost Plugin Setup
 
 This guide will talk through how to setup Teleport with Mattermost. Teleport to
 Mattermost integration allows teams to approve or deny Teleport access requests

--- a/docs/5.0/pages/enterprise/workflow/ssh-approval-pagerduty.md
+++ b/docs/5.0/pages/enterprise/workflow/ssh-approval-pagerduty.md
@@ -1,9 +1,8 @@
 ---
 title: SSH login approval via Pager Duty
 description: How to configure SSH login approval using PagerDuty and Teleport
+h1: SSH Login Approval using PagerDuty
 ---
-
-# SSH Login Approval using PagerDuty
 
 ## Teleport Pagerduty Plugin Setup
 

--- a/docs/5.0/pages/enterprise/workflow/ssh-approval-slack.md
+++ b/docs/5.0/pages/enterprise/workflow/ssh-approval-slack.md
@@ -1,9 +1,9 @@
 ---
 title: Teleport integration with Slack
 description: This guide explains how to setup a Slack plugin for Teleport for privilege elevation approvals.
+h1: Teleport Slack Plugin Setup
 ---
 
-# Teleport Slack Plugin Setup
 This guide will talk through how to setup Teleport with Slack. Teleport to Slack integration allows you to treat Teleport access and permission requests via Slack message and inline interactive components.
 
 !!! warning

--- a/docs/5.0/pages/faq.md
+++ b/docs/5.0/pages/faq.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport FAQ
 description: Frequently Asked Questions about using Teleport for SSH and Kubernetes access
+h1: FAQ
 ---
-
-# FAQ
 
 ## Community FAQ
 

--- a/docs/5.0/pages/features/enhanced-session-recording.md
+++ b/docs/5.0/pages/features/enhanced-session-recording.md
@@ -1,9 +1,9 @@
 ---
 title: Session Recording for SSH and Kubernetes
 description: How to record your SSH and Kubernetes sessions into the audit log.
+h1: Enhanced Session Recording
 ---
 
-# Enhanced Session Recording
 Teleport [SSH and Kubernetes session recording](../architecture/nodes.md#session-recording)
 feature captures what is echoed to a terminal.
 

--- a/docs/5.0/pages/features/ssh-pam.md
+++ b/docs/5.0/pages/features/ssh-pam.md
@@ -1,15 +1,13 @@
 ---
 title: Configuring Teleport SSH with PAM (pluggable authentication modules)
 description: How to configure Teleport SSH access to play nicely with PAM (pluggable authentication modules)
+h1: Pluggable Authentication Modules (PAM)
 ---
-
-# Pluggable Authentication Modules (PAM)
 
 Teleport's node service can be configured to integrate with [PAM](https://en.wikipedia.org/wiki/Linux_PAM). This allows Teleport to create user sessions using PAM session profiles.
 
 Teleport only supports the `auth`, `account` and `session` stack. The `auth`
 stack is optional and not used by default.
-
 
 ## Introduction to Pluggable Authentication Modules
 

--- a/docs/5.0/pages/gcp-guide.md
+++ b/docs/5.0/pages/gcp-guide.md
@@ -3,8 +3,6 @@ title: Running Teleport on GCP
 description: How to install and configure Gravitational Teleport on GCP for SSH and Kubernetes access.
 ---
 
-# Running Teleport on GCP
-
 We've created this guide to give customers a high level overview of how to use Teleport
 on [Google Cloud](https://cloud.google.com/gcp/) (GCP). This guide provides a high level
 introduction leading to a deep dive into how to setup and run Teleport in production.

--- a/docs/5.0/pages/ibm-cloud-guide.md
+++ b/docs/5.0/pages/ibm-cloud-guide.md
@@ -3,8 +3,6 @@ title: Running Teleport on IBM Cloud
 description: How to install and configure Gravitational Teleport on IBM cloud for SSH and Kubernetes access.
 ---
 
-# Running Teleport on IBM Cloud
-
 We've created this guide to give customers a high level overview of how to use Teleport
 on the [IBM Cloud](https://www.ibm.com/cloud). This guide provides a high level
 introduction leading to a deep dive into how to setup and run Teleport in production.

--- a/docs/5.0/pages/index.md
+++ b/docs/5.0/pages/index.md
@@ -1,9 +1,8 @@
 ---
 title: Introduction to Teleport
 description: How to install and quickly get up and running with Teleport to set up SSH and Kubernetes access to cloud environments.
+h1: Introduction
 ---
-
-# Introduction
 
 ## What is Teleport?
 

--- a/docs/5.0/pages/installation.md
+++ b/docs/5.0/pages/installation.md
@@ -1,9 +1,8 @@
 ---
 title: Installing Teleport
 description: The guide for installing Teleport on servers and into Kubernetes clusters
+h1: Installation
 ---
-
-# Installation
 
 Teleport core service [`teleport`](cli-docs.md#teleport) and admin tool [`tctl`](cli-docs.md#tctl) have been designed to run on **Linux** and **Mac** operating systems. The Teleport user client [`tsh`](cli-docs.md#tsh) and UI are available for **Linux, Mac** and **Windows** operating systems.
 

--- a/docs/5.0/pages/kubernetes-5.0-migration.md
+++ b/docs/5.0/pages/kubernetes-5.0-migration.md
@@ -1,9 +1,8 @@
 ---
 title: Kubernetes 5.0 Migration Guide
 description: How to migrate pre-5.0 Teleport clusters to new configuration
+h1: Migrating to Teleport Kubernetes Access 5.0
 ---
-
-# Migrating to Teleport Kubernetes Access 5.0
 
 In release 5.0, Teleport has changed the [Kubernetes
 integration](kubernetes-access.md) to improve configuration and user experience.

--- a/docs/5.0/pages/kubernetes-access.md
+++ b/docs/5.0/pages/kubernetes-access.md
@@ -1,9 +1,8 @@
 ---
 title: Kubernetes Access Guide
 description: How to set up and configure Teleport for Kubernetes access with SSO and RBAC
+h1: Teleport Kubernetes Access
 ---
-
-# Teleport Kubernetes Access
 
 Teleport handles SSO and provides a unified access plane for Kubernetes clusters.
 

--- a/docs/5.0/pages/metrics-logs-reference.md
+++ b/docs/5.0/pages/metrics-logs-reference.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Metrics
 description: How to set up Prometheus to monitor Teleport for SSH and Kubernetes access
+h1: Metrics
 ---
-
-# Metrics
 
 ## Teleport Prometheus Endpoint
 

--- a/docs/5.0/pages/openssh-teleport.md
+++ b/docs/5.0/pages/openssh-teleport.md
@@ -3,8 +3,6 @@ title: Using Teleport with OpenSSH
 description: How to use Teleport on legacy systems with OpenSSH and sshd
 ---
 
-# Using Teleport with OpenSSH
-
 Teleport is fully compatible with OpenSSH and can be quickly setup to record and
 audit all SSH activity. Using Teleport and OpenSSH has the advantage of getting you up
 and running, but in the long run we would recommend replacing `sshd` with `teleport`.

--- a/docs/5.0/pages/preview/cloud.md
+++ b/docs/5.0/pages/preview/cloud.md
@@ -3,8 +3,6 @@ title: Teleport Cloud Preview
 description: Teleport hosted and managed by the Teleport team.
 ---
 
-# Teleport Cloud Preview
-
 Teleport Cloud is a hosted, managed Teleport cluster.
 Currently Teleport Cloud is in preview status and we are maintaining a
 wait-list of interested parties wanting access to the service.

--- a/docs/5.0/pages/preview/database-access.md
+++ b/docs/5.0/pages/preview/database-access.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Database Access
 description: Secure and Audited Access to Postgres Databases. Documentation to outline our preview.
+h1: Teleport Database Access Preview
 ---
-
-# Teleport Database Access Preview
 
 Teleport Database Access allows organizations to use Teleport as a proxy to
 provide secure access to their databases while improving both visibility and

--- a/docs/5.0/pages/preview/upcoming-releases.md
+++ b/docs/5.0/pages/preview/upcoming-releases.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Upcoming Releases
 description: A timeline of upcoming Teleport releases.
+h1: Upcoming Teleport Releases
 ---
-
-# Upcoming Teleport Releases
 
 The teleport team delivers a new major release roughly every 3 months.
 

--- a/docs/5.0/pages/production.md
+++ b/docs/5.0/pages/production.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Production Guide
 description: How to configure SSH and Kubernetes access with SSO on AWS, GCE and your own infrastructure.
+h1: Production Guide
 ---
-
-# Production Guide
 
 This guide provides more in-depth details for running Teleport in Production.
 

--- a/docs/5.0/pages/quickstart-docker.md
+++ b/docs/5.0/pages/quickstart-docker.md
@@ -1,9 +1,8 @@
 ---
 title: Getting started with Teleport using Docker
 description: How to get started with Teleport using Docker for SSH access
+h1: Run Teleport using Docker
 ---
-
-# Run Teleport using Docker
 
 We provide pre-built Docker images for every version of Teleport. These images are hosted on quay.io.
 

--- a/docs/5.0/pages/quickstart.md
+++ b/docs/5.0/pages/quickstart.md
@@ -3,8 +3,6 @@ title: Getting started with Teleport
 description: The getting started with guide for how to set up modern SSH access to cloud or edge infrastructure.
 ---
 
-# Getting started with Teleport
-
 This tutorial will guide you through the steps needed to install and run
 Teleport on Linux machine(s).
 

--- a/docs/5.0/pages/trustedclusters.md
+++ b/docs/5.0/pages/trustedclusters.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport Trusted Clusters
 description: How to configure access and trust between two SSH and Kubernetes environments
+h1: Trusted Clusters
 ---
-
-# Trusted Clusters
 
 The design of trusted clusters allows Teleport users to connect to compute infrastructure
 located behind firewalls without any open TCP ports. The real world usage examples of this

--- a/docs/5.0/pages/user-manual.md
+++ b/docs/5.0/pages/user-manual.md
@@ -1,9 +1,8 @@
 ---
 title: Teleport User Manual
 description: Manual for how to manage user identities, share sessions for SSH and Kubernetes access using the command line and the Web UI.
+h1: Teleport User Manual
 ---
-
-# Teleport User Manual
 
 This User Manual covers usage of the Teleport client tool, `tsh` and Teleport's Web interface.
 


### PR DESCRIPTION
- Moved all h1 (`#`) to frontmatter in the old files.
- In the new files if `#` and `title` has different values, added `h1` field to frontmetter with the `#` content.

New structure is this:

```
---
title: Title and h1 value if h1 is not set
description: Description value
h1: Optional field for h1 value that is different from title
---