### PR TITLE
Allow loadtest teleport image to be configurable

### DIFF
--- a/assets/loadtest/Makefile
+++ b/assets/loadtest/Makefile
@@ -1,5 +1,6 @@
 SOAK_TEST_DURATION ?= 30m
 USE_CERT_MANAGER ?= yes
+TELEPORT_IMAGE ?= quay.io/gravitational/teleport-ent:8.0.0
 
 .PHONY: reserve-ips
 reserve-ips:
@@ -19,12 +20,12 @@ delete-cluster:
 # deploy teleport with etcd backend to loadtest namespace
 .PHONY: deploy-etcd-cluster
 deploy-etcd-cluster:
-	@make -C k8s apply BACKEND=etcd USE_CERT_MANAGER=$(USE_CERT_MANAGER)
+	@make -C k8s apply BACKEND=etcd USE_CERT_MANAGER=$(USE_CERT_MANAGER) TELEPORT_IMAGE=$(TELEPORT_IMAGE)
 
 # deploy teleport with etcd backend to loadtest namespace
 .PHONY: deploy-firestore-cluster
 deploy-firestore-cluster:
-	@make -C k8s apply BACKEND=firestore USE_CERT_MANAGER=$(USE_CERT_MANAGER)
+	@make -C k8s apply BACKEND=firestore USE_CERT_MANAGER=$(USE_CERT_MANAGER) TELEPORT_IMAGE=$(TELEPORT_IMAGE)
 
 # delete the loadtest namespace
 .PHONY: delete-deploy
@@ -34,7 +35,7 @@ delete-deploy:
 # run soak tests
 .PHONY: run-soak-tests
 run-soak-tests:
-	@make -C k8s run-soak-tests SOAK_TEST_DURATION=$(SOAK_TEST_DURATION)	
+	@make -C k8s run-soak-tests SOAK_TEST_DURATION=$(SOAK_TEST_DURATION) TELEPORT_IMAGE=$(TELEPORT_IMAGE)
 
 # run 500 node trusted cluster scaling test
 # This installs 500 trusted clusters, waits for a period of time and then
@@ -42,7 +43,7 @@ run-soak-tests:
 # The test helps identify any potential memory leaks caused by remote clusters
 .PHONY: run-tc-scaling-test
 run-tc-scaling-test:
-	@make -C k8s run-tc-scaling-test
+	@make -C k8s run-tc-scaling-test TELEPORT_IMAGE=$(TELEPORT_IMAGE)
 
 # run the 10k scaling test
 # This tests installs 10,000 IoT nodes and then removes all 10,000 nodes after a fixed period of time.
@@ -50,7 +51,7 @@ run-tc-scaling-test:
 # potential memory leaks caused by large clusters for both non-IoT and IoT nodes.
 .PHONY: run-scaling-test
 run-scaling-test:
-	@make -C k8s run-scaling-test
+	@make -C k8s run-scaling-test TELEPORT_IMAGE=$(TELEPORT_IMAGE)
 
 # list pods in loadtest namespace
 .PHONY: pods

--- a/assets/loadtest/Makefile
+++ b/assets/loadtest/Makefile
@@ -58,6 +58,11 @@ run-scaling-test:
 pods:
 	@make -C k8s pods
 
+# get cluster credentials
+.PHONY: get-creds
+get-creds:
+	@make -C cluster get-creds
+
 # collect heap and goroutine profiles
 .PHONY: collect-profiles
 collect-profiles:

--- a/assets/loadtest/k8s/Makefile
+++ b/assets/loadtest/k8s/Makefile
@@ -3,6 +3,7 @@ CERT_MANAGER_VERSION ?= 1.6.0
 SOAK_TEST_DURATION ?= 30m
 BACKEND ?= etcd
 USE_CERT_MANAGER ?= yes
+TELEPORT_IMAGE ?= quay.io/gravitational/teleport-ent:8.0.0
 
 # performs initialization needed for cluster
 # 1) generates etcd certs
@@ -12,6 +13,13 @@ USE_CERT_MANAGER ?= yes
 # 4) creates and applies secrets
 .PHONY: setup
 setup:
+	@if [ -z ${TELEPORT_IMAGE} ]; then \
+		echo "TELEPORT_IMAGE is not set, cannot apply cluster."; \
+		exit 1; \
+	fi
+
+
+	@echo "applying image: ${TELEPORT_IMAGE}"
 ifeq ($(BACKEND), etcd)
 	make -C ../etcd/certs all
 endif
@@ -170,7 +178,8 @@ setup-auth:
 		--from-file=user.yaml=../teleport/soaktest-user.yaml \
 		--dry-run=client -o yaml | kubectl apply -f -
 
