### PR TITLE
Update rdp-rs to fix horizontal scroll + extended keys

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -21,5 +21,5 @@ num-traits = "0.2"
 # RustCrypto doesn't expose the low-level primitives we need for the smartcard
 # challenge signing (see src/piv.rs for details).
 openssl = { version = "0.10.36", features = ["vendored"] }
-rdp-rs = { git = "https://github.com/gravitational/rdp-rs", rev = "3bf61e5354218516b72156b4b0708aa05ecc86f2" }
+rdp-rs = { git = "https://github.com/gravitational/rdp-rs", rev = "755e950dcff0fc6965aa518c4596b995ede3417d" }
 uuid = { version = "0.8", features = ["v4"] }


### PR DESCRIPTION
This pulls in the fixes from gravitational/rdp-rs#4

Updates #8742

Backport to v8 required.