### PR TITLE
fileconf: change LDAP config from password to password_file

### DIFF
--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -70,9 +70,9 @@ windows_desktop_service:
     # likely "EXAMPLE". When connecting as the "Administrator" user, you should
     # use the format: "EXAMPLE\Administrator".
     username: '$LDAP_USERNAME'
-    # LDAP password for authentication. This is usually the same password you
-    # use to login to the Domain Controller.
-    password: '$LDAP_PASSWORD'
+    # Plain text file containing the LDAP password for authentication.
+    # This is usually the same password you use to login to the Domain Controller.
+    password_file: /var/lib/ldap-pass
 ```
 
 After updating `teleport.yaml`, start Teleport as usual using `teleport start`.

--- a/docs/pages/desktop-access/reference.mdx
+++ b/docs/pages/desktop-access/reference.mdx
@@ -45,9 +45,9 @@ windows_desktop_service:
     # likely "EXAMPLE". When connecting as the "Administrator" user, you should
     # use the format: "EXAMPLE\Administrator".
     username: '$LDAP_USERNAME'
-    # LDAP password for authentication. This is usually the same password you
-    # use to login to the Domain Controller.
-    password: '$LDAP_PASSWORD'
+    # Plain text file containing the LDAP password for authentication.
+    # This is usually the same password you use to login to the Domain Controller.
+    password_file: /var/lib/ldap-pass
   # Rules for applying labels to Windows hosts based on regular expressions
   # matched against the host name. If multiple rules match, the desktop will
   # get the union of all matching labels.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1308,16 +1308,13 @@ type WindowsHostLabelRule struct {
 }
 
 // LDAPConfig is the LDAP connection parameters.
-//
-// TODO(awly): these credentials are very sensitive. Add support for loading
-// from a file.
 type LDAPConfig struct {
-	// Addr is the address:port of the LDAP server (typically port 389).
+	// Addr is the host:port of the LDAP server (typically port 389).
 	Addr string `yaml:"addr"`
 	// Domain is the ActiveDirectory domain name.
 	Domain string `yaml:"domain"`
 	// Username for LDAP authentication.
 	Username string `yaml:"username"`
-	// Password for LDAP authentication.
-	Password string `yaml:"password"`
+	// PasswordFile is a text file containing the password for LDAP authentication.
+	PasswordFile string `yaml:"password_file"`
 }


### PR DESCRIPTION
This approach avoids the need to put sensitive credentials in the
teleport config file, which is often shared for examples, testing
and troubleshooting purposes.

Fixes #8544 