### PR TITLE
Fixes ACME default configuration

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -380,10 +380,10 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 	if flags.ACMEEnabled {
 		p.ACME.EnabledFlag = "yes"
 		p.ACME.Email = flags.ACMEEmail
-		p.PublicAddr = utils.Strings{
-			net.JoinHostPort(flags.ClusterName,
-				fmt.Sprintf("%d", conf.Proxy.WebAddr.Port(defaults.HTTPListenPort))),
-		}
+		// ACME uses TLS-ALPN-01 challenge that requires port 443
+		// https://letsencrypt.org/docs/challenge-types/#tls-alpn-01
+		p.PublicAddr = utils.Strings{net.JoinHostPort(flags.ClusterName, fmt.Sprintf("%d", teleport.StandardHTTPSPort))}
+		p.WebAddr = fmt.Sprintf(":%d", teleport.StandardHTTPSPort)
 	}
 
 	fc = &FileConfig{

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -213,7 +213,7 @@ func (u *UserCommand) Add(client auth.ClientI) error {
 			// A caller has attempted to mix legacy and new format.
 			if len(u.allowedLogins) != 0 || len(u.createRoles) != 0 {
 				return trace.BadParameter(
-					"please use --roles flag without use of logins positional argument, --k8s-users and k8s-groups flags")
+					`please use --roles and --logins flags instead of deprecated positional arguments, --k8s-users and k8s-groups flags`)
 			}
 			return u.legacyAdd(client)
 			// This is a legacy OSS scenario: `tctl users add bob`


### PR DESCRIPTION
Fixes #5771, tctl configure has to generate port :443
when ACME is on, because TLS-ALPN-01 challenge only works on 443 port.