### PR TITLE
[backport master] Removed 443/3080 port from tsh login examples

### DIFF
--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -50,7 +50,7 @@ tctl status
 
 # Output
 Cluster  acme.example.com
-Version  6.0.2
+Version  (=teleport.version=)
 Host CA  never updated
 User CA  never updated
 Jwt CA   never updated
@@ -244,14 +244,14 @@ Alice and Ivan can review and approve request using Web UI or CLI:
   <TabItem label="Web UI">
     ![Teleport-Approve](../../../img/access-controls/dual-authz/teleport-6-ivan-approve.png)
   </TabItem>
-  
+
   <TabItem label="CLI">
     ```bash
     tsh request list
-  
+
     # Output
     ID                                   User             Roles   Created (UTC)       Status
-    ------------------------------------ ---------------  ------- ------------------- ------- 
+    ------------------------------------ ---------------  ------- ------------------- -------
     9c721e54-b049-4ef8-a7f6-c777aa066764 bob@example.com  dbadmin 03 Apr 21 03:58 UTC PENDING
 
     tsh request review --approve --reason="hello" 9c721e54-b049-4ef8-a7f6-c777aa066764

--- a/docs/pages/access-controls/guides/impersonation.mdx
+++ b/docs/pages/access-controls/guides/impersonation.mdx
@@ -24,7 +24,7 @@ tctl status
 
 # Output
 Cluster  acme.example.com
-Version  6.0.2
+Version  (=teleport.version=)
 Host CA  never updated
 User CA  never updated
 Jwt CA   never updated
@@ -119,7 +119,7 @@ tctl users add alice  --roles=impersonator,access
 Alice can login using `tsh` and issue a cert for `jenkins`:
 
 ```bash
-tsh login --proxy=teleport.localhost:3080 --user=alice --auth=local
+tsh login --proxy=teleport.localhost --user=alice --auth=local
 tctl auth sign --user=jenkins --format=openssh --out=jenkins --ttl=240h
 ```
 

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -29,7 +29,7 @@ tctl status
 
 # Output
 Cluster  acme.example.com
-Version  6.0.2
+Version  (=teleport.version=)
 Host CA  never updated
 User CA  never updated
 Jwt CA   never updated
@@ -143,7 +143,7 @@ spec:
 Update both user's entries with `tctl create -f` command:
 
 ```bash
-tctl create -f traits.yaml 
+tctl create -f traits.yaml
 # user "alice" has been updated
 ```
 
@@ -151,7 +151,7 @@ Once Alice logs in, she will receive SSH and X.509 certificates with
 a new role and SSH logins and Kubernetes groups set:
 
 ```bash
-tsh login --proxy=teleport.example.com:443 --user=alice
+tsh login --proxy=teleport.example.com --user=alice
 
 # Output
 > Profile URL:        https://teleport.example.com:443
@@ -236,7 +236,7 @@ Once Bob logs in using SSO, he will receive SSH and X.509 certificates with
 a new role and SSH logins generated using `sso-users` role template:
 
 ```bash
-tsh login --proxy=teleport.example.com:443 --auth=github
+tsh login --proxy=teleport.example.com --auth=github
 
 > Profile URL:        https://teleport.example.com:443
   Logged in as:       bob
@@ -290,7 +290,7 @@ spec:
     database_users: ['{{email.local(external.email)}}']
     database_labels:
       'env': '{{regexp.replace(external.access["env"], "^(staging)$", "$1")}}'
-    
+
     # Labels can mix template and hard-coded values.
     node_labels:
       'env': '{{external.access["env"]}}'

--- a/docs/pages/api/getting-started.mdx
+++ b/docs/pages/api/getting-started.mdx
@@ -40,7 +40,7 @@ Log in as the newly created user with `tsh`.
 
 ```bash
 # generate tsh profile
-tsh login --user=api-admin --proxy=tele.example.com:443
+tsh login --user=api-admin --proxy=tele.example.com
 ```
 
 The [Profile Credentials loader](https://pkg.go.dev/github.com/gravitational/teleport/api/client#LoadProfile)
@@ -48,7 +48,7 @@ will automatically retrieve Credentials from the current profile in the next ste
 
 ## Step 3/3. Create a Go project
 
-Set up a new [Go module](https://golang.org/doc/tutorial/create-module) and import the `client` package: 
+Set up a new [Go module](https://golang.org/doc/tutorial/create-module) and import the `client` package:
 
 ```bash
 mkdir client-demo && cd client-demo
