### PR TITLE
[v6.1] access requests from workflows

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -124,7 +124,7 @@
           "slug": "/enterprise/quickstart-enterprise/"
         },
         { "title": "Single Sign-On (SSO)", "slug": "/enterprise/sso/ssh-sso/" },
-        { "title": "Access Workflows", "slug": "/enterprise/workflow/" },
+        { "title": "Access Requests", "slug": "/enterprise/workflow/" },
         {
           "title": "FedRAMP for SSH & K8s",
           "slug": "/enterprise/ssh-kubernetes-fedramp/"

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -101,7 +101,7 @@ spec:
       'cluster_name': '^us.*\.example\.com$'
 
     # Defines roles that this user can request.
-    # Needed for teleport's request workflow
+    # Needed for teleport's access request workflow
     # https://goteleport.com/teleport/docs/enterprise/workflow/
     request:
       roles:

--- a/docs/pages/api-reference.mdx
+++ b/docs/pages/api-reference.mdx
@@ -787,11 +787,11 @@ if err = client.UpdateRemoteCluster(ctx, rc); err != nil {
 }
 ```
 
-## Access Workflows
+## Access Requests
 
-[Access Workflows](enterprise/workflow/index.mdx) can be used by Teleport users to request one or more additional roles on the fly. These requests can be partially or fully approved or denied by a Teleport Administrator.
+[Access Requests](enterprise/workflow/index.mdx) can be used by Teleport users to request one or more additional roles on the fly. These requests can be partially or fully approved or denied by a Teleport Administrator.
 
-You may want to use manage Access Workflows using the API if:
+You may want to use manage Access Requests using the API if:
 
 - You want to automatically administer the scaling up and down of permissions for developers depending on their task
 - You want to utilize our supported [external tools](enterprise/workflow/index.mdx#integrating-with-an-external-tool) or other third-party tools to control the flow of access

--- a/docs/pages/database-access/introduction.mdx
+++ b/docs/pages/database-access/introduction.mdx
@@ -13,7 +13,7 @@ Some of the things you can do with Database Access:
 - Users can retrieve short-lived database certificates using single sign-on
   flow thus maintaining their organization-wide identity.
 - Configure role-based access controls for databases and implement custom
-  [access workflows](../enterprise/workflow/index.mdx).
+  [access request](../enterprise/workflow/index.mdx) workflows.
 - Capture database access events as well as query activity in the audit log.
 
 ## Demo

--- a/docs/pages/docs.mdx
+++ b/docs/pages/docs.mdx
@@ -69,7 +69,7 @@ Readers should be able to scroll down the guide and get to the end without leavi
 
 Specific kinds of *guides* include:
 
-1. **Integration** - *integration guides* explain how to set up Teleport with other tools. E.g. - "Access Workflows with Slack".
+1. **Integration** - *integration guides* explain how to set up Teleport with other tools. E.g. - "Access Requests with Slack".
 2. **Best Practices** - *best practices guides* are about best deployment and usage practices. They sometimes describe common patterns and anti-patterns.
 3. **Troubleshooting** - *troubleshooting guides* list common failures and how to diagnose them, they explain logs, remedies, and tips and tricks.
 

--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -120,8 +120,8 @@ cryptographic module (BoringCrypto) and fails to start if it was not.
 
 See our [FedRAMP for SSH and Kubernetes](ssh-kubernetes-fedramp.mdx) guide for more infromation.
 
-## Approval Requests
+## Access Requests
 
 With Teleport 4.2 we've introduced the ability for users to request additional roles. The Access Requests API makes it easy to dynamically approve or deny these requests.
 
-Read the [Approval Requests Guide for more information](workflow/index.mdx)
+Read the [Access Requests Guide for more information](workflow/index.mdx)

--- a/docs/pages/enterprise/introduction.mdx
+++ b/docs/pages/enterprise/introduction.mdx
@@ -120,8 +120,8 @@ cryptographic module (BoringCrypto) and fails to start if it was not.
 
 See our [FedRAMP for SSH and Kubernetes](ssh-kubernetes-fedramp.mdx) guide for more infromation.
 
-## Approval Workflows
+## Approval Requests
 
-With Teleport 4.2 we've introduced the ability for users to request additional roles. The workflow API makes it easy to dynamically approve or deny these requests.
+With Teleport 4.2 we've introduced the ability for users to request additional roles. The Access Requests API makes it easy to dynamically approve or deny these requests.
 
-Read the [Approval Workflows Guide for more information](workflow/index.mdx)
+Read the [Approval Requests Guide for more information](workflow/index.mdx)

--- a/docs/pages/enterprise/workflow/index.mdx
+++ b/docs/pages/enterprise/workflow/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: Access Workflows for SSH and Kubernetes Access
+title: Access Requests for SSH and Kubernetes Access
 description: How to customize SSH and Kubernetes access using Teleport.
-h1: Teleport Access Workflows
+h1: Teleport Access Requests
 ---
 
 #### Approving Workflow using an External Integration
@@ -12,7 +12,7 @@ h1: Teleport Access Workflows
 - [Integrating Teleport with Jira Server](ssh-approval-jira-server.mdx)
 - [Integrating Teleport with PagerDuty](ssh-approval-pagerduty.mdx)
 
-## Access Workflows Setup
+## Access Requests Setup
 
 Teleport 4.2 introduced the ability for users to request additional roles. The
 workflow API makes it easy to dynamically approve or deny these requests.
@@ -72,7 +72,7 @@ spec:
 # List of allow-rules, see
 # https://gravitational.com/teleport/docs/enterprise/ssh-rbac/
 rules:
-    # Access Request is part of Access Workflows introduced in 4.2
+    # Access Request is part of Access Requests introduced in 4.2
     # `access_request` should only be given to Teleport Admins.
     - resources: [access_request]
       verbs: [list, read, update, delete]
@@ -123,13 +123,13 @@ deny:
     roles: ['admin']
 ```
 
-## Adding a Reason to Access Workflows
+## Adding a Reason to Access Requests
 
 Teleport 4.4.4 introduced the ability for users to request additional roles. `tctl`
-or the Access Workflows API makes it easy to dynamically approve or deny these requests.
+or the Access Requests API makes it easy to dynamically approve or deny these requests.
 
 By requiring a reason along with an access request, you can provide users with a default
-unprivileged state where they must always go through the Access Workflows API to
+unprivileged state where they must always go through the Access Requests API to
 gain meaningful privilege.
 
 Teams can leverage claims (traits) provided by external identity providers both when

--- a/docs/pages/enterprise/workflow/index.mdx
+++ b/docs/pages/enterprise/workflow/index.mdx
@@ -4,7 +4,7 @@ description: How to customize SSH and Kubernetes access using Teleport.
 h1: Teleport Access Requests
 ---
 
-#### Approving Workflow using an External Integration
+#### Approving Requests using an External Integration
 
 - [Integrating Teleport with Slack](ssh-approval-slack.mdx)
 - [Integrating Teleport with Mattermost](ssh-approval-mattermost.mdx)
@@ -15,7 +15,7 @@ h1: Teleport Access Requests
 ## Access Requests Setup
 
 Teleport 4.2 introduced the ability for users to request additional roles. The
-workflow API makes it easy to dynamically approve or deny these requests.
+Access Request API makes it easy to dynamically approve or deny these requests.
 
 ### Setup
 
@@ -223,7 +223,7 @@ Because automatically generated requests always include all roles that the user 
 $ tctl request approve --roles=role-1,role-3 --reason='Approved, but not role-2 right now' 28a3fb86-0230-439d-ad88-11cfcb213193
 ```
 
-### Other features of Access Workflows
+### Other features of Access Requests
 
 - Users can request multiple roles at one time. e.g `roles: ['dba','netsec','cluster-x']`
 - Approved requests do not affect Teleport's behavior outside of allowing additional

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
@@ -9,7 +9,7 @@ h1: SSH login approvals using Jira
 This guide will talk through how to set up Teleport with Jira. Teleport to Jira integration allows you to treat Teleport access and permission requests using Jira tickets.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
+  The Access Request workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
 
 ## Setup

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
@@ -9,7 +9,7 @@ h1: SSH login approvals using Jira
 This guide will talk through how to set up Teleport with Jira. Teleport to Jira integration allows you to treat Teleport access and permission requests using Jira tickets.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
+  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
 
 ## Setup

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-cloud.mdx
@@ -8,8 +8,8 @@ h1: SSH login approvals using Jira
 
 This guide will talk through how to set up Teleport with Jira. Teleport to Jira integration allows you to treat Teleport access and permission requests using Jira tickets.
 
-<Admonition type="warning">
-  The Approval Workflow only works with Teleport Enterprise as it requires several roles.
+<Admonition type="tip">
+  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
 </Admonition>
 
 ## Setup

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
@@ -9,7 +9,7 @@ h1: SSH login approvals using Jira Server
 This guide will talk through how to set up Teleport with Jira Server. Teleport to Jira Server integration allows you to treat Teleport access and permission requests as Jira Tasks.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
+  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
 
 <Admonition type="note">

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
@@ -9,7 +9,7 @@ h1: SSH login approvals using Jira Server
 This guide will talk through how to set up Teleport with Jira Server. Teleport to Jira Server integration allows you to treat Teleport access and permission requests as Jira Tasks.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
+  The Access Request workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
 
 <Admonition type="note">

--- a/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-jira-server.mdx
@@ -8,8 +8,8 @@ h1: SSH login approvals using Jira Server
 
 This guide will talk through how to set up Teleport with Jira Server. Teleport to Jira Server integration allows you to treat Teleport access and permission requests as Jira Tasks.
 
-<Admonition type="warning">
-  The Approval Workflow only works with Teleport Enterprise as it requires several roles.
+<Admonition type="tip">
+  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
 </Admonition>
 
 <Admonition type="note">

--- a/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
@@ -8,8 +8,8 @@ This guide will talk through how to set up Teleport with Mattermost. Teleport to
 Mattermost integration allows teams to approve or deny Teleport access requests
 using [Mattermost](https://mattermost.com/) an open-source messaging platform.
 
-<Admonition type="warning">
-  The Approval Workflow only works with Teleport Enterprise as it requires several roles.
+<Admonition type="tip">
+  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
 </Admonition>
 
 #### Example Mattermost Request

--- a/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
@@ -9,7 +9,7 @@ Mattermost integration allows teams to approve or deny Teleport access requests
 using [Mattermost](https://mattermost.com/) an open-source messaging platform.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
+  The Access Request workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
 
 #### Example Mattermost Request

--- a/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
@@ -9,7 +9,7 @@ Mattermost integration allows teams to approve or deny Teleport access requests
 using [Mattermost](https://mattermost.com/) an open-source messaging platform.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
+  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
 
 #### Example Mattermost Request

--- a/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
@@ -12,7 +12,7 @@ requests as Pagerduty incidents — notifying the appropriate team, and approve
 or deny the requests via Pagerduty special action.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
+  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
 
 ## Setup

--- a/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
@@ -11,8 +11,8 @@ Pagerduty integration  allows you to treat Teleport access and permission
 requests as Pagerduty incidents — notifying the appropriate team, and approve
 or deny the requests via Pagerduty special action.
 
-<Admonition type="warning">
-  The Approval Workflow only works with Teleport Enterprise as it requires several roles.
+<Admonition type="tip">
+  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
 </Admonition>
 
 ## Setup

--- a/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-pagerduty.mdx
@@ -12,8 +12,9 @@ requests as Pagerduty incidents — notifying the appropriate team, and approve
 or deny the requests via Pagerduty special action.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
+  The Access Request workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
+
 
 ## Setup
 

--- a/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
@@ -6,8 +6,8 @@ h1: Teleport Slack Plugin Setup
 
 This guide will talk through how to set up Teleport with Slack. Teleport to Slack integration allows you to treat Teleport access and permission requests via Slack message and inline interactive components.
 
-<Admonition type="warning">
-  The Approval Workflow only works with Teleport Enterprise as it requires several roles.
+<Admonition type="tip">
+  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
 </Admonition>
 
 #### Example Slack request
@@ -211,7 +211,7 @@ INFO   Starting insecure HTTP server on 0.0.0.0:8081 utils/http.go:64
 INFO   Watcher connected slack/main.go:298
 ```
 
-### Testing the approval workflow
+### Testing the request approval workflow
 
 You can create a test permissions request with `tctl` and check if the plugin works as expected like this:
 

--- a/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
@@ -7,8 +7,9 @@ h1: Teleport Slack Plugin Setup
 This guide will talk through how to set up Teleport with Slack. Teleport to Slack integration allows you to treat Teleport access and permission requests via Slack message and inline interactive components.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
+  The Access Request workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
+
 
 #### Example Slack request
 

--- a/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
@@ -7,7 +7,7 @@ h1: Teleport Slack Plugin Setup
 This guide will talk through how to set up Teleport with Slack. Teleport to Slack integration allows you to treat Teleport access and permission requests via Slack message and inline interactive components.
 
 <Admonition type="tip">
-  The Request Approval workflow is now supported in both Teleport Enterprise (multirole) and Open Source.
+  The Request Approval workflow is now supported in both the Teleport Open Source and Enterprise Editions.
 </Admonition>
 
 #### Example Slack request

--- a/docs/pages/kubernetes-access/introduction.mdx
+++ b/docs/pages/kubernetes-access/introduction.mdx
@@ -6,7 +6,7 @@ description: Teleport Kubernetes Access introduction, demo, and resources
 Teleport provides unified access for Kubernetes clusters.
 
 - Users can receive short-lived certificates using Single Sign-On (SSO) and switch between clusters without logins.
-- Admins can use *roles* to implement policies like the best practice that *developers must not access production* and enforce dual authorization using [access workflows](../enterprise/workflow/index.mdx) for privileged operations.
+- Admins can use *roles* to implement policies like the best practice that *developers must not access production* and enforce dual authorization using [access requests](../enterprise/workflow/index.mdx) for privileged operations.
 - Organizations can achieve compliance by capturing `kubectl` events and session recordings for `kubectl`.
 
 ## SSO and Audit for Kubernetes Clusters


### PR DESCRIPTION
This PR addresses updates to v6.1 docs for https://github.com/gravitational/teleport/issues/6588:

1. `Access Workflows` -> `Access Requests` or `Access Request workflows` where appropriate
2. Update `config.json` to update TOC names
3. Update admonitions to `tips` and state support for this feature in both Open Source and Enterprise versions now

Thanks!