### PR TITLE
`tsh db connect` doesn't respect TELEPORT_HOME

### DIFF
--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -287,7 +287,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	profile, err := client.StatusCurrent("", cf.Proxy)
+	profile, err := client.StatusCurrent(cf.HomePath, cf.Proxy)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Currently `tsh db connect` still looks for the home directory in os home even when `TELEPORT_HOME` is provided. Example:
```sh
TELEPORT_HOME=/home/jnyckowski/tsh tsh -d db connect prod
INFO [CLIENT]    no host login given. defaulting to jnyckowski client/api.go:1071
INFO [CLIENT]    [KEY AGENT] Connected to the system agent: "/run/user/1000/keyring/ssh" client/api.go:2881
DEBU [KEYSTORE]  Returning Teleport TLS certificate "/home/jnyckowski/tsh/keys/example.com/bob-x509.pem" valid until "2021-12-04 11:30:11 +0000 UTC". client/keystore.go:280
DEBU [KEYSTORE]  Reading certificates from path "/home/jnyckowski/tsh/keys/example.com/bob-ssh/localhost-cert.pub". client/keystore.go:303
INFO [KEYAGENT]  Loading SSH key for user "bob" and cluster "localhost". client/keyagent.go:180
DEBU [CLIENT]    Failed to stat file: stat /home/jnyckowski/.tsh: no such file or directory. client/api.go:702

ERROR REPORT:
Original Error: *trace.NotFoundError stat /home/jnyckowski/.tsh: no such file or directory
Stack Trace:
	/home/jnyckowski/projects/teleport/lib/client/api.go:704 github.com/gravitational/teleport/lib/client.Status
	/home/jnyckowski/projects/teleport/lib/client/api.go:657 github.com/gravitational/teleport/lib/client.StatusCurrent
	/home/jnyckowski/projects/teleport/tool/tsh/db.go:290 main.onDatabaseConnect
	/home/jnyckowski/projects/teleport/tool/tsh/tsh.go:658 main.Run
	/home/jnyckowski/projects/teleport/tool/tsh/tsh.go:274 main.main
	/home/jnyckowski/apps/go/go1.17.3/src/runtime/proc.go:255 runtime.main
	/home/jnyckowski/apps/go/go1.17.3/src/runtime/asm_amd64.s:1581 runtime.goexit
User Message: stat /home/jnyckowski/.tsh: no such file or directory
```