### PR TITLE
Add webauthn support for web terminal mfa prompt

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -649,8 +649,8 @@ const (
 	// WebsocketU2FChallenge is sending a U2F challenge.
 	WebsocketU2FChallenge = "u"
 
-	// WebsocketWebAuthnChallenge is sending a webauthn challenge.
-	WebsocketWebAuthnChallenge = "n"
+	// WebsocketWebauthnChallenge is sending a webauthn challenge.
+	WebsocketWebauthnChallenge = "n"
 )
 
 // The following are cryptographic primitives Teleport does not support in

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -648,6 +648,9 @@ const (
 
 	// WebsocketU2FChallenge is sending a U2F challenge.
 	WebsocketU2FChallenge = "u"
+
+	// WebsocketWebAuthnChallenge is sending a webauthn challenge.
+	WebsocketWebAuthnChallenge = "n"
 )
 
 // The following are cryptographic primitives Teleport does not support in

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1034,9 +1034,8 @@ func TestTerminalRequireSessionMfa(t *testing.T) {
 				ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
 					Type:         constants.Local,
 					SecondFactor: constants.SecondFactorWebauthn,
-					U2F: &types.U2F{
-						AppID:  "https://localhost",
-						Facets: []string{"https://localhost"},
+					Webauthn: &types.Webauthn{
+						RPID: "localhost",
 					},
 					RequireSessionMFA: true,
 				})

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1013,166 +1013,132 @@ func (s *WebSuite) TestTerminal(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *WebSuite) TestTerminalRequireSessionMfa_WithU2F(c *C) {
+func TestTerminalRequireSessionMfa(t *testing.T) {
 	ctx := context.Background()
-	pack1 := s.authPack(c, "llama")
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "llama")
 
-	// Enable require session mfa.
-	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
-		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorU2F,
-		U2F: &types.U2F{
-			AppID:  "https://localhost",
-			Facets: []string{"https://localhost"},
+	clt, err := env.server.NewClient(auth.TestUser("llama"))
+	require.NoError(t, err)
+
+	cases := []struct {
+		name                      string
+		getAuthPreference         func() types.AuthPreference
+		registerDevice            func() *auth.TestDevice
+		getChallengeResponseBytes func(chals *auth.MFAAuthenticateChallenge, dev *auth.TestDevice) []byte
+	}{
+		{
+			name: "with webauthn",
+			getAuthPreference: func() types.AuthPreference {
+				ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
+					Type:         constants.Local,
+					SecondFactor: constants.SecondFactorWebauthn,
+					U2F: &types.U2F{
+						AppID:  "https://localhost",
+						Facets: []string{"https://localhost"},
+					},
+					RequireSessionMFA: true,
+				})
+				require.NoError(t, err)
+
+				return ap
+			},
+			registerDevice: func() *auth.TestDevice {
+				webauthnDev, err := auth.RegisterTestDevice(ctx, clt, "webauthn", apiProto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
+				require.NoError(t, err)
+
+				return webauthnDev
+			},
+			getChallengeResponseBytes: func(chals *auth.MFAAuthenticateChallenge, dev *auth.TestDevice) []byte {
+				res, err := dev.SolveAuthn(&apiProto.MFAAuthenticateChallenge{
+					WebauthnChallenge: wanlib.CredentialAssertionToProto(chals.WebauthnChallenge),
+				})
+				require.Nil(t, err)
+
+				webauthnResBytes, err := json.Marshal(wanlib.CredentialAssertionResponseFromProto(res.GetWebauthn()))
+				require.Nil(t, err)
+
+				return webauthnResBytes
+			},
 		},
-		RequireSessionMFA: true,
-	})
-	c.Assert(err, IsNil)
-	err = s.server.Auth().SetAuthPreference(ctx, ap)
-	c.Assert(err, IsNil)
+		{
+			name: "with u2f",
+			getAuthPreference: func() types.AuthPreference {
+				ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
+					Type:         constants.Local,
+					SecondFactor: constants.SecondFactorU2F,
+					U2F: &types.U2F{
+						AppID:  "https://localhost",
+						Facets: []string{"https://localhost"},
+					},
+					RequireSessionMFA: true,
+				})
+				require.NoError(t, err)
 
