### PR TITLE
Fix docker-compose Getting Started guide issues

### DIFF
--- a/docker/sshd/scripts/generate-certs.sh
+++ b/docker/sshd/scripts/generate-certs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -x
+set -o pipefail
 
 TCTL="/usr/local/bin/tctl --auth-server=proxy.luna.teleport:3025"
 cd /mnt/shared/certs || exit 1

--- a/docs/pages/getting-started/docker-compose.mdx
+++ b/docs/pages/getting-started/docker-compose.mdx
@@ -114,19 +114,17 @@ https://proxy.luna.teleport:443/web/invite/your-token-here
 NOTE: Make sure proxy.luna.teleport:443 points at a Teleport proxy which users can access.
 ```
 
-The Web UI will be available at the displayed URL. 
+Port `443` on the Teleport container is published to the local host, so you can access the invitation page at `https://localhost/web/invite/your-token-here`.
 
 (!docs/pages/includes/insecure-certificate.mdx!)
 
-Explore audit log, session recordings and other features of Teleport.
-
 ## Next steps
 
-- Try out one of our [Helm Guides](../kubernetes-access/helm/guides.mdx).
+- Learn about [Teleport Server Access](../server-access/introduction.mdx).
+- Learn about [Teleport Access Controls](../access-controls/getting-started.mdx).
+- Get started with [Teleport Session Recording](../server-access/guides/bpf-session-recording.mdx).
 - Try out one of our [Database Access Guides](../database-access/guides.mdx).
-- Learn about [Teleport Server Access](../server-access/introduction.mdx).
-- Learn about [Teleport Server Access](../server-access/introduction.mdx).
-- Learn about [Teleport Access Control](../access-controls/getting-started.mdx).
+- For Kubernetes environments, try out one of our [Helm Guides](../kubernetes-access/helm/guides.mdx).
 
 ## Under the hood
 

--- a/docs/pages/includes/insecure-certificate.mdx
+++ b/docs/pages/includes/insecure-certificate.mdx
@@ -1,8 +1,8 @@
 <Admonition type="tip" title="Insecure Certificate Error">
   If you encounter an "Insecure Certificate Error" (or equivalent warning) that prevents the Teleport Web UI from opening, you can:
 
-  1. Open the URL in Safari.
-  2. Use the Chrome flag `--ignore-certificate-errors` instead.
+  1. Open the URL in Safari or Firefox.
+  2. In Chrome, visit `chrome://flags` and enable "Allow invalid certificates for resources loaded from localhost."
 
-  Both options will allow you to open the Web UI and continue with the Quickstart.
+  Both options will allow you to open the Web UI.
 </Admonition>

--- a/docs/pages/includes/insecure-certificate.mdx
+++ b/docs/pages/includes/insecure-certificate.mdx
@@ -1,8 +1,8 @@
 <Admonition type="tip" title="Insecure Certificate Error">
-  If you encounter an "Insecure Certificate Error" (or equivalent warning) that prevents the Teleport Web UI from opening, you can:
+  If you encounter an "Insecure Certificate Error" (or equivalent warning) that prevents the Teleport Web UI from opening, you can perform one of the following actions depending on your browser:
 
-  1. Open the URL in Safari or Firefox.
-  2. In Chrome, visit `chrome://flags` and enable "Allow invalid certificates for resources loaded from localhost."
+  - In Safari's "This Connection Is Not Private" page, click "Show Details," then click "visit this website."
+  - In Firefox, click "Advanced" from the warning page, then click "Accept the Risk and Continue."
+  - In Chrome's warning page, type `thisisunsafe` to ignore certificate validation for the Teleport Web UI.
 
-  Both options will allow you to open the Web UI.
 </Admonition>


### PR DESCRIPTION
This addresses several issues with the Docker Compose Getting
Started Guide.

- Intermittent SSH failures and password prompts from the term
  container

  In the bootstrap container, the "generate-certs.sh" script is
  used to generate certificates for other containers in the
  environment. This uses two "tctl auth export" commands. If
  the Teleport container is not available, i.e., it hasn't
  finished booting, generate-cert.sh is supposed to execute a
  "return" statement from either of the two "tctl auth export"
  commands with a nonzero code, causing the script to try
  again after one second.

  However, since the output of each "tctl auth export" command
  is piped into a "sed" command, the "generate_certs()"
  function continues without retrying if the Teleport
  container is not yet available. This means that the
  term container does not have access to the certificate it
  needs to connect to the OpenSSH server, public key
  authentication fails, and SSH issues a password challenge.

  This change adds the "set -o pipefail" option to the
  "generate-certs.sh" script so that the "tctl auth export"
  commands return a nonzero exit code if they fail and
  the retry logic works as intended.

- Add session recording to the "Next steps" section

  This demo isn't set up for session recording, so we remove
  the mention from the main body of the guide to avoid
  misleading users that this is supposed to be set up here.
  Instead, this mentions it as a next step.

- Update instructions for accessing the Web UI.

  This mentions the currently valid Chrome flag to use and
  indicates that you can visit the invite page in your browser
  via localhost.

Fixes #9687
Fixes #7872