### PR TITLE
Document docs labels

### DIFF
--- a/docs/pages/docs/best-practices.mdx
+++ b/docs/pages/docs/best-practices.mdx
@@ -7,6 +7,17 @@ description: Best practices for documentation
 
 This article serves to define [documentation](../docs) best practices.
 
+## GitHub labels
+To help us organize our time responding to issues and pull requests, please add the `documentation` label if you are proposing or making a change to the documentation. You can also help us estimate the time it will take to plan (or review) a change by adding one of the following labels:
+
+|Label|Meaning|
+|:---|:---|
+|docs-new|Requires creating a new docs page|
+|docs-edit|Requires editing an existing docs page (perhaps substantially)|
+|docs-plumbing|Changes to how we build, display, and deploy the docs. May involve [gravitational/next](https://github.com/gravitational/next)|
+|docs-minor-tweak|Straightforward change to a single paragraph or code snippet|
+|docs-assess-scope|Need to assess the scope of the project before starting work|
+
 ## Work Flow
 
 This section describes the general workflow for writing documentation:


### PR DESCRIPTION
To help the docs team estimate time, we have added labels to
GitHub issues and PRs. This change documents these labels
in the Docs Best Practices page.