### PR TITLE
[v6.2] docs: update steps 1

### DIFF
--- a/docs/pages/admin-guide.mdx
+++ b/docs/pages/admin-guide.mdx
@@ -93,17 +93,7 @@ daemon manually.
 
 Teleport services listen on several ports. This table shows the default port numbers.
 
-| Port | Service | Description | Ingress | Egress |
-| --- | --- | --- | --- | --- |
-| `443` | Proxy | Default proxy port when using ACME for TLS/SSL. | {/* TODO */} | {/* TODO */} |
-| `3022` | Node | SSH port to the Node Service. This is Teleport's equivalent of port `22` for SSH. | Allow inbound traffic from the proxy host. | Allow outbound traffic to the proxy host. |
-| `3023` | Proxy | SSH port clients connect to after authentication. A proxy will forward this connection to port `3022` on the destination node. | Allow inbound traffic from SSH clients. | Allow outbound traffic to SSH clients. |
-| `3024` | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. | {/* TODO */} | {/* TODO */} |
-| `3025` | Auth | SSH port used by the Auth Service to serve its Auth API to other nodes in a cluster. | Allow inbound connections from all cluster nodes. | Allow outbound traffic to cluster nodes. |
-| `3026` | Kubernetes | HTTPS Kubernetes proxy `proxy_service.kube_listen_addr`. Port used for `kubectl` to access Teleport. | {/* TODO */} | {/* TODO */} |
-| `3027` | Kubernetes | Kubernetes Service `kubernetes_service.listen_addr` | {/* TODO */} | {/* TODO */} |
-| `3036` | DB | Teleport MySQL proxy listen address. | {/* TODO */} | {/* TODO */} |
-| `3080` | Proxy | HTTPS port clients connect to. Used to authenticate `tsh` users and web users into the cluster. | Allow inbound connections from HTTP and SSH clients. | Allow outbound connections to HTTP and SSH clients. |
+(!docs/pages/includes/port-table.mdx!)
 
 ### Filesystem layout
 

--- a/docs/pages/admin-guide.mdx
+++ b/docs/pages/admin-guide.mdx
@@ -93,15 +93,17 @@ daemon manually.
 
 Teleport services listen on several ports. This table shows the default port numbers.
 
