### PR TITLE
Sasha/newlines (#5738)

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -187,16 +187,16 @@ func UserMessageFromError(err error) string {
 	}
 	if err != nil {
 		var buf bytes.Buffer
-		fmt.Fprintln(&buf, Color(Red, "ERROR:"))
+		fmt.Fprint(&buf, Color(Red, "ERROR: "))
 		// If the error is a trace error, check if it has a user message embedded in
 		// it, if it does, print it, otherwise escape and print the original error.
 		if er, ok := err.(*trace.TraceErr); ok {
 			for _, message := range er.Messages {
-				fmt.Fprintln(&buf, "\t"+EscapeControl(message))
+				fmt.Fprintln(&buf, AllowNewlines(message))
 			}
-			fmt.Fprintln(&buf, "\t"+EscapeControl(trace.Unwrap(er).Error()))
+			fmt.Fprintln(&buf, AllowNewlines(trace.Unwrap(er).Error()))
 		} else {
-			fmt.Fprintln(&buf, EscapeControl(err.Error()))
+			fmt.Fprintln(&buf, AllowNewlines(err.Error()))
 		}
 		return buf.String()
 	}
@@ -256,6 +256,21 @@ func EscapeControl(s string) string {
 		return fmt.Sprintf("%q", s)
 	}
 	return s
+}
+
+// AllowNewlines escapes all ANSI escape sequences except newlines from string and returns a
+// string that is safe to print on the CLI. This is to ensure that malicious
+// servers can not hide output. For more details, see:
+//   * https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
+func AllowNewlines(s string) string {
+	if !strings.Contains(s, "\n") {
+		return EscapeControl(s)
+	}
+	parts := strings.Split(s, "\n")
+	for i, part := range parts {
+		parts[i] = EscapeControl(part)
+	}
+	return strings.Join(parts, "\n")
 }
 
 // NewStdlogger creates a new stdlib logger that uses the specified leveled logger

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Gravitational, Inc.
+Copyright 2019-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -26,16 +27,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/check.v1"
 )
 
-type CLISuite struct {
-}
-
-var _ = check.Suite(&CLISuite{})
-
-func (s *CLISuite) TestUserMessageFromError(c *check.C) {
-	c.Skip("Enable after https://drone.gravitational.io/gravitational/teleport/3517 is merged.")
+func TestUserMessageFromError(t *testing.T) {
+	t.Skip("Enable after https://drone.gravitational.io/gravitational/teleport/3517 is merged.")
 	tests := []struct {
 		comment   string
 		inError   error
@@ -59,9 +54,8 @@ func (s *CLISuite) TestUserMessageFromError(c *check.C) {
 	}
 
 	for _, tt := range tests {
-		comment := check.Commentf(tt.comment)
 		message := UserMessageFromError(tt.inError)
-		c.Assert(strings.HasPrefix(message, tt.outString), check.Equals, true, comment)
+		require.True(t, strings.HasPrefix(message, tt.outString), tt.comment)
 	}
 }
 
@@ -72,4 +66,62 @@ func TestConsolefLongComponent(t *testing.T) {
 		component := strings.Repeat("na ", 10) + "batman!"
 		Consolef(ioutil.Discard, logrus.New(), component, "test message")
 	})
+}
+
+// TestEscapeControl tests escape control
+func TestEscapeControl(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  "hello, world!",
+			out: "hello, world!",
+		},
+		{
+			in:  "hello,\nworld!",
+			out: `"hello,\nworld!"`,
+		},
+		{
+			in:  "hello,\r\tworld!",
+			out: `"hello,\r\tworld!"`,
+		},
+	}
+
+	for i, tt := range tests {
+		require.Equal(t, tt.out, EscapeControl(tt.in), fmt.Sprintf("test case %v", i))
+	}
+}
+
+// TestAllowNewlines tests escape control that allows newlines
+func TestAllowNewlines(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{
+			in:  "hello, world!",
+			out: "hello, world!",
+		},
+		{
+			in:  "hello,\nworld!",
+			out: "hello,\nworld!",
+		},
+		{
+			in:  "hello,\r\tworld!",
+			out: `"hello,\r\tworld!"`,
+		},
+		{
+			in:  "hello,\n\r\tworld!",
+			out: "hello,\n" + `"\r\tworld!"`,
+		},
+		{
+			in:  "hello,\t\n\r\tworld!",
+			out: `"hello,\t"` + "\n" + `"\r\tworld!"`,
+		},
+	}
+
+	for i, tt := range tests {
+		require.Equal(t, tt.out, AllowNewlines(tt.in), fmt.Sprintf("test case %v", i))
+	}
 }


### PR DESCRIPTION
* Improves CLI error reporting

Escapes control characters, while allowing newlines.
Removes tabs in output.