### PR TITLE
Error on tctl get docs. Has delete instead of get.

### DIFF
--- a/docs/5.0/pages/cli-docs.mdx
+++ b/docs/5.0/pages/cli-docs.mdx
@@ -516,7 +516,7 @@ creating new user roles or connecting trusted clusters.
 | `-d, --debug` | none | none | Enable verbose logging to stderr
 `-c, --config` | `/etc/teleport.yaml` | **string** filepath | Path to a configuration file
 
-## tctl  help
+## tctl help
 
 Shows help.
 
@@ -947,9 +947,9 @@ Print a YAML declaration of various Teleport resources
 
 ### Arguments
 
-* `[<resource-type/resource-name>]` Resource to delete
+* `[<resource-type/resource-name>]` Resource to get
     - `<resource type>` Type of a resource [for example: `user,cluster,token` ]
-    - `<resource name>` Resource name to delete
+    - `<resource name>` Resource name to get
 
 ### Flags
 


### PR DESCRIPTION
Fixed some typos/copy-pasta errors on `tctl get`. The `tctl get` docs was copied from the `tctl rm` above it and `delete` was still in some of the examples instead of `get`