### PR TITLE
kube: add kube_public_addr config field to proxy_service

### DIFF
--- a/docs/5.0/pages/config-reference.md
+++ b/docs/5.0/pages/config-reference.md
@@ -355,6 +355,8 @@ proxy_service:
       cert_file: /etc/letsencrypt/live/*.teleport.example.com/fullchain.pem
 
     kube_listen_addr: 0.0.0.0:3026
+    # optional: set a different public address for kubernetes access
+    kube_public_addr: kube.example.com:3026
 
 # This section configures the 'application service'
 app_service:

--- a/docs/5.0/pages/kubernetes-5.0-migration.md
+++ b/docs/5.0/pages/kubernetes-5.0-migration.md
@@ -152,7 +152,7 @@ auth_service:
   - kube:secret_static_join_token
 
 proxy_service:
-  public_addr: [root.example.com]
+  kube_public_addr: [root.example.com]
   kube_listen_addr: 0.0.0.0:3026
 
 ---
@@ -262,7 +262,7 @@ After 5.0:
 ```yaml
 # teleport.yaml
 proxy_service:
-  public_addr: [root.example.com]
+  kube_public_addr: [root.example.com]
   kube_listen_addr: 0.0.0.0:3026
 
 kubernetes_service:

--- a/docs/5.0/pages/kubernetes-access.md
+++ b/docs/5.0/pages/kubernetes-access.md
@@ -41,7 +41,7 @@ Let's take a closer look at the available Kubernetes settings:
 Connecting the Teleport proxy to Kubernetes.
 
 Teleport Auth And Proxy can be ran anywhere (inside or outside of k8s). The Teleport
-proxy must have `kube_listen_addr` set.
+proxy must have `kube_listen_addr` set and optionally `kube_public_addr` set.
 
 - Options for connecting k8s clusters:
     - `kubernetes_service` in a pod [Using our Helm Chart](https://github.com/gravitational/teleport/blob/master/examples/chart/teleport-kube-agent/README.md)
@@ -70,6 +70,8 @@ auth_service:
 proxy_service:
   public_addr: proxy.example.com:3080
   kube_listen_addr: 0.0.0.0:3027
+  # optional: set a different public address for kubernetes access
+  kube_public_addr: kube.example.com:3027
 ```
 
 To get quickly setup, we provide a Helm chart that'll connect to the above root cluster.
@@ -108,6 +110,8 @@ auth_service:
 proxy_service:
   public_addr: proxy.example.com:3080
   kube_listen_addr: 0.0.0.0:3026
+  # optional: set a different public address for kubernetes access
+  kube_public_addr: kube.example.com:3026
 
 kubernetes_service:
   enabled: yes

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -38,10 +38,12 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/gravitational/trace"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/check.v1"
+
+	"github.com/gravitational/trace"
 )
 
 type testConfigFiles struct {
@@ -1084,7 +1086,7 @@ func TestProxyKube(t *testing.T) {
 			cfg := &service.Config{}
 			err := applyProxyConfig(fc, cfg)
 			tt.checkErr(t, err)
-			require.Empty(t, cmp.Diff(cfg.Proxy.Kube, tt.want))
+			require.Empty(t, cmp.Diff(cfg.Proxy.Kube, tt.want, cmpopts.EquateEmpty()))
 		})
 	}
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -173,6 +173,7 @@ var (
 		"kubernetes_service":      true,
 		"kube_cluster_name":       false,
 		"kube_listen_addr":        false,
+		"kube_public_addr":        false,
 		"app_service":             true,
 		"db_service":              true,
 		"protocol":                false,
@@ -972,6 +973,8 @@ type Proxy struct {
 	// KubeAddr is a shorthand for enabling the Kubernetes endpoint without a
 	// local Kubernetes cluster.
 	KubeAddr string `yaml:"kube_listen_addr,omitempty"`
+	// KubePublicAddr is a public address of the kubernetes endpoint.
+	KubePublicAddr utils.Strings `yaml:"kube_public_addr,omitempty"`
 
 	// PublicAddr sets the hostport the proxy advertises for the HTTP endpoint.
 	// The hosts in PublicAddr are included in the list of host principals


### PR DESCRIPTION
With the introduction of `kube_listen_addr`, some users are confused on
how to set a public address for k8s access that's different from
`public_addr` of the proxy. `kube_public_addr` removes that confusion
and more closely resembles the other proxy endpoints.

This config:

```yaml
proxy_service:
  kube_listen_addr: 0.0.0.0:3026
  kube_public_addr: kube.example.com:3026
```

translates to the old format:

```yaml
proxy_service:
  kubernetes:
    enabled: yes
    listen_addr: 0.0.0.0:3026
    public_addr: kube.example.com:3026
```

Fixes https://github.com/gravitational/teleport/issues/5110