### PR TITLE
Add Teleport loadtest infrastructure and grafana dashboard

### DIFF
--- a/assets/loadtest/.gitignore
+++ b/assets/loadtest/.gitignore
@@ -1,0 +1,15 @@
+etcd/certs/*.pem
+
+teleport/oidc.yaml
+k8s/certificate.yaml
+
+k8s/secrets/**
+!k8s/secrets/Makefile
+**/*-gen.yaml
+
+**/profiles/**
+
+**/.terraform
+**/.terraform.lock*
+**/terraform.tfstate*
+**/terraform.tfvars

--- a/assets/loadtest/Makefile
+++ b/assets/loadtest/Makefile
@@ -1,0 +1,56 @@
+SOAK_TEST_DURATION ?= 30m
+USE_CERT_MANAGER ?= yes
+
+.PHONY: reserve-ips
+reserve-ips:
+	@make -C network apply
+
+# create gke cluster 
+.PHONY: create-cluster
+create-cluster:
+	@make -C ./cluster apply
+	@make -C ./cluster get-creds
+
+# delete gke cluster
+.PHONY: delete-cluster
+delete-cluster:
+	@make -C cluster destroy USE_CERT_MANAGER=$(USE_CERT_MANAGER)
+
+# deploy teleport with etcd backend to loadtest namespace
+.PHONY: deploy-etcd-cluster
+deploy-etcd-cluster:
+	@make -C k8s apply BACKEND=etcd USE_CERT_MANAGER=$(USE_CERT_MANAGER)
+
+# deploy teleport with etcd backend to loadtest namespace
+.PHONY: deploy-firestore-cluster
+deploy-firestore-cluster:
+	@make -C k8s apply BACKEND=firestore USE_CERT_MANAGER=$(USE_CERT_MANAGER)
+
+# delete the loadtest namespace
+.PHONY: delete-deploy
+delete-deploy:
+	@make -C k8s clean USE_CERT_MANAGER=$(USE_CERT_MANAGER)
+
+# run soak tests
+.PHONY: run-soak-tests
+run-soak-tests:
+	@make -C k8s run-soak-tests SOAK_TEST_DURATION=$(SOAK_TEST_DURATION)	
+
+# run 500 node trusted cluster scaling test
+.PHONY: run-tc-scaling-test
+run-tc-scaling-test:
+	@make -C k8s run-tc-scaling-test
+
+.PHONY: run-scaling-test
+run-scaling-test:
+	@make -C k8s run-scaling-test
+
+# list pods in loadtest namespace
+.PHONY: pods
+pods:
+	@make -C k8s pods
+
+# collect heap and goroutine profiles
+.PHONY: collect-profiles
+collect-profiles:
+	@make -C k8s collect-profiles PROFILE_LOCATION=$(shell pwd)

--- a/assets/loadtest/Makefile
+++ b/assets/loadtest/Makefile
@@ -37,10 +37,17 @@ run-soak-tests:
 	@make -C k8s run-soak-tests SOAK_TEST_DURATION=$(SOAK_TEST_DURATION)	
 
 # run 500 node trusted cluster scaling test
+# This installs 500 trusted clusters, waits for a period of time and then
+# deletes all 500. When they are all removed from auth the process is repeated once more.
+# The test helps identify any potential memory leaks caused by remote clusters
 .PHONY: run-tc-scaling-test
 run-tc-scaling-test:
 	@make -C k8s run-tc-scaling-test
 
+# run the 10k scaling test
+# This tests installs 10,000 IoT nodes and then removes all 10,000 nodes after a fixed period of time.
+# The process repeats once more and then the same is done for non-IoT nodes. The test helps identify any
+# potential memory leaks caused by large clusters for both non-IoT and IoT nodes.
 .PHONY: run-scaling-test
 run-scaling-test:
 	@make -C k8s run-scaling-test

--- a/assets/loadtest/README.md
+++ b/assets/loadtest/README.md
@@ -24,7 +24,7 @@ Teleports manual release test plan.
 ### Creating the Cluster
 
 First create a cluster, if you are running this automation for the first time, you may be asked to run
-`terraform init` before continuing. To resize the cluster, edit [`terraform.tfvars`](./cluster/terraform.tfvars) as needed.
+`terraform init` from the cluster directory before continuing. To resize the cluster, edit [`terraform.tfvars`](./cluster/terraform.tfvars) as needed.
 
 ```bash
 $ make create-cluster
@@ -77,11 +77,9 @@ $ make delpoy-etcd-cluster
 ### Firestore Backend
 
 To use the firestore backend you must have a GCP service account key with `Cloud Datastore User`, `Cloud Datastore Index Admin`
-`Storage Object Creator`, `Storage Object Viewer`. Set `GCP_CREDS_LOCATION` to the location that you saved the service account key. You
-must also set the `GCP_PROJECT` variable to the name of the GCP project.
+`Storage Object Creator`, `Storage Object Viewer`. Set `GCP_CREDS_LOCATION` to the location that you saved the service account key.
 
 ```bash
