### PR TITLE
Move redirects to docs config for branch/v6

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -147,5 +147,17 @@
       "latest_oss_docker_image": "quay.io/gravitational/teleport:6",
       "latest_ent_docker_image": "quay.io/gravitational/teleport-ent:6"
     }
-  }
+  },
+  "redirects": [
+    {
+      "source": "/quickstart/",
+      "destination": "/getting-started/",
+      "permanent": true
+    },
+    {
+      "source": "/kubernetes-ssh/",
+      "destination": "/kubernetes-access/",
+      "permanent": true
+    }
+  ]
 }


### PR DESCRIPTION
Move redirects from the docs engine to docs. Closes this 2 issues:

- https://github.com/gravitational/next/issues/117
- https://github.com/gravitational/next/issues/135