### PR TITLE
Add github teams to available traits

### DIFF
--- a/api/types/github.go
+++ b/api/types/github.go
@@ -75,6 +75,8 @@ type GithubClaims struct {
 	Username string
 	// OrganizationToTeams is the user's organization and team membership
 	OrganizationToTeams map[string][]string
+	// Teams is the users team membership
+	Teams []string
 }
 
 // GetVersion returns resource version

--- a/constants.go
+++ b/constants.go
@@ -525,6 +525,10 @@ const (
 	// allowed database users.
 	TraitDBUsers = "db_users"
 
+	// TraitTeams is the name of the role variable use to store team
+	// membership information
+	TraitTeams = "github_teams"
+
 	// TraitInternalLoginsVariable is the variable used to store allowed
 	// logins for local accounts.
 	TraitInternalLoginsVariable = "{{internal.logins}}"

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -80,6 +80,7 @@ func (s *GithubSuite) TestPopulateClaims(c *check.C) {
 			"org1": {"team1", "team2"},
 			"org2": {"team1"},
 		},
+		Teams: []string{"team1", "team2", "team1"},
 	})
 }
 


### PR DESCRIPTION
This adds a team entry to GithubClaims so that a user can have `team` set in their traits.

#3160