### PR TITLE
Enable PluginData for users

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -64,6 +64,10 @@ const (
 	// only to plugin data associated with access requests.
 	KindAccessPluginData = "access_plugin_data"
 
+	// KindUserPluginData is a resource directive that applies
+	// only to plugin data associated with users.
+	KindUserPluginData = "user_plugin_data"
+
 	// KindOIDC is OIDC connector resource
 	KindOIDC = "oidc"
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -151,6 +151,9 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 	if cfg.KeyStoreConfig.HostUUID == "" {
 		cfg.KeyStoreConfig.HostUUID = cfg.HostUUID
 	}
+	if cfg.PluginData == nil {
+		cfg.PluginData = local.NewPluginDataService(cfg.Backend)
+	}
 
 	limiter, err := limiter.NewConnectionsLimiter(limiter.Config{
 		MaxConnections: defaults.LimiterMaxConcurrentSignatures,
@@ -192,6 +195,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 			IAuditLog:            cfg.AuditLog,
 			Events:               cfg.Events,
 			WindowsDesktops:      cfg.WindowsDesktops,
+			PluginData:           cfg.PluginData,
 		},
 		keyStore: keyStore,
 	}
@@ -217,6 +221,7 @@ type Services struct {
 	services.Apps
 	services.Databases
 	services.WindowsDesktops
+	services.PluginData
 	types.Events
 	events.IAuditLog
 }
@@ -3345,6 +3350,71 @@ func (a *Server) SetNetworkRestrictions(ctx context.Context, nr types.NetworkRes
 // DeleteNetworkRestrictions deletes the network restrictions in the backend
 func (a *Server) DeleteNetworkRestrictions(ctx context.Context) error {
 	return a.Services.Restrictions.DeleteNetworkRestrictions(ctx)
+}
+
+// GetPluginData loads all plugin data matching the supplied filter.
+func (a *Server) GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
+	if !isAllowedPluginDataKind(filter.Kind) {
+		return nil, trace.BadParameter("unsupported resource kind %q", filter.Kind)
+	}
+
+	return a.Services.PluginData.GetPluginData(ctx, filter)
+}
+
+// GetPluginData loads all plugin data matching the supplied filter.
+func (a *Server) UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
+	if !isAllowedPluginDataKind(params.Kind) {
+		return trace.BadParameter("unsupported resource kind %q", params.Kind)
+	}
+
+	// Load parent resource expiration value. Nil means that a parent resource does not exist.
+	// Non-existent parent resource is fine on update. There are the cases when we need to access
+	// PluginData of a just deleted resource. We need to prevent creation of PluginData entries
+	// for a missing resources.
+	//
+	// Expires itself is needed to prevent orphaned plugin data, we automatically
+	// configure new instances to expire shortly after the resource to which they are associated.
+	expires, err := a.getResourceExpiry(ctx, params.Resource, params.Kind)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return a.PluginData.UpsertPluginData(ctx, params, expires)
+}
+
+// isAllowedPluginDataKind returns true if PluginData can be attached to a resource kind.
+func isAllowedPluginDataKind(kind string) bool {
+	return kind == types.KindAccessRequest || kind == types.KindUser
+}
+
+// getResourceExpiry returns a resource expiration time or nil if a resource does not exist
+func (a *Server) getResourceExpiry(ctx context.Context, resource string, kind string) (*time.Time, error) {
+	switch kind {
+	case types.KindAccessRequest:
+		req, err := a.GetAccessRequests(ctx, types.AccessRequestFilter{ID: resource})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if len(req) == 0 { // Equals to NotFound error
+			return nil, nil
+		}
+
+		// GetAccessExpiry() might be less than the RequestAccess object Expiry()
+		exp := req[0].GetAccessExpiry()
+		return &exp, nil
+	case types.KindUser:
+		u, err := a.GetUser(resource, false)
+		if err != nil {
+			if trace.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, trace.Wrap(err)
+		}
+		exp := u.Expiry()
+		return &exp, nil
+	}
+
+	return nil, trace.BadParameter("unsupported resource kind %q", kind)
 }
 
 func mergeKeySets(a, b types.CAKeySet) types.CAKeySet {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3354,19 +3354,11 @@ func (a *Server) DeleteNetworkRestrictions(ctx context.Context) error {
 
 // GetPluginData loads all plugin data matching the supplied filter.
 func (a *Server) GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
-	if !isAllowedPluginDataKind(filter.Kind) {
-		return nil, trace.BadParameter("unsupported resource kind %q", filter.Kind)
-	}
-
 	return a.Services.PluginData.GetPluginData(ctx, filter)
 }
 
 // GetPluginData loads all plugin data matching the supplied filter.
 func (a *Server) UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
-	if !isAllowedPluginDataKind(params.Kind) {
-		return trace.BadParameter("unsupported resource kind %q", params.Kind)
-	}
-
 	// Load parent resource expiration value. Nil means that a parent resource does not exist.
 	// Non-existent parent resource is fine on update. There are the cases when we need to access
 	// PluginData of a just deleted resource. We need to prevent creation of PluginData entries
@@ -3380,11 +3372,6 @@ func (a *Server) UpdatePluginData(ctx context.Context, params types.PluginDataUp
 	}
 
 	return a.PluginData.UpsertPluginData(ctx, params, expires)
-}
-
-// isAllowedPluginDataKind returns true if PluginData can be attached to a resource kind.
-func isAllowedPluginDataKind(kind string) bool {
-	return kind == types.KindAccessRequest || kind == types.KindUser
 }
 
 // getResourceExpiry returns a resource expiration time or nil if a resource does not exist

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1229,6 +1229,13 @@ func (a *ServerWithRoles) GetPluginData(ctx context.Context, filter types.Plugin
 			}
 		}
 		return a.authServer.GetPluginData(ctx, filter)
