### PR TITLE
[v6.2] Set the static name of singleton resources in CheckAndSetDefaults

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -248,6 +248,9 @@ func (c *AuthPreferenceV2) GetRequireSessionMFA() bool {
 
 // CheckAndSetDefaults verifies the constraints for AuthPreference.
 func (c *AuthPreferenceV2) CheckAndSetDefaults() error {
+	if c.Metadata.Name == "" {
+		c.Metadata.Name = MetaNameClusterAuthPreference
+	}
 	// make sure we have defaults for all metadata fields
 	err := c.Metadata.CheckAndSetDefaults()
 	if err != nil {

--- a/api/types/clusterconfig.go
+++ b/api/types/clusterconfig.go
@@ -288,6 +288,9 @@ func (c *ClusterConfigV3) SetLocalAuth(b bool) {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults.
 func (c *ClusterConfigV3) CheckAndSetDefaults() error {
+	if c.Metadata.Name == "" {
+		c.Metadata.Name = MetaNameClusterConfig
+	}
 	// make sure we have defaults for all metadata fields
 	err := c.Metadata.CheckAndSetDefaults()
 	if err != nil {

--- a/api/types/clustername.go
+++ b/api/types/clustername.go
@@ -132,6 +132,9 @@ func (c *ClusterNameV2) GetClusterName() string {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults.
 func (c *ClusterNameV2) CheckAndSetDefaults() error {
+	if c.Metadata.Name == "" {
+		c.Metadata.Name = MetaNameClusterName
+	}
 	// make sure we have defaults for all metadata fields
 	err := c.Metadata.CheckAndSetDefaults()
 	if err != nil {

--- a/api/types/statictokens.go
+++ b/api/types/statictokens.go
@@ -131,6 +131,9 @@ func (c *StaticTokensV2) GetStaticTokens() []ProvisionToken {
 
 // CheckAndSetDefaults checks validity of all parameters and sets defaults.
 func (c *StaticTokensV2) CheckAndSetDefaults() error {
+	if c.Metadata.Name == "" {
+		c.Metadata.Name = MetaNameStaticTokens
+	}
 	// make sure we have defaults for all metadata fields
 	err := c.Metadata.CheckAndSetDefaults()
 	if err != nil {


### PR DESCRIPTION
Should fix any accidental "missing parameter Name" errors.