### PR TITLE
Use single policy for auto-IAM

### DIFF
--- a/lib/cloud/aws/policy.go
+++ b/lib/cloud/aws/policy.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/gravitational/trace"
+)
+
+// PolicyDocument represents a parsed AWS IAM policy document.
+type PolicyDocument struct {
+	// Version is the policy version.
+	Version string `json:"Version"`
+	// Statements is a list of the policy statements.
+	Statements []*Statement `json:"Statement"`
+}
+
+// Statement is a single AWS IAM policy statement.
+type Statement struct {
+	// Effect is the statement effect such as Allow or Deny.
+	Effect string `json:"Effect"`
+	// Actions is a list of actions.
+	Actions []string `json:"Action"`
+	// Resources is a list of resources.
+	Resources []string `json:"Resource"`
+}
+
+// ParsePolicyDocument returns parsed AWS IAM policy document.
+func ParsePolicyDocument(document string) (*PolicyDocument, error) {
+	// Policy document returned from AWS API can be URL-encoded:
+	// https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetRolePolicy.html
+	decoded, err := url.QueryUnescape(document)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var parsed PolicyDocument
+	if err := json.Unmarshal([]byte(decoded), &parsed); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &parsed, nil
+}
+
+// NewPolicyDocument returns new empty AWS IAM policy document.
+func NewPolicyDocument() *PolicyDocument {
+	return &PolicyDocument{
+		Version: PolicyVersion,
+	}
+}
+
+// Ensure ensures that the policy document contains the specified resource
+// action.
+//
+// Returns true if the resource action was already a part of the policy and
+// false otherwise.
+func (p *PolicyDocument) Ensure(effect, action, resource string) bool {
+	for _, s := range p.Statements {
+		if s.Effect != effect {
+			continue
+		}
+		for _, a := range s.Actions {
+			if a != action {
+				continue
+			}
+			for _, r := range s.Resources {
+				// Resource action is already in the policy.
+				if r == resource {
+					return true
+				}
+			}
+			// Action exists but resource is missing.
+			s.Resources = append(s.Resources, resource)
+			return false
+		}
+	}
+	// No statement yet for this resource action, add it.
+	p.Statements = append(p.Statements, &Statement{
+		Effect:    effect,
+		Actions:   []string{action},
+		Resources: []string{resource},
+	})
+	return false
+}
+
+// Delete deletes the specified resource action from the policy.
+func (p *PolicyDocument) Delete(effect, action, resource string) {
+	for i, s := range p.Statements {
+		if s.Effect != effect {
+			continue
+		}
+		for _, a := range s.Actions {
+			if a != action {
+				continue
+			}
+			for i, r := range s.Resources {
+				if r == resource {
+					s.Resources = append(s.Resources[:i], s.Resources[i+1:]...)
+				}
+			}
+		}
+		// If we removed last resource, remove the statement.
+		if len(s.Resources) == 0 {
+			p.Statements = append(p.Statements[:i], p.Statements[i+1:]...)
+		}
+	}
+}
+
+const (
+	// PolicyVersion is default IAM policy version.
+	PolicyVersion = "2012-10-17"
+	// EffectAllow is the "allow" IAM policy effect.
+	EffectAllow = "Allow"
+)

--- a/lib/cloud/aws/policy_test.go
+++ b/lib/cloud/aws/policy_test.go
@@ -121,7 +121,60 @@ func TestIAMPolicy(t *testing.T) {
 	// Delete last resource action, policy should be empty.
 	policy.Delete(EffectAllow, "action-2", "resource-3")
 	require.Equal(t, &PolicyDocument{
-		Version:    PolicyVersion,
-		Statements: []*Statement{},
+		Version: PolicyVersion,
+	}, policy)
+
+	// Policy with duplicate statement.
+	policy = &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+		},
+	}
+	policy.Delete(EffectAllow, "action-1", "resource-1")
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+	}, policy)
+
+	// Policy with deny statement.
+	policy = &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1", "resource-2"},
+			},
+			{
+				Effect:    EffectDeny,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-2"},
+			},
+		},
+	}
+	policy.Delete(EffectAllow, "action-1", "resource-2")
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+			{
+				Effect:    EffectDeny,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-2"},
+			},
+		},
 	}, policy)
 }

