### PR TITLE
Fix app server goroutine leak

### DIFF
--- a/lib/httplib/connstate.go
+++ b/lib/httplib/connstate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Gravitational, Inc.
+Copyright 2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/httplib/connstate.go
+++ b/lib/httplib/connstate.go
@@ -1,0 +1,221 @@
+package httplib
+
+import (
+	"net"
+	"net/http"
+	"sync"
+)
+
+// AllConnStates indicates a subscription to all http.ConnState events
+// in ConnStateEvents and ServerConnState. Pass to the Notify
+// function of each to subscribe to all events.
+const AllConnStates = -1
+
+// TerminalConnState returns true when state is terminal.
+func TerminalConnState(state http.ConnState) bool {
+	return state == http.StateHijacked || state == http.StateClosed
+}
+
+// ServerConnState tracks connection state for HTTP server connections.
+// Its Notify method implements the http.Server.ConnState function
+// which should be attached to the Server instance to initiate tracking.
+// Calling Channel and passing a connection will return a chan that
+// receives state change events.
+//
+// All net.Conn instances passed to this type must be comparable or calls
+// will panic. The net.Conn instances passed by http.Server such as *tls.Conn
+// are comparable.
+//
+//    server := http.Server{...}
+//    connState := NewServerConnState()
+//    server.ConnState = connState.Notify
+//    ...
+//    tlsConn := tls.Server(...)
+//    listener := listener.Wrap(tlsConn) // fake listener to pass to Serve
+//    ch := connState.Channel(tlsConn, http.StateClosed)
+//    server.Serve(listener)
+//    <-ch // releases once tlsConn is closed
+type ServerConnState struct {
+	mu sync.Mutex
+
+	// conns tracks open connection state. A ConnStateEvents is created
+	// for each connection, which processes notifications for subscribers
+	// of that connection.
+	//
+	// NOTE: using net.Conn as a map key is not safe if someone creates
+	// a net.Conn using a concrete type that is not comparable. net.Conn
+	// is stateful, so implementations should be comparable. Using net.Conn
+	// simplified the implementation and allows for this functionality to
+	// be extended, at the expense of strange implementations that will
+	// panic on the first test.
+	conns map[net.Conn]*ConnStateEvents
+}
+
+// NewServerConnState returns an initialized ServerConnState.
+func NewServerConnState() *ServerConnState {
+	return &ServerConnState{conns: make(map[net.Conn]*ConnStateEvents)}
+}
+
+// Notify subscribers of a connection state change.
+// Terminal states remove the connection from tracking.
+//
+// Notify implements http.Server.ConnState.
+func (s *ServerConnState) Notify(conn net.Conn, state http.ConnState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	c, ok := s.conns[conn]
+	if TerminalConnState(state) {
+		delete(s.conns, conn)
+	} else if !ok {
+		s.conns[conn] = nil
+	}
+
+	if c != nil {
+		c.Notify(state)
+	}
+}
+
+// Channel returns a read-only channel that will receive http.ConnState
+// events for conn. The state parameter determines which states are
+// received by the channel. The channel will receive all events when state
+// is AllConnStates. All channels will receive terminal states (http.StateClosed
+// & http.StateHijacked) events after which the channel is closed. Multiple
+// calls for the same connection are supported.
+//
+// Passing a closed connection will result in no events received and leak
+// both the conn and channel unless followed by a Release call.
+//
+// Calling Channel when conn is already in the desired state will result
+// in no events until the connection moves to a different state and back
+// again (e.g. idle->active->idle).
+func (s *ServerConnState) Channel(conn net.Conn, state http.ConnState) <-chan http.ConnState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c := s.conns[conn]
+	if c == nil {
+		c = NewConnStateEvents()
+		s.conns[conn] = c
+	}
+	return c.Channel(state)
+}
+
+// Release resources for conn when something goes wrong after calling
+// Channel and before http.Serve registers conn to trigger events. This
+// will remove net.Conn state. This method is only required if http.Serve
+// returns an error because state is removed when connections enter a
+// terminal state.
+//
+// The conn will be tracked again, without previously registered
+// subscriptions, if it is passed to Notify after calling Release.
+func (s *ServerConnState) Release(conn net.Conn) {
+	s.mu.Lock()
+	c := s.conns[conn]
+	delete(s.conns, conn)
+	s.mu.Unlock()
+
+	if c != nil {
+		c.Stop()
+	}
+}
+
+// ConnStateEvents tracks connection state for a single connection.
+// This type is created by ServerConnState for each distinct connection.
+type ConnStateEvents struct {
+	events chan interface{}
+}
+
+// NewConnStateEvents returns an initialized ConnStateEvents.
+func NewConnStateEvents() *ConnStateEvents {
+	c := &ConnStateEvents{events: make(chan interface{}, connStateEventsQueueSize)}
+	go c.processEvents()
+	return c
+}
+
+// Notify state change.
+func (c *ConnStateEvents) Notify(state http.ConnState) {
+	c.events <- state
+}
+
+// Channel returns a read-only channel that will receive http.ConnState events.
+// The state parameter determines which states are received by the channel.
+// The channel will receive all events when state is AllConnStates. All channels
+// will receive terminal states (http.StateClosed & http.StateHijacked) events
+// after which the channel is closed. Multiple calls are supported.
+//
+// Passing a closed connection will result in no events received and leak
+// the channel unless followed by a Stop call.
+//
+// Calling Channel when already in the desired state will result
+// in no events until state moves to a different state and back
+// again (e.g. idle->active->idle).
+func (c *ConnStateEvents) Channel(state http.ConnState) <-chan http.ConnState {
+	// chan buffer=1: assume channel is being serviced, but don't sync with reader
+	ch := make(chan http.ConnState, 1)
+	c.events <- connStateChannel{state: state, ch: ch}
+	return ch
+}
+
+// Stop receiving events and close all subscriber channels.
+func (c *ConnStateEvents) Stop() {
+	c.events <- connStateStop{}
+}
+
+// processEvents is the core goroutine that runs for each instance.
+// It serializes all events: channel subscriptions, state change events,
+// and stop requests. It exits when it receives a connStateStop message,
+// which can be accomplished by calling Stop.
+func (c *ConnStateEvents) processEvents() {
+	var channels []connStateChannel
+	for event := range c.events {
+		switch v := event.(type) {
+		case connStateChannel:
+			channels = append(channels, v)
+		case http.ConnState:
+			c.notify(channels, v)
+			if TerminalConnState(v) {
+				return
+			}
+		case connStateStop:
+			for _, channel := range channels {
+				close(channel.ch)
+			}
+			return
+		}
+	}
+}
+
+// notify channels of new state & close channels when state is terminal.
+// notify is called from processEvents.
+func (c *ConnStateEvents) notify(channels []connStateChannel, state http.ConnState) {
+	if TerminalConnState(state) {
+		for _, channel := range channels {
+			channel.ch <- state
+			close(channel.ch)
+		}
+		return
+	}
+
+	for _, channel := range channels {
+		if state == channel.state || channel.state == AllConnStates {
+			channel.ch <- state
+		}
+	}
+}
+
+// connStateChannel is a message passed to ConnStateEvents.processEvents
+// from ConnStateEvents.Channel to subscribe to new events.
+type connStateChannel struct {
+	state http.ConnState
+	ch    chan http.ConnState
+}
+
+// connStateStop is a message passed to ConnStateEvents.processEvents
+// from ConnStateEvents.Stop to stop emitting events.
+type connStateStop struct{}
+
+// connStateEventsQueueSize sets the channel buffer size for ConnStateEvents.
+// Connections do not change state very quickly and it is assumed (and documented)
+// that subscriber channels will be serviced quickly, so this value should not
+// have to be very big.
+const connStateEventsQueueSize = 8

