### PR TITLE
[v6.2] docs: correct query

### DIFF
--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -343,4 +343,3 @@ Feel free to shut down, clean up, and delete your resources or use them in furth
 - [Announcing Teleport SSH Server](https://goteleport.com/blog/announcing-teleport-ssh-server/)  
 - [How to SSH properly](https://goteleport.com/blog/how-to-ssh-properly/)  
 - Consider whether [OpenSSH or Teleport SSH](https://goteleport.com/blog/openssh-vs-teleport/) is right for you.  
-- Learn about [Teleconsole](https://goteleport.com/blog/instant-ssh-github/) built on Teleport 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -297,7 +297,7 @@ We can use `tsh` to SSH into the cluster:
 
    ```bash
    # Query all Nodes with a label
-   tsh ssh root@env=example
+   tsh ls env=example
    ```
 
    - Customized labels can be defined in your `teleport.yaml` configuration file or during Node creation.  


### PR DESCRIPTION
Corrected query in Getting Started document.

Should use `ls` instead of remoting in (although both are valid).