### PR TITLE
[v6.2] docs: Add CertificateFile to OpenSSH user manual

### DIFF
--- a/docs/pages/user-manual.mdx
+++ b/docs/pages/user-manual.mdx
@@ -571,8 +571,8 @@ Host teleport.proxy
 ### Passing Teleport SSH certificate to OpenSSH client
 
 If a user does not want to use an SSH agent or if the agent is not available,
-the certificate must be passed to `ssh` via `IdentityFile` option (see `man
-ssh_config`). Consider this example: the Teleport user `joe` wants to login into
+the certificate must be passed to `ssh` via `IdentityFile` and `CertificateFile` options
+(see `man ssh_config`). Consider this example: the Teleport user `joe` wants to login into
 the proxy named `lab.example.com`.
 
 He executes the [`tsh login`](cli-docs.mdx#tsh-login) command:
@@ -588,6 +588,7 @@ His identity is now stored in `~/.tsh/keys/lab.example.com`, so his `~/.ssh/conf
 Host *.lab.example.com
     Port 3022
     IdentityFile ~/.tsh/keys/lab.example.com/joe
+    CertificateFile ~/.tsh/keys/lab.example.com/joe-ssh/lab.example.com-cert.pub
     ProxyCommand ssh -i ~/.tsh/keys/lab.example.com/joe -p 3023 %r@lab.example.com -s proxy:%h:%p
 ```
 

--- a/docs/pages/user-manual.mdx
+++ b/docs/pages/user-manual.mdx
@@ -573,7 +573,7 @@ Host teleport.proxy
 If a user does not want to use an SSH agent or if the agent is not available,
 the certificate must be passed to `ssh` via `IdentityFile` and `CertificateFile` options
 (see `man ssh_config`). Consider this example: the Teleport user `joe` wants to login into
-the proxy named `lab.example.com`.
+the Teleport cluster named `lab.example.com`.
 
 He executes the [`tsh login`](cli-docs.mdx#tsh-login) command:
 


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/6212 changed the default path for SSH certificates generated on `tsh login` from `~/.tsh/keys/<proxy>/<username>-cert.pub` to `~/.tsh/keys/<proxy>/<username>-ssh/<cluster>-cert.pub`. This breaks [OpenSSH's default behaviour](https://github.com/openssh/openssh-portable/blob/master/authfile.c#L308-L309) which is to try and load the certificate from `<identityfile>-cert.pub`. Our documentation relied on that behaviour.

This modifies the mention of `IdentityFile` in our documentation to add the correct path to `CertificateFile` which will enable things to work as expected again.

Forward-ports needed:
- `master`