### PR TITLE
Deprecate SetTTL

### DIFF
--- a/api/types/access_request.go
+++ b/api/types/access_request.go
@@ -354,13 +354,6 @@ func (r *AccessRequestV3) SetExpiry(expiry time.Time) {
 	r.Metadata.SetExpiry(expiry)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (r *AccessRequestV3) SetTTL(clock Clock, ttl time.Duration) {
-	r.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata gets Metadata
 func (r *AccessRequestV3) GetMetadata() Metadata {
 	return r.Metadata

--- a/api/types/audit.go
+++ b/api/types/audit.go
@@ -120,13 +120,6 @@ func (c *ClusterAuditConfigV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *ClusterAuditConfigV2) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata.
 func (c *ClusterAuditConfigV2) GetMetadata() Metadata {
 	return c.Metadata

--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -143,13 +143,6 @@ func (c *AuthPreferenceV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *AuthPreferenceV2) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata.
 func (c *AuthPreferenceV2) GetMetadata() Metadata {
 	return c.Metadata
@@ -379,18 +372,17 @@ func (d *MFADevice) CheckAndSetDefaults() error {
 	return nil
 }
 
-func (d *MFADevice) GetKind() string                       { return d.Kind }
-func (d *MFADevice) GetSubKind() string                    { return d.SubKind }
-func (d *MFADevice) SetSubKind(sk string)                  { d.SubKind = sk }
-func (d *MFADevice) GetVersion() string                    { return d.Version }
-func (d *MFADevice) GetMetadata() Metadata                 { return d.Metadata }
-func (d *MFADevice) GetName() string                       { return d.Metadata.GetName() }
-func (d *MFADevice) SetName(n string)                      { d.Metadata.SetName(n) }
-func (d *MFADevice) GetResourceID() int64                  { return d.Metadata.ID }
-func (d *MFADevice) SetResourceID(id int64)                { d.Metadata.SetID(id) }
-func (d *MFADevice) Expiry() time.Time                     { return d.Metadata.Expiry() }
-func (d *MFADevice) SetExpiry(exp time.Time)               { d.Metadata.SetExpiry(exp) }
-func (d *MFADevice) SetTTL(clock Clock, ttl time.Duration) { d.Metadata.SetTTL(clock, ttl) }
+func (d *MFADevice) GetKind() string         { return d.Kind }
+func (d *MFADevice) GetSubKind() string      { return d.SubKind }
+func (d *MFADevice) SetSubKind(sk string)    { d.SubKind = sk }
+func (d *MFADevice) GetVersion() string      { return d.Version }
+func (d *MFADevice) GetMetadata() Metadata   { return d.Metadata }
+func (d *MFADevice) GetName() string         { return d.Metadata.GetName() }
+func (d *MFADevice) SetName(n string)        { d.Metadata.SetName(n) }
+func (d *MFADevice) GetResourceID() int64    { return d.Metadata.ID }
+func (d *MFADevice) SetResourceID(id int64)  { d.Metadata.SetID(id) }
+func (d *MFADevice) Expiry() time.Time       { return d.Metadata.Expiry() }
+func (d *MFADevice) SetExpiry(exp time.Time) { d.Metadata.SetExpiry(exp) }
 
 // MFAType returns the human-readable name of the MFA protocol of this device.
 func (d *MFADevice) MFAType() string {

--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -169,13 +169,6 @@ func (ca *CertAuthorityV2) Expiry() time.Time {
 	return ca.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (ca *CertAuthorityV2) SetTTL(clock Clock, ttl time.Duration) {
-	ca.Metadata.SetTTL(clock, ttl)
-}
-
 // GetResourceID returns resource ID
 func (ca *CertAuthorityV2) GetResourceID() int64 {
 	return ca.Metadata.ID

--- a/api/types/clusterconfig.go
+++ b/api/types/clusterconfig.go
@@ -149,13 +149,6 @@ func (c *ClusterConfigV3) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *ClusterConfigV3) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata
 func (c *ClusterConfigV3) GetMetadata() Metadata {
 	return c.Metadata

--- a/api/types/clustername.go
+++ b/api/types/clustername.go
@@ -110,13 +110,6 @@ func (c *ClusterNameV2) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *ClusterNameV2) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata
 func (c *ClusterNameV2) GetMetadata() Metadata {
 	return c.Metadata

--- a/api/types/databaseserver.go
+++ b/api/types/databaseserver.go
@@ -161,13 +161,6 @@ func (s *DatabaseServerV3) Expiry() time.Time {
 	return s.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (s *DatabaseServerV3) SetTTL(clock Clock, ttl time.Duration) {
-	s.Metadata.SetTTL(clock, ttl)
-}
-
 // GetName returns the resource name.
 func (s *DatabaseServerV3) GetName() string {
 	return s.Metadata.Name

--- a/api/types/github.go
+++ b/api/types/github.go
@@ -127,13 +127,6 @@ func (c *GithubConnectorV3) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *GithubConnectorV3) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // SetMetadata sets connector metadata
 func (c *GithubConnectorV3) SetMetadata(meta Metadata) {
 	c.Metadata = meta

--- a/api/types/license.go
+++ b/api/types/license.go
@@ -164,13 +164,6 @@ func (c *LicenseV3) SetExpiry(t time.Time) {
 	c.Metadata.SetExpiry(t)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *LicenseV3) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata
 func (c *LicenseV3) GetMetadata() Metadata {
 	return c.Metadata

--- a/api/types/namespace.go
+++ b/api/types/namespace.go
@@ -100,13 +100,6 @@ func (n *Namespace) SetExpiry(expires time.Time) {
 	n.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (n *Namespace) SetTTL(clock Clock, ttl time.Duration) {
-	n.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata
 func (n *Namespace) GetMetadata() Metadata {
 	return n.Metadata

--- a/api/types/networking.go
+++ b/api/types/networking.go
@@ -119,13 +119,6 @@ func (c *ClusterNetworkingConfigV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *ClusterNetworkingConfigV2) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata.
 func (c *ClusterNetworkingConfigV2) GetMetadata() Metadata {
 	return c.Metadata

--- a/api/types/oidc.go
+++ b/api/types/oidc.go
@@ -213,13 +213,6 @@ func (o *OIDCConnectorV2) Expiry() time.Time {
 	return o.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (o *OIDCConnectorV2) SetTTL(clock Clock, ttl time.Duration) {
-	o.Metadata.SetTTL(clock, ttl)
-}
-
 // GetName returns the name of the connector
 func (o *OIDCConnectorV2) GetName() string {
 	return o.Metadata.GetName()

--- a/api/types/plugin_data.go
+++ b/api/types/plugin_data.go
@@ -100,13 +100,6 @@ func (r *PluginDataV3) SetExpiry(expiry time.Time) {
 	r.Metadata.SetExpiry(expiry)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (r *PluginDataV3) SetTTL(clock Clock, ttl time.Duration) {
-	r.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata gets the resource metadata
 func (r *PluginDataV3) GetMetadata() Metadata {
 	return r.Metadata

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -167,13 +167,6 @@ func (p *ProvisionTokenV2) Expiry() time.Time {
 	return p.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (p *ProvisionTokenV2) SetTTL(clock Clock, ttl time.Duration) {
-	p.Metadata.SetTTL(clock, ttl)
-}
-
 // GetName returns server name
 func (p *ProvisionTokenV2) GetName() string {
 	return p.Metadata.Name

--- a/api/types/remotecluster.go
+++ b/api/types/remotecluster.go
@@ -137,13 +137,6 @@ func (c *RemoteClusterV3) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *RemoteClusterV3) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetName returns the name of the RemoteCluster.
 func (c *RemoteClusterV3) GetName() string {
 	return c.Metadata.Name

--- a/api/types/resetpasswordtoken.go
+++ b/api/types/resetpasswordtoken.go
@@ -105,13 +105,6 @@ func (u *ResetPasswordTokenV3) SetExpiry(t time.Time) {
 	u.Metadata.SetExpiry(t)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (u *ResetPasswordTokenV3) SetTTL(clock Clock, ttl time.Duration) {
-	u.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata
 func (u *ResetPasswordTokenV3) GetMetadata() Metadata {
 	return u.Metadata

--- a/api/types/resetpasswordtokensecrets.go
+++ b/api/types/resetpasswordtokensecrets.go
@@ -104,13 +104,6 @@ func (u *ResetPasswordTokenSecretsV3) SetExpiry(t time.Time) {
 	u.Metadata.SetExpiry(t)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (u *ResetPasswordTokenSecretsV3) SetTTL(clock Clock, ttl time.Duration) {
-	u.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata
 func (u *ResetPasswordTokenSecretsV3) GetMetadata() Metadata {
 	return u.Metadata

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -44,10 +44,6 @@ type Resource interface {
 	Expiry() time.Time
 	// SetExpiry sets object expiry
 	SetExpiry(time.Time)
-	// SetTTL sets Expires header using the provided clock.
-	// Use SetExpiry instead.
-	// DELETE IN 7.0.0
-	SetTTL(clock Clock, ttl time.Duration)
 	// GetMetadata returns object metadata
 	GetMetadata() Metadata
 	// GetResourceID returns resource ID
@@ -77,13 +73,6 @@ type ResourceWithOrigin interface {
 	Origin() string
 	// SetOrigin sets the origin value of the resource.
 	SetOrigin(string)
-}
-
-// Clock is used to track TTL of resources.
-// This is only used in SetTTL which is deprecated.
-// DELETE IN 7.0.0
-type Clock interface {
-	Now() time.Time
 }
 
 // GetVersion returns resource version
@@ -119,13 +108,6 @@ func (h *ResourceHeader) Expiry() time.Time {
 // SetExpiry sets object expiry
 func (h *ResourceHeader) SetExpiry(t time.Time) {
 	h.Metadata.SetExpiry(t)
-}
-
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (h *ResourceHeader) SetTTL(clock Clock, ttl time.Duration) {
-	h.Metadata.SetTTL(clock, ttl)
 }
 
 // GetMetadata returns object metadata
@@ -210,14 +192,6 @@ func (m *Metadata) SetOrigin(origin string) {
 		m.Labels = map[string]string{}
 	}
 	m.Labels[OriginLabel] = origin
-}
-
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (m *Metadata) SetTTL(clock Clock, ttl time.Duration) {
-	expireTime := clock.Now().UTC().Add(ttl)
-	m.Expires = &expireTime
 }
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -186,13 +186,6 @@ func (r *RoleV4) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (r *RoleV4) SetTTL(clock Clock, ttl time.Duration) {
-	r.Metadata.SetTTL(clock, ttl)
-}
-
 // SetName sets the role name and is a shortcut for SetMetadata().Name.
 func (r *RoleV4) SetName(s string) {
 	r.Metadata.Name = s

--- a/api/types/saml.go
+++ b/api/types/saml.go
@@ -235,13 +235,6 @@ func (o *SAMLConnectorV2) Expiry() time.Time {
 	return o.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (o *SAMLConnectorV2) SetTTL(clock Clock, ttl time.Duration) {
-	o.Metadata.SetTTL(clock, ttl)
-}
-
 // GetName returns the name of the connector
 func (o *SAMLConnectorV2) GetName() string {
 	return o.Metadata.GetName()

--- a/api/types/semaphore.go
+++ b/api/types/semaphore.go
@@ -260,13 +260,6 @@ func (c *SemaphoreV3) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *SemaphoreV3) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata
 func (c *SemaphoreV3) GetMetadata() Metadata {
 	return c.Metadata

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -146,13 +146,6 @@ func (s *ServerV2) Expiry() time.Time {
 	return s.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (s *ServerV2) SetTTL(clock Clock, ttl time.Duration) {
-	s.Metadata.SetTTL(clock, ttl)
-}
-
 // SetPublicAddr sets the public address this cluster can be reached at.
 func (s *ServerV2) SetPublicAddr(addr string) {
 	s.Spec.PublicAddr = addr

--- a/api/types/session.go
+++ b/api/types/session.go
@@ -143,13 +143,6 @@ func (ws *WebSessionV2) SetExpiry(expiry time.Time) {
 	ws.Metadata.SetExpiry(expiry)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (ws *WebSessionV2) SetTTL(clock Clock, ttl time.Duration) {
-	ws.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata gets resource Metadata
 func (ws *WebSessionV2) GetMetadata() Metadata {
 	return ws.Metadata
@@ -408,11 +401,6 @@ func (r *WebTokenV3) GetResourceID() int64 {
 // SetResourceID sets the token resource ID
 func (r *WebTokenV3) SetResourceID(id int64) {
 	r.Metadata.SetID(id)
-}
-
-// SetTTL sets the token resource TTL (time-to-live) value
-func (r *WebTokenV3) SetTTL(clock Clock, ttl time.Duration) {
-	r.Metadata.SetTTL(clock, ttl)
 }
 
 // GetToken returns the token value

--- a/api/types/sessionrecording.go
+++ b/api/types/sessionrecording.go
@@ -105,13 +105,6 @@ func (c *SessionRecordingConfigV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *SessionRecordingConfigV2) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata.
 func (c *SessionRecordingConfigV2) GetMetadata() Metadata {
 	return c.Metadata

--- a/api/types/statictokens.go
+++ b/api/types/statictokens.go
@@ -105,13 +105,6 @@ func (c *StaticTokensV2) SetExpiry(expires time.Time) {
 	c.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *StaticTokensV2) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetMetadata returns object metadata
 func (c *StaticTokensV2) GetMetadata() Metadata {
 	return c.Metadata

--- a/api/types/trustedcluster.go
+++ b/api/types/trustedcluster.go
@@ -169,13 +169,6 @@ func (c *TrustedClusterV2) Expiry() time.Time {
 	return c.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (c *TrustedClusterV2) SetTTL(clock Clock, ttl time.Duration) {
-	c.Metadata.SetTTL(clock, ttl)
-}
-
 // GetName returns the name of the TrustedCluster.
 func (c *TrustedClusterV2) GetName() string {
 	return c.Metadata.Name

--- a/api/types/tunnel.go
+++ b/api/types/tunnel.go
@@ -106,13 +106,6 @@ func (r *ReverseTunnelV2) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (r *ReverseTunnelV2) SetTTL(clock Clock, ttl time.Duration) {
-	r.Metadata.SetTTL(clock, ttl)
-}
-
 // GetName returns the name of the User
 func (r *ReverseTunnelV2) GetName() string {
 	return r.Metadata.Name

--- a/api/types/tunnelconn.go
+++ b/api/types/tunnelconn.go
@@ -127,13 +127,6 @@ func (r *TunnelConnectionV2) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (r *TunnelConnectionV2) SetTTL(clock Clock, ttl time.Duration) {
-	r.Metadata.SetTTL(clock, ttl)
-}
-
 // GetName returns the name of the User
 func (r *TunnelConnectionV2) GetName() string {
 	return r.Metadata.Name

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -133,13 +133,6 @@ func (u *UserV2) SetExpiry(expires time.Time) {
 	u.Metadata.SetExpiry(expires)
 }
 
-// SetTTL sets Expires header using the provided clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (u *UserV2) SetTTL(clock Clock, ttl time.Duration) {
-	u.Metadata.SetTTL(clock, ttl)
-}
-
 // GetName returns the name of the User
 func (u *UserV2) GetName() string {
 	return u.Metadata.Name

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -57,7 +57,7 @@ func (a *Server) CreateGithubAuthRequest(req services.GithubAuthRequest) (*servi
 	req.RedirectURL = client.AuthCodeURL(req.StateToken, "", "")
 	log.WithFields(logrus.Fields{trace.Component: "github"}).Debugf(
 		"Redirect URL: %v.", req.RedirectURL)
-	req.SetTTL(a.GetClock(), defaults.GithubAuthRequestTTL)
+	req.SetExpiry(a.GetClock().Now().UTC().Add(defaults.GithubAuthRequestTTL))
 	err = a.Identity.CreateGithubAuthRequest(req)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gokyle/hotp"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -273,12 +272,6 @@ type GithubAuthRequest struct {
 	RouteToCluster string `json:"route_to_cluster,omitempty"`
 	// KubernetesCluster is the name of Kubernetes cluster to issue credentials for.
 	KubernetesCluster string `json:"kubernetes_cluster,omitempty"`
-}
-
-// SetTTL sets Expires header using realtime clock
-func (r *GithubAuthRequest) SetTTL(clock clockwork.Clock, ttl time.Duration) {
-	expireTime := clock.Now().UTC().Add(ttl)
-	r.Expires = &expireTime
 }
 
 // SetExpiry sets expiry time for the object

--- a/lib/services/parser.go
+++ b/lib/services/parser.go
@@ -286,13 +286,6 @@ func (r *EmptyResource) Expiry() time.Time {
 	return r.Metadata.Expiry()
 }
 
-// SetTTL sets TTL header using realtime clock.
-// Use SetExpiry instead.
-// DELETE IN 7.0.0
-func (r *EmptyResource) SetTTL(clock types.Clock, ttl time.Duration) {
-	r.Metadata.SetTTL(clock, ttl)
-}
-
 // SetName sets the role name and is a shortcut for SetMetadata().Name.
 func (r *EmptyResource) SetName(s string) {
 	r.Metadata.Name = s


### PR DESCRIPTION
Deprecated SetTTL in favor of SetExpiry. Almost all SetTTL functions were marked for deleting in 7.0.0, the few that weren't shouldn't be a backwards compatibility concern.