### PR TITLE
Backport v6: docs: fix typos in sample roles in MFA guide

### DIFF
--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -82,11 +82,11 @@ metadata:
 spec:
   allow:
     node_labels:
-    - env: dev
+      env: dev
     kubernetes_labels:
-    - env: dev
+      env: dev
   deny: {}
-
+---
 # access-prod.yaml
 kind: role
 version: v3
@@ -98,9 +98,9 @@ metadata:
 spec:
   allow:
     node_labels:
-    - env: prod
+      env: prod
     kubernetes_labels:
-    - env: prod
+      env: prod
   deny: {}
 ```
 


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/6543 into branch/v6