+
+	case types.KindUser:
+		// TODO: Put correct auth checks here
+		if err := a.action(apidefaults.Namespace, types.KindUserPluginData, types.VerbRead); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return a.authServer.GetPluginData(ctx, filter)
 	default:
 		return nil, trace.BadParameter("unsupported resource kind %q", filter.Kind)
 	}
@@ -1246,6 +1253,13 @@ func (a *ServerWithRoles) UpdatePluginData(ctx context.Context, params types.Plu
 			}
 		}
 		return a.authServer.UpdatePluginData(ctx, params)
+	case types.KindUser:
+		// TODO: Put correct auth checks here
+		if err := a.action(apidefaults.Namespace, types.KindUserPluginData, types.VerbUpdate); err != nil {
+			return trace.Wrap(err)
+		}
+		return a.authServer.UpdatePluginData(ctx, params)
+
 	default:
 		return trace.BadParameter("unsupported resource kind %q", params.Kind)
 	}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1231,7 +1231,6 @@ func (a *ServerWithRoles) GetPluginData(ctx context.Context, filter types.Plugin
 		return a.authServer.GetPluginData(ctx, filter)
 
 	case types.KindUser:
-		// TODO: Put correct auth checks here
 		if err := a.action(apidefaults.Namespace, types.KindUserPluginData, types.VerbRead); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -1254,8 +1253,7 @@ func (a *ServerWithRoles) UpdatePluginData(ctx context.Context, params types.Plu
 		}
 		return a.authServer.UpdatePluginData(ctx, params)
 	case types.KindUser:
-		// TODO: Put correct auth checks here
-		if err := a.action(apidefaults.Namespace, types.KindUserPluginData, types.VerbUpdate); err != nil {
+		if err := a.action(apidefaults.Namespace, types.KindUserPluginData, types.VerbUpdate, types.VerbCreate); err != nil {
 			return trace.Wrap(err)
 		}
 		return a.authServer.UpdatePluginData(ctx, params)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -944,7 +944,7 @@ func CreateAccessPluginUser(ctx context.Context, clt clt, username string) (type
 			Verbs:     []string{types.VerbRead, types.VerbList},
 		},
 		types.Rule{
-			Resources: []string{types.KindAccessPluginData},
+			Resources: []string{types.KindAccessPluginData, types.KindUserPluginData},
 			Verbs:     []string{types.VerbRead, types.VerbList, types.VerbUpdate},
 		},
 	)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -172,6 +172,9 @@ type InitConfig struct {
 
 	// WindowsServices is a service that manages Windows desktop resources.
 	WindowsDesktops services.WindowsDesktops
+
+	// PluginData is a service that manages per-resource PluginData entries
+	PluginData services.PluginData
 }
 
 // Init instantiates and configures an instance of AuthServer

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1805,9 +1805,14 @@ func (s *TLSSuite) TestPluginData(c *check.C) {
 
 	c.Assert(userClient.CreateAccessRequest(context.TODO(), req), check.IsNil)
 
-	err = pluginClient.UpdatePluginData(context.TODO(), types.PluginDataUpdateParams{
-		Kind:     types.KindAccessRequest,
-		Resource: req.GetName(),
+	s.testPluginData(c, pluginClient, plugin, types.KindAccessRequest, req.GetName())
+	s.testPluginData(c, pluginClient, plugin, types.KindUser, user)
+}
+
+func (s *TLSSuite) testPluginData(c *check.C, pluginClient *Client, plugin string, kind string, resource string) {
+	err := pluginClient.UpdatePluginData(context.TODO(), types.PluginDataUpdateParams{
+		Kind:     kind,
+		Resource: resource,
 		Plugin:   plugin,
 		Set: map[string]string{
 			"foo": "bar",
@@ -1816,8 +1821,8 @@ func (s *TLSSuite) TestPluginData(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	data, err := pluginClient.GetPluginData(context.TODO(), types.PluginDataFilter{
-		Kind:     types.KindAccessRequest,
-		Resource: req.GetName(),
+		Kind:     kind,
+		Resource: resource,
 	})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(data), check.Equals, 1)
@@ -1827,8 +1832,8 @@ func (s *TLSSuite) TestPluginData(c *check.C) {
 	c.Assert(entry.Data, check.DeepEquals, map[string]string{"foo": "bar"})
 
 	err = pluginClient.UpdatePluginData(context.TODO(), types.PluginDataUpdateParams{
-		Kind:     types.KindAccessRequest,
-		Resource: req.GetName(),
+		Kind:     kind,
+		Resource: resource,
 		Plugin:   plugin,
 		Set: map[string]string{
 			"foo":  "",
@@ -1841,8 +1846,8 @@ func (s *TLSSuite) TestPluginData(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	data, err = pluginClient.GetPluginData(context.TODO(), types.PluginDataFilter{
-		Kind:     types.KindAccessRequest,
-		Resource: req.GetName(),
+		Kind:     kind,
+		Resource: resource,
 	})
 	c.Assert(err, check.IsNil)
 	c.Assert(len(data), check.Equals, 1)

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -96,10 +96,6 @@ type DynamicAccessCore interface {
 	GetAccessRequests(ctx context.Context, filter types.AccessRequestFilter) ([]types.AccessRequest, error)
 	// DeleteAccessRequest deletes an access request.
 	DeleteAccessRequest(ctx context.Context, reqID string) error
-	// GetPluginData loads all plugin data matching the supplied filter.
-	GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error)
-	// UpdatePluginData updates a per-resource PluginData entry.
-	UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error
 }
 
 // DynamicAccess is a service which manages dynamic RBAC.  Specifically, this is the

--- a/lib/services/local/dynamic_access.go
+++ b/lib/services/local/dynamic_access.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
@@ -186,6 +185,7 @@ func (s *DynamicAccessService) ApplyAccessReview(ctx context.Context, params typ
 	return nil, trace.CompareFailed("too many concurrent writes to access request %s, try again later", params.RequestID)
 }
 
+// GetAccessRequest gets an existing AccessRequest by name
 func (s *DynamicAccessService) GetAccessRequest(ctx context.Context, name string) (types.AccessRequest, error) {
 	item, err := s.Get(ctx, accessRequestKey(name))
 	if err != nil {
@@ -275,160 +275,6 @@ func (s *DynamicAccessService) UpsertAccessRequest(ctx context.Context, req type
 	return nil
 }
 
-// GetPluginData loads all plugin data matching the supplied filter.
-func (s *DynamicAccessService) GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
-	switch filter.Kind {
-	case types.KindAccessRequest:
-		data, err := s.getAccessRequestPluginData(ctx, filter)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return data, nil
-	default:
-		return nil, trace.BadParameter("unsupported resource kind %q", filter.Kind)
-	}
-}
-
-func (s *DynamicAccessService) getAccessRequestPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
-	// Filters which specify Resource are a special case since they will match exactly zero or one
-	// possible PluginData instances.
-	if filter.Resource != "" {
-		item, err := s.Get(ctx, pluginDataKey(types.KindAccessRequest, filter.Resource))
-		if err != nil {
-			// A filter with zero matches is still a success, it just
-			// happens to return an empty slice.
-			if trace.IsNotFound(err) {
-				return nil, nil
-			}
-			return nil, trace.Wrap(err)
-		}
-		data, err := itemToPluginData(*item)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		if !filter.Match(data) {
-			// A filter with zero matches is still a success, it just
-			// happens to return an empty slice.
-			return nil, nil
-		}
-		return []types.PluginData{data}, nil
-	}
-	prefix := backend.Key(pluginDataPrefix, types.KindAccessRequest)
-	result, err := s.GetRange(ctx, prefix, backend.RangeEnd(prefix), backend.NoLimit)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var matches []types.PluginData
-	for _, item := range result.Items {
-		if !bytes.HasSuffix(item.Key, []byte(paramsPrefix)) {
-			// Item represents a different resource type in the
-			// same namespace.
-			continue
-		}
-		data, err := itemToPluginData(item)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		if !filter.Match(data) {
-			continue
-		}
-		matches = append(matches, data)
-	}
-	return matches, nil
-}
-
-// UpdatePluginData updates a per-resource PluginData entry.
-func (s *DynamicAccessService) UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
-	switch params.Kind {
-	case types.KindAccessRequest:
-		return trace.Wrap(s.updateAccessRequestPluginData(ctx, params))
-	default:
-		return trace.BadParameter("unsupported resource kind %q", params.Kind)
-	}
-}
-
-func (s *DynamicAccessService) updateAccessRequestPluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
-	retryPeriod := retryPeriodMs * time.Millisecond
-	retry, err := utils.NewLinear(utils.LinearConfig{
-		Step: retryPeriod / 7,
-		Max:  retryPeriod,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	// Update is attempted multiple times in the event of concurrent writes.
-	for i := 0; i < maxCmpAttempts; i++ {
-		var create bool
-		var data types.PluginData
-		item, err := s.Get(ctx, pluginDataKey(types.KindAccessRequest, params.Resource))
-		if err == nil {
-			data, err = itemToPluginData(*item)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			create = false
-		} else {
-			if !trace.IsNotFound(err) {
-				return trace.Wrap(err)
-			}
-			// In order to prevent orphaned plugin data, we automatically
-			// configure new instances to expire shortly after the AccessRequest
-			// to which they are associated.  This discrepency in expiry gives
-			// plugins the ability to use stored data when handling an expiry
-			// (OpDelete) event.
-			req, err := s.GetAccessRequest(ctx, params.Resource)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			data, err = types.NewPluginData(params.Resource, types.KindAccessRequest)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			data.SetExpiry(req.GetAccessExpiry().Add(time.Hour))
-			create = true
-		}
-		if err := data.Update(params); err != nil {
-			return trace.Wrap(err)
-		}
-		if err := data.CheckAndSetDefaults(); err != nil {
-			return trace.Wrap(err)
-		}
-		newItem, err := itemFromPluginData(data)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		if create {
-			if _, err := s.Create(ctx, newItem); err != nil {
-				if trace.IsAlreadyExists(err) {
-					select {
-					case <-retry.After():
-						retry.Inc()
-						continue
-					case <-ctx.Done():
-						return trace.Wrap(ctx.Err())
-					}
-				}
-				return trace.Wrap(err)
-			}
-		} else {
-			if _, err := s.CompareAndSwap(ctx, *item, newItem); err != nil {
-				if trace.IsCompareFailed(err) {
-					select {
-					case <-retry.After():
-						retry.Inc()
-						continue
-					case <-ctx.Done():
-						return trace.Wrap(ctx.Err())
-					}
-				}
-				return trace.Wrap(err)
-			}
-		}
-		return nil
-	}
-	return trace.CompareFailed("too many concurrent writes to plugin data %s", params.Resource)
-}
-
 func itemFromAccessRequest(req types.AccessRequest) (backend.Item, error) {
 	value, err := services.MarshalAccessRequest(req)
 	if err != nil {
@@ -458,47 +304,10 @@ func itemToAccessRequest(item backend.Item, opts ...services.MarshalOption) (typ
 	return req, nil
 }
 
-func itemFromPluginData(data types.PluginData) (backend.Item, error) {
-	value, err := services.MarshalPluginData(data)
-	if err != nil {
-		return backend.Item{}, trace.Wrap(err)
-	}
-	// enforce explicit limit on resource size in order to prevent PluginData from
-	// growing uncontrollably.
-	if len(value) > teleport.MaxResourceSize {
-		return backend.Item{}, trace.BadParameter("plugin data size limit exceeded")
-	}
-	return backend.Item{
-		Key:     pluginDataKey(data.GetSubKind(), data.GetName()),
-		Value:   value,
-		Expires: data.Expiry(),
-		ID:      data.GetResourceID(),
-	}, nil
-}
-
-func itemToPluginData(item backend.Item) (types.PluginData, error) {
-	data, err := services.UnmarshalPluginData(
-		item.Value,
-		services.WithResourceID(item.ID),
-		services.WithExpires(item.Expires),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return data, nil
-}
-
 func accessRequestKey(name string) []byte {
 	return backend.Key(accessRequestsPrefix, name, paramsPrefix)
 }
 
-func pluginDataKey(kind string, name string) []byte {
-	return backend.Key(pluginDataPrefix, kind, name, paramsPrefix)
-}
-
 const (
 	accessRequestsPrefix = "access_requests"
-	pluginDataPrefix     = "plugin_data"
-	maxCmpAttempts       = 7
-	retryPeriodMs        = 2048
 )

--- a/lib/services/local/plugin_data.go
+++ b/lib/services/local/plugin_data.go
@@ -1,0 +1,219 @@
+package local
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+)
+
+// PluginDataService manages PluginData
+type PluginDataService struct {
+	backend.Backend
+}
+
+// NewPluginDataService creates a new PluginDataService
+func NewPluginDataService(backend backend.Backend) *PluginDataService {
+	return &PluginDataService{backend}
+}
+
+// GetPluginData loads all plugin data matching the supplied filter.
+func (s *PluginDataService) GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
+	data, err := s.getPluginData(ctx, filter)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return data, nil
+}
+
+// getPluginData returns an array of PluginData matching filter criteria
+func (s *PluginDataService) getPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
+	// Filters which specify Resource are a special case since they will match exactly zero or one
+	// possible PluginData instances.
+	if filter.Resource != "" {
+		item, err := s.Get(ctx, pluginDataKey(filter.Kind, filter.Resource))
+		if err != nil {
+			// A filter with zero matches is still a success, it just
+			// happens to return an empty slice.
+			if trace.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, trace.Wrap(err)
+		}
+		data, err := itemToPluginData(*item)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !filter.Match(data) {
+			// A filter with zero matches is still a success, it just
+			// happens to return an empty slice.
+			return nil, nil
+		}
+		return []types.PluginData{data}, nil
+	}
+
+	prefix := backend.Key(pluginDataPrefix, filter.Kind)
+	result, err := s.GetRange(ctx, prefix, backend.RangeEnd(prefix), backend.NoLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var matches []types.PluginData
+	for _, item := range result.Items {
+		if !bytes.HasSuffix(item.Key, []byte(paramsPrefix)) {
+			// Item represents a different resource type in the
+			// same namespace.
+			continue
+		}
+		data, err := itemToPluginData(item)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !filter.Match(data) {
+			continue
+		}
+		matches = append(matches, data)
+	}
+	return matches, nil
+}
+
+// UpsertsPluginData upserts a per-resource PluginData entry.
+func (s *PluginDataService) UpsertPluginData(ctx context.Context, params types.PluginDataUpdateParams, parentExpiresAt *time.Time) error {
+	return trace.Wrap(s.upsertPluginData(ctx, params, parentExpiresAt))
+}
+
+// updatePluginData updates or creates PluginData using CAS
+func (s *PluginDataService) upsertPluginData(ctx context.Context, params types.PluginDataUpdateParams, parentExpiresAt *time.Time) error {
+	retryPeriod := retryPeriodMs * time.Millisecond
+	retry, err := utils.NewLinear(utils.LinearConfig{
+		Step: retryPeriod / 7,
+		Max:  retryPeriod,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// Update is attempted multiple times in the event of concurrent writes.
+	for i := 0; i < maxCmpAttempts; i++ {
+		var create bool
+		var data types.PluginData
+		item, err := s.Get(ctx, pluginDataKey(params.Kind, params.Resource))
+		if err == nil {
+			data, err = itemToPluginData(*item)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			create = false
+		} else {
+			if !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
+			// In order to prevent orphaned plugin data, we automatically
+			// configure new instances to expire shortly after the resource
+			// to which they are associated.  This discrepency in expiry gives
+			// plugins the ability to use stored data when handling an expiry
+			// (OpDelete) event.
+			if parentExpiresAt == nil {
+				return trace.BadParameter("missing parent resource %q", params.Kind)
+			}
+			exp := *parentExpiresAt
+
+			data, err = types.NewPluginData(params.Resource, params.Kind)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			// A resource can have empty expiration time by default.
+			// In this case, we should leave PluginData expiration time empty as well.
+			// TODO: PluginData must be destroyed with parent resource. This needs to be addressed in future.
+			if !exp.IsZero() {
+				data.SetExpiry(exp.Add(time.Hour))
+			}
+			create = true
+		}
+		if err := data.Update(params); err != nil {
+			return trace.Wrap(err)
+		}
+		if err := data.CheckAndSetDefaults(); err != nil {
+			return trace.Wrap(err)
+		}
+		newItem, err := itemFromPluginData(data)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if create {
+			if _, err := s.Create(ctx, newItem); err != nil {
+				if trace.IsAlreadyExists(err) {
+					select {
+					case <-retry.After():
+						retry.Inc()
+						continue
+					case <-ctx.Done():
+						return trace.Wrap(ctx.Err())
+					}
+				}
+				return trace.Wrap(err)
+			}
+		} else {
+			if _, err := s.CompareAndSwap(ctx, *item, newItem); err != nil {
+				if trace.IsCompareFailed(err) {
+					select {
+					case <-retry.After():
+						retry.Inc()
+						continue
+					case <-ctx.Done():
+						return trace.Wrap(ctx.Err())
+					}
+				}
+				return trace.Wrap(err)
+			}
+		}
+		return nil
+	}
+	return trace.CompareFailed("too many concurrent writes to plugin data %s", params.Resource)
+}
+
+// pluginDataKey constructs PluginData entry backend key
+func pluginDataKey(kind string, name string) []byte {
+	return backend.Key(pluginDataPrefix, kind, name, paramsPrefix)
+}
+
+func itemFromPluginData(data types.PluginData) (backend.Item, error) {
+	value, err := services.MarshalPluginData(data)
+	if err != nil {
+		return backend.Item{}, trace.Wrap(err)
+	}
+	// enforce explicit limit on resource size in order to prevent PluginData from
+	// growing uncontrollably.
+	if len(value) > teleport.MaxResourceSize {
+		return backend.Item{}, trace.BadParameter("plugin data size limit exceeded")
+	}
+	return backend.Item{
+		Key:     pluginDataKey(data.GetSubKind(), data.GetName()),
+		Value:   value,
+		Expires: data.Expiry(),
+		ID:      data.GetResourceID(),
+	}, nil
+}
+
+func itemToPluginData(item backend.Item) (types.PluginData, error) {
+	data, err := services.UnmarshalPluginData(
+		item.Value,
+		services.WithResourceID(item.ID),
+		services.WithExpires(item.Expires),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return data, nil
+}
+
+const (
+	pluginDataPrefix = "plugin_data" // PluginData storage prefix
+	maxCmpAttempts   = 7             // Max CAS attempts on plugin save
+	retryPeriodMs    = 2048          // CAS retry period
+)

--- a/lib/services/plugin_data.go
+++ b/lib/services/plugin_data.go
@@ -17,11 +17,23 @@ limitations under the License.
 package services
 
 import (
+	"context"
+	"time"
+
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+// PluginData is responsible for managing a per-resource PluginData entries.
+type PluginData interface {
+	// GetPluginData loads all plugin data matching the supplied filter.
+	GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error)
+
+	// UpsertPluginData upserts a per-resource PluginData entry.
+	UpsertPluginData(ctx context.Context, params types.PluginDataUpdateParams, parentExpiresAt *time.Time) error
+}
 
 //MarshalPluginData marshals the PluginData resource to JSON.
 func MarshalPluginData(pluginData types.PluginData, opts ...MarshalOption) ([]byte, error) {


### PR DESCRIPTION
For now, PluginData is attachable to AccessRequest only. While it is still possible to attach PluginData to a whole entity (without id specified), a plugin might not have access to AccessRequests at all (as event handler, for example). We need a way to store plugin-wide persistent data. The easiest approach is to attach plugin-wide data to a plugin primary user.

This PR enables attaching PluginData to User.

Please, check TODOs: 

1. lib/auth/auth_with_roles.go: I am not sure how to correctly perform auth checks in UpdatePluginData() and GetPluginData(). We must ensure not only that a user has access to "UserPluginData", but that a user has access to a specific user in scope (himself).
2. AccessRequests have expiration time. PluginData TTL is explicitly set to parent AccessRequest.Expires + 1h on create. This ensures that there would be no orphaned PluginData. Normally, user does not have any TTL. So, PluginData is created with no expiration by default. That might become a problem. However, I am not sure that this is the scope of this PR.