### PR TITLE
[Backport 6.2] Stop changing kube context by default on tsh login (#6721)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## 6.2
 
-This release of teleport contains minor features and bugfixes.
+This release of teleport contains multiple features and bugfixes.
 
 * Changed DynamoDB events backend indexing strategy. [#6583](https://github.com/gravitational/teleport/pull/6583)
   Warning! This will trigger a data migration on the first start after upgrade. For optimal performance perform this migration with only one auth server online. It may take some time and progress will be periodically written to the auth server log. Once Teleport starts and is accessible via Web UI, the rest of the cluster may be started.
+* Stopped changing current kubectl context by default during `tsh login`. [#6721](https://github.com/gravitational/teleport/pull/6721)
+  Use `tsh login --kube-cluster=<kube cluster>` or `tsh kube login <kube cluster>` to change your current kubectl context.
 
 ## 6.1.4
 

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -227,7 +227,7 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 		//
 		// Re-generate kubeconfig contexts and try selecting this kube cluster
 		// again.
-		if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
+		if err := updateKubeConfig(cf, tc); err != nil {
 			return trace.Wrap(err)
 		}
 		if err := kubeconfig.SelectContext(currentTeleportCluster, c.kubeCluster); err != nil {
@@ -268,6 +268,94 @@ func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleport
 		return "", nil, trace.Wrap(err)
 	}
 	return teleportCluster, kubeClusters, nil
+}
+
+// kubernetesStatus holds teleport client information necessary to populate the user's kubeconfig.
+type kubernetesStatus struct {
+	clusterAddr         string
+	teleportClusterName string
+	kubeClusters        []string
+	credentials         *client.Key
+}
+
+// fetchKubeStatus returns a kubernetesStatus populated from the given TeleportClient.
+func fetchKubeStatus(ctx context.Context, tc *client.TeleportClient) (*kubernetesStatus, error) {
+	var err error
+	kubeStatus := &kubernetesStatus{
+		clusterAddr: tc.KubeClusterAddr(),
+	}
+	kubeStatus.credentials, err = tc.LocalAgent().GetCoreKey()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	kubeStatus.teleportClusterName, kubeStatus.kubeClusters, err = fetchKubeClusters(ctx, tc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return kubeStatus, nil
+}
+
+// buildKubeConfigUpdate returns a kubeconfig.Values suitable for updating the user's kubeconfig
+// based on the CLI parameters and the given kubernetesStatus.
+func buildKubeConfigUpdate(cf *CLIConf, kubeStatus *kubernetesStatus) (*kubeconfig.Values, error) {
+	v := &kubeconfig.Values{
+		ClusterAddr:         kubeStatus.clusterAddr,
+		TeleportClusterName: kubeStatus.teleportClusterName,
+		Credentials:         kubeStatus.credentials,
+	}
+
+	if cf.executablePath == "" {
+		// Don't know tsh path.
+		// Fall back to the old kubeconfig, with static credentials from v.Credentials.
+		return v, nil
+	}
+
+	if len(kubeStatus.kubeClusters) == 0 {
+		// If there are no registered k8s clusters, we may have an older teleport cluster.
+		// Fall back to the old kubeconfig, with static credentials from v.Credentials.
+		log.Debug("Disabling exec plugin mode for kubeconfig because this Teleport cluster has no Kubernetes clusters.")
+		return v, nil
+	}
+
+	v.Exec = &kubeconfig.ExecValues{
+		TshBinaryPath:     cf.executablePath,
+		TshBinaryInsecure: cf.InsecureSkipVerify,
+		KubeClusters:      kubeStatus.kubeClusters,
+	}
+
+	// Only switch the current context if kube-cluster is explicitly set on the command line.
+	if cf.KubernetesCluster != "" {
+		if !utils.SliceContainsStr(kubeStatus.kubeClusters, cf.KubernetesCluster) {
+			return nil, trace.BadParameter("Kubernetes cluster %q is not registered in this Teleport cluster; you can list registered Kubernetes clusters using 'tsh kube ls'.", cf.KubernetesCluster)
+		}
+		v.Exec.SelectCluster = cf.KubernetesCluster
+	}
+	return v, nil
+}
+
+// updateKubeConfig adds Teleport configuration to the users's kubeconfig based on the CLI
+// parameters and the kubernetes services in the current Teleport cluster.
+func updateKubeConfig(cf *CLIConf, tc *client.TeleportClient) error {
+	// Fetch proxy's advertised ports to check for k8s support.
+	if _, err := tc.Ping(cf.Context); err != nil {
+		return trace.Wrap(err)
+	}
+	if tc.KubeProxyAddr == "" {
+		// Kubernetes support disabled, don't touch kubeconfig.
+		return nil
+	}
+
+	kubeStatus, err := fetchKubeStatus(cf.Context, tc)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	values, err := buildKubeConfigUpdate(cf, kubeStatus)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(kubeconfig.Update("", *values))
 }
 
 // Required magic boilerplate to use the k8s encoder.

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -693,7 +693,7 @@ func onLogin(cf *CLIConf) error {
 		// in case if nothing is specified, re-fetch kube clusters and print
 		// current status
 		case cf.Proxy == "" && cf.SiteName == "" && cf.DesiredRoles == "" && cf.IdentityFileOut == "":
-			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
+			if err := updateKubeConfig(cf, tc); err != nil {
 				return trace.Wrap(err)
 			}
 			printProfiles(cf.Debug, profile, profiles)
@@ -701,7 +701,7 @@ func onLogin(cf *CLIConf) error {
 		// in case if parameters match, re-fetch kube clusters and print
 		// current status
 		case host(cf.Proxy) == host(profile.ProxyURL.Host) && cf.SiteName == profile.Cluster && cf.DesiredRoles == "":
-			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
+			if err := updateKubeConfig(cf, tc); err != nil {
 				return trace.Wrap(err)
 			}
 			printProfiles(cf.Debug, profile, profiles)
@@ -721,7 +721,7 @@ func onLogin(cf *CLIConf) error {
 			if err := tc.SaveProfile("", true); err != nil {
 				return trace.Wrap(err)
 			}
-			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
+			if err := updateKubeConfig(cf, tc); err != nil {
 				return trace.Wrap(err)
 			}
 			return trace.Wrap(onStatus(cf))
@@ -732,7 +732,7 @@ func onLogin(cf *CLIConf) error {
 			if err := executeAccessRequest(cf, tc); err != nil {
 				return trace.Wrap(err)
 			}
-			if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
+			if err := updateKubeConfig(cf, tc); err != nil {
 				return trace.Wrap(err)
 			}
 			return trace.Wrap(onStatus(cf))
@@ -794,7 +794,7 @@ func onLogin(cf *CLIConf) error {
 
 	// If the proxy is advertising that it supports Kubernetes, update kubeconfig.
 	if tc.KubeProxyAddr != "" {
-		if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
+		if err := updateKubeConfig(cf, tc); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -2039,7 +2039,7 @@ func reissueWithRequests(cf *CLIConf, tc *client.TeleportClient, reqIDs ...strin
 	if err := tc.SaveProfile("", true); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := kubeconfig.UpdateWithClient(cf.Context, "", tc, cf.executablePath); err != nil {
+	if err := updateKubeConfig(cf, tc); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil


### PR DESCRIPTION
With this change `tsh login` will still always add teleport contexts and
credentials to the kubeconfig, but will only update the current context if:
- `tsh login` is called with `--kube-cluster` set, or
- `tsh kube login <kube cluster>` is called.