### PR TITLE
Add missing database cli flags

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -114,6 +114,8 @@ type CommandLineFlags struct {
 
 	// DatabaseName is the name of the database to proxy.
 	DatabaseName string
+	// DatabaseDescription is a free-form database description.
+	DatabaseDescription string
 	// DatabaseProtocol is the type of the proxied database e.g. postgres or mysql.
 	DatabaseProtocol string
 	// DatabaseURI is the address to connect to the proxied database.
@@ -122,6 +124,12 @@ type CommandLineFlags struct {
 	DatabaseCACertFile string
 	// DatabaseAWSRegion is an optional database cloud region e.g. when using AWS RDS.
 	DatabaseAWSRegion string
+	// DatabaseAWSRedshiftClusterID is Redshift cluster identifier.
+	DatabaseAWSRedshiftClusterID string
+	// DatabaseGCPProjectID is GCP Cloud SQL project identifier.
+	DatabaseGCPProjectID string
+	// DatabaseGCPInstanceID is GCP Cloud SQL instance identifier.
+	DatabaseGCPInstanceID string
 }
 
 // ReadConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)
@@ -1238,6 +1246,7 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 		}
 		db := service.Database{
 			Name:          clf.DatabaseName,
+			Description:   clf.DatabaseDescription,
 			Protocol:      clf.DatabaseProtocol,
 			URI:           clf.DatabaseURI,
 			StaticLabels:  staticLabels,
@@ -1245,6 +1254,13 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 			CACert:        caBytes,
 			AWS: service.DatabaseAWS{
 				Region: clf.DatabaseAWSRegion,
+				Redshift: service.DatabaseAWSRedshift{
+					ClusterID: clf.DatabaseAWSRedshiftClusterID,
+				},
+			},
+			GCP: service.DatabaseGCP{
+				ProjectID:  clf.DatabaseGCPProjectID,
+				InstanceID: clf.DatabaseGCPInstanceID,
 			},
 		}
 		if err := db.Check(); err != nil {

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -504,7 +504,7 @@ var (
 	DataDir = "/var/lib/teleport"
 
 	// StartRoles is default roles teleport assumes when started via 'start' command
-	StartRoles = []string{RoleProxy, RoleNode, RoleAuthService, RoleApp}
+	StartRoles = []string{RoleProxy, RoleNode, RoleAuthService, RoleApp, RoleDatabase}
 
 	// ETCDPrefix is default key in ETCD clustered configurations
 	ETCDPrefix = "/teleport"

--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -90,13 +90,12 @@ This token will expire in %d minutes
 
 Fill out and run this command on a node to make the application available:
 
-> teleport start \
-   --roles=%v \
+> teleport app start \
    --token=%v \
    --ca-pin=%v \
    --auth-server=%v \
-   --app-name=%-30v ` + "`" + `# Change "%v" to the name of your application.` + "`" + ` \
-   --app-uri=%-31v ` + "`" + `# Change "%v" to the address of your application.` + "`" + `
+   --name=%-30v ` + "`" + `# Change "%v" to the name of your application.` + "`" + ` \
+   --uri=%-31v ` + "`" + `# Change "%v" to the address of your application.` + "`" + `
 
 Your application will be available at %v.
 

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -91,14 +91,13 @@ This token will expire in {{.minutes}} minutes.
 
 Fill out and run this command on a node to start proxying the database:
 
-> teleport start \
-   --roles={{.roles}} \
+> teleport db start \
    --token={{.token}} \
    --ca-pin={{.ca_pin}} \
    --auth-server={{.auth_server}} \
-   --db-name={{.db_name}} \
-   --db-protocol={{.db_protocol}} \
-   --db-uri={{.db_uri}}
+   --name={{.db_name}} \
+   --protocol={{.db_protocol}} \
+   --uri={{.db_uri}}
 
 Please note:
 

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -184,7 +184,6 @@ func (c *TokenCommand) Add(client auth.ClientI) error {
 		fmt.Printf(appMessage,
 			token,
 			int(c.ttl.Minutes()),
-			strings.ToLower(roles.String()),
 			token,
 			caPin,
 			proxies[0].GetPublicAddr(),
@@ -209,7 +208,6 @@ func (c *TokenCommand) Add(client auth.ClientI) error {
 			map[string]interface{}{
 				"token":       token,
 				"minutes":     c.ttl.Minutes(),
-				"roles":       strings.ToLower(roles.String()),
 				"ca_pin":      caPin,
 				"auth_server": proxies[0].GetPublicAddr(),
 				"db_name":     c.dbName,

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -35,8 +35,8 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils/scp"
 	"github.com/gravitational/teleport/lib/utils"
 
+	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
-
 	log "github.com/sirupsen/logrus"
 )
 
@@ -50,7 +50,7 @@ type Options struct {
 }
 
 // Run inits/starts the process according to the provided options
-func Run(options Options) (executedCommand string, conf *service.Config) {
+func Run(options Options) (app *kingpin.Application, executedCommand string, conf *service.Config) {
 	var err error
 
 	// configure trace's errors to produce full stack traces
@@ -61,7 +61,7 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 	// configure logger for a typical CLI scenario until configuration file is
 	// parsed
 	utils.InitLogger(utils.LoggingForDaemon, log.ErrorLevel)
-	app := utils.InitCLIParser("teleport", "Clustered SSH service. Learn more at https://goteleport.com/teleport")
+	app = utils.InitCLIParser("teleport", "Clustered SSH service. Learn more at https://goteleport.com/teleport")
 
 	// define global flags:
 	var ccf config.CommandLineFlags
@@ -128,33 +128,77 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 		"Start Teleport in FedRAMP/FIPS 140-2 mode.").
 		Default("false").
 		BoolVar(&ccf.FIPS)
+	// All top-level --app-XXX flags are deprecated in favor of
+	// "teleport start app" subcommand.
 	start.Flag("app-name",
-		"Name of the application to start").
+		"Name of the application to start").Hidden().
 		StringVar(&ccf.AppName)
 	start.Flag("app-uri",
-		"Internal address of the application to proxy.").
+		"Internal address of the application to proxy.").Hidden().
 		StringVar(&ccf.AppURI)
 	start.Flag("app-public-addr",
-		"Public address of the application to proxy.").
+		"Public address of the application to proxy.").Hidden().
 		StringVar(&ccf.AppPublicAddr)
+	// All top-level --db-XXX flags are deprecated in favor of
+	// "teleport start db" subcommand.
 	start.Flag("db-name",
-		"Name of the proxied database.").
+		"Name of the proxied database.").Hidden().
 		StringVar(&ccf.DatabaseName)
 	start.Flag("db-protocol",
-		fmt.Sprintf("Proxied database protocol. Supported are: %v.", defaults.DatabaseProtocols)).
+		fmt.Sprintf("Proxied database protocol. Supported are: %v.", defaults.DatabaseProtocols)).Hidden().
 		StringVar(&ccf.DatabaseProtocol)
 	start.Flag("db-uri",
-		"Address the proxied database is reachable at.").
+		"Address the proxied database is reachable at.").Hidden().
 		StringVar(&ccf.DatabaseURI)
 	start.Flag("db-ca-cert",
-		"Database CA certificate path.").
+		"Database CA certificate path.").Hidden().
 		StringVar(&ccf.DatabaseCACertFile)
 	start.Flag("db-aws-region",
-		"AWS region RDS/Aurora database instance is running in.").
+		"AWS region RDS, Aurora or Redshift database instance is running in.").Hidden().
 		StringVar(&ccf.DatabaseAWSRegion)
 
 	// define start's usage info (we use kingpin's "alias" field for this)
 	start.Alias(usageNotes + usageExamples)
