### PR TITLE
Implement where conditions for active sessions (#9040)

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1067,7 +1067,7 @@ func testDisconnectScenarios(t *testing.T, suite *integrationTestSuite) {
 			},
 			disconnectTimeout: 4 * time.Second,
 		}, {
-			//"verify that concurrent connection limits are applied when recording at node",
+			// "verify that concurrent connection limits are applied when recording at node",
 			recordingMode: types.RecordAtNode,
 			options: types.RoleOptions{
 				MaxConnections: 1,

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -176,7 +176,7 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	srv.POST("/:version/tokens/register", srv.withAuth(srv.registerUsingToken))
 	srv.POST("/:version/tokens/register/auth", srv.withAuth(srv.registerNewAuthServer))
 
-	// active sesssions
+	// Active sessions
 	srv.POST("/:version/namespaces/:namespace/sessions", srv.withAuth(srv.createSession))
 	srv.PUT("/:version/namespaces/:namespace/sessions/:id", srv.withAuth(srv.updateSession))
 	srv.DELETE("/:version/namespaces/:namespace/sessions/:id", srv.withAuth(srv.deleteSession))

--- a/lib/auth/apiserver_active_sessions_test.go
+++ b/lib/auth/apiserver_active_sessions_test.go
@@ -1,0 +1,242 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/session"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIServer_activeSessions_whereConditions(t *testing.T) {
+	t.Parallel()
+
+	tlsServer := newTestTLSServer(t)
+	authServer := tlsServer.Auth()
+
+	// - "admin" has permissions to access all active sessions
+	// - "alpaca" has permissions to access only their own active sessions
+	// Each user is assigned its corresponding role, plus whatever extra
+	// permissions are needed to run the scenario.
+	const admin = "admin"
+	const alpaca = "alpaca"
+	alpacaRole := services.RoleForUser(&types.UserV2{Metadata: types.Metadata{Name: alpaca}})
+	alpacaRole.SetLogins(types.Allow, []string{alpaca})
+	alpacaRole.SetRules(types.Allow, append(alpacaRole.GetRules(types.Allow), types.Rule{
+		Resources: []string{"ssh_session"},
+		// Allow all ssh_session verbs, deny rule below takes precedence.
+		Verbs: []string{"*"},
+	}))
+	alpacaRole.SetRules(types.Deny, append(alpacaRole.GetRules(types.Deny), types.Rule{
+		Resources: []string{"ssh_session"},
+		Verbs:     []string{"list", "read", "update", "delete"},
+		Where:     "!contains(ssh_session.participants, user.metadata.name)",
+	}))
+	_, err := CreateUser(authServer, alpaca, alpacaRole)
+	require.NoError(t, err)
+
+	// Prepare clients.
+	adminClient, err := tlsServer.NewClient(TestAdmin())
+	require.NoError(t, err)
+	alpacaClient, err := tlsServer.NewClient(TestUser(alpaca))
+	require.NoError(t, err)
+
+	// Prepare one session per user.
+	createSession := func(clt ClientI, user string) session.ID {
+		id := session.NewID()
+		now := time.Now()
+
+		// Create initial session.
+		require.NoError(t, clt.CreateSession(session.Session{
+			ID:        id,
+			Namespace: apidefaults.Namespace,
+			TerminalParams: session.TerminalParams{
+				W: 100,
+				H: 100,
+			},
+			Login:      user,
+			Created:    now,
+			LastActive: now,
+		}))
+
+		// Add parties, must be done via update.
+		// Usually the Node does this, in the test we are taking a shortcut and
+		// using admin due to its powerful permissions.
+		require.NoError(t, adminClient.UpdateSession(session.UpdateRequest{
+			ID:        id,
+			Namespace: apidefaults.Namespace,
+			Parties: &[]session.Party{
+				{ID: session.NewID(), User: user},
+			},
+		}))
+		return id
+	}
+	adminSessionID := createSession(adminClient, admin)
+	alpacaSessionID := createSession(alpacaClient, alpaca)
+
+	t.Run("GetSessions respects role conditions", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			clt     ClientI
+			wantIDs []session.ID
+		}{
+			{
+				name:    admin,
+				clt:     adminClient,
+				wantIDs: []session.ID{adminSessionID, alpacaSessionID},
+			},
+			{
+				name:    alpaca,
+				clt:     alpacaClient,
+				wantIDs: []session.ID{alpacaSessionID},
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				sessions, err := test.clt.GetSessions(apidefaults.Namespace)
+				require.NoError(t, err)
+
+				got := make([]session.ID, len(sessions))
+				for i, s := range sessions {
+					got[i] = s.ID
+				}
+				want := test.wantIDs
+				sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+				sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+				if diff := cmp.Diff(test.wantIDs, got); diff != "" {
+					t.Errorf("GetSessions() mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
+	})
+
+	// Helper functions used by test cases below.
+	getSession := func(clt ClientI) func(id session.ID) error {
+		return func(id session.ID) error {
+			_, err := clt.GetSession(apidefaults.Namespace, id)
+			return err
+		}
+	}
+	updateSession := func(clt ClientI) func(id session.ID) error {
+		return func(id session.ID) error {
+			return clt.UpdateSession(session.UpdateRequest{
+				ID:             id,
+				Namespace:      apidefaults.Namespace,
+				TerminalParams: &session.TerminalParams{W: 150, H: 150},
+			})
+		}
+	}
+	deleteSession := func(clt ClientI) func(id session.ID) error {
+		return func(id session.ID) error {
+			return clt.UpdateSession(session.UpdateRequest{
+				ID:             id,
+				Namespace:      apidefaults.Namespace,
+				TerminalParams: &session.TerminalParams{W: 150, H: 150},
+			})
+		}
+	}
+
+	t.Run("users can't interact with denied sessions", func(t *testing.T) {
+		clt := alpacaClient
+		sessionID := adminSessionID
+		tests := []struct {
+			name string
+			fn   func(id session.ID) error
+		}{
+			{
+				name: "GetSession",
+				fn:   getSession(clt),
+			},
+			{
+				name: "UpdateSession",
+				fn:   updateSession(clt),
+			},
+			{
+				name: "DeleteSession",
+				fn:   deleteSession(clt),
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				err := test.fn(sessionID)
+				require.True(t, trace.IsAccessDenied(err), "unexpected err: %v (want access denied)", err)
+			})
+		}
+	})
+
+	t.Run("users can interact with allowed sessions", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			fn        func(session.ID) error
+			sessionID session.ID
+		}{
+			{
+				name:      "admin reads own session",
+				fn:        getSession(adminClient),
+				sessionID: adminSessionID,
+			},
+			{
+				name:      "admin updates own session",
+				fn:        updateSession(adminClient),
+				sessionID: adminSessionID,
+			},
+			{
+				name:      "admin deletes own session",
+				fn:        deleteSession(adminClient),
+				sessionID: adminSessionID,
+			},
+			{
+				name:      "admin reads alpaca session",
+				fn:        getSession(adminClient),
+				sessionID: alpacaSessionID,
+			},
+			{
+				name:      "admin updates alpaca session",
+				fn:        updateSession(adminClient),
+				sessionID: alpacaSessionID,
+			},
+
+			{
+				name:      "alpaca reads own session",
+				fn:        getSession(alpacaClient),
+				sessionID: alpacaSessionID,
+			},
+			{
+				name:      "alpaca updates own session",
+				fn:        updateSession(alpacaClient),
+				sessionID: alpacaSessionID,
+			},
+			{
+				name:      "alpaca deletes own session",
+				fn:        deleteSession(alpacaClient),
+				sessionID: alpacaSessionID,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				require.NoError(t, test.fn(test.sessionID))
+			})
+		}
+	})
+}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -136,38 +136,60 @@ func (a *ServerWithRoles) authConnectorAction(namespace string, resource string,
 	return nil
 }
 
