### PR TITLE
Fix Rust buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -83,7 +83,7 @@ RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home
  ENV RUSTUP_HOME=/usr/local/rustup \
      CARGO_HOME=/usr/local/cargo \
      PATH=/usr/local/cargo/bin:$PATH \
-     RUST_VERSION=1.56.0
+     RUST_VERSION=1.56.1
 
  COPY --from=rust:1.56.1 /usr/local/rustup /usr/local/rustup
  COPY --from=rust:1.56.1 /usr/local/cargo /usr/local/cargo

--- a/lib/datalog/roletester/rust-toolchain.toml
+++ b/lib/datalog/roletester/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "stable-2021-06-17"


### PR DESCRIPTION
This PR removes a toolchain file for the datalog tester to let it inherit from the root toolchain spec and adjusts a variable in the buildbox to allow it to compile Rust on other architectures.