### PR TITLE
Update VERSION on master to v7.0.0-dev

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -439,7 +439,7 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: push-build-linux-i386
+name: push-build-linux-386
 
 environment:
   RUNTIME: go1.15.5
@@ -2348,7 +2348,7 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: build-linux-i386
+name: build-linux-386
 
 environment:
   RUNTIME: go1.15.5
@@ -2392,7 +2392,7 @@ steps:
       # set version
       - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
-  - name: Build i386 release artifacts
+  - name: Build 386 release artifacts
     image: docker
     environment:
       UID: 1000
@@ -2448,7 +2448,7 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: build-linux-i386-rpm
+name: build-linux-386-rpm
 
 trigger:
   event:
@@ -2461,7 +2461,7 @@ trigger:
       - gravitational/*
 
 depends_on:
-  - build-linux-i386
+  - build-linux-386
 
 workspace:
   path: /go
@@ -2508,7 +2508,7 @@ steps:
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
 
-  - name: Build i386 RPM artifacts
+  - name: Build 386 RPM artifacts
     image: docker
     environment:
       ARCH: "386"
@@ -2533,7 +2533,7 @@ steps:
       - make rpm
       - rm -rf $GNUPG_DIR
 
-  - name: Copy i386 RPM artifacts
+  - name: Copy 386 RPM artifacts
     image: docker
     commands:
       - cd /go/src/github.com/gravitational/teleport
@@ -2574,7 +2574,7 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: build-linux-i386-deb
+name: build-linux-386-deb
 
 trigger:
   event:
@@ -2587,7 +2587,7 @@ trigger:
       - gravitational/*
 
 depends_on:
-  - build-linux-i386
+  - build-linux-386
 
 workspace:
   path: /go
@@ -2634,7 +2634,7 @@ steps:
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
 
-  - name: Build i386 DEB artifacts
+  - name: Build 386 DEB artifacts
     image: docker
     environment:
       ARCH: "386"
@@ -2650,7 +2650,7 @@ steps:
       - export VERSION=$(cat /go/.version.txt)
       - make deb
 
-  - name: Copy i386 DEB artifacts
+  - name: Copy 386 DEB artifacts
     image: docker
     commands:
       - cd /go/src/github.com/gravitational/teleport
@@ -4248,6 +4248,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 5c4d5d5c3855e7dd20f071226c92af4fc26a5cc5dcd21d13cc26e0a4159feb1d
+hmac: 6baf5750d2c9efc862345883c05f35f823a7639498f39811d7d15f34ab269f7e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -3376,7 +3376,7 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: build-windows
+name: build-windows-amd64
 
 environment:
   RUNTIME: go1.15.5
@@ -4248,6 +4248,6 @@ volumes:
 
 ---
 kind: signature
-hmac: efa30a770e82303f06a263968c53de1aaeba4600f8dffa7c214fc2e3c5d526ab
+hmac: 5c4d5d5c3855e7dd20f071226c92af4fc26a5cc5dcd21d13cc26e0a4159feb1d
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=6.0.0-alpha.2
+VERSION=7.0.0-dev
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "6.0.0-alpha.2"
+	Version = "7.0.0-dev"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
VERSION on master should be updated now 6.0 is out.

This PR also makes some changes to match the style of other pipeline naming (which is important for [`dronegen`](https://github.com/gravitational/teleport/pull/5644)):
- renames the `build-windows` Drone pipeline to `build-windows-amd64`
- renames `i386` in pipeline names to `386`