### PR TITLE
Add `lint-api` target and fix lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ docs-test-whitespace:
 # Runs all Go/shell tests, called by CI/CD.
 #
 .PHONY: test
-test: test-sh test-go
+test: test-sh test-api test-go
 
 #
 # Runs all Go tests except integration, called by CI/CD.
@@ -281,6 +281,15 @@ test-go: CHAOS_FOLDERS := $(shell find . -type f -name '*chaos*.go' -not -path '
 test-go: $(VERSRC)
 	$(GO_BINARY) test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
 	$(GO_BINARY) test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" -test.run=TestChaos $(CHAOS_FOLDERS) -cover
+
+# Runs API Go tests. These have to be run separately as the package name is different.
+#
+.PHONY: test-api
+test-api:
+test-api: FLAGS ?= '-race'
+test-api: PACKAGES := $(shell cd api && $(GO_BINARY) list ./...)
+test-api: $(VERSRC)
+	$(GO_BINARY) test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
 
 # Find and run all shell script unit tests (using https://github.com/bats-core/bats-core)
 .PHONY: test-sh

--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ lint-go: GO_LINT_FLAGS ?=
 lint-go:
 	golangci-lint run -c .golangci.yml $(GO_LINT_FLAGS)
 
-# api is no longer part of the teleport package, so golang-ci skips it by default
+# api is no longer part of the teleport package, so golangci-lint skips it by default
 .PHONY: lint-api
 lint-api: GO_LINT_FLAGS ?=
 lint-api:

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,7 @@ test-api:
 test-api: FLAGS ?= '-race'
 test-api: PACKAGES := $(shell cd api && $(GO_BINARY) list ./...)
 test-api: $(VERSRC)
-	$(GO_BINARY) test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
+	GOMODCACHE=/tmp $(GO_BINARY) test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
 
 # Find and run all shell script unit tests (using https://github.com/bats-core/bats-core)
 .PHONY: test-sh

--- a/Makefile
+++ b/Makefile
@@ -320,13 +320,14 @@ lint: lint-sh lint-helm lint-api lint-go
 .PHONY: lint-go
 lint-go: GO_LINT_FLAGS ?=
 lint-go:
-	golangci-lint run -c .golangci.yml $(GO_LINT_FLAGS)
+	golangci-lint run .golangci.yml $(GO_LINT_FLAGS)
 
 # api is no longer part of the teleport package, so golangci-lint skips it by default
+# GOMODCACHE needs to be set here as api downloads dependencies and cannot write to /go/pkg/mod/cache
 .PHONY: lint-api
-lint-api: GO_LINT_FLAGS ?=
+lint-api: GO_LINT_API_FLAGS ?=
 lint-api:
-	cd api && golangci-lint run -c ../.golangci.yml $(GO_LINT_FLAGS)
+	cd api && GOMODCACHE=/tmp golangci-lint run -c ../.golangci.yml $(GO_LINT_API_FLAGS)
 
 # TODO(awly): remove the `--exclude` flag after cleaning up existing scripts
 .PHONY: lint-sh

--- a/Makefile
+++ b/Makefile
@@ -315,12 +315,18 @@ integration-root:
 # changes (or last commit).
 #
 .PHONY: lint
-lint: lint-sh lint-helm lint-go
+lint: lint-sh lint-helm lint-api lint-go
 
 .PHONY: lint-go
 lint-go: GO_LINT_FLAGS ?=
 lint-go:
 	golangci-lint run -c .golangci.yml $(GO_LINT_FLAGS)
+
+# api is no longer part of the teleport package, so golang-ci skips it by default
+.PHONY: lint-api
+lint-api: GO_LINT_FLAGS ?=
+lint-api:
+	cd api && golangci-lint run -c ../.golangci.yml $(GO_LINT_FLAGS)
 
 # TODO(awly): remove the `--exclude` flag after cleaning up existing scripts
 .PHONY: lint-sh

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ lint: lint-sh lint-helm lint-api lint-go
 .PHONY: lint-go
 lint-go: GO_LINT_FLAGS ?=
 lint-go:
-	golangci-lint run .golangci.yml $(GO_LINT_FLAGS)
+	golangci-lint run -c .golangci.yml $(GO_LINT_FLAGS)
 
 # api is no longer part of the teleport package, so golangci-lint skips it by default
 # GOMODCACHE needs to be set here as api downloads dependencies and cannot write to /go/pkg/mod/cache

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -86,7 +86,7 @@ type Client struct {
 // A predefined dialer must be provided in cfg, or the first addr must be to an auth server.
 // The connection will be dialed in the background, so the connection is not guaranteed
 // to be open. This option is primarily meant for internal use where the client has
-// direct access to server values that guarentee a successful connection.
+// direct access to server values that guarantee a successful connection.
 func New(ctx context.Context, cfg Config) (clt *Client, err error) {
 	if err = cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
@@ -260,7 +260,7 @@ func connect(ctx context.Context, cfg Config) (*Client, error) {
 			// errChan is closed, return errors.
 			if len(errs) == 0 {
 				if len(cfg.Addrs) == 0 && cfg.Dialer == nil {
-					// Some credentials don't require these fields. If no errors propogate, then they need to provide these fields.
+					// Some credentials don't require these fields. If no errors propagate, then they need to provide these fields.
 					return nil, trace.Errorf("all auth methods failed: try providing Addrs or Dialer in config")
 				}
 				return nil, trace.Errorf("all auth methods failed")

--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -146,11 +146,11 @@ func TestLoadProfile(t *testing.T) {
 	require.NoError(t, os.MkdirAll(p.keyDir(), 0700))
 	require.NoError(t, os.MkdirAll(p.userKeyDir(), 0700))
 	require.NoError(t, os.MkdirAll(p.sshDir(), 0700))
-	require.NoError(t, ioutil.WriteFile(p.keyPath(), []byte(keyPEM), 0600))
-	require.NoError(t, ioutil.WriteFile(p.tlsCertPath(), []byte(tlsCert), 0600))
-	require.NoError(t, ioutil.WriteFile(p.tlsCasPath(), []byte(tlsCACert), 0600))
-	require.NoError(t, ioutil.WriteFile(p.sshCertPath(), []byte(sshCert), 0600))
-	require.NoError(t, ioutil.WriteFile(p.sshCasPath(), []byte(sshCACert), 0600))
+	require.NoError(t, ioutil.WriteFile(p.keyPath(), keyPEM, 0600))
+	require.NoError(t, ioutil.WriteFile(p.tlsCertPath(), tlsCert, 0600))
+	require.NoError(t, ioutil.WriteFile(p.tlsCasPath(), tlsCACert, 0600))
+	require.NoError(t, ioutil.WriteFile(p.sshCertPath(), sshCert, 0600))
+	require.NoError(t, ioutil.WriteFile(p.sshCasPath(), sshCACert, 0600))
 
 	// Load profile from disk.
 	creds := LoadProfile(dir, name)

--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -228,7 +228,7 @@ func (r *AccessRequestV3) GetOriginalRoles() []string {
 }
 
 // getThreshold is a helper for getting a threshold by its stored index.
-func (r *AccessRequestV3) getThreshold(tid uint32) (AccessReviewThreshold, error) {
+func (r *AccessRequestV3) getThreshold(tid uint32) (AccessReviewThreshold, error) { //nolint:unused
 	idx := int(tid)
 	if len(r.Spec.Thresholds) <= idx {
 		return AccessReviewThreshold{}, trace.Errorf("threshold index '%d' out of range (this is a bug)", tid)

--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -227,15 +227,6 @@ func (r *AccessRequestV3) GetOriginalRoles() []string {
 	return roles
 }
 
-// getThreshold is a helper for getting a threshold by its stored index.
-func (r *AccessRequestV3) getThreshold(tid uint32) (AccessReviewThreshold, error) { //nolint:unused
-	idx := int(tid)
-	if len(r.Spec.Thresholds) <= idx {
-		return AccessReviewThreshold{}, trace.Errorf("threshold index '%d' out of range (this is a bug)", tid)
-	}
-	return r.Spec.Thresholds[idx], nil
-}
-
 // GetThresholds gets the review thresholds.
 func (r *AccessRequestV3) GetThresholds() []AccessReviewThreshold {
 	return r.Spec.Thresholds

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -108,8 +108,5 @@ ENV PROTO_INCLUDE "/usr/local/include":"${GOPATH}/src":"${GOPATH}/src/github.com
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install
 
-# Ensure that the ci user inside the container has permission to write to the Go directory.
-RUN chown -R ci:ci /go
-
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -108,5 +108,8 @@ ENV PROTO_INCLUDE "/usr/local/include":"${GOPATH}/src":"${GOPATH}/src/github.com
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install
 
+# Ensure that the ci user inside the container has permission to write to the Go directory.
+RUN chown -R ci:ci /go
+
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/6153

- Adds a `lint-api` Makefile target which will run as part of the regular CI linting
- Fixes the current lint failures
- Changes the owner of `/go` to `ci:ci` to allow necessary dependencies to be downloaded

@Joerger I'm presuming that `getThreshold` is being added to support upcoming functionality, so added a `nolint` directive to avoid us needing to delete it.