### PR TITLE
Properly marks k8s stream complete on error exit

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -806,8 +806,6 @@ func (f *Forwarder) exec(ctx *authContext, w http.ResponseWriter, req *http.Requ
 	}
 	defer proxy.Close()
 
-	f.log.Debugf("Created streams, getting executor.")
-
 	executor, err := f.getExecutor(*ctx, sess, req)
 	if err != nil {
 		f.log.WithError(err).Warning("Failed creating executor.")
@@ -836,130 +834,134 @@ func (f *Forwarder) exec(ctx *authContext, w http.ResponseWriter, req *http.Requ
 		streamOptions.Stderr = utils.NewBroadcastWriter(streamOptions.Stderr, recorder)
 	}
 
+	// Defer a cleanup handler that will mark the stream as complete on exit, regardless of
+	// whether it exits successfully, or with an error.
+	// NOTE that this cleanup handler MAY MODIFY the returned error value.
+	defer func() {
+		if err := proxy.sendStatus(err); err != nil {
+			f.log.WithError(err).Warning("Failed to send status. Exec command was aborted by client.")
+		}
+
+		if request.tty {
+			sessionDataEvent := &events.SessionData{
+				Metadata: events.Metadata{
+					Type:        events.SessionDataEvent,
+					Code:        events.SessionDataCode,
+					ClusterName: f.cfg.ClusterName,
+				},
+				ServerMetadata: events.ServerMetadata{
+					ServerID:        f.cfg.ServerID,
+					ServerNamespace: f.cfg.Namespace,
+				},
+				SessionMetadata: events.SessionMetadata{
+					SessionID: string(sessionID),
+					WithMFA:   ctx.Identity.GetIdentity().MFAVerified,
+				},
+				UserMetadata: events.UserMetadata{
+					User:         ctx.User.GetName(),
+					Login:        ctx.User.GetName(),
+					Impersonator: ctx.Identity.GetIdentity().Impersonator,
+				},
+				ConnectionMetadata: events.ConnectionMetadata{
+					RemoteAddr: req.RemoteAddr,
+					LocalAddr:  sess.teleportCluster.targetAddr,
+					Protocol:   events.EventProtocolKube,
+				},
+				// Bytes transmitted from user to pod.
+				BytesTransmitted: trackIn.Count(),
+				// Bytes received from pod by user.
+				BytesReceived: trackOut.Count() + trackErr.Count(),
+			}
+			if err := emitter.EmitAuditEvent(f.ctx, sessionDataEvent); err != nil {
+				f.log.WithError(err).Warn("Failed to emit session data event.")
+			}
+			sessionEndEvent := &events.SessionEnd{
+				Metadata: events.Metadata{
+					Type:        events.SessionEndEvent,
+					Code:        events.SessionEndCode,
+					ClusterName: f.cfg.ClusterName,
+				},
+				ServerMetadata: events.ServerMetadata{
+					ServerID:        f.cfg.ServerID,
+					ServerNamespace: f.cfg.Namespace,
+				},
+				SessionMetadata: events.SessionMetadata{
+					SessionID: string(sessionID),
+					WithMFA:   ctx.Identity.GetIdentity().MFAVerified,
+				},
+				UserMetadata: events.UserMetadata{
+					User:         ctx.User.GetName(),
+					Login:        ctx.User.GetName(),
+					Impersonator: ctx.Identity.GetIdentity().Impersonator,
+				},
+				ConnectionMetadata: events.ConnectionMetadata{
+					RemoteAddr: req.RemoteAddr,
+					LocalAddr:  sess.teleportCluster.targetAddr,
+					Protocol:   events.EventProtocolKube,
+				},
+				Interactive: true,
+				// There can only be 1 participant, k8s sessions are not join-able.
+				Participants:              []string{ctx.User.GetName()},
+				StartTime:                 sessionStart,
+				EndTime:                   f.cfg.Clock.Now().UTC(),
+				KubernetesClusterMetadata: ctx.eventClusterMeta(),
+				KubernetesPodMetadata:     eventPodMeta,
+				InitialCommand:            request.cmd,
+			}
+			if err := emitter.EmitAuditEvent(f.ctx, sessionEndEvent); err != nil {
+				f.log.WithError(err).Warn("Failed to emit session end event.")
+			}
+		} else {
+			// send an exec event
+			execEvent := &events.Exec{
+				Metadata: events.Metadata{
+					Type:        events.ExecEvent,
+					ClusterName: f.cfg.ClusterName,
+				},
+				ServerMetadata: events.ServerMetadata{
+					ServerID:        f.cfg.ServerID,
+					ServerNamespace: f.cfg.Namespace,
+				},
+				SessionMetadata: events.SessionMetadata{
+					SessionID: string(sessionID),
+					WithMFA:   ctx.Identity.GetIdentity().MFAVerified,
+				},
+				UserMetadata: events.UserMetadata{
+					User:         ctx.User.GetName(),
+					Login:        ctx.User.GetName(),
+					Impersonator: ctx.Identity.GetIdentity().Impersonator,
+				},
+				ConnectionMetadata: events.ConnectionMetadata{
+					RemoteAddr: req.RemoteAddr,
+					LocalAddr:  sess.teleportCluster.targetAddr,
+					Protocol:   events.EventProtocolKube,
+				},
+				CommandMetadata: events.CommandMetadata{
+					Command: strings.Join(request.cmd, " "),
+				},
+				KubernetesClusterMetadata: ctx.eventClusterMeta(),
+				KubernetesPodMetadata:     eventPodMeta,
+			}
+			if err != nil {
+				execEvent.Code = events.ExecFailureCode
+				execEvent.Error = err.Error()
+				if exitErr, ok := err.(utilexec.ExitError); ok && exitErr.Exited() {
+					execEvent.ExitCode = fmt.Sprintf("%d", exitErr.ExitStatus())
+				}
+			} else {
+				execEvent.Code = events.ExecCode
+			}
+			if err := emitter.EmitAuditEvent(f.ctx, execEvent); err != nil {
+				f.log.WithError(err).Warn("Failed to emit event.")
+			}
+		}
+	}()
+
 	if err = executor.Stream(streamOptions); err != nil {
 		f.log.WithError(err).Warning("Executor failed while streaming.")
 		return nil, trace.Wrap(err)
 	}
-	if err := proxy.sendStatus(err); err != nil {
-		f.log.WithError(err).Warning("Failed to send status. Exec command was aborted by client.")
-		return nil, trace.Wrap(err)
-	}
 
-	if request.tty {
-		sessionDataEvent := &events.SessionData{
-			Metadata: events.Metadata{
-				Type:        events.SessionDataEvent,
-				Code:        events.SessionDataCode,
-				ClusterName: f.cfg.ClusterName,
-			},
-			ServerMetadata: events.ServerMetadata{
-				ServerID:        f.cfg.ServerID,
-				ServerNamespace: f.cfg.Namespace,
-			},
-			SessionMetadata: events.SessionMetadata{
-				SessionID: string(sessionID),
-				WithMFA:   ctx.Identity.GetIdentity().MFAVerified,
-			},
-			UserMetadata: events.UserMetadata{
-				User:         ctx.User.GetName(),
-				Login:        ctx.User.GetName(),
-				Impersonator: ctx.Identity.GetIdentity().Impersonator,
-			},
-			ConnectionMetadata: events.ConnectionMetadata{
-				RemoteAddr: req.RemoteAddr,
-				LocalAddr:  sess.teleportCluster.targetAddr,
-				Protocol:   events.EventProtocolKube,
-			},
-			// Bytes transmitted from user to pod.
-			BytesTransmitted: trackIn.Count(),
-			// Bytes received from pod by user.
-			BytesReceived: trackOut.Count() + trackErr.Count(),
-		}
-		if err := emitter.EmitAuditEvent(f.ctx, sessionDataEvent); err != nil {
-			f.log.WithError(err).Warn("Failed to emit session data event.")
-		}
-		sessionEndEvent := &events.SessionEnd{
-			Metadata: events.Metadata{
-				Type:        events.SessionEndEvent,
-				Code:        events.SessionEndCode,
-				ClusterName: f.cfg.ClusterName,
-			},
-			ServerMetadata: events.ServerMetadata{
-				ServerID:        f.cfg.ServerID,
-				ServerNamespace: f.cfg.Namespace,
-			},
-			SessionMetadata: events.SessionMetadata{
-				SessionID: string(sessionID),
-				WithMFA:   ctx.Identity.GetIdentity().MFAVerified,
-			},
-			UserMetadata: events.UserMetadata{
-				User:         ctx.User.GetName(),
-				Login:        ctx.User.GetName(),
-				Impersonator: ctx.Identity.GetIdentity().Impersonator,
-			},
-			ConnectionMetadata: events.ConnectionMetadata{
-				RemoteAddr: req.RemoteAddr,
-				LocalAddr:  sess.teleportCluster.targetAddr,
-				Protocol:   events.EventProtocolKube,
-			},
-			Interactive: true,
-			// There can only be 1 participant, k8s sessions are not join-able.
-			Participants:              []string{ctx.User.GetName()},
-			StartTime:                 sessionStart,
-			EndTime:                   f.cfg.Clock.Now().UTC(),
-			KubernetesClusterMetadata: ctx.eventClusterMeta(),
-			KubernetesPodMetadata:     eventPodMeta,
-			InitialCommand:            request.cmd,
-		}
-		if err := emitter.EmitAuditEvent(f.ctx, sessionEndEvent); err != nil {
-			f.log.WithError(err).Warn("Failed to emit session end event.")
-		}
-	} else {
-		// send an exec event
-		execEvent := &events.Exec{
-			Metadata: events.Metadata{
-				Type:        events.ExecEvent,
-				ClusterName: f.cfg.ClusterName,
-			},
-			ServerMetadata: events.ServerMetadata{
-				ServerID:        f.cfg.ServerID,
-				ServerNamespace: f.cfg.Namespace,
-			},
-			SessionMetadata: events.SessionMetadata{
-				SessionID: string(sessionID),
-				WithMFA:   ctx.Identity.GetIdentity().MFAVerified,
-			},
-			UserMetadata: events.UserMetadata{
-				User:         ctx.User.GetName(),
-				Login:        ctx.User.GetName(),
-				Impersonator: ctx.Identity.GetIdentity().Impersonator,
-			},
-			ConnectionMetadata: events.ConnectionMetadata{
-				RemoteAddr: req.RemoteAddr,
-				LocalAddr:  sess.teleportCluster.targetAddr,
-				Protocol:   events.EventProtocolKube,
-			},
-			CommandMetadata: events.CommandMetadata{
-				Command: strings.Join(request.cmd, " "),
-			},
-			KubernetesClusterMetadata: ctx.eventClusterMeta(),
-			KubernetesPodMetadata:     eventPodMeta,
-		}
-		if err != nil {
-			execEvent.Code = events.ExecFailureCode
-			execEvent.Error = err.Error()
-			if exitErr, ok := err.(utilexec.ExitError); ok && exitErr.Exited() {
-				execEvent.ExitCode = fmt.Sprintf("%d", exitErr.ExitStatus())
-			}
-		} else {
-			execEvent.Code = events.ExecCode
-		}
-		if err := emitter.EmitAuditEvent(f.ctx, execEvent); err != nil {
-			f.log.WithError(err).Warn("Failed to emit event.")
-		}
-	}
-
-	f.log.Debugf("Exited successfully.")
 	return nil, nil
 }
 


### PR DESCRIPTION
Addresses #5624

When a k8s stream exits it emits events that mark the session recording
as complete. Prior to this patch, when the `exec` handler exited before
emitting these "session complete" events due to an error, leaving the
recordings orphaned.

This patch wraps the stream cleanup in a `defer`ed cleanup handler
that marks the stream as complete in any exit mode.