### PR TITLE
bpf: Add build support to FIPS Dockerfile

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2647,6 +2647,12 @@ steps:
     environment:
       OS: darwin
       ARCH: amd64
+      APPLE_USERNAME:
+        from_secret: APPLE_USERNAME
+      APPLE_PASSWORD:
+        from_secret: APPLE_PASSWORD
+      BUILDBOX_PASSWORD:
+        from_secret: BUILDBOX_PASSWORD
       OSS_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
       ENT_TARBALL_PATH: /tmp/build-darwin-amd64-pkg/go/artifacts
       WORKSPACE_DIR: /tmp/build-darwin-amd64-pkg
@@ -2654,6 +2660,13 @@ steps:
       - set -u
       - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
       - export VERSION=$(cat $WORKSPACE_DIR/go/.version.txt)
+      # set HOME explicitly (as Drone overrides it normally)
+      - export HOME=/Users/build
+      # unlock login keychain
+      - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
+      # show available certificates
+      - security find-identity -v
+      # build teleport pkg
       - make pkg OS=$OS ARCH=$ARCH
 
   - name: Copy Mac pkg artifacts
@@ -2797,7 +2810,7 @@ steps:
       - security unlock-keychain -p $${BUILDBOX_PASSWORD} login.keychain
       # show available certificates
       - security find-identity -v
-      # build pkg
+      # build tsh pkg
       - make pkg-tsh OS=$OS ARCH=$ARCH
 
   - name: Copy Mac tsh pkg artifacts
@@ -4386,6 +4399,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 6fb06de638133160c0989682a9034201405e43ee5b74f6f263cca7b0f69651c6
+hmac: a6eb9db27be4297501980988a17b963076717be5b64fe774bb47f742d5c8b493
 
 ...

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -77,8 +77,9 @@ RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNT
     chmod a-w /
 
 # Install libbpf
-RUN mkdir -p /opt && cd /opt && curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v0.3.tar.gz | tar xz && \
-    cd /opt/libbpf-0.3/src && \
+ARG LIBBPF_VERSION
+RUN mkdir -p /opt && cd /opt && curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+    cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make && \
     make install
 

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -19,9 +19,31 @@ ENV LANGUAGE="en_US.UTF-8" \
 
 RUN apt-get update -y --fix-missing && \
     apt-get -q -y upgrade && \
-    apt-get install -q -y apt-utils curl gcc git gzip libbpfcc-dev libc6-dev libpam-dev libsqlite3-0 locales make net-tools tar tree zip && \
+    apt-get install -y --no-install-recommends apt-utils ca-certificates curl && \
+    apt-get install -q -y --no-install-recommends \
+        clang-10 \
+        clang-format-10 \
+        gcc \
+        git \
+        gzip \
+        libc6-dev \
+        libelf-dev \
+        libpam-dev \
+        libsqlite3-0 \
+        llvm-10 \
+        locales \
+        make \
+        net-tools \
+        openssh-client \
+        pkg-config \
+        tar \
+        tree \
+        unzip \
+        zip \
+        && \
     dpkg-reconfigure locales && \
-    apt-get -y autoclean && apt-get -y clean
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ARG UID
 ARG GID
@@ -39,6 +61,12 @@ RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.
     chmod a+w /go && \
     chmod a+w /var/lib && \
     chmod a-w /
+
+# Install libbpf
+RUN mkdir -p /opt && cd /opt && curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v0.3.tar.gz | tar xz && \
+    cd /opt/libbpf-0.3/src && \
+    make && \
+    make install
 
 ENV GOPATH="/go" \
     GOROOT="/opt/go" \

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -63,8 +63,9 @@ RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.
     chmod a-w /
 
 # Install libbpf
-RUN mkdir -p /opt && cd /opt && curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v0.3.tar.gz | tar xz && \
-    cd /opt/libbpf-0.3/src && \
+ARG LIBBPF_VERSION
+RUN mkdir -p /opt && cd /opt && curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+    cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make && \
     make install
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -18,6 +18,7 @@ OS ?= linux
 ARCH ?= amd64
 RUNTIME ?= go1.16.2
 BORINGCRYPTO_RUNTIME=$(RUNTIME)b7
+LIBBPF_VERSION ?= 0.3
 
 UID := $$(id -u)
 GID := $$(id -g)
@@ -109,6 +110,7 @@ buildbox:
 			--build-arg PROTOC_VER=$(PROTOC_VER) \
 			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg PROTOC_PLATFORM=$(PROTOC_PLATFORM) \
+			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 			--cache-from $(BUILDBOX) \
 			--tag $(BUILDBOX) . ; \
 	fi
@@ -124,6 +126,7 @@ buildbox-fips:
 			--build-arg UID=$(UID) \
 			--build-arg GID=$(GID) \
 			--build-arg BORINGCRYPTO_RUNTIME=$(BORINGCRYPTO_RUNTIME) \
+			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 			--cache-from $(BUILDBOX_FIPS) \
 			--tag $(BUILDBOX_FIPS) -f Dockerfile-fips . ; \
 	fi


### PR DESCRIPTION
Some necessary packages to build BPF support into Teleport binaries are missing from the FIPS buildbox `Dockerfile` - this adds them. Also makes the set of packages installed into the FIPS buildbox more consistent with the regular buildbox Dockerfile.

After fixing this build failure, also discovered that regular Mac pkg builds are failing on `master` because #5866 enabled signing for both `teleport` and `tsh` pkgs (without the appropriate changes to Drone to unlock the signing keychain) and then this didn't get completely reverted via #6265. ce0b0e7 adds the necessary changes to sign regular `teleport` packages for MacOS too.

Required for https://github.com/gravitational/teleport.e/pull/279

Fixes #7076 
Fixes https://github.com/gravitational/teleport/issues/3437