--- a/lib/httplib/connstate.go
+++ b/lib/httplib/connstate.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package httplib
 
 import (

--- a/lib/httplib/connstate_test.go
+++ b/lib/httplib/connstate_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Gravitational, Inc.
+Copyright 2021 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/httplib/connstate_test.go
+++ b/lib/httplib/connstate_test.go
@@ -1,0 +1,162 @@
+package httplib
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestConnStateEvents(t *testing.T) {
+	t.Parallel()
+	t.Run("Notify non-terminal states", func(t *testing.T) {
+		c := NewConnStateEvents()
+		ch := c.Channel(AllConnStates)
+		states := []http.ConnState{http.StateNew, http.StateActive, http.StateIdle, http.StateActive}
+		for _, state := range states {
+			c.Notify(state)
+		}
+		for i, expect := range states {
+			got, more := <-ch
+			if expect != got {
+				t.Errorf("[%d] expected %s got %s", i, expect, got)
+			} else if !more {
+				t.Error("expected channel to be open")
+			}
+		}
+	})
+	t.Run("Notify terminal state", func(t *testing.T) {
+		states := []http.ConnState{http.StateHijacked, http.StateClosed}
+		for i, state := range states {
+			c := NewConnStateEvents()
+			ch := c.Channel(state)
+			c.Notify(http.StateIdle) // should be ignored
+			c.Notify(state)
+			got, more := <-ch
+			if got != state {
+				t.Errorf("[%d] expected %s got %s", i, state, got)
+			} else if !more {
+				t.Error("expected channel to be open")
+			}
+			got, more = <-ch
+			if got != 0 {
+				t.Errorf("[%d] expected zero value got %s", i, got)
+			} else if more {
+				t.Error("expected channel to be closed")
+			}
+		}
+	})
+	t.Run("Stop", func(t *testing.T) {
+		c := NewConnStateEvents()
+		ch := c.Channel(http.StateActive)
+		c.Stop()
+		got, more := <-ch
+		if got != 0 {
+			t.Errorf("expected zero value got %s", got)
+		} else if more {
+			t.Error("expected channel to be closed")
+		}
+	})
+	t.Run("Notify new conn", func(t *testing.T) {
+		c := NewServerConnState()
+		conn := new(noopConn)
+		c.Notify(conn, http.StateNew)
+		expect := http.StateActive
+		ch := c.Channel(conn, expect)
+		c.Notify(conn, http.StateActive)
+		got, more := <-ch
+		if got != expect {
+			t.Errorf("expected %s got %s", expect, got)
+		} else if !more {
+			t.Error("expected channel to be open")
+		}
+
+	})
+}
+
+func TestServerConnState(t *testing.T) {
+	t.Parallel()
+	t.Run("Multiple connections", func(t *testing.T) {
+		c := NewServerConnState()
+		connA := new(noopConn)
+		connB := new(noopConn)
+		chA := c.Channel(connA, AllConnStates)
+		chB := c.Channel(connB, http.StateClosed)
+		chA2 := c.Channel(connA, http.StateIdle)
+		c.Notify(connA, http.StateActive)
+		c.Notify(connB, http.StateClosed)
+		c.Notify(connA, http.StateIdle)
+		c.Notify(connA, http.StateHijacked)
+
+		// chA
+		expected := []http.ConnState{http.StateActive, http.StateIdle, http.StateHijacked}
+		for i, expect := range expected {
+			got, more := <-chA
+			if got != expect {
+				t.Errorf("[%d] chA expected %s got %s", i, expect, got)
+			} else if !more {
+				t.Errorf("[%d] chA expected more", i)
+			}
+		}
+
+		// chA2
+		expected = []http.ConnState{http.StateIdle, http.StateHijacked}
+		for i, expect := range expected {
+			got, more := <-chA2
+			if got != expect {
+				t.Errorf("[%d] chA expected %s got %s", i, expect, got)
+			} else if !more {
+				t.Errorf("[%d] chA expected more", i)
+			}
+		}
+
+		// chB
+		expect := http.StateClosed
+		got, more := <-chB
+		if got != expect {
+			t.Errorf("chB expected %s got %s", expect, got)
+		} else if !more {
+			t.Error("chB expected more")
+		}
+
+		// all channels should be closed
+		channels := []<-chan http.ConnState{chA, chB, chA2}
+		names := []string{"chA", "chB", "chA2"}
+		for i, channel := range channels {
+			got, more = <-channel
+			if got != 0 {
+				t.Errorf("%s expected zero value got %s", names[i], got)
+			} else if more {
+				t.Errorf("%s expected to be closed", names[i])
+			}
+		}
+	})
+	t.Run("Release", func(t *testing.T) {
+		c := NewServerConnState()
+		conn := new(noopConn)
+		ch := c.Channel(conn, AllConnStates)
+		c.Release(conn)
+		got, more := <-ch
+		if got != 0 {
+			t.Errorf("expected zero value got %s", got)
+		} else if more {
+			t.Error("expected channel to be closed")
+		}
+	})
+}
+
+type noopConn struct {
+	// need a single field prevents compiler optimization
+	// when creating multiple noopConns (compiler uses a single
+	// instance when creating new instances of a zero field struct)
+	_ int
+}
+
+func (noopConn) Read(b []byte) (n int, err error)   { return 0, nil }
+func (noopConn) Write(b []byte) (n int, err error)  { return 0, nil }
+func (noopConn) Close() error                       { return nil }
+func (noopConn) LocalAddr() net.Addr                { return nil }
+func (noopConn) RemoteAddr() net.Addr               { return nil }
+func (noopConn) SetDeadline(t time.Time) error      { return nil }
+func (noopConn) SetReadDeadline(t time.Time) error  { return nil }
+func (noopConn) SetWriteDeadline(t time.Time) error { return nil }

--- a/lib/httplib/connstate_test.go
+++ b/lib/httplib/connstate_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package httplib
 
 import (

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -569,7 +569,9 @@ func (s *Server) HandleConnection(conn net.Conn) {
 		return
 	}
 
-	// block until conn or Server is closed
+	// The reversetunnel transport calls this function and closes its
+	// SSH channel once we return. So we need to block until tlsConn
+	// or Server is closed.
 	select {
 	case <-s.closeContext.Done():
 	case <-closeCh:

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -255,10 +255,6 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	// Register handler that monitors tls connection state changes.
-	// This is used by HandleConnection to detect closed connections.
-	s.httpServer.ConnState = s.httpConnState.Notify
-
 	// Create a new session cache, this holds sessions that can be used to
 	// forward requests.
 	s.cache, err = newSessionCache(s.closeContext, s.log)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -722,6 +722,7 @@ func (s *Server) newHTTPServer() *http.Server {
 		Handler:           authMiddleware,
 		ReadHeaderTimeout: apidefaults.DefaultDialTimeout,
 		ErrorLog:          utils.NewStdlogger(s.log.Error, teleport.ComponentApp),
+		ConnState:         s.httpConnState.Notify,
 	}
 }
 

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -569,10 +569,8 @@ func (s *Suite) checkHTTPResponse(t *testing.T, clientCert tls.Certificate, chec
 	checkResp(resp)
 	require.NoError(t, resp.Body.Close())
 
-	// Context will close because of the net.Pipe, expect a context canceled
-	// error here.
-	err = s.appServer.Close()
-	require.NotNil(t, err)
+	// Close should not trigger an error.
+	require.NoError(t, s.appServer.Close())
 
 	// Wait for the application server to actually stop serving before
 	// closing the test. This will make sure the server removes the listeners


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport-private/issues/79
LAT-APP21-4: DOS - Goroutine leak in app server
    
Change app server listener.Accept method to return an error the second time it is called. This will trigger the http.Serve function to exit gracefully rather than block until the server is closed.

This also changes the checkHTTPResponse server test. Closing the server in the test no longer produces a context canceled error because that error was coming from the blocked listener when the server called listener.Close.

This change uses the new ServerConnState type in httplib that tracks connection state for an http.Server instance. This is used to wait for the connection to close before returning from HandleConnection.
