### PR TITLE
Implement attestation for Webauthn

### DIFF
--- a/lib/auth/mocku2f/mocku2f.go
+++ b/lib/auth/mocku2f/mocku2f.go
@@ -45,6 +45,9 @@ type Key struct {
 	KeyHandle  []byte
 	PrivateKey *ecdsa.PrivateKey
 
+	// Cert is the Key attestation certificate.
+	Cert []byte
+
 	// PreferRPID instructs the Key to use favor using the RPID for Webauthn
 	// ceremonies, even if the U2F App ID extension is present.
 	PreferRPID bool
@@ -54,7 +57,6 @@ type Key struct {
 	// credentials.
 	IgnoreAllowedCredentials bool
 
-	cert    []byte
 	counter uint32
 }
 
@@ -122,7 +124,7 @@ func CreateWithKeyHandle(keyHandle []byte) (*Key, error) {
 	return &Key{
 		KeyHandle:  keyHandle,
 		PrivateKey: privatekey,
-		cert:       cert,
+		Cert:       cert,
 		counter:    1,
 	}, nil
 }
@@ -190,7 +192,7 @@ func (muk *Key) signRegister(appIDHash, clientDataHash []byte) (*signRegisterRes
 	regData = append(regData, pubKey[:]...)
 	regData = append(regData, byte(len(muk.KeyHandle)))
 	regData = append(regData, muk.KeyHandle[:]...)
-	regData = append(regData, muk.cert[:]...)
+	regData = append(regData, muk.Cert[:]...)
 	regData = append(regData, sig[:]...)
 
 	return &signRegisterResult{

--- a/lib/auth/mocku2f/webauthn.go
+++ b/lib/auth/mocku2f/webauthn.go
@@ -170,7 +170,7 @@ func (muk *Key) SignCredentialCreation(origin string, cc *wanlib.CredentialCreat
 		Format: "fido-u2f",
 		AttStatement: map[string]interface{}{
 			"sig": res.Signature,
-			"x5c": []interface{}{muk.cert},
+			"x5c": []interface{}{muk.Cert},
 		},
 	})
 	if err != nil {

--- a/lib/auth/webauthn/attestation.go
+++ b/lib/auth/webauthn/attestation.go
@@ -1,0 +1,148 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthn
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/trace"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// x5cFormats enumerates all attestation formats that supply an attestation
+// chain through the "x5c" field.
+// See https://www.w3.org/TR/webauthn/#sctn-defined-attestation-formats.
+var x5cFormats = []string{
+	"packed",
+	"tpm",
+	"android-key",
+	"fido-u2f",
+	"apple",
+}
+
+func verifyAttestation(cfg *types.Webauthn, obj protocol.AttestationObject) error {
+	if len(cfg.AttestationAllowedCAs) == 0 && len(cfg.AttestationDeniedCAs) == 0 {
+		return nil // Attestation disabled.
+	}
+
+	attestationChain, err := getChainFromObj(obj)
+	if err != nil {
+		return trace.Wrap(
+			err, "failed to read attestation certificate; make sure you are using a device from a trusted manufacturer")
+	}
+
+	// We don't really expect errors at this stage, by the time the configuration
+	// gets here it was already validated by Teleport.
+	allowedPool, err := x509PEMsToCertPool(cfg.AttestationAllowedCAs)
+	if err != nil {
+		return trace.Wrap(err, "invalid webauthn attestation_allowed_ca")
+	}
+	deniedPool, err := x509PEMsToCertPool(cfg.AttestationDeniedCAs)
+	if err != nil {
+		return trace.Wrap(err, "invalid webauthn attestation_denied_ca")
+	}
+
+	// Attestation check works as follows:
+	// 1. At least one certificate must belong to the allowed pool.
+	// 2. No certificates may belong to the denied pool.
+	//
+	// It is possible for both allowed and denied CAs to be present. It's also
+	// possible for configurations to allow a broad range of options (eg, all
+	// YubiKey devices) while denying a smaller subset (a certain model or lot),
+	// so both checks (allowed and denied) may be true for the same cert.
+	allowed := len(cfg.AttestationAllowedCAs) == 0
+	for _, cert := range attestationChain {
+		if _, err := cert.Verify(x509.VerifyOptions{Roots: allowedPool}); err == nil {
+			allowed = true // OK, but keep checking
+		}
+		if _, err := cert.Verify(x509.VerifyOptions{Roots: deniedPool}); err == nil {
+			return trace.BadParameter("attestation certificate %q from issuer %q not allowed", cert.Subject, cert.Issuer)
+		}
+	}
+	if !allowed {
+		return trace.BadParameter(
+			"failed to verify device attestation certificate; make sure you are using a device from a trusted manufacturer")
+	}
+	return nil
+}
+
+func x509PEMsToCertPool(certPEMs []string) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	for _, cert := range certPEMs {
+		if !pool.AppendCertsFromPEM([]byte(cert)) {
+			return nil, trace.BadParameter("failed to parse certificate PEM")
+		}
+	}
+	return pool, nil
+}
+
+func getChainFromObj(obj protocol.AttestationObject) ([]*x509.Certificate, error) {
+	if utils.SliceContainsStr(x5cFormats, obj.Format) {
+		return getChainFromX5C(obj)
+	}
+	if obj.Format == "none" {
+		// Return a nicer error for "none", since we do allow it in non-attestation
+		// scenarios.
+		return nil, trace.BadParameter("attestation format %q not allowed for direct attestation", obj.Format)
+	}
+	return nil, trace.BadParameter("attestation format %q not supported", obj.Format)
+}
+
+func getChainFromX5C(obj protocol.AttestationObject) ([]*x509.Certificate, error) {
+	x5c, ok := obj.AttStatement["x5c"]
+	if !ok {
+		// Warn about self-attestation and Touch ID, it may save someone some grief.
+		return nil, trace.BadParameter(
+			"%q attestation: self attestation not allowed; includes Touch ID in non-Apple browsers", obj.Format)
+	}
+	x5cArray, ok := x5c.([]interface{})
+	if !ok {
+		return nil, trace.BadParameter("%q attestation: unexpected x5c type: %T", obj.Format, x5c)
+	}
+	if len(x5cArray) == 0 {
+		return nil, trace.BadParameter("%q attestation: empty certificate chain", obj.Format)
+	}
+	chain := make([]*x509.Certificate, len(x5cArray))
+	for i, val := range x5cArray {
+		cert, ok := val.([]byte)
+		if !ok {
+			return nil, trace.BadParameter("%q attestation: unexpected x5c element type at index %v: %T", obj.Format, i, val)
+		}
+		var err error
+		chain[i], err = x509.ParseCertificate(cert)
+		if err != nil {
+			return nil, trace.Wrap(err, "%q attestation: failed to parse certificate at index %v", obj.Format, i)
+		}
+	}
+
+	// Print out attestation certs if debug is enabled.
+	// This may come in handy for people having trouble with their setups.
+	if log.IsLevelEnabled(log.DebugLevel) {
+		for _, cert := range chain {
+			certPEM := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: cert.Raw,
+			})
+			log.Debugf("WebAuthn: got %q attestation certificate:\n\n%s", obj.Format, certPEM)
+		}
+	}
+
+	return chain, nil
+}

