### PR TITLE
auth: remove DataDir from RegisterParams

### DIFF
--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -65,9 +65,6 @@ func LocalRegister(id IdentityID, authServer *Server, additionalPrincipals, dnsN
 // RegisterParams specifies parameters
 // for first time register operation with auth server
 type RegisterParams struct {
-	// DataDir is the data directory
-	// storing CA certificate
-	DataDir string
 	// Token is a secure token to join the cluster
 	Token string
 	// ID is identity ID
@@ -237,7 +234,7 @@ func insecureRegisterClient(params RegisterParams) (*Client, error) {
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
 	tlsConfig.Time = params.Clock.Now
 
-	cert, err := readCA(params)
+	cert, err := readCA(params.CAPath)
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
@@ -275,14 +272,14 @@ func insecureRegisterClient(params RegisterParams) (*Client, error) {
 
 // readCA will read in CA that will be used to validate the certificate that
 // the Auth Server presents.
-func readCA(params RegisterParams) (*x509.Certificate, error) {
-	certBytes, err := utils.ReadPath(params.CAPath)
+func readCA(path string) (*x509.Certificate, error) {
+	certBytes, err := utils.ReadPath(path)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	cert, err := tlsca.ParseCertificatePEM(certBytes)
 	if err != nil {
-		return nil, trace.Wrap(err, "failed to parse certificate at %v", params.CAPath)
+		return nil, trace.Wrap(err, "failed to parse certificate at %v", path)
 	}
 	return cert, nil
 }

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -358,7 +358,6 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 		}
 
 		identity, err = auth.Register(auth.RegisterParams{
-			DataDir:              process.Config.DataDir,
 			Token:                process.Config.Token,
 			ID:                   id,
 			Servers:              process.Config.AuthServers,


### PR DESCRIPTION
We stopped using this field years ago when support for CA pinning was added in e69e67e372c3c376eddd76307b2c604d24a567d1.