### PR TITLE
[v6] fix routing_strategy schema and release patch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.18
+
+* Fix type error in config validation when using `routing_strategy` config option.
+
 ## 6.2.16
 
 This release of teleport contains performance improvements and a feature.

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=6.2.17
+VERSION=6.2.18
 
 DOCKER_IMAGE ?= quay.io/gravitational/teleport
 DOCKER_IMAGE_CI ?= quay.io/gravitational/teleport-ci

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-cluster
 apiVersion: v2
-version: "6.2.17"
-appVersion: "6.2.17"
+version: "6.2.18"
+appVersion: "6.2.18"
 description: Teleport is a unified access plane for your infrastructure
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "6.2.17"
-appVersion: "6.2.17"
+version: "6.2.18"
+appVersion: "6.2.18"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/lib/services/clusterconfig.go
+++ b/lib/services/clusterconfig.go
@@ -105,7 +105,7 @@ const ClusterConfigSpecSchemaTemplate = `{
 		"anyOf": [{"type": "string"}, { "type": "boolean"}]
 	  },
 	  "routing_strategy": {
-	  	"type": "string"
+		"type": "number"
 	  },
 	  "audit": {
 		"type": "object",

--- a/lib/services/clusterconfig_test.go
+++ b/lib/services/clusterconfig_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/api/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClusterConfigSchema verifies basic cluster config schema passes.
+func TestClusterConfigSchema(t *testing.T) {
+	cfg := DefaultClusterConfig()
+
+	require.NoError(t, cfg.CheckAndSetDefaults())
+
+	// default strategy is omitted during serialization, so explicitly set a non-zero value.
+	cfg.SetRoutingStrategy(types.RoutingStrategy_MOST_RECENT)
+
+	m, err := MarshalClusterConfig(cfg)
+	require.NoError(t, err)
+
+	_, err = UnmarshalClusterConfig(m)
+	require.NoError(t, err)
+}

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "6.2.17"
+	Version = "6.2.18"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
Fixes incorrect type in JSON schema and release patch.  JSON schema validataion no longer exists in more recent versions of teleport, so this fix only targets v6.