### PR TITLE
Build Rust libraries using Centos 7 - please do not merge yet

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+dep-info-basedir = "."

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,72 +1,11 @@
 # This Dockerfile makes the "build box": the container used to build official
 # releases of Teleport and its documentation.
 
-# Set the desired Rust version once.
-ARG RUST_VERSION=1.56.1
-FROM rust:$RUST_VERSION AS officialrust
-
-# Run the Rust builds from a Centos 7 container, to link against a glibc version
-# compatible with Centos 7. Using a newer base image will build against a newer
-# glibc, which creates a runtime requirement for the host to have a newer glibc
-# too.
-FROM centos:7 AS rustbuilder
-ARG RUST_VERSION
-
-# OS/ARCH for pre-building the Rust libraries
-ARG OS
-ARG ARCH
-
-# Install Rust
-#
-# Rust installation based on official Dockerfile here:
-#   https://github.com/rust-lang/docker-rust/blob/master/$RUST_VERSION/bullseye/Dockerfile
-#
-# The original Rust docker image uses a script to install `rustup`, and from
-# there rustc and associated tools.
-#
-# Rather than execute an arbitrary `rustup` installation script, we are cherry-
-# picking the appropriate files off the official docker image and then installing
-# the extra tooling/targets we need.
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=$RUST_VERSION
-
-COPY --from=officialrust /usr/local/rustup /usr/local/rustup
-COPY --from=officialrust /usr/local/cargo /usr/local/cargo
-
-# Install dev tools (make, etc) and a Perl package needed to compile OpenSSL.
-RUN yum groupinstall -y "Development Tools"
-RUN yum install -y perl-IPC-Cmd
-
-# TODO: install Go (for GOPATH, GOARCH, etc)
-
-RUN set -eux \
-    make -v; \
-    rustup --version; \
-    cargo --version; \
-    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup target add i686-unknown-linux-gnu; \
-    rustup target add arm-unknown-linux-gnueabihf; \
-    rustup target add aarch64-unknown-linux-gnu; \
-    rustup target list | grep installed; \
-    rustc --version;
-
-RUN git clone https://github.com/gravitational/teleport.git /teleport-source
-WORKDIR /teleport-source
-# TODO: switch to correct branch
-RUN make rdpclient
-RUN make roletester
-
 FROM ubuntu:18.04
 ARG RUST_VERSION
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile
-
-COPY --from=rustbuilder /teleport-source/lib/srv/desktop/rdp/rdpclient/target /teleport-rust-build-cache/rdpclient/target
-COPY --from=rustbuilder /teleport-source/lib/datalog/roletester/target /teleport-rust-build-cache/roletester/target
 
 ENV LANGUAGE="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
@@ -124,26 +63,6 @@ ARG UID
 ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
-
-
-# Install Rust, using the same process as above.
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=$RUST_VERSION
-
-COPY --from=officialrust /usr/local/rustup /usr/local/rustup
-COPY --from=officialrust /usr/local/cargo /usr/local/cargo
-RUN set -eux \
-    rustup --version; \
-    cargo --version; \
-    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup target add i686-unknown-linux-gnu; \
-    rustup target add arm-unknown-linux-gnueabihf; \
-    rustup target add aarch64-unknown-linux-gnu; \
-    rustup target list | grep installed; \
-    rustc --version;
 
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
@@ -211,6 +130,29 @@ COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install
 
 ENV SOFTHSM2_PATH "/usr/lib/softhsm/libsofthsm2.so"
+
+# For official builds, Rust libraries and compiled in a separate buildbox image,
+# but it is helpful to have the Rust tooling in this buildbox as well.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=$RUST_VERSION
+
+RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
+    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
+
+# Install Rust as the ci user to ensure permissions
+# are set up correctly.
+USER ci
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+    rustup --version && \
+    cargo --version && \
+    rustc --version && \
+    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy && \
+    rustup target add i686-unknown-linux-gnu && \
+    rustup target add arm-unknown-linux-gnueabihf && \
+    rustup target add aarch64-unknown-linux-gnu && \
+    cargo install cbindgen
 
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,15 +1,72 @@
 # This Dockerfile makes the "build box": the container used to build official
 # releases of Teleport and its documentation.
 
