### PR TITLE
scaling improvements

### DIFF
--- a/lib/backend/defaults.go
+++ b/lib/backend/defaults.go
@@ -30,7 +30,7 @@ const (
 	DefaultPollStreamPeriod = time.Second
 	// DefaultEventsTTL is a default events TTL period
 	DefaultEventsTTL = 10 * time.Minute
-	// DefaultLargeLimit is used to specify some very large limit when limit is not specified
-	// explicitly to prevent OOM
-	DefaultLargeLimit = 30000
+	// DefaultRangeLimit is used to specify some very large limit when limit is not specified
+	// explicitly to prevent OOM due to infinite loops or other issues along those lines.
+	DefaultRangeLimit = 200_000
 )

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -357,7 +357,7 @@ func (b *Backend) getRangeDocs(ctx context.Context, startKey []byte, endKey []by
 		return nil, trace.BadParameter("missing parameter endKey")
 	}
 	if limit <= 0 {
-		limit = backend.DefaultLargeLimit
+		limit = backend.DefaultRangeLimit
 	}
 	docs, err := b.svc.Collection(b.CollectionName).
 		Where(keyDocProperty, ">=", startKey).
@@ -375,7 +375,12 @@ func (b *Backend) getRangeDocs(ctx context.Context, startKey []byte, endKey []by
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return append(docs, legacyDocs...), nil
+
+	allDocs := append(docs, legacyDocs...)
+	if len(allDocs) >= backend.DefaultRangeLimit {
+		b.Warnf("Range query hit backend limit. (this is a bug!) startKey=%q,limit=%d", startKey, backend.DefaultRangeLimit)
+	}
+	return allDocs, nil
 }
 
 // GetRange returns range of elements
