### PR TITLE
authenticate to LDAP with client certificates

### DIFF
--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -19,7 +19,8 @@ Desktop Access and log into a Windows desktop from that domain.
 
 This guide requires you to have:
 
-- An Active Directory domain, configured for LDAPS (Teleport requires an encrypted LDAP connection)
+- An Active Directory domain, configured for LDAPS (Teleport requires an
+  encrypted LDAP connection)
 - Access to a Domain Controller
 - An existing Teleport cluster and user, version 8.0 or newer
   - See [Teleport Getting Started](../getting-started.mdx) if you're new to Teleport
@@ -28,23 +29,19 @@ This guide requires you to have:
 
 ## Step 1/6. Create a restrictive service account
 
-Teleport requires a service account to connect to your Active Directory domain. We recommend creating a dedicated service account with restrictive permissions
-for maximal security.
+Teleport requires a service account to connect to your Active Directory domain.
+We recommend creating a dedicated service account with restrictive permissions
+for maximum security.
 
-To create the service account, open a PowerShell prompt and copy-paste in the commands below. Note that a password for this service account
-will be randomly generated for you, and saved as plaintext in a file (`$OutputFile`) so that you can provide it to the Teleport configuration yaml later.
-
-<Admonition type="warning" title="Warning">
-  `$OutputFile` will contain the plaintext password of the service account you
-  are about to create. It is best practice to delete this file after you have
-  transfered it to your Teleport host machine and confirmed that LDAP
-  authentication is working (Steps 5 and 6).
-</Admonition>
+To create the service account, open a PowerShell prompt and copy-paste in the
+commands below. A password for this service account will be randomly generated,
+but immediately discarded. Teleport does not need this password, as it uses x509
+certificates for LDAP authentication. You can reset the password for this
+account should you need to perform password authentication.
 
 ```powershell
 $Name="Teleport Service Account"
 $SamAccountName="svc-teleport"
-$OutputFile="teleport-svc-pass.txt"
 
 # Generate a random password that meets the "Password must meet complexity requirements" security policy setting.
 # Note: if the minimum complexity requirements have been changed from the Windows default, this part of the script may need to be modified.
@@ -54,9 +51,6 @@ do {
 } until ($Password -match '\d')
 $SecureStringPassword=ConvertTo-SecureString $Password -AsPlainText -Force
 
-# Save the plaintext password to a file for later use in your teleport.yaml.
-$Password | Out-File $OutputFile
-
 New-ADUser `
   -Name $Name `
   -SamAccountName $SamAccountName `
@@ -64,7 +58,8 @@ New-ADUser `
   -Enabled $true
 ```
 
-Next, in the same PowerShell prompt, enter the following commands to limit your service account's permissions.
+Next, in the same PowerShell prompt, enter the following commands to limit your
+service account's permissions.
 
 ```powershell
 # Save your domain's distinguished name to a variable.
@@ -99,12 +94,15 @@ dsacls "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuratio
   domain).
 </Admonition>
 
-The Teleport service account is only needed to authenticate over LDAP, meaning that it needn't be able to login to Windows machines like an ordinary user.
-Restrict it from doing so by creating a new Group Policy Object (GPO) linked to your entire domain, and then deny it interactive login.
+The Teleport service account is only needed to authenticate over LDAP, meaning
+that it needn't be able to login to Windows machines like an ordinary user.
+Restrict it from doing so by creating a new Group Policy Object (GPO) linked to
+your entire domain, and then deny it interactive login.
 
 ### Create a GPO
 
-1. Open a PowerShell prompt and change the `$GPOName` variable below to your desired GPO name, or leave the recommended name:
+1. Open a PowerShell prompt and change the `$GPOName` variable below to your
+   desired GPO name, or leave the recommended name:
 
 ```powershell
 $GPOName="Block teleport-svc Interactive Login"
@@ -118,7 +116,10 @@ New-GPO -Name $GPOName | New-GPLink -Target $((Get-ADDomain).DistinguishedName)
 
 ### Deny interactive login
 
