### PR TITLE
Fix service spec indent error

### DIFF
--- a/examples/chart/teleport-cluster/templates/service.yaml
+++ b/examples/chart/teleport-cluster/templates/service.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   type: {{ default "LoadBalancer" .Values.service.type }}
   {{- with .Values.service.spec }}
-  {{- toYaml . | nindent 4 }}
+  {{- toYaml . | nindent 2 }}
   {{- end }}
   ports:
   - name: https


### PR DESCRIPTION
Fix Helm chart YAML error found in original PR https://github.com/gravitational/teleport/pull/8774/files#r783545055

The `nindent` should be 2 instead of 4 here as it produces invalid yaml that looks like below
```
# Source: teleport-cluster/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: teleport
  namespace: cert-manager
  labels:
    app: teleport
spec:
  type: LoadBalancer
    loadBalancerIP: 1.1.1.1
...
```

and produces the following error with `helm template teleport teleport/teleport-cluster --values=values.yaml`
```
Error: YAML parse error on teleport-cluster/templates/service.yaml: error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
```

for the following `values.yaml`
```
clusterName: teleport.example.com
service:
  spec:
    loadBalancerIP: 1.1.1.1
```