### PR TITLE
fix double-init emission and buffer overflows

### DIFF
--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -22,20 +22,58 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 
 	radix "github.com/armon/go-radix"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
 )
+
+type bufferConfig struct {
+	gracePeriod time.Duration
+	capacity    int
+	clock       clockwork.Clock
+}
+
+type BufferOption func(*bufferConfig)
+
+// BufferCapacity sets the event capacity of the circular buffer.
+func BufferCapacity(c int) BufferOption {
+	return func(cfg *bufferConfig) {
+		if c > 0 {
+			cfg.capacity = c
+		}
+	}
+}
+
+// BacklogGracePeriod sets the amount of time a watcher with a backlog will be tolerated.
+func BacklogGracePeriod(d time.Duration) BufferOption {
+	return func(cfg *bufferConfig) {
+		if d > 0 {
+			cfg.gracePeriod = d
+		}
+	}
+}
+
+// BufferClock sets a custom clock for the buffer (used in tests).
+func BufferClock(c clockwork.Clock) BufferOption {
+	return func(cfg *bufferConfig) {
+		if c != nil {
+			cfg.clock = c
+		}
+	}
+}
 
 // CircularBuffer implements in-memory circular buffer
 // of predefined size, that is capable of fan-out of the backend events.
 type CircularBuffer struct {
 	sync.Mutex
 	*log.Entry
+	cfg          bufferConfig
 	events       []Event
 	start        int
 	end          int
@@ -45,21 +83,26 @@ type CircularBuffer struct {
 }
 
 // NewCircularBuffer returns a new uninitialized instance of circular buffer.
-func NewCircularBuffer(size int) (*CircularBuffer, error) {
-	if size <= 0 {
-		return nil, trace.BadParameter("circular buffer size should be > 0")
+func NewCircularBuffer(opts ...BufferOption) *CircularBuffer {
+	cfg := bufferConfig{
+		gracePeriod: DefaultBacklogGracePeriod,
+		capacity:    DefaultBufferCapacity,
+		clock:       clockwork.NewRealClock(),
 	}
-	buf := &CircularBuffer{
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &CircularBuffer{
 		Entry: log.WithFields(log.Fields{
 			trace.Component: teleport.ComponentBuffer,
 		}),
-		events:   make([]Event, size),
+		cfg:      cfg,
+		events:   make([]Event, cfg.capacity),
 		start:    -1,
 		end:      -1,
 		size:     0,
 		watchers: newWatcherTree(),
 	}
-	return buf, nil
 }
 
 // Clear clears all events from the queue and closes all active watchers,
@@ -134,11 +177,6 @@ func (c *CircularBuffer) Close() error {
 	return nil
 }
 
-// Size returns circular buffer size
-func (c *CircularBuffer) Size() int {
-	return c.size
-}
-
 // Events returns a copy of records as arranged from start to end
 func (c *CircularBuffer) Events() []Event {
 	c.Lock()
@@ -205,15 +243,13 @@ func (c *CircularBuffer) fanOutEvent(r Event) {
 		if watcher.MetricComponent != "" {
 			watcherQueues.WithLabelValues(watcher.MetricComponent).Set(float64(len(watcher.eventsC)))
 		}
-		select {
-		case watcher.eventsC <- r:
-		default:
+		if !watcher.emit(r) {
 			watchersToDelete = append(watchersToDelete, watcher)
 		}
 	})
 
 	for _, watcher := range watchersToDelete {
-		c.Warningf("Closing %v, buffer overflow at %v elements.", watcher, len(watcher.eventsC))
+		c.Warningf("Closing %v, buffer overflow at %v (backlog=%v).", watcher, len(watcher.eventsC), watcher.backlogLen())
 		watcher.closeWatcher()
 		c.watchers.rm(watcher)
 	}
@@ -303,7 +339,12 @@ func (c *CircularBuffer) removeWatcherWithLock(watcher *BufferWatcher) {
 type BufferWatcher struct {
 	buffer *CircularBuffer
 	Watch
-	eventsC  chan Event
+	eventsC chan Event
+
+	bmu          sync.Mutex
+	backlog      []Event
+	backlogSince time.Time
+
 	ctx      context.Context
 	cancel   context.CancelFunc
 	initOnce sync.Once
@@ -317,14 +358,71 @@ func (w *BufferWatcher) String() string {
 	return fmt.Sprintf("Watcher(name=%v, prefixes=%v, capacity=%v, size=%v)", w.Name, string(bytes.Join(w.Prefixes, []byte(", "))), w.capacity, len(w.eventsC))
 }
 
-// Events returns events channel
+// Events returns events channel.  This method performs internal work and should be re-called after each event
+// is received, rather than having its output cached.
 func (w *BufferWatcher) Events() <-chan Event {
+	w.bmu.Lock()
+	defer w.bmu.Unlock()
+	// it is possible that the channel has been drained, but events exist in
+	// the backlog, so make sure to flush the backlog.  we can ignore the result
+	// of the flush here since we don't actually care if the backlog was fully
+	// flushed, only that the event channel is non-empty if a backlog does exist.
+	w.flushBacklog()
 	return w.eventsC
 }
 
 // Done channel is closed when watcher is closed
 func (w *BufferWatcher) Done() <-chan struct{} {
 	return w.ctx.Done()
+}
+
+// flushBacklog attempts to push any backlogged events into the
+// event channel.  returns true if backlog is empty.
+func (w *BufferWatcher) flushBacklog() (ok bool) {
+	for i, e := range w.backlog {
+		select {
+		case w.eventsC <- e:
+		default:
+			w.backlog = w.backlog[i:]
+			return false
+		}
+	}
+	w.backlogSince = time.Time{}
+	w.backlog = nil
+	return true
+}
+
+// emit attempts to emit an event. Returns false if the watcher has
+// exceeded the backlog grace period.
+func (w *BufferWatcher) emit(e Event) (ok bool) {
+	w.bmu.Lock()
+	defer w.bmu.Unlock()
+
+	if !w.flushBacklog() {
+		if w.buffer.cfg.clock.Now().After(w.backlogSince.Add(w.buffer.cfg.gracePeriod)) {
+			// backlog has existed for longer than grace period,
+			// this watcher needs to be removed.
+			return false
+		}
+		// backlog exists, but we are still within grace period.
+		w.backlog = append(w.backlog, e)
+		return true
+	}
+
+	select {
+	case w.eventsC <- e:
+	default:
+		// primary event buffer is full; start backlog.
+		w.backlog = append(w.backlog, e)
+		w.backlogSince = w.buffer.cfg.clock.Now()
+	}
+	return true
+}
+
+func (w *BufferWatcher) backlogLen() int {
+	w.bmu.Lock()
+	defer w.bmu.Unlock()
+	return len(w.backlog)
 }
 
 // init transmits the OpInit event.  safe to double-call.

--- a/lib/backend/buffer_test.go
+++ b/lib/backend/buffer_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+
+	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
 	check "gopkg.in/check.v1"
 )
@@ -45,8 +47,9 @@ func (s *BufferSuite) SetUpSuite(c *check.C) {
 }
 
 func (s *BufferSuite) list(c *check.C, bufferSize int, listSize int) {
-	b, err := NewCircularBuffer(bufferSize)
-	c.Assert(err, check.IsNil)
+	b := NewCircularBuffer(
+		BufferCapacity(bufferSize),
+	)
 	defer b.Close()
 	b.SetInit()
 	s.listWithBuffer(c, b, bufferSize, listSize)
@@ -83,8 +86,9 @@ func (s *BufferSuite) TestBufferSizes(c *check.C) {
 // TestBufferSizesReset tests various combinations of various
 // buffer sizes and lists with clear.
 func (s *BufferSuite) TestBufferSizesReset(c *check.C) {
-	b, err := NewCircularBuffer(1)
-	c.Assert(err, check.IsNil)
+	b := NewCircularBuffer(
+		BufferCapacity(1),
+	)
 	defer b.Close()
 	b.SetInit()
 
@@ -95,9 +99,10 @@ func (s *BufferSuite) TestBufferSizesReset(c *check.C) {
 
 // TestWatcherSimple tests scenarios with watchers
 func (s *BufferSuite) TestWatcherSimple(c *check.C) {
-	ctx := context.TODO()
-	b, err := NewCircularBuffer(3)
-	c.Assert(err, check.IsNil)
+	ctx := context.Background()
+	b := NewCircularBuffer(
+		BufferCapacity(3),
+	)
 	defer b.Close()
 	b.SetInit()
 
@@ -134,11 +139,84 @@ func (s *BufferSuite) TestWatcherSimple(c *check.C) {
 	}
 }
 
+// TestWatcherCapacity checks various watcher capacity scenarios
+func (s *BufferSuite) TestWatcherCapacity(c *check.C) {
+	const gracePeriod = time.Second
+	clock := clockwork.NewFakeClock()
+
+	ctx := context.Background()
+	b := NewCircularBuffer(
+		BufferCapacity(1),
+		BufferClock(clock),
+		BacklogGracePeriod(gracePeriod),
+	)
+	defer b.Close()
+	b.SetInit()
+
+	w, err := b.NewWatcher(ctx, Watch{
+		QueueSize: 1,
+	})
+	c.Assert(err, check.IsNil)
+	defer w.Close()
+
+	select {
+	case e := <-w.Events():
+		c.Assert(e.Type, check.Equals, types.OpInit)
+	default:
+		c.Fatalf("Expected immediate OpInit.")
+	}
+
+	// emit and then consume 10 events.  this is much larger than our queue size,
+	// but should succeed since we consume within our grace period.
+	for i := 0; i < 10; i++ {
+		b.Emit(Event{Item: Item{Key: []byte{Separator}, ID: int64(i + 1)}})
+	}
+	for i := 0; i < 10; i++ {
+		select {
+		case e := <-w.Events():
+			c.Assert(e.Item.ID, check.Equals, int64(i+1))
+		default:
+			c.Fatalf("Expected events to be immediately available")
+		}
+	}
+
+	// advance further than grace period.
+	clock.Advance(gracePeriod + time.Second)
+
+	// emit another event, which will cause buffer to reevaluate the grace period.
+	b.Emit(Event{Item: Item{Key: []byte{Separator}, ID: int64(11)}})
+
+	// ensure that buffer did not close watcher, since previously created backlog
+	// was drained within grace period.
+	select {
+	case <-w.Done():
+		c.Fatalf("Watcher should not have backlog, but was closed anyway")
+	default:
+	}
+
+	// create backlog again, and this time advance past grace period without draining it.
+	for i := 0; i < 10; i++ {
+		b.Emit(Event{Item: Item{Key: []byte{Separator}, ID: int64(i + 12)}})
+	}
+	clock.Advance(gracePeriod + time.Second)
+
+	// emit another event, which will cause buffer to realize that watcher is past
+	// its grace period.
+	b.Emit(Event{Item: Item{Key: []byte{Separator}, ID: int64(22)}})
+
+	select {
+	case <-w.Done():
+	default:
+		c.Fatalf("buffer did not close watcher that was past grace period")
+	}
+}
+
 // TestWatcherClose makes sure that closed watcher
 // will be removed
 func (s *BufferSuite) TestWatcherClose(c *check.C) {
-	b, err := NewCircularBuffer(3)
-	c.Assert(err, check.IsNil)
+	b := NewCircularBuffer(
+		BufferCapacity(3),
+	)
 	defer b.Close()
 	b.SetInit()
 
@@ -193,8 +271,9 @@ func (s *BufferSuite) TestRemoveRedundantPrefixes(c *check.C) {
 // TestWatcherMulti makes sure that watcher
 // with multiple matching prefixes will get an event only once
 func (s *BufferSuite) TestWatcherMulti(c *check.C) {
-	b, err := NewCircularBuffer(3)
-	c.Assert(err, check.IsNil)
+	b := NewCircularBuffer(
+		BufferCapacity(3),
+	)
 	defer b.Close()
 	b.SetInit()
 
@@ -224,8 +303,9 @@ func (s *BufferSuite) TestWatcherMulti(c *check.C) {
 
 // TestWatcherReset tests scenarios with watchers and buffer resets
 func (s *BufferSuite) TestWatcherReset(c *check.C) {
-	b, err := NewCircularBuffer(3)
-	c.Assert(err, check.IsNil)
+	b := NewCircularBuffer(
+		BufferCapacity(3),
+	)
 	defer b.Close()
 	b.SetInit()
 

--- a/lib/backend/defaults.go
+++ b/lib/backend/defaults.go
@@ -19,9 +19,13 @@ import (
 )
 
 const (
-	// DefaultBufferSize is a default circular buffer size
+	// DefaultBufferCapacity is a default circular buffer size
 	// used by backends to fan out events
-	DefaultBufferSize = 1024
+	DefaultBufferCapacity = 1024
+	// DefaultBacklogGracePeriod is the default amount of time
+	// that the circular buffer will tolerate an event backlog
+	// in one of its watchers.
+	DefaultBacklogGracePeriod = time.Second * 30
 	// DefaultPollStreamPeriod is a default event poll stream period
 	DefaultPollStreamPeriod = time.Second
 	// DefaultEventsTTL is a default events TTL period

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -106,7 +106,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 		cfg.WriteCapacityUnits = DefaultWriteCapacityUnits
 	}
 	if cfg.BufferSize == 0 {
-		cfg.BufferSize = backend.DefaultBufferSize
+		cfg.BufferSize = backend.DefaultBufferCapacity
 	}
 	if cfg.PollStreamPeriod == 0 {
 		cfg.PollStreamPeriod = backend.DefaultPollStreamPeriod
@@ -212,10 +212,9 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	buf := backend.NewCircularBuffer(
+		backend.BufferCapacity(cfg.BufferSize),
+	)
 	closeCtx, cancel := context.WithCancel(ctx)
 	watchStarted, signalWatchStart := context.WithCancel(ctx)
 	b := &Backend{

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -206,10 +206,9 @@ func New(ctx context.Context, params backend.Params) (*EtcdBackend, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	buf := backend.NewCircularBuffer(
+		backend.BufferCapacity(cfg.BufferSize),
+	)
 	closeCtx, cancel := context.WithCancel(ctx)
 	b := &EtcdBackend{
 		Entry:     log.WithFields(log.Fields{trace.Component: GetName()}),
@@ -273,7 +272,7 @@ func (cfg *Config) Validate() error {
 		}
 	}
 	if cfg.BufferSize == 0 {
-		cfg.BufferSize = backend.DefaultBufferSize
+		cfg.BufferSize = backend.DefaultBufferCapacity
 	}
 	if cfg.DialTimeout == 0 {
 		cfg.DialTimeout = apidefaults.DefaultDialTimeout

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -78,7 +78,7 @@ func (cfg *backendConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("firestore: project_id is not specified")
 	}
 	if cfg.BufferSize == 0 {
-		cfg.BufferSize = backend.DefaultBufferSize
+		cfg.BufferSize = backend.DefaultBufferCapacity
 	}
 	if cfg.PurgeExpiredDocumentsPollInterval == 0 {
 		cfg.PurgeExpiredDocumentsPollInterval = defaultPurgeInterval
@@ -262,11 +262,9 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 	// It won't be needed after New returns.
 	defer firestoreAdminClient.Close()
 
-	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
-	if err != nil {
-		cancel()
-		return nil, trace.Wrap(err)
-	}
+	buf := backend.NewCircularBuffer(
+		backend.BufferCapacity(cfg.BufferSize),
+	)
 	watchStarted, signalWatchStart := context.WithCancel(ctx)
 	b := &Backend{
 		svc:              firestoreClient,

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -99,7 +99,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 		return trace.BadParameter("specify directory path to the database using 'path' parameter")
 	}
 	if cfg.BufferSize == 0 {
-		cfg.BufferSize = backend.DefaultBufferSize
+		cfg.BufferSize = backend.DefaultBufferCapacity
 	}
 	if cfg.PollStreamPeriod == 0 {
 		cfg.PollStreamPeriod = backend.DefaultPollStreamPeriod
@@ -153,10 +153,9 @@ func NewWithConfig(ctx context.Context, cfg Config) (*Backend, error) {
 	}
 	// serialize access to sqlite to avoid database is locked errors
 	db.SetMaxOpenConns(1)
-	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	buf := backend.NewCircularBuffer(
+		backend.BufferCapacity(cfg.BufferSize),
+	)
 	closeCtx, cancel := context.WithCancel(ctx)
 	watchStarted, signalWatchStart := context.WithCancel(ctx)
 	l := &Backend{

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -72,7 +72,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 		cfg.Context = context.Background()
 	}
 	if cfg.BufferSize == 0 {
-		cfg.BufferSize = backend.DefaultBufferSize
+		cfg.BufferSize = backend.DefaultBufferCapacity
 	}
 	if cfg.BTreeDegree <= 0 {
 		cfg.BTreeDegree = defaultBTreeDegree
@@ -92,11 +92,9 @@ func New(cfg Config) (*Memory, error) {
 		return nil, trace.Wrap(err)
 	}
 	ctx, cancel := context.WithCancel(cfg.Context)
-	buf, err := backend.NewCircularBuffer(cfg.BufferSize)
-	if err != nil {
-		cancel()
-		return nil, trace.Wrap(err)
-	}
+	buf := backend.NewCircularBuffer(
+		backend.BufferCapacity(cfg.BufferSize),
+	)
 	buf.SetInit()
 	m := &Memory{
 		Mutex: &sync.Mutex{},

--- a/lib/services/fanout.go
+++ b/lib/services/fanout.go
@@ -79,10 +79,10 @@ func (f *Fanout) NewWatcher(ctx context.Context, watch types.Watch) (types.Watch
 		return nil, trace.Wrap(err)
 	}
 	if f.init {
-		// fanout is already initialized; emit OpInit immediately.
-		if err := w.emit(types.Event{Type: types.OpInit}); err != nil {
+		// fanout is already initialized; emit init event immediately.
+		if !w.init() {
 			w.cancel()
-			return nil, trace.Wrap(err)
+			return nil, trace.BadParameter("failed to send init event")
 		}
 	}
 	f.addWatcher(w)
@@ -100,8 +100,7 @@ func (f *Fanout) SetInit() {
 	for _, entries := range f.watchers {
 		var remove []*fanoutWatcher
 		for _, entry := range entries {
-			if err := entry.watcher.emit(types.Event{Type: types.OpInit}); err != nil {
-				entry.watcher.setError(err)
+			if !entry.watcher.init() {
 				remove = append(remove, entry.watcher)
 			}
 		}
@@ -284,13 +283,28 @@ func newFanoutWatcher(ctx context.Context, f *Fanout, watch types.Watch) (*fanou
 }
 
 type fanoutWatcher struct {
-	emux   sync.Mutex
-	fanout *Fanout
-	err    error
-	watch  types.Watch
-	eventC chan types.Event
-	cancel context.CancelFunc
-	ctx    context.Context
+	emux     sync.Mutex
+	fanout   *Fanout
+	err      error
+	watch    types.Watch
+	eventC   chan types.Event
+	cancel   context.CancelFunc
+	ctx      context.Context
+	initOnce sync.Once
+	initOk   bool
+}
+
+// init transmits the OpInit event.  safe to double-call.
+func (w *fanoutWatcher) init() (ok bool) {
+	w.initOnce.Do(func() {
+		select {
+		case w.eventC <- types.Event{Type: types.OpInit}:
+			w.initOk = true
+		default:
+			w.initOk = false
+		}
+	})
+	return w.initOk
 }
 
 func (w *fanoutWatcher) emit(event types.Event) error {


### PR DESCRIPTION
Fixes two related event system issues:

1. If a watcher was enqueued in an uninitialized fanout instance, it would recieve multiple init events when the fanout instance was initialized if the watcher was registered for more than one resource kind.  Watcher init emission is now protected by a `sync.Once`.
2. Backends in very large clusters could emit a massive number of simultaneous events which would trigger buffer overflow errors in backend event watchers.  Changed backend buffer to now observe a "grace period" where a watcher may exceed its allotted capacity, so long as it catches up before the grace period elapses.  This allows the watcher system to continue to prune slow chronically slow watchers without failing on spikes of activity.

The above issues could "feed into" one another, as errors in the buffer could cause caches to re-initialize, and double-inits could cause crashes that lead to flurries of reconnects and reset heartbeat intervals that would induce spiky load.

Fixes #7534 