### PR TITLE
ssh: fix relogin with jumphosts

### DIFF
--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -370,6 +370,16 @@ func (k *Key) CheckCert() error {
 		return trace.Wrap(err)
 	}
 
+	// Check that the certificate was for the current public key. If not, the
+	// public/private key pair may have been rotated.
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(k.Pub)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !sshutils.KeysEqual(cert.Key, pub) {
+		return trace.CompareFailed("public key in profile does not match the public key in SSH certificate")
+	}
+
 	// A valid principal is always passed in because the principals are not being
 	// checked here, but rather the validity period, signature, and algorithms.
 	certChecker := utils.CertChecker{

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -305,6 +305,7 @@ func (fs *FSLocalKeyStore) GetKey(idx KeyIndex, opts ...CertOption) (*Key, error
 		Priv:     priv,
 		TLSCert:  tlsCert,
 		TrustedCA: []auth.TrustedCerts{{
+			ClusterName:     idx.ClusterName,
 			TLSCertificates: tlsCA,
 		}},
 		KubeTLSCerts: make(map[string][]byte),

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -293,7 +293,7 @@ func (fs *FSLocalKeyStore) GetKey(idx KeyIndex, opts ...CertOption) (*Key, error
 		fs.log.Error(err)
 		return nil, trace.ConvertSystemError(err)
 	}
-	tlsCA, err := fs.GetTrustedCertsPEM(idx.ProxyHost)
+	tlsCAs, err := fs.GetTrustedCertsPEM(idx.ProxyHost)
 	if err != nil {
 		fs.log.Error(err)
 		return nil, trace.ConvertSystemError(err)
@@ -305,8 +305,7 @@ func (fs *FSLocalKeyStore) GetKey(idx KeyIndex, opts ...CertOption) (*Key, error
 		Priv:     priv,
 		TLSCert:  tlsCert,
 		TrustedCA: []auth.TrustedCerts{{
-			ClusterName:     idx.ClusterName,
-			TLSCertificates: tlsCA,
+			TLSCertificates: tlsCAs,
 		}},
 		KubeTLSCerts: make(map[string][]byte),
 		DBTLSCerts:   make(map[string][]byte),

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -293,7 +293,7 @@ func (fs *FSLocalKeyStore) GetKey(idx KeyIndex, opts ...CertOption) (*Key, error
 		fs.log.Error(err)
 		return nil, trace.ConvertSystemError(err)
 	}
-	tlsCAs, err := fs.GetTrustedCertsPEM(idx.ProxyHost)
+	tlsCA, err := fs.GetTrustedCertsPEM(idx.ProxyHost)
 	if err != nil {
 		fs.log.Error(err)
 		return nil, trace.ConvertSystemError(err)
@@ -305,7 +305,7 @@ func (fs *FSLocalKeyStore) GetKey(idx KeyIndex, opts ...CertOption) (*Key, error
 		Priv:     priv,
 		TLSCert:  tlsCert,
 		TrustedCA: []auth.TrustedCerts{{
-			TLSCertificates: tlsCAs,
+			TLSCertificates: tlsCA,
 		}},
 		KubeTLSCerts: make(map[string][]byte),
 		DBTLSCerts:   make(map[string][]byte),


### PR DESCRIPTION
Several fixes to make `tsh ssh -J leaf.proxy.com` work if the root cert
is missing/expired.