### PR TITLE
Update U2F App ID guidance in documentation (#8434)

### DIFF
--- a/docs/pages/access-controls/guides/u2f.mdx
+++ b/docs/pages/access-controls/guides/u2f.mdx
@@ -29,7 +29,7 @@ auth_service:
     # to enable U2F support, set this field to 'u2f', 'on' or 'optional'
     second_factor: u2f
     u2f:
-       app_id: https://example.com:443
+       app_id: https://example.com
        facets:
        - https://example.com:443
        - https://example.com
@@ -42,7 +42,12 @@ auth_service:
 The fields in the above snippet are:
 
 - `app_id` - public address of the Teleport proxy, *including* the `https://`
-  prefix and port number.
+  prefix. If you use a port number other than 443, include it as well.
+
+  Examples:
+
+  - `https://example.com` (uses default port 443)
+  - `https://example.com:3080` (uses non-default port 3080)
 
 <Admonition
   type="warning"
@@ -62,8 +67,9 @@ The fields in the above snippet are:
 
   For compatibility with multiple browsers, it's recommended to write down the
   proxy address in several formats. For example, if your `app_id` is
-  `https://example.com:443`, your `facets` should include
-  `https://example.com:443`, `https://example.com` and `example.com:443`.
+  `https://example.com`, your `facets` should include
+  `https://example.com:443`, `https://example.com`, `example.com:443` and
+  `example.com`.
 
 - `device_attestation_cas` - optional list of certificate authorities (as local
   file paths or in-line PEM certificate string) for U2F [device

--- a/docs/pages/cloud/guides/u2f.mdx
+++ b/docs/pages/cloud/guides/u2f.mdx
@@ -51,6 +51,7 @@ spec:
     facets:
     - 'https://example.teleport.sh:443'
     - 'https://example.teleport.sh'
+    - 'example.teleport.sh:443'
     - 'example.teleport.sh'
 version: v2
 ```

--- a/docs/pages/setup/admin/github-sso.mdx
+++ b/docs/pages/setup/admin/github-sso.mdx
@@ -101,6 +101,7 @@ Configure Teleport Auth Service Github for authentication:
       facets:
       - 'https://example.teleport.sh:443'
       - 'https://example.teleport.sh'
+      - 'example.teleport.sh:443'
       - 'example.teleport.sh'
   version: v2
   ```

--- a/docs/pages/setup/reference/authentication.mdx
+++ b/docs/pages/setup/reference/authentication.mdx
@@ -49,6 +49,7 @@ You can modify these settings in the static config `teleport.yaml`  or using dyn
       facets:
       - 'https://example.teleport.sh:443'
       - 'https://example.teleport.sh'
+      - 'example.teleport.sh:443'
       - 'example.teleport.sh'
   version: v2
   ```

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -203,7 +203,12 @@ auth_service:
         # this section is used if second_factor is set to 'u2f'
         u2f:
             # public address of the Teleport proxy, _including_ the `https://`
-            # prefix and port number.
+            # prefix. If you use a port number other than 443, include it as
+            # well.
+            #
+            # Examples:
+            # - "https://example.com" (uses default port 443)
+            # - "https://example.com:3080" (uses non-default port 3080)
             #
             # IMPORTANT: app_id must never change in the lifetime of the
             # cluster, because it's recorded in the registration data on the

--- a/docs/pages/setup/reference/terraform-provider.mdx
+++ b/docs/pages/setup/reference/terraform-provider.mdx
@@ -451,7 +451,7 @@ Spec contains parameters of a resource.
 | `u2f`                        | set         | U2F defines settings for U2F device                                           |
 | `u2f.app_id`                 | string      | The application ID for universal second factor                                |
 | `u2f.facets`                 | string list | The facets for universal second factor                                        |
-| `u2f.device_attestation_c_as | string list | Trusted attestation CAs for U2F  devices                                      |
+| `u2f.device_attestation_cas` | string list | Trusted attestation CAs for U2F  devices                                      |
 | `require_session_mfa`        | bool        | Causes all sessions in this cluster to require MFA  checks                    |
 | `disconnect_expired_cert`    | bool        | If true, connections with expired client certificates will get disconnected   |
 | `allow_local_auth`           | bool        | If true, local authentication is enabled                                      |


### PR DESCRIPTION
Update U2F documentation to not include port 443 in the U2F App ID.

This is recommended by the standard, plus including port 443 in the App ID
causes issues with Chrome, as explained at #8017[1]. Non-standard ports are fair
game and should be included.

References:
* https://fidoalliance.org/specs/fido-u2f-v1.0-ps-20141009/fido-appid-and-facets-ps-20141009.html#determining-the-facetid-of-a-calling-application
* https://developers.yubico.com/U2F/App_ID.html
* https://www.npmjs.com/package/u2f-api#user-content-common-problems

[1] https://github.com/gravitational/teleport/issues/8017#issuecomment-931594038

* Update U2F App ID guidance in documentation
* Fix u2f.device_attestation_cas in Terraform docs