### PR TITLE
Fix reverse tunnel dialing for Windows Desktops

### DIFF
--- a/api/utils/sshutils/conn.go
+++ b/api/utils/sshutils/conn.go
@@ -17,11 +17,11 @@ limitations under the License.
 package sshutils
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -76,8 +76,8 @@ func ConnectProxyTransport(sconn ssh.Conn, req *DialReq, exclusive bool) (*ChCon
 
 		// Pull the error message from the tunnel client (remote cluster)
 		// passed to us via stderr.
-		errMessageBytes, _ := ioutil.ReadAll(channel.Stderr())
-		errMessage := strings.TrimSpace(string(errMessageBytes))
+		errMessageBytes, _ := io.ReadAll(channel.Stderr())
+		errMessage := string(bytes.TrimSpace(errMessageBytes))
 		if len(errMessage) == 0 {
 			errMessage = fmt.Sprintf("failed connecting to %v [%v]", req.Address, req.ServerID)
 		}

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -246,10 +246,11 @@ func (p *transport) start() {
 			p.log.Debugf("Forwarding connection to %q", p.kubeDialAddr.Addr)
 			servers = append(servers, p.kubeDialAddr.Addr)
 		}
+
 	// LocalNode requests are for the single server running in the agent pool.
-	case LocalNode:
+	case LocalNode, LocalWindowsDesktop:
 		// Transport is allocated with both teleport.ComponentReverseTunnelAgent
-		// and teleport.ComponentReverseTunneServer. However, dialing to this address
+		// and teleport.ComponentReverseTunnelServer. However, dialing to this address
 		// only makes sense when running within a teleport.ComponentReverseTunnelAgent.
 		if p.component == teleport.ComponentReverseTunnelServer {
 			p.reply(req, false, []byte("connection rejected: no local node"))
@@ -375,7 +376,7 @@ func (p *transport) getConn(servers []string, r *sshutils.DialReq) (net.Conn, bo
 		p.log.Debugf("Attempting to dial directly %v.", servers)
 		conn, err = directDial(servers)
 		if err != nil {
-			return nil, false, trace.ConnectionProblem(err, "failed dialing through tunnel (%v) or directly (%v)", err, errTun)
+			return nil, false, trace.ConnectionProblem(err, "failed dialing through tunnel (%v) or directly (%v)", errTun, err)
 		}
 
 		p.log.Debugf("Returning direct dialed connection to %v.", servers)

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -102,7 +102,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 
 	// Start a local listener and let proxies dial in.
 	case !conn.UseTunnel() && !cfg.WindowsDesktop.ListenAddr.IsEmpty():
-		log.Debug("Turning on Windows desktop service listening address.")
+		log.Info("Using local listener and registering directly with auth server")
 		listener, err = process.importOrCreateListener(listenerWindowsDesktop, cfg.WindowsDesktop.ListenAddr.Addr)
 		if err != nil {
 			return trace.Wrap(err)
@@ -142,7 +142,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 				agentPool.Stop()
 			}
 		}()
-		log.Info("Started reverse tunnel client.")
+		log.Info("Using a reverse tunnel to register and handle proxy connections")
 	}
 
 	lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -110,7 +110,7 @@ func createDesktopConnection(
 		From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: r.RemoteAddr},
 		To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: service.GetAddr()},
 		ConnType: types.WindowsDesktopTunnel,
-		ServerID: service.GetName(),
+		ServerID: service.GetName() + "." + ctx.parent.clusterName,
 	})
 	if err != nil {
 		return trace.WrapWithMessage(err, "failed to connect to windows_desktop_service at %q: %v", service.GetAddr(), err)


### PR DESCRIPTION
- Ensure that the dial request uses proper "server ID" format,
  which is `<uuid>.<cluster_name>`
- Update reverse tunnel agent to handle tunnel connections
  to desktops