### PR TITLE
[v6.2] correct logging and console outputs

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -594,9 +594,9 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 			return trace.Errorf("https cert does not exist: %s", p.Certificate)
 		}
 
-		// Read in certificate from disk. If Teleport finds a self signed
+		// Read in certificate from disk. If Teleport finds a self-signed
 		// certificate chain, log a warning, and then accept whatever certificate
-		// was passed. If the certificate is not self signed, verify the certificate
+		// was passed. If the certificate is not self-signed, verify the certificate
 		// chain from leaf to root with the trust store on the computer so browsers
 		// don't complain.
 		certificateChainBytes, err := utils.ReadPath(p.Certificate)

--- a/lib/fixtures/keys.go
+++ b/lib/fixtures/keys.go
@@ -87,7 +87,7 @@ func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "
 // TLSConfig is TLS configuration for running local TLS tests
 type TLSConfig struct {
 	// CertPool is a trusted certificate authority pool
-	// that consists of self signed cert
+	// that consists of self-signed cert
 	CertPool *x509.CertPool
 	// Certificate is a client x509 client cert
 	Certificate *x509.Certificate
@@ -106,7 +106,7 @@ func (t *TLSConfig) NewClient() *http.Client {
 	}
 }
 
-// LocalTLSConfig returns local TLS config with self signed certificate
+// LocalTLSConfig returns local TLS config with self-signed certificate
 func LocalTLSConfig() (*TLSConfig, error) {
 	cert, err := tls.X509KeyPair(LocalhostCert, LocalhostKey)
 	if err != nil {

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -318,7 +318,7 @@ type ProxyConfig struct {
 	// Enabled turns proxy role on or off for this process
 	Enabled bool
 
-	//DisableTLS is enabled if we don't want self signed certs
+	//DisableTLS is enabled if we don't want self-signed certs
 	DisableTLS bool
 
 	// DisableWebInterface allows to turn off serving the Web UI interface

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -382,7 +382,7 @@ func (process *TeleportProcess) firstTimeConnect(role teleport.Role) (*Connector
 		process.deleteKeyPair(role, reason)
 	}
 
-	process.log.Infof("%v has obtained credentials to connect to cluster.", role)
+	process.log.Infof("%v has obtained credentials to connect to the cluster.", role)
 	var connector *Connector
 	if role == teleport.RoleAdmin || role == teleport.RoleAuth {
 		connector = &Connector{
@@ -423,7 +423,7 @@ func (process *TeleportProcess) firstTimeConnect(role teleport.Role) (*Connector
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	process.log.Infof("The process has successfully wrote credentials and state of %v to disk.", role)
+	process.log.Infof("The process successfully wrote the credentials and state of %v to the disk.", role)
 	return connector, nil
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2183,7 +2183,7 @@ func (process *TeleportProcess) getAdditionalPrincipals(role teleport.Role) ([]s
 //    2. proxy SSH connections to nodes running with 'node' role
 //    3. take care of reverse tunnels
 func (process *TeleportProcess) initProxy() error {
-	// If no TLS key was provided for the web UI, generate a self signed cert
+	// If no TLS key was provided for the web UI, generate a self-signed cert
 	if len(process.Config.Proxy.KeyPairs) == 0 &&
 		!process.Config.Proxy.DisableTLS &&
 		!process.Config.Proxy.DisableWebService &&
@@ -3301,7 +3301,7 @@ func validateConfig(cfg *Config) error {
 // initSelfSignedHTTPSCert generates and self-signs a TLS key+cert pair for https connection
 // to the proxy server.
 func initSelfSignedHTTPSCert(cfg *Config) (err error) {
-	cfg.Log.Warningf("No TLS Keys provided, using self signed certificate.")
+	cfg.Log.Warningf("No TLS Keys provided, using self-signed certificate.")
 
 	keyPath := filepath.Join(cfg.DataDir, defaults.SelfSignedKeyPath)
 	certPath := filepath.Join(cfg.DataDir, defaults.SelfSignedCertPath)
@@ -3319,7 +3319,7 @@ func initSelfSignedHTTPSCert(cfg *Config) (err error) {
 	if !os.IsNotExist(err) {
 		return trace.Wrap(err, "unrecognized error reading certs")
 	}
-	cfg.Log.Warningf("Generating self signed key and cert to %v %v.", keyPath, certPath)
+	cfg.Log.Warningf("Generating self-signed key and cert to %v %v.", keyPath, certPath)
 
 	creds, err := utils.GenerateSelfSignedCert([]string{cfg.Hostname, "localhost"})
 	if err != nil {

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -196,14 +196,14 @@ func VerifyCertificateChain(certificateChain []*x509.Certificate) error {
 }
 
 // IsSelfSigned checks if the certificate is a self-signed certificate. To
-// check if a certificate is self signed, we make sure that only one
+// check if a certificate is self-signed, we make sure that only one
 // certificate is in the chain and that the SubjectKeyId and AuthorityKeyId
 // match.
 //
 // From RFC5280: https://tools.ietf.org/html/rfc5280#section-4.2.1.1
 //
 //   The signature on a self-signed certificate is generated with the private
-//   key associated with the certificate's subject public key.  (This
+//   key associated with the certificate's subject public key. (This
 //   proves that the issuer possesses both the public and private keys.)
 //   In this case, the subject and authority key identifiers would be
 //   identical, but only the subject key identifier is needed for

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -88,7 +88,7 @@ type TLSCredentials struct {
 	Cert       []byte
 }
 
-// GenerateSelfSignedCert generates a self signed certificate that
+// GenerateSelfSignedCert generates a  certificate that
 // is valid for given domain names and ips, returns PEM-encoded bytes with key and cert
 func GenerateSelfSignedCert(hostNames []string) (*TLSCredentials, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, teleport.RSAKeySize)

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -88,7 +88,7 @@ type TLSCredentials struct {
 	Cert       []byte
 }
 
-// GenerateSelfSignedCert generates a  certificate that
+// GenerateSelfSignedCert generates a self-signed certificate that
 // is valid for given domain names and ips, returns PEM-encoded bytes with key and cert
 func GenerateSelfSignedCert(hostNames []string) (*TLSCredentials, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, teleport.RSAKeySize)


### PR DESCRIPTION
Noticed a few start messages could be slightly reworded during testing.

These are logging and comment changes:

1.  GREP'ing on `self-signed` certs will get all references
2. Nit: Clarify message to state which cluster and disk