### PR TITLE
Validation Consistency and Loop Hole Fix

### DIFF
--- a/api/types/clusterconfig.go
+++ b/api/types/clusterconfig.go
@@ -106,20 +106,11 @@ type ClusterConfig interface {
 
 // NewClusterConfig is a convenience wrapper to create a ClusterConfig resource.
 func NewClusterConfig(spec ClusterConfigSpecV3) (ClusterConfig, error) {
-	cc := ClusterConfigV3{
-		Kind:    KindClusterConfig,
-		Version: V3,
-		Metadata: Metadata{
-			Name:      MetaNameClusterConfig,
-			Namespace: defaults.Namespace,
-		},
-		Spec: spec,
-	}
+	cc := &ClusterConfigV3{Spec: spec}
 	if err := cc.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return &cc, nil
+	return cc, nil
 }
 
 // GetVersion returns resource version
@@ -288,9 +279,16 @@ func (c *ClusterConfigV3) SetLocalAuth(b bool) {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults.
 func (c *ClusterConfigV3) CheckAndSetDefaults() error {
+	c.Version = V3
+	if c.Kind == "" {
+		c.Kind = KindClusterConfig
+	}
+	if c.Metadata.Name == "" {
+		c.Metadata.Name = MetaNameClusterConfig
+	}
+
 	// make sure we have defaults for all metadata fields
-	err := c.Metadata.CheckAndSetDefaults()
-	if err != nil {
+	if err := c.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/api/types/clustername.go
+++ b/api/types/clustername.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
-
 	"github.com/gravitational/trace"
 )
 
@@ -42,19 +40,10 @@ type ClusterName interface {
 
 // NewClusterName is a convenience wrapper to create a ClusterName resource.
 func NewClusterName(spec ClusterNameSpecV2) (ClusterName, error) {
-	cn := ClusterNameV2{
-		Kind:    KindClusterName,
-		Version: V2,
-		Metadata: Metadata{
-			Name:      MetaNameClusterName,
-			Namespace: defaults.Namespace,
-		},
-		Spec: spec,
-	}
+	cn := ClusterNameV2{Spec: spec}
 	if err := cn.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	return &cn, nil
 }
 
@@ -132,9 +121,16 @@ func (c *ClusterNameV2) GetClusterName() string {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults.
 func (c *ClusterNameV2) CheckAndSetDefaults() error {
+	c.Version = V2
+	if c.Kind == "" {
+		c.Kind = KindClusterName
+	}
+	if c.Metadata.Name == "" {
+		c.Metadata.Name = MetaNameClusterName
+	}
+
 	// make sure we have defaults for all metadata fields
-	err := c.Metadata.CheckAndSetDefaults()
-	if err != nil {
+	if err := c.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/api/types/databaseserver.go
+++ b/api/types/databaseserver.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
 )
@@ -77,17 +75,18 @@ type DatabaseServer interface {
 }
 
 // NewDatabaseServerV3 creates a new database server instance.
-func NewDatabaseServerV3(name string, labels map[string]string, spec DatabaseServerSpecV3) *DatabaseServerV3 {
-	return &DatabaseServerV3{
-		Kind:    KindDatabaseServer,
-		Version: V3,
+func NewDatabaseServerV3(name string, labels map[string]string, spec DatabaseServerSpecV3) (*DatabaseServerV3, error) {
+	s := &DatabaseServerV3{
 		Metadata: Metadata{
-			Name:      name,
-			Namespace: defaults.Namespace,
-			Labels:    labels,
+			Name:   name,
+			Labels: labels,
 		},
 		Spec: spec,
 	}
+	if err := s.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return s, nil
 }
 
 // GetVersion returns the database server resource version.
@@ -261,12 +260,15 @@ func (s *DatabaseServerV3) String() string {
 
 // CheckAndSetDefaults checks and sets default values for any missing fields.
 func (s *DatabaseServerV3) CheckAndSetDefaults() error {
+	s.Version = V3
+	if s.Kind == "" {
+		s.Kind = KindDatabaseServer
+	}
+
 	if err := s.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
-	if s.Kind == "" {
-		return trace.BadParameter("database server %q kind is empty", s.GetName())
-	}
+
 	for key := range s.Spec.DynamicLabels {
 		if !IsValidLabelKey(key) {
 			return trace.BadParameter("database server %q invalid label key: %q", s.GetName(), key)

--- a/api/types/github.go
+++ b/api/types/github.go
@@ -19,7 +19,6 @@ package types
 import (
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/utils"
 
 	"github.com/gravitational/trace"
@@ -59,16 +58,17 @@ type GithubConnector interface {
 }
 
 // NewGithubConnector creates a new Github connector from name and spec
-func NewGithubConnector(name string, spec GithubConnectorSpecV3) GithubConnector {
-	return &GithubConnectorV3{
-		Kind:    KindGithubConnector,
-		Version: V3,
+func NewGithubConnector(name string, spec GithubConnectorSpecV3) (GithubConnector, error) {
+	c := &GithubConnectorV3{
 		Metadata: Metadata{
-			Name:      name,
-			Namespace: defaults.Namespace,
+			Name: name,
 		},
 		Spec: spec,
 	}
+	if err := c.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return c, nil
 }
 
 // GithubConnectorV3 represents a Github connector
@@ -201,6 +201,11 @@ func (c *GithubConnectorV3) WithoutSecrets() Resource {
 
 // CheckAndSetDefaults verifies the connector is valid and sets some defaults
 func (c *GithubConnectorV3) CheckAndSetDefaults() error {
+	c.Version = V3
+	if c.Kind == "" {
+		c.Kind = KindGithubConnector
+	}
+
 	if err := c.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/api/types/license.go
+++ b/api/types/license.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/trace"
 )
 
 // License defines teleport License Information
@@ -79,15 +79,16 @@ type License interface {
 
 // NewLicense is a convenience method to to create LicenseV3.
 func NewLicense(name string, spec LicenseSpecV3) (License, error) {
-	return &LicenseV3{
-		Kind:    KindLicense,
-		Version: V3,
+	license := &LicenseV3{
 		Metadata: Metadata{
-			Name:      name,
-			Namespace: defaults.Namespace,
+			Name: name,
 		},
 		Spec: spec,
-	}, nil
+	}
+	if err := license.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return license, nil
 }
 
 // LicenseV3 represents License resource version V3
@@ -203,6 +204,10 @@ func (c *LicenseV3) SetReportsUsage(reports Bool) {
 
 // CheckAndSetDefaults verifies the constraints for License.
 func (c *LicenseV3) CheckAndSetDefaults() error {
+	c.Version = V3
+	if c.Kind == "" {
+		c.Kind = KindLicense
+	}
 	return c.Metadata.CheckAndSetDefaults()
 }
 

--- a/api/types/namespace.go
+++ b/api/types/namespace.go
@@ -24,21 +24,29 @@ import (
 )
 
 // NewNamespace returns new namespace
-func NewNamespace(name string) Namespace {
-	return Namespace{
-		Kind:    KindNamespace,
-		Version: V2,
+func NewNamespace(name string) (Namespace, error) {
+	n := Namespace{
 		Metadata: Metadata{
 			Name: name,
 		},
 	}
+	if err := n.CheckAndSetDefaults(); err != nil {
+		return Namespace{}, trace.Wrap(err)
+	}
+	return n, nil
 }
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults
 func (n *Namespace) CheckAndSetDefaults() error {
+	n.Version = V2
+	if n.Kind == "" {
+		n.Kind = KindNamespace
+	}
+
 	if err := n.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+
 	isValid := IsValidNamespace(n.Metadata.Name)
 	if !isValid {
 		return trace.BadParameter("namespace %q is invalid", n.Metadata.Name)

--- a/api/types/plugin_data.go
+++ b/api/types/plugin_data.go
@@ -45,8 +45,6 @@ type PluginData interface {
 // name of an access request).
 func NewPluginData(resourceName string, resourceKind string) (PluginData, error) {
 	data := PluginDataV3{
-		Kind:    KindPluginData,
-		Version: V3,
 		// If additional resource kinds become supported, make
 		// this a parameter.
 		SubKind: resourceKind,
@@ -131,9 +129,15 @@ func (r *PluginDataV3) String() string {
 
 // CheckAndSetDefaults checks and sets default values for PluginData.
 func (r *PluginDataV3) CheckAndSetDefaults() error {
+	r.Version = V3
+	if r.Kind == "" {
+		r.Kind = KindPluginData
+	}
+
 	if err := r.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
+
 	if r.SubKind == "" {
 		return trace.BadParameter("plugin data missing subkind")
 	}

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -47,12 +47,9 @@ type ProvisionToken interface {
 // NewProvisionToken returns a new instance of provision token resource
 func NewProvisionToken(token string, roles SystemRoles, expires time.Time) (ProvisionToken, error) {
 	t := &ProvisionTokenV2{
-		Kind:    KindToken,
-		Version: V2,
 		Metadata: Metadata{
-			Name:      token,
-			Expires:   &expires,
-			Namespace: defaults.Namespace,
+			Name:    token,
+			Expires: &expires,
 		},
 		Spec: ProvisionTokenSpecV2{
 			Roles: roles,
@@ -76,7 +73,11 @@ func MustCreateProvisionToken(token string, roles SystemRoles, expires time.Time
 
 // CheckAndSetDefaults checks and set default values for any missing fields.
 func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
-	p.Kind = KindToken
+	p.Version = V2
+	if p.Kind == "" {
+		p.Kind = KindToken
+	}
+
 	err := p.Metadata.CheckAndSetDefaults()
 	if err != nil {
 		return trace.Wrap(err)

--- a/api/types/remotecluster.go
+++ b/api/types/remotecluster.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/trace"
 )
 
 // RemoteCluster represents a remote cluster that has connected via reverse tunnel
@@ -47,14 +47,15 @@ type RemoteCluster interface {
 
 // NewRemoteCluster is a convenience way to create a RemoteCluster resource.
 func NewRemoteCluster(name string) (RemoteCluster, error) {
-	return &RemoteClusterV3{
-		Kind:    KindRemoteCluster,
-		Version: V3,
+	rc := &RemoteClusterV3{
 		Metadata: Metadata{
-			Name:      name,
-			Namespace: defaults.Namespace,
+			Name: name,
 		},
-	}, nil
+	}
+	if err := rc.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return rc, nil
 }
 
 // GetVersion returns resource version
@@ -89,6 +90,10 @@ func (c *RemoteClusterV3) SetResourceID(id int64) {
 
 // CheckAndSetDefaults checks and sets default values
 func (c *RemoteClusterV3) CheckAndSetDefaults() error {
+	c.Version = V3
+	if c.Kind == "" {
+		c.Kind = KindRemoteCluster
+	}
 	return c.Metadata.CheckAndSetDefaults()
 }
 

--- a/api/types/resetpasswordtoken.go
+++ b/api/types/resetpasswordtoken.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/trace"
 )
 
 // ResetPasswordToken represents a temporary token used to reset passwords
@@ -44,15 +44,16 @@ type ResetPasswordToken interface {
 }
 
 // NewResetPasswordToken creates an instance of ResetPasswordToken.
-func NewResetPasswordToken(tokenID string) ResetPasswordToken {
-	return &ResetPasswordTokenV3{
-		Kind:    KindResetPasswordToken,
-		Version: V3,
+func NewResetPasswordToken(tokenID string) (ResetPasswordToken, error) {
+	t := &ResetPasswordTokenV3{
 		Metadata: Metadata{
-			Name:      tokenID,
-			Namespace: defaults.Namespace,
+			Name: tokenID,
 		},
 	}
+	if err := t.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return t, nil
 }
 
 // GetName returns Name
@@ -149,6 +150,10 @@ func (u *ResetPasswordTokenV3) SetSubKind(s string) {
 
 // CheckAndSetDefaults checks and set default values for any missing fields.
 func (u ResetPasswordTokenV3) CheckAndSetDefaults() error {
+	u.Version = V3
+	if u.Kind == "" {
+		u.Kind = KindResetPasswordToken
+	}
 	return u.Metadata.CheckAndSetDefaults()
 }
 

--- a/api/types/resetpasswordtokensecrets.go
+++ b/api/types/resetpasswordtokensecrets.go
@@ -45,20 +45,15 @@ type ResetPasswordTokenSecrets interface {
 
 // NewResetPasswordTokenSecrets creates an instance of ResetPasswordTokenSecrets.
 func NewResetPasswordTokenSecrets(tokenID string) (ResetPasswordTokenSecrets, error) {
-	secrets := ResetPasswordTokenSecretsV3{
-		Kind:    KindResetPasswordTokenSecrets,
-		Version: V3,
+	secrets := &ResetPasswordTokenSecretsV3{
 		Metadata: Metadata{
 			Name: tokenID,
 		},
 	}
-
-	err := secrets.CheckAndSetDefaults()
-	if err != nil {
-		return &ResetPasswordTokenSecretsV3{}, trace.Wrap(err)
+	if err := secrets.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
 	}
-
-	return &secrets, nil
+	return secrets, nil
 }
 
 // GetName returns Name
@@ -155,6 +150,10 @@ func (u *ResetPasswordTokenSecretsV3) SetSubKind(s string) {
 
 // CheckAndSetDefaults checks and set default values for any missing fields.
 func (u ResetPasswordTokenSecretsV3) CheckAndSetDefaults() error {
+	u.Version = V3
+	if u.Kind == "" {
+		u.Kind = KindResetPasswordTokenSecrets
+	}
 	return u.Metadata.CheckAndSetDefaults()
 }
 

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -115,20 +115,16 @@ type Role interface {
 
 // NewRole constructs new standard role
 func NewRole(name string, spec RoleSpecV3) (Role, error) {
-	role := RoleV3{
-		Kind:    KindRole,
-		Version: V3,
+	role := &RoleV3{
 		Metadata: Metadata{
-			Name:      name,
-			Namespace: defaults.Namespace,
+			Name: name,
 		},
 		Spec: spec,
 	}
 	if err := role.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	return &role, nil
+	return role, nil
 }
 
 // RoleConditionType specifies if it's an allow rule (true) or deny rule (false).
@@ -493,6 +489,11 @@ func (r *RoleV3) SetRules(rct RoleConditionType, in []Rule) {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults
 func (r *RoleV3) CheckAndSetDefaults() error {
+	r.Version = V3
+	if r.Kind == "" {
+		r.Kind = KindRole
+	}
+
 	err := r.Metadata.CheckAndSetDefaults()
 	if err != nil {
 		return trace.Wrap(err)

--- a/api/types/semaphore.go
+++ b/api/types/semaphore.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/api/constants"
-	"github.com/gravitational/teleport/api/defaults"
 
 	"github.com/gravitational/trace"
 )
@@ -58,12 +57,9 @@ type Semaphore interface {
 // these acquire parameters.
 func (s *AcquireSemaphoreRequest) ConfigureSemaphore() (Semaphore, error) {
 	sem := SemaphoreV3{
-		Kind:    KindSemaphore,
 		SubKind: s.SemaphoreKind,
-		Version: V3,
 		Metadata: Metadata{
-			Name:      s.SemaphoreName,
-			Namespace: defaults.Namespace,
+			Name: s.SemaphoreName,
 		},
 	}
 	sem.SetExpiry(s.Expires)
@@ -282,6 +278,11 @@ func (c *SemaphoreV3) String() string {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults.
 func (c *SemaphoreV3) CheckAndSetDefaults() error {
+	c.Version = V3
+	if c.Kind == "" {
+		c.Kind = KindSemaphore
+	}
+
 	// make sure we have defaults for all metadata fields
 	err := c.Metadata.CheckAndSetDefaults()
 	if err != nil {

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -308,15 +308,15 @@ func LabelsAsString(static map[string]string, dynamic map[string]CommandLabelV2)
 
 // CheckAndSetDefaults checks and set default values for any missing fields.
 func (s *ServerV2) CheckAndSetDefaults() error {
+	s.Version = V2
+	if s.Kind == "" {
+		return trace.BadParameter("server Kind is empty")
+	}
 	// TODO(awly): default s.Metadata.Expiry if not set (use
 	// defaults.ServerAnnounceTTL).
 
-	err := s.Metadata.CheckAndSetDefaults()
-	if err != nil {
+	if err := s.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
-	}
-	if s.Kind == "" {
-		return trace.BadParameter("server Kind is empty")
 	}
 
 	for key := range s.Spec.CmdLabels {

--- a/api/types/statictokens.go
+++ b/api/types/statictokens.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
-
 	"github.com/gravitational/trace"
 )
 
@@ -41,19 +39,10 @@ type StaticTokens interface {
 
 // NewStaticTokens is a convenience wrapper to create a StaticTokens resource.
 func NewStaticTokens(spec StaticTokensSpecV2) (StaticTokens, error) {
-	st := StaticTokensV2{
-		Kind:    KindStaticTokens,
-		Version: V2,
-		Metadata: Metadata{
-			Name:      MetaNameStaticTokens,
-			Namespace: defaults.Namespace,
-		},
-		Spec: spec,
-	}
+	st := StaticTokensV2{Spec: spec}
 	if err := st.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	return &st, nil
 }
 
@@ -131,9 +120,15 @@ func (c *StaticTokensV2) GetStaticTokens() []ProvisionToken {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults.
 func (c *StaticTokensV2) CheckAndSetDefaults() error {
+	c.Kind = KindStaticTokens
+	if c.Version == "" {
+		c.Version = V2
+	}
+	if c.Metadata.Name == "" {
+		c.Metadata.Name = MetaNameStaticTokens
+	}
 	// make sure we have defaults for all metadata fields
-	err := c.Metadata.CheckAndSetDefaults()
-	if err != nil {
+	if err := c.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/api/types/trustedcluster.go
+++ b/api/types/trustedcluster.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/utils"
 
 	"github.com/gravitational/trace"
@@ -68,15 +67,16 @@ type TrustedCluster interface {
 
 // NewTrustedCluster is a convenience way to create a TrustedCluster resource.
 func NewTrustedCluster(name string, spec TrustedClusterSpecV2) (TrustedCluster, error) {
-	return &TrustedClusterV2{
-		Kind:    KindTrustedCluster,
-		Version: V2,
+	c := &TrustedClusterV2{
 		Metadata: Metadata{
-			Name:      name,
-			Namespace: defaults.Namespace,
+			Name: name,
 		},
 		Spec: spec,
-	}, nil
+	}
+	if err := c.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return c, nil
 }
 
 // TrustedClusterV2 implements TrustedCluster.
@@ -125,18 +125,24 @@ type TrustedClusterSpecV2 struct {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults
 func (c *TrustedClusterV2) CheckAndSetDefaults() error {
-	// make sure we have defaults for all fields
-	if err := c.Metadata.CheckAndSetDefaults(); err != nil {
-		return trace.Wrap(err)
-	}
-	// This is to force users to migrate
-	if len(c.Spec.Roles) != 0 && len(c.Spec.RoleMap) != 0 {
-		return trace.BadParameter("should set either 'roles' or 'role_map', not both")
+	c.Version = V2
+	if c.Kind == "" {
+		c.Kind = KindTrustedCluster
 	}
 	// Imply that by default proxy listens on the same port for
 	// web and reverse tunnel connections
 	if c.Spec.ReverseTunnelAddress == "" {
 		c.Spec.ReverseTunnelAddress = c.Spec.ProxyAddress
+	}
+
+	// make sure we have defaults for all fields
+	if err := c.Metadata.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// This is to force users to migrate
+	if len(c.Spec.Roles) != 0 && len(c.Spec.RoleMap) != 0 {
+		return trace.BadParameter("should set either 'roles' or 'role_map', not both")
 	}
 	return nil
 }

--- a/api/types/tunnelconn.go
+++ b/api/types/tunnelconn.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
-
 	"github.com/gravitational/trace"
 )
 
@@ -57,12 +55,8 @@ type TunnelConnection interface {
 // NewTunnelConnection returns new connection from V2 spec
 func NewTunnelConnection(name string, spec TunnelConnectionSpecV2) (TunnelConnection, error) {
 	conn := &TunnelConnectionV2{
-		Kind:    KindTunnelConnection,
-		SubKind: spec.ClusterName,
-		Version: V2,
 		Metadata: Metadata{
-			Name:      name,
-			Namespace: defaults.Namespace,
+			Name: name,
 		},
 		Spec: spec,
 	}
@@ -153,6 +147,14 @@ func (r *TunnelConnectionV2) V2() *TunnelConnectionV2 {
 
 // CheckAndSetDefaults checks and sets default values
 func (r *TunnelConnectionV2) CheckAndSetDefaults() error {
+	r.Version = V2
+	if r.Kind == "" {
+		r.Kind = KindTunnelConnection
+	}
+	if r.SubKind == "" {
+		r.SubKind = r.Spec.ClusterName
+	}
+
 	err := r.Metadata.CheckAndSetDefaults()
 	if err != nil {
 		return trace.Wrap(err)

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/utils"
 
 	"github.com/gravitational/trace"
@@ -71,11 +70,8 @@ type User interface {
 // NewUser creates new empty user
 func NewUser(name string) (User, error) {
 	u := &UserV2{
-		Kind:    KindUser,
-		Version: V2,
 		Metadata: Metadata{
-			Name:      name,
-			Namespace: defaults.Namespace,
+			Name: name,
 		},
 	}
 	if err := u.CheckAndSetDefaults(); err != nil {
@@ -174,13 +170,16 @@ func (u *UserV2) SetTraits(traits map[string][]string) {
 
 // CheckAndSetDefaults checks and set default values for any missing fields.
 func (u *UserV2) CheckAndSetDefaults() error {
-	err := u.Metadata.CheckAndSetDefaults()
-	if err != nil {
+	u.Version = V2
+	if u.Kind == "" {
+		u.Kind = KindUser
+	}
+
+	if err := u.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
 
-	err = u.Check()
-	if err != nil {
+	if err := u.Check(); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -962,8 +962,9 @@ func (s *AuthSuite) TestTrustedClusterCRUDEventEmitted(c *C) {
 func (s *AuthSuite) TestGithubConnectorCRUDEventsEmitted(c *C) {
 	ctx := context.Background()
 	// test github create event
-	github := services.NewGithubConnector("test", services.GithubConnectorSpecV3{})
-	err := s.a.upsertGithubConnector(ctx, github)
+	github, err := services.NewGithubConnector("test", services.GithubConnectorSpecV3{})
+	c.Assert(err, IsNil)
+	err = s.a.upsertGithubConnector(ctx, github)
 	c.Assert(err, IsNil)
 	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.GithubConnectorCreatedEvent)
 	s.mockEmitter.Reset()
@@ -983,8 +984,9 @@ func (s *AuthSuite) TestGithubConnectorCRUDEventsEmitted(c *C) {
 func (s *AuthSuite) TestOIDCConnectorCRUDEventsEmitted(c *C) {
 	ctx := context.Background()
 	// test oidc create event
-	oidc := services.NewOIDCConnector("test", services.OIDCConnectorSpecV2{ClientID: "a"})
-	err := s.a.UpsertOIDCConnector(ctx, oidc)
+	oidc, err := services.NewOIDCConnector("test", services.OIDCConnectorSpecV2{ClientID: "a"})
+	c.Assert(err, IsNil)
+	err = s.a.UpsertOIDCConnector(ctx, oidc)
 	c.Assert(err, IsNil)
 	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.OIDCConnectorCreatedEvent)
 	s.mockEmitter.Reset()
@@ -1020,12 +1022,13 @@ func (s *AuthSuite) TestSAMLConnectorCRUDEventsEmitted(c *C) {
 	c.Assert(err, IsNil)
 
 	// test saml create
-	saml := services.NewSAMLConnector("test", services.SAMLConnectorSpecV2{
+	saml, err := services.NewSAMLConnector("test", services.SAMLConnectorSpecV2{
 		AssertionConsumerService: "a",
 		Issuer:                   "b",
 		SSO:                      "c",
 		Cert:                     string(certBytes),
 	})
+	c.Assert(err, IsNil)
 
 	err = s.a.UpsertSAMLConnector(ctx, saml)
 	c.Assert(err, IsNil)

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -583,12 +583,13 @@ func TestGenerateUserSingleUseCert(t *testing.T) {
 	err = srv.Auth().UpsertKubeService(ctx, k8sSrv)
 	require.NoError(t, err)
 	// Register a database.
-	db := types.NewDatabaseServerV3("db-a", nil, types.DatabaseServerSpecV3{
+	db, err := types.NewDatabaseServerV3("db-a", nil, types.DatabaseServerSpecV3{
 		Protocol: "postgres",
 		URI:      "localhost",
 		Hostname: "localhost",
 		HostID:   "localhost",
 	})
+	require.NoError(t, err)
 	_, err = srv.Auth().UpsertDatabaseServer(ctx, db)
 	require.NoError(t, err)
 

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -291,7 +291,11 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	log.Infof("Updating cluster configuration: %v.", cfg.AuthPreference)
 
 	// always create the default namespace
-	err = asrv.UpsertNamespace(services.NewNamespace(defaults.Namespace))
+	n, err := services.NewNamespace(defaults.Namespace)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	err = asrv.UpsertNamespace(n)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -601,7 +601,7 @@ func TestMigrateOSS(t *testing.T) {
 		err := as.CreateRole(services.NewAdminRole())
 		require.NoError(t, err)
 
-		connector := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
+		connector, err := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
 			ClientID:     "aaa",
 			ClientSecret: "bbb",
 			RedirectURL:  "https://localhost:3080/v1/webapi/github/callback",
@@ -622,6 +622,7 @@ func TestMigrateOSS(t *testing.T) {
 				},
 			},
 		})
+		require.NoError(t, err)
 
 		err = as.CreateGithubConnector(connector)
 		require.NoError(t, err)

--- a/lib/auth/resetpasswordtoken.go
+++ b/lib/auth/resetpasswordtoken.go
@@ -298,7 +298,10 @@ func (s *Server) newResetPasswordToken(req CreateResetPasswordTokenRequest) (ser
 		return nil, trace.Wrap(err)
 	}
 
-	token := services.NewResetPasswordToken(tokenID)
+	token, err := services.NewResetPasswordToken(tokenID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	token.SetExpiry(s.clock.Now().UTC().Add(req.TTL))
 	token.SetUser(req.Name)
 	token.SetCreated(s.clock.Now().UTC())

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -87,13 +87,16 @@ func (s *Server) CreateAppSession(ctx context.Context, req services.CreateAppSes
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	session := services.NewWebSession(sessionID, services.KindWebSession, services.KindAppSession, services.WebSessionSpecV2{
+	session, err := services.NewWebSession(sessionID, services.KindWebSession, services.KindAppSession, services.WebSessionSpecV2{
 		User:    req.Username,
 		Priv:    privateKey,
 		Pub:     certs.ssh,
 		TLSCert: certs.tls,
 		Expires: s.clock.Now().Add(ttl),
 	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if err = s.Identity.UpsertAppSession(ctx, session); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -699,9 +699,12 @@ func (a *Server) deactivateCertAuthority(t services.TrustedCluster) error {
 // createReverseTunnel will create a services.ReverseTunnel givenin the
 // services.TrustedCluster resource.
 func (a *Server) createReverseTunnel(t services.TrustedCluster) error {
-	reverseTunnel := services.NewReverseTunnel(
+	reverseTunnel, err := services.NewReverseTunnel(
 		t.GetName(),
 		[]string{t.GetReverseTunnelAddress()},
 	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return trace.Wrap(a.UpsertReverseTunnel(reverseTunnel))
 }

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -894,9 +894,10 @@ func (s *CacheSuite) TestNamespaces(c *check.C) {
 	p := s.newPackForProxy(c)
 	defer p.Close()
 
-	v := services.NewNamespace("universe")
+	v, err := services.NewNamespace("universe")
+	c.Assert(err, check.IsNil)
 	ns := &v
-	err := p.presenceS.UpsertNamespace(*ns)
+	err = p.presenceS.UpsertNamespace(*ns)
 	c.Assert(err, check.IsNil)
 
 	ns, err = p.presenceS.GetNamespace(ns.GetName())
@@ -1081,10 +1082,10 @@ func (s *CacheSuite) TestReverseTunnels(c *check.C) {
 	p := s.newPackForProxy(c)
 	defer p.Close()
 
-	tunnel := services.NewReverseTunnel("example.com", []string{"example.com:2023"})
+	tunnel, err := services.NewReverseTunnel("example.com", []string{"example.com:2023"})
+	c.Assert(err, check.IsNil)
 	c.Assert(p.presenceS.UpsertReverseTunnel(tunnel), check.IsNil)
 
-	var err error
 	tunnel, err = p.presenceS.GetReverseTunnel(tunnel.GetName())
 	c.Assert(err, check.IsNil)
 
@@ -1605,13 +1606,14 @@ func TestDatabaseServers(t *testing.T) {
 	ctx := context.Background()
 
 	// Upsert database server into backend.
-	server := types.NewDatabaseServerV3("foo", nil,
+	server, err := types.NewDatabaseServerV3("foo", nil,
 		types.DatabaseServerSpecV3{
 			Protocol: defaults.ProtocolPostgres,
 			URI:      "localhost:5432",
 			Hostname: "localhost",
 			HostID:   uuid.New(),
 		})
+	require.NoError(t, err)
 	_, err = p.presenceS.UpsertDatabaseServer(ctx, server)
 	require.NoError(t, err)
 

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
 
 	"gopkg.in/check.v1"
 )
@@ -354,7 +355,7 @@ func (t *testCertGetter) GetTrustedCA(ctx context.Context, clusterName string) (
 
 	for _, clusterName := range t.clusterNames {
 		// Only the cluster name is checked in tests, pass in nil for the keys.\
-		ca := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
 			Type:         services.HostCA,
 			ClusterName:  clusterName,
 			SigningKeys:  nil,
@@ -362,6 +363,9 @@ func (t *testCertGetter) GetTrustedCA(ctx context.Context, clusterName string) (
 			Roles:        nil,
 			SigningAlg:   services.CertAuthoritySpecV2_UNKNOWN,
 		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		cas = append(cas, ca)
 	}
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1101,7 +1101,10 @@ func (t *ReverseTunnel) ConvertAndValidate() (services.ReverseTunnel, error) {
 		t.Addresses[i] = addr.String()
 	}
 
-	out := services.NewReverseTunnel(t.DomainName, t.Addresses)
+	out, err := services.NewReverseTunnel(t.DomainName, t.Addresses)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if err := services.ValidateReverseTunnel(out); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1133,10 +1136,13 @@ type Authority struct {
 
 // Parse reads values and returns parsed CertAuthority
 func (a *Authority) Parse() (services.CertAuthority, services.Role, error) {
-	ca := types.NewCertAuthority(types.CertAuthoritySpecV2{
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
 		Type:        a.Type,
 		ClusterName: a.DomainName,
 	})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
 
 	// transform old allowed logins into roles
 	role := services.RoleForCertAuthority(ca)
@@ -1231,7 +1237,7 @@ func (o *OIDCConnector) Parse() (services.OIDCConnector, error) {
 		})
 	}
 
-	v2 := services.NewOIDCConnector(o.ID, services.OIDCConnectorSpecV2{
+	v2, err := services.NewOIDCConnector(o.ID, services.OIDCConnectorSpecV2{
 		IssuerURL:     o.IssuerURL,
 		ClientID:      o.ClientID,
 		ClientSecret:  o.ClientSecret,
@@ -1240,6 +1246,9 @@ func (o *OIDCConnector) Parse() (services.OIDCConnector, error) {
 		Scope:         o.Scope,
 		ClaimsToRoles: mappings,
 	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	v2.SetACR(o.ACR)
 	v2.SetProvider(o.Provider)

--- a/lib/reversetunnel/rc_manager_test.go
+++ b/lib/reversetunnel/rc_manager_test.go
@@ -43,46 +43,71 @@ func TestRemoteClusterTunnelManagerSync(t *testing.T) {
 		{
 			desc: "one reverse tunnel with one address",
 			reverseTunnels: []services.ReverseTunnel{
-				services.NewReverseTunnel("cluster-a", []string{"addr-a"}),
+				&services.ReverseTunnelV2{
+					Spec: services.ReverseTunnelSpecV2{
+						ClusterName: "cluster-a",
+						DialAddrs:   []string{"addr-a"},
+					},
+				},
 			},
 			wantPools: map[remoteClusterKey]*AgentPool{
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+				{cluster: "cluster-a", addr: "addr-a"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
 			},
 			assertErr: require.NoError,
 		},
 		{
 			desc: "one reverse tunnel added with multiple addresses",
 			reverseTunnels: []services.ReverseTunnel{
-				services.NewReverseTunnel("cluster-a", []string{"addr-a", "addr-b", "addr-c"}),
+				&services.ReverseTunnelV2{
+					Spec: services.ReverseTunnelSpecV2{
+						ClusterName: "cluster-a",
+						DialAddrs:   []string{"addr-a", "addr-b", "addr-c"},
+					},
+				},
 			},
 			wantPools: map[remoteClusterKey]*AgentPool{
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-c"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
+				{cluster: "cluster-a", addr: "addr-a"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+				{cluster: "cluster-a", addr: "addr-b"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
+				{cluster: "cluster-a", addr: "addr-c"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
 			},
 			assertErr: require.NoError,
 		},
 		{
 			desc: "one reverse tunnel added and one removed",
 			reverseTunnels: []services.ReverseTunnel{
-				services.NewReverseTunnel("cluster-b", []string{"addr-b"}),
+				&services.ReverseTunnelV2{
+					Spec: services.ReverseTunnelSpecV2{
+						ClusterName: "cluster-b",
+						DialAddrs:   []string{"addr-b"},
+					},
+				},
 			},
 			wantPools: map[remoteClusterKey]*AgentPool{
-				remoteClusterKey{cluster: "cluster-b", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
+				{cluster: "cluster-b", addr: "addr-b"}: {cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
 			},
 			assertErr: require.NoError,
 		},
 		{
 			desc: "multiple reverse tunnels",
 			reverseTunnels: []services.ReverseTunnel{
-				services.NewReverseTunnel("cluster-a", []string{"addr-a", "addr-b", "addr-c"}),
-				services.NewReverseTunnel("cluster-b", []string{"addr-b"}),
+				&services.ReverseTunnelV2{
+					Spec: services.ReverseTunnelSpecV2{
+						ClusterName: "cluster-a",
+						DialAddrs:   []string{"addr-a", "addr-b", "addr-c"},
+					},
+				},
+				&services.ReverseTunnelV2{
+					Spec: services.ReverseTunnelSpecV2{
+						ClusterName: "cluster-b",
+						DialAddrs:   []string{"addr-b"},
+					},
+				},
 			},
 			wantPools: map[remoteClusterKey]*AgentPool{
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-c"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
-				remoteClusterKey{cluster: "cluster-b", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
+				{cluster: "cluster-a", addr: "addr-a"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+				{cluster: "cluster-a", addr: "addr-b"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
+				{cluster: "cluster-a", addr: "addr-c"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
+				{cluster: "cluster-b", addr: "addr-b"}: {cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
 			},
 			assertErr: require.NoError,
 		},
@@ -90,26 +115,41 @@ func TestRemoteClusterTunnelManagerSync(t *testing.T) {
 			desc:              "GetReverseTunnels error, keep existing pools",
 			reverseTunnelsErr: errors.New("nah"),
 			wantPools: map[remoteClusterKey]*AgentPool{
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-c"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
-				remoteClusterKey{cluster: "cluster-b", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
+				{cluster: "cluster-a", addr: "addr-a"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+				{cluster: "cluster-a", addr: "addr-b"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
+				{cluster: "cluster-a", addr: "addr-c"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
+				{cluster: "cluster-b", addr: "addr-b"}: {cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
 			},
 			assertErr: require.Error,
 		},
 		{
 			desc: "AgentPool creation fails, keep existing pools",
 			reverseTunnels: []services.ReverseTunnel{
-				services.NewReverseTunnel("cluster-a", []string{"addr-a", "addr-b", "addr-c"}),
-				services.NewReverseTunnel("cluster-b", []string{"addr-b"}),
-				services.NewReverseTunnel("cluster-c", []string{"addr-c1", "addr-c2"}),
+				&services.ReverseTunnelV2{
+					Spec: services.ReverseTunnelSpecV2{
+						ClusterName: "cluster-a",
+						DialAddrs:   []string{"addr-a", "addr-b", "addr-c"},
+					},
+				},
+				&services.ReverseTunnelV2{
+					Spec: services.ReverseTunnelSpecV2{
+						ClusterName: "cluster-b",
+						DialAddrs:   []string{"addr-b"},
+					},
+				},
+				&services.ReverseTunnelV2{
+					Spec: services.ReverseTunnelSpecV2{
+						ClusterName: "cluster-c",
+						DialAddrs:   []string{"addr-c1", "addr-c2"},
+					},
+				},
 			},
 			newAgentPoolErr: errors.New("nah"),
 			wantPools: map[remoteClusterKey]*AgentPool{
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-a"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
-				remoteClusterKey{cluster: "cluster-a", addr: "addr-c"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
-				remoteClusterKey{cluster: "cluster-b", addr: "addr-b"}: &AgentPool{cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
+				{cluster: "cluster-a", addr: "addr-a"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-a"}},
+				{cluster: "cluster-a", addr: "addr-b"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-b"}},
+				{cluster: "cluster-a", addr: "addr-c"}: {cfg: AgentPoolConfig{Cluster: "cluster-a", ProxyAddr: "addr-c"}},
+				{cluster: "cluster-b", addr: "addr-b"}: {cfg: AgentPoolConfig{Cluster: "cluster-b", ProxyAddr: "addr-b"}},
 			},
 			assertErr: require.Error,
 		},
@@ -118,6 +158,10 @@ func TestRemoteClusterTunnelManagerSync(t *testing.T) {
 	ctx := context.TODO()
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			for _, rt := range tt.reverseTunnels {
+				err := rt.CheckAndSetDefaults()
+				require.NoError(t, err)
+			}
 			w.cfg.AuthClient = mockAuthClient{
 				reverseTunnels:    tt.reverseTunnels,
 				reverseTunnelsErr: tt.reverseTunnelsErr,

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -39,17 +39,20 @@ func TestServerKeyAuth(t *testing.T) {
 	priv, pub, err := ca.GenerateKeyPair("")
 	require.NoError(t, err)
 
+	mockCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:         services.HostCA,
+		ClusterName:  "cluster-name",
+		SigningKeys:  [][]byte{priv},
+		CheckingKeys: [][]byte{pub},
+		Roles:        nil,
+		SigningAlg:   services.CertAuthoritySpecV2_RSA_SHA2_256,
+	})
+	require.NoError(t, err)
+
 	s := &server{
 		log: testlog.FailureOnly(t),
 		localAccessPoint: mockAccessPoint{
-			ca: types.NewCertAuthority(types.CertAuthoritySpecV2{
-				Type:         services.HostCA,
-				ClusterName:  "cluster-name",
-				SigningKeys:  [][]byte{priv},
-				CheckingKeys: [][]byte{pub},
-				Roles:        nil,
-				SigningAlg:   services.CertAuthoritySpecV2_RSA_SHA2_256,
-			}),
+			ca: mockCA,
 		},
 	}
 	con := mockSSHConnMetadata{}

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -84,7 +84,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 	// Create database server for each of the proxied databases.
 	var databaseServers []types.DatabaseServer
 	for _, db := range process.Config.Databases.Databases {
-		databaseServers = append(databaseServers, types.NewDatabaseServerV3(
+		s, err := types.NewDatabaseServerV3(
 			db.Name,
 			db.StaticLabels,
 			types.DatabaseServerSpecV3{
@@ -97,7 +97,11 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 				Version:       teleport.Version,
 				Hostname:      process.Config.Hostname,
 				HostID:        process.Config.HostUUID,
-			}))
+			})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		databaseServers = append(databaseServers, s)
 	}
 
 	clusterName := conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority]

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -497,6 +497,10 @@ func UnmarshalAccessRequest(data []byte, opts ...MarshalOption) (AccessRequest, 
 
 // MarshalAccessRequest marshals the AccessRequest resource to JSON.
 func MarshalAccessRequest(accessRequest AccessRequest, opts ...MarshalOption) ([]byte, error) {
+	if err := ValidateAccessRequest(accessRequest); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -504,9 +508,6 @@ func MarshalAccessRequest(accessRequest AccessRequest, opts ...MarshalOption) ([
 
 	switch accessRequest := accessRequest.(type) {
 	case *AccessRequestV3:
-		if version := accessRequest.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched access request version %v and type %T", version, accessRequest)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/authentication.go
+++ b/lib/services/authentication.go
@@ -307,6 +307,9 @@ func UnmarshalAuthPreference(bytes []byte, opts ...MarshalOption) (AuthPreferenc
 			return nil, trace.BadParameter(err.Error())
 		}
 	}
+	if err := authPreference.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if cfg.ID != 0 {
 		authPreference.SetResourceID(cfg.ID)
 	}
@@ -317,6 +320,9 @@ func UnmarshalAuthPreference(bytes []byte, opts ...MarshalOption) (AuthPreferenc
 }
 
 // MarshalAuthPreference marshals the AuthPreference resource to JSON.
-func MarshalAuthPreference(c AuthPreference, opts ...MarshalOption) ([]byte, error) {
-	return json.Marshal(c)
+func MarshalAuthPreference(authPreference AuthPreference, opts ...MarshalOption) ([]byte, error) {
+	if err := authPreference.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return json.Marshal(authPreference)
 }

--- a/lib/services/clusterconfig.go
+++ b/lib/services/clusterconfig.go
@@ -187,6 +187,10 @@ func UnmarshalClusterConfig(bytes []byte, opts ...MarshalOption) (ClusterConfig,
 
 // MarshalClusterConfig marshals the ClusterConfig resource to JSON.
 func MarshalClusterConfig(clusterConfig ClusterConfig, opts ...MarshalOption) ([]byte, error) {
+	if err := clusterConfig.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -194,9 +198,6 @@ func MarshalClusterConfig(clusterConfig ClusterConfig, opts ...MarshalOption) ([
 
 	switch clusterConfig := clusterConfig.(type) {
 	case *ClusterConfigV3:
-		if version := clusterConfig.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched cluster config version %v and type %T", version, clusterConfig)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/clustername.go
+++ b/lib/services/clustername.go
@@ -87,6 +87,10 @@ func UnmarshalClusterName(bytes []byte, opts ...MarshalOption) (ClusterName, err
 
 // MarshalClusterName marshals the ClusterName resource to JSON.
 func MarshalClusterName(clusterName ClusterName, opts ...MarshalOption) ([]byte, error) {
+	if err := clusterName.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -94,9 +98,6 @@ func MarshalClusterName(clusterName ClusterName, opts ...MarshalOption) ([]byte,
 
 	switch clusterName := clusterName.(type) {
 	case *ClusterNameV2:
-		if version := clusterName.GetVersion(); version != V2 {
-			return nil, trace.BadParameter("mismatched cluster name version %v and type %T", version, clusterName)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/databaseserver.go
+++ b/lib/services/databaseserver.go
@@ -73,6 +73,7 @@ func MarshalDatabaseServer(databaseServer types.DatabaseServer, opts ...MarshalO
 	if err := databaseServer.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -80,9 +81,6 @@ func MarshalDatabaseServer(databaseServer types.DatabaseServer, opts ...MarshalO
 
 	switch databaseServer := databaseServer.(type) {
 	case *types.DatabaseServerV3:
-		if version := databaseServer.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched database server version %v and type %T", version, databaseServer)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/github.go
+++ b/lib/services/github.go
@@ -111,6 +111,10 @@ func UnmarshalGithubConnector(bytes []byte) (GithubConnector, error) {
 
 // MarshalGithubConnector marshals the GithubConnector resource to JSON.
 func MarshalGithubConnector(githubConnector GithubConnector, opts ...MarshalOption) ([]byte, error) {
+	if err := githubConnector.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -118,9 +122,6 @@ func MarshalGithubConnector(githubConnector GithubConnector, opts ...MarshalOpti
 
 	switch githubConnector := githubConnector.(type) {
 	case *GithubConnectorV3:
-		if version := githubConnector.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched github connector version %v and type %T", version, githubConnector)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/github_test.go
+++ b/lib/services/github_test.go
@@ -43,7 +43,7 @@ func (g *GithubSuite) TestUnmarshal(c *check.C) {
 }}`)
 	connector, err := UnmarshalGithubConnector(data)
 	c.Assert(err, check.IsNil)
-	expected := NewGithubConnector("github", GithubConnectorSpecV3{
+	expected, err := NewGithubConnector("github", GithubConnectorSpecV3{
 		ClientID:     "aaa",
 		ClientSecret: "bbb",
 		RedirectURL:  "https://localhost:3080/v1/webapi/github/callback",
@@ -56,11 +56,12 @@ func (g *GithubSuite) TestUnmarshal(c *check.C) {
 			},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	c.Assert(expected, check.DeepEquals, connector)
 }
 
 func (g *GithubSuite) TestMapClaims(c *check.C) {
-	connector := NewGithubConnector("github", GithubConnectorSpecV3{
+	connector, err := NewGithubConnector("github", GithubConnectorSpecV3{
 		ClientID:     "aaa",
 		ClientSecret: "bbb",
 		RedirectURL:  "https://localhost:3080/v1/webapi/github/callback",
@@ -81,6 +82,7 @@ func (g *GithubSuite) TestMapClaims(c *check.C) {
 			},
 		},
 	})
+	c.Assert(err, check.IsNil)
 	logins, kubeGroups, kubeUsers := connector.MapClaims(GithubClaims{
 		OrganizationToTeams: map[string][]string{
 			"gravitational": {"admins"},

--- a/lib/services/license.go
+++ b/lib/services/license.go
@@ -85,6 +85,10 @@ func UnmarshalLicense(bytes []byte) (License, error) {
 
 // MarshalLicense marshals the License resource to JSON.
 func MarshalLicense(license License, opts ...MarshalOption) ([]byte, error) {
+	if err := license.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -92,9 +96,6 @@ func MarshalLicense(license License, opts ...MarshalOption) ([]byte, error) {
 
 	switch license := license.(type) {
 	case *LicenseV3:
-		if version := license.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched license version %v and type %T", version, license)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -119,13 +119,14 @@ func TestDatabaseServersCRUD(t *testing.T) {
 	presence := NewPresenceService(backend)
 
 	// Create a database server.
-	server := types.NewDatabaseServerV3("foo", nil,
+	server, err := types.NewDatabaseServerV3("foo", nil,
 		types.DatabaseServerSpecV3{
 			Protocol: defaults.ProtocolPostgres,
 			URI:      "localhost:5432",
 			Hostname: "localhost",
 			HostID:   uuid.New(),
 		})
+	require.NoError(t, err)
 
 	// Initially expect not to be returned any servers.
 	out, err := presence.GetDatabaseServers(ctx, defaults.Namespace)

--- a/lib/services/namespace.go
+++ b/lib/services/namespace.go
@@ -50,19 +50,24 @@ func GetNamespaceSchema() string {
 }
 
 // MarshalNamespace marshals the Namespace resource to JSON.
-func MarshalNamespace(resource Namespace, opts ...MarshalOption) ([]byte, error) {
+func MarshalNamespace(namespace Namespace, opts ...MarshalOption) ([]byte, error) {
+	if err := namespace.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	if !cfg.PreserveResourceID {
 		// avoid modifying the original object
 		// to prevent unexpected data races
-		copy := resource
+		copy := namespace
 		copy.SetResourceID(0)
-		resource = copy
+		namespace = copy
 	}
-	return utils.FastMarshal(resource)
+	return utils.FastMarshal(namespace)
 }
 
 // UnmarshalNamespace unmarshals the Namespace resource from JSON.

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -185,6 +185,10 @@ func UnmarshalOIDCConnector(bytes []byte, opts ...MarshalOption) (OIDCConnector,
 
 // MarshalOIDCConnector marshals the OIDCConnector resource to JSON.
 func MarshalOIDCConnector(oidcConnector OIDCConnector, opts ...MarshalOption) ([]byte, error) {
+	if err := ValidateOIDCConnector(oidcConnector); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -192,9 +196,6 @@ func MarshalOIDCConnector(oidcConnector OIDCConnector, opts ...MarshalOption) ([
 
 	switch oidcConnector := oidcConnector.(type) {
 	case *OIDCConnectorV2:
-		if version := oidcConnector.GetVersion(); version != V2 {
-			return nil, trace.BadParameter("mismatched OIDC connector version %v and type %T", version, oidcConnector)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/oidc_test.go
+++ b/lib/services/oidc_test.go
@@ -29,7 +29,7 @@ import (
 // Verify that an OIDC connector with no mappings produces no roles.
 func TestOIDCRoleMappingEmpty(t *testing.T) {
 	// create a connector
-	oidcConnector := NewOIDCConnector("example", OIDCConnectorSpecV2{
+	oidcConnector, err := NewOIDCConnector("example", OIDCConnectorSpecV2{
 		IssuerURL:    "https://www.exmaple.com",
 		ClientID:     "example-client-id",
 		ClientSecret: "example-client-secret",
@@ -37,6 +37,7 @@ func TestOIDCRoleMappingEmpty(t *testing.T) {
 		Display:      "sign in with example.com",
 		Scope:        []string{"foo", "bar"},
 	})
+	require.NoError(t, err)
 
 	// create some claims
 	var claims = make(jose.Claims)
@@ -55,7 +56,7 @@ func TestOIDCRoleMappingEmpty(t *testing.T) {
 // TestOIDCRoleMapping verifies basic mapping from OIDC claims to roles.
 func TestOIDCRoleMapping(t *testing.T) {
 	// create a connector
-	oidcConnector := NewOIDCConnector("example", OIDCConnectorSpecV2{
+	oidcConnector, err := NewOIDCConnector("example", OIDCConnectorSpecV2{
 		IssuerURL:    "https://www.exmaple.com",
 		ClientID:     "example-client-id",
 		ClientSecret: "example-client-secret",
@@ -70,6 +71,7 @@ func TestOIDCRoleMapping(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 
 	// create some claims
 	var claims = make(jose.Claims)

--- a/lib/services/plugin_data.go
+++ b/lib/services/plugin_data.go
@@ -39,6 +39,10 @@ func GetPluginDataSchema() string {
 
 //MarshalPluginData marshals the PluginData resource to JSON.
 func MarshalPluginData(pluginData PluginData, opts ...MarshalOption) ([]byte, error) {
+	if err := pluginData.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -46,9 +50,6 @@ func MarshalPluginData(pluginData PluginData, opts ...MarshalOption) ([]byte, er
 
 	switch pluginData := pluginData.(type) {
 	case *PluginDataV3:
-		if version := pluginData.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched plugin data version %v and type %T", version, pluginData)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/provisioning.go
+++ b/lib/services/provisioning.go
@@ -120,6 +120,10 @@ func UnmarshalProvisionToken(data []byte, opts ...MarshalOption) (ProvisionToken
 
 // MarshalProvisionToken marshals the ProvisionToken resource to JSON.
 func MarshalProvisionToken(provisionToken ProvisionToken, opts ...MarshalOption) ([]byte, error) {
+	if err := provisionToken.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -127,9 +131,6 @@ func MarshalProvisionToken(provisionToken ProvisionToken, opts ...MarshalOption)
 
 	switch provisionToken := provisionToken.(type) {
 	case *types.ProvisionTokenV2:
-		if version := provisionToken.GetVersion(); version != V2 {
-			return nil, trace.BadParameter("mismatched provision token version %v and type %T", version, provisionToken)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/remotecluster.go
+++ b/lib/services/remotecluster.go
@@ -94,6 +94,10 @@ func UnmarshalRemoteCluster(bytes []byte, opts ...MarshalOption) (RemoteCluster,
 
 // MarshalRemoteCluster marshals the RemoteCluster resource to JSON.
 func MarshalRemoteCluster(remoteCluster RemoteCluster, opts ...MarshalOption) ([]byte, error) {
+	if err := remoteCluster.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -101,9 +105,6 @@ func MarshalRemoteCluster(remoteCluster RemoteCluster, opts ...MarshalOption) ([
 
 	switch remoteCluster := remoteCluster.(type) {
 	case *RemoteClusterV3:
-		if version := remoteCluster.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched remote cluster version %v and type %T", version, remoteCluster)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/resetpasswordtoken.go
+++ b/lib/services/resetpasswordtoken.go
@@ -52,11 +52,17 @@ func UnmarshalResetPasswordToken(bytes []byte, opts ...MarshalOption) (ResetPass
 	if err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
+	if err := token.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return &token, nil
 }
 
 // MarshalResetPasswordToken marshals the ResetPasswordToken resource to JSON.
 func MarshalResetPasswordToken(token ResetPasswordToken, opts ...MarshalOption) ([]byte, error) {
+	if err := token.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return utils.FastMarshal(token)
 }

--- a/lib/services/resetpasswordtokensecrets.go
+++ b/lib/services/resetpasswordtokensecrets.go
@@ -52,11 +52,17 @@ func UnmarshalResetPasswordTokenSecrets(bytes []byte, opts ...MarshalOption) (Re
 	if err != nil {
 		return nil, trace.BadParameter(err.Error())
 	}
+	if err := secrets.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return &secrets, nil
 }
 
 // MarshalResetPasswordTokenSecrets marshals the ResetPasswordTokenSecrets resource to JSON.
 func MarshalResetPasswordTokenSecrets(secrets ResetPasswordTokenSecrets, opts ...MarshalOption) ([]byte, error) {
+	if err := secrets.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return utils.FastMarshal(secrets)
 }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2084,6 +2084,10 @@ func UnmarshalRole(bytes []byte, opts ...MarshalOption) (Role, error) {
 
 // MarshalRole marshals the Role resource to JSON.
 func MarshalRole(role Role, opts ...MarshalOption) ([]byte, error) {
+	if err := ValidateRole(role); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -2091,9 +2095,6 @@ func MarshalRole(role Role, opts ...MarshalOption) ([]byte, error) {
 
 	switch role := role.(type) {
 	case *RoleV3:
-		if version := role.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched role version %v and type %T", version, role)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -2149,12 +2149,14 @@ func TestBoolOptions(t *testing.T) {
 }
 
 func TestCheckAccessToDatabase(t *testing.T) {
-	dbStage := types.NewDatabaseServerV3("stage",
+	dbStage, err := types.NewDatabaseServerV3("stage",
 		map[string]string{"env": "stage"},
 		types.DatabaseServerSpecV3{})
-	dbProd := types.NewDatabaseServerV3("prod",
+	require.NoError(t, err)
+	dbProd, err := types.NewDatabaseServerV3("prod",
 		map[string]string{"env": "prod"},
 		types.DatabaseServerSpecV3{})
+	require.NoError(t, err)
 	roleDevStage := &RoleV3{
 		Metadata: Metadata{Name: "dev-stage", Namespace: defaults.Namespace},
 		Spec: RoleSpecV3{
@@ -2291,12 +2293,14 @@ func TestCheckAccessToDatabase(t *testing.T) {
 }
 
 func TestCheckAccessToDatabaseUser(t *testing.T) {
-	dbStage := types.NewDatabaseServerV3("stage",
+	dbStage, err := types.NewDatabaseServerV3("stage",
 		map[string]string{"env": "stage"},
 		types.DatabaseServerSpecV3{})
-	dbProd := types.NewDatabaseServerV3("prod",
+	require.NoError(t, err)
+	dbProd, err := types.NewDatabaseServerV3("prod",
 		map[string]string{"env": "prod"},
 		types.DatabaseServerSpecV3{})
+	require.NoError(t, err)
 	roleDevStage := &RoleV3{
 		Metadata: Metadata{Name: "dev-stage", Namespace: defaults.Namespace},
 		Spec: RoleSpecV3{
@@ -2459,22 +2463,26 @@ func TestCheckDatabaseNamesAndUsers(t *testing.T) {
 }
 
 func TestCheckAccessToDatabaseService(t *testing.T) {
-	dbNoLabels := types.NewDatabaseServerV3("test",
+	dbNoLabels, err := types.NewDatabaseServerV3("test",
 		nil,
 		types.DatabaseServerSpecV3{})
-	dbStage := types.NewDatabaseServerV3("stage",
+	require.NoError(t, err)
+	dbStage, err := types.NewDatabaseServerV3("stage",
 		map[string]string{"env": "stage"},
 		types.DatabaseServerSpecV3{
 			DynamicLabels: map[string]CommandLabelV2{"arch": {Result: "x86"}},
 		})
-	dbStage2 := types.NewDatabaseServerV3("stage2",
+	require.NoError(t, err)
+	dbStage2, err := types.NewDatabaseServerV3("stage2",
 		map[string]string{"env": "stage"},
 		types.DatabaseServerSpecV3{
 			DynamicLabels: map[string]CommandLabelV2{"arch": {Result: "amd64"}},
 		})
-	dbProd := types.NewDatabaseServerV3("prod",
+	require.NoError(t, err)
+	dbProd, err := types.NewDatabaseServerV3("prod",
 		map[string]string{"env": "prod"},
 		types.DatabaseServerSpecV3{})
+	require.NoError(t, err)
 	roleAdmin := &RoleV3{
 		Metadata: Metadata{Name: "admin", Namespace: defaults.Namespace},
 		Spec: RoleSpecV3{

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -312,6 +312,10 @@ func UnmarshalSAMLConnector(bytes []byte, opts ...MarshalOption) (SAMLConnector,
 
 // MarshalSAMLConnector marshals the SAMLConnector resource to JSON.
 func MarshalSAMLConnector(samlConnector SAMLConnector, opts ...MarshalOption) ([]byte, error) {
+	if err := ValidateSAMLConnector(samlConnector); err != nil {
+		return nil, err
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -319,9 +323,6 @@ func MarshalSAMLConnector(samlConnector SAMLConnector, opts ...MarshalOption) ([
 
 	switch samlConnector := samlConnector.(type) {
 	case *SAMLConnectorV2:
-		if version := samlConnector.GetVersion(); version != V2 {
-			return nil, trace.BadParameter("mismatched SAML connector version %v and type %T", version, samlConnector)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/semaphore.go
+++ b/lib/services/semaphore.go
@@ -282,15 +282,17 @@ func UnmarshalSemaphore(bytes []byte, opts ...MarshalOption) (Semaphore, error) 
 
 // MarshalSemaphore marshals the Semaphore resource to JSON.
 func MarshalSemaphore(semaphore Semaphore, opts ...MarshalOption) ([]byte, error) {
+	if err := semaphore.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	switch semaphore := semaphore.(type) {
 	case *SemaphoreV3:
-		if version := semaphore.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched semaphore version %v and type %T", version, semaphore)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -483,6 +483,7 @@ func MarshalServer(server Server, opts ...MarshalOption) ([]byte, error) {
 	if err := server.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -490,9 +491,6 @@ func MarshalServer(server Server, opts ...MarshalOption) ([]byte, error) {
 
 	switch server := server.(type) {
 	case *ServerV2:
-		if version := server.GetVersion(); version != V2 {
-			return nil, trace.BadParameter("mismatched server version %v and type %T", version, server)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/session.go
+++ b/lib/services/session.go
@@ -97,6 +97,10 @@ func UnmarshalWebSession(bytes []byte, opts ...MarshalOption) (types.WebSession,
 
 // MarshalWebSession marshals the WebSession resource to JSON.
 func MarshalWebSession(webSession types.WebSession, opts ...MarshalOption) ([]byte, error) {
+	if err := webSession.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -104,9 +108,6 @@ func MarshalWebSession(webSession types.WebSession, opts ...MarshalOption) ([]by
 
 	switch webSession := webSession.(type) {
 	case *WebSessionV2:
-		if version := webSession.GetVersion(); version != V2 {
-			return nil, trace.BadParameter("mismatched web session version %v and type %T", version, webSession)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races
@@ -122,6 +123,10 @@ func MarshalWebSession(webSession types.WebSession, opts ...MarshalOption) ([]by
 
 // MarshalWebToken serializes the web token as JSON-encoded payload
 func MarshalWebToken(webToken types.WebToken, opts ...MarshalOption) ([]byte, error) {
+	if err := webToken.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -129,9 +134,6 @@ func MarshalWebToken(webToken types.WebToken, opts ...MarshalOption) ([]byte, er
 
 	switch webToken := webToken.(type) {
 	case *types.WebTokenV3:
-		if version := webToken.GetVersion(); version != V3 {
-			return nil, trace.BadParameter("mismatched web token version %v and type %T", version, webToken)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -554,13 +554,14 @@ func (s *ServicesTestSuite) WebSessionCRUD(c *check.C) {
 	c.Assert(trace.IsNotFound(err), check.Equals, true, check.Commentf("%#v", err))
 
 	dt := s.Clock.Now().Add(1 * time.Minute)
-	ws := types.NewWebSession("sid1", services.KindWebSession, services.KindWebSession,
+	ws, err := types.NewWebSession("sid1", services.KindWebSession, services.KindWebSession,
 		types.WebSessionSpecV2{
 			User:    "user1",
 			Pub:     []byte("pub123"),
 			Priv:    []byte("priv123"),
 			Expires: dt,
 		})
+	c.Assert(err, check.IsNil)
 	err = s.WebS.WebSessions().Upsert(context.TODO(), ws)
 	c.Assert(err, check.IsNil)
 
@@ -568,13 +569,14 @@ func (s *ServicesTestSuite) WebSessionCRUD(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(out, check.DeepEquals, ws)
 
-	ws1 := types.NewWebSession("sid1", services.KindWebSession, services.KindWebSession,
+	ws1, err := types.NewWebSession("sid1", services.KindWebSession, services.KindWebSession,
 		types.WebSessionSpecV2{
 			User:    "user1",
 			Pub:     []byte("pub321"),
 			Priv:    []byte("priv321"),
 			Expires: dt,
 		})
+	c.Assert(err, check.IsNil)
 	err = s.WebS.WebSessions().Upsert(context.TODO(), ws1)
 	c.Assert(err, check.IsNil)
 

--- a/lib/services/tunnel.go
+++ b/lib/services/tunnel.go
@@ -105,6 +105,10 @@ func UnmarshalReverseTunnel(bytes []byte, opts ...MarshalOption) (ReverseTunnel,
 
 // MarshalReverseTunnel marshals the ReverseTunnel resource to JSON.
 func MarshalReverseTunnel(reverseTunnel ReverseTunnel, opts ...MarshalOption) ([]byte, error) {
+	if err := ValidateReverseTunnel(reverseTunnel); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -112,9 +116,6 @@ func MarshalReverseTunnel(reverseTunnel ReverseTunnel, opts ...MarshalOption) ([
 
 	switch reverseTunnel := reverseTunnel.(type) {
 	case *ReverseTunnelV2:
-		if version := reverseTunnel.GetVersion(); version != V2 {
-			return nil, trace.BadParameter("mismatched reverse tunnel version %v and type %T", version, reverseTunnel)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/tunnelconn.go
+++ b/lib/services/tunnelconn.go
@@ -117,6 +117,10 @@ func UnmarshalTunnelConnection(data []byte, opts ...MarshalOption) (TunnelConnec
 
 // MarshalTunnelConnection marshals the TunnelConnection resource to JSON.
 func MarshalTunnelConnection(tunnelConnection TunnelConnection, opts ...MarshalOption) ([]byte, error) {
+	if err := tunnelConnection.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -124,9 +128,6 @@ func MarshalTunnelConnection(tunnelConnection TunnelConnection, opts ...MarshalO
 
 	switch tunnelConnection := tunnelConnection.(type) {
 	case *TunnelConnectionV2:
-		if version := tunnelConnection.GetVersion(); version != V2 {
-			return nil, trace.BadParameter("mismatched tunnel connection version %v and type %T", version, tunnelConnection)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/services/user.go
+++ b/lib/services/user.go
@@ -231,6 +231,10 @@ func UnmarshalUser(bytes []byte, opts ...MarshalOption) (User, error) {
 
 // MarshalUser marshals the User resource to JSON.
 func MarshalUser(user User, opts ...MarshalOption) ([]byte, error) {
+	if err := ValidateUser(user); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -238,9 +242,6 @@ func MarshalUser(user User, opts ...MarshalOption) ([]byte, error) {
 
 	switch user := user.(type) {
 	case *UserV2:
-		if version := user.GetVersion(); version != V2 {
-			return nil, trace.BadParameter("mismatched user version %v and type %T", version, user)
-		}
 		if !cfg.PreserveResourceID {
 			// avoid modifying the original object
 			// to prevent unexpected data races

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -763,8 +763,9 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 
 	// Create a reverse tunnel and remote cluster simulating what the trusted
 	// cluster exchange does.
-	err = s.server.Auth().UpsertReverseTunnel(
-		services.NewReverseTunnel(s.server.ClusterName(), []string{reverseTunnelAddress.String()}))
+	rt, err := services.NewReverseTunnel(s.server.ClusterName(), []string{reverseTunnelAddress.String()})
+	c.Assert(err, IsNil)
+	err = s.server.Auth().UpsertReverseTunnel(rt)
 	c.Assert(err, IsNil)
 	remoteCluster, err := services.NewRemoteCluster("localhost")
 	c.Assert(err, IsNil)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1560,9 +1560,13 @@ func (s *WebSuite) TestMultipleConnectors(c *C) {
 			},
 		},
 	}
-	err := s.server.Auth().UpsertOIDCConnector(ctx, services.NewOIDCConnector("foo", oidcConnectorSpec))
+	oidc, err := services.NewOIDCConnector("foo", oidcConnectorSpec)
 	c.Assert(err, IsNil)
-	err = s.server.Auth().UpsertOIDCConnector(ctx, services.NewOIDCConnector("bar", oidcConnectorSpec))
+	err = s.server.Auth().UpsertOIDCConnector(ctx, oidc)
+	c.Assert(err, IsNil)
+	oidc, err = services.NewOIDCConnector("bar", oidcConnectorSpec)
+	c.Assert(err, IsNil)
+	err = s.server.Auth().UpsertOIDCConnector(ctx, oidc)
 	c.Assert(err, IsNil)
 
 	// set the auth preferences to oidc with no connector name

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -80,7 +80,8 @@ spec:
   teams_to_logins: null
 version: v3
 `
-	githubConn := types.NewGithubConnector("githubName", types.GithubConnectorSpecV3{})
+	githubConn, err := types.NewGithubConnector("githubName", types.GithubConnectorSpecV3{})
+	require.NoError(t, err)
 	item, err := ui.NewResourceItem(githubConn)
 	require.Nil(t, err)
 	require.Equal(t, item, &ui.ResourceItem{
@@ -223,8 +224,10 @@ func TestGetGithubConnectors(t *testing.T) {
 	m := &mockedResourceAPIGetter{}
 
 	m.mockGetGithubConnectors = func(withSecrets bool) ([]types.GithubConnector, error) {
-		connector := types.NewGithubConnector("test", types.GithubConnectorSpecV3{})
-
+		connector, err := types.NewGithubConnector("test", types.GithubConnectorSpecV3{})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		return []types.GithubConnector{connector}, nil
 	}
 

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -346,9 +346,10 @@ func (c *SessionContext) Close() error {
 // is only useful immediately after a session has been created to query
 // the token.
 func (c *SessionContext) getToken() types.WebToken {
-	return types.NewWebToken(c.session.GetBearerTokenExpiryTime(), types.WebTokenSpecV3{
+	t, _ := types.NewWebToken(c.session.GetBearerTokenExpiryTime(), types.WebTokenSpecV3{
 		Token: c.session.GetBearerToken(),
 	})
+	return t
 }
 
 // expired returns whether this context has expired.

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -41,7 +41,7 @@ func TestAuthSignKubeconfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ca := types.NewCertAuthority(types.CertAuthoritySpecV2{
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
 		Type:         services.HostCA,
 		ClusterName:  "example.com",
 		SigningKeys:  nil,
@@ -49,6 +49,9 @@ func TestAuthSignKubeconfig(t *testing.T) {
 		Roles:        nil,
 		SigningAlg:   services.CertAuthoritySpecV2_RSA_SHA2_512,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	ca.SetTLSKeyPairs([]services.TLSKeyPair{{Cert: []byte("TLS CA cert")}})
 
 	client := mockClient{

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -116,12 +116,12 @@ func TestOIDCLogin(t *testing.T) {
 
 	// connector must exist, but does not need to be functional since we
 	// are going to mock the actual login operation.
-	connector := types.NewOIDCConnector("auth.example.com", types.OIDCConnectorSpecV2{
+	connector, err := types.NewOIDCConnector("auth.example.com", types.OIDCConnectorSpecV2{
 		IssuerURL:   "https://auth.example.com",
 		RedirectURL: "https://cluster.example.com",
 		ClientID:    "fake-client",
 	})
-	require.NoError(t, connector.CheckAndSetDefaults())
+	require.NoError(t, err)
 
 	authProcess, proxyProcess := makeTestServers(t, populist, dictator, connector, alice)
 


### PR DESCRIPTION
### Inconsistent Validation Stategy and loop holes:
Currently, validation can happen in a few places, each with a few holes.
 - Constructors
   - If the constructor is not used and a user provides the struct directly, some default values are not set, which can cause issues like #5811.
     - Some use cases, like the one linked, actually can't use the constructor, so this is an ineffective validation strategy to rely on.
 - Server request layer - immediately validates request values
   - Quicker validation response than marshalers, but it becomes redundant since marshalers will re-validate. This case is not necessary in most cases, but is mostly harmless.
 - Marshalers - validates values before entering data to the backend or when pulling it out
   - This is essential to guarantee invalid values don't reach the backend since this can cause major issues.
   - Most marshalers have no validation, except for the version check added by #5768, which can easily open up loop holes.

### Solution
I believe that the pattern of supplying default values in the constructors has remained because internally we all know to use these constructors, but we should not expect the same depth of knowledge of users of our now public API. 

My solution to both of these problems is to have all validation and default logic held in `CheckAndSetDefaults` functions, and possibly `services.Validate[Resource]` when necessary. For usage:
 - Marshalers + Unmarshalers should validate input with `Validate[Resource]` function if available, otherwise with `CheckAndSetDefaults`.
   - This should cover all possible server/backend breaking loopholes.
 - Constructors call `CheckAndSetDefaults` and return possible errors.
   - This does basic client side validation and makes it easy for a user to create a resource, but it is not essential now that marshalers consistently validate.
 - Validation can still be called immediately on requests to the backend, but the marshalers should cover all cases already. 
   - This will return an error slightly sooner than the marshalers would and it may be necessary in some situations, but I'd need to investigate more.

Closes #5811 