### PR TITLE
Bring back previous u2f challenge response for web terminal

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -361,6 +361,13 @@ func (t *TerminalHandler) promptMFAChallenge(ws *websocket.Conn) client.PromptMF
 				})
 			}
 			chal = &auth.MFAAuthenticateChallenge{
+				AuthenticateChallenge: &u2f.AuthenticateChallenge{
+					// Get the common challenge fields from the first item.
+					// All of these fields should be identical for all u2fChals.
+					Challenge: u2fChals[0].Challenge,
+					AppID:     u2fChals[0].AppID,
+					Version:   u2fChals[0].Version,
+				},
 				U2FChallenges: u2fChals,
 			}
 		default:


### PR DESCRIPTION
Fixes a regression bug, where firefox still requires global `appId` and `challenge`, unlike Chrome where it looks for it among the `u2f_challenges` list. I could've handled this in the client side by doing the same thing as we did here, but decided to keep the previous functionality