### PR TITLE
Clean Rust libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,8 @@ clean:
 	rm -rf $(BUILDDIR)
 	rm -rf $(ER_BPF_BUILDDIR)
 	rm -rf $(RS_BPF_BUILDDIR)
+	rm -rf lib/srv/desktop/rdp/rdpclient/target
+	rm -rf lib/datalog/roletester/target
 	-go clean -cache
 	rm -rf teleport
 	rm -rf *.gz


### PR DESCRIPTION
The clean target currently leaves behind the Rust libraries for the rolechecker and RDP client. Fix that, and update the `e` submodule to pick up the same fixes there as well.