### PR TITLE
Adjust break behaviour in DynamoDB driver to avoid loosing events

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -704,7 +704,6 @@ dateLoop:
 			}
 			g.WithFields(log.Fields{"duration": time.Since(start), "items": len(out.Items)}).Debugf("Query completed.")
 
-		itemLoop:
 			for _, item := range out.Items {
 				var e event
 				if err := dynamodbattribute.UnmarshalMap(item, &e); err != nil {
@@ -719,7 +718,7 @@ dateLoop:
 				for i := range eventFilter {
 					if fields.GetString(events.EventType) == eventFilter[i] {
 						accepted = true
-						break itemLoop
+						break
 					}
 				}
 				if accepted || !doFilter {


### PR DESCRIPTION
In #6583 I introduced a bug that that causes events to be lost from query results on the `SearchEvents` endpoint if a query filter is specified. This PR fixes that behaviour by breaking from the correct loop. This bug is not included in any release.

note: this needs to be backported to `branch/v6`