### PR TITLE
Align SNI routing logic

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3255,7 +3255,6 @@ func setupALPNRouter(listeners *proxyListeners, serverTLSConf *tls.Config, cfg *
 			MatchFunc: alpnproxy.MatchByProtocol(
 				alpncommon.ProtocolHTTP,
 				alpncommon.ProtocolHTTP2,
-				alpncommon.ProtocolAWSCLI,
 				acme.ALPNProto,
 			),
 			Handler:    webWrapper.HandleConnection,

--- a/lib/srv/alpnproxy/common/protocols.go
+++ b/lib/srv/alpnproxy/common/protocols.go
@@ -48,9 +48,6 @@ const (
 
 	// ProtocolAuth allows dialing local/remote auth service based on SNI cluster name value.
 	ProtocolAuth Protocol = "teleport-auth@"
-
-	// ProtocolAWSCLI allows accessing the AWS API by AWS CLI.
-	ProtocolAWSCLI = "teleport-aws-cli"
 )
 
 // SupportedProtocols is the list of supported ALPN protocols.

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -107,7 +107,7 @@ func createAWSAccessProxySuite(t *testing.T, cred *credentials.Credentials) *Loc
 	lp, err := NewLocalProxy(LocalProxyConfig{
 		Listener:           listener,
 		RemoteProxyAddr:    hs.Listener.Addr().String(),
-		Protocol:           common.ProtocolAWSCLI,
+		Protocol:           common.ProtocolHTTP,
 		ParentContext:      context.Background(),
 		InsecureSkipVerify: true,
 		AWSCredentials:     cred,

--- a/lib/srv/alpnproxy/proxy_test.go
+++ b/lib/srv/alpnproxy/proxy_test.go
@@ -305,19 +305,6 @@ func TestProxyALPNProtocolsRouting(t *testing.T) {
 			ClientNextProtos:    nil,
 			wantProtocolHandler: string(common.ProtocolHTTP),
 		},
-		{
-			name: "all client protocols are unsupported - default http handler should be called",
-			handlers: []HandlerDecs{
-				makeHandler(common.ProtocolHTTP),
-				makeHandler(common.ProtocolProxySSH),
-			},
-			ClientNextProtos: []string{
-				"unknown-protocol1",
-				"unknown-protocol2",
-				"unknown-protocol3",
-			},
-			wantProtocolHandler: string(common.ProtocolHTTP),
-		},
 	}
 
 	for _, tc := range tests {

--- a/tool/tsh/aws.go
+++ b/tool/tsh/aws.go
@@ -155,7 +155,7 @@ func createLocalAWSCLIProxy(cf *CLIConf, tc *client.TeleportClient, cred *creden
 	lp, err := alpnproxy.NewLocalProxy(alpnproxy.LocalProxyConfig{
 		Listener:           listener,
 		RemoteProxyAddr:    tc.WebProxyAddr,
-		Protocol:           alpncommon.ProtocolAWSCLI,
+		Protocol:           alpncommon.ProtocolHTTP,
 		InsecureSkipVerify: cf.InsecureSkipVerify,
 		ParentContext:      cf.Context,
 		SNI:                address.Host(),


### PR DESCRIPTION
## What 

 * go1.17 introduced `TLS strict ALPN`  https://golang.org/doc/go1.17#ALPN and broke current routing logic. 
Previously if client protocol was not supported by ALPN router the default http handler was used. 
After `TLS strict ALPN` alignment if client protocol is unknown the TLS handshake will fail with the ` client requested unsupported application protocols` thus fallback to http protocol won't work anymore. 


* replaced ProtocolAWSCLI with HTTP protocol in AWS CLI app access flow (AWS CLI access is handler by WebHandler thus `ProtocolAWSCLI` protocol was redundant and handler by proxy web application handler)   