-| Port | Service | Description |
-| - | - | - |
-| 3022 | Node | SSH port. This is Teleport's equivalent of port `#22` for SSH. |
-| 3023 | Proxy | SSH port clients connect to. A proxy will forward this connection to port `#3022` on the destination node. |
-| 3024 | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. |
-| 3025 | Auth | SSH port used by the Auth Service to serve its API to other nodes in a cluster. |
-| 3080 | Proxy | HTTPS connection to authenticate `tsh` users and web users into the cluster. The same connection is used to serve a Web UI. |
-| 3026 | Kubernetes | HTTPS Kubernetes proxy `proxy_service.kube_listen_addr` |
-| 3027 | Kubernetes | Kubernetes Service `kubernetes_service.listen_addr` |
+| Port | Service | Description | Ingress | Egress |
+| --- | --- | --- | --- | --- |
+| `443` | Proxy | Default proxy port when using ACME for TLS/SSL. | {/* TODO */} | {/* TODO */} |
+| `3022` | Node | SSH port to the Node Service. This is Teleport's equivalent of port `22` for SSH. | Allow inbound traffic from the proxy host. | Allow outbound traffic to the proxy host. |
+| `3023` | Proxy | SSH port clients connect to after authentication. A proxy will forward this connection to port `3022` on the destination node. | Allow inbound traffic from SSH clients. | Allow outbound traffic to SSH clients. |
+| `3024` | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. | {/* TODO */} | {/* TODO */} |
+| `3025` | Auth | SSH port used by the Auth Service to serve its Auth API to other nodes in a cluster. | Allow inbound connections from all cluster nodes. | Allow outbound traffic to cluster nodes. |
+| `3026` | Kubernetes | HTTPS Kubernetes proxy `proxy_service.kube_listen_addr`. Port used for `kubectl` to access Teleport. | {/* TODO */} | {/* TODO */} |
+| `3027` | Kubernetes | Kubernetes Service `kubernetes_service.listen_addr` | {/* TODO */} | {/* TODO */} |
+| `3036` | DB | Teleport MySQL proxy listen address. | {/* TODO */} | {/* TODO */} |
+| `3080` | Proxy | HTTPS port clients connect to. Used to authenticate `tsh` users and web users into the cluster. | Allow inbound connections from HTTP and SSH clients. | Allow outbound connections to HTTP and SSH clients. |
 
 ### Filesystem layout
 

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -38,7 +38,7 @@ Grafana can be launched in a [Docker container](https://grafana.com/docs/grafana
 with a single command:
 
 ```bash
-docker run -d -p 3000:3000 grafana/grafana
+docker run -d -p 127.0.0.1:3000:3000 grafana/grafana
 ```
 
 ## Step 2/3. Install and configure Teleport

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -29,54 +29,7 @@ Teleport (=teleport.version=) on Linux machines.
 
 (!docs/pages/includes/permission-warning.mdx!)
 
-<Tabs>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)">
-    ```bash
-    sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-    sudo yum install teleport
-
-    # Optional:  Using DNF on newer distributions
-    # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-    # $ sudo dnf install teleport
-    ```
-  </TabItem>
-
-  <TabItem label="Debian/Ubuntu (DEB)">
-    ```bash
-    curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    sudo apt-get update
-    sudo apt-get install teleport
-    ```
-  </TabItem>
-
-  <TabItem label="Linux">
-    ```bash
-    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    cd teleport
-    sudo ./install
-    ```
-  </TabItem>
-
-  <TabItem label="ARMv7 (32-bit)">
-    ```bash
-    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    cd teleport
-    sudo ./install
-    ```
-  </TabItem>
-
-  <TabItem label="ARMv8 (64-bit)">
-    ```bash
-    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    cd teleport
-    sudo ./install
-    ```
-  </TabItem>
-</Tabs>
+(!docs/pages/includes/install-steps.mdx!)
 
 Take a look at the [Installation Guide](installation.mdx) for more options.
 
@@ -156,41 +109,7 @@ Here's a selection of compatible two-factor authentication apps:
 
 ### Install a Teleport client locally
 
-<Tabs>
-  <TabItem label="Mac">
-    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (`tsh` client only, signed) file, double-click to run the installer.
-  </TabItem>
-
-  <TabItem label="Mac - Homebrew">
-    ```bash
-    brew install teleport
-    ```
-
-    <Admonition type="note">
-      The Teleport package in Homebrew is not maintained by Teleport. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
-    </Admonition>
-  </TabItem>
-
-  <TabItem label="Windows - Powershell">
-    ```bash
-    curl -O teleport-v(=teleport.version=)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
-    # Unzip the archive and move `tsh.exe` to your %PATH%
-    ```
-  </TabItem>
-
-  <TabItem label="Linux">
-    For more options (including RPM/DEB packages and downloads for i386/ARM/ARM64) please see our [installation page](installation.mdx).
-
-    ```bash
-    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    cd teleport
-    sudo ./install
-    # Teleport binaries have been copied to /usr/local/bin
-    # To configure the systemd service for Teleport take a look at examples/systemd/README.mdx
-    ```
-  </TabItem>
-</Tabs>
+(!docs/pages/includes/install-steps.mdx!)
 
 ## Step 3/4. Log in using tsh
 

