### PR TITLE
drone: GOCACHE and `docker:dind` fix, round 2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -345,7 +345,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -408,6 +408,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -445,7 +446,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -508,6 +509,7 @@ steps:
   environment:
     ARCH: "386"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -545,7 +547,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -612,6 +614,7 @@ steps:
     ARCH: amd64
     FIPS: "yes"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -649,7 +652,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -712,6 +715,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: windows
     UID: "1000"
@@ -846,7 +850,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -909,6 +913,7 @@ steps:
   environment:
     ARCH: arm
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -946,7 +951,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go:86
+# Generated at dronegen/push.go:87
 ################################################
 
 kind: pipeline
@@ -1009,6 +1014,7 @@ steps:
   environment:
     ARCH: arm64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -1276,7 +1282,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -1335,6 +1341,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -1378,7 +1385,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -1439,6 +1446,7 @@ steps:
     ARCH: amd64
     FIPS: "yes"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -1480,7 +1488,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -1539,6 +1547,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -1585,7 +1594,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -1646,6 +1655,7 @@ steps:
     ARCH: amd64
     FIPS: "yes"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -2179,7 +2189,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -2238,6 +2248,7 @@ steps:
   environment:
     ARCH: "386"
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -2915,7 +2926,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -2974,6 +2985,7 @@ steps:
   environment:
     ARCH: arm
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -3017,7 +3029,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -3076,6 +3088,7 @@ steps:
   environment:
     ARCH: arm64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: linux
     UID: "1000"
@@ -3615,7 +3628,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:187
+# Generated at dronegen/tag.go:188
 ################################################
 
 kind: pipeline
@@ -3674,6 +3687,7 @@ steps:
   environment:
     ARCH: amd64
     GID: "1000"
+    GOCACHE: /go/cache
     GOPATH: /go
     OS: windows
     UID: "1000"
@@ -4467,6 +4481,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 629cec9784e5dd58b9707254523a32ce2535be0a0a672be836c08e694d9dc57d
+hmac: cfe54e610604e21c5b7a3778d6a12988f5aa9edf0c83c9a2ca4037b3222c1381
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -3756,7 +3756,7 @@ steps:
       - git submodule update --init --recursive webassets || true
       - rm -f /root/.ssh/id_rsa
       # create necessary directories
-      - mkdir -p /go/artifacts ${GOCACHE}
+      - mkdir -p /go/artifacts $GOCACHE
       # set version
       - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt; else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
 
@@ -4467,6 +4467,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 3fce8ad586a155c767b29693a6df6358a96f33d4274c09ec9f254654f8563d37
+hmac: c0d3d6df21a9b5e5e01591a8885068b39829b084380dd8fd57a4752f1c75eda1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -185,7 +185,7 @@ steps:
     path: /var/run
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -295,7 +295,7 @@ steps:
     path: /var/run
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -433,7 +433,7 @@ steps:
     - failure
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -533,7 +533,7 @@ steps:
     - failure
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -637,7 +637,7 @@ steps:
     - failure
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -737,7 +737,7 @@ steps:
     - failure
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -934,7 +934,7 @@ steps:
     - failure
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -1034,7 +1034,7 @@ steps:
     - failure
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -1366,7 +1366,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -1468,7 +1468,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -1573,7 +1573,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -1677,7 +1677,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -1803,7 +1803,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -1931,7 +1931,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -2053,7 +2053,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -2167,7 +2167,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -2269,7 +2269,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -2395,7 +2395,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -2517,7 +2517,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -3005,7 +3005,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -3107,7 +3107,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -3224,7 +3224,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -3341,7 +3341,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -3467,7 +3467,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -3598,7 +3598,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -3704,7 +3704,7 @@ steps:
     target: teleport/tag/${DRONE_TAG##v}
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -4157,7 +4157,7 @@ steps:
   failure: ignore
 services:
 - name: Start Docker
-  image: docker:20.10.6-dind
+  image: docker:dind
   volumes:
   - name: dockersock
     path: /var/run
@@ -4467,6 +4467,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: c0d3d6df21a9b5e5e01591a8885068b39829b084380dd8fd57a4752f1c75eda1
+hmac: 629cec9784e5dd58b9707254523a32ce2535be0a0a672be836c08e694d9dc57d
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -52,7 +52,7 @@ GID := 1000
 NOROOT := -u 1000:1000
 # if running in CI and the GOCACHE environment variable is not set, set it to a sensible default
 ifeq ("$(GOCACHE)",)
-GOCACHE := $(shell go env GOCACHE)
+GOCACHE := /go/cache
 endif
 # pass external gocache path through to docker containers
 DOCKERFLAGS := $(DOCKERFLAGS) -v $(GOCACHE):/go/cache -e GOCACHE=/go/cache

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -75,7 +75,7 @@ type buildType struct {
 func dockerService(v ...volumeRef) service {
 	return service{
 		Name:    "Start Docker",
-		Image:   "docker:20.10.6-dind",
+		Image:   "docker:dind",
 		Volumes: append(v, volumeRefDocker),
 	}
 }

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -72,11 +72,12 @@ func pushPipeline(b buildType) pipeline {
 
 	pipelineName := fmt.Sprintf("push-build-%s-%s", b.os, b.arch)
 	pushEnvironment := map[string]value{
-		"UID":    value{raw: "1000"},
-		"GID":    value{raw: "1000"},
-		"GOPATH": value{raw: "/go"},
-		"OS":     value{raw: b.os},
-		"ARCH":   value{raw: b.arch},
+		"UID":     value{raw: "1000"},
+		"GID":     value{raw: "1000"},
+		"GOCACHE": value{raw: "/go/cache"},
+		"GOPATH":  value{raw: "/go"},
+		"OS":      value{raw: b.os},
+		"ARCH":    value{raw: b.arch},
 	}
 	if b.fips {
 		pipelineName += "-fips"

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -173,11 +173,12 @@ func tagPipeline(b buildType) pipeline {
 		pipelineName += "-centos6"
 	}
 	tagEnvironment := map[string]value{
-		"UID":    value{raw: "1000"},
-		"GID":    value{raw: "1000"},
-		"GOPATH": value{raw: "/go"},
-		"OS":     value{raw: b.os},
-		"ARCH":   value{raw: b.arch},
+		"UID":     value{raw: "1000"},
+		"GID":     value{raw: "1000"},
+		"GOCACHE": value{raw: "/go/cache"},
+		"GOPATH":  value{raw: "/go"},
+		"OS":      value{raw: b.os},
+		"ARCH":    value{raw: b.arch},
 	}
 	if b.fips {
 		pipelineName += "-fips"


### PR DESCRIPTION
This PR reverts the fixes made by #7193 (pinning the Drone docker-in-docker image) in favour of explicitly setting `GOCACHE` in pipelines where it's needed to prevent the underlying issue.

It also fixes an error made in https://github.com/gravitational/teleport/pull/7206 where the `${GOCACHE}` variable was expanded to a blank string by Drone, rather than to the value of `$GOCACHE` by the shell inside the container.

Backports needed:
- `branch/v6.2`