### PR TITLE
Clean up temp dir after app tests

### DIFF
--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -129,6 +129,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		Streamer:    config.ServerStreamer,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { s.authServer.Close() })
 
 	if config.ServerStreamer != nil {
 		err = s.authServer.AuthServer.SetSessionRecordingConfig(s.closeContext, &types.SessionRecordingConfigV2{
@@ -397,21 +398,25 @@ func TestAuthorizeWithLocks(t *testing.T) {
 // TestGetConfigForClient verifies that only the CAs of the requested cluster are returned.
 func TestGetConfigForClient(t *testing.T) {
 	// TODO(r0mant): Implement this.
+	t.Skip("Not Implemented")
 }
 
 // TestRewriteRequest verifies that requests are rewritten to include JWT headers.
 func TestRewriteRequest(t *testing.T) {
 	// TODO(r0mant): Implement this.
+	t.Skip("Not Implemented")
 }
 
 // TestRewriteResponse verifies that responses are rewritten if rewrite rules are specified.
 func TestRewriteResponse(t *testing.T) {
 	// TODO(r0mant): Implement this.
+	t.Skip("Not Implemented")
 }
 
 // TestSessionClose makes sure sessions are closed after the given session time period.
 func TestSessionClose(t *testing.T) {
 	// TODO(r0mant): Implement this.
+	t.Skip("Not Implemented")
 }
 
 // TestAWSConsoleRedirect verifies AWS management console access.


### PR DESCRIPTION
There is an intermittent issue where test will fail due to a non-empty
test directory at the end of a test. Temp dirs created by the `testing`
package are _not required to be empty_ at cleanup time, so something has
gone awry.

After looking at the code, it seems that an some Auth server instances
created as fixtures for several tests are never explicitly closed and
cleaned up when the test finishes. This leads to a hypothesis that
something in the audit writer is writing to the temp dir _while it is in
the process of being cleaned up_.

This patch add automatic cleanup to the Auth server test fixture, which
executes before the temp directory cleanup. The intention is to stop
any writes to the temp dir at the end of the test, so that it can be
cleaned up without error.

Also marks some not-implemented tests _skipped_ rather than _passed_, to
increase visibility.