+
+	// "teleport app" command and its subcommands
+	appCmd := app.Command("app", "Application proxy service commands.")
+	appStartCmd := appCmd.Command("start", "Start application proxy service.")
+	appStartCmd.Flag("debug", "Enable verbose logging to stderr.").Short('d').BoolVar(&ccf.Debug)
+	appStartCmd.Flag("pid-file", "Full path to the PID file. By default no PID file will be created.").StringVar(&ccf.PIDFile)
+	appStartCmd.Flag("auth-server", fmt.Sprintf("Address of the auth server [%s].", defaults.AuthConnectAddr().Addr)).StringsVar(&ccf.AuthServerAddr)
+	appStartCmd.Flag("token", "Invitation token to register with an auth server [none].").StringVar(&ccf.AuthToken)
+	appStartCmd.Flag("ca-pin", "CA pin to validate the auth server.").StringVar(&ccf.CAPin)
+	appStartCmd.Flag("config", fmt.Sprintf("Path to a configuration file [%v].", defaults.ConfigFilePath)).Short('c').ExistingFileVar(&ccf.ConfigFile)
+	appStartCmd.Flag("config-string", "Base64 encoded configuration string.").Hidden().Envar(defaults.ConfigEnvar).StringVar(&ccf.ConfigString)
+	appStartCmd.Flag("labels", "Comma-separated list of labels for this node, for example env=dev,app=web.").StringVar(&ccf.Labels)
+	appStartCmd.Flag("fips", "Start Teleport in FedRAMP/FIPS 140-2 mode.").Default("false").BoolVar(&ccf.FIPS)
+	appStartCmd.Flag("name", "Name of the application to start.").StringVar(&ccf.AppName)
+	appStartCmd.Flag("uri", "Internal address of the application to proxy.").StringVar(&ccf.AppURI)
+	appStartCmd.Flag("public-addr", "Public address of the application to proxy.").StringVar(&ccf.AppPublicAddr)
+	appStartCmd.Alias(appUsageExamples) // We're using "alias" section to display usage examples.
+
+	// "teleport db" command and its subcommands
+	dbCmd := app.Command("db", "Database proxy service commands.")
+	dbStartCmd := dbCmd.Command("start", "Start database proxy service.")
+	dbStartCmd.Flag("debug", "Enable verbose logging to stderr.").Short('d').BoolVar(&ccf.Debug)
+	dbStartCmd.Flag("pid-file", "Full path to the PID file. By default no PID file will be created.").StringVar(&ccf.PIDFile)
+	dbStartCmd.Flag("auth-server", fmt.Sprintf("Address of the auth server [%s].", defaults.AuthConnectAddr().Addr)).StringsVar(&ccf.AuthServerAddr)
+	dbStartCmd.Flag("token", "Invitation token to register with an auth server [none].").StringVar(&ccf.AuthToken)
+	dbStartCmd.Flag("ca-pin", "CA pin to validate the auth server.").StringVar(&ccf.CAPin)
+	dbStartCmd.Flag("config", fmt.Sprintf("Path to a configuration file [%v].", defaults.ConfigFilePath)).Short('c').ExistingFileVar(&ccf.ConfigFile)
+	dbStartCmd.Flag("config-string", "Base64 encoded configuration string.").Hidden().Envar(defaults.ConfigEnvar).StringVar(&ccf.ConfigString)
+	dbStartCmd.Flag("labels", "Comma-separated list of labels for this node, for example env=dev,app=web.").StringVar(&ccf.Labels)
+	dbStartCmd.Flag("fips", "Start Teleport in FedRAMP/FIPS 140-2 mode.").Default("false").BoolVar(&ccf.FIPS)
+	dbStartCmd.Flag("name", "Name of the proxied database.").StringVar(&ccf.DatabaseName)
+	dbStartCmd.Flag("description", "Description of the proxied database.").StringVar(&ccf.DatabaseDescription)
+	dbStartCmd.Flag("protocol", fmt.Sprintf("Proxied database protocol. Supported are: %v.", defaults.DatabaseProtocols)).StringVar(&ccf.DatabaseProtocol)
+	dbStartCmd.Flag("uri", "Address the proxied database is reachable at.").StringVar(&ccf.DatabaseURI)
+	dbStartCmd.Flag("ca-cert", "Database CA certificate path.").StringVar(&ccf.DatabaseCACertFile)
+	dbStartCmd.Flag("aws-region", "(Only for RDS, Aurora or Redshift) AWS region RDS, Aurora or Redshift database instance is running in.").StringVar(&ccf.DatabaseAWSRegion)
+	dbStartCmd.Flag("aws-redshift-cluster-id", "(Only for Redshift) Redshift database cluster identifier.").StringVar(&ccf.DatabaseAWSRedshiftClusterID)
+	dbStartCmd.Flag("gcp-project-id", "(Only for Cloud SQL) GCP Cloud SQL project identifier.").StringVar(&ccf.DatabaseGCPProjectID)
+	dbStartCmd.Flag("gcp-instance-id", "(Only for Cloud SQL) GCP Cloud SQL instance identifier.").StringVar(&ccf.DatabaseGCPInstanceID)
+	dbStartCmd.Alias(dbUsageExamples) // We're using "alias" section to display usage examples.
 
 	// define a hidden 'scp' command (it implements server-side implementation of handling
 	// 'scp' requests)
