### PR TITLE
Fixing bug on teleport config on 8.0.7

### DIFF
--- a/examples/chart/teleport-cluster/templates/config.yaml
+++ b/examples/chart/teleport-cluster/templates/config.yaml
@@ -40,11 +40,11 @@ data:
         {{- if .Values.gcp.credentialSecretName }}
         credentials_path: /etc/teleport-secrets/gcp-credentials.json
         {{- end }}
-        {{- if .Values.gcp.auditLogMirrorOnStdout -}}
+        {{- if .Values.gcp.auditLogMirrorOnStdout }}
         audit_events_uri: ['firestore://{{ required "gcp.auditLogTable is required in chart values" .Values.gcp.auditLogTable }}?projectID={{ required "gcp.projectId is required in chart values" .Values.gcp.projectId }}&credentialsPath=/etc/teleport-secrets/gcp-credentials.json', 'stdout://']
-        {{- else -}}
+        {{- else }}
         audit_events_uri: ['firestore://{{ required "gcp.auditLogTable is required in chart values" .Values.gcp.auditLogTable }}?projectID={{ required "gcp.projectId is required in chart values" .Values.gcp.projectId }}&credentialsPath=/etc/teleport-secrets/gcp-credentials.json']
-        {{- end -}}
+        {{- end }}
         audit_sessions_uri: "gs://{{ required "gcp.sessionRecordingBucket is required in chart values" .Values.gcp.sessionRecordingBucket }}?projectID={{ required "gcp.projectId is required in chart values" .Values.gcp.projectId }}&credentialsPath=/etc/teleport-secrets/gcp-credentials.json"
   {{- end }}
     auth_service:


### PR DESCRIPTION
Fix: config rendered in one line for audit_events_uri

The configuration rendered from helm teleport-cluster Chart's a bit off. 

Tested it locally

Error before change
```
      storage:
        type: firestore
        project_id: REDACTED
        collection_name: teleport-backend
        credentials_path: /etc/teleport-secrets/gcp-credentials.jsonaudit_events_uri: ['firestore://teleport-events?projectID=infrastructure-170520&credentialsPath=/etc/teleport-secrets/gcp-credentials.json']audit_events_uri: ['REDACTED']audit_sessions_uri: "REDACTED"
```


After change 
```
      storage:
        type: firestore
        project_id: REDACTED
        collection_name: teleport-backend
        credentials_path: /etc/teleport-secrets/gcp-credentials.json
        audit_events_uri: ['REDACTED']
        audit_sessions_uri: "REDACTED"
```