### PR TITLE
Improve etcd event processing

### DIFF
--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	cq "github.com/gravitational/teleport/lib/utils/concurrentqueue"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
@@ -109,6 +110,18 @@ var (
 			// lowest bucket start of upper bound 0.001 sec (1 ms) with factor 2
 			// highest bucket start of 0.001 sec * 2^15 == 32.768 sec
 			Buckets: prometheus.ExponentialBuckets(0.001, 2, 16),
+		},
+	)
+	eventCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "etcd_events",
+			Help: "Number of etcd events",
+		},
+	)
+	eventBackpressure = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "etcd_event_backpressure",
+			Help: "Number of etcd events that hit backpressure",
 		},
 	)
 
@@ -356,35 +369,137 @@ func (b *EtcdBackend) reconnect(ctx context.Context) error {
 }
 
 func (b *EtcdBackend) asyncWatch() {
-	err := b.watchEvents()
-	b.Debugf("Watch exited: %v.", err)
+	defer close(b.watchDone)
+	var err error
+WatchEvents:
+	for b.ctx.Err() == nil {
+		err = b.watchEvents(b.ctx)
+
+		b.Debugf("Watch exited: %v", err)
+
+		// pause briefly to prevent excessive watcher creation attempts
+		select {
+		case <-time.After(utils.HalfJitter(time.Millisecond * 1500)):
+		case <-b.ctx.Done():
+			break WatchEvents
+		}
+
+		// buffer must be reset before recreation in order to avoid duplicate
+		// and/or missing values in the buffer watcher event stream.
+		b.buf.Reset()
+	}
+	b.Debugf("Watch stopped: %v.", trace.NewAggregate(err, b.ctx.Err()))
 }
 
