### PR TITLE
drone: use emptyDir for /var/lib/docker filesystem and prevent repetitive docker pulls

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -182,6 +182,8 @@ services:
   volumes:
   - name: tmpfs
     path: /tmpfs
+  - name: dockertmpfs
+    path: /var/lib/docker
   - name: tmp-dind
     path: /tmp
   - name: dockersock
@@ -194,6 +196,9 @@ volumes:
   temp: {}
 - name: tmp-integration
   temp: {}
+- name: dockertmpfs
+  temp:
+    medium: memory
 - name: dockersock
   temp: {}
 
@@ -201,7 +206,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tests.go:203
+# Generated at dronegen/tests.go:212
 ################################################
 
 kind: pipeline
@@ -283,10 +288,15 @@ services:
   volumes:
   - name: tmpfs
     path: /tmpfs
+  - name: dockertmpfs
+    path: /var/lib/docker
   - name: dockersock
     path: /var/run
 volumes:
 - name: tmpfs
+  temp:
+    medium: memory
+- name: dockertmpfs
   temp:
     medium: memory
 - name: dockersock
@@ -4810,6 +4820,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: fa1617bb641bac2a46794d59f6d56cbc1b56d6d329819bd11902ca9c8d35f466
+hmac: 273dd935191f15a3702b79a2ee55d5557e51b27a2ae3fe567c94d251f6925a66
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -197,8 +197,7 @@ volumes:
 - name: tmp-integration
   temp: {}
 - name: dockertmpfs
-  temp:
-    medium: memory
+  temp: {}
 - name: dockersock
   temp: {}
 
@@ -297,8 +296,7 @@ volumes:
   temp:
     medium: memory
 - name: dockertmpfs
-  temp:
-    medium: memory
+  temp: {}
 - name: dockersock
   temp: {}
 
@@ -4820,6 +4818,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 273dd935191f15a3702b79a2ee55d5557e51b27a2ae3fe567c94d251f6925a66
+hmac: ae3ff2a037f49f8d0e65528ea54f3b36cce40fb8adc510399696b33d77e0858a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -197,7 +197,8 @@ volumes:
 - name: tmp-integration
   temp: {}
 - name: dockertmpfs
-  temp: {}
+  temp:
+    medium: memory
 - name: dockersock
   temp: {}
 
@@ -296,7 +297,8 @@ volumes:
   temp:
     medium: memory
 - name: dockertmpfs
-  temp: {}
+  temp:
+    medium: memory
 - name: dockersock
   temp: {}
 
@@ -4818,6 +4820,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: ae3ff2a037f49f8d0e65528ea54f3b36cce40fb8adc510399696b33d77e0858a
+hmac: 273dd935191f15a3702b79a2ee55d5557e51b27a2ae3fe567c94d251f6925a66
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4816,6 +4816,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: b1b878d26e4dd1ce8ed79ddee41c2755699ac00372e9005e217da381c517adc0
+hmac: ea48c40817f928bb53c17bfaae579a2475ee714cf210fea2822686b29b3d9128
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4816,6 +4816,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: e956d76b720c3936fbddd642d80d8c378a2f2c5c3b8886bbeb501f52b1ffb2c5
+hmac: f5e6036b7251ed5eeedc9a70a811e92c7c91f598094dd7f4de118b48f750cf9b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -184,7 +184,7 @@ services:
     path: /tmpfs
   - name: dockertmpfs
     path: /var/lib/docker
-  - name: tmp-dind
+  - name: tmp-integration
     path: /tmp
   - name: dockersock
     path: /var/run
@@ -192,8 +192,6 @@ volumes:
 - name: tmpfs
   temp:
     medium: memory
-- name: tmp-dind
-  temp: {}
 - name: tmp-integration
   temp: {}
 - name: dockertmpfs
@@ -205,7 +203,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tests.go:212
+# Generated at dronegen/tests.go:211
 ################################################
 
 kind: pipeline
@@ -4818,6 +4816,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: ae3ff2a037f49f8d0e65528ea54f3b36cce40fb8adc510399696b33d77e0858a
+hmac: 165609e63219f6d5946756788e82477a2f5336985fc985aaace1afbbe787c816
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4816,6 +4816,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: f5e6036b7251ed5eeedc9a70a811e92c7c91f598094dd7f4de118b48f750cf9b
+hmac: b1b878d26e4dd1ce8ed79ddee41c2755699ac00372e9005e217da381c517adc0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4816,6 +4816,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 165609e63219f6d5946756788e82477a2f5336985fc985aaace1afbbe787c816
+hmac: e956d76b720c3936fbddd642d80d8c378a2f2c5c3b8886bbeb501f52b1ffb2c5
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -88,6 +88,9 @@ build-binaries-fips: buildbox-fips
 
 #
 # Builds a Docker container which is used for building official Teleport binaries
