### PR TITLE
client: refactor and fix cluster cert reissue when using jumphosts

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -57,7 +57,7 @@ type ProxyClient struct {
 	proxyAddress    string
 	proxyPrincipal  string
 	hostKeyCallback ssh.HostKeyCallback
-	authMethod      ssh.AuthMethod
+	authMethods     []ssh.AuthMethod
 	siteName        string
 	clientAddr      string
 }
@@ -830,7 +830,7 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress NodeAdd
 		return proxy.PortForwardToNode(ctx, nodeAddress, user, quiet)
 	}
 
-	authMethod, err := proxy.sessionSSHCertificate(ctx, nodeAddress)
+	authMethods, err := proxy.sessionSSHCertificate(ctx, nodeAddress)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -919,7 +919,7 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress NodeAdd
 	)
 	sshConfig := &ssh.ClientConfig{
 		User:            user,
-		Auth:            []ssh.AuthMethod{authMethod},
+		Auth:            authMethods,
 		HostKeyCallback: proxy.hostKeyCallback,
 	}
 	conn, chans, reqs, err := newClientConn(ctx, pipeNetConn, nodeAddress.ProxyFormat(), sshConfig)
@@ -958,7 +958,7 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress NodeAdd
 func (proxy *ProxyClient) PortForwardToNode(ctx context.Context, nodeAddress NodeAddr, user string, quiet bool) (*NodeClient, error) {
 	log.Infof("Client=%v jumping to node=%s", proxy.clientAddr, nodeAddress)
 
-	authMethod, err := proxy.sessionSSHCertificate(ctx, nodeAddress)
+	authMethods, err := proxy.sessionSSHCertificate(ctx, nodeAddress)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -991,7 +991,7 @@ func (proxy *ProxyClient) PortForwardToNode(ctx context.Context, nodeAddress Nod
 
 	sshConfig := &ssh.ClientConfig{
 		User:            user,
-		Auth:            []ssh.AuthMethod{authMethod},
+		Auth:            authMethods,
 		HostKeyCallback: proxy.hostKeyCallback,
 	}
 	conn, chans, reqs, err := newClientConn(ctx, proxyConn, nodeAddress.Addr, sshConfig)
@@ -1369,12 +1369,12 @@ func (proxy *ProxyClient) currentCluster() (*services.Site, error) {
 	return nil, trace.NotFound("cluster %v not found", proxy.siteName)
 }
 
-func (proxy *ProxyClient) sessionSSHCertificate(ctx context.Context, nodeAddr NodeAddr) (ssh.AuthMethod, error) {
+func (proxy *ProxyClient) sessionSSHCertificate(ctx context.Context, nodeAddr NodeAddr) ([]ssh.AuthMethod, error) {
 	if _, err := proxy.teleportClient.localAgent.GetKey(nodeAddr.Cluster); err != nil {
 		if trace.IsNotFound(err) {
 			// Either running inside the web UI in a proxy or using an identity
 			// file. Fall back to whatever AuthMethod we currently have.
-			return proxy.authMethod, nil
+			return proxy.authMethods, nil
 		}
 		return nil, trace.Wrap(err)
 	}
@@ -1392,7 +1392,11 @@ func (proxy *ProxyClient) sessionSSHCertificate(ctx context.Context, nodeAddr No
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return key.AsAuthMethod()
+	am, err := key.AsAuthMethod()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return []ssh.AuthMethod{am}, nil
 }
 
 // localAgent returns for the Teleport client's local agent.

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -352,6 +352,15 @@ func (k *Key) AsAuthMethod() (ssh.AuthMethod, error) {
 	return sshutils.AsAuthMethod(cert, k.Priv)
 }
 
+// AsSigner returns an ssh.Signer using the SSH certificate in this key.
+func (k *Key) AsSigner() (ssh.Signer, error) {
+	cert, err := k.SSHCert()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return sshutils.AsSigner(cert, k.Priv)
+}
+
 // SSHCert returns parsed SSH certificate
 func (k *Key) SSHCert() (*ssh.Certificate, error) {
 	if k.Cert == nil {

--- a/lib/client/keyagent.go
+++ b/lib/client/keyagent.go
@@ -27,12 +27,13 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/prompt"
-	"github.com/gravitational/trace"
 
 	"github.com/sirupsen/logrus"
 )
@@ -489,12 +490,23 @@ func (a *LocalKeyAgent) DeleteKeys() error {
 	return nil
 }
 
-// AuthMethods returns the list of different authentication methods this agent supports:
-//	  1. First to try is the external SSH agent
-//    2. Itself (disk-based local agent)
-// It returns an error in case there is no auth method method available.
-func (a *LocalKeyAgent) AuthMethods() ([]ssh.AuthMethod, error) {
-	// combine our certificates with external SSH agent's:
+// certsForCluster returns a set of ssh.Signers using certificates for a
+// specific cluster. If clusterName is empty, certsForCluster returns
+// ssh.Signers for all known clusters.
+func (a *LocalKeyAgent) certsForCluster(clusterName string) ([]ssh.Signer, error) {
+	if clusterName != "" {
+		k, err := a.GetKey(clusterName, WithSSHCerts{})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		signer, err := k.AsSigner()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return []ssh.Signer{signer}, nil
+	}
+
+	// Load all certs, including the ones from a local SSH agent.
 	var signers []ssh.Signer
 	if a.sshAgent != nil {
 		if sshAgentCerts, _ := a.sshAgent.Signers(); sshAgentCerts != nil {
@@ -504,17 +516,16 @@ func (a *LocalKeyAgent) AuthMethods() ([]ssh.AuthMethod, error) {
 	if ourCerts, _ := a.Signers(); ourCerts != nil {
 		signers = append(signers, ourCerts...)
 	}
-	// for every certificate create a new "auth method" and return them
-	m := []ssh.AuthMethod{}
-	for i := range signers {
-		// filter out non-certificates (like regular public SSH keys stored in the SSH agent):
-		_, ok := signers[i].PublicKey().(*ssh.Certificate)
-		if ok {
-			m = append(m, sshutils.NewAuthMethodForCert(signers[i]))
+	// Filter out non-certificates (like regular public SSH keys stored in the SSH agent).
+	certs := make([]ssh.Signer, 0, len(signers))
+	for _, s := range signers {
+		if _, ok := s.PublicKey().(*ssh.Certificate); !ok {
+			continue
 		}
+		certs = append(certs, s)
 	}
-	if len(m) == 0 {
+	if len(certs) == 0 {
 		return nil, trace.BadParameter("no auth method available")
 	}
-	return m, nil
+	return certs, nil
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1821,7 +1821,7 @@ func authFromIdentity(k *client.Key) (ssh.AuthMethod, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return apisshutils.NewAuthMethodForCert(signer), nil
+	return ssh.PublicKeys(signer), nil
 }
 
 // onShow reads an identity file (a public SSH key or a cert) and dumps it to stdout


### PR DESCRIPTION
Refactor `TeleportClient.connectToProxy` to use `ssh.HostKeyCallback` + `ssh.PublicKeyCallback` to get a certificate matching the target jumphost proxy's cluster. This improves/fixes several things:
- all the logic is embedded in a single SSH connection (without a separate "probing" connection first)
- all available `ssh.AuthMethod`s are attempted in one `ssh.Dial` call (not in a loop with one connection per method)
- fixes an issue with `tsh ssh -J root.example.com node@leaf.example.com` (not an actual `tsh` command, but roughly what https://github.com/gravitational/teleport/blob/2b57a97b324af12b582f221ba6022aa711050d30/integration/integration_test.go#L1872-L1894 does); before this PR, the first "probe" connection would overwrite `tc.SiteName` to be the root cluster, which then failed to route the connection to the leaf cluster.
  `tc.SiteName` is now only overruled if target proxy is not in the root cluster

Also, fixed an issue when the client runs without a local profile directory (`~/.tsh`), such as inside the proxy. Instead of the profile, load access requests from SSH cert.