-	kubectl apply -f auth-etcd.yaml
+	@make expand-yaml FILENAME=auth-etcd
+	kubectl apply -f auth-etcd-gen.yaml
 else ifeq ($(BACKEND), firestore)
 .PHONY: setup-auth
 setup-auth:
@@ -184,7 +193,8 @@ setup-auth:
 		--from-file=user.yaml=../teleport/soaktest-user.yaml \
 		--dry-run=client -o yaml | kubectl apply -f -
 
-	kubectl apply -f auth-firestore.yaml
+	@make expand-yaml FILENAME=auth-firestore
+	kubectl apply -f auth-firestore-gen.yaml
 else
 .PHONY: setup-auth
 setup-auth:
@@ -195,8 +205,8 @@ endif
 # deletes auth deployment, services and configmaps
 .PHONY: delete-auth
 delete-auth:
-	kubectl delete -f auth-etcd.yaml --ignore-not-found
-	kubectl delete -f auth-firestore.yaml --ignore-not-found
+	kubectl delete -f auth-etcd-gen.yaml --ignore-not-found
+	kubectl delete -f auth-firestore-gen.yaml --ignore-not-found
 	kubectl delete configmap auth-config -n loadtest --ignore-not-found
 
 # install proxy
@@ -225,13 +235,13 @@ delete-nodes: delete-node delete-iot-node
 # deletes all non-IoT nodes
 .PHONY: delete-node
 delete-node:
-	kubectl delete -f node.yaml --ignore-not-found
+	kubectl delete -f node-gen.yaml --ignore-not-found
 	kubectl delete configmap node-config -n loadtest --ignore-not-found
 
 # deletes all IoT nodes
 .PHONY: delete-iot-node
 delete-iot-node:
-	kubectl delete -f iot-node.yaml --ignore-not-found
+	kubectl delete -f iot-node-gen.yaml --ignore-not-found
 	kubectl delete configmap iot-node-config -n loadtest --ignore-not-found
 
 # install one IoT node and one non-IoT node
@@ -246,7 +256,8 @@ install-iot-node:
 		--from-file=teleport.yaml=../teleport/teleport-iot-node-gen.yaml \
 		--dry-run=client -o yaml | kubectl apply -f -
 
-	kubectl apply -f iot-node.yaml
+	@make expand-yaml FILENAME=iot-node
+	kubectl apply -f iot-node-gen.yaml
 
 # install a non-IoT mode node
 .PHONY: install-node
@@ -255,8 +266,9 @@ install-node:
 	kubectl create configmap node-config -n loadtest \
 		--from-file=teleport.yaml=../teleport/teleport-node-gen.yaml \
 		--dry-run=client -o yaml | kubectl apply -f -
-	
-	kubectl apply -f node.yaml
+
+	@make expand-yaml FILENAME=node
+	kubectl apply -f node-gen.yaml
 
 # installs a trusted cluster
 .PHONY: install-tc
@@ -267,7 +279,8 @@ install-tc:
 		--from-file=cluster.yaml=../teleport/tc-gen.yaml \
 		--dry-run=client -o yaml | kubectl apply -f -
 
-	kubectl apply -f tc.yaml
+	@make expand-yaml FILENAME=tc
+	kubectl apply -f tc-gen.yaml
 
 # deletes all rc resources from teleport and deletes trusted cluster deployments and configmaps
 .PHONY: delete-tc
@@ -345,7 +358,9 @@ install-soaktest:
 		--from-file=auth=./secrets/soaktest-auth \
 		--dry-run=client -o yaml | kubectl apply -f -
 
-	kubectl create -f soaktest.yaml
+
+	@make expand-yaml FILENAME=soaktest
+	kubectl create -f soaktest-gen.yaml
 
 # deploys a job to run the soak tests
 .PHONY: run-soak-tests

--- a/assets/loadtest/k8s/auth-etcd.yaml
+++ b/assets/loadtest/k8s/auth-etcd.yaml
@@ -39,8 +39,8 @@ spec:
               subPath: telegraf.conf
               readOnly: true
         - name: teleport
-          image: gcr.io/teleport-loadtest/teleport:8.0.0-tross.dev.1
-          args: ["-d", "--insecure"]
+          image: ${TELEPORT_IMAGE}
+          args: ["-d", "--insecure", "--diag-addr=0.0.0.0:3434"]
           ports:
             - name: diag
               containerPort: 3434

--- a/assets/loadtest/k8s/auth-firestore.yaml
+++ b/assets/loadtest/k8s/auth-firestore.yaml
@@ -39,8 +39,8 @@ spec:
               subPath: telegraf.conf
               readOnly: true
         - name: teleport
