### PR TITLE
Return preferred MFA method on ping endpoints

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -273,7 +273,7 @@ type AuthenticationSettings struct {
 	// PreferredLocalMFA is a server-side hint for clients to pick an MFA method
 	// when various options are available.
 	// It is empty if there is nothing to suggest.
-	PreferredLocalMFA constants.SecondFactorType `json:"preferred_local_mfa"`
+	PreferredLocalMFA constants.SecondFactorType `json:"preferred_local_mfa,omitempty"`
 	// Webauthn contains MFA settings for Web Authentication.
 	Webauthn *Webauthn `json:"webauthn,omitempty"`
 	// U2F contains the Universal Second Factor settings needed for authentication.

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -262,13 +262,18 @@ type DBProxySettings struct {
 	MySQLPublicAddr string `json:"mysql_public_addr,omitempty"`
 }
 
-// PingResponse contains the form of authentication the auth server supports.
+// AuthenticationSettings contains information about server authentication
+// settings.
 type AuthenticationSettings struct {
 	// Type is the type of authentication, can be either local or oidc.
 	Type string `json:"type"`
 	// SecondFactor is the type of second factor to use in authentication.
 	// Supported options are: off, otp, and u2f.
 	SecondFactor constants.SecondFactorType `json:"second_factor,omitempty"`
+	// PreferredLocalMFA is a server-side hint for clients to pick an MFA method
+	// when various options are available.
+	// It is empty if there is nothing to suggest.
+	PreferredLocalMFA constants.SecondFactorType `json:"preferred_local_mfa"`
 	// Webauthn contains MFA settings for Web Authentication.
 	Webauthn *Webauthn `json:"webauthn,omitempty"`
 	// U2F contains the Universal Second Factor settings needed for authentication.

--- a/api/types/authentication_authpreference_test.go
+++ b/api/types/authentication_authpreference_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -328,6 +330,102 @@ func TestAuthPreferenceV2_CheckAndSetDefaults(t *testing.T) {
 			if err := test.wantCmp(test.prefs); err != nil {
 				t.Fatal(err)
 			}
+		})
+	}
+}
+
+func TestAuthPreferenceV2_GetPreferredLocalMFA(t *testing.T) {
+	u2fConfig := &types.U2F{
+		AppID: "https://example.com",
+		Facets: []string{
+			"https://example.com:443",
+			"https://example.com",
+			"example.com:443",
+			"example.com",
+		},
+	}
+	webConfig := &types.Webauthn{
+		RPID: "example.com",
+	}
+	disabledWebConfig := &types.Webauthn{
+		RPID:     "example.com",
+		Disabled: true,
+	}
+
+	tests := []struct {
+		name string
+		spec types.AuthPreferenceSpecV2
+		want constants.SecondFactorType
+	}{
+		{
+			name: "sf=off",
+			spec: types.AuthPreferenceSpecV2{
+				Type:         constants.Local,
+				SecondFactor: constants.SecondFactorOff,
+			},
+		},
+		{
+			name: "sf=otp",
+			spec: types.AuthPreferenceSpecV2{
+				Type:         constants.Local,
+				SecondFactor: constants.SecondFactorOTP,
+			},
+			want: constants.SecondFactorOTP,
+		},
+		{
+			name: "sf=u2f",
+			spec: types.AuthPreferenceSpecV2{
+				Type:         constants.Local,
+				SecondFactor: constants.SecondFactorU2F,
+				U2F:          u2fConfig,
+			},
+			want: constants.SecondFactorU2F,
+		},
+		{
+			name: "sf=webauthn",
+			spec: types.AuthPreferenceSpecV2{
+				Type:         constants.Local,
+				SecondFactor: constants.SecondFactorWebauthn,
+				Webauthn:     webConfig,
+			},
+			want: constants.SecondFactorWebauthn,
+		},
+		{
+			name: "sf=on favors WebAuthn",
+			spec: types.AuthPreferenceSpecV2{
+				Type:         constants.Local,
+				SecondFactor: constants.SecondFactorOn,
+				U2F:          u2fConfig,
+				Webauthn:     webConfig,
+			},
+			want: constants.SecondFactorWebauthn,
+		},
+		{
+			name: "sf=on disabled WebAuthn favors U2F",
+			spec: types.AuthPreferenceSpecV2{
+				Type:         constants.Local,
+				SecondFactor: constants.SecondFactorOn,
+				U2F:          u2fConfig,
+				Webauthn:     disabledWebConfig,
+			},
+			want: constants.SecondFactorU2F,
+		},
+		{
+			name: "sf=optional favors WebAuthn",
+			spec: types.AuthPreferenceSpecV2{
+				Type:         constants.Local,
+				SecondFactor: constants.SecondFactorOptional,
+				U2F:          u2fConfig,
+				Webauthn:     webConfig,
+			},
+			want: constants.SecondFactorWebauthn,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cap, err := types.NewAuthPreference(test.spec)
+			require.NoError(t, err, "invalid auth preference spec")
+			require.Equal(t, string(test.want), string(cap.GetPreferredLocalMFA()), "unexpected preferred local MFA")
 		})
 	}
 }