@@ -200,7 +244,14 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 
 	// execute the selected command unless we're running tests
 	switch command {
-	case start.FullCommand():
+	case start.FullCommand(), appStartCmd.FullCommand(), dbStartCmd.FullCommand():
+		// Set appropriate roles for "app" and "db" subcommands.
+		switch command {
+		case appStartCmd.FullCommand():
+			ccf.Roles = defaults.RoleApp
+		case dbStartCmd.FullCommand():
+			ccf.Roles = defaults.RoleDatabase
+		}
 		// configuration merge: defaults -> file-based conf -> CLI conf
 		if err = config.Configure(&ccf, conf); err != nil {
 			utils.FatalError(err)
@@ -224,7 +275,7 @@ func Run(options Options) (executedCommand string, conf *service.Config) {
 	if err != nil {
 		utils.FatalError(err)
 	}
-	return command, conf
+	return app, command, conf
 }
 
 // OnStart is the handler for "start" CLI command

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -53,7 +53,7 @@ func TestTeleportMain(t *testing.T) {
 	defaults.DataDir = "/tmp/teleport/var/lib/teleport"
 
 	t.Run("Default", func(t *testing.T) {
-		cmd, conf := Run(Options{
+		_, cmd, conf := Run(Options{
 			Args:     []string{"start"},
 			InitOnly: true,
 		})
@@ -68,7 +68,7 @@ func TestTeleportMain(t *testing.T) {
 	})
 
 	t.Run("RolesFlag", func(t *testing.T) {
-		cmd, conf := Run(Options{
+		_, cmd, conf := Run(Options{
 			Args:     []string{"start", "--roles=node"},
 			InitOnly: true,
 		})
@@ -77,7 +77,7 @@ func TestTeleportMain(t *testing.T) {
 		require.False(t, conf.Proxy.Enabled)
 		require.Equal(t, "start", cmd)
 
-		cmd, conf = Run(Options{
+		_, cmd, conf = Run(Options{
 			Args:     []string{"start", "--roles=proxy"},
 			InitOnly: true,
 		})
@@ -86,7 +86,7 @@ func TestTeleportMain(t *testing.T) {
 		require.True(t, conf.Proxy.Enabled)
 		require.Equal(t, "start", cmd)
 
-		cmd, conf = Run(Options{
+		_, cmd, conf = Run(Options{
 			Args:     []string{"start", "--roles=auth"},
 			InitOnly: true,
 		})
@@ -97,7 +97,7 @@ func TestTeleportMain(t *testing.T) {
 	})
 
 	t.Run("ConfigFile", func(t *testing.T) {
-		cmd, conf := Run(Options{
+		_, cmd, conf := Run(Options{
 			Args:     []string{"start", "--roles=node", "--labels=a=a1,b=b1", "--config=" + configFile},
 			InitOnly: true,
 		})

--- a/tool/teleport/common/usage.go
+++ b/tool/teleport/common/usage.go
@@ -1,5 +1,7 @@
 package common
 
+import "fmt"
+
 const (
 	usageNotes = `Notes:
   --roles=node,proxy,auth,app
@@ -15,43 +17,59 @@ const (
   and ignored afterwards.
 `
 
-	usageExamples = `
+	appUsageExamples = `
+> teleport app start --token=xyz --auth-server=proxy.example.com:3080 \
+    --name="example-app" \
+    --uri="http://localhost:8080"
+  Starts an app server that proxies the application "example-app" running at
+  http://localhost:8080.
+
+> teleport app start --token=xyz --auth-server=proxy.example.com:3080 \
+    --name="example-app" \
+    --uri="http://localhost:8080" \
+    --labels=group=dev
+  Same as the above, but the app server runs with "group=dev" label which only
+  allows access to users with the role "group=dev".`
+
+	dbUsageExamples = `
+> teleport db start --token=xyz --auth-server=proxy.example.com:3080 \
+  --name="example-db" \
+  --protocol="postgres" \
+  --uri="localhost:5432"
+Starts a database server that proxies PostgreSQL database "example-db" running
+at localhost:5432. The database must be configured with Teleport CA and key
+pair issued by "tctl auth sign --format=db".
+
+> teleport db start --token=xyz --auth-server=proxy.example.com:3080 \
+  --name="aurora-db" \
+  --protocol="mysql" \
+  --uri="example.cluster-abcdefghij.us-west-1.rds.amazonaws.com:3306" \
+  --aws-region=us-west-1 \
+  --labels=env=aws
+Starts a database server that proxies Aurora MySQL database running in AWS
+region us-west-1 which only allows access to users with the role "env=aws".`
+)
+
+var (
+	usageExamples = fmt.Sprintf(`
 Examples:
 
-> teleport start 
+> teleport start
   By default without any configuration, teleport starts running as a single-node
-  cluster. It's the equivalent of running with --roles=node,proxy,auth 
+  cluster. It's the equivalent of running with --roles=node,proxy,auth
 
 > teleport start --roles=node --auth-server=10.1.0.1 --token=xyz --nodename=db
-  Starts a node named 'db' running in strictly SSH mode role, joining the cluster 
+  Starts a node named 'db' running in strictly SSH mode role, joining the cluster
   serviced by the auth server running on 10.1.0.1
 
 > teleport start --roles=node --auth-server=10.1.0.1 --labels=db=master
   Same as the above, but the node runs with db=master label and can be connected
   to using that label in addition to its name.
+%v
+%v`, appUsageExamples, dbUsageExamples)
+)
 
-> teleport start --roles=app --token=xyz --auth-server=proxy.example.com:3080 \
-    --app-name="example-app" \
-    --app-uri="http://localhost:8080"
-  Starts an app server that proxies the application "example-app" running at
-  http://localhost:8080.
-
-> teleport start --roles=app --token=xyz --auth-server=proxy.example.com:3080 \
-    --app-name="example-app" \
-    --app-uri="http://localhost:8080" \
-    --labels=group=dev
-  Same as the above, but the app server runs with "group=dev" label which only
-  allows access to users with the role "group=dev".
-  
-> teleport start --roles=database --token=xyz --auth-server=proxy.example.com:3080 \
-    --db-name="example-db" \
-    --db-protocol="postgres" \
-    --db-uri="localhost:5432"
-  Starts a database server that proxies PostgreSQL database "example-db" running
-  at localhost:5432. The database must be configured with Teleport CA and key
-  pair issued by "tctl auth sign --format=db".
-`
-
+const (
 	sampleConfComment = `#
 # A Sample Teleport configuration file.
 # Creates a single proxy, auth and node server.


### PR DESCRIPTION
Add a few missing CLI flags to `teleport start` command without which it's impossible to start database service in some configurations e.g. Redshift or Cloud SQL. This is also required for Cloud which will be showing these commands for all various configurations. Closes https://github.com/gravitational/teleport/issues/6684.