-          image: quay.io/gravitational/teleport-ent:8.0.0
-          args: ["-d", "--insecure"]
+          image: ${TELEPORT_IMAGE}
+          args: ["-d", "--insecure", "--diag-addr=0.0.0.0:3434"]
           ports:
             - name: diag
               containerPort: 3434

--- a/assets/loadtest/k8s/iot-node.yaml
+++ b/assets/loadtest/k8s/iot-node.yaml
@@ -18,7 +18,7 @@ spec:
         node: iot
     spec:
       containers:
-        - image: gcr.io/teleport-loadtest/teleport:8.0.0-tross.dev.1
+        - image: ${TELEPORT_IMAGE}
           name: teleport
           args: ["-d", "--insecure"]
           ports:

--- a/assets/loadtest/k8s/node.yaml
+++ b/assets/loadtest/k8s/node.yaml
@@ -18,7 +18,7 @@ spec:
         node: regular
     spec:
       containers:
-        - image: gcr.io/teleport-loadtest/teleport:8.0.0-tross.dev.1
+        - image: ${TELEPORT_IMAGE}
           name: teleport
           args: ["-d", "--insecure"]
           ports:

--- a/assets/loadtest/k8s/proxy.yaml
+++ b/assets/loadtest/k8s/proxy.yaml
@@ -33,8 +33,8 @@ spec:
               mountPath: /etc/telegraf/telegraf.conf
               subPath: telegraf.conf
         - name: teleport
-          image: gcr.io/teleport-loadtest/teleport:8.0.0-tross.dev.1
-          args: ["-d", "--insecure"]
+          image: ${TELEPORT_IMAGE}
+          args: ["-d", "--insecure", "--diag-addr=0.0.0.0:3434"]
           ports:
             - name: diag
               containerPort: 3434

--- a/assets/loadtest/k8s/secrets/Makefile
+++ b/assets/loadtest/k8s/secrets/Makefile
@@ -13,6 +13,16 @@ all: grafana-pass influx-pass influx-token join-tokens env
 
 .PHONY: env
 env:
+	@if [ -z ${PROXY_HOST} ]; then \
+		echo "PROXY_HOST is not set, cannot apply cluster."; \
+		exit 1; \
+	fi
+
+	@if [ -z ${GRAFANA_HOST} ]; then \
+		echo "GRAFANA_IP is not set, cannot apply cluster."; \
+		exit 1; \
+	fi
+
 	@echo PROXY_IP=$(shell make -C ../../network get-proxy-ip) > secrets.env
 	@echo PROXY_HOST=${PROXY_HOST} >> secrets.env
 	@echo GRAFANA_IP=$(shell make -C ../../network get-grafana-ip) >> secrets.env

--- a/assets/loadtest/k8s/soaktest.yaml
+++ b/assets/loadtest/k8s/soaktest.yaml
@@ -18,7 +18,7 @@ spec:
           configMap:
             name: soaktest-config
       containers:
-        - image: quay.io/gravitational/teleport-ent:8.0.0
+        - image: ${TELEPORT_IMAGE}
           name: teleport
           envFrom:
           - configMapRef:

--- a/assets/loadtest/k8s/tc.yaml
+++ b/assets/loadtest/k8s/tc.yaml
@@ -23,7 +23,7 @@ spec:
           secret:
             secretName: license
       containers:
-        - image: quay.io/gravitational/teleport-ent:8.0.0
+        - image: ${TELEPORT_IMAGE}
           args: ["-d", "--insecure"]
           name: tc
           ports:

--- a/assets/loadtest/teleport/teleport-auth-etcd.yaml
+++ b/assets/loadtest/teleport/teleport-auth-etcd.yaml
@@ -4,7 +4,6 @@ teleport:
 
   data_dir: /var/lib/teleport
 
-  diag_addr: 0.0.0.0:3434
   advertise_ip: auth
 
   storage:

--- a/assets/loadtest/teleport/teleport-auth-firestore.yaml
+++ b/assets/loadtest/teleport/teleport-auth-firestore.yaml
@@ -4,7 +4,6 @@ teleport:
 
   data_dir: /var/lib/teleport
 
-  diag_addr: 0.0.0.0:3434
   advertise_ip: auth
 
   storage:

--- a/assets/loadtest/teleport/teleport-proxy.yaml
+++ b/assets/loadtest/teleport/teleport-proxy.yaml
@@ -2,7 +2,6 @@ teleport:
   log:
     severity: DEBUG
 
-  diag_addr: 0.0.0.0:3434
   data_dir: /var/lib/teleport
   auth_servers: ["auth:3025"]
   auth_token: "proxy-${PROXY_TOKEN}"


### PR DESCRIPTION
This makes the image used by the Teleport deployments configurable
via make. In order to support older images, the diagnostics address is now passed
via the cli flag instead of being set in the config file. We now also validate required environment 
variables are set prior to applying.