### PR TITLE
Delete extra % sign

### DIFF
--- a/docs/pages/cloud/faq.mdx
+++ b/docs/pages/cloud/faq.mdx
@@ -9,7 +9,7 @@ Yes.
 
 ## What is the cloud SLA
 
-Teleport Cloud commits to SLA of (=cloud.sla.monthly_percentage=)% of monthly uptime percentage,
+Teleport Cloud commits to SLA of (=cloud.sla.monthly_percentage=) of monthly uptime percentage,
 a maximum of (=cloud.sla.monthly_downtime=) of downtime per month.
 
 ### How does Cloud Billing work?


### PR DESCRIPTION
with the function, it renders like this, so deleted the % sign.

"Teleport Cloud commits to SLA of 99.5%% of monthly uptime percentage, a maximum of 3 hours 40 minutes of downtime per month."

Either need to merge this PR or fix in the function.