### PR TITLE
Remove initial 'v' from Teleport version tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1204,7 +1204,7 @@ steps:
       - name: dockersock
         path: /var/run
     commands:
-      - export TELEPORT_TAG=$(cat /go/build/CURRENT_VERSION_TAG.txt)
+      - export TELEPORT_TAG=$(cat /go/build/CURRENT_VERSION_TAG.txt | tr -d '^v')
       - export TELEPORT_LAB_IMAGE_NAME="quay.io/gravitational/teleport-lab:$(cat /go/build/CURRENT_VERSION_TAG_GENERIC.txt)"
       - apk add --no-cache curl
       - docker login -u="$PLUGIN_USERNAME" -p="$PLUGIN_PASSWORD" quay.io
@@ -4423,6 +4423,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 111b9577ccae5cbe5da195685d255e2cc5d0f5fd4b78a197415f9a30f4c046d4
+hmac: 83c6318881be7e49f513409221e402e8ceda7f054970c6283bd54213760e6961
 
 ...


### PR DESCRIPTION
Removes initial `v` from `TELEPORT_TAG` e.g. `v6.2.8` becomes `6.2.8`.

Fixes build failure: https://drone.teleport.dev/gravitational/teleport/2513/1/6