### PR TITLE
Require that public TLS and SSH keys are provided to register via token

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -222,7 +222,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 	tr := utils.NewTracer(utils.ThisFunction()).Start()
 	defer tr.Stop()
 
-	var tests = []struct {
+	tests := []struct {
 		comment          string
 		inRecordLocation string
 		inForwardAgent   bool
@@ -550,7 +550,7 @@ func testInteroperability(t *testing.T, suite *integrationTestSuite) {
 	teleport := suite.newTeleport(t, nil, true)
 	defer teleport.StopAll()
 
-	var tests = []struct {
+	tests := []struct {
 		inCommand   string
 		inStdin     string
 		outContains string
@@ -1333,7 +1333,7 @@ func testTwoClustersTunnel(t *testing.T, suite *integrationTestSuite) {
 
 	now := time.Now().In(time.UTC).Round(time.Second)
 
-	var tests = []struct {
+	tests := []struct {
 		inRecordLocation  string
 		outExecCountSiteA int
 		outExecCountSiteB int
@@ -1792,7 +1792,7 @@ func testMapRoles(t *testing.T, suite *integrationTestSuite) {
 	require.Equal(t, "hello world\n", output.String())
 
 	// make sure both clusters have the right certificate authorities with the right signing keys.
-	var tests = []struct {
+	tests := []struct {
 		name                       string
 		mainClusterName            string
 		auxClusterName             string
@@ -2848,7 +2848,7 @@ func testExternalClient(t *testing.T, suite *integrationTestSuite) {
 		return
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		desc             string
 		inRecordLocation string
 		inForwardAgent   bool
@@ -2973,7 +2973,7 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 		return
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		inRecordLocation string
 	}{
 		// Run tests when Teleport is recording sessions at the node.
@@ -3060,7 +3060,7 @@ func testProxyHostKeyCheck(t *testing.T, suite *integrationTestSuite) {
 	tr := utils.NewTracer(utils.ThisFunction()).Start()
 	defer tr.Stop()
 
-	var tests = []struct {
+	tests := []struct {
 		desc           string
 		inHostKeyCheck bool
 		outError       bool
@@ -3231,7 +3231,6 @@ func testAuditOff(t *testing.T, suite *integrationTestSuite) {
 // should be allowed to log in. If either the account or session module does
 // not return success, the user should not be able to log in.
 func testPAM(t *testing.T, suite *integrationTestSuite) {
-
 	tr := utils.NewTracer(utils.ThisFunction()).Start()
 	defer tr.Stop()
 
@@ -3248,7 +3247,7 @@ func testPAM(t *testing.T, suite *integrationTestSuite) {
 		t.Skip(skipMessage)
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		desc          string
 		inEnabled     bool
 		inServiceName string
@@ -4108,7 +4107,6 @@ func (s *integrationTestSuite) waitForReload(serviceC chan *service.TeleportProc
 		}
 	}
 	return svc, nil
-
 }
 
 // runAndMatch runs command and makes sure it matches the pattern
@@ -4223,7 +4221,6 @@ func testWindowChange(t *testing.T, suite *integrationTestSuite) {
 				return trace.BadParameter("timed out waiting for output, last output: %q doesn't contain any of the expected substrings: %q", t.Output(5000), outputs)
 			}
 		}
-
 	}
 
 	// Open session, the initial size will be 80x24.
@@ -4324,7 +4321,7 @@ func testList(t *testing.T, suite *integrationTestSuite) {
 	err = waitForNodes(clt, 2)
 	require.NoError(t, err)
 
-	var tests = []struct {
+	tests := []struct {
 		inRoleName string
 		inLabels   types.Labels
 		inLogin    string
@@ -4538,7 +4535,7 @@ func testBPFInteractive(t *testing.T, suite *integrationTestSuite) {
 	lsPath, err := exec.LookPath("ls")
 	require.NoError(t, err)
 
-	var tests = []struct {
+	tests := []struct {
 		desc               string
 		inSessionRecording string
 		inBPFEnabled       bool
@@ -4666,7 +4663,7 @@ func testBPFExec(t *testing.T, suite *integrationTestSuite) {
 	lsPath, err := exec.LookPath("ls")
 	require.NoError(t, err)
 
-	var tests = []struct {
+	tests := []struct {
 		desc               string
 		inSessionRecording string
 		inBPFEnabled       bool
@@ -4893,7 +4890,7 @@ func testExecEvents(t *testing.T, suite *integrationTestSuite) {
 	main := suite.newTeleport(t, nil, true)
 	defer main.StopAll()
 
-	var execTests = []struct {
+	execTests := []struct {
 		name          string
 		isInteractive bool
 		outCommand    string

--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -200,16 +200,26 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 			ClusterName: "localhost",
 			Dir:         tempdir,
 			Clock:       s.clock,
-		}})
+		},
+	})
 	require.NoError(t, err)
 
 	// set up host private key and certificate
+	priv, pub, err := s.server.Auth().GenerateKeyPair("")
+	require.NoError(t, err)
+
+	tlsPub, err := auth.PrivateKeyToPublicKeyTLS(priv)
+	require.NoError(t, err)
+
 	certs, err := s.server.Auth().GenerateServerKeys(auth.GenerateServerKeysRequest{
-		HostID:   hostID,
-		NodeName: s.server.ClusterName(),
-		Roles:    types.SystemRoles{types.RoleNode},
+		HostID:       hostID,
+		NodeName:     s.server.ClusterName(),
+		Roles:        types.SystemRoles{types.RoleNode},
+		PublicSSHKey: pub,
+		PublicTLSKey: tlsPub,
 	})
 	require.NoError(t, err)
+	certs.Key = priv
 
 	// set up user CA and set up a user that has access to the server
 	s.signer, err = sshutils.NewSigner(certs.Key, certs.Cert)
@@ -262,7 +272,8 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 			services.CommandLabels{
 				"baz": &types.CommandLabelV2{
 					Period:  types.NewDuration(time.Millisecond),
-					Command: []string{"expr", "1", "+", "3"}},
+					Command: []string{"expr", "1", "+", "3"},
+				},
 			},
 		),
 		regular.SetBPF(&bpf.NOP{}),

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1508,8 +1508,7 @@ func (a *Server) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedKeys,
 			remoteHost)
 	}
 
-	_, _, _, _, err = ssh.ParseAuthorizedKey(req.PublicSSHKey)
-	if err != nil {
+	if _, _, _, _, err := ssh.ParseAuthorizedKey(req.PublicSSHKey); err != nil {
 		return nil, trace.BadParameter("failed to parse SSH public key")
 	}
 	cryptoPubKey, err := tlsca.ParsePublicKeyPEM(req.PublicTLSKey)
@@ -1544,8 +1543,10 @@ func (a *Server) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedKeys,
 			return nil, trace.BadParameter("failed to load host CA for %q: %v", clusterName.GetClusterName(), err)
 		}
 		if !req.Rotation.Matches(ca.GetRotation()) {
-			return nil, trace.BadParameter("the client expected state is out of sync, server rotation state: %v, "+
-				"client rotation state: %v, re-register the client from scratch to fix the issue.", ca.GetRotation(), req.Rotation)
+			return nil, trace.BadParameter(""+
+				"the client expected state is out of sync, server rotation state: %v, "+
+				"client rotation state: %v, re-register the client from scratch to fix the issue.",
+				ca.GetRotation(), req.Rotation)
 		}
 	}
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -26,7 +26,6 @@ package auth
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"crypto/subtle"
 	"encoding/base64"
 	"errors"
@@ -1462,6 +1461,9 @@ func (req *GenerateServerKeysRequest) CheckAndSetDefaults() error {
 	if len(req.Roles) != 1 {
 		return trace.BadParameter("expected only one system role, got %v", len(req.Roles))
 	}
+	if len(req.PublicSSHKey) == 0 || len(req.PublicTLSKey) == 0 {
+		return trace.BadParameter("public keys for SSH and TLS are required")
+	}
 	return nil
 }
 
@@ -1506,31 +1508,13 @@ func (a *Server) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedKeys,
 			remoteHost)
 	}
 
-	var cryptoPubKey crypto.PublicKey
-	var privateKeyPEM, pubSSHKey []byte
-	if req.PublicSSHKey != nil || req.PublicTLSKey != nil {
-		_, _, _, _, err := ssh.ParseAuthorizedKey(req.PublicSSHKey)
-		if err != nil {
-			return nil, trace.BadParameter("failed to parse SSH public key")
-		}
-		pubSSHKey = req.PublicSSHKey
-		cryptoPubKey, err = tlsca.ParsePublicKeyPEM(req.PublicTLSKey)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	} else {
-		// generate private key
-		privateKeyPEM, pubSSHKey, err = a.GenerateKeyPair("")
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		// reuse the same RSA keys for SSH and TLS keys
-		cryptoPubKey, err = sshutils.CryptoPublicKey(pubSSHKey)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
+	_, _, _, _, err = ssh.ParseAuthorizedKey(req.PublicSSHKey)
+	if err != nil {
+		return nil, trace.BadParameter("failed to parse SSH public key")
+	}
+	cryptoPubKey, err := tlsca.ParsePublicKeyPEM(req.PublicTLSKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// get the certificate authority that will be signing the public key of the host,
@@ -1560,7 +1544,8 @@ func (a *Server) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedKeys,
 			return nil, trace.BadParameter("failed to load host CA for %q: %v", clusterName.GetClusterName(), err)
 		}
 		if !req.Rotation.Matches(ca.GetRotation()) {
-			return nil, trace.BadParameter("the client expected state is out of sync, server rotation state: %v, client rotation state: %v, re-register the client from scratch to fix the issue.", ca.GetRotation(), req.Rotation)
+			return nil, trace.BadParameter("the client expected state is out of sync, server rotation state: %v, "+
+				"client rotation state: %v, re-register the client from scratch to fix the issue.", ca.GetRotation(), req.Rotation)
 		}
 	}
 
@@ -1595,11 +1580,11 @@ func (a *Server) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedKeys,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// generate hostSSH certificate
+	// generate host SSH certificate
 	hostSSHCert, err := a.generateHostCert(services.HostCertParams{
 		CASigner:      caSigner,
 		CASigningAlg:  sshutils.GetSigningAlgName(ca),
-		PublicHostKey: pubSSHKey,
+		PublicHostKey: req.PublicSSHKey,
 		HostID:        req.HostID,
 		NodeName:      req.NodeName,
 		ClusterName:   clusterName.GetClusterName(),
@@ -1643,7 +1628,6 @@ func (a *Server) GenerateServerKeys(req GenerateServerKeysRequest) (*PackedKeys,
 		return nil, trace.Wrap(err)
 	}
 	return &PackedKeys{
-		Key:        privateKeyPEM,
 		Cert:       hostSSHCert,
 		TLSCert:    hostTLSCert,
 		TLSCACerts: services.GetTLSCerts(ca),

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -572,7 +572,7 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 	priv, pub, err := s.a.GenerateKeyPair("")
 	c.Assert(err, IsNil)
 
-	tlsPublicKey, err := privateKeyToPublicKeyTLS(priv)
+	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(priv)
 	c.Assert(err, IsNil)
 
 	// unsuccessful registration (wrong role)

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -572,7 +572,7 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 	priv, pub, err := s.a.GenerateKeyPair("")
 	c.Assert(err, IsNil)
 
-	tlsPublicKey, sshPublicKey, err := keypairToPublicKeys(priv, pub)
+	tlsPublicKey, err := privateKeyToPublicKeyTLS(priv)
 	c.Assert(err, IsNil)
 
 	// unsuccessful registration (wrong role)
@@ -582,7 +582,7 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 		NodeName:     "bad-node-name",
 		Role:         types.RoleProxy,
 		PublicTLSKey: tlsPublicKey,
-		PublicSSHKey: sshPublicKey,
+		PublicSSHKey: pub,
 	})
 	c.Assert(keys, IsNil)
 	c.Assert(err, NotNil)
@@ -616,7 +616,7 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 		Role:                 types.RoleProxy,
 		AdditionalPrincipals: []string{"example.com"},
 		PublicTLSKey:         tlsPublicKey,
-		PublicSSHKey:         sshPublicKey,
+		PublicSSHKey:         pub,
 	})
 	c.Assert(err, IsNil)
 
@@ -632,7 +632,7 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 		NodeName:     "node-name",
 		Role:         types.RoleProxy,
 		PublicTLSKey: tlsPublicKey,
-		PublicSSHKey: sshPublicKey,
+		PublicSSHKey: pub,
 	})
 	c.Assert(err, IsNil)
 
@@ -644,7 +644,7 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 		NodeName:     "node-name",
 		Role:         types.RoleProxy,
 		PublicTLSKey: tlsPublicKey,
-		PublicSSHKey: sshPublicKey,
+		PublicSSHKey: pub,
 	})
 	c.Assert(err, ErrorMatches, `"node-name" \[late.bird\] can not join the cluster with role Proxy, the token is not valid`)
 
@@ -670,7 +670,7 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 		NodeName:     "node-name",
 		Role:         types.RoleProxy,
 		PublicTLSKey: tlsPublicKey,
-		PublicSSHKey: sshPublicKey,
+		PublicSSHKey: pub,
 	})
 	c.Assert(err, IsNil)
 	_, err = s.a.RegisterUsingToken(RegisterUsingTokenRequest{
@@ -679,7 +679,7 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 		NodeName:     "node-name",
 		Role:         types.RoleAuth,
 		PublicTLSKey: tlsPublicKey,
-		PublicSSHKey: sshPublicKey,
+		PublicSSHKey: pub,
 	})
 	c.Assert(err, NotNil)
 	r, _, err := s.a.ValidateToken("static-token-value")

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -378,7 +378,8 @@ func (a *TestAuthServer) GenerateUserCert(key []byte, username string, ttl time.
 	return certs.ssh, nil
 }
 
-func privateKeyToPublicKeyTLS(privateKey []byte) (tlsPublicKey []byte, err error) {
+// PrivateKeyToPublicKeyTLS gets the TLS public key from a raw private key.
+func PrivateKeyToPublicKeyTLS(privateKey []byte) (tlsPublicKey []byte, err error) {
 	sshPrivate, err := ssh.ParseRawPrivateKey(privateKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -400,7 +401,7 @@ func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []b
 		return nil, nil, trace.Wrap(err)
 	}
 
-	tlsPublicKey, err := privateKeyToPublicKeyTLS(priv)
+	tlsPublicKey, err := PrivateKeyToPublicKeyTLS(priv)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -872,7 +873,7 @@ func NewServerIdentity(clt *Server, hostID string, role types.SystemRole) (*Iden
 		return nil, trace.Wrap(err)
 	}
 
-	publicTLS, err := privateKeyToPublicKeyTLS(priv)
+	publicTLS, err := PrivateKeyToPublicKeyTLS(priv)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -377,9 +378,33 @@ func (a *TestAuthServer) GenerateUserCert(key []byte, username string, ttl time.
 	return certs.ssh, nil
 }
 
+func keypairToPublicKeys(privateKey, publicKey []byte) (tlsPublicKey, sshPublicKey []byte, err error) {
+	sshPrivate, err := ssh.ParseRawPrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	tlsPublicKey, err = tlsca.MarshalPublicKeyFromPrivateKeyPEM(sshPrivate)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return tlsPublicKey, publicKey, nil
+}
+
 // generateCertificate generates certificate for identity,
 // returns private public key pair
 func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []byte, error) {
+	priv, pub, err := authServer.GenerateKeyPair("")
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	tlsPublicKey, sshPublicKey, err := keypairToPublicKeys(priv, pub)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
 	switch id := identity.I.(type) {
 	case LocalUser:
 		user, err := authServer.GetUser(id.Username, false)
@@ -392,10 +417,6 @@ func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []b
 		}
 		if identity.TTL == 0 {
 			identity.TTL = time.Hour
-		}
-		priv, pub, err := authServer.GenerateKeyPair("")
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
 		}
 		certs, err := authServer.generateUserCert(certRequest{
 			publicKey:      pub,
@@ -412,23 +433,29 @@ func generateCertificate(authServer *Server, identity TestIdentity) ([]byte, []b
 		return certs.tls, priv, nil
 	case BuiltinRole:
 		keys, err := authServer.GenerateServerKeys(GenerateServerKeysRequest{
-			HostID:   id.Username,
-			NodeName: id.Username,
-			Roles:    types.SystemRoles{id.Role},
+			HostID:       id.Username,
+			NodeName:     id.Username,
+			Roles:        types.SystemRoles{id.Role},
+			PublicTLSKey: tlsPublicKey,
+			PublicSSHKey: sshPublicKey,
 		})
+		keys.Key = priv
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
 		return keys.TLSCert, keys.Key, nil
 	case RemoteBuiltinRole:
 		keys, err := authServer.GenerateServerKeys(GenerateServerKeysRequest{
-			HostID:   id.Username,
-			NodeName: id.Username,
-			Roles:    types.SystemRoles{id.Role},
+			HostID:       id.Username,
+			NodeName:     id.Username,
+			Roles:        types.SystemRoles{id.Role},
+			PublicTLSKey: tlsPublicKey,
+			PublicSSHKey: sshPublicKey,
 		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
+		keys.Key = priv
 		return keys.TLSCert, keys.Key, nil
 	default:
 		return nil, nil, trace.BadParameter("identity of unknown type %T is unsupported", identity)
@@ -840,14 +867,27 @@ func (t *TestTLSServer) Stop() error {
 
 // NewServerIdentity generates new server identity, used in tests
 func NewServerIdentity(clt *Server, hostID string, role types.SystemRole) (*Identity, error) {
+	private, public, err := clt.GenerateKeyPair("")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	publicTLS, publicSSH, err := keypairToPublicKeys(private, public)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	keys, err := clt.GenerateServerKeys(GenerateServerKeysRequest{
-		HostID:   hostID,
-		NodeName: hostID,
-		Roles:    types.SystemRoles{types.RoleAuth},
+		HostID:       hostID,
+		NodeName:     hostID,
+		Roles:        types.SystemRoles{types.RoleAuth},
+		PublicTLSKey: publicTLS,
+		PublicSSHKey: publicSSH,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	keys.Key = private
 	return ReadIdentityFromKeyPair(keys)
 }
 

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -531,7 +531,8 @@ func createPresets(ctx context.Context, asrv *Server) error {
 	roles := []types.Role{
 		services.NewPresetEditorRole(),
 		services.NewPresetAccessRole(),
-		services.NewPresetAuditorRole()}
+		services.NewPresetAuditorRole(),
+	}
 	for _, role := range roles {
 		err := asrv.CreateRole(role)
 		if err != nil {
@@ -789,16 +790,29 @@ func checkResourceConsistency(keyStore keystore.KeyStore, clusterName string, re
 
 // GenerateIdentity generates identity for the auth server
 func GenerateIdentity(a *Server, id IdentityID, additionalPrincipals, dnsNames []string) (*Identity, error) {
+	priv, pub, err := a.GenerateKeyPair("")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tlsPub, err := PrivateKeyToPublicKeyTLS(priv)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	keys, err := a.GenerateServerKeys(GenerateServerKeysRequest{
 		HostID:               id.HostUUID,
 		NodeName:             id.NodeName,
 		Roles:                types.SystemRoles{id.Role},
 		AdditionalPrincipals: additionalPrincipals,
 		DNSNames:             dnsNames,
+		PublicSSHKey:         pub,
+		PublicTLSKey:         tlsPub,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	keys.Key = priv
 	return ReadIdentityFromKeyPair(keys)
 }
 

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1061,7 +1061,7 @@ func (s *TLSSuite) TestValidateUploadSessionRecording(c *check.C) {
 	serverID, err := s.server.Identity.ID.HostID()
 	c.Assert(err, check.IsNil)
 
-	var tests = []struct {
+	tests := []struct {
 		inServerID string
 		outError   bool
 	}{
@@ -1157,7 +1157,7 @@ func (s *TLSSuite) TestValidatePostSessionSlice(c *check.C) {
 	serverID, err := s.server.Identity.ID.HostID()
 	c.Assert(err, check.IsNil)
 
-	var tests = []struct {
+	tests := []struct {
 		inServerID string
 		outError   bool
 	}{
@@ -1891,6 +1891,8 @@ func TestGenerateCerts(t *testing.T) {
 			NodeName:             srv.AuthServer.ClusterName,
 			Roles:                types.SystemRoles{types.RoleNode},
 			AdditionalPrincipals: []string{"example.com"},
+			PublicSSHKey:         pub,
+			PublicTLSKey:         pubTLS,
 		})
 	require.NoError(t, err)
 
@@ -1922,17 +1924,21 @@ func TestGenerateCerts(t *testing.T) {
 		// attempt to elevate privileges by getting admin role in the certificate
 		_, err = hostClient.GenerateServerKeys(
 			GenerateServerKeysRequest{
-				HostID:   hostID,
-				NodeName: srv.AuthServer.ClusterName,
-				Roles:    types.SystemRoles{types.RoleAdmin},
+				HostID:       hostID,
+				NodeName:     srv.AuthServer.ClusterName,
+				Roles:        types.SystemRoles{types.RoleAdmin},
+				PublicSSHKey: pub,
+				PublicTLSKey: pubTLS,
 			})
 		require.True(t, trace.IsAccessDenied(err))
 
 		// attempt to get certificate for different host id
 		_, err = hostClient.GenerateServerKeys(GenerateServerKeysRequest{
-			HostID:   "some-other-host-id",
-			NodeName: srv.AuthServer.ClusterName,
-			Roles:    types.SystemRoles{types.RoleNode},
+			HostID:       "some-other-host-id",
+			NodeName:     srv.AuthServer.ClusterName,
+			Roles:        types.SystemRoles{types.RoleNode},
+			PublicSSHKey: pub,
+			PublicTLSKey: pubTLS,
 		})
 		require.True(t, trace.IsAccessDenied(err))
 	})
@@ -2260,7 +2266,7 @@ func (s *TLSSuite) TestGenerateAppToken(c *check.C) {
 	key, err := services.GetJWTSigner(signer, ca.GetClusterName(), s.clock)
 	c.Assert(err, check.IsNil)
 
-	var tests = []struct {
+	tests := []struct {
 		inMachineRole types.SystemRole
 		inComment     check.CommentInterface
 		outError      bool
@@ -2328,7 +2334,7 @@ func (s *TLSSuite) TestCertificateFormat(c *check.C) {
 	err = s.server.Auth().UpsertPassword(user.GetName(), pass)
 	c.Assert(err, check.IsNil)
 
-	var tests = []struct {
+	tests := []struct {
 		inRoleCertificateFormat   string
 		inClientCertificateFormat string
 		outCertContainsRole       bool

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -461,7 +461,8 @@ func TestOptions(t *testing.T) {
 				RequestTTY:            false,
 				StrictHostKeyChecking: true,
 			},
-		}, {
+		},
+		{
 			desc:        "Equals Sign Delimited",
 			inOptions:   []string{"AddKeysToAgent=yes"},
 			assertError: require.NoError,
@@ -471,12 +472,14 @@ func TestOptions(t *testing.T) {
 				RequestTTY:            false,
 				StrictHostKeyChecking: true,
 			},
-		}, {
+		},
+		{
 			desc:        "Invalid key",
 			inOptions:   []string{"foo foo"},
 			assertError: require.Error,
 			outOptions:  Options{},
-		}, {
+		},
+		{
 			desc:        "Incomplete option",
 			inOptions:   []string{"AddKeysToAgent"},
 			assertError: require.Error,
@@ -500,7 +503,8 @@ func TestOptions(t *testing.T) {
 				RequestTTY:            false,
 				StrictHostKeyChecking: true,
 			},
-		}, {
+		},
+		{
 			desc:        "Forward Agent No",
 			inOptions:   []string{"ForwardAgent no"},
 			assertError: require.NoError,
@@ -510,7 +514,8 @@ func TestOptions(t *testing.T) {
 				RequestTTY:            false,
 				StrictHostKeyChecking: true,
 			},
-		}, {
+		},
+		{
 			desc:        "Forward Agent Local",
 			inOptions:   []string{"ForwardAgent local"},
 			assertError: require.NoError,
@@ -520,7 +525,8 @@ func TestOptions(t *testing.T) {
 				RequestTTY:            false,
 				StrictHostKeyChecking: true,
 			},
-		}, {
+		},
+		{
 			desc:        "Forward Agent InvalidValue",
 			inOptions:   []string{"ForwardAgent potato"},
 			assertError: require.Error,


### PR DESCRIPTION
The original behavior attempted to make providing public keys optional,
and would generate keys if they were not provided. This had several
problems:

- The auth server is generating private keys for nodes and is
  potentially able to share them over the network.
- The return value for keys.Key would sometimes be set and sometimes
  be empty (the key is only set if the auth server generated it and
  knows what the key is)
- We only ever relied on this behavior as a shortcut in test code.
  In the production code this behavior was never used (and actually
  never worked due to a bug that would overwrite and discard the
  generated private key)

This commit requires that public keys are always provided, ensuring
that the private key is generated locally and never known by the
auth server.

It also results in a cleaner error message when either or both of the
public keys are missing from the request.