### PR TITLE
Fix ConnectionMonitor DisconnectExpiredCert

### DIFF
--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -164,7 +164,13 @@ func (w *Monitor) start(lockWatch types.Watcher) {
 
 	var certTime <-chan time.Time
 	if !w.DisconnectExpiredCert.IsZero() {
-		t := w.Clock.NewTicker(w.DisconnectExpiredCert.Sub(w.Clock.Now().UTC()))
+		discTime := w.DisconnectExpiredCert.Sub(w.Clock.Now().UTC())
+		if discTime <= 0 {
+			// Client cert is already expired.
+			// Disconnect the client immediately.
+			discTime = time.Microsecond
+		}
+		t := w.Clock.NewTicker(discTime)
 		defer t.Stop()
 		certTime = t.Chan()
 	}


### PR DESCRIPTION
# What
Fix bug introduced in https://github.com/gravitational/teleport/pull/6857 after changing the logic from 
```go
  time.NewTimer(w.DisconnectExpiredCert.Sub(w.Clock.Now().UTC()))
```
to
```go
   w.Clock.NewTicker(w.DisconnectExpiredCert.Sub(w.Clock.Now().UTC()))
```
In corner case when a client connects to the proxy and  cert expires before connection monitor is created the `w.DisconnectExpiredCert.Sub(w.Clock.Now().UTC()` is <= 0  thus the `w.Clock.NewTicker` call will panic.
