### PR TITLE
Don't create admin role as part of SSO guides

### DIFF
--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -79,39 +79,14 @@ $ tctl create oidc-connector.yaml
 
 ## Create Teleport Roles
 
-The next step is to define Teleport roles. They are created using the same
-`tctl` [resource commands](../../admin-guide.mdx#resources) as we used for the auth
-connector.
+A Teleport role `admin` for administrators exists by default.
 
-Below are two example roles that are mentioned above, the first is an admin
-with full access to the system while the second is a developer with limited
-access.
+Let's create a non-privileged role `dev` intended for regular developers.
+You can create the role using `tctl create dev-role.yaml` CLI command
+or via the Web UI.
 
 ```yaml
-# role-admin.yaml
-kind: "role"
-version: "v3"
-metadata:
-  name: "admin"
-spec:
-  options:
-    max_session_ttl: "90h0m0s"
-  allow:
-    logins: [root]
-    node_labels:
-      "*": "*"
-    rules:
-      - resources: ["*"]
-        verbs: ["*"]
-```
-
-Users are only allowed to login to nodes labelled with `access: relaxed`
-teleport label. Developers can log in as either `ubuntu` to a username that
-arrives in their assertions. Developers also do not have any rules needed to
-obtain admin access.
-
-```yaml
-# role-dev.yaml
+# dev-role.yaml
 kind: "role"
 version: "v3"
 metadata:
@@ -125,12 +100,12 @@ spec:
       access: relaxed
 ```
 
-Create both roles:
+Developers are only allowed to login to nodes labelled with `access: relaxed`
+teleport label. Developers can log in as either `ubuntu` or a username that
+arrives in their assertions. Developers also do not have any rules needed to
+obtain admin access.
 
-```bsh
-$ tctl create role-admin.yaml
-$ tctl create role-dev.yaml
-```
+**Notice:** Replace `ubuntu` with linux login available on your servers!
 
 ### Optional: ACR Values
 
@@ -166,8 +141,8 @@ spec:
        value: "admin"
        roles: [ "admin" ]
      - claim: "group"
-       value: "user"
-       roles: [ "user" ]
+       value: "dev"
+       roles: [ "dev" ]
 ```
 
 ### Optional: Redirect URL and Timeout

--- a/docs/pages/enterprise/sso/ssh-adfs.mdx
+++ b/docs/pages/enterprise/sso/ssh-adfs.mdx
@@ -82,39 +82,40 @@ associated with it. To check this open Server Manager then
 _"Tools -> Active Directory Users and Computers"_ and select the user and right
 click and open properties. Make sure the email address field is filled out.
 
+## Create a SAML Connector
+
+Next, create a SAML connector [resource](../../admin-guide.mdx#resources):
+
+```yaml
+{!examples/resources/adfs-connector.yaml!}
+```
+
+The `acs` field should match the value you set in ADFS earlier and you can
+obtain the `entity_descriptor_url` from ADFS under _"ADFS -> Service -> Endpoints -> Metadata"_.
+
+The `attributes_to_roles` is used to map attributes to the Teleport roles you
+just created. In our situation, we are mapping the _"Group"_ attribute whose full
+name is `http://schemas.xmlsoap.org/claims/Group` with a value of _"admins"_
+to the _"admin"_ role. Groups with the value _"users"_ is being mapped to the
+_"users"_ role.
+
 ## Create Teleport Roles
 
-Lets create two Teleport roles: one for administrators and the other is for
-normal users. You can create them using `tctl create {file name}` CLI command
+A Teleport role `admin` for administrators exists by default.
+
+Let's create a non-privileged role `dev` intended for regular developers.
+You can create the role using `tctl create dev-role.yaml` CLI command
 or via the Web UI.
 
 ```yaml
-# admin-role.yaml
-kind: "role"
-version: "v3"
-metadata:
-  name: "admin"
-spec:
-  options:
-    max_session_ttl: "8h0m0s"
-  allow:
-    logins: [ root ]
-    node_labels:
-      "*": "*"
-    rules:
-      - resources: ["*"]
-        verbs: ["*"]
-```
-
-```yaml
-# user-role.yaml
+# dev-role.yaml
 kind: "role"
 version: "v3"
 metadata:
   name: "dev"
 spec:
   options:
-    # regular users can only be guests and their certificates will have a TTL of 1 hour:
+    # regular devs can only be guests and their certificates will have a TTL of 1 hour
     max_session_ttl: "1h"
   allow:
     # only allow login as either ubuntu or the 'windowsaccountname' claim
@@ -125,29 +126,15 @@ spec:
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
-* Developers can log in as `ubuntu` user
-* Notice `{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}` login. It configures Teleport to look at
-  _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
-  Also note the double quotes (`"`) and square brackets (`[]`) around the claim name - these are important.
+* Developers are only allowed to login to nodes labelled with `access: relaxed` label.
+* All developers can log in using the `ubuntu` username.
+* In addition, each developer is allowed to use the login derived from their _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim.
+  This is configured by the `{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}` login entry.
+  Note the double quotes (`"`) and square brackets (`[]`) around the claim name - these are important.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 
-Next, create a SAML connector [resource](../../admin-guide.mdx#resources):
-
-```yaml
-{!examples/resources/adfs-connector.yaml!}
-```
-
-
-The `acs` field should match the value you set in ADFS earlier and you can
-obtain the `entity_descriptor_url` from ADFS under _"ADFS -> Service -> Endpoints -> Metadata"_.
-
-The `attributes_to_roles` is used to map attributes to the Teleport roles you
-just created. In our situation, we are mapping the _"Group"_ attribute whose full
-name is `http://schemas.xmlsoap.org/claims/Group` with a value of _"admins"_
-to the _"admin"_ role. Groups with the value _"users"_ is being mapped to the
-_"users"_ role.
+**Notice:** Replace `ubuntu` with linux login available on your servers!
 
 ## Export the Signing Key
 

--- a/docs/pages/enterprise/sso/ssh-azuread.mdx
+++ b/docs/pages/enterprise/sso/ssh-azuread.mdx
@@ -113,35 +113,14 @@ Teleport will automatically transform the contents of the connector when viewed 
 
 ## Create Teleport Roles
 
-We are going to create 2 roles:
+A Teleport role `admin` for administrators exists by default.
 
--  Privileged role `admin` who is able to login as root and is capable of administrating
-the cluster
-- Non-privileged role `dev`
-
-```yaml
-kind: role
-version: v3
-metadata:
-  name: admin
-spec:
-  options:
-    max_session_ttl: 24h
-  allow:
-    logins: [root]
-    node_labels:
-      "*": "*"
-    rules:
-      - resources: ["*"]
-        verbs: ["*"]
-```
-
-Devs are only allowed to login to nodes labeled with `access: relaxed`
-Teleport label. Developers can log in as either `ubuntu` or a username that
-arrives in their assertions. Developers also do not have any rules needed to
-obtain admin access to Teleport.
+Let's create a non-privileged role `dev` intended for regular developers.
+You can create the role using `tctl create dev-role.yaml` CLI command
+or via the Web UI.
 
 ```yaml
+# dev-role.yaml
 kind: role
 version: v3
 metadata:
@@ -155,12 +134,12 @@ spec:
       access: relaxed
 ```
 
-**Notice:** Replace `ubuntu` with linux login available on your servers!
+Devs are only allowed to login to nodes labeled with `access: relaxed`
+Teleport label. Developers can log in as either `ubuntu` or a username that
+arrives in their assertions. Developers also do not have any rules needed to
+obtain admin access to Teleport.
 
-```bsh
-$ tctl create admin.yaml
-$ tctl create dev.yaml
-```
+**Notice:** Replace `ubuntu` with linux login available on your servers!
 
 ## Testing
 

--- a/docs/pages/enterprise/sso/ssh-gsuite.mdx
+++ b/docs/pages/enterprise/sso/ssh-gsuite.mdx
@@ -117,35 +117,14 @@ $ tctl create gsuite-connector.yaml
 
 ## Create Teleport Roles
 
-We are going to create 2 roles:
+A Teleport role `admin` for administrators exists by default.
 
--  Privileged role admin who is able to login as root and is capable of administrating
-the cluster
-- Non-privileged dev
-
-```yaml
-kind: role
-version: v3
-metadata:
-  name: admin
-spec:
-  options:
-    max_session_ttl: 24h
-  allow:
-    logins: [root]
-    node_labels:
-      "*": "*"
-    rules:
-      - resources: ["*"]
-        verbs: ["*"]
-```
-
-Devs are only allowed to login to nodes labelled with `access: relaxed`
-Teleport label. Developers can log in as either `ubuntu` or a username that
-arrives in their assertions. Developers also do not have any rules needed to
-obtain admin access to Teleport.
+Let's create a non-privileged role `dev` intended for regular developers.
+You can create the role using `tctl create dev-role.yaml` CLI command
+or via the Web UI.
 
 ```yaml
+# dev-role.yaml
 kind: role
 version: v3
 metadata:
@@ -159,12 +138,12 @@ spec:
       access: relaxed
 ```
 
-**Notice:** Replace `ubuntu` with linux login available on your servers!
+Devs are only allowed to login to nodes labelled with `access: relaxed`
+Teleport label. Developers can log in as either `ubuntu` or a username that
+arrives in their assertions. Developers also do not have any rules needed to
+obtain admin access to Teleport.
 
-```bsh
-$ tctl create admin.yaml
-$ tctl create dev.yaml
-```
+**Notice:** Replace `ubuntu` with linux login available on your servers!
 
 ## Testing
 

--- a/docs/pages/enterprise/sso/ssh-okta.mdx
+++ b/docs/pages/enterprise/sso/ssh-okta.mdx
@@ -115,29 +115,14 @@ $ tctl create okta-connector.yaml
 
 ## Create Teleport Roles
 
-We are going to create 2 roles, privileged role admin who is able to login as
-root and is capable of administrating the cluster and non-privileged dev.
+A Teleport role `admin` for administrators exists by default.
+
+Let's create a non-privileged role `dev` intended for regular developers.
+You can create the role using `tctl create dev-role.yaml` CLI command
+or via the Web UI.
 
 ```yaml
-kind: role
-version: v3
-metadata:
-  name: admin
-spec:
-  options:
-    max_session_ttl: 24h
-  allow:
-    logins: [root]
-    node_labels:
-      "*": "*"
-    rules:
-      - resources: ["*"]
-        verbs: ["*"]
-```
-
-The developer role:
-
-```yaml
+# dev-role.yaml
 kind: role
 version: v3
 metadata:
@@ -151,19 +136,17 @@ spec:
       access: relaxed
 ```
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
-* Developers can log in as `ubuntu` user
-* Notice `{% raw %}{{external.username}}{% endraw %}` login. It configures Teleport to look at
-  _"username"_ Okta claim and use that field as an allowed login for each user.  This example uses email as the username format.  The `email.local(external.trait)` function will remove the `@domain` and just have the username prefix.
+This role declares:
+
+* Developers are only allowed to login to nodes labelled with `access: relaxed` label.
+* All developers can log in using the `ubuntu` username.
+* In addition, each developer is allowed to use the login derived from their _"username"_ Okta claim.
+  This is configured by the `{% raw %}{{email.local(external.username)}}{% endraw %}` login entry, which moreover
+  removes the `@domain` part and extracts just the username from the user's email address.
 * Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 
-Now, create both roles on the auth server:
-
-```bsh
-$ tctl create admin.yaml
-$ tctl create dev.yaml
-```
+**Notice:** Replace `ubuntu` with linux login available on your servers!
 
 ## Testing
 

--- a/docs/pages/enterprise/sso/ssh-one-login.mdx
+++ b/docs/pages/enterprise/sso/ssh-one-login.mdx
@@ -115,32 +115,14 @@ $ tctl create onelogin-connector.yaml
 
 ## Create Teleport Roles
 
-We are going to create 2 roles, privileged role admin who is able to login as
-root and is capable of administrating the cluster and non-privileged dev.
+A Teleport role `admin` for administrators exists by default.
+
+Let's create a non-privileged role `dev` intended for regular developers.
+You can create the role using `tctl create dev-role.yaml` CLI command
+or via the Web UI.
 
 ```yaml
-kind: role
-version: v3
-metadata:
-  name: admin
-spec:
-  options:
-    max_session_ttl: 24h
-  allow:
-    logins: [root]
-    node_labels:
-      "*": "*"
-    rules:
-      - resources: ["*"]
-        verbs: ["*"]
-```
-
-Devs are only allowed to login to nodes labelled with `access: relaxed`
-Teleport label. Developers can log in as either `ubuntu` to a username that
-arrives in their assertions. Developers also do not have any rules needed to
-obtain admin access to Teleport.
-
-```yaml
+# dev-role.yaml
 kind: role
 version: v3
 metadata:
@@ -154,12 +136,12 @@ spec:
       access: relaxed
 ```
 
-**Notice:** Replace `ubuntu` with linux login available on your servers!
+Developers are only allowed to login to nodes labelled with `access: relaxed`
+Teleport label. Developers can log in as either `ubuntu` or a username that
+arrives in their assertions. Developers also do not have any rules needed to
+obtain admin access to Teleport.
 
-```bsh
-$ tctl create admin.yaml
-$ tctl create dev.yaml
-```
+**Notice:** Replace `ubuntu` with linux login available on your servers!
 
 ## Testing
 

--- a/docs/pages/enterprise/sso/ssh-sso.mdx
+++ b/docs/pages/enterprise/sso/ssh-sso.mdx
@@ -21,7 +21,7 @@ or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 - [Active Directory (ADFS)](ssh-adfs.mdx)
 - [G Suite](ssh-gsuite.mdx)
 - [OneLogin](ssh-one-login.mdx)
-- [OIDC](oidc.mdx)
+- [OAuth2 / OpenID Connect](oidc.mdx)
 - [Okta](ssh-okta.mdx)
 
 ## How does SSO work with SSH?
@@ -93,12 +93,12 @@ spec:
     - {name: "groups", value: "okta-admin", roles: ["admin"]}
     - {name: "groups", value: "okta-dev", roles: ["dev"]}
 
-     # note that wildcards can also be used. the next line instructs Teleport
-     # to assign "admin" role to any user who has the SAML attribute that begins with "admin":
-     - { name: "group", value: "admin*", roles: ["admin"] }
-     # regular expressions with capture are also supported. the next line instructs Teleport
-     # to assign users to roles `admin-1` if his SAML "group" attribute equals 'ssh_admin_1':
-     - { name: "group", value: "^ssh_admin_(.*)$", roles: ["admin-$1"] }
+    # note that wildcards can also be used. the next line instructs Teleport
+    # to assign "admin" role to any user who has the SAML attribute that begins with "admin":
+    - { name: "groups", value: "admin*", roles: ["admin"] }
+    # regular expressions with capture are also supported. the next line instructs Teleport
+    # to assign users to roles `admin-1` if his SAML "group" attribute equals 'ssh_admin_1':
+    - { name: "groups", value: "^ssh_admin_(.*)$", roles: ["admin-$1"] }
 
   entity_descriptor: |
     <paste SAML XML contents here>
@@ -107,7 +107,7 @@ spec:
 * See [examples/resources](https://github.com/gravitational/teleport/tree/master/examples/resources)
   directory in the Teleport Github repository for examples of possible connectors.
 * You may use `entity_descriptor_url`, in lieu of `entity_descriptor`, to fetch the entity descriptor from
-your IDP. Though, we recommend "pinning" the entity descriptor by including the XML rather than fetching from a URL.
+  your IDP. Though, we recommend "pinning" the entity descriptor by including the XML rather than fetching from a URL.
 
 ### User Logins
 
@@ -181,14 +181,6 @@ $ tsh --proxy=proxy.example.com login --auth=okta
 # use local Teleport user DB:
 $ tsh --proxy=proxy.example.com login --auth=local --user=admin
 ```
-
-Refer to the following guides to configure authentication connectors of both
-SAML and OIDC types:
-
-* [SSH Authentication with Okta](ssh-okta.mdx)
-* [SSH Authentication with OneLogin](ssh-one-login.mdx)
-* [SSH Authentication with ADFS](ssh-adfs.mdx)
-* [SSH Authentication with OAuth2 / OpenID Connect](oidc.mdx)
 
 ## SSO Customization
 

--- a/examples/resources/adfs-connector.yaml
+++ b/examples/resources/adfs-connector.yaml
@@ -57,5 +57,5 @@ spec:
       value: "Administrators"
       roles: ["admin"]
     - name: "http://schemas.xmlsoap.org/claims/Group"
-      value: "Users"
-      roles: ["user"]
+      value: "Developers"
+      roles: ["dev"]


### PR DESCRIPTION
The `admin` role exists by default so following the steps as given
would have resulted in an error.