### PR TITLE
Use x509v3 extensions when (un-)marshaling identity

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -214,7 +214,7 @@ func NewInstance(cfg InstanceConfig) *TeleInstance {
 	fatalIf(err)
 	identity := tlsca.Identity{
 		Username: fmt.Sprintf("%v.%v", cfg.HostID, cfg.ClusterName),
-		Groups:   []string{string(teleport.RoleAdmin)},
+		Roles:    []string{string(teleport.RoleAdmin)},
 	}
 	clock := clockwork.NewRealClock()
 	subject, err := identity.Subject()

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -1215,7 +1215,7 @@ func kubeProxyClient(cfg kubeProxyConfig) (*kubernetes.Clientset, *rest.Config, 
 
 	id := tlsca.Identity{
 		Username:         cfg.username,
-		Groups:           user.GetRoles(),
+		Roles:            user.GetRoles(),
 		KubernetesUsers:  cfg.kubeUsers,
 		KubernetesGroups: cfg.kubeGroups,
 		RouteToCluster:   cfg.routeToCluster,

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -244,7 +244,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 	c.Assert(gotTLSCert.PublicKey, DeepEquals, inCryptoPub)
 	wantID := tlsca.Identity{
 		Username:         user,
-		Groups:           []string{role.GetName()},
+		Roles:            []string{role.GetName()},
 		Principals:       []string{user},
 		KubernetesUsers:  []string{user},
 		KubernetesGroups: []string{"system:masters"},
@@ -252,7 +252,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:   "me.localhost",
 		TeleportCluster:  "me.localhost",
 	}
-	gotID, err := tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
+	gotID, err := tlsca.FromCertificate(gotTLSCert)
 	c.Assert(err, IsNil)
 	c.Assert(*gotID, DeepEquals, wantID)
 
@@ -273,7 +273,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 	c.Assert(err, IsNil)
 	wantID = tlsca.Identity{
 		Username:         user,
-		Groups:           []string{role.GetName()},
+		Roles:            []string{role.GetName()},
 		Principals:       []string{user},
 		KubernetesUsers:  []string{user},
 		KubernetesGroups: []string{"system:masters"},
@@ -284,7 +284,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:    "leaf.localhost",
 		TeleportCluster:   "me.localhost",
 	}
-	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
+	gotID, err = tlsca.FromCertificate(gotTLSCert)
 	c.Assert(err, IsNil)
 	c.Assert(*gotID, DeepEquals, wantID)
 
@@ -317,7 +317,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 	c.Assert(err, IsNil)
 	wantID = tlsca.Identity{
 		Username:          user,
-		Groups:            []string{role.GetName()},
+		Roles:             []string{role.GetName()},
 		Principals:        []string{user},
 		KubernetesUsers:   []string{user},
 		KubernetesGroups:  []string{"system:masters"},
@@ -326,7 +326,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:    "me.localhost",
 		TeleportCluster:   "me.localhost",
 	}
-	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
+	gotID, err = tlsca.FromCertificate(gotTLSCert)
 	c.Assert(err, IsNil)
 	c.Assert(*gotID, DeepEquals, wantID)
 
@@ -350,7 +350,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 	c.Assert(err, IsNil)
 	wantID = tlsca.Identity{
 		Username:          user,
-		Groups:            []string{role.GetName()},
+		Roles:             []string{role.GetName()},
 		Principals:        []string{user},
 		KubernetesUsers:   []string{user},
 		KubernetesGroups:  []string{"system:masters"},
@@ -359,7 +359,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:    "me.localhost",
 		TeleportCluster:   "me.localhost",
 	}
-	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
+	gotID, err = tlsca.FromCertificate(gotTLSCert)
 	c.Assert(err, IsNil)
 	c.Assert(*gotID, DeepEquals, wantID)
 
@@ -392,7 +392,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 	c.Assert(err, IsNil)
 	wantID = tlsca.Identity{
 		Username:          user,
-		Groups:            []string{role.GetName()},
+		Roles:             []string{role.GetName()},
 		Principals:        []string{user},
 		KubernetesUsers:   []string{user},
 		KubernetesGroups:  []string{"system:masters"},
@@ -401,7 +401,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:    "me.localhost",
 		TeleportCluster:   "me.localhost",
 	}
-	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
+	gotID, err = tlsca.FromCertificate(gotTLSCert)
 	c.Assert(err, IsNil)
 	c.Assert(*gotID, DeepEquals, wantID)
 
@@ -425,7 +425,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 	c.Assert(err, IsNil)
 	wantID = tlsca.Identity{
 		Username:          user,
-		Groups:            []string{role.GetName()},
+		Roles:             []string{role.GetName()},
 		Principals:        []string{user},
 		KubernetesUsers:   []string{user},
 		KubernetesGroups:  []string{"system:masters"},
@@ -434,7 +434,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:    "me.localhost",
 		TeleportCluster:   "me.localhost",
 	}
-	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
+	gotID, err = tlsca.FromCertificate(gotTLSCert)
 	c.Assert(err, IsNil)
 	c.Assert(*gotID, DeepEquals, wantID)
 

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -18,7 +18,6 @@ package auth
 
 import (
 	"context"
-	"time"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -104,7 +103,7 @@ func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 	}
 
 	// Extract the identity from the CSR.
-	id, err := tlsca.FromSubject(csr.Subject, time.Time{})
+	id, err := tlsca.FromCSR(csr)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -123,7 +122,7 @@ func (s *Server) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 	}
 
 	// Extract user roles from the identity.
-	roles, err := services.FetchRoles(id.Groups, s, id.Traits)
+	roles, err := services.FetchRoles(id.Roles, s, id.Traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -724,7 +724,7 @@ func TestGenerateUserSingleUseCert(t *testing.T) {
 					require.NoError(t, err)
 					require.Equal(t, cert.NotAfter, clock.Now().Add(teleport.UserSingleUseCertTTL))
 
-					identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+					identity, err := tlsca.FromCertificate(cert)
 					require.NoError(t, err)
 					require.Equal(t, identity.MFAVerified, u2fDevID)
 					require.True(t, net.ParseIP(identity.ClientIP).IsLoopback())
@@ -756,7 +756,7 @@ func TestGenerateUserSingleUseCert(t *testing.T) {
 					require.NoError(t, err)
 					require.Equal(t, cert.NotAfter, clock.Now().Add(teleport.UserSingleUseCertTTL))
 
-					identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+					identity, err := tlsca.FromCertificate(cert)
 					require.NoError(t, err)
 					require.Equal(t, identity.MFAVerified, u2fDevID)
 					require.True(t, net.ParseIP(identity.ClientIP).IsLoopback())

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1067,7 +1067,7 @@ func ReadTLSIdentityFromKeyPair(keyBytes, certBytes []byte, caCertsBytes [][]byt
 		return nil, trace.Wrap(err, "failed to parse TLS certificate")
 	}
 
-	id, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+	id, err := tlsca.FromCertificate(cert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1081,7 +1081,7 @@ func ReadTLSIdentityFromKeyPair(keyBytes, certBytes []byte, caCertsBytes [][]byt
 		return nil, trace.BadParameter("misssing cluster name")
 	}
 	identity := &Identity{
-		ID:              IdentityID{HostUUID: id.Username, Role: teleport.Role(id.Groups[0])},
+		ID:              IdentityID{HostUUID: id.Username, Role: teleport.Role(id.Roles[0])},
 		ClusterName:     clusterName,
 		KeyBytes:        keyBytes,
 		TLSCertBytes:    certBytes,

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -425,7 +425,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 	}
 	clientCert := peers[0]
 
-	identity, err := tlsca.FromSubject(clientCert.Subject, clientCert.NotAfter)
+	identity, err := tlsca.FromCertificate(clientCert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -464,7 +464,7 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 		// the local auth server can not truste remote servers
 		// to issue certificates with system roles (e.g. Admin),
 		// to get unrestricted access to the local cluster
-		systemRole := findSystemRole(identity.Groups)
+		systemRole := findSystemRole(identity.Roles)
 		if systemRole != nil {
 			return RemoteBuiltinRole{
 				Role:        *systemRole,
@@ -481,14 +481,14 @@ func (a *Middleware) GetUser(connState tls.ConnectionState) (IdentityGetter, err
 			KubernetesUsers:  identity.KubernetesUsers,
 			DatabaseNames:    identity.DatabaseNames,
 			DatabaseUsers:    identity.DatabaseUsers,
-			RemoteRoles:      identity.Groups,
+			RemoteRoles:      identity.Roles,
 			Identity:         *identity,
 		}, nil
 	}
 	// code below expects user or service from local cluster, to distinguish between
 	// interactive users and services (e.g. proxies), the code below
 	// checks for presence of system roles issued in certificate identity
-	systemRole := findSystemRole(identity.Groups)
+	systemRole := findSystemRole(identity.Roles)
 	// in case if the system role is present, assume this is a service
 	// agent, e.g. Proxy, connecting to the cluster
 	if systemRole != nil {

--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -60,35 +60,35 @@ func TestMiddlewareGetUser(t *testing.T) {
 	var (
 		localUserIdentity = tlsca.Identity{
 			Username:        "foo",
-			Groups:          []string{"devs"},
+			Roles:           []string{"devs"},
 			TeleportCluster: localClusterName,
 			Expires:         now,
 		}
 		localUserIdentityNoTeleportCluster = tlsca.Identity{
 			Username: "foo",
-			Groups:   []string{"devs"},
+			Roles:    []string{"devs"},
 			Expires:  now,
 		}
 		localSystemRole = tlsca.Identity{
 			Username:        "node",
-			Groups:          []string{string(teleport.RoleNode)},
+			Roles:           []string{string(teleport.RoleNode)},
 			TeleportCluster: localClusterName,
 			Expires:         now,
 		}
 		remoteUserIdentity = tlsca.Identity{
 			Username:        "foo",
-			Groups:          []string{"devs"},
+			Roles:           []string{"devs"},
 			TeleportCluster: remoteClusterName,
 			Expires:         now,
 		}
 		remoteUserIdentityNoTeleportCluster = tlsca.Identity{
 			Username: "foo",
-			Groups:   []string{"devs"},
+			Roles:    []string{"devs"},
 			Expires:  now,
 		}
 		remoteSystemRole = tlsca.Identity{
 			Username:        "node",
-			Groups:          []string{string(teleport.RoleNode)},
+			Roles:           []string{string(teleport.RoleNode)},
 			TeleportCluster: remoteClusterName,
 			Expires:         now,
 		}
@@ -161,7 +161,7 @@ func TestMiddlewareGetUser(t *testing.T) {
 			wantID: RemoteUser{
 				ClusterName: remoteClusterName,
 				Username:    remoteUserIdentity.Username,
-				RemoteRoles: remoteUserIdentity.Groups,
+				RemoteRoles: remoteUserIdentity.Roles,
 				Identity:    remoteUserIdentity,
 			},
 			assertErr: require.NoError,
@@ -176,7 +176,7 @@ func TestMiddlewareGetUser(t *testing.T) {
 			wantID: RemoteUser{
 				ClusterName: remoteClusterName,
 				Username:    remoteUserIdentity.Username,
-				RemoteRoles: remoteUserIdentity.Groups,
+				RemoteRoles: remoteUserIdentity.Roles,
 				Identity:    remoteUserIdentity,
 			},
 			assertErr: require.NoError,

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -201,7 +201,7 @@ func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*Context, error) {
 	// identity information and confusing who's accessing a resource.
 	identity := tlsca.Identity{
 		Username:         user.GetName(),
-		Groups:           user.GetRoles(),
+		Roles:            user.GetRoles(),
 		Traits:           wrappers.Traits(traits),
 		Principals:       principals,
 		KubernetesGroups: kubeGroups,

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1710,10 +1710,10 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 		cert, err := tlsca.ParseCertificatePEM(tlsCert)
 		c.Assert(err, check.IsNil)
 
-		identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+		identity, err := tlsca.FromCertificate(cert)
 		c.Assert(err, check.IsNil)
 
-		return utils.SliceContainsStr(identity.Groups, role)
+		return utils.SliceContainsStr(identity.Roles, role)
 	}
 
 	// certLogins extracts the logins from an ssh certificate
@@ -2034,7 +2034,7 @@ func TestGenerateCerts(t *testing.T) {
 
 		tlsCert, err := tlsca.ParseCertificatePEM(userCerts.TLS)
 		require.NoError(t, err)
-		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		identity, err := tlsca.FromCertificate(tlsCert)
 		require.NoError(t, err)
 
 		// Because the original request has maxed out the possible max
@@ -2089,7 +2089,7 @@ func TestGenerateCerts(t *testing.T) {
 		// Make sure impersonator was not lost in the renewed cert
 		tlsCert, err = tlsca.ParseCertificatePEM(userCerts.TLS)
 		require.NoError(t, err)
-		identity, err = tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		identity, err = tlsca.FromCertificate(tlsCert)
 		require.NoError(t, err)
 		require.Equal(t, identity.Expires.Sub(clock.Now()), time.Hour)
 		require.Equal(t, impersonator.GetName(), identity.Impersonator)
@@ -2124,7 +2124,7 @@ func TestGenerateCerts(t *testing.T) {
 
 		tlsCert, err := tlsca.ParseCertificatePEM(userCerts.TLS)
 		require.NoError(t, err)
-		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		identity, err := tlsca.FromCertificate(tlsCert)
 		require.NoError(t, err)
 		require.True(t, identity.Expires.Before(time.Now().Add(testUser2.TTL)))
 		require.Equal(t, identity.RouteToCluster, rc1.GetName())
@@ -2234,7 +2234,7 @@ func TestGenerateCerts(t *testing.T) {
 
 		tlsCert, err := tlsca.ParseCertificatePEM(userCerts.TLS)
 		require.NoError(t, err)
-		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+		identity, err := tlsca.FromCertificate(tlsCert)
 		require.NoError(t, err)
 		require.Equal(t, identity.RouteToCluster, rc2.GetName())
 	})

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -571,7 +571,7 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tlsID, err := tlsca.FromSubject(tlsCert.Subject, time.Time{})
+	tlsID, err := tlsca.FromCertificate(tlsCert)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -582,7 +582,7 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 	}
 	var databases []tlsca.RouteToDatabase
 	for _, cert := range dbCerts {
-		tlsID, err := tlsca.FromSubject(cert.Subject, time.Time{})
+		tlsID, err := tlsca.FromCertificate(&cert)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -597,7 +597,7 @@ func readProfile(profileDir string, profileName string) (*ProfileStatus, error) 
 	}
 	var apps []tlsca.RouteToApp
 	for _, cert := range appCerts {
-		tlsID, err := tlsca.FromSubject(cert.Subject, time.Time{})
+		tlsID, err := tlsca.FromCertificate(&cert)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -61,7 +61,7 @@ func (s ForwarderSuite) TestRequestCertificate(c *check.C) {
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "remote-bob",
-				Groups:           []string{"remote group a", "remote group b"},
+				Roles:            []string{"remote group a", "remote group b"},
 				Usage:            []string{"usage a", "usage b"},
 				Principals:       []string{"principal a", "principal b"},
 				KubernetesGroups: []string{"remote k8s group a", "remote k8s group b"},
@@ -69,7 +69,7 @@ func (s ForwarderSuite) TestRequestCertificate(c *check.C) {
 			}),
 			UnmappedIdentity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
-				Groups:           []string{"group a", "group b"},
+				Roles:            []string{"group a", "group b"},
 				Usage:            []string{"usage a", "usage b"},
 				Principals:       []string{"principal a", "principal b"},
 				KubernetesGroups: []string{"k8s group a", "k8s group b"},
@@ -93,7 +93,7 @@ func (s ForwarderSuite) TestRequestCertificate(c *check.C) {
 	c.Assert(csrBlock, check.NotNil)
 	csr, err := x509.ParseCertificateRequest(csrBlock.Bytes)
 	c.Assert(err, check.IsNil)
-	idFromCSR, err := tlsca.FromSubject(csr.Subject, time.Time{})
+	idFromCSR, err := tlsca.FromCSR(csr)
 	c.Assert(err, check.IsNil)
 	c.Assert(*idFromCSR, check.DeepEquals, ctx.UnmappedIdentity.GetIdentity())
 }
@@ -594,7 +594,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "remote-bob",
-				Groups:           []string{"remote group a", "remote group b"},
+				Roles:            []string{"remote group a", "remote group b"},
 				Usage:            []string{"usage a", "usage b"},
 				Principals:       []string{"principal a", "principal b"},
 				KubernetesGroups: []string{"remote k8s group a", "remote k8s group b"},
@@ -602,7 +602,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 			}),
 			UnmappedIdentity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
-				Groups:           []string{"group a", "group b"},
+				Roles:            []string{"group a", "group b"},
 				Usage:            []string{"usage a", "usage b"},
 				Principals:       []string{"principal a", "principal b"},
 				KubernetesGroups: []string{"k8s group a", "k8s group b"},
@@ -633,7 +633,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "remote-bob",
-				Groups:           []string{"remote group a", "remote group b"},
+				Roles:            []string{"remote group a", "remote group b"},
 				Usage:            []string{"usage a", "usage b"},
 				Principals:       []string{"principal a", "principal b"},
 				KubernetesGroups: []string{"remote k8s group a", "remote k8s group b"},
@@ -641,7 +641,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 			}),
 			UnmappedIdentity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
-				Groups:           []string{"group a", "group b"},
+				Roles:            []string{"group a", "group b"},
 				Usage:            []string{"usage a", "usage b"},
 				Principals:       []string{"principal a", "principal b"},
 				KubernetesGroups: []string{"k8s group a", "k8s group b"},
@@ -670,7 +670,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 			User: user,
 			Identity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "remote-bob",
-				Groups:           []string{"remote group a", "remote group b"},
+				Roles:            []string{"remote group a", "remote group b"},
 				Usage:            []string{"usage a", "usage b"},
 				Principals:       []string{"principal a", "principal b"},
 				KubernetesGroups: []string{"remote k8s group a", "remote k8s group b"},
@@ -678,7 +678,7 @@ func (s ForwarderSuite) TestNewClusterSession(c *check.C) {
 			}),
 			UnmappedIdentity: auth.WrapIdentity(tlsca.Identity{
 				Username:         "bob",
-				Groups:           []string{"group a", "group b"},
+				Roles:            []string{"group a", "group b"},
 				Usage:            []string{"usage a", "usage b"},
 				Principals:       []string{"principal a", "principal b"},
 				KubernetesGroups: []string{"k8s group a", "k8s group b"},

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -938,7 +938,7 @@ func ExtractFromIdentity(access UserGetter, identity tlsca.Identity) ([]string, 
 		return u.GetRoles(), u.GetTraits(), nil
 	}
 
-	return identity.Groups, identity.Traits, nil
+	return identity.Roles, identity.Traits, nil
 }
 
 // FetchRoleList fetches roles by their names, applies the traits to role
@@ -983,7 +983,7 @@ func isFormatOld(cert *ssh.Certificate) bool {
 // missingIdentity returns true if the identity is missing or the identity
 // has no roles or traits.
 func missingIdentity(identity tlsca.Identity) bool {
-	if len(identity.Groups) == 0 || len(identity.Traits) == 0 {
+	if len(identity.Roles) == 0 || len(identity.Traits) == 0 {
 		return true
 	}
 	return false

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1938,7 +1938,7 @@ func TestExtractFrom(t *testing.T) {
 	// Create a TLS identity.
 	identity := &tlsca.Identity{
 		Username: "foo",
-		Groups:   origRoles,
+		Roles:    origRoles,
 		Traits:   origTraits,
 	}
 
@@ -1998,7 +1998,7 @@ func TestExtractFromLegacy(t *testing.T) {
 	// Create a TLS identity with only roles.
 	identity := &tlsca.Identity{
 		Username: "foo",
-		Groups:   origRoles,
+		Roles:    origRoles,
 	}
 
 	// At this point, services.User and the certificate/identity are still in

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -59,7 +59,7 @@ func (s *Server) newSession(ctx context.Context, identity *tlsca.Identity, app *
 	// Request a JWT token that will be attached to all requests.
 	jwt, err := s.c.AuthClient.GenerateAppToken(ctx, jwt_pkg.GenerateAppTokenRequest{
 		Username: identity.Username,
-		Roles:    identity.Groups,
+		Roles:    identity.Roles,
 		URI:      app.URI,
 		Expires:  identity.Expires,
 	})

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -179,7 +179,7 @@ func (h *Handler) extractSessionID(r *http.Request) (sessionID string, err error
 	// then connect to the apps with the issued certs.
 	if HasClientCert(r) {
 		certificate := r.TLS.PeerCertificates[0]
-		identity, err := tlsca.FromSubject(certificate.Subject, certificate.NotAfter)
+		identity, err := tlsca.FromCertificate(certificate)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -47,7 +47,7 @@ func (h *Handler) newSession(ctx context.Context, ws services.WebSession) (*sess
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	identity, err := tlsca.FromSubject(certificate.Subject, certificate.NotAfter)
+	identity, err := tlsca.FromCertificate(certificate)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -166,7 +166,7 @@ func (h *Handler) createAppSession(w http.ResponseWriter, r *http.Request, p htt
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	identity, err := tlsca.FromSubject(certificate.Subject, certificate.NotAfter)
+	identity, err := tlsca.FromCertificate(certificate)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
# What

Currently, we encode identity information into the certificate subject. Some properties go to standard subject fields (CN, O, OU, etc.), for some we use ASN1 extensions which are also encoded in the subject.

This pull requests updates identity marshal/unmarshal to use x509v3 extensions instead - in a backwards compatible fashion (with fallback to subject - see below).

# Why

The technical reason is it's needed for database access MongoDB integration I'm working on.

MongoDB clients, when using x509 authentication, use the entire certificates subject as a username. Currently, subjects in our issued client certificates look roughly like this (if you have traits and other stuff):

```
Subject: L=root, L=ubuntu/street=leaf/postalCode={"db_names":["db_name_from_okta"],"db_users":["db_user_from_okta"],"env":["prod"],"first_name":["Roman"],"groups":["Everyone","okta-admin","okta-dev"],"last_name":["Tkachenko"],"username":["roman@goteleport.com"]}, O=admin, OU=usage:apps, CN=roman@goteleport.com/1.3.9999.1.4=b01b91e2bbacdddb3570b7ae5e39f8225ff31ef7f6917ea799f63316cf722d93/1.3.9999.1.6=debug-leaf.gravitational.io/1.3.9999.1.5=leaf/1.3.9999.1.10=debug-leaf/1.3.9999.1.7=root/1.3.9999.2.5=asd/1.3.9999.2.6=asd/1.3.9999.2.6=db_user_from_okta
```

This whole string will be treated by `mongo` client as a username which of course doesn't work for auth.

Instead, this change allows us to generate client certificates for database access with subject like:

```
Subject: CN=r0mant
```

Other things will be encoded in extensions e.g.

```
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Basic Constraints: critical
                CA:FALSE
            1.3.9999.1.11:
                roman@goteleport.com
            ...
            1.3.9999.1.15:
                leaf
            1.3.9999.1.16:
                {"db_names":["db_name_from_okta"],"db_users":["db_user_from_okta"],"env":["prod"],"first_name":["Roman"],"groups":["Everyone","okta-admin","okta-dev"],"last_name":["Tkachenko"],"username":["roman@goteleport.com"]}
```

I'm not aware of any downsides of using extensions instead of subject, in fact I think it's what extensions are for. There's also a somewhat nice visual benefit cause extensions are split out better than subject so it's easier to debug stuff - I wish you could assign extensions actual names instead of OIDs but it doesn't seem to be supported.

# Compatibility

The change is fully backwards compatible.

For now, for all certificates we encode identity into _both_ subject and extensions. This ensures that:
* New-style certificates can parsed by older clients because info is present in subject also.
* New clients also parse old-style certificates - they prefer extensions but fallback to subject.

Going forward, in Teleport 8.0 we can remove encoding stuff in subject completely and only use extensions, according to our compat. guarantee (I've left appropriate `DELETE IN`'s in the code).

# Side note

As a bonus, I've also renamed `Groups` to `Roles` in the identity struct so it's less confusing.