### PR TITLE
Backport: tsh: handle missing cluster name in profile (#6257)

### DIFF
--- a/api/client/profile.go
+++ b/api/client/profile.go
@@ -247,6 +247,13 @@ func profileFromFile(filePath string) (*Profile, error) {
 		return nil, trace.Wrap(err)
 	}
 	p.Dir = filepath.Dir(filePath)
+
+	// Older versions of tsh did not always store the cluster name in the
+	// profile. If no cluster name is found, fallback to the name of the profile
+	// for backward compatibility.
+	if p.SiteName == "" {
+		p.SiteName = p.Name()
+	}
 	return p, nil
 }
 

--- a/api/client/profile_test.go
+++ b/api/client/profile_test.go
@@ -44,6 +44,7 @@ func TestProfileBasics(t *testing.T) {
 		ForwardedPorts:        []string{"8000:example.com:8000"},
 		DynamicForwardedPorts: []string{"localhost:8080"},
 		Dir:                   dir,
+		SiteName:              "example.com",
 	}
 
 	// verify that profile name is proxy host component

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -555,17 +555,6 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 	}
 	sort.Strings(extensions)
 
-	// Extract cluster name from the profile.
-	clusterName := profile.SiteName
-	// DELETE IN: 4.2.0.
-	//
-	// Older versions of tsh did not always store the cluster name in the
-	// profile. If no cluster name is found, fallback to the name of the profile
-	// for backward compatibility.
-	if clusterName == "" {
-		clusterName = profile.Name()
-	}
-
 	tlsCert, err := key.TeleportTLSCertificate()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -617,7 +606,7 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 		ValidUntil:     validUntil,
 		Extensions:     extensions,
 		Roles:          roles,
-		Cluster:        clusterName,
+		Cluster:        profile.SiteName,
 		Traits:         traits,
 		ActiveRequests: activeRequests,
 		KubeEnabled:    profile.KubeProxyAddr != "",

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1928,6 +1928,11 @@ func onStatus(cf *CLIConf) error {
 }
 
 func printProfiles(debug bool, profile *client.ProfileStatus, profiles []*client.ProfileStatus) {
+	if profile == nil && len(profiles) == 0 {
+		fmt.Printf("Not logged in.\n")
+		return
+	}
+
 	// Print the active profile.
 	if profile != nil {
 		printStatus(debug, profile, true)


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/6257 into v6

Cluster name can be missing in profiles created by older tsh versions.
Trying to load the client.Key without a cluster name now causes a
failure when using WithAllCerts (because ssh/db/kube certs are
per-cluster).

Also added some output to `tsh status` when no profiles can be loaded.