### PR TITLE
Add Handler for Generating Join Tokens

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1528,7 +1528,7 @@ type joinTokenResponse struct {
 //
 // POST /webapi/join
 //
-// {"roles": ["db", ...], "ttl": "1h0m0s"}
+// {"roles": ["Db", ...], "ttl": "1h0m0s"}
 //
 // Successful response:
 //
@@ -1540,12 +1540,12 @@ func (h *Handler) generateJoinToken(w http.ResponseWriter, r *http.Request, _ ht
 		return nil, trace.Wrap(err)
 	}
 
-	clt, err := ctx.GetClient()
+	roles, err := types.NewTeleportRoles(req.Roles)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	roles, err := types.NewTeleportRoles(req.Roles)
+	clt, err := ctx.GetClient()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -294,7 +294,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	// list available sites
 	h.GET("/webapi/sites", h.WithAuth(h.getClusters))
 
-	h.POST("/webapi/join", h.WithAuth(h.generateJoinToken))
+	h.POST("/webapi/token", h.WithAuth(h.generateJoinToken))
 
 	// Site specific API
 
@@ -1521,7 +1521,8 @@ type joinTokenRequest struct {
 
 // A response to a request to create a join token.
 type joinTokenResponse struct {
-	Token string `json:"token"`
+	Token  string    `json:"id"`
+	Expiry time.Time `json:"expiry"`
 }
 
 // generateJoinToken generates a new join token, similar to tctl tokens add.
@@ -1558,7 +1559,7 @@ func (h *Handler) generateJoinToken(w http.ResponseWriter, r *http.Request, _ ht
 		return nil, trace.Wrap(err)
 	}
 
-	return &joinTokenResponse{token}, nil
+	return &joinTokenResponse{token, time.Now().Add(req.TTL.Value())}, nil
 }
 
 // u2fRegisterRequest is called to get a U2F challenge for registering a U2F key

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3114,7 +3114,6 @@ func TestGenerateJoinToken(t *testing.T) {
 		var tokenResponse *joinTokenResponse
 		err = json.Unmarshal(resp.Bytes(), &tokenResponse)
 		require.NoError(t, err)
-
 		require.NotEmpty(t, tokenResponse.Token)
 	})
 


### PR DESCRIPTION
New handler does the same thing as `tctl tokens add` but for the web UI. Backend implementation of #7537.