### PR TITLE
Remove http no body check

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1371,10 +1371,8 @@ type renewSessionRequest struct {
 //   - default (none set): create new session with currently assigned roles
 func (h *Handler) renewSession(w http.ResponseWriter, r *http.Request, params httprouter.Params, ctx *SessionContext) (interface{}, error) {
 	req := renewSessionRequest{}
-	if r.Body != http.NoBody {
-		if err := httplib.ReadJSON(r, &req); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	if req.AccessRequestID != "" && req.Switchback {


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/6890

#### Description
Request body isn't guaranteed to be a type of `http.NoBody` when request is made with no JSON object which proceeds to `ReadJSON` leading to unmarshal error. Possible reason as to why that is is found here: https://github.com/golang/go/issues/39290#issuecomment-635448684

Originally the client would send no body if we want to use zero values for `renewSessionRequest` struct, but since this endpoint expects a JSON in other cases, we made it the clients responsibility to always send a JSON object