### PR TITLE
Update config.json

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -292,7 +292,7 @@
       "min_version": "3.6"
     },
     "teleport": {
-      "version": "6.2.7",
+      "version": "7.0.0",
       "golang": "1.16",
       "plugin": {
         "version": "6.2.7"


### PR DESCRIPTION
Update Teleport version on main. 

I was trying out Teleport lab, but hit a 404 due to it not having a branch v7.0.0.  This should fix it once we merge 7.0.  In the meantime `https://raw.githubusercontent.com/gravitational/teleport/branch/v7/docker/teleport-lab.yml` also works. 