### PR TITLE
Return more detailed error message for unimplemented grpc methods

### DIFF
--- a/vendor/github.com/gravitational/trace/trail/trail.go
+++ b/vendor/github.com/gravitational/trace/trail/trail.go
@@ -118,11 +118,14 @@ func FromGRPC(err error, args ...interface{}) error {
 	code := grpc.Code(err)
 	message := grpc.ErrorDesc(err)
 	var e error
+	const notImplementedMessage = "This server does not implement this feature yet. " +
+		"Likely the client version you are using is newer than the server. " +
+		"The server version: %v, the client version: %v. Please upgrade the server or downgrade the client."
 	switch code {
 	case codes.OK:
 		return nil
 	case codes.NotFound:
-		e = &trace.NotFoundError{Message: message}
+		e = &trace.NotFoundError{Message: notImplementedMessage}
 	case codes.AlreadyExists:
 		e = &trace.AlreadyExistsError{Message: message}
 	case codes.PermissionDenied:
@@ -136,7 +139,7 @@ func FromGRPC(err error, args ...interface{}) error {
 	case codes.Unavailable:
 		e = &trace.ConnectionProblemError{Message: message}
 	case codes.Unimplemented:
-		e = &trace.NotImplementedError{Message: message}
+		e = &trace.NotImplementedError{Message: notImplementedMessage}
 	default:
 		e = errors.New(message)
 	}


### PR DESCRIPTION
Return a more detailed error messages for methods which are not implemented on server side. See #5776 for more info.
What is missing to get the client and server version into the message. Pls also check if this message should be returned for `NotFound`.
@klizhentas @r0mant 
