### PR TITLE
Add app resource watcher/reconciler

### DIFF
--- a/api/types/app.go
+++ b/api/types/app.go
@@ -51,6 +51,8 @@ type Application interface {
 	GetDescription() string
 	// GetURI returns the app connection endpoint.
 	GetURI() string
+	// SetURI sets the app endpoint.
+	SetURI(string)
 	// GetPublicAddr returns the app public address.
 	GetPublicAddr() string
 	// GetInsecureSkipVerify returns the app insecure setting.
@@ -202,9 +204,14 @@ func (a *AppV3) GetDescription() string {
 	return a.Metadata.Description
 }
 
-// GetURI returns the database connection address.
+// GetURI returns the app connection address.
 func (a *AppV3) GetURI() string {
 	return a.Spec.URI
+}
+
+// SetURI sets the app connection address.
+func (a *AppV3) SetURI(uri string) {
+	a.Spec.URI = uri
 }
 
 // GetPublicAddr returns the app public address.
@@ -290,6 +297,14 @@ func (a Apps) Find(name string) Application {
 		}
 	}
 	return nil
+}
+
+// AsResources returns these apps as resources with labels.
+func (a Apps) AsResources() (resources ResourcesWithLabels) {
+	for _, app := range a {
+		resources = append(resources, app)
+	}
+	return resources
 }
 
 // Len returns the slice length.

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -394,6 +394,14 @@ func (d Databases) ToMap() map[string]Database {
 	return m
 }
 
+// AsResources returns these databases as resources with labels.
+func (d Databases) AsResources() (resources ResourcesWithLabels) {
+	for _, database := range d {
+		resources = append(resources, database)
+	}
+	return resources
+}
+
 // Len returns the slice length.
 func (d Databases) Len() int { return len(d) }
 

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -75,6 +75,36 @@ type ResourceWithOrigin interface {
 	SetOrigin(string)
 }
 
