### PR TITLE
Watcher System Metrics

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -19,6 +19,7 @@ package auth
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"time"
@@ -51,11 +52,27 @@ import (
 	_ "google.golang.org/grpc/encoding/gzip" // gzip compressor for gRPC.
 )
 
-var heartbeatConnectionsReceived = prometheus.NewCounter(
-	prometheus.CounterOpts{
-		Name: teleport.MetricHeartbeatConnectionsReceived,
-		Help: "Number of times auth received a heartbeat connection",
-	},
+var (
+	heartbeatConnectionsReceived = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: teleport.MetricHeartbeatConnectionsReceived,
+			Help: "Number of times auth received a heartbeat connection",
+		},
+	)
+	watcherEventsEmitted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: teleport.MetricWatcherEventsEmitted,
+			Help: "Number of watcher events emitted",
+		},
+		[]string{"resource", "size"},
+	)
+	watcherEventSizes = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    teleport.MetricWatcherEventSizes,
+			Help:    "Size of events being emitted",
+			Buckets: prometheus.LinearBuckets(0, 100, 20),
+		},
+	)
 )
 
 // GRPCServer is GPRC Auth Server API
@@ -302,11 +319,29 @@ func (g *GRPCServer) WatchEvents(watch *proto.Watch, stream proto.AuthService_Wa
 			if err != nil {
 				return trace.Wrap(err)
 			}
+
+			watcherEventsEmitted.WithLabelValues(resourceLabel(event), fmt.Sprintf("%d", out.Size())).Inc()
+			watcherEventSizes.Observe(float64(out.Size()))
+
 			if err := stream.Send(out); err != nil {
 				return trace.Wrap(err)
 			}
 		}
 	}
+}
+
+// resourceLabel returns the label for the provided types.Event
+func resourceLabel(event types.Event) string {
+	if event.Resource == nil {
+		return event.Type.String()
+	}
+
+	sub := event.Resource.GetSubKind()
+	if sub == "" {
+		return fmt.Sprintf("/%s", event.Resource.GetKind())
+	}
+
+	return fmt.Sprintf("/%s/%s", event.Resource.GetKind(), sub)
 }
 
 // eventToGRPC converts a types.Event to an proto.Event
@@ -3416,7 +3451,7 @@ func (cfg *GRPCServerConfig) CheckAndSetDefaults() error {
 
 // NewGRPCServer returns a new instance of GRPC server
 func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
-	err := utils.RegisterPrometheusCollectors(heartbeatConnectionsReceived)
+	err := utils.RegisterPrometheusCollectors(heartbeatConnectionsReceived, watcherEventsEmitted, watcherEventSizes)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -52,7 +52,7 @@ var (
 
 	certificateMismatchCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: teleport.MetricCertificateMistmatch,
+			Name: teleport.MetricCertificateMismatch,
 			Help: "Number of times there was a certificate mismatch",
 		},
 	)
@@ -60,7 +60,7 @@ var (
 	prometheusCollectors = []prometheus.Collector{failedLoginCount, certificateMismatchCount}
 )
 
