### PR TITLE
Add remote user (%r) to the exported ssh config.

### DIFF
--- a/tool/tsh/config.go
+++ b/tool/tsh/config.go
@@ -36,9 +36,9 @@ Host *.{{ .clusterName }} {{ .proxyHost }}
 Host *.{{ .clusterName }} !{{ .proxyHost }}
     Port 3022
     {{- if .leaf }}
-    ProxyCommand ssh -p {{ .proxyPort }} {{ .proxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p@{{ .clusterName }}	
+    ProxyCommand ssh -p {{ .proxyPort }} %r@{{ .proxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p@{{ .clusterName }}	
     {{- else }}
-    ProxyCommand ssh -p {{ .proxyPort }} {{ .proxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p
+    ProxyCommand ssh -p {{ .proxyPort }} %r@{{ .proxyHost }} -s proxy:$(echo %h | cut -d '.' -f 1):%p
     {{- end }}
 `
 


### PR DESCRIPTION
In my setup, my local username does not match my teleport username or any of the permitted remote users in any roles because my identity is coming from an OIDC provider.

| Description       | Value               |
| ----------------- | ------------------- |
| Local User    | `foobar`              |
| Teleport User (OIDC) | `foobar@example.com`  |
| Teleport Proxy    | `example.teleport.sh` |
| Remote User   | `root`               |

Adding the `%r` directive to the ssh config switches the username to one that my cloud-hosted teleport proxy accepts, while it will reject me if I omit it and ssh defaults to using my local system username. I have tested this with multiple remote users, including `root`.

Here is an ssh log if I omit the directive:

<details>
<summary><i>(click to expand)</i></summary>

```
$ ssh -vvvv -A root@testmachine.example.teleport.sh
OpenSSH_7.6p1 Ubuntu-4ubuntu0.5, OpenSSL 1.0.2n  7 Dec 2017
debug1: Reading configuration data /home/foobar/.ssh/config
debug3: /home/foobar/.ssh/config line 1: Including file /home/foobar/.ssh/config.d/teleport depth 0
debug1: Reading configuration data /home/foobar/.ssh/config.d/teleport
debug1: /home/foobar/.ssh/config.d/teleport line 6: Applying options for *.example.teleport.sh
debug1: /home/foobar/.ssh/config.d/teleport line 10: Applying options for *.example.teleport.sh
debug1: /home/foobar/.ssh/config line 12: Applying options for testmachine.example.teleport.sh
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: /etc/ssh/ssh_config line 19: Applying options for *
debug1: Executing proxy command: exec ssh -p 3023 example.teleport.sh -s proxy:$(echo testmachine.example.teleport.sh | cut -d '.' -f 1):3022
debug1: permanently_drop_suid: 1553201121
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_rsa type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_rsa-cert type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_dsa type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_dsa-cert type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_ecdsa type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_ecdsa-cert type -1
debug1: identity file /home/foobar/.ssh/id_ed25519 type 3
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_ed25519-cert type -1
debug1: Local version string SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.5
foobar@example.teleport.sh: Permission denied (publickey).
ssh_exchange_identification: Connection closed by remote host
```

</details>

Here is the same command when using the <b>%r</b> directive:

<details>
<summary><i>(click to expand)</i></summary>

```
$ ssh -vvvv -A root@testmachine.example.teleport.sh
OpenSSH_7.6p1 Ubuntu-4ubuntu0.5, OpenSSL 1.0.2n  7 Dec 2017
debug1: Reading configuration data /home/foobar/.ssh/config
debug3: /home/foobar/.ssh/config line 1: Including file /homefoobar/.ssh/config.d/teleport depth 0
debug1: Reading configuration data /home/foobar/.ssh/config.d/teleport
debug1: /home/foobar/.ssh/config.d/teleport line 6: Applying options for *.example.teleport.sh
debug1: /home/foobar/.ssh/config.d/teleport line 10: Applying options for *.example.teleport.sh
debug1: /home/foobar/.ssh/config line 12: Applying options for testmachine.example.teleport.sh
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: /etc/ssh/ssh_config line 19: Applying options for *
debug1: Executing proxy command: exec ssh -p 3023 root@example.teleport.sh -s proxy:$(echo testmachine.example.teleport.sh | cut -d '.' -f 1):3022
debug1: permanently_drop_suid: 1553201121
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_rsa type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_rsa-cert type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_dsa type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_dsa-cert type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_ecdsa type -1
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_ecdsa-cert type -1
debug1: identity file /home/foobar/.ssh/id_ed25519 type 3
debug1: key_load_public: No such file or directory
debug1: identity file /home/foobar/.ssh/id_ed25519-cert type -1
debug1: Local version string SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.5
debug1: Remote protocol version 2.0, remote software version Teleport
debug1: no match: Teleport
debug2: fd 6 setting O_NONBLOCK
debug2: fd 5 setting O_NONBLOCK
debug1: Authenticating to testmachine.example.teleport.sh:3022 as 'root'
debug3: put_host_port: [testmachine.example.teleport.sh]:3022
debug3: hostkeys_foreach: reading file "/home/foobar/.tsh/known_hosts"
debug3: send packet: type 20
debug1: SSH2_MSG_KEXINIT sent
debug3: receive packet: type 20
debug1: SSH2_MSG_KEXINIT received
debug2: local client KEXINIT proposal
debug2: KEX algorithms: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1,ext-info-c
debug2: host key algorithms: ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
debug2: ciphers ctos: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
debug2: ciphers stoc: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
debug2: MACs ctos: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
debug2: MACs stoc: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
debug2: compression ctos: none,zlib@openssh.com,zlib
debug2: compression stoc: none,zlib@openssh.com,zlib
debug2: languages ctos:
debug2: languages stoc:
debug2: first_kex_follows 0
debug2: reserved 0
debug2: peer server KEXINIT proposal
debug2: KEX algorithms: curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521
debug2: host key algorithms: ssh-rsa-cert-v01@openssh.com
debug2: ciphers ctos: aes128-gcm@openssh.com,chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr
debug2: ciphers stoc: aes128-gcm@openssh.com,chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr
debug2: MACs ctos: hmac-sha2-256-etm@openssh.com,hmac-sha2-256
debug2: MACs stoc: hmac-sha2-256-etm@openssh.com,hmac-sha2-256
debug2: compression ctos: none
debug2: compression stoc: none
debug2: languages ctos:
debug2: languages stoc:
debug2: first_kex_follows 0
debug2: reserved 0
debug1: kex: algorithm: curve25519-sha256@libssh.org
debug1: kex: host key algorithm: ssh-rsa-cert-v01@openssh.com
debug1: kex: server->client cipher: chacha20-poly1305@openssh.com MAC: <implicit> compression: none
debug1: kex: client->server cipher: chacha20-poly1305@openssh.com MAC: <implicit> compression: none
debug3: send packet: type 30
debug1: expecting SSH2_MSG_KEX_ECDH_REPLY
debug3: receive packet: type 31
debug1: Server host certificate: ssh-rsa-cert-v01@openssh.com SHA256:qxoiMCLqMztUeRS/RP0tlfdNZE4IFUwhexTCoWLnT+E, serial 0 ID "" CA ssh-rsa SHA256:w+Xq3/6j2QblHDN3YOHXbhIDoHD/aOD+50mNV1d01KE valid after 2021-06-21T12:23:23
debug2: Server host certificate hostname: ccd8b79a-4d26-4ad9-bec5-665fdc2ed05f.example.teleport.sh
debug2: Server host certificate hostname: ccd8b79a-4d26-4ad9-bec5-665fdc2ed05f
debug2: Server host certificate hostname: testmachine.example.teleport.sh
debug2: Server host certificate hostname: testmachine
debug2: Server host certificate hostname: localhost
debug2: Server host certificate hostname: 127.0.0.1
debug2: Server host certificate hostname: ::1
debug3: put_host_port: [testmachine.example.teleport.sh]:3022
debug3: hostkeys_foreach: reading file "/home/foobar/.tsh/known_hosts"
debug1: checking without port identifier
debug3: hostkeys_foreach: reading file "/home/foobar/.tsh/known_hosts"
debug3: record_hostkey: found ca key type RSA in file /home/foobar/.tsh/known_hosts:1
debug3: load_hostkeys: loaded 1 keys from testmachine.example.teleport.sh
debug1: Host 'testmachine.example.teleport.sh' is known and matches the RSA-CERT host certificate.
debug1: Found CA key in /home/foobar/.tsh/known_hosts:1
debug1: found matching key w/out port
debug3: send packet: type 21
debug2: set_newkeys: mode 1
debug1: rekey after 134217728 blocks
debug1: SSH2_MSG_NEWKEYS sent
debug1: expecting SSH2_MSG_NEWKEYS
debug3: receive packet: type 21
debug1: SSH2_MSG_NEWKEYS received
debug2: set_newkeys: mode 0
debug1: rekey after 134217728 blocks
debug2: key: /home/foobar/.ssh/id_ed25519 (0x55e16b341f10), agent
debug2: key: foobar@lt1tbqq13 (0x55e16b34fad0), agent
debug2: key: teleport:foobar@example.com (0x55e16b353320), agent
debug2: key: teleport:foobar@example.com (0x55e16b34f3d0), agent
debug2: key: foobar@lt1tbqq13 (0x55e16b3517c0), agent
debug2: key: /home/foobar/.ssh/id_rsa ((nil))
debug2: key: /home/foobar/.ssh/id_dsa ((nil))
debug2: key: /home/foobar/.ssh/id_ecdsa ((nil))
debug3: send packet: type 5
debug3: receive packet: type 6
debug2: service_accept: ssh-userauth
debug1: SSH2_MSG_SERVICE_ACCEPT received
debug3: send packet: type 50
debug3: receive packet: type 51
debug1: Authentications that can continue: publickey
debug3: start over, passed a different list publickey
debug3: preferred gssapi-keyex,gssapi-with-mic,publickey,keyboard-interactive,password
debug3: authmethod_lookup publickey
debug3: remaining preferred: keyboard-interactive,password
debug3: authmethod_is_enabled publickey
debug1: Next authentication method: publickey
debug1: Offering public key: ED25519 SHA256:SGIs83s/1RYSWQMx+8Y3rnbZvFoKiFB3iweJaBX1sb0 /home/foobar/.ssh/id_ed25519
debug3: send_pubkey_test
debug3: send packet: type 50
debug2: we sent a publickey packet, wait for reply
debug3: receive packet: type 51
debug1: Authentications that can continue: publickey
debug1: Offering public key: ED25519 SHA256:VuFCN8TDmNc3IF1amu2i15XF5kjdHdAF+Y/TbaDfd38 foobar@lt1tbqq13
debug3: send_pubkey_test
debug3: send packet: type 50
debug2: we sent a publickey packet, wait for reply
debug3: receive packet: type 51
debug1: Authentications that can continue: publickey
debug1: Offering public key: RSA-CERT SHA256:5a4TCy6aPnXg2I71npdPSiwx51Arxlx0eofH4CadiIs teleport:foobar@example.com
debug3: send_pubkey_test
debug3: send packet: type 50
debug2: we sent a publickey packet, wait for reply
debug3: receive packet: type 60
debug1: Server accepts key: pkalg ssh-rsa-cert-v01@openssh.com blen 1664
debug2: input_userauth_pk_ok: fp SHA256:5a4TCy6aPnXg2I71npdPSiwx51Arxlx0eofH4CadiIs
debug3: sign_and_send_pubkey: RSA-CERT SHA256:5a4TCy6aPnXg2I71npdPSiwx51Arxlx0eofH4CadiIs
debug2: sign_and_send_pubkey: using private key "teleport:foobar@example.com" from agent for certificate
debug3: send packet: type 50
debug3: receive packet: type 52
debug1: Authentication succeeded (publickey).
Authenticated to testmachine.example.teleport.sh (via proxy).
debug1: channel 0: new [client-session]
debug3: ssh_session2_open: channel_new: 0
debug2: channel 0: send open
debug3: send packet: type 90
debug1: Entering interactive session.
debug1: pledge: proc
debug3: receive packet: type 91
debug2: channel_input_open_confirmation: channel 0: callback start
debug1: Requesting authentication agent forwarding.
debug2: channel 0: request auth-agent-req@openssh.com confirm 0
debug3: send packet: type 98
debug2: client_session2_setup: id 0
debug2: channel 0: request pty-req confirm 1
debug3: send packet: type 98
debug1: Sending environment.
debug3: Ignored env CLUTTER_IM_MODULE
debug3: Ignored env NVM_DIR
debug3: Ignored env LS_COLORS
debug3: Ignored env LESSCLOSE
debug3: Ignored env TERMINATOR_UUID
debug3: Ignored env XDG_MENU_PREFIX
debug1: Sending env LANG = en_US.UTF-8
debug2: channel 0: request env confirm 0
debug3: send packet: type 98
debug3: Ignored env DISPLAY
debug3: Ignored env KUBECONFIG
debug3: Ignored env GNOME_SHELL_SESSION_MODE
debug3: Ignored env COLORTERM
debug3: Ignored env NVM_CD_FLAGS
debug3: Ignored env USERNAME
debug3: Ignored env XDG_VTNR
debug3: Ignored env GIO_LAUNCHED_DESKTOP_FILE_PID
debug3: Ignored env SSH_AUTH_SOCK
debug3: Ignored env MANDATORY_PATH
debug3: Ignored env VAULT_CACERT
debug3: Ignored env XDG_SESSION_ID
debug3: Ignored env USER
debug3: Ignored env DESKTOP_SESSION
debug3: Ignored env QT4_IM_MODULE
debug3: Ignored env TEXTDOMAINDIR
debug3: Ignored env DEFAULTS_PATH
debug3: Ignored env PWD
debug3: Ignored env HOME
debug3: Ignored env TEXTDOMAIN
debug3: Ignored env SSH_AGENT_PID
debug3: Ignored env QT_ACCESSIBILITY
debug3: Ignored env XDG_SESSION_TYPE
debug3: Ignored env KRB5CCNAME
debug3: Ignored env XDG_DATA_DIRS
debug3: Ignored env TERMINATOR_DBUS_NAME
debug3: Ignored env XDG_SESSION_DESKTOP
debug3: Ignored env GJS_DEBUG_OUTPUT
debug3: Ignored env GTK_MODULES
debug3: Ignored env TERMINATOR_DBUS_PATH
debug3: Ignored env WINDOWPATH
debug3: Ignored env VTE_VERSION
debug3: Ignored env TERM
debug3: Ignored env SHELL
debug3: Ignored env QT_IM_MODULE
debug3: Ignored env XMODIFIERS
debug3: Ignored env IM_CONFIG_PHASE
debug3: Ignored env NVM_BIN
debug3: Ignored env XDG_CURRENT_DESKTOP
debug3: Ignored env GPG_AGENT_INFO
debug3: Ignored env VAULT_ADDR
debug3: Ignored env GIO_LAUNCHED_DESKTOP_FILE
debug3: Ignored env XDG_SEAT
debug3: Ignored env SHLVL
debug3: Ignored env GDMSESSION
debug3: Ignored env GNOME_DESKTOP_SESSION_ID
debug3: Ignored env LOGNAME
debug3: Ignored env DBUS_SESSION_BUS_ADDRESS
debug3: Ignored env XDG_RUNTIME_DIR
debug3: Ignored env XAUTHORITY
debug3: Ignored env XDG_CONFIG_DIRS
debug3: Ignored env PATH
debug3: Ignored env NVM_INC
debug3: Ignored env GJS_DEBUG_TOPICS
debug3: Ignored env SESSION_MANAGER
debug3: Ignored env LESSOPEN
debug3: Ignored env GTK_IM_MODULE
debug3: Ignored env OLDPWD
debug3: Ignored env _
debug2: channel 0: request shell confirm 1
debug3: send packet: type 98
debug2: channel_input_open_confirmation: channel 0: callback done
debug2: channel 0: open confirm rwindow 2097152 rmax 32768
debug3: receive packet: type 99
debug2: channel_input_status_confirm: type 99 id 0
debug2: PTY allocation request accepted on channel 0
debug3: receive packet: type 99
debug2: channel_input_status_confirm: type 99 id 0
debug2: shell request accepted on channel 0
root@testmachine:~#
```

</details>