-	clt, err := s.server.NewClient(auth.TestUser("llama"))
-	c.Assert(err, IsNil)
-	u2fDev, err := auth.RegisterTestDevice(ctx, clt, "u2f", apiProto.DeviceType_DEVICE_TYPE_U2F, nil /* authenticator */)
-	c.Assert(err, IsNil)
+				return ap
+			},
+			registerDevice: func() *auth.TestDevice {
+				u2fDev, err := auth.RegisterTestDevice(ctx, clt, "u2f", apiProto.DeviceType_DEVICE_TYPE_U2F, nil /* authenticator */)
+				require.NoError(t, err)
 
-	// Open a terminal to a new session.
-	sid := session.NewID()
-	ws, err := s.makeTerminal(pack1, sid)
-	c.Assert(err, IsNil)
-	defer ws.Close()
+				return u2fDev
+			},
+			getChallengeResponseBytes: func(chals *auth.MFAAuthenticateChallenge, dev *auth.TestDevice) []byte {
+				res, err := dev.SolveAuthn(&apiProto.MFAAuthenticateChallenge{
+					U2F: []*apiProto.U2FChallenge{{
+						KeyHandle: chals.U2FChallenges[0].KeyHandle,
+						Challenge: chals.U2FChallenges[0].Challenge,
+						AppID:     chals.U2FChallenges[0].AppID,
+						Version:   chals.U2FChallenges[0].Version,
+					}},
+				})
+				require.NoError(t, err)
 
-	// Wait for websocket u2f challenge event.
-	payload, err := s.waitForMFAPromptEvent(ws, 5*time.Second)
-	c.Assert(err, IsNil)
-	chals := &auth.MFAAuthenticateChallenge{}
-	c.Assert(json.Unmarshal([]byte(payload), &chals), IsNil)
+				u2fResBytes, err := json.Marshal(&u2f.AuthenticateChallengeResponse{
+					KeyHandle:     res.GetU2F().KeyHandle,
+					SignatureData: res.GetU2F().Signature,
+					ClientData:    res.GetU2F().ClientData,
+				})
+				require.NoError(t, err)
 
-	res, err := u2fDev.SolveAuthn(&apiProto.MFAAuthenticateChallenge{
-		U2F: []*apiProto.U2FChallenge{{
-			KeyHandle: chals.U2FChallenges[0].KeyHandle,
-			Challenge: chals.U2FChallenges[0].Challenge,
-			AppID:     chals.U2FChallenges[0].AppID,
-			Version:   chals.U2FChallenges[0].Version,
-		}},
-	})
-	c.Assert(err, IsNil)
-
-	// Send response over ws.
-	u2fResBytes, err := json.Marshal(&u2f.AuthenticateChallengeResponse{
-		KeyHandle:     res.GetU2F().KeyHandle,
-		SignatureData: res.GetU2F().Signature,
-		ClientData:    res.GetU2F().ClientData,
-	})
-	c.Assert(err, IsNil)
-
-	termHandler := newTerminalHandler()
-	_, err = termHandler.write(u2fResBytes, ws)
-	c.Assert(err, IsNil)
-
-	// Test we can write.
-	stream := termHandler.asTerminalStream(ws)
-	_, err = io.WriteString(stream, "echo alpacas\r\n")
-	c.Assert(err, IsNil)
-	c.Assert(waitForOutput(stream, "alpacas"), IsNil)
-}
-
-func (s *WebSuite) TestTerminalRequireSessionMfa_WithWebAuthn(c *C) {
-	ctx := context.Background()
-	pack1 := s.authPack(c, "llama")
-
-	// Enable require session mfa.
-	ap, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{
-		Type:         constants.Local,
-		SecondFactor: constants.SecondFactorWebauthn,
-		U2F: &types.U2F{
-			AppID:  "https://localhost",
-			Facets: []string{"https://localhost"},
+				return u2fResBytes
+			},
 		},
-		RequireSessionMFA: true,
-	})
-	c.Assert(err, IsNil)
-	err = s.server.Auth().SetAuthPreference(ctx, ap)
-	c.Assert(err, IsNil)
+	}
 
-	clt, err := s.server.NewClient(auth.TestUser("llama"))
-	c.Assert(err, IsNil)
-	webautnDev, err := auth.RegisterTestDevice(ctx, clt, "webauthn", apiProto.DeviceType_DEVICE_TYPE_WEBAUTHN, nil /* authenticator */)
-	c.Assert(err, IsNil)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err = env.server.Auth().SetAuthPreference(ctx, tc.getAuthPreference())
+			require.NoError(t, err)
 
-	// Open a terminal to a new session.
-	sid := session.NewID()
-	ws, err := s.makeTerminal(pack1, sid)
-	c.Assert(err, IsNil)
-	defer ws.Close()
+			dev := tc.registerDevice()
 
