### PR TITLE
teleport configure: generate web_listen_addr

### DIFF
--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -144,7 +144,7 @@ func TestSampleConfig(t *testing.T) {
 			input: SampleFlags{
 				PublicAddr: "tele.example.com",
 			},
-			expectProxyPublicAddrs: apiutils.Strings{"tele.example.com"},
+			expectProxyPublicAddrs: apiutils.Strings{"tele.example.com:443"},
 			expectProxyWebAddr:     "0.0.0.0:443",
 		},
 		{

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -132,11 +132,20 @@ func TestSampleConfig(t *testing.T) {
 			expectProxyWebAddr:     "0.0.0.0:443",
 		},
 		{
-			name: "public addrs",
+			name: "public and web addr",
 			input: SampleFlags{
-				PublicAddrs: []string{"tele.example.com:443"},
+				PublicAddr: "tele.example.com:4422",
 			},
-			expectProxyPublicAddrs: apiutils.Strings{"tele.example.com:443"},
+			expectProxyPublicAddrs: apiutils.Strings{"tele.example.com:4422"},
+			expectProxyWebAddr:     "0.0.0.0:4422",
+		},
+		{
+			name: "public and web addr with default port",
+			input: SampleFlags{
+				PublicAddr: "tele.example.com",
+			},
+			expectProxyPublicAddrs: apiutils.Strings{"tele.example.com"},
+			expectProxyWebAddr:     "0.0.0.0:443",
 		},
 		{
 			name: "key file missing",

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -138,8 +138,8 @@ type SampleFlags struct {
 	ACMEEnabled bool
 	// Version is the Teleport Configuration version.
 	Version string
-	// PublicAddrs sets the hostport the proxy advertises for the HTTP endpoint.
-	PublicAddrs []string
+	// PublicAddr sets the hostport the proxy advertises for the HTTP endpoint.
+	PublicAddr string
 	// KeyFile is a TLS key file
 	KeyFile string
 	// CertFile is a TLS Certificate file
@@ -212,8 +212,16 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 		p.PublicAddr = apiutils.Strings{net.JoinHostPort(flags.ClusterName, fmt.Sprintf("%d", teleport.StandardHTTPSPort))}
 		p.WebAddr = net.JoinHostPort(defaults.BindIP, fmt.Sprintf("%d", teleport.StandardHTTPSPort))
 	}
-	if len(flags.PublicAddrs) > 0 {
-		p.PublicAddr = apiutils.Strings(flags.PublicAddrs)
+	if flags.PublicAddr != "" {
+		p.PublicAddr = apiutils.Strings{flags.PublicAddr}
+
+		// use same port for web addr, or default to 443 if port is not specified
+		publicAddr, err := utils.ParseAddr(flags.PublicAddr)
+		if err != nil {
+			return nil, err
+		}
+		webPort := publicAddr.Port(teleport.StandardHTTPSPort)
+		p.WebAddr = net.JoinHostPort(defaults.BindIP, fmt.Sprintf("%d", webPort))
 	}
 	if flags.KeyFile != "" && flags.CertFile != "" {
 		if _, err := tls.LoadX509KeyPair(flags.CertFile, flags.KeyFile); err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -213,13 +213,14 @@ func MakeSampleFileConfig(flags SampleFlags) (fc *FileConfig, err error) {
 		p.WebAddr = net.JoinHostPort(defaults.BindIP, fmt.Sprintf("%d", teleport.StandardHTTPSPort))
 	}
 	if flags.PublicAddr != "" {
-		p.PublicAddr = apiutils.Strings{flags.PublicAddr}
-
-		// use same port for web addr, or default to 443 if port is not specified
-		publicAddr, err := utils.ParseAddr(flags.PublicAddr)
+		// default to 443 if port is not specified
+		publicAddr, err := utils.ParseHostPortAddr(flags.PublicAddr, teleport.StandardHTTPSPort)
 		if err != nil {
-			return nil, err
+			return nil, trace.Wrap(err)
 		}
+		p.PublicAddr = apiutils.Strings{publicAddr.String()}
+
+		// use same port for web addr
 		webPort := publicAddr.Port(teleport.StandardHTTPSPort)
 		p.WebAddr = net.JoinHostPort(defaults.BindIP, fmt.Sprintf("%d", webPort))
 	}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -226,7 +226,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		"Email to receive updates from Letsencrypt.org.").StringVar(&dumpFlags.ACMEEmail)
 	dump.Flag("test", "Path to a configuration file to test.").ExistingFileVar(&dumpFlags.testConfigFile)
 	dump.Flag("version", "Teleport configuration version.").Default(defaults.TeleportConfigVersionV2).StringVar(&dumpFlags.Version)
-	dump.Flag("public-addr", "A list of public addresses that the proxy advertises for the HTTP endpoint.").StringsVar(&dumpFlags.PublicAddrs)
+	dump.Flag("public-addr", "The hostport that the proxy advertises for the HTTP endpoint.").StringVar(&dumpFlags.PublicAddr)
 	dump.Flag("cert-file", "Path to a TLS certificate file for the proxy.").ExistingFileVar(&dumpFlags.CertFile)
 	dump.Flag("key-file", "Path to a TLS key file for the proxy.").ExistingFileVar(&dumpFlags.KeyFile)
 


### PR DESCRIPTION
Follow up #9033 that we need to generate `web_listen_addr` to use the same port as public_addr. Also reduce `--public-addr` to a single string

Listening on same port as `public_addr`
```
$ ./teleport configure --public-addr "a.com:4422" --key-file ~/workspace/certs/key.pem --cert-file ~/workspace/certs/certificate.pem
...
proxy_service:
  enabled: "yes"
  web_listen_addr: 0.0.0.0:4422
  public_addr: a.com:4422
  https_keypairs:
...
```

Listening to 443 as default
```
$  ./teleport configure --public-addr "a.com" --key-file ~/workspace/certs/key.pem --cert-file ~/workspace/certs/certificate.pem 
...
proxy_service:
  enabled: "yes"
  web_listen_addr: 0.0.0.0:443
  public_addr: a.com:443
  https_keypairs:
...
```