### PR TITLE
Release v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 6.2.1
+
+This release of Teleport contains an improvement and several bug fixes.
+
+## Improvements
+
+* Improve performance of DynamoDB events migration introduced in `v6.2.0`.
+  [#7083](https://github.com/gravitational/teleport/pull/7083)
+
+## Fixes
+
+* Fixed an issue with connecting to etcd in insecure mode.
+  [#7049](https://github.com/gravitational/teleport/pull/7049)
+* Fixed an issue with running Teleport on systems without utmp/wtmp support such
+  as alpine. [#7059](https://github.com/gravitational/teleport/pull/7059)
+* Fixed an issue with signing database certificates using `tctl auth sign` via
+  proxy. See [#7071](https://github.com/gravitational/teleport/discussions/7071)
+  for details. [#7038](https://github.com/gravitational/teleport/pull/7038)
+
 ## 6.2
 
 Teleport 6.2 contains new features, improvements, and bug fixes.

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=6.2.0
+VERSION=6.2.1
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: "6.2.0"
-appVersion: "6.2.0"
+version: "6.2.1"
+appVersion: "6.2.1"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "6.2.0"
-appVersion: "6.2.0"
+version: "6.2.1"
+appVersion: "6.2.1"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "6.2.0"
+	Version = "6.2.1"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Should only go in after https://github.com/gravitational/teleport/pull/7083 gets merged.