### PR TITLE
aws: Update reference deployments to handle timesearchV2 format

### DIFF
--- a/docs/pages/aws-oss-guide.mdx
+++ b/docs/pages/aws-oss-guide.mdx
@@ -104,9 +104,9 @@ DynamoDB Table B - Teleport Cluster Events:
 | Primary partition key | SessionID (String) |
 | Primary sort key | EventIndex (Number) |
 
-| Indexes - `timesearch` | teleport-cluster-name-events |
+| Indexes - `timesearchV2` | teleport-cluster-name-events |
 | - | - |
-| Primary partition key | EventNamespace (String) |
+| Primary partition key | CreatedAtDate (String) |
 | Primary sort key | CreatedAt (Number) |
 | Attributes | ALL |
 
@@ -141,7 +141,7 @@ proxy and provides the TCP connections needed for Teleport proxy SSH connections
 
 ### IAM
 
-IAM is the recommended tool for creating service access. 
+IAM is the recommended tool for creating service access.
 
 (!docs/pages/includes/permission-warning.mdx!)
 
@@ -532,7 +532,7 @@ aws eks update-kubeconfig --name [teleport-cluster] --region us-west-2
 
 #### Creating TLS certificate for Teleport
 
-This section walks through configuring Teleport to acquire a TLS (SSL) certificate for HTTPS. 
+This section walks through configuring Teleport to acquire a TLS (SSL) certificate for HTTPS.
 
 <Admonition type="warning" title="Warning">
   It's essential to properly configure TLS (SSL) to secure your production resources!

--- a/examples/aws/cloudformation/ent.yaml
+++ b/examples/aws/cloudformation/ent.yaml
@@ -998,15 +998,15 @@ Resources:
       AttributeDefinitions:
       - {AttributeName: "SessionID", AttributeType: "S"}
       - {AttributeName: "EventIndex", AttributeType: "N"}
-      - {AttributeName: "EventNamespace", AttributeType: "S"}
+      - {AttributeName: "CreatedAtDate", AttributeType: "S"}
       - {AttributeName: "CreatedAt", AttributeType: "N"}
 
       TimeToLiveSpecification: {AttributeName: "Expires", Enabled: true}
 
       GlobalSecondaryIndexes:
-      - IndexName: "timesearch"
+      - IndexName: "timesearchV2"
         KeySchema:
-        - AttributeName: "EventNamespace"
+        - AttributeName: "CreatedAtDate"
           KeyType: "HASH"
         - AttributeName: "CreatedAt"
           KeyType: "RANGE"

--- a/examples/aws/cloudformation/oss.yaml
+++ b/examples/aws/cloudformation/oss.yaml
@@ -998,15 +998,15 @@ Resources:
       AttributeDefinitions:
       - {AttributeName: "SessionID", AttributeType: "S"}
       - {AttributeName: "EventIndex", AttributeType: "N"}
-      - {AttributeName: "EventNamespace", AttributeType: "S"}
+      - {AttributeName: "CreatedAtDate", AttributeType: "S"}
       - {AttributeName: "CreatedAt", AttributeType: "N"}
 
       TimeToLiveSpecification: {AttributeName: "Expires", Enabled: true}
 
       GlobalSecondaryIndexes:
-      - IndexName: "timesearch"
+      - IndexName: "timesearchV2"
         KeySchema:
-        - AttributeName: "EventNamespace"
+        - AttributeName: "CreatedAtDate"
           KeyType: "HASH"
         - AttributeName: "CreatedAt"
           KeyType: "RANGE"

--- a/examples/aws/terraform/ha-autoscale-cluster/dynamo.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/dynamo.tf
@@ -54,8 +54,8 @@ resource "aws_dynamodb_table" "teleport_events" {
   }
 
   global_secondary_index {
-    name            = "timesearch"
-    hash_key        = "EventNamespace"
+    name            = "timesearchV2"
+    hash_key        = "CreatedAtDate"
     range_key       = "CreatedAt"
     write_capacity  = 20
     read_capacity   = 20
@@ -63,10 +63,7 @@ resource "aws_dynamodb_table" "teleport_events" {
   }
 
   lifecycle {
-    ignore_changes = [
-      read_capacity,
-      write_capacity,
-    ]
+    ignore_changes = all
   }
 
   attribute {
@@ -80,7 +77,7 @@ resource "aws_dynamodb_table" "teleport_events" {
   }
 
   attribute {
-    name = "EventNamespace"
+    name = "CreatedAtDate"
     type = "S"
   }
 

--- a/examples/aws/terraform/starter-cluster/dynamo.tf
+++ b/examples/aws/terraform/starter-cluster/dynamo.tf
@@ -1,6 +1,6 @@
-/* 
+/*
 DynamoDB is used to store cluster state, event
-metadata, and a simple locking mechanism for SSL 
+metadata, and a simple locking mechanism for SSL
 cert generation and renewal.
 */
 
@@ -58,8 +58,8 @@ resource "aws_dynamodb_table" "teleport_events" {
   }
 
   global_secondary_index {
-    name            = "timesearch"
-    hash_key        = "EventNamespace"
+    name            = "timesearchV2"
+    hash_key        = "CreatedAtDate"
     range_key       = "CreatedAt"
     write_capacity  = 10
     read_capacity   = 10
@@ -67,10 +67,7 @@ resource "aws_dynamodb_table" "teleport_events" {
   }
 
   lifecycle {
-    ignore_changes = [
-      read_capacity,
-      write_capacity,
-    ]
+    ignore_changes = all
   }
 
   attribute {
@@ -84,7 +81,7 @@ resource "aws_dynamodb_table" "teleport_events" {
   }
 
   attribute {
-    name = "EventNamespace"
+    name = "CreatedAtDate"
     type = "S"
   }
 


### PR DESCRIPTION
This updates our reference Terraform and CloudFormation deployments to use the new index format defined in RFD 24 (https://github.com/gravitational/teleport/pull/6359) by default.

For Terraform, it additionally adds `lifecycle { ignore_changes = all }` to ignore all changes to the events table. This means that if the events table doesn't exist, it will be created, but if it does already exist then no changes will be forced to it. This will enable customers who are currently using our reference Terraform and who have already upgraded to Teleport 6.2.0+ to continue using their clusters with no downtime after updating their Terraform commit. The current state of `master` before this PR is that the newer `timesearchV2` index format will be deleted and the old `timesearch` format restored if you run `terraform apply`, breaking clusters.

Ideally I would have removed the definition of the DynamoDB tables from Terraform entirely and just let Teleport handle their creation, but this would probably cause any existing tables to be deleted (which is obviously unacceptable). As such, we still need to keep _a_ definition of the table in Terraform, but we can ignore all changes to avoid breaking customer deployments.

CloudFormation does not have the same ability to ignore changes as Terraform does, so the PR just updates the table and secondary index to the expected format. I don't believe we have any customers currently using the CloudFormation, so this is more of a procedural thing.

If any further changes are made to DynamoDB tables or indexes on the Teleport side, we should ensure that the Terraform and CloudFormation examples are also updated to reflect these changes at the same time. For Terraform though at least, future changes should no longer break existing deployments due to the lifecycle changes being ignored.

This PR also updates the mention of the `timesearch` index in the docs to the newer `timesearchV2` format.

Fixes #7306 