### PR TITLE
Make Teleport startup resilient to invalid roles

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -383,7 +383,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	}
 
 	// Create presets - convenience and example resources.
-	err = createPresets(ctx, asrv)
+	err = createPresets(asrv)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -493,8 +493,8 @@ func migrateLegacyResources(ctx context.Context, asrv *Server) error {
 	return nil
 }
 
-// createPresets creates preset resources - roles
-func createPresets(ctx context.Context, asrv *Server) error {
+// createPresets creates preset resources (eg, roles).
+func createPresets(asrv *Server) error {
 	roles := []types.Role{
 		services.NewPresetEditorRole(),
 		services.NewPresetAccessRole(),
@@ -1003,7 +1003,7 @@ func migrateCertAuthorities(ctx context.Context, asrv *Server) error {
 			continue
 		}
 		for _, ca := range cas {
-			if err := migrateCertAuthority(ctx, asrv, ca); err != nil {
+			if err := migrateCertAuthority(asrv, ca); err != nil {
 				errors = append(errors, trace.Wrap(err, "failed to migrate %v: %v", ca, err))
 				continue
 			}
@@ -1020,7 +1020,7 @@ func migrateCertAuthorities(ctx context.Context, asrv *Server) error {
 	return nil
 }
 
-func migrateCertAuthority(ctx context.Context, asrv *Server, ca types.CertAuthority) error {
+func migrateCertAuthority(asrv *Server, ca types.CertAuthority) error {
 	// Check if we need to migrate.
 	if needsMigration, err := services.CertAuthorityNeedsMigration(ca); err != nil || !needsMigration {
 		return trace.Wrap(err)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -502,11 +502,11 @@ func TestPresets(t *testing.T) {
 		clock := clockwork.NewFakeClock()
 		as.SetClock(clock)
 
-		err := createPresets(ctx, as)
+		err := createPresets(as)
 		require.NoError(t, err)
 
 		// Second call should not fail
-		err = createPresets(ctx, as)
+		err = createPresets(as)
 		require.NoError(t, err)
 
 		// Presets were created
@@ -527,7 +527,7 @@ func TestPresets(t *testing.T) {
 		err := as.CreateRole(access)
 		require.NoError(t, err)
 
-		err = createPresets(ctx, as)
+		err = createPresets(as)
 		require.NoError(t, err)
 
 		// Presets were created

--- a/lib/services/local/access.go
+++ b/lib/services/local/access.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"context"
+	"encoding/json"
 	"sort"
 	"strings"
 	"time"
@@ -55,7 +56,11 @@ func (s *AccessService) GetRoles(ctx context.Context) ([]types.Role, error) {
 		role, err := services.UnmarshalRole(item.Value,
 			services.WithResourceID(item.ID), services.WithExpires(item.Expires))
 		if err != nil {
-			return nil, trace.Wrap(err)
+			// Try to get the role name for the error, it allows admins to take action
+			// against the "bad" role.
+			h := &types.ResourceHeader{}
+			_ = json.Unmarshal(item.Value, h)
+			return nil, trace.WrapWithMessage(err, "role %q", h.GetName())
 		}
 		out = append(out, role)
 	}


### PR DESCRIPTION
Removing the old roles migration allows Teleport to start even in the face of invalid roles. The system will still be largely unusable, but `tctl rm` is now possible as a fallback.

Added logging makes it easier to determine the bad role.

Turns this scenario:

```shell
$ teleport start
> (...)
> ERROR: initialization failed
> could not parse 'where' rule: "!contains(ssh_session.participants, user.metadata.name)", error: ssh_session.participants is not defined
> (teleport exits)
```

into this:

```shell
$ teleport start
> (...)
> 2021-11-18T16:50:29-03:00 WARN [AUTH:1:CA] "Re-init the cache on error: role \"join_own_sessions_only\"\n\tcould not parse 'where' rule: \"!contains(ssh_session.participants, user.metadata.name)\", error: ssh_session.participants is not defined." cache/cache.go:725
> 2021-11-18T16:50:29-03:00 WARN [AUTH:1:CA] Cache "auth" first init failed, continuing re-init attempts in background. error:[
> ERROR REPORT:
> Original Error: *trace.BadParameterError could not parse &#39;where&#39; rule: &#34;!contains(ssh_session.participants, user.metadata.name)&#34;, error: ssh_session.participants is not defined
> Stack Trace:
> 	(...)
> User Message: role &#34;join_own_sessions_only&#34;
> 	could not parse &#39;where&#39; rule: &#34;!contains(ssh_session.participants, user.metadata.name)&#34;, error: ssh_session.participants is not defined] cache/cache.go:678
> 2021-11-18T16:50:35-03:00 WARN [AUTH:1:CA] "Re-init the cache on error: role \"join_own_sessions_only\"\n\tcould not parse 'where' rule: \"!contains(ssh_session.participants, user.metadata.name)\", error: ssh_session.participants is not defined." cache/cache.go:725
> (teleport running, tctl works)
```

See https://github.com/gravitational/teleport/issues/9059 for the larger context.