### PR TITLE
[v6.2] fix parent shard tracking

### DIFF
--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
 
 	radix "github.com/armon/go-radix"
 	"github.com/gravitational/trace"
@@ -35,27 +36,23 @@ import (
 type CircularBuffer struct {
 	sync.Mutex
 	*log.Entry
-	ctx      context.Context
-	cancel   context.CancelFunc
-	events   []Event
-	start    int
-	end      int
-	size     int
-	watchers *watcherTree
+	events       []Event
+	start        int
+	end          int
+	size         int
+	init, closed bool
+	watchers     *watcherTree
 }
 
-// NewCircularBuffer returns a new instance of circular buffer
-func NewCircularBuffer(ctx context.Context, size int) (*CircularBuffer, error) {
+// NewCircularBuffer returns a new uninitialized instance of circular buffer.
+func NewCircularBuffer(size int) (*CircularBuffer, error) {
 	if size <= 0 {
 		return nil, trace.BadParameter("circular buffer size should be > 0")
 	}
-	ctx, cancel := context.WithCancel(ctx)
 	buf := &CircularBuffer{
 		Entry: log.WithFields(log.Fields{
 			trace.Component: teleport.ComponentBuffer,
 		}),
-		ctx:      ctx,
-		cancel:   cancel,
 		events:   make([]Event, size),
 		start:    -1,
 		end:      -1,
@@ -65,11 +62,26 @@ func NewCircularBuffer(ctx context.Context, size int) (*CircularBuffer, error) {
 	return buf, nil
 }
 
-// Reset resets all events from the queue
-// and closes all active watchers
+// Clear clears all events from the queue and closes all active watchers,
+// but does not modify init state.
+func (c *CircularBuffer) Clear() {
+	c.Lock()
+	defer c.Unlock()
+	c.clear()
+}
+
+// Reset is equivalent to Clear except that is also sets the buffer into
+// an uninitialized state.  This method should only be used when resetting
+// after a broken event stream.  If only closure of watchers is desired,
+// use Clear instead.
 func (c *CircularBuffer) Reset() {
 	c.Lock()
 	defer c.Unlock()
+	c.clear()
+	c.init = false
+}
+
+func (c *CircularBuffer) clear() {
 	// could close multiple times
 	c.watchers.walk(func(w *BufferWatcher) {
 		w.closeWatcher()
@@ -83,10 +95,42 @@ func (c *CircularBuffer) Reset() {
 	}
 }
 
+// SetInit puts the buffer into an initialized state if it isn't already.  Any watchers already queued
+// will be sent init events, and watchers added after this call will have their init events sent immediately.
+// This function must be called *after* establishing a healthy parent event stream in order to preserve
+// correct cache behavior.
+func (c *CircularBuffer) SetInit() {
+	c.Lock()
+	defer c.Unlock()
+	if c.init {
+		return
+	}
+
+	var watchersToDelete []*BufferWatcher
+	c.watchers.walk(func(watcher *BufferWatcher) {
+		if ok := watcher.init(); !ok {
+			watchersToDelete = append(watchersToDelete, watcher)
+		}
+	})
+
+	for _, watcher := range watchersToDelete {
+		c.Warningf("Closing %v, failed to send init event.", watcher)
+		watcher.closeWatcher()
+		c.watchers.rm(watcher)
+	}
+
+	c.init = true
+}
+
 // Close closes circular buffer and all watchers
 func (c *CircularBuffer) Close() error {
-	c.cancel()
-	c.Reset()
+	c.Lock()
+	defer c.Unlock()
+	c.clear()
+	c.closed = true
+	// note that we do not modify init state here.  this is because
+	// calls to Close are allowed to happen concurrently with calls
+	// to Emit().
 	return nil
 }
 
@@ -118,24 +162,27 @@ func (c *CircularBuffer) eventsCopy() []Event {
 	return out
 }
 
-// PushBatch pushes elements to the queue as a batch
-func (c *CircularBuffer) PushBatch(events []Event) {
+// Emit emits events to currently registered watchers and stores them to
+// the buffer.  Panics if called before SetInit(), and returns false if called
+// after Close().
+func (c *CircularBuffer) Emit(events ...Event) (ok bool) {
 	c.Lock()
 	defer c.Unlock()
+
+	if c.closed {
+		return false
+	}
 
 	for i := range events {
-		c.push(events[i])
+		c.emit(events[i])
 	}
+	return true
 }
 
-// Push pushes elements to the queue
-func (c *CircularBuffer) Push(r Event) {
-	c.Lock()
-	defer c.Unlock()
-	c.push(r)
-}
-
-func (c *CircularBuffer) push(r Event) {
+func (c *CircularBuffer) emit(r Event) {
+	if !c.init {
+		panic("push called on uninitialized buffer instance")
+	}
 	if c.size == 0 {
 		c.start = 0
 		c.end = 0
@@ -160,8 +207,6 @@ func (c *CircularBuffer) fanOutEvent(r Event) {
 		}
 		select {
 		case watcher.eventsC <- r:
-		case <-c.ctx.Done():
-			return
 		default:
 			watchersToDelete = append(watchersToDelete, watcher)
 		}
@@ -201,10 +246,8 @@ func (c *CircularBuffer) NewWatcher(ctx context.Context, watch Watch) (Watcher, 
 	c.Lock()
 	defer c.Unlock()
 
-	select {
-	case <-c.ctx.Done():
-		return nil, trace.BadParameter("buffer is closed")
-	default:
+	if c.closed {
+		return nil, trace.Errorf("cannot register watcher, buffer is closed")
 	}
 
 	if watch.QueueSize == 0 {
@@ -231,14 +274,11 @@ func (c *CircularBuffer) NewWatcher(ctx context.Context, watch Watch) (Watcher, 
 		capacity: watch.QueueSize,
 	}
 	c.Debugf("Add %v.", w)
-	select {
-	case w.eventsC <- Event{Type: OpInit}:
-	case <-c.ctx.Done():
-		return nil, trace.BadParameter("buffer is closed")
-	default:
-		c.Warningf("Closing %v, buffer overflow.", w)
-		w.Close()
-		return nil, trace.BadParameter("buffer overflow")
+	if c.init {
+		if ok := w.init(); !ok {
+			c.Warningf("Closing %v, failed to send init event.", w)
+			return nil, trace.BadParameter("failed to send init event")
+		}
 	}
 	c.watchers.add(w)
 	return w, nil
@@ -266,6 +306,8 @@ type BufferWatcher struct {
 	eventsC  chan Event
 	ctx      context.Context
 	cancel   context.CancelFunc
+	initOnce sync.Once
+	initOk   bool
 	capacity int
 }
 
@@ -283,6 +325,19 @@ func (w *BufferWatcher) Events() <-chan Event {
 // Done channel is closed when watcher is closed
 func (w *BufferWatcher) Done() <-chan struct{} {
 	return w.ctx.Done()
+}
+
+// init transmits the OpInit event.  safe to double-call.
+func (w *BufferWatcher) init() (ok bool) {
+	w.initOnce.Do(func() {
+		select {
+		case w.eventsC <- Event{Type: types.OpInit}:
+			w.initOk = true
+		default:
+			w.initOk = false
+		}
+	})
+	return w.initOk
 }
 
 // Close closes the watcher, could

--- a/lib/backend/buffer_test.go
+++ b/lib/backend/buffer_test.go
@@ -44,9 +44,10 @@ func (s *BufferSuite) SetUpSuite(c *check.C) {
 }
 
 func (s *BufferSuite) list(c *check.C, bufferSize int, listSize int) {
-	b, err := NewCircularBuffer(context.Background(), bufferSize)
+	b, err := NewCircularBuffer(bufferSize)
 	c.Assert(err, check.IsNil)
 	defer b.Close()
+	b.SetInit()
 	s.listWithBuffer(c, b, bufferSize, listSize)
 }
 
@@ -59,7 +60,7 @@ func (s *BufferSuite) listWithBuffer(c *check.C, b *CircularBuffer, bufferSize i
 	// push through all elements of the list and make sure
 	// the slice always matches
 	for i := 0; i < len(elements); i++ {
-		b.Push(Event{Item: Item{ID: elements[i]}})
+		b.Emit(Event{Item: Item{ID: elements[i]}})
 		sliceEnd := i + 1 - bufferSize
 		if sliceEnd < 0 {
 			sliceEnd = 0
@@ -79,23 +80,25 @@ func (s *BufferSuite) TestBufferSizes(c *check.C) {
 }
 
 // TestBufferSizesReset tests various combinations of various
-// buffer sizes and lists with reset
+// buffer sizes and lists with clear.
 func (s *BufferSuite) TestBufferSizesReset(c *check.C) {
-	b, err := NewCircularBuffer(context.Background(), 1)
+	b, err := NewCircularBuffer(1)
 	c.Assert(err, check.IsNil)
 	defer b.Close()
+	b.SetInit()
 
 	s.listWithBuffer(c, b, 1, 100)
-	b.Reset()
+	b.Clear()
 	s.listWithBuffer(c, b, 1, 100)
 }
 
 // TestWatcherSimple tests scenarios with watchers
 func (s *BufferSuite) TestWatcherSimple(c *check.C) {
 	ctx := context.TODO()
-	b, err := NewCircularBuffer(ctx, 3)
+	b, err := NewCircularBuffer(3)
 	c.Assert(err, check.IsNil)
 	defer b.Close()
+	b.SetInit()
 
 	w, err := b.NewWatcher(ctx, Watch{})
 	c.Assert(err, check.IsNil)
@@ -108,7 +111,7 @@ func (s *BufferSuite) TestWatcherSimple(c *check.C) {
 		c.Fatalf("Timeout waiting for event.")
 	}
 
-	b.Push(Event{Item: Item{Key: []byte{Separator}, ID: 1}})
+	b.Emit(Event{Item: Item{Key: []byte{Separator}, ID: 1}})
 
 	select {
 	case e := <-w.Events():
@@ -118,7 +121,7 @@ func (s *BufferSuite) TestWatcherSimple(c *check.C) {
 	}
 
 	b.Close()
-	b.Push(Event{Item: Item{ID: 2}})
+	b.Emit(Event{Item: Item{ID: 2}})
 
 	select {
 	case <-w.Done():
@@ -133,12 +136,12 @@ func (s *BufferSuite) TestWatcherSimple(c *check.C) {
 // TestWatcherClose makes sure that closed watcher
 // will be removed
 func (s *BufferSuite) TestWatcherClose(c *check.C) {
-	ctx := context.TODO()
-	b, err := NewCircularBuffer(ctx, 3)
+	b, err := NewCircularBuffer(3)
 	c.Assert(err, check.IsNil)
 	defer b.Close()
+	b.SetInit()
 
-	w, err := b.NewWatcher(ctx, Watch{})
+	w, err := b.NewWatcher(context.TODO(), Watch{})
 	c.Assert(err, check.IsNil)
 
 	select {
@@ -189,12 +192,12 @@ func (s *BufferSuite) TestRemoveRedundantPrefixes(c *check.C) {
 // TestWatcherMulti makes sure that watcher
 // with multiple matching prefixes will get an event only once
 func (s *BufferSuite) TestWatcherMulti(c *check.C) {
-	ctx := context.TODO()
-	b, err := NewCircularBuffer(ctx, 3)
+	b, err := NewCircularBuffer(3)
 	c.Assert(err, check.IsNil)
 	defer b.Close()
+	b.SetInit()
 
-	w, err := b.NewWatcher(ctx, Watch{Prefixes: [][]byte{[]byte("/a"), []byte("/a/b")}})
+	w, err := b.NewWatcher(context.TODO(), Watch{Prefixes: [][]byte{[]byte("/a"), []byte("/a/b")}})
 	c.Assert(err, check.IsNil)
 	defer w.Close()
 
@@ -205,7 +208,7 @@ func (s *BufferSuite) TestWatcherMulti(c *check.C) {
 		c.Fatalf("Timeout waiting for event.")
 	}
 
-	b.Push(Event{Item: Item{Key: []byte("/a/b/c"), ID: 1}})
+	b.Emit(Event{Item: Item{Key: []byte("/a/b/c"), ID: 1}})
 
 	select {
 	case e := <-w.Events():
@@ -220,12 +223,12 @@ func (s *BufferSuite) TestWatcherMulti(c *check.C) {
 
 // TestWatcherReset tests scenarios with watchers and buffer resets
 func (s *BufferSuite) TestWatcherReset(c *check.C) {
-	ctx := context.TODO()
-	b, err := NewCircularBuffer(ctx, 3)
+	b, err := NewCircularBuffer(3)
 	c.Assert(err, check.IsNil)
 	defer b.Close()
+	b.SetInit()
 
-	w, err := b.NewWatcher(ctx, Watch{})
+	w, err := b.NewWatcher(context.TODO(), Watch{})
 	c.Assert(err, check.IsNil)
 	defer w.Close()
 
@@ -236,8 +239,8 @@ func (s *BufferSuite) TestWatcherReset(c *check.C) {
 		c.Fatalf("Timeout waiting for event.")
 	}
 
-	b.Push(Event{Item: Item{Key: []byte{Separator}, ID: 1}})
-	b.Reset()
+	b.Emit(Event{Item: Item{Key: []byte{Separator}, ID: 1}})
+	b.Clear()
 
 	// make sure watcher has been closed
 	select {
@@ -246,7 +249,7 @@ func (s *BufferSuite) TestWatcherReset(c *check.C) {
 		c.Fatalf("Timeout waiting for close event.")
 	}
 
-	w2, err := b.NewWatcher(ctx, Watch{})
+	w2, err := b.NewWatcher(context.TODO(), Watch{})
 	c.Assert(err, check.IsNil)
 	defer w2.Close()
 
@@ -257,7 +260,7 @@ func (s *BufferSuite) TestWatcherReset(c *check.C) {
 		c.Fatalf("Timeout waiting for event.")
 	}
 
-	b.Push(Event{Item: Item{Key: []byte{Separator}, ID: 2}})
+	b.Emit(Event{Item: Item{Key: []byte{Separator}, ID: 2}})
 
 	select {
 	case e := <-w2.Events():

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -212,7 +212,7 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	buf, err := backend.NewCircularBuffer(ctx, cfg.BufferSize)
+	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -530,11 +530,6 @@ func (b *Backend) Delete(ctx context.Context, key []byte) error {
 
 // NewWatcher returns a new event watcher
 func (b *Backend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.Watcher, error) {
-	select {
-	case <-b.watchStarted.Done():
-	case <-ctx.Done():
-		return nil, trace.ConnectionProblem(ctx.Err(), "context is closing")
-	}
 	return b.buf.NewWatcher(ctx, watch)
 }
 
@@ -594,7 +589,7 @@ func (b *Backend) Close() error {
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (b *Backend) CloseWatchers() {
-	b.buf.Reset()
+	b.buf.Clear()
 }
 
 type tableStatus int

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -59,7 +59,6 @@ func (b *Backend) asyncPollStreams(ctx context.Context) error {
 			b.Errorf("Poll streams returned with error: %v.", err)
 		}
 		b.Debugf("Reloading %v.", retry)
-		b.buf.Reset()
 		select {
 		case <-retry.After():
 			retry.Inc()
@@ -83,25 +82,69 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 	set := make(map[string]struct{})
 	eventsC := make(chan shardEvent)
 
-	refreshShards := func() error {
+	shouldStartPoll := func(shard *dynamodbstreams.Shard) bool {
+		sid := aws.StringValue(shard.ShardId)
+		if _, ok := set[sid]; ok {
+			// already being polled
+			return false
+		}
+		if _, ok := set[aws.StringValue(shard.ParentShardId)]; ok {
+			b.Debugf("Skipping child shard: %s, still polling parent %s", sid, aws.StringValue(shard.ParentShardId))
+			// still processing parent
+			return false
+		}
+		return true
+	}
+
+	refreshShards := func(init bool) error {
 		shards, err := b.collectActiveShards(ctx, streamArn)
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		var initC chan error
+		if init {
+			// first call to  refreshShards requires us to block on shard iterator
+			// registration.
+			initC = make(chan error, len(shards))
+		}
+
+		started := 0
 		for i := range shards {
+			if !shouldStartPoll(shards[i]) {
+				continue
+			}
 			shardID := aws.StringValue(shards[i].ShardId)
-			if _, ok := set[shardID]; !ok {
-				b.Debugf("Adding active shard %v.", shardID)
-				set[shardID] = struct{}{}
-				go b.asyncPollShard(ctx, streamArn, shards[i], eventsC)
+			b.Debugf("Adding active shard %v.", shardID)
+			set[shardID] = struct{}{}
+			go b.asyncPollShard(ctx, streamArn, shards[i], eventsC, initC)
+			started++
+		}
+
+		if init {
+			// block on shard iterator registration.
+			for i := 0; i < started; i++ {
+				select {
+				case err = <-initC:
+					if err != nil {
+						return trace.Wrap(err)
+					}
+				case <-ctx.Done():
+					return trace.Wrap(ctx.Err())
+				}
 			}
 		}
+
 		return nil
 	}
 
-	if err := refreshShards(); err != nil {
+	if err := refreshShards(true); err != nil {
 		return trace.Wrap(err)
 	}
+
+	// shard iterators are initialized, unblock any registered watchers
+	b.buf.SetInit()
+	defer b.buf.Reset()
 
 	ticker := time.NewTicker(b.PollStreamPeriod)
 	defer ticker.Stop()
@@ -123,10 +166,10 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 				}
 				b.Debugf("Shard ID %v exited gracefully.", event.shardID)
 			} else {
-				b.buf.PushBatch(event.events)
+				b.buf.Emit(event.events...)
 			}
 		case <-ticker.C:
-			if err := refreshShards(); err != nil {
+			if err := refreshShards(false); err != nil {
 				return trace.Wrap(err)
 			}
 		case <-ctx.Done():
@@ -149,15 +192,24 @@ func (b *Backend) findStream(ctx context.Context) (*string, error) {
 	return status.Table.LatestStreamArn, nil
 }
 
-func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent) error {
+func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent, initC chan<- error) error {
 	shardIterator, err := b.streams.GetShardIteratorWithContext(ctx, &dynamodbstreams.GetShardIteratorInput{
 		ShardId:           shard.ShardId,
 		ShardIteratorType: aws.String(dynamodbstreams.ShardIteratorTypeLatest),
 		StreamArn:         streamArn,
 	})
+
+	if initC != nil {
+		select {
+		case initC <- convertError(err):
+		case <-ctx.Done():
+			return trace.ConnectionProblem(ctx.Err(), "context is closing")
+		}
+	}
 	if err != nil {
 		return convertError(err)
 	}
+
 	ticker := time.NewTicker(b.PollStreamPeriod)
 	defer ticker.Stop()
 	iterator := shardIterator.ShardIterator
@@ -288,7 +340,7 @@ func toEvent(rec *dynamodbstreams.Record) (*backend.Event, error) {
 	}
 }
 
-func (b *Backend) asyncPollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent) {
+func (b *Backend) asyncPollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent, initC chan<- error) {
 	var err error
 	shardID := aws.StringValue(shard.ShardId)
 	defer func() {
@@ -302,7 +354,7 @@ func (b *Backend) asyncPollShard(ctx context.Context, streamArn *string, shard *
 			return
 		}
 	}()
-	err = b.pollShard(ctx, streamArn, shard, eventsC)
+	err = b.pollShard(ctx, streamArn, shard, eventsC, initC)
 }
 
 func (b *Backend) turnOnTimeToLive(ctx context.Context) error {

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -110,6 +110,12 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 		select {
 		case event := <-eventsC:
 			if event.err != nil {
+				if event.shardID == "" {
+					// empty shard IDs in err-variant events are programming bugs and will lead to
+					// invalid state.
+					b.WithError(err).Warnf("Forcing watch system reset due to empty shard ID on error (this is a bug)")
+					return trace.BadParameter("empty shard ID")
+				}
 				delete(set, event.shardID)
 				if event.err != io.EOF {
 					b.Debugf("Shard ID %v closed with error: %v, reseting buffers.", event.shardID, event.err)
@@ -283,12 +289,13 @@ func toEvent(rec *dynamodbstreams.Record) (*backend.Event, error) {
 
 func (b *Backend) asyncPollShard(ctx context.Context, streamArn *string, shard *dynamodbstreams.Shard, eventsC chan shardEvent) {
 	var err error
+	shardID := aws.StringValue(shard.ShardId)
 	defer func() {
 		if err == nil {
-			err = trace.BadParameter("shard exited unexpectedly")
+			err = trace.BadParameter("shard %q exited unexpectedly", shardID)
 		}
 		select {
-		case eventsC <- shardEvent{err: err}:
+		case eventsC <- shardEvent{err: err, shardID: shardID}:
 		case <-ctx.Done():
 			b.Debugf("Context is closing, returning")
 			return

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -182,6 +182,7 @@ func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard *dynam
 					b.Debugf("Shard is closed: %v.", aws.StringValue(shard.ShardId))
 					return io.EOF
 				}
+				iterator = out.NextShardIterator
 				continue
 			}
 			if out.NextShardIterator == nil {

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -140,17 +140,15 @@ func init() {
 type EtcdBackend struct {
 	nodes []string
 	*log.Entry
-	cfg              *Config
-	client           *clientv3.Client
-	cancelC          chan bool
-	stopC            chan bool
-	clock            clockwork.Clock
-	buf              *backend.CircularBuffer
-	ctx              context.Context
-	cancel           context.CancelFunc
-	watchStarted     context.Context
-	signalWatchStart context.CancelFunc
-	watchDone        chan struct{}
+	cfg       *Config
+	client    *clientv3.Client
+	cancelC   chan bool
+	stopC     chan bool
+	clock     clockwork.Clock
+	buf       *backend.CircularBuffer
+	ctx       context.Context
+	cancel    context.CancelFunc
+	watchDone chan struct{}
 }
 
 // Config represents JSON config for etcd backend
@@ -217,25 +215,22 @@ func New(ctx context.Context, params backend.Params) (*EtcdBackend, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	buf, err := backend.NewCircularBuffer(ctx, cfg.BufferSize)
+	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	closeCtx, cancel := context.WithCancel(ctx)
-	watchStarted, signalWatchStart := context.WithCancel(ctx)
 	b := &EtcdBackend{
-		Entry:            log.WithFields(log.Fields{trace.Component: GetName()}),
-		cfg:              cfg,
-		nodes:            cfg.Nodes,
-		cancelC:          make(chan bool, 1),
-		stopC:            make(chan bool, 1),
-		clock:            clockwork.NewRealClock(),
-		cancel:           cancel,
-		ctx:              closeCtx,
-		watchStarted:     watchStarted,
-		signalWatchStart: signalWatchStart,
-		watchDone:        make(chan struct{}),
-		buf:              buf,
+		Entry:     log.WithFields(log.Fields{trace.Component: GetName()}),
+		cfg:       cfg,
+		nodes:     cfg.Nodes,
+		cancelC:   make(chan bool, 1),
+		stopC:     make(chan bool, 1),
+		clock:     clockwork.NewRealClock(),
+		cancel:    cancel,
+		ctx:       closeCtx,
+		watchDone: make(chan struct{}),
+		buf:       buf,
 	}
 
 	// Check that the etcd nodes are at least the minimum version supported
@@ -264,14 +259,6 @@ func New(ctx context.Context, params backend.Params) (*EtcdBackend, error) {
 		return nil, trace.Wrap(err)
 	}
 	go b.asyncWatch()
-	// Wait for watch goroutine to start to avoid data races around the config
-	// struct in tests.
-	select {
-	case <-watchStarted.Done():
-	case <-ctx.Done():
-		b.Close()
-		return nil, trace.Wrap(ctx.Err())
-	}
 
 	// Wrap backend in a input sanitizer and return it.
 	return b, nil
@@ -325,7 +312,7 @@ func (b *EtcdBackend) Close() error {
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (b *EtcdBackend) CloseWatchers() {
-	b.buf.Reset()
+	b.buf.Clear()
 }
 
 func (b *EtcdBackend) reconnect(ctx context.Context) error {
@@ -401,10 +388,6 @@ WatchEvents:
 		case <-b.ctx.Done():
 			break WatchEvents
 		}
-
-		// buffer must be reset before recreation in order to avoid duplicate
-		// and/or missing values in the buffer watcher event stream.
-		b.buf.Reset()
 	}
 	b.Debugf("Watch stopped: %v.", trace.NewAggregate(err, b.ctx.Err()))
 }
@@ -455,30 +438,42 @@ func (b *EtcdBackend) watchEvents(ctx context.Context) error {
 		cq.InputBuf(120),
 		cq.OutputBuf(48),
 	)
-	defer q.Close()
 
-	// launch background process responsible for forwarding events from the queue
-	// to the buffer.
+	// emitDone signals that the background goroutine used for emitting the processed
+	// events to the buffer has halted.
+	emitDone := make(chan struct{})
+
+	// watcher must be registered before we initialize the buffer
+	eventsC := b.client.Watch(ctx, b.cfg.Key, clientv3.WithPrefix())
+
+	// set buffer to initialized state.
+	b.buf.SetInit()
+
+	// ensure correct cleanup ordering (buffer must not be reset until event emission has halted).
+	defer func() {
+		q.Close()
+		<-emitDone
+		b.buf.Reset()
+	}()
+
+	// launch background process responsible for event emission.
 	go func() {
-	PushToBuf:
+		defer close(emitDone)
+	EmitEvents:
 		for {
 			select {
 			case p := <-q.Pop():
 				r := p.(eventResult)
 				if r.err != nil {
 					b.WithError(r.err).Errorf("Failed to unmarshal event: %v.", r.original)
-					continue PushToBuf
+					continue EmitEvents
 				}
-				b.buf.Push(r.event)
+				b.buf.Emit(r.event)
 			case <-q.Done():
 				return
 			}
 		}
 	}()
-
-	// start watching
-	eventsC := b.client.Watch(ctx, b.cfg.Key, clientv3.WithPrefix())
-	b.signalWatchStart()
 
 	var lastBacklogWarning time.Time
 	for {
@@ -524,11 +519,6 @@ func (b *EtcdBackend) watchEvents(ctx context.Context) error {
 
 // NewWatcher returns a new event watcher
 func (b *EtcdBackend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.Watcher, error) {
-	select {
-	case <-b.watchStarted.Done():
-	case <-ctx.Done():
-		return nil, trace.ConnectionProblem(ctx.Err(), "context is closing")
-	}
 	return b.buf.NewWatcher(ctx, watch)
 }
 

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -260,7 +260,7 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 	// It won't be needed after New returns.
 	defer firestoreAdminClient.Close()
 
-	buf, err := backend.NewCircularBuffer(ctx, cfg.BufferSize)
+	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)
@@ -490,11 +490,6 @@ func (b *Backend) Delete(ctx context.Context, key []byte) error {
 
 // NewWatcher returns a new event watcher
 func (b *Backend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.Watcher, error) {
-	select {
-	case <-b.watchStarted.Done():
-	case <-ctx.Done():
-		return nil, trace.ConnectionProblem(ctx.Err(), "context is closing")
-	}
 	return b.buf.NewWatcher(ctx, watch)
 }
 
@@ -544,7 +539,7 @@ func (b *Backend) Close() error {
 
 // CloseWatchers closes all the watchers without closing the backend
 func (b *Backend) CloseWatchers() {
-	b.buf.Reset()
+	b.buf.Clear()
 }
 
 // Clock returns wall clock
@@ -603,14 +598,34 @@ func isCanceled(err error) bool {
 	}
 }
 
+// driftTolerance is the amount of clock drift between auth servers that we
+// will be resilient to.  Clock drift greater than this amount may result
+// in cache inconsistencies due to missing events which aught to have a "happens after"
+// relationship to associated reads.  This is because the firestore event stream
+// starts at a timestamp field that is defined by the auth server.  If a different
+// auth server is lagging behind us, it may modify a document after we established our
+// listener, but we will miss the event because it used an old timestamp.  We combat this
+// issue by starting our query slightly in the past.  If an auth server writes a document
+// and is lagging less than driftTolerance, subscribing caches will be correctly updated.
+// This has the unfortunate side-effect of potentially emitting old events, but this is OK
+// (if somewhat confusing).  All caching logic assumes that it may see some events which
+// happened before it's reads completed.  Missing an event that happened after is what
+// can lead to permanently bad cache state.
+const driftTolerance = time.Millisecond * 2500
+
 // watchCollection watches a firestore collection for changes and pushes those changes, events into the buffer for watchers
 func (b *Backend) watchCollection() error {
 	var snaps *firestore.QuerySnapshotIterator
+
 	if b.LimitWatchQuery {
-		snaps = b.svc.Collection(b.CollectionName).Query.Where(timestampDocProperty, ">=", b.clock.Now().UTC().Unix()).Snapshots(b.clientContext)
+		snaps = b.svc.Collection(b.CollectionName).Query.Where(timestampDocProperty, ">=", b.clock.Now().UTC().Add(-driftTolerance).Unix()).Snapshots(b.clientContext)
 	} else {
 		snaps = b.svc.Collection(b.CollectionName).Snapshots(b.clientContext)
 	}
+
+	b.buf.SetInit()
+	defer b.buf.Reset()
+
 	b.signalWatchStart()
 	defer snaps.Stop()
 	for {
@@ -640,7 +655,7 @@ func (b *Backend) watchCollection() error {
 					},
 				}
 			}
-			b.buf.Push(e)
+			b.buf.Emit(e)
 		}
 	}
 }

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -152,7 +152,7 @@ func NewWithConfig(ctx context.Context, cfg Config) (*Backend, error) {
 	}
 	// serialize access to sqlite to avoid database is locked errors
 	db.SetMaxOpenConns(1)
-	buf, err := backend.NewCircularBuffer(ctx, cfg.BufferSize)
+	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -775,11 +775,6 @@ func (l *Backend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.
 	if l.EventsOff {
 		return nil, trace.BadParameter("events are turned off for this backend")
 	}
-	select {
-	case <-l.watchStarted.Done():
-	case <-ctx.Done():
-		return nil, trace.ConnectionProblem(ctx.Err(), "context is closing")
-	}
 	return l.buf.NewWatcher(ctx, watch)
 }
 
@@ -792,7 +787,7 @@ func (l *Backend) Close() error {
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (l *Backend) CloseWatchers() {
-	l.buf.Reset()
+	l.buf.Clear()
 }
 
 func (l *Backend) isClosed() bool {

--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -128,8 +128,13 @@ func (l *Backend) pollEvents(rowid int64) (int64, error) {
 				return trace.Wrap(err)
 			}
 			row := q.QueryRow()
+			prevRowID := rowid
 			if err := row.Scan(&rowid); err != nil {
 				if err != sql.ErrNoRows {
+					// Scan does not explicitly promise not to modify its inputs if it returns an error (though this is likely
+					// how it behaves).  Just in case, make sure that rowid is preserved so that we don't accidentally skip
+					// some init logic on retry.
+					rowid = prevRowID
 					return trace.Wrap(err)
 				}
 				rowid = -1
@@ -143,6 +148,7 @@ func (l *Backend) pollEvents(rowid int64) (int64, error) {
 		}
 		l.Debugf("Initialized event ID iterator to %v", rowid)
 		l.signalWatchStart()
+		l.buf.SetInit()
 	}
 
 	var events []backend.Event
@@ -178,7 +184,7 @@ func (l *Backend) pollEvents(rowid int64) (int64, error) {
 	if err != nil {
 		return rowid, trace.Wrap(err)
 	}
-	l.buf.PushBatch(events)
+	l.buf.Emit(events...)
 	if len(events) != 0 {
 		return lastID, nil
 	}

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -91,11 +91,12 @@ func New(cfg Config) (*Memory, error) {
 		return nil, trace.Wrap(err)
 	}
 	ctx, cancel := context.WithCancel(cfg.Context)
-	buf, err := backend.NewCircularBuffer(ctx, cfg.BufferSize)
+	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)
 	}
+	buf.SetInit()
 	m := &Memory{
 		Mutex: &sync.Mutex{},
 		Entry: log.WithFields(log.Fields{
@@ -143,7 +144,7 @@ func (m *Memory) Close() error {
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (m *Memory) CloseWatchers() {
-	m.buf.Reset()
+	m.buf.Clear()
 }
 
 // Clock returns clock used by this backend
@@ -168,7 +169,7 @@ func (m *Memory) Create(ctx context.Context, i backend.Item) (*backend.Lease, er
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return m.newLease(i), nil
 }
@@ -209,7 +210,7 @@ func (m *Memory) Update(ctx context.Context, i backend.Item) (*backend.Lease, er
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return m.newLease(i), nil
 }
@@ -229,7 +230,7 @@ func (m *Memory) Put(ctx context.Context, i backend.Item) (*backend.Lease, error
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return m.newLease(i), nil
 }
@@ -255,7 +256,7 @@ func (m *Memory) PutRange(ctx context.Context, items []backend.Item) error {
 		}
 		m.processEvent(event)
 		if !m.EventsOff {
-			m.buf.Push(event)
+			m.buf.Emit(event)
 		}
 	}
 	return nil
@@ -281,7 +282,7 @@ func (m *Memory) Delete(ctx context.Context, key []byte) error {
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return nil
 }
@@ -306,7 +307,7 @@ func (m *Memory) DeleteRange(ctx context.Context, startKey, endKey []byte) error
 		}
 		m.processEvent(event)
 		if !m.EventsOff {
-			m.buf.Push(event)
+			m.buf.Emit(event)
 		}
 	}
 	return nil
@@ -350,7 +351,7 @@ func (m *Memory) KeepAlive(ctx context.Context, lease backend.Lease, expires tim
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return nil
 }
@@ -383,7 +384,7 @@ func (m *Memory) CompareAndSwap(ctx context.Context, expected backend.Item, repl
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Push(event)
+		m.buf.Emit(event)
 	}
 	return m.newLease(replaceWith), nil
 }
@@ -453,7 +454,7 @@ func (m *Memory) removeExpired() int {
 			},
 		}
 		if !m.EventsOff {
-			m.buf.Push(event)
+			m.buf.Emit(event)
 		}
 	}
 	if removed > 0 {

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -322,6 +322,8 @@ func (s *BackendSuite) KeepAlive(c *check.C) {
 	c.Assert(err, check.IsNil)
 	defer watcher.Close()
 
+	_ = collectEvents(c, watcher, 1)
+
 	item := backend.Item{Key: prefix("key"), Value: []byte("val1"), Expires: addSeconds(time.Now(), 2)}
 	lease, err := s.B.Put(ctx, item)
 	c.Assert(err, check.IsNil)
@@ -346,18 +348,18 @@ func (s *BackendSuite) KeepAlive(c *check.C) {
 	c.Assert(string(out.Value), check.Equals, string(item.Value))
 	c.Assert(string(out.Key), check.Equals, string(item.Key))
 
-	events := collectEvents(c, watcher, 3)
+	events := collectEvents(c, watcher, 2)
+	c.Assert(events[0].Type, check.Equals, backend.OpPut)
+	c.Assert(string(events[0].Item.Key), check.Equals, string(item.Key))
 	c.Assert(events[1].Type, check.Equals, backend.OpPut)
 	c.Assert(string(events[1].Item.Key), check.Equals, string(item.Key))
-	c.Assert(events[2].Type, check.Equals, backend.OpPut)
-	c.Assert(string(events[2].Item.Key), check.Equals, string(item.Key))
 
+	c.Assert(string(events[0].Item.Value), check.Equals, string(item.Value))
 	c.Assert(string(events[1].Item.Value), check.Equals, string(item.Value))
-	c.Assert(string(events[2].Item.Value), check.Equals, string(item.Value))
 
+	c.Assert(events[0].Item.Expires.IsZero(), check.Not(check.Equals), true, check.Commentf("expected non zero expiration time"))
 	c.Assert(events[1].Item.Expires.IsZero(), check.Not(check.Equals), true, check.Commentf("expected non zero expiration time"))
-	c.Assert(events[2].Item.Expires.IsZero(), check.Not(check.Equals), true, check.Commentf("expected non zero expiration time"))
-	c.Assert(events[2].Item.Expires.After(events[1].Item.Expires), check.Equals, true, check.Commentf("expected %v after %v", events[2].Item.Expires, events[1].Item.Expires))
+	c.Assert(events[1].Item.Expires.After(events[0].Item.Expires), check.Equals, true, check.Commentf("expected %v after %v", events[1].Item.Expires, events[0].Item.Expires))
 
 	err = s.B.Delete(ctx, item.Key)
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
Backports #7992 and re-enables the commits that were reverted in #7936.