### PR TITLE
[branch/4.4] Backport #6431

### DIFF
--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -104,6 +104,7 @@ func NewUploader(cfg UploaderConfig) (*Uploader, error) {
 	}
 	uploadCompleter, err := events.NewUploadCompleter(events.UploadCompleterConfig{
 		Uploader:  handler,
+		AuditLog:  cfg.AuditLog,
 		Unstarted: true,
 	})
 	if err != nil {


### PR DESCRIPTION
This adjusts the fix implemented in #6326 with the adjustments in #6431 to emit to the correct audit log instead of discarding.