### PR TITLE
Add timeout for RDP connections

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -151,8 +151,6 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 	return c, nil
 }
 
-// TODO(zmb3): allow passing a ctx or otherwise configuring a timeout here
-// (if we cannot route to the host this will hang indefinitely)
 func (c *Client) readClientUsername() error {
 	for {
 		msg, err := c.cfg.InputMessage()


### PR DESCRIPTION
Since the connection is made from Rust, we just hard code a
5-second connection timeout.

In a future change we can decide if we want to pass a timeout down
from Go, but for now this should improve the user experience.