### PR TITLE
ssh.ClientConfig.User fix

### DIFF
--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -190,7 +190,7 @@ func getExpectedTLSConfig(t *testing.T) *tls.Config {
 }
 
 func getExpectedSSHConfig(t *testing.T) *ssh.ClientConfig {
-	config, err := sshutils.SSHClientConfig(sshCert, keyPEM, [][]byte{sshCACert})
+	config, err := sshutils.ProxyClientSSHConfig(sshCert, keyPEM, [][]byte{sshCACert})
 	require.NoError(t, err)
 
 	return config

--- a/api/client/identityfile.go
+++ b/api/client/identityfile.go
@@ -86,10 +86,11 @@ func (i *IdentityFile) TLSConfig() (*tls.Config, error) {
 
 // SSHClientConfig returns the identity file's associated SSHClientConfig.
 func (i *IdentityFile) SSHClientConfig() (*ssh.ClientConfig, error) {
-	ssh, err := sshutils.SSHClientConfig(i.Certs.SSH, i.PrivateKey, i.CACerts.SSH)
+	ssh, err := sshutils.ProxyClientSSHConfig(i.Certs.SSH, i.PrivateKey, i.CACerts.SSH)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	return ssh, nil
 }
 

--- a/api/client/profile.go
+++ b/api/client/profile.go
@@ -131,7 +131,7 @@ func (p *Profile) SSHClientConfig() (*ssh.ClientConfig, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	ssh, err := sshutils.SSHClientConfig(cert, key, [][]byte{caCerts})
+	ssh, err := sshutils.ProxyClientSSHConfig(cert, key, [][]byte{caCerts})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -218,10 +218,23 @@ func (k *Key) clientTLSConfig(cipherSuites []uint16, tlsCertRaw []byte) (*tls.Co
 	return tlsConfig, nil
 }
 
-// ClientSSHConfig returns an ssh.ClientConfig with SSH credentials from this
+// ProxyClientSSHConfig returns an ssh.ClientConfig with SSH credentials from this
 // Key and HostKeyCallback matching SSH CAs in the Key.
-func (k *Key) ClientSSHConfig() (*ssh.ClientConfig, error) {
-	return sshutils.SSHClientConfig(k.Cert, k.Priv, k.SSHCAs())
+//
+// The config is set up to authenticate to proxy with the first available principal
+// and ( if keyStore != nil ) trust local SSH CAs without asking for public keys.
+//
+func (k *Key) ProxyClientSSHConfig(keyStore LocalKeyStore) (*ssh.ClientConfig, error) {
+	sshConfig, err := sshutils.ProxyClientSSHConfig(k.Cert, k.Priv, k.SSHCAs())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if keyStore != nil {
+		sshConfig.HostKeyCallback = NewKeyStoreCertChecker(keyStore)
+	}
+
+	return sshConfig, nil
 }
 
 // CertUsername returns the name of the Teleport user encoded in the SSH certificate.
@@ -401,27 +414,6 @@ func (k *Key) CheckCert() error {
 // fingerprint (same as OpenSSH does for an unknown host).
 func (k *Key) HostKeyCallback() (ssh.HostKeyCallback, error) {
 	return sshutils.HostKeyCallback(k.SSHCAs())
-}
-
-// ProxyClientSSHConfig returns an ssh.ClientConfig with SSH credentials from this
-// Key and HostKeyCallback matching SSH CAs in the Key.
-//
-// The config is set up to authenticate to proxy with the first
-// available principal and trust local SSH CAs without asking
-// for public keys.
-//
-func ProxyClientSSHConfig(k *Key, keyStore LocalKeyStore) (*ssh.ClientConfig, error) {
-	sshConfig, err := k.ClientSSHConfig()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	principals, err := k.CertPrincipals()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	sshConfig.User = principals[0]
-	sshConfig.HostKeyCallback = NewKeyStoreCertChecker(keyStore)
-	return sshConfig, nil
 }
 
 // RootClusterName extracts the root cluster name from the issuer

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -227,7 +227,7 @@ func TestProxySSHConfig(t *testing.T) {
 	err = s.store.AddKnownHostKeys("127.0.0.1", []ssh.PublicKey{caPub})
 	require.NoError(t, err)
 
-	clientConfig, err := ProxyClientSSHConfig(key, s.store)
+	clientConfig, err := key.ProxyClientSSHConfig(s.store)
 	require.NoError(t, err)
 
 	called := atomic.NewInt32(0)

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -384,7 +384,7 @@ func applyConfig(ccf *GlobalCLIFlags, cfg *service.Config) (*AuthServiceClientCo
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		authConfig.SSH, err = key.ClientSSHConfig()
+		authConfig.SSH, err = key.ProxyClientSSHConfig(nil)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -462,7 +462,7 @@ func loadConfigFromProfile(ccf *GlobalCLIFlags, cfg *service.Config) (*AuthServi
 		return nil, trace.Wrap(err)
 	}
 	authConfig.TLS.InsecureSkipVerify = ccf.Insecure
-	authConfig.SSH, err = client.ProxyClientSSHConfig(key, keyStore)
+	authConfig.SSH, err = key.ProxyClientSSHConfig(keyStore)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
The API Client fails to connect through ssh (with an identity file or tsh profile) because the ssh certificate's `KeyId` is not among the list of valid principals. The same issue occurs with `tctl` when connecting with an identity file rather than config. However, `tctl` does work through a profile because of this extra line: https://github.com/gravitational/teleport/blob/71ef02f70be44605553f64f3810254333a2add1f/lib/client/interfaces.go#L412

This PR changes each of the failure cases to use `cert.ValidPrincipals[0]` as the default ssh user as well.

TODO: find a cleaner way to reuse this functionality - combined with `ProxyClientSSHConfig`.