### PR TITLE
Alen/chart updates

### DIFF
--- a/examples/chart/teleport/templates/config.yaml
+++ b/examples/chart/teleport/templates/config.yaml
@@ -40,8 +40,11 @@ data:
 {{ toYaml .Values.config.teleport.auth_service.authentication | indent 8 }}
       tokens:
 {{ toYaml .Values.config.teleport.auth_service.tokens | indent 8 }}
-
+{{- if .Values.config.auth_public_address_list }}
+      public_addr: {{ .Values.config.auth_public_address_list }}
+{{- else }}
       public_addr: {{ .Values.config.public_address }}:{{ .Values.service.ports.authssh.port }}
+{{- end }}
       cluster_name: {{ .Values.config.public_address }}
       listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.authssh.containerPort }}
       client_idle_timeout: {{ .Values.config.teleport.auth_service.client_idle_timeout }}
@@ -155,8 +158,11 @@ data:
       tokens:
 {{ toYaml .Values.config.teleport.auth_service.tokens | indent 8 }}
 {{- end }}
-
+{{- if .Values.config.auth_public_address_list }}
+      public_addr: {{ .Values.config.auth_public_address_list }}
+{{- else }}
       public_addr: {{ .Values.config.auth_public_address }}:{{ .Values.service.ports.authssh.port }}
+{{- end }}
       cluster_name: {{ .Values.config.public_address }}
       listen_addr: {{ .Values.config.listen_addr }}:{{ .Values.ports.authssh.containerPort }}
       client_idle_timeout: {{ .Values.config.teleport.auth_service.client_idle_timeout }}

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -52,6 +52,13 @@ config:
   # High availability configuration with proxy and auth servers. No configured SSH service.
   proxyCount: 2
   authCount: 2
+  
+  # Uncomment and set "auth_public_address_list" addresses if multiple domains resolve to same auth endpoint or
+  # if you want to add multiple SANs to the teleport cert
+  #auth_public_address_list:
+  #  - "auth1.example.com"
+  #  - "auth2.example.com"
+  
   auth_public_address: auth.example.com
   authService:
     type: ClusterIP


### PR DESCRIPTION
Modified teleport helm chart to allow configuration of multiple auth server addresses in list format in both single and HA configs.