-# Use Ubuntu 18.04 as base to get an older glibc version.
-# Using a newer base image will build against a newer glibc, which creates a
-# runtime requirement for the host to have newer glibc too. For example,
-# teleport built on any newer Ubuntu version will not run on Centos 7 because
-# of this.
+# Set the desired Rust version once.
+ARG RUST_VERSION=1.56.1
+FROM rust:$RUST_VERSION AS officialrust
+
+# Run the Rust builds from a Centos 7 container, to link against a glibc version
+# compatible with Centos 7. Using a newer base image will build against a newer
+# glibc, which creates a runtime requirement for the host to have a newer glibc
+# too.
+FROM centos:7 AS rustbuilder
+ARG RUST_VERSION
+
+# OS/ARCH for pre-building the Rust libraries
+ARG OS
+ARG ARCH
+
+# Install Rust
+#
+# Rust installation based on official Dockerfile here:
+#   https://github.com/rust-lang/docker-rust/blob/master/$RUST_VERSION/bullseye/Dockerfile
+#
+# The original Rust docker image uses a script to install `rustup`, and from
+# there rustc and associated tools.
+#
+# Rather than execute an arbitrary `rustup` installation script, we are cherry-
+# picking the appropriate files off the official docker image and then installing
+# the extra tooling/targets we need.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=$RUST_VERSION
+
+COPY --from=officialrust /usr/local/rustup /usr/local/rustup
+COPY --from=officialrust /usr/local/cargo /usr/local/cargo
+
+# Install dev tools (make, etc) and a Perl package needed to compile OpenSSL.
+RUN yum groupinstall -y "Development Tools"
+RUN yum install -y perl-IPC-Cmd
+
+# TODO: install Go (for GOPATH, GOARCH, etc)
+
+RUN set -eux \
+    make -v; \
+    rustup --version; \
+    cargo --version; \
+    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup target add i686-unknown-linux-gnu; \
+    rustup target add arm-unknown-linux-gnueabihf; \
+    rustup target add aarch64-unknown-linux-gnu; \
+    rustup target list | grep installed; \
+    rustc --version;
+
+RUN git clone https://github.com/gravitational/teleport.git /teleport-source
+WORKDIR /teleport-source
+# TODO: switch to correct branch
+RUN make rdpclient
+RUN make roletester
+
 FROM ubuntu:18.04
+ARG RUST_VERSION
 
 COPY locale.gen /etc/locale.gen
 COPY profile /etc/profile
+
+COPY --from=rustbuilder /teleport-source/lib/srv/desktop/rdp/rdpclient/target /teleport-rust-build-cache/rdpclient/target
+COPY --from=rustbuilder /teleport-source/lib/datalog/roletester/target /teleport-rust-build-cache/roletester/target
 
 ENV LANGUAGE="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
@@ -68,29 +125,19 @@ ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
-# Install Rust
-#
-# Rust installation based on official rust image Dockerfile here:
-#   https://github.com/rust-lang/docker-rust/blob/master/1.56.0/bullseye/Dockerfile
-#
-# The original Rust docker image uses a script to install `rustup`, and from
-# there rustc and associated tools.
-#
-# Rather than execute an arbitrary `rustup` installation script, we are cherry-
-# picking the appropriate files off the official docker image and then installing
-# the extra tooling/targets we need.
 
- ENV RUSTUP_HOME=/usr/local/rustup \
-     CARGO_HOME=/usr/local/cargo \
-     PATH=/usr/local/cargo/bin:$PATH \
-     RUST_VERSION=1.56.1
+# Install Rust, using the same process as above.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=$RUST_VERSION
 
-COPY --from=rust:1.56.1 /usr/local/rustup /usr/local/rustup
-COPY --from=rust:1.56.1 /usr/local/cargo /usr/local/cargo
+COPY --from=officialrust /usr/local/rustup /usr/local/rustup
+COPY --from=officialrust /usr/local/cargo /usr/local/cargo
 RUN set -eux \
     rustup --version; \
     cargo --version; \
-    rustup component add --toolchain 1.56.1-x86_64-unknown-linux-gnu rustfmt clippy; \
+    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup target add i686-unknown-linux-gnu; \
     rustup target add arm-unknown-linux-gnueabihf; \

