### PR TITLE
go mod conflict fix - API dependency fix

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -11,11 +11,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/stretchr/testify v1.2.2
-<<<<<<< HEAD
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-=======
-	github.com/vulcand/predicate v1.1.0
->>>>>>> custom approval conditions
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	google.golang.org/grpc v1.27.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -45,8 +45,6 @@ github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/vulcand/predicate v1.1.0 h1:Gq/uWopa4rx/tnZu2opOSBqHK63Yqlou/SzrbwdJiNg=
-github.com/vulcand/predicate v1.1.0/go.mod h1:mlccC5IRBoc2cIFmCB8ZM62I3VDb6p2GXESMHa3CnZg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -26,8 +26,6 @@ import (
 	"github.com/gravitational/teleport/api/utils"
 
 	"github.com/gravitational/trace"
-
-	"github.com/vulcand/predicate"
 )
 
 // AccessRequest is a request for temporarily granted roles
@@ -404,23 +402,6 @@ func (r *AccessRequestV3) Equals(other AccessRequest) bool {
 		return false
 	}
 	return r.Spec.Equals(&o.Spec)
-}
-
-// MatchesFilter returns true if Filter rule matches
-// Empty Filter block always matches
-func (t AccessReviewThreshold) MatchesFilter(parser predicate.Parser) (bool, error) {
-	if t.Filter == "" {
-		return true, nil
-	}
-	ifn, err := parser.Parse(t.Filter)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	fn, ok := ifn.(predicate.BoolPredicate)
-	if !ok {
-		return false, trace.BadParameter("unsupported type: %T", ifn)
-	}
-	return fn(), nil
 }
 
 func (t AccessReviewThreshold) Equals(other AccessReviewThreshold) bool {


### PR DESCRIPTION
Moved usage of predicate package out of `/api`.

Also fixes the merge conflict that hit master.