### PR TITLE
Add support to configure `tsh` directory for data 

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -36,8 +36,8 @@ import (
 )
 
 const (
-	// profileDir is the default root directory where tsh stores profiles.
-	profileDir = ".tsh"
+	// ProfileDir is the default root directory where tsh stores profiles.
+	ProfileDir = ".tsh"
 	// currentProfileFilename is a file which stores the name of the
 	// currently active profile.
 	currentProfileFilename = "current-profile"
@@ -217,7 +217,7 @@ func defaultProfilePath() string {
 	if u, err := user.Current(); err == nil && u.HomeDir != "" {
 		home = u.HomeDir
 	}
-	return filepath.Join(home, profileDir)
+	return filepath.Join(home, ProfileDir)
 }
 
 // FromDir reads the user profile from a given directory. If dir is empty,

--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// ProfileDir is the default root directory where tsh stores profiles.
-	ProfileDir = ".tsh"
+	profileDir = ".tsh"
 	// currentProfileFilename is a file which stores the name of the
 	// currently active profile.
 	currentProfileFilename = "current-profile"
@@ -217,7 +217,7 @@ func defaultProfilePath() string {
 	if u, err := user.Current(); err == nil && u.HomeDir != "" {
 		home = u.HomeDir
 	}
-	return filepath.Join(home, ProfileDir)
+	return filepath.Join(home, profileDir)
 }
 
 // FromDir reads the user profile from a given directory. If dir is empty,

--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	// ProfileDir is the default root directory where tsh stores profiles.
+	// profileDir is the default root directory where tsh stores profiles.
 	profileDir = ".tsh"
 	// currentProfileFilename is a file which stores the name of the
 	// currently active profile.

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -317,6 +317,9 @@ type Config struct {
 
 	// MockSSOLogin is used in tests for mocking the SSO login response.
 	MockSSOLogin SSOLoginFunc
+
+	// HomePath is where tsh stores profiles
+	HomePath string
 }
 
 // CachePolicy defines cache policy for local clients

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -51,7 +51,7 @@ func onListDatabases(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 	// Retrieve profile to be able to show which databases user is logged into.
-	profile, err := client.StatusCurrent("", cf.Proxy)
+	profile, err := client.StatusCurrent(cf.HomePath, cf.Proxy)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -99,7 +99,7 @@ func onDatabaseLogin(cf *CLIConf) error {
 
 func databaseLogin(cf *CLIConf, tc *client.TeleportClient, db tlsca.RouteToDatabase, quiet bool) error {
 	log.Debugf("Fetching database access certificate for %s on cluster %v.", db, tc.SiteName)
-	profile, err := client.StatusCurrent("", cf.Proxy)
+	profile, err := client.StatusCurrent(cf.HomePath, cf.Proxy)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -117,7 +117,7 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, db tlsca.RouteToDatab
 		return trace.Wrap(err)
 	}
 	// Refresh the profile.
-	profile, err = client.StatusCurrent("", cf.Proxy)
+	profile, err = client.StatusCurrent(cf.HomePath, cf.Proxy)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -132,7 +132,7 @@ func databaseLogin(cf *CLIConf, tc *client.TeleportClient, db tlsca.RouteToDatab
 // fetchDatabaseCreds is called as a part of tsh login to refresh database
 // access certificates for databases the current profile is logged into.
 func fetchDatabaseCreds(cf *CLIConf, tc *client.TeleportClient) error {
-	profile, err := client.StatusCurrent("", cf.Proxy)
+	profile, err := client.StatusCurrent(cf.HomePath, cf.Proxy)
 	if err != nil && !trace.IsNotFound(err) {
 		return trace.Wrap(err)
 	}
@@ -156,7 +156,7 @@ func onDatabaseLogout(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	profile, err := client.StatusCurrent("", cf.Proxy)
+	profile, err := client.StatusCurrent(cf.HomePath, cf.Proxy)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -228,7 +228,7 @@ func onDatabaseConfig(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	profile, err := client.StatusCurrent("", cf.Proxy)
+	profile, err := client.StatusCurrent(cf.HomePath, cf.Proxy)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -268,7 +268,7 @@ Key:       %v
 // If logged into multiple databases, returns an error unless one specified
 // explicily via --db flag.
 func pickActiveDatabase(cf *CLIConf) (*tlsca.RouteToDatabase, error) {
-	profile, err := client.StatusCurrent("", cf.Proxy)
+	profile, err := client.StatusCurrent(cf.HomePath, cf.Proxy)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/asciitable"
@@ -1622,6 +1623,9 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, erro
 
 	// 1: start with the defaults
 	c := client.MakeDefaultConfig()
+
+	// Set tsh home directory
+	c.HomePath = cf.HomePath
 
 	// ProxyJump is an alias of Proxy flag
 	if cf.ProxyJump != "" {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1624,9 +1624,6 @@ func makeClient(cf *CLIConf, useProfileLogin bool) (*client.TeleportClient, erro
 	// 1: start with the defaults
 	c := client.MakeDefaultConfig()
 
-	// Set tsh home directory
-	c.HomePath = cf.HomePath
-
 	// ProxyJump is an alias of Proxy flag
 	if cf.ProxyJump != "" {
 		hosts, err := utils.ParseProxyJump(cf.ProxyJump)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
-	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/asciitable"
@@ -2240,10 +2239,6 @@ func handleUnimplementedError(ctx context.Context, perr error, cf CLIConf) error
 // readTeleportHome gets home directory from environment if configured.
 func readTeleportHome(cf *CLIConf, fn envGetter) {
 	if homeDir := fn(homeEnvVar); homeDir != "" {
-		cf.HomePath = tshHomeFullPath(homeDir)
+		cf.HomePath = path.Clean(homeDir)
 	}
-}
-
-func tshHomeFullPath(dir string) string {
-	return filepath.Join(path.Clean(dir), profile.ProfileDir)
 }

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
-	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/asciitable"

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -922,7 +922,7 @@ func TestReadTeleportHome(t *testing.T) {
 			comment:   "Environment is set",
 			inCLIConf: CLIConf{},
 			input:     "teleport-data/",
-			result:    "teleport-data/.tsh",
+			result:    "teleport-data",
 		},
 		{
 			comment:   "Environment not is set",

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -910,3 +910,33 @@ func mockSSOLogin(t *testing.T, authServer *auth.Server, user types.User) client
 		}, nil
 	}
 }
+
+func TestReadTeleportHome(t *testing.T) {
+	var tests = []struct {
+		comment   string
+		inCLIConf CLIConf
+		input     string
+		result    string
+	}{
+		{
+			comment:   "Environment is set",
+			inCLIConf: CLIConf{},
+			input:     "teleport-data/",
+			result:    "teleport-data/.tsh",
+		},
+		{
+			comment:   "Environment not is set",
+			inCLIConf: CLIConf{},
+			input:     "",
+			result:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.comment, func(t *testing.T) {
+			readTeleportHome(&tt.inCLIConf, func(homeEnvVar string) string {
+				return tt.input
+			})
+			require.Equal(t, tt.result, tt.inCLIConf.HomePath)
+		})
+	}
+}


### PR DESCRIPTION
### Purpose 

This PR adds support for configurable home location for `tsh` configuration and data. 

### Implementation 

Read in environment variable (if there is one) and store `tsh` data in configured path. 


Fixes #3375 
