### PR TITLE
Convert auth test from gocheck to standard lib

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -61,7 +61,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
-	. "gopkg.in/check.v1"
 )
 
 type testPack struct {
@@ -163,32 +162,27 @@ func newTestPack(ctx context.Context, dataDir string) (testPack, error) {
 	return p, nil
 }
 
+func newAuthSuite(t *testing.T) *testPack {
+	s, err := newTestPack(context.Background(), t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if s.bk != nil {
+			s.bk.Close()
+		}
+	})
+
+	return &s
+}
+
 func TestMain(m *testing.M) {
 	utils.InitLoggerForTests()
 	os.Exit(m.Run())
 }
 
-func TestAPI(t *testing.T) { TestingT(t) }
+func TestSessions(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
 
-type AuthSuite struct {
-	testPack
-}
-
-var _ = Suite(&AuthSuite{})
-
-func (s *AuthSuite) SetUpTest(c *C) {
-	p, err := newTestPack(context.Background(), c.MkDir())
-	c.Assert(err, IsNil)
-	s.testPack = p
-}
-
-func (s *AuthSuite) TearDownTest(c *C) {
-	if s.bk != nil {
-		s.bk.Close()
-	}
-}
-
-func (s *AuthSuite) TestSessions(c *C) {
 	ctx := context.Background()
 
 	user := "user1"
@@ -198,46 +192,49 @@ func (s *AuthSuite) TestSessions(c *C) {
 		Username: user,
 		Pass:     &PassCreds{Password: pass},
 	})
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	_, _, err = CreateUserAndRole(s.a, user, []string{user})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	err = s.a.UpsertPassword(user, pass)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	ws, err := s.a.AuthenticateWebUser(AuthenticateUserRequest{
 		Username: user,
 		Pass:     &PassCreds{Password: pass},
 	})
-	c.Assert(err, IsNil)
-	c.Assert(ws, NotNil)
+	require.NoError(t, err)
+	require.NotNil(t, ws)
 
 	out, err := s.a.GetWebSessionInfo(ctx, user, ws.GetName())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	ws.SetPriv(nil)
-	fixtures.DeepCompare(c, ws, out)
+	require.Equal(t, ws, out)
 
 	err = s.a.WebSessions().Delete(ctx, types.DeleteWebSessionRequest{
 		User:      user,
 		SessionID: ws.GetName(),
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	_, err = s.a.GetWebSession(ctx, types.GetWebSessionRequest{
 		User:      user,
 		SessionID: ws.GetName(),
 	})
-	c.Assert(trace.IsNotFound(err), Equals, true, Commentf("%#v", err))
+	require.True(t, trace.IsNotFound(err), "%#v", err)
 }
 
-func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
+func TestAuthenticateSSHUser(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	ctx := context.Background()
 
 	// Register the leaf cluster.
 	leaf, err := types.NewRemoteCluster("leaf.localhost")
-	c.Assert(err, IsNil)
-	c.Assert(s.a.CreateRemoteCluster(leaf), IsNil)
+	require.NoError(t, err)
+	require.NoError(t, s.a.CreateRemoteCluster(leaf))
 
 	user := "user1"
 	pass := []byte("abc123")
@@ -249,23 +246,23 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 			Pass:     &PassCreds{Password: pass},
 		},
 	})
-	c.Assert(err, NotNil)
-	c.Assert(trace.IsAccessDenied(err), Equals, true)
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err))
 
 	// Create the user.
 	_, role, err := CreateUserAndRole(s.a, user, []string{user})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	err = s.a.UpsertPassword(user, pass)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	// Give the role some k8s principals too.
 	role.SetKubeUsers(types.Allow, []string{user})
 	role.SetKubeGroups(types.Allow, []string{"system:masters"})
 	err = s.a.UpsertRole(ctx, role)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	kg := testauthority.New()
 	_, pub, err := kg.GetNewKeyPairFromPool()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Login to the root cluster.
 	resp, err := s.a.AuthenticateSSHUser(AuthenticateSSHRequest{
@@ -277,20 +274,20 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		TTL:            time.Hour,
 		RouteToCluster: s.clusterName.GetClusterName(),
 	})
