### PR TITLE
use aws sdk withcontext variants where possible

### DIFF
--- a/lib/backend/dynamo/configure.go
+++ b/lib/backend/dynamo/configure.go
@@ -73,7 +73,7 @@ func SetAutoScaling(ctx context.Context, svc *applicationautoscaling.Application
 	}
 
 	// Define scaling targets. Defines minimum and maximum {read,write} capacity.
-	if _, err := svc.RegisterScalableTarget(&applicationautoscaling.RegisterScalableTargetInput{
+	if _, err := svc.RegisterScalableTargetWithContext(ctx, &applicationautoscaling.RegisterScalableTargetInput{
 		MinCapacity:       aws.Int64(params.ReadMinCapacity),
 		MaxCapacity:       aws.Int64(params.ReadMaxCapacity),
 		ResourceId:        aws.String(resourceID),
@@ -82,7 +82,7 @@ func SetAutoScaling(ctx context.Context, svc *applicationautoscaling.Application
 	}); err != nil {
 		return convertError(err)
 	}
-	if _, err := svc.RegisterScalableTarget(&applicationautoscaling.RegisterScalableTargetInput{
+	if _, err := svc.RegisterScalableTargetWithContext(ctx, &applicationautoscaling.RegisterScalableTargetInput{
 		MinCapacity:       aws.Int64(params.WriteMinCapacity),
 		MaxCapacity:       aws.Int64(params.WriteMaxCapacity),
 		ResourceId:        aws.String(resourceID),
@@ -94,7 +94,7 @@ func SetAutoScaling(ctx context.Context, svc *applicationautoscaling.Application
 
 	// Define scaling policy. Defines the ratio of {read,write} consumed capacity to
 	// provisioned capacity DynamoDB will try and maintain.
-	if _, err := svc.PutScalingPolicy(&applicationautoscaling.PutScalingPolicyInput{
+	if _, err := svc.PutScalingPolicyWithContext(ctx, &applicationautoscaling.PutScalingPolicyInput{
 		PolicyName:        aws.String(getReadScalingPolicyName(resourceID)),
 		PolicyType:        aws.String(applicationautoscaling.PolicyTypeTargetTrackingScaling),
 		ResourceId:        aws.String(resourceID),
@@ -109,7 +109,7 @@ func SetAutoScaling(ctx context.Context, svc *applicationautoscaling.Application
 	}); err != nil {
 		return convertError(err)
 	}
-	if _, err := svc.PutScalingPolicy(&applicationautoscaling.PutScalingPolicyInput{
+	if _, err := svc.PutScalingPolicyWithContext(ctx, &applicationautoscaling.PutScalingPolicyInput{
 		PolicyName:        aws.String(getWriteScalingPolicyName(resourceID)),
 		PolicyType:        aws.String(applicationautoscaling.PolicyTypeTargetTrackingScaling),
 		ResourceId:        aws.String(resourceID),

--- a/lib/backend/dynamo/configure_test.go
+++ b/lib/backend/dynamo/configure_test.go
@@ -44,7 +44,7 @@ func TestContinuousBackups(t *testing.T) {
 
 	// Remove table after tests are done.
 	t.Cleanup(func() {
-		deleteTable(context.Background(), b.svc, b.Config.TableName)
+		require.NoError(t, deleteTable(context.Background(), b.svc, b.Config.TableName))
 	})
 
 	// Check status of continuous backups.
@@ -70,7 +70,7 @@ func TestAutoScaling(t *testing.T) {
 
 	// Remove table after tests are done.
 	t.Cleanup(func() {
-		deleteTable(context.Background(), b.svc, b.Config.TableName)
+		require.NoError(t, deleteTable(context.Background(), b.svc, b.Config.TableName))
 	})
 
 	// Check auto scaling values match.

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -671,7 +671,7 @@ func (b *Backend) createTable(ctx context.Context, tableName string, rangeKey st
 		KeySchema:             elems,
 		ProvisionedThroughput: &pThroughput,
 	}
-	_, err := b.svc.CreateTable(&c)
+	_, err := b.svc.CreateTableWithContext(ctx, &c)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -721,7 +721,7 @@ func (b *Backend) getRecords(ctx context.Context, startKey, endKey string, limit
 	if limit > 0 {
 		input.Limit = aws.Int64(int64(limit))
 	}
-	out, err := b.svc.Query(&input)
+	out, err := b.svc.QueryWithContext(ctx, &input)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -851,7 +851,7 @@ func (b *Backend) getKey(ctx context.Context, key []byte) (*record, error) {
 		TableName:      aws.String(b.TableName),
 		ConsistentRead: aws.Bool(true),
 	}
-	out, err := b.svc.GetItem(&input)
+	out, err := b.svc.GetItemWithContext(ctx, &input)
 	if err != nil || len(out.Item) == 0 {
 		return nil, trace.NotFound("%q is not found", string(key))
 	}

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -280,7 +280,7 @@ func New(ctx context.Context, cfg Config, backend backend.Backend) (*Log, error)
 	b.svc = dynamodb.New(b.session)
 
 	// check if the table exists?
-	ts, err := b.getTableStatus(b.Tablename)
+	ts, err := b.getTableStatus(ctx, b.Tablename)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -288,14 +288,14 @@ func New(ctx context.Context, cfg Config, backend backend.Backend) (*Log, error)
 	case tableStatusOK:
 		break
 	case tableStatusMissing:
-		err = b.createTable(b.Tablename)
+		err = b.createTable(ctx, b.Tablename)
 	case tableStatusNeedsMigration:
 		return nil, trace.BadParameter("unsupported schema")
 	}
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = b.turnOnTimeToLive()
+	err = b.turnOnTimeToLive(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -392,7 +392,7 @@ type migrationTask struct {
 // jittered interval until retrying migration again. This allows one server to pull ahead
 // and finish or make significant progress on the migration.
 func (l *Log) migrateRFD24(ctx context.Context) error {
-	hasIndexV1, err := l.indexExists(l.Tablename, indexTimeSearch)
+	hasIndexV1, err := l.indexExists(ctx, l.Tablename, indexTimeSearch)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -424,7 +424,7 @@ func (l *Log) migrateRFD24(ctx context.Context) error {
 	// Acquire a lock so that only one auth server attempts to perform the migration at any given time.
 	// If an auth server does in a HA-setup the other auth servers will pick up the migration automatically.
 	err = backend.RunWhileLocked(ctx, l.backend, rfd24MigrationLock, rfd24MigrationLockTTL, func(ctx context.Context) error {
-		hasIndexV1, err := l.indexExists(l.Tablename, indexTimeSearch)
+		hasIndexV1, err := l.indexExists(ctx, l.Tablename, indexTimeSearch)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -442,7 +442,7 @@ func (l *Log) migrateRFD24(ctx context.Context) error {
 
 		// Remove the old index, marking migration as complete
 		log.Info("Removing old DynamoDB index")
-		err = l.removeV1GSI()
+		err = l.removeV1GSI(ctx)
 		if err != nil {
 			return trace.WrapWithMessage(err, "Migrated all events to v6.2 format successfully but failed to remove old index.")
 		}
@@ -1013,8 +1013,8 @@ func (l *Log) WaitForDelivery(ctx context.Context) error {
 	return nil
 }
 
-func (l *Log) turnOnTimeToLive() error {
-	status, err := l.svc.DescribeTimeToLive(&dynamodb.DescribeTimeToLiveInput{
+func (l *Log) turnOnTimeToLive(ctx context.Context) error {
+	status, err := l.svc.DescribeTimeToLiveWithContext(ctx, &dynamodb.DescribeTimeToLiveInput{
 		TableName: aws.String(l.Tablename),
 	})
 	if err != nil {
@@ -1024,7 +1024,7 @@ func (l *Log) turnOnTimeToLive() error {
 	case dynamodb.TimeToLiveStatusEnabled, dynamodb.TimeToLiveStatusEnabling:
 		return nil
 	}
-	_, err = l.svc.UpdateTimeToLive(&dynamodb.UpdateTimeToLiveInput{
+	_, err = l.svc.UpdateTimeToLiveWithContext(ctx, &dynamodb.UpdateTimeToLiveInput{
 		TableName: aws.String(l.Tablename),
 		TimeToLiveSpecification: &dynamodb.TimeToLiveSpecification{
 			AttributeName: aws.String(keyExpires),
@@ -1035,8 +1035,8 @@ func (l *Log) turnOnTimeToLive() error {
 }
 
 // getTableStatus checks if a given table exists
-func (l *Log) getTableStatus(tableName string) (tableStatus, error) {
-	_, err := l.svc.DescribeTable(&dynamodb.DescribeTableInput{
+func (l *Log) getTableStatus(ctx context.Context, tableName string) (tableStatus, error) {
+	_, err := l.svc.DescribeTableWithContext(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),
 	})
 	err = convertError(err)
@@ -1050,8 +1050,8 @@ func (l *Log) getTableStatus(tableName string) (tableStatus, error) {
 }
 
 // indexExists checks if a given index exists on a given table and that it is active or updating.
-func (l *Log) indexExists(tableName, indexName string) (bool, error) {
-	tableDescription, err := l.svc.DescribeTable(&dynamodb.DescribeTableInput{
+func (l *Log) indexExists(ctx context.Context, tableName, indexName string) (bool, error) {
+	tableDescription, err := l.svc.DescribeTableWithContext(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),
 	})
 	if err != nil {
@@ -1077,7 +1077,7 @@ func (l *Log) indexExists(tableName, indexName string) (bool, error) {
 // - This function must be called before the
 //   backend is considered initialized and the main Teleport process is started.
 func (l *Log) createV2GSI(ctx context.Context) error {
-	v2Exists, err := l.indexExists(l.Tablename, indexTimeSearchV2)
+	v2Exists, err := l.indexExists(ctx, l.Tablename, indexTimeSearchV2)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1121,7 +1121,7 @@ func (l *Log) createV2GSI(ctx context.Context) error {
 		},
 	}
 
-	if _, err := l.svc.UpdateTable(&c); err != nil {
+	if _, err := l.svc.UpdateTableWithContext(ctx, &c); err != nil {
 		return trace.Wrap(convertError(err))
 	}
 
@@ -1131,7 +1131,7 @@ func (l *Log) createV2GSI(ctx context.Context) error {
 
 	// Wait until the index is created and active or updating.
 	for time.Now().Before(endWait) {
-		indexExists, err := l.indexExists(l.Tablename, indexTimeSearchV2)
+		indexExists, err := l.indexExists(ctx, l.Tablename, indexTimeSearchV2)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1159,8 +1159,8 @@ func (l *Log) createV2GSI(ctx context.Context) error {
 // Invariants:
 // - This function must not be called concurrently with itself.
 // - This may only be executed after the post RFD 24 global secondary index has been created.
-func (l *Log) removeV1GSI() error {
-	v1Exists, err := l.indexExists(l.Tablename, indexTimeSearch)
+func (l *Log) removeV1GSI(ctx context.Context) error {
+	v1Exists, err := l.indexExists(ctx, l.Tablename, indexTimeSearch)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1181,7 +1181,7 @@ func (l *Log) removeV1GSI() error {
 		},
 	}
 
-	if _, err := l.svc.UpdateTable(&c); err != nil {
+	if _, err := l.svc.UpdateTableWithContext(ctx, &c); err != nil {
 		return trace.Wrap(convertError(err))
 	}
 
@@ -1278,7 +1278,7 @@ func (l *Log) migrateMatchingEvents(ctx context.Context, filterExpr string, tran
 		// Resume the scan at the end of the previous one.
 		// This processes `DynamoBatchSize*maxMigrationWorkers` events at maximum
 		// which is why we need to run this multiple times on the dataset.
-		scanOut, err := l.svc.Scan(c)
+		scanOut, err := l.svc.ScanWithContext(ctx, c)
 		if err != nil {
 			return trace.Wrap(convertError(err))
 		}
@@ -1328,7 +1328,7 @@ func (l *Log) migrateMatchingEvents(ctx context.Context, filterExpr string, tran
 				defer workerBarrier.Done()
 				amountProcessed := len(batch)
 
-				if err := l.uploadBatch(batch); err != nil {
+				if err := l.uploadBatch(ctx, batch); err != nil {
 					workerErrors <- trace.Wrap(err)
 					return
 				}
@@ -1363,13 +1363,13 @@ func (l *Log) migrateMatchingEvents(ctx context.Context, filterExpr string, tran
 }
 
 // uploadBatch creates or updates a batch of `DynamoBatchSize` events or less in one API call.
-func (l *Log) uploadBatch(writeRequests []*dynamodb.WriteRequest) error {
+func (l *Log) uploadBatch(ctx context.Context, writeRequests []*dynamodb.WriteRequest) error {
 	for {
 		c := &dynamodb.BatchWriteItemInput{
 			RequestItems: map[string][]*dynamodb.WriteRequest{l.Tablename: writeRequests},
 		}
 
-		out, err := l.svc.BatchWriteItem(c)
+		out, err := l.svc.BatchWriteItemWithContext(ctx, c)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1387,7 +1387,7 @@ func (l *Log) uploadBatch(writeRequests []*dynamodb.WriteRequest) error {
 // rangeKey is the name of the 'range key' the schema requires.
 // currently is always set to "FullPath" (used to be something else, that's
 // why it's a parameter for migration purposes)
-func (l *Log) createTable(tableName string) error {
+func (l *Log) createTable(ctx context.Context, tableName string) error {
 	provisionedThroughput := dynamodb.ProvisionedThroughput{
 		ReadCapacityUnits:  aws.Int64(l.ReadCapacityUnits),
 		WriteCapacityUnits: aws.Int64(l.WriteCapacityUnits),
@@ -1428,12 +1428,12 @@ func (l *Log) createTable(tableName string) error {
 			},
 		},
 	}
-	_, err := l.svc.CreateTable(&c)
+	_, err := l.svc.CreateTableWithContext(ctx, &c)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	log.Infof("Waiting until table %q is created", tableName)
-	err = l.svc.WaitUntilTableExists(&dynamodb.DescribeTableInput{
+	err = l.svc.WaitUntilTableExistsWithContext(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),
 	})
 	if err == nil {
@@ -1448,8 +1448,8 @@ func (l *Log) Close() error {
 }
 
 // deleteAllItems deletes all items from the database, used in tests
-func (l *Log) deleteAllItems() error {
-	out, err := l.svc.Scan(&dynamodb.ScanInput{TableName: aws.String(l.Tablename)})
+func (l *Log) deleteAllItems(ctx context.Context) error {
+	out, err := l.svc.ScanWithContext(ctx, &dynamodb.ScanInput{TableName: aws.String(l.Tablename)})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1473,12 +1473,11 @@ func (l *Log) deleteAllItems() error {
 		chunk := requests[:top]
 		requests = requests[top:]
 
-		req, _ := l.svc.BatchWriteItemRequest(&dynamodb.BatchWriteItemInput{
+		_, err := l.svc.BatchWriteItemWithContext(ctx, &dynamodb.BatchWriteItemInput{
 			RequestItems: map[string][]*dynamodb.WriteRequest{
 				l.Tablename: chunk,
 			},
 		})
-		err = req.Send()
 		err = convertError(err)
 		if err != nil {
 			return trace.Wrap(err)
@@ -1489,15 +1488,15 @@ func (l *Log) deleteAllItems() error {
 }
 
 // deleteTable deletes DynamoDB table with a given name
-func (l *Log) deleteTable(tableName string, wait bool) error {
+func (l *Log) deleteTable(ctx context.Context, tableName string, wait bool) error {
 	tn := aws.String(tableName)
-	_, err := l.svc.DeleteTable(&dynamodb.DeleteTableInput{TableName: tn})
+	_, err := l.svc.DeleteTableWithContext(ctx, &dynamodb.DeleteTableInput{TableName: tn})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	if wait {
 		return trace.Wrap(
-			l.svc.WaitUntilTableNotExists(&dynamodb.DescribeTableInput{TableName: tn}))
+			l.svc.WaitUntilTableNotExistsWithContext(ctx, &dynamodb.DescribeTableInput{TableName: tn}))
 	}
 	return nil
 }

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -654,7 +654,7 @@ func (l *Log) GetSessionChunk(namespace string, sid session.ID, offsetBytes, max
 	return nil, nil
 }
 
-// Returns all events that happen during a session sorted by time
+// GetSessionEvents Returns all events that happen during a session sorted by time
 // (oldest first).
 //
 // after tells to use only return events after a specified cursor Id

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -85,13 +85,13 @@ func (s *suiteBase) SetUpSuite(c *check.C) {
 }
 
 func (s *suiteBase) SetUpTest(c *check.C) {
-	err := s.log.deleteAllItems()
+	err := s.log.deleteAllItems(context.Background())
 	c.Assert(err, check.IsNil)
 }
 
 func (s *suiteBase) TearDownSuite(c *check.C) {
 	if s.log != nil {
-		if err := s.log.deleteTable(s.log.Tablename, true); err != nil {
+		if err := s.log.deleteTable(context.Background(), s.log.Tablename, true); err != nil {
 			c.Fatalf("Failed to delete table: %#v", trace.DebugReport(err))
 		}
 	}
@@ -161,7 +161,7 @@ func (s *DynamoeventsSuite) TestSessionEventsCRUD(c *check.C) {
 
 // TestIndexExists tests functionality of the `Log.indexExists` function.
 func (s *DynamoeventsSuite) TestIndexExists(c *check.C) {
-	hasIndex, err := s.log.indexExists(s.log.Tablename, indexTimeSearchV2)
+	hasIndex, err := s.log.indexExists(context.Background(), s.log.Tablename, indexTimeSearchV2)
 	c.Assert(err, check.IsNil)
 	c.Assert(hasIndex, check.Equals, true)
 }

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -167,7 +167,7 @@ func composerRun(ctx context.Context, composer *storage.Composer) (*storage.Obje
 }
 
 // DefaultNewHandler returns a new handler with default GCS client settings derived from the config
-func DefaultNewHandler(cfg Config) (*Handler, error) {
+func DefaultNewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 	var args []option.ClientOption
 	if len(cfg.Endpoint) != 0 {
 		args = append(args, option.WithoutAuthentication(), option.WithEndpoint(cfg.Endpoint), option.WithGRPCDialOption(grpc.WithInsecure()))
@@ -175,7 +175,7 @@ func DefaultNewHandler(cfg Config) (*Handler, error) {
 		args = append(args, option.WithCredentialsFile(cfg.CredentialsPath))
 	}
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(ctx)
 	client, err := storage.NewClient(ctx, args...)
 	if err != nil {
 		cancelFunc()

--- a/lib/events/gcssessions/gcsstream_test.go
+++ b/lib/events/gcssessions/gcsstream_test.go
@@ -36,6 +36,7 @@ import (
 
 // TestStreams tests various streaming upload scenarios
 func TestStreams(t *testing.T) {
+	ctx := context.Background()
 	uri := os.Getenv(teleport.GCSTestURI)
 	if uri == "" {
 		t.Skip(
@@ -49,7 +50,7 @@ func TestStreams(t *testing.T) {
 	err = config.SetFromURL(u)
 	require.NoError(t, err)
 
-	handler, err := DefaultNewHandler(config)
+	handler, err := DefaultNewHandler(ctx, config)
 	require.NoError(t, err)
 	defer handler.Close()
 
@@ -79,7 +80,7 @@ func TestStreams(t *testing.T) {
 			return composer.Run(ctx)
 		}
 
-		handler, err := DefaultNewHandler(config)
+		handler, err := DefaultNewHandler(ctx, config)
 		require.NoError(t, err)
 		defer handler.Close()
 
@@ -105,7 +106,7 @@ func TestStreams(t *testing.T) {
 			return nil
 		}
 
-		handler, err := DefaultNewHandler(config)
+		handler, err := DefaultNewHandler(ctx, config)
 		require.NoError(t, err)
 		defer handler.Close()
 

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -124,7 +124,7 @@ func (s *Config) CheckAndSetDefaults() error {
 }
 
 // NewHandler returns new S3 uploader
-func NewHandler(cfg Config) (*Handler, error) {
+func NewHandler(ctx context.Context, cfg Config) (*Handler, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -140,7 +140,7 @@ func NewHandler(cfg Config) (*Handler, error) {
 	}
 	start := time.Now()
 	h.Infof("Setting up bucket %q, sessions path %q in region %q.", h.Bucket, h.Path, h.Region)
-	if err := h.ensureBucket(context.Background()); err != nil {
+	if err := h.ensureBucket(ctx); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	h.WithFields(log.Fields{"duration": time.Since(start)}).Infof("Setup bucket %q completed.", h.Bucket)

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -140,7 +140,7 @@ func NewHandler(cfg Config) (*Handler, error) {
 	}
 	start := time.Now()
 	h.Infof("Setting up bucket %q, sessions path %q in region %q.", h.Bucket, h.Path, h.Region)
-	if err := h.ensureBucket(); err != nil {
+	if err := h.ensureBucket(context.Background()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	h.WithFields(log.Fields{"duration": time.Since(start)}).Infof("Setup bucket %q completed.", h.Bucket)
@@ -190,7 +190,7 @@ func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer io.
 	// Get the oldest version of this object. This has to be done because S3
 	// allows overwriting objects in a bucket. To prevent corruption of recording
 	// data, get all versions and always return the first.
-	versionID, err := h.getOldestVersion(h.Bucket, h.path(sessionID))
+	versionID, err := h.getOldestVersion(ctx, h.Bucket, h.path(sessionID))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -221,11 +221,11 @@ type versionID struct {
 }
 
 // getOldestVersion returns the oldest version of the object.
-func (h *Handler) getOldestVersion(bucket string, prefix string) (string, error) {
+func (h *Handler) getOldestVersion(ctx context.Context, bucket string, prefix string) (string, error) {
 	var versions []versionID
 
 	// Get all versions of this object.
-	err := h.client.ListObjectVersionsPages(&s3.ListObjectVersionsInput{
+	err := h.client.ListObjectVersionsPagesWithContext(ctx, &s3.ListObjectVersionsInput{
 		Bucket: aws.String(bucket),
 		Prefix: aws.String(prefix),
 	}, func(page *s3.ListObjectVersionsOutput, lastPage bool) bool {
@@ -254,16 +254,16 @@ func (h *Handler) getOldestVersion(bucket string, prefix string) (string, error)
 }
 
 // delete bucket deletes bucket and all it's contents and is used in tests
-func (h *Handler) deleteBucket() error {
+func (h *Handler) deleteBucket(ctx context.Context) error {
 	// first, list and delete all the objects in the bucket
-	out, err := h.client.ListObjectVersions(&s3.ListObjectVersionsInput{
+	out, err := h.client.ListObjectVersionsWithContext(ctx, &s3.ListObjectVersionsInput{
 		Bucket: aws.String(h.Bucket),
 	})
 	if err != nil {
 		return ConvertS3Error(err)
 	}
 	for _, ver := range out.Versions {
-		_, err := h.client.DeleteObject(&s3.DeleteObjectInput{
+		_, err := h.client.DeleteObjectWithContext(ctx, &s3.DeleteObjectInput{
 			Bucket:    aws.String(h.Bucket),
 			Key:       ver.Key,
 			VersionId: ver.VersionId,
@@ -272,7 +272,7 @@ func (h *Handler) deleteBucket() error {
 			return ConvertS3Error(err)
 		}
 	}
-	_, err = h.client.DeleteBucket(&s3.DeleteBucketInput{
+	_, err = h.client.DeleteBucketWithContext(ctx, &s3.DeleteBucketInput{
 		Bucket: aws.String(h.Bucket),
 	})
 	return ConvertS3Error(err)
@@ -290,8 +290,8 @@ func (h *Handler) fromPath(path string) session.ID {
 }
 
 // ensureBucket makes sure bucket exists, and if it does not, creates it
-func (h *Handler) ensureBucket() error {
-	_, err := h.client.HeadBucket(&s3.HeadBucketInput{
+func (h *Handler) ensureBucket(ctx context.Context) error {
+	_, err := h.client.HeadBucketWithContext(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(h.Bucket),
 	})
 	err = ConvertS3Error(err)
@@ -307,7 +307,7 @@ func (h *Handler) ensureBucket() error {
 		Bucket: aws.String(h.Bucket),
 		ACL:    aws.String("private"),
 	}
-	_, err = h.client.CreateBucket(input)
+	_, err = h.client.CreateBucketWithContext(ctx, input)
 	err = ConvertS3Error(err, fmt.Sprintf("bucket %v already exists", aws.String(h.Bucket)))
 	if err != nil {
 		if !trace.IsAlreadyExists(err) {
@@ -324,7 +324,7 @@ func (h *Handler) ensureBucket() error {
 			Status: aws.String("Enabled"),
 		},
 	}
-	_, err = h.client.PutBucketVersioning(ver)
+	_, err = h.client.PutBucketVersioningWithContext(ctx, ver)
 	err = ConvertS3Error(err, fmt.Sprintf("failed to set versioning state for bucket %q", h.Bucket))
 	if err != nil {
 		return trace.Wrap(err)
@@ -332,7 +332,7 @@ func (h *Handler) ensureBucket() error {
 
 	// Turn on server-side encryption for the bucket.
 	if !h.DisableServerSideEncryption {
-		_, err = h.client.PutBucketEncryption(&s3.PutBucketEncryptionInput{
+		_, err = h.client.PutBucketEncryptionWithContext(ctx, &s3.PutBucketEncryptionInput{
 			Bucket: aws.String(h.Bucket),
 			ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
 				Rules: []*s3.ServerSideEncryptionRule{{

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -21,6 +21,7 @@ package s3sessions
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/gravitational/teleport/lib/events/test"

--- a/lib/events/s3sessions/s3handler_thirdparty_test.go
+++ b/lib/events/s3sessions/s3handler_thirdparty_test.go
@@ -42,7 +42,7 @@ func TestThirdpartyStreams(t *testing.T) {
 	faker := gofakes3.New(backend, gofakes3.WithLogger(gofakes3.GlobalLog()))
 	server := httptest.NewServer(faker.Server())
 
-	handler, err := NewHandler(Config{
+	handler, err := NewHandler(context.Background(), Config{
 		Credentials:                 credentials.NewStaticCredentials("YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", ""),
 		Region:                      "us-west-1",
 		Path:                        "/test/",

--- a/lib/events/s3sessions/s3handler_thirdparty_test.go
+++ b/lib/events/s3sessions/s3handler_thirdparty_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package s3sessions
 
 import (
+	"context"
 	"fmt"
 	"net/http/httptest"
 	"testing"
@@ -52,7 +53,7 @@ func TestThirdpartyStreams(t *testing.T) {
 	require.Nil(t, err)
 
 	defer func() {
-		if err := handler.deleteBucket(); err != nil {
+		if err := handler.deleteBucket(context.Background()); err != nil {
 			t.Fatalf("Failed to delete bucket: %#v", trace.DebugReport(err))
 		}
 	}()

--- a/lib/events/s3sessions/s3stream.go
+++ b/lib/events/s3sessions/s3stream.go
@@ -119,7 +119,7 @@ func (h *Handler) ListParts(ctx context.Context, upload events.StreamUpload) ([]
 	var parts []events.StreamPart
 	var partNumberMarker *int64
 	for i := 0; i < defaults.MaxIterationLimit; i++ {
-		re, err := h.client.ListParts(&s3.ListPartsInput{
+		re, err := h.client.ListPartsWithContext(ctx, &s3.ListPartsInput{
 			Bucket:           aws.String(h.Bucket),
 			Key:              aws.String(h.path(upload.SessionID)),
 			UploadId:         aws.String(upload.ID),
@@ -164,7 +164,7 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 			KeyMarker:      keyMarker,
 			UploadIdMarker: uploadIDMarker,
 		}
-		re, err := h.client.ListMultipartUploads(input)
+		re, err := h.client.ListMultipartUploadsWithContext(ctx, input)
 		if err != nil {
 			return nil, ConvertS3Error(err)
 		}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -905,7 +905,7 @@ func adminCreds() (*int, *int, error) {
 // initUploadHandler initializes upload handler based on the config settings,
 // currently the only upload handler supported is S3
 // the call can return trace.NotFound if no upload handler is setup
-func initUploadHandler(auditConfig types.ClusterAuditConfig, dataDir string) (events.MultipartHandler, error) {
+func initUploadHandler(ctx context.Context, auditConfig types.ClusterAuditConfig, dataDir string) (events.MultipartHandler, error) {
 	if !auditConfig.ShouldUploadSessions() {
 		recordsDir := filepath.Join(dataDir, events.RecordsDir)
 		if err := os.MkdirAll(recordsDir, teleport.SharedDirMode); err != nil {
@@ -937,7 +937,7 @@ func initUploadHandler(auditConfig types.ClusterAuditConfig, dataDir string) (ev
 		if err := config.SetFromURL(uri); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		handler, err := gcssessions.DefaultNewHandler(config)
+		handler, err := gcssessions.DefaultNewHandler(ctx, config)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -947,7 +947,7 @@ func initUploadHandler(auditConfig types.ClusterAuditConfig, dataDir string) (ev
 		if err := config.SetFromURL(uri, auditConfig.Region()); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		handler, err := s3sessions.NewHandler(config)
+		handler, err := s3sessions.NewHandler(ctx, config)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1103,7 +1103,7 @@ func (process *TeleportProcess) initAuthService() error {
 
 		auditConfig := cfg.Auth.AuditConfig
 		uploadHandler, err = initUploadHandler(
-			auditConfig, filepath.Join(cfg.DataDir, teleport.LogsDir))
+			process.ExitContext(), auditConfig, filepath.Join(cfg.DataDir, teleport.LogsDir))
 		if err != nil {
 			if !trace.IsNotFound(err) {
 				return trace.Wrap(err)


### PR DESCRIPTION
Ensure that dynamo and s3 requests are using the provided context so that timeouts and cancellation are respected.