### PR TITLE
Ensure defaults are set for DB integration tests

### DIFF
--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -383,7 +383,7 @@ type testOptions struct {
 
 type testOptionFunc func(*testOptions)
 
-func (o testOptions) setDefaultIfNotSet() {
+func (o *testOptions) setDefaultIfNotSet() {
 	if o.clock == nil {
 		o.clock = clockwork.NewRealClock()
 	}


### PR DESCRIPTION
`setDefaultIfNotSet` needs to have a pointer receiver, otherwise it will be setting defaults on a copy of the options, leaving the original unset.