### PR TITLE
Fixed a typo in GCP documentation

### DIFF
--- a/docs/5.0/pages/gcp-guide.mdx
+++ b/docs/5.0/pages/gcp-guide.mdx
@@ -34,7 +34,7 @@ This guide will cover how to setup, configure and run Teleport on GCP.
 GCP Services required to run Teleport in HA:
 
  - [Compute Engine: VM Instances with Instance Groups](#compute-engine-vm-instances-with-instance-groups)
- - [Computer Engine: Health Checks](#computer-engine-health-checks)
+ - [Compute Engine: Health Checks](#compute-engine-health-checks)
  - [Storage: Cloud Firestore](#storage-google-cloud-storage)
  - [Storage: Google Cloud Storage](#storage-google-cloud-storage)
  - [Network Services: Load Balancing](#network-services-load-balancing)
@@ -60,7 +60,7 @@ To run Teleport in a HA configuration we recommend using `n1-standard-2` instanc
 Production. It's best practice to separate the proxy and authentication server, using
 Instance groups for the proxy and auth server.
 
-### Computer Engine: Health Checks
+### Compute Engine: Health Checks
 GCP relies heavily on [Health Checks](https://cloud.google.com/load-balancing/docs/health-checks),
 this is helpful when adding new instances to an instance group.
 


### PR DESCRIPTION
Few occurrences of `computer` that needed to be renamed `compute` to match GCP naming.