### PR TITLE
Backport #6431 "set correct auditlog instead of discard"

### DIFF
--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -104,7 +104,7 @@ func NewUploader(cfg UploaderConfig) (*Uploader, error) {
 	}
 	uploadCompleter, err := events.NewUploadCompleter(events.UploadCompleterConfig{
 		Uploader:  handler,
-		AuditLog:  events.NewDiscardAuditLog(),
+		AuditLog:  cfg.AuditLog,
 		Unstarted: true,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR backports #6431 to 6.1 for a 6.1.4 release as it resolves a segfault impacting multiple customers and OSS users.