### PR TITLE
Delete unused RoleWeb

### DIFF
--- a/api/types/teleport_role.go
+++ b/api/types/teleport_role.go
@@ -34,8 +34,6 @@ type SystemRoles []SystemRole
 const (
 	// RoleAuth is for teleport auth server (authority, authentication and authorization)
 	RoleAuth SystemRole = "Auth"
-	// RoleWeb is for web access users
-	RoleWeb SystemRole = "Web"
 	// RoleNode is a role for SSH node in the cluster
 	RoleNode SystemRole = "Node"
 	// RoleProxy is a role for SSH proxy in the cluster
@@ -172,7 +170,7 @@ func (r *SystemRole) String() string {
 // if it's ok, false otherwise
 func (r *SystemRole) Check() error {
 	switch *r {
-	case RoleAuth, RoleWeb, RoleNode, RoleApp, RoleDatabase,
+	case RoleAuth, RoleNode, RoleApp, RoleDatabase,
 		RoleAdmin, RoleProvisionToken,
 		RoleTrustedCluster, LegacyClusterTokenType,
 		RoleSignup, RoleProxy, RoleNop, RoleKube:

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -493,24 +493,6 @@ func GetCheckerForBuiltinRole(clusterName string, clusterConfig services.Cluster
 					},
 				},
 			})
-	case teleport.RoleWeb:
-		return services.FromSpec(
-			role.String(),
-			services.RoleSpecV3{
-				Allow: services.RoleConditions{
-					Namespaces: []string{services.Wildcard},
-					Rules: []services.Rule{
-						services.NewRule(services.KindWebSession, services.RW()),
-						services.NewRule(services.KindWebToken, services.RW()),
-						services.NewRule(services.KindSSHSession, services.RW()),
-						services.NewRule(services.KindAuthServer, services.RO()),
-						services.NewRule(services.KindUser, services.RO()),
-						services.NewRule(services.KindRole, services.RO()),
-						services.NewRule(services.KindNamespace, services.RO()),
-						services.NewRule(services.KindTrustedCluster, services.RO()),
-					},
-				},
-			})
 	case teleport.RoleSignup:
 		return services.FromSpec(
 			role.String(),

--- a/roles.go
+++ b/roles.go
@@ -29,7 +29,6 @@ type Roles = types.SystemRoles
 
 var (
 	RoleAuth           = types.RoleAuth
-	RoleWeb            = types.RoleWeb
 	RoleNode           = types.RoleNode
 	RoleProxy          = types.RoleProxy
 	RoleAdmin          = types.RoleAdmin

--- a/roles_test.go
+++ b/roles_test.go
@@ -9,7 +9,7 @@ func TestRolesCheck(t *testing.T) {
 	}{
 		{roles: []Role{}, wantErr: false},
 		{roles: []Role{RoleAuth}, wantErr: false},
-		{roles: []Role{RoleAuth, RoleWeb, RoleNode, RoleProxy, RoleAdmin, RoleProvisionToken, RoleTrustedCluster, LegacyClusterTokenType, RoleSignup, RoleNop}, wantErr: false},
+		{roles: []Role{RoleAuth, RoleNode, RoleProxy, RoleAdmin, RoleProvisionToken, RoleTrustedCluster, LegacyClusterTokenType, RoleSignup, RoleNop}, wantErr: false},
 		{roles: []Role{RoleAuth, RoleNode, RoleAuth}, wantErr: true},
 		{roles: []Role{Role("unknown")}, wantErr: true},
 	}


### PR DESCRIPTION
RoleWeb is not used by any service since at least 4.0.
Clean it up.