### PR TITLE
Fix potential infinite loop in GetTrustedCertsPEM

### DIFF
--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -635,6 +635,7 @@ func (fs *fsLocalNonSessionKeyStore) GetTrustedCertsPEM(proxyHost string) ([][]b
 		}
 		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
 			fs.log.Debugf("Skipping PEM block type=%v headers=%v.", block.Type, block.Headers)
+			data = rest
 			continue
 		}
 		// rest contains the remainder of data after reading a block.

--- a/lib/client/keystore_test.go
+++ b/lib/client/keystore_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keypaths"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -326,9 +327,8 @@ func TestGetTrustedCertsPEM_nonCertificateBlocks(t *testing.T) {
 	// certs.pem. During regular use this shouldn't happen, but a bug was lurking
 	// around here.
 	proxy := "proxy.example.com"
-	proxyDir := filepath.Join(s.storeDir, "keys", proxy)
-	certsFile := filepath.Join(proxyDir, "certs.pem")
-	err := os.MkdirAll(proxyDir, 0700)
+	certsFile := keypaths.TLSCAsPath(s.storeDir, proxy)
+	err := os.MkdirAll(filepath.Dir(certsFile), 0700)
 	require.NoError(t, err)
 	err = ioutil.WriteFile(certsFile, []byte(`-----BEGIN RSA PUBLIC KEY-----
 MIIBCgKCAQEAp2eO39fYnpUI4PplyoS/bHrr5Yiy98t+1sdDwGIG01UPlkxAxzIi


### PR DESCRIPTION
A non-CERTIFICATE block in certs.pem causes tsh to get stuck.