### PR TITLE
Fix panic in web config loading.

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -749,6 +749,8 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 
 	authProviders := []ui.WebConfigAuthProvider{}
 	secondFactor := constants.SecondFactorOff
+	authType := constants.Local
+	localAuthEnabled := true
 
 	// get all OIDC connectors
 	oidcConnectors, err := h.cfg.ProxyClient.GetOIDCConnectors(r.Context(), false)
@@ -798,6 +800,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		h.log.WithError(err).Error("Cannot retrieve AuthPreferences.")
 	} else {
 		secondFactor = cap.GetSecondFactor()
+		authType = cap.GetType()
 	}
 
 	// disable joining sessions if proxy session recording is enabled
@@ -807,13 +810,14 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		h.log.WithError(err).Error("Cannot retrieve ClusterConfig.")
 	} else {
 		canJoinSessions = services.IsRecordAtProxy(clsCfg.GetSessionRecording()) == false
+		localAuthEnabled = clsCfg.GetLocalAuth()
 	}
 
 	authSettings := ui.WebConfigAuthSettings{
 		Providers:        authProviders,
 		SecondFactor:     secondFactor,
-		LocalAuthEnabled: clsCfg.GetLocalAuth(),
-		AuthType:         cap.GetType(),
+		LocalAuthEnabled: localAuthEnabled,
+		AuthType:         authType,
 	}
 
 	webCfg := ui.WebConfig{


### PR DESCRIPTION
`getWebConfig` method would cause nil deref if it could not load configuration.


Changed method to default to "local auth" if cfg could not be loaded.  I think that is what the old behavior used to be before the panics were introduced.  @alex-kovoy Can you confirm that this is the right way to fix this?