### PR TITLE
[v6.1] issue and edit pass backports

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -233,6 +233,11 @@
       "source": "/kubernetes-ssh/",
       "destination": "/kubernetes-access/",
       "permanent": true
+    },
+    {
+      "source": "/enterprise/sso/ssh-gsuite/",
+      "destination": "/enterprise/sso/ssh-google-workspace/",
+      "permanent": true
     }
   ]
 }

--- a/docs/pages/cli-docs.mdx
+++ b/docs/pages/cli-docs.mdx
@@ -241,7 +241,7 @@ tsh --proxy proxy.example.com play <session-id>
 
 Copies files from `source` to `dest`.
 
-**Usage**: `usage: tsh scp [<flags>] <source>... <dest>`
+**Usage**: `tsh scp [<flags>] <source>... <dest>`
 
 {/* TODO Confirm which flags are supported and whether supports multiple sources */}
 
@@ -273,7 +273,7 @@ $ tsh --proxy=proxy.example.com scp -P example.txt user@host/destination/dir
 
 List cluster nodes.
 
-**Usage**: `usage: tsh ls [<flags>] [<label>]`
+**Usage**: `tsh ls [<flags>] [<label>]`
 
 {/* TODO: label? or labels? seems like it only supports one label at a time */}
 
@@ -318,7 +318,7 @@ grav-02      10.156.0.7:3022    os:osx
 
 List Kubernetes Clusters.
 
-**Usage**: `usage: tsh kube ls`
+**Usage**: `tsh kube ls`
 
 #### Examples
 

--- a/docs/pages/enterprise/sso/ssh-one-login.mdx
+++ b/docs/pages/enterprise/sso/ssh-one-login.mdx
@@ -46,11 +46,8 @@ section:
 
 ### Download Icons
 
-<img src="../../../img/sso/onelogin/teleport.png" alt="Square Icon" width="100"/>  
-
-<img src="../../../img/sso/onelogin/teleportlogo@2x.png" alt="Rectangular Icon" width="100"/>  
-
-*Right-click and select "Save Image As...".*
+- [Square Icon](../../../img/sso/onelogin/teleport.png)
+- [Rectangular Icon](../../../img/sso/onelogin/teleportlogo@2x.png)
 
 <Admonition
   type="tip"

--- a/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-mattermost.mdx
@@ -49,11 +49,7 @@ Go back to your team, then "Integrations" → "Bot Accounts" → "Add Bot Accoun
 
 The new bot account will need the `Post All` permission.
 
-**App Icon:** 
-
-<img src="../../../img/enterprise/plugins/teleport_bot@2x.png" alt="Teleport Bot Icon" width="100"/>
-
-*Right-click and select "Save Image As...".*
+**App Icon:** <a href="../../../img/enterprise/plugins/teleport_bot@2x.png" download>Download Teleport Bot Icon</a>.
 
 ![Enable Mattermost Bots](../../../img/enterprise/plugins/mattermost/mattermost_bot.png)
 

--- a/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
+++ b/docs/pages/enterprise/workflow/ssh-approval-slack.mdx
@@ -113,11 +113,7 @@ Visit [https://api.slack.com/apps](https://api.slack.com/apps) to create a new S
 
 **App Name:** Teleport<br/>
 **Development Slack Workspace:** Pick the workspace you'd like the requests to show up in. <br/>
-**App Icon:** 
-
-<img src="../../../img/enterprise/plugins/teleport_bot@2x.png" alt="Teleport Bot Icon" width="100"/>
-
-*Right-click and select "Save Image As...".*
+**App Icon:** <a href="../../../img/enterprise/plugins/teleport_bot@2x.png" download>Download Teleport Bot Icon</a>
 
 ![Create Slack App](../../../img/enterprise/plugins/slack/Create-a-Slack-App.png)
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -61,6 +61,7 @@ Teleport provides security-critical support for the current and two previous rel
 
 | Release | Long Term Support | Release Date | Min tsh version |
 | - | - | - | - |
+| 6.1 | Yes | April 9th, 2021 | 3.1 |
 | 6 | Yes | March 4th, 2021 | 3.1 |
 | 5.0 | Yes | November 24th, 2020 | 3.1 |
 | 4.4 | Yes | October 20th, 2020 | 3.1 |

--- a/docs/pages/metrics-logs-reference.mdx
+++ b/docs/pages/metrics-logs-reference.mdx
@@ -31,8 +31,6 @@ Now you can see the monitoring information by visiting several endpoints:
 | `backend_batch_read_requests_total` | counter | cache | Number of read requests to the backend |
 | `backend_batch_read_seconds` | histogram | cache | Latency for batch read operations |
 | `backend_batch_write_requests_total` | counter | cache | Number of batch write requests to the backend |
-| `backend_batch_read_seconds` | histogram | cache | Latency for batch read operations |
-| `backend_batch_write_requests_total` | counter | cache | Number of batch write requests to the backend |
 | `backend_batch_write_seconds` | histogram | cache | Latency for backend batch write operations |
 | `backend_read_requests_total` | counter | cache | Number of read requests to the backend |
 | `backend_read_seconds` | histogram | cache | Latency for read operations |


### PR DESCRIPTION
Backport of some more expansive changes from https://github.com/gravitational/teleport/issues/6943

Removes duplicate words from reference documentation examples.

Also, [v6.1] relevant changes for https://github.com/gravitational/teleport/issues/4633 and https://github.com/gravitational/teleport/issues/6919 - adds URL for https://github.com/gravitational/teleport/pull/6729