### PR TITLE
[v6.2] Replace deb repo with a curl and dpkg -i

### DIFF
--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -43,10 +43,8 @@ Teleport (=teleport.version=) on Linux machines.
 
   <TabItem label="Debian/Ubuntu (DEB)">
     ```bash
-    curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    sudo apt-get update
-    sudo apt-get install teleport
+    curl -O https://get.gravitational.com/teleport-(=teleport.version=)_amd64.deb
+    sudo dpkg -i teleport_(=teleport.version=)_amd64.deb
     ```
   </TabItem>
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -18,14 +18,8 @@ up-to-date information.
 <Tabs>
   <TabItem label="Debian/Ubuntu (DEB)">
     ```bash
-    # Install our public key.
-    curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    # Add repo to APT
-    add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    # Update APT Cache
-    apt-get update
-    # Install Teleport
-    apt install teleport
+    curl -O https://get.gravitational.com/teleport-(=teleport.version=)_amd64.deb
+    sudo dpkg -i teleport_(=teleport.version=)_amd64.deb
     ```
   </TabItem>
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -90,10 +90,8 @@ This guide introduces some of these common scenarios and how to interact with Te
 
      <TabItem label="Debian/Ubuntu (DEB)">
       ```bash
-      curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-      sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-      sudo apt-get update
-      sudo apt-get install teleport
+      curl -O https://get.gravitational.com/teleport-(=teleport.version=)_amd64.deb
+      sudo dpkg -i teleport_(=teleport.version=)_amd64.deb
       ```
      </TabItem>
 


### PR DESCRIPTION
v6.2 backport of #9227 

The debian repo is currently broken, and we shouldn't recommend
customers use it until it is fixed.

Contributes to https://github.com/gravitational/teleport/issues/8166

This did encounter some merge conflicts, but I addressed them all, and doubled checked I caught all references with:

```console
$ rg 'apt ' docs
$ rg 'apt-get' docs
```