### PR TITLE
correct port number example for gcp cloud mysql

### DIFF
--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -147,7 +147,7 @@ db_service:
     # Database protocol.
     protocol: "mysql"
     # Database endpoint. For Cloud SQL use instance's public IP address.
-    uri: "35.1.2.3:5432"
+    uri: "35.1.2.3:3306"
     # Path to Cloud SQL instance root certificate you downloaded above.
     ca_cert_file: /path/to/cloudsql/instance/root.pem
     # GCP specific configuration when connecting Cloud SQL instance.


### PR DESCRIPTION
Example used postgres port, not 3306