### PR TITLE
Conditionally create a user in the build container

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -16,8 +16,9 @@ RUN apt-get install -q -y libc6-dev-i386
 RUN apt-get install -q -y net-tools
 RUN apt-get install -q -y tree
 
-RUN (groupadd jenkins --gid=$GID -o && useradd jenkins --uid=$UID --gid=$GID --create-home --shell=/bin/sh ;\
-     mkdir -p /var/lib/teleport && chown -R jenkins /var/lib/teleport)
+RUN (getent group  $GID || groupadd builder --gid=$GID -o && \
+     getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh; \
+     mkdir -p /var/lib/teleport && chown -R $UID:$GID /var/lib/teleport)
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz ;\


### PR DESCRIPTION
## Summary

We only want to create a user/group in the buildbox if that user/group don't already exist.  This allows the build to function when run as root (e.g. in a Drone CI kubernetes pipeline). Without this the bbox build may fail with the following error:

  useradd: UID 0 is not unique

As seen at https://drone.gravitational.io/gravitational/gravity/100/1/6

## Related Issues
This could be considered a partial backport of #3982, which solves the issue in a slightly different way (by declaring UID & GID = 1000).

Contributes to https://github.com/gravitational/gravity/pull/2415
Contributes to https://github.com/gravitational/ops/issues/139

## Notes
The need to build teleport from gravity is also mostly circumvented by https://github.com/gravitational/gravity/blob/e260f244036b31c8d92b3adcda6bf795707854d6/build.assets/Makefile#L502-L506, which will use a cached prebuilt version when available.  We only build from scratch (and thus hit this path) when teleport has been bumped, but the artifacts have not yet been published.  I'm still mulling over if there is worthwhie ROI to automating this publishing -- my gut feel is "not worth it".