### PR TITLE
Skip enumerating keys when cluster name is empty

### DIFF
--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -393,6 +393,9 @@ func (o withKubeCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error
 			key.KubeTLSCerts = make(map[string][]byte)
 		}
 		for _, fi := range kubeFiles {
+			if fi.IsDir() {
+				continue
+			}
 			data, err := ioutil.ReadFile(filepath.Join(kubeDir, fi.Name()))
 			if err != nil {
 				return trace.Wrap(err)
@@ -459,6 +462,9 @@ func (o withDBCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
 			key.DBTLSCerts = make(map[string][]byte)
 		}
 		for _, fi := range dbFiles {
+			if fi.IsDir() {
+				continue
+			}
 			data, err := ioutil.ReadFile(filepath.Join(dbDir, fi.Name()))
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -383,6 +383,16 @@ type withKubeCerts struct {
 func (o withKubeCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
 	switch s := store.(type) {
 	case *FSLocalKeyStore:
+		// If we are reading from a `~/.tsh` directrory made by a pre-6.0 version
+		// of `tsh`, the teleportClusterName can sometimes be empty, and we will
+		// end up enumerating the parent directory instead, and failing badly.
+		// For more info, see:
+		//    https://github.com/gravitational/teleport/issues/5774
+		if o.teleportClusterName == "" {
+			s.log.Warning("Empty teleport cluster name, abandoning key search.")
+			return nil
+		}
+
 		dirPath := s.dirFor(idx.proxyHost)
 		kubeDir := filepath.Join(dirPath, idx.username+kubeDirSuffix, o.teleportClusterName)
 		kubeFiles, err := ioutil.ReadDir(kubeDir)
@@ -393,9 +403,6 @@ func (o withKubeCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error
 			key.KubeTLSCerts = make(map[string][]byte)
 		}
 		for _, fi := range kubeFiles {
-			if fi.IsDir() {
-				continue
-			}
 			data, err := ioutil.ReadFile(filepath.Join(kubeDir, fi.Name()))
 			if err != nil {
 				return trace.Wrap(err)
@@ -452,6 +459,16 @@ type withDBCerts struct {
 func (o withDBCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
 	switch s := store.(type) {
 	case *FSLocalKeyStore:
+		// If we are reading from a `~/.tsh` directrory made by a pre-6.0 version
+		// of `tsh`, the teleportClusterName can sometimes be empty, and we will
+		// end up enumerating the parent directory instead, and failing badly.
+		// For more info, see:
+		//    https://github.com/gravitational/teleport/issues/5774
+		if o.teleportClusterName == "" {
+			s.log.Warning("Empty teleport cluster name, abandoning key search.")
+			return nil
+		}
+
 		dirPath := s.dirFor(idx.proxyHost)
 		dbDir := filepath.Join(dirPath, idx.username+dbDirSuffix, o.teleportClusterName)
 		dbFiles, err := ioutil.ReadDir(dbDir)
@@ -462,9 +479,6 @@ func (o withDBCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
 			key.DBTLSCerts = make(map[string][]byte)
 		}
 		for _, fi := range dbFiles {
-			if fi.IsDir() {
-				continue
-			}
 			data, err := ioutil.ReadFile(filepath.Join(dbDir, fi.Name()))
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -91,13 +91,12 @@ func TestEmbeddedDirsInKeystoreIsNotAnError(t *testing.T) {
 	require.NoError(t, s.addKey(host, user, key))
 
 	// ... *and* an invalid folder injected into it
-	p, err := s.store.dirFor(host, false)
-	require.NoError(t, err)
+	p := s.store.dirFor(host)
 	spuriousDirPath := path.Join(p, user+"-db", "root", "aaa-should-not-be-here")
 	require.NoError(t, os.MkdirAll(spuriousDirPath, 0700))
 
 	// When I attempt to enumerate the DB keys
-	_, err = s.store.GetKey(host, user, WithDBCerts(key.ClusterName, ""))
+	_, err := s.store.GetKey(host, user, WithDBCerts(key.ClusterName, ""))
 
 	// Expect the key enumeration to succeed
 	require.NoError(t, err)

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -89,12 +89,13 @@ func TestEmptyTeleportClusterNameIsNotAnError(t *testing.T) {
 	key := s.makeSignedKey(t, false)
 	require.NoError(t, s.addKey(host, user, key))
 
-	// When I attempt to enumerate the DB keys with an empty teleport
+	// When I attempt to enumerate the user's keys with an empty teleport
 	// cluster name
-	_, err := s.store.GetKey(host, user, WithDBCerts("", ""))
+	k, err := s.store.GetKey(host, user, WithDBCerts("", ""), WithKubeCerts(""))
 
 	// Expect the key enumeration to succeed
 	require.NoError(t, err)
+	require.NotNil(t, k)
 }
 
 func TestKeyCRUD(t *testing.T) {

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -96,7 +96,7 @@ func TestEmbeddedDirsInKeystoreIsNotAnError(t *testing.T) {
 	spuriousDirPath := path.Join(p, user+"-db", "root", "aaa-should-not-be-here")
 	require.NoError(t, os.MkdirAll(spuriousDirPath, 0700))
 
-	// When I attemp to enumerate the DB keys
+	// When I attempt to enumerate the DB keys
 	_, err = s.store.GetKey(host, user, WithDBCerts(key.ClusterName, ""))
 
 	// Expect the key enumeration to succeed

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"testing"
 	"time"
 
@@ -80,7 +79,7 @@ func TestListKeys(t *testing.T) {
 	require.Equal(t, samKey.Pub, skey.Pub)
 }
 
-func TestEmbeddedDirsInKeystoreIsNotAnError(t *testing.T) {
+func TestEmptyTeleportClusterNameIsNotAnError(t *testing.T) {
 	s, cleanup := newTest(t)
 	defer cleanup()
 
@@ -90,13 +89,9 @@ func TestEmbeddedDirsInKeystoreIsNotAnError(t *testing.T) {
 	key := s.makeSignedKey(t, false)
 	require.NoError(t, s.addKey(host, user, key))
 
-	// ... *and* an invalid folder injected into it
-	p := s.store.dirFor(host)
-	spuriousDirPath := path.Join(p, user+"-db", "root", "aaa-should-not-be-here")
-	require.NoError(t, os.MkdirAll(spuriousDirPath, 0700))
-
-	// When I attempt to enumerate the DB keys
-	_, err := s.store.GetKey(host, user, WithDBCerts(key.ClusterName, ""))
+	// When I attempt to enumerate the DB keys with an empty teleport
+	// cluster name
+	_, err := s.store.GetKey(host, user, WithDBCerts("", ""))
 
 	// Expect the key enumeration to succeed
 	require.NoError(t, err)


### PR DESCRIPTION
Addresses Issue #5774

Prior to this change key enumeration could fail with an error if the `cluster` value in the `tsh` config was missing, which is possible when a post-v6.0 `tsh` reads a `~/.tsh` directory created by a pre-v6.0 `tsh`. This would ultimately cause the key enumeration code to search the wrong directory for keys, resulting in an attempt to read a directory as a key file, and failing.

This patch adds detection for an empty cluster name, and aborts the key enumeration without error if found. 