### PR TITLE
Fixed performance issues with the Web UI.

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -225,7 +225,7 @@ func withAllowRules(t *testing.T, srv *TestAuthServer, allowRules []types.Rule) 
 	require.NoError(t, err)
 
 	localUser := LocalUser{Username: username, Identity: tlsca.Identity{Username: username}}
-	authContext, err := contextForLocalUser(localUser, srv.AuthServer.Identity, srv.AuthServer.Access)
+	authContext, err := contextForLocalUser(localUser, srv.AuthServer)
 	require.NoError(t, err)
 
 	return &ServerWithRoles{

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -238,7 +238,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	srv.Authorizer, err = NewAuthorizer(srv.ClusterName, srv.AuthServer.Access, srv.AuthServer.Identity, srv.AuthServer.Trust)
+	srv.Authorizer, err = NewAuthorizer(srv.ClusterName, srv.AuthServer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -48,20 +48,17 @@ func NewBuiltinRoleContext(role types.SystemRole) (*Context, error) {
 }
 
 // NewAuthorizer returns new authorizer using backends
-func NewAuthorizer(clusterName string, access services.Access, identity services.UserGetter, trust services.Trust) (Authorizer, error) {
+func NewAuthorizer(clusterName string, accessPoint ReadAccessPoint) (Authorizer, error) {
 	if clusterName == "" {
 		return nil, trace.BadParameter("missing parameter clusterName")
 	}
-	if access == nil {
-		return nil, trace.BadParameter("missing parameter access")
+	if accessPoint == nil {
+		return nil, trace.BadParameter("missing parameter accessPoint")
 	}
-	if identity == nil {
-		return nil, trace.BadParameter("missing parameter identity")
-	}
-	if trust == nil {
-		return nil, trace.BadParameter("missing parameter trust")
-	}
-	return &authorizer{clusterName: clusterName, access: access, identity: identity, trust: trust}, nil
+	return &authorizer{
+		clusterName: clusterName,
+		accessPoint: accessPoint,
+	}, nil
 }
 
 // Authorizer authorizes identity and returns auth context
@@ -73,9 +70,7 @@ type Authorizer interface {
 // authorizer creates new local authorizer
 type authorizer struct {
 	clusterName string
-	access      services.Access
-	identity    services.UserGetter
-	trust       services.Trust
+	accessPoint ReadAccessPoint
 }
 
 // AuthContext is authorization context
@@ -128,12 +123,12 @@ func (a *authorizer) fromUser(userI interface{}) (*Context, error) {
 
 // authorizeLocalUser returns authz context based on the username
 func (a *authorizer) authorizeLocalUser(u LocalUser) (*Context, error) {
-	return contextForLocalUser(u, a.identity, a.access)
+	return contextForLocalUser(u, a.accessPoint)
 }
 
 // authorizeRemoteUser returns checker based on cert authority roles
 func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*Context, error) {
-	ca, err := a.trust.GetCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: u.ClusterName}, false)
+	ca, err := a.accessPoint.GetCertAuthority(services.CertAuthID{Type: services.UserCA, DomainName: u.ClusterName}, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -170,7 +165,7 @@ func (a *authorizer) authorizeRemoteUser(u RemoteUser) (*Context, error) {
 	}
 	log.Debugf("Mapped roles %v of remote user %q to local roles %v and traits %v.",
 		u.RemoteRoles, u.Username, roleNames, traits)
-	checker, err := services.FetchRoles(roleNames, a.access, traits)
+	checker, err := services.FetchRoles(roleNames, a.accessPoint, traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -595,17 +590,17 @@ func contextForBuiltinRole(r BuiltinRole, clusterConfig services.ClusterConfig) 
 	}, nil
 }
 
-func contextForLocalUser(u LocalUser, identity services.UserGetter, access services.Access) (*Context, error) {
+func contextForLocalUser(u LocalUser, accessPoint ReadAccessPoint) (*Context, error) {
 	// User has to be fetched to check if it's a blocked username
-	user, err := identity.GetUser(u.Username, false)
+	user, err := accessPoint.GetUser(u.Username, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	roles, traits, err := services.ExtractFromIdentity(identity, u.Identity)
+	roles, traits, err := services.ExtractFromIdentity(accessPoint, u.Identity)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	checker, err := services.FetchRoles(roles, access, traits)
+	checker, err := services.FetchRoles(roles, accessPoint, traits)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -111,7 +111,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 
 	clusterName := conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority]
 
-	authorizer, err := auth.NewAuthorizer(clusterName, conn.Client, conn.Client, conn.Client)
+	authorizer, err := auth.NewAuthorizer(clusterName, accessPoint)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -177,7 +177,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	teleportClusterName := conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority]
 
 	// Create the kube server to service listener.
-	authorizer, err := auth.NewAuthorizer(teleportClusterName, conn.Client, conn.Client, conn.Client)
+	authorizer, err := auth.NewAuthorizer(teleportClusterName, accessPoint)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1201,7 +1201,7 @@ func (process *TeleportProcess) initAuthService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	authorizer, err := auth.NewAuthorizer(cfg.Auth.ClusterName.GetClusterName(), authServer.Access, authServer.Identity, authServer.Trust)
+	authorizer, err := auth.NewAuthorizer(cfg.Auth.ClusterName.GetClusterName(), authServer)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -2734,7 +2734,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	var kubeServer *kubeproxy.TLSServer
 	if listeners.kube != nil && !process.Config.Proxy.DisableReverseTunnel {
-		authorizer, err := auth.NewAuthorizer(clusterName, conn.Client, conn.Client, conn.Client)
+		authorizer, err := auth.NewAuthorizer(clusterName, accessPoint)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2792,7 +2792,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	// then routing them to a respective database server over the reverse tunnel
 	// framework.
 	if (listeners.db != nil || listeners.mysql != nil) && !process.Config.Proxy.DisableReverseTunnel {
-		authorizer, err := auth.NewAuthorizer(clusterName, conn.Client, conn.Client, conn.Client)
+		authorizer, err := auth.NewAuthorizer(clusterName, accessPoint)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -3063,7 +3063,7 @@ func (process *TeleportProcess) initApps() {
 		}
 		clusterName := conn.ServerIdentity.Cert.Extensions[utils.CertExtensionAuthority]
 
-		authorizer, err := auth.NewAuthorizer(clusterName, conn.Client, conn.Client, conn.Client)
+		authorizer, err := auth.NewAuthorizer(clusterName, accessPoint)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -197,7 +197,7 @@ func (s *Suite) SetUpTest(c *check.C) {
 	), 0755)
 	c.Assert(err, check.IsNil)
 
-	authorizer, err := auth.NewAuthorizer("cluster-name", s.authClient, s.authClient, s.authClient)
+	authorizer, err := auth.NewAuthorizer("cluster-name", s.authClient)
 	c.Assert(err, check.IsNil)
 
 	s.appServer, err = New(context.Background(), &Config{

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -437,7 +437,7 @@ func setupTestContext(ctx context.Context, t *testing.T, withDatabases ...withDa
 	// Auth client/authorizer for database service.
 	testCtx.authClient, err = testCtx.tlsServer.NewClient(auth.TestServerID(teleport.RoleDatabase, testCtx.hostID))
 	require.NoError(t, err)
-	dbAuthorizer, err := auth.NewAuthorizer(testCtx.clusterName, testCtx.authClient, testCtx.authClient, testCtx.authClient)
+	dbAuthorizer, err := auth.NewAuthorizer(testCtx.clusterName, testCtx.authClient)
 	require.NoError(t, err)
 	testCtx.hostCA, err = testCtx.authClient.GetCertAuthority(types.CertAuthID{Type: types.HostCA, DomainName: testCtx.clusterName}, false)
 	require.NoError(t, err)
@@ -445,7 +445,7 @@ func setupTestContext(ctx context.Context, t *testing.T, withDatabases ...withDa
 	// Auth client/authorizer for database proxy.
 	proxyAuthClient, err := testCtx.tlsServer.NewClient(auth.TestBuiltin(teleport.RoleProxy))
 	require.NoError(t, err)
-	proxyAuthorizer, err := auth.NewAuthorizer(testCtx.clusterName, proxyAuthClient, proxyAuthClient, proxyAuthClient)
+	proxyAuthorizer, err := auth.NewAuthorizer(testCtx.clusterName, proxyAuthClient)
 	require.NoError(t, err)
 
 	// TLS config for database proxy and database service.


### PR DESCRIPTION
**Description**

Fixed two issues that were causing a performance issue with the Web UI.

The first issue was that when an "Authorizer" was being created at process startup by Auth Service, it was by-passing the cache and always hitting the backend directly. All services have been updated to now use an cached access point.

The second issue was that the Web UI was not using the local cache when fetching the list of roles for a user. The Web UI has been updated to now use the local cached access point.

**Related Issues**

Fixes https://github.com/gravitational/teleport/issues/7088