### PR TITLE
aws: Various fixes for the AMI build process

### DIFF
--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -71,7 +71,7 @@ oss-ci-build:
 .PHONY: change-amis-to-public-oss
 change-amis-to-public-oss:
 	@echo "Making OSS AMIs public"
-	bash files/make-amis-public.sh oss
+	bash files/make-amis-public.sh oss $(DESTINATION_REGIONS)
 
 # Build local 'debug' AMI
 .PHONY: ent
@@ -99,12 +99,12 @@ ent-ci-build:
 .PHONY: change-amis-to-public-ent
 change-amis-to-public-ent:
 	@echo "Making Enterprise AMIs public"
-	bash files/make-amis-public.sh ent
+	bash files/make-amis-public.sh ent $(DESTINATION_REGIONS)
 
 .PHONY: change-amis-to-public-ent-fips
 change-amis-to-public-ent-fips:
 	@echo "Making FIPS Enterprise AMIs public"
-	bash files/make-amis-public.sh ent-fips
+	bash files/make-amis-public.sh ent-fips $(DESTINATION_REGIONS)
 
 
 # Other helpers

--- a/assets/aws/files/make-amis-public.sh
+++ b/assets/aws/files/make-amis-public.sh
@@ -10,6 +10,8 @@ else
     REGION_LIST="$2"
 fi
 
+# Note: to run this script on MacOS you will need to install coreutils (using Brew), then edit the PATH in your shell's
+# RC file to use coreutils versions first (something like "export PATH=/usr/local/opt/coreutils/libexec/gnubin:$PATH")
 ABSPATH=$(readlink -f "$0")
 SCRIPT_DIR=$(dirname "${ABSPATH}")
 BUILD_DIR=$(readlink -f "${SCRIPT_DIR}/build")

--- a/assets/aws/files/make-amis-public.sh
+++ b/assets/aws/files/make-amis-public.sh
@@ -40,6 +40,7 @@ fi
 BUILD_TIMESTAMP=$(<"${TIMESTAMP_FILE}")
 
 # Iterate through AMIs
+IFS=","
 for REGION in ${REGION_LIST}; do
     AMI_ID=$(aws ec2 describe-images --region ${REGION} --filters "Name=name,Values=${NAME_FILTER}" "Name=tag:BuildTimestamp,Values=${BUILD_TIMESTAMP}" "Name=tag:BuildType,Values=${AMI_TAG}"| jq -r '.Images[0].ImageId')
     if [[ "${AMI_ID}" == "" || "${AMI_ID}" == "null" ]]; then

--- a/assets/aws/files/make-amis-public.sh
+++ b/assets/aws/files/make-amis-public.sh
@@ -1,15 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
-# Define list of regions to run in
-REGION_LIST="us-east-1 us-east-2 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-central-1 eu-west-1 eu-west-2 sa-east-1"
-
-# Exit if oss/ent parameters not provided
-if [[ "$1" == "" ]]; then
-    echo "Usage: $(basename $0) [oss/ent/ent-fips]"
+# Exit if required parameters not provided
+if [[ "$1" == "" ]] || [[ "$2" == "" ]]; then
+    echo "Usage: $(basename $0) [oss/ent/ent-fips] [comma-separated-destination-region-list]"
     exit 1
 else
     RUN_MODE="$1"
+    REGION_LIST="$2"
 fi
 
 ABSPATH=$(readlink -f "$0")

--- a/assets/aws/update-ami-ids.sh
+++ b/assets/aws/update-ami-ids.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Note: to run this script on MacOS you will need to:
+# - install gnu-sed (using Brew), then edit the PATH in your shell's RC file to use the GNU version first
+# -- (something like "export PATH=/usr/local/opt/gnu-sed/libexec/gnubin:$PATH")
+# - install findutils (using Brew), then edit the PATH in your shell's RC file to use the GNU version first
+# -- (something like "export PATH=/usr/local/opt/findutils/libexec/gnubin:$PATH")
+
 # shellcheck disable=SC2086
 usage() { echo "Usage: $(basename $0) [-a <AWS account ID>] [-m <cloudformation/terraform>] [-t <oss/ent/ent-fips>] [-r <comma-separated regions>] [-v version]" 1>&2; exit 1; }
 while getopts ":a:m:t:r:v:" o; do

