### PR TITLE
Fix file event driver inconsistencies

### DIFF
--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -357,7 +357,7 @@ func (a *AuditTestSuite) TestLogRotation(c *check.C) {
 
 		// emit regular event:
 		event := &events.Resize{
-			Metadata:     events.Metadata{Type: "resize"},
+			Metadata:     events.Metadata{Type: "resize", Time: now},
 			TerminalSize: "10:10",
 		}
 		err = alog.EmitAuditEvent(context.TODO(), event)

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -19,6 +19,8 @@ package events
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -194,7 +196,7 @@ func (l *FileLog) EmitAuditEventLegacy(event Event, fields EventFields) error {
 	return nil
 }
 
-func (l *FileLog) SearchEvents(fromUTC, toUTC time.Time, namespace string, eventTypes []string, limit int, startKey string) ([]AuditEvent, string, error) {
+func (l *FileLog) SearchEvents(fromUTC, toUTC time.Time, namespace string, eventTypes []string, limit int, startAfter string) ([]AuditEvent, string, error) {
 	l.Debugf("SearchEvents(%v, %v, namespace=%v, eventType=%v, limit=%v)", fromUTC, toUTC, namespace, eventTypes, limit)
 	if limit <= 0 {
 		limit = defaults.EventsIterationLimit
@@ -202,31 +204,29 @@ func (l *FileLog) SearchEvents(fromUTC, toUTC time.Time, namespace string, event
 	if limit > defaults.EventsMaxIterationLimit {
 		return nil, "", trace.BadParameter("limit %v exceeds max iteration limit %v", limit, defaults.MaxIterationLimit)
 	}
+
 	// how many days of logs to search?
 	days := int(toUTC.Sub(fromUTC).Hours() / 24)
 	if days < 0 {
 		return nil, "", trace.BadParameter("invalid days")
 	}
-	filtered, err := l.matchingFiles(fromUTC, toUTC)
+	filesToSearch, err := l.matchingFiles(fromUTC, toUTC)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	foundStart := startKey == ""
-	var total int
-	var lastKey string
-	// search within each file:
+
 	dynamicEvents := make([]EventFields, 0)
-	for i := range filtered {
-		var found []EventFields
-		found, lastKey, foundStart, err = l.findInFile(filtered[i].path, eventTypes, &total, limit, startKey, foundStart)
+
+	// Fetch events from each file for further filtering.
+	for _, file := range filesToSearch {
+		eventsFromFile, err := l.findInFile(file.path, eventTypes)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
-		dynamicEvents = append(dynamicEvents, found...)
-		if limit > 0 && total >= limit {
-			break
-		}
+
+		dynamicEvents = append(dynamicEvents, eventsFromFile...)
 	}
+
 	// sort all accepted files by timestamp or by event index
 	// in case if events are associated with the same session, to make
 	// sure that events are not displayed out of order in case of multiple
@@ -234,15 +234,73 @@ func (l *FileLog) SearchEvents(fromUTC, toUTC time.Time, namespace string, event
 	sort.Sort(ByTimeAndIndex(dynamicEvents))
 
 	events := make([]AuditEvent, 0, len(dynamicEvents))
+
+	// This is used as a flag to check if we have found the startAfter checkpoint or not.
+	foundStart := startAfter == ""
+
 	for _, dynamicEvent := range dynamicEvents {
+		// Convert the event from a dynamic representation to a typed representation.
 		event, err := FromEventFields(dynamicEvent)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
+
+		// Skip until we've found the start checkpoint and once more
+		// since it was the last key of the previous set.
+		if !foundStart {
+			checkpoint, err := getCheckpointFromEvent(event)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+			if startAfter == checkpoint {
+				foundStart = true
+			}
+
+			continue
+		}
+
+		// Skip until we've found the first event within the desired timeframe.
+		if event.GetTime().Before(fromUTC) {
+			continue
+		}
+
+		// If we've found an event after the desired timeframe, all events from here
+		// on out will also be after the desired timeframe due
+		// to the sort so we just break out here and consider the query as finished.
+		if event.GetTime().After(toUTC) {
+			break
+		}
+
 		events = append(events, event)
+
+		// Check if there is a limit and if so, check if we've hit it.
+		// In the event that we've hit the limit, we consider the query partially complete
+		// and return a checkpoint to continue it.
+		if len(events) >= limit && limit > 0 {
+			checkpoint, err := getCheckpointFromEvent(events[len(events)-1])
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+			return events, checkpoint, nil
+		}
 	}
 
-	return events, lastKey, nil
+	// This return point is only hit if the query is finished and there are no further pages.
+	return events, "", nil
+}
+
+func getCheckpointFromEvent(event AuditEvent) (string, error) {
+	if event.GetID() == "" {
+		data, err := utils.FastMarshal(event)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		hash := sha256.Sum256(data)
+		return hex.EncodeToString(hash[:]), nil
+	}
+
+	return event.GetID(), nil
 }
 
 func (l *FileLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, startKey string) ([]AuditEvent, string, error) {
@@ -475,23 +533,22 @@ func parseFileTime(filename string) (time.Time, error) {
 
 // findInFile scans a given log file and returns events that fit the criteria
 // This simplistic implementation ONLY SEARCHES FOR EVENT TYPE(s)
-func (l *FileLog) findInFile(fn string, eventFilter []string, total *int, limit int, startKey string, foundStart bool) ([]EventFields, string, bool, error) {
-	l.Debugf("Called findInFile(%s, %v).", fn, eventFilter)
+func (l *FileLog) findInFile(path string, eventFilter []string) ([]EventFields, error) {
+	l.Debugf("Called findInFile(%s, %v).", path, eventFilter)
 	retval := make([]EventFields, 0)
-	var lastKey string
-	doFilter := len(eventFilter) > 0
 
 	// open the log file:
-	lf, err := os.OpenFile(fn, os.O_RDONLY, 0)
+	lf, err := os.OpenFile(path, os.O_RDONLY, 0)
 	if err != nil {
-		return nil, "", false, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	defer lf.Close()
 
 	// for each line...
 	scanner := bufio.NewScanner(lf)
+
 	for lineNo := 0; scanner.Scan(); lineNo++ {
-		accepted := false
+		accepted := len(eventFilter) == 0
 		// optimization: to avoid parsing JSON unnecessarily, lets see if we
 		// can filter out lines that don't even have the requested event type on the line
 		for i := range eventFilter {
@@ -500,14 +557,14 @@ func (l *FileLog) findInFile(fn string, eventFilter []string, total *int, limit 
 				break
 			}
 		}
-		if doFilter && !accepted {
+		if !accepted {
 			continue
 		}
 		// parse JSON on the line and compare event type field to what's
 		// in the query:
 		var ef EventFields
 		if err = json.Unmarshal(scanner.Bytes(), &ef); err != nil {
-			l.Warnf("invalid JSON in %s line %d", fn, lineNo)
+			l.Warnf("invalid JSON in %s line %d", path, lineNo)
 			continue
 		}
 		for i := range eventFilter {
@@ -517,21 +574,12 @@ func (l *FileLog) findInFile(fn string, eventFilter []string, total *int, limit 
 			}
 		}
 
-		id := ef.GetString(EventID)
-		if id == startKey {
-			foundStart = true
-		}
-
-		if (accepted || !doFilter) && foundStart {
+		if accepted {
 			retval = append(retval, ef)
-			lastKey = id
-			*total++
-			if limit > 0 && *total >= limit {
-				break
-			}
 		}
 	}
-	return retval, lastKey, foundStart, nil
+
+	return retval, nil
 }
 
 type eventFile struct {

--- a/lib/events/filelog_test.go
+++ b/lib/events/filelog_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/defaults"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileLogPagination(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	log, err := NewFileLog(FileLogConfig{
+		Dir:            t.TempDir(),
+		RotationPeriod: time.Hour * 24,
+		Clock:          clock,
+	})
+	require.Nil(t, err)
+
+	err = log.EmitAuditEvent(context.TODO(), &events.SessionJoin{
+		Metadata: events.Metadata{
+			ID:   "a",
+			Type: SessionJoinEvent,
+			Time: clock.Now().UTC(),
+		},
+		UserMetadata: UserMetadata{
+			User: "bob",
+		},
+	})
+	require.Nil(t, err)
+
+	err = log.EmitAuditEvent(context.TODO(), &events.SessionJoin{
+		Metadata: events.Metadata{
+			ID:   "b",
+			Type: SessionJoinEvent,
+			Time: clock.Now().Add(time.Minute).UTC(),
+		},
+		UserMetadata: UserMetadata{
+			User: "alice",
+		},
+	})
+	require.Nil(t, err)
+
+	err = log.EmitAuditEvent(context.TODO(), &events.SessionJoin{
+		Metadata: events.Metadata{
+			ID:   "c",
+			Type: SessionJoinEvent,
+			Time: clock.Now().Add(time.Minute * 2).UTC(),
+		},
+		UserMetadata: UserMetadata{
+			User: "dave",
+		},
+	})
+	require.Nil(t, err)
+
+	from := clock.Now().Add(-time.Hour).UTC()
+	to := clock.Now().Add(time.Hour).UTC()
+	eventArr, checkpoint, err := log.SearchEvents(from, to, defaults.Namespace, nil, 2, "")
+	require.Nil(t, err)
+	require.Len(t, eventArr, 2)
+	require.NotEqual(t, checkpoint, "")
+
+	eventArr, checkpoint, err = log.SearchEvents(from, to, defaults.Namespace, nil, 2, checkpoint)
+	require.Nil(t, err)
+	require.Len(t, eventArr, 1)
+	require.Equal(t, checkpoint, "")
+}

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -536,7 +536,12 @@ func (l *Log) SearchEvents(fromUTC, toUTC time.Time, namespace string, eventType
 		eventArr = append(eventArr, event)
 	}
 
-	return eventArr, fmt.Sprintf("%d", lastKey), nil
+	var lastKeyString string
+	if lastKey != 0 {
+		lastKeyString = fmt.Sprintf("%d", lastKey)
+	}
+
+	return eventArr, lastKeyString, nil
 }
 
 // SearchSessionEvents returns session related events only. This is used to

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1723,9 +1723,13 @@ func (s *WebSuite) TestConstructSSHResponseLegacy(c *C) {
 
 // TestSearchClusterEvents makes sure web API allows querying events by type.
 func (s *WebSuite) TestSearchClusterEvents(c *C) {
+	// We need a clock that uses the current time here to work around
+	// the fact that filelog doesn't support emitting past events.
+	clock := clockwork.NewRealClock()
+
 	sessionEvents := events.GenerateTestSession(events.SessionParams{
 		PrintEvents: 3,
-		Clock:       s.clock,
+		Clock:       clock,
 		ServerID:    s.proxy.ID(),
 	})
 
@@ -1737,6 +1741,9 @@ func (s *WebSuite) TestSearchClusterEvents(c *C) {
 	sessionPrint := sessionEvents[1]
 	sessionEnd := sessionEvents[4]
 
+	fromTime := []string{clock.Now().AddDate(0, -1, 0).UTC().Format(time.RFC3339)}
+	toTime := []string{clock.Now().AddDate(0, 1, 0).UTC().Format(time.RFC3339)}
+
 	testCases := []struct {
 		// Comment is the test case description.
 		Comment string
@@ -1747,24 +1754,37 @@ func (s *WebSuite) TestSearchClusterEvents(c *C) {
 	}{
 		{
 			Comment: "Empty query",
-			Query:   url.Values{},
-			Result:  sessionEvents,
+			Query: url.Values{
+				"from": fromTime,
+				"to":   toTime,
+			},
+			Result: sessionEvents,
 		},
 		{
 			Comment: "Query by session start event",
-			Query:   url.Values{"include": []string{sessionStart.GetType()}},
-			Result:  sessionEvents[:1],
+			Query: url.Values{
+				"include": []string{sessionStart.GetType()},
+				"from":    fromTime,
+				"to":      toTime,
+			},
+			Result: sessionEvents[:1],
 		},
 		{
 			Comment: "Query session start and session end events",
-			Query:   url.Values{"include": []string{sessionEnd.GetType() + ";" + sessionStart.GetType()}},
-			Result:  []events.AuditEvent{sessionStart, sessionEnd},
+			Query: url.Values{
+				"include": []string{sessionEnd.GetType() + ";" + sessionStart.GetType()},
+				"from":    fromTime,
+				"to":      toTime,
+			},
+			Result: []events.AuditEvent{sessionStart, sessionEnd},
 		},
 		{
 			Comment: "Query events with filter by type and limit",
 			Query: url.Values{
 				"include": []string{sessionPrint.GetType() + ";" + sessionEnd.GetType()},
 				"limit":   []string{"1"},
+				"from":    fromTime,
+				"to":      toTime,
 			},
 			Result: []events.AuditEvent{sessionPrint},
 		},
@@ -1786,12 +1806,7 @@ func (s *WebSuite) searchEvents(c *C, clt *client.WebClient, query url.Values, f
 	c.Assert(err, IsNil)
 	var out eventsListGetResponse
 	c.Assert(json.Unmarshal(response.Bytes(), &out), IsNil)
-	for _, event := range out.Events {
-		if utils.SliceContainsStr(filter, event.GetType()) {
-			result = append(result, event)
-		}
-	}
-	return result
+	return out.Events
 }
 
 func (s *WebSuite) TestGetClusterDetails(c *C) {


### PR DESCRIPTION
# What

Fix some issues such as sometimes not all of the limit being used up and a duplicate event. Thanks to @kimlisa for notifying me about this.

This patch simplifies the driver and makes the logic easier to reason about as it's more cleanly divided.

It also fixes a long-running bug where the file driver would slice events at days instead of precise timestamps, this change puts it in line with how the Firestore and DynamoDB drivers work. In line with this it also fixes tests that previously relied on this broken behaviour.

A small tradeoff has also been made in how `findInFile` handles limits to vastly simplify the implementation. My initial implementation of this patch attempted to shave every nanosecond and byte but code readability suffered drastically and it was hard to reason about and make changes to.

Some session events like `session.print` and `session.upload` do not have uids set either. As a bandaid fix another pagination method is used when encountering them.

# Tests

This should be covered by existing tests but in the future I want to also have the full event suite run on the file log as well. This is currently not done due to technical limitations requiring a future rework. @kimlisa will also manually verify this along with me.