### PR TITLE
Moves loadCredsFromProfile to OSS

### DIFF
--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -33,5 +33,5 @@ func main() {
 		&common.AppsCommand{},
 		&common.DBCommand{},
 	}
-	common.Run(commands, nil)
+	common.Run(commands)
 }


### PR DESCRIPTION
With 6.0 OSS migrated to RBAC, OSS tctl can connect
remotely with users credentials.

Also consider:

https://github.com/gravitational/teleport.e/pull/226