### PR TITLE
Allow custom webassets path if debug mode is on

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -252,6 +252,12 @@ const (
 	// DebugEnvVar tells tests to use verbose debug output
 	DebugEnvVar = "DEBUG"
 
+	// DebugAssetsPath allows users to set the path of the webassets if debug
+	// mode is enabled.
+	// For example,
+	// `DEBUG=1 DEBUG_ASSETS_PATH=/path/to/webassets/ teleport start`.
+	DebugAssetsPath = "DEBUG_ASSETS_PATH"
+
 	// VerboseLogEnvVar forces all logs to be verbose (down to DEBUG level)
 	VerboseLogsEnvVar = "TELEPORT_DEBUG"
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3693,8 +3693,10 @@ func newHTTPFileSystem() (http.FileSystem, error) {
 		}
 		return fs, nil
 	}
-	// Use debug HTTP file system with default assets path
-	fs, err := web.NewDebugFileSystem("")
+
+	// Use the supplied HTTP filesystem path (defaults to the current dir).
+	assetsPath := os.Getenv(teleport.DebugAssetsPath)
+	fs, err := web.NewDebugFileSystem(assetsPath)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Useful for debugging Teleport servers in modern IDEs.