### PR TITLE
[branch/v6.2] Backport: "teleport-kube-agent: Support multiple installations in a single cluster (#7057)"

### DIFF
--- a/docs/pages/ibm-cloud-guide.mdx
+++ b/docs/pages/ibm-cloud-guide.mdx
@@ -54,7 +54,7 @@ stores the audit logs.
 
 ### IBM Cloud: Virtual Servers with Instance Groups
 
-We recommend Gen 2 Cloud IBM [Virtual Servers](https://www.ibm.com/cloud/virtual-servers) and [Auto Scaling](https://www.ibm.com/cloud/auto-scaling)
+We recommend Gen 2 Cloud IBM [Virtual Servers](https://www.ibm.com/cloud/virtual-servers) and [Auto Scaling](https://cloud.ibm.com/docs/vpc?topic=vpc-faqs-auto-scale)
 
 - For Staging and POCs we recommend using `bx2-2x8` machines with 2 vCPUs, 4GB RAM, 4 Gbps.
 - For Production we would recommend `cx2-4x8` with 4 vCPUs, 8 GB RAM, 8 Gbps.

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -1325,9 +1325,9 @@ Set to a number higher than `1` for a high availability mode where multiple Tele
 
 | Type | Default value |
 | - | - |
-| `string` | `teleport-kube-agent` |
+| `string` | `nil` |
 
-`clusterRoleName` is the name of the Kubernetes `ClusterRole` used by the `teleport-kube-agent` chart's `ServiceAccount`.
+`clusterRoleName` can be optionally used to override the name of the Kubernetes `ClusterRole` used by the `teleport-kube-agent` chart's `ServiceAccount`.
 
 <Admonition type="note">
   Most users will not need to change this.
@@ -1354,10 +1354,10 @@ Set to a number higher than `1` for a high availability mode where multiple Tele
 
 | Type | Default value |
 | - | - |
-| `string` | `teleport-kube-agent` |
+| `string` | `nil` |
 
 
-`clusterRoleBindingName` is the name of the Kubernetes `ClusterRoleBinding` used by the `teleport-kube-agent` chart's `ServiceAccount`.
+`clusterRoleBindingName` can be optionally used to override the name of the Kubernetes `ClusterRoleBinding` used by the `teleport-kube-agent` chart's `ServiceAccount`.
 
 <Tabs>
   <TabItem label="values.yaml">
@@ -1380,9 +1380,9 @@ Set to a number higher than `1` for a high availability mode where multiple Tele
 
 | Type | Default value |
 | - | - |
-| `string` | `teleport-kube-agent` |
+| `string` | `nil` |
 
-`serviceAccountName` is the name of the Kubernetes `ServiceAccount` used by the `teleport-kube-agent` chart.
+`serviceAccountName` can be optionally used to override the name of the Kubernetes `ServiceAccount` used by the `teleport-kube-agent` chart.
 
 <Tabs>
   <TabItem label="values.yaml">

--- a/examples/chart/teleport-kube-agent/.lint/clusterrole.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/clusterrole.yaml
@@ -1,0 +1,7 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube
+kubeClusterName: test-kube-cluster
+clusterRoleName: teleport-kube-agent-test
+clusterRoleBindingName: teleport-kube-agent-test
+serviceAccountName: teleport-kube-agent-test

--- a/examples/chart/teleport-kube-agent/templates/clusterrole.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.clusterRoleName }}
+  name: {{ .Values.clusterRoleName | default .Release.Name }}
 rules:
 - apiGroups:
   - ""

--- a/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.clusterRoleBindingName }}
+  name: {{ .Values.clusterRoleBindingName | default .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.clusterRoleName }}
+  name: {{ .Values.clusterRoleName | default .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccountName }}
+  name: {{ .Values.serviceAccountName | default .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -127,4 +127,4 @@ spec:
 {{- if .Values.extraVolumes }}
   {{- toYaml .Values.extraVolumes | nindent 6 }}
 {{- end }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName | default .Release.Name }}

--- a/examples/chart/teleport-kube-agent/templates/psp.yaml
+++ b/examples/chart/teleport-kube-agent/templates/psp.yaml
@@ -58,5 +58,5 @@ roleRef:
   name: {{ .Release.Name }}-psp
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccountName }}
+  name: {{ .Values.serviceAccountName | default .Release.Name }}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccountName }}
+  name: {{ .Values.serviceAccountName | default .Release.Name }}
   namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -118,17 +118,17 @@
         "clusterRoleName": {
             "$id": "#/properties/clusterRoleName",
             "type": "string",
-            "default": "teleport-kube-agent"
+            "default": ""
         },
         "clusterRoleBindingName": {
             "$id": "#/properties/clusterRoleBindingName",
             "type": "string",
-            "default": "teleport-kube-agent"
+            "default": ""
         },
         "serviceAccountName": {
             "$id": "#/properties/serviceAccountName",
             "type": "string",
-            "default": "teleport-kube-agent"
+            "default": ""
         },
         "secretName": {
             "$id": "#/properties/secretName",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -66,12 +66,12 @@ labels: {}
 image: quay.io/gravitational/teleport
 # Number of replicas for the agent deployment.
 replicaCount: 1
-# Name of the ClusterRole, used by the agent's service account.
-clusterRoleName: teleport-kube-agent
-# Name of the ClusterRoleBinding, used by the agent's service account.
-clusterRoleBindingName: teleport-kube-agent
-# Name of the service account used by the agent.
-serviceAccountName: teleport-kube-agent
+# (optional) Override the name of the ClusterRole used by the agent's service account.
+clusterRoleName: ""
+# (optional) Override the name of the ClusterRoleBinding used by the agent's service account.
+clusterRoleBindingName: ""
+# (optional) Override the name of the service account used by the agent.
+serviceAccountName: ""
 # Name of the Secret to store the teleport join token.
 secretName: teleport-kube-agent-join-token
 # Log level for the Teleport process.


### PR DESCRIPTION
Backports #7057 to `branch/v6.2`