### PR TITLE
Fix string function to print dereferenced values for PortForwarding

### DIFF
--- a/api/types/role.go
+++ b/api/types/role.go
@@ -658,10 +658,7 @@ func (r *RoleV4) CheckAndSetDefaults() error {
 
 // String returns the human readable representation of a role.
 func (r *RoleV4) String() string {
-	options, err := json.Marshal(r.Spec.Options)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	options, _ := json.Marshal(r.Spec.Options)
 	return fmt.Sprintf("Role(Name=%v,Options=%v,Allow=%+v,Deny=%+v)",
 		r.GetName(), string(options), r.Spec.Allow, r.Spec.Deny)
 }

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -658,8 +658,12 @@ func (r *RoleV4) CheckAndSetDefaults() error {
 
 // String returns the human readable representation of a role.
 func (r *RoleV4) String() string {
+	options, err := json.Marshal(r.Spec.Options)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	return fmt.Sprintf("Role(Name=%v,Options=%v,Allow=%+v,Deny=%+v)",
-		r.GetName(), r.Spec.Options, r.Spec.Allow, r.Spec.Deny)
+		r.GetName(), string(options), r.Spec.Allow, r.Spec.Deny)
 }
 
 // IsEmpty returns true if conditions are unspecified


### PR DESCRIPTION
BoolOption in the RoleOptions struct is being printed as a memory index rather than a dereferenced value.  This should fix it.