### PR TITLE
[branch/v6] Propagate the mapped local user identity via auth.Context

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -237,7 +237,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	srv.Authorizer, err = NewAuthorizer(srv.AuthServer.Access, srv.AuthServer.Identity, srv.AuthServer.Trust)
+	srv.Authorizer, err = NewAuthorizer(srv.ClusterName, srv.AuthServer.Access, srv.AuthServer.Identity, srv.AuthServer.Trust)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -112,7 +112,7 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		roleNames, err = ca.CombinedMapping().Map(id.Groups)
+		roleNames, err = services.MapRoles(ca.CombinedMapping(), id.Groups)
 		if err != nil {
 			return nil, trace.AccessDenied("failed to map roles for remote user %q from cluster %q with remote roles %v", id.Username, id.TeleportCluster, id.Groups)
 		}

--- a/lib/auth/kube.go
+++ b/lib/auth/kube.go
@@ -105,8 +105,24 @@ func (s *Server) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	roleNames := id.Groups
+	// This is a remote user, map roles to local roles first.
+	if id.TeleportCluster != clusterName.GetClusterName() {
+		ca, err := s.GetCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: id.TeleportCluster}, false)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		roleNames, err = ca.CombinedMapping().Map(id.Groups)
+		if err != nil {
+			return nil, trace.AccessDenied("failed to map roles for remote user %q from cluster %q with remote roles %v", id.Username, id.TeleportCluster, id.Groups)
+		}
+		if len(roleNames) == 0 {
+			return nil, trace.AccessDenied("no roles mapped for remote user %q from cluster %q with remote roles %v", id.Username, id.TeleportCluster, id.Groups)
+		}
+	}
+
 	// Extract user roles from the identity (from the CSR Subject).
