### PR TITLE
Make teleport-kube-agent use persistence by default.

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -1446,7 +1446,7 @@ These labels can then be used with Teleport's RBAC policies to define access rul
 
 | Type | Default value |
 | - | - |
-| `bool` | `false` |
+| `bool` | `true` |
 
 Enables the creation of a Kubernetes persistent volume to hold Teleport agent state.
 

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -1450,18 +1450,23 @@ These labels can then be used with Teleport's RBAC policies to define access rul
 
 Enables the creation of a Kubernetes persistent volume to hold Teleport agent state.
 
+<Admonition type="note">
+    If you do not want to persist the Teleport agent state, or if your Kubernetes cluster does not have any storage
+    class available, set this to `false`.
+</Admonition>
+
 [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
 
 <Tabs>
   <TabItem label="values.yaml">
   ```yaml
   storage:
-    enabled: true
+    enabled: false
   ```
   </TabItem>
   <TabItem label="--set">
   ```bash
-  --set storage.enabled=true
+  --set storage.enabled=false
   ```
   </TabItem>
 </Tabs>
@@ -1472,8 +1477,8 @@ Enables the creation of a Kubernetes persistent volume to hold Teleport agent st
 | - | - |
 | `string` | `nil` |
 
-The storage class name the persistent volume should use when creating persistent volume claims. The provided storage class
-name needs to exist on the Kubernetes cluster for Teleport to use.
+The storage class name the persistent volume should use when creating persistent volume claims. If left blank, the cluster's
+default storage class will be used. The provided storage class name needs to exist on the Kubernetes cluster for Teleport to use.
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/storage-classes/)
 

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -14,10 +14,9 @@ To use it, you will need:
 - either a static or dynamic join token for the Teleport Cluster
   - a [static join token](https://goteleport.com/teleport/docs/admin-guide/#adding-nodes-to-the-cluster)
     for this Teleport cluster (`$JOIN_TOKEN`) is used by default.
-  - optionally a [dynamic join token](https://goteleport.com/teleport/docs/admin-guide/#adding-nodes-to-the-cluster) can
-    be used on Kubernetes clusters that support persistent volumes. Set `storage.enabled=true` and 
-    `storage.storageClassName=<storage class configured in kubernetes>` in the helm configuration to use persistent 
-    volumes.
+  - a [dynamic join token](https://goteleport.com/teleport/docs/admin-guide/#adding-nodes-to-the-cluster) can
+    be used on Kubernetes clusters that support persistent volumes.
+- A working kubernetes storageclass to persist the uuid and state of the teleport agent. You can optionally disable this for ephemeral use cases where persistence isn't necessary or for kubernetes clusters without persistent storage. Set `storage.storageClassName=<storage class configured in kubernetes>` to use a non-default storageclass in your cluster. Set `storage.enabled=false` in the helm configuration to disable persistent storage altogether.
 
 
 ## Combining roles

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -139,7 +139,9 @@ spec:
       name: "{{ .Release.Name }}-teleport-data"
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      {{- if .Values.storage.storageClassName }}
       storageClassName: {{ .Values.storage.storageClassName }}
+      {{- end}}
       resources:
         requests:
           storage: {{ .Values.storage.requests }}

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -77,7 +77,7 @@ labels: {}
 #   requests: The size of the volume to request from the persistent storage system
 ################################################################
 storage:
-  enabled: false
+  enabled: true
   storageClassName: ""
   requests: 128Mi
 


### PR DESCRIPTION
Benefits:

* This enables best practice to use dynamic tokens wherever possible.
* It helps avoid situations where a simple config change creates a "duplicate" resource while the 10-30 minutes pass to let the old resource expire