### PR TITLE
v5.0 syntax update

### DIFF
--- a/docs/pages/admin-guide.mdx
+++ b/docs/pages/admin-guide.mdx
@@ -295,11 +295,9 @@ connector. There are three possible values (types) of 2FA:
 - `otp` is the default. It implements [TOTP](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
   standard. You can use [Google Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator)
   or [Authy](https://www.authy.com/) or any other TOTP client.
-
-- `u2f` implements [U2F](https://en.wikipedia.org/wiki/Universal_2nd_Factor)
+- `u2f` implements [U2F](https://en.wikipedia.org/wiki/Universal\_2nd_Factor)
   standard for utilizing hardware (USB) keys for second factor. You can use [YubiKeys](https://www.yubico.com/),
   [SoloKeys](https://solokeys.com/) or any other hardware token which implements the FIDO U2F standard.
-
 - `off` turns off second factor authentication.
 
 Here is an example of this setting in the `teleport.yaml` :
@@ -361,7 +359,6 @@ hardware keys as a second authentication factor. By default U2F is disabled. To
 start using U2F:
 
 - Enable U2F in Teleport configuration `/etc/teleport.yaml` .
-
 - For web-based logins, check that your browser [supports
   U2F](https://caniuse.com/u2f).
 
@@ -749,7 +746,6 @@ two kinds of labels:
 1. `static labels` do not change over time, while [`teleport`](cli-docs.mdx#teleport)
    process is running.  Examples of static labels are physical location of nodes,
    name of the environment (staging vs production), etc.
-
 2. `dynamic labels` also known as "label commands" allow to generate labels at
    runtime. Teleport will execute an external command on a node at a configurable
    frequency and the output of a command becomes the label value. Examples include
@@ -810,7 +806,7 @@ app_service:
 
 `/path/to/executable` must be a valid executable command (i.e. executable bit
 must be set) which also includes shell scripts with a proper [shebang
-line](https://en.wikipedia.org/wiki/Shebang_(Unix)).
+line](https://en.wikipedia.org/wiki/Shebang_\(Unix\)).
 
 **Important:** notice that `command` setting is an array where the first element
 is a valid executable and each subsequent element is an argument, i.e:
@@ -834,11 +830,9 @@ the audit log:
 
 1. **SSH Events:** Teleport logs events like successful user logins along with
    the metadata like remote IP address, time and the session ID.
-
 2. **Recorded Sessions:** Every SSH shell session is recorded and can be
    replayed later. The recording is done by the nodes themselves, by default,
    but can be configured to be done by the proxy.
-
 3. **Optional: [Enhanced Session Recording](features/enhanced-session-recording.mdx)**
 
 Refer to the ["Audit Log" chapter in the Teleport
@@ -940,7 +934,6 @@ The recorded sessions are stored as raw bytes in the `sessions` directory under
 1. `.bytes` file or `.chunks.gz` compressed format represents the raw session bytes and is somewhat
    human-readable, although you are better off using [`tsh
    play`](cli-docs.mdx#tsh-play) or the Web UI to replay it.
-
 2. `.log` file or `.events.gz` compressed file contains the copies of the event log entries that are            related to this session.
 
 ```bash
@@ -961,10 +954,8 @@ A Teleport administrator has two tools to configure a Teleport cluster:
 
 - The [configuration file](#configuration) is used for static configuration like
   the cluster name.
-
 - The [`tctl`](cli-docs.mdx#tctl) admin tool is used for manipulating dynamic
-  records like Teleport
-  users.
+  records like Teleport users.
 
 [`tctl`](cli-docs.mdx#tctl) has convenient subcommands for dynamic
 configuration, like `tctl users` or `tctl nodes` . However, for dealing with
@@ -1352,8 +1343,6 @@ do this:
 - Use a load balancer to create a single auth API access point (AP) and
   specify this AP in `auth_servers` section of Teleport configuration for all
   nodes in a cluster. This load balancer should do TCP level forwarding.
-
-
 - If a load balancer is not an option, you must specify each instance of an
   auth server in `auth_servers` section of Teleport configuration.
 
@@ -1807,15 +1796,12 @@ teleport:
 
 - Replace `Example_GCP_Project_Name` and `Example_TELEPORT_FIRESTORE_TABLE_NAME`
   with your own settings. Teleport will create the table automatically.
-
 - `Example_TELEPORT_FIRESTORE_TABLE_NAME` and `Example_TELEPORT_FIRESTORE_EVENTS_TABLE_NAME`
   **must** be different Firestore tables. The schema is different for each. Using the same
   table name for both will result in errors.
-
 - The GCP authentication setting above can be omitted if the machine itself is
   running on a GCE instance with a Service Account that has access to the
   Firestore table.
-
 - Audit log settings above are optional. If specified, Teleport will store the
   audit log in Firestore and the session recordings **must** be stored in a GCP
   bucket, i.e.both `audit_xxx` settings must be present. If they are not set,
@@ -1848,11 +1834,9 @@ clients, etc), the following rules apply:
 
 - **Only patch** versions are always compatible, for example any 4.0.1 component will
   work with any 4.0.3 component.
-
 - Minor versions are always compatible with the **previous** minor release. This
   means you must not attempt to upgrade from 4.1.x straight to 4.3.x. You must
   upgrade to 4.2.x first.
-
 - Teleport clients [`tsh`](cli-docs.mdx#tsh) for users and [`tctl`](cli-docs.mdx#tctl) for admins
   may not be compatible with different versions of the `teleport` service.
 
@@ -1860,11 +1844,9 @@ clients, etc), the following rules apply:
 
 - **Patch and minor** versions are always compatible, for example any 5.0.1 component will
   work with any 5.0.3 component and 6.1.0 component will work with any 6.7.0 component.
-
 - Major versions are always compatible with the **previous** major release. This
   means you must not attempt to upgrade from 5.x.x straight to 7.x.x. You must
   upgrade to 6.x.x first.
-
 - The above applies to both clients and servers. For example, a 6.x.x proxy is
   compatible with 5.x.x nodes and 5.x.x `tsh`. But we don't guarantee that a
   7.x.x `tsh` will work with a 5.x.x proxy.
@@ -1906,10 +1888,8 @@ When upgrading a single Teleport cluster:
 1. **Upgrade the auth server first**. The auth server keeps the cluster state
    and if there are data format changes introduced in the new version this will
    perform necessary migrations.
-
 2. Then, upgrade the proxy servers. The proxy servers are stateless and can be
    upgraded in any sequence or at the same time.
-
 3. Finally, upgrade the SSH nodes in any sequence or at the same time.
 
 <Admonition
@@ -1993,9 +1973,9 @@ Using `tctl get all --with-secrets` will retrieve the below items:
 - Trusted Clusters
 - Connectors:
   - Github
-  - SAML [Teleport Enterprise]
-  - OIDC [Teleport Enterprise]
-  - Roles [Teleport Enterprise]
+  - SAML \[Teleport Enterprise]
+  - OIDC \[Teleport Enterprise]
+  - Roles \[Teleport Enterprise]
 
 When migrating backends, you should back up your auth server's `data_dir/storage` directly.
 
@@ -2039,7 +2019,6 @@ administrator must:
 
 1. Replace the Teleport binaries, usually [`teleport`](cli-docs.mdx#teleport)
    and [`tctl`](cli-docs.mdx#tctl)
-
 2. Execute `systemctl restart teleport`
 
 This will perform a graceful restart, i.e.the Teleport daemon will fork a new
@@ -2109,14 +2088,11 @@ Now you can see the monitoring information by visiting several endpoints:
 - `http://127.0.0.1:3000/metrics` is the list of internal metrics Teleport is
   tracking. It is compatible with [Prometheus](https://prometheus.io/)
   collectors. For a full list of metrics review our [metrics reference](metrics-logs-reference.mdx).
-
 - `http://127.0.0.1:3000/healthz` returns "OK" if the process is healthy or
   `503` otherwise.
-
 - `http://127.0.0.1:3000/readyz` is similar to `/healthz` , but it returns "OK"
   *only after* the node successfully joined the cluster, i.e.it draws the
   difference between "healthy" and "ready".
-
 - `http://127.0.0.1:3000/debug/pprof/` is Golang's standard profiler. It's only
   available when `-d` flag is given in addition to `--diag-addr`
 

--- a/docs/pages/application-access.mdx
+++ b/docs/pages/application-access.mdx
@@ -84,7 +84,7 @@ proxy_service:
   title="Using Certbot to obtain Wildcard Certs"
 >
   Let's Encrypt provides free wildcard certificates. If using [certbot](https://certbot.eff.org/)
-  with DNS challenge, the below script will make setup easy. Update [EMAIL] and [DOMAIN]
+  with DNS challenge, the below script will make setup easy. Update \[EMAIL] and \[DOMAIN]
 
   ```sh
   certbot certonly --manual \
@@ -119,7 +119,7 @@ teleport start --roles=app --token=xyz --auth-server=proxy.example.com:3080 \
 
 ### Application Name
 
-When picking an application name, it's important to make sure the name will make a valid sub-domain (&lt;=63 characters, no spaces, only `a-z 0-9 _ -` allowed).
+When picking an application name, it's important to make sure the name will make a valid sub-domain (\<=63 characters, no spaces, only `a-z 0-9 _ -` allowed).
 
 After Teleport is running, the application will be accessible at `app-name.proxy_public_addr.com` e.g. `jenkins.teleport.example.com`.  Teleport also provides the ability to override `public_addr`. e.g `jenkins.acme.com` if you configure the appropriate DNS entry to point to the Teleport proxy server.
 
@@ -182,7 +182,7 @@ proxy_service:
     cert_file: /etc/letsencrypt/live/*.teleport.example.com/fullchain.pem
 ```
 
-#### [Optional] Obtain a new App Token
+#### \[Optional] Obtain a new App Token
 
 In the above example we've hard coded a join token `a3aff444e182cf4ee5c2f78ad2a4cc47d8a30c95747a08f8`. You can use this to join apps or create a dynamic token using the `tctl` command below.
 

--- a/docs/pages/architecture/authentication.mdx
+++ b/docs/pages/architecture/authentication.mdx
@@ -108,7 +108,6 @@ by the system's SSH agent if it is running.
    their username, password, and 2nd-factor token. Users can log in with [`tsh
    login`](../cli-docs.mdx#tsh-login) or via the Web UI. The Auth Server checks
    the username and password against its identity storage and checks the 2nd factor token.
-
 2. If the correct credentials were offered, the Auth Server will generate a
    signed certificate and return it to the client. For users, certificates are
    stored in `~/.tsh` by default. If the client uses the Web UI the signed certificate

--- a/docs/pages/architecture/overview.mdx
+++ b/docs/pages/architecture/overview.mdx
@@ -15,16 +15,13 @@ Teleport was designed in accordance with the following principles:
 - **Off the Shelf Security**: Teleport does not re-implement any security
   primitives and uses well-established, popular implementations of the
   encryption and network protocols.
-
 - **Open Standards**: There is no security through obscurity. Teleport is fully
   compatible with existing and open standards and other software, including
   [OpenSSH](../admin-guide.mdx#using-teleport-with-openssh).
-
 - **Cluster-Oriented Design**: Teleport is built for managing clusters, not
   individual servers. In practice this means that hosts and [Users](../user-manual.mdx)
   have cluster memberships. Identity management and authorization happen on a
   cluster level.
-
 - **Built for Teams**: Teleport was created under the assumption of multiple
   teams operating on several disconnected clusters. Example use cases might be
   production-vs-staging environment, or a cluster-per-customer or
@@ -129,6 +126,7 @@ interface or a web browser. When establishing a connection, the client offers
 its certificate. Clients must always connect through a proxy for two reasons:
 
 1. Individual nodes may not always be reachable from outside a secure network.
+
 2. Proxies always record SSH sessions and keep track of active user sessions.
 
    This makes it possible for an SSH user to see if someone else is connected to

--- a/docs/pages/architecture/proxy.mdx
+++ b/docs/pages/architecture/proxy.mdx
@@ -10,10 +10,8 @@ Teleport cluster:
 1. It serves as an authentication gateway. It asks for credentials from
    connecting clients and forwards them to the Auth server via [Auth
    API](authentication.mdx#auth-api).
-
 2. It looks up the IP address for a requested Node and then proxies a connection
    from client to Node.
-
 3. It serves a Web UI which is used by cluster users to sign up and configure
    their accounts, explore Nodes in a cluster, log into remote Nodes, join
    existing SSH sessions or replay recorded sessions.

--- a/docs/pages/architecture/users.mdx
+++ b/docs/pages/architecture/users.mdx
@@ -82,7 +82,8 @@ connector and it is enforced by default.
 There are two types of 2FA supported:
 
 - [TOTP - e.g. Google Authenticator](https://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
-- [U2F - e.g. YubiKey](https://en.wikipedia.org/wiki/Universal_2nd_Factor)
+
+- [U2F - e.g. YubiKey](https://en.wikipedia.org/wiki/Universal\_2nd_Factor)
 
   `TOTP` is the default. You can use [Google
   Authenticator](https://en.wikipedia.org/wiki/Google_Authenticator) or

--- a/docs/pages/aws-oss-guide.mdx
+++ b/docs/pages/aws-oss-guide.mdx
@@ -498,7 +498,7 @@ aws ec2 associate-iam-instance-profile --iam-instance-profile Name=teleport-role
 3. Setup Teleport config file. `sudo cp teleport.yaml /etc/teleport.yaml`. An example is below.
 
 ```
-{!examples/aws/eks/teleport.yaml!}
+(!examples/aws/eks/teleport.yaml!)
 ```
 
 #### Download Kubectl on Teleport Server

--- a/docs/pages/aws-terraform-guide.mdx
+++ b/docs/pages/aws-terraform-guide.mdx
@@ -148,11 +148,11 @@ cluster from scratch, so choose carefully.
 
 ### ami_name
 
-Setting `export TF_VAR_ami_name="gravitational-teleport-ami-ent-{{ teleport.version }}"`
+Setting `export TF_VAR_ami_name="gravitational-teleport-ami-ent-(=teleport.version=)"`
 
 Gravitational automatically builds and publishes OSS, Enterprise and Enterprise FIPS 140-2 AMIs when we
 release a new version of Teleport. The AMI names follow the format: `gravitational-teleport-ami-<type>-<version>`
-where `<type>` is either `oss` or `ent` (Enterprise) and `version` is the version of Teleport e.g. `{{ teleport.version }}`.
+where `<type>` is either `oss` or `ent` (Enterprise) and `version` is the version of Teleport e.g. `(=teleport.version=)`.
 
 FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix.
 

--- a/docs/pages/aws-terraform-guide.mdx
+++ b/docs/pages/aws-terraform-guide.mdx
@@ -193,12 +193,12 @@ Teleport Enterprise/Pro functionality.
 
 (OSS users can provide any valid local file path here - it isn't used by the auth server in a Teleport OSS install)
 
-### route53_zone
+### route53\_zone
 
 Setting `export TF_VAR_route53_zone="example.com"`
 
 Our Terraform setup requires you to have your domain provisioned in AWS Route 53 - it will automatically add
-DNS records for [`route53_domain`](#route53_domain) as set up below. You can list these with this command:
+DNS records for [`route53_domain`](#route53\_domain) as set up below. You can list these with this command:
 
 ```bash
 $ aws route53 list-hosted-zones --query "HostedZones[*].Name" --output text
@@ -211,16 +211,16 @@ $ aws route53 list-hosted-zones --query "HostedZones[*].Name" --output text
 
 You should use the appropriate domain without the trailing dot.
 
-### route53_domain
+### route53\_domain
 
 Setting `export TF_VAR_route53_domain="teleport.example.com"`
 
 A subdomain to set up as a CNAME to the Teleport load balancer for web access. This will be the public-facing domain
 that people use to connect to your Teleport cluster, so choose wisely.
 
-This must be a subdomain of the domain you chose for [`route53_zone`](#route53_zone) above.
+This must be a subdomain of the domain you chose for [`route53_zone`](#route53\_zone) above.
 
-### s3_bucket_name
+### s3\_bucket_name
 
 Setting `export TF_VAR_s3_bucket_name="example-cluster"`
 
@@ -242,7 +242,7 @@ Setting `export TF_VAR_grafana_pass="CHANGE_THIS_VALUE"`
 
 We deploy Grafana along with every Terraform deployment and automatically make stats on cluster usage available in
 a custom dashboard. This variable sets up the password for the Grafana `admin` user. The Grafana web UI is served
-on the same subdomain as specified above in [`route53_domain`](#route53_domain) on port 8443.
+on the same subdomain as specified above in [`route53_domain`](#route53\_domain) on port 8443.
 
 With the variables set in this example, it would be available on [https://teleport.example.com:8443](https://teleport.example.com:8443)
 
@@ -255,7 +255,7 @@ to a known value at the outset.
 Setting `export TF_VAR_use_acm="false"`
 
 If set to the string `"false"`, Terraform will use [LetsEncrypt](https://letsencrypt.org/) to provision the public-facing
-web UI certificate for the Teleport cluster ([`route53_domain`](#route53_domain) - so [https://teleport.example.com](https://teleport.example.com) in this example).
+web UI certificate for the Teleport cluster ([`route53_domain`](#route53\_domain) - so [https://teleport.example.com](https://teleport.example.com) in this example).
 This uses an [AWS network load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html)
 to load-balance connections to the Teleport cluster's web UI, and its SSL termination is handled by Teleport itself.
 
@@ -310,7 +310,7 @@ More information about how Teleport works with DynamoDB can be found in our [Dyn
 ### Recorded session storage
 
 The reference Terraform deployment sets Teleport up to store recorded session logs in the same S3 bucket configured in
-the [`s3_bucket_name`](#s3_bucket_name) variable, under the `records` directory.
+the [`s3_bucket_name`](#s3\_bucket_name) variable, under the `records` directory.
 
 In our example this would be `s3://example-cluster/records`
 
@@ -326,7 +326,7 @@ In our example this would be `s3://example-cluster/records`
 ### Cluster domain
 
 The reference Terraform deployment sets the Teleport cluster up to be available on a domain defined in Route53, referenced
-by the [`route53_domain`](#route53_domain) variable. In our example this would be `teleport.example.com`
+by the [`route53_domain`](#route53\_domain) variable. In our example this would be `teleport.example.com`
 
 Teleport's web interface will be available on port 443 - [https://teleport.example.com](https://teleport.example.com) - this is via a configured CNAME
 to the AWS load balancer.
@@ -415,7 +415,7 @@ If you need to tear down a running deployment for any reason, you can run `terra
 ## Accessing the cluster after Terraform setup
 
 Once the Terraform setup is finished, your Teleport cluster's web UI should be available on
-https&#x3A;//[route53_domain](#route53_domain) - this is [https://teleport.example.com](https://teleport.example.com) in our example.
+https://[route53\_domain](#route53\_domain) - this is [https://teleport.example.com](https://teleport.example.com) in our example.
 
 ### Adding an admin user to the Teleport cluster
 

--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -3,4 +3,4 @@ title: Teleport Changelog
 description: Learn about what's new, improved and fixed in Teleport.
 ---
 
-`{!CHANGELOG.md!}`
+(!CHANGELOG.md!)

--- a/docs/pages/cli-docs.mdx
+++ b/docs/pages/cli-docs.mdx
@@ -141,9 +141,7 @@ Run shell or execute a command on a remote SSH node
 - `user` The login identity to use on the remote host. If `[user]` is not specified
   the user defaults to `$USER` or can be set with `--user` . If the flag `--user`
   and positional argument `[user]` are specified the arg `[user]` takes precedence.
-
 - `host` A `nodename` of a cluster node or a
-
 - `command` The command to execute on a remote host.
 
 #### Flags
@@ -153,7 +151,7 @@ Run shell or execute a command on a remote SSH node
 | `-p, --port` | none | port | SSH port on a remote host |
 | `-A, --forward-agent` | none | none | Forward agent to target node like `ssh -A` |
 | `-L, --forward` | none | none | Forward localhost connections to remote server |
-| `-D, --dynamic-forward ` | none | none | Forward localhost connections to remote server using SOCKS5 |
+| `-D, --dynamic-forward` | none | none | Forward localhost connections to remote server using SOCKS5 |
 | `-N, -no-remote-exec` | none | none | Don't execute remote command, useful for port forwarding |
 | `--local` | none | | Execute command on localhost after connecting to SSH node |
 | `-t, --tty` | `file` | | Allocate TTY |
@@ -164,10 +162,8 @@ Run shell or execute a command on a remote SSH node
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version-check, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
-Section](#tsh-global-flags)
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
 
 #### Examples
 
@@ -206,10 +202,8 @@ Joins an active session
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version-check, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
-Section](#tsh-global-flags)
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
 
 #### Examples
 
@@ -238,10 +232,8 @@ Plays back a prior session
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version-check, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
-Section](#tsh-global-flags)
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
 
 #### Examples
 
@@ -254,6 +246,7 @@ tsh --proxy proxy.example.com play <session-id>
 Copies files from source to dest
 
 **Usage** `usage: tsh scp [<flags>] <source>... <dest>`
+
 {/* TODO Confirm which flags are supported, and whether supports multiple sources */}
 
 #### Arguments
@@ -272,10 +265,8 @@ Copies files from source to dest
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
-Section](#tsh-global-flags)
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version, --debug, --jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
 
 #### Examples
 
@@ -288,6 +279,7 @@ $ tsh --proxy=proxy.example.com scp -P example.txt user@host/destination/dir
 List cluster nodes
 
 **Usage** `usage: tsh ls [<flags>] [<label>]`
+
 {/* TODO: label? or labels? seems like it only supports one label at a time */}
 
 #### Arguments
@@ -302,10 +294,8 @@ List cluster nodes
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
-Section](#tsh-global-flags)
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version, --debug, --jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
 
 #### Examples
 
@@ -358,10 +348,8 @@ microk8s
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
-Section](#tsh-global-flags)
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version, --debug, --jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
 
 #### Examples
 
@@ -402,10 +390,8 @@ interval via `--ttl` flag (capped by the server-side configuration).
 
 #### [Global Flags](#tsh-global-flags)
 
-These flags are available for all commands `--login, --proxy, --user, --ttl,
---identity, --cert-format, --insecure, --auth, --skip-version-check, --debug,
---jumphost `. Run ` tsh help <subcommand>` or see the [Global Flags
-Section](#tsh-global-flags)
+These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version-check, --debug, --jumphost`.
+Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
 
 #### Examples
 
@@ -666,7 +652,7 @@ Generate a node invitation token
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--roles` | `node` | `node,auth` or ` proxy` | Comma-separated list of roles for the new node to assume |
+| `--roles` | `node` | `node,auth` or `proxy` | Comma-separated list of roles for the new node to assume |
 | `--ttl` | 30m | relative duration like 5s, 2m, or 3h | Time to live for a generated token |
 | `--token` | none | **string** token value | A custom token to use, auto-generated if not provided. Should match token set with `teleport start --token` |
 
@@ -925,7 +911,7 @@ Delete a resource
 #### Arguments
 
 - `[<resource-type/resource-name>]` Resource to delete
-  - `<resource type>` Type of a resource [for example: `saml,oidc,github,user,cluster,token`]
+  - `<resource type>` Type of a resource \[for example: `saml,oidc,github,user,cluster,token`]
   - `<resource name>` Resource name to delete
 
 #### Examples
@@ -947,7 +933,7 @@ Print a YAML declaration of various Teleport resources
 #### Arguments
 
 - `[<resource-type/resource-name>]` Resource to delete
-  - `<resource type>` Type of a resource [for example: `user,cluster,token`]
+  - `<resource type>` Type of a resource \[for example: `user,cluster,token`]
   - `<resource name>` Resource name to delete
 
 #### Flags

--- a/docs/pages/docs/best-practices.mdx
+++ b/docs/pages/docs/best-practices.mdx
@@ -21,7 +21,7 @@ to accomplish their goal. This sometimes leads to duplication.
 Use include directives for repeated content. Remove backslash before the exclamation marks for it to work:
 
 ```bash
-{% raw %}{{\!CHANGELOG.md\!}}{% endraw %}
+(\!CHANGELOG.md\!)
 ```
 
 ## Diagrams

--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -98,7 +98,7 @@ See the [SSO for SSH](sso/ssh-sso.mdx) chapter for more details.
 ## FedRAMP/FIPS
 
 With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
-the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2),
+the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS\_140-2),
 also known as the Federal Information Processing Standard, which is the US
 government approved standard for cryptographic modules.
 

--- a/docs/pages/enterprise/quickstart-enterprise.mdx
+++ b/docs/pages/enterprise/quickstart-enterprise.mdx
@@ -388,12 +388,12 @@ SailPoint and others.
 
 We provide pre-built Docker images for every version of Teleport Enterprise. These images are hosted on quay.io.
 
-- [All tags under `quay.io/gravitational/teleport-ent` are Teleport Enterprise images](https://quay.io/repository/gravitational/teleport-ent?tag=latest&tab=tags)
+- [All tags under `quay.io/gravitational/teleport-ent` are Teleport Enterprise images](https://quay.io/repository/gravitational/teleport-ent?tag=latest\&tab=tags)
 
 We currently only offer Docker images for `x86_64` architectures.
 
 <Admonition type="note">
-  You will need a recent version of [Docker](https://hub.docker.com/search?q=&type=edition&offering=community) installed to follow this section of the quick start guide.
+  You will need a recent version of [Docker](https://hub.docker.com/search?q=\&type=edition\&offering=community) installed to follow this section of the quick start guide.
 </Admonition>
 
 <Admonition type="warning">
@@ -408,10 +408,10 @@ They are stable, and we recommend their use to easily keep your Teleport Enterpr
 
 | Image name | Community or Enterprise? | Teleport version | Image automatically updated? | Image base |
 | - | - | - | - | - |
-| `quay.io/gravitational/teleport-ent:(=version=)` | Enterprise | The latest version of Teleport Enterprise (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:(=version=)-fips` | Enterprise FIPS | The latest version of Teleport Enterprise (=version=) FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:(=teleport.version=)` | Enterprise | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:(=teleport.version=)-fips` | Enterprise FIPS | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=version=)` | Enterprise | The latest version of Teleport Enterprise (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=version=)-fips` | Enterprise FIPS | The latest version of Teleport Enterprise (=version=) FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=teleport.version=)` | Enterprise | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=teleport.version=)-fips` | Enterprise FIPS | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
 
 For testing, we always recommend that you use the latest release version of Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
 

--- a/docs/pages/enterprise/quickstart-enterprise.mdx
+++ b/docs/pages/enterprise/quickstart-enterprise.mdx
@@ -58,7 +58,7 @@ To start using Teleport Enterprise, you will need to Download the binaries and t
 After downloading the binary tarball, run:
 
 ```bsh
-$ tar -xzf teleport-ent-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-ent
 ```
 
@@ -129,7 +129,7 @@ $ sudo systemctl status teleport
 # after successful start retrieve the CA pin for using in the node
 $ sudo tctl status
 Cluster  teleport
-Version  {{ version }}
+Version  (=version=)
 Host CA  never updated
 User CA  never updated
 Jwt CA   never updated
@@ -408,12 +408,12 @@ They are stable, and we recommend their use to easily keep your Teleport Enterpr
 
 | Image name | Community or Enterprise? | Teleport version | Image automatically updated? | Image base |
 | - | - | - | - | - |
-| `quay.io/gravitational/teleport-ent:{{ version }}` | Enterprise | The latest version of Teleport Enterprise {{ version }} | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:{{ version }}-fips` | Enterprise FIPS | The latest version of Teleport Enterprise {{version }} FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:{{ teleport.version }}` | Enterprise | The version specified in the image's tag (i.e. {{ teleport.version }}) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:{{ teleport.version }}-fips` | Enterprise FIPS | The version specified in the image's tag (i.e. {{ teleport.version }}) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=version=)` | Enterprise | The latest version of Teleport Enterprise (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=version=)-fips` | Enterprise FIPS | The latest version of Teleport Enterprise (=version=) FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=teleport.version=)` | Enterprise | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport-ent:(=teleport.version=)-fips` | Enterprise FIPS | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
 
-For testing, we always recommend that you use the latest release version of Teleport Enterprise, which is currently `{{teleport.latest_ent_docker_image}}`.
+For testing, we always recommend that you use the latest release version of Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.
 
 ### Quickstart using docker-compose
 
@@ -456,7 +456,7 @@ cp ~/downloads/downloaded-license.pem ~/teleport/data/license.pem
 docker run --hostname localhost --rm \
   --entrypoint=/bin/sh \
   -v ~/teleport/config:/etc/teleport \
-  {{teleport.latest_ent_docker_image}} -c "teleport configure > /etc/teleport/teleport.yaml"
+  (=teleport.latest_ent_docker_image=) -c "teleport configure > /etc/teleport/teleport.yaml"
 
 # change the path to the license file in the sample config
 sed -i 's_/path/to/license-if-using-teleport-enterprise.pem_/var/lib/teleport/license.pem_g' ~/teleport/config/teleport.yaml
@@ -466,7 +466,7 @@ docker run --hostname localhost --name teleport \
   -v ~/teleport/config:/etc/teleport \
   -v ~/teleport/data:/var/lib/teleport \
   -p 3023:3023 -p 3025:3025 -p 3080:3080 \
-  {{teleport.latest_ent_docker_image}}
+  (=teleport.latest_ent_docker_image=)
 ```
 
 ### Creating a Teleport user when using Docker quickstart

--- a/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
+++ b/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
@@ -5,7 +5,7 @@ h1: FedRAMP for SSH and Kubernetes Access
 ---
 
 With Teleport 4.0 we have built the foundation to meet FedRAMP requirements for
-the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high
+the purposes of accessing infrastructure. This includes support for [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS\_140-2), also known as the Federal Information Processing Standard, which is the US government approved standard for cryptographic modules. This document outlines a high
 level overview of how Teleport FIPS mode works and how it can help your company to become FedRAMP certified.
 
 ### Obtain FedRAMP certification with Teleport
@@ -129,15 +129,10 @@ binary was compiled against an approved cryptographic module (BoringCrypto) and
 fails to start if it was not.
 
 - For OSS and Enterprise binaries not compiled with BoringCrypto, this flag will report that this version of Teleport is not compiled with the appropriate cryptographic module.
-
 - Running commands like `ps aux` can be useful to note that Teleport is running in FedRAMP enforcing mode.
-
 - If no ciphersuites are provided, Teleport will set the default ciphersuites to be FIPS 140-2 compliant.
-
 - If ciphersuites, key exchange and MAC algorithms are provided in the Teleport configuration, Teleport will validate that they are FIPS 140-2 compliant..
-
 - Teleport will always enable at-rest encryption for both DynamoDB and S3.
-
 - If recording proxy mode is selected, validation of host certificates should always happen.
 
 ### FedRAMP Audit Log

--- a/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
+++ b/docs/pages/enterprise/ssh-kubernetes-fedramp.mdx
@@ -38,7 +38,7 @@ Enterprise FIPS Binary.
 After downloading the binary tarball, run:
 
 ```bsh
-$ tar -xzf teleport-ent-v{{ teleport.version }}-linux-amd64-fips-bin.tar.gz
+$ tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-fips-bin.tar.gz
 $ cd teleport-ent
 $ sudo ./install
 # This will copy Teleport Enterprise to /usr/local/bin.

--- a/docs/pages/enterprise/ssh-rbac.mdx
+++ b/docs/pages/enterprise/ssh-rbac.mdx
@@ -113,12 +113,12 @@ spec:
   allow:
     # logins array defines the OS/UNIX logins a user is allowed to use.
     # a few special variables are supported here (see below)
-    logins: [root, '{% raw %}{{internal.logins}}{% endraw %}']
+    logins: [root, '{{internal.logins}}']
     # if kubernetes integration is enabled, this setting configures which
     # kubernetes groups the users of this role will be assigned to.
     # note that you can refer to a SAML/OIDC trait via the "external" property bag,
     # this allows you to specify Kubernetes group membership in an identity manager:
-    kubernetes_groups: ["system:masters", "{% raw %}{{external.trait_name}}{% endraw %}"]]
+    kubernetes_groups: ["system:masters", "{{external.trait_name}}"]]
 
     # list of node labels a user will be allowed to connect to:
     node_labels:
@@ -172,8 +172,8 @@ The following variables can be used with `logins` field:
 
 | Variable | Description |
 | - | - |
-| `{% raw %}{{internal.logins}}{% endraw %}` | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database. |
-| `{% raw %}{{external.xyz}}{% endraw %}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim. |
+| `{{internal.logins}}` | Substituted with "allowed logins" parameter used in `tctl users add [user] <allowed logins>` command. This applies only to users stored in Teleport's own local database. |
+| `{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on). If using SAML, this will be expanded with "xyz" assertion value. For OIDC, this will be expanded a value of "xyz" claim. |
 
 Both variables above are there to deliver the same benefit: they allow Teleport
 administrators to define allowed OS logins via the user database, be it the
@@ -193,7 +193,7 @@ Assuming you have the following SAML assertion attribute in your response:
 
 ```
 logins:
-   - '{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}'
+   - '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}'
 ```
 
 ### Role Options

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -71,7 +71,7 @@ from the identity provider then mapping the value to either to `admin` role or
 the `user` role depending on the value returned for `group` within the claims.
 
 ```yaml
-{!examples/resources/oidc-connector.yaml!}
+(!examples/resources/oidc-connector.yaml!)
 ```
 
 Create the connector:
@@ -123,7 +123,7 @@ spec:
   options:
     max_session_ttl: "90h0m0s"
   allow:
-    logins: [ "{% raw %}{{external.username}}{% endraw %}", ubuntu ]
+    logins: [ "{{external.username}}", ubuntu ]
     node_labels:
       access: relaxed
 ```

--- a/docs/pages/enterprise/sso/oidc.mdx
+++ b/docs/pages/enterprise/sso/oidc.mdx
@@ -42,7 +42,7 @@ documented on the identity providers website. Here are a few links:
 
 - [Auth0 Client Configuration](https://auth0.com/docs/applications)
 - [Google Identity Platform](https://developers.google.com/identity/protocols/OpenIDConnect)
-- [Keycloak Client Registration](https://www.keycloak.org/docs/latest/securing_apps/index.html#_client_registration)
+- [Keycloak Client Registration](https://www.keycloak.org/docs/latest/securing_apps/index.html#\_client_registration)
 
 Add your OIDC connector information to `teleport.yaml`. A few examples are
 provided below.
@@ -215,7 +215,7 @@ spec:
 ```
 
 A list of available optional prompt parameters are available from the
-[OpenID website](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest).
+[OpenID website](https://openid.net/specs/openid-connect-core-1\_0.html#AuthRequest).
 
 ## Testing
 

--- a/docs/pages/enterprise/sso/ssh-adfs.mdx
+++ b/docs/pages/enterprise/sso/ssh-adfs.mdx
@@ -121,7 +121,7 @@ spec:
     max_session_ttl: "1h"
   allow:
     # only allow login as either ubuntu or the 'windowsaccountname' claim
-    logins: [ '{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}', ubuntu ]
+    logins: [ '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}', ubuntu ]
     node_labels:
       "access": "relaxed"
 ```
@@ -130,7 +130,7 @@ This role declares:
 
 - Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 - Developers can log in as `ubuntu` user
-- Notice `{% raw %}{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}{% endraw %}` login. It configures Teleport to look at
+- Notice `{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}` login. It configures Teleport to look at
   *"[http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"](http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname")* ADFS claim and use that field as an allowed login for each user.
   Also note the double quotes (`"`) and square brackets (`[]`) around the claim name - these are important.
 - Developers also do not have any "allow rules" i.e. they will not be able to
@@ -139,7 +139,7 @@ This role declares:
 Next, create a SAML connector [resource](../../admin-guide.mdx#resources):
 
 ```yaml
-{!examples/resources/adfs-connector.yaml!}
+(!examples/resources/adfs-connector.yaml!)
 ```
 
 The `acs` field should match the value you set in ADFS earlier and you can

--- a/docs/pages/enterprise/sso/ssh-azuread.mdx
+++ b/docs/pages/enterprise/sso/ssh-azuread.mdx
@@ -47,8 +47,8 @@ Before you get started you’ll need:
 4. Enter the display name (Ex: Teleport)
    ![Enter application name](../../../img/azuread/azuread-4-enterappname.png)
 
-5.Select properties under Manage and turn off User assignment required
-![Turn off user assignment](../../../img/azuread/azuread-5-turnoffuserassign.png)
+5. Select properties under Manage and turn off User assignment required
+   ![Turn off user assignment](../../../img/azuread/azuread-5-turnoffuserassign.png)
 
 6. Select Single Sign-on under Manage and choose SAML
    ![Select SAML](../../../img/azuread/azuread-6-selectsaml.png)
@@ -69,7 +69,6 @@ Before you get started you’ll need:
 
    iii. Add a Claim to pass the username from transforming the AzureAD User name.
    ![Add a transformed username](../../../img/azuread/azuread-9c-usernameclaim.png)
-
 
 10. On the SAML Signing Certificate select to download SAML Download the Federation Metadata XML.
     ![Download Federation Metadata XML](../../../img/azuread/azuread-10-fedmeatadataxml.png)

--- a/docs/pages/enterprise/sso/ssh-azuread.mdx
+++ b/docs/pages/enterprise/sso/ssh-azuread.mdx
@@ -158,7 +158,7 @@ spec:
   options:
     max_session_ttl: 24h
   allow:
-    logins: [ "{% raw %}{{external.username}}{% endraw %}", ubuntu ]
+    logins: [ "{{external.username}}", ubuntu ]
     node_labels:
       access: relaxed
 ```

--- a/docs/pages/enterprise/sso/ssh-gsuite.mdx
+++ b/docs/pages/enterprise/sso/ssh-gsuite.mdx
@@ -48,16 +48,12 @@ Before you get started you’ll need:
 ## Configure G Suite
 
 1. Obtain OAuth 2.0 credentials  [https://developers.google.com/identity/protocols/OpenIDConnect](https://developers.google.com/identity/protocols/OpenIDConnect)
-
 2. Create a new Project.
    ![Create New Project](../../../img/gsuite/gsuite-1-new-project.png)
-
 3. Select OAuth client ID.
    ![Create OAuth Creds](../../../img/gsuite/gsuite-2-created-creds.png)
-
 4. Make Application Type Public & Setup Domain Verification
    ![Setup Application Type](../../../img/gsuite/gsuite-3-oauth.png)
-
 5. Copy OAuth Client ID and Client Secret for YAML Below.
    Note: The redirect_url: `https://teleport.example.com:3080/v1/webapi/oidc/callback`
 

--- a/docs/pages/enterprise/sso/ssh-gsuite.mdx
+++ b/docs/pages/enterprise/sso/ssh-gsuite.mdx
@@ -124,7 +124,7 @@ Now, create a OIDC connector [resource](../../admin-guide.mdx#resources).
 Write down this template as `gsuite-connector.yaml`:
 
 ```yaml
-{!examples/resources/gsuite-connector.yaml!}
+(!examples/resources/gsuite-connector.yaml!)
 ```
 
 Create the connector using `tctl` tool:
@@ -172,7 +172,7 @@ spec:
   options:
     max_session_ttl: 24h
   allow:
-    logins: [ "{% raw %}{{external.username}}{% endraw %}", ubuntu ]
+    logins: [ "{{external.username}}", ubuntu ]
     node_labels:
       access: relaxed
 ```

--- a/docs/pages/enterprise/sso/ssh-okta.mdx
+++ b/docs/pages/enterprise/sso/ssh-okta.mdx
@@ -67,7 +67,7 @@ SINGLE ATTRIBUTE STATEMENTS
 GROUP ATTRIBUTE STATEMENTS
 
 - Name: `groups` | Name format: `Unspecified`
-- Filter: `Matches regex` \|  `.*`
+- Filter: `Matches regex` |  `.*`
 
 ![Configure APP](../../../img/sso/okta/setup-redirection.png)
 

--- a/docs/pages/enterprise/sso/ssh-okta.mdx
+++ b/docs/pages/enterprise/sso/ssh-okta.mdx
@@ -110,7 +110,7 @@ configure a Teleport connector:
 Now, create a SAML connector [resource](../../admin-guide.mdx#resources):
 
 ```yaml
-{!examples/resources/saml-connector.yaml!}
+(!examples/resources/saml-connector.yaml!)
 ```
 
 Create the connector using `tctl` tool:
@@ -152,14 +152,14 @@ spec:
   options:
     max_session_ttl: 24h
   allow:
-    logins: [ "{% raw %}{{email.local(external.username)}}{% endraw %}", ubuntu ]
+    logins: [ "{{email.local(external.username)}}", ubuntu ]
     node_labels:
       access: relaxed
 ```
 
 - Devs are only allowed to login to nodes labelled with `access: relaxed` label.
 - Developers can log in as `ubuntu` user
-- Notice `{% raw %}{{external.username}}{% endraw %}` login. It configures Teleport to look at
+- Notice `{{external.username}}` login. It configures Teleport to look at
   *"username"* Okta claim and use that field as an allowed login for each user.  This example uses email as the username format.  The `email.local(external.trait)` function will remove the `@domain` and just have the username prefix.
 - Developers also do not have any "allow rules" i.e. they will not be able to
   see/replay past sessions or re-configure the Teleport cluster.

--- a/docs/pages/enterprise/sso/ssh-one-login.mdx
+++ b/docs/pages/enterprise/sso/ssh-one-login.mdx
@@ -94,7 +94,7 @@ Now, create a SAML connector [resource](../../admin-guide.mdx#resources).
 Write down this template as `onelogin-connector.yaml`:
 
 ```yaml
-{!examples/resources/onelogin-connector.yaml!}
+(!examples/resources/onelogin-connector.yaml!)
 ```
 
 To fill in the fields, open `SSO` tab:
@@ -158,7 +158,7 @@ spec:
   options:
     max_session_ttl: "24h"
   allow:
-    logins: [ "{% raw %}{{external.username}}{% endraw %}", ubuntu ]
+    logins: [ "{{external.username}}", ubuntu ]
     node_labels:
       access: relaxed
 ```

--- a/docs/pages/enterprise/sso/ssh-sso.mdx
+++ b/docs/pages/enterprise/sso/ssh-sso.mdx
@@ -115,7 +115,7 @@ connect to Teleport nodes. To support this:
 
 - Use the SSO provider to create a field called *"unix_login"* (you can use another name).
 - Make sure it's exposed as a claim via SAML/OIDC.
-- Update a Teleport SSH role to include `{% raw %}{{external.unix_login}}{% endraw %}` variable into the list of allowed logins:
+- Update a Teleport SSH role to include `{{external.unix_login}}` variable into the list of allowed logins:
 
 ```yaml
 kind: role
@@ -125,7 +125,7 @@ metadata:
 spec:
   allow:
     logins:
-    - '{% raw %}{{external.unix_login}}{% endraw %}'
+    - '{{external.unix_login}}'
     node_labels:
       '*': '*'
 ```
@@ -136,9 +136,9 @@ Along with sending groups, an SSO provider will also provide a user's email addr
 In many organizations, the username that a person uses to log into a system is the
 same as the first part of their email address - the 'local' part. For example, `dave.smith@acme.com` might log in with the username `dave.smith`. Teleport 4.2.6+ adds an easy way to
 extract the first part of an email address so it can be used as a username - this
-is the `{% raw %}{{email.local}}{% endraw %}` function.
+is the `{{email.local}}` function.
 
-If the email claim from the identity provider (which can be accessed via `{% raw %}{{external.email}}{% endraw %}`) is sent and contains an email address, you can extract the 'local' part of the email address before the @ sign like this: `{% raw %}{{email.local(external.email)}}{% endraw %}`
+If the email claim from the identity provider (which can be accessed via `{{external.email}}`) is sent and contains an email address, you can extract the 'local' part of the email address before the @ sign like this: `{{email.local(external.email)}}`
 
 Here's how this looks in a Teleport role:
 
@@ -152,7 +152,7 @@ spec:
     logins:
     # Extracts the local part of dave.smith@acme.com, so the login will
     # now support dave.smith.
-    - '{% raw %}{{email.local(external.email)}}{% endraw %}'
+    - '{{email.local(external.email)}}'
     node_labels:
       '*': '*'
 ```

--- a/docs/pages/enterprise/workflow/index.mdx
+++ b/docs/pages/enterprise/workflow/index.mdx
@@ -168,7 +168,7 @@ spec:
       # external identity provider to the plugin system.
       annotations:
         foo: ['bar']
-        groups: ['{% raw %}{{external.groups}}{% endraw %}']
+        groups: ['{{external.groups}}']
   options:
     # the `request_access` field can be set to 'always' or 'reason' to tell
     # tsh or the web UI to always create an access request on login. If it is
@@ -191,9 +191,9 @@ version: v3
 
   `^prod.*$` - Can request all `prod.*` clusters. e.g. prod.us-east
 
-  `dev-{% raw %}{{regexp.match("us-*")}}{% endraw %}` - Can request any dev cluster in the US. e.g. dev-us-east-a, dev-us-west-b
+  `dev-{{regexp.match("us-*")}}` - Can request any dev cluster in the US. e.g. dev-us-east-a, dev-us-west-b
 
-  `dev-{% raw %}{{regexp.not_match("beta")}}{% endraw %}-prod` - Can request any cluster, apart from beta cluster. e.g. Can access dev-alpha-prod, cannot access dev-beta-prod.
+  `dev-{{regexp.not_match("beta")}}-prod` - Can request any cluster, apart from beta cluster. e.g. Can access dev-alpha-prod, cannot access dev-beta-prod.
 </Admonition>
 
 **Unprivileged User Login**<br/>

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
@@ -135,8 +135,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/jira).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-jira-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-jira-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-jira/
 $ ./install
 $ which teleport-jira
@@ -158,7 +158,7 @@ $ sudo mv teleport-jira.toml /etc
 By default, Jira Teleport Plugin will use a config in `/etc/teleport-jira.toml`, and you can override it with `-c config/file/path.toml` flag.
 
 ```toml
-{!examples/resources/plugins/teleport-jira.toml!}
+(!examples/resources/plugins/teleport-jira.toml!)
 ```
 
 The `[teleport]` section describes where the teleport service running, and what keys should the plugin use to authenticate itself. Use the keys that you've generated.
@@ -199,7 +199,7 @@ In production, we recommend starting teleport plugin daemon via an init system l
 Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-jira.service!}
+(!examples/systemd/plugins/teleport-jira.service!)
 ```
 
 Save this as `teleport-jira.service`.

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
@@ -147,8 +147,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/jira).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-jira-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-jira-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-jira/
 $ sudo ./install
 # Teleport Jira Plugin binaries have been copied to /usr/local/bin
@@ -172,7 +172,7 @@ $ sudo mv teleport-jira.toml /etc
 By default, Jira Teleport Plugin will use a config in `/etc/teleport-jira.toml`, and you can override it with `-c config/file/path.toml` flag.
 
 ```toml
-{!examples/resources/plugins/teleport-jira.toml!}
+(!examples/resources/plugins/teleport-jira.toml!)
 ```
 
 The `[teleport]` section describes where is the teleport service running, and what keys should the plugin use to authenticate itself. Use the keys that you've generated [above in exporting your Certificate section](#export-access-plugin-certificate).
@@ -221,7 +221,7 @@ In production, we recommend starting teleport plugin daemon via an init system l
 Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-jira.service!}
+(!examples/systemd/plugins/teleport-jira.service!)
 ```
 
 Save this as `teleport-jira.service`.

--- a/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
@@ -125,8 +125,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/mattermost).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-mattermost-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-mattermost-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-mattermost
 $ ./install
 $ which teleport-mattermost
@@ -148,7 +148,7 @@ $ sudo mv teleport-mattermost.toml /etc
 Then, edit the config as needed.
 
 ```yaml
-{!examples/resources/plugins/teleport-mattermost.toml!}
+(!examples/resources/plugins/teleport-mattermost.toml!)
 ```
 
 ### Testing the Plugin
@@ -160,7 +160,7 @@ the bot can connect to Mattermost.
 ```bash
 $ teleport-mattermost start -d
 DEBU   DEBUG logging enabled logrus/exported.go:117
-INFO   Starting Teleport Access Mattermost Bot {{ teleport.plugin.version }}-dev.1: mattermost/main.go:140
+INFO   Starting Teleport Access Mattermost Bot (=teleport.plugin.version=)-dev.1: mattermost/main.go:140
 DEBU   Checking Teleport server version mattermost/main.go:234
 DEBU   Starting a request watcher... mattermost/main.go:296
 DEBU   Starting Mattermost API health check... mattermost/main.go:186
@@ -174,7 +174,7 @@ DEBU   Mattermost API health check finished ok mattermost/main.go:19
 In production, we recommend starting teleport plugin daemon via an init system like systemd . Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-mattermost.service!}
+(!examples/systemd/plugins/teleport-mattermost.service!)
 ```
 
 Save this as `teleport-mattermost.service`.

--- a/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
@@ -97,8 +97,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/pagerduty).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-pagerduty-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-pagerduty-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-pagerduty/
 $ ./install
 $ which teleport-pagerduty
@@ -122,7 +122,7 @@ After generating the config, edit it as follows:
 
 ```toml
 # Example PagerDuty config file
-{!examples/resources/plugins/teleport-pagerduty.toml!}
+(!examples/resources/plugins/teleport-pagerduty.toml!)
 ```
 
 ### Testing the Plugin
@@ -151,7 +151,7 @@ By default, `teleport-pagerduty` will assume its config is in `/etc/teleport-pag
 In production, we recommend starting teleport plugin daemon via an init system like systemd . Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-pagerduty.service!}
+(!examples/systemd/plugins/teleport-pagerduty.service!)
 ```
 
 Save this as `teleport-pagerduty.service`.

--- a/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
@@ -152,8 +152,8 @@ and Teleport Auth access.  We currently only provide linux-amd64 binaries, you c
 compile these plugins from [source](https://github.com/gravitational/teleport-plugins/tree/master/access/slack).
 
 ```bash
-$ wget https://get.gravitational.com/teleport-access-slack-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
-$ tar -xzf teleport-access-slack-v{{ teleport.plugin.version }}-linux-amd64-bin.tar.gz
+$ wget https://get.gravitational.com/teleport-access-slack-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
+$ tar -xzf teleport-access-slack-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
 $ cd teleport-access-slack/
 $ ./install
 $ which teleport-slack
@@ -175,7 +175,7 @@ $ sudo mv teleport-slack.toml /etc
 Then, edit the config as needed.
 
 ```yaml
-{!examples/resources/plugins/teleport-slack.toml!}
+(!examples/resources/plugins/teleport-slack.toml!)
 ```
 
 #### Editing the config file
@@ -189,7 +189,7 @@ Then set the plugin callback (where Slack sends its requests) to an address you 
 By default, Teleport Slack plugin will run with TLS on.
 
 ```conf
-{!examples/resources/plugins/teleport-slack.toml!}
+(!examples/resources/plugins/teleport-slack.toml!)
 ```
 
 ## Test Run
@@ -205,7 +205,7 @@ If everything works fine, the log output should look like this:
 
 ```bash
 $ teleport-slack start
-INFO   Starting Teleport Access Slack {{ teleport.plugin.version }}.1-0-slack/main.go:145
+INFO   Starting Teleport Access Slack (=teleport.plugin.version=).1-0-slack/main.go:145
 INFO   Starting a request watcher... slack/main.go:330
 INFO   Starting insecure HTTP server on 0.0.0.0:8081 utils/http.go:64
 INFO   Watcher connected slack/main.go:298
@@ -255,7 +255,7 @@ In production, we recommend starting teleport plugin daemon via an init system l
 Here's the recommended Teleport Plugin service unit file for systemd:
 
 ```bash
-{!examples/systemd/plugins/teleport-slack.service!}
+(!examples/systemd/plugins/teleport-slack.service!)
 ```
 
 Save this as `teleport-slack.service`.

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -81,7 +81,7 @@ We recommend that the Auth Server should be upgraded first, and proxy is bumped 
 
 ### Does Web UI support copy and paste?
 
-Yes. You can copy&paste using the mouse. For working with a keyboard, Teleport employs
+Yes. You can copy\&paste using the mouse. For working with a keyboard, Teleport employs
 `tmux`-like "prefix" mode. To enter prefix mode, press `Ctrl+A`.
 
 While in prefix mode, you can press `Ctrl+V` to paste, or enter text selection

--- a/docs/pages/features/enhanced-session-recording.mdx
+++ b/docs/pages/features/enhanced-session-recording.mdx
@@ -12,7 +12,8 @@ session recordings typically do not contain passwords that were entered into a t
 
 The disadvantage is that session recordings can by bypassed using several techniques:
 
-- **Obfuscation**. For example, even though the command ` echo Y3VybCBodHRwOi8vd3d3LmV4YW1wbGUuY29tCg== | base64 --decode | sh` does not contain
+- **Obfuscation**. For example, even though the command
+  `echo Y3VybCBodHRwOi8vd3d3LmV4YW1wbGUuY29tCg== | base64 --decode | sh` does not contain
   `curl http://www.example.com`, when decoded, that is what is run.
 - **Shell scripts**. For example, if a user uploads and executes a script, the commands
   run within the script are not captured, simply the output.

--- a/docs/pages/ibm-cloud-guide.mdx
+++ b/docs/pages/ibm-cloud-guide.mdx
@@ -56,7 +56,6 @@ stores the audit logs.
 We recommend Gen 2 Cloud IBM [Virtual Servers](https://www.ibm.com/cloud/virtual-servers) and [Auto Scaling](https://www.ibm.com/cloud/auto-scaling)
 
 - For Staging and POCs we recommend using `bx2-2x8` machines with 2 vCPUs, 4GB RAM, 4 Gbps.
-
 - For Production we would recommend `cx2-4x8` with 4 vCPUs, 8 GB RAM, 8 Gbps.
 
 ### Storage: Database for etcd

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -68,20 +68,20 @@ or a commercial edition ("Teleport Enterprise Edition").
 
 Teleport is officially supported on the platforms listed below. It is worth noting
 that the open source community has been successful in building and running Teleport on
-UNIX variants other than Linux [2].
+UNIX variants other than Linux \[2].
 
 | Operating System | Teleport Client | Teleport Server |
 | - | - | - |
 | Linux v2.6+ | yes | yes |
 | MacOS v10.12+ | yes | yes |
-| Windows [1] | yes [1] | no |
+| Windows \[1] | yes \[1] | no |
 
-[1] *Teleport server does not run on Windows yet, but `tsh` (the Teleport client)
+\[1] *Teleport server does not run on Windows yet, but `tsh` (the Teleport client)
 can be used on Windows to execute `tsh login` to retrieve a user's SSH
 certificate and use it with `ssh`, the OpenSSH client, running on a Windows
 client machine.*
 
-[2] *Teleport is written in Go and it is theoretically possible to build it on
+\[2] *Teleport is written in Go and it is theoretically possible to build it on
 any OS supported by the [Golang toolchain](https://github.com/golang/go/wiki/MinimumRequirements)*.
 
 ## Next Steps

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -36,12 +36,12 @@ up-to-date information.
 
   <TabItem label="ARMv7 (32-bit)">
     ```bash
-    $ curl https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz.sha256
+    $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz.sha256
     # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
-    $ shasum -a 256 teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
+    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+    $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
     # Verify that the checksums match
-    $ tar -xzf teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
+    $ tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
     $ cd teleport
     $ ./install
     ```
@@ -49,12 +49,12 @@ up-to-date information.
 
   <TabItem label="ARM64/ARMv8 (64-bit)">
     ```bash
-    $ curl https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz.sha256
+    $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz.sha256
     # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
-    $ shasum -a 256 teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
+    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+    $ shasum -a 256 teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
     # Verify that the checksums match
-    $ tar -xzf teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
+    $ tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
     $ cd teleport
     $ ./install
     ```
@@ -62,12 +62,12 @@ up-to-date information.
 
   <TabItem label="Tarball">
     ```bash
-    $ curl https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz.sha256
+    $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
     # <checksum> <filename>
-    $ curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-    $ shasum -a 256 teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    $ shasum -a 256 teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
     # Verify that the checksums match
-    $ tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    $ tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
     $ cd teleport
     $ ./install
     ```
@@ -79,7 +79,7 @@ up-to-date information.
 Please follow our [Getting started with Teleport using Docker](quickstart-docker.mdx) or with [Teleport Enterprise using Docker](enterprise/quickstart-enterprise.mdx#run-teleport-enterprise-using-docker) for install and setup instructions.
 
 ```bash
-$ docker pull quay.io/gravitational/teleport:{{ teleport.version }}
+$ docker pull quay.io/gravitational/teleport:(=teleport.version=)
 ```
 
 ## Helm
@@ -115,10 +115,10 @@ $ helm install teleport teleport/teleport
 
   <TabItem label="Terminal">
     ```bash
-    $ curl -O https://get.gravitational.com/teleport-{{ teleport.version }}.pkg
-    $ sudo installer -pkg teleport-{{ teleport.version }}.pkg -target / # Installs on Macintosh HD
+    $ curl -O https://get.gravitational.com/teleport-(=teleport.version=).pkg
+    $ sudo installer -pkg teleport-(=teleport.version=).pkg -target / # Installs on Macintosh HD
     Password:
-    installer: Package name is teleport-{{ teleport.version }}
+    installer: Package name is teleport-(=teleport.version=)
     installer: Upgrading at base path /
     installer: The upgrade was successful.
     $ which teleport
@@ -135,12 +135,12 @@ architecture - `teleport` and `tctl` are not supported.
 <Tabs>
   <TabItem label="Powershell">
     ```bash
-    > curl https://get.gravitational.com/teleport-v{{ teleport.version }}-windows-amd64-bin.zip.sha256
+    > curl https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip.sha256
     # <checksum> <filename>
-    > curl -O teleport-v{{ teleport.version }}-windows-amd64-bin.zip https://get.gravitational.com/teleport-v{{ teleport.version }}-windows-amd64-bin.zip
+    > curl -O teleport-v(=teleport.version=)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
     > echo %PATH% # Edit %PATH% if necessary
-    > certUtil -hashfile teleport-v{{ teleport.version }}-windows-amd64-bin.zip SHA256
-    SHA256 hash of teleport-v{{ teleport.version }}-windows-amd64-bin.zip:
+    > certUtil -hashfile teleport-v(=teleport.version=)-windows-amd64-bin.zip SHA256
+    SHA256 hash of teleport-v(=teleport.version=)-windows-amd64-bin.zip:
     # <checksum> <filename>
     CertUtil: -hashfile command completed successfully.
     # Verify that the checksums match
@@ -151,7 +151,7 @@ architecture - `teleport` and `tctl` are not supported.
 
 ## Installing from Source
 
-Gravitational Teleport is written in Go language. It requires **Golang v{{ teleport.golang }}**
+Gravitational Teleport is written in Go language. It requires **Golang v(=teleport.golang=)**
 or newer. Check [the repo
 README](https://github.com/gravitational/teleport#building-teleport) for the
 latest requirements.
@@ -202,7 +202,7 @@ obtain the checksum  by adding `.sha256` to the binary. This is the method shown
 in the installation examples.
 
 ```bash
-$ export version=v{{ teleport.version }}
+$ export version=v(=teleport.version=)
 $ export os=linux # 'darwin' 'linux' or 'windows'
 $ export arch=amd64 # '386' 'arm' on linux or 'amd64' for all distros
 $ curl https://get.gravitational.com/teleport-$version-$os-$arch-bin.tar.gz.sha256

--- a/docs/pages/kubernetes-5.0-migration.mdx
+++ b/docs/pages/kubernetes-5.0-migration.mdx
@@ -196,8 +196,7 @@ kubernetes_service:
 ```
 
 After all the Teleport agents are running, you can view the list of Kubernetes
-clusters using `tsh kube ls` and switch between them using `tsh kube login
-<kube_cluster_name>`:
+clusters using `tsh kube ls` and switch between them using `tsh kube login <kube_cluster_name>`:
 
 ```sh
 $ tsh kube ls

--- a/docs/pages/kubernetes-5.0-migration.mdx
+++ b/docs/pages/kubernetes-5.0-migration.mdx
@@ -351,10 +351,10 @@ metadata:
   name: admin
 spec:
   allow:
-    logins: ['{% raw %}{{internal.logins}}{% endraw %}']
+    logins: ['{{internal.logins}}']
     # Define the Kubernetes users and groups mapped to users with this role.
-    kubernetes_users: ["{% raw %}{{internal.kubernetes_users}}{% endraw %}"]
-    kubernetes_groups: ["some-group", "{% raw %}{{internal.kubernetes_groups}}{% endraw %}"]
+    kubernetes_users: ["{{internal.kubernetes_users}}"]
+    kubernetes_groups: ["some-group", "{{internal.kubernetes_groups}}"]
 
     # List of kubernetes labels a user will be allowed to connect to:
     kubernetes_labels:

--- a/docs/pages/kubernetes-access.mdx
+++ b/docs/pages/kubernetes-access.mdx
@@ -335,7 +335,7 @@ spec:
     # kubernetes groups the users of this role will be assigned to.
     # note that you can refer to a SAML/OIDC trait via the "external" property bag,
     # this allows you to specify Kubernetes group membership in an identity manager:
-    kubernetes_groups: ["system:masters", "{% raw %}{{external.trait_name}}{% endraw %}"]
+    kubernetes_groups: ["system:masters", "{{external.trait_name}}"]
 ```
 
 To add `kubernetes_groups` setting to an existing Teleport role, you can either
@@ -353,13 +353,13 @@ $ tctl create -f admin.yaml
   type="tip"
   title="Advanced Usage"
 >
-  `{% raw %}{{ external.trait_name }}{% endraw %}` example is shown to demonstrate how to fetch
+  `{{ external.trait_name }}` example is shown to demonstrate how to fetch
   the Kubernetes groups dynamically from Okta during login. In this case, you
   need to define Kubernetes group membership in Okta (as a trait) and use
   that trait name in the Teleport role.
 
   Teleport 4.3 has an option to extract the local part from an email claim. This can be helpful
-  since some operating systems don't support the @ symbol. This means by using `logins: ['{% raw %}{{email.local(external.email)}}{% endraw %}']` the resulting output will be `dave.smith` if the email was [dave.smith@acme.com](mailto:dave.smith@acme.com).
+  since some operating systems don't support the @ symbol. This means by using `logins: ['{{email.local(external.email)}}']` the resulting output will be `dave.smith` if the email was [dave.smith@acme.com](mailto:dave.smith@acme.com).
 </Admonition>
 
 Once setup is complete, when users execute `tsh login` and go through the usual Okta login

--- a/docs/pages/kubernetes-access.mdx
+++ b/docs/pages/kubernetes-access.mdx
@@ -33,7 +33,6 @@ Let's take a closer look at the available Kubernetes settings:
   a client's machine when a client executes tsh login command to retrieve its certificate.
   If you intend to run multiple Teleport proxies behind a load balancer, this must
   be the load balancer's public address.
-
 - `listen_addr` defines which network interface and port the Teleport proxy server
   should bind to. It defaults to port 3026 on all NICs.
 
@@ -208,7 +207,6 @@ configured. In this guide we'll look at two common configurations:
 
 - **Open source, Teleport Community edition** configured to authenticate users via [Github](admin-guide.mdx#github-oauth-20).
   In this case, we'll need to map Github teams to Kubernetes groups.
-
 - **Commercial, Teleport Enterprise edition** configured to authenticate users via [Okta SSO](enterprise/sso/ssh-okta.mdx).
   In this case, we'll need to map users' groups that come from Okta to Kubernetes
   groups.

--- a/docs/pages/metrics-logs-reference.mdx
+++ b/docs/pages/metrics-logs-reference.mdx
@@ -20,14 +20,11 @@ Now you can see the monitoring information by visiting several endpoints:
 - `http://127.0.0.1:3000/metrics` is the list of internal metrics Teleport is
   tracking. It is compatible with [Prometheus](https://prometheus.io/)
   collectors.
-
 - `http://127.0.0.1:3000/healthz` returns "OK" if the process is healthy or
   `503` otherwise.
-
 - `http://127.0.0.1:3000/readyz` is similar to `/healthz` , but it returns "OK"
   *only after* the node successfully joined the cluster, i.e.it draws the
   difference between "healthy" and "ready".
-
 - `http://127.0.0.1:3000/debug/pprof/` is Golang's standard profiler. It's only
   available when `-d` flag is given in addition to `--diag-addr`
 

--- a/docs/pages/openssh-teleport.mdx
+++ b/docs/pages/openssh-teleport.mdx
@@ -39,7 +39,6 @@ We consider the "recording proxy mode" to be less secure for two reasons:
   less critical to the security of the overall cluster. But if an attacker gains
   physical access to a proxy node running in the "recording" mode, they will be able
   to see the decrypted traffic and client keys stored in proxy's process memory.
-
 - Recording proxy mode requires the use of SSH agent forwarding. Agent forwarding is required
   because without it, a proxy will not be able to establish the 2nd connection to the
   destination node.
@@ -175,8 +174,8 @@ $ ssh -o "ForwardAgent yes" \
   type="tip"
   title="Tip"
 >
-  To avoid typing all this and use the usual `ssh user@host.example.com `, users
-  can update their ` ~/.ssh/config` file.
+  To avoid typing all this and use the usual `ssh user@host.example.com`, users
+  can update their `~/.ssh/config` file.
 </Admonition>
 
 ### Setup SSH agent forwarding

--- a/docs/pages/preview/database-access.mdx
+++ b/docs/pages/preview/database-access.mdx
@@ -624,8 +624,8 @@ propagating information from identity providers:
 ```yaml
 spec:
   allow:
-    db_names: ["{% raw %}{{internal.db_names}}{% endraw %}", "{% raw %}{{external.xxx}}{% endraw %}"]
-    db_users: ["{% raw %}{{internal.db_users}}{% endraw %}", "{% raw %}{{external.yyy}}{% endraw %}"]
+    db_names: ["{{internal.db_names}}", "{{external.xxx}}"]
+    db_users: ["{{internal.db_users}}", "{{external.yyy}}"]
 ```
 
 See general [RBAC](../enterprise/ssh-rbac.mdx) documentation for more details.

--- a/docs/pages/preview/upcoming-releases.mdx
+++ b/docs/pages/preview/upcoming-releases.mdx
@@ -82,10 +82,8 @@ They are not ready for production:
 
 - You can use alpha releases such as `5.0.1-alpha.1` for trying new features.
   Things can break and new changes may not be backwards-compatible.
-
 - Teleport `beta` releases, such as `5.0.1-beta.2` are suitable for staging environments.
   We are unlikely to change the APIs while we are ironing out bugs and UX glitches.
-
 - We mark release candidates as `5.0.1-rc.1` coding and bug fixes are finished.
   The team is going through the manual test plan to find any regressions.
 
@@ -95,7 +93,5 @@ Releases are ready for production use.
 
 - Releases `5.0.0` and `6.0.0` are major releases. We publish 4 major releases each year.
   Read more about upgrades and compatibility [here](../admin-guide.mdx#component-compatibility).
-
 - Releases `5.1.0` are minor releases. They contain minor backwards-compatible improvements and backports.
-
 - Versions like `5.0.1` are quick patches. They contain backwards-compatible fixes.

--- a/docs/pages/production.mdx
+++ b/docs/pages/production.mdx
@@ -80,7 +80,6 @@ There are a couple of important things to notice about this file:
 1. The start command in the unit file specifies `--config` as a file and there
    are very few flags passed to the `teleport` binary. Most of the configuration
    for Teleport should be done in the [configuration file](admin-guide.mdx#configuration).
-
 2. The **ExecReload** command allows admins to run `systemctl reload teleport`.
    This will attempt to perform a graceful restart of Teleport **but it only works if
    network-based backend storage like [DynamoDB](admin-guide.mdx#using-dynamodb) or

--- a/docs/pages/quickstart-docker.mdx
+++ b/docs/pages/quickstart-docker.mdx
@@ -28,10 +28,10 @@ easily keep your Teleport installation up to date.
 
 | Image name | Teleport version | Image automatically updated? | Image base |
 | - | - | - | - |
-| `quay.io/gravitational/teleport:{{ version }}` | The latest version of Teleport Community {{ version }} | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport:{{ teleport.version }}` | The version specified in the image's tag (i.e. {{ teleport.version }}) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport:(=version=)` | The latest version of Teleport Community (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport:(=teleport.version=)` | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
 
-For testing, we always recommend that you use the latest release version of Teleport, which is currently `{{teleport.latest_oss_docker_image}}`.
+For testing, we always recommend that you use the latest release version of Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
 
 ## Quickstart using docker-compose
 
@@ -69,14 +69,14 @@ mkdir -p ~/teleport/config ~/teleport/data
 docker run --hostname localhost --rm \
   --entrypoint=/bin/sh \
   -v ~/teleport/config:/etc/teleport \
-  {{teleport.latest_oss_docker_image}} -c "teleport configure > /etc/teleport/teleport.yaml"
+  (=teleport.latest_oss_docker_image=) -c "teleport configure > /etc/teleport/teleport.yaml"
 
 # start teleport with mounted config and data directories, plus all ports
 docker run --hostname localhost --name teleport \
   -v ~/teleport/config:/etc/teleport \
   -v ~/teleport/data:/var/lib/teleport \
   -p 3023:3023 -p 3025:3025 -p 3080:3080 \
-  {{teleport.latest_oss_docker_image}}
+  (=teleport.latest_oss_docker_image=)
 ```
 
 ## Creating a Teleport user when using Docker quickstart

--- a/docs/pages/quickstart-docker.mdx
+++ b/docs/pages/quickstart-docker.mdx
@@ -6,12 +6,12 @@ h1: Run Teleport using Docker
 
 We provide pre-built Docker images for every version of Teleport. These images are hosted on quay.io.
 
-- [All tags under `quay.io/gravitational/teleport` are Teleport Community images](https://quay.io/repository/gravitational/teleport?tag=latest&tab=tags)
+- [All tags under `quay.io/gravitational/teleport` are Teleport Community images](https://quay.io/repository/gravitational/teleport?tag=latest\&tab=tags)
 
 We currently only offer Docker images for `x86_64` architectures.
 
 <Admonition type="note">
-  You will need a recent version of [Docker](https://hub.docker.com/search?q=&type=edition&offering=community) installed to follow this section of the quick start guide.
+  You will need a recent version of [Docker](https://hub.docker.com/search?q=\&type=edition\&offering=community) installed to follow this section of the quick start guide.
 </Admonition>
 
 <Admonition type="warning">
@@ -28,8 +28,8 @@ easily keep your Teleport installation up to date.
 
 | Image name | Teleport version | Image automatically updated? | Image base |
 | - | - | - | - |
-| `quay.io/gravitational/teleport:(=version=)` | The latest version of Teleport Community (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
-| `quay.io/gravitational/teleport:(=teleport.version=)` | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/_/ubuntu) |
+| `quay.io/gravitational/teleport:(=version=)` | The latest version of Teleport Community (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `quay.io/gravitational/teleport:(=teleport.version=)` | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
 
 For testing, we always recommend that you use the latest release version of Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
 

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -51,8 +51,8 @@ Take a look at the [Teleport Installation](installation.mdx) page to pick the mo
 
   <TabItem label="ARMv7 (32-bit)">
     ```bash
-    curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
-    tar -xzf teleport-v{{ teleport.version }}-linux-arm-bin.tar.gz
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
     cd teleport
     sudo ./install
     ```
@@ -60,8 +60,8 @@ Take a look at the [Teleport Installation](installation.mdx) page to pick the mo
 
   <TabItem label="ARMv8 (64-bit)">
     ```bash
-    curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
-    tar -xzf teleport-v{{ teleport.version }}-linux-arm64-bin.tar.gz
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
     cd teleport
     sudo ./install
     ```
@@ -69,8 +69,8 @@ Take a look at the [Teleport Installation](installation.mdx) page to pick the mo
 
   <TabItem label="Linux Tarball">
     ```bash
-    curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-    tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
     cd teleport
     sudo ./install
     ```
@@ -232,7 +232,7 @@ Here's a selection of compatible Two-Factor authentication apps:
 
   <TabItem label="Windows - Powershell">
     ```bash
-    curl -O teleport-v{{ teleport.version }}-windows-amd64-bin.zip https://get.gravitational.com/teleport-v{{ teleport.version }}-windows-amd64-bin.zip
+    curl -O teleport-v(=teleport.version=)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
     # Unzip the archive and move `tsh.exe` to your %PATH%
     ```
   </TabItem>
@@ -241,8 +241,8 @@ Here's a selection of compatible Two-Factor authentication apps:
     For more options (including RPM/DEB packages and downloads for i386/ARM/ARM64) please see our [installation page](installation.mdx).
 
     ```bash
-    curl -O https://get.gravitational.com/teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
-    tar -xzf teleport-v{{ teleport.version }}-linux-amd64-bin.tar.gz
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
     cd teleport
     sudo ./install
     Teleport binaries have been copied to /usr/local/bin
@@ -357,8 +357,8 @@ Armed with these details, we'll bootstrap a new host using
 
     runcmd:
     - 'mkdir -p /tmp/teleport'
-    - 'cd /tmp/teleport && curl -O https://get.gravitational.com/teleport_{{ teleport.version }}_amd64.deb'
-    - 'dpkg -i /tmp/teleport/teleport_5.0.0-{{ teleport.version }}_amd64.deb'
+    - 'cd /tmp/teleport && curl -O https://get.gravitational.com/teleport_(=teleport.version=)_amd64.deb'
+    - 'dpkg -i /tmp/teleport/teleport_5.0.0-(=teleport.version=)_amd64.deb'
     - 'systemctl enable teleport.service'
     - 'systemctl start teleport.service'
     ```

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -205,10 +205,10 @@ Here's a selection of compatible Two-Factor authentication apps:
 >
   The OS users that you specify (`root`, `ubuntu` and `ec2-user` in our examples) must exist!
   On Linux, if a user does not already exist, you can create it with `adduser <login>`. If you
-  do not have the permission to create new users on the Linux host, run `tctl users add teleport
-  $(whoami)` to explicitly allow Teleport to authenticate as the user that you are currently logged
-  in as. If you do not map to an existing OS user,  you will get authentication errors later on in
-  this tutorial!
+  do not have the permission to create new users on the Linux host, run
+  `tctl users add teleport $(whoami)` to explicitly allow Teleport to authenticate as the user
+  that you are currently logged in as. If you do not map to an existing OS user,  you will get
+  authentication errors later on in this tutorial!
 </Admonition>
 
 ![Teleport UI Dashboard](../img/quickstart/teleport-nodes.png)

--- a/docs/pages/trustedclusters.mdx
+++ b/docs/pages/trustedclusters.mdx
@@ -88,11 +88,9 @@ This setup works as follows:
 
 1. The "leaf" creates an outbound reverse SSH tunnel to "root" and keeps the
    tunnel open.
-
 2. **Accessibility only works in one direction.** The "leaf" cluster allows
    users from "root" to access its nodes but users in the "leaf" cluster can not
    access the "root" cluster.
-
 3. When a user tries to connect to a node inside "leaf" using root's proxy, the
    reverse tunnel from step 1 is used to establish this connection shown as the
    green line above.
@@ -265,7 +263,6 @@ Lets make a few assumptions for this example:
 
 - The cluster "root" has two roles: *user* for regular users and *admin* for
   local administrators.
-
 - We want administrators from "root" (but not regular users!) to have
   restricted access to "leaf". We want to deny them access to machines
   with "environment=production" and any Government cluster labeled "customer=gov"

--- a/docs/pages/trustedclusters.mdx
+++ b/docs/pages/trustedclusters.mdx
@@ -516,15 +516,15 @@ role_map:
 The role `admin` of the leaf cluster can now be set up to use the root cluster role logins and `kubernetes_groups` using the following variables:
 
 ```yaml
-logins: ["{% raw %}{{internal.logins}}{% endraw %}"]
-kubernetes_groups: ["{% raw %}{{internal.kubernetes_groups}}{% endraw %}"]
+logins: ["{{internal.logins}}"]
+kubernetes_groups: ["{{internal.kubernetes_groups}}"]
 ```
 
 <Admonition
   type="tip"
   title="Note"
 >
-  In order to pass logins from a root trusted cluster to a leaf cluster, you must use the variable `{% raw %}{{internal.logins}}{% endraw %}`.
+  In order to pass logins from a root trusted cluster to a leaf cluster, you must use the variable `{{internal.logins}}`.
 </Admonition>
 
 ## How does it work?

--- a/docs/pages/user-manual.mdx
+++ b/docs/pages/user-manual.mdx
@@ -514,7 +514,6 @@ most of them can be mitigated.
    cluster you are connecting to. But if you execute `tsh --proxy=xxx login`,
    the current proxy will be saved in your `~/.tsh` profile and won't be needed
    for other `tsh` commands.
-
 2. `tsh ssh` operates *two* usernames: one for the cluster and another for the
    node you are trying to log into. See [User Identities](#user-identities)
    section below. For convenience, `tsh` assumes `$USER` for both by default.


### PR DESCRIPTION
DO NOT MERGE before deploying docs engine.

- Update variable syntax.
- Update includes syntax.
- Fix error with codeblocks inside tabs.
- Run markdown-fix.
- Manually fix list item spacing.
- Add thead/tbody to tables.