### PR TITLE
Updated the prerequisites to remove cloud requirement

### DIFF
--- a/docs/pages/access-controls/guides/u2f.mdx
+++ b/docs/pages/access-controls/guides/u2f.mdx
@@ -12,7 +12,7 @@ into individual SSH nodes or Kubernetes clusters (`tsh ssh` and `kubectl`).
 
 ## Prerequisites
 
-- Installed [Teleport](../getting-started.mdx) or [Teleport Cloud](../../cloud/introduction.mdx) >= (=teleport.version=)
+- Installed [Teleport](../getting-started.mdx) >= (=teleport.version=)
 - U2F hardware device, such as Yubikey or Solokey
 - Web browser that [supports U2F](https://caniuse.com/u2f)
 


### PR DESCRIPTION
Since Cloud isn't supported for U2F as of yet removed the requirement to alleviate confusion.