### PR TITLE
Fix uacc nil slice index bug and handle unexpected address formats correctly

### DIFF
--- a/lib/srv/uacc/uacc_linux.go
+++ b/lib/srv/uacc/uacc_linux.go
@@ -87,7 +87,7 @@ func Open(utmpPath, wtmpPath string, username, hostname string, remote [4]int32,
 	defer C.free(unsafe.Pointer(cIDName))
 
 	// Convert IPv6 array into C integer format.
-	cIP := [4]C.int{}
+	cIP := [4]C.int{0, 0, 0, 0}
 	for i := 0; i < 4; i++ {
 		cIP[i] = (C.int)(remote[i])
 	}

--- a/lib/srv/uacc/uacc_utils.go
+++ b/lib/srv/uacc/uacc_utils.go
@@ -31,8 +31,16 @@ func PrepareAddr(addr net.Addr) ([4]int32, error) {
 	}
 	ip := net.ParseIP(stringIP)
 	rawV6 := ip.To16()
+
+	// this case can occur if the net.Addr isn't in an expected IP format, in that case, ignore it
+	// we have to guard against this because the net.Addr internal format is implementation specific
+	if rawV6 == nil {
+		return [4]int32{}, nil
+	}
+
 	groupedV6 := [4]int32{}
 	for i := range groupedV6 {
+		// some bit magic to convert the byte array into 4 32 bit integers
 		groupedV6[i] = int32(binary.LittleEndian.Uint32(rawV6[i*4 : (i+1)*4]))
 	}
 	return groupedV6, nil


### PR DESCRIPTION
Fixes #6173 

Needs to be backported to 6.0 and 6.1.