### PR TITLE
Compatibility with ingress and self signed cert

### DIFF
--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: "7.0.0-beta.1"
-appVersion: "7.0.0-beta.1"
+version: "7.0.2"
+appVersion: "7.0.2"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-cluster/templates/certificate.yaml
+++ b/examples/chart/teleport-cluster/templates/certificate.yaml
@@ -15,3 +15,15 @@ spec:
     name: {{ required "highAvailability.certManager.issuerName is required in chart values" .Values.highAvailability.certManager.issuerName }}
     kind: {{ required "highAvailability.certManager.issuerKind is required in chart values" .Values.highAvailability.certManager.issuerKind }}
 {{- end }}
+
+{{- if or .Values.custom_tls.enabled .Values.custom_tls.generate_secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: teleport-tls
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.custom_tls.crt }}
+  tls.key: {{ .Values.custom_tls.key }}
+{{- end }}

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -54,7 +54,7 @@ data:
       public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
       kube_listen_addr: 0.0.0.0:3026
       enabled: true
-  {{- if .Values.highAvailability.certManager.enabled }}
+  {{- if or .Values.highAvailability.certManager.enabled .Values.custom_tls.enabled  }}
       https_keypairs:
       - key_file: /etc/teleport-tls/tls.key
         cert_file: /etc/teleport-tls/tls.crt

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -35,6 +35,11 @@ data:
     auth_service:
       enabled: true
       cluster_name: {{ required "clusterName is required in chart values" .Values.clusterName }}
+      {{- if .Values.authentication }}
+      authentication:
+        type:  {{ required "authentication type is required in chart values" .Values.authentication.type }}
+        second_factor:  {{ required "second factor auth type is required in chart values" .Values.authentication.second_factor }}
+      {{- end }}
   {{- if .Values.enterprise }}
       license_file: '/var/lib/license/license.pem'
   {{- end }}

--- a/examples/chart/teleport-cluster/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
           name: "gcp-credentials"
           readOnly: true
   {{- end }}
-  {{- if .Values.highAvailability.certManager.enabled }}
+  {{- if or .Values.highAvailability.certManager.enabled .Values.custom_tls.enabled}}
         - mountPath: /etc/teleport-tls
           name: "teleport-tls"
           readOnly: true
@@ -112,7 +112,7 @@ spec:
         {{- end }}
         args:
         - "--diag-addr=0.0.0.0:3000"
-        {{- if .Values.insecureSkipProxyTLSVerify }}
+        {{- if or .Values.insecureSkipProxyTLSVerify .Values.custom_tls.enabled }}
         - "--insecure"
         {{- end }}
         {{- if .Values.extraArgs }}
@@ -151,7 +151,7 @@ spec:
           name: "gcp-credentials"
           readOnly: true
 {{- end }}
-{{- if .Values.highAvailability.certManager.enabled }}
+{{- if or .Values.highAvailability.certManager.enabled .Values.custom_tls.enabled}}
         - mountPath: /etc/teleport-tls
           name: "teleport-tls"
           readOnly: true
@@ -175,7 +175,7 @@ spec:
         secret:
           secretName: {{ required "gcp.credentialSecretName is required in chart values" .Values.gcp.credentialSecretName }}
 {{- end }}
-{{- if .Values.highAvailability.certManager.enabled }}
+{{- if or .Values.highAvailability.certManager.enabled .Values.custom_tls.enabled }}
       - name: teleport-tls
         secret:
           secretName: teleport-tls

--- a/examples/chart/teleport-cluster/templates/ingress.yaml
+++ b/examples/chart/teleport-cluster/templates/ingress.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.ingress.enabled -}}
+{{- $ServiceName := .Release.Name -}}
+{{- $httpsServicePort := .Values.service.https_port -}}
+{{- $sshproxyServicePort := .Values.service.sshproxy_port -}}
+{{- $k8sServicePort := .Values.service.k8s_port -}}
+{{- $sshtunServicePort := .Values.service.sshtun_port -}}
+{{- $IngressPath := .Values.ingress.path -}}
+{{- $IngressPathType := .Values.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: {{ $IngressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $ServiceName }}
+                port:
+                  number: {{ $httpsServicePort  }}
+          - path: {{ $IngressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $ServiceName }}
+                port:
+                  number: {{ $sshproxyServicePort  }}
+          - path: {{ $IngressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $ServiceName }}
+                port:
+                  number: {{ $k8sServicePort  }}
+          - path: {{ $IngressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $ServiceName }}
+                port:
+                  number: {{ $sshtunServicePort  }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}
+

--- a/examples/chart/teleport-cluster/templates/service.yaml
+++ b/examples/chart/teleport-cluster/templates/service.yaml
@@ -17,22 +17,25 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  type: LoadBalancer
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.load_balancer_ip }}
+  loadBalancerIP: {{ .Values.service.load_balancer_ip  }}
+  {{- end }}
   ports:
   - name: https
-    port: 443
+    port: {{ .Values.service.https_port }}
     targetPort: 3080
     protocol: TCP
   - name: sshproxy
-    port: 3023
+    port: {{ .Values.service.sshproxy_port }}
     targetPort: 3023
     protocol: TCP
   - name: k8s
-    port: 3026
+    port: {{ .Values.service.k8s_port }}
     targetPort: 3026
     protocol: TCP
   - name: sshtun
-    port: 3024
+    port: {{ .Values.service.sshtun_port }}
     targetPort: 3024
     protocol: TCP
   selector:

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -14,7 +14,10 @@ kubeClusterName: ""
 ##################################################
 # Values that you may need to change.
 ##################################################
-
+#Authentication type
+authentication:
+  type: local
+  second_factor: otp
 # Version of teleport image, if different from chart version in Chart.yaml.
 teleportVersionOverride: ""
 

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -28,6 +28,33 @@ acmeEmail: ""
 # acmeURI is the ACME server to use for getting certificates. The default is to use Let's Encrypt's production server.
 acmeURI: ""
 
+service:
+  type: "LoadBalancer"
+  load_balancer_ip: ""
+  https_port: "443"
+  sshproxy_port: "3023"
+  k8s_port: "3026"
+  sshtun_port: "3024"
+
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - ""
+  # - teleport.domain.com
+  # The ingress path. Useful to host teleport on a subpath, such as `/teleport`.
+  path: /
+  labels:
+  
+# If you want to use your own certicate you can set it with these values:
+custom_tls:
+  generate_secret: false
+  enabled: false
+  crt: ""
+  key: ""
+
+insecureSkipProxyTLSVerify: false                      
+
 # Set enterprise to true to use enterprise image
 # You will need to download your Enterprise license from the Teleport dashboard and create a secret to use this:
 # kubectl -n ${TELEPORT_NAMESPACE?} create secret generic license --from-file=/path/to/downloaded/license.pem
@@ -52,6 +79,7 @@ labels: {}
 #     give it the same name as the Helm release and place it in the chart namespace.
 #     kubectl -n ${TELEPORT_NAMESPACE?} create configmap ${HELM_RELEASE_NAME?} --from-file=teleport.yaml
 chartMode: standalone
+
 
 ################################################################
 # Standalone-specific settings (only used in "standalone" mode)


### PR DESCRIPTION
Hi, we are setting up teleport in our environment and we needed to make these changes on the helm chart to make them configurable with our ingress controller and self signed certifcates. We use sslpassthrough with nginx to get it working. However we could'nt use our self certificate securely because teleport sshproxy is not compatible with Cloudflare proxy (https://github.com/gravitational/teleport/issues/7962)