### PR TITLE
Adapt lib/auth/webauthn to Identity and type changes

### DIFF
--- a/lib/auth/webauthn/config.go
+++ b/lib/auth/webauthn/config.go
@@ -19,6 +19,7 @@ package webauthn
 import (
 	"github.com/duo-labs/webauthn/protocol"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
 
 	wan "github.com/duo-labs/webauthn/webauthn"
 )
@@ -39,5 +40,6 @@ func newWebAuthn(cfg *types.Webauthn, rpID, origin string) (*wan.WebAuthn, error
 		RPDisplayName:         defaultDisplayName,
 		RPIcon:                defaultIcon,
 		AttestationPreference: attestation,
+		Timeout:               int(defaults.WebauthnChallengeTimeout.Milliseconds()),
 	})
 }

--- a/lib/auth/webauthn/config.go
+++ b/lib/auth/webauthn/config.go
@@ -18,6 +18,7 @@ package webauthn
 
 import (
 	"github.com/duo-labs/webauthn/protocol"
+	"github.com/gravitational/teleport/api/types"
 
 	wan "github.com/duo-labs/webauthn/webauthn"
 )
@@ -27,14 +28,7 @@ const (
 	defaultIcon        = ""
 )
 
-// Config represents the Webauthn configuration.
-// TODO(codingllama): Replace with types.Webauthn once it's merged.
-type Config struct {
-	RPID                                        string
-	AttestationAllowedCAs, AttestationDeniedCAs []string
-}
-
-func newWebAuthn(cfg *Config, rpID, origin string) (*wan.WebAuthn, error) {
+func newWebAuthn(cfg *types.Webauthn, rpID, origin string) (*wan.WebAuthn, error) {
 	attestation := protocol.PreferNoAttestation
 	if len(cfg.AttestationAllowedCAs) > 0 || len(cfg.AttestationDeniedCAs) > 0 {
 		attestation = protocol.PreferDirectAttestation

--- a/lib/auth/webauthn/login_identity_test.go
+++ b/lib/auth/webauthn/login_identity_test.go
@@ -19,4 +19,5 @@ import (
 )
 
 // Assert that Identity satisfies loginIdentity.
+// TODO(codingllama): Delete once real code wires Identity to loginIdentity.
 var _ loginIdentity = services.Identity(nil)

--- a/lib/auth/webauthn/login_identity_test.go
+++ b/lib/auth/webauthn/login_identity_test.go
@@ -1,0 +1,22 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthn
+
+import (
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// Assert that Identity satisfies loginIdentity.
+var _ loginIdentity = services.Identity(nil)

--- a/lib/auth/webauthn/login_test.go
+++ b/lib/auth/webauthn/login_test.go
@@ -79,6 +79,8 @@ func TestLoginFlow_BeginFinish_u2f(t *testing.T) {
 	require.Equal(t, u2fConfig.AppID, assertion.Response.Extensions["appid"])
 	// Did we record the SessionData in storage?
 	require.Len(t, identity.SessionData, 1)
+	// Retrieve session data without guessing the "sessionID" component of the
+	// key.
 	var sd *wantypes.SessionData
 	for _, v := range identity.SessionData {
 		sd = v

--- a/lib/auth/webauthn/login_test.go
+++ b/lib/auth/webauthn/login_test.go
@@ -61,7 +61,7 @@ func TestLoginFlow_BeginFinish_u2f(t *testing.T) {
 	}
 
 	u2fConfig := types.U2F{AppID: "https://example.com:3080"}
-	webConfig := wanlib.Config{RPID: "example.com"}
+	webConfig := types.Webauthn{RPID: "example.com"}
 	webLogin := wanlib.LoginFlow{
 		U2F:      &u2fConfig,
 		Webauthn: &webConfig,
@@ -135,7 +135,7 @@ func (f *fakeIdentity) GetUser(user string, withSecrets bool) (types.User, error
 	return f.User, nil
 }
 
-func (f *fakeIdentity) GetMFADevices(ctx context.Context, user string) ([]*types.MFADevice, error) {
+func (f *fakeIdentity) GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error) {
 	return f.User.GetLocalAuth().MFA, nil
 }
 
@@ -144,12 +144,12 @@ func (f *fakeIdentity) UpsertMFADevice(ctx context.Context, user string, d *type
 	return nil
 }
 
-func (f *fakeIdentity) UpsertWebAuthnSessionData(user, sessionID string, sd *wantypes.SessionData) error {
+func (f *fakeIdentity) UpsertWebauthnSessionData(ctx context.Context, user, sessionID string, sd *wantypes.SessionData) error {
 	f.SessionData[sessionDataKey(user, sessionID)] = sd
 	return nil
 }
 
-func (f *fakeIdentity) GetWebAuthnSessionData(user, sessionID string) (*wantypes.SessionData, error) {
+func (f *fakeIdentity) GetWebauthnSessionData(ctx context.Context, user, sessionID string) (*wantypes.SessionData, error) {
 	sd, ok := f.SessionData[sessionDataKey(user, sessionID)]
 	if !ok {
 		return nil, trace.NotFound("not found")
@@ -157,7 +157,7 @@ func (f *fakeIdentity) GetWebAuthnSessionData(user, sessionID string) (*wantypes
 	return sd, nil
 }
 
-func (f *fakeIdentity) DeleteWebAuthnSessionData(user, sessionID string) error {
+func (f *fakeIdentity) DeleteWebauthnSessionData(ctx context.Context, user, sessionID string) error {
 	delete(f.SessionData, sessionDataKey(user, sessionID))
 	return nil
 }

--- a/lib/auth/webauthn/user.go
+++ b/lib/auth/webauthn/user.go
@@ -17,44 +17,72 @@ limitations under the License.
 package webauthn
 
 import (
+	"context"
+
+	"github.com/google/uuid"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
 
 	wan "github.com/duo-labs/webauthn/webauthn"
 )
+
+// userIDStorage is used to keep getOrCreateUserWebauthnID as focused as
+// possible, since it's used both by login and registration.
+type userIDStorage interface {
+	UpsertWebauthnLocalAuth(ctx context.Context, user string, wla *types.WebauthnLocalAuth) error
+	GetWebauthnLocalAuth(ctx context.Context, user string) (*types.WebauthnLocalAuth, error)
+}
+
+func getOrCreateUserWebauthnID(ctx context.Context, user string, identity userIDStorage) ([]byte, error) {
+	wla, err := identity.GetWebauthnLocalAuth(ctx, user)
+	switch {
+	case trace.IsNotFound(err): // first-time user, create a new ID
+		webID := uuid.New()
+		err := identity.UpsertWebauthnLocalAuth(ctx, user, &types.WebauthnLocalAuth{
+			UserID: webID[:],
+		})
+		return webID[:], trace.Wrap(err)
+	case err != nil:
+		return nil, trace.Wrap(err)
+	default:
+		return wla.UserID, nil
+	}
+}
 
 // webUser implements a WebAuthn protocol user.
 // It is used to provide user information to WebAuthn APIs, but has no direct
 // counterpart in storage nor in other packages.
 type webUser struct {
 	credentials []wan.Credential
-	user        types.User
+	name        string
+	webID       []byte
 }
 
-func newWebUser(user types.User, idOnly bool, devices []*types.MFADevice) *webUser {
+func newWebUser(name string, webID []byte, credentialIDOnly bool, devices []*types.MFADevice) *webUser {
 	var credentials []wan.Credential
 	for _, dev := range devices {
-		c, ok := deviceToCredential(dev, idOnly)
+		c, ok := deviceToCredential(dev, credentialIDOnly)
 		if ok {
 			credentials = append(credentials, c)
 		}
 	}
 	return &webUser{
 		credentials: credentials,
-		user:        user,
+		name:        name,
+		webID:       webID,
 	}
 }
 
 func (w *webUser) WebAuthnID() []byte {
-	// TODO(codingllama): Create and initialize WebAuthn ID
-	return []byte(w.user.GetName())
+	return w.webID
 }
 
 func (w *webUser) WebAuthnName() string {
-	return w.user.GetName()
+	return w.name
 }
 
 func (w *webUser) WebAuthnDisplayName() string {
-	return w.user.GetName()
+	return w.name
 }
 
 func (w *webUser) WebAuthnIcon() string {

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -534,7 +534,6 @@ const (
 	U2FChallengeTimeout = 5 * time.Minute
 	// WebauthnChallengeTimeout is the timeout for ongoing Webauthn authentication
 	// or registration challenges.
-	// TODO(codingllama): Apply this to the lib/auth/webauthn package.
 	WebauthnChallengeTimeout = 5 * time.Minute
 )
 


### PR DESCRIPTION
Adjust lib/auth/webauthn to correctly match Identity methods (interfaces
deviated a little during reviews) and make use of WebauthnLocalAuth to create
and record Webauthn user IDs.