### PR TITLE
[v6] Cache per-cluster SSH certificates under ~/.tsh

### DIFF
--- a/api/client/profile.go
+++ b/api/client/profile.go
@@ -215,7 +215,7 @@ func FullProfilePath(dir string) string {
 // defaultProfilePath retrieves the default path of the TSH profile.
 func defaultProfilePath() string {
 	home := os.TempDir()
-	if u, err := user.Current(); err == nil {
+	if u, err := user.Current(); err == nil && u.HomeDir != "" {
 		home = u.HomeDir
 	}
 	return filepath.Join(home, profileDir)

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -132,6 +132,9 @@ const (
 const (
 	// SessionKeyDir is the sub-directory where session keys are stored (.tsh/keys).
 	SessionKeyDir = "keys"
+	// SSHDirSuffix is the suffix of the sub-directory where
+	// ssh keys are stored (.tsh/keys/profilename/username-ssh).
+	SSHDirSuffix = "-ssh"
 	// FileNameKnownHosts is a file that stores known hosts.
 	FileNameKnownHosts = "known_hosts"
 	// FileExtTLSCert is the filename extension/suffix of TLS certs
@@ -140,7 +143,8 @@ const (
 	// FileNameTLSCerts is the filename of Cert Authorities stored in a
 	// profile (./tsh/keys/profilename/certs.pem).
 	FileNameTLSCerts = "certs.pem"
-	// FileExtCert is a file extension used for SSH Certificate files.
+	// FileExtCert is a file extension used for SSH Certificate files
+	// (.tsh/keys/profilename/username-ssh/clustername-cert.pub).
 	FileExtSSHCert = "-cert.pub"
 	// FileExtPub is a file extension used for SSH Certificate Authorities
 	// stored in a profile (./tsh/keys/profilename/username.pub).

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -400,7 +400,7 @@ type UserCreds struct {
 
 // SetupUserCreds sets up user credentials for client
 func SetupUserCreds(tc *client.TeleportClient, proxyHost string, creds UserCreds) error {
-	_, err := tc.AddKey(proxyHost, &creds.Key)
+	_, err := tc.AddKey(&creds.Key)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1209,7 +1209,7 @@ func (i *TeleInstance) NewClient(cfg ClientConfig) (*client.TeleportClient, erro
 	if user.Key == nil {
 		return nil, trace.BadParameter("user %q has no key", cfg.Login)
 	}
-	_, err = tc.AddKey(cfg.Host, user.Key)
+	_, err = tc.AddKey(user.Key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -3430,9 +3430,10 @@ func (s *IntSuite) TestRotateSuccess(c *check.C) {
 	defer svc.Shutdown(context.TODO())
 
 	cfg := ClientConfig{
-		Login: s.me.Username,
-		Host:  Loopback,
-		Port:  t.GetPortSSHInt(),
+		Login:   s.me.Username,
+		Cluster: Site,
+		Host:    Loopback,
+		Port:    t.GetPortSSHInt(),
 	}
 	clt, err := t.NewClientWithCreds(cfg, *initialCreds)
 	c.Assert(err, check.IsNil)
@@ -3577,9 +3578,10 @@ func (s *IntSuite) TestRotateRollback(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	cfg := ClientConfig{
-		Login: s.me.Username,
-		Host:  Loopback,
-		Port:  t.GetPortSSHInt(),
+		Login:   s.me.Username,
+		Cluster: Site,
+		Host:    Loopback,
+		Port:    t.GetPortSSHInt(),
 	}
 	clt, err := t.NewClientWithCreds(cfg, *initialCreds)
 	c.Assert(err, check.IsNil)
@@ -4353,8 +4355,9 @@ func (s *IntSuite) TestList(c *check.C) {
 
 		// Create a Teleport client.
 		cfg := ClientConfig{
-			Login: tt.inLogin,
-			Port:  t.GetPortSSHInt(),
+			Login:   tt.inLogin,
+			Cluster: Site,
+			Port:    t.GetPortSSHInt(),
 		}
 		userClt, err := t.NewClientWithCreds(cfg, *initialCreds)
 		c.Assert(err, check.IsNil)
@@ -4452,8 +4455,9 @@ func (s *IntSuite) TestCmdLabels(c *check.C) {
 
 	for _, tt := range tts {
 		cfg := ClientConfig{
-			Login:  s.me.Username,
-			Labels: tt.labels,
+			Login:   s.me.Username,
+			Cluster: Site,
+			Labels:  tt.labels,
 		}
 
 		output, err := runCommand(t, tt.command, cfg, 1)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -57,7 +57,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/shell"
-	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/scp"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -454,6 +453,7 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) 
 		return trace.Wrap(err)
 	}
 	log.Debugf("Activating relogin on %v.", err)
+
 	key, err := tc.Login(ctx)
 	if err != nil {
 		if trace.IsTrustError(err) {
@@ -502,14 +502,16 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	key, err := store.GetKey(profile.Name(), profile.Username,
-		WithKubeCerts(profile.SiteName),
-		WithDBCerts(profile.SiteName, ""),
-		WithAppCerts(profile.SiteName))
+	idx := KeyIndex{
+		ProxyHost:   profile.Name(),
+		Username:    profile.Username,
+		ClusterName: profile.SiteName,
+	}
+	key, err := store.GetKey(idx, WithAllCerts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	sshCert, err := sshutils.ParseCertificate(key.Cert)
+	sshCert, err := key.SSHCert()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -714,6 +716,7 @@ func Status(profileDir, proxyHost string) (*ProfileStatus, []*ProfileStatus, err
 	// deleted but profile exists), treat this as the user not being logged in.
 	profile, err = readProfile(profileDir, profileName)
 	if err != nil {
+		log.Debug(err)
 		if !trace.IsNotFound(err) {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -734,6 +737,7 @@ func Status(profileDir, proxyHost string) (*ProfileStatus, []*ProfileStatus, err
 		}
 		ps, err := readProfile(profileDir, name)
 		if err != nil {
+			log.Debug(err)
 			// parts of profile are missing?
 			// status skips these files
 			if trace.IsNotFound(err) {
@@ -1038,6 +1042,33 @@ func NewClient(c *Config) (tc *TeleportClient, err error) {
 	return tc, nil
 }
 
+// LoadKeyForCluster fetches a cluster-specific SSH key and loads it into the
+// SSH agent.
+func (tc *TeleportClient) LoadKeyForCluster(clusterName string) error {
+	if tc.localAgent == nil {
+		return trace.BadParameter("TeleportClient.LoadKeyForCluster called on a client without localAgent")
+	}
+	_, err := tc.localAgent.LoadKeyForCluster(clusterName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// LoadKeyForCluster fetches a cluster-specific SSH key and loads it into the
+// SSH agent.  If the key is not found, it is requested to be reissued.
+func (tc *TeleportClient) LoadKeyForClusterWithReissue(ctx context.Context, clusterName string) error {
+	err := tc.LoadKeyForCluster(clusterName)
+	if err == nil {
+		return nil
+	}
+	if !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	// Reissuing also loads the new key.
+	return tc.ReissueUserCerts(ctx, ReissueParams{RouteToCluster: clusterName})
+}
+
 // accessPoint returns access point based on the cache policy
 func (tc *TeleportClient) accessPoint(clt auth.AccessPoint, proxyHostPort string, clusterName string) (auth.AccessPoint, error) {
 	// If no caching policy was set or on Windows (where Teleport does not
@@ -1187,8 +1218,8 @@ func (tc *TeleportClient) NewWatcher(ctx context.Context, watch services.Watch) 
 	}, nil
 }
 
-// WithRootClusterClient provides a functional interface for making calls against the root cluster's
-// auth server.
+// WithRootClusterClient provides a functional interface for making calls
+// against the root cluster's auth server.
 func (tc *TeleportClient) WithRootClusterClient(ctx context.Context, do func(clt auth.ClientI) error) error {
 	proxyClient, err := tc.ConnectToProxy(ctx)
 	if err != nil {
@@ -1857,14 +1888,21 @@ func (tc *TeleportClient) getProxySSHPrincipal() string {
 	return proxyPrincipal
 }
 
-// authMethods returns a list (slice) of all SSH auth methods this client
-// can use to try to authenticate
-func (tc *TeleportClient) authMethods() []ssh.AuthMethod {
-	m := append([]ssh.AuthMethod(nil), tc.Config.AuthMethods...)
+// authMethods returns a slice of all SSH auth methods this client
+// can use to try to authenticate.
+func (tc *TeleportClient) authMethods() ([]ssh.AuthMethod, error) {
+	m := append([]ssh.AuthMethod{}, tc.Config.AuthMethods...)
 	if tc.localAgent != nil {
-		m = append(m, tc.localAgent.AuthMethods()...)
+		agentMethods, err := tc.localAgent.AuthMethods()
+		if len(m) == 0 && err != nil {
+			return nil, trace.Wrap(err)
+		}
+		m = append(m, agentMethods...)
 	}
-	return m
+	if len(m) == 0 {
+		return nil, trace.BadParameter("no auth method available")
+	}
+	return m, nil
 }
 
 // ConnectToProxy will dial to the proxy server and return a ProxyClient when
@@ -1897,54 +1935,111 @@ func (tc *TeleportClient) ConnectToProxy(ctx context.Context) (*ProxyClient, err
 // successful.
 func (tc *TeleportClient) connectToProxy(ctx context.Context) (*ProxyClient, error) {
 	proxyPrincipal := tc.getProxySSHPrincipal()
-	sshConfig := &ssh.ClientConfig{
-		User:            proxyPrincipal,
-		HostKeyCallback: tc.HostKeyCallback,
-	}
 
 	sshProxyAddr := tc.Config.SSHProxyAddr
 	if len(tc.JumpHosts) > 0 {
 		log.Debugf("Overriding SSH proxy to JumpHosts's address %q", tc.JumpHosts[0].Addr.String())
 		sshProxyAddr = tc.JumpHosts[0].Addr.Addr
+
+		// Perform a "dummy" connection to the jumphost to examine its certificate
+		// and load a corresponding user certificate to be used by tc.authMethods.
+		//
+		// All the loading logic happens in HostKeyCallback and it will always
+		// force the connection to fail.
+		//
+		// TODO(andrej): Get rid of the individually packaged authMethods,
+		// and embed this reissue logic with ssh.PublicKeysCallback.
+		tmpConfig := &ssh.ClientConfig{
+			User:            proxyPrincipal,
+			HostKeyCallback: tc.loadKeyForClusterFromCert(ctx),
+		}
+		// This connection will always fail so no need to capture return
+		// values.
+		ssh.Dial("tcp", sshProxyAddr, tmpConfig)
 	}
 
-	// helper to create a ProxyClient struct
-	makeProxyClient := func(sshClient *ssh.Client, m ssh.AuthMethod) *ProxyClient {
-		return &ProxyClient{
+	sshConfig := &ssh.ClientConfig{
+		User:            proxyPrincipal,
+		HostKeyCallback: tc.HostKeyCallback,
+	}
+
+	authMethods, err := tc.authMethods()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// try to authenticate using every non interactive auth method we have:
+	var errs []error
+	for i, m := range authMethods {
+		log.Infof("Connecting proxy=%v login=%q method=%d", sshProxyAddr, sshConfig.User, i)
+
+		sshConfig.Auth = []ssh.AuthMethod{m}
+		sshClient, err := ssh.Dial("tcp", sshProxyAddr, sshConfig)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to authenticate with proxy %v.", sshProxyAddr)
+			errs = append(errs, err)
+			continue
+		}
+
+		log.Infof("Successful auth with proxy %v.", sshProxyAddr)
+		proxyClient := ProxyClient{
 			teleportClient:  tc,
 			Client:          sshClient,
 			proxyAddress:    sshProxyAddr,
 			proxyPrincipal:  proxyPrincipal,
 			hostKeyCallback: sshConfig.HostKeyCallback,
 			authMethod:      m,
-			hostLogin:       tc.Config.HostLogin,
-			siteName:        tc.Config.SiteName,
+			hostLogin:       tc.HostLogin,
+			siteName:        tc.SiteName,
 			clientAddr:      tc.ClientAddr,
 		}
+		return &proxyClient, nil
 	}
-	successMsg := fmt.Sprintf("Successful auth with proxy %v", sshProxyAddr)
-	var err error
-	// try to authenticate using every non interactive auth method we have:
-	for i, m := range tc.authMethods() {
-		log.Infof("Connecting proxy=%v login='%v' method=%d", sshProxyAddr, sshConfig.User, i)
-		var sshClient *ssh.Client
 
-		sshConfig.Auth = []ssh.AuthMethod{m}
-		sshClient, err = ssh.Dial("tcp", sshProxyAddr, sshConfig)
-		if err != nil {
-			log.Warningf("Failed to authenticate with proxy: %v", err)
-			err = trace.BadParameter("failed to authenticate with proxy %v: %v", sshProxyAddr, err)
-			continue
-		}
-		log.Infof(successMsg)
-		return makeProxyClient(sshClient, m), nil
-	}
 	// we have exhausted all auth existing auth methods and local login
 	// is disabled in configuration, or the user refused connecting to untrusted hosts
-	if err == nil {
-		err = trace.BadParameter("failed to authenticate with proxy %v", tc.Config.SSHProxyAddr)
+	return nil, trace.Wrap(trace.NewAggregate(errs...), "failed to authenticate with proxy %v", sshProxyAddr)
+}
+
+// loadKeyForClusterFromCert is a HostKeyCallback that attempts to detect the
+// cluster name associated with the host being connected to, in which case it
+// loads or reissues a corresponding SSH certificate for the user.
+func (tc *TeleportClient) loadKeyForClusterFromCert(ctx context.Context) ssh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		if err := tc.HostKeyCallback(hostname, remote, key); err != nil {
+			return trace.Wrap(err)
+		}
+		cert, ok := key.(*ssh.Certificate)
+		if !ok {
+			return trace.BadParameter("remote proxy did not present a host certificate")
+		}
+		proxyClusterName := cert.Permissions.Extensions[utils.CertExtensionAuthority]
+		if proxyClusterName == "" {
+			// No cluster name in the certificate, let's assume we're
+			// connecting to the same cluster.
+			return trace.BadParameter("(do not proceed with the SSH connection)")
+		}
+		err := tc.WithoutJumpHosts(func(tcNoJump *TeleportClient) error {
+			return tc.LoadKeyForClusterWithReissue(ctx, proxyClusterName)
+		})
+		if err != nil {
+			log.WithError(err).Warnf("Failed to load/reissue keys for cluster %q.", proxyClusterName)
+			return trace.Wrap(err)
+		}
+		tc.SiteName = proxyClusterName
+		return trace.BadParameter("(do not proceed with the SSH connection)")
 	}
-	return nil, trace.Wrap(err)
+}
+
+// WithoutJumpHosts executes the given function with a Teleport client that has
+// no JumpHosts set, i.e. presumably falling back to the proxy specified in the
+// profile.
+func (tc *TeleportClient) WithoutJumpHosts(fn func(tcNoJump *TeleportClient) error) error {
+	storedJumpHosts := tc.JumpHosts
+	tc.JumpHosts = nil
+	err := fn(tc)
+	tc.JumpHosts = storedJumpHosts
+	return trace.Wrap(err)
 }
 
 // Logout removes certificate and key for the currently logged in user from
@@ -1953,10 +2048,7 @@ func (tc *TeleportClient) Logout() error {
 	if tc.localAgent == nil {
 		return nil
 	}
-	return tc.localAgent.DeleteKey(
-		WithKubeCerts(tc.SiteName),
-		WithDBCerts(tc.SiteName, ""),
-		WithAppCerts(tc.SiteName))
+	return tc.localAgent.DeleteKey()
 }
 
 // LogoutDatabase removes certificate for a particular database.
@@ -1964,13 +2056,13 @@ func (tc *TeleportClient) LogoutDatabase(dbName string) error {
 	if tc.localAgent == nil {
 		return nil
 	}
+	if tc.SiteName == "" {
+		return trace.BadParameter("cluster name must be set for database logout")
+	}
 	if dbName == "" {
 		return trace.BadParameter("please specify database name to log out of")
 	}
-	return tc.localAgent.keyStore.DeleteKeyOption(
-		tc.localAgent.proxyHost,
-		tc.localAgent.username,
-		WithDBCerts(tc.SiteName, dbName))
+	return tc.localAgent.DeleteUserCerts(tc.SiteName, WithDBCerts{dbName})
 }
 
 // LogoutApp removes certificate for the specified app.
@@ -1978,13 +2070,13 @@ func (tc *TeleportClient) LogoutApp(appName string) error {
 	if tc.localAgent == nil {
 		return nil
 	}
+	if tc.SiteName == "" {
+		return trace.BadParameter("cluster name must be set for app logout")
+	}
 	if appName == "" {
 		return trace.BadParameter("please specify app name to log out of")
 	}
-	return tc.localAgent.keyStore.DeleteKeyOption(
-		tc.localAgent.proxyHost,
-		tc.localAgent.username,
-		WithNamedAppCerts(tc.SiteName, appName))
+	return tc.localAgent.DeleteUserCerts(tc.SiteName, WithAppCerts{appName})
 }
 
 // LogoutAll removes all certificates for all users from the filesystem
@@ -2005,9 +2097,6 @@ func (tc *TeleportClient) LogoutAll() error {
 // update local agent state.
 //
 func (tc *TeleportClient) Login(ctx context.Context) (*Key, error) {
-	// preserve original web proxy host that could have
-	webProxyHost, _ := tc.WebProxyHostPort()
-
 	// Ping the endpoint to see if it's up and find the type of authentication
 	// supported.
 	pr, err := tc.Ping(ctx)
@@ -2035,7 +2124,6 @@ func (tc *TeleportClient) Login(ctx context.Context) (*Key, error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
 		// in this case identity is returned by the proxy
 		tc.Username = response.Username
 		if tc.localAgent != nil {
@@ -2065,6 +2153,11 @@ func (tc *TeleportClient) Login(ctx context.Context) (*Key, error) {
 		return nil, trace.BadParameter("unsupported authentication type: %q", pr.Auth.Type)
 	}
 
+	// Check that a host certificate for at least one cluster was returned.
+	if len(response.HostSigners) == 0 {
+		return nil, trace.BadParameter("bad response from the server: expected at least one certificate, got 0")
+	}
+
 	// extract the new certificate out of the response
 	key.Cert = response.Cert
 	key.TLSCert = response.TLSCert
@@ -2074,17 +2167,15 @@ func (tc *TeleportClient) Login(ctx context.Context) (*Key, error) {
 	if tc.DatabaseService != "" {
 		key.DBTLSCerts[tc.DatabaseService] = response.TLSCert
 	}
-	key.ProxyHost = webProxyHost
 	key.TrustedCA = response.HostSigners
 
-	// Check that a host certificate for at least one cluster was returned and
-	// extract the name of the current cluster from the first host certificate.
-	if len(response.HostSigners) <= 0 {
-		return nil, trace.BadParameter("bad response from the server: expected at least one certificate, got 0")
+	// Store the requested cluster name in the key.
+	key.ClusterName = tc.SiteName
+	if key.ClusterName == "" {
+		rootClusterName := key.TrustedCA[0].ClusterName
+		key.ClusterName = rootClusterName
+		tc.SiteName = rootClusterName
 	}
-
-	// Add the cluster name into the key from the host certificate.
-	key.ClusterName = response.HostSigners[0].ClusterName
 
 	return key, nil
 }
@@ -2103,7 +2194,7 @@ func (tc *TeleportClient) ActivateKey(ctx context.Context, key *Key) error {
 	}
 
 	// save the list of TLS CAs client trusts
-	err = tc.localAgent.SaveCerts(key.TrustedCA)
+	err = tc.localAgent.SaveTrustedCerts(key.TrustedCA)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -2114,16 +2205,9 @@ func (tc *TeleportClient) ActivateKey(ctx context.Context, key *Key) error {
 		return trace.Wrap(err)
 	}
 
-	// Connect to the Auth Server of the main cluster and fetch the known hosts
-	// for this cluster.
-	if err := tc.UpdateTrustedCA(ctx, key.ClusterName); err != nil {
-		return trace.Wrap(err)
-	}
-
-	// Update the cluster name (which will be saved in the profile) with the
-	// name of the cluster the caller requested to connect to.
-	tc.SiteName, err = updateClusterName(ctx, tc, tc.SiteName, key.TrustedCA)
-	if err != nil {
+	// Connect to the Auth Server of the root cluster and fetch the known hosts.
+	rootClusterName := key.TrustedCA[0].ClusterName
+	if err := tc.UpdateTrustedCA(ctx, rootClusterName); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -2170,42 +2254,6 @@ func (tc *TeleportClient) Ping(ctx context.Context) (*client.PingResponse, error
 	return pr, nil
 }
 
-// certGetter is used in updateClusterName to control the response of
-// GetTrustedCA in testing.
-type certGetter interface {
-	// GetTrustedCA returns a list of trusted clusters.
-	GetTrustedCA(context.Context, string) ([]services.CertAuthority, error)
-}
-
-// updateClusterName returns the name of the cluster the user is connected to.
-func updateClusterName(ctx context.Context, certGetter certGetter, clusterName string, certificates []auth.TrustedCerts) (string, error) {
-	// Extract the name of the cluster the caller actually connected to.
-	if len(certificates) == 0 {
-		return "", trace.BadParameter("missing host certificates")
-	}
-	certificateClusterName := certificates[0].ClusterName
-
-	// The caller did not specify a cluster name, for example "tsh login", or
-	// requested the same name that is on the host certificate. In this case
-	// return the cluster name on the host certificate returned.
-	if clusterName == "" || clusterName == certificateClusterName {
-		return certificateClusterName, nil
-	}
-
-	// If the caller requested login to a leaf cluster, make sure the cluster
-	// exists.
-	leafClusters, err := certGetter.GetTrustedCA(ctx, certificateClusterName)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	for _, leafCluster := range leafClusters {
-		if leafCluster.GetClusterName() == clusterName {
-			return clusterName, nil
-		}
-	}
-	return "", trace.BadParameter(`unknown cluster: %q, run "tsh clusters" for a list of clusters`, clusterName)
-}
-
 // GetTrustedCA returns a list of host certificate authorities
 // trusted by the cluster client is authenticated with.
 func (tc *TeleportClient) GetTrustedCA(ctx context.Context, clusterName string) ([]services.CertAuthority, error) {
@@ -2250,7 +2298,7 @@ func (tc *TeleportClient) UpdateTrustedCA(ctx context.Context, clusterName strin
 	}
 
 	// Update the CA pool with all the CA the cluster knows about.
-	err = tc.localAgent.SaveCerts(trustedCerts)
+	err = tc.localAgent.SaveTrustedCerts(trustedCerts)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -2396,7 +2444,7 @@ func (tc *TeleportClient) AddTrustedCA(ca services.CertAuthority) error {
 	// only host CA has TLS certificates, user CA will overwrite trusted certs
 	// to empty file if called
 	if ca.GetType() == services.HostCA {
-		err = tc.localAgent.SaveCerts(auth.AuthoritiesToTrustedCerts([]services.CertAuthority{ca}))
+		err = tc.localAgent.SaveTrustedCerts(auth.AuthoritiesToTrustedCerts([]services.CertAuthority{ca}))
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2406,26 +2454,25 @@ func (tc *TeleportClient) AddTrustedCA(ca services.CertAuthority) error {
 }
 
 // AddKey adds a key to the client's local agent, used in tests.
-func (tc *TeleportClient) AddKey(host string, key *Key) (*agent.AddedKey, error) {
+func (tc *TeleportClient) AddKey(key *Key) (*agent.AddedKey, error) {
 	if tc.localAgent == nil {
 		return nil, trace.BadParameter("TeleportClient.AddKey called on a client without localAgent")
+	}
+	if key.ClusterName == "" {
+		key.ClusterName = tc.SiteName
 	}
 	return tc.localAgent.AddKey(key)
 }
 
 // directLogin asks for a password + HOTP token, makes a request to CA via proxy
 func (tc *TeleportClient) directLogin(ctx context.Context, secondFactorType constants.SecondFactorType, pub []byte) (*auth.SSHLoginResponse, error) {
-	var err error
-
-	var password string
-	var otpToken string
-
-	password, err = tc.AskPassword()
+	password, err := tc.AskPassword()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// only ask for a second factor if it's enabled
+	var otpToken string
 	if secondFactorType == constants.SecondFactorOTP {
 		otpToken, err = tc.AskOTP()
 		if err != nil {
@@ -2559,7 +2606,7 @@ func loopbackPool(proxyAddr string) *x509.CertPool {
 	return certPool
 }
 
-// connectToSSHAgent connects to the local SSH agent and returns a agent.Agent.
+// connectToSSHAgent connects to the system SSH agent and returns an agent.Agent.
 func connectToSSHAgent() agent.Agent {
 	socketPath := os.Getenv(teleport.SSHAuthSock)
 	conn, err := agentconn.Dial(socketPath)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -44,7 +44,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/sshutils/scp"
-	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/socks"
 
@@ -119,14 +118,11 @@ func (proxy *ProxyClient) GetSites() ([]services.Site, error) {
 
 // GetLeafClusters returns the leaf/remote clusters.
 func (proxy *ProxyClient) GetLeafClusters(ctx context.Context) ([]services.RemoteCluster, error) {
-	rootClusterName, err := proxy.RootClusterName()
+	clt, err := proxy.ConnectToRootCluster(ctx, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clt, err := proxy.ConnectToCluster(ctx, rootClusterName, false)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	defer clt.Close()
 
 	remoteClusters, err := clt.GetRemoteClusters(services.SkipValidation())
 	if err != nil {
@@ -164,6 +160,8 @@ func (p ReissueParams) usage() proto.UserCertsRequest_CertUsage {
 		return proto.UserCertsRequest_Kubernetes
 	case p.RouteToDatabase.ServiceName != "":
 		return proto.UserCertsRequest_Database
+	case p.RouteToApp.Name != "":
+		return proto.UserCertsRequest_App
 	default:
 		return proto.UserCertsRequest_All
 	}
@@ -191,7 +189,7 @@ func (proxy *ProxyClient) ReissueUserCerts(ctx context.Context, params ReissuePa
 	}
 
 	// save the cert to the local storage (~/.tsh usually):
-	_, err = proxy.teleportClient.LocalAgent().AddKey(key)
+	_, err = proxy.localAgent().AddKey(key)
 	return trace.Wrap(err)
 }
 
@@ -201,60 +199,28 @@ func (proxy *ProxyClient) reissueUserCerts(ctx context.Context, params ReissuePa
 	}
 	key := params.ExistingCreds
 	if key == nil {
-		localAgent := proxy.teleportClient.LocalAgent()
 		var err error
-		key, err = localAgent.GetKey(WithKubeCerts(params.RouteToCluster))
+		key, err = proxy.localAgent().GetKey(params.RouteToCluster, WithAllCerts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
-	cert, err := key.SSHCert()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	tlsCert, err := key.TeleportTLSCertificate()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	rootClusterName, err := tlsca.ClusterName(tlsCert.Issuer)
+
+	req, err := proxy.prepareUserCertsRequest(params, key, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := proxy.ConnectToCluster(ctx, rootClusterName, true)
+	clt, err := proxy.ConnectToRootCluster(ctx, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer clt.Close()
-
-	// Before requesting a certificate, check if the requested cluster is valid.
-	_, err = clt.GetCertAuthority(services.CertAuthID{
-		Type:       services.HostCA,
-		DomainName: params.RouteToCluster,
-	}, false)
-	if err != nil {
-		return nil, trace.NotFound("cluster %v not found", params.RouteToCluster)
-	}
-	req := proto.UserCertsRequest{
-		Username:          cert.KeyId,
-		PublicKey:         key.Pub,
-		Expires:           time.Unix(int64(cert.ValidBefore), 0),
-		RouteToCluster:    params.RouteToCluster,
-		KubernetesCluster: params.KubernetesCluster,
-		AccessRequests:    params.AccessRequests,
-		RouteToDatabase:   params.RouteToDatabase,
-		RouteToApp:        params.RouteToApp,
-		NodeName:          params.NodeName,
-		Usage:             proto.UserCertsRequest_All,
-	}
-	if _, ok := cert.Permissions.Extensions[teleport.CertExtensionTeleportRoles]; !ok {
-		req.Format = teleport.CertificateFormatOldSSH
-	}
-
-	certs, err := clt.GenerateUserCerts(ctx, req)
+	certs, err := clt.GenerateUserCerts(ctx, *req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	key.Cert = certs.SSH
 	key.TLSCert = certs.TLS
 	if params.KubernetesCluster != "" {
@@ -266,6 +232,7 @@ func (proxy *ProxyClient) reissueUserCerts(ctx context.Context, params ReissuePa
 	if params.RouteToApp.Name != "" {
 		key.AppTLSCerts[params.RouteToApp.Name] = certs.TLS
 	}
+	key.ClusterName = params.RouteToCluster
 	return key, nil
 }
 
@@ -283,24 +250,11 @@ func (proxy *ProxyClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 	}
 	key := params.ExistingCreds
 	if key == nil {
-		localAgent := proxy.teleportClient.LocalAgent()
 		var err error
-		key, err = localAgent.GetKey(WithKubeCerts(params.RouteToCluster))
+		key, err = proxy.localAgent().GetKey(params.RouteToCluster, WithAllCerts...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-	}
-	cert, err := key.SSHCert()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	tlsCert, err := key.TeleportTLSCertificate()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	rootClusterName, err := tlsca.ClusterName(tlsCert.Issuer)
-	if err != nil {
-		return nil, trace.Wrap(err)
 	}
 
 	// Connect to the target cluster (root or leaf) to check whether MFA is
@@ -316,7 +270,7 @@ func (proxy *ProxyClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 			// Probably talking to an older server, use the old non-MFA endpoint.
 			log.WithError(err).Debug("Auth server does not implement IsMFARequired.")
 			// SSH certs can be used without reissuing.
-			if params.usage() == proto.UserCertsRequest_SSH {
+			if params.usage() == proto.UserCertsRequest_SSH && key.Cert != nil {
 				return key, nil
 			}
 			return proxy.reissueUserCerts(ctx, params)
@@ -327,7 +281,7 @@ func (proxy *ProxyClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 		log.Debug("MFA not required for access.")
 		// MFA is not required.
 		// SSH certs can be used without embedding the node name.
-		if params.usage() == proto.UserCertsRequest_SSH {
+		if params.usage() == proto.UserCertsRequest_SSH && key.Cert != nil {
 			return key, nil
 		}
 		// All other targets need their name embedded in the cert for routing,
@@ -335,20 +289,12 @@ func (proxy *ProxyClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 		return proxy.reissueUserCerts(ctx, params)
 	}
 
-	if len(params.AccessRequests) == 0 {
-		// Get the active access requests to include in the cert.
-		var activeRequests services.RequestIDs
-		rawRequests, ok := cert.Extensions[teleport.CertExtensionTeleportActiveRequests]
-		if ok {
-			if err := activeRequests.Unmarshal([]byte(rawRequests)); err != nil {
-				return nil, trace.Wrap(err)
-			}
-		}
-		params.AccessRequests = activeRequests.AccessRequests
-	}
-
 	// Always connect to root for getting new credentials, but attempt to reuse
 	// the existing client if possible.
+	rootClusterName, err := key.RootClusterName()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if params.RouteToCluster != rootClusterName {
 		clt.Close()
 		clt, err = proxy.ConnectToCluster(ctx, rootClusterName, true)
@@ -365,7 +311,7 @@ func (proxy *ProxyClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 			// Probably talking to an older server, use the old non-MFA endpoint.
 			log.WithError(err).Debug("Auth server does not implement GenerateUserSingleUseCerts.")
 			// SSH certs can be used without reissuing.
-			if params.usage() == proto.UserCertsRequest_SSH {
+			if params.usage() == proto.UserCertsRequest_SSH && key.Cert != nil {
 				return key, nil
 			}
 			return proxy.reissueUserCerts(ctx, params)
@@ -374,19 +320,9 @@ func (proxy *ProxyClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 	}
 	defer stream.CloseSend()
 
-	initReq := &proto.UserCertsRequest{
-		Username:          proxy.hostLogin,
-		PublicKey:         key.Pub,
-		Expires:           time.Unix(int64(cert.ValidBefore), 0),
-		RouteToCluster:    params.RouteToCluster,
-		NodeName:          params.NodeName,
-		KubernetesCluster: params.KubernetesCluster,
-		AccessRequests:    params.AccessRequests,
-		RouteToDatabase:   params.RouteToDatabase,
-		Usage:             params.usage(),
-	}
-	if _, ok := cert.Permissions.Extensions[teleport.CertExtensionTeleportRoles]; !ok {
-		initReq.Format = teleport.CertificateFormatOldSSH
+	initReq, err := proxy.prepareUserCertsRequest(params, key, true)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	err = stream.Send(&proto.UserSingleUseCertsRequest{Request: &proto.UserSingleUseCertsRequest_Init{
 		Init: initReq,
@@ -435,26 +371,56 @@ func (proxy *ProxyClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 	default:
 		return nil, trace.BadParameter("server sent a %T SingleUseUserCert in response", certResp.Cert)
 	}
+	key.ClusterName = params.RouteToCluster
 	log.Debug("Issued single-use user certificate after an MFA check.")
 	return key, nil
 }
 
-// RootClusterName returns name of the current cluster
-func (proxy *ProxyClient) RootClusterName() (string, error) {
-	localAgent := proxy.teleportClient.LocalAgent()
-	key, err := localAgent.GetKey()
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
+func (proxy *ProxyClient) prepareUserCertsRequest(params ReissueParams, key *Key, withUsage bool) (*proto.UserCertsRequest, error) {
 	tlsCert, err := key.TeleportTLSCertificate()
 	if err != nil {
-		return "", trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
-	clusterName, err := tlsca.ClusterName(tlsCert.Issuer)
+
+	// withUsage is used by MFA cert issue requests.
+	// TODO: After the primary TLS certificate isn't rewritten with every
+	// reissue, all cert requests should include proper usage information.
+	// See https://github.com/gravitational/teleport/issues/6161
+	usage := proto.UserCertsRequest_All
+	if withUsage {
+		usage = params.usage()
+	}
+
+	if len(params.AccessRequests) == 0 {
+		profile, err := StatusCurrent("", proxy.proxyAddress)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		params.AccessRequests = profile.ActiveRequests.AccessRequests
+	}
+
+	return &proto.UserCertsRequest{
+		PublicKey:         key.Pub,
+		Username:          tlsCert.Subject.CommonName,
+		Expires:           tlsCert.NotAfter,
+		RouteToCluster:    params.RouteToCluster,
+		KubernetesCluster: params.KubernetesCluster,
+		AccessRequests:    params.AccessRequests,
+		RouteToDatabase:   params.RouteToDatabase,
+		RouteToApp:        params.RouteToApp,
+		NodeName:          params.NodeName,
+		Usage:             usage,
+		Format:            proxy.teleportClient.CertificateFormat,
+	}, nil
+}
+
+// RootClusterName returns name of the current cluster
+func (proxy *ProxyClient) RootClusterName() (string, error) {
+	tlsKey, err := proxy.localAgent().GetCoreKey()
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	return clusterName, nil
+	return tlsKey.RootClusterName()
 }
 
 // CreateAccessRequest registers a new access request with the auth server.
@@ -671,12 +637,11 @@ func (proxy *ProxyClient) ConnectToCluster(ctx context.Context, clusterName stri
 		})
 	}
 
-	localAgent := proxy.teleportClient.LocalAgent()
-	key, err := localAgent.GetKey()
+	tlsKey, err := proxy.localAgent().GetCoreKey()
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to fetch TLS key for %v", proxy.teleportClient.Username)
 	}
-	tlsConfig, err := key.TeleportClientTLSConfig(nil)
+	tlsConfig, err := tlsKey.TeleportClientTLSConfig(nil)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to generate client TLS config")
 	}
@@ -1403,10 +1368,13 @@ func (proxy *ProxyClient) currentCluster() (*services.Site, error) {
 }
 
 func (proxy *ProxyClient) sessionSSHCertificate(ctx context.Context, nodeAddr NodeAddr) (ssh.AuthMethod, error) {
-	if _, err := proxy.teleportClient.localAgent.GetKey(); trace.IsNotFound(err) {
-		// Either running inside the web UI in a proxy or using an identity
-		// file. Fall back to whatever AuthMethod we currently have.
-		return proxy.authMethod, nil
+	if _, err := proxy.teleportClient.localAgent.GetKey(nodeAddr.Cluster); err != nil {
+		if trace.IsNotFound(err) {
+			// Either running inside the web UI in a proxy or using an identity
+			// file. Fall back to whatever AuthMethod we currently have.
+			return proxy.authMethod, nil
+		}
+		return nil, trace.Wrap(err)
 	}
 
 	key, err := proxy.IssueUserCertsWithMFA(
@@ -1423,4 +1391,9 @@ func (proxy *ProxyClient) sessionSSHCertificate(ctx context.Context, nodeAddr No
 		return nil, trace.Wrap(err)
 	}
 	return key.AsAuthMethod()
+}
+
+// localAgent returns for the Teleport client's local agent.
+func (proxy *ProxyClient) localAgent() *LocalKeyAgent {
+	return proxy.teleportClient.LocalAgent()
 }

--- a/lib/client/identityfile/identity_test.go
+++ b/lib/client/identityfile/identity_test.go
@@ -15,11 +15,10 @@ import (
 func TestWrite(t *testing.T) {
 	outputDir := t.TempDir()
 	key := &client.Key{
-		Cert:        []byte("cert"),
-		TLSCert:     []byte("tls-cert"),
-		Priv:        []byte("priv"),
-		Pub:         []byte("pub"),
-		ClusterName: "foo",
+		Cert:    []byte("cert"),
+		TLSCert: []byte("tls-cert"),
+		Priv:    []byte("priv"),
+		Pub:     []byte("pub"),
 		TrustedCA: []auth.TrustedCerts{{
 			TLSCertificates: [][]byte{[]byte("ca-cert")},
 		}},
@@ -64,11 +63,10 @@ func TestWrite(t *testing.T) {
 
 func TestKubeconfigOverwrite(t *testing.T) {
 	key := &client.Key{
-		Cert:        []byte("cert"),
-		TLSCert:     []byte("tls-cert"),
-		Priv:        []byte("priv"),
-		Pub:         []byte("pub"),
-		ClusterName: "foo",
+		Cert:    []byte("cert"),
+		TLSCert: []byte("tls-cert"),
+		Priv:    []byte("priv"),
+		Pub:     []byte("pub"),
 		TrustedCA: []auth.TrustedCerts{{
 			TLSCertificates: [][]byte{[]byte("ca-cert")},
 		}},

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -370,6 +370,16 @@ func (k *Key) CheckCert() error {
 		return trace.Wrap(err)
 	}
 
+	// Check that the certificate was for the current public key. If not, the
+	// public/private key pair may have been rotated.
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(k.Pub)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !sshutils.KeysEqual(cert.Key, pub) {
+		return trace.CompareFailed("public key in profile does not match the public key in SSH certificate")
+	}
+
 	// A valid principal is always passed in because the principals are not being
 	// checked here, but rather the validity period, signature, and algorithms.
 	certChecker := utils.CertChecker{

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -36,8 +36,35 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
+// KeyIndex helps to identify a key in the store.
+type KeyIndex struct {
+	// ProxyHost is the root proxy hostname that a key is associated with.
+	ProxyHost string
+	// Username is the username that a key is associated with.
+	Username string
+	// ClusterName is the cluster name that a key is associated with.
+	ClusterName string
+}
+
+// Check verifies the KeyIndex is fully specified.
+func (idx KeyIndex) Check() error {
+	missingField := "key index field %s is not set"
+	if idx.ProxyHost == "" {
+		return trace.BadParameter(missingField, "ProxyHost")
+	}
+	if idx.Username == "" {
+		return trace.BadParameter(missingField, "Username")
+	}
+	if idx.ClusterName == "" {
+		return trace.BadParameter(missingField, "ClusterName")
+	}
+	return nil
+}
+
 // Key describes a complete (signed) client key
 type Key struct {
+	KeyIndex
+
 	// Priv is a PEM encoded private key
 	Priv []byte `json:"Priv,omitempty"`
 	// Pub is a public key
@@ -57,15 +84,8 @@ type Key struct {
 	// Map key is the application name.
 	AppTLSCerts map[string][]byte `json:"AppCerts,omitempty"`
 
-	// ProxyHost (optionally) contains the hostname of the proxy server
-	// which issued this key
-	ProxyHost string
-
 	// TrustedCA is a list of trusted certificate authorities
 	TrustedCA []auth.TrustedCerts
-
-	// ClusterName is a cluster name this key is associated with
-	ClusterName string
 }
 
 // NewKey generates a new unsigned key. Such key must be signed by a
@@ -173,21 +193,20 @@ func (k *Key) TeleportClientTLSConfig(cipherSuites []uint16) (*tls.Config, error
 }
 
 func (k *Key) clientTLSConfig(cipherSuites []uint16, tlsCertRaw []byte) (*tls.Config, error) {
-	tlsConfig := utils.TLSConfig(cipherSuites)
-
-	pool := x509.NewCertPool()
-	for _, ca := range k.TrustedCA {
-		for _, certPEM := range ca.TLSCertificates {
-			if !pool.AppendCertsFromPEM(certPEM) {
-				return nil, trace.BadParameter("failed to parse certificate received from the proxy")
-			}
-		}
-	}
-	tlsConfig.RootCAs = pool
 	tlsCert, err := tls.X509KeyPair(tlsCertRaw, k.Priv)
 	if err != nil {
-		return nil, trace.Wrap(err, "failed to parse TLS cert and key")
+		return nil, trace.Wrap(err)
 	}
+
+	pool := x509.NewCertPool()
+	for _, caPEM := range k.TLSCAs() {
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, trace.BadParameter("failed to parse TLS CA certificate")
+		}
+	}
+
+	tlsConfig := utils.TLSConfig(cipherSuites)
+	tlsConfig.RootCAs = pool
 	tlsConfig.Certificates = append(tlsConfig.Certificates, tlsCert)
 	// Use Issuer CN from the certificate to populate the correct SNI in
 	// requests.
@@ -293,7 +312,7 @@ func (k *Key) AppTLSCertificates() (certs []x509.Certificate, err error) {
 
 // TeleportTLSCertValidBefore returns the time of the TLS cert expiration
 func (k *Key) TeleportTLSCertValidBefore() (t time.Time, err error) {
-	cert, err := tlsca.ParseCertificatePEM(k.TLSCert)
+	cert, err := k.TeleportTLSCertificate()
 	if err != nil {
 		return t, trace.Wrap(err)
 	}
@@ -322,6 +341,9 @@ func (k *Key) AsAuthMethod() (ssh.AuthMethod, error) {
 
 // SSHCert returns parsed SSH certificate
 func (k *Key) SSHCert() (*ssh.Certificate, error) {
+	if k.Cert == nil {
+		return nil, trace.NotFound("SSH cert not available")
+	}
 	return sshutils.ParseCertificate(k.Cert)
 }
 
@@ -390,4 +412,18 @@ func ProxyClientSSHConfig(k *Key, keyStore LocalKeyStore) (*ssh.ClientConfig, er
 	sshConfig.User = principals[0]
 	sshConfig.HostKeyCallback = NewKeyStoreCertChecker(keyStore)
 	return sshConfig, nil
+}
+
+// RootClusterName extracts the root cluster name from the issuer
+// of the Teleport TLS certificate.
+func (k *Key) RootClusterName() (string, error) {
+	cert, err := k.TeleportTLSCertificate()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	clusterName := cert.Issuer.CommonName
+	if clusterName == "" {
+		return "", trace.NotFound("failed to extract root cluster name from Teleport TLS cert")
+	}
+	return clusterName, nil
 }

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -141,24 +140,6 @@ to support SSH certificates. To force load the certificate into the running agen
 the --add-keys-to-agent=yes flag.`)
 		}
 	}
-
-	// read in key for this user in proxy
-	key, err := a.GetKey()
-	if err != nil {
-		if trace.IsNotFound(err) {
-			return a, nil
-		}
-		return nil, trace.Wrap(err)
-	}
-
-	a.log.Infof("Loading key for %q", username)
-
-	// load key into the agent
-	_, err = a.LoadKey(*key)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	return a, nil
 }
 
@@ -167,9 +148,21 @@ func (a *LocalKeyAgent) UpdateProxyHost(proxyHost string) {
 	a.proxyHost = proxyHost
 }
 
+// LoadKeyForCluster fetches a cluster-specific SSH key and loads it into the
+// SSH agent.
+func (a *LocalKeyAgent) LoadKeyForCluster(clusterName string) (*agent.AddedKey, error) {
+	key, err := a.GetKey(clusterName, WithSSHCerts{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return a.LoadKey(*key)
+}
+
 // LoadKey adds a key into the Teleport ssh agent as well as the system ssh
 // agent.
 func (a *LocalKeyAgent) LoadKey(key Key) (*agent.AddedKey, error) {
+	a.log.Infof("Loading SSH key for user %q and cluster %q.", a.username, key.ClusterName)
+
 	agents := []agent.Agent{a.Agent}
 	if a.sshAgent != nil {
 		agents = append(agents, a.sshAgent)
@@ -262,12 +255,17 @@ func (a *LocalKeyAgent) UnloadKeys() error {
 	return nil
 }
 
-// GetKey returns the key for this user in a proxy from the backing key store.
-//
-// clusterName is an optional teleport cluster name to load kubernetes
-// certificates for.
-func (a *LocalKeyAgent) GetKey(opts ...KeyOption) (*Key, error) {
-	return a.keyStore.GetKey(a.proxyHost, a.username, opts...)
+// GetKey returns the key for the given cluster of the proxy from
+// the backing keystore.
+func (a *LocalKeyAgent) GetKey(clusterName string, opts ...CertOption) (*Key, error) {
+	idx := KeyIndex{a.proxyHost, a.username, clusterName}
+	return a.keyStore.GetKey(idx, opts...)
+}
+
+// GetCoreKey returns the key without any cluster-dependent certificates,
+// i.e. including only the RSA keypair and the Teleport TLS certificate.
+func (a *LocalKeyAgent) GetCoreKey() (*Key, error) {
+	return a.GetKey("")
 }
 
 // AddHostSignersToCache takes a list of CAs whom we trust. This list is added to a database
@@ -294,16 +292,15 @@ func (a *LocalKeyAgent) AddHostSignersToCache(certAuthorities []auth.TrustedCert
 	return nil
 }
 
-func (a *LocalKeyAgent) SaveCerts(certAuthorities []auth.TrustedCerts) error {
-	return a.keyStore.SaveCerts(a.proxyHost, certAuthorities)
+// SaveTrustedCerts saves trusted TLS certificates of certificate authorities.
+func (a *LocalKeyAgent) SaveTrustedCerts(certAuthorities []auth.TrustedCerts) error {
+	return a.keyStore.SaveTrustedCerts(a.proxyHost, certAuthorities)
 }
 
-func (a *LocalKeyAgent) GetCerts() (*x509.CertPool, error) {
-	return a.keyStore.GetCerts(a.proxyHost)
-}
-
-func (a *LocalKeyAgent) GetCertsPEM() ([][]byte, error) {
-	return a.keyStore.GetCertsPEM(a.proxyHost)
+// GetTrustedCertsPEM returns trusted TLS certificates of certificate authorities PEM
+// blocks.
+func (a *LocalKeyAgent) GetTrustedCertsPEM() ([][]byte, error) {
+	return a.keyStore.GetTrustedCertsPEM(a.proxyHost)
 }
 
 // UserRefusedHosts returns 'true' if a user refuses connecting to remote hosts
@@ -410,26 +407,31 @@ func (a *LocalKeyAgent) defaultHostPromptFunc(host string, key ssh.PublicKey, wr
 }
 
 // AddKey activates a new signed session key by adding it into the keystore and also
-// by loading it into the SSH agent
+// by loading it into the SSH agent.
 func (a *LocalKeyAgent) AddKey(key *Key) (*agent.AddedKey, error) {
+	if key == nil {
+		return nil, trace.BadParameter("key is nil")
+	}
+	if key.ProxyHost == "" {
+		key.ProxyHost = a.proxyHost
+	}
+	if key.Username == "" {
+		key.Username = a.username
+	}
 	// save it to the keystore (usually into ~/.tsh)
-	err := a.keyStore.AddKey(a.proxyHost, a.username, key)
+	err := a.keyStore.AddKey(key)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	// load key into the teleport agent and system agent
 	return a.LoadKey(*key)
 }
 
-// DeleteKey removes the key from the key store as well as unloading the key
-// from the agent.
-//
-// clusterName is an optional teleport cluster name to delete kubernetes
-// certificates for.
-func (a *LocalKeyAgent) DeleteKey(opts ...KeyOption) error {
+// DeleteKey removes the key with all its certs from the key store
+// and unloads the key from the agent.
+func (a *LocalKeyAgent) DeleteKey() error {
 	// remove key from key store
-	err := a.keyStore.DeleteKey(a.proxyHost, a.username, opts...)
+	err := a.keyStore.DeleteKey(KeyIndex{ProxyHost: a.proxyHost, Username: a.username})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -442,6 +444,13 @@ func (a *LocalKeyAgent) DeleteKey(opts ...KeyOption) error {
 	}
 
 	return nil
+}
+
+// DeleteUserCerts deletes only the specified certs of the user's key,
+// keeping the private key intact.
+func (a *LocalKeyAgent) DeleteUserCerts(clusterName string, opts ...CertOption) error {
+	err := a.keyStore.DeleteUserCerts(KeyIndex{a.proxyHost, a.username, clusterName}, opts...)
+	return trace.Wrap(err)
 }
 
 // DeleteKeys removes all keys from the keystore as well as unloads keys
@@ -462,11 +471,11 @@ func (a *LocalKeyAgent) DeleteKeys() error {
 	return nil
 }
 
-// AuthMethods returns the list of different authentication methods this agent supports
-// It returns two:
+// AuthMethods returns the list of different authentication methods this agent supports:
 //	  1. First to try is the external SSH agent
 //    2. Itself (disk-based local agent)
-func (a *LocalKeyAgent) AuthMethods() (m []ssh.AuthMethod) {
+// It returns an error in case there is no auth method method available.
+func (a *LocalKeyAgent) AuthMethods() ([]ssh.AuthMethod, error) {
 	// combine our certificates with external SSH agent's:
 	var signers []ssh.Signer
 	if a.sshAgent != nil {
@@ -478,7 +487,7 @@ func (a *LocalKeyAgent) AuthMethods() (m []ssh.AuthMethod) {
 		signers = append(signers, ourCerts...)
 	}
 	// for every certificate create a new "auth method" and return them
-	m = make([]ssh.AuthMethod, 0)
+	m := []ssh.AuthMethod{}
 	for i := range signers {
 		// filter out non-certificates (like regular public SSH keys stored in the SSH agent):
 		_, ok := signers[i].PublicKey().(*ssh.Certificate)
@@ -486,5 +495,8 @@ func (a *LocalKeyAgent) AuthMethods() (m []ssh.AuthMethod) {
 			m = append(m, sshutils.NewAuthMethodForCert(signers[i]))
 		}
 	}
-	return m
+	if len(m) == 0 {
+		return nil, trace.BadParameter("no auth method available")
+	}
+	return m, nil
 }

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -114,7 +114,7 @@ func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
 		s.username,                            // private key
 		s.username + constants.FileExtPub,     // public key
 		s.username + constants.FileExtTLSCert, // Teleport TLS certificate
-		filepath.Join(s.username+sshDirSuffix, s.key.ClusterName+constants.FileExtSSHCert), // SSH certificate
+		filepath.Join(s.username+constants.SSHDirSuffix, s.key.ClusterName+constants.FileExtSSHCert), // SSH certificate
 	}
 	for _, file := range expectedFiles {
 		_, err := os.Stat(filepath.Join(s.keyDir, "keys", s.hostname, file))

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -45,11 +45,12 @@ import (
 )
 
 type KeyAgentTestSuite struct {
-	keyDir   string
-	key      *Key
-	username string
-	hostname string
-	tlsca    *tlsca.CertAuthority
+	keyDir      string
+	key         *Key
+	username    string
+	hostname    string
+	clusterName string
+	tlsca       *tlsca.CertAuthority
 }
 
 var _ = check.Suite(&KeyAgentTestSuite{})
@@ -60,9 +61,10 @@ func (s *KeyAgentTestSuite) SetUpSuite(c *check.C) {
 	s.keyDir, err = ioutil.TempDir("", "keyagent-test-")
 	c.Assert(err, check.IsNil)
 
-	// temporary username and hostname to use during tests
+	// temporary names to use during tests
 	s.username = "foo"
 	s.hostname = "bar"
+	s.clusterName = "some-cluster"
 
 	pemBytes, ok := fixtures.PEMBytes["rsa"]
 	c.Assert(ok, check.Equals, true)
@@ -108,8 +110,14 @@ func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// check that the key has been written to disk
-	for _, ext := range []string{constants.FileExtSSHCert, "", constants.FileExtPub} {
-		_, err := os.Stat(fmt.Sprintf("%v/keys/%v/%v%v", s.keyDir, s.hostname, s.username, ext))
+	expectedFiles := []string{
+		s.username,                            // private key
+		s.username + constants.FileExtPub,     // public key
+		s.username + constants.FileExtTLSCert, // Teleport TLS certificate
+		filepath.Join(s.username+sshDirSuffix, s.key.ClusterName+constants.FileExtSSHCert), // SSH certificate
+	}
+	for _, file := range expectedFiles {
+		_, err := os.Stat(filepath.Join(s.keyDir, "keys", s.hostname, file))
 		c.Assert(err, check.IsNil)
 	}
 
@@ -455,6 +463,11 @@ func (s *KeyAgentTestSuite) makeKey(username string, allowedLogins []string, ttl
 		Pub:     publicKey,
 		Cert:    certificate,
 		TLSCert: tlsCert,
+		KeyIndex: KeyIndex{
+			ProxyHost:   s.hostname,
+			Username:    username,
+			ClusterName: s.clusterName,
+		},
 	}, nil
 }
 

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -41,7 +41,6 @@ import (
 )
 
 const (
-	sshDirSuffix  = "-ssh"
 	kubeDirSuffix = "-kube"
 	dbDirSuffix   = "-db"
 	appDirSuffix  = "-app"
@@ -177,7 +176,7 @@ func (fs *FSLocalKeyStore) AddKey(key *Key) error {
 	}
 
 	// Store per-cluster key data.
-	if err := fs.writeBytes(key.Cert, inProxyHostDir(key.Username+sshDirSuffix, key.ClusterName+constants.FileExtSSHCert)); err != nil {
+	if err := fs.writeBytes(key.Cert, inProxyHostDir(key.Username+constants.SSHDirSuffix, key.ClusterName+constants.FileExtSSHCert)); err != nil {
 		return trace.Wrap(err)
 	}
 	// TODO(awly): unit test this.
@@ -385,7 +384,7 @@ var WithAllCerts = []CertOption{WithSSHCerts{}, WithKubeCerts{}, WithDBCerts{}, 
 type WithSSHCerts struct{}
 
 func (o WithSSHCerts) relativeCertPath(idx KeyIndex) string {
-	components := []string{idx.ProxyHost, idx.Username + sshDirSuffix}
+	components := []string{idx.ProxyHost, idx.Username + constants.SSHDirSuffix}
 	if idx.ClusterName != "" {
 		components = append(components, idx.ClusterName+constants.FileExtSSHCert)
 	}

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"bufio"
-	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -42,6 +41,7 @@ import (
 )
 
 const (
+	sshDirSuffix  = "-ssh"
 	kubeDirSuffix = "-kube"
 	dbDirSuffix   = "-db"
 	appDirSuffix  = "-app"
@@ -60,24 +60,21 @@ const (
 //
 // The _only_ filesystem-based implementation of LocalKeyStore is declared
 // below (FSLocalKeyStore)
-//
-// TODO: add `getKubeTLSCerts`, `deleteKubeTLSCerts`, etc methods to `LocalKeyStore` to avoid handling different keystore implementations inside `KeyOption` implementations.
 type LocalKeyStore interface {
-	// AddKey adds the given session key for the proxy and username to the
-	// storage backend.
-	AddKey(proxy string, username string, key *Key) error
+	// AddKey adds the given key to the store.
+	AddKey(key *Key) error
 
-	// GetKey returns the session key for the given username and proxy.
-	GetKey(proxy, username string, opts ...KeyOption) (*Key, error)
+	// GetKey returns the user's key including the specified certs.
+	GetKey(idx KeyIndex, opts ...CertOption) (*Key, error)
 
-	// DeleteKey removes a specific session key from a proxy.
-	DeleteKey(proxyHost, username string, opts ...KeyOption) error
+	// DeleteKey deletes the user's key with all its certs.
+	DeleteKey(idx KeyIndex) error
 
-	// DeleteKeyOption deletes only secrets specified by the provided key
-	// options keeping user's SSH/TLS certificates and private key intact.
-	DeleteKeyOption(proxyHost, username string, opts ...KeyOption) error
+	// DeleteUserCerts deletes only the specified certs of the user's key,
+	// keeping the private key intact.
+	DeleteUserCerts(idx KeyIndex, opts ...CertOption) error
 
-	// DeleteKeys removes all session keys from disk.
+	// DeleteKeys removes all session keys.
 	DeleteKeys() error
 
 	// AddKnownHostKeys adds the public key to the list of known hosts for
@@ -87,15 +84,12 @@ type LocalKeyStore interface {
 	// GetKnownHostKeys returns all public keys for a hostname.
 	GetKnownHostKeys(hostname string) ([]ssh.PublicKey, error)
 
-	// SaveCerts saves trusted TLS certificates of certificate authorities.
-	SaveCerts(proxy string, cas []auth.TrustedCerts) error
+	// SaveTrustedCerts saves trusted TLS certificates of certificate authorities.
+	SaveTrustedCerts(proxyHost string, cas []auth.TrustedCerts) error
 
-	// GetCerts gets trusted TLS certificates of certificate authorities.
-	GetCerts(proxy string) (*x509.CertPool, error)
-
-	// GetCertsPEM gets trusted TLS certificates of certificate authorities.
+	// GetTrustedCertsPEM gets trusted TLS certificates of certificate authorities.
 	// Each returned byte slice contains an individual PEM block.
-	GetCertsPEM(proxy string) ([][]byte, error)
+	GetTrustedCertsPEM(proxyHost string) ([][]byte, error)
 }
 
 // FSLocalKeyStore implements LocalKeyStore interface using the filesystem.
@@ -104,30 +98,33 @@ type LocalKeyStore interface {
 // ~/.tsh/
 // ├── known_hosts                   --> trusted certificate authorities (their keys) in a format similar to known_hosts
 // └── keys
-//    ├── one.example.com            --> Proxy hostname
-//    │   ├── certs.pem              --> TLS CA certs for the Teleport CA
-//    │   ├── foo                    --> RSA Private Key for user "foo"
-//    │   ├── foo-cert.pub           --> SSH certificate for proxies and nodes
-//    │   ├── foo.pub                --> Public Key
-//    │   ├── foo-x509.pem           --> TLS client certificate for Auth Server
-//    │   ├── foo-kube               --> Kubernetes certs for user "foo"
-//    │   |   ├── root               --> Kubernetes certs for teleport cluster "root"
-//    │   |   │   ├── kubeA-x509.pem --> TLS cert for Kubernetes cluster "kubeA"
-//    │   |   │   └── kubeB-x509.pem --> TLS cert for Kubernetes cluster "kubeB"
-//    │   |   └── leaf               --> Kubernetes certs for teleport cluster "leaf"
-//    │   |       └── kubeC-x509.pem --> TLS cert for Kubernetes cluster "kubeC"
-//    |   └── foo-db                 --> Database access certs for user "foo"
-//    |       ├── root               --> Database access certs for cluster "root"
-//    │       │   ├── dbA-x509.pem   --> TLS cert for database service "dbA"
-//    │       │   └── dbB-x509.pem   --> TLS cert for database service "dbB"
-//    │       └── leaf               --> Database access certs for cluster "leaf"
-//    │           └── dbC-x509.pem   --> TLS cert for database service "dbC"
-//    └── two.example.com
-//        ├── certs.pem
-//        ├── bar
-//        ├── bar-cert.pub
-//        ├── bar.pub
-//        └── bar-x509.pem
+//    ├── one.example.com            --> Proxy hostname
+//    │   ├── certs.pem              --> TLS CA certs for the Teleport CA
+//    │   ├── foo                    --> RSA Private Key for user "foo"
+//    │   ├── foo.pub                --> Public Key
+//    │   ├── foo-x509.pem           --> TLS client certificate for Auth Server
+//    │   ├── foo-ssh                --> SSH certs for user "foo"
+//    │   │   ├── root-cert.pub      --> SSH cert for Teleport cluster "root"
+//    │   │   └── leaf-cert.pub      --> SSH cert for Teleport cluster "leaf"
+//    │   ├── foo-kube               --> Kubernetes certs for user "foo"
+//    │   │   ├── root               --> Kubernetes certs for Teleport cluster "root"
+//    │   │   │   ├── kubeA-x509.pem --> TLS cert for Kubernetes cluster "kubeA"
+//    │   │   │   └── kubeB-x509.pem --> TLS cert for Kubernetes cluster "kubeB"
+//    │   │   └── leaf               --> Kubernetes certs for Teleport cluster "leaf"
+//    │   │       └── kubeC-x509.pem --> TLS cert for Kubernetes cluster "kubeC"
+//    │   └── foo-db                 --> Database access certs for user "foo"
+//    │       ├── root               --> Database access certs for cluster "root"
+//    │       │   ├── dbA-x509.pem   --> TLS cert for database service "dbA"
+//    │       │   └── dbB-x509.pem   --> TLS cert for database service "dbB"
+//    │       └── leaf               --> Database access certs for cluster "leaf"
+//    │           └── dbC-x509.pem   --> TLS cert for database service "dbC"
+//    └── two.example.com
+//        ├── certs.pem
+//        ├── bar
+//        ├── bar.pub
+//        ├── bar-x509.pem
+//        └── bar-ssh
+//            └── clusterA-cert.pub
 type FSLocalKeyStore struct {
 	fsLocalNonSessionKeyStore
 }
@@ -141,54 +138,49 @@ func NewFSLocalKeyStore(dirPath string) (s *FSLocalKeyStore, err error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	return &FSLocalKeyStore{
 		fsLocalNonSessionKeyStore: fsLocalNonSessionKeyStore{
-			log: logrus.WithFields(logrus.Fields{
-				trace.Component: teleport.ComponentKeyStore,
-			}),
+			log:    logrus.WithField(trace.Component, teleport.ComponentKeyStore),
 			KeyDir: dirPath,
 		},
 	}, nil
 }
 
-// AddKey adds a new key to the session store. If a key for the host is already
-// stored, overwrites it.
-func (fs *FSLocalKeyStore) AddKey(host, username string, key *Key) error {
-	dirPath := fs.dirFor(host)
-	if err := os.MkdirAll(dirPath, profileDirPerms); err != nil {
-		fs.log.Error(err)
-		return trace.ConvertSystemError(err)
+// initKeysDir initializes the keystore root directory, usually `~/.tsh`.
+func initKeysDir(dirPath string) (string, error) {
+	dirPath = client.FullProfilePath(dirPath)
+	if err := os.MkdirAll(dirPath, os.ModeDir|profileDirPerms); err != nil {
+		return "", trace.ConvertSystemError(err)
 	}
-	writeBytes := func(fname string, data []byte) error {
-		fp := filepath.Join(dirPath, fname)
-		err := ioutil.WriteFile(fp, data, keyFilePerms)
-		if err != nil {
-			fs.log.Error(err)
-		}
-		return err
-	}
-	if err := writeBytes(username+constants.FileExtSSHCert, key.Cert); err != nil {
+	return dirPath, nil
+}
+
+// AddKey adds the given key to the store.
+func (fs *FSLocalKeyStore) AddKey(key *Key) error {
+	if err := key.KeyIndex.Check(); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := writeBytes(username+constants.FileExtTLSCert, key.TLSCert); err != nil {
+
+	inProxyHostDir := func(path ...string) string {
+		return fs.inSessionKeyDir(key.ProxyHost, filepath.Join(path...))
+	}
+
+	// Store core key data.
+	if err := fs.writeBytes(key.Priv, inProxyHostDir(key.Username)); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := writeBytes(username+constants.FileExtPub, key.Pub); err != nil {
+	if err := fs.writeBytes(key.Pub, inProxyHostDir(key.Username+constants.FileExtPub)); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := writeBytes(username, key.Priv); err != nil {
+	if err := fs.writeBytes(key.TLSCert, inProxyHostDir(key.Username+constants.FileExtTLSCert)); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Store per-cluster key data.
+	if err := fs.writeBytes(key.Cert, inProxyHostDir(key.Username+sshDirSuffix, key.ClusterName+constants.FileExtSSHCert)); err != nil {
 		return trace.Wrap(err)
 	}
 	// TODO(awly): unit test this.
-	kubeDir := filepath.Join(dirPath, username+kubeDirSuffix, key.ClusterName)
-	// Clean up any old kube certs.
-	if err := os.RemoveAll(kubeDir); err != nil {
-		return trace.Wrap(err)
-	}
-	if err := os.MkdirAll(kubeDir, os.ModeDir|profileDirPerms); err != nil {
-		return trace.Wrap(err)
-	}
 	for kubeCluster, cert := range key.KubeTLSCerts {
 		// Prevent directory traversal via a crafted kubernetes cluster name.
 		//
@@ -197,123 +189,121 @@ func (fs *FSLocalKeyStore) AddKey(host, username string, key *Key) error {
 		// don't expect any well-meaning user to create bad names.
 		kubeCluster = filepath.Clean(kubeCluster)
 
-		fname := filepath.Join(username+kubeDirSuffix, key.ClusterName, kubeCluster+constants.FileExtTLSCert)
-		if err := writeBytes(fname, cert); err != nil {
+		path := inProxyHostDir(key.Username+kubeDirSuffix, key.ClusterName, kubeCluster+constants.FileExtTLSCert)
+		if err := fs.writeBytes(cert, path); err != nil {
 			return trace.Wrap(err)
 		}
 	}
 	for db, cert := range key.DBTLSCerts {
-		fname := filepath.Join(username+dbDirSuffix, key.ClusterName, filepath.Clean(db)+constants.FileExtTLSCert)
-		if err := os.MkdirAll(filepath.Join(dirPath, filepath.Dir(fname)), os.ModeDir|profileDirPerms); err != nil {
-			return trace.Wrap(err)
-		}
-		if err := writeBytes(fname, cert); err != nil {
+		path := inProxyHostDir(key.Username+dbDirSuffix, key.ClusterName, filepath.Clean(db)+constants.FileExtTLSCert)
+		if err := fs.writeBytes(cert, path); err != nil {
 			return trace.Wrap(err)
 		}
 	}
 	for app, cert := range key.AppTLSCerts {
-		fname := filepath.Join(username+appDirSuffix, key.ClusterName, filepath.Clean(app)+constants.FileExtTLSCert)
-		if err := os.MkdirAll(filepath.Join(dirPath, filepath.Dir(fname)), os.ModeDir|profileDirPerms); err != nil {
-			return trace.Wrap(err)
-		}
-		if err := writeBytes(fname, cert); err != nil {
+		path := inProxyHostDir(key.Username+appDirSuffix, key.ClusterName, filepath.Clean(app)+constants.FileExtTLSCert)
+		if err := fs.writeBytes(cert, path); err != nil {
 			return trace.Wrap(err)
 		}
 	}
+
 	return nil
 }
 
-// DeleteKey deletes a key from the local store
-func (fs *FSLocalKeyStore) DeleteKey(host, username string, opts ...KeyOption) error {
-	dirPath := fs.dirFor(host)
+func (fs *FSLocalKeyStore) writeBytes(bytes []byte, fp string) error {
+	if err := os.MkdirAll(filepath.Dir(fp), os.ModeDir|profileDirPerms); err != nil {
+		fs.log.Error(err)
+		return trace.ConvertSystemError(err)
+	}
+	err := ioutil.WriteFile(fp, bytes, keyFilePerms)
+	if err != nil {
+		fs.log.Error(err)
+	}
+	return trace.ConvertSystemError(err)
+}
+
+// DeleteKey deletes the user's key with all its certs.
+func (fs *FSLocalKeyStore) DeleteKey(idx KeyIndex) error {
 	files := []string{
-		filepath.Join(dirPath, username+constants.FileExtSSHCert),
-		filepath.Join(dirPath, username+constants.FileExtTLSCert),
-		filepath.Join(dirPath, username+constants.FileExtPub),
-		filepath.Join(dirPath, username),
+		fs.inSessionKeyDir(idx.ProxyHost, idx.Username),
+		fs.inSessionKeyDir(idx.ProxyHost, idx.Username+constants.FileExtPub),
+		fs.inSessionKeyDir(idx.ProxyHost, idx.Username+constants.FileExtTLSCert),
 	}
 	for _, fn := range files {
 		if err := os.Remove(fn); err != nil {
-			return trace.Wrap(err)
+			return trace.ConvertSystemError(err)
 		}
 	}
-	for _, o := range opts {
-		if err := o.deleteKey(fs, keyIndex{proxyHost: host, username: username}); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-	return nil
+
+	// Clear ClusterName to delete the user certs stored for all clusters.
+	idx.ClusterName = ""
+	return fs.DeleteUserCerts(idx, WithAllCerts...)
 }
 
-// DeleteKeyOption deletes only secrets specified by the provided key options
-// keeping user's SSH/TLS certificates and private key intact.
+// DeleteUserCerts deletes only the specified certs of the user's key,
+// keeping the private key intact.
+// Empty clusterName indicates to delete the certs for all clusters.
 //
 // Useful when needing to log out of a specific service, like a particular
 // database proxy.
-func (fs *FSLocalKeyStore) DeleteKeyOption(host, username string, opts ...KeyOption) error {
+func (fs *FSLocalKeyStore) DeleteUserCerts(idx KeyIndex, opts ...CertOption) error {
 	for _, o := range opts {
-		if err := o.deleteKey(fs, keyIndex{proxyHost: host, username: username}); err != nil {
-			return trace.Wrap(err)
+		certPath := fs.inSessionKeyDir(o.relativeCertPath(idx))
+		if err := os.RemoveAll(certPath); err != nil {
+			return trace.ConvertSystemError(err)
 		}
 	}
 	return nil
 }
 
-// DeleteKeys removes all session keys from disk.
+// DeleteKeys removes all session keys.
 func (fs *FSLocalKeyStore) DeleteKeys() error {
-	dirPath := filepath.Join(fs.KeyDir, constants.SessionKeyDir)
-
-	err := os.RemoveAll(dirPath)
-	if err != nil {
-		return trace.Wrap(err)
+	if err := os.RemoveAll(fs.inSessionKeyDir()); err != nil {
+		return trace.ConvertSystemError(err)
 	}
-
 	return nil
 }
 
-// GetKey returns a key for a given host. If the key is not found,
-// returns trace.NotFound error.
-func (fs *FSLocalKeyStore) GetKey(proxyHost, username string, opts ...KeyOption) (*Key, error) {
-	dirPath := fs.dirFor(proxyHost)
-	_, err := ioutil.ReadDir(dirPath)
-	if err != nil {
-		return nil, trace.NotFound("no session keys for %v in %v", username, proxyHost)
+// GetKey returns the user's key including the specified certs.
+// If the key is not found, returns trace.NotFound error.
+func (fs *FSLocalKeyStore) GetKey(idx KeyIndex, opts ...CertOption) (*Key, error) {
+	if len(opts) > 0 {
+		if err := idx.Check(); err != nil {
+			return nil, trace.Wrap(err, "GetKey with CertOptions requires a fully specified KeyIndex")
+		}
 	}
 
-	certFile := filepath.Join(dirPath, username+constants.FileExtSSHCert)
-	cert, err := ioutil.ReadFile(certFile)
+	if _, err := ioutil.ReadDir(fs.inSessionKeyDir()); err != nil && trace.IsNotFound(err) {
+		return nil, trace.Wrap(err, "no session keys for %+v", idx)
+	}
+
+	priv, err := ioutil.ReadFile(fs.inSessionKeyDir(idx.ProxyHost, idx.Username))
 	if err != nil {
 		fs.log.Error(err)
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
-	tlsCertFile := filepath.Join(dirPath, username+constants.FileExtTLSCert)
+	pub, err := ioutil.ReadFile(fs.inSessionKeyDir(idx.ProxyHost, idx.Username+constants.FileExtPub))
+	if err != nil {
+		fs.log.Error(err)
+		return nil, trace.ConvertSystemError(err)
+	}
+	tlsCertFile := fs.inSessionKeyDir(idx.ProxyHost, idx.Username+constants.FileExtTLSCert)
 	tlsCert, err := ioutil.ReadFile(tlsCertFile)
 	if err != nil {
 		fs.log.Error(err)
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
-	pub, err := ioutil.ReadFile(filepath.Join(dirPath, username+constants.FileExtPub))
+	tlsCA, err := fs.GetTrustedCertsPEM(idx.ProxyHost)
 	if err != nil {
 		fs.log.Error(err)
-		return nil, trace.Wrap(err)
-	}
-	priv, err := ioutil.ReadFile(filepath.Join(dirPath, username))
-	if err != nil {
-		fs.log.Error(err)
-		return nil, trace.Wrap(err)
-	}
-	tlsCA, err := fs.GetCertsPEM(proxyHost)
-	if err != nil {
-		fs.log.Error(err)
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
 
 	key := &Key{
-		Pub:       pub,
-		Priv:      priv,
-		Cert:      cert,
-		ProxyHost: proxyHost,
-		TLSCert:   tlsCert,
+		KeyIndex: idx,
+		Pub:      pub,
+		Priv:     priv,
+		TLSCert:  tlsCert,
 		TrustedCA: []auth.TrustedCerts{{
 			TLSCertificates: tlsCA,
 		}},
@@ -322,355 +312,251 @@ func (fs *FSLocalKeyStore) GetKey(proxyHost, username string, opts ...KeyOption)
 		AppTLSCerts:  make(map[string][]byte),
 	}
 
+	tlsCertExpiration, err := key.TeleportTLSCertValidBefore()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	fs.log.Debugf("Returning Teleport TLS certificate %q valid until %q.", tlsCertFile, tlsCertExpiration)
+
 	for _, o := range opts {
-		if err := o.getKey(fs, keyIndex{proxyHost: proxyHost, username: username}, key); err != nil {
+		if err := fs.updateKeyWithCerts(o, key); err != nil && !trace.IsNotFound(err) {
 			fs.log.Error(err)
 			return nil, trace.Wrap(err)
 		}
 	}
 
-	// Validate the key loaded from disk.
-	err = key.CheckCert()
-	if err != nil {
-		// KeyStore should return expired certificates as well
-		if !utils.IsCertExpiredError(err) {
-			return nil, trace.Wrap(err)
-		}
-	}
-	sshCertExpiration, err := key.CertValidBefore()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	tlsCertExpiration, err := key.TeleportTLSCertValidBefore()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Note, we may be returning expired certificates here, that is okay. If the
-	// certificates is expired, it's the responsibility of the TeleportClient to
+	// Note, we may be returning expired certificates here, that is okay. If a
+	// certificate is expired, it's the responsibility of the TeleportClient to
 	// perform cleanup of the certificates and the profile.
-	fs.log.Debugf("Returning SSH certificate %q valid until %q, TLS certificate %q valid until %q.",
-		certFile, sshCertExpiration, tlsCertFile, tlsCertExpiration)
 
 	return key, nil
 }
 
-type keyIndex struct {
-	proxyHost   string
-	username    string
-	clusterName string
-}
+func (fs *FSLocalKeyStore) updateKeyWithCerts(o CertOption, key *Key) error {
+	certPath := fs.inSessionKeyDir(o.relativeCertPath(key.KeyIndex))
+	info, err := os.Stat(certPath)
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
 
-// KeyOption is an additional step to run when loading (LocalKeyStore.GetKey)
-// or deleting (LocalKeyStore.DeleteKey) keys. These are the steps skipped by
-// default to reduce the amount of work that Get/DeleteKey performs by default.
-type KeyOption interface {
-	getKey(store LocalKeyStore, idx keyIndex, key *Key) error
-	deleteKey(store LocalKeyStore, idx keyIndex) error
-}
+	fs.log.Debugf("Reading certificates from path %q.", certPath)
 
-// WithKubeCerts returns a GetKeyOption to load kubernetes certificates from
-// the store for a given teleport cluster.
-func WithKubeCerts(teleportClusterName string) KeyOption {
-	return withKubeCerts{teleportClusterName: teleportClusterName}
-}
-
-type withKubeCerts struct {
-	teleportClusterName string
-}
-
-// TODO(awly): unit test this.
-func (o withKubeCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
-	switch s := store.(type) {
-	case *FSLocalKeyStore:
-		dirPath := s.dirFor(idx.proxyHost)
-		kubeDir := filepath.Join(dirPath, idx.username+kubeDirSuffix, o.teleportClusterName)
-		kubeFiles, err := ioutil.ReadDir(kubeDir)
-		if err != nil && !os.IsNotExist(err) {
-			return trace.Wrap(err)
+	if info.IsDir() {
+		certDataMap := map[string][]byte{}
+		certFiles, err := ioutil.ReadDir(certPath)
+		if err != nil {
+			return trace.ConvertSystemError(err)
 		}
-		if key.KubeTLSCerts == nil {
-			key.KubeTLSCerts = make(map[string][]byte)
-		}
-		for _, fi := range kubeFiles {
-			data, err := ioutil.ReadFile(filepath.Join(kubeDir, fi.Name()))
+		for _, certFile := range certFiles {
+			data, err := ioutil.ReadFile(filepath.Join(certPath, certFile.Name()))
 			if err != nil {
-				return trace.Wrap(err)
+				return trace.ConvertSystemError(err)
 			}
-			kubeCluster := strings.TrimSuffix(filepath.Base(fi.Name()), constants.FileExtTLSCert)
-			key.KubeTLSCerts[kubeCluster] = data
+			name := strings.TrimSuffix(certFile.Name(), constants.FileExtTLSCert)
+			certDataMap[name] = data
 		}
-	case *MemLocalKeyStore:
-		idx.clusterName = o.teleportClusterName
-		stored, ok := s.inMem[idx]
-		if !ok {
-			return trace.NotFound("key for %v not found", idx)
-		}
-		key.KubeTLSCerts = stored.KubeTLSCerts
-	default:
-		return trace.BadParameter("unexpected key store type %T", store)
+		return o.updateKeyWithMap(key, certDataMap)
 	}
-	if key.ClusterName == "" {
-		key.ClusterName = o.teleportClusterName
+
+	certBytes, err := ioutil.ReadFile(certPath)
+	if err != nil {
+		return trace.ConvertSystemError(err)
 	}
-	return nil
+	return o.updateKeyWithBytes(key, certBytes)
 }
 
-func (o withKubeCerts) deleteKey(store LocalKeyStore, idx keyIndex) error {
-	switch s := store.(type) {
-	case *FSLocalKeyStore:
-		dirPath := s.dirFor(idx.proxyHost)
-		kubeCertsDir := filepath.Join(dirPath, idx.username+kubeDirSuffix, o.teleportClusterName)
-		if err := os.RemoveAll(kubeCertsDir); err != nil {
+// CertOption is an additional step to run when loading/deleting user certificates.
+type CertOption interface {
+	// relativeCertPath returns a path to the cert (or to a dir holding the certs)
+	// relative to the session key dir. For use with FSLocalKeyStore.
+	relativeCertPath(idx KeyIndex) string
+	// updateKeyWithBytes adds the cert bytes to the key and performs related checks.
+	updateKeyWithBytes(key *Key, certBytes []byte) error
+	// updateKeyWithMap adds the cert data map to the key and performs related checks.
+	updateKeyWithMap(key *Key, certMap map[string][]byte) error
+	// deleteFromKey deletes the cert data from the key.
+	deleteFromKey(key *Key)
+}
+
+// WithAllCerts lists all known CertOptions.
+var WithAllCerts = []CertOption{WithSSHCerts{}, WithKubeCerts{}, WithDBCerts{}, WithAppCerts{}}
+
+// WithSSHCerts is a CertOption for handling SSH certificates.
+type WithSSHCerts struct{}
+
+func (o WithSSHCerts) relativeCertPath(idx KeyIndex) string {
+	components := []string{idx.ProxyHost, idx.Username + sshDirSuffix}
+	if idx.ClusterName != "" {
+		components = append(components, idx.ClusterName+constants.FileExtSSHCert)
+	}
+	return filepath.Join(components...)
+}
+
+func (o WithSSHCerts) updateKeyWithBytes(key *Key, certBytes []byte) error {
+	key.Cert = certBytes
+
+	// Validate the SSH certificate.
+	if err := key.CheckCert(); err != nil {
+		if !utils.IsCertExpiredError(err) {
 			return trace.Wrap(err)
 		}
-	case *MemLocalKeyStore:
-		idx.clusterName = o.teleportClusterName
-		stored, ok := s.inMem[idx]
-		if ok {
-			stored.KubeTLSCerts = nil
-		}
-	default:
-		return trace.BadParameter("unexpected key store type %T", store)
 	}
 	return nil
 }
 
-// WithDBCerts returns a GetKeyOption to load database access certificates
-// from the store for a given Teleport cluster.
-func WithDBCerts(teleportClusterName, dbName string) KeyOption {
-	return withDBCerts{teleportClusterName: teleportClusterName, dbName: dbName}
+func (o WithSSHCerts) updateKeyWithMap(key *Key, certMap map[string][]byte) error {
+	return trace.NotImplemented("WithSSHCerts does not implement updateKeyWithMap")
 }
 
-type withDBCerts struct {
-	teleportClusterName, dbName string
+func (o WithSSHCerts) deleteFromKey(key *Key) {
+	key.Cert = nil
 }
 
-func (o withDBCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
-	switch s := store.(type) {
-	case *FSLocalKeyStore:
-		dirPath := s.dirFor(idx.proxyHost)
-		dbDir := filepath.Join(dirPath, idx.username+dbDirSuffix, o.teleportClusterName)
-		dbFiles, err := ioutil.ReadDir(dbDir)
-		if err != nil && !os.IsNotExist(err) {
-			return trace.Wrap(err)
-		}
-		if key.DBTLSCerts == nil {
-			key.DBTLSCerts = make(map[string][]byte)
-		}
-		for _, fi := range dbFiles {
-			data, err := ioutil.ReadFile(filepath.Join(dbDir, fi.Name()))
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			dbName := strings.TrimSuffix(filepath.Base(fi.Name()), constants.FileExtTLSCert)
-			key.DBTLSCerts[dbName] = data
-		}
-	case *MemLocalKeyStore:
-		idx.clusterName = o.teleportClusterName
-		stored, ok := s.inMem[idx]
-		if !ok {
-			return trace.NotFound("key for %v not found", idx)
-		}
-		key.DBTLSCerts = stored.DBTLSCerts
-	default:
-		return trace.BadParameter("unexpected key store type %T", store)
+// WithKubeCerts is a CertOption for handling kubernetes certificates.
+type WithKubeCerts struct{}
+
+func (o WithKubeCerts) relativeCertPath(idx KeyIndex) string {
+	components := []string{idx.ProxyHost, idx.Username + kubeDirSuffix}
+	if idx.ClusterName != "" {
+		components = append(components, idx.ClusterName)
 	}
-	if key.ClusterName == "" {
-		key.ClusterName = o.teleportClusterName
-	}
+	return filepath.Join(components...)
+}
+
+func (o WithKubeCerts) updateKeyWithBytes(key *Key, certBytes []byte) error {
+	return trace.NotImplemented("WithKubeCerts does not implement updateKeyWithBytes")
+}
+
+func (o WithKubeCerts) updateKeyWithMap(key *Key, certMap map[string][]byte) error {
+	key.KubeTLSCerts = certMap
 	return nil
 }
 
-func (o withDBCerts) deleteKey(store LocalKeyStore, idx keyIndex) error {
-	// If database name is specified, remove only that cert, otherwise remove
-	// certs for all databases a user is logged into.
-	switch s := store.(type) {
-	case *FSLocalKeyStore:
-		dirPath := s.dirFor(idx.proxyHost)
+func (o WithKubeCerts) deleteFromKey(key *Key) {
+	key.KubeTLSCerts = nil
+}
+
+// WithDBCerts is a CertOption for handling database access certificates.
+type WithDBCerts struct {
+	dbName string
+}
+
+func (o WithDBCerts) relativeCertPath(idx KeyIndex) string {
+	components := []string{idx.ProxyHost, idx.Username + dbDirSuffix}
+	if idx.ClusterName != "" {
+		components = append(components, idx.ClusterName)
 		if o.dbName != "" {
-			return os.Remove(filepath.Join(dirPath, idx.username+dbDirSuffix, o.teleportClusterName, o.dbName+constants.FileExtTLSCert))
+			components = append(components, o.dbName+constants.FileExtTLSCert)
 		}
-		return os.RemoveAll(filepath.Join(dirPath, idx.username+dbDirSuffix, o.teleportClusterName))
-	case *MemLocalKeyStore:
-		idx.clusterName = o.teleportClusterName
-		stored, ok := s.inMem[idx]
-		if !ok {
-			return trace.NotFound("key for %v not found", idx)
-		}
-		if o.dbName != "" {
-			stored.DBTLSCerts[o.dbName] = nil
-		} else {
-			stored.DBTLSCerts = nil
-		}
-	default:
-		return trace.BadParameter("unexpected key store type %T", store)
 	}
+	return filepath.Join(components...)
+}
+
+func (o WithDBCerts) updateKeyWithBytes(key *Key, certBytes []byte) error {
+	return trace.NotImplemented("WithDBCerts does not implement updateKeyWithBytes")
+}
+
+func (o WithDBCerts) updateKeyWithMap(key *Key, certMap map[string][]byte) error {
+	key.DBTLSCerts = certMap
 	return nil
 }
 
-// WithAppCerts returns a GetKeyOption to load application access certificates
-// from the store for a given Teleport cluster.
-func WithAppCerts(teleportClusterName string) KeyOption {
-	return withAppCerts{teleportClusterName: teleportClusterName}
+func (o WithDBCerts) deleteFromKey(key *Key) {
+	key.DBTLSCerts = nil
 }
 
-// WithNamedAppCerts returns a GetKeyOption to load application access certificates
-// from the store for a given Teleport cluster and particular application.
-func WithNamedAppCerts(teleportClusterName, appName string) KeyOption {
-	return withAppCerts{teleportClusterName: teleportClusterName, appName: appName}
+// WithAppCerts is a CertOption for handling application access certificates.
+type WithAppCerts struct {
+	appName string
 }
 
-type withAppCerts struct {
-	teleportClusterName, appName string
-}
-
-func (o withAppCerts) getKey(store LocalKeyStore, idx keyIndex, key *Key) error {
-	switch s := store.(type) {
-	case *FSLocalKeyStore:
-		dirPath := s.dirFor(idx.proxyHost)
-		appDir := filepath.Join(dirPath, idx.username+appDirSuffix, o.teleportClusterName)
-		appFiles, err := ioutil.ReadDir(appDir)
-		if err != nil && !os.IsNotExist(err) {
-			return trace.Wrap(err)
-		}
-		if key.AppTLSCerts == nil {
-			key.AppTLSCerts = make(map[string][]byte)
-		}
-		for _, fi := range appFiles {
-			data, err := ioutil.ReadFile(filepath.Join(appDir, fi.Name()))
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			appName := strings.TrimSuffix(filepath.Base(fi.Name()), constants.FileExtTLSCert)
-			key.AppTLSCerts[appName] = data
-		}
-	case *MemLocalKeyStore:
-		idx.clusterName = o.teleportClusterName
-		stored, ok := s.inMem[idx]
-		if !ok {
-			return trace.NotFound("key for %v not found", idx)
-		}
-		key.AppTLSCerts = stored.AppTLSCerts
-	default:
-		return trace.BadParameter("unexpected key store type %T", store)
-	}
-	if key.ClusterName == "" {
-		key.ClusterName = o.teleportClusterName
-	}
-	return nil
-}
-
-func (o withAppCerts) deleteKey(store LocalKeyStore, idx keyIndex) error {
-	// If app name is specified, remove only that cert, otherwise remove
-	// certs for all apps a user is logged into.
-	switch s := store.(type) {
-	case *FSLocalKeyStore:
-		dirPath := s.dirFor(idx.proxyHost)
+func (o WithAppCerts) relativeCertPath(idx KeyIndex) string {
+	components := []string{idx.ProxyHost, idx.Username + appDirSuffix}
+	if idx.ClusterName != "" {
+		components = append(components, idx.ClusterName)
 		if o.appName != "" {
-			return os.Remove(filepath.Join(dirPath, idx.username+appDirSuffix, o.teleportClusterName, o.appName+constants.FileExtTLSCert))
+			components = append(components, o.appName+constants.FileExtTLSCert)
 		}
-		return os.RemoveAll(filepath.Join(dirPath, idx.username+appDirSuffix, o.teleportClusterName))
-	case *MemLocalKeyStore:
-		idx.clusterName = o.teleportClusterName
-		stored, ok := s.inMem[idx]
-		if !ok {
-			return trace.NotFound("key for %v not found", idx)
-		}
-		if o.appName != "" {
-			stored.AppTLSCerts[o.appName] = nil
-		} else {
-			stored.AppTLSCerts = nil
-		}
-	default:
-		return trace.BadParameter("unexpected key store type %T", store)
 	}
+	return filepath.Join(components...)
+}
+
+func (o WithAppCerts) updateKeyWithBytes(key *Key, certBytes []byte) error {
+	return trace.NotImplemented("WithAppCerts does not implement updateKeyWithBytes")
+}
+
+func (o WithAppCerts) updateKeyWithMap(key *Key, certMap map[string][]byte) error {
+	key.AppTLSCerts = certMap
 	return nil
 }
 
-// initKeysDir initializes the keystore root directory. Usually it is ~/.tsh
-func initKeysDir(dirPath string) (string, error) {
-	dirPath = client.FullProfilePath(dirPath)
-	// create if doesn't exist:
-	if _, err := os.Stat(dirPath); err != nil {
-		if !os.IsNotExist(err) {
-			return "", trace.Wrap(err)
-		}
-		if err = os.MkdirAll(dirPath, os.ModeDir|profileDirPerms); err != nil {
-			return "", trace.ConvertSystemError(err)
-		}
-	}
-
-	return dirPath, nil
+func (o WithAppCerts) deleteFromKey(key *Key) {
+	key.AppTLSCerts = nil
 }
 
+// fsLocalNonSessionKeyStore is a FS-based store implementing methods
+// for CA certificates and known host fingerprints. It is embedded
+// in both FSLocalKeyStore and MemLocalKeyStore.
 type fsLocalNonSessionKeyStore struct {
 	// log holds the structured logger.
-	log *logrus.Entry
+	log logrus.FieldLogger
 
 	// KeyDir is the directory where all keys are stored.
 	KeyDir string
 }
 
-// dirFor returns the path to the session keys for a given host. The value
-// for fs.KeyDir is typically "~/.tsh", sessionKeyDir is typically "keys",
-// and proxyHost typically has values like "proxy.example.com".
-func (fs *fsLocalNonSessionKeyStore) dirFor(proxyHost string) string {
-	return filepath.Join(fs.KeyDir, constants.SessionKeyDir, proxyHost)
+// inSessionKeyDir prepends the given path components with the session key dir,
+// usually returning a path of the form `~/.tsh/keys/<path0>/<path1>/<...>`.
+func (fs *fsLocalNonSessionKeyStore) inSessionKeyDir(path ...string) string {
+	return filepath.Join(fs.KeyDir, constants.SessionKeyDir, filepath.Join(path...))
 }
 
-// GetCertsPEM returns trusted TLS certificates of certificate authorities PEM
-// blocks.
-func (fs *fsLocalNonSessionKeyStore) GetCertsPEM(proxy string) ([][]byte, error) {
-	dir := fs.dirFor(proxy)
-	data, err := ioutil.ReadFile(filepath.Join(dir, constants.FileNameTLSCerts))
+// AddKnownHostKeys adds a new entry to `known_hosts` file.
+func (fs *fsLocalNonSessionKeyStore) AddKnownHostKeys(hostname string, hostKeys []ssh.PublicKey) (retErr error) {
+	fp, err := os.OpenFile(filepath.Join(fs.KeyDir, constants.FileNameKnownHosts), os.O_CREATE|os.O_RDWR, 0640)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.ConvertSystemError(err)
 	}
-	var blocks [][]byte
-	for len(data) > 0 {
-		block, rest := pem.Decode(data)
-		if block == nil {
-			break
+	defer func() { retErr = fp.Close() }()
+	// read all existing entries into a map (this removes any pre-existing dupes)
+	entries := make(map[string]int)
+	output := make([]string, 0)
+	scanner := bufio.NewScanner(fp)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if _, exists := entries[line]; !exists {
+			output = append(output, line)
+			entries[line] = 1
 		}
-		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
-			fs.log.Debugf("Skipping PEM block type=%v headers=%v.", block.Type, block.Headers)
-			continue
-		}
-		// rest contains the remainder of data after reading a block.
-		// Therefore, the block length is len(data) - len(rest).
-		// Use that length to slice the block from the start of data.
-		blocks = append(blocks, data[:len(data)-len(rest)])
-		data = rest
 	}
-	return blocks, nil
-}
-
-// GetCerts returns trusted TLS certificates of certificate authorities as
-// x509.CertPool.
-func (fs *fsLocalNonSessionKeyStore) GetCerts(proxy string) (*x509.CertPool, error) {
-	blocks, err := fs.GetCertsPEM(proxy)
+	// check if the scanner ran into an error
+	if err := scanner.Err(); err != nil {
+		return trace.Wrap(err)
+	}
+	// add every host key to the list of entries
+	for i := range hostKeys {
+		fs.log.Debugf("Adding known host %s with key: %v", hostname, sshutils.Fingerprint(hostKeys[i]))
+		bytes := ssh.MarshalAuthorizedKey(hostKeys[i])
+		line := strings.TrimSpace(fmt.Sprintf("%s %s", hostname, bytes))
+		if _, exists := entries[line]; !exists {
+			output = append(output, line)
+		}
+	}
+	// re-create the file:
+	_, err = fp.Seek(0, 0)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
-	pool := x509.NewCertPool()
-	for _, bytes := range blocks {
-		block, _ := pem.Decode(bytes)
-		if block == nil {
-			continue
-		}
-
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return nil, trace.BadParameter("failed to parse certificate: %v", err)
-		}
-		fs.log.Debugf("Adding trusted cluster certificate authority %q to trusted pool.", cert.Issuer)
-		pool.AddCert(cert)
+	if err = fp.Truncate(0); err != nil {
+		return trace.Wrap(err)
 	}
-	return pool, nil
+	for _, line := range output {
+		fmt.Fprintf(fp, "%s\n", line)
+	}
+	return fp.Sync()
 }
 
-// GetKnownHostKeys returns all known public keys from 'known_hosts'
+// GetKnownHostKeys returns all known public keys from `known_hosts`.
 func (fs *fsLocalNonSessionKeyStore) GetKnownHostKeys(hostname string) ([]ssh.PublicKey, error) {
 	bytes, err := ioutil.ReadFile(filepath.Join(fs.KeyDir, constants.FileNameKnownHosts))
 	if err != nil {
@@ -708,62 +594,14 @@ func (fs *fsLocalNonSessionKeyStore) GetKnownHostKeys(hostname string) ([]ssh.Pu
 	return retval, nil
 }
 
-// AddKnownHostKeys adds a new entry to 'known_hosts' file
-func (fs *fsLocalNonSessionKeyStore) AddKnownHostKeys(hostname string, hostKeys []ssh.PublicKey) (retErr error) {
-	fp, err := os.OpenFile(filepath.Join(fs.KeyDir, constants.FileNameKnownHosts), os.O_CREATE|os.O_RDWR, 0640)
-	if err != nil {
-		return trace.ConvertSystemError(err)
-	}
-	defer func() { retErr = fp.Close() }()
-	// read all existing entries into a map (this removes any pre-existing dupes)
-	entries := make(map[string]int)
-	output := make([]string, 0)
-	scanner := bufio.NewScanner(fp)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if _, exists := entries[line]; !exists {
-			output = append(output, line)
-			entries[line] = 1
-		}
-	}
-
-	// check if the scanner ran into an error
-	if err := scanner.Err(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	// add every host key to the list of entries
-	for i := range hostKeys {
-		fs.log.Debugf("Adding known host %s with key: %v", hostname, sshutils.Fingerprint(hostKeys[i]))
-		bytes := ssh.MarshalAuthorizedKey(hostKeys[i])
-		line := strings.TrimSpace(fmt.Sprintf("%s %s", hostname, bytes))
-		if _, exists := entries[line]; !exists {
-			output = append(output, line)
-		}
-	}
-	// re-create the file:
-	_, err = fp.Seek(0, 0)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if err = fp.Truncate(0); err != nil {
-		return trace.Wrap(err)
-	}
-	for _, line := range output {
-		fmt.Fprintf(fp, "%s\n", line)
-	}
-	return fp.Sync()
-}
-
-// SaveCerts saves trusted TLS certificates of certificate authorities
-func (fs *fsLocalNonSessionKeyStore) SaveCerts(proxy string, cas []auth.TrustedCerts) (retErr error) {
-	dir := fs.dirFor(proxy)
-	if err := os.MkdirAll(dir, profileDirPerms); err != nil {
+// SaveTrustedCerts saves trusted TLS certificates of certificate authorities.
+func (fs *fsLocalNonSessionKeyStore) SaveTrustedCerts(proxyHost string, cas []auth.TrustedCerts) (retErr error) {
+	if err := os.MkdirAll(fs.inSessionKeyDir(proxyHost), os.ModeDir|profileDirPerms); err != nil {
 		fs.log.Error(err)
 		return trace.ConvertSystemError(err)
 	}
-
-	fp, err := os.OpenFile(filepath.Join(dir, constants.FileNameTLSCerts), os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
+	certsFile := fs.inSessionKeyDir(proxyHost, constants.FileNameTLSCerts)
+	fp, err := os.OpenFile(certsFile, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0640)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
@@ -781,76 +619,30 @@ func (fs *fsLocalNonSessionKeyStore) SaveCerts(proxy string, cas []auth.TrustedC
 	return fp.Sync()
 }
 
-// MemLocalKeyStore is an in-memory session keystore implementation.
-type MemLocalKeyStore struct {
-	fsLocalNonSessionKeyStore
-	inMem map[keyIndex]*Key
-}
-
-// NewMemLocalKeyStore initializes a MemLocalKeyStore, the key directory here is only used
-// for storing CA certificates and known host fingerprints.
-func NewMemLocalKeyStore(dirPath string) (*MemLocalKeyStore, error) {
-	dirPath, err := initKeysDir(dirPath)
+// GetTrustedCertsPEM returns trusted TLS certificates of certificate authorities PEM
+// blocks.
+func (fs *fsLocalNonSessionKeyStore) GetTrustedCertsPEM(proxyHost string) ([][]byte, error) {
+	data, err := ioutil.ReadFile(fs.inSessionKeyDir(proxyHost, constants.FileNameTLSCerts))
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.ConvertSystemError(err)
 	}
-
-	inMem := make(map[keyIndex]*Key)
-	return &MemLocalKeyStore{fsLocalNonSessionKeyStore: fsLocalNonSessionKeyStore{
-		log: logrus.WithFields(logrus.Fields{
-			trace.Component: teleport.ComponentKeyStore,
-		}),
-		KeyDir: dirPath,
-	}, inMem: inMem}, nil
-}
-
-// AddKey writes a key to the underlying key store.
-func (s *MemLocalKeyStore) AddKey(proxy string, username string, key *Key) error {
-	s.inMem[keyIndex{proxyHost: proxy, username: username}] = key
-	if key.ClusterName != "" {
-		s.inMem[keyIndex{proxyHost: proxy, username: username, clusterName: key.ClusterName}] = key
-	}
-	return nil
-}
-
-// GetKey returns the session key for the given username and proxy.
-func (s *MemLocalKeyStore) GetKey(proxy, username string, opts ...KeyOption) (*Key, error) {
-	idx := keyIndex{proxyHost: proxy, username: username}
-	entry, ok := s.inMem[idx]
-	if !ok {
-		return nil, trace.NotFound("key for %v not found", idx)
-	}
-	for _, o := range opts {
-		if err := o.getKey(s, idx, entry); err != nil {
-			s.log.Error(err)
-			return nil, trace.Wrap(err)
+	var blocks [][]byte
+	for len(data) > 0 {
+		block, rest := pem.Decode(data)
+		if block == nil {
+			break
 		}
-	}
-	return entry, nil
-}
-
-// DeleteKey removes a specific session key from a proxy.
-func (s *MemLocalKeyStore) DeleteKey(proxyHost, username string, opts ...KeyOption) error {
-	delete(s.inMem, keyIndex{proxyHost: proxyHost, username: username})
-	s.DeleteKeyOption(proxyHost, username, opts...)
-	return nil
-}
-
-// DeleteKeys removes all session keys.
-func (s *MemLocalKeyStore) DeleteKeys() error {
-	s.inMem = make(map[keyIndex]*Key)
-	return nil
-}
-
-// DeleteKeyOption deletes only secrets specified by the provided key
-// options keeping user's SSH/TLS certificates and private key intact.
-func (s *MemLocalKeyStore) DeleteKeyOption(proxyHost, username string, opts ...KeyOption) error {
-	for _, o := range opts {
-		if err := o.deleteKey(s, keyIndex{proxyHost: proxyHost, username: username}); err != nil {
-			return trace.Wrap(err)
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			fs.log.Debugf("Skipping PEM block type=%v headers=%v.", block.Type, block.Headers)
+			continue
 		}
+		// rest contains the remainder of data after reading a block.
+		// Therefore, the block length is len(data) - len(rest).
+		// Use that length to slice the block from the start of data.
+		blocks = append(blocks, data[:len(data)-len(rest)])
+		data = rest
 	}
-	return nil
+	return blocks, nil
 }
 
 // noLocalKeyStore is a LocalKeyStore representing the absence of a keystore.
@@ -860,16 +652,16 @@ type noLocalKeyStore struct{}
 
 var errNoLocalKeyStore = trace.NotFound("there is no local keystore")
 
-func (noLocalKeyStore) AddKey(proxy string, username string, key *Key) error {
+func (noLocalKeyStore) AddKey(key *Key) error {
 	return errNoLocalKeyStore
 }
-func (noLocalKeyStore) GetKey(proxy, username string, opts ...KeyOption) (*Key, error) {
+func (noLocalKeyStore) GetKey(idx KeyIndex, opts ...CertOption) (*Key, error) {
 	return nil, errNoLocalKeyStore
 }
-func (noLocalKeyStore) DeleteKey(proxyHost, username string, opts ...KeyOption) error {
+func (noLocalKeyStore) DeleteKey(idx KeyIndex) error {
 	return errNoLocalKeyStore
 }
-func (noLocalKeyStore) DeleteKeyOption(proxyHost, username string, opts ...KeyOption) error {
+func (noLocalKeyStore) DeleteUserCerts(idx KeyIndex, opts ...CertOption) error {
 	return errNoLocalKeyStore
 }
 func (noLocalKeyStore) DeleteKeys() error { return errNoLocalKeyStore }
@@ -879,8 +671,130 @@ func (noLocalKeyStore) AddKnownHostKeys(hostname string, keys []ssh.PublicKey) e
 func (noLocalKeyStore) GetKnownHostKeys(hostname string) ([]ssh.PublicKey, error) {
 	return nil, errNoLocalKeyStore
 }
-func (noLocalKeyStore) SaveCerts(proxy string, cas []auth.TrustedCerts) error {
+func (noLocalKeyStore) SaveTrustedCerts(proxyHost string, cas []auth.TrustedCerts) error {
 	return errNoLocalKeyStore
 }
-func (noLocalKeyStore) GetCerts(proxy string) (*x509.CertPool, error) { return nil, errNoLocalKeyStore }
-func (noLocalKeyStore) GetCertsPEM(proxy string) ([][]byte, error)    { return nil, errNoLocalKeyStore }
+func (noLocalKeyStore) GetTrustedCertsPEM(proxyHost string) ([][]byte, error) {
+	return nil, errNoLocalKeyStore
+}
+
+// MemLocalKeyStore is an in-memory session keystore implementation.
+type MemLocalKeyStore struct {
+	fsLocalNonSessionKeyStore
+	inMem memLocalKeyStoreMap
+}
+
+// memLocalKeyStoreMap is a three-dimensional map indexed by [proxyHost][username][clusterName]
+type memLocalKeyStoreMap = map[string]map[string]map[string]*Key
+
+// NewMemLocalKeyStore initializes a MemLocalKeyStore.
+// The key directory here is only used for storing CA certificates and known
+// host fingerprints.
+func NewMemLocalKeyStore(dirPath string) (*MemLocalKeyStore, error) {
+	dirPath, err := initKeysDir(dirPath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &MemLocalKeyStore{
+		fsLocalNonSessionKeyStore{
+			log:    logrus.WithField(trace.Component, teleport.ComponentKeyStore),
+			KeyDir: dirPath,
+		},
+		memLocalKeyStoreMap{},
+	}, nil
+}
+
+// AddKey writes a key to the underlying key store.
+func (s *MemLocalKeyStore) AddKey(key *Key) error {
+	if err := key.KeyIndex.Check(); err != nil {
+		return trace.Wrap(err)
+	}
+	_, ok := s.inMem[key.ProxyHost]
+	if !ok {
+		s.inMem[key.ProxyHost] = map[string]map[string]*Key{}
+	}
+	_, ok = s.inMem[key.ProxyHost][key.Username]
+	if !ok {
+		s.inMem[key.ProxyHost][key.Username] = map[string]*Key{}
+	}
+	s.inMem[key.ProxyHost][key.Username][key.ClusterName] = key
+	return nil
+}
+
+// GetKey returns the user's key including the specified certs.
+func (s *MemLocalKeyStore) GetKey(idx KeyIndex, opts ...CertOption) (*Key, error) {
+	var key *Key
+	if idx.ClusterName == "" {
+		// If clusterName is not specified then the cluster-dependent fields
+		// are not considered relevant and we may simply return any key
+		// associated with any cluster name whatsoever.
+		for _, found := range s.inMem[idx.ProxyHost][idx.Username] {
+			key = found
+			break
+		}
+	} else {
+		key = s.inMem[idx.ProxyHost][idx.Username][idx.ClusterName]
+	}
+	if key == nil {
+		return nil, trace.NotFound("key for %+v not found", idx)
+	}
+
+	// It is not necessary to handle opts because all the optional certs are
+	// already part of the Key struct as stored in memory.
+
+	tlsCertExpiration, err := key.TeleportTLSCertValidBefore()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	s.log.Debugf("Returning Teleport TLS certificate from memory, valid until %q.", tlsCertExpiration)
+
+	// Validate the SSH certificate.
+	if err := key.CheckCert(); err != nil {
+		if !utils.IsCertExpiredError(err) {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return key, nil
+}
+
+// DeleteKey deletes the user's key with all its certs.
+func (s *MemLocalKeyStore) DeleteKey(idx KeyIndex) error {
+	delete(s.inMem[idx.ProxyHost], idx.Username)
+	return nil
+}
+
+// DeleteKeys removes all session keys.
+func (s *MemLocalKeyStore) DeleteKeys() error {
+	s.inMem = memLocalKeyStoreMap{}
+	return nil
+}
+
+// DeleteUserCerts deletes only the specified certs of the user's key,
+// keeping the private key intact.
+// Empty clusterName indicates to delete the certs for all clusters.
+//
+// Useful when needing to log out of a specific service, like a particular
+// database proxy.
+func (s *MemLocalKeyStore) DeleteUserCerts(idx KeyIndex, opts ...CertOption) error {
+	var keys []*Key
+	if idx.ClusterName != "" {
+		key, ok := s.inMem[idx.ProxyHost][idx.Username][idx.ClusterName]
+		if !ok {
+			return nil
+		}
+		keys = []*Key{key}
+	} else {
+		keys = make([]*Key, 0, len(s.inMem[idx.ProxyHost][idx.Username]))
+		for _, key := range s.inMem[idx.ProxyHost][idx.Username] {
+			keys = append(keys, key)
+		}
+	}
+
+	for _, key := range keys {
+		for _, o := range opts {
+			o.deleteFromKey(key)
+		}
+	}
+	return nil
+}

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -54,26 +54,25 @@ func TestListKeys(t *testing.T) {
 	// add 5 keys for "bob"
 	keys := make([]Key, keyNum)
 	for i := 0; i < keyNum; i++ {
-		key := s.makeSignedKey(t, false)
-		host := fmt.Sprintf("host-%v", i)
-		require.NoError(t, s.addKey(host, "bob", key))
-		key.ProxyHost = host
+		idx := KeyIndex{fmt.Sprintf("host-%v", i), "bob", "root"}
+		key := s.makeSignedKey(t, idx, false)
+		require.NoError(t, s.addKey(key))
 		keys[i] = *key
 	}
 	// add 1 key for "sam"
-	samKey := s.makeSignedKey(t, false)
-	require.NoError(t, s.addKey("sam.host", "sam", samKey))
+	samIdx := KeyIndex{"sam.host", "sam", "root"}
+	samKey := s.makeSignedKey(t, samIdx, false)
+	require.NoError(t, s.addKey(samKey))
 
 	// read all bob keys:
 	for i := 0; i < keyNum; i++ {
-		host := fmt.Sprintf("host-%v", i)
-		keys2, err := s.store.GetKey(host, "bob", WithDBCerts(samKey.ClusterName, ""))
+		keys2, err := s.store.GetKey(keys[i].KeyIndex, WithSSHCerts{}, WithDBCerts{})
 		require.NoError(t, err)
 		require.Empty(t, cmp.Diff(*keys2, keys[i], cmpopts.EquateEmpty()))
 	}
 
 	// read sam's key and make sure it's the same:
-	skey, err := s.store.GetKey("sam.host", "sam")
+	skey, err := s.store.GetKey(samIdx, WithSSHCerts{})
 	require.NoError(t, err)
 	require.Equal(t, samKey.Cert, skey.Cert)
 	require.Equal(t, samKey.Pub, skey.Pub)
@@ -83,35 +82,37 @@ func TestKeyCRUD(t *testing.T) {
 	s, cleanup := newTest(t)
 	defer cleanup()
 
-	key := s.makeSignedKey(t, false)
+	idx := KeyIndex{"host.a", "bob", "root"}
+	key := s.makeSignedKey(t, idx, false)
 
 	// add key:
-	err := s.addKey("host.a", "bob", key)
+	err := s.addKey(key)
 	require.NoError(t, err)
 
 	// load back and compare:
-	keyCopy, err := s.store.GetKey("host.a", "bob", WithDBCerts(key.ClusterName, ""))
+	keyCopy, err := s.store.GetKey(idx, WithSSHCerts{}, WithDBCerts{})
 	require.NoError(t, err)
 	key.ProxyHost = keyCopy.ProxyHost
 	require.Empty(t, cmp.Diff(key, keyCopy, cmpopts.EquateEmpty()))
+	require.Len(t, key.DBTLSCerts, 1)
 
 	// Delete just the db cert, reload & verify it's gone
-	err = s.store.DeleteKeyOption("host.a", "bob", WithDBCerts(key.ClusterName, ""))
+	err = s.store.DeleteUserCerts(idx, WithDBCerts{})
 	require.NoError(t, err)
-	keyCopy, err = s.store.GetKey("host.a", "bob", WithDBCerts(key.ClusterName, ""))
+	keyCopy, err = s.store.GetKey(idx, WithSSHCerts{}, WithDBCerts{})
 	require.NoError(t, err)
 	key.DBTLSCerts = nil
 	require.Empty(t, cmp.Diff(key, keyCopy, cmpopts.EquateEmpty()))
 
 	// Delete & verify that it's gone
-	err = s.store.DeleteKey("host.a", "bob")
+	err = s.store.DeleteKey(idx)
 	require.NoError(t, err)
-	_, err = s.store.GetKey("host.a", "bob")
+	_, err = s.store.GetKey(idx)
 	require.Error(t, err)
 	require.True(t, trace.IsNotFound(err))
 
 	// Delete non-existing
-	err = s.store.DeleteKey("non-existing-host", "non-existing-user")
+	err = s.store.DeleteKey(KeyIndex{ProxyHost: "non-existing-host", Username: "non-existing-user"})
 	require.Error(t, err)
 	require.True(t, trace.IsNotFound(err))
 }
@@ -120,18 +121,22 @@ func TestDeleteAll(t *testing.T) {
 	s, cleanup := newTest(t)
 	defer cleanup()
 
-	key := s.makeSignedKey(t, false)
+	// generate keys
+	idxFoo := KeyIndex{"proxy.example.com", "foo", "root"}
+	keyFoo := s.makeSignedKey(t, idxFoo, false)
+	idxBar := KeyIndex{"proxy.example.com", "bar", "root"}
+	keyBar := s.makeSignedKey(t, idxBar, false)
 
 	// add keys
-	err := s.addKey("proxy.example.com", "foo", key)
+	err := s.addKey(keyFoo)
 	require.NoError(t, err)
-	err = s.addKey("proxy.example.com", "bar", key)
+	err = s.addKey(keyBar)
 	require.NoError(t, err)
 
 	// check keys exist
-	_, err = s.store.GetKey("proxy.example.com", "foo")
+	_, err = s.store.GetKey(idxFoo)
 	require.NoError(t, err)
-	_, err = s.store.GetKey("proxy.example.com", "bar")
+	_, err = s.store.GetKey(idxBar)
 	require.NoError(t, err)
 
 	// delete all keys
@@ -139,9 +144,9 @@ func TestDeleteAll(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify keys are gone
-	_, err = s.store.GetKey("proxy.example.com", "foo")
+	_, err = s.store.GetKey(idxFoo)
 	require.True(t, trace.IsNotFound(err))
-	_, err = s.store.GetKey("proxy.example.com", "bar")
+	_, err = s.store.GetKey(idxBar)
 	require.Error(t, err)
 }
 
@@ -192,17 +197,18 @@ func TestCheckKey(t *testing.T) {
 	s, cleanup := newTest(t)
 	defer cleanup()
 
-	key := s.makeSignedKey(t, false)
+	idx := KeyIndex{"host.a", "bob", "root"}
+	key := s.makeSignedKey(t, idx, false)
 
 	// Swap out the key with a ECDSA SSH key.
 	ellipticCertificate, _, err := utils.CreateEllipticCertificate("foo", ssh.UserCert)
 	require.NoError(t, err)
 	key.Cert = ssh.MarshalAuthorizedKey(ellipticCertificate)
 
-	err = s.addKey("host.a", "bob", key)
+	err = s.addKey(key)
 	require.NoError(t, err)
 
-	_, err = s.store.GetKey("host.a", "bob")
+	_, err = s.store.GetKey(idx)
 	require.NoError(t, err)
 }
 
@@ -212,7 +218,8 @@ func TestProxySSHConfig(t *testing.T) {
 	s, cleanup := newTest(t)
 	defer cleanup()
 
-	key := s.makeSignedKey(t, false)
+	idx := KeyIndex{"host.a", "bob", "root"}
+	key := s.makeSignedKey(t, idx, false)
 
 	caPub, _, _, _, err := ssh.ParseAuthorizedKey(CAPub)
 	require.NoError(t, err)
@@ -291,18 +298,19 @@ func TestCheckKeyFIPS(t *testing.T) {
 		t.Skip("This test only runs in FIPS mode.")
 	}
 
-	key := s.makeSignedKey(t, false)
+	idx := KeyIndex{"host.a", "bob", "root"}
+	key := s.makeSignedKey(t, idx, false)
 
 	// Swap out the key with a ECDSA SSH key.
 	ellipticCertificate, _, err := utils.CreateEllipticCertificate("foo", ssh.UserCert)
 	require.NoError(t, err)
 	key.Cert = ssh.MarshalAuthorizedKey(ellipticCertificate)
 
-	err = s.addKey("host.a", "bob", key)
+	err = s.addKey(key)
 	require.NoError(t, err)
 
 	// Should return trace.BadParameter error because only RSA keys are supported.
-	_, err = s.store.GetKey("host.a", "bob")
+	_, err = s.store.GetKey(idx)
 	require.True(t, trace.IsBadParameter(err))
 }
 
@@ -314,23 +322,22 @@ type keyStoreTest struct {
 	tlsCACert auth.TrustedCerts
 }
 
-func (s *keyStoreTest) addKey(host, user string, key *Key) error {
-	if err := s.store.AddKey(host, user, key); err != nil {
+func (s *keyStoreTest) addKey(key *Key) error {
+	if err := s.store.AddKey(key); err != nil {
 		return err
 	}
 	// Also write the trusted CA certs for the host.
-	return s.store.SaveCerts(host, []auth.TrustedCerts{s.tlsCACert})
+	return s.store.SaveTrustedCerts(key.ProxyHost, []auth.TrustedCerts{s.tlsCACert})
 }
 
 // makeSignedKey helper returns all 3 components of a user key (signed by CAPriv key)
-func (s *keyStoreTest) makeSignedKey(t *testing.T, makeExpired bool) *Key {
+func (s *keyStoreTest) makeSignedKey(t *testing.T, idx KeyIndex, makeExpired bool) *Key {
 	var (
 		err             error
 		priv, pub, cert []byte
 	)
 	priv, pub, _ = s.keygen.GenerateKeyPair("")
-	username := "vincento"
-	allowedLogins := []string{username, "root"}
+	allowedLogins := []string{idx.Username, "root"}
 	ttl := 20 * time.Minute
 	if makeExpired {
 		ttl = -ttl
@@ -341,7 +348,7 @@ func (s *keyStoreTest) makeSignedKey(t *testing.T, makeExpired bool) *Key {
 	require.NoError(t, err)
 	clock := clockwork.NewRealClock()
 	identity := tlsca.Identity{
-		Username: username,
+		Username: idx.Username,
 	}
 	subject, err := identity.Subject()
 	require.NoError(t, err)
@@ -357,7 +364,7 @@ func (s *keyStoreTest) makeSignedKey(t *testing.T, makeExpired bool) *Key {
 		PrivateCASigningKey:   CAPriv,
 		CASigningAlg:          defaults.CASignatureAlgorithm,
 		PublicUserKey:         pub,
-		Username:              username,
+		Username:              idx.Username,
 		AllowedLogins:         allowedLogins,
 		TTL:                   ttl,
 		PermitAgentForwarding: false,
@@ -365,13 +372,13 @@ func (s *keyStoreTest) makeSignedKey(t *testing.T, makeExpired bool) *Key {
 	})
 	require.NoError(t, err)
 	return &Key{
-		Priv:        priv,
-		Pub:         pub,
-		Cert:        cert,
-		TLSCert:     tlsCert,
-		TrustedCA:   []auth.TrustedCerts{s.tlsCACert},
-		DBTLSCerts:  map[string][]byte{"example-db": tlsCert},
-		ClusterName: "root",
+		KeyIndex:   idx,
+		Priv:       priv,
+		Pub:        pub,
+		Cert:       cert,
+		TLSCert:    tlsCert,
+		TrustedCA:  []auth.TrustedCerts{s.tlsCACert},
+		DBTLSCerts: map[string][]byte{"example-db": tlsCert},
 	}
 }
 
@@ -452,40 +459,39 @@ func TestMemLocalKeyStore(t *testing.T) {
 	s, cleanup := newTest(t)
 	defer cleanup()
 
-	// define some helpers
-	const proxy = "test.com"
-	const username = "test"
-
 	// create keystore
 	dir := t.TempDir()
 	keystore, err := NewMemLocalKeyStore(dir)
 	require.NoError(t, err)
 
-	// add test key
-	key := s.makeSignedKey(t, false)
-	err = keystore.AddKey(proxy, username, key)
+	// create a test key
+	idx := KeyIndex{"test.com", "test", "root"}
+	key := s.makeSignedKey(t, idx, false)
+
+	// add the test key to the memory store
+	err = keystore.AddKey(key)
 	require.NoError(t, err)
 
 	// check that the key exists in the store
-	retrievedKey, err := keystore.GetKey(proxy, username)
+	retrievedKey, err := keystore.GetKey(idx)
 	require.NoError(t, err)
 	require.Equal(t, key, retrievedKey)
 
 	// delete the key
-	err = keystore.DeleteKey(proxy, username)
+	err = keystore.DeleteKey(idx)
 	require.NoError(t, err)
 
 	// check that the key doesn't exist in the store
-	retrievedKey, err = keystore.GetKey(proxy, username)
+	retrievedKey, err = keystore.GetKey(idx)
 	require.Error(t, err)
 	require.Nil(t, retrievedKey)
 
 	// add it again
-	err = keystore.AddKey(proxy, username, key)
+	err = keystore.AddKey(key)
 	require.NoError(t, err)
 
-	// check for the key
-	retrievedKey, err = keystore.GetKey(proxy, username)
+	// check for the key, now without cluster name
+	retrievedKey, err = keystore.GetKey(KeyIndex{idx.ProxyHost, idx.Username, ""})
 	require.NoError(t, err)
 	require.Equal(t, key, retrievedKey)
 
@@ -494,7 +500,7 @@ func TestMemLocalKeyStore(t *testing.T) {
 	require.NoError(t, err)
 
 	// verify it's deleted
-	retrievedKey, err = keystore.GetKey(proxy, username)
+	retrievedKey, err = keystore.GetKey(idx)
 	require.Error(t, err)
 	require.Nil(t, retrievedKey)
 }

--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -75,7 +75,7 @@ func UpdateWithClient(ctx context.Context, path string, tc *client.TeleportClien
 		v.TeleportClusterName = tc.SiteName
 	}
 	var err error
-	v.Credentials, err = tc.LocalAgent().GetKey()
+	v.Credentials, err = tc.LocalAgent().GetCoreKey()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -450,7 +450,8 @@ func loadConfigFromProfile(ccf *GlobalCLIFlags, cfg *service.Config) (*AuthServi
 		return nil, trace.Wrap(err)
 	}
 	webProxyHost, _ := c.WebProxyHostPort()
-	key, err := keyStore.GetKey(webProxyHost, c.Username)
+	idx := client.KeyIndex{ProxyHost: webProxyHost, Username: c.Username, ClusterName: profile.Cluster}
+	key, err := keyStore.GetKey(idx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/access_request.go
+++ b/tool/tsh/access_request.go
@@ -206,7 +206,12 @@ func onRequestShow(cf *CLIConf) error {
 }
 
 func onRequestCreate(cf *CLIConf) error {
-	if err := executeAccessRequest(cf); err != nil {
+	tc, err := makeClient(cf, true)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := executeAccessRequest(cf, tc); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -77,7 +77,7 @@ func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
 	}
 
 	// Try loading existing keys.
-	k, err := tc.LocalAgent().GetKey(client.WithKubeCerts(c.teleportCluster))
+	k, err := tc.LocalAgent().GetKey(c.teleportCluster, client.WithKubeCerts{})
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
@@ -96,18 +96,12 @@ func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
 		// a new one.
 	}
 
-	activeRequests, err := k.ActiveRequests()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	log.Debugf("Requesting TLS cert for kubernetes cluster %q", c.kubeCluster)
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
 		var err error
 		k, err = tc.IssueUserCertsWithMFA(cf.Context, client.ReissueParams{
 			RouteToCluster:    c.teleportCluster,
 			KubernetesCluster: c.kubeCluster,
-			AccessRequests:    activeRequests.AccessRequests,
 		})
 		return err
 	})

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -42,6 +42,8 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
+	"github.com/gravitational/trace"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,14 +84,48 @@ func (p *cliModules) IsBoringBinary() bool {
 	return false
 }
 
+func TestFailedLogin(t *testing.T) {
+	os.RemoveAll(apiclient.FullProfilePath(""))
+	t.Cleanup(func() {
+		os.RemoveAll(apiclient.FullProfilePath(""))
+	})
+
+	connector := mockConnector(t)
+
+	_, proxyProcess := makeTestServers(t, connector)
+
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	// build a mock SSO login function to patch into tsh
+	loginFailed := trace.AccessDenied("login failed")
+	ssoLogin := func(ctx context.Context, connectorID string, pub []byte, protocol string) (*auth.SSHLoginResponse, error) {
+		return nil, loginFailed
+	}
+
+	err = Run([]string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--auth", connector.GetName(),
+		"--proxy", proxyAddr.String(),
+	}, cliOption(func(cf *CLIConf) error {
+		cf.mockSSOLogin = client.SSOLoginFunc(ssoLogin)
+		return nil
+	}))
+	require.ErrorIs(t, err, loginFailed)
+}
+
 func TestOIDCLogin(t *testing.T) {
 	os.RemoveAll(apiclient.FullProfilePath(""))
+	t.Cleanup(func() {
+		os.RemoveAll(apiclient.FullProfilePath(""))
+	})
 
 	modules.SetModules(&cliModules{})
-	defer os.RemoveAll(apiclient.FullProfilePath(""))
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	// set up an initial role with `request_access: always` in order to
 	// trigger automatic post-login escalation.
@@ -111,17 +147,9 @@ func TestOIDCLogin(t *testing.T) {
 
 	alice, err := types.NewUser("alice@example.com")
 	require.NoError(t, err)
-
 	alice.SetRoles([]string{"populist"})
 
-	// connector must exist, but does not need to be functional since we
-	// are going to mock the actual login operation.
-	connector := types.NewOIDCConnector("auth.example.com", types.OIDCConnectorSpecV2{
-		IssuerURL:   "https://auth.example.com",
-		RedirectURL: "https://cluster.example.com",
-		ClientID:    "fake-client",
-	})
-	require.NoError(t, connector.CheckAndSetDefaults())
+	connector := mockConnector(t)
 
 	authProcess, proxyProcess := makeTestServers(t, populist, dictator, connector, alice)
 
@@ -130,32 +158,6 @@ func TestOIDCLogin(t *testing.T) {
 
 	proxyAddr, err := proxyProcess.ProxyWebAddr()
 	require.NoError(t, err)
-
-	// build a mock SSO login function to patch into tsh
-	ssoLogin := func(ctx context.Context, connectorID string, pub []byte, protocol string) (*auth.SSHLoginResponse, error) {
-		// generate certificates for our user
-		sshCert, tlsCert, err := authServer.GenerateUserTestCerts(
-			pub, alice.GetName(), time.Hour,
-			teleport.CertificateFormatStandard,
-			"localhost",
-		)
-		require.NoError(t, err)
-
-		// load CA cert
-		authority, err := authServer.GetCertAuthority(services.CertAuthID{
-			Type:       services.HostCA,
-			DomainName: "localhost",
-		}, false)
-		require.NoError(t, err)
-
-		// build login response
-		return &auth.SSHLoginResponse{
-			Username:    alice.GetName(),
-			Cert:        sshCert,
-			TLSCert:     tlsCert,
-			HostSigners: auth.AuthoritiesToTrustedCerts([]services.CertAuthority{authority}),
-		}, nil
-	}
 
 	didAutoRequest := atomic.NewBool(false)
 
@@ -195,7 +197,8 @@ func TestOIDCLogin(t *testing.T) {
 		"--proxy", proxyAddr.String(),
 		"--user", "alice", // explicitly use wrong name
 	}, cliOption(func(cf *CLIConf) error {
-		cf.mockSSOLogin = client.SSOLoginFunc(ssoLogin)
+		cf.mockSSOLogin = mockSSOLogin(t, authServer, alice)
+		cf.SiteName = "localhost"
 		return nil
 	}))
 
@@ -209,8 +212,70 @@ func TestOIDCLogin(t *testing.T) {
 	// request to be generated.
 }
 
+func TestRelogin(t *testing.T) {
+	os.RemoveAll(apiclient.FullProfilePath(""))
+	t.Cleanup(func() {
+		os.RemoveAll(apiclient.FullProfilePath(""))
+	})
+
+	connector := mockConnector(t)
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{"admin"})
+
+	authProcess, proxyProcess := makeTestServers(t, connector, alice)
+
+	authServer := authProcess.GetAuthServer()
+	require.NotNil(t, authServer)
+
+	proxyAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	err = Run([]string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--auth", connector.GetName(),
+		"--proxy", proxyAddr.String(),
+	}, cliOption(func(cf *CLIConf) error {
+		cf.mockSSOLogin = mockSSOLogin(t, authServer, alice)
+		return nil
+	}))
+	require.NoError(t, err)
+
+	err = Run([]string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--proxy", proxyAddr.String(),
+		"localhost",
+	})
+	require.NoError(t, err)
+
+	err = Run([]string{"logout"})
+	require.NoError(t, err)
+
+	err = Run([]string{
+		"login",
+		"--insecure",
+		"--debug",
+		"--auth", connector.GetName(),
+		"--proxy", proxyAddr.String(),
+		"localhost",
+	}, cliOption(func(cf *CLIConf) error {
+		cf.mockSSOLogin = mockSSOLogin(t, authServer, alice)
+		return nil
+	}))
+	require.NoError(t, err)
+}
+
 func TestMakeClient(t *testing.T) {
 	os.RemoveAll(apiclient.FullProfilePath(""))
+	t.Cleanup(func() {
+		os.RemoveAll(apiclient.FullProfilePath(""))
+	})
+
 	var conf CLIConf
 
 	// empty config won't work:
@@ -377,7 +442,6 @@ func TestIdentityRead(t *testing.T) {
 }
 
 func TestOptions(t *testing.T) {
-
 	tests := []struct {
 		inOptions  []string
 		outError   bool
@@ -508,7 +572,70 @@ func TestFormatConnectCommand(t *testing.T) {
 			require.Equal(t, test.command, formatConnectCommand(cluster, test.db))
 		})
 	}
+}
 
+// TestReadClusterFlag tests that cluster environment flag is read in correctly.
+func TestReadClusterFlag(t *testing.T) {
+	var tests = []struct {
+		desc          string
+		inCLIConf     CLIConf
+		inSiteName    string
+		inClusterName string
+		outSiteName   string
+	}{
+		{
+			desc:          "nothing set",
+			inCLIConf:     CLIConf{},
+			inSiteName:    "",
+			inClusterName: "",
+			outSiteName:   "",
+		},
+		{
+			desc:          "TELEPORT_SITE set",
+			inCLIConf:     CLIConf{},
+			inSiteName:    "a.example.com",
+			inClusterName: "",
+			outSiteName:   "a.example.com",
+		},
+		{
+			desc:          "TELEPORT_CLUSTER set",
+			inCLIConf:     CLIConf{},
+			inSiteName:    "",
+			inClusterName: "b.example.com",
+			outSiteName:   "b.example.com",
+		},
+		{
+			desc:          "TELEPORT_SITE and TELEPORT_CLUSTER set, prefer TELEPORT_CLUSTER",
+			inCLIConf:     CLIConf{},
+			inSiteName:    "c.example.com",
+			inClusterName: "d.example.com",
+			outSiteName:   "d.example.com",
+		},
+		{
+			desc: "TELEPORT_SITE and TELEPORT_CLUSTER and CLI flag is set, prefer CLI",
+			inCLIConf: CLIConf{
+				SiteName: "e.example.com",
+			},
+			inSiteName:    "f.example.com",
+			inClusterName: "g.example.com",
+			outSiteName:   "e.example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			readClusterFlag(&tt.inCLIConf, func(envName string) string {
+				switch envName {
+				case siteEnvVar:
+					return tt.inSiteName
+				case clusterEnvVar:
+					return tt.inClusterName
+				default:
+					return ""
+				}
+			})
+			require.Equal(t, tt.outSiteName, tt.inCLIConf.SiteName)
+		})
+	}
 }
 
 func makeTestServers(t *testing.T, bootstrap ...services.Resource) (auth *service.TeleportProcess, proxy *service.TeleportProcess) {
@@ -593,66 +720,41 @@ func makeTestServers(t *testing.T, bootstrap ...services.Resource) (auth *servic
 	return auth, proxy
 }
 
-// TestReadClusterFlag tests that cluster environment flag is read in correctly.
-func TestReadClusterFlag(t *testing.T) {
-	var tests = []struct {
-		desc          string
-		inCLIConf     CLIConf
-		inSiteName    string
-		inClusterName string
-		outSiteName   string
-	}{
-		{
-			desc:          "nothing set",
-			inCLIConf:     CLIConf{},
-			inSiteName:    "",
-			inClusterName: "",
-			outSiteName:   "",
-		},
-		{
-			desc:          "TELEPORT_SITE set",
-			inCLIConf:     CLIConf{},
-			inSiteName:    "a.example.com",
-			inClusterName: "",
-			outSiteName:   "a.example.com",
-		},
-		{
-			desc:          "TELEPORT_CLUSTER set",
-			inCLIConf:     CLIConf{},
-			inSiteName:    "",
-			inClusterName: "b.example.com",
-			outSiteName:   "b.example.com",
-		},
-		{
-			desc:          "TELEPORT_SITE and TELEPORT_CLUSTER set, prefer TELEPORT_CLUSTER",
-			inCLIConf:     CLIConf{},
-			inSiteName:    "c.example.com",
-			inClusterName: "d.example.com",
-			outSiteName:   "d.example.com",
-		},
-		{
-			desc: "TELEPORT_SITE and TELEPORT_CLUSTER and CLI flag is set, prefer CLI",
-			inCLIConf: CLIConf{
-				SiteName: "e.example.com",
-			},
-			inSiteName:    "f.example.com",
-			inClusterName: "g.example.com",
-			outSiteName:   "e.example.com",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			readClusterFlag(&tt.inCLIConf, func(envName string) string {
-				switch envName {
-				case siteEnvVar:
-					return tt.inSiteName
-				case clusterEnvVar:
-					return tt.inClusterName
-				default:
-					return ""
-				}
-			})
-			require.Equal(t, tt.outSiteName, tt.inCLIConf.SiteName)
-		})
+func mockConnector(t *testing.T) types.OIDCConnector {
+	// Connector need not be functional since we are going to mock the actual
+	// login operation.
+	connector := types.NewOIDCConnector("auth.example.com", types.OIDCConnectorSpecV2{
+		IssuerURL:   "https://auth.example.com",
+		RedirectURL: "https://cluster.example.com",
+		ClientID:    "fake-client",
+	})
+	require.NoError(t, connector.CheckAndSetDefaults())
+	return connector
+}
+
+func mockSSOLogin(t *testing.T, authServer *auth.Server, user types.User) client.SSOLoginFunc {
+	return func(ctx context.Context, connectorID string, pub []byte, protocol string) (*auth.SSHLoginResponse, error) {
+		// generate certificates for our user
+		sshCert, tlsCert, err := authServer.GenerateUserTestCerts(
+			pub, user.GetName(), time.Hour,
+			teleport.CertificateFormatStandard,
+			"localhost",
+		)
+		require.NoError(t, err)
+
+		// load CA cert
+		authority, err := authServer.GetCertAuthority(services.CertAuthID{
+			Type:       services.HostCA,
+			DomainName: "localhost",
+		}, false)
+		require.NoError(t, err)
+
+		// build login response
+		return &auth.SSHLoginResponse{
+			Username:    user.GetName(),
+			Cert:        sshCert,
+			TLSCert:     tlsCert,
+			HostSigners: auth.AuthoritiesToTrustedCerts([]services.CertAuthority{authority}),
+		}, nil
 	}
 }


### PR DESCRIPTION
Backport of #5938.

```diff
 ~/.tsh/
 └── keys
    ├── one.example.com            --> Proxy hostname
    │   ├── certs.pem              --> TLS CA certs for the Teleport CA
    │   ├── foo                    --> RSA Private Key for user "foo"
    │   ├── foo.pub                --> Public Key
-   │   ├── foo-cert.pub           --> SSH certificate for proxies and nodes
    │   ├── foo-x509.pem           --> TLS client certificate for Auth Server
+   │   ├── foo-ssh                --> SSH certs for user "foo"
+   │   │   ├── root-cert.pub      --> SSH cert for Teleport cluster "root"
+   │   │   └── leaf-cert.pub      --> SSH cert for Teleport cluster "leaf"
```

When `-J` is provided, this also loads/reissues the SSH cert for the cluster associated with the jumphost's certificate. Fixes #5637.