### PR TITLE
Deny node access to terraform role, not terraform-impersonator role

### DIFF
--- a/docs/pages/setup/guides/terraform-provider.mdx
+++ b/docs/pages/setup/guides/terraform-provider.mdx
@@ -64,6 +64,9 @@ spec:
     rules:
       - resources: ['user', 'role', 'token', 'trusted_cluster', 'github', 'oidc', 'saml']
         verbs: ['list','create','read','update','delete']
+  deny:
+    node_labels:
+      '*': '*'
 version: v3
 ---
 kind: user
@@ -109,12 +112,6 @@ spec:
     impersonate:
       users: ['terraform']
       roles: ['terraform']
-
-  # the deny section uses the identical format as the 'allow' section.
-  # the deny rules always override allow rules.
-  deny:
-    node_labels:
-      '*': '*'
 ```
 
 ```bash


### PR DESCRIPTION
AFAIU it is supposed to deny users who can impersonate terraform to access nodes with impersonated identity. 

But currently, when you apply terraform-impersonate role to users it denies them access to all nodes with their own identity instead. So I've moved `deny` expression to terraform role.