### PR TITLE
Replace golint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,11 @@
 issues:
   exclude-rules:
-    - linters: gosimple
+    - linters:
+      - gosimple
       text: "S1002: should omit comparison to bool constant"
+    - linters:
+      - revive
+      text: "exported: exported const"
   exclude-use-default: true
   max-same-issues: 0
   max-issues-per-linter: 0
@@ -16,6 +20,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - revive
     - staticcheck
     - structcheck
     - typecheck

--- a/api/client/proto/types.go
+++ b/api/client/proto/types.go
@@ -66,9 +66,6 @@ func (req *HostCertsRequest) CheckAndSetDefaults() error {
 	if req.HostID == "" {
 		return trace.BadParameter("missing parameter HostID")
 	}
-	if err := req.Role.Check(); err != nil {
-		return err
-	}
 
-	return nil
+	return req.Role.Check()
 }

--- a/build.assets/render-tests/main.go
+++ b/build.assets/render-tests/main.go
@@ -32,7 +32,7 @@ import (
 	"time"
 )
 
-var covPattern *regexp.Regexp = regexp.MustCompile(`^coverage: (\d+\.\d+)\% of statements`)
+var covPattern = regexp.MustCompile(`^coverage: (\d+\.\d+)\% of statements`)
 
 type TestEvent struct {
 	Time           time.Time // encodes as an RFC3339-format string

--- a/examples/jwt/verify-jwt.go
+++ b/examples/jwt/verify-jwt.go
@@ -131,11 +131,8 @@ func validate(claims *claims, issuer string, subject string, audience string) er
 		Audience: jwt.Audience{audience},
 		Time:     time.Now(),
 	}
-	if err := claims.Validate(expectedClaims); err != nil {
-		return err
-	}
 
