### PR TITLE
dronegen: Add tag builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -201,7 +201,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tests.go:233
+# Generated at dronegen/tests.go:203
 ################################################
 
 kind: pipeline
@@ -324,7 +324,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:101
+# Generated at dronegen/push.go:95
 ################################################
 
 kind: pipeline
@@ -417,7 +417,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:101
+# Generated at dronegen/push.go:95
 ################################################
 
 kind: pipeline
@@ -510,7 +510,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:101
+# Generated at dronegen/push.go:95
 ################################################
 
 kind: pipeline
@@ -606,7 +606,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:101
+# Generated at dronegen/push.go:95
 ################################################
 
 kind: pipeline
@@ -796,7 +796,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:101
+# Generated at dronegen/push.go:95
 ################################################
 
 kind: pipeline
@@ -990,7 +990,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:101
+# Generated at dronegen/push.go:95
 ################################################
 
 kind: pipeline
@@ -1083,7 +1083,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:101
+# Generated at dronegen/push.go:95
 ################################################
 
 kind: pipeline
@@ -1410,7 +1410,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:200
+# Generated at dronegen/tag.go:209
 ################################################
 
 kind: pipeline
@@ -1450,7 +1450,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build release artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
@@ -1466,7 +1466,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy release artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -1501,7 +1501,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:200
+# Generated at dronegen/tag.go:209
 ################################################
 
 kind: pipeline
@@ -1541,7 +1541,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build FIPS release artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
@@ -1559,7 +1559,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy FIPS release artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -1593,7 +1593,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:200
+# Generated at dronegen/tag.go:209
 ################################################
 
 kind: pipeline
@@ -1633,7 +1633,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build CentOS 6 release artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
@@ -1649,7 +1649,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy CentOS 6 release artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -1687,7 +1687,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:200
+# Generated at dronegen/tag.go:209
 ################################################
 
 kind: pipeline
@@ -1727,7 +1727,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build CentOS 6 FIPS release artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
@@ -1745,7 +1745,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy CentOS 6 FIPS release artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -1781,7 +1781,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:366
+# Generated at dronegen/tag.go:345
 ################################################
 
 kind: pipeline
@@ -1821,7 +1821,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Download built tarball artifacts from S3
+- name: Download artifacts from S3
   image: amazon/aws-cli
   commands:
   - export VERSION=$(cat /go/.version.txt)
@@ -1836,7 +1836,7 @@ steps:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
       from_secret: AWS_SECRET_ACCESS_KEY
-- name: Build RPM artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache bash curl gzip make tar
@@ -1860,7 +1860,7 @@ steps:
     path: /var/run
   - name: tmpfs
     path: /tmpfs
-- name: Copy RPM artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -1899,7 +1899,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:366
+# Generated at dronegen/tag.go:345
 ################################################
 
 kind: pipeline
@@ -1939,7 +1939,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Download built tarball artifacts from S3
+- name: Download artifacts from S3
   image: amazon/aws-cli
   commands:
   - export VERSION=$(cat /go/.version.txt)
@@ -1953,7 +1953,7 @@ steps:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
       from_secret: AWS_SECRET_ACCESS_KEY
-- name: Build RPM artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache bash curl gzip make tar
@@ -1978,7 +1978,7 @@ steps:
     path: /var/run
   - name: tmpfs
     path: /tmpfs
-- name: Copy RPM artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -2016,7 +2016,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:366
+# Generated at dronegen/tag.go:345
 ################################################
 
 kind: pipeline
@@ -2056,7 +2056,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Download built tarball artifacts from S3
+- name: Download artifacts from S3
   image: amazon/aws-cli
   commands:
   - export VERSION=$(cat /go/.version.txt)
@@ -2071,7 +2071,7 @@ steps:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
       from_secret: AWS_SECRET_ACCESS_KEY
-- name: Build DEB artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache bash curl gzip make tar
@@ -2086,7 +2086,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy DEB artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -2120,7 +2120,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:366
+# Generated at dronegen/tag.go:345
 ################################################
 
 kind: pipeline
@@ -2160,7 +2160,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Download built tarball artifacts from S3
+- name: Download artifacts from S3
   image: amazon/aws-cli
   commands:
   - export VERSION=$(cat /go/.version.txt)
@@ -2174,7 +2174,7 @@ steps:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
       from_secret: AWS_SECRET_ACCESS_KEY
-- name: Build DEB artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache bash curl gzip make tar
@@ -2190,7 +2190,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy DEB artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -2223,7 +2223,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:200
+# Generated at dronegen/tag.go:209
 ################################################
 
 kind: pipeline
@@ -2263,7 +2263,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build release artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
@@ -2279,7 +2279,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy release artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -2314,7 +2314,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:366
+# Generated at dronegen/tag.go:345
 ################################################
 
 kind: pipeline
@@ -2354,7 +2354,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Download built tarball artifacts from S3
+- name: Download artifacts from S3
   image: amazon/aws-cli
   commands:
   - export VERSION=$(cat /go/.version.txt)
@@ -2369,7 +2369,7 @@ steps:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
       from_secret: AWS_SECRET_ACCESS_KEY
-- name: Build RPM artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache bash curl gzip make tar
@@ -2393,7 +2393,7 @@ steps:
     path: /var/run
   - name: tmpfs
     path: /tmpfs
-- name: Copy RPM artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -2432,7 +2432,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:366
+# Generated at dronegen/tag.go:345
 ################################################
 
 kind: pipeline
@@ -2472,7 +2472,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Download built tarball artifacts from S3
+- name: Download artifacts from S3
   image: amazon/aws-cli
   commands:
   - export VERSION=$(cat /go/.version.txt)
@@ -2487,7 +2487,7 @@ steps:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
       from_secret: AWS_SECRET_ACCESS_KEY
-- name: Build DEB artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache bash curl gzip make tar
@@ -2502,7 +2502,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy DEB artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -2922,7 +2922,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:200
+# Generated at dronegen/tag.go:209
 ################################################
 
 kind: pipeline
@@ -2962,7 +2962,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build release artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
@@ -2978,7 +2978,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy release artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -3013,7 +3013,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:200
+# Generated at dronegen/tag.go:209
 ################################################
 
 kind: pipeline
@@ -3053,7 +3053,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build release artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
@@ -3069,7 +3069,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy release artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -3104,7 +3104,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:200
+# Generated at dronegen/tag.go:209
 ################################################
 
 kind: pipeline
@@ -3144,7 +3144,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build FIPS release artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
@@ -3162,7 +3162,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy FIPS release artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -3196,7 +3196,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:200
+# Generated at dronegen/tag.go:209
 ################################################
 
 kind: pipeline
@@ -3236,7 +3236,7 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build release artifacts
+- name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
@@ -3252,7 +3252,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy release artifacts
+- name: Copy artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -4053,6 +4053,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 7c68271ee80313336eb89b0bf6751d0b6f4a6fd1541b3ae47555d2ba39ba7719
+hmac: 38e3aea7410c56e084300b100c1d74fda4efdcc017b546f033bffd82fa614360
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -83,10 +83,10 @@ steps:
   - cd /tmpfs/go/src/github.com/gravitational/teleport
   - make -C build.assets buildbox
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 - name: Run linter
   image: docker
   commands:
@@ -98,10 +98,10 @@ steps:
     GOCACHE: /tmpfs/go/cache
     GOPATH: /tmpfs/go
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 - name: Optionally skip tests
   image: docker:git
   commands:
@@ -133,10 +133,10 @@ steps:
     GOCACHE: /tmpfs/go/cache
     GOPATH: /tmpfs/go
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 - name: Run root-only integration tests
   image: docker
   commands:
@@ -147,12 +147,12 @@ steps:
     GOCACHE: /tmpfs/go/cache
     GOPATH: /tmpfs/go
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
   - name: tmp-integration
     path: /tmp
+  - name: dockersock
+    path: /var/run
 - name: Run integration tests
   image: docker
   commands:
@@ -170,31 +170,31 @@ steps:
     KUBECONFIG: /tmpfs/go/kubeconfig.ci
     TEST_KUBE: "true"
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
   - name: tmp-integration
     path: /tmp
+  - name: dockersock
+    path: /var/run
 services:
 - name: Start Docker
   image: docker:dind
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
   - name: tmp-dind
     path: /tmp
+  - name: dockersock
+    path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
 - name: tmp-dind
   temp: {}
 - name: tmp-integration
+  temp: {}
+- name: dockersock
   temp: {}
 
 ---
@@ -272,24 +272,24 @@ steps:
     GOCACHE: /tmpfs/go/cache
     UID: "1000"
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 services:
 - name: Start Docker
   image: docker:dind
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
+- name: dockersock
+  temp: {}
 
 ---
 kind: pipeline
@@ -324,7 +324,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:95
+# Generated at dronegen/push.go:86
 ################################################
 
 kind: pipeline
@@ -417,7 +417,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:95
+# Generated at dronegen/push.go:86
 ################################################
 
 kind: pipeline
@@ -510,7 +510,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:95
+# Generated at dronegen/push.go:86
 ################################################
 
 kind: pipeline
@@ -606,7 +606,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:95
+# Generated at dronegen/push.go:86
 ################################################
 
 kind: pipeline
@@ -796,7 +796,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:95
+# Generated at dronegen/push.go:86
 ################################################
 
 kind: pipeline
@@ -990,7 +990,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:95
+# Generated at dronegen/push.go:86
 ################################################
 
 kind: pipeline
@@ -1083,7 +1083,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:95
+# Generated at dronegen/push.go:86
 ################################################
 
 kind: pipeline
@@ -1410,7 +1410,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:209
+# Generated at dronegen/tag.go:190
 ################################################
 
 kind: pipeline
@@ -1501,7 +1501,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:209
+# Generated at dronegen/tag.go:190
 ################################################
 
 kind: pipeline
@@ -1593,7 +1593,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:209
+# Generated at dronegen/tag.go:190
 ################################################
 
 kind: pipeline
@@ -1687,7 +1687,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:209
+# Generated at dronegen/tag.go:190
 ################################################
 
 kind: pipeline
@@ -1781,7 +1781,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:345
+# Generated at dronegen/tag.go:331
 ################################################
 
 kind: pipeline
@@ -1856,10 +1856,10 @@ steps:
     OSS_TARBALL_PATH: /go/artifacts
     TMPDIR: /go
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 - name: Copy artifacts
   image: docker
   commands:
@@ -1884,22 +1884,22 @@ services:
 - name: Start Docker
   image: docker:dind
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
+- name: dockersock
+  temp: {}
 
 ---
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:345
+# Generated at dronegen/tag.go:331
 ################################################
 
 kind: pipeline
@@ -1974,10 +1974,10 @@ steps:
     RUNTIME: fips
     TMPDIR: /go
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 - name: Copy artifacts
   image: docker
   commands:
@@ -2001,22 +2001,22 @@ services:
 - name: Start Docker
   image: docker:dind
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
+- name: dockersock
+  temp: {}
 
 ---
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:345
+# Generated at dronegen/tag.go:331
 ################################################
 
 kind: pipeline
@@ -2120,7 +2120,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:345
+# Generated at dronegen/tag.go:331
 ################################################
 
 kind: pipeline
@@ -2223,7 +2223,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:209
+# Generated at dronegen/tag.go:190
 ################################################
 
 kind: pipeline
@@ -2314,7 +2314,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:345
+# Generated at dronegen/tag.go:331
 ################################################
 
 kind: pipeline
@@ -2389,10 +2389,10 @@ steps:
     OSS_TARBALL_PATH: /go/artifacts
     TMPDIR: /go
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 - name: Copy artifacts
   image: docker
   commands:
@@ -2417,22 +2417,22 @@ services:
 - name: Start Docker
   image: docker:dind
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: tmpfs
     path: /tmpfs
+  - name: dockersock
+    path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
+- name: dockersock
+  temp: {}
 
 ---
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:345
+# Generated at dronegen/tag.go:331
 ################################################
 
 kind: pipeline
@@ -2922,7 +2922,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:209
+# Generated at dronegen/tag.go:190
 ################################################
 
 kind: pipeline
@@ -3013,7 +3013,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:209
+# Generated at dronegen/tag.go:190
 ################################################
 
 kind: pipeline
@@ -3104,7 +3104,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:209
+# Generated at dronegen/tag.go:190
 ################################################
 
 kind: pipeline
@@ -3196,7 +3196,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:209
+# Generated at dronegen/tag.go:190
 ################################################
 
 kind: pipeline
@@ -4053,6 +4053,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 38e3aea7410c56e084300b100c1d74fda4efdcc017b546f033bffd82fa614360
+hmac: a0f8be7897035e436f78dcbe5f38908dad556831b563edd723611849f00051db
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tests.go:14
+# Generated at dronegen/tests.go:70
 ################################################
 
 kind: pipeline
@@ -57,7 +57,7 @@ steps:
       apk add --no-cache curl jq
       export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/${DRONE_REPO_NAME}/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
       echo "---> Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
-      # if the source repo for the PR matches DRONE_REPO, then        this is not a PR raised from a fork
+      # if the source repo for the PR matches DRONE_REPO, then this is not a PR raised from a fork
       if [ "$${PR_REPO}" = "${DRONE_REPO}" ] || [ "${DRONE_REPO}" = "gravitational/teleport-private" ]; then
         mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
         ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
@@ -201,12 +201,12 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tests.go:230
+# Generated at dronegen/tests.go:233
 ################################################
 
 kind: pipeline
 type: kubernetes
-name: test-docs-internal
+name: test-docs
 trigger:
   event:
     include:
@@ -220,9 +220,9 @@ clone:
   disable: true
 steps:
 - name: Check out code
-  image: golang:1.15.5
+  image: docker:git
   commands:
-  - mkdir -p /tmpfs/go/src/github.com/gravitational/teleport
+  - mkdir -p /tmpfs/go/src/github.com/gravitational/teleport /tmpfs/go/cache
   - cd /tmpfs/go/src/github.com/gravitational/teleport
   - git init && git remote add origin ${DRONE_REMOTE_URL}
   - |
@@ -249,120 +249,44 @@ steps:
   volumes:
   - name: tmpfs
     path: /tmpfs