+# If running in CI and there is no image with the buildbox name:tag combination present locally,
+# the image is pulled from the Docker repository. If this pull fails (i.e. when a new Go runtime is
+# first used), the error is ignored and the buildbox is built using the Dockerfile.
 #
 .PHONY:buildbox
 buildbox:

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -92,7 +92,7 @@ build-binaries-fips: buildbox-fips
 .PHONY:buildbox
 buildbox:
 	if [[ "$(BUILDBOX_NAME)" == "$(BUILDBOX)" ]]; then \
-		if [[ $${DRONE} == "true" ]]; then docker pull $(BUILDBOX) || true; fi; \
+		if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX) 2>&1 >/dev/null; then docker pull $(BUILDBOX) || true; fi; \
 		docker build \
 			--build-arg UID=$(UID) \
 			--build-arg GID=$(GID) \
@@ -110,7 +110,7 @@ buildbox:
 .PHONY:buildbox-fips
 buildbox-fips:
 	if [[ "$(BUILDBOX_FIPS_NAME)" == "$(BUILDBOX_FIPS)" ]]; then \
-		if [[ $${DRONE} == "true" ]]; then docker pull $(BUILDBOX_FIPS) || true; fi; \
+		if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_FIPS) 2>&1 >/dev/null; then docker pull $(BUILDBOX_FIPS) || true; fi; \
 		docker build \
 			--build-arg UID=$(UID) \
 			--build-arg GID=$(GID) \
@@ -124,7 +124,7 @@ buildbox-fips:
 #
 .PHONY:buildbox-centos6
 buildbox-centos6:
-	@if [[ $${DRONE} == "true" ]]; then docker pull $(BUILDBOX_CENTOS6) || true; fi;
+	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_CENTOS6) 2>&1 >/dev/null; then docker pull $(BUILDBOX_CENTOS6) || true; fi;
 	docker build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
@@ -137,7 +137,7 @@ buildbox-centos6:
 #
 .PHONY:buildbox-centos6-fips
 buildbox-centos6-fips:
-	@if [[ $${DRONE} == "true" ]]; then docker pull $(BUILDBOX_CENTOS6_FIPS) || true; fi;
+	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_CENTOS6_FIPS) 2>&1 >/dev/null; then docker pull $(BUILDBOX_CENTOS6_FIPS) || true; fi;
 	docker build \
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
@@ -152,7 +152,7 @@ buildbox-centos6-fips:
 #
 .PHONY:buildbox-arm
 buildbox-arm: buildbox
-	@if [[ $${DRONE} == "true" ]]; then docker pull $(BUILDBOX_ARM) || true; fi;
+	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_ARM) 2>&1 >/dev/null; then docker pull $(BUILDBOX_ARM) || true; fi;
 	docker build \
 		--build-arg RUNTIME=$(RUNTIME) \
 		--cache-from $(BUILDBOX) \
@@ -166,7 +166,7 @@ buildbox-arm: buildbox
 #
 .PHONY:buildbox-arm-fips
 buildbox-arm-fips: buildbox-fips
-	@if [[ $${DRONE} == "true" ]]; then docker pull $(BUILDBOX_ARM_FIPS) || true; fi;
+	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_ARM_FIPS) 2>&1 >/dev/null; then docker pull $(BUILDBOX_ARM_FIPS) || true; fi;
 	docker build \
 		--build-arg RUNTIME=$(RUNTIME) \
 		--cache-from $(BUILDBOX_FIPS) \

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -51,10 +51,6 @@ var (
 		Name: "dockertmpfs",
 		Path: "/var/lib/docker",
 	}
