### PR TITLE
(v8) URL-encode Postgres username in connection string

### DIFF
--- a/lib/client/db/postgres/connstring.go
+++ b/lib/client/db/postgres/connstring.go
@@ -19,6 +19,7 @@ package postgres
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -29,7 +30,10 @@ import (
 func GetConnString(c profile.ConnectProfile) string {
 	connStr := "postgres://"
 	if c.User != "" {
-		connStr += c.User + "@"
+		// Username may contain special characters in which case it should
+		// be percent-encoded. For example, when connecting to a Postgres
+		// instance on GCP user looks like "name@project-id.iam".
+		connStr += url.QueryEscape(c.User) + "@"
 	}
 	connStr += net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
 	if c.Database != "" {

--- a/lib/client/db/postgres/connstring_test.go
+++ b/lib/client/db/postgres/connstring_test.go
@@ -56,6 +56,11 @@ func TestConnString(t *testing.T) {
 			out:  "postgres://alice@localhost:5432?sslrootcert=/tmp/ca&sslcert=/tmp/cert&sslkey=/tmp/key&sslmode=verify-full",
 		},
 		{
+			name: "user with special characters",
+			user: "postgres@google-project-id.iam",
+			out:  "postgres://postgres%40google-project-id.iam@localhost:5432?sslrootcert=/tmp/ca&sslcert=/tmp/cert&sslkey=/tmp/key&sslmode=verify-full",
+		},
+		{
 			name:     "database set",
 			database: "test",
 			out:      "postgres://localhost:5432/test?sslrootcert=/tmp/ca&sslcert=/tmp/cert&sslkey=/tmp/key&sslmode=verify-full",


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/8771 backport.