### PR TITLE
Add ability to run Mongo proxy on separate listener

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -262,6 +262,10 @@ type DBProxySettings struct {
 	MySQLListenAddr string `json:"mysql_listen_addr,omitempty"`
 	// MySQLPublicAddr is advertised to MySQL clients.
 	MySQLPublicAddr string `json:"mysql_public_addr,omitempty"`
+	// MongoListenAddr is Mongo proxy listen address.
+	MongoListenAddr string `json:"mongo_listen_addr,omitempty"`
+	// MongoPublicAddr is advertised to Mongo clients.
+	MongoPublicAddr string `json:"mongo_public_addr,omitempty"`
 }
 
 // AuthenticationSettings contains information about server authentication

--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -65,6 +65,9 @@ type Profile struct {
 	// MySQLProxyAddr is the host:port the MySQL proxy can be accessed at.
 	MySQLProxyAddr string `yaml:"mysql_proxy_addr,omitempty"`
 
+	// MongoProxyAddr is the host:port the Mongo proxy can be accessed at.
+	MongoProxyAddr string `yaml:"mongo_proxy_addr,omitempty"`
+
 	// Username is the Teleport username for the client.
 	Username string `yaml:"user,omitempty"`
 

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -599,6 +599,10 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 			// Postgres proxy port was configured on a separate listener.
 			tconf.Proxy.PostgresAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortPostgres())
 		}
+		if i.Mongo != nil {
+			// Mongo proxy port was configured on a separate listener.
+			tconf.Proxy.MongoAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortMongo())
+		}
 	}
 	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.SSHAddr)
 	tconf.Auth.StorageConfig = backend.Config{

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -99,6 +99,18 @@ func separatePostgresPortSetup() *InstancePorts {
 	}
 }
 
