### PR TITLE
Revert TLS cert usage for database certs

### DIFF
--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -99,7 +99,8 @@ func NewProxyServer(ctx context.Context, config ProxyServerConfig) (*ProxyServer
 	server := &ProxyServer{
 		cfg: config,
 		middleware: &auth.Middleware{
-			AccessPoint: config.AccessPoint,
+			AccessPoint:   config.AccessPoint,
+			AcceptedUsage: []string{teleport.UsageDatabaseOnly},
 		},
 		closeCtx: ctx,
 		log:      logrus.WithField(trace.Component, "db:proxy"),


### PR DESCRIPTION
Database service doesn't fully support the cert usage restrictions yet
so we need an unrestricted cert again.