### PR TITLE
Add "create database agent configuration" CLI command

### DIFF
--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -1,0 +1,275 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/trace"
+)
+
+// databaseConfigTemplateFunc list of template functions used on the database
+// config template.
+var databaseConfigTemplateFuncs = template.FuncMap{
+	"quote": quote,
+	"join":  strings.Join,
+}
+
+// databaseAgentConfigurationTemplate database configuration template.
+var databaseAgentConfigurationTemplate = template.Must(template.New("").Funcs(databaseConfigTemplateFuncs).Parse(`#
+# Teleport database agent configuration file.
+# Configuration reference: https://goteleport.com/docs/database-access/reference/configuration/
+#
+teleport:
+  nodename: {{ .NodeName }}
+  data_dir: {{ .DataDir }}
+  auth_token: {{ .AuthToken }}
+  auth_servers:
+  {{- range .AuthServersAddr }}
+  - {{ . }}
+  {{- end }}
+  {{- if .CAPins }}
+  ca_pin:
+  {{- range .CAPins }}
+  - {{ . }}
+  {{- end }}
+  {{- end }}
+db_service:
+  enabled: "yes"
+  # Matchers for database resources created with "tctl create" command.
+  # For more information: https://goteleport.com/docs/database-access/guides/dynamic-registration/
+  resources:
+  - labels:
+      "*": "*"
+  {{- if or .RDSDiscoveryRegions .RedshiftDiscoveryRegions }}
+  # Matchers for registering AWS-hosted databases.
+  aws:
+  {{- end }}
+  {{- if .RDSDiscoveryRegions }}
+  # RDS/Aurora databases auto-discovery.
+  # For more information about RDS/Aurora auto-discovery: https://goteleport.com/docs/database-access/guides/rds/
+  - types: ["rds"]
+    # AWS regions to register databases from.
+    regions:
+    {{- range .RDSDiscoveryRegions }}
+    - {{ . }}
+    {{- end }}
+    # AWS resource tags to match when registering databases.
+    tags:
+      "*": "*"
+  {{- end }}
+  {{- if .RedshiftDiscoveryRegions }}
+  # Redshift databases auto-discovery.
+  # For more information about Redshift auto-discovery: https://goteleport.com/docs/database-access/guides/postgres-redshift/
+  - types: ["redshift"]
+    # AWS regions to register databases from.
+    regions:
+    {{- range .RedshiftDiscoveryRegions }}
+    - {{ . }}
+    {{- end }}
+    # AWS resource tags to match when registering databases.
+    tags:
+      "*": "*"
+  {{- end }}
+  # Lists statically registered databases proxied by this agent.
+  {{- if .StaticDatabaseName }}
+  databases:
+  - name: {{ .StaticDatabaseName }}
+    protocol: {{ .StaticDatabaseProtocol }}
+    uri: {{ .StaticDatabaseURI }}
+    {{- if .StaticDatabaseStaticLabels }}
+    static_labels:
+    {{- range $name, $value := .StaticDatabaseStaticLabels }}
+      "{{ $name }}": "{{ $value }}"
+    {{- end }}
+    {{- if .StaticDatabaseStaticLabels }}
+    dynamic_labels:
+    {{- range $name, $label := .StaticDatabaseDynamicLabels }}
+    - name: {{ $name }}
+      period: {{ $label.Period }}
+      command:
+      {{- range $command := $label.Command }}
+      - {{ $command | quote }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- else }}
+  # databases:
+  # # RDS database static configuration.
+  # # RDS/Aurora databases Auto-discovery reference: https://goteleport.com/docs/database-access/guides/rds/
+  # - name: rds
+  #   description: AWS RDS/Aurora instance configuration example.
+  #   # Supported protocols for RDS/Aurora: "postgres" or "mysql"
+  #   protocol: postgres
+  #   # Database connection endpoint. Must be reachable from Database Service.
+  #   uri: rds-instance-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432
+  #   # AWS specific configuration.
+  #   aws:
+  #     # Region the database is deployed in.
+  #     region: us-west-1
+  #     # RDS/Aurora specific configuration.
+  #     rds:
+  #       # RDS Instance ID. Only present on RDS databases.
+  #       instance_id: rds-instance-1
+  # # Aurora database static configuration.
+  # # RDS/Aurora databases Auto-discovery reference: https://goteleport.com/docs/database-access/guides/rds/
+  # - name: aurora
+  #   description: AWS Aurora cluster configuration example.
+  #   # Supported protocols for RDS/Aurora: "postgres" or "mysql"
+  #   protocol: postgres
+  #   # Database connection endpoint. Must be reachable from Database Service.
+  #   uri: aurora-cluster-1.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432
+  #   # AWS specific configuration.
+  #   aws:
+  #     # Region the database is deployed in.
+  #     region: us-west-1
+  #     # RDS/Aurora specific configuration.
+  #     rds:
+  #       # Aurora Cluster ID. Only present on Aurora databases.
+  #       cluster_id: aurora-cluster-1
+  # # Redshift database static configuration.
+  # # For more information: https://goteleport.com/docs/database-access/guides/postgres-redshift/
+  # - name: redshift
+  #   description: AWS Redshift cluster configuration example.
+  #   # Supported protocols for Redshift: "postgres".
+  #   protocol: postgres
+  #   # Database connection endpoint. Must be reachable from Database service.
+  #   uri: redshift-cluster-example-1.abcdefghijklmnop.us-west-1.redshift.amazonaws.com:5439
+  #   # AWS specific configuration.
+  #   aws:
+  #     # Region the database is deployed in.
+  #     region: us-west-1
+  #     # Redshift specific configuration.
+  #     redshift:
+  #       # Redshift Cluster ID.
+  #       cluster_id: redshift-cluster-example-1
+  # # Self-hosted static configuration.
+  # - name: self-hosted
+  #   description: Self-hosted database configuration.
+  #   # Supported protocols for self-hosted: {{ join .DatabaseProtocols ", " }}.
+  #   protocol: postgres
+  #   # Database connection endpoint. Must be reachable from Database service.
+  #   uri: database.example.com:5432
+  {{- end }}
+auth_service:
+  enabled: "no"
+ssh_service:
+  enabled: "no"
+proxy_service:
+  enabled: "no"`))
+
+// DatabaseSampleFlags specifies configuration parameters for a database agent.
+type DatabaseSampleFlags struct {
+	// StaticDatabaseName static database name provided by the user.
+	StaticDatabaseName string
+	// StaticDatabaseProtocol static databse protocol provided by the user.
+	StaticDatabaseProtocol string
+	// StaticDatabaseURI static database URI provided by the user.
+	StaticDatabaseURI string
+	// StaticDatabaseStaticLabels list of database static labels provided by
+	// the user.
+	StaticDatabaseStaticLabels map[string]string
+	// StaticDatabaseDynamicLabels list of database dynamic labels provided by
+	// the user.
+	StaticDatabaseDynamicLabels services.CommandLabels
+	// StaticDatabaseRawLabels "raw" list of database labels provided by the
+	// user.
+	StaticDatabaseRawLabels string
+	// NodeName `nodename` configuration.
+	NodeName string
+	// DataDir `data_dir` configuration.
+	DataDir string
+	// ProxyServerAddr is a list of addresses of the auth servers placed on
+	// the configuration.
+	AuthServersAddr []string
+	// AuthToken auth server token.
+	AuthToken string
+	// CAPins are the SKPI hashes of the CAs used to verify the Auth Server.
+	CAPins []string
+	// RDSDiscoveryRegions list of regions the RDS auto-discovery is
+	// configured.
+	RDSDiscoveryRegions []string
+	// RedshiftDiscoveryRegions list of regions the Redshift auto-discovery is
+	// configured.
+	RedshiftDiscoveryRegions []string
+	// DatabaseProtocols list of database protocols supported.
+	DatabaseProtocols []string
+}
+
+// CheckAndSetDefaults checks and sets default values for the flags.
+func (f *DatabaseSampleFlags) CheckAndSetDefaults() error {
+	conf := service.MakeDefaultConfig()
+	f.DatabaseProtocols = defaults.DatabaseProtocols
+
+	if f.NodeName == "" {
+		f.NodeName = conf.Hostname
+	}
+	if f.DataDir == "" {
+		f.DataDir = conf.DataDir
+	}
+
+	if f.StaticDatabaseName != "" || f.StaticDatabaseProtocol != "" || f.StaticDatabaseURI != "" {
+		if f.StaticDatabaseName == "" {
+			return trace.BadParameter("--name is required when configuring static database")
+		}
+		if f.StaticDatabaseProtocol == "" {
+			return trace.BadParameter("--protocol is required when configuring static database")
+		}
+		if f.StaticDatabaseURI == "" {
+			return trace.BadParameter("--uri is required when configuring static database")
+		}
+
+		if f.StaticDatabaseRawLabels != "" {
+			var err error
+			f.StaticDatabaseStaticLabels, f.StaticDatabaseDynamicLabels, err = parseLabels(f.StaticDatabaseRawLabels)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// MakeDatabaseAgentConfigString generates a simple database agent
+// configuration based on the flags provided. Returns the configuration as a
+// string.
+func MakeDatabaseAgentConfigString(flags DatabaseSampleFlags) (string, error) {
+	err := flags.CheckAndSetDefaults()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	buf := new(bytes.Buffer)
+	err = databaseAgentConfigurationTemplate.Execute(buf, flags)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return buf.String(), nil
+}
+
+// quote quotes a string, similar to the `quote` helper from Helm.
+// Implementation reference: https://github.com/Masterminds/sprig/blob/3ac42c7bc5e4be6aa534e036fb19dde4a996da2e/strings.go#L83
+func quote(str string) string {
+	return fmt.Sprintf("%q", str)
+}

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -1,0 +1,136 @@
+// Copyright 2022 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeDatabaseConfig(t *testing.T) {
+	t.Run("Global", func(t *testing.T) {
+		flags := DatabaseSampleFlags{
+			NodeName:        "testlocal",
+			DataDir:         "/var/lib/data",
+			AuthServersAddr: []string{"localhost:3080"},
+			AuthToken:       "/tmp/token.txt",
+			CAPins:          []string{"pin-1", "pin-2"},
+		}
+
+		configString, err := MakeDatabaseAgentConfigString(flags)
+		require.NoError(t, err)
+
+		fileConfig, err := ReadConfig(bytes.NewBuffer([]byte(configString)))
+		require.NoError(t, err)
+
+		require.Equal(t, flags.NodeName, fileConfig.NodeName)
+		require.Equal(t, flags.DataDir, fileConfig.DataDir)
+		require.ElementsMatch(t, flags.AuthServersAddr, fileConfig.AuthServers)
+		require.Equal(t, flags.AuthToken, fileConfig.AuthToken)
+		require.ElementsMatch(t, flags.CAPins, fileConfig.CAPin)
+	})
+
+	t.Run("RDSAutoDiscovery", func(t *testing.T) {
+		flags := DatabaseSampleFlags{
+			RDSDiscoveryRegions: []string{"us-west-1", "us-west-2"},
+		}
+
+		databases := generateAndParseConfig(t, flags)
+		require.Len(t, databases.AWSMatchers, 1)
+		require.ElementsMatch(t, []string{"rds"}, databases.AWSMatchers[0].Types)
+		require.ElementsMatch(t, flags.RDSDiscoveryRegions, databases.AWSMatchers[0].Regions)
+	})
+
+	t.Run("RedshiftAutoDiscovery", func(t *testing.T) {
+		flags := DatabaseSampleFlags{
+			RedshiftDiscoveryRegions: []string{"us-west-1", "us-west-2"},
+		}
+
+		databases := generateAndParseConfig(t, flags)
+		require.Len(t, databases.AWSMatchers, 1)
+		require.ElementsMatch(t, []string{"redshift"}, databases.AWSMatchers[0].Types)
+		require.ElementsMatch(t, flags.RedshiftDiscoveryRegions, databases.AWSMatchers[0].Regions)
+	})
+
+	t.Run("StaticDatabase", func(t *testing.T) {
+		flags := DatabaseSampleFlags{
+			StaticDatabaseName:      "sample",
+			StaticDatabaseProtocol:  "postgres",
+			StaticDatabaseURI:       "postgres://localhost:5432",
+			StaticDatabaseRawLabels: `env=prod,arch=[5m2s:/bin/uname -m "p1 p2"]`,
+		}
+
+		databases := generateAndParseConfig(t, flags)
+		require.Len(t, databases.Databases, 1)
+		require.Equal(t, flags.StaticDatabaseName, databases.Databases[0].Name)
+		require.Equal(t, flags.StaticDatabaseProtocol, databases.Databases[0].Protocol)
+		require.Equal(t, flags.StaticDatabaseURI, databases.Databases[0].URI)
+		require.Equal(t, map[string]string{"env": "prod"}, databases.Databases[0].StaticLabels)
+
+		require.Len(t, databases.Databases[0].DynamicLabels, 1)
+		require.ElementsMatch(t, []CommandLabel{
+			{
+				Name:    "arch",
+				Period:  time.Minute*5 + time.Second*2,
+				Command: []string{"/bin/uname", "-m", `"p1 p2"`},
+			},
+		}, databases.Databases[0].DynamicLabels)
+
+		t.Run("MissingFields", func(t *testing.T) {
+			tests := map[string]struct {
+				name     string
+				protocol string
+				uri      string
+				tags     string
+			}{
+				"Name":        {protocol: "postgres", uri: "postgres://localhost:5432"},
+				"Protocol":    {name: "sample", uri: "postgres://localhost:5432"},
+				"URI":         {name: "sample", protocol: "postgres"},
+				"InvalidTags": {name: "sample", protocol: "postgres", uri: "postgres://localhost:5432", tags: "abc"},
+			}
+
+			for name, test := range tests {
+				t.Run(name, func(t *testing.T) {
+					flags := DatabaseSampleFlags{
+						StaticDatabaseName:      test.name,
+						StaticDatabaseProtocol:  test.protocol,
+						StaticDatabaseURI:       test.uri,
+						StaticDatabaseRawLabels: test.tags,
+					}
+
+					_, err := MakeDatabaseAgentConfigString(flags)
+					require.Error(t, err)
+				})
+			}
+
+		})
+	})
+}
+
+// generateAndParse generetes config using provided flags, parse them using
+// `ReadConfig`, checks if the Database service is enable and return it.
+func generateAndParseConfig(t *testing.T, flags DatabaseSampleFlags) Databases {
+	configString, err := MakeDatabaseAgentConfigString(flags)
+	require.NoError(t, err)
+
+	fileConfig, err := ReadConfig(bytes.NewBuffer([]byte(configString)))
+	require.NoError(t, err)
+
+	require.True(t, fileConfig.Databases.Enabled())
+	return fileConfig.Databases
+}

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -98,6 +98,19 @@ Fill out and run this command on a node to start proxying the database:
    --protocol={{.db_protocol}} \
    --uri={{.db_uri}}
 
+Or, generate the configuration and start a Teleport agent using it:
+
+> teleport db configure create \
+   --token={{.token}} \{{range .ca_pins}}
+   --ca-pin={{.}} \{{end}}
+   --auth-server={{.auth_server}} \
+   --name={{.db_name}} \
+   --protocol={{.db_protocol}} \
+   --uri={{.db_uri}} \
+   --output file:///etc/teleport.yaml
+
+> teleport start -c /etc/teleport.yaml
+
 Please note:
 
   - This invitation token will expire in {{.minutes}} minutes.

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -67,6 +67,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	var ccf config.CommandLineFlags
 	var scpFlags scp.Flags
 	var dumpFlags dumpFlags
+	var dbConfigCreateFlags createDatabaseConfigFlags
 
 	// define commands:
 	start := app.Command("start", "Starts the Teleport service.")
@@ -205,6 +206,23 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dbStartCmd.Flag("diag-addr", "Start diagnostic prometheus and healthz endpoint.").StringVar(&ccf.DiagnosticAddr)
 	dbStartCmd.Flag("insecure", "Insecure mode disables certificate validation").BoolVar(&ccf.InsecureMode)
 	dbStartCmd.Alias(dbUsageExamples) // We're using "alias" section to display usage examples.
+	dbConfigure := dbCmd.Command("configure", "Provides commands for configuring Database Service agents.")
+	dbConfigureCreate := dbConfigure.Command("create", "Creates a sample Database Service configuration.")
+	dbConfigureCreate.Flag("proxy", fmt.Sprintf("Teleport proxy address to connect to [%s].", defaults.ProxyWebListenAddr().Addr)).
+		Default(defaults.ProxyWebListenAddr().Addr).
+		StringsVar(&dbConfigCreateFlags.AuthServersAddr)
+	dbConfigureCreate.Flag("token", "Invitation token to register with an auth server [none].").Default("/tmp/token").StringVar(&dbConfigCreateFlags.AuthToken)
+	dbConfigureCreate.Flag("rds-discovery", "List of AWS regions the agent will discover for RDS/Aurora instances.").StringsVar(&dbConfigCreateFlags.RDSDiscoveryRegions)
+	dbConfigureCreate.Flag("redshift-discovery", "List of AWS regions the agent will discover for Redshift instances.").StringsVar(&dbConfigCreateFlags.RedshiftDiscoveryRegions)
+	dbConfigureCreate.Flag("ca-pin", "CA pin to validate the auth server (can be repeated for multiple pins).").StringsVar(&dbConfigCreateFlags.CAPins)
+	dbConfigureCreate.Flag("name", "Name of the proxied database.").StringVar(&dbConfigCreateFlags.StaticDatabaseName)
+	dbConfigureCreate.Flag("protocol", fmt.Sprintf("Proxied database protocol. Supported are: %v.", defaults.DatabaseProtocols)).StringVar(&dbConfigCreateFlags.StaticDatabaseProtocol)
+	dbConfigureCreate.Flag("uri", "Address the proxied database is reachable at.").StringVar(&dbConfigCreateFlags.StaticDatabaseURI)
+	dbConfigureCreate.Flag("labels", "Comma-separated list of labels for the database, for example env=dev,dept=it").StringVar(&dbConfigCreateFlags.StaticDatabaseRawLabels)
+	dbConfigureCreate.Flag("output",
+		"Write to stdout with -o=stdout, default config file with -o=file or custom path with -o=file:///path").Short('o').Default(
+		teleport.SchemeStdout).StringVar(&dbConfigCreateFlags.output)
+	dbConfigureCreate.Alias(dbCreateConfigExamples) // We're using "alias" section to display usage examples.
 
 	// define a hidden 'scp' command (it implements server-side implementation of handling
 	// 'scp' requests)
@@ -254,8 +272,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 
 	// execute the selected command unless we're running tests
 	switch command {
-	case start.FullCommand(), appStartCmd.FullCommand(), dbStartCmd.FullCommand():
-		// Set appropriate roles for "app" and "db" subcommands.
+	case start.FullCommand(), appStartCmd.FullCommand(), dbStartCmd.FullCommand(): // Set appropriate roles for "app" and "db" subcommands.
 		switch command {
 		case appStartCmd.FullCommand():
 			ccf.Roles = defaults.RoleApp
@@ -281,6 +298,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		err = onForward()
 	case ver.FullCommand():
 		utils.PrintVersion()
+	case dbConfigureCreate.FullCommand():
+		err = onDumpDatabaseConfig(dbConfigCreateFlags)
 	}
 	if err != nil {
 		utils.FatalError(err)
@@ -327,19 +346,47 @@ func (flags *dumpFlags) CheckAndSetDefaults() error {
 	if flags.testConfigFile != "" && flags.output != teleport.SchemeStdout {
 		return trace.BadParameter("only --output or --test can be set, not both")
 	}
-	if flags.output == "" || flags.output == teleport.SchemeFile {
-		flags.output = teleport.SchemeFile + "://" + defaults.ConfigFilePath
-	} else if flags.output == teleport.SchemeStdout {
-		flags.output = teleport.SchemeStdout + "://"
+
+	err := checkConfigurationFileVersion(flags.Version)
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
+	flags.output = normalizeOutput(flags.output)
+	return nil
+}
+
+type createDatabaseConfigFlags struct {
+	config.DatabaseSampleFlags
+	// output is the destination to write the configuration to.
+	output string
+}
+
+// CheckAndSetDefaults checks and sets the defaults
+func (flags *createDatabaseConfigFlags) CheckAndSetDefaults() error {
+	flags.output = normalizeOutput(flags.output)
+	return nil
+}
+
+func normalizeOutput(output string) string {
+	switch output {
+	case teleport.SchemeFile, "":
+		output = teleport.SchemeFile + "://" + defaults.ConfigFilePath
+	case teleport.SchemeStdout:
+		output = teleport.SchemeStdout + "://"
+	}
+
+	return output
+}
+
+func checkConfigurationFileVersion(version string) error {
 	supportedVersions := []string{defaults.TeleportConfigVersionV1, defaults.TeleportConfigVersionV2}
-	switch flags.Version {
+	switch version {
 	case defaults.TeleportConfigVersionV1, defaults.TeleportConfigVersionV2, "":
 	default:
 		return trace.BadParameter(
 			"unsupported Teleport configuration version %q, supported are: %s",
-			flags.Version, strings.Join(supportedVersions, ","))
+			version, strings.Join(supportedVersions, ","))
 	}
 
 	return nil
@@ -347,6 +394,7 @@ func (flags *dumpFlags) CheckAndSetDefaults() error {
 
 // onConfigDump is the handler for "configure" CLI command
 func onConfigDump(flags dumpFlags) error {
+	var err error
 	if err := flags.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
@@ -360,13 +408,6 @@ func onConfigDump(flags dumpFlags) error {
 		}
 		fmt.Fprintf(os.Stderr, "OK %s\n", flags.testConfigFile)
 		return nil
-	}
-
-	// Generate a new config.
-	uri, err := url.Parse(flags.output)
-	if err != nil {
-		return trace.BadParameter("could not parse output value %q, use --output=%q",
-			flags.output, defaults.ConfigFilePath)
 	}
 
 	if modules.GetModules().BuildType() != modules.BuildOSS {
@@ -391,42 +432,89 @@ func onConfigDump(flags dumpFlags) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	configPath, err := dumpConfigFile(flags.output, sfc.DebugDumpToYAML(), sampleConfComment)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if configPath != "" {
+		if modules.GetModules().BuildType() == modules.BuildOSS {
+			fmt.Printf("Wrote config to file %q. Now you can start the server. Happy Teleporting!\n", configPath)
+		} else {
+			fmt.Printf("Wrote config to file %q. Add your license file to %v and start the server. Happy Teleporting!\n", configPath, flags.LicensePath)
+		}
+	}
+
+	return nil
+}
+
+func onDumpDatabaseConfig(flags createDatabaseConfigFlags) error {
+	if err := flags.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	sfc, err := config.MakeDatabaseAgentConfigString(flags.DatabaseSampleFlags)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	configPath, err := dumpConfigFile(flags.output, sfc, "")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if configPath != "" {
+		fmt.Printf("Wrote config to file %q. Now you can start the server. Happy Teleporting!\n", configPath)
+	}
+	return nil
+}
+
+func dumpConfigFile(outputURI, contents, comment string) (string, error) {
+	// Generate a new config.
+	uri, err := url.Parse(outputURI)
+	if err != nil {
+		return "", trace.BadParameter("could not parse output value %q, use --output=%q",
+			outputURI, defaults.ConfigFilePath)
+	}
+
 	switch uri.Scheme {
 	case teleport.SchemeStdout:
-		fmt.Printf("%s\n%s\n", sampleConfComment, sfc.DebugDumpToYAML())
+		fmt.Printf("%s\n%s\n", comment, contents)
+		return "", nil
 	case teleport.SchemeFile, "":
 		if uri.Path == "" {
-			return trace.BadParameter("missing path in --output=%q", uri)
+			return "", trace.BadParameter("missing path in --output=%q", uri)
 		}
 		if !filepath.IsAbs(uri.Path) {
-			return trace.BadParameter("please use absolute path for file %v", uri.Path)
+			return "", trace.BadParameter("please use absolute path for file %v", uri.Path)
 		}
 		f, err := os.OpenFile(uri.Path, os.O_RDWR|os.O_CREATE|os.O_EXCL, teleport.FileMaskOwnerOnly)
 		err = trace.ConvertSystemError(err)
 		if err != nil {
 			if trace.IsAlreadyExists(err) {
-				return trace.AlreadyExists("will not overwrite existing file %v, rm -f %v and try again", uri.Path, uri.Path)
+				return "", trace.AlreadyExists("will not overwrite existing file %v, rm -f %v and try again", uri.Path, uri.Path)
 			}
-			return trace.Wrap(err, "could not write to config file, missing sudo?")
+
+			if trace.IsAccessDenied(err) {
+				return "", trace.Wrap(err, "could not write to config file, missing sudo?")
+			}
+
+			return "", trace.Wrap(err)
 		}
-		if _, err := f.Write([]byte(sfc.DebugDumpToYAML())); err != nil {
+		if _, err := f.Write([]byte(contents)); err != nil {
 			f.Close()
-			return trace.Wrap(trace.ConvertSystemError(err), "could not write to config file, missing sudo?")
+			return "", trace.Wrap(trace.ConvertSystemError(err), "could not write to config file, missing sudo?")
 		}
 		if err := f.Close(); err != nil {
-			return trace.Wrap(err, "could not close file %v", uri.Path)
+			return "", trace.Wrap(err, "could not close file %v", uri.Path)
 		}
-		if modules.GetModules().BuildType() == modules.BuildOSS {
-			fmt.Printf("Wrote config to file %q. Now you can start the server. Happy Teleporting!\n", uri.Path)
-		} else {
-			fmt.Printf("Wrote config to file %q. Add your license file to %v and start the server. Happy Teleporting!\n", uri.Path, flags.LicensePath)
-		}
+
+		return uri.Path, nil
 	default:
-		return trace.BadParameter(
+		return "", trace.BadParameter(
 			"unsupported --output=%v, use path for example --output=%v", uri.Scheme, defaults.ConfigFilePath)
 	}
-
-	return nil
 }
 
 // onSCP implements handling of 'scp' requests on the server side. When the teleport SSH daemon

--- a/tool/teleport/common/usage.go
+++ b/tool/teleport/common/usage.go
@@ -62,6 +62,23 @@ pair issued by "tctl auth sign --format=db".
   --labels=env=aws
 Starts a database server that proxies Aurora MySQL database running in AWS
 region us-west-1 which only allows access to users with the role "env=aws".`
+
+	dbCreateConfigExamples = `
+> teleport db configure create --rds-discovery=us-west-1 --rds-discovery=us-west-2
+Generates a configuration with samples and Aurora/RDS auto-discovery enabled on
+the "us-west-1" and "us-west-2" regions.
+
+> teleport db configure create \
+   --token=/tmp/token \
+   --proxy=localhost:3080 \
+   --name=sample-db \
+   --protocol=postgres \
+   --uri=postgres://localhost:5432 \
+   --labels=env=prod
+Generates a configuration with a Postgres database.
+
+> teleport db configure create --output file:///etc/teleport.yaml
+Generates a configuration with samples and write to "/etc/teleport.yaml".`
 )
 
 var (


### PR DESCRIPTION
This PR is part of #8974. It implements the command `teleport db configure create`, which will generate database agent configurations (similar to the `teleport configure` command).

This command was introduced at #9719.