### PR TITLE
Fixed IBM Cloud AppID SSO integration.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go v1.37.17
 	github.com/beevik/etree v1.1.0
 	github.com/boombuler/barcode v1.0.1 // indirect
-	github.com/coreos/go-oidc v0.0.3
+	github.com/coreos/go-oidc v0.0.4
 	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/davecgh/go-spew v1.1.1
@@ -121,7 +121,7 @@ require (
 )
 
 replace (
-	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
+	github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.4
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 	github.com/gravitational/teleport/api => ./api
 	github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -302,8 +302,8 @@ github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70 h1:To76nCJtM3DI
 github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70/go.mod h1:88hFR45MpUd23d2vNWE/dYtesU50jKsbz0I9kH7UaBY=
 github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77 h1:ivambM2XeST8qfxeSm+0Y8CP/DlNbS3o/9tSF2KtGFk=
 github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
-github.com/gravitational/go-oidc v0.0.3 h1:VKhztRfuXq5KVcAPAEagF2y9rjoNgEXvZ/5PsRX9qt8=
-github.com/gravitational/go-oidc v0.0.3/go.mod h1:SevmOUNdOB0aD9BAIgjptZ6oHkKxMZZgA70nwPfgU/w=
+github.com/gravitational/go-oidc v0.0.4 h1:BOs9LLg2IncufQ7YRNVM22vnTQhg6DTXNAEGTGxTm58=
+github.com/gravitational/go-oidc v0.0.4/go.mod h1:SevmOUNdOB0aD9BAIgjptZ6oHkKxMZZgA70nwPfgU/w=
 github.com/gravitational/gobpf v0.0.1 h1:1NufkXUOOt/farCC4juGZ8FFU1qmA+2Zb4lPaVfUFoE=
 github.com/gravitational/gobpf v0.0.1/go.mod h1:464Ee3TMfw+IBUVWy7xyb4ud4nJkrU7RzE/GjhEGY+c=
 github.com/gravitational/kingpin v2.1.11-0.20190130013101-742f2714c145+incompatible h1:CfyZl3nyo9K5lLqOmqvl9/IElY1UCnOWKZiQxJ8HKdA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -130,7 +130,7 @@ github.com/boombuler/barcode/qr
 github.com/boombuler/barcode/utils
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
-# github.com/coreos/go-oidc v0.0.3 => github.com/gravitational/go-oidc v0.0.3
+# github.com/coreos/go-oidc v0.0.4 => github.com/gravitational/go-oidc v0.0.4
 ## explicit
 github.com/coreos/go-oidc/http
 github.com/coreos/go-oidc/jose
@@ -1024,7 +1024,7 @@ k8s.io/utils/integer
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.3
+# github.com/coreos/go-oidc => github.com/gravitational/go-oidc v0.0.4
 # github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 # github.com/gravitational/teleport/api => ./api
 # github.com/iovisor/gobpf => github.com/gravitational/gobpf v0.0.1


### PR DESCRIPTION
**Description**

IBM Cloud AppID SSO returns strings as well as integers in JWT headers.
Updated version of our go-oidc fork which handles string and integer
values in JWT headers.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/6717