### PR TITLE
Bring back cluster details

### DIFF
--- a/lib/web/ui/cluster.go
+++ b/lib/web/ui/cluster.go
@@ -50,13 +50,9 @@ type Cluster struct {
 func NewClusters(remoteClusters []reversetunnel.RemoteSite) ([]Cluster, error) {
 	clusters := make([]Cluster, 0, len(remoteClusters))
 	for _, site := range remoteClusters {
-		// Other fields such as node count, url, and proxy/auth versions are not set
-		// because each cluster will need to make network calls to retrieve information
-		// which does not scale well (ie: 1k clusters, each request will take seconds).
-		cluster := &Cluster{
-			Name:          site.GetName(),
-			LastConnected: site.GetLastConnected(),
-			Status:        site.GetStatus(),
+		cluster, err := GetClusterDetails(site, services.SkipValidation())
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
 		clusters = append(clusters, *cluster)
@@ -66,20 +62,6 @@ func NewClusters(remoteClusters []reversetunnel.RemoteSite) ([]Cluster, error) {
 		return clusters[i].Name < clusters[j].Name
 	})
 
-	return clusters, nil
-}
-
-// NewClustersFromRemote creates a slice of Cluster's, containing data about each cluster.
-func NewClustersFromRemote(remoteClusters []services.RemoteCluster) ([]Cluster, error) {
-	clusters := make([]Cluster, 0, len(remoteClusters))
-	for _, rc := range remoteClusters {
-		cluster := Cluster{
-			Name:          rc.GetName(),
-			LastConnected: rc.GetLastHeartbeat(),
-			Status:        rc.GetConnectionStatus(),
-		}
-		clusters = append(clusters, cluster)
-	}
 	return clusters, nil
 }
 


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/4734

#### Description
Brings back the cluster details (auth version, proxy url, node count).