### PR TITLE
Do Not Count PR Review Comments As Reviews

### DIFF
--- a/.github/workflows/ci/pkg/bot/bot.go
+++ b/.github/workflows/ci/pkg/bot/bot.go
@@ -45,6 +45,7 @@ type reviewLister interface {
 // Bot assigns reviewers and checks assigned reviewers for a pull request
 type Bot struct {
 	Config
+	GithubClient GithubClient
 }
 
 // GithubClient is a wrapper around the Github client
@@ -63,6 +64,9 @@ func New(c Config) (*Bot, error) {
 	}
 	return &Bot{
 		Config: c,
+		GithubClient: GithubClient{
+			Client: c.GithubClient,
+		},
 	}, nil
 }
 

--- a/.github/workflows/ci/pkg/bot/check.go
+++ b/.github/workflows/ci/pkg/bot/check.go
@@ -173,9 +173,8 @@ func hasRequiredApprovals(mostRecentReviews map[string]review, required []string
 }
 
 func (c *Bot) getMostRecentReviews(ctx context.Context) (map[string]review, error) {
-	env := c.Environment
 	pr := c.Environment.Metadata
-	reviews, _, err := env.Client.PullRequests.ListReviews(ctx, pr.RepoOwner,
+	reviews, _, err := c.listReviews.ListReviews(ctx, pr.RepoOwner,
 		pr.RepoName,
 		pr.Number,
 		&github.ListOptions{})

--- a/.github/workflows/ci/pkg/bot/check.go
+++ b/.github/workflows/ci/pkg/bot/check.go
@@ -184,6 +184,10 @@ func (c *Bot) getMostRecentReviews(ctx context.Context) (map[string]review, erro
 	}
 	currentReviewsSlice := []review{}
 	for _, rev := range reviews {
+		// Do not count pull request review comments as reviews.
+		if rev.GetState() == ci.Commented {
+			continue
+		}
 		// Because PRs can be submitted by anyone, input here is attacker controlled
 		// and do strict validation of input.
 		err := validateReviewFields(rev)

--- a/.github/workflows/ci/pkg/bot/check_test.go
+++ b/.github/workflows/ci/pkg/bot/check_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestApproved(t *testing.T) {
-	bot := &Bot{Config{Environment: &environment.PullRequestEnvironment{}}}
+	bot := &Bot{Config: Config{Environment: &environment.PullRequestEnvironment{}}}
 	pull := &environment.Metadata{Author: "test"}
 	tests := []struct {
 		botInstance    *Bot
@@ -144,7 +144,7 @@ func TestGetStaleReviews(t *testing.T) {
 	}
 	env := &environment.PullRequestEnvironment{Metadata: metadata}
 
-	bot := Bot{Config{Environment: env}}
+	bot := Bot{Config: Config{Environment: env}}
 	tests := []struct {
 		mockC    mockCommitComparer
 		reviews  map[string]review
@@ -205,7 +205,7 @@ func TestGetMostRecentReviews(t *testing.T) {
 	}
 	env := &environment.PullRequestEnvironment{Metadata: metadata}
 	cfg := Config{Environment: env, listReviews: &mockReviewLister{}}
-	bot := Bot{cfg}
+	bot := Bot{Config: cfg}
 	// Test login usernames.
 	testLogin1 := "test-reviewer1"
 	testLogin2 := "test-reviewer2"

--- a/.github/workflows/ci/pkg/bot/check_test.go
+++ b/.github/workflows/ci/pkg/bot/check_test.go
@@ -206,15 +206,19 @@ func TestGetMostRecentReviews(t *testing.T) {
 	env := &environment.PullRequestEnvironment{Metadata: metadata}
 	cfg := Config{Environment: env, listReviews: &mockReviewLister{}}
 	bot := Bot{Config: cfg}
+
 	// Test login usernames.
 	testLogin1 := "test-reviewer1"
 	testLogin2 := "test-reviewer2"
+
 	// Review state types.
 	typeCommented := "COMMENTED"
 	typeApproved := "APPROVED"
+
 	// Test IDs.
 	testCommitID := "commitID"
 	testID := int64(1)
+
 	// Test times.
 	testSubmittedAtNow := time.Now()
 	testSubmittedAtMostRecent := testSubmittedAtNow.Add(10 * time.Minute)


### PR DESCRIPTION
Currently, the bot will fail if the last review from a required reviewer was a comment because it is not in an "APPROVED" state. Sometimes, reviewers just want to leave a comment to discuss something and not explicitly approve/request changes so this change completely discards pull request review comments when looking for reviews. 