### PR TITLE
Add Security and UX sections to the canonical RFD

### DIFF
--- a/rfd/0000-rfds.md
+++ b/rfd/0000-rfds.md
@@ -101,3 +101,11 @@ The purpose of the `state` is to tell the reader whether they should care about
 this RFD at all. For example, `deprecated` RFDs can be skipped most of the
 time. `implemented` is relevant to Teleport users, but `draft` is mostly for
 Teleport engineers and early adopters.
+
+### Security
+
+Describe the security considerations for your design doc.
+
+### UX
+
+Describe the UX changes and impact of your design doc.

--- a/rfd/0000-rfds.md
+++ b/rfd/0000-rfds.md
@@ -105,7 +105,25 @@ Teleport engineers and early adopters.
 ### Security
 
 Describe the security considerations for your design doc.
+(Non-exhaustive list below.)
+
+* Explore possible attack vectors, explain how to prevent them
+* Explore DDoS and other outage-type attacks
+* If frontend, explore common web vulnerabilities
+* If introducing new attack surfaces (UI, CLI commands, API or gRPC endpoints),
+  consider how they may be abused and how to prevent it
+* If introducing new auth{n,z}, explain their design and consequences
+* If using crypto, show that best practices were used to define it
 
 ### UX
 
 Describe the UX changes and impact of your design doc.
+(Non-exhaustive list below.)
+
+* Explore UI, CLI and API user experience by diving through common scenarios
+  that users would go through
+* Show UI, CLI and API requests/responses that the user would observe
+* Make error messages actionable, explore common failure modes and how users can
+  recover
+* Consider the UX of configuration changes and their impact on Teleport upgrades
+* Consider the UX scenarios for Cloud users


### PR DESCRIPTION
Add Security and UX sections to the canonical RFD as a reminder of the importance of those topics.