### PR TITLE
Client Certificate Auth for GCP Cloud SQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,6 +216,6 @@ replace (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-0.20201123192827-2b9fcfaffcbf
 	github.com/gravitational/teleport/api => ./api
-	github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77
+	github.com/siddontang/go-mysql v1.1.0 => github.com/gravitational/go-mysql v1.1.1-0.20220124193150-55e6dc186430
 	github.com/sirupsen/logrus => github.com/gravitational/logrus v1.4.4-0.20210817004754-047e20245621
 )

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23 h1:havbccu
 github.com/gravitational/configure v0.0.0-20180808141939-c3428bd84c23/go.mod h1:XL9nebvlfNVvRzRPWdDcWootcyA0l7THiH/A+W1233g=
 github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70 h1:To76nCJtM3DI0mdq3nGLzXqTV1wNOJByxv01+u9/BxM=
 github.com/gravitational/form v0.0.0-20151109031454-c4048f792f70/go.mod h1:88hFR45MpUd23d2vNWE/dYtesU50jKsbz0I9kH7UaBY=
-github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77 h1:ivambM2XeST8qfxeSm+0Y8CP/DlNbS3o/9tSF2KtGFk=
-github.com/gravitational/go-mysql v1.1.1-0.20210212011549-886316308a77/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
+github.com/gravitational/go-mysql v1.1.1-0.20220124193150-55e6dc186430 h1:nVKk0tM/UWZSGql70abqAikOvpHBnrCzUfbNPGsViTA=
+github.com/gravitational/go-mysql v1.1.1-0.20220124193150-55e6dc186430/go.mod h1:re0JQZ1Cy5dVlIDGq0YksfDIla/GRZlxqOoC0XPSSGE=
 github.com/gravitational/go-oidc v0.0.5 h1:kxsCknoOZ+KqIAoYLLdHuQcvcc+SrQlnT7xxIM8oo6o=
 github.com/gravitational/go-oidc v0.0.5/go.mod h1:SevmOUNdOB0aD9BAIgjptZ6oHkKxMZZgA70nwPfgU/w=
 github.com/gravitational/kingpin v2.1.11-0.20190130013101-742f2714c145+incompatible h1:CfyZl3nyo9K5lLqOmqvl9/IElY1UCnOWKZiQxJ8HKdA=

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -1023,17 +1023,7 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t *testing.T, p a
 	testAuth, err := newTestAuth(common.AuthConfig{
 		AuthClient: c.authClient,
 		Clock:      c.clock,
-		Clients: &common.TestCloudClients{
-			GCPSQL: &cloud.GCPSQLAdminClientMock{
-				DatabaseInstance: &sqladmin.DatabaseInstance{
-					Settings: &sqladmin.Settings{
-						IpConfiguration: &sqladmin.IpConfiguration{
-							RequireSsl: false,
-						},
-					},
-				},
-			},
-		},
+		Clients:    &common.TestCloudClients{},
 	})
 	require.NoError(t, err)
 
@@ -1077,6 +1067,15 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t *testing.T, p a
 			RDS:      &cloud.RDSMock{},
 			Redshift: &cloud.RedshiftMock{},
 			IAM:      &cloud.IAMMock{},
