### PR TITLE
Node session race

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -423,7 +423,7 @@ func (s *IntSuite) TestAuditOn(c *check.C) {
 
 		// lets type "echo hi" followed by "enter" and then "exit" + "enter":
 		myTerm.Type("\aecho hi\n\r\aexit\n\r\a")
-		myTerm.Close()
+		myTerm.CloseSend()
 
 		// wait for session to end:
 		select {
@@ -868,7 +868,7 @@ func (s *IntSuite) verifySessionJoin(c *check.C, t *TeleInstance) {
 
 	personA := NewTerminal(250)
 	personB := NewTerminal(250)
-	personB.Close()
+	personB.CloseSend()
 
 	// PersonA: SSH into the server, wait one second, then type some commands on stdin:
 	openSession := func() {
@@ -906,7 +906,7 @@ func (s *IntSuite) verifySessionJoin(c *check.C, t *TeleInstance) {
 			}
 		}
 		c.Assert(err, check.IsNil)
-		personA.Close()
+		personA.CloseSend()
 	}
 
 	go openSession()
@@ -985,7 +985,7 @@ func (s *IntSuite) TestShutdown(c *check.C) {
 
 	// now type exit and wait for shutdown to complete
 	person.Type("exit\n\r")
-	person.Close()
+	person.CloseSend()
 
 	select {
 	case <-shutdownContext.Done():
@@ -1227,7 +1227,7 @@ func timeNow() string {
 
 func enterInput(ctx context.Context, c *check.C, person *Terminal, command, pattern string) {
 	person.Type(command)
-	defer person.Close()
+	defer person.CloseSend()
 	abortTime := time.Now().Add(10 * time.Second)
 	var matched bool
 	var output string
@@ -3239,7 +3239,7 @@ func (s *IntSuite) TestAuditOff(c *check.C) {
 
 	// lets type "echo hi" followed by "enter" and then "exit" + "enter":
 	myTerm.Type("\aecho hi\n\r\aexit\n\r\a")
-	myTerm.Close()
+	myTerm.CloseSend()
 
 	// wait for session to end
 	select {
@@ -3389,7 +3389,7 @@ func (s *IntSuite) TestPAM(c *check.C) {
 			cl.Stdin = termSession
 
 			termSession.Type("\aecho hi\n\r\aexit\n\r\a")
-			termSession.Close()
+			termSession.CloseSend()
 			err = cl.SSH(context.TODO(), []string{}, false)
 			c.Assert(err, check.IsNil)
 
@@ -4188,7 +4188,7 @@ func (s *IntSuite) TestWindowChange(c *check.C) {
 
 	personA := NewTerminal(250)
 	personB := NewTerminal(250)
-	personB.Close()
+	personB.CloseSend()
 
 	// openSession will open a new session on a server.
 	openSession := func() {
@@ -4294,7 +4294,7 @@ func (s *IntSuite) TestWindowChange(c *check.C) {
 
 	// Close the session.
 	personA.Type("\aexit\r\n\a")
-	personA.Close()
+	personA.CloseSend()
 }
 
 // TestList checks that the list of servers returned is identity aware.
@@ -4674,7 +4674,7 @@ func (s *IntSuite) TestBPFInteractive(c *check.C) {
 
 			// "Type" a command into the terminal.
 			term.Type(fmt.Sprintf("\a%v\n\r\aexit\n\r\a", lsPath))
-			term.Close()
+			term.CloseSend()
 			err = client.SSH(context.TODO(), []string{}, false)
 			c.Assert(err, check.IsNil)
 
@@ -4893,8 +4893,8 @@ func (s *IntSuite) TestBPFSessionDifferentiation(c *check.C) {
 	}
 	writeTerm(termA)
 	writeTerm(termB)
-	termA.Close()
-	termB.Close()
+	termA.CloseSend()
+	termB.CloseSend()
 
 	// Wait 10 seconds for both events to arrive, otherwise timeout.
 	timeout := time.After(10 * time.Second)
@@ -5191,7 +5191,8 @@ func (t *Terminal) Write(data []byte) (n int, err error) {
 	return t.written.Write(data)
 }
 
-func (t *Terminal) Close() {
+// CloseSend closes the input channel thus signalling the reads to exit
+func (t *Terminal) CloseSend() {
 	close(t.typed)
 }
 
@@ -5218,7 +5219,6 @@ func waitFor(c chan interface{}, timeout time.Duration) error {
 	case <-c:
 		return nil
 	case <-tick:
-		dumpGoroutineProfile()
 		return fmt.Errorf("timeout waiting for event")
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -423,6 +423,7 @@ func (s *IntSuite) TestAuditOn(c *check.C) {
 
 		// lets type "echo hi" followed by "enter" and then "exit" + "enter":
 		myTerm.Type("\aecho hi\n\r\aexit\n\r\a")
+		myTerm.Close()
 
 		// wait for session to end:
 		select {
@@ -867,6 +868,7 @@ func (s *IntSuite) verifySessionJoin(c *check.C, t *TeleInstance) {
 
 	personA := NewTerminal(250)
 	personB := NewTerminal(250)
+	personB.Close()
 
 	// PersonA: SSH into the server, wait one second, then type some commands on stdin:
 	openSession := func() {
@@ -904,6 +906,7 @@ func (s *IntSuite) verifySessionJoin(c *check.C, t *TeleInstance) {
 			}
 		}
 		c.Assert(err, check.IsNil)
+		personA.Close()
 	}
 
 	go openSession()
@@ -936,21 +939,12 @@ func (s *IntSuite) TestShutdown(c *check.C) {
 
 	person := NewTerminal(250)
 
-	// commandsC receive commands
-	commandsC := make(chan string)
-
 	// PersonA: SSH into the server, wait one second, then type some commands on stdin:
 	openSession := func() {
 		cl, err := t.NewClient(ClientConfig{Login: s.me.Username, Cluster: Site, Host: Host, Port: t.GetPortSSHInt()})
 		c.Assert(err, check.IsNil)
 		cl.Stdout = person
 		cl.Stdin = person
-
-		go func() {
-			for command := range commandsC {
-				person.Type(command)
-			}
-		}()
 
 		err = cl.SSH(context.TODO(), []string{}, false)
 		c.Assert(err, check.IsNil)
@@ -991,6 +985,7 @@ func (s *IntSuite) TestShutdown(c *check.C) {
 
 	// now type exit and wait for shutdown to complete
 	person.Type("exit\n\r")
+	person.Close()
 
 	select {
 	case <-shutdownContext.Done():
@@ -1020,6 +1015,7 @@ func (s *IntSuite) TestDisconnectScenarios(c *check.C) {
 
 	testCases := []disconnectTestCase{
 		{
+			comment:       "recording at node",
 			recordingMode: services.RecordAtNode,
 			options: services.RoleOptions{
 				ClientIdleTimeout: services.NewDuration(500 * time.Millisecond),
@@ -1027,6 +1023,7 @@ func (s *IntSuite) TestDisconnectScenarios(c *check.C) {
 			disconnectTimeout: time.Second,
 		},
 		{
+			comment:       "recording at proxy",
 			recordingMode: services.RecordAtProxy,
 			options: services.RoleOptions{
 				ForwardAgent:      services.NewBool(true),
@@ -1035,6 +1032,7 @@ func (s *IntSuite) TestDisconnectScenarios(c *check.C) {
 			disconnectTimeout: time.Second,
 		},
 		{
+			comment:       "recording at node: expired certificate is disconnected",
 			recordingMode: services.RecordAtNode,
 			options: services.RoleOptions{
 				DisconnectExpiredCert: services.NewBool(true),
@@ -1043,6 +1041,7 @@ func (s *IntSuite) TestDisconnectScenarios(c *check.C) {
 			disconnectTimeout: 4 * time.Second,
 		},
 		{
+			comment:       "recording at proxy: expired certificate is disconnected and forwarding agent",
 			recordingMode: services.RecordAtProxy,
 			options: services.RoleOptions{
 				ForwardAgent:          services.NewBool(true),
@@ -1215,7 +1214,7 @@ func (s *IntSuite) runDisconnectTest(c *check.C, tc disconnectTestCase) {
 	select {
 	case <-time.After(tc.disconnectTimeout + time.Second):
 		dumpGoroutineProfile()
-		c.Fatalf("%s: timeout waiting for session to exit: %+v", timeNow(), tc)
+		c.Fatalf("%s (%s): timeout waiting for session to exit: %+v", timeNow(), tc.comment, tc)
 	case <-ctx.Done():
 		// session closed.  a test case is successful if the first
 		// session to close encountered the expected error variant.
@@ -1228,6 +1227,7 @@ func timeNow() string {
 
 func enterInput(ctx context.Context, c *check.C, person *Terminal, command, pattern string) {
 	person.Type(command)
+	defer person.Close()
 	abortTime := time.Now().Add(10 * time.Second)
 	var matched bool
 	var output string
@@ -1245,7 +1245,7 @@ func enterInput(ctx context.Context, c *check.C, person *Terminal, command, patt
 			return
 		}
 		if time.Now().After(abortTime) {
-			c.Fatalf("failed to capture pattern %q in %q", pattern, output)
+			c.Fatalf("Failed to capture pattern %q in %q", pattern, output)
 		}
 	}
 }
@@ -3239,6 +3239,7 @@ func (s *IntSuite) TestAuditOff(c *check.C) {
 
 	// lets type "echo hi" followed by "enter" and then "exit" + "enter":
 	myTerm.Type("\aecho hi\n\r\aexit\n\r\a")
+	myTerm.Close()
 
 	// wait for session to end
 	select {
@@ -3248,9 +3249,7 @@ func (s *IntSuite) TestAuditOff(c *check.C) {
 	}
 
 	// audit log should have the fact that the session occurred recorded in it
-	sessions, err = site.GetSessions(defaults.Namespace)
-	c.Assert(err, check.IsNil)
-	c.Assert(len(sessions), check.Equals, 1)
+	// but the session could have been garbage collected at this point.
 
 	// however, attempts to read the actual sessions should fail because it was
 	// not actually recorded
@@ -3390,6 +3389,7 @@ func (s *IntSuite) TestPAM(c *check.C) {
 			cl.Stdin = termSession
 
 			termSession.Type("\aecho hi\n\r\aexit\n\r\a")
+			termSession.Close()
 			err = cl.SSH(context.TODO(), []string{}, false)
 			c.Assert(err, check.IsNil)
 
@@ -4188,6 +4188,7 @@ func (s *IntSuite) TestWindowChange(c *check.C) {
 
 	personA := NewTerminal(250)
 	personB := NewTerminal(250)
+	personB.Close()
 
 	// openSession will open a new session on a server.
 	openSession := func() {
@@ -4293,6 +4294,7 @@ func (s *IntSuite) TestWindowChange(c *check.C) {
 
 	// Close the session.
 	personA.Type("\aexit\r\n\a")
+	personA.Close()
 }
 
 // TestList checks that the list of servers returned is identity aware.
@@ -4672,6 +4674,7 @@ func (s *IntSuite) TestBPFInteractive(c *check.C) {
 
 			// "Type" a command into the terminal.
 			term.Type(fmt.Sprintf("\a%v\n\r\aexit\n\r\a", lsPath))
+			term.Close()
 			err = client.SSH(context.TODO(), []string{}, false)
 			c.Assert(err, check.IsNil)
 
@@ -4890,6 +4893,8 @@ func (s *IntSuite) TestBPFSessionDifferentiation(c *check.C) {
 	}
 	writeTerm(termA)
 	writeTerm(termB)
+	termA.Close()
+	termB.Close()
 
 	// Wait 10 seconds for both events to arrive, otherwise timeout.
 	timeout := time.After(10 * time.Second)
@@ -5082,6 +5087,8 @@ func runCommand(instance *TeleInstance, cmd []string, cfg ClientConfig, attempts
 		close(doneC)
 	}()
 	tc.Stdout = write
+	var buf bytes.Buffer
+	tc.Stdin = &buf
 	for i := 0; i < attempts; i++ {
 		err = tc.SSH(context.TODO(), cmd, false)
 		if err == nil {
@@ -5184,9 +5191,13 @@ func (t *Terminal) Write(data []byte) (n int, err error) {
 	return t.written.Write(data)
 }
 
+func (t *Terminal) Close() {
+	close(t.typed)
+}
+
 func (t *Terminal) Read(p []byte) (n int, err error) {
-	for n = 0; n < len(p); n++ {
-		p[n] = <-t.typed
+	for ch := range t.typed {
+		p[n] = ch
 		if p[n] == '\r' {
 			break
 		}
@@ -5195,6 +5206,7 @@ func (t *Terminal) Read(p []byte) (n int, err error) {
 			n--
 		}
 		time.Sleep(time.Millisecond * 10)
+		n++
 	}
 	return n, nil
 }
@@ -5206,6 +5218,7 @@ func waitFor(c chan interface{}, timeout time.Duration) error {
 	case <-c:
 		return nil
 	case <-tick:
+		dumpGoroutineProfile()
 		return fmt.Errorf("timeout waiting for event")
 	}
 }

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -266,6 +266,7 @@ func (s *KubeSuite) TestKubeExec(c *check.C) {
 	term := NewTerminal(250)
 	// lets type "echo hi" followed by "enter" and then "exit" + "enter":
 	term.Type("\aecho hi\n\r\aexit\n\r\a")
+	term.Close()
 
 	out = &bytes.Buffer{}
 	err = kubeExec(proxyClientConfig, kubeExecArgs{
@@ -309,6 +310,7 @@ loop:
 	// interactive command, allocate pty
 	term = NewTerminal(250)
 	term.Type("\aecho hi\n\r\aexit\n\r\a")
+	term.Close()
 	out = &bytes.Buffer{}
 	err = kubeExec(impersonatingProxyClientConfig, kubeExecArgs{
 		podName:      pod.Name,
@@ -326,6 +328,7 @@ loop:
 	// are allowed by the role
 	term = NewTerminal(250)
 	term.Type("\aecho hi\n\r\aexit\n\r\a")
+	term.Close()
 	out = &bytes.Buffer{}
 	err = kubeExec(scopedProxyClientConfig, kubeExecArgs{
 		podName:      pod.Name,

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -266,7 +266,7 @@ func (s *KubeSuite) TestKubeExec(c *check.C) {
 	term := NewTerminal(250)
 	// lets type "echo hi" followed by "enter" and then "exit" + "enter":
 	term.Type("\aecho hi\n\r\aexit\n\r\a")
-	term.Close()
+	term.CloseSend()
 
 	out = &bytes.Buffer{}
 	err = kubeExec(proxyClientConfig, kubeExecArgs{
@@ -310,7 +310,7 @@ loop:
 	// interactive command, allocate pty
 	term = NewTerminal(250)
 	term.Type("\aecho hi\n\r\aexit\n\r\a")
-	term.Close()
+	term.CloseSend()
 	out = &bytes.Buffer{}
 	err = kubeExec(impersonatingProxyClientConfig, kubeExecArgs{
 		podName:      pod.Name,
@@ -328,7 +328,7 @@ loop:
 	// are allowed by the role
 	term = NewTerminal(250)
 	term.Type("\aecho hi\n\r\aexit\n\r\a")
-	term.Close()
+	term.CloseSend()
 	out = &bytes.Buffer{}
 	err = kubeExec(scopedProxyClientConfig, kubeExecArgs{
 		podName:      pod.Name,

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -266,7 +266,7 @@ func (s *KubeSuite) TestKubeExec(c *check.C) {
 	term := NewTerminal(250)
 	// lets type "echo hi" followed by "enter" and then "exit" + "enter":
 	term.Type("\aecho hi\n\r\aexit\n\r\a")
-	term.CloseSend()
+	term.closeSend()
 
 	out = &bytes.Buffer{}
 	err = kubeExec(proxyClientConfig, kubeExecArgs{
@@ -310,7 +310,7 @@ loop:
 	// interactive command, allocate pty
 	term = NewTerminal(250)
 	term.Type("\aecho hi\n\r\aexit\n\r\a")
-	term.CloseSend()
+	term.closeSend()
 	out = &bytes.Buffer{}
 	err = kubeExec(impersonatingProxyClientConfig, kubeExecArgs{
 		podName:      pod.Name,
@@ -328,7 +328,7 @@ loop:
 	// are allowed by the role
 	term = NewTerminal(250)
 	term.Type("\aecho hi\n\r\aexit\n\r\a")
-	term.CloseSend()
+	term.closeSend()
 	out = &bytes.Buffer{}
 	err = kubeExec(scopedProxyClientConfig, kubeExecArgs{
 		podName:      pod.Name,

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -35,6 +35,8 @@ import (
 
 	"github.com/moby/term"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client/escape"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -42,7 +44,6 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
 )
 
 type NodeSession struct {
@@ -230,17 +231,8 @@ func (ns *NodeSession) interactiveSession(callback interactiveCallback) error {
 	// Catch term signals, but only if we're attached to a real terminal
 	if ns.isTerminalAttached() {
 		ns.watchSignals(remoteTerm)
-	}
 
-	// start piping input into the remote shell and pipe the output from
-	// the remote shell into stdout:
-	// Note, pipeInOut takes ownership of remoteTerm and will close it
-	// upon completion
-	var wg sync.WaitGroup
-	ns.pipeInOut(remoteTerm, &wg)
-
-	// switch the terminal to raw mode (and switch back on exit!)
-	if ns.isTerminalAttached() {
+		// switch the terminal to raw mode (and switch back on exit!)
 		ts, err := term.SetRawTerminal(0)
 		if err != nil {
 			log.Warn(err)
@@ -248,9 +240,13 @@ func (ns *NodeSession) interactiveSession(callback interactiveCallback) error {
 			defer term.RestoreTerminal(0, ts)
 		}
 	}
-	// wait for the session to end
-	<-ns.closer.C
-	wg.Wait()
+
+	// Pipe input into the remote shell and pipe the output from the remote
+	// shell into stdout.
+	//
+	// Note, pipeInOut takes ownership of remoteTerm and will close it upon
+	// completion.
+	ns.pipeInOut(remoteTerm)
 	return nil
 }
 
@@ -542,28 +538,47 @@ func (ns *NodeSession) watchSignals(shell io.Writer) {
 	}()
 }
 
-// pipeInOut launches two goroutines: one to pipe the local input into the remote shell,
-// and another to pipe the output of the remote shell into the local output
-// func (ns *NodeSession) pipeInOut(shell io.ReadWriteCloser, wg *sync.WaitGroup) {
-func (ns *NodeSession) pipeInOut(shell io.ReadWriteCloser, wg *sync.WaitGroup) {
+// pipeInOut pipes the local input into the remote shell, and the output of the
+// remote shell into the local output.
+func (ns *NodeSession) pipeInOut(shell io.ReadWriteCloser) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	// Create a pipe to use in front of ns.stdin.
+	//
+	// This allows us to close the goroutine sending stdin to the remote shell
+	// while blocked reading from stdin.
+	stdin, stdinSink := io.Pipe()
+	go func() {
+		// Forward actual stdin to the pipe.
+		//
+		// Note: this is not registered with the WaitGroup on purpse. This
+		// goroutine will dangle after the session was terminated, until the
+		// last read from ns.stdin unblocks.
+		_, err := io.Copy(stdinSink, ns.stdin)
+		stdinSink.CloseWithError(err)
+	}()
 	// copy from the remote shell to the local output
-	wg.Add(2)
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		defer ns.closer.Close()
+		defer stdinSink.Close()
 		_, err := io.Copy(ns.stdout, shell)
 		if err != nil {
 			log.Error("Error copying from shell:", err.Error())
 		}
 	}()
 	// copy from the local input to the remote shell:
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		defer ns.closer.Close()
 		defer shell.Close()
+		defer stdin.Close()
 		buf := make([]byte, 128)
 
-		stdin := ns.stdin
+		stdin := io.Reader(stdin)
 		if ns.isTerminalAttached() && ns.enableEscapeSequences {
 			stdin = escape.NewReader(stdin, ns.stderr, func(err error) {
 				switch err {
@@ -590,10 +605,11 @@ func (ns *NodeSession) pipeInOut(shell io.ReadWriteCloser, wg *sync.WaitGroup) {
 					}
 				}
 				if err != nil {
-					fmt.Fprintf(ns.stderr, "\r\n%v\r\n", trace.Wrap(err))
+					if err != io.EOF {
+						fmt.Fprintf(ns.stderr, "\r\n%v\r\n", trace.Wrap(err))
+					}
 					return
 				}
-
 			}
 		}
 	}()

--- a/lib/utils/broadcaster.go
+++ b/lib/utils/broadcaster.go
@@ -29,7 +29,7 @@ func NewCloseBroadcaster() *CloseBroadcaster {
 
 // CloseBroadcaster is a helper struct
 // that implements io.Closer and uses channel
-// to broadcast it's closed state once called
+// to broadcast its closed state once called
 type CloseBroadcaster struct {
 	sync.Once
 	C chan struct{}


### PR DESCRIPTION
This PR fixes a potential race in `NodeSession` where `ExitMsg` could be used concurrently from both [pipeInOut](https://github.com/gravitational/teleport/blob/7ca8d2902882dd23ff8e04ea430dc144af5cc236/lib/client/session.go#L580) and [runShell](https://github.com/gravitational/teleport/blob/7ca8d2902882dd23ff8e04ea430dc144af5cc236/lib/client/api.go#L1828-L1832).

The reason I chose to implement clean up via WaitGroup is to make the lifetime of the session deterministic. This necessitated explicit handling of terminal closure in integration tests.

An additional benefit of these changes is another flake exposed [here](https://github.com/gravitational/teleport/tree/7ca8d2902882dd23ff8e04ea430dc144af5cc236/) where a session was assumed to be still available but could have been already garbage collected by this point.

Updates https://github.com/gravitational/teleport/issues/6194