### PR TITLE
[v8] Clear web terminal when session ends (#8850)

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -149,6 +149,11 @@ func newSession(client *NodeClient,
 		defer ns.closeWait.Done()
 
 		<-ns.closer.C
+		if isFIPS() {
+			if err := ns.terminal.Clear(); err != nil {
+				log.Warnf("Failed to clear screen: %v.", err)
+			}
+		}
 		ns.terminal.Close()
 	}()
 

--- a/lib/client/terminal/terminal_common.go
+++ b/lib/client/terminal/terminal_common.go
@@ -67,3 +67,15 @@ func (e *signalEmitter) clearSubscribers() {
 	}
 	e.subscribers = e.subscribers[:0]
 }
+
+// Clear clears the terminal, including scrollback.
+func (t *Terminal) Clear() error {
+	// \x1b[3J - clears scrollback (it is needed at least for the Mac terminal) -
+	// https://newbedev.com/how-do-i-reset-the-scrollback-in-the-terminal-via-a-shell-command
+	// \x1b\x63 - clears current screen - same as '\0033\0143' from https://superuser.com/a/123007
+	const resetPattern = "\x1b[3J\x1b\x63\n"
+	if _, err := t.Stdout().Write([]byte(resetPattern)); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}


### PR DESCRIPTION
Backport of #8850.

This change clears the screen when an ssh session ends (only in FIPS mode). Note: This doesn't currently do anything in `tsh` on Windows since BoringCrypto isn't supported, but once it is supported, the behavior will match Unix and web.

Co-authored-by: Grzegorz <grzegorz.zdunek@goteleport.com>
Co-authored-by: Russell Jones <russjones@users.noreply.github.com>