### PR TITLE
Support Webauthn challenges in tsh login

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -366,7 +366,9 @@ func (a *Server) runPeriodicOperations() {
 	r := rand.New(rand.NewSource(a.GetClock().Now().UnixNano()))
 	period := defaults.HighResPollingPeriod + time.Duration(r.Intn(int(defaults.HighResPollingPeriod/time.Second)))*time.Second
 	log.Debugf("Ticking with period: %v.", period)
+	a.lock.RLock()
 	ticker := a.clock.NewTicker(period)
+	a.lock.RUnlock()
 	// Create a ticker with jitter
 	heartbeatCheckTicker := interval.New(interval.Config{
 		Duration: apidefaults.ServerKeepAliveTTL * 2,

--- a/lib/auth/mocku2f/webauthn.go
+++ b/lib/auth/mocku2f/webauthn.go
@@ -25,16 +25,8 @@ import (
 	"github.com/gravitational/trace"
 
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
-
-// collectedClientData is part of the data signed by authenticators (after
-// marshaled to JSON, hashed and appended to authData).
-// https://www.w3.org/TR/webauthn-2/#dictionary-client-data
-type collectedClientData struct {
-	Type      string `json:"type"`
-	Challenge string `json:"challenge"`
-	Origin    string `json:"origin"`
-}
 
 // SignAssertion signs a WebAuthn assertion following the
 // U2F-compat-getAssertion algorithm.
@@ -64,7 +56,7 @@ func (muk *Key) SignAssertion(origin string, assertion *wanlib.CredentialAsserti
 
 	// Marshal and hash collectedClientData - the result is what gets signed,
 	// after appended to authData.
-	ccd, err := json.Marshal(&collectedClientData{
+	ccd, err := json.Marshal(&wancli.CollectedClientData{
 		Type:      "webauthn.get",
 		Challenge: base64.RawURLEncoding.EncodeToString(assertion.Response.Challenge),
 		Origin:    origin,

--- a/lib/auth/u2f/authenticate.go
+++ b/lib/auth/u2f/authenticate.go
@@ -25,13 +25,13 @@ import (
 	"time"
 
 	"github.com/flynn/u2f/u2ftoken"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/gravitational/ttlmap"
 	"github.com/jonboulle/clockwork"
 	"github.com/tstranex/u2f"
 
-	"github.com/gravitational/trace"
-	"github.com/gravitational/ttlmap"
-
-	"github.com/gravitational/teleport/api/types"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
 
 // Authentication sequence:
@@ -190,7 +190,7 @@ func AuthenticateSignChallenge(ctx context.Context, facet string, challenges ...
 
 	var matchedAuthReq *authenticateRequest
 	var authResp *u2ftoken.AuthenticateResponse
-	if err := pollLocalDevices(ctx, func(t *u2ftoken.Token) error {
+	if err := wancli.RunOnU2FDevices(ctx, func(t wancli.Token) error {
 		var errs []error
 		for _, req := range authRequests {
 			if err := t.CheckAuthenticate(req.converted); err != nil {

--- a/lib/auth/u2f/device.go
+++ b/lib/auth/u2f/device.go
@@ -21,14 +21,10 @@ import (
 	"crypto/x509"
 	"time"
 
-	"github.com/flynn/u2f/u2fhid"
-	"github.com/flynn/u2f/u2ftoken"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
 	"github.com/pborman/uuid"
-	"github.com/sirupsen/logrus"
 	"github.com/tstranex/u2f"
-
-	"github.com/gravitational/teleport/api/types"
 )
 
 // DeviceStorage is a persistent storage for MFA devices.
@@ -99,71 +95,4 @@ func decodeDevicePubKey(d *types.U2FDevice) (*ecdsa.PublicKey, error) {
 		return nil, trace.BadParameter("expected *ecdsa.PublicKey, got %T", pubKeyI)
 	}
 	return pubKey, nil
-}
-
-// pollLocalDevices calls fn against all local U2F devices until one succeeds
-// (fn returns nil) or until the context is cancelled.
-func pollLocalDevices(ctx context.Context, fn func(t *u2ftoken.Token) error) error {
-	tick := time.NewTicker(200 * time.Millisecond)
-	defer tick.Stop()
-	for {
-		err := foreachLocalDevice(fn)
-		if err == nil {
-			return nil
-		}
-		// Don't spam the logs while we're waiting for a key to be plugged
-		// in or tapped.
-		if err != errAuthNoKeyOrUserPresence {
-			logrus.WithError(err).Debugf("Error polling U2F devices for registration")
-		}
-
-		select {
-		case <-ctx.Done():
-			return trace.Wrap(ctx.Err())
-		case <-tick.C:
-		}
-	}
-}
-
-// foreachLocalDevice runs fn against each currently available U2F device. It
-// stops when fn returns nil or when finished iterating against the available
-// devices.
-//
-// You most likely want to call pollLocalDevices instead.
-func foreachLocalDevice(fn func(t *u2ftoken.Token) error) error {
-	// Note: we fetch and open all devices on every polling iteration on
-	// purpose. This will handle the device that a user inserts after the
-	// polling has started.
-	devices, err := u2fhid.Devices()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	var errs []error
-	for _, d := range devices {
-		dev, err := u2fhid.Open(d)
-		if err != nil {
-			errs = append(errs, trace.Wrap(err))
-			continue
-		}
-		// There are usually 1-2 devices plugged in, so deferring closing all
-		// of them until the end of function is not too wasteful.
-		defer dev.Close()
-
-		t := u2ftoken.NewToken(dev)
-		// fn is usually t.Authenticate or t.Register. Both methods are
-		// non-blocking - the U2F device returns u2ftoken.ErrPresenceRequired
-		// immediately, unless the user has recently tapped the device.
-		if err := fn(t); err == u2ftoken.ErrPresenceRequired || err == errAuthNoKeyOrUserPresence {
-			continue
-		} else if err != nil {
-			errs = append(errs, trace.Wrap(err))
-			continue
-		}
-		return nil
-	}
-
-	if len(errs) > 0 {
-		return trace.NewAggregate(errs...)
-	}
-	return errAuthNoKeyOrUserPresence
 }

--- a/lib/auth/u2f/register.go
+++ b/lib/auth/u2f/register.go
@@ -25,14 +25,14 @@ import (
 	"errors"
 
 	"github.com/flynn/u2f/u2ftoken"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/tlsutils"
+	"github.com/gravitational/trace"
+	"github.com/gravitational/ttlmap"
 	"github.com/jonboulle/clockwork"
 	"github.com/tstranex/u2f"
 
-	"github.com/gravitational/trace"
-	"github.com/gravitational/ttlmap"
-
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils/tlsutils"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
 
 // Registration sequence:
@@ -159,7 +159,7 @@ func RegisterSignChallenge(ctx context.Context, c RegisterChallenge, facet strin
 	}
 
 	var regRespRaw []byte
-	if err := pollLocalDevices(ctx, func(t *u2ftoken.Token) error {
+	if err := wancli.RunOnU2FDevices(ctx, func(t wancli.Token) error {
 		var err error
 		regRespRaw, err = t.Register(regReq)
 		return err

--- a/lib/auth/webauthncli/client_data.go
+++ b/lib/auth/webauthncli/client_data.go
@@ -1,0 +1,24 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthncli
+
+// CollectedClientData is part of the data signed by authenticators
+// (after marshaled to JSON, hashed and appended to authData).
+// https://www.w3.org/TR/webauthn-2/#dictionary-client-data
+type CollectedClientData struct {
+	Type      string `json:"type"`
+	Challenge string `json:"challenge"`
+	Origin    string `json:"origin"`
+}

--- a/lib/auth/webauthncli/export_test.go
+++ b/lib/auth/webauthncli/export_test.go
@@ -1,0 +1,19 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthncli
+
+var U2FDevices = &u2fDevices
+var U2FOpen = &u2fOpen
+var U2FNewToken = &u2fNewToken

--- a/lib/auth/webauthncli/login.go
+++ b/lib/auth/webauthncli/login.go
@@ -58,7 +58,7 @@ func Login(ctx context.Context, origin string, assertion *wanlib.CredentialAsser
 	// https://www.w3.org/TR/webauthn-2/#sctn-op-get-assertion
 
 	ccdJSON, err := json.Marshal(&CollectedClientData{
-		Type:      "webauthn.get",
+		Type:      string(protocol.AssertCeremony),
 		Challenge: base64.RawURLEncoding.EncodeToString(assertion.Response.Challenge),
 		Origin:    origin,
 	})
@@ -137,7 +137,7 @@ func Login(ctx context.Context, origin string, assertion *wanlib.CredentialAsser
 		PublicKeyCredential: wanlib.PublicKeyCredential{
 			Credential: wanlib.Credential{
 				ID:   base64.RawURLEncoding.EncodeToString(authCred.CredentialID),
-				Type: "public-key",
+				Type: string(protocol.PublicKeyCredentialType),
 			},
 			RawID:      authCred.CredentialID,
 			Extensions: exts,

--- a/lib/auth/webauthncli/login.go
+++ b/lib/auth/webauthncli/login.go
@@ -1,0 +1,158 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthncli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/flynn/u2f/u2ftoken"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/trace"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+)
+
+// Login performs client-side, U2F-compatible Webauthn login.
+// This method blocks until either device authentication is successful or the
+// context is cancelled. Calling Login without a deadline or cancel condition
+// may cause it block forever.
+// The caller is expected to prompt the user for action before calling this
+// method.
+func Login(ctx context.Context, origin string, assertion *wanlib.CredentialAssertion) (*proto.MFAAuthenticateResponse, error) {
+	switch {
+	case origin == "":
+		return nil, trace.BadParameter("origin required")
+	case assertion == nil:
+		return nil, trace.BadParameter("assertion required")
+	case len(assertion.Response.Challenge) == 0:
+		return nil, trace.BadParameter("assertion challenge required")
+	case assertion.Response.RelyingPartyID == "":
+		return nil, trace.BadParameter("assertion RPID required")
+	case len(assertion.Response.AllowedCredentials) == 0:
+		return nil, trace.BadParameter("assertion has no allowed credentials")
+	case assertion.Response.UserVerification == protocol.VerificationRequired:
+		return nil, trace.BadParameter(
+			"assertion required user verification, but it cannot be guaranteed under CTAP1")
+	}
+
+	// References:
+	// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#u2f-authenticatorGetAssertion-interoperability
+	// https://www.w3.org/TR/webauthn-2/#sctn-op-get-assertion
+
+	ccdJSON, err := json.Marshal(&CollectedClientData{
+		Type:      "webauthn.get",
+		Challenge: base64.RawURLEncoding.EncodeToString(assertion.Response.Challenge),
+		Origin:    origin,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ccdHash := sha256.Sum256(ccdJSON)
+	rpID := assertion.Response.RelyingPartyID
+	rpIDHash := sha256.Sum256([]byte(rpID))
+
+	// Did we get the App ID extension?
+	var appID string
+	var appIDHash [32]byte
+	if value, ok := assertion.Response.Extensions[wanlib.AppIDExtension]; ok {
+		appID = fmt.Sprint(value)
+		appIDHash = sha256.Sum256([]byte(appID))
+	}
+
+	// Variables below are filled by the callback on success.
+	var authCred protocol.CredentialDescriptor
+	var authResp *u2ftoken.AuthenticateResponse
+	var usedAppID bool
+	makeAuthU2F := func(cred protocol.CredentialDescriptor, req u2ftoken.AuthenticateRequest, appID bool) func(Token) error {
+		return func(token Token) error {
+			if err := token.CheckAuthenticate(req); err != nil {
+				return err // don't wrap, inspected by RunOnU2FDevices
+			}
+			resp, err := token.Authenticate(req)
+			if err != nil {
+				return err // don't wrap, inspected by RunOnU2FDevices
+			}
+			authCred = cred
+			authResp = resp
+			usedAppID = appID
+			return nil
+		}
+	}
+
+	// Assemble credential+RPID pairs to attempt.
+	var fns []func(Token) error
+	for _, cred := range assertion.Response.AllowedCredentials {
+		req := u2ftoken.AuthenticateRequest{
+			Challenge:   ccdHash[:],
+			Application: rpIDHash[:],
+			KeyHandle:   cred.CredentialID,
+		}
+		fns = append(fns, makeAuthU2F(cred, req, false /* appID */))
+		if appID != "" {
+			req.Application = appIDHash[:]
+			fns = append(fns, makeAuthU2F(cred, req, true /* appID */))
+		}
+	}
+
+	// Run!
+	if err := RunOnU2FDevices(ctx, fns...); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Assemble extensions.
+	var exts *wanlib.AuthenticationExtensionsClientOutputs
+	if usedAppID {
+		exts = &wanlib.AuthenticationExtensionsClientOutputs{AppID: true}
+	}
+
+	// Assemble authenticator data.
+	// RPID (32 bytes) + User Presence (0x01, 1 byte) + Counter (4 bytes)
+	authData := &bytes.Buffer{}
+	if usedAppID {
+		authData.Write(appIDHash[:])
+	} else {
+		authData.Write(rpIDHash[:])
+	}
+	authData.Write(authResp.RawResponse[:5]) // User Presence (1) + Counter (4)
+
+	resp := &wanlib.CredentialAssertionResponse{
+		PublicKeyCredential: wanlib.PublicKeyCredential{
+			Credential: wanlib.Credential{
+				ID:   base64.RawURLEncoding.EncodeToString(authCred.CredentialID),
+				Type: "public-key",
+			},
+			RawID:      authCred.CredentialID,
+			Extensions: exts,
+		},
+		AssertionResponse: wanlib.AuthenticatorAssertionResponse{
+			AuthenticatorResponse: wanlib.AuthenticatorResponse{
+				ClientDataJSON: ccdJSON,
+			},
+			AuthenticatorData: authData.Bytes(),
+			Signature:         authResp.Signature,
+		},
+	}
+	return &proto.MFAAuthenticateResponse{
+		Response: &proto.MFAAuthenticateResponse_Webauthn{
+			Webauthn: wanlib.CredentialAssertionResponseToProto(resp),
+		},
+	}, nil
+}

--- a/lib/auth/webauthncli/login_test.go
+++ b/lib/auth/webauthncli/login_test.go
@@ -43,12 +43,12 @@ func TestLogin(t *testing.T) {
 	// Restore package defaults after test.
 	oldDevices, oldOpen, oldNewToken := *wancli.U2FDevices, *wancli.U2FOpen, *wancli.U2FNewToken
 	oldPollInterval := wancli.DevicePollInterval
-	defer func() {
+	t.Cleanup(func() {
 		*wancli.U2FDevices = oldDevices
 		*wancli.U2FOpen = oldOpen
 		*wancli.U2FNewToken = oldNewToken
 		wancli.DevicePollInterval = oldPollInterval
-	}()
+	})
 	wancli.DevicePollInterval = 1 // as tight as possible.
 
 	const appID = "https://example.com"

--- a/lib/auth/webauthncli/login_test.go
+++ b/lib/auth/webauthncli/login_test.go
@@ -1,0 +1,440 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthncli_test
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/flynn/hid"
+	"github.com/flynn/u2f/u2fhid"
+	"github.com/flynn/u2f/u2ftoken"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/mocku2f"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	wantypes "github.com/gravitational/teleport/api/types/webauthn"
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
+)
+
+func TestLogin(t *testing.T) {
+	// Restore package defaults after test.
+	oldDevices, oldOpen, oldNewToken := *wancli.U2FDevices, *wancli.U2FOpen, *wancli.U2FNewToken
+	oldPollInterval := wancli.DevicePollInterval
+	defer func() {
+		*wancli.U2FDevices = oldDevices
+		*wancli.U2FOpen = oldOpen
+		*wancli.U2FNewToken = oldNewToken
+		wancli.DevicePollInterval = oldPollInterval
+	}()
+	wancli.DevicePollInterval = 1 // as tight as possible.
+
+	const appID = "https://example.com"
+	const rpID = "example.com"
+	const username = "llama"
+	const origin = appID // URL including protocol
+
+	devUnknown, err := newFakeDevice("unknown" /* name */, "unknown" /* appID */)
+	require.NoError(t, err)
+	devRPID, err := newFakeDevice("rpid" /* name */, rpID /* appID */)
+	require.NoError(t, err)
+	devAppID, err := newFakeDevice("appid" /* name */, appID /* appID */)
+	require.NoError(t, err)
+
+	// Use a LoginFlow to create and check assertions.
+	identity := &fakeIdentity{
+		Devices: []*types.MFADevice{
+			devUnknown.mfaDevice,
+			devRPID.mfaDevice,
+			devAppID.mfaDevice,
+		},
+	}
+	loginFlow := &wanlib.LoginFlow{
+		U2F: &types.U2F{
+			AppID:  appID,
+			Facets: []string{appID, rpID},
+		},
+		Webauthn: &types.Webauthn{
+			RPID: rpID,
+		},
+		Identity: identity,
+	}
+
+	tests := []struct {
+		name            string
+		devs            []*fakeDevice
+		setUserPresence *fakeDevice
+		removeAppID     bool
+		wantErr         bool
+		wantRawID       []byte
+	}{
+		{
+			name:            "OK U2F login with App ID",
+			devs:            []*fakeDevice{devUnknown, devAppID},
+			setUserPresence: devAppID,
+			wantRawID:       devAppID.key.KeyHandle,
+		},
+		{
+			name:            "OK U2F login with RPID",
+			devs:            []*fakeDevice{devUnknown, devRPID},
+			setUserPresence: devRPID,
+			wantRawID:       devRPID.key.KeyHandle,
+		},
+		{
+			name:            "OK U2F login with both App ID and RPID",
+			devs:            []*fakeDevice{devUnknown, devRPID, devAppID},
+			setUserPresence: devAppID, // user presence decides the device
+			wantRawID:       devAppID.key.KeyHandle,
+		},
+		{
+			name:            "NOK U2F login with unknown App ID",
+			devs:            []*fakeDevice{devUnknown},
+			setUserPresence: devUnknown, // doesn't matter, App ID won't match.
+			wantErr:         true,
+		},
+		{
+			name: "NOK U2F login without user presence",
+			devs: []*fakeDevice{devUnknown, devAppID, devRPID},
+			// setUserPresent unset, no devices are "tapped".
+			wantErr: true,
+		},
+	}
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			defer cancel()
+
+			// Reset/set user presence flags.
+			for _, dev := range test.devs {
+				dev.SetUserPresence(false)
+			}
+			test.setUserPresence.SetUserPresence(true)
+
+			assertion, err := loginFlow.Begin(ctx, username)
+			require.NoError(t, err)
+			if test.removeAppID {
+				assertion.Response.Extensions = nil
+			}
+
+			fakeDevs := &fakeDevices{devs: test.devs}
+			*wancli.U2FDevices = fakeDevs.devices
+			*wancli.U2FOpen = fakeDevs.open
+			*wancli.U2FNewToken = fakeDevs.newToken
+
+			mfaResp, err := wancli.Login(ctx, origin, assertion)
+			switch hasErr := err != nil; {
+			case hasErr != test.wantErr:
+				t.Fatalf("Login returned err = %v, wantErr = %v", err, test.wantErr)
+			case hasErr:
+				return // OK, error expected
+			}
+			require.NotNil(t, mfaResp.GetWebauthn())
+			require.Equal(t, test.wantRawID, mfaResp.GetWebauthn().RawId)
+
+			_, err = loginFlow.Finish(ctx, username, wanlib.CredentialAssertionResponseFromProto(mfaResp.GetWebauthn()))
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestLogin_errors(t *testing.T) {
+	device, err := newFakeDevice("appid" /* name */, "localhost" /* appID */)
+	require.NoError(t, err)
+	loginFlow := &wanlib.LoginFlow{
+		Webauthn: &types.Webauthn{
+			RPID: "localhost",
+		},
+		Identity: &fakeIdentity{
+			Devices: []*types.MFADevice{
+				device.mfaDevice,
+			},
+		},
+	}
+
+	const user = "llama"
+	const origin = "https://localhost"
+	ctx := context.Background()
+	okAssertion, err := loginFlow.Begin(ctx, user)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		origin       string
+		getAssertion func() *wanlib.CredentialAssertion
+	}{
+		{
+			name:   "NOK origin empty",
+			origin: "",
+			getAssertion: func() *wanlib.CredentialAssertion {
+				return okAssertion
+			},
+		},
+		{
+			name:   "NOK assertion nil",
+			origin: origin,
+			getAssertion: func() *wanlib.CredentialAssertion {
+				return nil
+			},
+		},
+		{
+			name:   "NOK assertion empty",
+			origin: origin,
+			getAssertion: func() *wanlib.CredentialAssertion {
+				return &wanlib.CredentialAssertion{}
+			},
+		},
+		{
+			name:   "NOK assertion missing challenge",
+			origin: origin,
+			getAssertion: func() *wanlib.CredentialAssertion {
+				assertion, err := loginFlow.Begin(ctx, user)
+				require.NoError(t, err)
+				assertion.Response.Challenge = nil
+				return assertion
+			},
+		},
+		{
+			name:   "NOK assertion missing RPID",
+			origin: origin,
+			getAssertion: func() *wanlib.CredentialAssertion {
+				assertion, err := loginFlow.Begin(ctx, user)
+				require.NoError(t, err)
+				assertion.Response.RelyingPartyID = ""
+				return assertion
+			},
+		},
+		{
+			name:   "NOK assertion missing credentials",
+			origin: origin,
+			getAssertion: func() *wanlib.CredentialAssertion {
+				assertion, err := loginFlow.Begin(ctx, user)
+				require.NoError(t, err)
+				assertion.Response.AllowedCredentials = nil
+				return assertion
+			},
+		},
+		{
+			name:   "NOK assertion invalid user verification requirement",
+			origin: origin,
+			getAssertion: func() *wanlib.CredentialAssertion {
+				assertion, err := loginFlow.Begin(ctx, user)
+				require.NoError(t, err)
+				assertion.Response.UserVerification = protocol.VerificationRequired
+				return assertion
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+			defer cancel()
+
+			_, err := wancli.Login(ctx, test.origin, test.getAssertion())
+			require.True(t, trace.IsBadParameter(err))
+		})
+	}
+}
+
+type fakeDevices struct {
+	devs []*fakeDevice
+}
+
+func (f *fakeDevices) devices() ([]*hid.DeviceInfo, error) {
+	infos := make([]*hid.DeviceInfo, len(f.devs))
+	for i, dev := range f.devs {
+		infos[i] = dev.info
+	}
+	return infos, nil
+}
+
+func (f *fakeDevices) open(info *hid.DeviceInfo) (*u2fhid.Device, error) {
+	for _, dev := range f.devs {
+		if dev.info == info {
+			return dev.dev, nil
+		}
+	}
+	return nil, trace.NotFound("device not found")
+}
+
+func (f *fakeDevices) newToken(d u2ftoken.Device) wancli.Token {
+	innerDev := d.(*u2fhid.Device)
+	for _, dev := range f.devs {
+		if dev.dev == innerDev {
+			return dev
+		}
+	}
+	panic("device not found")
+}
+
+type fakeDevice struct {
+	name      string
+	appIDHash []byte
+	key       *mocku2f.Key
+
+	mfaDevice *types.MFADevice
+	info      *hid.DeviceInfo
+	dev       *u2fhid.Device
+
+	// presenceCounter is used to simulate u2ftoken.ErrPresenceRequired errors.
+	presenceCounter int
+	// userPresent true means that the fakeDevice is ready to Authenticate or
+	// Register.
+	userPresent bool
+}
+
+func newFakeDevice(name, appID string) (*fakeDevice, error) {
+	key, err := mocku2f.Create()
+	if err != nil {
+		return nil, err
+	}
+	pubKeyDER, err := x509.MarshalPKIXPublicKey(&key.PrivateKey.PublicKey)
+	if err != nil {
+		panic(err)
+	}
+
+	mfaDevice := types.NewMFADevice(
+		name /* name */, fmt.Sprintf("%X", key.KeyHandle) /* ID */, time.Now() /* addedAt */)
+	mfaDevice.Device = &types.MFADevice_U2F{
+		U2F: &types.U2FDevice{
+			KeyHandle: key.KeyHandle,
+			PubKey:    pubKeyDER,
+			Counter:   0, // always zeroed for simplicity
+		},
+	}
+
+	appIDHash := sha256.Sum256([]byte(appID))
+	return &fakeDevice{
+		name:      name,
+		appIDHash: appIDHash[:],
+		key:       key,
+		mfaDevice: mfaDevice,
+		info: &hid.DeviceInfo{
+			Path: fmt.Sprintf("%v-%X", appID, key.KeyHandle),
+		},
+		dev: &u2fhid.Device{},
+	}, nil
+}
+
+func (f *fakeDevice) SetUserPresence(present bool) {
+	if f == nil {
+		return
+	}
+	f.presenceCounter = 0
+	f.userPresent = present
+}
+
+func (f *fakeDevice) CheckAuthenticate(req u2ftoken.AuthenticateRequest) error {
+	// Is this the correct app and key handle?
+	if !bytes.Equal(req.Application, f.appIDHash) || !bytes.Equal(req.KeyHandle, f.key.KeyHandle) {
+		return u2ftoken.ErrUnknownKeyHandle
+	}
+	return nil
+}
+
+func (f *fakeDevice) Authenticate(req u2ftoken.AuthenticateRequest) (*u2ftoken.AuthenticateResponse, error) {
+	// Fail presence tests a few times.
+	const minPresenceCounter = 2
+	if !f.userPresent || f.presenceCounter < minPresenceCounter {
+		f.presenceCounter++
+		return nil, u2ftoken.ErrPresenceRequired
+	}
+	f.presenceCounter = 0
+
+	// Authenticate runs in a lower abstraction level than mocku2f.Key, so let's
+	// assemble the data and do the signing ourselves.
+	// See
+	// https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#authentication-response-message-success.
+	const userPresenceFlag = 1
+	counter := []byte{0, 0, 0, 0} // always zeroed, makes things simpler
+	dataToSign := &bytes.Buffer{}
+	dataToSign.Write(req.Application)
+	dataToSign.WriteByte(userPresenceFlag)
+	dataToSign.Write(counter)
+	dataToSign.Write(req.Challenge)
+	dataHash := sha256.Sum256(dataToSign.Bytes())
+
+	signature, err := f.key.PrivateKey.Sign(rand.Reader, dataHash[:], crypto.SHA256)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rawResponse := &bytes.Buffer{}
+	rawResponse.WriteByte(userPresenceFlag)
+	rawResponse.Write(counter)
+	rawResponse.Write(signature)
+
+	return &u2ftoken.AuthenticateResponse{
+		Counter:     0,
+		Signature:   signature,
+		RawResponse: rawResponse.Bytes(),
+	}, nil
+}
+
+func (f *fakeDevice) Register(req u2ftoken.RegisterRequest) ([]byte, error) {
+	// Unused by tests.
+	panic("unimplemented")
+}
+
+type fakeIdentity struct {
+	Devices     []*types.MFADevice
+	LocalAuth   *types.WebauthnLocalAuth
+	SessionData *wantypes.SessionData
+}
+
+func (f *fakeIdentity) UpsertWebauthnLocalAuth(ctx context.Context, user string, wla *types.WebauthnLocalAuth) error {
+	f.LocalAuth = wla
+	return nil
+}
+
+func (f *fakeIdentity) GetWebauthnLocalAuth(ctx context.Context, user string) (*types.WebauthnLocalAuth, error) {
+	if f.LocalAuth == nil {
+		return nil, trace.NotFound("not found") // code relies on not found to work properly
+	}
+	return f.LocalAuth, nil
+}
+
+func (f *fakeIdentity) GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error) {
+	return f.Devices, nil
+}
+
+func (f *fakeIdentity) UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error {
+	// Unimportant for the tests here.
+	return nil
+}
+
+func (f *fakeIdentity) UpsertWebauthnSessionData(ctx context.Context, user, sessionID string, sd *wantypes.SessionData) error {
+	f.SessionData = sd
+	return nil
+}
+
+func (f *fakeIdentity) GetWebauthnSessionData(ctx context.Context, user, sessionID string) (*wantypes.SessionData, error) {
+	return f.SessionData, nil
+}
+
+func (f *fakeIdentity) DeleteWebauthnSessionData(ctx context.Context, user, sessionID string) error {
+	f.SessionData = nil
+	return nil
+}

--- a/lib/auth/webauthncli/u2f.go
+++ b/lib/auth/webauthncli/u2f.go
@@ -69,7 +69,7 @@ func RunOnU2FDevices(ctx context.Context, runCredentials ...func(Token) error) e
 	unknownHandles := make(map[unknownHandleKey]bool)
 	for {
 		switch err := runOnU2FDevicesOnce(unknownHandles, runCredentials); {
-		case err == errKeyMissingOrNotVerified:
+		case errors.Is(err, errKeyMissingOrNotVerified):
 			// This is expected to happen a few times.
 		case err != nil:
 			log.WithError(err).Debug("Error interacting with U2F devices")

--- a/lib/auth/webauthncli/u2f.go
+++ b/lib/auth/webauthncli/u2f.go
@@ -1,0 +1,134 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthncli
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/flynn/u2f/u2fhid"
+	"github.com/flynn/u2f/u2ftoken"
+	"github.com/gravitational/trace"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// DevicePollInterval is the interval between polling attempts on Webauthn or
+// U2F devices.
+// Used by otherwise tight loops such as RunOnU2FDevices and related methods,
+// like Login.
+var DevicePollInterval = 200 * time.Millisecond
+
+var errKeyMissingOrNotVerified = errors.New("key missing or user presence not verified")
+
+// Token represents the actions possible using an U2F/CTAP1 token.
+type Token interface {
+	CheckAuthenticate(req u2ftoken.AuthenticateRequest) error
+	Authenticate(req u2ftoken.AuthenticateRequest) (*u2ftoken.AuthenticateResponse, error)
+	Register(req u2ftoken.RegisterRequest) ([]byte, error)
+}
+
+// u2fDevices, u2fOpen and u2fNewToken allows tests to fake interactions with
+// devices.
+var u2fDevices = u2fhid.Devices
+var u2fOpen = u2fhid.Open
+var u2fNewToken = func(d u2ftoken.Device) Token {
+	return u2ftoken.NewToken(d)
+}
+
+type unknownHandleKey struct {
+	Callback int
+	Path     string
+}
+
+// RunOnU2FDevices polls for new U2F/CTAP1 devices and invokes the callbacks
+// against them in regular intervals, running until either one callback succeeds
+// or the context is cancelled.
+// Typically, each callback represents a {credential,rpid} pair to check against
+// the device.
+// Calling this method using a context without a cancel or deadline means it
+// will execute until successful (which may be never).
+// Most callers should prefer higher-abstraction functions such as Login.
+func RunOnU2FDevices(ctx context.Context, runCredentials ...func(Token) error) error {
+	ticker := time.NewTicker(DevicePollInterval)
+	defer ticker.Stop()
+
+	unknownHandles := make(map[unknownHandleKey]bool)
+	for {
+		switch err := runOnU2FDevicesOnce(unknownHandles, runCredentials); {
+		case err == errKeyMissingOrNotVerified:
+			// This is expected to happen a few times.
+		case err != nil:
+			log.WithError(err).Debug("Error interacting with U2F devices")
+		default: // OK, success.
+			return nil
+		}
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		}
+	}
+}
+
+func runOnU2FDevicesOnce(unknownHandles map[unknownHandleKey]bool, runCredentials []func(Token) error) error {
+	// Ask for devices every iteration, the user may plug a new device.
+	infos, err := u2fDevices()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var swallowed []error
+	for _, info := range infos {
+		dev, err := u2fOpen(info)
+		if err != nil {
+			// u2fhid.Open is a bit more prone to errors, especially "hid: privilege
+			// violation" errors. Try other devices before bailing.
+			swallowed = append(swallowed, err)
+			continue
+		}
+
+		token := u2fNewToken(dev)
+		for i, fn := range runCredentials {
+			key := unknownHandleKey{Callback: i, Path: info.Path}
+			if info.Path != "" && unknownHandles[key] {
+				// Device doesn't know the KeyHandle+RPID pair. This won't change during
+				// the attempt.
+				// We may get to a situation where none of the devices know the
+				// {KeyHandle,RPID} pair, but we keep on trying because the user may
+				// plug another device.
+				continue
+			}
+
+			switch err := fn(token); {
+			case err == nil:
+				return nil // OK, we got it.
+			case err == u2ftoken.ErrPresenceRequired:
+				// Wait for user action, they will choose the device to use.
+			case err == u2ftoken.ErrUnknownKeyHandle:
+				unknownHandles[key] = true // No need to try this anymore.
+			case err != nil:
+				swallowed = append(swallowed, err)
+			}
+		}
+	}
+	if len(swallowed) > 0 {
+		return trace.NewAggregate(swallowed...)
+	}
+
+	return errKeyMissingOrNotVerified // don't wrap, simplifies comparisons
+}

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2828,7 +2828,7 @@ func (tc *TeleportClient) AskOTP() (token string, err error) {
 // AskPassword prompts the user to enter the password
 func (tc *TeleportClient) AskPassword() (pwd string, err error) {
 	fmt.Printf("Enter password for Teleport user %v:\n", tc.Config.Username)
-	pwd, err = passwordFromConsole()
+	pwd, err = passwordFromConsoleFn()
 	if err != nil {
 		fmt.Fprintln(tc.Stderr, err)
 		return "", trace.Wrap(err)
@@ -2876,6 +2876,10 @@ func (tc *TeleportClient) getServerVersion(nodeClient *NodeClient) (string, erro
 		return "", trace.NotFound("timed out waiting for server response")
 	}
 }
+
+// passwordFromConsoleFn allows tests to replace the passwordFromConsole
+// function.
+var passwordFromConsoleFn = passwordFromConsole
 
 // passwordFromConsole reads from stdin without echoing typed characters to stdout
 func passwordFromConsole() (string, error) {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2605,7 +2605,7 @@ func (tc *TeleportClient) localLogin(ctx context.Context, secondFactor constants
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-	case constants.SecondFactorU2F, constants.SecondFactorOn, constants.SecondFactorOptional:
+	case constants.SecondFactorU2F, constants.SecondFactorWebauthn, constants.SecondFactorOn, constants.SecondFactorOptional:
 		response, err = tc.mfaLocalLogin(ctx, pub)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -83,12 +83,12 @@ func TestTeleportClient_Login_localMFALogin(t *testing.T) {
 
 	// Replace (and later reset) user-prompting functions.
 	oldPwd, oldOTP, oldU2F, oldWAN := *client.PasswordFromConsoleFn, *client.PromptOTP, *client.PromptU2F, *client.PromptWebauthn
-	defer func() {
+	t.Cleanup(func() {
 		*client.PasswordFromConsoleFn = oldPwd
 		*client.PromptOTP = oldOTP
 		*client.PromptU2F = oldU2F
 		*client.PromptWebauthn = oldWAN
-	}()
+	})
 	*client.PasswordFromConsoleFn = func() (string, error) {
 		return password, nil
 	}

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -1,0 +1,305 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base32"
+	"encoding/base64"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/auth/mocku2f"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/prompt"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/require"
+
+	u2flib "github.com/gravitational/teleport/lib/auth/u2f"
+	log "github.com/sirupsen/logrus"
+)
+
+func TestTeleportClient_Login_localMFALogin(t *testing.T) {
+	// Silence logging during this test.
+	lvl := log.GetLevel()
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetLevel(lvl)
+	})
+	log.SetOutput(io.Discard)
+	log.SetLevel(log.PanicLevel)
+
+	clock := clockwork.NewFakeClockAt(time.Now())
+	sa := newStandaloneTeleport(t, clock)
+	username := sa.Username
+	password := sa.Password
+	device := sa.Device
+	otpKey := sa.OTPKey
+
+	// Prepare client config, it won't change throughout the test.
+	cfg := client.MakeDefaultConfig()
+	cfg.Stdout = io.Discard
+	cfg.Stderr = io.Discard
+	cfg.Stdin = &bytes.Buffer{}
+	cfg.Username = username
+	cfg.HostLogin = username
+	cfg.AddKeysToAgent = client.AddKeysToAgentNo
+	cfg.WebProxyAddr = sa.ProxyWebAddr
+	cfg.KeysDir = t.TempDir()
+	cfg.InsecureSkipVerify = true
+
+	// Replace (and later reset) user-prompting functions.
+	oldPwd, oldOTP, oldU2F := *client.PasswordFromConsoleFn, *client.PromptOTP, *client.PromptU2F
+	defer func() {
+		*client.PasswordFromConsoleFn = oldPwd
+		*client.PromptOTP = oldOTP
+		*client.PromptU2F = oldU2F
+	}()
+	*client.PasswordFromConsoleFn = func() (string, error) {
+		return password, nil
+	}
+
+	promptOTPNoop := func(ctx context.Context) (string, error) {
+		<-ctx.Done() // wait for timeout
+		return "", ctx.Err()
+	}
+	promptU2FNoop := func(ctx context.Context, facet string, challenges ...u2flib.AuthenticateChallenge) (*u2flib.AuthenticateChallengeResponse, error) {
+		<-ctx.Done() // wait for timeout
+		return nil, ctx.Err()
+	}
+
+	solveOTP := func(ctx context.Context) (string, error) {
+		return totp.GenerateCode(otpKey, clock.Now())
+	}
+	solveU2F := func(ctx context.Context, facet string, challenges ...u2flib.AuthenticateChallenge) (*u2flib.AuthenticateChallengeResponse, error) {
+		kh := base64.RawURLEncoding.EncodeToString(device.KeyHandle)
+		for _, c := range challenges {
+			if kh == c.KeyHandle {
+				return device.SignResponse(&c)
+			}
+		}
+		return nil, trace.BadParameter("key handle now found")
+	}
+
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		solveOTP func(context.Context) (string, error)
+		solveU2F func(ctx context.Context, facet string, challenges ...u2flib.AuthenticateChallenge) (*u2flib.AuthenticateChallengeResponse, error)
+	}{
+		{
+			name:     "OK OTP device login",
+			solveOTP: solveOTP,
+			solveU2F: promptU2FNoop,
+		},
+		{
+			name:     "OK U2F device login",
+			solveOTP: promptOTPNoop,
+			solveU2F: solveU2F,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			*client.PromptOTP = func(ctx context.Context, out io.Writer, in *prompt.ContextReader, question string) (string, error) {
+				return test.solveOTP(ctx)
+			}
+			*client.PromptU2F = func(ctx context.Context, facet string, challenges ...u2flib.AuthenticateChallenge) (*u2flib.AuthenticateChallengeResponse, error) {
+				return test.solveU2F(ctx, facet, challenges...)
+			}
+
+			tc, err := client.NewClient(cfg)
+			require.NoError(t, err)
+
+			clock.Advance(30 * time.Second)
+			_, err = tc.Login(ctx)
+			require.NoError(t, err)
+		})
+	}
+}
+
+type standaloneBundle struct {
+	AuthAddr, ProxyWebAddr string
+	Username, Password     string
+	Device                 *mocku2f.Key
+	OTPKey                 string
+	Auth, Proxy            *service.TeleportProcess
+}
+
+// TODO(codingllama): Consider refactoring newStandaloneTeleport into a public
+//  function and reusing in other places.
+func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundle {
+	randomAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
+
+	// Silent logger and console.
+	logger := utils.NewLoggerForTests()
+	logger.SetLevel(log.PanicLevel)
+	logger.SetOutput(io.Discard)
+	console := io.Discard
+
+	staticToken := uuid.New().String()
+
+	user, err := types.NewUser("llama")
+	require.NoError(t, err)
+	role, err := types.NewRole(user.GetName(), types.RoleSpecV4{
+		Allow: types.RoleConditions{
+			Logins: []string{user.GetName()},
+		},
+	})
+	require.NoError(t, err)
+
+	// AuthServer setup.
+	cfg := service.MakeDefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.Hostname = "localhost"
+	cfg.Clock = clock
+	cfg.Console = console
+	cfg.Log = logger
+	cfg.AuthServers = []utils.NetAddr{randomAddr} // must be present
+	cfg.Auth.Preference, err = types.NewAuthPreferenceFromConfigFile(types.AuthPreferenceSpecV2{
+		Type:         constants.Local,
+		SecondFactor: constants.SecondFactorOptional,
+		U2F: &types.U2F{
+			AppID:  "localhost",
+			Facets: []string{"https://localhost", "localhost"},
+		},
+	})
+	require.NoError(t, err)
+	cfg.Auth.Resources = []types.Resource{user, role}
+	cfg.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
+		StaticTokens: []types.ProvisionTokenV1{
+			{
+				Roles:   []types.SystemRole{types.RoleProxy},
+				Expires: time.Now().Add(1 * time.Hour),
+				Token:   staticToken,
+			},
+		},
+	})
+	require.NoError(t, err)
+	cfg.Auth.StorageConfig.Params = backend.Params{defaults.BackendPath: filepath.Join(cfg.DataDir, defaults.BackendDir)}
+	cfg.Auth.SSHAddr = randomAddr
+	cfg.Proxy.Enabled = false
+	cfg.SSH.Enabled = false
+	authProcess := startAndWait(t, cfg, service.AuthTLSReady)
+	t.Cleanup(func() { authProcess.Close() })
+	authAddr, err := authProcess.AuthSSHAddr()
+	require.NoError(t, err)
+
+	// Use the same clock on AuthServer, it doesn't appear to cascade from
+	// configs.
+	authServer := authProcess.GetAuthServer()
+	authServer.SetClock(clock)
+
+	// Initialize user's password and MFA.
+	ctx := context.Background()
+	username := user.GetName()
+	const password = "supersecretpassword"
+	token, err := authServer.CreateResetPasswordToken(ctx, auth.CreateUserTokenRequest{
+		Name: username,
+	})
+	require.NoError(t, err)
+	tokenID := token.GetName()
+	registerReq, err := authServer.CreateSignupU2FRegisterRequest(tokenID)
+	require.NoError(t, err)
+	device, err := mocku2f.Create()
+	require.NoError(t, err)
+	registerResp, err := device.RegisterResponse(registerReq)
+	require.NoError(t, err)
+	_, err = authServer.ChangeUserAuthentication(ctx, &proto.ChangeUserAuthenticationRequest{
+		TokenID:     tokenID,
+		NewPassword: []byte(password),
+		NewMFARegisterResponse: &proto.MFARegisterResponse{
+			Response: &proto.MFARegisterResponse_U2F{
+				U2F: &proto.U2FRegisterResponse{
+					RegistrationData: registerResp.RegistrationData,
+					ClientData:       registerResp.ClientData,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Insert an OTP device.
+	otpKey := base32.StdEncoding.EncodeToString([]byte("llamasrule"))
+	otpDevice, err := services.NewTOTPDevice("otp", otpKey, clock.Now() /* addedAt */)
+	require.NoError(t, err)
+	require.NoError(t, authServer.UpsertMFADevice(ctx, username, otpDevice))
+
+	// Proxy setup.
+	cfg = service.MakeDefaultConfig()
+	cfg.DataDir = t.TempDir()
+	cfg.Hostname = "localhost"
+	cfg.Token = staticToken
+	cfg.Clock = clock
+	cfg.Console = console
+	cfg.Log = logger
+	cfg.AuthServers = []utils.NetAddr{*authAddr}
+	cfg.Auth.Enabled = false
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.WebAddr = randomAddr
+	cfg.Proxy.SSHAddr = randomAddr
+	cfg.Proxy.ReverseTunnelListenAddr = randomAddr
+	cfg.Proxy.DisableWebInterface = true
+	cfg.SSH.Enabled = false
+	proxyProcess := startAndWait(t, cfg, service.ProxyWebServerReady)
+	t.Cleanup(func() { proxyProcess.Close() })
+	proxyWebAddr, err := proxyProcess.ProxyWebAddr()
+	require.NoError(t, err)
+
+	return &standaloneBundle{
+		AuthAddr:     authAddr.String(),
+		ProxyWebAddr: proxyWebAddr.String(),
+		Username:     username,
+		Password:     password,
+		Device:       device,
+		OTPKey:       otpKey,
+		Auth:         authProcess,
+		Proxy:        proxyProcess,
+	}
+}
+
+func startAndWait(t *testing.T, cfg *service.Config, eventName string) *service.TeleportProcess {
+	instance, err := service.NewTeleport(cfg)
+	require.NoError(t, err)
+	require.NoError(t, instance.Start())
+
+	eventC := make(chan service.Event, 1)
+	instance.WaitForEvent(instance.ExitContext(), eventName, eventC)
+	select {
+	case <-eventC:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Timed out waiting for teleport")
+	}
+
+	return instance
+}

--- a/lib/client/export_test.go
+++ b/lib/client/export_test.go
@@ -1,0 +1,24 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+// PasswordFromConsoleFn exports passwordFromConsoleFn for tests.
+var PasswordFromConsoleFn = &passwordFromConsoleFn
+
+// PromptOTP exports promptOTP for tests.
+var PromptOTP = &promptOTP
+
+// PromptU2F exports promptU2F for tests.
+var PromptU2F = &promptU2F

--- a/lib/client/export_test.go
+++ b/lib/client/export_test.go
@@ -22,3 +22,6 @@ var PromptOTP = &promptOTP
 
 // PromptU2F exports promptU2F for tests.
 var PromptU2F = &promptU2F
+
+// PromptWebauthn exports promptWebauthn for tests.
+var PromptWebauthn = &promptWebauthn

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -26,6 +26,9 @@ import (
 	"github.com/gravitational/teleport/lib/auth/u2f"
 	"github.com/gravitational/teleport/lib/utils/prompt"
 	"github.com/gravitational/trace"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
 
 // promptOTP allows tests to override the OTP prompt function.
@@ -34,6 +37,9 @@ var promptOTP = prompt.Input
 // promptU2F allows tests to override the U2F prompt function.
 var promptU2F = u2f.AuthenticateSignChallenge
 
+// promptWebauthn allows tests to override the Webauthn prompt function.
+var promptWebauthn = wancli.Login
+
 // PromptMFAChallenge prompts the user to complete MFA authentication
 // challenges.
 //
@@ -41,85 +47,104 @@ var promptU2F = u2f.AuthenticateSignChallenge
 // key" or "device". This is used to emphasize between different kinds of
 // devices, like registered vs new.
 func PromptMFAChallenge(ctx context.Context, proxyAddr string, c *proto.MFAAuthenticateChallenge, promptDevicePrefix string) (*proto.MFAAuthenticateResponse, error) {
-	switch {
-	// No challenge.
-	case c.TOTP == nil && len(c.U2F) == 0:
+	// Is there a challenge present?
+	if c.TOTP == nil && len(c.U2F) == 0 && c.WebauthnChallenge == nil {
 		return &proto.MFAAuthenticateResponse{}, nil
-	// TOTP only.
-	case c.TOTP != nil && len(c.U2F) == 0:
-		totpCode, err := promptOTP(ctx, os.Stderr, prompt.Stdin(), fmt.Sprintf("Enter an OTP code from a %sdevice", promptDevicePrefix))
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return &proto.MFAAuthenticateResponse{Response: &proto.MFAAuthenticateResponse_TOTP{
-			TOTP: &proto.TOTPResponse{Code: totpCode},
-		}}, nil
-	// U2F only.
-	case c.TOTP == nil && len(c.U2F) > 0:
-		fmt.Fprintf(os.Stderr, "Tap any %ssecurity key\n", promptDevicePrefix)
-		return promptU2FChallenges(ctx, proxyAddr, c.U2F)
-	// Both TOTP and U2F.
-	case c.TOTP != nil && len(c.U2F) > 0:
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		type response struct {
-			kind string
-			resp *proto.MFAAuthenticateResponse
-			err  error
-		}
-		resCh := make(chan response, 1)
-
-		go func() {
-			resp, err := promptU2FChallenges(ctx, proxyAddr, c.U2F)
-			select {
-			case resCh <- response{kind: "U2F", resp: resp, err: err}:
-			case <-ctx.Done():
-			}
-		}()
-
-		go func() {
-			totpCode, err := promptOTP(ctx, os.Stderr, prompt.Stdin(), fmt.Sprintf("Tap any %[1]ssecurity key or enter a code from a %[1]sOTP device", promptDevicePrefix, promptDevicePrefix))
-			res := response{kind: "TOTP", err: err}
-			if err == nil {
-				res.resp = &proto.MFAAuthenticateResponse{Response: &proto.MFAAuthenticateResponse_TOTP{
-					TOTP: &proto.TOTPResponse{Code: totpCode},
-				}}
-			}
-			select {
-			case resCh <- res:
-			case <-ctx.Done():
-			}
-		}()
-
-		for i := 0; i < 2; i++ {
-			select {
-			case res := <-resCh:
-				if res.err != nil {
-					log.WithError(res.err).Debugf("%s authentication failed", res.kind)
-					continue
-				}
-
-				// Print a newline after the TOTP prompt, so that any future
-				// output doesn't print on the prompt line.
-				fmt.Fprintln(os.Stderr)
-
-				return res.resp, nil
-			case <-ctx.Done():
-				return nil, trace.Wrap(ctx.Err())
-			}
-		}
-		return nil, trace.Errorf("failed to authenticate using all U2F and TOTP devices, rerun the command with '-d' to see error details for each device")
-	default:
-		return nil, trace.BadParameter("bug: non-exhaustive switch in promptMFAChallenge")
 	}
+
+	// We have three maximum challenges, from which we only pick two: TOTP and
+	// either Webauthn (preferred) or U2F.
+	hasTOTP := c.TOTP != nil
+	hasNonTOTP := len(c.U2F) > 0 || c.WebauthnChallenge != nil
+	var numGoroutines int
+	if hasTOTP && hasNonTOTP {
+		numGoroutines = 2
+	} else {
+		numGoroutines = 1
+	}
+
+	type response struct {
+		kind string
+		resp *proto.MFAAuthenticateResponse
+		err  error
+	}
+	respC := make(chan response, numGoroutines)
+
+	// Fire TOTP goroutine.
+	if hasTOTP {
+		go func() {
+			const kind = "TOTP"
+			var msg string
+			if hasNonTOTP {
+				msg = fmt.Sprintf("Tap any %[1]ssecurity key or enter a code from a %[1]sOTP device", promptDevicePrefix, promptDevicePrefix)
+			} else {
+				msg = fmt.Sprintf("Enter an OTP code from a %sdevice", promptDevicePrefix)
+			}
+			code, err := promptOTP(ctx, os.Stderr, prompt.Stdin(), msg)
+			fmt.Fprintln(os.Stderr) // Print a new line after the prompt
+			if err != nil {
+				respC <- response{kind: kind, err: err}
+				return
+			}
+			respC <- response{
+				kind: kind,
+				resp: &proto.MFAAuthenticateResponse{
+					Response: &proto.MFAAuthenticateResponse_TOTP{
+						TOTP: &proto.TOTPResponse{Code: code},
+					},
+				},
+			}
+		}()
+	} else {
+		fmt.Fprintf(os.Stderr, "Tap any %ssecurity key\n", promptDevicePrefix)
+	}
+
+	// TODO(codingllama): Make sure users get a reasonable error back when the
+	//  origin doesn't match the RPID. Webauthn isn't as flexible as U2F in this
+	//  regard.
+	origin := proxyAddr
+	if !strings.HasPrefix(origin, "https://") {
+		origin = "https://" + origin
+	}
+
+	// Fire Webauthn or U2F goroutine.
+	switch {
+	case c.WebauthnChallenge != nil:
+		go func() {
+			log.Debugf("WebAuthn: prompting U2F devices with origin %q", origin)
+			resp, err := promptWebauthn(ctx, origin, wanlib.CredentialAssertionFromProto(c.WebauthnChallenge))
+			// Technically it's kind="Webauthn", but we are not changing CLI
+			// nomenclature yet.
+			respC <- response{kind: "U2F", resp: resp, err: err}
+		}()
+	case len(c.U2F) > 0:
+		go func() {
+			log.Debugf("prompting U2F devices with facet %q", origin)
+			resp, err := promptU2FChallenges(ctx, proxyAddr, c.U2F)
+			respC <- response{kind: "U2F", resp: resp, err: err}
+		}()
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		select {
+		case resp := <-respC:
+			if err := resp.err; err != nil {
+				log.WithError(err).Debugf("%s authentication failed", resp.kind)
+				continue
+			}
+
+			// Exiting cancels the context via defer, which makes the remaining
+			// goroutines stop.
+			return resp.resp, nil
+		case <-ctx.Done():
+			return nil, trace.Wrap(ctx.Err())
+		}
+	}
+	return nil, trace.BadParameter(
+		"failed to authenticate using all U2F and TOTP devices, rerun the command with '-d' to see error details for each device")
 }
 
-func promptU2FChallenges(ctx context.Context, proxyAddr string, challenges []*proto.U2FChallenge) (*proto.MFAAuthenticateResponse, error) {
-	facet := proxyAddr
-	if !strings.HasPrefix(proxyAddr, "https://") {
-		facet = "https://" + facet
-	}
+func promptU2FChallenges(ctx context.Context, origin string, challenges []*proto.U2FChallenge) (*proto.MFAAuthenticateResponse, error) {
 	u2fChallenges := make([]u2f.AuthenticateChallenge, 0, len(challenges))
 	for _, chal := range challenges {
 		u2fChallenges = append(u2fChallenges, u2f.AuthenticateChallenge{
@@ -129,8 +154,7 @@ func promptU2FChallenges(ctx context.Context, proxyAddr string, challenges []*pr
 		})
 	}
 
-	log.Debugf("prompting U2F devices with facet %q", facet)
-	resp, err := promptU2F(ctx, facet, u2fChallenges...)
+	resp, err := promptU2F(ctx, origin, u2fChallenges...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -33,10 +33,11 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/u2f"
-	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 )
 
 const (
@@ -361,44 +362,54 @@ func SSHAgentMFALogin(ctx context.Context, login SSHLoginMFA) (*auth.SSHLoginRes
 		return nil, trace.Wrap(err)
 	}
 
-	// TODO(codingllama): Post to /webapi/mfa/login/begin instead.
-	chalRaw, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "u2f", "signrequest"), MFAChallengeRequest{
+	beginReq := MFAChallengeRequest{
 		User: login.User,
 		Pass: login.Password,
-	})
+	}
+	// TODO(codingllama): Decide endpoints based on the Ping server version, once
+	//  we have a known version for Webauthn.
+	challengeJSON, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "mfa", "login", "begin"), beginReq)
+	// DELETE IN 9.x, fallback not necessary after U2F is removed (codingllama)
+	if trace.IsNotImplemented(err) {
+		challengeJSON, err = clt.PostJSON(ctx, clt.Endpoint("webapi", "u2f", "signrequest"), beginReq)
+	}
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	var chal auth.MFAAuthenticateChallenge
-	if err := json.Unmarshal(chalRaw.Bytes(), &chal); err != nil {
+	challenge := &auth.MFAAuthenticateChallenge{}
+	if err := json.Unmarshal(challengeJSON.Bytes(), challenge); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if len(chal.U2FChallenges) == 0 && chal.AuthenticateChallenge != nil {
+	// DELETE IN 9.x, fallback not necessary after U2F is removed (codingllama)
+	if len(challenge.U2FChallenges) == 0 && challenge.AuthenticateChallenge != nil {
 		// Challenge sent by a pre-6.0 auth server, fall back to the old
 		// single-device format.
-		chal.U2FChallenges = []u2f.AuthenticateChallenge{*chal.AuthenticateChallenge}
+		challenge.U2FChallenges = []u2f.AuthenticateChallenge{*challenge.AuthenticateChallenge}
 	}
 
 	// Convert to auth gRPC proto challenge.
-	protoChal := new(proto.MFAAuthenticateChallenge)
-	if chal.TOTPChallenge {
-		protoChal.TOTP = new(proto.TOTPChallenge)
+	challengePB := &proto.MFAAuthenticateChallenge{}
+	if challenge.TOTPChallenge {
+		challengePB.TOTP = &proto.TOTPChallenge{}
 	}
-	for _, u2fChal := range chal.U2FChallenges {
-		protoChal.U2F = append(protoChal.U2F, &proto.U2FChallenge{
-			KeyHandle: u2fChal.KeyHandle,
-			Challenge: u2fChal.Challenge,
-			AppID:     u2fChal.AppID,
+	for _, c := range challenge.U2FChallenges {
+		challengePB.U2F = append(challengePB.U2F, &proto.U2FChallenge{
+			KeyHandle: c.KeyHandle,
+			Challenge: c.Challenge,
+			AppID:     c.AppID,
 		})
 	}
+	if challenge.WebauthnChallenge != nil {
+		challengePB.WebauthnChallenge = wanlib.CredentialAssertionToProto(challenge.WebauthnChallenge)
+	}
 
-	protoResp, err := PromptMFAChallenge(ctx, login.ProxyAddr, protoChal, "")
+	respPB, err := PromptMFAChallenge(ctx, login.ProxyAddr, challengePB, "")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	chalResp := AuthenticateSSHUserRequest{
+	challengeResp := AuthenticateSSHUserRequest{
 		User:              login.User,
 		Password:          login.Password,
 		PubKey:            login.PubKey,
@@ -408,32 +419,32 @@ func SSHAgentMFALogin(ctx context.Context, login SSHLoginMFA) (*auth.SSHLoginRes
 		KubernetesCluster: login.KubernetesCluster,
 	}
 	// Convert back from auth gRPC proto response.
-	switch r := protoResp.Response.(type) {
+	switch r := respPB.Response.(type) {
 	case *proto.MFAAuthenticateResponse_TOTP:
-		chalResp.TOTPCode = r.TOTP.Code
+		challengeResp.TOTPCode = r.TOTP.Code
 	case *proto.MFAAuthenticateResponse_U2F:
-		chalResp.U2FSignResponse = &u2f.AuthenticateChallengeResponse{
+		challengeResp.U2FSignResponse = &u2f.AuthenticateChallengeResponse{
 			KeyHandle:     r.U2F.KeyHandle,
 			SignatureData: r.U2F.Signature,
 			ClientData:    r.U2F.ClientData,
 		}
+	case *proto.MFAAuthenticateResponse_Webauthn:
+		challengeResp.WebauthnChallengeResponse = wanlib.CredentialAssertionResponseFromProto(r.Webauthn)
 	default:
 		// No challenge was sent, so we send back just username/password.
 	}
 
-	// TODO(codingllama): Post to /webapi/mfa/login/finish instead.
-	loginRespRaw, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "u2f", "certs"), chalResp)
+	loginRespJSON, err := clt.PostJSON(ctx, clt.Endpoint("webapi", "mfa", "login", "finish"), challengeResp)
+	// DELETE IN 9.x, fallback not necessary after U2F is removed (codingllama)
+	if trace.IsNotImplemented(err) {
+		loginRespJSON, err = clt.PostJSON(ctx, clt.Endpoint("webapi", "u2f", "certs"), challengeResp)
+	}
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	var loginResp *auth.SSHLoginResponse
-	err = json.Unmarshal(loginRespRaw.Bytes(), &loginResp)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return loginResp, nil
+	loginResp := &auth.SSHLoginResponse{}
+	return loginResp, trace.Wrap(json.Unmarshal(loginRespJSON.Bytes(), loginResp))
 }
 
 // HostCredentials is used to fetch host credentials for a node.


### PR DESCRIPTION
Implement the device polling loop for Webauthn devices and apply it to
`tsh login`.

A separate package, lib/auth/webauthncli, is introduced to hold client-focused
Webauthn logic. The separation highlights the distinction between server- and
client-side code and isolates client-side dependencies from the existing
lib/auth/webauthn.

Includes improved test coverage for TeleportClient.Login (local logins only) and
refactoring of existing code to support Webauthn challenges (PromptMFAChallenge
logic has less branching and U2F device loop extracted and refactored into
lib/auth/webauthncli).

In terms of device compatibility, this is identical to the existing U2F
solution- we are using the same underlying libraries and adapting the CTAP1
responses to Webauthn. This is easy to do and easy to reason about. I'm planning
for a native Webauthn solution, such as libfido2, but that is larger change that
doesn't seem to get us all the way to where we want for now (looking at you,
Touch ID).