--- a/build.assets/Dockerfile-rust
+++ b/build.assets/Dockerfile-rust
@@ -1,0 +1,65 @@
+# This Dockerfile makes the build box for Teleport Rust libraries.
+# The Rust libraries are intentionally built against a distro with
+# an older version of glibc in order to avoid creating a runtime
+# dependency on a newer glibc version.
+
+FROM centos:7
+ARG RUST_VERSION
+
+ARG OS
+ARG ARCH
+
+ENV LANGUAGE=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LC_CTYPE=en_US.UTF-8
+
+ARG UID
+ARG GID
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
+     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
+
+# Install dev tools (make, etc) and a Perl package needed to build OpenSSL.
+RUN yum groupinstall -y "Development Tools"
+RUN yum install -y perl-IPC-Cmd
+
+# Install etcd.
+RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
+     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
+
+# Install Go.
+ARG RUNTIME
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz && \
+    mkdir -p /go/src/github.com/gravitational/teleport && \
+    chmod a+w /go && \
+    chmod a+w /var/lib && \
+    /opt/go/bin/go version
+
+RUN chmod a-w /
+
+# Install Rust.
+ENV RUSTUP_HOME=/opt/bin/rustup \
+    CARGO_HOME=/opt/bin/cargo \
+    PATH=/opt/bin/cargo/bin:$PATH \
+    RUST_VERSION=$RUST_VERSION
+
+RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
+    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
+
+USER ci
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+    rustup --version && \
+    cargo --version && \
+    rustc --version && \
+    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy && \
+    rustup target add i686-unknown-linux-gnu && \
+    rustup target add arm-unknown-linux-gnueabihf && \
+    rustup target add aarch64-unknown-linux-gnu && \
+    cargo install cbindgen
+
+ENV GOPATH="/go" \
+    GOROOT="/opt/go" \
+    PATH="/opt/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
+
+VOLUME ["/go/src/github.com/gravitational/teleport"]
+EXPOSE 6600 2379 2380

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -111,6 +111,8 @@ buildbox:
 			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg PROTOC_PLATFORM=$(PROTOC_PLATFORM) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
+			--build-arg OS \
+			--build-arg ARCH \
 			--cache-from $(BUILDBOX) \
 			--tag $(BUILDBOX) . ; \
 	fi

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -290,18 +290,10 @@ enter-rust: buildbox-rust
 .PHONY:release
 release: buildbox buildbox-rust
 	set -e ;\
-	docker run $(DOCKERFLAGS) $(NOROOT) --rm=false $(BUILDBOX_RUST) /usr/bin/make rdpclient roletester -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) REPRODUCIBLE=yes ;\
-	LOCAL_RUST_BUILD_CACHE=../build/prebuilt-rust-libs ;\
-	mkdir -p $$LOCAL_RUST_BUILD_CACHE ;\
-	TELEPORT_RUST_BUILD_CONTAINER=$$(docker ps -alq) ;\
-	docker cp $$TELEPORT_RUST_BUILD_CONTAINER:$(SRCDIR)/lib/datalog/roletester/target $$LOCAL_RUST_BUILD_CACHE/roletester/ ;\
-	docker cp $$TELEPORT_RUST_BUILD_CONTAINER:$(SRCDIR)/lib/srv/desktop/rdp/rdpclient/target $$LOCAL_RUST_BUILD_CACHE/rdpclient/ ;\
-	docker rm $$TELEPORT_RUST_BUILD_CONTAINER ;\
-	docker run $(DOCKERFLAGS) $(NOROOT) -v $$(pwd)/$$LOCAL_RUST_BUILD_CACHE:/opt/teleport-rust-build-cache $(BUILDBOX_NAME) /usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) REPRODUCIBLE=yes ;
-
-# TODO(zmb3) clean this up
-#-rm -rf $$LOCAL_RUST_BUILD_CACHE ;
-
+	LOCAL_RUST_BUILD_CACHE=$$(mktemp -d /tmp/teleport-rust-build-cache-XXXX) ;\
+	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_RUST) /usr/bin/make rdpclient roletester populate-rust-build-cache -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) RUST_LIB_DESTINATION=$$LOCAL_RUST_BUILD_CACHE REPRODUCIBLE=yes ;\
+	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_NAME) /usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) RUST_PREBUILD_DIR=$$LOCAL_RUST_BUILD_CACHE REPRODUCIBLE=yes ;\
+	rm -rf $$LOCAL_RUST_BUILD_CACHE ;
 
 # These are aliases used to make build commands uniform.
 .PHONY: release-amd64

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -17,6 +17,7 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 RUNTIME ?= go1.17.2
+RUST_VERSION ?= 1.56.1
 BORINGCRYPTO_RUNTIME=$(RUNTIME)b7
 LIBBPF_VERSION ?= 0.3.1
 
@@ -32,6 +33,7 @@ BUILDBOX_FIPS=quay.io/gravitational/teleport-buildbox-fips:$(RUNTIME)
 BUILDBOX_CENTOS6=quay.io/gravitational/teleport-buildbox-centos6:$(RUNTIME)
 BUILDBOX_ARM=quay.io/gravitational/teleport-buildbox-arm:$(RUNTIME)
 BUILDBOX_ARM_FIPS=quay.io/gravitational/teleport-buildbox-arm-fips:$(RUNTIME)
+BUILDBOX_RUST=quay.io/gravitational/teleport-buildbox-rust:$(RUST_VERSION)
 
 # These variables are used to dynamically change the name of the buildbox Docker image used by the 'release'
 # target. The other solution was to remove the 'buildbox' dependency from the 'release' target, but this would
