### PR TITLE
Added mysql port to teleport-cluster helm chart

### DIFF
--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: "7.0.0-beta.1"
-appVersion: "7.0.0-beta.1"
+version: "7.1.0"
+appVersion: "7.1.0"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -55,6 +55,7 @@ data:
     proxy_service:
       public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
       kube_listen_addr: 0.0.0.0:3026
+      mysql_listen_addr: 0.0.0.0:3036      
       enabled: true
   {{- if .Values.highAvailability.certManager.enabled }}
       https_keypairs:

--- a/examples/chart/teleport-cluster/templates/service.yaml
+++ b/examples/chart/teleport-cluster/templates/service.yaml
@@ -35,5 +35,9 @@ spec:
     port: 3024
     targetPort: 3024
     protocol: TCP
+  - name: mysql
+    port: 3036
+    targetPort: 3036
+    protocol: TCP
   selector:
     app: {{ .Release.Name }}


### PR DESCRIPTION
The port definition for the mysql_listen_addr is not on by default.  This adds it in for the configmap and the service.