### PR TITLE
Fix an issue with impersonating SSO users

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1231,7 +1231,8 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		log.WithError(err).Debugf("Could not impersonate user %v. The user could not be fetched from local store.", req.Username)
 		return nil, trace.AccessDenied("access denied")
 	}
-	if user.GetCreatedBy().Connector != nil {
+	// Do not allow SSO users to be impersonated.
+	if req.Username != a.context.User.GetName() && user.GetCreatedBy().Connector != nil {
 		log.Warningf("User %v tried to issue a cert for externally managed user %v, this is not supported.", a.context.User.GetName(), req.Username)
 		return nil, trace.AccessDenied("access denied")
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSSOUserCanReissueCert makes sure that SSO user can reissue certificate
+// for themselves.
+func TestSSOUserCanReissueCert(t *testing.T) {
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+
+	// Create test SSO user.
+	user, _, err := CreateUserAndRole(srv.Auth(), "sso-user", []string{"role"})
+	require.NoError(t, err)
+	user.SetCreatedBy(types.CreatedBy{
+		Connector: &types.ConnectorRef{Type: "oidc", ID: "google"},
+	})
+	err = srv.Auth().UpdateUser(ctx, user)
+	require.NoError(t, err)
+
+	client, err := srv.NewClient(TestUser(user.GetName()))
+	require.NoError(t, err)
+
+	_, pub, err := srv.Auth().GenerateKeyPair("")
+	require.NoError(t, err)
+
+	_, err = client.GenerateUserCerts(ctx, proto.UserCertsRequest{
+		PublicKey: pub,
+		Username:  user.GetName(),
+		Expires:   time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fix an issue with SSO users not allowed to reissue certs for themselves due to impersonation checks. Fixes https://github.com/gravitational/teleport/issues/6075.