### PR TITLE
helm: make aws service annotations configurable

### DIFF
--- a/docs/pages/kubernetes-access/helm/guides/aws.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/aws.mdx
@@ -235,6 +235,7 @@ The `--set` CLI method is more appropriate for quick test deployments.
     backendTable: teleport-helm-backend             # DynamoDB table to use for the Teleport backend
     auditLogTable: teleport-helm-events             # DynamoDB table to use for the Teleport audit log (must be different to the backend table)
     sessionRecordingBucket: teleport-helm-sessions  # S3 bucket to use for Teleport session recordings
+    defaultServiceAnnotations: true                 # Use the default service annotations
   highAvailability:
     replicaCount: 2                                 # Number of replicas to configure
     certManager:
@@ -265,6 +266,7 @@ The `--set` CLI method is more appropriate for quick test deployments.
     --set aws.backendTable=teleport-helm-backend                          `# DynamoDB table to use for the Teleport backend` \
     --set aws.auditLogTable=teleport-helm-events                          `# DynamoDB table to use for the Teleport audit log (must be different to the backend table)` \
     --set aws.sessionRecordingBucket=teleport-helm-sessions               `# S3 bucket to use for Teleport session recordings` \
+    --set aws.defaultServiceAnnotations=true                              `# Use the default service annotations` \
     --set highAvailability.replicaCount=2                                 `# Number of replicas to configure` \
     --set highAvailability.certManager.enabled=true                       `# Enable cert-manager support to get TLS certificates` \
     --set highAvailability.certManager.issuerName=letsencrypt-production  `# Name of the cert-manager Issuer to use`

--- a/examples/chart/teleport-cluster/templates/service.yaml
+++ b/examples/chart/teleport-cluster/templates/service.yaml
@@ -1,3 +1,6 @@
+{{- if and (eq .Values.chartMode "aws") ( not .Values.aws.defaultServiceAnnotations ) (not .Values.annotations.service)}}
+{{- fail "AWS mode requires either the default AWS service annotations or define your own in .annotations.service" }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,7 +13,7 @@ metadata:
     {{- if .Values.annotations.service }}
       {{- toYaml .Values.annotations.service | nindent 4 }}
     {{- end }}
-    {{- if eq .Values.chartMode "aws" }}
+    {{- if and (eq .Values.chartMode "aws")  (.Values.aws.defaultServiceAnnotations) }}
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -118,6 +118,11 @@
                     "$id": "#/properties/aws/properties/sessionRecordingBucket",
                     "type": "string",
                     "default": ""
+                },
+                "defaultServiceAnnotations": {
+                    "$id": "#/properties/aws/properties/defaultServiceAnnotations",
+                    "type": "boolean",
+                    "default": true
                 }
             }
         },

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -77,6 +77,10 @@ aws:
   # The S3 bucket name to use for recorded session storage. Teleport will attempt to create this bucket automatically if it does not exist.
   # The container will need an appropriately-provisioned IAM role with permissions to create S3 buckets.
   sessionRecordingBucket: ""
+  # If true, use the default AWS service annotations
+  # If using a different controller for your services (i.e. AWS Load Balancer Controller)
+  #   set to false and define your own in annotations -> service
+  defaultServiceAnnotations: true
 
 ##################################################
 # GCP-specific settings (only used in "gcp" mode)


### PR DESCRIPTION
This would allow a user to keep the default configuration for the AWS K8s service object but also allow modification of that within values.yaml. Main use case is if you are using the AWS Load Balancer Controller, this allows you to change the annotations so it can control the service instead of the built-in controller.