### PR TITLE
Clarify node connection debug logs.

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -809,7 +809,7 @@ func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity 
 	// Try and connect to the Auth Server. If the request fails, try and
 	// connect through a tunnel.
 	logger := process.log.WithField("auth-addrs", utils.NetAddrsToStrings(authServers))
-	logger.Debugf("Attempting to connect to Auth Server directly.")
+	logger.Debug("Attempting to connect to Auth Server directly.")
 	directClient, err := process.newClientDirect(authServers, tlsConfig)
 	if err == nil {
 		logger.Debug("Connected to Auth Server with direct connection.")

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -808,20 +808,23 @@ func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity 
 
 	// Try and connect to the Auth Server. If the request fails, try and
 	// connect through a tunnel.
-	process.log.Debugf("Attempting to connect to Auth Server directly.")
+	logger := process.log.WithField("auth-addrs", utils.NetAddrsToStrings(authServers))
+	logger.Debugf("Attempting to connect to Auth Server directly.")
 	directClient, err := process.newClientDirect(authServers, tlsConfig)
 	if err == nil {
-		process.log.Debug("Connected to Auth Server with direct connection.")
+		logger.Debug("Connected to Auth Server with direct connection.")
 		return directClient, nil
 	}
-	process.log.Debug("Failed to connect to Auth Server directly.")
+	logger.Debug("Failed to connect to Auth Server directly.")
+	// store err in directLogger, only log it if tunnel dial fails.
+	directErrLogger := logger.WithError(err)
 
 	// Don't attempt to connect through a tunnel as a proxy or auth server.
 	if identity.ID.Role == teleport.RoleAuth || identity.ID.Role == teleport.RoleProxy {
 		return nil, trace.Wrap(err)
 	}
-	directDialErr := err
 
+	logger.Debug("Attempting to discover reverse tunnel address.")
 	var proxyAddr string
 	if process.Config.SSH.ProxyReverseTunnelFallbackAddr != nil {
 		proxyAddr = process.Config.SSH.ProxyReverseTunnelFallbackAddr.String()
@@ -829,17 +832,19 @@ func (process *TeleportProcess) newClient(authServers []utils.NetAddr, identity 
 		// Discover address of SSH reverse tunnel server.
 		proxyAddr, err = process.findReverseTunnel(authServers)
 		if err != nil {
-			process.log.Debug("Failed to discover reverse tunnel address.")
-			return nil, trace.NewAggregate(directDialErr, err)
+			directErrLogger.Debug("Failed to connect to Auth Server directly.")
+			logger.WithError(err).Debug("Failed to discover reverse tunnel address.")
+			return nil, trace.Errorf("Failed to connect to Auth Server directly or over tunnel, no methods remaining.")
 		}
 	}
 
-	logger := process.log.WithField("proxy-addr", proxyAddr)
+	logger = process.log.WithField("proxy-addr", proxyAddr)
 	logger.Debug("Attempting to connect to Auth Server through tunnel.")
 	tunnelClient, err := process.newClientThroughTunnel(proxyAddr, tlsConfig, identity.SSHClientConfig())
 	if err != nil {
-		logger.Debug("Failed to connect to Auth Server through tunnel.")
-		return nil, trace.NewAggregate(directDialErr, err)
+		directErrLogger.Debug("Failed to connect to Auth Server directly.")
+		logger.WithError(err).Debug("Failed to connect to Auth Server through tunnel.")
+		return nil, trace.Errorf("Failed to connect to Auth Server directly or over tunnel, no methods remaining.")
 	}
 
 	logger.Debug("Connected to Auth Server through tunnel.")


### PR DESCRIPTION
The node connection debug logs have continued to cause some confusion due to the aggregated direct dial and tunnel dial errors. The direct dial error is expected to fail so it should be ignored, but previously it wasn't clear which error was which.

I also added the `auth-addrs` field to relevant connection debug logs.

#### Example debug logs with this PR:

Failure
```
INFO [PROC:1]    Connecting to the cluster example.com with TLS client certificate. service/connect.go:133
DEBU [PROC:1]    Attempting to connect to Auth Server directly. auth-addrs:[127.0.0.1:3080] service/connect.go:812
DEBU [PROC:1]    Failed to connect to Auth Server directly. auth-addrs:[127.0.0.1:3080] service/connect.go:818
DEBU [PROC:1]    Attempting to discover reverse tunnel address. auth-addrs:[127.0.0.1:3080] service/connect.go:827
DEBU [PROC:1]    Attempting to connect to Auth Server through tunnel. proxy-addr:proxy.example.com:3024 service/connect.go:842
WARN [PROC:1]    Failed to connect to Auth Server directly. auth-addrs:[127.0.0.1:3080] error:[
ERROR REPORT:
Original Error: *trace.ConnectionProblemError Get &#34;https://teleport.cluster.local/v2/domain&#34;: x509: certificate is valid for server01, localhost, localhost.local, not 6578616d706c652e636f6d.teleport.cluster.local
Stack Trace:
	/home/bjoerger/gravitational/teleport/lib/httplib/httplib.go:133 github.com/gravitational/teleport/lib/httplib.ConvertResponse
	/home/bjoerger/gravitational/teleport/lib/auth/clt.go:310 github.com/gravitational/teleport/lib/auth.(*Client).Get
	/home/bjoerger/gravitational/teleport/lib/auth/clt.go:401 github.com/gravitational/teleport/lib/auth.(*Client).GetDomainName
	/home/bjoerger/gravitational/teleport/lib/auth/clt.go:1674 github.com/gravitational/teleport/lib/auth.(*Client).GetLocalClusterName
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:957 github.com/gravitational/teleport/lib/service.(*TeleportProcess).newClientDirect
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:813 github.com/gravitational/teleport/lib/service.(*TeleportProcess).newClient
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:134 github.com/gravitational/teleport/lib/service.(*TeleportProcess).connect
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:83 github.com/gravitational/teleport/lib/service.(*TeleportProcess).connectToAuthService
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:53 github.com/gravitational/teleport/lib/service.(*TeleportProcess).reconnectToAuthService
	/home/bjoerger/gravitational/teleport/lib/service/service.go:1868 github.com/gravitational/teleport/lib/service.(*TeleportProcess).registerWithAuthServer.func1
	/home/bjoerger/gravitational/teleport/lib/service/supervisor.go:457 github.com/gravitational/teleport/lib/service.(*LocalService).Serve
	/home/bjoerger/gravitational/teleport/lib/service/supervisor.go:246 github.com/gravitational/teleport/lib/service.(*LocalSupervisor).serve.func1
	/usr/local/go/src/runtime/asm_amd64.s:1371 runtime.goexit
User Message: Get &#34;https://teleport.cluster.local/v2/domain&#34;: x509: certificate is valid for server01, localhost, localhost.local, not 6578616d706c652e636f6d.teleport.cluster.local] service/connect.go:845
WARN [PROC:1]    Failed to connect to Auth Server through tunnel. error:[
ERROR REPORT:
Original Error: *errors.errorString fake tunnel dial error
Stack Trace:
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:914 github.com/gravitational/teleport/lib/service.(*TeleportProcess).newClientThroughTunnel
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:843 github.com/gravitational/teleport/lib/service.(*TeleportProcess).newClient
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:134 github.com/gravitational/teleport/lib/service.(*TeleportProcess).connect
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:83 github.com/gravitational/teleport/lib/service.(*TeleportProcess).connectToAuthService
	/home/bjoerger/gravitational/teleport/lib/service/connect.go:53 github.com/gravitational/teleport/lib/service.(*TeleportProcess).reconnectToAuthService
	/home/bjoerger/gravitational/teleport/lib/service/service.go:1868 github.com/gravitational/teleport/lib/service.(*TeleportProcess).registerWithAuthServer.func1
	/home/bjoerger/gravitational/teleport/lib/service/supervisor.go:457 github.com/gravitational/teleport/lib/service.(*LocalService).Serve
	/home/bjoerger/gravitational/teleport/lib/service/supervisor.go:246 github.com/gravitational/teleport/lib/service.(*LocalSupervisor).serve.func1
	/usr/local/go/src/runtime/asm_amd64.s:1371 runtime.goexit
User Message: fake tunnel dial error] proxy-addr:proxy.example.com:3024 service/connect.go:846
ERRO [PROC:1]    Node failed to establish connection to cluster: Failed to connect to Auth Server directly or over tunnel, no methods remaining.. service/connect.go:68
```
Success
```
INFO [PROC:1]    Connecting to the cluster example.com with TLS client certificate. service/connect.go:133
DEBU [PROC:1]    Attempting to connect to Auth Server directly. auth-addrs:[127.0.0.1:3080] service/connect.go:812
DEBU [PROC:1]    Failed to connect to Auth Server directly. auth-addrs:[127.0.0.1:3080] service/connect.go:818
DEBU [PROC:1]    Attempting to discover reverse tunnel address. auth-addrs:[127.0.0.1:3080] service/connect.go:827
DEBU [PROC:1]    Attempting to connect to Auth Server through tunnel. proxy-addr:proxy.example.com:3024 service/connect.go:842
DEBU [HTTP:PROX] No valid environment variables found. proxy/proxy.go:207
DEBU [HTTP:PROX] No proxy set in environment, returning direct dialer. proxy/proxy.go:122
DEBU [HTTP:PROX] No valid environment variables found. proxy/proxy.go:207
DEBU [HTTP:PROX] No proxy set in environment, returning direct dialer. proxy/proxy.go:122
DEBU [PROC:1]    Connected to Auth Server through tunnel. proxy-addr:proxy.example.com:3024 service/connect.go:850
```

This will be backported to 6.2.

Related to #6665