### PR TITLE
teleport-kube-agent: Add support for annotations.serviceAccount

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -705,6 +705,35 @@ Kubernetes annotations which should be applied to the `Service` created by the c
   </TabItem>
 </Tabs>
 
+## `annotations.serviceAccount`
+
+| Type | Default value | Can be used in `custom` mode? |
+| - | - | - |
+| `object` | `{}` | ✅  |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+
+Kubernetes annotations which should be applied to the `serviceAccount` created by the chart.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  annotations:
+    serviceAccount:
+      kubernetes.io/annotation: value
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```shell
+  --set annotations.serviceAccount."kubernetes\.io\/annotation"=value
+  ```
+  <Admonition type="warning" title="Escaping values">
+    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
+    using a `values.yaml` file instead to avoid confusion and errors.
+  </Admonition>
+  </TabItem>
+</Tabs>
+
 ## `extraArgs`
 
 | Type | Default value | Can be used in `custom` mode? |
@@ -1578,6 +1607,35 @@ Kubernetes annotations which should be applied to each `Pod` created by the char
   <TabItem label="--set">
   ```shell
   --set annotations.pod."kubernetes\.io\/annotation"=value
+  ```
+  <Admonition type="warning" title="Escaping values">
+    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
+    using a `values.yaml` file instead to avoid confusion and errors.
+  </Admonition>
+  </TabItem>
+</Tabs>
+
+## `annotations.serviceAccount`
+
+| Type | Default value | Can be used in `custom` mode? |
+| - | - | - |
+| `object` | `{}` | ✅  |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+
+Kubernetes annotations which should be applied to the `ServiceAccount` created by the chart.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  annotations:
+    serviceAccount:
+      kubernetes.io/annotation: value
+  ```
+  </TabItem>
+  <TabItem label="--set">
+  ```shell
+  --set annotations.serviceAccount."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend

--- a/examples/chart/teleport-kube-agent/.lint/annotations.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/annotations.yaml
@@ -12,3 +12,6 @@ annotations:
   pod:
     kubernetes.io/pod: "test-annotation"
     kubernetes.io/pod-different: 4
+  serviceAccount:
+    kubernetes.io/serviceaccount: "test-annotation"
+    kubernetes.io/serviceaccount-different: 5

--- a/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
@@ -3,3 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
+{{- if .Values.annotations.serviceAccount }}
+  annotations:
+{{- toYaml .Values.annotations.serviceAccount | nindent 4 }}
+{{- end -}}

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -115,21 +115,6 @@
             "type": "integer",
             "default": 1
         },
-        "clusterRoleName": {
-            "$id": "#/properties/clusterRoleName",
-            "type": "string",
-            "default": "teleport-kube-agent"
-        },
-        "clusterRoleBindingName": {
-            "$id": "#/properties/clusterRoleBindingName",
-            "type": "string",
-            "default": "teleport-kube-agent"
-        },
-        "serviceAccountName": {
-            "$id": "#/properties/serviceAccountName",
-            "type": "string",
-            "default": "teleport-kube-agent"
-        },
         "secretName": {
             "$id": "#/properties/secretName",
             "type": "string",
@@ -152,7 +137,8 @@
             "required": [
                 "config",
                 "deployment",
-                "pod"
+                "pod",
+                "serviceAccount"
             ],
             "properties": {
                 "config": {
@@ -167,6 +153,11 @@
                 },
                 "pod": {
                     "$id": "#/properties/annotations/properties/pod",
+                    "type": "object",
+                    "default": {}
+                },
+                "serviceAccount": {
+                    "$id": "#/properties/annotations/properties/serviceAccount",
                     "type": "object",
                     "default": {}
                 }

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -97,6 +97,8 @@ annotations:
   deployment: {}
   # Annotations for each Pod in the Deployment
   pod: {}
+  # Annotations for the ServiceAccount object
+  serviceAccount: {}
 
 # Extra volumes to mount into the Teleport pods
 # https://kubernetes.io/docs/concepts/storage/volumes/


### PR DESCRIPTION
This functionality is present in the `teleport-cluster` chart and it seems logical to duplicate it in the `teleport-kube-agent` chart.

Also adds missing documentation for `annotations.serviceAccount` to the `teleport-cluster` reference.

Backports required:
- `branch/v6.2`