@@ -406,7 +411,7 @@ func (b *Backend) GetRange(ctx context.Context, startKey []byte, endKey []byte, 
 
 // DeleteRange deletes range of items with keys between startKey and endKey
 func (b *Backend) DeleteRange(ctx context.Context, startKey, endKey []byte) error {
-	docSnaps, err := b.getRangeDocs(ctx, startKey, endKey, backend.DefaultLargeLimit)
+	docSnaps, err := b.getRangeDocs(ctx, startKey, endKey, backend.DefaultRangeLimit)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -610,7 +610,7 @@ func (l *Backend) GetRange(ctx context.Context, startKey []byte, endKey []byte, 
 		return nil, trace.BadParameter("missing parameter endKey")
 	}
 	if limit <= 0 {
-		limit = backend.DefaultLargeLimit
+		limit = backend.DefaultRangeLimit
 	}
 
 	// When in mirror mode, don't set the current time so the SELECT query
@@ -646,6 +646,9 @@ func (l *Backend) GetRange(ctx context.Context, startKey []byte, endKey []byte, 
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
+	}
+	if len(result.Items) == backend.DefaultRangeLimit {
+		l.Warnf("Range query hit backend limit. (this is a bug!) startKey=%q,limit=%d", startKey, backend.DefaultRangeLimit)
 	}
 	return &result, nil
 }

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -324,12 +324,15 @@ func (m *Memory) GetRange(ctx context.Context, startKey []byte, endKey []byte, l
 		return nil, trace.BadParameter("missing parameter endKey")
 	}
 	if limit <= 0 {
-		limit = backend.DefaultLargeLimit
+		limit = backend.DefaultRangeLimit
 	}
 	m.Lock()
 	defer m.Unlock()
 	m.removeExpired()
 	re := m.getRange(ctx, startKey, endKey, limit)
+	if len(re.Items) == backend.DefaultRangeLimit {
+		m.Warnf("Range query hit backend limit. (this is a bug!) startKey=%q,limit=%d", startKey, backend.DefaultRangeLimit)
+	}
 	return &re, nil
 }
 

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -350,7 +350,7 @@ type Cache struct {
 	webSessionCache      types.WebSessionInterface
 	webTokenCache        types.WebTokenInterface
 	windowsDesktopsCache services.WindowsDesktops
-	eventsFanout         *services.Fanout
+	eventsFanout         *services.FanoutSet
 
 	// closed indicates that the cache has been closed
 	closed *atomic.Bool
@@ -624,7 +624,7 @@ func New(config Config) (*Cache, error) {
 		webSessionCache:      local.NewIdentityService(wrapper).WebSessions(),
 		webTokenCache:        local.NewIdentityService(wrapper).WebTokens(),
 		windowsDesktopsCache: local.NewWindowsDesktopService(wrapper),
-		eventsFanout:         services.NewFanout(),
+		eventsFanout:         services.NewFanoutSet(),
 		Entry: log.WithFields(log.Fields{
 			trace.Component: config.Component,
 		}),

--- a/lib/services/fanout.go
+++ b/lib/services/fanout.go
@@ -23,6 +23,8 @@ import (
 	"github.com/gravitational/teleport/api/types"
 
 	"github.com/gravitational/trace"
+
+	"go.uber.org/atomic"
 )
 
 const defaultQueueSize = 64
@@ -201,7 +203,7 @@ func (f *Fanout) Emit(events ...types.Event) {
 func (f *Fanout) Reset() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.closeWatchers()
+	f.closeWatchersAsync()
 	f.init = false
 }
 
@@ -210,19 +212,31 @@ func (f *Fanout) Reset() {
 func (f *Fanout) Close() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.closeWatchers()
+	f.closeWatchersAsync()
 	f.closed = true
 }
 
-func (f *Fanout) closeWatchers() {
-	for _, entries := range f.watchers {
-		for _, entry := range entries {
-			entry.watcher.cancel()
-		}
-	}
-	// watcher map was potentially quite large, so
-	// relenguish that memory.
+// closeWatchersAsync moves ownership of the watcher mapping to a background goroutine
+// for asynchronous cancellation and sets up a new empty mapping.
+func (f *Fanout) closeWatchersAsync() {
+	watchersToClose := f.watchers
 	f.watchers = make(map[string][]fanoutEntry)
+	// goroutines run with a "happens after" releationship to the
+	// expressions that create them.  since we move ownership of the
+	// old watcher mapping prior to spawning this goroutine, we are
+	// "safe" to modify it without worrying about locking.  because
+	// we don't continue to hold the lock in the foreground goroutine,
+	// this fanout instance may permit new events/registrations/inits/resets
+	// while the old watchers are still being closed.  this is fine, since
+	// the aformentioned move guarantees that these old watchers aren't
+	// going to observe any of the new state transitions.
+	go func() {
+		for _, entries := range watchersToClose {
+			for _, entry := range entries {
+				entry.watcher.cancel()
+			}
+		}
+	}()
 }
 
 func (f *Fanout) addWatcher(w *fanoutWatcher) {
@@ -352,5 +366,88 @@ func (w *fanoutWatcher) Error() error {
 		return trace.Errorf("watcher closed")
 	default:
 		return nil
+	}
+}
+
+// fanoutSetSize is the number of members in a fanout set.  selected based on some experimentation with
+// the FanoutSetRegistration benchmark.  This value keeps 100K concurrent registrations well under 1s.
+const fanoutSetSize = 128
+
+// FanoutSet is a collection of separate Fanout instances. It exposes an identical API, and "load balances"
+// watcher registration across the enclosed instances. In very large clusters it is possible for tens of
+// thousands of nodes to simultaneously request watchers. This can cause serious contention issues. FanoutSet is
+// a simple but effective solution to that problem.
+type FanoutSet struct {
+	// rw mutex is used to ensure that Close and Reset operations are exclusive,
+	// since these operations close watchers. Enforcing this property isn't strictly
+	// necessary, but it prevents a scenario where watchers might observe a reset/close,
+	// attempt re-registration, and observe the *same* reset/close again. This isn't
+	// necessarily a problem, but it might confuse attempts to debug other event-system
+	// issues, so we choose to avoid it.
+	rw      sync.RWMutex
+	counter *atomic.Uint64
+	members []*Fanout
+}
+
+// NewFanoutSet creates a new FanoutSet instance in an uninitialized
+// state.  Until initialized, watchers will be queued but no
+// events will be sent.
+func NewFanoutSet() *FanoutSet {
+	members := make([]*Fanout, 0, fanoutSetSize)
+	for i := 0; i < fanoutSetSize; i++ {
+		members = append(members, NewFanout())
+	}
+	return &FanoutSet{
+		counter: atomic.NewUint64(0),
+		members: members,
+	}
+}
+
+// NewWatcher attaches a new watcher to a fanout instance.
+func (s *FanoutSet) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
+	s.rw.RLock() // see field-level docks for locking model
+	defer s.rw.RUnlock()
+	fi := int(s.counter.Inc() % uint64(len(s.members)))
+	return s.members[fi].NewWatcher(ctx, watch)
+}
+
+// SetInit sets the Fanout instances into an initialized state, sending OpInit
+// events to any watchers which were added prior to initialization.
+func (s *FanoutSet) SetInit() {
+	s.rw.RLock() // see field-level docks for locking model
+	defer s.rw.RUnlock()
+	for _, f := range s.members {
+		f.SetInit()
+	}
+}
+
+// Emit broadcasts events to all matching watchers that have been attached
+// to this fanout set.
+func (s *FanoutSet) Emit(events ...types.Event) {
+	s.rw.RLock() // see field-level docks for locking model
+	defer s.rw.RUnlock()
+	for _, f := range s.members {
+		f.Emit(events...)
+	}
+}
+
+// Reset closes all attached watchers and places the fanout instances
+// into an uninitialized state.  Reset may be called on an uninitialized
+// fanout set to remove "queued" watchers.
+func (s *FanoutSet) Reset() {
+	s.rw.Lock() // see field-level docks for locking model
+	defer s.rw.Unlock()
+	for _, f := range s.members {
+		f.Reset()
+	}
+}
+
+// Close permanently closes the fanout.  Existing watchers will be
+// closed and no new watchers will be added.
+func (s *FanoutSet) Close() {
+	s.rw.Lock() // see field-level docks for locking model
+	defer s.rw.Unlock()
+	for _, f := range s.members {
+		f.Close()
 	}
 }

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -110,7 +110,7 @@ func newResourceWatcher(ctx context.Context, collector resourceCollector, cfg Re
 		cancel:                cancel,
 		retry:                 retry,
 		LoopC:                 make(chan struct{}),
-		ResetC:                make(chan struct{}),
+		ResetC:                make(chan struct{}, 1),
 		StaleC:                make(chan struct{}, 1),
 	}
 	go p.runWatchLoop()

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -120,7 +120,15 @@ func TestMonitorStaleLocks(t *testing.T) {
 	default:
 		t.Fatal("No staleness event should be scheduled yet. This is a bug in the test.")
 	}
+
+	// ensure ResetC is drained
+	select {
+	case <-asrv.LockWatcher.ResetC:
+	default:
+	}
 	go asrv.Backend.CloseWatchers()
+
+	// wait for reset
 	select {
 	case <-asrv.LockWatcher.ResetC:
 	case <-time.After(2 * time.Second):


### PR DESCRIPTION
This PR contains a collection of small changes addressing performance issues when running very large teleport clusters.  While our current loadtesting only goes up to 10k (increasing soon!), some heroic pioneers have been pushing their teleport clusters to 30k and beyond.  The fixes here are intended to address some of the issues that have been observed at those scales:

- Improved performance for `Cache.ListNodes`: Recent improvements in the form of server-side filtering were mostly regressed by a very sub-optimal change I made when implementing TTL-based fallback caching, which used the `GetNodes` implementation to emulate fake pagination in the cache.  This was causing a lot of unnecessary deserialization that was slowing things down.  Updated the method to only fallback when the cache was actually unhealthy, and use "true" pagination the rest of the time.  Also added benchmarks to better confirm `Cache.ListNodes` performance at scale.
- Improved concurrent watcher registration: pprof profile dumps from a cluster running >30K nodes identified a serious contention problem with the mutex for `services.Fanout`, which needs to be acquired each time a node registers a watcher.  A "feedback loop", caused by fanout registration taking longer than the `NewWatcher` timeout, was identified as the likely culprit of some serious perf issues.  A "sharding" strategy was used, replacing the monolithic fanout instance with a collection of identical instances with new watchers being inserted round-robin.  Benchmarks were added that both validated the contention issue, and demonstrated significant improvements with the addition of sharding (102s -> 0.4s for 100k concurrent registrations).
- Bumped the hard limit on the size of backend range requests from 30k to 200k, and added warnings that now clearly indicate when a range request is hitting this limit (previously 30K limit was being silently enforced, with confusing results).