### PR TITLE
Revert "[v6.2] Sign rpm repo metadata"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3950,31 +3950,6 @@ steps:
     - yum -y install createrepo
     - createrepo --cachedir /rpmrepo/teleport/cache --update /rpmrepo/teleport
 
-  # This step requires centos:8 to get gpg 2.2+
-  # centos:7's gpg 2.0 doesn't understand the format of GPG_RPM_SIGNING_ARCHIVE
-  - name: Sign RPM repo metadata
-    image: centos:8
-    volumes:
-      - name: rpmrepo
-        path: /rpmrepo
-      # for in-memory tmpfs for key material
-      - name: tmpfs
-        path: /tmpfs
-    environment:
-      GNUPGHOME: /tmpfs/gnupg
-      GPG_RPM_SIGNING_ARCHIVE:
-        from_secret: GPG_RPM_SIGNING_ARCHIVE
-    commands:
-      - |
-        # extract signing key
-        mkdir -m0700 $GNUPGHOME
-        echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPGHOME
-        chown -R root:root $GNUPGHOME
-      # Sign rpm repo metadata (yum clients will automatically look for and verify repodata/repomd.xml.asc)
-      - gpg --detach-sign --armor /rpmrepo/teleport/repodata/repomd.xml
-      - cat /rpmrepo/teleport/repodata/repomd.xml.asc
-      - rm -rf $GNUPGHOME
-
   - name: Sync RPM repo changes to S3
     image: amazon/aws-cli
     environment:
@@ -4087,6 +4062,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 8af156cf5b97dce8c9dcae7b3a189fafd910f692f86dbf11a2e500f0185144d9
+hmac: f968f2bd14dc820d82b6ead7b297421b43c0c9bc8635a2c8d1a5a765b554ea50
 
 ...


### PR DESCRIPTION
Reverts https://github.com/gravitational/teleport/pull/9625, as this is causing failures like:

```
gpg: cannot open '/dev/tty': No such device or address
```

As seen at https://drone.teleport.dev/gravitational/teleport/9816/1/14

Contributes to https://github.com/gravitational/teleport/issues/9726