### PR TITLE
Fix MySQL log spam

### DIFF
--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -195,7 +195,7 @@ func (s *ProxyServer) ServeMySQL(listener net.Listener) error {
 		go func() {
 			defer clientConn.Close()
 			err := s.MySQLProxy().HandleConnection(s.closeCtx, clientConn)
-			if err != nil {
+			if err != nil && !utils.IsOKNetworkError(err) {
 				s.log.WithError(err).Error("Failed to handle MySQL client connection.")
 			}
 		}()


### PR DESCRIPTION
Prevent load balancer health checks on MySQL proxy port from spamming the logs. Closes https://github.com/gravitational/teleport/issues/8433.