### PR TITLE
Add access requests to TLS certificates

### DIFF
--- a/api/types/session.go
+++ b/api/types/session.go
@@ -510,6 +510,8 @@ type NewWebSessionRequest struct {
 	SessionTTL time.Duration
 	// LoginTime is the time that this user recently logged in.
 	LoginTime time.Time
+	// AccessRequests contains the UUIDs of the access requests currently in use.
+	AccessRequests []string
 }
 
 // Check validates the request.

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -985,11 +985,12 @@ func (a *Server) generateUserCert(req certRequest) (*proto.Certs, error) {
 			Username:    req.dbUser,
 			Database:    req.dbName,
 		},
-		DatabaseNames: dbNames,
-		DatabaseUsers: dbUsers,
-		MFAVerified:   req.mfaVerified,
-		ClientIP:      req.clientIP,
-		AWSRoleARNs:   roleARNs,
+		DatabaseNames:  dbNames,
+		DatabaseUsers:  dbUsers,
+		MFAVerified:    req.mfaVerified,
+		ClientIP:       req.clientIP,
+		AWSRoleARNs:    roleARNs,
+		ActiveRequests: req.activeRequests.AccessRequests,
 	}
 	subject, err := identity.Subject()
 	if err != nil {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1104,9 +1104,10 @@ func (a *Server) PreAuthenticatedSignIn(user string, identity tlsca.Identity) (t
 		return nil, trace.Wrap(err)
 	}
 	sess, err := a.NewWebSession(types.NewWebSessionRequest{
-		User:   user,
-		Roles:  roles,
-		Traits: traits,
+		User:           user,
+		Roles:          roles,
+		Traits:         traits,
+		AccessRequests: identity.ActiveRequests,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1560,6 +1560,10 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// If the user is generating a certificate, the roles and traits come from the logged in identity.
 	if req.Username == a.context.User.GetName() {
 		roles, traits, err = services.ExtractFromIdentity(a.authServer, a.context.Identity.GetIdentity())
+		// we're going to extend the roles list based on the access requests, so
+		// we ensure that all the current requests are added to the new
+		// certificate (and are checked again)
+		req.AccessRequests = append(req.AccessRequests, a.context.Identity.GetIdentity().ActiveRequests...)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -66,11 +66,12 @@ func (s *Server) CreateAppSession(ctx context.Context, req types.CreateAppSessio
 		return nil, trace.Wrap(err)
 	}
 	certs, err := s.generateUserCert(certRequest{
-		user:      user,
-		publicKey: publicKey,
-		checker:   checker,
-		ttl:       ttl,
-		traits:    traits,
+		user:           user,
+		publicKey:      publicKey,
+		checker:        checker,
+		ttl:            ttl,
+		traits:         traits,
+		activeRequests: services.RequestIDs{AccessRequests: identity.ActiveRequests},
 		// Only allow this certificate to be used for applications.
 		usage: []string{teleport.UsageAppsOnly},
 		// Add in the application routing information.

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1547,6 +1547,19 @@ func (s *TLSSuite) TestWebSessionWithApprovedAccessRequestAndSwitchback(c *check
 	_, hasRole = mappedRole["test-request-role"]
 	c.Assert(hasRole, check.Equals, true)
 
+	// certRequests extracts the active requests from a PEM encoded TLS cert.
+	certRequests := func(tlsCert []byte) []string {
+		cert, err := tlsca.ParseCertificatePEM(tlsCert)
+		c.Assert(err, check.IsNil)
+
+		identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+		c.Assert(err, check.IsNil)
+
+		return identity.ActiveRequests
+	}
+
+	c.Assert(certRequests(sess1.GetTLSCert()), check.DeepEquals, []string{accessReq.GetName()})
+
 	// Test switch back to default role and expiry.
 	sess2, err := web.ExtendWebSession(WebSessionReq{
 		User:          user,
@@ -1563,6 +1576,8 @@ func (s *TLSSuite) TestWebSessionWithApprovedAccessRequestAndSwitchback(c *check
 	roles, _, err = services.ExtractFromCertificate(sshcert)
 	c.Assert(err, check.IsNil)
 	c.Assert(roles, check.DeepEquals, []string{initialRole})
+
+	c.Assert(certRequests(sess2.GetTLSCert()), check.HasLen, 0)
 }
 
 // TestGetCertAuthority tests certificate authority permissions
@@ -1709,6 +1724,17 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 		return apiutils.SliceContainsStr(identity.Groups, role)
 	}
 
+	// certRequests extracts the active requests from a PEM encoded TLS cert.
+	certRequests := func(tlsCert []byte) []string {
+		cert, err := tlsca.ParseCertificatePEM(tlsCert)
+		c.Assert(err, check.IsNil)
+
+		identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
+		c.Assert(err, check.IsNil)
+
+		return identity.ActiveRequests
+	}
+
 	// certLogins extracts the logins from an ssh certificate
 	certLogins := func(sshCert []byte) []string {
 		cert, err := sshutils.ParseCertificate(sshCert)
@@ -1722,6 +1748,8 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 	if certContainsRole(userCerts.TLS, role) {
 		c.Errorf("unexpected role %s", role)
 	}
+	// ensure that the default identity doesn't have any active requests
+	c.Assert(certRequests(userCerts.TLS), check.HasLen, 0)
 
 	// verify that cert for user with no static logins is generated with
 	// exactly one login and that it is an invalid unix login (indicated
@@ -1748,12 +1776,35 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 	if !certContainsRole(userCerts.TLS, role) {
 		c.Errorf("missing requested role %s", role)
 	}
+	// ensure that the request is stored in the certs
+	c.Assert(certRequests(userCerts.TLS), check.DeepEquals, []string{req.GetName()})
 
 	// verify that dynamically applied role granted a login,
 	// which is is valid and has replaced the dummy login.
 	logins = certLogins(userCerts.SSH)
 	c.Assert(len(logins), check.Equals, 1)
 	c.Assert(rune(logins[0][0]), check.Not(check.Equals), '-')
+
+	elevatedCert, err := tls.X509KeyPair(userCerts.TLS, priv)
+	c.Assert(err, check.IsNil)
+	elevatedClient := s.server.NewClientWithCert(elevatedCert)
+
+	newCerts, err := elevatedClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
+		PublicKey: pub,
+		Username:  user,
+		Expires:   time.Now().Add(time.Hour).UTC(),
+		Format:    constants.CertificateFormatStandard,
+		// no new access requests
+		AccessRequests: nil,
+	})
+	c.Assert(err, check.IsNil)
+
+	// in spite of having no access requests, we still have elevated roles...
+	if !certContainsRole(newCerts.TLS, role) {
+		c.Errorf("missing requested role %s", role)
+	}
+	// ...and the certificate shows the access request
+	c.Assert(certRequests(newCerts.TLS), check.DeepEquals, []string{req.GetName()})
 
 	// attempt to apply request in DENIED state (should fail)
 	c.Assert(s.server.Auth().SetAccessRequestState(ctx, types.AccessRequestUpdate{RequestID: req.GetName(), State: types.RequestState_DENIED}), check.IsNil)
@@ -1765,6 +1816,17 @@ func (s *TLSSuite) TestAccessRequest(c *check.C) {
 
 	// ensure that once in the DENIED state, a request cannot be set back to APPROVED state.
 	c.Assert(s.server.Auth().SetAccessRequestState(ctx, types.AccessRequestUpdate{RequestID: req.GetName(), State: types.RequestState_APPROVED}), check.NotNil)
+
+	// ensure that identities with requests in the DENIED state can't reissue new certs.
+	_, err = elevatedClient.GenerateUserCerts(ctx, proto.UserCertsRequest{
+		PublicKey: pub,
+		Username:  user,
+		Expires:   time.Now().Add(time.Hour).UTC(),
+		Format:    constants.CertificateFormatStandard,
+		// no new access requests
+		AccessRequests: nil,
+	})
+	c.Assert(err, check.NotNil)
 }
 
 func (s *TLSSuite) TestPluginData(c *check.C) {


### PR DESCRIPTION
This PR adds a list of the currently active access requests that have contributed to the roles for a `tlsca.Identity`, similarly to what we already do for SSH certificates. Some minor changes were necessary with regards to web sessions and app sessions to ensure that the access requests are propagated correctly.

As a sanity check, `lib/auth/auth_with_roles.go:(*ServerWithRoles).generateUserCerts`, when called by a user to generate new certificates for themself, now requires that all the access requests in the user's identity are existing and valid - the previous behavior only checked the *new* access requests for validity before adding roles to the current set, so the old ones could've been deleted or marked as denied and nobody would've been the wiser.

## Security considerations

This feature can be used for both logging (as was the intention for adding access requests to SSH certificates, currently only implemented for the `session.start` event) and for locking a specific access request (see #9478).

Once those features are in place, a codepath that lets a malicious user obtain a certificate with elevated roles but incorrect access requests could then allow them to reduce their visibility by not showing the elevation in the event log, or outright ignore locks that target a specific access request (perhaps one that was identified as having been mistakingly or maliciously approved).

This PR aims to cover all paths in which we ultimately create a new `tlsca.Identity` and/or a new TLS certificate, both when reissuing a certificate for a different purpose but with the same privileges, and when issuing a new certificate adding privileges based on one or more access requests.