### PR TITLE
Install Go and Rust per-build for macOS

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -817,10 +817,37 @@ steps:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
     WORKSPACE_DIR: /tmp/push-build-darwin-amd64
+- name: Install Go Toolchain
+  commands:
+  - set -u
+  - mkdir -p ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
+  - curl --silent -O https://dl.google.com/go/$RUNTIME.darwin-amd64.tar.gz
+  - tar -C  ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains -xzf $RUNTIME.darwin-amd64.tar.gz
+  - rm -rf $RUNTIME.darwin-amd64.tar.gz
+  environment:
+    RUNTIME: go1.17.2
+- name: Install Rust Toolchain
+  commands:
+  - set -u
+  - export PATH=/Users/build/.cargo/bin:$PATH
+  - mkdir -p ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
+  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
+    | cut -d= -f2)
+  - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
+  - export RUST_HOME=$CARGO_HOME
+  - rustup toolchain install $RUST_VERSION
+  environment:
+    WORKSPACE_DIR: /tmp/push-build-darwin-amd64
 - name: Build Mac artifacts
   commands:
   - set -u
+  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
+    | cut -d= -f2)
+  - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
+  - export RUST_HOME=$CARGO_HOME
+  - export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
+  - rustup override set $RUST_VERSION
   - make clean release OS=$OS ARCH=$ARCH
   environment:
     ARCH: amd64
@@ -828,6 +855,24 @@ steps:
     GOPATH: /tmp/push-build-darwin-amd64/go
     OS: darwin
     WORKSPACE_DIR: /tmp/push-build-darwin-amd64
+- name: Clean up toolchains (post)
+  commands:
+  - set -u
+  - export PATH=/Users/build/.cargo/bin:$PATH
+  - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
+  - export RUST_HOME=$CARGO_HOME
+  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
+    | cut -d= -f2)
+  - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
+  - rustup override unset
+  - rustup toolchain uninstall $RUST_VERSION
+  - rm -rf ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
+  environment:
+    WORKSPACE_DIR: /tmp/push-build-darwin-amd64
+  when:
+    status:
+    - success
+    - failure
 - name: Clean up exec runner storage (post)
   commands:
   - set -u
@@ -2542,7 +2587,13 @@ steps:
 - name: Build Mac release artifacts
   commands:
   - set -u
+  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
+    | cut -d= -f2)
+  - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
+  - export RUST_HOME=$CARGO_HOME
+  - export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
+  - rustup override set $RUST_VERSION
   - make clean release OS=$OS ARCH=$ARCH
   environment:
     ARCH: amd64
@@ -4410,6 +4461,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: d60a86954b258af68b6a03ddee19f5257f97427dd193e1a9ffb2329b2df9bd21
+hmac: e60dc8b2dfa64a222ba26968ddb786c484693cc1061b03b6221eaa0bede46307
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ ifeq ("$(with_rdpclient)", "yes")
 rdpclient:
 	cargo build --manifest-path=lib/srv/desktop/rdp/rdpclient/Cargo.toml --release $(CARGO_TARGET)
 	cargo install cbindgen
-	cbindgen --crate rdp-client --output lib/srv/desktop/rdp/rdpclient/librdprs.h --lang c lib/srv/desktop/rdp/rdpclient/
+	cbindgen --quiet --crate rdp-client --output lib/srv/desktop/rdp/rdpclient/librdprs.h --lang c lib/srv/desktop/rdp/rdpclient/
 else
 .PHONY: rdpclient
 rdpclient:
@@ -632,7 +632,7 @@ $(VERSRC): Makefile
 # Note: any build flags needed to compile go files (such as build tags) should be provided below.
 .PHONY: update-api-module-path
 update-api-module-path:
-	go run build.assets/update_api_module_path/main.go -tags "bpf fips pam roletester desktop_access_beta"
+	go run build.assets/update_api_module_path/main.go -tags "bpf fips pam roletester desktop_access_rdp"
 	$(MAKE) update-vendor
 	$(MAKE) grpc
 

--- a/dronegen/mac.go
+++ b/dronegen/mac.go
@@ -49,6 +49,8 @@ func darwinPushPipeline() pipeline {
 			},
 			Commands: pushCheckoutCommandsDarwin(),
 		},
+		installGoToolchainStep(),
+		installRustToolchainStep(p.Workspace.Path),
 		{
 			Name: "Build Mac artifacts",
 			Environment: map[string]value{
@@ -60,6 +62,7 @@ func darwinPushPipeline() pipeline {
 			},
 			Commands: darwinTagBuildCommands(),
 		},
+		cleanUpToolchainsStep(p.Workspace.Path),
 		cleanUpExecStorageStep(p.Workspace.Path),
 		{
 			Name:        "Send Slack notification (exec)",
@@ -164,6 +167,61 @@ func setUpExecStorageStep(path string) step {
 	}
 }
 
+func installGoToolchainStep() step {
+	return step{
+		Name: "Install Go Toolchain",
+		Environment: map[string]value{
+			"RUNTIME": goRuntime,
+		},
+		Commands: []string{
+			`set -u`,
+			`mkdir -p ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
+			`curl --silent -O https://dl.google.com/go/$RUNTIME.darwin-amd64.tar.gz`,
+			`tar -C  ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains -xzf $RUNTIME.darwin-amd64.tar.gz`,
+			`rm -rf $RUNTIME.darwin-amd64.tar.gz`,
+		},
+	}
+}
+
+func installRustToolchainStep(path string) step {
+	return step{
+		Name:        "Install Rust Toolchain",
+		Environment: map[string]value{"WORKSPACE_DIR": {raw: path}},
+		Commands: []string{
+			`set -u`,
+			`export PATH=/Users/build/.cargo/bin:$PATH`,
+			`mkdir -p ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
+			`export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile | cut -d= -f2)`,
+			`export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
+			`export RUST_HOME=$CARGO_HOME`,
+			`rustup toolchain install $RUST_VERSION`,
+		},
+	}
+}
+
+func cleanUpToolchainsStep(path string) step {
+	return step{
+		Name:        "Clean up toolchains (post)",
+		Environment: map[string]value{"WORKSPACE_DIR": {raw: path}},
+		When: &condition{
+			Status: []string{"success", "failure"},
+		},
+		Commands: []string{
+			`set -u`,
+			`export PATH=/Users/build/.cargo/bin:$PATH`,
+			`export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
+			`export RUST_HOME=$CARGO_HOME`,
+			`export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile | cut -d= -f2)`,
+			`cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport`,
+			// clean up the rust toolchain even though we're about to delete the directory
+			// this ensures we don't leave behind a broken link
+			`rustup override unset`,
+			`rustup toolchain uninstall $RUST_VERSION`,
+			`rm -rf ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
+		},
+	}
+}
+
 func cleanUpExecStorageStep(path string) step {
 	return step{
 		Name:        "Clean up exec runner storage (post)",
@@ -187,7 +245,12 @@ func darwinTagCheckoutCommands() []string {
 func darwinTagBuildCommands() []string {
 	return []string{
 		`set -u`,
+		`export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile | cut -d= -f2)`,
+		`export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
+		`export RUST_HOME=$CARGO_HOME`,
+		`export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH`,
 		`cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport`,
+		`rustup override set $RUST_VERSION`,
 		`make clean release OS=$OS ARCH=$ARCH`,
 	}
 }


### PR DESCRIPTION
This makes the same changes as gravitational/teleport.e#346, but since this drone file is auto generated it includes updates to the dronegen tool to produce the correct output.