### PR TITLE
Added stateless merge queue.

### DIFF
--- a/.github/workflows/queue.yaml
+++ b/.github/workflows/queue.yaml
@@ -1,0 +1,37 @@
+# This workflow will run everytime a PR is merged into master and attempt
+# to update all open PRs that are out of date with master and have "Auto Merge"
+# enabled to mimic the behavior of a merge queue.
+name: "Merge Queue"
+on:
+  push:
+    branches:
+      - master
+
+# Limit the permissions on the GitHub token for this workflow to the subset
+# that is required. In this case, the merge queue needs to be able to write
+# to Pull Requests (to update them), nothing else.
+permissions:
+  actions: none
+  pull-requests: write
+  checks: none
+  contents: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  merge-queue:
+    name: "Merge Queue"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout master branch"
+        uses: "actions/checkout@v2"
+        with:
+          ref: "master"
+      - name: "Installing the latest version of Go"
+        uses: "actions/setup-go@v2"
+      - name: "Update PRs"
+        run: cd .github/workflows/robot && go run main.go -workflow=queue -token="${{ secrets.GITHUB_TOKEN }}" -reviewers="${{ secrets.reviewers }}"

--- a/.github/workflows/robot/internal/bot/bot_test.go
+++ b/.github/workflows/robot/internal/bot/bot_test.go
@@ -124,3 +124,11 @@ func (f *fakeGithub) ListWorkflowRuns(ctx context.Context, organization string, 
 func (f *fakeGithub) DeleteWorkflowRun(ctx context.Context, organization string, repository string, runID int64) error {
 	return nil
 }
+
+func (f *fakeGithub) GetBranch(ctx context.Context, organization string, repository string, branch string) (github.Branch, error) {
+	return github.Branch{}, nil
+}
+
+func (f *fakeGithub) UpdateBranch(ctx context.Context, organization string, repository string, number int) error {
+	return nil
+}

--- a/.github/workflows/robot/internal/bot/dismiss.go
+++ b/.github/workflows/robot/internal/bot/dismiss.go
@@ -49,8 +49,8 @@ func (b *Bot) Dismiss(ctx context.Context) error {
 		if pull.Fork {
 			// HEAD could be controlled by an attacker, however, all this would allow is
 			// the attacker to dismiss a workflow run.
-			if err := b.dismiss(ctx, b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHead); err != nil {
-				log.Printf("Failed to dismiss workflow: %v %v %v: %v.", b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHead, err)
+			if err := b.dismiss(ctx, b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHeadRef); err != nil {
+				log.Printf("Failed to dismiss workflow: %v %v %v: %v.", b.c.Environment.Organization, b.c.Environment.Repository, pull.UnsafeHeadRef, err)
 				continue
 			}
 		}

--- a/.github/workflows/robot/internal/bot/queue.go
+++ b/.github/workflows/robot/internal/bot/queue.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"context"
+	"log"
+
+	"github.com/gravitational/teleport/.github/workflows/robot/internal/github"
+	"github.com/gravitational/trace"
+)
+
+// Queue will update all eligible PRs with the base branch.
+func (b *Bot) Queue(ctx context.Context) error {
+	pulls, err := b.c.GitHub.ListPullRequests(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		"open")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Get the latest master, will be used to check if branch is up to date.
+	master, err := b.c.GitHub.GetBranch(ctx,
+		b.c.Environment.Organization,
+		b.c.Environment.Repository,
+		"master")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Filter out any PRs that are not eligible to be updated.
+	numbers, err := filter(pulls, master)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for _, number := range numbers {
+		err = b.c.GitHub.UpdateBranch(ctx,
+			b.c.Environment.Organization,
+			b.c.Environment.Repository,
+			number)
+		if err != nil {
+			log.Printf("Failed to update PR %v: %v.", number, err)
+			continue
+		}
+	}
+
+	return nil
+}
+
+func filter(pulls []github.PullRequest, master github.Branch) ([]int, error) {
+	var filtered []int
+
+	for _, pull := range pulls {
+		// Skip over PRs from forks, branches other than master, branches that are
+		// up to date with master, and auto merge is not turned on.
+		if pull.Fork {
+			continue
+		}
+		if pull.UnsafeBaseRef != "master" {
+			continue
+		}
+		if pull.BaseSHA == master.SHA {
+			continue
+		}
+		if !pull.AutoMerge {
+			continue
+		}
+
+		filtered = append(filtered, pull.Number)
+	}
+
+	return filtered, nil
+}

--- a/.github/workflows/robot/internal/bot/queue_test.go
+++ b/.github/workflows/robot/internal/bot/queue_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bot
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/.github/workflows/robot/internal/github"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFilter checks if the filtering correctly filters out non-eligible PRs.
+func TestFilter(t *testing.T) {
+	pulls := []github.PullRequest{
+		// From fork.
+		github.PullRequest{
+			Author:        "foo",
+			Repository:    "bar",
+			Number:        1,
+			UnsafeHeadRef: "baz/qux",
+			HeadSHA:       "0000000000000000000000000000000000000000000000000000000000000001",
+			UnsafeBaseRef: "master",
+			BaseSHA:       "0000000000000000000000000000000000000000000000000000000000000001",
+			Fork:          true,
+			AutoMerge:     true,
+		},
+		// Not master.
+		github.PullRequest{
+			Author:        "foo",
+			Repository:    "bar",
+			Number:        2,
+			UnsafeHeadRef: "baz/qux",
+			HeadSHA:       "0000000000000000000000000000000000000000000000000000000000000001",
+			UnsafeBaseRef: "branch/v0",
+			BaseSHA:       "0000000000000000000000000000000000000000000000000000000000000001",
+			Fork:          false,
+			AutoMerge:     true,
+		},
+		// No auto merge.
+		github.PullRequest{
+			Author:        "foo",
+			Repository:    "bar",
+			Number:        3,
+			UnsafeHeadRef: "baz/qux",
+			HeadSHA:       "0000000000000000000000000000000000000000000000000000000000000001",
+			UnsafeBaseRef: "master",
+			BaseSHA:       "0000000000000000000000000000000000000000000000000000000000000001",
+			Fork:          false,
+			AutoMerge:     false,
+		},
+		// Up to date.
+		github.PullRequest{
+			Author:        "foo",
+			Repository:    "bar",
+			Number:        4,
+			UnsafeHeadRef: "baz/qux",
+			HeadSHA:       "0000000000000000000000000000000000000000000000000000000000000001",
+			UnsafeBaseRef: "master",
+			BaseSHA:       "0000000000000000000000000000000000000000000000000000000000000001",
+			Fork:          false,
+			AutoMerge:     true,
+		},
+		// No up to date.
+		github.PullRequest{
+			Author:        "foo",
+			Repository:    "bar",
+			Number:        5,
+			UnsafeHeadRef: "baz/qux",
+			HeadSHA:       "0000000000000000000000000000000000000000000000000000000000000001",
+			UnsafeBaseRef: "master",
+			BaseSHA:       "0000000000000000000000000000000000000000000000000000000000000002",
+			Fork:          false,
+			AutoMerge:     true,
+		},
+	}
+	master := github.Branch{
+		UnsafeName: "master",
+		SHA:        "0000000000000000000000000000000000000000000000000000000000000001",
+	}
+
+	filtered, err := filter(pulls, master)
+	require.NoError(t, err)
+	require.ElementsMatch(t, filtered, []int{5})
+}

--- a/.github/workflows/robot/main.go
+++ b/.github/workflows/robot/main.go
@@ -60,6 +60,8 @@ func main() {
 		err = b.Dismiss(ctx)
 	case "label":
 		err = b.Label(ctx)
+	case "queue":
+		err = b.Queue(ctx)
 	default:
 		err = trace.BadParameter("unknown workflow: %v", workflow)
 	}


### PR DESCRIPTION
**Description**

Added stateless merge queue that uses a cron workflow to loop over all Pull Requests every 15 minutes. If the Pull Request has auto merge enabled, it will attempt to update the PR if it has gone out of date with the base branch.

This mimics a real merge queue, but does it in a stateless manner.