### PR TITLE
[v6.0] Replace deb repo with a curl and dpkg -i

### DIFF
--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -39,10 +39,8 @@ Teleport on Linux machines.
 
   <TabItem label="Debian/Ubuntu (DEB)">
     ```bash
-    curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    sudo apt-get update
-    sudo apt-get install teleport
+    curl -O https://get.gravitational.com/teleport-(=teleport.version=)_amd64.deb
+    sudo dpkg -i teleport_(=teleport.version=)_amd64.deb
     ```
   </TabItem>
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -16,14 +16,8 @@ up-to-date information.
 <Tabs>
   <TabItem label="Debian/Ubuntu (DEB)">
     ```bash
-    # Install our public key.
-    $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
-    # Add repo to APT
-    $ add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
-    # Update APT Cache
-    $ apt-get update
-    # Install Teleport
-    $ apt install teleport
+    $ curl -O https://get.gravitational.com/teleport-(=teleport.version=)_amd64.deb
+    $ sudo dpkg -i teleport_(=teleport.version=)_amd64.deb
     ```
   </TabItem>
 


### PR DESCRIPTION
v6.0 backport of #9227 

The debian repo is currently broken, and we shouldn't recommend
customers use it until it is fixed.

Contributes to https://github.com/gravitational/teleport/issues/8166

(cherry picked from commit df3146258a6a4102a0c35d03a776fa62df0ecf1b)
(cherry picked from commit aba4876763857d147756113cb23e793c6340fa43)

Note: This branch is out of support, and I'll probably never come back to
update these instructions when the issue is fixed.  That's ok though --
the dpkg solution works fine.