### PR TITLE
Restores CI lint for non-go files

### DIFF
--- a/.cloudbuild/ci/lint.yaml
+++ b/.cloudbuild/ci/lint.yaml
@@ -1,6 +1,6 @@
 steps:
   - name: us-docker.pkg.dev/ci-account/teleport/buildbox-root:v0.1.0
     id: lint
-    args: ['make', 'lint-go', 'lint-api']
+    args: ['make', 'lint']
 options:
   machineType: 'E2_HIGHCPU_32'

--- a/Makefile
+++ b/Makefile
@@ -621,7 +621,8 @@ ADDLICENSE_ARGS := -c 'Gravitational, Inc' -l apache \
 		-ignore 'version.go' \
 		-ignore 'webassets/**' \
 		-ignore 'ignoreme' \
-		-ignore lib/srv/desktop/rdp/rdpclient/target
+		-ignore 'lib/srv/desktop/rdp/rdpclient/target/**' \
+		-ignore 'lib/datalog/roletester/target/**'
 
 .PHONY: lint-license
 lint-license: $(ADDLICENSE)

--- a/build.assets/tooling/cmd/render-tests/args.go
+++ b/build.assets/tooling/cmd/render-tests/args.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/examples/chart/teleport-cluster/templates/service.yaml
+++ b/examples/chart/teleport-cluster/templates/service.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  type: {{- default "LoadBalancer" .Values.service.type }}
+  type: {{ default "LoadBalancer" .Values.service.type }}
   {{- with .Values.service.spec }}
   {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Linting for non-go files was accidentally dropped in the transition to
GCB (sorry!). This patch restores linting for non-go files and fixes
any lint failures that have crept in during the interim.