### PR TITLE
Updated TLS handshake timeout.

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -132,6 +132,10 @@ const (
 	// for the response headers to arrive
 	ReadHeadersTimeout = time.Second
 
+	// HandshakeReadDeadline is the default time to wait for the client during
+	// the TLS handshake.
+	HandshakeReadDeadline = 5 * time.Second
+
 	// SignupTokenTTL is a default TTL for a web signup one time token
 	SignupTokenTTL = time.Hour
 


### PR DESCRIPTION
Updated TLS handshake timeout. During some operations, Teleport can flood the network with traffic which causes the TLS handshake to occur slower than 1 second.

One example is during SSO login. The initial connection is an unauthenticated connection, and upon successful SSO login a "types.User" is created and replicated to all nodes. For large clusters this can mean 10k+ "types.User" objects getting replicated at the same time the user attempts to re-establishing another connection to Auth this time with valid identity credentials. This connection sometimes can take longer than the original 1 second timeout.