### PR TITLE
(v8) Do not parse MySQL server packets

### DIFF
--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -281,7 +281,7 @@ func (e *Engine) receiveFromServer(serverConn, clientConn net.Conn, serverErrCh 
 		close(serverErrCh)
 	}()
 	for {
-		packet, err := protocol.ParsePacket(serverConn)
+		packet, _, err := protocol.ReadPacket(serverConn)
 		if err != nil {
 			if utils.IsOKNetworkError(err) {
 				log.Debug("Server connection closed.")
@@ -291,7 +291,7 @@ func (e *Engine) receiveFromServer(serverConn, clientConn net.Conn, serverErrCh 
 			serverErrCh <- err
 			return
 		}
-		_, err = protocol.WritePacket(packet.Bytes(), clientConn)
+		_, err = protocol.WritePacket(packet, clientConn)
 		if err != nil {
 			log.WithError(err).Error("Failed to write client packet.")
 			serverErrCh <- err


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/9406. 

Previously all packets sent by MySQL client or server were parsed by the same `ParsePacket` function. This caused issues with some packets returned by the server. For example, our parsing code could get confused by a certain packet returned by server if it's "type" (5th byte in packet) would match one of client-side packets. This led to the issue where one of the result set packets returned by server was mistakenly interpreted as a `COM_CHANGE_USER` packet. This PR addressed it by not trying to interpret the server packets since we don't do any processing for them currently.