-	// Wait for websocket webauthn challenge event.
-	payload, err := s.waitForMFAPromptEvent(ws, 5*time.Second)
-	c.Assert(err, IsNil)
-	chals := &auth.MFAAuthenticateChallenge{}
-	c.Assert(json.Unmarshal([]byte(payload), &chals), IsNil)
+			// Open a terminal to a new session.
+			ws := proxy.makeTerminal(t, pack, session.NewID())
 
-	res, err := webautnDev.SolveAuthn(&apiProto.MFAAuthenticateChallenge{
-		WebauthnChallenge: wanlib.CredentialAssertionToProto(chals.WebauthnChallenge),
-	})
-	c.Assert(err, IsNil)
-
-	// Send response over ws.
-	u2fResBytes, err := json.Marshal(wanlib.CredentialAssertionResponseFromProto(res.GetWebauthn()))
-	c.Assert(err, IsNil)
-
-	termHandler := newTerminalHandler()
-	_, err = termHandler.write(u2fResBytes, ws)
-	c.Assert(err, IsNil)
-
-	// Test we can write.
-	stream := termHandler.asTerminalStream(ws)
-	_, err = io.WriteString(stream, "echo alpacas\r\n")
-	c.Assert(err, IsNil)
-	c.Assert(waitForOutput(stream, "alpacas"), IsNil)
-}
-
-type waitForMFAPromptResult struct {
-	err error
-	env Envelope
-}
-
-func (s *WebSuite) waitForMFAPromptEvent(ws *websocket.Conn, timeout time.Duration) (string, error) {
-	timeoutContext, timeoutCancel := context.WithTimeout(context.Background(), timeout)
-	defer timeoutCancel()
-
-	done := make(chan waitForMFAPromptResult, 1)
-
-	go func() {
-		for {
+			// Wait for websocket authn challenge event.
 			var raw []byte
-			res := waitForMFAPromptResult{}
-			if err := websocket.Message.Receive(ws, &raw); err != nil {
-				res.err = trace.Wrap(err)
-				done <- res
-				return
-			}
+			require.Nil(t, websocket.Message.Receive(ws, &raw))
+			var env Envelope
+			require.Nil(t, proto.Unmarshal(raw, &env))
 
-			if err := proto.Unmarshal(raw, &res.env); err != nil {
-				res.err = trace.Wrap(err)
-				done <- res
-				return
-			}
+			chals := &auth.MFAAuthenticateChallenge{}
+			require.Nil(t, json.Unmarshal([]byte(env.Payload), &chals))
 
-			if res.env.GetType() == defaults.WebsocketU2FChallenge || res.env.GetType() == defaults.WebsocketWebAuthnChallenge {
-				done <- res
-				return
-			}
-		}
-	}()
+			// Send response over ws.
+			termHandler := newTerminalHandler()
+			_, err := termHandler.write(tc.getChallengeResponseBytes(chals, dev), ws)
+			require.Nil(t, err)
 
-	for {
-		select {
-		case <-timeoutContext.Done():
-			return "", trace.BadParameter("timeout waiting for mfa prompt event")
-		case res := <-done:
-			return res.env.Payload, trace.Wrap(res.err)
-		}
+			// Test we can write.
+			stream := termHandler.asTerminalStream(ws)
+			_, err = io.WriteString(stream, "echo alpacas\r\n")
+			require.Nil(t, err)
+			require.Nil(t, waitForOutput(stream, "alpacas"))
+
+			require.Nil(t, ws.Close())
+		})
 	}
 }
 

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -34,6 +34,8 @@ import (
 	"github.com/gravitational/teleport"
 	authproto "github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/u2f"
 	"github.com/gravitational/teleport/lib/client"
@@ -336,29 +338,35 @@ func (t *TerminalHandler) issueSessionMFACerts(tc *client.TeleportClient, ws *we
 
 func (t *TerminalHandler) promptMFAChallenge(ws *websocket.Conn) client.PromptMFAChallengeHandler {
 	return func(ctx context.Context, proxyAddr string, c *authproto.MFAAuthenticateChallenge) (*authproto.MFAAuthenticateResponse, error) {
-		if len(c.U2F) == 0 {
-			return nil, trace.AccessDenied("only U2F challenges are supported on the web terminal, please register a U2F device using 'tsh mfa add' to connect to this server")
+		if len(c.U2F) == 0 && c.GetWebauthnChallenge() == nil {
+			return nil, trace.AccessDenied("only hardware keys are supported on the web terminal, please register a hardware device to connect to this server")
 		}
 
+		var chal *auth.MFAAuthenticateChallenge
+		var envelopeType string
+
 		// Convert from proto to JSON types.
-		u2fChals := make([]u2f.AuthenticateChallenge, 0, len(c.U2F))
-		for _, uc := range c.U2F {
-			u2fChals = append(u2fChals, u2f.AuthenticateChallenge{
-				Version:   uc.Version,
-				Challenge: uc.Challenge,
-				KeyHandle: uc.KeyHandle,
-				AppID:     uc.AppID,
-			})
-		}
-		chal := &auth.MFAAuthenticateChallenge{
-			AuthenticateChallenge: &u2f.AuthenticateChallenge{
-				// Get the common challenge fields from the first item.
-				// All of these fields should be identical for all u2fChals.
-				Challenge: u2fChals[0].Challenge,
-				AppID:     u2fChals[0].AppID,
-				Version:   u2fChals[0].Version,
-			},
-			U2FChallenges: u2fChals,
+		switch {
+		// Webauthn takes precedence.
+		case c.GetWebauthnChallenge() != nil:
+			envelopeType = defaults.WebsocketWebAuthnChallenge
+			chal = &auth.MFAAuthenticateChallenge{
+				WebauthnChallenge: wanlib.CredentialAssertionFromProto(c.WebauthnChallenge),
+			}
+		default:
+			u2fChals := make([]u2f.AuthenticateChallenge, 0, len(c.U2F))
+			envelopeType = defaults.WebsocketU2FChallenge
+			for _, uc := range c.U2F {
+				u2fChals = append(u2fChals, u2f.AuthenticateChallenge{
+					Version:   uc.Version,
+					Challenge: uc.Challenge,
+					KeyHandle: uc.KeyHandle,
+					AppID:     uc.AppID,
+				})
+			}
+			chal = &auth.MFAAuthenticateChallenge{
+				U2FChallenges: u2fChals,
+			}
 		}
 
 		// Send the challenge over the socket.
@@ -368,7 +376,7 @@ func (t *TerminalHandler) promptMFAChallenge(ws *websocket.Conn) client.PromptMF
 		}
 		envelope := &Envelope{
 			Version: defaults.WebsocketVersion,
-			Type:    defaults.WebsocketU2FChallenge,
+			Type:    envelopeType,
 			Payload: string(chalEnc),
 		}
 		envelopeBytes, err := proto.Marshal(envelope)
@@ -390,20 +398,39 @@ func (t *TerminalHandler) promptMFAChallenge(ws *websocket.Conn) client.PromptMF
 		if err = proto.Unmarshal(bytes, envelope); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		var resp u2f.AuthenticateChallengeResponse
-		if err := json.Unmarshal([]byte(envelope.Payload), &resp); err != nil {
-			return nil, trace.Wrap(err)
-		}
+
+		var mfaResponse *authproto.MFAAuthenticateResponse
+
 		// Convert from JSON to proto.
-		return &authproto.MFAAuthenticateResponse{
-			Response: &authproto.MFAAuthenticateResponse_U2F{
-				U2F: &authproto.U2FResponse{
-					KeyHandle:  resp.KeyHandle,
-					ClientData: resp.ClientData,
-					Signature:  resp.SignatureData,
+		switch envelopeType {
+		case defaults.WebsocketWebAuthnChallenge:
+			var webauthnResponse wanlib.CredentialAssertionResponse
+			if err := json.Unmarshal([]byte(envelope.Payload), &webauthnResponse); err != nil {
+				return nil, trace.Wrap(err)
+			}
+			mfaResponse = &authproto.MFAAuthenticateResponse{
+				Response: &authproto.MFAAuthenticateResponse_Webauthn{
+					Webauthn: wanlib.CredentialAssertionResponseToProto(&webauthnResponse),
 				},
-			},
-		}, nil
+			}
+
+		default:
+			var u2fResponse u2f.AuthenticateChallengeResponse
+			if err := json.Unmarshal([]byte(envelope.Payload), &u2fResponse); err != nil {
+				return nil, trace.Wrap(err)
+			}
+			mfaResponse = &authproto.MFAAuthenticateResponse{
+				Response: &authproto.MFAAuthenticateResponse_U2F{
+					U2F: &authproto.U2FResponse{
+						KeyHandle:  u2fResponse.KeyHandle,
+						ClientData: u2fResponse.ClientData,
+						Signature:  u2fResponse.SignatureData,
+					},
+				},
+			}
+		}
+
+		return mfaResponse, nil
 	}
 }
 


### PR DESCRIPTION
#### Description
Allow users to use webauthn when prompted to re-auth with their mfa from web terminal when `require_session_mfa` is enabled