### PR TITLE
Add jitter and backoff to prevent thundering herd on auth

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -613,6 +613,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 	tconf.Kube.CheckImpersonationPermissions = nullImpersonationCheck
 
 	tconf.Keygen = testauthority.New()
+	tconf.RetryPeriod = defaults.HighResPollingPeriod
 	i.Config = tconf
 	return tconf, nil
 }

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -613,7 +613,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 	tconf.Kube.CheckImpersonationPermissions = nullImpersonationCheck
 
 	tconf.Keygen = testauthority.New()
-	tconf.RetryPeriod = defaults.HighResPollingPeriod
+	tconf.MaxRetryPeriod = defaults.HighResPollingPeriod
 	i.Config = tconf
 	return tconf, nil
 }

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -35,6 +35,7 @@ import (
 	authority "github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/services"
@@ -326,9 +327,10 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 
 	srv.LockWatcher, err = services.NewLockWatcher(ctx, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: teleport.ComponentAuth,
-			Client:    srv.AuthServer,
-			Clock:     cfg.Clock,
+			Component:   teleport.ComponentAuth,
+			Client:      srv.AuthServer,
+			Clock:       cfg.Clock,
+			RetryPeriod: defaults.HighResPollingPeriod,
 		},
 	})
 	if err != nil {

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -327,10 +327,10 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 
 	srv.LockWatcher, err = services.NewLockWatcher(ctx, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component:   teleport.ComponentAuth,
-			Client:      srv.AuthServer,
-			Clock:       cfg.Clock,
-			RetryPeriod: defaults.HighResPollingPeriod,
+			Component:      teleport.ComponentAuth,
+			Client:         srv.AuthServer,
+			Clock:          cfg.Clock,
+			MaxRetryPeriod: defaults.HighResPollingPeriod,
 		},
 	})
 	if err != nil {

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -128,7 +128,7 @@ func memoryBackend(bool) packOption {
 }
 
 // newPackWithoutCache returns a new test pack without creating cache
-func newPackWithoutCache(dir string, ssetupConfig SetupConfigFn, opts ...packOption) (*testPack, error) {
+func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	ctx := context.Background()
 	var cfg packCfg
 	for _, opt := range opts {
@@ -194,7 +194,7 @@ func newPackWithoutCache(dir string, ssetupConfig SetupConfigFn, opts ...packOpt
 // newPack returns a new test pack or fails the test on error
 func newPack(dir string, setupConfig func(c Config) Config, opts ...packOption) (*testPack, error) {
 	ctx := context.Background()
-	p, err := newPackWithoutCache(dir, setupConfig, opts...)
+	p, err := newPackWithoutCache(dir, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2194,8 +2194,8 @@ func TestCache_Backoff(t *testing.T) {
 			require.LessOrEqual(t, duration, stepMax)
 
 			// add some extra to the duration to ensure the retry occurs
-			clock.Advance(duration * 2)
-		case <-time.After(time.Second):
+			clock.Advance(duration * 3)
+		case <-time.After(time.Minute):
 			t.Fatalf("timeout waiting for event")
 		}
 
@@ -2203,7 +2203,7 @@ func TestCache_Backoff(t *testing.T) {
 		select {
 		case event := <-p.eventsC:
 			require.Equal(t, WatcherFailed, event.Type)
-		case <-time.After(time.Second):
+		case <-time.After(30 * time.Second):
 			t.Fatalf("timeout waiting for event")
 		}
 	}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -428,15 +428,19 @@ var (
 	// restart if there has been more than `MaxConnectionErrorsBeforeRestart`
 	// errors in the preceding `ConnectionErrorMeasurementPeriod`
 	MaxConnectionErrorsBeforeRestart = 5
+
+	// MaxWatcherBackoff is the maximum retry time a watcher should use in
+	// the event of connection issues
+	MaxWatcherBackoff = time.Minute
 )
 
 // Default connection limits, they can be applied separately on any of the Teleport
 // services (SSH, auth, proxy)
 const (
-	// Number of max. simultaneous connections to a service
+	// LimiterMaxConnections Number of max. simultaneous connections to a service
 	LimiterMaxConnections = 15000
 
-	// Number of max. simultaneous connected users/logins
+	// LimiterMaxConcurrentUsers Number of max. simultaneous connected users/logins
 	LimiterMaxConcurrentUsers = 250
 
 	// LimiterMaxConcurrentSignatures limits maximum number of concurrently

--- a/lib/restrictedsession/watcher.go
+++ b/lib/restrictedsession/watcher.go
@@ -39,10 +39,10 @@ func NewRestrictionsWatcher(cfg RestrictionsWatcherConfig) (*RestrictionsWatcher
 		return nil, trace.Wrap(err)
 	}
 	retry, err := utils.NewLinear(utils.LinearConfig{
-		First:  utils.HalfJitter(defaults.HighResPollingPeriod),
-		Step:   cfg.RetryPeriod / 2,
-		Max:    cfg.RetryPeriod,
-		Jitter: utils.NewSeventhJitter(),
+		First:  utils.HalfJitter(cfg.MaxRetryPeriod / 10),
+		Step:   cfg.MaxRetryPeriod / 5,
+		Max:    cfg.MaxRetryPeriod,
+		Jitter: utils.NewHalfJitter(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -77,8 +77,8 @@ type RestrictionsWatcher struct {
 
 // RestrictionsWatcherConfig configures restrictions watcher
 type RestrictionsWatcherConfig struct {
-	// RetryPeriod is a retry period on failed watchers
-	RetryPeriod time.Duration
+	// MaxRetryPeriod is the maximum retry period on failed watchers
+	MaxRetryPeriod time.Duration
 	// ReloadPeriod is a failed period on failed watches
 	ReloadPeriod time.Duration
 	// Client is used by changeset to monitor restrictions updates
@@ -99,8 +99,8 @@ func (cfg *RestrictionsWatcherConfig) CheckAndSetDefaults() error {
 	if cfg.RestrictionsC == nil {
 		return trace.BadParameter("missing parameter RestrictionsC")
 	}
-	if cfg.RetryPeriod == 0 {
-		cfg.RetryPeriod = time.Minute
+	if cfg.MaxRetryPeriod == 0 {
+		cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
 	}
 	if cfg.ReloadPeriod == 0 {
 		cfg.ReloadPeriod = defaults.LowResPollingPeriod

--- a/lib/restrictedsession/watcher.go
+++ b/lib/restrictedsession/watcher.go
@@ -40,10 +40,9 @@ func NewRestrictionsWatcher(cfg RestrictionsWatcherConfig) (*RestrictionsWatcher
 	}
 	retry, err := utils.NewLinear(utils.LinearConfig{
 		First:  utils.HalfJitter(defaults.HighResPollingPeriod),
-		Step:   cs.Config.RetryPeriod / 2,
-		Max:    cs.Config.RetryPeriod,
+		Step:   cfg.RetryPeriod / 2,
+		Max:    cfg.RetryPeriod,
 		Jitter: utils.NewSeventhJitter(),
-		Clock:  cs.Clock,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -76,6 +76,8 @@ type RemoteClusterTunnelManagerConfig struct {
 	KubeDialAddr utils.NetAddr
 	// FIPS indicates if Teleport was started in FIPS mode.
 	FIPS bool
+	// Log is the logger
+	Log logrus.FieldLogger
 }
 
 func (c *RemoteClusterTunnelManagerConfig) CheckAndSetDefaults() error {
@@ -138,7 +140,7 @@ func (w *RemoteClusterTunnelManager) Run(ctx context.Context) {
 	w.mu.Unlock()
 
 	if err := w.Sync(ctx); err != nil {
-		logrus.Warningf("Failed to sync reverse tunnels: %v.", err)
+		w.cfg.Log.Warningf("Failed to sync reverse tunnels: %v.", err)
 	}
 
 	ticker := time.NewTicker(defaults.ResyncInterval)
@@ -147,11 +149,11 @@ func (w *RemoteClusterTunnelManager) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			logrus.Debugf("Closing.")
+			w.cfg.Log.Debugf("Closing.")
 			return
 		case <-ticker.C:
 			if err := w.Sync(ctx); err != nil {
-				logrus.Warningf("Failed to sync reverse tunnels: %v.", err)
+				w.cfg.Log.Warningf("Failed to sync reverse tunnels: %v.", err)
 				continue
 			}
 		}

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -99,6 +99,9 @@ func (c *RemoteClusterTunnelManagerConfig) CheckAndSetDefaults() error {
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()
 	}
+	if c.Log == nil {
+		c.Log = logrus.New()
+	}
 
 	return nil
 }

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -248,8 +248,8 @@ type Config struct {
 	// measured by the rotation state service.
 	RestartThreshold Rate
 
-	// RetryPeriod is a period between reconnection attempts to auth
-	RetryPeriod time.Duration
+	// MaxRetryPeriod is the maximum period between reconnection attempts to auth
+	MaxRetryPeriod time.Duration
 }
 
 // ApplyToken assigns a given token to all internal services but only if token
@@ -1056,7 +1056,7 @@ func ApplyDefaults(cfg *Config) {
 		Amount: defaults.MaxConnectionErrorsBeforeRestart,
 		Time:   defaults.ConnectionErrorMeasurementPeriod,
 	}
-	cfg.RetryPeriod = defaults.HighResPollingPeriod * 2
+	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
 }
 
 // ApplyFIPSDefaults updates default configuration to be FedRAMP/FIPS 140-2

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -247,6 +247,9 @@ type Config struct {
 	// unit time that the node can sustain before restarting itself, as
 	// measured by the rotation state service.
 	RestartThreshold Rate
+
+	// RetryPeriod is a period between reconnection attempts to auth
+	RetryPeriod time.Duration
 }
 
 // ApplyToken assigns a given token to all internal services but only if token
@@ -1053,6 +1056,7 @@ func ApplyDefaults(cfg *Config) {
 		Amount: defaults.MaxConnectionErrorsBeforeRestart,
 		Time:   defaults.ConnectionErrorMeasurementPeriod,
 	}
+	cfg.RetryPeriod = defaults.HighResPollingPeriod * 2
 }
 
 // ApplyFIPSDefaults updates default configuration to be FedRAMP/FIPS 140-2

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -19,7 +19,6 @@ package service
 import (
 	"crypto/tls"
 	"path/filepath"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 
@@ -46,11 +45,11 @@ import (
 // service until succeeds or process gets shut down
 func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*Connector, error) {
 	retry, err := utils.NewLinear(utils.LinearConfig{
-		First:  utils.HalfJitter(defaults.HighResPollingPeriod),
-		Step:   process.Config.RetryPeriod,
-		Max:    3 * time.Minute,
+		First:  utils.HalfJitter(process.Config.MaxRetryPeriod / 10),
+		Step:   process.Config.MaxRetryPeriod / 5,
+		Max:    process.Config.MaxRetryPeriod,
 		Clock:  process.Clock,
-		Jitter: utils.NewSeventhJitter(),
+		Jitter: utils.NewHalfJitter(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3024,6 +3024,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		return trace.Wrap(err)
 	}
 
+	rcWatchLog := logrus.WithFields(logrus.Fields{
+		trace.Component: teleport.Component(teleport.ComponentReverseTunnelAgent, process.id),
+	})
+
 	// Create and register reverse tunnel AgentPool.
 	rcWatcher, err := reversetunnel.NewRemoteClusterTunnelManager(reversetunnel.RemoteClusterTunnelManagerConfig{
 		HostUUID:            conn.ServerIdentity.ID.HostUUID,
@@ -3034,16 +3038,14 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		KubeDialAddr:        utils.DialAddrFromListenAddr(kubeDialAddr(cfg.Proxy, clusterNetworkConfig.GetProxyListenerMode())),
 		ReverseTunnelServer: tsrv,
 		FIPS:                process.Config.FIPS,
+		Log:                 rcWatchLog,
 	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	process.RegisterCriticalFunc("proxy.reversetunnel.watcher", func() error {
-		log := logrus.WithFields(logrus.Fields{
-			trace.Component: teleport.Component(teleport.ComponentReverseTunnelAgent, process.id),
-		})
-		log.Infof("Starting reverse tunnel agent pool.")
+		rcWatchLog.Infof("Starting reverse tunnel agent pool.")
 		done := make(chan struct{})
 		go func() {
 			defer close(done)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -531,4 +532,47 @@ func TestSetupProxyTLSConfig(t *testing.T) {
 			require.Equal(t, tc.wantNextProtos, tls.NextProtos)
 		})
 	}
+}
+
+func TestTeleportProcess_reconnectToAuth(t *testing.T) {
+	t.Parallel()
+	clock := clockwork.NewFakeClock()
+	// Create and configure a default Teleport configuration.
+	cfg := MakeDefaultConfig()
+	cfg.AuthServers = []utils.NetAddr{{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}}
+	cfg.Clock = clock
+	cfg.DataDir = t.TempDir()
+	cfg.Auth.Enabled = false
+	cfg.Proxy.Enabled = false
+	cfg.SSH.Enabled = true
+	process, err := NewTeleport(cfg)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c, err := process.reconnectToAuthService(types.RoleAdmin)
+		require.Equal(t, ErrTeleportExited, err)
+		require.Nil(t, c)
+	}()
+
+	retries := make([]time.Duration, 5)
+	for i := 0; i < 5; i++ {
+		// wait for connection to fail
+		select {
+		case duration := <-process.connectFailureC:
+			retries[i] = duration
+			// add some extra to the duration to ensure the retry occurs
+			clock.Advance(duration * 2)
+		case <-time.After(30 * time.Second):
+			t.Fatalf("timeout waiting for failure")
+		}
+	}
+
+	require.IsIncreasing(t, retries)
+	supervisor, ok := process.Supervisor.(*LocalSupervisor)
+	require.True(t, ok)
+	supervisor.signalExit()
+	wg.Wait()
 }

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -568,8 +568,8 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 			require.GreaterOrEqual(t, duration, stepMin)
 			require.LessOrEqual(t, duration, stepMax)
 			// add some extra to the duration to ensure the retry occurs
-			clock.Advance(duration * 2)
-		case <-time.After(30 * time.Second):
+			clock.Advance(duration * 3)
+		case <-time.After(time.Minute):
 			t.Fatalf("timeout waiting for failure")
 		}
 	}

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -62,30 +62,32 @@ func TestResourceWatcher_Backoff(t *testing.T) {
 
 	w, err := services.NewProxyWatcher(ctx, services.ProxyWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component:   "test",
-			Clock:       clock,
-			RetryPeriod: time.Minute,
-			Client:      &errorWatcher{},
+			Component:      "test",
+			Clock:          clock,
+			MaxRetryPeriod: defaults.MaxWatcherBackoff,
+			Client:         &errorWatcher{},
 		},
 		ProxyGetter: &nopProxyGetter{},
 	})
 	require.NoError(t, err)
 	t.Cleanup(w.Close)
 
-	retries := make([]time.Duration, 5)
+	step := w.MaxRetryPeriod / 5.0
 	for i := 0; i < 5; i++ {
 		// wait for watcher to reload
 		select {
 		case duration := <-w.ResetC:
-			retries[i] = duration
+			stepMin := step * time.Duration(i) / 2
+			stepMax := step * time.Duration(i+1)
+
+			require.GreaterOrEqual(t, duration, stepMin)
+			require.LessOrEqual(t, duration, stepMax)
 			// add some extra to the duration to ensure the retry occurs
 			clock.Advance(duration * 2)
 		case <-time.After(15 * time.Second):
 			t.Fatalf("timeout waiting for reset")
 		}
 	}
-
-	require.IsIncreasing(t, retries)
 }
 
 func TestProxyWatcher(t *testing.T) {
@@ -106,8 +108,8 @@ func TestProxyWatcher(t *testing.T) {
 	presence := local.NewPresenceService(bk)
 	w, err := services.NewProxyWatcher(ctx, services.ProxyWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component:   "test",
-			RetryPeriod: 200 * time.Millisecond,
+			Component:      "test",
+			MaxRetryPeriod: 200 * time.Millisecond,
 			Client: &client{
 				Presence: presence,
 				Events:   local.NewEventsService(bk),
@@ -199,8 +201,8 @@ func TestLockWatcher(t *testing.T) {
 	access := local.NewAccessService(bk)
 	w, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component:   "test",
-			RetryPeriod: 200 * time.Millisecond,
+			Component:      "test",
+			MaxRetryPeriod: 200 * time.Millisecond,
 			Client: &client{
 				Access: access,
 				Events: local.NewEventsService(bk),
@@ -304,8 +306,8 @@ func TestLockWatcherSubscribeWithEmptyTarget(t *testing.T) {
 	access := local.NewAccessService(bk)
 	w, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component:   "test",
-			RetryPeriod: 200 * time.Millisecond,
+			Component:      "test",
+			MaxRetryPeriod: 200 * time.Millisecond,
 			Client: &client{
 				Access: access,
 				Events: local.NewEventsService(bk),
@@ -382,8 +384,8 @@ func TestLockWatcherStale(t *testing.T) {
 	events := &withUnreliability{Events: local.NewEventsService(bk)}
 	w, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component:   "test",
-			RetryPeriod: 200 * time.Millisecond,
+			Component:      "test",
+			MaxRetryPeriod: 200 * time.Millisecond,
 			Client: &client{
 				Access: access,
 				Events: events,
@@ -525,8 +527,8 @@ func TestDatabaseWatcher(t *testing.T) {
 	databasesService := local.NewDatabasesService(bk)
 	w, err := services.NewDatabaseWatcher(ctx, services.DatabaseWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component:   "test",
-			RetryPeriod: 200 * time.Millisecond,
+			Component:      "test",
+			MaxRetryPeriod: 200 * time.Millisecond,
 			Client: &client{
 				Databases: databasesService,
 				Events:    local.NewEventsService(bk),
@@ -622,8 +624,8 @@ func TestAppWatcher(t *testing.T) {
 	appService := local.NewAppService(bk)
 	w, err := services.NewAppWatcher(ctx, services.AppWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component:   "test",
-			RetryPeriod: 200 * time.Millisecond,
+			Component:      "test",
+			MaxRetryPeriod: 200 * time.Millisecond,
 			Client: &client{
 				Apps:   appService,
 				Events: local.NewEventsService(bk),

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -80,7 +80,7 @@ func TestResourceWatcher_Backoff(t *testing.T) {
 			retries[i] = duration
 			// add some extra to the duration to ensure the retry occurs
 			clock.Advance(duration * 2)
-		case <-time.After(time.Second):
+		case <-time.After(15 * time.Second):
 			t.Fatalf("timeout waiting for reset")
 		}
 	}

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -83,8 +83,8 @@ func TestResourceWatcher_Backoff(t *testing.T) {
 			require.GreaterOrEqual(t, duration, stepMin)
 			require.LessOrEqual(t, duration, stepMax)
 			// add some extra to the duration to ensure the retry occurs
-			clock.Advance(duration * 2)
-		case <-time.After(15 * time.Second):
+			clock.Advance(duration * 3)
+		case <-time.After(time.Minute):
 			t.Fatalf("timeout waiting for reset")
 		}
 	}

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -440,7 +440,7 @@ func (h *Heartbeat) announce() error {
 			if !ok {
 				return trace.BadParameter("expected services.Server, got %#v", h.current)
 			}
-			err := h.Announcer.UpsertKubeService(context.TODO(), kube)
+			err := h.Announcer.UpsertKubeService(h.cancelCtx, kube)
 			if err != nil {
 				h.nextAnnounce = h.Clock.Now().UTC().Add(h.KeepAlivePeriod)
 				h.setState(HeartbeatStateAnnounceWait)

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -112,7 +112,7 @@ func TestMonitorStaleLocks(t *testing.T) {
 
 	select {
 	case <-asrv.LockWatcher.LoopC:
-	case <-time.After(2 * time.Second):
+	case <-time.After(15 * time.Second):
 		t.Fatal("Timeout waiting for LockWatcher loop check.")
 	}
 	select {
@@ -131,12 +131,12 @@ func TestMonitorStaleLocks(t *testing.T) {
 	// wait for reset
 	select {
 	case <-asrv.LockWatcher.ResetC:
-	case <-time.After(2 * time.Second):
+	case <-time.After(15 * time.Second):
 		t.Fatal("Timeout waiting for LockWatcher reset.")
 	}
 	select {
 	case <-conn.closedC:
-	case <-time.After(2 * time.Second):
+	case <-time.After(15 * time.Second):
 		t.Fatal("Timeout waiting for connection close.")
 	}
 	require.Equal(t, services.StrictLockingModeAccessDenied.Error(), emitter.LastEvent().(*apievents.ClientDisconnect).Reason)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1029,6 +1029,7 @@ func TestProxyReverseTunnel(t *testing.T) {
 		AccessPoint:         proxyClient,
 		ReverseTunnelServer: reverseTunnelServer,
 		LocalCluster:        f.testSrv.ClusterName(),
+		Log:                 logger,
 	})
 	require.NoError(t, err)
 

--- a/lib/utils/retry_test.go
+++ b/lib/utils/retry_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (


### PR DESCRIPTION
Move cache and resourceWatcher watchers from a 10s retry to a jittered backoff retry up to ~2min. Replace the
reconnectToAuthService interval with a retry to add jitter and backoff there as well for when a node restarts due to
changes introduced in #8102.

Fixes #6889.