### PR TITLE
Add missing : in tsh scp docs

### DIFF
--- a/docs/pages/cli-docs.mdx
+++ b/docs/pages/cli-docs.mdx
@@ -271,7 +271,7 @@ Run `tsh help <subcommand>` or see the [Global Flags Section](#tsh-global-flags)
 #### Examples
 
 ```bsh
-$ tsh --proxy=proxy.example.com scp -P example.txt user@host/destination/dir
+$ tsh --proxy=proxy.example.com scp -P example.txt user@host:/destination/dir
 ```
 
 ### tsh ls


### PR DESCRIPTION
The right command is also available in user manual: https://goteleport.com/docs/user-manual/#copying-files