### PR TITLE
Include O in MongoDB certs and improve some errors

### DIFF
--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -296,22 +296,25 @@ func (s *localSite) getConn(params DialParams) (conn net.Conn, useTunnel bool, e
 
 	s.log.WithError(tunnelErr).WithField("address", dreq.Address).Debug("Error occurred while dialing through a tunnel.")
 
+	tunnelMsg := fmt.Sprintf(`Teleport proxy failed to connect to %q agent %q over reverse tunnel:
+
+  %v
+
+This usually means that the agent is offline or has disconnected. Check the
+agent logs and, if the issue persists, try restarting it or re-registering it
+with the cluster.`, params.ConnType, dreq.Address, tunnelErr)
+
 	// Connections to application and database servers should never occur
 	// over a direct dial, return right away.
 	switch params.ConnType {
-	case types.AppTunnel:
-		return nil, false, trace.ConnectionProblem(err, "failed to connect to application server")
-	case types.DatabaseTunnel:
-		return nil, false, trace.ConnectionProblem(err, "failed to connect to database server")
+	case types.AppTunnel, types.DatabaseTunnel:
+		return nil, false, trace.ConnectionProblem(err, tunnelMsg)
 	}
-
-	offlineMsg := "the node is offline or has disconnected, if the issue " +
-		"persists, restart the node or re-register it in the cluster"
 
 	// This node can only be reached over a tunnel, don't attempt to dial
 	// remotely.
 	if params.To.String() == "" {
-		return nil, false, trace.ConnectionProblem(tunnelErr, offlineMsg)
+		return nil, false, trace.ConnectionProblem(tunnelErr, tunnelMsg)
 	}
 
 	// If no tunnel connection was found, dial to the target host.
@@ -320,7 +323,7 @@ func (s *localSite) getConn(params DialParams) (conn net.Conn, useTunnel bool, e
 	if directErr != nil {
 		s.log.WithError(directErr).WithField("address", params.To.String()).Debug("Error occurred while dialing directly.")
 		aggregateErr := trace.NewAggregate(tunnelErr, directErr)
-		return nil, false, trace.ConnectionProblem(aggregateErr, offlineMsg)
+		return nil, false, trace.ConnectionProblem(aggregateErr, tunnelMsg)
 	}
 
 	// Return a direct dialed connection.

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -126,7 +126,8 @@ func (a *dbAuth) GetRDSAuthToken(sessionCtx *Session) (string, error) {
 
   %v
 
-Make sure Teleport db service's AWS IAM policy allows it to connect to the RDS instance:
+Make sure that Teleport database agent's IAM policy is attached and has "rds-connect"
+permissions:
 
 %v
 `, err, GetRDSPolicy(sessionCtx.Server.GetAWS().Region))
@@ -158,7 +159,8 @@ func (a *dbAuth) GetRedshiftAuthToken(sessionCtx *Session) (string, string, erro
 
   %v
 
-Make sure Teleport db service's AWS IAM policy allows it to generate Redshift credentials:
+Make sure that Teleport database agent's IAM policy is attached and has permissions
+to generate Redshift credentials:
 
 %v
 `, err, GetRedshiftPolicy())

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -200,10 +200,11 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 
   %v
 
-Make sure Teleport db service's IAM policy allows it to connect to the RDS instance:
+Make sure that IAM auth is enabled for MySQL user %q and Teleport database
+agent's IAM policy has "rds-connect" permissions:
 
 %v
-`, common.ConvertError(err), common.GetRDSPolicy(sessionCtx.Server.GetAWS().Region))
+`, common.ConvertError(err), sessionCtx.DatabaseUser, common.GetRDSPolicy(sessionCtx.Server.GetAWS().Region))
 		}
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -209,10 +209,11 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*pgpr
 
   %v
 
-Make sure Teleport db service's IAM policy allows it to connect to the RDS instance:
+Make sure that Postgres user %q has "rds_iam" role and Teleport database
+agent's IAM policy has "rds-connect" permissions:
 
 %v
-`, common.ConvertError(err), common.GetRDSPolicy(sessionCtx.Server.GetAWS().Region))
+`, common.ConvertError(err), sessionCtx.DatabaseUser, common.GetRDSPolicy(sessionCtx.Server.GetAWS().Region))
 		}
 		return nil, nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
A couple of minor database access improvements:
* When generating MongoDB certificates with `tctl auth sign`, include Organization (O) attribute in the certificate subject. This is required to make the certificates compatible with MongoDB x509 internal members authentication.
* Further improve a few errors returned by database access.
