### PR TITLE
ami: Update InfluxDB version to 1.8.5

### DIFF
--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -14,7 +14,7 @@ AWS_REGION ?= us-west-2
 # This must be a _released_ version of Teleport, i.e. one which has binaries
 # available for download on https://gravitational.com/teleport/download
 # Unreleased versions will fail to build.
-TELEPORT_VERSION ?= 6.0.2
+TELEPORT_VERSION ?= 6.1.3
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007
@@ -35,7 +35,7 @@ BUILD_TIMESTAMP := $(shell TZ=UTC /bin/date "+%Y%m%d-%H%M%S%Z")
 TELEGRAF_VERSION ?= 1.9.3
 
 # InfluxDB version
-INFLUXDB_VERSION ?= 1.7.1
+INFLUXDB_VERSION ?= 1.8.5
 
 # Grafana version
 GRAFANA_VERSION ?= 5.4.3


### PR DESCRIPTION
InfluxDB 1.7.1 is no longer hosted and 404s. The lowest version of InfluxDB 1.x provided currently is 1.8.5.

Also updates Teleport version to 6.1.3.