### PR TITLE
Fix panic running TestIntegration/RotateChangeSigningAlg

### DIFF
--- a/lib/auth/rotate.go
+++ b/lib/auth/rotate.go
@@ -650,7 +650,7 @@ func completeRotation(clock clockwork.Clock, ca types.CertAuthority) {
 	rotation.Started = time.Time{}
 	rotation.State = types.RotationStateStandby
 	rotation.Phase = types.RotationPhaseStandby
-	rotation.LastRotated = clock.Now()
+	rotation.LastRotated = clock.Now().UTC()
 	rotation.Mode = ""
 	rotation.Schedule = types.RotationSchedule{}
 	ca.SetRotation(rotation)


### PR DESCRIPTION
Prior to this change:

```bash
go test -run "^TestIntegration/RotateChangeSigningAlg$" github.com/gravitational/teleport/integration
panic: merger not found for type:int

goroutine 2855 [running]:
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo(0xc0015f58c0)
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:662 +0xed9
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc0015f58c0, {0xc00081eaa0}, {0x33c0d40})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:113 +0x58
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func27({0xc001504d40}, {0x70})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:545 +0x226
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc001504d40, {0xc0003c5f80}, {0xc000c09238})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:139 +0x305
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func30({0x3aea080}, {0xc001ad3040})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:587 +0x8b
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc00022fdc0, {0x60c7fa0}, {0xc000c09318})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:139 +0x305
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func28({0xc000841fe0}, {0x100})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:555 +0x26
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc00093a080, {0xc001ad3100}, {0xc000394c40})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:139 +0x305
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func30({0x3a65840}, {0xc000f5f6b0})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:587 +0x8b
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc00022fd40, {0xc000c09578}, {0xc000c09570})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:139 +0x305
github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func28({0xc000d87080}, {0x30})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:555 +0x26
github.com/gogo/protobuf/proto.(*mergeInfo).merge(0xc00022f840, {0x5}, {0xc})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:139 +0x305
github.com/gogo/protobuf/proto.(*InternalMessageInfo).Merge(0x4159fd, {0x42953c8, 0xc000e0c280}, {0x42953c8, 0xc000f5f680})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/table_merge.go:50 +0xb6
github.com/gravitational/teleport/api/types.(*CertAuthorityV2).XXX_Merge(0x3ad9340, {0x42953c8, 0xc000f5f680})
	/home/tim/teleport/vendor/github.com/gravitational/teleport/api/types/types.pb.go:1832 +0x3a
github.com/gogo/protobuf/proto.Merge({0x42953c8, 0xc000e0c280}, {0x42953c8, 0xc000f5f680})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:95 +0x3f4
github.com/gogo/protobuf/proto.Clone({0x42953c8, 0xc000f5f680})
	/home/tim/teleport/vendor/github.com/gogo/protobuf/proto/clone.go:52 +0x17f
github.com/gravitational/teleport/api/types.(*CertAuthorityV2).Clone(...)
	/home/tim/teleport/vendor/github.com/gravitational/teleport/api/types/authority.go:115
github.com/gravitational/teleport/api/types.(*CertAuthorityV2).WithoutSecrets(0xc0013bf560)
	/home/tim/teleport/vendor/github.com/gravitational/teleport/api/types/authority.go:163 +0x25
github.com/gravitational/teleport/lib/services.filterEventSecrets(...)
	/home/tim/teleport/lib/services/fanout.go:120
github.com/gravitational/teleport/lib/services.(*Fanout).Emit(0xc000a4a120, {0xc001b41a98, 0x1, 0x0})
	/home/tim/teleport/lib/services/fanout.go:156 +0x16f
github.com/gravitational/teleport/lib/cache.(*Cache).processEvent(0xc000b90000, {0x42e8b50, 0xc0014a7680}, {0x0, {0x435b298, 0xc000f5f680}})
	/home/tim/teleport/lib/cache/cache.go:994 +0x1ac
github.com/gravitational/teleport/lib/cache.(*Cache).fetchAndWatch(0xc000b90000, {0x42e8b50, 0xc0014a7680}, {0x43087d8, 0xc000c3fce0}, 0xc001615720)
	/home/tim/teleport/lib/cache/cache.go:922 +0xead
github.com/gravitational/teleport/lib/cache.(*Cache).update(0xc000b90000, {0x42e8b50, 0xc0014a7680}, {0x43087d8, 0xc000c3fce0})
	/home/tim/teleport/lib/cache/cache.go:719 +0xf6
created by github.com/gravitational/teleport/lib/cache.New
	/home/tim/teleport/lib/cache/cache.go:671 +0x10c5
FAIL	github.com/gravitational/teleport/integration	0.815s
FAIL
```


After this change:
```bash
go test --count=10 -run "^TestIntegration/RotateChangeSigningAlg$" github.com/gravitational/teleport/integration
ok  	github.com/gravitational/teleport/integration	31.506s
```