### PR TITLE
[V8] Exclude Jitter from being marshaled in JSON logging

### DIFF
--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -112,7 +112,7 @@ type LinearConfig struct {
 	// Jitter is an optional jitter function to be applied
 	// to the delay.  Note that supplying a jitter means that
 	// successive calls to Duration may return different results.
-	Jitter Jitter
+	Jitter Jitter `json:"-"`
 	// AutoReset, if greater than zero, causes the linear retry to automatically
 	// reset after Max * AutoReset has elapsed since the last call to Incr.
 	AutoReset int64


### PR DESCRIPTION
[backport of #9417]

Jitter is a function so it doesn't have a reasonable JSON representation, telling the JSON formatted to exclude it fixes the error.

#9128