### PR TITLE
Adds LoadIdentityFileFromString to API client

### DIFF
--- a/api/client/credentials_test.go
+++ b/api/client/credentials_test.go
@@ -97,6 +97,52 @@ func TestLoadIdentityFile(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestLoadIdentityFileFromString(t *testing.T) {
+	t.Parallel()
+
+	// Load expected tls.Config and ssh.ClientConfig.
+	expectedTLSConfig := getExpectedTLSConfig(t)
+	expectedSSHConfig := getExpectedSSHConfig(t)
+
+	// Write identity file to disk.
+	path := filepath.Join(t.TempDir(), "file")
+	idFile := &identityfile.IdentityFile{
+		PrivateKey: keyPEM,
+		Certs: identityfile.Certs{
+			TLS: tlsCert,
+			SSH: sshCert,
+		},
+		CACerts: identityfile.CACerts{
+			TLS: [][]byte{tlsCACert},
+			SSH: [][]byte{sshCACert},
+		},
+	}
+	err := identityfile.Write(idFile, path)
+	require.NoError(t, err)
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	// Load identity file from disk.
+	creds := LoadIdentityFileFromString(string(b))
+	// Build tls.Config and compare to expected tls.Config.
+	tlsConfig, err := creds.TLSConfig()
+	require.NoError(t, err)
+	requireEqualTLSConfig(t, expectedTLSConfig, tlsConfig)
+
+	// Build ssh.ClientConfig and compare to expected ssh.ClientConfig.
+	sshConfig, err := creds.SSHClientConfig()
+	require.NoError(t, err)
+	requireEqualSSHConfig(t, expectedSSHConfig, sshConfig)
+
+	// Load invalid identity.
+	creds = LoadIdentityFileFromString("invalid_creds")
+	_, err = creds.TLSConfig()
+	require.Error(t, err)
+	_, err = creds.SSHClientConfig()
+	require.Error(t, err)
+}
+
 func TestLoadKeyPair(t *testing.T) {
 	t.Parallel()
 

--- a/api/client/doc_test.go
+++ b/api/client/doc_test.go
@@ -6,6 +6,7 @@ package client_test
 import (
 	"context"
 	"log"
+	"os"
 	"time"
 
 	"github.com/gravitational/teleport/api/client"
@@ -99,6 +100,7 @@ func ExampleNew() {
 			client.LoadProfile("", ""),
 			client.LoadIdentityFile("identity-path"),
 			client.LoadKeyPair("cert.crt", "cert.key", "cert.cas"),
+			client.LoadIdentityFileFromString(os.Getenv("TELEPORT_IDENTITY")),
 		},
 		// set to true if your web proxy doesn't have HTTP/TLS certificate
 		// configured yet (never use this in production).
@@ -137,6 +139,20 @@ func ExampleCredentials_loadIdentity() {
 // Load credentials from the specified identity file.
 func ExampleLoadIdentityFile() {
 	client.LoadIdentityFile("identity-file-path")
+}
+
+// Generate identity file with tsh or tctl.
+//  $ tsh login --user=api-user --out=identity-file-path
+//  $ tctl auth sign --user=api-user --out=identity-file-path
+//  $ export TELEPORT_IDENTITY=$(cat identity-file-path)
+// Load credentials from the envrironment variable.
+func ExampleCredentials_loadIdentityString() {
+	client.LoadIdentityFileFromString(os.Getenv("TELEPORT_IDENTITY"))
+}
+
+// Load credentials from the specified environment variable.
+func ExampleLoadIdentityFileFromString() {
+	client.LoadIdentityFileFromString(os.Getenv("TELEPORT_IDENTITY"))
 }
 
 // Generate certificate key pair with tctl.

--- a/api/identityfile/identityfile_test.go
+++ b/api/identityfile/identityfile_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package identityfile_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -46,10 +47,17 @@ func TestIdentityFileBasics(t *testing.T) {
 	err := identityfile.Write(writeIDFile, path)
 	require.NoError(t, err)
 
-	// Read identity file
-	readIDFile, err := identityfile.Read(path)
+	// Read identity file from file
+	readIDFile, err := identityfile.ReadFile(path)
+	require.NoError(t, err)
+
+	// Read identity file from string
+	s, err := os.ReadFile(path)
+	require.NoError(t, err)
+	fromStringIDFile, err := identityfile.FromString(string(s))
 	require.NoError(t, err)
 
 	// Check that read and write values are equal
 	require.Equal(t, writeIDFile, readIDFile)
+	require.Equal(t, writeIDFile, fromStringIDFile)
 }

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -107,7 +107,7 @@ func NewKey() (key *Key, err error) {
 // KeyFromIdentityFile loads the private key + certificate
 // from an identity file into a Key.
 func KeyFromIdentityFile(path string) (*Key, error) {
-	ident, err := identityfile.Read(path)
+	ident, err := identityfile.ReadFile(path)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to parse identity file")
 	}


### PR DESCRIPTION
What's inside:

- [x] `LoadIdentityFileFromString` which accepts string as the single argument and returns valid `Credentials` instance. This is required for Terraform Enterprise which, in turn, obliges to store identity in env var.
- [x] `identityfile.Read(io.Reader)`, `identityfile.ReadFile(path string)`, `identityfile.FromString(s string)`. I've changed public interface. This interface is used directly only in lib/client/interfaces.go (auth wrapper for all tools). Updated it as well. Looks working for me.

I think, it makes not much sense to do the same for TLS auth unless we have special request on this from a customer.