### PR TITLE
Fix backend init event emission & dynamo shard iterator errors.

### DIFF
--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -36,27 +36,23 @@ import (
 type CircularBuffer struct {
 	sync.Mutex
 	*log.Entry
-	ctx      context.Context
-	cancel   context.CancelFunc
-	events   []Event
-	start    int
-	end      int
-	size     int
-	watchers *watcherTree
+	events       []Event
+	start        int
+	end          int
+	size         int
+	init, closed bool
+	watchers     *watcherTree
 }
 
-// NewCircularBuffer returns a new instance of circular buffer
-func NewCircularBuffer(ctx context.Context, size int) (*CircularBuffer, error) {
+// NewCircularBuffer returns a new uninitialized instance of circular buffer.
+func NewCircularBuffer(size int) (*CircularBuffer, error) {
 	if size <= 0 {
 		return nil, trace.BadParameter("circular buffer size should be > 0")
 	}
-	ctx, cancel := context.WithCancel(ctx)
 	buf := &CircularBuffer{
 		Entry: log.WithFields(log.Fields{
 			trace.Component: teleport.ComponentBuffer,
 		}),
-		ctx:      ctx,
-		cancel:   cancel,
 		events:   make([]Event, size),
 		start:    -1,
 		end:      -1,
@@ -66,11 +62,26 @@ func NewCircularBuffer(ctx context.Context, size int) (*CircularBuffer, error) {
 	return buf, nil
 }
 
-// Reset resets all events from the queue
-// and closes all active watchers
+// Clear clears all events from the queue and closes all active watchers,
+// but does not modify init state.
+func (c *CircularBuffer) Clear() {
+	c.Lock()
+	defer c.Unlock()
+	c.clear()
+}
+
+// Reset is equivalent to Clear except that is also sets the buffer into
+// an uninitialized state.  This method should only be used when resetting
+// after a broken event stream.  If only closure of watchers is desired,
+// use Clear instead.
 func (c *CircularBuffer) Reset() {
 	c.Lock()
 	defer c.Unlock()
+	c.clear()
+	c.init = false
+}
+
+func (c *CircularBuffer) clear() {
 	// could close multiple times
 	c.watchers.walk(func(w *BufferWatcher) {
 		w.closeWatcher()
@@ -84,10 +95,42 @@ func (c *CircularBuffer) Reset() {
 	}
 }
 
+// SetInit puts the buffer into an initialized state if it isn't already.  Any watchers already queued
+// will be sent init events, and watchers added after this call will have their init events sent immediately.
+// This function must be called *after* establishing a healthy parent event stream in order to preserve
+// correct cache behavior.
+func (c *CircularBuffer) SetInit() {
+	c.Lock()
+	defer c.Unlock()
+	if c.init {
+		return
+	}
+
+	var watchersToDelete []*BufferWatcher
+	c.watchers.walk(func(watcher *BufferWatcher) {
+		if ok := watcher.init(); !ok {
+			watchersToDelete = append(watchersToDelete, watcher)
+		}
+	})
+
+	for _, watcher := range watchersToDelete {
+		c.Warningf("Closing %v, failed to send init event.", watcher)
+		watcher.closeWatcher()
+		c.watchers.rm(watcher)
+	}
+
+	c.init = true
+}
+
 // Close closes circular buffer and all watchers
 func (c *CircularBuffer) Close() error {
-	c.cancel()
-	c.Reset()
+	c.Lock()
+	defer c.Unlock()
+	c.clear()
+	c.closed = true
+	// note that we do not modify init state here.  this is because
+	// calls to Close are allowed to happen concurrently with calls
+	// to Emit().
 	return nil
 }
 
@@ -119,24 +162,27 @@ func (c *CircularBuffer) eventsCopy() []Event {
 	return out
 }
 
-// PushBatch pushes elements to the queue as a batch
-func (c *CircularBuffer) PushBatch(events []Event) {
+// Emit emits events to currently registered watchers and stores them to
+// the buffer.  Panics if called before SetInit(), and returns false if called
+// after Close().
+func (c *CircularBuffer) Emit(events ...Event) (ok bool) {
 	c.Lock()
 	defer c.Unlock()
+
+	if c.closed {
+		return false
+	}
 
 	for i := range events {
-		c.push(events[i])
+		c.emit(events[i])
 	}
+	return true
 }
 
-// Push pushes elements to the queue
-func (c *CircularBuffer) Push(r Event) {
-	c.Lock()
-	defer c.Unlock()
-	c.push(r)
-}
-
-func (c *CircularBuffer) push(r Event) {
+func (c *CircularBuffer) emit(r Event) {
+	if !c.init {
+		panic("push called on uninitialized buffer instance")
+	}
 	if c.size == 0 {
 		c.start = 0
 		c.end = 0
@@ -161,8 +207,6 @@ func (c *CircularBuffer) fanOutEvent(r Event) {
 		}
 		select {
 		case watcher.eventsC <- r:
-		case <-c.ctx.Done():
-			return
 		default:
 			watchersToDelete = append(watchersToDelete, watcher)
 		}
@@ -202,10 +246,8 @@ func (c *CircularBuffer) NewWatcher(ctx context.Context, watch Watch) (Watcher, 
 	c.Lock()
 	defer c.Unlock()
 
-	select {
-	case <-c.ctx.Done():
-		return nil, trace.BadParameter("buffer is closed")
-	default:
+	if c.closed {
+		return nil, trace.Errorf("cannot register watcher, buffer is closed")
 	}
 
 	if watch.QueueSize == 0 {
@@ -232,14 +274,11 @@ func (c *CircularBuffer) NewWatcher(ctx context.Context, watch Watch) (Watcher, 
 		capacity: watch.QueueSize,
 	}
 	c.Debugf("Add %v.", w)
-	select {
-	case w.eventsC <- Event{Type: types.OpInit}:
-	case <-c.ctx.Done():
-		return nil, trace.BadParameter("buffer is closed")
-	default:
-		c.Warningf("Closing %v, buffer overflow.", w)
-		w.Close()
-		return nil, trace.BadParameter("buffer overflow")
+	if c.init {
+		if ok := w.init(); !ok {
+			c.Warningf("Closing %v, failed to send init event.", w)
+			return nil, trace.BadParameter("failed to send init event")
+		}
 	}
 	c.watchers.add(w)
 	return w, nil
@@ -267,6 +306,8 @@ type BufferWatcher struct {
 	eventsC  chan Event
 	ctx      context.Context
 	cancel   context.CancelFunc
+	initOnce sync.Once
+	initOk   bool
 	capacity int
 }
 
@@ -284,6 +325,19 @@ func (w *BufferWatcher) Events() <-chan Event {
 // Done channel is closed when watcher is closed
 func (w *BufferWatcher) Done() <-chan struct{} {
 	return w.ctx.Done()
+}
+
+// init transmits the OpInit event.  safe to double-call.
+func (w *BufferWatcher) init() (ok bool) {
+	w.initOnce.Do(func() {
+		select {
+		case w.eventsC <- Event{Type: types.OpInit}:
+			w.initOk = true
+		default:
+			w.initOk = false
+		}
+	})
+	return w.initOk
 }
 
 // Close closes the watcher, could

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -212,7 +212,7 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	buf, err := backend.NewCircularBuffer(ctx, cfg.BufferSize)
+	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -530,11 +530,6 @@ func (b *Backend) Delete(ctx context.Context, key []byte) error {
 
 // NewWatcher returns a new event watcher
 func (b *Backend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.Watcher, error) {
-	select {
-	case <-b.watchStarted.Done():
-	case <-ctx.Done():
-		return nil, trace.ConnectionProblem(ctx.Err(), "context is closing")
-	}
 	return b.buf.NewWatcher(ctx, watch)
 }
 
@@ -594,7 +589,7 @@ func (b *Backend) Close() error {
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (b *Backend) CloseWatchers() {
-	b.buf.Reset()
+	b.buf.Clear()
 }
 
 type tableStatus int

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -60,7 +60,6 @@ func (b *Backend) asyncPollStreams(ctx context.Context) error {
 			b.Errorf("Poll streams returned with error: %v.", err)
 		}
 		b.Debugf("Reloading %v.", retry)
-		b.buf.Reset()
 		select {
 		case <-retry.After():
 			retry.Inc()
@@ -84,25 +83,69 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 	set := make(map[string]struct{})
 	eventsC := make(chan shardEvent)
 
-	refreshShards := func() error {
+	shouldStartPoll := func(shard *dynamodbstreams.Shard) bool {
+		sid := aws.StringValue(shard.ShardId)
+		if _, ok := set[sid]; ok {
+			// already being polled
+			return false
+		}
+		if _, ok := set[aws.StringValue(shard.ParentShardId)]; ok {
+			b.Debugf("Skipping child shard: %s, still polling parent %s", sid, aws.StringValue(shard.ParentShardId))
+			// still processing parent
+			return false
+		}
+		return true
+	}
+
+	refreshShards := func(init bool) error {
 		shards, err := b.collectActiveShards(ctx, streamArn)
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		var initC chan error
+		if init {
+			// first call to  refreshShards requires us to block on shard iterator
+			// registration.
+			initC = make(chan error, len(shards))
+		}
+
+		started := 0
 		for i := range shards {
+			if !shouldStartPoll(shards[i]) {
+				continue
+			}
 			shardID := aws.StringValue(shards[i].ShardId)
-			if _, ok := set[shardID]; !ok {
-				b.Debugf("Adding active shard %v.", shardID)
-				set[shardID] = struct{}{}
-				go b.asyncPollShard(ctx, streamArn, shards[i], eventsC)
+			b.Debugf("Adding active shard %v.", shardID)
+			set[shardID] = struct{}{}
+			go b.asyncPollShard(ctx, streamArn, shards[i], eventsC, initC)
+			started++
+		}
+
+		if init {
+			// block on shard iterator registration.
+			for i := 0; i < started; i++ {
+				select {
+				case err = <-initC:
+					if err != nil {
+						return trace.Wrap(err)
+					}
+				case <-ctx.Done():
+					return trace.Wrap(ctx.Err())
+				}
 			}
 		}
+
 		return nil
 	}
 
-	if err := refreshShards(); err != nil {
+	if err := refreshShards(true); err != nil {
 		return trace.Wrap(err)
 	}
+
+	// shard iterators are initialized, unblock any registered watchers
+	b.buf.SetInit()
+	defer b.buf.Reset()
 
 	ticker := time.NewTicker(b.PollStreamPeriod)
 	defer ticker.Stop()
@@ -118,10 +161,10 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 				}
 				b.Debugf("Shard ID %v exited gracefully.", event.shardID)
 			} else {
-				b.buf.PushBatch(event.events)
+				b.buf.Emit(event.events...)
 			}
 		case <-ticker.C:
-			if err := refreshShards(); err != nil {
+			if err := refreshShards(false); err != nil {
 				return trace.Wrap(err)
 			}
 		case <-ctx.Done():
@@ -144,15 +187,24 @@ func (b *Backend) findStream(ctx context.Context) (*string, error) {
 	return status.Table.LatestStreamArn, nil
 }
 
-func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent) error {
+func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent, initC chan<- error) error {
 	shardIterator, err := b.streams.GetShardIteratorWithContext(ctx, &dynamodbstreams.GetShardIteratorInput{
 		ShardId:           shard.ShardId,
 		ShardIteratorType: aws.String(dynamodbstreams.ShardIteratorTypeLatest),
 		StreamArn:         streamArn,
 	})
+
+	if initC != nil {
+		select {
+		case initC <- convertError(err):
+		case <-ctx.Done():
+			return trace.ConnectionProblem(ctx.Err(), "context is closing")
+		}
+	}
 	if err != nil {
 		return convertError(err)
 	}
+
 	ticker := time.NewTicker(b.PollStreamPeriod)
 	defer ticker.Stop()
 	iterator := shardIterator.ShardIterator
@@ -283,7 +335,7 @@ func toEvent(rec *dynamodbstreams.Record) (*backend.Event, error) {
 	}
 }
 
-func (b *Backend) asyncPollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent) {
+func (b *Backend) asyncPollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent, initC chan<- error) {
 	var err error
 	defer func() {
 		if err == nil {
@@ -296,7 +348,7 @@ func (b *Backend) asyncPollShard(ctx context.Context, streamArn *string, shard *
 			return
 		}
 	}()
-	err = b.pollShard(ctx, streamArn, shard, eventsC)
+	err = b.pollShard(ctx, streamArn, shard, eventsC, initC)
 }
 
 func (b *Backend) turnOnTimeToLive(ctx context.Context) error {

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -60,6 +60,7 @@ func (b *Backend) asyncPollStreams(ctx context.Context) error {
 			b.Errorf("Poll streams returned with error: %v.", err)
 		}
 		b.Debugf("Reloading %v.", retry)
+		b.buf.Reset()
 		select {
 		case <-retry.After():
 			retry.Inc()
@@ -176,6 +177,7 @@ func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard *dynam
 					b.Debugf("Shard is closed: %v.", aws.StringValue(shard.ShardId))
 					return io.EOF
 				}
+				iterator = out.NextShardIterator
 				continue
 			}
 			if out.NextShardIterator == nil {

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -153,7 +153,7 @@ func NewWithConfig(ctx context.Context, cfg Config) (*Backend, error) {
 	}
 	// serialize access to sqlite to avoid database is locked errors
 	db.SetMaxOpenConns(1)
-	buf, err := backend.NewCircularBuffer(ctx, cfg.BufferSize)
+	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -776,11 +776,6 @@ func (l *Backend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.
 	if l.EventsOff {
 		return nil, trace.BadParameter("events are turned off for this backend")
 	}
-	select {
-	case <-l.watchStarted.Done():
-	case <-ctx.Done():
-		return nil, trace.ConnectionProblem(ctx.Err(), "context is closing")
-	}
 	return l.buf.NewWatcher(ctx, watch)
 }
 
@@ -793,7 +788,7 @@ func (l *Backend) Close() error {
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (l *Backend) CloseWatchers() {
-	l.buf.Reset()
+	l.buf.Clear()
 }
 
 func (l *Backend) isClosed() bool {

--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -128,8 +128,13 @@ func (l *Backend) pollEvents(rowid int64) (int64, error) {
 				return trace.Wrap(err)
 			}
 			row := q.QueryRow()
+			prevRowID := rowid
 			if err := row.Scan(&rowid); err != nil {
 				if err != sql.ErrNoRows {
+					// Scan does not explicitly promise not to modify its inputs if it returns an error (though this is likely
+					// how it behaves).  Just in case, make sure that rowid is preserved so that we don't accidentally skip
+					// some init logic on retry.
+					rowid = prevRowID
 					return trace.Wrap(err)
 				}
 				rowid = -1
@@ -143,6 +148,7 @@ func (l *Backend) pollEvents(rowid int64) (int64, error) {
 		}
 		l.Debugf("Initialized event ID iterator to %v", rowid)
 		l.signalWatchStart()
+		l.buf.SetInit()
 	}
 
 	var events []backend.Event
@@ -178,7 +184,7 @@ func (l *Backend) pollEvents(rowid int64) (int64, error) {
 	if err != nil {
 		return rowid, trace.Wrap(err)
 	}
-	l.buf.PushBatch(events)
+	l.buf.Emit(events...)
 	if len(events) != 0 {
 		return lastID, nil
 	}

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -92,11 +92,12 @@ func New(cfg Config) (*Memory, error) {
 		return nil, trace.Wrap(err)
 	}
 	ctx, cancel := context.WithCancel(cfg.Context)
-	buf, err := backend.NewCircularBuffer(ctx, cfg.BufferSize)
+	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)
 	}
+	buf.SetInit()
 	m := &Memory{
 		Mutex: &sync.Mutex{},
 		Entry: log.WithFields(log.Fields{
@@ -144,7 +145,7 @@ func (m *Memory) Close() error {
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (m *Memory) CloseWatchers() {
-	m.buf.Reset()
+	m.buf.Clear()
 }
 
 // Clock returns clock used by this backend
@@ -169,7 +170,7 @@ func (m *Memory) Create(ctx context.Context, i backend.Item) (*backend.Lease, er
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return m.newLease(i), nil
 }
@@ -210,7 +211,7 @@ func (m *Memory) Update(ctx context.Context, i backend.Item) (*backend.Lease, er
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return m.newLease(i), nil
 }
@@ -233,7 +234,7 @@ func (m *Memory) Put(ctx context.Context, i backend.Item) (*backend.Lease, error
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return m.newLease(i), nil
 }
@@ -259,7 +260,7 @@ func (m *Memory) PutRange(ctx context.Context, items []backend.Item) error {
 		}
 		m.processEvent(event)
 		if !m.EventsOff {
-			m.buf.Push(event)
+			m.buf.Emit(event)
 		}
 	}
 	return nil
@@ -285,7 +286,7 @@ func (m *Memory) Delete(ctx context.Context, key []byte) error {
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return nil
 }
@@ -310,7 +311,7 @@ func (m *Memory) DeleteRange(ctx context.Context, startKey, endKey []byte) error
 		}
 		m.processEvent(event)
 		if !m.EventsOff {
-			m.buf.Push(event)
+			m.buf.Emit(event)
 		}
 	}
 	return nil
@@ -358,7 +359,7 @@ func (m *Memory) KeepAlive(ctx context.Context, lease backend.Lease, expires tim
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return nil
 }
@@ -391,7 +392,7 @@ func (m *Memory) CompareAndSwap(ctx context.Context, expected backend.Item, repl
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return m.newLease(replaceWith), nil
 }
@@ -461,7 +462,7 @@ func (m *Memory) removeExpired() int {
 			},
 		}
 		if !m.EventsOff {
-			m.buf.Push(event)
+			m.buf.Emit(event)
 		}
 	}
 	if removed > 0 {

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -329,6 +329,11 @@ func (s *BackendSuite) KeepAlive(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer watcher.Close()
 
+	init := collectEvents(c, watcher, 1)
+	verifyEvents(c, init, []backend.Event{
+		{Type: types.OpInit, Item: backend.Item{}},
+	})
+
 	expiresAt := addSeconds(s.Clock.Now(), 2)
 	item, lease := s.addItem(context.TODO(), c, prefix("key"), "val1", expiresAt)
 
@@ -344,9 +349,8 @@ func (s *BackendSuite) KeepAlive(c *check.C) {
 	// Since the backend translates absolute expiration timestamp to a TTL
 	// and collecting events takes arbitrary time, the expiration timestamps
 	// on the collected events might have a slight skew
-	events := collectEvents(c, watcher, 3)
+	events := collectEvents(c, watcher, 2)
 	verifyEvents(c, events, []backend.Event{
-		{Type: types.OpInit, Item: backend.Item{}},
 		{Type: types.OpPut, Item: backend.Item{Key: prefix("key"), Value: []byte("val1"), Expires: expiresAt}},
 		{Type: types.OpPut, Item: backend.Item{Key: prefix("key"), Value: []byte("val1"), Expires: updatedAt}},
 	})


### PR DESCRIPTION
Fixes #6201 by correctly updating shard iterators.

Fixes #7486, which turned out to be an instance of a broader problem with how all backends handled event emission.  Backends were not correctly signaling broken event streams, and were emitting `OpInit` events while their event streams were unhealthy, both of which are violations of the contract relied upon by the caching system.

*edit*: Also fixed an issue where dynamo events may arrive out of order due to child shards getting polled before their parent shards were exhausted.