### PR TITLE
backport branch/v6.0: Add google_service_account inline field option for Google Workspace/GSuite OIDC

### DIFF
--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -85,9 +85,13 @@ type OIDCConnector interface {
 	SetDisplay(string)
 	// GetGoogleServiceAccountURI returns path to google service account URI
 	GetGoogleServiceAccountURI() string
+	// GetGoogleServiceAccount returns google service account json for Google
+	GetGoogleServiceAccount() string
+	// SetGoogleServiceAccount sets the google service account json contents
+	SetGoogleServiceAccount(string)
 	// GetGoogleAdminEmail returns a google admin user email
 	// https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority
-	// "Note: Although you can use service accounts in applications that run from a G Suite domain, service accounts are not members of your G Suite account and aren’t subject to domain policies set by G Suite administrators. For example, a policy set in the G Suite admin console to restrict the ability of G Suite end users to share documents outside of the domain would not apply to service accounts."
+	// "Note: Although you can use service accounts in applications that run from a Google Workspace (formerly G Suite) domain, service accounts are not members of your Google Workspace account and aren’t subject to domain policies set by  administrators. For example, a policy set in the Google Workspace admin console to restrict the ability of end users to share documents outside of the domain would not apply to service accounts."
 	GetGoogleAdminEmail() string
 }
 
@@ -139,6 +143,16 @@ func (o *OIDCConnectorV2) GetGoogleServiceAccountURI() string {
 	return o.Spec.GoogleServiceAccountURI
 }
 
+// GetGoogleServiceAccount returns a string representing a Google service account
+func (o *OIDCConnectorV2) GetGoogleServiceAccount() string {
+	return o.Spec.GoogleServiceAccount
+}
+
+// SetGoogleServiceAccount sets a string representing a Google service account
+func (o *OIDCConnectorV2) SetGoogleServiceAccount(s string) {
+	o.Spec.GoogleServiceAccount = s
+}
+
 // GetGoogleAdminEmail returns a google admin user email
 func (o *OIDCConnectorV2) GetGoogleAdminEmail() string {
 	return o.Spec.GoogleAdminEmail
@@ -176,11 +190,13 @@ func (o *OIDCConnectorV2) SetResourceID(id int64) {
 
 // WithoutSecrets returns an instance of resource without secrets.
 func (o *OIDCConnectorV2) WithoutSecrets() Resource {
-	if o.GetClientSecret() == "" {
+	if o.GetClientSecret() == "" && o.GetGoogleServiceAccount() == "" {
 		return o
 	}
 	o2 := *o
+
 	o2.SetClientSecret("")
+	o2.SetGoogleServiceAccount("")
 	return &o2
 }
 
@@ -410,6 +426,8 @@ type OIDCConnectorSpecV2 struct {
 	ClaimsToRoles []ClaimMapping `json:"claims_to_roles,omitempty"`
 	// GoogleServiceAccountURI is a path to google service account uri
 	GoogleServiceAccountURI string `json:"google_service_account_uri,omitempty"`
+	// GoogleServiceAccount is a string containing the google service account credentials
+	GoogleServiceAccount string `json:"google_service_account,omitempty"`
 	// GoogleAdminEmail is email of google admin to impersonate
 	GoogleAdminEmail string `json:"google_admin_email,omitempty"`
 }

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -718,6 +718,7 @@ func (s *IdentityService) GetOIDCConnector(name string, withSecrets bool) (servi
 	}
 	if !withSecrets {
 		conn.SetClientSecret("")
+		conn.SetGoogleServiceAccount("")
 	}
 	return conn, nil
 }
@@ -738,6 +739,7 @@ func (s *IdentityService) GetOIDCConnectors(withSecrets bool) ([]services.OIDCCo
 		}
 		if !withSecrets {
 			conn.SetClientSecret("")
+			conn.SetGoogleServiceAccount("")
 		}
 		connectors[i] = conn
 	}

--- a/lib/services/oidc.go
+++ b/lib/services/oidc.go
@@ -38,6 +38,11 @@ func ValidateOIDCConnector(oc types.OIDCConnector) error {
 	if _, err := url.Parse(oc.GetRedirectURL()); err != nil {
 		return trace.BadParameter("RedirectURL: bad url: '%v'", oc.GetRedirectURL())
 	}
+
+	if oc.GetGoogleServiceAccountURI() != "" && oc.GetGoogleServiceAccount() != "" {
+		return trace.BadParameter("one of either google_service_account_uri or google_service_account is supported, not both")
+	}
+
 	if oc.GetGoogleServiceAccountURI() != "" {
 		uri, err := utils.ParseSessionsURI(oc.GetGoogleServiceAccountURI())
 		if err != nil {
@@ -48,6 +53,11 @@ func ValidateOIDCConnector(oc types.OIDCConnector) error {
 		}
 		if oc.GetGoogleAdminEmail() == "" {
 			return trace.BadParameter("whenever google_service_account_uri is specified, google_admin_email should be set as well, read https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority for more details")
+		}
+	}
+	if oc.GetGoogleServiceAccount() != "" {
+		if oc.GetGoogleAdminEmail() == "" {
+			return trace.BadParameter("whenever google_service_account is specified, google_admin_email should be set as well, read https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority for more details")
 		}
 	}
 	return nil
@@ -95,6 +105,7 @@ var OIDCConnectorSpecV2Schema = fmt.Sprintf(`{
 	  "display": {"type": "string"},
 	  "prompt": {"type": "string"},
 	  "google_service_account_uri": {"type": "string"},
+	  "google_service_account": {"type": "string"},
 	  "google_admin_email": {"type": "string"},
 	  "scope": {
 		"type": "array",


### PR DESCRIPTION
backport for using google_service_account field instead of JSON file in oidc connector
original PR:
https://github.com/gravitational/teleport/pull/5563