### PR TITLE
Encodes plus characters in sso redirect url

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2652,7 +2652,11 @@ type ssoRequestParams struct {
 }
 
 func parseSSORequestParams(r *http.Request) (*ssoRequestParams, error) {
-	query := r.URL.Query()
+	rawQuery := strings.Replace(r.URL.RawQuery, "+", "%2B", -1)
+	query, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	clientRedirectURL := query.Get("redirect_url")
 	if clientRedirectURL == "" {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2652,11 +2652,10 @@ type ssoRequestParams struct {
 }
 
 func parseSSORequestParams(r *http.Request) (*ssoRequestParams, error) {
+	// We are encoding plus characters to preserve them after parsing.
+	// Otherwise the query parser will replace the unencoded plus chars with spaces.
 	rawQuery := strings.Replace(r.URL.RawQuery, "+", "%2B", -1)
-	query, err := url.ParseQuery(rawQuery)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	query, _ := url.ParseQuery(rawQuery)
 
 	clientRedirectURL := query.Get("redirect_url")
 	if clientRedirectURL == "" {


### PR DESCRIPTION
#### Description
Encodes plus characters b/c the default behavior was replacing plus with a space. The plus character needs to be preserved so the frontend side can parse it correctly (plus is used to mark a filter as a AND filter)