-	volumeRefTmpDind = volumeRef{
-		Name: "tmp-dind",
-		Path: "/tmp",
-	}
 	volumeRefTmpIntegration = volumeRef{
 		Name: "tmp-integration",
 		Path: "/tmp",

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -22,6 +22,10 @@ var (
 		Name: "dockersock",
 		Temp: &volumeTemp{},
 	}
+	volumeDockerTmpfs = volume{
+		Name: "dockertmpfs",
+		Temp: &volumeTemp{Medium: "memory"},
+	}
 	volumeTmpfs = volume{
 		Name: "tmpfs",
 		Temp: &volumeTemp{Medium: "memory"},
@@ -42,6 +46,10 @@ var (
 	volumeRefDocker = volumeRef{
 		Name: "dockersock",
 		Path: "/var/run",
+	}
+	volumeRefDockerTmpfs = volumeRef{
+		Name: "dockertmpfs",
+		Path: "/var/lib/docker",
 	}
 	volumeRefTmpDind = volumeRef{
 		Name: "tmp-dind",

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -24,7 +24,7 @@ var (
 	}
 	volumeDockerTmpfs = volume{
 		Name: "dockertmpfs",
-		Temp: &volumeTemp{Medium: "memory"},
+		Temp: &volumeTemp{},
 	}
 	volumeTmpfs = volume{
 		Name: "tmpfs",

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -30,10 +30,6 @@ var (
 		Name: "tmpfs",
 		Temp: &volumeTemp{Medium: "memory"},
 	}
-	volumeTmpDind = volume{
-		Name: "tmp-dind",
-		Temp: &volumeTemp{},
-	}
 	volumeTmpIntegration = volume{
 		Name: "tmp-integration",
 		Temp: &volumeTemp{},

--- a/dronegen/tests.go
+++ b/dronegen/tests.go
@@ -77,7 +77,6 @@ func testCodePipeline() pipeline {
 	p.Workspace = workspace{Path: "/go"}
 	p.Volumes = dockerVolumes(
 		volumeTmpfs,
-		volumeTmpDind,
 		volumeTmpIntegration,
 		volumeDockerTmpfs,
 	)
@@ -85,7 +84,7 @@ func testCodePipeline() pipeline {
 		dockerService(
 			volumeRefTmpfs,
 			volumeRefDockerTmpfs,
-			volumeRefTmpDind,
+			volumeRefTmpIntegration,
 		),
 	}
 	goEnvironment := map[string]value{

--- a/dronegen/tests.go
+++ b/dronegen/tests.go
@@ -75,9 +75,18 @@ func testCodePipeline() pipeline {
 	}
 	p.Trigger = triggerPullRequest
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = dockerVolumes(volumeTmpfs, volumeTmpDind, volumeTmpIntegration)
+	p.Volumes = dockerVolumes(
+		volumeTmpfs,
+		volumeTmpDind,
+		volumeTmpIntegration,
+		volumeDockerTmpfs,
+	)
 	p.Services = []service{
-		dockerService(volumeRefTmpfs, volumeRefTmpDind),
+		dockerService(
+			volumeRefTmpfs,
+			volumeRefDockerTmpfs,
+			volumeRefTmpDind,
+		),
 	}
 	goEnvironment := map[string]value{
 		"GOCACHE": value{raw: "/tmpfs/go/cache"},
@@ -203,9 +212,15 @@ func testDocsPipeline() pipeline {
 	p := newKubePipeline("test-docs")
 	p.Trigger = triggerPullRequest
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = dockerVolumes(volumeTmpfs)
+	p.Volumes = dockerVolumes(
+		volumeTmpfs,
+		volumeDockerTmpfs,
+	)
 	p.Services = []service{
-		dockerService(volumeRefTmpfs),
+		dockerService(
+			volumeRefTmpfs,
+			volumeRefDockerTmpfs,
+		),
 	}
 	p.Steps = []step{
 		{


### PR DESCRIPTION
Explicitly mounts Docker-in-Docker's `/var/lib/docker` using an `emptyDir`, which will be backed by the worker's SSD filesystem. This will remove a layer of abstraction so we're not writing a Docker overlay filesystem inside a container which is itself running on an overlay filesystem.

Also adds a check when running in CI to see whether a Docker image with a matching `name:tag` is already present and avoid pulling if so. This prevents an edge case I introduced recently where a second image pull will reset the image digest after a changed build. The effect is described below.

Current pipeline:
- `make buildbox`
  - triggers `docker pull buildbox`
  - triggers `docker build buildbox`
    - if cache matches: this is basically a no-op
    - if cache doesn't match: buildbox gets rebuilt
- `make lint`
  - triggers `docker pull buildbox` again (which will change the digest back if `docker build` changed it)
  - triggers `docker build buildbox` again
    - if cache matches: no-op
    - if cache doesn't match: buildbox needlessly gets rebuilt again
- `make test` (same thing happens)
- `make integration` (same thing happens again)

New workflow with this PR (changes in **bold**):
- `make buildbox`
  - triggers `docker pull buildbox` as there is no image with that name:tag locally
  - triggers `docker build buildbox`
    - if cache matches: this is basically a no-op
    - if cache doesn't match: buildbox gets rebuilt
- `make lint`
  - **no longer triggers `docker pull buildbox` again as there is a matching image locally**
  - triggers `docker build buildbox` again
    - **this will always be a no-op using cache**
- `make test` (**uses local image**)
- `make integration` (**uses local image**)