### PR TITLE
Tweak LDAPS troubleshooting docs

### DIFF
--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -163,11 +163,14 @@ connecting to LDAP server: unable to read LDAP response packet: read tcp 172.18.
 
 **Solution:**  Enable LDAPS
 
-This means you do not have an LDAP certificate installed on your LDAP servers.
-You can resolve this by
-[installing Active Directory Certificate Services](https://docs.microsoft.com/en-us/windows-server/networking/core-network-guide/cncg/server-certs/install-the-certification-authority)
+This means you do not have an LDAP certificate installed on your LDAP servers,
+or you are trying to make an insecure connection on port 389. Teleport requires
+secure LDAPS connections, which are typically on port 636. First, confirm that
+you are connecting to the correct LDAPS port. If that doesn't resolve your
+issue, you can
+[instal Active Directory Certificate Services](https://docs.microsoft.com/en-us/windows-server/networking/core-network-guide/cncg/server-certs/install-the-certification-authority)
 (AD CS) or
-[importing](https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/enable-ldap-over-ssl-3rd-certification-authority)
+[import](https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/enable-ldap-over-ssl-3rd-certification-authority)
 your own third party certificate. Note that Active Directory is
 [extremely picky](https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/enable-ldap-over-ssl-3rd-certification-authority#requirements-for-an-ldaps-certificate)
 so take care to generate your certificates correctly.


### PR DESCRIPTION
Make it clear that an LDAP connection reset can be due to attempting to connect on port 389 (which is what our original instructions advised)