--- a/assets/aws/update-ami-ids.sh
+++ b/assets/aws/update-ami-ids.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # shellcheck disable=SC2086

--- a/examples/aws/cloudformation/ent.yaml
+++ b/examples/aws/cloudformation/ent.yaml
@@ -98,20 +98,23 @@ Mappings:
 
   AWSRegionArch2AMI:
     # All AMIs from AWS - gravitational-teleport-ami-ent-6.0.2
+    eu-north-1: {HVM64: ami-05ff5c0be3d4b8da4}
+    ap-south-1: {HVM64 : ami-0aca5db8064997b1a}
     eu-west-1: {HVM64 : ami-0c736c8094289e22a}
     eu-west-2: {HVM64 : ami-0748e8ecfc3ebb868}
-    us-east-1: {HVM64 : ami-098615f9e05054582}
-    us-east-2: {HVM64 : ami-092d37b152970c523}
-    us-west-2: {HVM64 : ami-09813e1ab7ef9abf2}
-    us-west-1: {HVM64 : ami-064cdbbd893bdda25}
-    ap-south-1: {HVM64 : ami-0aca5db8064997b1a}
+    eu-west-3: {HVM64: ami-087bdce4ab6a2964d}
+    ap-northeast-1: {HVM64 : ami-0ef2f3ec65297f8be}
     ap-northeast-2: {HVM64 : ami-0d3934da569981a70}
+    ap-northeast-3: {HVM64: ami-0a36f2dfdca83ea7d}
+    sa-east-1: {HVM64 : ami-02d7217c90d99d0d5}
+    ca-central-1: {HVM64 : ami-0f729b2b97644a7de}
     ap-southeast-1: {HVM64 : ami-0723170f168a437f5}
     ap-southeast-2: {HVM64 : ami-04fe9ecc0bc020b71}
-    ap-northeast-1: {HVM64 : ami-0ef2f3ec65297f8be}
-    ca-central-1: {HVM64 : ami-0f729b2b97644a7de}
     eu-central-1: {HVM64 : ami-0714fa1e74a8229de}
-    sa-east-1: {HVM64 : ami-02d7217c90d99d0d5}
+    us-east-1: {HVM64 : ami-098615f9e05054582}
+    us-east-2: {HVM64 : ami-092d37b152970c523}
+    us-west-1: {HVM64 : ami-064cdbbd893bdda25}
+    us-west-2: {HVM64 : ami-09813e1ab7ef9abf2}
 
 Resources:
 # Auth server setup

--- a/examples/aws/cloudformation/oss.yaml
+++ b/examples/aws/cloudformation/oss.yaml
@@ -98,20 +98,23 @@ Mappings:
 
   AWSRegionArch2AMI:
     # All AMIs from AWS - gravitational-teleport-ami-oss-6.0.2
+    eu-north-1: {HVM64: ami-0eef7480d85b07d78}
+    ap-south-1: {HVM64 : ami-05e4c581e8ed1aff1}
     eu-west-1: {HVM64 : ami-01fb303b9d3ed6e6e}
     eu-west-2: {HVM64 : ami-0fe50b996a5de236e}
-    us-east-1: {HVM64 : ami-03ea11a9030d743f7}
-    us-east-2: {HVM64 : ami-03a6f0406f904f5e0}
-    us-west-2: {HVM64 : ami-0226e43c16ebdc913}
-    us-west-1: {HVM64 : ami-073a0fb5af141ee60}
-    ap-south-1: {HVM64 : ami-05e4c581e8ed1aff1}
+    eu-west-3: {HVM64: ami-0211c6e2e821dd249}
+    ap-northeast-1: {HVM64 : ami-0535e53234f3af001}
     ap-northeast-2: {HVM64 : ami-01eceef32e28b922a}
+    ap-northeast-3: {HVM64: ami-02bb8618b75d025aa}
+    sa-east-1: {HVM64 : ami-02219a04cfa8b7a52}
+    ca-central-1: {HVM64 : ami-0848f22c493b90a5d}
     ap-southeast-1: {HVM64 : ami-0212cce94a761f9fa}
     ap-southeast-2: {HVM64 : ami-02f7eb20742a2c766}
