### PR TITLE
Fix flaky TestWebsocketPingLoop test

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1177,10 +1177,6 @@ func (s *WebSuite) TestWebsocketPingLoop(c *C) {
 	ws, err := s.makeTerminal(s.authPack(c, "foo"))
 	c.Assert(err, IsNil)
 
-	// flush out raw event (pty texts)
-	err = s.waitForRawEvent(ws, 5*time.Second)
-	c.Assert(err, IsNil)
-
 	var numPings int
 	start := time.Now()
 	for {
@@ -1194,8 +1190,8 @@ func (s *WebSuite) TestWebsocketPingLoop(c *C) {
 		if numPings > 1 {
 			break
 		}
-		if time.Since(start) > 5*time.Second {
-			c.Fatalf("received %d ping frames within 5s of opening a socket, expected at least 2", numPings)
+		if time.Since(start) > 15*time.Second {
+			c.Fatalf("received %d ping frames within 15s of opening a socket, expected at least 2", numPings)
 		}
 	}
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1190,8 +1190,8 @@ func (s *WebSuite) TestWebsocketPingLoop(c *C) {
 		if numPings > 1 {
 			break
 		}
-		if time.Since(start) > 15*time.Second {
-			c.Fatalf("received %d ping frames within 15s of opening a socket, expected at least 2", numPings)
+		if deadline := 15 * time.Second; time.Since(start) > deadline {
+			c.Fatalf("Received %v ping frames within %v of opening a socket, expected at least 2", numPings, deadline)
 		}
 	}
 


### PR DESCRIPTION
Prior to these changes:

```bash
go test --count=5 -check.f ^TestWebsocketPingLoop$ -check.vv .
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.522s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.386s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.541s

apiserver_test.go:1198:
    c.Fatalf("received %d ping frames within 5s of opening a socket, expected at least 2", numPings)
... Error: received 1 ping frames within 5s of opening a socket, expected at least 2

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

FAIL: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop

OOPS: 0 passed, 1 FAILED
--- FAIL: TestWeb (5.94s)
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.475s

apiserver_test.go:1198:
    c.Fatalf("received %d ping frames within 5s of opening a socket, expected at least 2", numPings)
... Error: received 1 ping frames within 5s of opening a socket, expected at least 2

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

FAIL: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop

OOPS: 0 passed, 1 FAILED
--- FAIL: TestWeb (5.88s)
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.559s

apiserver_test.go:1198:
    c.Fatalf("received %d ping frames within 5s of opening a socket, expected at least 2", numPings)
... Error: received 1 ping frames within 5s of opening a socket, expected at least 2

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

FAIL: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop

OOPS: 0 passed, 1 FAILED
--- FAIL: TestWeb (5.95s)
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.398s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.383s

OK: 1 passed
FAIL
exit status 1
FAIL	github.com/gravitational/teleport/lib/web	61.032s
```

With these changes:

```bash
go test --count=10 -check.f ^TestWebsocketPingLoop$ -check.vv .
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.001s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.340s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.387s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.506s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.398s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.576s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	5.820s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.389s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.645s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.390s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.458s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	5.823s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.386s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.546s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.387s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.325s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.388s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.429s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.003s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.393s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.467s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.003s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.393s

OK: 1 passed
START: apiserver_test.go:139: WebSuite.SetUpSuite
PASS: apiserver_test.go:139: WebSuite.SetUpSuite	0.000s

START: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop
START: apiserver_test.go:152: WebSuite.SetUpTest
PASS: apiserver_test.go:152: WebSuite.SetUpTest	0.272s

START: apiserver_test.go:357: WebSuite.TearDownTest
PASS: apiserver_test.go:357: WebSuite.TearDownTest	0.002s

PASS: apiserver_test.go:1160: WebSuite.TestWebsocketPingLoop	0.392s

OK: 1 passed
PASS
ok  	github.com/gravitational/teleport/lib/web	103.875s
```