### PR TITLE
drone: Disable CentOS 6 FIPS builds for Teleport 7.0+

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1606,112 +1606,6 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:188
-################################################
-
-kind: pipeline
-type: kubernetes
-name: build-linux-amd64-centos6-fips
-environment:
-  RUNTIME: go1.16.2
-trigger:
-  event:
-    include:
-    - tag
-  ref:
-    include:
-    - refs/tags/v*
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-steps:
-- name: Check out code
-  image: docker:git
-  commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - git submodule update --init --recursive webassets || true
-  - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt;
-    else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
-  commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  volumes:
-  - name: dockersock
-    path: /var/run
-- name: Build artifacts
-  image: docker
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - make -C build.assets release-amd64-centos6-fips
-  environment:
-    ARCH: amd64
-    FIPS: "yes"
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-- name: Copy artifacts
-  image: docker
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
-    \;
-  - export VERSION=$(cat /go/.version.txt)
-  - mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-fips-bin.tar.gz
-  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256;
-    done && ls -l
-- name: Upload to S3
-  image: plugins/s3
-  settings:
-    access_key:
-      from_secret: AWS_ACCESS_KEY_ID
-    bucket:
-      from_secret: AWS_S3_BUCKET
-    region: us-west-2
-    secret_key:
-      from_secret: AWS_SECRET_ACCESS_KEY
-    source: /go/artifacts/*
-    strip_prefix: /go/artifacts/
-    target: teleport/tag/${DRONE_TAG##v}
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: dockersock
-  temp: {}
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
 # Generated at dronegen/tag.go:330
 ################################################
 
@@ -4076,7 +3970,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/buildbox.go:57
+# Generated at dronegen/buildbox.go:58
 ################################################
 
 kind: pipeline
@@ -4130,7 +4024,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  failure: ignore
 - name: buildbox-fips
   image: docker
   commands:
@@ -4147,7 +4040,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  failure: ignore
 - name: buildbox-centos6
   image: docker
   commands:
@@ -4164,24 +4056,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  failure: ignore
-- name: buildbox-centos6-fips
-  image: docker
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - docker login -u="$$QUAYIO_DOCKER_USERNAME" -p="$$QUAYIO_DOCKER_PASSWORD" quay.io
-  - make -C build.assets buildbox-centos6-fips
-  - docker push quay.io/gravitational/teleport-buildbox-centos6-fips:$RUNTIME
-  environment:
-    QUAYIO_DOCKER_PASSWORD:
-      from_secret: QUAYIO_DOCKER_PASSWORD
-    QUAYIO_DOCKER_USERNAME:
-      from_secret: QUAYIO_DOCKER_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  failure: ignore
 - name: buildbox-arm
   image: docker
   commands:
@@ -4198,7 +4072,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  failure: ignore
 services:
 - name: Start Docker
   image: docker:dind
@@ -4513,6 +4386,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 7aa9349b1d1bd6a6b60aaa47abda52c8b2eaf7772a576195f40f38174717cae0
+hmac: 6fb06de638133160c0989682a9034201405e43ee5b74f6f263cca7b0f69651c6
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -29,7 +29,6 @@ GOGO_PROTO_TAG ?= v1.3.2
 BUILDBOX=quay.io/gravitational/teleport-buildbox:$(RUNTIME)
 BUILDBOX_FIPS=quay.io/gravitational/teleport-buildbox-fips:$(RUNTIME)
 BUILDBOX_CENTOS6=quay.io/gravitational/teleport-buildbox-centos6:$(RUNTIME)
-BUILDBOX_CENTOS6_FIPS=quay.io/gravitational/teleport-buildbox-centos6-fips:$(RUNTIME)
 BUILDBOX_ARM=quay.io/gravitational/teleport-buildbox-arm:$(RUNTIME)
 BUILDBOX_ARM_FIPS=quay.io/gravitational/teleport-buildbox-arm-fips:$(RUNTIME)
 
@@ -142,17 +141,8 @@ buildbox-centos6:
 		--cache-from $(BUILDBOX_CENTOS6) \
 		--tag $(BUILDBOX_CENTOS6) -f Dockerfile-centos6 .
 
-#
-# Builds a Docker buildbox for CentOS 6 FIPS builds
-# Teleport FIPS builds fail on CentOS 6 builds as of Go 1.16, so have been disabled for Teleport 7.0+
-# This is due to the lower glibc version used with CentOS 6 not supporting the 'getauxval' syscall,
-# preventing Go's boringcrypto fork being compiled from source.
+# CentOS 6 FIPS builds were removed in Teleport 7.0
 # https://github.com/gravitational/teleport/issues/7207
-#
-.PHONY:buildbox-centos6-fips
-buildbox-centos6-fips:
-	@echo "Teleport FIPS builds fail on CentOS 6 as of Go 1.16, so have been disabled for Teleport 7.0+."
-	@exit 1
 
 #
 # Builds a Docker buildbox for ARMv7/ARM64 builds
@@ -290,10 +280,6 @@ release-arm64: buildbox-arm
 release-amd64-centos6: buildbox-centos6
 	$(MAKE) release-centos6 ARCH=amd64
 
-.PHONY: release-amd64-centos6-fips
-release-amd64-centos6-fips: buildbox-centos6-fips
-	$(MAKE) release-centos6-fips ARCH=amd64 FIPS=yes
-
 #
 # Create a Teleport FIPS package using the build container.
 # This is a special case because it only builds and packages the Enterprise FIPS binaries, no OSS.
@@ -312,15 +298,6 @@ release-fips: buildbox-fips
 release-centos6: buildbox-centos6
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS6) \
 		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME)
-
-#
-# Create a Teleport FIPS package for CentOS 6 using the build container.
-#
-.PHONY:release-centos6-fips
-release-centos6-fips: buildbox-centos6-fips
-	@if [ -z ${VERSION} ]; then echo "VERSION is not set"; exit 1; fi
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS6_FIPS) \
-		/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION)
 
 #
 # Create a Windows Teleport package using the build container.

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -144,16 +144,15 @@ buildbox-centos6:
 
 #
 # Builds a Docker buildbox for CentOS 6 FIPS builds
+# Teleport FIPS builds fail on CentOS 6 builds as of Go 1.16, so have been disabled for Teleport 7.0+
+# This is due to the lower glibc version used with CentOS 6 not supporting the 'getauxval' syscall,
+# preventing Go's boringcrypto fork being compiled from source.
+# https://github.com/gravitational/teleport/issues/7207
 #
 .PHONY:buildbox-centos6-fips
 buildbox-centos6-fips:
-	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_CENTOS6_FIPS) 2>&1 >/dev/null; then docker pull $(BUILDBOX_CENTOS6_FIPS) || true; fi;
-	docker build \
-		--build-arg UID=$(UID) \
-		--build-arg GID=$(GID) \
-		--build-arg BORINGCRYPTO_RUNTIME=$(BORINGCRYPTO_RUNTIME) \
-		--cache-from $(BUILDBOX_CENTOS6_FIPS) \
-		--tag $(BUILDBOX_CENTOS6_FIPS) -f Dockerfile-centos6-fips .
+	@echo "Teleport FIPS builds fail on CentOS 6 as of Go 1.16, so have been disabled for Teleport 7.0+."
+	@exit 1
 
 #
 # Builds a Docker buildbox for ARMv7/ARM64 builds

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -21,6 +21,11 @@ func buildboxPipelineSteps() []step {
 			if name == "buildbox-arm" && fips {
 				continue
 			}
+			// FIPS is unsupported on CentOS 6 as of Teleport 7.0
+			// https://github.com/gravitational/teleport/issues/7207
+			if name == "buildbox-centos6" && fips {
+				continue
+			}
 			steps = append(steps, buildboxPipelineStep(name, fips))
 		}
 	}
@@ -38,10 +43,6 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 			"QUAYIO_DOCKER_USERNAME": {fromSecret: "QUAYIO_DOCKER_USERNAME"},
 			"QUAYIO_DOCKER_PASSWORD": {fromSecret: "QUAYIO_DOCKER_PASSWORD"},
 		},
-		// Buildbox builds run sequentially, so any failure of an earlier step will prevent later steps from running.
-		// The CentOS 6 FIPS buildbox is currently failing to build, so we ignore this to prevent pushes to
-		// master from being unnecessarily marked as failures. The underlying issue will be fixed soon.
-		Failure: "ignore",
 		Volumes: dockerVolumeRefs(),
 		Commands: []string{
 			`apk add --no-cache make`,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -154,8 +154,8 @@ func tagPipelines() []pipeline {
 	ps = append(ps, tagPipeline(buildType{os: "windows", arch: "amd64"}))
 
 	// Also add the two CentOS 6 artifacts.
+	// CentOS 6 FIPS builds have been removed in Teleport 7.0. See https://github.com/gravitational/teleport/issues/7207
 	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", centos6: true}))
-	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", centos6: true, fips: true}))
 	return ps
 }
 


### PR DESCRIPTION
Fixes #7207

Tested with a tag build here: https://drone.teleport.dev/gravitational/teleport/26 (the `build-docker-images` step fails due to a separate bug which is being fixed in another PR)