-	c.Assert(err, IsNil)
-	c.Assert(resp.Username, Equals, user)
+	require.NoError(t, err)
+	require.Equal(t, resp.Username, user)
 	// Verify the public key and principals in SSH cert.
 	inSSHPub, _, _, _, err := ssh.ParseAuthorizedKey(pub)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	gotSSHCert, err := sshutils.ParseCertificate(resp.Cert)
-	c.Assert(err, IsNil)
-	c.Assert(gotSSHCert.Key, DeepEquals, inSSHPub)
-	c.Assert(gotSSHCert.ValidPrincipals, DeepEquals, []string{user})
+	require.NoError(t, err)
+	require.Equal(t, gotSSHCert.Key, inSSHPub)
+	require.Equal(t, gotSSHCert.ValidPrincipals, []string{user})
 	// Verify the public key and Subject in TLS cert.
 	inCryptoPub := inSSHPub.(ssh.CryptoPublicKey).CryptoPublicKey()
 	gotTLSCert, err := tlsca.ParseCertificatePEM(resp.TLSCert)
-	c.Assert(err, IsNil)
-	c.Assert(gotTLSCert.PublicKey, DeepEquals, inCryptoPub)
+	require.NoError(t, err)
+	require.Equal(t, gotTLSCert.PublicKey, inCryptoPub)
 	wantID := tlsca.Identity{
 		Username:         user,
 		Groups:           []string{role.GetName()},
@@ -302,8 +299,8 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		TeleportCluster:  s.clusterName.GetClusterName(),
 	}
 	gotID, err := tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
-	c.Assert(err, IsNil)
-	c.Assert(*gotID, DeepEquals, wantID)
+	require.NoError(t, err)
+	require.Equal(t, *gotID, wantID)
 
 	// Login to the leaf cluster.
 	resp, err = s.a.AuthenticateSSHUser(AuthenticateSSHRequest{
@@ -316,10 +313,10 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:    "leaf.localhost",
 		KubernetesCluster: "leaf-kube-cluster",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	// Verify the TLS cert has the correct RouteToCluster set.
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	wantID = tlsca.Identity{
 		Username:         user,
 		Groups:           []string{role.GetName()},
@@ -334,8 +331,8 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		TeleportCluster:   s.clusterName.GetClusterName(),
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
-	c.Assert(err, IsNil)
-	c.Assert(*gotID, DeepEquals, wantID)
+	require.NoError(t, err)
+	require.Equal(t, *gotID, wantID)
 
 	// Register a kubernetes cluster to verify the defaulting logic in TLS cert
 	// generation.
@@ -347,7 +344,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 			KubernetesClusters: []*types.KubernetesCluster{{Name: "root-kube-cluster"}},
 		},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Login specifying a valid kube cluster. It should appear in the TLS cert.
 	resp, err = s.a.AuthenticateSSHUser(AuthenticateSSHRequest{
@@ -360,10 +357,10 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:    s.clusterName.GetClusterName(),
 		KubernetesCluster: "root-kube-cluster",
 	})
-	c.Assert(err, IsNil)
-	c.Assert(resp.Username, Equals, user)
+	require.NoError(t, err)
+	require.Equal(t, resp.Username, user)
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	wantID = tlsca.Identity{
 		Username:          user,
 		Groups:            []string{role.GetName()},
@@ -376,8 +373,8 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		TeleportCluster:   s.clusterName.GetClusterName(),
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
-	c.Assert(err, IsNil)
-	c.Assert(*gotID, DeepEquals, wantID)
+	require.NoError(t, err)
+	require.Equal(t, *gotID, wantID)
 
 	// Login without specifying kube cluster. A registered one should be picked
 	// automatically.
@@ -393,10 +390,10 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		// kubernetes cluster.
 		KubernetesCluster: "",
 	})
-	c.Assert(err, IsNil)
-	c.Assert(resp.Username, Equals, user)
+	require.NoError(t, err)
+	require.Equal(t, resp.Username, user)
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	wantID = tlsca.Identity{
 		Username:          user,
 		Groups:            []string{role.GetName()},
@@ -409,8 +406,8 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		TeleportCluster:   s.clusterName.GetClusterName(),
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
-	c.Assert(err, IsNil)
-	c.Assert(*gotID, DeepEquals, wantID)
+	require.NoError(t, err)
+	require.Equal(t, *gotID, wantID)
 
 	// Register a kubernetes cluster to verify the defaulting logic in TLS cert
 	// generation.
@@ -422,7 +419,7 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 			KubernetesClusters: []*types.KubernetesCluster{{Name: "root-kube-cluster"}},
 		},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// Login specifying a valid kube cluster. It should appear in the TLS cert.
 	resp, err = s.a.AuthenticateSSHUser(AuthenticateSSHRequest{
@@ -435,10 +432,10 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:    s.clusterName.GetClusterName(),
 		KubernetesCluster: "root-kube-cluster",
 	})
-	c.Assert(err, IsNil)
-	c.Assert(resp.Username, Equals, user)
+	require.NoError(t, err)
+	require.Equal(t, resp.Username, user)
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	wantID = tlsca.Identity{
 		Username:          user,
 		Groups:            []string{role.GetName()},
@@ -451,8 +448,8 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		TeleportCluster:   s.clusterName.GetClusterName(),
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
-	c.Assert(err, IsNil)
-	c.Assert(*gotID, DeepEquals, wantID)
+	require.NoError(t, err)
+	require.Equal(t, *gotID, wantID)
 
 	// Login without specifying kube cluster. A registered one should be picked
 	// automatically.
@@ -468,10 +465,10 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		// kubernetes cluster.
 		KubernetesCluster: "",
 	})