-1. Open the program named `Group Policy Management` and find the GPO you just created (`$FOREST > Domains > $DOMAIN > Group Policy Objects > Block teleport-svc Interactive Login`), right-click on it and select `Edit...` from the context menu.
+1. Open the program named `Group Policy Management` and find the GPO you just
+   created
+   (`$FOREST > Domains > $DOMAIN > Group Policy Objects > Block teleport-svc Interactive Login`),
+   right-click on it and select `Edit...` from the context menu.
 2. Select:
 
 ```text
@@ -126,8 +127,11 @@ Computer Configuration > Policies > Windows Settings > Security Settings > Local
 ```
 
 3. Double click `Deny log on locally` and in the popup, check `Define these policy settings`.
-4. Then click `Add User or Group...`, `Browse ...`, enter the SAM account name of the user you created above (`svc-teleport`) and hit `Check Names` select your Group, and then hit `OK` on all the windows.
-5. Repeat steps 3 and 4 for `Deny log on through Remote Desktop Services` (in lieu of `Deny log on locally`).
+4. Then click `Add User or Group...`, `Browse ...`, enter the SAM account name
+   of the user you created above (`svc-teleport`) and hit `Check Names` select
+   your Group, and then hit `OK` on all the windows.
+5. Repeat steps 3 and 4 for `Deny log on through Remote Desktop Services` (in
+   lieu of `Deny log on locally`).
 
 <Figure align="left" bordered caption="Deny Interactive Login">
   ![Deny Interactive Login](../../img/desktop-access/deny-interactive-login.png)
@@ -135,7 +139,9 @@ Computer Configuration > Policies > Windows Settings > Security Settings > Local
 
 ## Step 3/6: Configure a GPO to allow Teleport connections
 
-Next, we need to configure a GPO to allow Teleport desktop sessions. This includes telling your computers to trust Teleport's CA, allowing the certificate-based smart card authentication, and ensuring RDP is enabled.
+Next, we need to configure a GPO to allow Teleport desktop sessions. This
+includes telling your computers to trust Teleport's CA, allowing the
+certificate-based smart card authentication, and ensuring RDP is enabled.
 
 ### Export the Teleport CA
 
@@ -169,7 +175,8 @@ $GPOName="Teleport Access Policy"
 New-GPO -Name $GPOName | New-GPLink -Target $((Get-ADDomain).DistinguishedName)
 ```
 
-2. Again open the `Group Policy Management` program, and on the left pane, navigate to `$FOREST > Domains > $DOMAIN > Group Policy Objects`.
+2. Again open the `Group Policy Management` program, and on the left pane,
+   navigate to `$FOREST > Domains > $DOMAIN > Group Policy Objects`.
 3. Right click on the GPO you just made (`Teleport Access Policy`), and select `Edit...`.
 4. In the group policy editor, select:
 
@@ -184,6 +191,28 @@ Computer Configuration > Policies > Windows Settings > Security Settings > Publi
   ![Import Teleport CA](../../img/desktop-access/ca.png)
 </Figure>
 
+### Publish the Teleport CA to the NTAuth Store
+
+In order for authentication with Teleport-issued certificates to succeed, the
+Teleport CA needs to be published to the enterprise NTAuth store. Teleport will
+periodically publish its CA after it is able to authenticate, but this step
+needs to be performed manually the first time in order for Teleport to have LDAP
+access.
+
+1. Publish the CA to LDAP:
+
+```
+$ certutil –dspublish –f <PathToCertFile.cer> NTAuthCA
+```
+
+2. Force the retrieval of the CA from LDAP. While this step is not required, it
+   speeds up the process and allows you to proceed to the next steps without
+   waiting for the certificate to propagate.
+
+```
+$ certutil -pulse
+```
+
 ### Enable the Smart Card service
 
 Teleport performs certificate based authentication by emulating a smart card.
@@ -194,7 +223,8 @@ Teleport performs certificate based authentication by emulating a smart card.
 Computer Configuration > Policies > Windows Settings > Security Settings > System Services
 ```
 
