### PR TITLE
Correct Dismiss Function Spelling.

### DIFF
--- a/.github/workflows/robot/internal/bot/dismiss.go
+++ b/.github/workflows/robot/internal/bot/dismiss.go
@@ -32,7 +32,7 @@ import (
 //
 // This is needed because GitHub appends each "Check" workflow run to the status
 // of a PR instead of replacing the "Check" status of the previous run.
-func (b *Bot) Dimiss(ctx context.Context) error {
+func (b *Bot) Dismiss(ctx context.Context) error {
 	pulls, err := b.c.GitHub.ListPullRequests(ctx,
 		b.c.Environment.Organization,
 		b.c.Environment.Repository,

--- a/.github/workflows/robot/main.go
+++ b/.github/workflows/robot/main.go
@@ -57,7 +57,7 @@ func main() {
 	case "check":
 		err = b.Check(ctx)
 	case "dismiss":
-		err = b.Dimiss(ctx)
+		err = b.Dismiss(ctx)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", workflow)
 	}


### PR DESCRIPTION
Changes `Dimiss(...)` to `Dismiss(...)`.