### PR TITLE
[helm] Change path -> mountPath under extraVolumeMounts

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -899,7 +899,7 @@ mounts will also be mounted into any `initContainers` configured by the chart.
   ```yaml
   extraVolumeMounts:
   - name: myvolume
-    path: /path/to/mount/volume
+    mountPath: /path/to/mount/volume
   ```
   </TabItem>
   <TabItem label="--set">
@@ -1979,7 +1979,7 @@ mounts will also be mounted into any `initContainers` configured by the chart.
   ```yaml
   extraVolumeMounts:
   - name: myvolume
-    path: /path/to/mount/volume
+    mountPath: /path/to/mount/volume
   ```
   </TabItem>
   <TabItem label="--set">

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -195,7 +195,7 @@ extraVolumes: []
 # Extra volume mounts corresponding to the volumes mounted above
 extraVolumeMounts: []
 #- name: myvolume
-#  path: /path/on/host
+#  mountPath: /path/on/host
 
 # Allow the imagePullPolicy to be overridden
 imagePullPolicy: IfNotPresent

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -141,7 +141,7 @@ extraVolumes: []
 # Extra volume mounts corresponding to the volumes mounted above
 extraVolumeMounts: []
 #- name: myvolume
-#  path: /path/on/host
+#  mountPath: /path/on/host
 
 # Allow the imagePullPolicy to be overridden
 imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Change `path` to `mountPath` to prevent error:
```Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(Deployment.spec.template.spec.containers[0].volumeMounts[3]): unknown field "path" in io.k8s.api.core.v1.VolumeMount, ValidationError(Deployment.spec.template.spec.containers[0].volumeMounts[3]): missing required field "mountPath" in io.k8s.api.core.v1.VolumeMount]```

Backports required:
- `branch/v7`
- `branch/v8`? (depending on docs branch logic)