### PR TITLE
Create separate builds for CentOS7 (+fips)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -831,8 +831,8 @@ steps:
   - set -u
   - export PATH=/Users/build/.cargo/bin:$PATH
   - mkdir -p ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
-  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
-    | cut -d= -f2)
+  - export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
+    print-rust-version)
   - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
   - export RUST_HOME=$CARGO_HOME
   - rustup toolchain install $RUST_VERSION
@@ -841,8 +841,8 @@ steps:
 - name: Build Mac artifacts
   commands:
   - set -u
-  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
-    | cut -d= -f2)
+  - export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
+    print-rust-version)
   - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
   - export RUST_HOME=$CARGO_HOME
   - export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH
@@ -861,8 +861,8 @@ steps:
   - export PATH=/Users/build/.cargo/bin:$PATH
   - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
   - export RUST_HOME=$CARGO_HOME
-  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
-    | cut -d= -f2)
+  - export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
+    print-rust-version)
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
   - rustup override unset
   - rustup toolchain uninstall $RUST_VERSION
@@ -1363,7 +1363,220 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:221
+# Generated at dronegen/tag.go:233
+################################################
+
+kind: pipeline
+type: kubernetes
+name: build-linux-amd64-centos7
+environment:
+  RUNTIME: go1.17.2
+trigger:
+  event:
+    include:
+    - tag
+  ref:
+    include:
+    - refs/tags/v*
+  repo:
+    include:
+    - gravitational/*
+workspace:
+  path: /go
+clone:
+  disable: true
+steps:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
+    && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt;
+    else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Wait for docker
+  image: docker
+  commands:
+  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  volumes:
+  - name: dockersock
+    path: /var/run
+- name: Build artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - make -C build.assets release-amd64-centos7
+  environment:
+    ARCH: amd64
+    GID: "1000"
+    GOCACHE: /go/cache
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
+  - name: dockersock
+    path: /var/run
+- name: Copy artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
+    \;
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
+    \;
+  - export VERSION=$(cat /go/.version.txt)
+  - mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-v$${VERSION}-linux-amd64-centos7-bin.tar.gz
+  - mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos7-bin.tar.gz
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256;
+    done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts/
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
+
+---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:233
+################################################
+
+kind: pipeline
+type: kubernetes
+name: build-linux-amd64-centos7-fips
+environment:
+  RUNTIME: go1.17.2
+trigger:
+  event:
+    include:
+    - tag
+  ref:
+    include:
+    - refs/tags/v*
+  repo:
+    include:
+    - gravitational/*
+workspace:
+  path: /go
+clone:
+  disable: true
+steps:
+- name: Check out code
+  image: docker:git
+  commands:
+  - mkdir -p /go/src/github.com/gravitational/teleport
+  - cd /go/src/github.com/gravitational/teleport
+  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
+  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
+  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
+    && chmod 600 /root/.ssh/id_rsa
+  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
+  - git submodule update --init e
+  - git submodule update --init --recursive webassets || true
+  - rm -f /root/.ssh/id_rsa
+  - mkdir -p /go/cache /go/artifacts
+  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt;
+    else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
+  environment:
+    GITHUB_PRIVATE_KEY:
+      from_secret: GITHUB_PRIVATE_KEY
+- name: Wait for docker
+  image: docker
+  commands:
+  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  volumes:
+  - name: dockersock
+    path: /var/run
+- name: Build artifacts
+  image: docker
+  commands:
+  - apk add --no-cache make
+  - chown -R $UID:$GID /go
+  - cd /go/src/github.com/gravitational/teleport
+  - export VERSION=$(cat /go/.version.txt)
+  - make -C build.assets release-amd64-centos7-fips
+  environment:
+    ARCH: amd64
+    FIPS: "yes"
+    GID: "1000"
+    GOCACHE: /go/cache
+    GOPATH: /go
+    OS: linux
+    UID: "1000"
+  volumes:
+  - name: dockersock
+    path: /var/run
+- name: Copy artifacts
+  image: docker
+  commands:
+  - cd /go/src/github.com/gravitational/teleport
+  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
+    \;
+  - export VERSION=$(cat /go/.version.txt)
+  - mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos7-fips-bin.tar.gz
+  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256;
+    done && ls -l
+- name: Upload to S3
+  image: plugins/s3
+  settings:
+    access_key:
+      from_secret: AWS_ACCESS_KEY_ID
+    bucket:
+      from_secret: AWS_S3_BUCKET
+    region: us-west-2
+    secret_key:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    source: /go/artifacts/*
+    strip_prefix: /go/artifacts/
+    target: teleport/tag/${DRONE_TAG##v}
+services:
+- name: Start Docker
+  image: docker:dind
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+volumes:
+- name: dockersock
+  temp: {}
+
+---
+################################################
+# Generated using dronegen, do not edit by hand!
+# Use 'make dronegen' to update.
+# Generated at dronegen/tag.go:233
 ################################################
 
 kind: pipeline
@@ -1467,7 +1680,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:221
+# Generated at dronegen/tag.go:233
 ################################################
 
 kind: pipeline
@@ -1571,7 +1784,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:221
+# Generated at dronegen/tag.go:233
 ################################################
 
 kind: pipeline
@@ -1678,7 +1891,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -1810,7 +2023,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -1939,7 +2152,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -2057,7 +2270,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -2172,7 +2385,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:221
+# Generated at dronegen/tag.go:233
 ################################################
 
 kind: pipeline
@@ -2276,7 +2489,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -2408,7 +2621,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -2598,8 +2811,8 @@ steps:
   - set -u
   - export PATH=/Users/build/.cargo/bin:$PATH
   - mkdir -p ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
-  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
-    | cut -d= -f2)
+  - export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
+    print-rust-version)
   - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
   - export RUST_HOME=$CARGO_HOME
   - rustup toolchain install $RUST_VERSION
@@ -2608,8 +2821,8 @@ steps:
 - name: Build Mac release artifacts
   commands:
   - set -u
-  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
-    | cut -d= -f2)
+  - export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
+    print-rust-version)
   - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
   - export RUST_HOME=$CARGO_HOME
   - export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH
@@ -2652,8 +2865,8 @@ steps:
   - export PATH=/Users/build/.cargo/bin:$PATH
   - export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains
   - export RUST_HOME=$CARGO_HOME
-  - export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile
-    | cut -d= -f2)
+  - export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets
+    print-rust-version)
   - cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport
   - rustup override unset
   - rustup toolchain uninstall $RUST_VERSION
@@ -2950,7 +3163,7 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:221
+# Generated at dronegen/tag.go:233
 ################################################
 
 kind: pipeline
@@ -3054,7 +3267,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:221
+# Generated at dronegen/tag.go:233
 ################################################
 
 kind: pipeline
@@ -3158,7 +3371,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -3276,7 +3489,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -3394,7 +3607,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -3526,7 +3739,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:363
+# Generated at dronegen/tag.go:375
 ################################################
 
 kind: pipeline
@@ -3658,7 +3871,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go:221
+# Generated at dronegen/tag.go:233
 ################################################
 
 kind: pipeline
@@ -4543,6 +4756,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 28314d2ef716fd998f2d888cf53b403e3aa7139833d30481e7c28678f10975c3
+hmac: 7fee7b17d306d1d41f8aebe49dc1db2700253e682e438cbc88c5153a8caaed34
 
 ...

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -68,36 +68,6 @@ ARG GID
 RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
      mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
 
-# Install Rust
-#
-# Rust installation based on official rust image Dockerfile here:
-#   https://github.com/rust-lang/docker-rust/blob/master/1.56.0/bullseye/Dockerfile
-#
-# The original Rust docker image uses a script to install `rustup`, and from
-# there rustc and associated tools.
-#
-# Rather than execute an arbitrary `rustup` installation script, we are cherry-
-# picking the appropriate files off the official docker image and then installing
-# the extra tooling/targets we need.
-
- ENV RUSTUP_HOME=/usr/local/rustup \
-     CARGO_HOME=/usr/local/cargo \
-     PATH=/usr/local/cargo/bin:$PATH \
-     RUST_VERSION=1.56.1
-
-COPY --from=rust:1.56.1 /usr/local/rustup /usr/local/rustup
-COPY --from=rust:1.56.1 /usr/local/cargo /usr/local/cargo
-RUN set -eux \
-    rustup --version; \
-    cargo --version; \
-    rustup component add --toolchain 1.56.1-x86_64-unknown-linux-gnu rustfmt clippy; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup target add i686-unknown-linux-gnu; \
-    rustup target add arm-unknown-linux-gnueabihf; \
-    rustup target add aarch64-unknown-linux-gnu; \
-    rustup target list | grep installed; \
-    rustc --version;
-
 # Install etcd.
 RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
      cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
@@ -164,6 +134,27 @@ COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install
 
 ENV SOFTHSM2_PATH "/usr/lib/softhsm/libsofthsm2.so"
+
+# Install Rust
+ARG RUST_VERSION
+ENV RUSTUP_HOME=/usr/local/rustup \
+     CARGO_HOME=/usr/local/cargo \
+     PATH=/usr/local/cargo/bin:$PATH \
+     RUST_VERSION=$RUST_VERSION
+
+RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
+    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
+
+USER ci
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+    rustup --version && \
+    cargo --version && \
+    rustc --version && \
+    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy && \
+    rustup target add i686-unknown-linux-gnu && \
+    rustup target add arm-unknown-linux-gnueabihf && \
+    rustup target add aarch64-unknown-linux-gnu && \
+    cargo install cbindgen
 
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -1,6 +1,8 @@
 ARG RUNTIME
 FROM quay.io/gravitational/teleport-buildbox:$RUNTIME
 
+USER root
+
 RUN apt-get -y update && \
     apt-get -y install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu && \
     apt-get -y autoclean && apt-get -y clean

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -1,0 +1,60 @@
+FROM centos:7
+
+ENV LANGUAGE=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LC_CTYPE=en_US.UTF-8
+
+ARG RUNTIME
+ARG RUST_VERSION
+
+ARG UID
+ARG GID
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
+     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
+
+# Install dev tools (make, etc) and a Perl package needed to build OpenSSL.
+RUN yum groupinstall -y "Development Tools"
+RUN yum install -y pam-devel net-tools tree git zip libatomic perl-IPC-Cmd && \
+    yum clean all
+
+# Install etcd.
+RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
+     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
+
+# Install Go.
+RUN mkdir -p /opt && cd /opt && curl https://storage.googleapis.com/golang/$RUNTIME.linux-amd64.tar.gz | tar xz && \
+    mkdir -p /go/src/github.com/gravitational/teleport && \
+    chmod a+w /go && \
+    chmod a+w /var/lib && \
+    /opt/go/bin/go version
+
+# Install PAM module and policies for testing.
+COPY pam/ /opt/pam_teleport/
+RUN make -C /opt/pam_teleport install
+
+# Install Rust.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=$RUST_VERSION
+
+RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
+    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
+
+RUN chmod a-w /
+
+USER ci
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+    rustup --version && \
+    cargo --version && \
+    rustc --version && \
+    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy && \
+    cargo install cbindgen
+
+ENV GOPATH="/go" \
+    GOROOT="/opt/go" \
+    PATH="/opt/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
+
+VOLUME ["/go/src/github.com/gravitational/teleport"]
+EXPOSE 6600 2379 2380

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -1,0 +1,69 @@
+FROM centos:7
+
+ENV LANGUAGE=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LC_CTYPE=en_US.UTF-8
+
+ARG RUST_VERSION
+ARG BORINGCRYPTO_RUNTIME
+ARG GO_BOOTSTRAP_RUNTIME=go1.9.7
+
+ARG UID
+ARG GID
+RUN (groupadd ci --gid=$GID -o && useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
+     mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport)
+
+# Install dev tools (make, etc) and a Perl package needed to build OpenSSL.
+RUN yum groupinstall -y "Development Tools"
+RUN yum install -y pam-devel net-tools tree git zip libatomic perl-IPC-Cmd && \
+    yum clean all
+
+# Install etcd.
+RUN (curl -L https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz | tar -xz && \
+     cp etcd-v3.3.9-linux-amd64/etcd* /bin/)
+
+# BoringCrypto (unlike regular Go) requires glibc 2.14, so we have to build from source.
+# 1) Install older binary Go runtime for bootstrapping
+# 2) Get source for the correct Go boringcrypto runtime and compile it with Go bootstrap runtime
+# 3) Erase Go bootstrap runtime and create build directories
+# 4) Print compiled Go version
+RUN mkdir -p /go-bootstrap && cd /go-bootstrap && curl https://dl.google.com/go/${GO_BOOTSTRAP_RUNTIME}.linux-amd64.tar.gz | tar xz && \
+    mkdir -p /opt && cd /opt && curl https://go-boringcrypto.storage.googleapis.com/${BORINGCRYPTO_RUNTIME}.src.tar.gz | tar xz && \
+    cd /opt/go/src && GOROOT_BOOTSTRAP=/go-bootstrap/go ./make.bash && \
+    rm -rf /go-bootstrap && \
+    mkdir -p /go/src/github.com/gravitational/teleport && \
+    chmod a+w /go && \
+    chmod a+w /var/lib && \
+    chmod a-w / && \
+    /opt/go/bin/go version
+
+# Install PAM module and policies for testing.
+COPY pam/ /opt/pam_teleport/
+RUN make -C /opt/pam_teleport install
+
+# Install Rust.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=$RUST_VERSION
+
+RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
+    mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
+
+RUN chmod a-w /
+
+USER ci
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
+    rustup --version && \
+    cargo --version && \
+    rustc --version && \
+    rustup component add --toolchain $RUST_VERSION-x86_64-unknown-linux-gnu rustfmt clippy && \
+    cargo install cbindgen
+
+ENV GOPATH="/go" \
+    GOROOT="/opt/go" \
+    PATH="/opt/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
+
+VOLUME ["/go/src/github.com/gravitational/teleport"]
+EXPOSE 6600 2379 2380

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -17,6 +17,7 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 RUNTIME ?= go1.17.2
+RUST_VERSION ?= 1.56.1
 BORINGCRYPTO_RUNTIME=$(RUNTIME)b7
 LIBBPF_VERSION ?= 0.3.1
 
@@ -30,6 +31,8 @@ GOGO_PROTO_TAG ?= v1.3.2
 BUILDBOX=quay.io/gravitational/teleport-buildbox:$(RUNTIME)
 BUILDBOX_FIPS=quay.io/gravitational/teleport-buildbox-fips:$(RUNTIME)
 BUILDBOX_CENTOS6=quay.io/gravitational/teleport-buildbox-centos6:$(RUNTIME)
+BUILDBOX_CENTOS7=quay.io/gravitational/teleport-buildbox-centos7:$(RUNTIME)
+BUILDBOX_CENTOS7_FIPS=quay.io/gravitational/teleport-buildbox-centos7-fips:$(RUNTIME)
 BUILDBOX_ARM=quay.io/gravitational/teleport-buildbox-arm:$(RUNTIME)
 BUILDBOX_ARM_FIPS=quay.io/gravitational/teleport-buildbox-arm-fips:$(RUNTIME)
 
@@ -107,6 +110,7 @@ buildbox:
 			--build-arg UID=$(UID) \
 			--build-arg GID=$(GID) \
 			--build-arg RUNTIME=$(RUNTIME) \
+			--build-arg RUST_VERSION=$(RUST_VERSION) \
 			--build-arg PROTOC_VER=$(PROTOC_VER) \
 			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg PROTOC_PLATFORM=$(PROTOC_PLATFORM) \
@@ -146,6 +150,34 @@ buildbox-centos6:
 
 # CentOS 6 FIPS builds were removed in Teleport 7.0
 # https://github.com/gravitational/teleport/issues/7207
+
+#
+# Builds a Docker buildbox for CentOS 7 builds
+#
+.PHONY:buildbox-centos7
+buildbox-centos7:
+	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_CENTOS7) 2>&1 >/dev/null; then docker pull $(BUILDBOX_CENTOS7) || true; fi;
+	docker build \
+		--build-arg UID=$(UID) \
+		--build-arg GID=$(GID) \
+		--build-arg RUNTIME=$(RUNTIME) \
+		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--cache-from $(BUILDBOX_CENTOS7) \
+		--tag $(BUILDBOX_CENTOS7) -f Dockerfile-centos7 .
+
+#
+# Builds a Docker buildbox for CentOS 7 FIPS builds
+#
+.PHONY:buildbox-centos7-fips
+buildbox-centos7-fips:
+	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_CENTOS7_FIPS) 2>&1 >/dev/null; then docker pull $(BUILDBOX_CENTOS7_FIPS) || true; fi;
+	docker build \
+		--build-arg UID=$(UID) \
+		--build-arg GID=$(GID) \
+		--build-arg BORINGCRYPTO_RUNTIME=$(BORINGCRYPTO_RUNTIME) \
+		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--cache-from $(BUILDBOX_CENTOS7_FIPS) \
+		--tag $(BUILDBOX_CENTOS7_FIPS) -f Dockerfile-centos7-fips .
 
 #
 # Builds a Docker buildbox for ARMv7/ARM64 builds
@@ -287,6 +319,14 @@ release-arm64: buildbox-arm
 release-amd64-centos6: buildbox-centos6
 	$(MAKE) release-centos6 ARCH=amd64
 
+.PHONY: release-amd64-centos7
+release-amd64-centos7: buildbox-centos7
+	$(MAKE) release-centos7 ARCH=amd64
+
+.PHONY: release-amd64-centos7-fips
+release-amd64-centos7-fips: buildbox-centos7-fips
+	$(MAKE) release-centos7-fips ARCH=amd64 FIPS=yes
+
 #
 # Create a Teleport FIPS package using the build container.
 # This is a special case because it only builds and packages the Enterprise FIPS binaries, no OSS.
@@ -300,11 +340,29 @@ release-fips: buildbox-fips
 
 #
 # Create a Teleport package for CentOS 6 using the build container.
+# DELETE IN 9.0 (zmb3)
 #
 .PHONY:release-centos6
 release-centos6: buildbox-centos6
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS6) \
 		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) REPRODUCIBLE=no
+
+#
+# Create a Teleport package for CentOS 7 using the build container.
+#
+.PHONY:release-centos7
+release-centos7: buildbox-centos7
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
+		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) REPRODUCIBLE=no
+
+#
+# Create a Teleport FIPS package for CentOS 7 using the build container.
+# This only builds and packages enterprise FIPS binaries, no OSS.
+#
+.PHONY:release-centos7-fips
+release-centos7-fips:
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
+		/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(RUNTIME) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no
 
 #
 # Create a Windows Teleport package using the build container.
@@ -325,18 +383,33 @@ release-windows-unsigned: buildbox
 #
 # Run docs tester to detect problems.
 #
-.PHONY: docsbox
+.PHONY:docsbox
 docsbox:
 	if ! docker inspect --type=image $(DOCSBOX) 2>&1 >/dev/null; then docker pull $(DOCSBOX) || true; fi
 
-.PHONY: test-docs
-test-docs: DOCS_VERSION := $(shell grep -E ^VERSION $(MAKEFILE_ROOT_DIR)/Makefile | cut -d= -f2 | cut -d. -f1-2)
+.PHONY:test-docs
 test-docs: docsbox
-	docker run -i $(NOROOT) -v $$(pwd)/..:/src/content/$(DOCS_VERSION) $(DOCSBOX) \
+	docker run --platform=linux/amd64 -i $(NOROOT) -v $$(pwd)/..:/src/content $(DOCSBOX) \
 		/bin/sh -c "yarn markdown-lint-external-links"
 
-# build-centos6-assets builds assets needed by CentOS 6 in a container.
-.PHONY: build-centos6-assets
+#
+# Builds assets needed by CentOS 6 in a container.
+#
+.PHONY:build-centos6-assets
 build-centos6-assets:
 	docker build -t buildbox-centos6-assets -f Dockerfile-centos6-assets .
 	docker run -v $$(pwd):/centos6.assets -it buildbox-centos6-assets cp /centos6-assets.tar.gz /centos6.assets
+
+#
+# Print the Go version used to build Teleport.
+#
+.PHONY:print-go-version
+print-go-version:
+	@echo $(RUNTIME)
+
+#
+# Print the Rust version used to build Teleport.
+#
+.PHONY:print-rust-version
+print-rust-version:
+	@echo $(RUST_VERSION)

--- a/dronegen/mac.go
+++ b/dronegen/mac.go
@@ -194,7 +194,7 @@ func installRustToolchainStep(path string) step {
 			`set -u`,
 			`export PATH=/Users/build/.cargo/bin:$PATH`,
 			`mkdir -p ~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
-			`export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile | cut -d= -f2)`,
+			`export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets print-rust-version)`,
 			`export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
 			`export RUST_HOME=$CARGO_HOME`,
 			`rustup toolchain install $RUST_VERSION`,
@@ -214,7 +214,7 @@ func cleanUpToolchainsStep(path string) step {
 			`export PATH=/Users/build/.cargo/bin:$PATH`,
 			`export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
 			`export RUST_HOME=$CARGO_HOME`,
-			`export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile | cut -d= -f2)`,
+			`export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets print-rust-version)`,
 			`cd $WORKSPACE_DIR/go/src/github.com/gravitational/teleport`,
 			// clean up the rust toolchain even though we're about to delete the directory
 			// this ensures we don't leave behind a broken link
@@ -248,7 +248,7 @@ func darwinTagCheckoutCommands() []string {
 func darwinTagBuildCommands() []string {
 	return []string{
 		`set -u`,
-		`export RUST_VERSION=$(grep RUST_VERSION $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets/Dockerfile | cut -d= -f2)`,
+		`export RUST_VERSION=$(make -C $WORKSPACE_DIR/go/src/github.com/gravitational/teleport/build.assets print-rust-version)`,
 		`export CARGO_HOME=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains`,
 		`export RUST_HOME=$CARGO_HOME`,
 		`export PATH=~/build-$DRONE_BUILD_NUMBER-$DRONE_BUILD_CREATED-toolchains/go/bin:$CARGO_HOME/bin:/Users/build/.cargo/bin:$PATH`,

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -89,12 +89,12 @@ func pushPipeline(b buildType) pipeline {
 
 	pipelineName := fmt.Sprintf("push-build-%s-%s", b.os, b.arch)
 	pushEnvironment := map[string]value{
-		"UID":     value{raw: "1000"},
-		"GID":     value{raw: "1000"},
-		"GOCACHE": value{raw: "/go/cache"},
-		"GOPATH":  value{raw: "/go"},
-		"OS":      value{raw: b.os},
-		"ARCH":    value{raw: b.arch},
+		"UID":     {raw: "1000"},
+		"GID":     {raw: "1000"},
+		"GOCACHE": {raw: "/go/cache"},
+		"GOPATH":  {raw: "/go"},
+		"OS":      {raw: b.os},
+		"ARCH":    {raw: b.arch},
 	}
 	if b.fips {
 		pipelineName += "-fips"
@@ -104,8 +104,8 @@ func pushPipeline(b buildType) pipeline {
 	p := newKubePipeline(pipelineName)
 	p.Environment = map[string]value{
 		"RUNTIME": goRuntime,
-		"UID":     value{raw: "1000"},
-		"GID":     value{raw: "1000"},
+		"UID":     {raw: "1000"},
+		"GID":     {raw: "1000"},
 	}
 	p.Trigger = triggerPush
 	p.Workspace = workspace{Path: "/go"}
@@ -118,7 +118,7 @@ func pushPipeline(b buildType) pipeline {
 			Name:  "Check out code",
 			Image: "docker:git",
 			Environment: map[string]value{
-				"GITHUB_PRIVATE_KEY": value{fromSecret: "GITHUB_PRIVATE_KEY"},
+				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
 			Commands: pushCheckoutCommands(b.fips),
 		},
@@ -134,7 +134,7 @@ func pushPipeline(b buildType) pipeline {
 			Name:  "Send Slack notification",
 			Image: "plugins/slack",
 			Settings: map[string]value{
-				"webhook": value{fromSecret: "SLACK_WEBHOOK_DEV_TELEPORT"},
+				"webhook": {fromSecret: "SLACK_WEBHOOK_DEV_TELEPORT"},
 			},
 			Template: []string{
 				`*{{#success build.status}}✔{{ else }}✘{{/success}} {{ uppercasefirst build.status }}: Build #{{ build.number }}* (type: ` + "`{{ build.event }}`" + `)

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -113,18 +113,26 @@ func tagCopyArtifactCommands(b buildType) []string {
 		)
 	}
 
-	// we need to specifically rename artifacts which are created for CentOS 6
+	// we need to specifically rename artifacts which are created for CentOS
 	// these is the only special case where renaming is not handled inside the Makefile
 	if b.centos6 {
+		// for CentOS 6 we don't support FIPS, just OSS and enterprise
+		commands = append(commands,
+			`export VERSION=$(cat /go/.version.txt)`,
+			`mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-v$${VERSION}-linux-amd64-centos6-bin.tar.gz`,
+			`mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-bin.tar.gz`,
+		)
+	} else if b.centos7 {
+		// for CentOS 7, we support OSS, Enterprise, and FIPS (Enterprise only)
 		commands = append(commands, `export VERSION=$(cat /go/.version.txt)`)
 		if !b.fips {
 			commands = append(commands,
-				`mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-v$${VERSION}-linux-amd64-centos6-bin.tar.gz`,
-				`mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-bin.tar.gz`,
+				`mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-v$${VERSION}-linux-amd64-centos7-bin.tar.gz`,
+				`mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos7-bin.tar.gz`,
 			)
 		} else {
 			commands = append(commands,
-				`mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos6-fips-bin.tar.gz`,
+				`mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-fips-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos7-fips-bin.tar.gz`,
 			)
 		}
 	}
@@ -147,13 +155,13 @@ func uploadToS3Step(s s3Settings) step {
 		Name:  "Upload to S3",
 		Image: "plugins/s3",
 		Settings: map[string]value{
-			"bucket":       value{fromSecret: "AWS_S3_BUCKET"},
-			"access_key":   value{fromSecret: "AWS_ACCESS_KEY_ID"},
-			"secret_key":   value{fromSecret: "AWS_SECRET_ACCESS_KEY"},
-			"region":       value{raw: s.region},
-			"source":       value{raw: s.source},
-			"target":       value{raw: s.target},
-			"strip_prefix": value{raw: s.stripPrefix},
+			"bucket":       {fromSecret: "AWS_S3_BUCKET"},
+			"access_key":   {fromSecret: "AWS_ACCESS_KEY_ID"},
+			"secret_key":   {fromSecret: "AWS_SECRET_ACCESS_KEY"},
+			"region":       {raw: s.region},
+			"source":       {raw: s.source},
+			"target":       {raw: s.target},
+			"strip_prefix": {raw: s.stripPrefix},
 		},
 	}
 }
@@ -180,9 +188,11 @@ func tagPipelines() []pipeline {
 	// Only amd64 Windows is supported for now.
 	ps = append(ps, tagPipeline(buildType{os: "windows", arch: "amd64"}))
 
-	// Also add the two CentOS 6 artifacts.
+	// Also add CentOS artifacts
 	// CentOS 6 FIPS builds have been removed in Teleport 7.0. See https://github.com/gravitational/teleport/issues/7207
 	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", centos6: true}))
+	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", centos7: true}))
+	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", centos7: true, fips: true}))
 
 	ps = append(ps, darwinTagPipeline(), darwinTeleportPkgPipeline(), darwinTshPkgPipeline())
 	return ps
@@ -200,14 +210,16 @@ func tagPipeline(b buildType) pipeline {
 	pipelineName := fmt.Sprintf("build-%s-%s", b.os, b.arch)
 	if b.centos6 {
 		pipelineName += "-centos6"
+	} else if b.centos7 {
+		pipelineName += "-centos7"
 	}
 	tagEnvironment := map[string]value{
-		"UID":     value{raw: "1000"},
-		"GID":     value{raw: "1000"},
-		"GOCACHE": value{raw: "/go/cache"},
-		"GOPATH":  value{raw: "/go"},
-		"OS":      value{raw: b.os},
-		"ARCH":    value{raw: b.arch},
+		"UID":     {raw: "1000"},
+		"GID":     {raw: "1000"},
+		"GOCACHE": {raw: "/go/cache"},
+		"GOPATH":  {raw: "/go"},
+		"OS":      {raw: b.os},
+		"ARCH":    {raw: b.arch},
 	}
 	if b.fips {
 		pipelineName += "-fips"
@@ -233,7 +245,7 @@ func tagPipeline(b buildType) pipeline {
 			Name:  "Check out code",
 			Image: "docker:git",
 			Environment: map[string]value{
-				"GITHUB_PRIVATE_KEY": value{fromSecret: "GITHUB_PRIVATE_KEY"},
+				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
 			Commands: tagCheckoutCommands(b.fips),
 		},
@@ -309,9 +321,9 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 	}
 
 	environment := map[string]value{
-		"ARCH":             value{raw: b.arch},
-		"TMPDIR":           value{raw: "/go"},
-		"ENT_TARBALL_PATH": value{raw: "/go/artifacts"},
+		"ARCH":             {raw: b.arch},
+		"TMPDIR":           {raw: "/go"},
+		"ENT_TARBALL_PATH": {raw: "/go/artifacts"},
 	}
 
 	dependentPipeline := fmt.Sprintf("build-%s-%s", b.os, b.arch)
@@ -373,7 +385,7 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 			Name:  "Check out code",
 			Image: "docker:git",
 			Environment: map[string]value{
-				"GITHUB_PRIVATE_KEY": value{fromSecret: "GITHUB_PRIVATE_KEY"},
+				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
 			Commands: tagCheckoutCommands(b.fips),
 		},
@@ -382,10 +394,10 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 			Name:  "Download artifacts from S3",
 			Image: "amazon/aws-cli",
 			Environment: map[string]value{
-				"AWS_REGION":            value{raw: "us-west-2"},
-				"AWS_S3_BUCKET":         value{fromSecret: "AWS_S3_BUCKET"},
-				"AWS_ACCESS_KEY_ID":     value{fromSecret: "AWS_ACCESS_KEY_ID"},
-				"AWS_SECRET_ACCESS_KEY": value{fromSecret: "AWS_SECRET_ACCESS_KEY"},
+				"AWS_REGION":            {raw: "us-west-2"},
+				"AWS_S3_BUCKET":         {fromSecret: "AWS_S3_BUCKET"},
+				"AWS_ACCESS_KEY_ID":     {fromSecret: "AWS_ACCESS_KEY_ID"},
+				"AWS_SECRET_ACCESS_KEY": {fromSecret: "AWS_SECRET_ACCESS_KEY"},
 			},
 			Commands: tagDownloadArtifactCommands(b),
 		},

--- a/dronegen/tests.go
+++ b/dronegen/tests.go
@@ -84,8 +84,8 @@ func testCodePipeline() pipeline {
 	p := newKubePipeline("test")
 	p.Environment = map[string]value{
 		"RUNTIME": goRuntime,
-		"UID":     value{raw: "1000"},
-		"GID":     value{raw: "1000"},
+		"UID":     {raw: "1000"},
+		"GID":     {raw: "1000"},
 	}
 	p.Trigger = triggerPullRequest
 	p.Workspace = workspace{Path: "/go"}
@@ -102,15 +102,15 @@ func testCodePipeline() pipeline {
 		),
 	}
 	goEnvironment := map[string]value{
-		"GOCACHE": value{raw: "/tmpfs/go/cache"},
-		"GOPATH":  value{raw: "/tmpfs/go"},
+		"GOCACHE": {raw: "/tmpfs/go/cache"},
+		"GOPATH":  {raw: "/tmpfs/go"},
 	}
 	p.Steps = []step{
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
 			Environment: map[string]value{
-				"GITHUB_PRIVATE_KEY": value{fromSecret: "GITHUB_PRIVATE_KEY"},
+				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
 			Volumes: []volumeRef{
 				volumeRefTmpfs,
@@ -201,11 +201,11 @@ echo ""
 			Name:  "Run integration tests",
 			Image: "docker",
 			Environment: map[string]value{
-				"GOCACHE":                   value{raw: "/tmpfs/go/cache"},
-				"GOPATH":                    value{raw: "/tmpfs/go"},
-				"INTEGRATION_CI_KUBECONFIG": value{fromSecret: "INTEGRATION_CI_KUBECONFIG"},
-				"KUBECONFIG":                value{raw: "/tmpfs/go/kubeconfig.ci"},
-				"TEST_KUBE":                 value{raw: "true"},
+				"GOCACHE":                   {raw: "/tmpfs/go/cache"},
+				"GOPATH":                    {raw: "/tmpfs/go"},
+				"INTEGRATION_CI_KUBECONFIG": {fromSecret: "INTEGRATION_CI_KUBECONFIG"},
+				"KUBECONFIG":                {raw: "/tmpfs/go/kubeconfig.ci"},
+				"TEST_KUBE":                 {raw: "true"},
 			},
 			Volumes: dockerVolumeRefs(volumeRefTmpfs, volumeRefTmpIntegration),
 			Commands: []string{
@@ -250,9 +250,9 @@ func testDocsPipeline() pipeline {
 			Name:  "Run docs tests",
 			Image: "docker:git",
 			Environment: map[string]value{
-				"GOCACHE": value{raw: "/tmpfs/go/cache"},
-				"UID":     value{raw: "1000"},
-				"GID":     value{raw: "1000"},
+				"GOCACHE": {raw: "/tmpfs/go/cache"},
+				"UID":     {raw: "1000"},
+				"GID":     {raw: "1000"},
 			},
 			Volumes: dockerVolumeRefs(volumeRefTmpfs),
 			Commands: []string{


### PR DESCRIPTION
Add new buildboxes for centos7 and centos7-fips.

For now, we will continue to support both CentOS 6 and 7.
Eventually we will drop support for CentOS 6, and the only
supported CentOS builds will be these new CentOS 7 builds.

Additionally, this change makes build.assets/Makefile the
source of truth for which Go/Rust versions we use to compile,
creating a few less places that need to be manually updated 
when we wish to bump versions.

Fixes #9028
