### PR TITLE
[v6.2] Run gpg in batch mode

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3971,7 +3971,7 @@ steps:
         echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPGHOME
         chown -R root:root $GNUPGHOME
       # Sign rpm repo metadata (yum clients will automatically look for and verify repodata/repomd.xml.asc)
-      - gpg --detach-sign --armor /rpmrepo/teleport/repodata/repomd.xml
+      - gpg --batch --yes --detach-sign --armor /rpmrepo/teleport/repodata/repomd.xml
       - cat /rpmrepo/teleport/repodata/repomd.xml.asc
       - rm -rf $GNUPGHOME
 
@@ -4087,6 +4087,6 @@ volumes:
       name: drone-s3-debrepo-pvc
 ---
 kind: signature
-hmac: 8af156cf5b97dce8c9dcae7b3a189fafd910f692f86dbf11a2e500f0185144d9
+hmac: ab03c06bffc03426f49ea126d87dd41dc1c024ac5cbbd12d76298b0463c5f8c8
 
 ...


### PR DESCRIPTION
v6.2 backport of #9728

## Summary
This fixes a release bug when gpg attempts to sign repomd.xml when a signature is already present.

Contributes to https://github.com/gravitational/teleport/issues/9726.

## Testing Done
See #9728. No additional testing was done for this PR.