### PR TITLE
Update mysql-aws.mdx

### DIFF
--- a/docs/pages/database-access/guides/mysql-aws.mdx
+++ b/docs/pages/database-access/guides/mysql-aws.mdx
@@ -103,7 +103,7 @@ proxy_service:
   public_addr: teleport.example.com:3080
   # MySQL proxy is listening on a separate port and needs to be enabled
   # on the proxy server.
-  mysql_listen_addr: 0.0.0.0:3036
+  mysql_listen_addr: 0.0.0.0:3306
 ssh_service:
   enabled: "no"
 ```


### PR DESCRIPTION
Update the recommended mysql listen address to use the default mysql port 3306 on the proxy