-	c.Assert(err, IsNil)
-	c.Assert(resp.Username, Equals, user)
+	require.NoError(t, err)
+	require.Equal(t, resp.Username, user)
 	gotTLSCert, err = tlsca.ParseCertificatePEM(resp.TLSCert)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	wantID = tlsca.Identity{
 		Username:          user,
 		Groups:            []string{role.GetName()},
@@ -484,8 +481,8 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		TeleportCluster:   s.clusterName.GetClusterName(),
 	}
 	gotID, err = tlsca.FromSubject(gotTLSCert.Subject, gotTLSCert.NotAfter)
-	c.Assert(err, IsNil)
-	c.Assert(*gotID, DeepEquals, wantID)
+	require.NoError(t, err)
+	require.Equal(t, *gotID, wantID)
 
 	// Login specifying an invalid kube cluster. This should fail.
 	_, err = s.a.AuthenticateSSHUser(AuthenticateSSHRequest{
@@ -498,10 +495,13 @@ func (s *AuthSuite) TestAuthenticateSSHUser(c *C) {
 		RouteToCluster:    s.clusterName.GetClusterName(),
 		KubernetesCluster: "invalid-kube-cluster",
 	})
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 }
 
-func (s *AuthSuite) TestUserLock(c *C) {
+func TestUserLock(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	username := "user1"
 	pass := []byte("abc123")
 
@@ -509,21 +509,21 @@ func (s *AuthSuite) TestUserLock(c *C) {
 		Username: username,
 		Pass:     &PassCreds{Password: pass},
 	})
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	_, _, err = CreateUserAndRole(s.a, username, []string{username})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	err = s.a.UpsertPassword(username, pass)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// successful log in
 	ws, err := s.a.AuthenticateWebUser(AuthenticateUserRequest{
 		Username: username,
 		Pass:     &PassCreds{Password: pass},
 	})
-	c.Assert(err, IsNil)
-	c.Assert(ws, NotNil)
+	require.NoError(t, err)
+	require.NotNil(t, ws)
 
 	fakeClock := clockwork.NewFakeClock()
 	s.a.SetClock(fakeClock)
@@ -533,12 +533,12 @@ func (s *AuthSuite) TestUserLock(c *C) {
 			Username: username,
 			Pass:     &PassCreds{Password: []byte("wrong pass")},
 		})
-		c.Assert(err, NotNil)
+		require.Error(t, err)
 	}
 
 	user, err := s.a.Identity.GetUser(username, false)
-	c.Assert(err, IsNil)
-	c.Assert(user.GetStatus().IsLocked, Equals, true)
+	require.NoError(t, err)
+	require.True(t, user.GetStatus().IsLocked)
 
 	// advance time and make sure we can login again
 	fakeClock.Advance(defaults.AccountLockInterval + time.Second)
