### PR TITLE
(v6) Fix --insecure-no-tls flag

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -61,10 +62,11 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/testlog"
 
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/check.v1"
-
 	"github.com/gravitational/trace"
+	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/check.v1"
 )
 
 const (
@@ -5147,4 +5149,48 @@ func canTestBPF() error {
 
 func dumpGoroutineProfile() {
 	pprof.Lookup("goroutine").WriteTo(os.Stderr, 2)
+}
+
+// TestWebProxyInsecure makes sure that proxy endpoint works when TLS is disabled.
+func TestWebProxyInsecure(t *testing.T) {
+	startPort := utils.PortStartingNumber + (4 * AllocatePortsNum) + 1
+	ports, err := utils.GetFreeTCPPorts(AllocatePortsNum, startPort)
+	require.NoError(t, err)
+
+	privateKey, publicKey, err := testauthority.New().GenerateKeyPair("")
+	require.NoError(t, err)
+
+	rc := NewInstance(InstanceConfig{
+		ClusterName: "example.com",
+		HostID:      uuid.New(),
+		NodeName:    Host,
+		Ports:       ports.PopIntSlice(6),
+		Priv:        privateKey,
+		Pub:         publicKey,
+		log:         testlog.FailureOnly(t),
+	})
+
+	rcConf := service.MakeDefaultConfig()
+	rcConf.DataDir = t.TempDir()
+	rcConf.Auth.Enabled = true
+	rcConf.Auth.Preference.SetSecondFactor("off")
+	rcConf.Proxy.Enabled = true
+	rcConf.Proxy.DisableWebInterface = true
+	// DisableTLS flag should turn off TLS termination and multiplexing.
+	rcConf.Proxy.DisableTLS = true
+
+	err = rc.CreateEx(nil, rcConf)
+	require.NoError(t, err)
+
+	err = rc.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		rc.StopAll()
+	})
+
+	// Web proxy endpoint should just respond with 200 when called over http://,
+	// content doesn't matter.
+	resp, err := http.Get(fmt.Sprintf("http://%v", net.JoinHostPort(Loopback, rc.GetPortWeb())))
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2237,7 +2237,7 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 	}
 
 	if !cfg.Proxy.MySQLAddr.IsEmpty() {
-		process.log.Debug("Setup Proxy: MySQL proxy address: %v.", cfg.Proxy.MySQLAddr.Addr)
+		process.log.Debugf("Setup Proxy: MySQL proxy address: %v.", cfg.Proxy.MySQLAddr.Addr)
 		listener, err := process.importOrCreateListener(listenerProxyMySQL, cfg.Proxy.MySQLAddr.Addr)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -2318,7 +2318,7 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 			// Unless database proxy is explicitly disabled (which is currently
 			// only done by tests and not exposed via file config), the web
 			// listener is multiplexing both web and db client connections.
-			if !cfg.Proxy.DisableDatabaseProxy {
+			if !cfg.Proxy.DisableDatabaseProxy && !cfg.Proxy.DisableTLS {
 				process.log.Debug("Setup Proxy: Multiplexing web and database proxy on the same port.")
 				listeners.mux, err = multiplexer.New(multiplexer.Config{
 					EnableProxyProtocol: cfg.Proxy.EnableProxyProtocol,
@@ -2337,6 +2337,7 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 				listeners.db = listeners.mux.DB()
 				go listeners.mux.Serve()
 			} else {
+				process.log.Debug("Setup Proxy: TLS is disabled, multiplexing is off.")
 				listeners.web = listener
 			}
 		}


### PR DESCRIPTION
Discovered that I broke `--insecure-no-tls` flag when updating proxy listeners to support db protocols in our multiplexer.

This PR disables multiplexing if TLS is disabled, like it was before.