### PR TITLE
Implement Webauthn registration

### DIFF
--- a/lib/auth/mocku2f/webauthn.go
+++ b/lib/auth/mocku2f/webauthn.go
@@ -20,8 +20,12 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
+	"github.com/fxamacker/cbor/v2"
 	"github.com/gravitational/trace"
 
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
@@ -31,6 +35,9 @@ import (
 // SignAssertion signs a WebAuthn assertion following the
 // U2F-compat-getAssertion algorithm.
 func (muk *Key) SignAssertion(origin string, assertion *wanlib.CredentialAssertion) (*wanlib.CredentialAssertionResponse, error) {
+	// Reference:
+	// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#u2f-authenticatorGetAssertion-interoperability
+
 	// Is our credential allowed?
 	ok := false
 	for _, c := range assertion.Response.AllowedCredentials {
@@ -43,21 +50,22 @@ func (muk *Key) SignAssertion(origin string, assertion *wanlib.CredentialAsserti
 		return nil, trace.BadParameter("device not allowed")
 	}
 
-	// Is the U2F app ID present?
-	value, ok := assertion.Response.Extensions[wanlib.AppIDExtension]
-	if !ok {
-		return nil, trace.BadParameter("missing u2f app ID")
-	}
-	appID, ok := value.(string)
-	if !ok {
-		return nil, trace.BadParameter("u2f app ID has unexpected type: %T", value)
+	appID := assertion.Response.RelyingPartyID
+
+	// Use the U2F App ID?
+	var usedAppID bool
+	if value, ok := assertion.Response.Extensions[wanlib.AppIDExtension]; !muk.PreferRPID && ok {
+		if appID, ok = value.(string); !ok {
+			return nil, trace.BadParameter("u2f app ID has unexpected type: %T", value)
+		}
+		usedAppID = true
 	}
 	appIDHash := sha256.Sum256([]byte(appID))
 
 	// Marshal and hash collectedClientData - the result is what gets signed,
 	// after appended to authData.
 	ccd, err := json.Marshal(&wancli.CollectedClientData{
-		Type:      "webauthn.get",
+		Type:      string(protocol.AssertCeremony),
 		Challenge: base64.RawURLEncoding.EncodeToString(assertion.Response.Challenge),
 		Origin:    origin,
 	})
@@ -75,11 +83,11 @@ func (muk *Key) SignAssertion(origin string, assertion *wanlib.CredentialAsserti
 		PublicKeyCredential: wanlib.PublicKeyCredential{
 			Credential: wanlib.Credential{
 				ID:   base64.RawURLEncoding.EncodeToString(muk.KeyHandle),
-				Type: "public-key",
+				Type: string(protocol.PublicKeyCredentialType),
 			},
 			RawID: muk.KeyHandle,
 			Extensions: &wanlib.AuthenticationExtensionsClientOutputs{
-				AppID: true, // U2F App ID used.
+				AppID: usedAppID,
 			},
 		},
 		AssertionResponse: wanlib.AuthenticatorAssertionResponse{
@@ -89,6 +97,103 @@ func (muk *Key) SignAssertion(origin string, assertion *wanlib.CredentialAsserti
 			AuthenticatorData: res.AuthData,
 			// Signature starts after user presence (1byte) and counter (4 bytes).
 			Signature: res.SignData[5:],
+		},
+	}, nil
+}
+
+// SignCredentialCreation signs a WebAuthn credential creation request following
+// the U2F-compat-makeCredential algorithm.
+func (muk *Key) SignCredentialCreation(origin string, cc *wanlib.CredentialCreation) (*wanlib.CredentialCreationResponse, error) {
+	// Reference:
+	// https: // fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#fig-u2f-compat-makeCredential
+
+	// Is our credential allowed?
+	for _, cred := range cc.Response.CredentialExcludeList {
+		if bytes.Equal(cred.CredentialID, muk.KeyHandle) {
+			return nil, trace.BadParameter("credential in exclude list")
+		}
+	}
+
+	// Is our algorithm allowed?
+	ok := false
+	for _, params := range cc.Response.Parameters {
+		if params.Type == protocol.PublicKeyCredentialType && params.Algorithm == webauthncose.AlgES256 {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return nil, trace.BadParameter("ES256 not allowed by credential parameters")
+	}
+	// Can we fulfill the authenticator selection?
+	if aa := cc.Response.AuthenticatorSelection.AuthenticatorAttachment; aa == protocol.Platform {
+		return nil, trace.BadParameter("platform attachment required by authenticator selection")
+	}
+	if rrk := cc.Response.AuthenticatorSelection.RequireResidentKey; rrk != nil && *rrk {
+		return nil, trace.BadParameter("resident key required by authenticator selection")
+	}
+	if uv := cc.Response.AuthenticatorSelection.UserVerification; uv == protocol.VerificationRequired {
+		return nil, trace.BadParameter("user verification required by authenticator selection")
+	}
+
+	ccd, err := json.Marshal(&wancli.CollectedClientData{
+		Type:      string(protocol.CreateCeremony),
+		Challenge: base64.RawURLEncoding.EncodeToString(cc.Response.Challenge),
+		Origin:    origin,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ccdHash := sha256.Sum256(ccd)
+	appIDHash := sha256.Sum256([]byte(cc.Response.RelyingParty.ID))
+
+	res, err := muk.signRegister(appIDHash[:], ccdHash[:])
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pubKeyCBOR, err := wanlib.U2FKeyToCBOR(&muk.PrivateKey.PublicKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authData := &bytes.Buffer{}
+	authData.Write(appIDHash[:])
+	// Attested credential data present.
+	// https://www.w3.org/TR/webauthn-2/#attested-credential-data.
+	authData.WriteByte(byte(protocol.FlagAttestedCredentialData | protocol.FlagUserPresent))
+	binary.Write(authData, binary.BigEndian, uint32(0)) // counter, zeroed
+	authData.Write(make([]byte, 16))                    // AAGUID, zeroed
+	binary.Write(authData, binary.BigEndian, uint16(len(muk.KeyHandle)))
+	authData.Write(muk.KeyHandle)
+	authData.Write(pubKeyCBOR)
+
+	attObj, err := cbor.Marshal(&protocol.AttestationObject{
+		RawAuthData: authData.Bytes(),
+		// See https://www.w3.org/TR/webauthn-2/#sctn-fido-u2f-attestation.
+		Format: "fido-u2f",
+		AttStatement: map[string]interface{}{
+			"sig": res.Signature,
+			"x5c": []interface{}{muk.cert},
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &wanlib.CredentialCreationResponse{
+		PublicKeyCredential: wanlib.PublicKeyCredential{
+			Credential: wanlib.Credential{
+				ID:   base64.RawURLEncoding.EncodeToString(muk.KeyHandle),
+				Type: string(protocol.PublicKeyCredentialType),
+			},
+			RawID: muk.KeyHandle,
+		},
+		AttestationResponse: wanlib.AuthenticatorAttestationResponse{
+			AuthenticatorResponse: wanlib.AuthenticatorResponse{
+				ClientDataJSON: ccd,
+			},
+			AttestationObject: attObj,
 		},
 	}, nil
 }

--- a/lib/auth/webauthn/login.go
+++ b/lib/auth/webauthn/login.go
@@ -228,6 +228,10 @@ func (f *LoginFlow) Finish(ctx context.Context, user string, resp *CredentialAss
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if credential.Authenticator.CloneWarning {
+		log.Warnf(
+			"WebAuthn: Clone warning detected for user %q / device %q. Device counter may be malfunctioning.", user, dev.GetName())
+	}
 
 	// Update last used timestamp and device counter.
 	if err := setCounterAndTimestamps(dev, credential); err != nil {

--- a/lib/auth/webauthn/login_test.go
+++ b/lib/auth/webauthn/login_test.go
@@ -89,8 +89,8 @@ func TestLoginFlow_BeginFinish(t *testing.T) {
 		{
 			name:   "OK Webauthn device login",
 			user:   user,
-			origin: u2fOrigin,
-			key:    u2fKey,
+			origin: webOrigin,
+			key:    webKey,
 		},
 	}
 	for _, test := range tests {

--- a/lib/auth/webauthn/messages.go
+++ b/lib/auth/webauthn/messages.go
@@ -33,6 +33,22 @@ type CredentialAssertionResponse struct {
 	AssertionResponse AuthenticatorAssertionResponse `json:"response"`
 }
 
+// CredentialCreation is the payload sent to authenticators to initiate
+// registration.
+type CredentialCreation protocol.CredentialCreation
+
+// CredentialCreationResponse is the reply from authenticators to complete
+// registration.
+type CredentialCreationResponse struct {
+	// CredentialCreationResponse is manually redefined, instead of directly based
+	// in protocol.CredentialCreationResponse, for the same reasoning that
+	// CredentialAssertionResponse is - in short, we want a clean package.
+	// The nesting of types is identical to protocol.CredentialCreationResponse.
+
+	PublicKeyCredential
+	AttestationResponse AuthenticatorAttestationResponse `json:"response"`
+}
+
 type PublicKeyCredential struct {
 	Credential
 	RawID      protocol.URLEncodedBase64              `json:"rawId"`
@@ -53,3 +69,8 @@ type AuthenticatorAssertionResponse struct {
 }
 
 type AuthenticatorResponse protocol.AuthenticatorResponse
+
+type AuthenticatorAttestationResponse struct {
+	AuthenticatorResponse
+	AttestationObject protocol.URLEncodedBase64 `json:"attestationObject"`
+}

--- a/lib/auth/webauthn/origin.go
+++ b/lib/auth/webauthn/origin.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthn
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+)
+
+func validateOrigin(origin, rpID string) error {
+	parsedOrigin, err := url.Parse(origin)
+	if err != nil {
+		return trace.BadParameter("origin is not a valid URL: %v", err)
+	}
+	host, err := utils.Host(parsedOrigin.Host)
+	if err != nil {
+		return trace.BadParameter("extracting host from origin: %v", err)
+	}
+
+	// TODO(codingllama): Check origin against the public addresses of Proxies and
+	//  Auth Servers
+
+	// Accept origins whose host matches the RPID.
+	if host == rpID {
+		return nil
+	}
+
+	// Accept origins whose host is a subdomain of RPID.
+	originParts := strings.Split(host, ".")
+	rpParts := strings.Split(rpID, ".")
+	if len(originParts) <= len(rpParts) {
+		return trace.BadParameter("origin doesn't match RPID")
+	}
+	i := len(originParts) - 1
+	j := len(rpParts) - 1
+	for j >= 0 {
+		if originParts[i] != rpParts[j] {
+			return trace.BadParameter("origin doesn't match RPID")
+		}
+		i--
+		j--
+	}
+	return nil
+}

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -1,0 +1,218 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthn
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/google/uuid"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+
+	wan "github.com/duo-labs/webauthn/webauthn"
+	wantypes "github.com/gravitational/teleport/api/types/webauthn"
+	log "github.com/sirupsen/logrus"
+)
+
+// registrationSessionID is used as the per-user session identifier for
+// registrations.
+// A fixed identifier means that only one concurrent registration is allowed
+// (excluding registrations using in-memory SessionData storage).
+const registrationSessionID = "registration"
+
+// RegistrationIdentity represents the subset of Identity methods used by
+// RegistrationFlow.
+type RegistrationIdentity interface {
+	userIDStorage
+
+	GetMFADevices(ctx context.Context, user string, withSecrets bool) ([]*types.MFADevice, error)
+	UpsertMFADevice(ctx context.Context, user string, d *types.MFADevice) error
+	UpsertWebauthnSessionData(ctx context.Context, user, sessionID string, sd *wantypes.SessionData) error
+	GetWebauthnSessionData(ctx context.Context, user, sessionID string) (*wantypes.SessionData, error)
+	DeleteWebauthnSessionData(ctx context.Context, user, sessionID string) error
+}
+
+// RegistrationFlow represents the WebAuthn registration ceremony.
+//
+// Registration consists of:
+//
+// 1. Client requests a CredentialCreation (containing a challenge and various
+//    settings that may constrain allowed authenticators).
+// 2. Server runs Begin(), generates a credential creation.
+// 3. Client validates the credential creation, performs a user presence test
+//    (usually by asking the user to touch a secure token), and replies with a
+//    CredentialCreationResponse (containing the signed challenge and
+//    information about the credential and authenticator)
+// 4. Server runs Finish()
+// 5. If all server-side checks are successful, then registration is complete
+//    and the authenticator may now be used to login.
+type RegistrationFlow struct {
+	Webauthn *types.Webauthn
+	Identity RegistrationIdentity
+}
+
+// Begin is the first step of the registration ceremony.
+// The CredentialCreation created is relayed back to the client, who in turn
+// performs a user presence check and signs the challenge contained within it.
+// As a side effect Begin may assign (and record in storage) a WebAuthn ID for
+// the user.
+func (f *RegistrationFlow) Begin(ctx context.Context, user string) (*CredentialCreation, error) {
+	switch {
+	case f.Webauthn.Disabled:
+		return nil, trace.BadParameter("webauthn disabled")
+	case user == "":
+		return nil, trace.BadParameter("user required")
+	}
+
+	// Exclude known devices from the ceremony.
+	devices, err := f.Identity.GetMFADevices(ctx, user, false /* withSecrets */)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var exclusions []protocol.CredentialDescriptor
+	for _, dev := range devices {
+		cred, ok := deviceToCredential(dev, true /* idOnly */)
+		if !ok {
+			continue
+		}
+		exclusions = append(exclusions, protocol.CredentialDescriptor{
+			Type:         protocol.PublicKeyCredentialType,
+			CredentialID: cred.ID,
+		})
+	}
+
+	webID, err := getOrCreateUserWebauthnID(ctx, user, f.Identity)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	u := newWebUser(user, webID, true /* credentialIDOnly */, nil /* devices */)
+
+	web, err := newWebAuthn(f.Webauthn, f.Webauthn.RPID, "" /* origin */)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	credentialCreation, sessionData, err := web.BeginRegistration(u, wan.WithExclusions(exclusions))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sessionDataPB, err := sessionToPB(sessionData)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := f.Identity.UpsertWebauthnSessionData(ctx, user, registrationSessionID, sessionDataPB); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return (*CredentialCreation)(credentialCreation), nil
+}
+
+// Finish is the second and last step of the registration ceremony.
+// If successful, it returns the created MFADevice. Finish has the side effect
+// or writing the device to storage (using its Identity interface).
+func (f *RegistrationFlow) Finish(ctx context.Context, user, deviceName string, resp *CredentialCreationResponse) (*types.MFADevice, error) {
+	switch {
+	case f.Webauthn.Disabled:
+		return nil, trace.BadParameter("webauthn disabled")
+	case user == "":
+		return nil, trace.BadParameter("user required")
+	case deviceName == "":
+		return nil, trace.BadParameter("device name required")
+	case resp == nil:
+		return nil, trace.BadParameter("credential creation response required")
+	}
+
+	parsedResp, err := parseCredentialCreationResponse(resp)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	origin := parsedResp.Response.CollectedClientData.Origin
+	if err := validateOrigin(origin, f.Webauthn.RPID); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// TODO(codingllama): Verify that the public key matches the allowed
+	//  credential params? It doesn't look like duo-labs/webauthn does that.
+
+	wla, err := f.Identity.GetWebauthnLocalAuth(ctx, user)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	u := newWebUser(user, wla.UserID, true /* credentialIDOnly */, nil /* devices */)
+
+	sessionDataPB, err := f.Identity.GetWebauthnSessionData(ctx, user, registrationSessionID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	sessionData := sessionFromPB(sessionDataPB)
+
+	web, err := newWebAuthn(f.Webauthn, f.Webauthn.RPID, origin)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	credential, err := web.CreateCredential(u, *sessionData, parsedResp)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	newDevice := types.NewMFADevice(deviceName, uuid.NewString() /* id */, time.Now() /* addedAt */)
+	newDevice.Device = &types.MFADevice_Webauthn{
+		Webauthn: &types.WebauthnDevice{
+			CredentialId:     credential.ID,
+			PublicKeyCbor:    credential.PublicKey,
+			AttestationType:  credential.AttestationType,
+			Aaguid:           credential.Authenticator.AAGUID,
+			SignatureCounter: credential.Authenticator.SignCount,
+		},
+	}
+	// We delegate a few checks to identity, including:
+	// * The validity of the created MFADevice
+	// * Uniqueness validation of the deviceName
+	// * Uniqueness validation of the Webauthn credential ID.
+	if err := f.Identity.UpsertMFADevice(ctx, user, newDevice); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Registration complete, remove the registration challenge we just used.
+	if err := f.Identity.DeleteWebauthnSessionData(ctx, user, registrationSessionID); err != nil {
+		log.Warnf("WebAuthn: failed to delete registration SessionData for user %v", user)
+	}
+
+	return newDevice, nil
+}
+
+func parseCredentialCreationResponse(resp *CredentialCreationResponse) (*protocol.ParsedCredentialCreationData, error) {
+	// Remove extensions before marshaling, duo-labs/webauthn isn't expecting it.
+	exts := resp.Extensions
+	resp.Extensions = nil
+	defer func() {
+		resp.Extensions = exts
+	}()
+
+	// This is a roundabout way of getting resp validated, but unfortunately the
+	// APIs don't provide a better method (and it seems better than duplicating
+	// library code here).
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	parsedResp, err := protocol.ParseCredentialCreationResponseBody(bytes.NewReader(body))
+	return parsedResp, trace.Wrap(err)
+}

--- a/lib/auth/webauthn/register_test.go
+++ b/lib/auth/webauthn/register_test.go
@@ -1,0 +1,166 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthn_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/mocku2f"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+)
+
+// TODO(codingllama): Remove once registration is plugged into "real" code.
+//  For now this guarantees that our interface won't deviate from Identity.
+var _ wanlib.RegistrationIdentity = (services.Identity)(nil)
+
+func TestRegistrationFlow_BeginFinish(t *testing.T) {
+	const user = "llama"
+	const rpID = "localhost"
+	const origin = "https://localhost"
+	identity := newFakeIdentity(user)
+	webRegistration := wanlib.RegistrationFlow{
+		Webauthn: &types.Webauthn{
+			RPID: rpID,
+		},
+		Identity: identity,
+	}
+
+	ctx := context.Background()
+
+	// Begin is the first step in registration.
+	credentialCreation, err := webRegistration.Begin(ctx, user)
+	require.NoError(t, err)
+	// Assert some parts of the credentialCreation (it's framework-created, no
+	// need to go too deep).
+	require.NotNil(t, credentialCreation)
+	require.NotEmpty(t, credentialCreation.Response.Challenge)
+	require.Equal(t, webRegistration.Webauthn.RPID, credentialCreation.Response.RelyingParty.ID)
+	// Did we record the SessionData in storage?
+	require.NotEmpty(t, identity.SessionData)
+
+	// Sign CredentialCreation, typically requires user interaction.
+	dev, err := mocku2f.Create()
+	require.NoError(t, err)
+	ccr, err := dev.SignCredentialCreation(origin, credentialCreation)
+	require.NoError(t, err)
+
+	// Finish is the final step in registration.
+	newDevice, err := webRegistration.Finish(ctx, user, "webauthn1", ccr)
+	require.NoError(t, err)
+	// Did we get a proper WebauthnDevice?
+	gotDevice := newDevice.GetWebauthn()
+	require.NotNil(t, gotDevice)
+	require.NotEmpty(t, gotDevice.PublicKeyCbor) // validated indirectly via authentication
+	wantDevice := &types.WebauthnDevice{
+		CredentialId:     dev.KeyHandle,
+		PublicKeyCbor:    gotDevice.PublicKeyCbor,
+		AttestationType:  gotDevice.AttestationType,
+		Aaguid:           make([]byte, 16), // 16 zeroes
+		SignatureCounter: 0,
+	}
+	if diff := cmp.Diff(wantDevice, gotDevice); diff != "" {
+		t.Errorf("Finish() mismatch (-want +got):\n%s", diff)
+	}
+	// SessionData was cleared?
+	require.Empty(t, identity.SessionData)
+	// Device created in storage?
+	require.Len(t, identity.UpdatedDevices, 1)
+	require.Equal(t, newDevice, identity.UpdatedDevices[0])
+}
+
+func TestRegistrationFlow_Begin_errors(t *testing.T) {
+	const user = "llama"
+	webRegistration := &wanlib.RegistrationFlow{
+		Webauthn: &types.Webauthn{
+			RPID: "localhost",
+		},
+		Identity: newFakeIdentity(user),
+	}
+
+	ctx := context.Background()
+	_, err := webRegistration.Begin(ctx, "" /* user */)
+	require.True(t, trace.IsBadParameter(err)) // user required
+}
+
+func TestRegistrationFlow_Finish_errors(t *testing.T) {
+	const user = "llama"
+	webRegistration := &wanlib.RegistrationFlow{
+		Webauthn: &types.Webauthn{
+			RPID: "localhost",
+		},
+		Identity: newFakeIdentity(user),
+	}
+
+	ctx := context.Background()
+
+	cc, err := webRegistration.Begin(ctx, user)
+	require.NoError(t, err)
+	key, err := mocku2f.Create()
+	require.NoError(t, err)
+	okCCR, err := key.SignCredentialCreation("https://localhost" /* origin */, cc)
+	require.NoError(t, err)
+	badOriginCCR, err := key.SignCredentialCreation("https://alpacasarerad.com" /* origin */, cc)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		user, deviceName string
+		credentialResp   *wanlib.CredentialCreationResponse
+		wantErr          string
+	}{
+		{
+			name:           "NOK user empty",
+			user:           "",
+			deviceName:     "webauthn2",
+			credentialResp: okCCR,
+			wantErr:        "user required",
+		},
+		{
+			name:           "NOK device name empty",
+			user:           user,
+			deviceName:     "",
+			credentialResp: okCCR,
+			wantErr:        "device name required",
+		},
+		{
+			name:           "NOK credential response nil",
+			user:           user,
+			deviceName:     "webauthn2",
+			credentialResp: nil,
+			wantErr:        "response required",
+		},
+		{
+			name:           "NOK bad origin",
+			user:           user,
+			deviceName:     "webauthn2",
+			credentialResp: badOriginCCR,
+			wantErr:        "origin",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := webRegistration.Finish(ctx, test.user, test.deviceName, test.credentialResp)
+			require.True(t, trace.IsBadParameter(err))
+			require.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
Add server-side Webauthn registration logic to lib/auth/webauthn.

This allows both U2F and Webauthn-enabled devices to be registered.