### PR TITLE
[Backport v7] Update the GCP+GKE+Helm guide

### DIFF
--- a/docs/pages/kubernetes-access/helm/guides/gcp.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/gcp.mdx
@@ -257,6 +257,14 @@ kubectl --namespace teleport create -f gcp-issuer.yaml
 
 ## Step 5: Set values to configure the cluster
 
+<Admonition type="note">
+  If you are installing Teleport in a brand new GCP project, make sure you have enabled the
+  [Cloud Firestore API](https://console.cloud.google.com/apis/api/firestore.googleapis.com/overview)
+  and created a
+  [Firestore Database](https://console.cloud.google.com/firestore/welcome)
+  in your project before continuing.
+</Admonition>
+
 There are two different ways to configure the `teleport-cluster` Helm chart to use `gcp` mode - using a `values.yaml` file or using `--set`
 on the command line.
 

--- a/docs/pages/kubernetes-access/helm/guides/gcp.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/gcp.mdx
@@ -15,7 +15,7 @@ using Teleport Helm charts and Google Cloud Platform products (Firestore and Goo
   The steps below apply to Google Cloud Google Kubernetes Engine (GKE) Standard deployments.
 </Admonition>
 
-### Step 3: Google Cloud IAM configuration
+## Step 3: Google Cloud IAM configuration
 
 For Teleport to be able to create the Firestore collections, indexes, and the Google Cloud Storage bucket it needs,
 you'll need to configure a Google Cloud service account with permissions to use these services.


### PR DESCRIPTION
* Fix header for Step 3 (incorrectly using `<h3>` instead of `<h2>`)
* Add a note to enable Firestore / create a Firestore database
  Both cause an error on pod startup, the former rather descriptive, but the latter manifests as "rpc error: code = NotFound desc = Project '\<YOUR-GCP-PROJECT\>' does not exist.", which can take a while to figure out (since the project exists, the Firestore database is the resource missing).
