### PR TITLE
Support role bootstrapping in OSS

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -818,6 +818,11 @@ func checkResourceConsistency(clusterName string, resources ...services.Resource
 			if r.GetName() == clusterName {
 				return trace.BadParameter("trusted cluster has same name as local cluster (%q)", clusterName)
 			}
+		case services.Role:
+			// Some options are only available with enterprise subscription
+			if err := checkRoleFeatureSupport(r); err != nil {
+				return trace.Wrap(err)
+			}
 		default:
 			// No validation checks for this resource type
 		}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -418,6 +418,25 @@ func init() {
 		return rsc, nil
 	})
 
+	RegisterResourceMarshaler(KindRole, func(r Resource, opts ...MarshalOption) ([]byte, error) {
+		rsc, ok := r.(Role)
+		if !ok {
+			return nil, trace.BadParameter("expected Role, got %T", r)
+		}
+		raw, err := MarshalRole(rsc, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return raw, nil
+	})
+	RegisterResourceUnmarshaler(KindRole, func(b []byte, opts ...MarshalOption) (Resource, error) {
+		rsc, err := UnmarshalRole(b, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return rsc, nil
+	})
+
 	RegisterResourceMarshaler(KindCertAuthority, func(r Resource, opts ...MarshalOption) ([]byte, error) {
 		rsc, ok := r.(CertAuthority)
 		if !ok {


### PR DESCRIPTION
Adds support for roles in the OSS variant of the `--bootstrap` flag.  Supersedes #7036.