### PR TITLE
[branch/v6.1] Backport "Align atomics to prevent segmentation faults on ARMv7"

### DIFF
--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -186,7 +186,7 @@ func TestAsyncEmitter(t *testing.T) {
 
 	// Close makes sure that close cancels operations and context
 	t.Run("Close", func(t *testing.T) {
-		counter := &counterEmitter{}
+		counter := &counterEmitter{count: atomic.NewInt64(0)}
 		emitter, err := NewAsyncEmitter(AsyncEmitterConfig{
 			Inner:      counter,
 			BufferSize: len(events),
@@ -237,7 +237,7 @@ func (s *slowEmitter) EmitAuditEvent(ctx context.Context, event AuditEvent) erro
 }
 
 type counterEmitter struct {
-	count atomic.Int64
+	count *atomic.Int64
 }
 
 func (c *counterEmitter) EmitAuditEvent(ctx context.Context, event AuditEvent) error {


### PR DESCRIPTION
This PR backports #6711 to v6.1. Clean backport with no conflicts or functional changes.