--- a/docs/pages/includes/install-steps.mdx
+++ b/docs/pages/includes/install-steps.mdx
@@ -1,0 +1,48 @@
+<Tabs>
+  <TabItem label="Amazon Linux 2/RHEL (RPM)">
+    ```bash
+    yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+    yum install teleport
+
+    # Optional:  Using DNF on newer distributions
+    # dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
+    # dnf install teleport
+    ```
+  </TabItem>
+
+  <TabItem label="Debian/Ubuntu (DEB)">
+    ```bash
+    curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
+    add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
+    apt-get update
+    apt-get install teleport
+    ```
+  </TabItem>
+
+  <TabItem label="Linux">
+    ```bash
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
+    cd teleport
+    ./install
+    ```
+  </TabItem>
+
+  <TabItem label="ARMv7 (32-bit)">
+    ```bash
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
+    cd teleport
+    ./install
+    ```
+  </TabItem>
+
+  <TabItem label="ARMv8 (64-bit)">
+    ```bash
+    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+    tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
+    cd teleport
+    ./install
+    ```
+  </TabItem>
+</Tabs>

--- a/docs/pages/includes/port-table.mdx
+++ b/docs/pages/includes/port-table.mdx
@@ -14,7 +14,7 @@ Teleport services listen on several ports. This table shows the default port num
     <tr>
       <td>443</td>
       <td>Proxy</td>
-      <td>Default proxy port when using ACME for TLS/SSL.</td>
+      <td>Default proxy port when using ACME for TLS/SSL. Supercedes port `3025` if ACME is used.</td>
       <td>Allow inbound SSL/TLS connections to the proxy host.</td>
       <td>-</td>
     </tr>
@@ -42,7 +42,7 @@ Teleport services listen on several ports. This table shows the default port num
     <tr>
       <td>3025</td>
       <td>Auth</td>
-      <td>SSH port used by the Auth Service to serve its Auth API to other nodes in a cluster.</td>
+      <td>TLS port used by the Auth Service to serve its Auth API to other nodes in a cluster.</td>
       <td>Allow inbound connections from all cluster nodes.</td>
       <td>Allow outbound traffic to cluster nodes.</td>
     </tr>
@@ -70,7 +70,7 @@ Teleport services listen on several ports. This table shows the default port num
     <tr>
       <td>3080</td>
       <td>Proxy</td>
-      <td>HTTPS port clients connect to. Used to authenticate `tsh` users and web users into the cluster.</td>
+      <td>Default HTTPS port clients connect to. Will be superceded by port `443` if used. Used to authenticate `tsh` users and web users into the cluster.</td>
       <td>Allow inbound connections from HTTP and SSH clients.</td>
       <td>Allow outbound connections to HTTP and SSH clients.</td>
     </tr>

--- a/docs/pages/includes/port-table.mdx
+++ b/docs/pages/includes/port-table.mdx
@@ -1,0 +1,78 @@
+Teleport services listen on several ports. This table shows the default port numbers.
+
+<table>
+  <thead>
+    <tr>
+      <td>Port</td>
+      <td>Service</td>
+      <td>Description</td>
+      <td>Ingress</td>
+      <td>Egress</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>443</td>
+      <td>Proxy</td>
+      <td>Default proxy port when using ACME for TLS/SSL.</td>
+      <td>Allow inbound SSL/TLS connections to the proxy host.</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>3022</td>
+      <td>Node</td>
+      <td>SSH port to the Node Service. This is Teleport's equivalent of port `22` for SSH.</td>
+      <td>Allow inbound traffic from the proxy host.</td>
+      <td>Allow outbound traffic to the proxy host.</td>
+    </tr>
+    <tr>
+      <td>3023</td>
+      <td>Proxy</td>
+      <td>SSH port clients connect to after authentication. A proxy will forward this connection to port `3022` on the destination node.</td>
+      <td>Allow inbound traffic from SSH clients.</td>
+      <td>Allow outbound traffic to SSH clients.</td>
+    </tr>
+    <tr>
+      <td>3024</td>
+      <td>Proxy</td>
+      <td>SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server.</td>
+      <td>Alllow inbound traffic when behind a firewall.</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>3025</td>
+      <td>Auth</td>
+      <td>SSH port used by the Auth Service to serve its Auth API to other nodes in a cluster.</td>
+      <td>Allow inbound connections from all cluster nodes.</td>
+      <td>Allow outbound traffic to cluster nodes.</td>
+    </tr>
+    <tr>
+      <td>3026</td>
+      <td>Kubernetes</td>
+      <td>HTTPS Kubernetes proxy `proxy_service.kube_listen_addr`. Port used for `kubectl` to access Teleport.</td>
+      <td>Allow inbound connections to kubernetes proxy.</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>3027</td>
+      <td>Kubernetes</td>
+      <td>Kubernetes Service `kubernetes_service.listen_addr`.</td>
+      <td>Optional alternative incoming Kubernetes public address port.</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>3036</td>
+      <td>DB</td>
+      <td>Teleport MySQL proxy listen address.</td>
+      <td>Allow inbound MySQL connections using tsh.</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td>3080</td>
+      <td>Proxy</td>
+      <td>HTTPS port clients connect to. Used to authenticate `tsh` users and web users into the cluster.</td>
+      <td>Allow inbound connections from HTTP and SSH clients.</td>
+      <td>Allow outbound connections to HTTP and SSH clients.</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -15,66 +15,7 @@ up-to-date information.
 
 (!docs/pages/includes/permission-warning.mdx!)
 
