### PR TITLE
[6.2] Backport - Fix tclt --auth-servers flag panic.

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -423,7 +423,7 @@ func loadConfigFromProfile(ccf *GlobalCLIFlags, cfg *service.Config) (*AuthServi
 
 	proxyAddr := ""
 	if len(ccf.AuthServerAddr) != 0 {
-		proxyAddr = cfg.AuthServers[0].Addr
+		proxyAddr = ccf.AuthServerAddr[0]
 	}
 
 	profile, _, err := client.Status("", proxyAddr)


### PR DESCRIPTION
Backport of #6980