### PR TITLE
Add event deserialisation code for AccessRequestReviewEvent

### DIFF
--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -124,6 +124,14 @@ func FromEventFields(fields EventFields) (AuditEvent, error) {
 			return nil, trace.Wrap(err)
 		}
 		return &e, nil
+	case AccessRequestReviewEvent:
+		// note: access_request.review is a custom code applied on top of the same data as the access_request.create event
+		//       and they are thus functionally identical. There exists no direct gRPC version of access_request.review.
+		var e events.AccessRequestCreate
+		if err := utils.FastUnmarshal(data, &e); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &e, nil
 	case AccessRequestUpdateEvent:
 		var e events.AccessRequestCreate
 		if err := utils.FastUnmarshal(data, &e); err != nil {


### PR DESCRIPTION
This PR adds the code needed to deserialise events with the type `AccessRequestReviewEvent`.

This resolves #6959.