### PR TITLE
Fixed `tctl get`. Had `delete` instead of `get`

### DIFF
--- a/docs/pages/cli-docs.mdx
+++ b/docs/pages/cli-docs.mdx
@@ -947,9 +947,9 @@ Print a YAML declaration of various Teleport resources
 
 ### Arguments
 
-* `[<resource-type/resource-name>]` Resource to delete
+* `[<resource-type/resource-name>]` Resource to get
     - `<resource type>` Type of a resource [for example: `user,cluster,token` ]
-    - `<resource name>` Resource name to delete
+    - `<resource name>` Resource name to get
 
 ### Flags
 


### PR DESCRIPTION
The `tctl get` was copied from `tctl rm` it looks like and had some remaining `delete` statements when it should be `get` statements.

Also submitted a PR for v5 (current docs on the web that have the same typo).