-$ export GCP_PROJECT=loadtest-project
 $ export GCP_CREDS_LOCATION=/path/to/service/account/key
 $ make delpoy-firestore-cluster
 ```

--- a/assets/loadtest/README.md
+++ b/assets/loadtest/README.md
@@ -1,0 +1,122 @@
+# loadtest
+
+Automation for the `loadtest` kuberentes cluster and performing Teleport load tests.
+
+## About
+
+This automation sets up a kubernetes cluster named `loadtest` in the configured GCP project.  
+This cluster is used for, among other things, the `1k`/`10k` scaling tests that are performed as part of
+Teleports manual release test plan.
+
+## Setup
+
+### Prerequisites
+- Make sure you have the following tools installed:
+    - `terraform`
+    - `gcloud`
+    - `kubectl`
+- Make sure that you have a GCP service account key with `Compute Admin`, `Compute Network Admin`,
+      `Kubernetes Engine Admin`, `Kubernetes Engine Cluster Admin`, and `Service Account User`
+  - To authenticate as the service account follow these [instructions](https://cloud.google.com/docs/authentication/production)
+- Make sure you have reserved static ip addresses for the proxy and grafana
+  - This only needs to be done once per GCP project, see the [network docs](./network/README.md) for details
+
+### Creating the Cluster
+
+First create a cluster, if you are running this automation for the first time, you may be asked to run
+`terraform init` before continuing. To resize the cluster, edit [`terraform.tfvars`](./cluster/terraform.tfvars) as needed.
+
+```bash
+$ make create-cluster
+```
+
+### DNS Entries
+Before deploying anything to the cluster you first need to set `PROXY_HOST` and `GRAFANA_HOST`. These variables should
+be the DNS names to be used for the [`proxy`](./k8s/proxy.yaml)  and [`grafana`](./k8s/grafana.yaml) services. When everything is successfully deployed you should be able
+to navigate to `https://PROXY_HOST:3080` and `https://GRAFANA_HOST:8443` in your browser.
+
+```bash
+$ export PROXY_HOST=proxy.loadtest.com 
+$ export GRAFANA_HOST=grafana.loadtest.com
+```
+
+### TLS Certificates
+
+Certificates can be provisioned automatically via [cert-manager](https://cert-manager.io/) or by hand.
+
+#### cert-manager
+If you would like to use cert-manager to automatically retrieve TLS certificates for you, create 
+[`cetificate.yaml`](./k8s/certificate.yaml) with your `cert-manager.io/v1/ClusterIssuer`, `cert-manager.io/v1/Certificate` and any
+secrets required for your solver.
+
+#### Kubernetes secret
+
+To manual supply TLS certificates create a tls secret, run the following:
+
+```bash
+$ kubectl create secret tls teleport-tls -n loadtest \
+    --cert=path/to/cert/file \
+    --key=path/to/key/file
+```
+
+You **must** also provide `USE_CERT_MANAGER=no` to all make commands below.
+
+### Teleport Configuration
+You must supply an [OIDC Connector](https://goteleport.com/docs/enterprise/sso/oidc/) that will be used for authentication. Create [`oidc.yaml`](./teleport/oidc.yaml)
+before attempting to deploy Teleport to the cluster.
+
+
+## Deploy Teleport
+
+### etcd Backend
+
+```bash
+$ make delpoy-etcd-cluster
+```
+
+### Firestore Backend
+
+To use the firestore backend you must have a GCP service account key with `Cloud Datastore User`, `Cloud Datastore Index Admin`
+`Storage Object Creator`, `Storage Object Viewer`. Set `GCP_CREDS_LOCATION` to the location that you saved the service account key. You
+must also set the `GCP_PROJECT` variable to the name of the GCP project.
+
+```bash
+$ export GCP_PROJECT=loadtest-project
+$ export GCP_CREDS_LOCATION=/path/to/service/account/key
+$ make delpoy-firestore-cluster
+```
+
+## Running Tests
+
+To run soak tests:
+
+```bash
+$ make run-soak-tests
+```
+
+
+**Note:** You must have enough nodes in the cluster to run the following tests. Ensure your `node_count` in [`terraform.tfvars`](./cluster/terraform.tfvars) is correctly set.
+
+To run the 10k node scaling tests:
+
+```bash
+$ make run-scaling-test
+```
+
+To run the trusted cluster scaling test:
+```bash
+$ make run-tc-scaling-test
+```
+
+## Cleanup
+
+To delete the loadtest deployment:
+```bash
+$ make delete-deploy
+```
+
+
+To delete the entire cluster:
+```bash
+$ make delete-cluster
+```

--- a/assets/loadtest/README.md
+++ b/assets/loadtest/README.md
@@ -71,7 +71,7 @@ before attempting to deploy Teleport to the cluster.
 ### etcd Backend
 
 ```bash
-$ make delpoy-etcd-cluster
+$ make deploy-etcd-cluster
 ```
 
 ### Firestore Backend
@@ -81,7 +81,7 @@ To use the firestore backend you must have a GCP service account key with `Cloud
 
 ```bash
 $ export GCP_CREDS_LOCATION=/path/to/service/account/key
-$ make delpoy-firestore-cluster
+$ make deploy-firestore-cluster
 ```
 
 ## Running Tests

--- a/assets/loadtest/cluster/Makefile
+++ b/assets/loadtest/cluster/Makefile
@@ -22,3 +22,8 @@ destroy:
 .PHONY: get-cluster-name
 get-cluster-name:
 	@terraform output -raw cluster_name
+
+# print project name
+.PHONY: get-project
+get-project:
+	@terraform output -raw project

--- a/assets/loadtest/cluster/Makefile
+++ b/assets/loadtest/cluster/Makefile
@@ -1,0 +1,24 @@
+# preview cluster configuration
+.PHONY: plan
+plan:
+	terraform plan
+
+# apply cluster configuration
+.PHONY: apply
+apply:
+	terraform apply
+
+# authorize kubectl to manage the cluster
+.PHONY: get-creds
+get-creds:
+	gcloud container clusters get-credentials $(shell make get-cluster-name) --zone us-central1 --project teleport-loadtest
+
+# destroy the cluster
+.PHONY: destroy
+destroy:
+	terraform destroy
+
+# print cluster name
+.PHONY: get-cluster-name
+get-cluster-name:
+	@terraform output -raw cluster_name

--- a/assets/loadtest/cluster/README.md
+++ b/assets/loadtest/cluster/README.md
@@ -1,0 +1,43 @@
+# cluster
+
+Automation for creating the `loadtest` kuberentes cluster.
+
+## Usage
+
+Confirm that everything is working correctly:
+
+```bash
+$ make plan
+```
+
+If you are running this automation for the first time, you may be asked to run
+`terraform init` before continuing.
+
+
+To create/resize the cluster, edit [`terraform.tfvars`](./terraform.tfvars)
+as needed, then run:
+
+```bash
+$ make apply
+```
+
+*NOTE*: The node pool is spread across three regions, so the `nodes_per_zone` variable
+should be set to 1/3 the total desired nodes.  Nodes run ~100 pods each, so for a `1k` test for example, 
+you will need to set `nodes_per_zone` to `4`. Don't set this value larger than it needs to be.
+
+
+Once the cluster is up, configure `kubectl` with the appropriate credentials:
+
+```bash
+$ make get-creds
+```
+
+You should now be ready to proceed with test-specific setup (e.g. [k8s](../k8s)).
+
+---
+
+When you are done, make sure that you destroy the cluster:
+
+```bash
+$ make destroy
+```

--- a/assets/loadtest/cluster/README.md
+++ b/assets/loadtest/cluster/README.md
@@ -1,6 +1,6 @@
 # cluster
 
-Automation for creating the `loadtest` kuberentes cluster.
+Automation for creating the `loadtest` kubernetes cluster.
 
 ## Usage
 

--- a/assets/loadtest/cluster/main.tf
+++ b/assets/loadtest/cluster/main.tf
@@ -1,7 +1,7 @@
 provider "google" {
-  project     = var.project
-  region      = var.region
-  zone        = var.zone
+  project = var.project
+  region  = var.region
+  zone    = var.zone
 }
 
 terraform {

--- a/assets/loadtest/cluster/main.tf
+++ b/assets/loadtest/cluster/main.tf
@@ -1,0 +1,49 @@
+provider "google" {
+  project     = var.project
+  region      = var.region
+  zone        = var.zone
+}
+
+terraform {
+  required_version = ">= 0.12"
+}
+
+
+data "google_compute_network" "default" {
+  name = var.network
+}
+
+
+resource "google_container_cluster" "loadtest" {
+  name     = var.cluster_name
+  location = var.region
+
+  # clusters are always created with a default node pool,
+  # so specify the smallest allowed node count and then
+  # immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}
+
+resource "google_container_node_pool" "loadtest" {
+  name     = var.cluster_name
+  cluster  = google_container_cluster.loadtest.name
+  location = google_container_cluster.loadtest.location
+
+  node_count = var.nodes_per_zone
+
+  node_locations = var.node_locations
+
+  node_config {
+    machine_type = "n1-standard-8"
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}

--- a/assets/loadtest/cluster/main.tf
+++ b/assets/loadtest/cluster/main.tf
@@ -44,6 +44,7 @@ resource "google_container_node_pool" "loadtest" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
     ]
   }
 }

--- a/assets/loadtest/cluster/outputs.tf
+++ b/assets/loadtest/cluster/outputs.tf
@@ -1,4 +1,9 @@
 output "cluster_name" {
-    description = "The gke cluster name"
-    value       = google_container_cluster.loadtest.name
+  description = "The gke cluster name"
+  value       = google_container_cluster.loadtest.name
+}
+
+output "project" {
+  description = "The project that the cluster was created in"
+  value       = var.project
 }

--- a/assets/loadtest/cluster/outputs.tf
+++ b/assets/loadtest/cluster/outputs.tf
@@ -1,0 +1,4 @@
+output "cluster_name" {
+    description = "The gke cluster name"
+    value       = google_container_cluster.loadtest.name
+}

--- a/assets/loadtest/cluster/variables.tf
+++ b/assets/loadtest/cluster/variables.tf
@@ -1,0 +1,40 @@
+variable "project" {
+  type        = string
+  description = "The project to manage resources in."
+}
+
+variable "region" {
+  type        = string
+  description = "The region to manage resources in."
+  default     = "us-central1"
+}
+
+variable "zone" {
+  type        = string
+  description = "The zone to manage resources in."
+  default     = "us-central1-a"
+}
+
+variable "nodes_per_zone" {
+  type        = number
+  description = "The number of kubernetes nodes per zone"
+  default     = 1
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster, unique within the project and location."
+  default     = "loadtest"
+}
+
+variable "node_locations" {
+  type        = set(string)
+  description = "The list of zones in which the node pool's nodes should be located."
+  default     = ["us-central1-b", "us-central1-f", "us-central1-c"]
+}
+
+variable "network" {
+  type        = string
+  description = "The network to be used by the cluster"
+  default     = "default-us-central1"
+}

--- a/assets/loadtest/etcd/Makefile
+++ b/assets/loadtest/etcd/Makefile
@@ -1,0 +1,9 @@
+# generates certificates
+.PHONY: all
+all:
+	make -C certs all
+
+# deletes generated certificates
+.PHONY: destroy
+destroy:
+	make -C certs clean

--- a/assets/loadtest/etcd/README.md
+++ b/assets/loadtest/etcd/README.md
@@ -1,0 +1,14 @@
+# etcd
+
+To generate self-signed certificates for secure connectivity to etcd run:
+
+```bash
+$ make
+```
+
+
+To delete the generated certificates run:
+
+```bash
+$ make clean
+```

--- a/assets/loadtest/etcd/certs/Makefile
+++ b/assets/loadtest/etcd/certs/Makefile
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# output:
+#   ca-key.pem      : private key of the trusted CA
+#   ca-cert.pem     : self-signed CA cert
+#   client-crt.pem  : client cert signed by CA
+# 	client-key.pem  : private key of the client
+.PHONY:all
+all: ca-cert.pem server-cert.pem client-cert.pem
+	@rm -rf *csr
+
+client-cert.pem:
+	# generate client key:
+	openssl req \
+		-new \
+		-nodes \
+		-keyout client-key.pem \
+		-subj "/C=US/ST=San Francisco/L=SOMA/O=Gravitational/CN=localhost" \
+		-out client.csr
+	# sign it with CA:
+	@touch index.txt
+	@echo '03' > serial
+	openssl ca -batch \
+		-extensions etcd_client \
+		-config openssl.cnf \
+	    -keyfile ca-key.pem \
+	    -cert ca-cert.pem \
+	    -out client-cert.pem \
+		-infiles client.csr
+	@rm -rf *old index* serial* 01.pem 03.pem
+
+server-cert.pem:
+	# generate server key:
+	openssl req \
+		-new \
+		-nodes \
+		-keyout server-key.pem \
+		-subj "/C=US/ST=San Francisco/L=SOMA/O=Gravitational/CN=localhost" \
+		-out server.csr
+	# sign it with CA:
+	@touch index.txt
+	@echo '01' > serial
+	openssl ca -batch \
+		-extensions etcd_server \
+		-config openssl.cnf \
+	    -keyfile ca-key.pem \
+	    -cert ca-cert.pem \
+	    -out server-cert.pem \
+		-infiles server.csr
+	@rm -rf *old index* serial*
+
+# Generates the "root" private key+cert which will become the trusted CA 
+# which can sign client certificates
+ca-cert.pem:
+	openssl req -x509 \
+		-extensions v3_ca \
+		-config openssl.cnf \
+		-new \
+		-keyout ca-key.pem \
+		-out ca-cert.pem \
+		-subj "/C=US/ST=San Francisco/L=SOMA/O=Gravitational/CN=localhost" \
+		-days 3650 \
+		-nodes
+
+# removes everything
+.PHONY:clean
+clean:
+	rm -rf *pem *csr *crt index* serial *-pass influx-token

--- a/assets/loadtest/etcd/certs/Makefile
+++ b/assets/loadtest/etcd/certs/Makefile
@@ -7,7 +7,6 @@
 # 	client-key.pem  : private key of the client
 .PHONY:all
 all: ca-cert.pem server-cert.pem client-cert.pem
-	@rm -rf *csr
 
 client-cert.pem:
 	# generate client key:
@@ -23,11 +22,11 @@ client-cert.pem:
 	openssl ca -batch \
 		-extensions etcd_client \
 		-config openssl.cnf \
-	    -keyfile ca-key.pem \
-	    -cert ca-cert.pem \
-	    -out client-cert.pem \
+		-keyfile ca-key.pem \
+		-cert ca-cert.pem \
+		-out client-cert.pem \
 		-infiles client.csr
-	@rm -rf *old index* serial* 01.pem 03.pem
+	@rm -rf *old index* serial* 01.pem 03.pem client.csr
 
 server-cert.pem:
 	# generate server key:
@@ -43,11 +42,11 @@ server-cert.pem:
 	openssl ca -batch \
 		-extensions etcd_server \
 		-config openssl.cnf \
-	    -keyfile ca-key.pem \
-	    -cert ca-cert.pem \
-	    -out server-cert.pem \
+		-keyfile ca-key.pem \
+		-cert ca-cert.pem \
+		-out server-cert.pem \
 		-infiles server.csr
-	@rm -rf *old index* serial*
+	@rm -rf *old index* serial* server.csr
 
 # Generates the "root" private key+cert which will become the trusted CA 
 # which can sign client certificates
@@ -65,4 +64,4 @@ ca-cert.pem:
 # removes everything
 .PHONY:clean
 clean:
-	rm -rf *pem *csr *crt index* serial *-pass influx-token
+	rm -rf *pem *csr *crt index* serial

--- a/assets/loadtest/etcd/certs/openssl.cnf
+++ b/assets/loadtest/etcd/certs/openssl.cnf
@@ -1,0 +1,78 @@
+# etcd OpenSSL configuration file.
+dir = .
+
+[ alt_names ]
+DNS.1 = etcd-0.etcd
+DNS.2 = etcd-1.etcd
+DNS.3 = etcd-2.etcd
+DNS.4 = localhost
+IP.4 = 127.0.0.1
+
+[ ca ]
+default_ca = etcd_ca
+
+[ etcd_ca ]
+certs            = $dir
+certificate      = $dir/ca-cert.pem
+crl              = $dir/crl.pem
+crl_dir          = $dir/crl
+crlnumber        = $dir/crlnumber
+database         = $dir/index.txt
+email_in_dn      = no
+new_certs_dir    = $dir
+private_key      = $dir/ca-key.pem
+serial           = $dir/serial
+RANDFILE         = $dir/.rand
+name_opt         = ca_default
+cert_opt         = ca_default
+default_days     = 3650
+default_crl_days = 30
+default_md       = sha512
+preserve         = no
+policy           = policy_etcd
+
+[ policy_etcd ]
+organizationName = optional
+commonName       = supplied
+
+[ req ]
+default_bits       = 4096
+default_keyfile    = privkey.pem
+distinguished_name = req_distinguished_name
+attributes         = req_attributes
+x509_extensions    = v3_ca
+string_mask        = utf8only
+req_extensions     = etcd_client
+
+[ req_distinguished_name ]
+countryName                = Country Name (2 letter code)
+countryName_default        = US
+countryName_min            = 2
+countryName_max            = 2
+commonName                 = Common Name (FQDN) 
+0.organizationName         = Organization Name (eg, company)
+0.organizationName_default = etcd-ca
+
+[ req_attributes ]
+
+[ v3_ca ]
+basicConstraints       = CA:true
+keyUsage               = keyCertSign,cRLSign
+subjectKeyIdentifier   = hash
+
+[ etcd_client ]
+basicConstraints       = CA:FALSE
+extendedKeyUsage       = clientAuth
+keyUsage               = digitalSignature, keyEncipherment
+
+[ etcd_peer ]
+basicConstraints       = CA:FALSE
+extendedKeyUsage       = clientAuth, serverAuth
+keyUsage               = digitalSignature, keyEncipherment
+subjectAltName         = @alt_names
+
+[ etcd_server ]
+basicConstraints       = CA:FALSE
+extendedKeyUsage       = clientAuth, serverAuth
+keyUsage               = digitalSignature, keyEncipherment
+subjectAltName         = @alt_names

--- a/assets/loadtest/etcd/telegraf.conf
+++ b/assets/loadtest/etcd/telegraf.conf
@@ -1,0 +1,137 @@
+# Configuration for telegraf agent
+[agent]
+    ## Default data collection interval for all inputs
+    interval = "10s"
+    ## Rounds collection interval to 'interval'
+    ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+    round_interval = true
+
+    ## Telegraf will send metrics to outputs in batches of at
+    ## most metric_batch_size metrics.
+    metric_batch_size = 1000
+    ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+    ## output, and will flush this buffer on a successful write. Oldest metrics
+    ## are dropped first when this buffer fills.
+    metric_buffer_limit = 10000
+
+    ## Collection jitter is used to jitter the collection by a random amount.
+    ## Each plugin will sleep for a random time within jitter before collecting.
+    ## This can be used to avoid many plugins querying things like sysfs at the
+    ## same time, which can have a measurable effect on the system.
+    collection_jitter = "0s"
+
+    ## Default flushing interval for all outputs. You shouldn't set this below
+    ## interval. Maximum flush_interval will be flush_interval + flush_jitter
+    flush_interval = "10s"
+    ## Jitter the flush interval by a random amount. This is primarily to avoid
+    ## large write spikes for users running a large number of telegraf instances.
+    ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+    flush_jitter = "0s"
+
+    ## By default, precision will be set to the same timestamp order as the
+    ## collection interval, with the maximum being 1s.
+    ## Precision will NOT be used for service inputs, such as logparser and statsd.
+    precision = ""
+    ## Run telegraf in debug mode
+    debug = false
+    ## Run telegraf in quiet mode
+    quiet = false
+    ## Override default hostname, if empty use os.Hostname()
+    hostname = ""
+    ## If set to true, do no set the "host" tag in the telegraf agent.
+    omit_hostname = false
+
+
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+
+[[inputs.procstat]]
+    exe = "etcd"
+    prefix = "etcd"
+
+[[inputs.prometheus]]
+    # An array of urls to scrape metrics from.
+    urls = ["https://127.0.0.1:2379/metrics"]
+    tls_ca = "/etc/etcd/certs/ca-cert.pem"
+    tls_cert = "/etc/etcd/certs/client-cert.pem"
+    tls_key = "/etc/etcd/certs/client-key.pem"
+    name_prefix = "etcd_"
+
+    # Add tags to be able to make beautiful dashboards
+    [inputs.prometheus.tags]
+    teleservice = "etcd"
+
+# Read metrics about cpu usage
+[[inputs.cpu]]
+    ## Whether to report per-cpu stats or not
+    percpu = true
+    ## Whether to report total system cpu stats or not
+    totalcpu = true
+    ## If true, collect raw CPU time metrics.
+    collect_cpu_time = false
+    ## If true, compute and report the sum of all non-idle CPU states.
+    report_active = false
+
+# Read metrics about disk usage by mount point
+[[inputs.disk]]
+    ## By default, telegraf gather stats for all mountpoints.
+    ## Setting mountpoints will restrict the stats to the specified mountpoints.
+    # mount_points = ["/"]
+
+    ## Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
+    ## present on /run, /var/run, /dev/shm or /dev).
+    ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
+
+# Read metrics about disk IO by device
+[[inputs.diskio]]
+
+# Get kernel statistics from /proc/stat
+[[inputs.kernel]]
+    # no configuration
+
+# Read metrics about memory usage
+[[inputs.mem]]
+    # no configuration
+
+# Get the number of processes and group them by status
+[[inputs.processes]]
+    # no configuration
+
+# Read metrics about swap memory usage
+[[inputs.swap]]
+    # no configuration
+
+# Read metrics about system load & uptime
+[[inputs.system]]
+    # no configuration
+
+# Read netstat info
+[[inputs.netstat]]
+
+# Read net info
+[[inputs.net]]
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+
+# Configuration for influxdb server to send metrics to
+[[outputs.influxdb_v2]]
+    ## The full HTTP or UDP endpoint URL for your InfluxDB instance.
+    ## Multiple urls can be specified as part of the same cluster,
+    ## this means that only ONE of the urls will be written to each interval.
+    urls = ["http://influxdb:8086"] # required
+
+    ## Token for authentication.
+    token = "${INFLUXDB_TOKEN}"
+
+    ## Organization is the name of the organization you wish to write to; must exist.
+    organization = "teleport"
+
+    ## Destination bucket to write into.
+    bucket = "telegraf"
+
+    ## Write timeout (for the InfluxDB client), formatted as a string.
+    ## If not provided, will default to 5s. 0s means no timeout (not recommended).
+    timeout = "5s"

--- a/assets/loadtest/grafana/dashboard.yaml
+++ b/assets/loadtest/grafana/dashboard.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+providers:
+  - name: Default
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/assets/loadtest/grafana/health-dashboard.json
+++ b/assets/loadtest/grafana/health-dashboard.json
@@ -1,0 +1,781 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Teleport",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Goroutine Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "hide": false,
+          "query": "  from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"teleport_go_goroutines\" and r._field == \"gauge\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines (Max Per Interval)",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "host"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "File Descriptors (Max)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": "  from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) =>r._measurement == \"teleport_process_open_fds\" and r._field == \"gauge\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Open File Descriptors (Max)",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "host"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Megabytes",
+            "axisPlacement": "auto",
+            "barAlignment": -1,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": " from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) =>r._measurement == \"teleport_go_memstats_heap_inuse_bytes\" and r._field == \"gauge\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Heap In Use Bytes",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "host"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Number of Cores",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": " from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) =>r._measurement == \"teleport_process_cpu_seconds_total\" and r._field == \"counter\")\n  |> derivative(nonNegative: true, unit: 10s)\n  |> map(fn: (r) => ({ r with _value: r._value / float(v: 10) }))",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Cores",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "host"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Event Size",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.2.3",
+      "targets": [
+        {
+          "query": "from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) =>r._measurement == \"teleport_watcher_events\" and r._field == \"sum\")\n  |> group(columns: [\"host\"])\n  |> sort(columns: [\"_time\"], desc: true)\n  |> aggregateWindow(every: 10s, fn: sum, createEmpty: false)\n  |> derivative(nonNegative: true, unit: 10s)",
+          "refId": "A"
+        }
+      ],
+      "title": "Events Per/Sec By Host",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "host"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Number of Events",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "query": " from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) =>r._measurement == \"teleport_watcher_events\" and r._field == \"count\")\n  |> group(columns: [\"host\"])\n  |> sort(columns: [\"_time\"], desc: true)\n  |> aggregateWindow(every: 10s, fn: sum, createEmpty: false)\n  |> derivative(nonNegative: true, unit: 10s)\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Events Emitted",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "host"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Event Size",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "hide": false,
+          "query": "from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"teleport_watcher_events\" and r._field == \"sum\")\n  |> map(fn: (r) => ({r with resource: if r.resource =~ /tunnel_connection\\/.*$/ then \"/tunnel_connection\" else r.resource}))\n  |> group(columns: [\"resource\"])\n  |> sort(columns: [\"_time\"], desc: true)\n  |> aggregateWindow(every: 10s, fn: sum, createEmpty: false)\n  |> derivative(nonNegative: true, unit: 10s)\n\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Events Per/Sec By Resource",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.2.3",
+      "targets": [
+        {
+          "query": "from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"teleport_watcher_events\" and r._field == \"count\")\n  |> map(fn: (r) => ({r with resource: if r.resource =~ /tunnel_connection\\/.*$/ then \"/tunnel_connection\" else r.resource}))\n  |> group(columns: [\"resource\"])\n  |> sort(columns: [\"_time\"], desc: true) \n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)",
+          "refId": "A"
+        }
+      ],
+      "title": "Resources Emitted",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "resource"
+          }
+        }
+      ],
+      "type": "piechart"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 24,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "8.2.3",
+      "targets": [
+        {
+          "query": "from(bucket: v.bucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"teleport_watcher_events\" and r._field == \"sum\")\n  |> map(fn: (r) => ({r with resource: if r.resource =~ /tunnel_connection\\/.*$/ then \"/tunnel_connection\" else r.resource}))\n  |> group(columns: [\"resource\"])\n  |> sort(columns: [\"_time\"], desc: true) \n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)",
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Sizes",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 31,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Teleport Health Stats",
+  "uid": "anXQA8F7z",
+  "version": 1
+}

--- a/assets/loadtest/grafana/influxdb-datasource.yaml
+++ b/assets/loadtest/grafana/influxdb-datasource.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+datasources:
+  - name: InfluxDB-Flux
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    user: admin
+    password: ${INFLUXDB_PASS}
+    isDefault: true
+    editable: true
+    basicAuth: true
+    jsonData:
+      version: Flux
+      defaultBucket: telegraf
+      organization: teleport
+    secureJsonData:
+      token: ${INFLUXDB_TOKEN}

--- a/assets/loadtest/grafana/nginx.conf
+++ b/assets/loadtest/grafana/nginx.conf
@@ -1,0 +1,65 @@
+worker_processes auto;
+user www-data;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 2048;
+}
+
+http {
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# TLS settings - we are pretty strict here
+    # but well, it's a dev service, why not?
+	##
+	ssl_protocols TLSv1.2;
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+	error_log stderr debug;
+	access_log /dev/stdout;
+
+
+	##
+	# Gzip Settings
+	##
+	gzip on;
+
+    #
+    # Frontend grafana with TLS
+    #
+    server {
+        listen 8443 default_server   ssl;
+        ssl_certificate_key          /etc/tls/certs/tls.key;
+        ssl_certificate              /etc/tls/certs/tls.crt;
+        ssl_ciphers                  AES256+EECDH:AES256+EDH:!aNULL;
+    
+        location / {
+            proxy_pass http://grafana:3000;
+        }
+    }
+
+    server {
+        listen 8888;
+    
+        location /healthz {
+            return 200 'alive and kicking!';
+        }
+    }
+}
+
+

--- a/assets/loadtest/k8s/Makefile
+++ b/assets/loadtest/k8s/Makefile
@@ -1,0 +1,449 @@
+LICENSE_PATH ?= /var/lib/teleport/license.pem
+CERT_MANAGER_VERSION ?= 1.6.0
+SOAK_TEST_DURATION ?= 30m
+BACKEND ?= etcd
+USE_CERT_MANAGER ?= yes
+
+# performs initialization needed for cluster
+# 1) generates etcd certs
+# 2) generates credentials for grafana and influx
+# 2) creates loadtest namespace
+# 3) installs cert-manager
+# 4) creates and applies secrets
+.PHONY: setup
+.PHONY: setup
+setup:
+ifeq ($(BACKEND), etcd)
+	make -C ../etcd/certs all
+endif
+	kubectl create namespace loadtest --dry-run=client -o yaml | kubectl apply -f -
+	make -C ./secrets all
+ifeq ($(USE_CERT_MANAGER), yes)
+	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v$(CERT_MANAGER_VERSION)/cert-manager.yaml
+endif
+	make generate-secrets
+
+# create kubernetes secrets 
+.PHONY: generate-secrets
+generate-secrets:
+ifeq ($(BACKEND), etcd)
+	kubectl create secret generic etcd-client-certs -n loadtest \
+		--from-file=client-cert.pem=../etcd/certs/client-cert.pem \
+		--from-file=client-key.pem=../etcd/certs/client-key.pem \
+		--from-file=ca-cert.pem=../etcd/certs/ca-cert.pem \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl create secret generic etcd-server-certs -n loadtest \
+		--from-file=server-cert.pem=../etcd/certs/server-cert.pem \
+		--from-file=server-key.pem=../etcd/certs/server-key.pem \
+		--from-file=ca-cert.pem=../etcd/certs/ca-cert.pem \
+		--dry-run=client -o yaml | kubectl apply -f -
+endif
+
+ifeq ($(BACKEND), firestore)
+	kubectl create secret generic gcp-creds -n loadtest \
+		--from-file=gcp_creds.json=${GCP_CREDS_LOCATION} \
+		--dry-run=client -o yaml | kubectl apply -f -
+endif
+
+	kubectl create secret generic influxdb-creds -n loadtest \
+		--from-file=INFLUXDB_PASS=./secrets/influx-pass \
+		--from-file=INFLUXDB_TOKEN=./secrets/influx-token \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl create secret generic grafana-creds -n loadtest \
+		--from-file=GF_SECURITY_ADMIN_PASSWORD=./secrets/grafana-pass \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl create secret generic license -n loadtest \
+		--from-file=license.pem=$(LICENSE_PATH) \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+# deletes the loadtest and cert-manager namespaces
+.PHONY: clean
+clean:
+	make -C secrets clean
+	make -C ../etcd/certs clean
+	kubectl delete namespace loadtest --ignore-not-found
+	kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v$(CERT_MANAGER_VERSION)/cert-manager.yaml --ignore-not-found
+
+
+ifeq ($(BACKEND), etcd)
+# deploys etcd, grafana, influxdb, and teleport to the loadtest namespace
+.PHONY: apply
+apply: setup install-etcd generate-certificates install-monitor install-teleport
+
+else ifeq ($(BACKEND), firestore)
+# deploys grafana, influxdb, and teleport to the loadtest namespace
+.PHONY: apply
+apply: setup generate-certificates install-monitor install-teleport
+
+endif
+
+ifeq ($(USE_CERT_MANAGER), yes)
+# generate-certificates applies a cert-manager.io/v1/ClusterIssuer and a cert-manager.io/v1/Certificate
+# that will automatically fetch tls certificates
+.PHONY: generate-certificates
+generate-certificates:
+	kubectl wait --for=condition=available --timeout=600s deploy cert-manager -n cert-manager
+	kubectl wait --for=condition=available --timeout=600s deploy cert-manager-webhook -n cert-manager
+	kubectl wait --for=condition=available --timeout=600s deploy cert-manager-cainjector -n cert-manager
+# we have to sleep here to due to issues with certmanager
+# Error from server (InternalError): error when creating "certificate.yaml": Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": x509: certificate signed by unknown authority
+# Error from server (InternalError): error when creating "certificate.yaml": Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": x509: certificate signed by unknown authority
+# See https://github.com/jetstack/cert-manager/issues/2602 and https://github.com/jetstack/cert-manager/issues/2752
+	@echo "waiting for cert-manager to be ready..."
+	@sleep 90
+	kubectl apply -f certificate.yaml
+else
+.PHONY: generate-certificates
+generate-certificates:
+endif
+
+# installs teleport auth, proxy, one IoT node and one non-IoT node
+.PHONY: install-teleport
+install-teleport: install-auth install-proxy install-node install-iot-node
+
+# deletes teleport deployments, services, and configmaps
+.PHONY: delete-teleport
+delete-teleport: delete-tc delete-nodes delete-proxy delete-auth
+
+# installs grafana and influxdb
+.PHONY: install-monitor
+install-monitor:
+	kubectl create configmap grafana-config -n loadtest \
+		--from-file=influxdb-datasource.yaml=../grafana/influxdb-datasource.yaml \
+		--from-file=health-dashboard.json=../grafana/health-dashboard.json \
+		--from-file=default.yaml=../grafana/dashboard.yaml \
+		--from-file=nginx.conf=../grafana/nginx.conf \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl apply -f influxdb.yaml
+	@make expand-yaml FILENAME=grafana
+	kubectl apply -f grafana-gen.yaml
+
+# deletes grafana and influxdb deployments, services and configmaps
+.PHONY: delete-monitor
+delete-monitor:
+	kubectl delete -f influxdb.yaml --ignore-not-found
+	kubectl delete -f grafana-gen.yaml --ignore-not-found
+	kubectl delete configmap grafana-config -n loadtest --ignore-not-found
+
+# installs an etcd cluster
+.PHONY: install-etcd
+install-etcd:
+	kubectl create configmap etcd-telegraf-config -n loadtest \
+		--from-file=telegraf.conf=../etcd/telegraf.conf \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl apply -f etcd.yaml
+
+# deletes etcd deployment, services, and configmaps
+.PHONY: delete-etcd
+delete-etcd:
+	kubectl delete -f etcd.yaml --ignore-not-found
+	kubectl delete configmap etcd-telegraf-config -n loadtest --ignore-not-found
+
+
+# install auth and applies required teleport resources for loadtests
+.PHONY: install-auth
+install-auth: setup-auth
+	kubectl wait --for=condition=ready pod -l teleport-role=auth -n loadtest --timeout=120s
+
+	kubectl -n loadtest exec deploy/auth -c teleport -it \
+		-- tctl --config /etc/teleport/teleport.yaml create -f /etc/teleport/admin.yaml
+	kubectl -n loadtest exec deploy/auth -c teleport -it \
+		-- tctl --config /etc/teleport/teleport.yaml create -f /etc/teleport/oidc.yaml
+	kubectl -n loadtest exec deploy/auth -c teleport -it \
+		-- tctl --config /etc/teleport/teleport.yaml create -f /etc/teleport/user.yaml
+
+
+ifeq ($(BACKEND), etcd)
+.PHONY: setup-auth
+setup-auth:
+	@make expand-yaml FILENAME=../teleport/teleport-auth-etcd
+
+	kubectl create configmap auth-config -n loadtest \
+		--from-file=teleport.yaml=../teleport/teleport-auth-etcd-gen.yaml \
+		--from-file=telegraf.conf=../teleport/telegraf.conf \
+		--from-file=oidc.yaml=../teleport/oidc.yaml \
+		--from-file=admin.yaml=../teleport/admin.yaml \
+		--from-file=user.yaml=../teleport/soaktest-user.yaml \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl apply -f auth-etcd.yaml
+else ifeq ($(BACKEND), firestore)
+.PHONY: setup-auth
+setup-auth:
+	@make expand-yaml FILENAME=../teleport/teleport-auth-firestore
+
+	kubectl create configmap auth-config -n loadtest \
+		--from-file=teleport.yaml=../teleport/teleport-auth-firestore-gen.yaml \
+		--from-file=telegraf.conf=../teleport/telegraf.conf \
+		--from-file=oidc.yaml=../teleport/oidc.yaml \
+		--from-file=admin.yaml=../teleport/admin.yaml \
+		--from-file=user.yaml=../teleport/soaktest-user.yaml \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl apply -f auth-firestore.yaml
+else
+.PHONY: setup-auth
+setup-auth:
+	@echo "unknown backend $(BACKEND)"
+	exit 1
+endif
+
+# deletes auth deployment, services and configmaps
+.PHONY: delete-auth
+delete-auth:
+	kubectl delete -f auth-etcd.yaml --ignore-not-found
+	kubectl delete -f auth-firestore.yaml --ignore-not-found
+	kubectl delete configmap auth-config -n loadtest --ignore-not-found
+
+# install proxy
+.PHONY: install-proxy
+install-proxy:
+	@make expand-yaml FILENAME=../teleport/teleport-proxy
+	kubectl create configmap proxy-config -n loadtest \
+		--from-file=teleport.yaml=../teleport/teleport-proxy-gen.yaml \
+		--from-file=telegraf.conf=../teleport/telegraf.conf \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+
+	@make expand-yaml FILENAME=proxy
+	kubectl apply -f proxy-gen.yaml
+
+# deletes proxy deployment, services and configmaps
+.PHONY: delete-proxy
+delete-proxy:
+	kubectl delete -f proxy-gen.yaml --ignore-not-found
+	kubectl delete configmap proxy-config -n loadtest --ignore-not-found
+
+# deletes all node deployment and configmaps
+.PHONY: delete-nodes
+delete-nodes: delete-node delete-iot-node
+
+# deletes all non-IoT nodes
+.PHONY: delete-node
+delete-node:
+	kubectl delete -f node.yaml --ignore-not-found
+	kubectl delete configmap node-config -n loadtest --ignore-not-found
+
+# deletes all IoT nodes
+.PHONY: delete-iot-node
+delete-iot-node:
+	kubectl delete -f iot-node.yaml --ignore-not-found
+	kubectl delete configmap iot-node-config -n loadtest --ignore-not-found
+
+# install one IoT node and one non-IoT node
+.PHONY: install-nodes
+install-nodes: install-iot-node install-node
+
+# install an IoT mode node
+.PHONY: install-iot-node
+install-iot-node:
+	@make expand-yaml FILENAME=../teleport/teleport-iot-node
+	kubectl create configmap iot-node-config -n loadtest \
+		--from-file=teleport.yaml=../teleport/teleport-iot-node-gen.yaml \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl apply -f iot-node.yaml
+
+# install a non-IoT mode node
+.PHONY: install-node
+install-node:
+	@make expand-yaml FILENAME=../teleport/teleport-node
+	kubectl create configmap node-config -n loadtest \
+		--from-file=teleport.yaml=../teleport/teleport-node-gen.yaml \
+		--dry-run=client -o yaml | kubectl apply -f -
+	
+	kubectl apply -f node.yaml
+
+# installs a trusted cluster
+.PHONY: install-tc
+install-tc:
+	@make expand-yaml FILENAME=../teleport/tc
+	kubectl create configmap tc-config -n loadtest \
+		--from-file=teleport.yaml=../teleport/teleport-tc.yaml \
+		--from-file=cluster.yaml=../teleport/tc-gen.yaml \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl apply -f tc.yaml
+
+# deletes all rc resources from teleport and deletes trusted cluster deployments and configmaps
+.PHONY: delete-tc
+delete-tc:
+	kubectl delete -f tc-gen.yaml --ignore-not-found
+	kubectl delete configmap tc-config -n loadtest --ignore-not-found
+
+	kubectl -n loadtest exec deploy/auth -c teleport -it \
+		-- /bin/bash -c "tctl --config /etc/teleport/teleport.yaml get rc | grep ' name:' | cut -d ':' -f2- | xargs -P 20 -n 1 -I {} tctl --config /etc/teleport/teleport.yaml rm rc/{}"
+
+# joins all trusted clusters to root cluster
+.PHONY: setup-tc
+setup-tc:
+	kubectl get pod -n loadtest -l app="tc" -o custom-columns=name:metadata.name --no-headers \
+    	| xargs -P 20 -n 1 -I {} kubectl -n loadtest exec {} -- tctl --config /etc/teleport/teleport.yaml create -f /etc/teleport/cluster.yaml
+
+# scales trusted clusters to 500
+.PHONY: scale-tc-500
+scale-tc-500:
+	kubectl scale --replicas=50 deploy tc -n loadtest
+
+# scales trusted cluters to 1
+.PHONY: scale-tc-1
+scale-tc-1:
+	kubectl scale --replicas=1 deploy tc -n loadtest
+
+# scales nodes to 1
+.PHONY: scale-1-non-iot
+scale-1-non-iot:
+	kubectl scale --replicas=1 deploy node -n loadtest
+
+# scales nodes to 1000
+.PHONY: scale-1k-non-iot
+scale-1k-non-iot:
+	kubectl scale --replicas=100 deploy node -n loadtest
+
+# scales nodes to 10000
+.PHONY: scale-10k-non-iot
+scale-10k-non-iot:
+	kubectl scale --replicas=10000 deploy node -n loadtest
+
+# scales nodes to 1
+.PHONY: scale-1-iot
+scale-1-iot:
+	kubectl scale --replicas=1 deploy iot-node -n loadtest
+
+# scales nodes to 1000
+.PHONY: scale-1k-iot
+scale-1k-iot:
+	kubectl scale --replicas=100 deploy iot-node -n loadtest
+
+# scales nodes to 10000
+.PHONY: scale-10k-iot
+scale-10k-iot:
+	kubectl scale --replicas=10000 deploy iot-node -n loadtest
+
+# gets pods in loadtest namespace
+.PHONY: pods
+pods:
+	kubectl get pods -n loadtest
+
+# removes all soak test jobs and configmaps
+.PHONY: delete-soaktest
+.PHONY: delete-soaktest
+delete-soaktest:
+	kubectl delete job -l app=soaktest -n loadtest --ignore-not-found
+
+	kubectl delete configmap soaktest-config -n loadtest --ignore-not-found
+
+# creates the soak test job
+.PHONY: install-soaktest
+install-soaktest:
+	kubectl create configmap soaktest-config -n loadtest \
+		--from-literal=DURATION=$(SOAK_TEST_DURATION) \
+		--from-file=auth=./secrets/soaktest-auth \
+		--dry-run=client -o yaml | kubectl apply -f -
+
+	kubectl create -f soaktest.yaml
+
+# deploys a job to run the soak tests
+.PHONY: run-soak-tests
+run-soak-tests:
+	kubectl -n loadtest exec $$(kubectl get pod -n loadtest -l teleport-role="auth" -o jsonpath="{.items[0].metadata.name}") -c teleport -it \
+		-- tctl auth sign --overwrite --user=soaktest-runner --out=/data/soaktest-auth --ttl=8760h --config /etc/teleport/teleport.yaml
+
+	kubectl cp -c teleport loadtest/$$(kubectl get pod -n loadtest -l teleport-role="auth" -o jsonpath="{.items[0].metadata.name}"):/data/soaktest-auth ./secrets/soaktest-auth
+
+	kubectl wait --for=condition=available --timeout=600s deploy/node -n loadtest
+	kubectl wait --for=condition=available --timeout=600s deploy/iot-node -n loadtest
+
+	@make install-soaktest
+
+	@sleep 1
+
+	kubectl wait --for=condition=ready pod $$(kubectl get pods --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}" -l app=soaktest -n loadtest) -n loadtest --timeout=120s
+	kubectl logs $$(kubectl get pods --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}" -l app=soaktest -n loadtest) -n loadtest --tail -1 -f
+
+# runs the node scaling tests
+.PHONY: run-scaling-test
+run-scaling-test:
+	@make delete-nodes
+	@make install-node
+	@make scale-10k-non-iot
+	@kubectl wait --for=condition=available deploy/node -n loadtest --timeout=60m
+	@sleep 30
+	@make scale-1-non-iot
+	@sleep 15
+	@make scale-10k-non-iot
+	@kubectl wait --for=condition=available deploy/node -n loadtest --timeout=60m
+	@sleep 15
+	@make scale-1-non-iot
+
+	@sleep 15
+
+	@make delete-nodes
+	@make install-iot-node
+	@make scale-10k-iot
+	@kubectl wait --for=condition=available deploy/iot-node -n loadtest --timeout=60m
+	@sleep 30
+	@make scale-1-iot
+	@sleep 15
+	@make scale-10k-iot
+	@kubectl wait --for=condition=available  deploy/iot-node -n loadtest --timeout=60m
+	@sleep 15
+	@make scale-1
+
+	@make delete-nodes
+	@make install-nodes
+
+# runs the trusted-cluster scaling tests
+.PHONY: run-tc-scaling-test
+run-tc-scaling-test:
+	@make install-tc
+	@make scale-tc-500
+	kubectl wait --for=condition=available deploy/tc -n loadtest --timeout=60m
+	@sleep 60
+	@make setup-tc
+
+	@sleep 180
+
+	@make delete-tc
+
+	@sleep 60
+
+	@make scale-tc-500
+	kubectl wait --for=condition=available deploy/tc -n loadtest --timeout=60m
+	@sleep 60
+	@make setup-tc
+	
+	@sleep 180
+	
+	@make delete-tc
+
+# collect goroutine and heap go profiles from the auth deployment
+.PHONY: collect-profiles
+collect-profiles:
+	kubectl port-forward service/auth 3434:3434 -n loadtest > /dev/null 2>&1 &
+
+	@echo "waiting for auth to be available..."
+
+	@timeout 30 sh -c 'until nc -z localhost 3434; do sleep 0.5; done'
+
+	@make fetch-profiles LOCATION=$(shell date +%s)
+
+	kill -s kill $$(pgrep -f 3434:3434)
+
+# downloads the remote profiles
+.PHONY: fetch-profiles
+fetch-profiles:
+	mkdir -p $(shell pwd)/profiles/$(LOCATION)/
+	curl -o $(shell pwd)/profiles/$(LOCATION)/goroutine.profile http://127.0.0.1:3434/debug/pprof/goroutine
+	curl -o $(shell pwd)/profiles/$(LOCATION)/heap.profile http://127.0.0.1:3434/debug/pprof/heap
+
+# expands any placeholders in the provided yaml file with the value in the matching environment variable. the
+# output file will be named the same with a -gen suffix, i.e input = test then output will be test-gen.yaml
+.PHONY: expand-yaml
+expand-yaml:
+	@bash -c "set -a && source ./secrets/secrets.env && set +a && envsubst < $(FILENAME).yaml > $(FILENAME)-gen.yaml"

--- a/assets/loadtest/k8s/Makefile
+++ b/assets/loadtest/k8s/Makefile
@@ -11,7 +11,6 @@ USE_CERT_MANAGER ?= yes
 # 3) installs cert-manager
 # 4) creates and applies secrets
 .PHONY: setup
-.PHONY: setup
 setup:
 ifeq ($(BACKEND), etcd)
 	make -C ../etcd/certs all

--- a/assets/loadtest/k8s/auth-etcd.yaml
+++ b/assets/loadtest/k8s/auth-etcd.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth
+  namespace: loadtest
+  labels:
+    teleport-role: auth
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      teleport-role: auth
+  template:
+    metadata:
+      labels:
+        teleport-role: auth
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: auth-config
+        - name: certs
+          secret:
+            secretName: etcd-client-certs
+        - name: license
+          secret:
+            secretName: license
+        - name: storage
+          emptyDir: {}
+      containers:
+        - name: telegraf
+          image: telegraf:1.20.3
+          envFrom:
+            - secretRef:
+                name: influxdb-creds
+          volumeMounts:
+            - name: config
+              mountPath: /etc/telegraf/telegraf.conf
+              subPath: telegraf.conf
+              readOnly: true
+        - name: teleport
+          image: quay.io/gravitational/teleport-ent:8.0.0
+          args: ["-d", "--insecure"]
+          ports:
+            - name: diag
+              containerPort: 3434
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 3434
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3434
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/teleport/
+              readOnly: true
+            - name: license
+              mountPath: /var/lib/teleport/license.pem
+              subPath: license.pem
+              readOnly: true
+            - name: certs
+              mountPath: /etc/etcd/certs/
+              readOnly: true
+            - mountPath: /data
+              name: storage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth
+  namespace: loadtest
+spec:
+  ports:
+    - name: auth
+      port: 3025
+      targetPort: 3025
+    - name: diag
+      port: 3434
+      targetPort: 3434
+  selector:
+    teleport-role: auth
+  type: ClusterIP

--- a/assets/loadtest/k8s/auth-etcd.yaml
+++ b/assets/loadtest/k8s/auth-etcd.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     teleport-role: auth
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       teleport-role: auth
@@ -39,7 +39,7 @@ spec:
               subPath: telegraf.conf
               readOnly: true
         - name: teleport
-          image: quay.io/gravitational/teleport-ent:8.0.0
+          image: gcr.io/teleport-loadtest/teleport:8.0.0-tross.dev.1
           args: ["-d", "--insecure"]
           ports:
             - name: diag

--- a/assets/loadtest/k8s/auth-firestore.yaml
+++ b/assets/loadtest/k8s/auth-firestore.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth
+  namespace: loadtest
+  labels:
+    teleport-role: auth
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      teleport-role: auth
+  template:
+    metadata:
+      labels:
+        teleport-role: auth
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: auth-config
+        - name: creds
+          secret:
+            secretName: gcp-creds
+        - name: license
+          secret:
+            secretName: license
+        - name: storage
+          emptyDir: {}
+      containers:
+        - name: telegraf
+          image: telegraf:1.20.3
+          envFrom:
+            - secretRef:
+                name: influxdb-creds
+          volumeMounts:
+            - name: config
+              mountPath: /etc/telegraf/telegraf.conf
+              subPath: telegraf.conf
+              readOnly: true
+        - name: teleport
+          image: quay.io/gravitational/teleport-ent:8.0.0
+          args: ["-d", "--insecure"]
+          ports:
+            - name: diag
+              containerPort: 3434
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 3434
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3434
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/teleport/
+              readOnly: true
+            - name: license
+              mountPath: /var/lib/teleport/license.pem
+              subPath: license.pem
+              readOnly: true
+            - name: creds
+              mountPath: /var/lib/teleport/gcp_creds.json
+              subPath: gcp_creds.json
+              readOnly: true
+            - mountPath: /data
+              name: storage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth
+  namespace: loadtest
+spec:
+  ports:
+    - name: auth
+      port: 3025
+      targetPort: 3025
+    - name: diag
+      port: 3434
+      targetPort: 3434
+  selector:
+    teleport-role: auth
+  type: ClusterIP

--- a/assets/loadtest/k8s/etcd.yaml
+++ b/assets/loadtest/k8s/etcd.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: etcd
+  namespace: loadtest
+  labels:
+    app: etcd
+spec:
+  serviceName: etcd
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+  template:
+    metadata:
+      name: etcd
+      labels:
+        app: etcd
+    spec:
+      volumes:
+        - name: telegraf-config
+          configMap:
+            name: etcd-telegraf-config
+        - name: server-certs
+          secret:
+            secretName: etcd-server-certs
+        - name: client-certs
+          secret:
+            secretName: etcd-client-certs
+      containers:
+        - name: telegraf
+          image: telegraf:1.20.3
+          envFrom:
+            - secretRef:
+                name: influxdb-creds
+          volumeMounts:
+            - name: telegraf-config
+              mountPath: /etc/telegraf
+              readOnly: true
+            - name: client-certs
+              mountPath: /etc/etcd/certs/
+              readOnly: true
+        - name: etcd
+          image: quay.io/coreos/etcd:v3.3.25
+          ports:
+            - containerPort: 2379
+              name: client
+            - containerPort: 2380
+              name: peer
+          volumeMounts:
+            - name: server-certs
+              mountPath: /etc/etcd/certs/
+              readOnly: true
+          command:
+            - /bin/sh
+            - -c
+            - |
+              PEERS="etcd-0=https://etcd-0.etcd:2380,etcd-1=https://etcd-1.etcd:2380,etcd-2=https://etcd-2.etcd:2380"
+              exec etcd \
+                --name ${HOSTNAME} \
+                --advertise-client-urls https://${HOSTNAME}.etcd:2379 \
+                --listen-client-urls https://0.0.0.0:2379 \
+                --initial-advertise-peer-urls https://${HOSTNAME}.etcd:2380 \
+                --listen-peer-urls https://0.0.0.0:2380 \
+                --initial-cluster ${PEERS} \
+                --trusted-ca-file=/etc/etcd/certs/ca-cert.pem \
+                --cert-file=/etc/etcd/certs/server-cert.pem \
+                --key-file=/etc/etcd/certs/server-key.pem \
+                --peer-cert-file=/etc/etcd/certs/server-cert.pem \
+                --peer-key-file=/etc/etcd/certs/server-key.pem \
+                --peer-trusted-ca-file=/etc/etcd/certs/ca-cert.pem \
+                --client-cert-auth \
+                --peer-client-cert-auth \
+                --auto-compaction-retention=1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+  namespace: loadtest
+  labels:
+    app: etcd
+spec:
+  clusterIP: None
+  ports:
+    - port: 2379
+      name: client
+    - port: 2380
+      name: peer
+  selector:
+    app: etcd

--- a/assets/loadtest/k8s/grafana.yaml
+++ b/assets/loadtest/k8s/grafana.yaml
@@ -1,0 +1,140 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+  namespace: loadtest
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      volumes:
+        - name: grafana-config
+          configMap:
+            name: grafana-config
+        - name: teleport-tls
+          secret:
+            secretName: teleport-tls
+      securityContext:
+        fsGroup: 472
+        supplementalGroups:
+          - 0
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 8443
+              name: https-grafana
+              protocol: TCP
+            - containerPort: 8888
+              name: health
+              protocol: TCP
+          volumeMounts:
+            - name: teleport-tls
+              mountPath: /etc/tls/certs/
+              readOnly: true
+            - name: grafana-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8888
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 8888
+        - name: grafana
+          image: grafana/grafana:8.2.3
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: grafana-creds
+            - secretRef:
+                name: influxdb-creds
+          ports:
+            - containerPort: 3000
+              name: http-grafana
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /robots.txt
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3000
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 250m
+              memory: 750Mi
+          volumeMounts:
+            - mountPath: /etc/grafana/provisioning/datasources/influxdb-datasource.yaml
+              name: grafana-config
+              readOnly: true
+              subPath: influxdb-datasource.yaml
+            - mountPath: /etc/grafana/provisioning/dashboards/default.yaml
+              name: grafana-config
+              readOnly: true
+              subPath: default.yaml
+            - mountPath: /var/lib/grafana/dashboards/health-dashboard.json
+              name: grafana-config
+              subPath: health-dashboard.json
+              readOnly: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-https
+  namespace: loadtest
+spec:
+  type: LoadBalancer
+  loadBalancerIP: ${GRAFANA_IP}
+  selector:
+    app: grafana
+  ports:
+    - name: web
+      protocol: TCP
+      port: 8443
+      targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: loadtest
+spec:
+  selector:
+    app: grafana
+  ports:
+    - name: web
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+

--- a/assets/loadtest/k8s/influxdb.yaml
+++ b/assets/loadtest/k8s/influxdb.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: influxdb-config
+  namespace: loadtest
+data:
+  DOCKER_INFLUXDB_INIT_MODE: setup
+  DOCKER_INFLUXDB_INIT_USERNAME: admin
+  DOCKER_INFLUXDB_INIT_ORG: teleport
+  DOCKER_INFLUXDB_INIT_BUCKET: telegraf
+  DOCKER_INFLUXDB_INIT_RETENTION: 1w
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: influxdb
+  name: influxdb
+  namespace: loadtest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: influxdb
+  template:
+    metadata:
+      labels:
+        app: influxdb
+    spec:
+      containers:
+        - image: influxdb:2.0.9
+          name: influxdb
+          ports:
+            - containerPort: 8086
+              name: influxdb
+          env:
+            - name: DOCKER_INFLUXDB_INIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: influxdb-creds
+                  key: INFLUXDB_PASS
+            - name: DOCKER_INFLUXDB_INIT_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: influxdb-creds
+                  key: INFLUXDB_TOKEN
+          envFrom:
+            - configMapRef:
+                name: influxdb-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: influxdb
+  namespace: loadtest
+spec:
+  ports:
+    - name: influxdb
+      port: 8086
+      targetPort: 8086
+  selector:
+    app: influxdb
+  type: ClusterIP

--- a/assets/loadtest/k8s/iot-node.yaml
+++ b/assets/loadtest/k8s/iot-node.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    teleport-role: node
+  name: iot-node
+  namespace: loadtest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      teleport-role: node
+      node: iot
+  template:
+    metadata:
+      labels:
+        teleport-role: node
+        node: iot
+    spec:
+      containers:
+        - image: quay.io/gravitational/teleport-ent:8.0.0
+          name: teleport
+          args: ["-d", "--insecure"]
+          ports:
+            - name: nodessh
+              containerPort: 3022
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/teleport
+              name: config
+              readOnly: true
+      volumes:
+        - configMap:
+            name: iot-node-config
+          name: config

--- a/assets/loadtest/k8s/iot-node.yaml
+++ b/assets/loadtest/k8s/iot-node.yaml
@@ -18,7 +18,7 @@ spec:
         node: iot
     spec:
       containers:
-        - image: quay.io/gravitational/teleport-ent:8.0.0
+        - image: gcr.io/teleport-loadtest/teleport:8.0.0-tross.dev.1
           name: teleport
           args: ["-d", "--insecure"]
           ports:

--- a/assets/loadtest/k8s/node.yaml
+++ b/assets/loadtest/k8s/node.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    teleport-role: node
+  name: node
+  namespace: loadtest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      teleport-role: node
+      node: regular
+  template:
+    metadata:
+      labels:
+        teleport-role: node
+        node: regular
+    spec:
+      containers:
+        - image: quay.io/gravitational/teleport-ent:8.0.0
+          name: teleport
+          args: ["-d", "--insecure"]
+          ports:
+            - name: nodessh
+              containerPort: 3022
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/teleport
+              name: config
+              readOnly: true
+      volumes:
+        - configMap:
+            name: node-config
+          name: config

--- a/assets/loadtest/k8s/node.yaml
+++ b/assets/loadtest/k8s/node.yaml
@@ -18,7 +18,7 @@ spec:
         node: regular
     spec:
       containers:
-        - image: quay.io/gravitational/teleport-ent:8.0.0
+        - image: gcr.io/teleport-loadtest/teleport:8.0.0-tross.dev.1
           name: teleport
           args: ["-d", "--insecure"]
           ports:

--- a/assets/loadtest/k8s/proxy.yaml
+++ b/assets/loadtest/k8s/proxy.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxy
+  namespace: loadtest
+  labels:
+    teleport-role: proxy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      teleport-role: proxy
+  template:
+    metadata:
+      labels:
+        teleport-role: proxy
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: proxy-config
+        - name: teleport-tls
+          secret:
+            secretName: teleport-tls
+      containers:
+        - name: telegraf
+          image: telegraf:1.20.3
+          envFrom:
+            - secretRef:
+                name: influxdb-creds
+          volumeMounts:
+            - name: config
+              mountPath: /etc/telegraf/telegraf.conf
+              subPath: telegraf.conf
+        - name: teleport
+          image: quay.io/gravitational/teleport-ent:8.0.0
+          args: ["-d", "--insecure"]
+          ports:
+            - name: diag
+              containerPort: 3434
+              protocol: TCP
+            - name: web
+              containerPort: 3080
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 3434
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3434
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/teleport/
+              readOnly: true
+            - name: teleport-tls
+              mountPath: /etc/teleport-tls/
+              readOnly: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy
+  namespace: loadtest
+  labels:
+    teleport-role: proxy
+spec:
+  type: LoadBalancer  
+  loadBalancerIP: ${PROXY_IP}
+  ports:
+  - name: https
+    port: 3080
+    targetPort: 3080
+    protocol: TCP
+  - name: sshproxy
+    port: 3023
+    targetPort: 3023
+    protocol: TCP
+  - name: k8s
+    port: 3026
+    targetPort: 3026
+    protocol: TCP
+  - name: sshtun
+    port: 3024
+    targetPort: 3024
+    protocol: TCP
+  - name: mysql
+    port: 3036
+    targetPort: 3036
+    protocol: TCP
+  selector:
+    teleport-role: proxy

--- a/assets/loadtest/k8s/proxy.yaml
+++ b/assets/loadtest/k8s/proxy.yaml
@@ -33,7 +33,7 @@ spec:
               mountPath: /etc/telegraf/telegraf.conf
               subPath: telegraf.conf
         - name: teleport
-          image: quay.io/gravitational/teleport-ent:8.0.0
+          image: gcr.io/teleport-loadtest/teleport:8.0.0-tross.dev.1
           args: ["-d", "--insecure"]
           ports:
             - name: diag

--- a/assets/loadtest/k8s/secrets/Makefile
+++ b/assets/loadtest/k8s/secrets/Makefile
@@ -20,7 +20,7 @@ env:
 	@echo NODE_TOKEN=$(shell cat node-token) >> secrets.env
 	@echo PROXY_TOKEN=$(shell cat proxy-token) >> secrets.env
 	@echo TC_TOKEN=$(shell cat tc-token) >> secrets.env
-	@echo GCP_PROJECT=${GCP_PROJECT} >> secrets.env
+	@echo GCP_PROJECT=$(shell make -C ../../cluster get-project) >> secrets.env
 
 grafana-pass:
 	openssl rand -base64 32 | tr -d '\n' > grafana-pass

--- a/assets/loadtest/k8s/secrets/Makefile
+++ b/assets/loadtest/k8s/secrets/Makefile
@@ -1,0 +1,49 @@
+
+# output:
+#   grafana-pass    : admin password for grafana
+#   influx-pass     : admin password for influxdb
+#   influx-token    : admin token for influxdb
+#   node-token      : static join token for teleport nodes
+#   proxy-token     : static join token for teleport proxies
+#   tc-token        : static join token for teleport trusted clusters
+#   secrets.env     : env file to be used to replace placeholder values in yaml files
+.PHONY:all
+all: grafana-pass influx-pass influx-token join-tokens env
+	@rm -rf *csr
+
+.PHONY: env
+env:
+	@echo PROXY_IP=$(shell make -C ../../network get-proxy-ip) > secrets.env
+	@echo PROXY_HOST=${PROXY_HOST} >> secrets.env
+	@echo GRAFANA_IP=$(shell make -C ../../network get-grafana-ip) >> secrets.env
+	@echo GRAFANA_HOST=${GRAFANA_HOST} >> secrets.env
+	@echo NODE_TOKEN=$(shell cat node-token) >> secrets.env
+	@echo PROXY_TOKEN=$(shell cat proxy-token) >> secrets.env
+	@echo TC_TOKEN=$(shell cat tc-token) >> secrets.env
+	@echo GCP_PROJECT=${GCP_PROJECT} >> secrets.env
+
+grafana-pass:
+	openssl rand -base64 32 | tr -d '\n' > grafana-pass
+
+influx-pass:
+	openssl rand -base64 32 | tr -d '\n' > influx-pass
+
+influx-token:
+	openssl rand -base64 32 | tr -d '\n' > influx-token
+
+node-token:
+	openssl rand -base64 32 | tr -d '\n' > node-token
+
+proxy-token:
+	openssl rand -base64 32 | tr -d '\n' > proxy-token
+
+tc-token:
+	openssl rand -base64 32 | tr -d '\n' > tc-token
+
+.PHONY: join-tokens
+join-tokens: node-token proxy-token tc-token
+
+# removes everything
+.PHONY:clean
+clean:
+	rm -rf *-pass *-token *-auth *.env

--- a/assets/loadtest/k8s/soaktest.yaml
+++ b/assets/loadtest/k8s/soaktest.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: soaktest-
+  namespace: loadtest
+  labels:
+    app: soaktest
+spec:      
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: soaktest
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: soaktest-config
+      containers:
+        - image: quay.io/gravitational/teleport-ent:8.0.0
+          name: teleport
+          envFrom:
+          - configMapRef:
+              name: soaktest-config
+          command:
+            - /bin/sh
+            - -c
+            - |
+              node=$(tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth -l root ls -f names | grep -v iot)
+              iot_node=$(tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth -l root ls -f names | grep iot)
+              
+              echo "----Non-IoT Mode Test via ${node}----"
+              echo "tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth bench --duration=${DURATION} root@${node} ls"
+              tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth bench --duration=${DURATION} root@${node} ls
+
+              echo "tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth bench --duration=${DURATION} --interactive root@${node} ps aux"
+              tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth bench --duration=${DURATION} --interactive root@${node} ps aux
+
+              echo "----IoT Mode Test via ${iot_node}----"
+              echo "tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth bench --duration=${DURATION} root@${iot_node} ls"
+              tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth bench --duration=${DURATION} root@${iot_node} ls
+
+              echo "tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth bench --duration=${DURATION} --interactive root@${iot_node} ps aux"
+              tsh --insecure --proxy=monster.gravitational.co:3080 -i /etc/teleport/auth bench --duration=${DURATION} --interactive root@${iot_node} ps aux
+          volumeMounts:
+            - mountPath: /etc/teleport
+              name: config
+              readOnly: true
+
+      restartPolicy: Never

--- a/assets/loadtest/k8s/tc.yaml
+++ b/assets/loadtest/k8s/tc.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tc
+  name: tc
+  namespace: loadtest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tc
+  template:
+    metadata:
+      labels:
+        app: tc
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: tc-config
+        - name: license
+          secret:
+            secretName: license
+      containers:
+        - image: quay.io/gravitational/teleport-ent:8.0.0
+          args: ["-d", "--insecure"]
+          name: tc
+          ports:
+            - containerPort: 3022
+              name: nodessh
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/teleport/
+              readOnly: true
+            - name: license
+              mountPath: /var/lib/teleport/license.pem
+              subPath: license.pem
+              readOnly: true

--- a/assets/loadtest/network/Makefile
+++ b/assets/loadtest/network/Makefile
@@ -1,0 +1,29 @@
+# preview address configuration
+.PHONY: plan
+plan:
+	terraform plan
+
+# reserve static ips
+.PHONY: apply
+apply:
+	terraform apply
+
+# release static ips
+.PHONY: destroy
+destroy:
+	terraform destroy
+
+# print static ips
+.PHONY: get-ips
+get-ips:
+	@terraform output
+
+# print proxy static ip
+.PHONY: get-proxy-ip
+get-proxy-ip:
+	@terraform output -raw proxy_ip
+
+# print grafana static ip
+.PHONY: get-grafana-ip
+get-grafana-ip:
+	@terraform output -raw grafana_ip

--- a/assets/loadtest/network/README.md
+++ b/assets/loadtest/network/README.md
@@ -1,0 +1,30 @@
+# Network
+
+This reserves external static ip addresses to be used
+for the [`k8s/proxy`](../k8s/proxy.yaml) and [`k8s/grafana`](../k8s/grafana.yaml) services.
+Once you have the ips you **must** setup the DNS records accordingly.
+
+**NOTE**: This only needs to be run once for a GCP project.
+
+## Usage
+
+Confirm that everything is working correctly:
+
+```bash
+$ make plan
+```
+
+If you are running this automation for the first time, you may be asked to run
+`terraform init` before continuing.
+
+```bash
+$ make apply
+```
+
+---
+
+To release the static ip addresses run:
+
+```bash
+$ make destroy
+```

--- a/assets/loadtest/network/main.tf
+++ b/assets/loadtest/network/main.tf
@@ -1,0 +1,17 @@
+provider "google" {
+  project     = var.project
+  region      = var.region
+  zone        = var.zone
+}
+
+resource "google_compute_address" "proxy_ip" {
+  name         = "proxy-ip"
+  address_type = "EXTERNAL"
+  network_tier = "PREMIUM"
+}
+
+resource "google_compute_address" "grafana_ip" {
+  name         = "grafana-ip"
+  address_type = "EXTERNAL"
+  network_tier = "PREMIUM"
+}

--- a/assets/loadtest/network/main.tf
+++ b/assets/loadtest/network/main.tf
@@ -4,6 +4,14 @@ provider "google" {
   zone        = var.zone
 }
 
+terraform {
+  required_version = ">= 0.12"
+  backend "gcs" {
+    bucket  = "loadtest-tf-state"
+    prefix  = "terraform/state"
+  }
+}
+
 resource "google_compute_address" "proxy_ip" {
   name         = "proxy-ip"
   address_type = "EXTERNAL"

--- a/assets/loadtest/network/main.tf
+++ b/assets/loadtest/network/main.tf
@@ -1,14 +1,14 @@
 provider "google" {
-  project     = var.project
-  region      = var.region
-  zone        = var.zone
+  project = var.project
+  region  = var.region
+  zone    = var.zone
 }
 
 terraform {
   required_version = ">= 0.12"
   backend "gcs" {
-    bucket  = "loadtest-tf-state"
-    prefix  = "terraform/state"
+    bucket = "loadtest-tf-state"
+    prefix = "terraform/state"
   }
 }
 

--- a/assets/loadtest/network/outputs.tf
+++ b/assets/loadtest/network/outputs.tf
@@ -1,9 +1,9 @@
 output "proxy_ip" {
-    description = "The static proxy ip address"
-    value       = google_compute_address.proxy_ip.address
+  description = "The static proxy ip address"
+  value       = google_compute_address.proxy_ip.address
 }
 
 output "grafana_ip" {
-    description = "The static grafana ip address"
-    value       = google_compute_address.grafana_ip.address
+  description = "The static grafana ip address"
+  value       = google_compute_address.grafana_ip.address
 }

--- a/assets/loadtest/network/outputs.tf
+++ b/assets/loadtest/network/outputs.tf
@@ -1,0 +1,9 @@
+output "proxy_ip" {
+    description = "The static proxy ip address"
+    value       = google_compute_address.proxy_ip.address
+}
+
+output "grafana_ip" {
+    description = "The static grafana ip address"
+    value       = google_compute_address.grafana_ip.address
+}

--- a/assets/loadtest/network/variables.tf
+++ b/assets/loadtest/network/variables.tf
@@ -1,0 +1,16 @@
+variable "project" {
+  type        = string
+  description = "The project to manage resources in."
+}
+
+variable "region" {
+  type        = string
+  description = "The region to manage resources in."
+  default     = "us-central1"
+}
+
+variable "zone" {
+  type        = string
+  description = "The zone to manage resources in."
+  default     = "us-central1-a"
+}

--- a/assets/loadtest/teleport/admin.yaml
+++ b/assets/loadtest/teleport/admin.yaml
@@ -1,0 +1,33 @@
+kind: role
+version: v3
+metadata:
+  name: clusteradmin
+spec:
+  # SSH options used for user sessions 
+  options:
+    # max_session_ttl defines the TTL (time to live) of SSH certificates 
+    # issued to the users with this role.
+    max_session_ttl: 8h
+
+    # forward_agent controls either users are allowed to use SSH agent forwarding
+    forward_agent: true
+
+  # allow section declares a list of resource/verb combinations that are
+  # allowed for the users of this role. by default nothing is allowed.
+  allow:
+    # logins array defines the OS logins a user is allowed to use.
+    # A few special variables are supported here (see below)
+    logins: [root, ubuntu]
+
+    # node labels that a user can connect to. The wildcard ('*') means "any node"
+    node_labels:
+      '*': '*'
+
+    # see below.
+    rules:
+    - resources: ['*']
+      verbs: ['*']
+
+  # the deny section uses the identical format as the 'allow' section.
+  # the deny rules always override allow rules.
+  deny: {}

--- a/assets/loadtest/teleport/soaktest-user.yaml
+++ b/assets/loadtest/teleport/soaktest-user.yaml
@@ -1,0 +1,6 @@
+kind: user
+metadata:
+  name: soaktest-runner
+spec:
+  roles: ['clusteradmin']
+version: v2

--- a/assets/loadtest/teleport/tc.yaml
+++ b/assets/loadtest/teleport/tc.yaml
@@ -1,0 +1,12 @@
+kind: trusted_cluster
+version: v2
+metadata:
+  name: one
+spec:
+  enabled: true
+  token: cluster-${TC_TOKEN}
+  tunnel_addr: "${PROXY_HOST}:3024"
+  web_proxy_addr: "${PROXY_HOST}:3080"
+  role_map:
+    - remote: '*'
+      local: ['access']

--- a/assets/loadtest/teleport/telegraf.conf
+++ b/assets/loadtest/teleport/telegraf.conf
@@ -1,0 +1,134 @@
+# Configuration for telegraf agent
+[agent]
+    ## Default data collection interval for all inputs
+    interval = "10s"
+    ## Rounds collection interval to 'interval'
+    ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+    round_interval = true
+
+    ## Telegraf will send metrics to outputs in batches of at
+    ## most metric_batch_size metrics.
+    metric_batch_size = 1000
+    ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+    ## output, and will flush this buffer on a successful write. Oldest metrics
+    ## are dropped first when this buffer fills.
+    metric_buffer_limit = 10000
+
+    ## Collection jitter is used to jitter the collection by a random amount.
+    ## Each plugin will sleep for a random time within jitter before collecting.
+    ## This can be used to avoid many plugins querying things like sysfs at the
+    ## same time, which can have a measurable effect on the system.
+    collection_jitter = "0s"
+
+    ## Default flushing interval for all outputs. You shouldn't set this below
+    ## interval. Maximum flush_interval will be flush_interval + flush_jitter
+    flush_interval = "10s"
+    ## Jitter the flush interval by a random amount. This is primarily to avoid
+    ## large write spikes for users running a large number of telegraf instances.
+    ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+    flush_jitter = "0s"
+
+    ## By default, precision will be set to the same timestamp order as the
+    ## collection interval, with the maximum being 1s.
+    ## Precision will NOT be used for service inputs, such as logparser and statsd.
+    precision = ""
+    ## Run telegraf in debug mode
+    debug = false
+    ## Run telegraf in quiet mode
+    quiet = false
+    ## Override default hostname, if empty use os.Hostname()
+    hostname = ""
+    ## If set to true, do no set the "host" tag in the telegraf agent.
+    omit_hostname = false
+
+
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+
+[[inputs.procstat]]
+    exe = "teleport"
+    prefix = "teleport"
+
+[[inputs.prometheus]]
+    # An array of urls to scrape metrics from.
+    urls = ["http://127.0.0.1:3434/metrics"]
+    name_prefix = "teleport_"
+
+    # Add tags to be able to make beautiful dashboards
+    [inputs.prometheus.tags]
+    teleservice = "teleport"
+
+# Read metrics about cpu usage
+[[inputs.cpu]]
+    ## Whether to report per-cpu stats or not
+    percpu = true
+    ## Whether to report total system cpu stats or not
+    totalcpu = true
+    ## If true, collect raw CPU time metrics.
+    collect_cpu_time = false
+    ## If true, compute and report the sum of all non-idle CPU states.
+    report_active = false
+
+# Read metrics about disk usage by mount point
+[[inputs.disk]]
+    ## By default, telegraf gather stats for all mountpoints.
+    ## Setting mountpoints will restrict the stats to the specified mountpoints.
+    # mount_points = ["/"]
+
+    ## Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
+    ## present on /run, /var/run, /dev/shm or /dev).
+    ignore_fs = ["tmpfs", "devtmpfs", "devfs"]
+
+# Read metrics about disk IO by device
+[[inputs.diskio]]
+
+# Get kernel statistics from /proc/stat
+[[inputs.kernel]]
+    # no configuration
+
+# Read metrics about memory usage
+[[inputs.mem]]
+    # no configuration
+
+# Get the number of processes and group them by status
+[[inputs.processes]]
+    # no configuration
+
+# Read metrics about swap memory usage
+[[inputs.swap]]
+    # no configuration
+
+# Read metrics about system load & uptime
+[[inputs.system]]
+    # no configuration
+
+# Read netstat info
+[[inputs.netstat]]
+
+# Read net info
+[[inputs.net]]
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+
+# Configuration for influxdb server to send metrics to
+[[outputs.influxdb_v2]]
+    ## The full HTTP or UDP endpoint URL for your InfluxDB instance.
+    ## Multiple urls can be specified as part of the same cluster,
+    ## this means that only ONE of the urls will be written to each interval.
+    urls = ["http://influxdb:8086"] # required
+
+    ## Token for authentication.
+    token = "${INFLUXDB_TOKEN}"
+
+    ## Organization is the name of the organization you wish to write to; must exist.
+    organization = "teleport"
+
+    ## Destination bucket to write into.
+    bucket = "telegraf"
+
+    ## Write timeout (for the InfluxDB client), formatted as a string.
+    ## If not provided, will default to 5s. 0s means no timeout (not recommended).
+    timeout = "5s"

--- a/assets/loadtest/teleport/teleport-auth-etcd.yaml
+++ b/assets/loadtest/teleport/teleport-auth-etcd.yaml
@@ -1,0 +1,39 @@
+teleport:
+  log:
+    severity: DEBUG
+
+  data_dir: /var/lib/teleport
+
+  diag_addr: 0.0.0.0:3434
+  advertise_ip: auth
+
+  storage:
+    type: etcd
+    peers: [https://etcd-0.etcd:2379, https://etcd-1.etcd:2379, https://etcd-2.etcd:2379]
+    tls_cert_file: /etc/etcd/certs/client-cert.pem
+    tls_key_file: /etc/etcd/certs/client-key.pem
+    tls_ca_file: /etc/etcd/certs/ca-cert.pem
+    prefix: teleport
+  connection_limits:
+    max_connections: 65000
+    max_users: 10000
+
+auth_service:
+  enabled: yes
+
+  listen_addr: 0.0.0.0:3025
+
+  authentication:
+    type: oidc
+
+  cluster_name: one
+  tokens: 
+      - "node:node-${NODE_TOKEN}"
+      - "proxy:proxy-${PROXY_TOKEN}"
+      - "trusted_cluster:cluster-${TC_TOKEN}"
+
+ssh_service:
+  enabled: no
+
+proxy_service:
+  enabled: no

--- a/assets/loadtest/teleport/teleport-auth-firestore.yaml
+++ b/assets/loadtest/teleport/teleport-auth-firestore.yaml
@@ -1,0 +1,39 @@
+teleport:
+  log:
+    severity: DEBUG
+
+  data_dir: /var/lib/teleport
+
+  diag_addr: 0.0.0.0:3434
+  advertise_ip: auth
+
+  storage:
+    type: firestore
+    collection_name: cluster-data
+    credentials_path: /var/lib/teleport/gcp_creds.json
+    project_id: "${GCP_PROJECT}"
+    audit_events_uri: "firestore://events?projectID=${GCP_PROJECT}&credentialsPath=/var/lib/teleport/gcp_creds.json"
+    audit_sessions_uri: "gs://teleport-session-storage-2?projectID=${GCP_PROJECT}&credentialsPath=/var/lib/teleport/gcp_creds.json"
+  connection_limits:
+    max_connections: 65000
+    max_users: 10000
+
+auth_service:
+  enabled: yes
+
+  listen_addr: 0.0.0.0:3025
+
+  authentication:
+    type: oidc
+
+  cluster_name: one
+  tokens: 
+      - "node:node-${NODE_TOKEN}"
+      - "proxy:proxy-${PROXY_TOKEN}"
+      - "trusted_cluster:cluster-${TC_TOKEN}"
+
+ssh_service:
+  enabled: no
+
+proxy_service:
+  enabled: no

--- a/assets/loadtest/teleport/teleport-iot-node.yaml
+++ b/assets/loadtest/teleport/teleport-iot-node.yaml
@@ -1,0 +1,14 @@
+teleport:
+  data_dir: /var/lib/teleport
+  log:
+    severity: DEBUG
+  storage:
+    type: dir
+  auth_servers: ["${PROXY_HOST}:3080"]
+  auth_token: "node-${NODE_TOKEN}"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: true

--- a/assets/loadtest/teleport/teleport-node.yaml
+++ b/assets/loadtest/teleport/teleport-node.yaml
@@ -1,0 +1,14 @@
+teleport:
+  data_dir: /var/lib/teleport
+  log:
+    severity: DEBUG
+  storage:
+    type: dir
+  auth_servers: ["auth:3025"]
+  auth_token: "node-${NODE_TOKEN}"
+auth_service:
+  enabled: false
+proxy_service:
+  enabled: false
+ssh_service:
+  enabled: true

--- a/assets/loadtest/teleport/teleport-proxy.yaml
+++ b/assets/loadtest/teleport/teleport-proxy.yaml
@@ -1,0 +1,26 @@
+teleport:
+  log:
+    severity: DEBUG
+
+  diag_addr: 0.0.0.0:3434
+  data_dir: /var/lib/teleport
+  auth_servers: ["auth:3025"]
+  auth_token: "proxy-${PROXY_TOKEN}"
+  cache:
+    type: in-memory
+  connection_limits:
+    max_connections: 65000
+    max_users: 10000
+
+auth_service:
+  enabled: no
+
+ssh_service:
+  enabled: no
+
+proxy_service:
+  enabled: yes
+  https_cert_file: /etc/teleport-tls/tls.crt
+  https_key_file: /etc/teleport-tls/tls.key
+  public_addr: "${PROXY_HOST}:3080"
+  tunnel_public_addr: "${PROXY_HOST}:3024"

--- a/assets/loadtest/teleport/teleport-tc.yaml
+++ b/assets/loadtest/teleport/teleport-tc.yaml
@@ -1,0 +1,13 @@
+auth_service:
+  enabled: true
+proxy_service:
+  enabled: true
+ssh_service:
+  enabled: true
+teleport:
+  data_dir: /var/lib/teleport
+  log:
+    output: stderr
+    severity: DEBUG
+  storage:
+    type: dir


### PR DESCRIPTION
This adds loadtesting automation and k8s yamls to deploy teleport. The grafana
health dashboard is also included and can be consumed by end users to better monitor
their teleport clusters.

Closes #8709