### PR TITLE
[v6.1] Fix links to community.gravitational.com

### DIFF
--- a/docs/pages/admin-guide.mdx
+++ b/docs/pages/admin-guide.mdx
@@ -1778,7 +1778,6 @@ As an extra precaution, you might want to backup your application before upgradi
 >
   Teleport 4.0+ switched to GRPC and HTTP/2 as an API protocol. The HTTP/2 spec bans
   two previously recommended ciphers. `tls-rsa-with-aes-128-gcm-sha256` & `tls-rsa-with-aes-256-gcm-sha384`, make sure these are removed from `teleport.yaml`
-  [Visit our community for more details](https://community.gravitational.com/t/drop-ciphersuites-blacklisted-by-http-2-spec/446)
 
   If upgrading you might want to consider rotating CA to SHA-256 or SHA-512 for RSA
   SSH certificate signatures. The previous default was SHA-1, which is now considered weak against brute-force attacks. SHA-1 certificate signatures are also no longer accepted by OpenSSH versions 8.2 and above. All new Teleport clusters will default
@@ -1997,7 +1996,7 @@ Now you can see the monitoring information by visiting several endpoints:
 
 ## Getting help
 
-If you need help, please ask on our [community forum](https://community.gravitational.com/). You can also open an [issue on Github](https://github.com/gravitational/teleport/issues).
+If you need help, please open an [issue on Github](https://github.com/gravitational/teleport/issues).
 
 For commercial support, you can create a ticket through the [customer dashboard](https://dashboard.gravitational.com/web/login).
 

--- a/docs/pages/aws-oss-guide.mdx
+++ b/docs/pages/aws-oss-guide.mdx
@@ -675,5 +675,3 @@ below to Teleport Nodes in `etc/teleport.yaml` to have helpful labels in the Tel
         command: [curl, "http://169.254.169.254/latest/meta-data/public-ipv4"]
         period: 1h0m0s
 ```
-
-Create labels based on [EC2 Tags](https://community.gravitational.com/t/setting-teleport-labels-based-on-ec2-tags-for-use-with-rbac/558).

--- a/docs/pages/aws-oss-guide.mdx
+++ b/docs/pages/aws-oss-guide.mdx
@@ -675,3 +675,5 @@ below to Teleport Nodes in `etc/teleport.yaml` to have helpful labels in the Tel
         command: [curl, "http://169.254.169.254/latest/meta-data/public-ipv4"]
         period: 1h0m0s
 ```
+
+Create labels based on [EC2 Tags](https://goteleport.com/docs/setup/guides/ec2-tags/).

--- a/docs/pages/production.mdx
+++ b/docs/pages/production.mdx
@@ -187,7 +187,7 @@ proxy_service:
 When setting up on Teleport on AWS or GCP, we recommend leveraging their certificate
 managers.
 
-- [ACM](https://gravitational.com/teleport/docs/aws-oss-guide/#acm) on AWS
+- ACM on AWS
 - [Google-managed SSL certificates](https://cloud.google.com/load-balancing/docs/ssl-certificates) on GCP
 
 When setting up Teleport with a Cloud Provider, it can be common to terminate

--- a/docs/pages/user-manual.mdx
+++ b/docs/pages/user-manual.mdx
@@ -605,7 +605,7 @@ want to reset it to a clean state by deleting temporary keys and other data from
 
 ## Getting help
 
-If you need help, please ask on our [community forum](https://community.gravitational.com/). You can also open an [issue on Github](https://github.com/gravitational/teleport/issues).
+If you need help, please ask on our [community forum](https://github.com/gravitational/teleport/discussions). You can also open an [issue on Github](https://github.com/gravitational/teleport/issues).
 
 For commercial support, you can create a ticket through the [customer dashboard](https://dashboard.gravitational.com/).
 


### PR DESCRIPTION
I found these were broken in a https://github.com/gravitational/teleport/pull/9231 CI failure:

```
content/docs/pages/admin-guide.mdx
  1781:3-1781:129  warning  Link to https://community.gravitational.com/t/drop-ciphersuites-blacklisted-by-http-2-spec/446 is dead                 no-dead-urls  remark-lint
  2000:37-2000:92  warning  Link to https://community.gravitational.com/ is dead                                                                   no-dead-urls  remark-lint

content/docs/pages/aws-oss-guide.mdx
   679:24-679:137  warning  Link to https://community.gravitational.com/t/setting-teleport-labels-based-on-ec2-tags-for-use-with-rbac/558 is dead  no-dead-urls  remark-lint

content/docs/pages/production.mdx
     190:3-190:68  warning  Link to https://gravitational.com/teleport/docs/aws-oss-guide/#acm is dead                                             no-dead-urls  remark-lint

content/docs/pages/user-manual.mdx
    608:37-608:92  warning  Link to https://community.gravitational.com/ is dead 
```

## Testing Done

```console
walt@work:~/git/teleport$ make -C build.assets test-docs                                                                                                                                      
make: Entering directory '/home/walt/git/teleport/build.assets'                                                                                                                               
grep: /Makefile: No such file or directory                                                                                                                                                    
docker pull quay.io/gravitational/next:main || true                                                                                                                                           
main: Pulling from gravitational/next                                                                                                                                                         
Digest: sha256:6286b22eb3d535d2390670e884e7e8ba80e8124bd92476aebd5b88b619949b36                                                                                                               
Status: Image is up to date for quay.io/gravitational/next:main                                                                                                                               
quay.io/gravitational/next:main                                                                                                                                                               
docker run -i -u $(id -u):$(id -g) -v $(pwd)/..:/src/content/ quay.io/gravitational/next:main \                                                                                               
        /bin/sh -c "yarn markdown-lint-external-links"                                                                                                                                        
yarn run v1.22.15                                                                                                                                                                             
$ WITH_EXTERNAL_LINKS=true yarn markdown-lint                                                                                                                                                 
$ remark 'content/**/docs/pages/**/*.mdx' --frail                                                                                                                                             
                                                                                                                                                                                              
content/docs/pages/access-controls/faq.mdx: no issues found
// snip lots...
content/docs/pages/user-manual.mdx: no issues found                                                                                                                                           
Done in 34.79s.                                                                                                                                                                               
make: Leaving directory '/home/walt/git/teleport/build.assets'
```

CI should also come back clean.