### PR TITLE
[Backport 6.2] Fix non-interactive ssh output in teleport log

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -147,10 +147,9 @@ func (e *localExec) Start(channel ssh.Channel) (*ExecResult, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// Connect stdout and stderr to the channel so the user can interact with
-	// the command.
-	e.Cmd.Stderr = io.MultiWriter(os.Stderr, channel.Stderr())
-	e.Cmd.Stdout = io.MultiWriter(os.Stdout, channel)
+	// Connect stdout and stderr to the channel so the user can interact with the command.
+	e.Cmd.Stderr = channel.Stderr()
+	e.Cmd.Stdout = channel
 
 	// Copy from the channel (client input) into stdin of the process.
 	inputWriter, err := e.Cmd.StdinPipe()


### PR DESCRIPTION
Issue #6556

This commit removes copying of stdout and stderr from non-interactive ssh commands to stdout and stderr of the teleport server process. This was introduced in e65eac59b0 and appears to have been put in for debugging.