### PR TITLE
[v6] fix packer version & bump patch.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3773,7 +3773,7 @@ steps:
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/src/github.com/gravitational/teleport/assets/aws/files
 
   - name: Build OSS AMIs
-    image: hashicorp/packer
+    image: hashicorp/packer:1.7.6
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_PACKER_ACCESS_KEY_ID
@@ -3876,7 +3876,7 @@ steps:
       - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/src/github.com/gravitational/teleport/assets/aws/files
 
   - name: Build Enterprise AMIs
-    image: hashicorp/packer
+    image: hashicorp/packer:1.7.6
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: AWS_PACKER_ACCESS_KEY_ID
@@ -4367,6 +4367,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 4a3df7fd7a3d608a741d11981e4fb7bcfb558630e4d90aef713837510160c365
+hmac: 3ba76e3c07bd461f609320f396cca4e3bea86fdf90bfbd60f0c264ae9e4ebe2f
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=6.2.16
+VERSION=6.2.17
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: "6.2.16"
-appVersion: "6.2.16"
+version: "6.2.17"
+appVersion: "6.2.17"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "6.2.16"
-appVersion: "6.2.16"
+version: "6.2.17"
+appVersion: "6.2.17"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "6.2.16"
+	Version = "6.2.17"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Release automation is unchanged, but packer is now failing since new version came out.  Updated drone to explicitly pull down packer `v1.4`, as indicated by `assets/aws/README.md` and bumped patch version so that we have a new release target.  If this fixes the issue, I'll port the change forward.