### PR TITLE
[5.0] Rotate Mac signing certificates

### DIFF
--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -68,9 +68,9 @@ VENDOR="Gravitational"
 DESCRIPTION="Gravitational Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API"
 DOCS_URL="https://gravitational.com/teleport/docs"
 
-# signing IDs to use for mac (must be pre-loaded into the keychain on the build box)
-DEVELOPER_ID_APPLICATION="Developer ID Application: Gravitational Inc." # used for signing binaries
-DEVELOPER_ID_INSTALLER="Developer ID Installer: Gravitational Inc." # used for signing packages
+# SHA1 fingerprints of certificates used for signing mac artifacts (certificates must be pre-loaded into the keychain on the build box)
+DEVELOPER_ID_APPLICATION="0FFD3E3413AB4C599C53FBB1D8CA690915E33D83" # used for signing binaries
+DEVELOPER_ID_INSTALLER="82B625AD327C241B378A54B4B254BB08CE71B5DF" # used for signing packages
 
 # download root for packages
 DOWNLOAD_ROOT="https://get.gravitational.com"


### PR DESCRIPTION
5.0 backport of https://github.com/gravitational/teleport/pull/8230

This switches mac signing from from our previous certs (provisioned 2019-11-14):

```
68CD25020529571A1E44BC749A24963FC926D335 "Developer ID Application: Gravitational Inc. (QH8AA5B8UP)"
D270EA0CF20ECB1728B221E1D5B67CFE50FFAB62 "Developer ID Installer: Gravitational Inc. (QH8AA5B8UP)"
```

to our new certs (provisioned 2021-07-26)

```
0FFD3E3413AB4C599C53FBB1D8CA690915E33D83 "Developer ID Application: Gravitational Inc. (QH8AA5B8UP)"
82B625AD327C241B378A54B4B254BB08CE71B5DF "Developer ID Installer: Gravitational Inc. (QH8AA5B8UP)"
```

All of these certificates are present on our mac builder.

## Testing Done

See:
https://drone.teleport.dev/gravitational/teleport/4156/12/4
https://drone.teleport.dev/gravitational/teleport/4156/13/4
 