### PR TITLE
Fixes racy backend test suite

### DIFF
--- a/examples/etcd/start-etcd.sh
+++ b/examples/etcd/start-etcd.sh
@@ -19,6 +19,4 @@ etcd --name teleportstorage \
      --trusted-ca-file certs/ca-cert.pem \
      --advertise-client-urls=https://127.0.0.1:2379 \
      --listen-client-urls=https://127.0.0.1:2379 \
-     --client-cert-auth 
-
-echo ">>> etcd exited with $?"
+     --client-cert-auth

--- a/examples/etcd/start-etcd.sh
+++ b/examples/etcd/start-etcd.sh
@@ -19,4 +19,6 @@ etcd --name teleportstorage \
      --trusted-ca-file certs/ca-cert.pem \
      --advertise-client-urls=https://127.0.0.1:2379 \
      --listen-client-urls=https://127.0.0.1:2379 \
-     --client-cert-auth
+     --client-cert-auth 
+
+echo ">>> etcd exited with $?"

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -523,7 +523,11 @@ func (s *BackendSuite) Locking(c *check.C, bk backend.Backend) {
 	tok2 := "token2"
 	ttl := 5 * time.Second
 
-	ctx := context.TODO()
+	// If all this takes more than a minute then something external to the test has probably
+	// gone bad (e.g. db server has ceased to exist), so it's probably best to bail out with
+	// a sensible error rather than wait for the test to time out
+	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
+	defer cancel()
 
 	lock, err := backend.AcquireLock(ctx, bk, tok1, ttl)
 	c.Assert(err, check.IsNil)

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -523,11 +523,30 @@ func (s *BackendSuite) Locking(c *check.C, bk backend.Backend) {
 	tok2 := "token2"
 	ttl := 5 * time.Second
 
-	// If all this takes more than a minute then something external to the test has probably
-	// gone bad (e.g. db server has ceased to exist), so it's probably best to bail out with
-	// a sensible error rather than wait for the test to time out
+	// If all this takes more than a minute then something external to the test
+	// has probably gone bad (e.g. db server has ceased to exist), so it's
+	// probably best to bail out with a sensible error (& call stack) rather
+	// than wait for the test to time out
 	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
 	defer cancel()
+
+	// Manually drive the clock at ~10x speed to make sure anyone waiting on it
+	// will eventually be woken. This will automatically be stopped when the
+	// test exits thanks to the deferred cancel above.
+	go func() {
+		t := time.NewTicker(100 * time.Millisecond)
+		defer t.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-t.C:
+				s.Clock.Advance(1 * time.Second)
+			}
+		}
+	}()
 
 	lock, err := backend.AcquireLock(ctx, bk, tok1, ttl)
 	c.Assert(err, check.IsNil)
@@ -536,8 +555,6 @@ func (s *BackendSuite) Locking(c *check.C, bk backend.Backend) {
 	go func() {
 		atomic.StoreInt32(&x, 9)
 		c.Assert(lock.Release(ctx, bk), check.IsNil)
-		// Force the clock to periodically move after release so waiters can be awoken
-		s.Clock.Advance(1 * time.Second)
 	}()
 	lock, err = backend.AcquireLock(ctx, bk, tok1, ttl)
 	c.Assert(err, check.IsNil)
@@ -552,8 +569,6 @@ func (s *BackendSuite) Locking(c *check.C, bk backend.Backend) {
 	go func() {
 		atomic.StoreInt32(&x, 9)
 		c.Assert(lock.Release(ctx, bk), check.IsNil)
-		// Force the clock to periodically move after release so waiters can be awoken
-		s.Clock.Advance(1 * time.Second)
 	}()
 	lock, err = backend.AcquireLock(ctx, bk, tok1, ttl)
 	c.Assert(err, check.IsNil)
@@ -570,8 +585,6 @@ func (s *BackendSuite) Locking(c *check.C, bk backend.Backend) {
 		atomic.StoreInt32(&y, 15)
 		c.Assert(lock1.Release(ctx, bk), check.IsNil)
 		c.Assert(lock2.Release(ctx, bk), check.IsNil)
-		// Force the clock to periodically move after release so waiters can be awoken
-		s.Clock.Advance(1 * time.Second)
 	}()
 
 	lock, err = backend.AcquireLock(ctx, bk, tok1, ttl)


### PR DESCRIPTION
After routinely having CI builds fail in parts of the system unrelated to the change, I started to dig.

Many of these failures happened inside the backend compliance test suite, specifically in `BackendSuite.Locking()`. After a few more test failures it became apparent that the backend under test (`etcd`, `memory`, etc) didn't really matter; it was the test suite itself at fault.

It turns out that there are polling loops in helpers used by the test that require a `clockwork.Clock` to measure a polling interval. In the test case, this was implemented by a `clockwork.fakeClock` that requires manual advancing, or else the time the clock reports stays the same forever.

The working hypothersis is that, in almost all test runs, either
 1. AcquireLock() succeeds on the first try, meaning it never needs to enter the polling loop, or
 2. The one-off manual clock advance written into the test happened to occur during the wait, and so the polling loop was woken

In either case, all would be well and the test would pass. If neither of these cases happened then the test would lock up, waiting for a clock update that would never come and eventually the test would time out after 10 minutes.

This patchset:
1. Adds a 1-minute timeout to the `Lock()` test, so that it fails faster if the deadlock condition is hit
2. Adds a regular, asynchronous update to the `fakeClock` at 10x real-time to ensure that waiting code does not rely on hitting a one-of clock update, and
2. Refactors the polling loop in `backend.AcquireLock()` to honour context cancellation
