### PR TITLE
Fix kubernetes_service nil ptr dereference

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -174,6 +174,13 @@ func extractKubeCreds(ctx context.Context, cluster string, clientCfg *rest.Confi
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to generate TLS config from kubeconfig: %v", err)
 	}
+	if tlsConfig == nil {
+		cc := rest.AnonymousClientConfig(clientCfg)
+		if len(cc.CAData) != 0 {
+			cc.CAData = []byte("REDACTED")
+		}
+		return nil, trace.BadParameter("failed to generate TLS config from kubeConfig. clientConfig: %s", cc.String())
+	}
 	transportConfig, err := clientCfg.TransportConfig()
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to generate transport config from kubeconfig: %v", err)

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -17,9 +17,16 @@ limitations under the License.
 package proxy
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
+	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -128,12 +135,49 @@ func failsForCluster(clusterName string) ImpersonationPermissionsChecker {
 func TestGetKubeCreds(t *testing.T) {
 	ctx := context.TODO()
 	const teleClusterName = "teleport-cluster"
+	testDir := t.TempDir()
 
-	tmpFile, err := os.CreateTemp("", "teleport")
+	cert, err := utils.GenerateSelfSignedCert([]string{"localhost"})
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-	kubeconfigPath := tmpFile.Name()
-	_, err = tmpFile.Write([]byte(`
+
+	certFilePath := filepath.Join(testDir, "certfile")
+	require.NoError(t, os.WriteFile(certFilePath, cert.Cert, fs.ModePerm))
+	keyFilePath := filepath.Join(testDir, "keyfile")
+	require.NoError(t, os.WriteFile(keyFilePath, cert.PrivateKey, fs.ModePerm))
+	tlsConfig, err := utils.CreateTLSConfiguration(certFilePath, keyFilePath, utils.DefaultCipherSuites())
+	require.NoError(t, err)
+
+	kubeconfigPath := filepath.Join(testDir, "kubeconf")
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(fmt.Sprintf(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://example.com:3026
+  name: example
+contexts:
+- context:
+    cluster: example
+    user: creds
+  name: foo
+- context:
+    cluster: example
+    user: creds
+  name: bar
+- context:
+    cluster: example
+    user: creds
+  name: baz
+users:
+- name: creds
+  user:
+    client-certificate: %s
+    client-key: %s
+current-context: foo
+`, certFilePath, keyFilePath)), fs.ModePerm))
+
+	kubeconfigbadPath := filepath.Join(testDir, "kubeconfbad")
+	require.NoError(t, os.WriteFile(kubeconfigbadPath, []byte(`
 apiVersion: v1
 kind: Config
 clusters:
@@ -156,9 +200,12 @@ contexts:
 users:
 - name: creds
 current-context: foo
-`))
-	require.NoError(t, err)
-	require.NoError(t, tmpFile.Close())
+`), fs.ModePerm))
+
+	logger := utils.NewLoggerForTests()
+	buf := bytes.NewBuffer([]byte{})
+	logger.SetOutput(buf)
+	sc := bufio.NewScanner(buf)
 
 	tests := []struct {
 		desc               string
@@ -193,16 +240,19 @@ current-context: foo
 			impersonationCheck: alwaysSucceeds,
 			want: map[string]*kubeCreds{
 				"foo": {
+					tlsConfig:       tlsConfig,
 					targetAddr:      "example.com:3026",
 					transportConfig: &transport.Config{},
 					kubeClient:      &kubernetes.Clientset{},
 				},
 				"bar": {
+					tlsConfig:       tlsConfig,
 					targetAddr:      "example.com:3026",
 					transportConfig: &transport.Config{},
 					kubeClient:      &kubernetes.Clientset{},
 				},
 				"baz": {
+					tlsConfig:       tlsConfig,
 					targetAddr:      "example.com:3026",
 					transportConfig: &transport.Config{},
 					kubeClient:      &kubernetes.Clientset{},
@@ -223,6 +273,7 @@ current-context: foo
 			impersonationCheck: alwaysSucceeds,
 			want: map[string]*kubeCreds{
 				teleClusterName: {
+					tlsConfig:       tlsConfig,
 					targetAddr:      "example.com:3026",
 					transportConfig: &transport.Config{},
 					kubeClient:      &kubernetes.Clientset{},
@@ -236,27 +287,45 @@ current-context: foo
 			impersonationCheck: failsForCluster("bar"),
 			want: map[string]*kubeCreds{
 				"foo": {
+					tlsConfig:       tlsConfig,
 					targetAddr:      "example.com:3026",
 					transportConfig: &transport.Config{},
 					kubeClient:      &kubernetes.Clientset{},
 				},
 				"bar": {
+					tlsConfig:       tlsConfig,
 					targetAddr:      "example.com:3026",
 					transportConfig: &transport.Config{},
 					kubeClient:      &kubernetes.Clientset{},
 				},
 				"baz": {
+					tlsConfig:       tlsConfig,
 					targetAddr:      "example.com:3026",
 					transportConfig: &transport.Config{},
 					kubeClient:      &kubernetes.Clientset{},
 				},
 			},
 			assertErr: require.NoError,
+		}, {
+			desc:               "kubernetes_service, bad kube creds",
+			serviceType:        KubeService,
+			kubeconfigPath:     kubeconfigbadPath,
+			impersonationCheck: alwaysSucceeds,
+			assertErr: func(tt require.TestingT, err error, i ...interface{}) {
+				findErr := "failed to generate TLS config from kubeConfig. clientConfig"
+				for sc.Scan() {
+					if strings.Contains(sc.Text(), findErr) {
+						return
+					}
+				}
+				t.Fatalf("Failed to find error %q in the logs", findErr)
+			},
+			want: map[string]*kubeCreds{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			got, err := getKubeCreds(ctx, utils.NewLoggerForTests(), teleClusterName, "", tt.kubeconfigPath, tt.serviceType, tt.impersonationCheck)
+			got, err := getKubeCreds(ctx, logger, teleClusterName, "", tt.kubeconfigPath, tt.serviceType, tt.impersonationCheck)
 			tt.assertErr(t, err)
 			if err != nil {
 				return
@@ -265,6 +334,7 @@ current-context: foo
 				cmp.AllowUnexported(kubeCreds{}),
 				cmp.Comparer(func(a, b *transport.Config) bool { return (a == nil) == (b == nil) }),
 				cmp.Comparer(func(a, b *kubernetes.Clientset) bool { return (a == nil) == (b == nil) }),
+				cmp.Comparer(func(a, b *tls.Config) bool { return (a == nil) == (b == nil) }),
 			))
 		})
 	}


### PR DESCRIPTION
Based off of the stack trace in #9721 (havent successfuly reproduced the issue), it appears that the nil ptr dereference happens when `creds.tlsConfig` is nil. 

#9721