@@ -547,44 +547,47 @@ func (s *AuthSuite) TestUserLock(c *C) {
 		Username: username,
 		Pass:     &PassCreds{Password: pass},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 }
 
-func (s *AuthSuite) TestTokensCRUD(c *C) {
+func TestTokensCRUD(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	ctx := context.Background()
 
 	// before we do anything, we should have 0 tokens
 	btokens, err := s.a.GetTokens(ctx)
-	c.Assert(err, IsNil)
-	c.Assert(len(btokens), Equals, 0)
+	require.NoError(t, err)
+	require.Empty(t, btokens, 0)
 
 	// generate persistent token
 	tok, err := s.a.GenerateToken(ctx, GenerateTokenRequest{Roles: types.SystemRoles{types.RoleNode}})
-	c.Assert(err, IsNil)
-	c.Assert(len(tok), Equals, 2*TokenLenBytes)
+	require.NoError(t, err)
+	require.Len(t, tok, 2*TokenLenBytes)
 	tokens, err := s.a.GetTokens(ctx)
-	c.Assert(err, IsNil)
-	c.Assert(len(tokens), Equals, 1)
-	c.Assert(tokens[0].GetName(), Equals, tok)
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+	require.Equal(t, tokens[0].GetName(), tok)
 
 	roles, _, err := s.a.ValidateToken(ctx, tok)
-	c.Assert(err, IsNil)
-	c.Assert(roles.Include(types.RoleNode), Equals, true)
-	c.Assert(roles.Include(types.RoleProxy), Equals, false)
+	require.NoError(t, err)
+	require.True(t, roles.Include(types.RoleNode))
+	require.False(t, roles.Include(types.RoleProxy))
 
 	// generate predefined token
 	customToken := "custom-token"
 	tok, err = s.a.GenerateToken(ctx, GenerateTokenRequest{Roles: types.SystemRoles{types.RoleNode}, Token: customToken})
-	c.Assert(err, IsNil)
-	c.Assert(tok, Equals, customToken)
+	require.NoError(t, err)
+	require.Equal(t, tok, customToken)
 
 	roles, _, err = s.a.ValidateToken(ctx, tok)
-	c.Assert(err, IsNil)
-	c.Assert(roles.Include(types.RoleNode), Equals, true)
-	c.Assert(roles.Include(types.RoleProxy), Equals, false)
+	require.NoError(t, err)
+	require.True(t, roles.Include(types.RoleNode))
+	require.False(t, roles.Include(types.RoleProxy))
 
 	err = s.a.DeleteToken(ctx, customToken)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// lets use static tokens now
 	roles = types.SystemRoles{types.RoleProxy}
@@ -595,46 +598,52 @@ func (s *AuthSuite) TestTokensCRUD(c *C) {
 			Expires: time.Unix(0, 0).UTC(),
 		}},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	err = s.a.SetStaticTokens(st)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	r, _, err := s.a.ValidateToken(ctx, "static-token-value")
-	c.Assert(err, IsNil)
-	c.Assert(r, DeepEquals, roles)
+	require.NoError(t, err)
+	require.Equal(t, r, roles)
 
 	// List tokens (should see 2: one static, one regular)
 	tokens, err = s.a.GetTokens(ctx)
-	c.Assert(err, IsNil)
-	c.Assert(len(tokens), Equals, 2)
+	require.NoError(t, err)
+	require.Len(t, tokens, 2)
 }
 
-func (s *AuthSuite) TestBadTokens(c *C) {
+func TestBadTokens(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	ctx := context.Background()
 	// empty
 	_, _, err := s.a.ValidateToken(ctx, "")
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	// garbage
 	_, _, err = s.a.ValidateToken(ctx, "bla bla")
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	// tampered
 	tok, err := s.a.GenerateToken(ctx, GenerateTokenRequest{Roles: types.SystemRoles{types.RoleAuth}})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	tampered := string(tok[0]+1) + tok[1:]
 	_, _, err = s.a.ValidateToken(ctx, tampered)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 }
 
-func (s *AuthSuite) TestGenerateTokenEventsEmitted(c *C) {
+func TestGenerateTokenEventsEmitted(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	ctx := context.Background()
 	// test trusted cluster token emit
 	_, err := s.a.GenerateToken(ctx, GenerateTokenRequest{Roles: types.SystemRoles{types.RoleTrustedCluster}})
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.TrustedClusterTokenCreateEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.TrustedClusterTokenCreateEvent)
 	s.mockEmitter.Reset()
 
 	// test emit with multiple roles
@@ -643,19 +652,22 @@ func (s *AuthSuite) TestGenerateTokenEventsEmitted(c *C) {
 		types.RoleTrustedCluster,
 		types.RoleAuth,
 	}})
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.TrustedClusterTokenCreateEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.TrustedClusterTokenCreateEvent)
 }
 