-2. Double click on `Smart Card`, select `Define this policy setting` and switch to `Automatic` then click `OK`.
+2. Double click on `Smart Card`, select `Define this policy setting` and switch
+   to `Automatic` then click `OK`.
 
 <Figure align="left" bordered caption="Enable the Smart Card Service">
   ![Enable Smartcard](../../img/desktop-access/smartcard.png)
@@ -255,10 +285,13 @@ gpupdate.exe /force
 
 ## Step 4/6. Export your LDAP CA certificate
 
-Teleport connects to your Domain Controller via LDAPS. This means that you must let Teleport know that the certificate sent
-by your Domain Controller during the initial SSL connection is trusted. If your Domain Controller's certificate is trusted by
-the system repository on the system running Teleport, you can skip this step. If you are unable to acquire the LDAP CA certificate,
-you can skip TLS verification by setting `insecure_skip_verify: true`. We do not recommend skipping TLS verification in production environments.
+Teleport connects to your Domain Controller via LDAPS. This means that you must
+let Teleport know that the certificate sent by your Domain Controller during the
+initial SSL connection is trusted. If your Domain Controller's certificate is
+trusted by the system repository on the system running Teleport, you can skip
+this step. If you are unable to acquire the LDAP CA certificate, you can skip
+TLS verification by setting `insecure_skip_verify: true`. We do not recommend
+skipping TLS verification in production environments.
 
 ### To export a CA certificate
 
@@ -271,8 +304,9 @@ you can skip TLS verification by setting `insecure_skip_verify: true`. We do not
 5. Click `Next` in the Certificate Export Wizard, and ensure that `DER encoded binary X.509 (.CER)` is selected
 6. Select a name and location for you certificate and click through the wizard.
 
-Now transfer the exported file to the system where you're running Teleport. You can either add this certificate to your system's
-trusted repository or provide the filepath to the `der_ca_file` configuration variable.
+Now transfer the exported file to the system where you're running Teleport. You
+can either add this certificate to your system's trusted repository or provide
+the filepath to the `der_ca_file` configuration variable.
 
 ## Step 5/6. Configure Teleport
 
@@ -295,7 +329,6 @@ windows_desktop_service:
     addr: "$LDAP_SERVER_ADDRESS"
     domain: "$LDAP_DOMAIN_NAME"
     username: '$LDAP_USERNAME'
-    password_file: /var/lib/teleport-svc-pass.txt
     # This should be the path to the certificate exported in Step 4.
     der_ca_file: /path/to/cert
   discovery:
@@ -308,8 +341,10 @@ After updating `teleport.yaml`, start Teleport as usual using `teleport start`.
 
 ### Create a Teleport user/role for Windows Desktop Access
 
