### PR TITLE
Support token paths that begin with . and /

### DIFF
--- a/lib/utils/token.go
+++ b/lib/utils/token.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -27,9 +28,10 @@ import (
 // from the disk if it looks like a path,
 // otherwise, treat it as a value
 func ReadToken(token string) (string, error) {
-	if !strings.HasPrefix(token, "/") {
+	if !strings.ContainsRune(token, filepath.Separator) {
 		return token, nil
 	}
+
 	// treat it as a file
 	out, err := ioutil.ReadFile(token)
 	if err != nil {

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -491,22 +491,25 @@ func (s *UtilsSuite) TestMarshalYAML(c *check.C) {
 }
 
 // TestReadToken tests reading token from file and as is
-func (s *UtilsSuite) TestReadToken(c *check.C) {
+func TestReadToken(t *testing.T) {
 	tok, err := ReadToken("token")
-	c.Assert(tok, check.Equals, "token")
-	c.Assert(err, check.IsNil)
+	require.Equal(t, tok, "token")
+	require.NoError(t, err)
 
 	_, err = ReadToken("/tmp/non-existent-token-for-teleport-tests-not-found")
-	fixtures.ExpectNotFound(c, err)
+	fixtures.AssertNotFound(t, err)
 
-	dir := c.MkDir()
+	_, err = ReadToken("./non-existent-token-for-teleport-tests-not-found")
+	fixtures.AssertNotFound(t, err)
+
+	dir := t.TempDir()
 	tokenPath := filepath.Join(dir, "token")
 	err = ioutil.WriteFile(tokenPath, []byte("shmoken"), 0644)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	tok, err = ReadToken(tokenPath)
-	c.Assert(err, check.IsNil)
-	c.Assert(tok, check.Equals, "shmoken")
+	require.NoError(t, err)
+	require.Equal(t, tok, "shmoken")
 }
 
 // TestStringsSet makes sure that nil slice returns empty set (less error prone)


### PR DESCRIPTION
This commit improves detection of token paths

Treats token as a file path:

--token=./file
--token=/file

Treats token as a value:

--token=hello-insecure