### PR TITLE
Add an --order-by flag to `tsh ls`, which sorts output by named label values

### DIFF
--- a/docs/pages/setup/reference/cli.mdx
+++ b/docs/pages/setup/reference/cli.mdx
@@ -364,6 +364,7 @@ $ tsh ls [<flags>] [<label>]
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
+| `--order-by` | none | | The label whose value will be used to sort nodes, if empty nodes will be ordered by hostname |
 | `-v, --verbose` | none | none | also print Node ID |
 
 #### [Global Flags](#tsh-global-flags)


### PR DESCRIPTION
_This is my first time making a PR to teleport, so please let me know if there's any steps I missed. Thank you._

Currently Teleport only sorts the output of `tsh ls` by the hostname assigned to SSH nodes. For Teleport clusters deployed in PaaS environments with many similar instances cross multiple subnet ranges (for example, distributed evenly across different availability zones on AWS or GCP), listing nodes online in the Teleport cluster by hostname can be hard to use, as default hostnames for these PaaS environments are IP-based, and different types of instances running in the same subnet / availability zone become interlaced in `tsh ls`.

This PR adds a client-side optional flag in `tsh` to list nodes in the alphabetical order of value for a named label, if specified. This does not change the default behaviour of sorting nodes only by the alphabetical order of hostnames. When specified, hostnames are also used as a secondary index, so that we have a stable order for nodes with the same label value.

With option:

```
❯ ./build/tsh ls --order-by=role
Node Name     Address            Labels                
------------- ------------------ --------------------- 
10.xxx.66.13x 10.xxx.66.13x:3022 role=alpha        
10.xxx.29.21x 10.xxx.29.21x:3022 role=kilo-echo
10.xxx.24.15x 10.xxx.24.15x:3022 role=kilo     
10.xxx.24.17x 10.xxx.24.17x:3022 role=kilo     
```

Without:

```
❯ ./build/tsh ls
Node Name     Address            Labels                
------------- ------------------ --------------------- 
10.xxx.24.15x 10.xxx.24.15x:3022 role=kilo      
10.xxx.24.17x 10.xxx.24.17x:3022 role=kilo       
10.xxx.29.21x 10.xxx.29.21x:3022 role=kilo-echo 
10.xxx.66.13x 10.xxx.66.13x:3022 role=alpha  
```