### PR TITLE
add jitter to periodic cert rotation and fix spurious writes

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/interval"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -433,16 +434,21 @@ func (process *TeleportProcess) periodicSyncRotationState() error {
 		return nil
 	}
 
-	retryTicker := time.NewTicker(defaults.HighResPollingPeriod)
-	defer retryTicker.Stop()
+	periodic := interval.New(interval.Config{
+		Duration:      defaults.HighResPollingPeriod,
+		FirstDuration: utils.HalfJitter(defaults.HighResPollingPeriod),
+		Jitter:        utils.NewSeventhJitter(),
+	})
+	defer periodic.Stop()
+
 	for {
 		err := process.syncRotationStateCycle()
 		if err == nil {
 			return nil
 		}
-		process.log.Warningf("Sync rotation state cycle failed: %v, going to retry after %v.", err, defaults.HighResPollingPeriod)
+		process.log.Warningf("Sync rotation state cycle failed: %v, going to retry after ~%v.", err, defaults.HighResPollingPeriod)
 		select {
-		case <-retryTicker.C:
+		case <-periodic.Next():
 		case <-process.ExitContext().Done():
 			return nil
 		}
@@ -481,8 +487,12 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 	}
 	defer watcher.Close()
 
-	t := time.NewTicker(process.Config.PollingPeriod)
-	defer t.Stop()
+	periodic := interval.New(interval.Config{
+		Duration:      process.Config.PollingPeriod,
+		FirstDuration: utils.HalfJitter(process.Config.PollingPeriod),
+		Jitter:        utils.NewSeventhJitter(),
+	})
+	defer periodic.Stop()
 	for {
 		select {
 		case event := <-watcher.Events():
@@ -511,7 +521,7 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 			}
 		case <-watcher.Done():
 			return trace.ConnectionProblem(watcher.Error(), "watcher has disconnected")
-		case <-t.C:
+		case <-periodic.Next():
 			status, err := process.syncRotationStateAndBroadcast(conn)
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -33,10 +33,18 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/trace"
 )
+
+// CertAuthoritiesEquivalent checks if a pair of certificate authority resources are equivalent.
+// This differs from normal equality only in that resource IDs are ignored.
+func CertAuthoritiesEquivalent(lhs, rhs CertAuthority) bool {
+	return cmp.Equal(lhs, rhs, cmpopts.IgnoreFields(types.Metadata{}, "ID"))
+}
 
 // NewJWTAuthority creates and returns a services.CertAuthority with a new
 // key pair.

