### PR TITLE
Update Teleport Cloud -> Teleport Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ implementation. It is _fully compatible with OpenSSH_,
 | [Blog](https://goteleport.com/blog/) | Our blog where we publish Teleport news. |
 | [Forum](https://github.com/gravitational/teleport/discussions) | Ask us a setup question, post your tutorial, feedback, or idea on our forum. |
 | [Slack](https://goteleport.com/slack) | Need help with your setup? Ping us in our Slack channel. |
-| [Teleport Pro](https://goteleport.com/pricing) | Teleport Pro is a cloud hosted Teleport service. For teams that require easy and secure access to their computing environments. |
+| [Cloud-hosted](https://goteleport.com/pricing) | We offer Teleport Pro and Enteprise with a Cloud-hosted option. For teams that require easy and secure access to their computing environments. |
 
 
 [Teleport 6.0 - 4:00m Demo Video](https://www.youtube.com/watch?v=0HlyGk8dihM)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ implementation. It is _fully compatible with OpenSSH_,
 | [Blog](https://goteleport.com/blog/) | Our blog where we publish Teleport news. |
 | [Forum](https://github.com/gravitational/teleport/discussions) | Ask us a setup question, post your tutorial, feedback, or idea on our forum. |
 | [Slack](https://goteleport.com/slack) | Need help with your setup? Ping us in our Slack channel. |
-| [Cloud](https://goteleport.com/pricing) | We run Teleport Cloud as hosted, managed Teleport as a service. Connect your nodes, web applications, kubernetes clusters, and databases. |
+| [Teleport Pro](https://goteleport.com/pricing) | Teleport Pro is a cloud hosted Teleport service. For teams that require easy and secure access to their computing environments. |
 
 
 [Teleport 6.0 - 4:00m Demo Video](https://www.youtube.com/watch?v=0HlyGk8dihM)


### PR DESCRIPTION
Change wording for our hosted offering, from Teleport Cloud -> Teleport Pro 