### PR TITLE
[v8] Add ability to run Postgres and Mongo proxy on separate listeners

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -254,12 +254,18 @@ type SSHProxySettings struct {
 
 // DBProxySettings contains database access specific proxy settings.
 type DBProxySettings struct {
+	// PostgresListenAddr is Postgres proxy listen address.
+	PostgresListenAddr string `json:"postgres_listen_addr,omitempty"`
 	// PostgresPublicAddr is advertised to Postgres clients.
 	PostgresPublicAddr string `json:"postgres_public_addr,omitempty"`
 	// MySQLListenAddr is MySQL proxy listen address.
 	MySQLListenAddr string `json:"mysql_listen_addr,omitempty"`
 	// MySQLPublicAddr is advertised to MySQL clients.
 	MySQLPublicAddr string `json:"mysql_public_addr,omitempty"`
+	// MongoListenAddr is Mongo proxy listen address.
+	MongoListenAddr string `json:"mongo_listen_addr,omitempty"`
+	// MongoPublicAddr is advertised to Mongo clients.
+	MongoPublicAddr string `json:"mongo_public_addr,omitempty"`
 }
 
 // AuthenticationSettings contains information about server authentication

--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -65,6 +65,9 @@ type Profile struct {
 	// MySQLProxyAddr is the host:port the MySQL proxy can be accessed at.
 	MySQLProxyAddr string `yaml:"mysql_proxy_addr,omitempty"`
 
+	// MongoProxyAddr is the host:port the Mongo proxy can be accessed at.
+	MongoProxyAddr string `yaml:"mongo_proxy_addr,omitempty"`
+
 	// Username is the Teleport username for the client.
 	Username string `yaml:"user,omitempty"`
 

--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -85,14 +85,22 @@ proxy_service:
   # MySQL proxy is listening on a separate port and needs to be enabled
   # on the proxy server.
   mysql_listen_addr: "0.0.0.0:3036"
+  # Postgres proxy is listening address. If provided proxy will use a separate listener
+  # instead of multiplexing Postgres protocol on web_listener_addr.
+  postgres_listen_addr: "0.0.0.0:5432"
+  # Mongo proxy is listening address. If provided proxy will use a separate listener
+  # instead of multiplexing Mongo protocol on web_listener_addr.
+  mongo_listen_addr: "0.0.0.0:27017"
   # By default database clients will be connecting to the Proxy over this
   # hostname. To override public address for specific database protocols
   # use postgres_public_addr and mysql_public_addr.
   public_addr: "teleport.example.com:3080"
-  # Address advertised to PostgreSQL clients. If not set, public_addr is used.
-  postgres_public_addr: "postgres.teleport.example.com:443"
   # Address advertised to MySQL clients. If not set, public_addr is used.
   mysql_public_addr: "mysql.teleport.example.com:3306"
+  # Address advertised to PostgreSQL clients. If not set, public_addr is used.
+  postgres_public_addr: "postgres.teleport.example.com:5432"
+  # Address advertised to Mongo clients. If not set, public_addr is used.
+  mongo_public_addr: "mongo.teleport.example.com:27017"
 ```
 
 ## Database resource

--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -85,12 +85,12 @@ proxy_service:
   # MySQL proxy is listening on a separate port and needs to be enabled
   # on the proxy server.
   mysql_listen_addr: "0.0.0.0:3036"
-  # Postgres proxy is listening address. If provided proxy will use a separate listener
+  # Postgres proxy listening address. If provided, proxy will use a separate listener
   # instead of multiplexing Postgres protocol on web_listener_addr.
-  postgres_listen_addr: "0.0.0.0:5432"
-  # Mongo proxy is listening address. If provided proxy will use a separate listener
+  # postgres_listen_addr: "0.0.0.0:5432"
+  # Mongo proxy listening address. If provided, proxy will use a separate listener
   # instead of multiplexing Mongo protocol on web_listener_addr.
-  mongo_listen_addr: "0.0.0.0:27017"
+  # mongo_listen_addr: "0.0.0.0:27017"
   # By default database clients will be connecting to the Proxy over this
   # hostname. To override public address for specific database protocols
   # use postgres_public_addr and mysql_public_addr.
@@ -98,9 +98,9 @@ proxy_service:
   # Address advertised to MySQL clients. If not set, public_addr is used.
   mysql_public_addr: "mysql.teleport.example.com:3306"
   # Address advertised to PostgreSQL clients. If not set, public_addr is used.
-  postgres_public_addr: "postgres.teleport.example.com:5432"
+  postgres_public_addr: "postgres.teleport.example.com:443"
   # Address advertised to Mongo clients. If not set, public_addr is used.
-  mongo_public_addr: "mongo.teleport.example.com:27017"
+  mongo_public_addr: "mongo.teleport.example.com:443"
 ```
 
 ## Database resource

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -509,7 +509,7 @@ proxy_service:
     # postgres_listen_addr: "0.0.0.0:5432"
 
     # Mongo Proxy listener address. If provided, proxy will use a separate listener
-    # instead of multiplexing Postgres protocol on web_listener_addr.
+    # instead of multiplexing Mongo protocol on web_listener_addr.
     # mongo_listen_addr: "0.0.0.0:27017"
 
     # Address advertised to MySQL clients. If not set, public_addr is used.

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -504,22 +504,22 @@ proxy_service:
     # "v1": defaults to 0.0.0.0:3036
     mysql_listen_addr: "0.0.0.0:3036"
 
-    # Postgres Proxy listener address. If provided proxy will use a separate listener
+    # Postgres Proxy listener address. If provided, proxy will use a separate listener
     # instead of multiplexing Postgres protocol on web_listener_addr.
-    postgres_listen_addr: "0.0.0.0:5432"
+    # postgres_listen_addr: "0.0.0.0:5432"
 
-    # Mongo Proxy listener address. If provided proxy will use a separate listener
+    # Mongo Proxy listener address. If provided, proxy will use a separate listener
     # instead of multiplexing Postgres protocol on web_listener_addr.
-    mongo_listen_addr: "0.0.0.0:27017"
+    # mongo_listen_addr: "0.0.0.0:27017"
 
     # Address advertised to MySQL clients. If not set, public_addr is used.
     mysql_public_addr: "mysql.teleport.example.com:3306"
 
     # Address advertised to PostgresSQL clients. If not set, public_addr is used.
-    postgres_public_addr: "postgres.teleport.example.com:5432"
+    postgres_public_addr: "postgres.teleport.example.com:443"
 
     # Address advertised to Mongo clients. If not set, public_addr is used.
-    mongo_public_addr: "mongo.teleport.example.com:27017"
+    mongo_public_addr: "mongo.teleport.example.com:443"
 
     # Get an automatic certificate from Letsencrypt.org using ACME via TLS_ALPN-01 challenge.
     # When using ACME, the cluster name must match the 'public_addr' of Teleport and

--- a/docs/pages/setup/reference/config.mdx
+++ b/docs/pages/setup/reference/config.mdx
@@ -504,11 +504,22 @@ proxy_service:
     # "v1": defaults to 0.0.0.0:3036
     mysql_listen_addr: "0.0.0.0:3036"
 
-    # Address advertised to PostgreSQL clients. If not set, public_addr is used.
-    postgres_public_addr: "postgres.teleport.example.com:443"
+    # Postgres Proxy listener address. If provided proxy will use a separate listener
+    # instead of multiplexing Postgres protocol on web_listener_addr.
+    postgres_listen_addr: "0.0.0.0:5432"
+
+    # Mongo Proxy listener address. If provided proxy will use a separate listener
+    # instead of multiplexing Postgres protocol on web_listener_addr.
+    mongo_listen_addr: "0.0.0.0:27017"
 
     # Address advertised to MySQL clients. If not set, public_addr is used.
     mysql_public_addr: "mysql.teleport.example.com:3306"
+
+    # Address advertised to PostgresSQL clients. If not set, public_addr is used.
+    postgres_public_addr: "postgres.teleport.example.com:5432"
+
+    # Address advertised to Mongo clients. If not set, public_addr is used.
+    mongo_public_addr: "mongo.teleport.example.com:27017"
 
     # Get an automatic certificate from Letsencrypt.org using ACME via TLS_ALPN-01 challenge.
     # When using ACME, the cluster name must match the 'public_addr' of Teleport and

--- a/integration/db_integration_test.go
+++ b/integration/db_integration_test.go
@@ -354,6 +354,70 @@ func TestDatabaseAccessUnspecifiedHostname(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestDatabaseAccessPostgresSeparateListener tests postgres proxy listener running on separate port.
+func TestDatabaseAccessPostgresSeparateListener(t *testing.T) {
+	pack := setupDatabaseTest(t,
+		withPortSetupDatabaseTest(separatePostgresPortSetup),
+	)
+
+	// Connect to the database service in root cluster.
+	client, err := postgres.MakeTestClient(context.Background(), common.TestClientConfig{
+		AuthClient: pack.root.cluster.GetSiteAPI(pack.root.cluster.Secrets.SiteName),
+		AuthServer: pack.root.cluster.Process.GetAuthServer(),
+		Address:    net.JoinHostPort(Loopback, pack.root.cluster.GetPortPostgres()),
+		Cluster:    pack.root.cluster.Secrets.SiteName,
+		Username:   pack.root.user.GetName(),
+		RouteToDatabase: tlsca.RouteToDatabase{
+			ServiceName: pack.root.postgresService.Name,
+			Protocol:    pack.root.postgresService.Protocol,
+			Username:    "postgres",
+			Database:    "test",
+		},
+	})
+	require.NoError(t, err)
+
+	// Execute a query.
+	result, err := client.Exec(context.Background(), "select 1").ReadAll()
+	require.NoError(t, err)
+	require.Equal(t, []*pgconn.Result{postgres.TestQueryResponse}, result)
+	require.Equal(t, uint32(1), pack.root.postgres.QueryCount())
+	require.Equal(t, uint32(0), pack.leaf.postgres.QueryCount())
+
+	// Disconnect.
+	err = client.Close(context.Background())
+	require.NoError(t, err)
+}
+
+// TestDatabaseAccessMongoSeparateListener tests mongo proxy listener running on separate port.
+func TestDatabaseAccessMongoSeparateListener(t *testing.T) {
+	pack := setupDatabaseTest(t,
+		withPortSetupDatabaseTest(separateMongoPortSetup),
+	)
+
+	// Connect to the database service in root cluster.
+	client, err := mongodb.MakeTestClient(context.Background(), common.TestClientConfig{
+		AuthClient: pack.root.cluster.GetSiteAPI(pack.root.cluster.Secrets.SiteName),
+		AuthServer: pack.root.cluster.Process.GetAuthServer(),
+		Address:    net.JoinHostPort(Loopback, pack.root.cluster.GetPortMongo()),
+		Cluster:    pack.root.cluster.Secrets.SiteName,
+		Username:   pack.root.user.GetName(),
+		RouteToDatabase: tlsca.RouteToDatabase{
+			ServiceName: pack.root.mongoService.Name,
+			Protocol:    pack.root.mongoService.Protocol,
+			Username:    "admin",
+		},
+	})
+	require.NoError(t, err)
+
+	// Execute a query.
+	_, err = client.Database("test").Collection("test").Find(context.Background(), bson.M{})
+	require.NoError(t, err)
+
+	// Disconnect.
+	err = client.Disconnect(context.Background())
+	require.NoError(t, err)
+}
+
 func waitForAuditEventTypeWithBackoff(t *testing.T, cli *auth.Server, startTime time.Time, eventType string) []apievents.AuditEvent {
 	max := time.Second
 	timeout := time.After(max)

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -595,6 +595,14 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 		tconf.Proxy.SSHAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortProxy())
 		tconf.Proxy.WebAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortWeb())
 		tconf.Proxy.MySQLAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortMySQL())
+		if i.Postgres != nil {
+			// Postgres proxy port was configured on a separate listener.
+			tconf.Proxy.PostgresAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortPostgres())
+		}
+		if i.Mongo != nil {
+			// Mongo proxy port was configured on a separate listener.
+			tconf.Proxy.MongoAddr.Addr = net.JoinHostPort(i.Hostname, i.GetPortMongo())
+		}
 	}
 	tconf.AuthServers = append(tconf.AuthServers, tconf.Auth.SSHAddr)
 	tconf.Auth.StorageConfig = backend.Config{

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -87,6 +87,30 @@ func webReverseTunnelMuxPortSetup() *InstancePorts {
 	}
 }
 
