### PR TITLE
Check if HEAD Is A Fork

### DIFF
--- a/.github/workflows/robot/internal/github/github.go
+++ b/.github/workflows/robot/internal/github/github.go
@@ -173,7 +173,7 @@ func (c *client) ListPullRequests(ctx context.Context, organization string, repo
 				Author:     pr.GetUser().GetLogin(),
 				Repository: repository,
 				UnsafeHead: pr.GetHead().GetRef(),
-				Fork:       pr.GetBase().GetRepo().GetFork(),
+				Fork:       pr.GetHead().GetRepo().GetFork(),
 			})
 		}
 		if resp.NextPage == 0 {


### PR DESCRIPTION
HEAD should be checked if it's a fork, not BASE. 

Re: #9300 