### PR TITLE
Escape access request and access resolution reasons in tctl

### DIFF
--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -383,8 +383,8 @@ func printRequestsOverview(reqs []types.AccessRequest, format string) error {
 				fmt.Sprintf("roles=%s", strings.Join(req.GetRoles(), ",")),
 				req.GetCreationTime().Format(time.RFC822),
 				req.GetState().String(),
-				req.GetRequestReason(),
-				req.GetResolveReason(),
+				quoteOrDefault(req.GetRequestReason(), ""),
+				quoteOrDefault(req.GetResolveReason(), ""),
 			})
 		}
 		_, err := table.AsBuffer().WriteTo(os.Stdout)
@@ -407,8 +407,8 @@ func printRequestsDetailed(reqs []types.AccessRequest, format string) error {
 			table.AddRow([]string{"Metadata: ", fmt.Sprintf("roles=%s", strings.Join(req.GetRoles(), ","))})
 			table.AddRow([]string{"Created At (UTC): ", req.GetCreationTime().Format(time.RFC822)})
 			table.AddRow([]string{"Status: ", req.GetState().String()})
-			table.AddRow([]string{"Request Reason: ", req.GetRequestReason()})
-			table.AddRow([]string{"Resolve Reason: ", req.GetResolveReason()})
+			table.AddRow([]string{"Request Reason: ", quoteOrDefault(req.GetRequestReason(), "[none]")})
+			table.AddRow([]string{"Resolve Reason: ", quoteOrDefault(req.GetResolveReason(), "[none]")})
 
 			_, err := table.AsBuffer().WriteTo(os.Stdout)
 			if err != nil {
@@ -431,4 +431,11 @@ func printJSON(in interface{}, desc string) error {
 	}
 	fmt.Printf("%s\n", out)
 	return nil
+}
+
+func quoteOrDefault(s string, d string) string {
+	if s == "" {
+		return d
+	}
+	return fmt.Sprintf("%q", s)
 }

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -433,7 +433,7 @@ func printJSON(in interface{}, desc string) error {
 	return nil
 }
 
-func quoteOrDefault(s string, d string) string {
+func quoteOrDefault(s, d string) string {
 	if s == "" {
 		return d
 	}


### PR DESCRIPTION
As request and resolution reasons can contain newlines, control characters and ANSI escape codes, we pass them through `fmt.Printf("%q")` like it's done in `tsh`.

This fixes TEL-Q321-5.