### PR TITLE
Proxy line support for mysql

### DIFF
--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -319,9 +319,12 @@ func detect(conn net.Conn, enableProxyProtocol bool) (*Conn, error) {
 	return nil, trace.BadParameter("unknown protocol")
 }
 
+// Protocol defines detected protocol type.
+type Protocol int
+
 const (
 	// ProtoUnknown is for unknown protocol
-	ProtoUnknown = iota
+	ProtoUnknown Protocol = iota
 	// ProtoTLS is TLS protocol
 	ProtoTLS
 	// ProtoSSH is SSH protocol
@@ -379,7 +382,7 @@ func isHTTP(in []byte) bool {
 	return false
 }
 
-func detectProto(in []byte) (int, error) {
+func detectProto(in []byte) (Protocol, error) {
 	switch {
 	// reader peeks only 3 bytes, slice the longer proxy prefix
 	case bytes.HasPrefix(in, proxyPrefix[:3]):

--- a/lib/multiplexer/testproxy.go
+++ b/lib/multiplexer/testproxy.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplexer
+
+import (
+	"io"
+	"net"
+
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// TestProxy is tcp passthrough proxy that sends a proxy-line when connecting
+// to the target server.
+type TestProxy struct {
+	listener net.Listener
+	target   string
+	closeCh  chan (struct{})
+	log      logrus.FieldLogger
+}
+
+// NewTestProxy creates a new test proxy that sends a proxy-line when
+// proxying connections to the provided target address.
+func NewTestProxy(target string) (*TestProxy, error) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &TestProxy{
+		listener: listener,
+		target:   target,
+		closeCh:  make(chan struct{}),
+		log:      logrus.WithField(trace.Component, "test:proxy"),
+	}, nil
+}
+
+// Address returns the proxy listen address.
+func (p *TestProxy) Address() string {
+	return p.listener.Addr().String()
+}
+
+// Serve starts accepting client connections and proxying them to the target.
+func (p *TestProxy) Serve() error {
+	for {
+		clientConn, err := p.listener.Accept()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		go func() {
+			if err := p.handleConnection(clientConn); err != nil {
+				p.log.WithError(err).Error("Failed to handle connection.")
+			}
+		}()
+	}
+}
+
+// handleConnection dials the target address, sends a proxy line to it and
+// then starts proxying all traffic b/w client and target.
+func (p *TestProxy) handleConnection(clientConn net.Conn) error {
+	serverConn, err := net.Dial("tcp", p.target)
+	if err != nil {
+		clientConn.Close()
+		return trace.Wrap(err)
+	}
+	defer serverConn.Close()
+	errCh := make(chan error, 2)
+	go func() { // Client -> server.
+		defer clientConn.Close()
+		defer serverConn.Close()
+		// Write proxy-line first and then start proxying from client.
+		err := p.sendProxyLine(clientConn, serverConn)
+		if err == nil {
+			_, err = io.Copy(serverConn, clientConn)
+		}
+		errCh <- trace.Wrap(err)
+	}()
+	go func() { // Server -> client.
+		defer clientConn.Close()
+		defer serverConn.Close()
+		_, err := io.Copy(clientConn, serverConn)
+		errCh <- trace.Wrap(err)
+	}()
+	var errs []error
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errCh:
+			if err != nil && !utils.IsOKNetworkError(err) {
+				errs = append(errs, err)
+			}
+		case <-p.closeCh:
+			p.log.Debug("Closing.")
+			return trace.NewAggregate(errs...)
+		}
+	}
+	return trace.NewAggregate(errs...)
+}
+
+// sendProxyLine sends proxy-line to the server.
+func (p *TestProxy) sendProxyLine(clientConn, serverConn net.Conn) error {
+	clientAddr, err := utils.ParseAddr(clientConn.RemoteAddr().String())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	serverAddr, err := utils.ParseAddr(serverConn.RemoteAddr().String())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	proxyLine := &ProxyLine{
+		Protocol:    TCP4,
+		Source:      net.TCPAddr{IP: net.ParseIP(clientAddr.Host()), Port: clientAddr.Port(0)},
+		Destination: net.TCPAddr{IP: net.ParseIP(serverAddr.Host()), Port: serverAddr.Port(0)},
+	}
+	_, err = serverConn.Write([]byte(proxyLine.String()))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// Close closes the proxy listener.
+func (p *TestProxy) Close() error {
+	close(p.closeCh)
+	return p.listener.Close()
+}

--- a/lib/srv/db/audit_test.go
+++ b/lib/srv/db/audit_test.go
@@ -35,7 +35,6 @@ import (
 func TestAuditPostgres(t *testing.T) {
 	ctx := context.Background()
 	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
-	t.Cleanup(func() { testCtx.Close() })
 	go testCtx.startHandlingConnections()
 
 	testCtx.createUserAndRole(ctx, t, "alice", "admin", []string{"postgres"}, []string{"postgres"})
@@ -71,7 +70,6 @@ func TestAuditPostgres(t *testing.T) {
 func TestAuditMySQL(t *testing.T) {
 	ctx := context.Background()
 	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
-	t.Cleanup(func() { testCtx.Close() })
 	go testCtx.startHandlingConnections()
 
 	testCtx.createUserAndRole(ctx, t, "alice", "admin", []string{"root"}, []string{types.Wildcard})

--- a/lib/srv/db/auth_test.go
+++ b/lib/srv/db/auth_test.go
@@ -42,7 +42,6 @@ func TestAuthTokens(t *testing.T) {
 		withCloudSQLPostgres("postgres-cloudsql-incorrect-token", "qwe123"),
 		withRDSMySQL("mysql-rds-correct-token", "root", rdsAuthToken),
 		withRDSMySQL("mysql-rds-incorrect-token", "root", "qwe123"))
-	t.Cleanup(func() { testCtx.Close() })
 	go testCtx.startHandlingConnections()
 
 	testCtx.createUserAndRole(ctx, t, "alice", "admin", []string{types.Wildcard}, []string{types.Wildcard})

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -19,12 +19,11 @@ package mysql
 import (
 	"context"
 	"net"
-	"strings"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/mysql/protocol"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/siddontang/go-mysql/client"
 	"github.com/siddontang/go-mysql/packet"
@@ -64,8 +63,8 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 	proxyConn := server.Conn{Conn: packet.NewConn(clientConn)}
 	defer func() {
 		if err != nil {
-			if err := proxyConn.WriteError(err); err != nil {
-				e.Log.WithError(err).Error("Failed to send error to client.")
+			if writeErr := proxyConn.WriteError(err); writeErr != nil {
+				e.Log.WithError(writeErr).Debugf("Failed to send error %q to MySQL client.", err)
 			}
 		}
 	}()
@@ -174,10 +173,17 @@ func (e *Engine) receiveFromClient(clientConn, serverConn net.Conn, clientErrCh 
 		"client": clientConn.RemoteAddr(),
 		"server": serverConn.RemoteAddr(),
 	})
-	defer log.Debug("Stop receiving from client.")
+	defer func() {
+		log.Debug("Stop receiving from client.")
+		close(clientErrCh)
+	}()
 	for {
 		packet, err := protocol.ParsePacket(clientConn)
 		if err != nil {
+			if utils.IsOKNetworkError(err) {
+				log.Debug("Client connection closed.")
+				return
+			}
 			log.WithError(err).Error("Failed to read client packet.")
 			clientErrCh <- err
 			return
@@ -186,7 +192,6 @@ func (e *Engine) receiveFromClient(clientConn, serverConn net.Conn, clientErrCh 
 		case *protocol.Query:
 			e.Audit.OnQuery(e.Context, sessionCtx, pkt.Query())
 		case *protocol.Quit:
-			clientErrCh <- nil
 			return
 		}
 		_, err = protocol.WritePacket(packet.Bytes(), serverConn)
@@ -206,13 +211,15 @@ func (e *Engine) receiveFromServer(serverConn, clientConn net.Conn, serverErrCh 
 		"client": clientConn.RemoteAddr(),
 		"server": serverConn.RemoteAddr(),
 	})
-	defer log.Debug("Stop receiving from server.")
+	defer func() {
+		log.Debug("Stop receiving from server.")
+		close(serverErrCh)
+	}()
 	for {
 		packet, err := protocol.ParsePacket(serverConn)
 		if err != nil {
-			if strings.Contains(err.Error(), teleport.UseOfClosedNetworkConnection) {
+			if utils.IsOKNetworkError(err) {
 				log.Debug("Server connection closed.")
-				serverErrCh <- nil
 				return
 			}
 			log.WithError(err).Error("Failed to read server packet.")

--- a/lib/srv/db/proxy_test.go
+++ b/lib/srv/db/proxy_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/multiplexer"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestProxyProtocolPostgres ensures that clients can successfully connect to a
+// Postgres database when Teleport is running behind a proxy that sends a proxy
+// line.
+func TestProxyProtocolPostgres(t *testing.T) {
+	ctx := context.Background()
+	testCtx := setupTestContext(ctx, t, withSelfHostedPostgres("postgres"))
+	go testCtx.startHandlingConnections()
+
+	testCtx.createUserAndRole(ctx, t, "alice", "admin", []string{"postgres"}, []string{"postgres"})
+
+	// Point our proxy to the Teleport's db listener on the multiplexer.
+	proxy, err := multiplexer.NewTestProxy(testCtx.mux.DB().Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { proxy.Close() })
+	go proxy.Serve()
+
+	// Connect to the proxy instead of directly to Postgres listener and make
+	// sure the connection succeeds.
+	psql, err := testCtx.postgresClientWithAddr(ctx, proxy.Address(), "alice", "postgres", "postgres", "postgres")
+	require.NoError(t, err)
+	require.NoError(t, psql.Close(ctx))
+}
+
+// TestProxyProtocolMySQL ensures that clients can successfully connect to a
+// MySQL database when Teleport is running behind a proxy that sends a proxy
+// line.
+func TestProxyProtocolMySQL(t *testing.T) {
+	ctx := context.Background()
+	testCtx := setupTestContext(ctx, t, withSelfHostedMySQL("mysql"))
+	go testCtx.startHandlingConnections()
+
+	testCtx.createUserAndRole(ctx, t, "alice", "admin", []string{"root"}, []string{types.Wildcard})
+
+	// Point our proxy to the Teleport's MySQL listener.
+	proxy, err := multiplexer.NewTestProxy(testCtx.mysqlListener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { proxy.Close() })
+	go proxy.Serve()
+
+	// Connect to the proxy instead of directly to MySQL listener and make
+	// sure the connection succeeds.
+	mysql, err := testCtx.mysqlClientWithAddr(proxy.Address(), "alice", "mysql", "root")
+	require.NoError(t, err)
+	require.NoError(t, mysql.Close())
+}

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -259,7 +259,7 @@ func (s *ProxyServer) Proxy(ctx context.Context, clientConn, serviceConn io.Read
 	for i := 0; i < 2; i++ {
 		select {
 		case err := <-errCh:
-			if err != nil && !trace.IsEOF(err) && !strings.Contains(err.Error(), teleport.UseOfClosedNetworkConnection) {
+			if err != nil && !utils.IsOKNetworkError(err) {
 				s.log.WithError(err).Warn("Connection problem.")
 				errs = append(errs, err)
 			}

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -34,11 +34,9 @@ func TestDatabaseServerStart(t *testing.T) {
 	testCtx := setupTestContext(ctx, t,
 		withSelfHostedPostgres("postgres"),
 		withSelfHostedMySQL("mysql"))
-	t.Cleanup(func() { testCtx.Close() })
 
 	err := testCtx.server.Start()
 	require.NoError(t, err)
-	t.Cleanup(func() { testCtx.server.Close() })
 
 	tests := []struct {
 		server types.DatabaseServer

--- a/lib/utils/errors.go
+++ b/lib/utils/errors.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"github.com/gravitational/teleport"
+
+	"github.com/gravitational/trace"
 )
 
 // IsUseOfClosedNetworkError returns true if the specified error
@@ -30,4 +32,10 @@ func IsUseOfClosedNetworkError(err error) bool {
 		return false
 	}
 	return strings.Contains(err.Error(), teleport.UseOfClosedNetworkConnection)
+}
+
+// IsOKNetworkError returns true if the provided error received from a network
+// operation is one of those that usually indicate normal connection close.
+func IsOKNetworkError(err error) bool {
+	return trace.IsEOF(err) || IsUseOfClosedNetworkError(err)
 }


### PR DESCRIPTION
Add proxy protocol support to MySQL listener. Without this, MySQL access doesn't currently work in the Cloud. Fixes https://github.com/gravitational/teleport/issues/6517.

Needs backport to 6.2.