### PR TITLE
Improve SSH agent forwarding error message in proxy mode

### DIFF
--- a/lib/sshutils/ctx.go
+++ b/lib/sshutils/ctx.go
@@ -95,7 +95,7 @@ func (a *agentChannel) Close() error {
 func (c *ConnectionContext) StartAgentChannel() (teleagent.Agent, error) {
 	// refuse to start an agent if forwardAgent has not yet been set.
 	if !c.GetForwardAgent() {
-		return nil, trace.AccessDenied("agent forwarding not requested or not authorized")
+		return nil, trace.AccessDenied("agent forwarding required in proxy recording mode")
 	}
 	// open a agent channel to client
 	ch, _, err := c.ServerConn.OpenChannel(AuthAgentRequest, nil)


### PR DESCRIPTION
Proxy mode requires SSH agent forwarding permissions to work properly.
This tweaks the error message to mention that in a more direct manner.

Previous message:

```shell
$ tsh ssh mynode
> ERROR: failed connecting to node mynode. agent forwarding not requested or not authorized
```

New message:

```shell
$ tsh ssh mynode
> ERROR: failed connecting to node mynode. agent forwarding required in proxy recording mode
```