### PR TITLE
Support single empty string for ca_pin in teleport.yaml

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -315,8 +315,11 @@ func ApplyFileConfig(fc *FileConfig, cfg *service.Config) error {
 		cfg.CASignatureAlgorithm = fc.CASignatureAlgorithm
 	}
 
-	// Read in how nodes will validate the CA.
-	cfg.CAPins = fc.CAPin
+	// Read in how nodes will validate the CA. A single empty string in the file
+	// conf should indicate no pins.
+	if len(fc.CAPin) > 1 || (len(fc.CAPin) == 1 && fc.CAPin[0] != "") {
+		cfg.CAPins = fc.CAPin
+	}
 
 	// Set diagnostic address
 	if fc.DiagAddr != "" {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -612,6 +612,7 @@ SREzU8onbBsjMg9QDiSf5oJLKvd/Ren+zGY7
 	require.Equal(t, "example_token", cfg.Auth.KeyStore.TokenLabel)
 	require.Equal(t, 1, *cfg.Auth.KeyStore.SlotNumber)
 	require.Equal(t, "example_pin", cfg.Auth.KeyStore.Pin)
+	require.Empty(t, cfg.CAPins)
 }
 
 // TestApplyConfigNoneEnabled makes sure that if a section is not enabled,

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -105,6 +105,7 @@ teleport:
       average: 170
       burst: 171
   diag_addr: 127.0.0.1:3000
+  ca_pin: ""
 auth_service:
   enabled: yes
   listen_addr: 10.5.5.1:3025


### PR DESCRIPTION
For backward compatibility, a single empty string in the `ca_pin` field should indicate that no CA pin should be used.

This was broken in https://github.com/gravitational/teleport/pull/7905