### PR TITLE
Added client-side retries to curl.

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -8,6 +8,8 @@
 # of this.
 FROM ubuntu:18.04
 
+ARG CURL_FLAGS
+
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile
 
@@ -23,7 +25,7 @@ RUN apt-get update -y --fix-missing && \
     apt-get -q -y upgrade && \
     apt-get install -y --no-install-recommends apt-utils ca-certificates curl gnupg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    curl $CURL_FLAGS https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
     apt-get -y update && \
     apt-get install -q -y --no-install-recommends \
         apt-utils \
@@ -69,12 +71,13 @@ RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
-RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
-     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
+RUN (curl $CURL_FLAGS -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
+    cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Install Go.
 ARG RUNTIME
-RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz && \
+RUN mkdir -p /opt && cd /opt && \
+    curl $CURL_FLAGS https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
@@ -82,7 +85,8 @@ RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNT
 
 # Install libbpf
 ARG LIBBPF_VERSION
-RUN mkdir -p /opt && cd /opt && curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+RUN mkdir -p /opt && cd /opt && \
+    curl $CURL_FLAGS -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make && \
     make install
@@ -92,19 +96,20 @@ ENV GOPATH="/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
 # Install meta-linter.
-RUN (curl -L https://github.com/golangci/golangci-lint/releases/download/v1.38.0/golangci-lint-1.38.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz && \
-     cp golangci-lint-1.38.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ && \
-     rm -r golangci-lint*)
+RUN (curl $CURL_FLAGS -L https://github.com/golangci/golangci-lint/releases/download/v1.38.0/golangci-lint-1.38.0-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -xz && \
+    cp golangci-lint-1.38.0-$(go env GOOS)-$(go env GOARCH)/golangci-lint /bin/ && \
+    rm -r golangci-lint*)
 
 # Install helm.
-RUN (mkdir -p helm-tarball && curl -L https://get.helm.sh/helm-v3.5.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C helm-tarball -xz && \
-     cp helm-tarball/$(go env GOOS)-$(go env GOARCH)/helm /bin/ && \
-     rm -r helm-tarball*)
+RUN (mkdir -p helm-tarball && \
+    curl $CURL_FLAGS -L https://get.helm.sh/helm-v3.5.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C helm-tarball -xz && \
+    cp helm-tarball/$(go env GOOS)-$(go env GOARCH)/helm /bin/ && \
+    rm -r helm-tarball*)
 
 # Install bats.
-RUN (curl -L https://github.com/bats-core/bats-core/archive/v1.2.1.tar.gz | tar -xz && \
-     cd bats-core-1.2.1 && ./install.sh /usr/local && cd .. && \
-     rm -r bats-core-1.2.1)
+RUN (curl $CURL_FLAGS -L https://github.com/bats-core/bats-core/archive/v1.2.1.tar.gz | tar -xz && \
+    cd bats-core-1.2.1 && ./install.sh /usr/local && cd .. && \
+    rm -r bats-core-1.2.1)
 
 # Install protobuf and grpc build tools.
 ARG PROTOC_VER
@@ -114,9 +119,9 @@ ARG GOGO_PROTO_TAG
 ENV PROTOC_TARBALL protoc-${PROTOC_VER}-${PROTOC_PLATFORM}.zip
 ENV GOGOPROTO_ROOT ${GOPATH}/src/github.com/gogo/protobuf
 
-RUN (curl -L -o /tmp/${PROTOC_TARBALL} https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/${PROTOC_TARBALL} && \
-     cd /tmp && unzip /tmp/${PROTOC_TARBALL} -d /usr/local && \
-     rm /tmp/${PROTOC_TARBALL})
+RUN (curl $CURL_FLAGS -L -o /tmp/${PROTOC_TARBALL} https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/${PROTOC_TARBALL} && \
+    cd /tmp && unzip /tmp/${PROTOC_TARBALL} -d /usr/local && \
+    rm /tmp/${PROTOC_TARBALL})
 RUN (git clone https://github.com/gogo/protobuf.git ${GOPATH}/src/github.com/gogo/protobuf && go install golang.org/x/tools/cmd/goimports@latest && \
      cd ${GOPATH}/src/github.com/gogo/protobuf && \
      git reset --hard ${GOGO_PROTO_TAG} && \

--- a/build.assets/Dockerfile-centos6
+++ b/build.assets/Dockerfile-centos6
@@ -2,6 +2,8 @@
 # releases of Teleport and its documentation.
 FROM centos:6
 
+ARG CURL_FLAGS
+
 ENV LANGUAGE=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
@@ -21,8 +23,8 @@ RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
-RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
-     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
+RUN (curl $CURL_FLAGS -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
+   cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Go 1.16 upgraded to a newer distro for creating their prebuilt binaries, so they no longer work on CentOS 6.
 # As such, we now build from source in the same way as we do for BoringCrypto.
@@ -32,8 +34,10 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
 # 4) Print compiled Go version
 ARG RUNTIME
 ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
-RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
-    mkdir -p /opt && cd /opt && curl -L https://golang.org/dl/${RUNTIME}.src.tar.gz | tar xz && \
+RUN mkdir -p /go-bootstrap && cd /go-bootstrap && \
+    curl $CURL_FLAGS https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
+    mkdir -p /opt && cd /opt && \
+    curl $CURL_FLAGS -L https://golang.org/dl/${RUNTIME}.src.tar.gz | tar xz && \
     cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
     rm -rf /go-bootstrap && \
     mkdir -p /go/src/github.com/gravitational/teleport && \

--- a/build.assets/Dockerfile-centos6-fips
+++ b/build.assets/Dockerfile-centos6-fips
@@ -2,6 +2,8 @@
 # releases of Teleport and its documentation.
 FROM centos:6
 
+ARG CURL_FLAGS
+
 ENV LANGUAGE=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
@@ -21,8 +23,8 @@ RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
-RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
-     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
+RUN (curl $CURL_FLAGS -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
+    cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # BoringCrypto (unlike regular Go) requires glibc 2.14, so we have to build from source.
 # 1) Install older binary Go runtime for bootstrapping
@@ -31,8 +33,10 @@ RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9
 # 4) Print compiled Go version
 ARG BORINGCRYPTO_RUNTIME
 ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
-RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
-    mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${BORINGCRYPTO_RUNTIME}.src.tar.gz | tar xz && \
+RUN mkdir -p /go-bootstrap && cd /go-bootstrap && \
+    curl $CURL_FLAGS https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
+    mkdir -p /opt && cd /opt && \
+    curl $CURL_FLAGS https://go-boringcrypto.storage.googleapis.com/${BORINGCRYPTO_RUNTIME}.src.tar.gz | tar xz && \
     cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
     rm -rf /go-bootstrap && \
     mkdir -p /go/src/github.com/gravitational/teleport && \

--- a/build.assets/Dockerfile-fips
+++ b/build.assets/Dockerfile-fips
@@ -8,6 +8,8 @@
 # of this.
 FROM ubuntu:18.04
 
+ARG CURL_FLAGS
+
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile
 
@@ -52,12 +54,13 @@ RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
 # Install etcd.
-RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
-     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
+RUN (curl $CURL_FLAGS -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
+    cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
 
 # Install Go.
 ARG BORINGCRYPTO_RUNTIME
-RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${BORINGCRYPTO_RUNTIME}.linux-amd64.tar.gz | tar xz && \
+RUN mkdir -p /opt && cd /opt && \
+    curl $CURL_FLAGS https://go-boringcrypto.storage.googleapis.com/${BORINGCRYPTO_RUNTIME}.linux-amd64.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
@@ -65,7 +68,8 @@ RUN mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.
 
 # Install libbpf
 ARG LIBBPF_VERSION
-RUN mkdir -p /opt && cd /opt && curl -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
+RUN mkdir -p /opt && cd /opt && \
+    curl $CURL_FLAGS -L https://github.com/gravitational/libbpf/archive/refs/tags/v${LIBBPF_VERSION}.tar.gz | tar xz && \
     cd /opt/libbpf-${LIBBPF_VERSION}/src && \
     make && \
     make install

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -27,6 +27,10 @@ PROTOC_VER ?= 3.6.1
 PROTOC_PLATFORM := linux-x86_64
 GOGO_PROTO_TAG ?= v1.3.2
 
+# CURL_FLAGS defines flags to support client-side retries, delays, and timeouts
+# to make downloads more resilient against intermittent network issues.
+CURL_FLAGS := "--connect-timeout 120 --retry 10 --retry-delay 30"
+
 BUILDBOX=quay.io/gravitational/teleport-buildbox:$(RUNTIME)
 BUILDBOX_FIPS=quay.io/gravitational/teleport-buildbox-fips:$(RUNTIME)
 BUILDBOX_CENTOS6=quay.io/gravitational/teleport-buildbox-centos6:$(RUNTIME)
@@ -111,6 +115,7 @@ buildbox:
 			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg PROTOC_PLATFORM=$(PROTOC_PLATFORM) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
+			--build-arg CURL_FLAGS=$(CURL_FLAGS) \
 			--cache-from $(BUILDBOX) \
 			--tag $(BUILDBOX) . ; \
 	fi
@@ -127,6 +132,7 @@ buildbox-fips:
 			--build-arg GID=$(GID) \
 			--build-arg BORINGCRYPTO_RUNTIME=$(BORINGCRYPTO_RUNTIME) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
+			--build-arg CURL_FLAGS=$(CURL_FLAGS) \
 			--cache-from $(BUILDBOX_FIPS) \
 			--tag $(BUILDBOX_FIPS) -f Dockerfile-fips . ; \
 	fi
@@ -141,6 +147,7 @@ buildbox-centos6:
 		--build-arg UID=$(UID) \
 		--build-arg GID=$(GID) \
 		--build-arg RUNTIME=$(RUNTIME) \
+		--build-arg CURL_FLAGS=$(CURL_FLAGS) \
 		--cache-from $(BUILDBOX_CENTOS6) \
 		--tag $(BUILDBOX_CENTOS6) -f Dockerfile-centos6 .
 
@@ -157,6 +164,7 @@ buildbox-arm: buildbox
 	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_ARM) 2>&1 >/dev/null; then docker pull $(BUILDBOX_ARM) || true; fi;
 	docker build \
 		--build-arg RUNTIME=$(RUNTIME) \
+		--build-arg CURL_FLAGS=$(CURL_FLAGS) \
 		--cache-from $(BUILDBOX) \
 		--cache-from $(BUILDBOX_ARM) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
@@ -171,6 +179,7 @@ buildbox-arm-fips: buildbox-fips
 	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_ARM_FIPS) 2>&1 >/dev/null; then docker pull $(BUILDBOX_ARM_FIPS) || true; fi;
 	docker build \
 		--build-arg RUNTIME=$(RUNTIME) \
+		--build-arg CURL_FLAGS=$(CURL_FLAGS) \
 		--cache-from $(BUILDBOX_FIPS) \
 		--cache-from $(BUILDBOX_ARM_FIPS) \
 		--tag $(BUILDBOX_ARM_FIPS) -f Dockerfile-arm-fips .


### PR DESCRIPTION
Downloading of external assets (like etcd, golangci-lint, etc) were timing out on CI during builds with the following error:

```
curl: (28) Operation timed out after n milliseconds with 0 out of 0 bytes received
```

Added client-side retries, delays, and timeouts to curl to make downloads more resilient against intermittent network issues.