### PR TITLE
(v8) Retry app access requests in different servers when there is a connection failure

### DIFF
--- a/integration/app_integration_test.go
+++ b/integration/app_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -634,6 +633,92 @@ func TestAppAuditEvents(t *testing.T) {
 	})
 }
 
+func TestAppServersHA(t *testing.T) {
+	testCases := map[string]struct {
+		publicAddr  func(pack *pack) string
+		makeRequest func(pack *pack, inCookie string) (status int, err error)
+	}{
+		"HTTPApp": {
+			publicAddr: func(pack *pack) string { return pack.rootAppPublicAddr },
+			makeRequest: func(pack *pack, inCookie string) (int, error) {
+				status, _, err := pack.makeRequest(inCookie, http.MethodGet, "/")
+				return status, err
+			},
+		},
+		"WebSocketApp": {
+			publicAddr: func(pack *pack) string { return pack.rootWSPublicAddr },
+			makeRequest: func(pack *pack, inCookie string) (int, error) {
+				_, err := pack.makeWebsocketRequest(inCookie, "/")
+				return 0, err
+			},
+		},
+	}
+
+	// asserts that the response has error.
+	responseWithError := func(t *testing.T, status int, err error) {
+		if status > 0 {
+			require.NoError(t, err)
+			require.Equal(t, http.StatusInternalServerError, status)
+			return
+		}
+
+		require.Error(t, err)
+	}
+	// asserts that the response has no errors.
+	responseWithoutError := func(t *testing.T, status int, err error) {
+		if status > 0 {
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, status)
+			return
+		}
+
+		require.NoError(t, err)
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			pack := setupWithOptions(t, appTestOptions{rootAppServersCount: 3})
+			inCookie := pack.createAppSession(t, test.publicAddr(pack), pack.rootAppClusterName)
+
+			status, err := test.makeRequest(pack, inCookie)
+			responseWithoutError(t, status, err)
+
+			// Stop all root app servers.
+			for i, appServer := range pack.rootAppServers {
+				appServer.Close()
+
+				// issue a request right after a server is gone.
+				status, err = test.makeRequest(pack, inCookie)
+				if i == len(pack.rootAppServers)-1 {
+					// fails only when the last one is closed.
+					responseWithError(t, status, err)
+				} else {
+					// otherwise the request should be handled by another
+					// server.
+					responseWithoutError(t, status, err)
+				}
+			}
+
+			servers := pack.startRootAppServers(t, 3, []service.App{})
+			status, err = test.makeRequest(pack, inCookie)
+			responseWithoutError(t, status, err)
+
+			// Start an additional app server and stop all current running
+			// ones.
+			pack.startRootAppServers(t, 1, []service.App{})
+			for _, appServer := range servers {
+				appServer.Close()
+
+				// Everytime a app server stops we issue a request to
+				// guarantee that the requests are going to be resolved by
+				// the remaining app servers.
+				status, err = test.makeRequest(pack, inCookie)
+				responseWithoutError(t, status, err)
+			}
+		})
+	}
+}
+
 // pack contains identity as well as initialized Teleport clusters and instances.
 type pack struct {
 	username string
@@ -646,9 +731,9 @@ type pack struct {
 	webCookie string
 	webToken  string
 
-	rootCluster   *TeleInstance
-	rootAppServer *service.TeleportProcess
-	rootCertPool  *x509.CertPool
+	rootCluster    *TeleInstance
+	rootAppServers []*service.TeleportProcess
+	rootCertPool   *x509.CertPool
 
 	rootAppName        string
 	rootAppPublicAddr  string
@@ -702,12 +787,13 @@ type pack struct {
 }
 
 type appTestOptions struct {
-	extraRootApps    []service.App
-	extraLeafApps    []service.App
-	userLogins       []string
-	userTraits       map[string][]string
-	rootClusterPorts *InstancePorts
-	leafClusterPorts *InstancePorts
+	extraRootApps       []service.App
+	extraLeafApps       []service.App
+	userLogins          []string
+	userTraits          map[string][]string
+	rootClusterPorts    *InstancePorts
+	leafClusterPorts    *InstancePorts
+	rootAppServersCount int
 
 	rootConfig func(config *service.Config)
 	leafConfig func(config *service.Config)
@@ -872,8 +958,7 @@ func setupWithOptions(t *testing.T, opts appTestOptions) *pack {
 	rcConf := service.MakeDefaultConfig()
 	rcConf.Console = nil
 	rcConf.Log = log
-	rcConf.DataDir, err = ioutil.TempDir("", "cluster-"+p.rootCluster.Secrets.SiteName)
-	require.NoError(t, err)
+	rcConf.DataDir = t.TempDir()
 	t.Cleanup(func() { os.RemoveAll(rcConf.DataDir) })
 	rcConf.Auth.Enabled = true
 	rcConf.Auth.Preference.SetSecondFactor("off")
@@ -889,8 +974,7 @@ func setupWithOptions(t *testing.T, opts appTestOptions) *pack {
 	lcConf := service.MakeDefaultConfig()
 	lcConf.Console = nil
 	lcConf.Log = log
-	lcConf.DataDir, err = ioutil.TempDir("", "cluster-"+p.leafCluster.Secrets.SiteName)
-	require.NoError(t, err)
+	lcConf.DataDir = t.TempDir()
 	t.Cleanup(func() { os.RemoveAll(lcConf.DataDir) })
 	lcConf.Auth.Enabled = true
 	lcConf.Auth.Preference.SetSecondFactor("off")
@@ -919,64 +1003,17 @@ func setupWithOptions(t *testing.T, opts appTestOptions) *pack {
 		p.rootCluster.StopAll()
 	})
 
-	raConf := service.MakeDefaultConfig()
-	raConf.Console = nil
-	raConf.Log = log
-	raConf.DataDir, err = ioutil.TempDir("", "app-server-"+p.rootCluster.Secrets.SiteName)
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(raConf.DataDir) })
-	raConf.Token = "static-token-value"
-	raConf.AuthServers = []utils.NetAddr{
-		{
-			AddrNetwork: "tcp",
-			Addr:        net.JoinHostPort(Loopback, p.rootCluster.GetPortWeb()),
-		},
+	// At least one rootAppServer should start during the setup
+	rootAppServersCount := 1
+	if opts.rootAppServersCount > 0 {
+		rootAppServersCount = opts.rootAppServersCount
 	}
-	raConf.Auth.Enabled = false
-	raConf.Proxy.Enabled = false
-	raConf.SSH.Enabled = false
-	raConf.Apps.Enabled = true
-	raConf.Apps.Apps = append([]service.App{
-		{
-			Name:       p.rootAppName,
-			URI:        rootServer.URL,
-			PublicAddr: p.rootAppPublicAddr,
-		},
-		{
-			Name:       p.rootWSAppName,
-			URI:        rootWSServer.URL,
-			PublicAddr: p.rootWSPublicAddr,
-		},
-		{
-			Name:       p.rootWSSAppName,
-			URI:        rootWSSServer.URL,
-			PublicAddr: p.rootWSSPublicAddr,
-		},
-		{
-			Name:       p.jwtAppName,
-			URI:        jwtServer.URL,
-			PublicAddr: p.jwtAppPublicAddr,
-		},
-		{
-			Name:       p.headerAppName,
-			URI:        headerServer.URL,
-			PublicAddr: p.headerAppPublicAddr,
-		},
-		{
-			Name:       p.flushAppName,
-			URI:        flushServer.URL,
-			PublicAddr: p.flushAppPublicAddr,
-		},
-	}, opts.extraRootApps...)
-	p.rootAppServer, err = p.rootCluster.StartApp(raConf)
-	require.NoError(t, err)
-	t.Cleanup(func() { p.rootAppServer.Close() })
+	p.rootAppServers = p.startRootAppServers(t, rootAppServersCount, opts.extraRootApps)
 
 	laConf := service.MakeDefaultConfig()
 	laConf.Console = nil
 	laConf.Log = log
-	laConf.DataDir, err = ioutil.TempDir("", "app-server-"+p.leafCluster.Secrets.SiteName)
-	require.NoError(t, err)
+	laConf.DataDir = t.TempDir()
 	t.Cleanup(func() { os.RemoveAll(laConf.DataDir) })
 	laConf.Token = "static-token-value"
 	laConf.AuthServers = []utils.NetAddr{
@@ -1324,7 +1361,7 @@ func (p *pack) makeWebsocketRequest(sessionCookie, endpoint string) (string, err
 		return "", trace.Wrap(err)
 	}
 	defer conn.Close()
-	data, err := ioutil.ReadAll(conn)
+	data, err := io.ReadAll(conn)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -1365,7 +1402,7 @@ func (p *pack) sendRequest(req *http.Request, tlsConfig *tls.Config) (int, strin
 	defer resp.Body.Close()
 
 	// Read in response body.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, "", trace.Wrap(err)
 	}
@@ -1395,6 +1432,71 @@ func (p *pack) waitForLogout(appCookie string) (int, error) {
 			return 0, trace.BadParameter("timed out waiting for logout")
 		}
 	}
+}
+
+func (p *pack) startRootAppServers(t *testing.T, count int, extraApps []service.App) []*service.TeleportProcess {
+	log := utils.NewLoggerForTests()
+
+	servers := make([]*service.TeleportProcess, count)
+
+	for i := 0; i < count; i++ {
+		raConf := service.MakeDefaultConfig()
+		raConf.Console = nil
+		raConf.Log = log
+		raConf.DataDir = t.TempDir()
+		t.Cleanup(func() { os.RemoveAll(raConf.DataDir) })
+		raConf.Token = "static-token-value"
+		raConf.AuthServers = []utils.NetAddr{
+			{
+				AddrNetwork: "tcp",
+				Addr:        net.JoinHostPort(Loopback, p.rootCluster.GetPortWeb()),
+			},
+		}
+		raConf.Auth.Enabled = false
+		raConf.Proxy.Enabled = false
+		raConf.SSH.Enabled = false
+		raConf.Apps.Enabled = true
+		raConf.Apps.Apps = append([]service.App{
+			{
+				Name:       p.rootAppName,
+				URI:        p.rootAppURI,
+				PublicAddr: p.rootAppPublicAddr,
+			},
+			{
+				Name:       p.rootWSAppName,
+				URI:        p.rootWSAppURI,
+				PublicAddr: p.rootWSPublicAddr,
+			},
+			{
+				Name:       p.rootWSSAppName,
+				URI:        p.rootWSSAppURI,
+				PublicAddr: p.rootWSSPublicAddr,
+			},
+			{
+				Name:       p.jwtAppName,
+				URI:        p.jwtAppURI,
+				PublicAddr: p.jwtAppPublicAddr,
+			},
+			{
+				Name:       p.headerAppName,
+				URI:        p.headerAppURI,
+				PublicAddr: p.headerAppPublicAddr,
+			},
+			{
+				Name:       p.flushAppName,
+				URI:        p.flushAppURI,
+				PublicAddr: p.flushAppPublicAddr,
+			},
+		}, extraApps...)
+
+		appServer, err := p.rootCluster.StartApp(raConf)
+		require.NoError(t, err)
+		t.Cleanup(func() { appServer.Close() })
+
+		servers[i] = appServer
+	}
+
+	return servers
 }
 
 var forwardedHeaderNames = []string{

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchAll(t *testing.T) {
+	falseMatcher := func(_ types.AppServer) bool { return false }
+	trueMatcher := func(_ types.AppServer) bool { return true }
+
+	require.True(t, MatchAll(trueMatcher, trueMatcher, trueMatcher)(nil))
+	require.False(t, MatchAll(trueMatcher, trueMatcher, falseMatcher)(nil))
+	require.False(t, MatchAll(falseMatcher, falseMatcher, falseMatcher)(nil))
+}
+
+func TestMatchHealthy(t *testing.T) {
+	testCases := map[string]struct {
+		dialErr error
+		match   bool
+	}{
+		"WithHealthyApp": {
+			match: true,
+		},
+		"WithUnhealthyApp": {
+			dialErr: errors.New("failed to connect"),
+			match:   false,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			identity := &tlsca.Identity{RouteToApp: tlsca.RouteToApp{ClusterName: ""}}
+			match := MatchHealthy(&mockProxyClient{
+				remoteSite: &mockRemoteSite{
+					dialErr: test.dialErr,
+				},
+			}, identity)
+
+			app, err := types.NewAppV3(
+				types.Metadata{
+					Name:      "test-app",
+					Namespace: defaults.Namespace,
+				},
+				types.AppSpecV3{
+					URI: "https://app.localhost",
+				},
+			)
+			require.NoError(t, err)
+
+			appServer, err := types.NewAppServerV3FromApp(app, "localhost", "123")
+			require.NoError(t, err)
+			require.Equal(t, test.match, match(appServer))
+		})
+	}
+}
+
+type mockProxyClient struct {
+	reversetunnel.Tunnel
+	remoteSite *mockRemoteSite
+}
+
+func (p *mockProxyClient) GetSite(_ string) (reversetunnel.RemoteSite, error) {
+	return p.remoteSite, nil
+}
+
+type mockRemoteSite struct {
+	reversetunnel.RemoteSite
+	dialErr error
+}
+
+func (r *mockRemoteSite) Dial(_ reversetunnel.DialParams) (net.Conn, error) {
+	return nil, r.dialErr
+}

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
@@ -32,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/oxy/forward"
 	"github.com/gravitational/trace"
@@ -43,13 +45,14 @@ type transportConfig struct {
 	accessPoint  auth.ReadProxyAccessPoint
 	cipherSuites []uint16
 	identity     *tlsca.Identity
-	server       types.AppServer
+	servers      []types.AppServer
 	ws           types.WebSession
 	clusterName  string
+	log          *logrus.Entry
 }
 
 // Check validates configuration.
-func (c transportConfig) Check() error {
+func (c *transportConfig) Check() error {
 	if c.proxyClient == nil {
 		return trace.BadParameter("proxy client missing")
 	}
@@ -62,8 +65,8 @@ func (c transportConfig) Check() error {
 	if c.identity == nil {
 		return trace.BadParameter("identity missing")
 	}
-	if c.server == nil {
-		return trace.BadParameter("server missing")
+	if len(c.servers) == 0 {
+		return trace.BadParameter("servers missing")
 	}
 	if c.ws == nil {
 		return trace.BadParameter("web session missing")
@@ -83,13 +86,26 @@ type transport struct {
 	// tr is used for forwarding http connections.
 	tr http.RoundTripper
 
-	// dialer is used for forwarding websocket connections.
-	dialer forward.Dialer
+	// clientTLSConfig is the TLS config used for mutual authentication.
+	clientTLSConfig *tls.Config
+
+	// servers is the list of servers that the transport can connect to
+	// organized in a map where the key is the server ID, and the value is the
+	// `types.AppServer`.
+	servers *sync.Map
 }
 
 // newTransport creates a new transport.
 func newTransport(c *transportConfig) (*transport, error) {
+	var err error
 	if err := c.Check(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	t := &transport{c: c, servers: &sync.Map{}}
+
+	t.clientTLSConfig, err = configureTLS(c)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -98,17 +114,15 @@ func newTransport(c *transportConfig) (*transport, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tr.DialContext = dialFunc(c)
-	tr.TLSClientConfig, err = configureTLS(c)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	tr.DialContext = t.DialContext
+	tr.TLSClientConfig = t.clientTLSConfig
+
+	for _, server := range t.c.servers {
+		t.servers.Store(server.GetResourceID(), server)
 	}
 
-	return &transport{
-		c:      c,
-		tr:     tr,
-		dialer: websocketsDialer(tr),
-	}, nil
+	t.tr = tr
+	return t, nil
 }
 
 // RoundTrip will rewrite the request, forward the request to the target
@@ -159,39 +173,79 @@ func (t *transport) rewriteRequest(r *http.Request) error {
 	return nil
 }
 
-// websocketsDialer returns a function that dials a websocket connection
-// over the transport's reverse tunnel.
-func websocketsDialer(tr *http.Transport) forward.Dialer {
-	return func(network, address string) (net.Conn, error) {
-		conn, err := tr.DialContext(context.Background(), network, address)
-		if err != nil {
-			return nil, trace.Wrap(err)
+// DialContext dials and connect to the application service over the reverse
+// tunnel subsystem.
+func (t *transport) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	var err error
+	var conn net.Conn
+
+	t.servers.Range(func(serverID, appServerInterface interface{}) bool {
+		appServer, ok := appServerInterface.(types.AppServer)
+		if !ok {
+			t.c.log.Warnf("Failed to load AppServer, invalid type %T", appServerInterface)
+			return true
 		}
-		// App access connections over reverse tunnel use mutual TLS.
-		return tls.Client(conn, tr.TLSClientConfig), nil
+
+		var dialErr error
+		conn, dialErr = dialAppServer(t.c.proxyClient, t.c.identity, appServer)
+		if dialErr != nil {
+			// Connection problem with the server.
+			if trace.IsConnectionProblem(dialErr) {
+				t.c.log.Warnf("Failed to connect to application server %q: %v.", serverID, dialErr)
+				t.servers.Delete(serverID)
+				// Only goes for the next server if the error returned is a
+				// connection problem. Otherwise, stop iterating over the
+				// servers and return the error.
+				return true
+			}
+		}
+
+		// "save" dial error to return as the function error.
+		err = dialErr
+		return false
+	})
+
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-}
 
-// dialFunc returns a function that can Dial and connect to the application
-// service over the reverse tunnel subsystem.
-func dialFunc(c *transportConfig) func(ctx context.Context, network string, addr string) (net.Conn, error) {
-	return func(ctx context.Context, network string, addr string) (net.Conn, error) {
-		clusterClient, err := c.proxyClient.GetSite(c.identity.RouteToApp.ClusterName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		conn, err := clusterClient.Dial(reversetunnel.DialParams{
-			From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: "@web-proxy"},
-			To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalNode},
-			ServerID: fmt.Sprintf("%v.%v", c.server.GetHostID(), c.identity.RouteToApp.ClusterName),
-			ConnType: types.AppTunnel,
-		})
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
+	if conn != nil {
 		return conn, nil
 	}
+
+	return nil, trace.ConnectionProblem(nil, "no application servers remaining to connect")
+}
+
+// DialWebsocket dials a websocket connection over the transport's reverse
+// tunnel.
+func (t *transport) DialWebsocket(network, address string) (net.Conn, error) {
+	conn, err := t.DialContext(context.Background(), network, address)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// App access connections over reverse tunnel use mutual TLS.
+	return tls.Client(conn, t.clientTLSConfig), nil
+}
+
+// dialAppServer dial and connect to the application service over the reverse
+// tunnel subsystem.
+func dialAppServer(proxyClient reversetunnel.Tunnel, identity *tlsca.Identity, server types.AppServer) (net.Conn, error) {
+	clusterClient, err := proxyClient.GetSite(identity.RouteToApp.ClusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	conn, err := clusterClient.Dial(reversetunnel.DialParams{
+		From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: "@web-proxy"},
+		To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalNode},
+		ServerID: fmt.Sprintf("%v.%v", server.GetHostID(), identity.RouteToApp.ClusterName),
+		ConnType: types.AppTunnel,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return conn, nil
 }
 
 // configureTLS creates and configures a *tls.Config that will be used for

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -306,12 +306,16 @@ func (h *Handler) resolveDirect(ctx context.Context, proxy reversetunnel.Tunnel,
 		return nil, "", trace.Wrap(err)
 	}
 
-	server, err := app.Match(ctx, authClient, app.MatchPublicAddr(publicAddr))
+	servers, err := app.Match(ctx, authClient, app.MatchPublicAddr(publicAddr))
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	return server, clusterName, nil
+	if len(servers) == 0 {
+		return nil, "", trace.NotFound("failed to match applications with public addr %s", publicAddr)
+	}
+
+	return servers[0], clusterName, nil
 }
 
 // resolveFQDN makes a best effort attempt to resolve FQDN to an application


### PR DESCRIPTION
Backport of #9288 to `branch/v8`. Same "manual" tests were performed in this branch.