### PR TITLE
Support registration of Webauthn devices

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -55,6 +55,9 @@ type AuthPreference interface {
 	IsSecondFactorTOTPAllowed() bool
 	// IsSecondFactorU2FAllowed checks if users are allowed to register U2F devices.
 	IsSecondFactorU2FAllowed() bool
+	// IsSecondFactorWebauthnAllowed checks if users are allowed to register
+	// Webauthn devices.
+	IsSecondFactorWebauthnAllowed() bool
 
 	// GetConnectorName gets the name of the OIDC or SAML connector to use. If
 	// this value is empty, we fall back to the first connector in the backend.
@@ -229,12 +232,24 @@ func (c *AuthPreferenceV2) IsSecondFactorEnforced() bool {
 
 // IsSecondFactorTOTPAllowed checks if users are allowed to register TOTP devices.
 func (c *AuthPreferenceV2) IsSecondFactorTOTPAllowed() bool {
-	return c.Spec.SecondFactor == constants.SecondFactorOTP || c.Spec.SecondFactor == constants.SecondFactorOptional || c.Spec.SecondFactor == constants.SecondFactorOn
+	return c.Spec.SecondFactor == constants.SecondFactorOTP ||
+		c.Spec.SecondFactor == constants.SecondFactorOptional ||
+		c.Spec.SecondFactor == constants.SecondFactorOn
 }
 
 // IsSecondFactorU2FAllowed checks if users are allowed to register U2F devices.
 func (c *AuthPreferenceV2) IsSecondFactorU2FAllowed() bool {
-	return c.Spec.SecondFactor == constants.SecondFactorU2F || c.Spec.SecondFactor == constants.SecondFactorOptional || c.Spec.SecondFactor == constants.SecondFactorOn
+	return c.Spec.SecondFactor == constants.SecondFactorU2F ||
+		c.Spec.SecondFactor == constants.SecondFactorOptional ||
+		c.Spec.SecondFactor == constants.SecondFactorOn
+}
+
+// IsSecondFactorWebauthnAllowed checks if users are allowed to register
+// Webauthn devices.
+func (c *AuthPreferenceV2) IsSecondFactorWebauthnAllowed() bool {
+	return c.Spec.SecondFactor == constants.SecondFactorWebauthn ||
+		c.Spec.SecondFactor == constants.SecondFactorOptional ||
+		c.Spec.SecondFactor == constants.SecondFactorOn
 }
 
 // GetConnectorName gets the name of the OIDC or SAML connector to use. If

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1225,11 +1225,10 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 	}
 
 	kindToSF := map[string]constants.SecondFactorType{
-		fmt.Sprintf("%T", &types.MFADevice_Totp{}): constants.SecondFactorOTP,
-		fmt.Sprintf("%T", &types.MFADevice_U2F{}):  constants.SecondFactorU2F,
-		// TODO(codingllama): Map Webauthn devices to second factor.
+		fmt.Sprintf("%T", &types.MFADevice_Totp{}):     constants.SecondFactorOTP,
+		fmt.Sprintf("%T", &types.MFADevice_U2F{}):      constants.SecondFactorU2F,
+		fmt.Sprintf("%T", &types.MFADevice_Webauthn{}): constants.SecondFactorWebauthn,
 	}
-
 	sfToCount := make(map[constants.SecondFactorType]int)
 	var knownDevices int
 	var deviceToDelete *types.MFADevice
@@ -1250,11 +1249,9 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 			continue
 		}
 
-		count := sfToCount[sf]
-		sfToCount[sf] = count + 1
+		sfToCount[sf]++
 		knownDevices++
 	}
-
 	if deviceToDelete == nil {
 		return trace.NotFound("MFA device %q does not exist", deviceName)
 	}
@@ -1268,10 +1265,7 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 			return trace.BadParameter(
 				"cannot delete the last MFA device for this user; add a replacement device first to avoid getting locked out")
 		}
