### PR TITLE
De-duplicate kube names

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1888,10 +1888,16 @@ func TestClusterKubesGet(t *testing.T) {
 		Kind:     services.KindKubeService,
 		Version:  services.V2,
 		Spec: services.ServerSpecV2{
-			KubernetesClusters: []*services.KubernetesCluster{{
-				Name:         "test-kube-name",
-				StaticLabels: map[string]string{"test-field": "test-value"},
-			}},
+			KubernetesClusters: []*services.KubernetesCluster{
+				{
+					Name:         "test-kube-name",
+					StaticLabels: map[string]string{"test-field": "test-value"},
+				},
+				// tests for de-duplication
+				{
+					Name:         "test-kube-name",
+					StaticLabels: map[string]string{"test-field": "test-value"},
+				}},
 		},
 	})
 	require.NoError(t, err)

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -108,33 +108,40 @@ type Kube struct {
 
 // MakeKubes creates ui kube objects and returns a list..
 func MakeKubes(clusterName string, servers []types.Server) []Kube {
-	uiKubeClusters := []Kube{}
+	kubeClusters := map[string]*types.KubernetesCluster{}
+
+	// Get unique kube clusters
 	for _, server := range servers {
 		// Process each kube cluster.
 		for _, cluster := range server.GetKubernetesClusters() {
-			uiLabels := []Label{}
+			kubeClusters[cluster.Name] = cluster
+		}
+	}
 
-			for name, value := range cluster.StaticLabels {
-				uiLabels = append(uiLabels, Label{
-					Name:  name,
-					Value: value,
-				})
-			}
+	uiKubeClusters := make([]Kube, 0, len(kubeClusters))
+	for _, cluster := range kubeClusters {
+		uiLabels := []Label{}
 
-			for name, cmd := range cluster.DynamicLabels {
-				uiLabels = append(uiLabels, Label{
-					Name:  name,
-					Value: cmd.GetResult(),
-				})
-			}
-
-			sort.Sort(sortedLabels(uiLabels))
-
-			uiKubeClusters = append(uiKubeClusters, Kube{
-				Name:   cluster.Name,
-				Labels: uiLabels,
+		for name, value := range cluster.StaticLabels {
+			uiLabels = append(uiLabels, Label{
+				Name:  name,
+				Value: value,
 			})
 		}
+
+		for name, cmd := range cluster.DynamicLabels {
+			uiLabels = append(uiLabels, Label{
+				Name:  name,
+				Value: cmd.GetResult(),
+			})
+		}
+
+		sort.Sort(sortedLabels(uiLabels))
+
+		uiKubeClusters = append(uiKubeClusters, Kube{
+			Name:   cluster.Name,
+			Labels: uiLabels,
+		})
 	}
 
 	return uiKubeClusters


### PR DESCRIPTION
#### Description
Return unique kube cluster names


Resolves duplicated listings of kube names:
![image](https://user-images.githubusercontent.com/43280172/119197368-78a7d080-ba3c-11eb-9e82-a2053866d448.png)
