### PR TITLE
Add Webauthn devices via tsh mfa add

### DIFF
--- a/lib/auth/mocku2f/mocku2f.go
+++ b/lib/auth/mocku2f/mocku2f.go
@@ -152,6 +152,16 @@ func (muk *Key) RegisterResponse(req *u2f.RegisterRequest) (*u2f.RegisterRespons
 	}, nil
 }
 
+// RegisterRaw signs low-level U2F registration data.
+// Most callers should use either RegisterResponse or SignCredentialCreation.
+func (muk *Key) RegisterRaw(appHash, challengeHash []byte) ([]byte, error) {
+	res, err := muk.signRegister(appHash, challengeHash)
+	if err != nil {
+		return nil, err
+	}
+	return res.RawResp, nil
+}
+
 type signRegisterResult struct {
 	RawResp   []byte
 	Signature []byte
@@ -220,6 +230,16 @@ func (muk *Key) SignResponse(req *u2f.SignRequest) (*u2f.SignResponse, error) {
 		SignatureData: encodeBase64(res.SignData),
 		ClientData:    encodeBase64(clientDataJSON),
 	}, nil
+}
+
+// AuthenticateRaw signs low-level U2F authentication data.
+// Most callers should use either SignResponse or SignAssertion.
+func (muk *Key) AuthenticateRaw(appHash, challengeHash []byte) ([]byte, error) {
+	res, err := muk.signAuthn(appHash, challengeHash)
+	if err != nil {
+		return nil, err
+	}
+	return res.SignData, nil
 }
 
 type signAuthnResult struct {

--- a/lib/auth/webauthn/device.go
+++ b/lib/auth/webauthn/device.go
@@ -87,7 +87,6 @@ func u2fDERKeyToCBOR(der []byte) ([]byte, error) {
 
 // U2FKeyToCBOR transforms a DER-encoded U2F into its CBOR counterpart.
 func U2FKeyToCBOR(pubKey *ecdsa.PublicKey) ([]byte, error) {
-
 	// X and Y coordinates must be exactly 32 bytes.
 	xBytes := make([]byte, 32)
 	yBytes := make([]byte, 32)

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -167,6 +167,9 @@ func (f *RegistrationFlow) Begin(ctx context.Context, user string) (*CredentialC
 		return nil, trace.Wrap(err)
 	}
 
+	// TODO(codingllama): Send U2F App ID back in creation requests too. Useful to
+	//  detect duplicate devices.
+
 	sessionDataPB, err := sessionToPB(sessionData)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/webauthncli/login_test.go
+++ b/lib/auth/webauthncli/login_test.go
@@ -17,10 +17,9 @@ package webauthncli_test
 import (
 	"bytes"
 	"context"
-	"crypto"
-	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/binary"
 	"fmt"
 	"testing"
 	"time"
@@ -40,16 +39,7 @@ import (
 )
 
 func TestLogin(t *testing.T) {
-	// Restore package defaults after test.
-	oldDevices, oldOpen, oldNewToken := *wancli.U2FDevices, *wancli.U2FOpen, *wancli.U2FNewToken
-	oldPollInterval := wancli.DevicePollInterval
-	t.Cleanup(func() {
-		*wancli.U2FDevices = oldDevices
-		*wancli.U2FOpen = oldOpen
-		*wancli.U2FNewToken = oldNewToken
-		wancli.DevicePollInterval = oldPollInterval
-	})
-	wancli.DevicePollInterval = 1 // as tight as possible.
+	resetU2FCallbacksAfterTest(t)
 
 	const appID = "https://example.com"
 	const rpID = "example.com"
@@ -140,9 +130,7 @@ func TestLogin(t *testing.T) {
 			}
 
 			fakeDevs := &fakeDevices{devs: test.devs}
-			*wancli.U2FDevices = fakeDevs.devices
-			*wancli.U2FOpen = fakeDevs.open
-			*wancli.U2FNewToken = fakeDevs.newToken
+			fakeDevs.assignU2FCallbacks()
 
 			mfaResp, err := wancli.Login(ctx, origin, assertion)
 			switch hasErr := err != nil; {
@@ -258,8 +246,26 @@ func TestLogin_errors(t *testing.T) {
 	}
 }
 
+func resetU2FCallbacksAfterTest(t *testing.T) {
+	oldDevices, oldOpen, oldNewToken := *wancli.U2FDevices, *wancli.U2FOpen, *wancli.U2FNewToken
+	oldPollInterval := wancli.DevicePollInterval
+	t.Cleanup(func() {
+		*wancli.U2FDevices = oldDevices
+		*wancli.U2FOpen = oldOpen
+		*wancli.U2FNewToken = oldNewToken
+		wancli.DevicePollInterval = oldPollInterval
+	})
+}
+
 type fakeDevices struct {
 	devs []*fakeDevice
+}
+
+func (f *fakeDevices) assignU2FCallbacks() {
+	*wancli.U2FDevices = f.devices
+	*wancli.U2FOpen = f.open
+	*wancli.U2FNewToken = f.newToken
+	wancli.DevicePollInterval = 1 // as tight as possible.
 }
 
 func (f *fakeDevices) devices() ([]*hid.DeviceInfo, error) {
@@ -355,47 +361,45 @@ func (f *fakeDevice) CheckAuthenticate(req u2ftoken.AuthenticateRequest) error {
 }
 
 func (f *fakeDevice) Authenticate(req u2ftoken.AuthenticateRequest) (*u2ftoken.AuthenticateResponse, error) {
-	// Fail presence tests a few times.
-	const minPresenceCounter = 2
-	if !f.userPresent || f.presenceCounter < minPresenceCounter {
-		f.presenceCounter++
-		return nil, u2ftoken.ErrPresenceRequired
+	if err := f.checkUserPresent(); err != nil {
+		return nil, err // Do no wrap.
 	}
-	f.presenceCounter = 0
 
-	// Authenticate runs in a lower abstraction level than mocku2f.Key, so let's
-	// assemble the data and do the signing ourselves.
-	// See
-	// https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#authentication-response-message-success.
-	const userPresenceFlag = 1
-	counter := []byte{0, 0, 0, 0} // always zeroed, makes things simpler
-	dataToSign := &bytes.Buffer{}
-	dataToSign.Write(req.Application)
-	dataToSign.WriteByte(userPresenceFlag)
-	dataToSign.Write(counter)
-	dataToSign.Write(req.Challenge)
-	dataHash := sha256.Sum256(dataToSign.Bytes())
-
-	signature, err := f.key.PrivateKey.Sign(rand.Reader, dataHash[:], crypto.SHA256)
+	rawResp, err := f.key.AuthenticateRaw(req.Application, req.Challenge)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	rawResponse := &bytes.Buffer{}
-	rawResponse.WriteByte(userPresenceFlag)
-	rawResponse.Write(counter)
-	rawResponse.Write(signature)
+	var counter uint32
+	binary.Read(bytes.NewReader(rawResp[1:5]), binary.BigEndian, &counter)
+	sign := rawResp[5:]
 
 	return &u2ftoken.AuthenticateResponse{
-		Counter:     0,
-		Signature:   signature,
-		RawResponse: rawResponse.Bytes(),
+		Counter:     counter,
+		Signature:   sign,
+		RawResponse: rawResp,
 	}, nil
 }
 
 func (f *fakeDevice) Register(req u2ftoken.RegisterRequest) ([]byte, error) {
-	// Unused by tests.
-	panic("unimplemented")
+	if err := f.checkUserPresent(); err != nil {
+		return nil, err // Do no wrap.
+	}
+
+	resp, err := f.key.RegisterRaw(req.Application, req.Challenge)
+	return resp, trace.Wrap(err)
+}
+
+func (f *fakeDevice) checkUserPresent() error {
+	// Fail presence tests a few times.
+	const minPresenceCounter = 2
+	if !f.userPresent || f.presenceCounter < minPresenceCounter {
+		f.presenceCounter++
+		return u2ftoken.ErrPresenceRequired
+	}
+
+	// Allowed.
+	f.presenceCounter = 0
+	return nil
 }
 
 type fakeIdentity struct {

--- a/lib/auth/webauthncli/register.go
+++ b/lib/auth/webauthncli/register.go
@@ -1,0 +1,273 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthncli
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
+	"github.com/flynn/u2f/u2ftoken"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/trace"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	log "github.com/sirupsen/logrus"
+)
+
+// Register performs client-side, U2F-compatible Webauthn registration.
+// This method blocks until either device authentication is successful or the
+// context is cancelled. Calling Register without a deadline or cancel condition
+// may cause it block forever.
+// The caller is expected to prompt the user for action before calling this
+// method.
+func Register(ctx context.Context, origin string, cc *wanlib.CredentialCreation) (*proto.MFARegisterResponse, error) {
+	// Preliminary checks, more below.
+	switch {
+	case origin == "":
+		return nil, trace.BadParameter("origin required")
+	case cc == nil:
+		return nil, trace.BadParameter("credential creation required")
+	case cc.Response.RelyingParty.ID == "":
+		return nil, trace.BadParameter("credential creation missing relying party ID")
+	}
+
+	// U2F/CTAP1 is limited to ES256, check if it's allowed.
+	ok := false
+	for _, params := range cc.Response.Parameters {
+		if params.Type == protocol.PublicKeyCredentialType && params.Algorithm == webauthncose.AlgES256 {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return nil, trace.BadParameter("ES256 not allowed by credential parameters")
+	}
+
+	// Can we fulfill the authenticator selection?
+	if aa := cc.Response.AuthenticatorSelection.AuthenticatorAttachment; aa == protocol.Platform {
+		return nil, trace.BadParameter("platform attachment required by authenticator selection")
+	}
+	if rrk := cc.Response.AuthenticatorSelection.RequireResidentKey; rrk != nil && *rrk {
+		return nil, trace.BadParameter("resident key required by authenticator selection")
+	}
+	if uv := cc.Response.AuthenticatorSelection.UserVerification; uv == protocol.VerificationRequired {
+		return nil, trace.BadParameter("user verification required by authenticator selection")
+	}
+
+	// Prepare challenge data for the device.
+	ccdJSON, err := json.Marshal(&CollectedClientData{
+		Type:      string(protocol.CreateCeremony),
+		Challenge: base64.RawURLEncoding.EncodeToString(cc.Response.Challenge),
+		Origin:    origin,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ccdHash := sha256.Sum256(ccdJSON)
+	rpIDHash := sha256.Sum256([]byte(cc.Response.RelyingParty.ID))
+
+	var appIDHash []byte
+	if value, ok := cc.Response.Extensions[wanlib.AppIDExtension]; ok {
+		appID := fmt.Sprint(value)
+		h := sha256.Sum256([]byte(appID))
+		appIDHash = h[:]
+	}
+
+	// Register!
+	var rawResp []byte
+	if err := RunOnU2FDevices(ctx, func(t Token) error {
+		// Is the authenticator in the credential exclude list?
+		for _, cred := range cc.Response.CredentialExcludeList {
+			for _, app := range [][]byte{rpIDHash[:], appIDHash} {
+				if len(app) == 0 {
+					continue
+				}
+				if err := t.CheckAuthenticate(u2ftoken.AuthenticateRequest{
+					Challenge:   ccdHash[:],
+					Application: app,
+					KeyHandle:   cred.CredentialID,
+				}); err == nil {
+					log.Warnf(
+						"WebAuthn: Authenticator already registered under credential ID %q",
+						base64.RawURLEncoding.EncodeToString(cred.CredentialID))
+					return ErrAlreadyRegistered // Remove authenticator from list
+				}
+			}
+		}
+
+		var err error
+		rawResp, err = t.Register(u2ftoken.RegisterRequest{
+			Challenge:   ccdHash[:],
+			Application: rpIDHash[:],
+		})
+		return err
+	}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Parse U2F response and convert to Webauthn - after that we are done.
+	resp, err := parseU2FRegistrationResponse(rawResp)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ccr, err := credentialResponseFromU2F(ccdJSON, rpIDHash[:], resp)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &proto.MFARegisterResponse{
+		Response: &proto.MFARegisterResponse_Webauthn{
+			Webauthn: wanlib.CredentialCreationResponseToProto(ccr),
+		},
+	}, nil
+}
+
+type u2fRegistrationResponse struct {
+	PubKey                                *ecdsa.PublicKey
+	KeyHandle, AttestationCert, Signature []byte
+}
+
+func parseU2FRegistrationResponse(resp []byte) (*u2fRegistrationResponse, error) {
+	// Reference:
+	// https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#registration-response-message-success
+
+	// minRespLen is based on:
+	// 1 byte reserved +
+	// 65 pubKey +
+	// 1 key handle length +
+	// N key handle (at least 1) +
+	// N attestation cert (at least 1, need to parse to find out) +
+	// N signature (at least 1, spec says 71-73 bytes, YMMV)
+	const pubKeyLen = 65
+	const minRespLen = 1 + pubKeyLen + 4
+	if len(resp) < minRespLen {
+		return nil, trace.BadParameter("U2F response too small, got %v bytes, expected at least %v", len(resp), minRespLen)
+	}
+
+	// Reads until the key handle length are guaranteed by the size checking
+	// above.
+	buf := resp
+	if buf[0] != 0x05 {
+		return nil, trace.BadParameter("invalid reserved byte")
+	}
+	buf = buf[1:]
+
+	// public key
+	x, y := elliptic.Unmarshal(elliptic.P256(), buf[:pubKeyLen])
+	if x == nil {
+		return nil, trace.BadParameter("failed to parse public key")
+	}
+	buf = buf[pubKeyLen:]
+	pubKey := &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     x,
+		Y:     y,
+	}
+
+	// key handle
+	l := int(buf[0])
+	buf = buf[1:]
+	// Size checking resumed from now on.
+	if len(buf) < l {
+		return nil, trace.BadParameter("key handle length is %v, but only %v bytes are left", l, len(buf))
+	}
+	keyHandle := buf[:l]
+	buf = buf[l:]
+
+	// Parse the certificate to figure out its size, then call
+	// x509.ParseCertificate with a correctly-sized byte slice.
+	sig, err := asn1.Unmarshal(buf, &asn1.RawValue{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Parse the cert to check that it is valid - we don't actually need the
+	// parsed cert after it is proved to be well-formed.
+	attestationCert := buf[:len(buf)-len(sig)]
+	if _, err := x509.ParseCertificate(attestationCert); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &u2fRegistrationResponse{
+		PubKey:          pubKey,
+		KeyHandle:       keyHandle,
+		AttestationCert: attestationCert,
+		Signature:       sig,
+	}, nil
+}
+
+func credentialResponseFromU2F(ccdJSON, appIDHash []byte, resp *u2fRegistrationResponse) (*wanlib.CredentialCreationResponse, error) {
+	// Reference:
+	// https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#fig-u2f-compat-makeCredential
+
+	pubKeyCBOR, err := wanlib.U2FKeyToCBOR(resp.PubKey)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Assemble authenticator data.
+	authData := &bytes.Buffer{}
+	authData.Write(appIDHash[:])
+	// Attested credential data present.
+	// https://www.w3.org/TR/webauthn-2/#attested-credential-data.
+	authData.WriteByte(byte(protocol.FlagAttestedCredentialData | protocol.FlagUserPresent))
+	binary.Write(authData, binary.BigEndian, uint32(0))                   // counter, zeroed
+	authData.Write(make([]byte, 16))                                      // AAGUID, zeroed
+	binary.Write(authData, binary.BigEndian, uint16(len(resp.KeyHandle))) // L
+	authData.Write(resp.KeyHandle)
+	authData.Write(pubKeyCBOR)
+
+	// Assemble attestation object
+	attestationObj, err := cbor.Marshal(&protocol.AttestationObject{
+		RawAuthData: authData.Bytes(),
+		// See https://www.w3.org/TR/webauthn-2/#sctn-fido-u2f-attestation.
+		Format: "fido-u2f",
+		AttStatement: map[string]interface{}{
+			"sig": resp.Signature,
+			"x5c": []interface{}{resp.AttestationCert},
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &wanlib.CredentialCreationResponse{
+		PublicKeyCredential: wanlib.PublicKeyCredential{
+			Credential: wanlib.Credential{
+				ID:   base64.RawURLEncoding.EncodeToString(resp.KeyHandle),
+				Type: string(protocol.PublicKeyCredentialType),
+			},
+			RawID: resp.KeyHandle,
+		},
+		AttestationResponse: wanlib.AuthenticatorAttestationResponse{
+			AuthenticatorResponse: wanlib.AuthenticatorResponse{
+				ClientDataJSON: ccdJSON,
+			},
+			AttestationObject: attestationObj,
+		},
+	}, nil
+}

--- a/lib/auth/webauthncli/register.go
+++ b/lib/auth/webauthncli/register.go
@@ -106,6 +106,12 @@ func Register(ctx context.Context, origin string, cc *wanlib.CredentialCreation)
 				if len(app) == 0 {
 					continue
 				}
+
+				// Check if the device is already registered by calling
+				// CheckAuthenticate.
+				// If the method succeeds then the device knows about the
+				// {key handle, app} pair, which means it is already registered.
+				// CheckAuthenticate doesn't require user interaction.
 				if err := t.CheckAuthenticate(u2ftoken.AuthenticateRequest{
 					Challenge:   ccdHash[:],
 					Application: app,

--- a/lib/auth/webauthncli/register_test.go
+++ b/lib/auth/webauthncli/register_test.go
@@ -1,0 +1,203 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthncli_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/stretchr/testify/require"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
+)
+
+func TestRegister(t *testing.T) {
+	resetU2FCallbacksAfterTest(t)
+
+	const user = "llama"
+	const rpID = "example.com"
+	const origin = "https://example.com"
+
+	// Prepare a few fake devices.
+	u2fKey, err := newFakeDevice("u2fkey" /* name */, "" /* appID */)
+	require.NoError(t, err)
+	registeredKey, err := newFakeDevice("regkey" /* name */, rpID /* appID */)
+	require.NoError(t, err)
+
+	// Create a registration flow, we'll use it to both generate credential
+	// requests and to validate them.
+	webRegistration := &wanlib.RegistrationFlow{
+		Webauthn: &types.Webauthn{
+			RPID: rpID,
+		},
+		Identity: &fakeIdentity{
+			Devices: []*types.MFADevice{registeredKey.mfaDevice},
+		},
+	}
+
+	ctx := context.Background()
+	tests := []struct {
+		name            string
+		devs            []*fakeDevice
+		setUserPresence *fakeDevice
+		wantErr         bool
+		wantRawID       []byte
+	}{
+		{
+			name:            "U2F-compatible registration",
+			devs:            []*fakeDevice{u2fKey},
+			setUserPresence: u2fKey,
+			wantRawID:       u2fKey.key.KeyHandle,
+		},
+		{
+			name:            "Registered key ignored",
+			devs:            []*fakeDevice{u2fKey, registeredKey},
+			setUserPresence: registeredKey,
+			wantErr:         true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// 100ms is an eternity when probing devices at 1ns intervals.
+			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			defer cancel()
+
+			cc, err := webRegistration.Begin(ctx, user)
+			require.NoError(t, err)
+
+			// Reset/set presence indicator.
+			for _, dev := range test.devs {
+				dev.SetUserPresence(false)
+			}
+			test.setUserPresence.SetUserPresence(true)
+
+			// Replace U2F library functions with our mocked versions.
+			fakeDevs := &fakeDevices{devs: test.devs}
+			fakeDevs.assignU2FCallbacks()
+
+			resp, err := wancli.Register(ctx, origin, cc)
+			switch hasErr := err != nil; {
+			case hasErr != test.wantErr:
+				t.Fatalf("Register returned err = %v, wantErr = %v", err, test.wantErr)
+			case hasErr: // OK.
+				return
+			}
+			require.Equal(t, test.wantRawID, resp.GetWebauthn().RawId)
+
+			_, err = webRegistration.Finish(ctx, user, u2fKey.name, wanlib.CredentialCreationResponseFromProto(resp.GetWebauthn()))
+			require.NoError(t, err, "server-side registration failed")
+		})
+	}
+}
+
+func TestRegister_errors(t *testing.T) {
+	ctx := context.Background()
+
+	const origin = "https://example.com"
+	webRegistration := &wanlib.RegistrationFlow{
+		Webauthn: &types.Webauthn{
+			RPID: "example.com",
+		},
+		Identity: &fakeIdentity{},
+	}
+	okCC, err := webRegistration.Begin(ctx, "llama" /* user */)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		origin  string
+		makeCC  func() *wanlib.CredentialCreation
+		wantErr string
+	}{
+		{
+			name:    "NOK empty origin",
+			origin:  "",
+			makeCC:  func() *wanlib.CredentialCreation { return okCC },
+			wantErr: "origin",
+		},
+		{
+			name:    "NOK nil credential creation",
+			origin:  origin,
+			makeCC:  func() *wanlib.CredentialCreation { return nil },
+			wantErr: "credential creation required",
+		},
+		{
+			name:    "NOK nil empty creation",
+			origin:  origin,
+			makeCC:  func() *wanlib.CredentialCreation { return &wanlib.CredentialCreation{} },
+			wantErr: "relying party",
+		},
+		{
+			name:   "NOK ES256 algorithm not allowed",
+			origin: origin,
+			makeCC: func() *wanlib.CredentialCreation {
+				cp := *okCC
+				var params []protocol.CredentialParameter
+				for _, p := range cp.Response.Parameters {
+					if p.Algorithm == webauthncose.AlgES256 {
+						continue
+					}
+					params = append(params, p)
+				}
+				cp.Response.Parameters = params
+				return &cp
+			},
+			wantErr: "ES256 not allowed",
+		},
+		{
+			name:   "NOK platform attachment required",
+			origin: origin,
+			makeCC: func() *wanlib.CredentialCreation {
+				cp := *okCC
+				cp.Response.AuthenticatorSelection.AuthenticatorAttachment = protocol.Platform
+				return &cp
+			},
+			wantErr: "platform",
+		},
+		{
+			name:   "NOK resident key required",
+			origin: origin,
+			makeCC: func() *wanlib.CredentialCreation {
+				cp := *okCC
+				rrk := true
+				cp.Response.AuthenticatorSelection.RequireResidentKey = &rrk
+				return &cp
+			},
+			wantErr: "resident key",
+		},
+		{
+			name:   "NOK user verification required",
+			origin: origin,
+			makeCC: func() *wanlib.CredentialCreation {
+				cp := *okCC
+				cp.Response.AuthenticatorSelection.UserVerification = protocol.VerificationRequired
+				return &cp
+			},
+			wantErr: "user verification",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := wancli.Register(ctx, test.origin, test.makeCC())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -82,7 +82,6 @@ func PromptMFAChallenge(ctx context.Context, proxyAddr string, c *proto.MFAAuthe
 				msg = fmt.Sprintf("Enter an OTP code from a %sdevice", promptDevicePrefix)
 			}
 			code, err := promptOTP(ctx, os.Stderr, prompt.Stdin(), msg)
-			fmt.Fprintln(os.Stderr) // Print a new line after the prompt
 			if err != nil {
 				respC <- response{kind: kind, err: err}
 				return
@@ -132,6 +131,10 @@ func PromptMFAChallenge(ctx context.Context, proxyAddr string, c *proto.MFAAuthe
 			if err := resp.err; err != nil {
 				log.WithError(err).Debugf("%s authentication failed", resp.kind)
 				continue
+			}
+
+			if hasTOTP {
+				fmt.Fprintln(os.Stderr) // Print a new line after the prompt
 			}
 
 			// Exiting cancels the context via defer, which makes the remaining

--- a/lib/services/authentication.go
+++ b/lib/services/authentication.go
@@ -85,6 +85,9 @@ func ValidateMFADevice(d *types.MFADevice) error {
 		if err := u2f.ValidateDevice(dd.U2F); err != nil {
 			return trace.Wrap(err)
 		}
+	case *types.MFADevice_Webauthn:
+		// TODO(codingllama): Refactor Webauthn device validation so it runs here as
+		//  well?
 	default:
 		return trace.BadParameter("MFADevice has Device field of unknown type %T", d.Device)
 	}

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -43,8 +43,14 @@ import (
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
 
+const (
+	totpDeviceType     = "TOTP"
+	u2fDeviceType      = "U2F"
+	webauthnDeviceType = "WEBAUTHN"
+)
+
 // deviceTypes lists the supported device types for `tsh mfa add`.
-var deviceTypes = []string{"TOTP", "U2F", "WEBAUTHN"}
+var deviceTypes = []string{totpDeviceType, u2fDeviceType, webauthnDeviceType}
 
 type mfaCommands struct {
 	ls  *mfaLSCommand
@@ -162,11 +168,11 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 	}
 	var devType proto.AddMFADeviceRequestInit_DeviceType
 	switch strings.ToUpper(c.devType) {
-	case "TOTP":
+	case totpDeviceType:
 		devType = proto.AddMFADeviceRequestInit_TOTP
-	case "U2F":
+	case u2fDeviceType:
 		devType = proto.AddMFADeviceRequestInit_U2F
-	case "WEBAUTHN":
+	case webauthnDeviceType:
 		devType = proto.AddMFADeviceRequestInit_Webauthn
 	default:
 		return trace.BadParameter("unknown device type %q, must be one of %v", c.devType, strings.Join(deviceTypes, ", "))


### PR DESCRIPTION
Introduce client-side registration for Webauthn and ensures `tsh mfa` commands
are compatible.