+			GCPSQL: &cloud.GCPSQLAdminClientMock{
+				DatabaseInstance: &sqladmin.DatabaseInstance{
+					Settings: &sqladmin.Settings{
+						IpConfiguration: &sqladmin.IpConfiguration{
+							RequireSsl: false,
+						},
+					},
+				},
+			},
 		},
 	})
 	require.NoError(t, err)

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -56,6 +56,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 func TestMain(m *testing.M) {
@@ -1021,8 +1022,18 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t *testing.T, p a
 	// Create test database auth tokens generator.
 	testAuth, err := newTestAuth(common.AuthConfig{
 		AuthClient: c.authClient,
-		Clients:    &common.TestCloudClients{},
 		Clock:      c.clock,
+		Clients: &common.TestCloudClients{
+			GCPSQL: &cloud.GCPSQLAdminClientMock{
+				DatabaseInstance: &sqladmin.DatabaseInstance{
+					Settings: &sqladmin.Settings{
+						IpConfiguration: &sqladmin.IpConfiguration{
+							RequireSsl: false,
+						},
+					},
+				},
+			},
+		},
 	})
 	require.NoError(t, err)
 

--- a/lib/srv/db/cloud/mocks.go
+++ b/lib/srv/db/cloud/mocks.go
@@ -17,6 +17,9 @@ limitations under the License.
 package cloud
 
 import (
+	"context"
+	"crypto/tls"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -27,7 +30,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/redshift/redshiftiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/trace"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 // STSMock mocks AWS STS API.
@@ -306,4 +311,25 @@ func (m *IAMMockUnauth) GetUserPolicyWithContext(ctx aws.Context, input *iam.Get
 
 func (m *IAMMockUnauth) PutUserPolicyWithContext(ctx aws.Context, input *iam.PutUserPolicyInput, options ...request.Option) (*iam.PutUserPolicyOutput, error) {
 	return nil, trace.AccessDenied("unauthorized")
+}
+
+// GCPSQLAdminClientMock implements a test mock
+// for the common.GCPSQLAdminClient interface.
+type GCPSQLAdminClientMock struct {
+	// DatabaseInstance is returned from GetDatabaseInstance.
+	DatabaseInstance *sqladmin.DatabaseInstance
+	// EphemeralCert is returned from GenerateEphemeralCert.
+	EphemeralCert *tls.Certificate
+}
+
+func (g *GCPSQLAdminClientMock) UpdateUser(ctx context.Context, sessionCtx *common.Session, user *sqladmin.User) error {
+	return nil
+}
+
+func (g *GCPSQLAdminClientMock) GetDatabaseInstance(ctx context.Context, sessionCtx *common.Session) (*sqladmin.DatabaseInstance, error) {
+	return g.DatabaseInstance, nil
+}
+
+func (g *GCPSQLAdminClientMock) GenerateEphemeralCert(ctx context.Context, sessionCtx *common.Session) (*tls.Certificate, error) {
+	return g.EphemeralCert, nil
 }

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -356,11 +356,6 @@ func (a *dbAuth) getTLSConfigVerifyFull(ctx context.Context, sessionCtx *Session
 		tlsConfig.InsecureSkipVerify = true
 		// This will verify CN and cert chain on each connection.
 		tlsConfig.VerifyConnection = getVerifyCloudSQLCertificate(tlsConfig.RootCAs)
-		// Generate client SSL certificate when instance's RequireSsl is enabled.
-		tlsConfig, err = a.appendGCPSQLClientCert(ctx, sessionCtx, tlsConfig)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 	}
 
 	dbTLSConfig := sessionCtx.Database.GetTLS()
@@ -369,9 +364,8 @@ func (a *dbAuth) getTLSConfigVerifyFull(ctx context.Context, sessionCtx *Session
 		tlsConfig.ServerName = dbTLSConfig.ServerName
 	}
 
-	// RDS/Aurora/Redshift auth is done with an auth token so
+	// RDS/Aurora/Redshift and Cloud SQL auth is done with an auth token so
 	// don't generate a client certificate and exit here.
-	// GCP SQL client certificate was already generated above.
 	if sessionCtx.Database.IsCloudHosted() {
 		return tlsConfig, nil
 	}
@@ -506,34 +500,6 @@ func (a *dbAuth) GetAuthPreference(ctx context.Context) (types.AuthPreference, e
 // Close releases all resources used by authenticator.
 func (a *dbAuth) Close() error {
 	return a.cfg.Clients.Close()
-}
-
-// appendGCPSQLClientCert to tlsConfig for the project/instance
-// configured in Session. The ephemeral client certificate is created
-// by calling the GenerateEphemeralCert Cloud SQL API. The tlsConfig is
-// only modified when the instance's RequireSsl configuration is enabled.
-func (a *dbAuth) appendGCPSQLClientCert(ctx context.Context, sessionCtx *Session, tlsConfig *tls.Config) (*tls.Config, error) {
-	svc, err := a.cfg.Clients.GetGCPSQLAdminClient(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	dbi, err := svc.GetDatabaseInstance(ctx, sessionCtx)
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to get Cloud SQL instance information for %q", tlsConfig.ServerName)
-	} else if dbi.Settings == nil || dbi.Settings.IpConfiguration == nil {
-		return nil, trace.Errorf("failed to find Cloud SQL settings for %q", tlsConfig.ServerName)
-	}
-
-	if dbi.Settings.IpConfiguration.RequireSsl {
-		cert, err := svc.GenerateEphemeralCert(ctx, sessionCtx)
-		if err != nil {
-			return nil, trace.Wrap(err, "failed to generate Cloud SQL ephemeral client certificate for %q", tlsConfig.ServerName)
-		}
-		tlsConfig.Certificates = []tls.Certificate{*cert}
-	}
-
-	return tlsConfig, nil
 }
 
 // getVerifyCloudSQLCertificate returns a function that performs verification

--- a/lib/srv/db/common/gcp.go
+++ b/lib/srv/db/common/gcp.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/trace"
+
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+)
+
+// GCPSQLAdminClient defines an interface providing access to the GCP Cloud SQL API.
+type GCPSQLAdminClient interface {
+	// UpdateUser updates an existing user
+	// for the project/instance configured in sessionCtx.
+	UpdateUser(ctx context.Context, sessionCtx *Session, user *sqladmin.User) error
+	// GetDatabaseInstance returns database instance details
+	// for the project/instance configured in sessionCtx.
+	GetDatabaseInstance(ctx context.Context, sessionCtx *Session) (*sqladmin.DatabaseInstance, error)
+	// GenerateEphemeralCert returns a new client certificate with RSA key
+	// for the project/instance configured in sessionCtx.
+	GenerateEphemeralCert(ctx context.Context, sessionCtx *Session) (*tls.Certificate, error)
+}
+
+// NewGCPSQLAdminClient returns a GCPSQLAdminClient
+// interface wrapping sqladmin.Service.
+func NewGCPSQLAdminClient(ctx context.Context) (GCPSQLAdminClient, error) {
+	service, err := sqladmin.NewService(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &gcpSQLAdminClient{service: service}, nil
+}
+
+// gcpSQLAdminClient implements the GCPSQLAdminClient
+// interface by wrapping sqladmin.Service.
+type gcpSQLAdminClient struct {
+	service *sqladmin.Service
+}
+
+// UpdateUser updates an existing user in a Cloud SQL
+// for the project/instance configured in sessionCtx.
+func (g *gcpSQLAdminClient) UpdateUser(ctx context.Context, sessionCtx *Session, user *sqladmin.User) error {
+	_, err := g.service.Users.Update(
+		sessionCtx.Database.GetGCP().ProjectID,
+		sessionCtx.Database.GetGCP().InstanceID,
+		user).Name(sessionCtx.DatabaseUser).Host("%").Context(ctx).Do()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// GetDatabaseInstance returns database instance details from Cloud SQL
+// for the project/instance configured in sessionCtx.
+func (g *gcpSQLAdminClient) GetDatabaseInstance(ctx context.Context, sessionCtx *Session) (*sqladmin.DatabaseInstance, error) {
+	gcp := sessionCtx.Database.GetGCP()
+	dbi, err := g.service.Instances.Get(gcp.ProjectID, gcp.InstanceID).Context(ctx).Do()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return dbi, nil
+
+}
+
+// GenerateEphemeralCert returns a new client certificate with RSA key created
+// using the GenerateEphemeralCertRequest Cloud SQL API. Client certificates are
+// required when enabling SSL in Cloud SQL.
+func (g *gcpSQLAdminClient) GenerateEphemeralCert(ctx context.Context, sessionCtx *Session) (*tls.Certificate, error) {
+	// TODO(jimbishopp): cache database certificates to avoid expensive generate
+	// operation on each connection.
+
+	// generate RSA private key, x509 encoded public key,
+	// and append to certificate request
+	pkey, err := rsa.GenerateKey(rand.Reader, constants.RSAKeySize)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	pkix, err := x509.MarshalPKIXPublicKey(pkey.Public())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// make api call
+	gcp := sessionCtx.Database.GetGCP()
+	req := g.service.Connect.GenerateEphemeralCert(gcp.ProjectID, gcp.InstanceID, &sqladmin.GenerateEphemeralCertRequest{
+		PublicKey: string(pem.EncodeToMemory(&pem.Block{Bytes: pkix, Type: "RSA PUBLIC KEY"})),
+	})
+	resp, err := req.Context(ctx).Do()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// create tls certificate from returned ephemeral cert and private key
+	cert, err := tls.X509KeyPair([]byte(resp.EphemeralCert.Cert), tlsca.MarshalPrivateKeyPEM(pkey))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &cert, nil
+}

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -208,7 +208,7 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 		// use TLS dialer instead of mysql client when GCP requires SSL
 		if requireSSL {
 			connectOpt = func(*client.Conn) {}
-			dialer = e.gcpGCPTLSDialer(ctx, sessionCtx, tlsConfig)
+			dialer = e.newGCPTLSDialer(ctx, sessionCtx, tlsConfig)
 		}
 	case sessionCtx.Database.IsAzure():
 		password, err = e.Auth.GetAzureAccessToken(ctx, sessionCtx)
@@ -384,9 +384,9 @@ func (e *Engine) appendGCPClientCert(ctx context.Context, sessionCtx *common.Ses
 	return false, nil
 }
 
-// getGCPTLSDialer returns a TLS dialer configured to connect to the Cloud Proxy
+// newGCPTLSDialer returns a TLS dialer configured to connect to the Cloud Proxy
 // port rather than the default mysql port.
-func (e *Engine) gcpGCPTLSDialer(ctx context.Context, sessionCtx *common.Session, tlsConfig *tls.Config) client.Dialer {
+func (e *Engine) newGCPTLSDialer(ctx context.Context, sessionCtx *common.Session, tlsConfig *tls.Config) client.Dialer {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
 		// workaround issue generating ephemeral certs for secure connections
 		// by creating a TLS connection to the cloud proxy port overridding

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -205,7 +205,7 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		// use TLS dialer instead of mysql client when GCP requires SSL
+		// use TLS dialer instead of the default net dialer when GCP requires SSL
 		if requireSSL {
 			connectOpt = func(*client.Conn) {}
 			dialer = e.newGCPTLSDialer(ctx, sessionCtx, tlsConfig)

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -758,20 +758,22 @@ func (s *Server) createEngine(sessionCtx *common.Session, audit common.Audit) (c
 	switch sessionCtx.Database.GetProtocol() {
 	case defaults.ProtocolPostgres, defaults.ProtocolCockroachDB:
 		return &postgres.Engine{
-			Auth:    s.cfg.Auth,
-			Audit:   audit,
-			Context: s.closeContext,
-			Clock:   s.cfg.Clock,
-			Log:     sessionCtx.Log,
+			Auth:         s.cfg.Auth,
+			Audit:        audit,
+			Context:      s.closeContext,
+			Clock:        s.cfg.Clock,
+			CloudClients: s.cfg.CloudClients,
+			Log:          sessionCtx.Log,
 		}, nil
 	case defaults.ProtocolMySQL:
 		return &mysql.Engine{
-			Auth:       s.cfg.Auth,
-			Audit:      audit,
-			AuthClient: s.cfg.AuthClient,
-			Context:    s.closeContext,
-			Clock:      s.cfg.Clock,
-			Log:        sessionCtx.Log,
+			Auth:         s.cfg.Auth,
+			Audit:        audit,
+			AuthClient:   s.cfg.AuthClient,
+			Context:      s.closeContext,
+			Clock:        s.cfg.Clock,
+			CloudClients: s.cfg.CloudClients,
+			Log:          sessionCtx.Log,
 		}, nil
 	case defaults.ProtocolMongoDB:
 		return &mongodb.Engine{


### PR DESCRIPTION
Allow users to secure Cloud SQL instances by setting "Allow only SSL connections". To support this, generate client certificates using the GenerateEphemeralCert function in the Google API (added to the Connect service in v0.51). And workaround the issue with mysql's cloud instance not trusting the generated cert's CA by connecting to the cloud proxy port instead.

- [x] Add ConnectWithDialer to Teleport port of go-mysql v1.1.0.
- [x] Return new GCPSQLAdminClient interface from CloudClients.GetGCPSQLAdminClient.
- [x] Implement GCPSQLAdminClient interface with UpdateUser, GetDatabaseInstance, and GenerateEphemeralCert methods.
- [x] Add GCPSQLAdminClientMock to implement GCPSQLAdminClient for tests.
- [x] Append ephemeral client certificate to TLS config when RequireSsl is enabled.
- [x] Refactor mysql.Engine.connect to support new mysql Dialer.
- [x] Detect and override default mysql port with Cloud Proxy port when RequireSsl is enabled.
- [x] Test coverage for RequireSsl=false.
- [x] Test coverage for RequireSsl=true/GenerateEphemeralCert
- [ ] Add Teleport tag to mysql version
- [ ] Update Teleport Cloud SQL documentation with RequireSsl/ephemeral certificate functionality.