-	case constants.SecondFactorWebauthn:
-		// TODO(codingllama): Handle webauthn device deletion.
-		return trace.NotImplemented("webauthn device deletion not yet implemented")
-	default:
+	default: // SecondFactorOTP, SecondFactorU2F, SecondFactorWebauthn
 		if sfToCount[sf] < minDevices {
 			return trace.BadParameter(
 				"cannot delete the last %v device for this user; add a replacement device first to avoid getting locked out", sf)
@@ -1336,82 +1330,23 @@ func (a *Server) verifyMFARespAndAddDevice(ctx context.Context, regResp *proto.M
 		return nil, trace.BadParameter("second factor disabled by cluster configuration")
 	}
 
-	// Validate MFARegisterResponse and upsert the new device on success.
 	var dev *types.MFADevice
 	switch regResp.GetResponse().(type) {
 	case *proto.MFARegisterResponse_TOTP:
-		if !cap.IsSecondFactorTOTPAllowed() {
-			return nil, trace.BadParameter("second factor TOTP not allowed by cluster")
-		}
-
-		var totpSecret string
-		switch {
-		case req.tokenID != "":
-			secrets, err := a.Identity.GetUserTokenSecrets(ctx, req.tokenID)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			totpSecret = secrets.GetOTPKey()
-		case req.totpSecret != "":
-			totpSecret = req.totpSecret
-		default:
-			return nil, trace.BadParameter("missing TOTP secret")
-		}
-
-		dev, err = services.NewTOTPDevice(req.newDeviceName, totpSecret, a.clock.Now())
+		dev, err = a.registerTOTPDevice(ctx, regResp, req)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		if err := a.checkTOTP(ctx, req.username, regResp.GetTOTP().GetCode(), dev); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		if err := a.UpsertMFADevice(ctx, req.username, dev); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
 	case *proto.MFARegisterResponse_U2F:
-		if !cap.IsSecondFactorU2FAllowed() {
-			return nil, trace.BadParameter("second factor U2F not allowed by cluster")
-		}
-
-		u2fConfig, err := cap.GetU2F()
+		dev, err = a.registerU2FDevice(ctx, regResp, req)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
-		var storageKey string
-		var storage u2f.RegistrationStorage
-		switch {
-		case req.tokenID != "":
-			storage = a.Identity
-			storageKey = req.tokenID
-		case req.u2fStorage != nil:
-			storage = req.u2fStorage
-			storageKey = req.username
-		default:
-			return nil, trace.BadParameter("missing U2F storage")
-		}
-
-		// u2f.RegisterVerify will upsert the new device internally.
-		dev, err = u2f.RegisterVerify(ctx, u2f.RegisterVerifyParams{
-			DevName: req.newDeviceName,
-			Resp: u2f.RegisterChallengeResponse{
-				RegistrationData: regResp.GetU2F().GetRegistrationData(),
-				ClientData:       regResp.GetU2F().GetClientData(),
-			},
-			RegistrationStorageKey: req.username,
-			ChallengeStorageKey:    storageKey,
-			Storage:                storage,
-			Clock:                  a.GetClock(),
-			AttestationCAs:         u2fConfig.DeviceAttestationCAs,
-		})
-
+	case *proto.MFARegisterResponse_Webauthn:
+		dev, err = a.registerWebauthnDevice(ctx, regResp, req)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
 	default:
 		return nil, trace.BadParameter("MFARegisterResponse is an unknown response type %T", regResp.Response)
 	}
@@ -1435,6 +1370,108 @@ func (a *Server) verifyMFARespAndAddDevice(ctx context.Context, regResp *proto.M
 	}
 
 	return dev, nil
+}
+
+func (a *Server) registerTOTPDevice(ctx context.Context, regResp *proto.MFARegisterResponse, req *newMFADeviceFields) (*types.MFADevice, error) {
+	cap, err := a.GetAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if !cap.IsSecondFactorTOTPAllowed() {
+		return nil, trace.BadParameter("second factor TOTP not allowed by cluster")
+	}
+
+	var secret string
+	switch {
+	case req.tokenID != "":
+		secrets, err := a.Identity.GetUserTokenSecrets(ctx, req.tokenID)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		secret = secrets.GetOTPKey()
+	case req.totpSecret != "":
+		secret = req.totpSecret
+	default:
+		return nil, trace.BadParameter("missing TOTP secret")
+	}
+
+	dev, err := services.NewTOTPDevice(req.newDeviceName, secret, a.clock.Now())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := a.checkTOTP(ctx, req.username, regResp.GetTOTP().GetCode(), dev); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := a.UpsertMFADevice(ctx, req.username, dev); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return dev, nil
+}
+
+func (a *Server) registerU2FDevice(ctx context.Context, regResp *proto.MFARegisterResponse, req *newMFADeviceFields) (*types.MFADevice, error) {
+	cap, err := a.GetAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if !cap.IsSecondFactorU2FAllowed() {
+		return nil, trace.BadParameter("second factor U2F not allowed by cluster")
+	}
+
+	u2fConfig, err := cap.GetU2F()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var storageKey string
+	var storage u2f.RegistrationStorage
+	switch {
+	case req.tokenID != "":
+		storage = a.Identity
+		storageKey = req.tokenID
+	case req.u2fStorage != nil:
+		storage = req.u2fStorage
+		storageKey = req.username
+	default:
+		return nil, trace.BadParameter("missing U2F storage")
+	}
+
+	// u2f.RegisterVerify will upsert the new device internally.
+	dev, err := u2f.RegisterVerify(ctx, u2f.RegisterVerifyParams{
+		DevName: req.newDeviceName,
+		Resp: u2f.RegisterChallengeResponse{
+			RegistrationData: regResp.GetU2F().GetRegistrationData(),
+			ClientData:       regResp.GetU2F().GetClientData(),
+		},
+		RegistrationStorageKey: req.username,
+		ChallengeStorageKey:    storageKey,
+		Storage:                storage,
+		Clock:                  a.GetClock(),
+		AttestationCAs:         u2fConfig.DeviceAttestationCAs,
+	})
+	return dev, trace.Wrap(err)
+}
+
+func (a *Server) registerWebauthnDevice(ctx context.Context, regResp *proto.MFARegisterResponse, req *newMFADeviceFields) (*types.MFADevice, error) {
+	cap, err := a.GetAuthPreference(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if !cap.IsSecondFactorWebauthnAllowed() {
+		return nil, trace.BadParameter("second factor webauthn not allowed by cluster")
+	}
+
+	webConfig, err := cap.GetWebauthn()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	webRegistration := &wanlib.RegistrationFlow{
+		Webauthn: webConfig,
+		Identity: a.Identity,
+	}
+	// Finish upserts the device on success.
+	dev, err := webRegistration.Finish(
+		ctx, req.username, req.newDeviceName, wanlib.CredentialCreationResponseFromProto(regResp.GetWebauthn()))
+	return dev, trace.Wrap(err)
 }
 
 func (a *Server) CheckU2FSignResponse(ctx context.Context, user string, response *u2f.AuthenticateChallengeResponse) (*types.MFADevice, error) {
@@ -2872,7 +2909,10 @@ func groupByDeviceType(devs []*types.MFADevice, groupU2F, groupWebauthn bool) de
 			if groupWebauthn {
 				res.Webauthn = append(res.Webauthn, dev)
 			}
-			// TODO(codingllama): Handle Webauthn device once we have it.
+		case *types.MFADevice_Webauthn:
+			if groupWebauthn {
+				res.Webauthn = append(res.Webauthn, dev)
+			}
 		default:
 			log.Warningf("Skipping MFA device of unknown type %T.", dev.Device)
 		}
@@ -2882,6 +2922,7 @@ func groupByDeviceType(devs []*types.MFADevice, groupU2F, groupWebauthn bool) de
 }
 
 func (a *Server) validateMFAAuthResponse(ctx context.Context, user string, resp *proto.MFAAuthenticateResponse, u2fStorage u2f.AuthenticationStorage) (*types.MFADevice, error) {
+	// TODO(codingllama): Consolidate with authenticateUser?
 	switch res := resp.Response.(type) {
 	case *proto.MFAAuthenticateResponse_TOTP:
 		return a.checkOTP(user, res.TOTP.Code)
@@ -2891,6 +2932,22 @@ func (a *Server) validateMFAAuthResponse(ctx context.Context, user string, resp 
 			ClientData:    res.U2F.ClientData,
 			SignatureData: res.U2F.Signature,
 		}, u2fStorage)
+	case *proto.MFAAuthenticateResponse_Webauthn:
+		cap, err := a.GetAuthPreference(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		u2f, _ := cap.GetU2F()
+		webConfig, err := cap.GetWebauthn()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		webLogin := &wanlib.LoginFlow{
+			U2F:      u2f,
+			Webauthn: webConfig,
+			Identity: a.Identity,
+		}
+		return webLogin.Finish(ctx, user, wanlib.CredentialAssertionResponseFromProto(res.Webauthn))
 	default:
 		return nil, trace.BadParameter("unknown or missing MFAAuthenticateResponse type %T", resp.Response)
 	}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1265,11 +1265,13 @@ func (a *Server) deleteMFADeviceSafely(ctx context.Context, user, deviceName str
 			return trace.BadParameter(
 				"cannot delete the last MFA device for this user; add a replacement device first to avoid getting locked out")
 		}
-	default: // SecondFactorOTP, SecondFactorU2F, SecondFactorWebauthn
+	case constants.SecondFactorOTP, constants.SecondFactorU2F, constants.SecondFactorWebauthn:
 		if sfToCount[sf] < minDevices {
 			return trace.BadParameter(
-				"cannot delete the last %v device for this user; add a replacement device first to avoid getting locked out", sf)
+				"cannot delete the last %s device for this user; add a replacement device first to avoid getting locked out", sf)
 		}
