### PR TITLE
[v6.2] docs: add ACME and other Setup steps + Setup FAQ

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -18,7 +18,6 @@
       "icon": "wrench",
       "title": "Setup",
       "entries": [
-        { "title": "Configuration", "slug": "/setup/configuration/" },
         { "title": "Installation", "slug": "/setup/installation/" },
         {
           "title": "Guides",
@@ -28,7 +27,8 @@
             { "title": "Docker Compose", "slug": "/setup/guides/docker-compose/" },
             { "title": "Fluentd", "slug": "/setup/guides/fluentd/" }
           ]
-        }
+        },
+        { "title": "FAQ", "slug": "/setup/faq/" }
       ]
     },
     {

--- a/docs/config.json
+++ b/docs/config.json
@@ -7,7 +7,6 @@
         { "title": "Introduction", "slug": "/" },
         { "title": "Adopters", "slug": "/adopters/" },
         { "title": "Getting Started", "slug": "/getting-started/" },
-        { "title": "Installation", "slug": "/installation/" },
         { "title": "User Manual", "slug": "/user-manual/" },
         { "title": "Admin Manual", "slug": "/admin-guide/" },
         { "title": "Production Guide", "slug": "/production/" },
@@ -19,6 +18,8 @@
       "icon": "wrench",
       "title": "Setup",
       "entries": [
+        { "title": "Configuration", "slug": "/setup/configuration/" },
+        { "title": "Installation", "slug": "/setup/installation/" },
         {
           "title": "Guides",
           "slug": "/setup/guides/",
@@ -359,6 +360,11 @@
     {
       "source": "/cloud/faq/",
       "destination": "/pro/faq/",
+      "permanent": true
+    },
+    {
+      "source": "/installation/",
+      "destination": "/setup/installation/",
       "permanent": true
     }
   ]

--- a/docs/pages/admin-guide.mdx
+++ b/docs/pages/admin-guide.mdx
@@ -7,7 +7,7 @@ This manual covers the installation and configuration of Teleport and the ongoin
 
 ## Installing
 
-Please visit our [installation page](installation.mdx) for instructions on downloading and installing Teleport.
+Please visit our [installation page](setup/installation.mdx) for instructions on downloading and installing Teleport.
 
 (!docs/pages/includes/permission-warning.mdx!)
 

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -6,7 +6,7 @@ description: How to configure Teleport for Application Access.
 # Connecting Web Applications
 
 Download the latest version of Teleport for your platform from our [downloads page](https://goteleport.com/teleport/download)
-and follow the installation [instructions](../../installation.mdx).
+and follow the installation [instructions](../../setup/installation.mdx).
 
 ## Start Auth/Proxy service
 

--- a/docs/pages/aws-oss-guide.mdx
+++ b/docs/pages/aws-oss-guide.mdx
@@ -489,7 +489,7 @@ aws ec2 associate-iam-instance-profile --iam-instance-profile Name=teleport-role
 
 #### Install Teleport
 
-1. [Download and Install Teleport](installation.mdx)
+1. [Download and Install Teleport](setup/installation.mdx)
 2. [Setup systemd](production.mdx#running-teleport-in-production)
 3. Setup Teleport config file. `sudo cp teleport.yaml /etc/teleport.yaml`. An example is below.
 

--- a/docs/pages/database-access/guides/mysql-aws.mdx
+++ b/docs/pages/database-access/guides/mysql-aws.mdx
@@ -81,7 +81,7 @@ Teleport Database Access is available starting from the `6.0` release.
 
 Download the appropriate version of Teleport for your platform from our [downloads page](https://goteleport.com/teleport/download).
 
-Follow the installation [instructions](../../installation.mdx).
+Follow the installation [instructions](../../setup/installation.mdx).
 
 ### Start Auth/Proxy Service
 

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -87,7 +87,7 @@ Teleport Database Access is available starting from the `6.0` release.
 
 Download the appropriate version of Teleport for your platform from our [downloads page](https://goteleport.com/teleport/download).
 
-Follow the installation [instructions](../../installation.mdx).
+Follow the installation [instructions](../../setup/installation.mdx).
 
 ### Start the Auth/Proxy Service
 

--- a/docs/pages/database-access/guides/postgres-aws.mdx
+++ b/docs/pages/database-access/guides/postgres-aws.mdx
@@ -85,7 +85,7 @@ Teleport Database Access is available starting from the `6.0` release.
 Download the appropriate version of Teleport for your platform from
 our [downloads page](https://goteleport.com/teleport/download).
 
-Follow the installation [instructions](../../installation.mdx).
+Follow the installation [instructions](../../setup/installation.mdx).
 
 ### Start the Auth/Proxy Service
 

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -85,7 +85,7 @@ Teleport Database Access is available starting from the `6.0` release.
 Download the appropriate version of Teleport for your platform from
 our [downloads page](https://goteleport.com/teleport/download).
 
-Follow the installation [instructions](../../installation.mdx).
+Follow the installation [instructions](../../setup/installation.mdx).
 
 ### Start Auth and Proxy Services
 

--- a/docs/pages/features/enhanced-session-recording.mdx
+++ b/docs/pages/features/enhanced-session-recording.mdx
@@ -294,7 +294,7 @@ We recommend installing BCC tools using your distribution's package manager wher
 
 ## Step 3/5. Install and configure Teleport Node
 
-Follow our [installation instructions](../installation.mdx) to install Teleport Auth, Proxy
+Follow our [installation instructions](../setup/installation.mdx) to install Teleport Auth, Proxy
 and Nodes.
 
 Set up the Teleport node with this `etc/teleport.yaml`. See our [configuration file setup](../admin-guide.mdx#configuration) for more instructions.

--- a/docs/pages/gcp-guide.mdx
+++ b/docs/pages/gcp-guide.mdx
@@ -112,7 +112,7 @@ We recommend starting by creating the resources. We highly recommend creating th
 
 ### Install and configure Teleport
 
-Follow install instructions from our [installation page](installation.mdx#linux).
+Follow install instructions from our [installation page](setup/installation.mdx#linux).
 
 We recommend further configuring Teleport using the following steps.
 

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -78,7 +78,7 @@ Teleport (=teleport.version=) on Linux machines.
   </TabItem>
 </Tabs>
 
-Take a look at the [Installation Guide](installation.mdx) for more options.
+Take a look at the [Installation Guide](setup/installation.mdx) for more options.
 
 ### Configure Teleport
 
@@ -179,7 +179,7 @@ Here's a selection of compatible two-factor authentication apps:
   </TabItem>
 
   <TabItem label="Linux">
-    For more options (including RPM/DEB packages and downloads for i386/ARM/ARM64) please see our [installation page](installation.mdx).
+    For more options (including RPM/DEB packages and downloads for i386/ARM/ARM64) please see our [installation page](setup/installation.mdx).
 
     ```bash
     curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-linux-amd64-bin.tar.gz
@@ -315,7 +315,7 @@ Add a new application:
 
 Check out our collection of step-by-step guides for common Teleport tasks.
 
-- [Install Teleport](installation.mdx)
+- [Install Teleport](setup/installation.mdx)
 - [Admin Guide](admin-guide.mdx)
 - [Share Sessions](user-manual.mdx#sharing-sessions)
 - [Manage Users](admin-guide.mdx#adding-and-deleting-users)

--- a/docs/pages/includes/insecure-flag.mdx
+++ b/docs/pages/includes/insecure-flag.mdx
@@ -1,0 +1,3 @@
+<Admonition type="warning" title="Warning">
+  The `--insecure` flag is not recommended in production but can be used to bypass certain TLS and port requirements when testing locally.
+</Admonition>

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -212,7 +212,7 @@ kubectl exec -ti ${POD?} -- tctl users add alice --roles=member
 ```
 
 Let's install `tsh` and `tctl` on Linux.
-For other install options, check out [install guide](../installation.mdx)
+For other install options, check out [install guide](../setup/installation.mdx)
 
 <Tabs>
   <TabItem label="Open Source">

--- a/docs/pages/production.mdx
+++ b/docs/pages/production.mdx
@@ -13,7 +13,7 @@ This guide provides more in-depth details for running Teleport in Production.
 ## Prerequisites
 
 - Read the [Architecture Overview](architecture/overview.mdx)
-- Read through the [Installation Guide](installation.mdx) to see the available packages and binaries available.
+- Read through the [Installation Guide](setup/installation.mdx) to see the available packages and binaries available.
 - Read the CLI Docs for [`teleport`](cli-docs.mdx#teleport)
 
 ## Designing your cluster
@@ -49,9 +49,9 @@ Teleport services listen on several ports. This table shows the default port num
 
 ## Installation
 
-We have a detailed [installation guide](installation.mdx) which shows how to
+We have a detailed [installation guide](setup/installation.mdx) which shows how to
 install all available binaries or [install from
-source](installation.mdx#installing-from-source). Reference that guide to learn the best way to install Teleport for your system, then return to finish your production install.
+source](setup/installation.mdx#installing-from-source). Reference that guide to learn the best way to install Teleport for your system, then return to finish your production install.
 
 (!docs/pages/includes/permission-warning.mdx!)
 

--- a/docs/pages/setup/configuration.mdx
+++ b/docs/pages/setup/configuration.mdx
@@ -3,11 +3,11 @@ title: Teleport Configuration
 description: A general guide to common Teleport configuration scenarios and questions.
 ---
 
-This guide is intended to address several common scenario's you're likely to encounter when setting up Teleport for the first time.
+This guide is intended to address several common scenarios you're likely to encounter when setting up Teleport for the first time.
 
 (!docs/pages/includes/permission-warning.mdx!)
 
-## ACME
+## Let's Encrypt ACME
 
 By default, Teleport requires a valid TLS certificate to operate and can fetch one automatically
 using the [Let's Encrypt ACME](https://letsencrypt.org/how-it-works/) standard through a [TLS_ALPN-01](https://datatracker.ietf.org/doc/html/rfc8737) challenge.
@@ -48,13 +48,32 @@ proxy_service:
      192.168.1.1
 
      # Good
+     example.com
      tele.example.com
-     test.website.com
      subdomain.domain.net
      ```
 
   3. The Teleport Proxy Node (`public_addr`) must be publicly accessible over port `443`.
 </Admonition>
+
+## Subdomain configuration
+
+If you foresee a significant amount of testing or testing using many Teleport Nodes, you'll likely want to configure TLS by subdomain name (rather than domain name). 
+
+Doing so will allow you to use the same, top-level, domain name but avoid rate-limiting and some cross-site restrictions when testing.
+
+To add a subdomain to your existing domain name (`example.com`):
+
+1. Create an `A` record in your domain registrar entry for the new subdomain (`tele`).
+2. Supply the relevant IP address as the `A` record value for the new subdomain.
+
+<Figure
+  align="center"
+  bordered
+  caption="Subdomain and IP mapping"
+>
+  ![Subdomain and IP mapping](../../img/server-access/subdomains.png)
+</Figure>
 
 ## The insecure flag
 
@@ -72,7 +91,7 @@ There are generally two places where you'll likely disable this feature:
   tsh login --proxy=localhost:3080 --insecure --user=testuser
   ```
 
-2. Pass the flag when starting a Teleport Node through the command-line: 
+2. Pass the flag when starting a Teleport Node through the command line: 
 
   ```bash
   sudo teleport start --insecure

--- a/docs/pages/setup/configuration.mdx
+++ b/docs/pages/setup/configuration.mdx
@@ -101,6 +101,8 @@ There are generally two places where you'll likely disable this feature:
   `--insecure` is `disabled` by default and can be permanently overidden using YAML.
 </Admonition>
 
+(!docs/pages/includes/insecure-certificate.mdx!)
+
 Quick links:
 
 - Read the [tsh --insecure](../cli-docs.mdx#tsh) Reference Documentation

--- a/docs/pages/setup/configuration.mdx
+++ b/docs/pages/setup/configuration.mdx
@@ -1,0 +1,89 @@
+---
+title: Teleport Configuration
+description: A general guide to common Teleport configuration scenarios and questions.
+---
+
+This guide is intended to address several common scenario's you're likely to encounter when setting up Teleport for the first time.
+
+(!docs/pages/includes/permission-warning.mdx!)
+
+## ACME
+
+By default, Teleport requires a valid TLS certificate to operate and can fetch one automatically
+using the [Let's Encrypt ACME](https://letsencrypt.org/how-it-works/) standard through a [TLS_ALPN-01](https://datatracker.ietf.org/doc/html/rfc8737) challenge.
+
+Configure Teleport to obtain a TLS certificate through the command line:
+
+```bash
+sudo teleport configure --acme --acme-email=user@example.com --cluster-name=tele.example.com -o file
+```
+
+Or through YAML:
+
+```yaml
+proxy_service:
+  enabled: "yes"
+  listen_addr: 0.0.0.0:3023
+  web_listen_addr: :443
+  public_addr: tele.example.com:443
+  https_keypairs: []
+  acme:
+    enabled: "yes"
+    email: user@example.com
+```
+
+(Configuring Teleport to use ACME through the command line will generate the above YAML for you automatically.)
+
+<Admonition type="note" title="ACME Requirements">
+  When using ACME:
+
+  1. Let's Encrypt ACME will use the value supplied by `--cluster-name` and/or `public_addr`. If both are used, they must match to the domain or subdomain name.
+  
+  2. Let's Encrypt ACME doesn't support using `localhost`, `127.0.0.1`, or any numeric IP Address. The supplied address must be a domain name:
+
+     ```
+     # Bad
+     127.0.0.1
+     localhost
+     192.168.1.1
+
+     # Good
+     tele.example.com
+     test.website.com
+     subdomain.domain.net
+     ```
+
+  3. The Teleport Proxy Node (`public_addr`) must be publicly accessible over port `443`.
+</Admonition>
+
+## The insecure flag
+
+While we generally don't recommend disabling Teleport's in-built TLS, certificate, and security verifications in some circumstances it may be desirable to temporarily disable (or skip) Teleport's default behavior. 
+
+For example, one might wish to skip configuring domain name registration or obtaining an ACME TLS certificate to quickly get set up locally. In another circumstance, one might wish to test Teleport with heightened port restrictions.
+
+(!docs/pages/includes/insecure-flag.mdx!)
+
+There are generally two places where you'll likely disable this feature:
+
+1. Pass the `--insecure` flag when connecting to an SSH server or a Teleport SSH Node: 
+
+  ```bash
+  tsh login --proxy=localhost:3080 --insecure --user=testuser
+  ```
+
+2. Pass the flag when starting a Teleport Node through the command-line: 
+
+  ```bash
+  sudo teleport start --insecure
+  ```
+
+<Admonition type="tip" title="Tip">
+  `--insecure` is `disabled` by default and can be permanently overidden using YAML.
+</Admonition>
+
+Quick links:
+
+- Read the [tsh --insecure](../cli-docs.mdx#tsh) Reference Documentation
+- Read the [tctl --insecure](../cli-docs.mdx#tctl) Reference Documentation
+- Read the [teleport --insecure](../cli-docs.mdx#teleport) Reference Documentation

--- a/docs/pages/setup/faq.mdx
+++ b/docs/pages/setup/faq.mdx
@@ -1,6 +1,6 @@
 ---
-title: Teleport Configuration
-description: A general guide to common Teleport configuration scenarios and questions.
+title: Teleport Setup FAQ
+description: FAQ covering common Teleport configuration scenarios and questions.
 ---
 
 This guide is intended to address several common scenarios you're likely to encounter when setting up Teleport for the first time.

--- a/docs/pages/setup/guides/docker-compose.mdx
+++ b/docs/pages/setup/guides/docker-compose.mdx
@@ -118,9 +118,7 @@ Open a second terminal and issue the command:
 tsh login --proxy=localhost:3080 --insecure --user=testuser
 ```
 
-<Admonition type="note" title="Note">
-  The `--insecure` flag is not recommended in production but can be used to bypass certain TLS and port requirements when testing locally.
-</Admonition>
+(!docs/pages/includes/insecure-flag.mdx!)
 
 You will be prompted to enter the password and One-Time Passcode you created for your user `testuser`:
 
@@ -175,4 +173,4 @@ root@localhost:~#
 - [Remove your user](../../cli-docs.mdx#tctl-users-add) to restart the quickstart.
 - Try out one of our [Helm Guides](../../kubernetes-access/helm/guides.mdx).
 - Try out one of our [Database Access Guides](../../database-access/guides.mdx).
-- Learn about the [Teleport Server Access](../../server-access/introduction.mdx).
+- Learn about [Teleport Server Access](../../server-access/introduction.mdx).

--- a/docs/pages/setup/installation.mdx
+++ b/docs/pages/setup/installation.mdx
@@ -78,7 +78,7 @@ up-to-date information.
 
 ## Docker
 
-Please follow our [Getting started with Teleport using Docker](./setup/guides/docker-compose.mdx#quickstart-using-docker-run) or with [Teleport Enterprise using Docker](enterprise/quickstart-enterprise.mdx#run-teleport-enterprise-using-docker) for install and setup instructions.
+Please follow our [Getting started with Teleport using Docker](./guides/docker-compose.mdx#quickstart-using-docker-run) or with [Teleport Enterprise using Docker](../enterprise/quickstart-enterprise.mdx#run-teleport-enterprise-using-docker) for install and setup instructions.
 
 ```bash
 docker pull quay.io/gravitational/teleport:(=teleport.version=)

--- a/docs/pages/setup/installation.mdx
+++ b/docs/pages/setup/installation.mdx
@@ -4,7 +4,7 @@ description: The guide for installing Teleport on servers and into Kubernetes cl
 h1: Installation
 ---
 
-Teleport core service [`teleport`](cli-docs.mdx#teleport) and admin tool [`tctl`](cli-docs.mdx#tctl) have been designed to run on **Linux** and **Mac** operating systems. The Teleport user client [`tsh`](cli-docs.mdx#tsh) and UI are available for **Linux, Mac**, and **Windows** operating systems.
+Teleport core service [`teleport`](../cli-docs.mdx#teleport) and admin tool [`tctl`](../cli-docs.mdx#tctl) have been designed to run on **Linux** and **Mac** operating systems. The Teleport user client [`tsh`](../cli-docs.mdx#tsh) and UI are available for **Linux, Mac**, and **Windows** operating systems.
 
 ## Linux
 
@@ -194,7 +194,7 @@ If the build succeeds, the binaries `teleport, tsh`, and `tctl` are now in the d
 Gravitational Teleport provides a checksum from the [Downloads](https://gravitational.com/teleport/download/).
 This should be used to verify the integrity of our binary.
 
-![Teleport Checksum](../img/teleport-sha.png)
+![Teleport Checksum](../../img/teleport-sha.png)
 
 If you download Teleport via an automated system, you can programmatically
 obtain the checksum by adding `.sha256` to the binary. This is the method shown


### PR DESCRIPTION
This PR:

1. Addresses: https://github.com/gravitational/teleport/issues/7204
2. Provides additional instructions to assist with: https://github.com/gravitational/teleport/issues/6448
3. Support wider efforts surrounding: https://github.com/gravitational/teleport/issues/4117
4. Moves the Installation Guide to the new Setup Section. (There are pending changes for that Guide so this should be merged or updated after those other items get merged.)
5. Addresses: https://github.com/gravitational/teleport/issues/2040 with updates.

Two previous tickets are relevant:

1. https://github.com/gravitational/teleport/issues/6716
2. https://github.com/gravitational/teleport/issues/6696

I've reviewed most of our existing ACME documentation and it's pretty scant, covers how to automatically acquire a cert through the command line and addressed 443 but not in a consistent way. Ideally, we'd be refactoring all of those items into this one as well but for now, we'll likely leave them in place (we now have a target destination for anything about ACME if we decide to simply redirect/link people to this article - open to that as well).

Also, we mention that we recommend using subdomains in a few places but don't go into much detail about this. The comments above apply to this as well. Ideally all "setup" (read: first time or very common installation steps would be moved in here too).