### PR TITLE
client: load all SSH certs when connecting to proxy

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1939,7 +1939,14 @@ func (tc *TeleportClient) connectToProxy(ctx context.Context) (*ProxyClient, err
 			}
 		}
 	} else if tc.localAgent != nil {
-		signers, err := tc.localAgent.certsForCluster(tc.SiteName)
+		// tc.SiteName does not necessarily point to the cluster we're
+		// connecting to (or that we have certs for). For example tsh login
+		// leaf will set tc.SiteName as "leaf" even though we're connecting to
+		// root proxy to fetch leaf certs.
+		//
+		// Instead, load SSH certs for all clusters we have (by passing an
+		// empty string to certsForCluster).
+		signers, err := tc.localAgent.certsForCluster("")
 		// errNoLocalKeyStore is returned when running in the proxy. The proxy
 		// should be passing auth methods via tc.Config.AuthMethods.
 		if err != nil && !errors.Is(err, errNoLocalKeyStore) {


### PR DESCRIPTION
`tc.SiteName` does not necessarily point to the cluster we're connecting
to (or that we have certs for). For example `tsh login leaf` will set
`tc.SiteName` as `"leaf"` even though we're connecting to root proxy to
fetch leaf certs.