### PR TITLE
Update fips documentation for proxy_checks_host_keys

### DIFF
--- a/docs/5.0/pages/enterprise/ssh-kubernetes-fedramp.mdx
+++ b/docs/5.0/pages/enterprise/ssh-kubernetes-fedramp.mdx
@@ -80,7 +80,7 @@ auth_service:
 
   # If using Proxy Mode, Teleport requires host key checks.
   # This setting needs is required to start in Teleport in FIPS mode
-  proxy_checks_host_keys: true
+  proxy_checks_host_keys: yes
 
   # SSH is also enabled on this node:
 ssh_service:


### PR DESCRIPTION
The parameter `proxy_checks_host_keys` accepts only yes|no in the config file. If set to true you get the below error:

```
ERROR REPORT:
Original Error: *trace.BadParameterError proxy_checks_host_keys must be one of: yes,no
Stack Trace:
	/go/src/github.com/gravitational/teleport/lib/services/clusterconfig.go:392 github.com/gravitational/teleport/lib/services.(*ClusterConfigV3).CheckAndSetDefaults
	/go/src/github.com/gravitational/teleport/lib/services/clusterconfig.go:119 github.com/gravitational/teleport/lib/services.NewClusterConfig
	/go/src/github.com/gravitational/teleport/lib/config/configuration.go:459 github.com/gravitational/teleport/lib/config.applyAuthConfig
	/go/src/github.com/gravitational/teleport/lib/config/configuration.go:339 github.com/gravitational/teleport/lib/config.ApplyFileConfig
	/go/src/github.com/gravitational/teleport/lib/config/configuration.go:1047 github.com/gravitational/teleport/lib/config.Configure
	/go/src/github.com/gravitational/teleport/tool/teleport/common/teleport.go:170 github.com/gravitational/teleport/tool/teleport/common.Run
	/go/src/github.com/gravitational/teleport/e/tool/teleport/main.go:22 main.main
	/opt/go/src/runtime/proc.go:213 runtime.main
	/opt/go/src/runtime/asm_amd64.s:1375 runtime.goexit
User Message: proxy_checks_host_keys must be one of: yes,no
```