-func (s *AuthSuite) TestValidateACRValues(c *C) {
+func TestValidateACRValues(t *testing.T) {
+	s := newAuthSuite(t)
+
 	tests := []struct {
+		comment       string
 		inIDToken     string
 		inACRValue    string
 		inACRProvider string
-		outIsValid    bool
+		outIsValid    require.ErrorAssertionFunc
 	}{
-		// 0 - default, acr values match
 		{
+			"0 - default, acr values match",
 			`
 {
 	"acr": "foo",
@@ -665,10 +677,10 @@ func (s *AuthSuite) TestValidateACRValues(c *C) {
 			`,
 			"foo",
 			"",
-			true,
+			require.NoError,
 		},
-		// 1 - default, acr values do not match
 		{
+			"1 - default, acr values do not match",
 			`
 {
 	"acr": "foo",
@@ -678,10 +690,10 @@ func (s *AuthSuite) TestValidateACRValues(c *C) {
 			`,
 			"bar",
 			"",
-			false,
+			require.Error,
 		},
-		// 2 - netiq, acr values match
 		{
+			"2 - netiq, acr values match",
 			`
 {
     "acr": {
@@ -695,10 +707,10 @@ func (s *AuthSuite) TestValidateACRValues(c *C) {
 			`,
 			"foo/bar/baz",
 			"netiq",
-			true,
+			require.NoError,
 		},
-		// 3 - netiq, invalid format
 		{
+			"3 - netiq, invalid format",
 			`
 {
     "acr": {
@@ -710,10 +722,10 @@ func (s *AuthSuite) TestValidateACRValues(c *C) {
 			`,
 			"foo/bar/baz",
 			"netiq",
-			false,
+			require.Error,
 		},
-		// 4 - netiq, invalid value
 		{
+			"4 - netiq, invalid value",
 			`
 {
     "acr": {
@@ -727,40 +739,41 @@ func (s *AuthSuite) TestValidateACRValues(c *C) {
 			`,
 			"foo/bar/baz",
 			"netiq",
-			false,
+			require.Error,
 		},
 	}
 
-	for i, tt := range tests {
-		comment := Commentf("Test %v", i)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.comment, func(t *testing.T) {
+			t.Parallel()
+			var claims jose.Claims
+			err := json.Unmarshal([]byte(tt.inIDToken), &claims)
+			require.NoError(t, err)
 
-		var claims jose.Claims
-		err := json.Unmarshal([]byte(tt.inIDToken), &claims)
-		c.Assert(err, IsNil, comment)
-
-		err = s.a.validateACRValues(tt.inACRValue, tt.inACRProvider, claims)
-		if tt.outIsValid {
-			c.Assert(err, IsNil, comment)
-		} else {
-			c.Assert(err, NotNil, comment)
-		}
+			err = s.a.validateACRValues(tt.inACRValue, tt.inACRProvider, claims)
+			tt.outIsValid(t, err)
+		})
 	}
 }
 
