### PR TITLE
[v6.1] docs: update version in install and getting started guides

### DIFF
--- a/docs/pages/aws-oss-guide.mdx
+++ b/docs/pages/aws-oss-guide.mdx
@@ -72,7 +72,7 @@ DynamoDB is a key-value and document database that delivers single-digit millise
 performance at any scale. For large clusters, you can provision usage but for smaller
 deployments, you can leverage DynamoDB's autoscaling.
 
-Teleport 4.0 leverages [DynamoDB's streaming feature](https://github.com/gravitational/teleport/issues/2430). When turning this on, you'll need
+Teleport 4.0+ leverages [DynamoDB's streaming feature](https://github.com/gravitational/teleport/issues/2430). When turning this on, you'll need
 to specify `New Image` from the streaming options. DynamoDB backend supports two
 types of Teleport data:
 

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -11,7 +11,7 @@ to a PostgreSQL AWS Aurora database.
 Here's an overview of what we will do:
 
 1. Configure AWS Aurora database with IAM authentication.
-2. Download and install Teleport and connect it to the Aurora database.
+2. Download and install Teleport (=teleport.version=) and connect it to the Aurora database.
 3. Connect to the Aurora database via Teleport.
 
 ## Step 1/3. Setup Aurora

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -4,7 +4,7 @@ description: Getting started with Teleport - identity-aware, multi-protocol acce
 ---
 
 This tutorial will guide you through the steps needed to install and run
-Teleport on Linux machines.
+Teleport (=teleport.version=) on Linux machines.
 
 ### Prerequisites
 


### PR DESCRIPTION
Addressing the main item here: #5357

Also two other articles.

Backport of https://github.com/gravitational/teleport/pull/6810