### PR TITLE
V6.0 syntax update

### DIFF
--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -67,58 +67,56 @@ she will be able to act as a system administrator and auditor at the same time.
 We are going to setup Github connector for OSS and Okta for Enterprises version.
 
 <Tabs>
-<TabItem label="Open Source">
+  <TabItem label="Open Source">
+    Save the file below as `github.yaml` and update the fields. You will need to set up
+    [Github OAuth 2.0 Connector](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) app.
+    Any member belonging to the Github organization `octocats` and on team `admin` will be able to assume a built-in role `access`.
 
-Save the file below as `github.yaml` and update the fields. You will need to set up
-[Github OAuth 2.0 Connector](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) app.
-Any member belonging to the Github organization `octocats` and on team `admin` will be able to assume a built-in role `access`.
+    ```yaml
+    kind: github
+    version: v3
+    metadata:
+      # connector name that will be used with `tsh --auth=github login`
+      name: github
+    spec:
+      # client ID of Github OAuth app
+      client_id: client-id
+      # client secret of Github OAuth app
+      client_secret: client-secret
+      # This name will be shown on UI login screen
+      display: Github
+      # Change tele.example.com to your domain name
+      redirect_url: https://tele.example.com:443/v1/webapi/github/callback
+      # Map github teams to teleport roles
+      teams_to_logins:
+        - organization: octocats # Github organization name
+          team: admin            # Github team name within that organization
+          # map github admin team to Teleport's "access" role
+          logins: ["access"]
+    ```
+  </TabItem>
 
-```yaml
-kind: github
-version: v3
-metadata:
-  # connector name that will be used with `tsh --auth=github login`
-  name: github
-spec:
-  # client ID of Github OAuth app
-  client_id: client-id
-  # client secret of Github OAuth app
-  client_secret: client-secret
-  # This name will be shown on UI login screen
-  display: Github
-  # Change tele.example.com to your domain name
-  redirect_url: https://tele.example.com:443/v1/webapi/github/callback
-  # Map github teams to teleport roles
-  teams_to_logins:
-    - organization: octocats # Github organization name
-      team: admin            # Github team name within that organization
-      # map github admin team to Teleport's "access" role
-      logins: ["access"]
-```
-</TabItem>
-<TabItem label="Enterprise">
+  <TabItem label="Enterprise">
+    Follow [SAML Okta Guide](../enterprise/sso/ssh-okta.mdx#configure-okta) to create a SAML app.
+    Check out [OIDC guides](../enterprise/sso/oidc.mdx#identity-providers) for OpenID Connect apps.
+    Save the file below as `okta.yaml` and update the `acs` field.
+    Any member in Okta group `okta-admin` will assume a builtin role `admin`.
 
-Follow [SAML Okta Guide](../enterprise/sso/ssh-okta.mdx#configure-okta) to create a SAML app.
-Check out [OIDC guides](../enterprise/sso/oidc.mdx#identity-providers) for OpenID Connect apps.
-Save the file below as `okta.yaml` and update the `acs` field.
-Any member in Okta group `okta-admin` will assume a builtin role `admin`.
-
-```yaml
-kind: saml
-version: v2
-metadata:
-  name: okta
-spec:
-  acs: https://tele.example.com/v1/webapi/saml/acs
-  attributes_to_roles:
-  - {name: "groups", value: "okta-admin", roles: ["access"]}
-  entity_descriptor: |
-    <?xml !!! Make sure to shift all lines in XML descriptor
-    with 4 spaces, otherwise things will not work
-```
-</TabItem>
+    ```yaml
+    kind: saml
+    version: v2
+    metadata:
+      name: okta
+    spec:
+      acs: https://tele.example.com/v1/webapi/saml/acs
+      attributes_to_roles:
+      - {name: "groups", value: "okta-admin", roles: ["access"]}
+      entity_descriptor: |
+        <?xml !!! Make sure to shift all lines in XML descriptor
+        with 4 spaces, otherwise things will not work
+    ```
+  </TabItem>
 </Tabs>
-
 
 ## Step 3/3 Create a custom role
 
@@ -171,4 +169,3 @@ $ tctl get roles --format text
 ## Next Steps
 
 - [Mapping SSO and Local Users Traits with Role Templates](./guides/role-templates.mdx)
-

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -13,8 +13,8 @@ with creating your own role.
 
 ## Prerequisites
 
-- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../cloud.mdx) >= {{teleport_version}}
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= {{teleport_version}}
+- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../cloud.mdx) >= (=teleport.version=)
+- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport_version=)
 
 Verify that your Teleport client is connected:
 

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -19,8 +19,8 @@ Let's explore how Teleport's role templates provide a way to describe these and 
 
 ## Prerequisites
 
-- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../../cloud.mdx) >= {{teleport_version}}
-- [Tctl admin tool](https://goteleport.com/teleport/download) >= {{teleport_version}}
+- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../../cloud.mdx) >= (=teleport.version=)
+- [Tctl admin tool](https://goteleport.com/teleport/download) >= (=teleport_version=)
 
 Verify that your Teleport client is connected:
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -74,12 +74,12 @@ spec:
   allow:
     # logins array defines the OS/UNIX logins a user is allowed to use.
     # a few special variables are supported here (see below)
-    logins: [root, '{% raw %}{{internal.logins}}{% endraw %}']
+    logins: [root, '{{internal.logins}}']
     # if kubernetes integration is enabled, this setting configures which
     # kubernetes groups the users of this role will be assigned to.
     # note that you can refer to a SAML/OIDC trait via the "external" property bag,
     # this allows you to specify Kubernetes group membership in an identity manager:
-    kubernetes_groups: ["system:masters", "{% raw %}{{external.trait_name}}{% endraw %}"]]
+    kubernetes_groups: ["system:masters", "{{external.trait_name}}"]]
 
     # list of node labels a user will be allowed to connect to:
     node_labels:
@@ -133,8 +133,8 @@ The following variables can be used with `logins` field:
 
 | Variable | Description |
 | - | - |