-func (s *AuthSuite) TestUpdateConfig(c *C) {
+func TestUpdateConfig(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	cn, err := s.a.GetClusterName()
-	c.Assert(err, IsNil)
-	c.Assert(cn.GetClusterName(), Equals, s.clusterName.GetClusterName())
+	require.NoError(t, err)
+	require.Equal(t, cn.GetClusterName(), s.clusterName.GetClusterName())
 	st, err := s.a.GetStaticTokens()
-	c.Assert(err, IsNil)
-	c.Assert(st.GetStaticTokens(), DeepEquals, []types.ProvisionToken{})
+	require.NoError(t, err)
+	require.Equal(t, st.GetStaticTokens(), []types.ProvisionToken{})
 
 	// try and set cluster name, this should fail because you can only set the
 	// cluster name once
 	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
 		ClusterName: "foo.localhost",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	// use same backend but start a new auth server with different config.
 	authConfig := &InitConfig{
 		ClusterName:            clusterName,
@@ -769,10 +782,10 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 		SkipPeriodicOperations: true,
 	}
 	authServer, err := NewServer(authConfig)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	err = authServer.SetClusterName(clusterName)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 	// try and set static tokens, this should be successful because the last
 	// one to upsert tokens wins
 	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
@@ -781,18 +794,18 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 			Roles: types.SystemRoles{types.SystemRole("baz")},
 		}},
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	err = authServer.SetStaticTokens(staticTokens)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// check first auth server and make sure it returns the correct values
 	// (original cluster name, new static tokens)
 	cn, err = s.a.GetClusterName()
-	c.Assert(err, IsNil)
-	c.Assert(cn.GetClusterName(), Equals, s.clusterName.GetClusterName())
+	require.NoError(t, err)
+	require.Equal(t, cn.GetClusterName(), s.clusterName.GetClusterName())
 	st, err = s.a.GetStaticTokens()
