### PR TITLE
Clarify Kubernetes Getting Started guide

### DIFF
--- a/docs/pages/kubernetes-access/getting-started/cluster.mdx
+++ b/docs/pages/kubernetes-access/getting-started/cluster.mdx
@@ -5,11 +5,17 @@ description: Getting started with Teleport. Let's deploy Teleport in a Kubernete
 
 # Getting Started
 
-Let's deploy Teleport in a Kubernetes with SSO and Audit logs:
+Let's deploy Teleport in a Kubernetes cluster with SSO and Audit logs:
 
 - Install Teleport in a Kubernetes cluster.
 - Set up Single Sign-On (SSO).
 - Capture and playback Kubernetes commands.
+
+While completing this guide, you will deploy a single Teleport pod running the Auth Service and Proxy Service on your Kubernetes cluster, and a load balancer that allows outside traffic to your Teleport cluster.
+
+<Admonition type="tip" title="Have an existing Teleport cluster?">
+If you are already running Teleport on another platform, you can use your existing Teleport deployment to access your Kubernetes cluster. [Follow our guide](./agent.mdx) to connect your Kubernetes cluster to Teleport.
+</Admonition>
 
 ## Follow along with our video guide
 
@@ -23,6 +29,15 @@ Let's deploy Teleport in a Kubernetes with SSO and Audit logs:
 />
 
 ## Prerequisites
+- A registered domain name. This is required for Teleport to set up TLS via Let's Encrypt and for Teleport clients to verify the Proxy Service host.
+
+- A Kubernetes cluster hosted by a cloud provider, which is required for the load balancer we deploy in this guide.
+
+<Admonition title="Local-only setups" type="tip">
+Teleport also supports Kubernetes in on-premise and air-gapped environments. If you would like to try out Teleport on your local machine, we recommend following our [Docker Compose guide](../../getting-started/docker-compose.mdx). 
+
+You can also [contact us](/contact-us/) so we can work with you to determine the best setup for your Kubernetes environment.
+</Admonition>
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
 
@@ -30,11 +45,13 @@ Let's deploy Teleport in a Kubernetes with SSO and Audit logs:
 
 ## Step 1/3. Install Teleport
 
-Let's start with a single-pod Teleport using persistent volume as a backend.
+Let's start with a single-pod Teleport using persistent volume as a backend. Modify the values of `CLUSTER_NAME` and `EMAIL` according to your environment, where `CLUSTER_NAME` is the domain name you are using for your Teleport deployment and `EMAIL` is an email address used for notifications.
 
 <Tabs>
   <TabItem label="Open Source">
     ```code
+    $ CLUSTER_NAME="tele.example.com"
+    $ EMAIL="mail@example.com"
     $ helm repo add teleport https://charts.releases.teleport.dev
 
     # Install a single node teleport cluster and provision a cert using ACME.
@@ -47,6 +64,8 @@ Let's start with a single-pod Teleport using persistent volume as a backend.
 
   <TabItem label="Enterprise">
     ```code
+    $ CLUSTER_NAME="tele.example.com"
+    $ EMAIL="mail@example.com"
     $ helm repo add teleport https://charts.releases.teleport.dev
 
     # Create a namespace for a deployment.
@@ -84,6 +103,12 @@ to create a public IP for Teleport.
     $ echo $MYIP
     # 192.168.2.1
     ```
+
+    If `$MYIP` is blank, your cloud provider may have assigned a hostname to the load balancer rather than an IP address. Run the following command to retrieve the hostname:
+
+    ```code 
+    $ MYHOSTNAME=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    ```
   </TabItem>
 
   <TabItem label="Enterprise">
@@ -100,6 +125,12 @@ to create a public IP for Teleport.
     $ MYIP=$(kubectl get services teleport-cluster-ent -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     $ echo $MYIP
     # 192.168.2.1
+    ```
+
+    If `$MYIP` is blank, your cloud provider may have assigned a hostname to the load balancer rather than an IP address. Run the following command to retrieve the hostname:
+
+    ```code 
+    $ MYHOSTNAME=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
     ```
   </TabItem>
 </Tabs>