--- a/lib/cloud/aws/policy_test.go
+++ b/lib/cloud/aws/policy_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIAMPolicy verifies AWS IAM policy manipulations.
+func TestIAMPolicy(t *testing.T) {
+	policy := NewPolicyDocument()
+
+	// Add a new action/resource.
+	alreadyExisted := policy.Ensure(EffectAllow, "action-1", "resource-1")
+	require.False(t, alreadyExisted)
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+		},
+	}, policy)
+
+	// Add the same action/resource.
+	alreadyExisted = policy.Ensure(EffectAllow, "action-1", "resource-1")
+	require.True(t, alreadyExisted)
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1"},
+			},
+		},
+	}, policy)
+
+	// Add a new resource to existing action.
+	alreadyExisted = policy.Ensure(EffectAllow, "action-1", "resource-2")
+	require.False(t, alreadyExisted)
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1", "resource-2"},
+			},
+		},
+	}, policy)
+
+	// Add another action/resource.
+	alreadyExisted = policy.Ensure(EffectAllow, "action-2", "resource-3")
+	require.False(t, alreadyExisted)
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-1", "resource-2"},
+			},
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-2"},
+				Resources: []string{"resource-3"},
+			},
+		},
+	}, policy)
+
+	// Delete existing resource action.
+	policy.Delete(EffectAllow, "action-1", "resource-1")
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-1"},
+				Resources: []string{"resource-2"},
+			},
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-2"},
+				Resources: []string{"resource-3"},
+			},
+		},
+	}, policy)
+
+	// Delete last resource from first action, statement should get removed as well.
+	policy.Delete(EffectAllow, "action-1", "resource-2")
+	require.Equal(t, &PolicyDocument{
+		Version: PolicyVersion,
+		Statements: []*Statement{
+			{
+				Effect:    EffectAllow,
+				Actions:   []string{"action-2"},
+				Resources: []string{"resource-3"},
+			},
+		},
+	}, policy)
+
+	// Delete last resource action, policy should be empty.
+	policy.Delete(EffectAllow, "action-2", "resource-3")
+	require.Equal(t, &PolicyDocument{
+		Version:    PolicyVersion,
+		Statements: []*Statement{},
+	}, policy)
+}

--- a/lib/cloud/doc.go
+++ b/lib/cloud/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cloud contains common methods and utilities for integrations with
+// various cloud providers such as AWS, GCP or Azure.
+package cloud

--- a/lib/srv/db/cloud/aws.go
+++ b/lib/srv/db/cloud/aws.go
@@ -18,10 +18,11 @@ package cloud
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -39,7 +40,7 @@ type awsConfig struct {
 	// clients is an interface for creating AWS clients.
 	clients common.CloudClients
 	// identity is AWS identity this database agent is running as.
-	identity cloud.AWSIdentity
+	identity awslib.Identity
 	// database is the database instance to configure.
 	database types.Database
 	// hostID is the host identifier where this agent's running.
@@ -104,9 +105,9 @@ func (r *awsClient) setupIAM(ctx context.Context) error {
 			errors = append(errors, err)
 		}
 	}
