### PR TITLE
[5.0] Disable drone deb repo publishing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3347,20 +3347,7 @@ steps:
         # copy artifacts to PVC
         cp -r /go/reprepro/teleport /debrepo/
 
-  - name: Sync DEB repo changes to S3
-    image: amazon/aws-cli
-    environment:
-      AWS_S3_BUCKET:
-        from_secret: DEBREPO_AWS_S3_BUCKET
-      AWS_ACCESS_KEY_ID:
-        from_secret: DEBREPO_AWS_ACCESS_KEY_ID
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: DEBREPO_AWS_SECRET_ACCESS_KEY
-    volumes:
-      - name: debrepo
-        path: /debrepo
-    commands:
-    - aws s3 sync /debrepo/teleport/ s3://$AWS_S3_BUCKET/teleport/
+  # Deb repo publish disabled for https://github.com/gravitational/teleport/issues/8166
 
 services:
   - name: Start Docker
@@ -3389,6 +3376,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 45e3ba7312b372ba3e892098cbc4ea200abd109397ef89e775e7d8f6188aad2a
+hmac: e0c9a444f13dc7affad8deabd4d212ebe83bc34e71026151f6481d3b253747f4
 
 ...


### PR DESCRIPTION
v5.0 backport of #9237. See discussion there for more info about why wer're disabling publish on branches older than 8.

With 6.0 released and a long term fix to https://github.com/gravitational/teleport/issues/8166 outstanding, we do not want to publish 5.0 debs to deb.releases.teleport.dev until we've moved off reprepo.

(cherry picked from commit 377b1929633ca42e6b54914d3082198cace65bc6)

This is as far back as this change needs to go.  4.4 doesn't have reprepro publishing:

https://github.com/gravitational/teleport/blob/7a402dca8f0a6f184f749ca25a55d3445b99dd5e/.drone.yml#L2855-L2994