### PR TITLE
[v6.0] Don't use OpaqueAccessDenied with CheckAccessToRule

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -55,11 +55,11 @@ func (a *ServerWithRoles) CloseContext() context.Context {
 }
 
 func (a *ServerWithRoles) actionWithContext(ctx *services.Context, namespace string, resource string, action string) error {
-	return utils.OpaqueAccessDenied(a.context.Checker.CheckAccessToRule(ctx, namespace, resource, action, false))
+	return a.context.Checker.CheckAccessToRule(ctx, namespace, resource, action, false)
 }
 
 func (a *ServerWithRoles) action(namespace string, resource string, action string) error {
-	return utils.OpaqueAccessDenied(a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, action, false))
+	return a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, action, false)
 }
 
 // currentUserAction is a special checker that allows certain actions for users
@@ -69,10 +69,8 @@ func (a *ServerWithRoles) currentUserAction(username string) error {
 	if a.hasLocalUserRole(a.context.Checker) && username == a.context.User.GetName() {
 		return nil
 	}
-	return utils.OpaqueAccessDenied(
-		a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User},
-			defaults.Namespace, services.KindUser, services.VerbCreate, true),
-	)
+	return a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User},
+		defaults.Namespace, services.KindUser, services.VerbCreate, true)
 }
 
 // authConnectorAction is a special checker that grants access to auth
@@ -82,7 +80,7 @@ func (a *ServerWithRoles) currentUserAction(username string) error {
 func (a *ServerWithRoles) authConnectorAction(namespace string, resource string, verb string) error {
 	if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, resource, verb, true); err != nil {
 		if err := a.context.Checker.CheckAccessToRule(&services.Context{User: a.context.User}, namespace, services.KindAuthConnector, verb, false); err != nil {
-			return utils.OpaqueAccessDenied(err)
+			return trace.Wrap(err)
 		}
 	}
 	return nil

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -243,19 +243,19 @@ func (s *TLSSuite) TestRemoteRotation(c *check.C) {
 	clone := remoteCA.Clone()
 	clone.SetName(s.server.ClusterName())
 	err = remoteProxy.RotateExternalCertAuthority(clone)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	// remote proxy can't upsert the certificate authority,
 	// only to rotate it (in remote rotation only certain fields are updated)
 	err = remoteProxy.UpsertCertAuthority(remoteCA)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	// remote proxy can't read local cert authority with secrets
 	_, err = remoteProxy.GetCertAuthority(services.CertAuthID{
 		DomainName: s.server.ClusterName(),
 		Type:       services.HostCA,
 	}, true)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	// no secrets read is allowed
 	_, err = remoteProxy.GetCertAuthority(services.CertAuthID{
@@ -311,7 +311,7 @@ func (s *TLSSuite) TestLocalProxyPermissions(c *check.C) {
 
 	// local proxy can't update local cert authorities
 	err = proxy.UpsertCertAuthority(ca)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	// local proxy is allowed to update host CA of remote cert authorities
 	remoteCA, err := s.server.Auth().GetCertAuthority(services.CertAuthID{
@@ -859,15 +859,15 @@ func (s *TLSSuite) TestNopUser(c *check.C) {
 
 	// But can not get users or nodes
 	_, err = client.GetUsers(false)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	_, err = client.GetNodes(defaults.Namespace, services.SkipValidation())
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	// Endpoints that allow current user access should return access denied to
 	// the Nop user.
 	err = client.CheckPassword("foo", nil, "")
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 }
 
 // TestOwnRole tests that user can read roles assigned to them (used by web UI)
@@ -893,7 +893,7 @@ func (s *TLSSuite) TestReadOwnRole(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	_, err = userClient2.GetRole(userRole.GetName())
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 }
 
 func (s *TLSSuite) TestAuthPreference(c *check.C) {
@@ -1444,7 +1444,7 @@ func (s *TLSSuite) TestWebSessionWithoutAccessRequest(c *check.C) {
 
 	// Requesting forbidden action for user fails
 	err = web.DeleteUser(context.TODO(), user)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	err = clt.DeleteWebSession(user, ws.GetName())
 	c.Assert(err, check.IsNil)
@@ -1550,7 +1550,7 @@ func (s *TLSSuite) TestGetCertAuthority(c *check.C) {
 		DomainName: s.server.ClusterName(),
 		Type:       services.HostCA,
 	}, true)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	// non-admin users are not allowed to get access to private key material
 	user, err := services.NewUser("bob")
@@ -1581,7 +1581,7 @@ func (s *TLSSuite) TestGetCertAuthority(c *check.C) {
 		DomainName: s.server.ClusterName(),
 		Type:       services.HostCA,
 	}, true)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 }
 
 func (s *TLSSuite) TestAccessRequest(c *check.C) {
@@ -2208,7 +2208,7 @@ func (s *TLSSuite) TestClusterConfigContext(c *check.C) {
 	_, err = proxy.GenerateHostCert(pub,
 		"a", "b", nil,
 		"localhost", teleport.Roles{teleport.RoleProxy}, 0)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	// update cluster config to record at the proxy
 	clusterConfig, err := services.NewClusterConfig(services.ClusterConfigSpecV3{
@@ -2700,7 +2700,7 @@ func (s *TLSSuite) TestEventsNodePresence(c *check.C) {
 	defer nopClt.Close()
 
 	_, err = nopClt.UpsertNode(node)
-	fixtures.ExpectNotFound(c, err)
+	fixtures.ExpectAccessDenied(c, err)
 
 	k2, err := nopClt.NewKeepAliver(ctx)
 	c.Assert(err, check.IsNil)
@@ -2825,7 +2825,7 @@ func (s *TLSSuite) TestEventsPermissions(c *check.C) {
 		case <-watcher.Done():
 		}
 
-		fixtures.ExpectNotFound(c, watcher.Error())
+		fixtures.ExpectAccessDenied(c, watcher.Error())
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Addressing problems with `OpaqueAccessDenied` reported in #6225.