### PR TITLE
Use teleport logger instead of gravitational/trace

### DIFF
--- a/lib/backend/buffer_test.go
+++ b/lib/backend/buffer_test.go
@@ -23,11 +23,11 @@ import (
 	"time"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/trace"
-
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
-	check "gopkg.in/check.v1"
+	"gopkg.in/check.v1"
 )
 
 func TestInit(t *testing.T) { check.TestingT(t) }
@@ -36,10 +36,9 @@ type BufferSuite struct{}
 
 var _ = check.Suite(&BufferSuite{})
 
-func (s *BufferSuite) SetUpSuite(c *check.C) {
+func (s *BufferSuite) SetUpSuite(_ *check.C) {
 	log.StandardLogger().Hooks = make(log.LevelHooks)
-	formatter := &trace.TextFormatter{DisableTimestamp: false}
-	log.SetFormatter(formatter)
+	log.SetFormatter(utils.NewDefaultTextFormatter(trace.IsTerminal(os.Stderr)))
 	if testing.Verbose() {
 		log.SetLevel(log.DebugLevel)
 		log.SetOutput(os.Stdout)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -460,7 +460,7 @@ func applyLogConfig(loggerConfig Log, logger *log.Logger) error {
 	case "":
 		fallthrough // not set. defaults to 'text'
 	case "text":
-		formatter := &textFormatter{
+		formatter := &utils.TextFormatter{
 			ExtraFields:  loggerConfig.Format.ExtraFields,
 			EnableColors: trace.IsTerminal(os.Stderr),
 		}
@@ -471,8 +471,8 @@ func applyLogConfig(loggerConfig Log, logger *log.Logger) error {
 
 		logger.SetFormatter(formatter)
 	case "json":
-		formatter := &jsonFormatter{
-			extraFields: loggerConfig.Format.ExtraFields,
+		formatter := &utils.JsonFormatter{
+			ExtraFields: loggerConfig.Format.ExtraFields,
 		}
 
 		if err := formatter.CheckAndSetDefaults(); err != nil {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -471,7 +471,7 @@ func applyLogConfig(loggerConfig Log, logger *log.Logger) error {
 
 		logger.SetFormatter(formatter)
 	case "json":
-		formatter := &utils.JsonFormatter{
+		formatter := &utils.JSONFormatter{
 			ExtraFields: loggerConfig.Format.ExtraFields,
 		}
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2029,7 +2029,7 @@ func TestTextFormatter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.comment, func(t *testing.T) {
-			formatter := &textFormatter{
+			formatter := &utils.TextFormatter{
 				ExtraFields: tt.formatConfig,
 			}
 			tt.assertErr(t, formatter.CheckAndSetDefaults())
@@ -2057,8 +2057,8 @@ func TestJSONFormatter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.comment, func(t *testing.T) {
-			formatter := &jsonFormatter{
-				extraFields: tt.extraFields,
+			formatter := &utils.JsonFormatter{
+				ExtraFields: tt.extraFields,
 			}
 			tt.assertErr(t, formatter.CheckAndSetDefaults())
 		})

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2057,7 +2057,7 @@ func TestJSONFormatter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.comment, func(t *testing.T) {
-			formatter := &utils.JsonFormatter{
+			formatter := &utils.JSONFormatter{
 				ExtraFields: tt.extraFields,
 			}
 			tt.assertErr(t, formatter.CheckAndSetDefaults())

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -56,21 +56,15 @@ func InitLogger(purpose LoggingPurpose, level log.Level, verbose ...bool) {
 	switch purpose {
 	case LoggingForCLI:
 		// If debug logging was asked for on the CLI, then write logs to stderr.
-		// Otherwise discard all logs.
+		// Otherwise, discard all logs.
 		if level == log.DebugLevel {
-			log.SetFormatter(&trace.TextFormatter{
-				DisableTimestamp: true,
-				EnableColors:     trace.IsTerminal(os.Stderr),
-			})
+			log.SetFormatter(NewDefaultTextFormatter(trace.IsTerminal(os.Stderr)))
 			log.SetOutput(os.Stderr)
 		} else {
 			log.SetOutput(ioutil.Discard)
 		}
 	case LoggingForDaemon:
-		log.SetFormatter(&trace.TextFormatter{
-			DisableTimestamp: true,
-			EnableColors:     trace.IsTerminal(os.Stderr),
-		})
+		log.SetFormatter(NewDefaultTextFormatter(trace.IsTerminal(os.Stderr)))
 		log.SetOutput(os.Stderr)
 	}
 }
@@ -82,7 +76,7 @@ func InitLoggerForTests() {
 
 	logger := log.StandardLogger()
 	logger.ReplaceHooks(make(log.LevelHooks))
-	logger.SetFormatter(&trace.TextFormatter{})
+	log.SetFormatter(NewTestTextFormatter())
 	logger.SetLevel(log.DebugLevel)
 	logger.SetOutput(os.Stderr)
 	if testing.Verbose() {
@@ -96,7 +90,7 @@ func InitLoggerForTests() {
 func NewLoggerForTests() *log.Logger {
 	logger := log.New()
 	logger.ReplaceHooks(make(log.LevelHooks))
-	logger.SetFormatter(&trace.TextFormatter{})
+	logger.SetFormatter(NewTestTextFormatter())
 	logger.SetLevel(log.DebugLevel)
 	logger.SetOutput(os.Stderr)
 	return logger
@@ -111,10 +105,7 @@ func WrapLogger(logger *log.Entry) Logger {
 // NewLogger creates a new empty logger
 func NewLogger() *log.Logger {
 	logger := log.New()
-	logger.SetFormatter(&trace.TextFormatter{
-		DisableTimestamp: true,
-		EnableColors:     trace.IsTerminal(os.Stderr),
-	})
+	logger.SetFormatter(NewDefaultTextFormatter(trace.IsTerminal(os.Stderr)))
 	return logger
 }
 

--- a/lib/utils/formatter.go
+++ b/lib/utils/formatter.go
@@ -123,11 +123,6 @@ func (tf *TextFormatter) CheckAndSetDefaults() error {
 // Format formats each log line as configured in teleport config file
 func (tf *TextFormatter) Format(e *log.Entry) ([]byte, error) {
 	var data []byte
-
-	//if tf.FormatCaller == nil {
-	//	tf.FormatCaller = formatCallerWithPathAndLine
-	//}
-
 	caller := tf.FormatCaller()
 	w := &writer{}
 

--- a/lib/utils/formatter.go
+++ b/lib/utils/formatter.go
@@ -1,29 +1,32 @@
 /*
-Copyright 2021 Gravitational, Inc.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Copyright 2022 Gravitational, Inc.
 
-    http://www.apache.org/licenses/LICENSE-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+
 */
 
-package config
+package utils
 
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -32,7 +35,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type textFormatter struct {
+type TextFormatter struct {
 	// ComponentPadding is a padding to pick when displaying
 	// and formatting component field, defaults to DefaultComponentPadding
 	ComponentPadding int
@@ -66,8 +69,25 @@ const (
 	messageField   = "message"
 )
 
+func NewDefaultTextFormatter(enableColors bool) *TextFormatter {
+	return &TextFormatter{
+		ComponentPadding: trace.DefaultComponentPadding,
+		FormatCaller:     formatCallerWithPathAndLine,
+		ExtraFields:      KnownFormatFields.names(),
+		EnableColors:     enableColors,
+		callerEnabled:    true,
+		timestampEnabled: false,
+	}
+}
+
+func NewTestTextFormatter() *TextFormatter {
+	formatter := NewDefaultTextFormatter(trace.IsTerminal(os.Stderr))
+	formatter.timestampEnabled = true
+	return formatter
+}
+
 // CheckAndSetDefaults checks and sets log format configuration
-func (tf *textFormatter) CheckAndSetDefaults() error {
+func (tf *TextFormatter) CheckAndSetDefaults() error {
 	// set padding
 	if tf.ComponentPadding == 0 {
 		tf.ComponentPadding = trace.DefaultComponentPadding
@@ -100,9 +120,14 @@ func (tf *textFormatter) CheckAndSetDefaults() error {
 	return nil
 }
 
-// Format formats each log line as confiured in teleport config file
-func (tf *textFormatter) Format(e *log.Entry) ([]byte, error) {
+// Format formats each log line as configured in teleport config file
+func (tf *TextFormatter) Format(e *log.Entry) ([]byte, error) {
 	var data []byte
+
+	//if tf.FormatCaller == nil {
+	//	tf.FormatCaller = formatCallerWithPathAndLine
+	//}
+
 	caller := tf.FormatCaller()
 	w := &writer{}
 
@@ -172,26 +197,26 @@ func (tf *textFormatter) Format(e *log.Entry) ([]byte, error) {
 	return data, nil
 }
 
-// jsonFormatter implements the logrus.Formatter interface and adds extra
+// JsonFormatter implements the logrus.Formatter interface and adds extra
 // fields to log entries
-type jsonFormatter struct {
+type JsonFormatter struct {
 	log.JSONFormatter
 
-	extraFields []string
+	ExtraFields []string
 
 	callerEnabled    bool
 	componentEnabled bool
 }
 
 // CheckAndSetDefaults checks and sets log format configuration
-func (j *jsonFormatter) CheckAndSetDefaults() error {
+func (j *JsonFormatter) CheckAndSetDefaults() error {
 	// set log formatting
-	if j.extraFields == nil {
-		j.extraFields = KnownFormatFields.names()
+	if j.ExtraFields == nil {
+		j.ExtraFields = KnownFormatFields.names()
 	}
 
 	// parse input
-	res, err := parseInputFormat(j.extraFields)
+	res, err := parseInputFormat(j.ExtraFields)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -221,7 +246,7 @@ func (j *jsonFormatter) CheckAndSetDefaults() error {
 }
 
 // Format implements logrus.Formatter interface
-func (j *jsonFormatter) Format(e *log.Entry) ([]byte, error) {
+func (j *JsonFormatter) Format(e *log.Entry) ([]byte, error) {
 	if j.callerEnabled {
 		path := formatCallerWithPathAndLine()
 		e.Data[callerField] = path
@@ -259,15 +284,6 @@ func (w *writer) writeField(value interface{}, color int) {
 		w.WriteByte(' ')
 	}
 	w.writeValue(value, color)
-}
-
-func needsQuoting(text string) bool {
-	for _, r := range text {
-		if !strconv.IsPrint(r) {
-			return true
-		}
-	}
-	return false
 }
 
 func (w *writer) writeKeyValue(key string, value interface{}) {
@@ -342,7 +358,7 @@ func formatCallerWithPathAndLine() (path string) {
 	return ""
 }
 
-var frameIgnorePattern = regexp.MustCompile(`github\.com/(gravitational|(S|s)irupsen)/logrus`)
+var frameIgnorePattern = regexp.MustCompile(`github\.com/sirupsen/logrus`)
 
 // findFrames positions the stack pointer to the first
 // function that does not match the frameIngorePattern
@@ -359,7 +375,7 @@ func findFrame() *frameCursor {
 	frames := runtime.CallersFrames(pcs)
 	for i := 0; i < n; i++ {
 		frame, _ := frames.Next()
-		if !frameIgnorePattern.MatchString(frame.File) {
+		if !frameIgnorePattern.MatchString(frame.Function) {
 			return &frameCursor{
 				current: &frame,
 				rest:    frames,

--- a/lib/utils/formatter.go
+++ b/lib/utils/formatter.go
@@ -192,9 +192,9 @@ func (tf *TextFormatter) Format(e *log.Entry) ([]byte, error) {
 	return data, nil
 }
 
-// JsonFormatter implements the logrus.Formatter interface and adds extra
+// JSONFormatter implements the logrus.Formatter interface and adds extra
 // fields to log entries
-type JsonFormatter struct {
+type JSONFormatter struct {
 	log.JSONFormatter
 
 	ExtraFields []string
@@ -204,7 +204,7 @@ type JsonFormatter struct {
 }
 
 // CheckAndSetDefaults checks and sets log format configuration
-func (j *JsonFormatter) CheckAndSetDefaults() error {
+func (j *JSONFormatter) CheckAndSetDefaults() error {
 	// set log formatting
 	if j.ExtraFields == nil {
 		j.ExtraFields = KnownFormatFields.names()
@@ -241,7 +241,7 @@ func (j *JsonFormatter) CheckAndSetDefaults() error {
 }
 
 // Format implements logrus.Formatter interface
-func (j *JsonFormatter) Format(e *log.Entry) ([]byte, error) {
+func (j *JSONFormatter) Format(e *log.Entry) ([]byte, error) {
 	if j.callerEnabled {
 		path := formatCallerWithPathAndLine()
 		e.Data[callerField] = path


### PR DESCRIPTION
After removing `vendor/` our tests and CLI print incorrect caller path. example:
```
$tsh -d status
DEBU [KEYSTORE]  Returning Teleport TLS certificate "/Users/jnyckowski/tsh/keys/example.com/bob-x509.pem" valid until "2022-01-11 07:23:05 +0000 UTC". logrus@v1.4.4-0.20210817004754-047e20245621/entry.go:289
DEBU [KEYSTORE]  Reading certificates from path "/Users/jnyckowski/tsh/keys/example.com/bob-ssh/example.com-cert.pub". logrus@v1.4.4-0.20210817004754-047e20245621/entry.go:289
DEBU [KEYSTORE]  Reading certificates from path "/Users/jnyckowski/tsh/keys/example.com/bob-db/example.com". logrus@v1.4.4-0.20210817004754-047e20245621/entry.go:289
```
### What happened:
After removing the vendor our logging library is no more checked out in `vendor/github.com/sirupsen/logrus` but currently resides in `${GOPATH}/pkg/mod/github.com/gravitational/logrus@...` which cause our regex (which checks for file path) to match incorrect frame https://github.com/gravitational/trace/blob/0e951686b663a70b48ee0a1ccfe28658eee36c93/log.go#L193

### Solution
1. This PR removes use of formatter from `github.com/gravitational/trace` as it's really confusing that some part of our code are using our internal formatter and some still depends on 3rd party library. I adjusted the output so it looks the same after switching to our formatter.
2. `findFrame()` which is responsible for finding a caller frame uses function name instead of file path. Filepath with go modules is different for every fork of `logrus` where function name is always prefixed with full module name ex: 'github.com/sirupsen/logrus.(*Entry).write` so if we ever decide to use upstream version or change our fork this logic should still work.
3. I simplify the regex as I don't think anyone is still using `Sirupsen/logrus`.