### PR TITLE
Fix unsoundness and improve errors in user accounting logic

### DIFF
--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -115,6 +115,34 @@ func TestRootUTMPEntryExists(t *testing.T) {
 	t.Errorf("did not detect utmp entry within 5 minutes")
 }
 
+// TestUsernameLimit tests that the maximum length of usernames is a hard error.
+func TestRootUsernameLimit(t *testing.T) {
+	if !isRoot() {
+		t.Skip("This test will be skipped because tests are not being run as root.")
+	}
+
+	dir := t.TempDir()
+	utmpPath := path.Join(dir, "utmp")
+	wtmpPath := path.Join(dir, "wtmp")
+
+	err := TouchFile(utmpPath)
+	require.NoError(t, err)
+	err = TouchFile(wtmpPath)
+	require.NoError(t, err)
+
+	// A 33 character long username.
+	username := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	host := [4]int32{0, 0, 0, 0}
+	tty := os.NewFile(uintptr(0), "/proc/self/fd/0")
+	err = uacc.Open(utmpPath, wtmpPath, username, "localhost", host, tty)
+	require.Error(t, err)
+
+	// A 32 character long username.
+	username = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	err = uacc.Open(utmpPath, wtmpPath, username, "localhost", host, tty)
+	require.NoError(t, err)
+}
+
 // upack holds all ssh signing artefacts needed for signing and checking user keys
 type upack struct {
 	// key is a raw private user key

--- a/lib/srv/uacc/uacc.h
+++ b/lib/srv/uacc/uacc.h
@@ -210,7 +210,7 @@ static int uacc_has_entry_with_user(const char *utmp_path, const char *user) {
     }
     struct utmp *entry = getutent();
     while (entry != NULL) {
-        if (entry->ut_type == USER_PROCESS && strcmp(user, entry->ut_user) == 0) {
+        if (entry->ut_type == USER_PROCESS && strncmp(user, entry->ut_user, sizeof(entry->ut_user)) == 0) {
             endutent();
             return 0;
         }

--- a/lib/srv/uacc/uacc_linux.go
+++ b/lib/srv/uacc/uacc_linux.go
@@ -39,8 +39,11 @@ import (
 // Due to thread safety design in glibc we must serialize all access to the accounting database.
 var accountDb sync.Mutex
 
-// Max length of username and hostname as defined by glibc.
-const nameMaxLen = 255
+// Max hostname length as defined by glibc.
+const hostMaxLen = 255
+
+// Max username length as defined by glibc.
+const userMaxLen = 32
 
 // Open writes a new entry to the utmp database with a tag of `USER_PROCESS`.
 // This should be called when an interactive session is started.
@@ -56,10 +59,10 @@ func Open(utmpPath, wtmpPath string, username, hostname string, remote [4]int32,
 	}
 
 	// String parameter validation.
-	if len(username) > nameMaxLen {
+	if len(username) > userMaxLen {
 		return trace.BadParameter("username length exceeds OS limits")
 	}
-	if len(hostname) > nameMaxLen {
+	if len(hostname) > hostMaxLen {
 		return trace.BadParameter("hostname length exceeds OS limits")
 	}
 	if len(ttyName) > (int)(C.max_len_tty_name()-1) {
@@ -183,7 +186,7 @@ func Close(utmpPath, wtmpPath string, tty *os.File) error {
 
 // UserWithPtyInDatabase checks the user accounting database for the existence of an USER_PROCESS entry with the given username.
 func UserWithPtyInDatabase(utmpPath string, username string) error {
-	if len(username) > nameMaxLen {
+	if len(username) > userMaxLen {
 		return trace.BadParameter("username length exceeds OS limits")
 	}
 


### PR DESCRIPTION
This PR addresses the concerns of @ben-latacora in #5491 and applies appropriate fixes.

1. It returns a correct length error for usernames. The maximum length should be 32 and not 255. This is did not cause any terribly bad behaviour but was silently truncated.

2. It replaces a `strcmp` with a `strncmp` to make sure it doesn't read out of bounds on the username field. This could previously cause bad behaviour in the form of incorrect or missing accounting logs if the username was precisely 32 characters (in some rare cases).