### PR TITLE
Fall back to old CA schema when retrieving keys and certs

### DIFF
--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -313,6 +313,7 @@ func (ca *CertAuthorityV2) GetActiveKeys() CAKeySet {
 	}
 	return keySet
 }
+
 func (ca *CertAuthorityV2) SetActiveKeys(ks CAKeySet) error {
 	if err := ks.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
@@ -320,8 +321,8 @@ func (ca *CertAuthorityV2) SetActiveKeys(ks CAKeySet) error {
 	ca.Spec.ActiveKeys = ks
 	return nil
 }
+
 func (ca *CertAuthorityV2) GetAdditionalTrustedKeys() CAKeySet {
-	return ca.Spec.AdditionalTrustedKeys
 	haveNewCAKeys := len(ca.Spec.AdditionalTrustedKeys.SSH) > 0 || len(ca.Spec.AdditionalTrustedKeys.TLS) > 0 || len(ca.Spec.AdditionalTrustedKeys.JWT) > 0
 	if haveNewCAKeys {
 		return ca.Spec.AdditionalTrustedKeys
@@ -346,6 +347,7 @@ func (ca *CertAuthorityV2) GetAdditionalTrustedKeys() CAKeySet {
 	}
 	return keySet
 }
+
 func (ca *CertAuthorityV2) SetAdditionalTrustedKeys(ks CAKeySet) error {
 	if err := ks.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)

--- a/api/types/authority.go
+++ b/api/types/authority.go
@@ -288,7 +288,31 @@ func (ca *CertAuthorityV2) SetSigningAlg(alg CertAuthoritySpecV2_SigningAlgType)
 	ca.Spec.SigningAlg = alg
 }
 
-func (ca *CertAuthorityV2) GetActiveKeys() CAKeySet { return ca.Spec.ActiveKeys }
+func (ca *CertAuthorityV2) GetActiveKeys() CAKeySet {
+	haveNewCAKeys := len(ca.Spec.ActiveKeys.SSH) > 0 || len(ca.Spec.ActiveKeys.TLS) > 0 || len(ca.Spec.ActiveKeys.JWT) > 0
+	if haveNewCAKeys {
+		return ca.Spec.ActiveKeys
+	}
+	// fall back to old schema
+	var keySet CAKeySet
+	if len(ca.Spec.CheckingKeys) > 0 {
+		kp := &SSHKeyPair{
+			PrivateKeyType: PrivateKeyType_RAW,
+			PublicKey:      utils.CopyByteSlice(ca.Spec.CheckingKeys[0]),
+		}
+		if len(ca.Spec.SigningKeys) > 0 {
+			kp.PrivateKey = utils.CopyByteSlice(ca.Spec.SigningKeys[0])
+		}
+		keySet.SSH = []*SSHKeyPair{kp}
+	}
+	if len(ca.Spec.TLSKeyPairs) > 0 {
+		keySet.TLS = []*TLSKeyPair{ca.Spec.TLSKeyPairs[0].Clone()}
+	}
+	if len(ca.Spec.JWTKeyPairs) > 0 {
+		keySet.JWT = []*JWTKeyPair{ca.Spec.JWTKeyPairs[0].Clone()}
+	}
+	return keySet
+}
 func (ca *CertAuthorityV2) SetActiveKeys(ks CAKeySet) error {
 	if err := ks.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
@@ -296,7 +320,32 @@ func (ca *CertAuthorityV2) SetActiveKeys(ks CAKeySet) error {
 	ca.Spec.ActiveKeys = ks
 	return nil
 }
-func (ca *CertAuthorityV2) GetAdditionalTrustedKeys() CAKeySet { return ca.Spec.AdditionalTrustedKeys }
+func (ca *CertAuthorityV2) GetAdditionalTrustedKeys() CAKeySet {
+	return ca.Spec.AdditionalTrustedKeys
+	haveNewCAKeys := len(ca.Spec.AdditionalTrustedKeys.SSH) > 0 || len(ca.Spec.AdditionalTrustedKeys.TLS) > 0 || len(ca.Spec.AdditionalTrustedKeys.JWT) > 0
+	if haveNewCAKeys {
+		return ca.Spec.AdditionalTrustedKeys
+	}
+	// fall back to old schema
+	var keySet CAKeySet
+	if len(ca.Spec.CheckingKeys) > 1 {
+		kp := &SSHKeyPair{
+			PrivateKeyType: PrivateKeyType_RAW,
+			PublicKey:      utils.CopyByteSlice(ca.Spec.CheckingKeys[1]),
+		}
+		if len(ca.Spec.SigningKeys) > 1 {
+			kp.PrivateKey = utils.CopyByteSlice(ca.Spec.SigningKeys[1])
+		}
+		keySet.SSH = []*SSHKeyPair{kp}
+	}
+	if len(ca.Spec.TLSKeyPairs) > 1 {
+		keySet.TLS = []*TLSKeyPair{ca.Spec.TLSKeyPairs[1].Clone()}
+	}
+	if len(ca.Spec.JWTKeyPairs) > 1 {
+		keySet.JWT = []*JWTKeyPair{ca.Spec.JWTKeyPairs[1].Clone()}
+	}
+	return keySet
+}
 func (ca *CertAuthorityV2) SetAdditionalTrustedKeys(ks CAKeySet) error {
 	if err := ks.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
@@ -307,10 +356,10 @@ func (ca *CertAuthorityV2) SetAdditionalTrustedKeys(ks CAKeySet) error {
 
 func (ca *CertAuthorityV2) GetTrustedSSHKeyPairs() []*SSHKeyPair {
 	var kps []*SSHKeyPair
-	for _, k := range ca.Spec.ActiveKeys.SSH {
+	for _, k := range ca.GetActiveKeys().SSH {
 		kps = append(kps, k.Clone())
 	}
-	for _, k := range ca.Spec.AdditionalTrustedKeys.SSH {
+	for _, k := range ca.GetAdditionalTrustedKeys().SSH {
 		kps = append(kps, k.Clone())
 	}
 	return kps
@@ -318,10 +367,10 @@ func (ca *CertAuthorityV2) GetTrustedSSHKeyPairs() []*SSHKeyPair {
 
 func (ca *CertAuthorityV2) GetTrustedTLSKeyPairs() []*TLSKeyPair {
 	var kps []*TLSKeyPair
-	for _, k := range ca.Spec.ActiveKeys.TLS {
+	for _, k := range ca.GetActiveKeys().TLS {
 		kps = append(kps, k.Clone())
 	}
-	for _, k := range ca.Spec.AdditionalTrustedKeys.TLS {
+	for _, k := range ca.GetAdditionalTrustedKeys().TLS {
 		kps = append(kps, k.Clone())
 	}
 	return kps
@@ -329,10 +378,10 @@ func (ca *CertAuthorityV2) GetTrustedTLSKeyPairs() []*TLSKeyPair {
 
 func (ca *CertAuthorityV2) GetTrustedJWTKeyPairs() []*JWTKeyPair {
 	var kps []*JWTKeyPair
-	for _, k := range ca.Spec.ActiveKeys.JWT {
+	for _, k := range ca.GetActiveKeys().JWT {
 		kps = append(kps, k.Clone())
 	}
-	for _, k := range ca.Spec.AdditionalTrustedKeys.JWT {
+	for _, k := range ca.GetAdditionalTrustedKeys().JWT {
 		kps = append(kps, k.Clone())
 	}
 	return kps

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1387,9 +1387,8 @@ func migrateCertAuthorities(ctx context.Context, asrv *Server) error {
 
 func migrateCertAuthority(ctx context.Context, asrv *Server, ca types.CertAuthority) error {
 	// Check if we need to migrate.
-	if ks := ca.GetActiveKeys(); len(ks.TLS) != 0 || len(ks.SSH) != 0 || len(ks.JWT) != 0 {
-		// Already using the new format.
-		return nil
+	if needsMigration, err := services.CertAuthorityNeedsMigration(ca); err != nil || !needsMigration {
+		return trace.Wrap(err)
 	}
 	log.Infof("Migrating %v to 7.0 storage format.", ca)
 	// CA rotation can cause weird edge cases during migration, don't allow

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -411,6 +411,17 @@ func MarshalCertAuthority(certAuthority types.CertAuthority, opts ...MarshalOpti
 	}
 }
 
+// CertAuthorityNeedsMigrations returns true if the given CertAuthority needs to be migrated
+func CertAuthorityNeedsMigration(cai types.CertAuthority) (bool, error) {
+	ca, ok := cai.(*types.CertAuthorityV2)
+	if !ok {
+		return false, trace.BadParameter("unknown type %T", cai)
+	}
+	haveOldCAKeys := len(ca.Spec.CheckingKeys) > 0 || len(ca.Spec.TLSKeyPairs) > 0 || len(ca.Spec.JWTKeyPairs) > 0
+	haveNewCAKeys := len(ca.Spec.ActiveKeys.SSH) > 0 || len(ca.Spec.ActiveKeys.TLS) > 0 || len(ca.Spec.ActiveKeys.JWT) > 0
+	return haveOldCAKeys && !haveNewCAKeys, nil
+}
+
 // SyncCertAuthorityKeys backfills the old or new key formats, if one of them
 // is empty. If both formats are present, SyncCertAuthorityKeys does nothing.
 func SyncCertAuthorityKeys(cai types.CertAuthority) error {

--- a/lib/services/authority_test.go
+++ b/lib/services/authority_test.go
@@ -71,7 +71,7 @@ func TestCertPoolFromCertAuthorities(t *testing.T) {
 	require.NoError(t, err)
 	ca3, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
 		Type:        types.HostCA,
-		ClusterName: "cluster1",
+		ClusterName: "cluster3",
 		TLSKeyPairs: []types.TLSKeyPair{{
 			Cert: cert,
 			Key:  key,

--- a/lib/services/authority_test.go
+++ b/lib/services/authority_test.go
@@ -89,7 +89,7 @@ func TestCertPoolFromCertAuthorities(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, pool.Subjects(), 2)
 	})
-	t.Run("ca3 with 3 certs", func(t *testing.T) {
+	t.Run("ca3 with 1 cert", func(t *testing.T) {
 		pool, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca3})
 		require.NoError(t, err)
 		require.Len(t, pool.Subjects(), 1)

--- a/lib/services/authority_test.go
+++ b/lib/services/authority_test.go
@@ -66,6 +66,19 @@ func TestCertPoolFromCertAuthorities(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// CA for cluster3 with old schema
+	key, cert, err = tlsca.GenerateSelfSignedCA(pkix.Name{CommonName: "cluster3"}, nil, time.Minute)
+	require.NoError(t, err)
+	ca3, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.HostCA,
+		ClusterName: "cluster1",
+		TLSKeyPairs: []types.TLSKeyPair{{
+			Cert: cert,
+			Key:  key,
+		}},
+	})
+	require.NoError(t, err)
+
 	t.Run("ca1 with 1 cert", func(t *testing.T) {
 		pool, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca1})
 		require.NoError(t, err)
@@ -76,11 +89,16 @@ func TestCertPoolFromCertAuthorities(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, pool.Subjects(), 2)
 	})
-
-	t.Run("ca1 + ca2 with 3 certs total", func(t *testing.T) {
-		pool, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca1, ca2})
+	t.Run("ca3 with 3 certs", func(t *testing.T) {
+		pool, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca3})
 		require.NoError(t, err)
-		require.Len(t, pool.Subjects(), 3)
+		require.Len(t, pool.Subjects(), 1)
+	})
+
+	t.Run("ca1 + ca2 + ca3 with 4 certs total", func(t *testing.T) {
+		pool, err := CertPoolFromCertAuthorities([]types.CertAuthority{ca1, ca2, ca3})
+		require.NoError(t, err)
+		require.Len(t, pool.Subjects(), 4)
 	})
 }
 


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/7576 introduced in https://github.com/gravitational/teleport/pull/7245

With this PR `GetActiveKeys`, `GetAdditionalTrustedKeys`, `GetTrustedSSHKeyPairs`, `GetTrustedTLSKeyPairs`, and `GetTrustedJWTKeyPairs` will all fall back to the "old" CA schema if the new `ActiveKeys` or `AdditionalTrustedKeys` fields are not set. This allows new version of `tsh` to work with old versions of `teleport` where the CA has not been migrated.

I will backport this to `branch/v7`