### PR TITLE
[6.1] Backport - Close leaky directClient (#6297)

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -796,9 +796,12 @@ func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity 
 	// Try and connect to the Auth Server. If the request fails, try and
 	// connect through a tunnel.
 	process.log.Debugf("Attempting to connect to Auth Server directly.")
-	_, err = directClient.GetLocalClusterName()
-	if err != nil {
+	if _, err = directClient.GetLocalClusterName(); err != nil {
 		process.log.WithError(err).Warn("Failed to connect to Auth Server directly.")
+		if err := directClient.Close(); err != nil {
+			process.log.WithError(err).Warn("Failed to close direct Auth Server client.")
+		}
+
 		// Don't attempt to connect through a tunnel as a proxy or auth server.
 		if identity.ID.Role == teleport.RoleAuth || identity.ID.Role == teleport.RoleProxy {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
#6297 