### PR TITLE
Update default roles to V4

### DIFF
--- a/api/types/role.go
+++ b/api/types/role.go
@@ -118,11 +118,17 @@ type Role interface {
 	SetImpersonateConditions(rct RoleConditionType, cond ImpersonateConditions)
 }
 
-// NewRole constructs new standard role
+// NewRole constructs new standard role.
 func NewRole(name string, spec RoleSpecV4) (Role, error) {
+	return NewRoleWithDescription(name, "", spec)
+}
+
+// NewRoleWithDescription constructs new standard role with description.
+func NewRoleWithDescription(name, description string, spec RoleSpecV4) (Role, error) {
 	role := RoleV4{
 		Metadata: Metadata{
-			Name: name,
+			Description: description,
+			Name:        name,
 		},
 		Spec: spec,
 	}

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -487,11 +487,8 @@ func (r *RoleV4) SetRules(rct RoleConditionType, in []Rule) {
 // setStaticFields sets static resource header and metadata fields.
 func (r *RoleV4) setStaticFields() {
 	r.Kind = KindRole
-	// TODO(Joerger/nklaassen) Role should default to V4
-	// but shouldn't overwrite V3. For now, this does the
-	// opposite due to an internal reliance on V3 defaults.
-	if r.Version != V4 {
-		r.Version = V3
+	if r.Version != V3 {
+		r.Version = V4
 	}
 }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1162,7 +1162,11 @@ func runDisconnectTest(t *testing.T, suite *integrationTestSuite, tc disconnectT
 	role, err := types.NewRole("devs", types.RoleSpecV4{
 		Options: tc.options,
 		Allow: types.RoleConditions{
-			Logins: []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
 		},
 	})
 	require.NoError(t, err)
@@ -1694,7 +1698,11 @@ func testMapRoles(t *testing.T, suite *integrationTestSuite) {
 	mainDevs := "main-devs"
 	role, err := types.NewRole(mainDevs, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
 		},
 	})
 	require.NoError(t, err)
@@ -1722,7 +1730,11 @@ func testMapRoles(t *testing.T, suite *integrationTestSuite) {
 	auxDevs := "aux-devs"
 	role, err = types.NewRole(auxDevs, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
 		},
 	})
 	require.NoError(t, err)
@@ -1992,7 +2004,11 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 	mainDevs := "main-devs"
 	devsRole, err := types.NewRole(mainDevs, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
 		},
 	})
 	// If the test is using labels, the cluster will be labeled
@@ -2007,7 +2023,11 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 	mainAdmins := "main-admins"
 	adminsRole, err := types.NewRole(mainAdmins, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{"superuser"},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{"superuser"},
 		},
 	})
 	require.NoError(t, err)
@@ -2018,8 +2038,12 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 	mainOps := "main-ops"
 	mainOpsRole, err := types.NewRole(mainOps, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins:        []string{username},
-			ClusterLabels: types.Labels{"access": []string{"ops"}},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
+			ClusterLabels:    types.Labels{"access": []string{"ops"}},
 		},
 	})
 	require.NoError(t, err)
@@ -2047,7 +2071,11 @@ func trustedClusters(t *testing.T, suite *integrationTestSuite, test trustedClus
 	auxDevs := "aux-devs"
 	auxRole, err := types.NewRole(auxDevs, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
 		},
 	})
 	require.NoError(t, err)
@@ -2227,7 +2255,11 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 	mainDevs := "main-devs"
 	role, err := types.NewRole(mainDevs, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
 		},
 	})
 	require.NoError(t, err)
@@ -2255,7 +2287,11 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 	auxDevs := "aux-devs"
 	role, err = types.NewRole(auxDevs, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
 		},
 	})
 	require.NoError(t, err)
@@ -3711,7 +3747,11 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	mainDevs := "main-devs"
 	role, err := types.NewRole(mainDevs, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{suite.me.Username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{suite.me.Username},
 		},
 	})
 	require.NoError(t, err)
@@ -3729,7 +3769,11 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	auxDevs := "aux-devs"
 	role, err = types.NewRole(auxDevs, types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{suite.me.Username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{suite.me.Username},
 		},
 	})
 	require.NoError(t, err)
