### PR TITLE
backport #9133 to branch/v6.2

### DIFF
--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -588,6 +588,7 @@ func (i *TeleInstance) GenerateConfig(trustedSecrets []*InstanceSecrets, tconf *
 	}
 
 	tconf.Keygen = testauthority.New()
+	tconf.MaxRetryPeriod = defaults.HighResPollingPeriod
 	i.Config = tconf
 	return tconf, nil
 }

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -434,8 +434,8 @@ type Config struct {
 	WebToken types.WebTokenInterface
 	// Backend is a backend for local cache
 	Backend backend.Backend
-	// RetryPeriod is a period between cache retries on failures
-	RetryPeriod time.Duration
+	// MaxRetryPeriod is the maximum period between cache retries on failures
+	MaxRetryPeriod time.Duration
 	// WatcherInitTimeout is the maximum acceptable delay for an
 	// OpInit after a watcher has been started (default=1m).
 	WatcherInitTimeout time.Duration
@@ -474,8 +474,8 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()
 	}
-	if c.RetryPeriod == 0 {
-		c.RetryPeriod = defaults.HighResPollingPeriod
+	if c.MaxRetryPeriod == 0 {
+		c.MaxRetryPeriod = defaults.MaxWatcherBackoff
 	}
 	if c.WatcherInitTimeout == 0 {
 		c.WatcherInitTimeout = time.Minute
@@ -508,6 +508,9 @@ const (
 	// TombstoneWritten is emitted if cache is closed in a healthy
 	// state and successfully writes its tombstone.
 	TombstoneWritten = "tombstone_written"
+	// Reloading is emitted when an error occurred watching events
+	// and the cache is waiting to create a new watcher
+	Reloading = "reloading_cache"
 )
 
 // New creates a new instance of Cache
@@ -571,8 +574,11 @@ func New(config Config) (*Cache, error) {
 	}
 
 	retry, err := utils.NewLinear(utils.LinearConfig{
-		Step: cs.Config.RetryPeriod / 10,
-		Max:  cs.Config.RetryPeriod,
+		First:  utils.HalfJitter(cs.MaxRetryPeriod / 10),
+		Step:   cs.MaxRetryPeriod / 5,
+		Max:    cs.MaxRetryPeriod,
+		Jitter: utils.NewHalfJitter(),
+		Clock:  cs.Clock,
 	})
 	if err != nil {
 		cs.Close()
@@ -635,10 +641,20 @@ func (c *Cache) update(ctx context.Context, retry utils.Retry) {
 		if err != nil {
 			c.Warningf("Re-init the cache on error: %v.", err)
 		}
+
 		// events cache should be closed as well
-		c.Debugf("Reloading %v.", retry)
+		c.Debugf("Reloading cache.")
+
+		c.notify(ctx, Event{Type: Reloading, Event: types.Event{
+			Resource: &types.ResourceHeader{
+				Kind: retry.Duration().String(),
+			},
+		}})
+
+		startedWaiting := c.Clock.Now()
 		select {
-		case <-retry.After():
+		case t := <-retry.After():
+			c.Debugf("Initiating new watch after waiting %v.", t.Sub(startedWaiting))
 			retry.Inc()
 		case <-c.ctx.Done():
 			return

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1820,8 +1820,11 @@ func TestCache_Backoff(t *testing.T) {
 			require.GreaterOrEqual(t, duration, stepMin)
 			require.LessOrEqual(t, duration, stepMax)
 
+			// wait for cache to get to retry.After
+			clock.BlockUntil(1)
+
 			// add some extra to the duration to ensure the retry occurs
-			clock.Advance(duration * 3)
+			clock.Advance(p.cache.MaxRetryPeriod)
 		case <-time.After(time.Minute):
 			t.Fatalf("timeout waiting for event")
 		}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -404,15 +404,19 @@ var (
 
 	// AsyncBufferSize is a default buffer size for async emitters
 	AsyncBufferSize = 1024
+
+	// MaxWatcherBackoff is the maximum retry time a watcher should use in
+	// the event of connection issues
+	MaxWatcherBackoff = time.Minute
 )
 
 // Default connection limits, they can be applied separately on any of the Teleport
 // services (SSH, auth, proxy)
 const (
-	// Number of max. simultaneous connections to a service
+	// LimiterMaxConnections Number of max. simultaneous connections to a service
 	LimiterMaxConnections = 15000
 
-	// Number of max. simultaneous connected users/logins
+	// LimiterMaxConcurrentUsers Number of max. simultaneous connected users/logins
 	LimiterMaxConcurrentUsers = 250
 
 	// LimiterMaxConcurrentSignatures limits maximum number of concurrently

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -208,6 +208,9 @@ type Config struct {
 
 	// PluginRegistry allows adding enterprise logic to Teleport services
 	PluginRegistry plugin.Registry
+
+	// MaxRetryPeriod is the maximum period between reconnection attempts to auth
+	MaxRetryPeriod time.Duration
 }
 
 // ApplyToken assigns a given token to all internal services but only if token
@@ -848,6 +851,8 @@ func ApplyDefaults(cfg *Config) {
 
 	// Databases proxy service is disabled by default.
 	cfg.Databases.Enabled = false
+
+	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
 }
 
 // ApplyFIPSDefaults updates default configuration to be FedRAMP/FIPS 140-2

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -211,6 +211,9 @@ type Config struct {
 
 	// MaxRetryPeriod is the maximum period between reconnection attempts to auth
 	MaxRetryPeriod time.Duration
+
+	// ConnectFailureC is a channel to notify of failures to connect to auth (used in tests).
+	ConnectFailureC chan time.Duration
 }
 
 // ApplyToken assigns a given token to all internal services but only if token
@@ -292,7 +295,7 @@ type ProxyConfig struct {
 	// Enabled turns proxy role on or off for this process
 	Enabled bool
 
-	//DisableTLS is enabled if we don't want self-signed certs
+	// DisableTLS is enabled if we don't want self-signed certs
 	DisableTLS bool
 
 	// DisableWebInterface allows to turn off serving the Web UI interface
@@ -853,6 +856,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Databases.Enabled = false
 
 	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
+	cfg.ConnectFailureC = make(chan time.Duration, 1)
 }
 
 // ApplyFIPSDefaults updates default configuration to be FedRAMP/FIPS 140-2

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -80,7 +80,7 @@ func (process *TeleportProcess) reconnectToAuthService(role teleport.Role) (*Con
 
 		// Used for testing that auth service will attempt to reconnect in the provided duration.
 		select {
-		case process.connectFailureC <- retry.Duration():
+		case process.Config.ConnectFailureC <- retry.Duration():
 		default:
 		}
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -298,9 +298,6 @@ type TeleportProcess struct {
 
 	// clusterFeatures contain flags for supported and unsupported features.
 	clusterFeatures proto.Features
-
-	// connectFailureC is a channel to notify of failures to connect to auth (used in tests).
-	connectFailureC chan time.Duration
 }
 
 type keyPairKey struct {
@@ -671,7 +668,6 @@ func NewTeleport(cfg *Config) (*TeleportProcess, error) {
 		id:                  processID,
 		keyPairs:            make(map[keyPairKey]KeyPair),
 		appDependCh:         make(chan Event, 1024),
-		connectFailureC:     make(chan time.Duration),
 	}
 
 	process.registerAppDepend()

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -462,6 +462,8 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = true
+	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
+	cfg.ConnectFailureC = make(chan time.Duration, 5)
 	process, err := NewTeleport(cfg)
 	require.NoError(t, err)
 
@@ -478,14 +480,18 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		// wait for connection to fail
 		select {
-		case duration := <-process.connectFailureC:
+		case duration := <-process.Config.ConnectFailureC:
 			stepMin := step * time.Duration(i) / 2
 			stepMax := step * time.Duration(i+1)
 
 			require.GreaterOrEqual(t, duration, stepMin)
 			require.LessOrEqual(t, duration, stepMax)
+
+			// wait for connection to get to retry.After
+			clock.BlockUntil(1)
+
 			// add some extra to the duration to ensure the retry occurs
-			clock.Advance(duration * 3)
+			clock.Advance(cfg.MaxRetryPeriod)
 		case <-time.After(time.Minute):
 			t.Fatalf("timeout waiting for failure")
 		}

--- a/lib/services/local/services_test.go
+++ b/lib/services/local/services_test.go
@@ -76,9 +76,9 @@ func (s *ServicesSuite) SetUpTest(c *check.C) {
 		Clock:         clock,
 		NewProxyWatcher: func() (*services.ProxyWatcher, error) {
 			return services.NewProxyWatcher(services.ProxyWatcherConfig{
-				Context:     context.TODO(),
-				Component:   "test",
-				RetryPeriod: 200 * time.Millisecond,
+				Context:        context.TODO(),
+				Component:      "test",
+				MaxRetryPeriod: 200 * time.Millisecond,
 				Client: &client{
 					PresenceService: presenceService,
 					EventsService:   eventsService,

--- a/lib/services/proxywatcher_test.go
+++ b/lib/services/proxywatcher_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+var _ types.Events = (*errorWatcher)(nil)
+
+type errorWatcher struct {
+}
+
+func (e errorWatcher) GetProxies() ([]types.Server, error) {
+	return nil, nil
+}
+
+func (e errorWatcher) NewWatcher(context.Context, types.Watch) (types.Watcher, error) {
+	return nil, errors.New("watcher error")
+}
+
+func TestProxyWatcher_Backoff(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	w, err := services.NewProxyWatcher(services.ProxyWatcherConfig{
+		Context:        ctx,
+		Component:      "test",
+		Clock:          clock,
+		MaxRetryPeriod: defaults.MaxWatcherBackoff,
+		Client:         &errorWatcher{},
+		ProxiesC:       make(chan []types.Server, 1),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, w.Close()) })
+
+	step := w.MaxRetryPeriod / 5.0
+	for i := 0; i < 5; i++ {
+		// wait for watcher to reload
+		select {
+		case duration := <-w.ResetC:
+			stepMin := step * time.Duration(i) / 2
+			stepMax := step * time.Duration(i+1)
+
+			require.GreaterOrEqual(t, duration, stepMin)
+			require.LessOrEqual(t, duration, stepMax)
+			// add some extra to the duration to ensure the retry occurs
+			clock.Advance(duration * 3)
+		case <-time.After(time.Minute):
+			t.Fatalf("timeout waiting for reset")
+		}
+	}
+}

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1748,7 +1748,7 @@ func (s *ServicesTestSuite) ProxyWatcher(c *check.C) {
 	// since no proxy is yet present, the ProxyWatcher should immediately
 	// yield back to its retry loop.
 	select {
-	case <-w.Reset():
+	case <-w.ResetC:
 	case <-time.After(time.Second):
 		c.Fatalf("Timeout waiting for ProxyWatcher reset")
 	}

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -431,7 +431,7 @@ func (h *Heartbeat) announce() error {
 			if !ok {
 				return trace.BadParameter("expected services.Server, got %#v", h.current)
 			}
-			err := h.Announcer.UpsertKubeService(context.TODO(), kube)
+			err := h.Announcer.UpsertKubeService(h.cancelCtx, kube)
 			if err != nil {
 				h.nextAnnounce = h.Clock.Now().UTC().Add(h.KeepAlivePeriod)
 				h.setState(HeartbeatStateAnnounceWait)

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -773,6 +773,7 @@ func (s *SrvSuite) TestProxyReverseTunnel(c *C) {
 		AccessPoint:         s.proxyClient,
 		ReverseTunnelServer: reverseTunnelServer,
 		LocalCluster:        s.server.ClusterName(),
+		Log:                 logger,
 	})
 	c.Assert(err, IsNil)
 

--- a/lib/utils/retry.go
+++ b/lib/utils/retry.go
@@ -214,6 +214,9 @@ func (r *Linear) Duration() time.Duration {
 	if a <= r.Max {
 		return a
 	}
+	if r.Jitter != nil {
+		return r.Jitter(r.Max)
+	}
 	return r.Max
 }
 
@@ -233,7 +236,7 @@ func (r *Linear) String() string {
 	return fmt.Sprintf("Linear(attempt=%v, duration=%v)", r.attempt, r.Duration())
 }
 
-// RetryFastFor retries a function repeatedly for a set amount of
+// RetryStaticFor retries a function repeatedly for a set amount of
 // time before returning an error.
 //
 // Intended mostly for tests.


### PR DESCRIPTION
Backport of #9133 with minor modifications to account for differences between `ProxyWatcher` on __6.2__ and `resourceWathcer` on __master__

This also includes the flaky test fixes from  #9516