### PR TITLE
Go 1.17: Stop using ; as a separator in URL query strings

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -498,7 +498,7 @@ func (s *WebSuite) TestSAMLSuccess(c *C) {
 
 	csrfToken := "2ebcb768d0090ea4368e42880c970b61865c326172a4a2343b645cf5d7f20992"
 
-	baseURL, err := url.Parse(clt.Endpoint("webapi", "saml", "sso") + `?redirect_url=http://localhost/after;connector_id=` + connector.GetName())
+	baseURL, err := url.Parse(clt.Endpoint("webapi", "saml", "sso") + `?redirect_url=http://localhost/after&connector_id=` + connector.GetName())
 	c.Assert(err, IsNil)
 	req, err := http.NewRequest("GET", baseURL.String(), nil)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Go 1.17 (by default) disallows using `;` as a separator, which causes our tests to fail on Go 1.17. 

Go 1.17 also includes an escape hatch to revert to the legacy behavior, but it's a new API and would prevent our code from compiling on 1.16. Since we only do this in test code, it's easiest just to switch to `&` so we don't have a breakage when we start compiling with 1.17.

See also: https://github.com/golang/go/issues/25192

Error:

    2021/09/03 10:21:57 http: URL query contains semicolon, which is no longer a supported separator; parts of the query may be stripped when parsed; see golang.org/issue/25192

    ----------------------------------------------------------------------
    FAIL: apiserver_test.go:473: WebSuite.TestSAMLSuccess

    apiserver_test.go:524:
        c.Assert(u.Scheme+"://"+u.Host+u.Path, Equals, fixtures.SAMLOktaSSO)
    ... obtained string = ":///web/msg/error/login"
    ... expected string = "https://dev-813354.oktapreview.com/app/gravitationaldev813354_teleportsaml_1/exkafftca6RqPVgyZ0h7/sso/saml"