### PR TITLE
Add Webauthn SessionData persistence to Identity

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -528,6 +528,10 @@ const (
 const (
 	// U2FChallengeTimeout is hardcoded in the U2F library
 	U2FChallengeTimeout = 5 * time.Minute
+	// WebauthnChallengeTimeout is the timeout for ongoing Webauthn authentication
+	// or registration challenges.
+	// TODO(codingllama): Apply this to the lib/auth/webauthn package.
+	WebauthnChallengeTimeout = 5 * time.Minute
 )
 
 const (

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -26,6 +26,7 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	wantypes "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/lib/auth/u2f"
 	"github.com/gravitational/teleport/lib/defaults"
 
@@ -119,6 +120,20 @@ type Identity interface {
 
 	// GetU2FSignChallenge returns a U2F sign (auth) challenge
 	GetU2FSignChallenge(user string) (*u2f.Challenge, error)
+
+	// UpsertWebauthnSessionData creates or updates WebAuthn session data in
+	// storage, for the purpose of later verifying an authentication or
+	// registration challenge.
+	// Session data is expected to expire according to backend settings.
+	UpsertWebauthnSessionData(user, sessionID string, sd *wantypes.SessionData) error
+
+	// GetWebauthnSessionData retrieves a previously-stored session data by ID,
+	// if it exists and has not expired.
+	GetWebauthnSessionData(user, sessionID string) (*wantypes.SessionData, error)
+
+	// DeleteWebauthnSessionData deletes session data by ID, if it exists and has
+	// not expired.
+	DeleteWebauthnSessionData(user, sessionID string) error
 
 	// UpsertMFADevice upserts an MFA device for the user.
 	UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -125,15 +125,15 @@ type Identity interface {
 	// storage, for the purpose of later verifying an authentication or
 	// registration challenge.
 	// Session data is expected to expire according to backend settings.
-	UpsertWebauthnSessionData(user, sessionID string, sd *wantypes.SessionData) error
+	UpsertWebauthnSessionData(ctx context.Context, user, sessionID string, sd *wantypes.SessionData) error
 
 	// GetWebauthnSessionData retrieves a previously-stored session data by ID,
 	// if it exists and has not expired.
-	GetWebauthnSessionData(user, sessionID string) (*wantypes.SessionData, error)
+	GetWebauthnSessionData(ctx context.Context, user, sessionID string) (*wantypes.SessionData, error)
 
 	// DeleteWebauthnSessionData deletes session data by ID, if it exists and has
 	// not expired.
-	DeleteWebauthnSessionData(user, sessionID string) error
+	DeleteWebauthnSessionData(ctx context.Context, user, sessionID string) error
 
 	// UpsertMFADevice upserts an MFA device for the user.
 	UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -129,6 +129,10 @@ func (s *ServicesSuite) TestU2FCRUD(c *check.C) {
 	s.suite.U2FCRUD(c)
 }
 
+func (s *ServicesSuite) TestWebauthnSessionDataCRUD(c *check.C) {
+	s.suite.WebauthnSessionDataCRUD(c)
+}
+
 func (s *ServicesSuite) TestSAMLCRUD(c *check.C) {
 	s.suite.SAMLCRUD(c)
 }

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"time"
 
+	wantypes "github.com/gravitational/teleport/api/types/webauthn"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/google/go-cmp/cmp"
@@ -564,6 +565,59 @@ func (s *IdentityService) GetU2FRegisterChallenge(token string) (*u2f.Challenge,
 	return &u2fChal, nil
 }
 
+func (s *IdentityService) UpsertWebauthnSessionData(user, sessionID string, sd *wantypes.SessionData) error {
+	switch {
+	case user == "":
+		return trace.BadParameter("missing parameter user")
+	case sessionID == "":
+		return trace.BadParameter("missing parameter sessionID")
+	case sd == nil:
+		return trace.BadParameter("missing parameter sd")
+	}
+
+	value, err := json.Marshal(sd)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = s.Put(context.TODO(), backend.Item{
+		Key:     sessionDataKey(user, sessionID),
+		Value:   value,
+		Expires: s.Clock().Now().UTC().Add(defaults.WebauthnChallengeTimeout),
+	})
+	return trace.Wrap(err)
+}
+
+func (s *IdentityService) GetWebauthnSessionData(user, sessionID string) (*wantypes.SessionData, error) {
+	switch {
+	case user == "":
+		return nil, trace.BadParameter("missing parameter user")
+	case sessionID == "":
+		return nil, trace.BadParameter("missing parameter sessionID")
+	}
+
+	item, err := s.Get(context.TODO(), sessionDataKey(user, sessionID))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	sd := &wantypes.SessionData{}
+	return sd, trace.Wrap(json.Unmarshal(item.Value, sd))
+}
+
+func (s *IdentityService) DeleteWebauthnSessionData(user, sessionID string) error {
+	switch {
+	case user == "":
+		return trace.BadParameter("missing parameter user")
+	case sessionID == "":
+		return trace.BadParameter("missing parameter sessionID")
+	}
+
+	return trace.Wrap(s.Delete(context.TODO(), sessionDataKey(user, sessionID)))
+}
+
+func sessionDataKey(user, sessionID string) []byte {
+	return backend.Key(webPrefix, usersPrefix, user, webauthnSessionData, sessionID)
+}
+
 func (s *IdentityService) UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error {
 	if user == "" {
 		return trace.BadParameter("missing parameter user")
@@ -1075,6 +1129,7 @@ const (
 	usedTOTPTTL            = 30 * time.Second
 	mfaDevicePrefix        = "mfa"
 	u2fSignChallengePrefix = "u2fsignchallenge"
+	webauthnSessionData    = "webauthnsessiondata"
 
 	// DELETE IN 7.0: these prefixes are migrated to mfaDevicePrefix in 6.0 on
 	// first startup.

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -565,7 +565,7 @@ func (s *IdentityService) GetU2FRegisterChallenge(token string) (*u2f.Challenge,
 	return &u2fChal, nil
 }
 
-func (s *IdentityService) UpsertWebauthnSessionData(user, sessionID string, sd *wantypes.SessionData) error {
+func (s *IdentityService) UpsertWebauthnSessionData(ctx context.Context, user, sessionID string, sd *wantypes.SessionData) error {
 	switch {
 	case user == "":
 		return trace.BadParameter("missing parameter user")
@@ -579,7 +579,7 @@ func (s *IdentityService) UpsertWebauthnSessionData(user, sessionID string, sd *
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = s.Put(context.TODO(), backend.Item{
+	_, err = s.Put(ctx, backend.Item{
 		Key:     sessionDataKey(user, sessionID),
 		Value:   value,
 		Expires: s.Clock().Now().UTC().Add(defaults.WebauthnChallengeTimeout),
@@ -587,7 +587,7 @@ func (s *IdentityService) UpsertWebauthnSessionData(user, sessionID string, sd *
 	return trace.Wrap(err)
 }
 
-func (s *IdentityService) GetWebauthnSessionData(user, sessionID string) (*wantypes.SessionData, error) {
+func (s *IdentityService) GetWebauthnSessionData(ctx context.Context, user, sessionID string) (*wantypes.SessionData, error) {
 	switch {
 	case user == "":
 		return nil, trace.BadParameter("missing parameter user")
@@ -595,7 +595,7 @@ func (s *IdentityService) GetWebauthnSessionData(user, sessionID string) (*wanty
 		return nil, trace.BadParameter("missing parameter sessionID")
 	}
 
-	item, err := s.Get(context.TODO(), sessionDataKey(user, sessionID))
+	item, err := s.Get(ctx, sessionDataKey(user, sessionID))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -603,7 +603,7 @@ func (s *IdentityService) GetWebauthnSessionData(user, sessionID string) (*wanty
 	return sd, trace.Wrap(json.Unmarshal(item.Value, sd))
 }
 
-func (s *IdentityService) DeleteWebauthnSessionData(user, sessionID string) error {
+func (s *IdentityService) DeleteWebauthnSessionData(ctx context.Context, user, sessionID string) error {
 	switch {
 	case user == "":
 		return trace.BadParameter("missing parameter user")
@@ -611,7 +611,7 @@ func (s *IdentityService) DeleteWebauthnSessionData(user, sessionID string) erro
 		return trace.BadParameter("missing parameter sessionID")
 	}
 
-	return trace.Wrap(s.Delete(context.TODO(), sessionDataKey(user, sessionID)))
+	return trace.Wrap(s.Delete(ctx, sessionDataKey(user, sessionID)))
 }
 
 func sessionDataKey(user, sessionID string) []byte {

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -28,24 +28,23 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/crypto/ssh"
-
+	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	wantypes "github.com/gravitational/teleport/api/types/webauthn"
 	"github.com/gravitational/teleport/lib/auth/u2f"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
-
 	"github.com/gravitational/trace"
-
 	"github.com/jonboulle/clockwork"
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
 	"gopkg.in/check.v1"
 )
 
@@ -835,6 +834,77 @@ func (s *ServicesTestSuite) U2FCRUD(c *check.C) {
 	devs, err = s.WebS.GetMFADevices(ctx, user1)
 	c.Assert(err, check.IsNil)
 	c.Assert(devs, check.HasLen, 2)
+}
+
+func (s *ServicesTestSuite) WebauthnSessionDataCRUD(c *check.C) {
+	const user1 = "llama"
+	const user2 = "alpaca"
+	// Prepare a few different objects so we can assert that both "user" and
+	// "session" key components are used correctly.
+	user1Reg := &wantypes.SessionData{
+		Challenge: []byte("challenge1-reg"),
+		UserId:    []byte("llamaid"),
+	}
+	user1Login := &wantypes.SessionData{
+		Challenge:        []byte("challenge1-login"),
+		UserId:           []byte("llamaid"),
+		AllowCredentials: [][]byte{[]byte("cred1"), []byte("cred2")},
+	}
+	user2Login := &wantypes.SessionData{
+		Challenge: []byte("challenge2"),
+		UserId:    []byte("alpacaid"),
+	}
+
+	// Usually there are only 2 sessions for each user: login and registration.
+	const registerSession = "register"
+	const loginSession = "login"
+	params := []struct {
+		user, session string
+		sd            *wantypes.SessionData
+	}{
+		{user: user1, session: registerSession, sd: user1Reg},
+		{user: user1, session: loginSession, sd: user1Login},
+		{user: user2, session: loginSession, sd: user2Login},
+	}
+
+	// Verify upsert/create.
+	for _, p := range params {
+		err := s.WebS.UpsertWebauthnSessionData(p.user, p.session, p.sd)
+		c.Assert(err, check.IsNil)
+	}
+
+	// Verify read.
+	for _, p := range params {
+		got, err := s.WebS.GetWebauthnSessionData(p.user, p.session)
+		c.Assert(err, check.IsNil)
+		if diff := cmp.Diff(p.sd, got); diff != "" {
+			c.Fatalf("GetWebauthnSessionData() mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	// Verify upsert/update.
+	user1Login = &wantypes.SessionData{
+		Challenge: []byte("challenge1-another"),
+		UserId:    []byte("llamaid"),
+	}
+	err := s.WebS.UpsertWebauthnSessionData(user1, loginSession, user1Login)
+	c.Assert(err, check.IsNil)
+	got, err := s.WebS.GetWebauthnSessionData(user1, loginSession)
+	c.Assert(err, check.IsNil)
+	if diff := cmp.Diff(user1Login, got); diff != "" {
+		c.Fatalf("GetWebauthnSessionData() mismatch (-want +got):\n%s", diff)
+	}
+
+	// Verify deletion.
+	err = s.WebS.DeleteWebauthnSessionData(user1, loginSession)
+	c.Assert(err, check.IsNil)
+	_, err = s.WebS.GetWebauthnSessionData(user1, loginSession)
+	c.Assert(trace.IsNotFound(err), check.Equals, true)
+	params = params[1:]
+	for _, p := range params {
+		_, err := s.WebS.GetWebauthnSessionData(p.user, p.session)
+		c.Assert(err, check.IsNil) // Other keys preserved
+	}
 }
 
 func (s *ServicesTestSuite) SAMLCRUD(c *check.C) {

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -883,24 +883,24 @@ func (s *ServicesTestSuite) WebauthnSessionDataCRUD(c *check.C) {
 	}
 
 	// Verify upsert/update.
-	user1Login = &wantypes.SessionData{
-		Challenge: []byte("challenge1-another"),
+	user1Reg = &wantypes.SessionData{
+		Challenge: []byte("challenge1reg--another"),
 		UserId:    []byte("llamaid"),
 	}
-	err := s.WebS.UpsertWebauthnSessionData(user1, loginSession, user1Login)
+	err := s.WebS.UpsertWebauthnSessionData(user1, registerSession, user1Reg)
 	c.Assert(err, check.IsNil)
-	got, err := s.WebS.GetWebauthnSessionData(user1, loginSession)
+	got, err := s.WebS.GetWebauthnSessionData(user1, registerSession)
 	c.Assert(err, check.IsNil)
-	if diff := cmp.Diff(user1Login, got); diff != "" {
+	if diff := cmp.Diff(user1Reg, got); diff != "" {
 		c.Fatalf("GetWebauthnSessionData() mismatch (-want +got):\n%s", diff)
 	}
 
 	// Verify deletion.
-	err = s.WebS.DeleteWebauthnSessionData(user1, loginSession)
+	err = s.WebS.DeleteWebauthnSessionData(user1, registerSession)
 	c.Assert(err, check.IsNil)
-	_, err = s.WebS.GetWebauthnSessionData(user1, loginSession)
+	_, err = s.WebS.GetWebauthnSessionData(user1, registerSession)
 	c.Assert(trace.IsNotFound(err), check.Equals, true)
-	params = params[1:]
+	params = params[1:] // Remove user1/register from params
 	for _, p := range params {
 		_, err := s.WebS.GetWebauthnSessionData(p.user, p.session)
 		c.Assert(err, check.IsNil) // Other keys preserved

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -868,14 +868,15 @@ func (s *ServicesTestSuite) WebauthnSessionDataCRUD(c *check.C) {
 	}
 
 	// Verify upsert/create.
+	ctx := context.Background()
 	for _, p := range params {
-		err := s.WebS.UpsertWebauthnSessionData(p.user, p.session, p.sd)
+		err := s.WebS.UpsertWebauthnSessionData(ctx, p.user, p.session, p.sd)
 		c.Assert(err, check.IsNil)
 	}
 
 	// Verify read.
 	for _, p := range params {
-		got, err := s.WebS.GetWebauthnSessionData(p.user, p.session)
+		got, err := s.WebS.GetWebauthnSessionData(ctx, p.user, p.session)
 		c.Assert(err, check.IsNil)
 		if diff := cmp.Diff(p.sd, got); diff != "" {
 			c.Fatalf("GetWebauthnSessionData() mismatch (-want +got):\n%s", diff)
@@ -887,22 +888,22 @@ func (s *ServicesTestSuite) WebauthnSessionDataCRUD(c *check.C) {
 		Challenge: []byte("challenge1reg--another"),
 		UserId:    []byte("llamaid"),
 	}
-	err := s.WebS.UpsertWebauthnSessionData(user1, registerSession, user1Reg)
+	err := s.WebS.UpsertWebauthnSessionData(ctx, user1, registerSession, user1Reg)
 	c.Assert(err, check.IsNil)
-	got, err := s.WebS.GetWebauthnSessionData(user1, registerSession)
+	got, err := s.WebS.GetWebauthnSessionData(ctx, user1, registerSession)
 	c.Assert(err, check.IsNil)
 	if diff := cmp.Diff(user1Reg, got); diff != "" {
 		c.Fatalf("GetWebauthnSessionData() mismatch (-want +got):\n%s", diff)
 	}
 
 	// Verify deletion.
-	err = s.WebS.DeleteWebauthnSessionData(user1, registerSession)
+	err = s.WebS.DeleteWebauthnSessionData(ctx, user1, registerSession)
 	c.Assert(err, check.IsNil)
-	_, err = s.WebS.GetWebauthnSessionData(user1, registerSession)
+	_, err = s.WebS.GetWebauthnSessionData(ctx, user1, registerSession)
 	c.Assert(trace.IsNotFound(err), check.Equals, true)
 	params = params[1:] // Remove user1/register from params
 	for _, p := range params {
-		_, err := s.WebS.GetWebauthnSessionData(p.user, p.session)
+		_, err := s.WebS.GetWebauthnSessionData(ctx, p.user, p.session)
 		c.Assert(err, check.IsNil) // Other keys preserved
 	}
 }


### PR DESCRIPTION
SessionData is persisted in the initial steps of login or registration and
verified in the second step against user-provided data.

WebAuthn Support RFD[1]

[1] https://github.com/gravitational/teleport/pull/7808