-	c.Assert(err, IsNil)
-	c.Assert(st.GetStaticTokens(), DeepEquals, types.ProvisionTokensFromV1([]types.ProvisionTokenV1{{
+	require.NoError(t, err)
+	require.Equal(t, st.GetStaticTokens(), types.ProvisionTokensFromV1([]types.ProvisionTokenV1{{
 		Token: "bar",
 		Roles: types.SystemRoles{types.SystemRole("baz")},
 	}}))
@@ -800,16 +813,19 @@ func (s *AuthSuite) TestUpdateConfig(c *C) {
 	// check second auth server and make sure it also has the correct values
 	// new static tokens
 	st, err = authServer.GetStaticTokens()
-	c.Assert(err, IsNil)
-	c.Assert(st.GetStaticTokens(), DeepEquals, types.ProvisionTokensFromV1([]types.ProvisionTokenV1{{
+	require.NoError(t, err)
+	require.Equal(t, st.GetStaticTokens(), types.ProvisionTokensFromV1([]types.ProvisionTokenV1{{
 		Token: "bar",
 		Roles: types.SystemRoles{types.SystemRole("baz")},
 	}}))
 }
 
-func (s *AuthSuite) TestCreateAndUpdateUserEventsEmitted(c *C) {
+func TestCreateAndUpdateUserEventsEmitted(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	user, err := types.NewUser("some-user")
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	ctx := context.Background()
 
@@ -818,39 +834,42 @@ func (s *AuthSuite) TestCreateAndUpdateUserEventsEmitted(c *C) {
 		User: types.UserRef{Name: "some-auth-user"},
 	})
 	err = s.a.CreateUser(ctx, user)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.UserCreateEvent)
-	c.Assert(s.mockEmitter.LastEvent().(*apievents.UserCreate).User, Equals, "some-auth-user")
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.UserCreateEvent)
+	require.Equal(t, s.mockEmitter.LastEvent().(*apievents.UserCreate).User, "some-auth-user")
 	s.mockEmitter.Reset()
 
 	// test create user with existing user
 	err = s.a.CreateUser(ctx, user)
-	c.Assert(trace.IsAlreadyExists(err), Equals, true)
-	c.Assert(s.mockEmitter.LastEvent(), IsNil)
+	require.True(t, trace.IsAlreadyExists(err))
+	require.Nil(t, s.mockEmitter.LastEvent())
 
 	// test createdBy gets set to default
 	user2, err := types.NewUser("some-other-user")
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	err = s.a.CreateUser(ctx, user2)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().(*apievents.UserCreate).User, Equals, teleport.UserSystem)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().(*apievents.UserCreate).User, teleport.UserSystem)
 	s.mockEmitter.Reset()
 
 	// test update on non-existent user
 	user3, err := types.NewUser("non-existent-user")
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	err = s.a.UpdateUser(ctx, user3)
-	c.Assert(trace.IsNotFound(err), Equals, true)
-	c.Assert(s.mockEmitter.LastEvent(), IsNil)
+	require.True(t, trace.IsNotFound(err))
+	require.Nil(t, s.mockEmitter.LastEvent())
 
 	// test update user
 	err = s.a.UpdateUser(ctx, user)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.UserUpdatedEvent)
-	c.Assert(s.mockEmitter.LastEvent().(*apievents.UserCreate).User, Equals, teleport.UserSystem)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.UserUpdatedEvent)
+	require.Equal(t, s.mockEmitter.LastEvent().(*apievents.UserCreate).User, teleport.UserSystem)
 }
 
-func (s *AuthSuite) TestTrustedClusterCRUDEventEmitted(c *C) {
+func TestTrustedClusterCRUDEventEmitted(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	ctx := context.Background()
 	s.a.emitter = s.mockEmitter
 
@@ -861,90 +880,99 @@ func (s *AuthSuite) TestTrustedClusterCRUDEventEmitted(c *C) {
 		Roles:                []string{"a"},
 		ReverseTunnelAddress: "b",
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	_, err = s.a.Presence.UpsertTrustedCluster(ctx, tc)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
-	c.Assert(s.a.UpsertCertAuthority(suite.NewTestCA(types.UserCA, "test")), IsNil)
-	c.Assert(s.a.UpsertCertAuthority(suite.NewTestCA(types.HostCA, "test")), IsNil)
+	require.NoError(t, s.a.UpsertCertAuthority(suite.NewTestCA(types.UserCA, "test")))
+	require.NoError(t, s.a.UpsertCertAuthority(suite.NewTestCA(types.HostCA, "test")))
 
 	err = s.a.createReverseTunnel(tc)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// test create event for switch case: when tc exists but enabled is false
 	tc.SetEnabled(false)
 
 	_, err = s.a.UpsertTrustedCluster(ctx, tc)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.TrustedClusterCreateEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.TrustedClusterCreateEvent)
 	s.mockEmitter.Reset()
 
 	// test create event for switch case: when tc exists but enabled is true
 	tc.SetEnabled(true)
 
 	_, err = s.a.UpsertTrustedCluster(ctx, tc)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.TrustedClusterCreateEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.TrustedClusterCreateEvent)
 	s.mockEmitter.Reset()
 
 	// test delete event
 	err = s.a.DeleteTrustedCluster(ctx, "test")
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.TrustedClusterDeleteEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.TrustedClusterDeleteEvent)
 }
 
-func (s *AuthSuite) TestGithubConnectorCRUDEventsEmitted(c *C) {
+func TestGithubConnectorCRUDEventsEmitted(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	ctx := context.Background()
 	// test github create event
 	github, err := types.NewGithubConnector("test", types.GithubConnectorSpecV3{})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	err = s.a.upsertGithubConnector(ctx, github)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.GithubConnectorCreatedEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.GithubConnectorCreatedEvent)
 	s.mockEmitter.Reset()
 
 	// test github update event
 	err = s.a.upsertGithubConnector(ctx, github)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.GithubConnectorCreatedEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.GithubConnectorCreatedEvent)
 	s.mockEmitter.Reset()
 
 	// test github delete event
 	err = s.a.deleteGithubConnector(ctx, "test")
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.GithubConnectorDeletedEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.GithubConnectorDeletedEvent)
 }
 
-func (s *AuthSuite) TestOIDCConnectorCRUDEventsEmitted(c *C) {
+func TestOIDCConnectorCRUDEventsEmitted(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	ctx := context.Background()
 	// test oidc create event
 	oidc, err := types.NewOIDCConnector("test", types.OIDCConnectorSpecV3{ClientID: "a"})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	err = s.a.UpsertOIDCConnector(ctx, oidc)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.OIDCConnectorCreatedEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.OIDCConnectorCreatedEvent)
 	s.mockEmitter.Reset()
 
 	// test oidc update event
 	err = s.a.UpsertOIDCConnector(ctx, oidc)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.OIDCConnectorCreatedEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.OIDCConnectorCreatedEvent)
 	s.mockEmitter.Reset()
 
 	// test oidc delete event
 	err = s.a.DeleteOIDCConnector(ctx, "test")
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.OIDCConnectorDeletedEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.OIDCConnectorDeletedEvent)
 }
 
