### PR TITLE
[helm] Re-add space after type in service definition

### DIFF
--- a/examples/chart/teleport-cluster/templates/service.yaml
+++ b/examples/chart/teleport-cluster/templates/service.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  type: {{- default "LoadBalancer" .Values.service.type }}
+  type: {{ default "LoadBalancer" .Values.service.type }}
   {{- with .Values.service.spec }}
   {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
The whitespace after `type:` was being trimmed, which was causing a lint error. Not sure how this got through the linter in the first place.