### PR TITLE
Adds docs-test-whitespace Makefile target needed for docs tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ release-windows: clean all
 # Builds docs using containerized mkdocs
 #
 .PHONY:docs
-docs:
+docs: docs-test
 	$(MAKE) -C build.assets docs
 
 #
@@ -189,6 +189,43 @@ docs:
 .PHONY:run-docs
 run-docs:
 	$(MAKE) -C build.assets run-docs
+
+#
+# Remove trailing whitespace in all markdown files under docs/
+#
+.PHONY:docs-fix-whitespace
+docs-fix-whitespace:
+	find docs/ -type f -name '*.md' | xargs sed -i -E 's/\s+$$//g'
+
+#
+# Test docs for trailing whitespace and broken links
+#
+.PHONY:docs-test
+docs-test: docs-test-whitespace docs-test-links
+
+#
+# Check for trailing whitespace in all markdown files under docs/
+#
+.PHONY:docs-test-whitespace
+docs-test-whitespace:
+	if find docs/ -type f -name '*.md' | xargs grep -E '\s+$$'; then \
+		echo "trailing whitespace found in docs/ (see above)"; \
+		echo "run 'make docs-fix-whitespace' to fix it"; \
+		exit 1; \
+	fi
+
+#
+# Run milv in docs to detect broken links.
+# milv is installed if missing.
+#
+.PHONY:docs-test-links
+docs-test-links: DOCS_FOLDERS := $(shell find -name milv.config.yaml | xargs dirname)
+docs-test-links:
+	go get -v github.com/magicmatatjahu/milv
+	for docs_dir in $(DOCS_FOLDERS); do \
+		echo "running milv in $${docs_dir}"; \
+		cd $${docs_dir} && milv ; cd $(PWD); \
+	done
 
 #
 # tests everything: called by Jenkins


### PR DESCRIPTION
This is the same as commit 186f9738fb0f7cf799aff836f4037c277206f372 but I couldn't cherry-pick it locally due to `git gc` having cleaned it up as an orphan commit.