-// sessionRecordingAction is a special checker that grants access to session
-// recordings. It allows access to specific recordings based on the `where`
-// section of the user's access rule.
-func (a *ServerWithRoles) sessionRecordingAction(namespace string, sid session.ID, verb string) error {
+// actionForListWithCondition extracts a restrictive filter condition to be
+// added to a list query after a simple resource check fails.
+func (a *ServerWithRoles) actionForListWithCondition(namespace, resource, identifier string) (*types.WhereExpr, error) {
+	origErr := a.withOptions(quietAction(true)).action(namespace, resource, types.VerbList)
+	if origErr == nil || !trace.IsAccessDenied(origErr) {
+		return nil, trace.Wrap(origErr)
+	}
+	cond, err := a.context.Checker.ExtractConditionForIdentifier(&services.Context{User: a.context.User}, namespace, resource, types.VerbList, identifier)
+	if trace.IsAccessDenied(err) {
+		log.WithError(err).Infof("Access to %v %v in namespace %v denied to %v.", types.VerbList, resource, namespace, a.context.Checker)
+		// Return the original AccessDenied to avoid leaking information.
+		return nil, trace.Wrap(origErr)
+	}
+	return cond, trace.Wrap(err)
+}
+
+// actionWithExtendedContext performs an additional RBAC check with extended
+// rule context after a simple resource check fails.
+func (a *ServerWithRoles) actionWithExtendedContext(namespace, kind, verb string, extendContext func(*services.Context) error) error {
 	ruleCtx := &services.Context{User: a.context.User}
-	origErr := a.context.Checker.CheckAccessToRule(ruleCtx, namespace, types.KindSession, verb, true)
+	origErr := a.context.Checker.CheckAccessToRule(ruleCtx, namespace, kind, verb, true)
 	if origErr == nil || !trace.IsAccessDenied(origErr) {
 		return trace.Wrap(origErr)
 	}
-	sessionEvents, err := a.alog.GetSessionEvents(namespace, sid, 0, false)
-	if err != nil {
-		log.WithError(err).Warnf("An error occurred while fetching session.end for session ID %q.", sid)
+	if err := extendContext(ruleCtx); err != nil {
+		log.WithError(err).Warning("Failed to extend context for second RBAC check.")
+		// Return the original AccessDenied to avoid leaking information.
 		return trace.Wrap(origErr)
 	}
-	for _, ef := range sessionEvents {
-		if ef.GetType() == events.SessionEndEvent {
-			event, err := events.FromEventFields(ef)
-			if err != nil {
-				log.WithError(err).Warnf("An error occurred while extracting session.end for session ID %q.", sid)
-				return trace.Wrap(origErr)
-			}
-			session, ok := event.(*apievents.SessionEnd)
-			if !ok {
-				log.Warnf("Unexpected event type %T of session.end found for session ID %q.", event, sid)
-				return trace.Wrap(origErr)
-			}
-			ruleCtx.Session = session
-			return trace.Wrap(a.context.Checker.CheckAccessToRule(ruleCtx, namespace, types.KindSession, verb, false))
-		}
+	return trace.Wrap(a.context.Checker.CheckAccessToRule(ruleCtx, namespace, kind, verb, false))
+}
+
+// actionForKindSession is a special checker that grants access to session
+// recordings.  It can allow access to a specific recording based on the
+// `where` section of the user's access rule for kind `session`.
+func (a *ServerWithRoles) actionForKindSession(namespace, verb string, sid session.ID) error {
+	extendContext := func(ctx *services.Context) error {
+		sessionEnd, err := a.findSessionEndEvent(namespace, sid)
+		ctx.Session = sessionEnd
+		return trace.Wrap(err)
 	}
-	log.Warnf("session.end event not found for session ID %q.", sid)
-	return trace.Wrap(origErr)
+	return trace.Wrap(a.actionWithExtendedContext(namespace, types.KindSession, verb, extendContext))
+}
+
+// actionForKindSSHSession is a special checker that grants access to active
+// sessions.  It can allow access to a specific session based on the `where`
+// section of the user's access rule for kind `ssh_session`.
+func (a *ServerWithRoles) actionForKindSSHSession(namespace, verb string, sid session.ID) error {
+	extendContext := func(ctx *services.Context) error {
+		session, err := a.sessions.GetSession(namespace, sid)
+		ctx.SSHSession = session
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(a.actionWithExtendedContext(namespace, types.KindSSHSession, verb, extendContext))
 }
 
 // hasBuiltinRole checks the type of the role set returned and the name.
@@ -237,15 +259,34 @@ func (a *ServerWithRoles) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHL
 }
 
 func (a *ServerWithRoles) GetSessions(namespace string) ([]session.Session, error) {
-	if err := a.action(namespace, types.KindSSHSession, types.VerbList); err != nil {
+	cond, err := a.actionForListWithCondition(namespace, types.KindSSHSession, services.SSHSessionIdentifier)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return a.sessions.GetSessions(namespace)
+	sessions, err := a.sessions.GetSessions(namespace)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if cond == nil {
+		return sessions, nil
+	}
+
+	// Filter sessions according to cond.
+	filteredSessions := make([]session.Session, 0, len(sessions))
+	ruleCtx := &services.Context{User: a.context.User}
+	for _, s := range sessions {
+		ruleCtx.SSHSession = &s
+		if err := a.context.Checker.CheckAccessToRule(ruleCtx, namespace, types.KindSSHSession, types.VerbList, true /* silent */); err != nil {
+			continue
+		}
+		filteredSessions = append(filteredSessions, s)
+	}
+	return filteredSessions, nil
 }
 
 func (a *ServerWithRoles) GetSession(namespace string, id session.ID) (*session.Session, error) {
-	if err := a.action(namespace, types.KindSSHSession, types.VerbRead); err != nil {
+	if err := a.actionForKindSSHSession(namespace, types.VerbRead, id); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return a.sessions.GetSession(namespace, id)
@@ -259,7 +300,7 @@ func (a *ServerWithRoles) CreateSession(s session.Session) error {
 }
 
 func (a *ServerWithRoles) UpdateSession(req session.UpdateRequest) error {
-	if err := a.action(req.Namespace, types.KindSSHSession, types.VerbUpdate); err != nil {
+	if err := a.actionForKindSSHSession(req.Namespace, types.VerbUpdate, req.ID); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.sessions.UpdateSession(req)
@@ -267,7 +308,7 @@ func (a *ServerWithRoles) UpdateSession(req session.UpdateRequest) error {
 
 // DeleteSession removes an active session from the backend.
 func (a *ServerWithRoles) DeleteSession(namespace string, id session.ID) error {
-	if err := a.action(namespace, types.KindSSHSession, types.VerbDelete); err != nil {
+	if err := a.actionForKindSSHSession(namespace, types.VerbDelete, id); err != nil {
 		return trace.Wrap(err)
 	}
 	return a.sessions.DeleteSession(namespace, id)
@@ -2039,7 +2080,7 @@ func (a *ServerWithRoles) UploadSessionRecording(r events.SessionRecording) erro
 }
 
 func (a *ServerWithRoles) GetSessionChunk(namespace string, sid session.ID, offsetBytes, maxBytes int) ([]byte, error) {
-	if err := a.sessionRecordingAction(namespace, sid, types.VerbRead); err != nil {
+	if err := a.actionForKindSession(namespace, types.VerbRead, sid); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -2047,11 +2088,30 @@ func (a *ServerWithRoles) GetSessionChunk(namespace string, sid session.ID, offs
 }
 
 func (a *ServerWithRoles) GetSessionEvents(namespace string, sid session.ID, afterN int, includePrintEvents bool) ([]events.EventFields, error) {
-	if err := a.sessionRecordingAction(namespace, sid, types.VerbRead); err != nil {
+	if err := a.actionForKindSession(namespace, types.VerbRead, sid); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return a.alog.GetSessionEvents(namespace, sid, afterN, includePrintEvents)
+}
+
+func (a *ServerWithRoles) findSessionEndEvent(namespace string, sid session.ID) (*apievents.SessionEnd, error) {
+	sessionEvents, err := a.alog.GetSessionEvents(namespace, sid, 0, false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, ef := range sessionEvents {
+		if ef.GetType() == events.SessionEndEvent {
+			event, err := events.FromEventFields(ef)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if sessionEnd, ok := event.(*apievents.SessionEnd); ok {
+				return sessionEnd, nil
+			}
+		}
+	}
+	return nil, trace.NotFound("session.end event not found for session ID %q", sid)
 }
 
 // GetNamespaces returns a list of namespaces
@@ -3127,19 +3187,12 @@ func (a *ServerWithRoles) SearchSessionEvents(fromUTC, toUTC time.Time, limit in
 		return nil, "", trace.BadParameter("cond is an internal parameter, should not be set by client")
 	}
 
-	if actionErr := a.action(apidefaults.Namespace, types.KindSession, types.VerbList); actionErr != nil {
-		if !trace.IsAccessDenied(actionErr) {
-			return nil, "", trace.Wrap(actionErr)
-		}
-		cond, err = a.context.Checker.ExtractConditionForIdentifier(&services.Context{User: a.context.User}, apidefaults.Namespace, types.KindSession, types.VerbList, services.SessionIdentifier)
-		if err != nil {
-			if !trace.IsAccessDenied(err) {
-				return nil, "", trace.Wrap(err)
-			}
-			return nil, "", trace.Wrap(actionErr)
-		}
+	cond, err = a.actionForListWithCondition(apidefaults.Namespace, types.KindSession, services.SessionIdentifier)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
 	}
 
+	// TODO(codingllama): Refactor cond out of SearchSessionEvents and simplify signature.
 	events, lastKey, err = a.alog.SearchSessionEvents(fromUTC, toUTC, limit, order, startKey, cond)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
@@ -3198,7 +3251,7 @@ func (a *ServerWithRoles) ReplaceRemoteLocks(ctx context.Context, clusterName st
 // channel if one is encountered. Otherwise it is simply closed when the stream ends.
 // The event channel is not closed on error to prevent race conditions in downstream select statements.
 func (a *ServerWithRoles) StreamSessionEvents(ctx context.Context, sessionID session.ID, startIndex int64) (chan apievents.AuditEvent, chan error) {
-	if err := a.sessionRecordingAction(apidefaults.Namespace, sessionID, types.VerbList); err != nil {
+	if err := a.actionForKindSession(apidefaults.Namespace, types.VerbList, sessionID); err != nil {
 		c, e := make(chan apievents.AuditEvent), make(chan error, 1)
 		e <- trace.Wrap(err)
 		return c, e

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -302,8 +302,8 @@ func (c *Client) ProcessKubeCSR(req KubeCSR) (*KubeCSRResponse, error) {
 	return &re, nil
 }
 
-// GetSessions returns a list of active sessions in the cluster
-// as reported by auth server
+// GetSessions returns a list of active sessions in the cluster as reported by
+// the auth server.
 func (c *Client) GetSessions(namespace string) ([]session.Session, error) {
 	if namespace == "" {
 		return nil, trace.BadParameter(MissingNamespaceError)

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -963,7 +963,7 @@ func CreateAccessPluginUser(ctx context.Context, clt clt, username string) (type
 	return user, nil
 }
 
-// CreateUser creates user and role and assignes role to a user, used in tests
+// CreateUser creates user and role and assigns role to a user, used in tests
 func CreateUser(clt clt, username string, roles ...types.Role) (types.User, error) {
 	ctx := context.TODO()
 	user, err := types.NewUser(username)
@@ -986,7 +986,7 @@ func CreateUser(clt clt, username string, roles ...types.Role) (types.User, erro
 	return user, nil
 }
 
-// CreateUserAndRole creates user and role and assignes role to a user, used in tests
+// CreateUserAndRole creates user and role and assigns role to a user, used in tests
 func CreateUserAndRole(clt clt, username string, allowedLogins []string) (types.User, types.Role, error) {
 	ctx := context.TODO()
 	user, err := types.NewUser(username)

--- a/lib/events/api_test.go
+++ b/lib/events/api_test.go
@@ -23,34 +23,9 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
 )
-
-func TestEventFields(t *testing.T) {
-	t.Parallel()
-	now := time.Now().Round(time.Minute)
-
-	slice := []string{"test", "string", "slice"}
-	slice2 := []interface{}{"test", "string", "slice"}
-	f := EventFields{
-		"one":      1,
-		"name":     "vincent",
-		"time":     now,
-		"strings":  slice,
-		"strings2": slice2,
-	}
-
-	require.Equal(t, 1, f.GetInt("one"))
-	require.Equal(t, 0, f.GetInt("two"))
-	require.Equal(t, "vincent", f.GetString("name"))
-	require.Equal(t, "", f.GetString("city"))
-	require.Equal(t, now, f.GetTime("time"))
-	require.Equal(t, slice, f.GetStrings("strings"))
-	require.Equal(t, slice, f.GetStrings("strings2"))
-	require.Nil(t, f.GetStrings("strings3"))
-}
 
 func TestUpdateEventFields(t *testing.T) {
 	t.Parallel()
@@ -74,23 +49,4 @@ func TestUpdateEventFields(t *testing.T) {
 		EventUser:   "test@example.com",
 		LoginMethod: LoginMethodOIDC,
 	}, fields)
-}
-
-func TestToEventFieldsCondition(t *testing.T) {
-	t.Parallel()
-
-	// !equals(login, "root") && contains(participants, "test-user")
-	expr := &types.WhereExpr{And: types.WhereExpr2{
-		L: &types.WhereExpr{Not: &types.WhereExpr{Equals: types.WhereExpr2{L: &types.WhereExpr{Field: "login"}, R: &types.WhereExpr{Literal: "root"}}}},
-		R: &types.WhereExpr{Contains: types.WhereExpr2{L: &types.WhereExpr{Field: "participants"}, R: &types.WhereExpr{Literal: "test-user"}}},
-	}}
-
-	cond, err := ToEventFieldsCondition(expr)
-	require.NoError(t, err)
-
-	require.False(t, cond(EventFields{}))
-	require.False(t, cond(EventFields{"login": "root", "participants": []string{"test-user", "observer"}}))
-	require.False(t, cond(EventFields{"login": "guest", "participants": []string{"another-user"}}))
-	require.True(t, cond(EventFields{"login": "guest", "participants": []string{"test-user", "observer"}}))
-	require.True(t, cond(EventFields{"participants": []string{"test-user"}}))
 }

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -362,7 +362,7 @@ func (l *FileLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order
 	l.Debugf("SearchSessionEvents(%v, %v, order=%v, limit=%v, cond=%q)", fromUTC, toUTC, order, limit, cond)
 	filter := searchEventsFilter{eventTypes: []string{SessionEndEvent}}
 	if cond != nil {
-		condFn, err := ToEventFieldsCondition(cond)
+		condFn, err := utils.ToFieldsCondition(cond)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -374,11 +374,11 @@ func (l *FileLog) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order
 
 type searchEventsFilter struct {
 	eventTypes []string
-	condition  EventFieldsCondition
+	condition  utils.FieldsCondition
 }
 
-// Close closes the audit log, which inluces closing all file handles and releasing
-// all session loggers
+// Close closes the audit log, which includes closing all file handles and
+// releasing all session loggers.
 func (l *FileLog) Close() error {
 	l.rw.Lock()
 	defer l.rw.Unlock()
@@ -621,7 +621,7 @@ func (l *FileLog) findInFile(path string, filter searchEventsFilter) ([]EventFie
 		}
 		// Check that the filter condition is satisfied.
 		if filter.condition != nil {
-			accepted = accepted && filter.condition(ef)
+			accepted = accepted && filter.condition(utils.Fields(ef))
 		}
 
 		if accepted {

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -585,7 +585,7 @@ func (l *Log) searchEventsOnce(fromUTC, toUTC time.Time, namespace string, limit
 		}
 
 		// Check that the filter condition is satisfied.
-		if filter.condition != nil && !filter.condition(fields) {
+		if filter.condition != nil && !filter.condition(utils.Fields(fields)) {
 			continue
 		}
 
@@ -630,7 +630,7 @@ func (l *Log) searchEventsOnce(fromUTC, toUTC time.Time, namespace string, limit
 func (l *Log) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order types.EventOrder, startKey string, cond *types.WhereExpr) ([]apievents.AuditEvent, string, error) {
 	filter := searchEventsFilter{eventTypes: []string{events.SessionEndEvent}}
 	if cond != nil {
-		condFn, err := events.ToEventFieldsCondition(cond)
+		condFn, err := utils.ToFieldsCondition(cond)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -641,7 +641,7 @@ func (l *Log) SearchSessionEvents(fromUTC, toUTC time.Time, limit int, order typ
 
 type searchEventsFilter struct {
 	eventTypes []string
-	condition  events.EventFieldsCondition
+	condition  utils.FieldsCondition
 }
 
 // WaitForDelivery waits for resources to be released and outstanding requests to

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
-
 	"github.com/jonboulle/clockwork"
 	"github.com/moby/term"
 	"github.com/pborman/uuid"
@@ -106,6 +105,15 @@ type Session struct {
 	ServerAddr string `json:"server_addr"`
 	// ClusterName is the name of cluster that this session belongs to.
 	ClusterName string `json:"cluster_name"`
+}
+
+// Participants returns the usernames of the current session participants.
+func (s *Session) Participants() []string {
+	participants := make([]string, 0, len(s.Parties))
+	for _, p := range s.Parties {
+		participants = append(participants, p.User)
+	}
+	return participants
 }
 
 // RemoveParty helper allows to remove a party by it's ID from the
@@ -228,8 +236,8 @@ const MaxSessionSliceLength = 1000
 // Service is a realtime SSH session service that has information about
 // sessions that are in-flight in the cluster at the moment.
 type Service interface {
-	// GetSessions returns a list of currently active sessions with all parties
-	// involved.
+	// GetSessions returns a list of currently active sessions matching
+	// the given condition.
 	GetSessions(namespace string) ([]Session, error)
 
 	// GetSession returns a session with it's parties by ID.
@@ -274,26 +282,24 @@ func activeKey(namespace string, key string) []byte {
 	return backend.Key("namespaces", namespace, "sessions", "active", key)
 }
 
-// GetSessions returns a list of active sessions. Returns an empty slice
-// if no sessions are active
+// GetSessions returns a list of active sessions.
+// Returns an empty slice if no sessions are active
 func (s *server) GetSessions(namespace string) ([]Session, error) {
 	prefix := activePrefix(namespace)
-
 	result, err := s.bk.GetRange(context.TODO(), prefix, backend.RangeEnd(prefix), MaxSessionSliceLength)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	out := make(Sessions, 0, len(result.Items))
 
-	for i := range result.Items {
-		var session Session
-		if err := json.Unmarshal(result.Items[i].Value, &session); err != nil {
+	sessions := make(Sessions, len(result.Items))
+	for i, item := range result.Items {
+		if err := json.Unmarshal(item.Value, &sessions[i]); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		out = append(out, session)
 	}
-	sort.Stable(out)
-	return out, nil
+
+	sort.Stable(sessions)
+	return sessions, nil
 }
 
 // Sessions type is created over []Session to implement sort.Interface to

--- a/lib/utils/fields.go
+++ b/lib/utils/fields.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
+)
+
+// Fields represents a generic string-keyed map.
+type Fields map[string]interface{}
+
+// GetString returns a string representation of a field.
+func (f Fields) GetString(key string) string {
+	val, found := f[key]
+	if !found {
+		return ""
+	}
+	return val.(string)
+}
+
+// GetStrings returns a slice-of-strings representation of a field.
+func (f Fields) GetStrings(key string) []string {
+	val, found := f[key]
+	if !found {
+		return nil
+	}
+	strings, ok := val.([]string)
+	if ok {
+		return strings
+	}
+	slice, _ := val.([]interface{})
+	res := make([]string, 0, len(slice))
+	for _, v := range slice {
+		s, ok := v.(string)
+		if ok {
+			res = append(res, s)
+		}
+	}
+	return res
+}
+
+// GetInt returns an int representation of a field.
+func (f Fields) GetInt(key string) int {
+	val, found := f[key]
+	if !found {
+		return 0
+	}
+	v, ok := val.(int)
+	if !ok {
+		f, ok := val.(float64)
+		if ok {
+			v = int(f)
+		}
+	}
+	return v
+}
+
+// GetTime returns a time.Time representation of a field.
+func (f Fields) GetTime(key string) time.Time {
+	val, found := f[key]
+	if !found {
+		return time.Time{}
+	}
+	v, ok := val.(time.Time)
+	if !ok {
+		s := f.GetString(key)
+		v, _ = time.Parse(time.RFC3339, s)
+	}
+	return v
+}
+
+// HasField returns true if the field exists.
+func (f Fields) HasField(key string) bool {
+	_, ok := f[key]
+	return ok
+}
+
+// FieldsCondition is a boolean function on Fields.
+type FieldsCondition func(Fields) bool
+
+// ToFieldsCondition converts a WhereExpr into a FieldsCondition.
+func ToFieldsCondition(expr *types.WhereExpr) (FieldsCondition, error) {
+	if expr == nil {
+		return nil, trace.BadParameter("expr is nil")
+	}
+
+	binOp := func(e types.WhereExpr2, op func(a, b bool) bool) (FieldsCondition, error) {
+		left, err := ToFieldsCondition(e.L)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		right, err := ToFieldsCondition(e.R)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return func(f Fields) bool { return op(left(f), right(f)) }, nil
+	}
+	if expr, err := binOp(expr.And, func(a, b bool) bool { return a && b }); err == nil {
+		return expr, nil
+	}
+	if expr, err := binOp(expr.Or, func(a, b bool) bool { return a || b }); err == nil {
+		return expr, nil
+	}
+	if inner, err := ToFieldsCondition(expr.Not); err == nil {
+		return func(f Fields) bool { return !inner(f) }, nil
+	}
+
+	if expr.Equals.L != nil && expr.Equals.R != nil {
+		left, right := expr.Equals.L, expr.Equals.R
+		switch {
+		case left.Field != "" && right.Field != "":
+			return func(f Fields) bool { return f[left.Field] == f[right.Field] }, nil
+		case left.Literal != nil && right.Field != "":
+			return func(f Fields) bool { return left.Literal == f[right.Field] }, nil
+		case left.Field != "" && right.Literal != nil:
+			return func(f Fields) bool { return f[left.Field] == right.Literal }, nil
+		}
+	}
+	if expr.Contains.L != nil && expr.Contains.R != nil {
+		left, right := expr.Contains.L, expr.Contains.R
+		switch {
+		case left.Field != "" && right.Field != "":
+			return func(f Fields) bool { return utils.SliceContainsStr(f.GetStrings(left.Field), f.GetString(right.Field)) }, nil
+		case left.Literal != nil && right.Field != "":
+			if ss, ok := left.Literal.([]string); ok {
+				return func(f Fields) bool { return utils.SliceContainsStr(ss, f.GetString(right.Field)) }, nil
+			}
+		case left.Field != "" && right.Literal != nil:
+			if s, ok := right.Literal.(string); ok {
+				return func(f Fields) bool { return utils.SliceContainsStr(f.GetStrings(left.Field), s) }, nil
+			}
+		}
+	}
+
+	return nil, trace.BadParameter("failed to convert expression %q to FieldsCondition", expr)
+}

--- a/lib/utils/fields_test.go
+++ b/lib/utils/fields_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestFields(t *testing.T) {
+	t.Parallel()
+	now := time.Now().Round(time.Minute)
+
+	sliceString := []string{"test", "string", "slice"}
+	sliceInterface := []interface{}{"test", "string", "slice"}
+	f := Fields{
+		"one":      1,
+		"name":     "vincent",
+		"time":     now,
+		"strings":  sliceString,
+		"strings2": sliceInterface,
+	}
+
+	require.Equal(t, 1, f.GetInt("one"))
+	require.Equal(t, 0, f.GetInt("two"))
+	require.Equal(t, "vincent", f.GetString("name"))
+	require.Equal(t, "", f.GetString("city"))
+	require.Equal(t, now, f.GetTime("time"))
+	require.Equal(t, sliceString, f.GetStrings("strings"))
+	require.Equal(t, sliceString, f.GetStrings("strings2"))
+	require.Nil(t, f.GetStrings("strings3"))
+}
+
+func TestToFieldsCondition(t *testing.T) {
+	t.Parallel()
+
+	// !equals(login, "root") && contains(participants, "test-user")
+	expr := &types.WhereExpr{And: types.WhereExpr2{
+		L: &types.WhereExpr{Not: &types.WhereExpr{Equals: types.WhereExpr2{L: &types.WhereExpr{Field: "login"}, R: &types.WhereExpr{Literal: "root"}}}},
+		R: &types.WhereExpr{Contains: types.WhereExpr2{L: &types.WhereExpr{Field: "participants"}, R: &types.WhereExpr{Literal: "test-user"}}},
+	}}
+
+	cond, err := ToFieldsCondition(expr)
+	require.NoError(t, err)
+
+	require.False(t, cond(Fields{}))
+	require.False(t, cond(Fields{"login": "root", "participants": []string{"test-user", "observer"}}))
+	require.False(t, cond(Fields{"login": "guest", "participants": []string{"another-user"}}))
+	require.True(t, cond(Fields{"login": "guest", "participants": []string{"test-user", "observer"}}))
+	require.True(t, cond(Fields{"participants": []string{"test-user"}}))
+}


### PR DESCRIPTION
Implements [RFD 45 / "where" conditions for active sessions](https://github.com/gravitational/teleport/blob/master/rfd/0045-ssh_session-where-condition.md).

In few words, the purpose of the RFD is to allow the creation of roles that permits users to only join a subset of active sessions (for example, only their own sessions).

Implementation goes a bit further than the RFD, allowing the conditions to be applied to  `update` and `delete` verbs as well.

Originally implemented by @andrejtokarcik (#8568), tweaks by @codingllama.