### PR TITLE
Fix log file location for vendorless

### DIFF
--- a/lib/config/formatter.go
+++ b/lib/config/formatter.go
@@ -342,7 +342,7 @@ func formatCallerWithPathAndLine() (path string) {
 	return ""
 }
 
-var frameIgnorePattern = regexp.MustCompile(`github\.com/(S|s)irupsen/logrus`)
+var frameIgnorePattern = regexp.MustCompile(`github\.com/(gravitational|(S|s)irupsen)/logrus`)
 
 // findFrames positions the stack pointer to the first
 // function that does not match the frameIngorePattern


### PR DESCRIPTION
Now that we're not using `vendor/`, all log entries report a location of `logrus@v1.4.4-0.20210817004754-047e20245621/entry.go:289`, because the path doesn't match `lib/config/formatter.go:frameIgnorePattern` anymore, as the path is now correctly reported as `github.com/gravitational/logrus`.

This fixes the regexp used by `findFrame` to account for both possibilities.