### PR TITLE
Don't allow running Desktop Access in FIPS mode.

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -813,6 +813,14 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 	}
 
 	if cfg.WindowsDesktop.Enabled {
+		// FedRAMP/FIPS is not supported for Desktop Access. Desktop Access uses
+		// Rust for the underlying RDP protocol implementation which in turn uses
+		// OpenSSL. Return an error if the user attempts to start Desktop Access in
+		// FedRAMP/FIPS mode for now until we can swap out OpenSSL for BoringCrypto.
+		if cfg.FIPS {
+			return nil, trace.BadParameter("FedRAMP/FIPS 140-2 compliant configuration for Desktop Access not supported in Teleport %v", teleport.Version)
+		}
+
 		process.initWindowsDesktopService()
 		serviceStarted = true
 	} else {

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -427,6 +427,28 @@ func TestGetAdditionalPrincipals(t *testing.T) {
 	}
 }
 
+// TestDesktopAccessFIPS makes sure that Desktop Access can not be started in
+// FIPS mode. Remove this test once Rust code has been updated to use
+// BoringCrypto instead of OpenSSL.
+func TestDesktopAccessFIPS(t *testing.T) {
+	t.Parallel()
+
+	// Create and configure a default Teleport configuration.
+	cfg := MakeDefaultConfig()
+	cfg.AuthServers = []utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}}
+	cfg.Clock = clockwork.NewFakeClock()
+	cfg.DataDir = t.TempDir()
+	cfg.Auth.Enabled = false
+	cfg.Proxy.Enabled = false
+	cfg.SSH.Enabled = false
+
+	// Enable FIPS mode and Desktop Access, this should fail.
+	cfg.FIPS = true
+	cfg.WindowsDesktop.Enabled = true
+	_, err := NewTeleport(cfg)
+	require.Error(t, err)
+}
+
 func waitForStatus(diagAddr string, statusCodes ...int) error {
 	tickCh := time.Tick(100 * time.Millisecond)
 	timeoutCh := time.After(10 * time.Second)


### PR DESCRIPTION
**Description**

Return an error if Desktop Access is requested in FIPS mode until Rust is updated to use BoringCrypto instead of OpenSSL.