### PR TITLE
Don't shell out to `go list` when not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -440,7 +440,6 @@ docs-test-whitespace:
 	fi
 
 
-ifeq (${DISABLE_TEST_TARGETS},)
 
 
 #
@@ -463,8 +462,8 @@ test: test-sh test-api test-go
 .PHONY: test-go
 test-go: ensure-webassets bpf-bytecode roletester rdpclient $(RENDER_TESTS)
 test-go: FLAGS ?= '-race'
-test-go: PACKAGES := $(shell go list ./... | grep -v integration)
-test-go: CHAOS_FOLDERS := $(shell find . -type f -name '*chaos*.go' | xargs dirname | uniq)
+test-go: PACKAGES = $(shell go list ./... | grep -v integration)
+test-go: CHAOS_FOLDERS = $(shell find . -type f -name '*chaos*.go' | xargs dirname | uniq)
 test-go: $(VERSRC)
 	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(ROLETESTER_TAG) $(RDPCLIENT_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS) \
 		| ${RENDER_TESTS}
@@ -478,7 +477,7 @@ UNIT_ROOT_REGEX := ^TestRoot
 .PHONY: test-go-root
 test-go-root: ensure-webassets bpf-bytecode roletester rdpclient
 test-go-root: FLAGS ?= '-race'
-test-go-root: PACKAGES := $(shell go list $(ADDFLAGS) ./... | grep -v integration)
+test-go-root: PACKAGES = $(shell go list $(ADDFLAGS) ./... | grep -v integration)
 test-go-root: $(VERSRC)
 	$(CGOFLAG) go test -run "$(UNIT_ROOT_REGEX)" -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(ROLETESTER_TAG) $(RDPCLIENT_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
 
@@ -487,7 +486,7 @@ test-go-root: $(VERSRC)
 .PHONY: test-api
 test-api:
 test-api: FLAGS ?= '-race'
-test-api: PACKAGES := $(shell cd api && go list ./...)
+test-api: PACKAGES = $(shell cd api && go list ./...)
 test-api: $(VERSRC)
 	$(CGOFLAG) go test -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(ROLETESTER_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS)
 
@@ -511,7 +510,7 @@ run-etcd:
 #
 .PHONY: integration
 integration: FLAGS ?= -v -race
-integration: PACKAGES := $(shell go list ./... | grep integration)
+integration: PACKAGES = $(shell go list ./... | grep integration)
 integration: $(RENDER_TESTS)
 	@echo KUBECONFIG is: $(KUBECONFIG), TEST_KUBE: $(TEST_KUBE)
 	$(CGOFLAG) go test -timeout 30m -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(ROLETESTER_TAG) $(RDPCLIENT_TAG)" $(PACKAGES) $(FLAGS) \
@@ -524,11 +523,10 @@ integration: $(RENDER_TESTS)
 INTEGRATION_ROOT_REGEX := ^TestRoot
 .PHONY: integration-root
 integration-root: FLAGS ?= -v -race
-integration-root: PACKAGES := $(shell go list ./... | grep integration)
+integration-root: PACKAGES = $(shell go list ./... | grep integration)
 integration-root: $(RENDER_TESTS)
 	$(CGOFLAG) go test -json -run "$(INTEGRATION_ROOT_REGEX)" $(PACKAGES) $(FLAGS) \
 		| $(RENDER_TESTS) -report-by test
-endif
 
 #
 # Lint the source code.

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -238,7 +238,7 @@ buildbox-arm-fips: buildbox-fips
 grpc: devbox
 	docker run \
 		$(DOCKERFLAGS) -e CLANG_FORMAT=/usr/bin/clang-format-10 -t $(DEVBOX) \
-		make -C /go/src/github.com/gravitational/teleport DISABLE_TEST_TARGETS=1 devbox-grpc
+		make -C /go/src/github.com/gravitational/teleport devbox-grpc
 
 #
 # Removes the docker image


### PR DESCRIPTION
This replaces all the `:=` assignments to target-local variables that are only used once with `=` assignments; as the `=` assignments are not expanded until needed, this prevents useless calls to `go list` or `find` that happen just as part of the makefile parsing.

The time for a `make full-ent` with a hot cache goes from 39.5 seconds to 3.6 seconds on my laptop; likewise, the time for `make print-version` goes from 2.8 seconds to 0.2 seconds on this machine (16" 2021 M1 Max MacBook Pro running macOS 12.1, go 1.17.6, rust 1.57.0).

This reverts the change in #9432 that selectively disabled the test targets when running the makefile as part of `make grpc` - the only reason that change was made was for performance, which this PR improves.