### PR TITLE
Adds md5 auth caveat to Self-Hosted Postgres Guide

### DIFF
--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -63,6 +63,10 @@ hostssl all             all             ::/0                    cert
 hostssl all             all             0.0.0.0/0               cert
 ```
 
+You should also ensure that you have no higher-priority `md5` authentication 
+rules that will match, otherwise PostgreSQL will offer them first, and the 
+certificate-based Teleport login will fail.
+
 See [The pg_hba.conf File](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
 in PostgreSQL documentation for more details.
 


### PR DESCRIPTION
The existing guide says to that several entries need to be added
to the PostgreSQL authentication rules file.

What is non-obvious is that simply appending these rules may not work,
as a higher-priority rule may override them. If this happens, PostgreSQL
may not let the Teleport DB proxy log in as, for example, as PostgreSQL
will expect a password that the proxy doesn't have.

This change adds a caveat to the `pg_hba.conf` configuration warning
that this might happen so the reader doesn't have to spend time
diagnosing login failures.