### PR TITLE
Add DialOpts and CallOpts to API client.

### DIFF
--- a/api/client/auditstreamer.go
+++ b/api/client/auditstreamer.go
@@ -32,7 +32,8 @@ import (
 // createOrResumeAuditStream creates or resumes audit stream described in the request.
 func (c *Client) createOrResumeAuditStream(ctx context.Context, request proto.AuditStreamRequest) (events.Stream, error) {
 	closeCtx, cancel := context.WithCancel(ctx)
-	stream, err := c.grpc.CreateAuditStream(closeCtx, grpc.UseCompressor(ggzip.Name))
+	callOpts := append(c.callOpts, grpc.UseCompressor(ggzip.Name))
+	stream, err := c.grpc.CreateAuditStream(closeCtx, callOpts...)
 	if err != nil {
 		cancel()
 		return nil, trail.FromGRPC(err)

--- a/api/client/keepaliver.go
+++ b/api/client/keepaliver.go
@@ -32,7 +32,7 @@ import (
 // returned value to release the keepAliver resources.
 func (c *Client) NewKeepAliver(ctx context.Context) (types.KeepAliver, error) {
 	cancelCtx, cancel := context.WithCancel(ctx)
-	stream, err := c.grpc.SendKeepAlives(cancelCtx)
+	stream, err := c.grpc.SendKeepAlives(cancelCtx, c.callOpts...)
 	if err != nil {
 		cancel()
 		return nil, trail.FromGRPC(err)

--- a/api/client/sessions.go
+++ b/api/client/sessions.go
@@ -40,7 +40,7 @@ func (c *Client) WebSessions() types.WebSessionInterface {
 
 // Get returns the web session for the specified request
 func (r *webSessions) Get(ctx context.Context, req types.GetWebSessionRequest) (types.WebSession, error) {
-	resp, err := r.c.grpc.GetWebSession(ctx, &req)
+	resp, err := r.c.grpc.GetWebSession(ctx, &req, r.c.callOpts...)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -49,7 +49,7 @@ func (r *webSessions) Get(ctx context.Context, req types.GetWebSessionRequest) (
 
 // List returns the list of all web sessions
 func (r *webSessions) List(ctx context.Context) ([]types.WebSession, error) {
-	resp, err := r.c.grpc.GetWebSessions(ctx, &empty.Empty{})
+	resp, err := r.c.grpc.GetWebSessions(ctx, &empty.Empty{}, r.c.callOpts...)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -67,7 +67,7 @@ func (r *webSessions) Upsert(ctx context.Context, session types.WebSession) erro
 
 // Delete deletes the web session specified with the request
 func (r *webSessions) Delete(ctx context.Context, req types.DeleteWebSessionRequest) error {
-	_, err := r.c.grpc.DeleteWebSession(ctx, &req)
+	_, err := r.c.grpc.DeleteWebSession(ctx, &req, r.c.callOpts...)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -76,7 +76,7 @@ func (r *webSessions) Delete(ctx context.Context, req types.DeleteWebSessionRequ
 
 // DeleteAll deletes all web sessions
 func (r *webSessions) DeleteAll(ctx context.Context) error {
-	_, err := r.c.grpc.DeleteAllWebSessions(ctx, &empty.Empty{})
+	_, err := r.c.grpc.DeleteAllWebSessions(ctx, &empty.Empty{}, r.c.callOpts...)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -100,7 +100,7 @@ func (c *Client) WebTokens() types.WebTokenInterface {
 
 // Get returns the web token for the specified request
 func (r *webTokens) Get(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
-	resp, err := r.c.grpc.GetWebToken(ctx, &req)
+	resp, err := r.c.grpc.GetWebToken(ctx, &req, r.c.callOpts...)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -109,7 +109,7 @@ func (r *webTokens) Get(ctx context.Context, req types.GetWebTokenRequest) (type
 
 // List returns the list of all web tokens
 func (r *webTokens) List(ctx context.Context) ([]types.WebToken, error) {
-	resp, err := r.c.grpc.GetWebTokens(ctx, &empty.Empty{})
+	resp, err := r.c.grpc.GetWebTokens(ctx, &empty.Empty{}, r.c.callOpts...)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -127,7 +127,7 @@ func (r *webTokens) Upsert(ctx context.Context, token types.WebToken) error {
 
 // Delete deletes the web token specified with the request
 func (r *webTokens) Delete(ctx context.Context, req types.DeleteWebTokenRequest) error {
-	_, err := r.c.grpc.DeleteWebToken(ctx, &req)
+	_, err := r.c.grpc.DeleteWebToken(ctx, &req, r.c.callOpts...)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -136,7 +136,7 @@ func (r *webTokens) Delete(ctx context.Context, req types.DeleteWebTokenRequest)
 
 // DeleteAll deletes all web tokens
 func (r *webTokens) DeleteAll(ctx context.Context) error {
-	_, err := r.c.grpc.DeleteAllWebTokens(ctx, &empty.Empty{})
+	_, err := r.c.grpc.DeleteAllWebTokens(ctx, &empty.Empty{}, r.c.callOpts...)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}

--- a/api/client/streamwatcher.go
+++ b/api/client/streamwatcher.go
@@ -34,7 +34,7 @@ func (c *Client) NewWatcher(ctx context.Context, watch types.Watch) (types.Watch
 	for _, kind := range watch.Kinds {
 		protoWatch.Kinds = append(protoWatch.Kinds, proto.FromWatchKind(kind))
 	}
-	stream, err := c.grpc.WatchEvents(cancelCtx, &protoWatch)
+	stream, err := c.grpc.WatchEvents(cancelCtx, &protoWatch, c.callOpts...)
 	if err != nil {
 		cancel()
 		return nil, trail.FromGRPC(err)


### PR DESCRIPTION
Changes:
 - Added `client.Config.DialOpts`.
 - Added `client.callOpts` which can be used through `WithCallOptions`. I chose this route for a few reasons:
   - It's a pretty clean way to give the ability to set call options without cluttering each request with an extra parameter.
   - Adding a `CallOptions` parameter to each requests break the `auth.ClientI` interface, which makes it more work than it's worth.
   - The main issue is that it makes a shallow copy of the client, which shares a connection and other fields. However this isn't problem if just use this for chaining (as inteded), which will cause the copy to get garbage collected after the call. 

Fixes #6276