### PR TITLE
Fix linker flags in datalog CGO wrapper

### DIFF
--- a/lib/datalog/access.go
+++ b/lib/datalog/access.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package datalog
 
-// #cgo LDFLAGS: -L./roletester/target/release -lrole_tester
+// #cgo LDFLAGS: -L./roletester/target/release -lrole_tester -ldl -lm
 // #include <stdio.h>
 // #include <stdlib.h>
 // typedef struct output output_t;


### PR DESCRIPTION
`-ldl` is needed to link in the appropriate system library for loading
shared objects.