### PR TITLE
Adds "edited" as a bot event

### DIFF
--- a/.github/workflows/ci/constants.go
+++ b/.github/workflows/ci/constants.go
@@ -82,7 +82,7 @@ const (
 	// Created is an event type that is triggered when a pull request review is created.
 	Created = "created"
 
-	// Edit events are emitted when a PR Title or Description is edited
+	// Edit events are emitted when a PR Title or Description is edited.
 	Edited = "edited"
 
 	// AnyAuthor is the symbol used to get reviewers for external contributors/contributors who

--- a/.github/workflows/ci/constants.go
+++ b/.github/workflows/ci/constants.go
@@ -82,7 +82,10 @@ const (
 	// Created is an event type that is triggered when a pull request review is created.
 	Created = "created"
 
-	// AnyAuthor is the symbol used to get reviewers for external contributors/contrtibutors who
+	// Edit events are emitted when a PR Title or Description is edited
+	Edited = "edited"
+
+	// AnyAuthor is the symbol used to get reviewers for external contributors/contributors who
 	// do not have designated reviewers.
 	AnyAuthor = "*"
 )

--- a/.github/workflows/ci/pkg/environment/environment.go
+++ b/.github/workflows/ci/pkg/environment/environment.go
@@ -247,7 +247,7 @@ func getMetadata(body []byte, action string) (*Metadata, error) {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-	case ci.Assigned, ci.Opened, ci.Reopened, ci.Ready:
+	case ci.Assigned, ci.Opened, ci.Reopened, ci.Ready, ci.Edited:
 		var pull PullRequestEvent
 		err := json.Unmarshal(body, &pull)
 		if err != nil {

--- a/.github/workflows/ci/pkg/environment/environment.go
+++ b/.github/workflows/ci/pkg/environment/environment.go
@@ -118,6 +118,7 @@ func New(c Config) (*PullRequestEnvironment, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	// Check if the pull request has changes to the `docs/` directory as that will affect who
 	// the required reviewers are.
 	docChanges, codeChanges, err := hasChanges(c.Context, pr, c.Client)
@@ -230,6 +231,9 @@ func GetMetadata(path string) (*Metadata, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	log.Infof("Handling action: %q", actionType.Action)
+
 	return getMetadata(body, actionType.Action)
 }
 


### PR DESCRIPTION
The review bot was not handling an "edited" event, and implicitly failing the check.