### PR TITLE
Open Sources Access Controls Docs (#6188)

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -5,6 +5,7 @@
       "title": "Documentation",
       "entries": [
         { "title": "Introduction", "slug": "/" },
+        { "title": "Adopters", "slug": "/adopters/" },
         { "title": "Getting Started", "slug": "/getting-started/" },
         { "title": "Installation", "slug": "/installation/" },
         { "title": "Application Access", "slug": "/application-access/" },
@@ -73,6 +74,23 @@
         { "title": "Architecture", "slug": "/database-access/architecture/" },
         { "title": "Reference", "slug": "/database-access/reference/" },
         { "title": "FAQ", "slug": "/database-access/faq/" }
+      ]
+    },
+    {
+      "icon": "lock",
+      "title": "Access Controls",
+      "entries": [
+        { "title": "Introduction", "slug": "/access-controls/introduction/" },
+        { "title": "Getting Started", "slug": "/access-controls/getting-started/" },
+        {
+          "title": "Guides",
+          "slug": "/access-controls/guides/",
+          "entries": [
+            { "title": "Role Templates", "slug": "/access-controls/guides/role-templates/" }
+          ]
+        },
+        { "title": "Reference", "slug": "/access-controls/reference/" },
+        { "title": "FAQ", "slug": "/access-controls/faq/" }
       ]
     },
     {
@@ -166,6 +184,11 @@
     }
   },
   "redirects": [
+    {
+      "source": "/enterprise/ssh-rbac/",
+      "destination": "/access-controls/introduction/",
+      "permanent": true
+    },
     {
       "source": "/quickstart/",
       "destination": "/getting-started/",

--- a/docs/pages/access-controls/faq.mdx
+++ b/docs/pages/access-controls/faq.mdx
@@ -1,0 +1,17 @@
+---
+title: Access Controls FAQ
+description: Frequently asked questions about Teleport RBAC
+---
+
+# Access Controls FAQ
+
+**Q:** What if a node has multiple labels?
+
+**A:** In this case, the access will be granted only if **all of the labels**
+defined in the role are present. This effectively means Teleport uses an "AND"
+operator when evaluating node-level access using labels.
+
+**Q:** Can I use node-level RBAC with OpenSSH servers?
+
+**A:** No. OpenSSH servers running `sshd` do not have the ability to label
+themselves. This is one of the reasons to run Teleport `node` service instead.

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -1,0 +1,175 @@
+---
+title: Getting Started With Access Controls
+description: Teleport Access Controls
+---
+
+# Getting Started
+
+In Teleport, any local, SSO or robot user can be a member of one or several
+roles. Roles govern access to databases, SSH servers, kubernetes clusters and web apps.
+
+We will start with local users and preset roles, map SSO users to roles and wrap up
+with creating your own role.
+
+## Prerequisites
+
+- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../cloud.mdx) >= {{teleport_version}}
+- [Tctl admin tool](https://goteleport.com/teleport/download) >= {{teleport_version}}
+
+Verify that your Teleport client is connected:
+
+```bash
+$ tctl status
+Cluster  acme.example.com
+Version  6.0.2                                                                   
+Host CA  never updated                                                           
+User CA  never updated                                                           
+Jwt CA   never updated                                                           
+CA pin   sha256:e63c7c44be468d37a5b0276b70e9d10b17f24f4be19d6b579810fc94eaa31783 
+
+```
+
+## Step 1/3 Add local users with preset roles
+
+Teleport provides a couple of preset roles: `admin`, `editor`, `auditor` and `access`.
+Members of `editor` role can modify cluster configuration, members of `auditor`
+role can view audit logs, and `access` members can access cluster resources.
+Members of `admin`, are full cluster administrators.
+
+Invite a local user Alice as cluster `editor`:
+
+```bash
+$ tctl users add alice --roles=editor
+```
+
+Once Alice signs up, she will be able to edit cluster configuration. You can list
+users and their roles using `tctl users ls`.
+
+```bash
+$ tctl users ls
+User                 Roles
+-------------------- -------------- 
+alice                editor
+admin@example.com    admin
+```
+
+You can update user's roles using `tctl users update` command:
+
+```bash
+# Once Alice relogins, she will be able to view audit logs
+$ tctl users update alice --set-roles=editor,auditor
+```
+
+Because Alice has two roles, permissions from those role create a union -
+she will be able to act as a system administrator and auditor at the same time.
+
+## Step 2/3 Map SSO users to roles
+
+We are going to setup Github connector for OSS and Okta for Enterprises version.
+
+<Tabs>
+<TabItem label="Open Source">
+
+Save the file below as `github.yaml` and update the fields. You will need to set up
+[Github OAuth 2.0 Connector](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) app.
+Any member belonging to the Github organization `octocats` and on team `admin` will be able to assume a built-in role `access`.
+
+```yaml
+kind: github
+version: v3
+metadata:
+  # connector name that will be used with `tsh --auth=github login`
+  name: github
+spec:
+  # client ID of Github OAuth app
+  client_id: client-id
+  # client secret of Github OAuth app
+  client_secret: client-secret
+  # This name will be shown on UI login screen
+  display: Github
+  # Change tele.example.com to your domain name
+  redirect_url: https://tele.example.com:443/v1/webapi/github/callback
+  # Map github teams to teleport roles
+  teams_to_logins:
+    - organization: octocats # Github organization name
+      team: admin            # Github team name within that organization
+      # map github admin team to Teleport's "access" role
+      logins: ["access"]
+```
+</TabItem>
+<TabItem label="Enterprise">
+
+Follow [SAML Okta Guide](../enterprise/sso/ssh-okta.mdx#configure-okta) to create a SAML app.
+Check out [OIDC guides](../enterprise/sso/oidc.mdx#identity-providers) for OpenID Connect apps.
+Save the file below as `okta.yaml` and update the `acs` field.
+Any member in Okta group `okta-admin` will assume a builtin role `admin`.
+
+```yaml
+kind: saml
+version: v2
+metadata:
+  name: okta
+spec:
+  acs: https://tele.example.com/v1/webapi/saml/acs
+  attributes_to_roles:
+  - {name: "groups", value: "okta-admin", roles: ["access"]}
+  entity_descriptor: |
+    <?xml !!! Make sure to shift all lines in XML descriptor
+    with 4 spaces, otherwise things will not work
+```
+</TabItem>
+</Tabs>
+
+
+## Step 3/3 Create a custom role
+
+Let's create a custom role for interns. Interns will have access
+to test or staging SSH servers as `readonly` users. We will let them
+view some monitoring web applications and dev kubernetes cluster.
+
+Save this role as `interns.yaml`:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: interns
+spec:
+  allow:
+    # Logins configures SSH login principals
+    logins: ['readonly']
+    # Assigns members of this role to built-in kubernetes group view
+    kubernetes_groups: ["view"]
+    # Allow access to SSH nodes, kubernetes clusters, apps or databases labeled with staging or test
+    node_labels:
+      'env': ['staging', 'test']
+    kubernetes_labels:
+      'env': 'dev'
+    app_labels:
+      'type': ['monitoring']
+  # The deny rules always override allow rules.
+  deny:
+    # deny access to any node, database, app or kubernetes cluster labeled
+    # as prod as any user.
+    node_labels:
+      'env': 'prod'
+    kubernetes_labels:
+      'env': 'prod'
+    db_labels:
+      'env': 'prod'
+    app_labels:
+      'env': 'prod'
+```
+
+Create a role using `tctl create -f` command:
+
+```bash
+$ tctl create -f /tmp/interns.yaml
+# Get list of all roles in the system
+$ tctl get roles --format text
+```
+
+## Next Steps
+
+- [Mapping SSO and Local Users Traits with Role Templates](./guides/role-templates.mdx)
+

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -21,12 +21,11 @@ Verify that your Teleport client is connected:
 ```bash
 $ tctl status
 Cluster  acme.example.com
-Version  6.0.2                                                                   
-Host CA  never updated                                                           
-User CA  never updated                                                           
-Jwt CA   never updated                                                           
-CA pin   sha256:e63c7c44be468d37a5b0276b70e9d10b17f24f4be19d6b579810fc94eaa31783 
-
+Version  6.0.2
+Host CA  never updated
+User CA  never updated
+Jwt CA   never updated
+CA pin   sha256:e63c7c44be468d37a5b0276b70e9d10b17f24f4be19d6b579810fc94eaa31783
 ```
 
 ## Step 1/3 Add local users with preset roles

--- a/docs/pages/access-controls/guides.mdx
+++ b/docs/pages/access-controls/guides.mdx
@@ -1,0 +1,8 @@
+---
+title: Access Controls Guides
+description: Detailed guides for configuring Teleport Access Controls
+---
+
+# Guides
+
+- [Dynamic Access Policies with Role Templates](./guides/role-templates.mdx)

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -1,0 +1,324 @@
+---
+title: Teleport Role Templates
+description: Mapping SSO and Local Users Traits to Roles with Template
+---
+
+# Role Templates
+
+As organizations grow, infrastructure teams have to figure out
+how to define access control policies that don't require manual configuration
+every time people join, leave and form new teams.
+
+Here are some common examples of such policies:
+
+- Grant every single sign-on user an SSH login generated from their email.
+- Assign each team member to their team's Kubernetes group.
+- Limit dev team to read-only replica of a database.
+
+Let's explore how Teleport's role templates provide a way to describe these and other policies.
+
+## Prerequisites
+
+- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../../cloud.mdx) >= {{teleport_version}}
+- [Tctl admin tool](https://goteleport.com/teleport/download) >= {{teleport_version}}
+
+Verify that your Teleport client is connected:
+
+```bash
+$ tctl status
+Cluster  acme.example.com
+Version  6.0.2
+Host CA  never updated
+User CA  never updated
+Jwt CA   never updated
+CA pin   sha256:e63c7c44be468d37a5b0276b70e9d10b17f24f4be19d6b579810fc94eaa31783
+```
+
+## Local Users
+
+Imagine you have two users, Alice and Bob. We would like to set the following
+access policies:
+
+- Alice to login as SSH user `admin` and Kubernetes group `edit`
+- Bob to login as `ubuntu` and Kubernetes group `view`
+
+We can create two roles, one for each user in file `roles.yaml`:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: alice
+spec:
+  allow:
+    logins: ['admin']
+    kubernetes_groups: ['edit']
+    node_labels:
+      '*': '*'
+    kubernetes_labels:
+      '*': '*'
+---
+kind: role
+version: v3
+metadata:
+  name: bob
+spec:
+  allow:
+    logins: ['ubuntu']
+    kubernetes_groups: ['view']
+    node_labels:
+      '*': '*'
+    kubernetes_labels:
+      '*': '*'
+```
+
+You can create roles and invite Alice and Bob as local users:
+
+```bash
+$ tctl create -f roles.yaml
+$ tctl users add alice --roles=alice
+$ tctl users add bob --roles=bob
+```
+
+Having one role per user is not going to scale well. Because the roles
+are so similar, we can assign variables to each user, and use just one role template
+for both Alice and Bob.
+
+Let's create a role template `devs.yaml`:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: devs
+spec:
+  allow:
+    logins: ['{{internal.logins}}']
+    kubernetes_groups: ['{{internal.kubernetes_groups}}']
+    node_labels:
+      '*': '*'
+    kubernetes_labels:
+      '*': '*'
+```
+
+Any role becomes a template once it starts using template variables.
+Just like roles, role templates are a valid YAML and validate both the structure and types.
+
+Role template `devs` is using `internal.` notation referring to local user's
+traits `logins` and `kubernetes_groups`.
+
+Use `tctl` to create a role template:
+
+```bash
+$ tctl create -f ~/scripts/access-controls/devs.yaml
+```
+
+The last step is to update Alice's and Bob's users with traits. Here is an example
+of user resources in a file `traits.yaml`:
+
+```yaml
+kind: user
+version: v2
+metadata:
+  name: alice
+spec:
+  roles: ['devs']
+  traits:
+    logins: ['admin']
+    kubernetes_groups: ['edit']
+---
+kind: user
+version: v2
+metadata:
+  name: bob
+spec:
+  roles: ['devs']
+  traits:
+    logins: ['ubuntu']
+    kubernetes_groups: ['view']
+```
+
+Update both user's entries with `tctl create -f` command:
+
+```bash
+$ tctl create -f traits.yaml 
+user "alice" has been updated
+```
+
+Once Alice logs in, she will receive SSH and X.509 certificates with
+a new role and SSH logins and Kubernetes groups set:
+
+```bash
+$ tsh login --proxy=teleport.example.com:443 --user=alice
+
+> Profile URL:        https://teleport.example.com:443
+  Logged in as:       alice
+  Cluster:            teleport.example.com
+  Roles:              devs*
+  Logins:             admin
+  Kubernetes:         enabled
+  Kubernetes groups:  edit
+  Valid until:        2021-03-26 07:13:57 -0700 PDT [valid for 12h0m0s]
+  Extensions:         permit-port-forwarding, permit-pty
+```
+
+## SSO Users
+
+Identity provider admins can assign metadata to a user, such as
+group membership or access permissions. Administrators configure what metadata
+is shared with Teleport. Teleport receives user metadata keys and values as OIDC claims or SAML
+attributes during [single sign-on redirect flow](https://goteleport.com/blog/how-oidc-authentication-works/):
+
+```yaml
+# Alice has an email alice@example.com. Email is a standard OIDC claim.
+email: "alice@example.com"
+# Alice is a member of groups admins and devs
+groups: ["admins", "devs"]
+# She can access prod and staging environments
+access: {"env": ["prod", "staging"]}
+```
+
+Let's create role template `sso-users` that expects external attribute `logins`
+to be set by identity provider. Save this role as `sso-users.yaml`:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: sso-users
+spec:
+  allow:
+    logins: ['{{external.logins}}']
+    node_labels:
+      '*': '*'
+    kubernetes_labels:
+      '*': '*'
+```
+
+A GitHub connector `github.yaml` maps every `cyber` team's member of organization `octocats` to
+the role `sso-logins`:
+
+```yaml
+kind: github
+version: v3
+metadata:
+  name: github
+spec:
+  # Client ID of Github OAuth app
+  client_id: client-id
+  # client secret of Github OAuth app
+  client_secret: secret-data-here
+  # connector display name that will be shown on web UI login screen
+  display: Github
+  # callback URL that will be called after successful authentication
+  redirect_url: https://teleport.example.com/v1/webapi/github/callback
+  # mapping of org/team memberships onto allowed logins and roles
+  teams_to_logins:
+    - organization: octocats # Github organization name
+      team: cyber # Github team name within that organization
+      # Role names to map to
+      logins:
+        - sso-users
+```
+
+Create this connector using `tctl`:
+
+```bash
+$ tctl create -f github.yaml
+```
+
+Once Bob logs in using SSO, he will receive SSH and X.509 certificates with
+a new role and SSH logins generated using `sso-users` role template:
+
+```bash
+$ tsh login --proxy=teleport.example.com:443 --auth=github
+
+> Profile URL:        https://teleport.example.com:443
+  Logged in as:       bob
+  Cluster:            teleport.example.com
+  Roles:              sso-users*
+  Logins:             bob
+  Kubernetes:         enabled
+  Kubernetes groups:  edit
+  Valid until:        2021-03-26 07:13:57 -0700 PDT [valid for 12h0m0s]
+  Extensions:         permit-port-forwarding, permit-pty
+```
+
+## Interpolation rules
+
+Administrators can configure what attributes identity providers return
+during single-sign on and present to Teleport. Let's review a couple of scenarios
+and see how Teleport interpolates the variables.
+
+Let's go back to the the list of attributes for Alice's user entry:
+
+```yaml
+# Alice has an email alice@example.com. Email is a standard OIDC claim.
+email: "alice@example.com"
+# Alice is a member of groups admins and devs
+groups: ["admins", "devs"]
+# She can access prod and staging environments
+access: {"env": ["prod", "staging"]}
+```
+
+Let's see how these variables a role template `interpolation`:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: interpolation
+spec:
+  allow:
+    # Role template fields can mix hard-coded values and variables.
+    logins: ['{{external.logins}}', 'admin']
+
+    # Roles support interpolation in string values.
+    kubernetes_users: ['IAM#{{external.foo}};']
+
+    # Lists get expanded into lists.
+    kubernetes_groups: ['{{external.groups}}']
+
+    # Functions transform variables.
+    database_users: ['{{email.local(external.email)}}']
+    
+    # Labels can mix template and hard-coded values
+    node_labels:
+      'env': '{{external.access["env"]}}'
+      'region': 'us-west-2'
+
+    kubernetes_labels:
+      '*': '*'
+```
+
+After interpolation with Alice's SSO user attributes, the role template will
+behave as the following role:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: interpolation
+spec:
+  allow:
+    # The variable external.logins is not sent by provider and it renders empty,
+    # leaving only hard-coded admin value
+    logins: ['admin']
+
+    # The variable external.email is expanded in a string.
+    kubernetes_users: ['IAM#alice@example.com;']
+
+    # The variable external.groups gets replaced with a list.
+    kubernetes_groups: ['devs', 'admins']
+
+    # The variable email.local will take a local part of the external.email attribute.
+    database_users: ['alice']
+
+    # Node labels have 'env' replaced from a variable
+    node_labels:
+      'env': ['prod', 'staging']
+      'region': 'us-west-2'
+
+    kubernetes_labels:
+      '*': '*'
+```

--- a/docs/pages/access-controls/introduction.mdx
+++ b/docs/pages/access-controls/introduction.mdx
@@ -1,0 +1,39 @@
+---
+title: Access Controls Introduction
+description: Provide Role Based Access Controls for SSH, Kubernetes, Databases and Web Apps
+h1: Access Controls for SSH, Kubernetes, Databases and Web Apps
+---
+
+## Introduction
+
+Here are examples of access policies you can define with Teleport:
+
+- Analytics team members can SSH into the MongoDB read replica, but not main database.
+- Interns can't access production databases.
+- Devops can access production server only when using a registered U2F hardware token.
+- Members of my team can access prod Kubernetes cluster if approved by someone else from the team.
+
+RBAC is almost always used in conjunction with Single Sign-On, Github in OSS and OIDC or SAML in Enterprise
+editions. It also works with users stored in Teleport's internal database.
+
+### How does it work?
+
+Let's assume a company is using [Okta](https://www.okta.com/) to authenticate users and place
+them into groups. A typical deployment of Teleport in this scenario
+would look like this:
+
+1. Configure Teleport to use existing user identities stored in Okta.
+2. Okta would have users placed in certain groups, perhaps "developers", "admins", "contractors", etc.
+3. Teleport would have certain *Teleport roles* defined. For example: "developers" and "admins".
+4. Mappings would connect the Okta groups (SAML assertions) to the Teleport roles.
+   Every Teleport user will be assigned a *Teleport role* based on their Okta
+   group membership.
+
+## Getting Started
+
+Configure Access Controls in a 5 minute [Getting Started](./getting-started.mdx)
+guide.
+
+## Guides
+
+- [Dynamic Access Policies with Role Templates](./guides/role-templates.mdx)

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -1,49 +1,10 @@
 ---
-title: Role Based Access Control for SSH and Kubernetes
-description: How to configure Teleport to provide unified Role Based Access Control for SSH and Kubernetes
-h1: Role Based Access Control for SSH & K8s
+title: Access Controls Reference
+description: Access Controls - Role options and properties
+h1: Teleport Access Controls Reference
 ---
 
-## Introduction
-
-Role Based Access Control (RBAC) gives Teleport administrators more
-granular access controls. An example of an RBAC policy could be:  *"admins can do
-anything, developers must never touch production servers and interns can only
-SSH into staging servers as guests"*
-
-RBAC is almost always used in conjunction with
-Single Sign-On ([SSO](https://en.wikipedia.org/wiki/Single_sign-on)) but it also works with
-users stored in Teleport's internal database.
-
-### How does it work?
-
-Let's assume a company is using [Okta](https://www.okta.com/) to authenticate users and place
-them into groups. A typical deployment of Teleport in this scenario
-would look like this:
-
-1. Configure Teleport to use existing user identities stored in Okta.
-2. Okta would have users placed in certain groups, perhaps "developers", "admins", "contractors", etc.
-3. Teleport would have certain *Teleport roles* defined. For example: "developers" and "admins".
-4. Mappings would connect the Okta groups (SAML assertions) to the Teleport roles.
-   Every Teleport user will be assigned a *Teleport role* based on their Okta
-   group membership.
-
 ## Roles
-
-Every user in Teleport is **always** assigned a set of roles. One can think of
-them as "SSH Roles". The open source edition of Teleport automatically assigns
-every user to the built-in `admin` role but the Teleport Enterprise allows
-administrators to define their own roles with far greater control over the
-user permissions.
-
-Some of the permissions a role could define include:
-
-- Which SSH nodes a user can or cannot access. Teleport uses [node
-  labels](../admin-guide.mdx#labeling-nodes-and-applications) to do this, i.e. some nodes can be
-  labeled "production" while others can be labeled "staging".
-- Ability to replay recorded sessions.
-- Ability to update cluster configuration.
-- Which UNIX logins a user is allowed to use when logging into servers.
 
 A Teleport `role` works by having two lists of rules: `allow` rules and `deny` rules.
 When declaring access rules, keep in mind the following:
@@ -323,16 +284,3 @@ List of all rule options defined below.
     - resources: [token]
       verbs: [list,create,read,update,delete]
 ```
-
-## FAQ
-
-**Q:** What if a node has multiple labels?
-
-**A:** In this case, the access will be granted only if **all of the labels**
-defined in the role are present. This effectively means Teleport uses an "AND"
-operator when evaluating node-level access using labels.
-
-**Q:** Can I use node-level RBAC with OpenSSH servers?
-
-**A:** No. OpenSSH servers running `sshd` do not have the ability to label
-themselves. This is one of the reasons to run Teleport `node` service instead.

--- a/docs/pages/adopters.mdx
+++ b/docs/pages/adopters.mdx
@@ -1,0 +1,128 @@
+---
+title: Teleport Adopters
+description: Who is using Teleport?
+h1: Teleport Adopters and Use-Cases
+---
+
+## Who is using Teleport?
+
+Whether you are using Teleport OSS, Enteprise or Cloud, tell us about your use-case.
+Just click "Improve the docs" and send us a PR.
+
+<table>
+<tr>
+  <th>Company</th>
+  <th>Industry</th>
+  <th>Use-cases and case-studies</th>
+</tr>
+<tr>
+  <td>Nasdaq</td>
+  <td>Finance</td>
+  <td>Secure access to internal infrastructure.</td>
+</tr>
+<tr>
+  <td>Auth0</td>
+  <td>Technology</td>
+  <td><a href="https://goteleport.com/case-study/auth0/"/></td>
+</tr>
+<tr>
+  <td>Elastic</td>
+  <td>Technology</td>
+  <td><a href="https://goteleport.com/case-study/elastic-testimonial/"/></td>
+</tr>
+<tr>
+  <td>VMware</td>
+  <td>Technology</td>
+  <td><a href="https://goteleport.com/case-study/vmware-testimonial/"/></td>
+</tr>
+<tr>
+  <td>Snowflake</td>
+  <td>Technology</td>
+  <td>Access for SSH and Kubernetes clusters.</td>
+</tr>
+<tr>
+  <td>Samsung</td>
+  <td>Technology</td>
+  <td>Secure access for SSH and Kubernetes.</td>
+</tr>
+<tr>
+  <td>ECMWF</td>
+  <td>Technology</td>
+  <td><a href="https://goteleport.com/case-study/ecmwf/"/></td>
+</tr>
+<tr>
+  <td>IBM</td>
+  <td>Technology</td>
+  <td>Protected access to internal Kubernetes clusters.</td>
+</tr>
+<tr>
+  <td>Infoblox</td>
+  <td>Technology</td>
+  <td>Secure access to internal infrastructure.</td>
+</tr>
+<tr>
+  <td>Wise</td>
+  <td>Fintech</td>
+  <td>Secure access for infrastructure.</td>
+</tr>
+<tr>
+  <td>Zapier</td>
+  <td>Technology</td>
+  <td>Secure access for SSH.</td>
+</tr>
+<tr>
+  <td>ExtraHop</td>
+  <td>Infosec</td>
+  <td><a href="https://goteleport.com/case-study/extrahop/"/></td>
+</tr>
+<tr>
+  <td>Twitch</td>
+  <td>Technology</td>
+  <td>SSH access.</td>
+</tr>
+<tr>
+  <td>GitLab</td>
+  <td>Technology</td>
+  <td><a href="https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/11568#note_451982812"/></td>
+</tr>
+<tr>
+  <td>SumoLogic</td>
+  <td>Technology</td>
+  <td>Achieve FedRamp compliance and secure access to infrastructure.</td>
+</tr>
+<tr>
+  <td>Gladly</td>
+  <td>Technology</td>
+  <td><a href="https://goteleport.com/case-study/gladly/"/></td>
+</tr>
+<tr>
+  <td>VerticalChange</td>
+  <td>Technology</td>
+  <td><a href="https://goteleport.com/case-study/verticalchange-testimonial/"/></td>
+</tr>
+<tr>
+  <td>Shockbyte</td>
+  <td>Technology</td>
+  <td><a href="https://goteleport.com/case-study/shockbyte-testimonial/"/></td>
+</tr>
+<tr>
+  <td>Lacework</td>
+  <td>Infosec</td>
+  <td><a href="https://goteleport.com/case-study/lacework-testimonial/"/></td>
+</tr>
+<tr>
+  <td>Glu Mobile</td>
+  <td>Gaming</td>
+  <td><a href="https://goteleport.com/case-study/glumobile-testimonial/"/></td>
+</tr>
+<tr>
+  <td>Decisiv</td>
+  <td>Transportation</td>
+  <td><a href="https://goteleport.com/case-study/decisiv/"/></td>
+</tr>
+<tr>
+  <td>Mattermost</td>
+  <td>Technology</td>
+  <td>Secure access to infrastructure.</td>
+</tr>
+</table>

--- a/docs/pages/adopters.mdx
+++ b/docs/pages/adopters.mdx
@@ -23,17 +23,17 @@ Just click "Improve the docs" and send us a PR.
 <tr>
   <td>Auth0</td>
   <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/auth0/"/></td>
+  <td><a href="https://goteleport.com/case-study/auth0/">case study</a></td>
 </tr>
 <tr>
   <td>Elastic</td>
   <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/elastic-testimonial/"/></td>
+  <td><a href="https://goteleport.com/case-study/elastic-testimonial/">testimonial</a></td>
 </tr>
 <tr>
   <td>VMware</td>
   <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/vmware-testimonial/"/></td>
+  <td><a href="https://goteleport.com/case-study/vmware-testimonial/">testimonial</a></td>
 </tr>
 <tr>
   <td>Snowflake</td>
@@ -48,7 +48,7 @@ Just click "Improve the docs" and send us a PR.
 <tr>
   <td>ECMWF</td>
   <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/ecmwf/"/></td>
+  <td><a href="https://goteleport.com/case-study/ecmwf/">case study</a></td>
 </tr>
 <tr>
   <td>IBM</td>
@@ -73,7 +73,7 @@ Just click "Improve the docs" and send us a PR.
 <tr>
   <td>ExtraHop</td>
   <td>Infosec</td>
-  <td><a href="https://goteleport.com/case-study/extrahop/"/></td>
+  <td><a href="https://goteleport.com/case-study/extrahop/">case study</a></td>
 </tr>
 <tr>
   <td>Twitch</td>
@@ -83,7 +83,7 @@ Just click "Improve the docs" and send us a PR.
 <tr>
   <td>GitLab</td>
   <td>Technology</td>
-  <td><a href="https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/11568#note_451982812"/></td>
+  <td><a href="https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/11568#note_451982812">team review</a></td>
 </tr>
 <tr>
   <td>SumoLogic</td>
@@ -93,32 +93,32 @@ Just click "Improve the docs" and send us a PR.
 <tr>
   <td>Gladly</td>
   <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/gladly/"/></td>
+  <td><a href="https://goteleport.com/case-study/gladly/">case study</a></td>
 </tr>
 <tr>
   <td>VerticalChange</td>
   <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/verticalchange-testimonial/"/></td>
+  <td><a href="https://goteleport.com/case-study/verticalchange-testimonial/">testimonial</a></td>
 </tr>
 <tr>
   <td>Shockbyte</td>
   <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/shockbyte-testimonial/"/></td>
+  <td><a href="https://goteleport.com/case-study/shockbyte-testimonial/">testimonial</a></td>
 </tr>
 <tr>
   <td>Lacework</td>
   <td>Infosec</td>
-  <td><a href="https://goteleport.com/case-study/lacework-testimonial/"/></td>
+  <td><a href="https://goteleport.com/case-study/lacework-testimonial/">testimonial</a></td>
 </tr>
 <tr>
   <td>Glu Mobile</td>
   <td>Gaming</td>
-  <td><a href="https://goteleport.com/case-study/glumobile-testimonial/"/></td>
+  <td><a href="https://goteleport.com/case-study/glumobile-testimonial/">testimonial</a></td>
 </tr>
 <tr>
   <td>Decisiv</td>
   <td>Transportation</td>
-  <td><a href="https://goteleport.com/case-study/decisiv/"/></td>
+  <td><a href="https://goteleport.com/case-study/decisiv/">case study</a></td>
 </tr>
 <tr>
   <td>Mattermost</td>

--- a/docs/pages/api-reference.mdx
+++ b/docs/pages/api-reference.mdx
@@ -100,7 +100,7 @@ This should result in three PEM encoded files being generated in the `/certs` di
 Move the `/certs` folder into your `/api-examples` folder.
 
 <Admonition type="note">
-  By default, `tctl auth sign` produces certificates with a relatively short lifetime. See our [Kubernetes Section](kubernetes-access.mdx#using-teleport-kubernetes-with-automation) for more information on automating the signing process for short lived certificates.
+  By default, `tctl auth sign` produces certificates with a relatively short lifetime. See our [Kubernetes Section](./kubernetes-access/guides/cicd.mdx) for more information on automating the signing process for short lived certificates.
 
   While we encourage you to use short lived certificates, we understand you may not have all the infrastructure to issues and obtain them at the onset. You can use the --ttl flag to extend the lifetime of a certificate in these cases but understand this reduces your security posture
 </Admonition>
@@ -345,7 +345,7 @@ type Resource struct {
 
 ## Roles
 
-Every user in Teleport is assigned a set of [roles](enterprise/ssh-rbac.mdx#roles). A user's roles defines what actions or resources the user is allowed or denied to access. We offer a wide array of permissions, allowing you to safely and precisely give developers access to the resources they need.
+Every user in Teleport is assigned a set of [roles](./access-controls/reference.mdx#roles). A user's roles defines what actions or resources the user is allowed or denied to access. We offer a wide array of permissions, allowing you to safely and precisely give developers access to the resources they need.
 
 Some of the permissions a role could define include:
 
@@ -370,7 +370,7 @@ You may want to use the API to manage roles if:
 
 A Teleport `role` is defined by its `Allow` rules, `Deny` rules, and OpenSSH `Options`. We'll break these down piece by piece below.
 
-To see a role example in `yaml` form, look at the the admin role in the [RBAC documentation](enterprise/ssh-rbac.mdx). You'll notice that the role object below has the same exact nested structure as its `yaml` counterpart.
+To see a role example in `yaml` form, look at the the admin role in the [RBAC documentation](./access-controls/reference.mdx#roles). You'll notice that the role object below has the same exact nested structure as its `yaml` counterpart.
 
 ```go
 // RoleV3 represents role resource specification
@@ -736,7 +736,7 @@ if err := client.DeleteToken(tokenString); err != nil {
 
 ## Cluster Labels
 
-Cluster Labels can be used to differentiate between leaf clusters in a [Trusted Cluster](trustedclusters.mdx). These can be useful when defining [roles](enterprise/ssh-rbac.mdx) within a trusted cluster, where each cluster has its own requirements for access.
+Cluster Labels can be used to differentiate between leaf clusters in a [Trusted Cluster](trustedclusters.mdx). These can be useful when defining [roles](./access-controls/reference.mdx#roles) within a trusted cluster, where each cluster has its own requirements for access.
 
 For example, if each cluster corresponds to a different product that should only be accessed by its product team, you can give each cluster a label like `product: A`. Then create a role for each product which allows access to clusters with its respective product label.
 

--- a/docs/pages/application-access.mdx
+++ b/docs/pages/application-access.mdx
@@ -41,9 +41,9 @@ Get started with Application Access in a 10 minute [guide](./application-access/
 
 ## Guides
 
-* [Connecting Applications](./application-access/guides/connecting-apps.mdx)
-* [JWT Tokens](./application-access/guides/jwt.mdx)
-* [API Access](./application-access/guides/api-access.mdx)
+- [Connecting Applications](./application-access/guides/connecting-apps.mdx)
+- [JWT Tokens](./application-access/guides/jwt.mdx)
+- [API Access](./application-access/guides/api-access.mdx)
 
 ## Example Legacy Apps
 

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -7,16 +7,27 @@ description: Getting started with Teleport Application Access
 
 Let's connect to Grafana using Teleport Application Access in 3 steps:
 
-1. Launch Grafana in a Docker container.
-2. Install Teleport and configure it it to proxy Grafana.
-3. Access Grafana through Teleport.
+- Launch Grafana in a Docker container.
+- Install Teleport and configure it it to proxy Grafana.
+- Access Grafana through Teleport.
+
+## Follow along with our video guide
+
+<iframe
+  width="712"
+  height="400"
+  src="https://www.youtube-nocookie.com/embed/5Uwhp3IQMHY?rel=0&modestbranding=1"
+  frameBorder="0"
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+/>
 
 ## Prerequisites
 
-* We will use Docker to launch Grafana in a container. Alternatively, if you
+- We will use Docker to launch Grafana in a container. Alternatively, if you
   have another web application you'd like to protect with App Access, you can
   use that instead.
-* We will assume your Teleport cluster is accessible at `teleport.example.com`
+- We will assume your Teleport cluster is accessible at `teleport.example.com`
   and `*.teleport.example.com`. Configured DNS records are required to
   automatically fetch a Let's Encrypt certificate.
 
@@ -89,11 +100,11 @@ There are a couple of ways to access the proxied application.
 
 Every application is assigned a public address which you use to navigate to
 the application directly. In our sample Grafana application we have provided a public address with
-the `--app-public-addr` flag, so go to https://grafana.teleport.example.com
+the `--app-public-addr` flag, so go to <a href="https://grafana.teleport.example.com"/>
 (replace with your app public address) to access the app. If you're not logged into Teleport,
 you will need to authenticate before the application will show.
 
-Alternatively, log into the Teleport web UI at https://teleport.example.com
+Alternatively, log into the Teleport web UI at <a href="https://teleport.example.com"/>
 (replace with your proxy public address). All available applications are
 displayed on the Applications tab. Click on the Grafana application tile
 to access it.
@@ -102,7 +113,7 @@ to access it.
 
 Dive deeper into the topics relevant to your Application Access use-case:
 
-* Learn in more detail about [connecting applications](./guides/connecting-apps.mdx) with Application Access.
-* Learn about integrating with [JWT tokens](./guides/jwt.mdx) for auth.
-* Learn how to use Application Access with [RESTful APIs](./guides/api-access.mdx).
-* See full configuration and CLI [reference](./reference.mdx).
+- Learn in more detail about [connecting applications](./guides/connecting-apps.mdx) with Application Access.
+- Learn about integrating with [JWT tokens](./guides/jwt.mdx) for auth.
+- Learn how to use Application Access with [RESTful APIs](./guides/api-access.mdx).
+- See full configuration and CLI [reference](./reference.mdx).

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -100,11 +100,11 @@ There are a couple of ways to access the proxied application.
 
 Every application is assigned a public address which you use to navigate to
 the application directly. In our sample Grafana application we have provided a public address with
-the `--app-public-addr` flag, so go to <a href="https://grafana.teleport.example.com"/>
+the `--app-public-addr` flag, so go to `https://grafana.teleport.example.com`
 (replace with your app public address) to access the app. If you're not logged into Teleport,
 you will need to authenticate before the application will show.
 
-Alternatively, log into the Teleport web UI at <a href="https://teleport.example.com"/>
+Alternatively, log into the Teleport web UI at `https://teleport.example.com`
 (replace with your proxy public address). All available applications are
 displayed on the Applications tab. Click on the Grafana application tile
 to access it.

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -12,7 +12,7 @@ tools like [curl](https://man7.org/linux/man-pages/man1/curl.1.html) or
 ## Prerequisites
 
 We will assume that you followed the [Getting Started](../getting-started.mdx)
-guide or the general [App Access Usage](./usage.mdx) guide to connect the web
+guide or the general [App Access Usage](./connecting-apps.mdx) guide to connect the web
 application providing an API to Teleport.
 
 For the simplicity of the guide, we will be using Grafana running in a

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -54,8 +54,8 @@ everyone will log into Teleport.
 
 In our example:
 
-* `teleport.example.com` will host the Access Plane.
-* `*.teleport.example.com` will host all of the applications e.g. `grafana.teleport.example.com`.
+- `teleport.example.com` will host the Access Plane.
+- `*.teleport.example.com` will host all of the applications e.g. `grafana.teleport.example.com`.
 
 Teleport can obtain a certificate automatically from Let's Encrypt using
 [ACME](https://letsencrypt.org/how-it-works/) protocol.

--- a/docs/pages/application-access/guides/jwt.mdx
+++ b/docs/pages/application-access/guides/jwt.mdx
@@ -11,8 +11,8 @@ to a target application in a `Teleport-Jwt-Assertion` header.
 You can use the JWT token to get information about the authenticated Teleport
 user and its roles. This allows you to:
 
-* Map Teleport identity/roles onto the identity/roles of your web application.
-* Trust Teleport identity to automatically sign in users into your application.
+- Map Teleport identity/roles onto the identity/roles of your web application.
+- Trust Teleport identity to automatically sign in users into your application.
 
 ## Introduction to JWTs
 

--- a/docs/pages/architecture/users.mdx
+++ b/docs/pages/architecture/users.mdx
@@ -76,7 +76,7 @@ connector and it is enforced by default.
 >
   2FA is not supported with SSO providers such as Github or OKTA. To learn
   more about SSO configuration check out the [SSO section of the Enterprise
-  Guide](/enterprise/introduction.mdx#sso)
+  Guide](../enterprise/introduction.mdx#sso)
 </Admonition>
 
 There are two types of 2FA supported:

--- a/docs/pages/database-access/rbac.mdx
+++ b/docs/pages/database-access/rbac.mdx
@@ -13,7 +13,7 @@ everything, QA team and engineers have full access to staging databases, and
 engineers can gain temporary access to the production database in case of
 emergency"*.
 
-For a more general description of Teleport roles and examples see [RBAC](../enterprise/ssh-rbac.mdx), as
+For a more general description of Teleport roles and examples see [RBAC](../access-controls/introduction.mdx), as
 this section focuses on configuring RBAC for Database Access.
 
 ## Role Configuration

--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -53,7 +53,7 @@ would look like this:
    to the Teleport Roles so every Teleport user will be assigned a role based
    on the group membership.
 
-See [RBAC for SSH](ssh-rbac.mdx) chapter to learn more about configuring RBAC with
+See [RBAC](../access-controls/introduction.mdx) chapter to learn more about configuring RBAC with
 Teleport.
 
 ## SSO

--- a/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
+++ b/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
@@ -15,7 +15,7 @@ government agencies.
 
 | Control | Teleport Features |
 | - | - |
-| [AC-03 Access Enforcement](https://nvd.nist.gov/800-53/Rev4/control/AC-3) | Teleport Enterprise supports robust [Role-based Access Controls (RBAC)](./ssh-rbac.mdx) to: <br/>• Control which SSH nodes a user can or cannot access. <br/>• Control cluster level configuration (session recording, configuration, etc.) <br/>• Control which UNIX logins a user is allowed to use when logging into a server. |
+| [AC-03 Access Enforcement](https://nvd.nist.gov/800-53/Rev4/control/AC-3) | Teleport Enterprise supports robust [Role-based Access Controls (RBAC)](../access-controls/introduction.mdx) to: <br/>• Control which SSH nodes a user can or cannot access. <br/>• Control cluster level configuration (session recording, configuration, etc.) <br/>• Control which UNIX logins a user is allowed to use when logging into a server. |
 | [AC-10 Concurrent Session Control](https://nvd.nist.gov/800-53/Rev4/control/AC-10) | Teleport administrators can define concurrent session limits using Teleport’s RBAC. |
 | [AC-17 Remote Access](https://nvd.nist.gov/800-53/Rev4/control/AC-17) | Teleport administrators create users with configurable roles that can be used to allow or deny access to system resources. |
 | [AC-20 Use of External Information Systems](https://nvd.nist.gov/800-53/Rev4/control/AC-20) | Teleport supports connecting multiple independent clusters using a feature called [Trusted Clusters](../trustedclusters.mdx). When allowing access from one cluster to another, roles are mapped according to a pre-defined relationship of the scope of access. |

--- a/docs/pages/enterprise/sso/gitlab.mdx
+++ b/docs/pages/enterprise/sso/gitlab.mdx
@@ -1,0 +1,201 @@
+---
+title: Authentication With GitLab as an SSO provider
+description: How to configure Teleport access using GitLab for SSO
+h1: Teleport SSO Authentication with GitLab
+---
+
+## How to use GitLab as a single sign-on (SSO) provider with Teleport
+
+This guide will cover how to configure [GitLab](https://www.gitlab.com/) to issue
+SSH credentials to specific groups of users. When used in combination with role
+based access control (RBAC), it allows administrators to define policies
+like:
+
+- Only members of "DBA" group can SSH into machines running PostgreSQL.
+- Only members of "ProductionKubernetes" can access production Kubernetes clusters
+- Developers must never SSH into production servers.
+
+<Admonition
+  type="warning"
+  title="Version Warning"
+>
+  This guide requires a commercial edition of Teleport. The open source
+  edition of Teleport only supports [Github](../../admin-guide.mdx#github-oauth-20) as
+  an SSO provider.
+</Admonition>
+
+## Enable OIDC Authentication
+
+First, configure Teleport auth server to use OIDC authentication instead of the local
+user database. Update `/etc/teleport.yaml` as shown below and restart the
+teleport daemon.
+
+```yaml
+auth_service:
+    authentication:
+        type: oidc
+```
+
+## Configure GitLab
+You should have at least one group configured in GitLab to map to Teleport roles. In this example we use the names `gitlab-dev` and `gitlab-admin`.  Assign users to each of these groups.
+1. Create a Application in one of your Groups that will allow using GitLab as a OAuh provider to Teleport.
+
+Settings
+
+- Redirect URL `https://<proxy url>/v1/webapi/oidc/callback` such as `https://teleport.example.com:3080/v1/webapi/oidc/callback`
+- Check `Confidential`, `openid`, `profile`, and `email`.
+![Create App](../../../img/sso/gitlab/gitlab-oidc-0.png)
+
+2. Collect the `Application ID` and `Secret` in the Application
+
+These will be used in the Teleport OIDC Auth Connector.
+![Collection Information](../../../img/sso/gitlab/gitlab-oidc-1.png)
+
+3. Confirm the GitLab Issuer Address
+
+For GitLab cloud that is `https://gitlab.com`. That allows accessing the Open-ID configuration at <a href="https://gitlab.com/.well-known/openid-configuration"/>.  If you are self hosting that is likely another local address.
+
+
+## Configure Teleport
+
+
+### Create a OIDC Connector
+
+Create a OIDC connector [resource](../../admin-guide.mdx#resources):
+Replace the Application ID and the Secret with the values from GitLab.
+
+```yaml
+kind: oidc
+metadata:
+  name: gitlab
+spec:
+  claims_to_roles:
+  - claim: groups
+    roles:
+    - admin
+    value: gitlab-admin
+  - claim: groups
+    roles:
+    - admin
+    value: gitlab-dev
+  client_id: Application_ID
+  client_secret: Secret
+  display: GitLab
+  issuer_url: https://gitlab.com
+  prompt: ""
+  redirect_url: https://teleport.example.com:3080/v1/webapi/oidc/callback
+  scope:
+  - email
+version: v2
+```
+
+<Admonition
+  type="note"
+  title="IMPORTANT"
+>
+  The `prompt` value must be blank.  Setting to blank means Teleport will not send this as a parameter sending the `select_account` parameter will result in an error from GitLab.
+</Admonition>
+
+Create the connector using `tctl` tool:
+
+```bsh
+$ tctl create oidc-connector.yaml
+```
+
+## Create Teleport Roles
+
+We are going to create 2 roles, privileged role admin who is able to login as
+root and is capable of administrating the cluster and non-privileged dev.
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: admin
+spec:
+  options:
+    max_session_ttl: 24h
+  allow:
+    logins: [root]
+    node_labels:
+      "*": "*"
+    rules:
+      - resources: ["*"]
+        verbs: ["*"]
+```
+
+The developer role:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: dev
+spec:
+  options:
+    max_session_ttl: 24h
+  allow:
+    logins: [ "{{email.local(external.email)}}", ubuntu ]
+    node_labels:
+      access: relaxed
+```
+
+- Devs are only allowed to login to nodes labelled with `access: relaxed` label.
+- Developers can log in as `ubuntu` user
+- Notice `{{external.email}}` login. It configures Teleport to look at
+  *"email"* GitLab claim and use that field as an allowed login for each user.  The `email.local(external.trait)` function will remove the `@domain` and just have the username prefix.
+- Developers also do not have any "allow rules" i.e. they will not be able to
+  see/replay past sessions or re-configure the Teleport cluster.
+
+Create both roles on the auth server:
+
+```bsh
+$ tctl create admin.yaml
+$ tctl create dev.yaml
+```
+
+## Testing
+
+The Web UI will now contain a new button: "Login with GitLab". The CLI is
+the same as before:
+
+```bsh
+$ tsh --proxy=teleport.example.com login
+```
+
+This command will print the SSO login URL (and will try to open it
+automatically in a browser).
+
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  Teleport can use multiple OIDC/SAML connectors. In this case a connector name
+  can be passed via `tsh login --auth=connector_name`
+</Admonition>
+
+<Admonition
+  type="note"
+  title="IMPORTANT"
+>
+  Teleport only supports sending party initiated flows for OIDC Connect. This
+  means you can not initiate login from your identity provider, you have to
+  initiate login from either the Teleport Web UI or CLI.
+</Admonition>
+
+## Troubleshooting
+
+If you get "access denied errors" the number one place to check is the events in the audit
+log on the Teleport auth server. The audit events log is located in `/var/lib/teleport/log/events.log` by
+default and it will contain the detailed reason why a user's login was denied.
+
+Some errors (like filesystem permissions or misconfigured network) can be
+diagnosed using Teleport's `stderr` log, which is usually available via:
+
+```bsh
+$ sudo journalctl -fu teleport
+```
+
+If you wish to increase the verbosity of Teleport's syslog, you can pass
+`--debug` flag to `teleport start` command.
+

--- a/docs/pages/enterprise/sso/gitlab.mdx
+++ b/docs/pages/enterprise/sso/gitlab.mdx
@@ -53,7 +53,8 @@ These will be used in the Teleport OIDC Auth Connector.
 
 3. Confirm the GitLab Issuer Address
 
-For GitLab cloud that is `https://gitlab.com`. That allows accessing the Open-ID configuration at <a href="https://gitlab.com/.well-known/openid-configuration"/>.  If you are self hosting that is likely another local address.
+For GitLab cloud that is `https://gitlab.com`. That allows accessing the Open-ID configuration at `https://gitlab.com/.well-known/openid-configuration`.
+If you are self hosting that is likely another local address.
 
 
 ## Configure Teleport

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -58,7 +58,6 @@ integration with identity managers for single sign-on (SSO).
 - [Teleport Enterprise Introduction](enterprise/introduction.mdx) - Overview of the additional capabilities of Teleport Enterprise.
 - [Teleport Enterprise Quick Start](enterprise/quickstart-enterprise.mdx) - A quick tutorial to show off the basic capabilities of Teleport Enterprise.
   A good place to start if you want to jump right in.
-- [RBAC for SSH](enterprise/ssh-rbac.mdx) - Details on how Teleport Enterprise provides Role-based Access Controls (RBAC) for SSH.
 - [SSO for SSH](enterprise/sso/ssh-sso.mdx) - Overview on how Teleport Enterprise works with external identity providers for single sign-on (SSO).
 
 Teleport is available through the free, open source edition ("Teleport Community Edition")

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -7,11 +7,11 @@ description: Getting started with Teleport Kubernetes Access
 
 Let's deploy Teleport in a Kubernetes with SSO and Audit logs:
 
-1. Install Teleport in a Kubernetes cluster.
-2. Set up Single Sign On
-3. Capture and play back Kubernetes commands.
+- Install Teleport in a Kubernetes cluster.
+- Set up Single Sign On
+- Capture and play back Kubernetes commands.
 
-### Follow along with our video guide
+## Follow along with our video guide
 
 <iframe
   width="712"

--- a/docs/pages/kubernetes-access/guides/migration.mdx
+++ b/docs/pages/kubernetes-access/guides/migration.mdx
@@ -337,7 +337,7 @@ of Kubernetes user/group identities). In 5.0, you can restrict user access to a
 subset of Kubernetes clusters using Kubernetes cluster labels and Teleport
 roles.
 
-This RBAC integration works exactly like the [integration for SSH nodes](../../enterprise/ssh-rbac.mdx).
+This RBAC integration works exactly like the [integration for SSH nodes](../../access-controls/reference.mdx).
 
 First, set the set of Kubernetes labels a user can access on their roles:
 


### PR DESCRIPTION
Moves RBAC to a separate access controls section,
adds a couple of guides and prepares
the structure for more content.