### PR TITLE
Backport 4.2: kube: handle large number of trusted clusters in mTLS handshake

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1023,7 +1023,7 @@ func (s *AuthServer) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedK
 	// HTTPS requests need to specify DNS name that should be present in the
 	// certificate as one of the DNS Names. It is not known in advance,
 	// that is why there is a default one for all certificates
-	if req.Roles.Include(teleport.RoleAuth) || req.Roles.Include(teleport.RoleAdmin) {
+	if req.Roles.Include(teleport.RoleAuth) || req.Roles.Include(teleport.RoleAdmin) || req.Roles.Include(teleport.RoleProxy) {
 		certRequest.DNSNames = append(certRequest.DNSNames, "*."+teleport.APIDomain, teleport.APIDomain)
 	}
 	// Unlike additional pricinpals, DNS Names is x509 specific


### PR DESCRIPTION
Backport of #6519 into 4.2