### PR TITLE
Add utmp/wtmp support to manual test plan

### DIFF
--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -106,6 +106,11 @@ With every user combination, try to login and signup with invalid second factor,
   - [ ] Connect to a OpenSSH node
   - [ ] Check agent forwarding is correct based on role and proxy mode.
 
+### User accounting
+
+- [ ] Verify that active interactive sessions are tracked in `/var/run/utmp` on Linux.
+- [ ] Verify that interactive sessions are logged in `/var/log/wtmp` on Linux.
+
 ### Combinations
 
 For some manual testing, many combinations need to be tested. For example, for


### PR DESCRIPTION
This PR adds two boxes to the manual test plan to verify that user accounting and logging works correctly.