-In order to gain access to a remote desktop, a Teleport user needs to have the appropriate permissions for that desktop.
-For example, you can create a role that gives its users access to all Windows desktop labels and the `"Administrator"` user:
+In order to gain access to a remote desktop, a Teleport user needs to have the
+appropriate permissions for that desktop. For example, you can create a role
+that gives its users access to all Windows desktop labels and the
+`"Administrator"` user:
 
 ```yaml
 kind: role
@@ -334,9 +369,9 @@ guide for instructions on how to create or update a user with a given role.
 At this point everything is ready for Desktop Access connections. Open
 the Teleport web UI and log in with a user with the role created above.
 
-On the left pane, select `Desktops (preview)`. You should see the list of all computers
-and Domain Controllers connected to your domain. Select one and click `CONNECT`
-on the right, selecting one of the available logins:
+On the left pane, select `Desktops (preview)`. You should see the list of all
+computers and Domain Controllers connected to your domain. Select one and click
+`CONNECT` on the right, selecting one of the available logins:
 
 <Figure align="left" bordered caption="Select Desktop">
   ![Select Desktop](../../img/desktop-access/select-desktop.png)
@@ -345,12 +380,8 @@ on the right, selecting one of the available logins:
 A new tab will open and, after a few seconds, you should be logged in to your
 target Windows host.
 
-<Admonition type="warning" title="Warning">
-  Remember to delete `$OutputFile` from Step 1 on your Windows host after you've
-  successfully completed this step.
-</Admonition>
-
 ## Troubleshooting
 
-If you hit any issues, check out the [Troubleshooting documentation](./troubleshooting.mdx)
-for common problems and solutions.
+If you hit any issues, check out the
+[Troubleshooting documentation](./troubleshooting.mdx) for common problems and
+solutions.

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -289,9 +289,13 @@ Teleport connects to your Domain Controller via LDAPS. This means that you must
 let Teleport know that the certificate sent by your Domain Controller during the
 initial SSL connection is trusted. If your Domain Controller's certificate is
 trusted by the system repository on the system running Teleport, you can skip
-this step. If you are unable to acquire the LDAP CA certificate, you can skip
-TLS verification by setting `insecure_skip_verify: true`. We do not recommend
-skipping TLS verification in production environments.
+this step.
+
+<Details title="Skipping TLS Verification">
+  If you are unable to acquire the LDAP CA certificate, you can skip
+  TLS verification by setting `insecure_skip_verify: true`. We do not recommend
+  skipping TLS verification in production environments.
+</Details>
 
 ### To export a CA certificate
 

--- a/docs/pages/includes/desktop-access/desktop-config.mdx
+++ b/docs/pages/includes/desktop-access/desktop-config.mdx
@@ -17,15 +17,13 @@ windows_desktop_service:
     # Active Directory domain name you are connecting to.
     domain:   '$LDAP_DOMAIN_NAME'
     # LDAP username for authentication. This username must include the domain
-    # NetBIOS name.
+    # NetBIOS name. The use of single quotes here is intentional in order to
+    # avoid the need to escape the backslash (\) character.
     #
     # For example, if your domain is "example.com", the NetBIOS name for it is
-    # likely "EXAMPLE". When connecting as the "Administrator" user, you should
-    # use the format: "EXAMPLE\Administrator".
+    # likely "EXAMPLE". When connecting as the "svc-teleport" user, you should
+    # use the format: "EXAMPLE\svc-teleport".
     username: '$LDAP_USERNAME'
-    # Plain text file containing the LDAP password for authentication.
-    # This is usually the same password you use to login to the Domain Controller.
-    password_file: /var/lib/ldap-pass
     # You can skip LDAPS certificate verification by setting
     # this to true. It is recommended that this be set to false
     # and the certificate added your system's trusted repository,

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1255,6 +1255,15 @@ func applyMetricsConfig(fc *FileConfig, cfg *service.Config) error {
 func applyWindowsDesktopConfig(fc *FileConfig, cfg *service.Config) error {
 	cfg.WindowsDesktop.Enabled = true
 
+	// Support for reading an LDAP password from a file was dropped for Teleport 9.
+	// Check if this old option is still set and issue a clear error for one major version.
+	// DELETE IN 10.0 (zmb3)
+	if len(fc.WindowsDesktop.LDAP.PasswordFile) > 0 {
+		return trace.BadParameter("Support for password_file was deprecated in Teleport 9 " +
+			"in favor of certificate-based authentication. Remove the password_file field from " +
+			"teleport.yaml to fix this error.")
+	}
+
 	if fc.WindowsDesktop.ListenAddress != "" {
 		listenAddr, err := utils.ParseHostPortAddr(fc.WindowsDesktop.ListenAddress, int(defaults.WindowsDesktopListenPort))
 		if err != nil {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -472,27 +472,6 @@ func TestConfigReading(t *testing.T) {
 	checkStaticConfig(t, conf)
 }
 
-func TestReadLDAPPasswordFromFile(t *testing.T) {
-	tmp := t.TempDir()
-	passwordFile := filepath.Join(tmp, "ldap-password")
-	require.NoError(t, os.WriteFile(passwordFile, []byte(" super-secret-password\n"), 0644))
-
-	fc := FileConfig{
-		WindowsDesktop: WindowsDesktopService{
-			LDAP: LDAPConfig{
-				Addr:         "test.example.com",
-				Domain:       "example.com",
-				Username:     "admin",
-				PasswordFile: passwordFile,
-			},
-		},
-	}
-
-	var sc service.Config
-	require.NoError(t, applyWindowsDesktopConfig(&fc, &sc))
-	require.Equal(t, "super-secret-password", sc.WindowsDesktop.LDAP.Password)
-}
-
 func TestLabelParsing(t *testing.T) {
 	var conf service.SSHConfig
 	var err error
@@ -1551,10 +1530,6 @@ func TestProxyConfigurationVersion(t *testing.T) {
 func TestWindowsDesktopService(t *testing.T) {
 	t.Parallel()
 
-	tmp := t.TempDir()
-	ldapPasswordFile := filepath.Join(tmp, "ldap-pass")
-	require.NoError(t, os.WriteFile(ldapPasswordFile, []byte("foo"), 0644))
-
 	for _, test := range []struct {
 		desc        string
 		mutate      func(fc *FileConfig)
@@ -1599,13 +1574,7 @@ func TestWindowsDesktopService(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			fc := &FileConfig{
-				WindowsDesktop: WindowsDesktopService{
-					LDAP: LDAPConfig{
-						PasswordFile: ldapPasswordFile,
-					},
-				},
-			}
+			fc := &FileConfig{}
 			test.mutate(fc)
 			cfg := &service.Config{}
 			err := applyWindowsDesktopConfig(fc, cfg)

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1572,6 +1572,13 @@ func TestWindowsDesktopService(t *testing.T) {
 				}
 			},
 		},
+		{
+			desc:        "NOK - uses deprecated password_file field",
+			expectError: require.Error,
+			mutate: func(fc *FileConfig) {
+				fc.WindowsDesktop.LDAP.PasswordFile = "/path/to/some/file"
+			},
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			fc := &FileConfig{}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1385,8 +1385,6 @@ type LDAPConfig struct {
 	Domain string `yaml:"domain"`
 	// Username for LDAP authentication.
 	Username string `yaml:"username"`
-	// PasswordFile is a text file containing the password for LDAP authentication.
-	PasswordFile string `yaml:"password_file"`
 	// InsecureSkipVerify decides whether whether we skip verifying with the LDAP server's CA when making the LDAPS connection.
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
 	// DEREncodedCAFile is the filepath to an optional DER encoded CA cert to be used for verification (if InsecureSkipVerify is set to false).

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1389,4 +1389,12 @@ type LDAPConfig struct {
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
 	// DEREncodedCAFile is the filepath to an optional DER encoded CA cert to be used for verification (if InsecureSkipVerify is set to false).
 	DEREncodedCAFile string `yaml:"der_ca_file,omitempty"`
+
+	// PasswordFile was used in Teleport 8 before we supported client certificates
+	// for LDAP authentication. Support for LDAP passwords was removed for Teleport 9
+	// and this field remains only to issue a warning to users who are upgrading to
+	// Teleport 9.
+	//
+	// TODO(zmb3) DELETE IN 10.0
+	PasswordFile string `yaml:"password_file"`
 }

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -967,8 +967,6 @@ type LDAPConfig struct {
 	Domain string
 	// Username for LDAP authentication.
 	Username string
-	// Password for LDAP authentication.
-	Password string
 	// InsecureSkipVerify decides whether whether we skip verifying with the LDAP server's CA when making the LDAPS connection.
 	InsecureSkipVerify bool
 	// CA is an optional CA cert to be used for verification if InsecureSkipVerify is set to false.

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -194,7 +194,7 @@ func (c *Client) readClientSize() error {
 }
 
 func (c *Client) connect(ctx context.Context) error {
-	userCertDER, userKeyDER, err := c.cfg.GenerateUserCert(ctx, c.username)
+	userCertDER, userKeyDER, err := c.cfg.GenerateUserCert(ctx, c.username, c.cfg.CertTTL)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -86,7 +86,7 @@ func init() {
 	// on the logrus log level
 	// (unless RUST_LOG is already explicitly set, then we
 	// assume the user knows what they want)
-	if rl := os.Getenv("RUST_LOG"); rl != "" {
+	if rl := os.Getenv("RUST_LOG"); rl == "" {
 		var rustLogLevel string
 		switch l := logrus.GetLevel(); l {
 		case logrus.TraceLevel:

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -20,6 +20,7 @@ package rdpclient
 import (
 	"context"
 	"image/png"
+	"time"
 
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/trace"
@@ -32,6 +33,7 @@ type Config struct {
 	Addr string
 	// UserCertGenerator generates user certificates for RDP authentication.
 	GenerateUserCert GenerateUserCertFn
+	CertTTL          time.Duration
 
 	// AuthorizeFn is called to authorize a user connecting to a Windows desktop.
 	AuthorizeFn func(login string) error
@@ -48,7 +50,7 @@ type Config struct {
 }
 
 // GenerateUserCertFn generates user certificates for RDP authentication.
-type GenerateUserCertFn func(ctx context.Context, username string) (certDER, keyDER []byte, err error)
+type GenerateUserCertFn func(ctx context.Context, username string, ttl time.Duration) (certDER, keyDER []byte, err error)
 
 //nolint:unused
 func (c *Config) checkAndSetDefaults() error {

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -793,7 +793,19 @@ func (s *WindowsService) updateCA(ctx context.Context) error {
 // CAs that are eligible to issue smart card login certificates and perform client
 // private key archival.
 //
-// This is equivalent to running `certutil –dspublish –f <PathToCertFile.cer> NTAuthCA`
+// This function is equivalent to running:
+//     certutil –dspublish –f <PathToCertFile.cer> NTAuthCA
+//
+// You can confirm the cert is present by running:
+//     certutil -viewstore "ldap:///CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,DC=example,DC=com>?caCertificate"
+//
+// Once the CA is published to LDAP, it should eventually sync and be present in the
+// machine's enterprise NTAuth store. You can check that with:
+//     certutil -viewstore -enterprise NTAuth
+//
+// You can expedite the synchronization by running:
+//     certutil -pulse
+//
 func (s *WindowsService) updateCAInNTAuthStore(ctx context.Context, caDER []byte) error {
 	// Check if our CA is already in the store. The LDAP entry for NTAuth store
 	// is constant and it should always exist.

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -153,7 +153,7 @@ func TestGenerateCredentials(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	certb, keyb, err := w.generateCredentials(ctx, user, domain)
+	certb, keyb, err := w.generateCredentials(ctx, user, domain, windowsDesktopCertTTL)
 	require.NoError(t, err)
 	require.NotNil(t, certb)
 	require.NotNil(t, keyb)

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -173,8 +173,7 @@ func (r *Linear) Reset() {
 	r.attempt = 0
 }
 
-// ResetToDelay resetes retry period to initial and increments to the next attempt
-// similar to Reset() and Inc()
+// ResetToDelay resets retry period and increments the number of attempts.
 func (r *Linear) ResetToDelay() {
 	r.Reset()
 	r.Inc()
@@ -243,7 +242,6 @@ func (r *Linear) String() string {
 }
 
 // For retries the provided function until it succeeds or the context expires.
-// Only errors matching retryIf filter are retried.
 func (r *Linear) For(ctx context.Context, retryFn func() error) error {
 	for {
 		err := retryFn()


### PR DESCRIPTION
Rather than requiring a password for the LDAP service account,
we can use a Teleport-issued certificate to authenticate.

This works because AD must already be configured to trust the Teleport
CA in order for desktop access to function.

Fixes #8921