-// HandlerConfig is the configuration for an application handler.
+// AuthHandlerConfig is the configuration for an application handler.
 type AuthHandlerConfig struct {
 	// Server is the services.Server in the backend.
 	Server Server

--- a/lib/utils/circular_buffer.go
+++ b/lib/utils/circular_buffer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018-2021 Gravitational, Inc.
+Copyright 2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ func (t *CircularBuffer) Data(n int) []float64 {
 		return nil
 	}
 
-	// skip first N items so that the most recent are always displayed
+	// skip first N items so that the most recent are always provided
 	start := t.start
 	if n < t.size {
 		start = (t.start + (t.size - n)) % len(t.buf)
@@ -65,7 +65,7 @@ func (t *CircularBuffer) Data(n int) []float64 {
 		return t.buf[start : t.end+1]
 	}
 
-	return append(t.buf[start:], t.buf[:start]...)
+	return append(t.buf[start:], t.buf[:t.end+1]...)
 }
 
 // Add pushes a new item onto the buffer

--- a/lib/utils/circular_buffer.go
+++ b/lib/utils/circular_buffer.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"sync"
+
+	"github.com/gravitational/trace"
+)
+
+// CircularBuffer implements an in-memory circular buffer of predefined size
+type CircularBuffer struct {
+	sync.Mutex
+	buf   []float64
+	start int
+	end   int
+	size  int
+}
+
+// NewCircularBuffer returns a new instance of a circular buffer that will hold
+// size elements before it rotates
+func NewCircularBuffer(size int) (*CircularBuffer, error) {
+	if size <= 0 {
+		return nil, trace.BadParameter("circular buffer size should be > 0")
+	}
+	buf := &CircularBuffer{
+		buf:   make([]float64, size),
+		start: -1,
+		end:   -1,
+		size:  0,
+	}
+	return buf, nil
+}
+
+// Data returns the most recent n elements in the correct order
+func (t *CircularBuffer) Data(n int) []float64 {
+	t.Lock()
+	defer t.Unlock()
+
+	if n <= 0 || t.size == 0 {
+		return nil
+	}
+
+	// skip first N items so that the most recent are always displayed
+	start := t.start
+	if n < t.size {
+		start = (t.start + (t.size - n)) % len(t.buf)
+	}
+
+	if start <= t.end {
+		return t.buf[start : t.end+1]
+	}
+
+	return append(t.buf[start:], t.buf[:start]...)
+}
+
+// Add pushes a new item onto the buffer
+func (t *CircularBuffer) Add(d float64) {
+	t.Lock()
+	defer t.Unlock()
+
+	if t.size == 0 {
+		t.start = 0
+		t.end = 0
+		t.size = 1
+	} else if t.size < len(t.buf) {
+		t.end++
+		t.size++
+	} else {
+		t.end = t.start
+		t.start = (t.start + 1) % len(t.buf)
+	}
+
+	t.buf[t.end] = d
+}

