### PR TITLE
[v6.2] Add description field to UI App object

### DIFF
--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -27,6 +27,8 @@ import (
 type App struct {
 	// Name is the name of the application.
 	Name string `json:"name"`
+	// Description is the app description.
+	Description string `json:"description"`
 	// URI is the internal address the application is available at.
 	URI string `json:"uri"`
 	// PublicAddr is the public address the application is accessible at.
@@ -57,12 +59,13 @@ func MakeApps(localClusterName string, localProxyDNSName string, appClusterName 
 			sort.Sort(sortedLabels(labels))
 
 			result = append(result, App{
-				Name:       teleApp.Name,
-				URI:        teleApp.URI,
-				PublicAddr: teleApp.PublicAddr,
-				Labels:     labels,
-				ClusterID:  appClusterName,
-				FQDN:       fqdn,
+				Name:        teleApp.Name,
+				Description: teleApp.Description,
+				URI:         teleApp.URI,
+				PublicAddr:  teleApp.PublicAddr,
+				Labels:      labels,
+				ClusterID:   appClusterName,
+				FQDN:        fqdn,
 			})
 		}
 	}


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/7947

#### Description
Backend now returns the description field for apps list.

The new UI app view (table list instead of cards) was also backported to v6.2, and in these UI changes we show `description` field that wasn't there before the change. This field wasn't returned from the backend originally b/c it wasn't required with the older UI.

#### Screenshot
![descriptioncolumn](https://user-images.githubusercontent.com/43280172/130126013-a7fefd9d-ae83-4d33-9e4a-992f3cf1be8a.png)
