### PR TITLE
Remove existing web sessions prior to setting new authn creds

### DIFF
--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -392,6 +392,12 @@ func (s *Server) CompleteAccountRecovery(ctx context.Context, req *proto.Complet
 		return trace.Wrap(err)
 	}
 
+	// Remove any existing web sessions before setting a new credential.
+	if err := s.deleteWebSessions(ctx, approvedToken.GetUser()); err != nil {
+		log.Error(trace.DebugReport(err))
+		return trace.AccessDenied(completeRecoveryGenericErrMsg)
+	}
+
 	// Check that the correct auth credential is being recovered before setting a new one.
 	switch req.GetNewAuthnCred().(type) {
 	case *proto.CompleteAccountRecoveryRequest_NewPassword:

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -626,7 +626,7 @@ func TestCompleteAccountRecovery(t *testing.T) {
 	// Test new password with lock that should not affect changing authn.
 	triggerLoginLock(t, srv.Auth(), u.username)
 
-	// Add webssion in backend to check for deletion later.
+	// Add web session in backend to check for deletion later.
 	sess, err := types.NewWebSession("web-session-id-2", types.KindWebSession, types.WebSessionSpecV2{
 		User: u.username,
 	})

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -351,6 +351,11 @@ func (s *Server) changeUserAuthentication(ctx context.Context, req *proto.Change
 		return nil, trace.BadParameter("expired token")
 	}
 
+	// Remove users exisitng web sessions before setting new credentials.
+	if err := s.deleteWebSessions(ctx, token.GetUser()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	err = s.changeUserSecondFactor(ctx, req, token)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -351,7 +351,7 @@ func (s *Server) changeUserAuthentication(ctx context.Context, req *proto.Change
 		return nil, trace.BadParameter("expired token")
 	}
 
-	// Remove users exisitng web sessions before setting new credentials.
+	// Remove users existing web sessions before setting new credentials.
 	if err := s.deleteWebSessions(ctx, token.GetUser()); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/password_test.go
+++ b/lib/auth/password_test.go
@@ -577,11 +577,11 @@ func TestChangeUserAuthentication_DeletePreviousWebSession(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add some pre web sessions to check for deletion later.
-	sess, err := types.NewWebSession("web-session-id-1", types.KindWebSession, types.WebSessionSpecV2{
+	sess1, err := types.NewWebSession("web-session-id-1", types.KindWebSession, types.WebSessionSpecV2{
 		User: username,
 	})
 	require.NoError(t, err)
-	err = srv.Auth().Identity.WebSessions().Upsert(ctx, sess)
+	err = srv.Auth().Identity.WebSessions().Upsert(ctx, sess1)
 	require.NoError(t, err)
 
 	sess2, err := types.NewWebSession("web-session-id-2", types.KindWebSession, types.WebSessionSpecV2{

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -236,6 +236,10 @@ func (s *Server) createSessionCert(user types.User, sessionTTL time.Duration, pu
 
 // deleteWebSessions deletes all web sessions for the specified user.
 func (s *Server) deleteWebSessions(ctx context.Context, username string) error {
+	// TODO(kimlisa) improve performance
+	// Due to how we store the session in the backend key(web/sessions/<sessionID>)
+	// this method will return all web sessions. This could cause performance issues with
+	// huge number of users.
 	websessions, err := s.Identity.WebSessions().List(ctx)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -233,3 +233,26 @@ func (s *Server) createSessionCert(user types.User, sessionTTL time.Duration, pu
 
 	return certs.SSH, certs.TLS, nil
 }
+
+// deleteWebSessions deletes all web sessions for the specified user.
+func (s *Server) deleteWebSessions(ctx context.Context, username string) error {
+	websessions, err := s.Identity.WebSessions().List(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for _, session := range websessions {
+		if session.GetUser() != username {
+			continue
+		}
+
+		if err = s.Identity.WebSessions().Delete(ctx, types.DeleteWebSessionRequest{
+			User:      username,
+			SessionID: session.GetName(),
+		}); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### Description
Delete previously existing web sessions prior to resetting of a users authentication credential (pointed out by @russjones)
Resetting of credential happens in two places:
- When user is changing their authentication from a reset or invite
- When user is recovering their account

Since web sessions are cached, it will take at most 10 minutes for a user to get logged out. 10 minute is the interval in which we renew web sessions. And when renewing, we fetch the session from the backend, which no longer exists, rejecting the renew session request and logging the user out as a result.

#### Question
We should also delete sessions (other than the current ont) when a user changes a password from their logged in dashboard?