### PR TITLE
Fix: AWS IAM roles may sit under paths

### DIFF
--- a/lib/utils/aws.go
+++ b/lib/utils/aws.go
@@ -32,13 +32,20 @@ func FilterAWSRoles(arns []string, accountID string) (result []AWSRole) {
 		if err != nil || (accountID != "" && parsed.AccountID != accountID) {
 			continue
 		}
-		// Example ARN: arn:aws:iam::1234567890:role/EC2FullAccess.
+
+		// In AWS convention, the display of the role is the last
+		// /-delineated substring.
+		//
+		// Example ARNs:
+		// arn:aws:iam::1234567890:role/EC2FullAccess      (display: EC2FullAccess)
+		// arn:aws:iam::1234567890:role/path/to/customrole (display: customrole)
 		parts := strings.Split(parsed.Resource, "/")
-		if len(parts) != 2 || parts[0] != "role" {
+		numParts := len(parts)
+		if numParts < 2 || parts[0] != "role" {
 			continue
 		}
 		result = append(result, AWSRole{
-			Display: parts[1],
+			Display: parts[numParts-1],
 			ARN:     roleARN,
 		})
 	}

--- a/lib/utils/aws_test.go
+++ b/lib/utils/aws_test.go
@@ -32,6 +32,10 @@ func TestFilterAWSRoles(t *testing.T) {
 		ARN:     "arn:aws:iam::1234567890:role/EC2ReadOnly",
 		Display: "EC2ReadOnly",
 	}
+	acc1ARN3 := AWSRole{
+		ARN:     "arn:aws:iam::1234567890:role/path/to/customrole",
+		Display: "customrole",
+	}
 	acc2ARN1 := AWSRole{
 		ARN:     "arn:aws:iam::0987654321:role/test-role",
 		Display: "test-role",
@@ -40,7 +44,7 @@ func TestFilterAWSRoles(t *testing.T) {
 		ARN: "invalid-arn",
 	}
 	allARNS := []string{
-		acc1ARN1.ARN, acc1ARN2.ARN, acc2ARN1.ARN, invalidARN.ARN,
+		acc1ARN1.ARN, acc1ARN2.ARN, acc2ARN1.ARN, acc2ARN3.ARN, invalidARN.ARN,
 	}
 	tests := []struct {
 		name      string
@@ -50,7 +54,7 @@ func TestFilterAWSRoles(t *testing.T) {
 		{
 			name:      "first account roles",
 			accountID: "1234567890",
-			outARNs:   []AWSRole{acc1ARN1, acc1ARN2},
+			outARNs:   []AWSRole{acc1ARN1, acc1ARN2, acc1ARN3},
 		},
 		{
 			name:      "second account roles",
@@ -60,7 +64,7 @@ func TestFilterAWSRoles(t *testing.T) {
 		{
 			name:      "all roles",
 			accountID: "",
-			outARNs:   []AWSRole{acc1ARN1, acc1ARN2, acc2ARN1},
+			outARNs:   []AWSRole{acc1ARN1, acc1ARN2, acc1ARN3, acc2ARN1},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Before this fix, any IAM roles sitting under a path would be silently
filtered out.
For more information about IAM paths, please consult
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html