### PR TITLE
Fix download page query param filter for mac

### DIFF
--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -158,7 +158,7 @@ Here's a selection of compatible two-factor authentication apps:
 
 <Tabs>
   <TabItem label="Mac">
-    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (`tsh` client only, signed) file, double-click to run the installer.
+    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=mac) (`tsh` client only, signed) file, double-click to run the installer.
   </TabItem>
 
   <TabItem label="Mac - Homebrew">
@@ -168,7 +168,7 @@ Here's a selection of compatible two-factor authentication apps:
 
     <Admonition type="note">
       The Teleport package in Homebrew is not maintained by Teleport and we can't
-      guarantee its reliability or security. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=macos).
+      guarantee its reliability or security. We recommend the use of our [own Teleport packages](https://goteleport.com/teleport/download?os=mac).
 
       If you choose to use Homebrew, you must verify that the versions of `tsh` and
       `tctl` are compatible with the versions you run server-side. Homebrew usually

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -97,7 +97,7 @@ helm install teleport teleport/teleport
 
 <Tabs>
   <TabItem label="Download">
-    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=macos) (tsh client only, signed) file, double-click to run the Installer.
+    [Download MacOS .pkg installer](https://goteleport.com/teleport/download?os=mac) (tsh client only, signed) file, double-click to run the Installer.
 
     <Admonition type="note">
       This method only installs the `tsh` client for interacting with Teleport clusters.
@@ -113,7 +113,7 @@ helm install teleport teleport/teleport
     <Admonition type="note">
       The Teleport package in Homebrew is not maintained by Teleport and we can't
       guarantee its reliability or security. We recommend the use of our [own
-      Teleport packages](https://goteleport.com/teleport/download?os=macos).
+      Teleport packages](https://goteleport.com/teleport/download?os=mac).
     </Admonition>
 
     <Admonition type="note">


### PR DESCRIPTION
The downloads page query parameter was changed from `macos` to `mac` at some point.

## Testing
Checked:
https://goteleport.com/teleport/download?os=macos (selects linux downloads)
vs
https://goteleport.com/teleport/download?os=mac (selects mac downloads)