-- name: Run docs tests (internal links only)
-  image: golang:1.15.5
+- name: Run docs tests
+  image: docker:git
   commands:
+  - apk add --no-cache make
   - cd /tmpfs/go/src/github.com/gravitational/teleport
-  - git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
+  - chown -R $UID:$GID /tmpfs/go
+  - git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | { grep -v ^$ || true; } > /tmp/docs-changes.txt
   - |
-    if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
-      echo "---> Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
-      # Check trailing whitespace
+    if [ $(cat /tmp/docs-changes.txt | wc -l) -gt 0 ]; then
+      echo "---> Changes to docs detected"
+      cat /tmp/docs-changes.txt
+      echo "---> Checking for trailing whitespace"
       make docs-test-whitespace
-      # Check links
-      for VERSION in $(cat /tmp/docs-versions-changed.txt); do
-        if [ -f docs/$VERSION/milv.config.yaml ]; then
-          go get github.com/magicmatatjahu/milv
-          cd docs/$VERSION
-          echo "---> Running milv on docs/$VERSION:"
-          milv -ignore-external
-          echo "------------------------------\n"
-          cd -
-        else
-          echo "---> No milv config found, skipping docs/$VERSION"
-        fi
-      done
-      else echo "---> No changes to docs detected, not running tests"
-    fi
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
-volumes:
-- name: tmpfs
-  temp:
-    medium: memory
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/tests.go:230
-################################################
-
-kind: pipeline
-type: kubernetes
-name: test-docs-external
-trigger:
-  event:
-    include:
-    - pull_request
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-steps:
-- name: Check out code
-  image: golang:1.15.5
-  commands:
-  - mkdir -p /tmpfs/go/src/github.com/gravitational/teleport
-  - cd /tmpfs/go/src/github.com/gravitational/teleport
-  - git init && git remote add origin ${DRONE_REMOTE_URL}
-  - |
-    # handle pull requests
-    if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
-      git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
-      git checkout ${DRONE_COMMIT_BRANCH}
-      git fetch origin ${DRONE_COMMIT_REF}:
-      git merge ${DRONE_COMMIT}
-    # handle tags
-    elif [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
-      git fetch origin +refs/tags/${DRONE_TAG}:
-      git checkout -qf FETCH_HEAD
-    # handle pushes/other events
+      echo "---> Checking for dead links"
+      make -C build.assets test-docs
     else
-      if [ "${DRONE_COMMIT_BRANCH}" = "" ]; then
-        git fetch origin
-        git checkout -qf ${DRONE_COMMIT_SHA}
-      else
-        git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
-        git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
-      fi
+      echo "---> No changes to docs detected, not running tests"
     fi
+  environment:
+    GID: "1000"
+    GOCACHE: /tmpfs/go/cache
+    UID: "1000"
   volumes:
+  - name: dockersock
+    path: /var/run
   - name: tmpfs
     path: /tmpfs
-- name: Run docs tests (external links only)
-  image: golang:1.15.5
-  commands:
-  - cd /tmpfs/go/src/github.com/gravitational/teleport
-  - git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt
-  - |
-    if [ $(stat --printf="%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
-      echo "---> Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
-      # Check trailing whitespace
-      make docs-test-whitespace
-      # Check links
-      for VERSION in $(cat /tmp/docs-versions-changed.txt); do
-        if [ -f docs/$VERSION/milv.config.yaml ]; then
-          go get github.com/magicmatatjahu/milv
-          cd docs/$VERSION
-          echo "---> Running milv on docs/$VERSION:"
-          milv -ignore-internal
-          echo "------------------------------\n"
-          cd -
-        else
-          echo "---> No milv config found, skipping docs/$VERSION"
-        fi
-      done
-      else echo "---> No changes to docs detected, not running tests"
-    fi
+services:
+- name: Start Docker
+  image: docker:dind
   volumes:
+  - name: dockersock
+    path: /var/run
   - name: tmpfs
     path: /tmpfs
 volumes:
+- name: dockersock
+  temp: {}
 - name: tmpfs
   temp:
     medium: memory
@@ -400,7 +324,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:83
+# Generated at dronegen/push.go:101
 ################################################
 
 kind: pipeline
@@ -445,9 +369,6 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
 - name: Build artifacts
   image: docker
   commands:
@@ -496,7 +417,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:83
+# Generated at dronegen/push.go:101
 ################################################
 
 kind: pipeline
@@ -541,9 +462,6 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
 - name: Build artifacts
   image: docker
   commands:
@@ -592,7 +510,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:83
+# Generated at dronegen/push.go:101
 ################################################
 
 kind: pipeline
@@ -638,15 +556,13 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
 - name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
   - make -C build.assets release-amd64-fips
   environment:
     ARCH: amd64
@@ -690,7 +606,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:83
+# Generated at dronegen/push.go:101
 ################################################
 
 kind: pipeline
@@ -735,9 +651,6 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
 - name: Build artifacts
   image: docker
   commands:
@@ -883,7 +796,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:83
+# Generated at dronegen/push.go:101
 ################################################
 
 kind: pipeline
@@ -928,9 +841,6 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
 - name: Build artifacts
   image: docker
   commands:
@@ -976,10 +886,111 @@ volumes:
   temp: {}
 
 ---
+kind: pipeline
+type: kubernetes
+name: push-build-linux-arm-fips
+
+environment:
+  RUNTIME: go1.15.5
+  UID: 1000
+  GID: 1000
+
+trigger:
+  event:
+    include:
+      - push
+    exclude:
+      - pull_request
+  branch:
+    include:
+      - master
+      - branch/*
+  repo:
+    include:
+      - gravitational/*
+
+workspace:
+  path: /go
+
+clone:
+  disable: true
+
+steps:
+  - name: Check out code
+    image: docker:git
+    environment:
+      GITHUB_PRIVATE_KEY:
+        from_secret: GITHUB_PRIVATE_KEY
+    commands:
+      - mkdir -p /go/src/github.com/gravitational/teleport /go/cache
+      - cd /go/src/github.com/gravitational/teleport
+      - git init && git remote add origin ${DRONE_REMOTE_URL}
+      - git fetch origin
+      - git checkout -qf ${DRONE_COMMIT_SHA}
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init webassets || true
+      - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+      - git submodule update --init e
+      # do a recursive submodule checkout to get both webassets and webassets/e
+      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+      - git submodule update --init --recursive webassets || true
+      - rm -f /root/.ssh/id_rsa
+      # set version
+      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+
+  - name: Build artifacts
+    image: docker
+    environment:
+      UID: 1000
+      GID: 1000
+      GOPATH: /go
+      OS: linux
+      ARCH: arm
+    volumes:
+      - name: dockersock
+        path: /var/run
+    commands:
+      - apk add --no-cache make
+      - chown -R $UID:$GID /go
+      - docker pull quay.io/gravitational/teleport-buildbox-fips:$RUNTIME || true
+      - docker pull quay.io/gravitational/teleport-buildbox-arm-fips:$RUNTIME || true
+      - cd /go/src/github.com/gravitational/teleport
+      - export VERSION=$(cat /go/.version.txt)
+      - make -C build.assets release-arm-fips VERSION=$VERSION OS=$OS ARCH=$ARCH FIPS=$FIPS
+
+  - name: Send Slack notification
+    image: plugins/slack
+    settings:
+      webhook:
+        from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+      template: |
+        *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
+        `${DRONE_STAGE_NAME}` artifact build failed.
+        *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
+        Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+        Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
+        Author: <https://github.com/{{ build.author }}|{{ build.author }}>
+        <{{ build.link }}|Visit Drone build page ↗>
+    when:
+      status: [failure]
+
+services:
+  - name: Start Docker
+    image: docker:dind
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:83
+# Generated at dronegen/push.go:101
 ################################################
 
 kind: pipeline
@@ -1024,9 +1035,6 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
 - name: Build artifacts
   image: docker
   commands:
@@ -1075,7 +1083,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:83
+# Generated at dronegen/push.go:101
 ################################################
 
 kind: pipeline
@@ -1121,15 +1129,13 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
 - name: Build artifacts
   image: docker
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
   - make -C build.assets release-arm64-fips
   environment:
     ARCH: arm64
@@ -1194,31 +1200,21 @@ steps:
       # increment these variables when a new major/minor version is released to bump the automatic builds
       # this only needs to be done on the master branch, as that's the branch that the Drone cron is configured for
       # build major version images which are just teleport:x
-      CURRENT_VERSION_ROOT: v5
-      # normally we only support the current release plus the two previous releases, but we're temporarily adding an
-      # extra version here during the migration over from x.y -> x.y-1 support to x -> x-1 support as per RFD 12.
-      OLD_CURRENT_VERSION_ROOT: v5.1
-      OLD_PREVIOUS_VERSION_ONE_ROOT: v5.0
-      OLD_PREVIOUS_VERSION_TWO_ROOT: v4.4
-      OLD_PREVIOUS_VERSION_THREE_ROOT: v4.3
+      CURRENT_VERSION_ROOT: v6
+      PREVIOUS_VERSION_ONE_ROOT: v5
+      PREVIOUS_VERSION_TWO_ROOT: v4.4
     commands:
       - apk --update --no-cache add curl
       - mkdir -p /go/build && cd /go/build
-      # CURRENT_VERSION
+      # CURRENT_VERSION (6)
       - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $CURRENT_VERSION_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/CURRENT_VERSION_TAG.txt
       - echo "$(cat /go/build/CURRENT_VERSION_TAG.txt | cut -d. -f1 | tr -d '^v')" > /go/build/CURRENT_VERSION_TAG_GENERIC.txt
-      # OLD_CURRENT_VERSION
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $OLD_CURRENT_VERSION_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/OLD_CURRENT_VERSION_TAG.txt
-      - echo "$(cat /go/build/OLD_CURRENT_VERSION_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/OLD_CURRENT_VERSION_TAG_GENERIC.txt
-      # OLD_PREVIOUS_VERSION_ONE
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $OLD_PREVIOUS_VERSION_ONE_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/OLD_PREVIOUS_VERSION_ONE_TAG.txt
-      - echo "$(cat /go/build/OLD_PREVIOUS_VERSION_ONE_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/OLD_PREVIOUS_VERSION_ONE_TAG_GENERIC.txt
-      # OLD_PREVIOUS_VERSION_TWO
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $OLD_PREVIOUS_VERSION_TWO_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/OLD_PREVIOUS_VERSION_TWO_TAG.txt
-      - echo "$(cat /go/build/OLD_PREVIOUS_VERSION_TWO_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/OLD_PREVIOUS_VERSION_TWO_TAG_GENERIC.txt
-      # OLD_PREVIOUS_VERSION_THREE
-      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $OLD_PREVIOUS_VERSION_THREE_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/OLD_PREVIOUS_VERSION_THREE_TAG.txt
-      - echo "$(cat /go/build/OLD_PREVIOUS_VERSION_THREE_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/OLD_PREVIOUS_VERSION_THREE_TAG_GENERIC.txt
+      # PREVIOUS_VERSION_ONE (5)
+      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_ONE_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/PREVIOUS_VERSION_ONE_TAG.txt
+      - echo "$(cat /go/build/PREVIOUS_VERSION_ONE_TAG.txt | cut -d. -f1 | tr -d '^v')" > /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt
+      # PREVIOUS_VERSION_TWO (4.4)
+      - echo $(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep $PREVIOUS_VERSION_TWO_ROOT | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1) > /go/build/PREVIOUS_VERSION_TWO_TAG.txt
+      - echo "$(cat /go/build/PREVIOUS_VERSION_TWO_TAG.txt | cut -d. -f1-2 | cut -dv -f2)" > /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt
       # list versions
       - for FILE in /go/build/*.txt; do echo $FILE; cat $FILE; done
       # get Dockerfiles
@@ -1255,7 +1251,7 @@ steps:
       - docker build --target teleport-fips --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
       - docker push $ENT_FIPS_IMAGE_NAME
 
-  - name: Build and push Teleport containers (OLD_CURRENT_VERSION)
+  - name: Build and push Teleport containers (PREVIOUS_VERSION_ONE)
     image: docker
     environment:
       OS: linux
@@ -1269,10 +1265,10 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
-      - export VERSION_TAG=$(cat /go/build/OLD_CURRENT_VERSION_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/OLD_CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/OLD_CURRENT_VERSION_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/OLD_CURRENT_VERSION_TAG_GENERIC.txt)-fips"
+      - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_ONE_TAG.txt)
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --target teleport --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
@@ -1284,7 +1280,7 @@ steps:
       - docker build --target teleport-fips --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
       - docker push $ENT_FIPS_IMAGE_NAME
 
-  - name: Build and push Teleport containers (OLD_PREVIOUS_VERSION_ONE)
+  - name: Build and push Teleport containers (PREVIOUS_VERSION_TWO)
     image: docker
     environment:
       OS: linux
@@ -1298,68 +1294,10 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
-      - export VERSION_TAG=$(cat /go/build/OLD_PREVIOUS_VERSION_ONE_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/OLD_PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/OLD_PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/OLD_PREVIOUS_VERSION_ONE_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
-      # OSS
-      - docker build --target teleport --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      - docker push $OSS_IMAGE_NAME
-      # Enterprise
-      - docker build --target teleport --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      - docker push $ENT_IMAGE_NAME
-      # Enterprise FIPS
-      - docker build --target teleport-fips --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      - docker push $ENT_FIPS_IMAGE_NAME
-
-  - name: Build and push Teleport containers (OLD_PREVIOUS_VERSION_TWO)
-    image: docker
-    environment:
-      OS: linux
-      ARCH: amd64
-    settings:
-      username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-      password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - export VERSION_TAG=$(cat /go/build/OLD_PREVIOUS_VERSION_TWO_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/OLD_PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/OLD_PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/OLD_PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
-      - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
-      # OSS
-      - docker build --target teleport --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      - docker push $OSS_IMAGE_NAME
-      # Enterprise
-      - docker build --target teleport --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH  -t $ENT_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      - docker push $ENT_IMAGE_NAME
-      # Enterprise FIPS
-      - docker build --target teleport-fips --build-arg DOWNLOAD_TYPE=teleport-ent --build-arg EXTRA_DOWNLOAD_ARGS="-fips" --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $ENT_FIPS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
-      - docker push $ENT_FIPS_IMAGE_NAME
-
-  - name: Build and push Teleport containers (OLD_PREVIOUS_VERSION_THREE)
-    image: docker
-    environment:
-      OS: linux
-      ARCH: amd64
-    settings:
-      username:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_USERNAME
-      password:
-        from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - export VERSION_TAG=$(cat /go/build/OLD_PREVIOUS_VERSION_THREE_TAG.txt)
-      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/OLD_PREVIOUS_VERSION_THREE_TAG_GENERIC.txt)"
-      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/OLD_PREVIOUS_VERSION_THREE_TAG_GENERIC.txt)"
-      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/OLD_PREVIOUS_VERSION_THREE_TAG_GENERIC.txt)-fips"
+      - export VERSION_TAG=$(cat /go/build/PREVIOUS_VERSION_TWO_TAG.txt)
+      - export OSS_IMAGE_NAME="quay.io/gravitational/teleport:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)"
+      - export ENT_FIPS_IMAGE_NAME="quay.io/gravitational/teleport-ent:$(cat /go/build/PREVIOUS_VERSION_TWO_TAG_GENERIC.txt)-fips"
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
       # OSS
       - docker build --target teleport --build-arg DOWNLOAD_TYPE=teleport --build-arg VERSION_TAG=$VERSION_TAG --build-arg OS=$OS --build-arg ARCH=$ARCH -t $OSS_IMAGE_NAME -f /go/build/Dockerfile-cron /go/build
@@ -1431,6 +1369,7 @@ steps:
       - cd /go/chart
       - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport
       - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport-kube-agent
+      - helm package /go/src/github.com/gravitational/teleport/examples/chart/teleport-cluster
       # copy index.html to root of the S3 bucket
       - cp /go/src/github.com/gravitational/teleport/examples/chart/index.html /go/chart
       # this will index all previous versions of the charts downloaded from the S3 bucket,
@@ -1471,7 +1410,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:149
+# Generated at dronegen/tag.go:184
 ################################################
 
 kind: pipeline
@@ -1506,7 +1445,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -1546,7 +1485,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -1562,7 +1501,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:149
+# Generated at dronegen/tag.go:184
 ################################################
 
 kind: pipeline
@@ -1597,7 +1536,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -1624,7 +1563,6 @@ steps:
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
-  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
   - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 - name: Upload to S3
@@ -1639,7 +1577,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -1863,7 +1801,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:307
+# Generated at dronegen/tag.go:350
 ################################################
 
 kind: pipeline
@@ -1898,7 +1836,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -1913,6 +1851,7 @@ steps:
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
+    AWS_REGION: us-west-2
     AWS_S3_BUCKET:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
@@ -1959,7 +1898,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -1967,6 +1906,8 @@ services:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: tmpfs
+    path: /tmpfs
 volumes:
 - name: dockersock
   temp: {}
@@ -1978,7 +1919,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:307
+# Generated at dronegen/tag.go:350
 ################################################
 
 kind: pipeline
@@ -2013,7 +1954,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -2027,6 +1968,7 @@ steps:
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
+    AWS_REGION: us-west-2
     AWS_S3_BUCKET:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
@@ -2073,7 +2015,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -2081,6 +2023,8 @@ services:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: tmpfs
+    path: /tmpfs
 volumes:
 - name: dockersock
   temp: {}
@@ -2092,7 +2036,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:307
+# Generated at dronegen/tag.go:350
 ################################################
 
 kind: pipeline
@@ -2127,7 +2071,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -2142,6 +2086,7 @@ steps:
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
+    AWS_REGION: us-west-2
     AWS_S3_BUCKET:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
@@ -2161,8 +2106,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: tmpfs
-    path: /tmpfs
 - name: Copy DEB artifacts
   image: docker
   commands:
@@ -2181,7 +2124,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -2192,15 +2135,12 @@ services:
 volumes:
 - name: dockersock
   temp: {}
-- name: tmpfs
-  temp:
-    medium: memory
 
 ---
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:307
+# Generated at dronegen/tag.go:350
 ################################################
 
 kind: pipeline
@@ -2235,7 +2175,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -2249,6 +2189,7 @@ steps:
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
+    AWS_REGION: us-west-2
     AWS_S3_BUCKET:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
@@ -2269,8 +2210,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: tmpfs
-    path: /tmpfs
 - name: Copy DEB artifacts
   image: docker
   commands:
@@ -2288,7 +2227,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -2299,15 +2238,12 @@ services:
 volumes:
 - name: dockersock
   temp: {}
-- name: tmpfs
-  temp:
-    medium: memory
 
 ---
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:149
+# Generated at dronegen/tag.go:184
 ################################################
 
 kind: pipeline
@@ -2342,7 +2278,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -2382,7 +2318,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -2398,7 +2334,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:307
+# Generated at dronegen/tag.go:350
 ################################################
 
 kind: pipeline
@@ -2433,7 +2369,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -2448,6 +2384,7 @@ steps:
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
+    AWS_REGION: us-west-2
     AWS_S3_BUCKET:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
@@ -2494,7 +2431,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -2502,6 +2439,8 @@ services:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: tmpfs
+    path: /tmpfs
 volumes:
 - name: dockersock
   temp: {}
@@ -2513,7 +2452,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:307
+# Generated at dronegen/tag.go:350
 ################################################
 
 kind: pipeline
@@ -2548,7 +2487,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -2563,6 +2502,7 @@ steps:
   environment:
     AWS_ACCESS_KEY_ID:
       from_secret: AWS_ACCESS_KEY_ID
+    AWS_REGION: us-west-2
     AWS_S3_BUCKET:
       from_secret: AWS_S3_BUCKET
     AWS_SECRET_ACCESS_KEY:
@@ -2582,8 +2522,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: tmpfs
-    path: /tmpfs
 - name: Copy DEB artifacts
   image: docker
   commands:
@@ -2602,7 +2540,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -2613,9 +2551,6 @@ services:
 volumes:
 - name: dockersock
   temp: {}
-- name: tmpfs
-  temp:
-    medium: memory
 
 ---
 kind: pipeline
@@ -3007,7 +2942,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:149
+# Generated at dronegen/tag.go:184
 ################################################
 
 kind: pipeline
@@ -3042,7 +2977,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -3082,7 +3017,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -3098,7 +3033,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:149
+# Generated at dronegen/tag.go:184
 ################################################
 
 kind: pipeline
@@ -3133,7 +3068,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -3173,7 +3108,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -3189,7 +3124,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:149
+# Generated at dronegen/tag.go:184
 ################################################
 
 kind: pipeline
@@ -3224,7 +3159,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -3251,7 +3186,6 @@ steps:
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
-  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
   - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
 - name: Upload to S3
@@ -3266,7 +3200,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -3282,7 +3216,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:149
+# Generated at dronegen/tag.go:184
 ################################################
 
 kind: pipeline
@@ -3317,7 +3251,7 @@ steps:
   - git submodule update --init e
   - git submodule update --init --recursive webassets || true
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts/e
+  - mkdir -p /go/cache /go/artifacts
   - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
@@ -3342,9 +3276,10 @@ steps:
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
-  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+  - find . -maxdepth 1 -iname "teleport*.zip" -print -exec cp {} /go/artifacts \;
+  - export VERSION=$(cat /go/.version.txt)
+  - cp /go/artifacts/teleport-v$${VERSION}-windows-amd64-bin.zip /go/artifacts/teleport-ent-v$${VERSION}-windows-amd64-bin.zip
+  - cd /go/artifacts && for FILE in teleport*.zip; do sha256sum $FILE > $FILE.sha256; done && ls -l
 - name: Upload to S3
   image: plugins/s3
   commands: []
@@ -3357,7 +3292,7 @@ steps:
     secret_key:
       from_secret: AWS_SECRET_ACCESS_KEY
     source: /go/artifacts/*
-    strip_prefix: /go/artifacts
+    strip_prefix: /go/artifacts/
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
@@ -4138,6 +4073,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 1d109a083ee2ec315c11984b75d1040a991456415cadf50df573e49b82de4aad
+hmac: bf15ca031d392f02d5705dd840da6563bd7b448a151ebaac7cc6e6cbc8a123df
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -400,7 +400,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:59
+# Generated at dronegen/push.go:83
 ################################################
 
 kind: pipeline
@@ -496,7 +496,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:59
+# Generated at dronegen/push.go:83
 ################################################
 
 kind: pipeline
@@ -592,7 +592,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:59
+# Generated at dronegen/push.go:83
 ################################################
 
 kind: pipeline
@@ -690,7 +690,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:59
+# Generated at dronegen/push.go:83
 ################################################
 
 kind: pipeline
@@ -883,7 +883,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:59
+# Generated at dronegen/push.go:83
 ################################################
 
 kind: pipeline
@@ -979,7 +979,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:59
+# Generated at dronegen/push.go:83
 ################################################
 
 kind: pipeline
@@ -1075,7 +1075,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:59
+# Generated at dronegen/push.go:83
 ################################################
 
 kind: pipeline
@@ -1468,205 +1468,188 @@ steps:
       status: [failure]
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:149
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-amd64
-
 environment:
   RUNTIME: go1.15.5
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts/e
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Build release artifacts
-    image: docker
-    environment:
-      UID: 1000
-      GID: 1000
-      GOPATH: /go
-      OS: linux
-      ARCH: amd64
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets release OS=$OS ARCH=$ARCH
-
-  - name: Copy artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Build release artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - make -C build.assets release-amd64 OS=linux ARCH=amd64
+  environment:
+    ARCH: amd64
+    GID: "1000"
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+- name: Copy artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:149
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-amd64-fips
-
 environment:
   RUNTIME: go1.15.5
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Build FIPS release artifacts
-    image: docker
-    environment:
-      UID: 1000
-      GID: 1000
-      GOPATH: /go
-      OS: linux
-      ARCH: amd64
-      FIPS: "yes"
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox-fips:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /go/.version.txt)
-      - make -C build.assets release-fips VERSION=$VERSION OS=$OS ARCH=$ARCH FIPS=$FIPS
-
-  - name: Copy FIPS artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Build release artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - make -C build.assets release-amd64-fips VERSION=$VERSION OS=linux ARCH=amd64 FIPS=yes
+  environment:
+    ARCH: amd64
+    FIPS: "yes"
+    GID: "1000"
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+- name: Copy artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
 
 ---
 kind: pipeline
@@ -1877,821 +1860,762 @@ volumes:
     temp: {}
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:307
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-amd64-rpm
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
-depends_on:
-  - build-linux-amd64
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
+depends_on:
+- build-linux-amd64
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Download built tarball artifacts from S3
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - export VERSION=$(cat /go/.version.txt)
-      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
-
-  - name: Build RPM artifacts
-    image: docker
-    environment:
-      ARCH: amd64
-      TMPDIR: /go
-      OSS_TARBALL_PATH: /go/artifacts
-      ENT_TARBALL_PATH: /go/artifacts
-      GNUPG_DIR: /tmpfs/gnupg
-      GPG_RPM_SIGNING_ARCHIVE:
-        from_secret: GPG_RPM_SIGNING_ARCHIVE
-    volumes:
-      - name: dockersock
-        path: /var/run
-      - name: tmpfs
-        path: /tmpfs
-    commands:
-      - apk add --no-cache bash curl gzip make tar
-      - cd /go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /go/.version.txt)
-      - mkdir -m0700 $GNUPG_DIR
-      - echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR
-      - chown -R root:root $GNUPG_DIR
-      - make rpm
-      - rm -rf $GNUPG_DIR
-
-  - name: Copy RPM artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives (and checksums) to artifact directory
-      - find build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
-      - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-      - name: tmpfs
-        path: /tmpfs
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Download built tarball artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - export VERSION=$(cat /go/.version.txt)
+  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+- name: Build RPM artifacts
+  image: docker
+  commands:
+  - apk add --no-cache bash curl gzip make tar
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - mkdir -m0700 $GNUPG_DIR
+  - echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR
+  - chown -R root:root $GNUPG_DIR
+  - make rpm
+  - rm -rf $GNUPG_DIR
+  environment:
+    ARCH: amd64
+    ENT_TARBALL_PATH: /go/artifacts
+    GNUPG_DIR: /tmpfs/gnupg
+    GPG_RPM_SIGNING_ARCHIVE:
+      from_secret: GPG_RPM_SIGNING_ARCHIVE
+    OSS_TARBALL_PATH: /go/artifacts
+    TMPDIR: /go
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
   - name: tmpfs
-    temp:
-      medium: memory
+    path: /tmpfs
+- name: Copy RPM artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+  - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
+- name: tmpfs
+  temp:
+    medium: memory
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:307
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-amd64-fips-rpm
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
-depends_on:
-  - build-linux-amd64-fips
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
+depends_on:
+- build-linux-amd64-fips
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Download built tarball artifacts from S3
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - export VERSION=$(cat /go/.version.txt)
-      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/
-
-  - name: Build FIPS RPM artifacts
-    image: docker
-    environment:
-      ARCH: amd64
-      FIPS: "yes"
-      # weird quirk of FIPS package builds
-      RUNTIME: fips
-      TMPDIR: /go
-      ENT_TARBALL_PATH: /go/artifacts
-      GNUPG_DIR: /tmpfs/gnupg
-      GPG_RPM_SIGNING_ARCHIVE:
-        from_secret: GPG_RPM_SIGNING_ARCHIVE
-    volumes:
-      - name: dockersock
-        path: /var/run
-      - name: tmpfs
-        path: /tmpfs
-    commands:
-      - apk add --no-cache bash curl gzip make tar
-      - cd /go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /go/.version.txt)
-      - mkdir -m0700 $GNUPG_DIR
-      - echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR
-      - chown -R root:root $GNUPG_DIR
-      # build enterprise only
-      - make -C e rpm
-      - rm -rf $GNUPG_DIR
-
-  - name: Copy FIPS RPM artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives (and checksums) to artifact directory
-      - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-      - name: tmpfs
-        path: /tmpfs
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Download built tarball artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - export VERSION=$(cat /go/.version.txt)
+  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+- name: Build RPM artifacts
+  image: docker
+  commands:
+  - apk add --no-cache bash curl gzip make tar
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - mkdir -m0700 $GNUPG_DIR
+  - echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR
+  - chown -R root:root $GNUPG_DIR
+  - make -C e rpm
+  - rm -rf $GNUPG_DIR
+  environment:
+    ARCH: amd64
+    ENT_TARBALL_PATH: /go/artifacts
+    FIPS: "yes"
+    GNUPG_DIR: /tmpfs/gnupg
+    GPG_RPM_SIGNING_ARCHIVE:
+      from_secret: GPG_RPM_SIGNING_ARCHIVE
+    RUNTIME: fips
+    TMPDIR: /go
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
   - name: tmpfs
-    temp:
-      medium: memory
+    path: /tmpfs
+- name: Copy RPM artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
+- name: tmpfs
+  temp:
+    medium: memory
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:307
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-amd64-deb
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
-depends_on:
-  - build-linux-amd64
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
+depends_on:
+- build-linux-amd64
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Download built tarball artifacts from S3
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - export VERSION=$(cat /go/.version.txt)
-      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
-
-  - name: Build DEB artifacts
-    image: docker
-    environment:
-      ARCH: amd64
-      TMPDIR: /go
-      OSS_TARBALL_PATH: /go/artifacts
-      ENT_TARBALL_PATH: /go/artifacts
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache bash curl make tar
-      - cd /go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /go/.version.txt)
-      - make deb
-
-  - name: Copy DEB artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives (and checksums) to artifact directory
-      - find build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
-      - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Download built tarball artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - export VERSION=$(cat /go/.version.txt)
+  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+- name: Build DEB artifacts
+  image: docker
+  commands:
+  - apk add --no-cache bash curl gzip make tar
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - make deb
+  environment:
+    ARCH: amd64
+    ENT_TARBALL_PATH: /go/artifacts
+    OSS_TARBALL_PATH: /go/artifacts
+    TMPDIR: /go
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+  - name: tmpfs
+    path: /tmpfs
+- name: Copy DEB artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
+  - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
+- name: tmpfs
+  temp:
+    medium: memory
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:307
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-amd64-fips-deb
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
-depends_on:
-  - build-linux-amd64-fips
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
+depends_on:
+- build-linux-amd64-fips
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Download built tarball artifacts from S3
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - export VERSION=$(cat /go/.version.txt)
-      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/
-
-  - name: Build FIPS DEB artifacts
-    image: docker
-    environment:
-      ARCH: amd64
-      FIPS: "yes"
-      # weird quirk with FIPS package builds
-      RUNTIME: "fips"
-      TMPDIR: /go
-      ENT_TARBALL_PATH: /go/artifacts
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache bash curl make tar
-      - cd /go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /go/.version.txt)
-      # build enterprise only
-      - make -C e deb
-
-  - name: Copy FIPS DEB artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives (and checksums) to artifact directory
-      - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
-      - ls -l /go/artifacts
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Download built tarball artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - export VERSION=$(cat /go/.version.txt)
+  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+- name: Build DEB artifacts
+  image: docker
+  commands:
+  - apk add --no-cache bash curl gzip make tar
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - make -C e deb
+  environment:
+    ARCH: amd64
+    ENT_TARBALL_PATH: /go/artifacts
+    FIPS: "yes"
+    RUNTIME: fips
+    TMPDIR: /go
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+  - name: tmpfs
+    path: /tmpfs
+- name: Copy DEB artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
+- name: tmpfs
+  temp:
+    medium: memory
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:149
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-386
-
 environment:
   RUNTIME: go1.15.5
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts/e
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Build i386 release artifacts
-    image: docker
-    environment:
-      UID: 1000
-      GID: 1000
-      GOPATH: /go
-      OS: linux
-      ARCH: "386"
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets release OS=$OS ARCH=$ARCH
-
-  - name: Copy artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Build release artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - make -C build.assets release-386 OS=linux ARCH=386
+  environment:
+    ARCH: "386"
+    GID: "1000"
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+- name: Copy artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:307
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-386-rpm
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
-depends_on:
-  - build-linux-386
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
+depends_on:
+- build-linux-386
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Download built tarball artifacts from S3
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - export VERSION=$(cat /go/.version.txt)
-      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
-
-  - name: Build i386 RPM artifacts
-    image: docker
-    environment:
-      ARCH: "386"
-      TMPDIR: /go
-      OSS_TARBALL_PATH: /go/artifacts
-      ENT_TARBALL_PATH: /go/artifacts
-      GNUPG_DIR: /tmpfs/gnupg
-      GPG_RPM_SIGNING_ARCHIVE:
-        from_secret: GPG_RPM_SIGNING_ARCHIVE
-    volumes:
-      - name: dockersock
-        path: /var/run
-      - name: tmpfs
-        path: /tmpfs
-    commands:
-      - apk add --no-cache bash curl gzip make tar
-      - cd /go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /go/.version.txt)
-      - mkdir -m0700 $GNUPG_DIR
-      - echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR
-      - chown -R root:root $GNUPG_DIR
-      - make rpm
-      - rm -rf $GNUPG_DIR
-
-  - name: Copy i386 RPM artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives (and checksums) to artifact directory
-      - find build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
-      - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-      - name: tmpfs
-        path: /tmpfs
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Download built tarball artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - export VERSION=$(cat /go/.version.txt)
+  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+- name: Build RPM artifacts
+  image: docker
+  commands:
+  - apk add --no-cache bash curl gzip make tar
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - mkdir -m0700 $GNUPG_DIR
+  - echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR
+  - chown -R root:root $GNUPG_DIR
+  - make rpm
+  - rm -rf $GNUPG_DIR
+  environment:
+    ARCH: "386"
+    ENT_TARBALL_PATH: /go/artifacts
+    GNUPG_DIR: /tmpfs/gnupg
+    GPG_RPM_SIGNING_ARCHIVE:
+      from_secret: GPG_RPM_SIGNING_ARCHIVE
+    OSS_TARBALL_PATH: /go/artifacts
+    TMPDIR: /go
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
   - name: tmpfs
-    temp:
-      medium: memory
+    path: /tmpfs
+- name: Copy RPM artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+  - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts \;
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
+- name: tmpfs
+  temp:
+    medium: memory
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:307
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-386-deb
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
-depends_on:
-  - build-linux-386
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
+depends_on:
+- build-linux-386
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Download built tarball artifacts from S3
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      AWS_REGION: us-west-2
-    commands:
-      - export VERSION=$(cat /go/.version.txt)
-      - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
-      - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
-
-  - name: Build i386 DEB artifacts
-    image: docker
-    environment:
-      ARCH: "386"
-      TMPDIR: /go
-      OSS_TARBALL_PATH: /go/artifacts
-      ENT_TARBALL_PATH: /go/artifacts
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache bash curl make tar
-      - cd /go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /go/.version.txt)
-      - make deb
-
-  - name: Copy i386 DEB artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives (and checksums) to artifact directory
-      - find build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
-      - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Download built tarball artifacts from S3
+  image: amazon/aws-cli
+  commands:
+  - export VERSION=$(cat /go/.version.txt)
+  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
+  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz /go/artifacts/
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_S3_BUCKET:
+      from_secret: AWS_S3_BUCKET
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+- name: Build DEB artifacts
+  image: docker
+  commands:
+  - apk add --no-cache bash curl gzip make tar
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - make deb
+  environment:
+    ARCH: "386"
+    ENT_TARBALL_PATH: /go/artifacts
+    OSS_TARBALL_PATH: /go/artifacts
+    TMPDIR: /go
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+  - name: tmpfs
+    path: /tmpfs
+- name: Copy DEB artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
+  - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts \;
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
+- name: tmpfs
+  temp:
+    medium: memory
 
 ---
 kind: pipeline
@@ -3080,413 +3004,370 @@ steps:
       - rm -rf $WORKSPACE_DIR/go $WORKSPACE_DIR/.ssh
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:149
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-arm
-
 environment:
   RUNTIME: go1.15.5
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts/e
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Build release artifacts
-    image: docker
-    environment:
-      UID: 1000
-      GID: 1000
-      GOPATH: /go
-      OS: linux
-      ARCH: arm
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - docker pull quay.io/gravitational/teleport-buildbox-arm:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets release-arm
-
-  - name: Copy artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Build release artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - make -C build.assets release-arm OS=linux ARCH=arm
+  environment:
+    ARCH: arm
+    GID: "1000"
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+- name: Copy artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:149
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-arm64
-
 environment:
   RUNTIME: go1.15.5
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts/e
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Build release artifacts
-    image: docker
-    environment:
-      UID: 1000
-      GID: 1000
-      GOPATH: /go
-      OS: linux
-      ARCH: arm64
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - docker pull quay.io/gravitational/teleport-buildbox-arm:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets release-arm64
-
-  - name: Copy artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Build release artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - make -C build.assets release-arm64 OS=linux ARCH=arm64
+  environment:
+    ARCH: arm64
+    GID: "1000"
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+- name: Copy artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:149
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-arm64-fips
-
 environment:
   RUNTIME: go1.15.5
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Build FIPS release artifacts
-    image: docker
-    environment:
-      UID: 1000
-      GID: 1000
-      GOPATH: /go
-      OS: linux
-      ARCH: arm64
-      FIPS: "yes"
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox-fips:$RUNTIME || true
-      - docker pull quay.io/gravitational/teleport-buildbox-arm-fips:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /go/.version.txt)
-      - make -C build.assets release-arm64-fips VERSION=$VERSION OS=$OS ARCH=$ARCH FIPS=$FIPS
-
-  - name: Copy FIPS artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Build release artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - make -C build.assets release-arm64-fips VERSION=$VERSION OS=linux ARCH=arm64 FIPS=yes
+  environment:
+    ARCH: arm64
+    FIPS: "yes"
+    GID: "1000"
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+- name: Copy artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:149
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-windows-amd64
-
 environment:
   RUNTIME: go1.15.5
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Build Windows release artifacts
-    image: docker
-    environment:
-      UID: 1000
-      GID: 1000
-      GOPATH: /go
-      OS: windows
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets release-windows OS=$OS
-
-  - name: Copy Windows artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives to build directory
-      - mkdir -p /go/artifacts/windows
-      - find . -maxdepth 1 -iname "teleport*.zip" -print -exec cp {} /go/artifacts \;
-      # make a copy of the Windows binaries named 'teleport-ent'
-      # our download portal looks for downloads starting with 'teleport-ent' to serve up, so
-      # for us to list any Windows Enterprise downloads, we need a 'teleport-ent*zip' binary
-      # The Windows artifacts only contain tsh.exe, which is the same for both OSS and Enterprise.
-      - export VERSION=$(cat /go/.version.txt)
-      - cp /go/artifacts/teleport-v$${VERSION}-windows-amd64-bin.zip /go/artifacts/teleport-ent-v$${VERSION}-windows-amd64-bin.zip
-      # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.zip; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts/e
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Build release artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - make -C build.assets release-amd64 OS=windows ARCH=amd64
+  environment:
+    ARCH: amd64
+    GID: "1000"
+    GOPATH: /go
+    OS: windows
+    UID: "1000"
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+- name: Copy artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
 
 ---
 kind: pipeline
@@ -4257,6 +4138,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: c6b4ffef788718d08916fd620c2e6a0d06f4e145dcab63286a935c0e3491ff6a
+hmac: d085dedc5560b239c093eabe2c7f10139f8d7046e68ee2a9c89c2de23b4e1247
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1410,7 +1410,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:184
+# Generated at dronegen/tag.go:200
 ################################################
 
 kind: pipeline
@@ -1456,7 +1456,7 @@ steps:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-amd64 OS=linux ARCH=amd64
+  - make -C build.assets release-amd64
   environment:
     ARCH: amd64
     GID: "1000"
@@ -1466,7 +1466,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy artifacts
+- name: Copy release artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -1501,7 +1501,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:184
+# Generated at dronegen/tag.go:200
 ################################################
 
 kind: pipeline
@@ -1541,14 +1541,14 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build release artifacts
+- name: Build FIPS release artifacts
   image: docker
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
   - export VERSION=$(cat /go/.version.txt)
-  - make -C build.assets release-amd64-fips VERSION=$VERSION OS=linux ARCH=amd64 FIPS=yes
+  - make -C build.assets release-amd64-fips
   environment:
     ARCH: amd64
     FIPS: "yes"
@@ -1559,7 +1559,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy artifacts
+- name: Copy FIPS release artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -1590,218 +1590,198 @@ volumes:
   temp: {}
 
 ---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:200
+################################################
+
 kind: pipeline
 type: kubernetes
 name: build-linux-amd64-centos6
-
 environment:
   RUNTIME: go1.15.5
-
 trigger:
   event:
+    include:
     - tag
   ref:
     include:
-      - refs/tags/v*
+    - refs/tags/v*
   repo:
     include:
-      - gravitational/*
-
+    - gravitational/*
 workspace:
   path: /go
-
 clone:
   disable: true
-
 steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts/e
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Build CentOS 6 release artifacts
-    image: docker
-    environment:
-      UID: 1000
-      GID: 1000
-      GOPATH: /go
-      OS: linux
-      ARCH: amd64
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox-centos6:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - make -C build.assets release-centos6 OS=$OS ARCH=$ARCH
-
-  - name: Copy CentOS 6 artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # rename artifacts
-      - export VERSION=$(cat /go/.version.txt)
-      - mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-v$${VERSION}-linux-amd64-centos6-bin.tar.gz
-      - mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-bin.tar.gz
-      # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
-services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Build CentOS 6 release artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - make -C build.assets release-amd64-centos6
+  environment:
+    ARCH: amd64
+    GID: "1000"
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
   - name: dockersock
-    temp: {}
-
----
-kind: pipeline
-type: kubernetes
-name: build-linux-amd64-centos6-fips
-
-environment:
-  RUNTIME: go1.15.5
-
-trigger:
-  event:
-    - tag
-  ref:
-    include:
-      - refs/tags/v*
-  repo:
-    include:
-      - gravitational/*
-
-workspace:
-  path: /go
-
-clone:
-  disable: true
-
-steps:
-  - name: Check out code
-    image: docker:git
-    environment:
-      GITHUB_PRIVATE_KEY:
-        from_secret: GITHUB_PRIVATE_KEY
-    commands:
-      - mkdir -p /go/src/github.com/gravitational/teleport
-      - cd /go/src/github.com/gravitational/teleport
-      - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-      - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-      # fetch enterprise submodules
-      - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-      - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-      - git submodule update --init e
-      # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-      - git submodule update --init --recursive webassets || true
-      - rm -f /root/.ssh/id_rsa
-      # create necessary directories
-      - mkdir -p /go/cache /go/artifacts
-      # set version
-      - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-
-  - name: Build CentOS 6 FIPS release artifacts
-    image: docker
-    environment:
-      UID: 1000
-      GID: 1000
-      GOPATH: /go
-      OS: linux
-      ARCH: amd64
-      FIPS: "yes"
-    volumes:
-      - name: dockersock
-        path: /var/run
-    commands:
-      - apk add --no-cache make
-      - chown -R $UID:$GID /go
-      - docker pull quay.io/gravitational/teleport-buildbox-centos6-fips:$RUNTIME || true
-      - cd /go/src/github.com/gravitational/teleport
-      - export VERSION=$(cat /go/.version.txt)
-      - make -C build.assets release-centos6-fips VERSION=$VERSION OS=$OS ARCH=$ARCH FIPS=$FIPS
-
-  - name: Copy CentOS 6 FIPS artifacts
-    image: docker
-    commands:
-      - cd /go/src/github.com/gravitational/teleport
-      # copy release archives to artifact directory
-      - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
-      # rename artifact
-      - export VERSION=$(cat /go/.version.txt)
-      - mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-fips-bin.tar.gz
-      # generate checksums
-      - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
-
-  - name: Upload to S3
-    image: plugins/s3
-    settings:
-      bucket:
-        from_secret: AWS_S3_BUCKET
-      access_key:
-        from_secret: AWS_ACCESS_KEY_ID
-      secret_key:
-        from_secret: AWS_SECRET_ACCESS_KEY
-      region: us-west-2
-      source: /go/artifacts/*
-      target: teleport/tag/${DRONE_TAG##v}
-      strip_prefix: /go/artifacts/
-
+    path: /var/run
+- name: Copy CentOS 6 release artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - export VERSION=$(cat /go/.version.txt)
+  - mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-v$${VERSION}-linux-amd64-centos6-bin.tar.gz
+  - mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-bin.tar.gz
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts/
+    target: teleport/tag/${DRONE_TAG##v}
 services:
-  - name: Start Docker
-    image: docker:dind
-    volumes:
-      - name: dockersock
-        path: /var/run
-
-volumes:
+- name: Start Docker
+  image: docker:dind
+  volumes:
   - name: dockersock
-    temp: {}
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
 
 ---
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:350
+# Generated at dronegen/tag.go:200
+################################################
+
+kind: pipeline
+type: kubernetes
+name: build-linux-amd64-centos6-fips
+environment:
+  RUNTIME: go1.15.5
+trigger:
+  event:
+    include:
+    - tag
+  ref:
+    include:
+    - refs/tags/v*
+  repo:
+    include:
+    - gravitational/*
+workspace:
+  path: /go
+clone:
+  disable: true
+steps:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Build CentOS 6 FIPS release artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - make -C build.assets release-amd64-centos6-fips
+  environment:
+    ARCH: amd64
+    FIPS: "yes"
+    GID: "1000"
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
+  - name: dockersock
+    path: /var/run
+- name: Copy CentOS 6 FIPS release artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;
+  - export VERSION=$(cat /go/.version.txt)
+  - mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-fips-bin.tar.gz
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  commands: []
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts/
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
+
+---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:366
 ################################################
 
 kind: pipeline
@@ -1919,7 +1899,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:350
+# Generated at dronegen/tag.go:366
 ################################################
 
 kind: pipeline
@@ -2036,7 +2016,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:350
+# Generated at dronegen/tag.go:366
 ################################################
 
 kind: pipeline
@@ -2140,7 +2120,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:350
+# Generated at dronegen/tag.go:366
 ################################################
 
 kind: pipeline
@@ -2243,7 +2223,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:184
+# Generated at dronegen/tag.go:200
 ################################################
 
 kind: pipeline
@@ -2289,7 +2269,7 @@ steps:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-386 OS=linux ARCH=386
+  - make -C build.assets release-386
   environment:
     ARCH: "386"
     GID: "1000"
@@ -2299,7 +2279,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy artifacts
+- name: Copy release artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -2334,7 +2314,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:350
+# Generated at dronegen/tag.go:366
 ################################################
 
 kind: pipeline
@@ -2452,7 +2432,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:350
+# Generated at dronegen/tag.go:366
 ################################################
 
 kind: pipeline
@@ -2942,7 +2922,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:184
+# Generated at dronegen/tag.go:200
 ################################################
 
 kind: pipeline
@@ -2988,7 +2968,7 @@ steps:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-arm OS=linux ARCH=arm
+  - make -C build.assets release-arm
   environment:
     ARCH: arm
     GID: "1000"
@@ -2998,7 +2978,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy artifacts
+- name: Copy release artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -3033,7 +3013,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:184
+# Generated at dronegen/tag.go:200
 ################################################
 
 kind: pipeline
@@ -3079,7 +3059,7 @@ steps:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-arm64 OS=linux ARCH=arm64
+  - make -C build.assets release-arm64
   environment:
     ARCH: arm64
     GID: "1000"
@@ -3089,7 +3069,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy artifacts
+- name: Copy release artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -3124,7 +3104,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:184
+# Generated at dronegen/tag.go:200
 ################################################
 
 kind: pipeline
@@ -3164,14 +3144,14 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Build release artifacts
+- name: Build FIPS release artifacts
   image: docker
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
   - export VERSION=$(cat /go/.version.txt)
-  - make -C build.assets release-arm64-fips VERSION=$VERSION OS=linux ARCH=arm64 FIPS=yes
+  - make -C build.assets release-arm64-fips
   environment:
     ARCH: arm64
     FIPS: "yes"
@@ -3182,7 +3162,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy artifacts
+- name: Copy FIPS release artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -3216,7 +3196,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:184
+# Generated at dronegen/tag.go:200
 ################################################
 
 kind: pipeline
@@ -3262,7 +3242,7 @@ steps:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
   - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-amd64 OS=windows ARCH=amd64
+  - make -C build.assets release-amd64
   environment:
     ARCH: amd64
     GID: "1000"
@@ -3272,7 +3252,7 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-- name: Copy artifacts
+- name: Copy release artifacts
   image: docker
   commands:
   - cd /go/src/github.com/gravitational/teleport
@@ -4073,6 +4053,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: bf15ca031d392f02d5705dd840da6563bd7b448a151ebaac7cc6e6cbc8a123df
+hmac: 7c68271ee80313336eb89b0bf6751d0b6f4a6fd1541b3ae47555d2ba39ba7719
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -984,104 +984,6 @@ volumes:
 
 kind: pipeline
 type: kubernetes
-name: push-build-linux-arm-fips
-environment:
-  GID: "1000"
-  RUNTIME: go1.15.5
-  UID: "1000"
-trigger:
-  event:
-    include:
-    - push
-    exclude:
-    - pull_request
-  repo:
-    include:
-    - gravitational/*
-  branch:
-    include:
-    - master
-    - branch/*
-workspace:
-  path: /go
-clone:
-  disable: true
-steps:
-- name: Check out code
-  image: docker:git
-  commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport /go/cache
-  - cd /go/src/github.com/gravitational/teleport
-  - git init && git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin
-  - git checkout -qf ${DRONE_COMMIT_SHA}
-  - git submodule update --init webassets || true
-  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - git submodule update --init --recursive webassets || true
-  - rm -f /root/.ssh/id_rsa
-  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
-- name: Build artifacts
-  image: docker
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-arm-fips
-  environment:
-    ARCH: arm
-    FIPS: "yes"
-    GID: "1000"
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-- name: Send Slack notification
-  image: plugins/slack
-  commands: []
-  settings:
-    webhook:
-      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-  template:
-  - |
-    *{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: `{{ build.event }}`)
-    `${DRONE_STAGE_NAME}` artifact build failed.
-    *Warning:* This is a genuine failure to build the Teleport binary from `{{ build.branch }}` (likely due to a bad merge or commit) and should be investigated immediately.
-    Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-    Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ repo.owner }}/{{ repo.name }}:{{ build.branch }}>
-    Author: <https://github.com/{{ build.author }}|{{ build.author }}>
-    <{{ build.link }}|Visit Drone build page ↗>
-  when:
-    status:
-    - failure
-services:
-- name: Start Docker
-  image: docker:dind
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: dockersock
-  temp: {}
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/push.go:59
-################################################
-
-kind: pipeline
-type: kubernetes
 name: push-build-linux-arm64
 environment:
   GID: "1000"
@@ -3484,7 +3386,7 @@ volumes:
 ---
 kind: pipeline
 type: kubernetes
-name: build-windows
+name: build-windows-amd64
 
 environment:
   RUNTIME: go1.15.5

--- a/.drone.yml
+++ b/.drone.yml
@@ -182,20 +182,20 @@ services:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: tmp-dind
-    path: /tmp
   - name: tmpfs
     path: /tmpfs
+  - name: tmp-dind
+    path: /tmp
 volumes:
 - name: dockersock
-  temp: {}
-- name: tmp-dind
-  temp: {}
-- name: tmp-integration
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+- name: tmp-dind
+  temp: {}
+- name: tmp-integration
+  temp: {}
 
 ---
 ################################################
@@ -4138,6 +4138,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: d085dedc5560b239c093eabe2c7f10139f8d7046e68ee2a9c89c2de23b4e1247
+hmac: 1d109a083ee2ec315c11984b75d1040a991456415cadf50df573e49b82de4aad
 
 ...

--- a/dronegen/build.go
+++ b/dronegen/build.go
@@ -1,6 +1,0 @@
-package main
-
-func buildPipelines() []pipeline {
-	// TODO: migrate
-	return nil
-}

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -10,6 +10,11 @@ var (
 		Branch: triggerRef{Include: []string{"master", "branch/*"}},
 		Repo:   triggerRef{Include: []string{"gravitational/*"}},
 	}
+	triggerTag = trigger{
+		Event: triggerRef{Include: []string{"tag"}},
+		Ref:   triggerRef{Include: []string{"refs/tags/v*"}},
+		Repo:  triggerRef{Include: []string{"gravitational/*"}},
+	}
 
 	volumeTmpfs = volume{
 		Name: "tmpfs",
@@ -20,27 +25,3 @@ var (
 		Path: "/tmpfs",
 	}
 )
-
-// buildCheckoutCommands builds a list of commands for Drone to check out a git commit
-func buildCheckoutCommands(fips bool) []string {
-	commands := []string{
-		`mkdir -p /go/src/github.com/gravitational/teleport /go/cache`,
-		`cd /go/src/github.com/gravitational/teleport`,
-		`git init && git remote add origin ${DRONE_REMOTE_URL}`,
-		`git fetch origin`,
-		`git checkout -qf ${DRONE_COMMIT_SHA}`,
-		// this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-		`git submodule update --init webassets || true`,
-		`mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa`,
-		`ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts`,
-		`git submodule update --init e`,
-		// do a recursive submodule checkout to get both webassets and webassets/e
-		// this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-		`git submodule update --init --recursive webassets || true`,
-		`rm -f /root/.ssh/id_rsa`,
-	}
-	if fips {
-		commands = append(commands, `if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt`)
-	}
-	return commands
-}

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -20,8 +20,17 @@ var (
 		Name: "tmpfs",
 		Temp: &volumeTemp{Medium: "memory"},
 	}
+	volumeDocker = volume{
+		Name: "dockersock",
+		Temp: &volumeTemp{},
+	}
+
 	volumeRefTmpfs = volumeRef{
 		Name: "tmpfs",
 		Path: "/tmpfs",
+	}
+	volumeRefDocker = volumeRef{
+		Name: "dockersock",
+		Path: "/var/run",
 	}
 )

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -16,21 +16,91 @@ var (
 		Repo:  triggerRef{Include: []string{"gravitational/*"}},
 	}
 
-	volumeTmpfs = volume{
-		Name: "tmpfs",
-		Temp: &volumeTemp{Medium: "memory"},
-	}
-	volumeDocker = volume{
-		Name: "dockersock",
-		Temp: &volumeTemp{},
-	}
-
-	volumeRefTmpfs = volumeRef{
-		Name: "tmpfs",
-		Path: "/tmpfs",
-	}
-	volumeRefDocker = volumeRef{
-		Name: "dockersock",
-		Path: "/var/run",
-	}
+	// TODO(gus): Set this from `make -C build.assets print-runtime-version` or similar rather
+	// than hardcoding it. Also remove the usage of RUNTIME as a pipeline-level environment variable
+	// (as support for these varies among Drone runners) and only set it for steps that need it.
+	goRuntime = value{raw: "go1.15.5"}
 )
+
+type buildType struct {
+	os      string
+	arch    string
+	fips    bool
+	centos6 bool
+}
+
+type extraVolumes struct {
+	tmpfs          bool
+	tmpDind        bool
+	tmpIntegration bool
+}
+
+// dockerService generates a docker:dind service and includes any extra volumes configured
+// in extraVolumes.
+func dockerService(v extraVolumes) service {
+	return service{
+		Name:    "Start Docker",
+		Image:   "docker:dind",
+		Volumes: volumeRefs(v),
+	}
+}
+
+// volumes generates a slice of volumes including the Docker socket by default,
+// plus any extra volumes configured in extraVolumes.
+func volumes(v extraVolumes) []volume {
+	volumes := []volume{
+		volume{
+			Name: "dockersock",
+			Temp: &volumeTemp{},
+		},
+	}
+	if v.tmpfs {
+		volumes = append(volumes, volume{
+			Name: "tmpfs",
+			Temp: &volumeTemp{Medium: "memory"},
+		})
+	}
+	if v.tmpDind {
+		volumes = append(volumes, volume{
+			Name: "tmp-dind",
+			Temp: &volumeTemp{},
+		})
+	}
+	if v.tmpIntegration {
+		volumes = append(volumes, volume{
+			Name: "tmp-integration",
+			Temp: &volumeTemp{},
+		})
+	}
+	return volumes
+}
+
+// volumeRefs generates a slice of volumeRefs including the Docker socket by default,
+// plus any extra volumes configured in extraVolumes.
+func volumeRefs(v extraVolumes) []volumeRef {
+	volumeRefs := []volumeRef{
+		volumeRef{
+			Name: "dockersock",
+			Path: "/var/run",
+		},
+	}
+	if v.tmpfs {
+		volumeRefs = append(volumeRefs, volumeRef{
+			Name: "tmpfs",
+			Path: "/tmpfs",
+		})
+	}
+	if v.tmpDind {
+		volumeRefs = append(volumeRefs, volumeRef{
+			Name: "tmp-dind",
+			Path: "/tmp",
+		})
+	}
+	if v.tmpIntegration {
+		volumeRefs = append(volumeRefs, volumeRef{
+			Name: "tmp-integration",
+			Path: "/tmp",
+		})
+	}
+	return volumeRefs
+}

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -16,6 +16,11 @@ var (
 		Repo:  triggerRef{Include: []string{"gravitational/*"}},
 	}
 
+	volumeRefTmpfs = volumeRef{
+		Name: "tmpfs",
+		Path: "/tmpfs",
+	}
+
 	// TODO(gus): Set this from `make -C build.assets print-runtime-version` or similar rather
 	// than hardcoding it. Also remove the usage of RUNTIME as a pipeline-level environment variable
 	// (as support for these varies among Drone runners) and only set it for steps that need it.

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -17,8 +17,8 @@ func main() {
 	var pipelines []pipeline
 
 	pipelines = append(pipelines, testPipelines()...)
-	pipelines = append(pipelines, buildPipelines()...)
 	pipelines = append(pipelines, pushPipelines()...)
+	pipelines = append(pipelines, tagPipelines()...)
 	pipelines = append(pipelines, cronPipelines()...)
 	pipelines = append(pipelines, promoteBuildPipeline())
 	pipelines = append(pipelines, updateDocsPipeline())

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -89,14 +89,14 @@ func pushPipeline(params pushBuildType) pipeline {
 	p.Trigger = triggerPush
 	p.Workspace = workspace{Path: "/go"}
 	p.Volumes = []volume{
-		{Name: "dockersock", Temp: &volumeTemp{}},
+		volumeDocker,
 	}
 	p.Services = []service{
 		{
 			Name:  "Start Docker",
 			Image: "docker:dind",
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 			},
 		},
 	}
@@ -117,7 +117,7 @@ func pushPipeline(params pushBuildType) pipeline {
 			Image:       "docker",
 			Environment: pushEnvironment,
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 			},
 			Commands: []string{
 				`apk add --no-cache make`,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -1,0 +1,373 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// rpmPackage is the RPM package type
+	rpmPackage = "rpm"
+	// debPackage is the DEB package type
+	debPackage = "deb"
+)
+
+type tagBuildType struct {
+	os      string
+	arch    string
+	fips    bool
+	centos6 bool
+}
+
+// tagMakefileTarget gets the correct tag pipeline Makefile target for a given arch/fips combo
+func tagMakefileTarget(params tagBuildType) string {
+	makefileTarget := fmt.Sprintf("release-%s", params.arch)
+	if params.centos6 {
+		makefileTarget += "-centos6"
+	}
+	if params.fips {
+		makefileTarget += "-fips"
+	}
+	return makefileTarget
+}
+
+// tagCheckoutCommands builds a list of commands for Drone to check out a git commit on a tag build
+func tagCheckoutCommands(fips bool) []string {
+	commands := []string{
+		`mkdir -p /go/src/github.com/gravitational/teleport`,
+		`cd /go/src/github.com/gravitational/teleport`,
+		`git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .`,
+		`git checkout ${DRONE_TAG:-$DRONE_COMMIT}`,
+		// fetch enterprise submodules
+		`mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa`,
+		`ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts`,
+		`git submodule update --init e`,
+		// this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+		`git submodule update --init --recursive webassets || true`,
+		`rm -f /root/.ssh/id_rsa`,
+		// create necessary directories
+		`mkdir -p /go/cache /go/artifacts/e`,
+		// set version
+		`if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt`,
+	}
+	return commands
+}
+
+// tagBuildCommands generates a list of commands for Drone to build an artifact as part of a tag build
+func tagBuildCommands(params tagBuildType) []string {
+	commands := []string{
+		`apk add --no-cache make`,
+		`chown -R $UID:$GID /go`,
+		`cd /go/src/github.com/gravitational/teleport`,
+	}
+	if params.fips {
+		commands = append(commands,
+			"export VERSION=$(cat /go/.version.txt)",
+			fmt.Sprintf(
+				`make -C build.assets %s VERSION=$VERSION OS=%s ARCH=%s FIPS=%s`, tagMakefileTarget(params), params.os, params.arch, "yes",
+			),
+		)
+	} else {
+		commands = append(commands,
+			fmt.Sprintf(
+				`make -C build.assets %s OS=%s ARCH=%s`, tagMakefileTarget(params), params.os, params.arch,
+			),
+		)
+	}
+	// we need to rename artifacts created for CentOS 6; these are the only kind where renaming is not handled inside the Makefile
+	if params.centos6 {
+		commands = append(commands,
+			// rename artifacts
+			`export VERSION=$(cat /go/.version.txt)`,
+			`mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-v$${VERSION}-linux-amd64-centos6-bin.tar.gz`,
+			`mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-bin.tar.gz`,
+		)
+	}
+	return commands
+}
+
+// tagPipelines builds all applicable tag pipeline combinations
+func tagPipelines() []pipeline {
+	var ps []pipeline
+	// regular tarball builds
+	for _, arch := range []string{"amd64", "386", "arm", "arm64"} {
+		for _, fips := range []bool{false, true} {
+			if (arch == "386" || arch == "arm") && fips {
+				// FIPS mode not supported on i386 or ARM
+				continue
+			}
+			ps = append(ps, tagPipeline(tagBuildType{os: "linux", arch: arch, fips: fips}))
+			// TODO(gus): support needs to be added upstream for building ARM/ARM64 packages first
+			// ps = append(ps, tagPackagePipeline(rpmPackage, tagBuildType{os: "linux", arch: arch, fips: fips}))
+			// ps = append(ps, tagPackagePipeline(debPackage, tagBuildType{os: "linux", arch: arch, fips: fips}))
+		}
+	}
+
+	// TODO(gus): needed until support is added upstream for building ARM/ARM64 packages
+	// Remove this section and uncomment above once this is added.
+	for _, arch := range []string{"amd64", "386"} {
+		for _, fips := range []bool{false, true} {
+			if (arch == "386" || arch == "arm") && fips {
+				// FIPS mode not supported on i386 or ARM
+				continue
+			}
+			ps = append(ps, tagPackagePipeline(rpmPackage, tagBuildType{os: "linux", arch: arch, fips: fips}))
+			ps = append(ps, tagPackagePipeline(debPackage, tagBuildType{os: "linux", arch: arch, fips: fips}))
+		}
+	}
+
+	// Only amd64 Windows is supported for now.
+	ps = append(ps, tagPipeline(tagBuildType{os: "windows", arch: "amd64"}))
+	return ps
+}
+
+// tagPipeline generates a tag pipeline for a given combination of os/arch/FIPS
+func tagPipeline(params tagBuildType) pipeline {
+	if params.os == "" {
+		panic("params.os must be set")
+	}
+	if params.arch == "" {
+		panic("params.arch must be set")
+	}
+
+	pipelineName := fmt.Sprintf("build-%s-%s", params.os, params.arch)
+	if params.centos6 {
+		pipelineName += "-centos6"
+	}
+	tagEnvironment := map[string]value{
+		"UID":    value{raw: "1000"},
+		"GID":    value{raw: "1000"},
+		"GOPATH": value{raw: "/go"},
+		"OS":     value{raw: params.os},
+		"ARCH":   value{raw: params.arch},
+	}
+	if params.fips {
+		pipelineName += "-fips"
+		tagEnvironment["FIPS"] = value{raw: "yes"}
+	}
+
+	p := newKubePipeline(pipelineName)
+	p.Environment = map[string]value{
+		"RUNTIME": value{raw: "go1.15.5"},
+	}
+	p.Trigger = triggerTag
+	p.Workspace = workspace{Path: "/go"}
+	p.Volumes = []volume{
+		{Name: "dockersock", Temp: &volumeTemp{}},
+	}
+	p.Services = []service{
+		{
+			Name:  "Start Docker",
+			Image: "docker:dind",
+			Volumes: []volumeRef{
+				{Name: "dockersock", Path: "/var/run"},
+			},
+		},
+	}
+	p.Steps = []step{
+		{
+			Name:  "Check out code",
+			Image: "docker:git",
+			Environment: map[string]value{
+				"GITHUB_PRIVATE_KEY": value{fromSecret: "GITHUB_PRIVATE_KEY"},
+			},
+			Commands: tagCheckoutCommands(params.fips),
+		},
+		{
+			Name:        "Build release artifacts",
+			Image:       "docker",
+			Environment: tagEnvironment,
+			Volumes: []volumeRef{
+				{Name: "dockersock", Path: "/var/run"},
+			},
+			Commands: tagBuildCommands(params),
+		},
+		{
+			Name:  "Copy artifacts",
+			Image: "docker",
+			Commands: []string{
+				`cd /go/src/github.com/gravitational/teleport`,
+				// copy release archives to artifact directory
+				`find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;`,
+				`find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;`,
+				// generate checksums
+				`cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l`,
+			},
+		},
+		{
+			Name:  "Upload to S3",
+			Image: "plugins/s3",
+			Settings: map[string]value{
+				"bucket":       value{fromSecret: "AWS_S3_BUCKET"},
+				"access_key":   value{fromSecret: "AWS_ACCESS_KEY_ID"},
+				"secret_key":   value{fromSecret: "AWS_SECRET_ACCESS_KEY"},
+				"region":       value{raw: "us-west-2"},
+				"source":       value{raw: "/go/artifacts/*"},
+				"target":       value{raw: "teleport/tag/${DRONE_TAG##v}"},
+				"strip_prefix": value{raw: "/go/artifacts"},
+			},
+		},
+	}
+	return p
+}
+
+// tagDownloadArtifactCommands generates a set of commands to download appropriate artifacts for creating a package as part of a tag build
+func tagDownloadArtifactCommands(params tagBuildType) []string {
+	commands := []string{
+		`export VERSION=$(cat /go/.version.txt)`,
+		`if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else export S3_PATH="tag/"; fi`,
+	}
+	artifactOSS := true
+	artifactEnterprise := true
+
+	artifactType := fmt.Sprintf("%s-%s", params.os, params.arch)
+	if params.fips {
+		artifactType += "-fips"
+		artifactOSS = false
+	}
+
+	if artifactOSS {
+		commands = append(commands,
+			fmt.Sprintf(`aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-%s-bin.tar.gz /go/artifacts/`, artifactType),
+		)
+	}
+	if artifactEnterprise {
+		commands = append(commands,
+			fmt.Sprintf(`aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-%s-bin.tar.gz /go/artifacts/`, artifactType),
+		)
+	}
+	return commands
+}
+
+// tagCopyArtifactCommands generates a set of commands to find and copy built package artifacts as part of a tag build
+func tagCopyArtifactCommands(params tagBuildType, packageType string) []string {
+	commands := []string{
+		`cd /go/src/github.com/gravitational/teleport`,
+	}
+	if !params.fips {
+		commands = append(commands, fmt.Sprintf(`find build -maxdepth 1 -iname "teleport*.%s*" -print -exec cp {} /go/artifacts \;`, packageType))
+	}
+	commands = append(commands, fmt.Sprintf(`find e/build -maxdepth 1 -iname "teleport*.%s*" -print -exec cp {} /go/artifacts \;`, packageType))
+	return commands
+}
+
+// tagPackagePipeline generates a tag package pipeline for a given combination of os/arch/FIPS
+func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
+	if packageType == "" {
+		panic("packageType must be set")
+	}
+	if params.os == "" {
+		panic("params.os must be set")
+	}
+	if params.arch == "" {
+		panic("params.arch must be set")
+	}
+
+	environment := map[string]value{
+		"ARCH":             value{raw: params.arch},
+		"TMPDIR":           value{raw: "/go"},
+		"ENT_TARBALL_PATH": value{raw: "/go/artifacts"},
+	}
+
+	dependentPipeline := fmt.Sprintf("build-%s-%s", params.os, params.arch)
+	packageBuildCommands := []string{
+		`apk add --no-cache bash curl gzip make tar`,
+		`cd /go/src/github.com/gravitational/teleport`,
+		`export VERSION=$(cat /go/.version.txt)`,
+	}
+
+	makeCommand := fmt.Sprintf("make %s", packageType)
+	if params.fips {
+		dependentPipeline += "-fips"
+		environment["FIPS"] = value{raw: "yes"}
+		environment["RUNTIME"] = value{raw: "fips"}
+		makeCommand = fmt.Sprintf("make -C e %s", packageType)
+	} else {
+		environment["OSS_TARBALL_PATH"] = value{raw: "/go/artifacts"}
+	}
+
+	if packageType == rpmPackage {
+		environment["GNUPG_DIR"] = value{raw: "/tmpfs/gnupg"}
+		environment["GPG_RPM_SIGNING_ARCHIVE"] = value{fromSecret: "GPG_RPM_SIGNING_ARCHIVE"}
+		packageBuildCommands = append(packageBuildCommands,
+			`mkdir -m0700 $GNUPG_DIR`,
+			`echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR`,
+			`chown -R root:root $GNUPG_DIR`,
+			makeCommand,
+			`rm -rf $GNUPG_DIR`,
+		)
+	} else if packageType == debPackage {
+		packageBuildCommands = append(packageBuildCommands,
+			makeCommand,
+		)
+	}
+
+	pipelineName := fmt.Sprintf("%s-%s", dependentPipeline, packageType)
+
+	p := newKubePipeline(pipelineName)
+	p.Trigger = triggerTag
+	p.DependsOn = []string{dependentPipeline}
+	p.Workspace = workspace{Path: "/go"}
+	p.Volumes = []volume{
+		{Name: "dockersock", Temp: &volumeTemp{}},
+		volumeTmpfs,
+	}
+	p.Services = []service{
+		{
+			Name:  "Start Docker",
+			Image: "docker:dind",
+			Volumes: []volumeRef{
+				{Name: "dockersock", Path: "/var/run"},
+			},
+		},
+	}
+	p.Steps = []step{
+		{
+			Name:  "Check out code",
+			Image: "docker:git",
+			Environment: map[string]value{
+				"GITHUB_PRIVATE_KEY": value{fromSecret: "GITHUB_PRIVATE_KEY"},
+			},
+			Commands: tagCheckoutCommands(params.fips),
+		},
+		{
+			Name:  "Download built tarball artifacts from S3",
+			Image: "amazon/aws-cli",
+			Environment: map[string]value{
+				"AWS_S3_BUCKET":         value{fromSecret: "AWS_S3_BUCKET"},
+				"AWS_ACCESS_KEY_ID":     value{fromSecret: "AWS_ACCESS_KEY_ID"},
+				"AWS_SECRET_ACCESS_KEY": value{fromSecret: "AWS_SECRET_ACCESS_KEY"},
+			},
+			Commands: tagDownloadArtifactCommands(params),
+		},
+		{
+			Name:        fmt.Sprintf("Build %s artifacts", strings.ToUpper(packageType)),
+			Image:       "docker",
+			Environment: environment,
+			Volumes: []volumeRef{
+				{Name: "dockersock", Path: "/var/run"},
+				volumeRefTmpfs,
+			},
+			Commands: packageBuildCommands,
+		},
+		{
+			Name:     fmt.Sprintf("Copy %s artifacts", strings.ToUpper(packageType)),
+			Image:    "docker",
+			Commands: tagCopyArtifactCommands(params, packageType),
+		},
+		{
+			Name:  "Upload to S3",
+			Image: "plugins/s3",
+			Settings: map[string]value{
+				"bucket":       value{fromSecret: "AWS_S3_BUCKET"},
+				"access_key":   value{fromSecret: "AWS_ACCESS_KEY_ID"},
+				"secret_key":   value{fromSecret: "AWS_SECRET_ACCESS_KEY"},
+				"region":       value{raw: "us-west-2"},
+				"source":       value{raw: "/go/artifacts/*"},
+				"target":       value{raw: "teleport/tag/${DRONE_TAG##v}"},
+				"strip_prefix": value{raw: "/go/artifacts"},
+			},
+		},
+	}
+	return p
+}

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -153,14 +153,14 @@ func tagPipeline(params tagBuildType) pipeline {
 	p.Trigger = triggerTag
 	p.Workspace = workspace{Path: "/go"}
 	p.Volumes = []volume{
-		{Name: "dockersock", Temp: &volumeTemp{}},
+		volumeDocker,
 	}
 	p.Services = []service{
 		{
 			Name:  "Start Docker",
 			Image: "docker:dind",
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 			},
 		},
 	}
@@ -178,7 +178,7 @@ func tagPipeline(params tagBuildType) pipeline {
 			Image:       "docker",
 			Environment: tagEnvironment,
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 			},
 			Commands: tagBuildCommands(params),
 		},
@@ -309,7 +309,7 @@ func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
 	p.DependsOn = []string{dependentPipeline}
 	p.Workspace = workspace{Path: "/go"}
 	p.Volumes = []volume{
-		{Name: "dockersock", Temp: &volumeTemp{}},
+		volumeDocker,
 		volumeTmpfs,
 	}
 	p.Services = []service{
@@ -317,7 +317,7 @@ func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
 			Name:  "Start Docker",
 			Image: "docker:dind",
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 			},
 		},
 	}
@@ -345,7 +345,7 @@ func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
 			Image:       "docker",
 			Environment: environment,
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 				volumeRefTmpfs,
 			},
 			Commands: packageBuildCommands,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -46,7 +46,7 @@ func tagCheckoutCommands(fips bool) []string {
 		`git submodule update --init --recursive webassets || true`,
 		`rm -f /root/.ssh/id_rsa`,
 		// create necessary directories
-		`mkdir -p /go/cache /go/artifacts/e`,
+		`mkdir -p /go/cache /go/artifacts`,
 		// set version
 		`if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt`,
 	}
@@ -83,6 +83,41 @@ func tagBuildCommands(params tagBuildType) []string {
 			`mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-bin.tar.gz`,
 		)
 	}
+	return commands
+}
+
+// tagCopyArtifactCommands generates a set of commands to find and copy built tarball artifacts as part of a tag build
+func tagCopyArtifactCommands(params tagBuildType) []string {
+	extension := ".tar.gz"
+	if params.os == "windows" {
+		extension = ".zip"
+	}
+
+	commands := []string{
+		`cd /go/src/github.com/gravitational/teleport`,
+	}
+
+	// don't copy OSS artifacts for FIPS builds
+	if !params.fips {
+		commands = append(commands,
+			fmt.Sprintf(`find . -maxdepth 1 -iname "teleport*%s" -print -exec cp {} /go/artifacts \;`, extension),
+		)
+	}
+
+	// copy enterprise artifacts
+	if params.os == "windows" {
+		commands = append(commands,
+			`export VERSION=$(cat /go/.version.txt)`,
+			`cp /go/artifacts/teleport-v$${VERSION}-windows-amd64-bin.zip /go/artifacts/teleport-ent-v$${VERSION}-windows-amd64-bin.zip`,
+		)
+	} else {
+		commands = append(commands,
+			`find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;`,
+		)
+	}
+
+	// generate checksums
+	commands = append(commands, fmt.Sprintf(`cd /go/artifacts && for FILE in teleport*%s; do sha256sum $FILE > $FILE.sha256; done && ls -l`, extension))
 	return commands
 }
 
@@ -183,16 +218,9 @@ func tagPipeline(params tagBuildType) pipeline {
 			Commands: tagBuildCommands(params),
 		},
 		{
-			Name:  "Copy artifacts",
-			Image: "docker",
-			Commands: []string{
-				`cd /go/src/github.com/gravitational/teleport`,
-				// copy release archives to artifact directory
-				`find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;`,
-				`find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts \;`,
-				// generate checksums
-				`cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256; done && ls -l`,
-			},
+			Name:     "Copy artifacts",
+			Image:    "docker",
+			Commands: tagCopyArtifactCommands(params),
 		},
 		{
 			Name:  "Upload to S3",
@@ -204,7 +232,7 @@ func tagPipeline(params tagBuildType) pipeline {
 				"region":       value{raw: "us-west-2"},
 				"source":       value{raw: "/go/artifacts/*"},
 				"target":       value{raw: "teleport/tag/${DRONE_TAG##v}"},
-				"strip_prefix": value{raw: "/go/artifacts"},
+				"strip_prefix": value{raw: "/go/artifacts/"},
 			},
 		},
 	}
@@ -239,8 +267,8 @@ func tagDownloadArtifactCommands(params tagBuildType) []string {
 	return commands
 }
 
-// tagCopyArtifactCommands generates a set of commands to find and copy built package artifacts as part of a tag build
-func tagCopyArtifactCommands(params tagBuildType, packageType string) []string {
+// tagCopyPackageArtifactCommands generates a set of commands to find and copy built package artifacts as part of a tag build
+func tagCopyPackageArtifactCommands(params tagBuildType, packageType string) []string {
 	commands := []string{
 		`cd /go/src/github.com/gravitational/teleport`,
 	}
@@ -286,6 +314,12 @@ func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
 		environment["OSS_TARBALL_PATH"] = value{raw: "/go/artifacts"}
 	}
 
+	tagVolumes := []volume{
+		volumeDocker,
+	}
+	tagVolumeRefs := []volumeRef{
+		volumeRefDocker,
+	}
 	if packageType == rpmPackage {
 		environment["GNUPG_DIR"] = value{raw: "/tmpfs/gnupg"}
 		environment["GPG_RPM_SIGNING_ARCHIVE"] = value{fromSecret: "GPG_RPM_SIGNING_ARCHIVE"}
@@ -296,6 +330,15 @@ func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
 			makeCommand,
 			`rm -rf $GNUPG_DIR`,
 		)
+		tagVolumes = []volume{
+			volumeDocker,
+			volumeTmpfs,
+		}
+		tagVolumeRefs = []volumeRef{
+			volumeRefDocker,
+			volumeRefTmpfs,
+		}
+
 	} else if packageType == debPackage {
 		packageBuildCommands = append(packageBuildCommands,
 			makeCommand,
@@ -308,17 +351,12 @@ func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
 	p.Trigger = triggerTag
 	p.DependsOn = []string{dependentPipeline}
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = []volume{
-		volumeDocker,
-		volumeTmpfs,
-	}
+	p.Volumes = tagVolumes
 	p.Services = []service{
 		{
-			Name:  "Start Docker",
-			Image: "docker:dind",
-			Volumes: []volumeRef{
-				volumeRefDocker,
-			},
+			Name:    "Start Docker",
+			Image:   "docker:dind",
+			Volumes: tagVolumeRefs,
 		},
 	}
 	p.Steps = []step{
@@ -334,6 +372,7 @@ func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
 			Name:  "Download built tarball artifacts from S3",
 			Image: "amazon/aws-cli",
 			Environment: map[string]value{
+				"AWS_REGION":            value{raw: "us-west-2"},
 				"AWS_S3_BUCKET":         value{fromSecret: "AWS_S3_BUCKET"},
 				"AWS_ACCESS_KEY_ID":     value{fromSecret: "AWS_ACCESS_KEY_ID"},
 				"AWS_SECRET_ACCESS_KEY": value{fromSecret: "AWS_SECRET_ACCESS_KEY"},
@@ -344,16 +383,13 @@ func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
 			Name:        fmt.Sprintf("Build %s artifacts", strings.ToUpper(packageType)),
 			Image:       "docker",
 			Environment: environment,
-			Volumes: []volumeRef{
-				volumeRefDocker,
-				volumeRefTmpfs,
-			},
-			Commands: packageBuildCommands,
+			Volumes:     tagVolumeRefs,
+			Commands:    packageBuildCommands,
 		},
 		{
 			Name:     fmt.Sprintf("Copy %s artifacts", strings.ToUpper(packageType)),
 			Image:    "docker",
-			Commands: tagCopyArtifactCommands(params, packageType),
+			Commands: tagCopyPackageArtifactCommands(params, packageType),
 		},
 		{
 			Name:  "Upload to S3",
@@ -365,7 +401,7 @@ func tagPackagePipeline(packageType string, params tagBuildType) pipeline {
 				"region":       value{raw: "us-west-2"},
 				"source":       value{raw: "/go/artifacts/*"},
 				"target":       value{raw: "teleport/tag/${DRONE_TAG##v}"},
-				"strip_prefix": value{raw: "/go/artifacts"},
+				"strip_prefix": value{raw: "/go/artifacts/"},
 			},
 		},
 	}

--- a/dronegen/tests.go
+++ b/dronegen/tests.go
@@ -1,15 +1,71 @@
 package main
 
-import "fmt"
-
 func testPipelines() []pipeline {
 	return []pipeline{
 		testCodePipeline(),
-		testDocsPipeline(false),
-		testDocsPipeline(true),
+		testDocsPipeline(),
 	}
 }
 
+// testCheckoutCommands returns a set of commands for checking out Teleport's code
+// Setting enterprise to true will also add a check against the Github API to determine whether
+// the pull request comes from a code fork (and will only check out Enterprise code if it does not)
+func testCheckoutCommands(enterprise bool) []string {
+	commands := []string{
+		`mkdir -p /tmpfs/go/src/github.com/gravitational/teleport /tmpfs/go/cache`,
+		`cd /tmpfs/go/src/github.com/gravitational/teleport`,
+		`git init && git remote add origin ${DRONE_REMOTE_URL}`,
+		`# handle pull requests
+if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
+  git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+  git checkout ${DRONE_COMMIT_BRANCH}
+  git fetch origin ${DRONE_COMMIT_REF}:
+  git merge ${DRONE_COMMIT}
+# handle tags
+elif [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
+  git fetch origin +refs/tags/${DRONE_TAG}:
+  git checkout -qf FETCH_HEAD
+# handle pushes/other events
+else
+  if [ "${DRONE_COMMIT_BRANCH}" = "" ]; then
+    git fetch origin
+    git checkout -qf ${DRONE_COMMIT_SHA}
+  else
+    git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
+    git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
+  fi
+fi
+`,
+	}
+	if enterprise {
+		commands = append(commands,
+			// this is allowed to fail because pre-4.3 Teleport versions
+			// don't use the webassets submodule.
+			`git submodule update --init webassets || true`,
+			// use the Github API to check whether this PR comes from a forked repo or not.
+			// if it does, don't check out the Enterprise code.
+			`if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
+  apk add --no-cache curl jq
+  export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/${DRONE_REPO_NAME}/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
+  echo "---> Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
+  # if the source repo for the PR matches DRONE_REPO, then this is not a PR raised from a fork
+  if [ "$${PR_REPO}" = "${DRONE_REPO}" ] || [ "${DRONE_REPO}" = "gravitational/teleport-private" ]; then
+    mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+    ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+    git submodule update --init e
+    # do a recursive submodule checkout to get both webassets and webassets/e
+    # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
+    git submodule update --init --recursive webassets || true
+    rm -f /root/.ssh/id_rsa
+  fi
+fi
+`,
+		)
+	}
+	return commands
+}
+
+// testCodePipeline returns a pipeline which runs the linter plus unit and integration tests
 func testCodePipeline() pipeline {
 	p := newKubePipeline("test")
 	p.Environment = map[string]value{
@@ -50,54 +106,7 @@ func testCodePipeline() pipeline {
 			Volumes: []volumeRef{
 				volumeRefTmpfs,
 			},
-			Commands: []string{
-				`mkdir -p /tmpfs/go/src/github.com/gravitational/teleport /tmpfs/go/cache`,
-				`cd /tmpfs/go/src/github.com/gravitational/teleport`,
-				`git init && git remote add origin ${DRONE_REMOTE_URL}`,
-				`# handle pull requests
-if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
-  git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
-  git checkout ${DRONE_COMMIT_BRANCH}
-  git fetch origin ${DRONE_COMMIT_REF}:
-  git merge ${DRONE_COMMIT}
-# handle tags
-elif [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
-  git fetch origin +refs/tags/${DRONE_TAG}:
-  git checkout -qf FETCH_HEAD
-# handle pushes/other events
-else
-  if [ "${DRONE_COMMIT_BRANCH}" = "" ]; then
-    git fetch origin
-    git checkout -qf ${DRONE_COMMIT_SHA}
-  else
-    git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
-    git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
-  fi
-fi
-`,
-				// this is allowed to fail because pre-4.3 Teleport versions
-				// don't use the webassets submodule.
-				`git submodule update --init webassets || true`,
-				// use the Github API to check whether this PR comes from a
-				// forked repo or not.
-				// if it does, don't check out the Enterprise code.
-				`if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
-  apk add --no-cache curl jq
-  export PR_REPO=$(curl -Ls https://api.github.com/repos/gravitational/${DRONE_REPO_NAME}/pulls/${DRONE_PULL_REQUEST} | jq -r '.head.repo.full_name')
-  echo "---> Source repo for PR ${DRONE_PULL_REQUEST}: $${PR_REPO}"
-  # if the source repo for the PR matches DRONE_REPO, then        this is not a PR raised from a fork
-  if [ "$${PR_REPO}" = "${DRONE_REPO}" ] || [ "${DRONE_REPO}" = "gravitational/teleport-private" ]; then
-    mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-    ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-    git submodule update --init e
-    # do a recursive submodule checkout to get both webassets and webassets/e
-    # this is allowed to fail because pre-4.3 Teleport versions don't use the webassets submodule
-    git submodule update --init --recursive webassets || true
-    rm -f /root/.ssh/id_rsa
-  fi
-fi
-`,
-			},
+			Commands: testCheckoutCommands(true),
 		},
 		{
 			Name:  "Build buildbox",
@@ -220,82 +229,61 @@ echo ""
 	return p
 }
 
-func testDocsPipeline(external bool) pipeline {
-	label := "internal"
-	milvFlag := "-ignore-external"
-	if external {
-		label = "external"
-		milvFlag = "-ignore-internal"
-	}
-	p := newKubePipeline(fmt.Sprintf("test-docs-%s", label))
+func testDocsPipeline() pipeline {
+	p := newKubePipeline("test-docs")
 	p.Trigger = triggerPullRequest
 	p.Workspace = workspace{Path: "/go"}
 	p.Volumes = []volume{
+		volumeDocker,
 		volumeTmpfs,
+	}
+	p.Services = []service{
+		{
+			Name:  "Start Docker",
+			Image: "docker:dind",
+			Volumes: []volumeRef{
+				volumeRefDocker,
+				volumeRefTmpfs,
+			},
+		},
 	}
 	p.Steps = []step{
 		{
 			Name:  "Check out code",
-			Image: "golang:1.15.5",
+			Image: "docker:git",
 			Volumes: []volumeRef{
 				volumeRefTmpfs,
 			},
-			Commands: []string{
-				`mkdir -p /tmpfs/go/src/github.com/gravitational/teleport`,
-				`cd /tmpfs/go/src/github.com/gravitational/teleport`,
-				`git init && git remote add origin ${DRONE_REMOTE_URL}`,
-				`# handle pull requests
-if [ "${DRONE_BUILD_EVENT}" = "pull_request" ]; then
-  git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
-  git checkout ${DRONE_COMMIT_BRANCH}
-  git fetch origin ${DRONE_COMMIT_REF}:
-  git merge ${DRONE_COMMIT}
-# handle tags
-elif [ "${DRONE_BUILD_EVENT}" = "tag" ]; then
-  git fetch origin +refs/tags/${DRONE_TAG}:
-  git checkout -qf FETCH_HEAD
-# handle pushes/other events
-else
-  if [ "${DRONE_COMMIT_BRANCH}" = "" ]; then
-    git fetch origin
-    git checkout -qf ${DRONE_COMMIT_SHA}
-  else
-    git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:
-    git checkout ${DRONE_COMMIT} -b ${DRONE_COMMIT_BRANCH}
-  fi
-fi
-`,
-			},
+			Commands: testCheckoutCommands(false),
 		},
 		{
-			Name:  fmt.Sprintf("Run docs tests (%s links only)", label),
-			Image: "golang:1.15.5",
+			Name:  "Run docs tests",
+			Image: "docker:git",
+			Environment: map[string]value{
+				"GOCACHE": value{raw: "/tmpfs/go/cache"},
+				"UID":     value{raw: "1000"},
+				"GID":     value{raw: "1000"},
+			},
 			Volumes: []volumeRef{
+				volumeRefDocker,
 				volumeRefTmpfs,
 			},
 			Commands: []string{
+				`apk add --no-cache make`,
 				`cd /tmpfs/go/src/github.com/gravitational/teleport`,
-				`git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | grep -v ^$ | cut -d/ -f2 | sort | uniq > /tmp/docs-versions-changed.txt`,
-				fmt.Sprintf(`if [ $(stat --printf="%%s" /tmp/docs-versions-changed.txt) -gt 0 ]; then
-  echo "---> Changes to docs detected, versions $(cat /tmp/docs-versions-changed.txt | tr '\n' ' ')"
-  # Check trailing whitespace
+				`chown -R $UID:$GID /tmpfs/go`,
+				`git diff --raw ${DRONE_COMMIT}..origin/${DRONE_COMMIT_BRANCH:-master} | awk '{print $6}' | grep -E '^docs' | { grep -v ^$ || true; } > /tmp/docs-changes.txt`,
+				`if [ $(cat /tmp/docs-changes.txt | wc -l) -gt 0 ]; then
+  echo "---> Changes to docs detected"
+  cat /tmp/docs-changes.txt
+  echo "---> Checking for trailing whitespace"
   make docs-test-whitespace
-  # Check links
-  for VERSION in $(cat /tmp/docs-versions-changed.txt); do
-    if [ -f docs/$VERSION/milv.config.yaml ]; then
-      go get github.com/magicmatatjahu/milv
-      cd docs/$VERSION
-      echo "---> Running milv on docs/$VERSION:"
-      milv %s
-      echo "------------------------------\n"
-      cd -
-    else
-      echo "---> No milv config found, skipping docs/$VERSION"
-    fi
-  done
-  else echo "---> No changes to docs detected, not running tests"
+  echo "---> Checking for dead links"
+  make -C build.assets test-docs
+else
+  echo "---> No changes to docs detected, not running tests"
 fi
-`, milvFlag),
+`,
 			},
 		},
 	}

--- a/dronegen/tests.go
+++ b/dronegen/tests.go
@@ -20,19 +20,19 @@ func testCodePipeline() pipeline {
 	p.Trigger = triggerPullRequest
 	p.Workspace = workspace{Path: "/go"}
 	p.Volumes = []volume{
-		{Name: "dockersock", Temp: &volumeTemp{}},
+		volumeDocker,
+		volumeTmpfs,
 		{Name: "tmp-dind", Temp: &volumeTemp{}},
 		{Name: "tmp-integration", Temp: &volumeTemp{}},
-		volumeTmpfs,
 	}
 	p.Services = []service{
 		{
 			Name:  "Start Docker",
 			Image: "docker:dind",
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
-				{Name: "tmp-dind", Path: "/tmp"},
+				volumeRefDocker,
 				volumeRefTmpfs,
+				{Name: "tmp-dind", Path: "/tmp"},
 			},
 		},
 	}
@@ -103,7 +103,7 @@ fi
 			Name:  "Build buildbox",
 			Image: "docker",
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 				volumeRefTmpfs,
 			},
 			Commands: []string{
@@ -119,7 +119,7 @@ fi
 			Image:       "docker",
 			Environment: goEnvironment,
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 				volumeRefTmpfs,
 			},
 			Commands: []string{
@@ -164,7 +164,7 @@ echo ""
 			Image:       "docker",
 			Environment: goEnvironment,
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 				volumeRefTmpfs,
 			},
 			Commands: []string{
@@ -181,7 +181,7 @@ echo ""
 			Image:       "docker",
 			Environment: goEnvironment,
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 				volumeRefTmpfs,
 				{Name: "tmp-integration", Path: "/tmp"},
 			},
@@ -202,7 +202,7 @@ echo ""
 				"TEST_KUBE":                 value{raw: "true"},
 			},
 			Volumes: []volumeRef{
-				{Name: "dockersock", Path: "/var/run"},
+				volumeRefDocker,
 				volumeRefTmpfs,
 				{Name: "tmp-integration", Path: "/tmp"},
 			},

--- a/dronegen/tests.go
+++ b/dronegen/tests.go
@@ -91,10 +91,7 @@ func testCodePipeline() pipeline {
 				"GITHUB_PRIVATE_KEY": value{fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
 			Volumes: []volumeRef{
-				volumeRef{
-					Name: "tmpfs",
-					Path: "/tmpfs",
-				},
+				volumeRefTmpfs,
 			},
 			Commands: testCheckoutCommands(true),
 		},
@@ -133,10 +130,7 @@ func testCodePipeline() pipeline {
 			Name:  "Optionally skip tests",
 			Image: "docker:git",
 			Volumes: []volumeRef{
-				volumeRef{
-					Name: "tmpfs",
-					Path: "/tmpfs",
-				},
+				volumeRefTmpfs,
 			},
 			Commands: []string{
 				`cd /tmpfs/go/src/github.com/gravitational/teleport
@@ -218,10 +212,7 @@ func testDocsPipeline() pipeline {
 			Name:  "Check out code",
 			Image: "docker:git",
 			Volumes: []volumeRef{
-				volumeRef{
-					Name: "tmpfs",
-					Path: "/tmpfs",
-				},
+				volumeRefTmpfs,
 			},
 			Commands: testCheckoutCommands(false),
 		},

--- a/dronegen/tests.go
+++ b/dronegen/tests.go
@@ -75,9 +75,9 @@ func testCodePipeline() pipeline {
 	}
 	p.Trigger = triggerPullRequest
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = volumes(extraVolumes{tmpfs: true, tmpDind: true, tmpIntegration: true})
+	p.Volumes = dockerVolumes(volumeTmpfs, volumeTmpDind, volumeTmpIntegration)
 	p.Services = []service{
-		dockerService(extraVolumes{tmpfs: true, tmpDind: true}),
+		dockerService(volumeRefTmpfs, volumeRefTmpDind),
 	}
 	goEnvironment := map[string]value{
 		"GOCACHE": value{raw: "/tmpfs/go/cache"},
@@ -98,7 +98,7 @@ func testCodePipeline() pipeline {
 		{
 			Name:    "Build buildbox",
 			Image:   "docker",
-			Volumes: volumeRefs(extraVolumes{tmpfs: true}),
+			Volumes: dockerVolumeRefs(volumeRefTmpfs),
 			Commands: []string{
 				`apk add --no-cache make`,
 				`chown -R $UID:$GID /tmpfs/go`,
@@ -111,7 +111,7 @@ func testCodePipeline() pipeline {
 			Name:        "Run linter",
 			Image:       "docker",
 			Environment: goEnvironment,
-			Volumes:     volumeRefs(extraVolumes{tmpfs: true}),
+			Volumes:     dockerVolumeRefs(volumeRefTmpfs),
 			Commands: []string{
 				`apk add --no-cache make`,
 				`chown -R $UID:$GID /tmpfs/go`,
@@ -153,7 +153,7 @@ echo ""
 			Name:        "Run unit and chaos tests",
 			Image:       "docker",
 			Environment: goEnvironment,
-			Volumes:     volumeRefs(extraVolumes{tmpfs: true}),
+			Volumes:     dockerVolumeRefs(volumeRefTmpfs),
 			Commands: []string{
 				`apk add --no-cache make`,
 				`chown -R $UID:$GID /tmpfs/go`,
@@ -167,7 +167,7 @@ echo ""
 			Name:        "Run root-only integration tests",
 			Image:       "docker",
 			Environment: goEnvironment,
-			Volumes:     volumeRefs(extraVolumes{tmpfs: true, tmpIntegration: true}),
+			Volumes:     dockerVolumeRefs(volumeRefTmpfs, volumeRefTmpIntegration),
 			Commands: []string{
 				`apk add --no-cache make`,
 				`cd /tmpfs/go/src/github.com/gravitational/teleport`,
@@ -184,7 +184,7 @@ echo ""
 				"KUBECONFIG":                value{raw: "/tmpfs/go/kubeconfig.ci"},
 				"TEST_KUBE":                 value{raw: "true"},
 			},
-			Volumes: volumeRefs(extraVolumes{tmpfs: true, tmpIntegration: true}),
+			Volumes: dockerVolumeRefs(volumeRefTmpfs, volumeRefTmpIntegration),
 			Commands: []string{
 				`apk add --no-cache make`,
 				// write kubeconfig to disk for use in kube integration tests
@@ -203,9 +203,9 @@ func testDocsPipeline() pipeline {
 	p := newKubePipeline("test-docs")
 	p.Trigger = triggerPullRequest
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = volumes(extraVolumes{tmpfs: true})
+	p.Volumes = dockerVolumes(volumeTmpfs)
 	p.Services = []service{
-		dockerService(extraVolumes{tmpfs: true}),
+		dockerService(volumeRefTmpfs),
 	}
 	p.Steps = []step{
 		{
@@ -224,7 +224,7 @@ func testDocsPipeline() pipeline {
 				"UID":     value{raw: "1000"},
 				"GID":     value{raw: "1000"},
 			},
-			Volumes: volumeRefs(extraVolumes{tmpfs: true}),
+			Volumes: dockerVolumeRefs(volumeRefTmpfs),
 			Commands: []string{
 				`apk add --no-cache make`,
 				`cd /tmpfs/go/src/github.com/gravitational/teleport`,


### PR DESCRIPTION
Implements tag builds using dronegen. Mostly just looking for style/flow comments.

`.drone.yml` diff has been validated using https://github.com/gravitational/teleport/commit/4beafe5bfdec77d107c28e4c04aaca8626a51c92
- Also renames `build.go` to `tag.go` to be a bit more descriptive.
- d5d9091 also contains the fixes to remove the old `test-docs-internal`/`test-docs-external` pipelines and implement the `test-docs` pipeline instead.
