### PR TITLE
[backport v6] Describe usage of TELEPORT_CONFIG_FILE in faq and cli page for remote tctl usage #6866

### DIFF
--- a/docs/pages/cli-docs.mdx
+++ b/docs/pages/cli-docs.mdx
@@ -543,7 +543,7 @@ including nodes, users, tokens, and certificates.
 creating new user roles or connecting trusted clusters.
 
 The `TELEPORT_CONFIG_FILE` environment variable indicates where the Teleport configuration file is. 
-If you connecting to a remote Teleport cluster (Teleport cloud) through a `tsh` session and have a file `/etc/teleport.yaml` on your machine set the `TELEPORT_CONFIG_FILE` to `""`.  Otherwise `tctl` will attempt to connect to a Teleport cluster on the machine which could result in the error `ERROR: open /var/lib/teleport/host_uuid: permission denied`.
+If you're connecting to a remote Teleport cluster (Teleport cloud) through a `tsh` session and have a file `/etc/teleport.yaml` on your machine set the `TELEPORT_CONFIG_FILE` to `""`.  Otherwise `tctl` will attempt to connect to a Teleport cluster on the machine which could result in the error `ERROR: open /var/lib/teleport/host_uuid: permission denied`.
 
 **Example**:
 ```bash

--- a/docs/pages/cli-docs.mdx
+++ b/docs/pages/cli-docs.mdx
@@ -542,6 +542,15 @@ including nodes, users, tokens, and certificates.
 `tctl` can also be used to modify the dynamic configuration of the cluster, like
 creating new user roles or connecting trusted clusters.
 
+The `TELEPORT_CONFIG_FILE` environment variable indicates where the Teleport configuration file is. 
+If you connecting to a remote Teleport cluster (Teleport cloud) through a `tsh` session and have a file `/etc/teleport.yaml` on your machine set the `TELEPORT_CONFIG_FILE` to `""`.  Otherwise `tctl` will attempt to connect to a Teleport cluster on the machine which could result in the error `ERROR: open /var/lib/teleport/host_uuid: permission denied`.
+
+**Example**:
+```bash
+export TELEPORT_CONFIG_FILE=""
+tctl tokens add --type=node
+```
+
 ### tctl Global Flags
 
 | Name | Default Value(s) | Allowed Value(s) | Description |

--- a/docs/pages/cloud/faq.mdx
+++ b/docs/pages/cloud/faq.mdx
@@ -34,6 +34,14 @@ $ tsh login --proxy=myinstance.teleport.sh:443
 # tctl (Enterprise edition) can use tsh credentials as of version 5.0
 $ tctl status
 ```
+### Why am I getting `permission denied` errors when using `tctl`?
+
+If you have a local file `/etc/teleport.yaml` on your machine `tctl` will attempt to use the local cluster. Set the environment variable `TELEPORT_CONFIG_FILE` to `""` so it will not attempt to use that Teleport configuration file.
+
+```bash
+$ export TELEPORT_CONFIG_FILE=""
+$ tctl tokens add --type=node
+```
 
 ### Are dynamic node tokens available?
 


### PR DESCRIPTION
backport of #6866 