### PR TITLE
Check If PR Is From A Fork Before Dismissing Stale Runs.

### DIFF
--- a/.github/workflows/robot/internal/bot/dismiss.go
+++ b/.github/workflows/robot/internal/bot/dismiss.go
@@ -42,11 +42,17 @@ func (b *Bot) Dimiss(ctx context.Context) error {
 	}
 
 	for _, pull := range pulls {
-		// HEAD could be controlled by an attacker, however, all this would allow is
-		// the attacker to dismiss a workflow run.
-		if err := b.dismiss(ctx, b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHead); err != nil {
-			log.Printf("Failed to dismiss workflow: %v %v %v: %v.", b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHead, err)
-			continue
+		// Only dismiss stale runs from forks (external) as the workflow that triggers
+		// this method is intended for. Dismissing runs for internal contributors
+		// (non-fork) here could result in a race condition as runs are deleted upon
+		// trigger separately during the `Check` workflow.
+		if pull.Fork {
+			// HEAD could be controlled by an attacker, however, all this would allow is
+			// the attacker to dismiss a workflow run.
+			if err := b.dismiss(ctx, b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHead); err != nil {
+				log.Printf("Failed to dismiss workflow: %v %v %v: %v.", b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHead, err)
+				continue
+			}
 		}
 	}
 

--- a/.github/workflows/robot/internal/github/github.go
+++ b/.github/workflows/robot/internal/github/github.go
@@ -145,6 +145,8 @@ type PullRequest struct {
 	// UnsafeHead is the name of the branch this PR is created from. It is marked
 	// unsafe as it can be attacker controlled.
 	UnsafeHead string
+	// Fork determines if the pull request is from a fork.
+	Fork bool
 }
 
 func (c *client) ListPullRequests(ctx context.Context, organization string, repository string, state string) ([]PullRequest, error) {
@@ -171,6 +173,7 @@ func (c *client) ListPullRequests(ctx context.Context, organization string, repo
 				Author:     pr.GetUser().GetLogin(),
 				Repository: repository,
 				UnsafeHead: pr.GetHead().GetRef(),
+				Fork:       pr.GetBase().GetRepo().GetFork(),
 			})
 		}
 		if resp.NextPage == 0 {


### PR DESCRIPTION
There have been a lot of pull requests where the `Check` workflow is not running and is stuck in a waiting status. I _believe_ it has to do with some race condition where either the CRON workflow or the `Check` workflow are deleting valid runs when running in parallel. Though I am not completely sure of it, this change will at least factor a potential issue out. 


