### PR TITLE
Add more context to the firestore backend test failure

### DIFF
--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -566,6 +566,7 @@ func testEvents(t *testing.T, newBackend Constructor) {
 // by a watcher within the supplied timeout, returning that event for further
 // inspection if successful.
 func requireEvent(t *testing.T, watcher backend.Watcher, eventType types.OpType, key []byte, timeout time.Duration) backend.Event {
+	t.Helper()
 	select {
 	case e := <-watcher.Events():
 		require.Equal(t, eventType, e.Type)
@@ -576,7 +577,7 @@ func requireEvent(t *testing.T, watcher backend.Watcher, eventType types.OpType,
 		require.FailNow(t, "Watcher has unexpectedly closed.")
 
 	case <-time.After(timeout):
-		require.FailNow(t, "Timeout waiting for event.")
+		require.FailNow(t, "Timed out after %v waiting for event %v", timeout, eventType.String())
 	}
 
 	return backend.Event{}


### PR DESCRIPTION
The `TestFirestoreDB` test fails often on Drone with a vague error:

```
--- FAIL: TestFirestoreDB (5.56s)
440	    --- FAIL: TestFirestoreDB/Events (2.06s)
441	        suite.go:579: 
442	            	Error Trace:	suite.go:579
443	            	            				suite.go:523
444	            	            				suite.go:140
445	            	Error:      	Timeout waiting for event.
446	            	Test:       	TestFirestoreDB/Events
447	FAIL
```

This change adds more context to the error message about what event we were waiting for, and ensures that the line number that is reported for the failure is useful.