### PR TITLE
[Backport v7] Fall back to old CA schema when retrieving keys and certs

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1387,9 +1387,8 @@ func migrateCertAuthorities(ctx context.Context, asrv *Server) error {
 
 func migrateCertAuthority(ctx context.Context, asrv *Server, ca types.CertAuthority) error {
 	// Check if we need to migrate.
-	if ks := ca.GetActiveKeys(); len(ks.TLS) != 0 || len(ks.SSH) != 0 || len(ks.JWT) != 0 {
-		// Already using the new format.
-		return nil
+	if needsMigration, err := services.CertAuthorityNeedsMigration(ca); err != nil || !needsMigration {
+		return trace.Wrap(err)
 	}
 	log.Infof("Migrating %v to 7.0 storage format.", ca)
 	// CA rotation can cause weird edge cases during migration, don't allow

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -411,6 +411,17 @@ func MarshalCertAuthority(certAuthority types.CertAuthority, opts ...MarshalOpti
 	}
 }
 
+// CertAuthorityNeedsMigrations returns true if the given CertAuthority needs to be migrated
+func CertAuthorityNeedsMigration(cai types.CertAuthority) (bool, error) {
+	ca, ok := cai.(*types.CertAuthorityV2)
+	if !ok {
+		return false, trace.BadParameter("unknown type %T", cai)
+	}
+	haveOldCAKeys := len(ca.Spec.CheckingKeys) > 0 || len(ca.Spec.TLSKeyPairs) > 0 || len(ca.Spec.JWTKeyPairs) > 0
+	haveNewCAKeys := len(ca.Spec.ActiveKeys.SSH) > 0 || len(ca.Spec.ActiveKeys.TLS) > 0 || len(ca.Spec.ActiveKeys.JWT) > 0
+	return haveOldCAKeys && !haveNewCAKeys, nil
+}
+
 // SyncCertAuthorityKeys backfills the old or new key formats, if one of them
 // is empty. If both formats are present, SyncCertAuthorityKeys does nothing.
 func SyncCertAuthorityKeys(cai types.CertAuthority) error {


### PR DESCRIPTION
Original PR https://github.com/gravitational/teleport/pull/7603

With this PR `GetActiveKeys`, `GetAdditionalTrustedKeys`, `GetTrustedSSHKeyPairs`, `GetTrustedTLSKeyPairs`, and `GetTrustedJWTKeyPairs` will all fall back to the "old" CA schema if the new `ActiveKeys` or `AdditionalTrustedKeys` fields are not set. This allows new version of `tsh` to work with old versions of `teleport` where the CA has not been migrated.