-<Tabs>
-  <TabItem label="Debian/Ubuntu (DEB)">
-    ```bash
-    # Install our public key.
-    curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    # Add repo to APT
-    add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    # Update APT Cache
-    apt-get update
-    # Install Teleport
-    apt install teleport
-    ```
-  </TabItem>
-
-  <TabItem label="Amazon Linux 2/RHEL/Fedora (RPM)">
-    ```bash
-    yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-    yum install teleport
-    ```
-  </TabItem>
-
-  <TabItem label="ARMv7 (32-bit)">
-    ```bash
-    curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz.sha256
-    # <checksum> <filename>
-    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    shasum -a 256 teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    # Verify that the checksums match
-    tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-    cd teleport
-    ./install
-    ```
-  </TabItem>
-
-  <TabItem label="ARM64/ARMv8 (64-bit)">
-    ```bash
-    curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz.sha256
-    # <checksum> <filename>
-    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    shasum -a 256 teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    # Verify that the checksums match
-    tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-    cd teleport
-    ./install
-    ```
-  </TabItem>
-
-  <TabItem label="Tarball">
-    ```bash
-    curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256
-    # <checksum> <filename>
-    curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    shasum -a 256 teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    # Verify that the checksums match
-    tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    cd teleport
-    ./install
-    ```
-  </TabItem>
-</Tabs>
+(!docs/pages/includes/install-steps.mdx!)
 
 ## Docker
 
