### PR TITLE
Make LDAP desktop discovery disabled by default

### DIFF
--- a/docs/pages/desktop-access/reference.mdx
+++ b/docs/pages/desktop-access/reference.mdx
@@ -48,6 +48,12 @@ windows_desktop_service:
     # Plain text file containing the LDAP password for authentication.
     # This is usually the same password you use to login to the Domain Controller.
     password_file: /var/lib/ldap-pass
+  # (optional) settings for enabling automatic desktop discovery via LDAP
+  discovery:
+    # currently supported values:
+    # '*' to search from the root of the domain
+    # ''  to disable desktop discovery
+    base_dn: '*'
   # Rules for applying labels to Windows hosts based on regular expressions
   # matched against the host name. If multiple rules match, the desktop will
   # get the union of all matching labels.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -36,6 +36,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
+	"github.com/go-ldap/ldap/v3"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
@@ -1183,6 +1184,14 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *service.Config) error {
 		}
 		cfg.WindowsDesktop.ListenAddr = *listenAddr
 	}
+
+	for _, filter := range fc.WindowsDesktop.Discovery.Filters {
+		if _, err := ldap.CompileFilter(ldap.EscapeFilter(filter)); err != nil {
+			return trace.BadParameter("WindowsDesktopService specifies invalid LDAP filter %q", filter)
+		}
+	}
+	cfg.WindowsDesktop.Discovery = fc.WindowsDesktop.Discovery
+
 	var err error
 	cfg.WindowsDesktop.PublicAddrs, err = utils.AddrsFromStrings(fc.WindowsDesktop.PublicAddr, defaults.WindowsDesktopListenPort)
 	if err != nil {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1089,6 +1089,7 @@ func makeConfigFixture() string {
 		},
 	}
 
+	// Windows Desktop Service
 	conf.WindowsDesktop = WindowsDesktopService{
 		Service: Service{
 			EnabledFlag:   "yes",

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1314,6 +1314,8 @@ type WindowsDesktopService struct {
 	PublicAddr apiutils.Strings `yaml:"public_addr,omitempty"`
 	// LDAP is the LDAP connection parameters.
 	LDAP LDAPConfig `yaml:"ldap"`
+	// Discovery configures desktop discovery via LDAP.
+	Discovery service.LDAPDiscoveryConfig `yaml:"discovery,omitempty"`
 	// Hosts is a list of static Windows hosts connected to this service in
 	// gateway mode.
 	Hosts []string `yaml:"hosts,omitempty"`

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -846,6 +846,10 @@ type WindowsDesktopConfig struct {
 	PublicAddrs []utils.NetAddr
 	// LDAP is the LDAP connection parameters.
 	LDAP LDAPConfig
+
+	// Discovery configures automatic desktop discovery via LDAP.
+	Discovery LDAPDiscoveryConfig
+
 	// Hosts is an optional list of static Windows hosts to expose through this
 	// service.
 	Hosts []utils.NetAddr
@@ -853,6 +857,16 @@ type WindowsDesktopConfig struct {
 	ConnLimiter limiter.Config
 	// HostLabels specifies rules that are used to apply labels to Windows hosts.
 	HostLabels HostLabelRules
+}
+
+type LDAPDiscoveryConfig struct {
+	// BaseDN is the base DN to search for desktops.
+	// Use the value '*' to search from the root of the domain,
+	// or leave blank to disable desktop discovery.
+	BaseDN string `yaml:"base_dn"`
+	// Filters are additional LDAP filters to apply to the search.
+	// See: https://ldap.com/ldap-filters/
+	Filters []string `yaml:"filters"`
 }
 
 // HostLabelRules is a collection of rules describing how to apply labels to hosts.

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -227,7 +227,8 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 				}
 			},
 		},
-		LDAPConfig: desktop.LDAPConfig(cfg.WindowsDesktop.LDAP),
+		LDAPConfig:      desktop.LDAPConfig(cfg.WindowsDesktop.LDAP),
+		DiscoveryBaseDN: cfg.WindowsDesktop.Discovery.BaseDN,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/rfd/0034-desktop-access-windows.md
+++ b/rfd/0034-desktop-access-windows.md
@@ -48,11 +48,10 @@ translates the Teleport desktop protocol into RDP:
 It can also talk to `localhost` RDP service, if installed on a Windows machine
 in agent mode (described below).
 
-If configured with Active Directory Domain Controller credentials,
-`windows_desktop_service` also discovers all available Windows hosts from
-Active Directory and registers them in Teleport as `WindowsDesktop` objects.
-Without Domain Controller credentials, `windows_desktop_service` uses a static
-list of Windows hosts provided in `teleport.yaml`.
+`windows_desktop_service` has the ability to automatically discover available
+Windows hosts from Active Directory by performing an LDAP search. In addition,
+`windows_desktop_service` can use a static list of Windows hosts provided in
+`teleport.yaml`.
 
 ### Supported versions
 
@@ -182,12 +181,16 @@ connect to. Internally, Teleport tracks known Windows hosts using
 
 There are 3 ways that `windows_desktop_service` discovers Windows hosts to
 register:
-- hardcoded list of standalone hosts provided in the config file (see
+- hardcoded list of hosts provided in the config file (see
   [configuration](#configuration))
 - list of Active Directory-enrolled hosts obtained from AD via LDAPS (LDAP over
   SSL)
   - LDAP library: https://pkg.go.dev/github.com/go-ldap/ldap/v3
 - local host, when running on a Windows machine in agent mode
+
+By default, Teleport will only register hosts that are provided in the
+configuration file. To enable host discovery over LDAP, additional configuration
+is necessary (see [configuration](#configuration)).
 
 #### Automatic Host Labels
 
@@ -243,6 +246,12 @@ windows_desktop_service:
   - win1.example.com
   - win2.example.com
   - ...
+  # (optional) settings for enabling automatic desktop discovery via LDAP
+  discovery:
+    base_dn: '*' # wildcard searches from the root, leave empty to disable discovery
+    filters:  # additional LDAP filters: https://ldap.com/ldap-filters/
+    - filter1 # note: multiple filters are combined into an AND filter
+    - filter2
   # (optional) host_labels applies labels to windows hosts for RBAC.
   # Each entry maps to a subset of hosts by regexp and applies a group of labels.
   # A host can match multiple regexps and will get a union of all the labels.


### PR DESCRIPTION
This is to address https://github.com/gravitational/teleport/pull/8615#issuecomment-948759160

Since our LDAP-based desktop discovery is not very configurable,
we opt to have it disabled by default.

Teleport will log a warning if desktop discovery is disabled and there
are no statically defined Windows desktops. In this case, the Windows
Desktop Service will simply sit idle, as there will be no desktops
available to connect to.

This commit implements the above, but also paves the way towards
a more flexible discovery system (described in the RFD).

We introduce a new config section:

```
    discovery:
      base_dn: '*'
      filters:
      - filter1
      - filter2
```

For now, the only valid value for base_dn is the wildcard, which
instructs Teleport to search from the domain root. Additionally,
teleport will validate that any provided filters are valid but
does not currently respect them when performing the search.

Future updates will allow for changing the base DN to something
more specific and filtering the results with LDAP filters.