+func separateMongoPortSetup() *InstancePorts {
+	return &InstancePorts{
+		Web:           newInstancePort(),
+		SSH:           newInstancePort(),
+		Auth:          newInstancePort(),
+		SSHProxy:      newInstancePort(),
+		ReverseTunnel: newInstancePort(),
+		MySQL:         newInstancePort(),
+		Mongo:         newInstancePort(),
+	}
+}
+
 type InstancePorts struct {
 	Host string
 	Web  *InstancePort
@@ -110,6 +122,7 @@ type InstancePorts struct {
 	ReverseTunnel *InstancePort
 	MySQL         *InstancePort
 	Postgres      *InstancePort
+	Mongo         *InstancePort
 
 	isSinglePortSetup bool
 }
@@ -121,6 +134,7 @@ func (i *InstancePorts) GetPortProxy() string         { return i.SSHProxy.String
 func (i *InstancePorts) GetPortWeb() string           { return i.Web.String() }
 func (i *InstancePorts) GetPortMySQL() string         { return i.MySQL.String() }
 func (i *InstancePorts) GetPortPostgres() string      { return i.Postgres.String() }
+func (i *InstancePorts) GetPortMongo() string         { return i.Mongo.String() }
 func (i *InstancePorts) GetPortReverseTunnel() string { return i.ReverseTunnel.String() }
 
 func (i *InstancePorts) GetSSHAddr() string {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -199,6 +199,9 @@ type Config struct {
 	// PostgresProxyAddr is the host:port the Postgres proxy can be accessed at.
 	PostgresProxyAddr string
 
+	// MongoProxyAddr is the host:port the Mongo proxy can be accessed at.
+	MongoProxyAddr string
+
 	// MySQLProxyAddr is the host:port the MySQL proxy can be accessed at.
 	MySQLProxyAddr string
 
@@ -800,6 +803,7 @@ func (c *Config) LoadProfile(profileDir string, proxyName string) error {
 	c.SSHProxyAddr = cp.SSHProxyAddr
 	c.PostgresProxyAddr = cp.PostgresProxyAddr
 	c.MySQLProxyAddr = cp.MySQLProxyAddr
+	c.MongoProxyAddr = cp.MongoProxyAddr
 	c.TLSRoutingEnabled = cp.TLSRoutingEnabled
 
 	c.LocalForwardPorts, err = ParsePortForwardSpec(cp.ForwardedPorts)
@@ -831,6 +835,7 @@ func (c *Config) SaveProfile(dir string, makeCurrent bool) error {
 	cp.KubeProxyAddr = c.KubeProxyAddr
 	cp.PostgresProxyAddr = c.PostgresProxyAddr
 	cp.MySQLProxyAddr = c.MySQLProxyAddr
+	cp.MongoProxyAddr = c.MongoProxyAddr
 	cp.ForwardedPorts = c.LocalForwardPorts.String()
 	cp.SiteName = c.SiteName
 	cp.TLSRoutingEnabled = c.TLSRoutingEnabled
@@ -996,6 +1001,17 @@ func (c *Config) PostgresProxyHostPort() (string, int) {
 	return c.WebProxyHostPort()
 }
 
+// MongoProxyHostPort returns the host and port of Mongo proxy.
+func (c *Config) MongoProxyHostPort() (string, int) {
+	if c.MongoProxyAddr != "" {
+		addr, err := utils.ParseAddr(c.MongoProxyAddr)
+		if err == nil {
+			return addr.Host(), addr.Port(defaults.MongoListenPort)
+		}
+	}
+	return c.WebProxyHostPort()
+}
+
 // MySQLProxyHostPort returns the host and port of MySQL proxy.
 func (c *Config) MySQLProxyHostPort() (string, int) {
 	if c.MySQLProxyAddr != "" {
@@ -1016,7 +1032,7 @@ func (c *Config) DatabaseProxyHostPort(db tlsca.RouteToDatabase) (string, int) {
 	case defaults.ProtocolMySQL:
 		return c.MySQLProxyHostPort()
 	case defaults.ProtocolMongoDB:
-		return c.WebProxyHostPort()
+		return c.MongoProxyHostPort()
 	}
 	return c.WebProxyHostPort()
 }
@@ -2661,6 +2677,24 @@ func (tc *TeleportClient) applyProxySettings(proxySettings webclient.ProxySettin
 	default:
 		webProxyHost, webProxyPort := tc.WebProxyHostPort()
 		tc.PostgresProxyAddr = net.JoinHostPort(webProxyHost, strconv.Itoa(webProxyPort))
+	}
+
+	// Read Mongo proxy settings.
+	switch {
+	case proxySettings.DB.MongoPublicAddr != "":
+		addr, err := utils.ParseAddr(proxySettings.DB.MongoPublicAddr)
+		if err != nil {
+			return trace.BadParameter("failed to parse Mongo public address received from server: %q, contact your administrator for help",
+				proxySettings.DB.MongoPublicAddr)
+		}
+		tc.MongoProxyAddr = net.JoinHostPort(addr.Host(), strconv.Itoa(addr.Port(tc.WebProxyPort())))
+	case proxySettings.DB.MongoListenAddr != "":
+		addr, err := utils.ParseAddr(proxySettings.DB.MongoListenAddr)
+		if err != nil {
+			return trace.BadParameter("failed to parse Mongo listen address received from server: %q, contact your administrator for help",
+				proxySettings.DB.MongoListenAddr)
+		}
+		tc.MongoProxyAddr = net.JoinHostPort(tc.WebProxyHost(), strconv.Itoa(addr.Port(defaults.MongoListenPort)))
 	}
 
 	// Read MySQL proxy settings if enabled on the server.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -671,6 +671,13 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 		}
 		cfg.Proxy.PostgresAddr = *addr
 	}
+	if fc.Proxy.MongoAddr != "" {
+		addr, err := utils.ParseHostPortAddr(fc.Proxy.MongoAddr, int(defaults.MongoListenPort))
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		cfg.Proxy.MongoAddr = *addr
+	}
 
 	// This is the legacy format. Continue to support it forever, but ideally
 	// users now use the list format below.
@@ -813,6 +820,17 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 			return trace.Wrap(err)
 		}
 		cfg.Proxy.MySQLPublicAddrs = addrs
+	}
+
+	if len(fc.Proxy.MongoPublicAddr) != 0 {
+		if fc.Proxy.MongoAddr == "" {
+			return trace.BadParameter("mongo_listen_addr must be set when mongo_public_addr is set")
+		}
+		addrs, err := utils.AddrsFromStrings(fc.Proxy.MongoPublicAddr, defaults.MongoListenPort)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		cfg.Proxy.MongoPublicAddrs = addrs
 	}
 
 	acme, err := fc.Proxy.ACME.Parse()

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -679,10 +679,13 @@ func TestApplyConfig(t *testing.T) {
 	require.Equal(t, "tcp://webhost:3080", cfg.Proxy.WebAddr.FullAddress())
 	require.Equal(t, "tcp://tunnelhost:1001", cfg.Proxy.ReverseTunnelListenAddr.FullAddress())
 	require.Equal(t, "tcp://webhost:3336", cfg.Proxy.MySQLAddr.FullAddress())
+	require.Equal(t, "tcp://webhost:27017", cfg.Proxy.MongoAddr.FullAddress())
 	require.Len(t, cfg.Proxy.PostgresPublicAddrs, 1)
 	require.Equal(t, "tcp://postgres.example:5432", cfg.Proxy.PostgresPublicAddrs[0].FullAddress())
 	require.Len(t, cfg.Proxy.MySQLPublicAddrs, 1)
 	require.Equal(t, "tcp://mysql.example:3306", cfg.Proxy.MySQLPublicAddrs[0].FullAddress())
+	require.Len(t, cfg.Proxy.MongoPublicAddrs, 1)
+	require.Equal(t, "tcp://mongo.example:27017", cfg.Proxy.MongoPublicAddrs[0].FullAddress())
 
 	require.Equal(t, "tcp://127.0.0.1:3000", cfg.DiagnosticAddr.FullAddress())
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1121,6 +1121,12 @@ type Proxy struct {
 	// PostgresPublicAddr is the hostport the proxy advertises for Postgres
 	// client connections.
 	PostgresPublicAddr apiutils.Strings `yaml:"postgres_public_addr,omitempty"`
+
+	// MongoAddr is Mongo proxy listen address.
+	MongoAddr string `yaml:"mongo_listen_addr,omitempty"`
+	// MongoPublicAddr is the hostport the proxy advertises for Mongo
+	// client connections.
+	MongoPublicAddr apiutils.Strings `yaml:"mongo_public_addr,omitempty"`
 }
 
 // ACME configures ACME protocol - automatic X.509 certificates

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -159,6 +159,8 @@ proxy_service:
   postgres_public_addr: postgres.example:5432
   mysql_listen_addr: webhost:3336
   mysql_public_addr: mysql.example:3306
+  mongo_listen_addr: webhost:27017
+  mongo_public_addr: mongo.example:27017
 `
 
 // NoServicesConfigString is a configuration file with no services enabled

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -63,6 +63,9 @@ const (
 	// PostgresListenPort is the default listen port for PostgreSQL proxy.
 	PostgresListenPort = 5432
 
+	// MongoListenPort is the default listen port for Mongo proxy.
+	MongoListenPort = 27017
+
 	// MetricsListenPort is the default listen port for the metrics service.
 	MetricsListenPort = 3081
 

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -361,6 +361,9 @@ type ProxyConfig struct {
 	// PostgresAddr is address of Postgres proxy.
 	PostgresAddr utils.NetAddr
 
+	// MongoAddr is address of Mongo proxy.
+	MongoAddr utils.NetAddr
+
 	Limiter limiter.Config
 
 	// PublicAddrs is a list of the public addresses the proxy advertises
@@ -385,6 +388,10 @@ type ProxyConfig struct {
 	// MySQLPublicAddrs is a list of the public addresses the proxy
 	// advertises for MySQL clients.
 	MySQLPublicAddrs []utils.NetAddr
+
+	// MongoPublicAddrs is a list of the public addresses the proxy
+	// advertises for Mongo clients.
+	MongoPublicAddrs []utils.NetAddr
 
 	// Kube specifies kubernetes proxy configuration
 	Kube KubeProxyConfig

--- a/lib/service/listeners.go
+++ b/lib/service/listeners.go
@@ -41,6 +41,7 @@ var (
 	listenerProxyTunnel       = listenerType(teleport.Component(teleport.ComponentProxy, "tunnel"))
 	listenerProxyMySQL        = listenerType(teleport.Component(teleport.ComponentProxy, "mysql"))
 	listenerProxyPostgres     = listenerType(teleport.Component(teleport.ComponentProxy, "postgres"))
+	listenerProxyMongo        = listenerType(teleport.Component(teleport.ComponentProxy, "mongo"))
 	listenerMetrics           = listenerType(teleport.ComponentMetrics)
 	listenerWindowsDesktop    = listenerType(teleport.ComponentWindowsDesktop)
 )

--- a/lib/service/proxy_settings.go
+++ b/lib/service/proxy_settings.go
@@ -81,6 +81,10 @@ func (p *proxySettings) buildProxySettings(proxyListenerMode types.ProxyListener
 		proxySettings.DB.PostgresListenAddr = p.cfg.Proxy.PostgresAddr.String()
 	}
 
+	if !p.cfg.Proxy.MongoAddr.IsEmpty() {
+		proxySettings.DB.MongoListenAddr = p.cfg.Proxy.MongoAddr.String()
+	}
+
 	if p.cfg.Proxy.Kube.Enabled {
 		proxySettings.Kube.ListenAddr = p.cfg.Proxy.Kube.ListenAddr.String()
 	}
@@ -116,6 +120,9 @@ func (p *proxySettings) setProxyPublicAddressesSettings(settings *webclient.Prox
 	}
 	if len(p.cfg.Proxy.MySQLPublicAddrs) > 0 {
 		settings.DB.MySQLPublicAddr = p.cfg.Proxy.MySQLPublicAddrs[0].String()
+	}
+	if len(p.cfg.Proxy.MongoPublicAddrs) > 0 {
+		settings.DB.MongoPublicAddr = p.cfg.Proxy.MongoPublicAddrs[0].String()
 	}
 	settings.DB.PostgresPublicAddr = p.getPostgresPublicAddr()
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2526,6 +2526,8 @@ type dbListeners struct {
 	postgres net.Listener
 	// mysql serves MySQL clients.
 	mysql net.Listener
+	// mongo serves Mongo clients.
+	mongo net.Listener
 	// tls serves database clients that use plain TLS handshake.
 	tls net.Listener
 }
@@ -2545,6 +2547,9 @@ func (l *dbListeners) Close() {
 	}
 	if l.tls != nil {
 		l.tls.Close()
+	}
+	if l.mongo != nil {
+		l.mongo.Close()
 	}
 }
 
@@ -2601,6 +2606,15 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 			return nil, trace.Wrap(err)
 		}
 		listeners.db.mysql = listener
+	}
+
+	if !cfg.Proxy.MongoAddr.IsEmpty() && !cfg.Proxy.DisableDatabaseProxy {
+		process.log.Debugf("Setup Proxy: Mongo proxy address: %v.", cfg.Proxy.MongoAddr.Addr)
+		listener, err := process.importOrCreateListener(listenerProxyMongo, cfg.Proxy.MongoAddr.Addr)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		listeners.db.mongo = listener
 	}
 
 	switch {
@@ -3166,6 +3180,16 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				log.Infof("Starting Database TLS proxy server on %v.", cfg.Proxy.WebAddr.Addr)
 				if err := dbProxyServer.ServeTLS(listeners.db.tls); err != nil {
 					log.WithError(err).Warn("Database TLS proxy server exited with error.")
+				}
+				return nil
+			})
+		}
+
+		if listeners.db.mongo != nil {
+			process.RegisterCriticalFunc("proxy.db.mongo", func() error {
+				log.Infof("Starting Database Mongo proxy server on %v.", cfg.Proxy.MongoAddr.Addr)
+				if err := dbProxyServer.ServeMongo(listeners.db.mongo, tlsConfigWeb.Clone()); err != nil {
+					log.WithError(err).Warn("Database Mongo proxy server exited with error.")
 				}
 				return nil
 			})


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/8400
## What 
Add ability to run proxy mongo listener instead of multiplexing mongo proxy service on WebPort. 


## How: 
Added following mongo proxy listen configuration: 
```yaml
proxy_service:
  mongo_listen_addr: webhost:27017
  mongo_public_addr: mongo.example:27017
  ```
If `mongo_listen_addr` address was provided  the proxy will also start mongo on `mongo_listen_addr` and additionally on webPort to provide `tsh` backward compatibility.  

