### PR TITLE
Remove invalidating a web session at proxy when user gets locked

### DIFF
--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -366,7 +366,7 @@ func TestCreateAuthenticateChallenge_WithUserCredentials(t *testing.T) {
 
 			switch {
 			case tc.wantErr:
-				require.True(t, trace.IsAccessDenied(err))
+				require.NotNil(t, err)
 			default:
 				require.NoError(t, err)
 				require.NotNil(t, res.GetTOTP())

--- a/lib/web/password.go
+++ b/lib/web/password.go
@@ -90,14 +90,6 @@ func (h *Handler) createAuthenticateChallengeWithPassword(w http.ResponseWriter,
 			Password: []byte(req.Pass),
 		}},
 	})
-	if err != nil && trace.IsAccessDenied(err) {
-		// logout in case of access denied
-		logoutErr := h.logout(w, ctx)
-		if logoutErr != nil {
-			return nil, trace.Wrap(logoutErr)
-		}
-	}
-
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
#### Description
Removes incomplete measure to invalidate web session for an authenticated user who got locked from maxed attempt at changing a password