### PR TITLE
Add Debian/Ubuntu Linux instructions

### DIFF
--- a/docs/pages/getting-started/linux-server.mdx
+++ b/docs/pages/getting-started/linux-server.mdx
@@ -37,6 +37,8 @@ Run the following commands to install the Teleport binary on your system:
   <TabItem label="Debian/Ubuntu (DEB)">
     ```code
     $ curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo apt-key add -
+    # software-properties-common includes add-apt-repository
+    $ apt-get install --no-install-recommends software-properties-common
     $ sudo add-apt-repository 'deb https://deb.releases.teleport.dev/ stable main'
     $ sudo apt-get update
     $ sudo apt-get install teleport


### PR DESCRIPTION
For users that haven't installed software-properties-common,
the instructions to use apt-add-repository in our Linux Getting
Started guide won't work. This adds instructions to install
the package.

Fixes #8609