--- a/lib/utils/interval/interval.go
+++ b/lib/utils/interval/interval.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interval
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// Interval functions similarly to time.Ticker, with the added benefit of being
+// able to specify a custom duration for the first "tick", and an optional
+// per-tick jitter.  When attempting to stagger periodic operations it is recommended
+// to apply a large jitter to the first duration, and provide a small jitter for the
+// per-tick jitter.  This will ensure that operations started at similar times will
+// have varying initial interval states, while minimizing the amount of extra work
+// introduced by the per-tick jitter.
+type Interval struct {
+	cfg       Config
+	ch        chan time.Time
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+// Config configures an interval.  The only required parameter is
+// the Duration field which *must* be a positive duration.
+type Config struct {
+	// Duration is the duration on which the interval "ticks" (if a jitter is
+	// applied, this represents the upper bound of the range).
+	Duration time.Duration
+
+	// FirstDuration is an optional special duration to be used for the first
+	// "tick" of the interval.  This duration is not jittered.
+	FirstDuration time.Duration
+
+	// Jitter is an optional jitter to be applied to each step of the interval.
+	// It is usually preferable to use a smaller jitter (e.g. NewSeventhJitter())
+	// for this parameter, since periodic operations are typically costly and the
+	// effect of the jitter is cumulative.
+	Jitter utils.Jitter
+}
+
+// New creates a new interval instance.  This function panics on non-positive
+// interval durations (equivalent to time.NewTicker).
+func New(cfg Config) *Interval {
+	if cfg.Duration <= 0 {
+		panic(errors.New("non-positive interval for interval.New"))
+	}
+
+	interval := &Interval{
+		ch:   make(chan time.Time, 1),
+		cfg:  cfg,
+		done: make(chan struct{}),
+	}
+
+	firstDuration := cfg.FirstDuration
+	if firstDuration == 0 {
+		firstDuration = interval.duration()
+	}
+
+	// start the timer in this goroutine to improve
+	// consistency of first tick.
+	timer := time.NewTimer(firstDuration)
+
+	go interval.run(timer)
+
+	return interval
+}
+
+// Stop permanently stops the interval.  Note that stopping an interval does not
+// close its output channel.  This is done in order to prevent concurrent stops
+// from generating erroneous "ticks" and is consistent with the behavior of
+// time.Ticker.
+func (i *Interval) Stop() {
+	i.closeOnce.Do(func() {
+		close(i.done)
+	})
+}
+
+// Next is the channel over which the intervals are delivered.
+func (i *Interval) Next() <-chan time.Time {
+	return i.ch
+}
+
+// duration gets the duration of the interval.  Each call applies the jitter
+// if one was supplied.
+func (i *Interval) duration() time.Duration {
+	if i.cfg.Jitter == nil {
+		return i.cfg.Duration
+	}
+	return i.cfg.Jitter(i.cfg.Duration)
+}
+
+func (i *Interval) run(timer *time.Timer) {
+	defer timer.Stop()
+
+	// we take advantage of the fact that sends on nil channels never complete,
+	// and only set ch when tick is valid and needs to be sent.
+	var tick time.Time
+	var ch chan<- time.Time
+	for {
+		select {
+		case tick = <-timer.C:
+			// timer has fired, reset to next duration and ensure that
+			// output channel is set.
+			timer.Reset(i.duration())
+			ch = i.ch
+		case ch <- tick:
+			// tick has been sent, set ch back to nil to prevent
+			// double-send and wait for next timer firing
+			ch = nil
+		case <-i.done:
+			// interval has been stopped.
+			return
+		}
+	}
+}

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -27,14 +27,26 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// HalfJitter is a global jitter instance used for one-off jitters.
+// Prefer instantiating a new jitter instance for operations that require
+// repeated calls.
+var HalfJitter = NewHalfJitter()
+
 // Jitter is a function which applies random jitter to a
 // duration.  Used to randomize backoff values.  Must be
 // safe for concurrent usage.
 type Jitter func(time.Duration) time.Duration
 
-// NewJitter returns the default jitter (currently jitters on
+// NewJitter builds a new default jitter (currently jitters on
 // the range [n/2,n), but this is subject to change).
 func NewJitter() Jitter {
+	return NewHalfJitter()
+}
+
+// NewHalfJitter returns a new jitter on the range [n/2,n).  This is
+// a large range and most suitable for jittering things like backoff
+// operations where breaking cycles quickly is a priority.
+func NewHalfJitter() Jitter {
 	var mu sync.Mutex
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return func(d time.Duration) time.Duration {
@@ -46,6 +58,24 @@ func NewJitter() Jitter {
 		mu.Lock()
 		defer mu.Unlock()
 		return (d / 2) + time.Duration(rng.Int63n(int64(d))/2)
+	}
+}
+
+// NewSeventhJitter builds a new jitter on the range [6n/7,n). Prefer smaller
+// jitters such as this when jittering periodic operations (e.g. cert rotation
+// checks) since large jitters result in significantly increased load.
+func NewSeventhJitter() Jitter {
+	var mu sync.Mutex
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return func(d time.Duration) time.Duration {
+		// values less than 1 cause rng to panic, and some logic
+		// relies on treating zero duration as non-blocking case.
+		if d < 1 {
+			return 0
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		return (6 * d / 7) + time.Duration(rng.Int63n(int64(d))/7)
 	}
 }
 


### PR DESCRIPTION
Adds randomized interval helper, adds jitter to certificate rotation periodics, and fixes an issue where spurious write events were being generated due to unnecessary calls to `UpsertCertAuthority`.