### PR TITLE
Update ssh-rbac.mdx to include remote_cluster

### DIFF
--- a/docs/pages/enterprise/ssh-rbac.mdx
+++ b/docs/pages/enterprise/ssh-rbac.mdx
@@ -156,6 +156,8 @@ spec:
       verbs: [list, read]
     - resources: [trusted_cluster]
       verbs: [list, create, read, update, delete]
+    - resources: [remote_cluster]
+      verbs: [list, create, read, update, delete]
     - resources: [event]
       verbs: [list, read]
     - resources: [user]
@@ -310,6 +312,10 @@ List of all rule options defined below.
     # Trusted Clusters:  CRUD options for managing Trusted Clusters
     - resources:
       - trusted_cluster
+      verbs: [list, create, read, update, delete]
+    # Remote Clusters:  CRUD options for managing Remote Clusters
+    - resources:
+      - remote_cluster
       verbs: [list, create, read, update, delete]
     # Events: Can view the audit log and session recordings.
     - resources:


### PR DESCRIPTION
The resolution to [Issue 5992](https://github.com/gravitational/teleport/issues/5992) and executing the command `tctl rm rc/<cluster-name>` via the proxy was to add the `remote_cluster` permissions to the Teleport role.  

The `remote_cluster` resource is not currently documented in our RBAC documentation.  Adding basic notes that the `remote_cluster` option is present and configurable in a role configuration.