### PR TITLE
Resolve test issues and event driver bugs

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -177,9 +177,6 @@ const (
 	// keyEventIndex is EventIndex key
 	keyEventIndex = "EventIndex"
 
-	// keyEventNamespace
-	keyEventNamespace = "EventNamespace"
-
 	// keyCreatedAt identifies created at key
 	keyCreatedAt = "CreatedAt"
 

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -75,8 +75,7 @@ func (s *DynamoeventsSuite) SetUpSuite(c *check.C) {
 	s.log = log
 	s.EventsSuite.Log = log
 	s.EventsSuite.Clock = fakeClock
-	s.EventsSuite.QueryDelay = time.Second * 30
-
+	s.EventsSuite.QueryDelay = time.Second * 5
 }
 
 func (s *DynamoeventsSuite) SetUpTest(c *check.C) {
@@ -106,10 +105,18 @@ func (s *DynamoeventsSuite) TestSessionEventsCRUD(c *check.C) {
 		c.Assert(err, check.IsNil)
 	}
 
-	time.Sleep(s.EventsSuite.QueryDelay)
+	var history []events.AuditEvent
 
-	history, _, err := s.Log.SearchEvents(s.Clock.Now().Add(-1*time.Hour), s.Clock.Now().Add(time.Hour), defaults.Namespace, nil, 0, "")
-	c.Assert(err, check.IsNil)
+	for i := 0; i < 10; i++ {
+		time.Sleep(s.EventsSuite.QueryDelay)
+
+		history, _, err = s.Log.SearchEvents(s.Clock.Now().Add(-1*time.Hour), s.Clock.Now().Add(time.Hour), defaults.Namespace, nil, 0, "")
+		c.Assert(err, check.IsNil)
+
+		if len(history) == 4000 {
+			break
+		}
+	}
 
 	// `check.HasLen` prints the entire array on failure, which pollutes the output
 	c.Assert(len(history), check.Equals, 4000)

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -122,7 +122,7 @@ func (s *DynamoeventsSuite) TestSessionEventsCRUD(c *check.C) {
 	}
 
 	// `check.HasLen` prints the entire array on failure, which pollutes the output
-	c.Assert(len(history), check.Equals, 4000)
+	c.Assert(len(history), check.Equals, eventCount)
 }
 
 // TestIndexExists tests functionality of the `Log.indexExists` function.

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -44,6 +44,8 @@ import (
 	"github.com/gravitational/trace"
 )
 
+const dynamoDBLargeQueryRetries int = 10
+
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
 	os.Exit(m.Run())
@@ -95,7 +97,8 @@ func (s *DynamoeventsSuite) TestSessionEventsCRUD(c *check.C) {
 	err := s.log.deleteAllItems()
 	c.Assert(err, check.IsNil)
 
-	for i := 0; i < 4000; i++ {
+	const eventCount int = 4000
+	for i := 0; i < eventCount; i++ {
 		err := s.Log.EmitAuditEventLegacy(events.UserLocalLoginE, events.EventFields{
 			events.LoginMethod:        events.LoginMethodSAML,
 			events.AuthAttemptSuccess: true,
@@ -107,13 +110,13 @@ func (s *DynamoeventsSuite) TestSessionEventsCRUD(c *check.C) {
 
 	var history []events.AuditEvent
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < dynamoDBLargeQueryRetries; i++ {
 		time.Sleep(s.EventsSuite.QueryDelay)
 
 		history, _, err = s.Log.SearchEvents(s.Clock.Now().Add(-1*time.Hour), s.Clock.Now().Add(time.Hour), defaults.Namespace, nil, 0, "")
 		c.Assert(err, check.IsNil)
 
-		if len(history) == 4000 {
+		if len(history) == eventCount {
 			break
 		}
 	}

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -75,7 +75,7 @@ func (s *DynamoeventsSuite) SetUpSuite(c *check.C) {
 	s.log = log
 	s.EventsSuite.Log = log
 	s.EventsSuite.Clock = fakeClock
-	s.EventsSuite.QueryDelay = time.Second
+	s.EventsSuite.QueryDelay = time.Second * 30
 
 }
 
@@ -89,7 +89,6 @@ func (s *DynamoeventsSuite) TestPagination(c *check.C) {
 }
 
 func (s *DynamoeventsSuite) TestSessionEventsCRUD(c *check.C) {
-	c.Assert(0, check.Equals, 5)
 	s.SessionEventsCRUD(c)
 
 	// In addition to the normal CRUD test above, we also check that we can retrieve all items from a large table

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -89,6 +89,7 @@ func (s *DynamoeventsSuite) TestPagination(c *check.C) {
 }
 
 func (s *DynamoeventsSuite) TestSessionEventsCRUD(c *check.C) {
+	c.Assert(0, check.Equals, 5)
 	s.SessionEventsCRUD(c)
 
 	// In addition to the normal CRUD test above, we also check that we can retrieve all items from a large table

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -477,7 +477,7 @@ func (l *Log) SearchEvents(fromUTC, toUTC time.Time, namespace string, eventType
 
 	modifyquery := func(query firestore.Query) firestore.Query {
 		if startKey != "" {
-			return query.StartAt(parsedStartKey)
+			return query.StartAfter(parsedStartKey)
 		}
 
 		return query

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -465,7 +465,7 @@ func (l *Log) SearchEvents(fromUTC, toUTC time.Time, namespace string, eventType
 
 	var lastKey int64
 	var values []events.EventFields
-	var parsedStartKey int64 = -1
+	var parsedStartKey int64
 	var err error
 
 	if startKey != "" {

--- a/lib/events/firestoreevents/firestoreevents_test.go
+++ b/lib/events/firestoreevents/firestoreevents_test.go
@@ -68,7 +68,7 @@ func (s *FirestoreeventsSuite) SetUpSuite(c *check.C) {
 	s.log = log
 	s.EventsSuite.Log = log
 	s.EventsSuite.Clock = fakeClock
-	s.EventsSuite.QueryDelay = time.Second
+	s.EventsSuite.QueryDelay = time.Second * 5
 }
 
 func emulatorRunning() bool {

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -111,7 +111,7 @@ func (s *EventsSuite) EventPagination(c *check.C) {
 	}
 
 	checkpoint = ""
-	for i := range []int{0, 2} {
+	for _, i := range []int{0, 2} {
 		nameA := names[i]
 		nameB := names[i+1]
 		arr, checkpoint, err = s.Log.SearchEvents(baseTime, toTime, defaults.Namespace, nil, 2, checkpoint)
@@ -174,7 +174,7 @@ func (s *EventsSuite) SessionEventsCRUD(c *check.C) {
 	// read the session event
 	historyEvents, err := s.Log.GetSessionEvents(defaults.Namespace, sessionID, 0, false)
 	c.Assert(err, check.IsNil)
-	c.Assert(history, check.HasLen, 2)
+	c.Assert(historyEvents, check.HasLen, 2)
 	c.Assert(historyEvents[0].GetString(events.EventType), check.Equals, events.SessionStartEvent)
 	c.Assert(historyEvents[1].GetString(events.EventType), check.Equals, events.SessionEndEvent)
 


### PR DESCRIPTION
In #6901 Gus noted that firestore tests were failing after reenabling them after some time being deactivated without anyone noticing.

Some deeper digging led me to discover that DynamoDB tests were also not running. I had previously assumed that they ran and relied upon it. I couldn't find any note about them being disabled either so I had no good way of knowing and CI also indicated that tests were ran but passed ok. This PR does not reenable them as that would require decent work with CI but it does contain fixes I made after running Dynamo and Firestore tests manually on a live environment.

Some test fixes also had to be made since they turned out to be broken both before and after my 6.2 PRs.

Having automated Dynamo tests up and running soon would be of great benefit.

Things fixed
- Resolved an off-by-one error in the firestore driver. Was not caught due to Firestore tests not running silently in CI which is fixed in #6901.
- A bug introduced in regarding session event slices in the DynamoDB driver introduced in my RFD 24 implementation. Was not caught due to DynamoDB tests being silently disabled in CI some months ago while showing as passed without my knowledge.
- Fixed DynamoDB tests which have also been broken for many months.
- AWS recently started validating and not allowing extra attribute declarations in API calls. This caused an error which is fixed.
- Fix a deserialization issue in the DynamoDB driver introduced last minute not caught due to tests not running.