### PR TITLE
Support key options with MemLocalKeyStore

### DIFF
--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -472,7 +472,6 @@ func (o withDBCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
 	default:
 		return trace.BadParameter("unexpected key store type %T", store)
 	}
-	return nil
 	if key.ClusterName == "" {
 		key.ClusterName = o.teleportClusterName
 	}

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -769,6 +769,9 @@ func NewMemLocalKeyStore(dirPath string) (*MemLocalKeyStore, error) {
 // AddKey writes a key to the underlying key store.
 func (s *MemLocalKeyStore) AddKey(proxy string, username string, key *Key) error {
 	s.inMem[keyIndex{proxyHost: proxy, username: username}] = key
+	if key.ClusterName != "" {
+		s.inMem[keyIndex{proxyHost: proxy, username: username, clusterName: key.ClusterName}] = key
+	}
 	return nil
 }
 
@@ -785,7 +788,6 @@ func (s *MemLocalKeyStore) GetKey(proxy, username string, opts ...KeyOption) (*K
 			return nil, trace.Wrap(err)
 		}
 	}
-
 	return entry, nil
 }
 


### PR DESCRIPTION
Add support for `KeyOption`s to the memory backend introduced in #5825. This should play nicely with the improvements coming in #5938.