### PR TITLE
Make CSP more strict

### DIFF
--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -63,13 +63,18 @@ func SetIndexHTMLHeaders(h http.Header) {
 
 	// Set content policy flags
 	var cspValue = strings.Join([]string{
-		// enterprise version uses stripe.com to update billing information
+		"default-src 'self'",
+		// cloud version uses stripe.com to update billing information
 		"script-src 'self' https://js.stripe.com",
-		// 'unsafe-inline' needed for reactjs inline styles
+		"frame-src https://js.stripe.com",
+		"frame-ancestors 'none'",
+		// 'unsafe-inline' is required by CSS-in-JS to work
 		"style-src 'self' 'unsafe-inline'",
 		"object-src 'none'",
 		"img-src 'self' data: blob:",
+		"font-src 'self' data:",
 		"base-uri 'self'",
+		"form-action 'self'",
 	}, ";")
 
 	h.Set("Content-Security-Policy", cspValue)


### PR DESCRIPTION
This PR adds the following CSP directives:

`default-src 'self'` - a default fallback for all directives that are not explicitly set. Self means that site content is restricted to its origin.

`frame-src` - specifies a set of sources for iframes that Teleport Web UI can host. 
`frame-ancestors 'none'` - disallows anyone from hosting Teleport Web UI in the iframe. This is in addition to existing `X-Frame-Options` 
