### PR TITLE
Fix ACME strict ALPN

### DIFF
--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -462,7 +462,7 @@ type mockReverseTunnelServer struct {
 
 func TestSetupProxyTLSConfig(t *testing.T) {
 	testCases := []struct {
-		name          string
+		name           string
 		acmeEnabled    bool
 		wantNextProtos []string
 	}{

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -448,5 +449,72 @@ func waitForStatus(diagAddr string, statusCodes ...int) error {
 		case <-timeoutCh:
 			return trace.BadParameter("timeout waiting for status: %v; last status: %v", statusCodes, lastStatus)
 		}
+	}
+}
+
+type mockAccessPoint struct {
+	auth.ProxyAccessPoint
+}
+
+type mockReverseTunnelServer struct {
+	reversetunnel.Server
+}
+
+func TestSetupProxyTLSConfig(t *testing.T) {
+	testCases := []struct {
+		name          string
+		acmeEnabled    bool
+		wantNextProtos []string
+	}{
+		{
+			name:        "ACME enabled, teleport ALPN protocols should be appended",
+			acmeEnabled: true,
+			wantNextProtos: []string{
+				"h2",
+				"http/1.1",
+				"acme-tls/1",
+				"teleport-postgres",
+				"teleport-mysql",
+				"teleport-mongodb",
+				"teleport-proxy-ssh",
+				"teleport-reversetunnel",
+				"teleport-auth@",
+			},
+		},
+		{
+			name:        "ACME disabled",
+			acmeEnabled: false,
+			// If server NextProtos list is empty server allows for connection with any protocol.
+			wantNextProtos: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := MakeDefaultConfig()
+			cfg.Proxy.ACME.Enabled = tc.acmeEnabled
+			cfg.DataDir = t.TempDir()
+			cfg.Proxy.PublicAddrs = utils.MustParseAddrList("localhost")
+			process := TeleportProcess{
+				Config: cfg,
+			}
+			conn := &Connector{
+				ServerIdentity: &auth.Identity{
+					Cert: &ssh.Certificate{
+						Permissions: ssh.Permissions{
+							Extensions: map[string]string{},
+						},
+					},
+				},
+			}
+			tls, err := process.setupProxyTLSConfig(
+				conn,
+				&mockReverseTunnelServer{},
+				&mockAccessPoint{},
+				"cluster",
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantNextProtos, tls.NextProtos)
+		})
 	}
 }


### PR DESCRIPTION
## What 
After switching to the go1.17  the client ALPN should be present in the server ALPN protocol list:  https://golang.org/doc/go1.17#ALPN - strict ALPN 

If ACME protocol was enabled the TLS Webcert  obtained from ACME manager contains only:  `h2`, `http/1.1` `acme-tls/1` protocols https://github.com/golang/crypto/blob/master/acme/autocert/autocert.go#L223  thus dialling with custom ALPN protocol like `teleport-reversetunnel` fails with the `tls: no application protocol` error thus custom ALPN protocols needs to be added to the ACME webcert.  


