### PR TITLE
Better handling of database access IAM errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/gravitational/ttlmap v0.0.0-20171116003245-91fd36b9004c
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jackc/pgconn v1.8.0
+	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/jackc/pgproto3/v2 v2.0.7
 	github.com/johannesboyne/gofakes3 v0.0.0-20210217223559-02ffa763be97
 	github.com/jonboulle/clockwork v0.2.2
@@ -73,6 +74,7 @@ require (
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
 	github.com/nsf/termbox-go v0.0.0-20210114135735-d04385b850e8 // indirect
 	github.com/pborman/uuid v1.2.1
+	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.3.0
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -399,6 +399,8 @@ github.com/jackc/pgconn v0.0.0-20190824142844-760dd75542eb/go.mod h1:lLjNuW/+OfW
 github.com/jackc/pgconn v0.0.0-20190831204454-2fabfa3c18b7/go.mod h1:ZJKsE/KZfsUgOEh9hBm+xYTstcNHg7UPMVJqRfQxq4s=
 github.com/jackc/pgconn v1.8.0 h1:FmjZ0rOyXTr1wfWs45i4a9vjnjWUAGpMuQLD9OSs+lw=
 github.com/jackc/pgconn v1.8.0/go.mod h1:1C2Pb36bGIP9QHGBYCjnyhqu7Rv3sGshaQUvmfGIB/o=
+github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451 h1:WAvSpGf7MsFuzAtK4Vk7R4EVe+liW4x83r4oWu0WHKw=
+github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2 h1:JVX6jT/XfzNqIjye4717ITLaNwV9mWbJx0dLCpcRzdA=

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -793,7 +793,7 @@ func withRDSPostgres(name, authToken string) withDatabaseOption {
 				HostID:        testCtx.hostID,
 				DynamicLabels: dynamicLabels,
 				AWS: types.AWS{
-					Region: "us-east-1",
+					Region: testAWSRegion,
 				},
 				// Set CA cert, otherwise we will attempt to download RDS roots.
 				CACert: testCtx.hostCA.GetActiveKeys().TLS[0].Cert,
@@ -828,7 +828,7 @@ func withRedshiftPostgres(name, authToken string) withDatabaseOption {
 				HostID:        testCtx.hostID,
 				DynamicLabels: dynamicLabels,
 				AWS: types.AWS{
-					Region:   "us-east-1",
+					Region:   testAWSRegion,
 					Redshift: types.Redshift{ClusterID: "redshift-cluster-1"},
 				},
 				// Set CA cert, otherwise we will attempt to download Redshift roots.
@@ -933,7 +933,7 @@ func withRDSMySQL(name, authUser, authToken string) withDatabaseOption {
 				HostID:        testCtx.hostID,
 				DynamicLabels: dynamicLabels,
 				AWS: types.AWS{
-					Region: "us-east-1",
+					Region: testAWSRegion,
 				},
 				// Set CA cert, otherwise we will attempt to download RDS roots.
 				CACert: testCtx.hostCA.GetActiveKeys().TLS[0].Cert,
@@ -1024,3 +1024,6 @@ var dynamicLabels = types.LabelsToV2(map[string]types.CommandLabel{
 		Command: []string{"echo", "test"},
 	},
 })
+
+// testAWSRegion is the AWS region used in tests.
+const testAWSRegion = "us-east-1"

--- a/lib/srv/db/auth_test.go
+++ b/lib/srv/db/auth_test.go
@@ -52,67 +52,62 @@ func TestAuthTokens(t *testing.T) {
 		desc     string
 		service  string
 		protocol string
-		err      bool
+		err      string
 	}{
 		{
 			desc:     "correct Postgres RDS IAM auth token",
 			service:  "postgres-rds-correct-token",
 			protocol: defaults.ProtocolPostgres,
-			err:      false,
 		},
 		{
 			desc:     "incorrect Postgres RDS IAM auth token",
 			service:  "postgres-rds-incorrect-token",
 			protocol: defaults.ProtocolPostgres,
-			err:      true,
+			err:      common.GetRDSPolicy(testAWSRegion), // Make sure we print example RDS IAM policy.
 		},
 		{
 			desc:     "correct Postgres Redshift IAM auth token",
 			service:  "postgres-redshift-correct-token",
 			protocol: defaults.ProtocolPostgres,
-			err:      false,
 		},
 		{
 			desc:     "incorrect Postgres Redshift IAM auth token",
 			service:  "postgres-redshift-incorrect-token",
 			protocol: defaults.ProtocolPostgres,
-			err:      true,
+			err:      "invalid auth token",
 		},
 		{
 			desc:     "correct Postgres Cloud SQL IAM auth token",
 			service:  "postgres-cloudsql-correct-token",
 			protocol: defaults.ProtocolPostgres,
-			err:      false,
 		},
 		{
 			desc:     "incorrect Postgres Cloud SQL IAM auth token",
 			service:  "postgres-cloudsql-incorrect-token",
 			protocol: defaults.ProtocolPostgres,
-			err:      true,
+			err:      "invalid auth token",
 		},
 		{
 			desc:     "correct MySQL RDS IAM auth token",
 			service:  "mysql-rds-correct-token",
 			protocol: defaults.ProtocolMySQL,
-			err:      false,
 		},
 		{
 			desc:     "incorrect MySQL RDS IAM auth token",
 			service:  "mysql-rds-incorrect-token",
 			protocol: defaults.ProtocolMySQL,
-			err:      true,
+			err:      common.GetRDSPolicy(testAWSRegion), // Make sure we print example RDS IAM policy.
 		},
 		{
 			desc:     "correct MySQL Cloud SQL IAM auth token",
 			service:  "mysql-cloudsql-correct-token",
 			protocol: defaults.ProtocolMySQL,
-			err:      false,
 		},
 		{
 			desc:     "incorrect MySQL Cloud SQL IAM auth token",
 			service:  "mysql-cloudsql-incorrect-token",
 			protocol: defaults.ProtocolMySQL,
-			err:      true,
+			err:      "Access denied for user",
 		},
 	}
 
@@ -121,16 +116,18 @@ func TestAuthTokens(t *testing.T) {
 			switch test.protocol {
 			case defaults.ProtocolPostgres:
 				conn, err := testCtx.postgresClient(ctx, "alice", test.service, "postgres", "postgres")
-				if test.err {
+				if test.err != "" {
 					require.Error(t, err)
+					require.Contains(t, err.Error(), test.err)
 				} else {
 					require.NoError(t, err)
 					require.NoError(t, conn.Close(ctx))
 				}
 			case defaults.ProtocolMySQL:
 				conn, err := testCtx.mysqlClient("alice", test.service, "root")
-				if test.err {
+				if test.err != "" {
 					require.Error(t, err)
+					require.Contains(t, err.Error(), test.err)
 				} else {
 					require.NoError(t, err)
 					require.NoError(t, conn.Close())

--- a/lib/srv/db/ca.go
+++ b/lib/srv/db/ca.go
@@ -207,8 +207,8 @@ const (
 
 To correct the error you can try the following:
 
-  * Make sure this database service GCP IAM role has "cloudsql.instances.get"
-    permission.
+  * Make sure this database service has "Cloud SQL Viewer" GCP IAM role, or
+    "cloudsql.instances.get" IAM permission.
 
   * Download root certificate for your Cloud SQL instance %q manually and set
     it in the database configuration using "ca_cert_file" configuration field.`

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -23,12 +23,10 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"io"
-	"net/http"
 	"time"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	libauth "github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -39,7 +37,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds/rdsutils"
 	"github.com/aws/aws-sdk-go/service/redshift"
 
-	"google.golang.org/api/googleapi"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 	gcpcredentialspb "google.golang.org/genproto/googleapis/iam/credentials/v1"
 
@@ -119,11 +116,22 @@ func (a *dbAuth) GetRDSAuthToken(sessionCtx *Session) (string, error) {
 		return "", trace.Wrap(err)
 	}
 	a.cfg.Log.Debugf("Generating RDS auth token for %s.", sessionCtx)
-	return rdsutils.BuildAuthToken(
+	token, err := rdsutils.BuildAuthToken(
 		sessionCtx.Server.GetURI(),
 		sessionCtx.Server.GetAWS().Region,
 		sessionCtx.DatabaseUser,
 		awsSession.Config.Credentials)
+	if err != nil {
+		return "", trace.AccessDenied(`Could not generate RDS IAM auth token:
+
+  %v
+
+Make sure Teleport db service's AWS IAM policy allows it to connect to the RDS instance:
+
+%v
+`, err, GetRDSPolicy(sessionCtx.Server.GetAWS().Region))
+	}
+	return token, nil
 }
 
 // GetRedshiftAuthToken returns authorization token that will be used as a
@@ -146,7 +154,14 @@ func (a *dbAuth) GetRedshiftAuthToken(sessionCtx *Session) (string, string, erro
 		DbGroups: []*string{},
 	})
 	if err != nil {
-		return "", "", trace.Wrap(err)
+		return "", "", trace.AccessDenied(`Could not generate Redshift IAM auth token:
+
+  %v
+
+Make sure Teleport db service's AWS IAM policy allows it to generate Redshift credentials:
+
+%v
+`, err, GetRedshiftPolicy())
 	}
 	return *resp.DbUser, *resp.DbPassword, nil
 }
@@ -178,7 +193,13 @@ func (a *dbAuth) GetCloudSQLAuthToken(ctx context.Context, sessionCtx *Session) 
 			},
 		})
 	if err != nil {
-		return "", trace.Wrap(err)
+		return "", trace.AccessDenied(`Could not generate GCP IAM auth token:
+
+  %v
+
+Make sure Teleport db service has "Service Account Token Creator" GCP IAM role,
+or "iam.serviceAccounts.getAccessToken" IAM permission.
+`, err)
 	}
 	return resp.AccessToken, nil
 }
@@ -194,7 +215,7 @@ func (a *dbAuth) GetCloudSQLPassword(ctx context.Context, sessionCtx *Session) (
 		return "", trace.Wrap(err)
 	}
 	a.cfg.Log.Debugf("Generating GCP user password for %s.", sessionCtx)
-	token, err := utils.CryptoRandomHex(auth.TokenLenBytes)
+	token, err := utils.CryptoRandomHex(libauth.TokenLenBytes)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -211,7 +232,7 @@ func (a *dbAuth) GetCloudSQLPassword(ctx context.Context, sessionCtx *Session) (
 		err := a.updateCloudSQLUser(ctx, sessionCtx, gcpCloudSQL, &sqladmin.User{
 			Password: token,
 		})
-		if err != nil && !isStatusConflictError(err) { // We only want to retry on 409.
+		if err != nil && !trace.IsCompareFailed(ConvertError(err)) { // We only want to retry on 409.
 			return utils.PermanentRetryError(err)
 		}
 		return trace.Wrap(err)
@@ -222,18 +243,22 @@ func (a *dbAuth) GetCloudSQLPassword(ctx context.Context, sessionCtx *Session) (
 	return token, nil
 }
 
-func isStatusConflictError(err error) bool {
-	e, ok := trace.Unwrap(err).(*googleapi.Error)
-	return ok && e.Code == http.StatusConflict
-}
-
 // updateCloudSQLUser makes a request to Cloud SQL API to update the provided user.
 func (a *dbAuth) updateCloudSQLUser(ctx context.Context, sessionCtx *Session, gcpCloudSQL *sqladmin.Service, user *sqladmin.User) error {
 	_, err := gcpCloudSQL.Users.Update(
 		sessionCtx.Server.GetGCP().ProjectID,
 		sessionCtx.Server.GetGCP().InstanceID,
 		user).Name(sessionCtx.DatabaseUser).Host("%").Context(ctx).Do()
-	return trace.Wrap(err)
+	if err != nil {
+		return trace.AccessDenied(`Could not update Cloud SQL user %q password:
+
+  %v
+
+Make sure Teleport db service has "Cloud SQL Admin" GCP IAM role, or
+"cloudsql.users.update" IAM permission.
+`, sessionCtx.DatabaseUser, err)
+	}
+	return nil
 }
 
 // GetTLSConfig builds the client TLS configuration for the session.

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
+	"github.com/pkg/errors"
+	"github.com/siddontang/go-mysql/mysql"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/status"
+
+	"github.com/gravitational/trace"
+	"github.com/gravitational/trace/trail"
+)
+
+// ConvertError converts errors to trace errors.
+func ConvertError(err error) error {
+	// Unwrap original error first.
+	if _, ok := err.(*trace.TraceErr); ok {
+		return ConvertError(trace.Unwrap(err))
+	}
+	if pgErr, ok := err.(pgError); ok {
+		return ConvertError(pgErr.Unwrap())
+	}
+	if _, ok := err.(causer); ok {
+		return ConvertError(errors.Cause(err))
+	}
+	if _, ok := status.FromError(err); ok {
+		return trail.FromGRPC(err)
+	}
+	switch e := trace.Unwrap(err).(type) {
+	case *googleapi.Error:
+		return convertGCPError(e)
+	case awserr.RequestFailure:
+		return convertAWSRequestFailureError(e)
+	case *pgconn.PgError:
+		return convertPostgresError(e)
+	case *mysql.MyError:
+		return convertMySQLError(e)
+	}
+	return err // Return unmodified.
+}
+
+// convertGCPError converts GCP errors to trace errors.
+func convertGCPError(err *googleapi.Error) error {
+	switch err.Code {
+	case http.StatusForbidden:
+		return trace.AccessDenied(err.Error())
+	case http.StatusConflict:
+		return trace.CompareFailed(err.Error())
+	}
+	return err // Return unmodified.
+}
+
+// convertAWSRequestFailureError converts AWS RequestFailure errors to trace errors.
+func convertAWSRequestFailureError(err awserr.RequestFailure) error {
+	switch err.StatusCode() {
+	case http.StatusForbidden:
+		return trace.AccessDenied(err.Error())
+	}
+	return err // Return unmodified.
+}
+
+// convertPostgresError converts Postgres driver errors to trace errors.
+func convertPostgresError(err *pgconn.PgError) error {
+	switch err.Code {
+	case pgerrcode.InvalidAuthorizationSpecification, pgerrcode.InvalidPassword:
+		return trace.AccessDenied(err.Error())
+	}
+	return err // Return unmodified.
+}
+
+// convertMySQLError converts MySQL driver errors to trace errors.
+func convertMySQLError(err *mysql.MyError) error {
+	switch err.Code {
+	case mysql.ER_ACCESS_DENIED_ERROR:
+		return trace.AccessDenied(err.Error())
+	}
+	return err // Return unmodified.
+}
+
+// causer defines an interface for errors wrapped by the "errors" package.
+type causer interface {
+	Cause() error
+}
+
+// pgError defines an interface for errors wrapped by Postgres driver.
+type pgError interface {
+	Unwrap() error
+}

--- a/lib/srv/db/common/policy.go
+++ b/lib/srv/db/common/policy.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+)
+
+// GetRedshiftPolicy returns example AWS IAM policy for Redshift.
+func GetRedshiftPolicy() string {
+	return redshiftPolicy
+}
+
+// GetRDSPolicy returns example AWS IAM policy for RDS in the specified region.
+func GetRDSPolicy(region string) string {
+	return fmt.Sprintf(rdsPolicy, region)
+}
+
+// redshiftPolicy is the example Redshift policy template.
+var redshiftPolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "redshift:GetClusterCredentials",
+      "Resource": [
+        "arn:aws:redshift:*:AWS_ACCOUNT_ID:dbuser:*/*",
+        "arn:aws:redshift:*:AWS_ACCOUNT_ID:dbname:*/*",
+        "arn:aws:redshift:*:AWS_ACCOUNT_ID:dbgroup:*/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "redshift:DescribeClusters",
+      "Resource": "*"
+    }
+  ]
+}`
+
+// rdsPolicy is the example RDS policy template.
+var rdsPolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "rds-db:connect",
+      "Resource": "arn:aws:rds-db:%v:AWS_ACCOUNT_ID:dbuser:AWS_RESOURCE_ID/*"
+    }
+  ]
+}`

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -195,6 +195,16 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 			conn.SetTLSConfig(tlsConfig)
 		})
 	if err != nil {
+		if trace.IsAccessDenied(common.ConvertError(err)) && sessionCtx.Server.IsRDS() {
+			return nil, trace.AccessDenied(`Could not connect to database:
+
+  %v
+
+Make sure Teleport db service's IAM policy allows it to connect to the RDS instance:
+
+%v
+`, common.ConvertError(err), common.GetRDSPolicy(sessionCtx.Server.GetAWS().Region))
+		}
 		return nil, trace.Wrap(err)
 	}
 	return conn, nil

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -204,6 +204,16 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*pgpr
 	// messages b/w server and client e.g. to get client's password.
 	conn, err := pgconn.ConnectConfig(ctx, connectConfig)
 	if err != nil {
+		if trace.IsAccessDenied(common.ConvertError(err)) && sessionCtx.Server.IsRDS() {
+			return nil, nil, trace.AccessDenied(`Could not connect to database:
+
+  %v
+
+Make sure Teleport db service's IAM policy allows it to connect to the RDS instance:
+
+%v
+`, common.ConvertError(err), common.GetRDSPolicy(sessionCtx.Server.GetAWS().Region))
+		}
 		return nil, nil, trace.Wrap(err)
 	}
 	// Hijacked connection exposes some internal connection data, such as

--- a/vendor/github.com/jackc/pgerrcode/LICENSE
+++ b/vendor/github.com/jackc/pgerrcode/LICENSE
@@ -1,0 +1,46 @@
+Copyright (c) 2019 Jack Christensen
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Underlying Data Under PostgreSQL License:
+
+PostgreSQL Database Management System
+(formerly known as Postgres, then as Postgres95)
+
+Portions Copyright © 1996-2019, The PostgreSQL Global Development Group
+
+Portions Copyright © 1994, The Regents of the University of California
+
+Permission to use, copy, modify, and distribute this software and its documentation for any purpose, without fee, and
+without a written agreement is hereby granted, provided that the above copyright notice and this paragraph and the
+following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR
+CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS"
+BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+MODIFICATIONS.

--- a/vendor/github.com/jackc/pgerrcode/README.md
+++ b/vendor/github.com/jackc/pgerrcode/README.md
@@ -1,0 +1,9 @@
+[![](https://godoc.org/github.com/jackc/pgerrcode?status.svg)](https://godoc.org/github.com/jackc/pgerrcode)
+
+# pgerrcode
+
+Package pgerrcode contains constants for PostgreSQL error codes.
+
+## License
+
+MIT for this package's code and PostgreSQL License for the underlying data.

--- a/vendor/github.com/jackc/pgerrcode/errcode.go
+++ b/vendor/github.com/jackc/pgerrcode/errcode.go
@@ -1,0 +1,739 @@
+// Package pgerrcode contains constants for PostgreSQL error codes.
+package pgerrcode
+
+// Source: https://www.postgresql.org/docs/13/errcodes-appendix.html
+// See gen.rb for script that can convert the error code table to Go code.
+
+const (
+
+	// Class 00 — Successful Completion
+	SuccessfulCompletion = "00000"
+
+	// Class 01 — Warning
+	Warning                          = "01000"
+	DynamicResultSetsReturned        = "0100C"
+	ImplicitZeroBitPadding           = "01008"
+	NullValueEliminatedInSetFunction = "01003"
+	PrivilegeNotGranted              = "01007"
+	PrivilegeNotRevoked              = "01006"
+	StringDataRightTruncationWarning = "01004"
+	DeprecatedFeature                = "01P01"
+
+	// Class 02 — No Data (this is also a warning class per the SQL standard)
+	NoData                                = "02000"
+	NoAdditionalDynamicResultSetsReturned = "02001"
+
+	// Class 03 — SQL Statement Not Yet Complete
+	SQLStatementNotYetComplete = "03000"
+
+	// Class 08 — Connection Exception
+	ConnectionException                           = "08000"
+	ConnectionDoesNotExist                        = "08003"
+	ConnectionFailure                             = "08006"
+	SQLClientUnableToEstablishSQLConnection       = "08001"
+	SQLServerRejectedEstablishmentOfSQLConnection = "08004"
+	TransactionResolutionUnknown                  = "08007"
+	ProtocolViolation                             = "08P01"
+
+	// Class 09 — Triggered Action Exception
+	TriggeredActionException = "09000"
+
+	// Class 0A — Feature Not Supported
+	FeatureNotSupported = "0A000"
+
+	// Class 0B — Invalid Transaction Initiation
+	InvalidTransactionInitiation = "0B000"
+
+	// Class 0F — Locator Exception
+	LocatorException            = "0F000"
+	InvalidLocatorSpecification = "0F001"
+
+	// Class 0L — Invalid Grantor
+	InvalidGrantor        = "0L000"
+	InvalidGrantOperation = "0LP01"
+
+	// Class 0P — Invalid Role Specification
+	InvalidRoleSpecification = "0P000"
+
+	// Class 0Z — Diagnostics Exception
+	DiagnosticsException                           = "0Z000"
+	StackedDiagnosticsAccessedWithoutActiveHandler = "0Z002"
+
+	// Class 20 — Case Not Found
+	CaseNotFound = "20000"
+
+	// Class 21 — Cardinality Violation
+	CardinalityViolation = "21000"
+
+	// Class 22 — Data Exception
+	DataException                             = "22000"
+	ArraySubscriptError                       = "2202E"
+	CharacterNotInRepertoire                  = "22021"
+	DatetimeFieldOverflow                     = "22008"
+	DivisionByZero                            = "22012"
+	ErrorInAssignment                         = "22005"
+	EscapeCharacterConflict                   = "2200B"
+	IndicatorOverflow                         = "22022"
+	IntervalFieldOverflow                     = "22015"
+	InvalidArgumentForLogarithm               = "2201E"
+	InvalidArgumentForNtileFunction           = "22014"
+	InvalidArgumentForNthValueFunction        = "22016"
+	InvalidArgumentForPowerFunction           = "2201F"
+	InvalidArgumentForWidthBucketFunction     = "2201G"
+	InvalidCharacterValueForCast              = "22018"
+	InvalidDatetimeFormat                     = "22007"
+	InvalidEscapeCharacter                    = "22019"
+	InvalidEscapeOctet                        = "2200D"
+	InvalidEscapeSequence                     = "22025"
+	NonstandardUseOfEscapeCharacter           = "22P06"
+	InvalidIndicatorParameterValue            = "22010"
+	InvalidParameterValue                     = "22023"
+	InvalidPrecedingOrFollowingSize           = "22013"
+	InvalidRegularExpression                  = "2201B"
+	InvalidRowCountInLimitClause              = "2201W"
+	InvalidRowCountInResultOffsetClause       = "2201X"
+	InvalidTablesampleArgument                = "2202H"
+	InvalidTablesampleRepeat                  = "2202G"
+	InvalidTimeZoneDisplacementValue          = "22009"
+	InvalidUseOfEscapeCharacter               = "2200C"
+	MostSpecificTypeMismatch                  = "2200G"
+	NullValueNotAllowedDataException          = "22004"
+	NullValueNoIndicatorParameter             = "22002"
+	NumericValueOutOfRange                    = "22003"
+	SequenceGeneratorLimitExceeded            = "2200H"
+	StringDataLengthMismatch                  = "22026"
+	StringDataRightTruncationDataException    = "22001"
+	SubstringError                            = "22011"
+	TrimError                                 = "22027"
+	UnterminatedCString                       = "22024"
+	ZeroLengthCharacterString                 = "2200F"
+	FloatingPointException                    = "22P01"
+	InvalidTextRepresentation                 = "22P02"
+	InvalidBinaryRepresentation               = "22P03"
+	BadCopyFileFormat                         = "22P04"
+	UntranslatableCharacter                   = "22P05"
+	NotAnXMLDocument                          = "2200L"
+	InvalidXMLDocument                        = "2200M"
+	InvalidXMLContent                         = "2200N"
+	InvalidXMLComment                         = "2200S"
+	InvalidXMLProcessingInstruction           = "2200T"
+	DuplicateJSONObjectKeyValue               = "22030"
+	InvalidArgumentForSQLJSONDatetimeFunction = "22031"
+	InvalidJSONText                           = "22032"
+	InvalidSQLJSONSubscript                   = "22033"
+	MoreThanOneSQLJSONItem                    = "22034"
+	NoSQLJSONItem                             = "22035"
+	NonNumericSQLJSONItem                     = "22036"
+	NonUniqueKeysInAJSONObject                = "22037"
+	SingletonSQLJSONItemRequired              = "22038"
+	SQLJSONArrayNotFound                      = "22039"
+	SQLJSONMemberNotFound                     = "2203A"
+	SQLJSONNumberNotFound                     = "2203B"
+	SQLJSONObjectNotFound                     = "2203C"
+	TooManyJSONArrayElements                  = "2203D"
+	TooManyJSONObjectMembers                  = "2203E"
+	SQLJSONScalarRequired                     = "2203F"
+
+	// Class 23 — Integrity Constraint Violation
+	IntegrityConstraintViolation = "23000"
+	RestrictViolation            = "23001"
+	NotNullViolation             = "23502"
+	ForeignKeyViolation          = "23503"
+	UniqueViolation              = "23505"
+	CheckViolation               = "23514"
+	ExclusionViolation           = "23P01"
+
+	// Class 24 — Invalid Cursor State
+	InvalidCursorState = "24000"
+
+	// Class 25 — Invalid Transaction State
+	InvalidTransactionState                         = "25000"
+	ActiveSQLTransaction                            = "25001"
+	BranchTransactionAlreadyActive                  = "25002"
+	HeldCursorRequiresSameIsolationLevel            = "25008"
+	InappropriateAccessModeForBranchTransaction     = "25003"
+	InappropriateIsolationLevelForBranchTransaction = "25004"
+	NoActiveSQLTransactionForBranchTransaction      = "25005"
+	ReadOnlySQLTransaction                          = "25006"
+	SchemaAndDataStatementMixingNotSupported        = "25007"
+	NoActiveSQLTransaction                          = "25P01"
+	InFailedSQLTransaction                          = "25P02"
+	IdleInTransactionSessionTimeout                 = "25P03"
+
+	// Class 26 — Invalid SQL Statement Name
+	InvalidSQLStatementName = "26000"
+
+	// Class 27 — Triggered Data Change Violation
+	TriggeredDataChangeViolation = "27000"
+
+	// Class 28 — Invalid Authorization Specification
+	InvalidAuthorizationSpecification = "28000"
+	InvalidPassword                   = "28P01"
+
+	// Class 2B — Dependent Privilege Descriptors Still Exist
+	DependentPrivilegeDescriptorsStillExist = "2B000"
+	DependentObjectsStillExist              = "2BP01"
+
+	// Class 2D — Invalid Transaction Termination
+	InvalidTransactionTermination = "2D000"
+
+	// Class 2F — SQL Routine Exception
+	SQLRoutineException                                = "2F000"
+	FunctionExecutedNoReturnStatement                  = "2F005"
+	ModifyingSQLDataNotPermittedSQLRoutineException    = "2F002"
+	ProhibitedSQLStatementAttemptedSQLRoutineException = "2F003"
+	ReadingSQLDataNotPermittedSQLRoutineException      = "2F004"
+
+	// Class 34 — Invalid Cursor Name
+	InvalidCursorName = "34000"
+
+	// Class 38 — External Routine Exception
+	ExternalRoutineException                                = "38000"
+	ContainingSQLNotPermitted                               = "38001"
+	ModifyingSQLDataNotPermittedExternalRoutineException    = "38002"
+	ProhibitedSQLStatementAttemptedExternalRoutineException = "38003"
+	ReadingSQLDataNotPermittedExternalRoutineException      = "38004"
+
+	// Class 39 — External Routine Invocation Exception
+	ExternalRoutineInvocationException                    = "39000"
+	InvalidSQLstateReturned                               = "39001"
+	NullValueNotAllowedExternalRoutineInvocationException = "39004"
+	TriggerProtocolViolated                               = "39P01"
+	SRFProtocolViolated                                   = "39P02"
+	EventTriggerProtocolViolated                          = "39P03"
+
+	// Class 3B — Savepoint Exception
+	SavepointException            = "3B000"
+	InvalidSavepointSpecification = "3B001"
+
+	// Class 3D — Invalid Catalog Name
+	InvalidCatalogName = "3D000"
+
+	// Class 3F — Invalid Schema Name
+	InvalidSchemaName = "3F000"
+
+	// Class 40 — Transaction Rollback
+	TransactionRollback                     = "40000"
+	TransactionIntegrityConstraintViolation = "40002"
+	SerializationFailure                    = "40001"
+	StatementCompletionUnknown              = "40003"
+	DeadlockDetected                        = "40P01"
+
+	// Class 42 — Syntax Error or Access Rule Violation
+	SyntaxErrorOrAccessRuleViolation   = "42000"
+	SyntaxError                        = "42601"
+	InsufficientPrivilege              = "42501"
+	CannotCoerce                       = "42846"
+	GroupingError                      = "42803"
+	WindowingError                     = "42P20"
+	InvalidRecursion                   = "42P19"
+	InvalidForeignKey                  = "42830"
+	InvalidName                        = "42602"
+	NameTooLong                        = "42622"
+	ReservedName                       = "42939"
+	DatatypeMismatch                   = "42804"
+	IndeterminateDatatype              = "42P18"
+	CollationMismatch                  = "42P21"
+	IndeterminateCollation             = "42P22"
+	WrongObjectType                    = "42809"
+	GeneratedAlways                    = "428C9"
+	UndefinedColumn                    = "42703"
+	UndefinedFunction                  = "42883"
+	UndefinedTable                     = "42P01"
+	UndefinedParameter                 = "42P02"
+	UndefinedObject                    = "42704"
+	DuplicateColumn                    = "42701"
+	DuplicateCursor                    = "42P03"
+	DuplicateDatabase                  = "42P04"
+	DuplicateFunction                  = "42723"
+	DuplicatePreparedStatement         = "42P05"
+	DuplicateSchema                    = "42P06"
+	DuplicateTable                     = "42P07"
+	DuplicateAlias                     = "42712"
+	DuplicateObject                    = "42710"
+	AmbiguousColumn                    = "42702"
+	AmbiguousFunction                  = "42725"
+	AmbiguousParameter                 = "42P08"
+	AmbiguousAlias                     = "42P09"
+	InvalidColumnReference             = "42P10"
+	InvalidColumnDefinition            = "42611"
+	InvalidCursorDefinition            = "42P11"
+	InvalidDatabaseDefinition          = "42P12"
+	InvalidFunctionDefinition          = "42P13"
+	InvalidPreparedStatementDefinition = "42P14"
+	InvalidSchemaDefinition            = "42P15"
+	InvalidTableDefinition             = "42P16"
+	InvalidObjectDefinition            = "42P17"
+
+	// Class 44 — WITH CHECK OPTION Violation
+	WithCheckOptionViolation = "44000"
+
+	// Class 53 — Insufficient Resources
+	InsufficientResources      = "53000"
+	DiskFull                   = "53100"
+	OutOfMemory                = "53200"
+	TooManyConnections         = "53300"
+	ConfigurationLimitExceeded = "53400"
+
+	// Class 54 — Program Limit Exceeded
+	ProgramLimitExceeded = "54000"
+	StatementTooComplex  = "54001"
+	TooManyColumns       = "54011"
+	TooManyArguments     = "54023"
+
+	// Class 55 — Object Not In Prerequisite State
+	ObjectNotInPrerequisiteState = "55000"
+	ObjectInUse                  = "55006"
+	CantChangeRuntimeParam       = "55P02"
+	LockNotAvailable             = "55P03"
+	UnsafeNewEnumValueUsage      = "55P04"
+
+	// Class 57 — Operator Intervention
+	OperatorIntervention = "57000"
+	QueryCanceled        = "57014"
+	AdminShutdown        = "57P01"
+	CrashShutdown        = "57P02"
+	CannotConnectNow     = "57P03"
+	DatabaseDropped      = "57P04"
+
+	// Class 58 — System Error (errors external to PostgreSQL itself)
+	SystemError   = "58000"
+	IOError       = "58030"
+	UndefinedFile = "58P01"
+	DuplicateFile = "58P02"
+
+	// Class 72 — Snapshot Failure
+	SnapshotTooOld = "72000"
+
+	// Class F0 — Configuration File Error
+	ConfigFileError = "F0000"
+	LockFileExists  = "F0001"
+
+	// Class HV — Foreign Data Wrapper Error (SQL/MED)
+	FDWError                             = "HV000"
+	FDWColumnNameNotFound                = "HV005"
+	FDWDynamicParameterValueNeeded       = "HV002"
+	FDWFunctionSequenceError             = "HV010"
+	FDWInconsistentDescriptorInformation = "HV021"
+	FDWInvalidAttributeValue             = "HV024"
+	FDWInvalidColumnName                 = "HV007"
+	FDWInvalidColumnNumber               = "HV008"
+	FDWInvalidDataType                   = "HV004"
+	FDWInvalidDataTypeDescriptors        = "HV006"
+	FDWInvalidDescriptorFieldIdentifier  = "HV091"
+	FDWInvalidHandle                     = "HV00B"
+	FDWInvalidOptionIndex                = "HV00C"
+	FDWInvalidOptionName                 = "HV00D"
+	FDWInvalidStringLengthOrBufferLength = "HV090"
+	FDWInvalidStringFormat               = "HV00A"
+	FDWInvalidUseOfNullPointer           = "HV009"
+	FDWTooManyHandles                    = "HV014"
+	FDWOutOfMemory                       = "HV001"
+	FDWNoSchemas                         = "HV00P"
+	FDWOptionNameNotFound                = "HV00J"
+	FDWReplyHandle                       = "HV00K"
+	FDWSchemaNotFound                    = "HV00Q"
+	FDWTableNotFound                     = "HV00R"
+	FDWUnableToCreateExecution           = "HV00L"
+	FDWUnableToCreateReply               = "HV00M"
+	FDWUnableToEstablishConnection       = "HV00N"
+
+	// Class P0 — PL/pgSQL Error
+	PLpgSQLError   = "P0000"
+	RaiseException = "P0001"
+	NoDataFound    = "P0002"
+	TooManyRows    = "P0003"
+	AssertFailure  = "P0004"
+
+	// Class XX — Internal Error
+	InternalError  = "XX000"
+	DataCorrupted  = "XX001"
+	IndexCorrupted = "XX002"
+)
+
+// IsSuccessfulCompletion asserts the error code class is Class 00 — Successful Completion
+func IsSuccessfulCompletion(code string) bool {
+	switch code {
+	case SuccessfulCompletion:
+		return true
+	}
+	return false
+}
+
+// IsWarning asserts the error code class is Class 01 — Warning
+func IsWarning(code string) bool {
+	switch code {
+	case Warning, DynamicResultSetsReturned, ImplicitZeroBitPadding, NullValueEliminatedInSetFunction, PrivilegeNotGranted, PrivilegeNotRevoked, StringDataRightTruncationWarning, DeprecatedFeature:
+		return true
+	}
+	return false
+}
+
+// IsNoData asserts the error code class is Class 02 — No Data (this is also a warning class per the SQL standard)
+func IsNoData(code string) bool {
+	switch code {
+	case NoData, NoAdditionalDynamicResultSetsReturned:
+		return true
+	}
+	return false
+}
+
+// IsSQLStatementNotYetComplete asserts the error code class is Class 03 — SQL Statement Not Yet Complete
+func IsSQLStatementNotYetComplete(code string) bool {
+	switch code {
+	case SQLStatementNotYetComplete:
+		return true
+	}
+	return false
+}
+
+// IsConnectionException asserts the error code class is Class 08 — Connection Exception
+func IsConnectionException(code string) bool {
+	switch code {
+	case ConnectionException, ConnectionDoesNotExist, ConnectionFailure, SQLClientUnableToEstablishSQLConnection, SQLServerRejectedEstablishmentOfSQLConnection, TransactionResolutionUnknown, ProtocolViolation:
+		return true
+	}
+	return false
+}
+
+// IsTriggeredActionException asserts the error code class is Class 09 — Triggered Action Exception
+func IsTriggeredActionException(code string) bool {
+	switch code {
+	case TriggeredActionException:
+		return true
+	}
+	return false
+}
+
+// IsFeatureNotSupported asserts the error code class is Class 0A — Feature Not Supported
+func IsFeatureNotSupported(code string) bool {
+	switch code {
+	case FeatureNotSupported:
+		return true
+	}
+	return false
+}
+
+// IsInvalidTransactionInitiation asserts the error code class is Class 0B — Invalid Transaction Initiation
+func IsInvalidTransactionInitiation(code string) bool {
+	switch code {
+	case InvalidTransactionInitiation:
+		return true
+	}
+	return false
+}
+
+// IsLocatorException asserts the error code class is Class 0F — Locator Exception
+func IsLocatorException(code string) bool {
+	switch code {
+	case LocatorException, InvalidLocatorSpecification:
+		return true
+	}
+	return false
+}
+
+// IsInvalidGrantor asserts the error code class is Class 0L — Invalid Grantor
+func IsInvalidGrantor(code string) bool {
+	switch code {
+	case InvalidGrantor, InvalidGrantOperation:
+		return true
+	}
+	return false
+}
+
+// IsInvalidRoleSpecification asserts the error code class is Class 0P — Invalid Role Specification
+func IsInvalidRoleSpecification(code string) bool {
+	switch code {
+	case InvalidRoleSpecification:
+		return true
+	}
+	return false
+}
+
+// IsDiagnosticsException asserts the error code class is Class 0Z — Diagnostics Exception
+func IsDiagnosticsException(code string) bool {
+	switch code {
+	case DiagnosticsException, StackedDiagnosticsAccessedWithoutActiveHandler:
+		return true
+	}
+	return false
+}
+
+// IsCaseNotFound asserts the error code class is Class 20 — Case Not Found
+func IsCaseNotFound(code string) bool {
+	switch code {
+	case CaseNotFound:
+		return true
+	}
+	return false
+}
+
+// IsCardinalityViolation asserts the error code class is Class 21 — Cardinality Violation
+func IsCardinalityViolation(code string) bool {
+	switch code {
+	case CardinalityViolation:
+		return true
+	}
+	return false
+}
+
+// IsDataException asserts the error code class is Class 22 — Data Exception
+func IsDataException(code string) bool {
+	switch code {
+	case DataException, ArraySubscriptError, CharacterNotInRepertoire, DatetimeFieldOverflow, DivisionByZero, ErrorInAssignment, EscapeCharacterConflict, IndicatorOverflow, IntervalFieldOverflow, InvalidArgumentForLogarithm, InvalidArgumentForNtileFunction, InvalidArgumentForNthValueFunction, InvalidArgumentForPowerFunction, InvalidArgumentForWidthBucketFunction, InvalidCharacterValueForCast, InvalidDatetimeFormat, InvalidEscapeCharacter, InvalidEscapeOctet, InvalidEscapeSequence, NonstandardUseOfEscapeCharacter, InvalidIndicatorParameterValue, InvalidParameterValue, InvalidPrecedingOrFollowingSize, InvalidRegularExpression, InvalidRowCountInLimitClause, InvalidRowCountInResultOffsetClause, InvalidTablesampleArgument, InvalidTablesampleRepeat, InvalidTimeZoneDisplacementValue, InvalidUseOfEscapeCharacter, MostSpecificTypeMismatch, NullValueNotAllowedDataException, NullValueNoIndicatorParameter, NumericValueOutOfRange, SequenceGeneratorLimitExceeded, StringDataLengthMismatch, StringDataRightTruncationDataException, SubstringError, TrimError, UnterminatedCString, ZeroLengthCharacterString, FloatingPointException, InvalidTextRepresentation, InvalidBinaryRepresentation, BadCopyFileFormat, UntranslatableCharacter, NotAnXMLDocument, InvalidXMLDocument, InvalidXMLContent, InvalidXMLComment, InvalidXMLProcessingInstruction, DuplicateJSONObjectKeyValue, InvalidArgumentForSQLJSONDatetimeFunction, InvalidJSONText, InvalidSQLJSONSubscript, MoreThanOneSQLJSONItem, NoSQLJSONItem, NonNumericSQLJSONItem, NonUniqueKeysInAJSONObject, SingletonSQLJSONItemRequired, SQLJSONArrayNotFound, SQLJSONMemberNotFound, SQLJSONNumberNotFound, SQLJSONObjectNotFound, TooManyJSONArrayElements, TooManyJSONObjectMembers, SQLJSONScalarRequired:
+		return true
+	}
+	return false
+}
+
+// IsIntegrityConstraintViolation asserts the error code class is Class 23 — Integrity Constraint Violation
+func IsIntegrityConstraintViolation(code string) bool {
+	switch code {
+	case IntegrityConstraintViolation, RestrictViolation, NotNullViolation, ForeignKeyViolation, UniqueViolation, CheckViolation, ExclusionViolation:
+		return true
+	}
+	return false
+}
+
+// IsInvalidCursorState asserts the error code class is Class 24 — Invalid Cursor State
+func IsInvalidCursorState(code string) bool {
+	switch code {
+	case InvalidCursorState:
+		return true
+	}
+	return false
+}
+
+// IsInvalidTransactionState asserts the error code class is Class 25 — Invalid Transaction State
+func IsInvalidTransactionState(code string) bool {
+	switch code {
+	case InvalidTransactionState, ActiveSQLTransaction, BranchTransactionAlreadyActive, HeldCursorRequiresSameIsolationLevel, InappropriateAccessModeForBranchTransaction, InappropriateIsolationLevelForBranchTransaction, NoActiveSQLTransactionForBranchTransaction, ReadOnlySQLTransaction, SchemaAndDataStatementMixingNotSupported, NoActiveSQLTransaction, InFailedSQLTransaction, IdleInTransactionSessionTimeout:
+		return true
+	}
+	return false
+}
+
+// IsInvalidSQLStatementName asserts the error code class is Class 26 — Invalid SQL Statement Name
+func IsInvalidSQLStatementName(code string) bool {
+	switch code {
+	case InvalidSQLStatementName:
+		return true
+	}
+	return false
+}
+
+// IsTriggeredDataChangeViolation asserts the error code class is Class 27 — Triggered Data Change Violation
+func IsTriggeredDataChangeViolation(code string) bool {
+	switch code {
+	case TriggeredDataChangeViolation:
+		return true
+	}
+	return false
+}
+
+// IsInvalidAuthorizationSpecification asserts the error code class is Class 28 — Invalid Authorization Specification
+func IsInvalidAuthorizationSpecification(code string) bool {
+	switch code {
+	case InvalidAuthorizationSpecification, InvalidPassword:
+		return true
+	}
+	return false
+}
+
+// IsDependentPrivilegeDescriptorsStillExist asserts the error code class is Class 2B — Dependent Privilege Descriptors Still Exist
+func IsDependentPrivilegeDescriptorsStillExist(code string) bool {
+	switch code {
+	case DependentPrivilegeDescriptorsStillExist, DependentObjectsStillExist:
+		return true
+	}
+	return false
+}
+
+// IsInvalidTransactionTermination asserts the error code class is Class 2D — Invalid Transaction Termination
+func IsInvalidTransactionTermination(code string) bool {
+	switch code {
+	case InvalidTransactionTermination:
+		return true
+	}
+	return false
+}
+
+// IsSQLRoutineException asserts the error code class is Class 2F — SQL Routine Exception
+func IsSQLRoutineException(code string) bool {
+	switch code {
+	case SQLRoutineException, FunctionExecutedNoReturnStatement, ModifyingSQLDataNotPermittedSQLRoutineException, ProhibitedSQLStatementAttemptedSQLRoutineException, ReadingSQLDataNotPermittedSQLRoutineException:
+		return true
+	}
+	return false
+}
+
+// IsInvalidCursorName asserts the error code class is Class 34 — Invalid Cursor Name
+func IsInvalidCursorName(code string) bool {
+	switch code {
+	case InvalidCursorName:
+		return true
+	}
+	return false
+}
+
+// IsExternalRoutineException asserts the error code class is Class 38 — External Routine Exception
+func IsExternalRoutineException(code string) bool {
+	switch code {
+	case ExternalRoutineException, ContainingSQLNotPermitted, ModifyingSQLDataNotPermittedExternalRoutineException, ProhibitedSQLStatementAttemptedExternalRoutineException, ReadingSQLDataNotPermittedExternalRoutineException:
+		return true
+	}
+	return false
+}
+
+// IsExternalRoutineInvocationException asserts the error code class is Class 39 — External Routine Invocation Exception
+func IsExternalRoutineInvocationException(code string) bool {
+	switch code {
+	case ExternalRoutineInvocationException, InvalidSQLstateReturned, NullValueNotAllowedExternalRoutineInvocationException, TriggerProtocolViolated, SRFProtocolViolated, EventTriggerProtocolViolated:
+		return true
+	}
+	return false
+}
+
+// IsSavepointException asserts the error code class is Class 3B — Savepoint Exception
+func IsSavepointException(code string) bool {
+	switch code {
+	case SavepointException, InvalidSavepointSpecification:
+		return true
+	}
+	return false
+}
+
+// IsInvalidCatalogName asserts the error code class is Class 3D — Invalid Catalog Name
+func IsInvalidCatalogName(code string) bool {
+	switch code {
+	case InvalidCatalogName:
+		return true
+	}
+	return false
+}
+
+// IsInvalidSchemaName asserts the error code class is Class 3F — Invalid Schema Name
+func IsInvalidSchemaName(code string) bool {
+	switch code {
+	case InvalidSchemaName:
+		return true
+	}
+	return false
+}
+
+// IsTransactionRollback asserts the error code class is Class 40 — Transaction Rollback
+func IsTransactionRollback(code string) bool {
+	switch code {
+	case TransactionRollback, TransactionIntegrityConstraintViolation, SerializationFailure, StatementCompletionUnknown, DeadlockDetected:
+		return true
+	}
+	return false
+}
+
+// IsSyntaxErrororAccessRuleViolation asserts the error code class is Class 42 — Syntax Error or Access Rule Violation
+func IsSyntaxErrororAccessRuleViolation(code string) bool {
+	switch code {
+	case SyntaxErrorOrAccessRuleViolation, SyntaxError, InsufficientPrivilege, CannotCoerce, GroupingError, WindowingError, InvalidRecursion, InvalidForeignKey, InvalidName, NameTooLong, ReservedName, DatatypeMismatch, IndeterminateDatatype, CollationMismatch, IndeterminateCollation, WrongObjectType, GeneratedAlways, UndefinedColumn, UndefinedFunction, UndefinedTable, UndefinedParameter, UndefinedObject, DuplicateColumn, DuplicateCursor, DuplicateDatabase, DuplicateFunction, DuplicatePreparedStatement, DuplicateSchema, DuplicateTable, DuplicateAlias, DuplicateObject, AmbiguousColumn, AmbiguousFunction, AmbiguousParameter, AmbiguousAlias, InvalidColumnReference, InvalidColumnDefinition, InvalidCursorDefinition, InvalidDatabaseDefinition, InvalidFunctionDefinition, InvalidPreparedStatementDefinition, InvalidSchemaDefinition, InvalidTableDefinition, InvalidObjectDefinition:
+		return true
+	}
+	return false
+}
+
+// IsWithCheckOptionViolation asserts the error code class is Class 44 — WITH CHECK OPTION Violation
+func IsWithCheckOptionViolation(code string) bool {
+	switch code {
+	case WithCheckOptionViolation:
+		return true
+	}
+	return false
+}
+
+// IsInsufficientResources asserts the error code class is Class 53 — Insufficient Resources
+func IsInsufficientResources(code string) bool {
+	switch code {
+	case InsufficientResources, DiskFull, OutOfMemory, TooManyConnections, ConfigurationLimitExceeded:
+		return true
+	}
+	return false
+}
+
+// IsProgramLimitExceeded asserts the error code class is Class 54 — Program Limit Exceeded
+func IsProgramLimitExceeded(code string) bool {
+	switch code {
+	case ProgramLimitExceeded, StatementTooComplex, TooManyColumns, TooManyArguments:
+		return true
+	}
+	return false
+}
+
+// IsObjectNotInPrerequisiteState asserts the error code class is Class 55 — Object Not In Prerequisite State
+func IsObjectNotInPrerequisiteState(code string) bool {
+	switch code {
+	case ObjectNotInPrerequisiteState, ObjectInUse, CantChangeRuntimeParam, LockNotAvailable, UnsafeNewEnumValueUsage:
+		return true
+	}
+	return false
+}
+
+// IsOperatorIntervention asserts the error code class is Class 57 — Operator Intervention
+func IsOperatorIntervention(code string) bool {
+	switch code {
+	case OperatorIntervention, QueryCanceled, AdminShutdown, CrashShutdown, CannotConnectNow, DatabaseDropped:
+		return true
+	}
+	return false
+}
+
+// IsSystemError asserts the error code class is Class 58 — System Error (errors external to PostgreSQL itself)
+func IsSystemError(code string) bool {
+	switch code {
+	case SystemError, IOError, UndefinedFile, DuplicateFile:
+		return true
+	}
+	return false
+}
+
+// IsSnapshotFailure asserts the error code class is Class 72 — Snapshot Failure
+func IsSnapshotFailure(code string) bool {
+	switch code {
+	case SnapshotTooOld:
+		return true
+	}
+	return false
+}
+
+// IsConfigurationFileError asserts the error code class is Class F0 — Configuration File Error
+func IsConfigurationFileError(code string) bool {
+	switch code {
+	case ConfigFileError, LockFileExists:
+		return true
+	}
+	return false
+}
+
+// IsForeignDataWrapperError asserts the error code class is Class HV — Foreign Data Wrapper Error (SQL/MED)
+func IsForeignDataWrapperError(code string) bool {
+	switch code {
+	case FDWError, FDWColumnNameNotFound, FDWDynamicParameterValueNeeded, FDWFunctionSequenceError, FDWInconsistentDescriptorInformation, FDWInvalidAttributeValue, FDWInvalidColumnName, FDWInvalidColumnNumber, FDWInvalidDataType, FDWInvalidDataTypeDescriptors, FDWInvalidDescriptorFieldIdentifier, FDWInvalidHandle, FDWInvalidOptionIndex, FDWInvalidOptionName, FDWInvalidStringLengthOrBufferLength, FDWInvalidStringFormat, FDWInvalidUseOfNullPointer, FDWTooManyHandles, FDWOutOfMemory, FDWNoSchemas, FDWOptionNameNotFound, FDWReplyHandle, FDWSchemaNotFound, FDWTableNotFound, FDWUnableToCreateExecution, FDWUnableToCreateReply, FDWUnableToEstablishConnection:
+		return true
+	}
+	return false
+}
+
+// IsPLpgSQLError asserts the error code class is Class P0 — PL/pgSQL Error
+func IsPLpgSQLError(code string) bool {
+	switch code {
+	case PLpgSQLError, RaiseException, NoDataFound, TooManyRows, AssertFailure:
+		return true
+	}
+	return false
+}
+
+// IsInternalError asserts the error code class is Class XX — Internal Error
+func IsInternalError(code string) bool {
+	switch code {
+	case InternalError, DataCorrupted, IndexCorrupted:
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/jackc/pgerrcode/gen.rb
+++ b/vendor/github.com/jackc/pgerrcode/gen.rb
@@ -1,0 +1,108 @@
+# Run this script against the data in table A.1. on https://www.postgresql.org/docs/13/errcodes-appendix.html.
+#
+# Source data should be formatted like the following:
+#
+# Class 00 — Successful Completion
+# 00000 	successful_completion
+# Class 01 — Warning
+# 01000 	warning
+# 0100C 	dynamic_result_sets_returned
+#
+# for best results pass through gofmt
+# ruby gen.rb < tablecontents.txt  | gofmt > errcode.go
+
+code_name_overrides = {
+  # Some error code names are repeated. In those cases add the error class as a suffix.
+  "01004" => "StringDataRightTruncationWarning",
+  "22001" => "StringDataRightTruncationDataException",
+  "22004" => "NullValueNotAllowedDataException",
+  "2F002" => "ModifyingSQLDataNotPermittedSQLRoutineException",
+  "2F003" => "ProhibitedSQLStatementAttemptedSQLRoutineException",
+  "2F004" => "ReadingSQLDataNotPermittedSQLRoutineException",
+	"38002" => "ModifyingSQLDataNotPermittedExternalRoutineException",
+	"38003" => "ProhibitedSQLStatementAttemptedExternalRoutineException",
+  "38004" => "ReadingSQLDataNotPermittedExternalRoutineException",
+  "39004" => "NullValueNotAllowedExternalRoutineInvocationException",
+
+  # Go casing corrections
+	"08001" => "SQLClientUnableToEstablishSQLConnection",
+  "08004" => "SQLServerRejectedEstablishmentOfSQLConnection",
+  "P0000" => "PLpgSQLError"
+}
+
+class_name_overrides = {
+  # Go casing corrections
+  "WITHCHECKOPTIONViolation" => "WithCheckOptionViolation"
+}
+
+cls_errs = Array.new
+cls_assertions = Array.new
+last_cls = ""
+last_cls_full = ""
+
+def build_assert_func(last_cls, last_cls_full, cls_errs)
+  <<~GO
+  // Is#{last_cls} asserts the error code class is #{last_cls_full}
+  func Is#{last_cls} (code string) bool {
+      switch code{
+          case #{cls_errs.join(", ")}:
+              return true
+      }
+      return false
+  }
+  GO
+end
+
+puts <<~STR
+// Package pgerrcode contains constants for PostgreSQL error codes.
+package pgerrcode
+
+// Source: https://www.postgresql.org/docs/13/errcodes-appendix.html
+// See gen.rb for script that can convert the error code table to Go code.
+
+const (
+STR
+
+ARGF.each do |line|
+  case line
+  when /^Class/
+    if cls_errs.length > 0 && last_cls != ""
+      assert_func = build_assert_func(class_name_overrides.fetch(last_cls) { last_cls }, last_cls_full, cls_errs)
+      cls_assertions.push(assert_func)
+    end
+    last_cls = line.split("—")[1]
+    .gsub(" ", "")
+    .gsub("/", "")
+    .gsub("\n", "")
+    .sub(/\(\w*\)/, "")
+    last_cls_full = line.gsub("\n", "")
+    cls_errs.clear
+    puts
+    puts "// #{line}"
+  when /^(\w{5})\s+(\w+)/
+    code = $1
+    name = code_name_overrides.fetch(code) do
+      $2.split("_").map(&:capitalize).join
+        .gsub("Sql", "SQL")
+        .gsub("Xml", "XML")
+        .gsub("Fdw", "FDW")
+        .gsub("Srf", "SRF")
+        .gsub("Io", "IO")
+        .gsub("Json", "JSON")
+    end
+    cls_errs.push(name)
+    puts %Q[#{name} = "#{code}"]
+  else
+    puts line
+  end
+end
+puts ")"
+
+if cls_errs.length > 0
+  assert_func = build_assert_func(class_name_overrides.fetch(last_cls) { last_cls }, last_cls_full, cls_errs)
+  cls_assertions.push(assert_func)
+end
+
+cls_assertions.each do |cls_assertion|
+  puts cls_assertion
+end

--- a/vendor/github.com/jackc/pgerrcode/go.mod
+++ b/vendor/github.com/jackc/pgerrcode/go.mod
@@ -1,0 +1,3 @@
+module github.com/jackc/pgerrcode
+
+go 1.12

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -285,12 +285,14 @@ github.com/gravitational/reporting/types
 github.com/gravitational/roundtrip
 # github.com/gravitational/teleport/api v0.0.0 => ./api
 ## explicit
+github.com/gravitational/teleport/api
 github.com/gravitational/teleport/api/client
 github.com/gravitational/teleport/api/client/proto
 github.com/gravitational/teleport/api/client/webclient
 github.com/gravitational/teleport/api/constants
 github.com/gravitational/teleport/api/defaults
 github.com/gravitational/teleport/api/identityfile
+github.com/gravitational/teleport/api/metadata
 github.com/gravitational/teleport/api/profile
 github.com/gravitational/teleport/api/types
 github.com/gravitational/teleport/api/types/events
@@ -319,6 +321,9 @@ github.com/jackc/chunkreader/v2
 ## explicit
 github.com/jackc/pgconn
 github.com/jackc/pgconn/internal/ctxwatch
+# github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
+## explicit
+github.com/jackc/pgerrcode
 # github.com/jackc/pgio v1.0.0
 github.com/jackc/pgio
 # github.com/jackc/pgpassfile v1.0.0
@@ -422,6 +427,7 @@ github.com/pborman/uuid
 # github.com/pingcap/errors v0.11.0
 github.com/pingcap/errors
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
Improve the way database access IAM errors are reported to users. Teleport will now detect errors such as failure to generate an IAM token or connect to an RDS/Redshift/GCP database and report the error to the user in a readable format explaining the reason and showing an example IAM policy where appropriate. This is a first step to improving database access UX.

Closes https://github.com/gravitational/teleport/issues/7369 and updates https://github.com/gravitational/teleport/issues/7265.