### PR TITLE
 [backport v6.2] Removes double quotes from acme examples in docs

### DIFF
--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -71,7 +71,7 @@ proxy_service:
   public_addr: "teleport.example.com:443"
   acme:
     enabled: "yes"
-    email: "alice@example.com"
+    email: alice@example.com
 ```
 
 <Admonition

--- a/docs/pages/config-reference.mdx
+++ b/docs/pages/config-reference.mdx
@@ -422,7 +422,7 @@ proxy_service:
     # 'teleport configure --acme --acme-email=email@example.com --cluster-name=tele.example.com -o file'
     #acme:
     #  enabled: yes
-    #  email: "user@example.com"
+    #  email: user@example.com
 
 # This section configures the 'application service'
 app_service:


### PR DESCRIPTION
backport of #7642 