-func (s *AuthSuite) TestSAMLConnectorCRUDEventsEmitted(c *C) {
+func TestSAMLConnectorCRUDEventsEmitted(t *testing.T) {
+	t.Parallel()
+	s := newAuthSuite(t)
+
 	ctx := context.Background()
 	// generate a certificate that makes ParseCertificatePEM happy, copied from ca_test.go
 	ca, err := tlsca.FromKeys([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, constants.RSAKeySize)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	testClock := clockwork.NewFakeClock()
 	certBytes, err := ca.GenerateCertificate(tlsca.CertificateRequest{
@@ -953,7 +981,7 @@ func (s *AuthSuite) TestSAMLConnectorCRUDEventsEmitted(c *C) {
 		Subject:   pkix.Name{CommonName: "test"},
 		NotAfter:  testClock.Now().Add(time.Hour),
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// test saml create
 	saml, err := types.NewSAMLConnector("test", types.SAMLConnectorSpecV2{
@@ -962,23 +990,23 @@ func (s *AuthSuite) TestSAMLConnectorCRUDEventsEmitted(c *C) {
 		SSO:                      "c",
 		Cert:                     string(certBytes),
 	})
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	err = s.a.UpsertSAMLConnector(ctx, saml)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.SAMLConnectorCreatedEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.SAMLConnectorCreatedEvent)
 	s.mockEmitter.Reset()
 
 	// test saml update event
 	err = s.a.UpsertSAMLConnector(ctx, saml)
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.SAMLConnectorCreatedEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.SAMLConnectorCreatedEvent)
 	s.mockEmitter.Reset()
 
 	// test saml delete event
 	err = s.a.DeleteSAMLConnector(ctx, "test")
-	c.Assert(err, IsNil)
-	c.Assert(s.mockEmitter.LastEvent().GetType(), DeepEquals, events.SAMLConnectorDeletedEvent)
+	require.NoError(t, err)
+	require.Equal(t, s.mockEmitter.LastEvent().GetType(), events.SAMLConnectorDeletedEvent)
 }
 
 func TestU2FSignChallengeCompat(t *testing.T) {
@@ -988,6 +1016,7 @@ func TestU2FSignChallengeCompat(t *testing.T) {
 	// New format is U2FAuthenticateChallenge as JSON.
 	// Old format was u2f.AuthenticateChallenge as JSON.
 	t.Run("old client, new server", func(t *testing.T) {
+		t.Parallel()
 		newChallenge := &MFAAuthenticateChallenge{
 			AuthenticateChallenge: &u2f.AuthenticateChallenge{
 				Challenge: "c1",
@@ -1008,6 +1037,7 @@ func TestU2FSignChallengeCompat(t *testing.T) {
 		require.Empty(t, cmp.Diff(oldChallenge, *newChallenge.AuthenticateChallenge))
 	})
 	t.Run("new client, old server", func(t *testing.T) {
+		t.Parallel()
 		oldChallenge := &u2f.AuthenticateChallenge{
 			Challenge: "c1",
 		}

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -19,6 +19,7 @@ package auth
 import (
 	"context"
 	"net/url"
+	"testing"
 	"time"
 
 	"github.com/gravitational/teleport/api/types"
@@ -32,6 +33,8 @@ import (
 	"github.com/jonboulle/clockwork"
 	"gopkg.in/check.v1"
 )
+
+func TestAPI(t *testing.T) { check.TestingT(t) }
 
 type GithubSuite struct {
 	a           *Server

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/jwt"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/session"
@@ -3161,6 +3162,10 @@ func (s *TLSSuite) TestEventsPermissions(c *check.C) {
 	}
 }
 
+func (*testModules) BuildType() string {
+	return modules.BuildOSS
+}
+
 // TestEvents tests events suite
 func (s *TLSSuite) TestEvents(c *check.C) {
 	clt, err := s.server.NewClient(TestAdmin())
@@ -3176,6 +3181,7 @@ func (s *TLSSuite) TestEvents(c *check.C) {
 		UsersS:        clt,
 	}
 	suite.Events(c)
+	modules.SetModules(&testModules{})
 }
 
 // TestEventsClusterConfig test cluster configuration


### PR DESCRIPTION
Testing for flakiness mentioned in issue 9492. I havent been able to reproduce flakiness while testing each test with `-count=100` though. .Parallel-ing the tests does give a nice speed boost at least.