### PR TITLE
[v8 backport] Update Docker image tags in docs

### DIFF
--- a/docs/pages/enterprise/getting-started.mdx
+++ b/docs/pages/enterprise/getting-started.mdx
@@ -374,8 +374,8 @@ They are stable, and we recommend their use to easily keep your Teleport Enterpr
 
 | Image name | Open Source or Enterprise? | Teleport version | Image automatically updated? | Image base |
 | - | - | - | - | - |
-| `quay.io/gravitational/teleport-ent:(=version=)` | Enterprise | The latest version of Teleport Enterprise (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
-| `quay.io/gravitational/teleport-ent:(=version=)-fips` | Enterprise FIPS | The latest version of Teleport Enterprise (=version=) FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `(=teleport.latest_ent_docker_image=)` | Enterprise | The latest version of Teleport Enterprise (=version=) | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `(=teleport.latest_ent_docker_image=)-fips` | Enterprise FIPS | The latest version of Teleport Enterprise (=version=) FIPS | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
 | `quay.io/gravitational/teleport-ent:(=teleport.version=)` | Enterprise | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
 | `quay.io/gravitational/teleport-ent:(=teleport.version=)-fips` | Enterprise FIPS | The version specified in the image's tag (i.e. (=teleport.version=)) | No | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
 

--- a/docs/pages/includes/image.mdx
+++ b/docs/pages/includes/image.mdx
@@ -17,7 +17,7 @@ keep your Teleport installation up to date.
    <tr><td>Image name</td><td>Teleport version</td><td>Image automatically updated?</td><td>Image base</td></tr>
  </thead>
  <tbody>
-   <tr><td>`quay.io/gravitational/teleport:(=version=)`</td><td>The latest version of Teleport Open Source (=version=)</td><td>Yes</td><td>[Ubuntu 20.04](https://hub.docker.com/\_/ubuntu)</td></tr>
+   <tr><td>`(=teleport.latest_oss_docker_image=)`</td><td>The latest version of Teleport Open Source (=version=)</td><td>Yes</td><td>[Ubuntu 20.04](https://hub.docker.com/\_/ubuntu)</td></tr>
    <tr><td>`quay.io/gravitational/teleport:(=teleport.version=)`</td><td>The version specified in the image's tag (i.e. (=teleport.version=))</td><td>No</td><td>[Ubuntu 20.04](https://hub.docker.com/\_/ubuntu)</td></tr> 
  </tbody>
 </table>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -81,7 +81,7 @@ up-to-date information.
 Please follow our [Getting started with Teleport using Docker](./setup/guides/docker.mdx) or with [Teleport Enterprise using Docker](enterprise/getting-started.mdx#run-teleport-enterprise-using-docker) for install and setup instructions.
 
 ```code
-$ docker pull quay.io/gravitational/teleport:(=teleport.version=)
+$ docker pull (=teleport.latest_oss_docker_image=)
 ```
 
 ## Helm


### PR DESCRIPTION
**backports:** https://github.com/gravitational/teleport/pull/9400

Some docs pages related to our Docker images use the
(= version =) variable to populate image tags. However, this
variable uses a different format for version numbers than our
image repositories, meaning that users attempting
to pull images mentioned in these docs see an error message.

This change uses the teleport.latest_(oss|ent)_docker_image
variable instead.

Closes #7871