### PR TITLE
Do not publish any pre-release versions to deb/rpm repos

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4329,13 +4329,14 @@ steps:
   # step, as there is a chance that everything afterwards will be skipped.
   #
   # this step exits early and skips all remanining steps in the pipeline if the
-  # tag looks like a pre-release, to avoid publishing RPMs for pre-release builds.
+  # tag looks like a pre-release (contains a hyphen) or has build metadata
+  # (contains a plus), to avoid publishing packages for pre-release builds.
   - name: Determine whether RPM/DEB packages should be published to repos
     image: docker
     commands:
       - |
         # length will be 0 after filtering if this is a pre-release, >0 otherwise
-        FILTERED_TAG_LENGTH=$(echo ${DRONE_TAG} | egrep -v '(alpha|beta|dev|rc)' | wc -c)
+        FILTERED_TAG_LENGTH=$(echo ${DRONE_TAG} | egrep -v '[-+]' | wc -c)
         if [ $$FILTERED_TAG_LENGTH -eq 0 ]; then
           echo "---> ${DRONE_TAG} looks like a pre-release, not publishing packages to repos"
           # exit pipeline early with success status
@@ -4500,6 +4501,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 133ae570a8876dfc189b0d952866a3f92b1d95a14ca9bcafef1122fddac84862
+hmac: 379a0c505039aeddd8508122362c4de5c1daf58a106314a59be5a8646e6c19ea
 
 ...


### PR DESCRIPTION
## Summary
We've seen a couple pre-release tags escape into our packages repos:

 * teleport_6.2.14-debug
 * teleport_6.2.18-label-debug

Instead of blocking a shortlist of unwanted tags, we now do not release
packages for any version with a '-' (prerelease) or a '+' (includes
build metadata), as either of these are noise our customers probably
don't need to see.

## Testing Done
```console
$ echo v6.2.18-label-debug.2  | egrep -v '[-+]'
$ echo $?
1
$ echo v8.0.0+12345678  | egrep -v '[-+]'
$ echo $?
1
$ echo v8.0.0  | egrep -v '[-+]'
v8.0.0
$ echo $?
0
```

## Other Tasks
I'll remove the two pre-release versions from our deb and rpm repos if/when this merges and is fully backported.