### PR TITLE
Refactor lib/asciitable, lib/tlsca, lib/shell, lib/session and lib/config tests to not use gocheck

### DIFF
--- a/lib/asciitable/table_test.go
+++ b/lib/asciitable/table_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,15 +19,8 @@ package asciitable
 import (
 	"testing"
 
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
-
-func TestAsciiTable(t *testing.T) { check.TestingT(t) }
-
-type TableTestSuite struct {
-}
-
-var _ = check.Suite(&TableTestSuite{})
 
 const fullTable = `Name          Motto                            Age  
 ------------- -------------------------------- ---- 
@@ -39,19 +32,19 @@ const headlessTable = `one  two
 1    2    
 `
 
-func (s *TableTestSuite) TestFullTable(c *check.C) {
-	t := MakeTable([]string{"Name", "Motto", "Age"})
-	t.AddRow([]string{"Joe Forrester", "Trains are much better than cars", "40"})
-	t.AddRow([]string{"Jesus", "Read the bible", "2018"})
+func TestFullTable(t *testing.T) {
+	table := MakeTable([]string{"Name", "Motto", "Age"})
+	table.AddRow([]string{"Joe Forrester", "Trains are much better than cars", "40"})
+	table.AddRow([]string{"Jesus", "Read the bible", "2018"})
 
-	c.Assert(t.AsBuffer().String(), check.Equals, fullTable)
+	require.Equal(t, table.AsBuffer().String(), fullTable)
 }
 
-func (s *TableTestSuite) TestHeadlessTable(c *check.C) {
-	t := MakeHeadlessTable(2)
-	t.AddRow([]string{"one", "two", "three"})
-	t.AddRow([]string{"1", "2", "3"})
+func TestHeadlessTable(t *testing.T) {
+	table := MakeHeadlessTable(2)
+	table.AddRow([]string{"one", "two", "three"})
+	table.AddRow([]string{"1", "2", "3"})
 
 	// The table shall have no header and also the 3rd column must be chopped off.
-	c.Assert(t.AsBuffer().String(), check.Equals, headlessTable)
+	require.Equal(t, table.AsBuffer().String(), headlessTable)
 }

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -18,31 +18,22 @@ package config
 
 import (
 	"encoding/base64"
+	"fmt"
+	"testing"
 
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
-type FileTestSuite struct {
-}
-
-var _ = check.Suite(&FileTestSuite{})
-
-func (s *FileTestSuite) SetUpSuite(c *check.C) {
-}
-
-func (s *FileTestSuite) TearDownSuite(c *check.C) {
-}
-
-func (s *FileTestSuite) SetUpTest(c *check.C) {
-}
-
-func (s *FileTestSuite) TestAuthenticationSection(c *check.C) {
+func TestAuthenticationSection(t *testing.T) {
 	tests := []struct {
+		comment                 string
 		inConfigString          string
 		outAuthenticationConfig *AuthenticationConfig
 	}{
 		// 0 - local with otp
 		{
+			`0 - local with otp`,
+
 			`
 auth_service:
   authentication:
@@ -56,6 +47,8 @@ auth_service:
 		},
 		// 1 - local auth without otp
 		{
+			`1 - local auth without otp`,
+
 			`
 auth_service:
   authentication:
@@ -69,6 +62,8 @@ auth_service:
 		},
 		// 2 - local auth with u2f
 		{
+			`2 - local auth with u2f`,
+
 			`
 auth_service:
    authentication:
@@ -93,37 +88,40 @@ auth_service:
 	}
 
 	// run tests
-	for i, tt := range tests {
-		comment := check.Commentf("Test %v", i)
-
+	for _, tt := range tests {
+		comment := fmt.Sprintf("Test %s", tt.comment)
 		encodedConfigString := base64.StdEncoding.EncodeToString([]byte(tt.inConfigString))
 
 		fc, err := ReadFromString(encodedConfigString)
-		c.Assert(err, check.IsNil, comment)
-
-		c.Assert(fc.Auth.Authentication, check.DeepEquals, tt.outAuthenticationConfig, comment)
+		require.NoError(t, err, comment)
+		require.Equal(t, fc.Auth.Authentication, tt.outAuthenticationConfig, comment)
 	}
 }
 
 // TestLegacySection ensures we continue to parse and correctly load deprecated
 // OIDC connector and U2F authentication configuration.
