### PR TITLE
Cleanup lint targets

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - bodyclose
     - deadcode
     - goimports
-    - golint
     - gosimple
     - govet
     - ineffassign

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ VERSION=8.0.0-alpha.1
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci
 
+GOPATH ?= $(shell go env GOPATH)
+
 # These are standard autotools variables, don't change them please
 ifneq ("$(wildcard /bin/bash)","")
 SHELL := /bin/bash -o pipefail
@@ -26,7 +28,6 @@ BINDIR ?= /usr/local/bin
 DATADIR ?= /usr/local/share/teleport
 ADDFLAGS ?=
 PWD ?= `pwd`
-GOPKGDIR ?= `go env GOPATH`/pkg/`go env GOHOSTOS`_`go env GOARCH`/github.com/gravitational/teleport*
 TELEPORT_DEBUG ?= no
 GITTAG=v$(VERSION)
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s'
@@ -275,7 +276,7 @@ ifneq ("$(OS)", "windows")
 endif
 
 #
-# make clean - Removed all build artifacts.
+# make clean - Removes all build artifacts.
 #
 .PHONY: clean
 clean:
@@ -284,7 +285,6 @@ clean:
 	rm -rf $(ER_BPF_BUILDDIR)
 	rm -rf $(RS_BPF_BUILDDIR)
 	-go clean -cache
-	rm -rf $(GOPKGDIR)
 	rm -rf teleport
 	rm -rf *.gz
 	rm -rf *.zip

--- a/lib/auth/state_unix.go
+++ b/lib/auth/state_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/lib/auth/state_windows.go
+++ b/lib/auth/state_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/lib/backend/dynamo/configure_test.go
+++ b/lib/backend/dynamo/configure_test.go
@@ -1,3 +1,4 @@
+//go:build dynamodb
 // +build dynamodb
 
 /*

--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/bpf/bpf_nop.go
+++ b/lib/bpf/bpf_nop.go
@@ -1,3 +1,4 @@
+//go:build !bpf || 386
 // +build !bpf 386
 
 /*

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/bpf/command.go
+++ b/lib/bpf/command.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/bpf/disk.go
+++ b/lib/bpf/disk.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/bpf/helper.go
+++ b/lib/bpf/helper.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/bpf/network.go
+++ b/lib/bpf/network.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/lib/datalog/access.go
+++ b/lib/datalog/access.go
@@ -1,3 +1,4 @@
+//go:build roletester
 // +build roletester
 
 /*

--- a/lib/datalog/access_nop.go
+++ b/lib/datalog/access_nop.go
@@ -1,3 +1,4 @@
+//go:build !roletester
 // +build !roletester
 
 /*

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 /*

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -1,3 +1,4 @@
+//go:build dynamodb
 // +build dynamodb
 
 /*

--- a/lib/fuzz/fuzz.go
+++ b/lib/fuzz/fuzz.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build gofuzz
 // +build gofuzz
 
 package fuzz

--- a/lib/pam/pam.go
+++ b/lib/pam/pam.go
@@ -1,3 +1,4 @@
+//go:build pam && cgo
 // +build pam,cgo
 
 /*

--- a/lib/pam/pam_nop.go
+++ b/lib/pam/pam_nop.go
@@ -1,3 +1,4 @@
+//go:build !pam && cgo
 // +build !pam,cgo
 
 /*

--- a/lib/restrictedsession/audit.go
+++ b/lib/restrictedsession/audit.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/restrictedsession/network.go
+++ b/lib/restrictedsession/network.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/restrictedsession/nop.go
+++ b/lib/restrictedsession/nop.go
@@ -1,3 +1,4 @@
+//go:build !bpf || 386
 // +build !bpf 386
 
 /*

--- a/lib/restrictedsession/restricted.go
+++ b/lib/restrictedsession/restricted.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/restrictedsession/restricted_test.go
+++ b/lib/restrictedsession/restricted_test.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/restrictedsession/watcher.go
+++ b/lib/restrictedsession/watcher.go
@@ -1,3 +1,4 @@
+//go:build bpf && !386
 // +build bpf,!386
 
 /*

--- a/lib/shell/shell_unix.go
+++ b/lib/shell/shell_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/lib/shell/shell_windows.go
+++ b/lib/shell/shell_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/lib/srv/reexec_linux.go
+++ b/lib/srv/reexec_linux.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
 // +build linux
 
 package srv

--- a/lib/srv/reexec_other.go
+++ b/lib/srv/reexec_other.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !linux
 // +build !linux
 
 package srv

--- a/lib/srv/uacc/uacc_linux.go
+++ b/lib/srv/uacc/uacc_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/lib/srv/uacc/uacc_stub.go
+++ b/lib/srv/uacc/uacc_stub.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/lib/utils/agentconn/agent_unix.go
+++ b/lib/utils/agentconn/agent_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/lib/utils/agentconn/agent_windows.go
+++ b/lib/utils/agentconn/agent_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/lib/utils/disk.go
+++ b/lib/utils/disk.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/lib/utils/disk_windows.go
+++ b/lib/utils/disk_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/lib/utils/fs_unix.go
+++ b/lib/utils/fs_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/lib/utils/fs_windows.go
+++ b/lib/utils/fs_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package utils

--- a/lib/utils/syslog.go
+++ b/lib/utils/syslog.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/lib/web/static.go
+++ b/lib/web/static.go
@@ -1,3 +1,4 @@
+//go:build !webassets_embed
 // +build !webassets_embed
 
 /*

--- a/lib/web/static_embed.go
+++ b/lib/web/static_embed.go
@@ -1,3 +1,4 @@
+//go:build webassets_embed
 // +build webassets_embed
 
 /*


### PR DESCRIPTION
- Don't assume an explicit $GOPATH is set
- Remove golint from linters - it's been deprecated for over a year
  and golangci-lint prints a warning instead of running it.