### PR TITLE
Load user key for cluster inferred from jumphost certificate

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1933,7 +1933,9 @@ func (tc *TeleportClient) connectToProxy(ctx context.Context) (*ProxyClient, err
 		sshProxyAddr = tc.JumpHosts[0].Addr.Addr
 
 		// Perform a "dummy" connection to the jumphost to examine its certificate
-		// and load a different user certificate if appropriate.
+		// and load a corresponding user certificate to be used by tc.authMethods.
+		// TODO(andrej): Get rid of the individually packaged authMethods,
+		// and embed this reissue logic with ssh.PublicKeysCallback.
 		tmpConfig := &ssh.ClientConfig{
 			User:            proxyPrincipal,
 			HostKeyCallback: tc.loadKeyForClusterFromCert(ctx),


### PR DESCRIPTION
Fixes #5637 according to #5566. Based on #5938.

Unfortunately, `golang.org/x/crypto/ssh` has most of the key exchange specific pieces unexported. Therefore I do a proper `ssh.Dial` call to analyze the jumphost cert which is just ended prematurely by an error always returned from the custom `HostKeyCallback`.