+	default:
+		return trace.BadParameter("unexpected second factor type: %s", sf)
 	}
 
 	if err := a.DeleteMFADevice(ctx, user, deviceToDelete.Id); err != nil {

--- a/lib/auth/mocku2f/mocku2f.go
+++ b/lib/auth/mocku2f/mocku2f.go
@@ -49,6 +49,11 @@ type Key struct {
 	// ceremonies, even if the U2F App ID extension is present.
 	PreferRPID bool
 
+	// IgnoreAllowedCredentials allows the Key to sign a Webauthn
+	// CredentialAssertion even it its KeyHandle is not among the allowed
+	// credentials.
+	IgnoreAllowedCredentials bool
+
 	cert    []byte
 	counter uint32
 }

--- a/lib/auth/mocku2f/webauthn.go
+++ b/lib/auth/mocku2f/webauthn.go
@@ -46,7 +46,7 @@ func (muk *Key) SignAssertion(origin string, assertion *wanlib.CredentialAsserti
 			break
 		}
 	}
-	if !ok {
+	if !ok && !muk.IgnoreAllowedCredentials {
 		return nil, trace.BadParameter("device not allowed")
 	}
 

--- a/lib/auth/webauthn/proto.go
+++ b/lib/auth/webauthn/proto.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 
 	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
 
 	wantypes "github.com/gravitational/teleport/api/types/webauthn"
 )
