### PR TITLE
getting started configure doc fix

### DIFF
--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -80,7 +80,7 @@ Acme turns on automatic TLS certificates from [Letsencrypt](https://letsencrypt.
 Set up email to receive updates from Letsencrypt, and use a valid DNS name for a cluster name.
 
 ```bash
-$ sudo teleport configure --acme --acme-email=your-email@example.com --cluster-name=tele.example.com -o
+$ sudo teleport configure --acme --acme-email=your-email@example.com --cluster-name=tele.example.com -o file
 Wrote config to file "/etc/teleport.yaml". Now you can start the server. Happy Teleporting!
 ```
 


### PR DESCRIPTION
teleport configure command was missing `file` parameter in `-o`