### PR TITLE
Remove libatomic dependency from non ARM packages.

### DIFF
--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -189,9 +189,12 @@ elif [[ "${ARCH}" == "amd64" ]]; then
     TEXT_ARCH="64-bit"
 elif [[ "${ARCH}" == "arm" ]]; then
     TEXT_ARCH="ARMv7"
-    # libatomic is only required on arm
+    # libatomic is only required on arm v7
     if [[ "${PACKAGE_TYPE}" == "deb" ]]; then
         DEPENDS="--depends libatomic1"
+        # Debian distinguish between arm soft and hard floats.
+        # We're building for linux-gnueabihf, so the correct arch is armhf.
+        ARCH="armhf"
     elif [[ "${PACKAGE_TYPE}" == "rpm" ]]; then
         DEPENDS="--depends libatomic"
     fi

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -47,6 +47,7 @@ PACKAGE_TYPE=${p}
 ARCH=${a}
 RUNTIME=${r}
 BUILD_MODE=${m}
+DEPENDS=""
 TARBALL_DIRECTORY=/tmp/teleport-tarballs
 DOWNLOAD_IF_NEEDED=true
 GNUPG_DIR=${GNUPG_DIR:-/tmp/gnupg}
@@ -188,6 +189,12 @@ elif [[ "${ARCH}" == "amd64" ]]; then
     TEXT_ARCH="64-bit"
 elif [[ "${ARCH}" == "arm" ]]; then
     TEXT_ARCH="ARMv7"
+    # libatomic is only required on arm
+    if [[ "${PACKAGE_TYPE}" == "deb" ]]; then
+        DEPENDS="--depends libatomic1"
+    elif [[ "${PACKAGE_TYPE}" == "rpm" ]]; then
+        DEPENDS="--depends libatomic"
+    fi
 elif [[ "${ARCH}" == "arm64" ]]; then
     TEXT_ARCH="ARMv8/ARM64"
 fi
@@ -399,6 +406,7 @@ else
         --provides teleport \
         --prefix / \
         --verbose \
+        ${DEPENDS} \
         ${CONFIG_FILE_STANZA} \
         ${FILE_PERMISSIONS_STANZA} \
         ${RPM_SIGN_STANZA} .

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -57,6 +57,7 @@ package rdpclient
 #cgo linux,arm LDFLAGS: -L${SRCDIR}/target/arm-unknown-linux-gnueabihf/release
 #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/target/aarch64-unknown-linux-gnu/release
 #cgo linux LDFLAGS: -l:librdp_client.a -lpthread -ldl -lm
+// linux,arm flags are split into to sections as linker require to pass -latomic flag after -l:librdp_client.a, otherwise it fails.
 #cgo linux,arm LDFLAGS: -latomic
 #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/target/x86_64-apple-darwin/release
 #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/target/aarch64-apple-darwin/release

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -56,7 +56,8 @@ package rdpclient
 #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/target/x86_64-unknown-linux-gnu/release
 #cgo linux,arm LDFLAGS: -L${SRCDIR}/target/arm-unknown-linux-gnueabihf/release
 #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/target/aarch64-unknown-linux-gnu/release
-#cgo linux LDFLAGS: -l:librdp_client.a -lpthread -ldl -lm -latomic
+#cgo linux LDFLAGS: -l:librdp_client.a -lpthread -ldl -lm
+#cgo linux,arm LDFLAGS: -latomic
 #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/target/x86_64-apple-darwin/release
 #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/target/aarch64-apple-darwin/release
 #cgo darwin LDFLAGS: -framework CoreFoundation -framework Security -lrdp_client -lpthread -ldl -lm


### PR DESCRIPTION
Currently `libatomic` is linked on all Linux systems, but looks like is really needed on ARM 32-bit systems. This PR removes the dependency on other systems, and adds `libatomic` to _depens_ section in our RPM/DEB packages.

- [ ] Check if `libatomic` needed on Debian based systems.

Fixes #9636