### PR TITLE
[branch/v6.2] docker: Restore Firestore emulator (#6901)

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get update -y --fix-missing && \
         gcc \
         gcc-multilib \
         git \
+        google-cloud-sdk \
+        google-cloud-sdk-firestore-emulator \
         gzip \
         libbpfcc-dev \
         libc6-dev \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -185,6 +185,8 @@ test: buildbox
 		$(DOCKERFLAGS) $(BCCFLAGS) $(NOROOT) -t $(BUILDBOX) \
 		/bin/bash -c \
 		"examples/etcd/start-etcd.sh & sleep 1; \
+		type gcloud 2>&1 >/dev/null || exit 1; \
+		gcloud -q beta emulators firestore start --host-port=localhost:8618 & sleep 1; \
 		ssh-agent > external.agent.tmp && source external.agent.tmp; \
 		cd $(SRCDIR) && make TELEPORT_DEBUG=0 FLAGS='-cover -race' clean test"
 


### PR DESCRIPTION
Backports #6901 to `branch/v6.2`