### PR TITLE
Release 6.2.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.2.14
+
+This release of Teleport contains multiple improvements.
+
+* Fixed performance and stability issues for large DynamoDB clusters. [#8279](https://github.com/gravitational/teleport/pull/8279)
+
 ## 6.2.13
 
 This release of Teleport contains two bug fixes.

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=6.2.13
+VERSION=6.2.14
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: "6.2.13"
-appVersion: "6.2.13"
+version: "6.2.14"
+appVersion: "6.2.14"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "6.2.13"
-appVersion: "6.2.13"
+version: "6.2.14"
+appVersion: "6.2.14"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "6.2.13"
+	Version = "6.2.14"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
### Description

Release 6.2.14, **do not merge yet**!

### Missing backports

- [x] https://github.com/gravitational/teleport/pull/8279