### PR TITLE
Default to `mongosh` when connecting to MongoDB. (#8472)

### DIFF
--- a/docs/pages/database-access/faq.mdx
+++ b/docs/pages/database-access/faq.mdx
@@ -43,7 +43,7 @@ Teleport relies on client certificates for authentication so any database client
 that supports this method of authentication and uses modern TLS (1.2+) should
 work.
 
-Standard command-line clients such as `psql`, `mysql`, or `mongo` are supported,
+Standard command-line clients such as `psql`, `mysql`, `mongo` or `mongosh` are supported,
 there are also instructions for configuring select [graphical clients](./guides/gui-clients.mdx).
 
 ## When will you support X database?

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -185,8 +185,8 @@ $ tsh db connect mongodb-atlas
 ```
 
 <Admonition type="note" title="Note">
-  The `mongo` command-line client should be available in PATH in order to be
-  able to connect.
+  Either the `mongosh` or `mongo` command-line clients should be available in PATH in order to be
+  able to connect. The `mongosh` is tried first with `mongo` being the fallback option.
 </Admonition>
 
 To log out of the database and remove credentials:

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -89,7 +89,7 @@ MongoDB treats the entire `Subject` line of the client certificate as a username
 When connecting to a MongoDB server, say as a user `alice`, Teleport will sign
 an ephemeral certificate with `CN=alice` subject.
 
-To create this user in the database, connect to it using `mongo` shell and run
+To create this user in the database, connect to it using `mongosh` or `mongo` shell and run
 the following command:
 
 ```js
@@ -225,7 +225,7 @@ $ tsh db connect example-mongo
 ```
 
 <Admonition type="note" title="Note">
-  The `mongo` command-line client should be available in PATH in order to be
+  The `mongosh` command-line client should be available in PATH in order to be
   able to connect.
 </Admonition>
 

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -225,8 +225,8 @@ $ tsh db connect example-mongo
 ```
 
 <Admonition type="note" title="Note">
-  The `mongosh` command-line client should be available in PATH in order to be
-  able to connect.
+  Either the `mongosh` or `mongo` command-line clients should be available in PATH in order to be
+  able to connect. The `mongosh` is tried first with `mongo` being the fallback option.
 </Admonition>
 
 To log out of the database and remove credentials:

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -138,7 +138,7 @@ $ tsh db connect --db-user=alice --db-name=db example
 ```
 
 <Admonition type="note" title="Note">
-  Respective database CLI clients (`psql`, `mysql` or `mongo`) should be
+  Respective database CLI clients (`psql`, `mysql`, `mongo` or `mongosh`) should be
   available in PATH.
 </Admonition>
 

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -590,7 +590,14 @@ func getMongoCommand(tc *client.TeleportClient, profile *client.ProfileStatus, d
 	if db.Database != "" {
 		args = append(args, db.Database)
 	}
-	return exec.Command(mongoBin, args...)
+
+	// look for `mongosh`, fall back to `mongo` if not found.
+	clientPath, err := exec.LookPath(mongoshBin)
+	if err != nil {
+		return exec.Command(mongoBin, args...)
+	}
+
+	return exec.Command(clientPath, args...)
 }
 
 func formatDatabaseListCommand(clusterFlag string) string {
@@ -642,6 +649,8 @@ const (
 	cockroachBin = "cockroach"
 	// mysqlBin is the MySQL client binary name.
 	mysqlBin = "mysql"
-	// mongoBin is the Mongo client binary name.
+	// mongoshBin is the Mongo Shell client binary name.
+	mongoshBin = "mongosh"
+	// mongoBin is the (legacy) Mongo client binary name.
 	mongoBin = "mongo"
 )


### PR DESCRIPTION
What
-----

Makes the `mongosh` default MongoDB command line client to look for. If it isn't available, we fallback to legacy `mongo` client. 

The docs are updated accordingly.

Fixes #8472.