### PR TITLE
[branch/v6] Backport "[tctl] Don't explicitly set value for config path and preserve backwards compatibility (#5731)"

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -131,12 +131,12 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 	// --config tells us to use a specific conf. file:
 	if cliConfigPath != "" {
 		configFilePath = cliConfigPath
-		if !fileExists(configFilePath) {
+		if !utils.FileExists(configFilePath) {
 			return nil, trace.NotFound("file %s is not found", configFilePath)
 		}
 	}
 	// default config doesn't exist? quietly return:
-	if !fileExists(configFilePath) {
+	if !utils.FileExists(configFilePath) {
 		log.Info("not using a config file")
 		return nil, nil
 	}
@@ -569,10 +569,10 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 	for _, p := range fc.Proxy.KeyPairs {
 		// Check that the certificate exists on disk. This exists to provide the
 		// user a sensible error message.
-		if !fileExists(p.PrivateKey) {
+		if !utils.FileExists(p.PrivateKey) {
 			return trace.Errorf("https private key does not exist: %s", p.PrivateKey)
 		}
-		if !fileExists(p.Certificate) {
+		if !utils.FileExists(p.Certificate) {
 			return trace.Errorf("https cert does not exist: %s", p.Certificate)
 		}
 
@@ -1450,14 +1450,6 @@ func replaceHost(addr *utils.NetAddr, newHost string) {
 		log.Errorf("failed parsing address: '%v'", addr.Addr)
 	}
 	addr.Addr = net.JoinHostPort(newHost, port)
-}
-
-func fileExists(fp string) bool {
-	_, err := os.Stat(fp)
-	if err != nil && os.IsNotExist(err) {
-		return false
-	}
-	return true
 }
 
 // validateRoles makes sure that value upassed to --roles flag is valid

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -66,13 +66,6 @@ func (s *ServiceTestSuite) TestDebugModeEnv(c *check.C) {
 }
 
 func (s *ServiceTestSuite) TestSelfSignedHTTPS(c *check.C) {
-	fileExists := func(fp string) bool {
-		_, err := os.Stat(fp)
-		if err != nil && os.IsNotExist(err) {
-			return false
-		}
-		return true
-	}
 	cfg := &Config{
 		DataDir:  c.MkDir(),
 		Hostname: "example.com",
@@ -81,8 +74,8 @@ func (s *ServiceTestSuite) TestSelfSignedHTTPS(c *check.C) {
 	err := initSelfSignedHTTPSCert(cfg)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Proxy.KeyPairs, check.HasLen, 1)
-	c.Assert(fileExists(cfg.Proxy.KeyPairs[0].Certificate), check.Equals, true)
-	c.Assert(fileExists(cfg.Proxy.KeyPairs[0].PrivateKey), check.Equals, true)
+	c.Assert(utils.FileExists(cfg.Proxy.KeyPairs[0].Certificate), check.Equals, true)
+	c.Assert(utils.FileExists(cfg.Proxy.KeyPairs[0].PrivateKey), check.Equals, true)
 }
 
 func TestMonitor(t *testing.T) {

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -519,6 +519,15 @@ func AddrsFromStrings(s Strings, defaultPort int) ([]NetAddr, error) {
 	return addrs, nil
 }
 
+// FileExists checks whether a file exists at a given path
+func FileExists(fp string) bool {
+	_, err := os.Stat(fp)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
 const (
 	// CertTeleportUser specifies teleport user
 	CertTeleportUser = "x-teleport-user"

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -96,12 +96,16 @@ func Run(commands []CLICommand, loadConfigExt LoadConfigFn) {
 
 	var ccf GlobalCLIFlags
 
-	// Initially, set the config file path to the default.
-	// If this is overridden by environment variable, update the path.
-	ccf.ConfigFile = defaults.ConfigFilePath
+	// If the config file path is being overridden by environment variable, set that.
+	// If not, check whether the default config file path exists and set that if so.
+	// This preserves tctl's default behavior for backwards compatibility.
 	configFileEnvar, isSet := os.LookupEnv(defaults.ConfigFileEnvar)
 	if isSet {
 		ccf.ConfigFile = configFileEnvar
+	} else {
+		if utils.FileExists(defaults.ConfigFilePath) {
+			ccf.ConfigFile = defaults.ConfigFilePath
+		}
 	}
 
 	// these global flags apply to all commands


### PR DESCRIPTION
Backports #5731 into `branch/v6`