--- a/lib/utils/circular_buffer.go
+++ b/lib/utils/circular_buffer.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018-2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (

--- a/lib/utils/circular_buffer_test.go
+++ b/lib/utils/circular_buffer_test.go
@@ -41,13 +41,11 @@ func TestCircularBuffer_Data(t *testing.T) {
 
 	expectData := func(expected []float64) {
 		for i := 0; i < 15; i++ {
+			e := expected
 			if i <= len(expected) {
-				data := buff.Data(i)
-				expect := expected[len(expected)-i:]
-				require.Empty(t, cmp.Diff(expect, data, cmpopts.EquateEmpty()), "i = %v", i)
-				continue
+				e = expected[len(expected)-i:]
 			}
-			require.Empty(t, cmp.Diff(expected, buff.Data(i), cmpopts.EquateEmpty()), "i = %v", i)
+			require.Empty(t, cmp.Diff(e, buff.Data(i), cmpopts.EquateEmpty()), "i = %v", i)
 		}
 	}
 

--- a/lib/utils/circular_buffer_test.go
+++ b/lib/utils/circular_buffer_test.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCircularBuffer(t *testing.T) {
+	buff, err := NewCircularBuffer(-1)
+	require.Error(t, err)
+	require.Nil(t, buff)
+
+	buff, err = NewCircularBuffer(5)
+	require.NoError(t, err)
+	require.NotNil(t, buff)
+	require.Len(t, buff.buf, 5)
+}
+
+func TestCircularBuffer_Data(t *testing.T) {
+	buff, err := NewCircularBuffer(5)
+	require.NoError(t, err)
+
+	data := buff.Data(1)
+	require.Nil(t, data)
+
+	buff.Add(1.0)
+
+	buff.Data(0)
+	require.Nil(t, data)
+
+	data = buff.Data(1)
+	require.Equal(t, []float64{1}, data)
+
+	data = buff.Data(2)
+	require.Equal(t, []float64{1}, data)
+
+	data = buff.Data(10)
+	require.Equal(t, []float64{1}, data)
+
+	buff.Add(2)
+	buff.Add(3)
+	buff.Add(4)
+
+	data = buff.Data(1)
+	require.Equal(t, []float64{4}, data)
+
+	data = buff.Data(2)
+	require.Equal(t, []float64{3, 4}, data)
+
+	data = buff.Data(10)
+	require.Equal(t, []float64{1, 2, 3, 4}, data)
+
+	buff.Add(5)
+	buff.Add(6)
+	buff.Add(7)
+
+	data = buff.Data(1)
+	require.Equal(t, []float64{7}, data)
+
+	data = buff.Data(2)
+	require.Equal(t, []float64{6, 7}, data)
+
+	data = buff.Data(10)
+	require.Equal(t, []float64{3, 4, 5, 6, 7}, data)
+
+}

--- a/lib/utils/circular_buffer_test.go
+++ b/lib/utils/circular_buffer_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018-2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (

--- a/metrics.go
+++ b/metrics.go
@@ -64,11 +64,17 @@ const (
 	// MetricHeartbeatConnectionsReceived counts heartbeat connections received by auth
 	MetricHeartbeatConnectionsReceived = "heartbeat_connections_received_total"
 
-	// MetricCertificateMistmatch counts login failures due to certificate mismatch
-	MetricCertificateMistmatch = "certificate_mismatch_total"
+	// MetricCertificateMismatch counts login failures due to certificate mismatch
+	MetricCertificateMismatch = "certificate_mismatch_total"
 
 	// MetricHeartbeatsMissed counts the nodes that failed to heartbeat
 	MetricHeartbeatsMissed = "heartbeats_missed_total"
+
+	// MetricWatcherEventsEmitted counts watcher events that are emitted
+	MetricWatcherEventsEmitted = "watcher_events"
+
+	// MetricWatcherEventSizes measures the size of watcher events that are emitted
+	MetricWatcherEventSizes = "watcher_event_sizes"
 
 	// TagCluster is a metric tag for a cluster
 	TagCluster = "cluster"
@@ -179,4 +185,10 @@ const (
 
 	// TagFalse is a tag value to mark false values
 	TagFalse = "false"
+
+	// TagResource is a tag specifying the resource for an event
+	TagResource = "resource"
+
+	// TagSize is a tag specifying the size of an event
+	TagSize = "size"
 )

--- a/metrics.go
+++ b/metrics.go
@@ -188,7 +188,4 @@ const (
 
 	// TagResource is a tag specifying the resource for an event
 	TagResource = "resource"
-
-	// TagSize is a tag specifying the size of an event
-	TagSize = "size"
 )

--- a/tool/tctl/common/top_command.go
+++ b/tool/tctl/common/top_command.go
@@ -831,8 +831,6 @@ func getWatcherStats(metrics map[string]*dto.MetricFamily, prev *WatcherStats, p
 	var (
 		eventsPerSec *utils.CircularBuffer
 		bytesPerSec  *utils.CircularBuffer
-		eventsRate   float64
-		bytesRate    float64
 	)
 	if prev == nil {
 		eps, err := utils.NewCircularBuffer(150)
@@ -851,12 +849,9 @@ func getWatcherStats(metrics map[string]*dto.MetricFamily, prev *WatcherStats, p
 		eventsPerSec = prev.EventsPerSecond
 		bytesPerSec = prev.BytesPerSecond
 
-		eventsRate = float64(histogram.Count-prev.EventSize.Count) / float64(period/time.Second)
-		bytesRate = histogram.Sum - prev.EventSize.Sum/float64(period/time.Second)
+		eventsPerSec.Add(float64(histogram.Count-prev.EventSize.Count) / float64(period/time.Second))
+		bytesPerSec.Add(histogram.Sum - prev.EventSize.Sum/float64(period/time.Second))
 	}
-
-	eventsPerSec.Add(eventsRate)
-	bytesPerSec.Add(bytesRate)
 
 	stats := &WatcherStats{
 		EventSize:       histogram,


### PR DESCRIPTION
**Purpose** 

Currently we have no insight into which events are being emitted, how often they are being emitted, and what the size of an event is. This makes it difficult to determine the source of high network utilization issues. By exposing metrics for the watcher system and consuming them on a new pane in `tctl top` we can get a real time view of the events being emitted.

**Implementation**

- Expose Prometheus metrics in the Auth GRPC Server
--  record events in `WatchEvents` streaming GRPC method before we `Send` on the stream 
-- use `Event.Size()` to estimate the amount of data being sent
- Add a new pane to `tctl top`
![2021-09-21_17-07](https://user-images.githubusercontent.com/39066650/134262128-ac0cb101-0b33-4d3b-83cc-8a7cc29b0860.png)


