### PR TITLE
Parse AWS info from RDS/Redshift endpoint

### DIFF
--- a/api/types/databaseserver_test.go
+++ b/api/types/databaseserver_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDatabaseServerRDSEndpoint verifies AWS info is correctly populated
+// based on the RDS endpoint.
+func TestDatabaseServerRDSEndpoint(t *testing.T) {
+	server, err := NewDatabaseServerV3("rds", nil, DatabaseServerSpecV3{
+		Protocol: "postgres",
+		URI:      "aurora-instance-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432",
+		Hostname: "host-1",
+		HostID:   "host-1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, AWS{
+		Region: "us-west-1",
+	}, server.GetAWS())
+}
+
+// TestDatabaseServerRedshiftEndpoint verifies AWS info is correctly populated
+// based on the Redshift endpoint.
+func TestDatabaseServerRedshiftEndpoint(t *testing.T) {
+	server, err := NewDatabaseServerV3("redshift", nil, DatabaseServerSpecV3{
+		Protocol: "postgres",
+		URI:      "redshift-cluster-1.abcdefghijklmnop.us-east-1.redshift.amazonaws.com:5438",
+		Hostname: "host-1",
+		HostID:   "host-1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, AWS{
+		Region: "us-east-1",
+		Redshift: Redshift{
+			ClusterID: "redshift-cluster-1",
+		},
+	}, server.GetAWS())
+}

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1403,21 +1403,6 @@ db_service:
 `,
 			outError: `invalid database "foo" address`,
 		},
-		{
-			desc: "missing Redshift region",
-			inConfigString: `
-db_service:
-  enabled: true
-  databases:
-  - name: foo
-    protocol: postgres
-    uri: 192.168.1.1:5438
-    aws:
-      redshift:
-        cluster_id: cluster-1
-`,
-			outError: `missing AWS region for Redshift database "foo"`,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -667,12 +667,6 @@ func (d *Database) Check() error {
 				d.Name, err)
 		}
 	}
-	// Validate Redshift specific configuration.
-	if d.AWS.Redshift.ClusterID != "" {
-		if d.AWS.Region == "" {
-			return trace.BadParameter("missing AWS region for Redshift database %q", d.Name)
-		}
-	}
 	// Validate Cloud SQL specific configuration.
 	switch {
 	case d.GCP.ProjectID != "" && d.GCP.InstanceID == "":

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -283,20 +283,6 @@ func TestCheckDatabase(t *testing.T) {
 			outErr: true,
 		},
 		{
-			desc: "Redshift region not set",
-			inDatabase: Database{
-				Name:     "example",
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "redshift-cluster-1.aaa.us-east-1.redshift.amazonaws.com:5439",
-				AWS: DatabaseAWS{
-					Redshift: DatabaseAWSRedshift{
-						ClusterID: "redshift-cluster-1",
-					},
-				},
-			},
-			outErr: true,
-		},
-		{
 			desc: "MongoDB connection string",
 			inDatabase: Database{
 				Name:     "example",

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -169,7 +169,7 @@ func New(ctx context.Context, config Config) (*Server, error) {
 	// starting up dynamic labels and loading root certs for RDS dbs.
 	for _, db := range server.cfg.Servers {
 		if err := server.initDatabaseServer(ctx, db); err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.Wrap(err, "failed to initialize %v", server)
 		}
 	}
 
@@ -186,6 +186,7 @@ func (s *Server) initDatabaseServer(ctx context.Context, server types.DatabaseSe
 	if err := s.initCACert(ctx, server); err != nil {
 		return trace.Wrap(err)
 	}
+	s.log.Debugf("Initialized %v.", server)
 	return nil
 }
 


### PR DESCRIPTION
This PR simplifies database access configuration for AWS-hosted databases by extracting information such as region and cluster ID from the RDS/Redshift endpoint if they're not set explicitly in the config.

This also applies automatically to starting database service with CLI flags as well, and will simplify getting started experience and database configuration via UI.

With these changes the config that previously looked like this:

```yaml
- name: "aurora"
  protocol: "postgres"
  uri: "aurora-instance-1.abcdefg.us-west-1.rds.amazonaws.com:5432"
  aws:
    region: "us-west-1"

- name: "redshift"
  protocol: "postgres"
  uri: "redshift-cluster-1.abcdefg.us-east-1.redshift.amazonaws.com:5439"
  aws:
    region: "us-east-1"
    redshift:
      cluster_id: "redshift-cluster-1"
```

can now be written like this:

```yaml
- name: "aurora"
  protocol: "postgres"
  uri: "aurora-instance-1.abcdefg.us-west-1.rds.amazonaws.com:5432"

- name: "redshift"
  protocol: "postgres"
  uri: "redshift-cluster-1.abcdefg.us-east-1.redshift.amazonaws.com:5439"
```

Closes https://github.com/gravitational/teleport/issues/7260.