### PR TITLE
Add app and db access flags to license

### DIFF
--- a/api/types/role.go
+++ b/api/types/role.go
@@ -818,6 +818,12 @@ func NewBool(b bool) Bool {
 	return Bool(b)
 }
 
+// NewBoolP returns Bool pointer
+func NewBoolP(b bool) *Bool {
+	val := NewBool(b)
+	return &val
+}
+
 // Bool is a wrapper around boolean values
 type Bool bool
 

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 
@@ -77,6 +78,11 @@ func (s *Server) GenerateDatabaseCert(ctx context.Context, req *proto.DatabaseCe
 // SignDatabaseCSR generates a client certificate used by proxy when talking
 // to a remote database service.
 func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequest) (*proto.DatabaseCSRResponse, error) {
+	if !modules.GetModules().Features().DB {
+		return nil, trace.AccessDenied(
+			"this Teleport cluster doesn't support database access, please contact the cluster administrator")
+	}
+
 	log.Debugf("Signing database CSR for cluster %v.", req.ClusterName)
 
 	clusterName, err := s.GetClusterName()

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/lib/jwt"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -37,6 +38,11 @@ import (
 // The certificate is used for all access requests, which is where access
 // control is enforced.
 func (s *Server) CreateAppSession(ctx context.Context, req services.CreateAppSessionRequest, user services.User, checker services.AccessChecker) (services.WebSession, error) {
+	if !modules.GetModules().Features().App {
+		return nil, trace.AccessDenied(
+			"this Teleport cluster doesn't support application access, please contact the cluster administrator")
+	}
+
 	// Check that a matching parent web session exists in the backend.
 	parentSession, err := s.GetWebSession(ctx, types.GetWebSessionRequest{
 		User:      req.Username,

--- a/lib/services/license.go
+++ b/lib/services/license.go
@@ -46,6 +46,12 @@ const LicenseSpecV3Template = `{
 		"k8s": {
 			"type": ["string", "boolean"]
 		},
+		"app": {
+			"type": ["string", "boolean"]
+		},
+		"db": {
+			"type": ["string", "boolean"]
+		},
 		"cloud": {
 			"type": ["string", "boolean"]
 		}

--- a/lib/services/license_test.go
+++ b/lib/services/license_test.go
@@ -19,6 +19,7 @@ package services
 import (
 	"testing"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
 
@@ -45,38 +46,43 @@ func (l *LicenseSuite) TestUnmarshal(c *check.C) {
 	testCases := []testCase{
 		{
 			description: "simple case",
-			input:       `{"kind": "license", "version": "v3", "metadata": {"name": "Teleport Commercial"}, "spec": {"account_id": "accountID", "usage": true, "k8s": true, "aws_account": "123", "aws_pid": "4"}}`,
+			input:       `{"kind": "license", "version": "v3", "metadata": {"name": "Teleport Commercial"}, "spec": {"account_id": "accountID", "usage": true, "k8s": true, "app": true, "db": true, "aws_account": "123", "aws_pid": "4"}}`,
 			expected: MustNew("Teleport Commercial", LicenseSpecV3{
-				ReportsUsage:       NewBool(true),
-				SupportsKubernetes: NewBool(true),
-				Cloud:              NewBool(false),
-				AWSAccountID:       "123",
-				AWSProductID:       "4",
-				AccountID:          "accountID",
+				ReportsUsage:              NewBool(true),
+				SupportsKubernetes:        NewBool(true),
+				SupportsApplicationAccess: types.NewBoolP(true),
+				SupportsDatabaseAccess:    NewBool(true),
+				Cloud:                     NewBool(false),
+				AWSAccountID:              "123",
+				AWSProductID:              "4",
+				AccountID:                 "accountID",
 			}),
 		},
 		{
 			description: "simple case with string booleans",
-			input:       `{"kind": "license", "version": "v3", "metadata": {"name": "license"}, "spec": {"account_id": "accountID", "usage": "yes", "k8s": "yes", "aws_account": "123", "aws_pid": "4"}}`,
+			input:       `{"kind": "license", "version": "v3", "metadata": {"name": "license"}, "spec": {"account_id": "accountID", "usage": "yes", "k8s": "yes", "app": "yes", "db": "yes", "aws_account": "123", "aws_pid": "4"}}`,
 			expected: MustNew("license", LicenseSpecV3{
-				ReportsUsage:       NewBool(true),
-				SupportsKubernetes: NewBool(true),
-				Cloud:              NewBool(false),
-				AWSAccountID:       "123",
-				AWSProductID:       "4",
-				AccountID:          "accountID",
+				ReportsUsage:              NewBool(true),
+				SupportsKubernetes:        NewBool(true),
+				SupportsApplicationAccess: types.NewBoolP(true),
+				SupportsDatabaseAccess:    NewBool(true),
+				Cloud:                     NewBool(false),
+				AWSAccountID:              "123",
+				AWSProductID:              "4",
+				AccountID:                 "accountID",
 			}),
 		},
 		{
 			description: "with cloud flag",
 			input:       `{"kind": "license", "version": "v3", "metadata": {"name": "license"}, "spec": {"cloud": "yes", "account_id": "accountID", "usage": "yes", "k8s": "yes", "aws_account": "123", "aws_pid": "4"}}`,
 			expected: MustNew("license", LicenseSpecV3{
-				ReportsUsage:       NewBool(true),
-				SupportsKubernetes: NewBool(true),
-				Cloud:              NewBool(true),
-				AWSAccountID:       "123",
-				AWSProductID:       "4",
-				AccountID:          "accountID",
+				ReportsUsage:           NewBool(true),
+				SupportsKubernetes:     NewBool(true),
+				SupportsDatabaseAccess: NewBool(false),
+				Cloud:                  NewBool(true),
+				AWSAccountID:           "123",
+				AWSProductID:           "4",
+				AccountID:              "accountID",
 			}),
 		},
 		{

--- a/lib/srv/uacc/uacc_stub.go
+++ b/lib/srv/uacc/uacc_stub.go
@@ -20,7 +20,7 @@ limitations under the License.
 Package uacc concerns itself with updating the user account database and log on nodes
 that a client connects to with an interactive session.
 
-This is a stub version that doesn't do anything and exists purely for compatability purposes with systems we don't support.
+This is a stub version that doesn't do anything and exists purely for compatibility purposes with systems we don't support.
 
 We do not support macOS yet because they introduced ASL for user accounting with Mac OS X 10.6 (Snow Leopard)
 and integrating with that takes additional effort.


### PR DESCRIPTION
Add "supports application access" and "supports database access" flags to our license.

A note on the behavior:

* Application access is **enabled** if there's no flag in the license. This is to ensure backward compatibility. Otherwise it will stop working for all people with existing licenses who are already using AAP. I can change it to be disabled though if we need.
* Database access is **disabled** by default. We'll have to issue licenses with this flag set for enterprise folks to use it.

Here's what the behavior looks like if these features are disabled.

App access:

<img width="999" alt="Screen Shot 2021-02-18 at 12 26 11 PM" src="https://user-images.githubusercontent.com/339322/108430801-c96a1c00-71f6-11eb-9be8-dca05f7247f8.png">

Database access:

<img width="1087" alt="Screen Shot 2021-02-18 at 12 25 54 PM" src="https://user-images.githubusercontent.com/339322/108430815-cd963980-71f6-11eb-9472-a82aa627938e.png">
