### PR TITLE
Clear terminal on session termination in FIPS mode

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -150,6 +150,9 @@ func newSession(client *NodeClient,
 
 		<-ns.closer.C
 		ns.terminal.Close()
+		if isFIPS() {
+			ns.ClearTerminal()
+		}
 	}()
 
 	return ns, nil
@@ -633,4 +636,12 @@ func (ns *NodeSession) Close() error {
 		ns.closeWait.Wait()
 	}
 	return nil
+}
+
+func (ns *NodeSession) ClearTerminal() {
+	const resetPattern = "\x1b[3J\x1b\x63\n" // clear scrollback and current screen
+
+	if _, err := ns.terminal.Stdout().Write([]byte(resetPattern)); err != nil {
+		log.Debugf("Failed to clear screen: %v.", err)
+	}
 }


### PR DESCRIPTION
### Purpose
In FIPS mode content of the terminal should be cleared when session ends. Fixes #6107 

### Implementation
The command is sent to the terminal which clears scrollback and the current screen