### PR TITLE
Fix Flaky Retry Tests

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2193,8 +2193,11 @@ func TestCache_Backoff(t *testing.T) {
 			require.GreaterOrEqual(t, duration, stepMin)
 			require.LessOrEqual(t, duration, stepMax)
 
+			// wait for cache to get to retry.After
+			clock.BlockUntil(1)
+
 			// add some extra to the duration to ensure the retry occurs
-			clock.Advance(duration * 3)
+			clock.Advance(p.cache.MaxRetryPeriod)
 		case <-time.After(time.Minute):
 			t.Fatalf("timeout waiting for event")
 		}

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -250,6 +250,9 @@ type Config struct {
 
 	// MaxRetryPeriod is the maximum period between reconnection attempts to auth
 	MaxRetryPeriod time.Duration
+
+	// ConnectFailureC is a channel to notify of failures to connect to auth (used in tests).
+	ConnectFailureC chan time.Duration
 }
 
 // ApplyToken assigns a given token to all internal services but only if token
@@ -1114,6 +1117,7 @@ func ApplyDefaults(cfg *Config) {
 		Time:   defaults.ConnectionErrorMeasurementPeriod,
 	}
 	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
+	cfg.ConnectFailureC = make(chan time.Duration, 1)
 }
 
 // ApplyFIPSDefaults updates default configuration to be FedRAMP/FIPS 140-2

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -86,7 +86,7 @@ func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*
 
 		// Used for testing that auth service will attempt to reconnect in the provided duration.
 		select {
-		case process.connectFailureC <- retry.Duration():
+		case process.Config.ConnectFailureC <- retry.Duration():
 		default:
 		}
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -319,9 +319,6 @@ type TeleportProcess struct {
 
 	// clusterFeatures contain flags for supported and unsupported features.
 	clusterFeatures proto.Features
-
-	// connectFailureC is a channel to notify of failures to connect to auth (used in tests).
-	connectFailureC chan time.Duration
 }
 
 type keyPairKey struct {
@@ -713,7 +710,6 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 		id:                  processID,
 		keyPairs:            make(map[keyPairKey]KeyPair),
 		appDependCh:         make(chan Event, 1024),
-		connectFailureC:     make(chan time.Duration),
 	}
 
 	process.registerAppDepend()

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -545,6 +545,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = true
+	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
 	process, err := NewTeleport(cfg)
 	require.NoError(t, err)
 
@@ -567,8 +568,12 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 
 			require.GreaterOrEqual(t, duration, stepMin)
 			require.LessOrEqual(t, duration, stepMax)
+
+			// wait for connection to get to retry.After
+			clock.BlockUntil(1)
+
 			// add some extra to the duration to ensure the retry occurs
-			clock.Advance(duration * 3)
+			clock.Advance(cfg.MaxRetryPeriod)
 		case <-time.After(time.Minute):
 			t.Fatalf("timeout waiting for failure")
 		}

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -546,6 +546,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = true
 	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
+	cfg.ConnectFailureC = make(chan time.Duration, 5)
 	process, err := NewTeleport(cfg)
 	require.NoError(t, err)
 
@@ -562,7 +563,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		// wait for connection to fail
 		select {
-		case duration := <-process.connectFailureC:
+		case duration := <-process.Config.ConnectFailureC:
 			stepMin := step * time.Duration(i) / 2
 			stepMax := step * time.Duration(i+1)
 

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -82,8 +82,12 @@ func TestResourceWatcher_Backoff(t *testing.T) {
 
 			require.GreaterOrEqual(t, duration, stepMin)
 			require.LessOrEqual(t, duration, stepMax)
+
+			// wait for watcher to get to retry.After
+			clock.BlockUntil(1)
+
 			// add some extra to the duration to ensure the retry occurs
-			clock.Advance(duration * 3)
+			clock.Advance(w.MaxRetryPeriod)
 		case <-time.After(time.Minute):
 			t.Fatalf("timeout waiting for reset")
 		}

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -66,6 +66,7 @@ func TestResourceWatcher_Backoff(t *testing.T) {
 			Clock:          clock,
 			MaxRetryPeriod: defaults.MaxWatcherBackoff,
 			Client:         &errorWatcher{},
+			ResetC:         make(chan time.Duration, 5),
 		},
 		ProxyGetter: &nopProxyGetter{},
 	})


### PR DESCRIPTION
Tests Addressed in this PR:

- `github.com/gravitational/teleport/lib/service.TestTeleportProcess_reconnectToAuth`
- `github.com/gravitational/teleport/lib/service.TestResourceWatcher_Backoff`
- `github.com/gravitational/teleport/lib/cache.TestCache_Backoff`


The Backoff/Reconnect tests now utilize `FakeClock.BlockUntil` to prevent advancing the clock until the underlying `utils.Retry` has called `After`.