### PR TITLE
[v7] correct tsh proxy alias in docker-compose example

### DIFF
--- a/docker/sshd/scripts/tsh.alias
+++ b/docker/sshd/scripts/tsh.alias
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-/usr/local/bin/tsh --insecure --proxy=proxy.luna.teleport:3080 -i /mnt/shared/certs/bot.pem "$@"
+/usr/local/bin/tsh --insecure --proxy=proxy.luna.teleport -i /mnt/shared/certs/bot.pem "$@"
 


### PR DESCRIPTION
removes port number so it can try 3080 and 443