### PR TITLE
[4.3-backport]  Update Architecture Overview With Link To User Roles

### DIFF
--- a/docs/pages/architecture/overview.mdx
+++ b/docs/pages/architecture/overview.mdx
@@ -80,7 +80,7 @@ steps are explained below the diagram.
   title="Caution"
 >
   The teleport daemon calls services "roles" in the CLI
-  client. The `--roles` flag has no relationship to concept of User Roles or
+  client. The `--roles` flag has no relationship to concept of [User Roles](users.mdx#user-roles) or
   permissions.
 </Admonition>
 


### PR DESCRIPTION
- updating architecture overview with link to user roles when referring
to user roles in the context of the --roles flag

Resolves: patch/arch-ovrvw-link-adj-4.3