### PR TITLE
Add caPin to teleport-kube-agent helmchart

### DIFF
--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -16,7 +16,9 @@ To use it, you will need:
   - this chart does not currently support dynamic join tokens; please [file an
     issue](https://github.com/gravitational/teleport/issues/new?labels=type%3A+feature+request&template=feature_request.md)
     if you require support for dynamic tokens
-- a [ca pin](https://goteleport.com/teleport/docs/admin-guide/#adding-nodes-to-the-cluster) for this Teleport cluster (optional but reccomended for production)
+
+For production use, it is reccomended that you provide:
+- a [ca pin](https://goteleport.com/teleport/docs/admin-guide/#adding-nodes-to-the-cluster) for the Teleport cluster (allows for validation of Teleport cluster cert)
 
 ## Combining roles
 
@@ -48,7 +50,7 @@ $ helm install teleport-kube-agent . \
   --set proxyAddr=${PROXY_ENDPOINT?} \
   --set authToken=${JOIN_TOKEN?} \
   --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?} \
-  --set caPin=${CA_PIN?} # optional, but reccomended for validating cluster certificates
+  --set caPin=${CA_PIN?} # optional, but recommended for validating cluster certificates
 ```
 
 Set the values in the above command as appropriate for your setup.

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -16,6 +16,7 @@ To use it, you will need:
   - this chart does not currently support dynamic join tokens; please [file an
     issue](https://github.com/gravitational/teleport/issues/new?labels=type%3A+feature+request&template=feature_request.md)
     if you require support for dynamic tokens
+- a [ca pin](https://goteleport.com/teleport/docs/admin-guide/#adding-nodes-to-the-cluster) for this Teleport cluster (optional but reccomended for production)
 
 ## Combining roles
 
@@ -46,7 +47,8 @@ $ helm install teleport-kube-agent . \
   --set roles=kube \
   --set proxyAddr=${PROXY_ENDPOINT?} \
   --set authToken=${JOIN_TOKEN?} \
-  --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?}
+  --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?} \
+  --set caPin=${CA_PIN?} # optional, but reccomended for validating cluster certificates
 ```
 
 Set the values in the above command as appropriate for your setup.

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -7,6 +7,9 @@ data:
     teleport:
       auth_token: "/etc/teleport-secrets/auth-token"
       auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
+      {{- if .Values.caPin }}
+      ca_pin: "{{ .Values.caPin }}"
+      {{- end }}
       log:
         severity: {{ .Values.logLevel }}
         output: stderr


### PR DESCRIPTION
I added this to my local version of the chart so that I could validate the cluster's certs.

Changes:
* Modified teleport-kube-agent/templates/config.yaml to use `Values.caPin` if it is set
* Updated the readme to document the new value