### PR TITLE
Remove .bash suffix from bats includes to enable compatibility with older versions

### DIFF
--- a/assets/aws/files/tests/fixtures/common.bash
+++ b/assets/aws/files/tests/fixtures/common.bash
@@ -7,7 +7,7 @@ export TELEPORT_TESTVAR_PUBLIC_IP=1.2.3.4
 TEST_SUITE="$(basename ${BATS_TEST_FILENAME%%.bats})"
 
 setup_file() {
-    load fixtures/test-setup.bash
+    load fixtures/test-setup
 
     # write_confd_file is a function defined to set up fixtures inside each test
     write_confd_file
@@ -24,5 +24,5 @@ setup_file() {
 }
 
 teardown_file() {
-    load fixtures/test-teardown.bash
+    load fixtures/test-teardown
 }

--- a/assets/aws/files/tests/ha-auth-fips.bats
+++ b/assets/aws/files/tests/ha-auth-fips.bats
@@ -17,7 +17,7 @@ EOF
     export TELEPORT_TEST_FIPS_MODE=true
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]

--- a/assets/aws/files/tests/ha-auth-oss.bats
+++ b/assets/aws/files/tests/ha-auth-oss.bats
@@ -15,7 +15,7 @@ USE_ACM=false
 EOF
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]

--- a/assets/aws/files/tests/ha-auth.bats
+++ b/assets/aws/files/tests/ha-auth.bats
@@ -16,7 +16,7 @@ USE_ACM=false
 EOF
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]

--- a/assets/aws/files/tests/ha-node.bats
+++ b/assets/aws/files/tests/ha-node.bats
@@ -9,7 +9,7 @@ USE_ACM=false
 EOF
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]

--- a/assets/aws/files/tests/ha-proxy-acm.bats
+++ b/assets/aws/files/tests/ha-proxy-acm.bats
@@ -13,7 +13,7 @@ USE_ACM=true
 EOF
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]

--- a/assets/aws/files/tests/ha-proxy.bats
+++ b/assets/aws/files/tests/ha-proxy.bats
@@ -13,7 +13,7 @@ export USE_ACM=false
 EOF
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
     [ ${GENERATE_EXIT_CODE?} -eq 0 ]

--- a/assets/aws/files/tests/starter-cluster-acm-fips.bats
+++ b/assets/aws/files/tests/starter-cluster-acm-fips.bats
@@ -19,7 +19,7 @@ EOF
 export TELEPORT_TEST_FIPS_MODE=true
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
   [ ${GENERATE_EXIT_CODE?} -eq 0 ]

--- a/assets/aws/files/tests/starter-cluster-acm.bats
+++ b/assets/aws/files/tests/starter-cluster-acm.bats
@@ -18,7 +18,7 @@ USE_ACM=true
 EOF
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
   [ ${GENERATE_EXIT_CODE?} -eq 0 ]

--- a/assets/aws/files/tests/starter-cluster-fips.bats
+++ b/assets/aws/files/tests/starter-cluster-fips.bats
@@ -19,7 +19,7 @@ EOF
 export TELEPORT_TEST_FIPS_MODE=true
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
   [ ${GENERATE_EXIT_CODE?} -eq 0 ]

--- a/assets/aws/files/tests/starter-cluster.bats
+++ b/assets/aws/files/tests/starter-cluster.bats
@@ -18,7 +18,7 @@ USE_ACM=false
 EOF
 }
 
-load fixtures/common.bash
+load fixtures/common
 
 @test "[${TEST_SUITE?}] config file was generated without error" {
   [ ${GENERATE_EXIT_CODE?} -eq 0 ]


### PR DESCRIPTION
Newer versions of `bats` (1.2.1+) don't stipulate that you must use a `.bash` extension on any files you wish to include, but older versions do. Newer versions have logic to check for both `file` and `file.bash`, so this PR removes the explicit `.bash` extension from all the includes to make it a little more backwards compatible.