### PR TITLE
Moves SSH tests to testify/testing package

### DIFF
--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -118,7 +118,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 
 	testServer, err := auth.NewTestServer(serverCfg)
 	require.NoError(t, err)
-	t.Cleanup(func() { testServer.Shutdown(context.Background()) })
+	t.Cleanup(func() { require.NoError(t, testServer.Shutdown(context.Background())) })
 
 	certs, err := testServer.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
 		HostID:   hostID,

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -174,7 +174,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 	require.NoError(t, err)
 	require.NoError(t, auth.CreateUploaderDir(nodeDir))
 	require.NoError(t, sshSrv.Start())
-	t.Cleanup(func() { sshSrv.Close() })
+	t.Cleanup(func() { require.NoError(t, sshSrv.Close()) })
 
 	require.NoError(t, sshSrv.heartbeat.ForceSend(time.Second))
 

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -51,35 +51,14 @@ import (
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/trace"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/pborman/uuid"
-	"github.com/sirupsen/logrus"
-	. "gopkg.in/check.v1"
 )
-
-func TestRegular(t *testing.T) { TestingT(t) }
-
-type SrvSuite struct {
-	srv         *Server
-	srvAddress  string
-	srvPort     string
-	srvHostPort string
-	clt         *ssh.Client
-	cltConfig   *ssh.ClientConfig
-	up          *upack
-	signer      ssh.Signer
-	user        string
-	proxyClient *auth.Client
-	proxyID     string
-	nodeClient  *auth.Client
-	nodeID      string
-	adminClient *auth.Client
-	clock       clockwork.FakeClock
-	server      *auth.TestServer
-}
 
 // teleportTestUser is additional user used for tests
 const teleportTestUser = "teleport-test"
@@ -88,8 +67,6 @@ const teleportTestUser = "teleport-test"
 var wildcardAllow = types.Labels{
 	types.Wildcard: []string{types.Wildcard},
 }
-
-var _ = Suite(&SrvSuite{})
 
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise it will run tests as normal.
@@ -105,77 +82,72 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-const hostID = "00000000-0000-0000-0000-000000000000"
+type sshTestFixture struct {
+	ssh struct {
+		srv         *Server
+		srvAddress  string
+		srvPort     string
+		srvHostPort string
+		clt         *ssh.Client
+		cltConfig   *ssh.ClientConfig
+	}
+	up      *upack
+	signer  ssh.Signer
+	user    string
+	clock   clockwork.FakeClock
+	testSrv *auth.TestServer
+}
 
