### PR TITLE
[v6.2] docs: correct and update links - fix

### DIFF
--- a/docs/pages/includes/permission-warning.mdx
+++ b/docs/pages/includes/permission-warning.mdx
@@ -8,5 +8,5 @@
   3. We encourage adherence to the *Principle of Least Privilege* (PoLP) and *Zero Admin* best practices. Don't give users the `admin` role when giving them the more restrictive `access,editor` roles will do instead.
   4. Saving tokens into a file rather than sharing tokens directly *as strings*.
 
-  Learn more about [Teleport Role-Based Access Control](../access-controls/introduction.mdx) best practices.
+  Learn more about [Teleport Role-Based Access Control](https://goteleport.com/docs/access-controls/introduction/) best practices.
 </Admonition>

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -59,7 +59,7 @@ Teleport is a Certificate Authority and an Access Plane for your infrastructure.
   </TileListItem>
   </TileList>
   <TileList title="For security teams" icon="lock">
-    <TileListItem href="./server-access/guides/openssh-teleport.mdx">
+    <TileListItem href="./server-access/guides/openssh.mdx">
      Capture sessions and manage certificates for existing OpenSSH fleet.
     </TileListItem>
     <TileListItem href="./architecture/authentication.mdx#issuing-user-certificates">


### PR DESCRIPTION
The note link uses a relative path. Will include in 7.0 port.