--- a/lib/auth/webauthn/attestation_test.go
+++ b/lib/auth/webauthn/attestation_test.go
@@ -1,0 +1,380 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthn_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/duo-labs/webauthn/protocol"
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+)
+
+type attestationTest struct {
+	name    string
+	obj     protocol.AttestationObject
+	wantErr bool
+}
+
+func TestVerifyAttestation(t *testing.T) {
+	var sig = []byte{1, 2, 3} // fake signature
+
+	// secureKeyCA stands for a security key manufacturer CA.
+	// In practice, attestation certs are likely to derive directly from this one,
+	// but for testing we include a couple intermediates as well (called
+	// "series 1" and "series 2").
+	secureKeyCACert, secureKeyCAKey, err := makeSelfSigned(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Llama Secure Key Root CA",
+		},
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:     true,
+	})
+	require.NoError(t, err)
+	series1CACert, series1CAKey, err := makeCertificate(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Llama Secure Key Series 1 CA",
+		},
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:     true,
+	}, secureKeyCACert, secureKeyCAKey)
+	require.NoError(t, err)
+	series2CACert, series2CAKey, err := makeCertificate(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Llama Secure Key Series 2 CA",
+		},
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:     true,
+	}, secureKeyCACert, secureKeyCAKey)
+	require.NoError(t, err)
+
+	// secureKeyDevCert is a typical secure key attestation cert.
+	secureKeyDevCert, _, err := makeCertificate(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Llama Secure Key Device #123",
+		},
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment,
+	}, secureKeyCACert, secureKeyCAKey)
+	require.NoError(t, err)
+	// series1 and series2DevCert are secure key attestation certs for specific
+	// device batches/series.
+	series1DevCert, _, err := makeCertificate(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Llama Secure Key Series 1 Device #124",
+		},
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment,
+	}, series1CACert, series1CAKey)
+	require.NoError(t, err)
+	series2DevCert, _, err := makeCertificate(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Llama Secure Key Series 2 Device #125",
+		},
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment,
+	}, series2CACert, series2CAKey)
+	require.NoError(t, err)
+
+	// platformRootCA stands for a platform device attestation CA.
+	// It simulates a chain where the device cert always comes from an "unknown"
+	// intermediate (like Touch ID).
+	platformRootCACert, platformRootCAKey, err := makeSelfSigned(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Llama Platform WebAuthn Root CA",
+		},
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:     true,
+	})
+	require.NoError(t, err)
+	platformIntermediateCACert, platformIntermediateCAKey, err := makeCertificate(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Llama Platform WebAuthn CA 1",
+		},
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:     true,
+	}, platformRootCACert, platformRootCAKey)
+	require.NoError(t, err)
+
+	// platformDevCert is a typical platform device attestation certificate.
+	platformDevCert, _, err := makeCertificate(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Llama Platform Device SN=1231231231",
+		},
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment,
+	}, platformIntermediateCACert, platformIntermediateCAKey)
+	require.NoError(t, err)
+
+	// unknownDevCert stands for a self-signed/unknown attestation certificate.
+	unknownDevCert, _, err := makeSelfSigned(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Totally Secure Device",
+		},
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:     true,
+	})
+	require.NoError(t, err)
+
+	cfg := &types.Webauthn{
+		RPID: "localhost",
+		AttestationAllowedCAs: derToPEMs([][]byte{
+			secureKeyCACert.Raw,    // trust secure keys
+			platformRootCACert.Raw, // trust platform authenticators
+		}),
+		AttestationDeniedCAs: derToPEMs([][]byte{
+			series1CACert.Raw, // exclude "bad" secure key series 1
+		}),
+	}
+
+	// Do a simple check of supported formats before we move on to other
+	// scenarios.
+	// Scenarios below are intended as a format-parsing-check, thus may be a bit
+	// unrealistic (ie, "apple" format with a Yubikey-looking cert).
+	var tests []attestationTest
+	for _, format := range []string{
+		"packed",
+		"tpm",
+		"android-key",
+		"fido-u2f",
+		"apple",
+	} {
+		tests = append(tests, attestationTest{
+			name: fmt.Sprintf("OK format=%v simple check", format),
+			obj: protocol.AttestationObject{
+				Format: format,
+				AttStatement: map[string]interface{}{
+					"alg": webauthncose.AlgES256,
+					"sig": sig,
+					"x5c": []interface{}{
+						secureKeyDevCert.Raw,
+					},
+				},
+			},
+		})
+	}
+
+	// All scenarios are based on responses where "direct" attestation was
+	// requested.
+	// YMMV if using other conveyance preferences.
+	// https://www.w3.org/TR/webauthn/#enum-attestation-convey.
+	tests = append(tests, []attestationTest{
+		{
+			// eg: Brave, Chrome and Safari using Yubikey.
+			name: "OK format=packed root-signed secure key",
+			obj: protocol.AttestationObject{
+				Format: "packed",
+				AttStatement: map[string]interface{}{
+					"alg": webauthncose.AlgES256,
+					"sig": sig,
+					"x5c": []interface{}{secureKeyDevCert.Raw},
+				},
+			},
+		},
+		{
+			// eg: Firefox using Yubikey, tsh.
+			name: "OK format=fido-u2f root-signed secure key",
+			obj: protocol.AttestationObject{
+				Format: "fido-u2f",
+				AttStatement: map[string]interface{}{
+					"sig": sig,
+					"x5c": []interface{}{secureKeyDevCert.Raw},
+				},
+			},
+		},
+		{
+			// eg: Touch ID on Safari.
+			name: "OK format=apple Touch ID attestation",
+			obj: protocol.AttestationObject{
+				Format: "apple",
+				AttStatement: map[string]interface{}{
+					"x5c": []interface{}{
+						platformDevCert.Raw,
+						platformIntermediateCACert.Raw,
+					},
+				},
+			},
+		},
+		{
+			// eg: Brave or Chrome using Touch ID.
+			name: "NOK format=packed self-attestation",
+			obj: protocol.AttestationObject{
+				Format: "packed",
+				AttStatement: map[string]interface{}{
+					"sig": sig,
+					// "x5c" not present.
+				},
+			},
+			wantErr: true,
+		},
+		{
+			// eg: Firefox using anonymized attestation.
+			// They aren't joking about the anonymized part.
+			name: "NOK format=none",
+			obj: protocol.AttestationObject{
+				Format:       "none",
+				AttStatement: map[string]interface{}{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "OK allowed device series",
+			obj: protocol.AttestationObject{
+				Format: "packed",
+				AttStatement: map[string]interface{}{
+					"alg": webauthncose.AlgES256,
+					"sig": sig,
+					"x5c": []interface{}{
+						series2DevCert.Raw,
+						series2CACert.Raw,
+					},
+				},
+			},
+		},
+		{
+			name: "NOK denied device series",
+			obj: protocol.AttestationObject{
+				Format: "packed",
+				AttStatement: map[string]interface{}{
+					"alg": webauthncose.AlgES256,
+					"sig": sig,
+					"x5c": []interface{}{
+						series1DevCert.Raw,
+						series1CACert.Raw, // series1CA prohibited by config
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "NOK unknown device",
+			obj: protocol.AttestationObject{
+				Format: "packed",
+				AttStatement: map[string]interface{}{
+					"alg": webauthncose.AlgES256,
+					"sig": sig,
+					"x5c": []interface{}{
+						unknownDevCert.Raw,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "NOK format not supported",
+			obj: protocol.AttestationObject{
+				Format:       "notsupported",
+				AttStatement: map[string]interface{}{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "NOK x5c empty",
+			obj: protocol.AttestationObject{
+				Format: "packed",
+				AttStatement: map[string]interface{}{
+					"x5c": []interface{}{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "NOK x5c with wrong type",
+			obj: protocol.AttestationObject{
+				Format: "packed",
+				AttStatement: map[string]interface{}{
+					// want []interface{} instead of [][]byte.
+					"x5c": [][]byte{secureKeyDevCert.Raw},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "NOK x5c cert with wrong type",
+			obj: protocol.AttestationObject{
+				Format: "packed",
+				AttStatement: map[string]interface{}{
+					// want []byte instead of string.
+					"x5c": []interface{}{string(secureKeyDevCert.Raw)},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "NOK x5c invalid cert",
+			obj: protocol.AttestationObject{
+				Format: "packed",
+				AttStatement: map[string]interface{}{
+					"x5c": []interface{}{[]byte("not a certificate")},
+				},
+			},
+			wantErr: true,
+		},
+	}...)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := wanlib.VerifyAttestation(cfg, test.obj)
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Errorf("VerifyAttestation returned err = %v, wantErr = %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func makeSelfSigned(template *x509.Certificate) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return makeCertificate(template, template, privKey)
+}
+
+func makeCertificate(template, parent *x509.Certificate, signingKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	var certKey *ecdsa.PrivateKey
+	if template == parent {
+		certKey = signingKey // aka self-signed
+	} else {
+		var err error
+		if certKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader); err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+	}
+
+	sn, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	template.SerialNumber = sn
+	template.NotBefore = time.Now().Add(-1 * time.Minute)
+	template.NotAfter = time.Now().Add(60 * time.Minute)
+	template.BasicConstraintsValid = true
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, parent, &certKey.PublicKey, signingKey)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	cert, err := x509.ParseCertificate(certBytes)
+	return cert, certKey, trace.Wrap(err)
+}

--- a/lib/auth/webauthn/export_test.go
+++ b/lib/auth/webauthn/export_test.go
@@ -18,3 +18,6 @@ package webauthn
 
 // ValidateOrigin lets tests access the validateOrigin method.
 var ValidateOrigin = validateOrigin
+
+// VerifyAttestation lets tests access the verifyAttestation method.
+var VerifyAttestation = verifyAttestation

--- a/lib/auth/webauthn/httpserver/index.html
+++ b/lib/auth/webauthn/httpserver/index.html
@@ -34,12 +34,12 @@
 </body>
 
 <script>
-  // URLBase64 to ArrayBuffer
+  // URLBase64 to ArrayBuffer.
   function bufferDecode(value) {
     return Uint8Array.from(atob(value), c => c.charCodeAt(0));
   }
 
-  // ArrayBuffer to URLBase64
+  // ArrayBuffer to URLBase64.
   function bufferEncode(value) {
     return btoa(String.fromCharCode.apply(null, new Uint8Array(value)))
       .replace(/\+/g, "-")
@@ -77,7 +77,7 @@
         if (res.status === 200) {
           return res;
         }
-        throw new Error(res.statusText);
+        throw res;
       })
       .then(res => res.json())
       .then(res => {
@@ -113,8 +113,13 @@
         if (res.status === 200) {
           alert("registration successful");
         } else {
-          alert("registration failed");
+          throw res;
         }
+      })
+      .catch(res => {
+        res.text().then(body => {
+          alert("Registration failed with HTTP " + res.status + "/" + res.statusMessage + ": " + body);
+        })
       });
   }
 
@@ -140,7 +145,7 @@
         if (res.status === 200) {
           return res;
         }
-        throw new Error(res.statusText);
+        throw res;
       })
       .then(res => res.json())
       .then(res => {
@@ -176,12 +181,17 @@
         if (res.status === 200) {
           alert("login successful");
         } else {
-          alert("login failed");
+          throw res;
         }
+      })
+      .catch(res => {
+        res.text().then(body => {
+          alert("Login failed with HTTP " + res.status + "/" + res.statusMessage + ": " + body);
+        })
       });
   }
 
-  // check whether current browser supports WebAuthn
+  // Is WebAuthn supported?
   if (!window.PublicKeyCredential) {
     alert("Error: this browser does not support WebAuthn");
   }

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -230,6 +230,13 @@ func (f *RegistrationFlow) Finish(ctx context.Context, user, deviceName string, 
 		return nil, trace.Wrap(err)
 	}
 
+	// Finally, check against attestation settings, if any.
+	// This runs after web.CreateCredential so we can take advantage of the
+	// attestation format validation it performs.
+	if err := verifyAttestation(f.Webauthn, parsedResp.Response.AttestationObject); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	newDevice := types.NewMFADevice(deviceName, uuid.NewString() /* id */, time.Now() /* addedAt */)
 	newDevice.Device = &types.MFADevice_Webauthn{
 		Webauthn: &types.WebauthnDevice{

--- a/lib/auth/webauthn/register_test.go
+++ b/lib/auth/webauthn/register_test.go
@@ -16,6 +16,7 @@ package webauthn_test
 
 import (
 	"context"
+	"encoding/pem"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -193,4 +194,102 @@ func TestRegistrationFlow_Finish_errors(t *testing.T) {
 			require.Contains(t, err.Error(), test.wantErr)
 		})
 	}
+}
+
+func TestRegistrationFlow_Finish_attestation(t *testing.T) {
+	const rpID = "localhost"
+	const origin = "https://localhost"
+	const user = "llama"
+	const devName = "web1" // OK to repeat, discarded between tests.
+
+	dev1, err := mocku2f.Create()
+	require.NoError(t, err)
+	dev2, err := mocku2f.Create()
+	require.NoError(t, err)
+	dev3, err := mocku2f.Create()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                  string
+		allowedCAs, deniedCAs [][]byte
+		dev                   *mocku2f.Key
+		wantOK                bool
+	}{
+		{
+			name:       "OK Device clears allow list",
+			allowedCAs: [][]byte{dev1.Cert, dev2.Cert},
+			dev:        dev1,
+			wantOK:     true,
+		},
+		{
+			name:      "OK Device clears deny list",
+			deniedCAs: [][]byte{dev1.Cert, dev2.Cert},
+			dev:       dev3,
+			wantOK:    true,
+		},
+		{
+			name:       "OK Device clears allow and deny lists",
+			allowedCAs: [][]byte{dev1.Cert},
+			deniedCAs:  [][]byte{dev2.Cert, dev3.Cert},
+			dev:        dev1,
+			wantOK:     true,
+		},
+		{
+			name:       "NOK Device not allowed",
+			allowedCAs: [][]byte{dev1.Cert, dev2.Cert},
+			dev:        dev3,
+		},
+		{
+			name:      "NOK Device denied",
+			deniedCAs: [][]byte{dev1.Cert, dev2.Cert},
+			dev:       dev1,
+		},
+		{
+			name:       "NOK Device denied (allow plus deny version)",
+			allowedCAs: [][]byte{dev1.Cert},
+			// Usually, in this case, the allowed CA would be broader than the denied
+			// CA, but we are going for a simplified (albeit odd) scenario in the
+			// test.
+			deniedCAs: [][]byte{dev1.Cert},
+			dev:       dev1,
+		},
+	}
+
+	ctx := context.Background()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			webRegistration := wanlib.RegistrationFlow{
+				Webauthn: &types.Webauthn{
+					RPID:                  rpID,
+					AttestationAllowedCAs: derToPEMs(test.allowedCAs),
+					AttestationDeniedCAs:  derToPEMs(test.deniedCAs),
+				},
+				Identity: newFakeIdentity(user),
+			}
+
+			cc, err := webRegistration.Begin(ctx, user)
+			require.NoError(t, err)
+
+			dev := test.dev
+			ccr, err := dev.SignCredentialCreation(origin, cc)
+			require.NoError(t, err)
+
+			_, err = webRegistration.Finish(ctx, user, devName, ccr)
+			if ok := err == nil; ok != test.wantOK {
+				t.Errorf("Finish returned err = %v, wantOK = %v", err, test.wantOK)
+			}
+		})
+	}
+}
+
+func derToPEMs(certs [][]byte) []string {
+	res := make([]string, len(certs))
+	for i, cert := range certs {
+		certPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert,
+		})
+		res[i] = string(certPEM)
+	}
+	return res
 }


### PR DESCRIPTION
Attestation allows Teleport admins a manner of control over the devices used for
MFA.

Attestation support for Webauthn works similarly to U2F attestation, but
provides both allow and deny lists for device CAs. The device's attestation
certificate must clear both lists before registration is complete.

Previously-registered devices are not affected (similarly to U2F).