### PR TITLE
Fix CheckAndSetDefaults for UserTokenSecretsV3

### DIFF
--- a/api/types/usertokensecrets.go
+++ b/api/types/usertokensecrets.go
@@ -146,7 +146,7 @@ func (u *UserTokenSecretsV3) setStaticFields() {
 }
 
 // CheckAndSetDefaults checks and set default values for any missing fields.
-func (u UserTokenSecretsV3) CheckAndSetDefaults() error {
+func (u *UserTokenSecretsV3) CheckAndSetDefaults() error {
 	u.setStaticFields()
 	if err := u.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Since `CheckAndSetDefaults` mutates the receiver, we need a pointer receiver.