### PR TITLE
Make error messages specific

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1084,6 +1084,28 @@ func TestU2FSignChallengeCompat(t *testing.T) {
 	})
 }
 
+func TestEmitSSOLoginFailureEvent(t *testing.T) {
+	mockE := &events.MockEmitter{}
+
+	emitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"))
+	event := mockE.LastEvent().(*events.UserLogin)
+
+	require.Equal(t, event.Method, "test")
+	require.Equal(t, event, &events.UserLogin{
+		Metadata: events.Metadata{
+			Type: events.UserLoginEvent,
+			Code: events.UserSSOLoginFailureCode,
+		},
+		Method: "test",
+		Status: events.Status{
+			Success:     false,
+			Error:       "some error",
+			UserMessage: "some error",
+		},
+	})
+
+}
+
 func newTestServices(t *testing.T) Services {
 	bk, err := memory.New(memory.Config{})
 	require.NoError(t, err)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -1088,10 +1088,8 @@ func TestEmitSSOLoginFailureEvent(t *testing.T) {
 	mockE := &events.MockEmitter{}
 
 	emitSSOLoginFailureEvent(context.Background(), mockE, "test", trace.BadParameter("some error"))
-	event := mockE.LastEvent().(*events.UserLogin)
 
-	require.Equal(t, event.Method, "test")
-	require.Equal(t, event, &events.UserLogin{
+	require.Equal(t, mockE.LastEvent(), &events.UserLogin{
 		Metadata: events.Metadata{
 			Type: events.UserLoginEvent,
 			Code: events.UserSSOLoginFailureCode,

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -139,11 +139,11 @@ func GetSAMLServiceProvider(sc SAMLConnector, clock clockwork.Clock) (*saml2.SAM
 			for _, samlCert := range kd.KeyInfo.X509Data.X509Certificates {
 				certData, err := base64.StdEncoding.DecodeString(strings.TrimSpace(samlCert.Data))
 				if err != nil {
-					return nil, trace.Wrap(err)
+					return nil, trace.Wrap(err, "failed to decode certificate defined in entity_descriptor")
 				}
 				cert, err := x509.ParseCertificate(certData)
 				if err != nil {
-					return nil, trace.Wrap(err, "failed to parse certificate in metadata")
+					return nil, trace.Wrap(err, "failed to parse certificate defined in entity_descriptor")
 				}
 				certStore.Roots = append(certStore.Roots, cert)
 			}
@@ -153,7 +153,7 @@ func GetSAMLServiceProvider(sc SAMLConnector, clock clockwork.Clock) (*saml2.SAM
 	if sc.GetCert() != "" {
 		cert, err := tlsca.ParseCertificatePEM([]byte(sc.GetCert()))
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.Wrap(err, "failed to parse certificate defined in cert")
 		}
 		certStore.Roots = append(certStore.Roots, cert)
 	}
@@ -163,7 +163,7 @@ func GetSAMLServiceProvider(sc SAMLConnector, clock clockwork.Clock) (*saml2.SAM
 
 	signingKeyStore, err := utils.ParseSigningKeyStorePEM(sc.GetSigningKeyPair().PrivateKey, sc.GetSigningKeyPair().Cert)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "failed to parse certificate defined in signing_key_pair")
 	}
 
 	// The encryption keystore here is defaulted to the value of the signing keystore
@@ -174,7 +174,7 @@ func GetSAMLServiceProvider(sc SAMLConnector, clock clockwork.Clock) (*saml2.SAM
 	if encryptionKeyPair != nil {
 		encryptionKeyStore, err = utils.ParseSigningKeyStorePEM(encryptionKeyPair.PrivateKey, encryptionKeyPair.Cert)
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.Wrap(err, "failed to parse certificate defined in assertion_key_pair")
 		}
 	}
 

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -189,6 +189,7 @@ func UserMessageFromError(err error) string {
 	if err != nil {
 		var buf bytes.Buffer
 		fmt.Fprint(&buf, Color(Red, "ERROR: "))
+
 		// If the error is a trace error, check if it has a user message embedded in
 		// it, if it does, print it, otherwise escape and print the original error.
 		if er, ok := err.(*trace.TraceErr); ok {
@@ -197,8 +198,15 @@ func UserMessageFromError(err error) string {
 			}
 			fmt.Fprintln(&buf, AllowNewlines(trace.Unwrap(er).Error()))
 		} else {
-			fmt.Fprintln(&buf, AllowNewlines(err.Error()))
+			strErr := err.Error()
+			// Error can be of type trace.proxyError where error message didn't get captured.
+			if strErr == "" {
+				fmt.Fprintln(&buf, "please check Teleport's log for more details")
+			} else {
+				fmt.Fprintln(&buf, AllowNewlines(err.Error()))
+			}
 		}
+
 		return buf.String()
 	}
 	return ""

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -914,17 +914,15 @@ func (h *Handler) githubLoginConsole(w http.ResponseWriter, r *http.Request, p h
 	logger := h.log.WithField("auth", "github")
 	logger.Debug("Console login start.")
 
-	generalErr := trace.AccessDenied(ssoLoginConsoleErr)
-
 	req := new(client.SSOLoginConsoleReq)
 	if err := httplib.ReadJSON(r, req); err != nil {
 		logger.WithError(err).Error("Error reading json.")
-		return nil, generalErr
+		return nil, trace.AccessDenied(ssoLoginConsoleErr)
 	}
 
 	if err := req.CheckAndSetDefaults(); err != nil {
 		logger.WithError(err).Error("Missing request parameters.")
-		return nil, generalErr
+		return nil, trace.AccessDenied(ssoLoginConsoleErr)
 	}
 
 	response, err := h.cfg.ProxyClient.CreateGithubAuthRequest(
@@ -939,7 +937,7 @@ func (h *Handler) githubLoginConsole(w http.ResponseWriter, r *http.Request, p h
 		})
 	if err != nil {
 		logger.WithError(err).Error("Failed to create Github auth request.")
-		return nil, generalErr
+		return nil, trace.AccessDenied(ssoLoginConsoleErr)
 	}
 
 	return &client.SSOLoginConsoleResponse{
@@ -1004,17 +1002,15 @@ func (h *Handler) oidcLoginConsole(w http.ResponseWriter, r *http.Request, p htt
 	logger := h.log.WithField("auth", "oidc")
 	logger.Debug("Console login start.")
 
-	generalErr := trace.AccessDenied(ssoLoginConsoleErr)
-
 	req := new(client.SSOLoginConsoleReq)
 	if err := httplib.ReadJSON(r, req); err != nil {
 		logger.WithError(err).Error("Error reading json.")
-		return nil, generalErr
+		return nil, trace.AccessDenied(ssoLoginConsoleErr)
 	}
 
 	if err := req.CheckAndSetDefaults(); err != nil {
 		logger.WithError(err).Error("Missing request parameters.")
-		return nil, generalErr
+		return nil, trace.AccessDenied(ssoLoginConsoleErr)
 	}
 
 	response, err := h.cfg.ProxyClient.CreateOIDCAuthRequest(
@@ -1030,7 +1026,7 @@ func (h *Handler) oidcLoginConsole(w http.ResponseWriter, r *http.Request, p htt
 		})
 	if err != nil {
 		logger.WithError(err).Error("Failed to create OIDC auth request.")
-		return nil, generalErr
+		return nil, trace.AccessDenied(ssoLoginConsoleErr)
 	}
 
 	return &client.SSOLoginConsoleResponse{

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -66,6 +66,11 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+const (
+	// ssoLoginConsoleErr is a generic error message to hide revealing sso login failure msgs.
+	ssoLoginConsoleErr = "Failed to login. Please check Teleport's log for more details."
+)
+
 // Handler is HTTP web proxy handler
 type Handler struct {
 	log logrus.FieldLogger
@@ -906,14 +911,22 @@ func (h *Handler) githubLoginWeb(w http.ResponseWriter, r *http.Request, p httpr
 }
 
 func (h *Handler) githubLoginConsole(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
-	h.log.WithField("auth", "github").Debug("Console login start.")
+	logger := h.log.WithField("auth", "github")
+	logger.Debug("Console login start.")
+
+	generalErr := trace.AccessDenied(ssoLoginConsoleErr)
+
 	req := new(client.SSOLoginConsoleReq)
 	if err := httplib.ReadJSON(r, req); err != nil {
-		return nil, trace.Wrap(err)
+		logger.WithError(err).Error("Error reading json.")
+		return nil, generalErr
 	}
+
 	if err := req.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
+		logger.WithError(err).Error("Missing request parameters.")
+		return nil, generalErr
 	}
+
 	response, err := h.cfg.ProxyClient.CreateGithubAuthRequest(
 		services.GithubAuthRequest{
 			ConnectorID:       req.ConnectorID,
@@ -925,8 +938,10 @@ func (h *Handler) githubLoginConsole(w http.ResponseWriter, r *http.Request, p h
 			KubernetesCluster: req.KubernetesCluster,
 		})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		logger.WithError(err).Error("Failed to create Github auth request.")
+		return nil, generalErr
 	}
+
 	return &client.SSOLoginConsoleResponse{
 		RedirectURL: response.RedirectURL,
 	}, nil
@@ -986,14 +1001,22 @@ func (h *Handler) githubCallback(w http.ResponseWriter, r *http.Request, p httpr
 }
 
 func (h *Handler) oidcLoginConsole(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
-	h.log.WithField("auth", "oidc").Debug("Console login start.")
+	logger := h.log.WithField("auth", "oidc")
+	logger.Debug("Console login start.")
+
+	generalErr := trace.AccessDenied(ssoLoginConsoleErr)
+
 	req := new(client.SSOLoginConsoleReq)
 	if err := httplib.ReadJSON(r, req); err != nil {
-		return nil, trace.Wrap(err)
+		logger.WithError(err).Error("Error reading json.")
+		return nil, generalErr
 	}
+
 	if err := req.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
+		logger.WithError(err).Error("Missing request parameters.")
+		return nil, generalErr
 	}
+
 	response, err := h.cfg.ProxyClient.CreateOIDCAuthRequest(
 		services.OIDCAuthRequest{
 			ConnectorID:       req.ConnectorID,
@@ -1006,8 +1029,10 @@ func (h *Handler) oidcLoginConsole(w http.ResponseWriter, r *http.Request, p htt
 			KubernetesCluster: req.KubernetesCluster,
 		})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		logger.WithError(err).Error("Failed to create OIDC auth request.")
+		return nil, generalErr
 	}
+
 	return &client.SSOLoginConsoleResponse{
 		RedirectURL: response.RedirectURL,
 	}, nil

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -57,17 +57,15 @@ func (h *Handler) samlSSOConsole(w http.ResponseWriter, r *http.Request, p httpr
 	logger := h.log.WithField("auth", "saml")
 	logger.Debug("Console login start.")
 
-	generalErr := trace.AccessDenied(ssoLoginConsoleErr)
-
 	req := new(client.SSOLoginConsoleReq)
 	if err := httplib.ReadJSON(r, req); err != nil {
 		logger.WithError(err).Error("Error reading json.")
-		return nil, generalErr
+		return nil, trace.AccessDenied(ssoLoginConsoleErr)
 	}
 
 	if err := req.CheckAndSetDefaults(); err != nil {
 		logger.WithError(err).Error("Missing request parameters.")
-		return nil, generalErr
+		return nil, trace.AccessDenied(ssoLoginConsoleErr)
 	}
 
 	response, err := h.cfg.ProxyClient.CreateSAMLAuthRequest(
@@ -82,7 +80,7 @@ func (h *Handler) samlSSOConsole(w http.ResponseWriter, r *http.Request, p httpr
 		})
 	if err != nil {
 		logger.WithError(err).Error("Failed to create SAML auth request.")
-		return nil, generalErr
+		return nil, trace.AccessDenied(ssoLoginConsoleErr)
 	}
 
 	return &client.SSOLoginConsoleResponse{RedirectURL: response.RedirectURL}, nil

--- a/lib/web/saml.go
+++ b/lib/web/saml.go
@@ -54,14 +54,22 @@ func (h *Handler) samlSSO(w http.ResponseWriter, r *http.Request, p httprouter.P
 }
 
 func (h *Handler) samlSSOConsole(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
-	h.log.WithField("auth", "saml").Debug("SSO console start.")
+	logger := h.log.WithField("auth", "saml")
+	logger.Debug("Console login start.")
+
+	generalErr := trace.AccessDenied(ssoLoginConsoleErr)
+
 	req := new(client.SSOLoginConsoleReq)
 	if err := httplib.ReadJSON(r, req); err != nil {
-		return nil, trace.Wrap(err)
+		logger.WithError(err).Error("Error reading json.")
+		return nil, generalErr
 	}
+
 	if err := req.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
+		logger.WithError(err).Error("Missing request parameters.")
+		return nil, generalErr
 	}
+
 	response, err := h.cfg.ProxyClient.CreateSAMLAuthRequest(
 		services.SAMLAuthRequest{
 			ConnectorID:       req.ConnectorID,
@@ -73,8 +81,10 @@ func (h *Handler) samlSSOConsole(w http.ResponseWriter, r *http.Request, p httpr
 			KubernetesCluster: req.KubernetesCluster,
 		})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		logger.WithError(err).Error("Failed to create SAML auth request.")
+		return nil, generalErr
 	}
+
 	return &client.SSOLoginConsoleResponse{RedirectURL: response.RedirectURL}, nil
 }
 


### PR DESCRIPTION
resolves https://github.com/gravitational/teleport/issues/6046

#### Description
Note: there is a bug with trace marshalling proxyErr: https://github.com/gravitational/teleport/pull/6108#discussion_r599795110

Purpose is to allow users with admin privilege that are able to view audit logs, to be able to debug SSO login failures from the UI as much as possible:
- emit audit events when there are failures from creating sso auth requests
- since we no longer expose any specific errors when users fail to login from UI, returned error messages are more specific so that it is clear what the error is when viewing audit logs
- return generic `login failed` message for sso CLI login failures (which are errors from creating an auth request) similar in the UI dashbaord where we also display generic error message
