### PR TITLE
Update DNS instructions in the AWS+EKS+Helm guide (#7672)

### DIFF
--- a/docs/pages/kubernetes-access/helm/guides/aws.mdx
+++ b/docs/pages/kubernetes-access/helm/guides/aws.mdx
@@ -304,35 +304,66 @@ replicaset.apps/teleport-5cf46ddf5f   2         2         2       4m21s
 ## Step 6. Set up DNS
 
 You'll need to set up two DNS `A` records: `teleport.example.com` for the web UI, and `*.teleport.example.com`
-for web apps using [application access](../../../application-access/introduction.mdx).
+for web apps using [application access](../../../application-access/introduction.mdx). In our example, both records are
+aliases to an ELB.
 
 Here's how to do this in a hosted zone with AWS Route 53:
 
 ```bash
 # Change these parameters if you altered them above
-NAMESPACE=teleport
-RELEASE_NAME=teleport
+NAMESPACE='teleport'
+RELEASE_NAME='teleport'
 
-# Tip for finding AWS zone id by the domain name (replace your namespace)
-MYIP=$(kubectl --namespace ${NAMESPACE?} get service/${RELEASE_NAME?} -o jsonpath='{.status.loadBalancer.ingress[*].hostname}')
-MYZONE_DNS="example.com"
-MYZONE=$(aws route53 list-hosted-zones-by-name --dns-name=${MYZONE_DNS?} | jq -r '.HostedZones[0].Id' | sed s_/hostedzone/__)
+# DNS settings (change as necessary)
+MYZONE_DNS='example.com'
+MYDNS='teleport.example.com'
+MY_CLUSTER_REGION='us-west-2'
 
-MYDNS="teleport.example.com"
+# Find AWS Zone ID and ELB Zone ID
+MYZONE="$(aws route53 list-hosted-zones-by-name --dns-name="${MYZONE_DNS?}" | jq -r '.HostedZones[0].Id' | sed s_/hostedzone/__)"
+MYELB="$(kubectl --namespace "${NAMESPACE?}" get "service/${RELEASE_NAME?}" -o jsonpath='{.status.loadBalancer.ingress[*].hostname}')"
+MYELB_NAME="${MYELB%%-*}"
+MYELB_ZONE="$(aws elb describe-load-balancers --region "${MY_CLUSTER_REGION?}" --load-balancer-names "${MYELB_NAME?}" | jq -r '.LoadBalancerDescriptions[0].CanonicalHostedZoneNameID')"
 
 # Create a JSON file changeset for AWS.
-jq -n --arg ip ${MYIP?} --arg dns ${MYDNS?} '{"Comment": "Create records", "Changes": [
-  {"Action": "CREATE", "ResourceRecordSet": {"Name": $dns, "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}},
-  {"Action": "CREATE", "ResourceRecordSet": {"Name": ("*." + $dns), "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}}
-  ]}' > myrecords.json
+jq -n --arg dns "${MYDNS?}" --arg elb "${MYELB?}" --arg elbz "${MYELB_ZONE?}" \
+    '{
+        "Comment": "Create records",
+        "Changes": [
+          {
+            "Action": "CREATE",
+            "ResourceRecordSet": {
+              "Name": $dns,
+              "Type": "A",
+              "AliasTarget": {
+                "HostedZoneId": $elbz,
+                "DNSName": ("dualstack." + $elb),
+                "EvaluateTargetHealth": false
+              }
+            }
+          },
+          {
+            "Action": "CREATE",
+            "ResourceRecordSet": {
+              "Name": ("*." + $dns),
+              "Type": "A",
+              "AliasTarget": {
+                "HostedZoneId": $elbz,
+                "DNSName": ("dualstack." + $elb),
+                "EvaluateTargetHealth": false
+              }
+            }
+          }
+      ]
+    }' > myrecords.json
 
 # Review records before applying.
 cat myrecords.json | jq
 # Apply the records and capture change id
-CHANGEID=$(aws route53 change-resource-record-sets --hosted-zone-id ${MYZONE?} --change-batch file://myrecords.json | jq -r '.ChangeInfo.Id')
+CHANGEID="$(aws route53 change-resource-record-sets --hosted-zone-id "${MYZONE?}" --change-batch file://myrecords.json | jq -r '.ChangeInfo.Id')"
 
 # Verify that change has been applied
-aws route53 get-change --id ${CHANGEID?} | jq '.ChangeInfo.Status'
+aws route53 get-change --id "${CHANGEID?}" | jq '.ChangeInfo.Status'
 "INSYNC"
 ```
 


### PR DESCRIPTION
Assuming `service/teleport` points to an ELB, which it does according to
the guide, then the change-resource-record-sets input needs to contain
an "AliasTarget" (instead of "ResourceRecords.Value").

Note that the hosted zone ID for `aws route53
change-resource-record-sets` remains as the DNS zone (ie, the zone for
"example.com"), but the hosted zone ID for the "ResourceRecordSet" is
the zone of the ELB (which doesn't necessarily match the zone for
"example.com"). I found that out by chance because I deployed my cluster
on sa-east-1 (instead of the more usual us-west or us-east).

Old change-resource-record-sets action:

```json
{
  "Action": "CREATE",
  "ResourceRecordSet": {
    "Name": "teleport.example.com",
    "Type": "A",
    "TTL": 300,
    "ResourceRecords": {
      "Value": "dualstack.a559a6696e58f48d6814781231623dc8-1207026150.sa-east-1.elb.amazonaws.com" // not allowed anymore!
    }
  }
}
```

New change-resource-record-sets action:

```json
{
  "Action": "CREATE",
  "ResourceRecordSet": {
    "Name": "teleport.example.com",
    "Type": "A",
    "AliasTarget": {
      "HostedZoneId": "<ELB_ZONE_ID>",
      "DNSName": "dualstack.a232d92df01f940339adea0e645d88bb-1576732600.us-east-1.elb.amazonaws.com",
      "EvaluateTargetHealth": false
    }
  }
}
```

Co-authored-by: Alexander Klizhentas <klizhentas@gmail.com>