### PR TITLE
Deduplicate access request IDs before signing certificates

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1575,6 +1575,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 
 	if len(req.AccessRequests) > 0 {
 		// add any applicable access request values.
+		req.AccessRequests = apiutils.Deduplicate(req.AccessRequests)
 		for _, reqID := range req.AccessRequests {
 			accessReq, err := services.GetAccessRequest(ctx, a.authServer, reqID)
 			if err != nil {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -2115,6 +2115,9 @@ func printStatus(debug bool, p *client.ProfileStatus, isActive bool) {
 
 	fmt.Printf("%vProfile URL:        %v\n", prefix, p.ProxyURL.String())
 	fmt.Printf("  Logged in as:       %v\n", p.Username)
+	if len(p.ActiveRequests.AccessRequests) != 0 {
+		fmt.Printf("  Active requests:    %v\n", strings.Join(p.ActiveRequests.AccessRequests, ", "))
+	}
 	if p.Cluster != "" {
 		fmt.Printf("  Cluster:            %v\n", p.Cluster)
 	}


### PR DESCRIPTION
An user with an approved access request `<request_id>` could repeatedly call `tsh login --request-id=<request_id>` and accumulate multiple copies of the same access request in their ssh certificate, so we just deduplicate the IDs before proceeding with the checks and the issuance.

As a bonus, we also display the current active requests (if any) in the output of `tsh status`.