### PR TITLE
Revert bot changes for `vendor/`

### DIFF
--- a/.github/workflows/robot/internal/bot/bot.go
+++ b/.github/workflows/robot/internal/bot/bot.go
@@ -94,6 +94,9 @@ func (b *Bot) parseChanges(ctx context.Context) (bool, bool, error) {
 }
 
 func hasDocs(filename string) bool {
+	if strings.HasPrefix(filename, "vendor/") {
+		return false
+	}
 	return strings.HasPrefix(filename, "docs/") ||
 		strings.HasSuffix(filename, ".md") ||
 		strings.HasSuffix(filename, ".mdx") ||

--- a/.github/workflows/robot/internal/bot/label.go
+++ b/.github/workflows/robot/internal/bot/label.go
@@ -62,6 +62,10 @@ func (b *Bot) labels(ctx context.Context) ([]string, error) {
 	}
 
 	for _, file := range files {
+		if strings.HasPrefix(file, "vendor/") {
+			continue
+		}
+
 		for k, v := range prefixes {
 			if strings.HasPrefix(file, k) {
 				log.Printf("Label: Found prefix %v, attaching labels: %v.", k, v)


### PR DESCRIPTION
The bot runs code from the `master` branch even for the stable branches that still use vendored dependencies, so we should keep ignoring the `vendor/` directory in the bot, or we might miscategorize PRs.