### PR TITLE
Desktop Access Fixes

### DIFF
--- a/lib/auth/permissions.go
+++ b/lib/auth/permissions.go
@@ -581,10 +581,11 @@ func GetCheckerForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					MaxSessionTTL: types.MaxDuration(),
 				},
 				Allow: types.RoleConditions{
-					Namespaces:    []string{types.Wildcard},
-					Logins:        []string{},
-					NodeLabels:    types.Labels{types.Wildcard: []string{types.Wildcard}},
-					ClusterLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+					Namespaces:           []string{types.Wildcard},
+					Logins:               []string{},
+					NodeLabels:           types.Labels{types.Wildcard: []string{types.Wildcard}},
+					ClusterLabels:        types.Labels{types.Wildcard: []string{types.Wildcard}},
+					WindowsDesktopLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
 					Rules: []types.Rule{
 						types.NewRule(types.Wildcard, services.RW()),
 					},

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
-	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
@@ -431,10 +430,11 @@ func (s *WindowsService) startDiscoveredHostHeartbeats() error {
 // dynamicHostHeartbeatInfo generates the Windows Desktop resource
 // for heartbeating hosts discovered via LDAP
 func (s *WindowsService) dynamicHostHeartbeatInfo(ctx context.Context, entry *ldap.Entry, getHostLabels func(string) map[string]string) (types.Resource, error) {
-	hostname := entry.GetAttributeValue("dNSHostName")
+	name := entry.GetAttributeValue(attrName)
+	hostname := entry.GetAttributeValue(attrDNSHostName)
 
 	labels := getHostLabels(hostname)
-	labels["teleport.dev/computer_name"] = entry.GetAttributeValue(attrName)
+	labels["teleport.dev/computer_name"] = name
 	labels["teleport.dev/dns_host_name"] = hostname
 	labels["teleport.dev/os"] = entry.GetAttributeValue(attrOS)
 	labels["teleport.dev/os_version"] = entry.GetAttributeValue(attrOSVersion)
@@ -446,14 +446,14 @@ func (s *WindowsService) dynamicHostHeartbeatInfo(ctx context.Context, entry *ld
 		return nil, trace.WrapWithMessage(err, "couldn't resolve %q", hostname)
 	}
 
-	s.cfg.Log.Debugf("resolved %v => %v", hostname, addrs[0])
+	s.cfg.Log.Debugf("resolved %v => %v", hostname, addrs)
 	addr, err := utils.ParseHostPortAddr(addrs[0], defaults.RDPListenPort)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return types.NewWindowsDesktopV3(
-		entry.GetAttributeValue("name"),
+		hostname,
 		labels,
 		types.WindowsDesktopSpecV3{
 			Addr:   addr.String(),
@@ -721,7 +721,14 @@ func (s *WindowsService) nameForStaticHost(addr string) (string, error) {
 			return d.GetName(), nil
 		}
 	}
-	return uuid.New().String(), nil
+
+	host, _, err := utils.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	parts := strings.Split(s.cfg.Heartbeat.HostUUID, "-")
+	suffix := parts[len(parts)-1]
+	return "static-" + strings.ReplaceAll(host, ".", "-") + "-" + suffix, nil
 }
 
 func (s *WindowsService) updateCA(ctx context.Context) error {


### PR DESCRIPTION
This PR includes a few fixes/improvements for desktop access:

1. Ensure the admin system role has access to Windows Desktops. While not strictly required, it's nice to be able to delete a desktop before waiting for it to time out.
2.  Ensure that desktops which are automatically discovered have an expiration. Prior to this they would stay in the backend forever and not time out, even if the Windows Desktop Service stops heartbeating.
3. Instead of using a UUID for naming static hosts, which means nothing to the end user, derive the name from a combination of: a `static-` prefix, the host's `addr`, and the `HostUUID` of the Windows Desktop Service reporting the host. This scheme ensures uniqueness, fixes a potential consistency issue where multiple Windows desktop services report the same host with different names, and conveys some extra information that may be useful for troubleshooting.