-func (s *SrvSuite) SetUpTest(c *C) {
+func newFixture(t *testing.T) *sshTestFixture {
+	return newCustomFixture(t, func(*auth.TestServerConfig) {})
+}
+
+func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshOpts ...ServerOption) *sshTestFixture {
 	u, err := user.Current()
-	c.Assert(err, IsNil)
-	s.user = u.Username
+	require.NoError(t, err)
 
-	s.clock = clockwork.NewFakeClock()
+	clock := clockwork.NewFakeClock()
 
-	s.server, err = auth.NewTestServer(auth.TestServerConfig{
+	serverCfg := auth.TestServerConfig{
 		Auth: auth.TestAuthServerConfig{
 			ClusterName: "localhost",
-			Dir:         c.MkDir(),
-			Clock:       s.clock,
+			Dir:         t.TempDir(),
+			Clock:       clock,
 		},
-	})
-	c.Assert(err, IsNil)
+	}
+	mutateCfg(&serverCfg)
 
-	// create proxy client used in some tests
-	s.proxyID = uuid.New()
-	s.proxyClient, err = s.server.NewClient(auth.TestIdentity{
-		I: auth.BuiltinRole{
-			Role:     types.RoleProxy,
-			Username: s.proxyID,
-		},
-	})
-	c.Assert(err, IsNil)
+	testServer, err := auth.NewTestServer(serverCfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { testServer.Shutdown(context.Background()) })
 
-	// admin client is for admin actions, e.g. creating new users
-	s.adminClient, err = s.server.NewClient(auth.TestBuiltin(types.RoleAdmin))
-	c.Assert(err, IsNil)
-
-	// set up SSH client using the user private key for signing
-	up, err := s.newUpack(s.user, []string{s.user}, wildcardAllow)
-	c.Assert(err, IsNil)
-
-	// set up host private key and certificate
-	certs, err := s.server.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
+	certs, err := testServer.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
 		HostID:   hostID,
-		NodeName: s.server.ClusterName(),
-		Roles:    types.SystemRoles{types.RoleNode},
+		NodeName: testServer.ClusterName(),
+		Roles:    types.SystemRoles{teleport.RoleNode},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// set up user CA and set up a user that has access to the server
-	s.signer, err = sshutils.NewSigner(certs.Key, certs.Cert)
-	c.Assert(err, IsNil)
+	signer, err := sshutils.NewSigner(certs.Key, certs.Cert)
+	require.NoError(t, err)
 
-	s.nodeID = uuid.New()
-	s.nodeClient, err = s.server.NewClient(auth.TestIdentity{
+	nodeID := uuid.New()
+	nodeClient, err := testServer.NewClient(auth.TestIdentity{
 		I: auth.BuiltinRole{
 			Role:     types.RoleNode,
-			Username: s.nodeID,
+			Username: nodeID,
 		},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
-	nodeDir := c.MkDir()
-	srv, err := New(
-		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
-		s.server.ClusterName(),
-		[]ssh.Signer{s.signer},
-		s.nodeClient,
-		nodeDir,
-		"",
-		utils.NetAddr{},
-		SetUUID(s.nodeID),
+	nodeDir := t.TempDir()
+	serverOptions := []ServerOption{
+		SetUUID(nodeID),
 		SetNamespace(defaults.Namespace),
-		SetEmitter(s.nodeClient),
+		SetEmitter(nodeClient),
 		SetShell("/bin/sh"),
-		SetSessionServer(s.nodeClient),
+		SetSessionServer(nodeClient),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetLabels(
 			map[string]string{"foo": "bar"},
@@ -186,19 +158,35 @@ func (s *SrvSuite) SetUpTest(c *C) {
 			},
 		),
 		SetBPF(&bpf.NOP{}),
-		SetClock(s.clock),
-	)
-	c.Assert(err, IsNil)
-	s.srv = srv
-	s.srv.isTestStub = true
-	c.Assert(auth.CreateUploaderDir(nodeDir), IsNil)
-	c.Assert(s.srv.Start(), IsNil)
-	c.Assert(s.srv.heartbeat.ForceSend(time.Second), IsNil)
+		SetClock(clock),
+	}
 
-	s.srvAddress = s.srv.Addr()
-	_, s.srvPort, err = net.SplitHostPort(s.srvAddress)
-	c.Assert(err, IsNil)
-	s.srvHostPort = fmt.Sprintf("%v:%v", s.server.ClusterName(), s.srvPort)
+	serverOptions = append(serverOptions, sshOpts...)
+
+	sshSrv, err := New(
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
+		testServer.ClusterName(),
+		[]ssh.Signer{signer},
+		nodeClient,
+		nodeDir,
+		"",
+		utils.NetAddr{},
+		serverOptions...)
+	require.NoError(t, err)
+	require.NoError(t, auth.CreateUploaderDir(nodeDir))
+	require.NoError(t, sshSrv.Start())
+	t.Cleanup(func() { sshSrv.Close() })
+
+	require.NoError(t, sshSrv.heartbeat.ForceSend(time.Second))
+
+	sshSrvAddress := sshSrv.Addr()
+	_, sshSrvPort, err := net.SplitHostPort(sshSrvAddress)
+	require.NoError(t, err)
+	sshSrvHostPort := fmt.Sprintf("%v:%v", testServer.ClusterName(), sshSrvPort)
+
+	// set up SSH client using the user private key for signing
+	up, err := newUpack(testServer, u.Username, []string{u.Username}, wildcardAllow)
+	require.NoError(t, err)
 
 	// set up an agent server and a client that uses agent for forwarding
 	keyring := agent.NewKeyring()
@@ -206,36 +194,76 @@ func (s *SrvSuite) SetUpTest(c *C) {
 		PrivateKey:  up.pkey,
 		Certificate: up.pcert,
 	}
-	c.Assert(keyring.Add(addedKey), IsNil)
-	s.up = up
-	s.cltConfig = &ssh.ClientConfig{
-		User:            s.user,
+	require.NoError(t, keyring.Add(addedKey))
+
+	cltConfig := &ssh.ClientConfig{
+		User:            u.Username,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", s.srv.Addr(), s.cltConfig)
-	c.Assert(err, IsNil)
-	c.Assert(agent.ForwardToAgent(client, keyring), IsNil)
-	s.clt = client
+	client, err := ssh.Dial("tcp", sshSrv.Addr(), cltConfig)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close() })
+	require.NoError(t, agent.ForwardToAgent(client, keyring))
+
+	return &sshTestFixture{
+		ssh: struct {
+			srv         *Server
+			srvAddress  string
+			srvPort     string
+			srvHostPort string
+			clt         *ssh.Client
+			cltConfig   *ssh.ClientConfig
+		}{
+			srv:         sshSrv,
+			srvAddress:  sshSrvAddress,
+			srvPort:     sshSrvPort,
+			srvHostPort: sshSrvHostPort,
+			clt:         client,
+			cltConfig:   cltConfig,
+		},
+		up:      up,
+		signer:  signer,
+		user:    u.Username,
+		clock:   clock,
+		testSrv: testServer,
+	}
 }
 
-func (s *SrvSuite) TearDownTest(c *C) {
-	if s.clt != nil {
-		c.Assert(s.clt.Close(), IsNil)
-	}
-	if s.srv != nil {
-		c.Assert(s.srv.Close(), IsNil)
-	}
-	if s.server != nil {
-		c.Assert(s.server.Shutdown(context.Background()), IsNil)
-	}
+func newProxyClient(t *testing.T, testSvr *auth.TestServer) (*auth.Client, string) {
+	// create proxy client used in some tests
+	proxyID := uuid.New()
+	proxyClient, err := testSvr.NewClient(auth.TestIdentity{
+		I: auth.BuiltinRole{
+			Role:     types.RoleProxy,
+			Username: proxyID,
+		},
+	})
+	require.NoError(t, err)
+	return proxyClient, proxyID
 }
+
+func newNodeClient(t *testing.T, testSvr *auth.TestServer) (*auth.Client, string) {
+	nodeID := uuid.New()
+	nodeClient, err := testSvr.NewClient(auth.TestIdentity{
+		I: auth.BuiltinRole{
+			Role:     teleport.RoleNode,
+			Username: nodeID,
+		},
+	})
+	require.NoError(t, err)
+	return nodeClient, nodeID
+}
+
+const hostID = "00000000-0000-0000-0000-000000000000"
 
 // TestDirectTCPIP ensures that the server can create a "direct-tcpip"
 // channel to the target address. The "direct-tcpip" channel is what port
 // forwarding is built upon.
-func (s *SrvSuite) TestDirectTCPIP(c *C) {
+func TestDirectTCPIP(t *testing.T) {
+	f := newFixture(t)
+
 	// Startup a test server that will reply with "hello, world\n"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "hello, world")
@@ -244,7 +272,7 @@ func (s *SrvSuite) TestDirectTCPIP(c *C) {
 
 	// Extract the host:port the test HTTP server is running on.
 	u, err := url.Parse(ts.URL)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Build a http.Client that will dial through the server to establish the
 	// connection. That's why a custom dialer is used and the dialer uses
@@ -252,25 +280,27 @@ func (s *SrvSuite) TestDirectTCPIP(c *C) {
 	httpClient := http.Client{
 		Transport: &http.Transport{
 			Dial: func(network string, addr string) (net.Conn, error) {
-				return s.clt.Dial("tcp", u.Host)
+				return f.ssh.clt.Dial("tcp", u.Host)
 			},
 		},
 	}
 
 	// Perform a HTTP GET to the test HTTP server through a "direct-tcpip" request.
 	resp, err := httpClient.Get(ts.URL)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer resp.Body.Close()
 
 	// Make sure the response is what was expected.
 	body, err := ioutil.ReadAll(resp.Body)
-	c.Assert(err, IsNil)
-	c.Assert(body, DeepEquals, []byte("hello, world\n"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello, world\n"), body)
 }
 
-func (s *SrvSuite) TestAdvertiseAddr(c *C) {
-	// No advertiseAddr was set in SetUpTest, should default to srvAddress.
-	c.Assert(s.srv.AdvertiseAddr(), Equals, s.srvAddress)
+func TestAdvertiseAddr(t *testing.T) {
+	f := newFixture(t)
+
+	// No advertiseAddr was set in fixture, should default to srvAddress.
+	require.Equal(t, f.ssh.srv.Addr(), f.ssh.srv.AdvertiseAddr())
 
 	var (
 		advIP      = utils.MustParseAddr("10.10.10.1")
@@ -278,134 +308,140 @@ func (s *SrvSuite) TestAdvertiseAddr(c *C) {
 		advBadAddr = &utils.NetAddr{Addr: "localhost:badport", AddrNetwork: "tcp"}
 	)
 	// IP-only advertiseAddr should use the port from srvAddress.
-	s.srv.setAdvertiseAddr(advIP)
-	c.Assert(s.srv.AdvertiseAddr(), Equals, fmt.Sprintf("%s:%s", advIP, s.srvPort))
+	f.ssh.srv.setAdvertiseAddr(advIP)
+	require.Equal(t, fmt.Sprintf("%s:%s", advIP, f.ssh.srvPort), f.ssh.srv.AdvertiseAddr())
 
 	// IP and port advertiseAddr should fully override srvAddress.
-	s.srv.setAdvertiseAddr(advIPPort)
-	c.Assert(s.srv.AdvertiseAddr(), Equals, advIPPort.String())
+	f.ssh.srv.setAdvertiseAddr(advIPPort)
+	require.Equal(t, advIPPort.String(), f.ssh.srv.AdvertiseAddr())
 
 	// nil advertiseAddr should default to srvAddress.
-	s.srv.setAdvertiseAddr(nil)
-	c.Assert(s.srv.AdvertiseAddr(), Equals, s.srvAddress)
+	f.ssh.srv.setAdvertiseAddr(nil)
+	require.Equal(t, f.ssh.srvAddress, f.ssh.srv.AdvertiseAddr())
 
 	// Invalid advertiseAddr should fall back to srvAddress.
-	s.srv.setAdvertiseAddr(advBadAddr)
-	c.Assert(s.srv.AdvertiseAddr(), Equals, s.srvAddress)
+	f.ssh.srv.setAdvertiseAddr(advBadAddr)
+	require.Equal(t, f.ssh.srvAddress, f.ssh.srv.AdvertiseAddr())
 }
 
 // TestAgentForwardPermission makes sure if RBAC rules don't allow agent
 // forwarding, we don't start an agent even if requested.
-func (s *SrvSuite) TestAgentForwardPermission(c *C) {
+func TestAgentForwardPermission(t *testing.T) {
+	f := newFixture(t)
 	ctx := context.Background()
-	// make sure the role does not allow agent forwarding
-	roleName := services.RoleNameForUser(s.user)
-	role, err := s.server.Auth().GetRole(ctx, roleName)
-	c.Assert(err, IsNil)
-	roleOptions := role.GetOptions()
-	roleOptions.ForwardAgent = types.NewBool(false)
-	role.SetOptions(roleOptions)
-	err = s.server.Auth().UpsertRole(ctx, role)
-	c.Assert(err, IsNil)
 
-	se, err := s.clt.NewSession()
-	c.Assert(err, IsNil)
-	defer se.Close()
+	// make sure the role does not allow agent forwarding
+	roleName := services.RoleNameForUser(f.user)
+	role, err := f.testSrv.Auth().GetRole(ctx, roleName)
+	require.NoError(t, err)
+
+	roleOptions := role.GetOptions()
+	roleOptions.ForwardAgent = services.NewBool(false)
+	role.SetOptions(roleOptions)
+	require.NoError(t, f.testSrv.Auth().UpsertRole(ctx, role))
+
+	se, err := f.ssh.clt.NewSession()
+	require.NoError(t, err)
+	t.Cleanup(func() { se.Close() })
 
 	// to interoperate with OpenSSH, requests for agent forwarding always succeed.
 	// however that does not mean the users agent will actually be forwarded.
-	err = agent.RequestAgentForwarding(se)
-	c.Assert(err, IsNil)
+	require.NoError(t, agent.RequestAgentForwarding(se))
 
 	// the output of env, we should not see SSH_AUTH_SOCK in the output
 	output, err := se.Output("env")
-	c.Assert(err, IsNil)
-	c.Assert(strings.Contains(string(output), "SSH_AUTH_SOCK"), Equals, false)
+	require.NoError(t, err)
+	require.NotContains(t, string(output), "SSH_AUTH_SOCK")
 }
 
 // TestMaxSesssions makes sure that MaxSessions RBAC rules prevent
 // too many concurrent sessions.
-func (s *SrvSuite) TestMaxSessions(c *C) {
+func TestMaxSessions(t *testing.T) {
 	const maxSessions int64 = 2
+	f := newFixture(t)
 	ctx := context.Background()
 	// make sure the role does not allow agent forwarding
-	roleName := services.RoleNameForUser(s.user)
-	role, err := s.server.Auth().GetRole(ctx, roleName)
-	c.Assert(err, IsNil)
+	roleName := services.RoleNameForUser(f.user)
+	role, err := f.testSrv.Auth().GetRole(ctx, roleName)
+	require.NoError(t, err)
 	roleOptions := role.GetOptions()
 	roleOptions.MaxSessions = maxSessions
 	role.SetOptions(roleOptions)
-	err = s.server.Auth().UpsertRole(ctx, role)
-	c.Assert(err, IsNil)
+	err = f.testSrv.Auth().UpsertRole(ctx, role)
+	require.NoError(t, err)
 
 	for i := int64(0); i < maxSessions; i++ {
-		se, err := s.clt.NewSession()
-		c.Assert(err, IsNil)
+		se, err := f.ssh.clt.NewSession()
+		require.NoError(t, err)
 		defer se.Close()
 	}
 
-	_, err = s.clt.NewSession()
-	c.Assert(err, NotNil)
-	c.Assert(strings.Contains(err.Error(), "too many session channels"), Equals, true)
+	_, err = f.ssh.clt.NewSession()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many session channels")
 
-	// verfiy that max sessions does not affect max connections.
+	// verify that max sessions does not affect max connections.
 	for i := int64(0); i <= maxSessions; i++ {
-		clt, err := ssh.Dial("tcp", s.srv.Addr(), s.cltConfig)
-		c.Assert(err, IsNil)
-		c.Assert(clt.Close(), IsNil)
+		clt, err := ssh.Dial("tcp", f.ssh.srv.Addr(), f.ssh.cltConfig)
+		require.NoError(t, err)
+		require.NoError(t, clt.Close())
 	}
 }
 
 // TestOpenExecSessionSetsSession tests that OpenExecSession()
 // sets ServerContext session.
-func (s *SrvSuite) TestOpenExecSessionSetsSession(c *C) {
-	se, err := s.clt.NewSession()
-	c.Assert(err, IsNil)
+func TestOpenExecSessionSetsSession(t *testing.T) {
+	f := newFixture(t)
+
+	se, err := f.ssh.clt.NewSession()
+	require.NoError(t, err)
 	defer se.Close()
 
 	// This will trigger an exec request, which will start a non-interactive session,
 	// which then triggers setting env for SSH_SESSION_ID.
 	output, err := se.Output("env")
-	c.Assert(err, IsNil)
-	c.Assert(strings.Contains(string(output), teleport.SSHSessionID), Equals, true)
+	require.NoError(t, err)
+	require.Contains(t, string(output), teleport.SSHSessionID)
 }
 
 // TestAgentForward tests agent forwarding via unix sockets
-func (s *SrvSuite) TestAgentForward(c *C) {
-	ctx := context.Background()
-	roleName := services.RoleNameForUser(s.user)
-	role, err := s.server.Auth().GetRole(ctx, roleName)
-	c.Assert(err, IsNil)
-	roleOptions := role.GetOptions()
-	roleOptions.ForwardAgent = types.NewBool(true)
-	role.SetOptions(roleOptions)
-	err = s.server.Auth().UpsertRole(ctx, role)
-	c.Assert(err, IsNil)
+func TestAgentForward(t *testing.T) {
+	f := newFixture(t)
 
-	se, err := s.clt.NewSession()
-	c.Assert(err, IsNil)
+	ctx := context.Background()
+	roleName := services.RoleNameForUser(f.user)
+	role, err := f.testSrv.Auth().GetRole(ctx, roleName)
+	require.NoError(t, err)
+	roleOptions := role.GetOptions()
+	roleOptions.ForwardAgent = services.NewBool(true)
+	role.SetOptions(roleOptions)
+	err = f.testSrv.Auth().UpsertRole(ctx, role)
+	require.NoError(t, err)
+
+	se, err := f.ssh.clt.NewSession()
+	require.NoError(t, err)
 	defer se.Close()
 
 	err = agent.RequestAgentForwarding(se)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// prepare to send virtual "keyboard input" into the shell:
 	keyboard, err := se.StdinPipe()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// start interactive SSH session (new shell):
 	err = se.Shell()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// create a temp file to collect the shell output into:
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "teleport-agent-forward-test")
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	tmpFile.Close()
 	defer os.Remove(tmpFile.Name())
 
 	// type 'printenv SSH_AUTH_SOCK > /path/to/tmp/file' into the session (dumping the value of SSH_AUTH_STOCK into the temp file)
 	_, err = keyboard.Write([]byte(fmt.Sprintf("printenv %v > %s\n\r", teleport.SSHAuthSock, tmpFile.Name())))
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// wait for the output
 	var output []byte
@@ -413,43 +449,43 @@ func (s *SrvSuite) TestAgentForward(c *C) {
 		time.Sleep(10 * time.Millisecond)
 		output, _ = ioutil.ReadFile(tmpFile.Name())
 	}
-	c.Assert(output, Not(Equals), "")
+	require.NotEmpty(t, output)
 	socketPath := strings.TrimSpace(string(output))
 
 	// try dialing the ssh agent socket:
 	file, err := net.Dial("unix", socketPath)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	clientAgent := agent.NewClient(file)
 
 	signers, err := clientAgent.Signers()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	sshConfig := &ssh.ClientConfig{
-		User:            s.user,
+		User:            f.user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signers...)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", s.srv.Addr(), sshConfig)
-	c.Assert(err, IsNil)
+	client, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	require.NoError(t, err)
 	err = client.Close()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// make sure the socket persists after the session is closed.
 	// (agents are started from specific sessions, but apply to all
 	// sessions on the connection).
 	err = se.Close()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	// Pause to allow closure to propagate.
 	time.Sleep(150 * time.Millisecond)
 	_, err = net.Dial("unix", socketPath)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// make sure the socket is gone after we closed the connection.
-	err = s.clt.Close()
-	c.Assert(err, IsNil)
+	require.NoError(t, f.ssh.clt.Close())
+
 	// clt must be nullified to prevent double-close during test cleanup
-	s.clt = nil
+	f.ssh.clt = nil
 	for i := 0; i < 4; i++ {
 		_, err = net.Dial("unix", socketPath)
 		if err != nil {
@@ -457,198 +493,215 @@ func (s *SrvSuite) TestAgentForward(c *C) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	c.Fatalf("expected socket to be closed, still could dial after 150 ms")
+	require.FailNow(t, "expected socket to be closed, still could dial after 150 ms")
 }
 
-func (s *SrvSuite) TestAllowedUsers(c *C) {
-	up, err := s.newUpack(s.user, []string{s.user}, wildcardAllow)
-	c.Assert(err, IsNil)
+func TestAllowedUsers(t *testing.T) {
+	f := newFixture(t)
+
+	up, err := newUpack(f.testSrv, f.user, []string{f.user}, wildcardAllow)
+	require.NoError(t, err)
 
 	sshConfig := &ssh.ClientConfig{
-		User:            s.user,
+		User:            f.user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", s.srv.Addr(), sshConfig)
-	c.Assert(err, IsNil)
-	c.Assert(client.Close(), IsNil)
+	client, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	require.NoError(t, err)
+	require.NoError(t, client.Close())
 
 	// now remove OS user from valid principals
-	up, err = s.newUpack(s.user, []string{"otheruser"}, wildcardAllow)
-	c.Assert(err, IsNil)
+	up, err = newUpack(f.testSrv, f.user, []string{"otheruser"}, wildcardAllow)
+	require.NoError(t, err)
 
 	sshConfig = &ssh.ClientConfig{
-		User:            s.user,
+		User:            f.user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	_, err = ssh.Dial("tcp", s.srv.Addr(), sshConfig)
-	c.Assert(err, NotNil)
+	_, err = ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	require.Error(t, err)
 }
 
-func (s *SrvSuite) TestAllowedLabels(c *C) {
+func TestAllowedLabels(t *testing.T) {
+	f := newFixture(t)
+
 	var tests = []struct {
+		desc       string
 		inLabelMap types.Labels
 		outError   bool
 	}{
 		// Valid static label.
 		{
+			desc:       "Valid Static",
 			inLabelMap: types.Labels{"foo": []string{"bar"}},
 			outError:   false,
 		},
 		// Invalid static label.
 		{
+			desc:       "Invalid Static",
 			inLabelMap: types.Labels{"foo": []string{"baz"}},
 			outError:   true,
 		},
 		// Valid dynamic label.
 		{
+			desc:       "Valid Dynamic",
 			inLabelMap: types.Labels{"baz": []string{"4"}},
 			outError:   false,
 		},
 		// Invalid dynamic label.
 		{
+			desc:       "Invalid Dynamic",
 			inLabelMap: types.Labels{"baz": []string{"5"}},
 			outError:   true,
 		},
 	}
 
 	for _, tt := range tests {
-		up, err := s.newUpack(s.user, []string{s.user}, tt.inLabelMap)
-		c.Assert(err, IsNil)
+		t.Run(tt.desc, func(t *testing.T) {
+			up, err := newUpack(f.testSrv, f.user, []string{f.user}, tt.inLabelMap)
+			require.NoError(t, err)
 
-		sshConfig := &ssh.ClientConfig{
-			User:            s.user,
-			Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
-			HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
-		}
+			sshConfig := &ssh.ClientConfig{
+				User:            f.user,
+				Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
+				HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
+			}
 
-		_, err = ssh.Dial("tcp", s.srv.Addr(), sshConfig)
-		if tt.outError {
-			c.Assert(err, NotNil)
-		} else {
-			c.Assert(err, IsNil)
-		}
+			_, err = ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+			if tt.outError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 
 // TestKeyAlgorithms makes sure Teleport does not accept invalid user
 // certificates. The main check is the certificate algorithms.
-func (s *SrvSuite) TestKeyAlgorithms(c *C) {
+func TestKeyAlgorithms(t *testing.T) {
+	f := newFixture(t)
+
 	_, ellipticSigner, err := utils.CreateEllipticCertificate("foo", ssh.UserCert)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	sshConfig := &ssh.ClientConfig{
-		User:            s.user,
+		User:            f.user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(ellipticSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	_, err = ssh.Dial("tcp", s.srv.Addr(), sshConfig)
-	c.Assert(err, NotNil)
+	_, err = ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	require.Error(t, err)
 }
 
-func (s *SrvSuite) TestInvalidSessionID(c *C) {
-	session, err := s.clt.NewSession()
-	c.Assert(err, IsNil)
+func TestInvalidSessionID(t *testing.T) {
+	f := newFixture(t)
+
+	session, err := f.ssh.clt.NewSession()
+	require.NoError(t, err)
 
 	err = session.Setenv(sshutils.SessionEnvVar, "foo")
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	err = session.Shell()
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 }
 
-func (s *SrvSuite) TestSessionHijack(c *C) {
+func TestSessionHijack(t *testing.T) {
 	_, err := user.Lookup(teleportTestUser)
 	if err != nil {
-		c.Skip(fmt.Sprintf("user %v is not found, skipping test", teleportTestUser))
+		t.Skip(fmt.Sprintf("user %v is not found, skipping test", teleportTestUser))
 	}
 
+	f := newFixture(t)
+
 	// user 1 has access to the server
-	up, err := s.newUpack(s.user, []string{s.user}, wildcardAllow)
-	c.Assert(err, IsNil)
+	up, err := newUpack(f.testSrv, f.user, []string{f.user}, wildcardAllow)
+	require.NoError(t, err)
 
 	// login with first user
 	sshConfig := &ssh.ClientConfig{
-		User:            s.user,
+		User:            f.user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client, err := ssh.Dial("tcp", s.srv.Addr(), sshConfig)
-	c.Assert(err, IsNil)
+	client, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig)
+	require.NoError(t, err)
 	defer func() {
 		err := client.Close()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	se, err := client.NewSession()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer se.Close()
 
 	firstSessionID := string(sess.NewID())
 	err = se.Setenv(sshutils.SessionEnvVar, firstSessionID)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	err = se.Shell()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// user 2 does not have s.user as a listed principal
-	up2, err := s.newUpack(teleportTestUser, []string{teleportTestUser}, wildcardAllow)
-	c.Assert(err, IsNil)
+	up2, err := newUpack(f.testSrv, teleportTestUser, []string{teleportTestUser}, wildcardAllow)
+	require.NoError(t, err)
 
 	sshConfig2 := &ssh.ClientConfig{
 		User:            teleportTestUser,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(up2.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	client2, err := ssh.Dial("tcp", s.srv.Addr(), sshConfig2)
-	c.Assert(err, IsNil)
+	client2, err := ssh.Dial("tcp", f.ssh.srv.Addr(), sshConfig2)
+	require.NoError(t, err)
 	defer func() {
 		err := client2.Close()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	se2, err := client2.NewSession()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer se2.Close()
 
 	err = se2.Setenv(sshutils.SessionEnvVar, firstSessionID)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// attempt to hijack, should return error
 	err = se2.Shell()
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 }
 
 // testClient dials targetAddr via proxyAddr and executes 2+3 command
-func (s *SrvSuite) testClient(c *C, proxyAddr, targetAddr, remoteAddr string, sshConfig *ssh.ClientConfig) {
+func testClient(t *testing.T, f *sshTestFixture, proxyAddr, targetAddr, remoteAddr string, sshConfig *ssh.ClientConfig) {
 	// Connect to node using registered address
 	client, err := ssh.Dial("tcp", proxyAddr, sshConfig)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer client.Close()
 
 	se, err := client.NewSession()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer se.Close()
 
 	writer, err := se.StdinPipe()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	reader, err := se.StdoutPipe()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Request opening TCP connection to the remote host
-	c.Assert(se.RequestSubsystem(fmt.Sprintf("proxy:%v", targetAddr)), IsNil)
+	require.NoError(t, se.RequestSubsystem(fmt.Sprintf("proxy:%v", targetAddr)))
 
 	local, err := utils.ParseAddr("tcp://" + proxyAddr)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	remote, err := utils.ParseAddr("tcp://" + remoteAddr)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	pipeNetConn := utils.NewPipeNetConn(
 		reader,
@@ -662,101 +715,105 @@ func (s *SrvSuite) testClient(c *C, proxyAddr, targetAddr, remoteAddr string, ss
 
 	// Open SSH connection via TCP
 	conn, chans, reqs, err := ssh.NewClientConn(pipeNetConn,
-		s.srv.Addr(), sshConfig)
-	c.Assert(err, IsNil)
+		f.ssh.srv.Addr(), sshConfig)
+	require.NoError(t, err)
 	defer conn.Close()
 
 	// using this connection as regular SSH
 	client2 := ssh.NewClient(conn, chans, reqs)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer client2.Close()
 
 	se2, err := client2.NewSession()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer se2.Close()
 
 	out, err := se2.Output("echo hello")
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
-	c.Assert(string(out), Equals, "hello\n")
+	require.Equal(t, "hello\n", string(out))
 }
 
-func (s *SrvSuite) mustListen(c *C) (net.Listener, utils.NetAddr) {
+func mustListen(t *testing.T) (net.Listener, utils.NetAddr) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	addr := utils.NetAddr{AddrNetwork: "tcp", Addr: l.Addr().String()}
 	return l, addr
 }
 
-func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
+func TestProxyReverseTunnel(t *testing.T) {
 	log.Infof("[TEST START] TestProxyReverseTunnel")
+	f := newFixture(t)
+
+	proxyClient, proxyID := newProxyClient(t, f.testSrv)
 
 	// Create host key and certificate for proxy.
-	proxyKeys, err := s.server.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
+	proxyKeys, err := f.testSrv.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
 		HostID:   hostID,
-		NodeName: s.server.ClusterName(),
-		Roles:    types.SystemRoles{types.RoleProxy},
+		NodeName: f.testSrv.ClusterName(),
+		Roles:    teleport.Roles{teleport.RoleProxy},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	proxySigner, err := sshutils.NewSigner(proxyKeys.Key, proxyKeys.Cert)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	logger := logrus.WithField("test", "TestProxyReverseTunnel")
-	listener, reverseTunnelAddress := s.mustListen(c)
+	listener, reverseTunnelAddress := mustListen(t)
 	defer listener.Close()
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
-		ClientTLS:                     s.proxyClient.TLSConfig(),
+		ClientTLS:                     proxyClient.TLSConfig(),
 		ID:                            hostID,
-		ClusterName:                   s.server.ClusterName(),
+		ClusterName:                   f.testSrv.ClusterName(),
 		Listener:                      listener,
 		HostSigners:                   []ssh.Signer{proxySigner},
-		LocalAuthClient:               s.proxyClient,
-		LocalAccessPoint:              s.proxyClient,
+		LocalAuthClient:               proxyClient,
+		LocalAccessPoint:              proxyClient,
 		NewCachingAccessPoint:         auth.NoCache,
 		NewCachingAccessPointOldProxy: auth.NoCache,
-		DirectClusters:                []reversetunnel.DirectCluster{{Name: s.server.ClusterName(), Client: s.proxyClient}},
-		DataDir:                       c.MkDir(),
+		DirectClusters:                []reversetunnel.DirectCluster{{Name: f.testSrv.ClusterName(), Client: proxyClient}},
+		DataDir:                       t.TempDir(),
 		Component:                     teleport.ComponentProxy,
-		Emitter:                       s.proxyClient,
+		Emitter:                       proxyClient,
 		Log:                           logger,
 	})
-	c.Assert(err, IsNil)
-	c.Assert(reverseTunnelServer.Start(), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, reverseTunnelServer.Start())
 	defer reverseTunnelServer.Close()
 
+	nodeClient, _ := newNodeClient(t, f.testSrv)
 	proxy, err := New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
-		s.server.ClusterName(),
-		[]ssh.Signer{s.signer},
-		s.proxyClient,
-		c.MkDir(),
+		f.testSrv.ClusterName(),
+		[]ssh.Signer{f.signer},
+		proxyClient,
+		t.TempDir(),
 		"",
 		utils.NetAddr{},
-		SetUUID(s.proxyID),
+		SetUUID(proxyID),
 		SetProxyMode(reverseTunnelServer),
-		SetSessionServer(s.proxyClient),
-		SetEmitter(s.nodeClient),
+		SetSessionServer(proxyClient),
+		SetEmitter(nodeClient),
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
-		SetClock(s.clock),
+		SetClock(f.clock),
 	)
-	c.Assert(err, IsNil)
-	c.Assert(proxy.Start(), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, proxy.Start())
 
 	// set up SSH client using the user private key for signing
-	up, err := s.newUpack(s.user, []string{s.user}, wildcardAllow)
-	c.Assert(err, IsNil)
+	up, err := newUpack(f.testSrv, f.user, []string{f.user}, wildcardAllow)
+	require.NoError(t, err)
 
 	rcWatcher, err := reversetunnel.NewRemoteClusterTunnelManager(reversetunnel.RemoteClusterTunnelManagerConfig{
-		AuthClient:          s.proxyClient,
+		AuthClient:          proxyClient,
 		HostSigner:          proxySigner,
-		HostUUID:            fmt.Sprintf("%v.%v", hostID, s.server.ClusterName()),
-		AccessPoint:         s.proxyClient,
+		HostUUID:            fmt.Sprintf("%v.%v", hostID, f.testSrv.ClusterName()),
+		AccessPoint:         proxyClient,
 		ReverseTunnelServer: reverseTunnelServer,
-		LocalCluster:        s.server.ClusterName(),
+		LocalCluster:        f.testSrv.ClusterName(),
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	go rcWatcher.Run(ctx)
@@ -764,40 +821,40 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 
 	// Create a reverse tunnel and remote cluster simulating what the trusted
 	// cluster exchange does.
-	err = s.server.Auth().UpsertReverseTunnel(
-		types.NewReverseTunnel(s.server.ClusterName(), []string{reverseTunnelAddress.String()}))
-	c.Assert(err, IsNil)
+	err = f.testSrv.Auth().UpsertReverseTunnel(
+		services.NewReverseTunnel(f.testSrv.ClusterName(), []string{reverseTunnelAddress.String()}))
+	require.NoError(t, err)
 	remoteCluster, err := types.NewRemoteCluster("localhost")
-	c.Assert(err, IsNil)
-	err = s.server.Auth().CreateRemoteCluster(remoteCluster)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
+	err = f.testSrv.Auth().CreateRemoteCluster(remoteCluster)
+	require.NoError(t, err)
 
 	err = rcWatcher.Sync(ctx)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Wait for both sites to show up.
 	err = waitForSites(reverseTunnelServer, 2)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	sshConfig := &ssh.ClientConfig{
-		User:            s.user,
+		User:            f.user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	_, err = s.newUpack("user1", []string{s.user}, wildcardAllow)
-	c.Assert(err, IsNil)
+	_, err = newUpack(f.testSrv, "user1", []string{f.user}, wildcardAllow)
+	require.NoError(t, err)
 
-	s.testClient(c, proxy.Addr(), s.srvAddress, s.srv.Addr(), sshConfig)
-	s.testClient(c, proxy.Addr(), s.srvHostPort, s.srv.Addr(), sshConfig)
+	testClient(t, f, proxy.Addr(), f.ssh.srvAddress, f.ssh.srv.Addr(), sshConfig)
+	testClient(t, f, proxy.Addr(), f.ssh.srvHostPort, f.ssh.srv.Addr(), sshConfig)
 
 	// adding new node
 	srv2, err := New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
 		"bob",
-		[]ssh.Signer{s.signer},
-		s.nodeClient,
-		c.MkDir(),
+		[]ssh.Signer{f.signer},
+		nodeClient,
+		t.TempDir(),
 		"",
 		utils.NetAddr{},
 		SetShell("/bin/sh"),
@@ -812,110 +869,118 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 					Command: []string{"expr", "2", "+", "3"}},
 			},
 		),
-		SetSessionServer(s.nodeClient),
+		SetSessionServer(nodeClient),
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
-		SetEmitter(s.nodeClient),
-		SetClock(s.clock),
+		SetEmitter(nodeClient),
+		SetClock(f.clock),
 	)
-	c.Assert(err, IsNil)
-	c.Assert(srv2.Start(), IsNil)
-	c.Assert(srv2.heartbeat.ForceSend(time.Second), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, srv2.Start())
+	require.NoError(t, srv2.heartbeat.ForceSend(time.Second))
 	defer srv2.Close()
+
 	// test proxysites
 	client, err := ssh.Dial("tcp", proxy.Addr(), sshConfig)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	se3, err := client.NewSession()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	defer se3.Close()
 
 	stdout := &bytes.Buffer{}
 	reader, err := se3.StdoutPipe()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	done := make(chan struct{})
 	go func() {
 		_, err := io.Copy(stdout, reader)
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 		close(done)
 	}()
 
 	// to make sure  labels have the right output
-	s.srv.syncUpdateLabels()
+	f.ssh.srv.syncUpdateLabels()
 	srv2.syncUpdateLabels()
-	c.Assert(s.srv.heartbeat.ForceSend(time.Second), IsNil)
-	c.Assert(srv2.heartbeat.ForceSend(time.Second), IsNil)
+	require.NoError(t, f.ssh.srv.heartbeat.ForceSend(time.Second))
+	require.NoError(t, srv2.heartbeat.ForceSend(time.Second))
+
 	// request "list of sites":
-	c.Assert(se3.RequestSubsystem("proxysites"), IsNil)
+	require.NoError(t, se3.RequestSubsystem("proxysites"))
 	<-done
 	var sites []types.Site
-	c.Assert(json.Unmarshal(stdout.Bytes(), &sites), IsNil)
-	c.Assert(sites, NotNil)
-	c.Assert(sites, HasLen, 2)
-	c.Assert(sites[0].Name, Equals, "localhost")
-	c.Assert(sites[0].Status, Equals, "online")
-	c.Assert(sites[1].Name, Equals, "localhost")
-	c.Assert(sites[1].Status, Equals, "online")
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &sites))
+	require.NotNil(t, sites)
+	require.Len(t, sites, 2)
 
-	c.Assert(time.Since(sites[0].LastConnected).Seconds() < 5, Equals, true)
-	c.Assert(time.Since(sites[1].LastConnected).Seconds() < 5, Equals, true)
+	require.Equal(t, "localhost", sites[0].Name)
+	require.Equal(t, "online", sites[0].Status)
+	require.Equal(t, "localhost", sites[1].Name)
+	require.Equal(t, "online", sites[1].Status)
 
-	err = s.server.Auth().DeleteReverseTunnel(s.server.ClusterName())
-	c.Assert(err, IsNil)
+	require.Less(t, time.Since(sites[0].LastConnected).Seconds(), 5.0)
+	require.Less(t, time.Since(sites[1].LastConnected).Seconds(), 5.0)
+
+	err = f.testSrv.Auth().DeleteReverseTunnel(f.testSrv.ClusterName())
+	require.NoError(t, err)
 
 	err = rcWatcher.Sync(ctx)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 }
 
-func (s *SrvSuite) TestProxyRoundRobin(c *C) {
+func TestProxyRoundRobin(t *testing.T) {
 	log.Infof("[TEST START] TestProxyRoundRobin")
+	f := newFixture(t)
+
+	proxyClient, _ := newProxyClient(t, f.testSrv)
+	nodeClient, _ := newNodeClient(t, f.testSrv)
 
 	logger := logrus.WithField("test", "TestProxyRoundRobin")
-	listener, reverseTunnelAddress := s.mustListen(c)
+	listener, reverseTunnelAddress := mustListen(t)
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
-		ClusterName:                   s.server.ClusterName(),
-		ClientTLS:                     s.proxyClient.TLSConfig(),
+		ClusterName:                   f.testSrv.ClusterName(),
+		ClientTLS:                     proxyClient.TLSConfig(),
 		ID:                            hostID,
 		Listener:                      listener,
-		HostSigners:                   []ssh.Signer{s.signer},
-		LocalAuthClient:               s.proxyClient,
-		LocalAccessPoint:              s.proxyClient,
+		HostSigners:                   []ssh.Signer{f.signer},
+		LocalAuthClient:               proxyClient,
+		LocalAccessPoint:              proxyClient,
 		NewCachingAccessPoint:         auth.NoCache,
 		NewCachingAccessPointOldProxy: auth.NoCache,
-		DirectClusters:                []reversetunnel.DirectCluster{{Name: s.server.ClusterName(), Client: s.proxyClient}},
-		DataDir:                       c.MkDir(),
-		Emitter:                       s.proxyClient,
+		DirectClusters:                []reversetunnel.DirectCluster{{Name: f.testSrv.ClusterName(), Client: proxyClient}},
+		DataDir:                       t.TempDir(),
+		Emitter:                       proxyClient,
 		Log:                           logger,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	logger.WithField("tun-addr", reverseTunnelAddress.String()).Info("Created reverse tunnel server.")
 
-	c.Assert(reverseTunnelServer.Start(), IsNil)
+	require.NoError(t, reverseTunnelServer.Start())
 	defer reverseTunnelServer.Close()
 
 	proxy, err := New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
-		s.server.ClusterName(),
-		[]ssh.Signer{s.signer},
-		s.proxyClient,
-		c.MkDir(),
+		f.testSrv.ClusterName(),
+		[]ssh.Signer{f.signer},
+		proxyClient,
+		t.TempDir(),
 		"",
 		utils.NetAddr{},
 		SetProxyMode(reverseTunnelServer),
-		SetSessionServer(s.proxyClient),
-		SetEmitter(s.nodeClient),
+		SetSessionServer(proxyClient),
+		SetEmitter(nodeClient),
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
-		SetClock(s.clock),
+		SetClock(f.clock),
 	)
-	c.Assert(err, IsNil)
-	c.Assert(proxy.Start(), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, proxy.Start())
+	defer proxy.Close()
 
 	// set up SSH client using the user private key for signing
-	up, err := s.newUpack(s.user, []string{s.user}, wildcardAllow)
-	c.Assert(err, IsNil)
+	up, err := newUpack(f.testSrv, f.user, []string{f.user}, wildcardAllow)
+	require.NoError(t, err)
 
 	// start agent and load balance requests
 	eventsC := make(chan string, 2)
@@ -923,28 +988,28 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 		Context:     context.TODO(),
 		Addr:        reverseTunnelAddress,
 		ClusterName: "remote",
-		Username:    fmt.Sprintf("%v.%v", hostID, s.server.ClusterName()),
-		Signer:      s.signer,
-		Client:      s.proxyClient,
-		AccessPoint: s.proxyClient,
+		Username:    fmt.Sprintf("%v.%v", hostID, f.testSrv.ClusterName()),
+		Signer:      f.signer,
+		Client:      proxyClient,
+		AccessPoint: proxyClient,
 		EventsC:     eventsC,
 		Log:         logger,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	rsAgent.Start()
 
 	rsAgent2, err := reversetunnel.NewAgent(reversetunnel.AgentConfig{
 		Context:     context.TODO(),
 		Addr:        reverseTunnelAddress,
 		ClusterName: "remote",
-		Username:    fmt.Sprintf("%v.%v", hostID, s.server.ClusterName()),
-		Signer:      s.signer,
-		Client:      s.proxyClient,
-		AccessPoint: s.proxyClient,
+		Username:    fmt.Sprintf("%v.%v", hostID, f.testSrv.ClusterName()),
+		Signer:      f.signer,
+		Client:      proxyClient,
+		AccessPoint: proxyClient,
 		EventsC:     eventsC,
 		Log:         logger,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	rsAgent2.Start()
 	defer rsAgent2.Close()
 
@@ -952,148 +1017,161 @@ func (s *SrvSuite) TestProxyRoundRobin(c *C) {
 	for i := 0; i < 2; i++ {
 		select {
 		case event := <-eventsC:
-			c.Assert(event, Equals, reversetunnel.ConnectedEvent)
+			require.Equal(t, reversetunnel.ConnectedEvent, event)
 		case <-timeout:
-			c.Fatalf("timeout waiting for clusters to connect")
+			require.FailNow(t, "timeout waiting for clusters to connect")
 		}
 	}
 
 	sshConfig := &ssh.ClientConfig{
-		User:            s.user,
+		User:            f.user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	_, err = s.newUpack("user1", []string{s.user}, wildcardAllow)
-	c.Assert(err, IsNil)
+	_, err = newUpack(f.testSrv, "user1", []string{f.user}, wildcardAllow)
+	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
-		s.testClient(c, proxy.Addr(), s.srvAddress, s.srv.Addr(), sshConfig)
+		testClient(t, f, proxy.Addr(), f.ssh.srvAddress, f.ssh.srv.Addr(), sshConfig)
 	}
 	// close first connection, and test it again
 	rsAgent.Close()
 
 	for i := 0; i < 3; i++ {
-		s.testClient(c, proxy.Addr(), s.srvAddress, s.srv.Addr(), sshConfig)
+		testClient(t, f, proxy.Addr(), f.ssh.srvAddress, f.ssh.srv.Addr(), sshConfig)
 	}
 }
 
 // TestProxyDirectAccess tests direct access via proxy bypassing
 // reverse tunnel
-func (s *SrvSuite) TestProxyDirectAccess(c *C) {
-	listener, _ := s.mustListen(c)
+func TestProxyDirectAccess(t *testing.T) {
+	f := newFixture(t)
+
+	listener, _ := mustListen(t)
 	logger := logrus.WithField("test", "TestProxyDirectAccess")
+	proxyClient, _ := newProxyClient(t, f.testSrv)
 	reverseTunnelServer, err := reversetunnel.NewServer(reversetunnel.Config{
-		ClientTLS:                     s.proxyClient.TLSConfig(),
+		ClientTLS:                     proxyClient.TLSConfig(),
 		ID:                            hostID,
-		ClusterName:                   s.server.ClusterName(),
+		ClusterName:                   f.testSrv.ClusterName(),
 		Listener:                      listener,
-		HostSigners:                   []ssh.Signer{s.signer},
-		LocalAuthClient:               s.proxyClient,
-		LocalAccessPoint:              s.proxyClient,
+		HostSigners:                   []ssh.Signer{f.signer},
+		LocalAuthClient:               proxyClient,
+		LocalAccessPoint:              proxyClient,
 		NewCachingAccessPoint:         auth.NoCache,
 		NewCachingAccessPointOldProxy: auth.NoCache,
-		DirectClusters:                []reversetunnel.DirectCluster{{Name: s.server.ClusterName(), Client: s.proxyClient}},
-		DataDir:                       c.MkDir(),
-		Emitter:                       s.proxyClient,
+		DirectClusters:                []reversetunnel.DirectCluster{{Name: f.testSrv.ClusterName(), Client: proxyClient}},
+		DataDir:                       t.TempDir(),
+		Emitter:                       proxyClient,
 		Log:                           logger,
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
-	c.Assert(reverseTunnelServer.Start(), IsNil)
+	require.NoError(t, reverseTunnelServer.Start())
 	defer reverseTunnelServer.Close()
+
+	nodeClient, _ := newNodeClient(t, f.testSrv)
 
 	proxy, err := New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
-		s.server.ClusterName(),
-		[]ssh.Signer{s.signer},
-		s.proxyClient,
-		c.MkDir(),
+		f.testSrv.ClusterName(),
+		[]ssh.Signer{f.signer},
+		proxyClient,
+		t.TempDir(),
 		"",
 		utils.NetAddr{},
 		SetProxyMode(reverseTunnelServer),
-		SetSessionServer(s.proxyClient),
-		SetEmitter(s.nodeClient),
+		SetSessionServer(proxyClient),
+		SetEmitter(nodeClient),
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
-		SetClock(s.clock),
+		SetClock(f.clock),
 	)
-	c.Assert(err, IsNil)
-	c.Assert(proxy.Start(), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, proxy.Start())
 	defer proxy.Close()
 
 	// set up SSH client using the user private key for signing
-	up, err := s.newUpack(s.user, []string{s.user}, wildcardAllow)
-	c.Assert(err, IsNil)
+	up, err := newUpack(f.testSrv, f.user, []string{f.user}, wildcardAllow)
+	require.NoError(t, err)
 
 	sshConfig := &ssh.ClientConfig{
-		User:            s.user,
+		User:            f.user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(up.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
-	_, err = s.newUpack("user1", []string{s.user}, wildcardAllow)
-	c.Assert(err, IsNil)
+	_, err = newUpack(f.testSrv, "user1", []string{f.user}, wildcardAllow)
+	require.NoError(t, err)
 
-	s.testClient(c, proxy.Addr(), s.srvAddress, s.srv.Addr(), sshConfig)
+	testClient(t, f, proxy.Addr(), f.ssh.srvAddress, f.ssh.srv.Addr(), sshConfig)
 }
 
 // TestPTY requests PTY for an interactive session
-func (s *SrvSuite) TestPTY(c *C) {
-	se, err := s.clt.NewSession()
-	c.Assert(err, IsNil)
+func TestPTY(t *testing.T) {
+	f := newFixture(t)
+	se, err := f.ssh.clt.NewSession()
+	require.NoError(t, err)
 	defer se.Close()
 
 	// request PTY with valid size
-	c.Assert(se.RequestPty("xterm", 30, 30, ssh.TerminalModes{}), IsNil)
+	require.NoError(t, se.RequestPty("xterm", 30, 30, ssh.TerminalModes{}))
 
 	// request PTY with invalid size, should still work (selects defaults)
-	c.Assert(se.RequestPty("xterm", 0, 0, ssh.TerminalModes{}), IsNil)
+	require.NoError(t, se.RequestPty("xterm", 0, 0, ssh.TerminalModes{}))
 }
 
 // TestEnv requests setting environment variables. (We are currently ignoring these requests)
-func (s *SrvSuite) TestEnv(c *C) {
-	se, err := s.clt.NewSession()
-	c.Assert(err, IsNil)
+func TestEnv(t *testing.T) {
+	f := newFixture(t)
+
+	se, err := f.ssh.clt.NewSession()
+	require.NoError(t, err)
 	defer se.Close()
 
-	c.Assert(se.Setenv("HOME", "/"), IsNil)
+	require.NoError(t, se.Setenv("HOME", "/"))
 }
 
-// TestNoAuth tries to log in with no auth methods and should be rejected
-func (s *SrvSuite) TestNoAuth(c *C) {
-	_, err := ssh.Dial("tcp", s.srv.Addr(), &ssh.ClientConfig{})
-	c.Assert(err, NotNil)
+// // TestNoAuth tries to log in with no auth methods and should be rejected
+func TestNoAuth(t *testing.T) {
+	f := newFixture(t)
+	_, err := ssh.Dial("tcp", f.ssh.srv.Addr(), &ssh.ClientConfig{})
+	require.Error(t, err)
 }
 
 // TestPasswordAuth tries to log in with empty pass and should be rejected
-func (s *SrvSuite) TestPasswordAuth(c *C) {
+func TestPasswordAuth(t *testing.T) {
+	f := newFixture(t)
 	config := &ssh.ClientConfig{
 		Auth:            []ssh.AuthMethod{ssh.Password("")},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
-	_, err := ssh.Dial("tcp", s.srv.Addr(), config)
-	c.Assert(err, NotNil)
+	_, err := ssh.Dial("tcp", f.ssh.srv.Addr(), config)
+	require.Error(t, err)
 }
 
-func (s *SrvSuite) TestClientDisconnect(c *C) {
+func TestClientDisconnect(t *testing.T) {
+	f := newFixture(t)
 	config := &ssh.ClientConfig{
-		User:            s.user,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(s.up.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		User:            f.user,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(f.up.certSigner)},
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
-	clt, err := ssh.Dial("tcp", s.srv.Addr(), config)
-	c.Assert(clt, NotNil)
-	c.Assert(err, IsNil)
+	clt, err := ssh.Dial("tcp", f.ssh.srv.Addr(), config)
+	require.NoError(t, err)
+	require.NotNil(t, clt)
 
-	se, err := s.clt.NewSession()
-	c.Assert(err, IsNil)
-	c.Assert(se.Shell(), IsNil)
-	c.Assert(clt.Close(), IsNil)
+	se, err := f.ssh.clt.NewSession()
+	require.NoError(t, err)
+	require.NoError(t, se.Shell())
+	require.NoError(t, clt.Close())
 }
 
-func (s *SrvSuite) TestLimiter(c *C) {
+func TestLimiter(t *testing.T) {
+	f := newFixture(t)
+
 	limiter, err := limiter.NewLimiter(
 		limiter.Config{
 			MaxConnections: 2,
@@ -1111,86 +1189,88 @@ func (s *SrvSuite) TestLimiter(c *C) {
 			},
 		},
 	)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
-	nodeStateDir := c.MkDir()
+	nodeClient, _ := newNodeClient(t, f.testSrv)
+	nodeStateDir := t.TempDir()
 	srv, err := New(
 		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
-		s.server.ClusterName(),
-		[]ssh.Signer{s.signer},
-		s.nodeClient,
+		f.testSrv.ClusterName(),
+		[]ssh.Signer{f.signer},
+		nodeClient,
 		nodeStateDir,
 		"",
 		utils.NetAddr{},
 		SetLimiter(limiter),
 		SetShell("/bin/sh"),
-		SetSessionServer(s.nodeClient),
-		SetEmitter(s.nodeClient),
+		SetSessionServer(nodeClient),
+		SetEmitter(nodeClient),
 		SetNamespace(defaults.Namespace),
 		SetPAMConfig(&pam.Config{Enabled: false}),
 		SetBPF(&bpf.NOP{}),
-		SetClock(s.clock),
+		SetClock(f.clock),
 	)
-	c.Assert(err, IsNil)
-	c.Assert(srv.Start(), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, srv.Start())
 
-	c.Assert(auth.CreateUploaderDir(nodeStateDir), IsNil)
+	require.NoError(t, auth.CreateUploaderDir(nodeStateDir))
 	defer srv.Close()
 
 	// maxConnection = 3
 	// current connections = 1 (one connection is opened from SetUpTest)
 	config := &ssh.ClientConfig{
-		User:            s.user,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(s.up.certSigner)},
-		HostKeyCallback: ssh.FixedHostKey(s.signer.PublicKey()),
+		User:            f.user,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(f.up.certSigner)},
+		HostKeyCallback: ssh.FixedHostKey(f.signer.PublicKey()),
 	}
 
 	clt0, err := ssh.Dial("tcp", srv.Addr(), config)
-	c.Assert(clt0, NotNil)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
+	require.NotNil(t, clt0)
+
 	se0, err := clt0.NewSession()
-	c.Assert(err, IsNil)
-	c.Assert(se0.Shell(), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, se0.Shell())
 
 	// current connections = 2
 	clt, err := ssh.Dial("tcp", srv.Addr(), config)
-	c.Assert(clt, NotNil)
-	c.Assert(err, IsNil)
+	require.NotNil(t, clt)
+	require.NoError(t, err)
 	se, err := clt.NewSession()
-	c.Assert(err, IsNil)
-	c.Assert(se.Shell(), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, se.Shell())
 
 	// current connections = 3
 	_, err = ssh.Dial("tcp", srv.Addr(), config)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
-	c.Assert(se.Close(), IsNil)
-	c.Assert(clt.Close(), IsNil)
+	require.NoError(t, se.Close())
+	require.NoError(t, clt.Close())
 	time.Sleep(50 * time.Millisecond)
 
 	// current connections = 2
 	clt, err = ssh.Dial("tcp", srv.Addr(), config)
-	c.Assert(clt, NotNil)
-	c.Assert(err, IsNil)
+	require.NotNil(t, clt)
+	require.NoError(t, err)
 	se, err = clt.NewSession()
-	c.Assert(err, IsNil)
-	c.Assert(se.Shell(), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, se.Shell())
 
 	// current connections = 3
 	_, err = ssh.Dial("tcp", srv.Addr(), config)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
-	c.Assert(se.Close(), IsNil)
-	c.Assert(clt.Close(), IsNil)
+	require.NoError(t, se.Close())
+	require.NoError(t, clt.Close())
 	time.Sleep(50 * time.Millisecond)
 
 	// current connections = 2
 	// requests rate should exceed now
 	clt, err = ssh.Dial("tcp", srv.Addr(), config)
-	c.Assert(clt, NotNil)
-	c.Assert(err, IsNil)
+	require.NotNil(t, clt)
+	require.NoError(t, err)
 	_, err = clt.NewSession()
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	clt.Close()
 }
@@ -1198,51 +1278,53 @@ func (s *SrvSuite) TestLimiter(c *C) {
 // TestServerAliveInterval simulates ServerAliveInterval and OpenSSH
 // interoperability by sending a keepalive@openssh.com global request to the
 // server and expecting a response in return.
-func (s *SrvSuite) TestServerAliveInterval(c *C) {
-	ok, _, err := s.clt.SendRequest(teleport.KeepAliveReqType, true, nil)
-	c.Assert(err, IsNil)
-	c.Assert(ok, Equals, true)
+func TestServerAliveInterval(t *testing.T) {
+	f := newFixture(t)
+	ok, _, err := f.ssh.clt.SendRequest(teleport.KeepAliveReqType, true, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 // TestGlobalRequestRecordingProxy simulates sending a global out-of-band
 // recording-proxy@teleport.com request.
-func (s *SrvSuite) TestGlobalRequestRecordingProxy(c *C) {
+func TestGlobalRequestRecordingProxy(t *testing.T) {
 	ctx := context.Background()
+	f := newFixture(t)
 
 	// set cluster config to record at the node
 	recConfig, err := types.NewSessionRecordingConfig(types.SessionRecordingConfigSpecV2{
 		Mode: types.RecordAtNode,
 	})
-	c.Assert(err, IsNil)
-	err = s.server.Auth().SetSessionRecordingConfig(ctx, recConfig)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
+	err = f.testSrv.Auth().SetSessionRecordingConfig(ctx, recConfig)
+	require.NoError(t, err)
 
 	// send the request again, we have cluster config and when we parse the
 	// response, it should be false because recording is occurring at the node.
-	ok, responseBytes, err := s.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
-	c.Assert(err, IsNil)
-	c.Assert(ok, Equals, true)
+	ok, responseBytes, err := f.ssh.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
 	response, err := strconv.ParseBool(string(responseBytes))
-	c.Assert(err, IsNil)
-	c.Assert(response, Equals, false)
+	require.NoError(t, err)
+	require.False(t, response)
 
 	// set cluster config to record at the proxy
 	recConfig, err = types.NewSessionRecordingConfig(types.SessionRecordingConfigSpecV2{
 		Mode: types.RecordAtProxy,
 	})
-	c.Assert(err, IsNil)
-	err = s.server.Auth().SetSessionRecordingConfig(ctx, recConfig)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
+	err = f.testSrv.Auth().SetSessionRecordingConfig(ctx, recConfig)
+	require.NoError(t, err)
 
 	// send request again, now that we have cluster config and it's set to record
 	// at the proxy, we should return true and when we parse the payload it should
 	// also be true
-	ok, responseBytes, err = s.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
-	c.Assert(err, IsNil)
-	c.Assert(ok, Equals, true)
+	ok, responseBytes, err = f.ssh.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
 	response, err = strconv.ParseBool(string(responseBytes))
-	c.Assert(err, IsNil)
-	c.Assert(response, Equals, true)
+	require.NoError(t, err)
+	require.True(t, response)
 }
 
 // rawNode is a basic non-teleport node which holds a
@@ -1252,6 +1334,7 @@ type rawNode struct {
 	listener net.Listener
 	cfg      ssh.ServerConfig
 	addr     string
+	errCh    chan error
 }
 
 // accept an incoming connection and perform a basic ssh handshake
@@ -1273,22 +1356,22 @@ func (r *rawNode) Close() error {
 }
 
 // newRawNode constructs a new raw node instance.
-func (s *SrvSuite) newRawNode(c *C) *rawNode {
+func newRawNode(t *testing.T, authSrv *auth.Server) *rawNode {
 	hostname, err := os.Hostname()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Create host key and certificate for node.
-	keys, err := s.server.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
+	keys, err := authSrv.GenerateServerKeys(auth.GenerateServerKeysRequest{
 		HostID:               "raw-node",
 		NodeName:             "raw-node",
 		Roles:                types.SystemRoles{types.RoleNode},
 		AdditionalPrincipals: []string{hostname},
 		DNSNames:             []string{hostname},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	signer, err := sshutils.NewSigner(keys.Key, keys.Cert)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// configure a server which allows any client to connect
 	cfg := ssh.ServerConfig{
@@ -1303,10 +1386,10 @@ func (s *SrvSuite) newRawNode(c *C) *rawNode {
 	cfg.AddHostKey(signer)
 
 	listener, err := net.Listen("tcp", ":0")
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	_, port, err := net.SplitHostPort(listener.Addr().String())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	addr := net.JoinHostPort(hostname, port)
 
@@ -1314,17 +1397,78 @@ func (s *SrvSuite) newRawNode(c *C) *rawNode {
 		listener: listener,
 		cfg:      cfg,
 		addr:     addr,
+		errCh:    make(chan error),
 	}
 }
 
-// startX11EchoServer starts a fake node which, for each incomging SSH connection, accepts an
+// startX11EchoServer starts a fake node which, for each incoming SSH connection, accepts an
 // X11 forwarding request and then dials a single X11 channel which echoes all bytes written
-// to it.  Used to verify the behavior of X11 forwarding in recording proxies.
-func (s *SrvSuite) startX11EchoServer(ctx context.Context, c *C) *rawNode {
-	node := s.newRawNode(c)
-	go func() {
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+// to it.  Used to verify the behavior of X11 forwarding in recording proxies. Returns a
+// node and an error channel that can be monitored for asynchronous failures.
+func startX11EchoServer(t *testing.T, ctx context.Context, authSrv *auth.Server) (*rawNode, <-chan error) {
+	node := newRawNode(t, authSrv)
+
+	sessionMain := func(ctx context.Context, conn *ssh.ServerConn, chs <-chan ssh.NewChannel) error {
+		defer conn.Close()
+
+		// expect client to open a session channel
+		var nch ssh.NewChannel
+		select {
+		case nch = <-chs:
+		case <-time.After(time.Second * 3):
+			return trace.LimitExceeded("Timeout waiting for session channel")
+		case <-ctx.Done():
+			return nil
+		}
+		if nch.ChannelType() != teleport.ChanSession {
+			return trace.BadParameter("Unexpected channel type: %q", nch.ChannelType())
+		}
+
+		sch, creqs, err := nch.Accept()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer sch.Close()
+
+		// expect client to send an X11 forwarding request
+		var req *ssh.Request
+		select {
+		case req = <-creqs:
+		case <-time.After(time.Second * 3):
+			return trace.LimitExceeded("Timeout waiting for x11 forwarding request")
+		case <-ctx.Done():
+			return nil
+		}
+
+		if req.Type != sshutils.X11ForwardRequest {
+			return trace.BadParameter("Unexpected request type %q", req.Type)
+		}
+
+		if err = req.Reply(true, nil); err != nil {
+			return trace.Wrap(err)
+		}
+
+		// start a fake X11 channel
+		xch, _, err := conn.OpenChannel(sshutils.X11ChannelRequest, nil)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer xch.Close()
+
+		// echo all bytes back across the X11 channel
+		_, err = io.Copy(xch, xch)
+		if err == nil {
+			xch.CloseWrite()
+		} else {
+			log.Errorf("X11 channel error: %v", err)
+		}
+
+		return nil
+	}
+
+	errorCh := make(chan error, 1)
+
+	nodeMain := func() {
 		for {
 			conn, chs, _, err := node.accept()
 			if err != nil {
@@ -1332,57 +1476,59 @@ func (s *SrvSuite) startX11EchoServer(ctx context.Context, c *C) *rawNode {
 				return
 			}
 			go func() {
-				defer conn.Close()
-
-				// expect client to open a session channel
-				var nch ssh.NewChannel
-				select {
-				case nch = <-chs:
-				case <-time.After(time.Second * 3):
-					c.Fatalf("Timeout waiting for session channel")
-				case <-ctx.Done():
-					return
-				}
-				c.Assert(nch.ChannelType(), Equals, teleport.ChanSession)
-
-				sch, creqs, err := nch.Accept()
-				c.Assert(err, IsNil)
-				defer sch.Close()
-
-				// expect client to send an X11 forwarding request
-				var req *ssh.Request
-				select {
-				case req = <-creqs:
-				case <-time.After(time.Second * 3):
-					c.Fatalf("Timeout waiting for x11 forwarding request")
-				case <-ctx.Done():
-					return
-				}
-
-				c.Assert(req.Type, Equals, sshutils.X11ForwardRequest)
-				c.Assert(req.Reply(true, nil), IsNil)
-
-				// start a fake X11 channel
-				xch, _, err := conn.OpenChannel(sshutils.X11ChannelRequest, nil)
-				c.Assert(err, IsNil)
-
-				defer xch.Close()
-				// echo all bytes back across the X11 channel
-				_, err = io.Copy(xch, xch)
-				if err == nil {
-					xch.CloseWrite()
-				} else {
-					log.Errorf("X11 channel error: %v", err)
+				if err := sessionMain(ctx, conn, chs); err != nil {
+					errorCh <- err
 				}
 			}()
 		}
+	}
+
+	go nodeMain()
+
+	return node, errorCh
+}
+
+// startGatheringErrors starts a goroutine that pulls error values from a
+// channel and aggregates them. Returns a channel where the goroutine will post
+// the aggregated errors when the routine is stopped.
+func startGatheringErrors(ctx context.Context, errCh <-chan error) <-chan []error {
+	doneGathering := make(chan []error)
+	go func() {
+		errors := []error{}
+		for {
+			select {
+			case err := <-errCh:
+				errors = append(errors, err)
+
+			case <-ctx.Done():
+				doneGathering <- errors
+				return
+			}
+		}
 	}()
-	return node
+	return doneGathering
+}
+
+// requireNoErrors waits for any aggregated errors to appear on the supplied channel
+// and asserts that the aggregation is empty
+func requireNoErrors(t *testing.T, errsCh <-chan []error) {
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	select {
+	case errs := <-errsCh:
+		require.Empty(t, errs)
+
+	case <-timeoutCtx.Done():
+		require.Fail(t, "Timed out waiting for errors")
+	}
 }
 
 // TestX11ProxySupport verifies that recording proxies correctly forward
 // X11 request/channels.
-func (s *SrvSuite) TestX11ProxySupport(c *C) {
+func TestX11ProxySupport(t *testing.T) {
+	f := newFixture(t)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1390,76 +1536,86 @@ func (s *SrvSuite) TestX11ProxySupport(c *C) {
 	recConfig, err := types.NewSessionRecordingConfig(types.SessionRecordingConfigSpecV2{
 		Mode: types.RecordAtProxy,
 	})
-	c.Assert(err, IsNil)
-	err = s.server.Auth().SetSessionRecordingConfig(ctx, recConfig)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
+	err = f.testSrv.Auth().SetSessionRecordingConfig(ctx, recConfig)
+	require.NoError(t, err)
 
 	// verify that the proxy is in recording mode
-	ok, responseBytes, err := s.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
-	c.Assert(err, IsNil)
-	c.Assert(ok, Equals, true)
+	ok, responseBytes, err := f.ssh.clt.SendRequest(teleport.RecordingProxyReqType, true, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
 	response, err := strconv.ParseBool(string(responseBytes))
-	c.Assert(err, IsNil)
-	c.Assert(response, Equals, true)
+	require.NoError(t, err)
+	require.True(t, response)
 
-	// setup our fake X11 echo server
-	node := s.startX11EchoServer(ctx, c)
+	// setup our fake X11 echo server.
+	x11Ctx, x11Cancel := context.WithCancel(ctx)
+	node, errCh := startX11EchoServer(t, x11Ctx, f.testSrv.Auth())
+
+	// start gathering errors from the X11 server
+	doneGathering := startGatheringErrors(x11Ctx, errCh)
+	defer requireNoErrors(t, doneGathering)
+
+	// The error gathering routine needs this context to expire or it will wait
+	// forever on the x11 server to exit. Hence we defer a call to the x11cancel
+	// here rather than directly below the context creation
+	defer x11Cancel()
 
 	// Create a direct TCP/IP connection from proxy to our X11 test server.
-	netConn, err := s.clt.Dial("tcp", node.addr)
-	c.Assert(err, IsNil)
+	netConn, err := f.ssh.clt.Dial("tcp", node.addr)
+	require.NoError(t, err)
 	defer netConn.Close()
 
 	// make an insecure version of our client config (this test is only about X11 forwarding,
 	// so we don't bother to verify recording proxy key generation here).
-	cltConfig := *s.cltConfig
+	cltConfig := *f.ssh.cltConfig
 	cltConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 
 	// Perform ssh handshake and setup client for X11 test server.
 	cltConn, chs, reqs, err := ssh.NewClientConn(netConn, node.addr, &cltConfig)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	clt := ssh.NewClient(cltConn, chs, reqs)
 
 	sess, err := clt.NewSession()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// register X11 channel handler before requesting forwarding to avoid races
 	xchs := clt.HandleChannelOpen(sshutils.X11ChannelRequest)
-	c.Assert(xchs, NotNil)
+	require.NotNil(t, xchs)
 
 	// Send an X11 forwarding request to the server
 	ok, err = sess.SendRequest(sshutils.X11ForwardRequest, true, nil)
-	c.Assert(err, IsNil)
-	c.Assert(ok, Equals, true)
+	require.NoError(t, err)
+	require.True(t, ok)
 
 	// wait for server to start an X11 channel
 	var xnc ssh.NewChannel
 	select {
 	case xnc = <-xchs:
 	case <-time.After(time.Second * 3):
-		c.Fatalf("Timeout waiting for X11 channel open from %v", node.addr)
+		require.Fail(t, "Timeout waiting for X11 channel open from %v", node.addr)
 	}
-	c.Assert(xnc, NotNil)
-	c.Assert(xnc.ChannelType(), Equals, sshutils.X11ChannelRequest)
+	require.NotNil(t, xnc)
+	require.Equal(t, sshutils.X11ChannelRequest, xnc.ChannelType())
 
 	xch, _, err := xnc.Accept()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	defer xch.Close()
 
 	// write some data to the channel
 	msg := []byte("testing!")
 	_, err = xch.Write(msg)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// send EOF
-	c.Assert(xch.CloseWrite(), IsNil)
+	require.NoError(t, xch.CloseWrite())
 
 	// expect node to successfully echo the data
 	rsp := make([]byte, len(msg))
 	_, err = io.ReadFull(xch, rsp)
-	c.Assert(err, IsNil)
-	c.Assert(string(msg), Equals, string(rsp))
+	require.NoError(t, err)
+	require.Equal(t, string(msg), string(rsp))
 }
 
 // upack holds all ssh signing artefacts needed for signing and checking user keys
@@ -1486,9 +1642,9 @@ type upack struct {
 	certSigner ssh.Signer
 }
 
-func (s *SrvSuite) newUpack(username string, allowedLogins []string, allowedLabels types.Labels) (*upack, error) {
+func newUpack(testSvr *auth.TestServer, username string, allowedLogins []string, allowedLabels types.Labels) (*upack, error) {
 	ctx := context.Background()
-	auth := s.server.Auth()
+	auth := testSvr.Auth()
 	upriv, upub, err := auth.GenerateKeyPair("")
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1515,7 +1671,7 @@ func (s *SrvSuite) newUpack(username string, allowedLogins []string, allowedLabe
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	ucert, err := s.server.AuthServer.GenerateUserCert(upub, user.GetName(), 5*time.Minute, constants.CertificateFormatStandard)
+	ucert, err := testSvr.AuthServer.GenerateUserCert(upub, user.GetName(), 5*time.Minute, constants.CertificateFormatStandard)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1405,7 +1405,7 @@ func newRawNode(t *testing.T, authSrv *auth.Server) *rawNode {
 // X11 forwarding request and then dials a single X11 channel which echoes all bytes written
 // to it.  Used to verify the behavior of X11 forwarding in recording proxies. Returns a
 // node and an error channel that can be monitored for asynchronous failures.
-func startX11EchoServer(t *testing.T, ctx context.Context, authSrv *auth.Server) (*rawNode, <-chan error) {
+func startX11EchoServer(ctx context.Context, t *testing.T, authSrv *auth.Server) (*rawNode, <-chan error) {
 	node := newRawNode(t, authSrv)
 
 	sessionMain := func(ctx context.Context, conn *ssh.ServerConn, chs <-chan ssh.NewChannel) error {
@@ -1550,7 +1550,7 @@ func TestX11ProxySupport(t *testing.T) {
 
 	// setup our fake X11 echo server.
 	x11Ctx, x11Cancel := context.WithCancel(ctx)
-	node, errCh := startX11EchoServer(t, x11Ctx, f.testSrv.Auth())
+	node, errCh := startX11EchoServer(x11Ctx, t, f.testSrv.Auth())
 
 	// start gathering errors from the X11 server
 	doneGathering := startGatheringErrors(x11Ctx, errCh)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -51,12 +51,11 @@ import (
 	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/trace"
-
 	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"github.com/pborman/uuid"
 )
 

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -54,9 +54,9 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"github.com/pborman/uuid"
 )
 
 // teleportTestUser is additional user used for tests

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -203,7 +203,7 @@ func newCustomFixture(t *testing.T, mutateCfg func(*auth.TestServerConfig), sshO
 
 	client, err := ssh.Dial("tcp", sshSrv.Addr(), cltConfig)
 	require.NoError(t, err)
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
 	require.NoError(t, agent.ForwardToAgent(client, keyring))
 
 	return &sshTestFixture{


### PR DESCRIPTION
Refactors the SSH tests to use the standard library `testing` package.

I couldn't make the existing GoCheck test suite do what I needed when writing a test for #6091. Not, at least, without duplicating a heap of code and breaking a lot of stuff. So rather than spend ages trying to inject the flexibility I needed into a deprecated test library, I used that time to remove it entirely.

The main changes in the PR are:
 * Removal of the `Check` test suite. All tests in the suite are now simple, standalone tests (which, incidentally, makes them _heaps_ easier to run in a debugger as I found out :smiley:).
 * The test setup provided by `GoCheck` has been replaced by a fixture that can be created & customised on a per-test basis.
 * The test teardown provided by `GoCheck` has been replaced by the `testing` package's cleanup functions
 * Test setup that is only used in a few tests (e.g. the `proxyClient`) has been moved from the fixture an into independent functions so as not to complicate the tests that don't need it.
 * Test fixture names have been updated in an attempt to be less ambiguous (e.g. you don't have to just _remember_ which one of `svr` and `sever` is the SSH server and which is the auth server any more) 
 * Asynchronous errors in the  X11 tests are now marshaled back into the main test goroutine for assertion.
 * Parallelises test execution

