### PR TITLE
Revert "[v7] Sign rpm repo metadata"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3983,31 +3983,6 @@ steps:
     - yum -y install createrepo
     - createrepo --cachedir /rpmrepo/teleport/cache --update /rpmrepo/teleport
 
-  # This step requires centos:8 to get gpg 2.2+
-  # centos:7's gpg 2.0 doesn't understand the format of GPG_RPM_SIGNING_ARCHIVE
-  - name: Sign RPM repository metadata
-    image: centos:8
-    volumes:
-      - name: rpmrepo
-        path: /rpmrepo
-      # for in-memory tmpfs for key material
-      - name: tmpfs
-        path: /tmpfs
-    environment:
-      GNUPGHOME: /tmpfs/gnupg
-      GPG_RPM_SIGNING_ARCHIVE:
-        from_secret: GPG_RPM_SIGNING_ARCHIVE
-    commands:
-      - |
-        # extract signing key
-        mkdir -m0700 $GNUPGHOME
-        echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPGHOME
-        chown -R root:root $GNUPGHOME
-      # Sign rpm repo metadata (yum clients will automatically look for and verify repodata/repomd.xml.asc)
-      - gpg --detach-sign --armor /rpmrepo/teleport/repodata/repomd.xml
-      - cat /rpmrepo/teleport/repodata/repomd.xml.asc
-      - rm -rf $GNUPGHOME
-
   - name: Sync RPM repo changes to S3
     image: amazon/aws-cli
     environment:
@@ -4120,6 +4095,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: e2ca92f19f5d5a8ac469bfa5b8fbb5a9827382e08b51417c3c2cc19c2c65bf4c
+hmac: 8aa5f7317d3c2d1bde25ae393c09b3be705ec5021dac7dd5d32e08b6e7006cef
 
 ...


### PR DESCRIPTION
Reverts https://github.com/gravitational/teleport/pull/9724, as this is causing failures like:

```
gpg: cannot open '/dev/tty': No such device or address
```

As seen at https://drone.teleport.dev/gravitational/teleport/9816/1/14

Contributes to https://github.com/gravitational/teleport/issues/9726