### PR TITLE
Handle LXC container edge cases in uacc code

### DIFF
--- a/lib/srv/uacc/uacc.h
+++ b/lib/srv/uacc/uacc.h
@@ -32,6 +32,8 @@ int UACC_UTMP_READ_ERROR = 3;
 int UACC_UTMP_FAILED_OPEN = 4;
 int UACC_UTMP_ENTRY_DOES_NOT_EXIST = 5;
 int UACC_UTMP_FAILED_TO_SELECT_FILE = 6;
+int UACC_UTMP_OTHER_ERROR = 7;
+int UACC_UTMP_PATH_DOES_NOT_EXIST = 8;
 
 // I initially attempted to use the login/logout BSD functions but ran into a string of unexpected behaviours such as
 // errno being set to undocument values along with wierd return values in certain cases. They also modify the utmp database
@@ -59,6 +61,30 @@ static char* get_absolute_path_with_fallback(char* buffer, const char* supplied_
     return realpath(path, buffer);
 }
 
+static int check_abs_path_err(const char* buffer) {
+    // check for errors
+    if (buffer == NULL) {
+        switch errno {
+            case EACCES: return UACC_UTMP_MISSING_PERMISSIONS;
+            case EINVAL: return UACC_UTMP_FAILED_OPEN;
+            case EIO: return UACC_UTMP_READ_ERROR;
+            case ELOOP: return UACC_UTMP_FAILED_OPEN;
+            case ENAMETOOLONG: return UACC_UTMP_FAILED_OPEN;
+            case ENOENT: return UACC_UTMP_PATH_DOES_NOT_EXIST;
+            case ENOTDIR: return UACC_UTMP_FAILED_OPEN;
+            default: return UACC_UTMP_OTHER_ERROR;
+        }
+    }
+
+    // check for GNU extension errors
+    if (errno == EACCES || errno == ENOENT) {
+        return UACC_UTMP_OTHER_ERROR;
+    }
+
+    // no error was found
+    return 0;
+}
+
 // Allow the Go side to read errno.
 static int get_errno() {
     return errno;
@@ -74,6 +100,10 @@ static int max_len_tty_name() {
 static int uacc_add_utmp_entry(const char *utmp_path, const char *wtmp_path, const char *username, const char *hostname, const int32_t remote_addr_v6[4], const char *tty_name, const char *id, int32_t tv_sec, int32_t tv_usec) {
     char resolved_utmp_buffer[PATH_MAX];
     const char* file = get_absolute_path_with_fallback(&resolved_utmp_buffer[0], utmp_path, _PATH_UTMP);
+    int status = check_abs_path_err(file);
+    if (status != 0) {
+        return status;
+    }
     if (utmpname(file) < 0) {
         return UACC_UTMP_FAILED_TO_SELECT_FILE;
     }
@@ -100,6 +130,10 @@ static int uacc_add_utmp_entry(const char *utmp_path, const char *wtmp_path, con
     endutent();
     char resolved_wtmp_buffer[PATH_MAX];
     const char* wtmp_file = get_absolute_path_with_fallback(&resolved_wtmp_buffer[0], wtmp_path, _PATH_WTMP);
+    status = check_abs_path_err(wtmp_file);
+    if (status != 0) {
+        return status;
+    }
     updwtmp(wtmp_file, &entry);
     return 0;
 }
@@ -109,6 +143,10 @@ static int uacc_add_utmp_entry(const char *utmp_path, const char *wtmp_path, con
 static int uacc_mark_utmp_entry_dead(const char *utmp_path, const char *wtmp_path, const char *tty_name, int32_t tv_sec, int32_t tv_usec) {
     char resolved_utmp_buffer[PATH_MAX];
     const char* file = get_absolute_path_with_fallback(&resolved_utmp_buffer[0], utmp_path, _PATH_UTMP);
+    int status = check_abs_path_err(file);
+    if (status != 0) {
+        return status;
+    }
     if (utmpname(file) < 0) {
         return UACC_UTMP_FAILED_TO_SELECT_FILE;
     }
@@ -145,6 +183,10 @@ static int uacc_mark_utmp_entry_dead(const char *utmp_path, const char *wtmp_pat
     endutent();
     char resolved_wtmp_buffer[PATH_MAX];
     const char* wtmp_file = get_absolute_path_with_fallback(&resolved_wtmp_buffer[0], wtmp_path, _PATH_WTMP);
+    status = check_abs_path_err(wtmp_file);
+    if (status != 0) {
+        return status;
+    }
     updwtmp(wtmp_file, &log_entry);
     return 0;
 }
@@ -154,6 +196,10 @@ static int uacc_mark_utmp_entry_dead(const char *utmp_path, const char *wtmp_pat
 static int uacc_has_entry_with_user(const char *utmp_path, const char *user) {
     char resolved_utmp_buffer[PATH_MAX];
     const char* file = get_absolute_path_with_fallback(&resolved_utmp_buffer[0], utmp_path, _PATH_UTMP);
+    int status = check_abs_path_err(file);
+    if (status != 0) {
+        return status;
+    }
     if (utmpname(file) < 0) {
         return UACC_UTMP_FAILED_TO_SELECT_FILE;
     }

--- a/lib/srv/uacc/uacc_linux.go
+++ b/lib/srv/uacc/uacc_linux.go
@@ -110,6 +110,8 @@ func Open(utmpPath, wtmpPath string, username, hostname string, remote [4]int32,
 		return trace.AccessDenied("failed to open user account database, code: %d", code)
 	case C.UACC_UTMP_FAILED_TO_SELECT_FILE:
 		return trace.BadParameter("failed to select file")
+	case C.UACC_UTMP_PATH_DOES_NOT_EXIST:
+		return trace.NotFound("user accounting files are missing from the system, running in a container?")
 	default:
 		if status != 0 {
 			return trace.Errorf("unknown error with code %d", status)
@@ -168,6 +170,8 @@ func Close(utmpPath, wtmpPath string, tty *os.File) error {
 		return trace.AccessDenied("failed to open user account database, code: %d", code)
 	case C.UACC_UTMP_FAILED_TO_SELECT_FILE:
 		return trace.BadParameter("failed to select file")
+	case C.UACC_UTMP_PATH_DOES_NOT_EXIST:
+		return trace.NotFound("user accounting files are missing from the system, running in a container?")
 	default:
 		if status != 0 {
 			return trace.Errorf("unknown error with code %d", status)
@@ -204,6 +208,8 @@ func UserWithPtyInDatabase(utmpPath string, username string) error {
 		return trace.NotFound("user not found")
 	case C.UACC_UTMP_FAILED_TO_SELECT_FILE:
 		return trace.BadParameter("failed to select file")
+	case C.UACC_UTMP_PATH_DOES_NOT_EXIST:
+		return trace.NotFound("user accounting files are missing from the system, running in a container?")
 	default:
 		if status != 0 {
 			return trace.Errorf("unknown error with code %d", status)


### PR DESCRIPTION
This handles an LXC container edge case where it thinks the user accounting database should exist but it doesn't, this notably happens in LXC since it doesn't run an init system and doesn't do this manually for consistency.