### PR TITLE
Print newlines in CLI errors

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -187,9 +187,9 @@ func UserMessageFromError(err error) string {
 		// it, if it does, print it, otherwise escape and print the original error.
 		if er, ok := err.(*trace.TraceErr); ok {
 			for _, message := range er.Messages {
-				fmt.Fprintln(&buf, "\t"+EscapeControl(message))
+				fmt.Fprintln(&buf, EscapeControl(message))
 			}
-			fmt.Fprintln(&buf, "\t"+EscapeControl(trace.Unwrap(er).Error()))
+			fmt.Fprintln(&buf, EscapeControl(trace.Unwrap(er).Error()))
 		} else {
 			fmt.Fprintln(&buf, EscapeControl(err.Error()))
 		}

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/gravitational/teleport"
 
@@ -296,7 +297,7 @@ type logWrapper struct {
 // needsQuoting returns true if any non-printable characters are found.
 func needsQuoting(text string) bool {
 	for _, r := range text {
-		if !strconv.IsPrint(r) {
+		if !unicode.IsPrint(r) && !unicode.IsSpace(r) {
 			return true
 		}
 	}


### PR DESCRIPTION
The error formatting facilities used by all of the three Teleport tools (e.g. via `utils.FatalError`) don't print errors with newlines properly. For example:

**What happened before**:
```
$ tctl rm cluster

ERROR:
	"provide a full resource name to delete, for example:\n$ tctl rm cluster/east\n"
```

**What happens with the proposed changes**:
```
$ tctl rm cluster

ERROR:
provide a full resource name to delete, for example:
$ tctl rm cluster/east
```