### PR TITLE
Log when a service connects to an unsupported version of the auth server.

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -18,13 +18,17 @@ package service
 
 import (
 	"crypto/tls"
+	"math"
 	"path/filepath"
 
 	"golang.org/x/crypto/ssh"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/roundtrip"
+	"github.com/gravitational/teleport"
 
 	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib"
@@ -62,11 +66,16 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			// client works, by using call that should succeed at all times
 			if connector.Client != nil {
 				pingResponse, err := connector.Client.Ping(process.ExitContext())
+				if err := process.compareVersions(&pingResponse); err != nil {
+					process.log.Debugf("Error comparing formats: %v", err)
+				}
+
 				if err == nil {
 					process.setClusterFeatures(pingResponse.GetServerFeatures())
 					process.log.Infof("%v: features loaded from auth server: %+v", role, pingResponse.GetServerFeatures())
 					return connector, nil
 				}
+
 				process.log.Debugf("Connected client %v failed to execute test call: %v. Node or proxy credentials are out of sync.", role, err)
 				if err := connector.Client.Close(); err != nil {
 					process.log.Debugf("Failed to close the client: %v.", err)
@@ -92,6 +101,21 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 			return nil, ErrTeleportExited
 		}
 	}
+}
+
+func (process *TeleportProcess) compareVersions(resp *proto.PingResponse) error {
+	serverVersion, err := semver.NewVersion(resp.ServerVersion)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	teleportVersion, err := semver.NewVersion(teleport.Version)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if math.Abs(float64(serverVersion.Major-teleportVersion.Major)) > 1 {
+		process.log.Warnf("Only versions %d and %d are supported, auth server is %s.", teleportVersion.Major, teleportVersion.Major-1, serverVersion.Major)
+	}
+	return nil
 }
 
 // connectToAuthService attempts to login into the auth servers specified in the


### PR DESCRIPTION
This is to inform the user that should they connect to an auth service that is out of date and no longer officially compatible with the version of teleport that is connecting.

https://github.com/gravitational/teleport/issues/9285