@@ -93,11 +34,11 @@ helm repo add teleport https://charts.releases.teleport.dev
 helm install teleport teleport/teleport-cluster
 ```
 
-## MacOS
+## macOS
 
 <Tabs>
   <TabItem label="Download">
-    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the Installer.
+    [Download macOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the Installer.
 
     <Admonition type="note">
       This method only installs the `tsh` client for interacting with Teleport clusters.
@@ -216,7 +157,7 @@ that the open-source community has been successful in building and running Telep
 | Operating System | Teleport Client | Teleport Server |
 | - | - | - |
 | Linux v2.6.23+ | yes | yes |
-| MacOS v10.12+ | yes | yes |
+| macOS v10.12+ | yes | yes |
 | Windows \[2] | yes \[2] | no |
 
 \[1] *Teleport is written in Go and it's possible to build it on

--- a/docs/pages/production.mdx
+++ b/docs/pages/production.mdx
@@ -32,19 +32,7 @@ Before installing anything there are a few things you should think about.
 
 ## Firewall configuration
 
-Teleport services listen on several ports. This table shows the default port numbers.
-
-| Port | Service | Description | Ingress | Egress |
-| --- | --- | --- | --- | --- |
-| `443` | Proxy | Default proxy port when using ACME for TLS/SSL. | {/* TODO */} | {/* TODO */} |
-| `3022` | Node | SSH port to the Node Service. This is Teleport's equivalent of port `22` for SSH. | Allow inbound traffic from the proxy host. | Allow outbound traffic to the proxy host. |
-| `3023` | Proxy | SSH port clients connect to after authentication. A proxy will forward this connection to port `3022` on the destination node. | Allow inbound traffic from SSH clients. | Allow outbound traffic to SSH clients. |
-| `3024` | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. | {/* TODO */} | {/* TODO */} |
-| `3025` | Auth | SSH port used by the Auth Service to serve its Auth API to other nodes in a cluster. | Allow inbound connections from all cluster nodes. | Allow outbound traffic to cluster nodes. |
-| `3026` | Kubernetes | HTTPS Kubernetes proxy `proxy_service.kube_listen_addr`. Port used for `kubectl` to access Teleport. | {/* TODO */} | {/* TODO */} |
-| `3027` | Kubernetes | Kubernetes Service `kubernetes_service.listen_addr` | {/* TODO */} | {/* TODO */} |
-| `3036` | DB | Teleport MySQL proxy listen address. | {/* TODO */} | {/* TODO */} |
-| `3080` | Proxy | HTTPS port clients connect to. Used to authenticate `tsh` users and web users into the cluster. | Allow inbound connections from HTTP and SSH clients. | Allow outbound connections to HTTP and SSH clients. |
+(!docs/pages/includes/port-table.mdx!)
 
 {
   /* TODO: Add several diagrams of firewall config examples */

--- a/docs/pages/production.mdx
+++ b/docs/pages/production.mdx
@@ -35,13 +35,16 @@ Before installing anything there are a few things you should think about.
 Teleport services listen on several ports. This table shows the default port numbers.
 
 | Port | Service | Description | Ingress | Egress |
-| - | - | - | - | - |
-| `3080` | Proxy | HTTPS port clients connect to. Used to authenticate `tsh` users and web users into the cluster. | Allow inbound connections from HTTP and SSH clients. | Allow outbound connections to HTTP and SSH clients. |
-| `3023` | Proxy | SSH port clients connect to after authentication. A proxy will forward this connection to port `3022` on the destination node. | Allow inbound traffic from SSH clients. | Allow outbound traffic to SSH clients. |
+| --- | --- | --- | --- | --- |
+| `443` | Proxy | Default proxy port when using ACME for TLS/SSL. | {/* TODO */} | {/* TODO */} |
 | `3022` | Node | SSH port to the Node Service. This is Teleport's equivalent of port `22` for SSH. | Allow inbound traffic from the proxy host. | Allow outbound traffic to the proxy host. |
-| `3025` | Auth | SSH port used by the Auth Service to serve its Auth API to other nodes in a cluster. | Allow inbound connections from all cluster nodes. | Allow outbound traffic to cluster nodes. |
+| `3023` | Proxy | SSH port clients connect to after authentication. A proxy will forward this connection to port `3022` on the destination node. | Allow inbound traffic from SSH clients. | Allow outbound traffic to SSH clients. |
 | `3024` | Proxy | SSH port used to create "reverse SSH tunnels" from behind-firewall environments into a trusted proxy server. | {/* TODO */} | {/* TODO */} |
-| `3026` | Kubernetes | Port used for `kubectl` to access Teleport | {/* TODO */} | {/* TODO */} |
+| `3025` | Auth | SSH port used by the Auth Service to serve its Auth API to other nodes in a cluster. | Allow inbound connections from all cluster nodes. | Allow outbound traffic to cluster nodes. |
+| `3026` | Kubernetes | HTTPS Kubernetes proxy `proxy_service.kube_listen_addr`. Port used for `kubectl` to access Teleport. | {/* TODO */} | {/* TODO */} |
+| `3027` | Kubernetes | Kubernetes Service `kubernetes_service.listen_addr` | {/* TODO */} | {/* TODO */} |
+| `3036` | DB | Teleport MySQL proxy listen address. | {/* TODO */} | {/* TODO */} |
+| `3080` | Proxy | HTTPS port clients connect to. Used to authenticate `tsh` users and web users into the cluster. | Allow inbound connections from HTTP and SSH clients. | Allow outbound connections to HTTP and SSH clients. |
 
 {
   /* TODO: Add several diagrams of firewall config examples */
@@ -52,8 +55,6 @@ Teleport services listen on several ports. This table shows the default port num
 We have a detailed [installation guide](installation.mdx) which shows how to
 install all available binaries or [install from
 source](installation.mdx#installing-from-source). Reference that guide to learn the best way to install Teleport for your system, then return to finish your production install.
-
-(!docs/pages/includes/permission-warning.mdx!)
 
 ### Filesystem layout
 
@@ -83,6 +84,8 @@ There are a couple of important things to notice about this file:
 
 You can start Teleport via systemd unit by enabling the `.service` file
 with the `systemctl` tool.
+
+(!docs/pages/includes/permission-warning.mdx!)
 
 ```bash
 # sudo cp teleport/examples/systemd/teleport.service /etc/systemd/system

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -76,54 +76,7 @@ This guide introduces some of these common scenarios and how to interact with Te
 
 2. Install Teleport on each instance.
 
