### PR TITLE
drone: Resign pipeline for drone.teleport.dev

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -186,6 +186,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -296,6 +297,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -435,6 +437,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -536,6 +539,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -641,6 +645,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -742,6 +747,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -940,6 +946,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -1041,6 +1048,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -1374,6 +1382,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -1477,6 +1486,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -1583,6 +1593,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -1688,6 +1699,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -1814,6 +1826,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -1942,6 +1955,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -2064,6 +2078,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -2178,6 +2193,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -2281,6 +2297,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -2407,6 +2424,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -2529,6 +2547,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -3018,6 +3037,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -3121,6 +3141,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -3238,6 +3259,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -3355,6 +3377,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -3481,6 +3504,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -3612,6 +3636,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: tmpfs
     path: /tmpfs
@@ -3719,6 +3744,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -4172,6 +4198,7 @@ steps:
 services:
 - name: Start Docker
   image: docker:dind
+  privileged: true
   volumes:
   - name: dockersock
     path: /var/run
@@ -4481,6 +4508,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 879948fdc442d6fa5af8dab4564d006354802aedc54dbcea67f5fa8cbbb76040
+hmac: 4af898bb73e8904bfeea5feea043a0a8f35ebd4347dbf15d151398af1d032467
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1193,6 +1193,7 @@ steps:
 services:
   - name: Start Docker
     image: docker:dind
+    privileged: true
     volumes:
       - name: dockersock
         path: /var/run
@@ -3857,6 +3858,7 @@ steps:
 services:
   - name: Start Docker
     image: docker:dind
+    privileged: true
     volumes:
       - name: dockersock
         path: /var/run
@@ -3957,6 +3959,7 @@ steps:
 services:
   - name: Start Docker
     image: docker:dind
+    privileged: true
     volumes:
       - name: dockersock
         path: /var/run
@@ -4060,6 +4063,7 @@ steps:
 services:
   - name: Start Docker
     image: docker:dind
+    privileged: true
     volumes:
       - name: dockersock
         path: /var/run
@@ -4486,6 +4490,7 @@ steps:
 services:
   - name: Start Docker
     image: docker:dind
+    privileged: true
     volumes:
       - name: dockersock
         path: /var/run
@@ -4508,6 +4513,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 4af898bb73e8904bfeea5feea043a0a8f35ebd4347dbf15d151398af1d032467
+hmac: 7aa9349b1d1bd6a6b60aaa47abda52c8b2eaf7772a576195f40f38174717cae0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1699,7 +1699,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -1830,7 +1830,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -1958,7 +1958,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -2075,7 +2075,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -2292,7 +2292,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -2423,7 +2423,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -3132,7 +3132,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -3249,7 +3249,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -3366,7 +3366,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -3497,7 +3497,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:329
+# Generated at dronegen/tag.go:330
 ################################################
 
 kind: pipeline
@@ -4481,6 +4481,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: cfe54e610604e21c5b7a3778d6a12988f5aa9edf0c83c9a2ca4037b3222c1381
+hmac: 879948fdc442d6fa5af8dab4564d006354802aedc54dbcea67f5fa8cbbb76040
 
 ...

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -74,9 +74,10 @@ type buildType struct {
 // It includes the Docker socket volume by default, plus any extra volumes passed in
 func dockerService(v ...volumeRef) service {
 	return service{
-		Name:    "Start Docker",
-		Image:   "docker:dind",
-		Volumes: append(v, volumeRefDocker),
+		Name:       "Start Docker",
+		Image:      "docker:dind",
+		Privileged: true,
+		Volumes:    append(v, volumeRefDocker),
 	}
 }
 

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -133,9 +133,10 @@ type volumeClaim struct {
 }
 
 type service struct {
-	Name    string      `yaml:"name"`
-	Image   string      `yaml:"image"`
-	Volumes []volumeRef `yaml:"volumes"`
+	Name       string      `yaml:"name"`
+	Image      string      `yaml:"image"`
+	Privileged bool        `yaml:"privileged"`
+	Volumes    []volumeRef `yaml:"volumes"`
 }
 
 type volumeRef struct {


### PR DESCRIPTION
Runs `make dronegen` to resign the Drone pipeline for https://drone.teleport.dev

This also adds `privileged: true` to all uses of `docker:dind` to provide the necessary privileged environment for running Docker-in-Docker. This wasn't needed on the previous Drone instance because `docker:dind` was a "whitelisted" image at the Drone level (and therefore always ran in privileged mode) but in the interests of security and clarity, @wadells and I decided to disable this behaviour on the new Drone instance and be explicit when privileged mode is being used.

Backports/versions required:
- `branch/v6.2`
- `branch/v6`
- `branch/5.0`
- `branch/4.4`