### PR TITLE
client: set TLS certificate usage for k8s/app/db certs

### DIFF
--- a/api/client/proto/authservice.pb.go
+++ b/api/client/proto/authservice.pb.go
@@ -72,11 +72,22 @@ func (Operation) EnumDescriptor() ([]byte, []int) {
 type UserCertsRequest_CertUsage int32
 
 const (
-	UserCertsRequest_All        UserCertsRequest_CertUsage = 0
-	UserCertsRequest_SSH        UserCertsRequest_CertUsage = 1
+	// All means a request for both SSH and TLS certificates for the
+	// overall user session. These certificates are not specific to any SSH
+	// node, Kubernetes cluster, database or web app.
+	UserCertsRequest_All UserCertsRequest_CertUsage = 0
+	// SSH means a request for an SSH certificate for access to a specific
+	// SSH node, as specified by NodeName.
+	UserCertsRequest_SSH UserCertsRequest_CertUsage = 1
+	// Kubernetes means a request for a TLS certificate for access to a
+	// specific Kubernetes cluster, as specified by KubernetesCluster.
 	UserCertsRequest_Kubernetes UserCertsRequest_CertUsage = 2
-	UserCertsRequest_Database   UserCertsRequest_CertUsage = 3
-	UserCertsRequest_App        UserCertsRequest_CertUsage = 4
+	// Database means a request for a TLS certificate for access to a
+	// specific database, as specified by RouteToDatabase.
+	UserCertsRequest_Database UserCertsRequest_CertUsage = 3
+	// App means a request for a TLS certificate for access to a specific
+	// web app, as specified by RouteToApp.
+	UserCertsRequest_App UserCertsRequest_CertUsage = 4
 )
 
 var UserCertsRequest_CertUsage_name = map[int32]string{

--- a/api/client/proto/authservice.proto
+++ b/api/client/proto/authservice.proto
@@ -152,10 +152,21 @@ message UserCertsRequest {
     string NodeName = 9 [ (gogoproto.jsontag) = "node_name,omitempty" ];
 
     enum CertUsage {
+        // All means a request for both SSH and TLS certificates for the
+        // overall user session. These certificates are not specific to any SSH
+        // node, Kubernetes cluster, database or web app.
         All = 0;
+        // SSH means a request for an SSH certificate for access to a specific
+        // SSH node, as specified by NodeName.
         SSH = 1;
+        // Kubernetes means a request for a TLS certificate for access to a
+        // specific Kubernetes cluster, as specified by KubernetesCluster.
         Kubernetes = 2;
+        // Database means a request for a TLS certificate for access to a
+        // specific database, as specified by RouteToDatabase.
         Database = 3;
+        // App means a request for a TLS certificate for access to a specific
+        // web app, as specified by RouteToApp.
         App = 4;
     }
     // CertUsage limits the resulting user certificate to a single protocol.

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -362,9 +362,6 @@ type ProfileStatus struct {
 	// kubernetes cluster.
 	KubeEnabled bool
 
-	// KubeCluster is the name of the kubernetes cluster used by this profile.
-	KubeCluster string
-
 	// KubeUsers are the kubernetes users used by this profile.
 	KubeUsers []string
 
@@ -625,7 +622,6 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 		Traits:         traits,
 		ActiveRequests: activeRequests,
 		KubeEnabled:    profile.KubeProxyAddr != "",
-		KubeCluster:    tlsID.KubernetesCluster,
 		KubeUsers:      tlsID.KubernetesUsers,
 		KubeGroups:     tlsID.KubernetesGroups,
 		Databases:      databases,

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -153,14 +153,25 @@ type ReissueParams struct {
 func (p ReissueParams) usage() proto.UserCertsRequest_CertUsage {
 	switch {
 	case p.NodeName != "":
+		// SSH means a request for an SSH certificate for access to a specific
+		// SSH node, as specified by NodeName.
 		return proto.UserCertsRequest_SSH
 	case p.KubernetesCluster != "":
+		// Kubernetes means a request for a TLS certificate for access to a
+		// specific Kubernetes cluster, as specified by KubernetesCluster.
 		return proto.UserCertsRequest_Kubernetes
 	case p.RouteToDatabase.ServiceName != "":
+		// Database means a request for a TLS certificate for access to a
+		// specific database, as specified by RouteToDatabase.
 		return proto.UserCertsRequest_Database
 	case p.RouteToApp.Name != "":
+		// App means a request for a TLS certificate for access to a specific
+		// web app, as specified by RouteToApp.
 		return proto.UserCertsRequest_App
 	default:
+		// All means a request for both SSH and TLS certificates for the
+		// overall user session. These certificates are not specific to any SSH
+		// node, Kubernetes cluster, database or web app.
 		return proto.UserCertsRequest_All
 	}
 }
@@ -252,7 +263,9 @@ func (proxy *ProxyClient) reissueUserCerts(ctx context.Context, cachePolicy Cert
 
 	key.ClusterName = params.RouteToCluster
 
-	// Only update the parts of key that match the usage.
+	// Only update the parts of key that match the usage. See the docs on
+	// proto.UserCertsRequest_CertUsage for which certificates match which
+	// usage.
 	//
 	// This prevents us from overwriting the top-level key.TLSCert with
 	// usage-restricted certificates.

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1893,8 +1893,8 @@ func printStatus(debug bool, p *client.ProfileStatus, isActive bool) {
 	fmt.Printf("  Logins:             %v\n", strings.Join(p.Logins, ", "))
 	if p.KubeEnabled {
 		fmt.Printf("  Kubernetes:         enabled\n")
-		if p.KubeCluster != "" {
-			fmt.Printf("  Kubernetes cluster: %q\n", p.KubeCluster)
+		if kubeCluster := selectedKubeCluster(p.Cluster); kubeCluster != "" {
+			fmt.Printf("  Kubernetes cluster: %q\n", kubeCluster)
 		}
 		if len(p.KubeUsers) > 0 {
 			fmt.Printf("  Kubernetes users:   %v\n", strings.Join(p.KubeUsers, ", "))


### PR DESCRIPTION
### TLS usage field

The certificate usage field prevents a certificate from being used for
other purposes. For example, a k8s-specific certificate will not be
accepted by a database service endpoint.

Server-side enforcement logic was already in place for a long time, but
we stopped setting the correct Usage in UserCertRequest during keystore
refactoring in 5.0 (with introduction of k8s certs).

### TLS certificate overwrite

As part of this, client.ReissueUserCerts will no longer write
usage-restricted certificates into the top-level TLS certificate used
for Teleport API authentication.

For example, when generating a k8s-specific certificate, we used to
overwrite both:
- `~/.tsh/keys/$proxy/$user-x509.pem`
- `~/.tsh/keys/$proxy/$user-kube/$cluster/$kubeCluster-x509.pem`
This PR stops overwriting `~/.tsh/keys/$proxy/$user-x509.pem`.
This is not a breaking change.

### Selected k8s cluster

Prior to this PR, `tsh status` printed the selected k8s cluster based on
the top-level TLS certificate. Since we no longer overwrite that
certificate, it will not contain a k8s cluster name.

Instead, we extract it from the kubeconfig, which is actually more
accurate since a user could switch to a different context out-of-band.

Updates https://github.com/gravitational/teleport/issues/6161
Updates https://github.com/gravitational/teleport/issues/5815