### PR TITLE
Improve TestTwoClustersTunnel troubleshooting

### DIFF
--- a/lib/utils/testlog/log.go
+++ b/lib/utils/testlog/log.go
@@ -23,13 +23,11 @@ import (
 	"testing"
 
 	"github.com/gravitational/teleport/lib/utils"
-
-	"gopkg.in/check.v1"
 )
 
 // FailureOnly returns a logger that only prints the logs to STDERR when the
 // test fails.
-func FailureOnly(t TestingInterface) utils.Logger {
+func FailureOnly(t *testing.T) utils.Logger {
 	// Collect all output into buf.
 	buf := utils.NewSyncBuffer()
 	logger := utils.NewLoggerForTests()
@@ -43,63 +41,4 @@ func FailureOnly(t TestingInterface) utils.Logger {
 	})
 
 	return utils.WrapLogger(logger.WithField("test", t.Name()))
-}
-
-// NewCheckTestWrapper creates a new logging wrapper for the specified
-// *gocheck.C value.
-// Returned value has an exported Log attribute that represents
-// the logger for the underlying test.
-// It is caller's responsibility to release the wrapper by invoking
-// Close after the test has completed.
-func NewCheckTestWrapper(c *check.C) *TestWrapper {
-	w := &TestWrapper{
-		c: c,
-	}
-	w.Log = FailureOnly(w)
-	return w
-}
-
-// Cleanup registers the specified handler f to be run
-// after the test has completed
-func (r *TestWrapper) Cleanup(f func()) {
-	r.cleanups = append(r.cleanups, f)
-}
-
-// Failed returns true if the underlying test has failed
-func (r *TestWrapper) Failed() bool {
-	return r.c.Failed()
-}
-
-// Name returns the name of the underlying test
-func (r *TestWrapper) Name() string {
-	return r.c.TestName()
-}
-
-// Close invokes all registered cleanup handlers
-func (r *TestWrapper) Close() {
-	for _, f := range r.cleanups {
-		f()
-	}
-}
-
-// TestWrapper wraps an existing *gocheck.C value for a specific test.
-// Implements TestingInterface
-type TestWrapper struct {
-	// Log specifies the logger that can be used to emit
-	// test-specific messages
-	Log utils.Logger
-
-	c        *check.C
-	cleanups []func()
-}
-
-// TestingInterface abstracts a testing implementation.
-type TestingInterface interface {
-	// Cleanup registers the specified handler f to be run
-	// after the test has completed
-	Cleanup(func())
-	// Failed returns true of the underlying test has failed
-	Failed() bool
-	// Name returns the name of the underlying test
-	Name() string
 }


### PR DESCRIPTION
This PR likely won't fix any of the flakiness, but should help in
debugging:

- Wait for TeleInstance's process to close
- Don't delete the data directory before the process is shut down
- Include site name in logging to make it easier to distinguish which
  site is shutting down
- Don't call StopAll twice (it was deferred and run manually)
- Include cluster name in log output
- Remove unused TestWrapper left over from the Check framework