@@ -93,7 +93,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to ping server: %v", err)
 	}
-	
+
 	log.Printf("Example success!")
 	log.Printf("Example server response: %s", resp)
 	log.Printf("Server version: %s", resp.ServerVersion)

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -41,7 +41,7 @@ app_service:
 Log into your Teleport cluster and view available applications:
 
 ```bash
-tsh login --proxy=teleport.example.com:443
+tsh login --proxy=teleport.example.com
 tsh app ls
 
 # Output
@@ -102,7 +102,7 @@ tsh app logout
 tsh app config
 ```
 
-shows current app URI and paths to the secrets. 
+shows current app URI and paths to the secrets.
 
 This is useful when configuring CLI tools (such as `curl`) or GUI tools (such as Postman).
 

--- a/docs/pages/application-access/guides/jwt.mdx
+++ b/docs/pages/application-access/guides/jwt.mdx
@@ -90,4 +90,4 @@ can be trusted. This endpoint is `https://[cluster-name]:3080/.well-known/jwks.j
 ```
 
 See the example Go program used to validate Teleport's JWT tokens on our
-[Github](https://github.com/gravitational/teleport/blob/v6.0.2/examples/jwt/verify-jwt.go).
+[Github](https://github.com/gravitational/teleport/blob/v(=teleport.version=)/examples/jwt/verify-jwt.go).

--- a/docs/pages/cloud/faq.mdx
+++ b/docs/pages/cloud/faq.mdx
@@ -37,11 +37,11 @@ There is no need to open any ports on your infrastructure for inbound traffic.
 We have made changes to allow you to log into your cluster using `tsh`, then use `tctl` remotely:
 
 ```bash
-$ tsh login --proxy=myinstance.teleport.sh:443
+$ tsh login --proxy=myinstance.teleport.sh
 # tctl (Enterprise edition) can use tsh credentials as of version 5.0
 $ tctl status
 ```
-You must use the enterprise version of `tctl`. 
+You must use the enterprise version of `tctl`.
 
 ### Why am I getting `permission denied` errors when using `tctl`?
 

--- a/docs/pages/cloud/getting-started.mdx
+++ b/docs/pages/cloud/getting-started.mdx
@@ -40,8 +40,8 @@ Install client libraries:
   <TabItem label="Linux">
     ```bash
     curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    # verify signature 
-    echo "$(curl  https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256)" | sha256sum --check 
+    # verify signature
+    echo "$(curl  https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256)" | sha256sum --check
     tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
     cd teleport-ent
     sudo ./install
@@ -53,11 +53,11 @@ Login into Teleport and test the connection:
 
 ```bash
 # tsh logs you in and receives short-lived certificates
-$ tsh login --proxy=myinstance.teleport.sh:443 --user=email@example.com
+$ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
 $ tsh ls
-Node Name Address    Labels 
---------- ---------- ------ 
-myserver  ⟵ Tunnel     
+Node Name Address    Labels
+--------- ---------- ------
+myserver  ⟵ Tunnel
 $ tsh ssh root@myserver
 ```
 

--- a/docs/pages/cloud/guides/u2f.mdx
+++ b/docs/pages/cloud/guides/u2f.mdx
@@ -14,8 +14,8 @@ Install client libraries:
   <TabItem label="Linux">
     ```bash
     curl -O https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
-    # verify signature 
-    echo "$(curl  https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256)" | sha256sum --check 
+    # verify signature
+    echo "$(curl  https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz.sha256)" | sha256sum --check
     tar -xzf teleport-ent-v(=teleport.version=)-linux-amd64-bin.tar.gz
     cd teleport-ent
     sudo ./install
@@ -27,7 +27,7 @@ Login with a teleport user with editor privileges:
 
 ```bash
 # tsh logs you in and receives short-lived certificates
-tsh login --proxy=myinstance.teleport.sh:443 --user=email@example.com
+tsh login --proxy=myinstance.teleport.sh --user=email@example.com
 # try out the connection
 tctl get nodes
 ```

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -156,7 +156,7 @@ Log into Teleport with the user we've just created. Make sure to use `tsh`
 version `6.0` or newer that includes Database Access support.
 
 ```shell
-tsh login --proxy=teleport.example.com:443 --user=alice
+tsh login --proxy=teleport.example.com --user=alice
 ```
 
 Now we can inspect available databases and retrieve credentials for the

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -152,7 +152,7 @@ certificate with `CN=alice` subject.
 Log into your Teleport cluster and see available databases:
 
 ```bash
-tsh login --proxy=teleport.example.com:3080 --user=alice
+tsh login --proxy=teleport.example.com --user=alice
 tsh db ls
 Name          Description Labels
 ------------- ----------- --------

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -193,7 +193,7 @@ in MongoDB documentation for more details.
 Log into your Teleport cluster and see available databases:
 
 ```bash
-tsh login --proxy=teleport.example.com:3080 --user=alice
+tsh login --proxy=teleport.example.com --user=alice
 tsh db ls
 Name          Description     Labels
 ------------- --------------- --------

--- a/docs/pages/database-access/guides/mysql-aws.mdx
+++ b/docs/pages/database-access/guides/mysql-aws.mdx
@@ -220,7 +220,7 @@ Once the database service has joined the cluster, login to see the available
 databases:
 
 ```sh
-$ tsh login --proxy=teleport.example.com:3080 --user=testuser
+$ tsh login --proxy=teleport.example.com --user=testuser
 $ tsh db ls
 Name   Description      Labels
 ------ ---------------- --------

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -201,7 +201,7 @@ Once the database service has joined the cluster, login to see the available
 databases:
 
 ```bash
-$ tsh login --proxy=teleport.example.com:3080 --user=alice
+$ tsh login --proxy=teleport.example.com --user=alice
 $ tsh db ls
 Name     Description         Labels
 -------- ------------------- --------

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -175,7 +175,7 @@ Once the database service has joined the cluster, login to see the available
 databases:
 
 ```sh
-$ tsh login --proxy=teleport.example.com:3080 --user=testuser
+$ tsh login --proxy=teleport.example.com --user=testuser
 $ tsh db ls
 Name    Description   Labels
 ------- ------------- --------

--- a/docs/pages/database-access/guides/postgres-aws.mdx
+++ b/docs/pages/database-access/guides/postgres-aws.mdx
@@ -209,7 +209,7 @@ Once the database service has joined the cluster, login to see the available
 databases:
 
 ```sh
-$ tsh login --proxy=teleport.example.com:3080 --user=testuser
+$ tsh login --proxy=teleport.example.com --user=testuser
 $ tsh db ls
 Name   Description           Labels
 ------ --------------------- --------

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -263,7 +263,7 @@ Once the database service has joined the cluster, login to see the available
 databases:
 
 ```sh
-$ tsh login --proxy=teleport.example.com:3080 --user=alice
+$ tsh login --proxy=teleport.example.com --user=alice
 $ tsh db ls
 Name     Description              Labels
 -------- ------------------------ --------

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -220,7 +220,7 @@ Once the database service has joined the cluster, login to see the available
 databases:
 
 ```bash
-$ tsh login --proxy=teleport.example.com:3080 --user=alice
+$ tsh login --proxy=teleport.example.com --user=alice
 $ tsh db ls
 Name     Description             Labels
 -------- ----------------------- --------

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -171,7 +171,7 @@ Once the database service has joined the cluster, login to see the available
 databases:
 
 ```sh
-$ tsh login --proxy=teleport.example.com:3080 --user=testuser
+$ tsh login --proxy=teleport.example.com --user=testuser
 $ tsh db ls
 Name    Description        Labels
 ------- ------------------ --------

--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -196,14 +196,14 @@ Log in to receive short-lived certificates from Teleport:
 
 ```bash
 # Replace teleport.example.com:443 with your Teleport cluster's public address as configured above.
-tsh login --proxy=teleport.example.com:443 --user=teleport-admin
+tsh login --proxy=teleport.example.com --user=teleport-admin
 ```
 
 ## Step 4/4. Have fun with Teleport!
 
 Congrats! You've completed setting up Teleport! Now, feel free to have fun and explore the many features Teleport has to offer.
 
-Here are several common commands and operations you'll likely find useful: 
+Here are several common commands and operations you'll likely find useful:
 
 ### View Status
 

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -12,7 +12,7 @@ tctl status
 To try this flow in the cloud, login into your cluster using tsh, then use tctl remotely:
 
 ```bash
-tsh login --proxy=myinstance.teleport.sh:443
+tsh login --proxy=myinstance.teleport.sh
 
 # tctl (Enterprise edition) can use tsh credentials as of version 5.0
 tctl status

--- a/docs/pages/kubernetes-access/getting-started/cluster.mdx
+++ b/docs/pages/kubernetes-access/getting-started/cluster.mdx
@@ -226,7 +226,7 @@ Try `tsh login` with a local user. Use a custom `KUBECONFIG` to prevent overwrit
 the default one in case there is a problem.
 
 ```bash
-KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com:443 --user=alice
+KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com --user=alice
 ```
 
 Teleport updated `KUBECONFIG` with a short-lived 12-hour certificate.
@@ -336,13 +336,13 @@ the default one in case there is a problem.
 <Tabs>
   <TabItem label="Open Source">
     ```bash
-    KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com:443 --auth=github
+    KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com --auth=github
     ```
   </TabItem>
 
   <TabItem label="Enterprise">
     ```bash
-    KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com:443 --auth=okta
+    KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com --auth=okta
     ```
   </TabItem>
 </Tabs>

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -15,7 +15,7 @@ This guide introduces some of these common scenarios and how to interact with Te
 3. Introspecting the cluster using Teleport features.
 
 <Admonition type="tip" title="Tip">
-  This guide also demonstrates how to configure Teleport Nodes into the *Bastion* pattern so that [only a single Node can be accessed publicly](https://goteleport.com/blog/ssh-bastion-host/). 
+  This guide also demonstrates how to configure Teleport Nodes into the *Bastion* pattern so that [only a single Node can be accessed publicly](https://goteleport.com/blog/ssh-bastion-host/).
 </Admonition>
 
 <Figure
@@ -117,7 +117,7 @@ This guide introduces some of these common scenarios and how to interact with Te
 
 3. Configure Teleport on the *Bastion Host*.
 
-   Teleport will now automatically acquire an X.509 certificate using the ACME protocol. 
+   Teleport will now automatically acquire an X.509 certificate using the ACME protocol.
 
    ```bash
    # Configure Teleport with TLS certs
@@ -146,18 +146,18 @@ This guide introduces some of these common scenarios and how to interact with Te
    # Let's save the token to a file
    sudo tctl tokens add --type=node | grep -oP '(?<=token:\s).*' > token.file
    ```
- 
-   Each Teleport Node can be configured into SSH mode (Teleport Node) and run as an enhanced SSH server. "Node" mode specifies that the Teleport Node will act and join as an SSH server.  
-   
+
+   Each Teleport Node can be configured into SSH mode (Teleport Node) and run as an enhanced SSH server. "Node" mode specifies that the Teleport Node will act and join as an SSH server.
+
    `> token.file` indicates that you'd like to save the output to a file name `token.file`.
-  
+
    <Admonition type="tip" title="Tip">
-     This helps to minimize the direct sharing of tokens even when they are *dynamically* generated.   
+     This helps to minimize the direct sharing of tokens even when they are *dynamically* generated.
    </Admonition>
 
 2. Now, create a third terminal and connect to `tele.example.com`.
-   
-   - Save `token.file` to an appropriate, secure, directory you have the rights and access to read on the second instance. 
+
+   - Save `token.file` to an appropriate, secure, directory you have the rights and access to read on the second instance.
 
    ```bash
    # Join cluster
@@ -175,7 +175,7 @@ This guide introduces some of these common scenarios and how to interact with Te
    ```bash
    # Add a user
    sudo tctl users add tele-admin --roles=editor,access --logins=root,ubuntu,ec2-user
-   ```  
+   ```
 
    This will generate an initial login link where you can set a password and set up Two-Factor Authentication for `tele-admin`.
 
@@ -195,17 +195,17 @@ This guide introduces some of these common scenarios and how to interact with Te
 
 ## Step 3/4. SSH into the server
 
-Now, that we've got our cluster up and running, let's see how easy it is to connect to our two Nodes. 
+Now, that we've got our cluster up and running, let's see how easy it is to connect to our two Nodes.
 
 We can use `tsh` to SSH into the cluster:
 
-1. On your local machine, log in through `tsh`: 
+1. On your local machine, log in through `tsh`:
 
    ```bash
    # Log in through tsh
-   tsh login --proxy=tele.example.com:443 --user=tele-admin
+   tsh login --proxy=tele.example.com --user=tele-admin
    ```
-   
+
    You'll be prompted to supply the password and One Time Passcode we set up previously.
 
 2. `tele-admin` will now see:
@@ -232,11 +232,11 @@ We can use `tsh` to SSH into the cluster:
 
    The *Bastion Host* Node is located on the bottom line below:
 
-   ```bash                        
-   Node Name        Address        Labels                                 
-   ---------------- -------------- -------------------------------------- 
-   ip-172-31-35-170 ⟵ Tunnel                                              
-   ip-172-31-41-144 127.0.0.1:3022 env=example, hostname=ip-172-31-41-144 
+   ```bash
+   Node Name        Address        Labels
+   ---------------- -------------- --------------------------------------
+   ip-172-31-35-170 ⟵ Tunnel
+   ip-172-31-41-144 127.0.0.1:3022 env=example, hostname=ip-172-31-41-144
    ```
 
 4. `tele-admin` can SSH into the *Bastion Host* Node by running the following command locally:
@@ -248,12 +248,12 @@ We can use `tsh` to SSH into the cluster:
 
    Now, they can:
 
-   - Connect to other Nodes in the cluster by using the appropriate IP address in the `tsh ssh` command.  
-   - Traverse the Linux file system.  
-   - Execute desired commands.  
+   - Connect to other Nodes in the cluster by using the appropriate IP address in the `tsh ssh` command.
+   - Traverse the Linux file system.
+   - Execute desired commands.
 
    All commands executed by `tele-admin` are recorded and can be replayed in the Teleport Web interface.
-   
+
    The `tsh ssh` command allows one to do anything they would if they were to SSH into a server using a third-party tool. Compare the two equivalent commands:
 
 <Tabs>
@@ -273,7 +273,7 @@ We can use `tsh` to SSH into the cluster:
 
 1. Now, `tele-admin` has the ability to SSH into other Nodes within the cluster, traverse the Linux file system, and execute commands.
 
-   - They have visibility into all resources within the cluster due to their defined and assigned roles.  
+   - They have visibility into all resources within the cluster due to their defined and assigned roles.
    - They can also quickly view any Node or grouping of Nodes that've been assigned a `label`.
 
 2. Execute the following command within your *Bastion Host* console:
@@ -283,13 +283,13 @@ We can use `tsh` to SSH into the cluster:
    sudo tctl nodes ls
    ```
 
-   It displays the unified resource catalog with all queried resources in one view: 
-   
+   It displays the unified resource catalog with all queried resources in one view:
+
    ```bash
-   Nodename         UUID                                 Address        Labels                                
-   ---------------- ------------------------------------ -------------- ------------------------------------- 
-   ip-172-31-35-170 4980899c-d260-414f-9aea-874feef71747                                                      
-   ip-172-31-41-144 f3d2a65f-3fa7-451d-b516-68d189ff9ae5 127.0.0.1:3022 env=example,hostname=ip-172-31-41-144                            
+   Nodename         UUID                                 Address        Labels
+   ---------------- ------------------------------------ -------------- -------------------------------------
+   ip-172-31-35-170 4980899c-d260-414f-9aea-874feef71747
+   ip-172-31-41-144 f3d2a65f-3fa7-451d-b516-68d189ff9ae5 127.0.0.1:3022 env=example,hostname=ip-172-31-41-144
    ```
 
 3. Note the "Labels" column on the farthest side. `tele-admin` can query all resources with a shared [label](../admin-guide.mdx#labeling-nodes-and-applications) using the command:
@@ -299,8 +299,8 @@ We can use `tsh` to SSH into the cluster:
    tsh ls env=example
    ```
 
-   - Customized labels can be defined in your `teleport.yaml` configuration file or during Node creation.  
-   - This is a convenient feature that allows for more advanced queries.  
+   - Customized labels can be defined in your `teleport.yaml` configuration file or during Node creation.
+   - This is a convenient feature that allows for more advanced queries.
    - Suppose an IP address changes, an admin can quickly find the current Node with that label since it remains unchanged.
 
 4. `tele-admin` can also execute commands on all Nodes that share a label vastly simplifying repeated operations. For example, the command:
@@ -308,8 +308,8 @@ We can use `tsh` to SSH into the cluster:
    ```bash
    # Run the ls command on all Nodes with a label
    tsh ssh root@env=example ls
-   ``` 
-   
+   ```
+
    will execute the `ls` command on each Node displaying the contents of each to the screen.
 
 ## Conclusion
@@ -319,9 +319,9 @@ We can use `tsh` to SSH into the cluster:
 
    If you'd like to further experiment with using Teleport according to the *Bastion* pattern:
 
-   - Close port `22` on your second, private, Linux instance now that your Node is configured and running.  
-   - Optionally close port `22` on your *Bastion Host*.  
-   - You'll be able to fully connect to both the *Bastion Host* and the private instance using `tsh ssh`.  
+   - Close port `22` on your second, private, Linux instance now that your Node is configured and running.
+   - Optionally close port `22` on your *Bastion Host*.
+   - You'll be able to fully connect to both the *Bastion Host* and the private instance using `tsh ssh`.
 </Admonition>
 
 To recap, this Getting Started Guide described:
@@ -333,12 +333,12 @@ Feel free to shut down, clean up, and delete your resources or use them in furth
 
 ## Next steps
 
-- Learn more about Teleport `tsh` through the [reference documentation](../setup/reference/cli.mdx#tsh-ssh).  
+- Learn more about Teleport `tsh` through the [reference documentation](../setup/reference/cli.mdx#tsh-ssh).
 - Learn more about [Teleport Nodes](../architecture/nodes.mdx#connecting-to-nodes)
 - For a complete list of ports used by Teleport, read [The Admin Guide](../admin-guide.mdx#ports).
 
 ## Resources
 
-- [Announcing Teleport SSH Server](https://goteleport.com/blog/announcing-teleport-ssh-server/)  
+- [Announcing Teleport SSH Server](https://goteleport.com/blog/announcing-teleport-ssh-server/)
 - [How to SSH properly](https://goteleport.com/blog/how-to-ssh-properly/)
 - Consider whether [OpenSSH or Teleport SSH](https://goteleport.com/blog/openssh-vs-teleport/) is right for you.

--- a/docs/pages/setup/deployments/aws-terraform.mdx
+++ b/docs/pages/setup/deployments/aws-terraform.mdx
@@ -489,7 +489,7 @@ You can [download the Teleport package containing the `tsh` client from here](ht
 - the client is the same for both OSS and Enterprise versions of Teleport.
 
 ```bash
-$ tsh login --proxy=${TF_VAR_route53_domain}:443 --user=teleport-admin
+$ tsh login --proxy=${TF_VAR_route53_domain} --user=teleport-admin
 Enter password for Teleport user teleport-admin:
 Enter your OTP token:
 567989

--- a/docs/pages/setup/guides/docker.mdx
+++ b/docs/pages/setup/guides/docker.mdx
@@ -63,7 +63,7 @@ https://localhost:3080/web/invite/4f2718a52ce107568b191f222ba069f7
 NOTE: Make sure localhost:3080 points at a Teleport proxy which users can access.
 ```
 
-The Web UI will be available at the displayed URL. 
+The Web UI will be available at the displayed URL.
 
 (!docs/pages/includes/insecure-certificate.mdx!)
 
@@ -76,7 +76,7 @@ Finish signing up and creating your user using the generated link created previo
 Open a second terminal and issue the command:
 
 ```bash
-tsh login --proxy=localhost:3080 --insecure --user=testuser
+tsh login --proxy=localhost --insecure --user=testuser
 ```
 
 <Admonition type="note" title="Note">
@@ -113,9 +113,9 @@ tsh ls
 
 ```
 # Output
-Node Name Address        Labels                          
---------- -------------- ------------------------------- 
-localhost 127.0.0.1:3022 env=example, hostname=localhost 
+Node Name Address        Labels
+--------- -------------- -------------------------------
+localhost 127.0.0.1:3022 env=example, hostname=localhost
 ```
 
 To SSH into the local Node `localhost` (running in your Docker container) issue the following `tsh` command:
@@ -127,7 +127,7 @@ tsh ssh root@localhost
 This will bring up the Linux command prompt where you can issue Bash commands, traverse the directory tree, and explore the container contents:
 
 ```bash
-root@localhost:~# 
+root@localhost:~#
 ```
 
 ## Next steps


### PR DESCRIPTION
backport of #8011 