-	return nil
+	return claims.Validate(expectedClaims)
 }
 
 func printClaims(claims *claims) {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3101,11 +3101,11 @@ func (a *Server) isMFARequired(ctx context.Context, checker services.AccessCheck
 		if cluster == nil || server == nil {
 			return nil, trace.Wrap(notFoundErr)
 		}
-		kV3, err := types.NewKubernetesClusterV3FromLegacyCluster(server.GetNamespace(), cluster)
+		k8sV3, err := types.NewKubernetesClusterV3FromLegacyCluster(server.GetNamespace(), cluster)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		noMFAAccessErr = checker.CheckAccess(kV3, services.AccessMFAParams{})
+		noMFAAccessErr = checker.CheckAccess(k8sV3, services.AccessMFAParams{})
 
 	case *proto.IsMFARequiredRequest_Database:
 		notFoundErr = trace.NotFound("database service %q not found", t.Database.ServiceName)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2961,11 +2961,11 @@ func (a *ServerWithRoles) UpsertKubeService(ctx context.Context, s types.Server)
 	}
 
 	for _, kube := range s.GetKubernetesClusters() {
-		kV3, err := types.NewKubernetesClusterV3FromLegacyCluster(s.GetNamespace(), kube)
+		k8sV3, err := types.NewKubernetesClusterV3FromLegacyCluster(s.GetNamespace(), kube)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		if err := a.context.Checker.CheckAccess(kV3, mfaParams); err != nil {
+		if err := a.context.Checker.CheckAccess(k8sV3, mfaParams); err != nil {
 			return utils.OpaqueAccessDenied(err)
 		}
 	}
@@ -2992,11 +2992,11 @@ func (a *ServerWithRoles) GetKubeServices(ctx context.Context) ([]types.Server, 
 	for _, server := range servers {
 		filtered := make([]*types.KubernetesCluster, 0, len(server.GetKubernetesClusters()))
 		for _, kube := range server.GetKubernetesClusters() {
-			kV3, err := types.NewKubernetesClusterV3FromLegacyCluster(server.GetNamespace(), kube)
+			k8sV3, err := types.NewKubernetesClusterV3FromLegacyCluster(server.GetNamespace(), kube)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			if err := a.context.Checker.CheckAccess(kV3, mfaParams); err != nil {
+			if err := a.context.Checker.CheckAccess(k8sV3, mfaParams); err != nil {
 				if trace.IsAccessDenied(err) {
 					continue
 				}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1745,7 +1745,7 @@ func isCmdLabelSpec(spec string) (types.CommandLabel, error) {
 		if len(cmdSpec) < 1 {
 			return nil, trace.Wrap(invalidSpecError)
 		}
-		var openQuote bool = false
+		openQuote := false
 		return &types.CommandLabelV2{
 			Period: types.NewDuration(period),
 			Command: strings.FieldsFunc(cmdSpec, func(c rune) bool {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -84,11 +84,7 @@ func writeTestConfigs() error {
 	}
 	// create a bad config file fixture
 	testConfigs.configFileBadContent = filepath.Join(testConfigs.tempDir, "bad-config.yaml")
-	if err = ioutil.WriteFile(testConfigs.configFileBadContent, []byte("bad-data!"), 0660); err != nil {
-		return err
-	}
-
-	return nil
+	return ioutil.WriteFile(testConfigs.configFileBadContent, []byte("bad-data!"), 0660)
 }
 
 func (tc testConfigFiles) cleanup() {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -69,22 +69,22 @@ func writeTestConfigs() error {
 	}
 	// create a good config file fixture
 	testConfigs.configFile = filepath.Join(testConfigs.tempDir, "good-config.yaml")
-	if err = ioutil.WriteFile(testConfigs.configFile, []byte(makeConfigFixture()), 0660); err != nil {
+	if err = os.WriteFile(testConfigs.configFile, []byte(makeConfigFixture()), 0660); err != nil {
 		return err
 	}
 	// create a static config file fixture
 	testConfigs.configFileStatic = filepath.Join(testConfigs.tempDir, "static-config.yaml")
-	if err = ioutil.WriteFile(testConfigs.configFileStatic, []byte(StaticConfigString), 0660); err != nil {
+	if err = os.WriteFile(testConfigs.configFileStatic, []byte(StaticConfigString), 0660); err != nil {
 		return err
 	}
 	// create an empty config file
 	testConfigs.configFileNoContent = filepath.Join(testConfigs.tempDir, "empty-config.yaml")
-	if err = ioutil.WriteFile(testConfigs.configFileNoContent, []byte(""), 0660); err != nil {
+	if err = os.WriteFile(testConfigs.configFileNoContent, []byte(""), 0660); err != nil {
 		return err
 	}
 	// create a bad config file fixture
 	testConfigs.configFileBadContent = filepath.Join(testConfigs.tempDir, "bad-config.yaml")
-	return ioutil.WriteFile(testConfigs.configFileBadContent, []byte("bad-data!"), 0660)
+	return os.WriteFile(testConfigs.configFileBadContent, []byte("bad-data!"), 0660)
 }
 
 func (tc testConfigFiles) cleanup() {
@@ -118,7 +118,7 @@ func TestConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, sfc)
 		fn := filepath.Join(t.TempDir(), "default-config.yaml")
-		err = ioutil.WriteFile(fn, []byte(sfc.DebugDumpToYAML()), 0660)
+		err = os.WriteFile(fn, []byte(sfc.DebugDumpToYAML()), 0660)
 		require.NoError(t, err)
 
 		// make sure it could be parsed:
@@ -565,7 +565,7 @@ teleport:
 func TestApplyConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	tokenPath := filepath.Join(tempDir, "small-config-token")
-	err := ioutil.WriteFile(tokenPath, []byte("join-token"), 0644)
+	err := os.WriteFile(tokenPath, []byte("join-token"), 0644)
 	require.NoError(t, err)
 
 	conf, err := ReadConfig(bytes.NewBufferString(fmt.Sprintf(SmallConfigString, tokenPath)))
@@ -1637,7 +1637,7 @@ db_service:
 func TestDatabaseCLIFlags(t *testing.T) {
 	// Prepare test CA certificate used to configure some databases.
 	testCertPath := filepath.Join(t.TempDir(), "cert.pem")
-	err := ioutil.WriteFile(testCertPath, fixtures.LocalhostCert, 0644)
+	err := os.WriteFile(testCertPath, fixtures.LocalhostCert, 0644)
 	require.NoError(t, err)
 	tests := []struct {
 		inFlags     CommandLineFlags

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -658,11 +658,11 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 			if ks.Name != actx.kubeCluster {
 				continue
 			}
-			kV3, err := types.NewKubernetesClusterV3FromLegacyCluster(s.GetNamespace(), ks)
+			k8sV3, err := types.NewKubernetesClusterV3FromLegacyCluster(s.GetNamespace(), ks)
 			if err != nil {
 				return trace.Wrap(err)
 			}
-			if err := actx.Checker.CheckAccess(kV3, mfaParams); err != nil {
+			if err := actx.Checker.CheckAccess(k8sV3, mfaParams); err != nil {
 				return clusterNotFound
 			}
 			return nil

--- a/lib/pam/pam_nop.go
+++ b/lib/pam/pam_nop.go
@@ -19,8 +19,7 @@ limitations under the License.
 
 package pam
 
-var buildHasPAM bool = false
-var systemHasPAM bool = false
+var buildHasPAM, systemHasPAM bool
 
 // PAM is used to create a PAM context and initiate PAM transactions to checks
 // the users account and open/close a session.

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -361,10 +361,10 @@ type ResourceMarshaler func(types.Resource, ...MarshalOption) ([]byte, error)
 type ResourceUnmarshaler func([]byte, ...MarshalOption) (types.Resource, error)
 
 // resourceMarshalers holds a collection of marshalers organized by kind.
-var resourceMarshalers map[string]ResourceMarshaler = make(map[string]ResourceMarshaler)
+var resourceMarshalers = make(map[string]ResourceMarshaler)
 
 // resourceUnmarshalers holds a collection of unmarshalers organized by kind.
-var resourceUnmarshalers map[string]ResourceUnmarshaler = make(map[string]ResourceUnmarshaler)
+var resourceUnmarshalers = make(map[string]ResourceUnmarshaler)
 
 // GetResourceMarshalerKinds lists all registered resource marshalers by kind.
 func GetResourceMarshalerKinds() []string {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -2985,10 +2985,10 @@ func TestCheckAccessToKubernetes(t *testing.T) {
 			for _, r := range tc.roles {
 				set = append(set, r)
 			}
-			kV3, err := types.NewKubernetesClusterV3FromLegacyCluster(apidefaults.Namespace, tc.cluster)
+			k8sV3, err := types.NewKubernetesClusterV3FromLegacyCluster(apidefaults.Namespace, tc.cluster)
 			require.NoError(t, err)
 
-			err = set.CheckAccess(kV3, tc.mfaParams)
+			err = set.CheckAccess(k8sV3, tc.mfaParams)
 			if tc.hasAccess {
 				require.NoError(t, err)
 			} else {

--- a/lib/utils/certs.go
+++ b/lib/utils/certs.go
@@ -221,9 +221,11 @@ func IsSelfSigned(certificateChain []*x509.Certificate) bool {
 // multiple certificates and returns a slice of x509.Certificate.
 func ReadCertificateChain(certificateChainBytes []byte) ([]*x509.Certificate, error) {
 	// build the certificate chain next
-	var certificateBlock *pem.Block
-	var remainingBytes []byte = bytes.TrimSpace(certificateChainBytes)
-	var certificateChain [][]byte
+	var (
+		certificateBlock *pem.Block
+		certificateChain [][]byte
+	)
+	remainingBytes := bytes.TrimSpace(certificateChainBytes)
 
 	for {
 		certificateBlock, remainingBytes = pem.Decode(remainingBytes)

--- a/lib/utils/otp.go
+++ b/lib/utils/otp.go
@@ -56,7 +56,7 @@ func GenerateOTPURL(typ string, label string, parameters map[string][]byte) stri
 	u.Host = typ
 	u.Path = label
 
-	var params url.Values = make(url.Values)
+	params := make(url.Values)
 	for k, v := range parameters {
 		if k == "secret" {
 			v = []byte(base32.StdEncoding.EncodeToString(v))

--- a/lib/utils/spki.go
+++ b/lib/utils/spki.go
@@ -62,7 +62,7 @@ outer:
 	return nil
 }
 
-var errorMessage string = "cluster pin does not match any provided certificate authority pin. " +
+var errorMessage = "cluster pin does not match any provided certificate authority pin. " +
 	"This could have occurred if the Certificate Authority (CA) for the cluster " +
 	"was rotated, invalidating the old pin. This could also occur if a new HSM was " +
 	"added. Run \"tctl status\" to compare the pin used to join the cluster to the " +

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -163,7 +163,7 @@ func CipherSuiteMapping(cipherSuites []string) ([]uint16, error) {
 
 // cipherSuiteMapping is the mapping between Teleport formatted cipher
 // suites strings and uint16 IDs.
-var cipherSuiteMapping map[string]uint16 = map[string]uint16{
+var cipherSuiteMapping = map[string]uint16{
 	"tls-rsa-with-aes-128-cbc-sha":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
 	"tls-rsa-with-aes-256-cbc-sha":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 	"tls-rsa-with-aes-128-cbc-sha256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -303,7 +303,7 @@ func (s *WebSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	// Expired sessions are purged immediately
-	var sessionLingeringThreshold time.Duration = 0
+	var sessionLingeringThreshold time.Duration
 	fs, err := NewDebugFileSystem("../../webassets/teleport")
 	c.Assert(err, IsNil)
 	handler, err := NewHandler(Config{


### PR DESCRIPTION
Replace the deprecated `golint` with `revive` to remove warning when running `make lint`