### PR TITLE
Document supported storage backends

### DIFF
--- a/docs/5.0/pages/admin-guide.md
+++ b/docs/5.0/pages/admin-guide.md
@@ -1282,7 +1282,7 @@ stored data (size, read/write ratio, mutability, etc.).
 |-----------|-------------|----------------------------|
 | core cluster state | Cluster configuration (e.g. users, roles, auth connectors) and identity (e.g. certificate authorities, registered nodes, trusted clusters). | Local directory (SQLite), etcd, AWS DynamoDB, GCP Firestore |
 | audit events | JSON-encoded events from the audit log (e.g. user logins, RBAC changes) | Local directory, AWS DynamoDB, GCP Firestore |
-| session recordings | Raw terminal recordings of interactive user sessions | Local directory, AWS S3, GCP Cloud Storage |
+| session recordings | Raw terminal recordings of interactive user sessions | Local directory, AWS S3 (and any S3-compatible product), GCP Cloud Storage |
 | teleport instance state | ID and credentials of a non-auth teleport instance (e.g. node, proxy) | Local directory |
 
 The [High Availability](#high-availability) section describes how to configure

--- a/docs/5.0/pages/admin-guide.md
+++ b/docs/5.0/pages/admin-guide.md
@@ -1271,6 +1271,23 @@ Kubernetes API.
 Follow our [Kubernetes guide](kubernetes-access.md) which contains some more specific
 examples and instructions.
 
+## Storage backends
+
+A Teleport cluster stores different types of data in different locations. By
+default everything is stored in a local directory at the Auth server.
+Integration with other storage types is implemented based on the nature of the
+stored data (size, read/write ratio, mutability, etc.).
+
+| Data type | Description | Supported storage backends |
+|-----------|-------------|----------------------------|
+| core cluster state | Cluster configuration (e.g. users, roles, auth connectors) and identity (e.g. certificate authorities, registered nodes, trusted clusters). | Local directory (SQLite), etcd, AWS DynamoDB, GCP Firestore |
+| audit events | JSON-encoded events from the audit log (e.g. user logins, RBAC changes) | Local directory, AWS DynamoDB, GCP Firestore |
+| session recordings | Raw terminal recordings of interactive user sessions | Local directory, AWS S3, GCP Cloud Storage |
+| teleport instance state | ID and credentials of a non-auth teleport instance (e.g. node, proxy) | Local directory |
+
+The [High Availability](#high-availability) section describes how to configure
+non-default storage backends.
+
 ## High Availability
 
 !!! tip "Tip"


### PR DESCRIPTION
This explains 2 things to the reader that may not be obvious from other
docs:
- what data teleport needs to persist
- where that data can be persisted