### PR TITLE
Fix confusing port example in standalone docs

### DIFF
--- a/docs/pages/kubernetes-access/guides/standalone-teleport.mdx
+++ b/docs/pages/kubernetes-access/guides/standalone-teleport.mdx
@@ -34,7 +34,7 @@ proxy_service:
 
   kube_listen_addr: 0.0.0.0:3026
   # optional: set a different public address for kubernetes access
-  kube_public_addr: kube.example.com:3027
+  kube_public_addr: kube.example.com:3026
 
 kubernetes_service:
   enabled: yes


### PR DESCRIPTION
External listeners should always be on port 3026, not 3027. This `kube_public_addr` doesn't conform and is causing confusion.

Backports required:
- `branch/v7`
- `branch/v8`