### PR TITLE
[backport 7.0] Correct reference to helm chart in teleport kube agent install

### DIFF
--- a/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
+++ b/docs/pages/kubernetes-access/guides/multiple-clusters.mdx
@@ -45,7 +45,7 @@ $ helm repo add teleport https://charts.releases.teleport.dev
 # Install Kubernetes agent. It dials back to the Teleport cluster tele.example.com.
 $ CLUSTER='cookie'
 $ PROXY='tele.example.com:443'
-$ helm install teleport-agent teleport-kube-agent --set kubeClusterName=${CLUSTER?}\
+$ helm install teleport-agent teleport/teleport-kube-agent --set kubeClusterName=${CLUSTER?}\
     --set proxyAddr=${PROXY?} --set authToken=${TOKEN?} --create-namespace --namespace=teleport-agent
 ```
 

--- a/docs/pages/production.mdx
+++ b/docs/pages/production.mdx
@@ -169,7 +169,7 @@ https_keypairs:
 If you already have a certificate these should be uploaded to the Teleport Proxy and
 can be set via `https_key_file` and `https_cert_file`. Make sure any certificates
 files uploaded contain a full certificate chain, complete with any intermediate
-certificates required - this [guide](https://www.digicert.com/ssl-support/pem-ssl-creation.htm) may help.
+certificates required.
 
 ```yaml
 # This section configures the 'proxy service'


### PR DESCRIPTION
backport of #7208 