### PR TITLE
Patch test that isn't compiling on v6.2

### DIFF
--- a/api/types/saml_test.go
+++ b/api/types/saml_test.go
@@ -24,14 +24,13 @@ import (
 
 // TestSAMLSecretsStrip tests the WithoutSecrets method on SAMLConnectorV2.
 func TestSAMLSecretsStrip(t *testing.T) {
-	connector, err := NewSAMLConnector("test", SAMLConnectorSpecV2{
+	connector := NewSAMLConnector("test", SAMLConnectorSpecV2{
 		AssertionConsumerService: "test",
 		SSO:                      "test",
 		EntityDescriptor:         "test",
 		SigningKeyPair:           &AsymmetricKeyPair{PrivateKey: "test"},
 		EncryptionKeyPair:        &AsymmetricKeyPair{PrivateKey: "test"},
 	})
-	require.Nil(t, err)
 	require.Equal(t, connector.GetSigningKeyPair().PrivateKey, "test")
 	require.Equal(t, connector.GetEncryptionKeyPair().PrivateKey, "test")
 


### PR DESCRIPTION
Somehow CI allowed #7858 to merge to v6.2 despite a test not compiling. This is uh, wierd to say the least but this PR makes the test compile.