### PR TITLE
Handle UserUpdatedEvent in event deserialization code

### DIFF
--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -104,6 +104,12 @@ func FromEventFields(fields EventFields) (AuditEvent, error) {
 			return nil, trace.Wrap(err)
 		}
 		return &e, nil
+	case UserUpdatedEvent:
+		var e events.UserCreate
+		if err := utils.FastUnmarshal(data, &e); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &e, nil
 	case UserPasswordChangeEvent:
 		var e events.UserPasswordChange
 		if err := utils.FastUnmarshal(data, &e); err != nil {

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -105,6 +105,8 @@ func FromEventFields(fields EventFields) (AuditEvent, error) {
 		}
 		return &e, nil
 	case UserUpdatedEvent:
+		// note: user.update is a custom code applied on top of the same data as the user.create event
+		//       and they are thus functionally identical. There exists no direct gRPC version of user.update.
 		var e events.UserCreate
 		if err := utils.FastUnmarshal(data, &e); err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
This occurred because the UserUpdatedEvent was not handled in the switch statement that deserialises JSON events.

Resolves #6935 