### PR TITLE
[Backport]  Restart entire node on tunnel collapse (#8102)

### DIFF
--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/lib"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/service"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLostConnectionToAuthCausesReload tests that a lost connection to the auth server
+// will eventually restart a node
+func TestLostConnectionToAuthCausesReload(t *testing.T) {
+	// Because testing that the node does a full restart is a bit tricky when
+	// running a cluster from inside a test runner (i.e. we don't want to
+	// SIGTERM the test runner), we will watch for the node emitting a
+	// `TeleportReload` even instead. In a proper Teleport instance, this
+	// event would be picked up at the Supervisor level and would eventually
+	// cause the instance to gracefully restart.
+
+	require := require.New(t)
+	log := log.StandardLogger()
+
+	log.Info(">>> Entering Test")
+
+	// InsecureDevMode needed for SSH connections
+	// TODO(tcsc): surface this as per-server config (see also issue #8913)
+	lib.SetInsecureDevMode(true)
+	defer lib.SetInsecureDevMode(false)
+
+	// GIVEN  a cluster with a running auth+proxy instance....
+	log.Info(">>> Creating cluster")
+	keygen := testauthority.New()
+	privateKey, publicKey, err := keygen.GenerateKeyPair("")
+	require.NoError(err)
+	auth := NewInstance(InstanceConfig{
+		ClusterName: "test-tunnel-collapse",
+		HostID:      "auth",
+		Priv:        privateKey,
+		Pub:         publicKey,
+		Ports:       standardPortSetup(),
+		log:         log,
+	})
+
+	log.Info(">>> Creating auth-proxy...")
+	authConf := service.MakeDefaultConfig()
+	authConf.Hostname = Host
+	authConf.Auth.Enabled = true
+	authConf.Proxy.Enabled = true
+	authConf.SSH.Enabled = false
+	authConf.Proxy.DisableWebInterface = true
+	authConf.Proxy.DisableDatabaseProxy = true
+	require.NoError(auth.CreateEx(t, nil, authConf))
+	t.Cleanup(func() { require.NoError(auth.StopAll()) })
+
+	log.Info(">>> Start auth-proxy...")
+	require.NoError(auth.Start())
+
+	// ... and an SSH node connected via a reverse tunnel configured to
+	// reload after only a few failed connection attempts per minute
+	log.Info(">>> Creating and starting node...")
+	nodeCfg := service.MakeDefaultConfig()
+	nodeCfg.Hostname = Host
+	nodeCfg.SSH.Enabled = true
+	nodeCfg.RotationConnectionInterval = 1 * time.Second
+	nodeCfg.RestartThreshold = service.Rate{Amount: 3, Time: 1 * time.Minute}
+	node, err := auth.StartReverseTunnelNode(nodeCfg)
+	require.NoError(err)
+
+	// WHEN I stop the auth node (and, by implication, disrupt the ssh node's
+	// connection to it)
+	log.Info(">>> Stopping auth node")
+	auth.StopAuth(false)
+
+	// EXPECT THAT the ssh node will eventually issue a reload request
+	log.Info(">>> Waiting for node restart request.")
+	waitCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	eventCh := make(chan service.Event)
+	node.WaitForEvent(waitCtx, service.TeleportReloadEvent, eventCh)
+	select {
+	case e := <-eventCh:
+		log.Infof(">>> Received Reload event: %v. Test passed.", e)
+
+	case <-waitCtx.Done():
+		require.FailNow("Timed out", "Timed out waiting for reload event")
+	}
+
+	log.Info(">>> TEST COMPLETE")
+}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -410,6 +410,18 @@ var (
 
 	// AsyncBufferSize is a default buffer size for async emitters
 	AsyncBufferSize = 1024
+
+	// ConnectionErrorMeasurementPeriod is the maximum age of a connection error
+	// to be considered when deciding to restart the process. The process will
+	// restart if there has been more than `MaxConnectionErrorsBeforeRestart`
+	// errors in the preceding `ConnectionErrorMeasurementPeriod`
+	ConnectionErrorMeasurementPeriod = 2 * time.Minute
+
+	// MaxConnectionErrorsBeforeRestart is the number or allowable network errors
+	// in the previous `ConnectionErrorMeasurementPeriod`. The process will
+	// restart if there has been more than `MaxConnectionErrorsBeforeRestart`
+	// errors in the preceding `ConnectionErrorMeasurementPeriod`
+	MaxConnectionErrorsBeforeRestart = 5
 )
 
 // Default connection limits, they can be applied separately on any of the Teleport

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -62,6 +62,13 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
+// Rate describes a rate ratio, i.e. the number of "events" that happen over
+// some unit time period
+type Rate struct {
+	Amount int
+	Time   time.Duration
+}
+
 // Config structure is used to initialize _all_ services Teleport can run.
 // Some settings are global (like DataDir) while others are grouped into
 // sections, like AuthConfig
@@ -231,6 +238,15 @@ type Config struct {
 
 	// PluginRegistry allows adding enterprise logic to Teleport services
 	PluginRegistry plugin.Registry
+
+	// RotationConnectionInterval is the interval between connection
+	// attempts as used by the rotation state service
+	RotationConnectionInterval time.Duration
+
+	// RestartThreshold describes the number of connection failures per
+	// unit time that the node can sustain before restarting itself, as
+	// measured by the rotation state service.
+	RestartThreshold Rate
 }
 
 // ApplyToken assigns a given token to all internal services but only if token
@@ -1021,6 +1037,12 @@ func ApplyDefaults(cfg *Config) {
 	// Windows desktop service is disabled by default.
 	cfg.WindowsDesktop.Enabled = false
 	defaults.ConfigureLimiter(&cfg.WindowsDesktop.ConnLimiter)
+
+	cfg.RotationConnectionInterval = defaults.HighResPollingPeriod
+	cfg.RestartThreshold = Rate{
+		Amount: defaults.MaxConnectionErrorsBeforeRestart,
+		Time:   defaults.ConnectionErrorMeasurementPeriod,
+	}
 }
 
 // ApplyFIPSDefaults updates default configuration to be FedRAMP/FIPS 140-2

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -89,6 +89,11 @@ func TestDefaultConfig(t *testing.T) {
 	proxy := config.Proxy
 	require.Equal(t, proxy.Limiter.MaxConnections, int64(defaults.LimiterMaxConnections))
 	require.Equal(t, proxy.Limiter.MaxNumberOfUsers, defaults.LimiterMaxConcurrentUsers)
+
+	// Misc levers and dials
+	require.Equal(t, config.RotationConnectionInterval, defaults.HighResPollingPeriod)
+	require.Equal(t, config.RestartThreshold.Amount, defaults.MaxConnectionErrorsBeforeRestart)
+	require.Equal(t, config.RestartThreshold.Time, defaults.ConnectionErrorMeasurementPeriod)
 }
 
 // TestCheckApp validates application configuration.

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -447,18 +447,35 @@ func (process *TeleportProcess) periodicSyncRotationState() error {
 	}
 
 	periodic := interval.New(interval.Config{
-		Duration:      defaults.HighResPollingPeriod,
-		FirstDuration: utils.HalfJitter(defaults.HighResPollingPeriod),
+		Duration:      process.Config.RotationConnectionInterval,
+		FirstDuration: utils.HalfJitter(process.Config.RotationConnectionInterval),
 		Jitter:        utils.NewSeventhJitter(),
 	})
 	defer periodic.Stop()
+
+	errors := utils.NewTimedCounter(process.Clock, process.Config.RestartThreshold.Time)
 
 	for {
 		err := process.syncRotationStateCycle()
 		if err == nil {
 			return nil
 		}
-		process.log.Warningf("Sync rotation state cycle failed: %v, going to retry after ~%v.", err, defaults.HighResPollingPeriod)
+		process.log.WithError(err).Warning("Sync rotation state cycle failed")
+
+		// If we have had a *lot* of failures very recently, then it's likely that our
+		// route to the auth server is gone. If we're using a tunnel then it's possible
+		// that the proxy has been reconfigured and the tunnel address has moved.
+		count := errors.Increment()
+		process.log.Warnf("%d connection errors in last %v.", count, process.Config.RestartThreshold.Time)
+		if count > process.Config.RestartThreshold.Amount {
+			// signal quit
+			process.log.Error("Connection error threshold exceeded. Asking for a graceful restart.")
+			process.BroadcastEvent(Event{Name: TeleportReloadEvent})
+			return nil
+		}
+
+		process.log.Warningf("Retrying in ~%v", process.Config.RotationConnectionInterval)
+
 		select {
 		case <-periodic.Next():
 		case <-process.GracefulExitContext().Done():
@@ -470,7 +487,7 @@ func (process *TeleportProcess) periodicSyncRotationState() error {
 // syncRotationCycle executes a rotation cycle that returns:
 //
 // * nil whenever rotation state leads to teleport reload event
-// * error whenever rotation sycle has to be restarted
+// * error whenever rotation cycle has to be restarted
 //
 // the function accepts extra delay timer extraDelay in case if parent
 // function needs a

--- a/lib/utils/timed_counter.go
+++ b/lib/utils/timed_counter.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+// TimedCounter is essentially a lightweight rate calculator. It counts events
+// that happen over a period of time, e.g. have there been more than 4 errors
+// in the last 30 seconds. Automatically expires old events so they are not
+// included in the count. Not safe for concurrent use.
+type TimedCounter struct {
+	clock   clockwork.Clock
+	timeout time.Duration
+	events  []time.Time
+}
+
+// TimedCounted creates a new timed counter with the specified timeout
+func NewTimedCounter(clock clockwork.Clock, timeout time.Duration) *TimedCounter {
+	return &TimedCounter{
+		clock:   clock,
+		timeout: timeout,
+		events:  nil,
+	}
+}
+
+// Increment adds a new item into the counter, returning the current count.
+func (c *TimedCounter) Increment() int {
+	c.trim()
+	c.events = append(c.events, c.clock.Now())
+	return len(c.events)
+}
+
+// Count fetches the number of recorded events currently in the measurement
+// time window.
+func (c *TimedCounter) Count() int {
+	c.trim()
+	return len(c.events)
+}
+
+func (c *TimedCounter) trim() {
+	deadline := c.clock.Now().Add(-c.timeout)
+	lastExpiredEvent := -1
+	for i := range c.events {
+		if c.events[i].After(deadline) {
+			break
+		}
+		lastExpiredEvent = i
+	}
+
+	if lastExpiredEvent > -1 {
+		c.events = c.events[lastExpiredEvent+1:]
+	}
+}

--- a/lib/utils/timed_counter_test.go
+++ b/lib/utils/timed_counter_test.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimedCounterReturnsZeroOnConstruction(t *testing.T) {
+	uut := NewTimedCounter(clockwork.NewFakeClock(), time.Second)
+	require.Zero(t, uut.Count())
+}
+
+func TestTimedCounterIncrement(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	uut := NewTimedCounter(clock, time.Second)
+	require.Equal(t, uut.Increment(), 1)
+}
+
+func TestTimedCounterExpiresEvents(t *testing.T) {
+	// Given a counter with a 10-second cutoff, primed with events at 1 second
+	// intervals
+	clock := clockwork.NewFakeClock()
+	uut := NewTimedCounter(clock, 10*time.Second)
+	for i := 1; i <= 5; i++ {
+		require.Equal(t, uut.Increment(), i)
+		require.Equal(t, uut.Count(), i)
+		clock.Advance(1 * time.Second)
+	}
+
+	// When I advance the clock to a time slightly earlier than the 10s
+	// cutoff for the first event...
+	clock.Advance(4900 * time.Millisecond) // 9.9s "after" the first event
+
+	// Expect that the all the events are still counted
+	require.Equal(t, uut.Count(), 5)
+
+	// When I advance the clock to just *after* the first event's cutoff...
+	clock.Advance(200 * time.Millisecond) // 10.1s "after" the first event
+
+	// Expect that the first event has expired and is no longer considered
+	// by the counter
+	require.Equal(t, uut.Count(), 4)
+
+	// When I advance the clock past another 3 events' cutoff times
+	clock.Advance(3 * time.Second)
+
+	// Expect that there is only one event left to count
+	require.Equal(t, uut.Count(), 1)
+
+	// When I advance the clock well past the final event's cutoff
+	clock.Advance(100 * time.Second)
+
+	// Expect that there are no events left to count
+	require.Equal(t, uut.Count(), 0)
+}
+
+func TestTimedCounterIncrementExpiresValues(t *testing.T) {
+	// Given a counter with a 10-second cutoff, primed with 5 events at 1-
+	// second intervals
+	clock := clockwork.NewFakeClock()
+
+	uut := NewTimedCounter(clock, 10*time.Second)
+	for i := 1; i <= 5; i++ {
+		require.Equal(t, uut.Increment(), i)
+		require.Equal(t, uut.Count(), i)
+		clock.Advance(1 * time.Second)
+	}
+
+	// When I advance the clock to 12.5s after the first event, by which time
+	// events at 0s, 1s and 2s should have expired.
+	clock.Advance(7500 * time.Millisecond)
+
+	// Expect that incrementing the count handles expiring three events and
+	// adding a new one (net result: 3 "live" events remaining)
+	require.Equal(t, 3, uut.Increment())
+}

--- a/lib/utils/workpool/workpool.go
+++ b/lib/utils/workpool/workpool.go
@@ -31,9 +31,11 @@ type Pool struct {
 	mu       sync.Mutex
 	leaseIDs *atomic.Uint64
 	groups   map[interface{}]*group
-	grantC   chan Lease
-	ctx      context.Context
-	cancel   context.CancelFunc
+	// grantC is an unbuffered channel that funnels available leases from the
+	// workgroups to the outside world
+	grantC chan Lease
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func NewPool(ctx context.Context) *Pool {
@@ -50,6 +52,9 @@ func NewPool(ctx context.Context) *Pool {
 // Acquire is the channel which must be received on to acquire
 // new leases.  Each lease acquired in this way *must* have its
 // Release method called when the lease is no longer needed.
+// Note this channel will deliver leases from all active work
+// groups. It's up to the receiver to differentiate what group
+// the lease refers to and act accordingly.
 func (p *Pool) Acquire() <-chan Lease {
 	return p.grantC
 }
@@ -103,6 +108,10 @@ func (p *Pool) start(key interface{}, target uint64) {
 		cancel:   cancel,
 	}
 	p.groups[key] = g
+
+	// Start a routine to monitor the group's lease acquisition
+	// and handle notifications when a lease is returned to the
+	// pool
 	go g.run()
 }
 
@@ -192,32 +201,44 @@ func (g *group) setTarget(target uint64) {
 	g.notify()
 }
 
+// run manages the issuing of leases and handling their return to the pool for
+// a given work group.
 func (g *group) run() {
 	var counts Counts
 	var nextLease Lease
 	var grant chan Lease
 	for {
+		// Are we able to grant new leases? We are only allowed to grant a lease
+		// while the number of outstanding leases is less than the target value.
+		// If anyone else wants one after that, they will have to wait until a
+		// lease is returned to the pool.
 		counts = g.loadCounts()
 		if counts.Active < counts.Target {
-			// we are in a "granting" state; ensure that the
-			// grant channel is non-nil, and initialize `nextLease`
-			// if it hasn't been already.
+			// We are in a "granting" state; prepare to issue the lease to the
+			// next person who asks.
 			grant = g.grantC
 			if nextLease.id == 0 {
 				nextLease = newLease(g)
 			}
 		} else {
-			// we are not in a "granting" state, ensure that the
-			// grant channel is nil (prevents sends).
+			// we are in a non-"granting" state; prepare to block until a new
+			// event wakes the routine.
 			grant = nil
 		}
-		// if grant is nil, this select statement blocks until
-		// notify() is called, or the context is canceled.
+
+		// Remembering that writes to a `nil` channel block indefinitely,
+		// if we're in a non-granting state this select blocks until `notify()`
+		// is called (usually by a lease being returned), or the context is
+		// canceled.
+		//
+		// Otherwise we post the lease to the outside world and block on
+		// someone picking it up (or cancellation)
 		select {
 		case grant <- nextLease:
 			g.incrActive()
 			nextLease = Lease{}
 		case <-g.notifyC:
+			// some event has woken the dispatch routine. Go back around.
 		case <-g.ctx.Done():
 			return
 		}
@@ -256,8 +277,8 @@ func (l Lease) IsZero() bool {
 	return l == Lease{}
 }
 
-// Release relenquishes this lease.  Each lease is unique,
-// so double-calling Release on the same Lease has no effect.
+// Release relinquishes this lease. Each lease is unique,
+// so double-calling Release() on the same Lease has no effect.
 func (l Lease) Release() {
 	if l.IsZero() {
 		return


### PR DESCRIPTION
Fixes #7606, where a node doesn't notice when the tunnel port changes. 

Imagine you have a cluster with a node connected in via a tunnel through a proxy `proxy.example.com` on port `3024`

Now change the proxy config so that `tunnel_public_address` is `proxy.example.com:4024`. You either restart the proxy, or reload the proxy config with a `SIGHUP`.

...and then the node
  a) loses its connection to auth (because the tunnel is gone), and 
  b)  _doesn't reconnect_, because even though the proxy address hasn't changed,
      the node has cached the old tunnel_public_address and keeps trying to connect
      to that.

You can always manually restart the node to have it reconnect, but that would be a pain if you have thousands of nodes.

In order to not have to manually restart all nodes, this change implements a check for a connection failures to the auth server, and re-starts the node if there are multiple connection failures in a given period of time. The check as-implemented piggybacks on the node's "common.rotate" service, which can already restart the node in certain circumstances, and uses the success of the periodic rotation sync as a proxy for the health of the node's connection to the auth server.

See-Also: #7606