### PR TITLE
Make /lib/web tests more reliable

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -40,8 +40,9 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
 
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/trace"
 )
 
 // TestAuthServerConfig is auth server test config
@@ -242,6 +243,14 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 	return srv, nil
+}
+
+func (a *TestAuthServer) Close() error {
+	return trace.NewAggregate(
+		a.Backend.Close(),
+		a.AuditLog.Close(),
+		a.AuthServer.Close(),
+	)
 }
 
 // GenerateUserCert takes the public key in the OpenSSH `authorized_keys`

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1403,7 +1403,6 @@ func TestU2FLogin(t *testing.T) {
 
 func testU2FLogin(t *testing.T, secondFactor constants.SecondFactorType) {
 	env := newWebPack(t, 1)
-	defer env.close(t)
 
 	// configure cluster authentication preferences
 	cap, err := services.NewAuthPreference(services.AuthPreferenceSpecV2{
@@ -1796,7 +1795,6 @@ func TestApplicationAccessDisabled(t *testing.T) {
 	modules.SetModules(&testModules{})
 
 	env := newWebPack(t, 1)
-	defer env.close(t)
 
 	proxy := env.proxies[0]
 	pack := proxy.authPack(t, "foo@example.com")
@@ -1943,7 +1941,6 @@ func (s *WebSuite) TestCreateAppSession(c *C) {
 // See https://github.com/gravitational/teleport/issues/5265
 func TestWebSessionsRenewDoesNotBreakExistingTerminalSession(t *testing.T) {
 	env := newWebPack(t, 2)
-	defer env.close(t)
 
 	proxy1, proxy2 := env.proxies[0], env.proxies[1]
 	// Connect to both proxies
@@ -1951,7 +1948,6 @@ func TestWebSessionsRenewDoesNotBreakExistingTerminalSession(t *testing.T) {
 	pack2 := proxy2.authPackFromPack(t, pack1)
 
 	ws := proxy2.makeTerminal(t, pack2, session.NewID())
-	defer ws.Close()
 
 	// Advance the time before renewing the session.
 	// This will allow the new session to have a more plausible
@@ -1983,7 +1979,6 @@ func TestWebSessionsRenewDoesNotBreakExistingTerminalSession(t *testing.T) {
 func TestWebSessionsRenewAllowsOldBearerTokenToLinger(t *testing.T) {
 	// Login to implicitly create a new web session
 	env := newWebPack(t, 1)
-	defer env.close(t)
 
 	proxy := env.proxies[0]
 	pack := proxy.authPack(t, "foo")
@@ -2311,9 +2306,11 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 		Clock:       clock,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
 	server, err := authServer.NewTestTLSServer()
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
 
 	// start auth server
 	certs, err := server.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
@@ -2334,6 +2331,7 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 		},
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, nodeClient.Close()) })
 
 	hostSigners := []ssh.Signer{signer}
 	// create SSH service:
@@ -2358,6 +2356,7 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 	require.NoError(t, err)
 
 	require.NoError(t, node.Start())
+	t.Cleanup(func() { require.NoError(t, node.Close()) })
 	require.NoError(t, auth.CreateUploaderDir(nodeDataDir))
 
 	var proxies []*proxy
@@ -2370,11 +2369,11 @@ func newWebPack(t *testing.T, numProxies int) *webPack {
 	for start := time.Now(); ; {
 		proxies, err := proxies[0].client.GetProxies()
 		require.NoError(t, err)
-		if len(proxies) != numProxies {
+		if len(proxies) == numProxies {
 			break
 		}
 		if time.Since(start) > 5*time.Second {
-			t.Fatal("Proxy didn't register within 5s after startup.")
+			t.Fatalf("Proxies didn't register within 5s after startup; registered: %d, want: %d", len(proxies), numProxies)
 		}
 	}
 
@@ -2397,9 +2396,11 @@ func createProxy(t *testing.T, proxyID string, node *regular.Server, authServer 
 		},
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
 
 	revTunListener, err := net.Listen("tcp", fmt.Sprintf("%v:0", authServer.ClusterName()))
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, revTunListener.Close()) })
 
 	revTunServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ID:                    node.ID(),
@@ -2415,6 +2416,7 @@ func createProxy(t *testing.T, proxyID string, node *regular.Server, authServer 
 		DataDir:               t.TempDir(),
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, revTunServer.Close()) })
 
 	proxyServer, err := regular.New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
@@ -2433,6 +2435,7 @@ func createProxy(t *testing.T, proxyID string, node *regular.Server, authServer 
 		regular.SetClock(clock),
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, proxyServer.Close()) })
 
 	fs, err := NewDebugFileSystem("../../webassets/teleport")
 	require.NoError(t, err)
@@ -2450,8 +2453,8 @@ func createProxy(t *testing.T, proxyID string, node *regular.Server, authServer 
 	}, SetSessionStreamPollPeriod(200*time.Millisecond), SetClock(clock))
 	require.NoError(t, err)
 
-	webServer := httptest.NewUnstartedServer(handler)
-	webServer.StartTLS()
+	webServer := httptest.NewTLSServer(handler)
+	t.Cleanup(webServer.Close)
 	require.NoError(t, proxyServer.Start())
 
 	proxyAddr := utils.MustParseAddr(proxyServer.Addr())
@@ -2487,17 +2490,6 @@ type webPack struct {
 	server  *auth.TestTLSServer
 	node    *regular.Server
 	clock   clockwork.FakeClock
-}
-
-func (r *webPack) close(t *testing.T) {
-	for _, p := range r.proxies {
-		p.web.Close()
-		p.proxy.Close()
-		p.revTun.Close()
-	}
-	require.NoError(t, r.node.Close())
-	require.NoError(t, r.server.Close())
-
 }
 
 type proxy struct {
@@ -2675,6 +2667,7 @@ func (r *proxy) makeTerminal(t *testing.T, pack *authPack, sessionID session.ID)
 
 	ws, err := websocket.DialConfig(wscfg)
 	require.NoError(t, err)
+	t.Cleanup(func() { ws.Close() })
 
 	return ws
 }


### PR DESCRIPTION
Fix condition on the proxy registration check.

Use t.Cleanup to close all servers and clients reliably and avoid
running out of file descriptors.

Fixes https://github.com/gravitational/teleport/issues/5648