-func (s *FileTestSuite) TestLegacyAuthenticationSection(c *check.C) {
+func TestLegacyAuthenticationSection(t *testing.T) {
 	encodedLegacyAuthenticationSection := base64.StdEncoding.EncodeToString([]byte(LegacyAuthenticationSection))
 
 	// read config into struct
 	fc, err := ReadFromString(encodedLegacyAuthenticationSection)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
-	// validate oidc connector
-	c.Assert(fc.Auth.OIDCConnectors, check.HasLen, 1)
-	c.Assert(fc.Auth.OIDCConnectors[0].ID, check.Equals, "google")
-	c.Assert(fc.Auth.OIDCConnectors[0].RedirectURL, check.Equals, "https://localhost:3080/v1/webapi/oidc/callback")
-	c.Assert(fc.Auth.OIDCConnectors[0].ClientID, check.Equals, "id-from-google.apps.googleusercontent.com")
-	c.Assert(fc.Auth.OIDCConnectors[0].ClientSecret, check.Equals, "secret-key-from-google")
-	c.Assert(fc.Auth.OIDCConnectors[0].IssuerURL, check.Equals, "https://accounts.google.com")
-
-	// validate u2f
-	c.Assert(fc.Auth.U2F.AppID, check.Equals, "https://graviton:3080")
-	c.Assert(fc.Auth.U2F.Facets, check.HasLen, 1)
-	c.Assert(fc.Auth.U2F.Facets[0], check.Equals, "https://graviton:3080")
+	// validate oidc connector and u2f
+	require.Equal(t, fc.Auth, Auth{
+		Service: Service{
+			defaultEnabled: true,
+		},
+		OIDCConnectors: []OIDCConnector{{
+			ID:           "google",
+			RedirectURL:  "https://localhost:3080/v1/webapi/oidc/callback",
+			ClientID:     "id-from-google.apps.googleusercontent.com",
+			ClientSecret: "secret-key-from-google",
+			IssuerURL:    "https://accounts.google.com",
+		}},
+		U2F: U2F{
+			AppID:  "https://graviton:3080",
+			Facets: []string{"https://graviton:3080"},
+		},
+	})
 }

--- a/lib/session/session_test.go
+++ b/lib/session/session_test.go
@@ -28,64 +28,68 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSessions(t *testing.T) { TestingT(t) }
+func TestSessions(t *testing.T) {
+	utils.InitLoggerForTests(testing.Verbose())
+	s := newsessionSuite(t)
+	t.Cleanup(func() { s.TearDown(t) })
 
-type SessionSuite struct {
+	t.Run("TestID", s.TestID)
+	t.Run("TestSessionsCRUD", s.TestSessionsCRUD)
+	t.Run("TestSessionsInactivity", s.TestSessionsInactivity)
+	t.Run("TestPartiesCRUD", s.TestPartiesCRUD)
+}
+
+type sessionSuite struct {
 	dir   string
 	srv   *server
 	bk    backend.Backend
 	clock clockwork.FakeClock
 }
 
-var _ = Suite(&SessionSuite{})
-
-func (s *SessionSuite) SetUpSuite(c *C) {
-	utils.InitLoggerForTests(testing.Verbose())
-}
-
-func (s *SessionSuite) SetUpTest(c *C) {
+func newsessionSuite(t *testing.T) *sessionSuite {
 	var err error
+	s := &sessionSuite{}
 
 	s.clock = clockwork.NewFakeClockAt(time.Date(2016, 9, 8, 7, 6, 5, 0, time.UTC))
-	s.dir = c.MkDir()
-
+	s.dir = t.TempDir()
 	s.bk, err = lite.NewWithConfig(context.TODO(),
 		lite.Config{
 			Path:  s.dir,
 			Clock: s.clock,
 		},
 	)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	srv, err := New(s.bk)
+	require.NoError(t, err)
 	srv.(*server).clock = s.clock
 	s.srv = srv.(*server)
-	c.Assert(err, IsNil)
+	return s
 }
 
-func (s *SessionSuite) TearDownTest(c *C) {
-	c.Assert(s.bk.Close(), IsNil)
+func (s *sessionSuite) TearDown(t *testing.T) {
+	require.NoError(t, s.bk.Close())
 }
 
-func (s *SessionSuite) TestID(c *C) {
+func (s *sessionSuite) TestID(t *testing.T) {
 	id := NewID()
 	id2, err := ParseID(id.String())
-	c.Assert(err, IsNil)
-	c.Assert(id, Equals, *id2)
+	require.NoError(t, err)
+	require.Equal(t, id, *id2)
 
 	for _, val := range []string{"garbage", "", "   ", string(id) + "extra"} {
 		id := ID(val)
-		c.Assert(id.Check(), NotNil)
+		require.Error(t, id.Check())
 	}
 }
 
-func (s *SessionSuite) TestSessionsCRUD(c *C) {
+func (s *sessionSuite) TestSessionsCRUD(t *testing.T) {
 	out, err := s.srv.GetSessions(defaults.Namespace)
-	c.Assert(err, IsNil)
-	c.Assert(len(out), Equals, 0)
+	require.NoError(t, err)
+	require.Empty(t, out)
 
 	// Create session.
 	sess := Session{
@@ -96,17 +100,17 @@ func (s *SessionSuite) TestSessionsCRUD(c *C) {
 		LastActive:     s.clock.Now().UTC(),
 		Created:        s.clock.Now().UTC(),
 	}
-	c.Assert(s.srv.CreateSession(sess), IsNil)
+	require.NoError(t, s.srv.CreateSession(sess))
 
 	// Make sure only one session exists.
 	out, err = s.srv.GetSessions(defaults.Namespace)
-	c.Assert(err, IsNil)
-	c.Assert(out, DeepEquals, []Session{sess})
+	require.NoError(t, err)
+	require.Equal(t, out, []Session{sess})
 
 	// Make sure the session is the one created above.
 	s2, err := s.srv.GetSession(defaults.Namespace, sess.ID)
-	c.Assert(err, IsNil)
-	c.Assert(s2, DeepEquals, &sess)
+	require.NoError(t, err)
+	require.Equal(t, s2, &sess)
 
 	// Update session terminal parameter
 	err = s.srv.UpdateSession(UpdateRequest{
@@ -114,26 +118,26 @@ func (s *SessionSuite) TestSessionsCRUD(c *C) {
 		Namespace:      defaults.Namespace,
 		TerminalParams: &TerminalParams{W: 101, H: 101},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Verify update was applied.
 	sess.TerminalParams = TerminalParams{W: 101, H: 101}
 	s2, err = s.srv.GetSession(defaults.Namespace, sess.ID)
-	c.Assert(err, IsNil)
-	c.Assert(s2, DeepEquals, &sess)
+	require.NoError(t, err)
+	require.Equal(t, s2, &sess)
 
 	// Remove the session.
 	err = s.srv.DeleteSession(defaults.Namespace, sess.ID)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Make sure session no longer exists.
 	_, err = s.srv.GetSession(defaults.Namespace, sess.ID)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 }
 
 // TestSessionsInactivity makes sure that session will be marked
 // as inactive after period of inactivity
-func (s *SessionSuite) TestSessionsInactivity(c *C) {
+func (s *sessionSuite) TestSessionsInactivity(t *testing.T) {
 	sess := Session{
 		ID:             NewID(),
 		Namespace:      defaults.Namespace,
@@ -142,19 +146,18 @@ func (s *SessionSuite) TestSessionsInactivity(c *C) {
 		LastActive:     s.clock.Now().UTC(),
 		Created:        s.clock.Now().UTC(),
 	}
-	c.Assert(s.srv.CreateSession(sess), IsNil)
+	require.NoError(t, s.srv.CreateSession(sess))
 
 	// move forward in time:
 	s.clock.Advance(defaults.ActiveSessionTTL + time.Second)
 
 	// should not be in active sessions:
 	s2, err := s.srv.GetSession(defaults.Namespace, sess.ID)
-	c.Assert(err, NotNil)
-	c.Assert(trace.IsNotFound(err), Equals, true)
-	c.Assert(s2, IsNil)
+	require.IsType(t, trace.NotFound(""), err)
+	require.Nil(t, s2)
 }
 
-func (s *SessionSuite) TestPartiesCRUD(c *C) {
+func (s *sessionSuite) TestPartiesCRUD(t *testing.T) {
 	// create session:
 	sess := Session{
 		ID:             NewID(),
@@ -164,7 +167,8 @@ func (s *SessionSuite) TestPartiesCRUD(c *C) {
 		LastActive:     s.clock.Now().UTC(),
 		Created:        s.clock.Now().UTC(),
 	}
-	c.Assert(s.srv.CreateSession(sess), IsNil)
+	err := s.srv.CreateSession(sess)
+	require.NoError(t, err)
 	// add two people:
 	parties := []Party{
 		{
@@ -182,31 +186,31 @@ func (s *SessionSuite) TestPartiesCRUD(c *C) {
 			LastActive: s.clock.Now().UTC(),
 		},
 	}
-	err := s.srv.UpdateSession(UpdateRequest{
+	err = s.srv.UpdateSession(UpdateRequest{
 		ID:        sess.ID,
 		Namespace: defaults.Namespace,
 		Parties:   &parties,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	// verify they're in the session:
 	copy, err := s.srv.GetSession(defaults.Namespace, sess.ID)
-	c.Assert(err, IsNil)
-	c.Assert(len(copy.Parties), Equals, 2)
+	require.NoError(t, err)
+	require.Len(t, copy.Parties, 2)
 
 	// empty update (list of parties must not change)
 	err = s.srv.UpdateSession(UpdateRequest{ID: sess.ID, Namespace: defaults.Namespace})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	copy, _ = s.srv.GetSession(defaults.Namespace, sess.ID)
-	c.Assert(len(copy.Parties), Equals, 2)
+	require.Len(t, copy.Parties, 2)
 
 	// remove the 2nd party:
 	deleted := copy.RemoveParty(parties[1].ID)
-	c.Assert(deleted, Equals, true)
+	require.True(t, deleted)
 	err = s.srv.UpdateSession(UpdateRequest{ID: copy.ID, Parties: &copy.Parties, Namespace: defaults.Namespace})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	copy, _ = s.srv.GetSession(defaults.Namespace, sess.ID)
-	c.Assert(len(copy.Parties), Equals, 1)
+	require.Len(t, copy.Parties, 1)
 
 	// we still have the 1st party in:
-	c.Assert(parties[0].ID, Equals, copy.Parties[0].ID)
+	require.Equal(t, parties[0].ID, copy.Parties[0].ID)
 }

--- a/lib/shell/shell_test.go
+++ b/lib/shell/shell_test.go
@@ -19,26 +19,19 @@ package shell
 import (
 	"testing"
 
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
-func Test(t *testing.T) { check.TestingT(t) }
-
-type ShellSuite struct {
-}
-
-var _ = check.Suite(&ShellSuite{})
-
-func (s *ShellSuite) TestGetShell(c *check.C) {
+func TestGetShell(t *testing.T) {
 	shell, err := GetLoginShell("root")
-	c.Assert(err, check.IsNil)
-	c.Assert(shell == "/bin/bash" || shell == "/bin/sh", check.Equals, true)
+	require.NoError(t, err)
+	require.True(t, shell == "/bin/bash" || shell == "/bin/sh")
 
 	shell, err = GetLoginShell("non-existent-user")
-	c.Assert(err, check.IsNil)
-	c.Assert(shell, check.Equals, DefaultShell)
+	require.NoError(t, err)
+	require.Equal(t, shell, DefaultShell)
 
 	shell, err = GetLoginShell("nobody")
-	c.Assert(err, check.IsNil)
-	c.Assert(shell, check.Matches, ".*(nologin|false)")
+	require.NoError(t, err)
+	require.Regexp(t, ".*(nologin|false)", shell)
 }

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -29,49 +29,40 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
-	check "gopkg.in/check.v1"
 )
-
-func TestTLSCA(t *testing.T) { check.TestingT(t) }
-
-type TLSCASuite struct {
-	clock clockwork.Clock
-}
-
-var _ = check.Suite(&TLSCASuite{
-	clock: clockwork.NewFakeClock(),
-})
 
 // TestPrincipals makes sure that SAN extension of generated x509 cert gets
 // correctly set with DNS names and IP addresses based on the provided
 // principals.
-func (s *TLSCASuite) TestPrincipals(c *check.C) {
+func TestPrincipals(t *testing.T) {
 	ca, err := FromKeys([]byte(fixtures.SigningCertPEM), []byte(fixtures.SigningKeyPEM))
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, teleport.RSAKeySize)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	hostnames := []string{"localhost", "example.com"}
 	ips := []string{"127.0.0.1", "192.168.1.1"}
 
+	clock := clockwork.NewFakeClock()
+
 	certBytes, err := ca.GenerateCertificate(CertificateRequest{
-		Clock:     s.clock,
+		Clock:     clock,
 		PublicKey: privateKey.Public(),
 		Subject:   pkix.Name{CommonName: "test"},
-		NotAfter:  s.clock.Now().Add(time.Hour),
+		NotAfter:  clock.Now().Add(time.Hour),
 		DNSNames:  append(hostnames, ips...),
 	})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	cert, err := ParseCertificatePEM(certBytes)
-	c.Assert(err, check.IsNil)
-	c.Assert(cert.DNSNames, check.DeepEquals, hostnames)
+	require.NoError(t, err)
+	require.ElementsMatch(t, cert.DNSNames, hostnames)
 	var certIPs []string
 	for _, ip := range cert.IPAddresses {
 		certIPs = append(certIPs, ip.String())
 	}
-	c.Assert(certIPs, check.DeepEquals, ips)
+	require.ElementsMatch(t, certIPs, ips)
 }
 
 // TestKubeExtensions test ASN1 subject kubernetes extensions


### PR DESCRIPTION
### What

Refactors `lib/asciitable`, `lib/tlsca`, `lib/shell`, `lib/session` and `lib/config` tests to use the Go test runner and the `require` package instead of `gocheck`.

### Why

Because we want to move away from `gocheck`.

### PR splitting

To avoid long and difficult rebases I believe it is better to do this incrementally. Also avoids breaking too many peoples work at the same time.