### PR TITLE
Always use the remote login when connecting to the proxy.

### DIFF
--- a/tool/tsh/config.go
+++ b/tool/tsh/config.go
@@ -36,9 +36,9 @@ Host *.{{ .clusterName }} {{ .proxyHost }}
 Host *.{{ .clusterName }} !{{ .proxyHost }}
     Port 3022
     {{- if .leaf }}
-    ProxyCommand ssh -p {{ .proxyPort }} {{ .proxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p@{{ .clusterName }}	
+    ProxyCommand ssh -p {{ .proxyPort }} -l %r {{ .proxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p@{{ .clusterName }}	
     {{- else }}
-    ProxyCommand ssh -p {{ .proxyPort }} {{ .proxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p
+    ProxyCommand ssh -p {{ .proxyPort }} -l %r {{ .proxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p
     {{- end }}
 `
 


### PR DESCRIPTION
The proxy expects the user to connect with a login name that is in the allowed list of logins. The user's default login may not be an allowed teleport login. Using the same login for the node and the proxy smooths out this experience.