+// ResourceWithLabels is a common interface for resources that have labels.
+type ResourceWithLabels interface {
+	// ResourceWithOrigin is the base resource interface.
+	ResourceWithOrigin
+	// GetAllLabels returns all resource's labels.
+	GetAllLabels() map[string]string
+}
+
+// ResourcesWithLabels is a list of labeled resources.
+type ResourcesWithLabels []ResourceWithLabels
+
+// Find returns resource with the specified name or nil.
+func (r ResourcesWithLabels) Find(name string) ResourceWithLabels {
+	for _, resource := range r {
+		if resource.GetName() == name {
+			return resource
+		}
+	}
+	return nil
+}
+
+// Len returns the slice length.
+func (r ResourcesWithLabels) Len() int { return len(r) }
+
+// Less compares resources by name.
+func (r ResourcesWithLabels) Less(i, j int) bool { return r[i].GetName() < r[j].GetName() }
+
+// Swap swaps two resources.
+func (r ResourcesWithLabels) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+
 // GetVersion returns resource version
 func (h *ResourceHeader) GetVersion() string {
 	return h.Version

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -995,6 +995,14 @@ func applyAppsConfig(fc *FileConfig, cfg *service.Config) error {
 	// Enable debugging application if requested.
 	cfg.Apps.DebugApp = fc.Apps.DebugApp
 
+	// Configure resource watcher selectors if present.
+	for _, selector := range fc.Apps.Selectors {
+		cfg.Apps.Selectors = append(cfg.Apps.Selectors,
+			services.Selector{
+				MatchLabels: selector.MatchLabels,
+			})
+	}
+
 	// Loop over all apps and load app configuration.
 	for _, application := range fc.Apps.Apps {
 		// Parse the static labels of the application.
@@ -1036,7 +1044,7 @@ func applyAppsConfig(fc *FileConfig, cfg *service.Config) error {
 				Headers:  headers,
 			}
 		}
-		if err := app.Check(); err != nil {
+		if err := app.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
 		cfg.Apps.Apps = append(cfg.Apps.Apps, app)
@@ -1408,7 +1416,7 @@ func Configure(clf *CommandLineFlags, cfg *service.Config) error {
 			StaticLabels:  static,
 			DynamicLabels: dynamic,
 		}
-		if err := app.Check(); err != nil {
+		if err := app.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
 		cfg.Apps.Apps = append(cfg.Apps.Apps, app)

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -268,7 +268,7 @@ func TestConfigReading(t *testing.T) {
 			KeyFile:  "/etc/teleport/proxy.key",
 			CertFile: "/etc/teleport/proxy.crt",
 			KeyPairs: []KeyPair{
-				KeyPair{
+				{
 					PrivateKey:  "/etc/teleport/proxy.key",
 					Certificate: "/etc/teleport/proxy.crt",
 				},
@@ -289,12 +289,19 @@ func TestConfigReading(t *testing.T) {
 				EnabledFlag: "yes",
 			},
 			Apps: []*App{
-				&App{
+				{
 					Name:          "foo",
 					URI:           "http://127.0.0.1:8080",
 					PublicAddr:    "foo.example.com",
 					StaticLabels:  Labels,
 					DynamicLabels: CommandLabels,
+				},
+			},
+			Selectors: []Selector{
+				{
+					MatchLabels: map[string]apiutils.Strings{
+						"*": {"*"},
+					},
 				},
 			},
 		},
@@ -325,7 +332,7 @@ func TestConfigReading(t *testing.T) {
 				EnabledFlag:   "yes",
 			},
 			KeyPairs: []KeyPair{
-				KeyPair{
+				{
 					PrivateKey:  "/etc/teleport/proxy.key",
 					Certificate: "/etc/teleport/proxy.crt",
 				},
@@ -971,7 +978,7 @@ func makeConfigFixture() string {
 	conf.Proxy.KeyFile = "/etc/teleport/proxy.key"
 	conf.Proxy.CertFile = "/etc/teleport/proxy.crt"
 	conf.Proxy.KeyPairs = []KeyPair{
-		KeyPair{
+		{
 			PrivateKey:  "/etc/teleport/proxy.key",
 			Certificate: "/etc/teleport/proxy.crt",
 		},
@@ -993,12 +1000,17 @@ func makeConfigFixture() string {
 	// Application service.
 	conf.Apps.EnabledFlag = "yes"
 	conf.Apps.Apps = []*App{
-		&App{
+		{
 			Name:          "foo",
 			URI:           "http://127.0.0.1:8080",
 			PublicAddr:    "foo.example.com",
 			StaticLabels:  Labels,
 			DynamicLabels: CommandLabels,
+		},
+	}
+	conf.Apps.Selectors = []Selector{
+		{
+			MatchLabels: map[string]apiutils.Strings{"*": {"*"}},
 		},
 	}
 
@@ -1024,7 +1036,7 @@ func makeConfigFixture() string {
 	conf.Metrics.ListenAddress = "tcp://metrics"
 	conf.Metrics.CACerts = []string{"/etc/teleport/ca.crt"}
 	conf.Metrics.KeyPairs = []KeyPair{
-		KeyPair{
+		{
 			PrivateKey:  "/etc/teleport/proxy.key",
 			Certificate: "/etc/teleport/proxy.crt",
 		},
@@ -1288,6 +1300,9 @@ app_service:
       name: foo
       public_addr: "foo.example.com"
       uri: "http://127.0.0.1:8080"
+  selectors:
+  - match_labels:
+      '*': '*'
 `,
 			inComment: "config is valid",
 			outError:  false,

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -958,6 +958,9 @@ type Apps struct {
 
 	// Apps is a list of applications that will be run by this service.
 	Apps []*App `yaml:"apps"`
+
+	// Selectors defines resource monitor selectors.
+	Selectors []Selector `yaml:"selectors,omitempty"`
 }
 
 // App is the specific application that will be proxied by the application

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -716,6 +716,9 @@ type AppsConfig struct {
 
 	// Apps is the list of applications that are being proxied.
 	Apps []App
+
+	// Selectors is a list of resource monitor selectors.
+	Selectors []services.Selector
 }
 
 // App is the specific application that will be proxied by the application
@@ -748,8 +751,8 @@ type App struct {
 	Rewrite *Rewrite
 }
 
-// Check validates an application.
-func (a App) Check() error {
+// CheckAndSetDefaults validates an application.
+func (a *App) CheckAndSetDefaults() error {
 	if a.Name == "" {
 		return trace.BadParameter("missing application name")
 	}
@@ -776,6 +779,11 @@ func (a App) Check() error {
 			return trace.BadParameter("application %q public_addr %q can not be an IP address, Teleport Application Access uses DNS names for routing", a.Name, a.PublicAddr)
 		}
 	}
+	// Mark the app as coming from the static configuration.
+	if a.StaticLabels == nil {
+		a.StaticLabels = make(map[string]string)
+	}
+	a.StaticLabels[types.OriginLabel] = types.OriginConfigFile
 	// Make sure there are no reserved headers in the rewrite configuration.
 	// They wouldn't be rewritten even if we allowed them here but catch it
 	// early and let the user know.

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -159,7 +159,7 @@ func TestCheckApp(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			err := tt.inApp.Check()
+			err := tt.inApp.CheckAndSetDefaults()
 			if tt.err != "" {
 				require.Contains(t, err.Error(), tt.err)
 			} else {

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -31,6 +31,9 @@ import (
 )
 
 func (process *TeleportProcess) initDatabases() {
+	if len(process.Config.Databases.Databases) == 0 && len(process.Config.Databases.Selectors) == 0 {
+		return
+	}
 	process.registerWithAuthServer(types.RoleDatabase, DatabasesIdentityEvent)
 	process.RegisterCriticalFunc("db.init", process.initDatabaseService)
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3336,7 +3336,7 @@ func (process *TeleportProcess) initApps() {
 	// If no applications are specified, exit early. This is due to the strange
 	// behavior in reading file configuration. If the user does not specify an
 	// "app_service" section, that is considered enabling "app_service".
-	if len(process.Config.Apps.Apps) == 0 && !process.Config.Apps.DebugApp {
+	if len(process.Config.Apps.Apps) == 0 && !process.Config.Apps.DebugApp && len(process.Config.Apps.Selectors) == 0 {
 		return
 	}
 
@@ -3500,6 +3500,7 @@ func (process *TeleportProcess) initApps() {
 			Hostname:     process.Config.Hostname,
 			GetRotation:  process.getRotation,
 			Apps:         applications,
+			Selectors:    process.Config.Apps.Selectors,
 			OnHeartbeat: func(err error) {
 				if err != nil {
 					process.BroadcastEvent(Event{Name: TeleportDegradedEvent, Payload: teleport.ComponentApp})

--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/api/types"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// ReconcilerConfig is the resource reconciler configuration.
+type ReconcilerConfig struct {
+	// Selectors is a list of selectors the reconciler will match resources against.
+	Selectors []Selector
+	// GetResources is used to fetch currently registered resources list.
+	GetResources func() types.ResourcesWithLabels
+	// OnCreate is called when a new resource is detected.
+	OnCreate func(context.Context, types.ResourceWithLabels) error
+	// OnUpdate is called when an existing resource is updated.
+	OnUpdate func(context.Context, types.ResourceWithLabels) error
+	// OnDelete is called when an existing resource is deleted.
+	OnDelete func(context.Context, types.ResourceWithLabels) error
+	// Log is the reconciler's logger.
+	Log logrus.FieldLogger
+}
+
+// CheckAndSetDefaults validates the reconciler configuration and sets defaults.
+func (c *ReconcilerConfig) CheckAndSetDefaults() error {
+	if c.GetResources == nil {
+		return trace.BadParameter("missing reconciler GetResources")
+	}
+	if c.OnCreate == nil {
+		return trace.BadParameter("missing reconciler OnCreate")
+	}
+	if c.OnUpdate == nil {
+		return trace.BadParameter("missing reconciler OnUpdate")
+	}
+	if c.OnDelete == nil {
+		return trace.BadParameter("missing reconciler OnDelete")
+	}
+	if c.Log == nil {
+		c.Log = logrus.WithField(trace.Component, "reconciler")
+	}
+	return nil
+}
+
+// NewReconciler creates a new reconciler with provided configuration.
+func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &Reconciler{
+		cfg: cfg,
+		log: cfg.Log.WithField("selectors", cfg.Selectors),
+	}, nil
+}
+
+// Reconciler reconciles a list of resources returned by GetResources from its
+// config with a list of provided resources.
+//
+// It's used in combination with watchers by agents (app, database) to enable
+// dynamically registered resources.
+type Reconciler struct {
+	cfg ReconcilerConfig
+	log logrus.FieldLogger
+}
+
+// Reconcile reconciles a list of resources returned by GetResources from its
+// config with newResources and calls appropriate callbacks.
+func (r *Reconciler) Reconcile(ctx context.Context, newResources types.ResourcesWithLabels) error {
+	r.log.Debugf("Reconciling with %v resources.", len(newResources))
+	var errs []error
+
+	// Process already registered resources to see if any of them were removed.
+	for _, current := range r.cfg.GetResources() {
+		if err := r.processRegisteredResource(ctx, newResources, current); err != nil {
+			errs = append(errs, trace.Wrap(err))
+		}
+	}
+
+	// Add new resources if there are any or refresh those that were updated.
+	for _, new := range newResources {
+		if err := r.processNewResource(ctx, new); err != nil {
+			errs = append(errs, trace.Wrap(err))
+		}
+	}
+
+	return trace.NewAggregate(errs...)
+}
+
+// processRegisteredResource checks the specified registered resource against the
+// new list of resources.
+func (r *Reconciler) processRegisteredResource(ctx context.Context, newResources types.ResourcesWithLabels, registered types.ResourceWithLabels) error {
+	// Skip resources marked as static as those usually come from static config.
+	// For backwards compatibility also consider empty "origin" value.
+	if registered.Origin() == types.OriginConfigFile || registered.Origin() == "" {
+		return nil
+	}
+
+	// See if this registered resource is still present among "new" resources.
+	if new := newResources.Find(registered.GetName()); new != nil {
+		return nil
+	}
+
+	r.log.Infof("%v removed, deleting.", registered)
+	if err := r.cfg.OnDelete(ctx, registered); err != nil {
+		return trace.Wrap(err, "failed to delete %v", registered)
+	}
+
+	return nil
+}
+
+// processNewResource checks the provided new resource agsinst currently
+// registered resources.
+func (r *Reconciler) processNewResource(ctx context.Context, new types.ResourceWithLabels) error {
+	// First see if the resource is already registered and if not, whether it
+	// matches the selector labels and should be registered.
+	registered := r.cfg.GetResources().Find(new.GetName())
+	if registered == nil {
+		if MatchResourceLabels(r.cfg.Selectors, new) {
+			r.log.Infof("%v matches, creating.", new)
+			if err := r.cfg.OnCreate(ctx, new); err != nil {
+				return trace.Wrap(err, "failed to create %v", new)
+			}
+			return nil
+		}
+		r.log.Debugf("%v doesn't match, not creating.", new)
+		return nil
+	}
+
+	// Do not overwrite static resources. Consider resources with empty
+	// origin as static for backwards compatibility.
+	if registered.Origin() == types.OriginConfigFile || registered.Origin() == "" {
+		r.log.Infof("%v is part of static configuration, not creating %v.", registered, new)
+		return nil
+	}
+
+	// If the resource is already registered but was updated, see if its
+	// labels still match.
+	if new.GetResourceID() != registered.GetResourceID() {
+		if MatchResourceLabels(r.cfg.Selectors, new) {
+			r.log.Infof("%v updated, updating.", new)
+			if err := r.cfg.OnUpdate(ctx, new); err != nil {
+				return trace.Wrap(err, "failed to update %v", new)
+			}
+			return nil
+		}
+		r.log.Infof("%v updated and no longer matches, deleting.", new)
+		if err := r.cfg.OnDelete(ctx, registered); err != nil {
+			return trace.Wrap(err, "failed to delete %v", new)
+		}
+		return nil
+	}
+
+	r.log.Debugf("%v is already registered.", new)
+	return nil
+}

--- a/lib/services/reconciler_test.go
+++ b/lib/services/reconciler_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReconciler makes sure appropriate callbacks are called during reconciliation.
+func TestReconciler(t *testing.T) {
+	tests := []struct {
+		description         string
+		selectors           []Selector
+		registeredResources types.ResourcesWithLabels
+		newResources        types.ResourcesWithLabels
+		onCreateCalls       types.ResourcesWithLabels
+		onUpdateCalls       types.ResourcesWithLabels
+		onDeleteCalls       types.ResourcesWithLabels
+	}{
+		{
+			description: "new matching resource should be registered",
+			selectors: []Selector{{
+				MatchLabels: types.Labels{"*": []string{"*"}},
+			}},
+			registeredResources: types.ResourcesWithLabels{},
+			newResources: types.ResourcesWithLabels{
+				makeDynamicResource("res1", nil),
+			},
+			onCreateCalls: types.ResourcesWithLabels{
+				makeDynamicResource("res1", nil),
+			},
+		},
+		{
+			description: "new non-matching resource should not be registered",
+			selectors: []Selector{{
+				MatchLabels: types.Labels{"env": []string{"prod"}},
+			}},
+			registeredResources: types.ResourcesWithLabels{},
+			newResources: types.ResourcesWithLabels{
+				makeDynamicResource("res1", map[string]string{"env": "dev"}),
+			},
+		},
+		{
+			description: "resource that's no longer present should be removed",
+			selectors: []Selector{{
+				MatchLabels: types.Labels{"*": []string{"*"}},
+			}},
+			registeredResources: types.ResourcesWithLabels{
+				makeDynamicResource("res1", nil),
+			},
+			newResources: types.ResourcesWithLabels{},
+			onDeleteCalls: types.ResourcesWithLabels{
+				makeDynamicResource("res1", nil),
+			},
+		},
+		{
+			description: "static resource should not be overwritten",
+			selectors: []Selector{{
+				MatchLabels: types.Labels{"*": []string{"*"}},
+			}},
+			registeredResources: types.ResourcesWithLabels{
+				makeStaticResource("res1", nil),
+			},
+			newResources: types.ResourcesWithLabels{
+				makeDynamicResource("res1", nil),
+			},
+		},
+		{
+			description: "resource with updated matching labels should be updated",
+			selectors: []Selector{{
+				MatchLabels: types.Labels{"*": []string{"*"}},
+			}},
+			registeredResources: types.ResourcesWithLabels{
+				makeDynamicResource("res1", nil),
+			},
+			newResources: types.ResourcesWithLabels{
+				makeDynamicResourceWithID("res1", map[string]string{"env": "dev"}, 1),
+			},
+			onUpdateCalls: types.ResourcesWithLabels{
+				makeDynamicResourceWithID("res1", map[string]string{"env": "dev"}, 1),
+			},
+		},
+		{
+			description: "non-matching updated resource should be removed",
+			selectors: []Selector{{
+				MatchLabels: types.Labels{"env": []string{"prod"}},
+			}},
+			registeredResources: types.ResourcesWithLabels{
+				makeDynamicResource("res1", map[string]string{"env": "prod"}),
+			},
+			newResources: types.ResourcesWithLabels{
+				makeDynamicResourceWithID("res1", map[string]string{"env": "dev"}, 1),
+			},
+			onDeleteCalls: types.ResourcesWithLabels{
+				makeDynamicResource("res1", map[string]string{"env": "prod"}),
+			},
+		},
+		{
+			description: "complex scenario with multiple created/updated/deleted resources",
+			selectors: []Selector{{
+				MatchLabels: types.Labels{"env": []string{"prod"}},
+			}},
+			registeredResources: types.ResourcesWithLabels{
+				makeStaticResource("res0", nil),
+				makeDynamicResource("res1", map[string]string{"env": "prod"}),
+				makeDynamicResource("res2", map[string]string{"env": "prod"}),
+				makeDynamicResource("res3", map[string]string{"env": "prod"}),
+				makeDynamicResource("res4", map[string]string{"env": "prod"}),
+			},
+			newResources: types.ResourcesWithLabels{
+				makeDynamicResource("res0", map[string]string{"env": "prod"}),
+				makeDynamicResourceWithID("res2", map[string]string{"env": "prod", "a": "b"}, 1),
+				makeDynamicResource("res3", map[string]string{"env": "prod"}),
+				makeDynamicResourceWithID("res4", map[string]string{"env": "dev"}, 1),
+				makeDynamicResource("res5", map[string]string{"env": "prod"}),
+				makeDynamicResource("res6", map[string]string{"env": "dev"}),
+			},
+			onCreateCalls: types.ResourcesWithLabels{
+				makeDynamicResource("res5", map[string]string{"env": "prod"}),
+			},
+			onUpdateCalls: types.ResourcesWithLabels{
+				makeDynamicResourceWithID("res2", map[string]string{"env": "prod", "a": "b"}, 1),
+			},
+			onDeleteCalls: types.ResourcesWithLabels{
+				makeDynamicResource("res1", map[string]string{"env": "prod"}),
+				makeDynamicResource("res4", map[string]string{"env": "prod"}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			// Reconciler will record all callback calls in these lists.
+			var onCreateCalls, onUpdateCalls, onDeleteCalls types.ResourcesWithLabels
+
+			reconciler, err := NewReconciler(ReconcilerConfig{
+				Selectors: test.selectors,
+				GetResources: func() types.ResourcesWithLabels {
+					return test.registeredResources
+				},
+				OnCreate: func(ctx context.Context, r types.ResourceWithLabels) error {
+					onCreateCalls = append(onCreateCalls, r)
+					return nil
+				},
+				OnUpdate: func(ctx context.Context, r types.ResourceWithLabels) error {
+					onUpdateCalls = append(onUpdateCalls, r)
+					return nil
+				},
+				OnDelete: func(ctx context.Context, r types.ResourceWithLabels) error {
+					onDeleteCalls = append(onDeleteCalls, r)
+					return nil
+				},
+			})
+			require.NoError(t, err)
+
+			// Reconcile and make sure we got all expected callback calls.
+			err = reconciler.Reconcile(context.Background(), test.newResources)
+			require.NoError(t, err)
+			require.Equal(t, test.onCreateCalls, onCreateCalls)
+			require.Equal(t, test.onUpdateCalls, onUpdateCalls)
+			require.Equal(t, test.onDeleteCalls, onDeleteCalls)
+		})
+	}
+}
+
+func makeStaticResource(name string, labels map[string]string) types.ResourceWithLabels {
+	return makeResource(name, labels, map[string]string{
+		types.OriginLabel: types.OriginConfigFile,
+	}, 0)
+}
+
+func makeDynamicResource(name string, labels map[string]string) types.ResourceWithLabels {
+	return makeResource(name, labels, map[string]string{
+		types.OriginLabel: types.OriginDynamic,
+	}, 0)
+}
+
+func makeDynamicResourceWithID(name string, labels map[string]string, id int64) types.ResourceWithLabels {
+	return makeResource(name, labels, map[string]string{
+		types.OriginLabel: types.OriginDynamic,
+	}, id)
+}
+
+func makeResource(name string, labels map[string]string, additionalLabels map[string]string, id int64) types.ResourceWithLabels {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	for k, v := range additionalLabels {
+		labels[k] = v
+	}
+	return &testResource{
+		name:   name,
+		labels: labels,
+		resID:  id,
+	}
+}
+
+type testResource struct {
+	types.ResourceWithLabels
+	name   string
+	labels map[string]string
+	resID  int64
+}
+
+func (r *testResource) GetName() string {
+	return r.name
+}
+
+func (r *testResource) Origin() string {
+	return r.labels[types.OriginLabel]
+}
+
+func (r testResource) GetResourceID() int64 {
+	return r.resID
+}
+
+func (r *testResource) GetAllLabels() map[string]string {
+	return r.labels
+}

--- a/lib/services/selector.go
+++ b/lib/services/selector.go
@@ -38,16 +38,16 @@ func (s Selector) String() string {
 	return ""
 }
 
-// MatchDatabase returns true if any of the provided selectors matches the provided database.
-func MatchDatabase(selectors []Selector, database types.Database) bool {
+// MatchResourceLabels returns true if any of the provided selectors matches the provided database.
+func MatchResourceLabels(selectors []Selector, resource types.ResourceWithLabels) bool {
 	for _, selector := range selectors {
 		if len(selector.MatchLabels) == 0 {
 			return false
 		}
-		match, _, err := MatchLabels(selector.MatchLabels, database.GetAllLabels())
+		match, _, err := MatchLabels(selector.MatchLabels, resource.GetAllLabels())
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to match labels %v: %v.",
-				selector.MatchLabels, database)
+				selector.MatchLabels, resource)
 			return false
 		}
 		if match {

--- a/lib/services/selector_test.go
+++ b/lib/services/selector_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestMatchDatabase tests matching databases against a selector.
-func TestMatchDatabase(t *testing.T) {
+// TestMatchResourceLabels tests matching a resource against a selector.
+func TestMatchResourceLabels(t *testing.T) {
 	tests := []struct {
 		description    string
 		selectors      []Selector
@@ -129,7 +129,7 @@ func TestMatchDatabase(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Equal(t, test.match, MatchDatabase(test.selectors, database))
+			require.Equal(t, test.match, MatchResourceLabels(test.selectors, database))
 		})
 	}
 }

--- a/lib/srv/app/watcher_test.go
+++ b/lib/srv/app/watcher_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWatcher verifies that app agent properly detects and applies
+// changes to application resources.
+func TestWatcher(t *testing.T) {
+	ctx := context.Background()
+
+	// Make a static configuration app.
+	app0, err := makeStaticApp("app0", nil)
+	require.NoError(t, err)
+
+	// This channel will receive new set of apps the server proxies
+	// after each reconciliation.
+	reconcileCh := make(chan types.Apps)
+
+	// Setup app server that proxies one static app and
+	// watches for apps with label group=a.
+	s := SetUpSuiteWithConfig(t, suiteConfig{
+		Apps: types.Apps{app0},
+		Selectors: []services.Selector{
+			{MatchLabels: types.Labels{
+				"group": []string{"a"},
+			}},
+		},
+		OnReconcile: func(a types.Apps) {
+			reconcileCh <- a
+		},
+	})
+
+	// Only app0 should be registered initially.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.Apps{app0}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Create app with label group=a.
+	app1, err := makeDynamicApp("app1", map[string]string{"group": "a"})
+	require.NoError(t, err)
+	err = s.authServer.AuthServer.CreateApp(ctx, app1)
+	require.NoError(t, err)
+
+	// It should be registered.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.Apps{app0, app1}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Try to update app0 which is registered statically.
+	app0Updated, err := makeDynamicApp("app0", map[string]string{"group": "a", types.OriginLabel: types.OriginDynamic})
+	require.NoError(t, err)
+	err = s.authServer.AuthServer.CreateApp(ctx, app0Updated)
+	require.NoError(t, err)
+
+	// It should not be registered, old app0 should remain.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.Apps{app0, app1}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Create app with label group=b.
+	app2, err := makeDynamicApp("app2", map[string]string{"group": "b"})
+	require.NoError(t, err)
+	err = s.authServer.AuthServer.CreateApp(ctx, app2)
+	require.NoError(t, err)
+
+	// It shouldn't be registered.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.Apps{app0, app1}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Update app2 labels so it matches.
+	app2.SetStaticLabels(map[string]string{"group": "a", types.OriginLabel: types.OriginDynamic})
+	err = s.authServer.AuthServer.UpdateApp(ctx, app2)
+	require.NoError(t, err)
+
+	// Both should be registered now.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.Apps{app0, app1, app2}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Update app2 URI so it gets re-registered.
+	app2.SetURI("localhost:2345")
+	err = s.authServer.AuthServer.UpdateApp(ctx, app2)
+	require.NoError(t, err)
+
+	// app2 should get updated.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.Apps{app0, app1, app2}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Update app1 labels so it doesn't match.
+	app1.SetStaticLabels(map[string]string{"group": "c", types.OriginLabel: types.OriginDynamic})
+	err = s.authServer.AuthServer.UpdateApp(ctx, app1)
+	require.NoError(t, err)
+
+	// Only app0 and app2 should remain registered.
+	select {
+	case a := <-reconcileCh:
+		sort.Sort(a)
+		require.Empty(t, cmp.Diff(types.Apps{app0, app2}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+
+	// Remove app2.
+	err = s.authServer.AuthServer.DeleteApp(ctx, app2.GetName())
+	require.NoError(t, err)
+
+	// Only static app should remain.
+	select {
+	case a := <-reconcileCh:
+		require.Empty(t, cmp.Diff(types.Apps{app0}, a,
+			cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		))
+	case <-time.After(time.Second):
+		t.Fatal("Didn't receive reconcile event after 1s.")
+	}
+}
+
+func makeStaticApp(name string, labels map[string]string) (*types.AppV3, error) {
+	return makeApp(name, labels, map[string]string{
+		types.OriginLabel: types.OriginConfigFile,
+	})
+}
+
+func makeDynamicApp(name string, labels map[string]string) (*types.AppV3, error) {
+	return makeApp(name, labels, map[string]string{
+		types.OriginLabel: types.OriginDynamic,
+	})
+}
+
+func makeApp(name string, labels map[string]string, additionalLabels map[string]string) (*types.AppV3, error) {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	for k, v := range additionalLabels {
+		labels[k] = v
+	}
+	return types.NewAppV3(types.Metadata{
+		Name:   name,
+		Labels: labels,
+	}, types.AppSpecV3{
+		URI: "localhost",
+	})
+}


### PR DESCRIPTION
This PR updates app agents to watch for changes in application resources within the cluster and make respective changes to their proxied apps, in line with what was done for databases in https://github.com/gravitational/teleport/pull/7957.

With this change, an app service can be configured to watch for specific application resources and will register/unregister them appropriately:

```yaml
app_service:
  enabled: "yes"
  selectors:
  - match_labels:
      "env": "local"
```

Since the reconciliation logic is pretty much the same for app and database resources, I have factored out the reconciler so it can be reused (potentially for other services too in future if needed).

This should be the final one of the number of changes for app/databases that lay down the groundwork for dynamic registration and open up a way for automatic discovery which will come next.

Refs https://github.com/gravitational/teleport/issues/6538.