### PR TITLE
Backport v6: docs: bump 6.2 release date to May 21st 

### DIFF
--- a/docs/pages/preview/upcoming-releases.mdx
+++ b/docs/pages/preview/upcoming-releases.mdx
@@ -16,9 +16,9 @@ and updates PagerDuty and Gitlab plugins to use the new API.
 
 | Version | Date | Description |
 | - | - | - |
-| First alpha | April 30th, 2021 | Good for testing and demos. |
-| First beta | May 5th | Deploy on staging. |
-| Release | May 10th, 2021 | Good to go for production. |
+| First alpha | May 7th, 2021 | Good for testing and demos. |
+| First beta | May 14th | Deploy on staging. |
+| Release | May 21st, 2021 | Good to go for production. |
 
 ### Features
 


### PR DESCRIPTION
Backport of #6652 into v6