### PR TITLE
Added stateless merge queue.

### DIFF
--- a/.github/workflows/queue.yaml
+++ b/.github/workflows/queue.yaml
@@ -1,0 +1,37 @@
+# This workflow will run every 15 minutes and if the branch is out-of-date
+# with the base branch it will merge the latest changes from master into this
+# branch.
+name: "Merge Queue"
+on:
+  schedule:
+    # Runs every 15 minutes.
+    - cron: '0,15 * * * *'
+
+# Limit the permissions on the GitHub token for this workflow to the subset
+# that is required. In this case, the merge queue needs to be able to write
+# to Pull Requests (to update them), nothing else.
+permissions:
+  actions: none
+  pull-requests: write
+  checks: none
+  contents: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  merge-queue:
+    name: "Merge Queue"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout master branch"
+        uses: "actions/checkout@v2"
+        with:
+          ref: "master"
+      - name: "Installing the latest version of Go"
+        uses: "actions/setup-go@v2"
+      - name: "Update PRs"
+        run: cd .github/workflows/robot && go run main.go -workflow=queue -token="${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/robot/internal/bot/bot_test.go
+++ b/.github/workflows/robot/internal/bot/bot_test.go
@@ -120,3 +120,7 @@ func (f *fakeGithub) ListWorkflowRuns(ctx context.Context, organization string, 
 func (f *fakeGithub) DeleteWorkflowRun(ctx context.Context, organization string, repository string, runID int64) error {
 	return nil
 }
+
+func (f *fakeGithub) UpdateBranch(ctx context.Context, organization string, repository string, number int) error {
+	return nil
+}

--- a/.github/workflows/robot/internal/bot/queue.go
+++ b/.github/workflows/robot/internal/bot/queue.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"context"
+	"log"
+
+	"github.com/gravitational/teleport/.github/workflows/robot/internal/github"
+	"github.com/gravitational/trace"
+)
+
+// Queue will update all eligible PRs with the base branch.
+func (b *Bot) Queue(ctx context.Context) error {
+	pulls, err := b.c.GitHub.ListPullRequests(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		"open")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for _, pull := range pulls {
+		if skipUpdate(pull) {
+			continue
+		}
+
+		err = b.c.GitHub.UpdateBranch(ctx,
+			b.c.Environment.Organization,
+			b.c.Environment.Repository,
+			pull.Number)
+		if err != nil {
+			log.Printf("Failed to update PR %v: %v.", pull.Number, err)
+			continue
+		}
+	}
+
+	return nil
+}
+
+// skipUpdate returns if this branch should be skipped over for updating. PRs
+// are skipped over if they are from a fork, are a branch other than master,
+// auto-merge is disabled, or are not mergeable.
+func skipUpdate(pull github.PullRequest) bool {
+	if pull.Fork {
+		return true
+	}
+	if pull.UnsafeBase != "master" {
+		return true
+	}
+	if !pull.AutoMerge {
+		return true
+	}
+	if pull.Mergeable {
+		return true
+	}
+
+	return false
+}

--- a/.github/workflows/robot/internal/bot/queue_test.go
+++ b/.github/workflows/robot/internal/bot/queue_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/.github/workflows/robot/internal/github"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSkipUpdate checks if PRs are appropriately skipped over.
+func TestSkipUpdate(t *testing.T) {
+	tests := []struct {
+		desc       string
+		pr         github.PullRequest
+		skipUpdate bool
+	}{
+		{
+			desc: "fork-skip",
+			pr: github.PullRequest{
+				Author:     "foo",
+				Repository: "bar",
+				UnsafeHead: "baz/qux",
+				UnsafeBase: "master",
+				Fork:       true,
+				AutoMerge:  true,
+				Mergeable:  false,
+			},
+			skipUpdate: true,
+		},
+		{
+			desc: "non-master-skip",
+			pr: github.PullRequest{
+				Author:     "foo",
+				Repository: "bar",
+				UnsafeHead: "baz/qux",
+				UnsafeBase: "branch/v0",
+				Fork:       false,
+				AutoMerge:  true,
+				Mergeable:  false,
+			},
+			skipUpdate: true,
+		},
+		{
+			desc: "no-auto-merge-skip",
+			pr: github.PullRequest{
+				Author:     "foo",
+				Repository: "bar",
+				UnsafeHead: "baz/qux",
+				UnsafeBase: "master",
+				Fork:       false,
+				AutoMerge:  false,
+				Mergeable:  false,
+			},
+			skipUpdate: true,
+		},
+		{
+			desc: "mergeable-skip",
+			pr: github.PullRequest{
+				Author:     "foo",
+				Repository: "bar",
+				UnsafeHead: "baz/qux",
+				UnsafeBase: "master",
+				Fork:       false,
+				AutoMerge:  true,
+				Mergeable:  true,
+			},
+			skipUpdate: true,
+		},
+		{
+			desc: "allow",
+			pr: github.PullRequest{
+				Author:     "foo",
+				Repository: "bar",
+				UnsafeHead: "baz/qux",
+				UnsafeBase: "master",
+				Fork:       false,
+				AutoMerge:  true,
+				Mergeable:  false,
+			},
+			skipUpdate: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ok := skipUpdate(test.pr)
+			require.Equal(t, ok, test.skipUpdate)
+		})
+	}
+}

--- a/.github/workflows/robot/main.go
+++ b/.github/workflows/robot/main.go
@@ -58,6 +58,8 @@ func main() {
 		err = b.Check(ctx)
 	case "dismiss":
 		err = b.Dismiss(ctx)
+	case "queue":
+		err = b.Queue(ctx)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", workflow)
 	}


### PR DESCRIPTION
**Description**

Added stateless merge queue that uses a cron workflow to loop over all Pull Requests every 15 minutes. If the Pull Request has auto merge enabled, it will attempt to update the PR if it has gone out of date with the base branch.

This mimics a real merge queue, but does it in a stateless manner.