### PR TITLE
Improve FirestoreDB/KeepAlive test failure message

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -183,6 +183,14 @@ type Item struct {
 	LeaseID int64
 }
 
+func (e Event) String() string {
+	val := string(e.Item.Value)
+	if len(val) > 20 {
+		val = val[:20] + "..."
+	}
+	return fmt.Sprintf("%v %s=%s", e.Type, e.Item.Key, val)
+}
+
 // Config is used for 'storage' config section. It's a combination of
 // values for various backends: 'boltdb', 'etcd', 'filesystem' and 'dynamodb'
 type Config struct {

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -484,7 +484,8 @@ func collectEvents(ctx context.Context, t *testing.T, watcher backend.Watcher, c
 		case <-watcher.Done():
 			require.FailNow(t, "Watcher has unexpectedly closed.")
 		case <-ctx.Done():
-			require.FailNowf(t, "Context expired waiting for event.", "Captured so far: %v", events)
+			require.FailNowf(t, "Context expired waiting for events.",
+				"Captured %d of %d so far: %v", len(events), count, events)
 		}
 	}
 	return events


### PR DESCRIPTION
The firestore keep alive test seems to fail many times per day. This does nothing to fix the issue but does make it easier to troubleshoot.

This commit makes it easier to see what went wrong by:
- including information on how many events were received and expected
- making `backend.Event` a `fmt.Stringer`, so that we don't dump a `[]byte` to the console

Failure message before:

    --- FAIL: TestFirestoreDB (13.05s)
        --- FAIL: TestFirestoreDB/KeepAlive (10.01s)
            suite.go:487:
                	Error Trace:	suite.go:487
                	            				suite.go:461
                	            				suite.go:136
                	Error:      	Context expired waiting for event.
                	Test:       	TestFirestoreDB/KeepAlive
                	Messages:   	Captured so far: [{Put {[47 101 97 97 101 53 49 48 56 45 50 50 56 49 45 52 49 55 100 45 57 98 99 99 45 52 50 97 102 49 53 54 52 99 98 97 99 107 101 121] [118 97 108 49] 1984-04-04 00:01:02 +0000 UTC 449884801000000000 0}}]

Failure message after:

    --- FAIL: TestFirestoreDB (10.01s)
        --- FAIL: TestFirestoreDB/KeepAlive (10.00s)
            suite.go:487:
                    Error Trace:    suite.go:487
                                                            suite.go:461
                                                            suite.go:136
                    Error:          Context expired waiting for events.
                    Test:           TestFirestoreDB/KeepAlive
                    Messages:       Captured 1 of 2 so far: [Put /545e2ee9-3e40-4a0c-ba58-0882ab9024e7key=val1]