### PR TITLE
[v6.1] Broken Images and Links in Docs

### DIFF
--- a/docs/pages/enterprise/sso/ssh-one-login.mdx
+++ b/docs/pages/enterprise/sso/ssh-one-login.mdx
@@ -46,8 +46,11 @@ section:
 
 ### Download Icons
 
-- [Square Icon](../../../img/sso/onelogin/teleport.png)
-- [Rectangular Icon](../../../img/sso/onelogin/teleportlogo@2x.png)
+<img src="../../../img/sso/onelogin/teleport.png" alt="Square Icon" width="100"/>  
+
+<img src="../../../img/sso/onelogin/teleportlogo@2x.png" alt="Rectangular Icon" width="100"/>  
+
+*Right-click and select "Save Image As...".*
 
 <Admonition
   type="tip"

--- a/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
@@ -49,7 +49,11 @@ Go back to your team, then "Integrations" → "Bot Accounts" → "Add Bot Accoun
 
 The new bot account will need the `Post All` permission.
 
-**App Icon:** <a href="../../../img/enterprise/plugins/teleport_bot@2x.png" download>Download Teleport Bot Icon</a>.
+**App Icon:** 
+
+<img src="../../../img/enterprise/plugins/teleport_bot@2x.png" alt="Teleport Bot Icon" width="100"/>
+
+*Right-click and select "Save Image As...".*
 
 ![Enable Mattermost Bots](../../../img/enterprise/plugins/mattermost/mattermost_bot.png)
 

--- a/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
@@ -113,7 +113,11 @@ Visit [https://api.slack.com/apps](https://api.slack.com/apps) to create a new S
 
 **App Name:** Teleport<br/>
 **Development Slack Workspace:** Pick the workspace you'd like the requests to show up in. <br/>
-**App Icon:** <a href="../../../img/enterprise/plugins/teleport_bot@2x.png" download>Download Teleport Bot Icon</a>
+**App Icon:** 
+
+<img src="../../../img/enterprise/plugins/teleport_bot@2x.png" alt="Teleport Bot Icon" width="100"/>
+
+*Right-click and select "Save Image As...".*
 
 ![Create Slack App](../../../img/enterprise/plugins/slack/Create-a-Slack-App.png)
 


### PR DESCRIPTION
This is a quick fix to correct the icon links for https://github.com/gravitational/next/issues/228.