### PR TITLE
Various fixes to SAML encryption key handling for SSO

### DIFF
--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -136,16 +136,18 @@ func (o *SAMLConnectorV2) SetResourceID(id int64) {
 func (o *SAMLConnectorV2) WithoutSecrets() Resource {
 	k1 := o.GetSigningKeyPair()
 	k2 := o.GetEncryptionKeyPair()
-	if k1 == nil && k2 == nil {
-		return o
+	var q1, q2 *AsymmetricKeyPair
+	if k1 != nil {
+		*q1 = *k1
+		q1.PrivateKey = ""
 	}
-	q1 := *k1
-	q2 := *k2
-	q1.PrivateKey = ""
-	q2.PrivateKey = ""
+	if k2 != nil {
+		*q2 = *k2
+		q2.PrivateKey = ""
+	}
 	o2 := *o
-	o2.SetSigningKeyPair(&q1)
-	o2.SetEncryptionKeyPair(&q2)
+	o2.SetSigningKeyPair(q1)
+	o2.SetEncryptionKeyPair(q2)
 	return &o2
 }
 

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Gravitational, Inc.
+Copyright 2020-2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -219,61 +219,6 @@ func (o *SAMLConnectorV2) SetAssertionConsumerService(v string) {
 	o.Spec.AssertionConsumerService = v
 }
 
-<<<<<<< HEAD
-=======
-// Equals returns true if the connectors are identical
-func (o *SAMLConnectorV2) Equals(other SAMLConnector) bool {
-	if o.GetName() != other.GetName() {
-		return false
-	}
-	if o.GetCert() != other.GetCert() {
-		return false
-	}
-	if o.GetAudience() != other.GetAudience() {
-		return false
-	}
-	if o.GetEntityDescriptor() != other.GetEntityDescriptor() {
-		return false
-	}
-	if o.Expiry() != other.Expiry() {
-		return false
-	}
-	if o.GetIssuer() != other.GetIssuer() {
-		return false
-	}
-	if (o.GetSigningKeyPair() == nil && other.GetSigningKeyPair() != nil) || (o.GetSigningKeyPair() != nil && other.GetSigningKeyPair() == nil) {
-		return false
-	}
-	if o.GetSigningKeyPair() != nil {
-		a, b := o.GetSigningKeyPair(), other.GetSigningKeyPair()
-		if a.Cert != b.Cert || a.PrivateKey != b.PrivateKey {
-			return false
-		}
-	}
-	if (o.GetEncryptionKeyPair() == nil && other.GetEncryptionKeyPair() != nil) || (o.GetEncryptionKeyPair() != nil && other.GetEncryptionKeyPair() == nil) {
-		return false
-	}
-	if o.GetEncryptionKeyPair() != nil {
-		a, b := o.GetEncryptionKeyPair(), other.GetEncryptionKeyPair()
-		if a.Cert != b.Cert || a.PrivateKey != b.PrivateKey {
-			return false
-		}
-	}
-	mappings := o.GetAttributesToRoles()
-	otherMappings := other.GetAttributesToRoles()
-	if len(mappings) != len(otherMappings) {
-		return false
-	}
-	for i := range mappings {
-		a, b := mappings[i], otherMappings[i]
-		if a.Name != b.Name || a.Value != b.Value || !utils.StringSlicesEqual(a.Roles, b.Roles) {
-			return false
-		}
-	}
-	return o.GetSSO() == other.GetSSO()
-}
-
->>>>>>> 218958534 (various fixes)
 // SetDisplay sets friendly name for this provider.
 func (o *SAMLConnectorV2) SetDisplay(display string) {
 	o.Spec.Display = display

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Gravitational, Inc.
+Copyright 2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -136,18 +136,17 @@ func (o *SAMLConnectorV2) SetResourceID(id int64) {
 func (o *SAMLConnectorV2) WithoutSecrets() Resource {
 	k1 := o.GetSigningKeyPair()
 	k2 := o.GetEncryptionKeyPair()
-	var q1, q2 *AsymmetricKeyPair
+	o2 := *o
 	if k1 != nil {
-		*q1 = *k1
+		q1 := *k1
 		q1.PrivateKey = ""
+		o2.SetSigningKeyPair(&q1)
 	}
 	if k2 != nil {
-		*q2 = *k2
+		q2 := *k2
 		q2.PrivateKey = ""
+		o2.SetEncryptionKeyPair(&q2)
 	}
-	o2 := *o
-	o2.SetSigningKeyPair(q1)
-	o2.SetEncryptionKeyPair(q2)
 	return &o2
 }
 

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -134,14 +134,18 @@ func (o *SAMLConnectorV2) SetResourceID(id int64) {
 
 // WithoutSecrets returns an instance of resource without secrets.
 func (o *SAMLConnectorV2) WithoutSecrets() Resource {
-	k := o.GetSigningKeyPair()
-	if k == nil {
+	k1 := o.GetSigningKeyPair()
+	k2 := o.GetEncryptionKeyPair()
+	if k1 == nil && k2 == nil {
 		return o
 	}
-	k2 := *k
-	k2.PrivateKey = ""
+	q1 := *k1
+	q2 := *k2
+	q1.PrivateKey = ""
+	q2.PrivateKey = ""
 	o2 := *o
-	o2.SetSigningKeyPair(&k2)
+	o2.SetSigningKeyPair(&q1)
+	o2.SetEncryptionKeyPair(&q2)
 	return &o2
 }
 
@@ -215,6 +219,61 @@ func (o *SAMLConnectorV2) SetAssertionConsumerService(v string) {
 	o.Spec.AssertionConsumerService = v
 }
 
+<<<<<<< HEAD
+=======
+// Equals returns true if the connectors are identical
+func (o *SAMLConnectorV2) Equals(other SAMLConnector) bool {
+	if o.GetName() != other.GetName() {
+		return false
+	}
+	if o.GetCert() != other.GetCert() {
+		return false
+	}
+	if o.GetAudience() != other.GetAudience() {
+		return false
+	}
+	if o.GetEntityDescriptor() != other.GetEntityDescriptor() {
+		return false
+	}
+	if o.Expiry() != other.Expiry() {
+		return false
+	}
+	if o.GetIssuer() != other.GetIssuer() {
+		return false
+	}
+	if (o.GetSigningKeyPair() == nil && other.GetSigningKeyPair() != nil) || (o.GetSigningKeyPair() != nil && other.GetSigningKeyPair() == nil) {
+		return false
+	}
+	if o.GetSigningKeyPair() != nil {
+		a, b := o.GetSigningKeyPair(), other.GetSigningKeyPair()
+		if a.Cert != b.Cert || a.PrivateKey != b.PrivateKey {
+			return false
+		}
+	}
+	if (o.GetEncryptionKeyPair() == nil && other.GetEncryptionKeyPair() != nil) || (o.GetEncryptionKeyPair() != nil && other.GetEncryptionKeyPair() == nil) {
+		return false
+	}
+	if o.GetEncryptionKeyPair() != nil {
+		a, b := o.GetEncryptionKeyPair(), other.GetEncryptionKeyPair()
+		if a.Cert != b.Cert || a.PrivateKey != b.PrivateKey {
+			return false
+		}
+	}
+	mappings := o.GetAttributesToRoles()
+	otherMappings := other.GetAttributesToRoles()
+	if len(mappings) != len(otherMappings) {
+		return false
+	}
+	for i := range mappings {
+		a, b := mappings[i], otherMappings[i]
+		if a.Name != b.Name || a.Value != b.Value || !utils.StringSlicesEqual(a.Roles, b.Roles) {
+			return false
+		}
+	}
+	return o.GetSSO() == other.GetSSO()
+}
+
+>>>>>>> 218958534 (various fixes)
 // SetDisplay sets friendly name for this provider.
 func (o *SAMLConnectorV2) SetDisplay(display string) {
 	o.Spec.Display = display

--- a/api/types/saml_test.go
+++ b/api/types/saml_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSAMLSecretsStrip tests the WithoutSecrets method on SAMLConnectorV2.
+func TestSAMLSecretsStrip(t *testing.T) {
+	connector, err := NewSAMLConnector("test", SAMLConnectorSpecV2{
+		AssertionConsumerService: "test",
+		SSO:                      "test",
+		EntityDescriptor:         "",
+		SigningKeyPair:           &AsymmetricKeyPair{},
+		EncryptionKeyPair:        &AsymmetricKeyPair{},
+	})
+	require.Nil(t, err)
+	require.NotNil(t, connector.GetSigningKeyPair())
+	require.NotNil(t, connector.GetEncryptionKeyPair())
+
+	withoutSecrets := connector.WithoutSecrets().(*SAMLConnectorV2)
+	require.Nil(t, withoutSecrets.GetSigningKeyPair())
+	require.Nil(t, withoutSecrets.GetEncryptionKeyPair())
+}

--- a/api/types/saml_test.go
+++ b/api/types/saml_test.go
@@ -27,15 +27,15 @@ func TestSAMLSecretsStrip(t *testing.T) {
 	connector, err := NewSAMLConnector("test", SAMLConnectorSpecV2{
 		AssertionConsumerService: "test",
 		SSO:                      "test",
-		EntityDescriptor:         "",
-		SigningKeyPair:           &AsymmetricKeyPair{},
-		EncryptionKeyPair:        &AsymmetricKeyPair{},
+		EntityDescriptor:         "test",
+		SigningKeyPair:           &AsymmetricKeyPair{PrivateKey: "test"},
+		EncryptionKeyPair:        &AsymmetricKeyPair{PrivateKey: "test"},
 	})
 	require.Nil(t, err)
-	require.NotNil(t, connector.GetSigningKeyPair())
-	require.NotNil(t, connector.GetEncryptionKeyPair())
+	require.Equal(t, connector.GetSigningKeyPair().PrivateKey, "test")
+	require.Equal(t, connector.GetEncryptionKeyPair().PrivateKey, "test")
 
 	withoutSecrets := connector.WithoutSecrets().(*SAMLConnectorV2)
-	require.Nil(t, withoutSecrets.GetSigningKeyPair())
-	require.Nil(t, withoutSecrets.GetEncryptionKeyPair())
+	require.Equal(t, withoutSecrets.GetSigningKeyPair().PrivateKey, "")
+	require.Equal(t, withoutSecrets.GetEncryptionKeyPair().PrivateKey, "")
 }

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -182,7 +182,7 @@ func GetSAMLServiceProvider(sc types.SAMLConnector, clock clockwork.Clock) (*sam
 		}
 	} else {
 		// Case 2: An encryption keypair is configured. This means that encrypted SAML responses are expected.
-		// Since gosaml2 always uses the main key for encryption, we set it to assrtion_key_pair.
+		// Since gosaml2 always uses the main key for encryption, we set it to assertion_key_pair.
 		// To handle signing correctly, we now instead set the optional signing key in gosaml2 to signing_key_pair.
 		log.Info("Detected assertion_key_pair and configured it to decrypt SAML responses.")
 		keyStore, err = utils.ParseKeyStorePEM(encryptionKeyPair.PrivateKey, encryptionKeyPair.Cert)

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -177,6 +177,7 @@ func GetSAMLServiceProvider(sc types.SAMLConnector, clock clockwork.Clock) (*sam
 		// This is done because gosaml2 mandates an encryption key even if not used.
 		log.Info("No assertion_key_pair was detected. Falling back to signing key for all SAML operations.")
 		keyStore, err = utils.ParseKeyStorePEM(signingKeyPair.PrivateKey, signingKeyPair.Cert)
+		signingKeyStore = keyStore
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to parse certificate or private key defined in signing_key_pair")
 		}

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -168,7 +168,7 @@ func GetSAMLServiceProvider(sc types.SAMLConnector, clock clockwork.Clock) (*sam
 	var signingKeyStore *utils.KeyStore
 	var err error
 
-	// Due to some wierd design choices with how gosaml2 keys are configured we have to do some trickery
+	// Due to some weird design choices with how gosaml2 keys are configured we have to do some trickery
 	// in order to default properly when SAML assertion encryption is turned off.
 	// Below are the different possible cases.
 	if encryptionKeyPair == nil {

--- a/lib/services/saml.go
+++ b/lib/services/saml.go
@@ -162,20 +162,36 @@ func GetSAMLServiceProvider(sc types.SAMLConnector, clock clockwork.Clock) (*sam
 		return nil, trace.BadParameter("no identity provider certificate provided, either set certificate as a parameter or via entity_descriptor")
 	}
 
-	signingKeyStore, err := utils.ParseSigningKeyStorePEM(sc.GetSigningKeyPair().PrivateKey, sc.GetSigningKeyPair().Cert)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to parse certificate defined in signing_key_pair")
-	}
-
-	// The encryption keystore here is defaulted to the value of the signing keystore
-	// if no separate assertion decryption keys are provided. We do this here to initialize
-	// the variable but if set to nil, gosaml2 will do this internally anyway.
-	encryptionKeyStore := signingKeyStore
+	signingKeyPair := sc.GetSigningKeyPair()
 	encryptionKeyPair := sc.GetEncryptionKeyPair()
-	if encryptionKeyPair != nil {
-		encryptionKeyStore, err = utils.ParseSigningKeyStorePEM(encryptionKeyPair.PrivateKey, encryptionKeyPair.Cert)
+	var keyStore *utils.KeyStore
+	var signingKeyStore *utils.KeyStore
+	var err error
+
+	// Due to some wierd design choices with how gosaml2 keys are configured we have to do some trickery
+	// in order to default properly when SAML assertion encryption is turned off.
+	// Below are the different possible cases.
+	if encryptionKeyPair == nil {
+		// Case 1: Only the signing key pair is set. This means that SAML encryption is not expected
+		// and we therefore configure the main key that gets used for all operations as the signing key.
+		// This is done because gosaml2 mandates an encryption key even if not used.
+		log.Info("No assertion_key_pair was detected. Falling back to signing key for all SAML operations.")
+		keyStore, err = utils.ParseKeyStorePEM(signingKeyPair.PrivateKey, signingKeyPair.Cert)
 		if err != nil {
-			return nil, trace.Wrap(err, "failed to parse certificate defined in assertion_key_pair")
+			return nil, trace.Wrap(err, "failed to parse certificate or private key defined in signing_key_pair")
+		}
+	} else {
+		// Case 2: An encryption keypair is configured. This means that encrypted SAML responses are expected.
+		// Since gosaml2 always uses the main key for encryption, we set it to assrtion_key_pair.
+		// To handle signing correctly, we now instead set the optional signing key in gosaml2 to signing_key_pair.
+		log.Info("Detected assertion_key_pair and configured it to decrypt SAML responses.")
+		keyStore, err = utils.ParseKeyStorePEM(encryptionKeyPair.PrivateKey, encryptionKeyPair.Cert)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to parse certificate or private key defined in assertion_key_pair")
+		}
+		signingKeyStore, err = utils.ParseKeyStorePEM(signingKeyPair.PrivateKey, signingKeyPair.Cert)
+		if err != nil {
+			return nil, trace.Wrap(err, "failed to parse certificate or private key defined in signing_key_pair")
 		}
 	}
 
@@ -188,8 +204,8 @@ func GetSAMLServiceProvider(sc types.SAMLConnector, clock clockwork.Clock) (*sam
 		SignAuthnRequestsCanonicalizer: dsig.MakeC14N11Canonicalizer(),
 		AudienceURI:                    sc.GetAudience(),
 		IDPCertificateStore:            &certStore,
-		SPKeyStore:                     encryptionKeyStore,
 		SPSigningKeyStore:              signingKeyStore,
+		SPKeyStore:                     keyStore,
 		Clock:                          dsig.NewFakeClock(clock),
 		NameIdFormat:                   "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
 	}

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -34,8 +34,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ParseSigningKeyStore parses signing key store from PEM encoded key pair
-func ParseSigningKeyStorePEM(keyPEM, certPEM string) (*SigningKeyStore, error) {
+// ParseKeyStore parses signing key store from PEM encoded key pair
+func ParseKeyStorePEM(keyPEM, certPEM string) (*KeyStore, error) {
 	_, err := tlsutils.ParseCertificatePEM([]byte(certPEM))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -46,22 +46,22 @@ func ParseSigningKeyStorePEM(keyPEM, certPEM string) (*SigningKeyStore, error) {
 	}
 	rsaKey, ok := key.(*rsa.PrivateKey)
 	if !ok {
-		return nil, trace.BadParameter("key of type %T is not supported, only RSA keys are supported for signatures", key)
+		return nil, trace.BadParameter("key of type %T is not supported, only RSA keys are supported", key)
 	}
 	certASN, _ := pem.Decode([]byte(certPEM))
 	if certASN == nil {
 		return nil, trace.BadParameter("expected PEM-encoded block")
 	}
-	return &SigningKeyStore{privateKey: rsaKey, cert: certASN.Bytes}, nil
+	return &KeyStore{privateKey: rsaKey, cert: certASN.Bytes}, nil
 }
 
-// SigningKeyStore is used to sign using X509 digital signatures
-type SigningKeyStore struct {
+// To sign and decrypt data using X509 digital signatures
+type KeyStore struct {
 	privateKey *rsa.PrivateKey
 	cert       []byte
 }
 
-func (ks *SigningKeyStore) GetKeyPair() (*rsa.PrivateKey, []byte, error) {
+func (ks *KeyStore) GetKeyPair() (*rsa.PrivateKey, []byte, error) {
 	return ks.privateKey, ks.cert, nil
 }
 

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -34,7 +34,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ParseKeyStore parses signing key store from PEM encoded key pair
+// ParseKeyStorePEM parses signing key store from PEM encoded key pair
 func ParseKeyStorePEM(keyPEM, certPEM string) (*KeyStore, error) {
 	_, err := tlsutils.ParseCertificatePEM([]byte(certPEM))
 	if err != nil {
@@ -55,7 +55,7 @@ func ParseKeyStorePEM(keyPEM, certPEM string) (*KeyStore, error) {
 	return &KeyStore{privateKey: rsaKey, cert: certASN.Bytes}, nil
 }
 
-// To sign and decrypt data using X509 digital signatures
+// KeyStore is used to sign and decrypt data using X509 digital signatures.
 type KeyStore struct {
 	privateKey *rsa.PrivateKey
 	cert       []byte


### PR DESCRIPTION
# Why

This PR resolves some issues and clarifies some code that handle SAML connector configuration in the scenario that SAML assertion encryption is enabled.

# How

Rewrites most of the handling logic and patches a bug where the encryption key would be included in a dump without secrets enabled.

# Testing

This code relies on existing SAML tests to not break basic functionality and manual testing has been performed with AD for encryption logic since we cannot test that programmatically.