### PR TITLE
Emit audit log events when `isMFARequired` denies a user.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2390,8 +2390,9 @@ func (a *Server) isMFARequired(ctx context.Context, checker services.AccessCheck
 					Code: events.AuthAttemptFailureCode,
 				},
 				UserMetadata: apievents.UserMetadata{
-					User:  user,
-					Login: noMFAAccessErrTarget,
+					User:         user,
+					Login:        noMFAAccessErrTarget,
+					Impersonator: ClientImpersonator(ctx),
 				},
 				Status: apievents.Status{
 					Success: false,


### PR DESCRIPTION
In Teleport v6.0 and earlier, audit log events were emitted when a user was denied node access by RBAC rules (e.g. missing login or label permissions). In Teleport v6.2, `isMFARequired` now ensures users have RBAC permissions for a node before login is ever attempted, the client never attempts to connect, and no audit event is emitted.

This adds a new audit log event before `isMFARequired` would otherwise return an error to the user.

Fixes #7652