### PR TITLE
Auto-discovery for RDS databases

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -303,10 +303,14 @@ const (
 	// OriginDynamic is an origin value indicating that the resource was
 	// committed as dynamic configuration.
 	OriginDynamic = "dynamic"
+
+	// OriginCloud is an origin value indicating that the resource was
+	// imported from a cloud provider.
+	OriginCloud = "cloud"
 )
 
 // OriginValues lists all possible origin values.
-var OriginValues = []string{OriginDefaults, OriginConfigFile, OriginDynamic}
+var OriginValues = []string{OriginDefaults, OriginConfigFile, OriginDynamic, OriginCloud}
 
 const (
 	// RecordAtNode is the default. Sessions are recorded at Teleport nodes.

--- a/lib/cloud/aws/policy.go
+++ b/lib/cloud/aws/policy.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/gravitational/trace"
+)
+
+// PolicyDocument represents a parsed AWS IAM policy document.
+//
+// Note that PolicyDocument and its Ensure/Delete methods are not currently
+// goroutine-safe. To create a policy using AWS IAM API, dump the object to
+// JSON format using json.Marshal.
+type PolicyDocument struct {
+	// Version is the policy version.
+	Version string `json:"Version"`
+	// Statements is a list of the policy statements.
+	Statements []*Statement `json:"Statement"`
+}
+
+// Statement is a single AWS IAM policy statement.
+type Statement struct {
+	// Effect is the statement effect such as Allow or Deny.
+	Effect string `json:"Effect"`
+	// Actions is a list of actions.
+	Actions []string `json:"Action"`
+	// Resources is a list of resources.
+	Resources []string `json:"Resource"`
+}
+
+// ParsePolicyDocument returns parsed AWS IAM policy document.
+func ParsePolicyDocument(document string) (*PolicyDocument, error) {
+	// Policy document returned from AWS API can be URL-encoded:
+	// https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetRolePolicy.html
+	decoded, err := url.QueryUnescape(document)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var parsed PolicyDocument
+	if err := json.Unmarshal([]byte(decoded), &parsed); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &parsed, nil
+}
+
+// NewPolicyDocument returns new empty AWS IAM policy document.
+func NewPolicyDocument() *PolicyDocument {
+	return &PolicyDocument{
+		Version: PolicyVersion,
+	}
+}
+
+// Ensure ensures that the policy document contains the specified resource
+// action.
+//
+// Returns true if the resource action was already a part of the policy and
+// false otherwise.
+func (p *PolicyDocument) Ensure(effect, action, resource string) bool {
+	for _, s := range p.Statements {
+		if s.Effect != effect {
+			continue
+		}
+		for _, a := range s.Actions {
+			if a != action {
+				continue
+			}
+			for _, r := range s.Resources {
+				// Resource action is already in the policy.
+				if r == resource {
+					return true
+				}
+			}
+			// Action exists but resource is missing.
+			s.Resources = append(s.Resources, resource)
+			return false
+		}
+	}
+	// No statement yet for this resource action, add it.
+	p.Statements = append(p.Statements, &Statement{
+		Effect:    effect,
+		Actions:   []string{action},
+		Resources: []string{resource},
+	})
+	return false
+}
+
+// Delete deletes the specified resource action from the policy.
+func (p *PolicyDocument) Delete(effect, action, resource string) {
+	var statements []*Statement
+	for _, s := range p.Statements {
+		if s.Effect != effect {
+			statements = append(statements, s)
+			continue
+		}
+		var resources []string
+		for _, a := range s.Actions {
+			for _, r := range s.Resources {
+				if a != action || r != resource {
+					resources = append(resources, r)
+				}
+			}
+		}
+		if len(resources) != 0 {
+			statements = append(statements, &Statement{
+				Effect:    s.Effect,
+				Actions:   s.Actions,
+				Resources: resources,
+			})
+		}
+	}
+	p.Statements = statements
+}
+
+const (
+	// PolicyVersion is default IAM policy version.
+	PolicyVersion = "2012-10-17"
+	// EffectAllow is the Allow IAM policy effect.
+	EffectAllow = "Allow"
+	// EffectDeny is the Deny IAM policy effect.
+	EffectDeny = "Deny"
+)

--- a/lib/cloud/aws/policy_test.go
+++ b/lib/cloud/aws/policy_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIAMPolicy verifies AWS IAM policy manipulations.
+func TestIAMPolicy(t *testing.T) {
+	policy := NewPolicyDocument()
+
+	// Add a new action/resource.
+	alreadyExisted := policy.Ensure(EffectAllow, "action-1", "resource-1")
+	require.False(t, alreadyExisted)
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+		},
+	}, policy)
+
+	// Add the same action/resource.
+	alreadyExisted = policy.Ensure(EffectAllow, "action-1", "resource-1")
+	require.True(t, alreadyExisted)
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+		},
+	}, policy)
+
+	// Add a new resource to existing action.
+	alreadyExisted = policy.Ensure(EffectAllow, "action-1", "resource-2")
+	require.False(t, alreadyExisted)
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1", "resource-2"},
+			},
+		},
+	}, policy)
+
+	// Add another action/resource.
+	alreadyExisted = policy.Ensure(EffectAllow, "action-2", "resource-3")
+	require.False(t, alreadyExisted)
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1", "resource-2"},
+			},
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-2"},
+				Resources: []string{"resource-3"},
+			},
+		},
+	}, policy)
+
+	// Delete existing resource action.
+	policy.Delete(EffectAllow, "action-1", "resource-1")
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-2"},
+			},
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-2"},
+				Resources: []string{"resource-3"},
+			},
+		},
+	}, policy)
+
+	// Delete last resource from first action, statement should get removed as well.
+	policy.Delete(EffectAllow, "action-1", "resource-2")
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-2"},
+				Resources: []string{"resource-3"},
+			},
+		},
+	}, policy)
+
+	// Delete last resource action, policy should be empty.
+	policy.Delete(EffectAllow, "action-2", "resource-3")
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+	}, policy)
+
+	// Policy with duplicate statement.
+	policy = &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+		},
+	}
+	policy.Delete(EffectAllow, "action-1", "resource-1")
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+	}, policy)
+
+	// Policy with deny statement.
+	policy = &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1", "resource-2"},
+			},
+			{
+				Effect:    EffectDeny,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-2"},
+			},
+		},
+	}
+	policy.Delete(EffectAllow, "action-1", "resource-2")
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+			{
+				Effect:    EffectDeny,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-2"},
+			},
+		},
+	}, policy)
+}

