### PR TITLE
Reduced shared library dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ RS_BPF_BUILDDIR := lib/restrictedsession/bytecode
 CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
 	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
 
-CGOFLAG = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -lbpf -Wl,-Bdynamic"
+CGOFLAG = CGO_ENABLED=1 CGO_LDFLAGS="-Wl,-Bstatic -lbpf -lelf -lz -Wl,-Bdynamic"
 endif
 endif
 endif

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update -y --fix-missing && \
         tree \
         unzip \
         zip \
+        zlib1g-dev \
         && \
     pip --no-cache-dir install yamllint && \
     dpkg-reconfigure locales && \
@@ -79,7 +80,7 @@ RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNT
 
 # Install libbpf
 ARG LIBBPF_VERSION
-RUN mkdir -p /opt && cd /opt && curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+RUN mkdir -p /opt && cd /opt && curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make && \
     make install

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -40,6 +40,7 @@ RUN apt-get update -y --fix-missing && \
         tree \
         unzip \
         zip \
+        zlib1g-dev \
         && \
     dpkg-reconfigure locales && \
     apt-get -y clean && \
@@ -64,7 +65,7 @@ RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.
 
 # Install libbpf
 ARG LIBBPF_VERSION
-RUN mkdir -p /opt && cd /opt && curl -L https://github.com/libbpf/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+RUN mkdir -p /opt && cd /opt && curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make && \
     make install

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -18,7 +18,7 @@ OS ?= linux
 ARCH ?= amd64
 RUNTIME ?= go1.16.2
 BORINGCRYPTO_RUNTIME=$(RUNTIME)b7
-LIBBPF_VERSION ?= 0.3
+LIBBPF_VERSION ?= 0.3.1
 
 UID := $$(id -u)
 GID := $$(id -g)


### PR DESCRIPTION
**Description**

Reduced Teleport shared library dependencies on `libbpf`, `libelf`, `libz`.

For `libbpf`, switched to forked version that does not rely on `fmemopen` which brings in a glibc 2.22 dependency. This allows binaries built on Ubuntu 18.04 box to run on CentOS 7 as well.

For `libelf` and `libz` (which `libbpf` uses), the build process has been updated to statically link both of them during the release process.

**Related Issues**

https://github.com/gravitational/teleport.e/pull/296