### PR TITLE
helm: Fixes for Linux/Mac interoperability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,16 +378,16 @@ lint-helm:
 			for VALUES in $${CHART}/.lint/*.yaml; do \
 				export HELM_TEMP=$$(mktemp); \
 				echo -n "Using values from '$${VALUES}': "; \
-				yamllint -c examples/chart/.lint-config.yaml $${VALUES} || { cat -En $${VALUES}; exit 1; }; \
+				yamllint -c examples/chart/.lint-config.yaml $${VALUES} || { cat -en $${VALUES}; exit 1; }; \
 				helm lint --strict $${CHART} -f $${VALUES} || exit 1; \
 				helm template test $${CHART} -f $${VALUES} 1>$${HELM_TEMP} || exit 1; \
-				yamllint -c examples/chart/.lint-config.yaml $${HELM_TEMP} || { cat -En $${HELM_TEMP}; exit 1; }; \
+				yamllint -c examples/chart/.lint-config.yaml $${HELM_TEMP} || { cat -en $${HELM_TEMP}; exit 1; }; \
 			done \
 		else \
 			export HELM_TEMP=$$(mktemp); \
 			helm lint --strict $${CHART} || exit 1; \
 			helm template test $${CHART} 1>$${HELM_TEMP} || exit 1; \
-			yamllint -c examples/chart/.lint-config.yaml $${HELM_TEMP} || { cat -En $${HELM_TEMP}; exit 1; }; \
+			yamllint -c examples/chart/.lint-config.yaml $${HELM_TEMP} || { cat -en $${HELM_TEMP}; exit 1; }; \
 		fi; \
 	done
 

--- a/version.mk
+++ b/version.mk
@@ -26,6 +26,7 @@ setver: helm-version
 # If the version contains '-dev' (as it does on the master branch, or for development builds) then we get the latest
 # published major version number by parsing a sorted list of git tags instead, to make deploying the chart from master
 # work as expected. Version numbers are quoted as a string because Helm otherwise treats dotted decimals as floats.
+# The weird -i usage is to make the sed commands work the same on both Linux and Mac. Test on both platforms if you change it.
 .PHONY:helm-version
 helm-version:
 	@if ! echo "$${VERSION}" | grep -q "\-dev"; then \
@@ -34,6 +35,7 @@ helm-version:
 		export CHART_VERSION=$$(git ls-remote --tags https://github.com/gravitational/teleport | cut -d'/' -f3 | grep -Ev '(alpha|beta|dev|rc)' | sort -rV | head -n1 | cut -d. -f1 | tr -d '^v'); \
 	fi; \
 	for CHART in teleport-cluster teleport-kube-agent; do \
-		sed -i "s_^version:\ .*_version: \"$${CHART_VERSION}\"_g" examples/chart/$${CHART}/Chart.yaml || exit 1; \
-		sed -i "s_^appVersion:\ .*_appVersion: \"$${CHART_VERSION}\"_g" examples/chart/$${CHART}/Chart.yaml || exit 1; \
+		sed -i'.bak' -e "s_^version:\ .*_version: \"$${CHART_VERSION}\"_g" examples/chart/$${CHART}/Chart.yaml || exit 1; \
+		sed -i'.bak' -e "s_^appVersion:\ .*_appVersion: \"$${CHART_VERSION}\"_g" examples/chart/$${CHART}/Chart.yaml || exit 1; \
+		rm -f examples/chart/$${CHART}/Chart.yaml.bak; \
 	done


### PR DESCRIPTION
Fixes a couple of issues related to Mac/Linux interop:
- `cat -E` isn't implemented on Mac, but `cat -e` does the same thing and also works on Linux.
- `sed -i` requires a suffix on Mac but does not on Linux. The easiest way to make it work on both platforms is just to write the backup file on both OSes and then clean it up afterwards.

Needs backporting to `branch/v6` once merged.