### PR TITLE
[v7] Replace deb repo with a curl and dpkg -i

### DIFF
--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -33,10 +33,8 @@ Teleport (=teleport.version=) on Linux machines.
 
   <TabItem label="Debian/Ubuntu (DEB)">
     ```code
-    $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    $ sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    $ sudo apt-get update
-    $ sudo apt-get install teleport
+    $ curl -O https://get.gravitational.com/teleport_(=teleport.version=)_amd64.deb
+    $ sudo dpkg -i teleport_(=teleport.version=)_amd64.deb
     ```
   </TabItem>
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -18,14 +18,8 @@ up-to-date information.
 <Tabs>
   <TabItem label="Debian/Ubuntu (DEB)">
     ```code
-    # Install our public key.
-    $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    # Add repo to APT
-    $ add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    # Update APT Cache
-    $ apt-get update
-    # Install Teleport
-    $ apt install teleport
+    $ curl -O https://get.gravitational.com/teleport_(=teleport.version=)_amd64.deb
+    $ sudo dpkg -i teleport_(=teleport.version=)_amd64.deb
     ```
   </TabItem>
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -80,10 +80,8 @@ This guide introduces some of these common scenarios and how to interact with Te
 
      <TabItem label="Debian/Ubuntu (DEB)">
       ```code
-      $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-      $ sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-      $ sudo apt-get update
-      $ sudo apt-get install teleport
+      $ curl -O https://get.gravitational.com/teleport_(=teleport.version=)_amd64.deb
+      $ sudo dpkg -i teleport_(=teleport.version=)_amd64.deb
       ```
      </TabItem>
 


### PR DESCRIPTION
v7 backport of #9227 

The debian repo is currently broken, and we shouldn't recommend
customers use it until it is fixed.

Contributes to https://github.com/gravitational/teleport/issues/8166

(cherry picked from commit df3146258a6a4102a0c35d03a776fa62df0ecf1b)