-    ap-northeast-1: {HVM64 : ami-0535e53234f3af001}
-    ca-central-1: {HVM64 : ami-0848f22c493b90a5d}
     eu-central-1: {HVM64 : ami-0de583abcab304f4a}
-    sa-east-1: {HVM64 : ami-02219a04cfa8b7a52}
+    us-east-1: {HVM64 : ami-03ea11a9030d743f7}
+    us-east-2: {HVM64 : ami-03a6f0406f904f5e0}
+    us-west-1: {HVM64 : ami-073a0fb5af141ee60}
+    us-west-2: {HVM64 : ami-0226e43c16ebdc913}
 
 Resources:
 # Auth server setup

--- a/examples/aws/terraform/AMIS.md
+++ b/examples/aws/terraform/AMIS.md
@@ -6,16 +6,19 @@ is updated when new AMI versions are released.
 ### OSS
 
 ```
+# eu-north-1 v6.2.0 OSS: ami-0eef7480d85b07d78
 # ap-south-1 v6.0.2 OSS: ami-05e4c581e8ed1aff1
-# ap-northeast-2 v6.0.2 OSS: ami-01eceef32e28b922a
-# ap-southeast-1 v6.0.2 OSS: ami-0212cce94a761f9fa
-# ap-southeast-2 v6.0.2 OSS: ami-02f7eb20742a2c766
-# ap-northeast-1 v6.0.2 OSS: ami-0535e53234f3af001
-# ca-central-1 v6.0.2 OSS: ami-0848f22c493b90a5d
-# eu-central-1 v6.0.2 OSS: ami-0de583abcab304f4a
 # eu-west-1 v6.0.2 OSS: ami-01fb303b9d3ed6e6e
 # eu-west-2 v6.0.2 OSS: ami-0fe50b996a5de236e
+# eu-west-3 v6.2.0 OSS: ami-0211c6e2e821dd249
+# ap-northeast-1 v6.0.2 OSS: ami-0535e53234f3af001
+# ap-northeast-2 v6.0.2 OSS: ami-01eceef32e28b922a
+# ap-northeast-3 v6.2.0 OSS: ami-02bb8618b75d025aa
 # sa-east-1 v6.0.2 OSS: ami-02219a04cfa8b7a52
+# ca-central-1 v6.0.2 OSS: ami-0848f22c493b90a5d
+# ap-southeast-1 v6.0.2 OSS: ami-0212cce94a761f9fa
+# ap-southeast-2 v6.0.2 OSS: ami-02f7eb20742a2c766
+# eu-central-1 v6.0.2 OSS: ami-0de583abcab304f4a
 # us-east-1 v6.0.2 OSS: ami-03ea11a9030d743f7
 # us-east-2 v6.0.2 OSS: ami-03a6f0406f904f5e0
 # us-west-1 v6.0.2 OSS: ami-073a0fb5af141ee60
@@ -25,16 +28,19 @@ is updated when new AMI versions are released.
 ### Enterprise
 
 ```
+# eu-north-1 v6.2.0 Enterprise: ami-05ff5c0be3d4b8da4
 # ap-south-1 v6.0.2 Enterprise: ami-0aca5db8064997b1a
-# ap-northeast-2 v6.0.2 Enterprise: ami-0d3934da569981a70
-# ap-southeast-1 v6.0.2 Enterprise: ami-0723170f168a437f5
-# ap-southeast-2 v6.0.2 Enterprise: ami-04fe9ecc0bc020b71
-# ap-northeast-1 v6.0.2 Enterprise: ami-0ef2f3ec65297f8be
-# ca-central-1 v6.0.2 Enterprise: ami-0f729b2b97644a7de
-# eu-central-1 v6.0.2 Enterprise: ami-0714fa1e74a8229de
 # eu-west-1 v6.0.2 Enterprise: ami-0c736c8094289e22a
 # eu-west-2 v6.0.2 Enterprise: ami-0748e8ecfc3ebb868
