### PR TITLE
Limit event search responses sizes to not exceed gRPC limits

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -594,6 +594,8 @@ type IAuditLog interface {
 	//
 	// The only mandatory requirement is a date range (UTC). Results must always
 	// show up sorted by date (newest first)
+	//
+	// This function may never return more than 1 MiB of event data.
 	SearchEvents(fromUTC, toUTC time.Time, namespace string, eventTypes []string, limit int, startKey string) ([]apievents.AuditEvent, string, error)
 
 	// SearchSessionEvents is a flexible way to find session events.
@@ -602,6 +604,8 @@ type IAuditLog interface {
 	//
 	// Event types to filter can be specified and pagination is handled by an iterator key that allows
 	// a query to be resumed.
+	//
+	// This function may never return more than 1 MiB of event data.
 	SearchSessionEvents(fromUTC time.Time, toUTC time.Time, limit int, startKey string) ([]apievents.AuditEvent, string, error)
 
 	// WaitForDelivery waits for resources to be released and outstanding requests to

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -19,6 +19,8 @@ package dynamoevents
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"math"
 	"net/url"
@@ -673,6 +675,10 @@ type checkpointKey struct {
 
 	// A DynamoDB query iterator. Allows us to resume a partial query.
 	Iterator map[string]*dynamodb.AttributeValue `json:"iterator,omitempty"`
+
+	// EventKey is a derived identifier for an event used for resuming
+	// sub-page breaks due to size constraints.
+	EventKey string `json:"event_key,omitempty"`
 }
 
 // SearchEvents is a flexible way to find events.
@@ -773,6 +779,7 @@ func (l *Log) searchEventsRaw(fromUTC, toUTC time.Time, namespace string, eventT
 	}
 
 	hasLeft := false
+	foundStart := checkpoint.EventKey == ""
 
 	// This is the main query loop, here we send individual queries for each date and
 	// we stop if we hit `limit` or process all dates, whichever comes first.
@@ -819,6 +826,20 @@ dateLoop:
 				if err := json.Unmarshal(data, &fields); err != nil {
 					return nil, "", trace.BadParameter("failed to unmarshal event %v", err)
 				}
+
+				if !foundStart {
+					key, err := getSubPageCheckpoint(&e)
+					if err != nil {
+						return nil, "", trace.Wrap(err)
+					}
+
+					if key != checkpoint.EventKey {
+						continue
+					}
+
+					foundStart = true
+				}
+
 				accepted := false
 				for i := range eventTypes {
 					if e.EventType == eventTypes[i] {
@@ -827,11 +848,23 @@ dateLoop:
 					}
 				}
 				if accepted || !doFilter {
+					// Because this may break on non page boundaries an additional
+					// checkpoint is needed for sub-page breaks.
+					if totalSize+len(data) >= events.MaxEventBytesInResponse {
+						hasLeft = i+1 != len(dates) || len(checkpoint.Iterator) != 0
+						key, err := getSubPageCheckpoint(&e)
+						if err != nil {
+							return nil, "", trace.Wrap(err)
+						}
+						checkpoint.EventKey = key
+						break dateLoop
+					}
+
 					totalSize += len(data)
 					values = append(values, e)
 					left--
 
-					if left == 0 || totalSize >= events.MaxEventBytesInResponse {
+					if left == 0 {
 						hasLeft = i+1 != len(dates) || len(checkpoint.Iterator) != 0
 						break dateLoop
 					}
@@ -855,6 +888,16 @@ dateLoop:
 	}
 
 	return values, string(lastKey), nil
+}
+
+func getSubPageCheckpoint(e *event) (string, error) {
+	data, err := utils.FastMarshal(e)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
 }
 
 // SearchSessionEvents returns session related events only. This is used to

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -749,6 +749,7 @@ func (l *Log) searchEventsRaw(fromUTC, toUTC time.Time, namespace string, eventT
 	}
 
 	var values []event
+	totalSize := 0
 	dates := daysBetween(fromUTC, toUTC)
 	query := "CreatedAtDate = :date AND CreatedAt BETWEEN :start and :end"
 	g := l.WithFields(log.Fields{"From": fromUTC, "To": toUTC, "Namespace": namespace, "EventTypes": eventTypes, "Limit": limit, "StartKey": startKey})
@@ -826,9 +827,11 @@ dateLoop:
 					}
 				}
 				if accepted || !doFilter {
+					totalSize += len(data)
 					values = append(values, e)
 					left--
-					if left == 0 {
+
+					if left == 0 || totalSize >= events.MaxEventBytesInResponse {
 						hasLeft = i+1 != len(dates) || len(checkpoint.Iterator) != 0
 						break dateLoop
 					}

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -469,6 +469,7 @@ func (l *Log) SearchEvents(fromUTC, toUTC time.Time, namespace string, eventType
 	var values []events.EventFields
 	var parsedStartKey int64
 	var err error
+	totalSize := 0
 
 	if startKey != "" {
 		parsedStartKey, err = strconv.ParseInt(startKey, 10, 64)
@@ -522,7 +523,8 @@ func (l *Log) SearchEvents(fromUTC, toUTC time.Time, namespace string, eventType
 		if accepted || !doFilter {
 			lastKey = docSnap.Data()["createdAt"].(int64)
 			values = append(values, fields)
-			if limit > 0 && len(values) >= limit {
+			totalSize += len(data)
+			if (limit > 0 && len(values) >= limit) || totalSize >= events.MaxEventBytesInResponse {
 				break
 			}
 		}

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -521,10 +521,14 @@ func (l *Log) SearchEvents(fromUTC, toUTC time.Time, namespace string, eventType
 			}
 		}
 		if accepted || !doFilter {
+			if totalSize+len(data) >= events.MaxEventBytesInResponse {
+				break
+			}
+
 			lastKey = docSnap.Data()["createdAt"].(int64)
 			values = append(values, fields)
 			totalSize += len(data)
-			if (limit > 0 && len(values) >= limit) || totalSize >= events.MaxEventBytesInResponse {
+			if limit > 0 && len(values) >= limit {
 				break
 			}
 		}

--- a/lib/events/sizelimit.go
+++ b/lib/events/sizelimit.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"github.com/gravitational/teleport/lib/utils"
+
+	"github.com/gravitational/trace"
+)
+
+// This is the max size of all the events we return when searching for events.
+// 1 MiB was picked as a good middleground that's commonly used by the backends and is well below
+// the max size limit of a response message. This may sometimes result in an even smaller size
+// when serialized as protobuf but we have no good way to check so we go by raw from each backend.
+const MaxEventBytesInResponse = 1024 * 1024
+
+func estimateEventSize(event EventFields) (int, error) {
+	data, err := utils.FastMarshal(event)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	return len(data), nil
+}


### PR DESCRIPTION
Currently, none of our backends cap the amount of data we send with each call to `SearchEvents` gracefully which sometimes results in a gRPC error as @alex-kovoy observed in #7249. This PR implements hard limits in all of our backends on the amount of data retrieved per call to stay within sane limits.