### PR TITLE
Add docs section on `provider` field in SSO connectors

### DIFF
--- a/docs/pages/enterprise/sso/ssh-sso.mdx
+++ b/docs/pages/enterprise/sso/ssh-sso.mdx
@@ -131,6 +131,23 @@ spec:
       '*': '*'
 ```
 
+### Provider-Specific Workarounds
+
+Certain SSO providers may require or benefit from changes to Teleport's SSO
+flow. These provider-specific changes can be enabled by setting the
+`spec.provider` property of the connector definition to one of the following
+values to match your identity provider:
+
+- `adfs` (SAML): Required for compatibility with Active Directory (ADFS); refer
+  to the full [ADFS guide](./ssh-adfs.mdx#create-teleport-roles) for details.
+- `netiq` (OIDC): Used to enable NetIQ-specific ACR value processing; refer to
+  the [OIDC guide](./oidc.mdx#optional-acr-values) for details.
+- `ping` (SAML): Required for compatibility with Ping Identity (including
+  PingOne and PingFederate) when "Enforced Signed Authn Requests" is enabled in
+  the application settings.
+
+At this time, the `spec.provider` field should not be set for any other identity providers.
+
 ## Working with External Email Identity
 
 Along with sending groups, an SSO provider will also provide a user's email address.


### PR DESCRIPTION
This adds a section to the SSO docs describing the (currently 3) possible values for the `provider` field in SSO connectors and provides links to details where available (ADFS and NetIQ).