@@ -4361,8 +4405,11 @@ func testList(t *testing.T, suite *integrationTestSuite) {
 			// Create role with logins and labels for this test.
 			role, err := types.NewRole(tt.inRoleName, types.RoleSpecV4{
 				Allow: types.RoleConditions{
-					Logins:     []string{tt.inLogin},
-					NodeLabels: tt.inLabels,
+					Logins:           []string{tt.inLogin},
+					NodeLabels:       tt.inLabels,
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 			require.NoError(t, err)
@@ -4968,6 +5015,9 @@ func testSessionStartContainsAccessRequest(t *testing.T, suite *integrationTestS
 	userRole, err := types.NewRole(userRoleName, types.RoleSpecV4{
 		Options: types.RoleOptions{},
 		Allow: types.RoleConditions{
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 			Request: &types.AccessRequestConditions{
 				Roles: []string{requestedRoleName},
 			},

--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -184,7 +184,10 @@ func testKubeExec(t *testing.T, suite *KubeSuite) {
 	kubeUsers := []string{"alice@example.com"}
 	role, err := types.NewRole("kubemaster", types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins:     []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}}, Logins: []string{username},
 			KubeGroups: kubeGroups,
 			KubeUsers:  kubeUsers,
 		},
@@ -354,9 +357,13 @@ func testKubeDeny(t *testing.T, suite *KubeSuite) {
 	kubeUsers := []string{"alice@example.com"}
 	role, err := types.NewRole("kubemaster", types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins:     []string{username},
-			KubeGroups: kubeGroups,
-			KubeUsers:  kubeUsers,
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
+			KubeGroups:       kubeGroups,
+			KubeUsers:        kubeUsers,
 		},
 		Deny: types.RoleConditions{
 			KubeGroups: kubeGroups,
@@ -406,8 +413,12 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 	kubeGroups := []string{testImpersonationGroup}
 	role, err := types.NewRole("kubemaster", types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins:     []string{username},
-			KubeGroups: kubeGroups,
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
+			KubeGroups:       kubeGroups,
 		},
 	})
 	require.NoError(t, err)
@@ -503,8 +514,12 @@ func testKubeTrustedClustersClientCert(t *testing.T, suite *KubeSuite) {
 	mainKubeGroups := []string{testImpersonationGroup}
 	mainRole, err := types.NewRole("main-kube", types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins:     []string{username},
-			KubeGroups: mainKubeGroups,
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
+			KubeGroups:       mainKubeGroups,
 		},
 	})
 	require.NoError(t, err)
@@ -539,7 +554,11 @@ func testKubeTrustedClustersClientCert(t *testing.T, suite *KubeSuite) {
 	auxKubeGroups := []string{teleport.TraitInternalKubeGroupsVariable}
 	auxRole, err := types.NewRole("aux-kube", types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
 			// Note that main cluster can pass it's kubernetes groups
 			// to the remote cluster, and remote cluster
 			// can choose to use them by using special variable
@@ -757,8 +776,12 @@ func testKubeTrustedClustersSNI(t *testing.T, suite *KubeSuite) {
 	mainKubeGroups := []string{testImpersonationGroup}
 	mainRole, err := types.NewRole("main-kube", types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins:     []string{username},
-			KubeGroups: mainKubeGroups,
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
+			KubeGroups:       mainKubeGroups,
 		},
 	})
 	require.NoError(t, err)
@@ -797,7 +820,11 @@ func testKubeTrustedClustersSNI(t *testing.T, suite *KubeSuite) {
 	auxKubeGroups := []string{teleport.TraitInternalKubeGroupsVariable}
 	auxRole, err := types.NewRole("aux-kube", types.RoleSpecV4{
 		Allow: types.RoleConditions{
-			Logins: []string{username},
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
 			// Note that main cluster can pass it's kubernetes groups
 			// to the remote cluster, and remote cluster
 			// can choose to use them by using special variable
@@ -1038,8 +1065,12 @@ func runKubeDisconnectTest(t *testing.T, suite *KubeSuite, tc disconnectTestCase
 	role, err := types.NewRole("kubemaster", types.RoleSpecV4{
 		Options: tc.options,
 		Allow: types.RoleConditions{
-			Logins:     []string{username},
-			KubeGroups: kubeGroups,
+			NodeLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
+			AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
+			Logins:           []string{username},
+			KubeGroups:       kubeGroups,
 		},
 	})
 	require.NoError(t, err)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -2131,9 +2131,6 @@ func (s *APIServer) upsertRole(auth ClientI, w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err = services.ValidateRole(role); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	err = auth.UpsertRole(r.Context(), role)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -600,10 +600,20 @@ func migrateLegacyResources(ctx context.Context, cfg InitConfig, asrv *Server) e
 
 // createPresets creates preset resources - roles
 func createPresets(ctx context.Context, asrv *Server) error {
-	roles := []types.Role{
-		services.NewPresetEditorRole(),
-		services.NewPresetAccessRole(),
-		services.NewPresetAuditorRole()}
+	editor, err := services.NewPresetEditorRole()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	access, err := services.NewPresetAccessRole()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	auditor, err := services.NewPresetAuditorRole()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	roles := []types.Role{editor, access, auditor}
+
 	for _, role := range roles {
 		err := asrv.CreateRole(role)
 		if err != nil {

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -600,10 +600,14 @@ func TestMigrateMFADevices(t *testing.T) {
 // TestPresets tests behavior of presets
 func TestPresets(t *testing.T) {
 	ctx := context.Background()
-	roles := []types.Role{
-		services.NewPresetEditorRole(),
-		services.NewPresetAccessRole(),
-		services.NewPresetAuditorRole()}
+
+	editor, err := services.NewPresetEditorRole()
+	require.NoError(t, err)
+	access, err := services.NewPresetAccessRole()
+	require.NoError(t, err)
+	auditor, err := services.NewPresetAuditorRole()
+	require.NoError(t, err)
+	roles := []types.Role{editor, access, auditor}
 
 	t.Run("EmptyCluster", func(t *testing.T) {
 		as := newTestAuthServer(ctx, t)
@@ -630,9 +634,10 @@ func TestPresets(t *testing.T) {
 		clock := clockwork.NewFakeClock()
 		as.SetClock(clock)
 
-		access := services.NewPresetEditorRole()
+		access, err := services.NewPresetEditorRole()
+		require.NoError(t, err)
 		access.SetLogins(types.Allow, []string{"root"})
-		err := as.CreateRole(access)
+		err = as.CreateRole(access)
 		require.NoError(t, err)
 
 		err = createPresets(ctx, as)

--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -279,6 +279,9 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, 
 						Where: builder.Equals(services.ResourceNameExpr, builder.String(r.ClusterName)).String(),
 					},
 				},
+				AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+				KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 			},
 		})
 	if err != nil {
@@ -309,6 +312,9 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					Rules: []types.Rule{
 						types.NewRule(types.KindAuthServer, services.RW()),
 					},
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 	case types.RoleProvisionToken:
@@ -341,6 +347,9 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindLock, services.RO()),
 						types.NewRule(types.KindNetworkRestrictions, services.RO()),
 					},
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 	case types.RoleApp:
@@ -370,6 +379,9 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindWebToken, services.RO()),
 						types.NewRule(types.KindJWT, services.RW()),
 					},
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 	case types.RoleDatabase:
@@ -397,6 +409,9 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindDatabaseServer, services.RW()),
 						types.NewRule(types.KindSemaphore, services.RW()),
 					},
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 	case types.RoleProxy:
@@ -462,6 +477,9 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 								).String(),
 							},
 						},
+						AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+						KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+						DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 					},
 				})
 		}
@@ -523,6 +541,9 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 							).String(),
 						},
 					},
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 	case types.RoleSignup:
@@ -535,6 +556,9 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindAuthServer, services.RO()),
 						types.NewRule(types.KindClusterAuthPreference, services.RO()),
 					},
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 	case types.RoleAdmin:
@@ -552,6 +576,9 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					Rules: []types.Rule{
 						types.NewRule(types.Wildcard, services.RW()),
 					},
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 	case types.RoleNop:
@@ -559,8 +586,11 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 			role.String(),
 			types.RoleSpecV4{
 				Allow: types.RoleConditions{
-					Namespaces: []string{},
-					Rules:      []types.Rule{},
+					Namespaces:       []string{},
+					Rules:            []types.Rule{},
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 	case types.RoleKube:
@@ -583,6 +613,9 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindRole, services.RO()),
 						types.NewRule(types.KindNamespace, services.RO()),
 					},
