### PR TITLE
makefile: explicitly set SHELL to /bin/bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 
 # These are standard autotools variables, don't change them please
+ifneq ("$(wildcard /bin/bash)","")
+SHELL := /bin/bash
+endif
 BUILDDIR ?= build
 ASSETS_BUILDDIR ?= lib/web/build
 BINDIR ?= /usr/local/bin

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -1,6 +1,9 @@
 #
 # This Makefile is used for producing official Teleport releases
 #
+ifneq ("$(wildcard /bin/bash)","")
+SHELL := /bin/bash
+endif
 HOSTNAME=buildbox
 SRCDIR=/go/src/github.com/gravitational/teleport
 GOMODCACHE ?= /tmp/gomodcache


### PR DESCRIPTION
When `SHELL` is not set, `make` defaults to `/bin/sh`.

On systems where `/bin/sh` is an alias for `/bin/bash`, everything works
as expected.

On systems where `/bin/sh` is actually the original Bourne Shell, some
bash-isms don't work. For example: `if [[ condition ]]` results in
`/bin/sh: 1: [[: not found`