### PR TITLE
(v6.2) Fix unspecified web hostname

### DIFF
--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -133,6 +133,8 @@ func TestConfig(t *testing.T) {
 		require.Equal(t, "INFO", fc.Logger.Severity)
 		require.Equal(t, fc.Auth.ClusterName, ClusterName("cookie.localhost"))
 		require.Equal(t, fc.Auth.LicenseFile, "/tmp/license.pem")
+		require.Equal(t, fc.Proxy.PublicAddr, utils.Strings{"cookie.localhost:443"})
+		require.Equal(t, fc.Proxy.WebAddr, "0.0.0.0:443")
 
 		require.False(t, lib.IsInsecureDevMode())
 	})

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -386,7 +386,7 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 		// ACME uses TLS-ALPN-01 challenge that requires port 443
 		// https://letsencrypt.org/docs/challenge-types/#tls-alpn-01
 		p.PublicAddr = utils.Strings{net.JoinHostPort(flags.ClusterName, fmt.Sprintf("%d", teleport.StandardHTTPSPort))}
-		p.WebAddr = fmt.Sprintf(":%d", teleport.StandardHTTPSPort)
+		p.WebAddr = net.JoinHostPort(defaults.BindIP, fmt.Sprintf("%d", teleport.StandardHTTPSPort))
 	}
 
 	fc = &FileConfig{

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2174,9 +2174,9 @@ func (process *TeleportProcess) getAdditionalPrincipals(role teleport.Role) ([]s
 		if addr.IsEmpty() {
 			continue
 		}
-		host, err := utils.Host(addr.Addr)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
+		host := addr.Host()
+		if host == "" {
+			host = defaults.BindIP
 		}
 		principals = append(principals, host)
 	}

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -310,6 +310,7 @@ func TestGetAdditionalPrincipals(t *testing.T) {
 					Enabled:     true,
 					PublicAddrs: utils.MustParseAddrList("proxy-kube-public-1", "proxy-kube-public-2"),
 				},
+				WebAddr: *utils.MustParseAddr(":443"),
 			},
 			Auth: AuthConfig{
 				PublicAddrs: utils.MustParseAddrList("auth-public-1", "auth-public-2"),
@@ -333,6 +334,7 @@ func TestGetAdditionalPrincipals(t *testing.T) {
 				"global-hostname",
 				"proxy-public-1",
 				"proxy-public-2",
+				defaults.BindIP,
 				string(teleport.PrincipalLocalhost),
 				string(teleport.PrincipalLoopbackV4),
 				string(teleport.PrincipalLoopbackV6),

--- a/lib/utils/addr.go
+++ b/lib/utils/addr.go
@@ -84,6 +84,11 @@ func (a *NetAddr) IsLoopback() bool {
 	return IsLoopback(a.Addr)
 }
 
+// IsHostUnspecified returns true if this address' host is unspecified.
+func (a *NetAddr) IsHostUnspecified() bool {
+	return a.Host() == "" || net.ParseIP(a.Host()).IsUnspecified()
+}
+
 // IsEmpty returns true if address is empty
 func (a *NetAddr) IsEmpty() bool {
 	return a == nil || (a.Addr == "" && a.AddrNetwork == "" && a.Path == "")

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2393,7 +2393,8 @@ func (h *Handler) ProxyWithRoles(ctx *SessionContext) (reversetunnel.Tunnel, err
 // ProxyHostPort returns the address of the proxy server using --proxy
 // notation, i.e. "localhost:8030,8023"
 func (h *Handler) ProxyHostPort() string {
-	// Proxy web address can set in the config like 0.0.0.0:3080.
+	// Proxy web address can be set in the config with unspecified host, like
+	// 0.0.0.0:3080 or :443.
 	//
 	// In this case, the dial will succeed (dialing 0.0.0.0 is same a dialing
 	// localhost in Go) but the SSH host certificate will not validate since
@@ -2403,7 +2404,7 @@ func (h *Handler) ProxyHostPort() string {
 	// As such, replace 0.0.0.0 with localhost in this case: proxy listens on
 	// all interfaces and localhost is always included in the valid principal
 	// set.
-	if net.ParseIP(h.cfg.ProxyWebAddr.Host()).IsUnspecified() {
+	if h.cfg.ProxyWebAddr.IsHostUnspecified() {
 		return fmt.Sprintf("localhost:%v,%s", h.cfg.ProxyWebAddr.Port(defaults.HTTPListenPort), h.sshPort)
 	}
 	return fmt.Sprintf("%s,%s", h.cfg.ProxyWebAddr.String(), h.sshPort)


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/8245 backport to v6.2.