### PR TITLE
Allow custom environment variables in PAM with SSO interpolation

### DIFF
--- a/build.assets/pam/pam_teleport.c
+++ b/build.assets/pam/pam_teleport.c
@@ -25,6 +25,13 @@ int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv)
         pam_info(pamh, "%s", getenv("TELEPORT_ROLES"));
     } else if (argc > 0 && argv[0][0] == '0') {
         return PAM_ACCT_EXPIRED;
+    } else if (argc > 0 && strcmp(argv[0], "test_custom_env") == 0) {
+        // If the "test_custom_env" command is requested it will verify custom env inputs.
+        if (strcmp(getenv("FIRST_NAME"), "JOHN") == 0
+            && strcmp(getenv("LAST_NAME"), "DOE") == 0
+            && strcmp(getenv("OTHER"), "integration") == 0) {
+            pam_info(pamh, "pam_custom_envs OK");
+        }
     }
 
     pam_info(pamh, "pam_sm_acct_mgmt OK");

--- a/build.assets/pam/policy/teleport-custom-env
+++ b/build.assets/pam/policy/teleport-custom-env
@@ -1,0 +1,3 @@
+account     required    pam_teleport.so test_custom_env
+auth        required    pam_teleport.so 1
+session     required    pam_teleport.so 1

