### PR TITLE
improve graceful restart behavior

### DIFF
--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -568,9 +568,10 @@ func (s *server) Close() error {
 }
 
 func (s *server) Shutdown(ctx context.Context) error {
-	s.cancel()
+	err := s.srv.Shutdown(ctx)
 	s.proxyWatcher.Close()
-	return s.srv.Shutdown(ctx)
+	s.cancel()
+	return trace.Wrap(err)
 }
 
 func (s *server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionContext, nch ssh.NewChannel) {
@@ -629,7 +630,7 @@ func (s *server) handleTransport(sconn *ssh.ServerConn, nch ssh.NewChannel) {
 // TODO(awly): unit test this
 func (s *server) handleHeartbeat(conn net.Conn, sconn *ssh.ServerConn, nch ssh.NewChannel) {
 	s.log.Debugf("New tunnel from %v.", sconn.RemoteAddr())
-	if sconn.Permissions.Extensions[extCertType] != extCertTypeHost {
+	if sconn.Permissions.Extensions[utils.ExtIntCertType] != utils.ExtIntCertTypeHost {
 		s.log.Error(trace.BadParameter("can't retrieve certificate type in certType"))
 		return
 	}
@@ -760,7 +761,7 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (perm *ssh.Pe
 		if !ok || certRole == "" {
 			return nil, trace.BadParameter("certificate missing %q extension; this SSH host certificate was not issued by Teleport or issued by an older version of Teleport; try upgrading your Teleport nodes/proxies", utils.CertExtensionRole)
 		}
-		certType = extCertTypeHost
+		certType = utils.ExtIntCertTypeHost
 		caType = types.HostCA
 	case ssh.UserCert:
 		var ok bool
@@ -780,7 +781,7 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (perm *ssh.Pe
 			return nil, trace.BadParameter("certificate missing roles in %q extension; make sure your user has some roles assigned (or ask your Teleport admin to) and log in again (or export an identity file, if that's what you used)", teleport.CertExtensionTeleportRoles)
 		}
 		certRole = roles[0]
-		certType = extCertTypeUser
+		certType = utils.ExtIntCertTypeUser
 		caType = types.UserCA
 	default:
 		return nil, trace.BadParameter("unsupported cert type: %v.", cert.CertType)
@@ -791,10 +792,10 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (perm *ssh.Pe
 	}
 	return &ssh.Permissions{
 		Extensions: map[string]string{
-			extHost:      conn.User(),
-			extCertType:  certType,
-			extCertRole:  certRole,
-			extAuthority: clusterName,
+			extHost:              conn.User(),
+			utils.ExtIntCertType: certType,
+			extCertRole:          certRole,
+			extAuthority:         clusterName,
 		},
 	}, nil
 }
@@ -1129,12 +1130,9 @@ func sendVersionRequest(ctx context.Context, sconn ssh.Conn) (string, error) {
 }
 
 const (
-	extHost         = "host@teleport"
-	extCertType     = "certtype@teleport"
-	extAuthority    = "auth@teleport"
-	extCertTypeHost = "host"
-	extCertTypeUser = "user"
-	extCertRole     = "role"
+	extHost      = "host@teleport"
+	extAuthority = "auth@teleport"
+	extCertRole  = "role"
 
 	versionRequest = "x-teleport-version"
 )

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/testlog"
 
 	"github.com/google/go-cmp/cmp"
@@ -87,10 +88,10 @@ func TestServerKeyAuth(t *testing.T) {
 				return key
 			}(),
 			wantExtensions: map[string]string{
-				extHost:      con.User(),
-				extCertType:  extCertTypeHost,
-				extCertRole:  string(types.RoleNode),
-				extAuthority: "host-cluster-name",
+				extHost:              con.User(),
+				utils.ExtIntCertType: utils.ExtIntCertTypeHost,
+				extCertRole:          string(types.RoleNode),
+				extAuthority:         "host-cluster-name",
 			},
 			wantErr: require.NoError,
 		},
@@ -114,10 +115,10 @@ func TestServerKeyAuth(t *testing.T) {
 				return key
 			}(),
 			wantExtensions: map[string]string{
-				extHost:      con.User(),
-				extCertType:  extCertTypeUser,
-				extCertRole:  "dev",
-				extAuthority: "user-cluster-name",
+				extHost:              con.User(),
+				utils.ExtIntCertType: utils.ExtIntCertTypeUser,
+				extCertRole:          "dev",
+				extAuthority:         "user-cluster-name",
 			},
 			wantErr: require.NoError,
 		},

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -433,7 +433,7 @@ func (process *TeleportProcess) periodicSyncRotationState() error {
 	select {
 	case <-eventC:
 		process.log.Infof("The new service has started successfully. Starting syncing rotation status with period %v.", process.Config.PollingPeriod)
-	case <-process.ExitContext().Done():
+	case <-process.GracefulExitContext().Done():
 		return nil
 	}
 
@@ -452,7 +452,7 @@ func (process *TeleportProcess) periodicSyncRotationState() error {
 		process.log.Warningf("Sync rotation state cycle failed: %v, going to retry after ~%v.", err, defaults.HighResPollingPeriod)
 		select {
 		case <-periodic.Next():
-		case <-process.ExitContext().Done():
+		case <-process.GracefulExitContext().Done():
 			return nil
 		}
 	}
@@ -532,7 +532,7 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 			if status.needsReload {
 				return nil
 			}
-		case <-process.ExitContext().Done():
+		case <-process.GracefulExitContext().Done():
 			return nil
 		}
 	}

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -229,6 +229,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 		if agentPool != nil {
 			agentPool.Stop()
 		}
+		warnOnErr(conn.Close(), log)
 		log.Info("Exited.")
 	})
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1385,7 +1385,7 @@ func (process *TeleportProcess) initAuthService() error {
 
 	heartbeat, err := srv.NewHeartbeat(srv.HeartbeatConfig{
 		Mode:      srv.HeartbeatModeAuth,
-		Context:   process.ExitContext(),
+		Context:   process.GracefulExitContext(),
 		Component: teleport.ComponentAuth,
 		Announcer: authServer,
 		GetServerInfo: func() (types.Resource, error) {
@@ -1446,9 +1446,14 @@ func (process *TeleportProcess) initAuthService() error {
 			log.Info("Shutting down immediately.")
 			warnOnErr(tlsServer.Close(), log)
 		} else {
-			log.Info("Shutting down gracefully.")
-			ctx := payloadContext(payload, log)
-			warnOnErr(tlsServer.Shutdown(ctx), log)
+			log.Info("Shutting down immediately (auth service does not currently support graceful shutdown).")
+			// NOTE: Graceful shutdown of auth.TLSServer is disabled right now, because we don't
+			// have a good model for performing it.  In particular, watchers and other GRPC streams
+			// are a problem.  Even if we distinguish between user-created and server-created streams
+			// (as is done with ssh connections), we don't have a way to distinguish "service accounts"
+			// such as access workflow plugins from normal users.  Without this, a graceful shutdown
+			// of the auth server basically never exits.
+			warnOnErr(tlsServer.Close(), log)
 		}
 		if uploadCompleter != nil {
 			warnOnErr(uploadCompleter.Close(), log)
@@ -1951,6 +1956,10 @@ func (process *TeleportProcess) initSSH() error {
 			warnOnErr(asyncEmitter.Close(), log)
 		}
 
+		if conn != nil {
+			warnOnErr(conn.Close(), log)
+		}
+
 		log.Infof("Exited.")
 	})
 
@@ -1967,13 +1976,6 @@ func (process *TeleportProcess) registerWithAuthServer(role types.SystemRole, ev
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		process.OnExit(fmt.Sprintf("auth.client.%v", serviceName), func(interface{}) {
-			process.log.Debugf("Closed client for %v.", role)
-			err := connector.Client.Close()
-			if err != nil {
-				process.log.Debugf("Failed to close client: %v", err)
-			}
-		})
 		process.BroadcastEvent(Event{Name: eventName, Payload: connector})
 		return nil
 	})
@@ -2206,7 +2208,7 @@ func (process *TeleportProcess) initDiagnosticService() error {
 			select {
 			case e := <-eventCh:
 				ps.update(e)
-			case <-process.ExitContext().Done():
+			case <-process.GracefulExitContext().Done():
 				log.Debugf("Teleport is exiting, returning.")
 				return nil
 			}
@@ -2398,11 +2400,8 @@ func (process *TeleportProcess) initProxy() error {
 			return trace.BadParameter("unsupported connector type: %T", event.Payload)
 		}
 
-		err := process.initProxyEndpoint(conn)
-		if err != nil {
-			if conn.Client != nil {
-				warnOnErr(conn.Client.Close(), process.log)
-			}
+		if err := process.initProxyEndpoint(conn); err != nil {
+			warnOnErr(conn.Close(), process.log)
 			return trace.Wrap(err)
 		}
 
@@ -3098,10 +3097,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		} else {
 			log.Infof("Shutting down gracefully.")
 			ctx := payloadContext(payload, log)
+			warnOnErr(sshProxy.Shutdown(ctx), log)
 			if tsrv != nil {
 				warnOnErr(tsrv.Shutdown(ctx), log)
 			}
-			warnOnErr(sshProxy.Shutdown(ctx), log)
 			if webServer != nil {
 				warnOnErr(webServer.Shutdown(ctx), log)
 			}
@@ -3115,11 +3114,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				warnOnErr(alpnServer.Close(), log)
 			}
 		}
-		// Close client after graceful shutdown has been completed,
-		// to make sure in flight streams are not terminated,
-		if conn.Client != nil {
-			warnOnErr(conn.Client.Close(), log)
-		}
+		warnOnErr(conn.Close(), log)
 		log.Infof("Exited.")
 	})
 	if err := process.initUploaderService(accessPoint, conn.Client); err != nil {
@@ -3354,6 +3349,7 @@ func (process *TeleportProcess) initApps() {
 
 	var appServer *app.Server
 	var agentPool *reversetunnel.AgentPool
+	var conn *Connector
 
 	process.RegisterCriticalFunc("apps.start", func() error {
 		var ok bool
@@ -3560,6 +3556,10 @@ func (process *TeleportProcess) initApps() {
 		}
 		if agentPool != nil {
 			agentPool.Stop()
+		}
+
+		if conn != nil {
+			warnOnErr(conn.Close(), log)
 		}
 
 		log.Infof("Exited.")

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -176,6 +176,13 @@ func (p *resourceWatcher) runWatchLoop() {
 	for {
 		p.Log.WithField("retry", p.retry).Debug("Starting watch.")
 		err := p.watch()
+
+		select {
+		case <-p.ctx.Done():
+			return
+		default:
+		}
+
 		if err != nil && p.failureStartedAt.IsZero() {
 			// Note that failureStartedAt is zeroed in the watch routine immediately
 			// after the local resource set has been successfully updated.

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -285,6 +285,15 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 	permissions.Extensions[utils.CertTeleportClusterName] = clusterName.GetClusterName()
 	permissions.Extensions[utils.CertTeleportUserCertificate] = string(ssh.MarshalAuthorizedKey(cert))
 
+	switch cert.CertType {
+	case ssh.UserCert:
+		permissions.Extensions[utils.ExtIntCertType] = utils.ExtIntCertTypeUser
+	case ssh.HostCert:
+		permissions.Extensions[utils.ExtIntCertType] = utils.ExtIntCertTypeHost
+	default:
+		log.Warnf("Unexpected cert type: %v", cert.CertType)
+	}
+
 	if h.isProxy() {
 		return permissions, nil
 	}

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -252,7 +252,11 @@ func wait(c *check.C, srv *Server) {
 func pass(need string) PasswordFunc {
 	return func(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
 		if string(password) == need {
-			return nil, nil
+			return &ssh.Permissions{
+				Extensions: map[string]string{
+					utils.ExtIntCertType: utils.ExtIntCertTypeUser,
+				},
+			}, nil
 		}
 		return nil, fmt.Errorf("passwords don't match")
 	}

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -590,4 +590,10 @@ const (
 	CertTeleportClusterName = "x-teleport-cluster-name"
 	// CertTeleportUserCertificate is the certificate of the authenticated in user.
 	CertTeleportUserCertificate = "x-teleport-certificate"
+	// ExtIntCertType is an internal extension used to propagate cert type.
+	ExtIntCertType = "certtype@teleport"
+	// ExtIntCertTypeHost indicates a host-type certificate.
+	ExtIntCertTypeHost = "host"
+	// ExtIntCertTypeUser indicates a user-type certificate.
+	ExtIntCertTypeUser = "user"
 )


### PR DESCRIPTION
This PR is a collection of various small tweaks to improve teleport's graceful restart behavior.  Most changes are simply reworks of shutdown ordering, to make sure that higher-level components are shutdown before the sub-components that they rely on. The three most significant changes are:

1. `Supervisor.ExitContext` is now cancelled at the end of a graceful restart instead of at the beginning (previous behavior was causing premature termination of important sub-components and background processes like the agent pool and cache).  A new `Supervisor.ShutdownContext` has been added which is canceled at the start of graceful shutdown.

2. SSH servers would previously refuse to shut down if they were handling _any_ ssh connections.  They now only track connections with _user_ certificates, ensuring that things like IoT node tunnels do not hold open ssh servers indefinitely.

3. Once I fixed the context-related issues that were killing the auth server's cache prematurely, it turned out that the auth server's graceful shutdown logic has never really worked, because it doesn't have a reasonable way to deal with persistent connections like watchers.  The existence of service-account esque users (e.g. access plugins) means that simply waiting for all user-created calls to complete is insufficient, since some users create watchers that exist indefinitely.  Graceful shutdown of the auth server is disabled for now, which effectively preserves its existing behavior, but with better error messages.