-   <Tabs>
-     <TabItem label="Amazon Linux 2/RHEL (RPM)">
-      ```bash
-      sudo yum-config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-      sudo yum install teleport
-
-      # Optional:  Using DNF on newer distributions
-      # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-      # $ sudo dnf install teleport
-      ```
-     </TabItem>
-
-     <TabItem label="Debian/Ubuntu (DEB)">
-      ```bash
-      curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-      sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-      sudo apt-get update
-      sudo apt-get install teleport
-      ```
-     </TabItem>
-
-     <TabItem label="Linux">
-      ```bash
-      curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-      tar -xzf teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
-      cd teleport
-      sudo ./install
-      ```
-     </TabItem>
-
-     <TabItem label="ARMv7 (32-bit)">
-      ```bash
-      curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-      tar -xzf teleport-v(=teleport.version=)-linux-arm-bin.tar.gz
-      cd teleport
-      sudo ./install
-      ```
-     </TabItem>
-
-     <TabItem label="ARMv8 (64-bit)">
-      ```bash
-      curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-      tar -xzf teleport-v(=teleport.version=)-linux-arm64-bin.tar.gz
-      cd teleport
-      sudo ./install
-      ```
-     </TabItem>
-   </Tabs>
+   (!docs/pages/includes/install-steps.mdx!)
 
 3. Configure Teleport on the *Bastion Host*.
 

--- a/docs/pages/setup/guides/terraform-provider.mdx
+++ b/docs/pages/setup/guides/terraform-provider.mdx
@@ -52,7 +52,7 @@ cd teleport-terraform
   ```
   </TabItem>
 
-  <TabItem label="MacOS">
+  <TabItem label="macOS">
   ```bash
   mkdir -p ${HOME?}/.terraform.d/plugins/gravitational.com/teleport/teleport/(=teleport.version=)/darwin_amd64
   curl -L -O https://get.gravitational.com/terraform-provider-teleport-v(=teleport.version=)-darwin-amd64-bin.tar.gz


### PR DESCRIPTION
Part of Refresh/Validation Pass: https://github.com/gravitational/teleport/issues/7259 - a chance to dive into each article step by step.

This is being factored out to make it easier for review. Most changes are step or command-specific.

Main items here:

1. Updated ports in Admin Guide and Production Guide to include new features. These are also ordered. Better explanation about ACME 443 port here as well (part of an ongoing effort to improve documenting this feature - a dedicated article will likely be added to the Setup Section called `Configuration` that we'll refactor many of these existing articles into).
2. Standardized all installation of Teleport steps. `sudo` was removed here. The new include is always preceded by the `sudo` warning so I think it should be clear that we recommend both non-root access and that `sudo` is implied where it should and must be used.
3. Corrected a few lingering examples of `macOS` being capitalized incorrectly. Think some of this is covered by the remaining Edit Pass but noticed a few of these.
4. Some steps were tweaked after manually testing.