### PR TITLE
Add unique IDs to upload events

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
+	"github.com/pborman/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -231,6 +232,7 @@ func (g *GRPCServer) CreateAuditStream(stream proto.AuthService_CreateAuditStrea
 					Metadata: apievents.Metadata{
 						Type:        events.SessionUploadEvent,
 						Code:        events.SessionUploadCode,
+						ID:          uuid.New(),
 						Index:       events.SessionUploadIndex,
 						ClusterName: clusterName.GetClusterName(),
 					},

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -154,6 +155,7 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 			Metadata: apievents.Metadata{
 				Type:  SessionUploadEvent,
 				Code:  SessionUploadCode,
+				ID:    uuid.New(),
 				Index: SessionUploadIndex,
 			},
 			SessionMetadata: apievents.SessionMetadata{


### PR DESCRIPTION
All events currently have a unique ID except `session.print` events and `session.upload` events.
`session.print` events are documented to not have an ID due to space reasons but `session.upload` events are expected
to have them. This PR adds the ID field to them too.

Fixes #8413 