### PR TITLE
Lint markdown files syntax for v3.2 with the new linter

### DIFF
--- a/docs/pages/admin-guide.mdx
+++ b/docs/pages/admin-guide.mdx
@@ -38,32 +38,35 @@ $ sudo mkdir -p /var/lib/teleport
 Before diving into configuring and running Teleport, it helps to take a look at the [Teleport Architecture](/architecture)
 and review the key concepts this document will be referring to:
 
-|Concept   | Description
-|----------|------------
-|Node      | Synonym to "server" or "computer", something one can "SSH to". A node must be running the `teleport` daemon with "node" role/service turned on.
-|Certificate Authority (CA) | A pair of public/private keys Teleport uses to manage access. A CA can sign a public key of a user or node, establishing their cluster membership.
-|Teleport Cluster | A Teleport Auth Service contains two CAs. One is used to sign user keys and the other signs node keys. A collection of nodes connected to the same CA is called a "cluster".
-|Cluster Name | Every Teleport cluster must have a name. If a name is not supplied via `teleport.yaml` configuration file, a GUID will be generated. **IMPORTANT:** renaming a cluster invalidates its keys and all certificates it had created.
-|Trusted Cluster | Teleport Auth Service can allow 3rd party users or nodes to connect if their public keys are signed by a trusted CA. A "trusted cluster" is a pair of public keys of the trusted CA. It can be configured via `teleport.yaml` file.
+| Concept | Description |
+| - | - |
+| Node | Synonym to "server" or "computer", something one can "SSH to". A node must be running the `teleport` daemon with "node" role/service turned on. |
+| Certificate Authority (CA) | A pair of public/private keys Teleport uses to manage access. A CA can sign a public key of a user or node, establishing their cluster membership. |
+| Teleport Cluster | A Teleport Auth Service contains two CAs. One is used to sign user keys and the other signs node keys. A collection of nodes connected to the same CA is called a "cluster". |
+| Cluster Name | Every Teleport cluster must have a name. If a name is not supplied via `teleport.yaml` configuration file, a GUID will be generated. **IMPORTANT:** renaming a cluster invalidates its keys and all certificates it had created. |
+| Trusted Cluster | Teleport Auth Service can allow 3rd party users or nodes to connect if their public keys are signed by a trusted CA. A "trusted cluster" is a pair of public keys of the trusted CA. It can be configured via `teleport.yaml` file. |
 
 ## Teleport Daemon
 
 The Teleport daemon is called `teleport` and it supports the following commands:
 
-|Command     | Description
-|------------|-------------------------------------------------------
-|start       | Starts the Teleport daemon.
-|configure   | Dumps a sample configuration file in YAML format into standard output.
-|version     | Shows the Teleport version.
-|status      | Shows the status of a Teleport connection. This command is only available from inside of an active SSH session.
-|help        | Shows help.
+| Command | Description |
+| - | - |
+| start | Starts the Teleport daemon. |
+| configure | Dumps a sample configuration file in YAML format into standard output. |
+| version | Shows the Teleport version. |
+| status | Shows the status of a Teleport connection. This command is only available from inside of an active SSH session. |
+| help | Shows help. |
 
 When experimenting, you can quickly start `teleport` with verbose logging by typing
 `teleport start -d`.
 
-<Admonition type="danger" title="WARNING">
-Teleport stores data in `/var/lib/teleport`. Make sure that regular/non-admin users do not
-have access to this folder on the Auth server.
+<Admonition
+  type="danger"
+  title="WARNING"
+>
+  Teleport stores data in `/var/lib/teleport`. Make sure that regular/non-admin users do not
+  have access to this folder on the Auth server.
 </Admonition>
 
 ### Systemd Unit File
@@ -94,44 +97,47 @@ will perform a graceful restart, i.e. the Teleport daemon will fork a new
 process to handle new incoming requests, leaving the old daemon process running
 until existing clients disconnect.
 
-<Admonition type="warning" title="Version warning">
-Graceful restarts only work if Teleport is deployed using network-based storage
-like DynamoDB or etcd 3.3+. Future versions of Teleport will not have this limitation.
+<Admonition
+  type="warning"
+  title="Version warning"
+>
+  Graceful restarts only work if Teleport is deployed using network-based storage
+  like DynamoDB or etcd 3.3+. Future versions of Teleport will not have this limitation.
 </Admonition>
 
 You can also perform restarts/upgrades by sending `kill` signals
 to a Teleport daemon manually.
 
-| Signal                  | Teleport Daemon Behavior
-|-------------------------|---------------------------------------
-| `USR1`                  | Dumps diagnostics/debugging information into syslog.
-| `TERM`, `INT` or `KILL` | Immediate non-graceful shutdown. All existing connections will be dropped.
-| `USR2`                  | Forks a new Teleport daemon to serve new connections.
-| `HUP`                   | Forks a new Teleport daemon to serve new connections **and** initiates the graceful shutdown of the existing process when there are no more clients connected to it.
+| Signal | Teleport Daemon Behavior |
+| - | - |
+| `USR1` | Dumps diagnostics/debugging information into syslog. |
+| `TERM`, `INT` or `KILL` | Immediate non-graceful shutdown. All existing connections will be dropped. |
+| `USR2` | Forks a new Teleport daemon to serve new connections. |
+| `HUP` | Forks a new Teleport daemon to serve new connections **and** initiates the graceful shutdown of the existing process when there are no more clients connected to it. |
 
 ### Ports
 
 Teleport services listen on several ports. This table shows the default port numbers.
 
-|Port      | Service    | Description
-|----------|------------|-------------------------------------------
-|3022      | Node       | SSH port. This is Teleport's equivalent of port `#22` for SSH.
-|3023      | Proxy      | SSH port clients connect to. A proxy will forward this connection to port `#3022` on the destination node.
-|3024      | Proxy      | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server.
-|3025      | Auth       | SSH port used by the Auth Service to serve its API to other nodes in a cluster.
-|3080      | Proxy      | HTTPS connection to authenticate `tsh` users and web users into the cluster. The same connection is used to serve a Web UI.
-|3026      | Kubernetes Proxy      | HTTPS Kubernetes proxy (if enabled)
+| Port | Service | Description |
+| - | - | - |
+| 3022 | Node | SSH port. This is Teleport's equivalent of port `#22` for SSH. |
+| 3023 | Proxy | SSH port clients connect to. A proxy will forward this connection to port `#3022` on the destination node. |
+| 3024 | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. |
+| 3025 | Auth | SSH port used by the Auth Service to serve its API to other nodes in a cluster. |
+| 3080 | Proxy | HTTPS connection to authenticate `tsh` users and web users into the cluster. The same connection is used to serve a Web UI. |
+| 3026 | Kubernetes Proxy | HTTPS Kubernetes proxy (if enabled) |
 
 ### Filesystem Layout
 
 By default, a Teleport node has the following files present. The location of all of them is configurable.
 
-Full path                    | Purpose
------------------------------|---------------------------
-`/etc/teleport.yaml`         | Teleport configuration file (optional).
-`/usr/local/bin/teleport`    | Teleport daemon binary.
-`/usr/local/bin/tctl`        | Teleport admin tool. It is only needed for auth servers.
-`/var/lib/teleport`          | Teleport data directory. Nodes keep their keys and certificates there. Auth servers store the audit log and the cluster keys there, but the audit log storage can be further configured via `auth_service` section in the config file.
+| Full path | Purpose |
+| - | - |
+| `/etc/teleport.yaml` | Teleport configuration file (optional). |
+| `/usr/local/bin/teleport` | Teleport daemon binary. |
+| `/usr/local/bin/tctl` | Teleport admin tool. It is only needed for auth servers. |
+| `/var/lib/teleport` | Teleport data directory. Nodes keep their keys and certificates there. Auth servers store the audit log and the cluster keys there, but the audit log storage can be further configured via `auth_service` section in the config file. |
 
 ## Configuration
 
@@ -161,17 +167,17 @@ Flags:
 
 Let's cover some of these flags in more detail:
 
-* `--insecure-no-tls` flag tells Teleport proxy to not generate default self-signed TLS
+- `--insecure-no-tls` flag tells Teleport proxy to not generate default self-signed TLS
   certificates. This is useful when running Teleport on kubernetes (behind reverse
   proxy) or behind things like AWS ELB, where SSL termination is provided externally.
   The possible values are `true` or  `false`. The default value is `false`.
 
-* `--roles` flag tells Teleport which services to start. It is a comma-separated
+- `--roles` flag tells Teleport which services to start. It is a comma-separated
   list of roles. The possible values are `auth`, `node` and `proxy`. The default
   value is `auth,node,proxy`. These roles are explained in the
   [Teleport Architecture](architecture.mdx) document.
 
-* `--advertise-ip` flag can be used when Teleport nodes are running behind NAT and
+- `--advertise-ip` flag can be used when Teleport nodes are running behind NAT and
   their externally routable IP cannot be automatically determined.
   For example, assume that a host "foo" can be reached via `10.0.0.10` but there is
   no `A` DNS record for "foo", so you cannot connect to it via `tsh ssh foo`. If
@@ -179,28 +185,31 @@ Let's cover some of these flags in more detail:
   tell Teleport proxy to use that IP when someone tries to connect
   to "foo". This is also useful when connecting to Teleport nodes using their labels.
 
-* `--nodename` flag lets you assign an alternative name for the node which can be used
+- `--nodename` flag lets you assign an alternative name for the node which can be used
   by clients to login. By default it's equal to the value returned by `hostname`
   command.
 
-* `--listen-ip` should be used to tell `teleport` daemon to bind to a specific network
+- `--listen-ip` should be used to tell `teleport` daemon to bind to a specific network
   interface. By default it listens on all.
 