@@ -25,6 +26,9 @@ import (
 // CredentialAssertionToProto converts a CredentialAssertion to its proto
 // counterpart.
 func CredentialAssertionToProto(assertion *CredentialAssertion) *wantypes.CredentialAssertion {
+	if assertion == nil {
+		return nil
+	}
 	return &wantypes.CredentialAssertion{
 		PublicKey: &wantypes.PublicKeyCredentialRequestOptions{
 			Challenge:        assertion.Response.Challenge,
@@ -39,6 +43,9 @@ func CredentialAssertionToProto(assertion *CredentialAssertion) *wantypes.Creden
 // CredentialAssertionResponseToProto converts a CredentialAssertionResponse to
 // its proto counterpart.
 func CredentialAssertionResponseToProto(car *CredentialAssertionResponse) *wantypes.CredentialAssertionResponse {
+	if car == nil {
+		return nil
+	}
 	return &wantypes.CredentialAssertionResponse{
 		Type:  car.Type,
 		RawId: car.RawID,
@@ -52,9 +59,49 @@ func CredentialAssertionResponseToProto(car *CredentialAssertionResponse) *wanty
 	}
 }
 
+// CredentialCreationToProto converts a CredentialCreation to its proto
+// counterpart.
+func CredentialCreationToProto(cc *CredentialCreation) *wantypes.CredentialCreation {
+	if cc == nil {
+		return nil
+	}
+	return &wantypes.CredentialCreation{
+		PublicKey: &wantypes.PublicKeyCredentialCreationOptions{
+			Challenge:            cc.Response.Challenge,
+			Rp:                   rpEntityToProto(cc.Response.RelyingParty),
+			User:                 userEntityToProto(cc.Response.User),
+			CredentialParameters: credentialParametersToProto(cc.Response.Parameters),
+			TimeoutMs:            int64(cc.Response.Timeout),
+			ExcludeCredentials:   credentialDescriptorsToProto(cc.Response.CredentialExcludeList),
+			Attestation:          string(cc.Response.Attestation),
+			Extensions:           inputExtensionsToProto(cc.Response.Extensions),
+		},
+	}
+}
+
+// CredentialCreationResponseToProto converts a CredentialCreationResponse to
+// its proto counterpart.
+func CredentialCreationResponseToProto(ccr *CredentialCreationResponse) *wantypes.CredentialCreationResponse {
+	if ccr == nil {
+		return nil
+	}
+	return &wantypes.CredentialCreationResponse{
+		Type:  ccr.Type,
+		RawId: ccr.RawID,
+		Response: &wantypes.AuthenticatorAttestationResponse{
+			ClientDataJson:    ccr.AttestationResponse.ClientDataJSON,
+			AttestationObject: ccr.AttestationResponse.AttestationObject,
+		},
+		Extensions: outputExtensionsToProto(ccr.Extensions),
+	}
+}
+
 // CredentialAssertionFromProto converts a CredentialAssertion proto to its lib
 // counterpart.
 func CredentialAssertionFromProto(assertion *wantypes.CredentialAssertion) *CredentialAssertion {
+	if assertion == nil {
+		return nil
+	}
 	return &CredentialAssertion{
 		Response: protocol.PublicKeyCredentialRequestOptions{
 			Challenge:          assertion.PublicKey.Challenge,
@@ -69,6 +116,9 @@ func CredentialAssertionFromProto(assertion *wantypes.CredentialAssertion) *Cred
 // CredentialAssertionResponseFromProto converts a CredentialAssertionResponse
 // proto to its lib counterpart.
 func CredentialAssertionResponseFromProto(car *wantypes.CredentialAssertionResponse) *CredentialAssertionResponse {
+	if car == nil {
+		return nil
+	}
 	return &CredentialAssertionResponse{
 		PublicKeyCredential: PublicKeyCredential{
 			Credential: Credential{
@@ -76,7 +126,7 @@ func CredentialAssertionResponseFromProto(car *wantypes.CredentialAssertionRespo
 				Type: car.Type,
 			},
 			RawID:      car.RawId,
-			Extensions: outputExtensionsFromProto(car),
+			Extensions: outputExtensionsFromProto(car.Extensions),
 		},
 		AssertionResponse: AuthenticatorAssertionResponse{
 			AuthenticatorResponse: AuthenticatorResponse{
@@ -89,12 +139,70 @@ func CredentialAssertionResponseFromProto(car *wantypes.CredentialAssertionRespo
 	}
 }
 
+// CredentialCreationFromProto converts a CredentialCreation proto to its lib
+// counterpart.
+func CredentialCreationFromProto(cc *wantypes.CredentialCreation) *CredentialCreation {
+	if cc == nil {
+		return nil
+	}
+	if cc.PublicKey == nil {
+		return &CredentialCreation{}
+	}
+	return &CredentialCreation{
+		Response: protocol.PublicKeyCredentialCreationOptions{
+			Challenge:             cc.PublicKey.Challenge,
+			RelyingParty:          rpEntityFromProto(cc.PublicKey.Rp),
+			User:                  userEntityFromProto(cc.PublicKey.User),
+			Parameters:            credentialParametersFromProto(cc.PublicKey.CredentialParameters),
+			Timeout:               int(cc.PublicKey.TimeoutMs),
+			CredentialExcludeList: credentialDescriptorsFromProto(cc.PublicKey.ExcludeCredentials),
+			Extensions:            inputExtensionsFromProto(cc.PublicKey.Extensions),
+			Attestation:           protocol.ConveyancePreference(cc.PublicKey.Attestation),
+		},
+	}
+}
+
+// CredentialCreationResponseFromProto converts a CredentialCreationResponse
+// proto to its lib counterpart.
+func CredentialCreationResponseFromProto(ccr *wantypes.CredentialCreationResponse) *CredentialCreationResponse {
+	if ccr == nil {
+		return nil
+	}
+	return &CredentialCreationResponse{
+		PublicKeyCredential: PublicKeyCredential{
+			Credential: Credential{
+				ID:   base64.RawURLEncoding.EncodeToString(ccr.RawId),
+				Type: ccr.Type,
+			},
+			RawID:      ccr.RawId,
+			Extensions: outputExtensionsFromProto(ccr.Extensions),
+		},
+		AttestationResponse: AuthenticatorAttestationResponse{
+			AuthenticatorResponse: AuthenticatorResponse{
+				ClientDataJSON: ccr.Response.ClientDataJson,
+			},
+			AttestationObject: ccr.Response.AttestationObject,
+		},
+	}
+}
+
 func credentialDescriptorsToProto(creds []protocol.CredentialDescriptor) []*wantypes.CredentialDescriptor {
 	res := make([]*wantypes.CredentialDescriptor, len(creds))
 	for i, cred := range creds {
 		res[i] = &wantypes.CredentialDescriptor{
 			Type: string(cred.Type),
 			Id:   cred.CredentialID,
+		}
+	}
+	return res
+}
+
+func credentialParametersToProto(params []protocol.CredentialParameter) []*wantypes.CredentialParameter {
+	res := make([]*wantypes.CredentialParameter, len(params))
+	for i, p := range params {
+		res[i] = &wantypes.CredentialParameter{
+			Type: string(p.Type),
+			Alg:  int32(p.Algorithm),
 		}
 	}
 	return res
@@ -124,12 +232,40 @@ func outputExtensionsToProto(exts *AuthenticationExtensionsClientOutputs) *wanty
 	}
 }
 
+func rpEntityToProto(rp protocol.RelyingPartyEntity) *wantypes.RelyingPartyEntity {
+	return &wantypes.RelyingPartyEntity{
+		Id:   rp.ID,
+		Name: rp.Name,
+		Icon: rp.Icon,
+	}
+}
+
+func userEntityToProto(user protocol.UserEntity) *wantypes.UserEntity {
+	return &wantypes.UserEntity{
+		Id:          user.ID,
+		Name:        user.Name,
+		DisplayName: user.DisplayName,
+		Icon:        user.Icon,
+	}
+}
+
 func credentialDescriptorsFromProto(creds []*wantypes.CredentialDescriptor) []protocol.CredentialDescriptor {
 	res := make([]protocol.CredentialDescriptor, len(creds))
 	for i, cred := range creds {
 		res[i] = protocol.CredentialDescriptor{
 			Type:         protocol.CredentialType(cred.Type),
 			CredentialID: cred.Id,
+		}
+	}
+	return res
+}
+
+func credentialParametersFromProto(params []*wantypes.CredentialParameter) []protocol.CredentialParameter {
+	res := make([]protocol.CredentialParameter, len(params))
+	for i, p := range params {
+		res[i] = protocol.CredentialParameter{
+			Type:      protocol.CredentialType(p.Type),
+			Algorithm: webauthncose.COSEAlgorithmIdentifier(p.Alg),
 		}
 	}
 	return res
@@ -146,11 +282,38 @@ func inputExtensionsFromProto(exts *wantypes.AuthenticationExtensionsClientInput
 	return res
 }
 
-func outputExtensionsFromProto(car *wantypes.CredentialAssertionResponse) *AuthenticationExtensionsClientOutputs {
-	if car.Extensions == nil {
+func outputExtensionsFromProto(exts *wantypes.AuthenticationExtensionsClientOutputs) *AuthenticationExtensionsClientOutputs {
+	if exts == nil {
 		return nil
 	}
 	return &AuthenticationExtensionsClientOutputs{
-		AppID: car.Extensions.AppId,
+		AppID: exts.AppId,
+	}
+}
+
+func rpEntityFromProto(rp *wantypes.RelyingPartyEntity) protocol.RelyingPartyEntity {
+	if rp == nil {
+		return protocol.RelyingPartyEntity{}
+	}
+	return protocol.RelyingPartyEntity{
+		CredentialEntity: protocol.CredentialEntity{
+			Name: rp.Name,
+			Icon: rp.Icon,
+		},
+		ID: rp.Id,
+	}
+}
+
+func userEntityFromProto(user *wantypes.UserEntity) protocol.UserEntity {
+	if user == nil {
+		return protocol.UserEntity{}
+	}
+	return protocol.UserEntity{
+		CredentialEntity: protocol.CredentialEntity{
+			Name: user.Name,
+			Icon: user.Icon,
+		},
+		DisplayName: user.DisplayName,
+		ID:          user.Id,
 	}
 }


### PR DESCRIPTION
Plug Webauthn registration into the *MFADevice RPC family: AddMFADevice,
DeleteMFADevice and GetMFADevices.

As a consequence, Webauthn authentication and registration become supported by
various other gRPC endpoints that defer authn and registration to the RPCs
above.

Further RPC support and refactors are punted to upcoming PRs.