### PR TITLE
Backport #6989 into the v6 branch

### DIFF
--- a/docs/pages/config-reference.mdx
+++ b/docs/pages/config-reference.mdx
@@ -333,6 +333,9 @@ ssh_service:
         enabled: no
         service_name: teleport
 
+    # Enables/disables TCP forwarding. Default is 'true'
+    port_forwarding: true
+
 # This section configures the 'proxy service'
 proxy_service:
     # Turns 'proxy' role on. Default is 'yes'

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"time"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/trace"
+	"gopkg.in/check.v1"
+)
+
+func extractPort(svr *httptest.Server) (int, error) {
+	u, err := url.Parse(svr.URL)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	n, err := strconv.Atoi(u.Port())
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+	return n, nil
+}
+
+func waitForSessionToBeEstablished(ctx context.Context, namespace string, site auth.ClientI) ([]session.Session, error) {
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+
+		case <-ticker.C:
+			ss, err := site.GetSessions(namespace)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if len(ss) > 0 {
+				return ss, nil
+			}
+		}
+	}
+}
+
+func (s *IntSuite) TestPortForwarding(c *check.C) {
+	s.setUpTest(c)
+	defer s.tearDownTest(c)
+
+	testCases := []struct {
+		desc                  string
+		portForwardingAllowed bool
+		expectSuccess         bool
+	}{
+		{
+			desc:                  "Enabled",
+			portForwardingAllowed: true,
+			expectSuccess:         true,
+		}, {
+			desc:                  "Disabled",
+			portForwardingAllowed: false,
+			expectSuccess:         false,
+		},
+	}
+
+	for _, tt := range testCases {
+		doTest := func() {
+			// Given a running teleport instance with port forwarding
+			// permissions set per the test case
+
+			cfg := s.defaultServiceConfig()
+			cfg.Auth.Enabled = true
+			cfg.Proxy.Enabled = true
+			cfg.Proxy.DisableWebService = false
+			cfg.Proxy.DisableWebInterface = true
+			cfg.SSH.Enabled = true
+			cfg.SSH.AllowTCPForwarding = tt.portForwardingAllowed
+
+			teleport := s.newTeleportWithConfig(c, nil, nil, cfg)
+			defer teleport.StopAll()
+
+			site := teleport.GetSiteAPI(Site)
+
+			// ...and a running dummy server
+			remoteSvr := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("Hello, World"))
+				}))
+			defer remoteSvr.Close()
+
+			// ... and a client connection that was launched with port
+			// forwarding enabled to that dummy server
+			localPort := ports.PopInt()
+			remotePort, err := extractPort(remoteSvr)
+			c.Assert(err, check.IsNil)
+
+			nodeSSHPort := teleport.GetPortSSHInt()
+			cl, err := teleport.NewClient(ClientConfig{
+				Login:   s.me.Username,
+				Cluster: Site,
+				Host:    Host,
+				Port:    nodeSSHPort,
+			})
+			c.Assert(err, check.IsNil)
+			cl.Config.LocalForwardPorts = []client.ForwardedPort{
+				{
+					SrcIP:    "127.0.0.1",
+					SrcPort:  localPort,
+					DestHost: "localhost",
+					DestPort: remotePort,
+				},
+			}
+			term := NewTerminal(250)
+			cl.Stdout = term
+			cl.Stdin = term
+
+			sshSessionCtx, sshSessionCancel := context.WithCancel(context.Background())
+			go cl.SSH(sshSessionCtx, []string{}, false)
+			defer sshSessionCancel()
+
+			timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, err = waitForSessionToBeEstablished(timeout, apidefaults.Namespace, site)
+			c.Assert(err, check.IsNil)
+
+			// When everything is *finally* set up, and I attempt to use the
+			// forwarded connection
+			localURL := fmt.Sprintf("http://%s:%d/", "localhost", localPort)
+			r, err := http.Get(localURL)
+
+			if r != nil {
+				r.Body.Close()
+			}
+
+			if tt.expectSuccess {
+				c.Assert(err, check.IsNil)
+				c.Assert(r, check.NotNil)
+			} else {
+				c.Assert(err, check.NotNil)
+			}
+		}
+		doTest()
+	}
+}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -803,6 +803,8 @@ func applySSHConfig(fc *FileConfig, cfg *service.Config) (err error) {
 		}
 	}
 
+	cfg.SSH.AllowTCPForwarding = fc.SSH.AllowTCPForwarding()
+
 	return nil
 }
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -835,6 +835,23 @@ type SSH struct {
 
 	// BPF is used to configure BPF-based auditing for this node.
 	BPF *BPF `yaml:"enhanced_recording,omitempty"`
+
+	// MaybeAllowTCPForwarding enables or disables TCP port forwarding. We're
+	// using a pointer-to-bool here because the system default is to allow TCP
+	// forwarding, we need to distinguish between an unset value and a false
+	// value so we can an override unset value with `true`.
+	//
+	// Don't read this value directly: call the AllowTCPForwarding method
+	// instead.
+	MaybeAllowTCPForwarding *bool `yaml:"port_forwarding,omitempty"`
+}
+
+// AllowTCPForwarding checks whether the config file allows TCP forwarding or not.
+func (ssh *SSH) AllowTCPForwarding() bool {
+	if ssh.MaybeAllowTCPForwarding == nil {
+		return true
+	}
+	return *ssh.MaybeAllowTCPForwarding
 }
 
 // CommandLabel is `command` section of `ssh_service` in the config file

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -523,6 +523,9 @@ type SSHConfig struct {
 	//
 	// See github.com/gravitational/teleport/issues/4141 for details.
 	ProxyReverseTunnelFallbackAddr *utils.NetAddr
+
+	// AllowTCPForwarding indicates that TCP port forwarding is allowed on this node
+	AllowTCPForwarding bool
 }
 
 // KubeConfig specifies configuration for kubernetes service
