### PR TITLE
[branch/v6.1] docs: Update docker tags to use latest 6.x version tag

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -184,8 +184,8 @@
       "plugin": {
         "version": "6.1.0"
       },
-      "latest_oss_docker_image": "quay.io/gravitational/teleport:6.1",
-      "latest_ent_docker_image": "quay.io/gravitational/teleport-ent:6.1"
+      "latest_oss_docker_image": "quay.io/gravitational/teleport:6",
+      "latest_ent_docker_image": "quay.io/gravitational/teleport-ent:6"
     }
   },
   "redirects": [


### PR DESCRIPTION
We don't create 6.0, 6.1 etc tags for Docker any more, we just have the 6 tag which is rebuilt nightly to point to the latest published 6.x version.