### PR TITLE
Change utmp error handling to best-effort

### DIFF
--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -164,12 +164,10 @@ func RunCommand() (io.Writer, int, error) {
 		}
 		errorWriter = tty
 		err = uacc.Open(c.UaccMetadata.UtmpPath, c.UaccMetadata.WtmpPath, c.Login, c.UaccMetadata.Hostname, c.UaccMetadata.RemoteAddr, tty)
-		if err != nil {
-			// the error is critical and we should fail command execution
-			if !trace.IsAccessDenied(err) && !trace.IsNotFound(err) {
-				return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(err)
-			}
-		} else {
+		// uacc support is best-effort, only enable it if Open is successful.
+		// Currently there is no way to log this error out-of-band with the
+		// command output, so for now we essentially ignore it.
+		if err == nil {
 			uaccEnabled = true
 		}
 	}
@@ -245,7 +243,7 @@ func RunCommand() (io.Writer, int, error) {
 
 	if uaccEnabled {
 		uaccErr := uacc.Close(c.UaccMetadata.UtmpPath, c.UaccMetadata.WtmpPath, tty)
-		if uaccErr != nil && !trace.IsAccessDenied(uaccErr) && !trace.IsNotFound(uaccErr) {
+		if uaccErr != nil {
 			return errorWriter, teleport.RemoteCommandFailure, trace.Wrap(uaccErr)
 		}
 	}


### PR DESCRIPTION
Issue #6782

Since utmp support is meant to be best effort, this change departs a bit from the issue description - rather than attempting to detect musl at runtime, if there is any error in `uacc.Open(...)` we can just give up on utmp support and continue with the user's command.

I considered logging the error from `uacc.Open(...)`, but since teleport has already been re-exec'd at this point the output would be mixed in with the user command's output rather than the teleport log.

If `uacc.Open(..)` was successful but there is an error with `uacc.Close(...)`, then something unexpected has happened and we should return the error.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/6782