### PR TITLE
Fix make grpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -704,7 +704,7 @@ remove-temp-files:
 docker:
 	make -C build.assets build
 
-# Dockerized build: useful for making Linux binaries on OSX
+# Dockerized build: useful for making Linux binaries on macOS
 .PHONY:docker-binaries
 docker-binaries: clean
 	make -C build.assets build-binaries
@@ -714,12 +714,13 @@ docker-binaries: clean
 enter:
 	make -C build.assets enter
 
-# grpc generates GRPC stubs from service definitions
+# grpc generates GRPC stubs from service definitions.
+# This target runs in the buildbox container.
 .PHONY: grpc
 grpc:
 	$(MAKE) -C build.assets grpc
 
-# buildbox-grpc generates GRPC stubs inside buildbox
+# buildbox-grpc generates GRPC stubs
 .PHONY: buildbox-grpc
 buildbox-grpc:
 # standard GRPC output

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -119,8 +119,9 @@ ENV GOGOPROTO_ROOT ${GOPATH}/src/github.com/gogo/protobuf
 
 RUN (curl -L -o /tmp/${PROTOC_TARBALL} https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VER}/${PROTOC_TARBALL} && \
      cd /tmp && unzip /tmp/${PROTOC_TARBALL} -d /usr/local && \
+     chmod -R a+r /usr/local/include/google/protobuf && \
      rm /tmp/${PROTOC_TARBALL})
-RUN (git clone https://github.com/gogo/protobuf.git ${GOPATH}/src/github.com/gogo/protobuf && go install golang.org/x/tools/cmd/goimports@latest && \
+RUN (git clone https://github.com/gogo/protobuf.git ${GOPATH}/src/github.com/gogo/protobuf && \
      cd ${GOPATH}/src/github.com/gogo/protobuf && \
      git reset --hard ${GOGO_PROTO_TAG} && \
      make install)
@@ -145,6 +146,8 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN mkdir -p $RUSTUP_HOME && chmod a+w $RUSTUP_HOME && \
     mkdir -p $CARGO_HOME/registry && chmod -R a+w $CARGO_HOME
 
+# Install Rust using the ci user, as that is the user that
+# will run builds using the Rust toolchains we install here.
 USER ci
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION && \
     rustup --version && \
@@ -156,5 +159,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
     rustup target add aarch64-unknown-linux-gnu && \
     cargo install cbindgen
 
+USER root
 VOLUME ["/go/src/github.com/gravitational/teleport"]
 EXPOSE 6600 2379 2380

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -207,7 +207,7 @@ buildbox-arm-fips: buildbox-fips
 		--cache-from $(BUILDBOX_ARM_FIPS) \
 		--tag $(BUILDBOX_ARM_FIPS) -f Dockerfile-arm-fips .
 
-# grpc generates GRPC stubs from service definitions
+# grpc generates GRPC stubs from inside the buildbox
 .PHONY: grpc
 grpc: buildbox
 	docker run --platform=linux/amd64 \


### PR DESCRIPTION
- Ensure that the protoc include directory is readable by all users
- Switch back to the root user by default

Either of these changes would have fixed the issue on their own,
but I decided to include both as GRPC should be readable by non-root
users, and I wanted to preserve the original behavior of running
as root unless the $(NOROOT) flags are specified.

Additionally: clarify comments on the make targets, which are
confusingly named, and stop installing goimports since it seems
it was never used.