### PR TITLE
Adjust tsh language in regards to Webauthn

### DIFF
--- a/lib/auth/webauthn/login.go
+++ b/lib/auth/webauthn/login.go
@@ -170,6 +170,7 @@ func (f *LoginFlow) Finish(ctx context.Context, user string, resp *CredentialAss
 
 	origin := parsedResp.Response.CollectedClientData.Origin
 	if err := validateOrigin(origin, f.Webauthn.RPID); err != nil {
+		log.WithError(err).Debugf("WebAuthn: origin validation failed")
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/webauthn/register.go
+++ b/lib/auth/webauthn/register.go
@@ -203,6 +203,7 @@ func (f *RegistrationFlow) Finish(ctx context.Context, user, deviceName string, 
 
 	origin := parsedResp.Response.CollectedClientData.Origin
 	if err := validateOrigin(origin, f.Webauthn.RPID); err != nil {
+		log.WithError(err).Debugf("WebAuthn: origin validation failed")
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -99,15 +99,11 @@ func PromptMFAChallenge(ctx context.Context, proxyAddr string, c *proto.MFAAuthe
 		fmt.Fprintf(os.Stderr, "Tap any %ssecurity key\n", promptDevicePrefix)
 	}
 
-	// TODO(codingllama): Make sure users get a reasonable error back when the
-	//  origin doesn't match the RPID. Webauthn isn't as flexible as U2F in this
-	//  regard.
+	// Fire Webauthn or U2F goroutine.
 	origin := proxyAddr
 	if !strings.HasPrefix(origin, "https://") {
 		origin = "https://" + origin
 	}
-
-	// Fire Webauthn or U2F goroutine.
 	switch {
 	case c.WebauthnChallenge != nil:
 		go func() {

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -113,9 +113,7 @@ func PromptMFAChallenge(ctx context.Context, proxyAddr string, c *proto.MFAAuthe
 		go func() {
 			log.Debugf("WebAuthn: prompting U2F devices with origin %q", origin)
 			resp, err := promptWebauthn(ctx, origin, wanlib.CredentialAssertionFromProto(c.WebauthnChallenge))
-			// Technically it's kind="Webauthn", but we are not changing CLI
-			// nomenclature yet.
-			respC <- response{kind: "U2F", resp: resp, err: err}
+			respC <- response{kind: "WEBAUTHN", resp: resp, err: err}
 		}()
 	case len(c.U2F) > 0:
 		go func() {
@@ -145,7 +143,7 @@ func PromptMFAChallenge(ctx context.Context, proxyAddr string, c *proto.MFAAuthe
 		}
 	}
 	return nil, trace.BadParameter(
-		"failed to authenticate using all U2F and TOTP devices, rerun the command with '-d' to see error details for each device")
+		"failed to authenticate using all MFA and TOTP devices, rerun the command with '-d' to see error details for each device")
 }
 
 func promptU2FChallenges(ctx context.Context, origin string, challenges []*proto.U2FChallenge) (*proto.MFAAuthenticateResponse, error) {

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -139,7 +139,7 @@ func PromptMFAChallenge(ctx context.Context, proxyAddr string, c *proto.MFAAuthe
 		}
 	}
 	return nil, trace.BadParameter(
-		"failed to authenticate using all MFA and TOTP devices, rerun the command with '-d' to see error details for each device")
+		"failed to authenticate using all MFA devices, rerun the command with '-d' to see error details for each device")
 }
 
 func promptU2FChallenges(ctx context.Context, origin string, challenges []*proto.U2FChallenge) (*proto.MFAAuthenticateResponse, error) {

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -199,7 +199,7 @@ type TOTPRegisterChallenge struct {
 	QRCode []byte `json:"qrCode"`
 }
 
-// MFAAuthenticateChallenge is an MFA register challenge sent on new MFA register.
+// MFARegisterChallenge is an MFA register challenge sent on new MFA register.
 type MFARegisterChallenge struct {
 	// U2F contains U2F register challenge.
 	U2F *u2f.RegisterChallenge `json:"u2f"`

--- a/lib/utils/prompt/confirmation.go
+++ b/lib/utils/prompt/confirmation.go
@@ -64,7 +64,8 @@ func PickOne(ctx context.Context, out io.Writer, in *ContextReader, question str
 			return opt, nil
 		}
 	}
-	return "", trace.BadParameter("%q is not a valid option, please specify one of [%s]", answerOrig, strings.Join(options, ", "))
+	return "", trace.BadParameter(
+		"%q is not a valid option, please specify one of [%s]", strings.TrimSpace(string(answerOrig)), strings.Join(options, ", "))
 }
 
 // Input prompts the user for freeform text input.

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -50,8 +50,8 @@ type tshDeviceType = string
 
 const (
 	totpDeviceType     tshDeviceType = "TOTP"
-	u2fDeviceType                    = "U2F"
-	webauthnDeviceType               = "WEBAUTHN"
+	u2fDeviceType      tshDeviceType = "U2F"
+	webauthnDeviceType tshDeviceType = "WEBAUTHN"
 )
 
 // defaultDeviceTypes lists the supported device types for `tsh mfa add`.

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -45,17 +45,14 @@ import (
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
 
-// tshDeviceType represents the device types that appear in the tsh CLI.
-type tshDeviceType = string
-
 const (
-	totpDeviceType     tshDeviceType = "TOTP"
-	u2fDeviceType      tshDeviceType = "U2F"
-	webauthnDeviceType tshDeviceType = "WEBAUTHN"
+	totpDeviceType     = "TOTP"
+	u2fDeviceType      = "U2F"
+	webauthnDeviceType = "WEBAUTHN"
 )
 
 // defaultDeviceTypes lists the supported device types for `tsh mfa add`.
-var defaultDeviceTypes = []tshDeviceType{totpDeviceType, u2fDeviceType, webauthnDeviceType}
+var defaultDeviceTypes = []string{totpDeviceType, u2fDeviceType, webauthnDeviceType}
 
 type mfaCommands struct {
 	ls  *mfaLSCommand
@@ -219,7 +216,7 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 	return nil
 }
 
-func deviceTypesFromPreferredMFA(preferredMFA constants.SecondFactorType) []tshDeviceType {
+func deviceTypesFromPreferredMFA(preferredMFA constants.SecondFactorType) []string {
 	log.Debugf("Got server-side preferred local MFA: %v", preferredMFA)
 
 	m := map[constants.SecondFactorType]string{
@@ -236,9 +233,9 @@ func deviceTypesFromPreferredMFA(preferredMFA constants.SecondFactorType) []tshD
 	case !ok: // Empty or unknown suggestion, fallback to defaults.
 		return defaultDeviceTypes
 	case preferredType == totpDeviceType: // OTP only
-		return []tshDeviceType{preferredType}
+		return []string{preferredType}
 	default: // OTP + Webauthn or U2F
-		return []tshDeviceType{totpDeviceType, preferredType}
+		return []string{totpDeviceType, preferredType}
 	}
 }
 

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -419,9 +419,6 @@ func promptU2FRegisterChallenge(ctx context.Context, proxyAddr string, c *proto.
 }
 
 func promptWebauthnRegisterChallenge(ctx context.Context, proxyAddr string, cc *wantypes.CredentialCreation) (*proto.MFARegisterResponse, error) {
-	// TODO(codingllama): Make sure users get a reasonable error back when the
-	//  origin doesn't match the RPID. Webauthn isn't as flexible as U2F in this
-	//  regard.
 	origin := proxyAddr
 	if !strings.HasPrefix(proxyAddr, "https://") {
 		origin = "https://" + origin

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -109,6 +110,9 @@ func (c *mfaLSCommand) run(cf *CLIConf) error {
 	}); err != nil {
 		return trace.Wrap(err)
 	}
+
+	// Sort by name before printing.
+	sort.Slice(devs, func(i, j int) bool { return devs[i].GetName() < devs[j].GetName() })
 
 	printMFADevices(devs, c.verbose)
 	return nil


### PR DESCRIPTION
This is a collection of a few small changes related to user presentation of
WebAuthn/MFA in tsh. The intent is to make tsh language match ongoing Web UI
changes.

Changes included:

* Use the PreferredLocalMFA server-side hint to decide lingo in `tsh mfa add`
* Adjust language when prompting for challenges to mention WEBAUTHN (and replace
  U2F with the more generic MFA)
* Sort devices by name on `tsh mfa ls`
* Address origin validation TODOS