--- a/api/types/authentication_authpreference_test.go
+++ b/api/types/authentication_authpreference_test.go
@@ -420,6 +420,16 @@ func TestAuthPreferenceV2_GetPreferredLocalMFA(t *testing.T) {
 			},
 			want: constants.SecondFactorWebauthn,
 		},
+		{
+			name: "sf=optional disabled WebAuthn favors U2F",
+			spec: types.AuthPreferenceSpecV2{
+				Type:         constants.Local,
+				SecondFactor: constants.SecondFactorOptional,
+				U2F:          u2fConfig,
+				Webauthn:     disabledWebConfig,
+			},
+			want: constants.SecondFactorU2F,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -574,20 +574,27 @@ func (h *Handler) getUserContext(w http.ResponseWriter, r *http.Request, p httpr
 
 func localSettings(cap types.AuthPreference) (webclient.AuthenticationSettings, error) {
 	as := webclient.AuthenticationSettings{
-		Type:         constants.Local,
-		SecondFactor: cap.GetSecondFactor(),
+		Type:              constants.Local,
+		SecondFactor:      cap.GetSecondFactor(),
+		PreferredLocalMFA: cap.GetPreferredLocalMFA(),
 	}
 
 	// U2F settings.
-	if u2f, _ := cap.GetU2F(); u2f != nil {
+	switch u2f, err := cap.GetU2F(); {
+	case err == nil:
 		as.U2F = &webclient.U2FSettings{AppID: u2f.AppID}
+	case !trace.IsNotFound(err):
+		log.WithError(err).Warnf("Error reading U2F settings")
 	}
 
 	// Webauthn settings.
-	if webConfig, _ := cap.GetWebauthn(); webConfig != nil {
+	switch webConfig, err := cap.GetWebauthn(); {
+	case err == nil:
 		as.Webauthn = &webclient.Webauthn{
 			RPID: webConfig.RPID,
 		}
+	case !trace.IsNotFound(err):
+		log.WithError(err).Warnf("Error reading WebAuthn settings")
 	}
 
 	return as, nil
@@ -848,10 +855,11 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 	}
 
 	authSettings := ui.WebConfigAuthSettings{
-		Providers:        authProviders,
-		SecondFactor:     secondFactor,
-		LocalAuthEnabled: localAuth,
-		AuthType:         authType,
+		Providers:         authProviders,
+		SecondFactor:      secondFactor,
+		LocalAuthEnabled:  localAuth,
+		AuthType:          authType,
+		PreferredLocalMFA: cap.GetPreferredLocalMFA(),
 	}
 
 	webCfg := ui.WebConfig{

--- a/lib/web/apiserver_ping_test.go
+++ b/lib/web/apiserver_ping_test.go
@@ -58,6 +58,7 @@ func TestPing(t *testing.T) {
 			assertResp: func(cap types.AuthPreference, resp *webclient.PingResponse) {
 				require.Equal(t, cap.GetType(), resp.Auth.Type)
 				require.Equal(t, cap.GetSecondFactor(), resp.Auth.SecondFactor)
+				require.NotEmpty(t, cap.GetPreferredLocalMFA(), "preferred local MFA empty")
 
 				u2f, _ := cap.GetU2F()
 				require.NotNil(t, resp.Auth.U2F)

--- a/lib/web/ui/webconfig.go
+++ b/lib/web/ui/webconfig.go
@@ -72,5 +72,5 @@ type WebConfigAuthSettings struct {
 	// PreferredLocalMFA is a server-side hint for clients to pick an MFA method
 	// when various options are available.
 	// It is empty if there is nothing to suggest.
-	PreferredLocalMFA constants.SecondFactorType `json:"preferredLocalMFA,omitempty"`
+	PreferredLocalMFA constants.SecondFactorType `json:"preferredLocalMfa,omitempty"`
 }

--- a/lib/web/ui/webconfig.go
+++ b/lib/web/ui/webconfig.go
@@ -72,5 +72,5 @@ type WebConfigAuthSettings struct {
 	// PreferredLocalMFA is a server-side hint for clients to pick an MFA method
 	// when various options are available.
 	// It is empty if there is nothing to suggest.
-	PreferredLocalMFA constants.SecondFactorType `json:"preferred_local_mfa"`
+	PreferredLocalMFA constants.SecondFactorType `json:"preferredLocalMFA,omitempty"`
 }

--- a/lib/web/ui/webconfig.go
+++ b/lib/web/ui/webconfig.go
@@ -69,4 +69,8 @@ type WebConfigAuthSettings struct {
 	LocalAuthEnabled bool `json:"localAuthEnabled"`
 	// AuthType is the authentication type.
 	AuthType string `json:"authType"`
+	// PreferredLocalMFA is a server-side hint for clients to pick an MFA method
+	// when various options are available.
+	// It is empty if there is nothing to suggest.
+	PreferredLocalMFA constants.SecondFactorType `json:"preferred_local_mfa"`
 }


### PR DESCRIPTION
Give Teleport clients a consistent hint of which MFA method they should
favor when facing multiple options.

To be used by tsh and Web UI to decide whether they should refer to
"U2F" or "WebAuthn" during the transitional period.