--- a/constants.go
+++ b/constants.go
@@ -494,6 +494,9 @@ const (
 	// local accounts.
 	TraitInternalPrefix = "internal"
 
+	// TraitExternalPrefix is the role variable prefix that indicates the data comes from an external identity provider.
+	TraitExternalPrefix = "external"
+
 	// TraitLogins is the name the role variable used to store
 	// allowed logins.
 	TraitLogins = "logins"

--- a/docs/pages/features/ssh-pam.mdx
+++ b/docs/pages/features/ssh-pam.mdx
@@ -73,6 +73,31 @@ but before the shell is run. It is generally used for important system-wide anno
 This feature can help you inform users that activity on the node is being audited
 and recorded.
 
+## Custom environment variables
+
+Teleport supports setting arbitrary environment variables for PAM modules as of version 6.1.
+These variables can also be role-style SSO claims in the form `{{ external.email }}`
+where `email` is a claim made by the configured SSO IdP.
+
+To set custom environment variables, update `/etc/teleport.yaml` with:
+
+```yaml
+ssh_service:
+  pam:
+    # disabled by default
+    enabled: true
+    # use /etc/pam.d/sshd configuration (the default)
+    service_name: "sshd"
+    # use the "auth" modules in the PAM config
+    # "false" by default
+    use_pam_auth: true
+    # sets custom environment variables for PAM modules
+    # no environment variables except the standard `TELEPORT_USERNAME`, `TELEPORT_LOGIN`, and `TELEPORT_ROLES`
+    environment:
+      FOO: "bar"
+      EMAIL: "{{ external.email }}"
+```
+
 ### Example node with PAM turned off
 
 ```yaml

--- a/docs/testplan.md
+++ b/docs/testplan.md
@@ -30,6 +30,8 @@ as well as an upgrade of the previous version of Teleport.
   - [ ] Allow/deny role option: SSH agent forwarding
   - [ ] Allow/deny role option: Port forwarding
 
+- [ ] Verify that custom PAM environment variables are available as expected.
+
 - [ ] Users
 With every user combination, try to login and signup with invalid second factor, invalid password to see how the system reacts.
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3224,6 +3224,7 @@ func (s *IntSuite) TestPAM(c *check.C) {
 		inServiceName string
 		inUsePAMAuth  bool
 		outContains   []string
+		environment   map[string]string
 	}{
 		// 0 - No PAM support, session should work but no PAM related output.
 		{
@@ -3269,6 +3270,23 @@ func (s *IntSuite) TestPAM(c *check.C) {
 			inUsePAMAuth:  true,
 			outContains:   []string{},
 		},
+		// 5 - PAM enabled, custom environment variables are passed.
+		{
+			inEnabled:     true,
+			inServiceName: "teleport-custom-env",
+			inUsePAMAuth:  false,
+			outContains: []string{
+				"pam_sm_acct_mgmt OK",
+				"pam_sm_open_session OK",
+				"pam_sm_close_session OK",
+				"pam_custom_envs OK",
+			},
+			environment: map[string]string{
+				"FIRST_NAME": "JOHN",
+				"LAST_NAME":  "DOE",
+				"OTHER":      "{{ external.testing }}",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3285,6 +3303,7 @@ func (s *IntSuite) TestPAM(c *check.C) {
 			tconf.SSH.PAM.Enabled = tt.inEnabled
 			tconf.SSH.PAM.ServiceName = tt.inServiceName
 			tconf.SSH.PAM.UsePAMAuth = tt.inUsePAMAuth
+			tconf.SSH.PAM.Environment = tt.environment
 
 			return c, nil, nil, tconf
 		}
@@ -5131,6 +5150,7 @@ func hasPAMPolicy() bool {
 		"/etc/pam.d/teleport-acct-failure",
 		"/etc/pam.d/teleport-session-failure",
 		"/etc/pam.d/teleport-success",
+		"/etc/pam.d/teleport-custom-env",
 	}
 
 	for _, fileName := range pamPolicyFiles {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -855,6 +855,10 @@ type PAM struct {
 	// UsePAMAuth specifies whether to trigger the "auth" PAM modules from the
 	// policy.
 	UsePAMAuth bool `yaml:"use_pam_auth"`
+
+	// Environment represents environment variables to pass to PAM.
+	// These may contain role-style interpolation syntax.
+	Environment map[string]string `yaml:"environment,omitempty"`
 }
 
 // Parse returns a parsed pam.Config.
@@ -868,6 +872,7 @@ func (p *PAM) Parse() *pam.Config {
 		Enabled:     enabled,
 		ServiceName: serviceName,
 		UsePAMAuth:  p.UsePAMAuth,
+		Environment: p.Environment,
 	}
 }
 

--- a/lib/pam/config.go
+++ b/lib/pam/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	// UsePAMAuth specifies whether to trigger the "auth" PAM modules from the
 	// policy.
 	UsePAMAuth bool
+
+	// Environment represents environment variables to pass to PAM.
+	// These may contain role-style interpolation syntax.
+	Environment map[string]string
 }
 
 // CheckDefaults makes sure the Config structure has minimum required values.

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -39,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/uacc"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -676,24 +678,70 @@ func (c *ServerContext) String() string {
 	return fmt.Sprintf("ServerContext(%v->%v, user=%v, id=%v)", c.ServerConn.RemoteAddr(), c.ServerConn.LocalAddr(), c.ServerConn.User(), c.id)
 }
 
-// ExecCommand takes a *ServerContext and extracts the parts needed to create
-// an *execCommand which can be re-sent to Teleport.
-func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
-	var pamEnabled bool
-	var pamServiceName string
-	var pamUseAuth bool
+func getPAMConfig(c *ServerContext) (*PAMConfig, error) {
+	// PAM should be disabled.
+	if c.srv.Component() != teleport.ComponentNode {
+		return nil, nil
+	}
 
-	// If this code is running on a node, check if PAM is enabled or not.
-	if c.srv.Component() == teleport.ComponentNode {
-		conf, err := c.srv.GetPAM()
+	localPAMConfig, err := c.srv.GetPAM()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// We use nil/empty to figure out if PAM is disabled later.
+	if !localPAMConfig.Enabled {
+		return nil, nil
+	}
+
+	// If the identity has roles, extract the role names.
+	var roleNames []string
+	if len(c.Identity.RoleSet) > 0 {
+		roleNames = c.Identity.RoleSet.RoleNames()
+	}
+
+	// Fill in the environment variables from the config and interpolate them if needed.
+	environment := make(map[string]string)
+	environment["TELEPORT_USERNAME"] = c.Identity.TeleportUser
+	environment["TELEPORT_LOGIN"] = c.Identity.Login
+	environment["TELEPORT_ROLES"] = strings.Join(roleNames, " ")
+	if localPAMConfig.Environment != nil {
+		user, err := c.srv.GetAccessPoint().GetUser(c.Identity.TeleportUser, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		pamEnabled = conf.Enabled
-		pamServiceName = conf.ServiceName
-		pamUseAuth = conf.UsePAMAuth
+
+		traits := user.GetTraits()
+
+		for key, value := range localPAMConfig.Environment {
+			expr, err := parse.NewExpression(value)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			if expr.Namespace() != teleport.TraitExternalPrefix && expr.Namespace() != parse.LiteralNamespace {
+				return nil, trace.BadParameter("PAM environment interpolation only supports external traits, found %q", value)
+			}
+
+			result, err := expr.Interpolate(traits)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			environment[key] = strings.Join(result, " ")
+		}
 	}
 
+	return &PAMConfig{
+		UsePAMAuth:  localPAMConfig.UsePAMAuth,
+		ServiceName: localPAMConfig.ServiceName,
+		Environment: environment,
+	}, nil
+}
+
+// ExecCommand takes a *ServerContext and extracts the parts needed to create
+// an *execCommand which can be re-sent to Teleport.
+func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 	// If the identity has roles, extract the role names.
 	var roleNames []string
 	if len(c.Identity.RoleSet) > 0 {
@@ -720,6 +768,11 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	pamConfig, err := getPAMConfig(c)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Create the execCommand that will be sent to the child process.
 	return &ExecCommand{
 		Command:               command,
@@ -731,9 +784,7 @@ func (c *ServerContext) ExecCommand() (*ExecCommand, error) {
 		RequestType:           requestType,
 		PermitUserEnvironment: c.srv.PermitUserEnvironment(),
 		Environment:           buildEnvironment(c),
-		PAM:                   pamEnabled,
-		ServiceName:           pamServiceName,
-		UsePAMAuth:            pamUseAuth,
+		PAMConfig:             pamConfig,
 		IsTestStub:            c.IsTestStub,
 		UaccMetadata:          *uaccMetadata,
 	}, nil

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -28,7 +28,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/gravitational/trace"
@@ -75,15 +74,8 @@ type ExecCommand struct {
 	// type: "exec" or "shell".
 	RequestType string `json:"request_type"`
 
-	// PAM indicates if PAM support was requested by the node.
-	PAM bool `json:"pam"`
-
-	// ServiceName is the name of the PAM service requested if PAM is enabled.
-	ServiceName string `json:"service_name"`
-
-	// UsePAMAuth specifies whether to trigger the "auth" PAM modules from the
-	// policy.
-	UsePAMAuth bool `json:"use_pam_auth"`
+	// PAMConfig is the configuration data that needs to be passed to the child and then to PAM modules.
+	PAMConfig *PAMConfig `json:"pam_config,omitempty"`
 
 	// Environment is a list of environment variables to add to the defaults.
 	Environment []string `json:"environment"`
@@ -96,7 +88,20 @@ type ExecCommand struct {
 	IsTestStub bool `json:"is_test_stub"`
 
 	// UaccMetadata contains metadata needed for user accounting.
-	UaccMetadata
+	UaccMetadata UaccMetadata `json:"uacc_meta"`
+}
+
+// PAMConfig represents all the configuration data that needs to be passed to the child.
+type PAMConfig struct {
+	// UsePAMAuth specifies whether to trigger the "auth" PAM modules from the
+	// policy.
+	UsePAMAuth bool `json:"use_pam_auth"`
+
+	// ServiceName is the name of the PAM service requested if PAM is enabled.
+	ServiceName string `json:"service_name"`
+
+	// Environment represents env variables to pass to PAM.
+	Environment map[string]string `json:"environment"`
 }
 
 // UaccMetadata contains information the child needs from the parent for user accounting.
@@ -157,7 +162,7 @@ func RunCommand() (io.Writer, int, error) {
 			return errorWriter, teleport.RemoteCommandFailure, trace.BadParameter("pty and tty not found")
 		}
 		errorWriter = tty
-		err = uacc.Open(c.UtmpPath, c.WtmpPath, c.Login, c.Hostname, c.RemoteAddr, tty)
+		err = uacc.Open(c.UaccMetadata.UtmpPath, c.UaccMetadata.WtmpPath, c.Login, c.UaccMetadata.Hostname, c.UaccMetadata.RemoteAddr, tty)
 		if err != nil && !trace.IsAccessDenied(err) {
 			return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
 		}
@@ -167,7 +172,7 @@ func RunCommand() (io.Writer, int, error) {
 	// else because PAM is sometimes used to create the local user used to
 	// launch the shell under.
 	var pamEnvironment []string
-	if c.PAM {
+	if c.PAMConfig != nil {
 		// Connect std{in,out,err} to the TTY if it's a shell request, otherwise
 		// discard std{out,err}. If this was not done, things like MOTD would be
 		// printed for "exec" requests.
@@ -186,17 +191,13 @@ func RunCommand() (io.Writer, int, error) {
 
 		// Open the PAM context.
 		pamContext, err := pam.Open(&pam.Config{
-			ServiceName: c.ServiceName,
-			UsePAMAuth:  c.UsePAMAuth,
+			ServiceName: c.PAMConfig.ServiceName,
+			UsePAMAuth:  c.PAMConfig.UsePAMAuth,
 			Login:       c.Login,
 			// Set Teleport specific environment variables that PAM modules
 			// like pam_script.so can pick up to potentially customize the
 			// account/session.
-			Env: map[string]string{
-				"TELEPORT_USERNAME": c.Username,
-				"TELEPORT_LOGIN":    c.Login,
-				"TELEPORT_ROLES":    strings.Join(c.Roles, " "),
-			},
+			Env:    c.PAMConfig.Environment,
 			Stdin:  stdin,
 			Stdout: stdout,
 			Stderr: stderr,
@@ -237,7 +238,7 @@ func RunCommand() (io.Writer, int, error) {
 	err = cmd.Wait()
 
 	if c.Terminal {
-		uaccErr := uacc.Close(c.UtmpPath, c.WtmpPath, tty)
+		uaccErr := uacc.Close(c.UaccMetadata.UtmpPath, c.UaccMetadata.WtmpPath, tty)
 		if uaccErr != nil && !trace.IsAccessDenied(uaccErr) {
 			return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(uaccErr)
 		}
@@ -274,10 +275,10 @@ func RunForward() (io.Writer, int, error) {
 	// If PAM is enabled, open a PAM context. This has to be done before anything
 	// else because PAM is sometimes used to create the local user used to
 	// launch the shell under.
-	if c.PAM {
+	if c.PAMConfig != nil {
 		// Open the PAM context.
 		pamContext, err := pam.Open(&pam.Config{
-			ServiceName: c.ServiceName,
+			ServiceName: c.PAMConfig.ServiceName,
 			Login:       c.Login,
 			Stdin:       os.Stdin,
 			Stdout:      ioutil.Discard,
@@ -285,11 +286,7 @@ func RunForward() (io.Writer, int, error) {
 			// Set Teleport specific environment variables that PAM modules
 			// like pam_script.so can pick up to potentially customize the
 			// account/session.
-			Env: map[string]string{
-				"TELEPORT_USERNAME": c.Username,
-				"TELEPORT_LOGIN":    c.Login,
-				"TELEPORT_ROLES":    strings.Join(c.Roles, " "),
-			},
+			Env: c.PAMConfig.Environment,
 		})
 		if err != nil {
 			return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)


### PR DESCRIPTION
Similar to #6087 which was delayed due to a pending discussion about dynamic configuration.