### PR TITLE
Update Prometheus Metrics Docs

### DIFF
--- a/docs/pages/setup/reference/metrics.mdx
+++ b/docs/pages/setup/reference/metrics.mdx
@@ -28,6 +28,14 @@ Now you can see the monitoring information by visiting several endpoints:
 
 | Name | Type | Component | Description |
 | - | - | - | - |
+| `audit_failed_disk_monitoring` | counter | Teleport Audit Log | Number of times disk monitoring failed. |
+| `audit_failed_emit_events` | counter | Teleport Audit Log | Number of times emitting audit event failed. |
+| `audit_percentage_disk_space_used` | gauge | Teleport Audit Log | Percentage disk space used. |
+| `audit_server_open_files` | gauge | Teleport Audit Log | Number of open audit files. |
+| `auth_generate_requests` | gauge | Teleport Auth | Number of current generate requests. |
+| `auth_generate_requests_throttled_total` | counter | Teleport Auth | Number of throttled requests to generate new server keys. |
+| `auth_generate_requests_total` | counter | Teleport Auth | Number of requests to generate new server keys. |
+| `auth_generate_seconds` | `histogram` | Teleport Auth | Latency for generate requests. |
 | `backend_batch_read_requests_total` | counter | cache | Number of read requests to the backend. |
 | `backend_batch_read_seconds` | histogram | cache | Latency for batch read operations. |
 | `backend_batch_write_requests_total` | counter | cache | Number of batch write requests to the backend. |
@@ -36,6 +44,8 @@ Now you can see the monitoring information by visiting several endpoints:
 | `backend_read_seconds` | histogram | cache | Latency for read operations. |
 | `backend_write_requests_total` | counter | cache | Number of write requests to the backend. |
 | `backend_write_seconds` | histogram | cache | Latency for backend write operations. |
+| `certificate_mismatch_total` | counter | Teleport Proxy | Number of times there was a certificate mismatch. |
+| `cluster_name_not_found_total` | counter | Teleport Auth | Number of times a cluster was not found. |
 | `etcd_backend_batch_read_requests` | counter | etcd | Number of read requests to the etcd database. |
 | `etcd_backend_batch_read_seconds` | histogram | etcd | Latency for etcd read operations. |
 | `etcd_backend_read_requests` | counter | etcd | Number of read requests to the etcd database. |
@@ -44,6 +54,8 @@ Now you can see the monitoring information by visiting several endpoints:
 | `etcd_backend_tx_seconds` | histogram | etcd | Latency for etcd transaction operations. |
 | `etcd_backend_write_requests` | counter | etcd | Number of write requests to the database. |
 | `etcd_backend_write_seconds` | histogram | etcd | Latency for etcd write operations. |
+| `failed_connect_to_node_attempts_total` | counter | Teleport Proxy | Number of times a user failed connecting to a node |
+| `failed_login_attempts_total` | counter | Teleport Proxy | Number of failed `tsh login` or `tsh ssh` logins. |
 | `firestore_events_backend_batch_read_requests` | counter | GCP Cloud Firestore | Number of batch read requests to Cloud Firestore events. |
 | `firestore_events_backend_batch_read_seconds` | histogram | GCP Cloud Firestore | Latency for Cloud Firestore events batch read operations. |
 | `firestore_events_backend_batch_write_requests` | counter | GCP Cloud Firestore | Number of batch write requests to Cloud Firestore events. |
@@ -80,6 +92,8 @@ Now you can see the monitoring information by visiting several endpoints:
 | `go_memstats_stack_sys_bytes` | gauge | Internal GoLang | Number of bytes obtained from system for stack allocator. |
 | `go_memstats_sys_bytes` | gauge | Internal GoLang | Number of bytes obtained from system. |
 | `go_threads` | gauge | Internal GoLang | Number of OS threads created. |
+| `heartbeat_connections_received_total` | counter | Teleport Auth | Number of times auth received a heartbeat connection. |
+| `heartbeat_connections_missed_total` | counter | Teleport Auth | Number of times auth did not receive a heartbeat from a node. |
 | `process_cpu_seconds_total` | counter | Internal GoLang | Total user and system CPU time spent in seconds. |
 | `process_max_fds` | gauge | Internal GoLang | Maximum number of open file descriptors. |
 | `process_open_fds` | gauge | Internal GoLang | Number of open file descriptors. |
@@ -89,25 +103,13 @@ Now you can see the monitoring information by visiting several endpoints:
 | `process_virtual_memory_max_bytes` | gauge | Internal GoLang | Maximum amount of virtual memory available in bytes. |
 | `promhttp_metric_handler_requests_in_flight` | gauge | prometheus | Current number of scrapes being served. |
 | `promhttp_metric_handler_requests_total` | counter | prometheus | Total number of scrapes by HTTP status code. |
+| `proxy_connection_limit_exceeded_total` | counter | Teleport Proxy | Number of connections that exceeded the proxy connection limit. |
 | `reversetunnel_connected_proxies` | gauge | Teleport | Number of known proxies being sought. |
 | `rx` | counter | Teleport | Number of bytes received. |
 | `server_interactive_sessions_total` | gauge | Teleport | Number of active sessions. |
 | `trusted_clusters` | gauge | Teleport | Number of tunnels per state. |
 | `tx` | counter | Teleport | Number of bytes transmitted. |
-| `audit_failed_disk_monitoring` | counter | Teleport Audit Log | Number of times disk monitoring failed. |
-| `audit_failed_emit_events` | counter | Teleport Audit Log | Number of times emitting audit event failed. |
-| `audit_percentage_disk_space_used` | gauge | Teleport Audit Log | Percentage disk space used. |
-| `audit_server_open_files` | gauge | Teleport Audit Log | Number of open audit files. |
-| `auth_generate_requests` | gauge | Teleport Auth | Number of current generate requests. |
-| `auth_generate_requests_throttled_total` | counter | Teleport Auth | Number of throttled requests to generate new server keys. |
-| `auth_generate_requests_total` | counter | Teleport Auth | Number of requests to generate new server keys. |
-| `auth_generate_seconds` | `histogram` | Teleport Auth | Latency for generate requests. |
-| `cluster_name_not_found_total` | counter | Teleport Auth | Number of times a cluster was not found. |
-| `heartbeat_connections_received_total` | counter | Teleport Auth | Number of times auth received a heartbeat connection. |
-| `heartbeat_connections_missed_total` | counter | Teleport Auth | Number of times auth did not receive a heartbeat from a node. |  
 | `user_login_total` | counter | Teleport Auth | Number of user logins. |
-| `failed_connect_to_node_attempts_total` | counter | Teleport Proxy | Number of times a user failed connecting to a node |
-| `proxy_connection_limit_exceeded_total` | counter | Teleport Proxy | Number of connections that exceeded the proxy connection limit. |
-| `certificate_mismatch_total` | counter | Teleport Proxy | Number of times there was a certificate mismatch. | 
-| `failed_login_attempts_total` | counter | Teleport Proxy | Number of failed `tsh login` or `tsh ssh` logins. | 
 | `user_max_concurrent_sessions_hit_total` | counter | Teleport Node | Number of times a user exceeded their concurrent session limit. |
+| `watcher_events` | histogram | cache | Per resource size of events emitted. |
+| `watcher_event_sizes` | histogram | cache | Overall size of events emitted. |


### PR DESCRIPTION
Add `watcher_events` and `watcher_event_sizes` to the metrics docs and sort metrics alphabetically.