### PR TITLE
Revert "[v8] Sign rpm repo metadata"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4311,31 +4311,6 @@ steps:
     - yum -y install createrepo
     - createrepo --cachedir /rpmrepo/teleport/cache --update /rpmrepo/teleport
 
-  # This step requires centos:8 to get gpg 2.2+
-  # centos:7's gpg 2.0 doesn't understand the format of GPG_RPM_SIGNING_ARCHIVE
-  - name: "RPM: Sign RPM repository metadata"
-    image: centos:8
-    volumes:
-      - name: rpmrepo
-        path: /rpmrepo
-      # for in-memory tmpfs for key material
-      - name: tmpfs
-        path: /tmpfs
-    environment:
-      GNUPGHOME: /tmpfs/gnupg
-      GPG_RPM_SIGNING_ARCHIVE:
-        from_secret: GPG_RPM_SIGNING_ARCHIVE
-    commands:
-      - |
-        # extract signing key
-        mkdir -m0700 $GNUPGHOME
-        echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPGHOME
-        chown -R root:root $GNUPGHOME
-      # Sign rpm repo metadata (yum clients will automatically look for and verify repodata/repomd.xml.asc)
-      - gpg --detach-sign --armor /rpmrepo/teleport/repodata/repomd.xml
-      - cat /rpmrepo/teleport/repodata/repomd.xml.asc
-      - rm -rf $GNUPGHOME
-
   - name: "RPM: Publish RPM repository to S3"
     image: amazon/aws-cli
     environment:
@@ -4461,6 +4436,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 942d6ab5b8b2ab250f3633359fa77080ddfcb5a807d03cb2f5f68c1e0a2d2b4c
+hmac: a477a3c665ca5abd6dfd1c188f0df2df695f716a4f1abfe90dace0ca217ec253
 
 ...


### PR DESCRIPTION
Reverts gravitational/teleport#9623, as this is causing failures like:

```
gpg: cannot open '/dev/tty': No such device or address
```

As seen at https://drone.teleport.dev/gravitational/teleport/9816/1/14

Contributes to https://github.com/gravitational/teleport/issues/9726.