@@ -130,10 +161,7 @@ for web apps using [application access](../../application-access/introduction.md
     $ MYDNS="tele.example.com"
 
     # Create a JSON file changeset for AWS.
-    $ jq -n --arg ip ${MYIP?} --arg dns ${MYDNS?} '{"Comment": "Create records", "Changes": [
-      {"Action": "CREATE", "ResourceRecordSet": {"Name": $dns, "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}},
-      {"Action": "CREATE", "ResourceRecordSet": {"Name": ("*." + $dns), "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}}
-      ]}' > myrecords.json
+    $ jq -n --arg ip ${MYIP?} --arg dns ${MYDNS?} '{"Comment": "Create records", "Changes": [{"Action": "CREATE","ResourceRecordSet": {"Name": $dns, "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}},{"Action": "CREATE", "ResourceRecordSet": {"Name": ("*." + $dns), "Type": "A", "TTL": 300, "ResourceRecords": [{ "Value": $ip}]}}]}' > myrecords.json
 
     # Review records before applying.
     $ cat myrecords.json | jq

--- a/docs/pages/kubernetes-access/getting-started/cluster.mdx
+++ b/docs/pages/kubernetes-access/getting-started/cluster.mdx
@@ -5,13 +5,12 @@ description: Getting started with Teleport. Let's deploy Teleport in a Kubernete
 
 # Getting Started
 
-Let's deploy Teleport in a Kubernetes cluster with SSO and Audit logs:
+Teleport can provide secure, unified access to your Kubernetes clusters. This guide will show you how to:
 
-- Install Teleport in a Kubernetes cluster.
-- Set up Single Sign-On (SSO).
-- Capture and playback Kubernetes commands.
+- Deploy Teleport in a Kubernetes cluster.
+- Set up Single Sign-On (SSO) for authentication to your Teleport cluster.
 
-While completing this guide, you will deploy a single Teleport pod running the Auth Service and Proxy Service on your Kubernetes cluster, and a load balancer that allows outside traffic to your Teleport cluster.
+While completing this guide, you will deploy a single Teleport pod running the Auth Service and Proxy Service in your Kubernetes cluster, and a load balancer that allows outside traffic to your Teleport cluster. Users can then access your Kubernetes cluster via the Teleport cluster running within it.
 
 <Admonition type="tip" title="Have an existing Teleport cluster?">
 If you are already running Teleport on another platform, you can use your existing Teleport deployment to access your Kubernetes cluster. [Follow our guide](./agent.mdx) to connect your Kubernetes cluster to Teleport.
@@ -45,7 +44,7 @@ You can also [contact us](/contact-us/) so we can work with you to determine the
 
 ## Step 1/3. Install Teleport
 
-Let's start with a single-pod Teleport using persistent volume as a backend. Modify the values of `CLUSTER_NAME` and `EMAIL` according to your environment, where `CLUSTER_NAME` is the domain name you are using for your Teleport deployment and `EMAIL` is an email address used for notifications.
+Let's start with a single-pod Teleport deployment using a persistent volume as a backend. Modify the values of `CLUSTER_NAME` and `EMAIL` according to your environment, where `CLUSTER_NAME` is the domain name you are using for your Teleport deployment and `EMAIL` is an email address used for notifications.
 
 <Tabs>
   <TabItem label="Open Source">
@@ -84,7 +83,7 @@ Let's start with a single-pod Teleport using persistent volume as a backend. Mod
   </TabItem>
 </Tabs>
 
-Teleport's helm chart uses an [external load balancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/)
+Teleport's Helm chart uses an [external load balancer](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/)
 to create a public IP for Teleport.
 
 <Tabs>
@@ -175,9 +174,7 @@ for web apps using [application access](../../application-access/introduction.md
   </TabItem>
 </Tabs>
 
-The first request to Teleport's API will take a bit longer because it gets
-a cert from [Let's Encrypt](https://letsencrypt.org).
-Teleport will respond with discovery info:
+Use the following command to confirm that Teleport is running:
 
 ```code
 $ curl https://tele.example.com/webapi/ping
@@ -252,7 +249,7 @@ the default one in case there is a problem.
 $ KUBECONFIG=${HOME?}/teleport.yaml tsh login --proxy=tele.example.com:443 --user=alice
 ```
 
-Teleport updated `KUBECONFIG` with a short-lived 12-hour certificate.
+Teleport updates `KUBECONFIG` with a short-lived 12-hour certificate.
 
 ```code
 # List connected Kubernetes clusters
@@ -272,12 +269,12 @@ $ KUBECONFIG=${HOME?}/teleport.yaml kubectl get -n teleport-cluster pods
 
 ## Step 3/3. SSO for Kubernetes
 
-We are going to setup Github connector for OSS and Okta for Enterprise version.
+In this step, we will set up the GitHub Single Sign-On connector for the OSS version of Teleport and Okta for the Enterprise version.
 
 <Tabs>
   <TabItem label="Open Source">
-    Save the file below as `github.yaml` and update the fields. You will need to set up
-    [Github OAuth 2.0 Connector](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) app.
+    Save the file below as `github.yaml` and update the fields. You will need to set up the
+    [GitHub OAuth 2.0 Connector](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) app.
     Any member with the team `admin` in the organization `octocats` will be able to assume a builtin role `access`.
 
     ```yaml
@@ -287,25 +284,25 @@ We are going to setup Github connector for OSS and Okta for Enterprise version.
       # connector name that will be used with `tsh --auth=github login`
       name: github
     spec:
-      # client ID of Github OAuth app
+      # client ID of your GitHub OAuth app
       client_id: client-id
-      # client secret of Github OAuth app
+      # client secret of your GitHub OAuth app
       client_secret: client-secret
       # This name will be shown on UI login screen
-      display: Github
+      display: GitHub
       # Change tele.example.com to your domain name
       redirect_url: https://tele.example.com:443/v1/webapi/github/callback
       # Map github teams to teleport roles
       teams_to_logins:
-        - organization: octocats # Github organization name
-          team: admin            # Github team name within that organization
-          # map Github's "admin" team to Teleport's "access" role
+        - organization: octocats # GitHub organization name
+          team: admin            # GitHub team name within that organization
+          # map GitHub's "admin" team to Teleport's "access" role
           logins: ["access"]
     ```
   </TabItem>
 
   <TabItem label="Enterprise">
-    Follow [SAML Okta Guide](../../enterprise/sso/okta.mdx#configure-okta) to create a SAML app.
+    Follow the [SAML Okta Guide](../../enterprise/sso/okta.mdx#configure-okta) to create a SAML app.
     Check out [OIDC guides](../../enterprise/sso/oidc.mdx#identity-providers) for OpenID Connect apps.
     Save the file below as `okta.yaml` and update the `acs` field.
     Any member in Okta group `okta-admin` will assume a builtin role `access`.
@@ -350,7 +347,7 @@ To create a connector, we are going to run Teleport's admin tool `tctl` from the
   </TabItem>
 </Tabs>
 
-Try `tsh login` with Github user. I am using a custom `KUBECONFIG` to prevent overwriting
+Try `tsh login` with a GitHub user. This example uses a custom `KUBECONFIG` to prevent overwriting
 the default one in case there is a problem.
 
 <Tabs>

--- a/docs/pages/kubernetes-access/getting-started/cluster.mdx
+++ b/docs/pages/kubernetes-access/getting-started/cluster.mdx
@@ -29,13 +29,10 @@ If you are already running Teleport on another platform, you can use your existi
 
 ## Prerequisites
 - A registered domain name. This is required for Teleport to set up TLS via Let's Encrypt and for Teleport clients to verify the Proxy Service host.
-
 - A Kubernetes cluster hosted by a cloud provider, which is required for the load balancer we deploy in this guide.
 
 <Admonition title="Local-only setups" type="tip">
 Teleport also supports Kubernetes in on-premise and air-gapped environments. If you would like to try out Teleport on your local machine, we recommend following our [Docker Compose guide](../../getting-started/docker-compose.mdx). 
-
-You can also [contact us](/contact-us/) so we can work with you to determine the best setup for your Kubernetes environment.
 </Admonition>
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
@@ -97,16 +94,16 @@ to create a public IP for Teleport.
     # NAME               TYPE           CLUSTER-IP   EXTERNAL-IP      PORT(S)                        AGE
     # teleport-cluster   LoadBalancer   10.4.4.73    104.199.126.88   443:31204/TCP,3026:32690/TCP   89s
 
-    # Save the pod IP or Hostname. If the IP is not available, check the pod and load balancer status.
+    # Save the pod IP or hostname.
     $ MYIP=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     $ echo $MYIP
     # 192.168.2.1
     ```
 
-    If `$MYIP` is blank, your cloud provider may have assigned a hostname to the load balancer rather than an IP address. Run the following command to retrieve the hostname:
+    If `$MYIP` is blank, your cloud provider may have assigned a hostname to the load balancer rather than an IP address. Run the following command to retrieve the hostname, which you will use in place of `$MYIP` for subsequent commands.
 
     ```code 
-    $ MYHOSTNAME=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    $ MYIP=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
     ```
   </TabItem>
 
@@ -120,16 +117,16 @@ to create a public IP for Teleport.
     # NAME                   TYPE           CLUSTER-IP   EXTERNAL-IP      PORT(S)                        AGE
     # teleport-cluster-ent   LoadBalancer   10.4.4.73    104.199.126.88   443:31204/TCP,3026:32690/TCP   89s
 
-    # Save the pod IP or Hostname. If the IP is not available, check the pod and load balancer status.
+    # Save the pod IP or hostname.
     $ MYIP=$(kubectl get services teleport-cluster-ent -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     $ echo $MYIP
     # 192.168.2.1
     ```
 
-    If `$MYIP` is blank, your cloud provider may have assigned a hostname to the load balancer rather than an IP address. Run the following command to retrieve the hostname:
+    If `$MYIP` is blank, your cloud provider may have assigned a hostname to the load balancer rather than an IP address. Run the following command to retrieve the hostname, which you will use in place of `$MYIP` for subsequent commands.
 
     ```code 
-    $ MYHOSTNAME=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    $ MYIP=$(kubectl get services teleport-cluster -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
     ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
This change address some issues I found while working through
the "Getting Started - Kubernetes with SSO" guide.

- Assign required env variables in code snippets, and offer
  instructions for changing them. Otherwise, a reader may not
  realize that these variables are required for a command when
  pasting code.

- Put the AWS Route 53 jq command on one line. This way, users
  can copy it using our single-line copy button, and most of
  the command will no longer display as a comment.

- Add an admonition that describes the difference between this
  guide and our other Kubernetes Getting Started guide. This
  way, a reader won't have to read through that guide to
  understand why we have two Getting Started guides for
  Kubernetes.

- Indicate that a domain name is required. Not having one
  really tripped me up when I worked through this guide the
  first time.

- For users with environments that preclude access to the public
  internet, I added an admonition linking to the docker-compose
  guide and our contact page, with a mention of our on-prem
  Kubernetes support. We can replace this with a link to a
  local-only Kubernetes guide when one is available.

- While some Kubernetes load balancers populate the hostname,
  rather than the IP in the status field, this guide only
  includes instructions for fetching the IP. This adds
  instructions for fetching the hostname as well.

  See:
  https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceStatus

Closes #9086
Closes #9112