### PR TITLE
Added metrics for missing SSH tunnels.

### DIFF
--- a/docs/pages/setup/reference/metrics.mdx
+++ b/docs/pages/setup/reference/metrics.mdx
@@ -104,6 +104,7 @@ Now you can see the monitoring information by visiting several endpoints:
 | `promhttp_metric_handler_requests_in_flight` | gauge | prometheus | Current number of scrapes being served. |
 | `promhttp_metric_handler_requests_total` | counter | prometheus | Total number of scrapes by HTTP status code. |
 | `proxy_connection_limit_exceeded_total` | counter | Teleport Proxy | Number of connections that exceeded the proxy connection limit. |
+| `proxy_missing_ssh_tunnels` | gauge | Teleport Proxy | Number of missing SSH tunnels. Used to debug if nodes have discovered all proxies. |
 | `reversetunnel_connected_proxies` | gauge | Teleport | Number of known proxies being sought. |
 | `rx` | counter | Teleport | Number of bytes received. |
 | `server_interactive_sessions_total` | gauge | Teleport | Number of active sessions. |

--- a/metrics.go
+++ b/metrics.go
@@ -76,6 +76,9 @@ const (
 	// MetricWatcherEventSizes measures the size of watcher events that are emitted
 	MetricWatcherEventSizes = "watcher_event_sizes"
 
+	// MetricMissingSSHTunnels returns the number of missing SSH tunnels for this proxy.
+	MetricMissingSSHTunnels = "proxy_missing_ssh_tunnels"
+
 	// TagCluster is a metric tag for a cluster
 	TagCluster = "cluster"
 )


### PR DESCRIPTION
**Description**

Added metrics and logging for missing SSH reverse tunnels. This is useful for debugging to find if nodes are discovering all proxies.