### PR TITLE
Update Helm charts to use Teleport 6 by default

### DIFF
--- a/examples/chart/teleport-auto-trustedcluster/Chart.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-auto-trustedcluster
 apiVersion: v2
-version: 0.0.7
-appVersion: "5"
+version: 0.0.8
+appVersion: "6"
 description: Teleport trusted cluster installation which automatically joins itself back to the provided root cluster.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-auto-trustedcluster/values.yaml
+++ b/examples/chart/teleport-auto-trustedcluster/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/gravitational/teleport-ent
   # This tag reflects the version of Teleport to deploy
-  tag: "5"
+  tag: "6"
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 name: teleport-cluster
 apiVersion: v2
-version: 6
+version: 6.0.0
 appVersion: "6"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: 5.0.0
-appVersion: "5.0"
+version: 6
+appVersion: "6"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-daemonset/Chart.yaml
+++ b/examples/chart/teleport-daemonset/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-daemonset
 apiVersion: v2
-version: 0.0.7
-appVersion: "5"
+version: 0.0.8
+appVersion: "6"
 description: Teleport daemonset installation which provides some access to underlying Kubernetes nodes.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-daemonset/values.yaml
+++ b/examples/chart/teleport-daemonset/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: quay.io/gravitational/teleport-ent
   # This tag reflects the version of Teleport to deploy
-  tag: "5"
+  tag: "6"
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.

--- a/examples/chart/teleport-kube-agent/.lint/lint-values-all-v5.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/lint-values-all-v5.yaml
@@ -1,3 +1,4 @@
+teleportVersionOverride: "5"
 authToken: auth-token
 proxyAddr: proxy.example.com:3080
 roles: kube,app,db

--- a/examples/chart/teleport-kube-agent/.lint/lint-values-all-v6.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/lint-values-all-v6.yaml
@@ -1,4 +1,3 @@
-teleportVersionOverride: 6
 authToken: auth-token
 proxyAddr: proxy.example.com:3080
 roles: kube,app,db

--- a/examples/chart/teleport-kube-agent/.lint/lint-values-db.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/lint-values-db.yaml
@@ -1,4 +1,3 @@
-teleportVersionOverride: 6
 authToken: auth-token
 proxyAddr: proxy.example.com:3080
 roles: db

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: 0.0.2
-appVersion: "5"
+version: 0.0.3
+appVersion: "6"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport/Chart.yaml
+++ b/examples/chart/teleport/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport
 apiVersion: v2
-version: 0.0.11
-appVersion: "5"
+version: 0.0.12
+appVersion: "6"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport/values.yaml
+++ b/examples/chart/teleport/values.yaml
@@ -12,7 +12,7 @@ image:
   # Used if license is disabled
   communityRepository: quay.io/gravitational/teleport
   # Version of Teleport
-  tag: "5"
+  tag: "6"
   pullPolicy: IfNotPresent
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.


### PR DESCRIPTION
Also bump chart versions so that people who have pinned versions don't get auto-updated to a different Teleport version.

This should be backported to `branch/v6` too as we've had requests in the past for Helm chart versions to match branch version.