### PR TITLE
Fix sessions endpoint and remove namespaces

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -67,7 +67,7 @@ func (m *mockServer) Ping(ctx context.Context, req *proto.PingRequest) (*proto.P
 
 // Implement ListNodes handling of limit exceeded errors.
 func (m *mockServer) ListNodes(ctx context.Context, req *proto.ListNodesRequest) (*proto.ListNodesResponse, error) {
-	nodes, err := testNodes(req.Namespace)
+	nodes, err := testNodes(defaults.Namespace)
 	if err != nil {
 		return nil, trail.ToGRPC(err)
 	}

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -67,7 +67,7 @@ func (m *mockServer) Ping(ctx context.Context, req *proto.PingRequest) (*proto.P
 
 // Implement ListNodes handling of limit exceeded errors.
 func (m *mockServer) ListNodes(ctx context.Context, req *proto.ListNodesRequest) (*proto.ListNodesResponse, error) {
-	nodes, err := testNodes(defaults.Namespace)
+	nodes, err := testNodes(req.Namespace)
 	if err != nil {
 		return nil, trail.ToGRPC(err)
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2859,7 +2859,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	// Register web proxy server
 	var webServer *http.Server
-	var webHandler *web.RewritingHandler
+	var webHandler *web.WebHandler
 	if !process.Config.Proxy.DisableWebService {
 		var fs http.FileSystem
 		if !process.Config.Proxy.DisableWebInterface {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2859,7 +2859,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	// Register web proxy server
 	var webServer *http.Server
-	var webHandler *web.WebHandler
+	var webHandler *web.WebAPIHandler
 	if !process.Config.Proxy.DisableWebService {
 		var fs http.FileSystem
 		if !process.Config.Proxy.DisableWebInterface {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -189,7 +189,7 @@ type Config struct {
 	ProxySettings proxySettingsGetter
 }
 
-type WebHandler struct {
+type WebAPIHandler struct {
 	handler *Handler
 
 	// appHandler is a http.Handler to forward requests to applications.
@@ -198,7 +198,7 @@ type WebHandler struct {
 
 // Check if this request should be forwarded to an application handler to
 // be handled by the UI and handle the request appropriately.
-func (h *WebHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *WebAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If the request is either to the fragment authentication endpoint or if the
 	// request is already authenticated (has a session cookie), forward to
 	// application handlers. If the request is unauthenticated and requesting a
@@ -215,12 +215,12 @@ func (h *WebHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handler.ServeHTTP(w, r)
 }
 
-func (h *WebHandler) Close() error {
+func (h *WebAPIHandler) Close() error {
 	return h.handler.Close()
 }
 
 // NewHandler returns a new instance of web proxy handler
-func NewHandler(cfg Config, opts ...HandlerOption) (*WebHandler, error) {
+func NewHandler(cfg Config, opts ...HandlerOption) (*WebAPIHandler, error) {
 	const apiPrefix = "/" + teleport.WebAPIVersion
 	h := &Handler{
 		cfg:             cfg,
@@ -518,7 +518,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*WebHandler, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	return &WebHandler{
+	return &WebAPIHandler{
 		handler:    h,
 		appHandler: appHandler,
 	}, nil

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -190,7 +190,6 @@ type Config struct {
 }
 
 type WebHandler struct {
-	http.Handler
 	handler *Handler
 
 	// appHandler is a http.Handler to forward requests to applications.
@@ -213,7 +212,7 @@ func (h *WebHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Serve the Web UI.
-	h.Handler.ServeHTTP(w, r)
+	h.handler.ServeHTTP(w, r)
 }
 
 func (h *WebHandler) Close() error {
@@ -520,7 +519,6 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*WebHandler, error) {
 	}
 
 	return &WebHandler{
-		Handler:    httplib.RewritePaths(h),
 		handler:    h,
 		appHandler: appHandler,
 	}, nil

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3369,7 +3369,7 @@ type proxy struct {
 	revTun  reversetunnel.Server
 	node    *regular.Server
 	proxy   *regular.Server
-	handler *RewritingHandler
+	handler *WebHandler
 	web     *httptest.Server
 	webURL  url.URL
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1302,7 +1302,7 @@ func (s *WebSuite) TestEmptySessionClusterHostnameIsSet(c *C) {
 
 	// Retrieve the session with the empty ClusterName.
 	pack := s.authPack(c, "baz")
-	res, err := pack.clt.Get(context.Background(), pack.clt.Endpoint("webapi", "sites", s.server.ClusterName(), "namespaces", "default", "sessions", sess1.ID.String()), url.Values{})
+	res, err := pack.clt.Get(context.Background(), pack.clt.Endpoint("webapi", "sites", s.server.ClusterName(), "sessions", sess1.ID.String()), url.Values{})
 	c.Assert(err, IsNil)
 
 	// Test that empty ClusterName and ServerHostname got set.
@@ -1320,7 +1320,7 @@ func (s *WebSuite) TestEmptySessionClusterHostnameIsSet(c *C) {
 	c.Assert(err, IsNil)
 
 	// Retrieve sessions list.
-	res, err = pack.clt.Get(context.Background(), pack.clt.Endpoint("webapi", "sites", s.server.ClusterName(), "namespaces", "default", "sessions"), url.Values{})
+	res, err = pack.clt.Get(context.Background(), pack.clt.Endpoint("webapi", "sites", s.server.ClusterName(), "sessions"), url.Values{})
 	c.Assert(err, IsNil)
 
 	var sessionList *siteSessionsGetResponse

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3359,7 +3359,7 @@ type proxy struct {
 	revTun  reversetunnel.Server
 	node    *regular.Server
 	proxy   *regular.Server
-	handler *WebHandler
+	handler *WebAPIHandler
 	web     *httptest.Server
 	webURL  url.URL
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -623,16 +623,6 @@ func (s *WebSuite) TestWebSessionsCRUD(c *C) {
 	c.Assert(trace.IsAccessDenied(err), Equals, true)
 }
 
-func (s *WebSuite) TestNamespace(c *C) {
-	pack := s.authPack(c, "foo")
-
-	_, err := pack.clt.Get(context.Background(), pack.clt.Endpoint("webapi", "sites", s.server.ClusterName(), "namespaces", "..%252fevents%3f", "nodes"), url.Values{})
-	c.Assert(err, NotNil)
-
-	_, err = pack.clt.Get(context.Background(), pack.clt.Endpoint("webapi", "sites", s.server.ClusterName(), "namespaces", "default", "nodes"), url.Values{})
-	c.Assert(err, IsNil)
-}
-
 func (s *WebSuite) TestCSRF(c *C) {
 	type input struct {
 		reqToken    string

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -19,6 +19,7 @@ package web
 import (
 	"net/http"
 
+	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/client"
@@ -50,10 +51,10 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 	req := fileTransferRequest{
 		cluster:        p.ByName("site"),
 		login:          p.ByName("login"),
-		namespace:      p.ByName("namespace"),
 		server:         p.ByName("server"),
 		remoteLocation: query.Get("location"),
 		filename:       query.Get("filename"),
+		namespace:      defaults.Namespace,
 	}
 
 	clt, err := ctx.GetUserClient(site)


### PR DESCRIPTION
## Purpose

Resolves the endpoint naming clash for fetching session recordings which was leading `/search` to be interpreted as a session UUID, causing the error `search is not a valid UUID`.

Also removes deprecated `namespace` from routes.

