### PR TITLE
Fix the UI to correctly determine if a user has access to a resource

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1799,16 +1799,18 @@ func (set RoleSet) String() string {
 	return fmt.Sprintf("roles %v", strings.Join(roleNames, ","))
 }
 
-// CheckAccessToAnyResource is used to determine if access is possible for an
-// entire category of resources.
-// Rules with a Where clause are handled differently by the method:
-// - "allow" rules have their "where" clause always match, as it's assumed that
-//   there could be a resource that matches it.
-// - "deny" rules have their "where" clause always fail, as it's assumed that
-//   there could be a resource that passes it.
-// Do not use this method to check for access for specific resources, instead
-// use CheckAccessToRule.
-func (set RoleSet) CheckAccessToAnyResource(ctx RuleContext, namespace string, resource string, verb string, silent bool) error {
+// GuessIfAccessIsPossible guesses if access is possible for an entire category
+// of resources.
+// It responds the question: "is it possible that there is a resource of this
+// kind that the current user can access?".
+// GuessIfAccessIsPossible is used, mainly, for UI decisions ("should the tab
+// for resource X appear"?). Most callers should use CheckAccessToRule instead.
+func (set RoleSet) GuessIfAccessIsPossible(ctx RuleContext, namespace string, resource string, verb string, silent bool) error {
+	// "Where" clause are handled differently by the method:
+	// - "allow" rules have their "where" clause always match, as it's assumed
+	//   that there could be a resource that matches it.
+	// - "deny" rules have their "where" clause always fail, as it's assumed that
+	//   there could be a resource that passes it.
 	return set.checkAccessToRuleImpl(checkAccessParams{
 		ctx:        ctx,
 		namespace:  namespace,

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1491,7 +1491,7 @@ func TestCheckRuleAccess(t *testing.T) {
 	}
 }
 
-func TestCheckAccessToAnyResource(t *testing.T) {
+func TestGuessIfAccessIsPossible(t *testing.T) {
 	// Examples from https://goteleport.com/docs/access-controls/reference/#rbac-for-sessions.
 	ownSessions, err := types.NewRole("own-sessions", types.RoleSpecV4{
 		Allow: types.RoleConditions{
@@ -1575,9 +1575,9 @@ func TestCheckAccessToAnyResource(t *testing.T) {
 		// wantRuleAccess fully evaluates where conditions, used to determine access
 		// to specific resources.
 		wantRuleAccess bool
-		// wantResourceAccess doesn't evaluate where conditions, used to determine
+		// wantGuessAccess doesn't evaluate where conditions, used to determine
 		// access to a category of resources.
-		wantResourceAccess bool
+		wantGuessAccess bool
 	}{
 		{
 			name:  "global session list/read allowed",
@@ -1587,8 +1587,8 @@ func TestCheckAccessToAnyResource(t *testing.T) {
 				resource:  types.KindSession,
 				verbs:     []string{types.VerbList, types.VerbRead},
 			},
-			wantRuleAccess:     true,
-			wantResourceAccess: true,
+			wantRuleAccess:  true,
+			wantGuessAccess: true,
 		},
 		{
 			name:  "own session list/read allowed",
@@ -1598,8 +1598,8 @@ func TestCheckAccessToAnyResource(t *testing.T) {
 				resource:  types.KindSession,
 				verbs:     []string{types.VerbList, types.VerbRead},
 			},
-			wantRuleAccess:     false, // where condition needs specific resource
-			wantResourceAccess: true,
+			wantRuleAccess:  false, // where condition needs specific resource
+			wantGuessAccess: true,
 		},
 		{
 			name:  "session list/read denied",
@@ -1630,8 +1630,8 @@ func TestCheckAccessToAnyResource(t *testing.T) {
 				resource:  types.KindSSHSession,
 				verbs:     []string{types.VerbList, types.VerbRead},
 			},
-			wantRuleAccess:     true,
-			wantResourceAccess: true,
+			wantRuleAccess:  true,
+			wantGuessAccess: true,
 		},
 		{
 			name:  "own SSH session list/read allowed",
@@ -1641,8 +1641,8 @@ func TestCheckAccessToAnyResource(t *testing.T) {
 				resource:  types.KindSSHSession,
 				verbs:     []string{types.VerbList, types.VerbRead},
 			},
-			wantRuleAccess:     false, // where condition needs specific resource
-			wantResourceAccess: true,
+			wantRuleAccess:  false, // where condition needs specific resource
+			wantGuessAccess: true,
 		},
 		{
 			name: "SSH session list/read denied",
@@ -1680,9 +1680,9 @@ func TestCheckAccessToAnyResource(t *testing.T) {
 					t.Errorf("CheckAccessToRule(verb=%q) returned err = %v=q, wantAccess = %v", verb, err, wantAccess)
 				}
 
-				err = test.roles.CheckAccessToAnyResource(&params.ctx, params.namespace, params.resource, verb, silent)
-				if gotAccess, wantAccess := err == nil, test.wantResourceAccess; gotAccess != wantAccess {
-					t.Errorf("CheckAccessToAnyResource(verb=%q) returned err = %q, wantAccess = %v", verb, err, wantAccess)
+				err = test.roles.GuessIfAccessIsPossible(&params.ctx, params.namespace, params.resource, verb, silent)
+				if gotAccess, wantAccess := err == nil, test.wantGuessAccess; gotAccess != wantAccess {
+					t.Errorf("GuessIfAccessIsPossible(verb=%q) returned err = %q, wantAccess = %v", verb, err, wantAccess)
 				}
 			}
 		})

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -149,14 +149,12 @@ func getWindowsDesktopLogins(roleSet services.RoleSet) []string {
 
 func hasAccess(roleSet services.RoleSet, ctx *services.Context, kind string, verbs ...string) bool {
 	for _, verb := range verbs {
-		// Since this check occurs often and it does not imply the caller is trying
-		// to access any resource, silence any logging done on the proxy.
-		err := roleSet.CheckAccessToRule(ctx, apidefaults.Namespace, kind, verb, true)
-		if err != nil {
+		// Since this check occurs often and does not imply the caller is trying to
+		// access any resource, silence any logging done on the proxy.
+		if err := roleSet.CheckAccessToAnyResource(ctx, apidefaults.Namespace, kind, verb, true); err != nil {
 			return false
 		}
 	}
-
 	return true
 }
 

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -151,7 +151,7 @@ func hasAccess(roleSet services.RoleSet, ctx *services.Context, kind string, ver
 	for _, verb := range verbs {
 		// Since this check occurs often and does not imply the caller is trying to
 		// access any resource, silence any logging done on the proxy.
-		if err := roleSet.CheckAccessToAnyResource(ctx, apidefaults.Namespace, kind, verb, true); err != nil {
+		if err := roleSet.GuessIfAccessIsPossible(ctx, apidefaults.Namespace, kind, verb, true); err != nil {
 			return false
 		}
 	}


### PR DESCRIPTION
Introduce the GuessIfAccessIsPossible method, so callers may verify if a user has access to a category of resources, instead of access to a specific resource.

Fixes a bug where the "Session Recordings" menu doesn't show for users with where-based roles.