### PR TITLE
Prevent infinite dialing to Auth

### DIFF
--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -119,6 +119,10 @@ type HTTPClient struct {
 
 // NewHTTPClient creates a new HTTP client with TLS authentication and the given dialer.
 func NewHTTPClient(cfg client.Config, tls *tls.Config, params ...roundtrip.ClientParam) (*HTTPClient, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, err
+	}
+
 	dialer := cfg.Dialer
 	if dialer == nil {
 		if len(cfg.Addrs) == 0 {

--- a/lib/auth/clt_test.go
+++ b/lib/auth/clt_test.go
@@ -33,30 +33,47 @@ func TestClient_DialTimeout(t *testing.T) {
 	}{
 		{
 			desc:    "dial timeout set to valid value",
-			timeout: 1 * time.Second,
+			timeout: 500 * time.Millisecond,
 		},
 		{
-			desc: "defaults prevent infinite timeout",
+			desc:    "defaults prevent infinite timeout",
+			timeout: 0,
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.desc, func(t *testing.T) {
+			tt := tt
 			t.Parallel()
 
-			// create a client that will attempt to connect a blackholed address. The address is reserved
+			// create a client that will attempt to connect to a blackholed address. The address is reserved
 			// for benchmarking by RFC 6890.
-			clt, err := NewClient(apiclient.Config{
+			cfg := apiclient.Config{
 				DialTimeout: tt.timeout,
 				Addrs:       []string{"198.18.0.254:1234"},
 				Credentials: []apiclient.Credentials{
 					apiclient.LoadTLS(&tls.Config{}),
 				},
-			})
+			}
+			clt, err := NewClient(cfg)
 			require.NoError(t, err)
 
-			// try to create a session - this will timeout after the DialTimeout threshold is exceeded
-			require.Error(t, clt.CreateSession(session.Session{Namespace: "test"}))
+			// call this so that the DialTimeout gets updated, if necessary, so that we know how long to
+			// wait before failing this test
+			require.NoError(t, cfg.CheckAndSetDefaults())
+
+			errChan := make(chan error, 1)
+			go func() {
+				// try to create a session - this will timeout after the DialTimeout threshold is exceeded
+				errChan <- clt.CreateSession(session.Session{Namespace: "test"})
+			}()
+
+			select {
+			case err := <-errChan:
+				require.Error(t, err)
+			case <-time.After(cfg.DialTimeout + (cfg.DialTimeout / 2)):
+				t.Fatal("Timed out waiting for dial to complete")
+			}
 		})
 	}
 }

--- a/lib/auth/clt_test.go
+++ b/lib/auth/clt_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_DialTimeout(t *testing.T) {
+	cases := []struct {
+		desc    string
+		timeout time.Duration
+	}{
+		{
+			desc:    "dial timeout set to valid value",
+			timeout: 1 * time.Second,
+		},
+		{
+			desc: "defaults prevent infinite timeout",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			// create a client that will attempt to connect a blackholed address. The address is reserved
+			// for benchmarking by RFC 6890.
+			clt, err := NewClient(apiclient.Config{
+				DialTimeout: tt.timeout,
+				Addrs:       []string{"198.18.0.254:1234"},
+				Credentials: []apiclient.Credentials{
+					apiclient.LoadTLS(&tls.Config{}),
+				},
+			})
+			require.NoError(t, err)
+
+			// try to create a session - this will timeout after the DialTimeout threshold is exceeded
+			require.Error(t, clt.CreateSession(session.Session{Namespace: "test"}))
+		})
+	}
+}


### PR DESCRIPTION
`NewHTTPClient` was not calling `CheckAndSetDefault` on the provided `client.Config` which
allowed the `DialTimeout` to be 0. This allowed dialing auth to hang forever if
auth is unreachable.

Fixes #8866