### PR TITLE
Rust & Desktop Access fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -521,7 +521,7 @@ lint: lint-sh lint-helm lint-api lint-go lint-license lint-rdp
 lint-rdp:
 	cd lib/srv/desktop/rdp/rdpclient \
 		&& cargo clippy --locked --all-targets -- -D warnings \
-		&& cargo fmt -- --check 
+		&& cargo fmt -- --check
 
 .PHONY: lint-go
 lint-go: GO_LINT_FLAGS ?=
@@ -590,7 +590,6 @@ ADDLICENSE_ARGS := -c 'Gravitational, Inc' -l apache \
 		-ignore '**/*.html' \
 		-ignore '**/*.js' \
 		-ignore '**/*.py' \
-		-ignore '**/*.rs' \
 		-ignore '**/*.sh' \
 		-ignore '**/*.tf' \
 		-ignore '**/*.yaml' \

--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,7 @@ integration-root:
 .PHONY: lint
 lint: lint-sh lint-helm lint-api lint-go lint-license lint-rdp
 
-.PHONY: lint-gdp
+.PHONY: lint-rdp
 lint-rdp:
 	cd lib/srv/desktop/rdp/rdpclient \
 		&& cargo fmt -- --check \

--- a/Makefile
+++ b/Makefile
@@ -520,9 +520,8 @@ lint: lint-sh lint-helm lint-api lint-go lint-license lint-rdp
 .PHONY: lint-rdp
 lint-rdp:
 	cd lib/srv/desktop/rdp/rdpclient \
-		&& cargo check --locked \
-		&& cargo fmt -- --check \
-		&& cargo clippy --all-targets -- -D warnings
+		&& cargo clippy --locked --all-targets -- -D warnings \
+		&& cargo fmt -- --check 
 
 .PHONY: lint-go
 lint-go: GO_LINT_FLAGS ?=

--- a/Makefile
+++ b/Makefile
@@ -510,12 +510,18 @@ integration-root:
 	$(CGOFLAG) go test -p 4 -run "$(INTEGRATION_ROOT_REGEX)" $(PACKAGES) $(FLAGS)
 
 #
-# Lint the Go code.
+# Lint the source code.
 # By default lint scans the entire repo. Pass GO_LINT_FLAGS='--new' to only scan local
 # changes (or last commit).
 #
 .PHONY: lint
-lint: lint-sh lint-helm lint-api lint-go lint-license
+lint: lint-sh lint-helm lint-api lint-go lint-license lint-rdp
+
+.PHONY: lint-gdp
+lint-rdp:
+	cd lib/srv/desktop/rdp/rdpclient \
+		&& cargo fmt -- --check \
+		&& cargo clippy cargo clippy --all-targets -- -D warnings
 
 .PHONY: lint-go
 lint-go: GO_LINT_FLAGS ?=

--- a/Makefile
+++ b/Makefile
@@ -521,7 +521,7 @@ lint: lint-sh lint-helm lint-api lint-go lint-license lint-rdp
 lint-rdp:
 	cd lib/srv/desktop/rdp/rdpclient \
 		&& cargo fmt -- --check \
-		&& cargo clippy cargo clippy --all-targets -- -D warnings
+		&& cargo clippy --all-targets -- -D warnings
 
 .PHONY: lint-go
 lint-go: GO_LINT_FLAGS ?=

--- a/Makefile
+++ b/Makefile
@@ -520,6 +520,7 @@ lint: lint-sh lint-helm lint-api lint-go lint-license lint-rdp
 .PHONY: lint-rdp
 lint-rdp:
 	cd lib/srv/desktop/rdp/rdpclient \
+		&& cargo check --locked \
 		&& cargo fmt -- --check \
 		&& cargo clippy --all-targets -- -D warnings
 

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -85,8 +85,8 @@ RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home
      PATH=/usr/local/cargo/bin:$PATH \
      RUST_VERSION=1.56.0
 
- COPY --from=rust:1.56.0 /usr/local/rustup /usr/local/rustup
- COPY --from=rust:1.56.0 /usr/local/cargo /usr/local/cargo
+ COPY --from=rust:1.56.1 /usr/local/rustup /usr/local/rustup
+ COPY --from=rust:1.56.1 /usr/local/cargo /usr/local/cargo
  RUN set -eux \
      rustup component add rustfmt clippy; \
      chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \

--- a/lib/datalog/roletester/build.rs
+++ b/lib/datalog/roletester/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::io::Result;
 
 fn main() -> Result<()> {

--- a/lib/datalog/roletester/src/role_tester.rs
+++ b/lib/datalog/roletester/src/role_tester.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use bytes::BytesMut;
 use crepe::crepe;
 use libc::{c_uchar, size_t};

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.lock
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.lock
@@ -124,9 +124,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"
@@ -136,9 +136,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cortex-m"
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "lock_api"
@@ -573,9 +573,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -593,18 +593,18 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-src"
-version = "111.16.0+1.1.1l"
+version = "300.0.2+3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
+checksum = "14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg",
  "cc",
@@ -616,15 +616,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-crate"
@@ -637,18 +637,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "rdp-rs"
 version = "0.1.0"
-source = "git+https://github.com/gravitational/rdp-rs?rev=3bf61e5354218516b72156b4b0708aa05ecc86f2#3bf61e5354218516b72156b4b0708aa05ecc86f2"
+source = "git+https://github.com/gravitational/rdp-rs?rev=755e950dcff0fc6965aa518c4596b995ede3417d#755e950dcff0fc6965aa518c4596b995ede3417d"
 dependencies = [
  "bufstream",
  "byteorder",
@@ -940,9 +940,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
-version = "1.0.77"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -12,14 +12,14 @@ bitflags = "1.3.2"
 byteorder = "1.4.3"
 env_logger = "0.9.0"
 iso7816 = "0.1.0-alpha.1"
-iso7816-tlv = "0.4.1"
-libc = "0.2.98"
+iso7816-tlv = "0.4.2"
+libc = "0.2.106"
 log = "0.4.14"
-num-derive = "0.3"
-num-traits = "0.2"
+num-derive = "0.3.3"
+num-traits = "0.2.14"
 # Ideally, we'd use RustCrypto/RSA instead of linking OpenSSL. Unfortunately,
 # RustCrypto doesn't expose the low-level primitives we need for the smartcard
 # challenge signing (see src/piv.rs for details).
-openssl = { version = "0.10.36", features = ["vendored"] }
+openssl = { version = "0.10.38", features = ["vendored"] }
 rdp-rs = { git = "https://github.com/gravitational/rdp-rs", rev = "755e950dcff0fc6965aa518c4596b995ede3417d" }
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "0.8.2", features = ["v4"] }

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -13,7 +13,6 @@ lto = "off"
 
 [profile.release]
 debug = 1
-lto = "thin"
 codegen-units = 1
 
 [dependencies]

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -7,6 +7,15 @@ edition = "2018"
 [lib]
 crate-type = ["staticlib"]
 
+[profile.dev]
+debug = 1
+lto = "off"
+
+[profile.release]
+debug = 1
+lto = "thin"
+codegen-units = 1
+
 [dependencies]
 bitflags = "1.3.2"
 byteorder = "1.4.3"

--- a/lib/srv/desktop/rdp/rdpclient/librdprs.h
+++ b/lib/srv/desktop/rdp/rdpclient/librdprs.h
@@ -20,8 +20,22 @@ typedef enum CGOPointerWheel {
   PointerWheelHorizontal,
 } CGOPointerWheel;
 
+/**
+ * Client has an unusual lifecycle:
+ * - connect_rdp creates it on the heap, grabs a raw pointer and returns in to Go
+ * - most other exported rdp functions take the raw pointer, convert it to a reference for use
+ *   without dropping the Client
+ * - close_rdp takes the raw pointer and drops it
+ *
+ * All of the exported rdp functions could run concurrently, so the rdp_client is synchronized.
+ * tcp_fd is only set in connect_rdp and used as read-only afterwards, so it does not need
+ * synchronization.
+ */
 typedef struct Client Client;
 
+/**
+ * CGOError is an alias for a C string pointer, for C API clarity.
+ */
 typedef char *CGOError;
 
 typedef struct ClientOrError {
@@ -29,6 +43,10 @@ typedef struct ClientOrError {
   CGOError err;
 } ClientOrError;
 
+/**
+ * CGOMousePointerEvent is a CGO-compatible version of PointerEvent that we pass back to Go.
+ * PointerEvent is a mouse move or click update from the user.
+ */
 typedef struct CGOMousePointerEvent {
   uint16_t x;
   uint16_t y;
@@ -38,16 +56,27 @@ typedef struct CGOMousePointerEvent {
   int16_t wheel_delta;
 } CGOMousePointerEvent;
 
+/**
+ * CGOKeyboardEvent is a CGO-compatible version of KeyboardEvent that we pass back to Go.
+ * KeyboardEvent is a keyboard update from the user.
+ */
 typedef struct CGOKeyboardEvent {
   uint16_t code;
   bool down;
 } CGOKeyboardEvent;
 
+/**
+ * CGOBitmap is a CGO-compatible version of BitmapEvent that we pass back to Go.
+ * BitmapEvent is a video output update from the server.
+ */
 typedef struct CGOBitmap {
   uint16_t dest_left;
   uint16_t dest_top;
   uint16_t dest_right;
   uint16_t dest_bottom;
+  /**
+   * The memory of this field is managed by the Rust side.
+   */
   uint8_t *data_ptr;
   uintptr_t data_len;
   uintptr_t data_cap;
@@ -55,6 +84,16 @@ typedef struct CGOBitmap {
 
 void init(void);
 
+/**
+ * connect_rdp establishes an RDP connection to go_addr with the provided credentials and screen
+ * size. If succeeded, the client is internally registered under client_ref. When done with the
+ * connection, the caller must call close_rdp.
+ *
+ * # Safety
+ *
+ * The caller mmust ensure that go_addr, go_username, cert_der, key_der point to valid buffers in respect
+ * to their corresponding parameters.
+ */
 struct ClientOrError connect_rdp(char *go_addr,
                                  char *go_username,
                                  uint32_t cert_der_len,
@@ -64,16 +103,53 @@ struct ClientOrError connect_rdp(char *go_addr,
                                  uint16_t screen_width,
                                  uint16_t screen_height);
 
+
+/**
+ * `read_rdp_output` reads incoming RDP bitmap frames from client at client_ref and forwards them to
+ * handle_bitmap.
+ *
+ * # Safety
+ *
+ * client_ptr must be a valid pointer to a Client.
+ * handle_bitmap *must not* free the memory of CGOBitmap.
+ */
 CGOError read_rdp_output(struct Client *client_ptr, uintptr_t client_ref);
 
+/**
+ * # Safety
+ *
+ * client_ptr must be a valid pointer to a Client.
+ */
 CGOError write_rdp_pointer(struct Client *client_ptr, struct CGOMousePointerEvent pointer);
 
+/**
+ * # Safety
+ *
+ * client_ptr must be a valid pointer to a Client.
+ */
 CGOError write_rdp_keyboard(struct Client *client_ptr, struct CGOKeyboardEvent key);
 
+/**
+ * # Safety
+ *
+ * client_ptr must be a valid pointer to a Client.
+ */
 CGOError close_rdp(struct Client *client_ptr);
 
+/**
+ * free_rdp lets the Go side inform us when it's done with Client and it can be dropped.
+ *
+ * # Safety
+ *
+ * client_ptr must be a valid pointer to a Client.
+ */
 void free_rdp(struct Client *client_ptr);
 
+/**
+ * # Safety
+ *
+ * The passed pointer must point to a C-style string allocated by Rust.
+ */
 void free_rust_string(char *s);
 
 extern void free_go_string(char *s);

--- a/lib/srv/desktop/rdp/rdpclient/src/errors.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/errors.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rdp::model::error::*;
 
 // Helper function to return an unmarshaling error.

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -34,15 +34,15 @@ pub extern "C" fn init() {
     env_logger::try_init().unwrap_or_else(|e| println!("failed to initialize Rust logger: {}", e));
 }
 
-// Client has an unusual lifecycle:
-// - connect_rdp creates it on the heap, grabs a raw pointer and returns in to Go
-// - most other exported rdp functions take the raw pointer, convert it to a reference for use
-//   without dropping the Client
-// - close_rdp takes the raw pointer and drops it
-//
-// All of the exported rdp functions could run concurrently, so the rdp_client is synchronized.
-// tcp_fd is only set in connect_rdp and used as read-only afterwards, so it does not need
-// synchronization.
+/// Client has an unusual lifecycle:
+/// - connect_rdp creates it on the heap, grabs a raw pointer and returns in to Go
+/// - most other exported rdp functions take the raw pointer, convert it to a reference for use
+///   without dropping the Client
+/// - close_rdp takes the raw pointer and drops it
+///
+/// All of the exported rdp functions could run concurrently, so the rdp_client is synchronized.
+/// tcp_fd is only set in connect_rdp and used as read-only afterwards, so it does not need
+/// synchronization.
 pub struct Client {
     rdp_client: Arc<Mutex<RdpClient<TcpStream>>>,
     tcp_fd: usize,
@@ -81,11 +81,16 @@ impl From<Result<Client, ConnectError>> for ClientOrError {
     }
 }
 
-// connect_rdp establishes an RDP connection to go_addr with the provided credentials and screen
-// size. If succeeded, the client is internally registered under client_ref. When done with the
-// connection, the caller must call close_rdp.
+/// connect_rdp establishes an RDP connection to go_addr with the provided credentials and screen
+/// size. If succeeded, the client is internally registered under client_ref. When done with the
+/// connection, the caller must call close_rdp.
+///
+/// # Safety
+///
+/// The caller mmust ensure that go_addr, go_username, cert_der, key_der point to valid buffers in respect
+/// to their corresponding parameters.
 #[no_mangle]
-pub extern "C" fn connect_rdp(
+pub unsafe extern "C" fn connect_rdp(
     go_addr: *mut c_char,
     go_username: *mut c_char,
     cert_der_len: u32,
@@ -114,20 +119,20 @@ pub extern "C" fn connect_rdp(
 
 #[derive(Debug)]
 enum ConnectError {
-    TCP(IoError),
-    RDP(RdpError),
+    Tcp(IoError),
+    Rdp(RdpError),
     InvalidAddr(),
 }
 
 impl From<IoError> for ConnectError {
     fn from(e: IoError) -> ConnectError {
-        ConnectError::TCP(e)
+        ConnectError::Tcp(e)
     }
 }
 
 impl From<RdpError> for ConnectError {
     fn from(e: RdpError) -> ConnectError {
-        ConnectError::RDP(e)
+        ConnectError::Rdp(e)
     }
 }
 
@@ -164,7 +169,7 @@ fn connect_rdp_inner(
         // Request the RDPDR (device redirection) static channel.
         // For some reason, we also need to request RDPSND (sound) along with it,
         // although it's never used explicitly from our end.
-        &vec!["rdpdr".to_string(), "rdpsnd".to_string()],
+        &["rdpdr".to_string(), "rdpsnd".to_string()],
     )?;
     // Password must be non-empty for autologin (sec::InfoFlag::InfoPasswordIsScPin) to trigger on
     // a smartcard.
@@ -198,7 +203,7 @@ fn connect_rdp_inner(
     })
 }
 
-// From rdp-rs/src/core/client.rs
+/// From rdp-rs/src/core/client.rs
 struct RdpClient<S> {
     mcs: mcs::Client<S>,
     global: global::Client,
@@ -239,15 +244,15 @@ impl<S: Read + Write> RdpClient<S> {
     }
 }
 
-// CGOBitmap is a CGO-compatible version of BitmapEvent that we pass back to Go.
-// BitmapEvent is a video output update from the server.
+/// CGOBitmap is a CGO-compatible version of BitmapEvent that we pass back to Go.
+/// BitmapEvent is a video output update from the server.
 #[repr(C)]
 pub struct CGOBitmap {
     pub dest_left: u16,
     pub dest_top: u16,
     pub dest_right: u16,
     pub dest_bottom: u16,
-    // Memory is freed on the Rust side.
+    /// The memory of this field is managed by the Rust side.
     pub data_ptr: *mut u8,
     pub data_len: usize,
     pub data_cap: usize,
@@ -277,6 +282,7 @@ impl TryFrom<BitmapEvent> for CGOBitmap {
         res.data_ptr = data.as_mut_ptr();
         res.data_len = data.len();
         res.data_cap = data.capacity();
+
         // Prevent the data field from being freed while Go handles it.
         // It will be dropped once CGOBitmap is dropped (see below).
         mem::forget(data);
@@ -289,7 +295,7 @@ impl Drop for CGOBitmap {
     fn drop(&mut self) {
         // Reconstruct into Vec to drop the allocated buffer.
         unsafe {
-            let _ = Vec::from_raw_parts(self.data_ptr, self.data_len, self.data_cap);
+            Vec::from_raw_parts(self.data_ptr, self.data_len, self.data_cap);
         }
     }
 }
@@ -312,11 +318,16 @@ fn wait_for_fd(fd: usize) -> bool {
     }
 }
 
-// read_rdp_output reads incoming RDP bitmap frames from client at client_ref and forwards them to
-// handle_bitmap. handle_bitmap *must not* free the memory of CGOBitmap.
+/// `read_rdp_output` reads incoming RDP bitmap frames from client at client_ref and forwards them to
+/// handle_bitmap.
+///
+/// # Safety
+///
+/// client_ptr must be a valid pointer to a Client.
+/// handle_bitmap *must not* free the memory of CGOBitmap.
 #[no_mangle]
-pub extern "C" fn read_rdp_output(client_ptr: *mut Client, client_ref: usize) -> CGOError {
-    let client = unsafe { Client::from_ptr(client_ptr) };
+pub unsafe extern "C" fn read_rdp_output(client_ptr: *mut Client, client_ref: i64) -> CGOError {
+    let client = Client::from_ptr(client_ptr);
     let client = match client {
         Some(client) => client,
         None => {
@@ -377,8 +388,8 @@ fn read_rdp_output_inner(client: &Client, client_ref: usize) -> Option<String> {
     None
 }
 
-// CGOMousePointerEvent is a CGO-compatible version of PointerEvent that we pass back to Go.
-// PointerEvent is a mouse move or click update from the user.
+/// CGOMousePointerEvent is a CGO-compatible version of PointerEvent that we pass back to Go.
+/// PointerEvent is a mouse move or click update from the user.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CGOMousePointerEvent {
@@ -429,12 +440,15 @@ impl From<CGOMousePointerEvent> for PointerEvent {
     }
 }
 
+/// # Safety
+///
+/// client_ptr must be a valid pointer to a Client.
 #[no_mangle]
-pub extern "C" fn write_rdp_pointer(
+pub unsafe extern "C" fn write_rdp_pointer(
     client_ptr: *mut Client,
     pointer: CGOMousePointerEvent,
 ) -> CGOError {
-    let client = unsafe { Client::from_ptr(client_ptr) };
+    let client = Client::from_ptr(client_ptr);
     let client = match client {
         Some(client) => client,
         None => {
@@ -446,6 +460,7 @@ pub extern "C" fn write_rdp_pointer(
         .lock()
         .unwrap()
         .write(RdpEvent::Pointer(pointer.into()));
+
     if let Err(e) = res {
         to_cgo_error(format!("failed writing RDP pointer event: {:?}", e))
     } else {
@@ -453,8 +468,8 @@ pub extern "C" fn write_rdp_pointer(
     }
 }
 
-// CGOKeyboardEvent is a CGO-compatible version of KeyboardEvent that we pass back to Go.
-// KeyboardEvent is a keyboard update from the user.
+/// CGOKeyboardEvent is a CGO-compatible version of KeyboardEvent that we pass back to Go.
+/// KeyboardEvent is a keyboard update from the user.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct CGOKeyboardEvent {
@@ -474,9 +489,15 @@ impl From<CGOKeyboardEvent> for KeyboardEvent {
     }
 }
 
+/// # Safety
+///
+/// client_ptr must be a valid pointer to a Client.
 #[no_mangle]
-pub extern "C" fn write_rdp_keyboard(client_ptr: *mut Client, key: CGOKeyboardEvent) -> CGOError {
-    let client = unsafe { Client::from_ptr(client_ptr) };
+pub unsafe extern "C" fn write_rdp_keyboard(
+    client_ptr: *mut Client,
+    key: CGOKeyboardEvent,
+) -> CGOError {
+    let client = Client::from_ptr(client_ptr);
     let client = match client {
         Some(client) => client,
         None => {
@@ -495,9 +516,12 @@ pub extern "C" fn write_rdp_keyboard(client_ptr: *mut Client, key: CGOKeyboardEv
     }
 }
 
+/// # Safety
+///
+/// client_ptr must be a valid pointer to a Client.
 #[no_mangle]
-pub extern "C" fn close_rdp(client_ptr: *mut Client) -> CGOError {
-    let client = unsafe { Client::from_ptr(client_ptr) };
+pub unsafe extern "C" fn close_rdp(client_ptr: *mut Client) -> CGOError {
+    let client = Client::from_ptr(client_ptr);
     let client = match client {
         Some(client) => client,
         None => {
@@ -511,36 +535,43 @@ pub extern "C" fn close_rdp(client_ptr: *mut Client) -> CGOError {
     }
 }
 
-// free_rdp lets the Go side inform us when it's done with Client and it can be dropped.
+/// free_rdp lets the Go side inform us when it's done with Client and it can be dropped.
+///
+/// # Safety
+///
+/// client_ptr must be a valid pointer to a Client.
 #[no_mangle]
-pub extern "C" fn free_rdp(client_ptr: *mut Client) {
-    unsafe { drop(Client::from_raw(client_ptr)) }
+pub unsafe extern "C" fn free_rdp(client_ptr: *mut Client) {
+    drop(Client::from_raw(client_ptr))
 }
 
+/// # Safety
+///
+/// The passed pointer must point to a C-style string allocated by Rust.
 #[no_mangle]
 pub unsafe extern "C" fn free_rust_string(s: *mut c_char) {
     let _ = CString::from_raw(s);
 }
 
 fn from_go_string(s: *mut c_char) -> String {
-    unsafe { CStr::from_ptr(s).to_string_lossy().into_owned().clone() }
+    unsafe { CStr::from_ptr(s).to_string_lossy().into_owned() }
 }
 
 fn from_go_array(len: u32, ptr: *mut u8) -> Vec<u8> {
     unsafe { slice::from_raw_parts(ptr, len as usize).to_vec() }
 }
 
-// CGOError is an alias for a C string pointer, for C API clarity.
+/// CGOError is an alias for a C string pointer, for C API clarity.
 pub type CGOError = *mut c_char;
 
-// CGO_OK is a CGOError value that means "success".
+/// CGO_OK is a CGOError value that means "success".
 const CGO_OK: CGOError = ptr::null_mut();
 
 fn to_cgo_error(s: String) -> CGOError {
     CString::new(s).expect("CString::new failed").into_raw()
 }
 
-// from_cgo_error copies CGOError into a String and frees the underlying Go memory.
+/// from_cgo_error copies CGOError into a String and frees the underlying Go memory.
 fn from_cgo_error(e: CGOError) -> String {
     let s = from_go_string(e);
     unsafe {
@@ -556,5 +587,5 @@ extern "C" {
     fn handle_bitmap(client_ref: usize, b: CGOBitmap) -> CGOError;
 }
 
-// Payload is a generic type used to represent raw incoming RDP messages for parsing.
+/// Payload is a generic type used to represent raw incoming RDP messages for parsing.
 pub(crate) type Payload = Cursor<Vec<u8>>;

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -194,7 +194,7 @@ fn connect_rdp_inner(
     let rdp_client = RdpClient { mcs, global, rdpdr };
     Ok(Client {
         rdp_client: Arc::new(Mutex::new(rdp_client)),
-        tcp_fd: tcp_fd,
+        tcp_fd,
     })
 }
 

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -381,7 +381,7 @@ fn read_rdp_output_inner(client: &Client, client_ref: usize) -> Option<String> {
             return Some(format!("failed forwarding RDP bitmap frame: {:?}", e));
         };
         if err != CGO_OK {
-            let err_str = from_cgo_error(err);
+            let err_str = unsafe { from_cgo_error(err) };
             return Some(format!("failed forwarding RDP bitmap frame: {}", err_str));
         }
     }
@@ -578,9 +578,9 @@ fn to_cgo_error(s: String) -> CGOError {
 }
 
 /// from_cgo_error copies CGOError into a String and frees the underlying Go memory.
-/// 
+///
 /// # Safety
-/// 
+///
 /// The pointer inside the CGOError must point to a valid null terminated Go string.
 unsafe fn from_cgo_error(e: CGOError) -> String {
     let s = from_go_string(e);

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod errors;
 pub mod piv;
 pub mod rdpdr;
@@ -326,7 +340,7 @@ fn wait_for_fd(fd: usize) -> bool {
 /// client_ptr must be a valid pointer to a Client.
 /// handle_bitmap *must not* free the memory of CGOBitmap.
 #[no_mangle]
-pub unsafe extern "C" fn read_rdp_output(client_ptr: *mut Client, client_ref: i64) -> CGOError {
+pub unsafe extern "C" fn read_rdp_output(client_ptr: *mut Client, client_ref: usize) -> CGOError {
     let client = Client::from_ptr(client_ptr);
     let client = match client {
         Some(client) => client,

--- a/lib/srv/desktop/rdp/rdpclient/src/piv.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/piv.rs
@@ -37,11 +37,11 @@ pub struct Card<const S: usize> {
 
 impl<const S: usize> Card<S> {
     pub fn new(uuid: Uuid, cert_der: &[u8], key_der: &[u8]) -> RdpResult<Self> {
-        let piv_auth_key = Rsa::private_key_from_der(key_der).or_else(|e| {
-            Err(invalid_data_error(&format!(
+        let piv_auth_key = Rsa::private_key_from_der(key_der).map_err(|e| {
+            invalid_data_error(&format!(
                 "failed to parse private key from DER: {:?}",
                 e
-            )))
+            ))
         })?;
 
         Ok(Self {
@@ -63,7 +63,8 @@ impl<const S: usize> Card<S> {
             Some(pending) => {
                 pending
                     .extend_from_command(&cmd)
-                    .or_else(|_| Err(invalid_data_error("could not build chained command")))?;
+                    .map_err(|_| invalid_data_error("could not build chained command"))?;
+
                 pending.clone()
             }
         };
@@ -120,7 +121,7 @@ impl<const S: usize> Card<S> {
                 )?,
             ]),
         )?;
-        Ok(Response::with_data(Status::Success, resp.to_vec().into()))
+        Ok(Response::with_data(Status::Success, resp.to_vec()))
     }
 
     fn handle_verify(&mut self, _cmd: Command<S>) -> RdpResult<Response> {
@@ -135,12 +136,12 @@ impl<const S: usize> Card<S> {
             return Ok(Response::new(Status::NotFound));
         }
         let request_tlv = Tlv::from_bytes(cmd.data())
-            .or_else(|e| Err(invalid_data_error(&format!("TLV invalid: {:?}", e))))?;
+            .map_err(|e| invalid_data_error(&format!("TLV invalid: {:?}", e)))?;
         if *request_tlv.tag() != tlv_tag(0x5C)? {
             return Ok(Response::new(Status::NotFound));
         }
         match request_tlv.value() {
-            Value::Primitive(tag) => match to_hex(&tag).as_str() {
+            Value::Primitive(tag) => match to_hex(tag).as_str() {
                 // Card Holder Unique Identifier.
                 "5FC102" => Ok(Response::with_data(Status::Success, self.chuid.clone())),
                 // X.509 Certificate for PIV Authentication
@@ -169,7 +170,7 @@ impl<const S: usize> Card<S> {
                 let mut chunk = chunk.to_vec();
                 chunk.truncate(n);
                 let remaining = cursor.get_ref().len() as u64 - cursor.position();
-                let status = if remaining <= 0 {
+                let status = if remaining == 0 {
                     Status::Success
                 } else if remaining < CHUNK_SIZE as u64 {
                     Status::MoreAvailable(remaining as u8)
@@ -205,7 +206,7 @@ impl<const S: usize> Card<S> {
         }
 
         let request_tlv = Tlv::from_bytes(cmd.data())
-            .or_else(|e| Err(invalid_data_error(&format!("TLV invalid: {:?}", e))))?;
+            .map_err(|e| invalid_data_error(&format!("TLV invalid: {:?}", e)))?;
         if *request_tlv.tag() != tlv_tag(TLV_TAG_DYNAMIC_AUTHENTICATION_TEMPLATE)? {
             return Err(invalid_data_error(&format!(
                 "general authenticate command TLV invalid: {:?}",
@@ -261,12 +262,12 @@ impl<const S: usize> Card<S> {
         //
         // TODO(zmb3): support non-RSA keys, if needed.
         self.piv_auth_key
-            .private_decrypt(&challenge, &mut signed_challenge, Padding::NONE)
-            .or_else(|e| {
-                Err(invalid_data_error(&format!(
+            .private_decrypt(challenge, &mut signed_challenge, Padding::NONE)
+            .map_err(|e| {
+                invalid_data_error(&format!(
                     "failed to sign challenge: {:?}",
                     e
-                )))
+                ))
             })?;
 
         // Return signed challenge.
@@ -359,7 +360,7 @@ impl Response {
     pub fn encode(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         if let Some(data) = &self.data {
-            buf.extend_from_slice(&data);
+            buf.extend_from_slice(data);
         }
         let status: [u8; 2] = self.status.into();
         buf.extend_from_slice(&status);
@@ -385,20 +386,20 @@ const TLV_TAG_CHALLENGE: u8 = 0x81;
 const TLV_TAG_RESPONSE: u8 = 0x82;
 
 fn tlv(tag: u8, value: Value) -> RdpResult<Tlv> {
-    Tlv::new(tlv_tag(tag)?, value).or_else(|e| {
-        Err(invalid_data_error(&format!(
+    Tlv::new(tlv_tag(tag)?, value).map_err(|e| {
+        invalid_data_error(&format!(
             "TLV with tag {:#X} invalid: {:?}",
             tag, e
-        )))
+        ))
     })
 }
 
 fn tlv_tag(val: u8) -> RdpResult<Tag> {
-    Tag::try_from(val).or_else(|e| {
-        Err(invalid_data_error(&format!(
+    Tag::try_from(val).map_err(|e| {
+        invalid_data_error(&format!(
             "TLV tag {:#X} invalid: {:?}",
             val, e
-        )))
+        ))
     })
 }
 

--- a/lib/srv/desktop/rdp/rdpclient/src/piv.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/piv.rs
@@ -38,10 +38,7 @@ pub struct Card<const S: usize> {
 impl<const S: usize> Card<S> {
     pub fn new(uuid: Uuid, cert_der: &[u8], key_der: &[u8]) -> RdpResult<Self> {
         let piv_auth_key = Rsa::private_key_from_der(key_der).map_err(|e| {
-            invalid_data_error(&format!(
-                "failed to parse private key from DER: {:?}",
-                e
-            ))
+            invalid_data_error(&format!("failed to parse private key from DER: {:?}", e))
         })?;
 
         Ok(Self {
@@ -263,12 +260,7 @@ impl<const S: usize> Card<S> {
         // TODO(zmb3): support non-RSA keys, if needed.
         self.piv_auth_key
             .private_decrypt(challenge, &mut signed_challenge, Padding::NONE)
-            .map_err(|e| {
-                invalid_data_error(&format!(
-                    "failed to sign challenge: {:?}",
-                    e
-                ))
-            })?;
+            .map_err(|e| invalid_data_error(&format!("failed to sign challenge: {:?}", e)))?;
 
         // Return signed challenge.
         let resp = tlv(
@@ -386,21 +378,13 @@ const TLV_TAG_CHALLENGE: u8 = 0x81;
 const TLV_TAG_RESPONSE: u8 = 0x82;
 
 fn tlv(tag: u8, value: Value) -> RdpResult<Tlv> {
-    Tlv::new(tlv_tag(tag)?, value).map_err(|e| {
-        invalid_data_error(&format!(
-            "TLV with tag {:#X} invalid: {:?}",
-            tag, e
-        ))
-    })
+    Tlv::new(tlv_tag(tag)?, value)
+        .map_err(|e| invalid_data_error(&format!("TLV with tag {:#X} invalid: {:?}", tag, e)))
 }
 
 fn tlv_tag(val: u8) -> RdpResult<Tag> {
-    Tag::try_from(val).map_err(|e| {
-        invalid_data_error(&format!(
-            "TLV tag {:#X} invalid: {:?}",
-            val, e
-        ))
-    })
+    Tag::try_from(val)
+        .map_err(|e| invalid_data_error(&format!("TLV tag {:#X} invalid: {:?}", val, e)))
 }
 
 fn hex_data<const S: usize>(cmd: &Command<S>) -> String {

--- a/lib/srv/desktop/rdp/rdpclient/src/piv.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/piv.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::errors::invalid_data_error;
 use iso7816::aid::Aid;
 use iso7816::command::instruction::Instruction;

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::errors::{invalid_data_error, NTSTATUS_OK, SPECIAL_NO_RESPONSE};
 use crate::scard;
 use crate::Payload;

--- a/lib/srv/desktop/rdp/rdpclient/src/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/scard.rs
@@ -223,11 +223,11 @@ impl Client {
         // Decode the card command before sending it to piv.rs.
         // In retrospect, piv.rs should probably handle this decoding.
         let cmd =
-            CardCommand::<TRANSMIT_DATA_LIMIT>::try_from(&req.send_buffer).or_else(|err| {
-                Err(invalid_data_error(&format!(
+            CardCommand::<TRANSMIT_DATA_LIMIT>::try_from(&req.send_buffer).map_err(|err| {
+                invalid_data_error(&format!(
                     "failed to parse smartcard command {:?}: {:?}",
                     &req.send_buffer, err
-                )))
+                ))
             })?;
 
         let card = self

--- a/lib/srv/desktop/rdp/rdpclient/src/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/scard.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::errors::{invalid_data_error, NTSTATUS_OK, SPECIAL_NO_RESPONSE};
 use crate::piv;
 use crate::Payload;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable-2021-11-01"
+profile = "default"


### PR DESCRIPTION
This is a rollup PR containing maintenance and multiple fixes to issues and nits I discovered when digging through how we build Rust and Desktop Access RDP code

This PR:
- Updates the Rust toolchain used in CI to 1.56.1 after members of the Rust Security team notified me about a vulnerability and released a Rust patch yesterday.
- Enforces usage of the same toolchain for CI and local development. Previously one could have a different toolchain than was used in CI and to build artifacts. We solve this with a pinning file that forces Cargo to fetch the same toolchain that is used in CI.
- Updates RDP client dependencies, multiple new versions containing performance improvements and bug fixes have been released.
- Specify full semver numbers for dependencies. This is recommended practice and has some mild changes on when cargo internally updates a dependency. Done using `cargo upgrade && cargo update`.
- Adds tuned Rust compilation profiles giving us better performance, binary sizes and sometimes compile speed.
- Formats the code using `rustfmt`.
- Enforces formatting and linting in CI via `rustfmt` and `clippy`. CI now fails on style if they aren't happy.
- Fixes a multitude of errors reported by `clippy`.
- Uses Rust doc comments instead of regular comments on language items to make `cargo doc` generate correct documentation.
- Marked extern functions that don't safely validate their input as `unsafe`. Previously you could trigger UB and memory corruption in safe Rust with this code by calling an extern function from inside Rust with incorrect parameters which violates Rust safety encapsulation rules and guidelines.
