### PR TITLE
[v7] Sign rpm repo metadata

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3983,6 +3983,31 @@ steps:
     - yum -y install createrepo
     - createrepo --cachedir /rpmrepo/teleport/cache --update /rpmrepo/teleport
 
+  # This step requires centos:8 to get gpg 2.2+
+  # centos:7's gpg 2.0 doesn't understand the format of GPG_RPM_SIGNING_ARCHIVE
+  - name: Sign RPM repository metadata
+    image: centos:8
+    volumes:
+      - name: rpmrepo
+        path: /rpmrepo
+      # for in-memory tmpfs for key material
+      - name: tmpfs
+        path: /tmpfs
+    environment:
+      GNUPGHOME: /tmpfs/gnupg
+      GPG_RPM_SIGNING_ARCHIVE:
+        from_secret: GPG_RPM_SIGNING_ARCHIVE
+    commands:
+      - |
+        # extract signing key
+        mkdir -m0700 $GNUPGHOME
+        echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPGHOME
+        chown -R root:root $GNUPGHOME
+      # Sign rpm repo metadata (yum clients will automatically look for and verify repodata/repomd.xml.asc)
+      - gpg --detach-sign --armor /rpmrepo/teleport/repodata/repomd.xml
+      - cat /rpmrepo/teleport/repodata/repomd.xml.asc
+      - rm -rf $GNUPGHOME
+
   - name: Sync RPM repo changes to S3
     image: amazon/aws-cli
     environment:
@@ -4095,6 +4120,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 8aa5f7317d3c2d1bde25ae393c09b3be705ec5021dac7dd5d32e08b6e7006cef
+hmac: e2ca92f19f5d5a8ac469bfa5b8fbb5a9827382e08b51417c3c2cc19c2c65bf4c
 
 ...


### PR DESCRIPTION
v7 backport of https://github.com/gravitational/teleport/pull/9027

## Summary

This PR introduces signing for RPM repo metadata in addition to the RPMs themselves.

This helps support zypper on Suse (#6445), and improves our general RPM
distribution security posture. The threat model is someone compromises
AWS, but not our signing keys. In this case, they could update repo
metatdata to point to an unsigned package. With metadata signed, this
is no longer possible -- both the index and the package are verified by
the various yum clients.

For more info on this change, see this very helpful blog post:

https://blog.packagecloud.io/eng/2014/11/24/howto-gpg-sign-verify-rpm-packages-yum-repositories/

Contributes to #6445.

## Testing Done
No extra for this branch, other than a `drone sign` (which verifies the yaml is syntactically sound).