-	roles, err := services.FetchRoles(id.Groups, s, id.Traits)
+	roles, err := services.FetchRoles(roleNames, s, id.Traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/kube_test.go
+++ b/lib/auth/kube_test.go
@@ -34,6 +34,7 @@ func (s *AuthSuite) TestProcessKubeCSR(c *check.C) {
 		Principals:       []string{"principal a", "principal b"},
 		KubernetesGroups: []string{"k8s group a", "k8s group b"},
 		Traits:           map[string][]string{"trait a": []string{"b", "c"}},
+		TeleportCluster:  clusterName,
 	}
 	subj, err := userID.Subject()
 	c.Assert(err, check.IsNil)

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -203,6 +203,7 @@ func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*Context, error) {
 		RouteToCluster:    u.Identity.RouteToCluster,
 		KubernetesCluster: u.Identity.KubernetesCluster,
 		RouteToApp:        u.Identity.RouteToApp,
+		RouteToDatabase:   u.Identity.RouteToDatabase,
 	}
 
 	return &Context{

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -169,7 +169,7 @@ func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*Context, error) {
 	user.SetRoles(roleNames)
 
 	// Adjust expiry based on locally mapped roles.
-	ttl := u.Identity.Expires.Sub(time.Now())
+	ttl := time.Until(u.Identity.Expires)
 	ttl = checker.AdjustSessionTTL(ttl)
 
 	kubeUsers, kubeGroups, err := checker.CheckKubeGroupsAndUsers(ttl, false)

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/wrappers"
 
 	"github.com/gravitational/trace"
 	"github.com/vulcand/predicate/builder"
@@ -33,7 +35,7 @@ import (
 
 // NewAdminContext returns new admin auth context
 func NewAdminContext() (*Context, error) {
-	authContext, err := contextForBuiltinRole("", nil, teleport.RoleAdmin, fmt.Sprintf("%v", teleport.RoleAdmin))
+	authContext, err := contextForBuiltinRole(BuiltinRole{Role: teleport.RoleAdmin, Username: fmt.Sprintf("%v", teleport.RoleAdmin)}, nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -41,7 +43,10 @@ func NewAdminContext() (*Context, error) {
 }
 
 // NewAuthorizer returns new authorizer using backends
-func NewAuthorizer(access services.Access, identity services.UserGetter, trust services.Trust) (Authorizer, error) {
+func NewAuthorizer(clusterName string, access services.Access, identity services.UserGetter, trust services.Trust) (Authorizer, error) {
+	if clusterName == "" {
+		return nil, trace.BadParameter("missing parameter clusterName")
+	}
 	if access == nil {
 		return nil, trace.BadParameter("missing parameter access")
 	}
@@ -51,7 +56,7 @@ func NewAuthorizer(access services.Access, identity services.UserGetter, trust s
 	if trust == nil {
 		return nil, trace.BadParameter("missing parameter trust")
 	}
-	return &authorizer{access: access, identity: identity, trust: trust}, nil
+	return &authorizer{clusterName: clusterName, access: access, identity: identity, trust: trust}, nil
 }
 
 // Authorizer authorizes identity and returns auth context
@@ -62,9 +67,10 @@ type Authorizer interface {
 
 // authorizer creates new local authorizer
 type authorizer struct {
-	access   services.Access
-	identity services.UserGetter
-	trust    services.Trust
+	clusterName string
+	access      services.Access
+	identity    services.UserGetter
+	trust       services.Trust
 }
 
 // AuthContext is authorization context
@@ -73,9 +79,18 @@ type Context struct {
 	User services.User
 	// Checker is access checker
 	Checker services.AccessChecker
-	// Identity holds user identity - whether it's a local or remote user,
-	// local or remote node, proxy or auth server
+	// Identity holds the caller identity:
+	// 1. If caller is a user
+	//   a. local user identity
+	//   b. remote user identity remapped to local identity based on trusted
+	//      cluster role mapping.
+	// 2. If caller is a teleport instance, Identity holds their identity as-is
+	//    (because there's no role mapping for non-human roles)
 	Identity IdentityGetter
+	// UnmappedIdentity holds the original caller identity. If this is a remote
+	// user, UnmappedIdentity holds the data before role mapping. Otherwise,
+	// it's identical to Identity.
+	UnmappedIdentity IdentityGetter
 }
 
 // Authorize authorizes user based on identity supplied via context
@@ -84,15 +99,10 @@ func (a *authorizer) Authorize(ctx context.Context) (*Context, error) {
 		return nil, trace.AccessDenied("missing authentication context")
 	}
 	userI := ctx.Value(ContextUser)
-	userWithIdentity, ok := userI.(IdentityGetter)
-	if !ok {
-		return nil, trace.AccessDenied("unsupported context type %T", userI)
-	}
 	authContext, err := a.fromUser(userI)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	authContext.Identity = userWithIdentity
 	return authContext, nil
 }
 
@@ -124,10 +134,10 @@ func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*Context, error) {
 	}
 	roleNames, err := services.MapRoles(ca.CombinedMapping(), u.RemoteRoles)
 	if err != nil {
-		return nil, trace.AccessDenied("failed to map roles for remote user %q from cluster %q", u.Username, u.ClusterName)
+		return nil, trace.AccessDenied("failed to map roles for remote user %q from cluster %q with remote roles %v", u.Username, u.ClusterName, u.RemoteRoles)
 	}
 	if len(roleNames) == 0 {
-		return nil, trace.AccessDenied("no roles mapped for remote user %q from cluster %q", u.Username, u.ClusterName)
+		return nil, trace.AccessDenied("no roles mapped for remote user %q from cluster %q with remote roles %v", u.Username, u.ClusterName, u.RemoteRoles)
 	}
 	// Set "logins" trait and "kubernetes_groups" for the remote user. This allows Teleport to work by
 	// passing exact logins, kubernetes groups and users to the remote cluster. Note that claims (OIDC/SAML)
@@ -158,9 +168,48 @@ func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*Context, error) {
 	// Set the list of roles this user has in the remote cluster.
 	user.SetRoles(roleNames)
 
+	// Adjust expiry based on locally mapped roles.
+	ttl := u.Identity.Expires.Sub(time.Now())
+	ttl = checker.AdjustSessionTTL(ttl)
+
+	kubeUsers, kubeGroups, err := checker.CheckKubeGroupsAndUsers(ttl, false)
+	// IsNotFound means that the user has no k8s users or groups, which is fine
+	// in many cases. The downstream k8s handler will ensure that users/groups
+	// are set if this is a k8s request.
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+	principals, err := checker.CheckLoginDuration(ttl)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Convert u.Identity into the mapped local identity.
+	//
+	// This prevents downstream users from accidentally using the unmapped
+	// identity information and confusing who's accessing a resource.
+	identity := tlsca.Identity{
+		Username:         user.GetName(),
+		Groups:           user.GetRoles(),
+		Traits:           wrappers.Traits(traits),
+		Principals:       principals,
+		KubernetesGroups: kubeGroups,
+		KubernetesUsers:  kubeUsers,
+		TeleportCluster:  a.clusterName,
+		Expires:          time.Now().Add(ttl),
+
+		// These fields are for routing and restrictions, safe to re-use from
+		// unmapped identity.
+		Usage:             u.Identity.Usage,
+		RouteToCluster:    u.Identity.RouteToCluster,
+		KubernetesCluster: u.Identity.KubernetesCluster,
+		RouteToApp:        u.Identity.RouteToApp,
+	}
+
 	return &Context{
-		User:    user,
-		Checker: RemoteUserRoleSet{checker},
+		User:             user,
+		Checker:          RemoteUserRoleSet{checker},
+		Identity:         WrapIdentity(identity),
+		UnmappedIdentity: u,
 	}, nil
 }
 
@@ -170,7 +219,7 @@ func (a *authorizer) authorizeBuiltinRole(r BuiltinRole) (*Context, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return contextForBuiltinRole(r.ClusterName, config, r.Role, r.Username)
+	return contextForBuiltinRole(r, config)
 }
 
 func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, error) {
@@ -217,8 +266,10 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, 
 	}
 	user.SetRoles([]string{string(teleport.RoleRemoteProxy)})
 	return &Context{
-		User:    user,
-		Checker: RemoteBuiltinRoleSet{roles},
+		User:             user,
+		Checker:          RemoteBuiltinRoleSet{roles},
+		Identity:         r,
+		UnmappedIdentity: r,
 	}, nil
 }
 
@@ -502,19 +553,21 @@ func GetCheckerForBuiltinRole(clusterName string, clusterConfig services.Cluster
 	return nil, trace.NotFound("%q is not recognized", role.String())
 }
 
-func contextForBuiltinRole(clusterName string, clusterConfig services.ClusterConfig, r teleport.Role, username string) (*Context, error) {
-	checker, err := GetCheckerForBuiltinRole(clusterName, clusterConfig, r)
+func contextForBuiltinRole(r BuiltinRole, clusterConfig services.ClusterConfig) (*Context, error) {
+	checker, err := GetCheckerForBuiltinRole(r.ClusterName, clusterConfig, r.Role)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	user, err := services.NewUser(username)
+	user, err := services.NewUser(r.Username)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	user.SetRoles([]string{string(r)})
+	user.SetRoles([]string{string(r.Role)})
 	return &Context{
-		User:    user,
-		Checker: BuiltinRoleSet{checker},
+		User:             user,
+		Checker:          BuiltinRoleSet{checker},
+		Identity:         r,
+		UnmappedIdentity: r,
 	}, nil
 }
 
@@ -543,8 +596,10 @@ func contextForLocalUser(u LocalUser, identity services.UserGetter, access servi
 	user.SetTraits(traits)
 
 	return &Context{
-		User:    user,
-		Checker: LocalUserRoleSet{checker},
+		User:             user,
+		Checker:          LocalUserRoleSet{checker},
+		Identity:         u,
+		UnmappedIdentity: u,
 	}, nil
 }
 
@@ -589,7 +644,11 @@ func (l LocalUser) GetIdentity() tlsca.Identity {
 	return l.Identity
 }
 
-// IdentityGetter returns client identity
+// IdentityGetter returns the unmapped client identity.
+//
+// Unmapped means that if the client is a remote cluster user, the returned
+// tlsca.Identity contains data from the remote cluster before role mapping is
+// applied.
 type IdentityGetter interface {
 	// GetIdentity  returns x509-derived identity of the user
 	GetIdentity() tlsca.Identity

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -25,9 +25,9 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/wrappers"
 
 	"github.com/gravitational/trace"
 	"github.com/vulcand/predicate/builder"

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -439,10 +439,28 @@ func (f *Forwarder) setupContext(ctx auth.Context, req *http.Request, isRemoteUs
 	// ttl requested in tsh or the session ttl for the role.
 	sessionTTL := roles.AdjustSessionTTL(time.Hour)
 
-	// check signing TTL and return a list of allowed logins
-	kubeGroups, kubeUsers, err := roles.CheckKubeGroupsAndUsers(sessionTTL, false)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	identity := ctx.Identity.GetIdentity()
+	teleportClusterName := identity.RouteToCluster
+	if teleportClusterName == "" {
+		teleportClusterName = f.cfg.ClusterName
+	}
+	isRemoteCluster := f.cfg.ClusterName != teleportClusterName
+
+	if isRemoteCluster && isRemoteUser {
+		return nil, trace.AccessDenied("access denied: remote user can not access remote cluster")
+	}
+
+	var kubeUsers, kubeGroups []string
+	// Only check k8s principals for local clusters.
+	//
+	// For remote clusters, everything will be remapped to new roles on the
+	// leaf and checked there.
+	if !isRemoteCluster {
+		// check signing TTL and return a list of allowed logins
+		kubeGroups, kubeUsers, err = roles.CheckKubeGroupsAndUsers(sessionTTL, false)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	// By default, if no kubernetes_users is set (which will be a majority),
@@ -457,17 +475,6 @@ func (f *Forwarder) setupContext(ctx auth.Context, req *http.Request, isRemoteUs
 	// kubectl clients will not work
 	if !utils.SliceContainsStr(kubeGroups, teleport.KubeSystemAuthenticated) {
 		kubeGroups = append(kubeGroups, teleport.KubeSystemAuthenticated)
-	}
-
-	identity := ctx.Identity.GetIdentity()
-	teleportClusterName := identity.RouteToCluster
-	if teleportClusterName == "" {
-		teleportClusterName = f.cfg.ClusterName
-	}
-	isRemoteCluster := f.cfg.ClusterName != teleportClusterName
-
-	if isRemoteCluster && isRemoteUser {
-		return nil, trace.AccessDenied("access denied: remote user can not access remote cluster")
 	}
 
 	// Get a dialer for either a k8s endpoint in current cluster or a tunneled
@@ -1597,11 +1604,16 @@ func (f *Forwarder) requestCertificate(ctx authContext) (*tls.Config, error) {
 		return nil, trace.Wrap(err, "failed to parse private key")
 	}
 
-	// Note: ctx.Identity can potentially have temporary roles granted via
+	// Note: ctx.UnmappedIdentity can potentially have temporary roles granted via
 	// workflow API. Always use the Subject() method to preserve the roles from
 	// caller's certificate.
-	identity := ctx.Identity.GetIdentity()
-	subject, err := identity.Subject()
+	//
+	// Also note: we need to send the UnmappedIdentity which could be a remote
+	// user identity. If we used the local mapped identity instead, the
+	// receiver of this certificate will think this is a local user and fail to
+	// find it in the backend.
+	callerIdentity := ctx.UnmappedIdentity.GetIdentity()
+	subject, err := callerIdentity.Subject()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -59,6 +59,14 @@ func (s ForwarderSuite) TestRequestCertificate(c *check.C) {
 		Context: auth.Context{
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
+				Username:         "remote-bob",
+				Groups:           []string{"remote group a", "remote group b"},
+				Usage:            []string{"usage a", "usage b"},
+				Principals:       []string{"principal a", "principal b"},
+				KubernetesGroups: []string{"remote k8s group a", "remote k8s group b"},
+				Traits:           map[string][]string{"trait a": []string{"b", "c"}},
+			}),
+			UnmappedIdentity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
 				Groups:           []string{"group a", "group b"},
 				Usage:            []string{"usage a", "usage b"},
@@ -86,7 +94,7 @@ func (s ForwarderSuite) TestRequestCertificate(c *check.C) {
 	c.Assert(err, check.IsNil)
 	idFromCSR, err := tlsca.FromSubject(csr.Subject, time.Time{})
 	c.Assert(err, check.IsNil)
-	c.Assert(*idFromCSR, check.DeepEquals, ctx.Identity.GetIdentity())
+	c.Assert(*idFromCSR, check.DeepEquals, ctx.UnmappedIdentity.GetIdentity())
 }
 
 func TestAuthenticate(t *testing.T) {
@@ -199,7 +207,7 @@ func TestAuthenticate(t *testing.T) {
 
 			wantCtx: &authContext{
 				kubeUsers:  utils.StringsSet([]string{"user-a"}),
-				kubeGroups: utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
+				kubeGroups: utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
 				teleportCluster: teleportClusterClient{
 					name:       "remote",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -217,7 +225,25 @@ func TestAuthenticate(t *testing.T) {
 
 			wantCtx: &authContext{
 				kubeUsers:  utils.StringsSet([]string{"user-a"}),
-				kubeGroups: utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
+				kubeGroups: utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
+				teleportCluster: teleportClusterClient{
+					name:       "remote",
+					remoteAddr: *utils.MustParseAddr(remoteAddr),
+					isRemote:   true,
+				},
+			},
+		},
+		{
+			desc:           "local user and remote cluster, no local kube users or groups",
+			user:           auth.LocalUser{},
+			roleKubeGroups: nil,
+			routeToCluster: "remote",
+			haveKubeCreds:  true,
+			tunnel:         tun,
+
+			wantCtx: &authContext{
+				kubeUsers:  utils.StringsSet([]string{"user-a"}),
+				kubeGroups: utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
 				teleportCluster: teleportClusterClient{
 					name:       "remote",
 					remoteAddr: *utils.MustParseAddr(remoteAddr),
@@ -346,7 +372,7 @@ func TestAuthenticate(t *testing.T) {
 
 			wantCtx: &authContext{
 				kubeUsers:   utils.StringsSet([]string{"user-a"}),
-				kubeGroups:  utils.StringsSet([]string{"kube-group-a", "kube-group-b", teleport.KubeSystemAuthenticated}),
+				kubeGroups:  utils.StringsSet([]string{teleport.KubeSystemAuthenticated}),
 				kubeCluster: "foo",
 				teleportCluster: teleportClusterClient{
 					name:       "remote",
@@ -559,6 +585,14 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 		Context: auth.Context{
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
+				Username:         "remote-bob",
+				Groups:           []string{"remote group a", "remote group b"},
+				Usage:            []string{"usage a", "usage b"},
+				Principals:       []string{"principal a", "principal b"},
+				KubernetesGroups: []string{"remote k8s group a", "remote k8s group b"},
+				Traits:           map[string][]string{"trait a": []string{"b", "c"}},
+			}),
+			UnmappedIdentity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
 				Groups:           []string{"group a", "group b"},
 				Usage:            []string{"usage a", "usage b"},
@@ -590,6 +624,14 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 		Context: auth.Context{
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
+				Username:         "remote-bob",
+				Groups:           []string{"remote group a", "remote group b"},
+				Usage:            []string{"usage a", "usage b"},
+				Principals:       []string{"principal a", "principal b"},
+				KubernetesGroups: []string{"remote k8s group a", "remote k8s group b"},
+				Traits:           map[string][]string{"trait a": []string{"b", "c"}},
+			}),
+			UnmappedIdentity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
 				Groups:           []string{"group a", "group b"},
 				Usage:            []string{"usage a", "usage b"},
@@ -619,6 +661,14 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 		Context: auth.Context{
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
+				Username:         "remote-bob",
+				Groups:           []string{"remote group a", "remote group b"},
+				Usage:            []string{"usage a", "usage b"},
+				Principals:       []string{"principal a", "principal b"},
+				KubernetesGroups: []string{"remote k8s group a", "remote k8s group b"},
+				Traits:           map[string][]string{"trait a": []string{"b", "c"}},
+			}),
+			UnmappedIdentity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
 				Groups:           []string{"group a", "group b"},
 				Usage:            []string{"usage a", "usage b"},

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -100,7 +100,9 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 			}))
 	}
 
-	authorizer, err := auth.NewAuthorizer(conn.Client, conn.Client, conn.Client)
+	clusterName := conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority]
+
+	authorizer, err := auth.NewAuthorizer(clusterName, conn.Client, conn.Client, conn.Client)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -170,7 +172,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 			Server:      dbService,
 			AccessPoint: conn.Client,
 			HostSigner:  conn.ServerIdentity.KeySigner,
-			Cluster:     conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority],
+			Cluster:     clusterName,
 		})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -174,8 +174,10 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		}()
 	}
 
+	teleportClusterName := conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority]
+
 	// Create the kube server to service listener.
-	authorizer, err := auth.NewAuthorizer(conn.Client, conn.Client, conn.Client)
+	authorizer, err := auth.NewAuthorizer(teleportClusterName, conn.Client, conn.Client, conn.Client)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -206,7 +208,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		ForwarderConfig: kubeproxy.ForwarderConfig{
 			Namespace:         defaults.Namespace,
 			Keygen:            cfg.Keygen,
-			ClusterName:       conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority],
+			ClusterName:       teleportClusterName,
 			Authz:             authorizer,
 			AuthClient:        conn.Client,
 			StreamEmitter:     streamEmitter,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2713,7 +2713,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	// then routing them to a respective database server over the reverse tunnel
 	// framework.
 	if (listeners.db != nil || listeners.mysql != nil) && !process.Config.Proxy.DisableReverseTunnel {
-		authorizer, err := auth.NewAuthorizer(conn.Client, conn.Client, conn.Client)
+		authorizer, err := auth.NewAuthorizer(clusterName, conn.Client, conn.Client, conn.Client)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -191,7 +191,7 @@ func (s *Suite) SetUpTest(c *check.C) {
 	), 0755)
 	c.Assert(err, check.IsNil)
 
-	authorizer, err := auth.NewAuthorizer(s.authClient, s.authClient, s.authClient)
+	authorizer, err := auth.NewAuthorizer("cluster-name", s.authClient, s.authClient, s.authClient)
 	c.Assert(err, check.IsNil)
 
 	s.appServer, err = New(context.Background(), &Config{

--- a/lib/srv/db/db_test.go
+++ b/lib/srv/db/db_test.go
@@ -427,13 +427,13 @@ func setupTestContext(ctx context.Context, t *testing.T) *testContext {
 	// Auth client/authorizer for database service.
 	dbAuthClient, err := tlsServer.NewClient(auth.TestServerID(teleport.RoleDatabase, hostID))
 	require.NoError(t, err)
-	dbAuthorizer, err := auth.NewAuthorizer(dbAuthClient, dbAuthClient, dbAuthClient)
+	dbAuthorizer, err := auth.NewAuthorizer("cluster-name", dbAuthClient, dbAuthClient, dbAuthClient)
 	require.NoError(t, err)
 
 	// Auth client/authorizer for database proxy.
 	proxyAuthClient, err := tlsServer.NewClient(auth.TestBuiltin(teleport.RoleProxy))
 	require.NoError(t, err)
-	proxyAuthorizer, err := auth.NewAuthorizer(proxyAuthClient, proxyAuthClient, proxyAuthClient)
+	proxyAuthorizer, err := auth.NewAuthorizer("cluster-name", proxyAuthClient, proxyAuthClient, proxyAuthClient)
 	require.NoError(t, err)
 
 	// TLS config for database proxy and database service.

--- a/lib/srv/db/db_test.go
+++ b/lib/srv/db/db_test.go
@@ -427,13 +427,13 @@ func setupTestContext(ctx context.Context, t *testing.T) *testContext {
 	// Auth client/authorizer for database service.
 	dbAuthClient, err := tlsServer.NewClient(auth.TestServerID(teleport.RoleDatabase, hostID))
 	require.NoError(t, err)
-	dbAuthorizer, err := auth.NewAuthorizer("cluster-name", dbAuthClient, dbAuthClient, dbAuthClient)
+	dbAuthorizer, err := auth.NewAuthorizer(clusterName, dbAuthClient, dbAuthClient, dbAuthClient)
 	require.NoError(t, err)
 
 	// Auth client/authorizer for database proxy.
 	proxyAuthClient, err := tlsServer.NewClient(auth.TestBuiltin(teleport.RoleProxy))
 	require.NoError(t, err)
-	proxyAuthorizer, err := auth.NewAuthorizer("cluster-name", proxyAuthClient, proxyAuthClient, proxyAuthClient)
+	proxyAuthorizer, err := auth.NewAuthorizer(clusterName, proxyAuthClient, proxyAuthClient, proxyAuthClient)
 	require.NoError(t, err)
 
 	// TLS config for database proxy and database service.


### PR DESCRIPTION
In particular, please verify the changes needed to be made to `lib/service/db.go`.