### PR TITLE
Update Architecture Docs link in Readme

### DIFF
--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -20,7 +20,7 @@ the ports to the other parts.
 
 We recommend familiarizing yourself with the following resources prior to reviewing our Terraform examples:
 
-- [Teleport Architecture](https://gravitational.com/teleport/docs/architecture/teleport_architecture_overview/)
+- [Teleport Architecture](https://goteleport.com/docs/architecture/overview/)
 - [Admin Guide](https://gravitational.com/teleport/docs/admin-guide/)
 
 In order to spin up AWS resources using these Terraform examples, you need the following software:


### PR DESCRIPTION
Pointed out by customer, link in Readme is no longer current link so updating to https://goteleport.com/docs/architecture/overview/