### PR TITLE
Backport: docs: document per-session MFA feature

### DIFF
--- a/docs/pages/access-controls/guides.mdx
+++ b/docs/pages/access-controls/guides.mdx
@@ -7,3 +7,5 @@ description: Detailed guides for configuring Teleport Access Controls
 
 - [Dynamic access policies with role templates](./guides/role-templates.mdx)
 - [Create certs for CI/CD using impersonation](./guides/impersonation.mdx)
+- [Second Factor - U2F](./guides/u2f.mdx)
+- [Per-session MFA](./guides/per-session-mfa.mdx)

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -1,0 +1,142 @@
+---
+title: Per-session MFA
+description: Require U2F checks for user SSH and Kubernetes sessions
+---
+
+# Per-session MFA
+
+Teleport supports U2F authentication on every SSH and Kubernetes "connection"
+(a single `tsh ssh` or `kubectl` call). This is an advanced security feature
+that protects users against compromises of their on-disk Teleport certificates.
+
+<Admonition type="note">
+  Per-session U2F checks don't apply to regular Teleport logins (`tsh login` or
+  logging into the Web UI). We encourage you to enable login MFA in your SSO
+  provider and/or for all [local Teleport
+  users](../../admin-guide.mdx#local-connector).
+</Admonition>
+
+## Prerequisites
+
+- [Teleport cluster](../getting-started.mdx)
+- [U2F configured](u2f.mdx) on this cluster
+- U2F hardware device, such as Yubikey or Solokey
+- Web browser that [supports U2F](https://caniuse.com/u2f) (if using SSH from
+  the Teleport Web UI)
+
+## Configuration
+
+Per-session MFA can be enforced cluster-wide or only for some specific roles.
+
+### Cluster-wide
+
+To enforce U2F checks cluster-wide, update `teleport.yaml` on the Auth server
+to contain:
+
+```yaml
+auth_service:
+  authentication:
+    # require per-session MFA cluster-wide
+    require_session_mfa: yes
+```
+
+### Per role
+
+To enforce U2F checks for a specific role, update the role to contain:
+
+```yaml
+kind: role
+version: v3
+metadata:
+  name: example-role-with-mfa
+spec:
+  options:
+    # require per-session MFA for this role
+    require_session_mfa: true
+  allow:
+    ...
+  deny:
+    ...
+```
+
+Role-specific enforcement only applies when accessing SSH nodes or Kubernetes
+clusters matching that role's `allow` section.
+
+#### Roles example
+
+Let's walk though an example of setting up per-session MFA checks for roles.
+
+Jerry is an engineer with access to the company infrastructure. The
+infrastructure is split into development and production environments. Security
+engineer Olga wants to enforce MFA checks for accessing production servers.
+Development servers don't require this to reduce engineers' friction.
+
+Olga defines two Teleport roles: `access-dev` and `access-prod`:
+
+```yaml
+# access-dev.yaml
+kind: role
+version: v3
+metadata:
+  name: access-dev
+spec:
+  allow:
+    node_labels:
+    - env: dev
+    kubernetes_labels:
+    - env: dev
+  deny: {}
+
+# access-prod.yaml
+kind: role
+version: v3
+metadata:
+  name: access-prod
+  options:
+    # require per-session MFA for production access
+    require_session_mfa: true
+spec:
+  allow:
+    node_labels:
+    - env: prod
+    kubernetes_labels:
+    - env: prod
+  deny: {}
+```
+
+Olga then assigns both roles to all engineers, including Jerry.
+
+When Jerry logs into node `dev1.example.com` (with label `env: dev`), nothing
+special happens:
+
+```sh
+jerry@localhost $ tsh ssh dev1.example.com
+
+jerry@dev1.example.com >
+```
+
+But when Jerry logs into node `prod3.example.com` (with label `env: prod`), he
+gets prompted for an MFA check:
+
+```sh
+jerry@localhost $ tsh ssh prod3.example.com
+Tap any security key <tap>
+
+jerry@prod3.example.com >
+```
+
+If per-session MFA was enabled cluster-wide, Jerry would be prompted for MFA
+even when logging into `dev1.example.com`.
+
+## Limitations
+
+There are several limitations for this feature:
+- U2F devices are currently not supported in `tsh` on Windows.
+- Only `tsh ssh` supports per-session U2F authentication for SSH (OpenSSH `ssh`
+  does not).
+- Only `kubectl` supports per-session U2F authentication for Kubernetes.
+- Database and Application access clients do not support per-session U2F
+  authentication yet, although cluster and role configuration applies to them.
+  If you enable per-session U2F checks cluster-wide, you will not be able to
+  use Database or Application access. We are working on integrating per-session
+  U2F checks for these clients.

--- a/docs/pages/access-controls/guides/u2f.mdx
+++ b/docs/pages/access-controls/guides/u2f.mdx
@@ -1,0 +1,122 @@
+---
+title: Second Factor - U2F
+description: Configuring U2F support in Teleport clusters
+---
+
+# U2F
+
+Teleport supports [FIDO U2F](https://www.yubico.com/about/background/fido/)
+hardware keys as a second authentication factor. U2F can be used for logging
+into Teleport (`tsh login` or the login page on the Web UI) and for logging
+into individual SSH nodes or Kubernetes clusters (`tsh ssh` and `kubectl`).
+
+## Prerequisites
+
+- [Teleport cluster](../getting-started.mdx)
+- U2F hardware device, such as Yubikey or Solokey
+- Web browser that [supports U2F](https://caniuse.com/u2f)
+
+## Enable U2F support
+
+By default U2F is disabled. To enable U2F support, edit the Teleport
+configuration file `/etc/teleport.yaml` like so:
+
+```yaml
+# snippet from /etc/teleport.yaml to show an example configuration of U2F:
+auth_service:
+  authentication:
+    type: local
+    # to enable U2F support, set this field to 'u2f', 'on' or 'optional'
+    second_factor: u2f
+    u2f:
+       app_id: https://example.com:443
+       facets:
+       - https://example.com:443
+       - https://example.com
+       - example.com:443
+       - example.com
+       device_attestation_cas:
+       - "/path/to/u2f_attestation_ca.pem"
+```
+
+The fields in the above snippet are:
+
+- `app_id` - public address of the Teleport proxy, *including* the `https://`
+  prefix and port number.
+
+<Admonition
+  type="warning"
+  title="Warning"
+>
+  The `app_id` must never change in the lifetime of the cluster, because it's
+  recorded in the registration data on the U2F device. If the App ID changes,
+  all existing U2F key registrations will become invalid and all users who use
+  U2F as the second factor will need to re-register. When using multiple proxy
+  servers, make sure they are reachable at the same public address (usually
+  behind a load balancer).
+</Admonition>
+
+- `facets` - list of allowed addresses of the Teleport proxy, checked during
+  authentication attempts. This list is used to prevent malicious websites and
+  proxies from requesting U2F challenges on behalf of the legitimate proxy.
+
+  For compatibility with multiple browsers, it's recommended to write down the
+  proxy address in several formats. For example, if your `app_id` is
+  `https://example.com:443`, your `facets` should include
+  `https://example.com:443`, `https://example.com` and `example.com:443`.
+
+- `device_attestation_cas` - optional list of certificate authorities (as local
+  file paths or in-line PEM certificate string) for U2F [device
+  attestation](https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-overview.html#verifying-that-a-u2f-device-is-genuine)
+  verification. This field allows you to restrict which U2F device vendors you
+  trust. Devices from other vendors will be rejected during registration. By
+  default, any vendor is allowed.
+
+Once the configuration file was edited, restart `teleport` to pick up the
+changes.
+
+## Register U2F devices as a user
+
+A user can register multiple U2F devices [using
+`tsh`](../../cli-docs.mdx#tsh-mfa-add):
+
+```bash
+$ tsh mfa add
+Choose device type [TOTP, U2F]: u2f
+Enter device name: desktop yubikey
+Tap any *registered* security key
+Tap your *new* security key
+MFA device "desktop yubikey" added.
+```
+
+<Admonition type="warning" title="Windows support">
+  U2F devices are currently not supported in `tsh` on Windows.
+</Admonition>
+
+## Login using U2F
+
+Once a U2F device is registered, the user will be prompted for it on login:
+
+```sh
+$ tsh login --proxy=example.com
+Enter password for Teleport user awly:
+Tap any security key <tap U2F token>
+> Profile URL:        https://example.com
+  Logged in as:       awly
+  Cluster:            example.com
+  Roles:              admin*
+  Logins:             awly
+  Kubernetes:         enabled
+  Valid until:        2021-04-01 23:32:29 -0700 PDT [valid for 12h0m0s]
+  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
+```
+
+<Admonition type="note">
+U2F for logging into Teleport is only required for [local
+users](../../admin-guide.mdx#local-connector). SSO users should configure
+multi-factor authentication in their SSO provider.
+</Admonition>
+
+## Next Steps
+
+- [Setup per-session U2F checks](per-session-mfa.mdx)

--- a/docs/pages/access-controls/introduction.mdx
+++ b/docs/pages/access-controls/introduction.mdx
@@ -38,3 +38,5 @@ guide.
 
 - [Dynamic Access Policies with Role Templates](./guides/role-templates.mdx)
 - [Create certs for CI/CD using impersonation](./guides/impersonation.mdx)
+- [Second Factor - U2F](./guides/u2f.mdx)
+- [Per-session MFA](./guides/per-session-mfa.mdx)

--- a/docs/pages/admin-guide.mdx
+++ b/docs/pages/admin-guide.mdx
@@ -364,56 +364,11 @@ auth_service:
     type: oidc
 ```
 
-### Hardware Keys - YubiKey FIDO U2F
+### Hardware Keys - FIDO U2F
 
 Teleport supports [FIDO U2F](https://www.yubico.com/about/background/fido/)
-hardware keys as a second authentication factor. By default U2F is disabled. To
-start using U2F:
-
-- Enable U2F in Teleport configuration `/etc/teleport.yaml` .
-- For web-based logins, check that your browser [supports
-  U2F](https://caniuse.com/u2f).
-
-```yaml
-# snippet from /etc/teleport.yaml to show an example configuration of U2F:
-auth_service:
-  authentication:
-    type: local
-    # to enabled U2F support, set this field to 'u2f', 'on' or 'optional'
-    second_factor: u2f
-    u2f:
-       # app_id must point to the URL of the Teleport Web UI (proxy) accessible
-       # by the end users
-       app_id: https://localhost:3080
-       # facets must list all proxy servers if there are more than one deployed
-       facets:
-       - https://localhost:3080
-```
-
-For single-proxy setups, the `app_id` setting can be equal to the domain name of
-the proxy, but this will prevent you from adding more proxies without changing
-the `app_id` . For multi-proxy setups, the `app_id` should be an HTTPS URL
-pointing to a JSON file that mirrors `facets` in the auth config.
-
-<Admonition
-  type="warning"
-  title="Warning"
->
-  The `app_id` must never change in the lifetime of the
-  cluster. If the App ID changes, all existing U2F key registrations will
-  become invalid and all users who use U2F as the second factor will need to
-  re-register. When adding a new proxy server, make sure to add it to the list
-  of "facets" in the configuration file, but also to the JSON file referenced
-  by `app_id`
-</Admonition>
-
-**Logging in with U2F**
-
-Invoke `tsh ssh` as usual to authenticate:
-
-```bash
-$ tsh --proxy <proxy-addr> ssh <hostname>
-```
+hardware keys as a second authentication factor. See [the U2F
+guide](access-controls/guides/u2f.mdx) for setup instructions.
 
 ## Adding and Deleting Users
 

--- a/docs/pages/config-reference.mdx
+++ b/docs/pages/config-reference.mdx
@@ -165,12 +165,38 @@ auth_service:
         second_factor: otp
         # this section is used if second_factor is set to 'u2f'
         u2f:
-            # app_id must point to the URL of the Teleport Web UI (proxy) accessible
-            # by the end users
+            # public address of the Teleport proxy, _including_ the `https://`
+            # prefix and port number.
+            #
+            # IMPORTANT: app_id must never change in the lifetime of the
+            # cluster, because it's recorded in the registration data on the
+            # U2F device. If the app_id changes, all existing U2F key
+            # registrations will become invalid and all users who use U2F as
+            # the second factor will need to re-register.
             app_id: https://localhost:3080
-            # facets must list all proxy servers if there are more than one deployed
+
+            # list of allowed addresses of the Teleport proxy, checked during
+            # authentication attempts. This list is used to prevent malicious
+            # websites and proxies from requesting U2F challenges on behalf of
+            # the legitimate proxy.
             facets:
             - https://localhost:3080
+            - https://localhost
+            - localhost:3080
+            - localhost
+
+            # optional list of certificate authorities (as local file paths or
+            # in-line PEM certificate string) for U2F [device
+            # attestation](https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-overview.html#verifying-that-a-u2f-device-is-genuine)
+            # verification. This field allows you to restrict which U2F device
+            # vendors you trust. Devices from other vendors will be rejected
+            # during registration. By default, any vendor is allowed.
+            device_attestation_cas:
+            - /path/to/u2f_ca.pem
+            - |
+              -----BEGIN CERTIFICATE-----
+              ...
+              -----END CERTIFICATE-----
 
     # IP and the port to bind to. Other Teleport nodes will be connecting to
     # this port (AKA "Auth API" or "Cluster API") to validate client


### PR DESCRIPTION
Backport of  #6285 into v6

* docs: document per-session MFA feature

Also, update general U2F configuration docs to explain server-side
configs better.

* docs: move U2F docs to dedicated guides