-	if err := r.attachIAMPolicy(ctx); err != nil {
+	if err := r.ensureIAMPolicy(ctx); err != nil {
 		if trace.IsAccessDenied(err) { // Permission errors are expected.
-			r.log.Debugf("No permissions to attach IAM policy: %v.", err)
+			r.log.Debugf("No permissions to ensure IAM policy: %v.", err)
 		} else {
 			errors = append(errors, err)
 		}
@@ -117,9 +118,9 @@ func (r *awsClient) setupIAM(ctx context.Context) error {
 // teardownIAM deconfigures IAM for RDS, Aurora or Redshift database.
 func (r *awsClient) teardownIAM(ctx context.Context) error {
 	var errors []error
-	if err := r.detachIAMPolicy(ctx); err != nil {
+	if err := r.deleteIAMPolicy(ctx); err != nil {
 		if trace.IsAccessDenied(err) { // Permission errors are expected.
-			r.log.Debugf("No permissions to detach IAM policy: %v.", err)
+			r.log.Debugf("No permissions to delete IAM policy: %v.", err)
 		} else {
 			errors = append(errors, err)
 		}
@@ -166,25 +167,105 @@ func (r *awsClient) enableIAMAuth(ctx context.Context) error {
 	return trace.BadParameter("no RDS cluster ID or instance ID for %v", r.cfg.database)
 }
 
-// attachIAMPolicy attaches IAM access policy to the identity this agent is running as.
-func (r *awsClient) attachIAMPolicy(ctx context.Context) error {
-	r.log.Debugf("Attaching IAM policy to %v.", r.cfg.identity)
-	var err error
+// ensureIAMPolicy adds database connect permissions to the agent's policy.
+func (r *awsClient) ensureIAMPolicy(ctx context.Context) error {
+	policy, err := r.getIAMPolicy(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	action := r.cfg.database.GetIAMAction()
+	var changed bool
+	for _, resource := range r.cfg.database.GetIAMResources() {
+		if policy.Ensure(awslib.EffectAllow, action, resource) {
+			r.log.Debugf("Permission %q for %q is already part of policy.", action, resource)
+		} else {
+			r.log.Debugf("Adding permission %q for %q to policy.", action, resource)
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	err = r.updateIAMPolicy(ctx, policy)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// deleteIAMPolicy deletes IAM access policy from the identity this agent is running as.
+func (r *awsClient) deleteIAMPolicy(ctx context.Context) error {
+	policy, err := r.getIAMPolicy(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	action := r.cfg.database.GetIAMAction()
+	for _, resource := range r.cfg.database.GetIAMResources() {
+		policy.Delete(awslib.EffectAllow, action, resource)
+	}
+	// If policy is empty now, delete it as IAM policy can't be empty.
+	if len(policy.Statements) == 0 {
+		return r.detachIAMPolicy(ctx)
+	}
+	return r.updateIAMPolicy(ctx, policy)
+}
+
+// getIAMPolicy fetches and returns this agent's parsed IAM policy document.
+func (r *awsClient) getIAMPolicy(ctx context.Context) (*awslib.PolicyDocument, error) {
+	var policyDocument string
 	switch r.cfg.identity.(type) {
-	case cloud.AWSRole:
+	case awslib.Role:
+		out, err := r.iam.GetRolePolicyWithContext(ctx, &iam.GetRolePolicyInput{
+			PolicyName: aws.String(r.policyName()),
+			RoleName:   aws.String(r.cfg.identity.GetName()),
+		})
+		if err != nil {
+			if trace.IsNotFound(common.ConvertError(err)) {
+				return awslib.NewPolicyDocument(), nil
+			}
+			return nil, common.ConvertError(err)
+		}
+		policyDocument = aws.StringValue(out.PolicyDocument)
+	case awslib.User:
+		out, err := r.iam.GetUserPolicyWithContext(ctx, &iam.GetUserPolicyInput{
+			PolicyName: aws.String(r.policyName()),
+			UserName:   aws.String(r.cfg.identity.GetName()),
+		})
+		if err != nil {
+			if trace.IsNotFound(common.ConvertError(err)) {
+				return awslib.NewPolicyDocument(), nil
+			}
+			return nil, common.ConvertError(err)
+		}
+		policyDocument = aws.StringValue(out.PolicyDocument)
+	default:
+		return nil, trace.BadParameter("can only fetch policies for roles or users, got %v", r.cfg.identity)
+	}
+	return awslib.ParsePolicyDocument(policyDocument)
+}
+
+// updateIAMPolicy attaches IAM access policy to the identity this agent is running as.
+func (r *awsClient) updateIAMPolicy(ctx context.Context, policy *awslib.PolicyDocument) error {
+	r.log.Debugf("Updating IAM policy for %v.", r.cfg.identity)
+	document, err := json.Marshal(policy)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	switch r.cfg.identity.(type) {
+	case awslib.Role:
 		_, err = r.iam.PutRolePolicyWithContext(ctx, &iam.PutRolePolicyInput{
 			PolicyName:     aws.String(r.policyName()),
-			PolicyDocument: aws.String(r.cfg.database.GetIAMPolicy()),
+			PolicyDocument: aws.String(string(document)),
 			RoleName:       aws.String(r.cfg.identity.GetName()),
 		})
-	case cloud.AWSUser:
+	case awslib.User:
 		_, err = r.iam.PutUserPolicyWithContext(ctx, &iam.PutUserPolicyInput{
 			PolicyName:     aws.String(r.policyName()),
-			PolicyDocument: aws.String(r.cfg.database.GetIAMPolicy()),
+			PolicyDocument: aws.String(string(document)),
 			UserName:       aws.String(r.cfg.identity.GetName()),
 		})
 	default:
-		return trace.BadParameter("can only attach policies to roles or users, got %v", r.cfg.identity)
+		return trace.BadParameter("can only update policies for roles or users, got %v", r.cfg.identity)
 	}
 	return common.ConvertError(err)
 }
@@ -194,12 +275,12 @@ func (r *awsClient) detachIAMPolicy(ctx context.Context) error {
 	r.log.Debugf("Detaching IAM policy from %v.", r.cfg.identity)
 	var err error
 	switch r.cfg.identity.(type) {
-	case cloud.AWSRole:
+	case awslib.Role:
 		_, err = r.iam.DeleteRolePolicyWithContext(ctx, &iam.DeleteRolePolicyInput{
 			PolicyName: aws.String(r.policyName()),
 			RoleName:   aws.String(r.cfg.identity.GetName()),
 		})
-	case cloud.AWSUser:
+	case awslib.User:
 		_, err = r.iam.DeleteUserPolicyWithContext(ctx, &iam.DeleteUserPolicyInput{
 			PolicyName: aws.String(r.policyName()),
 			UserName:   aws.String(r.cfg.identity.GetName()),
@@ -210,6 +291,7 @@ func (r *awsClient) detachIAMPolicy(ctx context.Context) error {
 	return common.ConvertError(err)
 }
 
+// policyName is the inline IAM policy name this agent is managing.
 func (r *awsClient) policyName() string {
-	return fmt.Sprintf("%v-%v", r.cfg.database.GetName(), r.cfg.hostID)
+	return fmt.Sprintf("teleport-%v", r.cfg.hostID)
 }

--- a/lib/srv/db/cloud/iam.go
+++ b/lib/srv/db/cloud/iam.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 
 	"github.com/gravitational/trace"
@@ -51,7 +51,7 @@ func (c *IAMConfig) Check() error {
 type IAM struct {
 	cfg         IAMConfig
 	log         logrus.FieldLogger
-	awsIdentity cloud.AWSIdentity
+	awsIdentity aws.Identity
 	mu          sync.RWMutex
 }
 
@@ -105,7 +105,7 @@ func (c *IAM) getAWSConfigurator(ctx context.Context, database types.Database) (
 }
 
 // getAWSIdentity returns this process' AWS identity.
-func (c *IAM) getAWSIdentity(ctx context.Context) (cloud.AWSIdentity, error) {
+func (c *IAM) getAWSIdentity(ctx context.Context) (aws.Identity, error) {
 	c.mu.RLock()
 	if c.awsIdentity != nil {
 		defer c.mu.RUnlock()
@@ -116,7 +116,7 @@ func (c *IAM) getAWSIdentity(ctx context.Context) (cloud.AWSIdentity, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	awsIdentity, err := cloud.GetAWSIdentityWithClient(ctx, sts)
+	awsIdentity, err := aws.GetIdentityWithClient(ctx, sts)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/iam_test.go
+++ b/lib/srv/db/cloud/iam_test.go
@@ -75,7 +75,7 @@ func TestAWSIAM(t *testing.T) {
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "localhost",
-		AWS:      types.AWS{RDS: types.RDS{InstanceID: "postgres-rds"}},
+		AWS:      types.AWS{RDS: types.RDS{InstanceID: "postgres-rds", ResourceID: "postgres-rds-resource-id"}},
 	})
 	require.NoError(t, err)
 
@@ -84,7 +84,7 @@ func TestAWSIAM(t *testing.T) {
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "localhost",
-		AWS:      types.AWS{RDS: types.RDS{ClusterID: "postgres-aurora"}},
+		AWS:      types.AWS{RDS: types.RDS{ClusterID: "postgres-aurora", ResourceID: "postgres-aurora-resource-id"}},
 	})
 	require.NoError(t, err)
 
@@ -113,33 +113,39 @@ func TestAWSIAM(t *testing.T) {
 	err = configurator.Setup(ctx, rdsDatabase)
 	require.NoError(t, err)
 	require.True(t, aws.BoolValue(rdsInstance.IAMDatabaseAuthenticationEnabled))
-	require.Equal(t, []string{"postgres-rds-host-id"}, iamClient.attachedRolePolicies["test-role"])
+	policy := iamClient.attachedRolePolicies["test-role"]["teleport-host-id"]
+	require.Contains(t, policy, rdsDatabase.GetAWS().RDS.ResourceID)
 
 	// Deconfigure RDS database, policy should get detached.
 	err = configurator.Teardown(ctx, rdsDatabase)
 	require.NoError(t, err)
-	require.Equal(t, []string{}, iamClient.attachedRolePolicies["test-role"])
+	policy = iamClient.attachedRolePolicies["test-role"]["teleport-host-id"]
+	require.NotContains(t, policy, rdsDatabase.GetAWS().RDS.ResourceID)
 
 	// Configure Aurora database and make sure IAM was enabled and policy was attached.
 	err = configurator.Setup(ctx, auroraDatabase)
 	require.NoError(t, err)
 	require.True(t, aws.BoolValue(auroraCluster.IAMDatabaseAuthenticationEnabled))
-	require.Equal(t, []string{"postgres-aurora-host-id"}, iamClient.attachedRolePolicies["test-role"])
+	policy = iamClient.attachedRolePolicies["test-role"]["teleport-host-id"]
+	require.Contains(t, policy, auroraDatabase.GetAWS().RDS.ResourceID)
 
 	// Deconfigure Aurora database, policy should get detached.
 	err = configurator.Teardown(ctx, auroraDatabase)
 	require.NoError(t, err)
-	require.Equal(t, []string{}, iamClient.attachedRolePolicies["test-role"])
+	policy = iamClient.attachedRolePolicies["test-role"]["teleport-host-id"]
+	require.NotContains(t, policy, auroraDatabase.GetAWS().RDS.ResourceID)
 
 	// Configure Redshift database and make sure policy was attached.
 	err = configurator.Setup(ctx, redshiftDatabase)
 	require.NoError(t, err)
-	require.Equal(t, []string{"redshift-host-id"}, iamClient.attachedRolePolicies["test-role"])
+	policy = iamClient.attachedRolePolicies["test-role"]["teleport-host-id"]
+	require.Contains(t, policy, redshiftDatabase.GetAWS().Redshift.ClusterID)
 
 	// Deconfigure Redshift database, policy should get detached.
 	err = configurator.Teardown(ctx, redshiftDatabase)
 	require.NoError(t, err)
-	require.Equal(t, []string{}, iamClient.attachedRolePolicies["test-role"])
+	policy = iamClient.attachedRolePolicies["test-role"]["teleport-host-id"]
+	require.NotContains(t, policy, redshiftDatabase.GetAWS().Redshift.ClusterID)
 }
 
 // TestAWSIAMNoPermissions tests that lack of AWS permissions does not produce


### PR DESCRIPTION
In the original auto-IAM configuration implementation, Teleport would create a separate inline IAM policy for each database.

I then learned that you can have as many inline policies as you want, however there is a limit on the _total character size_ of all inline policies combined (more info [here](https://aws.amazon.com/premiumsupport/knowledge-center/iam-increase-policy-size/)).

Knowing this, it seems quite wasteful to create a separate policy for each database because that basically places a limit on how many RDS/Redshift databases a single agent can auto-configure. A policy looks like this:

```yaml
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": "rds-db:connect",
      "Resource": "arn:aws:rds-db:1234567890:us-east-1:dbuser:db-XXX/*"
    }
  ]
}
```

With these changes, instead of duplicating basically the same policy for each database, Teleport will now manage a single inline policy per agent and update resource list appropriately.

So e.g. for 2 databases instead of having 2 policies like shown above, we'll have a single policy with 2 resources:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": "rds-db:connect",
      "Resource": [
        "arn:aws:rds-db:1234567890:us-east-1:dbuser:db-XXX/*",
        "arn:aws:rds-db:1234567890:us-east-1:dbuser:db-YYY/*"
      ]
    }
  ]
}
```