### PR TITLE
Fix last output timestamps on some systems

### DIFF
--- a/lib/srv/uacc/uacc.h
+++ b/lib/srv/uacc/uacc.h
@@ -106,7 +106,7 @@ static int uacc_add_utmp_entry(const char *utmp_path, const char *wtmp_path, con
 
 // Low level C function to mark a database entry as DEAD_PROCESS.
 // This function does not perform string argument validation.
-static int uacc_mark_utmp_entry_dead(const char *utmp_path, const char *wtmp_path, const char *tty_name) {
+static int uacc_mark_utmp_entry_dead(const char *utmp_path, const char *wtmp_path, const char *tty_name, int32_t tv_sec, int32_t tv_usec) {
     char resolved_utmp_buffer[PATH_MAX];
     const char* file = get_absolute_path_with_fallback(&resolved_utmp_buffer[0], utmp_path, _PATH_UTMP);
     if (utmpname(file) < 0) {
@@ -128,6 +128,8 @@ static int uacc_mark_utmp_entry_dead(const char *utmp_path, const char *wtmp_pat
     entry.ut_type = DEAD_PROCESS;
     memset(&entry.ut_user, 0, UT_NAMESIZE);
     struct utmp log_entry = entry;
+    log_entry.ut_tv.tv_sec = tv_sec;
+    log_entry.ut_tv.tv_usec = tv_usec;
     memset(&entry.ut_host, 0, UT_HOSTSIZE);
     memset(&entry.ut_line, 0, UT_LINESIZE);
     memset(&entry.ut_time, 0, 8);

--- a/lib/srv/uacc/uacc_linux.go
+++ b/lib/srv/uacc/uacc_linux.go
@@ -137,8 +137,12 @@ func Close(utmpPath, wtmpPath string, ttyName string) error {
 	cTtyName := C.CString(strings.TrimPrefix(ttyName, "/dev/"))
 	defer C.free(unsafe.Pointer(cTtyName))
 
+	timestamp := time.Now()
+	secondsElapsed := (C.int32_t)(timestamp.Unix())
+	microsFraction := (C.int32_t)((timestamp.UnixNano() % int64(time.Second)) / int64(time.Microsecond))
+
 	accountDb.Lock()
-	status := C.uacc_mark_utmp_entry_dead(cUtmpPath, cWtmpPath, cTtyName)
+	status := C.uacc_mark_utmp_entry_dead(cUtmpPath, cWtmpPath, cTtyName, secondsElapsed, microsFraction)
 	accountDb.Unlock()
 
 	switch status {


### PR DESCRIPTION
This PR fixes user accounting timeestamp handling which needs to be manually done on some systems.