### PR TITLE
Use a context to control server lifecycle

### DIFF
--- a/tool/tshd/main.go
+++ b/tool/tshd/main.go
@@ -29,7 +29,7 @@ var (
 	logFormat = flag.String("log_format", "", "Log format to use (json or text)")
 	logLevel  = flag.String("log_level", "", "Log level to use")
 
-	addr      = flag.String("addr", "tpc://localhost:", "Bind address for the Terminal server")
+	addr      = flag.String("addr", "tcp://localhost:", "Bind address for the Terminal server")
 	certFile  = flag.String("cert_file", "", "Cert file (or inline PEM) for the Terminal server. Enables TLS.")
 	certKey   = flag.String("cert_key", "", "Key file (or inline PEM) for the Terminal server. Enables TLS.")
 	clientCAs = flag.String("client_cas", "", "Client CA certificate (or inline PEM) for the Terminal server. Enables mTLS.")

--- a/tool/tshd/main.go
+++ b/tool/tshd/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"syscall"
@@ -66,11 +67,14 @@ func configureLogging() {
 }
 
 func run() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	var trustedCAs []string
 	if *clientCAs != "" {
 		trustedCAs = []string{*clientCAs}
 	}
-	server, err := terminal.Start(terminal.ServerOpts{
+	server, err := terminal.Start(ctx, terminal.ServerOpts{
 		Addr:            *addr,
 		CertFile:        *certFile,
 		KeyFile:         *certKey,
@@ -83,7 +87,6 @@ func run() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer server.Stop()
 
 	log.Infof("tshd running at %v", server.Addr)
 	return <-server.C


### PR DESCRIPTION
Instead of exposing the underlying gRPC server, pass a context to Start and
allow it to control the server's lifecycle.

Fix a few minor issues as well (double receives on server.C allowed, typo on
"tcp").