### PR TITLE
[v7] Run gpg in batch mode

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4004,7 +4004,7 @@ steps:
         echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPGHOME
         chown -R root:root $GNUPGHOME
       # Sign rpm repo metadata (yum clients will automatically look for and verify repodata/repomd.xml.asc)
-      - gpg --detach-sign --armor /rpmrepo/teleport/repodata/repomd.xml
+      - gpg --batch --yes --detach-sign --armor /rpmrepo/teleport/repodata/repomd.xml
       - cat /rpmrepo/teleport/repodata/repomd.xml.asc
       - rm -rf $GNUPGHOME
 
@@ -4120,6 +4120,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: e2ca92f19f5d5a8ac469bfa5b8fbb5a9827382e08b51417c3c2cc19c2c65bf4c
+hmac: 88359bb820fc8e66baad0afa8489a4117e2220eee72fef64febbd40b03631bb9
 
 ...


### PR DESCRIPTION
v7 backport of #9728

## Summary
This fixes a release bug when gpg attempts to sign repomd.xml when a signature is already present.

Contributes to https://github.com/gravitational/teleport/issues/9726.

## Testing Done
See #9728. No additional testing was done for this PR.