-| `{% raw %}{{internal.logins}}{% endraw %}` | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database. |
-| `{% raw %}{{external.xyz}}{% endraw %}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim. |
+| `{{internal.logins}}` | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database. |
+| `{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim. |
 
 Both variables above are there to deliver the same benefit: they allow Teleport
 administrators to define allowed OS logins via the user database, be it the
@@ -154,7 +154,7 @@ Assuming you have the following SAML assertion attribute in your response:
 
 ```
 logins:
-   - '{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}'
+   - '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}'
 ```
 
 ### Role Options

--- a/docs/pages/admin-guide.mdx
+++ b/docs/pages/admin-guide.mdx
@@ -295,19 +295,15 @@ connector. There are several possible values (types) of 2FA:
 - `otp` is the default. It implements [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
   standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator)
   or [Authy](https://www.authy.com/) or any other TOTP client.
-
-- `u2f` implements [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor)
+- `u2f` implements [U2F](https://en.wikipedia.org/wiki/Universal\_2nd_Factor)
   standard for utilizing hardware (USB) keys for second factor. You can use [YubiKeys](https://www.yubico.com/),
   [SoloKeys](https://solokeys.com/) or any other hardware token which implements the FIDO U2F standard.
-
 - `on` enables both TOTP and U2F, and all local users are required to have at
   least one 2FA device registered.
-
 - `optional` enables both TOTP and U2F but makes it optional for users. Local
   users that register a 2FA device will be prompted for it during login. This
   option is useful when you need to gradually enable 2FA usage before switching
   the value to `on`.
-
 - `off` turns off second factor authentication.
 
 Here is an example of this setting in the `teleport.yaml` :
@@ -375,7 +371,6 @@ hardware keys as a second authentication factor. By default U2F is disabled. To
 start using U2F:
 
 - Enable U2F in Teleport configuration `/etc/teleport.yaml` .
-
 - For web-based logins, check that your browser [supports
   U2F](https://caniuse.com/u2f).
 
@@ -767,7 +762,6 @@ two kinds of labels:
 1. `static labels` do not change over time, while [`teleport`](cli-docs.mdx#teleport)
    process is running.  Examples of static labels are physical location of nodes,
    name of the environment (staging vs production), etc.
-
 2. `dynamic labels` also known as "label commands" allow to generate labels at
    runtime. Teleport will execute an external command on a node at a configurable
    frequency and the output of a command becomes the label value. Examples include
@@ -828,7 +822,7 @@ app_service:
 
 `/path/to/executable` must be a valid executable command (i.e. executable bit
 must be set) which also includes shell scripts with a proper [shebang
-line](https://en.wikipedia.org/wiki/Shebang_(Unix)).
+line](https://en.wikipedia.org/wiki/Shebang_\(Unix\)).
 
 **Important:** notice that `command` setting is an array where the first element
 is a valid executable and each subsequent element is an argument, i.e:
@@ -852,11 +846,9 @@ the audit log:
 
 1. **SSH Events:** Teleport logs events like successful user logins along with
    the metadata like remote IP address, time and the session ID.
-
 2. **Recorded Sessions:** Every SSH shell session is recorded and can be
    replayed later. The recording is done by the nodes themselves, by default,
    but can be configured to be done by the proxy.
-
 3. **Optional: [Enhanced Session Recording](features/enhanced-session-recording.mdx)**
 
 Refer to the ["Audit Log" chapter in the Teleport
@@ -958,7 +950,6 @@ The recorded sessions are stored as raw bytes in the `sessions` directory under
 1. `.bytes` file or `.chunks.gz` compressed format represents the raw session bytes and is somewhat
    human-readable, although you are better off using [`tsh
    play`](cli-docs.mdx#tsh-play) or the Web UI to replay it.
-
 2. `.log` file or `.events.gz` compressed file contains the copies of the event log entries that are            related to this session.
 
 ```bash
@@ -979,7 +970,6 @@ A Teleport administrator has two tools to configure a Teleport cluster:
 
 - The [configuration file](#configuration) is used for static configuration like
   the cluster name.
-
 - The [`tctl`](cli-docs.mdx#tctl) admin tool is used for manipulating dynamic
   records like Teleport
   users.
@@ -1370,8 +1360,6 @@ do this:
 - Use a load balancer to create a single auth API access point (AP) and
   specify this AP in `auth_servers` section of Teleport configuration for all
   nodes in a cluster. This load balancer should do TCP level forwarding.
-
-
 - If a load balancer is not an option, you must specify each instance of an
   auth server in `auth_servers` section of Teleport configuration.
 
@@ -1827,15 +1815,12 @@ teleport:
 
 - Replace `Example_GCP_Project_Name` and `Example_TELEPORT_FIRESTORE_TABLE_NAME`
   with your own settings. Teleport will create the table automatically.
-
 - `Example_TELEPORT_FIRESTORE_TABLE_NAME` and `Example_TELEPORT_FIRESTORE_EVENTS_TABLE_NAME`
   **must** be different Firestore tables. The schema is different for each. Using the same
   table name for both will result in errors.
-
 - The GCP authentication setting above can be omitted if the machine itself is
   running on a GCE instance with a Service Account that has access to the
   Firestore table.
-
 - Audit log settings above are optional. If specified, Teleport will store the
   audit log in Firestore and the session recordings **must** be stored in a GCP
   bucket, i.e.both `audit_xxx` settings must be present. If they are not set,
@@ -1868,11 +1853,9 @@ clients, etc), the following rules apply:
 
 - **Only patch** versions are always compatible, for example any 4.0.1 component will
   work with any 4.0.3 component.
-
 - Minor versions are always compatible with the **previous** minor release. This
   means you must not attempt to upgrade from 4.1.x straight to 4.3.x. You must
   upgrade to 4.2.x first.
-
 - Teleport clients [`tsh`](cli-docs.mdx#tsh) for users and [`tctl`](cli-docs.mdx#tctl) for admins
   may not be compatible with different versions of the `teleport` service.
 
@@ -1880,11 +1863,9 @@ clients, etc), the following rules apply:
 
 - **Patch and minor** versions are always compatible, for example any 5.0.1 component will
   work with any 5.0.3 component and 6.1.0 component will work with any 6.7.0 component.
-
 - Major versions are always compatible with the **previous** major release. This
   means you must not attempt to upgrade from 5.x.x straight to 7.x.x. You must
   upgrade to 6.x.x first.
-
 - The above applies to both clients and servers. For example, a 6.x.x proxy is
   compatible with 5.x.x nodes and 5.x.x `tsh`. But we don't guarantee that a
   7.x.x `tsh` will work with a 5.x.x proxy.
@@ -1926,10 +1907,8 @@ When upgrading a single Teleport cluster:
 1. **Upgrade the auth server first**. The auth server keeps the cluster state
    and if there are data format changes introduced in the new version this will
    perform necessary migrations.
-
 2. Then, upgrade the proxy servers. The proxy servers are stateless and can be
    upgraded in any sequence or at the same time.
-
 3. Finally, upgrade the SSH nodes in any sequence or at the same time.
 
 <Admonition
@@ -2013,9 +1992,9 @@ Using `tctl get all --with-secrets` will retrieve the below items:
 - Trusted Clusters
 - Connectors:
   - Github
-  - SAML [Teleport Enterprise]
-  - OIDC [Teleport Enterprise]
-  - Roles [Teleport Enterprise]
+  - SAML \[Teleport Enterprise]
+  - OIDC \[Teleport Enterprise]
+  - Roles \[Teleport Enterprise]
 
 When migrating backends, you should back up your auth server's `data_dir/storage` directly.
 
@@ -2059,7 +2038,6 @@ administrator must:
 
 1. Replace the Teleport binaries, usually [`teleport`](cli-docs.mdx#teleport)
    and [`tctl`](cli-docs.mdx#tctl)
-
 2. Execute `systemctl restart teleport`
 
 This will perform a graceful restart, i.e.the Teleport daemon will fork a new
@@ -2123,14 +2101,11 @@ Now you can see the monitoring information by visiting several endpoints:
 - `http://127.0.0.1:3000/metrics` is the list of internal metrics Teleport is
   tracking. It is compatible with [Prometheus](https://prometheus.io/)
   collectors. For a full list of metrics review our [metrics reference](metrics-logs-reference.mdx).
-
 - `http://127.0.0.1:3000/healthz` returns "OK" if the process is healthy or
   `503` otherwise.
-
 - `http://127.0.0.1:3000/readyz` is similar to `/healthz` , but it returns "OK"
   *only after* the node successfully joined the cluster, i.e.it draws the
   difference between "healthy" and "ready".
-
 - `http://127.0.0.1:3000/debug/pprof/` is Golang's standard profiler. It's only
   available when `-d` flag is given in addition to `--diag-addr`
 

--- a/docs/pages/adopters.mdx
+++ b/docs/pages/adopters.mdx
@@ -10,119 +10,141 @@ Whether you are using Teleport OSS, Enteprise or Cloud, tell us about your use-c
 Just click "Improve the docs" and send us a PR.
 
 <table>
-<tr>
-  <th>Company</th>
-  <th>Industry</th>
-  <th>Use-cases and case-studies</th>
-</tr>
-<tr>
-  <td>Nasdaq</td>
-  <td>Finance</td>
-  <td>Secure access to internal infrastructure.</td>
-</tr>
-<tr>
-  <td>Auth0</td>
-  <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/auth0/">case study</a></td>
-</tr>
-<tr>
-  <td>Elastic</td>
-  <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/elastic-testimonial/">testimonial</a></td>
-</tr>
-<tr>
-  <td>VMware</td>
-  <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/vmware-testimonial/">testimonial</a></td>
-</tr>
-<tr>
-  <td>Snowflake</td>
-  <td>Technology</td>
-  <td>Access for SSH and Kubernetes clusters.</td>
-</tr>
-<tr>
-  <td>Samsung</td>
-  <td>Technology</td>
-  <td>Secure access for SSH and Kubernetes.</td>
-</tr>
-<tr>
-  <td>ECMWF</td>
-  <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/ecmwf/">case study</a></td>
-</tr>
-<tr>
-  <td>IBM</td>
-  <td>Technology</td>
-  <td>Protected access to internal Kubernetes clusters.</td>
-</tr>
-<tr>
-  <td>Infoblox</td>
-  <td>Technology</td>
-  <td>Secure access to internal infrastructure.</td>
-</tr>
-<tr>
-  <td>Wise</td>
-  <td>Fintech</td>
-  <td>Secure access for infrastructure.</td>
-</tr>
-<tr>
-  <td>Zapier</td>
-  <td>Technology</td>
-  <td>Secure access for SSH.</td>
-</tr>
-<tr>
-  <td>ExtraHop</td>
-  <td>Infosec</td>
-  <td><a href="https://goteleport.com/case-study/extrahop/">case study</a></td>
-</tr>
-<tr>
-  <td>Twitch</td>
-  <td>Technology</td>
-  <td>SSH access.</td>
-</tr>
-<tr>
-  <td>GitLab</td>
-  <td>Technology</td>
-  <td><a href="https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/11568#note_451982812">team review</a></td>
-</tr>
-<tr>
-  <td>SumoLogic</td>
-  <td>Technology</td>
-  <td>Achieve FedRamp compliance and secure access to infrastructure.</td>
-</tr>
-<tr>
-  <td>Gladly</td>
-  <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/gladly/">case study</a></td>
-</tr>
-<tr>
-  <td>VerticalChange</td>
-  <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/verticalchange-testimonial/">testimonial</a></td>
-</tr>
-<tr>
-  <td>Shockbyte</td>
-  <td>Technology</td>
-  <td><a href="https://goteleport.com/case-study/shockbyte-testimonial/">testimonial</a></td>
-</tr>
-<tr>
-  <td>Lacework</td>
-  <td>Infosec</td>
-  <td><a href="https://goteleport.com/case-study/lacework-testimonial/">testimonial</a></td>
-</tr>
-<tr>
-  <td>Glu Mobile</td>
-  <td>Gaming</td>
-  <td><a href="https://goteleport.com/case-study/glumobile-testimonial/">testimonial</a></td>
-</tr>
-<tr>
-  <td>Decisiv</td>
-  <td>Transportation</td>
-  <td><a href="https://goteleport.com/case-study/decisiv/">case study</a></td>
-</tr>
-<tr>
-  <td>Mattermost</td>
-  <td>Technology</td>
-  <td>Secure access to infrastructure.</td>
-</tr>
+  <tr>
+    <th>Company</th>
+    <th>Industry</th>
+    <th>Use-cases and case-studies</th>
+  </tr>
+
+  <tr>
+    <td>Nasdaq</td>
+    <td>Finance</td>
+    <td>Secure access to internal infrastructure.</td>
+  </tr>
+
+  <tr>
+    <td>Auth0</td>
+    <td>Technology</td>
+    <td><a href="https://goteleport.com/case-study/auth0/">case study</a></td>
+  </tr>
+
+  <tr>
+    <td>Elastic</td>
+    <td>Technology</td>
+    <td><a href="https://goteleport.com/case-study/elastic-testimonial/">testimonial</a></td>
+  </tr>
+
+  <tr>
+    <td>VMware</td>
+    <td>Technology</td>
+    <td><a href="https://goteleport.com/case-study/vmware-testimonial/">testimonial</a></td>
+  </tr>
+
+  <tr>
+    <td>Snowflake</td>
+    <td>Technology</td>
+    <td>Access for SSH and Kubernetes clusters.</td>
+  </tr>
+
+  <tr>
+    <td>Samsung</td>
+    <td>Technology</td>
+    <td>Secure access for SSH and Kubernetes.</td>
+  </tr>
+
+  <tr>
+    <td>ECMWF</td>
+    <td>Technology</td>
+    <td><a href="https://goteleport.com/case-study/ecmwf/">case study</a></td>
+  </tr>
+
+  <tr>
+    <td>IBM</td>
+    <td>Technology</td>
+    <td>Protected access to internal Kubernetes clusters.</td>
+  </tr>
+
+  <tr>
+    <td>Infoblox</td>
+    <td>Technology</td>
+    <td>Secure access to internal infrastructure.</td>
+  </tr>
+
+  <tr>
+    <td>Wise</td>
+    <td>Fintech</td>
+    <td>Secure access for infrastructure.</td>
+  </tr>
+
+  <tr>
+    <td>Zapier</td>
+    <td>Technology</td>
+    <td>Secure access for SSH.</td>
+  </tr>
+
+  <tr>
+    <td>ExtraHop</td>
+    <td>Infosec</td>
+    <td><a href="https://goteleport.com/case-study/extrahop/">case study</a></td>
+  </tr>
+
+  <tr>
+    <td>Twitch</td>
+    <td>Technology</td>
+    <td>SSH access.</td>
+  </tr>
+
+  <tr>
+    <td>GitLab</td>
+    <td>Technology</td>
+    <td><a href="https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/11568#note_451982812">team review</a></td>
+  </tr>
+
+  <tr>
+    <td>SumoLogic</td>
+    <td>Technology</td>
+    <td>Achieve FedRamp compliance and secure access to infrastructure.</td>
+  </tr>
+
+  <tr>
+    <td>Gladly</td>
+    <td>Technology</td>
+    <td><a href="https://goteleport.com/case-study/gladly/">case study</a></td>
+  </tr>
+
+  <tr>
+    <td>VerticalChange</td>
+    <td>Technology</td>
+    <td><a href="https://goteleport.com/case-study/verticalchange-testimonial/">testimonial</a></td>
+  </tr>
+
+  <tr>
+    <td>Shockbyte</td>
+    <td>Technology</td>
+    <td><a href="https://goteleport.com/case-study/shockbyte-testimonial/">testimonial</a></td>
+  </tr>
+
+  <tr>
+    <td>Lacework</td>
+    <td>Infosec</td>
+    <td><a href="https://goteleport.com/case-study/lacework-testimonial/">testimonial</a></td>
+  </tr>
+
+  <tr>
+    <td>Glu Mobile</td>
+    <td>Gaming</td>
+    <td><a href="https://goteleport.com/case-study/glumobile-testimonial/">testimonial</a></td>
+  </tr>
+
+  <tr>
+    <td>Decisiv</td>
+    <td>Transportation</td>
+    <td><a href="https://goteleport.com/case-study/decisiv/">case study</a></td>
+  </tr>
+
+  <tr>
+    <td>Mattermost</td>
+    <td>Technology</td>
+    <td>Secure access to infrastructure.</td>
+  </tr>
 </table>

--- a/docs/pages/adopters.mdx
+++ b/docs/pages/adopters.mdx
@@ -10,141 +10,123 @@ Whether you are using Teleport OSS, Enteprise or Cloud, tell us about your use-c
 Just click "Improve the docs" and send us a PR.
 
 <table>
-  <tr>
-    <th>Company</th>
-    <th>Industry</th>
-    <th>Use-cases and case-studies</th>
-  </tr>
-
-  <tr>
-    <td>Nasdaq</td>
-    <td>Finance</td>
-    <td>Secure access to internal infrastructure.</td>
-  </tr>
-
-  <tr>
-    <td>Auth0</td>
-    <td>Technology</td>
-    <td><a href="https://goteleport.com/case-study/auth0/">case study</a></td>
-  </tr>
-
-  <tr>
-    <td>Elastic</td>
-    <td>Technology</td>
-    <td><a href="https://goteleport.com/case-study/elastic-testimonial/">testimonial</a></td>
-  </tr>
-
-  <tr>
-    <td>VMware</td>
-    <td>Technology</td>
-    <td><a href="https://goteleport.com/case-study/vmware-testimonial/">testimonial</a></td>
-  </tr>
-
-  <tr>
-    <td>Snowflake</td>
-    <td>Technology</td>
-    <td>Access for SSH and Kubernetes clusters.</td>
-  </tr>
-
-  <tr>
-    <td>Samsung</td>
-    <td>Technology</td>
-    <td>Secure access for SSH and Kubernetes.</td>
-  </tr>
-
-  <tr>
-    <td>ECMWF</td>
-    <td>Technology</td>
-    <td><a href="https://goteleport.com/case-study/ecmwf/">case study</a></td>
-  </tr>
-
-  <tr>
-    <td>IBM</td>
-    <td>Technology</td>
-    <td>Protected access to internal Kubernetes clusters.</td>
-  </tr>
-
-  <tr>
-    <td>Infoblox</td>
-    <td>Technology</td>
-    <td>Secure access to internal infrastructure.</td>
-  </tr>
-
-  <tr>
-    <td>Wise</td>
-    <td>Fintech</td>
-    <td>Secure access for infrastructure.</td>
-  </tr>
-
-  <tr>
-    <td>Zapier</td>
-    <td>Technology</td>
-    <td>Secure access for SSH.</td>
-  </tr>
-
-  <tr>
-    <td>ExtraHop</td>
-    <td>Infosec</td>
-    <td><a href="https://goteleport.com/case-study/extrahop/">case study</a></td>
-  </tr>
-
-  <tr>
-    <td>Twitch</td>
-    <td>Technology</td>
-    <td>SSH access.</td>
-  </tr>
-
-  <tr>
-    <td>GitLab</td>
-    <td>Technology</td>
-    <td><a href="https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/11568#note_451982812">team review</a></td>
-  </tr>
-
-  <tr>
-    <td>SumoLogic</td>
-    <td>Technology</td>
-    <td>Achieve FedRamp compliance and secure access to infrastructure.</td>
-  </tr>
-
-  <tr>
-    <td>Gladly</td>
-    <td>Technology</td>
-    <td><a href="https://goteleport.com/case-study/gladly/">case study</a></td>
-  </tr>
-
-  <tr>
-    <td>VerticalChange</td>
-    <td>Technology</td>
-    <td><a href="https://goteleport.com/case-study/verticalchange-testimonial/">testimonial</a></td>
-  </tr>
-
-  <tr>
-    <td>Shockbyte</td>
-    <td>Technology</td>
-    <td><a href="https://goteleport.com/case-study/shockbyte-testimonial/">testimonial</a></td>
-  </tr>
-
-  <tr>
-    <td>Lacework</td>
-    <td>Infosec</td>
-    <td><a href="https://goteleport.com/case-study/lacework-testimonial/">testimonial</a></td>
-  </tr>
-
-  <tr>
-    <td>Glu Mobile</td>
-    <td>Gaming</td>
-    <td><a href="https://goteleport.com/case-study/glumobile-testimonial/">testimonial</a></td>
-  </tr>
-
-  <tr>
-    <td>Decisiv</td>
-    <td>Transportation</td>
-    <td><a href="https://goteleport.com/case-study/decisiv/">case study</a></td>
-  </tr>
-
-  <tr>
-    <td>Mattermost</td>
-    <td>Technology</td>
-    <td>Secure access to infrastructure.</td>
-  </tr>
+  <thead>
+    <tr>
+      <th>Company</th>
+      <th>Industry</th>
+      <th>Use-cases and case-studies</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Nasdaq</td>
+      <td>Finance</td>
+      <td>Secure access to internal infrastructure.</td>
+    </tr>
+    <tr>
+      <td>Auth0</td>
+      <td>Technology</td>
+      <td><a href="https://goteleport.com/case-study/auth0/">case study</a></td>
+    </tr>
+    <tr>
+      <td>Elastic</td>
+      <td>Technology</td>
+      <td><a href="https://goteleport.com/case-study/elastic-testimonial/">testimonial</a></td>
+    </tr>
+    <tr>
+      <td>VMware</td>
+      <td>Technology</td>
+      <td><a href="https://goteleport.com/case-study/vmware-testimonial/">testimonial</a></td>
+    </tr>
+    <tr>
+      <td>Snowflake</td>
+      <td>Technology</td>
+      <td>Access for SSH and Kubernetes clusters.</td>
+    </tr>
+    <tr>
+      <td>Samsung</td>
+      <td>Technology</td>
+      <td>Secure access for SSH and Kubernetes.</td>
+    </tr>
+    <tr>
+      <td>ECMWF</td>
+      <td>Technology</td>
+      <td><a href="https://goteleport.com/case-study/ecmwf/">case study</a></td>
+    </tr>
+    <tr>
+      <td>IBM</td>
+      <td>Technology</td>
+      <td>Protected access to internal Kubernetes clusters.</td>
+    </tr>
+    <tr>
+      <td>Infoblox</td>
+      <td>Technology</td>
+      <td>Secure access to internal infrastructure.</td>
+    </tr>
+    <tr>
+      <td>Wise</td>
+      <td>Fintech</td>
+      <td>Secure access for infrastructure.</td>
+    </tr>
+    <tr>
+      <td>Zapier</td>
+      <td>Technology</td>
+      <td>Secure access for SSH.</td>
+    </tr>
+    <tr>
+      <td>ExtraHop</td>
+      <td>Infosec</td>
+      <td><a href="https://goteleport.com/case-study/extrahop/">case study</a></td>
+    </tr>
+    <tr>
+      <td>Twitch</td>
+      <td>Technology</td>
+      <td>SSH access.</td>
+    </tr>
+    <tr>
+      <td>GitLab</td>
+      <td>Technology</td>
+      <td><a href="https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/11568#note_451982812">team review</a></td>
+    </tr>
+    <tr>
+      <td>SumoLogic</td>
+      <td>Technology</td>
+      <td>Achieve FedRamp compliance and secure access to infrastructure.</td>
+    </tr>
+    <tr>
+      <td>Gladly</td>
+      <td>Technology</td>
+      <td><a href="https://goteleport.com/case-study/gladly/">case study</a></td>
+    </tr>
+    <tr>
+      <td>VerticalChange</td>
+      <td>Technology</td>
+      <td><a href="https://goteleport.com/case-study/verticalchange-testimonial/">testimonial</a></td>
+    </tr>
+    <tr>
+      <td>Shockbyte</td>
+      <td>Technology</td>
+      <td><a href="https://goteleport.com/case-study/shockbyte-testimonial/">testimonial</a></td>
+    </tr>
+    <tr>
+      <td>Lacework</td>
+      <td>Infosec</td>
+      <td><a href="https://goteleport.com/case-study/lacework-testimonial/">testimonial</a></td>
+    </tr>
+    <tr>
+      <td>Glu Mobile</td>
+      <td>Gaming</td>
+      <td><a href="https://goteleport.com/case-study/glumobile-testimonial/">testimonial</a></td>
+    </tr>
+    <tr>
+      <td>Decisiv</td>
+      <td>Transportation</td>
+      <td><a href="https://goteleport.com/case-study/decisiv/">case study</a></td>
+    </tr>
+    <tr>
+      <td>Mattermost</td>
+      <td>Technology</td>
+      <td>Secure access to infrastructure.</td>
+    </tr>
+  </tbody>
 </table>

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -66,9 +66,12 @@ curl \
 The login message shows an example `curl` command you can run to call the
 target application's API through Teleport App Access.
 
-<Admonition type="note" title="CA and Key Pair Files">
-Note the paths to the CA certificate and your user's certificate/key pair in
-the command - `curl` will use a client certificate to authenticate with Teleport.
+<Admonition
+  type="note"
+  title="CA and Key Pair Files"
+>
+  Note the paths to the CA certificate and your user's certificate/key pair in
+  the command - `curl` will use a client certificate to authenticate with Teleport.
 </Admonition>
 
 As Grafana's API requires authentication, let's update the `curl` command to

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -127,7 +127,7 @@ a reverse tunnel.
 
 ### Application Name
 
-An application name should make a valid sub-domain (&lt;=63 characters, no spaces, only `a-z 0-9 _ -` allowed).
+An application name should make a valid sub-domain (\<=63 characters, no spaces, only `a-z 0-9 _ -` allowed).
 
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`
 e.g. `grafana.teleport.example.com`. You can also override `public_addr` e.g
@@ -216,8 +216,11 @@ address. To override the public address, specify the `public_addr` field:
 
 ### Skip TLS Certificate Verification
 
-<Admonition type="warning" title="Danger Zone">
-This is insecure and not recommended for use in production.
+<Admonition
+  type="warning"
+  title="Danger Zone"
+>
+  This is insecure and not recommended for use in production.
 </Admonition>
 
 Teleport checks if the certificates presented by the applications are signed

--- a/docs/pages/architecture/authentication.mdx
+++ b/docs/pages/architecture/authentication.mdx
@@ -108,7 +108,6 @@ by the system's SSH agent if it is running.
    their username, password, and 2nd-factor token. Users can log in with [`tsh
    login`](../cli-docs.mdx#tsh-login) or via the Web UI. The Auth Server checks
    the username and password against its identity storage and checks the 2nd factor token.
-
 2. If the correct credentials were offered, the Auth Server will generate a
    signed certificate and return it to the client. For users, certificates are
    stored in `~/.tsh` by default. If the client uses the Web UI the signed certificate

--- a/docs/pages/architecture/overview.mdx
+++ b/docs/pages/architecture/overview.mdx
@@ -15,16 +15,13 @@ Teleport was designed in accordance with the following principles:
 - **Off the Shelf Security**: Teleport does not re-implement any security
   primitives and uses well-established, popular implementations of the
   encryption and network protocols.
-
 - **Open Standards**: There is no security through obscurity. Teleport is fully
   compatible with existing and open standards and other software, including
   [OpenSSH](../admin-guide.mdx#using-teleport-with-openssh).
-
 - **Cluster-Oriented Design**: Teleport is built for managing clusters, not
   individual servers. In practice this means that hosts and [Users](../user-manual.mdx)
   have cluster memberships. Identity management and authorization happen on a
   cluster level.
-
 - **Built for Teams**: Teleport was created under the assumption of multiple
   teams operating on several disconnected clusters. Example use cases might be
   production-vs-staging environment, or a cluster-per-customer or
@@ -129,6 +126,7 @@ interface or a web browser. When establishing a connection, the client offers
 its certificate. Clients must always connect through a proxy for two reasons:
 
 1. Individual nodes may not always be reachable from outside a secure network.
+
 2. Proxies always record SSH sessions and keep track of active user sessions.
 
    This makes it possible for an SSH user to see if someone else is connected to

--- a/docs/pages/architecture/proxy.mdx
+++ b/docs/pages/architecture/proxy.mdx
@@ -10,10 +10,8 @@ Teleport cluster:
 1. It serves as an authentication gateway. It asks for credentials from
    connecting clients and forwards them to the Auth server via [Auth
    API](authentication.mdx#auth-api).
-
 2. It looks up the IP address for a requested Node and then proxies a connection
    from client to Node.
-
 3. It serves a Web UI which is used by cluster users to sign up and configure
    their accounts, explore Nodes in a cluster, log into remote Nodes, join
    existing SSH sessions or replay recorded sessions.

--- a/docs/pages/architecture/users.mdx
+++ b/docs/pages/architecture/users.mdx
@@ -82,7 +82,8 @@ connector and it is enforced by default.
 There are two types of 2FA supported:
 
 - [TOTP - e.g. Google Authenticator](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
-- [U2F - e.g. YubiKey](https://en.wikipedia.org/wiki/Universal_2nd_Factor)
+
+- [U2F - e.g. YubiKey](https://en.wikipedia.org/wiki/Universal\_2nd_Factor)
 
   `TOTP` is the default. You can use [Google
   Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator) or

--- a/docs/pages/aws-oss-guide.mdx
+++ b/docs/pages/aws-oss-guide.mdx
@@ -498,7 +498,7 @@ aws ec2 associate-iam-instance-profile --iam-instance-profile Name=teleport-role
 3. Setup Teleport config file. `sudo cp teleport.yaml /etc/teleport.yaml`. An example is below.
 
 ```
-{!examples/aws/eks/teleport.yaml!}
+(!examples/aws/eks/teleport.yaml!)
 ```
 
 #### Download Kubectl on Teleport Server

--- a/docs/pages/aws-terraform-guide.mdx
+++ b/docs/pages/aws-terraform-guide.mdx
@@ -193,12 +193,12 @@ Teleport Enterprise/Pro functionality.
 
 (OSS users can provide any valid local file path here - it isn't used by the auth server in a Teleport OSS install)
 
-### route53_zone
+### route53\_zone
 
 Setting `export TF_VAR_route53_zone="example.com"`
 
 Our Terraform setup requires you to have your domain provisioned in AWS Route 53 - it will automatically add
-DNS records for [`route53_domain`](#route53_domain) as set up below. You can list these with this command:
+DNS records for [`route53_domain`](#route53\_domain) as set up below. You can list these with this command:
 
 ```bash
 $ aws route53 list-hosted-zones --query "HostedZones[*].Name" --output text
@@ -211,16 +211,16 @@ $ aws route53 list-hosted-zones --query "HostedZones[*].Name" --output text
 
 You should use the appropriate domain without the trailing dot.
 
-### route53_domain
+### route53\_domain
 
 Setting `export TF_VAR_route53_domain="teleport.example.com"`
 
 A subdomain to set up as a CNAME to the Teleport load balancer for web access. This will be the public-facing domain
 that people use to connect to your Teleport cluster, so choose wisely.
 
-This must be a subdomain of the domain you chose for [`route53_zone`](#route53_zone) above.
+This must be a subdomain of the domain you chose for [`route53_zone`](#route53\_zone) above.
 
-### s3_bucket_name
+### s3\_bucket_name
 
 Setting `export TF_VAR_s3_bucket_name="example-cluster"`
 
@@ -242,7 +242,7 @@ Setting `export TF_VAR_grafana_pass="CHANGE_THIS_VALUE"`
 
 We deploy Grafana along with every Terraform deployment and automatically make stats on cluster usage available in
 a custom dashboard. This variable sets up the password for the Grafana `admin` user. The Grafana web UI is served
-on the same subdomain as specified above in [`route53_domain`](#route53_domain) on port 8443.
+on the same subdomain as specified above in [`route53_domain`](#route53\_domain) on port 8443.
 
 With the variables set in this example, it would be available on [https://teleport.example.com:8443](https://teleport.example.com:8443)
 
@@ -255,7 +255,7 @@ to a known value at the outset.
 Setting `export TF_VAR_use_acm="false"`
 
 If set to the string `"false"`, Terraform will use [LetsEncrypt](https://letsencrypt.org/) to provision the public-facing
-web UI certificate for the Teleport cluster ([`route53_domain`](#route53_domain) - so [https://teleport.example.com](https://teleport.example.com) in this example).
+web UI certificate for the Teleport cluster ([`route53_domain`](#route53\_domain) - so [https://teleport.example.com](https://teleport.example.com) in this example).
 This uses an [AWS network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html)
 to load-balance connections to the Teleport cluster's web UI, and its SSL termination is handled by Teleport itself.
 
@@ -310,7 +310,7 @@ More information about how Teleport works with DynamoDB can be found in our [Dyn
 ### Recorded session storage
 
 The reference Terraform deployment sets Teleport up to store recorded session logs in the same S3 bucket configured in
-the [`s3_bucket_name`](#s3_bucket_name) variable, under the `records` directory.
+the [`s3_bucket_name`](#s3\_bucket_name) variable, under the `records` directory.
 
 In our example this would be `s3://example-cluster/records`
 
@@ -326,7 +326,7 @@ In our example this would be `s3://example-cluster/records`
 ### Cluster domain
 
 The reference Terraform deployment sets the Teleport cluster up to be available on a domain defined in Route53, referenced
-by the [`route53_domain`](#route53_domain) variable. In our example this would be `teleport.example.com`
+by the [`route53_domain`](#route53\_domain) variable. In our example this would be `teleport.example.com`
 
 Teleport's web interface will be available on port 443 - [https://teleport.example.com](https://teleport.example.com) - this is via a configured CNAME
 to the AWS load balancer.
@@ -335,7 +335,7 @@ Teleport's proxy SSH interface will be available via a network load balancer wit
 This is the default port used when connecting with the `tsh` client and will not require any additional configuration.
 
 Teleport's tunnel interface will be available via the same network load balancer with an AWS-controlled hostname on port
-3024. This allows trusted clusters and nodes connected via node tunnelling to access the cluster.
+3024\. This allows trusted clusters and nodes connected via node tunnelling to access the cluster.
 
 After deploying, you can get the hostname of the proxy/tunnel network load balancer if needed with this command:
 
@@ -415,7 +415,7 @@ If you need to tear down a running deployment for any reason, you can run `terra
 ## Accessing the cluster after Terraform setup
 
 Once the Terraform setup is finished, your Teleport cluster's web UI should be available on
-https&#x3A;//[route53_domain](#route53_domain) - this is [https://teleport.example.com](https://teleport.example.com) in our example.
+https://[route53\_domain](#route53\_domain) - this is [https://teleport.example.com](https://teleport.example.com) in our example.
 
 ### Adding an admin user to the Teleport cluster
 

--- a/docs/pages/aws-terraform-guide.mdx
+++ b/docs/pages/aws-terraform-guide.mdx
@@ -148,11 +148,11 @@ cluster from scratch, so choose carefully.
 
 ### ami_name
 
-Setting `export TF_VAR_ami_name="gravitational-teleport-ami-ent-{{ teleport.version }}"`
+Setting `export TF_VAR_ami_name="gravitational-teleport-ami-ent-(=teleport.version=)"`
 
 Gravitational automatically builds and publishes OSS, Enterprise and Enterprise FIPS 140-2 AMIs when we
 release a new version of Teleport. The AMI names follow the format: `gravitational-teleport-ami-<type>-<version>`
-where `<type>` is either `oss` or `ent` (Enterprise) and `version` is the version of Teleport e.g. `{{ teleport.version }}`.
+where `<type>` is either `oss` or `ent` (Enterprise) and `version` is the version of Teleport e.g. `(=teleport.version=)`.
 
 FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix.
 

--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -3,4 +3,4 @@ title: Teleport Changelog
 description: Learn about what's new, improved and fixed in Teleport.
 ---
 
-`{!CHANGELOG.md!}`
+(!CHANGELOG.md!)

--- a/docs/pages/cli-docs.mdx
+++ b/docs/pages/cli-docs.mdx
@@ -141,9 +141,7 @@ Run shell or execute a command on a remote SSH node
 - `user` The login identity to use on the remote host. If `[user]` is not specified
   the user defaults to `$USER` or can be set with `--user` . If the flag `--user`
   and positional argument `[user]` are specified the arg `[user]` takes precedence.
-
 - `host` A `nodename` of a cluster node or a
-
 - `command` The command to execute on a remote host.
 
 #### Flags
@@ -153,7 +151,7 @@ Run shell or execute a command on a remote SSH node
 | `-p, --port` | none | port | SSH port on a remote host |
 | `-A, --forward-agent` | none | none | Forward agent to target node like `ssh -A` |
 | `-L, --forward` | none | none | Forward localhost connections to remote server |
-| `-D, --dynamic-forward ` | none | none | Forward localhost connections to remote server using SOCKS5 |
+| ` -D, --dynamic-forward  ` | none | none | Forward localhost connections to remote server using SOCKS5 |
 | `-N, -no-remote-exec` | none | none | Don't execute remote command, useful for port forwarding |
 | `--local` | none | | Execute command on localhost after connecting to SSH node |
 | `-t, --tty` | `file` | | Allocate TTY |
@@ -164,9 +162,7 @@ Run shell or execute a command on a remote SSH node
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version-check, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
+These flags are available for all commands ` --login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost  `. Run `  tsh help <subcommand> ` or see the [Global Flags
 Section](#tsh-global-flags)
 
 #### Examples
@@ -206,9 +202,7 @@ Joins an active session
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version-check, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
+These flags are available for all commands ` --login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost  `. Run `  tsh help <subcommand> ` or see the [Global Flags
 Section](#tsh-global-flags)
 
 #### Examples
@@ -238,9 +232,7 @@ Plays back a prior session
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version-check, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
+These flags are available for all commands ` --login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost  `. Run `  tsh help <subcommand> ` or see the [Global Flags
 Section](#tsh-global-flags)
 
 #### Examples
@@ -254,6 +246,7 @@ tsh --proxy proxy.example.com play <session-id>
 Copies files from source to dest
 
 **Usage** `usage: tsh scp [<flags>] <source>... <dest>`
+
 {/* TODO Confirm which flags are supported, and whether supports multiple sources */}
 
 #### Arguments
@@ -272,9 +265,7 @@ Copies files from source to dest
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
+These flags are available for all commands ` --login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version, --debug, --jumphost  `. Run `  tsh help <subcommand> ` or see the [Global Flags
 Section](#tsh-global-flags)
 
 #### Examples
@@ -288,6 +279,7 @@ $ tsh --proxy=proxy.example.com scp -P example.txt user@host/destination/dir
 List cluster nodes
 
 **Usage** `usage: tsh ls [<flags>] [<label>]`
+
 {/* TODO: label? or labels? seems like it only supports one label at a time */}
 
 #### Arguments
@@ -302,9 +294,7 @@ List cluster nodes
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
+These flags are available for all commands ` --login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version, --debug, --jumphost  `. Run `  tsh help <subcommand> ` or see the [Global Flags
 Section](#tsh-global-flags)
 
 #### Examples
@@ -358,9 +348,7 @@ microk8s
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
+These flags are available for all commands ` --login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version, --debug, --jumphost  `. Run `  tsh help <subcommand> ` or see the [Global Flags
 Section](#tsh-global-flags)
 
 #### Examples
@@ -402,9 +390,7 @@ interval via `--ttl` flag (capped by the server-side configuration).
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version-check, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
+These flags are available for all commands ` --login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost  `. Run `  tsh help <subcommand> ` or see the [Global Flags
 Section](#tsh-global-flags)
 
 #### Examples
@@ -713,7 +699,7 @@ Generate a node invitation token
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--roles` | `node` | `node,auth` or ` proxy` | Comma-separated list of roles for the new node to assume |
+| `--roles` | `node` | `node,auth` or `  proxy ` | Comma-separated list of roles for the new node to assume |
 | `--ttl` | 30m | relative duration like 5s, 2m, or 3h | Time to live for a generated token |
 | `--token` | none | **string** token value | A custom token to use, auto-generated if not provided. Should match token set with `teleport start --token` |
 
@@ -972,7 +958,7 @@ Delete a resource
 #### Arguments
 
 - `[<resource-type/resource-name>]` Resource to delete
-  - `<resource type>` Type of a resource [for example: `saml,oidc,github,user,cluster,token`]
+  - `<resource type>` Type of a resource \[for example: `saml,oidc,github,user,cluster,token`]
   - `<resource name>` Resource name to delete
 
 #### Examples
@@ -994,7 +980,7 @@ Print a YAML declaration of various Teleport resources
 #### Arguments
 
 - `[<resource-type/resource-name>]` Resource to get
-  - `<resource type>` Type of a resource [for example: `user,cluster,token`]
+  - `<resource type>` Type of a resource \[for example: `user,cluster,token`]
   - `<resource name>` Resource name to get
 
 #### Flags

--- a/docs/pages/cloud/getting-started.mdx
+++ b/docs/pages/cloud/getting-started.mdx
@@ -13,14 +13,12 @@ Install client libraries:
 
 <Tabs>
   <TabItem label="Linux">
-    ````bash
-    curl -O https://get.gravitational.com/teleport-ent-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-    tar -xzf teleport-ent-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    ```bash
+    curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
     cd teleport
     sudo ./install
     ```
-
-    ````
   </TabItem>
 </Tabs>
 

--- a/docs/pages/database-access/rbac.mdx
+++ b/docs/pages/database-access/rbac.mdx
@@ -110,7 +110,7 @@ database names from the user's Okta `databases` assertion:
 ```yaml
 spec:
   allow:
-    db_names: ["{% raw %}{{external.databases}}{% endraw %}"]
+    db_names: ["{{external.databases}}"]
 ```
 
 The `{{internal.db_users}}` and `{{internal.db_names}}` variables permit sharing
@@ -132,6 +132,6 @@ accounts and names:
 ```yaml
 spec:
   allow:
-    db_users: ["{% raw %}{{internal.db_users}}{% endraw %}"]
-    db_names: ["{% raw %}{{internal.db_names}}{% endraw %}"]
+    db_users: ["{{internal.db_users}}"]
+    db_names: ["{{internal.db_names}}"]
 ```

--- a/docs/pages/docs/best-practices.mdx
+++ b/docs/pages/docs/best-practices.mdx
@@ -21,7 +21,7 @@ to accomplish their goal. This sometimes leads to duplication.
 Use include directives for repeated content. Remove backslash before the exclamation marks for it to work:
 
 ```bash
-{% raw %}{{\!CHANGELOG.md\!}}{% endraw %}
+{{\!CHANGELOG.md\!}}
 ```
 
 ## Diagrams

--- a/docs/pages/docs/best-practices.mdx
+++ b/docs/pages/docs/best-practices.mdx
@@ -21,7 +21,7 @@ to accomplish their goal. This sometimes leads to duplication.
 Use include directives for repeated content. Remove backslash before the exclamation marks for it to work:
 
 ```bash
-{{\!CHANGELOG.md\!}}
+(\!CHANGELOG.md\!)
 ```
 
 ## Diagrams

--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -98,7 +98,7 @@ See the [SSO for SSH](sso/ssh-sso.mdx) chapter for more details.
 ## FedRAMP/FIPS
 
 With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
-the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2),
+the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS\_140-2),
 also known as the Federal Information Processing Standard, which is the US
 government approved standard for cryptographic modules.
 

--- a/docs/pages/enterprise/quickstart-enterprise.mdx
+++ b/docs/pages/enterprise/quickstart-enterprise.mdx
@@ -388,12 +388,12 @@ SailPoint and others.
 
 We provide pre-built Docker images for every version of Teleport Enterprise. These images are hosted on quay.io.
 
-- [All tags under `quay.io/gravitational/teleport-ent` are Teleport Enterprise images](https://quay.io/repository/gravitational/teleport-ent?tag=latest&tab=tags)
+- [All tags under `quay.io/gravitational/teleport-ent` are Teleport Enterprise images](https://quay.io/repository/gravitational/teleport-ent?tag=latest\&tab=tags)
 
 We currently only offer Docker images for `x86_64` architectures.
 
 <Admonition type="note">
-  You will need a recent version of [Docker](https://hub.docker.com/search?q=&type=edition&offering=community) installed to follow this section of the quick start guide.
+  You will need a recent version of [Docker](https://hub.docker.com/search?q=\&type=edition\&offering=community) installed to follow this section of the quick start guide.
 </Admonition>
 
 <Admonition type="warning">
@@ -408,10 +408,10 @@ They are stable, and we recommend their use to easily keep your Teleport Enterpr
 
 | Image name | Community or Enterprise? | Teleport version | Image automatically updated? | Image base |
 | - | - | - | - | - |
-| `quay.io/gravitational/teleport-ent:(=version=)` | Enterprise | The latest version of Teleport Enterprise (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:(=version=)-fips` | Enterprise FIPS | The latest version of Teleport Enterprise (=version=) FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:(=teleport.version=)` | Enterprise | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:(=teleport.version=)-fips` | Enterprise FIPS | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=version=)` | Enterprise | The latest version of Teleport Enterprise (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=version=)-fips` | Enterprise FIPS | The latest version of Teleport Enterprise (=version=) FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=teleport.version=)` | Enterprise | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=teleport.version=)-fips` | Enterprise FIPS | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
 
 For testing, we always recommend that you use the latest release version of Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
 

--- a/docs/pages/enterprise/quickstart-enterprise.mdx
+++ b/docs/pages/enterprise/quickstart-enterprise.mdx
@@ -58,7 +58,7 @@ To start using Teleport Enterprise, you will need to Download the binaries and t
 After downloading the binary tarball, run:
 
 ```bsh
-$ tar -xzf teleport-ent-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-ent
 ```
 
@@ -129,7 +129,7 @@ $ sudo systemctl status teleport
 # after successful start retrieve the CA pin for using in the node
 $ sudo tctl status
 Cluster  teleport
-Version  {{ version }}
+Version  (=version=)
 Host CA  never updated
 User CA  never updated
 Jwt CA   never updated
@@ -408,12 +408,12 @@ They are stable, and we recommend their use to easily keep your Teleport Enterpr
 
 | Image name | Community or Enterprise? | Teleport version | Image automatically updated? | Image base |
 | - | - | - | - | - |
-| `quay.io/gravitational/teleport-ent:{{ version }}` | Enterprise | The latest version of Teleport Enterprise {{ version }} | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:{{ version }}-fips` | Enterprise FIPS | The latest version of Teleport Enterprise {{version }} FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:{{ teleport.version }}` | Enterprise | The version specified in the image's tag (i.e. {{ teleport.version }}) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:{{ teleport.version }}-fips` | Enterprise FIPS | The version specified in the image's tag (i.e. {{ teleport.version }}) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=version=)` | Enterprise | The latest version of Teleport Enterprise (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=version=)-fips` | Enterprise FIPS | The latest version of Teleport Enterprise (=version=) FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=teleport.version=)` | Enterprise | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=teleport.version=)-fips` | Enterprise FIPS | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
 
-For testing, we always recommend that you use the latest release version of Teleport Enterprise, which is currently `{{teleport.latest_ent_docker_image}}`.
+For testing, we always recommend that you use the latest release version of Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
 
 ### Quickstart using docker-compose
 
@@ -456,7 +456,7 @@ cp ~/downloads/downloaded-license.pem ~/teleport/data/license.pem
 docker run --hostname localhost --rm \
   --entrypoint=/bin/sh \
   -v ~/teleport/config:/etc/teleport \
-  {{teleport.latest_ent_docker_image}} -c "teleport configure > /etc/teleport/teleport.yaml"
+  (=teleport.latest_ent_docker_image=) -c "teleport configure > /etc/teleport/teleport.yaml"
 
 # change the path to the license file in the sample config
 sed -i 's_/path/to/license-if-using-teleport-enterprise.pem_/var/lib/teleport/license.pem_g' ~/teleport/config/teleport.yaml
@@ -466,7 +466,7 @@ docker run --hostname localhost --name teleport \
   -v ~/teleport/config:/etc/teleport \
   -v ~/teleport/data:/var/lib/teleport \
   -p 3023:3023 -p 3025:3025 -p 3080:3080 \
-  {{teleport.latest_ent_docker_image}}
+  (=teleport.latest_ent_docker_image=)
 ```
 
 ### Creating a Teleport user when using Docker quickstart

--- a/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
+++ b/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
@@ -5,7 +5,7 @@ h1: FedRAMP for SSH and Kubernetes Access
 ---
 
 With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
-the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high
+the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS\_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high
 level overview of how Teleport FIPS mode works and how it can help your company to become FedRAMP certified.
 
 ### Obtain FedRAMP certification with Teleport
@@ -129,15 +129,10 @@ binary was compiled against an approved cryptographic module (BoringCrypto) and
 fails to start if it was not.
 
 - For OSS and Enterprise binaries not compiled with BoringCrypto, this flag will report that this version of Teleport is not compiled with the appropriate cryptographic module.
-
 - Running commands like `ps aux` can be useful to note that Teleport is running in FedRAMP enforcing mode.
-
 - If no ciphersuites are provided, Teleport will set the default ciphersuites to be FIPS 140-2 compliant.
-
 - If ciphersuites, key exchange and MAC algorithms are provided in the Teleport configuration, Teleport will validate that they are FIPS 140-2 compliant..
-
 - Teleport will always enable at-rest encryption for both DynamoDB and S3.
-
 - If recording proxy mode is selected, validation of host certificates should always happen.
 
 ### FedRAMP Audit Log

--- a/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
+++ b/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
@@ -38,7 +38,7 @@ Enterprise FIPS Binary.
 After downloading the binary tarball, run:
 
 ```bsh
-$ tar -xzf teleport-ent-v{{ teleport.version }}-linux-amd64-fips-bin.tar.gz
+$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
 $ cd teleport-ent
 $ sudo ./install
 # This will copy Teleport Enterprise to /usr/local/bin.

--- a/docs/pages/enterprise/sso/gitlab.mdx
+++ b/docs/pages/enterprise/sso/gitlab.mdx
@@ -37,14 +37,16 @@ auth_service:
 ```
 
 ## Configure GitLab
+
 You should have at least one group configured in GitLab to map to Teleport roles. In this example we use the names `gitlab-dev` and `gitlab-admin`.  Assign users to each of these groups.
+
 1. Create a Application in one of your Groups that will allow using GitLab as a OAuh provider to Teleport.
 
 Settings
 
 - Redirect URL `https://<proxy url>/v1/webapi/oidc/callback` such as `https://teleport.example.com:3080/v1/webapi/oidc/callback`
 - Check `Confidential`, `openid`, `profile`, and `email`.
-![Create App](../../../img/sso/gitlab/gitlab-oidc-0.png)
+  ![Create App](../../../img/sso/gitlab/gitlab-oidc-0.png)
 
 2. Collect the `Application ID` and `Secret` in the Application
 
@@ -56,9 +58,7 @@ These will be used in the Teleport OIDC Auth Connector.
 For GitLab cloud that is `https://gitlab.com`. That allows accessing the Open-ID configuration at `https://gitlab.com/.well-known/openid-configuration`.
 If you are self hosting that is likely another local address.
 
-
 ## Configure Teleport
-
 
 ### Create a OIDC Connector
 
@@ -199,4 +199,3 @@ $ sudo journalctl -fu teleport
 
 If you wish to increase the verbosity of Teleport's syslog, you can pass
 `--debug` flag to `teleport start` command.
-

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -71,7 +71,7 @@ from the identity provider then mapping the value to either to `admin` role or
 the `user` role depending on the value returned for `group` within the claims.
 
 ```yaml
-{!examples/resources/oidc-connector.yaml!}
+(!examples/resources/oidc-connector.yaml!)
 ```
 
 Create the connector:
@@ -123,7 +123,7 @@ spec:
   options:
     max_session_ttl: "90h0m0s"
   allow:
-    logins: [ "{% raw %}{{external.username}}{% endraw %}", ubuntu ]
+    logins: [ "{{external.username}}", ubuntu ]
     node_labels:
       access: relaxed
 ```

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -42,7 +42,7 @@ documented on the identity providers website. Here are a few links:
 
 - [Auth0 Client Configuration](https://auth0.com/docs/applications)
 - [Google Identity Platform](https://developers.google.com/identity/protocols/OpenIDConnect)
-- [Keycloak Client Registration](https://www.keycloak.org/docs/latest/securing_apps/index.html#_client_registration)
+- [Keycloak Client Registration](https://www.keycloak.org/docs/latest/securing_apps/index.html#\_client_registration)
 
 Add your OIDC connector information to `teleport.yaml`. A few examples are
 provided below.
@@ -215,7 +215,7 @@ spec:
 ```
 
 A list of available optional prompt parameters are available from the
-[OpenID website](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+[OpenID website](https://openid.net/specs/openid-connect-core-1\_0.html#AuthRequest).
 
 ## Testing
 

--- a/docs/pages/enterprise/sso/ssh-adfs.mdx
+++ b/docs/pages/enterprise/sso/ssh-adfs.mdx
@@ -121,7 +121,7 @@ spec:
     max_session_ttl: "1h"
   allow:
     # only allow login as either ubuntu or the 'windowsaccountname' claim
-    logins: [ '{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}', ubuntu ]
+    logins: [ '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
@@ -130,7 +130,7 @@ This role declares:
 
 - Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 - Developers can log in as `ubuntu` user
-- Notice `{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}` login. It configures Teleport to look at
+- Notice `{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}` login. It configures Teleport to look at
   *"[http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"](http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname")* ADFS claim and use that field as an allowed login for each user.
   Also note the double quotes (`"`) and square brackets (`[]`) around the claim name - these are important.
 - Developers also do not have any "allow rules" i.e. they will not be able to
@@ -139,7 +139,7 @@ This role declares:
 Next, create a SAML connector [resource](../../admin-guide.mdx#resources):
 
 ```yaml
-{!examples/resources/adfs-connector.yaml!}
+(!examples/resources/adfs-connector.yaml!)
 ```
 
 The `acs` field should match the value you set in ADFS earlier and you can

--- a/docs/pages/enterprise/sso/ssh-azuread.mdx
+++ b/docs/pages/enterprise/sso/ssh-azuread.mdx
@@ -37,40 +37,27 @@ Before you get started you’ll need:
 
 1. Select Enterprise Applications from the AzureAD Directory Home
    ![Select Enterprise Applications From Manage](../../../img/azuread/azuread-1-home.png)
-
 2. Select New application
    ![Select New Applications From Manage](../../../img/azuread/azuread-2-newapp.png)
-
 3. Select a Non-gallery application
    ![Select Non-gallery application](../../../img/azuread/azuread-3-selectnongalleryapp.png)
-
 4. Enter the display name (Ex: Teleport)
    ![Enter application name](../../../img/azuread/azuread-4-enterappname.png)
-
-5.Select properties under Manage and turn off User assignment required
-![Turn off user assignment](../../../img/azuread/azuread-5-turnoffuserassign.png)
-
+5. Select properties under Manage and turn off User assignment required
+   ![Turn off user assignment](../../../img/azuread/azuread-5-turnoffuserassign.png)
 6. Select Single Sign-on under Manage and choose SAML
    ![Select SAML](../../../img/azuread/azuread-6-selectsaml.png)
-
 7. Select to edit Basic SAML Configuration
    ![Edit Basic SAML Configuration](../../../img/azuread/azuread-7-editbasicsaml.png)
-
 8. Put in the Entity ID and Reply URL the same proxy url [https://teleport.example.com:3080/v1/webapi/saml/acs](https://teleport.example.com:3080/v1/webapi/saml/acs)
    ![Put in Entity ID and Reply URL](../../../img/azuread/azuread-8-entityandreplyurl.png)
-
 9. Edit User Attributes & Claims
-
    i. Edit the Claim Name.  Change the name identifier format to Default. Make sure the source attribute is user.userprincipalname.
    ![Confirm Name Identifier](../../../img/azuread/azuread-9a-nameidentifier.png)
-
    ii. Add a group Claim to have user security groups available to the connector
    ![Put in Security group claim](../../../img/azuread/azuread-9b-groupclaim.png)
-
    iii. Add a Claim to pass the username from transforming the AzureAD User name.
    ![Add a transformed username](../../../img/azuread/azuread-9c-usernameclaim.png)
-
-
 10. On the SAML Signing Certificate select to download SAML Download the Federation Metadata XML.
     ![Download Federation Metadata XML](../../../img/azuread/azuread-10-fedmeatadataxml.png)
 

--- a/docs/pages/enterprise/sso/ssh-azuread.mdx
+++ b/docs/pages/enterprise/sso/ssh-azuread.mdx
@@ -158,7 +158,7 @@ spec:
   options:
     max_session_ttl: 24h
   allow:
-    logins: [ "{% raw %}{{external.username}}{% endraw %}", ubuntu ]
+    logins: [ "{{external.username}}", ubuntu ]
     node_labels:
       access: relaxed
 ```

--- a/docs/pages/enterprise/sso/ssh-gsuite.mdx
+++ b/docs/pages/enterprise/sso/ssh-gsuite.mdx
@@ -48,16 +48,12 @@ Before you get started you’ll need:
 ## Configure G Suite
 
 1. Obtain OAuth 2.0 credentials  [https://developers.google.com/identity/protocols/OpenIDConnect](https://developers.google.com/identity/protocols/OpenIDConnect)
-
 2. Create a new Project.
    ![Create New Project](../../../img/gsuite/gsuite-1-new-project.png)
-
 3. Select OAuth client ID.
    ![Create OAuth Creds](../../../img/gsuite/gsuite-2-created-creds.png)
-
 4. Make Application Type Public & Setup Domain Verification
    ![Setup Application Type](../../../img/gsuite/gsuite-3-oauth.png)
-
 5. Copy OAuth Client ID and Client Secret for YAML Below.
    Note: The redirect_url: `https://teleport.example.com:3080/v1/webapi/oidc/callback`
 

--- a/docs/pages/enterprise/sso/ssh-gsuite.mdx
+++ b/docs/pages/enterprise/sso/ssh-gsuite.mdx
@@ -124,7 +124,7 @@ Now, create a OIDC connector [resource](../../admin-guide.mdx#resources).
 Write down this template as `gsuite-connector.yaml`:
 
 ```yaml
-{!examples/resources/gsuite-connector.yaml!}
+(!examples/resources/gsuite-connector.yaml!)
 ```
 
 Create the connector using `tctl` tool:
@@ -172,7 +172,7 @@ spec:
   options:
     max_session_ttl: 24h
   allow:
-    logins: [ "{% raw %}{{external.username}}{% endraw %}", ubuntu ]
+    logins: [ "{{external.username}}", ubuntu ]
     node_labels:
       access: relaxed
 ```

--- a/docs/pages/enterprise/sso/ssh-okta.mdx
+++ b/docs/pages/enterprise/sso/ssh-okta.mdx
@@ -67,7 +67,7 @@ SINGLE ATTRIBUTE STATEMENTS
 GROUP ATTRIBUTE STATEMENTS
 
 - Name: `groups` | Name format: `Unspecified`
-- Filter: `Matches regex` \|  `.*`
+- Filter: `Matches regex` |  `.*`
 
 ![Configure APP](../../../img/sso/okta/setup-redirection.png)
 

--- a/docs/pages/enterprise/sso/ssh-okta.mdx
+++ b/docs/pages/enterprise/sso/ssh-okta.mdx
@@ -110,7 +110,7 @@ configure a Teleport connector:
 Now, create a SAML connector [resource](../../admin-guide.mdx#resources):
 
 ```yaml
-{!examples/resources/saml-connector.yaml!}
+(!examples/resources/saml-connector.yaml!)
 ```
 
 Create the connector using `tctl` tool:
@@ -152,14 +152,14 @@ spec:
   options:
     max_session_ttl: 24h
   allow:
-    logins: [ "{% raw %}{{email.local(external.username)}}{% endraw %}", ubuntu ]
+    logins: [ "{{email.local(external.username)}}", ubuntu ]
     node_labels:
       access: relaxed
 ```
 
 - Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 - Developers can log in as `ubuntu` user
-- Notice `{% raw %}{{external.username}}{% endraw %}` login. It configures Teleport to look at
+- Notice `{{external.username}}` login. It configures Teleport to look at
   *"username"* Okta claim and use that field as an allowed login for each user.  This example uses email as the username format.  The `email.local(external.trait)` function will remove the `@domain` and just have the username prefix.
 - Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.

--- a/docs/pages/enterprise/sso/ssh-one-login.mdx
+++ b/docs/pages/enterprise/sso/ssh-one-login.mdx
@@ -95,7 +95,7 @@ Now, create a SAML connector [resource](../../admin-guide.mdx#resources).
 Write down this template as `onelogin-connector.yaml`:
 
 ```yaml
-{!examples/resources/onelogin-connector.yaml!}
+(!examples/resources/onelogin-connector.yaml!)
 ```
 
 To fill in the fields, open `SSO` tab:
@@ -159,7 +159,7 @@ spec:
   options:
     max_session_ttl: "24h"
   allow:
-    logins: [ "{% raw %}{{external.username}}{% endraw %}", ubuntu ]
+    logins: [ "{{external.username}}", ubuntu ]
     node_labels:
       access: relaxed
 ```

--- a/docs/pages/enterprise/sso/ssh-sso.mdx
+++ b/docs/pages/enterprise/sso/ssh-sso.mdx
@@ -25,7 +25,6 @@ or [OAuth2/OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect).
 - [OIDC](oidc.mdx)
 - [Okta](ssh-okta.mdx)
 
-
 ## How does SSO work with SSH?
 
 From the user's perspective they need to execute the following command login:

--- a/docs/pages/enterprise/sso/ssh-sso.mdx
+++ b/docs/pages/enterprise/sso/ssh-sso.mdx
@@ -117,7 +117,7 @@ connect to Teleport nodes. To support this:
 
 - Use the SSO provider to create a field called *"unix_login"* (you can use another name).
 - Make sure it's exposed as a claim via SAML/OIDC.
-- Update a Teleport SSH role to include `{% raw %}{{external.unix_login}}{% endraw %}` variable into the list of allowed logins:
+- Update a Teleport SSH role to include `{{external.unix_login}}` variable into the list of allowed logins:
 
 ```yaml
 kind: role
@@ -127,7 +127,7 @@ metadata:
 spec:
   allow:
     logins:
-    - '{% raw %}{{external.unix_login}}{% endraw %}'
+    - '{{external.unix_login}}'
     node_labels:
       '*': '*'
 ```
@@ -138,9 +138,9 @@ Along with sending groups, an SSO provider will also provide a user's email addr
 In many organizations, the username that a person uses to log into a system is the
 same as the first part of their email address - the 'local' part. For example, `dave.smith@acme.com` might log in with the username `dave.smith`. Teleport 4.2.6+ adds an easy way to
 extract the first part of an email address so it can be used as a username - this
-is the `{% raw %}{{email.local}}{% endraw %}` function.
+is the `{{email.local}}` function.
 
-If the email claim from the identity provider (which can be accessed via `{% raw %}{{external.email}}{% endraw %}`) is sent and contains an email address, you can extract the 'local' part of the email address before the @ sign like this: `{% raw %}{{email.local(external.email)}}{% endraw %}`
+If the email claim from the identity provider (which can be accessed via `{{external.email}}`) is sent and contains an email address, you can extract the 'local' part of the email address before the @ sign like this: `{{email.local(external.email)}}`
 
 Here's how this looks in a Teleport role:
 
@@ -154,7 +154,7 @@ spec:
     logins:
     # Extracts the local part of dave.smith@acme.com, so the login will
     # now support dave.smith.
-    - '{% raw %}{{email.local(external.email)}}{% endraw %}'
+    - '{{email.local(external.email)}}'
     node_labels:
       '*': '*'
 ```

--- a/docs/pages/enterprise/workflow/index.mdx
+++ b/docs/pages/enterprise/workflow/index.mdx
@@ -168,7 +168,7 @@ spec:
       # external identity provider to the plugin system.
       annotations:
         foo: ['bar']
-        groups: ['{% raw %}{{external.groups}}{% endraw %}']
+        groups: ['{{external.groups}}']
   options:
     # the `request_access` field can be set to 'always' or 'reason' to tell
     # tsh or the web UI to always create an access request on login. If it is
@@ -191,9 +191,9 @@ version: v3
 
   `^prod.*$` - Can request all `prod.*` clusters. e.g. prod.us-east
 
-  `dev-{% raw %}{{regexp.match("us-*")}}{% endraw %}` - Can request any dev cluster in the US. e.g. dev-us-east-a, dev-us-west-b
+  `dev-{{regexp.match("us-*")}}` - Can request any dev cluster in the US. e.g. dev-us-east-a, dev-us-west-b
 
-  `dev-{% raw %}{{regexp.not_match("beta")}}{% endraw %}-prod` - Can request any cluster, apart from beta cluster. e.g. Can access dev-alpha-prod, cannot access dev-beta-prod.
+  `dev-{{regexp.not_match("beta")}}-prod` - Can request any cluster, apart from beta cluster. e.g. Can access dev-alpha-prod, cannot access dev-beta-prod.
 </Admonition>
 
 **Unprivileged User Login**<br/>

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
@@ -135,8 +135,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/jira).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-jira-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-jira-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-jira/
 $ ./install
 $ which teleport-jira
@@ -158,7 +158,7 @@ $ sudo mv teleport-jira.toml /etc
 By default, Jira Teleport Plugin will use a config in `/etc/teleport-jira.toml`, and you can override it with `-c config/file/path.toml` flag.
 
 ```toml
-{!examples/resources/plugins/teleport-jira.toml!}
+(!examples/resources/plugins/teleport-jira.toml!)
 ```
 
 The `[teleport]` section describes where the teleport service running, and what keys should the plugin use to authenticate itself. Use the keys that you've generated.
@@ -199,7 +199,7 @@ In production, we recommend starting teleport plugin daemon via an init system l
 Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-jira.service!}
+(!examples/systemd/plugins/teleport-jira.service!)
 ```
 
 Save this as `teleport-jira.service`.

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
@@ -147,8 +147,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/jira).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-jira-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-jira-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-jira/
 $ sudo ./install
 # Teleport Jira Plugin binaries have been copied to /usr/local/bin
@@ -172,7 +172,7 @@ $ sudo mv teleport-jira.toml /etc
 By default, Jira Teleport Plugin will use a config in `/etc/teleport-jira.toml`, and you can override it with `-c config/file/path.toml` flag.
 
 ```toml
-{!examples/resources/plugins/teleport-jira.toml!}
+(!examples/resources/plugins/teleport-jira.toml!)
 ```
 
 The `[teleport]` section describes where is the teleport service running, and what keys should the plugin use to authenticate itself. Use the keys that you've generated [above in exporting your Certificate section](#export-access-plugin-certificate).
@@ -221,7 +221,7 @@ In production, we recommend starting teleport plugin daemon via an init system l
 Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-jira.service!}
+(!examples/systemd/plugins/teleport-jira.service!)
 ```
 
 Save this as `teleport-jira.service`.

--- a/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
@@ -125,8 +125,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/mattermost).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-mattermost-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-mattermost-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-mattermost
 $ ./install
 $ which teleport-mattermost
@@ -148,7 +148,7 @@ $ sudo mv teleport-mattermost.toml /etc
 Then, edit the config as needed.
 
 ```yaml
-{!examples/resources/plugins/teleport-mattermost.toml!}
+(!examples/resources/plugins/teleport-mattermost.toml!)
 ```
 
 ### Testing the Plugin
@@ -160,7 +160,7 @@ the bot can connect to Mattermost.
 ```bash
 $ teleport-mattermost start -d
 DEBU   DEBUG logging enabled logrus/exported.go:117
-INFO   Starting Teleport Access Mattermost Bot {{ teleport.plugin.version }}-dev.1: mattermost/main.go:140
+INFO   Starting Teleport Access Mattermost Bot (=teleport.plugin.version=)-dev.1: mattermost/main.go:140
 DEBU   Checking Teleport server version mattermost/main.go:234
 DEBU   Starting a request watcher... mattermost/main.go:296
 DEBU   Starting Mattermost API health check... mattermost/main.go:186
@@ -174,7 +174,7 @@ DEBU   Mattermost API health check finished ok mattermost/main.go:19
 In production, we recommend starting teleport plugin daemon via an init system like systemd . Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-mattermost.service!}
+(!examples/systemd/plugins/teleport-mattermost.service!)
 ```
 
 Save this as `teleport-mattermost.service`.

--- a/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
@@ -97,8 +97,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/pagerduty).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-pagerduty-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-pagerduty-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-pagerduty/
 $ ./install
 $ which teleport-pagerduty
@@ -122,7 +122,7 @@ After generating the config, edit it as follows:
 
 ```toml
 # Example PagerDuty config file
-{!examples/resources/plugins/teleport-pagerduty.toml!}
+(!examples/resources/plugins/teleport-pagerduty.toml!)
 ```
 
 ### Testing the Plugin
@@ -151,7 +151,7 @@ By default, `teleport-pagerduty` will assume its config is in `/etc/teleport-pag
 In production, we recommend starting teleport plugin daemon via an init system like systemd . Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-pagerduty.service!}
+(!examples/systemd/plugins/teleport-pagerduty.service!)
 ```
 
 Save this as `teleport-pagerduty.service`.

--- a/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
@@ -152,8 +152,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/slack).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-slack-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-slack-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-slack-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-slack-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-slack/
 $ ./install
 $ which teleport-slack
@@ -175,7 +175,7 @@ $ sudo mv teleport-slack.toml /etc
 Then, edit the config as needed.
 
 ```yaml
-{!examples/resources/plugins/teleport-slack.toml!}
+(!examples/resources/plugins/teleport-slack.toml!)
 ```
 
 #### Editing the config file
@@ -189,7 +189,7 @@ Then set the plugin callback (where Slack sends its requests) to an address you 
 By default, Teleport Slack plugin will run with TLS on.
 
 ```conf
-{!examples/resources/plugins/teleport-slack.toml!}
+(!examples/resources/plugins/teleport-slack.toml!)
 ```
 
 ## Test Run
@@ -205,7 +205,7 @@ If everything works fine, the log output should look like this:
 
 ```bash
 $ teleport-slack start
-INFO   Starting Teleport Access Slack {{ teleport.plugin.version }}.1-0-slack/main.go:145
+INFO   Starting Teleport Access Slack (=teleport.plugin.version=).1-0-slack/main.go:145
 INFO   Starting a request watcher... slack/main.go:330
 INFO   Starting insecure HTTP server on 0.0.0.0:8081 utils/http.go:64
 INFO   Watcher connected slack/main.go:298
@@ -255,7 +255,7 @@ In production, we recommend starting teleport plugin daemon via an init system l
 Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-slack.service!}
+(!examples/systemd/plugins/teleport-slack.service!)
 ```
 
 Save this as `teleport-slack.service`.

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -76,7 +76,7 @@ We recommend that the Auth Server should be upgraded first, and proxy is bumped 
 
 ### Does Web UI support copy and paste?
 
-Yes. You can copy&paste using the mouse. For working with a keyboard, Teleport employs
+Yes. You can copy\&paste using the mouse. For working with a keyboard, Teleport employs
 `tmux`-like "prefix" mode. To enter prefix mode, press `Ctrl+A`.
 
 While in prefix mode, you can press `Ctrl+V` to paste, or enter text selection

--- a/docs/pages/features/enhanced-session-recording.mdx
+++ b/docs/pages/features/enhanced-session-recording.mdx
@@ -94,19 +94,15 @@ We recommend installing BCC tools using your distribution's package manager wher
 
 <Tabs>
   <TabItem label="Ubuntu/Debian 18.04+">
-    ````sh
+    ``sh
     apt -y install bpfcc-tools
     ```
-
-    ````
   </TabItem>
 
   <TabItem label="CentOS/RHEL 8+">
-    ````sh
+    ``sh
     yum -y install bcc-tools
     ```
-
-    ````
   </TabItem>
 
   <TabItem label="Amazon Linux 2+">
@@ -114,7 +110,7 @@ We recommend installing BCC tools using your distribution's package manager wher
 
     Make sure the the machine is at Kernel 4.19+/5+ (`uname -r`). Run the following script, sourced from [BCC github](https://github.com/iovisor/bcc/blob/master/INSTALL.md#amazon-linux-2---binary), to enable BCC in Amazon Linux Extras, install required `kernel-devel` package for the Kernel version and install the BCC tools.
 
-    ````sh
+    ```sh
     #!/bin/bash
     # Enable BCC within the Amazon Linux Extras
     sudo amazon-linux-extras enable BCC
@@ -122,7 +118,6 @@ We recommend installing BCC tools using your distribution's package manager wher
     sudo yum install -y kernel-devel-$(uname -r)
     # Install BCC
     sudo yum install -y bcc
-
     ```
 
     You should see output similar to below:
@@ -134,8 +129,6 @@ We recommend installing BCC tools using your distribution's package manager wher
     Dependency Installed:
       bcc-tools.x86_64 0:0.10.0-1.amzn2.0.1  python2-bcc.x86_64 0:0.10.0-1.amzn2.0.1
     ```
-
-    ````
   </TabItem>
 
   <TabItem label="Ubuntu and Debian (compile from source)">
@@ -146,7 +139,7 @@ We recommend installing BCC tools using your distribution's package manager wher
       Compiling from source can take a long time and may break if your kernel version changes.
     </Admonition>
 
-    ````sh
+    ```sh
     #!/bin/bash
 
     # Download LLVM and Clang from the Trusty Repos.
@@ -178,8 +171,6 @@ We recommend installing BCC tools using your distribution's package manager wher
     # Install is done.
     echo "Install is complete, try running /usr/share/bcc/tools/execsnoop to verify install."
     ```
-
-    ````
   </TabItem>
 
   <TabItem label="CentOS (compile from source)">
@@ -190,7 +181,7 @@ We recommend installing BCC tools using your distribution's package manager wher
       Compiling from source can take a long time and may break if your kernel version changes.
     </Admonition>
 
-    ````sh
+    ```sh
     #!/bin/bash
 
     set -e
@@ -251,8 +242,6 @@ We recommend installing BCC tools using your distribution's package manager wher
     rm -fr $BUILD_DIR
     echo "Install is complete, try running /usr/share/bcc/tools/execsnoop to verify install."
     ```
-
-    ````
   </TabItem>
 </Tabs>
 
@@ -350,15 +339,13 @@ be a JSON log for each command and network request.
 
 <Tabs>
   <TabItem label="json">
-    ````json
+    ```json
     {"argv":["google.com"],"cgroup_id":4294968064,"code":"T4000I","ei":5,"event":"session.command","login":"root","namespace":"default","path":"/bin/ping","pid":2653,"ppid":2660,"program":"ping","return_code":0,"server_id":"96f2bed2-ebd1-494a-945c-2fd57de41644","sid":"44c6cea8-362f-11ea-83aa-125400432324","time":"2020-01-13T18:05:53.919Z","uid":"734930bb-00e6-4ee6-8798-37f1e9473fac","user":"benarent"}
     ```
-
-    ````
   </TabItem>
 
   <TabItem label="json formatted">
-    ````json
+    ```json
     {
       "argv":[
         "google.com"
@@ -381,7 +368,5 @@ be a JSON log for each command and network request.
       "user":"benarent"
     }
     ```
-
-    ````
   </TabItem>
 </Tabs>

--- a/docs/pages/features/enhanced-session-recording.mdx
+++ b/docs/pages/features/enhanced-session-recording.mdx
@@ -12,7 +12,7 @@ session recordings typically do not contain passwords that were entered into a t
 
 The disadvantage is that session recordings can by bypassed using several techniques:
 
-- **Obfuscation**. For example, even though the command ` echo Y3VybCBodHRwOi8vd3d3LmV4YW1wbGUuY29tCg== | base64 --decode | sh` does not contain
+- **Obfuscation**. For example, even though the command `echo Y3VybCBodHRwOi8vd3d3LmV4YW1wbGUuY29tCg== | base64 --decode | sh` does not contain
   `curl http://www.example.com`, when decoded, that is what is run.
 - **Shell scripts**. For example, if a user uploads and executes a script, the commands
   run within the script are not captured, simply the output.
@@ -94,13 +94,13 @@ We recommend installing BCC tools using your distribution's package manager wher
 
 <Tabs>
   <TabItem label="Ubuntu/Debian 18.04+">
-    ``sh
+    ```sh
     apt -y install bpfcc-tools
     ```
   </TabItem>
 
   <TabItem label="CentOS/RHEL 8+">
-    ``sh
+    ```sh
     yum -y install bcc-tools
     ```
   </TabItem>

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -26,48 +26,52 @@ Teleport on Linux machines.
 ## Step 1: Install Teleport on a Linux Host
 
 <Tabs>
-<TabItem label="Amazon Linux 2/RHEL (RPM)">
-```bash
-sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-sudo yum install teleport
+  <TabItem label="Amazon Linux 2/RHEL (RPM)">
+    ```bash
+    sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+    sudo yum install teleport
 
-# Optional:  Using DNF on newer distributions
-# $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-# $ sudo dnf install teleport
-```
-</TabItem>
-<TabItem label="Debian/Ubuntu (DEB)">
-```bash
-curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-sudo apt-get update
-sudo apt-get install teleport
-```
-</TabItem>
-<TabItem label="Linux">
-```bash
-curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-cd teleport
-sudo ./install
-```
-</TabItem>
-<TabItem label="ARMv7 (32-bit)">
-```bash
-curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-tar -xzf teleport-v=(teleport.version=)-linux-arm-bin.tar.gz
-cd teleport
-sudo ./install
-```
-</TabItem>
-<TabItem label="ARMv8 (64-bit)">
-```bash
-curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-cd teleport
-sudo ./install
-```
-</TabItem>
+    # Optional:  Using DNF on newer distributions
+    # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+    # $ sudo dnf install teleport
+    ```
+  </TabItem>
+
+  <TabItem label="Debian/Ubuntu (DEB)">
+    ```bash
+    curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
+    sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
+    sudo apt-get update
+    sudo apt-get install teleport
+    ```
+  </TabItem>
+
+  <TabItem label="Linux">
+    ```bash
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    cd teleport
+    sudo ./install
+    ```
+  </TabItem>
+
+  <TabItem label="ARMv7 (32-bit)">
+    ```bash
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+    tar -xzf teleport-v=(teleport.version=)-linux-arm-bin.tar.gz
+    cd teleport
+    sudo ./install
+    ```
+  </TabItem>
+
+  <TabItem label="ARMv8 (64-bit)">
+    ```bash
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+    cd teleport
+    sudo ./install
+    ```
+  </TabItem>
 </Tabs>
 
 Take a look at the [Installation Guide](installation.mdx) for more options.
@@ -90,12 +94,15 @@ Teleport requires a secure public endpoint for the Teleport UI and for end users
 To get started setup two `A` records for `tele.example.com` and `*.tele.example.com`
 pointing to the IP/FQDN of the machine with Teleport installed.
 
-<Admonition type="tip" title="Tip">
-You can use `dig` to make sure that DNS records are propagated:
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  You can use `dig` to make sure that DNS records are propagated:
 
-```bash
-dig @8.8.8.8 tele.example.com
-```
+  ```bash
+  dig @8.8.8.8 tele.example.com
+  ```
 </Admonition>
 
 Start Teleport:
@@ -135,8 +142,8 @@ Here's a selection of compatible Two-Factor authentication apps:
 >
   The OS users that you specify (`root`, `ubuntu` and `ec2-user` in our examples) must exist!
   On Linux, if a user does not already exist, you can create it with `adduser <login>`. If you
-  do not have the permission to create new users on the Linux host, run `tctl users add teleport
-    $(whoami)` to explicitly allow Teleport to authenticate as the user that you are currently logged
+  do not have the permission to create new users on the Linux host, run `tctl users add teleport $(whoami)`
+  to explicitly allow Teleport to authenticate as the user that you are currently logged
   in as. If you do not map to an existing OS user,  you will get authentication errors later on in
   this tutorial!
 </Admonition>
@@ -146,36 +153,39 @@ Here's a selection of compatible Two-Factor authentication apps:
 ## Step 2a: Install a Teleport client locally
 
 <Tabs>
-<TabItem label="Mac">
-[Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the installer.
-</TabItem>
-<TabItem label="Mac - Homebrew">
-```bash
-brew install teleport
-```
+  <TabItem label="Mac">
+    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the installer.
+  </TabItem>
 
-<Admonition type="note">
-The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
-</Admonition>
-</TabItem>
-<TabItem label="Windows - Powershell">
-```bash
-curl -O teleport-v(=teleport.version=)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
-# Unzip the archive and move `tsh.exe` to your %PATH%
-```
-</TabItem>
-<TabItem label="Linux">
-For more options (including RPM/DEB packages and downloads for i386/ARM/ARM64) please see our [installation page](installation.mdx).
+  <TabItem label="Mac - Homebrew">
+    ```bash
+    brew install teleport
+    ```
 
-```bash
-curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-cd teleport
-sudo ./install
-Teleport binaries have been copied to /usr/local/bin
-To configure the systemd service for Teleport take a look at examples/systemd/README.mdx
-```
-</TabItem>
+    <Admonition type="note">
+      The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
+    </Admonition>
+  </TabItem>
+
+  <TabItem label="Windows - Powershell">
+    ```bash
+    curl -O teleport-v(=teleport.version=)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
+    # Unzip the archive and move `tsh.exe` to your %PATH%
+    ```
+  </TabItem>
+
+  <TabItem label="Linux">
+    For more options (including RPM/DEB packages and downloads for i386/ARM/ARM64) please see our [installation page](installation.mdx).
+
+    ```bash
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    cd teleport
+    sudo ./install
+    Teleport binaries have been copied to /usr/local/bin
+    To configure the systemd service for Teleport take a look at examples/systemd/README.mdx
+    ```
+  </TabItem>
 </Tabs>
 
 ## Step 3: Log in using `tsh`
@@ -219,51 +229,52 @@ sudo tctl tokens add --type=node
 Bootstrap a new node:
 
 <Tabs>
-<TabItem label="teleport start">
-Replace `auth_servers` with the hostname and port of your Teleport cluster,
-`token` with the token you generated above.
+  <TabItem label="teleport start">
+    Replace `auth_servers` with the hostname and port of your Teleport cluster,
+    `token` with the token you generated above.
 
-```bash
-sudo teleport start \
---roles=node \
---auth-server=https://teleport.example.com:443 \
---token=${TOKEN?} \
---labels=env=demo
-```
-</TabItem>
-<TabItem label="cloud-config">
-Replace `auth_servers` with the hostname and port of your Teleport cluster,
-`auth_token` with the token you generated above.
+    ```bash
+    sudo teleport start \
+    --roles=node \
+    --auth-server=https://teleport.example.com:443 \
+    --token=${TOKEN?} \
+    --labels=env=demo
+    ```
+  </TabItem>
 
-```ini
-#cloud-config
+  <TabItem label="cloud-config">
+    Replace `auth_servers` with the hostname and port of your Teleport cluster,
+    `auth_token` with the token you generated above.
 
-package_upgrade: true
+    ```ini
+    #cloud-config
 
-write_files:
-- path: /etc/teleport.yaml
-    content: |
-        teleport:
-            auth_token: ""
-            auth_servers:
-                - "https://teleport.example.com:443"
-        auth_service:
-            enabled: false
-        proxy_service:
-            enabled: false
-        ssh_service:
-            enabled: true
-            labels:
-                env: demo
+    package_upgrade: true
 
-runcmd:
-- 'mkdir -p /tmp/teleport'
-- 'cd /tmp/teleport && curl -O https://get.gravitational.com/teleport_(=teleport.version=)_amd64.deb'
-- 'dpkg -i /tmp/teleport/teleport_(=teleport.version=)_amd64.deb'
-- 'systemctl enable teleport.service'
-- 'systemctl start teleport.service'
-```
-</TabItem>
+    write_files:
+    - path: /etc/teleport.yaml
+        content: |
+            teleport:
+                auth_token: ""
+                auth_servers:
+                    - "https://teleport.example.com:443"
+            auth_service:
+                enabled: false
+            proxy_service:
+                enabled: false
+            ssh_service:
+                enabled: true
+                labels:
+                    env: demo
+
+    runcmd:
+    - 'mkdir -p /tmp/teleport'
+    - 'cd /tmp/teleport && curl -O https://get.gravitational.com/teleport_(=teleport.version=)_amd64.deb'
+    - 'dpkg -i /tmp/teleport/teleport_(=teleport.version=)_amd64.deb'
+    - 'systemctl enable teleport.service'
+    - 'systemctl start teleport.service'
+    ```
+  </TabItem>
 </Tabs>
 
 ### Add an Application to your Teleport cluster
@@ -277,19 +288,19 @@ sudo tctl tokens add --type=app
 Add a new application:
 
 <Tabs>
-<TabItem label="teleport start">
-Install Teleport on the target node, then start it using a command as shown below.
-Review and update `auth-server`, `token`, `app-name` and `app-uri` before running this command.
+  <TabItem label="teleport start">
+    Install Teleport on the target node, then start it using a command as shown below.
+    Review and update `auth-server`, `token`, `app-name` and `app-uri` before running this command.
 
-```bash
-sudo teleport start \
---roles=app \
---token=${TOKEN?} \
---auth-server=teleport.example.com:3080 \
---app-name=example-app  \ # Change "example-app" to the name of your application.
---app-uri=http://localhost:8080  # Change "http://localhost:8080" to the address of your application.
-```
-</TabItem>
+    ```bash
+    sudo teleport start \
+    --roles=app \
+    --token=${TOKEN?} \
+    --auth-server=teleport.example.com:3080 \
+    --app-name=example-app  \ # Change "example-app" to the name of your application.
+    --app-uri=http://localhost:8080  # Change "http://localhost:8080" to the address of your application.
+    ```
+  </TabItem>
 </Tabs>
 
 ### Guides

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -46,24 +46,24 @@ sudo apt-get install teleport
 </TabItem>
 <TabItem label="Linux">
 ```bash
-curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
 cd teleport
 sudo ./install
 ```
 </TabItem>
 <TabItem label="ARMv7 (32-bit)">
 ```bash
-curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
-tar -xzf teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
+curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+tar -xzf teleport-v=(teleport.version=)-linux-arm-bin.tar.gz
 cd teleport
 sudo ./install
 ```
 </TabItem>
 <TabItem label="ARMv8 (64-bit)">
 ```bash
-curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
-tar -xzf teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
+curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
 cd teleport
 sudo ./install
 ```
@@ -160,7 +160,7 @@ The Teleport package in Homebrew is not maintained by Teleport. We recommend the
 </TabItem>
 <TabItem label="Windows - Powershell">
 ```bash
-curl -O teleport-v{{ teleport.version }}-windows-amd64-bin.zip https://get.gravitational.com/teleport-v{{ teleport.version }}-windows-amd64-bin.zip
+curl -O teleport-v(=teleport.version=)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
 # Unzip the archive and move `tsh.exe` to your %PATH%
 ```
 </TabItem>
@@ -168,8 +168,8 @@ curl -O teleport-v{{ teleport.version }}-windows-amd64-bin.zip https://get.gravi
 For more options (including RPM/DEB packages and downloads for i386/ARM/ARM64) please see our [installation page](installation.mdx).
 
 ```bash
-curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
 cd teleport
 sudo ./install
 Teleport binaries have been copied to /usr/local/bin
@@ -258,8 +258,8 @@ write_files:
 
 runcmd:
 - 'mkdir -p /tmp/teleport'
-- 'cd /tmp/teleport && curl -O https://get.gravitational.com/teleport_{{ teleport.version }}_amd64.deb'
-- 'dpkg -i /tmp/teleport/teleport_{{ teleport.version }}_amd64.deb'
+- 'cd /tmp/teleport && curl -O https://get.gravitational.com/teleport_(=teleport.version=)_amd64.deb'
+- 'dpkg -i /tmp/teleport/teleport_(=teleport.version=)_amd64.deb'
 - 'systemctl enable teleport.service'
 - 'systemctl start teleport.service'
 ```

--- a/docs/pages/ibm-cloud-guide.mdx
+++ b/docs/pages/ibm-cloud-guide.mdx
@@ -56,7 +56,6 @@ stores the audit logs.
 We recommend Gen 2 Cloud IBM [Virtual Servers](https://www.ibm.com/cloud/virtual-servers) and [Auto Scaling](https://www.ibm.com/cloud/auto-scaling)
 
 - For Staging and POCs we recommend using `bx2-2x8` machines with 2 vCPUs, 4GB RAM, 4 Gbps.
-
 - For Production we would recommend `cx2-4x8` with 4 vCPUs, 8 GB RAM, 8 Gbps.
 
 ### Storage: Database for etcd

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -67,20 +67,20 @@ or a commercial edition ("Teleport Enterprise Edition").
 
 Teleport is officially supported on the platforms listed below. It is worth noting
 that the open source community has been successful in building and running Teleport on
-UNIX variants other than Linux [2].
+UNIX variants other than Linux \[2].
 
 | Operating System | Teleport Client | Teleport Server |
 | - | - | - |
 | Linux v2.6+ | yes | yes |
 | MacOS v10.12+ | yes | yes |
-| Windows [1] | yes [1] | no |
+| Windows \[1] | yes \[1] | no |
 
-[1] *Teleport server does not run on Windows yet, but `tsh` (the Teleport client)
+\[1] *Teleport server does not run on Windows yet, but `tsh` (the Teleport client)
 can be used on Windows to execute `tsh login` to retrieve a user's SSH
 certificate and use it with `ssh`, the OpenSSH client, running on a Windows
 client machine.*
 
-[2] *Teleport is written in Go and it is theoretically possible to build it on
+\[2] *Teleport is written in Go and it is theoretically possible to build it on
 any OS supported by the [Golang toolchain](https://github.com/golang/go/wiki/MinimumRequirements)*.
 
 ## Next Steps

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -36,12 +36,12 @@ up-to-date information.
 
   <TabItem label="ARMv7 (32-bit)">
     ```bash
-    $ curl https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz.sha256
+    $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz.sha256
     # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
-    $ shasum -a 256 teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
+    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+    $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
     # Verify that the checksums match
-    $ tar -xzf teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
+    $ tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
     $ cd teleport
     $ ./install
     ```
@@ -49,12 +49,12 @@ up-to-date information.
 
   <TabItem label="ARM64/ARMv8 (64-bit)">
     ```bash
-    $ curl https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz.sha256
+    $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz.sha256
     # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
-    $ shasum -a 256 teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
+    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+    $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
     # Verify that the checksums match
-    $ tar -xzf teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
+    $ tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
     $ cd teleport
     $ ./install
     ```
@@ -62,12 +62,12 @@ up-to-date information.
 
   <TabItem label="Tarball">
     ```bash
-    $ curl https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz.sha256
+    $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
     # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-    $ shasum -a 256 teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    $ shasum -a 256 teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
     # Verify that the checksums match
-    $ tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    $ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
     $ cd teleport
     $ ./install
     ```
@@ -79,7 +79,7 @@ up-to-date information.
 Please follow our [Getting started with Teleport using Docker](quickstart-docker.mdx) or with [Teleport Enterprise using Docker](enterprise/quickstart-enterprise.mdx#run-teleport-enterprise-using-docker) for install and setup instructions.
 
 ```bash
-$ docker pull quay.io/gravitational/teleport:{{ teleport.version }}
+$ docker pull quay.io/gravitational/teleport:(=teleport.version=)
 ```
 
 ## Helm
@@ -115,10 +115,10 @@ $ helm install teleport teleport/teleport
 
   <TabItem label="Terminal">
     ```bash
-    $ curl -O https://get.gravitational.com/teleport-{{ teleport.version }}.pkg
-    $ sudo installer -pkg teleport-{{ teleport.version }}.pkg -target / # Installs on Macintosh HD
+    $ curl -O https://get.gravitational.com/teleport-(=teleport.version=).pkg
+    $ sudo installer -pkg teleport-(=teleport.version=).pkg -target / # Installs on Macintosh HD
     Password:
-    installer: Package name is teleport-{{ teleport.version }}
+    installer: Package name is teleport-(=teleport.version=)
     installer: Upgrading at base path /
     installer: The upgrade was successful.
     $ which teleport
@@ -135,12 +135,12 @@ architecture - `teleport` and `tctl` are not supported.
 <Tabs>
   <TabItem label="Powershell">
     ```bash
-    > curl https://get.gravitational.com/teleport-v{{ teleport.version }}-windows-amd64-bin.zip.sha256
+    > curl https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip.sha256
     # <checksum> <filename>
-    > curl -O teleport-v{{ teleport.version }}-windows-amd64-bin.zip https://get.gravitational.com/teleport-v{{ teleport.version }}-windows-amd64-bin.zip
+    > curl -O teleport-v(=teleport.version=)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
     > echo %PATH% # Edit %PATH% if necessary
-    > certUtil -hashfile teleport-v{{ teleport.version }}-windows-amd64-bin.zip SHA256
-    SHA256 hash of teleport-v{{ teleport.version }}-windows-amd64-bin.zip:
+    > certUtil -hashfile teleport-v(=teleport.version=)-windows-amd64-bin.zip SHA256
+    SHA256 hash of teleport-v(=teleport.version=)-windows-amd64-bin.zip:
     # <checksum> <filename>
     CertUtil: -hashfile command completed successfully.
     # Verify that the checksums match
@@ -151,7 +151,7 @@ architecture - `teleport` and `tctl` are not supported.
 
 ## Installing from Source
 
-Gravitational Teleport is written in Go language. It requires **Golang v{{ teleport.golang }}**
+Gravitational Teleport is written in Go language. It requires **Golang v(=teleport.golang=)**
 or newer. Check [the repo
 README](https://github.com/gravitational/teleport#building-teleport) for the
 latest requirements.
@@ -202,7 +202,7 @@ obtain the checksum  by adding `.sha256` to the binary. This is the method shown
 in the installation examples.
 
 ```bash
-$ export version=v{{ teleport.version }}
+$ export version=v(=teleport.version=)
 $ export os=linux # 'darwin' 'linux' or 'windows'
 $ export arch=amd64 # '386' 'arm' on linux or 'amd64' for all distros
 $ curl https://get.gravitational.com/teleport-$version-$os-$arch-bin.tar.gz.sha256

--- a/docs/pages/kubernetes-access.mdx
+++ b/docs/pages/kubernetes-access.mdx
@@ -7,22 +7,31 @@ Teleport provides a unified access for Kubernetes clusters.
 
 - Users can receive short-lived certificates using Single Sign-On and switch between clusters without relogins.
 - Admins can use roles to implement policies "developers must not access production" and enforce
-dual authorization using [access workflows](./enterprise/workflow/index.mdx) for privileged operations.
+  dual authorization using [access workflows](./enterprise/workflow/index.mdx) for privileged operations.
 - Organizations can achieve compliance by capturing `kubectl` events and session recordings for `kubectl`.
 
 ## SSO and Audit for Kubernetes Clusters
 
 Set up single sign on, capture audit events and sessions with Teleport running in a Kubernetes cluster.
 
-<video muted playsInline controls>
-  <source src="https://goteleport.com/teleport/videos/kubernetes-access/kubelogin.mp4" type="video/mp4" />
-  <source src="https://goteleport.com/teleport/videos/kubernetes-access/kubelogin.webm" type="video/webm" />
-Your browser does not support the video tag.
+<video
+  muted
+  playsInline
+  controls
+>
+  <source
+    src="https://goteleport.com/teleport/videos/kubernetes-access/kubelogin.mp4"
+    type="video/mp4"
+  />
+
+  <source
+    src="https://goteleport.com/teleport/videos/kubernetes-access/kubelogin.webm"
+    type="video/webm"
+  />
+
+  Your browser does not support the video tag.
 </video>
 
 ## Getting Started
 
 Configure Kubernetes Access in a 10 minute [Getting Started](./kubernetes-access/getting-started.mdx) guide.
-
-
-

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -16,68 +16,69 @@ Here are examples of connectors that map SSO users to Kubernetes groups in OSS
 and Teleport's roles in enterprise:
 
 <Tabs>
-<TabItem label="Open Source">
-Github's `teams_to_logins` section maps users to roles based on users's teams.
+  <TabItem label="Open Source">
+    Github's `teams_to_logins` section maps users to roles based on users's teams.
 
-```yaml
-kind: github
-version: v3
-metadata:
-  # connector name that will be used with `tsh --auth=github login`
-  name: github
-spec:
-  # client ID of Github OAuth app
-  client_id: client-id
-  # client secret of Github OAuth app
-  client_secret: client-secret
-  # This name will be shown on UI login screen
-  display: Github
-  # Change tele.example.com to your domain name
-  redirect_url: https://tele.example.com:443/v1/webapi/github/callback
-  # Map github teams to teleport roles
-  teams_to_logins:
-    - organization: octocats # Github organization name
-      team: admin            # Github team name within that organization
-      # keep this field as is for now
-      logins: ["admin"]
-```
-</TabItem>
-<TabItem label="Enterprise">
-OIDC and SAML connectors `claims_to_roles` and `attributes_to_roles` sections map
-attribute statements and claims received from identity providers to Teleport's roles.
+    ```yaml
+    kind: github
+    version: v3
+    metadata:
+      # connector name that will be used with `tsh --auth=github login`
+      name: github
+    spec:
+      # client ID of Github OAuth app
+      client_id: client-id
+      # client secret of Github OAuth app
+      client_secret: client-secret
+      # This name will be shown on UI login screen
+      display: Github
+      # Change tele.example.com to your domain name
+      redirect_url: https://tele.example.com:443/v1/webapi/github/callback
+      # Map github teams to teleport roles
+      teams_to_logins:
+        - organization: octocats # Github organization name
+          team: admin            # Github team name within that organization
+          # keep this field as is for now
+          logins: ["admin"]
+    ```
+  </TabItem>
 
-```yaml
-kind: saml
-version: v2
-metadata:
-  name: okta
-spec:
-  acs: https://tele.example.com/v1/webapi/saml/acs
-  attributes_to_roles:
-  # Any user who has SAML `groups` atrribute with value `okta-admin`
-  # will be given the Teleport `admin` role.
-  - {name: "groups", value: "okta-admin", roles: ["admin"]}
-  entity_descriptor: |
-    <?xml !!! Make sure to shift all lines in XML descriptor 
-    with 4 spaces, otherwise things will not work
-```
-    
-Members of the role `admin` have a property `kubernetes_groups` that assigns them to [Kubernetes groups](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects)
+  <TabItem label="Enterprise">
+    OIDC and SAML connectors `claims_to_roles` and `attributes_to_roles` sections map
+    attribute statements and claims received from identity providers to Teleport's roles.
 
-```yaml
-kind: role
-version: v3
-metadata:
-  name: admin
-spec:
-  allow:
-    # if kubernetes integration is enabled, this setting configures which
-    # kubernetes groups the users of this role will be assigned to.
-    # note that you can refer to a SAML/OIDC trait named 'property' via the "{{external.property}}" template variable,
-    # this allows you to specify Kubernetes group membership via your identity provider:
-    kubernetes_groups: ["system:masters"]
-```
-</TabItem>
+    ```yaml
+    kind: saml
+    version: v2
+    metadata:
+      name: okta
+    spec:
+      acs: https://tele.example.com/v1/webapi/saml/acs
+      attributes_to_roles:
+      # Any user who has SAML `groups` atrribute with value `okta-admin`
+      # will be given the Teleport `admin` role.
+      - {name: "groups", value: "okta-admin", roles: ["admin"]}
+      entity_descriptor: |
+        <?xml !!! Make sure to shift all lines in XML descriptor 
+        with 4 spaces, otherwise things will not work
+    ```
+
+    Members of the role `admin` have a property `kubernetes_groups` that assigns them to [Kubernetes groups](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-subjects)
+
+    ```yaml
+    kind: role
+    version: v3
+    metadata:
+      name: admin
+    spec:
+      allow:
+        # if kubernetes integration is enabled, this setting configures which
+        # kubernetes groups the users of this role will be assigned to.
+        # note that you can refer to a SAML/OIDC trait named 'property' via the "{{external.property}}" template variable,
+        # this allows you to specify Kubernetes group membership via your identity provider:
+        kubernetes_groups: ["system:masters"]
+    ```
+  </TabItem>
 </Tabs>
 
 ## Mapping OIDC claims and SAML attributes to Kubernetes groups
@@ -125,71 +126,73 @@ $ tctl create -f member.yaml
 Assign this role to a user in OIDC or SAML connector:
 
 <Tabs>
-<TabItem label="Github (OSS)">
-```yaml
-kind: github
-version: v3
-metadata:
-  # connector name that will be used with `tsh --auth=github login`
-  name: github
-spec:
-  # client ID of Github OAuth app
-  client_id: client-id
-  # client secret of Github OAuth app
-  client_secret: client-secret
-  # This name will be shown on UI login screen
-  display: Github
-  # Change tele.example.com to your domain name
-  redirect_url: https://tele.example.com:443/v1/webapi/github/callback
-  # Map github teams to kubernetes groups
-  teams_to_logins:
-    - organization: octocats # Github organization name
-      team: admin            # Github team name within that organization
-      # list of Kubernetes groups this Github team is allowed to connect to
-      # keep this field as is for now
-      logins: ["admins"]
-```
-</TabItem>
-<TabItem label="OIDC (Enterprise)">
-```yaml
-kind: oidc
-version: v2
-metadata:
-  name: auth0
-spec:
-  redirect_url: https://tele.example.com/v1/webapi/oidc/callback
-  client_id: client-id-here
-  client_secret: client-secret-here
-  issuer_url: https://idp.example.com/
-  # request groups scope from OIDC provider
-  # read more about scopes here https://auth0.com/docs/scopes/openid-connect-scopes
-  scope: [groups]
-  claims_to_roles:
-    - {claim: "groups", value: "*", roles: ["group-member"]}
-```
-</TabItem>
-<TabItem label="SAML (Enterprise)">
-```yaml
-kind: saml
-version: v2
-metadata:
-  name: okta
-spec:
-  acs: https://tele.example.com/v1/webapi/saml/acs
-  attributes_to_roles:
-  - {name: "groups", value: "*", roles: ["group-member"]}
-  entity_descriptor: |
-    <?xml !!! Make sure to indent all lines in XML descriptor 
-    with 4 spaces, otherwise things will not work
-```
-</TabItem>
+  <TabItem label="Github (OSS)">
+    ```yaml
+    kind: github
+    version: v3
+    metadata:
+      # connector name that will be used with `tsh --auth=github login`
+      name: github
+    spec:
+      # client ID of Github OAuth app
+      client_id: client-id
+      # client secret of Github OAuth app
+      client_secret: client-secret
+      # This name will be shown on UI login screen
+      display: Github
+      # Change tele.example.com to your domain name
+      redirect_url: https://tele.example.com:443/v1/webapi/github/callback
+      # Map github teams to kubernetes groups
+      teams_to_logins:
+        - organization: octocats # Github organization name
+          team: admin            # Github team name within that organization
+          # list of Kubernetes groups this Github team is allowed to connect to
+          # keep this field as is for now
+          logins: ["admins"]
+    ```
+  </TabItem>
+
+  <TabItem label="OIDC (Enterprise)">
+    ```yaml
+    kind: oidc
+    version: v2
+    metadata:
+      name: auth0
+    spec:
+      redirect_url: https://tele.example.com/v1/webapi/oidc/callback
+      client_id: client-id-here
+      client_secret: client-secret-here
+      issuer_url: https://idp.example.com/
+      # request groups scope from OIDC provider
+      # read more about scopes here https://auth0.com/docs/scopes/openid-connect-scopes
+      scope: [groups]
+      claims_to_roles:
+        - {claim: "groups", value: "*", roles: ["group-member"]}
+    ```
+  </TabItem>
+
+  <TabItem label="SAML (Enterprise)">
+    ```yaml
+    kind: saml
+    version: v2
+    metadata:
+      name: okta
+    spec:
+      acs: https://tele.example.com/v1/webapi/saml/acs
+      attributes_to_roles:
+      - {name: "groups", value: "*", roles: ["group-member"]}
+      entity_descriptor: |
+        <?xml !!! Make sure to indent all lines in XML descriptor 
+        with 4 spaces, otherwise things will not work
+    ```
+  </TabItem>
 </Tabs>
 
 ## Local Users
 
 Local users are mapped to Kubernetes groups using roles:
 
-``` bash
+```bash
 # Specify `kubernetes_groups` property in a role "admins" and
 # create a user assigned to the role.
 $ tctl users add joe --roles="admins"
@@ -200,24 +203,25 @@ $ tctl users add joe --roles="admins"
 Label each cluster with key value pairs describing the cluster:
 
 <Tabs>
-<TabItem label="Helm">
-```bash
-# install or upgrade the agent or cluster and set labels:
-$ helm upgrade teleport-agent teleport-kube-agent --set kubeClusterName={CLUSTER?}\
-    --set proxyAddr=${PROXY?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent\
-    --set labels.env=prod --set labels.region=us-west-1
-```
-</TabItem>
-<TabItem label="Config">
-```yaml
-kubernetes_service:
-  enabled: true
-  kube_cluster_name: cookie
-  labels:
-    env: prod
-    region: us-west-1
-```
-</TabItem>
+  <TabItem label="Helm">
+    ```bash
+    # install or upgrade the agent or cluster and set labels:
+    $ helm upgrade teleport-agent teleport-kube-agent --set kubeClusterName={CLUSTER?}\
+        --set proxyAddr=${PROXY?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent\
+        --set labels.env=prod --set labels.region=us-west-1
+    ```
+  </TabItem>
+
+  <TabItem label="Config">
+    ```yaml
+    kubernetes_service:
+      enabled: true
+      kube_cluster_name: cookie
+      labels:
+        env: prod
+        region: us-west-1
+    ```
+  </TabItem>
 </Tabs>
 
 Limit access to cluster based on the label:
@@ -284,7 +288,7 @@ subjects:
   namespace: default
 ```
 
-Take a look at the example usage in a [Teleport Helm chart](https://github.com/gravitational/teleport/blob/v(=teleport.version=)/examples/chart/teleport-cluster/templates/clusterrole.yaml)
+Take a look at the example usage in a [Teleport Helm chart](https://github.com/gravitational/teleport/blob/v\(=teleport.version=\)/examples/chart/teleport-cluster/templates/clusterrole.yaml)
 
 ## Next Steps
 

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -97,7 +97,7 @@ access: {"env": ["prod", "staging"]}
 ```
 
 Teleport's roles map OIDC claims or SAML attributes using template variables.
-Template variable `{% raw %}{{external.groups}}{% endraw %}` will
+Template variable `{{external.groups}}` will
 be substituted to the users's group list in the role definition.
 
 ```yaml
@@ -111,9 +111,9 @@ spec:
     # for Kubernetes to work until we fix it.
     logins: ['keep-this-value-here']
     # For Alice, will be substituted with the list ["admins", "devs"]
-    kubernetes_groups: ["{% raw %}{{external.groups}}{% endraw %}"]
+    kubernetes_groups: ["{{external.groups}}"]
     # For Alice, will be substituted with ["alice@example.com"]
-    kubernetes_users: ["{% raw %}{{external.email}}{% endraw %}"]
+    kubernetes_users: ["{{external.email}}"]
 ```
 
 Create or update this role using `tctl`:
@@ -284,7 +284,7 @@ subjects:
   namespace: default
 ```
 
-Take a look at the example usage in a [Teleport Helm chart](https://github.com/gravitational/teleport/blob/v{{teleport_version}}/examples/chart/teleport-cluster/templates/clusterrole.yaml)
+Take a look at the example usage in a [Teleport Helm chart](https://github.com/gravitational/teleport/blob/v(=teleport.version=)/examples/chart/teleport-cluster/templates/clusterrole.yaml)
 
 ## Next Steps
 

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -210,16 +210,16 @@ For other install options, check out [install guide](../installation.mdx)
 <Tabs>
 <TabItem label="Open Source">
 ```bash
-$ curl -L -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
 $ sudo mv teleport/tsh /usr/local/bin/tsh
 $ sudo mv teleport/tctl /usr/local/bin/tctl
 ```
 </TabItem>
 <TabItem label="Enterprise">
 ```bash
-$ curl -L -O https://get.gravitational.com/teleport-ent-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-ent-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+$ curl -L -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
 $ sudo mv teleport/tsh /usr/local/bin/tsh
 $ sudo mv teleport/tctl /usr/local/bin/tctl
 ```

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -43,116 +43,118 @@ Server Version: version.Info{Major:"1", Minor:"17+"}
 Let's start with a single-pod Teleport using persistent volume as a backend.
 
 <Tabs>
-<TabItem label="Open Source">
-```bash
-$ helm repo add teleport https://charts.releases.teleport.dev
+  <TabItem label="Open Source">
+    ```bash
+    $ helm repo add teleport https://charts.releases.teleport.dev
 
-# Install a single node teleport cluster and provision a cert using ACME.
-# Set clusterName to unique hostname, for example tele.example.com
-# Set acmeEmail to receive correspondence from Letsencrypt certificate authority.
-$ helm install teleport-cluster teleport/teleport-cluster --create-namespace --namespace=teleport-cluster \
-  --set clusterName=${CLUSTER_NAME?} --set acme=true --set acmeEmail=${EMAIL?}
-```
-</TabItem>
-<TabItem label="Enterprise">
-```bash
-$ helm repo add teleport https://charts.releases.teleport.dev
+    # Install a single node teleport cluster and provision a cert using ACME.
+    # Set clusterName to unique hostname, for example tele.example.com
+    # Set acmeEmail to receive correspondence from Letsencrypt certificate authority.
+    $ helm install teleport-cluster teleport/teleport-cluster --create-namespace --namespace=teleport-cluster \
+      --set clusterName=${CLUSTER_NAME?} --set acme=true --set acmeEmail=${EMAIL?}
+    ```
+  </TabItem>
 
-# Create a namespace for a deployment.
-$ kubectl create namespace teleport-cluster-ent
+  <TabItem label="Enterprise">
+    ```bash
+    $ helm repo add teleport https://charts.releases.teleport.dev
 
-# Set kubectl context to the namespace to save some typing
-$ kubectl config set-context --current --namespace=teleport-cluster-ent
+    # Create a namespace for a deployment.
+    $ kubectl create namespace teleport-cluster-ent
 
-# Get a license from Teleport and create a secret "license" in the namespace teleport-cluster-ent
-$ kubectl -n teleport-cluster-ent create secret generic license --from-file=license-enterprise.pem
+    # Set kubectl context to the namespace to save some typing
+    $ kubectl config set-context --current --namespace=teleport-cluster-ent
 
-# Install Teleport
-$ helm install teleport-cluster teleport/teleport-cluster --namespace=teleport-cluster-ent \
-  --set clusterName=${CLUSTER_NAME?} --set acme=true --set acmeEmail=${EMAIL?} --set enterprise=true
-```
-</TabItem>
+    # Get a license from Teleport and create a secret "license" in the namespace teleport-cluster-ent
+    $ kubectl -n teleport-cluster-ent create secret generic license --from-file=license-enterprise.pem
+
+    # Install Teleport
+    $ helm install teleport-cluster teleport/teleport-cluster --namespace=teleport-cluster-ent \
+      --set clusterName=${CLUSTER_NAME?} --set acme=true --set acmeEmail=${EMAIL?} --set enterprise=true
+    ```
+  </TabItem>
 </Tabs>
 
 Teleport's helm chart uses an [external load balancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/)
 to create a public IP for Teleport.
 
 <Tabs>
-<TabItem label="Open Source">
-```bash
-# Set kubectl context to the namespace to save some typing
-$ kubectl config set-context --current --namespace=teleport-cluster
+  <TabItem label="Open Source">
+    ```bash
+    # Set kubectl context to the namespace to save some typing
+    $ kubectl config set-context --current --namespace=teleport-cluster
 
-# Service is up, load balancer is created
-$ kubectl get services
-NAME               TYPE           CLUSTER-IP   EXTERNAL-IP      PORT(S)                        AGE
-teleport-cluster   LoadBalancer   10.4.4.73    104.199.126.88   443:31204/TCP,3026:32690/TCP   89s
+    # Service is up, load balancer is created
+    $ kubectl get services
+    NAME               TYPE           CLUSTER-IP   EXTERNAL-IP      PORT(S)                        AGE
+    teleport-cluster   LoadBalancer   10.4.4.73    104.199.126.88   443:31204/TCP,3026:32690/TCP   89s
 
-# Save the pod IP. If the IP is not available, check the pod and load balancer status.
-$ MYIP=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-$ echo $MYIP
-192.168.2.1
-```
-</TabItem>
-<TabItem label="Enterprise">
-```bash
-# Set kubectl context to the namespace to set some typing
-$ kubectl config set-context --current --namespace=teleport-cluster-ent
+    # Save the pod IP. If the IP is not available, check the pod and load balancer status.
+    $ MYIP=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    $ echo $MYIP
+    192.168.2.1
+    ```
+  </TabItem>
 
-# Service is up, load balancer is created
-$ kubectl get services
-NAME                   TYPE           CLUSTER-IP   EXTERNAL-IP      PORT(S)                        AGE
-teleport-cluster-ent   LoadBalancer   10.4.4.73    104.199.126.88   443:31204/TCP,3026:32690/TCP   89s
+  <TabItem label="Enterprise">
+    ```bash
+    # Set kubectl context to the namespace to set some typing
+    $ kubectl config set-context --current --namespace=teleport-cluster-ent
 
-# Save the pod IP. If the IP is not available, check the pod and load balancer status.
-$ MYIP=$(kubectl get services teleport-cluster-ent -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-$ echo $MYIP
-192.168.2.1
-```
-</TabItem>
+    # Service is up, load balancer is created
+    $ kubectl get services
+    NAME                   TYPE           CLUSTER-IP   EXTERNAL-IP      PORT(S)                        AGE
+    teleport-cluster-ent   LoadBalancer   10.4.4.73    104.199.126.88   443:31204/TCP,3026:32690/TCP   89s
+
+    # Save the pod IP. If the IP is not available, check the pod and load balancer status.
+    $ MYIP=$(kubectl get services teleport-cluster-ent -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    $ echo $MYIP
+    192.168.2.1
+    ```
+  </TabItem>
 </Tabs>
-
 
 Set up two `A` DNS records - `tele.example.com` for UI and `*.tele.example.com`
 for web apps using [application access](../application-access.mdx).
 
 <Tabs>
-<TabItem label="GCP Cloud DNS">
-```bash
-$ MYZONE="myzone"
-$ MYDNS="tele.example.com"
+  <TabItem label="GCP Cloud DNS">
+    ```bash
+    $ MYZONE="myzone"
+    $ MYDNS="tele.example.com"
 
-$ gcloud dns record-sets transaction start --zone="${MYZONE?}"
-$ gcloud dns record-sets transaction add ${MYIP?} --name="${MYDNS?}" --ttl="30" --type="A" --zone="${MYZONE?}"
-$ gcloud dns record-sets transaction add ${MYIP?} --name="*.${MYDNS?}" --ttl="30" --type="A" --zone="${MYZONE?}"
-$ gcloud dns record-sets transaction describe --zone="${MYZONE?}"
-$ gcloud dns record-sets transaction execute --zone="${MYZONE?}"
-```
-</TabItem>
-<TabItem label="AWS Route 53">
-```bash
-# Tip for finding AWS zone id by the domain name.
-$ MYZONE_DNS="example.com"
-$ MYZONE=$(aws route53 list-hosted-zones-by-name --dns-name=${MYZONE_DNS?} | jq -r '.HostedZones[0].Id' | sed s_/hostedzone/__)
+    $ gcloud dns record-sets transaction start --zone="${MYZONE?}"
+    $ gcloud dns record-sets transaction add ${MYIP?} --name="${MYDNS?}" --ttl="30" --type="A" --zone="${MYZONE?}"
+    $ gcloud dns record-sets transaction add ${MYIP?} --name="*.${MYDNS?}" --ttl="30" --type="A" --zone="${MYZONE?}"
+    $ gcloud dns record-sets transaction describe --zone="${MYZONE?}"
+    $ gcloud dns record-sets transaction execute --zone="${MYZONE?}"
+    ```
+  </TabItem>
 
-$ MYDNS="tele.example.com"
+  <TabItem label="AWS Route 53">
+    ```bash
+    # Tip for finding AWS zone id by the domain name.
+    $ MYZONE_DNS="example.com"
+    $ MYZONE=$(aws route53 list-hosted-zones-by-name --dns-name=${MYZONE_DNS?} | jq -r '.HostedZones[0].Id' | sed s_/hostedzone/__)
 
-# Create a JSON file changeset for AWS.
-$ jq -n --arg ip ${MYIP?} --arg dns ${MYDNS?} '{"Comment": "Create records", "Changes": [
-  {"Action": "CREATE", "ResourceRecordSet": {"Name": $dns, "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}},
-  {"Action": "CREATE", "ResourceRecordSet": {"Name": ("*." + $dns), "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}}
-  ]}' > myrecords.json
+    $ MYDNS="tele.example.com"
 
-# Review records before applying.
-$ cat myrecords.json | jq
-# Apply the records and capture change id
-$ CHANGEID=$(aws route53 change-resource-record-sets --hosted-zone-id ${MYZONE?} --change-batch file://myrecords.json | jq -r '.ChangeInfo.Id')
+    # Create a JSON file changeset for AWS.
+    $ jq -n --arg ip ${MYIP?} --arg dns ${MYDNS?} '{"Comment": "Create records", "Changes": [
+      {"Action": "CREATE", "ResourceRecordSet": {"Name": $dns, "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}},
+      {"Action": "CREATE", "ResourceRecordSet": {"Name": ("*." + $dns), "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}}
+      ]}' > myrecords.json
 
-# Verify that change has been applied
-$ aws route53 get-change --id ${CHANGEID?} | jq '.ChangeInfo.Status'
-"INSYNC"
-```
-</TabItem>
+    # Review records before applying.
+    $ cat myrecords.json | jq
+    # Apply the records and capture change id
+    $ CHANGEID=$(aws route53 change-resource-record-sets --hosted-zone-id ${MYZONE?} --change-batch file://myrecords.json | jq -r '.ChangeInfo.Id')
+
+    # Verify that change has been applied
+    $ aws route53 get-change --id ${CHANGEID?} | jq '.ChangeInfo.Status'
+    "INSYNC"
+    ```
+  </TabItem>
 </Tabs>
 
 The first request to Teleport's API will take a bit longer because it gets
@@ -208,22 +210,23 @@ Let's install `tsh` and `tctl` on Linux.
 For other install options, check out [install guide](../installation.mdx)
 
 <Tabs>
-<TabItem label="Open Source">
-```bash
-$ curl -L -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-$ sudo mv teleport/tsh /usr/local/bin/tsh
-$ sudo mv teleport/tctl /usr/local/bin/tctl
-```
-</TabItem>
-<TabItem label="Enterprise">
-```bash
-$ curl -L -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
-$ sudo mv teleport/tsh /usr/local/bin/tsh
-$ sudo mv teleport/tctl /usr/local/bin/tctl
-```
-</TabItem>
+  <TabItem label="Open Source">
+    ```bash
+    $ curl -L -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    $ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    $ sudo mv teleport/tsh /usr/local/bin/tsh
+    $ sudo mv teleport/tctl /usr/local/bin/tctl
+    ```
+  </TabItem>
+
+  <TabItem label="Enterprise">
+    ```bash
+    $ curl -L -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    $ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    $ sudo mv teleport/tsh /usr/local/bin/tsh
+    $ sudo mv teleport/tctl /usr/local/bin/tctl
+    ```
+  </TabItem>
 </Tabs>
 
 Try `tsh login` with a local user. Use a custom `KUBECONFIG` to prevent overwriting
@@ -260,106 +263,110 @@ teleport-cluster-6c9b88fd8f-glmhf   1/1     Running   0          127m
 We are going to setup Github connector for OSS and Okta for Enterprises version.
 
 <Tabs>
-<TabItem label="Open Source">
+  <TabItem label="Open Source">
+    Save the file below as `github.yaml` and update the fields. You will need to set up
+    [Github OAuth 2.0 Connector](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) app.
+    Any member belonging to the Github organization `octocats` and on team `admin` will be able to assume a built-in role `access`.
 
-Save the file below as `github.yaml` and update the fields. You will need to set up
-[Github OAuth 2.0 Connector](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) app.
-Any member belonging to the Github organization `octocats` and on team `admin` will be able to assume a built-in role `access`.
+    ```yaml
+    kind: github
+    version: v3
+    metadata:
+      # connector name that will be used with `tsh --auth=github login`
+      name: github
+    spec:
+      # client ID of Github OAuth app
+      client_id: client-id
+      # client secret of Github OAuth app
+      client_secret: client-secret
+      # This name will be shown on UI login screen
+      display: Github
+      # Change tele.example.com to your domain name
+      redirect_url: https://tele.example.com:443/v1/webapi/github/callback
+      # Map github teams to teleport roles
+      teams_to_logins:
+        - organization: octocats # Github organization name
+          team: admin            # Github team name within that organization
+          # map github admin team to Teleport's "access" role
+          logins: ["access"]
+    ```
+  </TabItem>
 
-```yaml
-kind: github
-version: v3
-metadata:
-  # connector name that will be used with `tsh --auth=github login`
-  name: github
-spec:
-  # client ID of Github OAuth app
-  client_id: client-id
-  # client secret of Github OAuth app
-  client_secret: client-secret
-  # This name will be shown on UI login screen
-  display: Github
-  # Change tele.example.com to your domain name
-  redirect_url: https://tele.example.com:443/v1/webapi/github/callback
-  # Map github teams to teleport roles
-  teams_to_logins:
-    - organization: octocats # Github organization name
-      team: admin            # Github team name within that organization
-      # map github admin team to Teleport's "access" role
-      logins: ["access"]
-```
-</TabItem>
-<TabItem label="Enterprise">
+  <TabItem label="Enterprise">
+    Follow [SAML Okta Guide](../enterprise/sso/ssh-okta.mdx#configure-okta) to create a SAML app.
+    Check out [OIDC guides](../enterprise/sso/oidc.mdx#identity-providers) for OpenID Connect apps.
+    Save the file below as `okta.yaml` and update the `acs` field.
+    Any member in Okta group `okta-admin` will assume a builtin role `admin`.
 
-Follow [SAML Okta Guide](../enterprise/sso/ssh-okta.mdx#configure-okta) to create a SAML app.
-Check out [OIDC guides](../enterprise/sso/oidc.mdx#identity-providers) for OpenID Connect apps.
-Save the file below as `okta.yaml` and update the `acs` field.
-Any member in Okta group `okta-admin` will assume a builtin role `admin`.
-
-```yaml
-kind: saml
-version: v2
-metadata:
-  name: okta
-spec:
-  acs: https://tele.example.com/v1/webapi/saml/acs
-  attributes_to_roles:
-  - {name: "groups", value: "okta-admin", roles: ["access"]}
-  entity_descriptor: |
-    <?xml !!! Make sure to shift all lines in XML descriptor
-    with 4 spaces, otherwise things will not work
-```
-</TabItem>
+    ```yaml
+    kind: saml
+    version: v2
+    metadata:
+      name: okta
+    spec:
+      acs: https://tele.example.com/v1/webapi/saml/acs
+      attributes_to_roles:
+      - {name: "groups", value: "okta-admin", roles: ["access"]}
+      entity_descriptor: |
+        <?xml !!! Make sure to shift all lines in XML descriptor
+        with 4 spaces, otherwise things will not work
+    ```
+  </TabItem>
 </Tabs>
 
 To create a connector, we are going to run Teleport's admin tool `tctl` from the pod.
 
 <Tabs>
-<TabItem label="Open Source">
-```bash
-# To create a Github connector, we are going to run Teleport's admin tool tctl from the pod.
-$ kubectl config set-context --current --namespace=teleport-cluster
-$ POD=$(kubectl get po -l app=teleport-cluster -o jsonpath='{.items[0].metadata.name}')
+  <TabItem label="Open Source">
+    ```bash
+    # To create a Github connector, we are going to run Teleport's admin tool tctl from the pod.
+    $ kubectl config set-context --current --namespace=teleport-cluster
+    $ POD=$(kubectl get po -l app=teleport-cluster -o jsonpath='{.items[0].metadata.name}')
 
-$ kubectl exec -i ${POD?} -- tctl create -f < github.yaml
-authentication connector "github" has been created
-```
-</TabItem>
-<TabItem label="Enterprise">
-```bash
-# To create an Okta connector, we are going to run Teleport's admin tool tctl from the pod.
-$ POD=$(kubectl get po -l app=teleport-cluster-ent -o jsonpath='{.items[0].metadata.name}')
+    $ kubectl exec -i ${POD?} -- tctl create -f < github.yaml
+    authentication connector "github" has been created
+    ```
+  </TabItem>
 
-$ kubectl exec -i ${POD?} -- tctl create -f < okta.yaml
-authentication connector 'okta' has been created
-```
-</TabItem>
+  <TabItem label="Enterprise">
+    ```bash
+    # To create an Okta connector, we are going to run Teleport's admin tool tctl from the pod.
+    $ POD=$(kubectl get po -l app=teleport-cluster-ent -o jsonpath='{.items[0].metadata.name}')
+
+    $ kubectl exec -i ${POD?} -- tctl create -f < okta.yaml
+    authentication connector 'okta' has been created
+    ```
+  </TabItem>
 </Tabs>
 
 Try `tsh login` with Github user. I am using a custom `KUBECONFIG` to prevent overwriting
 the default one in case there is a problem.
 
 <Tabs>
-<TabItem label="Open Source">
-```bash
-$ KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com:443 --auth=github
-```
-</TabItem>
-<TabItem label="Enterprise">
-```bash
-$ KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com:443 --auth=okta
-```
-</TabItem>
+  <TabItem label="Open Source">
+    ```bash
+    $ KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com:443 --auth=github
+    ```
+  </TabItem>
+
+  <TabItem label="Enterprise">
+    ```bash
+    $ KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com:443 --auth=okta
+    ```
+  </TabItem>
 </Tabs>
 
-<Admonition type="note" title="Debugging SSO">
-If you are getting a login error, take a look at the audit log for details:
+<Admonition
+  type="note"
+  title="Debugging SSO"
+>
+  If you are getting a login error, take a look at the audit log for details:
 
-```bash
-kubectl exec -ti "${POD?}" -- tail -n 100 /var/lib/teleport/log/events.log
+  ```bash
+  kubectl exec -ti "${POD?}" -- tail -n 100 /var/lib/teleport/log/events.log
 
-{"error":"user \"alice\" does not belong to any teams configured in \"github\" connector","method":"github","attributes":{"octocats":["devs"]}}
-```
+  {"error":"user \"alice\" does not belong to any teams configured in \"github\" connector","method":"github","attributes":{"octocats":["devs"]}}
+  ```
 </Admonition>
 
 ## Next Steps

--- a/docs/pages/kubernetes-access/guides/cicd.mdx
+++ b/docs/pages/kubernetes-access/guides/cicd.mdx
@@ -56,10 +56,13 @@ $ cat kubeconfig
 $ kubectl --kubeconfig /path/to/kubeconfig get pods
 ```
 
-<Admonition type="tip" title="Short-Lived Certs">
-Short lived certificates expire in hours or minutes. You don't have to revoke
-them if the host gets compromised.
-Generate a new kubeconfig every hour using `tctl` or [API](../../api-reference.mdx)
-and publish it to secret storage, like [AWS](https://aws.amazon.com/secrets-manager/) or
-[GCP](https://cloud.google.com/secret-manager) secret managers.
+<Admonition
+  type="tip"
+  title="Short-Lived Certs"
+>
+  Short lived certificates expire in hours or minutes. You don't have to revoke
+  them if the host gets compromised.
+  Generate a new kubeconfig every hour using `tctl` or [API](../../api-reference.mdx)
+  and publish it to secret storage, like [AWS](https://aws.amazon.com/secrets-manager/) or
+  [GCP](https://cloud.google.com/secret-manager) secret managers.
 </Admonition>

--- a/docs/pages/kubernetes-access/guides/federation.mdx
+++ b/docs/pages/kubernetes-access/guides/federation.mdx
@@ -27,7 +27,7 @@ For example, consider the following setup:
 
 In this scenario, users usually login using this command:
 
-``` bash
+```bash
 # Using login without arguments
 $ tsh --proxy=main.example.com login
 

--- a/docs/pages/kubernetes-access/guides/migration.mdx
+++ b/docs/pages/kubernetes-access/guides/migration.mdx
@@ -195,8 +195,7 @@ kubernetes_service:
 ```
 
 After all the Teleport agents are running, you can view the list of Kubernetes
-clusters using `tsh kube ls` and switch between them using `tsh kube login
-<kube_cluster_name>`:
+clusters using `tsh kube ls` and switch between them using `tsh kube login <kube_cluster_name>`:
 
 ```sh
 $ tsh kube ls

--- a/docs/pages/kubernetes-access/guides/migration.mdx
+++ b/docs/pages/kubernetes-access/guides/migration.mdx
@@ -349,10 +349,10 @@ metadata:
   name: admin
 spec:
   allow:
-    logins: ['{% raw %}{{internal.logins}}{% endraw %}']
+    logins: ['{{internal.logins}}']
     # Define the Kubernetes users and groups mapped to users with this role.
-    kubernetes_users: ["{% raw %}{{internal.kubernetes_users}}{% endraw %}"]
-    kubernetes_groups: ["some-group", "{% raw %}{{internal.kubernetes_groups}}{% endraw %}"]
+    kubernetes_users: ["{{internal.kubernetes_users}}"]
+    kubernetes_groups: ["some-group", "{{internal.kubernetes_groups}}"]
 
     # List of kubernetes labels a user will be allowed to connect to:
     kubernetes_labels:

--- a/docs/pages/metrics-logs-reference.mdx
+++ b/docs/pages/metrics-logs-reference.mdx
@@ -18,14 +18,11 @@ Now you can see the monitoring information by visiting several endpoints:
 - `http://127.0.0.1:3000/metrics` is the list of internal metrics Teleport is
   tracking. It is compatible with [Prometheus](https://prometheus.io/)
   collectors.
-
 - `http://127.0.0.1:3000/healthz` returns "OK" if the process is healthy or
   `503` otherwise.
-
 - `http://127.0.0.1:3000/readyz` is similar to `/healthz` , but it returns "OK"
   *only after* the node successfully joined the cluster, i.e.it draws the
   difference between "healthy" and "ready".
-
 - `http://127.0.0.1:3000/debug/pprof/` is Golang's standard profiler. It's only
   available when `-d` flag is given in addition to `--diag-addr`
 

--- a/docs/pages/openssh-teleport.mdx
+++ b/docs/pages/openssh-teleport.mdx
@@ -39,7 +39,6 @@ We consider the "recording proxy mode" to be less secure for two reasons:
   less critical to the security of the overall cluster. But if an attacker gains
   physical access to a proxy node running in the "recording" mode, they will be able
   to see the decrypted traffic and client keys stored in proxy's process memory.
-
 - Recording proxy mode requires the use of SSH agent forwarding. Agent forwarding is required
   because without it, a proxy will not be able to establish the 2nd connection to the
   destination node.
@@ -175,8 +174,8 @@ $ ssh -o "ForwardAgent yes" \
   type="tip"
   title="Tip"
 >
-  To avoid typing all this and use the usual `ssh user@host.example.com `, users
-  can update their ` ~/.ssh/config` file.
+  To avoid typing all this and use the usual `ssh user@host.example.com`, users
+  can update their `~/.ssh/config` file.
 </Admonition>
 
 ### Setup SSH agent forwarding

--- a/docs/pages/preview/upcoming-releases.mdx
+++ b/docs/pages/preview/upcoming-releases.mdx
@@ -40,10 +40,8 @@ They are not ready for production:
 
 - You can use alpha releases such as `5.0.1-alpha.1` for trying new features.
   Things can break and new changes may not be backwards-compatible.
-
 - Teleport `beta` releases, such as `5.0.1-beta.2` are suitable for staging environments.
   We are unlikely to change the APIs while we are ironing out bugs and UX glitches.
-
 - We mark release candidates as `5.0.1-rc.1` coding and bug fixes are finished.
   The team is going through the manual test plan to find any regressions.
 
@@ -53,7 +51,5 @@ Releases are ready for production use.
 
 - Releases `5.0.0` and `6.0.0` are major releases. We publish 4 major releases each year.
   Read more about upgrades and compatibility [here](../admin-guide.mdx#component-compatibility).
-
 - Releases `5.1.0` are minor releases. They contain minor backwards-compatible improvements and backports.
-
 - Versions like `5.0.1` are quick patches. They contain backwards-compatible fixes.

--- a/docs/pages/production.mdx
+++ b/docs/pages/production.mdx
@@ -80,7 +80,6 @@ There are a couple of important things to notice about this file:
 1. The start command in the unit file specifies `--config` as a file and there
    are very few flags passed to the `teleport` binary. Most of the configuration
    for Teleport should be done in the [configuration file](admin-guide.mdx#configuration).
-
 2. The **ExecReload** command allows admins to run `systemctl reload teleport`.
    This will attempt to perform a graceful restart of Teleport **but it only works if
    network-based backend storage like [DynamoDB](admin-guide.mdx#using-dynamodb) or

--- a/docs/pages/quickstart-docker.mdx
+++ b/docs/pages/quickstart-docker.mdx
@@ -28,10 +28,10 @@ easily keep your Teleport installation up to date.
 
 | Image name | Teleport version | Image automatically updated? | Image base |
 | - | - | - | - |
-| `quay.io/gravitational/teleport:{{ version }}` | The latest version of Teleport Community {{ version }} | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport:{{ teleport.version }}` | The version specified in the image's tag (i.e. {{ teleport.version }}) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport:(=version=)` | The latest version of Teleport Community (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport:(=teleport.version=)` | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
 
-For testing, we always recommend that you use the latest release version of Teleport, which is currently `{{teleport.latest_oss_docker_image}}`.
+For testing, we always recommend that you use the latest release version of Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
 
 ## Quickstart using docker-compose
 
@@ -69,14 +69,14 @@ mkdir -p ~/teleport/config ~/teleport/data
 docker run --hostname localhost --rm \
   --entrypoint=/bin/sh \
   -v ~/teleport/config:/etc/teleport \
-  {{teleport.latest_oss_docker_image}} -c "teleport configure > /etc/teleport/teleport.yaml"
+  (=teleport.latest_oss_docker_image=) -c "teleport configure > /etc/teleport/teleport.yaml"
 
 # start teleport with mounted config and data directories, plus all ports
 docker run --hostname localhost --name teleport \
   -v ~/teleport/config:/etc/teleport \
   -v ~/teleport/data:/var/lib/teleport \
   -p 3023:3023 -p 3025:3025 -p 3080:3080 \
-  {{teleport.latest_oss_docker_image}}
+  (=teleport.latest_oss_docker_image=)
 ```
 
 ## Creating a Teleport user when using Docker quickstart

--- a/docs/pages/quickstart-docker.mdx
+++ b/docs/pages/quickstart-docker.mdx
@@ -6,12 +6,12 @@ h1: Run Teleport using Docker
 
 We provide pre-built Docker images for every version of Teleport. These images are hosted on quay.io.
 
-- [All tags under `quay.io/gravitational/teleport` are Teleport Community images](https://quay.io/repository/gravitational/teleport?tag=latest&tab=tags)
+- [All tags under `quay.io/gravitational/teleport` are Teleport Community images](https://quay.io/repository/gravitational/teleport?tag=latest\&tab=tags)
 
 We currently only offer Docker images for `x86_64` architectures.
 
 <Admonition type="note">
-  You will need a recent version of [Docker](https://hub.docker.com/search?q=&type=edition&offering=community) installed to follow this section of the quick start guide.
+  You will need a recent version of [Docker](https://hub.docker.com/search?q=\&type=edition\&offering=community) installed to follow this section of the quick start guide.
 </Admonition>
 
 <Admonition type="warning">
@@ -28,8 +28,8 @@ easily keep your Teleport installation up to date.
 
 | Image name | Teleport version | Image automatically updated? | Image base |
 | - | - | - | - |
-| `quay.io/gravitational/teleport:(=version=)` | The latest version of Teleport Community (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport:(=teleport.version=)` | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport:(=version=)` | The latest version of Teleport Community (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `quay.io/gravitational/teleport:(=teleport.version=)` | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
 
 For testing, we always recommend that you use the latest release version of Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
 

--- a/docs/pages/trustedclusters.mdx
+++ b/docs/pages/trustedclusters.mdx
@@ -88,11 +88,9 @@ This setup works as follows:
 
 1. The "leaf" creates an outbound reverse SSH tunnel to "root" and keeps the
    tunnel open.
-
 2. **Accessibility only works in one direction.** The "leaf" cluster allows
    users from "root" to access its nodes but users in the "leaf" cluster can not
    access the "root" cluster.
-
 3. When a user tries to connect to a node inside "leaf" using root's proxy, the
    reverse tunnel from step 1 is used to establish this connection shown as the
    green line above.
@@ -265,7 +263,6 @@ Lets make a few assumptions for this example:
 
 - The cluster "root" has two roles: *user* for regular users and *admin* for
   local administrators.
-
 - We want administrators from "root" (but not regular users!) to have
   restricted access to "leaf". We want to deny them access to machines
   with "environment=production" and any Government cluster labeled "customer=gov"

--- a/docs/pages/trustedclusters.mdx
+++ b/docs/pages/trustedclusters.mdx
@@ -516,15 +516,15 @@ role_map:
 The role `admin` of the leaf cluster can now be set up to use the root cluster role logins and `kubernetes_groups` using the following variables:
 
 ```yaml
-logins: ["{% raw %}{{internal.logins}}{% endraw %}"]
-kubernetes_groups: ["{% raw %}{{internal.kubernetes_groups}}{% endraw %}"]
+logins: ["{{internal.logins}}"]
+kubernetes_groups: ["{{internal.kubernetes_groups}}"]
 ```
 
 <Admonition
   type="tip"
   title="Note"
 >
-  In order to pass logins from a root trusted cluster to a leaf cluster, you must use the variable `{% raw %}{{internal.logins}}{% endraw %}`.
+  In order to pass logins from a root trusted cluster to a leaf cluster, you must use the variable `{{internal.logins}}`.
 </Admonition>
 
 ## How does it work?

--- a/docs/pages/user-manual.mdx
+++ b/docs/pages/user-manual.mdx
@@ -514,7 +514,6 @@ most of them can be mitigated.
    cluster you are connecting to. But if you execute `tsh --proxy=xxx login`,
    the current proxy will be saved in your `~/.tsh` profile and won't be needed
    for other `tsh` commands.
-
 2. `tsh ssh` operates *two* usernames: one for the cluster and another for the
    node you are trying to log into. See [User Identities](#user-identities)
    section below. For convenience, `tsh` assumes `$USER` for both by default.


### PR DESCRIPTION
DO NOT MERGE

PR to show and discuss syntax and remark changes. We can still change syntax to something else having with below restrictions in mind.

First commit:

- Changed variables syntax: `{{variable}}`, `(=variable=)`. (Had to select syntax without `<>`, `{}` and `[]` to prevent conflicts with existing syntaxes).
- Changed include syntax from `{! CHANGELOG.mdx !}` to `(! CHANGELOG.mdx !)` same reasons as above.
- Removed `{% raw %}` and `{% endraw %}` syntax.

Second commit:

- Updated remark parser and rerun `markdown-fix` task. New parser reeeeally like to escape symbols that can have double meaning now. Can revert it if we are ok with fixing errors manually instead of automated fixing.