### PR TITLE
[master] docs: Fix typo in MacOS Terraform provider instructions

### DIFF
--- a/docs/pages/setup/guides/terraform-provider.mdx
+++ b/docs/pages/setup/guides/terraform-provider.mdx
@@ -55,7 +55,7 @@ mkdir -p teleport-terraform
   ```bash
   mkdir -p ${HOME?}/.terraform.d/plugins/gravitational.com/teleport/teleport/(=teleport.version=)/darwin_amd64
   curl -L -O https://get.gravitational.com/terraform-provider-teleport-v(=teleport.version=)-darwin-amd64-bin.tar.gz
-  tar -zxvf terraform-provider-teleport-v(=teleport.version=)-darwin-amd64-bin.tar.gz -C ${HOME?}/.terraform.d/plugins/gravitational.com/teleport/teleport/(=teleport.version=)/linux_amd64
+  tar -zxvf terraform-provider-teleport-v(=teleport.version=)-darwin-amd64-bin.tar.gz -C ${HOME?}/.terraform.d/plugins/gravitational.com/teleport/teleport/(=teleport.version=)/darwin_amd64
   ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Forward-ports #7426 to `master`