### PR TITLE
Fix issue with local agent forwarding

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -187,7 +187,11 @@ func (ns *NodeSession) createServerSession() (*ssh.Session, error) {
 	// forward the agent to endpoint.
 	tc := ns.nodeClient.Proxy.teleportClient
 	if tc.ForwardAgent && tc.localAgent.Agent != nil {
-		err = agent.ForwardToAgent(ns.nodeClient.Client, tc.localAgent.Agent)
+		var forwardAgent = tc.localAgent.Agent
+		if tc.UseLocalSSHAgent && tc.localAgent.sshAgent != nil {
+			forwardAgent = tc.localAgent.sshAgent
+		}
+		err = agent.ForwardToAgent(ns.nodeClient.Client, forwardAgent)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/1571

Tested locally with:

```
➜  ./build/tsh ssh --use-local-ssh-agent -A -D1111 <host> 'ssh-add -L | wc -l'
4
```

before the fix only the teleport keys would be added
```
➜  tsh ssh --use-local-ssh-agent -A -D1111 <host> 'ssh-add -L | wc -l'      
2
```