--- a/lib/cloud/doc.go
+++ b/lib/cloud/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cloud contains common methods and utilities for integrations with
+// various cloud providers such as AWS, GCP or Azure.
+package cloud

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -937,10 +937,18 @@ func applyKubeConfig(fc *FileConfig, cfg *service.Config) error {
 // applyDatabasesConfig applies file configuration for the "db_service" section.
 func applyDatabasesConfig(fc *FileConfig, cfg *service.Config) error {
 	cfg.Databases.Enabled = true
-	for _, selector := range fc.Databases.Selectors {
-		cfg.Databases.Selectors = append(cfg.Databases.Selectors,
-			services.Selector{
-				MatchLabels: selector.MatchLabels,
+	for _, matcher := range fc.Databases.ResourceMatchers {
+		cfg.Databases.ResourceMatchers = append(cfg.Databases.ResourceMatchers,
+			services.ResourceMatcher{
+				Labels: matcher.Labels,
+			})
+	}
+	for _, matcher := range fc.Databases.AWSMatchers {
+		cfg.Databases.AWSMatchers = append(cfg.Databases.AWSMatchers,
+			services.AWSMatcher{
+				Types:   matcher.Types,
+				Regions: matcher.Regions,
+				Tags:    matcher.Tags,
 			})
 	}
 	for _, database := range fc.Databases.Databases {
@@ -1006,10 +1014,10 @@ func applyAppsConfig(fc *FileConfig, cfg *service.Config) error {
 	cfg.Apps.DebugApp = fc.Apps.DebugApp
 
 	// Configure resource watcher selectors if present.
-	for _, selector := range fc.Apps.Selectors {
-		cfg.Apps.Selectors = append(cfg.Apps.Selectors,
-			services.Selector{
-				MatchLabels: selector.MatchLabels,
+	for _, matcher := range fc.Apps.ResourceMatchers {
+		cfg.Apps.ResourceMatchers = append(cfg.Apps.ResourceMatchers,
+			services.ResourceMatcher{
+				Labels: matcher.Labels,
 			})
 	}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -297,9 +297,9 @@ func TestConfigReading(t *testing.T) {
 					DynamicLabels: CommandLabels,
 				},
 			},
-			Selectors: []Selector{
+			ResourceMatchers: []ResourceMatcher{
 				{
-					MatchLabels: map[string]apiutils.Strings{
+					Labels: map[string]apiutils.Strings{
 						"*": {"*"},
 					},
 				},
@@ -318,10 +318,26 @@ func TestConfigReading(t *testing.T) {
 					DynamicLabels: CommandLabels,
 				},
 			},
-			Selectors: []Selector{
+			ResourceMatchers: []ResourceMatcher{
 				{
-					MatchLabels: map[string]apiutils.Strings{
+					Labels: map[string]apiutils.Strings{
 						"*": {"*"},
+					},
+				},
+			},
+			AWSMatchers: []AWSMatcher{
+				{
+					Types:   []string{"rds"},
+					Regions: []string{"us-west-1", "us-east-1"},
+					Tags: map[string]apiutils.Strings{
+						"a": {"b"},
+					},
+				},
+				{
+					Types:   []string{"rds"},
+					Regions: []string{"us-central-1"},
+					Tags: map[string]apiutils.Strings{
+						"c": {"d"},
 					},
 				},
 			},
@@ -1008,9 +1024,9 @@ func makeConfigFixture() string {
 			DynamicLabels: CommandLabels,
 		},
 	}
-	conf.Apps.Selectors = []Selector{
+	conf.Apps.ResourceMatchers = []ResourceMatcher{
 		{
-			MatchLabels: map[string]apiutils.Strings{"*": {"*"}},
+			Labels: map[string]apiutils.Strings{"*": {"*"}},
 		},
 	}
 
@@ -1025,9 +1041,21 @@ func makeConfigFixture() string {
 			DynamicLabels: CommandLabels,
 		},
 	}
-	conf.Databases.Selectors = []Selector{
+	conf.Databases.ResourceMatchers = []ResourceMatcher{
 		{
-			MatchLabels: map[string]apiutils.Strings{"*": {"*"}},
+			Labels: map[string]apiutils.Strings{"*": {"*"}},
+		},
+	}
+	conf.Databases.AWSMatchers = []AWSMatcher{
+		{
+			Types:   []string{"rds"},
+			Regions: []string{"us-west-1", "us-east-1"},
+			Tags:    map[string]apiutils.Strings{"a": {"b"}},
+		},
+		{
+			Types:   []string{"rds"},
+			Regions: []string{"us-central-1"},
+			Tags:    map[string]apiutils.Strings{"c": {"d"}},
 		},
 	}
 
@@ -1356,8 +1384,8 @@ app_service:
       name: foo
       public_addr: "foo.example.com"
       uri: "http://127.0.0.1:8080"
-  selectors:
-  - match_labels:
+  resources:
+  - labels:
       '*': '*'
 `,
 			inComment: "config is valid",
@@ -1494,8 +1522,13 @@ func TestDatabaseConfig(t *testing.T) {
 			inConfigString: `
 db_service:
   enabled: true
-  selectors:
-  - match_labels:
+  resources:
+  - labels:
+      '*': '*'
+  aws:
+  - types: ["rds", "redshift"]
+    regions: ["us-east-1", "us-west-1"]
+    tags:
       '*': '*'
   databases:
   - name: foo

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -900,14 +900,26 @@ type Databases struct {
 	Service `yaml:",inline"`
 	// Databases is a list of databases proxied by the service.
 	Databases []*Database `yaml:"databases"`
-	// Selectors defines resource monitor selectors.
-	Selectors []Selector `yaml:"selectors,omitempty"`
+	// ResourceMatchers match cluster database resources.
+	ResourceMatchers []ResourceMatcher `yaml:"resources,omitempty"`
+	// AWSMatchers match AWS hosted databases.
+	AWSMatchers []AWSMatcher `yaml:"aws,omitempty"`
 }
 
-// Selector represents a single resource monitor selector.
-type Selector struct {
-	// MatchLabels represents a selector that matches labels.
-	MatchLabels map[string]apiutils.Strings `yaml:"match_labels,omitempty"`
+// ResourceMatcher matches cluster resources.
+type ResourceMatcher struct {
+	// Labels match resource labels.
+	Labels map[string]apiutils.Strings `yaml:"labels,omitempty"`
+}
+
+// AWSMatcher matches AWS databases.
+type AWSMatcher struct {
+	// Types are AWS database types to match, "rds" or "redshift".
+	Types []string `yaml:"types,omitempty"`
+	// Regions are AWS regions to query for databases.
+	Regions []string `yaml:"regions,omitempty"`
+	// Tags are AWS tags to match.
+	Tags map[string]apiutils.Strings `yaml:"tags,omitempty"`
 }
 
 // Database represents a single database proxied by the service.
@@ -978,8 +990,8 @@ type Apps struct {
 	// Apps is a list of applications that will be run by this service.
 	Apps []*App `yaml:"apps"`
 
-	// Selectors defines resource monitor selectors.
-	Selectors []Selector `yaml:"selectors,omitempty"`
+	// ResourceMatchers match cluster application resources.
+	ResourceMatchers []ResourceMatcher `yaml:"resources,omitempty"`
 }
 
 // App is the specific application that will be proxied by the application

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -602,8 +602,10 @@ type DatabasesConfig struct {
 	Enabled bool
 	// Databases is a list of databases proxied by this service.
 	Databases []Database
-	// Selectors is a list of resource monitor selectors.
-	Selectors []services.Selector
+	// ResourceMatchers match cluster database resources.
+	ResourceMatchers []services.ResourceMatcher
+	// AWSMatchers match AWS hosted databases.
+	AWSMatchers []services.AWSMatcher
 }
 
 // Database represents a single database that's being proxied.
@@ -728,8 +730,8 @@ type AppsConfig struct {
 	// Apps is the list of applications that are being proxied.
 	Apps []App
 
-	// Selectors is a list of resource monitor selectors.
-	Selectors []services.Selector
+	// ResourceMatchers match cluster database resources.
+	ResourceMatchers []services.ResourceMatcher
 }
 
 // App is the specific application that will be proxied by the application

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -31,7 +31,9 @@ import (
 )
 
 func (process *TeleportProcess) initDatabases() {
-	if len(process.Config.Databases.Databases) == 0 && len(process.Config.Databases.Selectors) == 0 {
+	if len(process.Config.Databases.Databases) == 0 &&
+		len(process.Config.Databases.ResourceMatchers) == 0 &&
+		len(process.Config.Databases.AWSMatchers) == 0 {
 		return
 	}
 	process.registerWithAuthServer(types.RoleDatabase, DatabasesIdentityEvent)
@@ -168,13 +170,14 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 			Emitter:  asyncEmitter,
 			Streamer: streamer,
 		},
-		Authorizer:  authorizer,
-		TLSConfig:   tlsConfig,
-		GetRotation: process.getRotation,
-		Hostname:    process.Config.Hostname,
-		HostID:      process.Config.HostUUID,
-		Databases:   databases,
-		Selectors:   process.Config.Databases.Selectors,
+		Authorizer:       authorizer,
+		TLSConfig:        tlsConfig,
+		GetRotation:      process.getRotation,
+		Hostname:         process.Config.Hostname,
+		HostID:           process.Config.HostUUID,
+		Databases:        databases,
+		ResourceMatchers: process.Config.Databases.ResourceMatchers,
+		AWSMatchers:      process.Config.Databases.AWSMatchers,
 		OnHeartbeat: func(err error) {
 			if err != nil {
 				process.BroadcastEvent(Event{Name: TeleportDegradedEvent, Payload: teleport.ComponentDatabase})

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3348,7 +3348,9 @@ func (process *TeleportProcess) initApps() {
 	// If no applications are specified, exit early. This is due to the strange
 	// behavior in reading file configuration. If the user does not specify an
 	// "app_service" section, that is considered enabling "app_service".
-	if len(process.Config.Apps.Apps) == 0 && !process.Config.Apps.DebugApp && len(process.Config.Apps.Selectors) == 0 {
+	if len(process.Config.Apps.Apps) == 0 &&
+		!process.Config.Apps.DebugApp &&
+		len(process.Config.Apps.ResourceMatchers) == 0 {
 		return
 	}
 
@@ -3503,17 +3505,17 @@ func (process *TeleportProcess) initApps() {
 		}
 
 		appServer, err = app.New(process.ExitContext(), &app.Config{
-			DataDir:      process.Config.DataDir,
-			AuthClient:   conn.Client,
-			AccessPoint:  accessPoint,
-			Authorizer:   authorizer,
-			TLSConfig:    tlsConfig,
-			CipherSuites: process.Config.CipherSuites,
-			HostID:       process.Config.HostUUID,
-			Hostname:     process.Config.Hostname,
-			GetRotation:  process.getRotation,
-			Apps:         applications,
-			Selectors:    process.Config.Apps.Selectors,
+			DataDir:          process.Config.DataDir,
+			AuthClient:       conn.Client,
+			AccessPoint:      accessPoint,
+			Authorizer:       authorizer,
+			TLSConfig:        tlsConfig,
+			CipherSuites:     process.Config.CipherSuites,
+			HostID:           process.Config.HostUUID,
+			Hostname:         process.Config.Hostname,
+			GetRotation:      process.getRotation,
+			Apps:             applications,
+			ResourceMatchers: process.Config.Apps.ResourceMatchers,
 			OnHeartbeat: func(err error) {
 				if err != nil {
 					process.BroadcastEvent(Event{Name: TeleportDegradedEvent, Payload: teleport.ComponentApp})

--- a/lib/services/compare.go
+++ b/lib/services/compare.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"github.com/gravitational/teleport/api/types"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// CompareResources compares two resources by all significant fields.
+func CompareResources(resA, resB types.Resource) int {
+	equal := cmp.Equal(resA, resB,
+		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
+		cmpopts.IgnoreFields(types.DatabaseV3{}, "Status"),
+		cmpopts.EquateEmpty())
+	if equal {
+		return Equal
+	}
+	return Different
+}

--- a/lib/services/matchers_test.go
+++ b/lib/services/matchers_test.go
@@ -30,22 +30,22 @@ import (
 func TestMatchResourceLabels(t *testing.T) {
 	tests := []struct {
 		description    string
-		selectors      []Selector
+		selectors      []ResourceMatcher
 		databaseLabels map[string]string
 		match          bool
 	}{
 		{
 			description: "wildcard selector matches empty labels",
-			selectors: []Selector{
-				{MatchLabels: types.Labels{types.Wildcard: []string{types.Wildcard}}},
+			selectors: []ResourceMatcher{
+				{Labels: types.Labels{types.Wildcard: []string{types.Wildcard}}},
 			},
 			databaseLabels: nil,
 			match:          true,
 		},
 		{
 			description: "wildcard selector matches any label",
-			selectors: []Selector{
-				{MatchLabels: types.Labels{types.Wildcard: []string{types.Wildcard}}},
+			selectors: []ResourceMatcher{
+				{Labels: types.Labels{types.Wildcard: []string{types.Wildcard}}},
 			},
 			databaseLabels: map[string]string{
 				uuid.New(): uuid.New(),
@@ -55,40 +55,40 @@ func TestMatchResourceLabels(t *testing.T) {
 		},
 		{
 			description: "selector doesn't match empty labels",
-			selectors: []Selector{
-				{MatchLabels: types.Labels{"env": []string{"dev"}}},
+			selectors: []ResourceMatcher{
+				{Labels: types.Labels{"env": []string{"dev"}}},
 			},
 			databaseLabels: nil,
 			match:          false,
 		},
 		{
 			description: "selector matches specific label",
-			selectors: []Selector{
-				{MatchLabels: types.Labels{"env": []string{"dev"}}},
+			selectors: []ResourceMatcher{
+				{Labels: types.Labels{"env": []string{"dev"}}},
 			},
 			databaseLabels: map[string]string{"env": "dev"},
 			match:          true,
 		},
 		{
 			description: "selector doesn't match label",
-			selectors: []Selector{
-				{MatchLabels: types.Labels{"env": []string{"dev"}}},
+			selectors: []ResourceMatcher{
+				{Labels: types.Labels{"env": []string{"dev"}}},
 			},
 			databaseLabels: map[string]string{"env": "prod"},
 			match:          false,
 		},
 		{
 			description: "selector matches label",
-			selectors: []Selector{
-				{MatchLabels: types.Labels{"env": []string{"dev", "prod"}}},
+			selectors: []ResourceMatcher{
+				{Labels: types.Labels{"env": []string{"dev", "prod"}}},
 			},
 			databaseLabels: map[string]string{"env": "prod"},
 			match:          true,
 		},
 		{
 			description: "selector doesn't match multiple labels",
-			selectors: []Selector{
-				{MatchLabels: types.Labels{
+			selectors: []ResourceMatcher{
+				{Labels: types.Labels{
 					"env":     []string{"dev"},
 					"cluster": []string{"root"},
 				}},
@@ -98,8 +98,8 @@ func TestMatchResourceLabels(t *testing.T) {
 		},
 		{
 			description: "selector matches multiple labels",
-			selectors: []Selector{
-				{MatchLabels: types.Labels{
+			selectors: []ResourceMatcher{
+				{Labels: types.Labels{
 					"env":     []string{"dev"},
 					"cluster": []string{"root"},
 				}},
@@ -109,9 +109,9 @@ func TestMatchResourceLabels(t *testing.T) {
 		},
 		{
 			description: "one of multiple selectors matches",
-			selectors: []Selector{
-				{MatchLabels: types.Labels{"env": []string{"dev"}}},
-				{MatchLabels: types.Labels{"cluster": []string{"root"}}},
+			selectors: []ResourceMatcher{
+				{Labels: types.Labels{"env": []string{"dev"}}},
+				{Labels: types.Labels{"cluster": []string{"root"}}},
 			},
 			databaseLabels: map[string]string{"cluster": "root"},
 			match:          true,

--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -27,10 +27,12 @@ import (
 
 // ReconcilerConfig is the resource reconciler configuration.
 type ReconcilerConfig struct {
-	// Selectors is a list of selectors the reconciler will match resources against.
-	Selectors []Selector
-	// GetResources is used to fetch currently registered resources list.
-	GetResources func() types.ResourcesWithLabels
+	// Matcher is used to match resources.
+	Matcher Matcher
+	// GetCurrentResources returns currently registered resources.
+	GetCurrentResources func() types.ResourcesWithLabels
+	// GetNewResources returns resources to compare current resources against.
+	GetNewResources func() types.ResourcesWithLabels
 	// OnCreate is called when a new resource is detected.
 	OnCreate func(context.Context, types.ResourceWithLabels) error
 	// OnUpdate is called when an existing resource is updated.
@@ -41,10 +43,19 @@ type ReconcilerConfig struct {
 	Log logrus.FieldLogger
 }
 
+// Matcher is used by reconciler to match resources.
+type Matcher func(types.ResourceWithLabels) bool
+
 // CheckAndSetDefaults validates the reconciler configuration and sets defaults.
 func (c *ReconcilerConfig) CheckAndSetDefaults() error {
-	if c.GetResources == nil {
-		return trace.BadParameter("missing reconciler GetResources")
+	if c.Matcher == nil {
+		return trace.BadParameter("missing reconciler Matcher")
+	}
+	if c.GetCurrentResources == nil {
+		return trace.BadParameter("missing reconciler GetCurrentResources")
+	}
+	if c.GetNewResources == nil {
+		return trace.BadParameter("missing reconciler GetNewResources")
 	}
 	if c.OnCreate == nil {
 		return trace.BadParameter("missing reconciler OnCreate")
@@ -68,12 +79,12 @@ func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
 	}
 	return &Reconciler{
 		cfg: cfg,
-		log: cfg.Log.WithField("selectors", cfg.Selectors),
+		log: cfg.Log,
 	}, nil
 }
 
-// Reconciler reconciles a list of resources returned by GetResources from its
-// config with a list of provided resources.
+// Reconcile reconciles currently registered resources with new resources and
+// creates/updates/deletes them appropriately.
 //
 // It's used in combination with watchers by agents (app, database) to enable
 // dynamically registered resources.
@@ -82,14 +93,19 @@ type Reconciler struct {
 	log logrus.FieldLogger
 }
 
-// Reconcile reconciles a list of resources returned by GetResources from its
-// config with newResources and calls appropriate callbacks.
-func (r *Reconciler) Reconcile(ctx context.Context, newResources types.ResourcesWithLabels) error {
-	r.log.Debugf("Reconciling with %v resources.", len(newResources))
+// Reconcile reconciles currently registered resources with new resources and
+// creates/updates/deletes them appropriately.
+func (r *Reconciler) Reconcile(ctx context.Context) error {
+	currentResources := r.cfg.GetCurrentResources()
+	newResources := r.cfg.GetNewResources()
+
+	r.log.Debugf("Reconciling %v current resources with %v new resources.",
+		len(currentResources), len(newResources))
+
 	var errs []error
 
 	// Process already registered resources to see if any of them were removed.
-	for _, current := range r.cfg.GetResources() {
+	for _, current := range currentResources {
 		if err := r.processRegisteredResource(ctx, newResources, current); err != nil {
 			errs = append(errs, trace.Wrap(err))
 		}
@@ -97,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, newResources types.Resources
 
 	// Add new resources if there are any or refresh those that were updated.
 	for _, new := range newResources {
-		if err := r.processNewResource(ctx, new); err != nil {
+		if err := r.processNewResource(ctx, currentResources, new); err != nil {
 			errs = append(errs, trace.Wrap(err))
 		}
 	}
@@ -108,12 +124,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, newResources types.Resources
 // processRegisteredResource checks the specified registered resource against the
 // new list of resources.
 func (r *Reconciler) processRegisteredResource(ctx context.Context, newResources types.ResourcesWithLabels, registered types.ResourceWithLabels) error {
-	// Skip resources marked as static as those usually come from static config.
-	// For backwards compatibility also consider empty "origin" value.
-	if registered.Origin() == types.OriginConfigFile || registered.Origin() == "" {
-		return nil
-	}
-
 	// See if this registered resource is still present among "new" resources.
 	if new := newResources.Find(registered.GetName()); new != nil {
 		return nil
@@ -129,12 +139,12 @@ func (r *Reconciler) processRegisteredResource(ctx context.Context, newResources
 
 // processNewResource checks the provided new resource agsinst currently
 // registered resources.
-func (r *Reconciler) processNewResource(ctx context.Context, new types.ResourceWithLabels) error {
+func (r *Reconciler) processNewResource(ctx context.Context, currentResources types.ResourcesWithLabels, new types.ResourceWithLabels) error {
 	// First see if the resource is already registered and if not, whether it
 	// matches the selector labels and should be registered.
-	registered := r.cfg.GetResources().Find(new.GetName())
+	registered := currentResources.Find(new.GetName())
 	if registered == nil {
-		if MatchResourceLabels(r.cfg.Selectors, new) {
+		if r.cfg.Matcher(new) {
 			r.log.Infof("%v matches, creating.", new)
 			if err := r.cfg.OnCreate(ctx, new); err != nil {
 				return trace.Wrap(err, "failed to create %v", new)
@@ -145,17 +155,17 @@ func (r *Reconciler) processNewResource(ctx context.Context, new types.ResourceW
 		return nil
 	}
 
-	// Do not overwrite static resources. Consider resources with empty
-	// origin as static for backwards compatibility.
-	if registered.Origin() == types.OriginConfigFile || registered.Origin() == "" {
-		r.log.Infof("%v is part of static configuration, not creating %v.", registered, new)
+	// Don't overwrite resource of a different origin.
+	if registered.Origin() != new.Origin() {
+		r.log.Debugf("%v has different origin (%v vs %v), not updating.", new,
+			new.Origin(), registered.Origin())
 		return nil
 	}
 
 	// If the resource is already registered but was updated, see if its
 	// labels still match.
-	if new.GetResourceID() != registered.GetResourceID() {
-		if MatchResourceLabels(r.cfg.Selectors, new) {
+	if CompareResources(new, registered) != Equal {
+		if r.cfg.Matcher(new) {
 			r.log.Infof("%v updated, updating.", new)
 			if err := r.cfg.OnUpdate(ctx, new); err != nil {
 				return trace.Wrap(err, "failed to update %v", new)

--- a/lib/services/reconciler_test.go
+++ b/lib/services/reconciler_test.go
@@ -29,7 +29,7 @@ import (
 func TestReconciler(t *testing.T) {
 	tests := []struct {
 		description         string
-		selectors           []Selector
+		selectors           []ResourceMatcher
 		registeredResources types.ResourcesWithLabels
 		newResources        types.ResourcesWithLabels
 		onCreateCalls       types.ResourcesWithLabels
@@ -38,8 +38,8 @@ func TestReconciler(t *testing.T) {
 	}{
 		{
 			description: "new matching resource should be registered",
-			selectors: []Selector{{
-				MatchLabels: types.Labels{"*": []string{"*"}},
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
 			}},
 			registeredResources: types.ResourcesWithLabels{},
 			newResources: types.ResourcesWithLabels{
@@ -51,8 +51,8 @@ func TestReconciler(t *testing.T) {
 		},
 		{
 			description: "new non-matching resource should not be registered",
-			selectors: []Selector{{
-				MatchLabels: types.Labels{"env": []string{"prod"}},
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"env": []string{"prod"}},
 			}},
 			registeredResources: types.ResourcesWithLabels{},
 			newResources: types.ResourcesWithLabels{
@@ -60,9 +60,21 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		{
+			description: "resources with different origins don't overwrite each other",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
+			}},
+			registeredResources: types.ResourcesWithLabels{
+				makeStaticResource("res1", nil),
+			},
+			newResources: types.ResourcesWithLabels{
+				makeDynamicResource("res1", nil),
+			},
+		},
+		{
 			description: "resource that's no longer present should be removed",
-			selectors: []Selector{{
-				MatchLabels: types.Labels{"*": []string{"*"}},
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
 			}},
 			registeredResources: types.ResourcesWithLabels{
 				makeDynamicResource("res1", nil),
@@ -73,42 +85,30 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		{
-			description: "static resource should not be overwritten",
-			selectors: []Selector{{
-				MatchLabels: types.Labels{"*": []string{"*"}},
-			}},
-			registeredResources: types.ResourcesWithLabels{
-				makeStaticResource("res1", nil),
-			},
-			newResources: types.ResourcesWithLabels{
-				makeDynamicResource("res1", nil),
-			},
-		},
-		{
 			description: "resource with updated matching labels should be updated",
-			selectors: []Selector{{
-				MatchLabels: types.Labels{"*": []string{"*"}},
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
 			}},
 			registeredResources: types.ResourcesWithLabels{
 				makeDynamicResource("res1", nil),
 			},
 			newResources: types.ResourcesWithLabels{
-				makeDynamicResourceWithID("res1", map[string]string{"env": "dev"}, 1),
+				makeDynamicResource("res1", map[string]string{"env": "dev"}),
 			},
 			onUpdateCalls: types.ResourcesWithLabels{
-				makeDynamicResourceWithID("res1", map[string]string{"env": "dev"}, 1),
+				makeDynamicResource("res1", map[string]string{"env": "dev"}),
 			},
 		},
 		{
 			description: "non-matching updated resource should be removed",
-			selectors: []Selector{{
-				MatchLabels: types.Labels{"env": []string{"prod"}},
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"env": []string{"prod"}},
 			}},
 			registeredResources: types.ResourcesWithLabels{
 				makeDynamicResource("res1", map[string]string{"env": "prod"}),
 			},
 			newResources: types.ResourcesWithLabels{
-				makeDynamicResourceWithID("res1", map[string]string{"env": "dev"}, 1),
+				makeDynamicResource("res1", map[string]string{"env": "dev"}),
 			},
 			onDeleteCalls: types.ResourcesWithLabels{
 				makeDynamicResource("res1", map[string]string{"env": "prod"}),
@@ -116,8 +116,8 @@ func TestReconciler(t *testing.T) {
 		},
 		{
 			description: "complex scenario with multiple created/updated/deleted resources",
-			selectors: []Selector{{
-				MatchLabels: types.Labels{"env": []string{"prod"}},
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"env": []string{"prod"}},
 			}},
 			registeredResources: types.ResourcesWithLabels{
 				makeStaticResource("res0", nil),
@@ -128,9 +128,9 @@ func TestReconciler(t *testing.T) {
 			},
 			newResources: types.ResourcesWithLabels{
 				makeDynamicResource("res0", map[string]string{"env": "prod"}),
-				makeDynamicResourceWithID("res2", map[string]string{"env": "prod", "a": "b"}, 1),
+				makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"}),
 				makeDynamicResource("res3", map[string]string{"env": "prod"}),
-				makeDynamicResourceWithID("res4", map[string]string{"env": "dev"}, 1),
+				makeDynamicResource("res4", map[string]string{"env": "dev"}),
 				makeDynamicResource("res5", map[string]string{"env": "prod"}),
 				makeDynamicResource("res6", map[string]string{"env": "dev"}),
 			},
@@ -138,7 +138,7 @@ func TestReconciler(t *testing.T) {
 				makeDynamicResource("res5", map[string]string{"env": "prod"}),
 			},
 			onUpdateCalls: types.ResourcesWithLabels{
-				makeDynamicResourceWithID("res2", map[string]string{"env": "prod", "a": "b"}, 1),
+				makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"}),
 			},
 			onDeleteCalls: types.ResourcesWithLabels{
 				makeDynamicResource("res1", map[string]string{"env": "prod"}),
@@ -153,9 +153,14 @@ func TestReconciler(t *testing.T) {
 			var onCreateCalls, onUpdateCalls, onDeleteCalls types.ResourcesWithLabels
 
 			reconciler, err := NewReconciler(ReconcilerConfig{
-				Selectors: test.selectors,
-				GetResources: func() types.ResourcesWithLabels {
+				Matcher: func(rwl types.ResourceWithLabels) bool {
+					return MatchResourceLabels(test.selectors, rwl)
+				},
+				GetCurrentResources: func() types.ResourcesWithLabels {
 					return test.registeredResources
+				},
+				GetNewResources: func() types.ResourcesWithLabels {
+					return test.newResources
 				},
 				OnCreate: func(ctx context.Context, r types.ResourceWithLabels) error {
 					onCreateCalls = append(onCreateCalls, r)
@@ -173,7 +178,7 @@ func TestReconciler(t *testing.T) {
 			require.NoError(t, err)
 
 			// Reconcile and make sure we got all expected callback calls.
-			err = reconciler.Reconcile(context.Background(), test.newResources)
+			err = reconciler.Reconcile(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, test.onCreateCalls, onCreateCalls)
 			require.Equal(t, test.onUpdateCalls, onUpdateCalls)
@@ -185,22 +190,16 @@ func TestReconciler(t *testing.T) {
 func makeStaticResource(name string, labels map[string]string) types.ResourceWithLabels {
 	return makeResource(name, labels, map[string]string{
 		types.OriginLabel: types.OriginConfigFile,
-	}, 0)
+	})
 }
 
 func makeDynamicResource(name string, labels map[string]string) types.ResourceWithLabels {
 	return makeResource(name, labels, map[string]string{
 		types.OriginLabel: types.OriginDynamic,
-	}, 0)
+	})
 }
 
-func makeDynamicResourceWithID(name string, labels map[string]string, id int64) types.ResourceWithLabels {
-	return makeResource(name, labels, map[string]string{
-		types.OriginLabel: types.OriginDynamic,
-	}, id)
-}
-
-func makeResource(name string, labels map[string]string, additionalLabels map[string]string, id int64) types.ResourceWithLabels {
+func makeResource(name string, labels map[string]string, additionalLabels map[string]string) types.ResourceWithLabels {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
@@ -208,31 +207,26 @@ func makeResource(name string, labels map[string]string, additionalLabels map[st
 		labels[k] = v
 	}
 	return &testResource{
-		name:   name,
-		labels: labels,
-		resID:  id,
+		Metadata: types.Metadata{
+			Name:   name,
+			Labels: labels,
+		},
 	}
 }
 
 type testResource struct {
 	types.ResourceWithLabels
-	name   string
-	labels map[string]string
-	resID  int64
+	Metadata types.Metadata
 }
 
 func (r *testResource) GetName() string {
-	return r.name
+	return r.Metadata.Name
 }
 
 func (r *testResource) Origin() string {
-	return r.labels[types.OriginLabel]
-}
-
-func (r testResource) GetResourceID() int64 {
-	return r.resID
+	return r.Metadata.Labels[types.OriginLabel]
 }
 
 func (r *testResource) GetAllLabels() map[string]string {
-	return r.labels
+	return r.Metadata.Labels
 }

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -90,8 +90,8 @@ type Config struct {
 	// Cloud provides cloud provider access related functionality.
 	Cloud Cloud
 
-	// Selectors is a list of resource monitor selectors.
-	Selectors []services.Selector
+	// ResourceMatchers is a list of app resource matchers.
+	ResourceMatchers []services.ResourceMatcher
 
 	// OnReconcile is called after each database resource reconciliation.
 	OnReconcile func(types.Apps)
@@ -160,7 +160,15 @@ type Server struct {
 	mu            sync.RWMutex
 	heartbeats    map[string]*srv.Heartbeat
 	dynamicLabels map[string]*labels.Dynamic
-	apps          map[string]types.Application
+
+	// apps are all apps this server currently proxies. Proxied apps are
+	// reconciled against monitoredApps below.
+	apps map[string]types.Application
+	// monitoredApps contains all cluster apps the proxied apps are
+	// reconciled against.
+	monitoredApps monitoredApps
+	// reconcileCh triggers reconciliation of proxied apps.
+	reconcileCh chan struct{}
 
 	proxyPort string
 
@@ -168,8 +176,32 @@ type Server struct {
 
 	// watcher monitors changes to application resources.
 	watcher *services.AppWatcher
-	// reconciler reconciles proxied apps with application resources.
-	reconciler *services.Reconciler
+}
+
+// monitoredApps is a collection of applications from different sources
+// like configuration file and dynamic resources.
+//
+// It's updated by respective watchers and is used for reconciling with the
+// currently proxied apps.
+type monitoredApps struct {
+	// static are apps from the agent's YAML configuration.
+	static types.Apps
+	// resources are apps created via CLI or API.
+	resources types.Apps
+	// mu protects access to the fields.
+	mu sync.Mutex
+}
+
+func (m *monitoredApps) setResources(apps types.Apps) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.resources = apps
+}
+
+func (m *monitoredApps) get() types.ResourcesWithLabels {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append(m.static, m.resources...).AsResources()
 }
 
 // New returns a new application server.
@@ -187,6 +219,10 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		heartbeats:    make(map[string]*srv.Heartbeat),
 		dynamicLabels: make(map[string]*labels.Dynamic),
 		apps:          make(map[string]types.Application),
+		monitoredApps: monitoredApps{
+			static: c.Apps,
+		},
+		reconcileCh: make(chan struct{}),
 	}
 
 	s.closeContext, s.closeFunc = context.WithCancel(ctx)
@@ -213,12 +249,6 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 
 	// Figure out the port the proxy is running on.
 	s.proxyPort = s.getProxyPort()
-
-	// Reconciler will be reconciling application resources with proxied apps.
-	s.reconciler, err = s.getReconciler()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
 	return s, nil
 }
@@ -433,7 +463,7 @@ func (s *Server) getApps() (apps types.Apps) {
 }
 
 // Start starts proxying all registered apps.
-func (s *Server) Start(ctx context.Context) error {
+func (s *Server) Start(ctx context.Context) (err error) {
 	// Register all apps from static configuration.
 	for _, app := range s.c.Apps {
 		if err := s.registerApp(ctx, app); err != nil {
@@ -441,18 +471,15 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}
 
-	// Register all matching apps from resources.
-	apps, err := s.c.AccessPoint.GetApps(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if err := s.reconciler.Reconcile(ctx, types.Apps(apps).AsResources()); err != nil {
+	// Start reconciler that will be reconciling proxied apps with
+	// application resources.
+	if err := s.startReconciler(ctx); err != nil {
 		return trace.Wrap(err)
 	}
 
 	// Initialize watcher that will be dynamically (un-)registering
 	// proxied apps based on the application resources.
-	if s.watcher, err = s.startWatcher(ctx); err != nil {
+	if s.watcher, err = s.startResourceWatcher(ctx); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -96,8 +96,8 @@ func (s *Suite) TearDown(t *testing.T) {
 }
 
 type suiteConfig struct {
-	// Selectors are resource watcher selectors.
-	Selectors []services.Selector
+	// ResourceMatchers are resource watcher matchers.
+	ResourceMatchers []services.ResourceMatcher
 	// OnReconcile sets app resource reconciliation callback.
 	OnReconcile func(types.Apps)
 	// Apps are the apps to configure.
@@ -242,21 +242,21 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	}
 
 	s.appServer, err = New(s.closeContext, &Config{
-		Clock:        s.clock,
-		DataDir:      s.dataDir,
-		AccessPoint:  s.authClient,
-		AuthClient:   s.authClient,
-		TLSConfig:    tlsConfig,
-		CipherSuites: utils.DefaultCipherSuites(),
-		HostID:       s.hostUUID,
-		Hostname:     "test",
-		Authorizer:   authorizer,
-		GetRotation:  testRotationGetter,
-		Apps:         apps,
-		OnHeartbeat:  func(err error) {},
-		Cloud:        &testCloud{},
-		Selectors:    config.Selectors,
-		OnReconcile:  config.OnReconcile,
+		Clock:            s.clock,
+		DataDir:          s.dataDir,
+		AccessPoint:      s.authClient,
+		AuthClient:       s.authClient,
+		TLSConfig:        tlsConfig,
+		CipherSuites:     utils.DefaultCipherSuites(),
+		HostID:           s.hostUUID,
+		Hostname:         "test",
+		Authorizer:       authorizer,
+		GetRotation:      testRotationGetter,
+		Apps:             apps,
+		OnHeartbeat:      func(err error) {},
+		Cloud:            &testCloud{},
+		ResourceMatchers: config.ResourceMatchers,
+		OnReconcile:      config.OnReconcile,
 	})
 	require.NoError(t, err)
 

--- a/lib/srv/app/watcher_test.go
+++ b/lib/srv/app/watcher_test.go
@@ -47,8 +47,8 @@ func TestWatcher(t *testing.T) {
 	// watches for apps with label group=a.
 	s := SetUpSuiteWithConfig(t, suiteConfig{
 		Apps: types.Apps{app0},
-		Selectors: []services.Selector{
-			{MatchLabels: types.Labels{
+		ResourceMatchers: []services.ResourceMatcher{
+			{Labels: types.Labels{
 				"group": []string{"a"},
 			}},
 		},

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -824,8 +824,8 @@ type agentParams struct {
 	Databases types.Databases
 	// HostID is an optional host id.
 	HostID string
-	// Selectors are optional database resource selectors.
-	Selectors []services.Selector
+	// ResourceMatchers are optional database resource matchers.
+	ResourceMatchers []services.ResourceMatcher
 	// GetServerInfoFn overrides heartbeat's server info function.
 	GetServerInfoFn func(database types.Database) func() (types.Resource, error)
 	// OnReconcile sets database resource reconciliation callback.
@@ -870,19 +870,19 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t *testing.T, p a
 
 	// Create database server agent itself.
 	server, err := New(ctx, Config{
-		Clock:           clockwork.NewFakeClockAt(time.Now()),
-		DataDir:         t.TempDir(),
-		AuthClient:      c.authClient,
-		AccessPoint:     c.authClient,
-		StreamEmitter:   c.authClient,
-		Authorizer:      dbAuthorizer,
-		Hostname:        constants.APIDomain,
-		HostID:          p.HostID,
-		TLSConfig:       tlsConfig,
-		Auth:            testAuth,
-		Databases:       p.Databases,
-		Selectors:       p.Selectors,
-		GetServerInfoFn: p.GetServerInfoFn,
+		Clock:            clockwork.NewFakeClockAt(time.Now()),
+		DataDir:          t.TempDir(),
+		AuthClient:       c.authClient,
+		AccessPoint:      c.authClient,
+		StreamEmitter:    c.authClient,
+		Authorizer:       dbAuthorizer,
+		Hostname:         constants.APIDomain,
+		HostID:           p.HostID,
+		TLSConfig:        tlsConfig,
+		Auth:             testAuth,
+		Databases:        p.Databases,
+		ResourceMatchers: p.ResourceMatchers,
+		GetServerInfoFn:  p.GetServerInfoFn,
 		GetRotation: func(types.SystemRole) (*types.Rotation, error) {
 			return &types.Rotation{}, nil
 		},

--- a/lib/srv/db/ca_test.go
+++ b/lib/srv/db/ca_test.go
@@ -120,7 +120,7 @@ func TestInitCACert(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			var database types.Database
-			for _, db := range databaseServer.getDatabases() {
+			for _, db := range databaseServer.getProxiedDatabases() {
 				if db.GetName() == test.database {
 					database = db
 				}

--- a/lib/srv/db/cloud/meta.go
+++ b/lib/srv/db/cloud/meta.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -149,20 +150,7 @@ func fetchRDSInstanceMetadata(ctx context.Context, rdsClient rdsiface.RDSAPI, in
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	parsedARN, err := arn.Parse(aws.StringValue(rdsInstance.DBInstanceArn))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &types.AWS{
-		Region:    parsedARN.Region,
-		AccountID: parsedARN.AccountID,
-		RDS: types.RDS{
-			InstanceID: aws.StringValue(rdsInstance.DBInstanceIdentifier),
-			ClusterID:  aws.StringValue(rdsInstance.DBClusterIdentifier),
-			ResourceID: aws.StringValue(rdsInstance.DbiResourceId),
-			IAMAuth:    aws.BoolValue(rdsInstance.IAMDatabaseAuthenticationEnabled),
-		},
-	}, nil
+	return services.MetadataFromRDSInstance(rdsInstance)
 }
 
 // describeRDSInstance returns AWS RDS instance for the specified ID.
@@ -185,19 +173,7 @@ func fetchRDSClusterMetadata(ctx context.Context, rdsClient rdsiface.RDSAPI, clu
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	parsedARN, err := arn.Parse(aws.StringValue(rdsCluster.DBClusterArn))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &types.AWS{
-		Region:    parsedARN.Region,
-		AccountID: parsedARN.AccountID,
-		RDS: types.RDS{
-			ClusterID:  aws.StringValue(rdsCluster.DBClusterIdentifier),
-			ResourceID: aws.StringValue(rdsCluster.DbClusterResourceId),
-			IAMAuth:    aws.BoolValue(rdsCluster.IAMDatabaseAuthenticationEnabled),
-		},
-	}, nil
+	return services.MetadataFromRDSCluster(rdsCluster)
 }
 
 // describeRDSCluster returns AWS Aurora cluster for the specified ID.

--- a/lib/srv/db/cloud/meta_test.go
+++ b/lib/srv/db/cloud/meta_test.go
@@ -34,7 +34,7 @@ import (
 func TestAWSMetadata(t *testing.T) {
 	// Configure RDS API mock.
 	rds := &RDSMock{
-		dbInstances: []*rds.DBInstance{
+		DBInstances: []*rds.DBInstance{
 			// Standalone RDS instance.
 			{
 				DBInstanceArn:                    aws.String("arn:aws:rds:us-west-1:1234567890:db:postgres-rds"),
@@ -49,7 +49,7 @@ func TestAWSMetadata(t *testing.T) {
 				DBClusterIdentifier:  aws.String("postgres-aurora"),
 			},
 		},
-		dbClusters: []*rds.DBCluster{
+		DBClusters: []*rds.DBCluster{
 			// Aurora cluster.
 			{
 				DBClusterArn:        aws.String("arn:aws:rds:us-east-1:1234567890:cluster:postgres-aurora"),
@@ -61,7 +61,7 @@ func TestAWSMetadata(t *testing.T) {
 
 	// Configure Redshift API mock.
 	redshift := &RedshiftMock{
-		clusters: []*redshift.Cluster{
+		Clusters: []*redshift.Cluster{
 			{
 				ClusterNamespaceArn: aws.String("arn:aws:redshift:us-west-1:1234567890:namespace:namespace-id"),
 				ClusterIdentifier:   aws.String("redshift-cluster-1"),

--- a/lib/srv/db/cloud/mocks.go
+++ b/lib/srv/db/cloud/mocks.go
@@ -33,29 +33,29 @@ import (
 // STSMock mocks AWS STS API.
 type STSMock struct {
 	stsiface.STSAPI
-	arn string
+	ARN string
 }
 
 func (m *STSMock) GetCallerIdentityWithContext(aws.Context, *sts.GetCallerIdentityInput, ...request.Option) (*sts.GetCallerIdentityOutput, error) {
 	return &sts.GetCallerIdentityOutput{
-		Arn: aws.String(m.arn),
+		Arn: aws.String(m.ARN),
 	}, nil
 }
 
 // RDSMock mocks AWS RDS API.
 type RDSMock struct {
 	rdsiface.RDSAPI
-	dbInstances []*rds.DBInstance
-	dbClusters  []*rds.DBCluster
+	DBInstances []*rds.DBInstance
+	DBClusters  []*rds.DBCluster
 }
 
 func (m *RDSMock) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, options ...request.Option) (*rds.DescribeDBInstancesOutput, error) {
 	if aws.StringValue(input.DBInstanceIdentifier) == "" {
 		return &rds.DescribeDBInstancesOutput{
-			DBInstances: m.dbInstances,
+			DBInstances: m.DBInstances,
 		}, nil
 	}
-	for _, instance := range m.dbInstances {
+	for _, instance := range m.DBInstances {
 		if aws.StringValue(instance.DBInstanceIdentifier) == aws.StringValue(input.DBInstanceIdentifier) {
 			return &rds.DescribeDBInstancesOutput{
 				DBInstances: []*rds.DBInstance{instance},
@@ -65,13 +65,20 @@ func (m *RDSMock) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.Des
 	return nil, trace.NotFound("instance %v not found", aws.StringValue(input.DBInstanceIdentifier))
 }
 
+func (m *RDSMock) DescribeDBInstancesPagesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, fn func(*rds.DescribeDBInstancesOutput, bool) bool, options ...request.Option) error {
+	fn(&rds.DescribeDBInstancesOutput{
+		DBInstances: m.DBInstances,
+	}, true)
+	return nil
+}
+
 func (m *RDSMock) DescribeDBClustersWithContext(ctx aws.Context, input *rds.DescribeDBClustersInput, options ...request.Option) (*rds.DescribeDBClustersOutput, error) {
 	if aws.StringValue(input.DBClusterIdentifier) == "" {
 		return &rds.DescribeDBClustersOutput{
-			DBClusters: m.dbClusters,
+			DBClusters: m.DBClusters,
 		}, nil
 	}
-	for _, cluster := range m.dbClusters {
+	for _, cluster := range m.DBClusters {
 		if aws.StringValue(cluster.DBClusterIdentifier) == aws.StringValue(input.DBClusterIdentifier) {
 			return &rds.DescribeDBClustersOutput{
 				DBClusters: []*rds.DBCluster{cluster},
@@ -81,14 +88,21 @@ func (m *RDSMock) DescribeDBClustersWithContext(ctx aws.Context, input *rds.Desc
 	return nil, trace.NotFound("cluster %v not found", aws.StringValue(input.DBClusterIdentifier))
 }
 
+func (m *RDSMock) DescribeDBClustersPagesWithContext(aws aws.Context, input *rds.DescribeDBClustersInput, fn func(*rds.DescribeDBClustersOutput, bool) bool, options ...request.Option) error {
+	fn(&rds.DescribeDBClustersOutput{
+		DBClusters: m.DBClusters,
+	}, true)
+	return nil
+}
+
 func (m *RDSMock) ModifyDBInstanceWithContext(ctx aws.Context, input *rds.ModifyDBInstanceInput, options ...request.Option) (*rds.ModifyDBInstanceOutput, error) {
-	for i, instance := range m.dbInstances {
+	for i, instance := range m.DBInstances {
 		if aws.StringValue(instance.DBInstanceIdentifier) == aws.StringValue(input.DBInstanceIdentifier) {
 			if aws.BoolValue(input.EnableIAMDatabaseAuthentication) {
-				m.dbInstances[i].IAMDatabaseAuthenticationEnabled = aws.Bool(true)
+				m.DBInstances[i].IAMDatabaseAuthenticationEnabled = aws.Bool(true)
 			}
 			return &rds.ModifyDBInstanceOutput{
-				DBInstance: m.dbInstances[i],
+				DBInstance: m.DBInstances[i],
 			}, nil
 		}
 	}
@@ -96,13 +110,13 @@ func (m *RDSMock) ModifyDBInstanceWithContext(ctx aws.Context, input *rds.Modify
 }
 
 func (m *RDSMock) ModifyDBClusterWithContext(ctx aws.Context, input *rds.ModifyDBClusterInput, options ...request.Option) (*rds.ModifyDBClusterOutput, error) {
-	for i, cluster := range m.dbClusters {
+	for i, cluster := range m.DBClusters {
 		if aws.StringValue(cluster.DBClusterIdentifier) == aws.StringValue(input.DBClusterIdentifier) {
 			if aws.BoolValue(input.EnableIAMDatabaseAuthentication) {
-				m.dbClusters[i].IAMDatabaseAuthenticationEnabled = aws.Bool(true)
+				m.DBClusters[i].IAMDatabaseAuthenticationEnabled = aws.Bool(true)
 			}
 			return &rds.ModifyDBClusterOutput{
-				DBCluster: m.dbClusters[i],
+				DBCluster: m.DBClusters[i],
 			}, nil
 		}
 	}
@@ -112,48 +126,76 @@ func (m *RDSMock) ModifyDBClusterWithContext(ctx aws.Context, input *rds.ModifyD
 // IAMMock mocks AWS IAM API.
 type IAMMock struct {
 	iamiface.IAMAPI
-	attachedRolePolicies map[string][]string
-	attachedUserPolicies map[string][]string
+	// attachedRolePolicies maps roleName -> policyName -> policyDocument
+	attachedRolePolicies map[string]map[string]string
+	// attachedUserPolicies maps userName -> policyName -> policyDocument
+	attachedUserPolicies map[string]map[string]string
+}
+
+func (m *IAMMock) GetRolePolicyWithContext(ctx aws.Context, input *iam.GetRolePolicyInput, options ...request.Option) (*iam.GetRolePolicyOutput, error) {
+	policy, ok := m.attachedRolePolicies[*input.RoleName]
+	if !ok {
+		return nil, trace.NotFound("policy not found")
+	}
+	policyDocument, ok := policy[*input.PolicyName]
+	if !ok {
+		return nil, trace.NotFound("policy not found")
+	}
+	return &iam.GetRolePolicyOutput{
+		PolicyDocument: &policyDocument,
+		PolicyName:     input.PolicyName,
+		RoleName:       input.RoleName,
+	}, nil
 }
 
 func (m *IAMMock) PutRolePolicyWithContext(ctx aws.Context, input *iam.PutRolePolicyInput, options ...request.Option) (*iam.PutRolePolicyOutput, error) {
 	if m.attachedRolePolicies == nil {
-		m.attachedRolePolicies = make(map[string][]string)
+		m.attachedRolePolicies = make(map[string]map[string]string)
 	}
-	m.attachedRolePolicies[aws.StringValue(input.RoleName)] = append(
-		m.attachedRolePolicies[aws.StringValue(input.RoleName)],
-		aws.StringValue(input.PolicyName))
+	if m.attachedRolePolicies[*input.RoleName] == nil {
+		m.attachedRolePolicies[*input.RoleName] = make(map[string]string)
+	}
+	m.attachedRolePolicies[*input.RoleName][*input.PolicyName] = *input.PolicyDocument
 	return &iam.PutRolePolicyOutput{}, nil
 }
 
-func (m *IAMMock) PutUserPolicyWithContext(ctx aws.Context, input *iam.PutUserPolicyInput, options ...request.Option) (*iam.PutUserPolicyOutput, error) {
-	if m.attachedUserPolicies == nil {
-		m.attachedUserPolicies = make(map[string][]string)
-	}
-	m.attachedUserPolicies[aws.StringValue(input.UserName)] = append(
-		m.attachedUserPolicies[aws.StringValue(input.UserName)],
-		aws.StringValue(input.PolicyName))
-	return &iam.PutUserPolicyOutput{}, nil
-}
-
 func (m *IAMMock) DeleteRolePolicyWithContext(ctx aws.Context, input *iam.DeleteRolePolicyInput, options ...request.Option) (*iam.DeleteRolePolicyOutput, error) {
-	for i, policy := range m.attachedRolePolicies[aws.StringValue(input.RoleName)] {
-		if policy == aws.StringValue(input.PolicyName) {
-			m.attachedRolePolicies[aws.StringValue(input.RoleName)] = append(
-				m.attachedRolePolicies[aws.StringValue(input.RoleName)][:i],
-				m.attachedRolePolicies[aws.StringValue(input.RoleName)][i+1:]...)
-		}
+	if _, ok := m.attachedRolePolicies[*input.RoleName]; ok {
+		delete(m.attachedRolePolicies[*input.RoleName], *input.PolicyName)
 	}
 	return &iam.DeleteRolePolicyOutput{}, nil
 }
 
+func (m *IAMMock) GetUserPolicyWithContext(ctx aws.Context, input *iam.GetUserPolicyInput, options ...request.Option) (*iam.GetUserPolicyOutput, error) {
+	policy, ok := m.attachedUserPolicies[*input.UserName]
+	if !ok {
+		return nil, trace.NotFound("policy not found")
+	}
+	policyDocument, ok := policy[*input.PolicyName]
+	if !ok {
+		return nil, trace.NotFound("policy not found")
+	}
+	return &iam.GetUserPolicyOutput{
+		PolicyDocument: &policyDocument,
+		PolicyName:     input.PolicyName,
+		UserName:       input.UserName,
+	}, nil
+}
+
+func (m *IAMMock) PutUserPolicyWithContext(ctx aws.Context, input *iam.PutUserPolicyInput, options ...request.Option) (*iam.PutUserPolicyOutput, error) {
+	if m.attachedUserPolicies == nil {
+		m.attachedUserPolicies = make(map[string]map[string]string)
+	}
+	if m.attachedUserPolicies[*input.UserName] == nil {
+		m.attachedUserPolicies[*input.UserName] = make(map[string]string)
+	}
+	m.attachedUserPolicies[*input.UserName][*input.PolicyName] = *input.PolicyDocument
+	return &iam.PutUserPolicyOutput{}, nil
+}
+
 func (m *IAMMock) DeleteUserPolicyWithContext(ctx aws.Context, input *iam.DeleteUserPolicyInput, options ...request.Option) (*iam.DeleteUserPolicyOutput, error) {
-	for i, policy := range m.attachedUserPolicies[aws.StringValue(input.UserName)] {
-		if policy == aws.StringValue(input.PolicyName) {
-			m.attachedUserPolicies[aws.StringValue(input.UserName)] = append(
-				m.attachedUserPolicies[aws.StringValue(input.UserName)][:i],
-				m.attachedUserPolicies[aws.StringValue(input.UserName)][i+1:]...)
-		}
+	if _, ok := m.attachedUserPolicies[*input.UserName]; ok {
+		delete(m.attachedUserPolicies[*input.UserName], *input.PolicyName)
 	}
 	return &iam.DeleteUserPolicyOutput{}, nil
 }
@@ -161,16 +203,16 @@ func (m *IAMMock) DeleteUserPolicyWithContext(ctx aws.Context, input *iam.Delete
 // RedshiftMock mocks AWS Redshift API.
 type RedshiftMock struct {
 	redshiftiface.RedshiftAPI
-	clusters []*redshift.Cluster
+	Clusters []*redshift.Cluster
 }
 
 func (m *RedshiftMock) DescribeClustersWithContext(ctx aws.Context, input *redshift.DescribeClustersInput, options ...request.Option) (*redshift.DescribeClustersOutput, error) {
 	if aws.StringValue(input.ClusterIdentifier) == "" {
 		return &redshift.DescribeClustersOutput{
-			Clusters: m.clusters,
+			Clusters: m.Clusters,
 		}, nil
 	}
-	for _, cluster := range m.clusters {
+	for _, cluster := range m.Clusters {
 		if aws.StringValue(cluster.ClusterIdentifier) == aws.StringValue(input.ClusterIdentifier) {
 			return &redshift.DescribeClustersOutput{
 				Clusters: []*redshift.Cluster{cluster},
@@ -215,18 +257,18 @@ type IAMMockUnauth struct {
 	iamiface.IAMAPI
 }
 
+func (m *IAMMockUnauth) GetRolePolicyWithContext(ctx aws.Context, input *iam.GetRolePolicyInput, options ...request.Option) (*iam.GetRolePolicyOutput, error) {
+	return nil, trace.AccessDenied("unauthorized")
+}
+
 func (m *IAMMockUnauth) PutRolePolicyWithContext(ctx aws.Context, input *iam.PutRolePolicyInput, options ...request.Option) (*iam.PutRolePolicyOutput, error) {
 	return nil, trace.AccessDenied("unauthorized")
 }
 
+func (m *IAMMockUnauth) GetUserPolicyWithContext(ctx aws.Context, input *iam.GetUserPolicyInput, options ...request.Option) (*iam.GetUserPolicyOutput, error) {
+	return nil, trace.AccessDenied("unauthorized")
+}
+
 func (m *IAMMockUnauth) PutUserPolicyWithContext(ctx aws.Context, input *iam.PutUserPolicyInput, options ...request.Option) (*iam.PutUserPolicyOutput, error) {
-	return nil, trace.AccessDenied("unauthorized")
-}
-
-func (m *IAMMockUnauth) DeleteRolePolicyWithContext(ctx aws.Context, input *iam.DeleteRolePolicyInput, options ...request.Option) (*iam.DeleteRolePolicyOutput, error) {
-	return nil, trace.AccessDenied("unauthorized")
-}
-
-func (m *IAMMockUnauth) DeleteUserPolicyWithContext(ctx aws.Context, input *iam.DeleteUserPolicyInput, options ...request.Option) (*iam.DeleteUserPolicyOutput, error) {
 	return nil, trace.AccessDenied("unauthorized")
 }

--- a/lib/srv/db/cloud/watchers/rds.go
+++ b/lib/srv/db/cloud/watchers/rds.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// rdsFetcherConfig is the RDS databases fetcher configuration.
+type rdsFetcherConfig struct {
+	// Labels is a selector to match cloud databases.
+	Labels types.Labels
+	// RDS is the RDS API client.
+	RDS rdsiface.RDSAPI
+	// Region is the AWS region to query databases in.
+	Region string
+}
+
+// CheckAndSetDefaults validates the config and sets defaults.
+func (c *rdsFetcherConfig) CheckAndSetDefaults() error {
+	if len(c.Labels) == 0 {
+		return trace.BadParameter("missing parameter Labels")
+	}
+	if c.RDS == nil {
+		return trace.BadParameter("missing parameter RDS")
+	}
+	if c.Region == "" {
+		return trace.BadParameter("missing parameter Region")
+	}
+	return nil
+}
+
+// rdsFetcher retrieves RDS databases.
+type rdsFetcher struct {
+	cfg rdsFetcherConfig
+	log logrus.FieldLogger
+}
+
+// newRDSFetcher returns a new RDS databases fetcher instance.
+func newRDSFetcher(config rdsFetcherConfig) (Fetcher, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &rdsFetcher{
+		cfg: config,
+		log: logrus.WithFields(logrus.Fields{
+			trace.Component: "rds-watcher",
+			"labels":        config.Labels,
+			"region":        config.Region,
+		}),
+	}, nil
+}
+
+// Get returns RDS and Aurora databases matching the watcher's selectors.
+func (f *rdsFetcher) Get(ctx context.Context) (types.Databases, error) {
+	rdsDatabases, err := f.getRDSDatabases(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	auroraDatabases, err := f.getAuroraDatabases(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var result types.Databases
+	for _, database := range append(rdsDatabases, auroraDatabases...) {
+		match, _, err := services.MatchLabels(f.cfg.Labels, database.GetAllLabels())
+		if err != nil {
+			f.log.Warnf("Failed to match %v against selector: %v.", database, err)
+		} else if match {
+			result = append(result, database)
+		} else {
+			f.log.Debugf("%v doesn't match selector.", database)
+		}
+	}
+	return result, nil
+}
+
+// getRDSDatabases returns a list of database resources representing RDS instances.
+func (f *rdsFetcher) getRDSDatabases(ctx context.Context) (types.Databases, error) {
+	instances, err := getAllDBInstances(ctx, f.cfg.RDS, maxPages)
+	if err != nil {
+		return nil, common.ConvertError(err)
+	}
+	databases := make(types.Databases, 0, len(instances))
+	for _, instance := range instances {
+		database, err := services.NewDatabaseFromRDSInstance(instance)
+		if err != nil {
+			f.log.Infof("Could not convert RDS instance %q to database resource: %v.",
+				aws.StringValue(instance.DBInstanceIdentifier), err)
+		} else {
+			databases = append(databases, database)
+		}
+	}
+	return databases, nil
+}
+
+// getAllDBInstances fetches all RDS instances using the provided client, up
+// to the specified max number of pages.
+func getAllDBInstances(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int) (instances []*rds.DBInstance, err error) {
+	var pageNum int
+	err = rdsClient.DescribeDBInstancesPagesWithContext(ctx, &rds.DescribeDBInstancesInput{
+		Filters: rdsFilters(),
+	}, func(ddo *rds.DescribeDBInstancesOutput, lastPage bool) bool {
+		pageNum++
+		instances = append(instances, ddo.DBInstances...)
+		return pageNum <= maxPages
+	})
+	return instances, common.ConvertError(err)
+}
+
+// getAuroraDatabases returns a list of database resources representing RDS clusters.
+func (f *rdsFetcher) getAuroraDatabases(ctx context.Context) (types.Databases, error) {
+	clusters, err := getAllDBClusters(ctx, f.cfg.RDS, maxPages)
+	if err != nil {
+		return nil, common.ConvertError(err)
+	}
+	databases := make(types.Databases, 0, len(clusters))
+	for _, cluster := range clusters {
+		database, err := services.NewDatabaseFromRDSCluster(cluster)
+		if err != nil {
+			f.log.Infof("Could not convert RDS cluster %q to database resource: %v.",
+				aws.StringValue(cluster.DBClusterIdentifier), err)
+		} else {
+			databases = append(databases, database)
+		}
+	}
+	return databases, nil
+}
+
+// getAllDBClusters fetches all RDS clusters using the provided client, up to
+// the specified max number of pages.
+func getAllDBClusters(ctx context.Context, rdsClient rdsiface.RDSAPI, maxPages int) (clusters []*rds.DBCluster, err error) {
+	var pageNum int
+	err = rdsClient.DescribeDBClustersPagesWithContext(ctx, &rds.DescribeDBClustersInput{
+		Filters: auroraFilters(),
+	}, func(ddo *rds.DescribeDBClustersOutput, lastPage bool) bool {
+		pageNum++
+		clusters = append(clusters, ddo.DBClusters...)
+		return pageNum <= maxPages
+	})
+	return clusters, common.ConvertError(err)
+}
+
+// String returns the fetcher's string description.
+func (f *rdsFetcher) String() string {
+	return fmt.Sprintf("rdsFetcher(Region=%v, Labels=%v)",
+		f.cfg.Region, f.cfg.Labels)
+}
+
+// rdsFilters returns filters to make sure DescribeDBInstances call returns
+// only databases with engines Teleport supports.
+func rdsFilters() []*rds.Filter {
+	return []*rds.Filter{{
+		Name: aws.String("engine"),
+		Values: aws.StringSlice([]string{
+			services.RDSEnginePostgres,
+			services.RDSEngineMySQL}),
+	}}
+}
+
+// auroraFilters returns filters to make sure DescribeDBClusters call returns
+// only databases with engines Teleport supports.
+func auroraFilters() []*rds.Filter {
+	return []*rds.Filter{{
+		Name: aws.String("engine"),
+		Values: aws.StringSlice([]string{
+			services.RDSEngineAurora,
+			services.RDSEngineAuroraMySQL,
+			services.RDSEngineAuroraPostgres}),
+	}}
+}
+
+// maxPages is the maximum number of pages to iterate over when fetching databases.
+const maxPages = 10

--- a/lib/srv/db/cloud/watchers/watcher.go
+++ b/lib/srv/db/cloud/watchers/watcher.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchers
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+)
+
+// WatcherConfig is the cloud watcher configuration.
+type WatcherConfig struct {
+	// AWSMatchers is a list of matchers for AWS databases.
+	AWSMatchers []services.AWSMatcher
+	// Clients provides cloud API clients.
+	Clients common.CloudClients
+	// Interval is the interval between fetches.
+	Interval time.Duration
+}
+
+// CheckAndSetDefaults validates the config.
+func (c *WatcherConfig) CheckAndSetDefaults() error {
+	if c.Clients == nil {
+		c.Clients = common.NewCloudClients()
+	}
+	if c.Interval == 0 {
+		c.Interval = 5 * time.Minute
+	}
+	return nil
+}
+
+// Watcher monitors cloud databases according to the provided selectors.
+type Watcher struct {
+	// cfg is the watcher config.
+	cfg WatcherConfig
+	// log is the watcher logger.
+	log logrus.FieldLogger
+	// ctx is the watcher close context.
+	ctx context.Context
+	// fetchers fetch databases according to their selectors.
+	fetchers []Fetcher
+	// databasesC is a channel where fetched databases are sent.
+	databasesC chan (types.Databases)
+}
+
+// Fetcher fetches cloud databases.
+type Fetcher interface {
+	// Get returns cloud databases matching the fetcher's selector.
+	Get(context.Context) (types.Databases, error)
+}
+
+// NewWatcher returns a new instance of a cloud databases watcher.
+func NewWatcher(ctx context.Context, config WatcherConfig) (*Watcher, error) {
+	if err := config.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	fetchers, err := makeFetchers(config.Clients, config.AWSMatchers)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if len(fetchers) == 0 {
+		return nil, trace.NotFound("no cloud selectors")
+	}
+	return &Watcher{
+		cfg:        config,
+		log:        logrus.WithField(trace.Component, "watcher:cloud"),
+		ctx:        ctx,
+		fetchers:   fetchers,
+		databasesC: make(chan types.Databases),
+	}, nil
+}
+
+// Start starts fetching cloud databases and sending them to the channel.
+//
+// TODO(r0mant): In future, instead of (or in addition to) polling, we can
+// use a combination of EventBridge (former CloudWatch Events) and SQS/SNS to
+// subscribe to events such as created/removed instances and tag changes, but
+// this will require Teleport to have more AWS permissions.
+func (w *Watcher) Start() {
+	ticker := time.NewTicker(w.cfg.Interval)
+	defer ticker.Stop()
+	w.log.Debugf("Starting cloud databases watcher.")
+	w.fetchAndSend()
+	for {
+		select {
+		case <-ticker.C:
+			w.fetchAndSend()
+		case <-w.ctx.Done():
+			w.log.Debugf("Cloud databases watcher done.")
+			return
+		}
+	}
+}
+
+// fetchAndSend fetches databases from all fetchers and sends them to the channel.
+func (w *Watcher) fetchAndSend() {
+	var result types.Databases
+	for _, fetcher := range w.fetchers {
+		databases, err := fetcher.Get(w.ctx)
+		if err != nil {
+			w.log.WithError(err).Errorf("%s failed.", fetcher)
+			return
+		}
+		result = append(result, databases...)
+	}
+	select {
+	case w.databasesC <- result:
+	case <-w.ctx.Done():
+	}
+}
+
+// DatabasesC returns a channel that receives fetched cloud databases.
+func (w *Watcher) DatabasesC() <-chan types.Databases {
+	return w.databasesC
+}
+
+// makeFetchers returns cloud fetchers for the provided matchers.
+func makeFetchers(clients common.CloudClients, matchers []services.AWSMatcher) (result []Fetcher, err error) {
+	for _, matcher := range matchers {
+		if utils.SliceContainsStr(matcher.Types, services.AWSMatcherRDS) {
+			for _, region := range matcher.Regions {
+				fetcher, err := makeRDSFetcher(clients, region, matcher.Tags)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+				result = append(result, fetcher)
+			}
+		}
+	}
+	return result, nil
+}
+
+// makeRDSFetcher returns RDS fetcher for the provided region and tags.
+func makeRDSFetcher(clients common.CloudClients, region string, tags types.Labels) (Fetcher, error) {
+	rds, err := clients.GetAWSRDSClient(region)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return newRDSFetcher(rdsFetcherConfig{
+		Region: region,
+		Labels: tags,
+		RDS:    rds,
+	})
+}

--- a/lib/srv/db/cloud/watchers/watcher_test.go
+++ b/lib/srv/db/cloud/watchers/watcher_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watchers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/cloud"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWatcher tests cloud databases watcher.
+func TestWatcher(t *testing.T) {
+	ctx := context.Background()
+
+	rdsInstance1, rdsDatabase1 := makeRDSInstance(t, "instance-1", "us-east-1", map[string]string{"env": "prod"})
+	rdsInstance2, _ := makeRDSInstance(t, "instance-2", "us-east-2", map[string]string{"env": "prod"})
+	rdsInstance3, _ := makeRDSInstance(t, "instance-3", "us-east-1", map[string]string{"env": "dev"})
+
+	auroraCluster1, auroraDatabase1 := makeRDSCluster(t, "cluster-1", "us-east-1", map[string]string{"env": "prod"})
+	auroraCluster2, auroraDatabase2 := makeRDSCluster(t, "cluster-2", "us-east-2", map[string]string{"env": "dev"})
+	auroraCluster3, _ := makeRDSCluster(t, "cluster-3", "us-east-2", map[string]string{"env": "prod"})
+
+	watcher, err := NewWatcher(ctx, WatcherConfig{
+		AWSMatchers: []services.AWSMatcher{
+			{
+				Types:   []string{services.AWSMatcherRDS},
+				Regions: []string{"us-east-1"},
+				Tags:    types.Labels{"env": []string{"prod"}},
+			},
+			{
+				Types:   []string{services.AWSMatcherRDS},
+				Regions: []string{"us-east-2"},
+				Tags:    types.Labels{"env": []string{"dev"}},
+			},
+		},
+		Clients: &common.TestCloudClients{
+			RDSPerRegion: map[string]rdsiface.RDSAPI{
+				"us-east-1": &cloud.RDSMock{
+					DBInstances: []*rds.DBInstance{rdsInstance1, rdsInstance3},
+					DBClusters:  []*rds.DBCluster{auroraCluster1},
+				},
+				"us-east-2": &cloud.RDSMock{
+					DBInstances: []*rds.DBInstance{rdsInstance2},
+					DBClusters:  []*rds.DBCluster{auroraCluster2, auroraCluster3},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	go watcher.fetchAndSend()
+	select {
+	case databases := <-watcher.DatabasesC():
+		require.Equal(t, types.Databases{
+			rdsDatabase1, auroraDatabase1, auroraDatabase2}, databases)
+	case <-time.After(time.Second):
+		t.Fatal("didn't receive databases after 1 second")
+	}
+}
+
+func makeRDSInstance(t *testing.T, name, region string, labels map[string]string) (*rds.DBInstance, types.Database) {
+	instance := &rds.DBInstance{
+		DBInstanceArn:        aws.String(fmt.Sprintf("arn:aws:rds:%v:1234567890:db:%v", region, name)),
+		DBInstanceIdentifier: aws.String(name),
+		DbiResourceId:        aws.String(uuid.New()),
+		Engine:               aws.String(services.RDSEnginePostgres),
+		Endpoint: &rds.Endpoint{
+			Address: aws.String("localhost"),
+			Port:    aws.Int64(5432),
+		},
+		TagList: labelsToTags(labels),
+	}
+	database, err := services.NewDatabaseFromRDSInstance(instance)
+	require.NoError(t, err)
+	return instance, database
+}
+
+func makeRDSCluster(t *testing.T, name, region string, labels map[string]string) (*rds.DBCluster, types.Database) {
+	cluster := &rds.DBCluster{
+		DBClusterArn:        aws.String(fmt.Sprintf("arn:aws:rds:%v:1234567890:cluster:%v", region, name)),
+		DBClusterIdentifier: aws.String(name),
+		DbClusterResourceId: aws.String(uuid.New()),
+		Engine:              aws.String(services.RDSEngineAuroraMySQL),
+		Endpoint:            aws.String("localhost"),
+		Port:                aws.Int64(3306),
+		TagList:             labelsToTags(labels),
+	}
+	database, err := services.NewDatabaseFromRDSCluster(cluster)
+	require.NoError(t, err)
+	return cluster, database
+}
+
+func labelsToTags(labels map[string]string) (tags []*rds.Tag) {
+	for key, val := range labels {
+		tags = append(tags, &rds.Tag{
+			Key:   aws.String(key),
+			Value: aws.String(val),
+		})
+	}
+	return tags
+}

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -127,7 +127,7 @@ func (a *dbAuth) GetRDSAuthToken(sessionCtx *Session) (string, error) {
   %v
 
 Make sure that Teleport database agent's IAM policy is attached and has "rds-connect"
-permissions:
+permissions (note that IAM changes may take a few minutes to propagate):
 
 %v
 `, err, sessionCtx.Database.GetIAMPolicy())
@@ -160,7 +160,8 @@ func (a *dbAuth) GetRedshiftAuthToken(sessionCtx *Session) (string, string, erro
   %v
 
 Make sure that Teleport database agent's IAM policy is attached and has permissions
-to generate Redshift credentials:
+to generate Redshift credentials (note that IAM changes may take a few minutes to
+propagate):
 
 %v
 `, err, sessionCtx.Database.GetIAMPolicy())

--- a/lib/srv/db/common/cloud.go
+++ b/lib/srv/db/common/cloud.go
@@ -210,10 +210,11 @@ func (c *cloudClients) initGCPSQLAdminClient(ctx context.Context) (*sqladmin.Ser
 
 // TestCloudClients are used in tests.
 type TestCloudClients struct {
-	RDS      rdsiface.RDSAPI
-	Redshift redshiftiface.RedshiftAPI
-	IAM      iamiface.IAMAPI
-	STS      stsiface.STSAPI
+	RDS          rdsiface.RDSAPI
+	RDSPerRegion map[string]rdsiface.RDSAPI
+	Redshift     redshiftiface.RedshiftAPI
+	IAM          iamiface.IAMAPI
+	STS          stsiface.STSAPI
 }
 
 // GetAWSSession returns AWS session for the specified region.
@@ -223,6 +224,9 @@ func (c *TestCloudClients) GetAWSSession(region string) (*awssession.Session, er
 
 // GetAWSRDSClient returns AWS RDS client for the specified region.
 func (c *TestCloudClients) GetAWSRDSClient(region string) (rdsiface.RDSAPI, error) {
+	if len(c.RDSPerRegion) != 0 {
+		return c.RDSPerRegion[region], nil
+	}
 	return c.RDS, nil
 }
 

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -33,6 +33,9 @@ import (
 
 // ConvertError converts errors to trace errors.
 func ConvertError(err error) error {
+	if err == nil {
+		return nil
+	}
 	// Unwrap original error first.
 	if _, ok := err.(*trace.TraceErr); ok {
 		return ConvertError(trace.Unwrap(err))

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -199,7 +199,8 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
   %v
 
 Make sure that IAM auth is enabled for MySQL user %q and Teleport database
-agent's IAM policy has "rds-connect" permissions:
+agent's IAM policy has "rds-connect" permissions (note that IAM changes may
+take a few minutes to propagate):
 
 %v
 `, common.ConvertError(err), sessionCtx.DatabaseUser, sessionCtx.Database.GetIAMPolicy())

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -218,7 +218,8 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*pgpr
   %v
 
 Make sure that Postgres user %q has "rds_iam" role and Teleport database
-agent's IAM policy has "rds-connect" permissions:
+agent's IAM policy has "rds-connect" permissions (note that IAM changes may
+take a few minutes to propagate):
 
 %v
 `, common.ConvertError(err), sessionCtx.DatabaseUser, sessionCtx.Database.GetIAMPolicy())

--- a/lib/srv/db/watcher.go
+++ b/lib/srv/db/watcher.go
@@ -22,18 +22,53 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/cloud/watchers"
 
 	"github.com/gravitational/trace"
 )
 
-// startWatcher starts watching changes to database resources and registers /
-// unregisters the proxied databases accordingly.
-func (s *Server) startWatcher(ctx context.Context) (*services.DatabaseWatcher, error) {
-	if len(s.cfg.Selectors) == 0 {
-		s.log.Debug("Not initializing database resource watcher.")
+// startReconciler starts reconciler that registers/unregisters proxied
+// databases according to the up-to-date list of database resources and
+// databases imported from the cloud.
+func (s *Server) startReconciler(ctx context.Context) error {
+	reconciler, err := services.NewReconciler(services.ReconcilerConfig{
+		Matcher:             s.matcher,
+		GetCurrentResources: s.getResources,
+		GetNewResources:     s.monitoredDatabases.get,
+		OnCreate:            s.onCreate,
+		OnUpdate:            s.onUpdate,
+		OnDelete:            s.onDelete,
+		Log:                 s.log,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	go func() {
+		for {
+			select {
+			case <-s.reconcileCh:
+				if err := reconciler.Reconcile(ctx); err != nil {
+					s.log.WithError(err).Error("Failed to reconcile.")
+				} else if s.cfg.OnReconcile != nil {
+					s.cfg.OnReconcile(s.getProxiedDatabases())
+				}
+			case <-ctx.Done():
+				s.log.Debug("Reconciler done.")
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// startResourceWatcher starts watching changes to database resources and
+// registers/unregisters the proxied databases accordingly.
+func (s *Server) startResourceWatcher(ctx context.Context) (*services.DatabaseWatcher, error) {
+	if len(s.cfg.ResourceMatchers) == 0 {
+		s.log.Debug("Not starting database resource watcher.")
 		return nil, nil
 	}
-	s.log.Debug("Initializing database resource watcher.")
+	s.log.Debug("Starting database resource watcher.")
 	watcher, err := services.NewDatabaseWatcher(ctx, services.DatabaseWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentDatabase,
@@ -45,17 +80,18 @@ func (s *Server) startWatcher(ctx context.Context) (*services.DatabaseWatcher, e
 		return nil, trace.Wrap(err)
 	}
 	go func() {
+		defer s.log.Debug("Database resource watcher done.")
 		defer watcher.Close()
 		for {
 			select {
 			case databases := <-watcher.DatabasesC:
-				if err := s.reconciler.Reconcile(ctx, databases.AsResources()); err != nil {
-					s.log.WithError(err).Errorf("Failed to reconcile %v.", databases)
-				} else if s.cfg.OnReconcile != nil {
-					s.cfg.OnReconcile(s.getDatabases())
+				s.monitoredDatabases.setResources(databases)
+				select {
+				case s.reconcileCh <- struct{}{}:
+				case <-ctx.Done():
+					return
 				}
 			case <-ctx.Done():
-				s.log.Debug("Database resource watcher done.")
 				return
 			}
 		}
@@ -63,21 +99,49 @@ func (s *Server) startWatcher(ctx context.Context) (*services.DatabaseWatcher, e
 	return watcher, nil
 }
 
-func (s *Server) getReconciler() (*services.Reconciler, error) {
-	return services.NewReconciler(services.ReconcilerConfig{
-		Selectors:    s.cfg.Selectors,
-		GetResources: s.getResources,
-		OnCreate:     s.onCreate,
-		OnUpdate:     s.onUpdate,
-		OnDelete:     s.onDelete,
-		Log:          s.log,
+// startCloudWatcher starts fetching cloud databases according to the
+// selectors and register/unregister them appropriately.
+func (s *Server) startCloudWatcher(ctx context.Context) error {
+	watcher, err := watchers.NewWatcher(ctx, watchers.WatcherConfig{
+		AWSMatchers: s.cfg.AWSMatchers,
+		Clients:     s.cfg.CloudClients,
 	})
+	if err != nil {
+		if trace.IsNotFound(err) {
+			s.log.Debugf("Not starting cloud database watcher: %v.", err)
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+	go watcher.Start()
+	go func() {
+		defer s.log.Debug("Cloud database watcher done.")
+		for {
+			select {
+			case databases := <-watcher.DatabasesC():
+				s.monitoredDatabases.setCloud(databases)
+				select {
+				case s.reconcileCh <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return nil
 }
 
+// getResources returns proxied databases as resources.
 func (s *Server) getResources() (resources types.ResourcesWithLabels) {
-	return s.getDatabases().AsResources()
+	for _, database := range s.getProxiedDatabases() {
+		resources = append(resources, database)
+	}
+	return resources
 }
 
+// onCreate is called by reconciler when a new database is created.
 func (s *Server) onCreate(ctx context.Context, resource types.ResourceWithLabels) error {
 	database, ok := resource.(types.Database)
 	if !ok {
@@ -86,6 +150,7 @@ func (s *Server) onCreate(ctx context.Context, resource types.ResourceWithLabels
 	return s.registerDatabase(ctx, database)
 }
 
+// onUpdate is called by reconciler when an already proxied database is updated.
 func (s *Server) onUpdate(ctx context.Context, resource types.ResourceWithLabels) error {
 	database, ok := resource.(types.Database)
 	if !ok {
@@ -94,10 +159,23 @@ func (s *Server) onUpdate(ctx context.Context, resource types.ResourceWithLabels
 	return s.updateDatabase(ctx, database)
 }
 
+// onDelete is called by reconciler when a proxied database is deleted.
 func (s *Server) onDelete(ctx context.Context, resource types.ResourceWithLabels) error {
 	database, ok := resource.(types.Database)
 	if !ok {
 		return trace.BadParameter("expected types.Database, got %T", resource)
 	}
 	return s.unregisterDatabase(ctx, database)
+}
+
+// matcher is used by reconciler to check if database matches selectors.
+func (s *Server) matcher(resource types.ResourceWithLabels) bool {
+	database, ok := resource.(types.Database)
+	if !ok {
+		return false
+	}
+	if database.IsRDS() || database.IsRedshift() {
+		return true // Cloud fetchers return only matching databases.
+	}
+	return services.MatchResourceLabels(s.cfg.ResourceMatchers, database)
 }

--- a/lib/srv/db/watcher_test.go
+++ b/lib/srv/db/watcher_test.go
@@ -49,8 +49,8 @@ func TestWatcher(t *testing.T) {
 	// watches for databases with label group=a.
 	testCtx.setupDatabaseServer(ctx, t, agentParams{
 		Databases: []types.Database{db0},
-		Selectors: []services.Selector{
-			{MatchLabels: types.Labels{
+		ResourceMatchers: []services.ResourceMatcher{
+			{Labels: types.Labels{
 				"group": []string{"a"},
 			}},
 		},


### PR DESCRIPTION
Subj. pretty much. With these changes, you can place the following configuration in your database agent config:

```yaml
db_service:
  aws:
  - types: ["rds"]
    regions: ["us-west-1"]
    tags:
      "*": "*"
```

The agent will then discover all RDS databases from the specified regions matching the tags, configure IAM for them and start proxying. The agent will also keep monitoring them for changes and update/unregister/register new ones appropriately.

Some other notable changes that were needed to make this work include:
- Make lib/services/reconciler I introduced for dynamic registration a bit more generic so it's easier to reuse.
- Update configuration syntax for resource matchers a bit as well so it's more user-friendly:

```yaml
db_service:
  resources:
  - labels:
      "*": "*"
```

Like mentioned above, auto-discovery is only for RDS right now. Redshift will be quite easy to add on top of this.