@@ -107,12 +109,11 @@ buildbox:
 			--build-arg UID=$(UID) \
 			--build-arg GID=$(GID) \
 			--build-arg RUNTIME=$(RUNTIME) \
+			--build-arg RUST_VERSION=$(RUST_VERSION) \
 			--build-arg PROTOC_VER=$(PROTOC_VER) \
 			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg PROTOC_PLATFORM=$(PROTOC_PLATFORM) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
-			--build-arg OS \
-			--build-arg ARCH \
 			--cache-from $(BUILDBOX) \
 			--tag $(BUILDBOX) . ; \
 	fi
@@ -132,6 +133,23 @@ buildbox-fips:
 			--cache-from $(BUILDBOX_FIPS) \
 			--tag $(BUILDBOX_FIPS) -f Dockerfile-fips . ; \
 	fi
+
+#
+# Builds a Docker buildbox for Rust libraries
+#
+.PHONY:buildbox-rust
+buildbox-rust:
+	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_RUST) 2>&1 >/dev/null; then docker pull $(BUILDBOX_RUST) || true; fi;
+	docker build --platform=linux/amd64 \
+		--build-arg UID=$(UID) \
+		--build-arg GID=$(GID) \
+		--build-arg RUNTIME=$(RUNTIME) \
+		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--build-arg OS \
+		--build-arg ARCH \
+		--cache-from $(BUILDBOX_RUST) \
+		--tag $(BUILDBOX_RUST) -f Dockerfile-rust .
+
 
 #
 # Builds a Docker buildbox for CentOS 6 builds
@@ -255,14 +273,35 @@ enter: buildbox
 	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
 		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX) /bin/bash
 
+.PHONY:enter-rust
+enter-rust: buildbox-rust
+	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
+		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_RUST) /bin/bash
+
+
 #
 # Create a Teleport package using the build container.
 # Don't use this target directly; call named Makefile targets like release-amd64.
 #
+# Note: we build the Rust libraries first in a separate container, then copy them
+# into a local cache which we mount in the Teleport build container.
+# This ensures that the Rust libraries don't inadvertendly create a runtime dependency
+# on a too-new version of glibc.
 .PHONY:release
-release: buildbox
-	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_NAME) \
-		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) REPRODUCIBLE=yes
+release: buildbox buildbox-rust
+	set -e ;\
+	docker run $(DOCKERFLAGS) $(NOROOT) --rm=false $(BUILDBOX_RUST) /usr/bin/make rdpclient roletester -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) REPRODUCIBLE=yes ;\
+	LOCAL_RUST_BUILD_CACHE=../build/prebuilt-rust-libs ;\
+	mkdir -p $$LOCAL_RUST_BUILD_CACHE ;\
+	TELEPORT_RUST_BUILD_CONTAINER=$$(docker ps -alq) ;\
+	docker cp $$TELEPORT_RUST_BUILD_CONTAINER:$(SRCDIR)/lib/datalog/roletester/target $$LOCAL_RUST_BUILD_CACHE/roletester/ ;\
+	docker cp $$TELEPORT_RUST_BUILD_CONTAINER:$(SRCDIR)/lib/srv/desktop/rdp/rdpclient/target $$LOCAL_RUST_BUILD_CACHE/rdpclient/ ;\
+	docker rm $$TELEPORT_RUST_BUILD_CONTAINER ;\
+	docker run $(DOCKERFLAGS) $(NOROOT) -v $$(pwd)/$$LOCAL_RUST_BUILD_CACHE:/opt/teleport-rust-build-cache $(BUILDBOX_NAME) /usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) REPRODUCIBLE=yes ;
+
+# TODO(zmb3) clean this up
+#-rm -rf $$LOCAL_RUST_BUILD_CACHE ;
+
 
 # These are aliases used to make build commands uniform.
 .PHONY: release-amd64


### PR DESCRIPTION
🚨do not merge yet - still needs updates to e and roletester 🚨

Our Ubuntu 18.04 base image contains a version of glibc that is
too new for Centos 7. As a result, our builds contain a runtime
dependency on this new version and will not run on Centos 7.

This commit leverages multi stage builds to build the Rust static
libraries on a Centos 7 box. These binaries are copied into a
special directory in the buildbox image, which make will look for.

In addition:
- Configure Cargo to generate dep-info paths relative to the teleport directory.
  https://doc.rust-lang.org/cargo/guide/build-cache.html#dep-info-files
- Leverage these dep info files to so that make is smart enough to run
  Cargo only if there have been changes to the Rust code.

Fixes #9028