### PR TITLE
Revert "[web] Check for cloud feature before setting billing access"

### DIFF
--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -18,7 +18,6 @@ package ui
 
 import (
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -179,11 +178,7 @@ func NewUserContext(user services.User, userRoles services.RoleSet) (*UserContex
 	nodeAccess := newAccess(userRoles, ctx, services.KindNode)
 	appServerAccess := newAccess(userRoles, ctx, services.KindAppServer)
 	requestAccess := newAccess(userRoles, ctx, services.KindAccessRequest)
-
-	var billingAccess access
-	if modules.GetModules().Features().Cloud {
-		billingAccess = newAccess(userRoles, ctx, services.KindBilling)
-	}
+	billingAccess := newAccess(userRoles, ctx, services.KindBilling)
 
 	logins := getLogins(userRoles)
 	accessStrategy := getAccessStrategy(userRoles)


### PR DESCRIPTION
Reverting commit that is causing panic caused by accessing nil modules when auth/proxy are run separately (so it isn't blocking devs from using UI while proper fix is coming)