### PR TITLE
Improve RFD 24 Dynamo migration efficiency and performance

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -175,11 +175,11 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	ctx := context.TODO()
 
 	domainName := cfg.ClusterName.GetClusterName()
-	err := backend.AcquireLock(ctx, cfg.Backend, domainName, 30*time.Second)
+	lock, err := backend.AcquireLock(ctx, cfg.Backend, domainName, 30*time.Second)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer backend.ReleaseLock(ctx, cfg.Backend, domainName)
+	defer lock.Release(ctx, cfg.Backend)
 
 	// check that user CA and host CA are present and set the certs if needed
 	asrv, err := NewServer(&cfg, opts...)

--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -17,27 +17,49 @@ limitations under the License.
 package backend
 
 import (
+	"bytes"
 	"context"
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/siddontang/go-log/log"
 )
 
 const locksPrefix = ".locks"
 
+type BackendLock struct {
+	key []byte
+	id  []byte
+	ttl time.Duration
+}
+
+func randomID() ([]byte, error) {
+	uuid, err := uuid.NewRandom()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	bytes := [16]byte(uuid)
+	return bytes[:], nil
+}
+
 // AcquireLock grabs a lock that will be released automatically in TTL
-func AcquireLock(ctx context.Context, backend Backend, lockName string, ttl time.Duration) (err error) {
+func AcquireLock(ctx context.Context, backend Backend, lockName string, ttl time.Duration) (BackendLock, error) {
 	if lockName == "" {
-		return trace.BadParameter("missing parameter lock name")
+		return BackendLock{}, trace.BadParameter("missing parameter lock name")
 	}
 	key := []byte(filepath.Join(locksPrefix, lockName))
+	id, err := randomID()
+	if err != nil {
+		return BackendLock{}, trace.Wrap(err)
+	}
 	for {
 		// Get will clear TTL on a lock
 		backend.Get(ctx, key)
 
 		// CreateVal is atomic:
-		_, err = backend.Create(ctx, Item{Key: key, Value: []byte{1}, Expires: backend.Clock().Now().UTC().Add(ttl)})
+		_, err = backend.Create(ctx, Item{Key: key, Value: id, Expires: backend.Clock().Now().UTC().Add(ttl)})
 		if err == nil {
 			break // success
 		}
@@ -45,52 +67,78 @@ func AcquireLock(ctx context.Context, backend Backend, lockName string, ttl time
 			backend.Clock().Sleep(250 * time.Millisecond)
 			continue
 		}
-		return trace.ConvertSystemError(err)
+		return BackendLock{}, trace.ConvertSystemError(err)
 	}
-	return nil
+	return BackendLock{key: key, id: id, ttl: ttl}, nil
 }
 
-// ReleaseLock forces lock release
-func ReleaseLock(ctx context.Context, backend Backend, lockName string) error {
-	if lockName == "" {
-		return trace.BadParameter("missing parameter lockName")
-	}
-	key := []byte(filepath.Join(locksPrefix, lockName))
-	if err := backend.Delete(ctx, key); err != nil {
+// Release forces lock release
+func (l *BackendLock) Release(ctx context.Context, backend Backend) error {
+	if err := backend.Delete(ctx, l.key); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-// ResetLockTTL resets the TTL on a given lock.
-func ResetLockTTL(ctx context.Context, backend Backend, lockName string) error {
-	if lockName == "" {
-		return trace.BadParameter("missing parameter lock name")
-	}
-
-	key := []byte(filepath.Join(locksPrefix, lockName))
-
-	item, err := backend.Get(ctx, key)
+// resetTTL resets the TTL on a given lock.
+func (l *BackendLock) resetTTL(ctx context.Context, backend Backend) error {
+	prev, err := backend.Get(ctx, l.key)
 	if err != nil {
+		if trace.IsNotFound(err) {
+			return trace.CompareFailed("cannot refresh lock %s (expired)", l.id)
+		}
 		return trace.Wrap(err)
 	}
 
-	if _, err := backend.Put(ctx, *item); err != nil {
-		return trace.Wrap(err)
+	if !bytes.Equal(prev.Value, l.id) {
+		return trace.CompareFailed("cannot refresh lock %s (ownership changed)", l.id)
+	}
+
+	next := *prev
+	next.Expires = backend.Clock().Now().UTC().Add(l.ttl)
+
+	_, err = backend.CompareAndSwap(ctx, *prev, next)
+	if err != nil {
+		return trace.WrapWithMessage(err, "failed to fresh lock %s (cas failed)", l.id)
 	}
 
 	return nil
 }
 
 // RunWhileLocked allows you to run a function while a lock is held.
-func RunWhileLocked(ctx context.Context, backend Backend, lockName string, ttl time.Duration, fn func() error) error {
-	if err := AcquireLock(ctx, backend, lockName, ttl); err != nil {
+func RunWhileLocked(ctx context.Context, backend Backend, lockName string, ttl time.Duration, fn func(context.Context) error) error {
+	if ttl < time.Minute {
+		return trace.BadParameter("lock TTL must be at least one minute")
+	}
+
+	lock, err := AcquireLock(ctx, backend, lockName, ttl)
+	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	fnErr := fn()
+	subContext, cancelFunction := context.WithCancel(ctx)
 
-	if err := ReleaseLock(ctx, backend, lockName); err != nil {
+	stopRefresh := make(chan struct{})
+	go func() {
+		refreshAfter := ttl - time.Second*45
+		for {
+			select {
+			case <-time.After(refreshAfter):
+				if err := lock.resetTTL(ctx, backend); err != nil {
+					cancelFunction()
+					log.Errorf("%v", err)
+					return
+				}
+			case <-stopRefresh:
+				return
+			}
+		}
+	}()
+
+	fnErr := fn(subContext)
+	stopRefresh <- struct{}{}
+
+	if err := lock.Release(ctx, backend); err != nil {
 		return trace.NewAggregate(fnErr, err)
 	}
 

--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -133,7 +133,7 @@ func RunWhileLocked(ctx context.Context, backend Backend, lockName string, ttl t
 			select {
 			case <-time.After(refreshAfter):
 				if err := lock.resetTTL(ctx, backend); err != nil {
-					cancelFunction()
+					defer cancelFunction()
 					log.Errorf("%v", err)
 					return
 				}
@@ -144,7 +144,7 @@ func RunWhileLocked(ctx context.Context, backend Backend, lockName string, ttl t
 	}()
 
 	fnErr := fn(subContext)
-	stopRefresh <- struct{}{}
+	close(stopRefresh)
 
 	if err := lock.Release(ctx, backend); err != nil {
 		return trace.NewAggregate(fnErr, err)

--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -119,10 +119,6 @@ func (l *Lock) resetTTL(ctx context.Context, backend Backend) error {
 
 // RunWhileLocked allows you to run a function while a lock is held.
 func RunWhileLocked(ctx context.Context, backend Backend, lockName string, ttl time.Duration, fn func(context.Context) error) error {
-	if ttl < time.Minute {
-		return trace.BadParameter("lock TTL must be at least one minute")
-	}
-
 	lock, err := AcquireLock(ctx, backend, lockName, ttl)
 	if err != nil {
 		return trace.Wrap(err)
@@ -132,7 +128,7 @@ func RunWhileLocked(ctx context.Context, backend Backend, lockName string, ttl t
 
 	stopRefresh := make(chan struct{})
 	go func() {
-		refreshAfter := ttl - time.Second*45
+		refreshAfter := ttl / 2
 		for {
 			select {
 			case <-time.After(refreshAfter):

--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -67,8 +67,15 @@ func ResetLockTTL(ctx context.Context, backend Backend, lockName string) error {
 	if lockName == "" {
 		return trace.BadParameter("missing parameter lock name")
 	}
+
 	key := []byte(filepath.Join(locksPrefix, lockName))
-	if _, err := backend.Get(ctx, key); err != nil {
+
+	item, err := backend.Get(ctx, key)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := backend.Put(ctx, *item); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/siddontang/go-log/log"
+	log "github.com/sirupsen/logrus"
 )
 
 const locksPrefix = ".locks"

--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -61,3 +61,16 @@ func ReleaseLock(ctx context.Context, backend Backend, lockName string) error {
 	}
 	return nil
 }
+
+// ResetLockTTL resets the TTL on a given lock.
+func ResetLockTTL(ctx context.Context, backend Backend, lockName string) error {
+	if lockName == "" {
+		return trace.BadParameter("missing parameter lock name")
+	}
+	key := []byte(filepath.Join(locksPrefix, lockName))
+	if _, err := backend.Get(ctx, key); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -524,54 +524,56 @@ func (s *BackendSuite) Locking(c *check.C, bk backend.Backend) {
 
 	ctx := context.TODO()
 
-	err := backend.ReleaseLock(ctx, bk, tok1)
-	fixtures.ExpectNotFound(c, err)
-
-	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
+	lock, err := backend.AcquireLock(ctx, bk, tok1, ttl)
+	c.Assert(err, check.IsNil)
 	x := int32(7)
 
 	go func() {
 		atomic.StoreInt32(&x, 9)
-		c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
+		c.Assert(lock.Release(ctx, bk), check.IsNil)
 		// Force the clock to periodically move after release so waiters can be awoken
 		s.Clock.Advance(1 * time.Second)
 	}()
-	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
+	lock, err = backend.AcquireLock(ctx, bk, tok1, ttl)
+	c.Assert(err, check.IsNil)
 	atomic.AddInt32(&x, 9)
 
 	c.Assert(atomic.LoadInt32(&x), check.Equals, int32(18))
-	c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
+	c.Assert(lock.Release(ctx, bk), check.IsNil)
 
-	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
+	lock, err = backend.AcquireLock(ctx, bk, tok1, ttl)
+	c.Assert(err, check.IsNil)
 	atomic.StoreInt32(&x, 7)
 	go func() {
 		atomic.StoreInt32(&x, 9)
-		c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
+		c.Assert(lock.Release(ctx, bk), check.IsNil)
 		// Force the clock to periodically move after release so waiters can be awoken
 		s.Clock.Advance(1 * time.Second)
 	}()
-	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
+	lock, err = backend.AcquireLock(ctx, bk, tok1, ttl)
+	c.Assert(err, check.IsNil)
 	atomic.AddInt32(&x, 9)
 	c.Assert(atomic.LoadInt32(&x), check.Equals, int32(18))
-	c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
+	c.Assert(lock.Release(ctx, bk), check.IsNil)
 
 	y := int32(0)
-	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
-	c.Assert(backend.AcquireLock(ctx, bk, tok2, ttl), check.IsNil)
+	lock1, err := backend.AcquireLock(ctx, bk, tok1, ttl)
+	c.Assert(err, check.IsNil)
+	lock2, err := backend.AcquireLock(ctx, bk, tok2, ttl)
+	c.Assert(err, check.IsNil)
 	go func() {
 		atomic.StoreInt32(&y, 15)
-		c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
-		c.Assert(backend.ReleaseLock(ctx, bk, tok2), check.IsNil)
+		c.Assert(lock1.Release(ctx, bk), check.IsNil)
+		c.Assert(lock2.Release(ctx, bk), check.IsNil)
 		// Force the clock to periodically move after release so waiters can be awoken
 		s.Clock.Advance(1 * time.Second)
 	}()
 
-	c.Assert(backend.AcquireLock(ctx, bk, tok1, ttl), check.IsNil)
+	lock, err = backend.AcquireLock(ctx, bk, tok1, ttl)
+	c.Assert(err, check.IsNil)
 	c.Assert(atomic.LoadInt32(&y), check.Equals, int32(15))
 
-	c.Assert(backend.ReleaseLock(ctx, bk, tok1), check.IsNil)
-	err = backend.ReleaseLock(ctx, bk, tok1)
-	fixtures.ExpectNotFound(c, err)
+	c.Assert(lock.Release(ctx, bk), check.IsNil)
 }
 
 // ConcurrentOperations tests concurrent operations on the same

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1147,7 +1147,8 @@ func (l *Log) migrateDateAttribute(ctx context.Context) error {
 				top = len(writeRequests)
 			}
 
-			batch := writeRequests[:top]
+			// We need to make a copy of the slice here so it doesn't get changed later due to subslicing.
+			batch := append(make([]*dynamodb.WriteRequest, 0, DynamoBatchSize), writeRequests[:top]...)
 			writeRequests = writeRequests[top:]
 
 			// Don't exceed maximum workers.

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/utils"
-	"go.uber.org/atomic"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -44,6 +43,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
+	"go.uber.org/atomic"
 )
 
 // iso8601DateFormat is the time format used by the date attribute on events.

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -418,7 +418,7 @@ func (l *Log) migrateRFD24(ctx context.Context) error {
 				return nil
 			})
 
-			if err != nil {
+			if err == nil {
 				break
 			}
 

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1047,7 +1047,7 @@ func (l *Log) removeV1GSI() error {
 // Invariants:
 // - This function must be called after `createV2GSI` has completed successfully on the table.
 // - This function must not be called concurrently with itself.
-// - The rfd24MigrationLock must exist.
+// - The rfd24MigrationLock must be held by the node.
 func (l *Log) migrateDateAttribute(ctx context.Context) error {
 	var total int64 = 0
 	var startKey map[string]*dynamodb.AttributeValue

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1085,6 +1085,7 @@ func (l *Log) migrateDateAttribute(ctx context.Context) error {
 		// that adds the new date attribute.
 		for _, item := range scanOut.Items {
 			if time.Since(lastRefresh) > time.Minute {
+				lastRefresh = time.Now()
 				if err := backend.ResetLockTTL(ctx, l.backend, rfd24MigrationLock); err != nil {
 					return trace.Wrap(err)
 				}

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -72,7 +72,7 @@ func (s *DynamoeventsSuite) SetUpSuite(c *check.C) {
 
 	fakeClock := clockwork.NewFakeClock()
 	log, err := New(context.Background(), Config{
-		Region:       "us-west-1",
+		Region:       "eu-north-1",
 		Tablename:    fmt.Sprintf("teleport-test-%v", uuid.New()),
 		Clock:        fakeClock,
 		UIDGenerator: utils.NewFakeUID(),

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/test"
@@ -66,13 +67,16 @@ func (s *DynamoeventsSuite) SetUpSuite(c *check.C) {
 		c.Skip("Skipping AWS-dependent test suite.")
 	}
 
+	backend, err := memory.New(memory.Config{})
+	c.Assert(err, check.IsNil)
+
 	fakeClock := clockwork.NewFakeClock()
 	log, err := New(context.Background(), Config{
 		Region:       "us-west-1",
 		Tablename:    fmt.Sprintf("teleport-test-%v", uuid.New()),
 		Clock:        fakeClock,
 		UIDGenerator: utils.NewFakeUID(),
-	})
+	}, backend)
 	c.Assert(err, check.IsNil)
 	s.log = log
 	s.EventsSuite.Log = log

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -187,7 +187,7 @@ func (s *DynamoeventsSuite) TestEventMigration(c *check.C) {
 	var eventArr []event
 
 	for time.Since(waitStart) < attemptWaitFor {
-		utils.RetryStaticFor(time.Minute*5, time.Second*5, func() error {
+		err = utils.RetryStaticFor(time.Minute*5, time.Second*5, func() error {
 			eventArr, _, err = s.log.searchEventsRaw(start, end, defaults.Namespace, []string{"test.event"}, 1000, "")
 			return err
 		})

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
@@ -102,7 +103,10 @@ func (s *EventsSuite) EventPagination(c *check.C) {
 	var checkpoint string
 
 	for _, name := range names {
-		arr, checkpoint, err = s.Log.SearchEvents(baseTime, toTime, defaults.Namespace, nil, 1, checkpoint)
+		utils.RetryStaticFor(time.Minute*5, time.Second*5, func() error {
+			arr, checkpoint, err = s.Log.SearchEvents(baseTime, toTime, defaults.Namespace, nil, 1, checkpoint)
+			return err
+		})
 		c.Assert(err, check.IsNil)
 		c.Assert(arr, check.HasLen, 1)
 		event, ok := arr[0].(*events.UserLogin)
@@ -142,7 +146,13 @@ func (s *EventsSuite) SessionEventsCRUD(c *check.C) {
 		time.Sleep(s.QueryDelay)
 	}
 
-	history, _, err := s.Log.SearchEvents(s.Clock.Now().Add(-1*time.Hour), s.Clock.Now().Add(time.Hour), defaults.Namespace, nil, 100, "")
+	var history []events.AuditEvent
+
+	utils.RetryStaticFor(time.Minute*5, time.Second*5, func() error {
+		history, _, err = s.Log.SearchEvents(s.Clock.Now().Add(-1*time.Hour), s.Clock.Now().Add(time.Hour), defaults.Namespace, nil, 100, "")
+		return err
+	})
+
 	c.Assert(err, check.IsNil)
 	c.Assert(history, check.HasLen, 1)
 

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -103,7 +103,7 @@ func (s *EventsSuite) EventPagination(c *check.C) {
 	var checkpoint string
 
 	for _, name := range names {
-		utils.RetryStaticFor(time.Minute*5, time.Second*5, func() error {
+		err = utils.RetryStaticFor(time.Minute*5, time.Second*5, func() error {
 			arr, checkpoint, err = s.Log.SearchEvents(baseTime, toTime, defaults.Namespace, nil, 1, checkpoint)
 			return err
 		})
@@ -148,11 +148,10 @@ func (s *EventsSuite) SessionEventsCRUD(c *check.C) {
 
 	var history []events.AuditEvent
 
-	utils.RetryStaticFor(time.Minute*5, time.Second*5, func() error {
+	err = utils.RetryStaticFor(time.Minute*5, time.Second*5, func() error {
 		history, _, err = s.Log.SearchEvents(s.Clock.Now().Add(-1*time.Hour), s.Clock.Now().Add(time.Hour), defaults.Namespace, nil, 100, "")
 		return err
 	})
-
 	c.Assert(err, check.IsNil)
 	c.Assert(history, check.HasLen, 1)
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -931,7 +931,7 @@ func initUploadHandler(auditConfig services.AuditConfig, dataDir string) (events
 
 // initExternalLog initializes external storage, if the storage is not
 // setup, returns (nil, nil).
-func initExternalLog(ctx context.Context, auditConfig services.AuditConfig, log logrus.FieldLogger) (events.IAuditLog, error) {
+func initExternalLog(ctx context.Context, auditConfig services.AuditConfig, log logrus.FieldLogger, backend backend.Backend) (events.IAuditLog, error) {
 	//
 	// DELETE IN: 5.0
 	// We could probably just remove AuditTableName now (its been deprecated for a while), but
@@ -983,7 +983,7 @@ func initExternalLog(ctx context.Context, auditConfig services.AuditConfig, log 
 				return nil, trace.Wrap(err)
 			}
 
-			logger, err := dynamoevents.New(ctx, cfg)
+			logger, err := dynamoevents.New(ctx, cfg, backend)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -1088,7 +1088,7 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 		// initialize external loggers.  may return (nil, nil) if no
 		// external loggers have been defined.
-		externalLog, err := initExternalLog(process.ExitContext(), auditConfig, process.log)
+		externalLog, err := initExternalLog(process.ExitContext(), auditConfig, process.log, process.backend)
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				return trace.Wrap(err)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
@@ -264,6 +265,9 @@ func (s *ServiceTestSuite) TestInitExternalLog(c *check.C) {
 		{events: []string{"file://localhost"}, isErr: true},
 	}
 
+	backend, err := memory.New(memory.Config{})
+	c.Assert(err, check.IsNil)
+
 	for i, tt := range tts {
 		// isErr implies isNil.
 		if tt.isErr {
@@ -274,7 +278,7 @@ func (s *ServiceTestSuite) TestInitExternalLog(c *check.C) {
 
 		loggers, err := initExternalLog(context.Background(), services.AuditConfig{
 			AuditEventsURI: tt.events,
-		}, t.Log)
+		}, t.Log, backend)
 
 		if tt.isErr {
 			c.Assert(err, check.NotNil, cmt)

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -232,3 +232,22 @@ func (r *Linear) After() <-chan time.Time {
 func (r *Linear) String() string {
 	return fmt.Sprintf("Linear(attempt=%v, duration=%v)", r.attempt, r.Duration())
 }
+
+// RetryFastFor retries a function repeatedly for a set amount of
+// time before returning an error.
+//
+// Intended mostly for tests.
+func RetryStaticFor(d time.Duration, w time.Duration, f func() error) error {
+	start := time.Now()
+	var err error
+
+	for time.Since(start) < d {
+		if err = f(); err == nil {
+			break
+		}
+
+		time.Sleep(w)
+	}
+
+	return err
+}


### PR DESCRIPTION
# Why

Running the v6.2 DynamoDB data migration is that the moment not recommended on HA deployments with more than one auth server online due to multiple servers duplicating the work and sending large amounts of API calls to DynamoDB and a slow event migration rate.

# What

This PR introduces backend locks to allow for safe live cluster data migration in a HA-setup on DynamoDB. This means that only one auth server will attempt to perform the migration at any given time and if one suddenly fails, another auth server will realise this and continue the migration.

It also introduces batching and parallelisation in order to make Dynamo event migration faster which is important on customer deployments with dozens of millions of events.

This implementation can migrate about 800 events per second but relies heavily on Dynamo scaling up R/W units fast enough and the latency to be relatively low.

# Testing

This PR relies on the already existing migration tests from the RFD 24 PR. Since they do not run in CI presently due to work required to reintegrate a DynamoDB emulation into our pipeline, I've made sure they pass locally.

# Patch release

When this is merged and backported to 6.2 a patch release should go out.