### PR TITLE
Backport #5942 onto branch/v6

### DIFF
--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -388,6 +388,16 @@ type withKubeCerts struct {
 func (o withKubeCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
 	switch s := store.(type) {
 	case *FSLocalKeyStore:
+		// If we are reading from a `~/.tsh` directrory made by a pre-6.0 version
+		// of `tsh`, the teleportClusterName can sometimes be empty, and we will
+		// end up enumerating the parent directory instead, and failing badly.
+		// For more info, see:
+		//    https://github.com/gravitational/teleport/issues/5774
+		if o.teleportClusterName == "" {
+			s.log.Warning("Empty teleport cluster name, abandoning key search.")
+			return nil
+		}
+
 		dirPath := s.dirFor(idx.proxyHost)
 		kubeDir := filepath.Join(dirPath, idx.username+kubeDirSuffix, o.teleportClusterName)
 		kubeFiles, err := ioutil.ReadDir(kubeDir)
@@ -454,6 +464,16 @@ type withDBCerts struct {
 func (o withDBCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
 	switch s := store.(type) {
 	case *FSLocalKeyStore:
+		// If we are reading from a `~/.tsh` directrory made by a pre-6.0 version
+		// of `tsh`, the teleportClusterName can sometimes be empty, and we will
+		// end up enumerating the parent directory instead, and failing badly.
+		// For more info, see:
+		//    https://github.com/gravitational/teleport/issues/5774
+		if o.teleportClusterName == "" {
+			s.log.Warning("Empty teleport cluster name, abandoning key search.")
+			return nil
+		}
+
 		dirPath := s.dirFor(idx.proxyHost)
 		dbDir := filepath.Join(dirPath, idx.username+dbDirSuffix, o.teleportClusterName)
 		dbFiles, err := ioutil.ReadDir(dbDir)

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -80,6 +80,25 @@ func TestListKeys(t *testing.T) {
 	require.Equal(t, samKey.Pub, skey.Pub)
 }
 
+func TestEmptyTeleportClusterNameIsNotAnError(t *testing.T) {
+	s, cleanup := newTest(t)
+	defer cleanup()
+
+	// Given a key store with a valid directory structure
+	host := "some-host"
+	user := "zaphod"
+	key := s.makeSignedKey(t, false)
+	require.NoError(t, s.addKey(host, user, key))
+
+	// When I attempt to enumerate the user's keys with an empty teleport
+	// cluster name
+	k, err := s.store.GetKey(host, user, WithDBCerts("", ""), WithKubeCerts(""))
+
+	// Expect the key enumeration to succeed
+	require.NoError(t, err)
+	require.NotNil(t, k)
+}
+
 func TestKeyCRUD(t *testing.T) {
 	s, cleanup := newTest(t)
 	defer cleanup()


### PR DESCRIPTION
Skip enumerating keys when cluster name is empty (#5942)

Addresses Issue #5774

Prior to this change key enumeration could fail with an error if the cluster value in the `tsh` config was missing, which is possible when a post-v6.0 `tsh` reads a ~/.tsh directory created by a pre-v6.0 `tsh`. This would ultimately cause the key enumeration code to search the wrong directory for keys, resulting in an attempt to read a directory as a key file, and failing.

This patch adds detection for an empty cluster name, and gracefully aborts the key enumeration without error if found.