### PR TITLE
unify embed assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ default.etcd
 darwin
 
 # web asset directory
-/lib/web/build
+/embed.assets/web/*
 
 # usually release tarballs get in the way
 *.gz

--- a/embed.assets/README.md
+++ b/embed.assets/README.md
@@ -1,0 +1,3 @@
+## Embed Assets
+
+After builds, this directory contains files that are embedded within Teleport.

--- a/embed.go
+++ b/embed.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package teleport
 
 import (
@@ -13,8 +27,8 @@ func EmbedFS() embed.FS {
 }
 
 var (
-	EmbedAssetsBuildDir       = "embed.assets"
-	EnhancedRecordingBuildDir = filepath.Join(EmbedAssetsBuildDir, "enhancedrecording")
-	RestrictedSessionBuildDir = filepath.Join(EmbedAssetsBuildDir, "restrictedsession")
-	WebAssetsBuildDir         = filepath.Join(EmbedAssetsBuildDir, "web")
+	EmbedAssetsDir             = "embed.assets"
+	EnhancedRecordingAssetsDir = filepath.Join(EmbedAssetsDir, "enhancedrecording")
+	RestrictedSessionAssetsDir = filepath.Join(EmbedAssetsDir, "restrictedsession")
+	WebAssetsDir               = filepath.Join(EmbedAssetsDir, "web")
 )

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,20 @@
+package teleport
+
+import (
+	"embed"
+	"path/filepath"
+)
+
+//go:embed embed.assets
+var embedFS embed.FS
+
+func EmbedFS() embed.FS {
+	return embedFS
+}
+
+var (
+	EmbedAssetsBuildDir       = "embed.assets"
+	EnhancedRecordingBuildDir = filepath.Join(EmbedAssetsBuildDir, "enhancedrecording")
+	RestrictedSessionBuildDir = filepath.Join(EmbedAssetsBuildDir, "restrictedsession")
+	WebAssetsBuildDir         = filepath.Join(EmbedAssetsBuildDir, "web")
+)

--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -25,7 +25,6 @@ import "C"
 import (
 	"bytes"
 	"context"
-	"embed"
 	"encoding/binary"
 	"net"
 	"strconv"
@@ -42,9 +41,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/gravitational/ttlmap"
 )
-
-//go:embed bytecode
-var embedFS embed.FS
 
 // SessionWatch is a map of cgroup IDs that the BPF service is watching and
 // emitting events for.

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -20,7 +20,6 @@ package bpf
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"io/ioutil"
 	"net/http"

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -27,12 +27,14 @@ import (
 	"net/http/httptest"
 	"os"
 	os_exec "os/exec"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
 	"unsafe"
 
 	"github.com/aquasecurity/libbpfgo"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -395,7 +397,7 @@ func (s *Suite) TestBPFCounter(c *check.C) {
 		c.Skip(fmt.Sprintf("Tests for package bpf can not be run: %v.", err))
 	}
 
-	counterTestBPF, err := embedFS.ReadFile("bytecode/counter_test.bpf.o")
+	counterTestBPF, err := teleport.EmbedFS().ReadFile(filepath.Join(teleport.EnhancedRecordingBuildDir, "counter_test.bpf.o"))
 	if err != nil {
 		c.Skip(fmt.Sprintf("Tests for package bpf can not be run: %v.", err))
 	}

--- a/lib/bpf/bytecode/README.md
+++ b/lib/bpf/bytecode/README.md
@@ -1,3 +1,0 @@
-## BPF Bytecode
-
-After builds, this directory contains CO-RE BFP bytecode that is embedded within Teleport.

--- a/lib/bpf/command.go
+++ b/lib/bpf/command.go
@@ -19,7 +19,6 @@ limitations under the License.
 package bpf
 
 import (
-	_ "embed"
 	"path/filepath"
 
 	"github.com/gravitational/teleport"

--- a/lib/bpf/command.go
+++ b/lib/bpf/command.go
@@ -19,15 +19,15 @@ limitations under the License.
 package bpf
 
 import (
+	_ "embed"
+	"path/filepath"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 
-	"github.com/gravitational/trace"
-
 	"github.com/aquasecurity/libbpfgo"
+	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
-
-	_ "embed"
 )
 
 var (
@@ -85,7 +85,7 @@ func startExec(bufferSize int) (*exec, error) {
 
 	e := &exec{}
 
-	commandBPF, err := embedFS.ReadFile("bytecode/command.bpf.o")
+	commandBPF, err := teleport.EmbedFS().ReadFile(filepath.Join(teleport.EnhancedRecordingBuildDir, "command.bpf.o"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/bpf/disk.go
+++ b/lib/bpf/disk.go
@@ -19,14 +19,15 @@ limitations under the License.
 package bpf
 
 import (
+	_ "embed"
+	"path/filepath"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
 
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/prometheus/client_golang/prometheus"
-
-	_ "embed"
 )
 
 var (
@@ -81,7 +82,7 @@ func startOpen(bufferSize int) (*open, error) {
 
 	o := &open{}
 
-	diskBPF, err := embedFS.ReadFile("bytecode/disk.bpf.o")
+	diskBPF, err := teleport.EmbedFS().ReadFile(filepath.Join(teleport.EnhancedRecordingBuildDir, "disk.bpf.o"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/bpf/disk.go
+++ b/lib/bpf/disk.go
@@ -19,7 +19,6 @@ limitations under the License.
 package bpf
 
 import (
-	_ "embed"
 	"path/filepath"
 
 	"github.com/gravitational/teleport"

--- a/lib/bpf/network.go
+++ b/lib/bpf/network.go
@@ -19,14 +19,15 @@ limitations under the License.
 package bpf
 
 import (
-	"github.com/aquasecurity/libbpfgo"
-	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
-	"github.com/prometheus/client_golang/prometheus"
+	_ "embed"
+	"path/filepath"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/utils"
 
-	_ "embed"
+	"github.com/aquasecurity/libbpfgo"
+	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -110,7 +111,7 @@ func startConn(bufferSize int) (*conn, error) {
 
 	c := &conn{}
 
-	networkBPF, err := embedFS.ReadFile("bytecode/network.bpf.o")
+	networkBPF, err := teleport.EmbedFS().ReadFile(filepath.Join(teleport.EnhancedRecordingBuildDir, "network.bpf.o"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/bpf/network.go
+++ b/lib/bpf/network.go
@@ -19,7 +19,6 @@ limitations under the License.
 package bpf
 
 import (
-	_ "embed"
 	"path/filepath"
 
 	"github.com/gravitational/teleport"

--- a/lib/restrictedsession/bytecode/README.md
+++ b/lib/restrictedsession/bytecode/README.md
@@ -1,3 +1,0 @@
-## BPF Bytecode
-
-After builds, this directory contains CO-RE BFP bytecode that is embedded within Teleport.

--- a/lib/restrictedsession/restricted.go
+++ b/lib/restrictedsession/restricted.go
@@ -20,15 +20,15 @@ package restrictedsession
 
 import (
 	"bytes"
-	"embed"
 	"encoding/binary"
+	"path/filepath"
 	"sync"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/bpf"
+
 	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/sirupsen/logrus"
 )
@@ -45,9 +45,6 @@ var (
 		},
 	)
 )
-
-//go:embed bytecode
-var embedFS embed.FS
 
 func init() {
 	prometheus.MustRegister(lostRestrictedEvents)
@@ -95,7 +92,7 @@ func New(config *Config, wc RestrictionsWatcherClient) (Manager, error) {
 
 	log.Debugf("Starting restricted session.")
 
-	restrictedBPF, err := embedFS.ReadFile("bytecode/restricted.bpf.o")
+	restrictedBPF, err := teleport.EmbedFS().ReadFile(filepath.Join(teleport.RestrictedSessionBuildDir, "restricted.bpf.o"))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/static_embed.go
+++ b/lib/web/static_embed.go
@@ -19,20 +19,17 @@ limitations under the License.
 package web
 
 import (
-	"embed"
 	"io/fs"
 	"net/http"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 )
-
-//go:embed build/webassets
-var webassetFS embed.FS
 
 // NewStaticFileSystem returns the initialized implementation of http.FileSystem
 // interface which can be used to serve Teleport Proxy Web UI
 func NewStaticFileSystem() (http.FileSystem, error) {
-	wfs, err := fs.Sub(webassetFS, "build/webassets")
+	wfs, err := fs.Sub(teleport.EmbedFS(), teleport.WebAssetsBuildDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/static_embed.go
+++ b/lib/web/static_embed.go
@@ -29,7 +29,7 @@ import (
 // NewStaticFileSystem returns the initialized implementation of http.FileSystem
 // interface which can be used to serve Teleport Proxy Web UI
 func NewStaticFileSystem() (http.FileSystem, error) {
-	wfs, err := fs.Sub(teleport.EmbedFS(), teleport.WebAssetsBuildDir)
+	wfs, err := fs.Sub(teleport.EmbedFS(), teleport.WebAssetsDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR is a follow up to [this commit](https://github.com/gravitational/teleport/pull/7432/commits/31b666dcfb0ac4ee201469f23810c9694eeddc19).

BPF, web, and other embeded assets will now populate the `embed.assets` directory. They can be imported from `teleport/embed.go` with `teleport.EmbedFS()`.

With this change, missing object files will be a runtime error rather than a compile error. A `README.md` is placed in `embed.assets` for this reason. This makes it possible to import the teleport module in teleport-plugins without libbpf tools or our webassets.

e PR - https://github.com/gravitational/teleport.e/pull/314