### PR TITLE
[v7] Add link to Teleport Changelog in helm chart repository site.

### DIFF
--- a/examples/chart/index.html
+++ b/examples/chart/index.html
@@ -31,5 +31,7 @@
         --set proxyAddr=${PROXY_ENDPOINT?} \
         --set authToken=${JOIN_TOKEN?} \
         --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?}</pre>
+    <h3>Changelog</h3>
+    <pre>See the <a href="https://goteleport.com/docs/changelog/">Teleport Changelog</a> for a list of important changes between Helm chart versions.</pre>
   </body>
 </html>


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/8734