### PR TITLE
Enabling volumes/env variables for database services in teleport kube agent

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
 {{- if .Values.environmentVariables }}
         env:
 {{ toYaml .Values.environmentVariables | indent 8 }}
-{{- end }}          
+{{- end }}
         args:
         - "--diag-addr=0.0.0.0:3000"
         {{- if .Values.insecureSkipProxyTLSVerify }}
@@ -72,7 +72,7 @@ spec:
           name: "data"
 {{- if .Values.serviceVolumeMounts }}
 {{ toYaml .Values.serviceVolumeMounts | indent 8 }}
-{{- end }}          
+{{- end }}
       volumes:
       - name: "config"
         configMap:
@@ -84,5 +84,5 @@ spec:
         emptyDir: {}
 {{- if .Values.serviceVolumes }}
 {{ toYaml .Values.serviceVolumes | indent 6 }}
-{{- end }}            
+{{- end }}
       serviceAccountName: {{ .Values.serviceAccountName }}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       containers:
       - name: "teleport"
         image: "{{ if .Values.enterprise }}{{ .Values.enterpriseImage }}{{ else }}{{ .Values.image }}{{ end }}:{{ .teleportVersion }}"
+{{- if .Values.environmentVariables }}
+        env:
+{{ toYaml .Values.environmentVariables | indent 8 }}
+{{- end }}          
         args:
         - "--diag-addr=0.0.0.0:3000"
         {{- if .Values.insecureSkipProxyTLSVerify }}
@@ -66,6 +70,9 @@ spec:
           readOnly: true
         - mountPath: /var/lib/teleport
           name: "data"
+{{- if .Values.serviceVolumeMounts }}
+{{ toYaml .Values.serviceVolumeMounts | indent 8 }}
+{{- end }}          
       volumes:
       - name: "config"
         configMap:
@@ -75,4 +82,7 @@ spec:
           secretName: {{ .Values.secretName }}
       - name: "data"
         emptyDir: {}
+{{- if .Values.serviceVolumes }}
+{{ toYaml .Values.serviceVolumes | indent 6 }}
+{{- end }}            
       serviceAccountName: {{ .Values.serviceAccountName }}

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -58,6 +58,26 @@ podSecurityPolicy:
 labels: {}
 
 ################################################################
+# Database services that use certificates and other files 
+# volumes and volume mounts.
+################################################################
+
+
+# Volume and volume mounts used for any of the service configuration 
+serviceVolumes: []
+serviceVolumeMounts: []
+
+
+################################################################
+# Environment variables that are needed such as cloudsql 
+# GOOGLE_APPLICATION_CREDENTIALS file or
+# other services.  The file should be made available from volumes.
+################################################################
+environmentVariables: []
+#  - name: GOOGLE_APPLICATION_CREDENTIALS
+ #   value: "/var/lib/googlecred/teleport-db.json"
+
+################################################################
 # Values that you shouldn't need to change.
 ################################################################
 


### PR DESCRIPTION
Adds in options for volumes, volume mounts and env variables.  These are required to allow cloudsql or other dbs that require files in their authentication.

Following the cloudsql db guide (https://goteleport.com/docs/database-access/guides/postgres-cloudsql/)  a admin could add the files as secrets.

```bash
kubectl create secret -n teleport generic server-ca --from-file=server-ca.pem
kubectl create secret -n teleport generic teleport-db --from-file=teleport-db.json
```

Then specify the db service, the volumes, volume mounts, and env variable. 

```yaml

databases:
  - name: "cloudsql2"
 #   Free-form description of the database proxy instance.
    description: "GCP Cloud SQL PostgreSQL"
 #  Database protocol.
    protocol: "postgres"
 # Database endpoint. For Cloud SQL use instance's public IP address.
    uri: "server:5432"
 # Path to Cloud SQL instance root certificate you downloaded above.
    ca_cert_file: /var/lib/ca/server-ca.pem
     # GCP specific configuration when connecting Cloud SQL instance.
    gcp:
 # GCP project ID.
      project_id: "weighty-stuff-305123"
 # Cloud SQL instance ID.
      instance_id: "mydb"
    static_labels:
      env: dev
      tier: dev

# Volume and volume mounts used for any of the service configuration 
serviceVolumes:
 - name: "teleportjson"
   secret:
     secretName: teleport-db
 - name: "teleportca"
   secret:
     secretName: server-ca
serviceVolumeMounts:
  - mountPath: /var/lib/googlecred
    name: teleportjson
    readOnly: true
  - mountPath: /var/lib/ca
    name: teleportca
    readOnly: true


################################################################
# Environment variables that are needed such as cloudsql 
# GOOGLE_APPLICATION_CREDENTIALS file or
# other services
################################################################
environmentVariables:
  - name: GOOGLE_APPLICATION_CREDENTIALS
    value: "/var/lib/googlecred/teleport-db.json"
```