### PR TITLE
Update MySQL custom configuration file example

### DIFF
--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -25,7 +25,7 @@ which you'll need to enable mutual TLS on your MySQL server.
 ## Configure MySQL Server
 
 To configure MySQL server to accept TLS connections, add the following to
-MySQL configuration file `mysql.cnf`:
+a MySQL custom configuration file such as `/etc/mysql/conf.d/teleportmysql.cnf`:
 
 ```conf
 [mysqld]


### PR DESCRIPTION
To work in mysql V8 need to store mysql custom configurations under `/etc/mysql/conf.d` not `/etc/mysql/mysql.cnf` that did work in V5