### PR TITLE
[branch/v6] Fix incorrect GOCACHE volume being passed to `docker:dind`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -325,7 +325,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -381,6 +381,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -419,7 +420,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -475,6 +476,7 @@ steps:
   environment:
     ARCH: "386"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -513,7 +515,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -573,6 +575,7 @@ steps:
     ARCH: amd64
     FIPS: "yes"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -611,7 +614,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -667,6 +670,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: windows
     UID: "1000"
@@ -802,7 +806,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -858,6 +862,7 @@ steps:
   environment:
     ARCH: arm
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -896,7 +901,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -952,6 +957,7 @@ steps:
   environment:
     ARCH: arm64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -1221,7 +1227,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -1273,6 +1279,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -1317,7 +1324,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -1371,6 +1378,7 @@ steps:
     ARCH: amd64
     FIPS: "yes"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -1413,7 +1421,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -1465,6 +1473,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -1512,7 +1521,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -1566,6 +1575,7 @@ steps:
     ARCH: amd64
     FIPS: "yes"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -1610,7 +1620,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -1735,7 +1745,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -1857,7 +1867,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -1968,7 +1978,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -2076,7 +2086,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -2128,6 +2138,7 @@ steps:
   environment:
     ARCH: "386"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -2172,7 +2183,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -2297,7 +2308,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -2794,7 +2805,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -2846,6 +2857,7 @@ steps:
   environment:
     ARCH: arm
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -2890,7 +2902,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -2942,6 +2954,7 @@ steps:
   environment:
     ARCH: arm64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -2986,7 +2999,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -3097,7 +3110,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -3208,7 +3221,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -3333,7 +3346,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:328
+# Generated at dronegen/tag.go:329
 ################################################
 
 kind: pipeline
@@ -3458,7 +3471,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -3510,6 +3523,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: windows
     UID: "1000"
@@ -3593,7 +3607,7 @@ steps:
       - git submodule update --init --recursive webassets || true
       - rm -f /root/.ssh/id_rsa
       # create necessary directories
-      - mkdir -p /go/artifacts ${GOCACHE}
+      - mkdir -p /go/artifacts $GOCACHE
       # set version
       - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
@@ -4303,6 +4317,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 4fee2a24376485b7ef2791980e1f51f83d0c891683dd4cc662d3b8e7f08236ae
+hmac: 7fd96f13abe865136e229b290a67b69b2dab18575b442ffd67dd8e19f0b25968
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -43,7 +43,7 @@ GID := 1000
 NOROOT := -u 1000:1000
 # if running in CI and the GOCACHE environment variable is not set, set it to a sensible default
 ifeq ("$(GOCACHE)",)
-GOCACHE := $(shell go env GOCACHE)
+GOCACHE := /go/cache
 endif
 # pass external gocache path through to docker containers
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(GOCACHE):/go/cache -e GOCACHE=/go/cache

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -72,11 +72,12 @@ func pushPipeline(b buildType) pipeline {
 
 	pipelineName := fmt.Sprintf("push-build-%s-%s", b.os, b.arch)
 	pushEnvironment := map[string]value{
-		"UID":    value{raw: "1000"},
-		"GID":    value{raw: "1000"},
-		"GOPATH": value{raw: "/go"},
-		"OS":     value{raw: b.os},
-		"ARCH":   value{raw: b.arch},
+		"UID":     value{raw: "1000"},
+		"GID":     value{raw: "1000"},
+		"GOCACHE": value{raw: "/go/cache"},
+		"GOPATH":  value{raw: "/go"},
+		"OS":      value{raw: b.os},
+		"ARCH":    value{raw: b.arch},
 	}
 	if b.fips {
 		pipelineName += "-fips"

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -173,11 +173,12 @@ func tagPipeline(b buildType) pipeline {
 		pipelineName += "-centos6"
 	}
 	tagEnvironment := map[string]value{
-		"UID":    value{raw: "1000"},
-		"GID":    value{raw: "1000"},
-		"GOPATH": value{raw: "/go"},
-		"OS":     value{raw: b.os},
-		"ARCH":   value{raw: b.arch},
+		"UID":     value{raw: "1000"},
+		"GID":     value{raw: "1000"},
+		"GOCACHE": value{raw: "/go/cache"},
+		"GOPATH":  value{raw: "/go"},
+		"OS":      value{raw: b.os},
+		"ARCH":    value{raw: b.arch},
 	}
 	if b.fips {
 		pipelineName += "-fips"


### PR DESCRIPTION
This PR now actually fixes the `GOCACHE` and `docker:dind` issues in `.drone.yml`.

Using `${GOCACHE}` instead of `$GOCACHE` causes Drone to attempt to expand the variable instead of the shell, which doesn't work because it isn't aware of its own environment. This was an error introduced by https://github.com/gravitational/teleport/pull/7223

Also, using `go env GOCACHE` in `build.assets/Makefile` doesn't work because the image used to run these `make` steps in Drone pipelines is `docker` (which doesn't have `go` installed) rather than `golang`.  As this `GOCACHE` logic only conditionally applies when running inside CI/Drone, we can be sure that `/go/cache` is always the correct path to use so we don't need the `go env` expansion.

Forward-ports needed:
- `branch/v6` (also revert `docker:20.10.6-dind` change)
- `master` (also revert `docker:20.10.6-dind` change)

This same fix also needs to be applied to `branch/5.0` and possibly `branch/4.4`, but this should be done manually as cherry-picking the commit won't work due to the Drone pipelines being significantly different.