### PR TITLE
Use t.Setenv in tests

### DIFF
--- a/.github/workflows/ci/pkg/environment/environment_test.go
+++ b/.github/workflows/ci/pkg/environment/environment_test.go
@@ -192,7 +192,7 @@ func TestCheckAndSetDefaults(t *testing.T) {
 
 	client := github.NewClient(nil)
 	ctx := context.Background()
-	os.Setenv(ci.GithubEventPath, "path/to/event.json")
+	t.Setenv(ci.GithubEventPath, "path/to/event.json")
 	tests := []struct {
 		cfg      Config
 		desc     string

--- a/api/client/webclient/webclient_test.go
+++ b/api/client/webclient/webclient_test.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -104,14 +103,10 @@ func TestPlainHttpFallback(t *testing.T) {
 }
 
 func TestGetTunnelAddr(t *testing.T) {
-	ctx := context.Background()
-	t.Run("should use TELEPORT_TUNNEL_PUBLIC_ADDR", func(t *testing.T) {
-		os.Setenv(defaults.TunnelPublicAddrEnvar, "tunnel.example.com:4024")
-		t.Cleanup(func() { os.Unsetenv(defaults.TunnelPublicAddrEnvar) })
-		tunnelAddr, err := GetTunnelAddr(ctx, "", true, nil)
-		require.NoError(t, err)
-		require.Equal(t, "tunnel.example.com:4024", tunnelAddr)
-	})
+	t.Setenv(defaults.TunnelPublicAddrEnvar, "tunnel.example.com:4024")
+	tunnelAddr, err := GetTunnelAddr(context.Background(), "", true, nil)
+	require.NoError(t, err)
+	require.Equal(t, "tunnel.example.com:4024", tunnelAddr)
 }
 
 func TestTunnelAddr(t *testing.T) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -858,8 +858,7 @@ func testCustomReverseTunnel(t *testing.T, suite *integrationTestSuite) {
 	nodeConf.Auth.Enabled = false
 	nodeConf.Proxy.Enabled = false
 	nodeConf.SSH.Enabled = true
-	os.Setenv(apidefaults.TunnelPublicAddrEnvar, main.GetWebAddr())
-	t.Cleanup(func() { os.Unsetenv(apidefaults.TunnelPublicAddrEnvar) })
+	t.Setenv(apidefaults.TunnelPublicAddrEnvar, main.GetWebAddr())
 
 	// verify the node is able to join the cluster
 	_, err = main.StartReverseTunnelNode(nodeConf)
@@ -1401,7 +1400,7 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 
 	// clear out any proxy environment variables
 	for _, v := range []string{"http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"} {
-		os.Setenv(v, "")
+		t.Setenv(v, "")
 	}
 
 	username := suite.me.Username
@@ -1568,8 +1567,7 @@ func testTwoClustersProxy(t *testing.T, suite *integrationTestSuite) {
 	// set the http_proxy environment variable
 	u, err := url.Parse(ts.URL)
 	require.NoError(t, err)
-	os.Setenv("http_proxy", u.Host)
-	defer os.Setenv("http_proxy", "")
+	t.Setenv("http_proxy", u.Host)
 
 	username := suite.me.Username
 

--- a/integration/proxy_test.go
+++ b/integration/proxy_test.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -213,8 +212,7 @@ func TestALPNSNIHTTPSProxy(t *testing.T) {
 	// set the http_proxy environment variable
 	u, err := url.Parse(ts.URL)
 	require.NoError(t, err)
-	os.Setenv("http_proxy", u.Host)
-	defer os.Setenv("http_proxy", "")
+	t.Setenv("http_proxy", u.Host)
 
 	username := mustGetCurrentUser(t).Username
 

--- a/lib/auth/keystore/testhelpers.go
+++ b/lib/auth/keystore/testhelpers.go
@@ -74,7 +74,7 @@ func SetupSoftHSMTest(t *testing.T) Config {
 		require.NoError(t, configFile.Close())
 
 		// set env
-		os.Setenv("SOFTHSM2_CONF", configFile.Name())
+		t.Setenv("SOFTHSM2_CONF", configFile.Name())
 	}
 
 	// create test token (max length is 32 chars)

--- a/lib/client/keyagent_test.go
+++ b/lib/client/keyagent_test.go
@@ -18,13 +18,11 @@ package client
 
 import (
 	"bytes"
-	"fmt"
-	"io/ioutil"
-	"math/rand"
+	"io"
 	"net"
-	"os"
 	"path/filepath"
 	"sync"
+	"testing"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -40,11 +38,11 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/trace"
 
 	"github.com/jonboulle/clockwork"
-	"gopkg.in/check.v1"
 )
 
 type KeyAgentTestSuite struct {
@@ -54,43 +52,31 @@ type KeyAgentTestSuite struct {
 	hostname    string
 	clusterName string
 	tlsca       *tlsca.CertAuthority
-	close       func()
 }
 
-var _ = check.Suite(&KeyAgentTestSuite{})
+func makeSuite(t *testing.T) *KeyAgentTestSuite {
+	t.Helper()
 
-func (s *KeyAgentTestSuite) SetUpSuite(c *check.C) {
-	var err error
-	// path to temporary  ~/.tsh directory to use during tests
-	s.keyDir, err = ioutil.TempDir("", "keyagent-test-")
-	c.Assert(err, check.IsNil)
+	err := startDebugAgent(t)
+	require.NoError(t, err)
 
-	// temporary names to use during tests
-	s.username = "foo"
-	s.hostname = "bar"
-	s.clusterName = "some-cluster"
+	s := &KeyAgentTestSuite{
+		keyDir:      t.TempDir(),
+		username:    "foo",
+		hostname:    "bar",
+		clusterName: "some-cluster",
+	}
 
 	pemBytes, ok := fixtures.PEMBytes["rsa"]
-	c.Assert(ok, check.Equals, true)
+	require.True(t, ok)
 
 	s.tlsca, _, err = newSelfSignedCA(pemBytes)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
-	// temporary key to use during tests
 	s.key, err = s.makeKey(s.username, []string{s.username}, 1*time.Minute)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
-	// start a debug agent that will be used in tests
-	s.close, err = startDebugAgent()
-	c.Assert(err, check.IsNil)
-}
-
-func (s *KeyAgentTestSuite) TearDownSuite(c *check.C) {
-	err := os.RemoveAll(s.keyDir)
-	c.Assert(err, check.IsNil)
-	if s.close != nil {
-		s.close()
-	}
+	return s
 }
 
 // TestAddKey ensures correct adding of ssh keys. This test checks the following:
@@ -101,10 +87,12 @@ func (s *KeyAgentTestSuite) TearDownSuite(c *check.C) {
 //     the both the teleport ssh agent and the system ssh agent.
 //   * When we add a key, it's tagged with a comment that indicates that it's
 //     a teleport key with the teleport username.
-func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
+func TestAddKey(t *testing.T) {
+	s := makeSuite(t)
+
 	// make a new local agent
 	keystore, err := NewFSLocalKeyStore(s.keyDir)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	lka, err := NewLocalAgent(
 		LocalAgentConfig{
 			Keystore:   keystore,
@@ -112,12 +100,12 @@ func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
 			Username:   s.username,
 			KeysOption: AddKeysToAgentAuto,
 		})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// add the key to the local agent, this should write the key
 	// to disk as well as load it in the agent
 	_, err = lka.AddKey(s.key)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// check that the key has been written to disk
 	expectedFiles := []string{
@@ -127,23 +115,22 @@ func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
 		keypaths.SSHCertPath(s.keyDir, s.hostname, s.username, s.key.ClusterName), // SSH certificate
 	}
 	for _, file := range expectedFiles {
-		_, err := os.Stat(file)
-		c.Assert(err, check.IsNil)
+		require.FileExists(t, file)
 	}
 
 	// get all agent keys from teleport agent and system agent
 	teleportAgentKeys, err := lka.Agent.List()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	systemAgentKeys, err := lka.sshAgent.List()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// check that we've loaded a cert as well as a private key into the teleport agent
 	// and it's for the user we expected to add a certificate for
-	c.Assert(teleportAgentKeys, check.HasLen, 2)
-	c.Assert(teleportAgentKeys[0].Type(), check.Equals, "ssh-rsa-cert-v01@openssh.com")
-	c.Assert(teleportAgentKeys[0].Comment, check.Equals, "teleport:"+s.username)
-	c.Assert(teleportAgentKeys[1].Type(), check.Equals, "ssh-rsa")
-	c.Assert(teleportAgentKeys[1].Comment, check.Equals, "teleport:"+s.username)
+	require.Len(t, teleportAgentKeys, 2)
+	require.Equal(t, "ssh-rsa-cert-v01@openssh.com", teleportAgentKeys[0].Type())
+	require.Equal(t, "teleport:"+s.username, teleportAgentKeys[0].Comment)
+	require.Equal(t, "ssh-rsa", teleportAgentKeys[1].Type())
+	require.Equal(t, "teleport:"+s.username, teleportAgentKeys[1].Comment)
 
 	// check that we've loaded a cert as well as a private key into the system again
 	found := false
@@ -152,18 +139,18 @@ func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
 			found = true
 		}
 	}
-	c.Assert(true, check.Equals, found)
+	require.True(t, found)
 	found = false
 	for _, sak := range systemAgentKeys {
 		if sak.Comment == "teleport:"+s.username && sak.Type() == "ssh-rsa-cert-v01@openssh.com" {
 			found = true
 		}
 	}
-	c.Assert(true, check.Equals, found)
+	require.True(t, found)
 
 	// unload all keys for this user from the teleport agent and system agent
 	err = lka.UnloadKey()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 }
 
 // TestLoadKey ensures correct loading of a key into an agent. This test
@@ -172,103 +159,107 @@ func (s *KeyAgentTestSuite) TestAddKey(c *check.C) {
 //   * The key is correctly loaded into the agent. This is tested by having
 //     the agent sign data that is then verified using the public key
 //     directly.
-func (s *KeyAgentTestSuite) TestLoadKey(c *check.C) {
+func TestLoadKey(t *testing.T) {
+	s := makeSuite(t)
+
 	userdata := []byte("hello, world")
 
 	// make a new local agent
 	keystore, err := NewFSLocalKeyStore(s.keyDir)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	lka, err := NewLocalAgent(LocalAgentConfig{
 		Keystore:   keystore,
 		ProxyHost:  s.hostname,
 		Username:   s.username,
 		KeysOption: AddKeysToAgentAuto,
 	})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// unload any keys that might be in the agent for this user
 	err = lka.UnloadKey()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// get all the keys in the teleport and system agent
 	teleportAgentKeys, err := lka.Agent.List()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	teleportAgentInitialKeyCount := len(teleportAgentKeys)
 	systemAgentKeys, err := lka.sshAgent.List()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	systemAgentInitialKeyCount := len(systemAgentKeys)
 
 	// load the key to the twice, this should only
 	// result in one key for this user in the agent
 	_, err = lka.LoadKey(*s.key)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	_, err = lka.LoadKey(*s.key)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// get all the keys in the teleport and system agent
 	teleportAgentKeys, err = lka.Agent.List()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	systemAgentKeys, err = lka.sshAgent.List()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// check if we have the correct counts
-	c.Assert(teleportAgentKeys, check.HasLen, teleportAgentInitialKeyCount+2)
-	c.Assert(systemAgentKeys, check.HasLen, systemAgentInitialKeyCount+2)
+	require.Len(t, teleportAgentKeys, teleportAgentInitialKeyCount+2)
+	require.Len(t, systemAgentKeys, systemAgentInitialKeyCount+2)
 
 	// now sign data using the teleport agent and system agent
 	teleportAgentSignature, err := lka.Agent.Sign(teleportAgentKeys[0], userdata)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	systemAgentSignature, err := lka.sshAgent.Sign(systemAgentKeys[0], userdata)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// parse the pem bytes for the private key, create a signer, and extract the public key
 	sshPrivateKey, err := ssh.ParseRawPrivateKey(s.key.Priv)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	sshSigner, err := ssh.NewSignerFromKey(sshPrivateKey)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	sshPublicKey := sshSigner.PublicKey()
 
 	// verify data signed by both the teleport agent and system agent was signed correctly
 	err = sshPublicKey.Verify(userdata, teleportAgentSignature)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = sshPublicKey.Verify(userdata, systemAgentSignature)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// unload all keys from the teleport agent and system agent
 	err = lka.UnloadKey()
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 }
 
-func (s *KeyAgentTestSuite) TestHostCertVerification(c *check.C) {
+func TestHostCertVerification(t *testing.T) {
+	s := makeSuite(t)
+
 	// Make a new local agent.
 	keystore, err := NewFSLocalKeyStore(s.keyDir)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	lka, err := NewLocalAgent(LocalAgentConfig{
 		Keystore:   keystore,
 		ProxyHost:  s.hostname,
 		Username:   s.username,
 		KeysOption: AddKeysToAgentAuto,
 	})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// By default user has not refused any hosts.
-	c.Assert(lka.UserRefusedHosts(), check.Equals, false)
+	require.False(t, lka.UserRefusedHosts())
 
 	// Create a CA, generate a keypair for the CA, and add it to the known
 	// hosts cache (done by "tsh login").
 	keygen := testauthority.New()
 	caPriv, caPub, err := keygen.GenerateKeyPair("")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	caSigner, err := ssh.ParsePrivateKey(caPriv)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	caPublicKey, _, _, _, err := ssh.ParseAuthorizedKey(caPub)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	err = lka.keyStore.AddKnownHostKeys("example.com", s.hostname, []ssh.PublicKey{caPublicKey})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// Generate a host certificate for node with role "node".
 	_, hostPub, err := keygen.GenerateKeyPair("")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	hostCertBytes, err := keygen.GenerateHostCert(services.HostCertParams{
 		CASigner:      caSigner,
 		CASigningAlg:  defaults.CASignatureAlgorithm,
@@ -282,55 +273,55 @@ func (s *KeyAgentTestSuite) TestHostCertVerification(c *check.C) {
 		Role:        types.RoleNode,
 		TTL:         1 * time.Hour,
 	})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	hostPublicKey, _, _, _, err := ssh.ParseAuthorizedKey(hostCertBytes)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	tests := []struct {
-		inAddr   string
-		outError bool
+		inAddr string
+		assert require.ErrorAssertionFunc
 	}{
 		// Correct DNS is valid.
 		{
-			inAddr:   "server01.example.com:3022",
-			outError: false,
+			inAddr: "server01.example.com:3022",
+			assert: require.NoError,
 		},
 		// Hostname only is valid.
 		{
-			inAddr:   "server01:3022",
-			outError: false,
+			inAddr: "server01:3022",
+			assert: require.NoError,
 		},
 		// IP is valid.
 		{
-			inAddr:   "127.0.0.1:3022",
-			outError: false,
+			inAddr: "127.0.0.1:3022",
+			assert: require.NoError,
 		},
 		// UUID is valid.
 		{
-			inAddr:   "5ff40d80-9007-4f28-8f49-7d4fda2f574d.example.com:3022",
-			outError: false,
+			inAddr: "5ff40d80-9007-4f28-8f49-7d4fda2f574d.example.com:3022",
+			assert: require.NoError,
 		},
 		// Wrong DNS name is invalid.
 		{
-			inAddr:   "server02.example.com:3022",
-			outError: true,
+			inAddr: "server02.example.com:3022",
+			assert: require.Error,
 		},
 	}
 
 	for _, tt := range tests {
-		err = lka.CheckHostSignature(tt.inAddr, nil, hostPublicKey)
-		if tt.outError {
-			c.Assert(err, check.NotNil)
-		} else {
-			c.Assert(err, check.IsNil)
-		}
+		t.Run(tt.inAddr, func(t *testing.T) {
+			err = lka.CheckHostSignature(tt.inAddr, nil, hostPublicKey)
+			tt.assert(t, err)
+		})
 	}
 }
 
-func (s *KeyAgentTestSuite) TestHostKeyVerification(c *check.C) {
+func TestHostKeyVerification(t *testing.T) {
+	s := makeSuite(t)
+
 	// make a new local agent
 	keystore, err := NewFSLocalKeyStore(s.keyDir)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	lka, err := NewLocalAgent(LocalAgentConfig{
 		Keystore:   keystore,
 		ProxyHost:  s.hostname,
@@ -338,34 +329,34 @@ func (s *KeyAgentTestSuite) TestHostKeyVerification(c *check.C) {
 		KeysOption: AddKeysToAgentAuto,
 		Insecure:   true,
 	})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// by default user has not refused any hosts:
-	c.Assert(lka.UserRefusedHosts(), check.Equals, false)
+	require.False(t, lka.UserRefusedHosts())
 
 	// make a fake host key:
 	keygen := testauthority.New()
 	_, pub, err := keygen.GenerateKeyPair("")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	pk, _, _, _, err := ssh.ParseAuthorizedKey(pub)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	// test user refusing connection:
 	fakeErr := trace.Errorf("luna cannot be trusted!")
 	lka.hostPromptFunc = func(host string, k ssh.PublicKey) error {
-		c.Assert(host, check.Equals, "luna")
-		c.Assert(k, check.Equals, pk)
+		require.Equal(t, "luna", host)
+		require.Equal(t, pk, k)
 		return fakeErr
 	}
 	var a net.TCPAddr
 	err = lka.CheckHostSignature("luna", &a, pk)
-	c.Assert(err, check.NotNil)
-	c.Assert(err.Error(), check.Equals, "luna cannot be trusted!")
-	c.Assert(lka.UserRefusedHosts(), check.Equals, true)
+	require.Error(t, err)
+	require.Equal(t, "luna cannot be trusted!", err.Error())
+	require.True(t, lka.UserRefusedHosts())
 
 	// clean user answer:
 	delete(lka.noHosts, "luna")
-	c.Assert(lka.UserRefusedHosts(), check.Equals, false)
+	require.False(t, lka.UserRefusedHosts())
 
 	// now lets simulate user being asked:
 	userWasAsked := false
@@ -374,67 +365,67 @@ func (s *KeyAgentTestSuite) TestHostKeyVerification(c *check.C) {
 		userWasAsked = true
 		return nil
 	}
-	c.Assert(lka.UserRefusedHosts(), check.Equals, false)
+	require.False(t, lka.UserRefusedHosts())
 	err = lka.CheckHostSignature("luna", &a, pk)
-	c.Assert(err, check.IsNil)
-	c.Assert(userWasAsked, check.Equals, true)
+	require.NoError(t, err)
+	require.True(t, userWasAsked)
 
 	// now lets simulate automatic host verification (no need to ask user, he
 	// just said "yes")
 	userWasAsked = false
-	c.Assert(lka.UserRefusedHosts(), check.Equals, false)
+	require.False(t, lka.UserRefusedHosts())
 	err = lka.CheckHostSignature("luna", &a, pk)
-	c.Assert(err, check.IsNil)
-	c.Assert(userWasAsked, check.Equals, false)
+	require.NoError(t, err)
+	require.False(t, userWasAsked)
 }
 
-func (s *KeyAgentTestSuite) TestDefaultHostPromptFunc(c *check.C) {
+func TestDefaultHostPromptFunc(t *testing.T) {
+	s := makeSuite(t)
+
 	keygen := testauthority.New()
 
 	keystore, err := NewFSLocalKeyStore(s.keyDir)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	a, err := NewLocalAgent(LocalAgentConfig{
 		Keystore:   keystore,
 		ProxyHost:  s.hostname,
 		Username:   s.username,
 		KeysOption: AddKeysToAgentAuto,
 	})
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	_, keyBytes, err := keygen.GenerateKeyPair("")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	key, _, _, _, err := ssh.ParseAuthorizedKey(keyBytes)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 
 	tests := []struct {
 		inAnswer []byte
-		outError bool
+		assert   require.ErrorAssertionFunc
 	}{
 		{
 			inAnswer: []byte("y\n"),
-			outError: false,
+			assert:   require.NoError,
 		},
 		{
 			inAnswer: []byte("n\n"),
-			outError: true,
+			assert:   require.Error,
 		},
 		{
 			inAnswer: []byte("foo\n"),
-			outError: true,
+			assert:   require.Error,
 		},
 	}
 
 	for _, tt := range tests {
-		// Write an answer to the "keyboard".
-		var buf bytes.Buffer
-		buf.Write(tt.inAnswer)
+		t.Run(string(bytes.TrimSpace(tt.inAnswer)), func(t *testing.T) {
+			// Write an answer to the "keyboard".
+			var buf bytes.Buffer
+			buf.Write(tt.inAnswer)
 
-		err = a.defaultHostPromptFunc("example.com", key, ioutil.Discard, &buf)
-		if tt.outError {
-			c.Assert(err, check.NotNil)
-		} else {
-			c.Assert(err, check.IsNil)
-		}
+			err = a.defaultHostPromptFunc("example.com", key, io.Discard, &buf)
+			tt.assert(t, err)
+		})
 	}
 }
 
@@ -506,18 +497,15 @@ func (s *KeyAgentTestSuite) makeKey(username string, allowedLogins []string, ttl
 	}, nil
 }
 
-func startDebugAgent() (closer func(), err error) {
-	rand.Seed(time.Now().Unix())
-	socketpath := filepath.Join(os.TempDir(),
-		fmt.Sprintf("teleport-%d-%d.socket", os.Getpid(), rand.Uint32()))
-
+func startDebugAgent(t *testing.T) error {
+	socketpath := filepath.Join(t.TempDir(), "teleport-test")
 	listener, err := net.Listen("unix", socketpath)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
 	systemAgent := agent.NewKeyring()
-	os.Setenv(teleport.SSHAuthSock, socketpath)
+	t.Setenv(teleport.SSHAuthSock, socketpath)
 
 	startedC := make(chan struct{})
 	doneC := make(chan struct{})
@@ -525,7 +513,6 @@ func startDebugAgent() (closer func(), err error) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		defer os.Setenv(teleport.SSHAuthSock, "")
 		// agent is listening and environment variable is set, unblock now
 		close(startedC)
 		for {
@@ -555,10 +542,12 @@ func startDebugAgent() (closer func(), err error) {
 		wg.Done()
 	}()
 
-	// block until agent is started
-	<-startedC
-	return func() {
+	t.Cleanup(func() {
 		close(doneC)
 		wg.Wait()
-	}, nil
+	})
+
+	// block until agent is started
+	<-startedC
+	return nil
 }

--- a/lib/utils/proxy/proxy_test.go
+++ b/lib/utils/proxy/proxy_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package proxy
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/gravitational/teleport/lib/utils"
-
-	"gopkg.in/check.v1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -30,13 +30,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestProxy(t *testing.T) { check.TestingT(t) }
-
-type ProxySuite struct{}
-
-var _ = check.Suite(&ProxySuite{})
-
-func (s *ProxySuite) TestGetProxyAddress(c *check.C) {
+func TestGetProxyAddress(t *testing.T) {
 	type env struct {
 		name string
 		val  string
@@ -98,21 +92,12 @@ func (s *ProxySuite) TestGetProxyAddress(c *check.C) {
 	}
 
 	for i, tt := range tests {
-		comment := check.Commentf("Test %v %v", i, tt.info)
-
-		unsetEnv()
-		for _, env := range tt.env {
-			os.Setenv(env.name, env.val)
-		}
-		p := getProxyAddress(tt.targetAddr)
-		unsetEnv()
-
-		c.Assert(p, check.Equals, tt.proxyAddr, comment)
-	}
-}
-
-func unsetEnv() {
-	for _, envname := range []string{"http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "no_proxy"} {
-		os.Unsetenv(envname)
+		t.Run(fmt.Sprintf("%v: %v", i, tt.info), func(t *testing.T) {
+			for _, env := range tt.env {
+				t.Setenv(env.name, env.val)
+			}
+			p := getProxyAddress(tt.targetAddr)
+			require.Equal(t, tt.proxyAddr, p)
+		})
 	}
 }

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -35,9 +34,7 @@ import (
 
 // TestProxySSHDial verifies "tsh proxy ssh" command.
 func TestProxySSHDial(t *testing.T) {
-	// Setup ssh agent.
-	sockPath := createAgent(t)
-	os.Setenv("SSH_AUTH_SOCK", sockPath)
+	createAgent(t)
 
 	os.RemoveAll(profile.FullProfilePath(""))
 	t.Cleanup(func() {
@@ -94,14 +91,15 @@ func TestProxySSHDial(t *testing.T) {
 	require.Contains(t, err.Error(), "subsystem request failed")
 }
 
-func createAgent(t *testing.T) string {
+func createAgent(t *testing.T) {
+	t.Helper()
+
 	user, err := user.Current()
 	require.NoError(t, err)
 
-	sockDir, err := ioutil.TempDir("", "int-test")
-	require.NoError(t, err)
-
+	sockDir := t.TempDir()
 	sockPath := filepath.Join(sockDir, "agent.sock")
+	t.Setenv("SSH_AUTH_SOCK", sockPath)
 
 	uid, err := strconv.Atoi(user.Uid)
 	require.NoError(t, err)
@@ -120,6 +118,4 @@ func createAgent(t *testing.T) string {
 	t.Cleanup(func() {
 		teleAgent.Close()
 	})
-
-	return sockPath
 }


### PR DESCRIPTION
This new feature in Go 1.17 automatically restores the environment
variable to its previous value when a test ends, making it simpler
to set up the environment for tests and less likely that we accidentally
leave behind global state.

Also convert some of the remaining uses of check to standard Go tests.