### PR TITLE
Do not prompt for hardware MFA using `tsh` on Windows

### DIFF
--- a/lib/auth/webauthncli/platform_other.go
+++ b/lib/auth/webauthncli/platform_other.go
@@ -1,0 +1,24 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package webauthncli
+
+// HasPlatformSupport returns true if the platform supports client-side
+// WebAuthn-compatible logins.
+func HasPlatformSupport() bool {
+	return true
+}

--- a/lib/auth/webauthncli/platform_windows.go
+++ b/lib/auth/webauthncli/platform_windows.go
@@ -1,0 +1,21 @@
+// Copyright 2021 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webauthncli
+
+// HasPlatformSupport returns true if the platform supports client-side
+// WebAuthn-compatible logins.
+func HasPlatformSupport() bool {
+	return false
+}


### PR DESCRIPTION
`tsh` doesn't support MFA logins on Windows; we make that explicit by warning users when necessary, instead of directing them to a hopeless workflow.

Example attempt:

```shell
$ tsh login
> Enter password for Teleport user codingllama: <password>
> ERROR: hardware device MFA not supported by your platform, please register an OTP device
>
> exit status 1
```