### PR TITLE
Update rdp-rs

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/Cargo.lock
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.lock
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "b58a4469763e4e3a906c4ed786e1c70512d16aa88f84dded826da42640fc6a1c"
 
 [[package]]
 name = "lock_api"
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "rdp-rs"
 version = "0.1.0"
-source = "git+https://github.com/gravitational/rdp-rs?rev=755e950dcff0fc6965aa518c4596b995ede3417d#755e950dcff0fc6965aa518c4596b995ede3417d"
+source = "git+https://github.com/gravitational/rdp-rs?rev=cb61119d2803f647b60e6c9b2ef05ab587cc1966#cb61119d2803f647b60e6c9b2ef05ab587cc1966"
 dependencies = [
  "bufstream",
  "byteorder",

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rdp-client"
 version = "0.1.0"
-authors = ["Andrew Lytvynov <andrew@goteleport.com>"]
+authors = ["Andrew Lytvynov <andrew@goteleport.com>", "Zac Bergquist <zac@goteleport.com>"]
 edition = "2018"
 
 [lib]
@@ -21,7 +21,7 @@ byteorder = "1.4.3"
 env_logger = "0.9.0"
 iso7816 = "0.1.0-alpha.1"
 iso7816-tlv = "0.4.2"
-libc = "0.2.106"
+libc = "0.2.110"
 log = "0.4.14"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
@@ -29,5 +29,5 @@ num-traits = "0.2.14"
 # RustCrypto doesn't expose the low-level primitives we need for the smartcard
 # challenge signing (see src/piv.rs for details).
 openssl = { version = "0.10.38", features = ["vendored"] }
-rdp-rs = { git = "https://github.com/gravitational/rdp-rs", rev = "755e950dcff0fc6965aa518c4596b995ede3417d" }
+rdp-rs = { git = "https://github.com/gravitational/rdp-rs", rev = "cb61119d2803f647b60e6c9b2ef05ab587cc1966" }
 uuid = { version = "0.8.2", features = ["v4"] }


### PR DESCRIPTION
This includes gravitational/rdp-rs#5 which will show a better
error message for protocol negotiation failures.

Also bump the libc dependency while we're at it.
All other crates are still up to date.