### PR TITLE
Allow second_factor 'on' and 'optional' without U2F

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -271,6 +271,12 @@ func (c *AuthPreferenceV2) IsSecondFactorTOTPAllowed() bool {
 
 // IsSecondFactorU2FAllowed checks if users are allowed to register U2F devices.
 func (c *AuthPreferenceV2) IsSecondFactorU2FAllowed() bool {
+	// Is U2F configured?
+	if _, err := c.GetU2F(); err != nil {
+		return false
+	}
+
+	// Are second factor settings in accordance?
 	return c.Spec.SecondFactor == constants.SecondFactorU2F ||
 		c.Spec.SecondFactor == constants.SecondFactorOptional ||
 		c.Spec.SecondFactor == constants.SecondFactorOn
@@ -279,6 +285,12 @@ func (c *AuthPreferenceV2) IsSecondFactorU2FAllowed() bool {
 // IsSecondFactorWebauthnAllowed checks if users are allowed to register
 // Webauthn devices.
 func (c *AuthPreferenceV2) IsSecondFactorWebauthnAllowed() bool {
+	// Is Webauthn configured and enabled?
+	if webConfig, err := c.GetWebauthn(); err != nil || webConfig.Disabled {
+		return false
+	}
+
+	// Are second factor settings in accordance?
 	return c.Spec.SecondFactor == constants.SecondFactorWebauthn ||
 		c.Spec.SecondFactor == constants.SecondFactorOptional ||
 		c.Spec.SecondFactor == constants.SecondFactorOn
@@ -311,8 +323,7 @@ func (c *AuthPreferenceV2) SetU2F(u2f *U2F) {
 
 func (c *AuthPreferenceV2) GetWebauthn() (*Webauthn, error) {
 	if c.Spec.Webauthn == nil {
-		// TODO(codingllama): Update with configuration guide once we have it.
-		return nil, trace.NotFound("Webauthn is not configured in this cluster, please contact your administrator")
+		return nil, trace.NotFound("Webauthn is not configured in this cluster, please contact your administrator and ask them to follow https://goteleport.com/docs/access-controls/guides/webauthn/")
 	}
 	return c.Spec.Webauthn, nil
 }
@@ -412,35 +423,57 @@ func (c *AuthPreferenceV2) CheckAndSetDefaults() error {
 	case constants.SecondFactorOff, constants.SecondFactorOTP:
 	case constants.SecondFactorU2F:
 		if c.Spec.U2F == nil {
-			return trace.BadParameter("missing required U2F configuration for second factor type %q", c.Spec.SecondFactor)
+			return trace.BadParameter("missing required U2F configuration for second factor type %q", sf)
 		}
 		if err := c.Spec.U2F.Check(); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.SecondFactorWebauthn:
-		if c.Spec.Webauthn == nil {
-			c.Spec.Webauthn = &Webauthn{} // Try to get the defaults from U2F.
-		}
-		// Validate U2F, as we take some defaults from it.
+		// If U2F is present validate it, we can derive Webauthn from it.
 		if c.Spec.U2F != nil {
 			if err := c.Spec.U2F.Check(); err != nil {
 				return trace.Wrap(err)
 			}
+			if c.Spec.Webauthn == nil {
+				// Not a problem, try to derive from U2F.
+				c.Spec.Webauthn = &Webauthn{}
+			}
 		}
-		if err := c.Spec.Webauthn.CheckAndSetDefaults(sf, c.Spec.U2F); err != nil {
+		switch {
+		case c.Spec.Webauthn == nil:
+			return trace.BadParameter("missing required webauthn configuration for second factor type %q", sf)
+		case c.Spec.Webauthn.Disabled:
+			return trace.BadParameter("disabled webauthn configuration not allowed for second factor type %q", sf)
+		}
+		if err := c.Spec.Webauthn.CheckAndSetDefaults(c.Spec.U2F); err != nil {
 			return trace.Wrap(err)
 		}
 	case constants.SecondFactorOn, constants.SecondFactorOptional:
-		if c.Spec.U2F == nil {
-			return trace.BadParameter("missing required U2F configuration for second factor type %q", c.Spec.SecondFactor)
+		// The following scenarios are allowed for "on" and "optional":
+		// - Webauthn is configured (preferred)
+		// - U2F is configured, Webauthn derived from it (U2F-compat mode)
+		// - U2F is configured, Webauthn is disabled (fallback mode)
+
+		switch {
+		case c.Spec.Webauthn == nil && c.Spec.U2F == nil:
+			return trace.BadParameter("missing required webauthn configuration for second factor type %q", sf)
+		case c.Spec.Webauthn != nil && c.Spec.Webauthn.Disabled && c.Spec.U2F == nil:
+			return trace.BadParameter("missing u2f configuration with disabled webauthn not allowed for second factor %q", sf)
 		}
-		if err := c.Spec.U2F.Check(); err != nil {
-			return trace.Wrap(err)
+
+		// Is U2F configured?
+		if c.Spec.U2F != nil {
+			if err := c.Spec.U2F.Check(); err != nil {
+				return trace.Wrap(err)
+			}
+			if c.Spec.Webauthn == nil {
+				// Not a problem, try to derive from U2F.
+				c.Spec.Webauthn = &Webauthn{}
+			}
 		}
-		if c.Spec.Webauthn == nil {
-			c.Spec.Webauthn = &Webauthn{} // Try to get the defaults from U2F.
-		}
-		if err := c.Spec.Webauthn.CheckAndSetDefaults(sf, c.Spec.U2F); err != nil {
+
+		// Is Webauthn valid? At this point we should always have a config.
+		if err := c.Spec.Webauthn.CheckAndSetDefaults(c.Spec.U2F); err != nil {
 			return trace.Wrap(err)
 		}
 	default:
@@ -476,7 +509,7 @@ func (u *U2F) Check() error {
 	return nil
 }
 
-func (w *Webauthn) CheckAndSetDefaults(secondFactor constants.SecondFactorType, u *U2F) error {
+func (w *Webauthn) CheckAndSetDefaults(u *U2F) error {
 	// RPID.
 	switch {
 	case w.RPID != "": // Explicit RPID
@@ -525,11 +558,6 @@ func (w *Webauthn) CheckAndSetDefaults(secondFactor constants.SecondFactorType, 
 		if err := isValidAttestationCert(pem); err != nil {
 			return trace.BadParameter("webauthn denied CAs entry invalid: %v", err)
 		}
-	}
-
-	// Global disable flag.
-	if secondFactor == constants.SecondFactorWebauthn && w.Disabled {
-		return trace.BadParameter("webauthn cannot be disabled when second_factor = %v", constants.SecondFactorWebauthn)
 	}
 
 	return nil

--- a/api/types/authentication_authpreference_test.go
+++ b/api/types/authentication_authpreference_test.go
@@ -63,379 +63,447 @@ U9psmyPzK+Vsgw2jeRQ5JlKDyqE0hebfC1tvFu0CCrJFcw==
 -----END CERTIFICATE-----`
 )
 
-func TestAuthPreferenceV2_CheckAndSetDefaults(t *testing.T) {
+func TestAuthPreferenceV2_CheckAndSetDefaults_secondFactor(t *testing.T) {
 	t.Parallel()
 
-	validU2FPref := &types.AuthPreferenceV2{
-		Spec: types.AuthPreferenceSpecV2{
-			Type:         "local",
-			SecondFactor: "u2f",
-			U2F: &types.U2F{
-				AppID: "https://localhost:3080",
-				Facets: []string{
-					"https://localhost:3080",
-					"https://localhost",
-					"localhost:3080",
-					"localhost",
-				},
-			},
+	secondFactorAll := []constants.SecondFactorType{
+		constants.SecondFactorOff,
+		constants.SecondFactorOTP,
+		constants.SecondFactorU2F,
+		constants.SecondFactorWebauthn,
+		constants.SecondFactorOn,
+		constants.SecondFactorOptional,
+	}
+	secondFactorWebActive := []constants.SecondFactorType{
+		constants.SecondFactorWebauthn,
+		constants.SecondFactorOn,
+		constants.SecondFactorOptional,
+	}
+
+	minimalU2F := &types.U2F{
+		AppID: "https://localhost:3080",
+		Facets: []string{
+			"https://localhost:3080",
+			"https://localhost",
+			"localhost:3080",
+			"localhost",
 		},
+	}
+	minimalWeb := &types.Webauthn{
+		RPID: "localhost",
 	}
 
 	tests := []struct {
-		name  string
-		prefs *types.AuthPreferenceV2
+		name string
+
+		secondFactors []constants.SecondFactorType
+		spec          types.AuthPreferenceSpecV2
+
 		// wantErr is a substring of the returned error
 		wantErr string
-		// wantCmp is an optional asserting function
-		wantCmp func(got *types.AuthPreferenceV2) error
+		// assertFn is an optional asserting function
+		assertFn func(t *testing.T, got *types.AuthPreferenceV2)
 	}{
-		{name: "ok", prefs: &types.AuthPreferenceV2{}},
+		// General testing.
 		{
-			name:  "u2f_valid",
-			prefs: validU2FPref,
+			name: "OK empty config",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOff,
+				constants.SecondFactorOTP,
+			},
+		},
+		// U2F tests.
+		{
+			name:          "OK U2F minimal configuration",
+			secondFactors: secondFactorAll,
+			spec: types.AuthPreferenceSpecV2{
+				U2F: minimalU2F,
+			},
 		},
 		{
-			name: "u2f_invalid_missingU2F",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "u2f",
-				},
+			name: "NOK U2F missing U2F",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorU2F, // only mode where U2F is mandatory
 			},
 			wantErr: "missing required U2F configuration",
 		},
+		// Webauthn tests.
 		{
-			name: "webauthn_derivedFromU2F",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "webauthn",
-					U2F: &types.U2F{
-						AppID:                "https://example.com:1234",
-						Facets:               []string{"https://example.com:1234"},
-						DeviceAttestationCAs: []string{yubicoU2FCA},
-					},
-					Webauthn: nil,
-				},
+			name: "OK Webauthn minimal configuration",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOff,
+				constants.SecondFactorOTP,
+				// constants.SecondFactorU2F excluded.
+				constants.SecondFactorWebauthn,
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
 			},
-			wantCmp: func(got *types.AuthPreferenceV2) error {
-				want := &types.Webauthn{
-					RPID:                  "example.com",
-					AttestationAllowedCAs: []string{yubicoU2FCA},
-				}
-				if diff := cmp.Diff(want, got.Spec.Webauthn); diff != "" {
-					return fmt.Errorf("webauthn mismatch (-want +got):\n%s", diff)
-				}
-				return nil
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: minimalWeb,
 			},
 		},
 		{
-			name: "webauthn_derivedFromU2F_nonURL",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "webauthn",
-					U2F: &types.U2F{
-						AppID:  "teleport", // "teleport" gets parsed as a Path, not a Host.
-						Facets: []string{"teleport"},
-					},
-					Webauthn: nil,
+			name:          "OK Webauthn derived from U2F",
+			secondFactors: secondFactorWebActive,
+			spec: types.AuthPreferenceSpecV2{
+				U2F: &types.U2F{
+					AppID:                "https://example.com:1234",
+					Facets:               []string{"https://example.com:1234"},
+					DeviceAttestationCAs: []string{yubicoU2FCA},
 				},
 			},
-			wantCmp: func(got *types.AuthPreferenceV2) error {
-				want := &types.Webauthn{
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				// Did we derive the WebAuthn config from U2F?
+				if sf := got.GetSecondFactor(); sf == constants.SecondFactorWebauthn ||
+					sf == constants.SecondFactorOn ||
+					sf == constants.SecondFactorOptional {
+					wantWeb := &types.Webauthn{
+						RPID:                  "example.com",
+						AttestationAllowedCAs: []string{yubicoU2FCA},
+					}
+					gotWeb, err := got.GetWebauthn()
+					require.NoError(t, err, "webauthn config not found")
+					require.Empty(t, cmp.Diff(wantWeb, gotWeb))
+				}
+			},
+		},
+		{
+			name:          "OK Webauthn derived from non-URL",
+			secondFactors: secondFactorWebActive,
+			spec: types.AuthPreferenceSpecV2{
+				U2F: &types.U2F{
+					AppID:  "teleport", // "teleport" gets parsed as a Path, not a Host.
+					Facets: []string{"teleport"},
+				},
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				wantWeb := &types.Webauthn{
 					RPID: "teleport",
 				}
-				if diff := cmp.Diff(want, got.Spec.Webauthn); diff != "" {
-					return fmt.Errorf("webauthn mismatch (-want +got):\n%s", diff)
-				}
-				return nil
+				gotWeb, err := got.GetWebauthn()
+				require.NoError(t, err, "webauthn config not found")
+				require.Empty(t, cmp.Diff(wantWeb, gotWeb))
 			},
 		},
 		{
-			name: "webauthn_valid_minimal",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "webauthn",
-					Webauthn: &types.Webauthn{
-						RPID: "example.com",
-					},
+			name: "OK Webauthn disabled with fallback",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOff,
+				constants.SecondFactorOTP,
+				constants.SecondFactorU2F,
+				// constants.SecondFactorWebauthn excluded
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				U2F: minimalU2F,
+				Webauthn: &types.Webauthn{
+					Disabled: true,
+				},
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.False(t, got.IsSecondFactorWebauthnAllowed(), "webauthn second factor allowed")
+				require.NotEqual(t, constants.SecondFactorWebauthn, got.GetPreferredLocalMFA(), "webauthn set as preferred MFA")
+			},
+		},
+		{
+			name: "NOK Webauthn disabled in own mode",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorWebauthn,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: &types.Webauthn{
+					Disabled: true,
+				},
+			},
+			wantErr: "disabled webauthn configuration not allowed",
+		},
+		{
+			name: "NOK Webauthn disabled without fallback",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: &types.Webauthn{
+					Disabled: true,
+				},
+			},
+			wantErr: "missing u2f configuration",
+		},
+		{
+			name:          "OK Webauthn with attestation CAs",
+			secondFactors: secondFactorWebActive,
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: &types.Webauthn{
+					RPID:                  "example.com",
+					AttestationAllowedCAs: []string{appleWebauthnRoot},
+					AttestationDeniedCAs:  []string{yubicoU2FCA},
 				},
 			},
 		},
 		{
-			name: "webauthn_valid_attestationCAs",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "webauthn",
-					Webauthn: &types.Webauthn{
-						RPID:                  "example.com",
-						AttestationAllowedCAs: []string{appleWebauthnRoot},
-						AttestationDeniedCAs:  []string{yubicoU2FCA},
-					},
-				},
-			},
+			name:          "NOK Webauthn empty",
+			secondFactors: secondFactorWebActive,
+			wantErr:       "missing required webauthn configuration",
 		},
 		{
-			name: "webauthn_invalid_empty",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "webauthn",
-				},
+			name:          "NOK Webauthn missing RPID",
+			secondFactors: secondFactorWebActive,
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: &types.Webauthn{},
 			},
 			wantErr: "missing rp_id",
 		},
 		{
-			name: "webauthn_invalid_invalidU2F",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "webauthn",
-					U2F:          &types.U2F{},
-				},
-			},
-			wantErr: "missing app_id",
-		},
-		{
-			name: "webauthn_invalid_attestationAllowedCA",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "webauthn",
-					Webauthn: &types.Webauthn{
-						RPID:                  "example.com",
-						AttestationAllowedCAs: []string{"bad inline cert"},
-					},
+			name:          "NOK Webauthn invalid allowed CA",
+			secondFactors: secondFactorWebActive,
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: &types.Webauthn{
+					RPID:                  "example.com",
+					AttestationAllowedCAs: []string{"bad inline cert"},
 				},
 			},
 			wantErr: "webauthn allowed CAs",
 		},
 		{
-			name: "webauthn_invalid_attestationDeniedCA",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "webauthn",
-					Webauthn: &types.Webauthn{
-						RPID:                 "example.com",
-						AttestationDeniedCAs: []string{"bad inline cert"},
-					},
+			name:          "NOK Webauthn invalid denied CA",
+			secondFactors: secondFactorWebActive,
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: &types.Webauthn{
+					RPID:                 "example.com",
+					AttestationDeniedCAs: []string{"bad inline cert"},
 				},
 			},
 			wantErr: "webauthn denied CAs",
 		},
+		// IsSecondFactorEnforced?
 		{
-			name: "webauthn_invalid_disabled",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "webauthn",
-					Webauthn: &types.Webauthn{
-						RPID:     "example.com",
-						Disabled: true, // Cannot disable when second_factor=webauthn
-					},
-				},
+			name: "OK second factor enforced",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOTP,
+				constants.SecondFactorU2F,
+				constants.SecondFactorWebauthn,
+				constants.SecondFactorOn,
 			},
-			wantErr: "webauthn cannot be disabled",
-		},
-		{
-			name: "webauthn_valid_disabledSecondFactorOn",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "on",
-					U2F:          validU2FPref.Spec.U2F,
-					Webauthn: &types.Webauthn{
-						RPID:     "example.com",
-						Disabled: true, // OK, fallback to U2F
-					},
-				},
+			spec: types.AuthPreferenceSpecV2{
+				U2F:      minimalU2F,
+				Webauthn: minimalWeb,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.True(t, got.IsSecondFactorEnforced(), "second factor not enforced")
 			},
 		},
 		{
-			name: "webauthn_valid_disabledSecondFactorOptional",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "optional",
-					U2F:          validU2FPref.Spec.U2F,
-					Webauthn: &types.Webauthn{
-						RPID:     "example.com",
-						Disabled: true, // OK, fallback to U2F
-					},
-				},
+			name: "OK second factor not enforced",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOff,
+				constants.SecondFactorOptional,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: minimalWeb,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.False(t, got.IsSecondFactorEnforced(), "second factor enforced")
+			},
+		},
+		// IsSecondFactor*Allowed?
+		{
+			name: "OK OTP second factor allowed",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOTP,
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: minimalWeb,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.True(t, got.IsSecondFactorTOTPAllowed(), "OTP not allowed")
 			},
 		},
 		{
-			name: "on_valid",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "on",
-					U2F:          validU2FPref.Spec.U2F,
-				},
+			name: "OK OTP second factor not allowed",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOff,
+				constants.SecondFactorU2F,
+				constants.SecondFactorWebauthn,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				U2F:      minimalU2F,
+				Webauthn: minimalWeb,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.False(t, got.IsSecondFactorTOTPAllowed(), "OTP allowed")
 			},
 		},
 		{
-			name: "on_invalid_requiresU2F",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "on",
-					U2F:          nil,
-				},
+			name: "OK U2F second factor allowed",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorU2F,
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
 			},
-			wantErr: "missing required U2F configuration",
-		},
-		{
-			name: "optional_valid",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "optional",
-					U2F:          validU2FPref.Spec.U2F,
-				},
+			spec: types.AuthPreferenceSpecV2{
+				U2F: minimalU2F,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.True(t, got.IsSecondFactorU2FAllowed(), "U2F not allowed")
 			},
 		},
 		{
-			name: "optional_invalid_requiresU2f",
-			prefs: &types.AuthPreferenceV2{
-				Spec: types.AuthPreferenceSpecV2{
-					Type:         "local",
-					SecondFactor: "optional",
-					U2F:          nil,
+			name: "OK U2F second factor not allowed",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOff,
+				constants.SecondFactorOTP,
+				constants.SecondFactorWebauthn,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				U2F:      minimalU2F,
+				Webauthn: minimalWeb,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.False(t, got.IsSecondFactorU2FAllowed(), "U2F allowed")
+			},
+		},
+		{
+			name: "OK U2F second factor not allowed when not configured",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: minimalWeb,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.False(t, got.IsSecondFactorU2FAllowed(), "U2F allowed")
+			},
+		},
+
+		{
+			name: "OK Webauthn second factor allowed",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorWebauthn,
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				Webauthn: minimalWeb,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.True(t, got.IsSecondFactorWebauthnAllowed(), "Webauthn not allowed")
+			},
+		},
+		{
+			name: "OK Webauthn second factor not allowed",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOff,
+				constants.SecondFactorOTP,
+				constants.SecondFactorU2F,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				U2F:      minimalU2F,
+				Webauthn: minimalWeb,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.False(t, got.IsSecondFactorWebauthnAllowed(), "Webauthn allowed")
+			},
+		},
+		{
+			name: "OK Webauthn second factor not allowed when disabled",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				U2F: minimalU2F,
+				Webauthn: &types.Webauthn{
+					Disabled: true,
 				},
 			},
-			wantErr: "missing required U2F configuration",
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.False(t, got.IsSecondFactorWebauthnAllowed(), "Webauthn allowed")
+			},
+		},
+		// GetPreferredLocalMFA
+		{
+			name: "OK preferred local MFA empty",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOff,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.Empty(t, got.GetPreferredLocalMFA(), "preferred local MFA not empty")
+			},
+		},
+		{
+			name: "OK preferred local MFA = OTP",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorOTP,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.Equal(t, constants.SecondFactorOTP, got.GetPreferredLocalMFA())
+			},
+		},
+		{
+			name: "OK preferred local MFA = U2F",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorU2F,
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				U2F: minimalU2F,
+				Webauthn: &types.Webauthn{
+					Disabled: true,
+				},
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.Equal(t, constants.SecondFactorU2F, got.GetPreferredLocalMFA())
+			},
+		},
+		{
+			name: "OK preferred local MFA = Webauthn",
+			secondFactors: []constants.SecondFactorType{
+				constants.SecondFactorWebauthn,
+				constants.SecondFactorOn,
+				constants.SecondFactorOptional,
+			},
+			spec: types.AuthPreferenceSpecV2{
+				U2F:      minimalU2F,
+				Webauthn: minimalWeb,
+			},
+			assertFn: func(t *testing.T, got *types.AuthPreferenceV2) {
+				require.Equal(t, constants.SecondFactorWebauthn, got.GetPreferredLocalMFA())
+			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.prefs.CheckAndSetDefaults()
-			switch {
-			case err == nil && test.wantErr == "": // OK
-			case err == nil && test.wantErr != "":
-				t.Fatalf("CheckAndSetDefaults = nil, want %q", test.wantErr)
-			case !strings.Contains(err.Error(), test.wantErr) || test.wantErr == "":
-				t.Fatalf("CheckAndSetDefaults = %q, want %q", err, test.wantErr)
+			// Sanity check setup.
+			require.NotEmpty(t, test.secondFactors, "test must provide second factor values")
+
+			cap := &types.AuthPreferenceV2{
+				Spec: test.spec,
 			}
 
-			if test.wantCmp == nil {
-				return
-			}
-			if err := test.wantCmp(test.prefs); err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-}
+			for _, sf := range test.secondFactors {
+				t.Run(fmt.Sprintf("sf=%v", sf), func(t *testing.T) {
+					cap.Spec.SecondFactor = sf
 
-func TestAuthPreferenceV2_GetPreferredLocalMFA(t *testing.T) {
-	u2fConfig := &types.U2F{
-		AppID: "https://example.com",
-		Facets: []string{
-			"https://example.com:443",
-			"https://example.com",
-			"example.com:443",
-			"example.com",
-		},
-	}
-	webConfig := &types.Webauthn{
-		RPID: "example.com",
-	}
-	disabledWebConfig := &types.Webauthn{
-		RPID:     "example.com",
-		Disabled: true,
-	}
+					switch err := cap.CheckAndSetDefaults(); {
+					case err == nil && test.wantErr == "": // OK
+					case err == nil && test.wantErr != "":
+						t.Fatalf("CheckAndSetDefaults = nil, want %q", test.wantErr)
+					case !strings.Contains(err.Error(), test.wantErr) || test.wantErr == "":
+						t.Fatalf("CheckAndSetDefaults = %q, want %q", err, test.wantErr)
+					}
 
-	tests := []struct {
-		name string
-		spec types.AuthPreferenceSpecV2
-		want constants.SecondFactorType
-	}{
-		{
-			name: "sf=off",
-			spec: types.AuthPreferenceSpecV2{
-				Type:         constants.Local,
-				SecondFactor: constants.SecondFactorOff,
-			},
-		},
-		{
-			name: "sf=otp",
-			spec: types.AuthPreferenceSpecV2{
-				Type:         constants.Local,
-				SecondFactor: constants.SecondFactorOTP,
-			},
-			want: constants.SecondFactorOTP,
-		},
-		{
-			name: "sf=u2f",
-			spec: types.AuthPreferenceSpecV2{
-				Type:         constants.Local,
-				SecondFactor: constants.SecondFactorU2F,
-				U2F:          u2fConfig,
-			},
-			want: constants.SecondFactorU2F,
-		},
-		{
-			name: "sf=webauthn",
-			spec: types.AuthPreferenceSpecV2{
-				Type:         constants.Local,
-				SecondFactor: constants.SecondFactorWebauthn,
-				Webauthn:     webConfig,
-			},
-			want: constants.SecondFactorWebauthn,
-		},
-		{
-			name: "sf=on favors WebAuthn",
-			spec: types.AuthPreferenceSpecV2{
-				Type:         constants.Local,
-				SecondFactor: constants.SecondFactorOn,
-				U2F:          u2fConfig,
-				Webauthn:     webConfig,
-			},
-			want: constants.SecondFactorWebauthn,
-		},
-		{
-			name: "sf=on disabled WebAuthn favors U2F",
-			spec: types.AuthPreferenceSpecV2{
-				Type:         constants.Local,
-				SecondFactor: constants.SecondFactorOn,
-				U2F:          u2fConfig,
-				Webauthn:     disabledWebConfig,
-			},
-			want: constants.SecondFactorU2F,
-		},
-		{
-			name: "sf=optional favors WebAuthn",
-			spec: types.AuthPreferenceSpecV2{
-				Type:         constants.Local,
-				SecondFactor: constants.SecondFactorOptional,
-				U2F:          u2fConfig,
-				Webauthn:     webConfig,
-			},
-			want: constants.SecondFactorWebauthn,
-		},
-		{
-			name: "sf=optional disabled WebAuthn favors U2F",
-			spec: types.AuthPreferenceSpecV2{
-				Type:         constants.Local,
-				SecondFactor: constants.SecondFactorOptional,
-				U2F:          u2fConfig,
-				Webauthn:     disabledWebConfig,
-			},
-			want: constants.SecondFactorU2F,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			cap, err := types.NewAuthPreference(test.spec)
-			require.NoError(t, err, "invalid auth preference spec")
-			require.Equal(t, string(test.want), string(cap.GetPreferredLocalMFA()), "unexpected preferred local MFA")
+					if test.assertFn == nil {
+						return
+					}
+					test.assertFn(t, cap)
+				})
+			}
 		})
 	}
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3172,44 +3172,19 @@ func (a *Server) mfaAuthChallenge(ctx context.Context, user string, u2fStorage u
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var enableTOTP, enableU2F, enableWebauthn bool
-	switch apref.GetSecondFactor() {
-	case constants.SecondFactorOTP:
-		enableTOTP = true
-	case constants.SecondFactorU2F:
-		enableU2F = true
-	case constants.SecondFactorWebauthn:
-		enableWebauthn = true
-	case constants.SecondFactorOn, constants.SecondFactorOptional:
-		enableTOTP, enableU2F, enableWebauthn = true, true, true
-	case constants.SecondFactorOff: // All disabled.
-	default:
-		return nil, trace.BadParameter("unexpected second_factor value: %s", apref.GetSecondFactor())
-	}
+	enableTOTP := apref.IsSecondFactorTOTPAllowed()
+	enableU2F := apref.IsSecondFactorU2FAllowed()
+	enableWebauthn := apref.IsSecondFactorWebauthnAllowed()
 
-	// Read U2F configuration regardless, Webauthn uses it.
-	u2fPref, err := apref.GetU2F()
-	if err != nil && enableU2F {
-		if !trace.IsNotFound(err) {
-			return nil, trace.Wrap(err)
-		}
-		// If U2F parameters were not set in the auth server config, disable U2F
-		// challenges.
-		enableU2F = false
+	// Fetch configurations. The IsSecondFactor*Allowed calls above already
+	// include the necessary checks of config empty, disabled, etc.
+	var u2fPref *types.U2F
+	if val, err := apref.GetU2F(); err == nil {
+		u2fPref = val
 	}
-
-	webConfig, err := apref.GetWebauthn()
-	switch {
-	case err == nil:
-		enableWebauthn = enableWebauthn && !webConfig.Disabled // Apply global disable
-	case err != nil && enableWebauthn:
-		if apref.GetSecondFactor() == constants.SecondFactorWebauthn {
-			// Fail explicitly for second_factor:"webauthn".
-			return nil, trace.BadParameter("second_factor set to %s, but webauthn config not present", constants.SecondFactorWebauthn)
-		}
-		// Fail silently for other modes.
-		log.WithError(err).Warningf("WebAuthn: failed to fetch configuration, disabling WebAuthn challenges")
-		enableWebauthn = false
+	var webConfig *types.Webauthn
+	if val, err := apref.GetWebauthn(); err == nil {
+		webConfig = val
 	}
 
 	devs, err := a.Identity.GetMFADevices(ctx, user, true)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3179,11 +3179,19 @@ func (a *Server) mfaAuthChallenge(ctx context.Context, user string, u2fStorage u
 	// Fetch configurations. The IsSecondFactor*Allowed calls above already
 	// include the necessary checks of config empty, disabled, etc.
 	var u2fPref *types.U2F
-	if val, err := apref.GetU2F(); err == nil {
+	switch val, err := apref.GetU2F(); {
+	case trace.IsNotFound(err): // OK, may happen.
+	case err != nil: // NOK, unexpected.
+		return nil, trace.Wrap(err)
+	default:
 		u2fPref = val
 	}
 	var webConfig *types.Webauthn
-	if val, err := apref.GetWebauthn(); err == nil {
+	switch val, err := apref.GetWebauthn(); {
+	case trace.IsNotFound(err): // OK, may happen.
+	case err != nil: // NOK, unexpected.
+		return nil, trace.Wrap(err)
+	default:
 		webConfig = val
 	}
 

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -139,22 +139,6 @@ func TestServer_CreateAuthenticateChallenge_authPreference(t *testing.T) {
 			},
 		},
 		{
-			name: "OK second_factor:webauthn (derived from U2F)",
-			spec: &types.AuthPreferenceSpecV2{
-				Type:         constants.Local,
-				SecondFactor: constants.SecondFactorWebauthn,
-				U2F: &types.U2F{
-					AppID:  "https://localhost",
-					Facets: []string{"https://localhost"},
-				},
-			},
-			assertChallenge: func(challenge *proto.MFAAuthenticateChallenge) {
-				require.Empty(t, challenge.GetTOTP())
-				require.Empty(t, challenge.GetU2F())
-				require.NotEmpty(t, challenge.GetWebauthnChallenge())
-			},
-		},
-		{
 			name: "OK second_factor:optional",
 			spec: &types.AuthPreferenceSpecV2{
 				Type:         constants.Local,

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -385,25 +385,20 @@ func (s *Server) changeUserSecondFactor(ctx context.Context, req *proto.ChangeUs
 		return trace.Wrap(err)
 	}
 
-	secondFactor := cap.GetSecondFactor()
-	if secondFactor == constants.SecondFactorOff {
+	switch sf := cap.GetSecondFactor(); {
+	case sf == constants.SecondFactorOff:
 		return nil
-	}
-
-	if req.GetNewMFARegisterResponse() == nil {
-		switch secondFactor {
-		case constants.SecondFactorOptional:
-			// Optional second factor does not enforce users to add a MFA device.
-			// No need to check if a user already has registered devices since we expect
-			// users to have no devices at this point.
-			//
-			// The ChangeUserAuthenticationRequest is made
-			// with a reset or invite token where a reset token would've reset the users MFA devices,
-			// and an invite token is a new user with no devices.
-			return nil
-		default:
-			return trace.BadParameter("no second factor sent during user %q password reset", username)
-		}
+	case req.GetNewMFARegisterResponse() == nil && sf == constants.SecondFactorOptional:
+		// Optional second factor does not enforce users to add a MFA device.
+		// No need to check if a user already has registered devices since we expect
+		// users to have no devices at this point.
+		//
+		// The ChangeUserAuthenticationRequest is made with a reset or invite token
+		// where a reset token would've reset the users' MFA devices, and an invite
+		// token is a new user with no devices.
+		return nil
+	case req.GetNewMFARegisterResponse() == nil:
+		return trace.BadParameter("no second factor sent during user %q password reset", username)
 	}
 
 	// Default device name still used as UI invite/reset

--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -492,8 +492,7 @@ func (s *Server) CreatePrivilegeToken(ctx context.Context, req *proto.CreatePriv
 	// For a user to add a device, second factor must be enabled.
 	// A nil request will be interpreted as a user who has second factor enabled
 	// but does not have any MFA registered, as can be the case with second factor optional.
-	secondFactor := authPref.GetSecondFactor()
-	if secondFactor == constants.SecondFactorOff {
+	if authPref.GetSecondFactor() == constants.SecondFactorOff {
 		return nil, trace.AccessDenied("second factor must be enabled")
 	}
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -661,7 +661,7 @@ type AuthenticationConfig struct {
 func (a *AuthenticationConfig) Parse() (types.AuthPreference, error) {
 	var err error
 
-	var u types.U2F
+	var u *types.U2F
 	if a.U2F != nil {
 		u, err = a.U2F.Parse()
 		if err != nil {
@@ -681,7 +681,7 @@ func (a *AuthenticationConfig) Parse() (types.AuthPreference, error) {
 		Type:              a.Type,
 		SecondFactor:      a.SecondFactor,
 		ConnectorName:     a.ConnectorName,
-		U2F:               &u,
+		U2F:               u,
 		Webauthn:          w,
 		RequireSessionMFA: a.RequireSessionMFA,
 		LockingMode:       a.LockingMode,
@@ -695,12 +695,12 @@ type UniversalSecondFactor struct {
 	DeviceAttestationCAs []string `yaml:"device_attestation_cas"`
 }
 
-func (u *UniversalSecondFactor) Parse() (types.U2F, error) {
+func (u *UniversalSecondFactor) Parse() (*types.U2F, error) {
 	attestationCAs, err := getAttestationPEMs(u.DeviceAttestationCAs)
 	if err != nil {
-		return types.U2F{}, trace.BadParameter("u2f.device_attestation_cas: %v", err)
+		return nil, trace.BadParameter("u2f.device_attestation_cas: %v", err)
 	}
-	return types.U2F{
+	return &types.U2F{
 		AppID:                u.AppID,
 		Facets:               u.Facets,
 		DeviceAttestationCAs: attestationCAs,


### PR DESCRIPTION
Before this change, second_factor types 'on' and 'optional' required U2F.
Starting at the next Teleport version, those settings require Webauthn by
default and treat U2F as optional.

Group second factor tests by second factor type, which is a more natural way to
think about configuration and cuts some repetition in testing.