### PR TITLE
kubectl exec and port-forward requests use the right dialer

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -176,12 +176,13 @@ func extractKubeCreds(ctx context.Context, cluster string, clientCfg *rest.Confi
 		return nil, trace.Wrap(err, "failed to generate TLS config from kubeconfig: %v", err)
 	}
 
-	// Parse host from address and set as SNI for TLS handshake
-	host, _, err := net.SplitHostPort(targetAddr)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if tlsConfig != nil && tlsConfig.ServerName != "" {
+		// Parse host from address and set as SNI for TLS handshake
+		tlsConfig.ServerName, _, err = net.SplitHostPort(targetAddr)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
-	tlsConfig.ServerName = host
 
 	transportConfig, err := clientCfg.TransportConfig()
 	if err != nil {

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -170,20 +170,10 @@ func extractKubeCreds(ctx context.Context, cluster string, clientCfg *rest.Confi
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	tlsConfig, err := rest.TLSConfigFor(clientCfg)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to generate TLS config from kubeconfig: %v", err)
 	}
-
-	if tlsConfig != nil && tlsConfig.ServerName != "" {
-		// Parse host from address and set as SNI for TLS handshake
-		tlsConfig.ServerName, _, err = net.SplitHostPort(targetAddr)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
 	transportConfig, err := clientCfg.TransportConfig()
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to generate transport config from kubeconfig: %v", err)

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -170,10 +170,19 @@ func extractKubeCreds(ctx context.Context, cluster string, clientCfg *rest.Confi
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	tlsConfig, err := rest.TLSConfigFor(clientCfg)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to generate TLS config from kubeconfig: %v", err)
 	}
+
+	// Parse host from address and set as SNI for TLS handshake
+	host, _, err := net.SplitHostPort(targetAddr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	tlsConfig.ServerName = host
+
 	transportConfig, err := clientCfg.TransportConfig()
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to generate transport config from kubeconfig: %v", err)

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1108,9 +1108,9 @@ func (f *Forwarder) setupForwardingHeaders(sess *clusterSession, req *http.Reque
 	req.URL.Scheme = "https"
 	req.RequestURI = req.URL.Path + "?" + req.URL.RawQuery
 
-	// SNI will be used for TLS handshake, and the session's custom dialer will handle
-	// Host address, so this URL Host address just needs to pass request validation.
-	req.URL.Host = "example.com"
+	// Since the forwarder uses a custom dialer and SNI is used for TLS handshake,
+	// the host below just needs to be set to pass request validation.
+	req.URL.Host = "host"
 
 	// add origin headers so the service consuming the request on the other site
 	// is aware of where it came from

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -654,12 +654,9 @@ func TestNewClusterSessionLocal(t *testing.T) {
 
 	// Make sure newClusterSession used provided creds
 	// instead of requesting a Teleport client cert.
-	require.Equal(t, f.creds["local"].tlsConfig.Certificates, sess.tlsConfig.Certificates)
+	require.Equal(t, f.creds["local"].tlsConfig, sess.tlsConfig)
 	require.Nil(t, f.cfg.AuthClient.(*mockCSRClient).lastCert)
 	require.Empty(t, 0, f.clientCredentials.Len())
-
-	// Make sure SNI was set correctly
-	require.Equal(t, utils.MustParseAddr(f.creds["local"].targetAddr).Host(), sess.tlsConfig.ServerName)
 }
 
 func TestNewClusterSessionRemote(t *testing.T) {
@@ -677,9 +674,6 @@ func TestNewClusterSessionRemote(t *testing.T) {
 	require.Equal(t, f.cfg.AuthClient.(*mockCSRClient).lastCert.Raw, sess.tlsConfig.Certificates[0].Certificate[0])
 	require.Equal(t, [][]byte{f.cfg.AuthClient.(*mockCSRClient).ca.Cert.RawSubject}, sess.tlsConfig.RootCAs.Subjects())
 	require.Equal(t, 1, f.clientCredentials.Len())
-
-	// Make sure SNI was set correctly
-	require.Equal(t, reversetunnel.LocalKubernetes, sess.tlsConfig.ServerName)
 }
 
 func TestNewClusterSessionDirect(t *testing.T) {
@@ -728,9 +722,6 @@ func TestNewClusterSessionDirect(t *testing.T) {
 	require.Equal(t, f.cfg.AuthClient.(*mockCSRClient).lastCert.Raw, sess.tlsConfig.Certificates[0].Certificate[0])
 	require.Equal(t, [][]byte{f.cfg.AuthClient.(*mockCSRClient).ca.Cert.RawSubject}, sess.tlsConfig.RootCAs.Subjects())
 	require.Equal(t, 1, f.clientCredentials.Len())
-
-	// Make sure SNI was set correctly
-	require.Equal(t, reversetunnel.LocalKubernetes, sess.tlsConfig.ServerName)
 }
 
 func TestClusterSessionDial(t *testing.T) {


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/8362, I introduced `dialWithEndpoints` to properly forward kubectl requests for kube clusters with multiple `kube_service` registrations. However, this dial logic was not properly propogated to `kubectl exec` and `kubectl port-forward` requests. 

This PR fixes that by changing `clusterSession.Dial` to switch between a direct dial and `dialWithEndpoints` depending on the targets available in the `clusterSession`. Now all consumers of `Dial` or `DialWithContext` will get the new functionality safely.

Bug report - https://gravitational.slack.com/archives/C01TYKHFVTQ/p1634136552298200