+					AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 				},
 			})
 	}

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -636,7 +636,7 @@ type roleParser struct {
 func (p *roleParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		return resourceHeader(event, types.KindRole, types.V3, 1)
+		return resourceHeader(event, types.KindRole, types.V4, 1)
 	case types.OpPut:
 		resource, err := services.UnmarshalRole(event.Item.Value,
 			services.WithResourceID(event.Item.ID),

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -59,6 +59,12 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindRemoteCluster, RW()),
 					types.NewRule(types.KindToken, RW()),
 				},
+				// These labels were inadvertently set by role.CheckAndSetDefaults. Since this
+				// is no longer done for V4 roles, these need to be added during role version migration.
+				// DELETE IN 8.0.0
+				AppLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+				KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+				DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 			},
 		},
 	}

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -28,16 +29,9 @@ import (
 
 // NewPresetEditorRole returns a new pre-defined role for cluster
 // editors who can edit cluster configuration resources.
-func NewPresetEditorRole() types.Role {
-	role := &types.RoleV4{
-		Kind:    types.KindRole,
-		Version: types.V4,
-		Metadata: types.Metadata{
-			Name:        teleport.PresetEditorRoleName,
-			Namespace:   apidefaults.Namespace,
-			Description: "Edit cluster configuration",
-		},
-		Spec: types.RoleSpecV4{
+func NewPresetEditorRole() (types.Role, error) {
+	return types.NewRoleWithDescription(teleport.PresetEditorRoleName, "Edit cluster configuration",
+		types.RoleSpecV4{
 			Options: types.RoleOptions{
 				CertificateFormat: constants.CertificateFormatStandard,
 				MaxSessionTTL:     types.NewDuration(apidefaults.MaxCertDuration),
@@ -67,22 +61,14 @@ func NewPresetEditorRole() types.Role {
 				DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 			},
 		},
-	}
-	return role
+	)
 }
 
 // NewPresetAccessRole creates a role for users who are allowed to initiate
 // interactive sessions.
-func NewPresetAccessRole() types.Role {
-	role := &types.RoleV4{
-		Kind:    types.KindRole,
-		Version: types.V4,
-		Metadata: types.Metadata{
-			Name:        teleport.PresetAccessRoleName,
-			Namespace:   apidefaults.Namespace,
-			Description: "Access cluster resources",
-		},
-		Spec: types.RoleSpecV4{
+func NewPresetAccessRole() (types.Role, error) {
+	role, err := types.NewRoleWithDescription(teleport.PresetAccessRoleName, "Access cluster resources",
+		types.RoleSpecV4{
 			Options: types.RoleOptions{
 				CertificateFormat: constants.CertificateFormatStandard,
 				MaxSessionTTL:     types.NewDuration(apidefaults.MaxCertDuration),
@@ -103,26 +89,22 @@ func NewPresetAccessRole() types.Role {
 				},
 			},
 		},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	role.SetLogins(Allow, []string{teleport.TraitInternalLoginsVariable})
 	role.SetKubeUsers(Allow, []string{teleport.TraitInternalKubeUsersVariable})
 	role.SetKubeGroups(Allow, []string{teleport.TraitInternalKubeGroupsVariable})
-	return role
+	return role, nil
 }
 
 // NewPresetAuditorRole returns a new pre-defined role for cluster
 // auditor - someone who can review cluster events and replay sessions,
 // but can't initiate interactive sessions or modify configuration.
-func NewPresetAuditorRole() types.Role {
-	role := &types.RoleV4{
-		Kind:    types.KindRole,
-		Version: types.V4,
-		Metadata: types.Metadata{
-			Name:        teleport.PresetAuditorRoleName,
-			Namespace:   apidefaults.Namespace,
-			Description: "Review cluster events and replay sessions",
-		},
-		Spec: types.RoleSpecV4{
+func NewPresetAuditorRole() (types.Role, error) {
+	role, err := types.NewRoleWithDescription(teleport.PresetAuditorRoleName, "Review cluster events and replay sessions",
+		types.RoleSpecV4{
 			Options: types.RoleOptions{
 				CertificateFormat: constants.CertificateFormatStandard,
 				MaxSessionTTL:     types.NewDuration(apidefaults.MaxCertDuration),
@@ -142,7 +124,10 @@ func NewPresetAuditorRole() types.Role {
 				DatabaseLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
 			},
 		},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	role.SetLogins(Allow, []string{"no-login-" + uuid.New()})
-	return role
+	return role, nil
 }

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -31,7 +31,7 @@ import (
 func NewPresetEditorRole() types.Role {
 	role := &types.RoleV4{
 		Kind:    types.KindRole,
-		Version: types.V3,
+		Version: types.V4,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetEditorRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -70,7 +70,7 @@ func NewPresetEditorRole() types.Role {
 func NewPresetAccessRole() types.Role {
 	role := &types.RoleV4{
 		Kind:    types.KindRole,
-		Version: types.V3,
+		Version: types.V4,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetAccessRoleName,
 			Namespace:   apidefaults.Namespace,
@@ -110,7 +110,7 @@ func NewPresetAccessRole() types.Role {
 func NewPresetAuditorRole() types.Role {
 	role := &types.RoleV4{
 		Kind:    types.KindRole,
-		Version: types.V3,
+		Version: types.V4,
 		Metadata: types.Metadata{
 			Name:        teleport.PresetAuditorRoleName,
 			Namespace:   apidefaults.Namespace,

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2063,10 +2063,8 @@ func UnmarshalRole(bytes []byte, opts ...MarshalOption) (types.Role, error) {
 	}
 
 	switch h.Version {
-	case types.V4:
-		// V4 roles are identical to V3 except for their defaults
-		fallthrough
-	case types.V3:
+	// V4 roles are identical to V3 except for their defaults
+	case types.V4, types.V3:
 		var role types.RoleV4
 		if err := utils.FastUnmarshal(bytes, &role); err != nil {
 			return nil, trace.BadParameter(err.Error())

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -722,7 +722,7 @@ func (s *ServicesTestSuite) RolesCRUD(c *check.C) {
 	rout, err := s.Access.GetRole(ctx, role.GetName())
 	c.Assert(err, check.IsNil)
 	role.SetResourceID(rout.GetResourceID())
-	fixtures.DeepCompare(c, rout, &role)
+	fixtures.DeepCompare(c, rout, role)
 
 	role.SetLogins(types.Allow, []string{"bob"})
 	err = s.Access.UpsertRole(ctx, role)
@@ -730,7 +730,7 @@ func (s *ServicesTestSuite) RolesCRUD(c *check.C) {
 	rout, err = s.Access.GetRole(ctx, role.GetName())
 	c.Assert(err, check.IsNil)
 	role.SetResourceID(rout.GetResourceID())
-	c.Assert(rout, check.DeepEquals, &role)
+	c.Assert(rout, check.DeepEquals, role)
 
 	err = s.Access.DeleteRole(ctx, role.GetName())
 	c.Assert(err, check.IsNil)

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -98,16 +98,8 @@ metadata:
   name: roleName
 spec:
   allow:
-    app_labels:
-      '*': '*'
-    db_labels:
-      '*': '*'
-    kubernetes_labels:
-      '*': '*'
     logins:
     - test
-    node_labels:
-      '*': '*'
   deny: {}
   options:
     cert_format: standard
@@ -117,7 +109,7 @@ spec:
     forward_agent: false
     max_session_ttl: 30h0m0s
     port_forwarding: true
-version: v3
+version: v4
 `
 	role, err := types.NewRole("roleName", types.RoleSpecV4{
 		Allow: types.RoleConditions{

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -357,10 +357,6 @@ func (rc *ResourceCommand) createRole(client auth.ClientI, raw services.UnknownR
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = role.CheckAndSetDefaults()
-	if err != nil {
-		return trace.Wrap(err)
-	}
 
 	if err := services.ValidateAccessPredicates(role); err != nil {
 		// check for syntax errors in predicates


### PR DESCRIPTION
Changes:
- `setStaticFields` sets Version to V4 if unset, making V4 the default version rather than V3
  - the only difference between V4 and V3 is that V4 roles won't set wildcard labels by default
    - this could affect the labels of any role that uses `types.NewRole` or `role.CheckAndSetDefaults`, so I went through them all individually and added labels explicitly where needed
- editor, access, and auditor presets use `NewRole` constructor to set defaults.
  - no changes have been made to the end role
  - editor now explicitly sets wildcard labels for backwards compatibility
- roles made by permission.go constructors now explicitly set wildcard
- `roleParser.parse` sets resource header version to V4
- `NewImplicitRole` no longer sets wildcard labels
- Roles used in tests have been updated to set wildcard labels explicitly where needed.
- strictly redundant validation removed 
  - `ValidateRole` directly after `UnmarshalRole`
  - `CheckAndSetDefaults` directly after `UnmarshalRole`