### PR TITLE
[Bug] Add empty token check for mfa optional logins

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1242,8 +1242,14 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 	switch cap.GetSecondFactor() {
 	case constants.SecondFactorOff:
 		webSession, err = h.auth.AuthWithoutOTP(req.User, req.Pass)
-	case constants.SecondFactorOTP, constants.SecondFactorOn, constants.SecondFactorOptional:
+	case constants.SecondFactorOTP, constants.SecondFactorOn:
 		webSession, err = h.auth.AuthWithOTP(req.User, req.Pass, req.SecondFactorToken)
+	case constants.SecondFactorOptional:
+		if req.SecondFactorToken == "" {
+			webSession, err = h.auth.AuthWithoutOTP(req.User, req.Pass)
+		} else {
+			webSession, err = h.auth.AuthWithOTP(req.User, req.Pass, req.SecondFactorToken)
+		}
 	default:
 		return nil, trace.AccessDenied("unknown second factor type: %q", cap.GetSecondFactor())
 	}


### PR DESCRIPTION
#### Description
Fixes a tiny bug where if 2fa type is `optional`, users with no 2fa enrolled cannot login. This PR checks for an empty token b/c of these line where otp token may or may not be empty: https://github.com/gravitational/teleport/blob/master/lib/web/sessions.go#L488
https://github.com/gravitational/teleport/blob/master/lib/auth/methods.go#L150