### PR TITLE
Fix the client idle disconnect audit event for desktops

### DIFF
--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -582,13 +582,13 @@ func (s *WindowsService) handleConnection(con net.Conn) {
 		return
 	}
 
-	// Fetch the target desktop info. UUID of the desktop is passed via SNI.
-	desktopUUID := strings.TrimSuffix(tlsConn.ConnectionState().ServerName, SNISuffix)
-	log = log.WithField("desktop-uuid", desktopUUID)
+	// Fetch the target desktop info. Name of the desktop is passed via SNI.
+	desktopName := strings.TrimSuffix(tlsConn.ConnectionState().ServerName, SNISuffix)
+	log = log.WithField("desktop-name", desktopName)
 
-	desktop, err := s.cfg.AccessPoint.GetWindowsDesktop(ctx, desktopUUID)
+	desktop, err := s.cfg.AccessPoint.GetWindowsDesktop(ctx, desktopName)
 	if err != nil {
-		log.WithError(err).Warning("Failed to fetch desktop by UUID")
+		log.WithError(err).Warning("Failed to fetch desktop by name")
 		return
 	}
 
@@ -653,7 +653,7 @@ func (s *WindowsService) connectRDP(ctx context.Context, log logrus.FieldLogger,
 		LockTargets:       services.LockTargetsFromTLSIdentity(identity),
 		Tracker:           rdpc,
 		TeleportUser:      identity.Username,
-		ServerID:          desktop.GetName(),
+		ServerID:          s.cfg.Heartbeat.HostUUID,
 	}
 	shouldDisconnectExpiredCert := authCtx.Checker.AdjustDisconnectExpiredCert(authPref.GetDisconnectExpiredCert())
 	if shouldDisconnectExpiredCert && !identity.Expires.IsZero() {


### PR DESCRIPTION
We were attempting to use the desktop name as the server ID,
but in order to publish audit events we must use the `HostUUID`
of the `windows_desktop_service`.

Updates #8665