### PR TITLE
simplify connection establishment

### DIFF
--- a/lib/srv/desktop/desktop.go
+++ b/lib/srv/desktop/desktop.go
@@ -23,8 +23,8 @@ import "github.com/gravitational/teleport/api/constants"
 const (
 	// SNISuffix is the server name suffix used during SNI to specify the
 	// target desktop to connect to. The client (proxy_service) will use SNI
-	// like "${UUID}.desktop.teleport.cluster.local" to pass the UUID of the
-	// desktop.
+	// like "login_width_height_desktopName.desktop.teleport.cluster.local"
+	// to pass the UUID of the desktop.
 	SNISuffix = ".desktop." + constants.APIDomain
 	// WildcardServiceDNS is a wildcard DNS address to embed in the service TLS
 	// certificate for SNI-based routing. Note: this is different from ALPN SNI

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -230,7 +230,7 @@ func (c *Client) start() {
 		// Remember mouse coordinates to send them with all CGOPointer events.
 		var mouseX, mouseY uint32
 		for {
-			msg, err := c.cfg.InputMessage()
+			msg, err := c.cfg.TDPConn.InputMessage()
 			if err != nil {
 				c.cfg.Log.Warningf("Failed reading RDP input message: %v", err)
 				return
@@ -358,7 +358,7 @@ func (c *Client) handleBitmap(cb C.CGOBitmap) C.CGOError {
 	})
 	copy(img.Pix, data)
 
-	if err := c.cfg.OutputMessage(tdp.PNGFrame{Img: img}); err != nil {
+	if err := c.cfg.TDPConn.OutputMessage(tdp.PNGFrame{Img: img}); err != nil {
 		return C.CString(fmt.Sprintf("failed to send PNG frame %v: %v", img.Rect, err))
 	}
 	return nil

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -70,6 +70,7 @@ import (
 	"image"
 	"os"
 	"runtime/cgo"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -142,14 +143,22 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 		readyForInput: 0,
 	}
 
-	c.username = c.cfg.Username
+	c.username = c.cfg.Login
 
 	if err := cfg.AuthorizeFn(c.username); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	c.clientWidth = uint16(strconv.Atoi(cfg.Width))
-	c.clientHeight = uint16(strconv.Atoi(cfg.Height))
+	clientWidth, err := strconv.Atoi(cfg.Width)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	clientHeight, err := strconv.Atoi(cfg.Height)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	c.clientWidth = uint16(clientWidth)
+	c.clientHeight = uint16(clientHeight)
 
 	if err := c.connect(ctx); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -42,13 +42,8 @@ type Config struct {
 	// AuthorizeFn is called to authorize a user connecting to a Windows desktop.
 	AuthorizeFn func(login string) error
 
-	// TODO(zmb3): replace these callbacks with a tdp.Conn
-
-	// InputMessage is called to receive a message from the client for the RDP
-	// server. This function should block until there is a message.
-	InputMessage func() (tdp.Message, error)
-	// OutputMessage is called to send a message from RDP server to the client.
-	OutputMessage func(tdp.Message) error
+	// TDPConn is the TDP connection.
+	TDPConn *tdp.Conn
 
 	// Log is the logger for status messages.
 	Log logrus.FieldLogger
@@ -75,11 +70,8 @@ func (c *Config) checkAndSetDefaults() error {
 		return trace.BadParameter("missing Height in rdpclient.Config")
 	}
 
-	if c.InputMessage == nil {
-		return trace.BadParameter("missing InputMessage in rdpclient.Config")
-	}
-	if c.OutputMessage == nil {
-		return trace.BadParameter("missing OutputMessage in rdpclient.Config")
+	if c.TDPConn == nil {
+		return trace.BadParameter("missing tdpConn in rdpclient.Config")
 	}
 	if c.AuthorizeFn == nil {
 		return trace.BadParameter("missing AuthorizeFn in rdpclient.Config")

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -32,6 +32,13 @@ type Config struct {
 	// UserCertGenerator generates user certificates for RDP authentication.
 	GenerateUserCert GenerateUserCertFn
 
+	// Login is the Windows login name.
+	Login string
+	// Width is the initial screen width.
+	Width string
+	// Height is the initial screen Height.
+	Height string
+
 	// AuthorizeFn is called to authorize a user connecting to a Windows desktop.
 	AuthorizeFn func(login string) error
 
@@ -58,6 +65,16 @@ func (c *Config) checkAndSetDefaults() error {
 	if c.GenerateUserCert == nil {
 		return trace.BadParameter("missing GenerateUserCert in rdpclient.Config")
 	}
+	if c.Login == "" {
+		return trace.BadParameter("missing Login in rdpclient.Config")
+	}
+	if c.Width == "" {
+		return trace.BadParameter("missing Width in rdpclient.Config")
+	}
+	if c.Height == "" {
+		return trace.BadParameter("missing Height in rdpclient.Config")
+	}
+
 	if c.InputMessage == nil {
 		return trace.BadParameter("missing InputMessage in rdpclient.Config")
 	}

--- a/lib/srv/desktop/tdp/conn.go
+++ b/lib/srv/desktop/tdp/conn.go
@@ -41,6 +41,7 @@ func NewConn(rw io.ReadWriter) *Conn {
 }
 
 // InputMessage reads the next incoming message from the connection.
+// Blocks until there is a message.
 func (c *Conn) InputMessage() (Message, error) {
 	m, err := decode(c.bufr)
 	return m, trace.Wrap(err)

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -614,9 +614,8 @@ func (s *WindowsService) handleConnection(con net.Conn) {
 		GenerateUserCert: func(ctx context.Context, username string) (certDER, keyDER []byte, err error) {
 			return s.generateCredentials(ctx, username, desktop.GetDomain())
 		},
-		Addr:          desktop.GetAddr(),
-		InputMessage:  tdpConn.InputMessage,
-		OutputMessage: tdpConn.OutputMessage,
+		Addr:    desktop.GetAddr(),
+		TDPConn: tdpConn,
 		AuthorizeFn: func(login string) error {
 			return authContext.Checker.CheckAccess(
 				desktop,

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -589,12 +589,15 @@ func (s *WindowsService) handleConnection(con net.Conn) {
 	}
 
 	// Fetch the target desktop parameters passed via SNI.
-	// "login.width.height.desktopName.SNISuffix"
+	// "login_width_height_desktopName.SNISuffix"
 	targetParams := strings.Split(strings.TrimSuffix(tlsConn.ConnectionState().ServerName, SNISuffix), "_")
 	if len(targetParams) != 4 {
 		log.Errorf("received incorrect number of target params in SNI, got %v but expected the format %v",
-			tlsConn.ConnectionState().ServerName, "login.width.height.desktopName"+SNISuffix)
+			tlsConn.ConnectionState().ServerName, "login_width_height_desktopName"+SNISuffix)
 	}
+	login := targetParams[0]
+	width := targetParams[1]
+	height := targetParams[2]
 	desktopName := targetParams[3]
 	log = log.WithField("desktop-name", desktopName)
 
@@ -622,9 +625,9 @@ func (s *WindowsService) handleConnection(con net.Conn) {
 				services.AccessMFAParams{Verified: true},
 				services.NewWindowsLoginMatcher(login))
 		},
-		Login:  targetParams[0],
-		Width:  targetParams[1],
-		Height: targetParams[2],
+		Login:  login,
+		Width:  width,
+		Height: height,
 	}
 
 	if err := s.connectRDP(ctx, log, tlsConn, desktop, authContext, rdpCfg); err != nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -411,7 +411,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*RewritingHandler, error) {
 	// Desktop access endpoints.
 	h.GET("/webapi/sites/:site/desktops", h.WithClusterAuth(h.getDesktopsHandle))
 	h.GET("/webapi/sites/:site/desktops/:desktopName", h.WithClusterAuth(h.getDesktopHandle))
-	h.GET("/webapi/sites/:site/desktops/:desktopName/connect", h.WithClusterAuth(h.handleDesktopAccessWebsocket))
+	h.GET("/webapi/sites/:site/desktops/:desktopName/connect", h.WithClusterAuth(h.handleDesktopAccessWebsocket)) // ?access_token=bearer_token&params=<urlencoded json-structure>
 
 	// if Web UI is enabled, check the assets dir:
 	var indexPage *template.Template

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -116,7 +116,7 @@ func (h *Handler) handleDesktopAccessWebsocket(
 	}
 	defer serviceCon.Close()
 	tlsConfig := ctx.clt.Config()
-	// Pass target parameters via SNI: "login.width.height.desktopName.SNISuffix".
+	// Pass target parameters via SNI: "login_width_height_desktopName.SNISuffix".
 	tlsConfig.ServerName = strings.Join([]string{
 		queryParams.Login,
 		strconv.Itoa(queryParams.Screen.W),

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -121,7 +121,7 @@ func (h *Handler) handleDesktopAccessWebsocket(
 		queryParams.Login,
 		strconv.Itoa(queryParams.Screen.W),
 		strconv.Itoa(queryParams.Screen.H),
-		desktopName}, ".") + desktop.SNISuffix
+		desktopName}, "_") + desktop.SNISuffix
 	serviceConTLS := tls.Client(serviceCon, ctx.clt.Config())
 	log.Debug("Connected to windows_desktop_service")
 


### PR DESCRIPTION
It turns out that passing the initial username/screen-size parameters in the connection string was non-trivial, because we are limited in what we can pass from the handler in the proxy to the desktop service.

I've "solved" this by adding to Andrew's wizardry of [passing information via the SNI](https://github.com/gravitational/teleport/blob/c37d5792cfb57cb2469dd7c135e5466042ef3cbc/lib/web/desktop.go#L119-L126) and then [decoding it](https://github.com/gravitational/teleport/blob/c37d5792cfb57cb2469dd7c135e5466042ef3cbc/lib/srv/desktop/windows_server.go#L591-L601) on the other side of the connection.

Also takes the opportunity to remove the `InputMessage` and `OutputMessage` callbacks and replace them with a `tdp.Conn`.

TODO: remove send username from tdp

Compatible with the branch of the same name in `webapps`.

Fixes #8688 