-func (b *EtcdBackend) watchEvents() error {
-	defer close(b.watchDone)
+// eventResult is used to ferry the result of event processing
+type eventResult struct {
+	original clientv3.Event
+	event    backend.Event
+	err      error
+}
 
-start:
-	eventsC := b.client.Watch(b.ctx, b.cfg.Key, clientv3.WithPrefix())
+// watchEvents spawns an etcd watcher and forwards events to the event buffer. the internals of this
+// function are complicated somewhat by the fact that we need to make a per-event API call to translate
+// lease IDs into expiry times. if events are being created faster than their expiries can be resolved,
+// this eventually results in runaway memory usage within the etcd client.  To combat this, we use a
+// concurrentqueue.Queue to parallelize the event processing logic while preserving event order.  While
+// effective, this strategy still suffers from a "head of line blocking"-esque issue since event order
+// must be preserved.
+func (b *EtcdBackend) watchEvents(ctx context.Context) error {
+
+	// etcd watch client relies on context cancellation for cleanup,
+	// so create a new subscope for this function.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// wrap fromEvent in a closure compatible with the concurrent queue
+	workfn := func(v interface{}) interface{} {
+		original := v.(clientv3.Event)
+		var event backend.Event
+		e, err := b.fromEvent(ctx, original)
+		if e != nil {
+			event = *e
+		}
+		return eventResult{
+			original: original,
+			event:    event,
+			err:      err,
+		}
+	}
+
+	// constants here are a bit arbitrary. the goal is to set up the queue s.t.
+	// it could handle >100 events per second assuming an avg of .2 seconds of processing
+	// time per event (as seen in tests of under-provisioned etcd instances).
+	q := cq.New(
+		workfn,
+		cq.Workers(24),
+		cq.Capacity(240),
+		cq.InputBuf(120),
+		cq.OutputBuf(48),
+	)
+	defer q.Close()
+
+	// launch background process responsible for forwarding events from the queue
+	// to the buffer.
+	go func() {
+	PushToBuf:
+		for {
+			select {
+			case p := <-q.Pop():
+				r := p.(eventResult)
+				if r.err != nil {
+					b.WithError(r.err).Errorf("Failed to unmarshal event: %v.", r.original)
+					continue PushToBuf
+				}
+				b.buf.Push(r.event)
+			case <-q.Done():
+				return
+			}
+		}
+	}()
+
+	// start watching
+	eventsC := b.client.Watch(ctx, b.cfg.Key, clientv3.WithPrefix())
 	b.signalWatchStart()
+
+	var lastBacklogWarning time.Time
 	for {
 		select {
 		case e, ok := <-eventsC:
 			if e.Canceled || !ok {
-				b.Debugf("Watch channel has closed.")
-				goto start
+				return trace.ConnectionProblem(nil, "etcd watch channel closed")
 			}
-			out := make([]backend.Event, 0, len(e.Events))
+
+		PushToQueue:
 			for i := range e.Events {
-				event, err := b.fromEvent(b.ctx, *e.Events[i])
-				if err != nil {
-					b.Errorf("Failed to unmarshal event: %v %v.", err, *e.Events[i])
-				} else {
-					out = append(out, *event)
+				eventCount.Inc()
+
+				var event clientv3.Event = *e.Events[i]
+				// attempt non-blocking push.  We allocate a large input buffer for the queue, so this
+				// aught to succeed reliably.
+				select {
+				case q.Push() <- event:
+					continue PushToQueue
+				default:
+				}
+
+				eventBackpressure.Inc()
+
+				// limit backlog warnings to once per minute to prevent log spam.
+				if now := time.Now(); now.After(lastBacklogWarning.Add(time.Minute)) {
+					b.Warnf("Etcd event processing backlog; may result in excess memory usage and stale cluster state.")
+					lastBacklogWarning = now
+				}
+
+				// fallblack to blocking push
+				select {
+				case q.Push() <- event:
+				case <-ctx.Done():
+					return trace.ConnectionProblem(ctx.Err(), "context is closing")
 				}
 			}
-			b.buf.PushBatch(out)
-		case <-b.ctx.Done():
-			return trace.ConnectionProblem(b.ctx.Err(), "context is closing")
+		case <-ctx.Done():
+			return trace.ConnectionProblem(ctx.Err(), "context is closing")
 		}
 	}
 }

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -891,6 +892,9 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry, timer *tim
 	retry.Reset()
 
 	c.notify(c.ctx, Event{Type: WatcherStarted})
+
+	var lastStalenessWarning time.Time
+	var staleEventCount int
 	for {
 		select {
 		case <-watcher.Done():
@@ -898,6 +902,35 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry utils.Retry, timer *tim
 		case <-c.ctx.Done():
 			return trace.ConnectionProblem(c.ctx.Err(), "context is closing")
 		case event := <-watcher.Events():
+			// check for expired resources in OpPut events and log them periodically. stale OpPut events
+			// may be an indicator of poor performance, and can lead to confusing and inconsistent state
+			// as the cache may prune items that aught to exist.
+			//
+			// NOTE: The inconsistent state mentioned above is a symptom of a deeper issue with the cache
+			// design.  The cache should not expire individual items.  It should instead rely on OpDelete events
+			// from backend expiries.  As soon as the cache has expired at least one item, it is no longer
+			// a faithful representation of a real backend state, since it is 'anticipating' a change in
+			// backend state that may or may not have actually happened.  Instead, it aught to serve the
+			// most recent internally-consistent "view" of the backend, and individual consumers should
+			// determine if the resources they are handling are sufficiently fresh.  Resource-level expiry
+			// is a convenience/cleanup feature and aught not be relied upon for meaningful logic anyhow.
+			// If we need to protect against a stale cache, we aught to invalidate the cache in its entirity, rather
+			// than pruning the resources that we think *might* have been removed from the real backend.
+			// TODO(fspmarshall): ^^^
+			//
+			if event.Type == types.OpPut && !event.Resource.Expiry().IsZero() {
+				staleEventCount++
+				if now := c.Clock.Now(); now.After(event.Resource.Expiry()) && now.After(lastStalenessWarning.Add(time.Minute)) {
+					kind := event.Resource.GetKind()
+					if sk := event.Resource.GetSubKind(); sk != "" {
+						kind = fmt.Sprintf("%s/%s", kind, sk)
+					}
+					c.Warningf("Encountered %d stale event(s), may indicate degraded backend or event system performance. last_kind=%q", staleEventCount, kind)
+					lastStalenessWarning = now
+					staleEventCount = 0
+				}
+			}
+
 			err = c.processEvent(ctx, event)
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/utils/concurrentqueue/queue.go
+++ b/lib/utils/concurrentqueue/queue.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concurrentqueue
+
+import (
+	"sync"
+)
+
+type config struct {
+	workers   int
+	capacity  int
+	inputBuf  int
+	outputBuf int
+}
+
+// Option is a queue configuration option.
+type Option func(*config)
+
+// Workers is the number of concurrent workers to be used for the
+// queue.  Defaults to 4.
+func Workers(w int) Option {
+	return func(cfg *config) {
+		cfg.workers = w
+	}
+}
+
+// Capacity is the amount of "in flight" items the queue can hold, not including
+// any extra capacity in the input/output buffers. Assuming unbuffered input/output,
+// this is the number of items that can be pushed to a queue before it begins to exhibit
+// backpressure.  A value of 8-16x the number of workers is probably a reasonable choice
+// for most applications.  Note that a queue always has a capacity at least equal to the
+// number of workers, so `New(fn,Workers(7),Capacity(3))` results in a queue with capacity
+// `7`. Defaults to 64.
+func Capacity(c int) Option {
+	return func(cfg *config) {
+		cfg.capacity = c
+	}
+}
+
+// InputBuf is the amount of buffer to be used in the input/push channel. Defaults to 0 (unbuffered).
+func InputBuf(b int) Option {
+	return func(cfg *config) {
+		cfg.inputBuf = b
+	}
+}
+
+// OutputBuf is the amount of buffer to be used in the output/pop channel.  Allocating output
+// buffer space may improve performance when items are able to be popped in quick succession.
+// Defaults to 0 (unbuffered).
+func OutputBuf(b int) Option {
+	return func(cfg *config) {
+		cfg.outputBuf = b
+	}
+}
+
+// item is the internal "work item" used by the queue.  it holds a value, and a nonce indicating the
+// order in which the value was received.
+type item struct {
+	value interface{}
+	nonce uint64
+}
+
+// Queue is a data processing helper which uses a worker pool to apply a closure to a series of
+// values concurrently, preserving the correct ordering of results.  It is essentially the concurrent
+// equivalent of this:
+//    for msg := range inputChannel {
+//        outputChannel <- workFunction(msg)
+//    }
+// In order to prevent indefinite memory growth within the queue due to slow consumption and/or
+// workers, the queue will exert backpressure over its input channel once a configurable capacity
+// is reached.
+type Queue struct {
+	input     chan interface{}
+	output    chan interface{}
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+// Push accesses the queue's input channel.  The type of sent values must match
+// that expected by the queue's work function.  If the queue was configured with
+// a buffered input/push channel, non-blocking sends can be used as a heuristic for
+// detecting backpressure due to queue capacity.  This is not a perfect test, but
+// the rate of false positives will be extremely low for a queue with a decent
+// capacity and non-trivial work function.
+func (q *Queue) Push() chan<- interface{} {
+	return q.input
+}
+
+// Pop accesses the queue's output channel.  The type of the received value
+// will match the output of the work function.
+func (q *Queue) Pop() <-chan interface{} {
+	return q.output
+}
+
+// Done signals closure of the queue.
+func (q *Queue) Done() <-chan struct{} {
+	return q.done
+}
+
+// Close permanently terminates all background operations.  If the queue is not drained before
+// closure, items may be lost.
+func (q *Queue) Close() error {
+	q.closeOnce.Do(func() {
+		close(q.done)
+	})
+	return nil
+}
+
+// New builds a new queue instance around the supplied work function.
+func New(workfn func(interface{}) interface{}, opts ...Option) *Queue {
+	const defaultWorkers = 4
+	const defaultCapacity = 64
+
+	var cfg config
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.workers < 1 {
+		cfg.workers = defaultWorkers
+	}
+	if cfg.capacity < 1 {
+		cfg.capacity = defaultCapacity
+	}
+
+	// capacity must be at least equal to the number of workers or else workers
+	// will always be idle.
+	if cfg.capacity < cfg.workers {
+		cfg.capacity = cfg.workers
+	}
+
+	q := &Queue{
+		input:  make(chan interface{}, cfg.inputBuf),
+		output: make(chan interface{}, cfg.outputBuf),
+		done:   make(chan struct{}),
+	}
+
+	go q.run(workfn, cfg)
+
+	return q
+}
+
+// run spawns background tasks and then blocks on collection/reordering routine.
+func (q *Queue) run(workfn func(interface{}) interface{}, cfg config) {
+	// internal worker input/output channels. due to the semaphore channel below,
+	// sends on these channels never block, as they are each allocated with sufficient
+	// capacity to hold all in-flight items.
+	workerIn, workerOut := make(chan item, cfg.capacity), make(chan item, cfg.capacity)
+
+	// semaphore channel used to limit the number of "in flight" items.  a message is added prior to accepting
+	// every input and removed upon emission of every output.  this allows us to exert backpressure and prevent
+	// uncapped memory growth due to a slow worker.  this also keeps the queue's "capacity" consistent, regardless
+	// of whether we are experiencing general slowness or a "head of line blocking" type scenario.
+	sem := make(chan struct{}, cfg.capacity)
+
+	// spawn workers
+	for i := 0; i < cfg.workers; i++ {
+		go func() {
+			for {
+				var itm item
+				select {
+				case itm = <-workerIn:
+				case <-q.done:
+					return
+				}
+
+				itm.value = workfn(itm.value)
+
+				select {
+				case workerOut <- itm:
+				default:
+					panic("cq worker output channel already full (semaphore violation)")
+				}
+			}
+		}()
+	}
+
+	go q.distribute(workerIn, sem)
+
+	q.collect(workerOut, sem)
+}
+
+// distribute takes inbound work items, applies a nonce, and then distributes
+// them to the workers.
+func (q *Queue) distribute(workerIn chan<- item, sem chan struct{}) {
+	var nonce uint64
+	for {
+		// we are about to accept an input, add an item to the in-flight semaphore channel
+		select {
+		case sem <- struct{}{}:
+		case <-q.done:
+			return
+		}
+
+		var value interface{}
+		select {
+		case value = <-q.input:
+		case <-q.done:
+			return
+		}
+
+		select {
+		case workerIn <- item{value: value, nonce: nonce}:
+		default:
+			panic("cq worker input channel already full (semaphore violation)")
+		}
+
+		nonce++
+	}
+}
+
+// collect takes the potentially disordered worker output and unifies it into
+// an ordered output.
+func (q *Queue) collect(workerOut <-chan item, sem chan struct{}) {
+	// items that cannot be emitted yet (due to arriving out of order),
+	// stored in mapping of nonce => value.
+	queue := make(map[uint64]interface{})
+
+	// the nonce of the item we need to emit next.  incremented upon
+	// successful emission.
+	var nonce uint64
+
+	// output value to be emitted (if any).  note that nil is a valid
+	// output value, so we cannot inspect this value directly to
+	// determine our state.
+	var out interface{}
+
+	// emit indicates whether or not we should be attempting to emit
+	// the output value.
+	var emit bool
+
+	for {
+		outc := q.output
+		if !emit {
+			// we do not have the next output item yet, do not attempt to send
+			outc = nil
+		}
+
+		select {
+		case itm := <-workerOut:
+			if itm.nonce == nonce {
+				// item matches current nonce, proceed directly to emitting state
+				out, emit = itm.value, true
+			} else {
+				// item does not match current nonce, store it in queue
+				queue[itm.nonce] = itm.value
+			}
+		case outc <- out:
+			// successfully sent current item, increment nonce and setup next
+			// output if it is present.
+			nonce++
+			out, emit = queue[nonce]
+			delete(queue, nonce)
+
+			// event has been emitted, remove an item from in-flight semaphore channel
+			select {
+			case <-sem:
+			default:
+				panic("cq sem channel already empty (semaphore violation)")
+			}
+		case <-q.done:
+			return
+		}
+
+	}
+}

--- a/lib/utils/concurrentqueue/queue_test.go
+++ b/lib/utils/concurrentqueue/queue_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package concurrentqueue
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// TestOrdering verifies that the queue yields items in the order of
+// insertion, rather than the order of completion.
+func TestOrdering(t *testing.T) {
+	const testItems = 1024
+
+	q := New(func(v interface{}) interface{} {
+		// introduce a short random delay to ensure that work
+		// completes out of order.
+		time.Sleep(time.Duration(rand.Int63n(int64(time.Millisecond * 12))))
+		return v
+	}, Workers(10))
+	t.Cleanup(func() { require.NoError(t, q.Close()) })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// verify that queue outputs items in expected order
+		for i := 0; i < testItems; i++ {
+			itm := <-q.Pop()
+			val, ok := itm.(int)
+			require.True(t, ok)
+			require.Equal(t, i, val)
+		}
+	}()
+
+	for i := 0; i < testItems; i++ {
+		q.Push() <- i
+	}
+	<-done
+}
+
+// bpt is backpressure test table
+type bpt struct {
+	// queue parameters
+	workers  int
+	capacity int
+	inBuf    int
+	outBuf   int
+	// simulate head of line blocking
+	headOfLine bool
+	// simulate worker deadlock blocking
+	deadlock bool
+	// expected queue capacity for scenario (i.e. if expect=5, then
+	// backpressure should be hit for the sixth item).
+	expect int
+}
+
+// TestBackpressure verifies that backpressure appears at the expected point.  This test covers
+// both "external" backpressure (where items are not getting popped), and "internal" backpressure,
+// where the queue cannot yield items because of one or more slow workers.  Internal scenarios are
+// verified to behave equivalently for head of line scenarios (next item in output order is blocked)
+// and deadlock scenarios (all workers are blocked).
+func TestBackpressure(t *testing.T) {
+	tts := []bpt{
+		{
+			// unbuffered + external
+			workers:  1,
+			capacity: 1,
+			expect:   1,
+		},
+		{
+			// buffered + external
+			workers:  2,
+			capacity: 4,
+			inBuf:    1,
+			outBuf:   1,
+			expect:   6,
+		},
+		{ // unbuffered + internal (hol variant)
+			workers:    2,
+			capacity:   4,
+			expect:     4,
+			headOfLine: true,
+		},
+		{ // buffered + internal (hol variant)
+			workers:    3,
+			capacity:   9,
+			inBuf:      2,
+			outBuf:     2,
+			expect:     11,
+			headOfLine: true,
+		},
+		{ // unbuffered + internal (deadlock variant)
+			workers:  2,
+			capacity: 4,
+			expect:   4,
+			deadlock: true,
+		},
+		{ // buffered + internal (deadlock variant)
+			workers:  3,
+			capacity: 9,
+			inBuf:    2,
+			outBuf:   2,
+			expect:   11,
+			deadlock: true,
+		},
+	}
+
+	for _, tt := range tts {
+		runBackpressureScenario(t, tt)
+	}
+}
+
+func runBackpressureScenario(t *testing.T, tt bpt) {
+	done := make(chan struct{})
+	defer close(done)
+
+	workfn := func(v interface{}) interface{} {
+		// simulate a blocking worker if necessary
+		if tt.deadlock || (tt.headOfLine && v.(int) == 0) {
+			<-done
+		}
+		return v
+	}
+
+	q := New(
+		workfn,
+		Workers(tt.workers),
+		Capacity(tt.capacity),
+		InputBuf(tt.inBuf),
+		OutputBuf(tt.outBuf),
+	)
+	defer func() { require.NoError(t, q.Close()) }()
+
+	for i := 0; i < tt.expect; i++ {
+		select {
+		case q.Push() <- i:
+		case <-time.After(time.Millisecond * 200):
+			require.FailNowf(t, "early backpressure", "expected %d, got %d ", tt.expect, i)
+		}
+	}
+
+	select {
+	case q.Push() <- tt.expect:
+		require.FailNowf(t, "missing backpressure", "expected %d", tt.expect)
+	case <-time.After(time.Millisecond * 200):
+	}
+}
+
+/*
+goos: linux
+goarch: amd64
+pkg: github.com/gravitational/teleport/lib/utils/concurrentqueue
+cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
+BenchmarkQueue-16    	     193	   6192192 ns/op
+*/
+func BenchmarkQueue(b *testing.B) {
+	const workers = 16
+	const iters = 4096
+	workfn := func(v interface{}) interface{} {
+		// XXX: should we be doing something to
+		// add noise here?
+		return v
+	}
+
+	q := New(workfn, Workers(workers))
+	defer q.Close()
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		collected := make(chan struct{})
+		go func() {
+			for i := 0; i < iters; i++ {
+				<-q.Pop()
+			}
+			close(collected)
+		}()
+		for i := 0; i < iters; i++ {
+			q.Push() <- i
+		}
+		<-collected
+	}
+}


### PR DESCRIPTION
Fixes an issue where slow etcd event processing in very large teleport clusters could lead to serious issues, including uncapped growth in memory usage, and disappearing nodes.

---

The etcd backend implementation must make per-event API calls against the etcd server in order to determine the expiry of items (translating a lease ID to a TTL).  Under very specific circumstances, it is possible for events to be created at a faster rate than their expirations can be looked up, causing backpressure against the etcd client.  Not only does this cause teleport's event stream to get stale (eventually causing expiring resources such as nodes to disappear from caches), but it also causes uncapped memory growth within the etcd client itself.

To address this problem while preserving correct event order in the final output (required for cache validity), a new `utils/concurrentqueue` package was added which provides a helper for concurrently processing values while preserving correct result ordering.

Stale event stream created a lot of "red herring" issues that complicated the debugging process, so caches now emit warnings when they see stale events.

Example of auth server memory usage before and after deployment of this change:

![mem-usage-2](https://user-images.githubusercontent.com/30576607/123346294-ccf71200-d50c-11eb-922a-0004ba17fac6.png)


Fixes #6474 