### PR TITLE
Update --label definition for consistency

### DIFF
--- a/docs/5.0/pages/cli-docs.mdx
+++ b/docs/5.0/pages/cli-docs.mdx
@@ -41,7 +41,7 @@ the following services.
 | `--nodename` | `hostname` command on the machine | **string** | assigns an alternative name for the node which can be used by clients to login. By default it's equal to the value returned by
 | `-c, --config` | `/etc/teleport.yaml` | **string** `.yaml` filepath | starts services with config specified in the YAML file, overrides CLI flags if set
 | `--bootstrap` | none | **string** `.yaml` filepath | bootstrap configured YAML resources {/* TODO link how to configure this file */}
-| `--labels` | none | **string** comma-separated list | assigns a set of labels to a node. See the explanation of labeling mechanism in the [Labeling Nodes](admin-guide.mdx#labeling-nodes-and-applications) section.
+| `--labels` | none | **string** comma-separated list | assigns a set of labels to a node [env=dev,app=web]. See the explanation of labeling mechanism in the [Labeling Nodes](admin-guide.mdx#labeling-nodes-and-applications) section.
 | `--insecure` | none | none | disable certificate validation on Proxy Service, validation still occurs on Auth Service.
 | `--fips` | none | none | start Teleport in FedRAMP/FIPS 140-2 mode.
 | `--diag-addr` | none | none | Enable diagnostic endpoints
@@ -70,7 +70,7 @@ $ teleport start --roles=node --auth-server=10.1.0.1 --labels=db=master
 $ teleport start --roles=app --token=xyz --auth-server=proxy.example.com:3080 \
     --app-name="example-app" \
     --app-uri="http://localhost:8080" \
-    --labels=group:dev
+    --labels=group=dev
 ```
 
 ## teleport status

--- a/docs/5.0/pages/cli-docs.mdx
+++ b/docs/5.0/pages/cli-docs.mdx
@@ -41,7 +41,7 @@ the following services.
 | `--nodename` | `hostname` command on the machine | **string** | assigns an alternative name for the node which can be used by clients to login. By default it's equal to the value returned by
 | `-c, --config` | `/etc/teleport.yaml` | **string** `.yaml` filepath | starts services with config specified in the YAML file, overrides CLI flags if set
 | `--bootstrap` | none | **string** `.yaml` filepath | bootstrap configured YAML resources {/* TODO link how to configure this file */}
-| `--labels` | none | **string** comma-separated list | assigns a set of labels to a node, for example [env=dev,app=web]. See the explanation of labeling mechanism in the [Labeling Nodes](admin-guide.mdx#labeling-nodes-and-applications) section.
+| `--labels` | none | **string** comma-separated list | assigns a set of labels to a node, for example env=dev,app=web. See the explanation of labeling mechanism in the [Labeling Nodes](admin-guide.mdx#labeling-nodes-and-applications) section.
 | `--insecure` | none | none | disable certificate validation on Proxy Service, validation still occurs on Auth Service.
 | `--fips` | none | none | start Teleport in FedRAMP/FIPS 140-2 mode.
 | `--diag-addr` | none | none | Enable diagnostic endpoints

--- a/docs/5.0/pages/cli-docs.mdx
+++ b/docs/5.0/pages/cli-docs.mdx
@@ -41,7 +41,7 @@ the following services.
 | `--nodename` | `hostname` command on the machine | **string** | assigns an alternative name for the node which can be used by clients to login. By default it's equal to the value returned by
 | `-c, --config` | `/etc/teleport.yaml` | **string** `.yaml` filepath | starts services with config specified in the YAML file, overrides CLI flags if set
 | `--bootstrap` | none | **string** `.yaml` filepath | bootstrap configured YAML resources {/* TODO link how to configure this file */}
-| `--labels` | none | **string** comma-separated list | assigns a set of labels to a node [env=dev,app=web]. See the explanation of labeling mechanism in the [Labeling Nodes](admin-guide.mdx#labeling-nodes-and-applications) section.
+| `--labels` | none | **string** comma-separated list | assigns a set of labels to a node, for example [env=dev,app=web]. See the explanation of labeling mechanism in the [Labeling Nodes](admin-guide.mdx#labeling-nodes-and-applications) section.
 | `--insecure` | none | none | disable certificate validation on Proxy Service, validation still occurs on Auth Service.
 | `--fips` | none | none | start Teleport in FedRAMP/FIPS 140-2 mode.
 | `--diag-addr` | none | none | Enable diagnostic endpoints

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -117,9 +117,9 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 	start.Flag("config-string",
 		"Base64 encoded configuration string").Hidden().Envar(defaults.ConfigEnvar).
 		StringVar(&ccf.ConfigString)
-	start.Flag("labels", "List of labels for this node").StringVar(&ccf.Labels)
+	start.Flag("labels", "Comma-separated list of labels for this node [env=dev,app=web]").StringVar(&ccf.Labels)
 	start.Flag("diag-addr",
-		"Start diangonstic prometheus and healthz endpoint.").Hidden().StringVar(&ccf.DiagnosticAddr)
+		"Start diagnostic prometheus and healthz endpoint.").Hidden().StringVar(&ccf.DiagnosticAddr)
 	start.Flag("permit-user-env",
 		"Enables reading of ~/.tsh/environment when creating a session").BoolVar(&ccf.PermitUserEnvironment)
 	start.Flag("insecure",

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -117,7 +117,7 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 	start.Flag("config-string",
 		"Base64 encoded configuration string").Hidden().Envar(defaults.ConfigEnvar).
 		StringVar(&ccf.ConfigString)
-	start.Flag("labels", "Comma-separated list of labels for this node [env=dev,app=web]").StringVar(&ccf.Labels)
+	start.Flag("labels", "Comma-separated list of labels for this node, for example env=dev,app=web").StringVar(&ccf.Labels)
 	start.Flag("diag-addr",
 		"Start diagnostic prometheus and healthz endpoint.").Hidden().StringVar(&ccf.DiagnosticAddr)
 	start.Flag("permit-user-env",

--- a/tool/teleport/common/usage.go
+++ b/tool/teleport/common/usage.go
@@ -39,7 +39,7 @@ Examples:
 > teleport start --roles=app --token=xyz --auth-server=proxy.example.com:3080 \
     --app-name="example-app" \
     --app-uri="http://localhost:8080" \
-    --labels=group:dev
+    --labels=group=dev
   Same as the above, but the app server runs with "group=dev" label which only
   allows access to users with the role "group=dev".
   


### PR DESCRIPTION
correct spelling for `diag-addr` description and made labels consistent with roles description. Also added an example on specifying labels as the `:` usage in YAML vs `=` in CLI caused some confusion. 