### PR TITLE
Link libatomic on Linux

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -56,7 +56,7 @@ package rdpclient
 #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/target/x86_64-unknown-linux-gnu/release
 #cgo linux,arm LDFLAGS: -L${SRCDIR}/target/arm-unknown-linux-gnueabihf/release
 #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/target/aarch64-unknown-linux-gnu/release
-#cgo linux LDFLAGS: -l:librdp_client.a -lpthread -ldl -lm
+#cgo linux LDFLAGS: -l:librdp_client.a -lpthread -ldl -lm -latomic
 #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/target/x86_64-apple-darwin/release
 #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/target/aarch64-apple-darwin/release
 #cgo darwin LDFLAGS: -framework CoreFoundation -framework Security -lrdp_client -lpthread -ldl -lm


### PR DESCRIPTION
A recent update to OpenSSL requires `-latomic` for 32-bit Linux builds. This resulted in linux/arm builds failing starting with 074dbe7f5dad79b817339fb516fcddf9d9f91668.

https://github.com/openssl/openssl/pull/15086