### PR TITLE
Moves loadCredsFromProfile to OSS (#5891)

### DIFF
--- a/tool/tctl/main.go
+++ b/tool/tctl/main.go
@@ -33,5 +33,5 @@ func main() {
 		&common.AppsCommand{},
 		&common.DBCommand{},
 	}
-	common.Run(commands, nil)
+	common.Run(commands)
 }


### PR DESCRIPTION
With 6.0 OSS migrated to RBAC, OSS tctl can connect
remotely with users credentials.