### PR TITLE
Add --verbose flag for tsh kube ls

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -527,7 +527,7 @@ func Run(args []string, opts ...cliOption) error {
 	reqReview.Flag("reason", "Review reason message").StringVar(&cf.ReviewReason)
 
 	// Kubernetes subcommands.
-	kube := newKubeCommand(app)
+	kube := newKubeCommand(app, &cf)
 	// MFA subcommands.
 	mfa := newMFACommand(app)
 


### PR DESCRIPTION
Fixes #4960 

Displays the labels for the kubernetes clusters with `--verbose` flag is used.
![image](https://user-images.githubusercontent.com/52544819/140756417-d68d1fe6-4365-4700-9928-bfb5e298e827.png)
