### PR TITLE
[v6.2] Sign rpm repo metadata

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3950,6 +3950,31 @@ steps:
     - yum -y install createrepo
     - createrepo --cachedir /rpmrepo/teleport/cache --update /rpmrepo/teleport
 
+  # This step requires centos:8 to get gpg 2.2+
+  # centos:7's gpg 2.0 doesn't understand the format of GPG_RPM_SIGNING_ARCHIVE
+  - name: Sign RPM repo metadata
+    image: centos:8
+    volumes:
+      - name: rpmrepo
+        path: /rpmrepo
+      # for in-memory tmpfs for key material
+      - name: tmpfs
+        path: /tmpfs
+    environment:
+      GNUPGHOME: /tmpfs/gnupg
+      GPG_RPM_SIGNING_ARCHIVE:
+        from_secret: GPG_RPM_SIGNING_ARCHIVE
+    commands:
+      - |
+        # extract signing key
+        mkdir -m0700 $GNUPGHOME
+        echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPGHOME
+        chown -R root:root $GNUPGHOME
+      # Sign rpm repo metadata (yum clients will automatically look for and verify repodata/repomd.xml.asc)
+      - gpg --detach-sign --armor /rpmrepo/teleport/repodata/repomd.xml
+      - cat /rpmrepo/teleport/repodata/repomd.xml.asc
+      - rm -rf $GNUPGHOME
+
   - name: Sync RPM repo changes to S3
     image: amazon/aws-cli
     environment:
@@ -4062,6 +4087,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: f968f2bd14dc820d82b6ead7b297421b43c0c9bc8635a2c8d1a5a765b554ea50
+hmac: 8af156cf5b97dce8c9dcae7b3a189fafd910f692f86dbf11a2e500f0185144d9
 
 ...


### PR DESCRIPTION
v6.2 backport of https://github.com/gravitational/teleport/pull/9027

## Summary

This PR introduces signing for RPM repo metadata in addition to the RPMs themselves.

This helps support zypper on Suse (#6445), and improves our general RPM
distribution security posture. The threat model is someone compromises
AWS, but not our signing keys. In this case, they could update repo
metatdata to point to an unsigned package. With metadata signed, this
is no longer possible -- both the index and the package are verified by
the various clients.

For more info on this change, see this very helpful blog post:

https://blog.packagecloud.io/eng/2014/11/24/howto-gpg-sign-verify-rpm-packages-yum-repositories/

Contributes to #6445.

## Testing Done
No extra for this branch, other than a `drone sign` (which verifies the yaml is syntactically sound).

## Notes
This is as far back as I plan to port this change.  While `branches/5.0` could clobber the rpm repo metadata signature if we ran a release off it, I don't believe we will, per https://github.com/gravitational/teleport/pull/9005/files#diff-adf7bb97509b09600d8a9214ce415eacf99c037d53baa974d027fa1c858cf554R130

I considered foolproofing via either: 

1) Backporting this to v5
2) Removing the publish pipeline entirely from v5 to prevent a misguided attempt there from invalidating more recent signatures.

However, the above require a pessimistic view of our peers and process, so I chose to skip messing with 5.0 unless someone else thinks a release there is likely.