### PR TITLE
Update admin-guide.mdx Teleport Upgrade section for clarity around the 4.4.x to 5.x transition

### DIFF
--- a/docs/pages/admin-guide.mdx
+++ b/docs/pages/admin-guide.mdx
@@ -1760,6 +1760,7 @@ clients, etc), the following rules apply:
 - Minor versions are always compatible with the **previous** minor release. This means you must not attempt to upgrade from 4.1.x straight to 4.3.x. You must upgrade to 4.2.x first.
 - Teleport clients [`tsh`](cli-docs.mdx#tsh) for users and [`tctl`](cli-docs.mdx#tctl) for admins
   may not be compatible with different versions of the `teleport` service.
+- Version 4.4.x is fully compatible with all minor 5.x releases, for example, any 4.4.9 component will work with any 5.2.1 component.
 
 **After 5.0.0**
 


### PR DESCRIPTION
Adding a line to the pre 5.0 upgrade guide indicating that the 4.4.x minor version is fully compatible with all 5.x minor versions for Teleport upgrades