+# eu-west-3 v6.2.0 Enterprise: ami-087bdce4ab6a2964d
+# ap-northeast-1 v6.0.2 Enterprise: ami-0ef2f3ec65297f8be
+# ap-northeast-2 v6.0.2 Enterprise: ami-0d3934da569981a70
+# ap-northeast-3 v6.2.0 Enterprise: ami-0a36f2dfdca83ea7d
 # sa-east-1 v6.0.2 Enterprise: ami-02d7217c90d99d0d5
+# ca-central-1 v6.0.2 Enterprise: ami-0f729b2b97644a7de
+# ap-southeast-1 v6.0.2 Enterprise: ami-0723170f168a437f5
+# ap-southeast-2 v6.0.2 Enterprise: ami-04fe9ecc0bc020b71
+# eu-central-1 v6.0.2 Enterprise: ami-0714fa1e74a8229de
 # us-east-1 v6.0.2 Enterprise: ami-098615f9e05054582
 # us-east-2 v6.0.2 Enterprise: ami-092d37b152970c523
 # us-west-1 v6.0.2 Enterprise: ami-064cdbbd893bdda25
@@ -44,16 +50,19 @@ is updated when new AMI versions are released.
 ### Enterprise FIPS
 
 ```
+# eu-north-1 v6.2.0 Enterprise FIPS: ami-0ef3a593cf76412cc
 # ap-south-1 v6.0.2 Enterprise FIPS: ami-0252c2f03c38d5a83
-# ap-northeast-2 v6.0.2 Enterprise FIPS: ami-06a6404a60f7e0e38
-# ap-southeast-1 v6.0.2 Enterprise FIPS: ami-094ea89a3f60855ec
-# ap-southeast-2 v6.0.2 Enterprise FIPS: ami-0020456844cb76968
-# ap-northeast-1 v6.0.2 Enterprise FIPS: ami-0b9ee56285aae9d05
-# ca-central-1 v6.0.2 Enterprise FIPS: ami-076b22ef0dfe4037f
-# eu-central-1 v6.0.2 Enterprise FIPS: ami-0154cb54cc8587e58
 # eu-west-1 v6.0.2 Enterprise FIPS: ami-08975755b8c23c164
 # eu-west-2 v6.0.2 Enterprise FIPS: ami-07cef22c77c0633ac
+# eu-west-3 v6.2.0 Enterprise FIPS: ami-08cbdce943ef2d229
+# ap-northeast-1 v6.0.2 Enterprise FIPS: ami-0b9ee56285aae9d05
+# ap-northeast-2 v6.0.2 Enterprise FIPS: ami-06a6404a60f7e0e38
+# ap-northeast-3 v6.2.0 Enterprise FIPS: ami-02911fb25bdc7d813
 # sa-east-1 v6.0.2 Enterprise FIPS: ami-0063942600c3e7bac
+# ca-central-1 v6.0.2 Enterprise FIPS: ami-076b22ef0dfe4037f
+# ap-southeast-1 v6.0.2 Enterprise FIPS: ami-094ea89a3f60855ec
+# ap-southeast-2 v6.0.2 Enterprise FIPS: ami-0020456844cb76968
+# eu-central-1 v6.0.2 Enterprise FIPS: ami-0154cb54cc8587e58
 # us-east-1 v6.0.2 Enterprise FIPS: ami-02a9b68643fef4ef7
 # us-east-2 v6.0.2 Enterprise FIPS: ami-06354cb40cd214d92
 # us-west-1 v6.0.2 Enterprise FIPS: ami-016c28b5e4b5923f1


### PR DESCRIPTION
Although #6282 and its backports added support for AMIs in other AWS regions, the script which handles making the AMIs public as part of the Drone promotion step (https://github.com/gravitational/teleport/blob/master/assets/aws/files/make-amis-public.sh) still had a hardcoded region list which was not updated at the same time.

This PR removes that region list and passes it through from the single source of truth in the `Makefile` instead so this doesn't happen again. I'm going to manually make the affected AMIs public myself now.

This PR also:
- changes the shebang line in AWS-related scripts to use `#!/usr/bin/env bash` instead of just `#/bin/bash` so they also work on systems which alter the default path to `bash`
- adds a note about needing to install `coreutils` to run directly on MacOS

Backports required to:
- `branch/v6`
- `branch/v6.2`

Updates #7030 