@@ -863,6 +866,7 @@ func ApplyDefaults(cfg *Config) {
 	defaults.ConfigureLimiter(&cfg.SSH.Limiter)
 	cfg.SSH.PAM = &pam.Config{Enabled: false}
 	cfg.SSH.BPF = &bpf.Config{Enabled: false}
+	cfg.SSH.AllowTCPForwarding = true
 
 	// Kubernetes service defaults.
 	cfg.Kube.Enabled = false

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -83,6 +83,7 @@ func TestDefaultConfig(t *testing.T) {
 	ssh := config.SSH
 	require.Equal(t, ssh.Limiter.MaxConnections, int64(defaults.LimiterMaxConnections))
 	require.Equal(t, ssh.Limiter.MaxNumberOfUsers, defaults.LimiterMaxConcurrentUsers)
+	require.Equal(t, ssh.AllowTCPForwarding, true)
 
 	// proxy section
 	proxy := config.Proxy

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1771,6 +1771,7 @@ func (process *TeleportProcess) initSSH() error {
 					process.BroadcastEvent(Event{Name: TeleportOKEvent, Payload: teleport.ComponentNode})
 				}
 			}),
+			regular.SetAllowTCPForwarding(cfg.SSH.AllowTCPForwarding),
 		)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -160,6 +160,10 @@ type Server struct {
 
 	// wtmpPath is the path to the user accounting log.
 	wtmpPath string
+
+	// allowTCPForwarding indicates whether the ssh server is allowed to offer
+	// TCP port forwarding.
+	allowTCPForwarding bool
 }
 
 // GetClock returns server clock implementation
@@ -490,6 +494,16 @@ func SetOnHeartbeat(fn func(error)) ServerOption {
 	}
 }
 
+// SetAllowTCPForwarding sets the TCP port forwarding mode that this server is
+// allowed to offer. The default value is SSHPortForwardingModeAll, i.e. port
+// forwarding is allowed.
+func SetAllowTCPForwarding(allow bool) ServerOption {
+	return func(s *Server) error {
+		s.allowTCPForwarding = allow
+		return nil
+	}
+}
+
 // New returns an unstarted server
 func New(addr utils.NetAddr,
 	hostname string,
@@ -508,15 +522,16 @@ func New(addr utils.NetAddr,
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	s := &Server{
-		addr:            addr,
-		authService:     authService,
-		hostname:        hostname,
-		proxyPublicAddr: proxyPublicAddr,
-		uuid:            uuid,
-		cancel:          cancel,
-		ctx:             ctx,
-		clock:           clockwork.NewRealClock(),
-		dataDir:         dataDir,
+		addr:               addr,
+		authService:        authService,
+		hostname:           hostname,
+		proxyPublicAddr:    proxyPublicAddr,
+		uuid:               uuid,
+		cancel:             cancel,
+		ctx:                ctx,
+		clock:              clockwork.NewRealClock(),
+		dataDir:            dataDir,
+		allowTCPForwarding: true,
 	}
 	s.limiter, err = limiter.NewLimiter(limiter.Config{})
 	if err != nil {
@@ -1017,7 +1032,7 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 					Reason:  events.SessionRejectedReasonMaxSessions,
 					Maximum: max,
 				}); err != nil {
-					log.WithError(err).Warn("Failed to emit sesion reject event.")
+					log.WithError(err).Warn("Failed to emit session reject event.")
 				}
 				rejectChannel(nch, ssh.Prohibited, fmt.Sprintf("too many session channels for user %q (max=%d)", identityContext.TeleportUser, max))
 				return
@@ -1059,6 +1074,24 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 	}
 }
 
+// canPortForward determines if port forwarding is allowed for the current
+// user/role/node combo. Returns nil if port forwarding is allowed, non-nil
+// if denied.
+func (s *Server) canPortForward(scx *srv.ServerContext, channel ssh.Channel) error {
+	// Is the node configured to allow port forwarding?
+	if !s.allowTCPForwarding {
+		return trace.AccessDenied("node does not allow port forwarding")
+	}
+
+	// Check if the role allows port forwarding for this user.
+	err := s.authHandlers.CheckPortForward(scx.DstAddr, scx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // handleDirectTCPIPRequest handles port forwarding requests.
 func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.ConnectionContext, identityContext srv.IdentityContext, channel ssh.Channel, req *sshutils.DirectTCPIPReq) {
 	// Create context for this channel. This context will be closed when
@@ -1078,9 +1111,9 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 
 	channel = scx.TrackActivity(channel)
 
-	// Check if the role allows port forwarding for this user.
-	err = s.authHandlers.CheckPortForward(scx.DstAddr, scx)
-	if err != nil {
+	// Bail out now if TCP port forwarding is not allowed for this node/user/role
+	// combo
+	if err = s.canPortForward(scx, channel); err != nil {
 		writeStderr(channel, err.Error())
 		return
 	}


### PR DESCRIPTION
Backports #6989 into the v6 branch.

Only major change from v7 line is reverting tests to use `check` framework instead of `testing` and `testify`.