-* `--labels` flag assigns a set of labels to a node. See the explanation
+- `--labels` flag assigns a set of labels to a node. See the explanation
   of labeling mechanism in the [Labeling Nodes](#labeling-nodes) section below.
 
-* `--pid-file` flag creates a PID file if a path is given.
+- `--pid-file` flag creates a PID file if a path is given.
 
-* `--permit-user-env` flag reads in environment variables from `~/.tsh/environment`
+- `--permit-user-env` flag reads in environment variables from `~/.tsh/environment`
   when creating a session.
 
 ### Configuration File
 
 Teleport uses the YAML file format for configuration. A sample configuration file is shown below. By default, it is stored in `/etc/teleport.yaml`
 
-<Admonition type="note" title="IMPORTANT">
-When editing YAML configuration, please pay attention to how your editor
-handles white space. YAML requires consistent handling of tab characters.
+<Admonition
+  type="note"
+  title="IMPORTANT"
+>
+  When editing YAML configuration, please pay attention to how your editor
+  handles white space. YAML requires consistent handling of tab characters.
 </Admonition>
 
 ```yaml
@@ -498,8 +507,8 @@ public_addr: ["proxy-one.example.com", "proxy-two.example.com"]
 
 Specifying a public address for a Teleport service may be useful in the following use cases:
 
-* You have multiple identical services, like proxies, behind a load balancer.
-* You want Teleport to issue SSH certificate for the service with the
+- You have multiple identical services, like proxies, behind a load balancer.
+- You want Teleport to issue SSH certificate for the service with the
   additional principals, e.g. host names.
 
 ## Authentication
@@ -513,12 +522,12 @@ Local authentication is used to authenticate against a local Teleport user datab
 is managed by `tctl users` command. Teleport also supports second factor authentication
 (2FA) for the local connector. There are three possible values (types) of 2FA:
 
-  * `otp` is the default. It implements [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
-     standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator) or
-    [Authy](https://www.authy.com/) or any other TOTP client.
-  * `u2f` implements [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) standard for utilizing hardware (USB)
-    keys for second factor.
-  * `off` turns off second factor authentication.
+- `otp` is the default. It implements [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
+  standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator) or
+  [Authy](https://www.authy.com/) or any other TOTP client.
+- `u2f` implements [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor) standard for utilizing hardware (USB)
+  keys for second factor.
+- `off` turns off second factor authentication.
 
 Here is an example of this setting in the `teleport.yaml`:
 
@@ -572,15 +581,14 @@ auth_service:
     type: oidc
 ```
 
-
 ### FIDO U2F
 
 Teleport supports [FIDO U2F](https://www.yubico.com/about/background/fido/)
 hardware keys as a second authentication factor. By default U2F is disabled. To start using U2F:
 
-* Enable U2F in Teleport configuration `/etc/teleport.yaml`.
-* For CLI-based logins you have to install [u2f-host](https://developers.yubico.com/libu2f-host/) utility.
-* For web-based logins you have to use Google Chrome, as it is the only browser supporting U2F at this time.
+- Enable U2F in Teleport configuration `/etc/teleport.yaml`.
+- For CLI-based logins you have to install [u2f-host](https://developers.yubico.com/libu2f-host/) utility.
+- For web-based logins you have to use Google Chrome, as it is the only browser supporting U2F at this time.
 
 ```yaml
 # snippet from /etc/teleport.yaml to show an examlpe configuration of U2F:
@@ -603,12 +611,15 @@ proxy, but this will prevent you from adding more proxies without changing the
 `app_id`. For multi-proxy setups, the `app_id` should be an HTTPS URL pointing to
 a JSON file that mirrors `facets` in the auth config.
 
-<Admonition type="warning" title="Warning">
-The `app_id` must never change in the lifetime of the cluster. If the App ID
-changes, all existing U2F key registrations will become invalid and all users
-who use U2F as the second factor will need to re-register.
-When adding a new proxy server, make sure to add it to the list of "facets"
-in the configuration file, but also to the JSON file referenced by `app_id`
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  The `app_id` must never change in the lifetime of the cluster. If the App ID
+  changes, all existing U2F key registrations will become invalid and all users
+  who use U2F as the second factor will need to re-register.
+  When adding a new proxy server, make sure to add it to the list of "facets"
+  in the configuration file, but also to the JSON file referenced by `app_id`
 </Admonition>
 
 **Logging in with U2F**
@@ -630,16 +641,19 @@ Then invoke `tsh ssh` as usual to authenticate:
 tsh --proxy <proxy-addr> ssh <hostname>
 ```
 
-<Admonition type="tip" title="Version Warning">
-External user identities are only supported in [Teleport Enterprise](/enterprise/). Please reach
-out to `sales@gravitational.com` for more information.
+<Admonition
+  type="tip"
+  title="Version Warning"
+>
+  External user identities are only supported in [Teleport Enterprise](/enterprise/). Please reach
+  out to `sales@gravitational.com` for more information.
 </Admonition>
 
 ## Adding and Deleting Users
 
 This section covers internal user identities, i.e. user accounts created and
 stored in Teleport's internal storage. Most production users of Teleport use
-_external_ users via [Github](#github-oauth-20) or [Okta](ssh-okta) or any
+*external* users via [Github](#github-oauth-20) or [Okta](ssh-okta.mdx) or any
 other SSO provider (Teleport Enterprise supports any SAML or OIDC compliant
 identity provider).
 
@@ -648,11 +662,11 @@ of a cluster have multiple OS users on them. A Teleport administrator creates Te
 
 Let's look at this table:
 
-|Teleport User | Allowed OS Logins | Description
-|------------------|---------------|-----------------------------
-|joe    | joe,root | Teleport user 'joe' can login into member nodes as OS user 'joe' or 'root'
-|bob    | bob      | Teleport user 'bob' can login into member nodes only as OS user 'bob'
-|ross   |          | If no OS login is specified, it defaults to the same name as the Teleport user.
+| Teleport User | Allowed OS Logins | Description |
+| - | - | - |
+| joe | joe,root | Teleport user 'joe' can login into member nodes as OS user 'joe' or 'root' |
+| bob | bob | Teleport user 'bob' can login into member nodes only as OS user 'bob' |
+| ross | | If no OS login is specified, it defaults to the same name as the Teleport user. |
 
 To add a new user to Teleport, you have to use the `tctl` tool on the same node where
 the auth server is running, i.e. `teleport` was started with `--roles=auth`.
@@ -688,7 +702,7 @@ joe            joe,root
 ```
 
 Joe would then use the `tsh` client tool to log in to member node "luna" via
-bastion "work" _as root_:
+bastion "work" *as root*:
 
 ```yaml
 $ tsh --proxy=work --user=joe root@luna
@@ -737,8 +751,8 @@ which role a new host can assume within a cluster: `auth`, `proxy` or `node`.
 
 There are two ways to create invitation tokens:
 
-* **Static Tokens** are easy to use and somewhat less secure.
-* **Dynamic Tokens** are more secure but require more planning.
+- **Static Tokens** are easy to use and somewhat less secure.
+- **Dynamic Tokens** are more secure but require more planning.
 
 ### Static Tokens
 
@@ -859,14 +873,20 @@ teleport:
     - "10.12.0.6:3025"
 ```
 
-<Admonition type="warning" title="Warning">
-If a CA pin not provided, Teleport node will join a cluster but it will print
-a `WARN` message (warning) into it's standard error output.
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  If a CA pin not provided, Teleport node will join a cluster but it will print
+  a `WARN` message (warning) into it's standard error output.
 </Admonition>
 
-<Admonition type="warning" title="Warning">
-The CA pin becomes invalid if a Teleport administrator performs the CA
-rotation by executing `tctl auth rotate`.
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  The CA pin becomes invalid if a Teleport administrator performs the CA
+  rotation by executing `tctl auth rotate`.
 </Admonition>
 
 ## Revoking Invitations
@@ -919,7 +939,6 @@ There are two ways to configure node labels.
 1. Via command line, by using `--labels` flag to `teleport start` command.
 2. Using `/etc/teleport.yaml` configuration file on the nodes.
 
-
 To define labels as command line arguments, use `--labels` flag like shown below.
 This method works well for static labels or simple commands:
 
@@ -970,7 +989,6 @@ command: ["/bin/uname -m"]
 command: ["/bin/sh", "-c", "uname -a | egrep -o '[0-9]+\.[0-9]+\.[0-9]+'"]
 ```
 
-
 ## Audit Log
 
 Teleport logs every SSH event into its audit log. There are two components of the audit log:
@@ -981,7 +999,7 @@ Teleport logs every SSH event into its audit log. There are two components of th
    later. The recording is done by the nodes themselves, by default, but can be configured
    to be done by the proxy.
 
-Refer to the ["Audit Log" chapter in the Teleport Architecture](architecture#audit-log)
+Refer to the ["Audit Log" chapter in the Teleport Architecture](architecture.mdx#audit-log)
 to learn more about how the audit Log and session recording are designed.
 
 ### SSH Events
@@ -1037,17 +1055,17 @@ Each line represents an event and has the following format:
 
 The possible event types are:
 
-Event Type      | Description
-----------------|----------------
-auth            | Authentication attempt. Adds the following fields: `{"success": "false", "error": "access denied"}`
-session.start   | Started an interactive shell session.
-session.end     | An interactive shell session has ended.
-session.join    | A new user has joined the existing interactive shell session.
-session.leave   | A user has left the session.
-exec            | Remote command has been executed via SSH, like `tsh ssh root@node ls /`. The following fields will be logged: `{"command": "ls /", "exitCode": 0, "exitError": ""}`
-scp             | Remote file copy has been executed. The following fields will be logged: `{"path": "/path/to/file.txt", "len": 32344, "action": "read" }`
-resize          | Terminal has been resized.
-user.login      | A user logged into web UI or via tsh. The following fields will be logged: `{"user": "alice@example.com", "method": "local"}`.
+| Event Type | Description |
+| - | - |
+| auth | Authentication attempt. Adds the following fields: `{"success": "false", "error": "access denied"}` |
+| session.start | Started an interactive shell session. |
+| session.end | An interactive shell session has ended. |
+| session.join | A new user has joined the existing interactive shell session. |
+| session.leave | A user has left the session. |
+| exec | Remote command has been executed via SSH, like `tsh ssh root@node ls /`. The following fields will be logged: `{"command": "ls /", "exitCode": 0, "exitError": ""}` |
+| scp | Remote file copy has been executed. The following fields will be logged: `{"path": "/path/to/file.txt", "len": 32344, "action": "read" }` |
+| resize | Terminal has been resized. |
+| user.login | A user logged into web UI or via tsh. The following fields will be logged: `{"user": "alice@example.com", "method": "local"}`. |
 
 ### Recorded Sessions
 
@@ -1061,8 +1079,8 @@ The recorded sessions are stored as raw bytes in the `sessions` directory under 
 Each session consists of two files, both are named after the session ID:
 
 1. `.bytes` file represents the raw session bytes and is somewhat
-    human-readable, although you are better off using `tsh play` or
-    the Web UI to replay it.
+   human-readable, although you are better off using `tsh play` or
+   the Web UI to replay it.
 2. `.log` file contains the copies of the event log entries that are related
    to this session.
 
@@ -1080,7 +1098,7 @@ $ tsh --proxy=proxy play 4c146ec8-eab6-11e6-b1b3-40167e68e931
 
 ### Recording Proxy Mode
 
-See [Audit Log Architecture](architecture/#audit-log) to understand how the session
+See [Audit Log Architecture](architecture.mdx#audit-log) to understand how the session
 recording works. By default, the recording is not
 available if a cluster runs `sshd` (the OpenSSH daemon) on the nodes.
 
@@ -1116,7 +1134,7 @@ When in recording mode, Teleport will check that the host certificate of the
 node a user connects to is signed by a Teleport CA. By default this is a strict
 check. If the node presents just a key, or a certificate signed by a different
 CA, Teleport will reject this connection with the error message saying
-_"ssh: handshake failed: remote host presented a public key, expected a host certificate"_
+*"ssh: handshake failed: remote host presented a public key, expected a host certificate"*
 
 You can disable strict host checks as shown below. However, this opens the possibility for
 Man-in-the-Middle (MITM) attacks and is not recommended.
@@ -1158,9 +1176,12 @@ ssh -o "ForwardAgent yes" \
     user@host.example.com
 ```
 
-<Admonition type="tip" title="Tip">
-To avoid typing all this and use the usual `ssh user@host.example.com`, users can update their
-`~/.ssh/config` file. See "Using Teleport with OpenSSH" chapter for more examples.
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  To avoid typing all this and use the usual `ssh user@host.example.com`, users can update their
+  `~/.ssh/config` file. See "Using Teleport with OpenSSH" chapter for more examples.
 </Admonition>
 
 **IMPORTANT**
@@ -1175,10 +1196,13 @@ $ tsh login --proxy=proxy.example.com joe
 $ ssh-add -L
 ```
 
-<Admonition type="warning" title="GNOME Keyring SSH Agent">
-It is well-known that Gnome Keyring SSH agent, used by many popular Linux
-desktops like Ubuntu, does not support SSH certificates. We recommend using
-the `ssh-agent` command from `openssh-client` package.
+<Admonition
+  type="warning"
+  title="GNOME Keyring SSH Agent"
+>
+  It is well-known that Gnome Keyring SSH agent, used by many popular Linux
+  desktops like Ubuntu, does not support SSH certificates. We recommend using
+  the `ssh-agent` command from `openssh-client` package.
 </Admonition>
 
 ### OpenSSH Rate Limiting
@@ -1205,7 +1229,7 @@ A Teleport administrator has two tools to configure a Teleport cluster:
 
 - The [configuration file](#configuration) is used for static configuration like the cluster name.
 - The `tctl` admin tool is used for manipulating dynamic records
-like Teleport users.
+  like Teleport users.
 
 `tctl` has convenient subcommands for dynamic configuration, like `tctl users` or `tctl nodes`.
 However, for dealing with more advanced topics, like connecting clusters together or
@@ -1218,24 +1242,27 @@ that can be performed on them: `get`, `create`, `remove`.
 
 A resource is defined as a [YAML](https://en.wikipedia.org/wiki/YAML) file. Every resource in Teleport has three required fields:
 
-* `Kind` - The type of resource
-* `Name` - A required field in the `metadata` to uniquely identify the resource
-* `Version` - The version of the resource format
+- `Kind` - The type of resource
+- `Name` - A required field in the `metadata` to uniquely identify the resource
+- `Version` - The version of the resource format
 
 Everything else is resource-specific and any component of a Teleport cluster can be
 manipulated with just 3 CLI commands:
 
-Command         | Description | Examples
-----------------|-------------|----------
-`tctl get`      | Get one or multipe resources           | `tctl get users` or `tctl get user/joe`
-`tctl rm`       | Delete a resource by type/name         | `tctl rm user/joe`
-`tctl create`   | Create a new resource from a YAML file. Use `-f` to overide / update | `tctl create -f joe.yaml`
+| Command | Description | Examples |
+| - | - | - |
+| `tctl get` | Get one or multipe resources | `tctl get users` or `tctl get user/joe` |
+| `tctl rm` | Delete a resource by type/name | `tctl rm user/joe` |
+| `tctl create` | Create a new resource from a YAML file. Use `-f` to overide / update | `tctl create -f joe.yaml` |
 
-<Admonition type="warning" title="YAML Format">
-By default Teleport uses [YAML format](https://en.wikipedia.org/wiki/YAML)
-to describe resources. YAML is a wonderful and very human-readable
-alternative to JSON or XML, but it's sensitive to white space. Pay
-attention to spaces vs tabs!
+<Admonition
+  type="warning"
+  title="YAML Format"
+>
+  By default Teleport uses [YAML format](https://en.wikipedia.org/wiki/YAML)
+  to describe resources. YAML is a wonderful and very human-readable
+  alternative to JSON or XML, but it's sensitive to white space. Pay
+  attention to spaces vs tabs!
 </Admonition>
 
 Here's an example how the YAML resource definition for a user Joe might look like.
@@ -1270,22 +1297,24 @@ spec:
       name: builtin-Admin
 ```
 
-<Admonition type="tip" title="Note">
-Some of the fields you will see when printing resources are used only
-internally and are not meant to be changed.  Others are reserved for future
-use.
+<Admonition
+  type="tip"
+  title="Note"
+>
+  Some of the fields you will see when printing resources are used only
+  internally and are not meant to be changed.  Others are reserved for future
+  use.
 </Admonition>
 
 Here's the list of resources currently exposed via `tctl`:
 
-Resource Kind   | Description
-----------------|--------------
-user            | A user record in the internal Teleport user DB.
-node            | A registered SSH node. The same record is displayed via `tctl nodes ls`
-cluster         | A trusted cluster. See [here](#trusted-clusters) for more details on connecting clusters together.
-role            | A role assumed by users. The open source Teleport only includes one role: "admin", but Enterprise teleport users can define their own roles.
-connector       | Authentication connectors for [single sign-on](ssh-sso) (SSO) for SAML, OIDC and Github.
-
+| Resource Kind | Description |
+| - | - |
+| user | A user record in the internal Teleport user DB. |
+| node | A registered SSH node. The same record is displayed via `tctl nodes ls` |
+| cluster | A trusted cluster. See [here](#trusted-clusters) for more details on connecting clusters together. |
+| role | A role assumed by users. The open source Teleport only includes one role: "admin", but Enterprise teleport users can define their own roles. |
+| connector | Authentication connectors for [single sign-on](ssh-sso.mdx) (SSO) for SAML, OIDC and Github. |
 
 **Examples:**
 
@@ -1310,14 +1339,14 @@ $ tctl rm users/admin
 ```
 
 <Admonition type="note">
-Although `tctl get connectors` will show you every connector, when working with an individual
-connector you must use the correct `kind`, such as `saml` or `oidc`. You can see each
-connector's `kind` at the top of its YAML output from `tctl get connectors`.
+  Although `tctl get connectors` will show you every connector, when working with an individual
+  connector you must use the correct `kind`, such as `saml` or `oidc`. You can see each
+  connector's `kind` at the top of its YAML output from `tctl get connectors`.
 </Admonition>
 
 ## Trusted Clusters
 
-As explained in the [architecture document](architecture/#core-concepts),
+As explained in the [architecture document](architecture.mdx#core-concepts),
 Teleport can partition compute infrastructure into multiple clusters.
 A cluster is a group of nodes connected to the cluster's auth server,
 acting as a certificate authority (CA) for all users and nodes.
@@ -1366,10 +1395,10 @@ The design of trusted clusters allows Teleport users to connect to compute
 infrastructure located behind firewalls without any open TCP ports. The real
 world usage examples of this capability include:
 
-* Managed service providers (MSP) remotely managing infrastructure of their clients.
-* Device manufacturers remotely maintaining computing appliances
+- Managed service providers (MSP) remotely managing infrastructure of their clients.
+- Device manufacturers remotely maintaining computing appliances
   deployed on premises.
-* Large cloud software vendors manage multiple data centers using a common proxy.
+- Large cloud software vendors manage multiple data centers using a common proxy.
 
 Let's take a look at how a connection is established between the "main" cluster and the "east" cluster:
 
@@ -1381,12 +1410,15 @@ This setup works as follows:
 2. **Accessibility only works in one direction.** The "east" cluster allows users from "main" to access its nodes but users in the "east" cluster can not access the "main" cluster.
 3. When a user tries to connect to a node inside "east" using main's proxy, the reverse tunnel from step 1 is used to establish this connection shown as the green line above.
 
-<Admonition type="tip" title="Load Balancers">
-The scheme above also works even if the "main" cluster uses multiple
-proxies behind a load balancer (LB) or a DNS entry with multiple values.
-This works by "east" establishing a tunnel to _every_ proxy in "main",
-assuming that an LB uses round-robin or a similar non-sticky balancing
-algorithm.
+<Admonition
+  type="tip"
+  title="Load Balancers"
+>
+  The scheme above also works even if the "main" cluster uses multiple
+  proxies behind a load balancer (LB) or a DNS entry with multiple values.
+  This works by "east" establishing a tunnel to *every* proxy in "main",
+  assuming that an LB uses round-robin or a similar non-sticky balancing
+  algorithm.
 </Admonition>
 
 ### Example Configuration
@@ -1458,13 +1490,16 @@ $ tctl create cluster.yaml
 At this point the users of the main cluster should be able to see "east" in the
 list of available clusters.
 
-<Admonition type="warning" title="HTTPS configuration">
-If the `web_proxy_addr` endpoint of the main cluster uses a self-signed or
-invalid HTTPS certificate, you will get an error: _"the trusted cluster
-uses misconfigured HTTP/TLS certificate"_. For ease of testing the teleport
-daemon of "east" can be started with `--insecure` CLI flag to accept
-self-signed certificates. Make sure to configure HTTPS properly and remove
-the insecure flag for production use.
+<Admonition
+  type="warning"
+  title="HTTPS configuration"
+>
+  If the `web_proxy_addr` endpoint of the main cluster uses a self-signed or
+  invalid HTTPS certificate, you will get an error: *"the trusted cluster
+  uses misconfigured HTTP/TLS certificate"*. For ease of testing the teleport
+  daemon of "east" can be started with `--insecure` CLI flag to accept
+  self-signed certificates. Make sure to configure HTTPS properly and remove
+  the insecure flag for production use.
 </Admonition>
 
 ### Using Trusted Clusters
@@ -1505,7 +1540,7 @@ and set `enabled` to "false", then update it:
 $ tctl create --force cluster.yaml
 ```
 
-If you want to _permanently_ disconnect one cluster from the other:
+If you want to *permanently* disconnect one cluster from the other:
 
 ```yaml
 # execute this command on "main" side to disconnect "east":
@@ -1514,9 +1549,9 @@ $ tctl rm tc/east
 
 While accessibility is only granted in one direction, trust is granted in both directions. If you remote "east" from "main", the following will happen:
 
-* Two clusters will be disconnected, becase "main" will drop the inbound SSH tunnel connection from "east" and will not allow a new one.
-* "main" will stop trusting certificates issued by "east".
-* "east" will continue to trust certificates issued by "main".
+- Two clusters will be disconnected, becase "main" will drop the inbound SSH tunnel connection from "east" and will not allow a new one.
+- "main" will stop trusting certificates issued by "east".
+- "east" will continue to trust certificates issued by "main".
 
 If you wish to permanently remove all trust relationships and the connections between both clusters:
 
@@ -1529,12 +1564,12 @@ $ tctl rm tc/main
 
 ### Advanced Configuration
 
-Take a look at [Trusted Clusters Guide](trustedclusters) to learn more about
+Take a look at [Trusted Clusters Guide](trustedclusters.mdx) to learn more about
 advanced topics:
 
-* Using dynamic cluster join tokens instead of pre-defined static tokens for
+- Using dynamic cluster join tokens instead of pre-defined static tokens for
   enhanced security.
-* Defining role-mapping between clusters (Teleport Enterprise only).
+- Defining role-mapping between clusters (Teleport Enterprise only).
 
 ## Github OAuth 2.0
 
@@ -1581,11 +1616,11 @@ spec:
 ```
 
 <Admonition type="note">
-For open-source Teleport the `logins` field contains a list of allowed OS
-logins. For the commercial Teleport Enterprise offering, which supports
-role-based access control, the same field is treated as a list of _roles_
-that users from the matching org/team assume after going through the
-authorization flow.
+  For open-source Teleport the `logins` field contains a list of allowed OS
+  logins. For the commercial Teleport Enterprise offering, which supports
+  role-based access control, the same field is treated as a list of *roles*
+  that users from the matching org/team assume after going through the
+  authorization flow.
 </Admonition>
 
 To obtain client ID and client secret, please follow Github documentation
@@ -1600,10 +1635,10 @@ $ tctl create github.yaml
 ```
 
 <Admonition type="tip">
-When going through the Github authentication flow for the first time,
-the application must be granted the access to all organizations that
-are present in the "teams to logins" mapping, otherwise Teleport will
-not be able to determine team memberships for these orgs.
+  When going through the Github authentication flow for the first time,
+  the application must be granted the access to all organizations that
+  are present in the "teams to logins" mapping, otherwise Teleport will
+  not be able to determine team memberships for these orgs.
 </Admonition>
 
 ## HTTP CONNECT Proxies
@@ -1635,10 +1670,13 @@ Environment="HTTPS_PROXY=http://proxy.example.com:8080/"
 Environment="NO_PROXY=localhost,127.0.0.1,192.168.0.0/16,172.16.0.0/12,10.0.0.0/8"
 ```
 
-<Admonition type="tip" title="Note">
-`localhost` and `127.0.0.1` are invalid values for the proxy host. If for
-some reason your proxy runs locally, you'll need to provide some other DNS
-name or a private IP address for it.
+<Admonition
+  type="tip"
+  title="Note"
+>
+  `localhost` and `127.0.0.1` are invalid values for the proxy host. If for
+  some reason your proxy runs locally, you'll need to provide some other DNS
+  name or a private IP address for it.
 </Admonition>
 
 ## PAM Integration
@@ -1664,14 +1702,13 @@ removed if you uninstall `openssh-server` package. We recommend creating your
 own PAM service file like `/etc/pam.d/teleport` and specifying it as
 `service_name` above.
 
-
 ## Using Teleport with OpenSSH
 
 Teleport is a standards-compliant SSH proxy and it can work in environments with
 existing SSH implementations, such as OpenSSH. This section will cover:
 
-* Configuring OpenSSH client `ssh` to login into nodes inside a Teleport cluster.
-* Configuring OpenSSH server `sshd` to join a Teleport cluster.
+- Configuring OpenSSH client `ssh` to login into nodes inside a Teleport cluster.
+- Configuring OpenSSH server `sshd` to join a Teleport cluster.
 
 ### Using OpenSSH Client
 
@@ -1739,12 +1776,15 @@ behind `work.example.com`:
 $ ssh root@database.work.example.com
 ```
 
-<Admonition type="tip" title="NOTE">
-Teleport uses OpenSSH certificates instead of keys which means you can not connect
-to a Teleport node by IP address. You have to connect by DNS name. This is because
-OpenSSH ensures the DNS name of the node you are connecting is listed under
-the `Principals` section of the OpenSSH certificate to verify you are connecting
-to the correct node.
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  Teleport uses OpenSSH certificates instead of keys which means you can not connect
+  to a Teleport node by IP address. You have to connect by DNS name. This is because
+  OpenSSH ensures the DNS name of the node you are connecting is listed under
+  the `Principals` section of the OpenSSH certificate to verify you are connecting
+  to the correct node.
 </Admonition>
 
 ### Integrating with OpenSSH Servers
@@ -1759,13 +1799,13 @@ $ tctl auth export --type=user > teleport-user-ca.pub
 ```
 
 To allow access per-user, append the contents of `teleport-user-ca.pub` to
-  `~/.ssh/authorized_keys`.
+`~/.ssh/authorized_keys`.
 
 To allow access for all users:
 
-  * Edit `teleport-user-ca.pub` and remove `cert-authority` from the start of line.
-  * Copy `teleport-user-ca.pub` to `/etc/ssh/teleport-user-ca.pub`
-  * Update `sshd` configuration (usually `/etc/ssh/sshd_config`) to point to this
+- Edit `teleport-user-ca.pub` and remove `cert-authority` from the start of line.
+- Copy `teleport-user-ca.pub` to `/etc/ssh/teleport-user-ca.pub`
+- Update `sshd` configuration (usually `/etc/ssh/sshd_config`) to point to this
   file: `TrustedUserCAKeys /etc/ssh/teleport-user-ca.pub`
 
 ## Certificate Rotation
@@ -1775,14 +1815,14 @@ architecture document to learn how the certificate rotation works. This section
 will show you how to implement certificate rotation in practice.
 
 The easiest way to start the rotation is to execute this command on a cluster's
-_auth server_:
+*auth server*:
 
 ```bsh
 $ tctl auth rotate
 ```
 
-This will trigger a rotation process for both hosts and users with a _grace
-period_ of 48 hours.
+This will trigger a rotation process for both hosts and users with a *grace
+period* of 48 hours.
 
 This can be customized, i.e.
 
@@ -1798,13 +1838,16 @@ The rotation takes time, especially for hosts, because each node in a cluster
 needs to be notified that a rotation is taking place and request a new
 certificate for itself before the grace period ends.
 
-<Admonition type="warning" title="Warning">
-Be careful when choosing a grace period when rotating host certificates.
-The grace period needs to be long enough for all nodes in a cluster to
-request a new certificate. If some nodes go offline during the rotation and
-come back only after the grace period has ended, they will be forced to
-leave the cluster, i.e. users will no longer be allowed to SSH into
-them.
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  Be careful when choosing a grace period when rotating host certificates.
+  The grace period needs to be long enough for all nodes in a cluster to
+  request a new certificate. If some nodes go offline during the rotation and
+  come back only after the grace period has ended, they will be forced to
+  leave the cluster, i.e. users will no longer be allowed to SSH into
+  them.
 </Admonition>
 
 To check the status of certificate rotation:
@@ -1813,25 +1856,31 @@ To check the status of certificate rotation:
 $ tctl status
 ```
 
-<Admonition type="danger" title="Version Warning">
-Certificate rotation can only be used with clusters running version 2.6 of
-Teleport or newer. If trusted clusters are used, make sure _all_ connected
-clusters are running version 2.6+. If one of the trusted clusters is running
-an older version of Teleport the trust/connection to that cluster will be
-lost.
+<Admonition
+  type="danger"
+  title="Version Warning"
+>
+  Certificate rotation can only be used with clusters running version 2.6 of
+  Teleport or newer. If trusted clusters are used, make sure *all* connected
+  clusters are running version 2.6+. If one of the trusted clusters is running
+  an older version of Teleport the trust/connection to that cluster will be
+  lost.
 </Admonition>
 
-<Admonition type="warning" title="CA Pinning Warning">
-If you are using [CA Pinning](#untrusted-auth-servers) when adding new nodes,
-the CA pin will changes after the rotation.
+<Admonition
+  type="warning"
+  title="CA Pinning Warning"
+>
+  If you are using [CA Pinning](#untrusted-auth-servers) when adding new nodes,
+  the CA pin will changes after the rotation.
 </Admonition>
 
 ## Ansible Integration
 
 Ansible uses the OpenSSH client by default. This makes it compatible with Teleport without any extra work, except configuring OpenSSH client to work with Teleport Proxy:
 
-* configure your OpenSSH to connect to Teleport proxy and use `ssh-agent` socket
-* enable scp mode in the Ansible config file (default is `/etc/ansible/ansible.cfg`):
+- configure your OpenSSH to connect to Teleport proxy and use `ssh-agent` socket
+- enable scp mode in the Ansible config file (default is `/etc/ansible/ansible.cfg`):
 
 ```bsh
 scp_if_ssh = True
@@ -1848,7 +1897,8 @@ a Kubernetes cluster:
 
 ![teleport-kubernetes-integration](../img/teleport-kube.png)
 
-For more detailed information, please take a look at [Kubernetes Integration with SSH](architecture.mdx#kubernetes-integration)
+For more detailed information, please take a look
+at [Kubernetes Integration with SSH](architecture.mdx#kubernetes-integration)
 section in the Architecture chapter.
 
 In the scenario illustrated above a user would execute the following commands:
@@ -1889,8 +1939,8 @@ proxy_service:
 To make this work, the Teleport proxy server must be able to access a
 Kubernetes API endpoint.  This can be done either by:
 
-* Deploying the proxy service inside a Kubernetes pod.
-* Deploying the proxy service outside Kubernetes adding a valid `kubeconfig` setting to the configuration file as shown above.
+- Deploying the proxy service inside a Kubernetes pod.
+- Deploying the proxy service outside Kubernetes adding a valid `kubeconfig` setting to the configuration file as shown above.
 
 When adding new local users you have to specify which Kubernetes groups they belong to:
 
@@ -1918,13 +1968,13 @@ When multiple trusted clusters are present behind a Teleport proxy, the
 `kubeconfig` generated by `tsh login` will contain the Kubernetes API endpoint
 determined by the `<cluster>` argument to `tsh login`.
 
-* There are three Teleport/Kubernetes clusters: "main", "east" and "west".
+- There are three Teleport/Kubernetes clusters: "main", "east" and "west".
   These are the names set in `cluster_name` setting in their configuration
   files.
-* The clusters "east" and "west" are trusted clusters for "main".
-* Users always authenticate against "main" but use their certificates to
+- The clusters "east" and "west" are trusted clusters for "main".
+- Users always authenticate against "main" but use their certificates to
   access SSH nodes and Kubernetes API in all three clusters.
-* The DNS name of the main proxy server is "main.example.com"
+- The DNS name of the main proxy server is "main.example.com"
 
 In this scenario, users usually login using this command:
 
@@ -1944,9 +1994,13 @@ $ tsh --proxy=main.example.com login east
 
 ## High Availability
 
-<Admonition type="tip" title="Tip">
-Before continuing, please make sure to take a look at the [Cluster State section](architecture/#cluster-state)
-in the Teleport Architecture documentation.
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  Before continuing, please make sure to take a look at
+  the [Cluster State section](architecture.mdx#cluster-state)
+  in the Teleport Architecture documentation.
 </Admonition>
 
 Usually there are two ways to achieve high availability. You can "outsource"
@@ -1964,11 +2018,11 @@ In order to run multiple instances of Teleport Auth Server, you must switch to a
 Also, you must tell each node in a cluster that there is
 more than one auth server available. There are two ways to do this:
 
-  * Use a load balancer to create a single the auth API access point (AP) and
-    specify this AP in `auth_servers` section of Teleport configuration for
-    all nodes in a cluster. This load balancer should do TCP level forwarding.
-  * If a load balancer is not an option, you must specify each instance of an
-    auth server in `auth_servers` section of Teleport configuration.
+- Use a load balancer to create a single the auth API access point (AP) and
+  specify this AP in `auth_servers` section of Teleport configuration for
+  all nodes in a cluster. This load balancer should do TCP level forwarding.
+- If a load balancer is not an option, you must specify each instance of an
+  auth server in `auth_servers` section of Teleport configuration.
 
 **IMPORTANT:** with multiple instances of the auth servers running, special
 attention needs to be paid to keeping their configuration identical. Settings
@@ -1986,18 +2040,24 @@ configure your load balancer to forward the ports you specified for
 for your users, while the remaining ports should do TCP level forwarding, since
 Teleport will handle its own SSL on top of that with its own certificates.
 
-<Admonition type="tip" title="NOTE">
-If you terminate TLS with your own certificate at a load balancer you'll need
-to Teleport with `--insecure`
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  If you terminate TLS with your own certificate at a load balancer you'll need
+  to Teleport with `--insecure`
 </Admonition>
 
 If your load balancer supports health checks, configure it to hit the
 `/webapi/ping` endpoint on the proxy. This endpoint will reply `200 OK` if the
 proxy is running without problems.
 
-<Admonition type="tip" title="NOTE">
-As the new auth servers get added to the cluster and the old servers get decommissioned, nodes and proxies will refresh the list of available auth servers and store it in their local cache `/var/lib/teleport/authservers.json`. The values from the cache file will take precedence over the configuration
-file.
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  As the new auth servers get added to the cluster and the old servers get decommissioned, nodes and proxies will refresh the list of available auth servers and store it in their local cache `/var/lib/teleport/authservers.json`. The values from the cache file will take precedence over the configuration
+  file.
 </Admonition>
 
 We'll cover how to use `etcd` and `DynamoDB` storage back-ends to make Teleport
@@ -2012,13 +2072,13 @@ keys and user records will be stored.
 
 To configure Teleport for using etcd as a storage back-end:
 
-* Make sure you are using **etcd version 3.3** or newer.
-* Install etcd and configure peer and client TLS authentication using the
+- Make sure you are using **etcd version 3.3** or newer.
+- Install etcd and configure peer and client TLS authentication using the
   [etcd security guide](https://coreos.com/etcd/docs/latest/security.html).
-* Configure all Teleport Auth servers to use etcd in the "storage" section of
+- Configure all Teleport Auth servers to use etcd in the "storage" section of
   the config file as shown below.
-* Deploy several auth servers connected to etcd back-end.
-* Deploy several proxy nodes that have `auth_servers` pointed to list of auth servers to connect to.
+- Deploy several auth servers connected to etcd back-end.
+- Deploy several proxy nodes that have `auth_servers` pointed to list of auth servers to connect to.
 
 ```yaml
 teleport:
@@ -2046,23 +2106,29 @@ teleport:
 
 ### Using Amazon S3
 
-<Admonition type="tip" title="Tip">
-Before continuing, please make sure to take a look at the [cluster state section](architecture/#cluster-state)
-in Teleport Architecture documentation.
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  Before continuing, please make sure to take a look at
+  the [cluster state section](architecture.mdx#cluster-state)
+  in Teleport Architecture documentation.
 </Admonition>
 
-<Admonition type="tip" title="AWS Authentication">
-The configuration examples below contain AWS access keys and secret keys. They are optional,
-they exist for your convenience but we DO NOT RECOMMEND usign them in
-production. If Teleport is running on an AWS instance it will automatically
-use the instance IAM role. Teleport also will pick up AWS credentials from
-the `~/.aws` folder, just like the AWS CLI tool.
+<Admonition
+  type="tip"
+  title="AWS Authentication"
+>
+  The configuration examples below contain AWS access keys and secret keys. They are optional,
+  they exist for your convenience but we DO NOT RECOMMEND usign them in
+  production. If Teleport is running on an AWS instance it will automatically
+  use the instance IAM role. Teleport also will pick up AWS credentials from
+  the `~/.aws` folder, just like the AWS CLI tool.
 </Admonition>
 
 S3 buckets can only be used as a storage for the recorded sessions. S3 cannot store
 the audit log or the cluster state. Below is an example of how to configure a Teleport
 auth server to store the recorded sessions in an S3 bucket.
-
 
 ```yaml
 teleport:
@@ -2086,29 +2152,33 @@ running on an EC2 instance with an IAM role.
 
 ### Using DynamoDB
 
-<Admonition type="tip" title="Tip">
-Before continuing, please make sure to take a look at the [cluster state section](architecture/#cluster-state)
-in Teleport Architecture documentation.
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  Before continuing, please make sure to take a look at
+  the [cluster state section](architecture.mdx#cluster-state)
+  in Teleport Architecture documentation.
 </Admonition>
 
 If you are running Teleport on AWS, you can use [DynamoDB](https://aws.amazon.com/dynamodb/)
 as a storage back-end to achieve high availability. DynamoDB back-end supports two types
 of Teleport data:
 
-* Cluster state
-* Audit log events
+- Cluster state
+- Audit log events
 
 DynamoDB cannot store the recorded sessions. You are advised to use AWS S3 for that as shown above.
 To configure Teleport to use DynamoDB:
 
-* Make sure you have AWS access key and a secret key which give you access to
+- Make sure you have AWS access key and a secret key which give you access to
   DynamoDB account. If you're using (as recommended) an IAM role for this, the policy
   with necessary permissions is listed below.
-* Configure all Teleport Auth servers to use DynamoDB back-end in the "storage" section
+- Configure all Teleport Auth servers to use DynamoDB back-end in the "storage" section
   of `teleport.yaml` as shown below.
-* Deploy several auth servers connected to DynamoDB storage back-end.
-* Deploy several proxy nodes.
-* Make sure that all Teleport nodes have `auth_servers` configuration setting populated with the auth servers.
+- Deploy several auth servers connected to DynamoDB storage back-end.
+- Deploy several proxy nodes.
+- Make sure that all Teleport nodes have `auth_servers` configuration setting populated with the auth servers.
 
 ```yaml
 teleport:
@@ -2131,22 +2201,25 @@ teleport:
     audit_sessions_uri: 's3://example.com/teleport.events'
 ```
 
-* Replace `region` and `table_name` with your own settings. Teleport will
+- Replace `region` and `table_name` with your own settings. Teleport will
   create the table automatically.
-* The AWS authentication setting above can be omitted if the machine itself is
+- The AWS authentication setting above can be omitted if the machine itself is
   running on an EC2 instance with an IAM role.
-* Audit log settings above are optional. If specified, Teleport will store the
+- Audit log settings above are optional. If specified, Teleport will store the
   audit log in DyamoDB and the session recordings **must** be stored in an S3
   bucket, i.e. both `audit_xxx` settings must be present. If they are not set,
   Teleport will default to a local file system for the audit log, i.e.
   `/var/lib/teleport/log` on an auth server.
-* If DynamoDB is used for the audit log, the logged events will be stored with
+- If DynamoDB is used for the audit log, the logged events will be stored with
   a TTL of 1 year. Currently this TTL is not configurable.
 
-<Admonition type="warning" title="Access to DynamoDB">
-Make sure that the IAM role assigned to Teleport is configured with the
-sufficient access to DynamoDB. Below is the example of the IAM policy you
-can use:
+<Admonition
+  type="warning"
+  title="Access to DynamoDB"
+>
+  Make sure that the IAM role assigned to Teleport is configured with the
+  sufficient access to DynamoDB. Below is the example of the IAM policy you
+  can use:
 </Admonition>
 
 ```js
@@ -2181,26 +2254,29 @@ which makes it easy to tell if a specific version is recommended for production 
 When running multiple binaries of Teleport within a cluster (nodes, proxies,
 clients, etc), the following rules apply:
 
-* Patch versions are always compatible, for example any 2.4.1 compoment will
+- Patch versions are always compatible, for example any 2.4.1 compoment will
   work with any 2.4.3 component.
-* Other versions are always compatible with their **previous** release. This
+- Other versions are always compatible with their **previous** release. This
   means you must not attempt to upgrade from 2.3 straight to 2.5. You must
   upgrade to 2.4 first.
-* Teleport clients (`tsh` for users and `tctl` for admins) may not be compatible if older than the auth or the proxy server. They will print an error if there is an incompatibility.
+- Teleport clients (`tsh` for users and `tctl` for admins) may not be compatible if older than the auth or the proxy server. They will print an error if there is an incompatibility.
 
 ### Upgrade Sequence
 
 When upgrading a single Teleport cluster:
 
 1. **Upgrade the auth server first**. The auth server keeps the cluster state and
-    if there are data format changes introduced in the new version this will
-    perform necessary migrations.
+   if there are data format changes introduced in the new version this will
+   perform necessary migrations.
 2. Then, upgrade the proxy servers. The proxy servers are stateless and can be upgraded
    in any sequence or at the same time.
 3. Finally, upgrade the SSH nodes in any sequence or at the same time.
 
-<Admonition type="warning" title="Warning">
-If several auth servers are running in HA configuration (for example, in AWS auto-scaling group) you have to shrink the group to **just one auth server** prior to performing an upgrade. While Teleport will attempt to perform any necessary migrations, we recommend users create a backup of their backend before upgrading the Auth Server, as a precaution. This allows for a safe rollback in case the migration itself fails.
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  If several auth servers are running in HA configuration (for example, in AWS auto-scaling group) you have to shrink the group to **just one auth server** prior to performing an upgrade. While Teleport will attempt to perform any necessary migrations, we recommend users create a backup of their backend before upgrading the Auth Server, as a precaution. This allows for a safe rollback in case the migration itself fails.
 </Admonition>
 
 When upgrading multiple clusters:
@@ -2240,9 +2316,12 @@ The `license_file` path can be either absolute or relative to the configured
 `data_dir`. If license file path is not set, Teleport will look for the
 `license.pem` file in the configured `data_dir`.
 
-<Admonition type="tip" title="NOTE">
-Only Auth servers require the license. Proxies and Nodes that do not also
-have Auth role enabled do not need the license.
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  Only Auth servers require the license. Proxies and Nodes that do not also
+  have Auth role enabled do not need the license.
 </Admonition>
 
 ## Troubleshooting
@@ -2250,9 +2329,12 @@ have Auth role enabled do not need the license.
 To diagnose problems you can configure `teleport` to run with verbose logging enabled
 by passing it `-d` flag.
 
-<Admonition type="tip" title="NOTE">
-It is not recommended to run Teleport in production with verbose logging
-as it generates a substantial amount of data.
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  It is not recommended to run Teleport in production with verbose logging
+  as it generates a substantial amount of data.
 </Admonition>
 
 Sometimes you may want to reset `teleport` to a clean state. This can be accomplished
@@ -2268,13 +2350,13 @@ $ teleport start --diag-addr=127.0.0.1:3000
 
 Now you can see the monitoring information by visiting several endpoints:
 
-* `http://127.0.0.1:3000/metrics` is the list of internal metrics Teleport is tracking.
-   It is compatible with [Prometheus](https://prometheus.io/) collectors.
-* `http://127.0.0.1:3000/healthz` returns "OK" if the process is healthy or `503` otherwise.
-* `http://127.0.0.1:3000/readyz` is similar to `/healthz`, but it returns "OK"
-  _only after_ the node successfully joined the cluster, i.e. it draws the
+- `http://127.0.0.1:3000/metrics` is the list of internal metrics Teleport is tracking.
+  It is compatible with [Prometheus](https://prometheus.io/) collectors.
+- `http://127.0.0.1:3000/healthz` returns "OK" if the process is healthy or `503` otherwise.
+- `http://127.0.0.1:3000/readyz` is similar to `/healthz`, but it returns "OK"
+  *only after* the node successfully joined the cluster, i.e. it draws the
   difference between "healthy" and "ready".
-* `http://127.0.0.1:3000/debug/pprof/` is Golang's standard profiler. It's only
+- `http://127.0.0.1:3000/debug/pprof/` is Golang's standard profiler. It's only
   available when `-d` flag is given in addition to `--diag-addr`
 
 ## Getting Help

--- a/docs/pages/architecture.mdx
+++ b/docs/pages/architecture.mdx
@@ -9,17 +9,17 @@ detailed description of Teleport architecture.
 
 Teleport was designed in accordance with the following principles:
 
-* **Off the Shelf Security**: Teleport does not re-implement any security primitives
+- **Off the Shelf Security**: Teleport does not re-implement any security primitives
   and uses well-established, popular implementations of the encryption and network protocols.
 
-* **Open Standards**: There is no security through obscurity. Teleport is fully compatible
+- **Open Standards**: There is no security through obscurity. Teleport is fully compatible
   with existing and open standards and other software, including OpenSSH.
 
-* **Cluster-Oriented Design**: Teleport is built for managing clusters, not individual
+- **Cluster-Oriented Design**: Teleport is built for managing clusters, not individual
   servers. In practice this means that hosts and users have cluster memberships. Identity
   management and authorization happen on a cluster level.
 
-* **Built for Teams**: Teleport was created under the assumption of multiple teams operating
+- **Built for Teams**: Teleport was created under the assumption of multiple teams operating
   on several disconnected clusters (production-vs-staging, or perhaps
   on a cluster-per-customer or cluster-per-application basis).
 
@@ -27,52 +27,55 @@ Teleport was designed in accordance with the following principles:
 
 The following core concepts are integral to understanding the Teleport architecture.
 
-* **Cluster of Nodes**. Unlike the traditional SSH service, Teleport operates on a _cluster_ of nodes.
-   A cluster is a set of nodes (servers). There are several ramifications of this:
-	* User identities and user permissions are defined and enforced on a cluster level.
-	* A node must become a _cluster member_ before any user can connect to it via SSH.
-	* SSH access to any cluster node is _always_ performed through a cluster proxy,
-       sometimes called an "SSH bastion".
+- **Cluster of Nodes**. Unlike the traditional SSH service, Teleport operates on a *cluster* of nodes.
+  A cluster is a set of nodes (servers). There are several ramifications of this:
+  - User identities and user permissions are defined and enforced on a cluster level.
+  - A node must become a *cluster member* before any user can connect to it via SSH.
+  - SSH access to any cluster node is *always* performed through a cluster proxy,
+    sometimes called an "SSH bastion".
 
-* **User Account**. Unlike traditional SSH, Teleport introduces the concept of a User Account.
-   A User Account is not the same as SSH login. For example, there can be a Teleport user "johndoe"
-   who can be given permission to login as "root" to a specific subset of nodes.
+- **User Account**. Unlike traditional SSH, Teleport introduces the concept of a User Account.
+  A User Account is not the same as SSH login. For example, there can be a Teleport user "johndoe"
+  who can be given permission to login as "root" to a specific subset of nodes.
 
-* **Teleport Services**. A Teleport cluster consists of three separate services, also called
-   "node roles": `proxy`, `auth` and `node`. Each Teleport node can run any combination of them
-   by passing `--role` flag to the `teleport` daemon.
+- **Teleport Services**. A Teleport cluster consists of three separate services, also called
+  "node roles": `proxy`, `auth` and `node`. Each Teleport node can run any combination of them
+  by passing `--role` flag to the `teleport` daemon.
 
-* **User Roles**. Unlike traditional SSH, each Teleport user account is assigned a `role`.
-   Having roles allows Teleport to implement role-based access control (RBAC), i.e. assign
-   users to groups (roles) and restrict each role to a subset of actions on a subset of
-   nodes in a cluster.
+- **User Roles**. Unlike traditional SSH, each Teleport user account is assigned a `role`.
+  Having roles allows Teleport to implement role-based access control (RBAC), i.e. assign
+  users to groups (roles) and restrict each role to a subset of actions on a subset of
+  nodes in a cluster.
 
-* **Certificates**. Teleport uses SSH certificates to authenticate nodes and users within
-   a cluster. Teleport does not allow public key or password-based SSH authentication.
+- **Certificates**. Teleport uses SSH certificates to authenticate nodes and users within
+  a cluster. Teleport does not allow public key or password-based SSH authentication.
 
-* **Dynamic Configuration**. Nearly everything in Teleport can be configured via the
-   configuration file, `/etc/teleport.yaml` by default. But some settings can be changed
-   at runtime, by modifying the cluster state (eg., creating user roles or
-   connecting to trusted clusters). These operations are called 'dynamic configuration'.
+- **Dynamic Configuration**. Nearly everything in Teleport can be configured via the
+  configuration file, `/etc/teleport.yaml` by default. But some settings can be changed
+  at runtime, by modifying the cluster state (eg., creating user roles or
+  connecting to trusted clusters). These operations are called 'dynamic configuration'.
 
 ## User Accounts
 
 Teleport supports two types of user accounts:
 
-* **Local users** are created and stored in Teleport's own identitiy storage. A cluster
+- **Local users** are created and stored in Teleport's own identitiy storage. A cluster
   administrator has to create account entries for every Teleport user.
   Teleport supports second factor authentication (2FA) and it is enforced by default.
   There are two types of 2FA supported:
-    * [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
-      is the default. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator) or
-      [Authy](https://www.authy.com/) or any other TOTP client.
-    * [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor).
-* **External users** are users stored elsewhere within an organization. Examples include
+  - [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
+    is the default. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator) or
+    [Authy](https://www.authy.com/) or any other TOTP client.
+  - [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor).
+- **External users** are users stored elsewhere within an organization. Examples include
   Github, Active Directory (AD) or any identity store with an OpenID/OAuth2 or SAML endpoint.
 
-<Admonition type="tip" title="Version Warning">
-SAML, OIDC and Active Directory are only supported in Teleport Enterprise. Please
-take a look at the [Teleport Enterprise](enterprise.mdx) chapter for more information.
+<Admonition
+  type="tip"
+  title="Version Warning"
+>
+  SAML, OIDC and Active Directory are only supported in Teleport Enterprise. Please
+  take a look at the [Teleport Enterprise](enterprise.mdx) chapter for more information.
 </Admonition>
 
 It is possible to have multiple identity sources configured for a Teleport cluster. In this
@@ -96,22 +99,24 @@ of network calls performed by Teleport components when the client tries to conne
 node:
 
 1) The client tries to establish an SSH connection to a proxy using either the CLI interface or a
-   web browser (via HTTPS). When establishing a connection, the client offers its public key. Clients must always connect through a proxy for two reasons:
+web browser (via HTTPS). When establishing a connection, the client offers its public key. Clients must always connect through a proxy for two reasons:
 
-* Individual nodes may not always be reachable from "the outside".
-* Proxies always record SSH sessions and keep track of active user sessions. This makes it possible for an SSH user to see if someone else is connected to a node she is about to work on.
+- Individual nodes may not always be reachable from "the outside".
+- Proxies always record SSH sessions and keep track of active user sessions. This makes it possible for an SSH user to see if someone else is connected to a node she is about to work on.
 
 2) The proxy checks if the submitted certificate has been previously signed by the auth server.
-   If there was no key previously offered (first time login) or if the certificate has expired, the
-   proxy denies the connection and asks the client to login interactively using a password and a
-   2nd factor.
+If there was no key previously offered (first time login) or if the certificate has expired, the
+proxy denies the connection and asks the client to login interactively using a password and a
+2nd factor.
 
- Teleport uses [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en)
-    for the two-step authentication. The password + 2nd factor are submitted to a proxy via HTTPS, therefore it is critical for a secure configuration of Teleport to install a proper HTTPS certificate on a proxy.
+Teleport uses [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en)
+for the two-step authentication. The password + 2nd factor are submitted to a proxy via HTTPS, therefore it is critical for a secure configuration of Teleport to install a proper HTTPS certificate on a proxy.
 
-
-<Admonition type="warning" title="Warning">
-Do not use a self-signed certificate in production!
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  Do not use a self-signed certificate in production!
 </Admonition>
 
 If the credentials are correct, the auth server generates and signs a new certificate and returns
@@ -119,35 +124,38 @@ it to a client via the proxy. The client stores this key and will use it for sub
 logins. The key will automatically expire after 12 hours by default. This TTL can be configured to another value by the cluster administrator.
 
 3) At this step, the proxy tries to locate the requested node in a cluster. There are three
-   lookup mechanisms a proxy uses to find the node's IP address:
+lookup mechanisms a proxy uses to find the node's IP address:
 
-* Tries to resolve the name requested by the client.
-* Asks the auth server if there is a node registered with this `nodename`.
-* Asks the auth server to find a node (or nodes) with a label that matches the requested name.
+- Tries to resolve the name requested by the client.
+- Asks the auth server if there is a node registered with this `nodename`.
+- Asks the auth server to find a node (or nodes) with a label that matches the requested name.
 
 If the node is located, the proxy establishes the connection between the client and the
 requested node. The destination node then begins recording the session, sending the session history to the auth server to be stored.
 
-<Admonition type="note" title="Note">
-Teleport may also be configured to have the session recording occur on the proxy, see [Session Recording](architecture/#session-recording) for more information.
+<Admonition
+  type="note"
+  title="Note"
+>
+  Teleport may also be configured to have the session recording occur on the proxy,
+  see [Session Recording](architecture.mdx#session-recording) for more information.
 </Admonition>
 
 4) When the node receives a connection request, it also checks with the auth server to validate
-   the submitted client certificate. The node requests the auth server to provide a list
-   of OS users (user mappings) for the connecting client, to make sure the client is authorized
-   to use the requested OS login.
+the submitted client certificate. The node requests the auth server to provide a list
+of OS users (user mappings) for the connecting client, to make sure the client is authorized
+to use the requested OS login.
 
-   In other words, every connection is authenticated twice before being authorized to log in:
+In other words, every connection is authenticated twice before being authorized to log in:
 
-* User's cluster membership is validated when connecting a proxy.
-* User's cluster membership is validated again when connecting to a node.
-* User's node-level permissions are validated before authorizing her to interact with SSH
-      subsystems.
+- User's cluster membership is validated when connecting a proxy.
+- User's cluster membership is validated again when connecting to a node.
+- User's node-level permissions are validated before authorizing her to interact with SSH
+  subsystems.
 
 **Detailed Diagram of a Teleport cluster**
 
 ![Teleport Everything](../img/everything.svg)
-
 
 ## Cluster State
 
@@ -155,21 +163,21 @@ Each cluster node is completely stateless and holds no secrets such as keys, pas
 The persistent state of a Teleport cluster is kept by the auth server. There are three types
 of data stored by the auth server:
 
-* **Cluster State**. A Teleport cluster is a set of machines whose public keys
+- **Cluster State**. A Teleport cluster is a set of machines whose public keys
   are signed by the same certificate authority (CA), with the auth server
   acting as the CA of a cluster. The auth server stores its own keys in a cluster state
   storage. All of cluster dynamic configuration is stored there as well, including:
-    * Node membership information and online/offline status for each node.
-    * List of active sessions.
-    * List of locally stored users.
-    * [RBAC](ssh-rbac) configuration (roles and permissions).
-    * Other dynamic configuration.
+  - Node membership information and online/offline status for each node.
+  - List of active sessions.
+  - List of locally stored users.
+  - [RBAC](ssh-rbac.mdx) configuration (roles and permissions).
+  - Other dynamic configuration.
 
-* **Audit Log**. When users log into a Teleport cluster, execute remote commands and logout,
+- **Audit Log**. When users log into a Teleport cluster, execute remote commands and logout,
   that activity is recorded in the audit log. See [Audit Log](admin-guide.mdx#audit-log)
   for more details.
 
-* **Recorded Sessions**. When Teleport users launch remote shells via `tsh ssh` command, their
+- **Recorded Sessions**. When Teleport users launch remote shells via `tsh ssh` command, their
   interactive sessions are recorded and stored by the auth server. Each recorded
   session is a file which is saved in `/var/lib/teleport` by default, but can also be
   saved in external storage, like an AWS S3 bucket.
@@ -179,20 +187,23 @@ of data stored by the auth server:
 Different types of cluster data can be configured with different storage back-ends as shown
 in the table below:
 
-Data Type        | Supported Back-ends       | Notes
------------------|---------------------------|---------
-Cluster state    | `dir`, `etcd`, `dynamodb` | If multi-server (HA) configuration is used with `dir` backend, users must use NFS or similar networked filesystem to keep the `data_dir` in sync between the auth servers.
-Audit Log Events | `dir`, `dynamodb`         | If `dynamodb` is used for the audit log events, `s3` back-end **must** be used for the recorded sessions.
-Recorded Sessions| `dir`, `s3`               | `s3` is mandatory if `dynamodb` is used for the audit log.
+| Data Type | Supported Back-ends | Notes |
+| - | - | - |
+| Cluster state | `dir`, `etcd`, `dynamodb` | If multi-server (HA) configuration is used with `dir` backend, users must use NFS or similar networked filesystem to keep the `data_dir` in sync between the auth servers. |
+| Audit Log Events | `dir`, `dynamodb` | If `dynamodb` is used for the audit log events, `s3` back-end **must** be used for the recorded sessions. |
+| Recorded Sessions | `dir`, `s3` | `s3` is mandatory if `dynamodb` is used for the audit log. |
 
-<Admonition type="tip" title="Note">
-The reason Teleport designers split the audit log events and the recorded
-sessions into different back-ends is because of the nature of the data. A
-recorded session is a compressed binary stream (blob) while the event is a
-well-defined JSON structure. `dir` works well enough for both in small
-deployments, but large clusters require specialized data stores: S3 is
-perfect for uploading session blobs, while DynamoDB or `etcd` are better
-suited to store the cluster state.
+<Admonition
+  type="tip"
+  title="Note"
+>
+  The reason Teleport designers split the audit log events and the recorded
+  sessions into different back-ends is because of the nature of the data. A
+  recorded session is a compressed binary stream (blob) while the event is a
+  well-defined JSON structure. `dir` works well enough for both in small
+  deployments, but large clusters require specialized data stores: S3 is
+  perfect for uploading session blobs, while DynamoDB or `etcd` are better
+  suited to store the cluster state.
 </Admonition>
 
 The combination of DynamoDB + S3 is especially popular among AWS users because it allows them to
@@ -202,22 +213,22 @@ run Teleport clusters completely devoid of local state.
 
 There are three types of services (roles) in a Teleport cluster.
 
-| Service (Node Role)  | Description
-|----------------|------------------------------------------------------------------------
-| node   | This role provides the SSH access to a node. Typically every machine in a cluster runs this role. It is stateless and lightweight.
-| proxy  | The proxy accepts inbound connections from the clients and routes them to the appropriate nodes. The proxy also serves the Web UI.
-| auth   | This service provides authentication and authorization service to proxies and nodes. It is the certificate authority (CA) of a cluster and the storage for audit logs. It is the only stateful component of a Teleport cluster.
+| Service (Node Role) | Description |
+| - | - |
+| node | This role provides the SSH access to a node. Typically every machine in a cluster runs this role. It is stateless and lightweight. |
+| proxy | The proxy accepts inbound connections from the clients and routes them to the appropriate nodes. The proxy also serves the Web UI. |
+| auth | This service provides authentication and authorization service to proxies and nodes. It is the certificate authority (CA) of a cluster and the storage for audit logs. It is the only stateful component of a Teleport cluster. |
 
 Although `teleport` daemon is a single binary, it can provide any combination of these services
 via `--roles` command line flag or via the configuration file.
 
 In addition to `teleport` daemon, there are three client tools:
 
-| Tool           | Description
-|----------------|------------------------------------------------------------------------
-| tctl    | Cluster administration tool used to invite nodes to a cluster and manage user accounts. `tctl` must be used on the same machine where `auth` is running.
-| tsh     | Teleport client tool, similar in principle to OpenSSH's `ssh`. It is used to log into remote SSH nodes, list and search for nodes in a cluster, securely upload/download files, etc. `tsh` can work in conjunction with `ssh` by acting as an SSH agent.
-| Web browser | You can use your web browser to log into any Teleport node. Just open `https://<proxy-host>:3080` (`proxy-host` is one of the machines that has proxy service enabled).
+| Tool | Description |
+| - | - |
+| tctl | Cluster administration tool used to invite nodes to a cluster and manage user accounts. `tctl` must be used on the same machine where `auth` is running. |
+| tsh | Teleport client tool, similar in principle to OpenSSH's `ssh`. It is used to log into remote SSH nodes, list and search for nodes in a cluster, securely upload/download files, etc. `tsh` can work in conjunction with `ssh` by acting as an SSH agent. |
+| Web browser | You can use your web browser to log into any Teleport node. Just open `https://<proxy-host>:3080` (`proxy-host` is one of the machines that has proxy service enabled). |
 
 Let's explore each of the Teleport services in detail.
 
@@ -228,8 +239,8 @@ based on SSH certificates and every certificate must be signed by the cluster au
 
 There are two types of [certificates](#certificates) the auth server can sign:
 
-* **Host certificates** are used to add new nodes to a cluster.
-* **User certificates** are used to authenticate users when they try to log into a cluster node.
+- **Host certificates** are used to add new nodes to a cluster.
+- **User certificates** are used to authenticate users when they try to log into a cluster node.
 
 Upon initialization, the auth server generates a public / private keypair and stores it in the
 configurable key storage. The auth server also keeps the records of what has been happening
@@ -243,9 +254,12 @@ the node and signs its certificate.
 To join a cluster for the first time, a node must present a "join token" to the auth server.
 The token can be static (configured via a config file) or a dynamic, single-use token.
 
-<Admonition type="tip" title="NOTE">
-When using dynamic tokens, their default time to live (TTL) is 15 minutes, but it can be
-reduced (not increased) via `tctl` flag.
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  When using dynamic tokens, their default time to live (TTL) is 15 minutes, but it can be
+  reduced (not increased) via `tctl` flag.
 </Admonition>
 
 Nodes that are members of a Teleport cluster can interact with the auth server using the auth API.
@@ -261,10 +275,13 @@ discover the member nodes of the cluster.
 
 Cluster administration is performed using `tctl` command line tool.
 
-<Admonition type="tip" title="NOTE">
-For high availability in production, a Teleport cluster can be serviced by multiple auth servers
-running in sync. Check [HA configuration](admin-guide.mdx#high-availability) in the
-Admin Guide.
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  For high availability in production, a Teleport cluster can be serviced by multiple auth servers
+  running in sync. Check [HA configuration](admin-guide.mdx#high-availability) in the
+  Admin Guide.
 </Admonition>
 
 ### The Proxy Service
@@ -286,8 +303,11 @@ recommended to have several of them running.
 When you launch the Teleport Proxy for the first time, it will generate a self-signed HTTPS
 certificate to make it easier to explore Teleport.
 
-<Admonition type="warning" title="Warning">
-It is absolutely crucial to properly configure TLS for HTTPS when you use Teleport Proxy in production.
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  It is absolutely crucial to properly configure TLS for HTTPS when you use Teleport Proxy in production.
 </Admonition>
 
 ### Web to SSH Proxy
@@ -305,8 +325,11 @@ In this mode, Teleport Proxy implements WSS (secure web sockets) to SSH proxy:
 4. From the SSH node's perspective, it's a regular SSH client connection that is authenticated using an
    OpenSSH certificate, so no special logic is needed.
 
-<Admonition type="tip" title="NOTE">
-When using the web UI, Teleport Proxy terminates the traffic and re-encodes for SSH client connection.
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  When using the web UI, Teleport Proxy terminates the traffic and re-encodes for SSH client connection.
 </Admonition>
 
 ### SSH Proxy
@@ -332,8 +355,11 @@ Once the client has obtained a short lived certificate, it can use it to authent
 2. Proxy dials to the target TCP address and starts forwarding the traffic to the client.
 3. SSH client uses established SSH tunnel to open a new SSH connection and authenticate with the target node using its client certificate.
 
-<Admonition type="tip" title="NOTE">
-Teleport's proxy command makes it compatible with [SSH jump hosts](https://wiki.gentoo.org/wiki/SSH_jump_host) implemented using OpenSSH's `ProxyCommand`
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  Teleport's proxy command makes it compatible with [SSH jump hosts](https://wiki.gentoo.org/wiki/SSH_jump_host) implemented using OpenSSH's `ProxyCommand`
 </Admonition>
 
 ## Certificates
@@ -343,18 +369,18 @@ Teleport uses standard SSH certificates for client and host authentication.
 One can think of an SSH certificate as a "permit" issued and time-stamped by a
 certificate authority. A certificate contains four important pieces of data:
 
-* List of principals (identities) this certificate belongs to.
-* Signature of the certificate authority who issued it, i.e. the _auth server_.
-* The expiration date, also known as "time to live" or simply TTL.
-* Additional data, often stored as a certificate extension.
+- List of principals (identities) this certificate belongs to.
+- Signature of the certificate authority who issued it, i.e. the *auth server*.
+- The expiration date, also known as "time to live" or simply TTL.
+- Additional data, often stored as a certificate extension.
 
-One can think of a Teleport _auth server_ as a certificate authority (CA) of a
+One can think of a Teleport *auth server* as a certificate authority (CA) of a
 cluster which issues certificates. The reality is a bit more complicated
 because cluster hosts need their own certificates too. Therefore, there are two
-CAs inside the _auth server_ per cluster:
+CAs inside the *auth server* per cluster:
 
-* **Host CA** issues host certificates.
-* **User CA** issues user certificates.
+- **Host CA** issues host certificates.
+- **User CA** issues user certificates.
 
 ### Host Certificates
 
@@ -371,7 +397,7 @@ get auth servers registered in the cluster).
 
 ### User Certificates
 
-The _auth server_ uses its _user CA_ to issue user certificates. In addition to
+The *auth server* uses its *user CA* to issue user certificates. In addition to
 user's identity, user certificates also contain user roles and SSH options,
 like "permit-agent-forwarding".
 
@@ -382,19 +408,19 @@ signature.
 
 By default, all user certificates have an expiration date, also known as time to
 live (TTL). This TTL can be configured by a Teleport administrator. But the
-host certificates issued by an _auth server_ are valid indefinitely by default.
+host certificates issued by an *auth server* are valid indefinitely by default.
 
-Teleport supports certificate rotation, i.e. the process of invalidating _all_
+Teleport supports certificate rotation, i.e. the process of invalidating *all*
 previously issued certificates regardless of their TTL. Certificate rotation is
 triggered by `tctl auth rotate` command. When this command is invoked by a Teleport
-administrator on one of cluster's _auth servers_, the following happens:
+administrator on one of cluster's *auth servers*, the following happens:
 
-* A new certificate authority (CA) key is generated.
-* The old CA will be considered valid _alongside_ the new CA for some period of
-  time. This period of time is called a _grace period_.
-* During the grace period, all previously issued certificates will be considered
+- A new certificate authority (CA) key is generated.
+- The old CA will be considered valid *alongside* the new CA for some period of
+  time. This period of time is called a *grace period*.
+- During the grace period, all previously issued certificates will be considered
   valid, assuming their TTL isn't expired.
-* After the grace period is over, the certificates issued by the old CA are no
+- After the grace period is over, the certificates issued by the old CA are no
   longer accepted.
 
 This process is repeated twice, for both the host CA and the user CA. Take a
@@ -407,24 +433,30 @@ The Teleport auth server keeps the audit log of SSH-related events that take
 place on any node with a Teleport cluster. It is important to understand that
 the SSH nodes emit audit events and submit them to the auth server.
 
-<Admonition type="warning" title="Compatibility Warning">
-Because all SSH events like `exec` or `session_start` are reported by the
-Teleport node service, they will not be logged if you are using OpenSSH
-`sshd` daemon on your nodes.
+<Admonition
+  type="warning"
+  title="Compatibility Warning"
+>
+  Because all SSH events like `exec` or `session_start` are reported by the
+  Teleport node service, they will not be logged if you are using OpenSSH
+  `sshd` daemon on your nodes.
 </Admonition>
 
 Only an SSH server can report what's happening to the Teleport auth server.
 The audit log is a JSON file which is by default stored on the auth server's
 filesystem under `/var/lib/teleport/log`. The format of the file is documented
-in the [Admin Manual](admin-guide/#audit-log).
+in the [Admin Manual](admin-guide.mdx#audit-log).
 
 Teleport users are encouraged to export the events into external, long term
 storage.
 
-<Admonition type="tip" title="Deployment Considerations">
-If multiple Teleport auth servers are used to service the same cluster (HA mode)
-a network file system must be used for `/var/lib/teleport/log` to allow them
-to combine all audit events into the same audit log.
+<Admonition
+  type="tip"
+  title="Deployment Considerations"
+>
+  If multiple Teleport auth servers are used to service the same cluster (HA mode)
+  a network file system must be used for `/var/lib/teleport/log` to allow them
+  to combine all audit events into the same audit log.
 </Admonition>
 
 ### Session Recording
@@ -450,7 +482,7 @@ server to be recorded, as shown below:
 
 ![recorindg-proxy](../img/recording-proxy.svg)
 
-The recording proxy mode, although _less secure_, was added to allow Teleport
+The recording proxy mode, although *less secure*, was added to allow Teleport
 users to enable session recording for OpenSSH's servers running `sshd`, which is
 helpful when gradually transitioning large server fleets to Teleport.
 
@@ -470,7 +502,7 @@ at the nodes, a root user can add iptables rules to prevent sessions logs from r
 the Auth Server. With sessions recorded at the proxy, users with root privileges on nodes
 have no way of disabling the audit.
 
-See the [admin guide](admin-guide#recorded-sessions) to learn how to turn on the
+See the [admin guide](admin-guide.mdx#recorded-sessions) to learn how to turn on the
 recording proxy mode.
 
 ## Teleport CLI Tools

--- a/docs/pages/enterprise.mdx
+++ b/docs/pages/enterprise.mdx
@@ -4,27 +4,30 @@ title: Teleport Enterprise
 
 This section will give an overview of Teleport Enterprise, the commercial product built around
 the open source Teleport Community core. For those that want to jump right in, you can play with
-the [Quick Start Guide of Teleport Enterprise](quickstart-enterprise).
+the [Quick Start Guide of Teleport Enterprise](quickstart-enterprise.mdx).
 
 The table below gives a quick overview of the
 benefits of Teleport Enterprise.
 
-|Teleport Enterprise Feature|Description
----------|--------------
-|[Role Based Access Control (RBAC)](#rbac)|Allows Teleport administrators to define User Roles and restrict each role to specific actions. RBAC also allows administrators to partition cluster nodes into groups with different access permissions.
-|[Single Sign-On (SSO)](#sso)| Allows Teleport to integrate with existing enterprise identity systems. Examples include Active Directory, Github, Google Apps and numerous identity middleware solutions like Auth0, Okta, and so on. Teleport supports SAML and OAuth/OpenID Connect protocols to interact with them.
-|Commercial Support | In addition to these features, Teleport Enterprise also comes with a premium support SLA with guaranteed response times.
+| Teleport Enterprise Feature | Description |
+| - | - |
+| [Role Based Access Control (RBAC)](#rbac) | Allows Teleport administrators to define User Roles and restrict each role to specific actions. RBAC also allows administrators to partition cluster nodes into groups with different access permissions. |
+| [Single Sign-On (SSO)](#sso) | Allows Teleport to integrate with existing enterprise identity systems. Examples include Active Directory, Github, Google Apps and numerous identity middleware solutions like Auth0, Okta, and so on. Teleport supports SAML and OAuth/OpenID Connect protocols to interact with them. |
+| Commercial Support | In addition to these features, Teleport Enterprise also comes with a premium support SLA with guaranteed response times. |
 
-<Admonition type="tip" title="Contact Information">
-If you are interested in Teleport Enterprise, please reach out to
-`sales@gravitational.com` for more information.
+<Admonition
+  type="tip"
+  title="Contact Information"
+>
+  If you are interested in Teleport Enterprise, please reach out to
+  `sales@gravitational.com` for more information.
 </Admonition>
 
 ## RBAC
 
-Role Based Access Control ("RBAC") allows Teleport administrators to grant granular access permissions to users. An example of an RBAC policy might be:  _"admins can do anything,
+Role Based Access Control ("RBAC") allows Teleport administrators to grant granular access permissions to users. An example of an RBAC policy might be:  *"admins can do anything,
 developers must never touch production servers, and interns can only SSH into
-staging servers as guests"_
+staging servers as guests"*
 
 ### How does it work?
 
@@ -64,7 +67,6 @@ Other identity management systems are supported as long as they provide an
 SSO mechanism based on either [SAML](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
 or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
-
 ### How does SSO work with SSH?
 
 From the user's perspective they need to execute the following command to retrieve their SSH certificate.
@@ -80,9 +82,12 @@ prompt, along with the 2FA, as enforced by the SSO provider. If user supplies
 valid credentials, Teleport will issue an SSH certificate.
 
 Moreover, SSO can be used in combination with role-based access control (RBAC)
-to enforce SSH access policies like _"developers must not touch production data"_.
+to enforce SSH access policies like *"developers must not touch production data"*.
 See the [SSO for SSH](ssh-sso.mdx) chapter for more details.
 
-<Admonition type="tip" title="Contact Information">
-For more information about Teleport Enterprise or Telekube please reach out us to `sales@gravitational.com` or fill out the contact for on our [website](https://gravitational.com/demo)
+<Admonition
+  type="tip"
+  title="Contact Information"
+>
+  For more information about Teleport Enterprise or Telekube please reach out us to `sales@gravitational.com` or fill out the contact for on our [website](https://gravitational.com/demo)
 </Admonition>

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -19,7 +19,7 @@ available unless the Teleport SSH daemon is present on all cluster nodes.
 ### Can I use OpenSSH with a Teleport cluster?
 
 Yes, this question comes up often and is related to the previous one. Take a
-look at [Using OpenSSH client](user-manual.mdx##using-teleport-with-openssh)
+look at [Using OpenSSH client](user-manual.mdx#using-openssh-client)
 section in the User Manual and [Using OpenSSH servers](admin-guide.mdx) in the
 Admin Manual.
 
@@ -52,10 +52,10 @@ Gravitational offers this feature for the [commercial versions of Teleport](ente
 
 The Teleport Enterprise offering gives users the following additional features:
 
-* Role-based access control, also known as [RBAC](enterprise#rbac).
-* Authentication via SAML and OpenID with providers like Okta, Active
-  Directory, Auth0, etc. (aka, [SSO](ssh-sso)).
-* Premium support.
+- Role-based access control, also known as [RBAC](enterprise.mdx#rbac).
+- Authentication via SAML and OpenID with providers like Okta, Active
+  Directory, Auth0, etc. (aka, [SSO](ssh-sso.mdx)).
+- Premium support.
 
 We also offer implementation services, to help you integrate
 Teleport with your existing systems and processes.
@@ -70,8 +70,8 @@ commercial versions of Teleport may or may not be configured to send anonymized
 information to Gravitational, depending on the license purchased. This
 information contains the following:
 
-* Anonymized user ID: SHA256 hash of a username with a randomly generated prefix.
-* Anonymized server ID: SHA256 hash of a server IP with a randomly generated prefix.
+- Anonymized user ID: SHA256 hash of a username with a randomly generated prefix.
+- Anonymized server ID: SHA256 hash of a server IP with a randomly generated prefix.
 
 This allows Teleport Pro to print a warning if users are exceeding the usage limits
 of their license. The reporting library code is [on Github](https://github.com/gravitational/reporting).

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -8,26 +8,25 @@ Gravitational Teleport is a gateway for managing access to clusters of Linux
 servers via SSH or the Kubernetes API. It is intended to be used instead of
 traditional OpenSSH for organizations that need to:
 
-* Secure their infrastructure and comply with security best-practices and
+- Secure their infrastructure and comply with security best-practices and
   regulatory requirements.
-* Have complete visibility into activity happening across their infrastructure.
-* Reduce the operational overhead of privileged access management across both
+- Have complete visibility into activity happening across their infrastructure.
+- Reduce the operational overhead of privileged access management across both
   traditional and cloud-native infrastructure.
-
 
 Teleport aims to be a cloud-native SSH solution, i.e. it makes it natural to think of
 environments, not servers. Below is the list of most popular Teleport features:
 
-* Single SSH/Kubernetes access gateway for an entire organization.
-* Certificate based authentication instead of static keys.
-* The ability to manage trust between teams, organizations and data centers.
-* SSH/Kubernetes access into behind-firewall environments without any open ports.
-* Role-based access control (RBAC) for SSH.
-* A single tool ("pane of glass") to manage RBAC for both SSH and Kubernetes.
-* Audit log with session recording/replay.
-* Kubernetes audit log, including the recording of interactive commands executed via `kubectl`.
-* The same workflows and ease of that they get with familiar `ssh` / `kubectl` commands.
-* Ability to run in "agentless" mode, i.e. most of Teleport features are
+- Single SSH/Kubernetes access gateway for an entire organization.
+- Certificate based authentication instead of static keys.
+- The ability to manage trust between teams, organizations and data centers.
+- SSH/Kubernetes access into behind-firewall environments without any open ports.
+- Role-based access control (RBAC) for SSH.
+- A single tool ("pane of glass") to manage RBAC for both SSH and Kubernetes.
+- Audit log with session recording/replay.
+- Kubernetes audit log, including the recording of interactive commands executed via `kubectl`.
+- The same workflows and ease of that they get with familiar `ssh` / `kubectl` commands.
+- Ability to run in "agentless" mode, i.e. most of Teleport features are
   available on clusters with pre-existing SSH daemons, usually `sshd`.
 
 Teleport is available through the free, open source edition ("Teleport Community Edition")
@@ -39,19 +38,19 @@ Teleport is officially supported on the platforms listed below, it is worth noti
 that the open source community has been successful building and running Teleport on
 UNIX variants other than Linux [2].
 
-Operating System      |  Teleport Client   | Teleport Server
-----------------------|--------------------|-----------------
-Linux v2.6+           |  yes               | yes
-MacOS v10.12+         |  yes               | yes
-Windows [1]           |  yes [1]           | no
+| Operating System | Teleport Client | Teleport Server |
+| - | - | - |
+| Linux v2.6+ | yes | yes |
+| MacOS v10.12+ | yes | yes |
+| Windows [1] | yes [1] | no |
 
-[1] _Teleport server does not run on Windows yet, but `tsh` (the Teleport client)
-  can be used on Windows to execute `tsh login` to retrieve a user's SSH
-  certificate and use it with `ssh`, the OpenSSH client, running on a Windows
-  client machine._
+[1] *Teleport server does not run on Windows yet, but `tsh` (the Teleport client)
+can be used on Windows to execute `tsh login` to retrieve a user's SSH
+certificate and use it with `ssh`, the OpenSSH client, running on a Windows
+client machine.*
 
-[2] _Teleport is written in Go and it is theoretically possible to build it on
-    any OS supported by the [Golang toolchain](https://github.com/golang/go/wiki/MinimumRequirements)_.
+[2] *Teleport is written in Go and it is theoretically possible to build it on
+any OS supported by the [Golang toolchain](https://github.com/golang/go/wiki/MinimumRequirements)*.
 
 ## Teleport Community
 
@@ -61,16 +60,16 @@ code. This documentation is also available in [the Github
 repository](https://github.com/gravitational/teleport/tree/master/docs), so feel
 free to create an issue or pull request if you have comments.
 
-- [Quickstart Guide](quickstart/) - A quick tutorial to show off the basic
+- [Quickstart Guide](quickstart.mdx) - A quick tutorial to show off the basic
   capabilities of Teleport. A good place to start if you want to jump right in.
-- [Teleport Architecture](architecture/) - This section covers the underlying
+- [Teleport Architecture](architecture.mdx) - This section covers the underlying
   design principles of Teleport and a detailed description of Teleport
   architecture. A good place to learn about Teleport's design and how it works.
-- [User Manual](user-manual/) - This manual expands on the Quickstart and
+- [User Manual](user-manual.mdx) - This manual expands on the Quickstart and
   provides end users with all they need to know about how to use Teleport.
-- [Admin Manual](admin-guide/) - This manual covers installation and
+- [Admin Manual](admin-guide.mdx) - This manual covers installation and
   configuration of Teleport and the ongoing management of Teleport.
-- [FAQ](faq/) - Common questions about Teleport.
+- [FAQ](faq.mdx) - Common questions about Teleport.
 
 ## Teleport Enterprise
 
@@ -80,21 +79,21 @@ integration with identity managers for single sign-on (SSO). Because the
 majority of documentation between the Community and Enterprise Editions overlap,
 we have separated out the documentation that is specific to Teleport Enterprise.
 
-- [Teleport Enterprise Introduction](enterprise) - Overview of the additional capabilities of Teleport Enterprise.
-- [Teleport Enterprise Quick Start](quickstart-enterprise) - A quick tutorial to show off the basic capabilities of Teleport Enterprise.
-A good place to start if you want to jump right in.
-- [RBAC for SSH](ssh-rbac) - Details on how Teleport Enterprise provides Role-based Access Controls (RBAC) for SSH.
-- [SSO for SSH](ssh-sso) - Overview on how Teleport Enterprise works with external identity providers for single sign-on (SSO).
+- [Teleport Enterprise Introduction](enterprise.mdx) - Overview of the additional capabilities of Teleport Enterprise.
+- [Teleport Enterprise Quick Start](quickstart-enterprise.mdx) - A quick tutorial to show off the basic capabilities of Teleport Enterprise.
+  A good place to start if you want to jump right in.
+- [RBAC for SSH](ssh-rbac.mdx) - Details on how Teleport Enterprise provides Role-based Access Controls (RBAC) for SSH.
+- [SSO for SSH](ssh-sso.mdx) - Overview on how Teleport Enterprise works with external identity providers for single sign-on (SSO).
 
 ## Guides
 
 We also have several guides that go through the most typical configurations and integrations.
 
-- [Okta Integration](ssh-okta) - How to integrate Teleport Enterprise with Okta.
-- [ADFS Integration](ssh-adfs) - How to integrate Teleport Enterprise with Active Directory.
-- [One Login Integration](ssh-one-login) - How to integrate Teleport Enterprise with One Login.
-- [OIDC Integration](oidc) - How to integrate Teleport Enterprise with identity providers using OIDC/OAuth2.
-- [Kubernetes Integration](kubernetes-ssh) - How to configure Teleport to serve as a unified gateway for Kubernetes clusters and clusters of regular SSH nodes.
+- [Okta Integration](ssh-okta.mdx) - How to integrate Teleport Enterprise with Okta.
+- [ADFS Integration](ssh-adfs.mdx) - How to integrate Teleport Enterprise with Active Directory.
+- [One Login Integration](ssh-one-login.mdx) - How to integrate Teleport Enterprise with One Login.
+- [OIDC Integration](oidc.mdx) - How to integrate Teleport Enterprise with identity providers using OIDC/OAuth2.
+- [Kubernetes Integration](kubernetes-ssh.mdx) - How to configure Teleport to serve as a unified gateway for Kubernetes clusters and clusters of regular SSH nodes.
 
 ## Support and Contributing
 
@@ -102,9 +101,9 @@ We offer a few different options for support. First of all, we try to provide cl
 
 If you still have questions after reviewing our docs, you can also:
 
-* Join the [Teleport Community](https://community.gravitational.com/c/teleport) to ask questions. Our engineers are available there to help you.
-* If you want to contribute to Teleport or file a bug report/issue, you can do so by creating an issue in [Github](https://github.com/gravitational/teleport/).
-* If you are interested in Teleport Enterprise or more responsive support during a POC, we can also create a dedicated Slack channel for you during your POC. You can [reach out to us through our website](https://gravitational.com/teleport/) to arrange for a POC.
+- Join the [Teleport Community](https://community.gravitational.com/c/teleport) to ask questions. Our engineers are available there to help you.
+- If you want to contribute to Teleport or file a bug report/issue, you can do so by creating an issue in [Github](https://github.com/gravitational/teleport/).
+- If you are interested in Teleport Enterprise or more responsive support during a POC, we can also create a dedicated Slack channel for you during your POC. You can [reach out to us through our website](https://gravitational.com/teleport/) to arrange for a POC.
 
 Teleport is made by [Gravitational](https://gravitational.com/). We hope you
 enjoy using Teleport. If you have comments or questions, feel free to reach out

--- a/docs/pages/kubernetes-ssh.mdx
+++ b/docs/pages/kubernetes-ssh.mdx
@@ -4,12 +4,12 @@ title: Kubernetes and SSH Integration Guide
 
 Teleport v.3.0+ has the ability to act as a compliance gateway for managing privileged access to Kubernetes clusters. This enables the following capabilities:
 
-* A Teleport Proxy can act as a single authentication endpoint for both SSH and
+- A Teleport Proxy can act as a single authentication endpoint for both SSH and
   Kubernetes. Users can authenticate against a Teleport proxy using Teleport's `tsh login` command and retrieve credentials for both SSH and Kubernetes API.
-* Users RBAC roles are always synchronized between SSH and Kubernetes, making
-  it easier to implement policies like _developers must not access production
-  data_.
-* Teleport's session recording and audit log extend to Kubernetes, as well.
+- Users RBAC roles are always synchronized between SSH and Kubernetes, making
+  it easier to implement policies like *developers must not access production
+  data*.
+- Teleport's session recording and audit log extend to Kubernetes, as well.
   Regular `kubectl exec` commands are logged into the audit log and the
   interactive commands are recorded as regular sessions that can be stored and replayed in the
   future.
@@ -39,13 +39,13 @@ proxy_service:
 
 Let's take a closer look at the available Kubernetes settings:
 
-* `public_addr` defines the publicly accessible address which Kubernetes API
+- `public_addr` defines the publicly accessible address which Kubernetes API
   clients like `kubectl` will connect to. This address will be placed inside of
   `kubeconfig` on a client's machine when a client executes `tsh login` command
   to retrieve its certificate. If you intend to run multiple Teleport proxies behind
   a load balancer, this must be the load balancer's public address.
 
-* `listen_addr` defines which network interface and port the Teleport proxy server
+- `listen_addr` defines which network interface and port the Teleport proxy server
   should bind to. It defaults to port 3026 on all NICs.
 
 ## Connecting the Teleport proxy to Kubernetes
@@ -124,10 +124,10 @@ proxy. The next step is to configure Teleport to assign the correct Kubernetes g
 Mapping Kubernetes groups to Teleport users depends on how Teleport is
 configured. In this guide we'll look at two common configurations:
 
-* **Open source, Teleport Community edition** configured to authenticate users via [Github](admin-guide.mdx#github-oauth-20).
+- **Open source, Teleport Community edition** configured to authenticate users via [Github](admin-guide.mdx#github-oauth-20).
   In this case, we'll need to map Github teams to Kubernetes groups.
 
-* **Commercial, Teleport Enterprise edition** configured to authenticate users via [Okta SSO](ssh-okta.mdx).
+- **Commercial, Teleport Enterprise edition** configured to authenticate users via [Okta SSO](ssh-okta.mdx).
   In this case, we'll need to map users' groups that come from Okta to Kubernetes
   groups.
 
@@ -162,6 +162,7 @@ spec:
       # list of Kubernetes groups this Github team is allowed to connect to
       kubernetes_groups: ["system:masters"]
 ```
+
 To obtain client ID and client secret from Github, please follow [Github documentation](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) on how to create and register an OAuth app. Be sure to set the "Authorization callback URL" to the same value as redirect_url in the resource spec.
 
 Finally, create the Github connector with the command: `tctl create -f github.yaml`. Now, when Teleport users execute the Teleport's `tsh login` command, they will be prompted to login through the Github SSO and upon successful authentication, they have access to Kubernetes.
@@ -178,7 +179,8 @@ The `kubectl exec` request will be routed through the Teleport proxy and
 Teleport will log the audit record and record the session.
 
 <Admonition type="note">
-For more information on integrating Teleport with Github SSO, please see the [Github section in the Admin Manual](admin-guide/#github-oauth-20).
+  For more information on integrating Teleport with Github SSO, please see
+  the [Github section in the Admin Manual](admin-guide.mdx#github-oauth-20).
 </Admonition>
 
 ### Okta Auth
@@ -215,16 +217,19 @@ $ tctl get roles/admin > admin.yaml
 $ tctl create -f admin.yaml
 ```
 
-<Admonition type="tip" title="Advanced Usage">
-`{{ external.trait_name }}` example is shown to demonstrate how to fetch
-the Kubernetes groups dynamically from Okta during login. In this case, you
-need to define Kubernetes group membership in Okta (as a trait) and use
-that trait name in the Teleport role.
+<Admonition
+  type="tip"
+  title="Advanced Usage"
+>
+  `{{ external.trait_name }}` example is shown to demonstrate how to fetch
+  the Kubernetes groups dynamically from Okta during login. In this case, you
+  need to define Kubernetes group membership in Okta (as a trait) and use
+  that trait name in the Teleport role.
 </Admonition>
 
 Once this is complete, when users execute `tsh login` and go through the usual Okta login
 sequence, their `kubeconfig` will be updated with their Kubernetes credentials.
 
 <Admonition type="note">
-For more information on integrating Teleport with Okta, please see the [Okta integration guide](/ssh-okta/).
+  For more information on integrating Teleport with Okta, please see the [Okta integration guide](/ssh-okta/).
 </Admonition>

--- a/docs/pages/oidc.mdx
+++ b/docs/pages/oidc.mdx
@@ -7,14 +7,17 @@ This guide will cover how to configure an SSO provider using [OpenID Connect](ht
 When used in combination with role based access control (RBAC) it allows SSH
 administrators to define policies like:
 
-* Only members of "DBA" group can SSH into machines running PostgreSQL.
-* Developers must never SSH into production servers.
-* ... and many others.
+- Only members of "DBA" group can SSH into machines running PostgreSQL.
+- Developers must never SSH into production servers.
+- ... and many others.
 
-<Admonition type="warning" title="Version Warning">
-This guide requires a commercial edition of Teleport. The open source
-edition of Teleport only supports [Github](admin-guide/#github-oauth-20) as
-an SSO provider.
+<Admonition
+  type="warning"
+  title="Version Warning"
+>
+  This guide requires a commercial edition of Teleport. The open source
+  edition of Teleport only supports [Github](admin-guide.mdx#github-oauth-20) as
+  an SSO provider.
 </Admonition>
 
 ## Enable OIDC Authentication
@@ -35,9 +38,9 @@ Register Teleport with the external identity provider you will be using and
 obtain your `client_id` and `client_secret`. This information should be
 documented on the identity providers website. Here are a few links:
 
-   * [Auth0 Client Configuration](https://auth0.com/docs/clients)
-   * [Google Identity Platform](https://developers.google.com/identity/protocols/OpenIDConnect)
-   * [Keycloak Client Registration](https://www.keycloak.org/docs/latest/securing_apps/index.html#_client_registration)
+- [Auth0 Client Configuration](https://auth0.com/docs/clients)
+- [Google Identity Platform](https://developers.google.com/identity/protocols/OpenIDConnect)
+- [Keycloak Client Registration](https://www.keycloak.org/docs/latest/securing_apps/index.html#_client_registration)
 
 Add your OIDC connector information to `teleport.yaml`. A few examples are
 provided below.
@@ -54,7 +57,7 @@ should be `https://proxy.example.com:3080/v1/webapi/oidc/callback`
 ## OIDC connector configuration
 
 The next step is to add an OIDC connector to Teleport. The connectors are manipulated
-via `tctl` [resource commands](admin-guide#resources). To create a new connector,
+via `tctl` [resource commands](admin-guide.mdx#resources). To create a new connector,
 create a connector resource file in YAML format, for example `oidc-connector.yaml`.
 
 The file contents are shown below. This connector requests the scope `group`
@@ -102,7 +105,7 @@ $ tctl create oidc-connector.yaml
 ## Create Teleport Roles
 
 The next step is to define Teleport roles. They are created using the same
-`tctl` [resource commands](admin-guide#resources) as we used for the auth
+`tctl` [resource commands](admin-guide.mdx#resources) as we used for the auth
 connector.
 
 Below are two example roles that are mentioned above, the first is an admin
@@ -219,4 +222,3 @@ $ sudo journalctl -fu teleport
 
 If you wish to increase the verbocity of Teleport's syslog, you can pass
 `--debug` flag to `teleport start` command.
-

--- a/docs/pages/quickstart-enterprise.mdx
+++ b/docs/pages/quickstart-enterprise.mdx
@@ -22,11 +22,11 @@ The `teleport` daemon runs all three of these services by default. This Quick
 Start Guide will be using this default behavior to create a cluster and
 interact with it using Teleport's client-side tools:
 
-| Tool       | Description
-|------------|------------
-| tctl       | Cluster administration tool used to invite nodes to a cluster and manage user accounts.
-| tsh        | Similar in principle to OpenSSH's `ssh`. Used to login into remote SSH nodes, list and search for nodes in a cluster, securely upload/download files, etc.
-| browser    | You can use your web browser to login into any Teleport node by opening `https://<proxy-host>:3080`.
+| Tool | Description |
+| - | - |
+| tctl | Cluster administration tool used to invite nodes to a cluster and manage user accounts. |
+| tsh | Similar in principle to OpenSSH's `ssh`. Used to login into remote SSH nodes, list and search for nodes in a cluster, securely upload/download files, etc. |
+| browser | You can use your web browser to login into any Teleport node by opening `https://<proxy-host>:3080`. |
 
 ## Prerequisites
 
@@ -35,10 +35,10 @@ to download the software. You will also need three computers: two servers and
 one client (probably a laptop) to complete this tutorial. Lets assume the servers have
 the following DNS names and IPs:
 
-Server Name    |  IP Address    | Purpose
----------------|----------------|--------------
-_"auth.example.com"_  | 10.1.1.10      | This server will be used to run all three Teleport services: auth, proxy and node.
-_"node.example.com"_  | 10.1.1.11      | This server will only run the SSH service. The vast majority of servers in production will be nodes.
+| Server Name | IP Address | Purpose |
+| - | - | - |
+| *"auth.example.com"* | 10.1.1.10 | This server will be used to run all three Teleport services: auth, proxy and node. |
+| *"node.example.com"* | 10.1.1.11 | This server will only run the SSH service. The vast majority of servers in production will be nodes. |
 
 This Quick Start Guide assumes that the both servers are running a [systemd-based](https://www.freedesktop.org/wiki/Software/systemd/)
 Linux distribution such as Debian, Ubuntu or a RHEL deriviative.
@@ -53,9 +53,9 @@ $ tar -xzf teleport-ent-binary-release.tar.gz
 $ cd teleport-ent
 ```
 
-* Copy `teleport` and `tctl` binaries to a bin directory (we suggest `/usr/local/bin`) on the auth server.
-* Copy `teleport` binary to a bin directory on the node server.
-* Copy `tsh` binary to a bin directory on the client computer.
+- Copy `teleport` and `tctl` binaries to a bin directory (we suggest `/usr/local/bin`) on the auth server.
+- Copy `teleport` binary to a bin directory on the node server.
+- Copy `tsh` binary to a bin directory on the client computer.
 
 ### License File
 
@@ -65,10 +65,9 @@ private key in [PEM format](https://en.wikipedia.org/wiki/Privacy-enhanced_Elect
 Download the license file from the [customer portal](https://dashboard.gravitational.com)
 and save it as `/var/lib/teleport/license.pem` on the auth server.
 
-
 ### Configuration File
 
-Save the following configuration file as `/etc/teleport.yaml` on the _node.example.com_:
+Save the following configuration file as `/etc/teleport.yaml` on the *node.example.com*:
 
 ```yaml
 teleport:
@@ -86,7 +85,7 @@ proxy_service:
   enabled: false
 ```
 
-Now, save the following configuration file as `/etc/teleport.yaml` on the _auth.example.com_:
+Now, save the following configuration file as `/etc/teleport.yaml` on the *auth.example.com*:
 
 ```yaml
 teleport:
@@ -131,7 +130,7 @@ $ sudo systemctl start teleport
 ```
 
 Teleport daemon should start and you can use `netstat -lptne` to make sure that
-it's listening on [TCP/IP ports](admin-guide/#ports). On _auth.example.com_, it should
+it's listening on [TCP/IP ports](admin-guide.mdx#ports). On *auth.example.com*, it should
 look something like this:
 
 ```bsh
@@ -145,7 +144,7 @@ tcp6       0      0 :::3022         LISTEN      0          337/teleport
 tcp6       0      0 :::3023         LISTEN      0          337/teleport
 ```
 
-and _node.example.com_ should look something like this:
+and *node.example.com* should look something like this:
 
 ```bsh
 $ node.example.com ~: sudo netstat -lptne
@@ -159,7 +158,7 @@ See [troubleshooting](#troubleshooting) section at the bottom if something is no
 ## Adding Users
 
 This portion of the Quick Start Guide should be performed on the auth server, i.e.
-on _auth.example.com_
+on *auth.example.com*
 
 Every user in a Teleport cluster must be assigned at least one role. By
 default, Teleport comes with one pre-configured role called "admin". You can
@@ -199,18 +198,21 @@ spec:
   deny: {}
 ```
 
-Pay attention to the _allow/logins_ field in the role definition: by default, this
+Pay attention to the *allow/logins* field in the role definition: by default, this
 role only allows SSH logins as `root@host`.
 
-<Admonition type="note" title="Note">
-Ignore `{{internal.logins}}` "allowed login" for now. It exists for
-compatibility purposes when upgrading existing open source Teleport
-clusters.
+<Admonition
+  type="note"
+  title="Note"
+>
+  Ignore `{{internal.logins}}` "allowed login" for now. It exists for
+  compatibility purposes when upgrading existing open source Teleport
+  clusters.
 </Admonition>
 
 You probably want to replace "root" with something else. Let's assume there will
 be a local UNIX account called "admin" on all hosts. In this case you cand
-dump the role definition YAML into _admin-role.yaml_ file and update "allow/logins"
+dump the role definition YAML into *admin-role.yaml* file and update "allow/logins"
 to look like this:
 
 ```yaml
@@ -270,10 +272,13 @@ Note that "--user=joe" part can be omitted if `$USER` environment variable is "j
 Notice that `tsh` client always needs `--proxy` flag because all client connections
 in Teleport always must to go through an SSH proxy, sometimes called an "SSH bastion".
 
-<Admonition type="warning" title="Warning">
-For the purposes of this quickstart we are using the `--insecure` flag which allows
-us to skip configuring the HTTP/TLS certificate for Teleport proxy.
-Never use `--insecure` in production. You must configure the HTTP/TLS proxy certificate.
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  For the purposes of this quickstart we are using the `--insecure` flag which allows
+  us to skip configuring the HTTP/TLS certificate for Teleport proxy.
+  Never use `--insecure` in production. You must configure the HTTP/TLS proxy certificate.
 </Admonition>
 
 If successful, `tsh login` command will receive Joe's user certificate and will
@@ -297,15 +302,14 @@ $ tsh logout
 The local account is good for administrative purposes but regular users of
 Teleport Enterprise should be using a Single Sign-On (SSO) mechanism that use SAML or OIDC protocols.
 
-
-Take a look at the [SSH via Single Sign-on](ssh-sso/) chapter learn the basics of integrating
+Take a look at the [SSH via Single Sign-on](ssh-sso.mdx) chapter learn the basics of integrating
 Teleport with SSO providers. We have the following detailed guides for
 configuring SSO providers:
 
-* [Okta](ssh-okta/)
-* [Active Directory](ssh-adfs/)
-* [One Login](ssh-one-login/)
-* [Github](admin-guide/#github-oauth-20)
+- [Okta](ssh-okta.mdx)
+- [Active Directory](ssh-adfs.mdx)
+- [One Login](ssh-one-login.mdx)
+- [Github](admin-guide.mdx#github-oauth-20)
 
 Any SAML-compliant provider can be configured with Teleport by following the
 same steps.  There are Teleport Enterprise customers who are using Oracle IDM,
@@ -321,10 +325,10 @@ $ sudo journalctl -fu teleport
 
 Usually the error will be reported there. Common reasons for failure are:
 
-* Mismatched tokens, i.e. "auth_token" on the node does not match "tokens/node" value on the auth server.
-* Network issues: port `3025` is closed via iptables.
-* Network issues: ports `3025` or `3022` are occupied by another process.
-* Disk issues: Teleport fails to create `/var/lib/teleport` because the volume is read-only or not accessible.
+- Mismatched tokens, i.e. "auth_token" on the node does not match "tokens/node" value on the auth server.
+- Network issues: port `3025` is closed via iptables.
+- Network issues: ports `3025` or `3022` are occupied by another process.
+- Disk issues: Teleport fails to create `/var/lib/teleport` because the volume is read-only or not accessible.
 
 ## Getting Help
 

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -22,11 +22,11 @@ The `teleport` daemon runs all three of these services by default. This Quick St
 be using this default behavior to create a cluster and interact with it
 using Teleport's client-side tools:
 
-| Tool    | Description
-|---------|-------------
-| tctl    | Cluster administration tool used to invite nodes to a cluster and manage user accounts.
-| tsh     | Similar in principle to OpenSSH's `ssh`. Used to login into remote SSH nodes, list and search for nodes in a cluster, securely upload/download files, etc.
-| browser | You can use your web browser to login into any Teleport node by opening `https://<proxy-host>:3080`.
+| Tool | Description |
+| - | - |
+| tctl | Cluster administration tool used to invite nodes to a cluster and manage user accounts. |
+| tsh | Similar in principle to OpenSSH's `ssh`. Used to login into remote SSH nodes, list and search for nodes in a cluster, securely upload/download files, etc. |
+| browser | You can use your web browser to login into any Teleport node by opening `https://<proxy-host>:3080`. |
 
 ## Installing and Starting
 
@@ -113,10 +113,13 @@ $ tsh --proxy=localhost --insecure login
 Notice that `tsh` client always needs `--proxy` flag because all client connections
 in Teleport must to go through a proxy, sometimes called a "bastion".
 
-<Admonition type="warning" title="Warning">
-For the purposes of this quickstart we are using the `--insecure` flag which allows
-us to skip configuring the HTTP/TLS certificate for Teleport proxy.
-Never use `--insecure` in production. You must configure the HTTP/TLS proxy certificate.
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  For the purposes of this quickstart we are using the `--insecure` flag which allows
+  us to skip configuring the HTTP/TLS certificate for Teleport proxy.
+  Never use `--insecure` in production. You must configure the HTTP/TLS proxy certificate.
 </Admonition>
 
 If successful, `tsh login` command will receive a user certificate for a given proxy
@@ -128,8 +131,11 @@ With a certificate in place, a user can SSH into any host behind the proxy:
 $ tsh ssh localhost
 ```
 
-<Admonition type="tip" title="Tip">
-To avoid typing "tsh ssh" a user may rename `tsh` binary to `ssh` and use the familiar syntax as in `ssh localhost`.
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  To avoid typing "tsh ssh" a user may rename `tsh` binary to `ssh` and use the familiar syntax as in `ssh localhost`.
 </Admonition>
 
 ## Adding Nodes to Cluster
@@ -159,8 +165,11 @@ localhost     xxxxx-xxxx-xxxx-xxxxxxx     10.0.10.1:3022
 new-node      xxxxx-xxxx-xxxx-xxxxxxx     10.0.10.2:3022
 ```
 
-<Admonition type="tip" title="NOTE">
-Teleport also supports static pre-defined invitation tokens which can be set in the [configuration file](admin-guide.mdx#adding-nodes-to-the-cluster)
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  Teleport also supports static pre-defined invitation tokens which can be set in the [configuration file](admin-guide.mdx#adding-nodes-to-the-cluster)
 </Admonition>
 
 ## Using Node Labels
@@ -177,10 +186,10 @@ $ sudo teleport start --roles=node --auth-server=10.0.10.1 --nodename=db --label
 
 Notice a few things here:
 
-* We did not use `--token` flag this time, because this node is already a member of the cluster.
-* We explicitly named this node as "db" because this machine is running a database. This name only exists within Teleport, the actual hostname has not changed.
-* We assigned a static label "location" to this host and set it to "virginia".
-* We also assigned a dynamic label "arch" which will evaluate `/bin/uname -m` command once an hour and assign the output to this label value.
+- We did not use `--token` flag this time, because this node is already a member of the cluster.
+- We explicitly named this node as "db" because this machine is running a database. This name only exists within Teleport, the actual hostname has not changed.
+- We assigned a static label "location" to this host and set it to "virginia".
+- We also assigned a dynamic label "arch" which will evaluate `/bin/uname -m` command once an hour and assign the output to this label value.
 
 Let's take a look at our cluster now:
 
@@ -238,8 +247,11 @@ Also, people can join your session via terminal assuming they have Teleport inst
 $ tsh --proxy=teleport.example.com join 7645d523-60cb-436d-b732-99c5df14b7c4
 ```
 
-<Admonition type="tip" title="NOTE">
-For this to work, both of you must have proper user mappings allowing you access `db` under the same OS user.
+<Admonition
+  type="tip"
+  title="NOTE"
+>
+  For this to work, both of you must have proper user mappings allowing you access `db` under the same OS user.
 </Admonition>
 
 ## Running in Production
@@ -252,4 +264,3 @@ We hope this quickstart guide has helped you to quickly set up and play with Tel
 - Use a configuration file instead of command line flags because it gives you
   more flexibility.
 - Review the [Architecture Overview](architecture.mdx), [Admin Manual](admin-guide.mdx) and [User Manual](user-manual.mdx) for a better understanding of Teleport.
-

--- a/docs/pages/ssh-adfs.mdx
+++ b/docs/pages/ssh-adfs.mdx
@@ -8,14 +8,17 @@ SSH credentials to specific groups of users. When used in combination with role
 based access control (RBAC) it allows SSH administrators to define policies
 like:
 
-* Only members of "DBA" group can SSH into machines running PostgreSQL.
-* Developers must never SSH into production servers.
-* ... and many others.
+- Only members of "DBA" group can SSH into machines running PostgreSQL.
+- Developers must never SSH into production servers.
+- ... and many others.
 
-<Admonition type="warning" title="Version Warning">
-This guide requires a commercial edition of Teleport. The open source
-edition of Teleport only supports [Github](admin-guide/#github-oauth-20) as
-an SSO provider.
+<Admonition
+  type="warning"
+  title="Version Warning"
+>
+  This guide requires a commercial edition of Teleport. The open source
+  edition of Teleport only supports [Github](admin-guide.mdx#github-oauth-20) as
+  an SSO provider.
 </Admonition>
 
 ## Enable ADFS Authentication
@@ -58,23 +61,23 @@ using `https://localhost:3080/v1/webapi/saml/acs` as the Assertion Consumer
 Service (ACS) URL, but for production you'll want to change this to a domain
 that can be accessed by other users as well.
 
-* Create a claims aware trust.
-* Enter data about the relying party manually.
-* Set the display name to something along the lines of "Teleport".
-* Skip the token encryption certificate.
-* Select _"Enable support for SAML 2.0 Web SSO protocol"_ and set the URL to `https://localhost:3080/v1/webapi/saml/acs`.
-* Set the relying party trust identifier to `https://localhost:3080/v1/webapi/saml/acs` as well.
-* For access control policy select _"Permit everyone"_.
+- Create a claims aware trust.
+- Enter data about the relying party manually.
+- Set the display name to something along the lines of "Teleport".
+- Skip the token encryption certificate.
+- Select *"Enable support for SAML 2.0 Web SSO protocol"* and set the URL to `https://localhost:3080/v1/webapi/saml/acs`.
+- Set the relying party trust identifier to `https://localhost:3080/v1/webapi/saml/acs` as well.
+- For access control policy select *"Permit everyone"*.
 
 Once the Relying Party Trust has been created, update the Claim Issuance Policy
 for it. Like before make sure you send at least `Name ID` and `Group` claims to the
 relying party (Teleport). If you are using dynamic roles, it may be useful to
-map the LDAP Attribute `SAM-Account-Name` to _"Windows account name"_ and create
-another mapping of `E-Mail-Addresses` to _"UPN"_.
+map the LDAP Attribute `SAM-Account-Name` to *"Windows account name"* and create
+another mapping of `E-Mail-Addresses` to *"UPN"*.
 
 Lastly, ensure the user you create in Active Directory has an email address
 associated with it. To check this open Server Manager then
-_"Tools -> Active Directory Users and Computers"_ and select the user and right
+*"Tools -> Active Directory Users and Computers"* and select the user and right
 click and open properties. Make sure the email address field is filled out.
 
 ## Create Teleport Roles
@@ -120,15 +123,15 @@ spec:
 
 This role declares:
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
-* Developers can log in as `ubuntu` user
-* Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
-  _"http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"_ ADFS claim and use that field as an allowed login for each user.
+- Devs are only allowed to login to nodes labelled with `access: relaxed` label.
+- Developers can log in as `ubuntu` user
+- Notice `{{external."http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"}}` login. It configures Teleport to look at
+  *"[http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"](http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname")* ADFS claim and use that field as an allowed login for each user.
   Also note the double quotes (`"`) around the claim name - these are important.
-* Developers also do not have any "allow rules" i.e. they will not be able to
+- Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 
-Next, create a SAML connector [resource](admin-guide#resources):
+Next, create a SAML connector [resource](admin-guide.mdx#resources):
 
 ```yaml
 kind: saml
@@ -152,13 +155,13 @@ spec:
 ```
 
 The `acs` field should match the value you set in ADFS earlier and you can
-obtain the `entity_descriptor_url` from ADFS under _"ADFS -> Service -> Endpoints -> Metadata"_.
+obtain the `entity_descriptor_url` from ADFS under *"ADFS -> Service -> Endpoints -> Metadata"*.
 
 The `attributes_to_roles` is used to map attributes to the Teleport roles you
-just creataed. In our situation, we are mapping the _"Group"_ attribute whose full
-name is `http://schemas.xmlsoap.org/claims/Group` with a value of _"teleadmins"_
-to the _"admin"_ role. Groups with the value _"teleusers"_ is being mapped to the
-_"users"_ role.
+just creataed. In our situation, we are mapping the *"Group"* attribute whose full
+name is `http://schemas.xmlsoap.org/claims/Group` with a value of *"teleadmins"*
+to the *"admin"* role. Groups with the value *"teleusers"* is being mapped to the
+*"users"* role.
 
 ## Export the Signing Key
 
@@ -184,15 +187,21 @@ $ tsh --proxy=proxy.example.com login
 This command will print the SSO login URL (and will try to open it
 automatically in a browser).
 
-<Admonition type="tip" title="Tip">
-Teleport can use multiple SAML connectors. In this case a connector name
-can be passed via `tsh login --auth=connector_name`
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  Teleport can use multiple SAML connectors. In this case a connector name
+  can be passed via `tsh login --auth=connector_name`
 </Admonition>
 
-<Admonition type="note" title="IMPORTANT">
-Teleport only supports sending party initiated flows for SAML 2.0. This
-means you can not initiate login from your identity provider, you have to
-initiate login from either the Teleport Web UI or CLI.
+<Admonition
+  type="note"
+  title="IMPORTANT"
+>
+  Teleport only supports sending party initiated flows for SAML 2.0. This
+  means you can not initiate login from your identity provider, you have to
+  initiate login from either the Teleport Web UI or CLI.
 </Admonition>
 
 ## Troubleshooting
@@ -210,4 +219,3 @@ $ sudo journalctl -fu teleport
 
 If you wish to increase the verbocity of Teleport's syslog, you can pass
 `--debug` flag to `teleport start` command.
-

--- a/docs/pages/ssh-okta.mdx
+++ b/docs/pages/ssh-okta.mdx
@@ -7,13 +7,16 @@ SSH credentials to specific groups of users. When used in combination with role
 based access control (RBAC), it allows SSH administrators to define policies
 like:
 
-* Only members of "DBA" group can SSH into machines running PostgreSQL.
-* Developers must never SSH into production servers.
+- Only members of "DBA" group can SSH into machines running PostgreSQL.
+- Developers must never SSH into production servers.
 
-<Admonition type="warning" title="Version Warning">
-This guide requires a commercial edition of Teleport. The open source
-edition of Teleport only supports [Github](admin-guide/#github-oauth-20) as
-an SSO provider.
+<Admonition
+  type="warning"
+  title="Version Warning"
+>
+  This guide requires a commercial edition of Teleport. The open source
+  edition of Teleport only supports [Github](admin-guide.mdx#github-oauth-20) as
+  an SSO provider.
 </Admonition>
 
 ## Enable SAML Authentication
@@ -65,14 +68,17 @@ GROUP ATTRIBUTE STATEMENTS
 
 - Name: `groups` | Name format: `Unspecified`
 
--  Filter: `Matches regex` |  `.*`
+- Filter: `Matches regex` \|  `.*`
 
 ![Configure APP](../img/okta-saml-3.png)
 
-<Admonition type="tip" title="Important">
-Notice that we have set "NameID" to the email format and mappped the groups with
-a wildcard regex in the Group Attribute statements. We have also set the "Audience"
-and SSO URL to the same value.
+<Admonition
+  type="tip"
+  title="Important"
+>
+  Notice that we have set "NameID" to the email format and mappped the groups with
+  a wildcard regex in the Group Attribute statements. We have also set the "Audience"
+  and SSO URL to the same value.
 </Admonition>
 
 ### Assign Groups
@@ -86,10 +92,9 @@ configure a Teleport connector:
 
 ![Download metadata](../img/okta-saml-4.png)
 
-
 ## Create a SAML Connector
 
-Now, create a SAML connector [resource](admin-guide#resources):
+Now, create a SAML connector [resource](admin-guide.mdx#resources):
 
 ```yaml
 # okta-connector.yaml
@@ -154,11 +159,11 @@ spec:
       access: relaxed
 ```
 
-* Devs are only allowed to login to nodes labelled with `access: relaxed` label.
-* Developers can log in as `ubuntu` user
-* Notice `{{external.username}}` login. It configures Teleport to look at
-  _"username"_ Okta claim and use that field as an allowed login for each user.
-* Developers also do not have any "allow rules" i.e. they will not be able to
+- Devs are only allowed to login to nodes labelled with `access: relaxed` label.
+- Developers can log in as `ubuntu` user
+- Notice `{{external.username}}` login. It configures Teleport to look at
+  *"username"* Okta claim and use that field as an allowed login for each user.
+- Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.
 
 Now, create both roles on the auth server:
@@ -180,15 +185,21 @@ $ tsh --proxy=proxy.example.com login
 This command will print the SSO login URL (and will try to open it
 automatically in a browser).
 
-<Admonition type="tip" title="Tip">
-Teleport can use multiple SAML connectors. In this case a connector name
-can be passed via `tsh login --auth=connector_name`
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  Teleport can use multiple SAML connectors. In this case a connector name
+  can be passed via `tsh login --auth=connector_name`
 </Admonition>
 
-<Admonition type="note" title="IMPORTANT">
-Teleport only supports sending party initiated flows for SAML 2.0. This
-means you can not initiate login from your identity provider, you have to
-initiate login from either the Teleport Web UI or CLI.
+<Admonition
+  type="note"
+  title="IMPORTANT"
+>
+  Teleport only supports sending party initiated flows for SAML 2.0. This
+  means you can not initiate login from your identity provider, you have to
+  initiate login from either the Teleport Web UI or CLI.
 </Admonition>
 
 ## Troubleshooting
@@ -206,4 +217,3 @@ $ sudo journalctl -fu teleport
 
 If you wish to increase the verbocity of Teleport's syslog, you can pass
 `--debug` flag to `teleport start` command.
-

--- a/docs/pages/ssh-one-login.mdx
+++ b/docs/pages/ssh-one-login.mdx
@@ -7,14 +7,17 @@ SSH credentials to specific groups of users. When used in combination with role
 based access control (RBAC) it allows SSH administrators to define policies
 like:
 
-* Only members of "DBA" group can SSH into machines running PostgreSQL.
-* Developers must never SSH into production servers.
-* ... and many others.
+- Only members of "DBA" group can SSH into machines running PostgreSQL.
+- Developers must never SSH into production servers.
+- ... and many others.
 
-<Admonition type="warning" title="Version Warning">
-This guide requires a commercial edition of Teleport. The open source
-edition of Teleport only supports [Github](admin-guide/#github-oauth-20) as
-an SSO provider.
+<Admonition
+  type="warning"
+  title="Version Warning"
+>
+  This guide requires a commercial edition of Teleport. The open source
+  edition of Teleport only supports [Github](admin-guide.mdx#github-oauth-20) as
+  an SSO provider.
 </Admonition>
 
 ## Enable SAML Authentication
@@ -36,9 +39,12 @@ section:
 
 ![Create APP](../img/onelogin-saml-1.png)
 
-<Admonition type="tip" title="Important">
-Make sure to pick `SAML Test Connector (SP)` and not `SAML Test Connector (IdP)`,
-because teleport only supports `SP` - service provider initiated SAML flows.
+<Admonition
+  type="tip"
+  title="Important"
+>
+  Make sure to pick `SAML Test Connector (SP)` and not `SAML Test Connector (IdP)`,
+  because teleport only supports `SP` - service provider initiated SAML flows.
 </Admonition>
 
 Set `Audience`, `Recipient` and `ACS (Consumer) URL Validator` to the same value:
@@ -54,8 +60,11 @@ exposed as SAML attribute statements:
 ![Configure APP](../img/onelogin-saml-3.png)
 ![Configure APP](../img/onelogin-saml-4.png)
 
-<Admonition type="warning" title="Important">
-Make sure to check `Include in SAML assertion` checkbox.
+<Admonition
+  type="warning"
+  title="Important"
+>
+  Make sure to check `Include in SAML assertion` checkbox.
 </Admonition>
 
 Add users to the application:
@@ -64,7 +73,7 @@ Add users to the application:
 
 ## Create a SAML Connector
 
-Now, create a SAML connector [resource](admin-guide#resources).
+Now, create a SAML connector [resource](admin-guide.mdx#resources).
 Write down this template as `onelogin-connector.yaml`:
 
 ```yaml
@@ -91,15 +100,18 @@ To fill in the fields, open `SSO` tab:
 
 ![Configure APP](../img/onelogin-saml-6.png)
 
-* `acs` - is the name of the teleport web proxy, e.g. `https://teleport.example.com/v1/webapi/saml/acs`
-* `issuer` - use value from `Issuer URL field`, e.g. `https://app.onelogin.com/saml/metadata/123456`
-* `sso` - use the value from the value from field `SAML 2.0 Endpoint (HTTP)` but replace `http-post` with `http-redirect`, e.g. `https://mycompany.onelogin.com/trust/saml2/http-redirect/sso/123456`
+- `acs` - is the name of the teleport web proxy, e.g. `https://teleport.example.com/v1/webapi/saml/acs`
+- `issuer` - use value from `Issuer URL field`, e.g. `https://app.onelogin.com/saml/metadata/123456`
+- `sso` - use the value from the value from field `SAML 2.0 Endpoint (HTTP)` but replace `http-post` with `http-redirect`, e.g. `https://mycompany.onelogin.com/trust/saml2/http-redirect/sso/123456`
 
-<Admonition type="tip" title="Important">
-Make sure to replace `http-post` with `http-redirect`!
+<Admonition
+  type="tip"
+  title="Important"
+>
+  Make sure to replace `http-post` with `http-redirect`!
 </Admonition>
 
-* `cert` - download certificate, by clicking "view details link" and add to `cert` section
+- `cert` - download certificate, by clicking "view details link" and add to `cert` section
 
 ![Configure APP](../img/onelogin-saml-7.png)
 
@@ -169,15 +181,21 @@ $ tsh --proxy=proxy.example.com login
 This command will print the SSO login URL (and will try to open it
 automatically in a browser).
 
-<Admonition type="tip" title="Tip">
-Teleport can use multiple SAML connectors. In this case a connector name
-can be passed via `tsh login --auth=connector_name`
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  Teleport can use multiple SAML connectors. In this case a connector name
+  can be passed via `tsh login --auth=connector_name`
 </Admonition>
 
-<Admonition type="note" title="IMPORTANT">
-Teleport only supports sending party initiated flows for SAML 2.0. This
-means you can not initiate login from your identity provider, you have to
-initiate login from either the Teleport Web UI or CLI.
+<Admonition
+  type="note"
+  title="IMPORTANT"
+>
+  Teleport only supports sending party initiated flows for SAML 2.0. This
+  means you can not initiate login from your identity provider, you have to
+  initiate login from either the Teleport Web UI or CLI.
 </Admonition>
 
 ## Troubleshooting
@@ -195,4 +213,3 @@ $ sudo journalctl -fu teleport
 
 If you wish to increase the verbocity of Teleport's syslog, you can pass
 `--debug` flag to `teleport start` command.
-

--- a/docs/pages/ssh-rbac.mdx
+++ b/docs/pages/ssh-rbac.mdx
@@ -5,9 +5,9 @@ title: Role Based Access Control for SSH
 ## Introduction
 
 Role Based Access Control (RBAC) gives Teleport administrators more
-granular access controls. An example of an RBAC policy could be:  _"admins can do
+granular access controls. An example of an RBAC policy could be:  *"admins can do
 anything, developers must never touch production servers and interns can only
-SSH into staging servers as guests"_
+SSH into staging servers as guests"*
 
 RBAC is almost always used in conjunction with
 Single Sign-On ([SSO](https://en.wikipedia.org/wiki/Single_sign-on)) but it also works with
@@ -21,9 +21,9 @@ would look like this:
 
 1. Configure Teleport to use existing user identities stored in Okta.
 2. Okta would have users placed in certain groups, perhaps "developers", "admins", "contractors", etc.
-3. Teleport would have certain _Teleport roles_ defined. For example: "developers" and "admins".
+3. Teleport would have certain *Teleport roles* defined. For example: "developers" and "admins".
 4. Mappings would connect the Okta groups (SAML assertions) to the Teleport roles.
-   Every Teleport user will be assigned a _Teleport role_ based on their Okta
+   Every Teleport user will be assigned a *Teleport role* based on their Okta
    group membership.
 
 ## Roles
@@ -36,18 +36,18 @@ user permissions.
 
 Some of the permissions a role could define include:
 
-* Which SSH nodes a user can or cannot access. Teleport uses [node
-  labels](admin-guide/#labeling-nodes) to do this, i.e. some nodes can be
+- Which SSH nodes a user can or cannot access. Teleport uses [node
+  labels](admin-guide.mdx#labeling-nodes) to do this, i.e. some nodes can be
   labeled "production" while others can be labeled "staging".
-* Ability to replay recorded sessions.
-* Ability to update cluster configuration.
-* Which UNIX logins a user is allowed to use when logging into servers.
+- Ability to replay recorded sessions.
+- Ability to update cluster configuration.
+- Which UNIX logins a user is allowed to use when logging into servers.
 
 A Teleport `role` works by having two lists of rules: `allow` rules and `deny` rules.
 When declaring access rules, keep in mind the following:
 
-* Everything is denied by default.
-* Deny rules get evaluated first and take priority.
+- Everything is denied by default.
+- Deny rules get evaluated first and take priority.
 
 A rule consists of two parts: the resources and verbs. Here's an example of an
 `allow` rule describing a `list` verb applied to the SSH `sessions` resource.  It means "allow
@@ -65,7 +65,7 @@ all of the available resources and verbs under the `allow` section in the `admin
 below.
 
 To manage cluster roles, a Teleport administrator can use the Web UI or the command
-line using [tctl resource commands](admin-guide#resources). To see the list of
+line using [tctl resource commands](admin-guide.mdx#resources). To see the list of
 roles in a Teleport cluster, an administrator can execute:
 
 ```bsh
@@ -140,16 +140,16 @@ spec:
 
 The following variables can be used with `logins` field:
 
-Variable                | Description
-------------------------|--------------------------
-`{{internal.logins}}` | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database.
-`{{external.xyz}}`    | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim.
+| Variable | Description |
+| - | - |
+| `{{internal.logins}}` | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database. |
+| `{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim. |
 
 Both variables above are there to deliver the same benefit: they allow Teleport
 administrators to define allowed OS logins via the user database, be it the
 local DB, or an identity manager behind a SAML or OIDC endpoint.
 
-#### An example of a SAML assertion:
+### An example of a SAML assertion
 
 Assuming you have the following SAML assertion attribute in your response:
 
@@ -160,30 +160,29 @@ Assuming you have the following SAML assertion attribute in your response:
 ```
 
 ... you can use the following format in your role:
+
 ```
 logins:
    - '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}'
 ```
-
 
 ### Role Options
 
 As shown above, a role can define certain restrictions on SSH sessions initiated by users.
 The table below documents the behavior of each option if multiple roles are assigned to a user.
 
-Option                    | Description                          | Multi-role behavior
---------------------------|--------------------------------------|---------------------
-`max_session_ttl`         | Max. time to live (TTL) of a user's SSH certificates | The shortest TTL wins
-`forward_agent`           | Allow SSH agent forwarding         | Logical "OR" i.e. if any role allows agent forwarding, it's allowed
-`port_forwarding`         | Allow TCP port forwarding          | Logical "OR" i.e. if any role allows port forwarding, it's allowed
-`client_idle_timeout`     | Forcefully terminate active SSH sessions after an idle interval | The shortest timeout value wins, i.e. the most restrictive value is selected
-`disconnect_expired_cert` | Forcefully terminate active SSH sessions when a client certificate expires | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination
-
+| Option | Description | Multi-role behavior |
+| - | - | - |
+| `max_session_ttl` | Max. time to live (TTL) of a user's SSH certificates | The shortest TTL wins |
+| `forward_agent` | Allow SSH agent forwarding | Logical "OR" i.e. if any role allows agent forwarding, it's allowed |
+| `port_forwarding` | Allow TCP port forwarding | Logical "OR" i.e. if any role allows port forwarding, it's allowed |
+| `client_idle_timeout` | Forcefully terminate active SSH sessions after an idle interval | The shortest timeout value wins, i.e. the most restrictive value is selected |
+| `disconnect_expired_cert` | Forcefully terminate active SSH sessions when a client certificate expires | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 
 ## RBAC for Hosts
 
 A Teleport role can also define which hosts (nodes) a user can have access to.
-This works by [labeling nodes](admin-guide/#labeling-nodes) and listing
+This works by [labeling nodes](admin-guide.mdx#labeling-nodes) and listing
 allow/deny labels in a role definition.
 
 Consider the following use case:
@@ -217,11 +216,14 @@ spec:
       'workload': ['database', 'backup']
 ```
 
-<Admonition type="tip" title="Dynamic RBAC">
-Node labels can be dynamic, i.e. determined at runtime by an output
-of an executable. In this case, you can implement "permissions follow workload"
-policies (eg., any server where PostgreSQL is running becomes _automatically_
-accessible only by the members of the "DBA" group and nobody else).
+<Admonition
+  type="tip"
+  title="Dynamic RBAC"
+>
+  Node labels can be dynamic, i.e. determined at runtime by an output
+  of an executable. In this case, you can implement "permissions follow workload"
+  policies (eg., any server where PostgreSQL is running becomes *automatically*
+  accessible only by the members of the "DBA" group and nobody else).
 </Admonition>
 
 ## RBAC for Sessions
@@ -235,13 +237,11 @@ rules:
     verbs: [list, read]
 ```
 
-* "list" determines if a user is allowed to see the list of past sessions.
-* "read" determines if a user is allowed to replay a session.
+- "list" determines if a user is allowed to see the list of past sessions.
+- "read" determines if a user is allowed to replay a session.
 
 It is possible to restrict "list" but to allow "read" (in this case a user will
 be able to replay a session using `tsh play` if they know the session ID)
-
-
 
 ## FAQ
 

--- a/docs/pages/ssh-sso.mdx
+++ b/docs/pages/ssh-sso.mdx
@@ -16,7 +16,6 @@ Other identity management systems are supported as long as they provide an
 SSO mechanism based on either [SAML](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
 or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 
-
 ## How does SSO work with SSH?
 
 From the user's perspective they need to execute the following command login:
@@ -39,25 +38,25 @@ succeeds, Teleport will retrieve an SSH certificate and will store it in
 ## Configuring SSO
 
 Teleport works with SSO providers by relying on a concept called
-_"authentication connector"_. An auth connector is a plugin which controls how
+*"authentication connector"*. An auth connector is a plugin which controls how
 a user logs in and which group he or she belongs to.
 
 The following connectors are supported:
 
-* `local` connector type uses the built-in user database. This database can be
+- `local` connector type uses the built-in user database. This database can be
   manipulated by the `tctl users` command.
-* `saml` connector type uses the [SAML protocol](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
+- `saml` connector type uses the [SAML protocol](https://en.wikipedia.org/wiki/Security_Assertion_Markup_Language)
   to authenticate users and query their group membership.
-* `oidc` connector type uses the [OpenID Connect protocol](https://en.wikipedia.org/wiki/OpenID_Connect)
+- `oidc` connector type uses the [OpenID Connect protocol](https://en.wikipedia.org/wiki/OpenID_Connect)
   to authenticate users and query their group membership.
 
 To configure [SSO](https://en.wikipedia.org/wiki/Single_sign-on), a Teleport administrator must:
 
-* Update `/etc/teleport.yaml` on the auth server to set the default
+- Update `/etc/teleport.yaml` on the auth server to set the default
   authentication connector.
-* Define the connector [resource](admin-guide/#resources) and save it into
+- Define the connector [resource](admin-guide.mdx#resources) and save it into
   a YAML file (like `connector.yaml`)
-* Create the connector using `tctl create connector.yaml`.
+- Create the connector using `tctl create connector.yaml`.
 
 ```yaml
 # snippet from /etc/teleport.yaml on the auth server:
@@ -96,7 +95,7 @@ spec:
     <paste SAML XML contents here>
 ```
 
-* See [examples/resources](https://github.com/gravitational/teleport/tree/master/examples/resources)
+- See [examples/resources](https://github.com/gravitational/teleport/tree/master/examples/resources)
   directory in the Teleport Github repository for examples of possible connectors.
 
 ### User Logins
@@ -104,9 +103,9 @@ spec:
 Often it is required to restrict SSO users to their unique UNIX logins when they
 connect to Teleport nodes. To support this:
 
-* Use the SSO provider to create a field called _"unix_login"_ (you can use another name).
-* Make sure it's exposed as a claim via SAML/OIDC.
-* Update a Teleport SSH role to include `{{external.unix_login}}` variable into the list of allowed logins:
+- Use the SSO provider to create a field called *"unix_login"* (you can use another name).
+- Make sure it's exposed as a claim via SAML/OIDC.
+- Update a Teleport SSH role to include `{{external.unix_login}}` variable into the list of allowed logins:
 
 ```yaml
 kind: role
@@ -133,7 +132,7 @@ $ tctl get connectors
 ```
 
 To delete/update connectors, use the usual `tctl rm` and `tctl create` commands
-as described in the [Resources section](admin-guide/#resources) in the Admin Manual.
+as described in the [Resources section](admin-guide.mdx#resources) in the Admin Manual.
 
 If multiple authentication connectors exist, the clients must supply a
 connector name to `tsh login` via `--auth` argument:
@@ -146,31 +145,28 @@ $ tsh --proxy=proxy.example.com login --auth=okta
 $ tsh --proxy=proxy.example.com login --auth=local --user=admin
 ```
 
-
 Refer to the following guides to configure authentication connectors of both
 SAML and OIDC types:
 
-* [SSH Authentication with Okta](ssh-okta)
-* [SSH Authentication with OneLogin](ssh-one-login)
-* [SSH Authentication with ADFS](ssh-adfs)
-* [SSH Authentication with OAuth2 / OpenID Connect](oidc)
+- [SSH Authentication with Okta](ssh-okta.mdx)
+- [SSH Authentication with OneLogin](ssh-one-login.mdx)
+- [SSH Authentication with ADFS](ssh-adfs.mdx)
+- [SSH Authentication with OAuth2 / OpenID Connect](oidc.mdx)
 
 ## Troubleshooting
 
 Troubleshooting SSO configuration can be challenging. Usually a Teleport administrator
 must be able to:
 
-* Ensure that HTTP/TLS certificates are configured properly for both Teleport
+- Ensure that HTTP/TLS certificates are configured properly for both Teleport
   proxy and the SSO provider.
-* Be able to see what SAML/OIDC claims and values are getting exported and passed
+- Be able to see what SAML/OIDC claims and values are getting exported and passed
   by the SSO provider to Teleport.
-* Be able to see how Teleport maps the received claims to role mappings as defined
+- Be able to see how Teleport maps the received claims to role mappings as defined
   in the connector.
 
 If something is not working, we recommend to:
 
-* Double-check the host names, tokens and TCP ports in a connector definition.
-* Look into Teleport's audit log for claim mapping problems. It is usually stored on the
+- Double-check the host names, tokens and TCP ports in a connector definition.
+- Look into Teleport's audit log for claim mapping problems. It is usually stored on the
   auth server in the `/var/lib/teleport/log` directory.
-
-

--- a/docs/pages/trustedclusters.mdx
+++ b/docs/pages/trustedclusters.mdx
@@ -8,28 +8,28 @@ in the Admin Guide we recommend you review that for an overview before continuin
 The Trusted Clusters chapter in the Admin Guide
 offers an example of a simple configuration which:
 
-* Uses a static cluster join token defined in a configuration file.
-* Does not cover inter-cluster role based access control (RBAC).
+- Uses a static cluster join token defined in a configuration file.
+- Does not cover inter-cluster role based access control (RBAC).
 
 This guide's focus is on more in-depth coverage of trusted clusters features and will cover the following topics:
 
-* How to add and remove trusted clusters using CLI commands.
-* Enable/disable trust between clusters.
-* Establish permissions mapping between clusters using Teleport roles.
+- How to add and remove trusted clusters using CLI commands.
+- Enable/disable trust between clusters.
+- Establish permissions mapping between clusters using Teleport roles.
 
 ## Introduction
 
-As explained in the [architecture document](architecture/#core-concepts),
+As explained in the [architecture document](architecture.mdx#core-concepts),
 Teleport can partition compute infrastructure into multiple clusters.
-A cluster is a group of SSH nodes connected to the cluster's _auth server_
+A cluster is a group of SSH nodes connected to the cluster's *auth server*
 acting as a certificate authority (CA) for all users and nodes.
 
 To retrieve an SSH certificate, users must authenticate with a cluster through a
-_proxy server_. So, if users want to connect to nodes belonging to different
+*proxy server*. So, if users want to connect to nodes belonging to different
 clusters, they would normally have to use different `--proxy` flags for each
 cluster. This is not always convenient.
 
-The concept of _trusted clusters_ allows Teleport administrators to connect
+The concept of *trusted clusters* allows Teleport administrators to connect
 multiple clusters together and establish trust between them. Trusted clusters
 allow users of one cluster to seamlessly SSH into the nodes of another cluster
 without having to "hop" between proxy servers. Moreover, users don't even need
@@ -52,12 +52,12 @@ $ tsh clusters
 ```
 
 Trusted clusters also have their own restrictions on user access, i.e.
-_permissions mapping_ takes place.
+*permissions mapping* takes place.
 
 ## Cluster Setup
 
 When you first setup a cluster it's important to correctly set the cluster name.
-The cluster name is set via the [Configuration File](admin-guide/#configuration-file) using
+The cluster name is set via the [Configuration File](admin-guide.mdx#configuration-file) using
 the `cluster_name` option.  We recommend picking a short alias for your cluster as it'll
 be used with the `tsh` command to login to a cluster.
 
@@ -80,9 +80,12 @@ auth_service:
     cluster_name: "production-aws"
 ```
 
-<Admonition type="warning" title="Warning">
-If you change cluster_name, it will invalidate all generated
-certificates and keys (may need to wipe out /var/lib/teleport directory)
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  If you change cluster_name, it will invalidate all generated
+  certificates and keys (may need to wipe out /var/lib/teleport directory)
 </Admonition>
 
 Once set you'll be able to see the cluster name in the Teleport UI.
@@ -96,8 +99,8 @@ Lets start with the diagram of how connection between two clusters is establishe
 ![Tunnels](../img/tunnel.svg)
 
 The first step in establishing a secure tunnel between two clusters is for the
-_trusting_ cluster "east" to connect to the _trusted_ cluster "main". When this
-happens for _the first time_, clusters know nothing about each other, thus a
+*trusting* cluster "east" to connect to the *trusted* cluster "main". When this
+happens for *the first time*, clusters know nothing about each other, thus a
 shared secret needs to exist in order for "main" to accept the connection from
 "east".
 
@@ -105,10 +108,13 @@ This shared secret is called a "join token". There are two ways to create join
 tokens: to statically define them in a configuration file, or to create them on
 the fly using `tctl` tool.
 
-<Admonition type="tip" title="Important">
-It is important to realize that join tokens are only used to establish the
-connection for the first time. The clusters will exchange certificates and
-won't be using the token to re-establish the connection in the future.
+<Admonition
+  type="tip"
+  title="Important"
+>
+  It is important to realize that join tokens are only used to establish the
+  connection for the first time. The clusters will exchange certificates and
+  won't be using the token to re-establish the connection in the future.
 </Admonition>
 
 ### Static Tokens
@@ -132,7 +138,7 @@ Creating a token dynamically with a CLI tool offers the advantage of applying a
 time to live (TTL) interval on it, i.e. it will be impossible to re-use such
 token after a specified period of time.
 
-To create a token using the CLI tool, execute this command on the _auth server_
+To create a token using the CLI tool, execute this command on the *auth server*
 of cluster "main":
 
 ```bsh
@@ -161,31 +167,34 @@ more complicated.
 
 ## RBAC
 
-<Admonition type="warning" title="Version Warning">
-The RBAC section is applicable only to Teleport Enterprise. The open source
-version does not suppport SSH roles.
+<Admonition
+  type="warning"
+  title="Version Warning"
+>
+  The RBAC section is applicable only to Teleport Enterprise. The open source
+  version does not suppport SSH roles.
 </Admonition>
 
-When a _trusting_ cluster "east" from the diagram above establishes trust with
-the _trusted_ cluster "main", it needs a way to configure which users from
+When a *trusting* cluster "east" from the diagram above establishes trust with
+the *trusted* cluster "main", it needs a way to configure which users from
 "main" should be allowed in and what permissions should they have. Teleport
-Enterprise uses _role mapping_ to achieve this.
+Enterprise uses *role mapping* to achieve this.
 
 Consider the following:
 
-* Both clusters "main" and "east" have their own locally defined roles.
-* Every user in Teleport Enterprise is assigned a role.
-* When creating a _trusted cluster_ resource, the administrator of "east" must
+- Both clusters "main" and "east" have their own locally defined roles.
+- Every user in Teleport Enterprise is assigned a role.
+- When creating a *trusted cluster* resource, the administrator of "east" must
   define how roles from "main" map to roles on "east".
 
 ### Example
 
 Lets make a few assumptions for this example:
 
-* The cluster "main" has two roles: _user_ for regular users and _admin_ for
+- The cluster "main" has two roles: *user* for regular users and *admin* for
   local administrators.
 
-* We want administrators from "main" (but not regular users!) to have
+- We want administrators from "main" (but not regular users!) to have
   restricted access to "east". We want to deny them access to machines
   with "environment=production" label.
 
@@ -208,7 +217,7 @@ spec:
 ```
 
 Now, we need to establish trust between roles "main:admin" and "east:local-admin". This is
-done by creating a trusted cluster [resource](admin-guide/#resources) on "east"
+done by creating a trusted cluster [resource](admin-guide.mdx#resources) on "east"
 which looks like this:
 
 ```yaml
@@ -228,7 +237,7 @@ spec:
   web_proxy_addr: main.example.com:3080
 ```
 
-What if we wanted to let _any_ user from "main" to be allowed to connect to
+What if we wanted to let *any* user from "main" to be allowed to connect to
 nodes on "east"? In this case we can use a wildcard `*` in the `role_map` like this:
 
 ```yaml
@@ -285,9 +294,12 @@ db2.east  3879d133-fe81-3212 10.0.5.3:3022  role=db-follower
 $ tsh ssh --cluster=east root@db1.east
 ```
 
-<Admonition type="tip" title="Note">
-Trusted clusters work only one way. So, in the example above users from "east"
-cannot see or connect to the nodes in "main".
+<Admonition
+  type="tip"
+  title="Note"
+>
+  Trusted clusters work only one way. So, in the example above users from "east"
+  cannot see or connect to the nodes in "main".
 </Admonition>
 
 ### Disabling Trust
@@ -300,7 +312,6 @@ and set `enabled` to "false", then update it:
 $ tctl create --force cluster.yaml
 ```
 
-
 ## How does it work?
 
 At a first glance, Trusted Clusters in combination with RBAC may seem
@@ -310,13 +321,13 @@ which is fairly easy to reason about:
 One can think of an SSH certificate as a "permit" issued and time-stamped by a
 certificate authority. A certificate contains four important pieces of data:
 
-* List of allowed UNIX logins a user can use. They are called "principals" in
+- List of allowed UNIX logins a user can use. They are called "principals" in
   the certificate.
-* Signature of the certificate authority who issued it (the _auth_ server)
-* Metadata (certificate extensions): additional data protected by the signature
+- Signature of the certificate authority who issued it (the *auth* server)
+- Metadata (certificate extensions): additional data protected by the signature
   above. Teleport uses the metadata to store the list of user roles and SSH
   options like "permit-agent-forwarding".
-* The expiration date.
+- The expiration date.
 
 Try executing `tsh status` right after `tsh login` to see all these fields in the
 client certificate.
@@ -325,22 +336,22 @@ When a user from "main" tries to connect to a node inside "east" cluster, her
 certificate is presented to the auth server of "east" and it performs the
 following checks:
 
-* Checks that the certificate signature matches one of the trusted clusters.
-* Tries to find a local role which maps to the list of principals found in the certificate.
-* Checks if the local role allows the requested identity (UNIX login) to have access.
-* Checks that the certificate is not expired.
+- Checks that the certificate signature matches one of the trusted clusters.
+- Tries to find a local role which maps to the list of principals found in the certificate.
+- Checks if the local role allows the requested identity (UNIX login) to have access.
+- Checks that the certificate is not expired.
 
 ## Troubleshooting
 
 There are three common types of problems Teleport administrators can run into when configuring
 trust between two clusters:
 
-* **HTTPS configuration**: when the main cluster uses a self-sgined or invalid HTTPS certificate.
+- **HTTPS configuration**: when the main cluster uses a self-sgined or invalid HTTPS certificate.
 
-* **Connectivity problems**: when a trusting cluster "east" does not show up in
+- **Connectivity problems**: when a trusting cluster "east" does not show up in
   `tsh clusters` output on "main".
 
-* **Access problems**: when users from "main" get "access denied" error messages
+- **Access problems**: when users from "main" get "access denied" error messages
   trying to connect to nodes on "east".
 
 ### HTTPS configuration
@@ -381,11 +392,11 @@ how your network security groups are configured on AWS.
 Troubleshooting access denied messages can be challenging. A Teleport administrator
 should check to see the following:
 
-* Which roles a user is assigned on "main" when they retrieve their SSH
+- Which roles a user is assigned on "main" when they retrieve their SSH
   certificate via `tsh login`. You can inspect the retrieved certificate with
   `tsh status` command on the client side.
-* Which roles a user is assigned on "east" when the role mapping takes place.
+- Which roles a user is assigned on "east" when the role mapping takes place.
   The role mapping result is reflected in the Teleport audit log. By default,
-  it is stored in `/var/lib/teleport/log` on a _auth_ server of a cluster.
+  it is stored in `/var/lib/teleport/log` on a *auth* server of a cluster.
   Check the audit log messages on both clusters to get answers for the
   questions above.

--- a/docs/pages/user-manual.mdx
+++ b/docs/pages/user-manual.mdx
@@ -5,12 +5,12 @@ title: Teleport User Manual
 This User Manual covers usage of the Teleport client tool, `tsh`. In this
 document you will learn how to:
 
-* Log into interactive shell on remote cluster nodes.
-* Copy files to and from cluster nodes.
-* Connect to SSH clusters behind firewalls without any open ports using SSH reverse tunnels.
-* Explore a cluster and execute commands on specific nodes in a cluster.
-* Share interactive shell sessions with colleagues or join someone else's session.
-* Replay recorded interactive sessions.
+- Log into interactive shell on remote cluster nodes.
+- Copy files to and from cluster nodes.
+- Connect to SSH clusters behind firewalls without any open ports using SSH reverse tunnels.
+- Explore a cluster and execute commands on specific nodes in a cluster.
+- Share interactive shell sessions with colleagues or join someone else's session.
+- Replay recorded interactive sessions.
 
 In addition to this document, you can always simply type `tsh` into your terminal for
 the CLI reference.
@@ -110,11 +110,10 @@ $ tsh login --proxy=work.example.com:5000
 $ tsh login --proxy=work.example.com:,23
 ```
 
-Port               | Description
--------------------|-------------------------------------
-https_proxy_port   | the HTTPS port the proxy host is listening to (defaults to 3080).
-ssh_proxy_port     | the SSH port the proxy is listening to (defaults to 3023).
-
+| Port | Description |
+| - | - |
+| https_proxy_port | the HTTPS port the proxy host is listening to (defaults to 3080). |
+| ssh_proxy_port | the SSH port the proxy is listening to (defaults to 3023). |
 
 The login command retrieves a user's certificate and stores it
 in `~/.tsh` directory as well as in the [ssh agent](https://en.wikipedia.org/wiki/Ssh-agent),
@@ -125,10 +124,13 @@ Subsequent `tsh ssh` commands will run without asking for credentials
 until the temporary certificate expires. By default, Teleport issues user
 certificates with a TTL (time to live) of 12 hours.
 
-<Admonition type="tip" title="Tip">
-It is recommended to always use `tsh login` before using any other `tsh` commands.
-This allows users to omit `--proxy` flag in subsequent tsh commands. For example
-`tsh ssh user@host` will work.
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  It is recommended to always use `tsh login` before using any other `tsh` commands.
+  This allows users to omit `--proxy` flag in subsequent tsh commands. For example
+  `tsh ssh user@host` will work.
 </Admonition>
 
 A Teleport cluster can be configured for multiple user identity sources. For
@@ -308,7 +310,7 @@ via `--proxy` flag as shown:
 tsh --proxy=proxy.example.com:5000,5001
 ```
 
-This means _use port `5000` for HTTPS and `5001` for SSH_
+This means *use port `5000` for HTTPS and `5001` for SSH*
 
 ### Port Forwarding
 
@@ -447,7 +449,7 @@ $ tsh join 7645d523-60cb-436d-b732-99c5df14b7c4
 ```
 
 <Admonition type="note">
-Joining sessions is not supported in recording proxy mode (where `session_recording` is set to `proxy`).
+  Joining sessions is not supported in recording proxy mode (where `session_recording` is set to `proxy`).
 </Admonition>
 
 ## Connecting to SSH Clusters behind Firewalls
@@ -458,7 +460,7 @@ behind-firewall environments into a Teleport proxy you have access to. This
 feature is called "Trusted Clusters".
 
 This chapter explains how to a user may connect to a trusted cluster.
-Refer to [the admin manual](admin-guide/#trusted-clusters) to learn how a trusted
+Refer to [the admin manual](admin-guide.mdx#trusted-clusters) to learn how a trusted
 cluster can be configured.
 
 Assuming the "work" Teleport proxy server is configured with a few trusted
@@ -506,21 +508,24 @@ You can also join other users in active sessions.
 There are a few differences between Teleport's `tsh` and OpenSSH's `ssh` but most of them can be mitigated.
 
 1. `tsh` always requires the `--proxy` flag because `tsh` needs to know which cluster
-    you are connecting to. But if you execute `tsh --proxy=xxx login`, the
-    current proxy will be saved in your `~/.tsh` profile and won't be needed
-    for other `tsh` commands.
+   you are connecting to. But if you execute `tsh --proxy=xxx login`, the
+   current proxy will be saved in your `~/.tsh` profile and won't be needed
+   for other `tsh` commands.
 
-* `tsh ssh` operates _two_ usernames: one for the cluster and another for the node you
+- `tsh ssh` operates *two* usernames: one for the cluster and another for the node you
   are trying to log into. See [User Identities](#user-identities) section below.
   For convenience, `tsh` assumes `$USER` for both by default. But again, if you
   use `tsh login` before `tsh ssh`, your Teleport username will be stored in
   `~/.tsh`
 
-<Admonition type="tip" title="Tip">
-To avoid typing `tsh ssh user@host` when logging into servers, you can
-create a symlink `ssh -> tsh` and execute the symlink. It will behave exactly
-like a standard `ssh` command, i.e. `ssh login@host`. This is helpful with other
-tools that expect `ssh` to just work.
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  To avoid typing `tsh ssh user@host` when logging into servers, you can
+  create a symlink `ssh -> tsh` and execute the symlink. It will behave exactly
+  like a standard `ssh` command, i.e. `ssh login@host`. This is helpful with other
+  tools that expect `ssh` to just work.
 </Admonition>
 
 Teleport is built using standard SSH constructs: keys, certificates and protocols.
@@ -584,7 +589,6 @@ Now he can SSH into any machine behind `lab.example.com` using the OpenSSH clien
 ```bash
 $ ssh jenkins.lab.example.com
 ```
-
 
 ## Troubleshooting
 


### PR DESCRIPTION
Unfixed stuff:

```
content/3.2/docs/pages/admin-guide.mdx
  1901:4-1901:78  warning  Link to unknown heading in `architecture.mdx`: `kubernetes-integration`                      missing-heading-in-file  remark-validate-links
content/3.2/docs/pages/ssh-adfs.mdx
```

Upd: Added microsoft link to whitelist