+func separatePostgresPortSetup() *InstancePorts {
+	return &InstancePorts{
+		Web:           newInstancePort(),
+		SSH:           newInstancePort(),
+		Auth:          newInstancePort(),
+		SSHProxy:      newInstancePort(),
+		ReverseTunnel: newInstancePort(),
+		MySQL:         newInstancePort(),
+		Postgres:      newInstancePort(),
+	}
+}
+
+func separateMongoPortSetup() *InstancePorts {
+	return &InstancePorts{
+		Web:           newInstancePort(),
+		SSH:           newInstancePort(),
+		Auth:          newInstancePort(),
+		SSHProxy:      newInstancePort(),
+		ReverseTunnel: newInstancePort(),
+		MySQL:         newInstancePort(),
+		Mongo:         newInstancePort(),
+	}
+}
+
 type InstancePorts struct {
 	Host string
 	Web  *InstancePort
@@ -97,6 +121,8 @@ type InstancePorts struct {
 	Auth          *InstancePort
 	ReverseTunnel *InstancePort
 	MySQL         *InstancePort
+	Postgres      *InstancePort
+	Mongo         *InstancePort
 
 	isSinglePortSetup bool
 }
@@ -107,6 +133,8 @@ func (i *InstancePorts) GetPortAuth() string          { return i.Auth.String() }
 func (i *InstancePorts) GetPortProxy() string         { return i.SSHProxy.String() }
 func (i *InstancePorts) GetPortWeb() string           { return i.Web.String() }
 func (i *InstancePorts) GetPortMySQL() string         { return i.MySQL.String() }
+func (i *InstancePorts) GetPortPostgres() string      { return i.Postgres.String() }
+func (i *InstancePorts) GetPortMongo() string         { return i.Mongo.String() }
 func (i *InstancePorts) GetPortReverseTunnel() string { return i.ReverseTunnel.String() }
 
 func (i *InstancePorts) GetSSHAddr() string {

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -199,6 +199,9 @@ type Config struct {
 	// PostgresProxyAddr is the host:port the Postgres proxy can be accessed at.
 	PostgresProxyAddr string
 
+	// MongoProxyAddr is the host:port the Mongo proxy can be accessed at.
+	MongoProxyAddr string
+
 	// MySQLProxyAddr is the host:port the MySQL proxy can be accessed at.
 	MySQLProxyAddr string
 
@@ -785,6 +788,7 @@ func (c *Config) LoadProfile(profileDir string, proxyName string) error {
 	c.SSHProxyAddr = cp.SSHProxyAddr
 	c.PostgresProxyAddr = cp.PostgresProxyAddr
 	c.MySQLProxyAddr = cp.MySQLProxyAddr
+	c.MongoProxyAddr = cp.MongoProxyAddr
 	c.TLSRoutingEnabled = cp.TLSRoutingEnabled
 
 	c.LocalForwardPorts, err = ParsePortForwardSpec(cp.ForwardedPorts)
@@ -816,6 +820,7 @@ func (c *Config) SaveProfile(dir string, makeCurrent bool) error {
 	cp.KubeProxyAddr = c.KubeProxyAddr
 	cp.PostgresProxyAddr = c.PostgresProxyAddr
 	cp.MySQLProxyAddr = c.MySQLProxyAddr
+	cp.MongoProxyAddr = c.MongoProxyAddr
 	cp.ForwardedPorts = c.LocalForwardPorts.String()
 	cp.SiteName = c.SiteName
 	cp.TLSRoutingEnabled = c.TLSRoutingEnabled
@@ -981,6 +986,17 @@ func (c *Config) PostgresProxyHostPort() (string, int) {
 	return c.WebProxyHostPort()
 }
 
+// MongoProxyHostPort returns the host and port of Mongo proxy.
+func (c *Config) MongoProxyHostPort() (string, int) {
+	if c.MongoProxyAddr != "" {
+		addr, err := utils.ParseAddr(c.MongoProxyAddr)
+		if err == nil {
+			return addr.Host(), addr.Port(defaults.MongoListenPort)
+		}
+	}
+	return c.WebProxyHostPort()
+}
+
 // MySQLProxyHostPort returns the host and port of MySQL proxy.
 func (c *Config) MySQLProxyHostPort() (string, int) {
 	if c.MySQLProxyAddr != "" {
@@ -1001,7 +1017,7 @@ func (c *Config) DatabaseProxyHostPort(db tlsca.RouteToDatabase) (string, int) {
 	case defaults.ProtocolMySQL:
 		return c.MySQLProxyHostPort()
 	case defaults.ProtocolMongoDB:
-		return c.WebProxyHostPort()
+		return c.MongoProxyHostPort()
 	}
 	return c.WebProxyHostPort()
 }
@@ -2636,9 +2652,34 @@ func (tc *TeleportClient) applyProxySettings(proxySettings webclient.ProxySettin
 				proxySettings.DB.PostgresPublicAddr)
 		}
 		tc.PostgresProxyAddr = net.JoinHostPort(addr.Host(), strconv.Itoa(addr.Port(tc.WebProxyPort())))
+	case proxySettings.DB.PostgresListenAddr != "":
+		addr, err := utils.ParseAddr(proxySettings.DB.PostgresListenAddr)
+		if err != nil {
+			return trace.BadParameter("failed to parse Postgres listen address received from server: %q, contact your administrator for help",
+				proxySettings.DB.PostgresListenAddr)
+		}
+		tc.PostgresProxyAddr = net.JoinHostPort(tc.WebProxyHost(), strconv.Itoa(addr.Port(defaults.PostgresListenPort)))
 	default:
 		webProxyHost, webProxyPort := tc.WebProxyHostPort()
 		tc.PostgresProxyAddr = net.JoinHostPort(webProxyHost, strconv.Itoa(webProxyPort))
+	}
+
+	// Read Mongo proxy settings.
+	switch {
+	case proxySettings.DB.MongoPublicAddr != "":
+		addr, err := utils.ParseAddr(proxySettings.DB.MongoPublicAddr)
+		if err != nil {
+			return trace.BadParameter("failed to parse Mongo public address received from server: %q, contact your administrator for help",
+				proxySettings.DB.MongoPublicAddr)
+		}
+		tc.MongoProxyAddr = net.JoinHostPort(addr.Host(), strconv.Itoa(addr.Port(tc.WebProxyPort())))
+	case proxySettings.DB.MongoListenAddr != "":
+		addr, err := utils.ParseAddr(proxySettings.DB.MongoListenAddr)
+		if err != nil {
+			return trace.BadParameter("failed to parse Mongo listen address received from server: %q, contact your administrator for help",
+				proxySettings.DB.MongoListenAddr)
+		}
+		tc.MongoProxyAddr = net.JoinHostPort(tc.WebProxyHost(), strconv.Itoa(addr.Port(defaults.MongoListenPort)))
 	}
 
 	// Read MySQL proxy settings if enabled on the server.

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -679,10 +679,13 @@ func TestApplyConfig(t *testing.T) {
 	require.Equal(t, "tcp://webhost:3080", cfg.Proxy.WebAddr.FullAddress())
 	require.Equal(t, "tcp://tunnelhost:1001", cfg.Proxy.ReverseTunnelListenAddr.FullAddress())
 	require.Equal(t, "tcp://webhost:3336", cfg.Proxy.MySQLAddr.FullAddress())
+	require.Equal(t, "tcp://webhost:27017", cfg.Proxy.MongoAddr.FullAddress())
 	require.Len(t, cfg.Proxy.PostgresPublicAddrs, 1)
 	require.Equal(t, "tcp://postgres.example:5432", cfg.Proxy.PostgresPublicAddrs[0].FullAddress())
 	require.Len(t, cfg.Proxy.MySQLPublicAddrs, 1)
 	require.Equal(t, "tcp://mysql.example:3306", cfg.Proxy.MySQLPublicAddrs[0].FullAddress())
+	require.Len(t, cfg.Proxy.MongoPublicAddrs, 1)
+	require.Equal(t, "tcp://mongo.example:27017", cfg.Proxy.MongoPublicAddrs[0].FullAddress())
 
 	require.Equal(t, "tcp://127.0.0.1:3000", cfg.DiagnosticAddr.FullAddress())
 
@@ -811,6 +814,28 @@ func TestPostgresPublicAddr(t *testing.T) {
 				},
 			},
 			out: []string{net.JoinHostPort("postgres.example.com", strconv.Itoa(defaults.HTTPListenPort))},
+		},
+		{
+			desc: "when PostgresAddr is provided with port, the explicitly provided port should be use",
+			fc: &FileConfig{
+				Proxy: Proxy{
+					WebAddr:            "0.0.0.0:8080",
+					PostgresAddr:       "0.0.0.0:12345",
+					PostgresPublicAddr: []string{"postgres.example.com"},
+				},
+			},
+			out: []string{"postgres.example.com:12345"},
+		},
+		{
+			desc: "when PostgresAddr is provided without port, defaults PostgresPort should be used",
+			fc: &FileConfig{
+				Proxy: Proxy{
+					WebAddr:            "0.0.0.0:8080",
+					PostgresAddr:       "0.0.0.0",
+					PostgresPublicAddr: []string{"postgres.example.com"},
+				},
+			},
+			out: []string{net.JoinHostPort("postgres.example.com", strconv.Itoa(defaults.PostgresListenPort))},
 		},
 	}
 	for _, test := range tests {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1115,9 +1115,18 @@ type Proxy struct {
 	// MySQLPublicAddr is the hostport the proxy advertises for MySQL
 	// client connections.
 	MySQLPublicAddr apiutils.Strings `yaml:"mysql_public_addr,omitempty"`
+
+	// PostgresAddr is Postgres proxy listen address.
+	PostgresAddr string `yaml:"postgres_listen_addr,omitempty"`
 	// PostgresPublicAddr is the hostport the proxy advertises for Postgres
 	// client connections.
 	PostgresPublicAddr apiutils.Strings `yaml:"postgres_public_addr,omitempty"`
+
+	// MongoAddr is Mongo proxy listen address.
+	MongoAddr string `yaml:"mongo_listen_addr,omitempty"`
+	// MongoPublicAddr is the hostport the proxy advertises for Mongo
+	// client connections.
+	MongoPublicAddr apiutils.Strings `yaml:"mongo_public_addr,omitempty"`
 }
 
 // ACME configures ACME protocol - automatic X.509 certificates

--- a/lib/config/testdata_test.go
+++ b/lib/config/testdata_test.go
@@ -159,6 +159,8 @@ proxy_service:
   postgres_public_addr: postgres.example:5432
   mysql_listen_addr: webhost:3336
   mysql_public_addr: mysql.example:3306
+  mongo_listen_addr: webhost:27017
+  mongo_public_addr: mongo.example:27017
 `
 
 // NoServicesConfigString is a configuration file with no services enabled

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -60,6 +60,12 @@ const (
 	// MySQLListenPort is the default listen port for MySQL proxy.
 	MySQLListenPort = 3036
 
+	// PostgresListenPort is the default listen port for PostgreSQL proxy.
+	PostgresListenPort = 5432
+
+	// MongoListenPort is the default listen port for Mongo proxy.
+	MongoListenPort = 27017
+
 	// MetricsListenPort is the default listen port for the metrics service.
 	MetricsListenPort = 3081
 

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -58,8 +58,8 @@ type Config struct {
 	DisableSSH bool
 	// DisableTLS disables TLS socket
 	DisableTLS bool
-	// DisableDB disables database access proxy listener
-	DisableDB bool
+	// DisablePostgres disables Postgres access proxy listener
+	DisablePostgres bool
 	// ID is an identifier used for debugging purposes
 	ID string
 }
@@ -249,7 +249,7 @@ func (m *Mux) detectAndForward(conn net.Conn) {
 		conn.Close()
 	case ProtoPostgres:
 		m.WithField("protocol", connWrapper.protocol).Debug("Detected Postgres client connection.")
-		if m.DisableDB {
+		if m.DisablePostgres {
 			m.Debug("Closing Postgres client connection: db proxy listener is disabled.")
 			conn.Close()
 			return

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -358,6 +358,12 @@ type ProxyConfig struct {
 	// MySQLAddr is address of MySQL proxy.
 	MySQLAddr utils.NetAddr
 
+	// PostgresAddr is address of Postgres proxy.
+	PostgresAddr utils.NetAddr
+
+	// MongoAddr is address of Mongo proxy.
+	MongoAddr utils.NetAddr
+
 	Limiter limiter.Config
 
 	// PublicAddrs is a list of the public addresses the proxy advertises
@@ -382,6 +388,10 @@ type ProxyConfig struct {
 	// MySQLPublicAddrs is a list of the public addresses the proxy
 	// advertises for MySQL clients.
 	MySQLPublicAddrs []utils.NetAddr
+
+	// MongoPublicAddrs is a list of the public addresses the proxy
+	// advertises for Mongo clients.
+	MongoPublicAddrs []utils.NetAddr
 
 	// Kube specifies kubernetes proxy configuration
 	Kube KubeProxyConfig

--- a/lib/service/listeners.go
+++ b/lib/service/listeners.go
@@ -40,6 +40,8 @@ var (
 	listenerProxyWeb          = listenerType(teleport.Component(teleport.ComponentProxy, "web"))
 	listenerProxyTunnel       = listenerType(teleport.Component(teleport.ComponentProxy, "tunnel"))
 	listenerProxyMySQL        = listenerType(teleport.Component(teleport.ComponentProxy, "mysql"))
+	listenerProxyPostgres     = listenerType(teleport.Component(teleport.ComponentProxy, "postgres"))
+	listenerProxyMongo        = listenerType(teleport.Component(teleport.ComponentProxy, "mongo"))
 	listenerMetrics           = listenerType(teleport.ComponentMetrics)
 	listenerWindowsDesktop    = listenerType(teleport.ComponentWindowsDesktop)
 )

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2526,6 +2526,8 @@ type dbListeners struct {
 	postgres net.Listener
 	// mysql serves MySQL clients.
 	mysql net.Listener
+	// mongo serves Mongo clients.
+	mongo net.Listener
 	// tls serves database clients that use plain TLS handshake.
 	tls net.Listener
 }
@@ -2545,6 +2547,9 @@ func (l *dbListeners) Close() {
 	}
 	if l.tls != nil {
 		l.tls.Close()
+	}
+	if l.mongo != nil {
+		l.mongo.Close()
 	}
 }
 
@@ -2584,6 +2589,7 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 		}
 	}
 
+	useSeparatePostgresListener := !cfg.Proxy.PostgresAddr.IsEmpty()
 	if cfg.Proxy.Kube.Enabled && !cfg.Proxy.Kube.ListenAddr.IsEmpty() {
 		process.log.Debugf("Setup Proxy: turning on Kubernetes proxy.")
 		listener, err := process.importOrCreateListener(listenerProxyKube, cfg.Proxy.Kube.ListenAddr.Addr)
@@ -2602,6 +2608,15 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 		listeners.db.mysql = listener
 	}
 
+	if !cfg.Proxy.MongoAddr.IsEmpty() && !cfg.Proxy.DisableDatabaseProxy {
+		process.log.Debugf("Setup Proxy: Mongo proxy address: %v.", cfg.Proxy.MongoAddr.Addr)
+		listener, err := process.importOrCreateListener(listenerProxyMongo, cfg.Proxy.MongoAddr.Addr)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		listeners.db.mongo = listener
+	}
+
 	switch {
 	case cfg.Proxy.DisableWebService && cfg.Proxy.DisableReverseTunnel:
 		process.log.Debugf("Setup Proxy: Reverse tunnel proxy and web proxy are disabled.")
@@ -2617,7 +2632,7 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 			Listener:            listener,
 			DisableTLS:          cfg.Proxy.DisableWebService,
 			DisableSSH:          cfg.Proxy.DisableReverseTunnel,
-			DisableDB:           cfg.Proxy.DisableDatabaseProxy,
+			DisablePostgres:     cfg.Proxy.DisableDatabaseProxy || useSeparatePostgresListener,
 			ID:                  teleport.Component(teleport.ComponentProxy, "tunnel", "web", process.id),
 		})
 		if err != nil {
@@ -2625,7 +2640,9 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 			return nil, trace.Wrap(err)
 		}
 		listeners.web = listeners.mux.TLS()
-		listeners.db.postgres = listeners.mux.DB()
+		if err := process.setPostgresListener(cfg, &listeners); err != nil {
+			return nil, trace.Wrap(err)
+		}
 		listeners.reverseTunnel = listeners.mux.SSH()
 		go listeners.mux.Serve()
 		return &listeners, nil
@@ -2640,7 +2657,7 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 			Listener:            listener,
 			DisableTLS:          false,
 			DisableSSH:          true,
-			DisableDB:           cfg.Proxy.DisableDatabaseProxy,
+			DisablePostgres:     cfg.Proxy.DisableDatabaseProxy || useSeparatePostgresListener,
 			ID:                  teleport.Component(teleport.ComponentProxy, "web", process.id),
 		})
 		if err != nil {
@@ -2648,7 +2665,9 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 			return nil, trace.Wrap(err)
 		}
 		listeners.web = listeners.mux.TLS()
-		listeners.db.postgres = listeners.mux.DB()
+		if err := process.setPostgresListener(cfg, &listeners); err != nil {
+			return nil, trace.Wrap(err)
+		}
 		if !cfg.Proxy.ReverseTunnelListenAddr.IsEmpty() {
 			listeners.reverseTunnel, err = process.importOrCreateListener(listenerProxyTunnel, cfg.Proxy.ReverseTunnelListenAddr.Addr)
 			if err != nil {
@@ -2684,7 +2703,7 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 					Listener:            listener,
 					DisableTLS:          false, // Web service is enabled or we wouldn't have gotten here.
 					DisableSSH:          true,  // Reverse tunnel is on a separate listener created above.
-					DisableDB:           false, // Database proxy is enabled or we wouldn't have gotten here.
+					DisablePostgres:     false, // Database proxy is enabled or we wouldn't have gotten here.
 					ID:                  teleport.Component(teleport.ComponentProxy, "web", process.id),
 				})
 				if err != nil {
@@ -2693,7 +2712,9 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 					return nil, trace.Wrap(err)
 				}
 				listeners.web = listeners.mux.TLS()
-				listeners.db.postgres = listeners.mux.DB()
+				if err := process.setPostgresListener(cfg, &listeners); err != nil {
+					return nil, trace.Wrap(err)
+				}
 				go listeners.mux.Serve()
 			} else {
 				process.log.Debug("Setup Proxy: TLS is disabled, multiplexing is off.")
@@ -2710,6 +2731,29 @@ func (process *TeleportProcess) setupProxyListeners() (*proxyListeners, error) {
 		}
 		return &listeners, nil
 	}
+}
+
+// setPostgresListener start Postgres proxy listener based on configuration settings. By default, Postgres service is
+// multiplexed on Teleport Proxy web port but if the postgres_listen_addr flag was provided, the
+// Postgres service runs on a separate port taken from it.
+func (process *TeleportProcess) setPostgresListener(cfg *Config, listeners *proxyListeners) error {
+	if cfg.Proxy.DisableDatabaseProxy {
+		return nil
+	}
+	if cfg.Proxy.PostgresAddr.IsEmpty() {
+		// Postgres service is multiplexed on Proxy Web port.
+		listeners.db.postgres = listeners.mux.DB()
+		return nil
+	}
+	// If cfg.Proxy.PostgresAddr address was provided start Postgres service on separate listener without
+	// multiplexing it on webPort.
+	process.log.Debugf("Setup Proxy: Postgres proxy address: %v.", cfg.Proxy.PostgresAddr.Addr)
+	listener, err := process.importOrCreateListener(listenerProxyPostgres, cfg.Proxy.PostgresAddr.Addr)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	listeners.db.postgres = listener
+	return nil
 }
 
 func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
@@ -3116,7 +3160,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if listeners.db.postgres != nil {
 			process.RegisterCriticalFunc("proxy.db.postgres", func() error {
 				log.Infof("Starting Postgres proxy server on %v.", cfg.Proxy.WebAddr.Addr)
-				if err := dbProxyServer.Serve(listeners.db.postgres); err != nil {
+				if err := dbProxyServer.ServePostgres(listeners.db.postgres); err != nil {
 					log.WithError(err).Warn("Postgres proxy server exited with error.")
 				}
 				return nil
@@ -3136,6 +3180,16 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				log.Infof("Starting Database TLS proxy server on %v.", cfg.Proxy.WebAddr.Addr)
 				if err := dbProxyServer.ServeTLS(listeners.db.tls); err != nil {
 					log.WithError(err).Warn("Database TLS proxy server exited with error.")
+				}
+				return nil
+			})
+		}
+
+		if listeners.db.mongo != nil {
+			process.RegisterCriticalFunc("proxy.db.mongo", func() error {
+				log.Infof("Starting Database Mongo proxy server on %v.", cfg.Proxy.MongoAddr.Addr)
+				if err := dbProxyServer.ServeMongo(listeners.db.mongo, tlsConfigWeb.Clone()); err != nil {
+					log.WithError(err).Warn("Database Mongo proxy server exited with error.")
 				}
 				return nil
 			})

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -617,7 +617,7 @@ func (c *testContext) startProxy() {
 	// Start TLS multiplexer.
 	go c.webListener.Serve()
 	// Start database proxy server.
-	go c.proxyServer.Serve(c.mux.DB())
+	go c.proxyServer.ServePostgres(c.mux.DB())
 	// Start MySQL proxy server.
 	go c.proxyServer.ServeMySQL(c.mysqlListener)
 	// Start database TLS proxy server.


### PR DESCRIPTION
Backport for:  https://github.com/gravitational/teleport/pull/8323 https://github.com/gravitational/teleport/pull/9194 https://github.com/gravitational/teleport/pull/9340