### PR TITLE
fallback to calling origin if rc is missing from cache

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1525,7 +1525,7 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 	tcHasReconnected := func() bool {
 		return tc.SSH(context.TODO(), cmd, false) == nil
 	}
-	require.Eventually(t, tcHasReconnected, 2500*time.Millisecond, 250*time.Millisecond,
+	require.Eventually(t, tcHasReconnected, 10*time.Second, 250*time.Millisecond,
 		"Timed out waiting for Site A to restart")
 
 	clientHasEvents := func(site auth.ClientI, count int) func() bool {

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -676,7 +676,7 @@ func (s *session) startInteractive(ch ssh.Channel, ctx *ServerContext) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		s.recorder, err = events.NewAuditWriter(events.AuditWriterConfig{
+		rec, err := events.NewAuditWriter(events.AuditWriterConfig{
 			// Audit stream is using server context, not session context,
 			// to make sure that session is uploaded even after it is closed
 			Context:      ctx.srv.Context(),
@@ -692,6 +692,7 @@ func (s *session) startInteractive(ch ssh.Channel, ctx *ServerContext) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		s.recorder = rec
 	}
 	s.writer.addWriter("session-recorder", utils.WriteCloserWithContext(ctx.srv.Context(), s.recorder), true)
 
@@ -874,7 +875,7 @@ func (s *session) startExec(channel ssh.Channel, ctx *ServerContext) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		s.recorder, err = events.NewAuditWriter(events.AuditWriterConfig{
+		rec, err := events.NewAuditWriter(events.AuditWriterConfig{
 			// Audit stream is using server context, not session context,
 			// to make sure that session is uploaded even after it is closed
 			Context:      ctx.srv.Context(),
@@ -890,6 +891,7 @@ func (s *session) startExec(channel ssh.Channel, ctx *ServerContext) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		s.recorder = rec
 	}
 
 	// Emit a session.start event for the exec session.


### PR DESCRIPTION
A lot of our cache lookups for singular named resources (e.g. a specific user or CA) fallback to calling the upstream cache/backend if they hit a `NotFound` error.  This is useful in situations where a resource needs to be loadable immediately after its creation.  This PR adds the standard fallback logic to `Cache.GetRemoteCluster` as well.

This change is intended to improve the reliability of dialing a node in a remote cluster immediately after the cluster was added, and reduce the flakiness of tunneling-related tests.  Previously, it was possible that attempting to dial a node in a remote cluster would hit a `NotFound` error, even *after* the remote cluster's tunnel was established and healthy (as seen in some recent failures of the `TwoClustersTunnel` integration test).