### PR TITLE
helm: Support dynamic AWS database discovery in teleport-kube-agent chart

### DIFF
--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -1515,16 +1515,16 @@ You can specify multiple database filters by adding additional list elements.
   </TabItem>
   <TabItem label="--set">
   ```code
-  $ --set "databases[0].name=aurora" \
-  --set "databases[0].uri=postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432" \
-  --set "databases[0].protocol=postgres" \
-  --set "databases[0].aws.region=us-east-1" \
-  --set "databases[0].static_labels.env=staging" \
-  --set "databases[1].name=mysql" \
-  --set "databases[1].uri=mysql-instance-1.xxx.us-east-1.rds.amazonaws.com:3306" \
-  --set "databases[1].protocol=mysql" \
-  --set "databases[1].aws.region=us-east-1" \
-  --set "databases[1].static_labels.env=staging"
+  $ --set "awsDatabases[0].types[0]=rds" \
+  --set "awsDatabases[0].regions[0]=us-east-1" \
+  --set "awsDatabases[0].regions[1]=us-west-2" \
+  --set "awsDatabases[0].tags[0].environment=production" \
+  --set "awsDatabases[1].types[0]=rds" \
+  --set "awsDatabases[1].regions[0]=us-east-1" \
+  --set "awsDatabases[1].tags[0].environment=dev" \
+  --set "awsDatabases[2].types[0]=rds" \
+  --set "awsDatabases[2].regions[0]=eu-west-1" \
+  --set "awsDatabases[2].tags[0].*=*"
   ```
 
   <Admonition type="note">

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -1480,6 +1480,64 @@ You can specify multiple apps by adding additional list elements.
   You can see a list of all the supported [values which can be used in a Teleport application access configuration here](../../application-access/reference.mdx#configuration).
 </Admonition>
 
+## `awsDatabases`
+
+| Type | Default value | Required? |
+| - | - | - |
+| `list` | `[]` | When `db` chart role is used |
+
+`awsDatabases` is a YAML list object detailing the filters for the AWS databases that should be discovered and proxied by Teleport Database access.
+
+You can specify multiple database filters by adding additional list elements.
+
+<Tabs>
+  <TabItem label="values.yaml">
+  ```yaml
+  awsDatabases:
+    - types: ["rds", "aurora"]
+      regions: ["us-east-1", "us-west-2"]
+      tags:
+        "environment": "production"
+    - types: ["rds"]
+      regions: ["us-east-1"]
+      tags:
+        "environment": "dev"
+    - types: ["aurora"]
+      regions: ["eu-west-1"]
+      tags:
+        "*": "*"
+  ```
+
+  <Admonition type="note" title="YAML formatting">
+    YAML is very sensitive to correct spacing. When specifying lists in a `values.yaml` file, you might like
+    to [use a linter](https://codebeautify.org/yaml-validator) to validate your YAML list and ensure that it is correctly formatted.
+  </Admonition>
+  </TabItem>
+  <TabItem label="--set">
+  ```code
+  $ --set "databases[0].name=aurora" \
+  --set "databases[0].uri=postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432" \
+  --set "databases[0].protocol=postgres" \
+  --set "databases[0].aws.region=us-east-1" \
+  --set "databases[0].static_labels.env=staging" \
+  --set "databases[1].name=mysql" \
+  --set "databases[1].uri=mysql-instance-1.xxx.us-east-1.rds.amazonaws.com:3306" \
+  --set "databases[1].protocol=mysql" \
+  --set "databases[1].aws.region=us-east-1" \
+  --set "databases[1].static_labels.env=staging"
+  ```
+
+  <Admonition type="note">
+    Note that when using `--set` syntax, YAML list elements must be indexed starting at `0`.
+  </Admonition>
+
+  </TabItem>
+</Tabs>
+
+<Admonition type="tip" title="Supported values">
+  You can see a list of all the supported [values which can be used in a Teleport database service configuration here](../../database-access/reference/configuration.mdx).
+</Admonition>
+
 ## `databases`
 
 | Type | Default value | Required? |

--- a/docs/pages/kubernetes-access/helm/reference.mdx
+++ b/docs/pages/kubernetes-access/helm/reference.mdx
@@ -1494,7 +1494,7 @@ You can specify multiple database filters by adding additional list elements.
   <TabItem label="values.yaml">
   ```yaml
   awsDatabases:
-    - types: ["rds", "aurora"]
+    - types: ["rds"]
       regions: ["us-east-1", "us-west-2"]
       tags:
         "environment": "production"
@@ -1502,7 +1502,7 @@ You can specify multiple database filters by adding additional list elements.
       regions: ["us-east-1"]
       tags:
         "environment": "dev"
-    - types: ["aurora"]
+    - types: ["rds"]
       regions: ["eu-west-1"]
       tags:
         "*": "*"

--- a/examples/chart/teleport-kube-agent/.lint/awsDb.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/awsDb.yaml
@@ -1,0 +1,8 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: db
+awsDatabases:
+  - types: ["rds", "aurora"]
+    regions: ["us-east-1"]
+    tags:
+      "*": "*"

--- a/examples/chart/teleport-kube-agent/.lint/awsDb.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/awsDb.yaml
@@ -2,7 +2,7 @@ authToken: auth-token
 proxyAddr: proxy.example.com:3080
 roles: db
 awsDatabases:
-  - types: ["rds", "aurora"]
+  - types: ["rds"]
     regions: ["us-east-1"]
     tags:
       "*": "*"

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "8.0.0-alpha.1"
-appVersion: "8.0.0-alpha.1"
+version: "8.1.0"
+appVersion: "8.1.0"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "8.1.0"
-appVersion: "8.1.0"
+version: "8.0.0-alpha.1"
+appVersion: "8.0.0-alpha.1"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/examples/chart/teleport-kube-agent/templates/config.yaml
+++ b/examples/chart/teleport-kube-agent/templates/config.yaml
@@ -53,6 +53,23 @@ data:
     db_service:
       {{- if contains "db" (.Values.roles | toString) }}
       enabled: true
+      {{- if (or .Values.awsDatabases .Values.databases) }}
+      {{- if .Values.awsDatabases }}
+      aws:
+      {{- range $db := .Values.awsDatabases }}
+          {{- if not (hasKey $db "types") }}
+            {{- fail "'types' is required for all 'awsDatabases' in chart values when db role is enabled, see README" }}
+          {{- end }}
+          {{- if not (hasKey $db "regions") }}
+            {{- fail "'regions' is required for all 'awsDatabases' is required in chart values when db role is enabled, see README" }}
+          {{- end }}
+          {{- if not (hasKey $db "tags") }}
+            {{- fail "'tags' is required for all 'awsDatabases' in chart values when db role is enabled, see README" }}
+          {{- end }}
+      {{- end }}
+      {{- toYaml .Values.awsDatabases | nindent 8 }}
+      {{- end }}
+      {{- if .Values.databases }}
       databases:
         {{- range $db := .Values.databases }}
           {{- if not (hasKey $db "name") }}
@@ -65,7 +82,9 @@ data:
             {{- fail "'protocol' is required for all 'databases' in chart values when db role is enabled, see README" }}
           {{- end }}
         {{- end }}
-        {{- required "'databases' map is required in chart values when db role is enabled, see README" .Values.databases | toYaml | nindent 8 }}
+        {{- .Values.databases | toYaml | nindent 8 }}
+      {{- end }}
+      {{- end }}
       {{- else }}
       enabled: false
       {{- end }}

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -7,6 +7,7 @@
         "roles",
         "kubeClusterName",
         "apps",
+        "awsDatabases",
         "databases",
         "teleportVersionOverride",
         "insecureSkipProxyTLSVerify",
@@ -69,6 +70,34 @@
                     "default": ""
                 },
                 "additionalProperties": true
+            }
+        },
+        "awsDatabases": {
+            "$id": "#/properties/awsDatabases",
+            "type": "array",
+            "default": [],
+            "required": [
+                "types",
+                "regions",
+                "tags"
+            ],
+            "properties": {
+                "types": {
+                    "$id": "#/properties/awsDatabases/types",
+                    "type": "array",
+                    "default": []
+                },
+                "regions": {
+                    "$id": "#/properties/awsDatabases/regions",
+                    "type": "string",
+                    "default": []
+                },
+                "tags": {
+                    "$id": "#/properties/awsDatabases/tags",
+                    "type": "string",
+                    "default": []
+                },
+                "additionalProperties": false
             }
         },
         "databases": {

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -32,6 +32,14 @@ apps: []
 # Values that must be provided if Database access is enabled.
 ################################################################
 
+# Details of at least one awsDatabase discovery pattern to be discovered
+# and proxied. Example:
+# awsDatabases:
+# - types: ["rds", "aurora"]
+#   regions: ["us-east-1"]
+#   tags:
+#     "environment": "production"
+awsDatabases: []
 # Details of at least one database to be proxied. Example:
 # databases:
 #  - name: aurora

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -35,7 +35,7 @@ apps: []
 # Details of at least one awsDatabase discovery pattern to be discovered
 # and proxied. Example:
 # awsDatabases:
-# - types: ["rds", "aurora"]
+# - types: ["rds"]
 #   regions: ["us-east-1"]
 #   tags:
 #     "environment": "production"


### PR DESCRIPTION
Hi,

I've been using the `teleport-kube-agent` chart to deploy a pool of agents to proxy connections to DBs. 

Now that automated discovery of AWS databases is available in Teleport 8.0, I wanted to leverage it from the `teleport-kube-agent` chart, which doesn't currently support it. 

Therefore this PR adds a new value in `teleport-kube-agent`, `awsDatabases` (I welcome feedback on the naming of this value).

I've also added the file for the linter, as well as updated the documentation to reflect the new value.

Finally, one last note:
`semverCompare` was breaking on the `appVersion: 8.0.0-alpha.1`. I've bumped it to `8.1.0` since that is the latest release for Teleport (and since that is the only way to actually exercise the new templating without removing `semverCompare`) , but I can 100% remove that if not desired.

