### PR TITLE
Creates preset roles

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -556,8 +556,22 @@ const SCP = "scp"
 const Root = "root"
 
 // AdminRoleName is the name of the default admin role for all local users if
-// another role is not explicitly assigned (Enterprise only).
+// another role is not explicitly assigned
 const AdminRoleName = "admin"
+
+const (
+	// PresetEditorRoleName is a name of a preset role that allows
+	// editing cluster configuration.
+	PresetEditorRoleName = "editor"
+
+	// PresetAccessRoleName is a name of a preset role that allows
+	// accessing cluster resources.
+	PresetAccessRoleName = "access"
+
+	// PresetAuditorRoleName is a name of a preset role that allows
+	// reading cluster events and playing back session records.
+	PresetAuditorRoleName = "auditor"
+)
 
 // OSSMigratedV6 is a label to mark migrated OSS users and resources
 const OSSMigratedV6 = "migrate-v6.0"

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -114,7 +114,7 @@ SSH hosts as any of the principals `root`, `ubuntu` or `ec2-user`.
 
 ```bash
 # tctl is an administrative tool that is used to configure Teleport's auth service.
-sudo tctl users add teleport-admin root,ubuntu,ec2-user
+sudo tctl users add teleport-admin --roles=editor,access --logins=root,ubuntu,ec2-user
 ```
 
 Teleport will always enforce the use of 2-factor authentication by default. It supports one-time

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -467,6 +467,12 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	// Create presets - convenience and example resources.
+	err = createPresets(ctx, asrv)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if !cfg.SkipPeriodicOperations {
 		log.Infof("Auth server is running periodic operations.")
 		go asrv.runPeriodicOperations()
@@ -497,6 +503,23 @@ func migrateLegacyResources(ctx context.Context, cfg InitConfig, asrv *Server) e
 		return trace.Wrap(err)
 	}
 
+	return nil
+}
+
+// createPresets creates preset resources - roles
+func createPresets(ctx context.Context, asrv *Server) error {
+	roles := []services.Role{
+		services.NewPresetEditorRole(),
+		services.NewPresetAccessRole(),
+		services.NewPresetAuditorRole()}
+	for _, role := range roles {
+		err := asrv.CreateRole(role)
+		if err != nil {
+			if !trace.IsAlreadyExists(err) {
+				return trace.Wrap(err, "failed to create preset role")
+			}
+		}
+	}
 	return nil
 }
 

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"github.com/gravitational/teleport"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/pborman/uuid"
+)
+
+// NewPresetEditorRole returuns new pre-defined role for cluster
+// editors who can edit cluster configuration resources.
+func NewPresetEditorRole() Role {
+	role := &RoleV3{
+		Kind:    KindRole,
+		Version: V3,
+		Metadata: Metadata{
+			Name:        teleport.PresetEditorRoleName,
+			Namespace:   defaults.Namespace,
+			Description: "Edit cluster configuration",
+		},
+		Spec: RoleSpecV3{
+			Options: RoleOptions{
+				CertificateFormat: teleport.CertificateFormatStandard,
+				MaxSessionTTL:     NewDuration(defaults.MaxCertDuration),
+				PortForwarding:    NewBoolOption(true),
+				ForwardAgent:      NewBool(true),
+				BPF:               defaults.EnhancedEvents(),
+			},
+			Allow: RoleConditions{
+				Namespaces: []string{defaults.Namespace},
+				Rules: []Rule{
+					NewRule(KindUser, RW()),
+					NewRule(KindRole, RW()),
+					NewRule(KindOIDC, RW()),
+					NewRule(KindSAML, RW()),
+					NewRule(KindGithub, RW()),
+					NewRule(KindClusterAuthPreference, RW()),
+					NewRule(KindClusterConfig, RW()),
+					NewRule(KindTrustedCluster, RW()),
+					NewRule(KindRemoteCluster, RW()),
+				},
+			},
+		},
+	}
+	return role
+}
+
+// NewPresetAccessRole creates a role for users who are allowed to initiate
+// interactive sessions.
+func NewPresetAccessRole() Role {
+	role := &RoleV3{
+		Kind:    KindRole,
+		Version: V3,
+		Metadata: Metadata{
+			Name:        teleport.PresetAccessRoleName,
+			Namespace:   defaults.Namespace,
+			Description: "Access cluster resources",
+		},
+		Spec: RoleSpecV3{
+			Options: RoleOptions{
+				CertificateFormat: teleport.CertificateFormatStandard,
+				MaxSessionTTL:     NewDuration(defaults.MaxCertDuration),
+				PortForwarding:    NewBoolOption(true),
+				ForwardAgent:      NewBool(true),
+				BPF:               defaults.EnhancedEvents(),
+			},
+			Allow: RoleConditions{
+				Namespaces:       []string{defaults.Namespace},
+				NodeLabels:       Labels{Wildcard: []string{Wildcard}},
+				AppLabels:        Labels{Wildcard: []string{Wildcard}},
+				KubernetesLabels: Labels{Wildcard: []string{Wildcard}},
+				DatabaseLabels:   Labels{Wildcard: []string{Wildcard}},
+				DatabaseNames:    []string{teleport.TraitInternalDBNamesVariable},
+				DatabaseUsers:    []string{teleport.TraitInternalDBUsersVariable},
+				Rules: []Rule{
+					NewRule(KindEvent, RO()),
+				},
+			},
+		},
+	}
+	role.SetLogins(Allow, []string{teleport.TraitInternalLoginsVariable})
+	role.SetKubeUsers(Allow, []string{teleport.TraitInternalKubeUsersVariable})
+	role.SetKubeGroups(Allow, []string{teleport.TraitInternalKubeGroupsVariable})
+	return role
+}
+
+// NewPresetAuditorRole returuns new pre-defined role for cluster
+// auditor - someone who can review cluster events and replay sessions,
+// but can't initiate interactive sessions or modify configuration.
+func NewPresetAuditorRole() Role {
+	role := &RoleV3{
+		Kind:    KindRole,
+		Version: V3,
+		Metadata: Metadata{
+			Name:        teleport.PresetAuditorRoleName,
+			Namespace:   defaults.Namespace,
+			Description: "Review cluster events and replay sessions",
+		},
+		Spec: RoleSpecV3{
+			Options: RoleOptions{
+				CertificateFormat: teleport.CertificateFormatStandard,
+				MaxSessionTTL:     NewDuration(defaults.MaxCertDuration),
+			},
+			Allow: RoleConditions{
+				Namespaces: []string{defaults.Namespace},
+				Rules: []Rule{
+					NewRule(KindSession, RO()),
+					NewRule(KindEvent, RO()),
+				},
+			},
+			Deny: RoleConditions{
+				Namespaces:       []string{Wildcard},
+				NodeLabels:       Labels{Wildcard: []string{Wildcard}},
+				AppLabels:        Labels{Wildcard: []string{Wildcard}},
+				KubernetesLabels: Labels{Wildcard: []string{Wildcard}},
+				DatabaseLabels:   Labels{Wildcard: []string{Wildcard}},
+			},
+		},
+	}
+	role.SetLogins(Allow, []string{"no-login-" + uuid.New()})
+	return role
+}


### PR DESCRIPTION
Fixes #5917

Preset roles are helpful for users
who are getting started with teleport.

This commit introduces auditor, editor and access roles.
These roles will get created by the system if they don't
exist, but won't be updated if they already exist.