### PR TITLE
Clean up system role parsing

### DIFF
--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -81,9 +81,6 @@ var roleMappings = map[string]SystemRole{
 	"windows_desktop": RoleWindowsDesktop,
 }
 
-// LegacyClusterTokenType exists for backwards compatibility reasons, needed to upgrade to 2.3
-const LegacyClusterTokenType SystemRole = "Trustedcluster"
-
 // NewTeleportRoles return a list of teleport roles from slice of strings
 func NewTeleportRoles(in []string) (SystemRoles, error) {
 	var roles SystemRoles
@@ -200,7 +197,7 @@ func (r *SystemRole) String() string {
 	switch *r {
 	case RoleSignup:
 		return "Password"
-	case RoleTrustedCluster, LegacyClusterTokenType:
+	case RoleTrustedCluster:
 		return "trusted_cluster"
 	default:
 		return string(*r)
@@ -209,14 +206,13 @@ func (r *SystemRole) String() string {
 
 // Check checks if this a a valid teleport role value, returns nil
 // if it's ok, false otherwise
+// Check checks if this a a valid teleport role value, returns nil
+// if it's ok, false otherwise
 func (r *SystemRole) Check() error {
-	switch *r {
-	case RoleAuth, RoleNode, RoleApp, RoleDatabase,
-		RoleAdmin, RoleProvisionToken,
-		RoleTrustedCluster, LegacyClusterTokenType,
-		RoleSignup, RoleProxy, RoleRemoteProxy,
-		RoleNop, RoleKube, RoleWindowsDesktop:
+	sr, ok := roleMappings[strings.ToLower(string(*r))]
+	if ok && string(*r) == string(sr) {
 		return nil
 	}
+
 	return trace.BadParameter("role %v is not registered", *r)
 }

--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -17,7 +17,6 @@ limitations under the License.
 package types
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -181,7 +180,7 @@ func (r *SystemRole) String() string {
 	case RoleTrustedCluster, LegacyClusterTokenType:
 		return "trusted_cluster"
 	default:
-		return fmt.Sprintf("%v", string(*r))
+		return string(*r)
 	}
 }
 

--- a/api/types/system_role_test.go
+++ b/api/types/system_role_test.go
@@ -85,6 +85,17 @@ func TestParseTeleportRoles(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			in:      "windowsdesktop",
+			out:     SystemRoles{RoleWindowsDesktop},
+			wantErr: false,
+		},
+		{
+			// allow underscores for camelcase roles
+			in:      "windows_desktop,trusted_cluster,remote_proxy",
+			out:     SystemRoles{RoleWindowsDesktop, RoleTrustedCluster, RoleRemoteProxy},
+			wantErr: false,
+		},
+		{
 			// multiple comma-separated roles
 			in:      "Auth,Proxy",
 			out:     SystemRoles{RoleAuth, RoleProxy},

--- a/api/types/system_role_test.go
+++ b/api/types/system_role_test.go
@@ -17,6 +17,8 @@ package types
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRolesCheck(t *testing.T) {
@@ -60,5 +62,68 @@ func TestRolesEqual(t *testing.T) {
 		if got := tt.a.Equals(tt.b); got != tt.want {
 			t.Errorf("%v.Equals(%v): got %v, want %v", tt.a, tt.b, got, tt.want)
 		}
+	}
+}
+
+func TestParseTeleportRoles(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		in      string
+		out     SystemRoles
+		wantErr bool
+	}{
+		{
+			// system role constant
+			in:      string(RoleNode),
+			out:     SystemRoles{RoleNode},
+			wantErr: false,
+		},
+		{
+			// alternate capitalization
+			in:      "node",
+			out:     SystemRoles{RoleNode},
+			wantErr: false,
+		},
+		{
+			// multiple comma-separated roles
+			in:      "Auth,Proxy",
+			out:     SystemRoles{RoleAuth, RoleProxy},
+			wantErr: false,
+		},
+		{
+			// extra whitespace handled properly
+			in:      "Auth , Proxy,WindowsDesktop",
+			out:     SystemRoles{RoleAuth, RoleProxy, RoleWindowsDesktop},
+			wantErr: false,
+		},
+		{
+			// duplicate roles is an error
+			in:      "Auth,Auth",
+			wantErr: true,
+		},
+		{
+			in:      "Auth, auth",
+			wantErr: true,
+		},
+		{
+			// invalid role errors
+			in:      "invalidrole",
+			wantErr: true,
+		},
+		{
+			// valid + invalid role errors
+			in:      "Admin,invalidrole",
+			wantErr: true,
+		},
+	} {
+		t.Run(test.in, func(t *testing.T) {
+			roles, err := ParseTeleportRoles(test.in)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.out, roles)
+			}
+		})
 	}
 }

--- a/api/types/system_role_test.go
+++ b/api/types/system_role_test.go
@@ -28,7 +28,7 @@ func TestRolesCheck(t *testing.T) {
 	}{
 		{roles: []SystemRole{}, wantErr: false},
 		{roles: []SystemRole{RoleAuth}, wantErr: false},
-		{roles: []SystemRole{RoleAuth, RoleNode, RoleProxy, RoleAdmin, RoleProvisionToken, RoleTrustedCluster, LegacyClusterTokenType, RoleSignup, RoleNop}, wantErr: false},
+		{roles: []SystemRole{RoleAuth, RoleNode, RoleProxy, RoleAdmin, RoleProvisionToken, RoleTrustedCluster, RoleSignup, RoleNop}, wantErr: false},
 		{roles: []SystemRole{RoleAuth, RoleNode, RoleAuth}, wantErr: true},
 		{roles: []SystemRole{SystemRole("unknown")}, wantErr: true},
 	}

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -538,7 +538,7 @@ func (a *Server) validateTrustedClusterToken(token string) (map[string]string, e
 		return nil, trace.AccessDenied("the remote server denied access: invalid cluster token")
 	}
 
-	if !roles.Include(types.RoleTrustedCluster) && !roles.Include(types.LegacyClusterTokenType) {
+	if !roles.Include(types.RoleTrustedCluster) {
 		return nil, trace.AccessDenied("role does not match")
 	}
 

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -144,9 +144,9 @@ func (c *NodeCommand) Invite(client auth.ClientI) error {
 		return trace.Errorf("This cluster does not have any auth servers running.")
 	}
 
-	// output format swtich:
+	// output format switch:
 	if c.format == "text" {
-		if roles.Include(types.RoleTrustedCluster) || roles.Include(types.LegacyClusterTokenType) {
+		if roles.Include(types.RoleTrustedCluster) {
 			fmt.Printf(trustedClusterMessage, token, int(c.ttl.Minutes()))
 		} else {
 			return nodeMessageTemplate.Execute(os.Stdout, map[string]interface{}{

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -213,7 +213,7 @@ func (c *TokenCommand) Add(client auth.ClientI) error {
 				"db_protocol": c.dbProtocol,
 				"db_uri":      c.dbURI,
 			})
-	case roles.Include(types.RoleTrustedCluster), roles.Include(types.LegacyClusterTokenType):
+	case roles.Include(types.RoleTrustedCluster):
 		fmt.Printf(trustedClusterMessage,
 			token,
 			int(c.ttl.Minutes()))


### PR DESCRIPTION
Be more consistent in what inputs we accept when referring to system roles, such as in the `tctl tokens add` call. 

Also add missing test coverage for this parser.

Fixes #9752