### PR TITLE
Prevent Linear Retry from converging on Max

### DIFF
--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -220,6 +220,9 @@ func (r *Linear) Duration() time.Duration {
 	if a <= r.Max {
 		return a
 	}
+	if r.Jitter != nil {
+		return r.Jitter(r.Max)
+	}
 	return r.Max
 }
 

--- a/lib/utils/retry_test.go
+++ b/lib/utils/retry_test.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_LinearRetryMax(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		desc              string
+		config            LinearConfig
+		previousCompareFn require.ComparisonAssertionFunc
+	}{
+		{
+			desc: "HalfJitter",
+			config: LinearConfig{
+				First:  time.Second * 45,
+				Step:   time.Second * 30,
+				Max:    time.Minute,
+				Jitter: NewJitter(),
+			},
+			previousCompareFn: require.NotEqual,
+		},
+		{
+			desc: "SeventhJitter",
+			config: LinearConfig{
+				First:  time.Second * 45,
+				Step:   time.Second * 30,
+				Max:    time.Minute,
+				Jitter: NewSeventhJitter(),
+			},
+			previousCompareFn: require.NotEqual,
+		},
+		{
+			desc: "NoJitter",
+			config: LinearConfig{
+				First: time.Second * 45,
+				Step:  time.Second * 30,
+				Max:   time.Minute,
+			},
+			previousCompareFn: require.Equal,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			linear, err := NewLinear(tc.config)
+			require.NoError(t, err)
+
+			// artificially spike the attempts to get to max
+			linear.attempt = 100
+
+			// get the initial previous value to compare with
+			previous := linear.Duration()
+			linear.Inc()
+
+			for i := 0; i < 50; i++ {
+				duration := linear.Duration()
+				linear.Inc()
+
+				// ensure duration does not exceed maximum
+				require.LessOrEqual(t, duration, tc.config.Max)
+
+				// ensure duration comparison to previous is satisfied
+				tc.previousCompareFn(t, duration, previous)
+
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prior to this change, if the `Duration` of a `Linear` Retry was greater
than the configured `Max`, then the `Max` value would be returned - regardless
of whether or not a `Jitter` was provided. This modification applies any provided
`Jitter` to the `Max` value in the event that the calculated `Duration` is greater
than the `Max`.

Closes #9384 