### PR TITLE
Fix TestIntegrations/TwoClustersTunnel test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1525,7 +1525,7 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 	tcHasReconnected := func() bool {
 		return tc.SSH(context.TODO(), cmd, false) == nil
 	}
-	require.Eventually(t, tcHasReconnected, 2500*time.Millisecond, 250*time.Millisecond,
+	require.Eventually(t, tcHasReconnected, 10*time.Second, 250*time.Millisecond,
 		"Timed out waiting for Site A to restart")
 
 	clientHasEvents := func(site auth.ClientI, count int) func() bool {


### PR DESCRIPTION
The following error has been received multiple times in the TestIntegrations/TwoClustersTunnel test: "Timed out waiting for Site A to restart".

Change TwoClustersTunnel test to wait for reconnect from 2.5 seconds to 10, so it is the same amount of time the test waits for the initial connection.

