### PR TITLE
fix example cluster config 

### DIFF
--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -80,7 +80,7 @@ Set up an email to receive updates from Let's Encrypt, and use a valid DNS name 
 
 ```code
 $ sudo teleport configure --acme --acme-email=your-email@example.com --cluster-name=tele.example.com -o file
-Wrote config to file "/etc/teleport.yaml". Now you can start the server. Happy Teleporting!
+# Wrote config to file "/etc/teleport.yaml". Now you can start the server. Happy Teleporting!
 ```
 
 {/* Convert to new UI component https://github.com/gravitational/next/issues/275 */}


### PR DESCRIPTION
since it was't commented out, the output of the cluster `sudo teleport config` was included for copy/paste