### PR TITLE
Ensure that teleport start --roles=windowsdesktop works

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1786,7 +1786,7 @@ func replaceHost(addr *utils.NetAddr, newHost string) {
 	addr.Addr = net.JoinHostPort(newHost, port)
 }
 
-// validateRoles makes sure that value upassed to --roles flag is valid
+// validateRoles makes sure that value passed to the --roles flag is valid
 func validateRoles(roles string) error {
 	for _, role := range splitRoles(roles) {
 		switch role {
@@ -1794,8 +1794,8 @@ func validateRoles(roles string) error {
 			defaults.RoleNode,
 			defaults.RoleProxy,
 			defaults.RoleApp,
-			defaults.RoleDatabase:
-			break
+			defaults.RoleDatabase,
+			defaults.RoleWindowsDesktop:
 		default:
 			return trace.Errorf("unknown role: '%s'", role)
 		}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -464,6 +464,8 @@ const (
 	RoleApp = "app"
 	// RoleDatabase is a database proxy role.
 	RoleDatabase = "db"
+	// RoleWindowsDesktop is a Windows desktop service.
+	RoleWindowsDesktop = "windowsdesktop"
 )
 
 const (


### PR DESCRIPTION
Looks like this validation just got missed in one of the early
desktop access PRs. This enables behavior that is consistent
with our current docs and the message printed by tctl.